### PR TITLE
feat(cli): inject codebase env vars for bash nodes

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -595,11 +595,16 @@ export async function workflowRunCommand(
   // Inject codebase env vars into process.env so bash nodes inherit them.
   // AI nodes already receive them via the Claude SDK client, but bash nodes
   // are spawned directly and only see process.env.
+  // Snapshot previous values so we can restore after execution.
+  const previousEnvForInjectedKeys: Record<string, string | undefined> = {};
   if (codebase) {
     try {
       const codebaseEnvVars = await envVarDb.getCodebaseEnvVars(codebase.id);
       const injectedCount = Object.keys(codebaseEnvVars).length;
       if (injectedCount > 0) {
+        for (const key of Object.keys(codebaseEnvVars)) {
+          previousEnvForInjectedKeys[key] = process.env[key];
+        }
         Object.assign(process.env, codebaseEnvVars);
         getLog().info({ codebaseId: codebase.id, injectedCount }, 'cli.codebase_env_vars_injected');
       }
@@ -625,6 +630,14 @@ export async function workflowRunCommand(
       codebase?.id
     );
   } finally {
+    // Restore process.env to its pre-injection state
+    for (const [key, previousValue] of Object.entries(previousEnvForInjectedKeys)) {
+      if (previousValue === undefined) {
+        Reflect.deleteProperty(process.env, key);
+      } else {
+        process.env[key] = previousValue;
+      }
+    }
     unsubscribe?.();
   }
 

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -30,6 +30,7 @@ import {
 } from '@archon/core/operations/workflow-operations';
 import * as conversationDb from '@archon/core/db/conversations';
 import * as codebaseDb from '@archon/core/db/codebases';
+import * as envVarDb from '@archon/core/db/env-vars';
 import * as isolationDb from '@archon/core/db/isolation-environments';
 import * as messageDb from '@archon/core/db/messages';
 import * as workflowDb from '@archon/core/db/workflows';
@@ -590,6 +591,25 @@ export async function workflowRunCommand(
     : getWorkflowEventEmitter().subscribeForConversation(conversationId, event => {
         renderWorkflowEvent(event, verbose ?? false);
       });
+
+  // Inject codebase env vars into process.env so bash nodes inherit them.
+  // AI nodes already receive them via the Claude SDK client, but bash nodes
+  // are spawned directly and only see process.env.
+  if (codebase) {
+    try {
+      const codebaseEnvVars = await envVarDb.getCodebaseEnvVars(codebase.id);
+      const injectedCount = Object.keys(codebaseEnvVars).length;
+      if (injectedCount > 0) {
+        Object.assign(process.env, codebaseEnvVars);
+        getLog().info({ codebaseId: codebase.id, injectedCount }, 'cli.codebase_env_vars_injected');
+      }
+    } catch (error) {
+      getLog().warn(
+        { err: error as Error, codebaseId: codebase.id },
+        'cli.codebase_env_vars_load_failed'
+      );
+    }
+  }
 
   // Execute workflow with workingCwd (may be worktree path)
   let result: Awaited<ReturnType<typeof executeWorkflow>>;


### PR DESCRIPTION
## Summary

- **Problem:** CLI-executed workflow bash nodes don't receive codebase env vars stored in Archon's database. AI nodes get them via the Claude SDK client, but bash nodes are spawned as direct child processes and only see `process.env`.
- **Why it matters:** Bash nodes exist to avoid AI credits for simple shell commands. Without env vars, scripts like `source setup-env.sh && terraform validate` can't resolve credentials, making bash nodes useless against cloned codebases that rely on DB-stored env vars.
- **What changed:** After codebase resolution in the CLI workflow runner, load env vars from the DB and merge into `process.env` before `executeWorkflow()`. All child processes (bash and AI) inherit them.
- **What did not change:** Server-side execution, AI node env var injection (Claude SDK client), the env var DB schema, or any workflow executor logic.

## UX Journey

### Before

```
  User                   CLI                      Bash Node
  ----                   ---                      ---------
  archon workflow run --> resolves codebase
                         starts workflow
                         spawns bash node -------> source setup-env.sh
                                                   MY_API_TOKEN=(empty)
                                                   tool-that-needs-auth FAILS
  sees "FAIL" <--------- reports result
```

### After

```
  User                   CLI                      Bash Node
  ----                   ---                      ---------
  archon workflow run --> resolves codebase
                         [loads env vars from DB]
                         [merges into process.env]
                         starts workflow
                         spawns bash node -------> source setup-env.sh
                                                   MY_API_TOKEN=[SET]
                                                   tool-that-needs-auth runs
  sees result <--------- reports result
```

## Architecture Diagram

### Before

```
  CLI (workflow.ts)
    |
    +-- resolves codebase (codebaseDb)
    |
    +-- executeWorkflow(deps, adapter, cwd, ...)
          |
          +-- AI nodes --> Claude SDK --> subprocess (has env vars via SDK)
          |
          +-- Bash nodes --> child_process --> subprocess (NO env vars)
```

### After

```
  CLI (workflow.ts)
    |
    +-- resolves codebase (codebaseDb)
    |
    +-- [~] loads env vars (envVarDb) --> Object.assign(process.env, vars)
    |
    +-- executeWorkflow(deps, adapter, cwd, ...)
          |
          +-- AI nodes --> Claude SDK --> subprocess (has env vars via SDK + process.env)
          |
          +-- Bash nodes --> child_process --> subprocess (inherits process.env)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| CLI workflow.ts | codebaseDb | unchanged | Codebase resolution |
| CLI workflow.ts | envVarDb | **new** | Load codebase env vars |
| CLI workflow.ts | process.env | **new** | Merge env vars before execution |
| process.env | bash child_process | unchanged | Standard inheritance (now has vars) |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `cli`
- Module: `cli:workflow`

## Change Metadata

- Change type: `feature`
- Primary scope: `cli`

## Linked Issue

- None (discovered during workflow testing with cloned codebases)

## Validation Evidence (required)

```bash
bun run validate  # PASS - type-check, lint, format, tests all green (exit code 0)
```

- Test: Ran a workflow with a bash node (`source setup-env.sh && terraform validate`) against an Archon-cloned codebase (no `.env` file on disk). Before the fix: env vars empty. After: all 8 codebase env vars injected, tools authenticated successfully.
- `bun run test` — all packages pass, 0 failures.

## Security Impact (required)

- New permissions/capabilities? `No` — env vars are already stored in the DB and used by AI nodes. This extends the same access to bash nodes.
- New external network calls? `No`
- Secrets/tokens handling changed? `Yes` — codebase env vars (which may contain API tokens) are now merged into process.env for the CLI process lifetime. This is the same trust boundary as the existing Claude SDK injection.
- File system access scope changed? `No`
- Mitigation: Env vars are already trusted (user configured them). The CLI is a single-developer local tool. No new trust boundary crossed.

## Compatibility / Migration

- Backward compatible? `Yes` — if no codebase is resolved or no env vars are set, behavior is unchanged.
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

- Verified: Workflow with bash node against Archon-cloned codebase — env vars injected, downstream tools authenticated
- Verified: Same workflow against local repo with `.env` on disk — still works (env vars from both sources merge)
- Edge cases checked: No codebase found (skips injection), empty env vars (no-op), DB read failure (logs warning, continues)
- Not verified: Server-side execution path (unchanged, should not be affected)

## Side Effects / Blast Radius (required)

- Affected: CLI workflow execution only (`workflowRunCommand` in `packages/cli/src/commands/workflow.ts`)
- Potential: If a codebase env var name collides with an existing process.env var, the DB value wins (Object.assign overwrites). This is intentional — codebase-specific config should override ambient env.
- Guardrails: Logged at `info` level with count of injected vars. Failed loads logged at `warn` level.

## Rollback Plan (required)

- Fast rollback: Revert single commit (1 file, 20 lines)
- Feature flags: None — always active when a codebase is resolved
- Observable failure: If reverted, bash nodes in CLI workflows won't see codebase env vars (same as before this PR)

## Risks and Mitigations

- Risk: Env var name collision between codebase vars and existing process.env
  - Mitigation: Intentional behavior — codebase config takes precedence. Logged for observability.
- Risk: Env vars persist in process.env after workflow completes (if CLI reused for multiple runs)
  - Mitigation: CLI process exits after each `archon workflow run` invocation. No persistence across runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflows now automatically load and inject codebase environment variables during execution with graceful error handling.
* **Bug Fixes**
  * Environment variables injected for a workflow are restored to their prior state after the run to avoid leaking changes.
* **Chores**
  * Added success and warning logs for environment variable load/injection events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->