### PR TITLE
fix(web): allow workflow graph view to load without a codebase

### DIFF
--- a/packages/web/src/components/workflows/WorkflowExecution.tsx
+++ b/packages/web/src/components/workflows/WorkflowExecution.tsx
@@ -235,8 +235,9 @@ export function WorkflowExecution({ runId }: WorkflowExecutionProps): React.Reac
   }, [codebaseId]);
 
   // Fetch workflow definition for DAG topology (depends_on edges).
-  // Only gated on workflowName — codebaseCwd is optional; the server falls back to bundled
-  // defaults when cwd is absent (handles CLI runs and "No project" web runs).
+  // Only gated on workflowName — codebaseCwd is optional; when absent the server tries the
+  // first registered codebase before falling back to bundled defaults (handles CLI runs and
+  // "No project" web runs).
   const { data: workflowDef } = useQuery({
     queryKey: ['workflowDefinition', initialData?.workflowName, codebaseCwd],
     queryFn: () => getWorkflow(initialData?.workflowName ?? '', codebaseCwd ?? undefined),


### PR DESCRIPTION
## Summary

- **Problem**: The Graph tab shows \"Loading graph...\" indefinitely for any workflow run that has no associated project (`codebase_id = null`).
- **Why it matters**: CLI-triggered runs and \"No project\" web runs always have `codebase_id = null`, making the Graph tab permanently unusable for a significant portion of workflow runs.
- **What changed**: Removed `&& !!codebaseCwd` from the `useQuery` `enabled` gate in `WorkflowExecution.tsx`. The server already falls back to bundled defaults when `cwd` is absent — the client now trusts that fallback.
- **What did not change**: Server-side route logic (`GET /api/workflows/:name`), `getWorkflow` API client, all other queries in `WorkflowExecution.tsx`.

## UX Journey

### Before

```
User opens Graph tab for a CLI/no-project run
  → initialData.codebaseId = null
  → codebaseCwd stays undefined (no codebase record to fetch)
  → useQuery enabled = !!workflowName && !!undefined = false
  → workflowDef never populated
  → dagDefinitionNodes = null
  → Graph tab renders "Loading graph..." forever
```

### After

```
User opens Graph tab for a CLI/no-project run
  → initialData.codebaseId = null
  → codebaseCwd stays undefined (unchanged)
  → useQuery enabled = !!workflowName = true  ← [changed]
  → GET /api/workflows/:name fires (no cwd param)
  → Server falls back to bundled defaults → returns workflow definition
  → workflowDef populated → dagDefinitionNodes resolved
  → Graph tab renders correctly
```

## Architecture Diagram

### Before

```
WorkflowExecution.tsx
  ├── useQuery workflowDef
  │     enabled: !!workflowName && !!codebaseCwd   ← blocks when codebaseCwd is falsy
  │     queryFn: getWorkflow(name, codebaseCwd)
  └── dagDefinitionNodes = workflowDef?.workflow?.nodes ?? null
                                                          ↑ always null for no-project runs
```

### After

```
WorkflowExecution.tsx
  ├── useQuery workflowDef
  │     enabled: !!workflowName                    ← [~] no longer gated on codebaseCwd
  │     queryFn: getWorkflow(name, codebaseCwd)    (codebaseCwd is undefined → omitted)
  └── dagDefinitionNodes = workflowDef?.workflow?.nodes ?? null
                                                          ↑ populated via server fallback
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `WorkflowExecution.tsx` | `GET /api/workflows/:name` | **modified** | `cwd` query param now optional instead of required |
| `GET /api/workflows/:name` | bundled defaults | unchanged | Server-side fallback already existed |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `web`
- Module: `web:workflow-execution`

## Change Metadata

- Change type: `bug`
- Primary scope: `web`

## Linked Issue

- Closes #958

## Validation Evidence (required)

```bash
bun run type-check   # ✅ No errors across all 9 packages
bun run lint         # ✅ 0 errors, 0 warnings (--max-warnings 0)
bun run format:check # ✅ All files formatted
bun run test         # ✅ All suites passed, 0 failures
```

- All four CI checks pass. Full test suite (2000+ tests across 9 packages) passes.
- Build step (`bun run build:web`) has a pre-existing Windows/Bun path resolution issue with `mdast-util-gfm` unrelated to this change; it is not part of the CI pipeline.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — the server API already accepted an optional `cwd` param; we're just allowing the client to omit it.
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: Code inspection confirms the `enabled` gate change and that `getWorkflow` already accepts `cwd` as optional. Server route confirmed to have fallback logic.
- Edge cases checked: `workflowName` still guards against firing when name is unknown. Server 404 for unknown names results in an error state rather than infinite loading.
- What was not verified: Live manual browser test in a running instance (not performed in this session).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Graph tab in `WorkflowExecution.tsx` only.
- Potential unintended effects: For runs with a project assigned, `codebaseCwd` is still passed as before — no change in behavior. For no-project runs, the server falls back to the first registered codebase then bundled defaults; the returned definition may not match a project-specific override, but this is a strict improvement over infinite loading.
- Guardrails/monitoring for early detection: No new monitoring needed; graph rendering failure is immediately visible in the UI.

## Rollback Plan (required)

- Fast rollback command/path: Revert the single line change in `WorkflowExecution.tsx` — restore `&& !!codebaseCwd` to the `enabled` gate.
- Feature flags or config toggles: None.
- Observable failure symptoms: Graph tab would revert to showing \"Loading graph...\" for no-project runs.

## Risks and Mitigations

- Risk: Server returns a different workflow definition when `cwd` is absent (falls back to first registered codebase instead of the run's project).
  - Mitigation: This only affects the graph topology display, not execution. The run's actual execution context is unchanged. For runs that have no project, there is no correct `cwd` to use anyway — any result is better than infinite loading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved workflow definition fetching to support server-side fallback resolution when codebase path is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->