### PR TITLE
Fix crawler attempting to navigate to binary files

### DIFF
--- a/python/src/server/services/crawling/helpers/url_handler.py
+++ b/python/src/server/services/crawling/helpers/url_handler.py
@@ -49,6 +49,54 @@ class URLHandler:
             return False
     
     @staticmethod
+    def is_binary_file(url: str) -> bool:
+        """
+        Check if a URL points to a binary file that shouldn't be crawled.
+        
+        Args:
+            url: URL to check
+            
+        Returns:
+            True if URL is a binary file, False otherwise
+        """
+        try:
+            # Remove query parameters and fragments for cleaner extension checking
+            parsed = urlparse(url)
+            path = parsed.path.lower()
+            
+            # Comprehensive list of binary and non-HTML file extensions
+            binary_extensions = {
+                # Archives
+                '.zip', '.tar', '.gz', '.rar', '.7z', '.bz2', '.xz', '.tgz',
+                # Executables and installers
+                '.exe', '.dmg', '.pkg', '.deb', '.rpm', '.msi', '.app', '.appimage',
+                # Documents (non-HTML)
+                '.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.odt', '.ods',
+                # Images
+                '.jpg', '.jpeg', '.png', '.gif', '.svg', '.webp', '.ico', '.bmp', '.tiff',
+                # Audio/Video
+                '.mp3', '.mp4', '.avi', '.mov', '.wmv', '.flv', '.webm', '.mkv', '.wav', '.flac',
+                # Data files
+                '.csv', '.sql', '.db', '.sqlite',
+                # Binary data
+                '.iso', '.img', '.bin', '.dat',
+                # Development files (usually not meant to be crawled as pages)
+                '.wasm', '.pyc', '.jar', '.war', '.class', '.dll', '.so', '.dylib'
+            }
+            
+            # Check if the path ends with any binary extension
+            for ext in binary_extensions:
+                if path.endswith(ext):
+                    logger.debug(f"Skipping binary file: {url} (matched extension: {ext})")
+                    return True
+                    
+            return False
+        except Exception as e:
+            logger.warning(f"Error checking if URL is binary file: {e}")
+            # In case of error, don't skip the URL (safer to attempt crawl than miss content)
+            return False
+    
+    @staticmethod
     def transform_github_url(url: str) -> str:
         """
         Transform GitHub URLs to raw content URLs for better content extraction.

--- a/python/tests/test_url_handler.py
+++ b/python/tests/test_url_handler.py
@@ -1,0 +1,125 @@
+"""Unit tests for URLHandler class."""
+import pytest
+from src.server.services.crawling.helpers.url_handler import URLHandler
+
+
+class TestURLHandler:
+    """Test suite for URLHandler class."""
+
+    def test_is_binary_file_archives(self):
+        """Test detection of archive file formats."""
+        handler = URLHandler()
+        
+        # Should detect various archive formats
+        assert handler.is_binary_file("https://example.com/file.zip") is True
+        assert handler.is_binary_file("https://example.com/archive.tar.gz") is True
+        assert handler.is_binary_file("https://example.com/compressed.rar") is True
+        assert handler.is_binary_file("https://example.com/package.7z") is True
+        assert handler.is_binary_file("https://example.com/backup.tgz") is True
+
+    def test_is_binary_file_executables(self):
+        """Test detection of executable and installer files."""
+        handler = URLHandler()
+        
+        assert handler.is_binary_file("https://example.com/setup.exe") is True
+        assert handler.is_binary_file("https://example.com/installer.dmg") is True
+        assert handler.is_binary_file("https://example.com/package.deb") is True
+        assert handler.is_binary_file("https://example.com/app.msi") is True
+        assert handler.is_binary_file("https://example.com/program.appimage") is True
+
+    def test_is_binary_file_documents(self):
+        """Test detection of document files."""
+        handler = URLHandler()
+        
+        assert handler.is_binary_file("https://example.com/document.pdf") is True
+        assert handler.is_binary_file("https://example.com/report.docx") is True
+        assert handler.is_binary_file("https://example.com/spreadsheet.xlsx") is True
+        assert handler.is_binary_file("https://example.com/presentation.pptx") is True
+
+    def test_is_binary_file_media(self):
+        """Test detection of image and media files."""
+        handler = URLHandler()
+        
+        # Images
+        assert handler.is_binary_file("https://example.com/photo.jpg") is True
+        assert handler.is_binary_file("https://example.com/image.png") is True
+        assert handler.is_binary_file("https://example.com/icon.svg") is True
+        assert handler.is_binary_file("https://example.com/favicon.ico") is True
+        
+        # Audio/Video
+        assert handler.is_binary_file("https://example.com/song.mp3") is True
+        assert handler.is_binary_file("https://example.com/video.mp4") is True
+        assert handler.is_binary_file("https://example.com/movie.mkv") is True
+
+    def test_is_binary_file_case_insensitive(self):
+        """Test that detection is case-insensitive."""
+        handler = URLHandler()
+        
+        assert handler.is_binary_file("https://example.com/FILE.ZIP") is True
+        assert handler.is_binary_file("https://example.com/Document.PDF") is True
+        assert handler.is_binary_file("https://example.com/Image.PNG") is True
+
+    def test_is_binary_file_with_query_params(self):
+        """Test that query parameters don't affect detection."""
+        handler = URLHandler()
+        
+        assert handler.is_binary_file("https://example.com/file.zip?version=1.0") is True
+        assert handler.is_binary_file("https://example.com/document.pdf?download=true") is True
+        assert handler.is_binary_file("https://example.com/image.png#section") is True
+
+    def test_is_binary_file_html_pages(self):
+        """Test that HTML pages are not detected as binary."""
+        handler = URLHandler()
+        
+        # Regular HTML pages should not be detected as binary
+        assert handler.is_binary_file("https://example.com/") is False
+        assert handler.is_binary_file("https://example.com/index.html") is False
+        assert handler.is_binary_file("https://example.com/page") is False
+        assert handler.is_binary_file("https://example.com/blog/post") is False
+        assert handler.is_binary_file("https://example.com/about.htm") is False
+        assert handler.is_binary_file("https://example.com/contact.php") is False
+
+    def test_is_binary_file_edge_cases(self):
+        """Test edge cases and special scenarios."""
+        handler = URLHandler()
+        
+        # URLs with periods in path but not file extensions
+        assert handler.is_binary_file("https://example.com/v1.0/api") is False
+        assert handler.is_binary_file("https://example.com/jquery.min.js") is False  # JS files might be crawlable
+        
+        # Real-world example from the error
+        assert handler.is_binary_file("https://docs.crawl4ai.com/apps/crawl4ai-assistant/crawl4ai-assistant-v1.3.0.zip") is True
+
+    def test_is_sitemap(self):
+        """Test sitemap detection."""
+        handler = URLHandler()
+        
+        assert handler.is_sitemap("https://example.com/sitemap.xml") is True
+        assert handler.is_sitemap("https://example.com/path/sitemap.xml") is True
+        assert handler.is_sitemap("https://example.com/sitemap/index.xml") is True
+        assert handler.is_sitemap("https://example.com/regular-page") is False
+
+    def test_is_txt(self):
+        """Test text file detection."""
+        handler = URLHandler()
+        
+        assert handler.is_txt("https://example.com/robots.txt") is True
+        assert handler.is_txt("https://example.com/readme.txt") is True
+        assert handler.is_txt("https://example.com/file.pdf") is False
+
+    def test_transform_github_url(self):
+        """Test GitHub URL transformation."""
+        handler = URLHandler()
+        
+        # Should transform GitHub blob URLs to raw URLs
+        original = "https://github.com/owner/repo/blob/main/file.py"
+        expected = "https://raw.githubusercontent.com/owner/repo/main/file.py"
+        assert handler.transform_github_url(original) == expected
+        
+        # Should not transform non-blob URLs
+        non_blob = "https://github.com/owner/repo"
+        assert handler.transform_github_url(non_blob) == non_blob
+        
+        # Should not transform non-GitHub URLs
+        other = "https://example.com/file"
+        assert handler.transform_github_url(other) == other


