### PR TITLE
fix(claude): embed SDK cli.js via /embed entry point for compiled binaries

### DIFF
--- a/packages/core/src/clients/claude.ts
+++ b/packages/core/src/clients/claude.ts
@@ -19,6 +19,15 @@ import {
   type HookCallback,
   type HookCallbackMatcher,
 } from '@anthropic-ai/claude-agent-sdk';
+// The `/embed` entry point uses `import ... with { type: 'file' }` to embed
+// the SDK's `cli.js` into the compiled binary's $bunfs virtual filesystem,
+// then extracts it to a temp path at runtime so the subprocess can exec it.
+// Without this, the SDK falls back to resolving `cli.js` from
+// `import.meta.url` of its own module — which bun freezes at build time to
+// the build host's absolute node_modules path, producing a "Module not found
+// /Users/runner/..." error on any machine other than the CI runner.
+// Safe in dev too: resolves to the real on-disk cli.js.
+import cliPath from '@anthropic-ai/claude-agent-sdk/embed';
 import {
   type AssistantRequestOptions,
   type IAssistantClient,
@@ -315,6 +324,7 @@ export class ClaudeClient implements IAssistantClient {
 
       const options: Options = {
         cwd,
+        pathToClaudeCodeExecutable: cliPath,
         env: requestOptions?.env
           ? { ...buildSubprocessEnv(), ...requestOptions.env }
           : buildSubprocessEnv(),


### PR DESCRIPTION
## Summary

Fixes a P0 bug in v0.3.1 where every compiled binary fails to spawn Claude with `Module not found "/Users/runner/work/Archon/Archon/node_modules/.bun/@anthropic-ai+claude-agent-sdk@0.2.89+.../cli.js"`.

## Root cause

The Claude Agent SDK, when `pathToClaudeCodeExecutable` is not set, falls back to:

```js
const dir = path.dirname(fileURLToPath(import.meta.url));
pathToClaudeCodeExecutable = path.join(dir, "cli.js");
```

In a `bun build --compile` binary, `import.meta.url` of a bundled module is **frozen at build time** to the absolute path where that module lived on the build host. In CI that's `/Users/runner/work/Archon/Archon/node_modules/.bun/...` — a path that only exists on the GitHub Actions runner. Every shipped binary carried the CI path, and every workflow run hit `spawn ENOENT` on the three-retry loop before failing.

## Fix

The SDK ships a dedicated `@anthropic-ai/claude-agent-sdk/embed` entry point built for exactly this case. It uses `import cli.js with { type: 'file' }` so Bun's bundler embeds `cli.js` into the compiled binary's `$bunfs` virtual filesystem, then `extractFromBunfs()` copies it to a real temp path at runtime (child processes cannot read the parent's `$bunfs`). We import that entry point and pass the result as `pathToClaudeCodeExecutable`.

Safe in dev (`bun link`) too — the embed module resolves to the real on-disk `cli.js`.

## Verification

Built a local binary via `scripts/build-binaries.sh` on this branch and ran:

```
./dist/test-archon-darwin-arm64 workflow run assist --no-worktree "say hello and nothing else"
```

Result: Claude subprocess spawned successfully, returned "Hello", workflow completed in 3.9s. Same test against v0.3.1 fails with `Module not found` after three retries.

## Why this escaped every prior release

- Dev (`bun link`) never exercises this path — normal node resolution finds `cli.js`.
- Local binary builds bake *your own* laptop's `node_modules` path, which exists locally, so the binary "works" for the person who built it.
- v0.3.0's homebrew formula had stale SHAs so no one ever installed v0.3.0 via brew successfully.
- v0.3.1 is the first release where `/test-release brew` could actually run — and it surfaced this instantly.

## Related

- Codex SDK has a related but distinct issue (`createRequire(import.meta.url).resolve('@openai/codex/package.json')` plus unembeddable native platform binaries). That's out of scope for this fix — filing separately.
- A CI smoke test that runs `workflow run assist` against the built binary inside the release workflow would have caught this. Worth adding as a follow-up.

## Test plan

- [x] `bun run type-check` clean
- [x] Local binary built via `scripts/build-binaries.sh` spawns Claude and completes `assist` workflow
- [ ] After merge: cut v0.3.2, run `/test-release brew 0.3.2` end-to-end before announcing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Claude SDK configuration to improve subprocess handling reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->