### PR TITLE
fix(server): strip leading slash in serveStatic for absolute webDistPath

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -73,12 +73,8 @@ export async function serveCommand(opts: ServeOptions): Promise<number> {
   // process.exit(exitCode) would kill it. Wait on a promise that only resolves
   // on SIGINT/SIGTERM so the server stays running.
   await new Promise<void>(resolve => {
-    process.on('SIGINT', () => {
-      resolve();
-    });
-    process.on('SIGTERM', () => {
-      resolve();
-    });
+    process.once('SIGINT', resolve);
+    process.once('SIGTERM', resolve);
   });
   return 0;
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -604,7 +604,12 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
       opts.webDistPath ??
       pathModule.join(pathModule.dirname(pathModule.dirname(import.meta.dir)), 'web', 'dist');
 
-    app.use('/assets/*', serveStatic({ root: webDistPath }));
+    // Strip leading slash from request path — path.join treats absolute segments
+    // as root resets, so "/assets/foo.js" would discard the webDistPath entirely.
+    const stripLeadingSlash = (path: string): string => path.replace(/^\//, '');
+
+    app.use('/assets/*', serveStatic({ root: webDistPath, rewriteRequestPath: stripLeadingSlash }));
+    app.use('/favicon.png', serveStatic({ root: webDistPath, path: 'favicon.png' }));
     // SPA fallback - serve index.html for unmatched routes (after all API routes)
     app.get('*', serveStatic({ root: webDistPath, path: 'index.html' }));
   }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -604,11 +604,11 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
       opts.webDistPath ??
       pathModule.join(pathModule.dirname(pathModule.dirname(import.meta.dir)), 'web', 'dist');
 
-    // Strip leading slash from request path — path.join treats absolute segments
-    // as root resets, so "/assets/foo.js" would discard the webDistPath entirely.
-    const stripLeadingSlash = (path: string): string => path.replace(/^\//, '');
+    if (!existsSync(webDistPath)) {
+      getLog().warn({ webDistPath }, 'web_dist_not_found');
+    }
 
-    app.use('/assets/*', serveStatic({ root: webDistPath, rewriteRequestPath: stripLeadingSlash }));
+    app.use('/assets/*', serveStatic({ root: webDistPath }));
     app.use('/favicon.png', serveStatic({ root: webDistPath, path: 'favicon.png' }));
     // SPA fallback - serve index.html for unmatched routes (after all API routes)
     app.get('*', serveStatic({ root: webDistPath, path: 'index.html' }));


### PR DESCRIPTION
## Summary

- Problem: Hono's `serveStatic` passes `c.req.path` (e.g. `/assets/foo.js`) to `path.join` with the `root` option. When `root` is an absolute path (like `~/.archon/web-dist/0.3.4`), `path.join` treats the leading `/` in the request path as an absolute segment and **discards the root entirely** — resolving to `/assets/foo.js` instead of `~/.archon/web-dist/0.3.4/assets/foo.js`
- Why it matters: `archon serve` downloads the web UI to an absolute path, so all static files (CSS, JS, favicon) fail to load — the web UI shows a blank page
- What changed: Added `rewriteRequestPath` to strip the leading slash before `path.join`, and an explicit `/favicon.png` route
- What did **not** change: SPA fallback (`index.html`) already worked because it uses `path: 'index.html'` (relative, no leading slash). API routes unaffected.

## UX Journey

### Before

```
  Browser                    Server
  ───────                    ──────
  GET /assets/index.js ────▶ serveStatic({ root: "/Users/.../web-dist/0.3.4" })
                             path.join("/Users/.../0.3.4", "/assets/index.js")
                             → "/assets/index.js" (root discarded!)
                             Bun.file("/assets/index.js") → not found
  blank page ◀──────────────  empty 200
```

### After

```
  Browser                    Server
  ───────                    ──────
  GET /assets/index.js ────▶ rewriteRequestPath: strip leading /
                             path.join("/Users/.../0.3.4", "assets/index.js")
                             → "/Users/.../0.3.4/assets/index.js" ✓
  web UI loads ◀────────────  200 + file content
```

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `server`
- Module: `server:static-serving`

## Change Metadata

- Change type: `bug`
- Primary scope: `server`

## Validation Evidence (required)

Tested in production mode with built web dist:
```
Root:    200  839 bytes (index.html)
CSS:     200  95,637 bytes
Favicon: 200  48,205 bytes
API:     200  7 codebases
```

- Type check: passes
- Lint: passes (after adding return type annotation)

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

- Verified: dev server in production mode serves all static assets correctly
- Edge cases: SPA fallback for `/chat` returns `index.html`
- Not verified: compiled binary (needs release build)

## Side Effects / Blast Radius (required)

- Affected: static file serving in production mode only
- No effect on dev mode (uses Vite dev server)
- No effect on API routes

## Rollback Plan (required)

- Fast rollback: `git revert <commit>`
- Observable failure: blank web UI page

## Risks and Mitigations

- Risk: `rewriteRequestPath` might affect other Hono middleware
  - Mitigation: Only applied to `/assets/*` route, scoped narrowly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Static asset serving improved: missing production web build now logs a clear warning and favicon requests are handled reliably.
  * Server shutdown behavior hardened: termination signals are handled once to ensure predictable, single-run shutdown processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->