### PR TITLE
Fix bug report submission issues (#273)

### DIFF
--- a/archon-ui-main/src/components/bug-report/BugReportModal.tsx
+++ b/archon-ui-main/src/components/bug-report/BugReportModal.tsx
@@ -24,7 +24,7 @@ export const BugReportModal: React.FC<BugReportModalProps> = ({
   context,
 }) => {
   const [report, setReport] = useState<Omit<BugReportData, "context">>({
-    title: `🐛 ${context.error.name}: ${context.error.message}`,
+    title: "",
     description: "",
     stepsToReproduce: "",
     expectedBehavior: "",
@@ -39,6 +39,11 @@ export const BugReportModal: React.FC<BugReportModalProps> = ({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    if (!report.title.trim()) {
+      showToast("Please provide a title for the bug report", "error");
+      return;
+    }
 
     if (!report.description.trim()) {
       showToast(
@@ -188,7 +193,7 @@ export const BugReportModal: React.FC<BugReportModalProps> = ({
                 {/* Error Preview */}
                 <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md p-3">
                   <div className="font-medium text-red-800 dark:text-red-200 text-sm">
-                    {context.error.name}: {context.error.message}
+                    {context.error.message || "Manual bug report"}
                   </div>
                   {context.error.stack && (
                     <details className="mt-2">

--- a/archon-ui-main/src/hooks/useBugReport.ts
+++ b/archon-ui-main/src/hooks/useBugReport.ts
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { bugReportService, BugContext } from '../services/bugReportService';
+import { useState } from "react";
+import { bugReportService, BugContext } from "../services/bugReportService";
 
 export const useBugReport = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -8,36 +8,36 @@ export const useBugReport = () => {
 
   const openBugReport = async (error?: Error) => {
     setLoading(true);
-    
+
     try {
       const bugContext = await bugReportService.collectBugContext(error);
       setContext(bugContext);
       setIsOpen(true);
     } catch (contextError) {
-      console.error('Failed to collect bug context:', contextError);
+      console.error("Failed to collect bug context:", contextError);
       // Still open the modal but with minimal context
       setContext({
         error: {
-          message: error?.message || 'Manual bug report',
+          message: error?.message || "Manual bug report",
           stack: error?.stack,
-          name: error?.name || 'UserReportedError'
+          name: error?.name || "Bug Report",
         },
         app: {
-          version: 'unknown',
+          version: "unknown",
           url: window.location.href,
-          timestamp: new Date().toISOString()
+          timestamp: new Date().toISOString(),
         },
         system: {
           platform: navigator.platform,
           userAgent: navigator.userAgent,
-          memory: 'unknown'
+          memory: "unknown",
         },
         services: {
           server: false,
           mcp: false,
-          agents: false
+          agents: false,
         },
-        logs: ['Failed to collect logs']
+        logs: ["Failed to collect logs"],
       });
       setIsOpen(true);
     } finally {
@@ -55,6 +55,6 @@ export const useBugReport = () => {
     context,
     loading,
     openBugReport,
-    closeBugReport
+    closeBugReport,
   };
 };

--- a/python/src/server/api_routes/bug_report_api.py
+++ b/python/src/server/api_routes/bug_report_api.py
@@ -47,7 +47,7 @@ class BugReportResponse(BaseModel):
 class GitHubService:
     def __init__(self):
         self.token = os.getenv("GITHUB_TOKEN")
-        self.repo = os.getenv("GITHUB_REPO", "dynamous-community/Archon-V2-Alpha")
+        self.repo = os.getenv("GITHUB_REPO", "coleam00/Archon")
 
     async def create_issue(self, bug_report: BugReportRequest) -> dict[str, Any]:
         """Create a GitHub issue from a bug report."""
@@ -243,14 +243,14 @@ def _create_manual_submission_response(bug_report: BugReportRequest) -> BugRepor
     import urllib.parse
 
     base_url = f"https://github.com/{github_service.repo}/issues/new"
+    
+    # Don't use template for manual submission - this allows the body to be pre-filled
+    # The template parameter doesn't support pre-filling individual form fields
     params = {
-        "template": "bug_report.yml",
-        "title": bug_report.title,
+        "title": f"🐛 {bug_report.title}",
         "labels": f"bug,auto-report,severity:{bug_report.severity},component:{bug_report.component}",
+        "body": issue_body,
     }
-
-    # Add the formatted body as a parameter
-    params["body"] = issue_body
 
     # Build the URL
     query_string = urllib.parse.urlencode(params)
@@ -275,6 +275,6 @@ async def bug_report_health():
         "status": "healthy" if github_configured else "degraded",
         "github_token_configured": github_configured,
         "github_repo_configured": repo_configured,
-        "repo": os.getenv("GITHUB_REPO", "dynamous-community/Archon-V2-Alpha"),
+        "repo": os.getenv("GITHUB_REPO", "coleam00/Archon"),
         "message": "Bug reporting is ready" if github_configured else "GitHub token not configured",
     }


### PR DESCRIPTION
# Pull Request

## Summary
Fixes issue #273 where bug reports were being submitted to the old repository URL and had confusing auto-generated titles.

## Changes Made
- Updated repository reference from `dynamous-community/Archon-V2-Alpha` to `coleam00/Archon` in bug report API
- Removed auto-generated title containing "UserReportedError" text - users now must enter their own title
- Made bug title field mandatory with proper validation
- Simplified GitHub issue creation for manual submissions to preserve all user input
- Removed template parameter from manual submissions to allow full content transfer

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Affected Services
- [x] Frontend (React UI)
- [x] Server (FastAPI backend)

## Testing
- [x] Manually tested affected user flows
- [x] Docker builds succeed for all services

### Test Evidence
```bash
# Verified bug report flow works correctly
# Checked that all form fields are preserved when redirecting to GitHub
# Confirmed repository URL points to correct location
```

## Checklist
- [x] My code follows the service architecture patterns
- [x] If using an AI coding assistant, I used the CLAUDE.md rules
- [x] My changes generate no new warnings
- [x] I have verified no regressions in existing features

## Breaking Changes
None - all changes are backward compatible.

## Additional Notes
This fix addresses the immediate issue of bug reports failing due to incorrect repository references. The manual submission now uses GitHub's standard issue creation (without the YAML template) to ensure all user-entered data is preserved when redirecting to GitHub.

Fixes #273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Bug Report modal now requires a user-entered title with a clear prompt if missing.
  - Error preview shows the actual error message or “Manual bug report” when none is available.
  - “Actual behavior” is auto-filled from the error message to speed up reporting.
  - Manual GitHub submission opens a pre-filled issue with an emoji-prefixed title and formatted body.

- Chores
  - Default GitHub repository for bug reports updated to the new project location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->