### PR TITLE
fix(core): surface auth errors instead of silently dropping them

### DIFF
--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -960,10 +960,11 @@ async function handleStreamMode(
       }
       if (msg.isError) {
         getLog().warn({ conversationId, errorSubtype: msg.errorSubtype }, 'ai_result_error');
-        await platform.sendMessage(
-          conversationId,
-          '⚠️ AI error. Check your credentials or use /reset.'
-        );
+        const syntheticError = new Error(msg.errorSubtype ?? 'AI result error');
+        await platform.sendMessage(conversationId, classifyAndFormatError(syntheticError));
+        if (newSessionId) {
+          await tryPersistSessionId(session.id, newSessionId);
+        }
         return;
       }
       if (!commandDetected && platform.sendStructuredEvent) {
@@ -1082,10 +1083,11 @@ async function handleBatchMode(
       }
       if (msg.isError) {
         getLog().warn({ conversationId, errorSubtype: msg.errorSubtype }, 'ai_result_error');
-        await platform.sendMessage(
-          conversationId,
-          '⚠️ AI error. Check your credentials or use /reset.'
-        );
+        const syntheticError = new Error(msg.errorSubtype ?? 'AI result error');
+        await platform.sendMessage(conversationId, classifyAndFormatError(syntheticError));
+        if (newSessionId) {
+          await tryPersistSessionId(session.id, newSessionId);
+        }
         return;
       }
     }

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -954,8 +954,17 @@ async function handleStreamMode(
       if (!commandDetected && platform.sendStructuredEvent) {
         await platform.sendStructuredEvent(conversationId, msg);
       }
-    } else if (msg.type === 'result' && msg.sessionId) {
-      newSessionId = msg.sessionId;
+    } else if (msg.type === 'result') {
+      if (msg.sessionId) {
+        newSessionId = msg.sessionId;
+      }
+      if (msg.isError) {
+        await platform.sendMessage(
+          conversationId,
+          '⚠️ AI error. Check your credentials or use /reset.'
+        );
+        return;
+      }
       if (!commandDetected && platform.sendStructuredEvent) {
         await platform.sendStructuredEvent(conversationId, msg);
       }
@@ -1066,8 +1075,17 @@ async function handleBatchMode(
         allChunks.push({ type: 'tool', content: toolMessage });
         getLog().debug({ toolName: msg.toolName }, 'tool_call');
       }
-    } else if (msg.type === 'result' && msg.sessionId) {
-      newSessionId = msg.sessionId;
+    } else if (msg.type === 'result') {
+      if (msg.sessionId) {
+        newSessionId = msg.sessionId;
+      }
+      if (msg.isError) {
+        await platform.sendMessage(
+          conversationId,
+          '⚠️ AI error. Check your credentials or use /reset.'
+        );
+        return;
+      }
     }
 
     if (!commandDetected && allChunks.length > MAX_BATCH_TOTAL_CHUNKS) {

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -959,6 +959,7 @@ async function handleStreamMode(
         newSessionId = msg.sessionId;
       }
       if (msg.isError) {
+        getLog().warn({ conversationId, errorSubtype: msg.errorSubtype }, 'ai_result_error');
         await platform.sendMessage(
           conversationId,
           '⚠️ AI error. Check your credentials or use /reset.'
@@ -1080,6 +1081,7 @@ async function handleBatchMode(
         newSessionId = msg.sessionId;
       }
       if (msg.isError) {
+        getLog().warn({ conversationId, errorSubtype: msg.errorSubtype }, 'ai_result_error');
         await platform.sendMessage(
           conversationId,
           '⚠️ AI error. Check your credentials or use /reset.'

--- a/packages/core/src/utils/error-formatter.test.ts
+++ b/packages/core/src/utils/error-formatter.test.ts
@@ -19,6 +19,40 @@ describe('classifyAndFormatError', () => {
     });
   });
 
+  describe('OAuth refresh-token errors', () => {
+    test('detects "refresh token" in message', () => {
+      const result = classifyAndFormatError(new Error('Your refresh token was already used'));
+      expect(result).toBe(
+        '⚠️ AI authentication error. Please re-login (e.g. `claude /login`) and try again.'
+      );
+    });
+
+    test('detects "could not be refreshed" in message', () => {
+      const result = classifyAndFormatError(new Error('Your access token could not be refreshed'));
+      expect(result).toBe(
+        '⚠️ AI authentication error. Please re-login (e.g. `claude /login`) and try again.'
+      );
+    });
+
+    test('detects "log out and sign in" in message', () => {
+      const result = classifyAndFormatError(new Error('Please log out and sign in again'));
+      expect(result).toBe(
+        '⚠️ AI authentication error. Please re-login (e.g. `claude /login`) and try again.'
+      );
+    });
+
+    test('handles full Claude OAuth error message', () => {
+      const result = classifyAndFormatError(
+        new Error(
+          'Claude Code auth error: Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.'
+        )
+      );
+      expect(result).toBe(
+        '⚠️ AI authentication error. Please re-login (e.g. `claude /login`) and try again.'
+      );
+    });
+  });
+
   describe('authentication errors', () => {
     test('detects "API key" in message', () => {
       const result = classifyAndFormatError(new Error('Invalid API key provided'));
@@ -27,6 +61,13 @@ describe('classifyAndFormatError', () => {
 
     test('detects "authentication" in message', () => {
       const result = classifyAndFormatError(new Error('authentication failed'));
+      expect(result).toBe('⚠️ AI service authentication error. Please check configuration.');
+    });
+
+    test('detects "auth error" prefix in message', () => {
+      const result = classifyAndFormatError(
+        new Error('Claude Code auth error: something went wrong')
+      );
       expect(result).toBe('⚠️ AI service authentication error. Please check configuration.');
     });
 
@@ -230,6 +271,16 @@ describe('classifyAndFormatError', () => {
       // "rate limit" message is also short, but rate-limit branch fires first
       const result = classifyAndFormatError(new Error('rate limit'));
       expect(result).toBe('⚠️ AI rate limit reached. Please wait a moment and try again.');
+    });
+
+    test('OAuth check takes precedence over general auth check', () => {
+      // Contains both "refresh token" and "auth error" — OAuth branch fires first
+      const result = classifyAndFormatError(
+        new Error('Claude Code auth error: refresh token expired')
+      );
+      expect(result).toBe(
+        '⚠️ AI authentication error. Please re-login (e.g. `claude /login`) and try again.'
+      );
     });
 
     test('auth check takes precedence over short-message fallback', () => {

--- a/packages/core/src/utils/error-formatter.test.ts
+++ b/packages/core/src/utils/error-formatter.test.ts
@@ -19,66 +19,97 @@ describe('classifyAndFormatError', () => {
     });
   });
 
-  describe('OAuth refresh-token errors', () => {
+  describe('Claude OAuth refresh-token errors', () => {
     test('detects "refresh token" in message', () => {
       const result = classifyAndFormatError(new Error('Your refresh token was already used'));
-      expect(result).toBe(
-        '⚠️ AI authentication error. Please re-login (e.g. `claude /login`) and try again.'
-      );
+      expect(result).toContain('Claude authentication expired');
+      expect(result).toContain('/login');
     });
 
     test('detects "could not be refreshed" in message', () => {
       const result = classifyAndFormatError(new Error('Your access token could not be refreshed'));
-      expect(result).toBe(
-        '⚠️ AI authentication error. Please re-login (e.g. `claude /login`) and try again.'
-      );
+      expect(result).toContain('Claude authentication expired');
     });
 
     test('detects "log out and sign in" in message', () => {
       const result = classifyAndFormatError(new Error('Please log out and sign in again'));
-      expect(result).toBe(
-        '⚠️ AI authentication error. Please re-login (e.g. `claude /login`) and try again.'
-      );
+      expect(result).toContain('Claude authentication expired');
     });
 
-    test('handles full Claude OAuth error message', () => {
+    test('detects "OAuth token has expired" in message', () => {
+      const result = classifyAndFormatError(
+        new Error('API Error: 401 OAuth token has expired. Please run /login')
+      );
+      expect(result).toContain('Claude authentication expired');
+      expect(result).toContain('claude logout && claude login');
+    });
+
+    test('detects "sign-in has expired" in message', () => {
+      const result = classifyAndFormatError(
+        new Error('Unable to start session: sign-in has expired')
+      );
+      expect(result).toContain('Claude authentication expired');
+    });
+
+    test('handles full Claude OAuth error with refresh token race condition', () => {
       const result = classifyAndFormatError(
         new Error(
           'Claude Code auth error: Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.'
         )
       );
-      expect(result).toBe(
-        '⚠️ AI authentication error. Please re-login (e.g. `claude /login`) and try again.'
-      );
+      expect(result).toContain('Claude authentication expired');
     });
   });
 
-  describe('authentication errors', () => {
+  describe('Claude general auth errors', () => {
+    test('detects "Claude Code auth error:" prefix for non-OAuth errors', () => {
+      const result = classifyAndFormatError(new Error('Claude Code auth error: 403 forbidden'));
+      expect(result).toContain('Claude authentication error');
+      expect(result).toContain('/login');
+    });
+  });
+
+  describe('Codex auth errors', () => {
+    test('detects Codex 401 retry exhaustion', () => {
+      const result = classifyAndFormatError(
+        new Error('Codex query failed: exceeded retry limit, last status: 401 Unauthorized')
+      );
+      expect(result).toContain('Codex authentication error');
+      expect(result).toContain('codex login');
+    });
+
+    test('detects Codex query failed with Unauthorized', () => {
+      const result = classifyAndFormatError(new Error('Codex query failed: Unauthorized'));
+      expect(result).toContain('Codex authentication error');
+      expect(result).toContain('codex login');
+    });
+  });
+
+  describe('general authentication errors', () => {
     test('detects "API key" in message', () => {
       const result = classifyAndFormatError(new Error('Invalid API key provided'));
-      expect(result).toBe('⚠️ AI service authentication error. Please check configuration.');
+      expect(result).toContain('authentication error');
     });
 
-    test('detects "authentication" in message', () => {
-      const result = classifyAndFormatError(new Error('authentication failed'));
-      expect(result).toBe('⚠️ AI service authentication error. Please check configuration.');
+    test('detects "authentication_error" in message', () => {
+      const result = classifyAndFormatError(new Error('authentication_error: invalid'));
+      expect(result).toContain('authentication error');
     });
 
-    test('detects "auth error" prefix in message', () => {
-      const result = classifyAndFormatError(
-        new Error('Claude Code auth error: something went wrong')
-      );
-      expect(result).toBe('⚠️ AI service authentication error. Please check configuration.');
+    test('detects "authentication error" in message', () => {
+      const result = classifyAndFormatError(new Error('authentication error'));
+      expect(result).toContain('authentication error');
     });
 
     test('detects "401" in message', () => {
       const result = classifyAndFormatError(new Error('HTTP 401 Unauthorized'));
-      expect(result).toBe('⚠️ AI service authentication error. Please check configuration.');
+      expect(result).toContain('authentication error');
     });
 
-    test('detects 401 as standalone in message', () => {
-      const result = classifyAndFormatError(new Error('Status: 401'));
-      expect(result).toBe('⚠️ AI service authentication error. Please check configuration.');
+    test('does not false-positive on generic messages containing "auth"', () => {
+      // "auth" alone should NOT match — only specific patterns
+      const result = classifyAndFormatError(new Error('author name missing'));
+      expect(result).not.toContain('authentication');
     });
   });
 
@@ -273,19 +304,24 @@ describe('classifyAndFormatError', () => {
       expect(result).toBe('⚠️ AI rate limit reached. Please wait a moment and try again.');
     });
 
-    test('OAuth check takes precedence over general auth check', () => {
-      // Contains both "refresh token" and "auth error" — OAuth branch fires first
+    test('Claude OAuth check takes precedence over general auth check', () => {
+      // Contains both "refresh token" and "Claude Code auth error:" — OAuth branch fires first
       const result = classifyAndFormatError(
         new Error('Claude Code auth error: refresh token expired')
       );
-      expect(result).toBe(
-        '⚠️ AI authentication error. Please re-login (e.g. `claude /login`) and try again.'
-      );
+      expect(result).toContain('Claude authentication expired');
+    });
+
+    test('Codex auth takes precedence over generic Codex error handler', () => {
+      // Contains "Codex query failed:" AND "401" — Codex auth branch fires first
+      const result = classifyAndFormatError(new Error('Codex query failed: 401 Unauthorized'));
+      expect(result).toContain('Codex authentication error');
+      expect(result).toContain('codex login');
     });
 
     test('auth check takes precedence over short-message fallback', () => {
       const result = classifyAndFormatError(new Error('API key'));
-      expect(result).toBe('⚠️ AI service authentication error. Please check configuration.');
+      expect(result).toContain('authentication error');
     });
 
     test('Codex check is applied before generic fallback', () => {

--- a/packages/core/src/utils/error-formatter.ts
+++ b/packages/core/src/utils/error-formatter.ts
@@ -19,10 +19,20 @@ export function classifyAndFormatError(error: Error): string {
     return '⚠️ AI rate limit reached. Please wait a moment and try again.';
   }
 
+  // AI/SDK errors - OAuth credential refresh (e.g. "claude /login" token expired)
+  if (
+    message.includes('refresh token') ||
+    message.includes('could not be refreshed') ||
+    message.includes('log out and sign in')
+  ) {
+    return '⚠️ AI authentication error. Please re-login (e.g. `claude /login`) and try again.';
+  }
+
   // AI/SDK errors - authentication
   if (
     message.includes('API key') ||
     message.includes('authentication') ||
+    message.includes('auth error') ||
     message.includes('401')
   ) {
     return '⚠️ AI service authentication error. Please check configuration.';

--- a/packages/core/src/utils/error-formatter.ts
+++ b/packages/core/src/utils/error-formatter.ts
@@ -19,23 +19,42 @@ export function classifyAndFormatError(error: Error): string {
     return '⚠️ AI rate limit reached. Please wait a moment and try again.';
   }
 
-  // AI/SDK errors - OAuth credential refresh (e.g. "claude /login" token expired)
+  // Claude-specific auth errors — OAuth token refresh failures
+  // These come from Claude Code subprocess stderr or SDK result subtypes.
+  // Recovery: `/login` in-session or `claude logout && claude login` in terminal.
   if (
     message.includes('refresh token') ||
     message.includes('could not be refreshed') ||
-    message.includes('log out and sign in')
+    message.includes('log out and sign in') ||
+    message.includes('OAuth token has expired') ||
+    message.includes('sign-in has expired')
   ) {
-    return '⚠️ AI authentication error. Please re-login (e.g. `claude /login`) and try again.';
+    return '⚠️ Claude authentication expired. Run `/login` inside Claude Code or `claude logout && claude login` in your terminal.';
   }
 
-  // AI/SDK errors - authentication
+  // Claude-specific auth errors — general (subprocess crash with auth classification)
+  if (message.startsWith('Claude Code auth error:')) {
+    return '⚠️ Claude authentication error. Run `/login` inside Claude Code or check your API key configuration.';
+  }
+
+  // Codex-specific auth errors — 401 retry exhaustion
+  // Codex surfaces auth failures as "exceeded retry limit, last status: 401 Unauthorized"
+  // Recovery: `codex login` in terminal.
+  if (
+    message.includes('Codex query failed:') &&
+    (message.includes('401') || message.includes('Unauthorized'))
+  ) {
+    return '⚠️ Codex authentication error. Run `codex login` in your terminal to re-authenticate.';
+  }
+
+  // General AI/SDK authentication errors
   if (
     message.includes('API key') ||
-    message.includes('authentication') ||
-    message.includes('auth error') ||
+    message.includes('authentication_error') ||
+    message.includes('authentication error') ||
     message.includes('401')
   ) {
-    return '⚠️ AI service authentication error. Please check configuration.';
+    return '⚠️ AI service authentication error. Please check your API key or credentials.';
   }
 
   // Network errors - timeout


### PR DESCRIPTION
## Summary

- **Problem**: When a Claude OAuth refresh token is expired, the SDK yields a `result` chunk with `is_error: true` and no `session_id`. Both `handleStreamMode` and `handleBatchMode` guarded the result branch with `&& msg.sessionId`, silently dropping the error chunk entirely — the user sees no response.
- **Why it matters**: Every auth failure leaves the chat UI hanging indefinitely with zero user feedback and no actionable guidance.
- **What changed**: Removed the `&& msg.sessionId` guard from both result branches; added `isError` early-exit that sends a visible error message. Added 4 missing OAuth patterns to `AUTH_PATTERNS` in both `claude.ts` and `codex.ts` to prevent unnecessary 3× retries. Extended `error-formatter.ts` to produce actionable re-login guidance for OAuth refresh-token errors.
- **What did not change**: No UI changes, no database schema changes, no architectural changes. Codex `turn.failed` session-ID loss issue is out of scope.

## UX Journey

### Before

```
User                   Archon (orchestrator)         Claude SDK
────                   ─────────────────────         ──────────
sends message ──────▶  resolves session
                       streams to AI ───────────────▶ attempts auth
                       result chunk received ◀─────── { type:'result', is_error:true, session_id:undefined }
                       msg.sessionId = undefined → condition false
                       result chunk DROPPED (silent)
                       allMessages empty → early return (no sendMessage)
user sees nothing ✗    (hangs forever)
```

### After

```
User                   Archon (orchestrator)         Claude SDK
────                   ─────────────────────         ──────────
sends message ──────▶  resolves session
                       streams to AI ───────────────▶ attempts auth
                       result chunk received ◀─────── { type:'result', is_error:true, session_id:undefined }
                       [msg.type === 'result'] → enters branch
                       [msg.sessionId undefined] → skip session capture
                       [msg.isError === true] → sendMessage(error msg) + return
user sees error ✓   ◀─ "⚠️ AI error. Check your credentials or use /reset."
```

## Architecture Diagram

### Before

```
orchestrator-agent.ts
  handleStreamMode()
    for await chunk:
      type='result' && sessionId  ← both conditions required
        newSessionId = msg.sessionId
        sendStructuredEvent()
      [MISSING: isError path]

claude.ts / codex.ts
  AUTH_PATTERNS = ['credit balance','unauthorized','authentication',
                   'invalid token','401','403']
  [MISSING: 'refresh token','access token','could not be refreshed','log out and sign in']

error-formatter.ts
  checks 'API key' | 'authentication' | '401'
  [MISSING: 'auth error' prefix, 'refresh token', 'could not be refreshed']
```

### After

```
orchestrator-agent.ts
  handleStreamMode() / handleBatchMode()
    for await chunk:
  [~] type='result'  ← sessionId guard removed
        if sessionId → newSessionId = msg.sessionId
  [+]   if isError → sendMessage(error) + return
        sendStructuredEvent()

[~] claude.ts / codex.ts
  AUTH_PATTERNS += ['refresh token','access token',
                    'could not be refreshed','log out and sign in']

[~] error-formatter.ts
  [+] checks 'refresh token'|'could not be refreshed'|'log out and sign in' → re-login msg
      checks 'API key'|'authentication'|'auth error'|'401' → auth config msg
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| orchestrator-agent.ts | platform.sendMessage | **modified** | Now called on isError result (was skipped) |
| orchestrator-agent.ts | newSessionId capture | **modified** | Decoupled from result entry condition |
| claude.ts AUTH_PATTERNS | error classifier | **modified** | 4 new OAuth patterns added |
| codex.ts AUTH_PATTERNS | error classifier | **modified** | 4 new OAuth patterns added |
| error-formatter.ts | OAuth error message | **new** | Re-login guidance for refresh-token errors |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`
- Module: `core:orchestrator`, `core:clients`, `core:utils`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #1076

## Validation Evidence (required)

```bash
bun run type-check  # ✅ Pass — all 9 packages, 0 errors
bun run lint        # ✅ Pass — 0 errors, 0 warnings
bun run format:check # ✅ Pass — all files formatted
bun run test        # ✅ Pass — 400+ core tests, 0 failures
# Full suite:
bun run validate    # ✅ ALL_PASS
```

- Evidence provided: All checks ran and passed (see validation.md artifact)
- New tests: 51 lines added to `error-formatter.test.ts` covering OAuth refresh-token and auth-error-prefix branches

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No — error messages mention token refresh but no tokens are logged or transmitted
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — purely additive error handling; no breaking interface changes
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: Type check, lint, format, and full test suite all pass (automated via `bun run validate`)
- Edge cases checked: isError with sessionId present (session captured before early return); partial stream before auth error (existing chunks sent, error appended)
- What was not verified: Live OAuth expiry test (requires an actual expired token); this is documented as manual verification step in the investigation artifact

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Chat orchestration path only — affects stream and batch mode result processing
- Potential unintended effects: None expected — the `isError` guard only fires when the SDK explicitly signals an error; normal success results are unaffected
- Guardrails/monitoring for early detection: Existing orchestrator tests (89 passing); the error message is user-visible so regressions surface immediately

## Rollback Plan (required)

- Fast rollback command/path: `git revert 06b37a4e` on `dev`
- Feature flags or config toggles: None
- Observable failure symptoms: Chat UI hangs silently after a message with no AI response — same as the pre-fix behavior described in #1076

## Risks and Mitigations

- Risk: `isError` result with a valid `sessionId` (e.g. max-turns reached mid-session) causes early return that discards accumulated assistant content
  - Mitigation: `newSessionId` is captured before the `isError` check, so the session is preserved. The early return is correct — partial output without a completion signal is confusing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for failed operations with enhanced session persistence and message clarity.
  * Authentication errors now display specific, actionable guidance tailored to Claude OAuth token refresh, Claude Code authentication, and Codex login issues.
  * Refined error classification and formatting for more precise error diagnosis and user remediation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->