### PR TITLE
Release 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5] - 2026-04-10
+
+Fixes for `archon serve` process lifecycle and static file serving.
+
+### Fixed
+
+- **`archon serve` process exits immediately**: the CLI called `process.exit(0)` after `startServer()` returned, killing the server. Now blocks on SIGINT/SIGTERM so the server stays running (#1047)
+- **Web dist path existence check**: server logs a warning at startup if the web dist directory is missing, instead of silently serving 404s
+- **Favicon route**: added explicit `/favicon.png` route for the web UI
+
 ## [0.3.4] - 2026-04-10
 
 Binary env loading fix and release infrastructure improvements.

--- a/homebrew/archon.rb
+++ b/homebrew/archon.rb
@@ -7,28 +7,28 @@
 class Archon < Formula
   desc "Remote agentic coding platform - control AI assistants from anywhere"
   homepage "https://github.com/coleam00/Archon"
-  version "0.3.3"
+  version "0.3.4"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-darwin-arm64"
-      sha256 "86d4d8ce3a09d2f23db87d42dc193f822e9563aa109d91db1f98ed6d9dcbda68"
+      sha256 "98604b134a25d6b04f6ec9e1614d0bf60c43fa096d4f7e396b1d844cfbbc06db"
     end
     on_intel do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-darwin-x64"
-      sha256 "f9ca4493e0c6eb4205f7d384ab3b5f427eaa0423493ab388fe9ec6a50ce76744"
+      sha256 "f897229a9b802853e3b1f99920c1d9f73987c30b319cca887b2b2fa86e9e5110"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-linux-arm64"
-      sha256 "f0e6d1f51a1b0276c8de53ca029fa4c6c3e54dbdf65603dbaec770b66a93d4a5"
+      sha256 "1a96484d11436efa8f3ce092f8032cd672b4320f4123e5bc35ac9ead5b744ec8"
     end
     on_intel do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-linux-x64"
-      sha256 "d4e29f2a5620af49b50ec3029d6ddaa1a55042efc1dc2b157b5f375f84da7b81"
+      sha256 "2ed29b960b1ff2437dea420e347165d7ebc5129d60fcae5400f23250712a52b6"
     end
   end
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "archon",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archon/adapters",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archon/cli",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "type": "module",
   "main": "./src/cli.ts",
   "bin": {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -73,12 +73,8 @@ export async function serveCommand(opts: ServeOptions): Promise<number> {
   // process.exit(exitCode) would kill it. Wait on a promise that only resolves
   // on SIGINT/SIGTERM so the server stays running.
   await new Promise<void>(resolve => {
-    process.on('SIGINT', () => {
-      resolve();
-    });
-    process.on('SIGTERM', () => {
-      resolve();
-    });
+    process.once('SIGINT', resolve);
+    process.once('SIGTERM', resolve);
   });
   return 0;
 }

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -69,7 +69,17 @@ export async function serveCommand(opts: ServeOptions): Promise<number> {
     return 1;
   }
 
-  // Server runs until SIGINT/SIGTERM — never returns
+  // Block forever — Bun.serve() keeps the event loop alive, but the CLI's
+  // process.exit(exitCode) would kill it. Wait on a promise that only resolves
+  // on SIGINT/SIGTERM so the server stays running.
+  await new Promise<void>(resolve => {
+    process.on('SIGINT', () => {
+      resolve();
+    });
+    process.on('SIGTERM', () => {
+      resolve();
+    });
+  });
   return 0;
 }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archon/core",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/docs-web/package.json
+++ b/packages/docs-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archon/docs-web",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "scripts": {
     "dev": "astro dev",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archon/git",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/isolation/package.json
+++ b/packages/isolation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archon/isolation",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archon/paths",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archon/server",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "type": "module",
   "main": "./src/index.ts",
   "scripts": {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -604,7 +604,12 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
       opts.webDistPath ??
       pathModule.join(pathModule.dirname(pathModule.dirname(import.meta.dir)), 'web', 'dist');
 
-    app.use('/assets/*', serveStatic({ root: webDistPath }));
+    // Strip leading slash from request path — path.join treats absolute segments
+    // as root resets, so "/assets/foo.js" would discard the webDistPath entirely.
+    const stripLeadingSlash = (path: string): string => path.replace(/^\//, '');
+
+    app.use('/assets/*', serveStatic({ root: webDistPath, rewriteRequestPath: stripLeadingSlash }));
+    app.use('/favicon.png', serveStatic({ root: webDistPath, path: 'favicon.png' }));
     // SPA fallback - serve index.html for unmatched routes (after all API routes)
     app.get('*', serveStatic({ root: webDistPath, path: 'index.html' }));
   }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -604,11 +604,11 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
       opts.webDistPath ??
       pathModule.join(pathModule.dirname(pathModule.dirname(import.meta.dir)), 'web', 'dist');
 
-    // Strip leading slash from request path — path.join treats absolute segments
-    // as root resets, so "/assets/foo.js" would discard the webDistPath entirely.
-    const stripLeadingSlash = (path: string): string => path.replace(/^\//, '');
+    if (!existsSync(webDistPath)) {
+      getLog().warn({ webDistPath }, 'web_dist_not_found');
+    }
 
-    app.use('/assets/*', serveStatic({ root: webDistPath, rewriteRequestPath: stripLeadingSlash }));
+    app.use('/assets/*', serveStatic({ root: webDistPath }));
     app.use('/favicon.png', serveStatic({ root: webDistPath, path: 'favicon.png' }));
     // SPA fallback - serve index.html for unmatched routes (after all API routes)
     app.get('*', serveStatic({ root: webDistPath, path: 'index.html' }));

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archon/web",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archon/workflows",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "type": "module",
   "exports": {
     "./schemas/*": "./src/schemas/*.ts",


### PR DESCRIPTION
## Release 0.3.5

Fixes for `archon serve` process lifecycle and static file serving.

### Fixed

- **`archon serve` process exits immediately**: the CLI called `process.exit(0)` after `startServer()` returned, killing the server. Now blocks on SIGINT/SIGTERM so the server stays running (#1047)
- **Web dist path existence check**: server logs a warning at startup if the web dist directory is missing, instead of silently serving 404s
- **Favicon route**: added explicit `/favicon.png` route for the web UI

---

Merging this PR releases 0.3.5 to main.