### PR TITLE
fix(docs): prevent theme reset to dark after user switches to auto/light

### DIFF
--- a/packages/docs-web/astro.config.mjs
+++ b/packages/docs-web/astro.config.mjs
@@ -15,7 +15,7 @@ export default defineConfig({
       head: [
         {
           tag: 'script',
-          content: `if(!localStorage.getItem('starlight-theme')){localStorage.setItem('starlight-theme','dark');document.documentElement.dataset.theme='dark';}`,
+          content: `if(!localStorage.getItem('archon-theme-init')){localStorage.setItem('archon-theme-init','1');localStorage.setItem('starlight-theme','dark');document.documentElement.dataset.theme='dark';}`,
         },
       ],
       social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/coleam00/Archon' }],


### PR DESCRIPTION
## Summary

- **Problem:** The docs site (archon.diy) resets to dark theme on every page refresh or internal navigation after the user switches to "auto" or "light" mode
- **Why it matters:** Users cannot use any theme other than dark — their preference is silently discarded on every navigation
- **What changed:** The `<head>` init script now uses a separate `archon-theme-init` localStorage sentinel instead of checking `starlight-theme` directly. Starlight deletes `starlight-theme` when the user selects "auto", which caused the old guard to re-fire and force dark on every load
- **What did not change (scope boundary):** No CSS, no Starlight config, no other docs-web files

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `docs`
- Module: `docs:theme`

## Change Metadata

- Change type: `bug`
- Primary scope: `docs`

## Validation Evidence (required)

```bash
bun run validate  # all pass (type-check, lint, format, tests)
```

- Local Playwright test verified the full flow:
  1. First visit → defaults to dark ✅
  2. Switch to auto → theme changes to light (system default in headless) ✅
  3. Refresh → theme stays light (no longer forced back to dark) ✅

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios: First visit defaults to dark; switching to auto persists across refresh and internal navigation
- Edge cases checked: localStorage cleared → re-initializes dark (correct first-visit behavior)
- What was not verified: Live deployment on archon.diy

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: docs-web theme initialization only
- Potential unintended effects: None — the sentinel key is independent of Starlight internals
- Guardrails/monitoring: Visual check on archon.diy after deploy

## Rollback Plan (required)

- Fast rollback: Revert this single commit
- Observable failure symptoms: Theme not defaulting to dark on first visit

## Risks and Mitigations

- Risk: Existing users who already have `starlight-theme` in localStorage but no `archon-theme-init` will see the init script run once more on next visit, setting dark again
  - Mitigation: This is the same as current behavior (one-time), and only affects the very first page load after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced theme initialization to ensure dark theme settings are properly applied and persisted across page reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->