### PR TITLE
Fix proxy when specifying PROD=true

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,11 @@ ARCHON_AGENTS_PORT=8052
 ARCHON_UI_PORT=3737
 ARCHON_DOCS_PORT=3838
 
+# When enabled, PROD mode will proxy ARCHON_SERVER_PORT through ARCHON_UI_PORT. This exposes both the 
+# Archon UI and API through a single port. This is useful when deploying Archon behind a reverse 
+# proxy where you want to expose the frontend on a single external domain.
+PROD=false
+
 # Embedding Configuration
 # Dimensions for embedding vectors (1536 for OpenAI text-embedding-3-small)
 EMBEDDING_DIMENSIONS=1536

--- a/archon-ui-main/src/components/layouts/MainLayout.tsx
+++ b/archon-ui-main/src/components/layouts/MainLayout.tsx
@@ -45,7 +45,7 @@ export const MainLayout: React.FC<MainLayoutProps> = ({
         const timeoutId = setTimeout(() => controller.abort(), 5000);
         
         // Check if backend is responding with a simple health check
-        const response = await fetch(`${credentialsService['baseUrl']}/health`, {
+        const response = await fetch(`${credentialsService['baseUrl']}/api/health`, {
           method: 'GET',
           signal: controller.signal
         });

--- a/archon-ui-main/src/config/api.ts
+++ b/archon-ui-main/src/config/api.ts
@@ -8,7 +8,7 @@
 // Get the API URL from environment or construct it
 export function getApiUrl(): string {
   // For relative URLs in production (goes through proxy)
-  if (import.meta.env.PROD === 'true') {
+  if (import.meta.env.PROD) {
     return '';
   }
 

--- a/archon-ui-main/src/config/api.ts
+++ b/archon-ui-main/src/config/api.ts
@@ -7,14 +7,14 @@
 
 // Get the API URL from environment or construct it
 export function getApiUrl(): string {
+  // For relative URLs in production (goes through proxy)
+  if (import.meta.env.PROD === 'true') {
+    return '';
+  }
+
   // Check if VITE_API_URL is provided (set by docker-compose)
   if (import.meta.env.VITE_API_URL) {
     return import.meta.env.VITE_API_URL;
-  }
-
-  // For relative URLs in production (goes through proxy)
-  if (import.meta.env.PROD) {
-    return '';
   }
 
   // For development, construct from window location

--- a/archon-ui-main/test/config/api.test.ts
+++ b/archon-ui-main/test/config/api.test.ts
@@ -35,7 +35,9 @@ describe('API Configuration', () => {
     it('should return empty string in production mode', async () => {
       // Set production mode
       (import.meta.env as any).PROD = true;
-      delete (import.meta.env as any).VITE_API_URL;
+
+      // It should not use VITE_API_URL
+      (import.meta.env as any).VITE_API_URL = 'http://custom-api:9999';
       
       const { getApiUrl } = await import('../../src/config/api');
       expect(getApiUrl()).toBe('');

--- a/archon-ui-main/vite.config.ts
+++ b/archon-ui-main/vite.config.ts
@@ -280,6 +280,7 @@ export default defineConfig(({ mode }: ConfigEnv): UserConfig => {
       host: '0.0.0.0', // Listen on all network interfaces with explicit IP
       port: parseInt(process.env.ARCHON_UI_PORT || env.ARCHON_UI_PORT || '3737'), // Use configurable port
       strictPort: true, // Exit if port is in use
+      allowedHosts: [env.HOST, 'localhost', '127.0.0.1'],
       proxy: {
         '/api': {
           target: `http://${host}:${port}`,
@@ -308,6 +309,7 @@ export default defineConfig(({ mode }: ConfigEnv): UserConfig => {
     define: {
       'import.meta.env.VITE_HOST': JSON.stringify(host),
       'import.meta.env.VITE_PORT': JSON.stringify(port),
+      'import.meta.env.PROD': JSON.stringify(env.PROD || false),
     },
     resolve: {
       alias: {

--- a/archon-ui-main/vite.config.ts
+++ b/archon-ui-main/vite.config.ts
@@ -309,7 +309,7 @@ export default defineConfig(({ mode }: ConfigEnv): UserConfig => {
     define: {
       'import.meta.env.VITE_HOST': JSON.stringify(host),
       'import.meta.env.VITE_PORT': JSON.stringify(port),
-      'import.meta.env.PROD': JSON.stringify(env.PROD || false),
+      'import.meta.env.PROD': env.PROD === 'true',
     },
     resolve: {
       alias: {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,6 +154,7 @@ services:
       - VITE_ARCHON_SERVER_PORT=${ARCHON_SERVER_PORT:-8181}
       - ARCHON_SERVER_PORT=${ARCHON_SERVER_PORT:-8181}
       - HOST=${HOST:-localhost}
+      - PROD=${PROD:-false}
     networks:
       - app-network
     healthcheck:


### PR DESCRIPTION
# Pull Request

## Summary
<!-- Provide a brief description of what this PR accomplishes -->
There appears to be a `PROD` env variable that was intended to make a Vite proxy handle API request. It's nearly hooked up, but the `PROD` environment variable isn't forwarded from the .env file, and the health endpoint is not using the proxied version of the URL.

Default behavior should remain unchanged, but it looks like in some cases the proxy was already used. This was true in places where `getApiUrl` was not used, for example: [knowledgeBaseService](https://github.com/michaelphines/Archon/blob/fix-proxy/archon-ui-main/src/services/knowledgeBaseService.ts#L73:L82) uses [`API_BASE_URL` and not `API_FULL_URL`](https://github.com/michaelphines/Archon/blob/fix-proxy/archon-ui-main/src/config/api.ts#L62)

## Changes Made
<!-- List the main changes in this PR -->
- Update the health checker to use the `/api/health` version of the health endpoint rather than `/health`
- Pass `PROD` through docker-compose and Vite
- If `"true"`, make the `PROD` setting override the `VITE_API_URL` (because `VITE_API_URL` always seems to be set)
- Add `HOST` to `allowedHosts`

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Affected Services
<!-- Mark all that apply with an "x" -->
- [x] Frontend (React UI)
- [ ] Server (FastAPI backend)
- [ ] MCP Server (Model Context Protocol)
- [ ] Agents (PydanticAI service)
- [ ] Database (migrations/schema)
- [ ] Docker/Infrastructure
- [ ] Documentation site

## Testing
<!-- Describe how you tested your changes -->
- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested affected user flows
- [x] Docker builds succeed for all services

### Test Evidence
<!-- Provide specific test commands run and their results -->

```
Michael ~/projects/archon/archon-ui-main $ npm run test

> archon-ui@0.1.0 test
> vitest

[snip]

·············································································
JSON report written to /Users/Michael/projects/archon/archon-ui-main/public/test-results/test-results.json

 Test Files  7 passed (7)
      Tests  77 passed (77)
   Start at  00:33:13
   Duration  1.64s (transform 339ms, setup 1.02s, collect 359ms, tests 734ms, environment 2.01s, prepare 417ms)
```

## Checklist
<!-- Mark completed items with an "x" -->
- [x] My code follows the service architecture patterns
- [ ] If using an AI coding assistant, I used the CLAUDE.md rules
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass locally
- [x] My changes generate no new warnings
- [ ] I have updated relevant documentation
- [x] I have verified no regressions in existing features

## Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
<!-- Include migration steps if applicable -->
None

## Additional Notes
<!-- Any additional information that reviewers should know -->
<!-- Screenshots, performance metrics, dependencies added, etc. -->
Given that the proxy here is already partially used even with `PROD` unset, I'm guessing it probably makes sense to make the `PROD` behavior the default (or even only) behavior. I didn't think that decision was appropriately in scope for this PR, however. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated health-check path for improved service compatibility.
  - Corrected production API URL resolution so production ignores custom API URL.
- **Development**
  - Dev server accepts localhost, 127.0.0.1, and custom hostnames.
  - Exposes a runtime PROD flag for consistent environment handling.
- **Chores**
  - Added PROD environment variable to compose and example config.
- **Tests**
  - Adjusted tests to validate production behavior ignoring custom API URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->