### PR TITLE
Fix Documentation Service build process

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -8,7 +8,7 @@ export default {
   baseUrl: '/',
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
-  favicon: 'favicon.png',
+  favicon: 'img/favicon.svg',
   organizationName: 'archon',
   projectName: 'archon',
   
@@ -132,7 +132,7 @@ export default {
         title: 'Archon',
         logo: {
           alt: 'Archon Logo',
-          src: 'logo-neon.png',
+          src: 'img/logo-neon.svg',
         },
         items: [
           {

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -267,7 +267,7 @@ const ReactFlowDiagram = ({ reactFlowInstance, lucideIcons }) => {
           style={{ background: '#8b5cf6', border: '2px solid #8b5cf6' }}
         />
 <img src="/img/Python-logo-notext.svg" alt="Python" className={styles.pythonIcon} />
-        <img src="/logo-neon.png" alt="Archon" className={styles.archonIcon} />
+        <img src="/img/logo-neon.svg" alt="Archon" className={styles.archonIcon} />
         <div className={styles.archonText}>
           <h3>{data.label}</h3>
           <p>{data.subtitle}</p>

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -18,7 +18,7 @@
   transform: translateY(-50%);
   width: 55%;
   height: 95%;
-  background-image: url('/img/logo-neon.png');
+  background-image: url('/img/logo-neon.svg');
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center right;


### PR DESCRIPTION
# Pull Request for Fixes #750 

## Summary
Fixes the problem with the invalid logo in the build process.

## Changes Made
- Changed `logo-neon.png` to `logo-neon.svg`.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Affected Services
<!-- Mark all that apply with an "x" -->
- [ ] Frontend (React UI)
- [ ] Server (FastAPI backend)
- [ ] MCP Server (Model Context Protocol)
- [ ] Agents (PydanticAI service)
- [ ] Database (migrations/schema)
- [ ] Docker/Infrastructure
- [x] Documentation site

## Testing
<!-- Describe how you tested your changes -->
- [ ] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested affected user flows
- [x] Docker builds succeed for all services

## Checklist
<!-- Mark completed items with an "x" -->
- [x] My code follows the service architecture patterns
- [ ] If using an AI coding assistant, I used the CLAUDE.md rules
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass locally
- [x] My changes generate no new warnings
- [ ] I have updated relevant documentation
- [x] I have verified no regressions in existing features

## Additional Notes
The Archon UI still uses a PNG image, but it exists there.
Btw: The logos are different. Is that intentional? 😏 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated site visuals to SVG assets, including the favicon, navbar logo, hero banner background, and diagram node logo for crisper rendering and better scaling on high‑DPI displays.
  - Improved visual consistency across the documentation site.

- Documentation
  - Refreshed branding assets on the docs site with no changes to functionality or navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->