### PR TITLE
Fix task counts returning 0 for projects beyond Supabase 1000 row limit

### DIFF
--- a/python/src/server/services/projects/task_service.py
+++ b/python/src/server/services/projects/task_service.py
@@ -482,22 +482,42 @@ class TaskService:
         try:
             logger.debug("Fetching task counts for all projects in batch")
 
-            # Query all non-archived tasks grouped by project_id and status
-            response = (
-                self.supabase_client.table("archon_tasks")
-                .select("project_id, status")
-                .or_("archived.is.null,archived.is.false")
-                .execute()
-            )
+            # Query all non-archived tasks using pagination
+            # Supabase has a hard limit of 1000 rows per request
+            all_tasks = []
+            page_size = 1000
+            offset = 0
 
-            if not response.data:
+            while True:
+                response = (
+                    self.supabase_client.table("archon_tasks")
+                    .select("project_id, status")
+                    .or_("archived.is.null,archived.is.false")
+                    .range(offset, offset + page_size - 1)
+                    .execute()
+                )
+
+                if not response.data:
+                    break
+
+                all_tasks.extend(response.data)
+
+                # If we got fewer than page_size, we've reached the end
+                if len(response.data) < page_size:
+                    break
+
+                offset += page_size
+
+            if not all_tasks:
                 logger.debug("No tasks found")
                 return True, {}
+
+            logger.info(f"Task counts query returned {len(all_tasks)} tasks (paginated)")
 
             # Process results into counts by project and status
             counts_by_project = {}
 
-            for task in response.data:
+            for task in all_tasks:
                 project_id = task.get("project_id")
                 status = task.get("status")
 


### PR DESCRIPTION
## Summary

- Fix bug where project cards display `ToDo: 0, Doing: 0, Review: 0, Done: 0` for projects beyond Supabase's 1000 row limit
- Implement pagination in `get_all_project_task_counts()` to fetch all tasks in batches of 1000

## Problem

Supabase has a hard limit of 1000 rows per request. The `get_all_project_task_counts()` method was only retrieving the first 1000 tasks, causing projects created after that limit to show incorrect (zero) task counts.

**Before fix:** API returns exactly 1000 tasks, newer projects missing from results
**After fix:** API returns all tasks via pagination (tested with 1055 tasks)

## Root Cause

The query in `task_service.py` didn't specify `.range()` or pagination:
```python
response = (
    self.supabase_client.table("archon_tasks")
    .select("project_id, status")
    .or_("archived.is.null,archived.is.false")
    .execute()  # ← No pagination = capped at 1000
)
```

## Solution

Implement pagination with a while loop to fetch all tasks:
```python
all_tasks = []
page_size = 1000
offset = 0

while True:
    response = (
        self.supabase_client.table("archon_tasks")
        .select("project_id, status")
        .or_("archived.is.null,archived.is.false")
        .range(offset, offset + page_size - 1)
        .execute()
    )
    if not response.data:
        break
    all_tasks.extend(response.data)
    if len(response.data) < page_size:
        break
    offset += page_size
```

## Test Plan

- [x] Verified `/api/projects/task-counts` returns >1000 tasks after fix
- [x] Verified previously missing projects now appear with correct counts
- [x] Verified UI displays correct task counts on project cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized task count retrieval for projects by implementing paginated batch processing, improving efficiency when handling large task datasets while maintaining existing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->