### PR DESCRIPTION
# Pull Request

## Summary
Fixes the issue where the recursive crawler attempts to navigate to binary files (ZIP, PDF, executables) as if they were web pages, causing `net::ERR_ABORTED` errors in crawl4ai.

## Changes Made
- Added `is_binary_file()` method to URLHandler class to detect 40+ binary file extensions
- Updated RecursiveCrawlStrategy to filter out binary files before adding URLs to crawl queue
- Added comprehensive unit tests for binary file detection (11 tests, all passing)
- Added debug logging to track when binary files are skipped

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Affected Services
- [x] Server (FastAPI backend)

## Testing
- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested affected user flows
- [x] Docker builds succeed for all services

### Test Evidence
```bash
# Unit tests run and passed
uv run pytest tests/test_url_handler.py -v
# Result: 11 passed, 2 warnings in 0.66s

# Docker service tested
docker-compose restart archon-server
# Server restarted successfully and is healthy
```

## Checklist
- [x] My code follows the service architecture patterns
- [x] If using an AI coding assistant, I used the CLAUDE.md rules
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass locally
- [x] My changes generate no new warnings
- [x] I have verified no regressions in existing features

## Breaking Changes
None - this is a backwards-compatible bug fix that adds filtering logic without changing existing APIs.

## Additional Notes
- Root cause: The recursive crawler was extracting all internal links including binary files and attempting to crawl them
- Solution: Filter URLs at the application level before they reach crawl4ai's navigation methods
- The fix prevents errors like: `Page.goto: net::ERR_ABORTED at https://docs.crawl4ai.com/apps/crawl4ai-assistant/crawl4ai-assistant-v1.3.0.zip`
- DNS errors for non-existent domains (like old.docs.crawl4ai.com) are unrelated and expected behavior