### PR TITLE
Fix Supabase client initialization

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -401,7 +401,7 @@ def get_clients():
     supabase_key = get_env_var("SUPABASE_SERVICE_KEY")
     if supabase_url and supabase_key:
         try:
-            supabase: Client = Client(supabase_url, supabase_key)
+            supabase = create_client(supabase_url, supabase_key)
         except Exception as e:
             print(f"Failed to initialize Supabase: {e}")
             write_to_log(f"Failed to initialize Supabase: {e}")


### PR DESCRIPTION
### Description
`utils.get_clients` now builds the Supabase client via `create_client()` instead of direct `Client()` construction. This prevents runtime instantiation errors and restores all documentation-retrieval tools that rely on a working Supabase connection.