### PR TITLE
feat(isolation): add configurable worktree creation timeout

### DIFF
--- a/packages/core/src/config/config-types.ts
+++ b/packages/core/src/config/config-types.ts
@@ -152,6 +152,13 @@ export interface RepoConfig {
      * @example [".env", ".archon", "data/fixtures/"]
      */
     copyFiles?: string[];
+
+    /**
+     * Timeout in milliseconds for worktree creation (git worktree add, fetch, checkout).
+     * Increase for repos with heavy post-checkout hooks.
+     * @default 30000
+     */
+    timeout?: number;
   };
 
   /**

--- a/packages/isolation/src/providers/worktree.ts
+++ b/packages/isolation/src/providers/worktree.ts
@@ -556,7 +556,10 @@ export class WorktreeProvider implements IIsolationProvider {
       await mkdirAsync(join(worktreeBase, owner, repo), { recursive: true });
     }
 
-    const timeout = worktreeConfig?.timeout ?? 30000;
+    const timeout =
+      typeof worktreeConfig?.timeout === 'number' && worktreeConfig.timeout > 0
+        ? worktreeConfig.timeout
+        : 30000;
 
     if (isPRIsolationRequest(request)) {
       // For PRs: fetch and checkout the PR branch (actual or synthetic)

--- a/packages/isolation/src/providers/worktree.ts
+++ b/packages/isolation/src/providers/worktree.ts
@@ -556,12 +556,14 @@ export class WorktreeProvider implements IIsolationProvider {
       await mkdirAsync(join(worktreeBase, owner, repo), { recursive: true });
     }
 
+    const timeout = worktreeConfig?.timeout ?? 30000;
+
     if (isPRIsolationRequest(request)) {
       // For PRs: fetch and checkout the PR branch (actual or synthetic)
-      await this.createFromPR(request, worktreePath);
+      await this.createFromPR(request, worktreePath, timeout);
     } else {
       // For issues, tasks, threads: create new branch
-      await this.createNewBranch(request, repoPath, worktreePath, branchName, baseBranch);
+      await this.createNewBranch(request, repoPath, worktreePath, branchName, baseBranch, timeout);
     }
 
     // Copy git-ignored files based on repo config
@@ -722,7 +724,11 @@ export class WorktreeProvider implements IIsolationProvider {
    * When prSha is provided, the worktree is initially created at the specific
    * commit (detached HEAD), then a local tracking branch is created.
    */
