### PR TITLE
fix: display original crawling URL in knowledge item edit modal

### DIFF
--- a/python/src/server/services/knowledge/knowledge_item_service.py
+++ b/python/src/server/services/knowledge/knowledge_item_service.py
@@ -365,7 +365,7 @@ class KnowledgeItemService:
         return {
             "id": source_id,
             "title": source.get("title", source.get("summary", "Untitled")),
-            "url": first_page_url,
+            "url": source_metadata.get("original_url") or first_page_url,
             "source_id": source_id,
             "code_examples": code_examples,
             "metadata": {


### PR DESCRIPTION
## Summary
- ✅ Fixed knowledge item edit modal URL display issue
- ✅ Shows original user-provided URL instead of random crawled page
- ✅ Single-line backend fix with backward compatibility
- ✅ No frontend changes required

## Problem
When users created knowledge items by crawling a URL (e.g., `https://example.com`), the edit modal would show a random page discovered during crawling (e.g., `https://example.com/random-page-1`) instead of the original URL they provided.

## Root Cause
**File:** `python/src/server/services/knowledge/knowledge_item_service.py`  
**Method:** `_transform_source_to_item()`  
**Issue:** Line 368 was using `first_page_url` instead of `metadata.original_url`

The backend correctly stored the original URL in `metadata.original_url` but the data transformation layer was using the wrong source for the display URL.

## Solution
**Single Line Fix:**
```python
# Before (WRONG):
"url": first_page_url,

# After (FIXED):  
"url": source_metadata.get("original_url") or first_page_url,
```

## Technical Details

### Why This Approach
1. **Root Cause Fix:** Addresses the actual source of wrong data in backend
2. **Backward Compatible:** Falls back to `first_page_url` for legacy items  
3. **Minimal Risk:** Single line change with clear fallback logic
4. **No UI Changes:** Works with existing frontend components

### Data Flow Fix
- **Before:** User input → Storage ✅ → Transform ❌ → Display ❌
- **After:** User input → Storage ✅ → Transform ✅ → Display ✅

### Behavior
- **New Knowledge Items:** Uses `metadata.original_url` (user input)
- **Legacy Items:** Falls back to `first_page_url` (existing behavior)
- **Edge Cases:** Gracefully handles missing/empty `original_url`

## Impact

### ✅ Benefits
- Edit modal now shows meaningful URLs that match user expectations
- Consistent URL display across all knowledge item interfaces
- Improved user experience and data integrity
- No breaking changes to existing functionality

### ✅ Affected Components
- Knowledge item edit modal (primary fix)
- Knowledge items list view
- API responses for knowledge items
- Any component displaying `item.url`

## Test Plan
- [ ] Create new knowledge item via URL crawl
- [ ] Verify edit modal shows original crawling URL (not random page)
- [ ] Test with existing knowledge items (should show improved URLs)
- [ ] Verify API endpoints return correct URL data
- [ ] Test edge cases: legacy items without `original_url` metadata

## Files Changed
- `python/src/server/services/knowledge/knowledge_item_service.py`

**1 file changed, +1/-1 lines**

## Example
**Before Fix:**
- User enters: `https://docs.example.com`
- Edit modal shows: `https://docs.example.com/api/v1/users/endpoint-reference`

**After Fix:**
- User enters: `https://docs.example.com`  
- Edit modal shows: `https://docs.example.com` ✅

🤖 Generated with [Claude Code](https://claude.ai/code)