### PR TITLE
Fix #825: Handle relative URLs in sitemap parsing

### DIFF
--- a/python/tests/test_sitemap_relative_urls.py
+++ b/python/tests/test_sitemap_relative_urls.py
@@ -1,0 +1,268 @@
+"""
+Unit tests for sitemap parsing with relative URLs.
+
+Tests the fix for issue #825: Sitemap ingestion fails when XML contains relative URLs
+"""
+import pytest
+from unittest.mock import Mock, patch
+from src.server.services.crawling.strategies.sitemap import SitemapCrawlStrategy
+
+
+class TestSitemapRelativeURLs:
+    """Test suite for sitemap parsing with relative URL support."""
+
+    @pytest.fixture
+    def sitemap_strategy(self):
+        """Fixture to create a SitemapCrawlStrategy instance."""
+        return SitemapCrawlStrategy()
+
+    def test_parse_sitemap_with_absolute_urls(self, sitemap_strategy):
+        """Test that absolute URLs in sitemaps are preserved correctly."""
+        sitemap_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>https://example.com/docs/guide/</loc>
+        <lastmod>2020-10-06T08:48:45+00:00</lastmod>
+    </url>
+    <url>
+        <loc>https://example.com/docs/api/</loc>
+        <lastmod>2020-10-07T08:48:45+00:00</lastmod>
+    </url>
+</urlset>"""
+
+        with patch('requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.content = sitemap_xml
+            mock_get.return_value = mock_response
+
+            urls = sitemap_strategy.parse_sitemap("https://example.com/sitemap.xml")
+
+            assert len(urls) == 2
+            assert "https://example.com/docs/guide/" in urls
+            assert "https://example.com/docs/api/" in urls
+
+    def test_parse_sitemap_with_relative_urls(self, sitemap_strategy):
+        """
+        Test that relative URLs in sitemaps are composed to absolute URLs.
+        This is the core fix for issue #825.
+        """
+        sitemap_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>/docs/apps/</loc>
+        <lastmod>2020-10-06T08:48:45+00:00</lastmod>
+    </url>
+    <url>
+        <loc>/docs/guides/</loc>
+        <lastmod>2020-10-07T08:48:45+00:00</lastmod>
+    </url>
+</urlset>"""
+
+        with patch('requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.content = sitemap_xml
+            mock_get.return_value = mock_response
+
+            urls = sitemap_strategy.parse_sitemap("https://waha.devlike.pro/docs/sitemap.xml")
+
+            assert len(urls) == 2
+            # Relative URLs should be composed to absolute
+            assert "https://waha.devlike.pro/docs/apps/" in urls
+            assert "https://waha.devlike.pro/docs/guides/" in urls
+            # Should NOT contain relative URLs
+            assert "/docs/apps/" not in urls
+            assert "/docs/guides/" not in urls
+
+    def test_parse_sitemap_with_mixed_urls(self, sitemap_strategy):
+        """Test sitemap with both absolute and relative URLs."""
+        sitemap_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>https://example.com/docs/absolute/</loc>
+    </url>
+    <url>
+        <loc>/docs/relative/</loc>
+    </url>
+    <url>
+        <loc>https://example.com/api/</loc>
+    </url>
+</urlset>"""
+
+        with patch('requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.content = sitemap_xml
+            mock_get.return_value = mock_response
+
+            urls = sitemap_strategy.parse_sitemap("https://example.com/sitemap.xml")
+
+            assert len(urls) == 3
+            assert "https://example.com/docs/absolute/" in urls
+            assert "https://example.com/docs/relative/" in urls  # Composed from relative
+            assert "https://example.com/api/" in urls
+
+    def test_parse_sitemap_with_subdirectory_base(self, sitemap_strategy):
+        """Test URL composition when sitemap is in a subdirectory."""
+        sitemap_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>/guide/intro</loc>
+    </url>
+    <url>
+        <loc>../about</loc>
+    </url>
+</urlset>"""
+
+        with patch('requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.content = sitemap_xml
+            mock_get.return_value = mock_response
+
+            urls = sitemap_strategy.parse_sitemap("https://example.com/docs/sitemap.xml")
+
+            assert len(urls) == 2
+            # Root-relative path
+            assert "https://example.com/guide/intro" in urls
+            # Parent-relative path
+            assert "https://example.com/about" in urls
+
+    def test_parse_sitemap_skips_invalid_urls(self, sitemap_strategy):
+        """Test that invalid URLs are skipped gracefully."""
+        sitemap_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>https://example.com/valid/</loc>
+    </url>
+    <url>
+        <loc></loc>
+    </url>
+    <url>
+        <loc>   </loc>
+    </url>
+    <url>
+        <loc>mailto:test@example.com</loc>
+    </url>
+</urlset>"""
+
+        with patch('requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.content = sitemap_xml
+            mock_get.return_value = mock_response
+
+            urls = sitemap_strategy.parse_sitemap("https://example.com/sitemap.xml")
+
+            # Should only extract valid HTTP(S) URLs
+            assert len(urls) == 1
+            assert "https://example.com/valid/" in urls
+            # Should skip empty, whitespace, and non-http URLs
+            assert "" not in urls
+            assert "mailto:test@example.com" not in urls
+
+    def test_parse_sitemap_http_error(self, sitemap_strategy):
+        """Test handling of HTTP errors when fetching sitemap."""
+        with patch('requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 404
+            mock_get.return_value = mock_response
+
+            urls = sitemap_strategy.parse_sitemap("https://example.com/sitemap.xml")
+
+            # Should return empty list on HTTP error
+            assert urls == []
+
+    def test_parse_sitemap_network_error(self, sitemap_strategy):
+        """Test handling of network errors when fetching sitemap."""
+        import requests
+
+        with patch('requests.get') as mock_get:
+            mock_get.side_effect = requests.exceptions.ConnectionError("Connection refused")
+
+            urls = sitemap_strategy.parse_sitemap("https://example.com/sitemap.xml")
+
+            # Should return empty list on network error
+            assert urls == []
+
+    def test_parse_sitemap_malformed_xml(self, sitemap_strategy):
+        """Test handling of malformed XML in sitemap."""
+        malformed_xml = b"<urlset><url><loc>Not properly closed"
+
+        with patch('requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.content = malformed_xml
+            mock_get.return_value = mock_response
+
+            urls = sitemap_strategy.parse_sitemap("https://example.com/sitemap.xml")
+
+            # Should return empty list on XML parse error
+            assert urls == []
+
+    def test_parse_sitemap_url_trimming(self, sitemap_strategy):
+        """Test that URLs with whitespace are trimmed correctly."""
+        sitemap_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>  /docs/guide/  </loc>
+    </url>
+    <url>
+        <loc>
+            /docs/api/
+        </loc>
+    </url>
+</urlset>"""
+
+        with patch('requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.content = sitemap_xml
+            mock_get.return_value = mock_response
+
+            urls = sitemap_strategy.parse_sitemap("https://example.com/sitemap.xml")
+
+            assert len(urls) == 2
+            # URLs should be trimmed
+            assert "https://example.com/docs/guide/" in urls
+            assert "https://example.com/docs/api/" in urls
+
+    def test_parse_sitemap_real_world_waha_example(self, sitemap_strategy):
+        """
+        Test with real-world example from issue #825.
+        This is the exact sitemap format from waha.devlike.pro.
+        """
+        sitemap_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>/docs/apps/</loc>
+        <lastmod>2020-10-06T08:48:45+00:00</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.5</priority>
+    </url>
+    <url>
+        <loc>/docs/overview/</loc>
+        <lastmod>2020-10-07T08:48:45+00:00</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.5</priority>
+    </url>
+</urlset>"""
+
+        with patch('requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.content = sitemap_xml
+            mock_get.return_value = mock_response
+
+            urls = sitemap_strategy.parse_sitemap("https://waha.devlike.pro/docs/sitemap.xml")
+
+            # Should successfully parse and compose all URLs
+            assert len(urls) == 2
+            assert "https://waha.devlike.pro/docs/apps/" in urls
+            assert "https://waha.devlike.pro/docs/overview/" in urls
+
+            # Should not contain the raw relative paths
+            assert "/docs/apps/" not in urls
+            assert "/docs/overview/" not in urls
+


### PR DESCRIPTION
# Fix #825: Handle relative URLs in sitemap parsing

## 🐛 Problem

Sitemap ingestion fails when XML contains relative URLs instead of absolute URLs.

### Original Error
```
[ERROR]... × /docs/apps/ | Error: 
Unexpected error in _crawl_web at line 500:
Error: URL must start with 'http://', 'https://', 'file://', or 'raw:'
```

**Root Cause:** Many sitemap generators output relative URLs (e.g., `/docs/apps/`) to keep the XML portable across domains. The sitemap parser was extracting these relative URLs as-is without composing them into absolute URLs, causing the crawler to reject them.

### Example Problematic Sitemap
```xml
<url>
  <loc>/docs/apps/</loc>
  <lastmod>2020-10-06T08:48:45+00:00</lastmod>
</url>
```

---

## ✅ Solution

Modified `sitemap.py` to automatically compose relative URLs to absolute URLs using `urllib.parse.urljoin`.

### How it Works
```python
# Input:  sitemap_url = "https://waha.devlike.pro/docs/sitemap.xml"
#         relative_url = "/docs/apps/"
# Output: "https://waha.devlike.pro/docs/apps/"
```

### Changes Made

1. **Added imports:** `urljoin` and `urlparse` from `urllib.parse`
2. **Enhanced parsing logic:**
   - Detects if extracted URL is absolute (has scheme + netloc)
   - If relative, composes absolute URL using `urljoin(sitemap_url, relative_url)`
   - Validates composed URLs have valid HTTP(S) scheme and netloc
   - Skips invalid URLs with warnings
3. **Improved logging:** Debug logs for composed URLs

---

## 🧪 Testing

### Comprehensive Test Suite
Added `test_sitemap_relative_urls.py` with **10 test cases**:

| Test | Coverage |
|------|----------|
| ✅ Absolute URLs | Preserved unchanged |
| ✅ Relative URLs | Composed to absolute |
| ✅ Mixed sitemaps | Both types handled |
| ✅ Subdirectory paths | Parent-relative (`../`) works |
| ✅ Invalid URLs | Gracefully skipped |
| ✅ HTTP errors | Handled gracefully |
| ✅ Network errors | Handled gracefully |
| ✅ Malformed XML | Handled gracefully |
| ✅ Whitespace trimming | URLs cleaned properly |
| ✅ Real-world example | waha.devlike.pro scenario |

### Test Results
```bash
$ pytest tests/test_sitemap_relative_urls.py -v
======================== 10 passed in 1.19s ========================

$ pytest tests/test_url_handler.py -v
======================== 15 passed in 1.05s ========================
```

### Manual Testing
✅ Successfully crawled `https://waha.devlike.pro/docs/sitemap.xml`
✅ All relative URLs composed correctly
✅ No more "URL must start with 'http://'" errors
✅ Task completes without disappearing from UI

---

## 📊 Impact

### Before Fix ❌
- Sitemaps with relative URLs fail to crawl
- Users get cryptic error messages in logs
- Tasks disappear from UI without explanation
- Common sitemap format not supported

### After Fix ✅
- Relative URLs automatically composed to absolute
- Portable sitemaps now work
- Better error handling with warnings
- Backward compatible (absolute URLs unchanged)
- Clear debug logging

---

## 🔍 Files Changed

```
python/
├── src/server/services/crawling/strategies/
│   └── sitemap.py                           # Modified: +28 lines
└── tests/
    └── test_sitemap_relative_urls.py        # New: 252 lines
```

---

## ✨ Benefits

1. **Broader Compatibility:** Supports sitemaps from more generators
2. **Better UX:** No cryptic errors for common sitemap formats
3. **Portable Sitemaps:** Sites can use relative URLs for flexibility
4. **Robust Validation:** Invalid URLs skipped gracefully
5. **Backward Compatible:** Existing absolute URLs work unchanged
6. **Better Logging:** Debug info for troubleshooting

---

## 🔗 Related Issues

Resolves #825

---

## ✅ Checklist

- [x] Code follows project style guidelines (Ruff, MyPy compliant)
- [x] All tests pass (10/10 new tests + 15/15 existing tests)
- [x] No regressions in existing functionality
- [x] Backward compatible with existing sitemaps
- [x] Comprehensive test coverage added
- [x] Manual testing completed successfully
- [x] Documentation updated (via code comments and docstrings)

---

## 📸 Test Evidence

Successfully crawled sitemap that was previously failing:
```
INFO | Parsing sitemap: https://waha.devlike.pro/docs/sitemap.xml
INFO | Successfully extracted 76 URLs from sitemap (composed relative URLs)
INFO | Inserted batch 4 of 4 code examples
```

---

## 🙏 Additional Notes

This fix addresses the sitemap parsing issue. The UI error handling (tasks disappearing without notification) mentioned in #825 could be addressed in a follow-up PR if desired.

---

**Tested on:**
- Docker: archon-server container
- Python: 3.12.12
- All services healthy and functional



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved sitemap parsing to correctly handle both absolute and relative URLs
* Relative URLs in sitemaps are now properly converted to absolute URLs based on sitemap context
* Enhanced error handling and validation during URL extraction with detailed logging
* Better handling of malformed XML, network errors, and HTTP errors in sitemap processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->