### PR TITLE
fix: Windows HOME resolution and MCP plugin warning suppression

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -6,6 +6,7 @@
  */
 import { describe, it, expect } from 'bun:test';
 import { parseArgs } from 'util';
+import { getArchonHome } from '@archon/paths';
 import * as git from '@archon/git';
 
 // Test the argument parsing logic used in cli.ts
@@ -237,7 +238,7 @@ describe('CLI env isolation', () => {
     process.env.TEST_ARCHON_OVERRIDE = 'from-cwd-env';
 
     // Write a temporary env content and load with override
-    const globalEnvPath = resolve(process.env.HOME ?? '~', '.archon', '.env');
+    const globalEnvPath = resolve(getArchonHome(), '.env');
     if (existsSync(globalEnvPath)) {
       const result = config({ path: globalEnvPath, override: true });
       // If ~/.archon/.env exists and has DATABASE_URL, it should override

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -10,6 +10,7 @@
 // Must be the very first import — strips Bun-auto-loaded CWD .env keys before
 // any module reads process.env at init time (e.g. @archon/paths/logger reads LOG_LEVEL).
 import '@archon/paths/strip-cwd-env-boot';
+import { getArchonHome } from '@archon/paths';
 import { parseArgs } from 'util';
 import { config } from 'dotenv';
 import { resolve } from 'path';
@@ -19,7 +20,7 @@ import { existsSync } from 'fs';
 // over shell-inherited env vars (e.g. PORT, LOG_LEVEL from shell profile).
 // CWD .env keys are already gone (stripCwdEnv above), so override only
 // affects shell-inherited values, which is the intended behavior.
-const globalEnvPath = resolve(process.env.HOME ?? '~', '.archon', '.env');
+const globalEnvPath = resolve(getArchonHome(), '.env');
 if (existsSync(globalEnvPath)) {
   const result = config({ path: globalEnvPath, override: true });
   if (result.error) {

--- a/packages/core/src/providers/claude.ts
+++ b/packages/core/src/providers/claude.ts
@@ -385,6 +385,10 @@ export class ClaudeProvider implements IAgentProvider {
         allowDangerouslySkipPermissions: true,
         systemPrompt: requestOptions?.systemPrompt ?? { type: 'preset', preset: 'claude_code' },
         settingSources: requestOptions?.settingSources ?? ['project'],
+        // Disable user plugins in the subprocess — Archon manages its own MCP servers
+        // via the mcpServers option. User plugins (e.g., telegram) can fail to connect
+        // in the headless subprocess and produce spurious warnings.
+        settings: { enabledPlugins: {} },
         // Merge user-provided hooks with our PostToolUse capture hook
         hooks: {
           ...(requestOptions?.hooks ?? {}),

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -13,7 +13,7 @@ import '@archon/paths/strip-cwd-env-boot';
 import { config } from 'dotenv';
 import { resolve } from 'path';
 import { existsSync } from 'fs';
-import { BUNDLED_IS_BINARY } from '@archon/paths';
+import { BUNDLED_IS_BINARY, getArchonHome } from '@archon/paths';
 
 // In dev/source mode, load the repo root .env (platform tokens, API keys, etc.)
 // import.meta.dir is frozen at build time, so skip in compiled binaries.
@@ -31,7 +31,7 @@ if (envPath) {
 // Load ~/.archon/.env with override — Archon's config always wins over any
 // Bun-auto-loaded CWD vars. In binary mode this is the single source of truth.
 // In dev mode it overrides CWD vars for keys like DATABASE_URL.
-const globalEnvPath = resolve(process.env.HOME ?? '~', '.archon', '.env');
+const globalEnvPath = resolve(getArchonHome(), '.env');
 if (existsSync(globalEnvPath)) {
   const globalResult = config({ path: globalEnvPath, override: true });
   if (globalResult.error) {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -822,6 +822,11 @@ async function executeNodeInternal(
   const aiClient = deps.getAgentProvider(provider);
   const streamingMode = platform.getStreamingMode();
 
+  // Track workflow-configured MCP server names to distinguish from user plugin MCP servers.
+  // User plugins (e.g., telegram) can fail to connect in headless subprocesses — those
+  // failures are non-fatal noise and should not be surfaced to the user.
+  const workflowMcpNames = new Set(Object.keys(nodeOptions?.mcpServers ?? {}));
+
   let nodeOutputText = ''; // Always accumulate regardless of streaming mode
   let structuredOutput: unknown;
   let newSessionId: string | undefined;
@@ -1026,22 +1031,48 @@ async function executeNodeInternal(
         }
         break; // Result is the "I'm done" signal — don't wait for subprocess to exit
       } else if (msg.type === 'system' && msg.content) {
-        // Surface MCP connection failures to the user
+        // MCP connection failures — only surface for workflow-configured servers,
+        // not for user plugins (e.g., telegram) that fail in headless subprocesses.
         if (msg.content.startsWith('MCP server connection failed:')) {
-          getLog().warn(
-            { nodeId: node.id, mcpStatus: msg.content },
-            'dag.mcp_server_connection_failed'
-          );
-          const delivered = await safeSendMessage(
-            platform,
-            conversationId,
-            msg.content,
-            nodeContext
-          );
-          if (!delivered) {
-            getLog().error(
-              { nodeId: node.id, mcpStatus: msg.content, workflowRunId: workflowRun.id },
-              'dag.mcp_connection_failure_delivery_failed'
+          // Parse failed entries: "MCP server connection failed: name1 (status1), name2 (status2)"
+          const failedEntries = msg.content
+            .slice('MCP server connection failed: '.length)
+            .split(', ')
+            .map(entry => entry.trim())
+            .filter(Boolean);
+          const workflowFailures = failedEntries.filter(entry => {
+            const name = entry.split(' (')[0];
+            return workflowMcpNames.has(name);
+          });
+
+          if (workflowFailures.length > 0) {
+            const workflowMsg = `MCP server connection failed: ${workflowFailures.join(', ')}`;
+            getLog().warn(
+              { nodeId: node.id, mcpStatus: workflowMsg },
+              'dag.mcp_server_connection_failed'
+            );
+            const delivered = await safeSendMessage(
+              platform,
+              conversationId,
+              workflowMsg,
+              nodeContext
+            );
+            if (!delivered) {
+              getLog().error(
+                { nodeId: node.id, mcpStatus: workflowMsg, workflowRunId: workflowRun.id },
+                'dag.mcp_connection_failure_delivery_failed'
+              );
+            }
+          }
+          // User-plugin MCP failures: log at debug, don't surface to user
+          const pluginFailures = failedEntries.filter(entry => {
+            const name = entry.split(' (')[0];
+            return !workflowMcpNames.has(name);
+          });
+          if (pluginFailures.length > 0) {
+            getLog().debug(
+              { nodeId: node.id, mcpStatus: pluginFailures.join(', ') },
+              'dag.mcp_plugin_connection_failed'
             );
           }
         } else {


### PR DESCRIPTION
## Summary
- Fix Windows path resolution bug where `HOME` environment variable is unset, causing CLI and server to fail loading `~/.archon/.env` configuration
- Suppress non-fatal MCP connection failures from user-level plugins (e.g., telegram) in headless workflow subprocesses — only surface warnings for workflow-configured MCP servers

## Changes

### Windows HOME Resolution (`@archon/cli`, `@archon/server`)
- Replace `process.env.HOME` with `getArchonHome()` from `@archon/paths` for cross-platform config path resolution in both CLI and server entry points
- On Windows, `HOME` is often unset — `getArchonHome()` correctly falls back to `USERPROFILE` or `HOMEDRIVE+HOMEPATH`

### MCP Plugin Warning Suppression (`@archon/workflows`, `@archon/core`)
- Track workflow-configured MCP server names in the DAG executor
- Filter MCP connection failure messages to only surface warnings for servers explicitly configured via `mcp:` in workflow YAML
- User-level plugin MCP failures (e.g., telegram) are logged at `debug` level instead of `warn` and not sent to the user
- Pass `settings: { enabledPlugins: {} }` to Claude Agent SDK subprocess to attempt disabling user plugins

## Test plan
- [x] Verified on Windows 11 where `HOME` is unset — CLI and server now correctly load `~/.archon/.env`
- [x] Verified `archon workflow run archon-assist "Say hello"` completes without telegram MCP warning
- [x] TypeScript type-check passes for all packages
- [x] ESLint + Prettier pass (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP server connection error handling by distinguishing between workflow-level and plugin-level failures; only workflow failures are reported to users, while plugin failures are logged internally.

* **New Features**
  * Claude agent subprocess now exclusively uses explicitly configured MCP servers for enhanced predictability and control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->