### PR TITLE
feat(core): inject workflow run context into orchestrator prompt

### DIFF
--- a/packages/core/src/db/messages.test.ts
+++ b/packages/core/src/db/messages.test.ts
@@ -3,6 +3,7 @@ import { createQueryResult, mockPostgresDialect } from '../test/mocks/database';
 import type { MessageRow } from './messages';
 
 const mockQuery = mock(() => Promise.resolve(createQueryResult([])));
+const mockGetDatabaseType = mock(() => 'postgresql' as const);
 
 // Mock the connection module before importing the module under test
 mock.module('./connection', () => ({
@@ -10,9 +11,22 @@ mock.module('./connection', () => ({
     query: mockQuery,
   },
   getDialect: () => mockPostgresDialect,
+  getDatabaseType: mockGetDatabaseType,
 }));
 
-import { addMessage, listMessages } from './messages';
+// Mock @archon/paths to avoid lazy logger initialization issues in tests
+mock.module('@archon/paths', () => ({
+  createLogger: mock(() => ({
+    fatal: mock(() => undefined),
+    error: mock(() => undefined),
+    warn: mock(() => undefined),
+    info: mock(() => undefined),
+    debug: mock(() => undefined),
+    trace: mock(() => undefined),
+  })),
+}));
+
+import { addMessage, listMessages, getRecentWorkflowResultMessages } from './messages';
 
 describe('messages', () => {
   beforeEach(() => {
@@ -119,6 +133,78 @@ describe('messages', () => {
       await listMessages('conv-456', 50);
 
       expect(mockQuery).toHaveBeenCalledWith(expect.any(String), ['conv-456', 50]);
+    });
+  });
+
+  describe('getRecentWorkflowResultMessages', () => {
+    beforeEach(() => {
+      mockGetDatabaseType.mockClear();
+    });
+
+    test('uses PostgreSQL JSON extraction syntax when dbType is postgresql', async () => {
+      mockGetDatabaseType.mockReturnValueOnce('postgresql');
+      mockQuery.mockResolvedValueOnce(createQueryResult([]));
+
+      await getRecentWorkflowResultMessages('conv-1');
+
+      const sql = mockQuery.mock.calls[0]?.[0] as string;
+      expect(sql).toContain("metadata->>'workflowResult'");
+      expect(sql).not.toContain('json_extract');
+    });
+
+    test('uses SQLite JSON extraction syntax when dbType is sqlite', async () => {
+      mockGetDatabaseType.mockReturnValueOnce('sqlite');
+      mockQuery.mockResolvedValueOnce(createQueryResult([]));
+
+      await getRecentWorkflowResultMessages('conv-1');
+
+      const sql = mockQuery.mock.calls[0]?.[0] as string;
+      expect(sql).toContain("json_extract(metadata, '$.workflowResult')");
+      expect(sql).not.toContain("->>'" + 'workflowResult');
+    });
+
+    test('passes correct parameters: conversationId and limit', async () => {
+      mockGetDatabaseType.mockReturnValueOnce('postgresql');
+      mockQuery.mockResolvedValueOnce(createQueryResult([]));
+
+      await getRecentWorkflowResultMessages('conv-42', 5);
+
+      expect(mockQuery).toHaveBeenCalledWith(expect.any(String), ['conv-42', 5]);
+    });
+
+    test('default limit is 3', async () => {
+      mockGetDatabaseType.mockReturnValueOnce('postgresql');
+      mockQuery.mockResolvedValueOnce(createQueryResult([]));
+
+      await getRecentWorkflowResultMessages('conv-1');
+
+      expect(mockQuery).toHaveBeenCalledWith(expect.any(String), ['conv-1', 3]);
+    });
+
+    test('returns empty array on query error (non-throwing contract)', async () => {
+      mockGetDatabaseType.mockReturnValueOnce('postgresql');
+      mockQuery.mockRejectedValueOnce(new Error('connection refused'));
+
+      const result = await getRecentWorkflowResultMessages('conv-1');
+
+      expect(result).toEqual([]);
+    });
+
+    test('returns rows from successful query', async () => {
+      const row: MessageRow = {
+        id: 'msg-1',
+        conversation_id: 'conv-1',
+        role: 'assistant',
+        content: 'Workflow summary here.',
+        metadata: '{"workflowResult":{"workflowName":"plan","runId":"run-1"}}',
+        created_at: '2026-01-01T00:00:00Z',
+      };
+      mockGetDatabaseType.mockReturnValueOnce('postgresql');
+      mockQuery.mockResolvedValueOnce(createQueryResult([row]));
+
+      const result = await getRecentWorkflowResultMessages('conv-1');
+
+      expect(result).toEqual([row]);
     });
   });
 });

--- a/packages/core/src/db/messages.ts
+++ b/packages/core/src/db/messages.ts
@@ -1,7 +1,7 @@
 /**
  * Database operations for conversation messages (Web UI history)
  */
-import { pool, getDialect } from './connection';
+import { pool, getDialect, getDatabaseType } from './connection';
 import { createLogger } from '@archon/paths';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
@@ -63,4 +63,35 @@ export async function listMessages(
     [conversationId, limit]
   );
   return result.rows;
+}
+
+/**
+ * Get recent messages with workflowResult metadata for a conversation.
+ * Used to inject workflow context into the orchestrator prompt.
+ * Non-throwing — returns empty array on error.
+ */
+export async function getRecentWorkflowResultMessages(
+  conversationId: string,
+  limit = 3
+): Promise<readonly MessageRow[]> {
+  const dbType = getDatabaseType();
+  const metadataFilter =
+    dbType === 'postgresql'
+      ? "(metadata->>'category') = $2"
+      : "json_extract(metadata, '$.category') = $2";
+  try {
+    const result = await pool.query<MessageRow>(
+      `SELECT * FROM remote_agent_messages
+       WHERE conversation_id = $1
+       AND ${metadataFilter}
+       ORDER BY created_at DESC
+       LIMIT $3`,
+      [conversationId, 'workflow_result', limit]
+    );
+    return result.rows;
+  } catch (error) {
+    const err = error as Error;
+    getLog().warn({ err, conversationId }, 'db.workflow_result_messages_query_failed');
+    return [];
+  }
 }

--- a/packages/core/src/db/messages.ts
+++ b/packages/core/src/db/messages.ts
@@ -1,5 +1,5 @@
 /**
- * Database operations for conversation messages (Web UI history)
+ * Database operations for conversation messages (Web UI history and orchestrator prompt enrichment)
  */
 import { pool, getDialect, getDatabaseType } from './connection';
 import { createLogger } from '@archon/paths';
@@ -16,7 +16,7 @@ export interface MessageRow {
   conversation_id: string;
   role: 'user' | 'assistant';
   content: string;
-  metadata: string; // JSON string - parsed by frontend
+  metadata: string; // JSON string - parsed by frontend and server-side (orchestrator prompt enrichment)
   created_at: string;
 }
 
@@ -77,18 +77,18 @@ export async function getRecentWorkflowResultMessages(
   const dbType = getDatabaseType();
   const metadataFilter =
     dbType === 'postgresql'
-      ? "(metadata->>'category') = $2"
-      : "json_extract(metadata, '$.category') = $2";
+      ? "(metadata->>'workflowResult') IS NOT NULL"
+      : "json_extract(metadata, '$.workflowResult') IS NOT NULL";
   try {
-    const result = await pool.query<MessageRow>(
-      `SELECT * FROM remote_agent_messages
+    const result = await pool.query<Pick<MessageRow, 'id' | 'content' | 'metadata'>>(
+      `SELECT id, content, metadata FROM remote_agent_messages
        WHERE conversation_id = $1
        AND ${metadataFilter}
        ORDER BY created_at DESC
-       LIMIT $3`,
-      [conversationId, 'workflow_result', limit]
+       LIMIT $2`,
+      [conversationId, limit]
     );
-    return result.rows;
+    return result.rows as MessageRow[];
   } catch (error) {
     const err = error as Error;
     getLog().warn({ err, conversationId }, 'db.workflow_result_messages_query_failed');

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -142,6 +142,16 @@ mock.module('./orchestrator', () => ({
 mock.module('./prompt-builder', () => ({
   buildOrchestratorPrompt: mock(() => 'orchestrator system prompt'),
   buildProjectScopedPrompt: mock(() => 'project scoped system prompt'),
+  formatWorkflowContextSection: mock((results: unknown[]) =>
+    results.length > 0 ? '## Recent Workflow Results\n\n...' : ''
+  ),
+}));
+
+const mockGetRecentWorkflowResultMessages = mock(() => Promise.resolve([]));
+mock.module('../db/messages', () => ({
+  addMessage: mock(() => Promise.resolve()),
+  listMessages: mock(() => Promise.resolve([])),
+  getRecentWorkflowResultMessages: mockGetRecentWorkflowResultMessages,
 }));
 
 mock.module('@archon/isolation', () => ({
@@ -1405,5 +1415,78 @@ describe('discoverAllWorkflows — merge repo workflows over global', () => {
 
     // discoverWorkflowsWithConfig should have been called twice (global + repo)
     expect(mockDiscoverWorkflowsWithConfig).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ─── handleMessage — workflow context injection ───────────────────────────────
+
+describe('handleMessage — workflow context injection', () => {
+  beforeEach(() => {
+    mockGetRecentWorkflowResultMessages.mockClear();
+    mockGetOrCreateConversation.mockReset();
+    mockListCodebases.mockReset();
+    mockDiscoverWorkflowsWithConfig.mockReset();
+    mockLogger.warn.mockClear();
+
+    mockGetOrCreateConversation.mockImplementation(() => Promise.resolve(makeConversation()));
+    mockListCodebases.mockImplementation(() => Promise.resolve([]));
+    mockDiscoverWorkflowsWithConfig.mockImplementation(() =>
+      Promise.resolve({ workflows: [], errors: [] })
+    );
+    mockGetRecentWorkflowResultMessages.mockImplementation(() => Promise.resolve([]));
+  });
+
+  test('calls getRecentWorkflowResultMessages for the conversation', async () => {
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', 'What happened?');
+
+    expect(mockGetRecentWorkflowResultMessages).toHaveBeenCalledWith('conv-1', 3);
+  });
+
+  test('does not throw when getRecentWorkflowResultMessages returns empty array', async () => {
+    mockGetRecentWorkflowResultMessages.mockResolvedValueOnce([]);
+    const platform = makePlatform();
+
+    await expect(handleMessage(platform, 'conv-1', 'Hello')).resolves.toBeUndefined();
+  });
+
+  test('handles malformed metadata JSON without throwing', async () => {
+    const badRow = {
+      id: 'msg-1',
+      conversation_id: 'conv-1',
+      role: 'assistant' as const,
+      content: 'Summary.',
+      metadata: 'not-valid-json',
+      created_at: '2026-01-01T00:00:00Z',
+    };
+    mockGetRecentWorkflowResultMessages.mockResolvedValueOnce([badRow]);
+    const platform = makePlatform();
+
+    await expect(
+      handleMessage(platform, 'conv-1', 'What did the workflow do?')
+    ).resolves.toBeUndefined();
+  });
+
+  test('handles metadata with missing workflowResult key gracefully', async () => {
+    const rowNoWorkflowResult = {
+      id: 'msg-2',
+      conversation_id: 'conv-1',
+      role: 'assistant' as const,
+      content: 'Summary.',
+      metadata: '{"someOtherKey":"value"}',
+      created_at: '2026-01-01T00:00:00Z',
+    };
+    mockGetRecentWorkflowResultMessages.mockResolvedValueOnce([rowNoWorkflowResult]);
+    const platform = makePlatform();
+
+    await expect(handleMessage(platform, 'conv-1', 'Follow-up')).resolves.toBeUndefined();
+  });
+
+  test('continues without workflow context when outer fetch throws', async () => {
+    mockGetRecentWorkflowResultMessages.mockRejectedValueOnce(new Error('unexpected'));
+    const platform = makePlatform();
+
+    // Non-critical path — must not block message handling
+    await expect(handleMessage(platform, 'conv-1', 'Hello')).resolves.toBeUndefined();
   });
 });

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -760,13 +760,19 @@ export async function handleMessage(
           let workflowName = 'unknown';
           let runId = 'unknown';
           try {
-            const meta = JSON.parse(msg.metadata) as {
+            const parsed =
+              typeof msg.metadata === 'string' ? JSON.parse(msg.metadata) : msg.metadata;
+            const meta = parsed as {
               workflowResult?: { workflowName?: string; runId?: string };
             };
             workflowName = meta.workflowResult?.workflowName ?? 'unknown';
             runId = meta.workflowResult?.runId ?? 'unknown';
-          } catch {
+          } catch (metaErr) {
             // Malformed metadata — use defaults
+            getLog().warn(
+              { err: metaErr as Error, conversationId, messageId: msg.id },
+              'orchestrator.workflow_result_metadata_parse_failed'
+            );
           }
           return { workflowName, runId, summary: msg.content };
         });

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -43,7 +43,13 @@ import type { MergedConfig } from '../config/config-types';
 import { generateAndSetTitle } from '../services/title-generator';
 import { validateAndResolveIsolation, dispatchBackgroundWorkflow } from './orchestrator';
 import { IsolationBlockedError } from '@archon/isolation';
-import { buildOrchestratorPrompt, buildProjectScopedPrompt } from './prompt-builder';
+import {
+  buildOrchestratorPrompt,
+  buildProjectScopedPrompt,
+  formatWorkflowContextSection,
+} from './prompt-builder';
+import type { WorkflowResultContext } from './prompt-builder';
+import * as messageDb from '../db/messages';
 import * as workflowDb from '../db/workflows';
 import * as workflowEventDb from '../db/workflow-events';
 import type { ApprovalContext } from '@archon/workflows/schemas/workflow-run';
@@ -451,7 +457,8 @@ function buildFullPrompt(
   message: string,
   issueContext: string | undefined,
   threadContext: string | undefined,
-  attachedFiles?: AttachedFile[]
+  attachedFiles?: AttachedFile[],
+  workflowContext?: string
 ): string {
   const scopedCodebase = conversation.codebase_id
     ? codebases.find(c => c.id === conversation.codebase_id)
@@ -471,11 +478,14 @@ function buildFullPrompt(
           .join('\n')
       : '';
 
+  const workflowContextSuffix = workflowContext ? '\n\n---\n\n' + workflowContext : '';
+
   if (threadContext) {
     return (
       systemPrompt +
       '\n\n---\n\n## Thread Context (previous messages)\n\n' +
       threadContext +
+      workflowContextSuffix +
       '\n\n---\n\n## Current Request\n\n' +
       message +
       contextSuffix +
@@ -483,7 +493,14 @@ function buildFullPrompt(
     );
   }
 
-  return systemPrompt + '\n\n---\n\n## User Message\n\n' + message + contextSuffix + fileSuffix;
+  return (
+    systemPrompt +
+    workflowContextSuffix +
+    '\n\n---\n\n## User Message\n\n' +
+    message +
+    contextSuffix +
+    fileSuffix
+  );
 }
 
 // ─── Main Handler ───────────────────────────────────────────────────────────
@@ -731,6 +748,38 @@ export async function handleMessage(
       });
     }
 
+    // Build workflow context for follow-up awareness
+    let workflowContext: string | undefined;
+    try {
+      const recentResultMessages = await messageDb.getRecentWorkflowResultMessages(
+        conversation.id,
+        3
+      );
+      if (recentResultMessages.length > 0) {
+        const workflowResults: WorkflowResultContext[] = recentResultMessages.map(msg => {
+          let workflowName = 'unknown';
+          let runId = 'unknown';
+          try {
+            const meta = JSON.parse(msg.metadata) as {
+              workflowResult?: { workflowName?: string; runId?: string };
+            };
+            workflowName = meta.workflowResult?.workflowName ?? 'unknown';
+            runId = meta.workflowResult?.runId ?? 'unknown';
+          } catch {
+            // Malformed metadata — use defaults
+          }
+          return { workflowName, runId, summary: msg.content };
+        });
+        workflowContext = formatWorkflowContextSection(workflowResults);
+      }
+    } catch (error) {
+      getLog().warn(
+        { err: error as Error, conversationId },
+        'orchestrator.workflow_context_fetch_failed'
+      );
+      // Non-critical — continue without context
+    }
+
     const fullPrompt = buildFullPrompt(
       conversation,
       codebases,
@@ -738,7 +787,8 @@ export async function handleMessage(
       message,
       issueContext,
       threadContext,
-      attachedFiles
+      attachedFiles,
+      workflowContext
     );
     const cwd = getArchonWorkspacesPath();
 

--- a/packages/core/src/orchestrator/prompt-builder.test.ts
+++ b/packages/core/src/orchestrator/prompt-builder.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { buildRoutingRulesWithProject } from './prompt-builder';
+import { buildRoutingRulesWithProject, formatWorkflowContextSection } from './prompt-builder';
 
 describe('buildRoutingRulesWithProject', () => {
   test('routing rules include --prompt in invocation format', () => {
@@ -29,5 +29,44 @@ describe('buildRoutingRulesWithProject', () => {
     const rules = buildRoutingRulesWithProject();
 
     expect(rules).toContain('NO knowledge of the conversation history');
+  });
+});
+
+describe('formatWorkflowContextSection', () => {
+  test('returns empty string for empty results array', () => {
+    expect(formatWorkflowContextSection([])).toBe('');
+  });
+
+  test('includes section header for non-empty results', () => {
+    const result = formatWorkflowContextSection([
+      { workflowName: 'plan', runId: 'run-1', summary: 'Created implementation plan.' },
+    ]);
+    expect(result).toContain('## Recent Workflow Results');
+    expect(result).toContain('Use this context to answer follow-up questions');
+  });
+
+  test('formats each result with workflowName and runId', () => {
+    const result = formatWorkflowContextSection([
+      { workflowName: 'implement', runId: 'abc-123', summary: 'Added auth module.' },
+    ]);
+    expect(result).toContain('**implement** (run: abc-123)');
+    expect(result).toContain('Added auth module.');
+  });
+
+  test('formats multiple results sequentially', () => {
+    const results = [
+      { workflowName: 'plan', runId: 'run-1', summary: 'Plan done.' },
+      { workflowName: 'implement', runId: 'run-2', summary: 'Implement done.' },
+    ];
+    const result = formatWorkflowContextSection(results);
+    expect(result).toContain('**plan**');
+    expect(result).toContain('**implement**');
+  });
+
+  test('output does not end with trailing whitespace', () => {
+    const result = formatWorkflowContextSection([
+      { workflowName: 'assist', runId: 'r-1', summary: 'Done.' },
+    ]);
+    expect(result).toBe(result.trimEnd());
   });
 });

--- a/packages/core/src/orchestrator/prompt-builder.ts
+++ b/packages/core/src/orchestrator/prompt-builder.ts
@@ -37,6 +37,33 @@ export function formatWorkflowSection(workflows: readonly WorkflowDefinition[]):
   return section;
 }
 
+/** WorkflowResult type for prompt context injection */
+export interface WorkflowResultContext {
+  workflowName: string;
+  runId: string;
+  summary: string;
+}
+
+/**
+ * Format recent workflow results for injection into the orchestrator prompt.
+ * Returns empty string when there are no results (caller checks truthiness).
+ */
+export function formatWorkflowContextSection(results: readonly WorkflowResultContext[]): string {
+  if (results.length === 0) return '';
+
+  let section = '## Recent Workflow Results\n\n';
+  section +=
+    'The following workflows recently ran in this conversation. ' +
+    'Use this context to answer follow-up questions.\n\n';
+
+  for (const r of results) {
+    section += `**${r.workflowName}** (run: ${r.runId})\n`;
+    section += r.summary + '\n\n';
+  }
+
+  return section.trimEnd();
+}
+
 /**
  * Build the routing rules section of the prompt.
  */

--- a/packages/core/src/orchestrator/prompt-builder.ts
+++ b/packages/core/src/orchestrator/prompt-builder.ts
@@ -46,7 +46,8 @@ export interface WorkflowResultContext {
 
 /**
  * Format recent workflow results for injection into the orchestrator prompt.
- * Returns empty string when there are no results (caller checks truthiness).
+ * Returns empty string when there are no results; buildFullPrompt checks for
+ * a non-empty string before including the section in the prompt.
  */
 export function formatWorkflowContextSection(results: readonly WorkflowResultContext[]): string {
   if (results.length === 0) return '';


### PR DESCRIPTION
## Summary

- **Problem**: After a workflow completes, the AI has zero awareness of what the workflow produced. Users asking follow-up questions like "what did it change?" get unhelpful responses.
- **Why it matters**: Workflow summaries are already persisted in the DB as `workflow_result` messages, but `buildFullPrompt()` never loaded them — wasted data and broken UX.
- **What changed**: Three targeted additions: (1) `getRecentWorkflowResultMessages()` DB query in `messages.ts`, (2) `formatWorkflowContextSection()` formatter in `prompt-builder.ts`, (3) `handleMessage()` fetches and injects the context into `buildFullPrompt()` via a new optional `workflowContext` parameter.
- **What did not change**: No schema migrations, no new tables, no changes to how workflow results are stored. Platform-specific behavior is unchanged. `buildFullPrompt()` output is byte-for-byte identical when no workflow results exist.

## UX Journey

### Before

```
  User                   Archon                      AI
  ────                   ──────                      ──
  "Fix issue #42" ─────▶ routes to workflow
                         workflow runs, stores summary in DB
  sees result card ◀──── UI shows result

  "What did it change?" ▶ handleMessage() builds prompt
                          NO workflow context loaded
                          AI: "I don't have context about
                               recent workflow results"  ✗
```

### After

```
  User                   Archon                      AI
  ────                   ──────                      ──
  "Fix issue #42" ─────▶ routes to workflow
                         workflow runs, stores summary in DB
  sees result card ◀──── UI shows result

  "What did it change?" ▶ [handleMessage() queries recent workflow_result messages]
                          [formatWorkflowContextSection() builds context block]
                          [buildFullPrompt() injects "Recent Workflow Results" section]
                          AI: "The workflow made the following changes: ..."  ✓
```

## Architecture Diagram

### Before

```
  handleMessage()
      │
      ├─▶ buildFullPrompt(conversation, codebases, workflows, message,
      │                   issueContext, threadContext, attachedFiles)
      │       └─▶ builds prompt (NO workflow history)
      │
      └─▶ assistant.query(fullPrompt)
```

### After

```
  handleMessage()
      │
      ├─▶ [messageDb.getRecentWorkflowResultMessages(conversation.id, 3)]  [+]
      │       └─▶ remote_agent_messages WHERE category='workflow_result'    [+]
      │
      ├─▶ [formatWorkflowContextSection(workflowResults)]                   [+]
      │
      ├─▶ buildFullPrompt(conversation, codebases, workflows, message,
      │                   issueContext, threadContext, attachedFiles,
      │                   workflowContext)                                   [~]
      │       └─▶ injects "Recent Workflow Results" section when present    [~]
      │
      └─▶ assistant.query(fullPrompt)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `handleMessage()` | `messageDb.getRecentWorkflowResultMessages()` | **new** | Fetches up to 3 recent workflow results |
| `handleMessage()` | `formatWorkflowContextSection()` | **new** | Formats results into prompt section |
| `handleMessage()` | `buildFullPrompt()` | **modified** | Adds `workflowContext` optional param |
| `buildFullPrompt()` | prompt output | **modified** | Injects context block when present |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`
- Module: `core:orchestrator`

## Change Metadata

- Change type: `feature`
- Primary scope: `core`

## Linked Issue

- Closes #1055

## Validation Evidence (required)

```bash
bun run validate
```

- Type check: ✅ Pass — all 9 packages, no errors
- Lint: ✅ Pass — 0 errors, 0 warnings
- Format: ✅ Pass — all files formatted
- Tests: ✅ Pass — all packages, 0 failures (@archon/paths 107+6skip, @archon/git 135, @archon/isolation 211, @archon/workflows ~700+, @archon/core ~900+, @archon/adapters 343, @archon/server ~235, @archon/cli ~130, @archon/web 117)

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — `workflowContext` is optional; when undefined, `buildFullPrompt()` output is byte-for-byte identical to pre-PR behavior
- Config/env changes? No
- Database migration needed? No — queries existing `remote_agent_messages` rows with existing `metadata` JSON structure

## Human Verification (required)

- Verified scenarios: Type-check, lint, format, and full test suite all pass via `bun run validate`
- Edge cases checked: `formatWorkflowContextSection([])` returns `''` (no empty section injected); malformed metadata JSON defaults to `'unknown'` names but still surfaces the summary content; DB errors return `[]` non-throwing with warn log
- What was not verified: Live end-to-end workflow run followed by follow-up question (requires running app)

## Side Effects / Blast Radius (required)

- Affected subsystems: `@archon/core` orchestrator prompt building only
- Potential unintended effects: Minor token budget increase (~200-500 tokens) for conversations with recent workflow results; bounded by `limit=3` default
- Guardrails: Non-throwing query — DB failure silently returns empty context; `formatWorkflowContextSection([])` returns `''` so no noise when no workflows have run

## Rollback Plan (required)

- Fast rollback: Revert the commit (`git revert 3e3ddf25`)
- Feature flags: None — the injection is gated on `workflowContext` being non-empty, which requires actual workflow result rows in the DB
- Observable failure symptoms: Orchestrator responses would include an unexpected "Recent Workflow Results" section — easy to spot in logs

## Risks and Mitigations

- Risk: `buildFullPrompt()` output changes for existing conversations with workflow history
  - Mitigation: Only changes output when `workflowContext` is truthy; `getRecentWorkflowResultMessages()` returns `[]` for conversations with no workflow results (no change at all)
- Risk: JSON parse failure on malformed message metadata
  - Mitigation: Inner try/catch defaults to `'unknown'` for workflowName/runId while still including the summary content
- Risk: Token budget increase from injected context
  - Mitigation: Hard limit of 3 results at the DB query level; each entry is a single summary paragraph

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The orchestrator now retrieves and uses recent workflow execution results as context when generating responses, enabling more informed follow-up answers based on actual workflow history.
  * Improved system reliability with graceful error handling—context retrieval failures no longer interrupt agent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->