### PR TITLE
fix(web): show env keys checkbox in add project dialog

### DIFF
--- a/packages/web/src/routes/SettingsPage.tsx
+++ b/packages/web/src/routes/SettingsPage.tsx
@@ -251,15 +251,6 @@ function EnvVarsPanel({ codebaseId }: { codebaseId: string }): React.ReactElemen
   );
 }
 
-function isEnvLeakError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    'status' in error &&
-    (error as Error & { status: number }).status === 422 &&
-    error.message.startsWith('Cannot add codebase')
-  );
-}
-
 function ProjectsSection(): React.ReactElement {
   const queryClient = useQueryClient();
   const [addPath, setAddPath] = useState('');
@@ -449,18 +440,6 @@ function ProjectsSection(): React.ReactElement {
             {addMutation.error instanceof Error
               ? addMutation.error.message
               : 'Failed to add project'}
-            {isEnvLeakError(addMutation.error) && (
-              <label className="mt-2 flex items-center gap-2 text-text-secondary">
-                <input
-                  type="checkbox"
-                  checked={allowEnvKeys}
-                  onChange={e => {
-                    setAllowEnvKeys(e.target.checked);
-                  }}
-                />
-                Allow env keys (I understand the risk)
-              </label>
-            )}
           </div>
         )}
       </CardContent>

--- a/packages/web/src/routes/SettingsPage.tsx
+++ b/packages/web/src/routes/SettingsPage.tsx
@@ -394,30 +394,43 @@ function ProjectsSection(): React.ReactElement {
         )}
 
         {showAdd ? (
-          <form onSubmit={handleAddSubmit} className="mt-3 flex gap-2">
-            <Input
-              value={addPath}
-              onChange={e => {
-                setAddPath(e.target.value);
-              }}
-              placeholder="/path/to/repository"
-              className="flex-1"
-            />
-            <Button type="submit" size="sm" disabled={addMutation.isPending}>
-              Add
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                setShowAdd(false);
-                setAddPath('');
-              }}
-            >
-              Cancel
-            </Button>
-          </form>
+          <div className="mt-3 space-y-2">
+            <form onSubmit={handleAddSubmit} className="flex gap-2">
+              <Input
+                value={addPath}
+                onChange={e => {
+                  setAddPath(e.target.value);
+                }}
+                placeholder="/path/to/repository"
+                className="flex-1"
+              />
+              <Button type="submit" size="sm" disabled={addMutation.isPending}>
+                Add
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setShowAdd(false);
+                  setAddPath('');
+                  setAllowEnvKeys(false);
+                }}
+              >
+                Cancel
+              </Button>
+            </form>
+            <label className="flex items-center gap-2 text-sm text-text-secondary">
+              <input
+                type="checkbox"
+                checked={allowEnvKeys}
+                onChange={e => {
+                  setAllowEnvKeys(e.target.checked);
+                }}
+              />
+              Allow env keys (I understand the risk)
+            </label>
+          </div>
         ) : (
           <Button
             variant="outline"


### PR DESCRIPTION
## Problem
When adding a project that contains sensitive keys in `.env` (e.g. `ANTHROPIC_API_KEY`), the add fails with a 422 error. The "Allow env keys" checkbox was supposed to appear in the error message after the failed attempt, but it was not visible — leaving users with no way to opt in through the UI. The only workaround was setting `allow_target_repo_keys: true` in `~/.archon/config.yaml`.

## Summary
- Add the "Allow env keys (I understand the risk)" checkbox directly into the add project form so it is always visible
- Remove the broken error-state checkbox and unused `isEnvLeakError` helper
- Reset checkbox state when cancelling the add form

## Test plan
- [ ] Open Settings → Projects → + Add Project
- [ ] Verify "Allow env keys (I understand the risk)" checkbox is visible below the path input
- [ ] Add a repo with sensitive .env keys without checking → should fail with error
- [ ] Check the checkbox, click Add again → should succeed
- [ ] Cancel and reopen → checkbox should be unchecked