### PR TITLE
fix: pass parentConversationId for interactive workflow resume

### DIFF
--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -274,7 +274,10 @@ async function dispatchOrchestratorWorkflow(
         workflow,
         userMessage,
         conversation.id,
-        codebase.id
+        codebase.id,
+        undefined, // issueContext
+        undefined, // isolationContext
+        conversation.id // parentConversationId — needed for resume lookup
       );
     } else if (workflow.interactive) {
       // Interactive workflows run in foreground so output stays in the user's conversation
@@ -286,7 +289,10 @@ async function dispatchOrchestratorWorkflow(
         workflow,
         userMessage,
         conversation.id,
-        codebase.id
+        codebase.id,
+        undefined, // issueContext
+        undefined, // isolationContext
+        conversation.id // parentConversationId — needed for resume lookup after approval gates
       );
     } else {
       await dispatchBackgroundWorkflow(


### PR DESCRIPTION
## Summary
- Interactive and resumable-run workflow dispatches in `dispatchOrchestratorWorkflow` were missing the `parentConversationId` argument to `executeWorkflow`, storing NULL in the DB
- This broke `findResumableRunByParentConversation` after approval gates — the SQL `WHERE parent_conversation_id = $2` never matches NULL, so interactive workflows could never resume after user approval
- Fix: pass `conversation.id` as `parentConversationId` for both the resume and interactive branches

## Reproduction
1. Create a workflow with `interactive: true` and an interactive loop gate (e.g., `plan-gate` with `interactive: true` + `gate_message`)
2. Run it from the web UI — it pauses at the gate
3. Approve (via button or typing in chat)
4. The workflow never resumes — no events written after `approval_received`

Root cause: `parent_conversation_id` is NULL on the run, so `findResumableRunByParentConversation` returns no match. Background workflows set this field via `dispatchBackgroundWorkflow` (pre-created run), but interactive/foreground workflows skipped it.

## Test plan
- [x] Type-check passes (`bun run type-check`)
- [x] Lint passes (`bun run lint`)
- [x] All 89 orchestrator-agent tests pass
- [ ] Manual: run an interactive workflow from web UI, approve at gate, verify it resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation resumption during workflow execution by properly passing conversation context through approval gate workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->