### PR TITLE
fix: unblock Archon when launched from a Claude Code terminal and on Bun 1.3+

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
     },
     "packages/adapters": {
       "name": "@archon/adapters",
-      "version": "0.1.0",
+      "version": "0.3.5",
       "dependencies": {
         "@archon/core": "workspace:*",
         "@archon/git": "workspace:*",
@@ -41,7 +41,7 @@
     },
     "packages/cli": {
       "name": "@archon/cli",
-      "version": "0.2.13",
+      "version": "0.3.5",
       "bin": {
         "archon": "./src/cli.ts",
       },
@@ -62,7 +62,7 @@
     },
     "packages/core": {
       "name": "@archon/core",
-      "version": "0.2.0",
+      "version": "0.3.5",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.89",
         "@archon/git": "workspace:*",
@@ -83,7 +83,7 @@
     },
     "packages/docs-web": {
       "name": "@archon/docs-web",
-      "version": "0.2.12",
+      "version": "0.3.5",
       "dependencies": {
         "@astrojs/starlight": "^0.38.0",
         "astro": "^6.1.0",
@@ -92,7 +92,7 @@
     },
     "packages/git": {
       "name": "@archon/git",
-      "version": "0.1.0",
+      "version": "0.3.5",
       "dependencies": {
         "@archon/paths": "workspace:*",
       },
@@ -102,7 +102,7 @@
     },
     "packages/isolation": {
       "name": "@archon/isolation",
-      "version": "0.1.0",
+      "version": "0.3.5",
       "dependencies": {
         "@archon/git": "workspace:*",
         "@archon/paths": "workspace:*",
@@ -113,7 +113,7 @@
     },
     "packages/paths": {
       "name": "@archon/paths",
-      "version": "0.2.0",
+      "version": "0.3.5",
       "dependencies": {
         "pino": "^9",
         "pino-pretty": "^13",
@@ -124,7 +124,7 @@
     },
     "packages/server": {
       "name": "@archon/server",
-      "version": "0.2.0",
+      "version": "0.3.5",
       "dependencies": {
         "@archon/adapters": "workspace:*",
         "@archon/core": "workspace:*",
@@ -142,7 +142,7 @@
     },
     "packages/web": {
       "name": "@archon/web",
-      "version": "0.2.0",
+      "version": "0.3.5",
       "dependencies": {
         "@dagrejs/dagre": "^2.0.4",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -194,7 +194,7 @@
     },
     "packages/workflows": {
       "name": "@archon/workflows",
-      "version": "0.1.0",
+      "version": "0.3.5",
       "dependencies": {
         "@archon/git": "workspace:*",
         "@archon/paths": "workspace:*",
@@ -205,6 +205,9 @@
         "typescript": "^5.0.0",
       },
     },
+  },
+  "patchedDependencies": {
+    "telegraf@4.16.3": "patches/telegraf@4.16.3.patch",
   },
   "overrides": {
     "test-exclude": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.74"
+  },
+  "patchedDependencies": {
+    "telegraf@4.16.3": "patches/telegraf@4.16.3.patch"
   }
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -38,6 +38,21 @@ if (!process.env.CLAUDE_API_KEY && !process.env.CLAUDE_CODE_OAUTH_TOKEN) {
   }
 }
 
+// Strip Claude Code's nested-session markers from process.env.
+// When Archon is launched from inside a Claude Code terminal session, the parent
+// exports CLAUDECODE and several CLAUDE_CODE_* markers. The embedded CLI spawned
+// by the Claude Agent SDK refuses to launch if it sees any of them (nested-session
+// guard). SUBPROCESS_ENV_ALLOWLIST already excludes these, but the SDK leaks
+// process.env into the subprocess anyway, so we delete at the process level.
+// Auth/config vars (OAUTH_TOKEN, USE_BEDROCK, USE_VERTEX) are kept — only the
+// nested-session markers below are removed.
+delete process.env.CLAUDECODE;
+delete process.env.CLAUDE_CODE_ENTRYPOINT;
+delete process.env.CLAUDE_CODE_EXECPATH;
+delete process.env.CLAUDE_CODE_HIDE_ACCOUNT_INFO;
+delete process.env.CLAUDE_CODE_NO_FLICKER;
+delete process.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS;
+
 // DATABASE_URL is no longer required - SQLite will be used as default
 
 // Import commands after dotenv is loaded

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -48,6 +48,21 @@ if (
   process.env.CLAUDE_USE_GLOBAL_AUTH = 'true';
 }
 
+// Strip Claude Code's nested-session markers from process.env.
+// When Archon is launched from inside a Claude Code terminal session, the parent
+// exports CLAUDECODE and several CLAUDE_CODE_* markers. The embedded CLI spawned
+// by the Claude Agent SDK refuses to launch if it sees any of them (nested-session
+// guard). SUBPROCESS_ENV_ALLOWLIST already excludes these, but the SDK leaks
+// process.env into the subprocess anyway, so we delete at the process level.
+// Auth/config vars (OAUTH_TOKEN, USE_BEDROCK, USE_VERTEX) are kept — only the
+// nested-session markers below are removed.
+delete process.env.CLAUDECODE;
+delete process.env.CLAUDE_CODE_ENTRYPOINT;
+delete process.env.CLAUDE_CODE_EXECPATH;
+delete process.env.CLAUDE_CODE_HIDE_ACCOUNT_INFO;
+delete process.env.CLAUDE_CODE_NO_FLICKER;
+delete process.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS;
+
 import { OpenAPIHono } from '@hono/zod-openapi';
 import { validationErrorHook } from './routes/openapi-defaults';
 import { TelegramAdapter, GitHubAdapter, DiscordAdapter, SlackAdapter } from '@archon/adapters';

--- a/patches/telegraf@4.16.3.patch
+++ b/patches/telegraf@4.16.3.patch
@@ -1,0 +1,18 @@
+diff --git a/lib/core/network/client.js b/lib/core/network/client.js
+index 25fbbbb47c7f88e83ae26f629e5ae1a0c141725c..7ee7bc4fc5e5d8fdb2f6307ecfdf0e3b932d1943 100644
+--- a/lib/core/network/client.js
++++ b/lib/core/network/client.js
+@@ -245,7 +245,12 @@ async function answerToWebhook(response, payload, options) {
+     return true;
+ }
+ function redactToken(error) {
+-    error.message = error.message.replace(/\/(bot|user)(\d+):[^/]+\//, '/$1$2:[REDACTED]/');
++    // Bun frozen Error.message workaround: assignment may throw TypeError in Bun
++    // runtimes where error.message is non-writable. Fall back to re-throwing the
++    // original error rather than killing the polling loop.
++    try {
++        error.message = error.message.replace(/\/(bot|user)(\d+):[^/]+\//, '/$1$2:[REDACTED]/');
++    } catch (_) { /* message is read-only; re-throw original */ }
+     throw error;
+ }
+ class ApiClient {


### PR DESCRIPTION
## Summary

Two blockers hit during a fresh setup on macOS, from inside a Claude Code terminal on Bun 1.3.12 — both reproduce deterministically and leave the orchestrator silently hung with no actionable error.

### 1. Claude Agent SDK subprocess refuses to launch (nested-session guard)

The parent Claude Code shell exports these markers:

- \`CLAUDECODE=1\`
- \`CLAUDE_CODE_ENTRYPOINT\`
- \`CLAUDE_CODE_EXECPATH\`
- \`CLAUDE_CODE_HIDE_ACCOUNT_INFO\`
- \`CLAUDE_CODE_NO_FLICKER\`
- \`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS\`

Archon's existing cleanup in \`buildSubprocessEnv()\` (\`packages/core/src/clients/claude.ts:167\`) only stripped \`CLAUDECODE\`. Worse, the Claude Agent SDK leaks \`process.env\` into the spawned child **regardless of the explicit \`env\` option passed to \`query()\`** — so even vars that \`SUBPROCESS_ENV_ALLOWLIST\` correctly excludes still reach the subprocess. The child then hits its own nested-session guard and the orchestrator hangs after logging \`using_global_auth\` twice, with no \`query_failed\`, no \`subprocess_error\`, no outbound connection to api.anthropic.com, and no visible child process.

The only bulletproof fix until the SDK stops leaking \`process.env\` is to delete the markers at the process level at server and CLI entry points. Auth vars (\`CLAUDE_CODE_OAUTH_TOKEN\`, \`CLAUDE_CODE_USE_BEDROCK\`, \`CLAUDE_CODE_USE_VERTEX\`) are kept — only the six nested-session markers are removed.

### 2. Telegram adapter dies on first polling error on Bun 1.3+

Telegraf's \`redactToken()\` (\`node_modules/telegraf/lib/core/network/client.js:248\`) does:

\`\`\`js
error.message = error.message.replace(/\/(bot|user)(\d+):[^/]+\//, '/\$1\$2:[REDACTED]/');
\`\`\`

On Bun 1.3+, \`Error.message\` on certain error instances (fetch/network errors) is non-writable, so the assignment throws \`TypeError: Attempted to assign to readonly property.\`, kills the polling loop, and leaves the adapter silently dead. The single log line is:

\`\`\`
telegram.start_failed  TypeError: Attempted to assign to readonly property.
  at redactToken (telegraf/lib/core/network/client.js:248:5)
\`\`\`

Patched via \`bun patch telegraf\` to wrap the assignment in \`try/catch\`. The original error is still re-thrown unchanged, so Telegraf's own retry/reconnect logic runs normally; the only difference is that we survive one specific Bun runtime quirk.

### 3. Incidental: \`bun.lock\` re-sync

\`bun patch --commit\` re-serialized \`bun.lock\` and picked up workspace version bumps that were already in the individual \`package.json\` files (\`0.3.5\`) but stale in the lockfile (\`0.1.0\`/\`0.2.0\`). No behavioral change — just brings the lockfile in sync with reality.

## Files

- \`packages/server/src/index.ts\` — strip six markers right after dotenv loads, before any application imports
- \`packages/cli/src/cli.ts\` — same strip at CLI entry
- \`patches/telegraf@4.16.3.patch\` — \`try/catch\` around the \`redactToken\` assignment
- \`package.json\` — \`patchedDependencies\` entry for the telegraf patch
- \`bun.lock\` — pick up \`patchedDependencies\` + workspace version re-sync

## Reproduction

From inside a Claude Code terminal on Bun 1.3+:

\`\`\`bash
# Before this PR
archon chat "say hi"
# Hangs forever after "using_global_auth". No error.

# After this PR
archon chat "say hi"
# "Hello!" (or similar)
\`\`\`

And for the Telegram bug: configure a bot token, start the server, run \`curl https://api.telegram.org/bot<TOKEN>/getUpdates\` to trigger a 409 conflict in the long-poll — before this PR the adapter logs \`telegram.start_failed\` and stops polling forever; after, it logs the upstream error and reconnects.

## Test plan

- [x] \`bun run validate\` passes (type-check, lint, format, tests)
- [x] \`archon chat\` works end-to-end
- [x] Telegram bot replies to DMs
- [x] Web UI chat replies
- [ ] Verified CI passes on this branch

## Related latent issues (not fixed in this PR)

1. \`~/.archon/workspaces\` is the orchestrator's fallback cwd for new conversations without a registered codebase (\`orchestrator-agent.ts:743\`). If the dir doesn't exist, Bun's \`spawn()\` hangs silently instead of erroring — another way to reproduce the exact same symptoms as #1 above. A follow-up PR should \`mkdirSync(getArchonWorkspacesPath(), { recursive: true })\` during server/CLI startup.
2. The \`process.env\` leak in the Claude Agent SDK (#1 root cause) should be reported upstream to \`@anthropic-ai/claude-agent-sdk\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error message handling in network operations to work across different runtime environments.

* **Chores**
  * Enhanced environment variable cleanup during CLI and server startup to prevent context leakage to spawned subprocesses.
  * Applied dependency patch to improve stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->