### PR TITLE
fix(setup): quote repo path in --spawn terminal commands (fixes #1035)

### DIFF
--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -361,6 +361,17 @@ CODEX_ACCOUNT_ID=account1
       // Just verify the function is exported and callable
       expect(typeof spawnTerminalWithSetup).toBe('function');
     });
+
+    it('should quote paths with spaces for Windows terminal spawning', () => {
+      // Verify the function handles paths with spaces without throwing
+      // On non-Windows platforms, this just tests that the fallback path works
+      const pathWithSpaces = join(tmpdir(), 'path with spaces', 'Archon');
+      const result = spawnTerminalWithSetup(pathWithSpaces);
+      // On CI/Linux, all terminal spawns will fail (no wt.exe, no gnome-terminal, etc.)
+      // That's expected — we just verify it doesn't crash and returns a proper result
+      expect(result).toHaveProperty('success');
+      expect(typeof result.success).toBe('boolean');
+    });
   });
 
   describe('copyArchonSkill', () => {

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -1223,19 +1223,28 @@ function trySpawn(
  * Tries: Windows Terminal -> cmd.exe with start
  */
 function spawnWindowsTerminal(repoPath: string): SpawnResult {
+  // Quote the path for Windows shell expansion — paths like
+  // "C:\Users\...\GitHub Libraries\Archon" must be double-quoted
+  // to survive both wt.exe and cmd.exe argument parsing (#1035).
+  const quoted = `"${repoPath}"`;
+
   // Try Windows Terminal first (modern Windows 10/11)
+  // wt.exe parses its own command line, so we need shell: true
+  // with explicit quoting rather than relying on Node's auto-quoting.
   if (
-    trySpawn('wt.exe', ['-d', repoPath, 'cmd', '/k', 'archon setup'], {
+    trySpawn('wt.exe', ['-d', quoted, 'cmd', '/k', 'archon setup'], {
       detached: true,
       stdio: 'ignore',
+      shell: true,
     })
   ) {
     return { success: true };
   }
 
   // Fallback to cmd.exe with start command (works on all Windows)
+  // /D requires a quoted path when it contains spaces.
   if (
-    trySpawn('cmd.exe', ['/c', 'start', '""', '/D', repoPath, 'cmd', '/k', 'archon setup'], {
+    trySpawn('cmd.exe', ['/c', 'start', '""', '/D', quoted, 'cmd', '/k', 'archon setup'], {
       detached: true,
       stdio: 'ignore',
       shell: true,


### PR DESCRIPTION
## Problem

`archon setup --spawn` fails on Windows when the repo path contains spaces (e.g. `C:\Users\...\GitHub Libraries\Archon`). Both the Windows Terminal (`wt.exe`) and `cmd.exe` fallback paths pass the path unquoted, causing it to be split at the first space.

The user sees a Windows error dialog: `"Libraries\Archon\packages\cli" could not be found`.

## Fix

Wrap `repoPath` in double-quotes before passing to `wt.exe` and `cmd.exe`:

1. **wt.exe path**: Add explicit `"..."` quoting and switch to `shell: true` for consistent shell-level quoting
2. **cmd.exe path**: Quote the `/D` argument so `start` receives the full path

Both paths now handle spaces, special characters, and parentheses in directory names.

## Changes

- `packages/cli/src/commands/setup.ts`: Quote `repoPath` in `spawnWindowsTerminal()`
- `packages/cli/src/commands/setup.test.ts`: Add test for paths with spaces

## Validation

- `bun test packages/cli/src/commands/setup.test.ts` — 19 pass, 0 fail
- `bun run type-check` — clean across all packages
- `bun run lint` — clean

## Note

The Linux terminal spawning functions have a similar potential issue with unquoted paths (`--working-directory=` concatenation), but that is out of scope for this PR.

Closes #1035

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the CLI setup command would fail when repository paths contained spaces on Windows.

* **Tests**
  * Added test coverage for handling filesystem paths containing spaces during terminal initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->