### PR TITLE
deploy: harden cloud-init with archon user, swap, and fixes

### DIFF
--- a/deploy/cloud-init.yml
+++ b/deploy/cloud-init.yml
@@ -15,10 +15,12 @@
 #   3. Creates a 2GB swapfile (helps small VPS builds avoid OOM)
 #   4. Clones the repo to /opt/archon
 #   5. Prepares .env and Caddyfile from examples
-#   6. Creates a dedicated 'archon' user (sudo + docker groups)
+#   6. Creates a dedicated 'archon' user (docker group only, no sudo)
 #   7. Builds the Docker image (~5 min) as the archon user
 #
 # Note: On VPS with <2GB RAM, the docker build step can OOM without swap.
+# Note: The 'archon' user has docker access but NOT sudo. For administrative
+#       tasks (updates, reboots), use the default cloud user or root.
 #
 # After the server boots (~5-8 min), SSH in as the archon user:
 #   ssh archon@your-server-ip
@@ -31,6 +33,7 @@
 #
 
 package_update: true
+package_upgrade: true
 
 packages:
   - curl
@@ -41,9 +44,7 @@ users:
   - default
   - name: archon
     gecos: Archon Service User
-    groups: [sudo, docker]
     shell: /bin/bash
-    sudo: ALL=(ALL) NOPASSWD:ALL
     lock_passwd: true
 
 runcmd:
@@ -78,18 +79,20 @@ runcmd:
       chown -R archon:archon /home/archon/.ssh
     fi
 
-  # --- Firewall ---
+  # --- Firewall (443/udp needed for HTTP/3 QUIC via Caddy) ---
   - ufw allow 22/tcp
   - ufw allow 80/tcp
   - ufw allow 443/tcp
+  - ufw allow 443/udp
   - ufw --force enable
 
-  # --- Clone and configure (fail fast on errors) ---
-  - set -e
-  - git clone https://github.com/coleam00/Archon.git /opt/archon
-  - cp /opt/archon/.env.example /opt/archon/.env
-  - cp /opt/archon/Caddyfile.example /opt/archon/Caddyfile
-  - chown -R archon:archon /opt/archon
+  # --- Clone and configure (fail fast — single shell so set -e applies) ---
+  - |
+    set -e
+    git clone https://github.com/coleam00/Archon.git /opt/archon
+    cp /opt/archon/.env.example /opt/archon/.env
+    cp /opt/archon/Caddyfile.example /opt/archon/Caddyfile
+    chown -R archon:archon /opt/archon
 
   # --- Pre-pull external images (as archon, via docker group) ---
   - sudo -u archon docker pull postgres:17-alpine
@@ -107,6 +110,10 @@ runcmd:
 
     Log in as the 'archon' user (not root):
       ssh archon@<server-ip>
+
+    Note: the 'archon' user has docker access but no sudo. For system
+    maintenance (apt upgrade, reboots), log in as the default cloud user
+    or root.
 
     Next steps:
 


### PR DESCRIPTION
## Summary
- Adds a dedicated `archon` user (docker group) and runs all docker operations as that user instead of root
- Adds a 2GB swapfile to prevent OOM during `docker compose build` on small VPS (<2GB RAM)
- Several smaller hardening + cleanup fixes to the cloud-init script

## Changes
- **archon user**: created via `users:` block, docker-group only (no sudo — avoids trivial privilege escalation). SSH keys copied from default cloud user (root fallback). `/opt/archon` chowned, builds run via `sudo -u archon`.
- **Swap**: 2GB swapfile created idempotently, persisted in `/etc/fstab`.
- **`package_upgrade: true`** retained — applies security patches to base image before anything else.
- **Removed redundant** `systemctl enable/start docker` (get.docker.com handles it).
- **`ufw allow 443/tcp` + `443/udp`** — 443/udp needed for HTTP/3 (QUIC) via Caddy.
- **`set -e` in single shell block** before clone — real fail-fast on network errors (fixed review feedback).
- **Docs link** updated to https://archon.diy/deployment/docker/.
- **SETUP_COMPLETE** instructs `ssh archon@<server-ip>` and notes archon has no sudo (use default cloud user for maintenance).
- **Header** lists supported providers (incl. Hostinger) and documents new behavior.

## Test plan
- [x] Boot a fresh Ubuntu 22.04 VPS with the new cloud-init
- [x] Verify `ssh archon@<ip>` works after ~5-8 min
- [x] Verify `id archon` shows membership in `docker` group (no sudo)
- [x] Verify `swapon --show` shows 2GB swap active
- [x] Verify `/opt/archon` owned by `archon:archon`
- [x] Verify `docker images` (as archon) shows the built archon image
- [x] Verify `ufw status` shows 22/80/443 allowed (tcp + udp for 443)

## Review feedback addressed
- CodeRabbit: `set -e` merged into single shell block so fail-fast applies
- CodeRabbit: removed non-existent `docker` from initial `users.groups` (added later via `usermod`)
- CodeRabbit: added `ufw allow 443/udp` for HTTP/3
- @Wirasm: dropped passwordless sudo from archon user — docker group only
- @Wirasm: restored `package_upgrade: true` to patch CVEs in base image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure & Deployment**
  * Added automatic swap allocation to improve stability on low-RAM hosts
  * Introduced a dedicated application user with pre-configured SSH access and tightened file ownership/permissions
  * Refined firewall rules to explicitly allow HTTPS traffic

* **Documentation**
  * Updated deployment and access instructions with new SSH/login guidance and docs link

<!-- end of auto-generated comment: release notes by coderabbit.ai -->