### PR TITLE
In the MCP Streamlit page, added instructios for use in Claude Code.

### DIFF
--- a/streamlit_pages/mcp.py
+++ b/streamlit_pages/mcp.py
@@ -3,10 +3,7 @@ import platform
 import json
 import os
 
-def generate_mcp_config(ide_type):
-    """
-    Generate MCP configuration for the selected IDE type.
-    """
+def get_paths():
     # Get the absolute path to the current directory
     base_path = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
     
@@ -17,7 +14,13 @@ def generate_mcp_config(ide_type):
         python_path = os.path.join(base_path, 'venv', 'bin', 'python')
     
     server_script_path = os.path.join(base_path, 'mcp', 'mcp_server.py')
-    
+
+    return python_path, server_script_path
+
+def generate_mcp_config(ide_type, python_path, server_script_path):
+    """
+    Generate MCP configuration for the selected IDE type.
+    """    
     # Create the config dictionary for Python
     python_config = {
         "mcpServers": {
@@ -95,7 +98,8 @@ def mcp_tab():
     if st.session_state.selected_ide:
         selected_ide = st.session_state.selected_ide
         st.subheader(f"MCP Configuration for {selected_ide}")
-        python_config, docker_config = generate_mcp_config(selected_ide)
+        python_path, server_script_path = get_paths()
+        python_config, docker_config = generate_mcp_config(selected_ide, python_path, server_script_path)
         
         # Configuration type tabs
         config_tab1, config_tab2 = st.tabs(["Docker Configuration", "Python Configuration"])
@@ -150,12 +154,16 @@ def mcp_tab():
             5. Cline/Roo Code will automatically detect and start the MCP server
             """)
         elif selected_ide == "Claude Code":
-            st.markdown("""
+            st.markdown(f"""
             #### How to use in Claude Code:
             1. Deploy and run Archon in Docker
             2. In the Archon UI, start the MCP service.
             3. Open a terminal and navigate to your work folder.
-            4. Execute this command: `claude mcp add Archon docker --  run -i --rm -e GRAPH_SERVICE_URL=http://host.docker.internal:8100 archon-mcp:latest `   
+            4. Execute the command: 
+            
+            \tFor Docker: `claude mcp add Archon docker run -i --rm -e GRAPH_SERVICE_URL=http://host.docker.internal:8100 archon-mcp:latest `   
+            \tFor Python: `claude mcp add Archon {python_path} {server_script_path}`
+            
             5. Start Claude Code with the command `claude`. When Claude Code starts, at the bottom of the welcome section will be a listing of connected MCP Services, Archon should be listed with a status of _connected_.
             6. You can now use the Archon MCP service in your Claude Code projects
                         

--- a/streamlit_pages/mcp.py
+++ b/streamlit_pages/mcp.py
@@ -55,6 +55,8 @@ def generate_mcp_config(ide_type):
         return f"{python_path} {server_script_path}", f"docker run -i --rm -e GRAPH_SERVICE_URL=http://host.docker.internal:8100 archon-mcp:latest"
     elif ide_type == "Cline/Roo Code":
         return json.dumps(python_config, indent=2), json.dumps(docker_config, indent=2)
+    elif ide_type == "Claude Code":
+        return f"Not Required", "Not Required"
     else:
         return "Unknown IDE type selected", "Unknown IDE type selected"
 
@@ -64,7 +66,7 @@ def mcp_tab():
     st.write("Select your AI IDE to get the appropriate MCP configuration:")
     
     # IDE selection with side-by-side buttons
-    col1, col2, col3 = st.columns(3)
+    col1, col2, col3, col4 = st.columns(4)
     
     with col1:
         windsurf_button = st.button("Windsurf", use_container_width=True, key="windsurf_button")
@@ -72,6 +74,8 @@ def mcp_tab():
         cursor_button = st.button("Cursor", use_container_width=True, key="cursor_button")
     with col3:
         cline_button = st.button("Cline/Roo Code", use_container_width=True, key="cline_button")
+    with col4:
+        claude_button = st.button("Claude Code", use_container_width=True, key="claude_button")
     
     # Initialize session state for selected IDE if not present
     if "selected_ide" not in st.session_state:
@@ -84,6 +88,8 @@ def mcp_tab():
         st.session_state.selected_ide = "Cursor"
     elif cline_button:
         st.session_state.selected_ide = "Cline/Roo Code"
+    elif claude_button:
+        st.session_state.selected_ide = "Claude Code"
     
     # Display configuration if an IDE is selected
     if st.session_state.selected_ide:
@@ -142,4 +148,16 @@ def mcp_tab():
             3. The MCP settings file should be displayed in a tab in VS Code
             4. Paste the JSON from your preferred configuration tab above
             5. Cline/Roo Code will automatically detect and start the MCP server
+            """)
+        elif selected_ide == "Claude Code":
+            st.markdown("""
+            #### How to use in Claude Code:
+            1. Deploy and run Archon in Docker
+            2. In the Archon UI, start the MCP service.
+            3. Open a terminal and navigate to your work folder.
+            4. Execute this command: `claude mcp add Archon docker --  run -i --rm -e GRAPH_SERVICE_URL=http://host.docker.internal:8100 archon-mcp:latest `   
+            5. Start Claude Code with the command `claude`. When Claude Code starts, at the bottom of the welcome section will be a listing of connected MCP Services, Archon should be listed with a status of _connected_.
+            6. You can now use the Archon MCP service in your Claude Code projects
+                        
+            (NOTE: If you close the terminal, or start a session in a new terminal, you will need to re-add the MCP service.)
             """)


### PR DESCRIPTION
Updated the `streamlit_ui/mcp.py` file to include instructions to use Archon in Claude Code.