### PR TITLE
Enable Dependabot & CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,58 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+
+  # Check for updates to GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Check for updates to Python packages in root (actual iteration)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Check for updates to Python packages in mcp
+  - package-ecosystem: "pip"
+    directory: "/mcp"
+    schedule:
+      interval: "weekly"
+
+  # Check for updates in Dockerfile
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Check for updates in MCP Dockerfile
+  - package-ecosystem: "docker"
+    directory: "/mcp"
+    schedule:
+      interval: "weekly"
+
+
+  # Aditional: Structure to maintain previous iterations
+
+  # Update Version 1: Single Agent
+  # - package-ecosystem: "pip"
+  #   directory: "/iterations/v1-single-agent"
+  #   schedule:
+  #     interval: "monthly"
+
+  # Update Version 2: Agentic Workflow
+  # - package-ecosystem: "pip"
+  #   directory: "/iterations/v2-agentic-workflow"
+  #   schedule:
+  #     interval: "monthly"
+
+  # Upate Version 3: MCP Support
+  # - package-ecosystem: "pip"
+  #   directory: "/iterations/v3-mcp-support"
+  #   schedule:
+  #     interval: "monthly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,14 +48,24 @@ jobs:
 
   build-docker:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12', '3.13']
+        include:
+          - python-version: '3.13'
+            experimental: true
+      fail-fast: false
+
+    # Test on newer Python versions
+    continue-on-error: ${{ matrix.experimental || false }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
 
       - name: Modify run_docker.py for CI environment
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,48 @@
+name: Build Archon
+
+on:
+  push:
+    branches:
+      [ main, master ]
+  pull_request:
+    branches:
+      [ main, master ]
+
+permissions:
+  contents: read
+
+jobs:
+  build-locally:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12', '3.13']
+        include:
+          - python-version: '3.12'
+            experimental: true
+          - python-version: '3.13'
+            experimental: true
+      fail-fast: false
+
+    # Test on newer Python versions
+    continue-on-error: ${{ matrix.experimental || false }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          pip install -r requirements.txt
+
+      - name: Verify code compilation
+        run: |
+          source venv/bin/activate
+          python -m compileall -f .
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,3 +46,41 @@ jobs:
           source venv/bin/activate
           python -m compileall -f .
 
+  build-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        with:
+          python-version: '3.11'
+
+      - name: Modify run_docker.py for CI environment
+        run: |
+          cp run_docker.py run_docker_ci.py
+          # Modify the script to just build and verify containers without running them indefinitely
+          sed -i 's/"-d",/"-d", "--rm",/g' run_docker_ci.py
+          
+      - name: Run Docker setup script
+        run: |
+          chmod +x run_docker_ci.py
+          python run_docker_ci.py
+          
+      - name: Verify containers are built
+        run: |
+          docker images | grep archon
+          docker images | grep archon-mcp
+          
+      - name: Test container running status
+        run: |
+          docker ps -a | grep archon-container
+          
+      - name: Stop containers
+        run: |
+          docker stop archon-container || true
+          docker rm archon-container || true
+          docker stop archon-mcp || true
+          docker rm archon-mcp || true
+          docker ps -a | grep archon || echo "All containers successfully removed"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         include:
+          - python-version: '3.10'
+            experimental: true
           - python-version: '3.12'
             experimental: true
           - python-version: '3.13'
@@ -50,8 +52,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         include:
+          - python-version: '3.10'
+            experimental: true
           - python-version: '3.13'
             experimental: true
       fail-fast: false


### PR DESCRIPTION
As discussed in #41, Implements Dependabot to track updates for Docker and Python dependencies and sets up CI (Continuous Integration) to validate builds across multiple Python versions. This CI would validate Dependabot's updates when it tries to update dependencies as well as ensuring new functionalities added do not break the code.

I have included:
- `dependabot.yml`: monitoring updates for Docker and Python dependencies (in the latest project iteration, found in root), as well as github actions. I feft comments for a possible expansion to previous iterations in case we decide to maintain them (do not believe it is a necessity).
- `build.yml`: for Ci with 2 jobs: The first tests building an running locally whilst the second uses the recommended Docker build for usage. I kept Python `3.11` as the primary version (as stated in `README`) but I took it next level by including a matrix to test more versions of Python (3.12 and 3.13) with a working backport to 3.10.

LMK if anything needs tweaking or if you have any questions