### PR TITLE
feat: extract code examples during Knowledge uploads

### DIFF
--- a/python/src/server/services/storage/storage_services.py
+++ b/python/src/server/services/storage/storage_services.py
@@ -24,7 +24,6 @@ class DocumentStorageService(BaseStorageService):
         source_id: str,
         knowledge_type: str = "documentation",
         tags: list[str] | None = None,
-        extract_code_examples: bool = True,
         progress_callback: Any | None = None,
         cancellation_check: Any | None = None,
     ) -> tuple[bool, dict[str, Any]]:
@@ -37,7 +36,6 @@ class DocumentStorageService(BaseStorageService):
             source_id: Source identifier
             knowledge_type: Type of knowledge
             tags: Optional list of tags
-            extract_code_examples: Whether to extract code examples from the document
             progress_callback: Optional callback for progress
             cancellation_check: Optional function to check for cancellation
 
@@ -148,65 +146,10 @@ class DocumentStorageService(BaseStorageService):
                     cancellation_check=cancellation_check,
                 )
 
-                # Extract code examples if requested
-                code_examples_count = 0
-                if extract_code_examples and len(chunks) > 0:
-                    try:
-                        await report_progress("Extracting code examples...", 85)
-                        
-                        logger.info(f"🔍 DEBUG: Starting code extraction for {filename} | extract_code_examples={extract_code_examples}")
-                        
-                        # Import code extraction service
-                        from ..crawling.code_extraction_service import CodeExtractionService
-                        
-                        code_service = CodeExtractionService(self.supabase_client)
-                        
-                        # Create crawl_results format expected by code extraction service
-                        # markdown: cleaned plaintext (HTML->markdown for HTML files, raw content otherwise)
-                        # html: empty string to prevent HTML extraction path confusion
-                        # content_type: proper type to guide extraction method selection
-                        crawl_results = [{
-                            "url": doc_url,
-                            "markdown": file_content,  # Cleaned plaintext/markdown content
-                            "html": "",  # Empty to prevent HTML extraction path
-                            "content_type": "application/pdf" if filename.lower().endswith('.pdf') else (
-                                "text/markdown" if filename.lower().endswith(('.html', '.htm', '.md')) else "text/plain"
-                            )
-                        }]
-                        
-                        logger.info(f"🔍 DEBUG: Created crawl_results with url={doc_url}, content_length={len(file_content)}")
-                        
-                        # Create progress callback for code extraction
-                        async def code_progress_callback(data: dict):
-                            logger.info(f"🔍 DEBUG: Code extraction progress: {data}")
-                            if progress_callback:
-                                # Map code extraction progress (0-100) to our remaining range (85-95)
-                                raw_progress = data.get("progress", data.get("percentage", 0))
-                                mapped_progress = 85 + (raw_progress / 100.0) * 10  # 85% to 95%
-                                message = data.get("log", "Extracting code examples...")
-                                await progress_callback(message, int(mapped_progress))
-                        
-                        logger.info(f"🔍 DEBUG: About to call extract_and_store_code_examples...")
-                        code_examples_count = await code_service.extract_and_store_code_examples(
-                            crawl_results=crawl_results,
-                            url_to_full_document=url_to_full_document,
-                            source_id=source_id,
-                            progress_callback=code_progress_callback,
-                            cancellation_check=cancellation_check,
-                        )
-                        
-                        logger.info(f"🔍 DEBUG: Code extraction completed: {code_examples_count} code examples found for {filename}")
-                        
-                    except Exception as e:
-                        # Log error with full traceback but don't fail the entire upload
-                        logger.error(f"Code extraction failed for {filename}: {e}", exc_info=True)
-                        code_examples_count = 0
-                
                 await report_progress("Document upload completed!", 100)
 
                 result = {
                     "chunks_stored": len(chunks),
-                    "code_examples_stored": code_examples_count,
                     "total_word_count": total_word_count,
                     "source_id": source_id,
                     "filename": filename,
@@ -214,11 +157,10 @@ class DocumentStorageService(BaseStorageService):
 
                 span.set_attribute("success", True)
                 span.set_attribute("chunks_stored", len(chunks))
-                span.set_attribute("code_examples_stored", code_examples_count)
                 span.set_attribute("total_word_count", total_word_count)
 
                 logger.info(
-                    f"Document upload completed successfully: filename={filename}, chunks_stored={len(chunks)}, code_examples_stored={code_examples_count}, total_word_count={total_word_count}"
+                    f"Document upload completed successfully: filename={filename}, chunks_stored={len(chunks)}, total_word_count={total_word_count}"
                 )
 
                 return True, result
@@ -251,7 +193,6 @@ class DocumentStorageService(BaseStorageService):
                 source_id=doc.get("source_id", "upload"),
                 knowledge_type=doc.get("knowledge_type", "documentation"),
                 tags=doc.get("tags"),
-                extract_code_examples=doc.get("extract_code_examples", True),
                 progress_callback=kwargs.get("progress_callback"),
                 cancellation_check=kwargs.get("cancellation_check"),
             )

