### PR TITLE
fix: resolve Windows Bun virtual FS paths for Claude CLI subprocess

### DIFF
--- a/packages/core/src/clients/claude.test.ts
+++ b/packages/core/src/clients/claude.test.ts
@@ -1124,7 +1124,6 @@ describe('resolveWindowsBunfsCliPath', () => {
   });
 
   test('extracts Windows Bun virtual FS paths to a real temp file', () => {
-    // Create a real temp file that simulates a Windows ~BUN path content
     const testContent = '// fake cli.js content for test';
     const fakeBunDir = join(tmpdir(), 'archon-test-bunfs');
     mkdirSync(fakeBunDir, { recursive: true });
@@ -1135,10 +1134,8 @@ describe('resolveWindowsBunfsCliPath', () => {
       const result = resolveWindowsBunfsCliPath(fakeBunPath);
       expect(result).not.toBe(fakeBunPath);
       expect(result).toContain('cli.js');
-      // Verify the extracted file exists and has correct content
       expect(readFileSync(result, 'utf-8')).toBe(testContent);
     } finally {
-      // Clean up
       rmSync(fakeBunDir, { recursive: true, force: true });
     }
   });

--- a/packages/core/src/clients/claude.test.ts
+++ b/packages/core/src/clients/claude.test.ts
@@ -1,4 +1,7 @@
 import { describe, test, expect, mock, beforeEach, afterEach, spyOn } from 'bun:test';
+import { mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { createMockLogger } from '../test/mocks/logger';
 
 const mockLogger = createMockLogger();
@@ -1121,33 +1124,33 @@ describe('resolveWindowsBunfsCliPath', () => {
   });
 
   test('extracts Windows Bun virtual FS paths to a real temp file', () => {
-    const fs = require('fs');
-    const os = require('os');
-    const path = require('path');
-
     // Create a real temp file that simulates a Windows ~BUN path content
     const testContent = '// fake cli.js content for test';
-    const fakeBunDir = path.join(os.tmpdir(), 'archon-test-bunfs');
-    fs.mkdirSync(fakeBunDir, { recursive: true });
-    const fakeBunPath = path.join(fakeBunDir, '~BUN-test-cli.js');
-    fs.writeFileSync(fakeBunPath, testContent);
+    const fakeBunDir = join(tmpdir(), 'archon-test-bunfs');
+    mkdirSync(fakeBunDir, { recursive: true });
+    const fakeBunPath = join(fakeBunDir, '~BUN-test-cli.js');
+    writeFileSync(fakeBunPath, testContent);
 
     try {
       const result = resolveWindowsBunfsCliPath(fakeBunPath);
       expect(result).not.toBe(fakeBunPath);
       expect(result).toContain('cli.js');
       // Verify the extracted file exists and has correct content
-      expect(fs.readFileSync(result, 'utf-8')).toBe(testContent);
+      expect(readFileSync(result, 'utf-8')).toBe(testContent);
     } finally {
       // Clean up
-      fs.rmSync(fakeBunDir, { recursive: true, force: true });
+      rmSync(fakeBunDir, { recursive: true, force: true });
     }
   });
 
   test('falls back to original path if extraction fails', () => {
     // Path contains ~BUN but doesn't exist on disk
     const windowsBunfsPath = 'B:/~BUN/root/nonexistent-cli.js';
+    mockLogger.warn.mockClear();
     const result = resolveWindowsBunfsCliPath(windowsBunfsPath);
     expect(result).toBe(windowsBunfsPath);
+    // Verify the structured logger warn fires so operators can diagnose failures
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn.mock.calls[0][1]).toBe('claude.windows_bunfs_extraction_failed');
   });
 });

--- a/packages/core/src/clients/claude.test.ts
+++ b/packages/core/src/clients/claude.test.ts
@@ -1106,3 +1106,48 @@ describe('ClaudeClient', () => {
     });
   });
 });
+
+describe('resolveWindowsBunfsCliPath', () => {
+  const { resolveWindowsBunfsCliPath } = claudeModule;
+
+  test('returns non-Windows paths unchanged', () => {
+    const realPath = '/tmp/claude-agent-sdk-abc123/cli.js';
+    expect(resolveWindowsBunfsCliPath(realPath)).toBe(realPath);
+  });
+
+  test('returns $bunfs paths unchanged (already extracted by SDK)', () => {
+    const bunfsPath = '/$bunfs/root/cli.js';
+    expect(resolveWindowsBunfsCliPath(bunfsPath)).toBe(bunfsPath);
+  });
+
+  test('extracts Windows Bun virtual FS paths to a real temp file', () => {
+    const fs = require('fs');
+    const os = require('os');
+    const path = require('path');
+
+    // Create a real temp file that simulates a Windows ~BUN path content
+    const testContent = '// fake cli.js content for test';
+    const fakeBunDir = path.join(os.tmpdir(), 'archon-test-bunfs');
+    fs.mkdirSync(fakeBunDir, { recursive: true });
+    const fakeBunPath = path.join(fakeBunDir, '~BUN-test-cli.js');
+    fs.writeFileSync(fakeBunPath, testContent);
+
+    try {
+      const result = resolveWindowsBunfsCliPath(fakeBunPath);
+      expect(result).not.toBe(fakeBunPath);
+      expect(result).toContain('cli.js');
+      // Verify the extracted file exists and has correct content
+      expect(fs.readFileSync(result, 'utf-8')).toBe(testContent);
+    } finally {
+      // Clean up
+      fs.rmSync(fakeBunDir, { recursive: true, force: true });
+    }
+  });
+
+  test('falls back to original path if extraction fails', () => {
+    // Path contains ~BUN but doesn't exist on disk
+    const windowsBunfsPath = 'B:/~BUN/root/nonexistent-cli.js';
+    const result = resolveWindowsBunfsCliPath(windowsBunfsPath);
+    expect(result).toBe(windowsBunfsPath);
+  });
+});

