### PR TITLE
fix(claude-client): use || instead of ?? in hasExplicitTokens to handle empty-string env vars

### DIFF
--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -82,8 +82,9 @@ function normalizeClaudeUsage(usage?: {
  * - ~/.archon/.env loaded with override:true as the trusted source
  */
 function buildSubprocessEnv(): NodeJS.ProcessEnv {
+  // Using || intentionally: empty string should be treated as missing credential
   const hasExplicitTokens = Boolean(
-    process.env.CLAUDE_CODE_OAUTH_TOKEN ?? process.env.CLAUDE_API_KEY
+    process.env.CLAUDE_CODE_OAUTH_TOKEN || process.env.CLAUDE_API_KEY
   );
   const authMode = hasExplicitTokens ? 'explicit' : 'global';
   getLog().info(


### PR DESCRIPTION
## Problem

In `packages/core/src/clients/claude.ts`, the `hasExplicitTokens` variable is defined using nullish coalescing (`??`):

```ts
const hasExplicitTokens =
  process.env.CLAUDE_CODE_OAUTH_TOKEN ?? process.env.CLAUDE_API_KEY;
```

The `??` operator only falls back when the left operand is `null` or `undefined`. If `CLAUDE_CODE_OAUTH_TOKEN` is set to an empty string `""`, it is treated as a valid (truthy) value by `??`, preventing fallback to `CLAUDE_API_KEY`. This causes authentication to silently fail.

## Fix

Replace `??` with `||` so that an empty string `""` is treated as falsy and `CLAUDE_API_KEY` is used as the fallback:

```ts
const hasExplicitTokens =
  process.env.CLAUDE_CODE_OAUTH_TOKEN || process.env.CLAUDE_API_KEY;
```

Closes #1027

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication fallback: empty or blank tokens are now treated as missing, causing the system to reliably fall back to the alternative authentication method and update logging to reflect the chosen auth mode. This prevents accidental use of empty credentials and clarifies auth selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->