### PR TITLE
chore: Update Docker Hub username to kdegeek

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,38 @@
+# Deploying Archon to Production
+
+This guide provides instructions for building the production Docker images for Archon, tagging them, and pushing them to a Docker registry like Docker Hub.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) must be installed and running on your system.
+- You must have a Docker Hub account and be logged in. You can log in from your terminal with the command:
+  ```bash
+  docker login
+  ```
+
+## 1. Building the Production Images
+
+The `docker-compose.prod.yml` file is configured to build production-ready images for all of Archon's services. To build the images, run the following command from the root of the repository:
+
+```bash
+docker-compose -f docker-compose.prod.yml build
+```
+
+This will build the following images with the `kdegeek/` prefix, ready to be pushed to Docker Hub:
+- `kdegeek/archon-server:latest`
+- `kdegeek/archon-mcp:latest`
+- `kdegeek/archon-agents:latest`
+- `kdegeek/archon-ui:latest`
+
+## 2. Pushing the Images to Docker Hub
+
+Once the images are built, you can push them to Docker Hub:
+
+```bash
+docker push kdegeek/archon-server:latest
+docker push kdegeek/archon-mcp:latest
+docker push kdegeek/archon-agents:latest
+docker push kdegeek/archon-ui:latest
+```
+
+After these steps, your production-ready Docker images will be available on your Docker Hub repository, ready to be used in a production environment like Unraid.

--- a/README.md
+++ b/README.md
@@ -257,6 +257,35 @@ After changing hostname or ports:
 2. Access the UI at: `http://${HOST}:${ARCHON_UI_PORT}`
 3. Update your AI client configuration with the new hostname and MCP port
 
+## 🚀 Production Deployment
+
+This project is ready for production deployment using Docker. The provided `docker-compose.prod.yml` file can be used to build and run the services in a production environment.
+
+For detailed instructions on how to build the Docker images and push them to a container registry like Docker Hub, please see the [Deployment Guide](DEPLOYMENT.md).
+
+### Unraid Deployment
+
+This repository includes templates for deploying Archon on Unraid. To use them:
+
+1.  **Create a Custom Docker Network**:
+    - In your Unraid terminal, run the following command to create a network for the Archon services to communicate with each other:
+      ```bash
+      docker network create archon-net
+      ```
+
+2.  **Copy Templates to Unraid**:
+    - Copy the contents of the `unraid-templates` directory from this repository to the `templates` directory on your Unraid `flash` drive.
+
+3.  **Install the Templates**:
+    - In the Unraid web UI, go to the "Docker" tab.
+    - Click on "Add Container" and select one of the Archon templates from the "My Templates" dropdown (e.g., `Archon-Server`).
+    - Review the configuration and fill in all the required environment variables (Supabase URL/key, API keys, etc.).
+    - Click "Apply" to install the container.
+    - Repeat this process for all four Archon services: `Archon-Server`, `Archon-MCP`, `Archon-Agents`, and `Archon-UI`.
+
+4.  **Access the UI**:
+    - Once all containers are running, you can access the Archon UI at `http://<your-unraid-ip>:<your-ui-port>`.
+
 ## 🔧 Development
 
 For development with hot reload:

--- a/archon-ui-main/Dockerfile.prod
+++ b/archon-ui-main/Dockerfile.prod
@@ -1,0 +1,31 @@
+# Stage 1: Build the React application
+FROM node:18-alpine AS build
+
+WORKDIR /app
+
+# Copy package.json and package-lock.json
+COPY package*.json ./
+
+# Install dependencies
+RUN npm ci
+
+# Copy the rest of the application source code
+COPY . .
+
+# Build the application
+RUN npm run build
+
+# Stage 2: Serve the application with Nginx
+FROM nginx:stable-alpine
+
+# Copy the built assets from the build stage
+COPY --from=build /app/dist /usr/share/nginx/html
+
+# Copy the Nginx configuration file
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Expose port 80
+EXPOSE 80
+
+# Start Nginx
+CMD ["nginx", "-g", "daemon off;"]

