### PR TITLE
fix: Change Ollama default URL to host.docker.internal for Docker compatibility

### DIFF
--- a/archon-ui-main/src/components/settings/OllamaConfigurationPanel.tsx
+++ b/archon-ui-main/src/components/settings/OllamaConfigurationPanel.tsx
@@ -595,7 +595,7 @@ const OllamaConfigurationPanel: React.FC<OllamaConfigurationPanelProps> = ({
                     value={tempUrls[instance.id] !== undefined ? tempUrls[instance.id] : instance.baseUrl}
                     onChange={(e) => handleUrlChange(instance.id, e.target.value)}
                     onBlur={() => handleUrlBlur(instance.id)}
-                    placeholder="http://localhost:11434"
+                    placeholder="http://host.docker.internal:11434"
                     className={cn(
                       "text-sm",
                       tempUrls[instance.id] !== undefined && tempUrls[instance.id] !== instance.baseUrl 

--- a/archon-ui-main/src/components/settings/OllamaConfigurationPanel.tsx
+++ b/archon-ui-main/src/components/settings/OllamaConfigurationPanel.tsx
@@ -686,7 +686,7 @@ const OllamaConfigurationPanel: React.FC<OllamaConfigurationPanelProps> = ({
               />
               <Input
                 type="url"
-                placeholder="http://localhost:11434"
+                placeholder="http://host.docker.internal:11434"
                 value={newInstanceUrl}
                 onChange={(e) => setNewInstanceUrl(e.target.value)}
               />

--- a/archon-ui-main/src/components/settings/RAGSettings.tsx
+++ b/archon-ui-main/src/components/settings/RAGSettings.tsx
@@ -61,11 +61,11 @@ export const RAGSettings = ({
   // Instance configurations
   const [llmInstanceConfig, setLLMInstanceConfig] = useState({
     name: '',
-    url: ragSettings.LLM_BASE_URL || 'http://localhost:11434/v1'
+    url: ragSettings.LLM_BASE_URL || 'http://host.docker.internal:11434/v1'
   });
   const [embeddingInstanceConfig, setEmbeddingInstanceConfig] = useState({
     name: '', 
-    url: ragSettings.OLLAMA_EMBEDDING_URL || 'http://localhost:11434/v1'
+    url: ragSettings.OLLAMA_EMBEDDING_URL || 'http://host.docker.internal:11434/v1'
   });
 
   // Update instance configs when ragSettings change (after loading from database)
@@ -932,7 +932,7 @@ export const RAGSettings = ({
                               className="text-green-400 border-green-400 mb-1"
                               onClick={() => {
                                 // Quick setup: configure both instances with default values
-                                const defaultUrl = 'http://localhost:11434/v1';
+                                const defaultUrl = 'http://host.docker.internal:11434/v1';
                                 const defaultName = 'Default Ollama';
                                 setLLMInstanceConfig({ name: defaultName, url: defaultUrl });
                                 setEmbeddingInstanceConfig({ name: defaultName, url: defaultUrl });
@@ -1680,7 +1680,7 @@ export const RAGSettings = ({
                       });
                     }
                   }}
-                  placeholder="http://localhost:11434/v1"
+                  placeholder="http://host.docker.internal:11434/v1"
                 />
                 
                 {/* Convenience checkbox for single host setup */}
@@ -1753,7 +1753,7 @@ export const RAGSettings = ({
                   label="Instance URL"
                   value={embeddingInstanceConfig.url}
                   onChange={(e) => setEmbeddingInstanceConfig({...embeddingInstanceConfig, url: e.target.value})}
-                  placeholder="http://localhost:11434/v1"
+                  placeholder="http://host.docker.internal:11434/v1"
                 />
               </div>
               

--- a/docs/docs/rag.mdx
+++ b/docs/docs/rag.mdx
@@ -320,7 +320,7 @@ EMBEDDING_MODEL=text-embedding-004
 ### Ollama (Local/Private)
 ```bash
 LLM_PROVIDER=ollama
-LLM_BASE_URL=http://localhost:11434/v1
+LLM_BASE_URL=http://host.docker.internal:11434/v1
 MODEL_CHOICE=llama2
 EMBEDDING_MODEL=nomic-embed-text
 # Pros: Privacy, no API costs

--- a/migration/complete_setup.sql
+++ b/migration/complete_setup.sql
@@ -94,7 +94,7 @@ INSERT INTO archon_settings (key, encrypted_value, is_encrypted, category, descr
 -- LLM Provider configuration settings
 INSERT INTO archon_settings (key, value, is_encrypted, category, description) VALUES
 ('LLM_PROVIDER', 'openai', false, 'rag_strategy', 'LLM provider to use: openai, ollama, or google'),
-('LLM_BASE_URL', NULL, false, 'rag_strategy', 'Custom base URL for LLM provider (mainly for Ollama, e.g., http://localhost:11434/v1)'),
+('LLM_BASE_URL', NULL, false, 'rag_strategy', 'Custom base URL for LLM provider (mainly for Ollama, e.g., http://host.docker.internal:11434/v1)'),
 ('EMBEDDING_MODEL', 'text-embedding-3-small', false, 'rag_strategy', 'Embedding model for vector search and similarity matching (required for all embedding operations)')
 ON CONFLICT (key) DO NOTHING;
 

--- a/python/src/server/services/credential_service.py
+++ b/python/src/server/services/credential_service.py
@@ -475,7 +475,7 @@ class CredentialService:
     def _get_provider_base_url(self, provider: str, rag_settings: dict) -> str | None:
         """Get base URL for provider."""
         if provider == "ollama":
-            return rag_settings.get("LLM_BASE_URL", "http://localhost:11434/v1")
+            return rag_settings.get("LLM_BASE_URL", "http://host.docker.internal:11434/v1")
         elif provider == "google":
             return "https://generativelanguage.googleapis.com/v1beta/openai/"
         return None  # Use default for OpenAI

--- a/python/src/server/services/llm_provider_service.py
+++ b/python/src/server/services/llm_provider_service.py
@@ -203,7 +203,7 @@ async def _get_optimal_ollama_instance(instance_type: str | None = None,
                 return embedding_url if embedding_url.endswith('/v1') else f"{embedding_url}/v1"
 
         # Default to LLM base URL for chat operations
-        fallback_url = rag_settings.get("LLM_BASE_URL", "http://localhost:11434")
+        fallback_url = rag_settings.get("LLM_BASE_URL", "http://host.docker.internal:11434")
         return fallback_url if fallback_url.endswith('/v1') else f"{fallback_url}/v1"
 
     except Exception as e:
@@ -211,11 +211,11 @@ async def _get_optimal_ollama_instance(instance_type: str | None = None,
         # Final fallback to localhost only if we can't get RAG settings
         try:
             rag_settings = await credential_service.get_credentials_by_category("rag_strategy")
-            fallback_url = rag_settings.get("LLM_BASE_URL", "http://localhost:11434")
+            fallback_url = rag_settings.get("LLM_BASE_URL", "http://host.docker.internal:11434")
             return fallback_url if fallback_url.endswith('/v1') else f"{fallback_url}/v1"
         except Exception as fallback_error:
             logger.error(f"Could not retrieve fallback configuration: {fallback_error}")
-            return "http://localhost:11434/v1"
+            return "http://host.docker.internal:11434/v1"
 
 
 async def get_embedding_model(provider: str | None = None) -> str:

--- a/python/src/server/services/provider_discovery_service.py
+++ b/python/src/server/services/provider_discovery_service.py
@@ -23,7 +23,7 @@ _provider_cache: dict[str, tuple[Any, float]] = {}
 _CACHE_TTL_SECONDS = 300  # 5 minutes
 
 # Default Ollama instance URL (configurable via environment/settings)
-DEFAULT_OLLAMA_URL = "http://localhost:11434"
+DEFAULT_OLLAMA_URL = "http://host.docker.internal:11434"
 
 # Model pattern detection for dynamic capabilities (no hardcoded model names)
 CHAT_MODEL_PATTERNS = ["llama", "qwen", "mistral", "codellama", "phi", "gemma", "vicuna", "orca"]

--- a/python/tests/test_async_llm_provider_service.py
+++ b/python/tests/test_async_llm_provider_service.py
@@ -69,7 +69,7 @@ class TestAsyncLLMProviderService:
         return {
             "provider": "ollama",
             "api_key": "ollama",
-            "base_url": "http://localhost:11434/v1",
+            "base_url": "http://host.docker.internal:11434/v1",
             "chat_model": "llama2",
             "embedding_model": "nomic-embed-text",
         }
@@ -127,7 +127,7 @@ class TestAsyncLLMProviderService:
                 async with get_llm_client() as client:
                     assert client == mock_client
                     mock_openai.assert_called_once_with(
-                        api_key="ollama", base_url="http://localhost:11434/v1"
+                        api_key="ollama", base_url="http://host.docker.internal:11434/v1"
                     )
 
     @pytest.mark.asyncio
@@ -216,7 +216,7 @@ class TestAsyncLLMProviderService:
         }
         mock_credential_service.get_active_provider.return_value = config_without_key
         mock_credential_service.get_credentials_by_category = AsyncMock(return_value={
-            "LLM_BASE_URL": "http://localhost:11434"
+            "LLM_BASE_URL": "http://host.docker.internal:11434"
         })
 
         with patch(
@@ -234,7 +234,7 @@ class TestAsyncLLMProviderService:
                     # Verify it created an Ollama client with correct params
                     mock_openai.assert_called_once_with(
                         api_key="ollama",
-                        base_url="http://localhost:11434/v1"
+                        base_url="http://host.docker.internal:11434/v1"
                     )
 
     @pytest.mark.asyncio
@@ -480,7 +480,7 @@ class TestAsyncLLMProviderService:
         """Test creating clients for different providers in sequence"""
         configs = [
             {"provider": "openai", "api_key": "openai-key", "base_url": None},
-            {"provider": "ollama", "api_key": "ollama", "base_url": "http://localhost:11434/v1"},
+            {"provider": "ollama", "api_key": "ollama", "base_url": "http://host.docker.internal:11434/v1"},
             {
                 "provider": "google",
                 "api_key": "google-key",


### PR DESCRIPTION
## Summary
- Changed default Ollama URL from `localhost:11434` to `host.docker.internal:11434`
- This allows Docker containers to connect to Ollama running on the host machine
- Most users run Archon in Docker but Ollama as a local binary, making this a better default

## Changes Made
- Updated backend Python services (provider_discovery_service.py, llm_provider_service.py, credential_service.py)
- Updated frontend React components (RAGSettings.tsx, OllamaConfigurationPanel.tsx)
- Updated database migration script (complete_setup.sql)
- Updated documentation (rag.mdx)

## Why This Change?
The current default of `localhost:11434` doesn't work when Archon runs in Docker and Ollama runs as a local binary on the host machine. Using `host.docker.internal:11434` allows the Docker container to properly connect to the host's Ollama instance, which is the most common deployment scenario.

## Test Plan
- [ ] Verify Archon in Docker can connect to host Ollama with the new default
- [ ] Verify users can still override the URL if needed
- [ ] Check that existing configurations are not affected

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Changed default Ollama base URLs from localhost to host.docker.internal across the UI, backend services, fallbacks, and provider discovery; updated settings UI placeholders and quick-setup defaults.
* **Documentation**
  * Updated RAG docs and quick-setup examples to use host.docker.internal:11434/v1 for Ollama.
* **Tests**
  * Updated tests and fixtures to expect the new Ollama base URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->