### PR TITLE
fix(utils): correct misleading port-range comment in calculatePortOffset

### DIFF
--- a/packages/core/src/utils/port-allocation.ts
+++ b/packages/core/src/utils/port-allocation.ts
@@ -22,7 +22,7 @@ function getLog(): ReturnType<typeof createLogger> {
  */
 export function calculatePortOffset(path: string): number {
   const hash = createHash('md5').update(path).digest();
-  // 100-999 range: Offset starts at 100 to avoid default port 3000, results in ports 3100-3999
+  // 100-999 range: offset starts at 100; produces ports 3190-4089 when added to basePort (3090)
   return (hash.readUInt16BE(0) % 900) + 100;
 }
 


### PR DESCRIPTION
Closes #1008

## Problem
The inline comment in `calculatePortOffset` says ports will be in `3100-3999` range, but with `basePort = 3090` the actual range is `3190-4089`. This contradicts the comment and confuses developers reading the code.

## Fix
Updated the inline comment to correctly state `3190-4089` range. The JSDoc above the function was already accurate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal documentation clarity for port allocation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->