### PR TITLE
Use getArchonHome as fallback if workingDir is undefined

### DIFF
--- a/homebrew/archon.rb
+++ b/homebrew/archon.rb
@@ -7,28 +7,28 @@
 class Archon < Formula
   desc "Remote agentic coding platform - control AI assistants from anywhere"
   homepage "https://github.com/coleam00/Archon"
-  version "0.3.1"
+  version "0.3.2"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-darwin-arm64"
-      sha256 "2538346f483d9351d6738a0ef9299e0f475d402005c61286c2557ce41d8a47b9"
+      sha256 "aa71b295bf7bb7addfc9372629ac154411075405639d699382a75537ed08cf43"
     end
     on_intel do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-darwin-x64"
-      sha256 "2eb2c2b8a502270c5d049316f4a2e1314348df3e9112f36953132e3c2a2c67ce"
+      sha256 "b9ac05db31bd9caf37f23412882bd5549f132005161c195179ec97ddcb0a659e"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-linux-arm64"
-      sha256 "12c135688310ba0c0c334832f69418d93a13d50c4013ad84803b05cb776f14be"
+      sha256 "4db2ca27161011aa8c109ca7c658bb4cfe1a5ee8061b65e5c68054a7a9ff4cfd"
     end
     on_intel do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-linux-x64"
-      sha256 "071d8d1bb64e30a60a2c1514d581747a8f27d2fbe1cc33bcc66426b8265f3a65"
+      sha256 "f853efa7058ef8d8e064e2b0be9eabebc4b58ee4d123872cffcf9220d1daf22e"
     end
   end
 

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -1740,10 +1740,12 @@ export function registerApiRoutes(
       }
 
       if (!workingDir) {
-        return c.json({ workflows: [] });
+        workingDir = getArchonHome();
       }
 
-      const result = await discoverWorkflowsWithConfig(workingDir, loadConfig);
+      const result = await discoverWorkflowsWithConfig(workingDir, loadConfig, {
+        globalSearchPath: getArchonHome(),
+      });
       return c.json({
         workflows: result.workflows.map(ws => ({ workflow: ws.workflow, source: ws.source })),
         errors: result.errors.length > 0 ? result.errors : undefined,

--- a/packages/server/src/routes/api.workflows.test.ts
+++ b/packages/server/src/routes/api.workflows.test.ts
@@ -116,9 +116,28 @@ describe('GET /api/workflows', () => {
     expect(body.workflows[0]?.workflow.name).toBe('deploy');
     expect(body.workflows[0]?.source).toBe('bundled');
     expect(body.workflows.workflows).toBeUndefined();
-    expect(mockDiscoverWorkflows).toHaveBeenCalledWith('/tmp/project', expect.any(Function));
+    expect(mockDiscoverWorkflows).toHaveBeenCalledWith(
+      '/tmp/project',
+      expect.any(Function),
+      expect.objectContaining({ globalSearchPath: expect.stringContaining('.archon') })
+    );
     expect(body.errors).toBeDefined();
     expect(Array.isArray(body.errors)).toBe(true);
+  });
+
+  test('falls back to Archon home when no cwd and no registered codebases', async () => {
+    const app = createTestApp();
+    registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+    mockListCodebases.mockImplementationOnce(async () => []);
+
+    const response = await app.request('/api/workflows');
+    expect(response.status).toBe(200);
+    expect(mockDiscoverWorkflows).toHaveBeenCalledWith(
+      expect.stringContaining('.archon'),
+      expect.any(Function),
+      expect.objectContaining({ globalSearchPath: expect.stringContaining('.archon') })
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did **not** change (scope boundary):

## UX Journey

### Before

```
(Draw the user-facing flow BEFORE this PR. Show each step the user takes.)

Example:
  User                   Archon                   AI Client
  ────                   ──────                   ─────────
  sends message ──────▶  resolves session
                         loads context
                         streams to AI ──────────▶ processes prompt
                         receives chunks ◀──────── streams response
  sees reply ◀─────────  sends to platform
```

### After

```
(Draw the user-facing flow AFTER this PR. Highlight what changed with [brackets] or asterisks.)
```

## Architecture Diagram

### Before

```
(Map ALL modules touched or connected to this change. Draw lines between them.)
```

### After

```
(Same diagram with changes highlighted. Mark new modules with [+], removed with [-],
 modified with [~]. Mark new connections with ===, removed with --x--.)
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| | | unchanged / **new** / **removed** / **modified** | |

## Label Snapshot

- Risk: `risk: low|medium|high`
- Size: `size: XS|S|M|L|XL`
- Scope: `core|workflows|isolation|git|adapters|server|web|cli|paths|config|docs|dependencies|ci|tests|skills`
- Module: `<scope>:<component>` (e.g. `workflows:executor`, `adapters:slack`, `core:orchestrator`)

## Change Metadata

- Change type: `bug|feature|refactor|docs|security|chore`
- Primary scope: `core|workflows|isolation|git|adapters|server|web|cli|paths|multi`

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check
bun run lint
bun run format:check
bun run test
# Or all at once:
bun run validate
```

- Evidence provided (test/log/trace/screenshot):
- If any command is intentionally skipped, explain why:

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- New external network calls? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- File system access scope changed? (`Yes/No`)
- If any `Yes`, describe risk and mitigation:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Database migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
- Edge cases checked:
- What was not verified:

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows:
- Potential unintended effects:
- Guardrails/monitoring for early detection:

## Rollback Plan (required)

- Fast rollback command/path:
- Feature flags or config toggles (if any):
- Observable failure symptoms:

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk:
  - Mitigation:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated to version 0.3.2
  * Workflow discovery now searches global locations as a fallback when working directory is unavailable, providing access to more workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->