### PR TITLE
feat(docs): add logo, dark theme, feature cards to docs site

### DIFF
--- a/packages/docs-web/astro.config.mjs
+++ b/packages/docs-web/astro.config.mjs
@@ -7,7 +7,17 @@ export default defineConfig({
     starlight({
       title: 'Archon',
       favicon: '/favicon.png',
+      logo: {
+        src: './src/assets/logo.png',
+        alt: 'Archon',
+      },
       description: 'AI workflow engine — package your coding workflows as YAML, run them anywhere.',
+      head: [
+        {
+          tag: 'script',
+          content: `if(!localStorage.getItem('starlight-theme')){localStorage.setItem('starlight-theme','dark');document.documentElement.dataset.theme='dark';}`,
+        },
+      ],
       social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/coleam00/Archon' }],
       editLink: {
         baseUrl: 'https://github.com/coleam00/Archon/edit/main/packages/docs-web/',

--- a/packages/docs-web/src/content/docs/index.mdx
+++ b/packages/docs-web/src/content/docs/index.mdx
@@ -51,10 +51,13 @@ Archon is a **workflow engine for AI coding agents**. Define multi-step developm
   <Card title="Repeatable" icon="document">
     Package your best AI coding patterns as shareable YAML workflows
   </Card>
-  <Card title="Isolated" icon="random">
+  <Card title="Isolated" icon="laptop">
     Each workflow runs in its own git worktree — no conflicts, no mess
   </Card>
-  <Card title="Composable" icon="puzzle">
+  <Card title="Portable" icon="puzzle">
+    Run from CLI, Web UI, Slack, Telegram, GitHub, or Discord
+  </Card>
+  <Card title="Composable" icon="setting">
     Chain nodes into DAGs with dependencies, loops, and conditional logic
   </Card>
   <Card title="Multi-provider" icon="rocket">

--- a/packages/docs-web/src/content/docs/index.mdx
+++ b/packages/docs-web/src/content/docs/index.mdx
@@ -4,6 +4,9 @@ description: AI workflow engine — package your coding workflows as YAML, run t
 template: splash
 hero:
   title: Archon
+  image:
+    file: ../../assets/logo.png
+    alt: Archon Logo
   tagline: Package your AI coding workflows as YAML. Run them anywhere — CLI, Web, Slack, Telegram, GitHub, Discord.
   actions:
     - text: Get Started
@@ -15,6 +18,8 @@ hero:
       icon: external
       variant: minimal
 ---
+
+import { Card, CardGrid } from '@astrojs/starlight/components';
 
 ## Install in seconds
 
@@ -42,8 +47,17 @@ docker run --rm -v "$PWD:/workspace" ghcr.io/coleam00/archon:latest workflow lis
 
 Archon is a **workflow engine for AI coding agents**. Define multi-step development workflows in YAML — code review, bug fixes, feature implementation, testing — and run them with a single command.
 
-- **Repeatable**: Package your best AI coding patterns as shareable YAML workflows
-- **Isolated**: Each workflow runs in its own git worktree — no conflicts, no mess
-- **Portable**: Run from CLI, Web UI, Slack, Telegram, GitHub, or Discord
-- **Composable**: Chain workflow nodes into DAGs with dependencies, loops, and conditional logic
-- **Multi-provider**: Works with Claude Code SDK and Codex SDK
+<CardGrid>
+  <Card title="Repeatable" icon="document">
+    Package your best AI coding patterns as shareable YAML workflows
+  </Card>
+  <Card title="Isolated" icon="random">
+    Each workflow runs in its own git worktree — no conflicts, no mess
+  </Card>
+  <Card title="Composable" icon="puzzle">
+    Chain nodes into DAGs with dependencies, loops, and conditional logic
+  </Card>
+  <Card title="Multi-provider" icon="rocket">
+    Works with Claude Code SDK and Codex SDK
+  </Card>
+</CardGrid>

--- a/packages/docs-web/src/styles/custom.css
+++ b/packages/docs-web/src/styles/custom.css
@@ -13,11 +13,13 @@
   --sl-color-hairline-light: #1e293b;
 }
 
+/* !important needed: Starlight sets .hero padding/gap via inline styles */
 .hero {
   padding-block: 2rem !important;
   gap: 1rem !important;
 }
 
+/* .sidebar-content is an internal Starlight class (not a public API) — re-test after Starlight upgrades */
 [data-theme='dark'] .sidebar-content a[aria-current='page'] {
   background: linear-gradient(135deg, rgba(168, 85, 247, 0.15), rgba(59, 130, 246, 0.15));
   border-left-color: #a855f7;

--- a/packages/docs-web/src/styles/custom.css
+++ b/packages/docs-web/src/styles/custom.css
@@ -5,3 +5,20 @@
   --sl-font: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
   --sl-font-mono: 'JetBrains Mono', ui-monospace, monospace;
 }
+
+[data-theme='dark'] {
+  --sl-color-bg: #0f1219;
+  --sl-color-bg-sidebar: #131825;
+  --sl-color-bg-nav: #0f1219;
+  --sl-color-hairline-light: #1e293b;
+}
+
+.hero {
+  padding-block: 2rem !important;
+  gap: 1rem !important;
+}
+
+[data-theme='dark'] .sidebar-content a[aria-current='page'] {
+  background: linear-gradient(135deg, rgba(168, 85, 247, 0.15), rgba(59, 130, 246, 0.15));
+  border-left-color: #a855f7;
+}


### PR DESCRIPTION
## Summary

- **Problem**: The Archon docs site lacked brand identity — no logo in the header or hero, plain bullet lists where feature cards should be, excessive hero whitespace, and minimal custom CSS
- **Why it matters**: The gap between the polished Archon Web UI and the unbranded docs site created a disjointed developer experience
- **What changed**: Wired up the existing logo asset to the header and hero, converted the homepage to MDX to support feature cards, defaulted to dark theme, tightened hero spacing, and added sidebar gradient highlight
- **What did NOT change**: No navigation structure changes, no server/CLI/core packages touched — all changes confined to `packages/docs-web/`

## UX Journey

### Before

```
User visits docs
  ─────────────────────────────────────────────────────────
  Header:  [Archon - plain text, no logo]  [GitHub]
  Hero:    ~120px empty padding
           "Archon" (title)
           "Package your AI coding workflows..."
           [Get Started]  [View on GitHub]
           ~60px empty padding below buttons
  Content: ## What is Archon?
             - Repeatable: ...plain bullet
             - Isolated: ...plain bullet
             - Composable: ...plain bullet
             - Multi-provider: ...plain bullet
```

### After

```
User visits docs
  ─────────────────────────────────────────────────────────
  [CHANGED] Header:  [🛡 Shield logo + "Archon"]  [GitHub]
  [CHANGED] Hero:    compact 2rem padding
                     [shield logo image]  "Archon"
                     "Package your AI coding workflows..."
                     [Get Started]  [View on GitHub]
  [CHANGED] Content: ## What is Archon?
             ┌──────────────┐ ┌──────────────┐ ┌──────────────┐ ┌──────────────┐
             │ 📄 Repeatable│ │ Isolated     │ │ Composable   │ │ Multi-prov.  │
             │ Package your │ │ Git worktree │ │ Chain nodes  │ │ Claude+Codex │
             └──────────────┘ └──────────────┘ └──────────────┘ └──────────────┘
  [CHANGED] Theme: dark by default (user can toggle)
```

## Architecture Diagram

### Before

```
packages/docs-web/
├── astro.config.mjs          [no logo, no defaultTheme]
├── src/
│   ├── assets/logo.png       [exists but UNUSED in config]
│   ├── content/docs/
│   │   └── index.md          [.md - no MDX, plain bullets]
│   └── styles/custom.css     [8 lines, minimal vars]
```

### After

```
packages/docs-web/
├── astro.config.mjs          [~ logo wired up, head dark-theme script]
├── src/
│   ├── assets/logo.png       [unchanged, now REFERENCED]
│   ├── content/docs/
│   │   └── index.mdx         [~ renamed .md→.mdx, hero image, CardGrid]
│   └── styles/custom.css     [~ +17 lines: dark vars, hero spacing, sidebar gradient]
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| astro.config.mjs | src/assets/logo.png | **new** | Logo wired to header via `logo.src` |
| index.mdx | src/assets/logo.png | **new** | Hero image via `hero.image.file` |
| index.mdx | @astrojs/starlight/components | **new** | Card/CardGrid MDX import |
| custom.css | Starlight dark theme | **modified** | Dark background vars + sidebar gradient |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `docs`
- Module: `docs:ui`

## Change Metadata

- Change type: `feature`
- Primary scope: `docs`

## Linked Issue

- Closes #1018

## Validation Evidence (required)

```bash
bun run type-check   # ✅ All 9 packages pass
bun run lint         # ✅ 0 errors, 0 warnings
bun run format:check # ✅ All files formatted
bun run test         # ✅ All passed (0 failed)
cd packages/docs-web && bun run build  # ✅ 60 pages built, no errors
```

All checks passed on first run with no fixes required.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — no URL changes (index.md → index.mdx keeps same route `/`)
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: Docs build passes (60 pages, no errors); type-check, lint, format, tests all green
- Edge cases checked: MDX code-group syntax preserved after rename; logo paths verified relative to each file's location; `defaultTheme` config key not supported in Starlight v0.38.2 so replaced with inline `<head>` script
- What was not verified: Live visual rendering in a browser (build-only validation)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `packages/docs-web` only — zero impact on server, CLI, core, or any other package
- Potential unintended effects: None — all changes are static site assets and CSS; no runtime logic
- Guardrails/monitoring: Docs build CI step catches any broken MDX syntax or bad asset paths

## Rollback Plan (required)

- Fast rollback command/path: `git revert HEAD` — single atomic commit; docs rebuild redeploys
- Feature flags or config toggles: None needed — pure CSS/config changes
- Observable failure symptoms: Docs build fails in CI; logo missing from header; broken homepage

## Risks and Mitigations

- Risk: MDX code-group syntax breaks after .md → .mdx rename
  - Mitigation: Starlight's `:::code-group` remark plugin works in both `.md` and `.mdx`; build confirmed passing

- Risk: `defaultTheme` config key not supported in Starlight v0.38.2
  - Mitigation: Replaced with inline `<head>` script setting `localStorage` + `data-theme` attribute on first visit — identical UX effect, validated in build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Archon logo to the documentation site header.
  * Set dark mode as the default theme for first-time users.
  * Redesigned the installation section with a card-based layout showcasing key features.

* **Style**
  * Enhanced dark theme styling for improved visual consistency and readability across the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->