### PR TITLE
🐛 Fix sitemap URL detection causing XML parsing errors

### DIFF
--- a/python/src/server/services/crawling/helpers/url_handler.py
+++ b/python/src/server/services/crawling/helpers/url_handler.py
@@ -29,7 +29,10 @@ class URLHandler:
             True if URL is a sitemap, False otherwise
         """
         try:
-            return url.endswith("sitemap.xml") or "sitemap" in urlparse(url).path
+            parsed = urlparse(url)
+            path = parsed.path.lower()
+            # Only match URLs that end with .xml and contain sitemap in the filename
+            return path.endswith(".xml") and "sitemap" in path
         except Exception as e:
             logger.warning(f"Error checking if URL is sitemap: {e}")
             return False


### PR DESCRIPTION
## Summary
- Fixed sitemap URL detection logic to prevent XML parsing errors on HTML pages
- URLs containing 'sitemap' in path (like `https://nx.dev/see-also/sitemap`) are no longer incorrectly treated as XML sitemaps

## Problem Description
The crawler was incorrectly identifying any URL containing "sitemap" in the path as an XML sitemap, causing XML parsing failures when these URLs actually served HTML pages.

**Error before fix:**
```
xml.etree.ElementTree.ParseError: not well-formed (invalid token): line 3, column 84
ValueError: No content was crawled from the provided URL
```

## Changes Made
- Modified `URLHandler.is_sitemap()` to require both `.xml` extension AND 'sitemap' in path
- Now only actual XML sitemap files are detected as sitemaps

## Test Results
✅ All existing tests pass  
✅ Problematic URL `https://nx.dev/see-also/sitemap` → `False` (no longer treated as sitemap)  
✅ Valid sitemaps like `https://example.com/sitemap.xml` → `True` (still work correctly)

## Test plan
- [x] Run URL handler tests: `uv run pytest tests/test_url_handler.py -v`
- [x] Verify problematic URL no longer triggers XML parsing
- [x] Confirm valid sitemap URLs still work

Fixes #607

🤖 Generated with [Claude Code](https://claude.ai/code)