### PR TITLE
fix(core): add AWS env vars to subprocess allowlist for Bedrock auth

### DIFF
--- a/packages/core/src/utils/env-allowlist.ts
+++ b/packages/core/src/utils/env-allowlist.ts
@@ -34,6 +34,13 @@ export const SUBPROCESS_ENV_ALLOWLIST = new Set([
   'ANTHROPIC_BEDROCK_BASE_URL',
   'ANTHROPIC_VERTEX_PROJECT_ID',
   'ANTHROPIC_VERTEX_REGION',
+  // AWS credentials (needed for Bedrock auth)
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_SESSION_TOKEN',
+  'AWS_PROFILE',
+  'AWS_REGION',
+  'AWS_DEFAULT_REGION',
   // Archon runtime config
   'ARCHON_HOME',
   'ARCHON_DOCKER',


### PR DESCRIPTION
## Summary
- AWS credentials (`AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_DEFAULT_REGION`) were missing from the subprocess env allowlist
- This caused 401 authentication failures when using Claude Code via AWS Bedrock, because the Claude subprocess couldn't see the AWS credentials it needs
- The allowlist already included `CLAUDE_CODE_USE_BEDROCK` but not the AWS vars it depends on

## Test plan
- [x] Verified fix locally: server chat with Bedrock auth works after adding AWS vars to allowlist
- [ ] Verify no regression for direct Anthropic API users (no AWS vars present = no change)
- [ ] Verify Vertex users are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AWS environment variables are now available during code execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->