### PR TITLE
feat: Add multiple LangChain documentation sources

### DIFF
--- a/archon/crawl_pydantic_ai_docs.py
+++ b/archon/crawl_pydantic_ai_docs.py
@@ -1,3 +1,5 @@
+from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig, CacheMode
+from utils.utils import get_env_var, get_clients
 import os
 import sys
 import asyncio
@@ -16,44 +18,40 @@ from openai import AsyncOpenAI
 import re
 import html2text
 
-# Add the parent directory to sys.path to allow importing from the parent directory
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from utils.utils import get_env_var, get_clients
 
-from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig, CacheMode
 
 load_dotenv()
 
-# Initialize embedding and Supabase clients
 embedding_client, supabase = get_clients()
 
-# Define the embedding model for embedding the documentation for RAG
 embedding_model = get_env_var('EMBEDDING_MODEL') or 'text-embedding-3-small'
 
-# LLM client setup
+
 llm_client = None
 base_url = get_env_var('BASE_URL') or 'https://api.openai.com/v1'
 api_key = get_env_var('LLM_API_KEY') or 'no-api-key-provided'
 provider = get_env_var('LLM_PROVIDER') or 'OpenAI'
 
-# Setup OpenAI client for LLM
+
 if provider == "Ollama":
     if api_key == "NOT_REQUIRED":
-        api_key = "ollama"  # Use a dummy key for Ollama
+        api_key = "ollama"
     llm_client = AsyncOpenAI(base_url=base_url, api_key=api_key)
 else:
     llm_client = AsyncOpenAI(base_url=base_url, api_key=api_key)
 
-# Initialize HTML to Markdown converter
 html_converter = html2text.HTML2Text()
 html_converter.ignore_links = False
 html_converter.ignore_images = False
 html_converter.ignore_tables = False
-html_converter.body_width = 0  # No wrapping
+html_converter.body_width = 0
+
 
 @dataclass
 class ProcessedChunk:
     url: str
+    source: str
     chunk_number: int
     title: str
     summary: str
@@ -61,13 +59,14 @@ class ProcessedChunk:
     metadata: Dict[str, Any]
     embedding: List[float]
 
+
 class CrawlProgressTracker:
     """Class to track progress of the crawling process."""