--- a/python/tests/test_upload_code_extraction.py
+++ b/python/tests/test_upload_code_extraction.py
@@ -1,0 +1,135 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.server.api_routes import knowledge_api
+
+
+class FakeTracker:
+    def __init__(self) -> None:
+        self.updates: list[dict] = []
+        self.completed: list[dict] = []
+        self.errors: list[str] = []
+
+    async def update(self, **kwargs) -> None:
+        self.updates.append(kwargs)
+
+    async def complete(self, data: dict) -> None:
+        self.completed.append(data)
+
+    async def error(self, message: str) -> None:
+        self.errors.append(message)
+
+
+@pytest.mark.asyncio
+async def test_upload_triggers_code_extraction(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_upload_document(
+        self,
+        file_content: str,
+        filename: str,
+        source_id: str,
+        knowledge_type: str = "documentation",
+        tags: list[str] | None = None,
+        progress_callback=None,
+        cancellation_check=None,
+    ):
+        captured["upload_file_content"] = file_content
+        captured["upload_source_id"] = source_id
+        captured["upload_knowledge_type"] = knowledge_type
+        captured["upload_tags"] = tags or []
+
+        if progress_callback:
+            await progress_callback("Storing document chunks", 65, {"document_batches": 1})
+
+        return True, {"chunks_stored": 3, "source_id": source_id}
+
+    monkeypatch.setattr(
+        knowledge_api.DocumentStorageService,
+        "upload_document",
+        fake_upload_document,
+    )
+
+    dummy_client = object()
+    monkeypatch.setattr(knowledge_api, "get_supabase_client", lambda: dummy_client)
+
+    events: dict[str, object] = {}
+
+    class StubCodeExtractionService:
+        def __init__(self, client):
+            events["code_service_client"] = client
+
+        async def extract_and_store_code_examples(
+            self,
+            crawl_results,
+            url_to_full_document,
+            source_id,
+            progress_callback=None,
+            cancellation_check=None,
+        ):
+            events["code_source_id"] = source_id
+            events["code_crawl_results"] = crawl_results
+            events["code_url_map"] = url_to_full_document
+
+            if progress_callback:
+                await progress_callback(
+                    {
+                        "progress": 40,
+                        "log": "Extracting code blocks",
+                        "code_blocks_found": 4,
+                    }
+                )
+                await progress_callback(
+                    {
+                        "progress": 100,
+                        "log": "Stored code examples",
+                        "code_examples_stored": 2,
+                    }
+                )
+
+            return 2
+
+    monkeypatch.setattr(knowledge_api, "CodeExtractionService", StubCodeExtractionService)
+
+    monkeypatch.setattr(
+        knowledge_api.uuid,
+        "uuid4",
+        lambda: SimpleNamespace(hex="deadbeefcafebabe123456789abcdef0"),
+    )
+
+    tracker = FakeTracker()
+
+    file_bytes = b"""```python\nprint('hello world')\n```\n"""
+    file_metadata = {"filename": "example.md", "content_type": "text/markdown"}
+
+    await knowledge_api._perform_upload_with_progress(
+        progress_id="upload-test",
+        file_content=file_bytes,
+        file_metadata=file_metadata,
+        tag_list=["example"],
+        knowledge_type="technical",
+        extract_code_examples=True,
+        tracker=tracker,
+    )
+
+    expected_source_id = "file_example_md_deadbeef"
+    assert captured["upload_source_id"] == expected_source_id
+    assert events["code_source_id"] == expected_source_id
+
+    crawl_results = events["code_crawl_results"]
+    assert len(crawl_results) == 1
+    assert crawl_results[0]["url"] == "file://example.md"
+    assert crawl_results[0]["markdown"].strip().startswith("```python")
+    assert crawl_results[0]["title"] == "example.md"
+
+    url_map = events["code_url_map"]
+    assert url_map == {"file://example.md": captured["upload_file_content"]}
+
+    assert len(tracker.completed) == 1
+    completion_payload = tracker.completed[0]
+    assert completion_payload["codeExamplesStored"] == 2
+    assert completion_payload["code_examples_stored"] == 2
+
+    assert any(update.get("status") == "code_extraction" for update in tracker.updates)
+    assert tracker.errors == []


### PR DESCRIPTION
# Pull Request

## Summary
Uploads now explicitly trigger the code-extraction pipeline so Markdown documents produce stored code examples.

## Changes Made
  - Invoke `CodeExtractionService` from `_perform_upload_with_progress` and surface progress updates for the `code_extraction` stage.
  - Simplify `DocumentStorageService.upload_document` to focus on chunking/storage and return only chunk/word metadata.
  - Add `tests/test_upload_code_extraction.py` to cover the upload-driven extraction flow and ensure completion payload metrics are emitted.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Affected Services
<!-- Mark all that apply with an "x" -->
- [ ] Frontend (React UI)
- [x] Server (FastAPI backend)
- [ ] MCP Server (Model Context Protocol)
- [ ] Agents (PydanticAI service)
- [ ] Database (migrations/schema)
- [ ] Docker/Infrastructure
- [ ] Documentation site

## Testing
<!-- Describe how you tested your changes -->
- [ ] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested affected user flows
- [ ] Docker builds succeed for all services

### Test Evidence
<!-- Provide specific test commands run and their results -->
```bash
  uv run python -m pytest tests/test_upload_code_extraction.py -q
  uv run python -m pytest tests/test_crawl_orchestration_isolated.py -q
```

## Checklist
<!-- Mark completed items with an "x" -->
- [x] My code follows the service architecture patterns
- [ ] If using an AI coding assistant, I used the CLAUDE.md rules
- [x] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass locally
- [ ] My changes generate no new warnings
- [ ] I have updated relevant documentation
- [ ] I have verified no regressions in existing features

## Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
<!-- Include migration steps if applicable -->

## Additional Notes
  Restores code-example extraction for Markdown uploads that previously stored document chunks without generating code-example entries, addressing the missing
  samples observed in recent uploads.