### PR TITLE
Set MCP server logging level to ERROR to reduce log output in UI

### DIFF
--- a/mcp/mcp_server.py
+++ b/mcp/mcp_server.py
@@ -12,8 +12,8 @@ import os
 # Load environment variables from .env file
 load_dotenv()
 
-# Initialize FastMCP server
-mcp = FastMCP("archon")
+# Initialize FastMCP server with ERROR logging level
+mcp = FastMCP("archon", log_level="ERROR")
 
 # Store active threads
 active_threads: Dict[str, List[str]] = {}
@@ -110,3 +110,4 @@ if __name__ == "__main__":
     
     # Run MCP server
     mcp.run(transport='stdio')
+


### PR DESCRIPTION
#37 

Simple fix for changing the logging level from debug to error, so the tools are displayed instead of debug logging. 