### PR TITLE
fix: route dashboard SSE through shared base URL

### DIFF
--- a/packages/web/src/hooks/useDashboardSSE.test.ts
+++ b/packages/web/src/hooks/useDashboardSSE.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { getSSEStreamUrl } from '@/lib/api';
+
+const hookSource = fs.readFileSync(path.join(import.meta.dir, 'useDashboardSSE.ts'), 'utf8');
+
+describe('useDashboardSSE source contract', () => {
+  test('uses shared SSE URL helper for dashboard stream', () => {
+    expect(hookSource).toContain("new EventSource(getSSEStreamUrl('__dashboard__'))");
+    expect(hookSource).not.toContain("new EventSource('/api/stream/__dashboard__')");
+    expect(getSSEStreamUrl('__dashboard__')).toContain('/api/stream/__dashboard__');
+  });
+});

--- a/packages/web/src/hooks/useDashboardSSE.ts
+++ b/packages/web/src/hooks/useDashboardSSE.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { getSSEStreamUrl } from '@/lib/api';
 import { workflowSSEHandlers } from '@/stores/workflow-store';
 import type {
   WorkflowStatusEvent,
@@ -10,7 +11,7 @@ import type {
 /** Connects to the multiplexed dashboard SSE stream and routes events to the Zustand store. */
 export function useDashboardSSE(): void {
   useEffect(() => {
-    const es = new EventSource('/api/stream/__dashboard__');
+    const es = new EventSource(getSSEStreamUrl('__dashboard__'));
 
     es.onmessage = (e: MessageEvent<string>): void => {
       let event: { type: string };

--- a/packages/web/src/hooks/useSSE.ts
+++ b/packages/web/src/hooks/useSSE.ts
@@ -9,7 +9,7 @@ import type {
   WorkflowOutputPreviewEvent,
   DagNodeEvent,
 } from '@/lib/types';
-import { SSE_BASE_URL } from '@/lib/api';
+import { getSSEStreamUrl } from '@/lib/api';
 
 function parseSSEEvent(raw: string): SSEEvent | null {
   try {
@@ -74,7 +74,7 @@ export function useSSE(
     if (!conversationId) return;
 
     const eventSource = new EventSource(
-      `${SSE_BASE_URL}/api/stream/${encodeURIComponent(conversationId)}`
+      getSSEStreamUrl(encodeURIComponent(conversationId))
     );
 
     eventSource.onopen = (): void => {

--- a/packages/web/src/lib/api-sse.test.ts
+++ b/packages/web/src/lib/api-sse.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
 import { getSSEStreamUrl, SSE_BASE_URL } from '@/lib/api';
+
+const apiSource = fs.readFileSync(path.join(import.meta.dir, 'api.ts'), 'utf8');
+
+describe('getSSEBaseUrl source contract', () => {
+  test('guards window access during module initialization', () => {
+    expect(apiSource).toContain("typeof window !== 'undefined'");
+    expect(apiSource).toContain("window.location.hostname");
+  });
+});
 
 describe('getSSEStreamUrl', () => {
   test('builds dashboard SSE URL from shared SSE base URL', () => {

--- a/packages/web/src/lib/api-sse.test.ts
+++ b/packages/web/src/lib/api-sse.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test';
+import { getSSEStreamUrl, SSE_BASE_URL } from '@/lib/api';
+
+describe('getSSEStreamUrl', () => {
+  test('builds dashboard SSE URL from shared SSE base URL', () => {
+    expect(getSSEStreamUrl('__dashboard__')).toBe(`${SSE_BASE_URL}/api/stream/__dashboard__`);
+  });
+
+  test('builds conversation SSE URL from shared SSE base URL', () => {
+    expect(getSSEStreamUrl(encodeURIComponent('conv/123'))).toBe(
+      `${SSE_BASE_URL}/api/stream/conv%2F123`
+    );
+  });
+});

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -19,6 +19,10 @@ export const SSE_BASE_URL = import.meta.env.DEV
   ? `http://${window.location.hostname}:${apiPort}`
   : '';
 
+export function getSSEStreamUrl(streamPath: string): string {
+  return `${SSE_BASE_URL}/api/stream/${streamPath}`;
+}
+
 export interface ConversationResponse {
   id: string;
   platform_type: string;

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -15,9 +15,14 @@ export type DagNode = components['schemas']['DagNode'];
  * Uses the page hostname so it works from any network interface.
  */
 const apiPort = (import.meta.env.VITE_API_PORT as string | undefined) ?? '3090';
-export const SSE_BASE_URL = import.meta.env.DEV
-  ? `http://${window.location.hostname}:${apiPort}`
-  : '';
+
+export function getSSEBaseUrl(hostname?: string): string {
+  if (!import.meta.env.DEV) return '';
+  const resolvedHostname = hostname ?? (typeof window !== 'undefined' ? window.location.hostname : 'localhost');
+  return `http://${resolvedHostname}:${apiPort}`;
+}
+
+export const SSE_BASE_URL = getSSEBaseUrl();
 
 export function getSSEStreamUrl(streamPath: string): string {
   return `${SSE_BASE_URL}/api/stream/${streamPath}`;


### PR DESCRIPTION
## Summary

Make dashboard SSE use the same direct backend URL construction as chat SSE in dev mode.

Closes #1107

## Reproduction

The web package documents that SSE should bypass the Vite proxy in development because the proxy buffers SSE responses. `useSSE.ts` already used the shared SSE base URL, but `useDashboardSSE.ts` still opened `/api/stream/__dashboard__` directly.

## Patch Summary

- add a shared `getSSEStreamUrl()` helper in `packages/web/src/lib/api.ts`
- switch both SSE hooks to the shared helper
- add focused regression tests for helper output and dashboard hook usage

## Risks

Low. The change only touches SSE URL construction and keeps production behavior unchanged.

## Validation

- `cd packages/web && bun test src/lib/api-sse.test.ts src/hooks/useDashboardSSE.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Server-Sent Events URL construction consolidated into a shared helper and used consistently by SSE hooks, standardizing how stream endpoints are derived.

* **Tests**
  * Added tests validating SSE URL generation and confirming hooks use the shared URL helper rather than hardcoded paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->