### PR TITLE
fix: PowerShell Add-ToUserPath corrupts PATH when single entry exists

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -188,7 +188,7 @@ function Confirm-Checksum {
 function Add-ToUserPath {
     param([string]$Dir)
     $currentPath = [Environment]::GetEnvironmentVariable('Path', 'User')
-    $pathParts   = $currentPath -split ';' | Where-Object { $_ -ne '' }
+    $pathParts   = @($currentPath -split ';' | Where-Object { $_ -ne '' })
 
     if ($Dir -notin $pathParts) {
         $pathParts += $Dir


### PR DESCRIPTION
**Bug: PowerShell `Add-ToUserPath` corrupts PATH when only one entry exists**

---

**Problem**

When the user PATH contains exactly one entry, the following line returns a plain string instead of an array:

```powershell
$pathParts = $currentPath -split ';' | Where-Object { $_ -ne '' }
```

PowerShell only returns an array from a pipeline when there are **2 or more elements**. With a single element, `$pathParts` is typed as a `[string]`.

This causes the next line to behave as string concatenation instead of array append:

```powershell
$pathParts += $Dir
# "C:\existing" += "C:\new"
# → "C:\existingC:\new"  ❌  instead of  @("C:\existing", "C:\new")
```

The resulting PATH becomes corrupted:

```
C:\existingC:\new   ← missing semicolon separator
```

---

**Affected scenario**

This bug only triggers when the Windows user PATH contains **exactly one entry** — which is common on freshly configured machines or minimal environments.

---

**Fix**

Wrap the pipeline in `@()` to force an array regardless of the number of elements:

```powershell
# Before
$pathParts = $currentPath -split ';' | Where-Object { $_ -ne '' }

# After
$pathParts = @($currentPath -split ';' | Where-Object { $_ -ne '' })
```

---

**Testing**

To reproduce and verify the fix:

```powershell
# Simulate a single-entry user PATH
[Environment]::SetEnvironmentVariable('Path', 'C:\TestOnly', 'User')

# Call the function
Add-ToUserPath 'C:\NewTool'

# Expected
[Environment]::GetEnvironmentVariable('Path', 'User')
# → "C:\TestOnly;C:\NewTool"  ✅

# Actual (before fix)
# → "C:\TestOnlyC:\NewTool"   ❌
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PATH environment variable parsing in the installation process to ensure the application is properly registered and accessible on all systems. This resolves potential issues where the application might not be correctly added to the system PATH under certain conditions, particularly on systems with non-standard configurations or existing PATH entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->