-  private async createFromPR(request: PRIsolationRequest, worktreePath: string): Promise<void> {
+  private async createFromPR(
+    request: PRIsolationRequest,
+    worktreePath: string,
+    timeout: number
+  ): Promise<void> {
     // Clean up any orphan directory before creating worktree
     await this.cleanOrphanDirectoryIfExists(worktreePath);
 
@@ -732,10 +738,10 @@ export class WorktreeProvider implements IIsolationProvider {
     try {
       if (!request.isForkPR) {
         // Same-repo PR: Use the actual branch so changes push directly to PR
-        await this.createFromSameRepoPR(repoPath, worktreePath, request.prBranch);
+        await this.createFromSameRepoPR(repoPath, worktreePath, request.prBranch, timeout);
       } else {
         // Fork PR: Use synthetic review branch
-        await this.createFromForkPR(repoPath, worktreePath, prNumber, request.prSha);
+        await this.createFromForkPR(repoPath, worktreePath, prNumber, timeout, request.prSha);
       }
     } catch (error) {
       // Clean up orphaned git-registered worktree from partial failure
@@ -752,11 +758,12 @@ export class WorktreeProvider implements IIsolationProvider {
   private async createFromSameRepoPR(
     repoPath: string,
     worktreePath: string,
-    prBranch: string
+    prBranch: string,
+    timeout: number
   ): Promise<void> {
     // Fetch the PR's actual branch
     await execFileAsync('git', ['-C', repoPath, 'fetch', 'origin', prBranch], {
-      timeout: 30000,
+      timeout,
     });
 
     // Try to create worktree with the branch
@@ -765,14 +772,14 @@ export class WorktreeProvider implements IIsolationProvider {
       await execFileAsync(
         'git',
         ['-C', repoPath, 'worktree', 'add', worktreePath, '-b', prBranch, `origin/${prBranch}`],
-        { timeout: 30000 }
+        { timeout }
       );
     } catch (error) {
       const err = error as Error & { stderr?: string };
       // Branch already exists locally - use it directly
       if (err.stderr?.includes('already exists')) {
         await execFileAsync('git', ['-C', repoPath, 'worktree', 'add', worktreePath, prBranch], {
-          timeout: 30000,
+          timeout,
         });
       } else {
         throw error;
@@ -784,7 +791,7 @@ export class WorktreeProvider implements IIsolationProvider {
       await execFileAsync(
         'git',
         ['-C', worktreePath, 'branch', '--set-upstream-to', `origin/${prBranch}`],
-        { timeout: 30000 }
+        { timeout }
       );
     } catch (trackingError) {
       getLog().warn({ err: trackingError, worktreePath, prBranch }, 'upstream_tracking_failed');
@@ -802,6 +809,7 @@ export class WorktreeProvider implements IIsolationProvider {
     repoPath: string,
     worktreePath: string,
     prNumber: string,
+    timeout: number,
     prSha?: string
   ): Promise<void> {
     const reviewBranch = `pr-${prNumber}-review`;
@@ -809,11 +817,11 @@ export class WorktreeProvider implements IIsolationProvider {
     if (prSha) {
       // SHA provided: create at specific commit for reproducible reviews
       await execFileAsync('git', ['-C', repoPath, 'fetch', 'origin', `pull/${prNumber}/head`], {
-        timeout: 30000,
+        timeout,
       });
 
       await execFileAsync('git', ['-C', repoPath, 'worktree', 'add', worktreePath, prSha], {
-        timeout: 30000,
+        timeout,
       });
 
       // Create a local tracking branch so it's not detached HEAD
@@ -821,7 +829,7 @@ export class WorktreeProvider implements IIsolationProvider {
         repoPath,
         () =>
           execFileAsync('git', ['-C', worktreePath, 'checkout', '-b', reviewBranch, prSha], {
-            timeout: 30000,
+            timeout,
           }),
         reviewBranch
       );
@@ -833,13 +841,13 @@ export class WorktreeProvider implements IIsolationProvider {
           execFileAsync(
             'git',
             ['-C', repoPath, 'fetch', 'origin', `pull/${prNumber}/head:${reviewBranch}`],
-            { timeout: 30000 }
+            { timeout }
           ),
         reviewBranch
       );
 
       await execFileAsync('git', ['-C', repoPath, 'worktree', 'add', worktreePath, reviewBranch], {
-        timeout: 30000,
+        timeout,
       });
     }
   }
@@ -877,7 +885,8 @@ export class WorktreeProvider implements IIsolationProvider {
     repoPath: string,
     worktreePath: string,
     branchName: string,
-    baseBranch: string
+    baseBranch: string,
+    timeout: number
   ): Promise<void> {
     // Clean up any orphan directory before creating worktree
     await this.cleanOrphanDirectoryIfExists(worktreePath);
@@ -894,7 +903,7 @@ export class WorktreeProvider implements IIsolationProvider {
         'git',
         ['-C', repoPath, 'worktree', 'add', worktreePath, '-b', branchName, startPoint],
         {
-          timeout: 30000,
+          timeout,
         }
       );
     } catch (error) {
@@ -911,7 +920,7 @@ export class WorktreeProvider implements IIsolationProvider {
           );
         }
         await execFileAsync('git', ['-C', repoPath, 'worktree', 'add', worktreePath, branchName], {
-          timeout: 30000,
+          timeout,
         });
       } else {
         throw error;

--- a/packages/isolation/src/types.ts
+++ b/packages/isolation/src/types.ts
@@ -242,6 +242,7 @@ export interface IsolationEnvironmentRow {
 export interface WorktreeCreateConfig {
   baseBranch?: string;
   copyFiles?: string[];
+  timeout?: number;
 }
 
 export type RepoConfigLoader = (repoPath: string) => Promise<WorktreeCreateConfig | null>;


### PR DESCRIPTION
## Summary

- **Problem:** Worktree creation uses a hardcoded 30s timeout, causing failures for repos with heavy post-checkout hooks.
- **Why it matters:** Users with complex post-checkout hooks (linting, dependency install, etc.) can't use worktree isolation without the creation timing out.
- **What changed:** Added `worktree.timeout` config option (ms) that flows through the isolation layer to all worktree creation `execFileAsync` calls, with 30000ms default for backward compatibility.
- **What did not change (scope boundary):** Removal, listing, and branch cleanup operations keep their hardcoded timeouts. No changes to `@archon/git` package, `MergedConfig`, or `GlobalConfig`.

## UX Journey

### Before

```
  User                     .archon/config.yaml         WorktreeProvider
  ────                     ───────────────────         ────────────────
  triggers workflow ─────▶ worktree.baseBranch
                           worktree.copyFiles
                           (no timeout option)  ─────▶ hardcoded 30000ms
                                                       ↳ TIMEOUT if hooks > 30s ❌
```

### After

```
  User                     .archon/config.yaml         WorktreeProvider
  ────                     ───────────────────         ────────────────
  triggers workflow ─────▶ worktree.baseBranch
                           worktree.copyFiles
                          *worktree.timeout: 60000* ─▶ uses config timeout (or 30000ms default)
                                                       ↳ succeeds with heavy hooks ✅
```

## Architecture Diagram

### Before

```
RepoConfig.worktree ──▶ WorktreeCreateConfig ──▶ WorktreeProvider
  baseBranch                baseBranch              hardcoded 30000ms
  copyFiles                 copyFiles
```

### After

```
RepoConfig.worktree ──▶ WorktreeCreateConfig ──▶ WorktreeProvider
  baseBranch                baseBranch              config.timeout ?? 30000
  copyFiles                 copyFiles
  [~] timeout               [~] timeout
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `RepoConfig.worktree` | `WorktreeCreateConfig` | **modified** | Added `timeout?: number` |
| `WorktreeCreateConfig` | `WorktreeProvider.create` | **modified** | Timeout threaded to creation methods |
| `WorktreeProvider` → `execFileAsync` (creation) | N/A | **modified** | 11 instances use config timeout |
| `WorktreeProvider` → `execFileAsync` (removal/list) | N/A | unchanged | Keep hardcoded timeouts |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `isolation`, `config`
- Module: `isolation:worktree-provider`, `core:config-types`

## Change Metadata

- Change type: `feature`
- Primary scope: `isolation`

## Linked Issue

N/A — Feature request from workflow usage observation.

## Validation Evidence (required)

```bash
bun run validate  # ✅ All pass
```

- Type check: ✅ (9 packages)
- Lint: ✅ (0 errors, 0 warnings)
- Format: ✅
- Tests: ✅ (all packages, 2901+ tests)
- Build: ⚠️ Pre-existing `@archon/web` failure (missing `mdast-util-gfm` dep, identical on `dev`)

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes` — default remains 30000ms when not configured
- Config/env changes? `Yes` — new optional `worktree.timeout` in `.archon/config.yaml`
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios: `bun run validate` passes, diff reviewed for all 15 timeout instances (11 updated, 4 kept)
- Edge cases checked: Omitting config (default 30000ms), config injection path already passes full worktree object
- What was not verified: Manual test with an actual heavy post-checkout hook repo

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Only worktree creation in `@archon/isolation`
- Potential unintended effects: None — pure config plumbing with default fallback
- Guardrails/monitoring for early detection: Existing isolation tests cover all creation paths

## Rollback Plan (required)

- Fast rollback command/path: Revert the single commit
- Feature flags or config toggles: N/A (opt-in via config, default unchanged)
- Observable failure symptoms: Worktree creation timeouts (same as before this PR)

## Risks and Mitigations

- Risk: User sets unreasonably large timeout, causing long hangs on broken repos
  - Mitigation: This is user-controlled config; no worse than current hardcoded behavior. User can always Ctrl+C.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable timeout for worktree creation operations. Users can set the timeout (milliseconds) for git steps during worktree setup; default is 30,000 ms.
  * Timeout is applied to PR and non-PR worktree creation and validates as a positive number.
  * Branch-deletion retry behavior continues to use the fixed 30,000 ms timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->