### PR TITLE
CI fails now when unit tests for backend fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
           uv run pytest tests/ --verbose --tb=short \
             --cov=src --cov-report=xml --cov-report=html \
             --cov-report=term-missing \
-            --junitxml=test-results.xml || true
+            --junitxml=test-results.xml
 
       - name: Upload backend test results
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ help:
 install:
 	@echo "Installing dependencies..."
 	@cd archon-ui-main && npm install
-	@cd python && uv sync
+	@cd python && uv sync --group all --group dev
 	@echo "✓ Dependencies installed"
 
 # Check environment


### PR DESCRIPTION
# Pull Request

## Summary
Right now when backend unit tests with pytest fail, CI still passes. This PR fixes that.

## Changes Made
- Updated .github/workflows/ci.yml so that unit test failures actually cause the CI to fail
- Fixed up unit test command for make

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Affected Services
<!-- Mark all that apply with an "x" -->
- [ ] Frontend (React UI)
- [ ] Server (FastAPI backend)
- [ ] MCP Server (Model Context Protocol)
- [ ] Agents (PydanticAI service)
- [ ] Database (migrations/schema)
- [X] Docker/Infrastructure
- [ ] Documentation site

## Testing
<!-- Describe how you tested your changes -->
- [X] All existing tests pass
- [ ] Added new tests for new functionality
- [X] Manually tested affected user flows
- [X] Docker builds succeed for all services

### Test Evidence
```bash
make test-be
```

## Checklist
<!-- Mark completed items with an "x" -->
- [X] My code follows the service architecture patterns
- [X] If using an AI coding assistant, I used the CLAUDE.md rules
- [ ] I have added tests that prove my fix/feature works
- [X] All new and existing tests pass locally
- [X] My changes generate no new warnings
- [X] I have updated relevant documentation
- [X] I have verified no regressions in existing features