--- a/packages/core/src/clients/claude.ts
+++ b/packages/core/src/clients/claude.ts
@@ -13,6 +13,10 @@
  * - CLAUDE_USE_GLOBAL_AUTH=false: Use explicit tokens from env vars
  * - Not set: Auto-detect - use tokens if present in env, otherwise global auth
  */
+import { readFileSync, writeFileSync, mkdirSync, chmodSync, renameSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { createHash } from 'crypto';
 import {
   query,
   type Options,
@@ -43,10 +47,6 @@ import { buildCleanSubprocessEnv } from '../utils/env-allowlist';
 import { scanPathForSensitiveKeys, EnvLeakError } from '../utils/env-leak-scanner';
 import * as codebaseDb from '../db/codebases';
 import { loadConfig } from '../config/config-loader';
-import { readFileSync, writeFileSync, mkdirSync, chmodSync, renameSync } from 'fs';
-import { join } from 'path';
-import { tmpdir } from 'os';
-import { createHash } from 'crypto';
 
 /**
  * On Windows, Bun's virtual filesystem uses `B:/~BUN/root/` instead of `$bunfs`.
@@ -60,8 +60,8 @@ import { createHash } from 'crypto';
  */
 export function resolveWindowsBunfsCliPath(embeddedPath: string): string {
   // Windows Bun virtual FS paths contain '~BUN' (e.g. B:/~BUN/root/cli-xxx.js).
-  // Non-Windows paths are already resolved by extractFromBunfs (real temp file or
-  // real node_modules path) and don't contain this marker.
+  // Non-Windows paths are expected to have been resolved already by extractFromBunfs
+  // (real temp file or real node_modules path) and won't contain this marker.
   if (!embeddedPath.includes('~BUN')) {
     return embeddedPath;
   }
@@ -80,13 +80,13 @@ export function resolveWindowsBunfsCliPath(embeddedPath: string): string {
   } catch (err) {
     // Log warning but fall back to original path — will fail but that was the
     // pre-fix behavior. Fail-open here since we can't throw at module init time.
-    console.warn(
-      `[archon] Failed to extract Claude CLI from Windows $bunfs: ${(err as Error).message}. Claude Code subprocess will likely fail to start.`
-    );
+    getLog().warn({ err, embeddedPath }, 'claude.windows_bunfs_extraction_failed');
     return embeddedPath;
   }
 }
 
+// Module-level cached result: resolved once at import time so every call to
+// pathToClaudeCodeExecutable returns the same real path without re-extracting.
 const resolvedCliPath = resolveWindowsBunfsCliPath(cliPath);
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */

--- a/packages/core/src/clients/claude.ts
+++ b/packages/core/src/clients/claude.ts
@@ -27,6 +27,10 @@ import {
 // the build host's absolute node_modules path, producing a "Module not found
 // /Users/runner/..." error on any machine other than the CI runner.
 // Safe in dev too: resolves to the real on-disk cli.js.
+//
+// NOTE: The SDK's extractFromBunfs only handles $bunfs (Linux/Mac) paths.
+// On Windows, Bun uses B:/~BUN/root/ for its virtual FS — see resolveWindowsBunfsCliPath
+// below for the Windows workaround.
 import cliPath from '@anthropic-ai/claude-agent-sdk/embed';
 import {
   type AssistantRequestOptions,
@@ -39,6 +43,51 @@ import { buildCleanSubprocessEnv } from '../utils/env-allowlist';
 import { scanPathForSensitiveKeys, EnvLeakError } from '../utils/env-leak-scanner';
 import * as codebaseDb from '../db/codebases';
 import { loadConfig } from '../config/config-loader';
+import { readFileSync, writeFileSync, mkdirSync, chmodSync, renameSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { createHash } from 'crypto';
+
+/**
+ * On Windows, Bun's virtual filesystem uses `B:/~BUN/root/` instead of `$bunfs`.
+ * The SDK's `extractFromBunfs` only checks for `$bunfs`, so Windows virtual FS
+ * paths are returned unchanged — child processes cannot access the parent's virtual
+ * FS, causing "Module not found B:/~BUN/root/..." errors.
+ *
+ * This function detects Windows Bun FS paths and extracts them to a real temp file
+ * using the same logic as `extractFromBunfs`, so `pathToClaudeCodeExecutable` always
+ * points to a real file accessible to child processes.
+ */
+export function resolveWindowsBunfsCliPath(embeddedPath: string): string {
+  // Windows Bun virtual FS paths contain '~BUN' (e.g. B:/~BUN/root/cli-xxx.js).
+  // Non-Windows paths are already resolved by extractFromBunfs (real temp file or
+  // real node_modules path) and don't contain this marker.
+  if (!embeddedPath.includes('~BUN')) {
+    return embeddedPath;
+  }
+  try {
+    const content = readFileSync(embeddedPath);
+    const hash = createHash('sha256').update(content).digest('hex').slice(0, 16);
+    const tmpDir = join(tmpdir(), `claude-agent-sdk-${hash}`);
+    const tmpPath = join(tmpDir, 'cli.js');
+    mkdirSync(tmpDir, { recursive: true });
+    // Atomic write: write to temp file then rename to avoid truncation races
+    const tmpFile = join(tmpDir, `cli.js.tmp.${process.pid}`);
+    writeFileSync(tmpFile, content);
+    chmodSync(tmpFile, 0o755);
+    renameSync(tmpFile, tmpPath);
+    return tmpPath;
+  } catch (err) {
+    // Log warning but fall back to original path — will fail but that was the
+    // pre-fix behavior. Fail-open here since we can't throw at module init time.
+    console.warn(
+      `[archon] Failed to extract Claude CLI from Windows $bunfs: ${(err as Error).message}. Claude Code subprocess will likely fail to start.`
+    );
+    return embeddedPath;
+  }
+}
+
+const resolvedCliPath = resolveWindowsBunfsCliPath(cliPath);
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
@@ -324,7 +373,7 @@ export class ClaudeClient implements IAssistantClient {
 
       const options: Options = {
         cwd,
-        pathToClaudeCodeExecutable: cliPath,
+        pathToClaudeCodeExecutable: resolvedCliPath,
         env: requestOptions?.env
           ? { ...buildSubprocessEnv(), ...requestOptions.env }
           : buildSubprocessEnv(),

--- a/packages/core/src/clients/claude.ts
+++ b/packages/core/src/clients/claude.ts
@@ -85,16 +85,17 @@ export function resolveWindowsBunfsCliPath(embeddedPath: string): string {
   }
 }
 
-// Module-level cached result: resolved once at import time so every call to
-// pathToClaudeCodeExecutable returns the same real path without re-extracting.
-const resolvedCliPath = resolveWindowsBunfsCliPath(cliPath);
-
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
 function getLog(): ReturnType<typeof createLogger> {
   if (!cachedLog) cachedLog = createLogger('client.claude');
   return cachedLog;
 }
+
+// Module-level cached result: resolved once at import time so every call to
+// pathToClaudeCodeExecutable returns the same real path without re-extracting.
+// Must be declared after getLog() to avoid TDZ if extraction fails and logs a warning.
+const resolvedCliPath = resolveWindowsBunfsCliPath(cliPath);
 
 /**
  * Content block type for assistant messages


### PR DESCRIPTION
## Summary

- On Windows, the Archon binary sets `pathToClaudeCodeExecutable` to a Bun virtual FS path (`B:/~BUN/root/cli-xxx.js`) that child processes cannot access, causing exit code 1 and "Module not found" errors
- The SDK's `extractFromBunfs` utility only detects `$bunfs` (Linux/Mac) paths and silently passes Windows `B:/~BUN/root/` paths through unchanged
- Adds `resolveWindowsBunfsCliPath()` to `packages/core/src/clients/claude.ts` that detects Windows Bun FS paths by the `~BUN` marker and extracts them to a real temp file using the same atomic write pattern as `extractFromBunfs`

## Changes

- **`packages/core/src/clients/claude.ts`**: Added `resolveWindowsBunfsCliPath()` function and `resolvedCliPath` constant; `pathToClaudeCodeExecutable` now uses `resolvedCliPath` instead of raw `cliPath`; updated embed import comment to document the Windows workaround
- **`packages/core/src/clients/claude.test.ts`**: Added tests for `resolveWindowsBunfsCliPath` covering pass-through for non-Windows paths, Windows path extraction, and fallback behavior on extraction failure

## Validation

All checks passed on first run:

| Check | Result |
|-------|--------|
| `bun run type-check` | ✅ 0 errors (all 9 packages) |
| `bun run lint` | ✅ 0 errors, 0 warnings |
| `bun run format:check` | ✅ |
| `bun run test` | ✅ 58+ tests passed, 0 failed |

## Root Cause

The Archon binary cross-compiles on Linux for Windows (`--target bun-windows-x64`). At compile time, `import cliPath from '@anthropic-ai/claude-agent-sdk/embed'` embeds `cli.js` into the binary's virtual FS. On Linux/Mac binaries the embedded path format is `$bunfs/...`; on Windows binaries the format is `B:/~BUN/root/...`. The SDK's `extractFromBunfs.js` hardcodes a `$bunfs` check and returns Windows virtual FS paths unchanged — child processes then fail to find the module since they cannot access the parent's virtual FS.

Fixes #1087