### PR TITLE
fix(paths): skip pino-pretty transport in compiled binaries

### DIFF
--- a/packages/paths/src/logger.ts
+++ b/packages/paths/src/logger.ts
@@ -44,12 +44,35 @@ function getInitialLevel(): string {
 }
 
 /**
+ * Detect whether the current process is running as a `bun build --compile`
+ * binary. Inlined here because `@archon/paths` has zero `@archon/*` deps.
+ *
+ * pino-pretty cannot be loaded inside a compiled binary: pino transports spawn
+ * a worker that does a dynamic `require.resolve('pino-pretty')`, which fails
+ * inside Bun's virtual `/$bunfs/` filesystem and crashes the binary on startup.
+ */
+function isCompiledBinary(): boolean {
+  const dir = import.meta.dir ?? '';
+  if (dir.startsWith('/$bunfs/') || dir.startsWith('B:\\~BUN\\') || dir.startsWith('B:/~BUN/')) {
+    return true;
+  }
+  const exec = process.execPath ?? '';
+  const base = exec.split(/[/\\]/).pop() ?? '';
+  const withoutExt = base.replace(/\.exe$/i, '').toLowerCase();
+  return exec !== '' && withoutExt !== 'bun' && withoutExt !== 'node';
+}
+
+/**
  * Uses pino-pretty when stdout is a TTY and NODE_ENV !== 'production';
  * outputs newline-delimited JSON otherwise.
+ *
+ * Compiled binaries always use NDJSON (pino-pretty transport cannot resolve
+ * inside `/$bunfs/`).
  */
 function buildLoggerOptions(): pino.LoggerOptions {
   const level = getInitialLevel();
-  const usePretty = process.stdout.isTTY && process.env.NODE_ENV !== 'production';
+  const usePretty =
+    process.stdout.isTTY && process.env.NODE_ENV !== 'production' && !isCompiledBinary();
 
   if (usePretty) {
     return {


### PR DESCRIPTION
## Summary

- Compiled `bun build --compile` binaries crash on every TTY invocation with `error: unable to determine transport target for "pino-pretty"` because Pino transports do a dynamic `require.resolve('pino-pretty')` that cannot work inside Bun's `/$bunfs/` virtual filesystem.
- This PR makes the logger emit NDJSON unconditionally inside compiled binaries, so the transport worker is never started.
- Detection is inlined in `@archon/paths` because that package has zero `@archon/*` dependencies (per CLAUDE.md). It checks both `import.meta.dir` (ESM compiled binaries) and `process.execPath` basename (CJS bytecode binaries where `import.meta.dir` may be empty).

Fixes #960

## Test plan

- [x] `bun --filter @archon/paths test` — 83 pass, 0 fail
- [x] End-to-end smoke test: `bun build --compile --outfile dist/archon-test.exe packages/cli/src/cli.ts && ./dist/archon-test.exe version` now prints `Build: binary` instead of crashing.
- [x] `bun --filter @archon/paths type-check` — clean
- [x] eslint clean on changed file
- [ ] CI green on `dev`