### PR TITLE
Fix MCP configuration documentation for Claude Code

### DIFF
--- a/archon-ui-main/src/features/mcp/components/McpConfigSection.tsx
+++ b/archon-ui-main/src/features/mcp/components/McpConfigSection.tsx
@@ -27,7 +27,7 @@ const ideConfigurations: Record<
       JSON.stringify(
         {
           name: "archon",
-          transport: "http",
+          type: "http",
           url: `http://${config.host}:${config.port}/mcp`,
         },
         null,
@@ -203,7 +203,7 @@ export const McpConfigSection: React.FC<McpConfigSectionProps> = ({ config, stat
   };
 
   const handleClaudeCodeCommand = () => {
-    const command = `claude mcp add --transport http archon http://${config.host}:${config.port}/mcp`;
+    const command = `claude mcp add --type http archon http://${config.host}:${config.port}/mcp`;
     navigator.clipboard.writeText(command);
     showToast("Command copied to clipboard", "success");
   };
@@ -258,7 +258,7 @@ export const McpConfigSection: React.FC<McpConfigSectionProps> = ({ config, stat
               )}
             >
               <code className="text-sm font-mono text-cyan-600 dark:text-cyan-400">
-                claude mcp add --transport http archon http://{config.host}:{config.port}/mcp
+                claude mcp add --type http archon http://{config.host}:{config.port}/mcp
               </code>
               <Button variant="outline" size="sm" onClick={handleClaudeCodeCommand}>
                 <Copy className="w-3 h-3 mr-1" />


### PR DESCRIPTION
## Summary
Fixed incorrect MCP configuration documentation on the /mcp page that was preventing successful Claude Code connections.

## Issues Fixed

### 1. Command Line Parameter Error
**Before:** `claude mcp add --transport http ...`  
**After:** `claude mcp add --type http ...`

The Claude Code CLI uses `--type` parameter, not `--transport`.

### 2. JSON Configuration Property Error  
**Before:** `"transport": "http"`  
**After:** `"type": "http"`

The JSON configuration should use `"type"` property, not `"transport"`.

## Files Changed
- `src/features/mcp/components/McpConfigSection.tsx`
  - Fixed handleClaudeCodeCommand function 
  - Fixed displayed command text
  - Fixed JSON configuration generator

## Impact
- Users can now successfully connect Claude Code to Archon using the documented instructions
- Both the copy-to-clipboard command and displayed configuration are now correct

## Testing
- [x] Verified command syntax matches Claude Code CLI documentation
- [x] Confirmed JSON property names are correct for MCP transport configuration
- [x] Tested on live Archon instance - connection successful with corrected config

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Updated Claude Code configuration to use type: "http" for MCP URLs and build commands with --type http, replacing the outdated "transport"/--transport usage. Generated configs and CLI commands now align with current Claude Code behavior. Other IDE integrations are unchanged.
* Documentation
  * Refreshed the on-screen Claude Code example to show the correct --type http syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->