### PR TITLE
Add branch selection to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,6 +22,18 @@ body:
       required: true
 
   - type: dropdown
+    id: branch
+    attributes:
+      label: Branch
+      description: Which branch are you using?
+      options:
+        - "stable"
+        - "main"
+      default: 0
+    validations:
+      required: true
+
+  - type: dropdown
     id: severity
     attributes:
       label: Bug Severity


### PR DESCRIPTION
## Summary
- Added a dropdown field to the bug report template allowing reporters to specify which branch they're using
- Options: "stable" (default) or "main"
- Positioned after the Archon Version field
- Marked as required field

## Test plan
- [ ] Verify the bug report template renders correctly on GitHub
- [ ] Confirm the branch dropdown shows "stable" and "main" options
- [ ] Confirm "stable" is selected by default
- [ ] Test submitting a bug report with both options

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the bug report template to include a required "branch" field, enabling users to specify whether their issue occurs on the stable or main branch when submitting reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->