### PR TITLE
fix(workflows): stop warning about model/provider on loop nodes

### DIFF
--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -1277,6 +1277,82 @@ nodes:
       expect(node.provider).toBeUndefined();
       expect(node.model).toBeUndefined();
     });
+
+    it('should NOT warn about model/provider on loop nodes (they are supported)', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+
+      await writeFile(
+        join(workflowDir, 'loop-model.yaml'),
+        `
+name: loop-model
+description: Loop with model override
+nodes:
+  - id: iterate
+    loop:
+      prompt: "Do something"
+      until: "COMPLETE"
+      max_iterations: 3
+    provider: claude
+    model: claude-opus-4-6
+`
+      );
+
+      (mockLogger.warn as Mock<() => undefined>).mockClear();
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.errors).toHaveLength(0);
+      expect(result.workflows).toHaveLength(1);
+
+      const node = result.workflows[0].workflow.nodes[0];
+      expect(isLoopNode(node)).toBe(true);
+
+      // model and provider should NOT trigger a warning
+      const warnCalls = (mockLogger.warn as Mock<() => undefined>).mock.calls;
+      const aiFieldWarnings = warnCalls.filter(
+        call => typeof call[1] === 'string' && call[1].includes('ai_fields_ignored')
+      );
+      expect(aiFieldWarnings).toHaveLength(0);
+    });
+
+    it('should warn about unsupported AI fields on loop nodes (not model/provider)', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+
+      await writeFile(
+        join(workflowDir, 'loop-unsupported.yaml'),
+        `
+name: loop-unsupported
+description: Loop with unsupported AI fields
+nodes:
+  - id: iterate
+    loop:
+      prompt: "Do something"
+      until: "COMPLETE"
+      max_iterations: 3
+    model: claude-opus-4-6
+    output_format:
+      type: object
+      properties:
+        status:
+          type: string
+`
+      );
+
+      (mockLogger.warn as Mock<() => undefined>).mockClear();
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.errors).toHaveLength(0);
+
+      // Should warn about output_format but NOT about model
+      const warnCalls = (mockLogger.warn as Mock<() => undefined>).mock.calls;
+      const aiFieldWarnings = warnCalls.filter(
+        call => typeof call[1] === 'string' && call[1].includes('ai_fields_ignored')
+      );
+      expect(aiFieldWarnings).toHaveLength(1);
+      const warnedFields = (aiFieldWarnings[0][0] as { fields: string[] }).fields;
+      expect(warnedFields).toContain('output_format');
+      expect(warnedFields).not.toContain('model');
+      expect(warnedFields).not.toContain('provider');
+    });
   });
 
   describe('DAG output ref validation', () => {

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -5,7 +5,12 @@ import type { WorkflowDefinition, WorkflowLoadError, DagNode, WorkflowNodeHooks 
 import { isLoopNode, isApprovalNode, isCancelNode, isScriptNode } from './schemas';
 import { createLogger } from '@archon/paths';
 import { isModelCompatible } from './model-validation';
-import { dagNodeSchema, BASH_NODE_AI_FIELDS, SCRIPT_NODE_AI_FIELDS } from './schemas/dag-node';
+import {
+  dagNodeSchema,
+  BASH_NODE_AI_FIELDS,
+  SCRIPT_NODE_AI_FIELDS,
+  LOOP_NODE_AI_FIELDS,
+} from './schemas/dag-node';
 import { modelReasoningEffortSchema, webSearchModeSchema } from './schemas/workflow';
 import { workflowNodeHooksSchema } from './schemas/hooks';
 import { z } from '@hono/zod-openapi';
@@ -75,7 +80,11 @@ function parseDagNode(raw: unknown, index: number, errors: string[]): DagNode | 
     } else {
       nodeType = 'bash';
     }
-    const aiFields = isScriptNode(node) ? SCRIPT_NODE_AI_FIELDS : BASH_NODE_AI_FIELDS;
+    const aiFields = isLoopNode(node)
+      ? LOOP_NODE_AI_FIELDS
+      : isScriptNode(node)
+        ? SCRIPT_NODE_AI_FIELDS
+        : BASH_NODE_AI_FIELDS;
     const presentAiFields = aiFields.filter(f => (raw as Record<string, unknown>)[f] !== undefined);
     if (presentAiFields.length > 0) {
       getLog().warn({ id: node.id, fields: presentAiFields }, `${nodeType}_node_ai_fields_ignored`);

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -61,30 +61,25 @@ function parseDagNode(raw: unknown, index: number, errors: string[]): DagNode | 
   const node = result.data;
 
   // Warn about AI-specific fields on non-AI nodes (runtime behavior, not schema errors)
-  const isNonAiNode =
-    ('bash' in node && typeof node.bash === 'string') ||
-    isScriptNode(node) ||
-    isLoopNode(node) ||
-    isApprovalNode(node) ||
-    isCancelNode(node);
-  if (isNonAiNode) {
-    let nodeType: string;
-    if (isCancelNode(node)) {
-      nodeType = 'cancel';
-    } else if (isApprovalNode(node)) {
-      nodeType = 'approval';
-    } else if (isLoopNode(node)) {
-      nodeType = 'loop';
-    } else if (isScriptNode(node)) {
-      nodeType = 'script';
-    } else {
-      nodeType = 'bash';
-    }
-    const aiFields = isLoopNode(node)
-      ? LOOP_NODE_AI_FIELDS
-      : isScriptNode(node)
-        ? SCRIPT_NODE_AI_FIELDS
-        : BASH_NODE_AI_FIELDS;
+  let nodeType: string | undefined;
+  let aiFields: readonly string[] | undefined;
+  if (isCancelNode(node)) {
+    nodeType = 'cancel';
+    aiFields = BASH_NODE_AI_FIELDS;
+  } else if (isApprovalNode(node)) {
+    nodeType = 'approval';
+    aiFields = BASH_NODE_AI_FIELDS;
+  } else if (isLoopNode(node)) {
+    nodeType = 'loop';
+    aiFields = LOOP_NODE_AI_FIELDS;
+  } else if (isScriptNode(node)) {
+    nodeType = 'script';
+    aiFields = SCRIPT_NODE_AI_FIELDS;
+  } else if ('bash' in node && typeof node.bash === 'string') {
+    nodeType = 'bash';
+    aiFields = BASH_NODE_AI_FIELDS;
+  }
+  if (nodeType !== undefined && aiFields !== undefined) {
     const presentAiFields = aiFields.filter(f => (raw as Record<string, unknown>)[f] !== undefined);
     if (presentAiFields.length > 0) {
       getLog().warn({ id: node.id, fields: presentAiFields }, `${nodeType}_node_ai_fields_ignored`);

--- a/packages/workflows/src/schemas.test.ts
+++ b/packages/workflows/src/schemas.test.ts
@@ -6,6 +6,7 @@ import {
   isTriggerRule,
   TRIGGER_RULES,
   SCRIPT_NODE_AI_FIELDS,
+  LOOP_NODE_AI_FIELDS,
   approvalOnRejectSchema,
   dagNodeSchema,
 } from './schemas';
@@ -658,6 +659,39 @@ describe('SCRIPT_NODE_AI_FIELDS', () => {
     ];
     for (const field of expectedFields) {
       expect(SCRIPT_NODE_AI_FIELDS).toContain(field);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LOOP_NODE_AI_FIELDS constant
+// ---------------------------------------------------------------------------
+
+describe('LOOP_NODE_AI_FIELDS', () => {
+  test('excludes model and provider (loop nodes support them)', () => {
+    expect(LOOP_NODE_AI_FIELDS).not.toContain('model');
+    expect(LOOP_NODE_AI_FIELDS).not.toContain('provider');
+  });
+
+  test('contains all other AI-specific fields from BASH_NODE_AI_FIELDS', () => {
+    const expectedFields = [
+      'context',
+      'output_format',
+      'allowed_tools',
+      'denied_tools',
+      'hooks',
+      'mcp',
+      'skills',
+      'effort',
+      'thinking',
+      'maxBudgetUsd',
+      'systemPrompt',
+      'fallbackModel',
+      'betas',
+      'sandbox',
+    ];
+    for (const field of expectedFields) {
+      expect(LOOP_NODE_AI_FIELDS).toContain(field);
     }
   });
 });

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -291,7 +291,7 @@ export type DagNode =
   | ScriptNode;
 
 // ---------------------------------------------------------------------------
-// AI-specific fields that are meaningless on bash/loop nodes
+// AI-specific fields that are meaningless on non-AI nodes
 // ---------------------------------------------------------------------------
 
 /** AI-specific fields that are meaningless on bash nodes — exported for loader warnings */

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -294,7 +294,7 @@ export type DagNode =
 // AI-specific fields that are meaningless on bash/loop nodes
 // ---------------------------------------------------------------------------
 
-/** AI-specific fields that are meaningless on bash/loop nodes — exported for loader warnings */
+/** AI-specific fields that are meaningless on bash nodes — exported for loader warnings */
 export const BASH_NODE_AI_FIELDS: readonly string[] = [
   'provider',
   'model',
@@ -316,6 +316,15 @@ export const BASH_NODE_AI_FIELDS: readonly string[] = [
 
 /** AI-specific fields that are meaningless on script nodes — same as bash nodes */
 export const SCRIPT_NODE_AI_FIELDS: readonly string[] = BASH_NODE_AI_FIELDS;
+
+/**
+ * AI-specific fields that are unsupported on loop nodes.
+ * `model` and `provider` are excluded because the DAG executor resolves and
+ * forwards them to each iteration's AI call (see dag-executor.ts:2602-2648).
+ */
+export const LOOP_NODE_AI_FIELDS: readonly string[] = BASH_NODE_AI_FIELDS.filter(
+  f => f !== 'model' && f !== 'provider'
+);
 
 // ---------------------------------------------------------------------------
 // dagNodeSchema — flat validation schema with transform to DagNode

--- a/packages/workflows/src/schemas/index.ts
+++ b/packages/workflows/src/schemas/index.ts
@@ -47,6 +47,7 @@ export {
   isTriggerRule,
   BASH_NODE_AI_FIELDS,
   SCRIPT_NODE_AI_FIELDS,
+  LOOP_NODE_AI_FIELDS,
   effortLevelSchema,
   thinkingConfigSchema,
   sandboxSettingsSchema,


### PR DESCRIPTION
## Summary

- **Problem**: The workflow loader fired `loop_node_ai_fields_ignored` warnings for `model:` and `provider:` on loop nodes, even though the DAG executor has honored those fields since commit 594d5daa. Users who checked logs were misled into thinking their per-node model directive had no effect.
- **Why it matters**: Silent misleading warnings cause users to distrust their configuration or spend time debugging a non-existent problem; the loop body was never actually running on the wrong model, but the warning said otherwise.
- **What changed**: Added `LOOP_NODE_AI_FIELDS` constant (BASH list minus `model`/`provider`) in `dag-node.ts`; updated `loader.ts` to use it for loop nodes; added tests covering the corrected behavior.
- **What did not change**: Executor logic is untouched (it already worked); unsupported loop fields like `output_format`, `hooks`, `mcp`, and `skills` still emit warnings correctly.

## UX Journey

### Before

```
User writes workflow YAML:
  nodes:
    implement:
      loop:
        prompt: "..."
      model: claude-opus-4-6[1m]   ← user expects Opus

Archon loads workflow:
  [WARN] loop_node_ai_fields_ignored fields=["model"]
         ↑ misleading — user thinks model is ignored

Runtime: loop actually runs on Opus (executor was correct all along)
         but user sees the warning and changes config or files a bug
```

### After

```
User writes workflow YAML:
  nodes:
    implement:
      loop:
        prompt: "..."
      model: claude-opus-4-6[1m]

Archon loads workflow:
  [no warning for model or provider — they are supported]   ← [FIXED]

Runtime: loop runs on Opus (consistent with configuration)
```

## Architecture Diagram

### Before

```
loader.ts
  └─ isNonAiNode(node)?
       ├─ bash/script/approval/cancel/loop ← loop lumped here
       └─ aiFields = isScriptNode ? SCRIPT_NODE_AI_FIELDS : BASH_NODE_AI_FIELDS
                                                             ↑ includes model/provider
dag-node.ts
  └─ BASH_NODE_AI_FIELDS  ← has model, provider (used for loop too)
  └─ SCRIPT_NODE_AI_FIELDS
```

### After

```
loader.ts
  └─ isNonAiNode(node)?
       ├─ bash/script/approval/cancel/loop
       └─ aiFields = isLoopNode   ? LOOP_NODE_AI_FIELDS    [+]
                   : isScriptNode ? SCRIPT_NODE_AI_FIELDS
                   :                BASH_NODE_AI_FIELDS

dag-node.ts
  └─ BASH_NODE_AI_FIELDS  (comment fixed: removed "loop nodes" reference)  [~]
  └─ SCRIPT_NODE_AI_FIELDS
  └─ LOOP_NODE_AI_FIELDS  ← BASH minus model/provider                      [+]
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `loader.ts` | `BASH_NODE_AI_FIELDS` | unchanged | still used for bash/approval/cancel |
| `loader.ts` | `SCRIPT_NODE_AI_FIELDS` | unchanged | still used for script nodes |
| `loader.ts` | `LOOP_NODE_AI_FIELDS` | **new** | used for loop nodes |
| `dag-node.ts` | `LOOP_NODE_AI_FIELDS` | **new** | exported constant |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `workflows`
- Module: `workflows:loader`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes #1082

## Validation Evidence (required)

```bash
bun run validate
```

- `bun run type-check` — ✅ 0 errors across all 9 packages
- `bun run lint` — ✅ 0 errors, 0 warnings
- `bun run format:check` — ✅ all files formatted
- `bun run test` — ✅ all tests pass (0 failures); new tests added in `loader.test.ts` cover:
  - Loop node with `model:` and `provider:` does NOT trigger `loop_node_ai_fields_ignored`
  - Loop node with `output_format:` still triggers the warning (unsupported field)
- Evidence provided: validation.md artifact (all checks green)
- No commands skipped.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — removes a spurious warning; no behavior change at runtime
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: Loop node YAML with `model: claude-opus-4-6[1m]` loads without warning for `model`/`provider`; unsupported field warnings still fire for `output_format` on loop nodes
- Edge cases checked: Loop node with both `model` and an unsupported field emits warning only for the unsupported field
- What was not verified: Live end-to-end run against a real Claude API call (executor path was already fixed in 594d5daa and is not changed here)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Workflow loader warning logic only; executor unchanged
- Potential unintended effects: None — the change narrows the warning set for loop nodes, which was already incorrect
- Guardrails: Existing test suite covers loader warning behavior

## Rollback Plan (required)

- Fast rollback command/path: `git revert HEAD` on `dev`
- Feature flags or config toggles: None
- Observable failure symptoms: Spurious `loop_node_ai_fields_ignored` warnings reappear for `model`/`provider` on loop nodes

## Risks and Mitigations

- Risk: A loop node field that is truly unsupported might be accidentally excluded from warnings if `LOOP_NODE_AI_FIELDS` is defined incorrectly.
  - Mitigation: `LOOP_NODE_AI_FIELDS` is derived from `BASH_NODE_AI_FIELDS` via `.filter()` — only `model` and `provider` are removed; all other fields remain. Tests verify this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation of AI-specific fields on loop nodes. Loop nodes now correctly handle configuration fields that are resolved during execution, preventing false warnings while still alerting users to genuinely unsupported fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->