### PR TITLE
fix(web,server): show real platform connection status in Settings (closes #1031)

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -252,6 +252,11 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
   await webAdapter.start();
   persistence.startPeriodicFlush();
 
+  // Mutable — pushed to as each adapter starts, read by the /api/health endpoint.
+  // Must be a live reference because Telegram starts after the HTTP listener begins
+  // accepting requests, so a snapshot taken at registration time would miss it.
+  const activePlatforms: string[] = ['Web'];
+
   // Platform adapters (skipped in CLI serve mode or when not configured)
   let github: GitHubAdapter | null = null;
   let gitea: GiteaAdapter | null = null;
@@ -284,6 +289,7 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
         botMention
       );
       await github.start();
+      activePlatforms.push('GitHub');
     } else {
       getLog().info('github_adapter_skipped');
     }
@@ -300,6 +306,7 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
         giteaBotMention
       );
       await gitea.start();
+      activePlatforms.push('Gitea');
     } else {
       getLog().info('gitea_adapter_skipped');
     }
@@ -316,6 +323,7 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
         gitlabBotMention
       );
       await gitlab.start();
+      activePlatforms.push('GitLab');
     } else {
       getLog().info('gitlab_adapter_skipped');
     }
@@ -378,6 +386,7 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
       });
 
       await discord.start();
+      activePlatforms.push('Discord');
     } else {
       getLog().info('discord_adapter_skipped');
     }
@@ -433,6 +442,7 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
       });
 
       await slack.start();
+      activePlatforms.push('Slack');
     } else {
       getLog().info('slack_adapter_skipped');
     }
@@ -451,7 +461,7 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
   });
 
   // Register Web UI API routes
