### PR TITLE
Update setup_mcp.py

### DIFF
--- a/setup_mcp.py
+++ b/setup_mcp.py
@@ -2,6 +2,7 @@ import os
 import json
 import subprocess
 import sys
+import platform
 
 def setup_venv():
     # Get the absolute path to the current directory
@@ -21,8 +22,12 @@ def setup_venv():
     # Install requirements if we just created the venv
     if venv_created:
         print("\nInstalling requirements...")
-        # Use the venv's pip to install requirements
-        pip_path = os.path.join(venv_path, 'Scripts', 'pip.exe')
+        # Determine the correct pip path based on the OS
+        if platform.system() == "Windows":
+            pip_path = os.path.join(venv_path, 'Scripts', 'pip.exe')
+        else:  # macOS or Linux
+            pip_path = os.path.join(venv_path, 'bin', 'pip')
+        
         requirements_path = os.path.join(base_path, 'requirements.txt')
         subprocess.run([pip_path, 'install', '-r', requirements_path], check=True)
         print("Requirements installed successfully!")
@@ -31,8 +36,12 @@ def generate_mcp_config():
     # Get the absolute path to the current directory
     base_path = os.path.abspath(os.path.dirname(__file__))
     
-    # Construct the paths
-    python_path = os.path.join(base_path, 'venv', 'Scripts', 'python.exe')
+    # Determine the correct python path based on the OS
+    if platform.system() == "Windows":
+        python_path = os.path.join(base_path, 'venv', 'Scripts', 'python.exe')
+    else:  # macOS or Linux
+        python_path = os.path.join(base_path, 'venv', 'bin', 'python')
+    
     server_script_path = os.path.join(base_path, 'mcp_server.py')
     
     # Create the config dictionary
@@ -49,7 +58,7 @@ def generate_mcp_config():
     config_path = os.path.join(base_path, 'mcp-config.json')
     with open(config_path, 'w') as f:
         json.dump(config, f, indent=2)
-
+    
     print(f"\nMCP configuration has been written to: {config_path}")    
     print(f"\nMCP configuration for Cursor:\n\n{python_path} {server_script_path}")
     print("\nMCP configuration for Windsurf/Claude Desktop:")


### PR DESCRIPTION
Added import platform to detect the operating system Used platform.system() to check if it's Windows or not Adjusted pip and python paths:

Windows: uses 'Scripts' folder and '.exe' extension
Mac/Linux: uses 'bin' folder without extension

The script now automatically detects the operating system and uses the appropriate paths for each one, making it compatible with both Windows and macOS/Linux systems.