### PR TITLE
Fix business document categorization bug

### DIFF
--- a/python/src/server/api_routes/knowledge_api.py
+++ b/python/src/server/api_routes/knowledge_api.py
@@ -513,6 +513,11 @@ async def upload_document(
 ):
     """Upload and process a document with progress tracking."""
     try:
+        # DETAILED LOGGING: Track knowledge_type parameter flow
+        safe_logfire_info(
+            f"📋 UPLOAD: Starting document upload | filename={file.filename} | content_type={file.content_type} | knowledge_type={knowledge_type}"
+        )
+        
         safe_logfire_info(
             f"Starting document upload | filename={file.filename} | content_type={file.content_type} | knowledge_type={knowledge_type}"
         )

--- a/python/src/server/services/knowledge/knowledge_item_service.py
+++ b/python/src/server/services/knowledge/knowledge_item_service.py
@@ -369,9 +369,11 @@ class KnowledgeItemService:
             "source_id": source_id,
             "code_examples": code_examples,
             "metadata": {
+                # Spread source_metadata first, then override with computed values
+                **source_metadata,
                 "knowledge_type": source_metadata.get("knowledge_type", "technical"),
                 "tags": source_metadata.get("tags", []),
-                "source_type": source_type,
+                "source_type": source_type,  # This should be the correctly determined source_type
                 "status": "active",
                 "description": source_metadata.get("description", source.get("summary", "")),
                 "chunks_count": await self._get_chunks_count(source_id),  # Get actual chunk count
@@ -385,7 +387,6 @@ class KnowledgeItemService:
                 "file_type": source_metadata.get("file_type"),
                 "update_frequency": source.get("update_frequency", 7),
                 "code_examples_count": len(code_examples),
-                **source_metadata,
             },
             "created_at": source.get("created_at"),
             "updated_at": source.get("updated_at"),

--- a/python/src/server/services/source_management_service.py
+++ b/python/src/server/services/source_management_service.py
@@ -230,8 +230,14 @@ Provide only the title, nothing else."""
         except Exception as e:
             search_logger.error(f"Error generating title for {source_id}: {e}")
 
-    # Build metadata
-    metadata = {"knowledge_type": knowledge_type, "tags": tags or [], "auto_generated": True}
+    # Build metadata - determine source_type from source_id pattern
+    source_type = "file" if source_id.startswith("file_") else "url"
+    metadata = {
+        "knowledge_type": knowledge_type, 
+        "tags": tags or [], 
+        "source_type": source_type,
+        "auto_generated": True
+    }
 
     return title, metadata
 
@@ -260,6 +266,7 @@ def update_source_info(
         tags: List of tags
         update_frequency: Update frequency in days
     """
