### PR TITLE
fix(sqlite): add allow_env_keys column to codebases schema + migration

### DIFF
--- a/packages/core/src/db/adapters/sqlite.ts
+++ b/packages/core/src/db/adapters/sqlite.ts
@@ -215,6 +215,22 @@ export class SqliteAdapter implements IDatabase {
     } catch (e: unknown) {
       getLog().warn({ err: e as Error }, 'db.sqlite_migration_session_columns_failed');
     }
+
+    // Codebases columns (added in #983 — env-leak gate consent bit)
+    try {
+      const cbCols = this.db.prepare("PRAGMA table_info('remote_agent_codebases')").all() as {
+        name: string;
+      }[];
+      const cbColNames = new Set(cbCols.map(c => c.name));
+
+      if (!cbColNames.has('allow_env_keys')) {
+        this.db.run(
+          'ALTER TABLE remote_agent_codebases ADD COLUMN allow_env_keys INTEGER DEFAULT 0'
+        );
+      }
+    } catch (e: unknown) {
+      getLog().warn({ err: e as Error }, 'db.sqlite_migration_codebases_columns_failed');
+    }
   }
 
   /**
@@ -236,6 +252,7 @@ export class SqliteAdapter implements IDatabase {
         default_cwd TEXT NOT NULL,
         default_branch TEXT DEFAULT 'main',
         ai_assistant_type TEXT DEFAULT 'claude',
+        allow_env_keys INTEGER DEFAULT 0,
         commands TEXT DEFAULT '{}',
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))


### PR DESCRIPTION
## Summary

PR #983 shipped the env-leak gate `allow_env_keys` column via PostgreSQL migrations but never updated `packages/core/src/db/adapters/sqlite.ts`, which has its own independent schema bootstrap path. Every SQLite database is broken since #983 landed — `POST /api/codebases` fails with `table remote_agent_codebases has no column named allow_env_keys`.

Cole's deployed server at `archon-youtube.smartcode.diy` is hitting this live — the VPS runs docker-compose with the SQLite default (no separate postgres service), so every "add project" returns 500.

## Changes

Two surgical edits to `packages/core/src/db/adapters/sqlite.ts`, both copy-pasted from existing patterns in the file:

1. **`createSchema()`** — add `allow_env_keys INTEGER DEFAULT 0` to the `remote_agent_codebases` CREATE TABLE block. Fresh databases get the column. SQLite has no true BOOLEAN — INTEGER with 0/1 matches the existing pattern used for `hidden` on conversations.

2. **`migrateColumns()`** — add a new idempotent try/catch block that PRAGMA-checks the codebases table for `allow_env_keys` and ALTERs it in if missing. Pattern matches the existing migration blocks for Conversations, Workflow runs, and Sessions columns. Existing databases get the column on next startup.

The JavaScript read path in `db/codebases.ts` and the clients already uses truthy checks (`if (!codebase?.allow_env_keys)`), which works for both SQLite integer (0/1) and JS boolean (false/true) storage. No other changes needed.

## Test plan

- [x] `bun test packages/core/src/db/adapters/sqlite.test.ts` — all 68 tests pass
- [x] Diff scoped to one file, minimal blast radius
- [x] Pattern matches existing migration blocks (no new architectural choices)
- [ ] After merge: Cole's deployed server picks up the fix via docker rebuild, `migrateColumns()` adds the column to the existing DB on next startup
- [ ] After merge: cut v0.3.1 (includes #987 release workflow fix + this SQLite fix)

## Related

- #983 — the PR that added the column for PostgreSQL but missed SQLite
- #986 / #987 — the release workflow fix (separate concern, already merged to dev)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic database migration to include missing schema fields for managing environment keys in remote agent codebases, ensuring existing installations are properly updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->