### PR TITLE
fix: add explicit export entries for community forge adapters

### DIFF
--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -6,7 +6,9 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./*": "./src/*"
+    "./*": "./src/*",
+    "./community/forge/gitea": "./src/community/forge/gitea/index.ts",
+    "./community/forge/gitlab": "./src/community/forge/gitlab/index.ts"
   },
   "scripts": {
     "test": "bun test src/chat/ src/community/chat/ src/community/forge/gitlab/auth.test.ts src/forge/github/auth.test.ts src/utils/ && bun test src/forge/github/adapter.test.ts && bun test src/forge/github/context.test.ts && bun test src/community/forge/gitea/adapter.test.ts && bun test src/community/forge/gitlab/adapter.test.ts",


### PR DESCRIPTION
## Summary

- Problem: Binary builds fail — `bun build --compile` cannot resolve `@archon/adapters/community/forge/gitea` and `@archon/adapters/community/forge/gitlab` through the wildcard export map
- Why it matters: Release workflow will fail on next tag push; no binaries can be built
- What changed: Added two explicit export entries in `packages/adapters/package.json` for the deep subpaths
- What did **not** change: The wildcard `"./*"` is kept for all other subpath imports

## UX Journey

### Before

```
$ bash scripts/build-binaries.sh
error: Could not resolve: "@archon/adapters/community/forge/gitea"
error: Could not resolve: "@archon/adapters/community/forge/gitlab"
```

### After

```
$ bash scripts/build-binaries.sh
Building bun-darwin-arm64 → dist/binaries/archon-darwin-arm64
  [85ms]  minify
 [559ms]  bundle  1470 modules
 [241ms] compile
Build complete.
```

## Architecture Diagram

N/A — no architectural change, just a package.json exports fix.

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `adapters`
- Module: `adapters:exports`

## Change Metadata

- Change type: `fix`
- Primary scope: `adapters`

## Linked Issue

- Closes #1040

## Validation Evidence (required)

```bash
# Binary build succeeds:
VERSION=0.0.1 GIT_COMMIT=test1234 TARGET=bun-darwin-arm64 OUTFILE=/tmp/archon-test bash scripts/build-binaries.sh
# Build complete.

# Binary runs correctly:
/tmp/archon-test version
# Archon CLI v0.0.1 ...
# Update available: v0.0.1 → v0.3.2 — https://...

# Quiet mode suppresses notice:
/tmp/archon-test --quiet version
# (no update notice)
```

- type-check, lint, tests all unaffected (package.json exports only)

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: Built binary from repo root, ran `version` command, confirmed update notice works
- Edge cases checked: `--quiet` suppression, cached vs fresh fetch
- What was not verified: Cross-platform builds (CI handles those)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Binary build pipeline only
- Potential unintended effects: None — explicit entries take precedence over wildcard and resolve to the same files
- Guardrails/monitoring: CI release workflow will validate on next release

## Rollback Plan (required)

- Fast rollback command/path: Revert the commit (removes 2 lines from package.json)
- Feature flags: N/A
- Observable failure symptoms: Binary build fails with "Could not resolve" errors

## Risks and Mitigations

- None — minimal, well-understood change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gitea community forge adapter is now explicitly available for import
  * GitLab community forge adapter is now explicitly available for import

<!-- end of auto-generated comment: release notes by coderabbit.ai -->