+    search_logger.info(f"Updating source {source_id} with knowledge_type={knowledge_type}")
     try:
         # First, check if source already exists to preserve title
         existing_source = (
@@ -272,12 +279,15 @@ def update_source_info(
             search_logger.info(f"Preserving existing title for {source_id}: {existing_title}")
 
             # Update metadata while preserving title
+            source_type = "file" if source_id.startswith("file_") else "url"
             metadata = {
                 "knowledge_type": knowledge_type,
                 "tags": tags or [],
+                "source_type": source_type,
                 "auto_generated": False,  # Mark as not auto-generated since we're preserving
                 "update_frequency": update_frequency,
             }
+            search_logger.info(f"Updating existing source {source_id} metadata: knowledge_type={knowledge_type}")
             if original_url:
                 metadata["original_url"] = original_url
 
@@ -308,6 +318,7 @@ def update_source_info(
             if original_url:
                 metadata["original_url"] = original_url
 
+            search_logger.info(f"Creating new source {source_id} with knowledge_type={knowledge_type}")
             # Insert new source
             client.table("archon_sources").insert({
                 "source_id": source_id,

--- a/python/src/server/services/storage/storage_services.py
+++ b/python/src/server/services/storage/storage_services.py
@@ -45,6 +45,8 @@ class DocumentStorageService(BaseStorageService):
         Returns:
             Tuple of (success, result_dict)
         """
+        logger.info(f"Document upload starting: {filename} as {knowledge_type} knowledge")
+        
         with safe_span(
             "upload_document",
             filename=filename,
@@ -102,6 +104,7 @@ class DocumentStorageService(BaseStorageService):
                             "source": source_id,
                             "source_id": source_id,
                             "knowledge_type": knowledge_type,
+                            "source_type": "file",  # FIX: Mark as file upload
                             "filename": filename,
                         },
                     )
@@ -127,12 +130,16 @@ class DocumentStorageService(BaseStorageService):
                     extract_source_summary, source_id, file_content[:5000]
                 )
 
+                logger.info(f"Updating source info for {source_id} with knowledge_type={knowledge_type}")
                 await self.threading_service.run_io_bound(
                     update_source_info,
                     self.supabase_client,
                     source_id,
                     source_summary,
                     total_word_count,
+                    file_content[:1000],  # content for title generation
+                    knowledge_type,      # FIX: Pass knowledge_type parameter!
+                    tags,               # FIX: Pass tags parameter!
                 )
 
                 await report_progress("Storing document chunks...", 70)


### PR DESCRIPTION
# Pull Request

  ## Summary
  Fixes a critical bug where business documents uploaded via "Add Knowledge → Business Knowledge → Upload File" were incorrectly categorized as technical knowledge, causing them to appear with the wrong color theme       
  and in the wrong project sections.

  ## Changes Made
  - Fixed missing `knowledge_type` and `tags` parameters in `DocumentStorageService.upload_document()` call to `update_source_info()`
  - Added `source_type='file'` to document chunk metadata for proper categorization
  - Enhanced source metadata creation to include `source_type` based on source_id pattern
  - Fixed metadata spread order in `knowledge_item_service` to prevent `source_type` override
  - Business documents now correctly show pink color theme and appear in Business Documents section

  ## Type of Change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Code refactoring

  ## Affected Services
  - [ ] Frontend (React UI)
  - [x] Server (FastAPI backend)
  - [ ] MCP Server (Model Context Protocol)
  - [ ] Agents (PydanticAI service)
  - [ ] Database (migrations/schema)
  - [ ] Docker/Infrastructure
  - [ ] Documentation site

  ## Testing
  - [x] All existing tests pass
  - [ ] Added new tests for new functionality
  - [x] Manually tested affected user flows
  - [x] Docker builds succeed for all services

  ### Test Evidence
  ```bash
  # Manual testing performed:
  # 1. Uploaded business document via Knowledge Base → Add Knowledge → Business Knowledge → Upload File
  # 2. Verified document shows pink color theme (not blue)
  # 3. Verified document appears in Business Documents section in project management
  # 4. Confirmed technical documents still work correctly with purple color theme

  Checklist

  - My code follows the service architecture patterns
  - If using an AI coding assistant, I used the CLAUDE.md rules
  - I have added tests that prove my fix/feature works
  - All new and existing tests pass locally
  - My changes generate no new warnings
  - I have updated relevant documentation
  - I have verified no regressions in existing features

  Breaking Changes

  None - this is a backward-compatible bug fix that only affects the visual categorization and project linking of business documents.

  Additional Notes

  Root Cause: The document upload pipeline was not properly passing the knowledge_type parameter through the storage chain, causing business documents to default to "technical" classification.

  Files Changed:
  - python/src/server/services/storage/storage_services.py
  - python/src/server/services/source_management_service.py
  - python/src/server/services/knowledge/knowledge_item_service.py
  - python/src/server/api_routes/knowledge_api.py

  Impact: Business documents uploaded before this fix will remain incorrectly categorized, but new uploads will work correctly. Existing documents can be manually re-categorized using the project management
  interface.