### PR TITLE
fix(web): show tool calls for CLI-launched workflows in chat view

### DIFF
--- a/packages/web/src/components/chat/MessageList.tsx
+++ b/packages/web/src/components/chat/MessageList.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -9,7 +9,10 @@ import { ToolCallCard } from './ToolCallCard';
 import { ErrorCard } from './ErrorCard';
 import { WorkflowProgressCard } from './WorkflowProgressCard';
 import { useAutoScroll } from '@/hooks/useAutoScroll';
-import type { ChatMessage } from '@/lib/types';
+import { useQuery } from '@tanstack/react-query';
+import { getWorkflowRun } from '@/lib/api';
+import type { WorkflowEventResponse } from '@/lib/api';
+import type { ChatMessage, ToolCallDisplay } from '@/lib/types';
 
 // Hoisted to module scope to prevent new references on every render
 const WORKFLOW_RESULT_MARKDOWN_COMPONENTS = {
@@ -25,6 +28,42 @@ const WORKFLOW_RESULT_MARKDOWN_COMPONENTS = {
   ),
 };
 
+/** Extract ToolCallDisplay objects from workflow_events (tool_called + tool_completed pairs).
+ *  Mirrors the greedy matching in WorkflowExecution.tsx — duplicated intentionally (< 3 uses). */
+function extractToolCallsFromEvents(events: WorkflowEventResponse[]): ToolCallDisplay[] {
+  const completedEvents = events
+    .filter(ev => ev.event_type === 'tool_completed')
+    .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
+
+  const usedCompleted = new Set<string>();
+
+  return events
+    .filter(ev => ev.event_type === 'tool_called')
+    .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
+    .map(ev => {
+      const evTime = new Date(ev.created_at).getTime();
+      const toolName = ev.data.tool_name as string;
+      const stepName = ev.step_name;
+      const completed = completedEvents.find(
+        c =>
+          !usedCompleted.has(c.id) &&
+          (c.data.tool_name as string) === toolName &&
+          new Date(c.created_at).getTime() >= evTime &&
+          c.step_name === stepName
+      );
+      if (completed) usedCompleted.add(completed.id);
+      return {
+        id: ev.id,
+        name: toolName,
+        input: (ev.data.tool_input as Record<string, unknown>) ?? {},
+        output: undefined,
+        duration: completed ? (completed.data.duration_ms as number | undefined) : undefined,
+        startedAt: 0,
+        isExpanded: false,
+      };
+    });
+}
+
 function WorkflowResultCard({
   workflowName,
   runId,
@@ -36,6 +75,18 @@ function WorkflowResultCard({
 }): React.ReactElement {
   const navigate = useNavigate();
   const [expanded, setExpanded] = useState(false);
+  const [toolsExpanded, setToolsExpanded] = useState(false);
+
+  const { data: runData } = useQuery({
+    queryKey: ['workflow-run', runId],
+    queryFn: () => getWorkflowRun(runId),
+    staleTime: 30_000,
+  });
+
+  const toolCalls = useMemo(
+    () => extractToolCallsFromEvents(runData?.events ?? []),
+    [runData?.events]
+  );
 
   const lines = content.split('\n');
   const isTruncatable = content.length > 500 || lines.length > 8;
@@ -82,6 +133,26 @@ function WorkflowResultCard({
           </button>
         )}
       </div>
+      {toolCalls.length > 0 && (
+        <div className="border-t border-border px-3 py-2">
+          <button
+            onClick={(): void => {
+              setToolsExpanded(!toolsExpanded);
+            }}
+            className="text-[10px] text-text-tertiary hover:text-text-secondary transition-colors"
+          >
+            {toolsExpanded ? '\u25BE' : '\u25B8'} {toolCalls.length} tool call
+            {toolCalls.length !== 1 ? 's' : ''}
+          </button>
+          {toolsExpanded && (
+            <div className="mt-2 flex flex-col gap-1.5">
+              {toolCalls.map(tool => (
+                <ToolCallCard key={tool.id} tool={tool} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/web/src/components/chat/MessageList.tsx
+++ b/packages/web/src/components/chat/MessageList.tsx
@@ -101,10 +101,7 @@ function WorkflowResultCard({
 
   const lines = content.split('\n');
   const isTruncatable = content.length > 500 || lines.length > 8;
-  const previewText = lines.slice(0, 8).join('\n').slice(0, 500);
-  const preview = isTruncatable
-    ? previewText + (previewText.length < content.length ? '...' : '')
-    : content;
+  const preview = isTruncatable ? lines.slice(0, 8).join('\n').slice(0, 500) + '...' : content;
 
   const displayContent = expanded || !isTruncatable ? content : preview;
 
@@ -144,11 +141,12 @@ function WorkflowResultCard({
           </button>
         )}
       </div>
-      {isRunError ? (
+      {isRunError && (
         <div className="border-t border-border px-3 py-2">
           <span className="text-[10px] text-error">Failed to load tool calls</span>
         </div>
-      ) : toolCalls.length > 0 ? (
+      )}
+      {!isRunError && toolCalls.length > 0 && (
         <div className="border-t border-border px-3 py-2">
           <button
             onClick={(): void => {
@@ -167,7 +165,7 @@ function WorkflowResultCard({
             </div>
           )}
         </div>
-      ) : null}
+      )}
     </div>
   );
 }

--- a/packages/web/src/components/chat/MessageList.tsx
+++ b/packages/web/src/components/chat/MessageList.tsx
@@ -43,22 +43,22 @@ function extractToolCallsFromEvents(events: WorkflowEventResponse[]): ToolCallDi
     .map(ev => {
       const evTime = new Date(ev.created_at).getTime();
       const toolName = ev.data.tool_name as string;
-      const stepName = ev.step_name;
+      const stepName = ev.step_name ?? undefined;
       const completed = completedEvents.find(
         c =>
           !usedCompleted.has(c.id) &&
           (c.data.tool_name as string) === toolName &&
           new Date(c.created_at).getTime() >= evTime &&
-          c.step_name === stepName
+          (c.step_name ?? undefined) === stepName
       );
       if (completed) usedCompleted.add(completed.id);
       return {
         id: ev.id,
         name: toolName,
         input: (ev.data.tool_input as Record<string, unknown>) ?? {},
-        output: undefined,
+        output: undefined, // tool output not extracted here; WorkflowExecution.tsx also omits it
         duration: completed ? (completed.data.duration_ms as number | undefined) : undefined,
-        startedAt: 0,
+        startedAt: evTime, // use ev.created_at timestamp so ToolCallCard timer works for in-progress tools
         isExpanded: false,
       };
     });
@@ -77,11 +77,22 @@ function WorkflowResultCard({
   const [expanded, setExpanded] = useState(false);
   const [toolsExpanded, setToolsExpanded] = useState(false);
 
-  const { data: runData } = useQuery({
-    queryKey: ['workflow-run', runId],
+  const {
+    data: runData,
+    error: runError,
+    isError: isRunError,
+  } = useQuery({
+    queryKey: ['workflowRun', runId],
     queryFn: () => getWorkflowRun(runId),
-    staleTime: 30_000,
+    staleTime: 30_000, // longer than default — workflow run events are immutable once terminal
   });
+
+  if (isRunError) {
+    console.warn('[WorkflowResultCard] Failed to load run events for tool calls', {
+      runId,
+      error: runError instanceof Error ? runError.message : runError,
+    });
+  }
 
   const toolCalls = useMemo(
     () => extractToolCallsFromEvents(runData?.events ?? []),
@@ -133,7 +144,11 @@ function WorkflowResultCard({
           </button>
         )}
       </div>
-      {toolCalls.length > 0 && (
+      {isRunError ? (
+        <div className="border-t border-border px-3 py-2">
+          <span className="text-[10px] text-error">Failed to load tool calls</span>
+        </div>
+      ) : toolCalls.length > 0 ? (
         <div className="border-t border-border px-3 py-2">
           <button
             onClick={(): void => {
@@ -152,7 +167,7 @@ function WorkflowResultCard({
             </div>
           )}
         </div>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/packages/web/src/components/chat/MessageList.tsx
+++ b/packages/web/src/components/chat/MessageList.tsx
@@ -58,7 +58,7 @@ function extractToolCallsFromEvents(events: WorkflowEventResponse[]): ToolCallDi
         input: (ev.data.tool_input as Record<string, unknown>) ?? {},
         output: undefined, // tool output not extracted here; WorkflowExecution.tsx also omits it
         duration: completed ? (completed.data.duration_ms as number | undefined) : undefined,
-        startedAt: evTime, // use ev.created_at timestamp so ToolCallCard timer works for in-progress tools
+        startedAt: evTime, // epoch ms from ev.created_at — these runs are always terminal so the timer never ticks
         isExpanded: false,
       };
     });
@@ -101,7 +101,10 @@ function WorkflowResultCard({
 
   const lines = content.split('\n');
   const isTruncatable = content.length > 500 || lines.length > 8;
-  const preview = isTruncatable ? lines.slice(0, 8).join('\n').slice(0, 500) + '...' : content;
+  const previewText = lines.slice(0, 8).join('\n').slice(0, 500);
+  const preview = isTruncatable
+    ? previewText + (previewText.length < content.length ? '...' : '')
+    : content;
 
   const displayContent = expanded || !isTruncatable ? content : preview;
 


### PR DESCRIPTION
## Summary

- **Problem**: CLI-launched workflow runs store tool calls in `workflow_events` but never persist them to `messages.metadata.toolCalls` (CLI adapter uses batch streaming mode, which skips tool call dispatch). The Web UI chat view reads tool calls only from message metadata, so CLI-launched workflows showed zero tool calls in the `WorkflowResultCard`.
- **Why it matters**: Users who run workflows via CLI (`bun run cli workflow run ...`) see no tool call activity in the Web UI chat view, making the chat history for those runs significantly less informative than for web-launched workflows.
- **What changed**: `WorkflowResultCard` in `MessageList.tsx` now fetches `workflow_events` via `getWorkflowRun(runId)` (existing API) and renders a collapsed tool calls section extracted from `tool_called`/`tool_completed` event pairs — works for both CLI and web-launched workflows.
- **What did not change**: The CLI adapter, DAG executor, and `IPlatformAdapter` interface are untouched. No backend changes needed — `workflow_events` already persists tool calls unconditionally.

## UX Journey

### Before

```
User (CLI)               Archon CLI               Web UI
──────────               ──────────               ──────
runs workflow ─────────▶ batch streaming mode
                         tool calls skipped
                         (not in message metadata)
opens chat ◀──────────── WorkflowResultCard shows
                         ❌ no tool calls
```

### After

```
User (CLI)               Archon CLI               Web UI
──────────               ──────────               ──────
runs workflow ─────────▶ batch streaming mode
                         tool calls stored in
                         workflow_events (unchanged)
opens chat ◀──────────── WorkflowResultCard fetches
                         workflow_events → extracts
                         tool_called/tool_completed
                         ✅ shows "N tool calls" (collapsed)
                         click to expand tool cards
```

## Architecture Diagram

### Before

```
WorkflowResultCard
  └── renders content, navigate link
  (no tool call data)
```

### After

```
WorkflowResultCard
  ├── useQuery → getWorkflowRun(runId) → workflow_events table
  ├── extractToolCallsFromEvents() — greedy pair matching
  └── renders ToolCallCard[] (collapsed by default)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `WorkflowResultCard` | `getWorkflowRun` API | **new** | Fetches events for the completed run |
| `WorkflowResultCard` | `ToolCallCard` | **new** | Already imported; now rendered in result card too |
| `WorkflowResultCard` | `extractToolCallsFromEvents` | **new** | Local helper (duplicated from WorkflowExecution.tsx per Rule of Three) |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `web`
- Module: `web:chat`

## Change Metadata

- Change type: `bug`
- Primary scope: `web`

## Linked Issue

- Closes #1017

## Validation Evidence (required)

```bash
bun run type-check  # ✅ Pass — all 9 packages
bun run lint        # ✅ Pass — 0 errors, 0 warnings
bun run format:check # ✅ Pass
bun run test        # ✅ Pass — 2900+ tests across all packages, 0 failures
```

- Evidence provided: Automated validation run produced ALL_PASS (see workflow artifact `validation.md`)
- No commands skipped.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No — `getWorkflowRun` calls the local Archon server (existing internal API)
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — additive UI change only
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: Type check, lint, format, and full test suite pass
- Edge cases checked: Tool calls with no completions (duration undefined), zero tool calls (section hidden), collapsed-by-default rendering
- What was not verified: Manual end-to-end in browser (no live server available during implementation)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `WorkflowResultCard` component only — renders in chat view for any completed workflow message
- Potential unintended effects: Web-launched workflows now also show tool calls in result card (in addition to inline stream messages). They display collapsed; user must click to see. Not a regression — additive information.
- Guardrails/monitoring: `staleTime: 30_000` prevents excessive refetching; `useQuery` returns undefined gracefully if run is deleted (section hidden)

## Rollback Plan (required)

- Fast rollback command/path: Revert `packages/web/src/components/chat/MessageList.tsx` to prior commit
- Feature flags or config toggles: None
- Observable failure symptoms: `WorkflowResultCard` fails to render (React error boundary); no data fetched from `getWorkflowRun`

## Risks and Mitigations

- Risk: Extra API call per `WorkflowResultCard` rendered (one `GET /api/workflow-runs/:id` per card)
  - Mitigation: TanStack Query deduplicates concurrent calls; `staleTime: 30_000` caches result for 30s; only fires for completed workflow messages, not all messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tool calls from workflow runs are now displayed with execution details including timestamps and duration.
  * Added collapsible section to view and manage tool call information.
  * Improved error handling with user-friendly messaging when tool call data fails to load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->