### PR TITLE
Fix incorrect substep numbering in setup.md

### DIFF
--- a/.claude/skills/archon/guides/setup.md
+++ b/.claude/skills/archon/guides/setup.md
@@ -158,7 +158,7 @@ Both paths are normal — the manual path is not an error.
 
 Wait for the user to confirm they've completed the setup wizard before proceeding.
 
-### 5c: Verify Configuration
+### 4c: Verify Configuration
 
 After the user confirms setup is complete:
 
@@ -170,7 +170,7 @@ Should show:
 - `Database: sqlite` (default, zero setup) or `Database: postgresql` (if DATABASE_URL was configured)
 - No errors about missing configuration
 
-### 5d: Run Database Migrations (PostgreSQL only)
+### 4d: Run Database Migrations (PostgreSQL only)
 
 **SQLite users: skip this step.** SQLite is auto-initialized on first run with zero setup.
 


### PR DESCRIPTION
## Summary

- Problem: Incorrect substep numbering in setup.md (5c, 5d instead of 4c, 4d)
- Why it matters: Causes confusion when following setup steps
- What changed: Corrected substep labels to match Step 4 sequence
- What did not change (scope boundary): No logic, code, or behavior changes

## UX Journey

### Before

User follows setup instructions:

Step 4:
  4a
  4b
  5c   <-- incorrect
  5d   <-- incorrect

### After

User follows setup instructions:

Step 4:
  4a
  4b
  [4c]
  [4d]

## Architecture Diagram

### Before

No architecture impact (documentation-only change)

### After

No architecture impact (documentation-only change)

**Connection inventory**:

None

## Label Snapshot

- Risk: risk: low
- Size: size: XS
- Scope: docs
- Module: docs:setup

## Change Metadata

- Change type: docs
- Primary scope: docs

## Linked Issue

- Closes #

## Validation Evidence (required)

- Evidence provided (test/log/trace/screenshot): Visual verification of corrected numbering
- If any command is intentionally skipped, explain why:
  Skipped - change is documentation-only and does not affect code

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: Followed setup steps to confirm correct sequence
- Edge cases checked: N/A
- What was not verified: N/A

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: None
- Potential unintended effects: None
- Guardrails/monitoring for early detection: N/A

## Rollback Plan (required)

- Fast rollback command/path: Revert commit
- Feature flags or config toggles (if any): None
- Observable failure symptoms: N/A

## Risks and Mitigations

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected section numbering in the setup guide for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->