### PR TITLE
fix(agents): update deprecated pydantic-ai parameter

### DIFF
--- a/python/src/agents/document_agent.py
+++ b/python/src/agents/document_agent.py
@@ -76,7 +76,7 @@ class DocumentAgent(BaseAgent[DocumentDependencies, DocumentOperation]):
         agent = Agent(
             model=self.model,
             deps_type=DocumentDependencies,
-            result_type=DocumentOperation,
+            output_type=DocumentOperation,
             system_prompt="""You are a Document Management Assistant that helps users create, update, and modify project documents through conversation.
 
 **Your Capabilities:**


### PR DESCRIPTION
## Summary

Updates `result_type` to `output_type` in `DocumentAgent` for compatibility with pydantic-ai 1.0.x.

## Problem

The `Agent` class in pydantic-ai renamed the `result_type` parameter to `output_type` in version 1.0. This causes the document agent to fail initialization:

```
ERROR:src.agents.server:Failed to initialize document agent: Unknown keyword arguments: `result_type`
```

## Solution

Single-line fix renaming the parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Agent API parameter naming in DocumentAgent for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->