### PR TITLE
fix(env-leak-gate): skip pre-spawn scan for unregistered cwd paths (#991)

### DIFF
--- a/packages/core/src/clients/claude.test.ts
+++ b/packages/core/src/clients/claude.test.ts
@@ -978,7 +978,12 @@ describe('ClaudeClient', () => {
       spyScan.mockRestore();
     });
 
-    test('throws EnvLeakError when .env contains sensitive keys and codebase has no consent', async () => {
+    test('throws EnvLeakError when .env contains sensitive keys and registered codebase has no consent', async () => {
+      spyFindByDefaultCwd.mockResolvedValueOnce({
+        id: 'codebase-1',
+        allow_env_keys: false,
+        default_cwd: '/workspace',
+      });
       spyScan.mockReturnValueOnce({
         path: '/workspace',
         findings: [{ file: '.env', keys: ['ANTHROPIC_API_KEY'] }],
@@ -989,6 +994,24 @@ describe('ClaudeClient', () => {
           // consume
         }
       }).toThrow('Cannot run workflow');
+    });
+
+    test('skips scan entirely when cwd is not a registered codebase', async () => {
+      // Both lookups return null (default from beforeEach) → unregistered cwd.
+      // Even if sensitive keys would be present, the pre-spawn check must not run
+      // because the canonical gate is registerRepoAtPath, not sendQuery.
+      spyScan.mockReturnValue({
+        path: '/workspace',
+        findings: [{ file: '.env', keys: ['ANTHROPIC_API_KEY'] }],
+      });
+
+      const chunks = [];
+      for await (const chunk of client.sendQuery('test', '/workspace')) {
+        chunks.push(chunk);
+      }
+
+      expect(spyScan).not.toHaveBeenCalled();
+      expect(chunks).toHaveLength(1);
     });
 
     test('skips scan when codebase has allow_env_keys: true', async () => {
@@ -1007,17 +1030,23 @@ describe('ClaudeClient', () => {
       expect(chunks).toHaveLength(1);
     });
 
-    test('proceeds when cwd has no registered codebase and no sensitive keys', async () => {
+    test('proceeds without scanning when cwd has no registered codebase', async () => {
+      // Unregistered cwd — the pre-spawn safety net is out of scope.
       const chunks = [];
       for await (const chunk of client.sendQuery('test', '/workspace')) {
         chunks.push(chunk);
       }
 
-      expect(spyScan).toHaveBeenCalledTimes(1);
+      expect(spyScan).not.toHaveBeenCalled();
       expect(chunks).toHaveLength(1);
     });
 
     test('skips scan when allowTargetRepoKeys is true in merged config', async () => {
+      spyFindByDefaultCwd.mockResolvedValueOnce({
+        id: 'codebase-1',
+        allow_env_keys: false,
+        default_cwd: '/workspace',
+      });
       const spyLoadConfig = spyOn(configLoader, 'loadConfig').mockResolvedValueOnce({
         allowTargetRepoKeys: true,
       } as Awaited<ReturnType<typeof configLoader.loadConfig>>);
@@ -1038,6 +1067,11 @@ describe('ClaudeClient', () => {
     });
 
     test('falls back to scanner when loadConfig throws (fail-closed)', async () => {
+      spyFindByDefaultCwd.mockResolvedValueOnce({
+        id: 'codebase-1',
+        allow_env_keys: false,
+        default_cwd: '/workspace',
+      });
       const spyLoadConfig = spyOn(configLoader, 'loadConfig').mockRejectedValueOnce(
         new Error('YAML parse error')
       );

--- a/packages/core/src/clients/claude.ts
+++ b/packages/core/src/clients/claude.ts
@@ -276,7 +276,7 @@ export class ClaudeClient implements IAssistantClient {
     const codebase =
       (await codebaseDb.findCodebaseByDefaultCwd(cwd)) ??
       (await codebaseDb.findCodebaseByPathPrefix(cwd));
-    if (!codebase?.allow_env_keys) {
+    if (codebase && !codebase.allow_env_keys) {
       // Fail-closed: a config load failure (corrupt YAML, permission denied)
       // must NOT silently bypass the gate. Catch, log, and treat as
       // `allowTargetRepoKeys = false` so the scanner still runs.

--- a/packages/core/src/clients/codex.test.ts
+++ b/packages/core/src/clients/codex.test.ts
@@ -1029,9 +1029,12 @@ describe('CodexClient', () => {
       spyScan.mockRestore();
     });
 
-    test('throws EnvLeakError when .env contains sensitive keys and codebase has no consent', async () => {
-      spyFindByDefaultCwd.mockResolvedValueOnce(null);
-      spyFindByPathPrefix.mockResolvedValueOnce(null);
+    test('throws EnvLeakError when .env contains sensitive keys and registered codebase has no consent', async () => {
+      spyFindByDefaultCwd.mockResolvedValueOnce({
+        id: 'codebase-1',
+        allow_env_keys: false,
+        default_cwd: '/workspace',
+      });
       spyScan.mockReturnValueOnce({
         path: '/workspace',
         findings: [{ file: '.env', keys: ['ANTHROPIC_API_KEY'] }],
@@ -1044,6 +1047,22 @@ describe('CodexClient', () => {
       };
 
       await expect(consumeGenerator()).rejects.toThrow('Cannot run workflow');
+    });
+
+    test('skips scan entirely when cwd is not a registered codebase', async () => {
+      // Both lookups return null (default from beforeEach). Pre-spawn safety net
+      // is only for registered codebases; unregistered paths go through registerRepoAtPath.
+      spyScan.mockReturnValue({
+        path: '/workspace',
+        findings: [{ file: '.env', keys: ['ANTHROPIC_API_KEY'] }],
+      });
+
+      const chunks = [];
+      for await (const chunk of client.sendQuery('test', '/workspace')) {
+        chunks.push(chunk);
+      }
+
+      expect(spyScan).not.toHaveBeenCalled();
     });
 
     test('skips scan when codebase has allow_env_keys: true', async () => {
@@ -1061,13 +1080,13 @@ describe('CodexClient', () => {
       expect(spyScan).not.toHaveBeenCalled();
     });
 
-    test('proceeds when cwd has no registered codebase and no sensitive keys', async () => {
+    test('proceeds without scanning when cwd has no registered codebase', async () => {
       const chunks = [];
       for await (const chunk of client.sendQuery('test', '/workspace')) {
         chunks.push(chunk);
       }
 
-      expect(spyScan).toHaveBeenCalledTimes(1);
+      expect(spyScan).not.toHaveBeenCalled();
     });
 
     test('uses prefix lookup for worktree paths when exact match returns null', async () => {

--- a/packages/core/src/clients/codex.ts
+++ b/packages/core/src/clients/codex.ts
@@ -163,7 +163,7 @@ export class CodexClient implements IAssistantClient {
     const codebase =
       (await codebaseDb.findCodebaseByDefaultCwd(cwd)) ??
       (await codebaseDb.findCodebaseByPathPrefix(cwd));
-    if (!codebase?.allow_env_keys) {
+    if (codebase && !codebase.allow_env_keys) {
       // Fail-closed: a config load failure must NOT silently bypass the gate.
       let allowTargetRepoKeys = false;
       try {


### PR DESCRIPTION
## Summary

The pre-spawn env-leak guard in `ClaudeClient.sendQuery()` / `CodexClient.sendQuery()` used `if (!codebase?.allow_env_keys)`, which evaluates truthy when `codebase` is `null`. Any `sendQuery` call with an unregistered cwd — title generation, codebase-less orchestrator runs, DAG executor paths — ran the sensitive-key scanner and threw `EnvLeakError`, blocking every conversation creation on deployed servers whose `.env` is in scope.

## Root Cause

`!undefined === true`, so the defense-in-depth scanner branch was entered for unregistered paths it was never meant to cover. The canonical gate is `registerRepoAtPath()` in `clone.ts`; the pre-spawn check only exists for **registered** codebases without explicit consent.

Evidence:
- `packages/core/src/clients/claude.ts:279`
- `packages/core/src/clients/codex.ts:166`
- Trigger path: `packages/core/src/services/title-generator.ts:53` → `sendQuery` with unregistered cwd.

## Changes

| File | Change |
|------|--------|
| `packages/core/src/clients/claude.ts` | `!codebase?.allow_env_keys` → `codebase && !codebase.allow_env_keys` |
| `packages/core/src/clients/codex.ts` | Same predicate fix |
| `packages/core/src/clients/claude.test.ts` | Added regression test for unregistered cwd; updated existing tests that relied on the null-codebase path to use a registered codebase with `allow_env_keys: false` |
| `packages/core/src/clients/codex.test.ts` | Same test updates |

## Testing

- [x] `bun run type-check` passes
- [x] `bun --filter @archon/core test` passes (all 394+ tests)
- [x] `bun run lint` passes
- [x] New regression tests assert unregistered cwd skips the scan entirely
- [x] Existing "registered codebase without consent" path still throws `EnvLeakError`
- [x] Existing "registered codebase with `allow_env_keys: true`" path still skips scan

## Why This Is Safe

The pre-spawn check is a safety net, not the primary gate:
- **Registered without consent** — still gated (predicate still enters branch)
- **Registered with `allow_env_keys: true`** — still skipped
- **Unregistered cwd** — no codebase row exists to flip `allow_env_keys` on, so gating there was a dead-end; registration remains the enforcement point

## Scope

This is the shallow fix. The deeper architectural issue — that four upstream code paths call `sendQuery` with an unregistered cwd at all — is tracked in a companion issue for post-v0.3.2.

## Issue

Fixes #991

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected environment variable scanning behavior to properly skip when no registered codebase is detected, improving the accuracy of the security check logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->