--- a/archon-ui-main/nginx.conf
+++ b/archon-ui-main/nginx.conf
@@ -1,0 +1,14 @@
+server {
+  listen 80;
+
+  location / {
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+    try_files $uri $uri/ /index.html;
+  }
+
+  error_page   500 502 503 504  /50x.html;
+  location = /50x.html {
+    root   /usr/share/nginx/html;
+  }
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,103 @@
+services:
+  # Server Service (FastAPI + Socket.IO + Crawling)
+  archon-server:
+    build:
+      context: ./python
+      dockerfile: Dockerfile.server
+      args:
+        BUILDKIT_INLINE_CACHE: 1
+        ARCHON_SERVER_PORT: ${ARCHON_SERVER_PORT:-8181}
+    image: kdegeek/archon-server:latest
+    container_name: Archon-Server
+    ports:
+      - "${ARCHON_SERVER_PORT:-8181}:${ARCHON_SERVER_PORT:-8181}"
+    environment:
+      - SUPABASE_URL=${SUPABASE_URL}
+      - SUPABASE_SERVICE_KEY=${SUPABASE_SERVICE_KEY}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - LOGFIRE_TOKEN=${LOGFIRE_TOKEN:-}
+      - SERVICE_DISCOVERY_MODE=docker_compose
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - ARCHON_SERVER_PORT=${ARCHON_SERVER_PORT:-8181}
+      - ARCHON_MCP_PORT=${ARCHON_MCP_PORT:-8051}
+      - ARCHON_AGENTS_PORT=${ARCHON_AGENTS_PORT:-8052}
+    networks:
+      - app-network
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock  # Docker socket for MCP container control
+
+  # Lightweight MCP Server Service (HTTP-based)
+  archon-mcp:
+    build:
+      context: ./python
+      dockerfile: Dockerfile.mcp
+      args:
+        BUILDKIT_INLINE_CACHE: 1
+        ARCHON_MCP_PORT: ${ARCHON_MCP_PORT:-8051}
+    image: kdegeek/archon-mcp:latest
+    container_name: Archon-MCP
+    ports:
+      - "${ARCHON_MCP_PORT:-8051}:${ARCHON_MCP_PORT:-8051}"
+    environment:
+      - SUPABASE_URL=${SUPABASE_URL}
+      - SUPABASE_SERVICE_KEY=${SUPABASE_SERVICE_KEY}
+      - LOGFIRE_TOKEN=${LOGFIRE_TOKEN:-}
+      - SERVICE_DISCOVERY_MODE=docker_compose
+      - TRANSPORT=sse
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      # MCP needs to know where to find other services
+      - API_SERVICE_URL=http://archon-server:${ARCHON_SERVER_PORT:-8181}
+      - AGENTS_SERVICE_URL=http://archon-agents:${ARCHON_AGENTS_PORT:-8052}
+      - ARCHON_MCP_PORT=${ARCHON_MCP_PORT:-8051}
+      - ARCHON_SERVER_PORT=${ARCHON_SERVER_PORT:-8181}
+      - ARCHON_AGENTS_PORT=${ARCHON_AGENTS_PORT:-8052}
+    networks:
+      - app-network
+    depends_on:
+      - archon-server
+      - archon-agents
+
+  # AI Agents Service (ML/Reranking)
+  archon-agents:
+    build:
+      context: ./python
+      dockerfile: Dockerfile.agents
+      args:
+        BUILDID_INLINE_CACHE: 1
+        ARCHON_AGENTS_PORT: ${ARCHON_AGENTS_PORT:-8052}
+    image: kdegeek/archon-agents:latest
+    container_name: Archon-Agents
+    ports:
+      - "${ARCHON_AGENTS_PORT:-8052}:${ARCHON_AGENTS_PORT:-8052}"
+    environment:
+      - SUPABASE_URL=${SUPABASE_URL}
+      - SUPABASE_SERVICE_KEY=${SUPABASE_SERVICE_KEY}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - LOGFIRE_TOKEN=${LOGFIRE_TOKEN:-}
+      - SERVICE_DISCOVERY_MODE=docker_compose
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - ARCHON_AGENTS_PORT=${ARCHON_AGENTS_PORT:-8052}
+    networks:
+      - app-network
+
+  # Frontend
+  frontend:
+    build:
+      context: ./archon-ui-main
+      dockerfile: Dockerfile.prod
+    image: kdegeek/archon-ui:latest
+    container_name: Archon-UI
+    ports:
+      - "${ARCHON_UI_PORT:-3737}:80"
+    environment:
+      - VITE_API_URL=http://${HOST:-localhost}:${ARCHON_SERVER_PORT:-8181}
+      - ARCHON_SERVER_PORT=${ARCHON_SERVER_PORT:-8181}
+      - HOST=${HOST:-localhost}
+    networks:
+      - app-network
+    depends_on:
+      - archon-server
+
+networks:
+  app-network:
+    driver: bridge

--- a/unraid-templates/archon-agents.xml
+++ b/unraid-templates/archon-agents.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>Archon-Agents</Name>
+  <Repository>kdegeek/archon-agents:latest</Repository>
+  <Registry>https://hub.docker.com/r/kdegeek/archon-agents/</Registry>
+  <Network>archon-net</Network>
+  <MyIP/>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/coleam00/archon/discussions/</Support>
+  <Project>https://github.com/coleam00/archon/</Project>
+  <Overview>This is the Agents service for Archon. It handles AI/ML operations and reranking.&#xD;
+&#xD;
+You must create a custom docker network named 'archon-net' for the Archon containers to communicate.
+  </Overview>
+  <Category>Cloud;</Category>
+  <WebUI>http://[IP]:[PORT:8052]</WebUI>
+  <TemplateURL/>
+  <Icon>https://raw.githubusercontent.com/coleam00/archon/main/archon-ui-main/public/archon-main-graphic.png</Icon>
+  <ExtraParams/>
+  <PostArgs/>
+  <CPUset/>
+  <DateInstalled>1630224000</DateInstalled>
+  <DonateText/>
+  <DonateLink/>
+  <Requires/>
+  <Config Name="Agents Port" Target="8052" Default="8052" Mode="tcp" Description="Port for the Agents service" Type="Port" Display="always" Required="true" Mask="false">8052</Config>
+  <Config Name="Supabase URL" Target="SUPABASE_URL" Default="" Description="Your Supabase project URL." Type="Variable" Display="always" Required="true" Mask="false"/>
+  <Config Name="Supabase Service Key" Target="SUPABASE_SERVICE_KEY" Default="" Description="Your Supabase service key." Type="Variable" Display="always" Required="true" Mask="true"/>
+  <Config Name="OpenAI API Key" Target="OPENAI_API_KEY" Default="" Description="Your OpenAI API key." Type="Variable" Display="always" Required="false" Mask="true"/>
+  <Config Name="Logfire Token" Target="LOGFIRE_TOKEN" Default="" Description="Your Logfire token for logging." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="Log Level" Target="LOG_LEVEL" Default="INFO" Description="Set the log level for the application." Type="Variable" Display="advanced" Required="false" Mask="false">INFO</Config>
+</Container>

--- a/unraid-templates/archon-mcp.xml
+++ b/unraid-templates/archon-mcp.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>Archon-MCP</Name>
+  <Repository>kdegeek/archon-mcp:latest</Repository>
+  <Registry>https://hub.docker.com/r/kdegeek/archon-mcp/</Registry>
+  <Network>archon-net</Network>
+  <MyIP/>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/coleam00/archon/discussions/</Support>
+  <Project>https://github.com/coleam00/archon/</Project>
+  <Overview>This is the MCP (Model Context Protocol) server for Archon. It provides a lightweight interface for AI clients to connect to Archon.&#xD;
+&#xD;
+You must create a custom docker network named 'archon-net' for the Archon containers to communicate.
+  </Overview>
+  <Category>Cloud;</Category>
+  <WebUI>http://[IP]:[PORT:8051]</WebUI>
+  <TemplateURL/>
+  <Icon>https://raw.githubusercontent.com/coleam00/archon/main/archon-ui-main/public/archon-main-graphic.png</Icon>
+  <ExtraParams/>
+  <PostArgs/>
+  <CPUset/>
+  <DateInstalled>1630224000</DateInstalled>
+  <DonateText/>
+  <DonateLink/>
+  <Requires/>
+  <Config Name="MCP Port" Target="8051" Default="8051" Mode="tcp" Description="Port for the MCP server" Type="Port" Display="always" Required="true" Mask="false">8051</Config>
+  <Config Name="Supabase URL" Target="SUPABASE_URL" Default="" Description="Your Supabase project URL." Type="Variable" Display="always" Required="true" Mask="false"/>
+  <Config Name="Supabase Service Key" Target="SUPABASE_SERVICE_KEY" Default="" Description="Your Supabase service key." Type="Variable" Display="always" Required="true" Mask="true"/>
+  <Config Name="Logfire Token" Target="LOGFIRE_TOKEN" Default="" Description="Your Logfire token for logging." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="Log Level" Target="LOG_LEVEL" Default="INFO" Description="Set the log level for the application." Type="Variable" Display="advanced" Required="false" Mask="false">INFO</Config>
+  <Config Name="API Service URL" Target="API_SERVICE_URL" Default="http://Archon-Server:8181" Description="URL for the Archon Server service." Type="Variable" Display="advanced" Required="true" Mask="false">http://Archon-Server:8181</Config>
+  <Config Name="Agents Service URL" Target="AGENTS_SERVICE_URL" Default="http://Archon-Agents:8052" Description="URL for the Archon Agents service." Type="Variable" Display="advanced" Required="true" Mask="false">http://Archon-Agents:8052</Config>
+</Container>

--- a/unraid-templates/archon-server.xml
+++ b/unraid-templates/archon-server.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>Archon-Server</Name>
+  <Repository>kdegeek/archon-server:latest</Repository>
+  <Registry>https://hub.docker.com/r/kdegeek/archon-server/</Registry>
+  <Network>archon-net</Network>
+  <MyIP/>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/coleam00/archon/discussions/</Support>
+  <Project>https://github.com/coleam00/archon/</Project>
+  <Overview>This is the main backend server for Archon. It handles the core business logic, API endpoints, and web crawling capabilities.&#xD;
+&#xD;
+**NOTE:** This container requires access to the Docker socket to manage the MCP container. Please be aware of the security implications of this before installing.&#xD;
+&#xD;
+You must create a custom docker network named 'archon-net' for the Archon containers to communicate.
+  </Overview>
+  <Category>Cloud;</Category>
+  <WebUI>http://[IP]:[PORT:8181]</WebUI>
+  <TemplateURL/>
+  <Icon>https://raw.githubusercontent.com/coleam00/archon/main/archon-ui-main/public/archon-main-graphic.png</Icon>
+  <ExtraParams/>
+  <PostArgs/>
+  <CPUset/>
+  <DateInstalled>1630224000</DateInstalled>
+  <DonateText/>
+  <DonateLink/>
+  <Requires/>
+  <Config Name="WebUI Port" Target="8181" Default="8181" Mode="tcp" Description="Port for the WebUI" Type="Port" Display="always" Required="true" Mask="false">8181</Config>
+  <Config Name="Supabase URL" Target="SUPABASE_URL" Default="" Description="Your Supabase project URL." Type="Variable" Display="always" Required="true" Mask="false"/>
+  <Config Name="Supabase Service Key" Target="SUPABASE_SERVICE_KEY" Default="" Description="Your Supabase service key." Type="Variable" Display="always" Required="true" Mask="true"/>
+  <Config Name="OpenAI API Key" Target="OPENAI_API_KEY" Default="" Description="Your OpenAI API key." Type="Variable" Display="always" Required="false" Mask="true"/>
+  <Config Name="Logfire Token" Target="LOGFIRE_TOKEN" Default="" Description="Your Logfire token for logging." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="Log Level" Target="LOG_LEVEL" Default="INFO" Description="Set the log level for the application." Type="Variable" Display="advanced" Required="false" Mask="false">INFO</Config>
+  <Config Name="Docker Socket" Target="/var/run/docker.sock" Default="/var/run/docker.sock" Mode="rw" Description="Path to the Docker socket." Type="Path" Display="advanced" Required="true" Mask="false">/var/run/docker.sock</Config>
+</Container>

--- a/unraid-templates/archon-ui.xml
+++ b/unraid-templates/archon-ui.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>Archon-UI</Name>
+  <Repository>kdegeek/archon-ui:latest</Repository>
+  <Registry>https://hub.docker.com/r/kdegeek/archon-ui/</Registry>
+  <Network>archon-net</Network>
+  <MyIP/>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/coleam00/archon/discussions/</Support>
+  <Project>https://github.com/coleam00/archon/</Project>
+  <Overview>This is the user interface for Archon. It is a React-based single-page application served by Nginx.&#xD;
+&#xD;
+You must create a custom docker network named 'archon-net' for the Archon containers to communicate.
+  </Overview>
+  <Category>Cloud;</Category>
+  <WebUI>http://[IP]:[PORT:3737]</WebUI>
+  <TemplateURL/>
+  <Icon>https://raw.githubusercontent.com/coleam00/archon/main/archon-ui-main/public/archon-main-graphic.png</Icon>
+  <ExtraParams/>
+  <PostArgs/>
+  <CPUset/>
+  <DateInstalled>1630224000</DateInstalled>
+  <DonateText/>
+  <DonateLink/>
+  <Requires/>
+  <Config Name="UI Port" Target="80" Default="3737" Mode="tcp" Description="Port for the user interface" Type="Port" Display="always" Required="true" Mask="false">3737</Config>
+  <Config Name="API URL" Target="VITE_API_URL" Default="http://[IP]:8181" Description="URL for the Archon Server API. Replace [IP] with your Unraid server's IP address." Type="Variable" Display="always" Required="true" Mask="false"/>
+</Container>


### PR DESCRIPTION
This pull request introduces comprehensive support for production deployment of Archon using Docker and Unraid. It adds documentation, production-ready Docker configuration, and Unraid deployment templates for all services, making it much easier to deploy Archon in a real-world environment. The changes are organized into documentation improvements, new Docker production configuration, and Unraid support.

**Documentation and Deployment Guides**
* Added a new `DEPLOYMENT.md` file with step-by-step instructions for building, tagging, and pushing production Docker images to Docker Hub.
* Updated `README.md` with a new section on production deployment, including instructions for using the `docker-compose.prod.yml` file and deploying on Unraid, referencing the new deployment guide.

**Production Docker Configuration**
* Added `docker-compose.prod.yml` to define production builds for all four services (`archon-server`, `archon-mcp`, `archon-agents`, and `archon-ui`), including correct build contexts, environment variables, networking, and container dependencies.
* Added a production Dockerfile for the frontend (`archon-ui-main/Dockerfile.prod`) that builds the React app and serves it with Nginx, and included a custom Nginx configuration (`archon-ui-main/nginx.conf`). [[1]](diffhunk://#diff-e07d213ae2c885fe09e30ca96e15c6744139ba155bc975fba48b7add6ceab6c0R1-R31) [[2]](diffhunk://#diff-a324a4ea88b7d3594ec3858da56f05d803fbf54985cb32958d1c7e0372034dbbR1-R14)

**Unraid Deployment Support**
* Added Unraid XML templates for all four services (`archon-server`, `archon-mcp`, `archon-agents`, `archon-ui`), providing configuration options, environment variables, and setup instructions for easy deployment via Unraid’s web UI. [[1]](diffhunk://#diff-368666bc92faae04ae051eb8e1eac77fc691f5b0de3dfc3dfbeb6d42450cbf98R1-R36) [[2]](diffhunk://#diff-38fc068952f2c9a967337890791f5ad1add0720c049d35288822f365611f373eR1-R34) [[3]](diffhunk://#diff-2e22df09e0d84834daeadcfe89989b246f174065442a93867e2a2564c52c8717R1-R33) [[4]](diffhunk://#diff-53c53b98f93c71c10b9ff5945ad4fbaed54c74eee5045758477553ee289a7b99R1-R29)