### PR TITLE
fix(orchestrator): surface AI error results instead of silent drop (fixes #1076)

### DIFF
--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -37,10 +37,6 @@ const mockExecuteWorkflow = mock(() => Promise.resolve());
 const mockHandleCommand = mock(() =>
   Promise.resolve({ success: true, message: 'ok', workflow: undefined })
 );
-const mockSendQuery = mock(async function* () {
-  yield { type: 'assistant', content: 'test response' };
-  yield { type: 'result', sessionId: 'session-1' };
-});
 const mockGetCodebaseEnvVars = mock(() => Promise.resolve({}));
 const mockLoadConfig = mock(() =>
   Promise.resolve({
@@ -104,12 +100,14 @@ mock.module('@archon/workflows/executor', () => ({
   executeWorkflow: mockExecuteWorkflow,
 }));
 
+const mockSendQuery = mock(async function* () {});
+const mockGetAgentProvider = mock(() => ({
+  sendQuery: mockSendQuery,
+  getType: mock(() => 'claude'),
+  getCapabilities: mock(() => ({})),
+}));
 mock.module('@archon/providers', () => ({
-  getAgentProvider: mock(() => ({
-    sendQuery: mockSendQuery,
-    getType: mock(() => 'claude'),
-    getCapabilities: mock(() => ({})),
-  })),
+  getAgentProvider: mockGetAgentProvider,
   getProviderCapabilities: mock(() => ({ envInjection: true })),
 }));
 
@@ -1564,5 +1562,148 @@ describe('handleMessage — workflow context injection', () => {
 
     // Non-critical path — must not block message handling
     await expect(handleMessage(platform, 'conv-1', 'Hello')).resolves.toBeUndefined();
+  });
+});
+
+// ─── AI error result handling (stream + batch) ──────────────────────────────
+
+describe('AI error result handling', () => {
+  beforeEach(() => {
+    mockSendQuery.mockReset();
+    mockGetAgentProvider.mockClear();
+    mockGetAgentProvider.mockImplementation(() => ({
+      sendQuery: mockSendQuery,
+      getType: mock(() => 'claude'),
+      getCapabilities: mock(() => ({})),
+    }));
+    mockGetOrCreateConversation.mockReset();
+    mockGetCodebase.mockReset();
+    mockGetOrCreateConversation.mockImplementation(() => Promise.resolve(null));
+    mockGetCodebase.mockImplementation(() => Promise.resolve(null));
+    mockLogger.debug.mockClear();
+  });
+
+  describe('stream mode', () => {
+    function makeStreamPlatform(): IPlatformAdapter {
+      return {
+        sendMessage: mock(() => Promise.resolve()),
+        ensureThread: mock((id: string) => Promise.resolve(id)),
+        getStreamingMode: mock(() => 'stream' as const),
+        getPlatformType: mock(() => 'web'),
+        start: mock(() => Promise.resolve()),
+        stop: mock(() => {}),
+      };
+    }
+
+    test('sends error message when result has isError=true and no assistant messages', async () => {
+      const conversation = makeConversation({ codebase_id: null });
+      mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+      mockGetPausedWorkflowRun.mockReturnValueOnce(Promise.resolve(null));
+
+      mockSendQuery.mockImplementation(async function* () {
+        yield {
+          type: 'result',
+          isError: true,
+          errorSubtype: 'authentication_error',
+        };
+      });
+
+      const platform = makeStreamPlatform();
+      await handleMessage(platform, 'conv-1', 'hello');
+
+      expect(platform.sendMessage).toHaveBeenCalledWith(
+        'conv-1',
+        'AI error (authentication_error). Check your Claude credentials or use /reset.'
+      );
+    });
+
+    test('sends generic hint when errorSubtype is not authentication_error', async () => {
+      const conversation = makeConversation({ codebase_id: null });
+      mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+      mockGetPausedWorkflowRun.mockReturnValueOnce(Promise.resolve(null));
+
+      mockSendQuery.mockImplementation(async function* () {
+        yield {
+          type: 'result',
+          isError: true,
+          errorSubtype: 'rate_limit',
+        };
+      });
+
+      const platform = makeStreamPlatform();
+      await handleMessage(platform, 'conv-1', 'hello');
+
+      expect(platform.sendMessage).toHaveBeenCalledWith(
+        'conv-1',
+        'AI error (rate_limit). Check server logs for details.'
+      );
+    });
+
+    test('sends error message without subtype when errorSubtype is undefined', async () => {
+      const conversation = makeConversation({ codebase_id: null });
+      mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+      mockGetPausedWorkflowRun.mockReturnValueOnce(Promise.resolve(null));
+
+      mockSendQuery.mockImplementation(async function* () {
+        yield {
+          type: 'result',
+          isError: true,
+        };
+      });
+
+      const platform = makeStreamPlatform();
+      await handleMessage(platform, 'conv-1', 'hello');
+
+      expect(platform.sendMessage).toHaveBeenCalledWith(
+        'conv-1',
+        'AI error. Check server logs for details.'
+      );
+    });
+  });
+
+  describe('batch mode', () => {
+    test('sends error message when result has isError=true and no assistant messages', async () => {
+      const conversation = makeConversation({ codebase_id: null });
+      mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+      mockGetPausedWorkflowRun.mockReturnValueOnce(Promise.resolve(null));
+
+      mockSendQuery.mockImplementation(async function* () {
+        yield {
+          type: 'result',
+          isError: true,
+          errorSubtype: 'authentication_error',
+        };
+      });
+
+      const platform = makePlatform(); // batch mode by default
+      await handleMessage(platform, 'conv-1', 'hello');
+
+      expect(platform.sendMessage).toHaveBeenCalledWith(
+        'conv-1',
+        'AI error (authentication_error). Check your Claude credentials or use /reset.'
+      );
+    });
+
+    test('sends generic hint for non-authentication errors', async () => {
+      const conversation = makeConversation({ codebase_id: null });
+      mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+      mockGetPausedWorkflowRun.mockReturnValueOnce(Promise.resolve(null));
+
+      mockSendQuery.mockImplementation(async function* () {
+        yield {
+          type: 'result',
+          isError: true,
+          errorSubtype: 'internal_error',
+        };
+      });
+
+      const platform = makePlatform();
+      await handleMessage(platform, 'conv-1', 'hello');
+
+      expect(platform.sendMessage).toHaveBeenCalledWith(
+        'conv-1',
+        'AI error (internal_error). Check server logs for details.'
+      );
+    });
   });
 });

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -974,9 +974,10 @@ async function handleStreamMode(
 
   if (allMessages.length === 0) {
     if (errorResult) {
+      const providerLabel = aiClient.getType() === 'claude' ? 'Claude' : 'AI';
       const hint =
         errorResult.subtype === 'authentication_error'
-          ? 'Check your Claude credentials or use /reset.'
+          ? `Check your ${providerLabel} credentials or use /reset.`
           : 'Check server logs for details.';
       await platform.sendMessage(
         conversationId,
@@ -1124,9 +1125,10 @@ async function handleBatchMode(
 
   if (!finalMessage) {
     if (errorResult) {
+      const providerLabel = aiClient.getType() === 'claude' ? 'Claude' : 'AI';
       const hint =
         errorResult.subtype === 'authentication_error'
-          ? 'Check your Claude credentials or use /reset.'
+          ? `Check your ${providerLabel} credentials or use /reset.`
           : 'Check server logs for details.';
       await platform.sendMessage(
         conversationId,

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -916,6 +916,7 @@ async function handleStreamMode(
 ): Promise<void> {
   const allMessages: string[] = [];
   let newSessionId: string | undefined;
+  let errorResult: { subtype?: string } | undefined;
   let commandDetected = false;
 
   for await (const msg of aiClient.sendQuery(
@@ -959,13 +960,7 @@ async function handleStreamMode(
         newSessionId = msg.sessionId;
       }
       if (msg.isError) {
-        getLog().warn({ conversationId, errorSubtype: msg.errorSubtype }, 'ai_result_error');
-        const syntheticError = new Error(msg.errorSubtype ?? 'AI result error');
-        await platform.sendMessage(conversationId, classifyAndFormatError(syntheticError));
-        if (newSessionId) {
-          await tryPersistSessionId(session.id, newSessionId);
-        }
-        return;
+        errorResult = { subtype: msg.errorSubtype };
       }
       if (!commandDetected && platform.sendStructuredEvent) {
         await platform.sendStructuredEvent(conversationId, msg);
@@ -978,7 +973,17 @@ async function handleStreamMode(
   }
 
   if (allMessages.length === 0) {
-    getLog().debug({ conversationId }, 'no_ai_response');
+    if (errorResult) {
+      const hint =
+        errorResult.subtype === 'authentication_error'
+          ? 'Check your Claude credentials or use /reset.'
+          : 'Check server logs for details.';
+      await platform.sendMessage(
+        conversationId,
+        `AI error${errorResult.subtype ? ` (${errorResult.subtype})` : ''}. ${hint}`
+      );
+    }
+    getLog().debug({ conversationId, errorResult }, 'no_ai_response');
     return;
   }
 
@@ -1046,6 +1051,7 @@ async function handleBatchMode(
   let assistantChunksTruncated = false;
   let totalChunksTruncated = false;
   let newSessionId: string | undefined;
+  let errorResult: { subtype?: string } | undefined;
   let commandDetected = false;
 
   for await (const msg of aiClient.sendQuery(
@@ -1082,13 +1088,7 @@ async function handleBatchMode(
         newSessionId = msg.sessionId;
       }
       if (msg.isError) {
-        getLog().warn({ conversationId, errorSubtype: msg.errorSubtype }, 'ai_result_error');
-        const syntheticError = new Error(msg.errorSubtype ?? 'AI result error');
-        await platform.sendMessage(conversationId, classifyAndFormatError(syntheticError));
-        if (newSessionId) {
-          await tryPersistSessionId(session.id, newSessionId);
-        }
-        return;
+        errorResult = { subtype: msg.errorSubtype };
       }
     }
 
@@ -1123,7 +1123,17 @@ async function handleBatchMode(
   const finalMessage = filterToolIndicators(assistantMessages);
 
   if (!finalMessage) {
-    getLog().debug({ conversationId }, 'no_ai_response');
+    if (errorResult) {
+      const hint =
+        errorResult.subtype === 'authentication_error'
+          ? 'Check your Claude credentials or use /reset.'
+          : 'Check server logs for details.';
+      await platform.sendMessage(
+        conversationId,
+        `AI error${errorResult.subtype ? ` (${errorResult.subtype})` : ''}. ${hint}`
+      );
+    }
+    getLog().debug({ conversationId, errorResult }, 'no_ai_response');
     return;
   }
 


### PR DESCRIPTION
## Problem

When the Claude OAuth refresh token is expired (or any AI error occurs with no `session_id`), the chat UI shows **no response at all** — no error message, no indication of failure.

### Root Cause

Both `handleStreamMode` and `handleBatchMode` in `orchestrator-agent.ts` had a condition that required `msg.sessionId` to be truthy to process `result` messages:

```ts
} else if (msg.type === 'result' && msg.sessionId) {
```

When OAuth fails, the result message has `is_error: true` but `session_id: undefined`, so:
1. The error result is silently dropped
2. No assistant messages are produced → `allMessages.length === 0`
3. Early return with no user-facing feedback

### Fix

- **Split the result handler** to process `sessionId` and `isError` independently
- **Surface error messages** when AI errors produce no assistant content:
  - Auth errors: `AI error (authentication_error). Check your Claude credentials or use /reset.`
  - Other errors: `AI error (<subtype>). Check server logs for details.`
- **Enhanced logging**: include `errorResult` in debug log for observability

Applied to both stream and batch mode paths.

### Validation

- 5 new tests covering:
  - Stream mode: auth error, non-auth error, missing subtype
  - Batch mode: auth error, non-auth error
- All pre-existing tests pass
- `bun run type-check` clean across all packages
- `eslint` + `prettier` via lint-staged clean

Closes #1076

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider-based AI support (Claude and Codex) and new end-to-end smoke workflows to validate node types and scripts.
  * New env-var management endpoints and a /health endpoint.

* **Bug Fixes**
  * Improved user-facing AI error messages with authentication-specific hints and clearer guidance for other failures.

* **Tests**
  * Added extensive tests for AI error handling in both streaming and batch modes and provider behaviors.

* **Documentation**
  * Updated docs and guides to reflect “agent provider” terminology and new provider configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->