-    
-    def __init__(self, 
+
+    def __init__(self,
                  progress_callback: Optional[Callable[[Dict[str, Any]], None]] = None):
         """Initialize the progress tracker.
-        
+
         Args:
             progress_callback: Function to call with progress updates
         """
@@ -81,28 +80,28 @@ class CrawlProgressTracker:
         self.is_running = False
         self.start_time = None
         self.end_time = None
-    
+
     def log(self, message: str):
         """Add a log message and update progress."""
         timestamp = datetime.now().strftime("%H:%M:%S")
         log_entry = f"[{timestamp}] {message}"
         self.logs.append(log_entry)
         print(message)  # Also print to console
-        
+
         # Call the progress callback if provided
         if self.progress_callback:
             self.progress_callback(self.get_status())
-    
+
     def start(self):
         """Mark the crawling process as started."""
         self.is_running = True
         self.start_time = datetime.now()
         self.log("Crawling process started")
-        
+
         # Call the progress callback if provided
         if self.progress_callback:
             self.progress_callback(self.get_status())
-    
+
     def complete(self):
         """Mark the crawling process as completed."""
         self.is_running = False
@@ -110,11 +109,11 @@ class CrawlProgressTracker:
         duration = self.end_time - self.start_time if self.start_time else None
         duration_str = str(duration).split('.')[0] if duration else "unknown"
         self.log(f"Crawling process completed in {duration_str}")
-        
+
         # Call the progress callback if provided
         if self.progress_callback:
             self.progress_callback(self.get_status())
-    
+
     def get_status(self) -> Dict[str, Any]:
         """Get the current status of the crawling process."""
         return {
@@ -129,16 +128,17 @@ class CrawlProgressTracker:
             "start_time": self.start_time,
             "end_time": self.end_time
         }
-    
+
     @property
     def is_completed(self) -> bool:
         """Return True if the crawling process is completed."""
         return not self.is_running and self.end_time is not None
-    
+
     @property
     def is_successful(self) -> bool:
         """Return True if the crawling process completed successfully."""
         return self.is_completed and self.urls_failed == 0 and self.urls_succeeded > 0
+
 
 def chunk_text(text: str, chunk_size: int = 5000) -> List[str]:
     """Split text into chunks, respecting code blocks and paragraphs."""
@@ -185,6 +185,7 @@ def chunk_text(text: str, chunk_size: int = 5000) -> List[str]:
 
     return chunks
 
+
 async def get_title_and_summary(chunk: str, url: str) -> Dict[str, str]:
     """Extract title and summary using GPT-4."""
     system_prompt = """You are an AI that extracts titles and summaries from documentation chunks.
@@ -192,20 +193,22 @@ async def get_title_and_summary(chunk: str, url: str) -> Dict[str, str]:
     For the title: If this seems like the start of a document, extract its title. If it's a middle chunk, derive a descriptive title.
     For the summary: Create a concise summary of the main points in this chunk.
     Keep both title and summary concise but informative."""
-    
+
     try:
         response = await llm_client.chat.completions.create(
             model=get_env_var("PRIMARY_MODEL") or "gpt-4o-mini",
             messages=[
                 {"role": "system", "content": system_prompt},
-                {"role": "user", "content": f"URL: {url}\n\nContent:\n{chunk[:1000]}..."}  # Send first 1000 chars for context
+                {"role": "user",
+                    "content": f"URL: {url}\n\nContent:\n{chunk[:1000]}..."}
             ],
-            response_format={ "type": "json_object" }
+            response_format={"type": "json_object"}
         )
         return json.loads(response.choices[0].message.content)
     except Exception as e:
         print(f"Error getting title and summary: {e}")
         return {"title": "Error processing title", "summary": "Error processing summary"}
+
 
 async def get_embedding(text: str) -> List[float]:
     """Get embedding vector from OpenAI."""
@@ -219,24 +222,26 @@ async def get_embedding(text: str) -> List[float]:
         print(f"Error getting embedding: {e}")
         return [0] * 1536  # Return zero vector on error
 
-async def process_chunk(chunk: str, chunk_number: int, url: str) -> ProcessedChunk:
+
+async def process_chunk(chunk: str, chunk_number: int, url: str, source: str) -> ProcessedChunk:
     """Process a single chunk of text."""
     # Get title and summary
     extracted = await get_title_and_summary(chunk, url)
-    
+
     # Get embedding
     embedding = await get_embedding(chunk)
-    
+
     # Create metadata
     metadata = {
-        "source": "pydantic_ai_docs",
+        "source": source,
         "chunk_size": len(chunk),
         "crawled_at": datetime.now(timezone.utc).isoformat(),
         "url_path": urlparse(url).path
     }
-    
+
     return ProcessedChunk(
         url=url,
+        source=source,  # Store the source
         chunk_number=chunk_number,
         title=extracted['title'],
         summary=extracted['summary'],
@@ -244,6 +249,7 @@ async def process_chunk(chunk: str, chunk_number: int, url: str) -> ProcessedChu
         metadata=metadata,
         embedding=embedding
     )
+
 
 async def insert_chunk(chunk: ProcessedChunk):
     """Insert a processed chunk into Supabase."""
@@ -257,118 +263,122 @@ async def insert_chunk(chunk: ProcessedChunk):
             "metadata": chunk.metadata,
             "embedding": chunk.embedding
         }
-        
+
         result = supabase.table("site_pages").insert(data).execute()
-        print(f"Inserted chunk {chunk.chunk_number} for {chunk.url}")
+        print(
+            f"Inserted chunk {chunk.chunk_number} for {chunk.url} (Source: {chunk.source})")
         return result
     except Exception as e:
         print(f"Error inserting chunk: {e}")
         return None
 
-async def process_and_store_document(url: str, markdown: str, tracker: Optional[CrawlProgressTracker] = None):
+
+async def process_and_store_document(url: str, markdown: str, source: str, tracker: Optional[CrawlProgressTracker] = None):
     """Process a document and store its chunks in parallel."""
-    # Split into chunks
+
     chunks = chunk_text(markdown)
-    
+
     if tracker:
-        tracker.log(f"Split document into {len(chunks)} chunks for {url}")
-        # Ensure UI gets updated
+        tracker.log(
+            f"Split document into {len(chunks)} chunks for {url} (Source: {source})")
+
         if tracker.progress_callback:
             tracker.progress_callback(tracker.get_status())
     else:
