### PR TITLE
fix(db): throw on corrupt commands JSON instead of silent empty fallback

### DIFF
--- a/packages/core/src/db/codebases.test.ts
+++ b/packages/core/src/db/codebases.test.ts
@@ -202,9 +202,7 @@ describe('codebases', () => {
 
     test('parses valid JSON string from SQLite TEXT column', async () => {
       const commands = { plan: { path: 'plan.md', description: 'Plan' } };
-      mockQuery.mockResolvedValueOnce(
-        createQueryResult([{ commands: JSON.stringify(commands) }])
-      );
+      mockQuery.mockResolvedValueOnce(createQueryResult([{ commands: JSON.stringify(commands) }]));
 
       const result = await getCodebaseCommands('codebase-123');
       expect(result).toEqual(commands);

--- a/packages/core/src/db/codebases.test.ts
+++ b/packages/core/src/db/codebases.test.ts
@@ -191,6 +191,24 @@ describe('codebases', () => {
       // Original frozen object should be unchanged
       expect(frozenCommands).not.toHaveProperty('new-command');
     });
+
+    test('throws on corrupt JSON string (SQLite TEXT column)', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([{ commands: '{not valid json' }]));
+
+      await expect(getCodebaseCommands('codebase-123')).rejects.toThrow(
+        /Corrupt commands JSON for codebase codebase-123/
+      );
+    });
+
+    test('parses valid JSON string from SQLite TEXT column', async () => {
+      const commands = { plan: { path: 'plan.md', description: 'Plan' } };
+      mockQuery.mockResolvedValueOnce(
+        createQueryResult([{ commands: JSON.stringify(commands) }])
+      );
+
+      const result = await getCodebaseCommands('codebase-123');
+      expect(result).toEqual(commands);
+    });
   });
 
   describe('registerCommand', () => {

--- a/packages/core/src/db/codebases.ts
+++ b/packages/core/src/db/codebases.ts
@@ -61,8 +61,8 @@ export async function getCodebaseCommands(
   if (typeof raw === 'string') {
     try {
       parsed = JSON.parse(raw);
-    } catch (_err) {
-      getLog().error({ codebaseId: id, raw }, 'db.codebase_commands_json_parse_failed');
+    } catch (err) {
+      getLog().error({ codebaseId: id, raw, err }, 'db.codebase_commands_json_parse_failed');
       throw new Error(
         `Corrupt commands JSON for codebase ${id}: unable to parse stored data. ` +
           `Run UPDATE remote_agent_codebases SET commands = '{}' WHERE id = '${id}' to reset.`

--- a/packages/core/src/db/codebases.ts
+++ b/packages/core/src/db/codebases.ts
@@ -61,9 +61,12 @@ export async function getCodebaseCommands(
   if (typeof raw === 'string') {
     try {
       parsed = JSON.parse(raw);
-    } catch {
+    } catch (_err) {
       getLog().error({ codebaseId: id, raw }, 'db.codebase_commands_json_parse_failed');
-      return {};
+      throw new Error(
+        `Corrupt commands JSON for codebase ${id}: unable to parse stored data. ` +
+          `Run UPDATE remote_agent_codebases SET commands = '{}' WHERE id = '${id}' to reset.`
+      );
     }
   } else {
     parsed = raw ?? {};


### PR DESCRIPTION
Fixes #967

## Problem

`getCodebaseCommands()` silently returned `{}` when the `codebases.commands` column contained corrupt JSON. The error was logged but never surfaced to the caller, so a client receiving `{}` had no way to distinguish "no commands configured" from "commands exist but are unreadable."

## Fix

- **Throw** a descriptive `Error` instead of silently returning `{}`
- Error message includes the codebase ID and a SQL recovery hint for operators
- The corruption is still logged via the structured logger before throwing

## Changes

- `packages/core/src/db/codebases.ts` — replace `return {}` with `throw new Error(...)` in the JSON parse catch block
- `packages/core/src/db/codebases.test.ts` — add two test cases:
  - Corrupt JSON string throws with descriptive message
  - Valid JSON string from SQLite TEXT column parses correctly

## Validation

- `bun test` — 31 pass, 0 fail
- `bun run type-check` — all packages clean
- `bun run lint` — no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrupted serialized command data now surfaces a clear, descriptive error naming the affected codebase and advising how to reset the stored value, replacing prior silent failures.
* **Tests**
  * Added tests to verify behavior for both corrupted and valid serialized command data, ensuring parsing errors are detected and valid payloads are returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->