### PR TITLE
UX: copy-safe Docker command in error modal (follow-up to #442)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ This new vision for Archon replaces the old one (the agenteer). Archon used to b
    **Full Docker Mode (Recommended for Normal Archon Usage)**
 
    ```bash
+   docker compose up --build -d
+   # or, to match a previously used explicit profile:
    docker compose --profile full up --build -d
    # or
    make dev-docker # (Alternative: Requires make installed )

--- a/archon-ui-main/src/components/BackendStartupError.tsx
+++ b/archon-ui-main/src/components/BackendStartupError.tsx
@@ -49,11 +49,16 @@ export const BackendStartupError: React.FC = () => {
                   After fixing the issue in your .env file, recreate the Docker containers:
                 </p>
                 <code className="block mt-2 p-2 bg-black/70 rounded text-red-100 font-mono text-sm">
-                  docker compose down && docker compose up -d
+                  docker compose down && docker compose up --build -d
                 </code>
-                <p className="text-red-300 text-xs mt-2">
-                  Note: Use 'down' and 'up', not 'restart' - containers need to be recreated to load new environment variables
-                </p>
+                <div className="text-red-300 text-xs mt-2">
+                  <p>Note:</p>
+                  <p>• Use 'down' and 'up' (not 'restart') so new env vars are picked up.</p>
+                  <p>• If you originally started with a specific profile (backend, frontend, or full),</p>
+                  <p>&nbsp;&nbsp;run the same profile again:</p>
+                  <br />
+                  <code className="bg-black/50 px-1 rounded">docker compose --profile full up --build -d</code>
+                </div>
               </div>
 
               <div className="flex justify-center pt-4">


### PR DESCRIPTION
Default command is `docker compose up --build -d`. Adds a short note for users who started with a profile; README mirrors modal. Ref: #442.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * README Quick Start: Added an alternative default Docker Compose command and a clarifying comment alongside the existing profile-based option.
  * Backend startup error screen: Updated guidance to include rebuilding images (--build), clarified steps for picking up new env vars, and provided a profile-specific example command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->