### PR TITLE
fix: pass globalSearchPath to command handler workflow discovery

### DIFF
--- a/packages/core/src/handlers/command-handler.ts
+++ b/packages/core/src/handlers/command-handler.ts
@@ -16,7 +16,7 @@ import {
   cleanupStaleWorktrees,
   getWorktreeStatusBreakdown,
 } from '../services/cleanup-service';
-import { getArchonWorkspacesPath } from '@archon/paths';
+import { getArchonWorkspacesPath, getArchonHome } from '@archon/paths';
 import { loadConfig } from '../config/config-loader';
 import { discoverWorkflowsWithConfig } from '@archon/workflows/workflow-discovery';
 import { resolveWorkflowName } from '@archon/workflows/router';
@@ -563,7 +563,9 @@ async function handleWorkflowCommand(
       let workflowEntries: readonly WorkflowWithSource[];
       let errors: readonly WorkflowLoadError[];
       try {
-        const result = await discoverWorkflowsWithConfig(workflowCwd, loadConfig);
+        const result = await discoverWorkflowsWithConfig(workflowCwd, loadConfig, {
+          globalSearchPath: getArchonHome(),
+        });
         workflowEntries = result.workflows;
         errors = result.errors;
       } catch (error) {
@@ -609,7 +611,9 @@ async function handleWorkflowCommand(
     case 'reload': {
       try {
         const { workflows: reloadedWorkflows, errors: reloadErrors } =
-          await discoverWorkflowsWithConfig(workflowCwd, loadConfig);
+          await discoverWorkflowsWithConfig(workflowCwd, loadConfig, {
+            globalSearchPath: getArchonHome(),
+          });
         let msg = `Discovered ${String(reloadedWorkflows.length)} workflow(s).`;
         if (reloadErrors.length > 0) {
           msg += `\n\n**${String(reloadErrors.length)} failed to load:**\n`;
@@ -804,7 +808,9 @@ async function handleWorkflowCommand(
       let workflowEntries: readonly WorkflowWithSource[];
       let loadErrors: readonly WorkflowLoadError[];
       try {
-        const result = await discoverWorkflowsWithConfig(workflowCwd, loadConfig);
+        const result = await discoverWorkflowsWithConfig(workflowCwd, loadConfig, {
+          globalSearchPath: getArchonHome(),
+        });
         workflowEntries = result.workflows;
         loadErrors = result.errors;
       } catch (error) {

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -1767,7 +1767,9 @@ export function registerApiRoutes(
         return c.json({ workflows: [] });
       }
 
-      const result = await discoverWorkflowsWithConfig(workingDir, loadConfig);
+      const result = await discoverWorkflowsWithConfig(workingDir, loadConfig, {
+        globalSearchPath: getArchonHome(),
+      });
       return c.json({
         workflows: result.workflows.map(ws => ({ workflow: ws.workflow, source: ws.source })),
         errors: result.errors.length > 0 ? result.errors : undefined,


### PR DESCRIPTION
## Problem

The command handler (`packages/core/src/handlers/command-handler.ts`) calls `discoverWorkflowsWithConfig` without `globalSearchPath`. This means workflows in `~/.archon/.archon/workflows/` are invisible to webhook-triggered `/workflow run` and `/workflow list` commands.

The CLI (`cli.ts:125`) and orchestrator (`orchestrator-agent.ts:385`) already pass `globalSearchPath: getArchonHome()`. The command handler was the only caller that didn't.

**Symptom**: `@archon /workflow run my-custom-workflow` posted as a GitHub comment returns "Workflow not found", even though `archon workflow run my-custom-workflow` via CLI works.

## Fix

Pass `{ globalSearchPath: getArchonHome() }` to all three `discoverWorkflowsWithConfig` calls in `command-handler.ts` (`list`, `reload`, `run`).

## Changes

- Import `getArchonHome` from `@archon/paths` (already exported)
- 3 call sites updated (lines 566, 612, 807)

4 lines changed.