-        print(f"Split document into {len(chunks)} chunks for {url}")
-    
-    # Process chunks in parallel
+        print(
+            f"Split document into {len(chunks)} chunks for {url} (Source: {source})")
+
     tasks = [
-        process_chunk(chunk, i, url) 
+        process_chunk(chunk, i, url, source)
         for i, chunk in enumerate(chunks)
     ]
     processed_chunks = await asyncio.gather(*tasks)
-    
+
     if tracker:
-        tracker.log(f"Processed {len(processed_chunks)} chunks for {url}")
-        # Ensure UI gets updated
+        tracker.log(
+            f"Processed {len(processed_chunks)} chunks for {url} (Source: {source})")
+
         if tracker.progress_callback:
             tracker.progress_callback(tracker.get_status())
     else:
-        print(f"Processed {len(processed_chunks)} chunks for {url}")
-    
-    # Store chunks in parallel
+        print(
+            f"Processed {len(processed_chunks)} chunks for {url} (Source: {source})")
+
     insert_tasks = [
-        insert_chunk(chunk) 
+        insert_chunk(chunk)
         for chunk in processed_chunks
     ]
     await asyncio.gather(*insert_tasks)
-    
+
     if tracker:
         tracker.chunks_stored += len(processed_chunks)
-        tracker.log(f"Stored {len(processed_chunks)} chunks for {url}")
-        # Ensure UI gets updated
+        tracker.log(
+            f"Stored {len(processed_chunks)} chunks for {url} (Source: {source})")
+
         if tracker.progress_callback:
             tracker.progress_callback(tracker.get_status())
     else:
-        print(f"Stored {len(processed_chunks)} chunks for {url}")
+        print(
+            f"Stored {len(processed_chunks)} chunks for {url} (Source: {source})")
+
 
 def fetch_url_content(url: str) -> str:
     """Fetch content from a URL using requests and convert to markdown."""
     headers = {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
     }
-    
+
     try:
         response = requests.get(url, headers=headers, timeout=30)
         response.raise_for_status()
-        
+
         # Convert HTML to Markdown
         markdown = html_converter.handle(response.text)
-        
+
         # Clean up the markdown
-        markdown = re.sub(r'\n{3,}', '\n\n', markdown)  # Remove excessive newlines
-        
+        # Remove excessive newlines
+        markdown = re.sub(r'\n{3,}', '\n\n', markdown)
+
         return markdown
     except Exception as e:
         raise Exception(f"Error fetching {url}: {str(e)}")
 
-async def crawl_parallel_with_requests(urls: List[str], tracker: Optional[CrawlProgressTracker] = None, max_concurrent: int = 5):
+
+async def crawl_parallel_with_requests(urls_with_source: Dict[str, str], tracker: Optional[CrawlProgressTracker] = None, max_concurrent: int = 5):
     """Crawl multiple URLs in parallel with a concurrency limit using direct HTTP requests."""
-    # Create a semaphore to limit concurrency
     semaphore = asyncio.Semaphore(max_concurrent)
-    
-    async def process_url(url: str):
+
+    async def process_url(url: str, source: str):
         async with semaphore:
             if tracker:
-                tracker.log(f"Crawling: {url}")
-                # Ensure UI gets updated
+                tracker.log(f"Crawling: {url} (Source: {source})")
                 if tracker.progress_callback:
                     tracker.progress_callback(tracker.get_status())
             else:
-                print(f"Crawling: {url}")
-            
+                print(f"Crawling: {url} (Source: {source})")
+
             try:
-                # Use a thread pool to run the blocking HTTP request
                 loop = asyncio.get_running_loop()
                 if tracker:
                     tracker.log(f"Fetching content from: {url}")
                 else:
                     print(f"Fetching content from: {url}")
                 markdown = await loop.run_in_executor(None, fetch_url_content, url)
-                
+
                 if markdown:
                     if tracker:
                         tracker.urls_succeeded += 1
                         tracker.log(f"Successfully crawled: {url}")
-                        # Ensure UI gets updated
                         if tracker.progress_callback:
                             tracker.progress_callback(tracker.get_status())
                     else:
                         print(f"Successfully crawled: {url}")
