### PR TITLE
feat: disable agents service by default using Docker profiles

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,9 @@
-# Docker Compose Profiles Strategy:
-# - No profile: All services start by default when running 'docker compose up'
-# - "backend": Starts only backend services (server, mcp, agents) for hybrid development
-# - "frontend": Starts only the frontend UI service  
-# - "full": Starts all services for complete Docker deployment (same as no profile)
-# Use --profile flag to control which services start:
-#   docker compose up                      # All services (default behavior)
-#   docker compose --profile backend up    # Backend only for hybrid dev
-#   docker compose --profile full up       # Everything in Docker (same as default)
+# Docker Compose profiles:
+# - Default (no profile): Starts archon-server, archon-mcp, and archon-frontend
+# - Agents are opt-in: archon-agents starts only with the "agents" profile
+# Usage:
+#   docker compose up                        # Starts server, mcp, frontend (agents disabled)
+#   docker compose --profile agents up -d    # Also starts archon-agents
 
 services:
   # Server Service (FastAPI + Socket.IO + Crawling)
@@ -30,6 +27,7 @@ services:
       - ARCHON_SERVER_PORT=${ARCHON_SERVER_PORT:-8181}
       - ARCHON_MCP_PORT=${ARCHON_MCP_PORT:-8051}
       - ARCHON_AGENTS_PORT=${ARCHON_AGENTS_PORT:-8052}
+      - AGENTS_ENABLED=${AGENTS_ENABLED:-false}
     networks:
       - app-network
     volumes:
@@ -83,7 +81,8 @@ services:
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
       # MCP needs to know where to find other services
       - API_SERVICE_URL=http://archon-server:${ARCHON_SERVER_PORT:-8181}
-      - AGENTS_SERVICE_URL=http://archon-agents:${ARCHON_AGENTS_PORT:-8052}
+      - AGENTS_ENABLED=${AGENTS_ENABLED:-false}
+      - AGENTS_SERVICE_URL=${AGENTS_SERVICE_URL:-http://archon-agents:${ARCHON_AGENTS_PORT:-8052}}
       - ARCHON_MCP_PORT=${ARCHON_MCP_PORT:-8051}
       - ARCHON_SERVER_PORT=${ARCHON_SERVER_PORT:-8181}
       - ARCHON_AGENTS_PORT=${ARCHON_AGENTS_PORT:-8052}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,6 @@ services:
       - app-network
     depends_on:
       - archon-server
-      - archon-agents
     extra_hosts:
       - "host.docker.internal:host-gateway"
     healthcheck:
@@ -109,6 +108,8 @@ services:
 
   # AI Agents Service (ML/Reranking)
   archon-agents:
+    profiles:
+      - agents  # Only starts when explicitly using --profile agents
     build:
       context: ./python
       dockerfile: Dockerfile.agents


### PR DESCRIPTION
# Pull Request

## Summary
Disables the archon-agents service by default to prevent startup issues while it's under development. The service can still be enabled when needed using Docker profiles.

## Changes Made
- Added 'agents' profile to archon-agents service in docker-compose.yml
- Removed archon-agents as a dependency from archon-mcp service
- Service now only starts when explicitly using --profile agents flag

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Affected Services
- [ ] Frontend (React UI)
- [ ] Server (FastAPI backend)
- [x] MCP Server (Model Context Protocol)
- [x] Agents (PydanticAI service)
- [ ] Database (migrations/schema)
- [x] Docker/Infrastructure
- [ ] Documentation site

## Testing
- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested affected user flows
- [x] Docker builds succeed for all services

### Test Evidence
```bash
# Stopped all services
make stop
# ✓ Services stopped

# Started services without agents profile
docker compose up -d
# ✓ Only archon-server, archon-mcp, archon-ui started
# ✓ archon-agents did not start

# Verified services are healthy
docker ps --format "table {{.Names}}\t{{.Status}}" | grep archon
# archon-mcp       Up (healthy)
# archon-ui        Up (healthy)  
# archon-server    Up (healthy)

# Tested MCP health check
curl -s http://localhost:8181/api/mcp/health | jq .
# {"status": "healthy", "service": "mcp"}

# MCP tools working correctly
# health_check shows api_service=true, agents_service=false (correct)
```

## Checklist
- [x] My code follows the service architecture patterns
- [x] If using an AI coding assistant, I used the CLAUDE.md rules
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass locally
- [x] My changes generate no new warnings
- [ ] I have updated relevant documentation
- [x] I have verified no regressions in existing features

## Breaking Changes
None - This change is backward compatible. The agents service can be re-enabled at any time using:
```bash
docker compose --profile agents up -d
```

## Additional Notes
- The agents service needs major updates before it's usable, so disabling it by default prevents confusion and startup errors
- All core functionality (knowledge base, crawling, documents, MCP) continues to work without the agents service
- The chat panel in the UI will show connection errors but won't crash the application
- When the agents service is ready for use, it can be enabled without any code changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Docker Compose now starts server, MCP, and frontend by default; agents are opt-in via the "agents" profile (use --profile agents).
  * archon-agents disabled by default and will only start with the agents profile.
  * MCP no longer waits for agents and can start independently.
  * New environment toggles: AGENTS_ENABLED (default false) on server and MCP, and AGENTS_SERVICE_URL on MCP to point to the agents endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->