### PR TITLE
fix docker host in linux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
         BUILDKIT_INLINE_CACHE: 1
         ARCHON_SERVER_PORT: ${ARCHON_SERVER_PORT:-8181}
     container_name: Archon-Server
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - "${ARCHON_SERVER_PORT:-8181}:${ARCHON_SERVER_PORT:-8181}"
     environment:


### PR DESCRIPTION
Linux doesn't support the special docker hostname.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container-to-host networking by enabling resolution of host.docker.internal for the Archon-Server service, making it easier to connect to services running on the host machine during local use (e.g., databases, APIs).
  * No changes to ports, environment variables, volumes, or health checks; existing workflows remain unchanged.
  * Enhances reliability and reduces setup friction for local development and troubleshooting without impacting production behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->