-                    
-                    await process_and_store_document(url, markdown, tracker)
+
+                    await process_and_store_document(url, markdown, source, tracker)
                 else:
                     if tracker:
                         tracker.urls_failed += 1
                         tracker.log(f"Failed: {url} - No content retrieved")
-                        # Ensure UI gets updated
                         if tracker.progress_callback:
                             tracker.progress_callback(tracker.get_status())
                     else:
@@ -377,7 +387,6 @@ async def crawl_parallel_with_requests(urls: List[str], tracker: Optional[CrawlP
                 if tracker:
                     tracker.urls_failed += 1
                     tracker.log(f"Error processing {url}: {str(e)}")
-                    # Ensure UI gets updated
                     if tracker.progress_callback:
                         tracker.progress_callback(tracker.get_status())
                 else:
@@ -385,129 +394,226 @@ async def crawl_parallel_with_requests(urls: List[str], tracker: Optional[CrawlP
             finally:
                 if tracker:
                     tracker.urls_processed += 1
-                    # Ensure UI gets updated
                     if tracker.progress_callback:
                         tracker.progress_callback(tracker.get_status())
 
-        time.sleep(2)
-    
-    # Process all URLs in parallel with limited concurrency
+        await asyncio.sleep(1)
+
     if tracker:
-        tracker.log(f"Processing {len(urls)} URLs with concurrency {max_concurrent}")
-        # Ensure UI gets updated
+        tracker.log(
+            f"Processing {len(urls_with_source)} URLs from {len(set(urls_with_source.values()))} sources with concurrency {max_concurrent}")
         if tracker.progress_callback:
             tracker.progress_callback(tracker.get_status())
     else:
-        print(f"Processing {len(urls)} URLs with concurrency {max_concurrent}")
-    await asyncio.gather(*[process_url(url) for url in urls])
+        print(
+            f"Processing {len(urls_with_source)} URLs from {len(set(urls_with_source.values()))} sources with concurrency {max_concurrent}")
+
+    tasks = [process_url(url, source)
+             for url, source in urls_with_source.items()]
+    await asyncio.gather(*tasks)
+
+
+def _fetch_sitemap_urls(sitemap_url: str, source_name: str) -> List[str]:
+    """Helper function to fetch URLs from a sitemap."""
+    print(f"Fetching URLs from {source_name} sitemap ({sitemap_url})...")
+    try:
+        response = requests.get(sitemap_url, timeout=30)
+        response.raise_for_status()
+        root = ElementTree.fromstring(response.content)
+        namespace = {'ns': 'http://www.sitemaps.org/schemas/sitemap/0.9'}
+        urls = [loc.text for loc in root.findall('.//ns:loc', namespace)]
+        print(f"Found {len(urls)} URLs for {source_name}")
+        return urls
+    except requests.exceptions.RequestException as e:
+        print(
+            f"HTTP Error fetching {source_name} sitemap ({sitemap_url}): {e}")
+        return []
+    except ElementTree.ParseError as e:
+        print(
+            f"XML Parsing Error for {source_name} sitemap ({sitemap_url}): {e}")
+        return []
+    except Exception as e:
+        print(
+            f"Unexpected Error fetching {source_name} sitemap ({sitemap_url}): {e}")
+        return []
+
 
 def get_pydantic_ai_docs_urls() -> List[str]:
     """Get URLs from Pydantic AI docs sitemap."""
-    sitemap_url = "https://ai.pydantic.dev/sitemap.xml"
-    try:
-        response = requests.get(sitemap_url)
-        response.raise_for_status()
-        
-        # Parse the XML
-        root = ElementTree.fromstring(response.content)
-        
-        # Extract all URLs from the sitemap
-        namespace = {'ns': 'http://www.sitemaps.org/schemas/sitemap/0.9'}
-        urls = [loc.text for loc in root.findall('.//ns:loc', namespace)]
-        
-        return urls
-    except Exception as e:
-        print(f"Error fetching sitemap: {e}")
-        return []
+    return _fetch_sitemap_urls("https://ai.pydantic.dev/sitemap.xml", "pydantic_ai_docs")
 
-def clear_existing_records():
-    """Clear all existing records with source='pydantic_ai_docs' from the site_pages table."""
+
+def get_langgraph_docs_urls() -> List[str]:
+    """Get URLs from LangGraph docs sitemap."""
+    return _fetch_sitemap_urls("https://langchain-ai.github.io/langgraph/sitemap.xml", "langgraph_docs")
+
+
+def get_langgraphjs_docs_urls() -> List[str]:
+    """Get URLs from LangGraph JS docs sitemap."""
+    return _fetch_sitemap_urls("https://langchain-ai.github.io/langgraphjs/sitemap.xml", "langgraphjs_docs")
+
+
+def get_langsmith_docs_urls() -> List[str]:
+    """Get URLs from LangSmith docs sitemap."""
+    return _fetch_sitemap_urls("https://docs.smith.langchain.com/sitemap.xml", "langsmith_docs")
+
+
+def get_langchain_python_docs_urls() -> List[str]:
+    """Get URLs from LangChain Python docs sitemap."""
+    return _fetch_sitemap_urls("https://python.langchain.com/sitemap.xml", "langchain_python_docs")
+
+
+def get_langchain_js_docs_urls() -> List[str]:
+    """Get URLs from LangChain JS docs sitemap."""
+    return _fetch_sitemap_urls("https://js.langchain.com/sitemap.xml", "langchain_js_docs")
+
+
+def clear_existing_records(source: str):
+    """Clear all existing records for a specific source from the site_pages table."""
     try:
-        result = supabase.table("site_pages").delete().eq("metadata->>source", "pydantic_ai_docs").execute()
-        print("Cleared existing pydantic_ai_docs records from site_pages")
-        return result
+        print(f"Clearing existing records for source: {source}...")
+
+        delete_result = supabase.table("site_pages").delete().eq(
+            "metadata->>source", source).execute()
+
+        print(f"Cleared existing records for source: {source}")
+        return delete_result
     except Exception as e:
-        print(f"Error clearing existing records: {e}")
+        print(f"Error clearing existing records for {source}: {e}")
         return None
+
 
 async def main_with_requests(tracker: Optional[CrawlProgressTracker] = None):
     """Main function using direct HTTP requests instead of browser automation."""
+    start_time_main = time.time()
     try:
-        # Start tracking if tracker is provided
         if tracker:
             tracker.start()
         else:
             print("Starting crawling process...")
-        
-        # Clear existing records first
+
+        sources = {
+            "pydantic_ai_docs": get_pydantic_ai_docs_urls,
+            "langgraph_docs": get_langgraph_docs_urls,
+            "langgraphjs_docs": get_langgraphjs_docs_urls,
+            "langsmith_docs": get_langsmith_docs_urls,
+            "langchain_python_docs": get_langchain_python_docs_urls,
+            "langchain_js_docs": get_langchain_js_docs_urls,
+        }
+
+        clear_start_time = time.time()
+
+        clear_tasks = [asyncio.to_thread(
+            clear_existing_records, source_name) for source_name in sources.keys()]
+        results = await asyncio.gather(*clear_tasks, return_exceptions=True)
+        for source_name, result in zip(sources.keys(), results):
+            if isinstance(result, Exception):
+                log_msg = f"Failed to clear records for {source_name}: {result}"
+                if tracker:
+                    tracker.log(log_msg)
+                else:
+                    print(log_msg)
+
+        clear_duration = time.time() - clear_start_time
+        log_msg_clear = f"Finished clearing records for {len(sources)} sources in {clear_duration:.2f} seconds."
         if tracker:
-            tracker.log("Clearing existing Pydantic AI docs records...")
+            tracker.log(log_msg_clear)
         else:
-            print("Clearing existing Pydantic AI docs records...")
-        clear_existing_records()
-        if tracker:
-            tracker.log("Existing records cleared")
-        else:
-            print("Existing records cleared")
-        
-        # Get URLs from Pydantic AI docs
-        if tracker:
-            tracker.log("Fetching URLs from Pydantic AI sitemap...")
-        else:
-            print("Fetching URLs from Pydantic AI sitemap...")
-        urls = get_pydantic_ai_docs_urls()
-        
-        if not urls:
+            print(log_msg_clear)
+
+        fetch_start_time = time.time()
+        all_urls_with_source = {}
+        total_urls = 0
+
+        fetch_tasks = [asyncio.to_thread(fetch_func)
+                       for fetch_func in sources.values()]
+        fetch_results = await asyncio.gather(*fetch_tasks, return_exceptions=True)
+
+        for source_name, result in zip(sources.keys(), fetch_results):
+            if isinstance(result, Exception):
+                log_msg = f"Failed to fetch URLs for {source_name}: {result}"
+                if tracker:
+                    tracker.log(log_msg)
+                else:
+                    print(log_msg)
+                continue
+            elif isinstance(result, list):
+                urls = result
+                for url in urls:
+
+                    all_urls_with_source[url] = source_name
+                total_urls += len(urls)
+
+        fetch_duration = time.time() - fetch_start_time
+
+        if not all_urls_with_source:
+            log_msg = f"No URLs found to crawl from any source after {fetch_duration:.2f} seconds."
             if tracker:
-                tracker.log("No URLs found to crawl")
+                tracker.log(log_msg)
                 tracker.complete()
             else:
-                print("No URLs found to crawl")
+                print(log_msg)
             return
-        
+
+        log_msg_fetch = f"Found a total of {total_urls} URLs to crawl from {len(sources)} sources in {fetch_duration:.2f} seconds."
         if tracker:
-            tracker.urls_found = len(urls)
-            tracker.log(f"Found {len(urls)} URLs to crawl")
+            tracker.urls_found = total_urls
+            tracker.log(log_msg_fetch)
         else:
-            print(f"Found {len(urls)} URLs to crawl")
-        
-        # Crawl the URLs using direct HTTP requests
-        await crawl_parallel_with_requests(urls, tracker)
-        
-        # Mark as complete if tracker is provided
+            print(log_msg_fetch)
+
+        crawl_start_time = time.time()
+        await crawl_parallel_with_requests(all_urls_with_source, tracker)
+        crawl_duration = time.time() - crawl_start_time
+        log_msg_crawl = f"Crawling and processing finished in {crawl_duration:.2f} seconds."
+        if tracker:
+            tracker.log(log_msg_crawl)
+        else:
+            print(log_msg_crawl)
+
         if tracker:
             tracker.complete()
         else:
             print("Crawling process completed")
-            
+
     except Exception as e:
+        error_msg = f"Error in main crawling process: {str(e)}"
         if tracker:
-            tracker.log(f"Error in crawling process: {str(e)}")
-            tracker.complete()
+            tracker.log(error_msg)
+            if tracker.is_running:
+                tracker.complete()
         else:
-            print(f"Error in crawling process: {str(e)}")
+            print(error_msg)
+    finally:
+        main_duration = time.time() - start_time_main
+        print(
+            f"Total execution time for main_with_requests: {main_duration:.2f} seconds.")
+
 
 def start_crawl_with_requests(progress_callback: Optional[Callable[[Dict[str, Any]], None]] = None) -> CrawlProgressTracker:
     """Start the crawling process using direct HTTP requests in a separate thread and return the tracker."""
     tracker = CrawlProgressTracker(progress_callback)
-    
+
     def run_crawl():
         try:
+
             asyncio.run(main_with_requests(tracker))
         except Exception as e:
-            print(f"Error in crawl thread: {e}")
-            tracker.log(f"Thread error: {str(e)}")
-            tracker.complete()
-    
-    # Start the crawling process in a separate thread
+            error_msg = f"Error in crawl thread: {e}"
+            print(error_msg)
+            if tracker:
+                tracker.log(f"Thread error: {str(e)}")
+                if tracker.is_running:
+                    tracker.complete()
+
     thread = threading.Thread(target=run_crawl)
     thread.daemon = True
     thread.start()
-    
+
     return tracker
 
-if __name__ == "__main__":    
-    # Run the main function directly
+
+if __name__ == "__main__":
     print("Starting crawler...")
     asyncio.run(main_with_requests())
     print("Crawler finished.")


### PR DESCRIPTION
Expand the documentation crawler to index multiple LangChain-related sources in addition to Pydantic AI.

New sources added:
- LangGraph Python (langchain-ai.github.io/langgraph)
- LangGraph JS (langchain-ai.github.io/langgraphjs)
- LangSmith (docs.smith.langchain.com)
- LangChain Python (python.langchain.com)
- LangChain JS (js.langchain.com)

Key changes include:
- Added specific functions for each new sitemap URL.
- Refactored sitemap fetching logic into a common helper function.
- Updated the main process to fetch URLs and clear database records for all sources concurrently using asyncio, improving startup performance.
- Enhanced error handling and logging for fetching and clearing operations.