### PR TITLE
Update embedding API parameter for Ollama compatibility

### DIFF
--- a/iterations/v2-agentic-workflow/crawl_pydantic_ai_docs.py
+++ b/iterations/v2-agentic-workflow/crawl_pydantic_ai_docs.py
@@ -116,14 +116,22 @@ async def get_title_and_summary(chunk: str, url: str) -> Dict[str, str]:
 async def get_embedding(text: str) -> List[float]:
     """Get embedding vector from OpenAI."""
     try:
-        response = await openai_client.embeddings.create(
-            model= embedding_model,
-            input=text
-        )
+        # Check if using Ollama and use the correct parameter name
+        if is_ollama:
+            response = await openai_client.embeddings.create(
+                model=embedding_model,
+                prompt=text  # Use 'prompt' for Ollama
+            )
+        else:
+            response = await openai_client.embeddings.create(
+                model=embedding_model,
+                input=text  # Use 'input' for OpenAI
+            )
         return response.data[0].embedding
     except Exception as e:
         print(f"Error getting embedding: {e}")
         return [0] * 1536  # Return zero vector on error
+
 
 async def process_chunk(chunk: str, chunk_number: int, url: str) -> ProcessedChunk:
     """Process a single chunk of text."""


### PR DESCRIPTION
This commit fixes the 'NoneType object is not iterable' error when using Ollama for embeddings.

The issue occurs because Ollama's embedding API expects the parameter 'prompt' instead of 'input'.

Changes:
- Modified get_embedding() function to use 'prompt' parameter when Ollama is detected
- Maintained backward compatibility with OpenAI API which uses 'input' parameter
- Added conditional logic to check for Ollama provider before selecting parameter name

This fixes issue where document crawling and RAG functionality were failing with Ollama embedding models due to empty embedding arrays being returned.