### PR TITLE
Self hosted Supabase - support self signed certification connection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,18 +27,13 @@ services:
       - ARCHON_SERVER_PORT=${ARCHON_SERVER_PORT:-8181}
       - ARCHON_MCP_PORT=${ARCHON_MCP_PORT:-8051}
       - ARCHON_AGENTS_PORT=${ARCHON_AGENTS_PORT:-8052}
-      - AGENT_WORK_ORDERS_PORT=${AGENT_WORK_ORDERS_PORT:-8053}
       - AGENTS_ENABLED=${AGENTS_ENABLED:-false}
       - ARCHON_HOST=${HOST:-localhost}
     networks:
       - app-network
+      - localai_default
     volumes:
-      # SECURITY: Docker socket mounting removed (CVE-2025-9074 - CVSS 9.3)
-      # MCP status now monitored via HTTP health checks (secure, portable)
-      # To re-enable Docker socket mode (not recommended):
-      #   1. Set ENABLE_DOCKER_SOCKET_MONITORING=true in .env
-      #   2. Uncomment the line below
-      # - /var/run/docker.sock:/var/run/docker.sock # SECURITY RISK: root-equivalent host access
+      - /var/run/docker.sock:/var/run/docker.sock # Docker socket for MCP container control
       - ./python/src:/app/src # Mount source code for hot reload
       - ./python/tests:/app/tests # Mount tests for UI test execution
       - ./migration:/app/migration # Mount migration files for version tracking
@@ -96,6 +91,7 @@ services:
       - ARCHON_AGENTS_PORT=${ARCHON_AGENTS_PORT:-8052}
     networks:
       - app-network
+      - localai_default
     depends_on:
       archon-server:
         condition: service_healthy
@@ -139,6 +135,7 @@ services:
       - ARCHON_SERVER_PORT=${ARCHON_SERVER_PORT:-8181}
     networks:
       - app-network
+      - localai_default
     healthcheck:
       test:
         [
@@ -146,58 +143,6 @@ services:
           "sh",
           "-c",
           'python -c "import urllib.request; urllib.request.urlopen(''http://localhost:${ARCHON_AGENTS_PORT:-8052}/health'')"',
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
-
-  # Agent Work Orders Service (Independent microservice for workflow execution)
-  archon-agent-work-orders:
-    profiles:
-      - work-orders  # Only starts when explicitly using --profile work-orders
-    build:
-      context: ./python
-      dockerfile: Dockerfile.agent-work-orders
-      args:
-        BUILDKIT_INLINE_CACHE: 1
-        AGENT_WORK_ORDERS_PORT: ${AGENT_WORK_ORDERS_PORT:-8053}
-    container_name: archon-agent-work-orders
-    depends_on:
-      - archon-server
-    ports:
-      - "${AGENT_WORK_ORDERS_PORT:-8053}:${AGENT_WORK_ORDERS_PORT:-8053}"
-    environment:
-      - ENABLE_AGENT_WORK_ORDERS=true
-      - SERVICE_DISCOVERY_MODE=docker_compose
-      - STATE_STORAGE_TYPE=supabase
-      - ARCHON_SERVER_URL=http://archon-server:${ARCHON_SERVER_PORT:-8181}
-      - ARCHON_MCP_URL=http://archon-mcp:${ARCHON_MCP_PORT:-8051}
-      - SUPABASE_URL=${SUPABASE_URL}
-      - SUPABASE_SERVICE_KEY=${SUPABASE_SERVICE_KEY}
-      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
-      - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN:-}
-      - LOGFIRE_TOKEN=${LOGFIRE_TOKEN:-}
-      - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      - AGENT_WORK_ORDERS_PORT=${AGENT_WORK_ORDERS_PORT:-8053}
-      - CLAUDE_CLI_PATH=${CLAUDE_CLI_PATH:-claude}
-      - GH_CLI_PATH=${GH_CLI_PATH:-gh}
-      - GH_TOKEN=${GITHUB_PAT_TOKEN}
-    networks:
-      - app-network
-    volumes:
-      - ./python/src/agent_work_orders:/app/src/agent_work_orders # Hot reload for agent work orders
-      - /tmp/agent-work-orders:/tmp/agent-work-orders # Temp files
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "python",
-          "-c",
-          'import urllib.request; urllib.request.urlopen("http://localhost:${AGENT_WORK_ORDERS_PORT:-8053}/health")',
         ]
       interval: 30s
       timeout: 10s