-  registerApiRoutes(app, webAdapter, lockManager);
+  registerApiRoutes(app, webAdapter, lockManager, activePlatforms);
 
   // GitHub webhook endpoint
   if (github) {
@@ -607,6 +617,7 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
 
     try {
       await telegramAdapter.start();
+      activePlatforms.push('Telegram');
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
       getLog().error({ err: error, errorType: error.constructor.name }, 'telegram.start_failed');
@@ -667,15 +678,6 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
   // because it occurs AFTER the for-await generator loop exits (and thus outside
   // the try/catch in claude.ts). These are SDK cleanup races, not fatal app errors.
   process.on('unhandledRejection', handleUnhandledRejection);
-
-  // Show active platforms
-  const activePlatforms = ['Web'];
-  if (telegram) activePlatforms.push('Telegram');
-  if (discord) activePlatforms.push('Discord');
-  if (slack) activePlatforms.push('Slack');
-  if (github) activePlatforms.push('GitHub');
-  if (gitea) activePlatforms.push('Gitea');
-  if (gitlab) activePlatforms.push('GitLab');
 
   getLog().info({ activePlatforms, port }, 'server_ready');
 

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -819,6 +819,7 @@ const getHealthRoute = createRoute({
               runningWorkflows: z.number(),
               version: z.string().optional(),
               is_docker: z.boolean(),
+              activePlatforms: z.array(z.string()).optional(),
             })
             .openapi('HealthResponse'),
         },
@@ -851,7 +852,8 @@ const getUpdateCheckRoute = createRoute({
 export function registerApiRoutes(
   app: OpenAPIHono,
   webAdapter: WebAdapter,
-  lockManager: ConversationLockManager
+  lockManager: ConversationLockManager,
+  activePlatforms?: readonly string[]
 ): void {
   function apiError(
     c: Context,
@@ -2548,6 +2550,7 @@ export function registerApiRoutes(
       runningWorkflows: runningWorkflowRows.length,
       version: appVersion,
       is_docker: isDocker(),
+      activePlatforms: activePlatforms ? [...activePlatforms] : ['Web'],
     });
   });
 

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -56,6 +56,7 @@ export interface HealthResponse {
   runningWorkflows: number;
   version?: string;
   is_docker: boolean;
+  activePlatforms?: string[];
 }
 
 async function fetchJSON<T>(url: string, options?: RequestInit): Promise<T> {

--- a/packages/web/src/routes/SettingsPage.tsx
+++ b/packages/web/src/routes/SettingsPage.tsx
@@ -607,16 +607,19 @@ function AssistantConfigSection({ config }: { config: SafeConfigResponse }): Rea
 }
 
 function PlatformConnectionsSection({
-  adapter,
+  activePlatforms,
 }: {
-  adapter: string | undefined;
+  activePlatforms: string[] | undefined;
 }): React.ReactElement {
+  const active = new Set(activePlatforms ?? []);
   const platforms = [
-    { name: 'Web', connected: adapter === 'web' },
-    { name: 'Slack', connected: false },
-    { name: 'Telegram', connected: false },
-    { name: 'Discord', connected: false },
-    { name: 'GitHub', connected: false },
+    { name: 'Web', connected: active.has('Web') },
+    { name: 'Slack', connected: active.has('Slack') },
+    { name: 'Telegram', connected: active.has('Telegram') },
+    { name: 'Discord', connected: active.has('Discord') },
+    { name: 'GitHub', connected: active.has('GitHub') },
+    { name: 'Gitea', connected: active.has('Gitea') },
+    { name: 'GitLab', connected: active.has('GitLab') },
   ];
 
   return (
@@ -717,7 +720,7 @@ export function SettingsPage(): React.ReactElement {
 
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
             {configData && <AssistantConfigSection config={configData.config} />}
-            <PlatformConnectionsSection adapter={health?.adapter} />
+            <PlatformConnectionsSection activePlatforms={health?.activePlatforms} />
           </div>
 
           <ProjectsSection />


### PR DESCRIPTION
## Summary

- **Problem:** The Settings page's "Platform Connections" section hardcoded every platform except Web to "Not configured", so users couldn't tell whether their Slack/Telegram/Discord/GitHub/Gitea/GitLab adapters had actually started.
- **Why it matters:** Health/UX — config errors go undetected until a message arrives (or doesn't).
- **What changed:**
  - Server: `/api/health` now returns an `activePlatforms` array populated live as each adapter's `start()` resolves. The live reference is passed into `registerApiRoutes` because Telegram starts after the HTTP listener is already accepting requests, so a snapshot would miss it.
  - Web: `SettingsPage.PlatformConnectionsSection` reads `activePlatforms` and looks each platform up in a `Set`. Also adds Gitea and GitLab to the list (they already ship as adapters).
- **What did _not_ change (scope boundary):** No changes to the Telegram adapter — the telegraf/grammY startup semantics fix that was part of the original PR is no longer needed since `dev` migrated to grammY and now uses the `onStart` callback in `packages/adapters/src/chat/telegram/adapter.ts`. That portion of the original PR has been dropped on rebase.

## UX Journey

### Before

```
  User                 Server                   Web UI (Settings)
  ────                 ──────                   ─────────────────
  opens Settings ────▶ GET /api/health
                       returns { adapter } ────▶ shows only Web
                                                 others hardcoded 'Not configured' ❌
```

### After

```
  User                 Server                   Web UI (Settings)
  ────                 ──────                   ─────────────────
  opens Settings ────▶ GET /api/health
                       returns { adapter,
                              *activePlatforms*: ['Web','Slack',...] } ────▶ reflects real state ✅
```

## Architecture Diagram

### Before

```
startServer
├─ adapter.start() (each platform)
└─ (log-only) activePlatforms computed at end       registerApiRoutes
                                                    └─ GET /api/health → { adapter }
```

### After

```
startServer
├─ [+] const activePlatforms: string[] = ['Web']
├─ adapter.start(); [+] activePlatforms.push(name)   registerApiRoutes(..., [+] activePlatforms)
└─ log activePlatforms (reuses the live array)       └─ GET /api/health → { adapter, [+] activePlatforms }
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `startServer` | `registerApiRoutes(activePlatforms)` | **modified** | Live array reference |
| each adapter `start()` | `activePlatforms.push(...)` | **new** | Populated as they start |
| `GET /api/health` | `HealthResponse.activePlatforms` | **new** | Optional field, defaults to `['Web']` |
| `SettingsPage` | `health.activePlatforms` | **modified** | Reads real data (was hardcoded `false`) |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `server`, `web`
- Module: `server:index`, `server:routes/api`, `web:SettingsPage`

## Change Metadata

- Change type: `fix`
- Primary scope: `multi` (server + web)

## Linked Issue

- Closes #1031

## Validation Evidence (required)

```bash
bun run type-check              # ✅ 10 packages
bun run lint                    # ✅ 0 errors, 0 warnings
bun --filter @archon/server test  # ✅ 46 tests pass
```

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

`activePlatforms` exposes only platform *names* (e.g. `"Slack"`) — no tokens or config values.

## Compatibility / Migration

- Backward compatible? `Yes` — `activePlatforms` is an optional field; clients that ignore it see no change.
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios: type-check / lint / `@archon/server` test suite pass locally.
- Edge cases checked: Telegram starts after `registerApiRoutes` runs — the live array reference ensures `/api/health` reflects its state once it pushes. `getHealth()` without platforms configured returns `['Web']` as before.
- What was not verified: Live browser check of the Settings page rendering against a running server.

## Side Effects / Blast Radius (required)

- Affected subsystems: `/api/health`, Settings page.
- Potential unintended effects: None. The array is read-only from the handler's perspective; a copy is emitted each response.
- Guardrails: Existing adapter-start logs (`*.bot_started`, `github_webhook_registered`, etc.) remain the source of truth for startup observability.

## Rollback Plan (required)

- Fast rollback: `git revert <commit>` — single commit, 4 files, contained.
- Feature flags or config toggles: N/A.
- Observable failure symptoms: Settings page returns to showing everything as "Not configured".

## Risks and Mitigations

- Risk: Telegram adapter fails to start but earlier code path already pushes `'Telegram'` to the array.
  - Mitigation: Push is inside the `try` block after `await telegramAdapter.start()`; failure skips the push (matches pre-existing `telegram = null` handling).

---

Rebased from @liorfranko's original PR onto current `dev`. The adapter changes were dropped because dev migrated from telegraf to grammY and already resolves the `bot.launch()` never-resolves issue via the `onStart` callback — so that fix is no longer needed. The server + web portions remain and are credited to @liorfranko.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings panel now displays real-time connection status for all active platforms, including Gitea and GitLab.
  * Health check endpoint reports which platforms are currently active.

* **Bug Fixes**
  * Platform connection status now reflects actual running platforms instead of hardcoded defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->