### PR TITLE
feat(orchestrator): auto-reset stale Claude SDK sessions + bare 'reset' command for Slack

### DIFF
--- a/packages/core/src/clients/claude.test.ts
+++ b/packages/core/src/clients/claude.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, mock, beforeEach, afterEach, spyOn } from 'bun:test';
 import { createMockLogger } from '../test/mocks/logger';
+import { classifySubprocessError } from './claude';
 
 const mockLogger = createMockLogger();
 mock.module('@archon/paths', () => ({
@@ -856,6 +857,91 @@ describe('ClaudeClient', () => {
       expect(chunks).toHaveLength(1);
       expect(chunks[0]).toEqual({ type: 'assistant', content: 'Real content' });
     });
+
+    test('classifies stale session as fatal (no retry)', async () => {
+      const error = new Error('No conversation found');
+      mockQuery.mockImplementation(async function* () {
+        throw error;
+      });
+
+      let thrown: unknown;
+      const consumeGenerator = async () => {
+        try {
+          for await (const _ of client.sendQuery('test', '/workspace')) {
+            // consume
+          }
+        } catch (e) {
+          thrown = e;
+          throw e;
+        }
+      };
+
+      await expect(consumeGenerator()).rejects.toThrow(/Claude Code stale session/);
+      // Stale session should NOT retry - single call
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      // Enriched error must preserve original cause for stack trace diagnostics
+      expect((thrown as Error).cause).toBeDefined();
+    });
+
+    test('classifies "conversation not found" variant as stale session (no retry)', async () => {
+      const error = new Error('conversation not found');
+      mockQuery.mockImplementation(async function* () {
+        throw error;
+      });
+
+      let thrown: unknown;
+      const consumeGenerator = async () => {
+        try {
+          for await (const _ of client.sendQuery('test', '/workspace')) {
+            // consume
+          }
+        } catch (e) {
+          thrown = e;
+          throw e;
+        }
+      };
+
+      await expect(consumeGenerator()).rejects.toThrow(/Claude Code stale session/);
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      expect((thrown as Error).cause).toBeDefined();
+    });
+  });
+});
+
+describe('classifySubprocessError', () => {
+  test('classifies "no conversation found" as stale_session', () => {
+    expect(classifySubprocessError('No conversation found', '')).toBe('stale_session');
+  });
+
+  test('classifies stale session case-insensitively', () => {
+    expect(classifySubprocessError('NO CONVERSATION FOUND', '')).toBe('stale_session');
+  });
+
+  test('classifies "conversation not found" variant as stale_session', () => {
+    expect(classifySubprocessError('query failed', 'conversation not found')).toBe('stale_session');
+  });
+
+  test('classifies rate_limit correctly', () => {
+    expect(classifySubprocessError('rate limit exceeded', '')).toBe('rate_limit');
+  });
+
+  test('classifies auth errors correctly', () => {
+    expect(classifySubprocessError('unauthorized', '')).toBe('auth');
+  });
+
+  test('classifies crash correctly', () => {
+    expect(classifySubprocessError('exited with code 1', '')).toBe('crash');
+  });
+
+  test('returns unknown for unrelated errors', () => {
+    expect(classifySubprocessError('network timeout', '')).toBe('unknown');
+  });
+
+  test('stale_session is checked before crash — overlapping message classifies as stale_session', () => {
+    // A message containing both a crash token and a stale session token should be stale_session
+    expect(classifySubprocessError('exited with code 1: no conversation found', '')).toBe(
+      'stale_session'
+    );
   });
 
   describe('pre-spawn env leak gate', () => {

--- a/packages/core/src/clients/claude.ts
+++ b/packages/core/src/clients/claude.ts
@@ -142,13 +142,18 @@ const SUBPROCESS_CRASH_PATTERNS = [
   'operation aborted',
 ];
 
-function classifySubprocessError(
+/** Patterns indicating the Claude SDK session no longer exists (stale resume ID) */
+export const STALE_SESSION_PATTERNS = ['no conversation found', 'conversation not found'];
+
+/** Exported for testing only */
+export function classifySubprocessError(
   errorMessage: string,
   stderrOutput: string
-): 'rate_limit' | 'auth' | 'crash' | 'unknown' {
+): 'rate_limit' | 'auth' | 'crash' | 'stale_session' | 'unknown' {
   const combined = `${errorMessage} ${stderrOutput}`.toLowerCase();
   if (RATE_LIMIT_PATTERNS.some(p => combined.includes(p))) return 'rate_limit';
   if (AUTH_PATTERNS.some(p => combined.includes(p))) return 'auth';
+  if (STALE_SESSION_PATTERNS.some(p => combined.includes(p))) return 'stale_session'; // checked before crash: stale session is specific and non-retryable, like auth
   if (SUBPROCESS_CRASH_PATTERNS.some(p => combined.includes(p))) return 'crash';
   return 'unknown';
 }
@@ -617,6 +622,15 @@ export class ClaudeClient implements IAssistantClient {
         if (errorClass === 'auth') {
           const enrichedError = new Error(
             `Claude Code auth error: ${err.message}${stderrContext ? ` (${stderrContext})` : ''}`
+          );
+          enrichedError.cause = error;
+          throw enrichedError;
+        }
+
+        // Don't retry stale session errors - the SDK session ID is gone; orchestrator handles reset
+        if (errorClass === 'stale_session') {
+          const enrichedError = new Error(
+            `Claude Code stale session: ${err.message}${stderrContext ? ` (${stderrContext})` : ''}`
           );
           enrichedError.cause = error;
           throw enrichedError;

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -25,6 +25,7 @@ import { formatToolCall } from '@archon/workflows/utils/tool-formatter';
 import { classifyAndFormatError } from '../utils/error-formatter';
 import { toError } from '../utils/error';
 import { getAssistantClient } from '../clients/factory';
+import { STALE_SESSION_PATTERNS } from '../clients/claude';
 import { getArchonHome, getArchonWorkspacesPath } from '@archon/paths';
 import { syncArchonToWorktree } from '../utils/worktree-sync';
 import { syncWorkspace, toRepoPath } from '@archon/git';
@@ -61,6 +62,8 @@ function getLog(): ReturnType<typeof createLogger> {
 const MAX_BATCH_ASSISTANT_CHUNKS = 20;
 /** Max total chunks (assistant + tool) to keep in batch mode */
 const MAX_BATCH_TOTAL_CHUNKS = 200;
+/** Bare commands that Slack users commonly send without a leading slash */
+const SLACK_BARE_COMMANDS = new Set(['reset']);
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -319,6 +322,13 @@ async function dispatchOrchestratorWorkflow(
 
 // ─── Session Helpers ────────────────────────────────────────────────────────
 
+function isStaleSessionError(error: Error): boolean {
+  const msg = error.message.toLowerCase();
+  // Primary: claude.ts re-throws with "Claude Code stale session:" prefix
+  // Fallback: raw SDK pattern match via shared STALE_SESSION_PATTERNS (single source of truth)
+  return msg.includes('stale session') || STALE_SESSION_PATTERNS.some(p => msg.includes(p));
+}
+
 async function tryPersistSessionId(sessionId: string, assistantSessionId: string): Promise<void> {
   try {
     await sessionDb.updateSession(sessionId, assistantSessionId);
@@ -519,8 +529,15 @@ export async function handleMessage(
       conversationId
     );
 
+    // 1b. Normalize bare commands (Slack users often omit the leading slash)
+    const effectiveMessage =
+      platform.getPlatformType() === 'slack' &&
+      SLACK_BARE_COMMANDS.has(message.trim().toLowerCase())
+        ? `/${message.trim().toLowerCase()}`
+        : message;
+
     // 1c. Auto-generate title for untitled conversations (fire-and-forget)
-    if (!conversation.title && !message.startsWith('/')) {
+    if (!conversation.title && !effectiveMessage.startsWith('/')) {
       void generateAndSetTitle(
         conversation.id,
         message,
@@ -645,8 +662,8 @@ export async function handleMessage(
     }
 
     // 2. Check for deterministic commands
-    if (message.startsWith('/')) {
-      const { command } = commandHandler.parseCommand(message);
+    if (effectiveMessage.startsWith('/')) {
+      const { command } = commandHandler.parseCommand(effectiveMessage);
       const deterministicCommands = [
         'help',
         'status',
@@ -663,7 +680,7 @@ export async function handleMessage(
       if (deterministicCommands.includes(command)) {
         if (command === 'register-project') {
           getLog().debug({ command, conversationId }, 'deterministic_command');
-          const result = await handleRegisterProject(message, platform, conversationId);
+          const result = await handleRegisterProject(effectiveMessage, platform, conversationId);
           await platform.sendMessage(conversationId, result);
           return;
         }
@@ -683,7 +700,7 @@ export async function handleMessage(
         }
 
         getLog().debug({ command, conversationId }, 'deterministic_command');
-        const result = await commandHandler.handleCommand(conversation, message);
+        const result = await commandHandler.handleCommand(conversation, effectiveMessage);
         await platform.sendMessage(conversationId, result.message);
 
         if (result.workflow) {
@@ -836,53 +853,77 @@ async function handleStreamMode(
   const allMessages: string[] = [];
   let newSessionId: string | undefined;
   let commandDetected = false;
+  let sessionForQuery = session;
+  let retried = false;
 
-  for await (const msg of aiClient.sendQuery(
-    fullPrompt,
-    cwd,
-    session.assistant_session_id ?? undefined,
-    requestOptions
-  )) {
-    if (msg.type === 'assistant' && msg.content) {
-      if (!commandDetected) {
-        allMessages.push(msg.content);
-        const accumulated = allMessages.join('');
-        // Check for orchestrator commands BEFORE streaming to frontend.
-        // If detected, suppress this chunk and all future chunks — the full
-        // response will be parsed post-loop and the command dispatched there.
-        if (
-          /^\/invoke-workflow\s/m.test(accumulated) ||
-          /^\/register-project\s/m.test(accumulated)
-        ) {
-          commandDetected = true;
-        } else {
-          await platform.sendMessage(conversationId, msg.content);
+  async function runStreamQuery(): Promise<void> {
+    for await (const msg of aiClient.sendQuery(
+      fullPrompt,
+      cwd,
+      sessionForQuery.assistant_session_id ?? undefined,
+      requestOptions
+    )) {
+      if (msg.type === 'assistant' && msg.content) {
+        if (!commandDetected) {
+          allMessages.push(msg.content);
+          const accumulated = allMessages.join('');
+          // Check for orchestrator commands BEFORE streaming to frontend.
+          // If detected, suppress this chunk and all future chunks — the full
+          // response will be parsed post-loop and the command dispatched there.
+          if (
+            /^\/invoke-workflow\s/m.test(accumulated) ||
+            /^\/register-project\s/m.test(accumulated)
+          ) {
+            commandDetected = true;
+          } else {
+            await platform.sendMessage(conversationId, msg.content);
+          }
         }
-      }
-    } else if (msg.type === 'tool' && msg.toolName) {
-      if (!commandDetected) {
-        const toolMessage = formatToolCall(msg.toolName, msg.toolInput);
-        await platform.sendMessage(conversationId, toolMessage, {
-          category: 'tool_call_formatted',
-        });
-        if (platform.sendStructuredEvent) {
+      } else if (msg.type === 'tool' && msg.toolName) {
+        if (!commandDetected) {
+          const toolMessage = formatToolCall(msg.toolName, msg.toolInput);
+          await platform.sendMessage(conversationId, toolMessage, {
+            category: 'tool_call_formatted',
+          });
+          if (platform.sendStructuredEvent) {
+            await platform.sendStructuredEvent(conversationId, msg);
+          }
+        }
+      } else if (msg.type === 'tool_result' && msg.toolName) {
+        if (!commandDetected && platform.sendStructuredEvent) {
           await platform.sendStructuredEvent(conversationId, msg);
         }
-      }
-    } else if (msg.type === 'tool_result' && msg.toolName) {
-      if (!commandDetected && platform.sendStructuredEvent) {
-        await platform.sendStructuredEvent(conversationId, msg);
-      }
-    } else if (msg.type === 'result' && msg.sessionId) {
-      newSessionId = msg.sessionId;
-      if (!commandDetected && platform.sendStructuredEvent) {
-        await platform.sendStructuredEvent(conversationId, msg);
+      } else if (msg.type === 'result' && msg.sessionId) {
+        newSessionId = msg.sessionId;
+        if (!commandDetected && platform.sendStructuredEvent) {
+          await platform.sendStructuredEvent(conversationId, msg);
+        }
       }
     }
   }
 
+  try {
+    await runStreamQuery();
+  } catch (error) {
+    const err = toError(error);
+    if (!retried && isStaleSessionError(err) && sessionForQuery.assistant_session_id) {
+      retried = true;
+      getLog().warn({ conversationId, sessionId: sessionForQuery.id }, 'stale_session_auto_reset');
+      sessionForQuery = await sessionDb.transitionSession(conversationId, 'stale-session-cleared', {
+        ai_assistant_type: conversation.ai_assistant_type,
+      });
+      await platform.sendMessage(conversationId, '⚠️ Previous session expired — starting fresh.');
+      newSessionId = undefined; // Clear any partial state from failed attempt before retry
+      allMessages.length = 0;
+      commandDetected = false;
+      await runStreamQuery();
+    } else {
+      throw err;
+    }
+  }
+
   if (newSessionId) {
-    await tryPersistSessionId(session.id, newSessionId);
+    await tryPersistSessionId(sessionForQuery.id, newSessionId);
   }
 
   if (allMessages.length === 0) {
@@ -955,48 +996,75 @@ async function handleBatchMode(
   let totalChunksTruncated = false;
   let newSessionId: string | undefined;
   let commandDetected = false;
+  let sessionForQuery = session;
+  let retried = false;
 
-  for await (const msg of aiClient.sendQuery(
-    fullPrompt,
-    cwd,
-    session.assistant_session_id ?? undefined,
-    requestOptions
-  )) {
-    if (msg.type === 'assistant' && msg.content) {
-      if (!commandDetected) {
-        assistantMessages.push(msg.content);
-        allChunks.push({ type: 'assistant', content: msg.content });
+  async function runBatchQuery(): Promise<void> {
+    for await (const msg of aiClient.sendQuery(
+      fullPrompt,
+      cwd,
+      sessionForQuery.assistant_session_id ?? undefined,
+      requestOptions
+    )) {
+      if (msg.type === 'assistant' && msg.content) {
+        if (!commandDetected) {
+          assistantMessages.push(msg.content);
+          allChunks.push({ type: 'assistant', content: msg.content });
 
-        if (assistantMessages.length > MAX_BATCH_ASSISTANT_CHUNKS) {
-          assistantMessages.shift();
-          assistantChunksTruncated = true;
+          if (assistantMessages.length > MAX_BATCH_ASSISTANT_CHUNKS) {
+            assistantMessages.shift();
+            assistantChunksTruncated = true;
+          }
+          const accumulated = assistantMessages.join('');
+          if (
+            /^\/invoke-workflow\s/m.test(accumulated) ||
+            /^\/register-project\s/m.test(accumulated)
+          ) {
+            commandDetected = true;
+          }
         }
-        const accumulated = assistantMessages.join('');
-        if (
-          /^\/invoke-workflow\s/m.test(accumulated) ||
-          /^\/register-project\s/m.test(accumulated)
-        ) {
-          commandDetected = true;
+      } else if (msg.type === 'tool' && msg.toolName) {
+        if (!commandDetected) {
+          const toolMessage = formatToolCall(msg.toolName, msg.toolInput);
+          allChunks.push({ type: 'tool', content: toolMessage });
+          getLog().debug({ toolName: msg.toolName }, 'tool_call');
         }
+      } else if (msg.type === 'result' && msg.sessionId) {
+        newSessionId = msg.sessionId;
       }
-    } else if (msg.type === 'tool' && msg.toolName) {
-      if (!commandDetected) {
-        const toolMessage = formatToolCall(msg.toolName, msg.toolInput);
-        allChunks.push({ type: 'tool', content: toolMessage });
-        getLog().debug({ toolName: msg.toolName }, 'tool_call');
+
+      if (!commandDetected && allChunks.length > MAX_BATCH_TOTAL_CHUNKS) {
+        allChunks.shift();
+        totalChunksTruncated = true;
       }
-    } else if (msg.type === 'result' && msg.sessionId) {
-      newSessionId = msg.sessionId;
     }
+  }
 
-    if (!commandDetected && allChunks.length > MAX_BATCH_TOTAL_CHUNKS) {
-      allChunks.shift();
-      totalChunksTruncated = true;
+  try {
+    await runBatchQuery();
+  } catch (error) {
+    const err = toError(error);
+    if (!retried && isStaleSessionError(err) && sessionForQuery.assistant_session_id) {
+      retried = true;
+      getLog().warn({ conversationId, sessionId: sessionForQuery.id }, 'stale_session_auto_reset');
+      sessionForQuery = await sessionDb.transitionSession(conversationId, 'stale-session-cleared', {
+        ai_assistant_type: conversation.ai_assistant_type,
+      });
+      await platform.sendMessage(conversationId, '⚠️ Previous session expired — starting fresh.');
+      newSessionId = undefined; // Clear any partial state from failed attempt before retry
+      allChunks.length = 0;
+      assistantMessages.length = 0;
+      assistantChunksTruncated = false;
+      totalChunksTruncated = false;
+      commandDetected = false;
+      await runBatchQuery();
+    } else {
+      throw err;
     }
   }
 
   if (newSessionId) {
-    await tryPersistSessionId(session.id, newSessionId);
+    await tryPersistSessionId(sessionForQuery.id, newSessionId);
   }
 
   if (assistantChunksTruncated || totalChunksTruncated) {

--- a/packages/core/src/orchestrator/orchestrator.test.ts
+++ b/packages/core/src/orchestrator/orchestrator.test.ts
@@ -170,6 +170,11 @@ mock.module('@archon/workflows/utils/tool-formatter', () => ({
   formatToolCall: mock((toolName: string, _toolInput: unknown) => `🔧 ${toolName.toUpperCase()}`),
 }));
 
+// claude client constants mock (needed because orchestrator-agent imports STALE_SESSION_PATTERNS)
+mock.module('../clients/claude', () => ({
+  STALE_SESSION_PATTERNS: ['no conversation found', 'conversation not found'],
+}));
+
 // fs mock for existsSync
 const mockExistsSync = mock(() => true);
 mock.module('fs', () => ({
@@ -1491,6 +1496,138 @@ describe('orchestrator-agent handleMessage', () => {
       await handleMessage(platform, 'chat-456', 'Hello world');
 
       expect(mockGenerateAndSetTitle).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── Stale Session Auto-Reset ──────────────────────────────────────────
+
+  for (const mode of ['stream', 'batch'] as const) {
+    describe(`stale session recovery (${mode} mode)`, () => {
+      beforeEach(() => {
+        platform.getStreamingMode.mockReturnValue(mode);
+      });
+
+      test('resets session and retries once on stale session error', async () => {
+        // Session with existing assistant_session_id so stale-session guard fires
+        const staleSession: Session = { ...mockSession, assistant_session_id: 'old-session-id' };
+        const freshSession: Session = {
+          ...mockSession,
+          id: 'session-fresh',
+          assistant_session_id: 'new-session-id',
+        };
+        mockGetActiveSession.mockResolvedValue(staleSession);
+        mockTransitionSession.mockResolvedValue(freshSession);
+
+        let callCount = 0;
+        mockClient.sendQuery.mockImplementation(async function* () {
+          callCount += 1;
+          if (callCount === 1) {
+            throw new Error('Claude Code stale session: No conversation found');
+          }
+          yield { type: 'result', sessionId: 'new-session-id' };
+        });
+        mockGetAssistantClient.mockReturnValue(mockClient);
+
+        await handleMessage(platform, 'chat-456', 'hello');
+
+        expect(mockClient.sendQuery).toHaveBeenCalledTimes(2);
+        // conversationId is the platform conversation ID ('chat-456'), not the DB conversation ID
+        expect(mockTransitionSession).toHaveBeenCalledWith(
+          'chat-456',
+          'stale-session-cleared',
+          expect.any(Object)
+        );
+        expect(platform.sendMessage).toHaveBeenCalledWith(
+          'chat-456',
+          expect.stringContaining('session expired')
+        );
+        // Verify the retry uses the fresh session ID, not the stale one
+        const calls = mockClient.sendQuery.mock.calls;
+        expect(calls[0][2]).toBe('old-session-id'); // first call: stale session
+        expect(calls[1][2]).toBe('new-session-id'); // retry: fresh session
+      });
+
+      test('does NOT retry a third time if the retry also fails', async () => {
+        // handleMessage catches all errors and sends them as messages — no rejection
+        const staleSession: Session = { ...mockSession, assistant_session_id: 'old-session-id' };
+        mockGetActiveSession.mockResolvedValue(staleSession);
+        mockTransitionSession.mockResolvedValue({
+          ...mockSession,
+          assistant_session_id: 'mid-session',
+        });
+
+        mockClient.sendQuery.mockImplementation(async function* () {
+          throw new Error('Claude Code stale session: No conversation found');
+        });
+        mockGetAssistantClient.mockReturnValue(mockClient);
+
+        // handleMessage swallows the error and sends it as a message
+        await handleMessage(platform, 'chat-456', 'hello');
+        // sendQuery called twice: original attempt + one retry (retried guard prevents a third)
+        expect(mockClient.sendQuery).toHaveBeenCalledTimes(2);
+      });
+
+      test('skips stale-session reset when session has no assistant_session_id', async () => {
+        // Session with no assistant_session_id — guard should NOT fire
+        const newSession: Session = { ...mockSession, assistant_session_id: null };
+        mockGetActiveSession.mockResolvedValue(newSession);
+
+        mockClient.sendQuery.mockImplementation(async function* () {
+          throw new Error('Claude Code stale session: No conversation found');
+        });
+        mockGetAssistantClient.mockReturnValue(mockClient);
+
+        // handleMessage swallows the error; no retry attempted
+        await handleMessage(platform, 'chat-456', 'hello');
+        // Only called once — no retry when session has no assistant_session_id
+        expect(mockClient.sendQuery).toHaveBeenCalledTimes(1);
+        expect(mockTransitionSession).not.toHaveBeenCalledWith(
+          expect.anything(),
+          'stale-session-cleared',
+          expect.anything()
+        );
+      });
+    });
+  }
+
+  // ─── Bare Command Normalization ────────────────────────────────────────
+
+  describe('bare command normalization', () => {
+    test('treats bare "reset" as "/reset" command', async () => {
+      mockHandleCommand.mockResolvedValue({
+        message: 'Session cleared',
+        modified: false,
+        success: true,
+      });
+
+      await handleMessage(platform, 'chat-456', 'reset');
+
+      expect(mockParseCommand).toHaveBeenCalledWith('/reset');
+      expect(platform.sendMessage).toHaveBeenCalledWith('chat-456', 'Session cleared');
+    });
+
+    test('treats "  RESET  " (padded + uppercase) as "/reset"', async () => {
+      mockHandleCommand.mockResolvedValue({
+        message: 'Session cleared',
+        modified: false,
+        success: true,
+      });
+
+      await handleMessage(platform, 'chat-456', '  RESET  ');
+
+      expect(mockParseCommand).toHaveBeenCalledWith('/reset');
+    });
+
+    test('does NOT treat "resetall" as a bare command', async () => {
+      mockClient.sendQuery.mockImplementation(async function* () {
+        yield { type: 'result', sessionId: 'session-id' };
+      });
+
+      await handleMessage(platform, 'chat-456', 'resetall');
+
+      // Should NOT parse it as a command — goes to AI instead
+      expect(mockParseCommand).not.toHaveBeenCalledWith('/resetall');
+      expect(mockGetAssistantClient).toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/state/session-transitions.ts
+++ b/packages/core/src/state/session-transitions.ts
@@ -13,7 +13,8 @@ export type TransitionTrigger =
   | 'isolation-changed' // Working directory/worktree changed
   | 'reset-requested' // User requested /reset
   | 'worktree-removed' // Worktree manually removed
-  | 'conversation-closed'; // Platform conversation closed (issue/PR closed)
+  | 'conversation-closed' // Platform conversation closed (issue/PR closed)
+  | 'stale-session-cleared'; // Auto-reset on SDK stale session error (no conversation found)
 
 /**
  * Behavior category for each trigger.
@@ -31,6 +32,7 @@ const TRIGGER_BEHAVIOR: Record<TransitionTrigger, 'creates' | 'deactivates' | 'n
   'reset-requested': 'deactivates',
   'worktree-removed': 'deactivates',
   'conversation-closed': 'deactivates',
+  'stale-session-cleared': 'deactivates', // Deactivate only; next message creates new session
 };
 
 /**


### PR DESCRIPTION
### Summary

When the Claude Code SDK rejects a resume attempt with `No conversation found` or `conversation not found` (stale session ID), the orchestrator currently surfaces this as a retryable `crash` class error and eventually propagates it to the user, who then has to manually `/reset` and retry their message. This PR makes the orchestrator detect the stale-session error class, auto-reset the session transparently, and retry the query once with a fresh session ID — so the user never sees the interruption.

Also accepts bare `reset` without the leading slash on Slack. Slack intercepts `/reset` as its own built-in command, so users on Slack couldn't use the text slash-command to reset their Archon session.

### Motivation

Running Archon as a long-lived personal assistant (heartbeat + Slack DM + multi-day conversations), the SDK occasionally loses session state — the `assistant_session_id` becomes stale, the next query fails, and the conversation is effectively dead until the user notices and manually resets. Auto-reset turns a visible failure into a 0.5s hiccup.

### Changes

**`packages/core/src/clients/claude.ts`**
- Export `STALE_SESSION_PATTERNS` as a single source of truth
- Extend `classifySubprocessError()` to include `'stale_session'`
- Check stale_session before crash (specific wins over generic)

**`packages/core/src/state/session-transitions.ts`**
- New `'stale-session-cleared'` trigger

**`packages/core/src/orchestrator/orchestrator-agent.ts`**
- `isStaleSessionError()` helper using shared patterns
- Stream + batch handlers wrap AI-query in retry-once on stale session
- State cleared before retry (no partial content bleed)
- `SLACK_BARE_COMMANDS` normalization (Slack-only)

### Tests

- `classifySubprocessError` tests for stale-session patterns (case-insensitive, both paths)
- Priority: overlapping crash + stale_session → stale_session wins
- Stream + batch: successful reset + retry, no-third-retry guard, skip on fresh session
- Bare command normalization: `reset` → `/reset`, Slack-only

### Scope

- Claude only (not codex)
- One retry max
- Bare-command normalization scoped to Slack

Carried forward from `dynamous-community/remote-coding-agent @ v0.2.12` (commit 229217cf). Rebased onto latest main. Happy to split into two PRs if preferred.

### Test plan

- [ ] `bun run type-check` — clean
- [ ] `bun test packages/core/src/clients/claude.test.ts`
- [ ] `bun test packages/core/src/orchestrator/orchestrator.test.ts`
- [ ] Manual: trigger stale-session error → verify auto-recovery
- [ ] Manual: bare `reset` on Slack → treated as `/reset`