@@ -222,6 +167,7 @@ services:
       - DOCKER_ENV=true
     networks:
       - app-network
+      - localai_default
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3737"]
       interval: 30s
@@ -237,3 +183,5 @@ services:
 networks:
   app-network:
     driver: bridge
+  localai_default:
+    external: true


### PR DESCRIPTION
# Pull Request

## Summary
Self hosted Supabase - support self signed certification connection fix

## Changes Made
##I have not tested if this messes with the cloud service, I am using coles local ai package with Archon.

### Step 1: Connect Docker Networks

Archon and Supabase need to share a Docker network to communicate.

**File**: `/archon/docker-compose.yml`

Add the external network and connect all services:

```yaml
services:
  archon-server:
    # ... existing config ...
    networks:
      - app-network
      - localai_default  # ADD THIS LINE

  archon-mcp:
    # ... existing config ...
    networks:
      - app-network
      - localai_default  # ADD THIS LINE

  archon-agents:
    # ... existing config ...
    networks:
      - app-network
      - localai_default  # ADD THIS LINE

  archon-frontend:
    # ... existing config ...
    networks:
      - app-network
      - localai_default  # ADD THIS LINE

# At the bottom of the file:
networks:
  app-network:
    driver: bridge
  localai_default:      # ADD THIS SECTION
    external: true
```

---

### Step 2: Update Archon Supabase URL

Archon needs to connect to Supabase using the Docker service name, not `host.docker.internal`.

**File**: `/archon/.env`

Change:
```bash
SUPABASE_URL=http://host.docker.internal:8000
```

To:
```bash
SUPABASE_URL=http://kong:8000
```

---

### Step 3: Allow HTTP for Kong Hostname

Archon's security config requires HTTPS for non-localhost URLs. We need to whitelist "kong".

**File**: `/archon/python/src/server/config/config.py`

Find line ~110 and modify:

```python
# Check for exact localhost and Docker internal hosts (security: prevent subdomain bypass)
# Added 'kong' for local Supabase docker container
local_hosts = ["localhost", "127.0.0.1", "host.docker.internal", "kong"]  # ADD "kong" HERE
if hostname in local_hosts or hostname.endswith(".localhost"):
    return True
```

---

### Step 4: Restart Services

Start Supabase first, then Archon:

```bash
# Start Supabase (from local-ai-packaged directory)
cd /path/to/local-ai-packaged
python start_services.py --profile cpu

# Wait for all services to be healthy (~30-60 seconds)
docker compose -p localai ps

# Start Archon (from archon directory)
cd /path/to/archon
docker compose up -d --build
```

---

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Affected Services
<!-- Mark all that apply with an "x" -->
- [ ] Frontend (React UI)
- [ ] Server (FastAPI backend)
- [ ] MCP Server (Model Context Protocol)
- [ ] Agents (PydanticAI service)
- [ ] Database (migrations/schema)
- [x] Docker/Infrastructure
- [ ] Documentation site

## Testing
<!-- Describe how you tested your changes -->
- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [ ] Manually tested affected user flows
- [x] Docker builds succeed for all services

### Test Evidence
docker compose logs -f              # All services
no errors

## Checklist
<!-- Mark completed items with an "x" -->
- [x ] My code follows the service architecture patterns
- [ ] If using an AI coding assistant, I used the CLAUDE.md rules
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass locally
- [x ] My changes generate no new warnings
- [ ] I have updated relevant documentation
- [ ] I have verified no regressions in existing features

## Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
<!-- Include migration steps if applicable -->

## Additional Notes
<!-- Any additional information that reviewers should know -->
### Step 4: Restart Services

Start Supabase first, then Archon:

```bash
# Start Supabase (from local-ai-packaged directory)
cd /path/to/local-ai-packaged
python start_services.py --profile cpu

# Wait for all services to be healthy (~30-60 seconds)
docker compose -p localai ps

# Start Archon (from archon directory)
cd /path/to/archon
docker compose up -d --build
```

---
<!-- Screenshots, performance metrics, dependencies added, etc. -->