### PR TITLE
fix(core): add CLAUDE_CONFIG_DIR to subprocess env allowlist

### DIFF
--- a/packages/core/src/utils/env-allowlist.ts
+++ b/packages/core/src/utils/env-allowlist.ts
@@ -25,6 +25,7 @@ export const SUBPROCESS_ENV_ALLOWLIST = new Set([
   'TZ',
   'SSH_AUTH_SOCK',
   // Claude auth and config
+  'CLAUDE_CONFIG_DIR',
   'CLAUDE_USE_GLOBAL_AUTH',
   'CLAUDE_API_KEY',
   'CLAUDE_CODE_OAUTH_TOKEN',


### PR DESCRIPTION
## Summary

- Add `CLAUDE_CONFIG_DIR` to `SUBPROCESS_ENV_ALLOWLIST` so users with non-default Claude config locations can authenticate via Claude Code subprocesses
- Without this, users who set `CLAUDE_CONFIG_DIR` (e.g., `~/.config/claude-code/`) get "Not logged in" errors because the subprocess falls back to `~/.claude/`

## Test plan

- [ ] Set `CLAUDE_CONFIG_DIR` to a non-default path, authenticate with `claude /login`, and verify Archon Web UI can send messages without auth errors
- [ ] Verify default behavior (no `CLAUDE_CONFIG_DIR` set) is unchanged

Fixes #1098

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced subprocess environment configuration to properly support custom configuration directory settings across execution contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->