### PR TITLE
feat(workflows): symmetric fallback chain — workspace + global tiers for scripts/commands

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -10,7 +10,7 @@ import {
 } from '@archon/core';
 import { WORKFLOW_EVENT_TYPES, type WorkflowEventType } from '@archon/workflows/store';
 import { configureIsolation, getIsolationProvider } from '@archon/isolation';
-import { createLogger, getArchonHome } from '@archon/paths';
+import { createLogger, getArchonHome, getProjectArchonDir } from '@archon/paths';
 import { createWorkflowDeps } from '@archon/core/workflows/store-adapter';
 import { discoverWorkflowsWithConfig } from '@archon/workflows/workflow-discovery';
 import { resolveWorkflowName } from '@archon/workflows/router';
@@ -116,13 +116,26 @@ function renderWorkflowEvent(event: WorkflowEmitterEvent, verbose: boolean): voi
 }
 
 /**
+ * Compute the per-project, per-user Archon config dir for a cwd, or undefined
+ * when the cwd has no recognizable origin remote. Silently skips the workspace
+ * tier in that case — two-tier behavior is preserved.
+ */
+async function resolveWorkspaceArchonDir(cwd: string): Promise<string | undefined> {
+  const ownerRepo = await git.parseOwnerRepoFromGitRemote(cwd);
+  if (!ownerRepo) return undefined;
+  return getProjectArchonDir(ownerRepo.owner, ownerRepo.repo);
+}
+
+/**
  * Load workflows from cwd with standardized error handling.
  * Returns the WorkflowLoadResult with both workflows and errors.
  */
 async function loadWorkflows(cwd: string): Promise<WorkflowLoadResult> {
   try {
+    const workspaceSearchPath = await resolveWorkspaceArchonDir(cwd);
     return await discoverWorkflowsWithConfig(cwd, loadConfig, {
       globalSearchPath: getArchonHome(),
+      ...(workspaceSearchPath ? { workspaceSearchPath } : {}),
     });
   } catch (error) {
     const err = error as Error;

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -10,7 +10,7 @@ import {
 } from '@archon/core';
 import { WORKFLOW_EVENT_TYPES, type WorkflowEventType } from '@archon/workflows/store';
 import { configureIsolation, getIsolationProvider } from '@archon/isolation';
-import { createLogger, getArchonHome, getProjectArchonDir } from '@archon/paths';
+import { createLogger, getArchonHome, getProjectRoot } from '@archon/paths';
 import { createWorkflowDeps } from '@archon/core/workflows/store-adapter';
 import { discoverWorkflowsWithConfig } from '@archon/workflows/workflow-discovery';
 import { resolveWorkflowName } from '@archon/workflows/router';
@@ -116,14 +116,17 @@ function renderWorkflowEvent(event: WorkflowEmitterEvent, verbose: boolean): voi
 }
 
 /**
- * Compute the per-project, per-user Archon config dir for a cwd, or undefined
- * when the cwd has no recognizable origin remote. Silently skips the workspace
- * tier in that case — two-tier behavior is preserved.
+ * Compute the per-project workspace search path (~/.archon/workspaces/<owner>/<repo>)
+ * for a cwd, or undefined when the cwd has no recognizable origin remote.
+ * Silently skips the workspace tier in that case — two-tier behavior preserved.
+ *
+ * The returned path is the PROJECT ROOT, not the `.archon` subdir — matching
+ * how `globalSearchPath` works. Callers append `.archon/{workflows,commands,scripts}`.
  */
-async function resolveWorkspaceArchonDir(cwd: string): Promise<string | undefined> {
+async function resolveWorkspaceSearchPath(cwd: string): Promise<string | undefined> {
   const ownerRepo = await git.parseOwnerRepoFromGitRemote(cwd);
   if (!ownerRepo) return undefined;
-  return getProjectArchonDir(ownerRepo.owner, ownerRepo.repo);
+  return getProjectRoot(ownerRepo.owner, ownerRepo.repo);
 }
 
 /**
@@ -132,7 +135,7 @@ async function resolveWorkspaceArchonDir(cwd: string): Promise<string | undefine
  */
 async function loadWorkflows(cwd: string): Promise<WorkflowLoadResult> {
   try {
-    const workspaceSearchPath = await resolveWorkspaceArchonDir(cwd);
+    const workspaceSearchPath = await resolveWorkspaceSearchPath(cwd);
     return await discoverWorkflowsWithConfig(cwd, loadConfig, {
       globalSearchPath: getArchonHome(),
       ...(workspaceSearchPath ? { workspaceSearchPath } : {}),

--- a/packages/core/src/handlers/clone.ts
+++ b/packages/core/src/handlers/clone.ts
@@ -6,7 +6,7 @@ import { access, rm } from 'fs/promises';
 import { join, basename, resolve } from 'path';
 import * as codebaseDb from '../db/codebases';
 import { sanitizeError } from '../utils/credential-sanitizer';
-import { execFileAsync } from '@archon/git';
+import { execFileAsync, parseOwnerRepoFromRemoteUrl } from '@archon/git';
 import {
   expandTilde,
   getCommandFolderSearchPaths,
@@ -385,21 +385,14 @@ export async function registerRepository(
   // Extract repo name from directory name
   const repoName = basename(localPath);
 
-  // Try to build owner/repo name from remote URL
+  // Try to build owner/repo name from remote URL via the shared parser
   let name = repoName;
   let ownerName = '_local';
   if (remoteUrl) {
-    const cleaned = remoteUrl.replace(/\.git$/, '').replace(/\/+$/, '');
-    let workingRemote = cleaned;
-    if (cleaned.startsWith('git@github.com:')) {
-      workingRemote = cleaned.replace('git@github.com:', 'https://github.com/');
-    }
-    const parts = workingRemote.split('/');
-    const r = parts.pop();
-    const o = parts.pop();
-    if (o && r) {
-      name = `${o}/${r}`;
-      ownerName = o;
+    const parsed = parseOwnerRepoFromRemoteUrl(remoteUrl);
+    if (parsed) {
+      name = `${parsed.owner}/${parsed.repo}`;
+      ownerName = parsed.owner;
     }
   }
 

--- a/packages/git/src/git.test.ts
+++ b/packages/git/src/git.test.ts
@@ -1894,4 +1894,102 @@ branch refs/heads/feature/auth
       );
     });
   });
+
+  describe('parseOwnerRepoFromRemoteUrl (pure)', () => {
+    test('parses HTTPS GitHub URL', () => {
+      expect(git.parseOwnerRepoFromRemoteUrl('https://github.com/owner/repo')).toEqual({
+        owner: 'owner',
+        repo: 'repo',
+      });
+    });
+
+    test('parses HTTPS GitHub URL with trailing .git', () => {
+      expect(git.parseOwnerRepoFromRemoteUrl('https://github.com/owner/repo.git')).toEqual({
+        owner: 'owner',
+        repo: 'repo',
+      });
+    });
+
+    test('parses SSH GitHub URL', () => {
+      expect(git.parseOwnerRepoFromRemoteUrl('git@github.com:owner/repo.git')).toEqual({
+        owner: 'owner',
+        repo: 'repo',
+      });
+    });
+
+    test('parses SSH URL from non-github host', () => {
+      expect(git.parseOwnerRepoFromRemoteUrl('git@gitlab.example.com:team/project.git')).toEqual({
+        owner: 'team',
+        repo: 'project',
+      });
+    });
+
+    test('parses ssh:// scheme', () => {
+      expect(git.parseOwnerRepoFromRemoteUrl('ssh://git@github.com/owner/repo.git')).toEqual({
+        owner: 'owner',
+        repo: 'repo',
+      });
+    });
+
+    test('strips trailing slashes', () => {
+      expect(git.parseOwnerRepoFromRemoteUrl('https://github.com/owner/repo/')).toEqual({
+        owner: 'owner',
+        repo: 'repo',
+      });
+    });
+
+    test('returns subgroup/repo for GitLab subgroups (two-level slug)', () => {
+      // GitLab allows nested groups. Our workspace layout is two-level, so we
+      // take the last two segments. This is a deliberate simplification.
+      expect(git.parseOwnerRepoFromRemoteUrl('https://gitlab.com/group/subgroup/repo.git')).toEqual(
+        { owner: 'subgroup', repo: 'repo' }
+      );
+    });
+
+    test('returns null for empty string', () => {
+      expect(git.parseOwnerRepoFromRemoteUrl('')).toBeNull();
+      expect(git.parseOwnerRepoFromRemoteUrl('   ')).toBeNull();
+    });
+
+    test('returns null for single-segment input', () => {
+      expect(git.parseOwnerRepoFromRemoteUrl('repo')).toBeNull();
+    });
+  });
+
+  describe('parseOwnerRepoFromGitRemote (async)', () => {
+    test('returns {owner, repo} for a real git repo with https origin', async () => {
+      const { execFileAsync } = git;
+      await execFileAsync('git', ['-C', testDir, 'init']);
+      await execFileAsync('git', [
+        '-C',
+        testDir,
+        'remote',
+        'add',
+        'origin',
+        'https://github.com/test-owner/test-repo.git',
+      ]);
+
+      const result = await git.parseOwnerRepoFromGitRemote(testDir);
+      expect(result).toEqual({ owner: 'test-owner', repo: 'test-repo' });
+    });
+
+    test('returns null for a git repo with no origin', async () => {
+      const { execFileAsync } = git;
+      await execFileAsync('git', ['-C', testDir, 'init']);
+      // No remote added
+      const result = await git.parseOwnerRepoFromGitRemote(testDir);
+      expect(result).toBeNull();
+    });
+
+    test('returns null when cwd is not a git repo', async () => {
+      const nonRepoDir = join(tmpdir(), `non-repo-${String(Date.now())}`);
+      await realMkdir(nonRepoDir, { recursive: true });
+      try {
+        const result = await git.parseOwnerRepoFromGitRemote(nonRepoDir);
+        expect(result).toBeNull();
+      } finally {
+        await rm(nonRepoDir, { recursive: true, force: true });
+      }
+    });
+  });
 });

--- a/packages/git/src/git.test.ts
+++ b/packages/git/src/git.test.ts
@@ -1954,6 +1954,54 @@ branch refs/heads/feature/auth
     test('returns null for single-segment input', () => {
       expect(git.parseOwnerRepoFromRemoteUrl('repo')).toBeNull();
     });
+
+    // ─── Path-traversal safety (defense in depth) ─────────────────────────
+    // These cases simulate what a crafted `git remote set-url origin ...`
+    // could inject. The parser must reject any owner/repo segment that
+    // could steer downstream path construction outside ~/.archon/workspaces/.
+
+    test('rejects .. as owner segment', () => {
+      expect(git.parseOwnerRepoFromRemoteUrl('git@host:../evil.git')).toBeNull();
+    });
+
+    test('rejects .. as repo segment', () => {
+      // `git@host:owner/..` normalizes to `https://__ssh__/owner/..`, the split
+      // produces owner='owner' repo='..' — must be rejected.
+      expect(git.parseOwnerRepoFromRemoteUrl('git@host:owner/..')).toBeNull();
+    });
+
+    test('rejects . (single-dot) segments', () => {
+      expect(git.parseOwnerRepoFromRemoteUrl('git@host:./repo')).toBeNull();
+      expect(git.parseOwnerRepoFromRemoteUrl('git@host:owner/.')).toBeNull();
+    });
+
+    test('rejects segments containing backslash', () => {
+      // An attacker-controlled remote URL could embed a backslash which on
+      // Windows or weird normalization paths is a separator.
+      expect(git.parseOwnerRepoFromRemoteUrl('git@host:ow\\ner/repo')).toBeNull();
+    });
+
+    test('rejects segments containing whitespace', () => {
+      expect(git.parseOwnerRepoFromRemoteUrl('git@host:own er/repo')).toBeNull();
+      expect(git.parseOwnerRepoFromRemoteUrl('git@host:owner/re\tpo')).toBeNull();
+    });
+
+    test('rejects segments containing shell metacharacters', () => {
+      expect(git.parseOwnerRepoFromRemoteUrl('git@host:owner/re;po')).toBeNull();
+      expect(git.parseOwnerRepoFromRemoteUrl('git@host:owner/re$po')).toBeNull();
+      expect(git.parseOwnerRepoFromRemoteUrl('git@host:owner/re|po')).toBeNull();
+    });
+
+    test('rejects segments containing null bytes', () => {
+      expect(git.parseOwnerRepoFromRemoteUrl('git@host:owner/re\x00po')).toBeNull();
+    });
+
+    test('accepts common legitimate slug characters', () => {
+      expect(git.parseOwnerRepoFromRemoteUrl('git@host:my-org/my_repo.js.git')).toEqual({
+        owner: 'my-org',
+        repo: 'my_repo.js',
+      });
+    });
   });
 
   describe('parseOwnerRepoFromGitRemote (async)', () => {

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -42,6 +42,8 @@ export {
 export {
   findRepoRoot,
   getRemoteUrl,
+  parseOwnerRepoFromGitRemote,
+  parseOwnerRepoFromRemoteUrl,
   syncWorkspace,
   cloneRepository,
   syncRepository,

--- a/packages/git/src/repo.ts
+++ b/packages/git/src/repo.ts
@@ -39,6 +39,69 @@ export async function findRepoRoot(startPath: string): Promise<RepoPath | null> 
 }
 
 /**
+ * Parse a git remote URL into an `{ owner, repo }` slug suitable for use
+ * under `~/.archon/workspaces/`. Pure function — no I/O, safe to reuse.
+ *
+ * Handles common URL shapes:
+ *   - `https://github.com/owner/repo(.git)?`
+ *   - `git@github.com:owner/repo(.git)?`
+ *   - `ssh://git@host/owner/repo(.git)?`
+ *   - `https://gitlab.com/group/subgroup/repo.git` (returns `subgroup/repo`;
+ *     the leading group segment is dropped because the workspace layout is
+ *     two-level: `~/.archon/workspaces/<owner>/<repo>/`)
+ *
+ * Returns `null` for unparseable URLs.
+ */
+export function parseOwnerRepoFromRemoteUrl(url: string): { owner: string; repo: string } | null {
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+
+  // Strip trailing .git and any trailing slashes
+  const cleaned = trimmed.replace(/\.git$/, '').replace(/\/+$/, '');
+
+  // SSH form `git@host:path` → normalize so a single split works
+  const normalized =
+    cleaned.startsWith('git@') && cleaned.includes(':') && !cleaned.includes('://')
+      ? cleaned.replace(/^[^@]+@[^:]+:/, 'https://__ssh__/')
+      : cleaned;
+
+  const parts = normalized.split('/').filter(Boolean);
+  const repo = parts.pop();
+  const owner = parts.pop();
+  if (!owner || !repo) return null;
+  return { owner, repo };
+}
+
+/**
+ * Fetch `origin` for the repo containing `cwd` and parse it into an
+ * `{ owner, repo }` slug suitable for use under `~/.archon/workspaces/`.
+ *
+ * Returns `null` on ANY failure (not a git repo, no origin, unparseable URL,
+ * git binary missing, permission denied). Callers should treat null as
+ * "this cwd is not a recognizable project" and fall back silently — no
+ * throwing, no logging at warn/error level.
+ *
+ * Unlike `getRemoteUrl`, this takes a plain string cwd (not a branded
+ * `RepoPath`) so it is ergonomic to call from CLI entry points and workflow
+ * execution where the cwd has not yet been type-validated.
+ */
+export async function parseOwnerRepoFromGitRemote(
+  cwd: string
+): Promise<{ owner: string; repo: string } | null> {
+  let stdout: string;
+  try {
+    const result = await execFileAsync('git', ['-C', cwd, 'remote', 'get-url', 'origin'], {
+      timeout: 10000,
+    });
+    stdout = result.stdout;
+  } catch {
+    // Not a repo, no remote, git missing, etc. — silent null.
+    return null;
+  }
+  return parseOwnerRepoFromRemoteUrl(stdout);
+}
+
+/**
  * Get the remote URL for origin (if it exists)
  * Returns null if no remote is configured
  */

--- a/packages/git/src/repo.ts
+++ b/packages/git/src/repo.ts
@@ -39,6 +39,34 @@ export async function findRepoRoot(startPath: string): Promise<RepoPath | null> 
 }
 
 /**
+ * Safe path segment pattern for owner/repo slugs. Rejects anything that
+ * could escape `~/.archon/workspaces/<owner>/<repo>/` — path separators,
+ * null bytes, dot segments, and control characters.
+ *
+ * Matches the character set GitHub and GitLab both allow in user/org and
+ * repo names (alphanumerics plus `-`, `_`, `.`). Strings containing only
+ * dots (`.`, `..`) are explicitly rejected by the additional check in
+ * `isSafePathSegment` below.
+ */
+const SAFE_SLUG_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * Return true iff `s` is safe to use as a single path segment when
+ * constructing a `~/.archon/workspaces/<owner>/<repo>/` directory path.
+ *
+ * Rejects:
+ *   - Empty strings
+ *   - `.` and `..` (directory traversal)
+ *   - Strings containing path separators, control characters, or other
+ *     characters outside the GitHub/GitLab-compatible slug character set
+ */
+function isSafePathSegment(s: string): boolean {
+  if (!s) return false;
+  if (s === '.' || s === '..') return false;
+  return SAFE_SLUG_PATTERN.test(s);
+}
+
+/**
  * Parse a git remote URL into an `{ owner, repo }` slug suitable for use
  * under `~/.archon/workspaces/`. Pure function — no I/O, safe to reuse.
  *
@@ -50,7 +78,11 @@ export async function findRepoRoot(startPath: string): Promise<RepoPath | null> 
  *     the leading group segment is dropped because the workspace layout is
  *     two-level: `~/.archon/workspaces/<owner>/<repo>/`)
  *
- * Returns `null` for unparseable URLs.
+ * Returns `null` for unparseable URLs **or** for URLs whose owner/repo
+ * segments contain anything outside the GitHub/GitLab-compatible safe
+ * slug character set (see `isSafePathSegment`). This prevents a crafted
+ * remote URL (`git remote set-url origin git@host:../../evil`) from
+ * steering workspace path construction outside `~/.archon/workspaces/`.
  */
 export function parseOwnerRepoFromRemoteUrl(url: string): { owner: string; repo: string } | null {
   const trimmed = url.trim();
@@ -69,6 +101,12 @@ export function parseOwnerRepoFromRemoteUrl(url: string): { owner: string; repo:
   const repo = parts.pop();
   const owner = parts.pop();
   if (!owner || !repo) return null;
+
+  // Defense-in-depth: reject any segment that could be used for directory
+  // traversal or contains unsafe characters. Callers rely on the result
+  // being usable as literal path components without further sanitization.
+  if (!isSafePathSegment(owner) || !isSafePathSegment(repo)) return null;
+
   return { owner, repo };
 }
 

--- a/packages/paths/src/archon-paths.ts
+++ b/packages/paths/src/archon-paths.ts
@@ -269,6 +269,20 @@ export function getProjectLogsPath(owner: string, repo: string): string {
 }
 
 /**
+ * Get the per-project, per-user Archon config directory.
+ * Returns: ~/.archon/workspaces/owner/repo/.archon/
+ *
+ * This is the third tier in workflow/command/script resolution:
+ * repo-local (`<cwd>/.archon/`) > this > user-global (`~/.archon/.archon/`) > defaults.
+ *
+ * Lets a user keep per-project automation outside the team repo (which
+ * doesn't want it committed) without making it apply to every project.
+ */
+export function getProjectArchonDir(owner: string, repo: string): string {
+  return join(getProjectRoot(owner, repo), '.archon');
+}
+
+/**
  * Get the artifacts directory for a specific workflow run.
  * Returns: ~/.archon/workspaces/owner/repo/artifacts/runs/{id}/
  */

--- a/packages/paths/src/index.ts
+++ b/packages/paths/src/index.ts
@@ -19,6 +19,7 @@ export {
   getProjectWorktreesPath,
   getProjectArtifactsPath,
   getProjectLogsPath,
+  getProjectArchonDir,
   getRunArtifactsPath,
   getRunLogPath,
   resolveProjectRootFromCwd,

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -19,7 +19,7 @@
     "./test-utils": "./src/test-utils.ts"
   },
   "scripts": {
-    "test": "bun test src/dag-executor.test.ts && bun test src/loader.test.ts && bun test src/logger.test.ts && bun test src/condition-evaluator.test.ts && bun test src/event-emitter.test.ts && bun test src/executor-shared.test.ts && bun test src/executor.test.ts && bun test src/executor-preamble.test.ts && bun test src/defaults/ src/model-validation.test.ts src/router.test.ts src/utils/ src/hooks.test.ts && bun test src/validation-parser.test.ts src/schemas.test.ts src/command-validation.test.ts && bun test src/validator.test.ts && bun test src/script-discovery.test.ts && bun test src/runtime-check.test.ts && bun test src/script-node-deps.test.ts",
+    "test": "bun test src/dag-executor.test.ts && bun test src/loader.test.ts && bun test src/logger.test.ts && bun test src/condition-evaluator.test.ts && bun test src/event-emitter.test.ts && bun test src/executor-shared.test.ts && bun test src/executor-shared-command-global.test.ts && bun test src/executor.test.ts && bun test src/executor-preamble.test.ts && bun test src/defaults/ src/model-validation.test.ts src/router.test.ts src/utils/ src/hooks.test.ts && bun test src/validation-parser.test.ts src/schemas.test.ts src/command-validation.test.ts && bun test src/validator.test.ts && bun test src/script-discovery.test.ts && bun test src/runtime-check.test.ts && bun test src/script-node-deps.test.ts && bun test src/dag-executor-script-global.test.ts",
     "type-check": "bun x tsc --noEmit"
   },
   "dependencies": {

--- a/packages/workflows/src/dag-executor-script-global.test.ts
+++ b/packages/workflows/src/dag-executor-script-global.test.ts
@@ -90,7 +90,7 @@ const mockSendQuery = mock(function* () {
   yield { type: 'result', sessionId: 'session' };
 });
 
-const mockGetAssistantClient = mock(() => ({
+const mockGetAgentProvider = mock(() => ({
   sendQuery: mockSendQuery,
   getType: () => 'claude',
 }));
@@ -98,7 +98,7 @@ const mockGetAssistantClient = mock(() => ({
 function createMockDeps(): WorkflowDeps {
   return {
     store: createMockStore(),
-    getAssistantClient: mockGetAssistantClient,
+    getAgentProvider: mockGetAgentProvider,
     loadConfig: mock(() =>
       Promise.resolve({
         assistant: 'claude' as const,

--- a/packages/workflows/src/dag-executor-script-global.test.ts
+++ b/packages/workflows/src/dag-executor-script-global.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests for the user-global script fallback in executeScriptNode.
+ *
+ * Isolated in its own test file (and its own bun test invocation — see package.json)
+ * because it mocks @archon/paths differently than dag-executor.test.ts:
+ * this file needs getArchonHome to return the test-controlled ARCHON_HOME,
+ * whereas dag-executor.test.ts points getArchonHome at /nonexistent/archon-home
+ * to neutralize the fallback. Two files cannot mock.module() the same path
+ * with different implementations in one batch.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, mock } from 'bun:test';
+import { mkdir, writeFile, rm, mkdtemp } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// --- Mock logger + @archon/paths (must come before imports under test) ---
+
+const mockLogFn = mock(() => {});
+const mockLogger = {
+  info: mockLogFn,
+  warn: mockLogFn,
+  error: mockLogFn,
+  debug: mockLogFn,
+  trace: mockLogFn,
+  fatal: mockLogFn,
+  child: mock(() => mockLogger),
+};
+mock.module('@archon/paths', () => ({
+  createLogger: mock(() => mockLogger),
+  getCommandFolderSearchPaths: (folder?: string): string[] => {
+    const paths = ['.archon/commands'];
+    if (folder) paths.unshift(folder);
+    return paths;
+  },
+  getDefaultCommandsPath: (): string => '/nonexistent/defaults',
+  getArchonHome: (): string => {
+    const envHome = process.env.ARCHON_HOME;
+    if (!envHome) throw new Error('ARCHON_HOME not set in test');
+    return envHome;
+  },
+}));
+
+// --- Imports (after mocks) ---
+import { executeDagWorkflow } from './dag-executor';
+import type { ScriptNode, WorkflowRun } from './schemas';
+import type { WorkflowDeps, IWorkflowPlatform, WorkflowConfig } from './deps';
+import type { IWorkflowStore } from './store';
+
+// --- Shared mock factories (duplicated from dag-executor.test.ts intentionally;
+//     keeping this file self-contained avoids cross-file import coupling) ---
+
+function createMockStore(): IWorkflowStore {
+  const dummyRun = {
+    id: 'mock-run-id',
+    workflow_name: 'mock',
+    conversation_id: 'conv-mock',
+    parent_conversation_id: null,
+    codebase_id: null,
+    status: 'running' as const,
+    user_message: 'mock message',
+    metadata: {},
+    started_at: new Date(),
+    completed_at: null,
+    last_activity_at: null,
+    working_path: null,
+  };
+  return {
+    createWorkflowRun: mock(() => Promise.resolve(dummyRun)),
+    getWorkflowRun: mock(() => Promise.resolve(null)),
+    getActiveWorkflowRunByPath: mock(() => Promise.resolve(null)),
+    failOrphanedRuns: mock(() => Promise.resolve({ count: 0 })),
+    findResumableRun: mock(() => Promise.resolve(null)),
+    resumeWorkflowRun: mock(() => Promise.resolve(dummyRun)),
+    updateWorkflowRun: mock(() => Promise.resolve()),
+    updateWorkflowActivity: mock(() => Promise.resolve()),
+    getWorkflowRunStatus: mock(() => Promise.resolve('running' as const)),
+    completeWorkflowRun: mock(() => Promise.resolve()),
+    failWorkflowRun: mock(() => Promise.resolve()),
+    pauseWorkflowRun: mock(() => Promise.resolve()),
+    cancelWorkflowRun: mock(() => Promise.resolve()),
+    createWorkflowEvent: mock(() => Promise.resolve()),
+    getCompletedDagNodeOutputs: mock(() => Promise.resolve(new Map<string, string>())),
+    getCodebase: mock(() => Promise.resolve(null)),
+    getCodebaseEnvVars: mock(() => Promise.resolve({})),
+  };
+}
+
+const mockSendQuery = mock(function* () {
+  yield { type: 'assistant', content: 'not used in script tests' };
+  yield { type: 'result', sessionId: 'session' };
+});
+
+const mockGetAssistantClient = mock(() => ({
+  sendQuery: mockSendQuery,
+  getType: () => 'claude',
+}));
+
+function createMockDeps(): WorkflowDeps {
+  return {
+    store: createMockStore(),
+    getAssistantClient: mockGetAssistantClient,
+    loadConfig: mock(() =>
+      Promise.resolve({
+        assistant: 'claude' as const,
+        commands: {},
+        defaults: { loadDefaultCommands: false, loadDefaultWorkflows: false },
+        assistants: { claude: {}, codex: {} },
+      })
+    ),
+  };
+}
+
+function createMockPlatform(): IWorkflowPlatform {
+  return {
+    sendMessage: mock(() => Promise.resolve()),
+    getStreamingMode: mock(() => 'batch' as const),
+    getPlatformType: mock(() => 'test'),
+    sendStructuredEvent: mock(() => Promise.resolve()),
+  };
+}
+
+function makeRun(id: string): WorkflowRun {
+  return {
+    id,
+    workflow_name: 'script-global-test',
+    conversation_id: `conv-${id}`,
+    parent_conversation_id: null,
+    codebase_id: null,
+    status: 'running',
+    user_message: 'test',
+    metadata: {},
+    started_at: new Date(),
+    completed_at: null,
+    last_activity_at: null,
+    working_path: null,
+  };
+}
+
+const minimalConfig: WorkflowConfig = {
+  assistant: 'claude',
+  assistants: { claude: {}, codex: {} },
+  commands: {},
+  defaults: { loadDefaultCommands: false, loadDefaultWorkflows: false },
+};
+
+// --- Tests ---
+
+describe('executeScriptNode — user-global fallback', () => {
+  let repoCwd: string;
+  let globalHome: string;
+
+  beforeAll(async () => {
+    repoCwd = await mkdtemp(join(tmpdir(), 'archon-script-repo-'));
+    globalHome = await mkdtemp(join(tmpdir(), 'archon-script-home-'));
+    process.env.ARCHON_HOME = globalHome;
+    // Subdirs the workflow needs
+    await mkdir(join(repoCwd, 'artifacts'), { recursive: true });
+    await mkdir(join(repoCwd, 'logs'), { recursive: true });
+  });
+
+  afterAll(async () => {
+    await rm(repoCwd, { recursive: true, force: true });
+    await rm(globalHome, { recursive: true, force: true });
+    delete process.env.ARCHON_HOME;
+  });
+
+  beforeEach(async () => {
+    // Wipe .archon dirs between tests
+    await rm(join(repoCwd, '.archon'), { recursive: true, force: true });
+    await rm(join(globalHome, '.archon'), { recursive: true, force: true });
+  });
+
+  it('executes a named script found only in the user-global .archon/scripts/', async () => {
+    // No repo-local script; only the global one
+    const globalScripts = join(globalHome, '.archon', 'scripts');
+    await mkdir(globalScripts, { recursive: true });
+    await writeFile(join(globalScripts, 'greet-global.ts'), 'console.log("hello from global")');
+
+    const platform = createMockPlatform();
+    const node: ScriptNode = {
+      id: 'run-greet-global',
+      script: 'greet-global',
+      runtime: 'bun',
+    };
+
+    await executeDagWorkflow(
+      createMockDeps(),
+      platform,
+      'conv-global',
+      repoCwd,
+      { name: 'script-global-test', nodes: [node] },
+      makeRun('script-global-only-run'),
+      'claude',
+      undefined,
+      join(repoCwd, 'artifacts'),
+      join(repoCwd, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
+    const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
+    // No "not found" message should have been sent
+    const notFound = messages.find(m => m.includes('not found'));
+    expect(notFound).toBeUndefined();
+    // No workflow-level failure message
+    const failed = messages.find(m => m.includes('no successful nodes'));
+    expect(failed).toBeUndefined();
+  });
+
+  it('prefers the repo-local copy over the user-global copy when both exist', async () => {
+    // Put a working script in BOTH locations; give them distinguishable output
+    const repoScripts = join(repoCwd, '.archon', 'scripts');
+    const globalScripts = join(globalHome, '.archon', 'scripts');
+    await mkdir(repoScripts, { recursive: true });
+    await mkdir(globalScripts, { recursive: true });
+    await writeFile(join(repoScripts, 'shared.ts'), 'console.log("from-repo")');
+    await writeFile(join(globalScripts, 'shared.ts'), 'console.log("from-global")');
+
+    const capturedStore = createMockStore();
+    const deps: WorkflowDeps = {
+      ...createMockDeps(),
+      store: capturedStore,
+    };
+
+    const platform = createMockPlatform();
+    const node: ScriptNode = { id: 'run-shared', script: 'shared', runtime: 'bun' };
+
+    await executeDagWorkflow(
+      deps,
+      platform,
+      'conv-shared',
+      repoCwd,
+      { name: 'script-shared-test', nodes: [node] },
+      makeRun('script-shared-run'),
+      'claude',
+      undefined,
+      join(repoCwd, 'artifacts'),
+      join(repoCwd, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    // Find the node_completed event and check its captured output contains 'from-repo'
+    const createEvent = capturedStore.createWorkflowEvent as ReturnType<typeof mock>;
+    const nodeCompletedCall = createEvent.mock.calls.find((call: unknown[]) => {
+      const event = call[0] as { event_type: string; step_name?: string };
+      return event.event_type === 'node_completed' && event.step_name === 'run-shared';
+    });
+    expect(nodeCompletedCall).toBeDefined();
+    if (nodeCompletedCall) {
+      const event = nodeCompletedCall[0] as { data?: { node_output?: string } };
+      expect(event.data?.node_output).toContain('from-repo');
+      expect(event.data?.node_output).not.toContain('from-global');
+    }
+  });
+
+  it('fails with the updated error message when missing in both repo and global', async () => {
+    // Neither dir has the script
+    const platform = createMockPlatform();
+    const node: ScriptNode = {
+      id: 'missing-script',
+      script: 'nowhere',
+      runtime: 'bun',
+    };
+
+    await executeDagWorkflow(
+      createMockDeps(),
+      platform,
+      'conv-missing',
+      repoCwd,
+      { name: 'script-missing-test', nodes: [node] },
+      makeRun('script-missing-run'),
+      'claude',
+      undefined,
+      join(repoCwd, 'artifacts'),
+      join(repoCwd, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
+    const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
+    const notFoundMsg = messages.find(m =>
+      m.includes('not found in .archon/scripts/ (repo or global)')
+    );
+    expect(notFoundMsg).toBeDefined();
+  });
+});

--- a/packages/workflows/src/dag-executor-script-global.test.ts
+++ b/packages/workflows/src/dag-executor-script-global.test.ts
@@ -296,15 +296,14 @@ describe('executeScriptNode — user-global fallback', () => {
 describe('executeScriptNode — workspace-in-userspace fallback', () => {
   let repoCwd: string;
   let globalHome: string;
-  let workspaceHome: string;
+  // The workspace search path stands in for `~/.archon/workspaces/<owner>/<repo>/`
+  // — the PROJECT ROOT. The engine probes `<root>/.archon/scripts/<name>.ts`.
+  let workspaceSearchPath: string;
 
   beforeAll(async () => {
     repoCwd = await mkdtemp(join(tmpdir(), 'archon-script-wsr-repo-'));
     globalHome = await mkdtemp(join(tmpdir(), 'archon-script-wsr-home-'));
-    // The workspace-in-userspace dir is ~/.archon/workspaces/<owner>/<repo>/.archon
-    // For test purposes we simulate that with a plain tmpdir — the engine just
-    // probes <dir>/scripts/<name>.ts and doesn't care about the parent layout.
-    workspaceHome = await mkdtemp(join(tmpdir(), 'archon-script-wsr-workspace-'));
+    workspaceSearchPath = await mkdtemp(join(tmpdir(), 'archon-script-wsr-workspace-'));
     process.env.ARCHON_HOME = globalHome;
     await mkdir(join(repoCwd, 'artifacts'), { recursive: true });
     await mkdir(join(repoCwd, 'logs'), { recursive: true });
@@ -313,14 +312,14 @@ describe('executeScriptNode — workspace-in-userspace fallback', () => {
   afterAll(async () => {
     await rm(repoCwd, { recursive: true, force: true });
     await rm(globalHome, { recursive: true, force: true });
-    await rm(workspaceHome, { recursive: true, force: true });
+    await rm(workspaceSearchPath, { recursive: true, force: true });
     delete process.env.ARCHON_HOME;
   });
 
   beforeEach(async () => {
     await rm(join(repoCwd, '.archon'), { recursive: true, force: true });
     await rm(join(globalHome, '.archon'), { recursive: true, force: true });
-    await rm(join(workspaceHome, 'scripts'), { recursive: true, force: true });
+    await rm(join(workspaceSearchPath, '.archon'), { recursive: true, force: true });
   });
 
   /**
@@ -356,14 +355,17 @@ describe('executeScriptNode — workspace-in-userspace fallback', () => {
       undefined, // configuredCommandFolder
       undefined, // issueContext
       undefined, // priorCompletedNodes
-      workspaceHome // workspaceArchonDir
+      workspaceSearchPath // workspaceSearchPath (project root)
     );
     return store;
   }
 
   it('executes a script found only in the workspace dir', async () => {
-    await mkdir(join(workspaceHome, 'scripts'), { recursive: true });
-    await writeFile(join(workspaceHome, 'scripts', 'ws-only.ts'), 'console.log("from-workspace")');
+    await mkdir(join(workspaceSearchPath, '.archon', 'scripts'), { recursive: true });
+    await writeFile(
+      join(workspaceSearchPath, '.archon', 'scripts', 'ws-only.ts'),
+      'console.log("from-workspace")'
+    );
 
     const platform = createMockPlatform();
     const store = await runWithWorkspace(platform, 'ws-only-run', 'ws-only');
@@ -382,9 +384,12 @@ describe('executeScriptNode — workspace-in-userspace fallback', () => {
 
   it('prefers repo over workspace', async () => {
     await mkdir(join(repoCwd, '.archon', 'scripts'), { recursive: true });
-    await mkdir(join(workspaceHome, 'scripts'), { recursive: true });
+    await mkdir(join(workspaceSearchPath, '.archon', 'scripts'), { recursive: true });
     await writeFile(join(repoCwd, '.archon', 'scripts', 'dup.ts'), 'console.log("from-repo")');
-    await writeFile(join(workspaceHome, 'scripts', 'dup.ts'), 'console.log("from-workspace")');
+    await writeFile(
+      join(workspaceSearchPath, '.archon', 'scripts', 'dup.ts'),
+      'console.log("from-workspace")'
+    );
 
     const platform = createMockPlatform();
     const store = await runWithWorkspace(platform, 'dup-run', 'dup');
@@ -403,9 +408,12 @@ describe('executeScriptNode — workspace-in-userspace fallback', () => {
   });
 
   it('prefers workspace over user-global', async () => {
-    await mkdir(join(workspaceHome, 'scripts'), { recursive: true });
+    await mkdir(join(workspaceSearchPath, '.archon', 'scripts'), { recursive: true });
     await mkdir(join(globalHome, '.archon', 'scripts'), { recursive: true });
-    await writeFile(join(workspaceHome, 'scripts', 'mid.ts'), 'console.log("from-workspace")');
+    await writeFile(
+      join(workspaceSearchPath, '.archon', 'scripts', 'mid.ts'),
+      'console.log("from-workspace")'
+    );
     await writeFile(join(globalHome, '.archon', 'scripts', 'mid.ts'), 'console.log("from-global")');
 
     const platform = createMockPlatform();

--- a/packages/workflows/src/dag-executor-script-global.test.ts
+++ b/packages/workflows/src/dag-executor-script-global.test.ts
@@ -285,8 +285,142 @@ describe('executeScriptNode — user-global fallback', () => {
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
     const notFoundMsg = messages.find(m =>
-      m.includes('not found in .archon/scripts/ (repo or global)')
+      m.includes('not found in .archon/scripts/ (repo, workspace, or global)')
     );
     expect(notFoundMsg).toBeDefined();
+  });
+});
+
+// ─── Workspace-in-userspace tier (repo > workspace > global) ────────────────
+
+describe('executeScriptNode — workspace-in-userspace fallback', () => {
+  let repoCwd: string;
+  let globalHome: string;
+  let workspaceHome: string;
+
+  beforeAll(async () => {
+    repoCwd = await mkdtemp(join(tmpdir(), 'archon-script-wsr-repo-'));
+    globalHome = await mkdtemp(join(tmpdir(), 'archon-script-wsr-home-'));
+    // The workspace-in-userspace dir is ~/.archon/workspaces/<owner>/<repo>/.archon
+    // For test purposes we simulate that with a plain tmpdir — the engine just
+    // probes <dir>/scripts/<name>.ts and doesn't care about the parent layout.
+    workspaceHome = await mkdtemp(join(tmpdir(), 'archon-script-wsr-workspace-'));
+    process.env.ARCHON_HOME = globalHome;
+    await mkdir(join(repoCwd, 'artifacts'), { recursive: true });
+    await mkdir(join(repoCwd, 'logs'), { recursive: true });
+  });
+
+  afterAll(async () => {
+    await rm(repoCwd, { recursive: true, force: true });
+    await rm(globalHome, { recursive: true, force: true });
+    await rm(workspaceHome, { recursive: true, force: true });
+    delete process.env.ARCHON_HOME;
+  });
+
+  beforeEach(async () => {
+    await rm(join(repoCwd, '.archon'), { recursive: true, force: true });
+    await rm(join(globalHome, '.archon'), { recursive: true, force: true });
+    await rm(join(workspaceHome, 'scripts'), { recursive: true, force: true });
+  });
+
+  /**
+   * Dispatch a workflow with a script node, passing workspaceArchonDir through
+   * via the last-parameter hole in executeDagWorkflow. The engine will use
+   * the explicitly-provided value and skip its own git-based lookup.
+   */
+  async function runWithWorkspace(
+    platform: IWorkflowPlatform,
+    runId: string,
+    scriptName: string
+  ): Promise<IWorkflowStore> {
+    const store = createMockStore();
+    const deps: WorkflowDeps = {
+      ...createMockDeps(),
+      store,
+    };
+    const node: ScriptNode = { id: 'run-it', script: scriptName, runtime: 'bun' };
+    await executeDagWorkflow(
+      deps,
+      platform,
+      `conv-${runId}`,
+      repoCwd,
+      { name: `script-wsr-${runId}`, nodes: [node] },
+      makeRun(runId),
+      'claude',
+      undefined,
+      join(repoCwd, 'artifacts'),
+      join(repoCwd, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined, // configuredCommandFolder
+      undefined, // issueContext
+      undefined, // priorCompletedNodes
+      workspaceHome // workspaceArchonDir
+    );
+    return store;
+  }
+
+  it('executes a script found only in the workspace dir', async () => {
+    await mkdir(join(workspaceHome, 'scripts'), { recursive: true });
+    await writeFile(join(workspaceHome, 'scripts', 'ws-only.ts'), 'console.log("from-workspace")');
+
+    const platform = createMockPlatform();
+    const store = await runWithWorkspace(platform, 'ws-only-run', 'ws-only');
+
+    const createEvent = store.createWorkflowEvent as ReturnType<typeof mock>;
+    const nodeCompleted = createEvent.mock.calls.find((call: unknown[]) => {
+      const event = call[0] as { event_type: string; step_name?: string };
+      return event.event_type === 'node_completed' && event.step_name === 'run-it';
+    });
+    expect(nodeCompleted).toBeDefined();
+    if (nodeCompleted) {
+      const event = nodeCompleted[0] as { data?: { node_output?: string } };
+      expect(event.data?.node_output).toContain('from-workspace');
+    }
+  });
+
+  it('prefers repo over workspace', async () => {
+    await mkdir(join(repoCwd, '.archon', 'scripts'), { recursive: true });
+    await mkdir(join(workspaceHome, 'scripts'), { recursive: true });
+    await writeFile(join(repoCwd, '.archon', 'scripts', 'dup.ts'), 'console.log("from-repo")');
+    await writeFile(join(workspaceHome, 'scripts', 'dup.ts'), 'console.log("from-workspace")');
+
+    const platform = createMockPlatform();
+    const store = await runWithWorkspace(platform, 'dup-run', 'dup');
+
+    const createEvent = store.createWorkflowEvent as ReturnType<typeof mock>;
+    const nodeCompleted = createEvent.mock.calls.find((call: unknown[]) => {
+      const event = call[0] as { event_type: string; step_name?: string };
+      return event.event_type === 'node_completed' && event.step_name === 'run-it';
+    });
+    expect(nodeCompleted).toBeDefined();
+    if (nodeCompleted) {
+      const event = nodeCompleted[0] as { data?: { node_output?: string } };
+      expect(event.data?.node_output).toContain('from-repo');
+      expect(event.data?.node_output).not.toContain('from-workspace');
+    }
+  });
+
+  it('prefers workspace over user-global', async () => {
+    await mkdir(join(workspaceHome, 'scripts'), { recursive: true });
+    await mkdir(join(globalHome, '.archon', 'scripts'), { recursive: true });
+    await writeFile(join(workspaceHome, 'scripts', 'mid.ts'), 'console.log("from-workspace")');
+    await writeFile(join(globalHome, '.archon', 'scripts', 'mid.ts'), 'console.log("from-global")');
+
+    const platform = createMockPlatform();
+    const store = await runWithWorkspace(platform, 'mid-run', 'mid');
+
+    const createEvent = store.createWorkflowEvent as ReturnType<typeof mock>;
+    const nodeCompleted = createEvent.mock.calls.find((call: unknown[]) => {
+      const event = call[0] as { event_type: string; step_name?: string };
+      return event.event_type === 'node_completed' && event.step_name === 'run-it';
+    });
+    expect(nodeCompleted).toBeDefined();
+    if (nodeCompleted) {
+      const event = nodeCompleted[0] as { data?: { node_output?: string } };
+      expect(event.data?.node_output).toContain('from-workspace');
+      expect(event.data?.node_output).not.toContain('from-global');
+    }
   });
 });

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -23,6 +23,10 @@ mock.module('@archon/paths', () => ({
     return paths;
   },
   getDefaultCommandsPath: () => '/nonexistent/defaults',
+  // Deliberately point at a nonexistent path so global script fallback is a no-op
+  // in tests that don't set up a global scripts dir. Tests that exercise the
+  // fallback live in dag-executor-script-global.test.ts (separate batch).
+  getArchonHome: () => '/nonexistent/archon-home',
 }));
 
 // --- Imports (after mocks) ---

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -42,7 +42,7 @@ import {
   isApprovalContext,
 } from './schemas';
 import { formatToolCall } from './utils/tool-formatter';
-import { createLogger, getArchonHome, getProjectArchonDir } from '@archon/paths';
+import { createLogger, getArchonHome, getProjectRoot } from '@archon/paths';
 import { parseOwnerRepoFromGitRemote } from '@archon/git';
 import { getWorkflowEventEmitter } from './event-emitter';
 import { evaluateCondition } from './condition-evaluator';
@@ -727,7 +727,7 @@ async function executeNodeInternal(
   resumeSessionId: string | undefined,
   configuredCommandFolder?: string,
   issueContext?: string,
-  workspaceArchonDir?: string
+  workspaceSearchPath?: string
 ): Promise<NodeExecutionResult> {
   const nodeStartTime = Date.now();
   const nodeContext: SendMessageContext = { workflowId: workflowRun.id, nodeName: node.id };
@@ -765,7 +765,7 @@ async function executeNodeInternal(
       cwd,
       node.command,
       configuredCommandFolder,
-      workspaceArchonDir
+      workspaceSearchPath
     );
     if (!promptResult.success) {
       const errMsg = promptResult.message;
@@ -1472,7 +1472,7 @@ async function executeScriptNode(
   baseBranch: string,
   docsDir: string,
   nodeOutputs: Map<string, NodeOutput>,
-  workspaceArchonDir?: string,
+  workspaceSearchPath?: string,
   issueContext?: string
 ): Promise<NodeOutput> {
   const nodeStartTime = Date.now();
@@ -1545,8 +1545,8 @@ async function executeScriptNode(
       let scriptDef = scripts.get(finalScript);
 
       // Tier 2: workspace-in-userspace (~/.archon/workspaces/<owner>/<repo>/.archon/scripts/)
-      if (!scriptDef && workspaceArchonDir) {
-        const workspaceScriptsDir = resolve(workspaceArchonDir, 'scripts');
+      if (!scriptDef && workspaceSearchPath) {
+        const workspaceScriptsDir = resolve(workspaceSearchPath, '.archon', 'scripts');
         if (workspaceScriptsDir !== scriptsDir) {
           try {
             const workspaceScripts = await discoverScripts(workspaceScriptsDir);
@@ -2264,7 +2264,7 @@ async function executeApprovalNode(
   workflowLevelOptions: WorkflowLevelOptions,
   configuredCommandFolder?: string,
   issueContext?: string,
-  workspaceArchonDir?: string
+  workspaceSearchPath?: string
 ): Promise<NodeOutput> {
   const msgContext = { workflowId: workflowRun.id, nodeName: node.id };
 
@@ -2362,7 +2362,7 @@ async function executeApprovalNode(
       undefined, // fresh session
       configuredCommandFolder,
       issueContext,
-      workspaceArchonDir
+      workspaceSearchPath
     );
 
     if (output.state === 'failed') {
@@ -2434,24 +2434,26 @@ export async function executeDagWorkflow(
   configuredCommandFolder?: string,
   issueContext?: string,
   priorCompletedNodes?: Map<string, string>,
-  workspaceArchonDir?: string
+  workspaceSearchPath?: string
 ): Promise<string | undefined> {
   const dagStartTime = Date.now();
 
-  // Resolve the workspace-in-userspace .archon dir once per run. If the caller
-  // didn't pre-compute it, derive it from the git remote. Null means the
+  // Resolve the workspace-in-userspace project root once per run. If the caller
+  // didn't pre-compute it, derive it from the git remote. Undefined means the
   // workspace tier is silently skipped for script/command lookups in this run.
-  let resolvedWorkspaceArchonDir: string | undefined = workspaceArchonDir;
-  if (resolvedWorkspaceArchonDir === undefined) {
+  // This is the PROJECT ROOT (no `.archon` suffix), matching how
+  // `globalSearchPath` works at the workflow-discovery layer.
+  let resolvedWorkspaceSearchPath: string | undefined = workspaceSearchPath;
+  if (resolvedWorkspaceSearchPath === undefined) {
     const ownerRepo = await parseOwnerRepoFromGitRemote(cwd);
     if (ownerRepo) {
-      resolvedWorkspaceArchonDir = getProjectArchonDir(ownerRepo.owner, ownerRepo.repo);
+      resolvedWorkspaceSearchPath = getProjectRoot(ownerRepo.owner, ownerRepo.repo);
       getLog().debug(
-        { cwd, workspaceArchonDir: resolvedWorkspaceArchonDir },
-        'dag.workspace_archon_dir_resolved'
+        { cwd, workspaceSearchPath: resolvedWorkspaceSearchPath },
+        'dag.workspace_search_path_resolved'
       );
     } else {
-      getLog().debug({ cwd }, 'dag.workspace_archon_dir_unavailable');
+      getLog().debug({ cwd }, 'dag.workspace_search_path_unavailable');
     }
   }
   const workflowLevelOptions = {
@@ -2746,7 +2748,7 @@ export async function executeDagWorkflow(
               workflowLevelOptions,
               configuredCommandFolder,
               issueContext,
-              resolvedWorkspaceArchonDir
+              resolvedWorkspaceSearchPath
             );
             return { nodeId: node.id, output };
           }
@@ -2797,7 +2799,7 @@ export async function executeDagWorkflow(
               baseBranch,
               docsDir,
               nodeOutputs,
-              resolvedWorkspaceArchonDir,
+              resolvedWorkspaceSearchPath,
               issueContext
             );
             return { nodeId: node.id, output };
@@ -2850,7 +2852,7 @@ export async function executeDagWorkflow(
               resumeSessionId,
               configuredCommandFolder,
               issueContext,
-              resolvedWorkspaceArchonDir
+              resolvedWorkspaceSearchPath
             );
 
             if (output.state !== 'failed') break;

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -42,7 +42,8 @@ import {
   isApprovalContext,
 } from './schemas';
 import { formatToolCall } from './utils/tool-formatter';
-import { createLogger, getArchonHome } from '@archon/paths';
+import { createLogger, getArchonHome, getProjectArchonDir } from '@archon/paths';
+import { parseOwnerRepoFromGitRemote } from '@archon/git';
 import { getWorkflowEventEmitter } from './event-emitter';
 import { evaluateCondition } from './condition-evaluator';
 import { isClaudeModel, isModelCompatible } from './model-validation';
@@ -725,7 +726,8 @@ async function executeNodeInternal(
   nodeOutputs: Map<string, NodeOutput>,
   resumeSessionId: string | undefined,
   configuredCommandFolder?: string,
-  issueContext?: string
+  issueContext?: string,
+  workspaceArchonDir?: string
 ): Promise<NodeExecutionResult> {
   const nodeStartTime = Date.now();
   const nodeContext: SendMessageContext = { workflowId: workflowRun.id, nodeName: node.id };
@@ -758,7 +760,13 @@ async function executeNodeInternal(
   // Load prompt
   let rawPrompt: string;
   if (node.command !== undefined) {
-    const promptResult = await loadCommandPrompt(deps, cwd, node.command, configuredCommandFolder);
+    const promptResult = await loadCommandPrompt(
+      deps,
+      cwd,
+      node.command,
+      configuredCommandFolder,
+      workspaceArchonDir
+    );
     if (!promptResult.success) {
       const errMsg = promptResult.message;
       getLog().error({ nodeId: node.id, error: errMsg }, 'dag_node_command_load_failed');
@@ -1464,6 +1472,7 @@ async function executeScriptNode(
   baseBranch: string,
   docsDir: string,
   nodeOutputs: Map<string, NodeOutput>,
+  workspaceArchonDir?: string,
   issueContext?: string
 ): Promise<NodeOutput> {
   const nodeStartTime = Date.now();
@@ -1528,13 +1537,36 @@ async function executeScriptNode(
       }
     } else {
       // Named script — look up in .archon/scripts/ directory.
-      // Priority: repo-local first, then ~/.archon/.archon/scripts/ (user-global).
-      // Mirrors the global command/workflow fallback so users can keep per-machine
-      // script libraries outside any repo.
+      // Priority: repo-local → workspace-in-userspace → user-global.
+      // Mirrors the command/workflow three-tier fallback so users can keep
+      // per-project or per-machine script libraries outside any repo.
       const scriptsDir = resolve(cwd, '.archon', 'scripts');
       const scripts = await discoverScripts(scriptsDir);
       let scriptDef = scripts.get(finalScript);
 
+      // Tier 2: workspace-in-userspace (~/.archon/workspaces/<owner>/<repo>/.archon/scripts/)
+      if (!scriptDef && workspaceArchonDir) {
+        const workspaceScriptsDir = resolve(workspaceArchonDir, 'scripts');
+        if (workspaceScriptsDir !== scriptsDir) {
+          try {
+            const workspaceScripts = await discoverScripts(workspaceScriptsDir);
+            scriptDef = workspaceScripts.get(finalScript);
+            if (scriptDef) {
+              getLog().debug(
+                { nodeId: node.id, scriptName: finalScript, source: 'workspace' },
+                'dag.script_loaded_workspace'
+              );
+            }
+          } catch (discoveryErr) {
+            getLog().warn(
+              { err: discoveryErr as Error, workspaceScriptsDir },
+              'dag.script_workspace_discovery_failed'
+            );
+          }
+        }
+      }
+
+      // Tier 3: user-global (~/.archon/.archon/scripts/)
       if (!scriptDef) {
         const globalScriptsDir = resolve(getArchonHome(), '.archon', 'scripts');
         if (globalScriptsDir !== scriptsDir) {
@@ -1559,7 +1591,7 @@ async function executeScriptNode(
       }
 
       if (!scriptDef) {
-        const errorMsg = `Script node '${node.id}': named script '${finalScript}' not found in .archon/scripts/ (repo or global)`;
+        const errorMsg = `Script node '${node.id}': named script '${finalScript}' not found in .archon/scripts/ (repo, workspace, or global)`;
         getLog().error({ nodeId: node.id, scriptName: finalScript }, 'script_not_found');
         await safeSendMessage(platform, conversationId, errorMsg, nodeContext);
         await logNodeError(logDir, workflowRun.id, node.id, errorMsg);
@@ -2231,7 +2263,8 @@ async function executeApprovalNode(
   config: WorkflowConfig,
   workflowLevelOptions: WorkflowLevelOptions,
   configuredCommandFolder?: string,
-  issueContext?: string
+  issueContext?: string,
+  workspaceArchonDir?: string
 ): Promise<NodeOutput> {
   const msgContext = { workflowId: workflowRun.id, nodeName: node.id };
 
@@ -2328,7 +2361,8 @@ async function executeApprovalNode(
       nodeOutputs,
       undefined, // fresh session
       configuredCommandFolder,
-      issueContext
+      issueContext,
+      workspaceArchonDir
     );
 
     if (output.state === 'failed') {
@@ -2399,9 +2433,27 @@ export async function executeDagWorkflow(
   config: WorkflowConfig,
   configuredCommandFolder?: string,
   issueContext?: string,
-  priorCompletedNodes?: Map<string, string>
+  priorCompletedNodes?: Map<string, string>,
+  workspaceArchonDir?: string
 ): Promise<string | undefined> {
   const dagStartTime = Date.now();
+
+  // Resolve the workspace-in-userspace .archon dir once per run. If the caller
+  // didn't pre-compute it, derive it from the git remote. Null means the
+  // workspace tier is silently skipped for script/command lookups in this run.
+  let resolvedWorkspaceArchonDir: string | undefined = workspaceArchonDir;
+  if (resolvedWorkspaceArchonDir === undefined) {
+    const ownerRepo = await parseOwnerRepoFromGitRemote(cwd);
+    if (ownerRepo) {
+      resolvedWorkspaceArchonDir = getProjectArchonDir(ownerRepo.owner, ownerRepo.repo);
+      getLog().debug(
+        { cwd, workspaceArchonDir: resolvedWorkspaceArchonDir },
+        'dag.workspace_archon_dir_resolved'
+      );
+    } else {
+      getLog().debug({ cwd }, 'dag.workspace_archon_dir_unavailable');
+    }
+  }
   const workflowLevelOptions = {
     effort: workflow.effort,
     thinking: workflow.thinking,
@@ -2693,7 +2745,8 @@ export async function executeDagWorkflow(
               config,
               workflowLevelOptions,
               configuredCommandFolder,
-              issueContext
+              issueContext,
+              resolvedWorkspaceArchonDir
             );
             return { nodeId: node.id, output };
           }
@@ -2744,6 +2797,7 @@ export async function executeDagWorkflow(
               baseBranch,
               docsDir,
               nodeOutputs,
+              resolvedWorkspaceArchonDir,
               issueContext
             );
             return { nodeId: node.id, output };
@@ -2795,7 +2849,8 @@ export async function executeDagWorkflow(
               // ensures the source is never mutated, so retries can safely resume from it.
               resumeSessionId,
               configuredCommandFolder,
-              issueContext
+              issueContext,
+              resolvedWorkspaceArchonDir
             );
 
             if (output.state !== 'failed') break;

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -810,7 +810,8 @@ async function executeNodeInternal(
       baseBranch,
       docsDir,
       issueContext,
-      `dag node '${node.id}' prompt`
+      `dag node '${node.id}' prompt`,
+      workspaceSearchPath ? resolve(workspaceSearchPath, '.archon') : undefined
     );
   } catch (error) {
     const err = error as Error;
@@ -1322,6 +1323,7 @@ async function executeBashNode(
   baseBranch: string,
   docsDir: string,
   nodeOutputs: Map<string, NodeOutput>,
+  workspaceSearchPath?: string,
   issueContext?: string
 ): Promise<NodeOutput> {
   const nodeStartTime = Date.now();
@@ -1352,7 +1354,12 @@ async function executeBashNode(
     nodeName: node.id,
   });
 
-  // Variable substitution on script
+  // Variable substitution on script. Derive $WORKSPACE_ARCHON_DIR from the
+  // workspace search path so bash scripts can wrap `bun run` on named workspace
+  // scripts via an absolute path.
+  const workspaceArchonDir = workspaceSearchPath
+    ? resolve(workspaceSearchPath, '.archon')
+    : undefined;
   const { prompt: substitutedScript } = substituteWorkflowVariables(
     node.bash,
     workflowRun.id,
@@ -1360,7 +1367,10 @@ async function executeBashNode(
     artifactsDir,
     baseBranch,
     docsDir,
-    issueContext
+    issueContext,
+    undefined,
+    undefined,
+    workspaceArchonDir
   );
   const finalScript = substituteNodeOutputRefs(substitutedScript, nodeOutputs, true);
 
@@ -1503,7 +1513,11 @@ async function executeScriptNode(
     nodeName: node.id,
   });
 
-  // Variable substitution on script field
+  // Variable substitution on script field. Derive $WORKSPACE_ARCHON_DIR so
+  // inline scripts can reference the workspace-tier .archon dir directly.
+  const workspaceArchonDir = workspaceSearchPath
+    ? resolve(workspaceSearchPath, '.archon')
+    : undefined;
   const { prompt: substitutedScript } = substituteWorkflowVariables(
     node.script,
     workflowRun.id,
@@ -1511,7 +1525,10 @@ async function executeScriptNode(
     artifactsDir,
     baseBranch,
     docsDir,
-    issueContext
+    issueContext,
+    undefined,
+    undefined,
+    workspaceArchonDir
   );
   const finalScript = substituteNodeOutputRefs(substitutedScript, nodeOutputs, false);
 
@@ -1770,7 +1787,8 @@ async function executeLoopNode(
   docsDir: string,
   nodeOutputs: Map<string, NodeOutput>,
   config: WorkflowConfig,
-  issueContext?: string
+  issueContext?: string,
+  workspaceSearchPath?: string
 ): Promise<NodeExecutionResult> {
   const loop = node.loop;
   const msgContext = { workflowId: workflowRun.id, nodeName: node.id };
@@ -1871,7 +1889,9 @@ async function executeLoopNode(
         baseBranch,
         docsDir,
         issueContext,
-        i === startIteration ? loopUserInput : ''
+        i === startIteration ? loopUserInput : '',
+        undefined,
+        workspaceSearchPath ? resolve(workspaceSearchPath, '.archon') : undefined
       );
       const finalPrompt = substituteNodeOutputRefs(substitutedPrompt, nodeOutputs);
 
@@ -2069,7 +2089,10 @@ async function executeLoopNode(
           artifactsDir,
           baseBranch,
           docsDir,
-          issueContext
+          issueContext,
+          undefined,
+          undefined,
+          workspaceSearchPath ? resolve(workspaceSearchPath, '.archon') : undefined
         );
         const substitutedBash = substituteNodeOutputRefs(
           bashPrompt,
@@ -2322,7 +2345,8 @@ async function executeApprovalNode(
       docsDir,
       issueContext,
       undefined, // loopUserInput
-      rejectionReason
+      rejectionReason,
+      workspaceSearchPath ? resolve(workspaceSearchPath, '.archon') : undefined
     );
 
     // Build a synthetic PromptNode to reuse executeNodeInternal
@@ -2673,6 +2697,7 @@ export async function executeDagWorkflow(
               baseBranch,
               docsDir,
               nodeOutputs,
+              resolvedWorkspaceSearchPath,
               issueContext
             );
             return { nodeId: node.id, output };
@@ -2723,7 +2748,8 @@ export async function executeDagWorkflow(
               docsDir,
               nodeOutputs,
               config,
-              issueContext
+              issueContext,
+              resolvedWorkspaceSearchPath
             );
             return { nodeId: node.id, output };
           }

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -42,7 +42,7 @@ import {
   isApprovalContext,
 } from './schemas';
 import { formatToolCall } from './utils/tool-formatter';
-import { createLogger } from '@archon/paths';
+import { createLogger, getArchonHome } from '@archon/paths';
 import { getWorkflowEventEmitter } from './event-emitter';
 import { evaluateCondition } from './condition-evaluator';
 import { isClaudeModel, isModelCompatible } from './model-validation';
@@ -1527,13 +1527,39 @@ async function executeScriptNode(
         args = ['run', ...withFlags, 'python', '-c', finalScript];
       }
     } else {
-      // Named script — look up in .archon/scripts/ directory
+      // Named script — look up in .archon/scripts/ directory.
+      // Priority: repo-local first, then ~/.archon/.archon/scripts/ (user-global).
+      // Mirrors the global command/workflow fallback so users can keep per-machine
+      // script libraries outside any repo.
       const scriptsDir = resolve(cwd, '.archon', 'scripts');
       const scripts = await discoverScripts(scriptsDir);
-      const scriptDef = scripts.get(finalScript);
+      let scriptDef = scripts.get(finalScript);
 
       if (!scriptDef) {
-        const errorMsg = `Script node '${node.id}': named script '${finalScript}' not found in .archon/scripts/`;
+        const globalScriptsDir = resolve(getArchonHome(), '.archon', 'scripts');
+        if (globalScriptsDir !== scriptsDir) {
+          try {
+            const globalScripts = await discoverScripts(globalScriptsDir);
+            scriptDef = globalScripts.get(finalScript);
+            if (scriptDef) {
+              getLog().debug(
+                { nodeId: node.id, scriptName: finalScript, source: 'global' },
+                'dag.script_loaded_global'
+              );
+            }
+          } catch (discoveryErr) {
+            // discoverScripts swallows ENOENT; surface any other error as a warning
+            // but still fall through to the not-found path below.
+            getLog().warn(
+              { err: discoveryErr as Error, globalScriptsDir },
+              'dag.script_global_discovery_failed'
+            );
+          }
+        }
+      }
+
+      if (!scriptDef) {
+        const errorMsg = `Script node '${node.id}': named script '${finalScript}' not found in .archon/scripts/ (repo or global)`;
         getLog().error({ nodeId: node.id, scriptName: finalScript }, 'script_not_found');
         await safeSendMessage(platform, conversationId, errorMsg, nodeContext);
         await logNodeError(logDir, workflowRun.id, node.id, errorMsg);

--- a/packages/workflows/src/executor-shared-command-global.test.ts
+++ b/packages/workflows/src/executor-shared-command-global.test.ts
@@ -141,40 +141,43 @@ describe('loadCommandPrompt — user-global fallback', () => {
 describe('loadCommandPrompt — workspace-in-userspace tier', () => {
   let repoCwd: string;
   let globalHome: string;
-  let workspaceArchonDir: string;
+  // workspaceSearchPath stands in for `~/.archon/workspaces/<owner>/<repo>/` —
+  // the PROJECT ROOT. The loader appends `.archon/commands/` to find files.
+  let workspaceSearchPath: string;
 
   beforeAll(async () => {
     repoCwd = await mkdtemp(join(tmpdir(), 'archon-wsr-repo-'));
     globalHome = await mkdtemp(join(tmpdir(), 'archon-wsr-home-'));
-    workspaceArchonDir = await mkdtemp(join(tmpdir(), 'archon-wsr-workspace-'));
+    workspaceSearchPath = await mkdtemp(join(tmpdir(), 'archon-wsr-workspace-'));
     process.env.ARCHON_HOME = globalHome;
   });
 
   afterAll(async () => {
     await rm(repoCwd, { recursive: true, force: true });
     await rm(globalHome, { recursive: true, force: true });
-    await rm(workspaceArchonDir, { recursive: true, force: true });
+    await rm(workspaceSearchPath, { recursive: true, force: true });
     delete process.env.ARCHON_HOME;
   });
 
   beforeEach(async () => {
     await rm(join(repoCwd, '.archon'), { recursive: true, force: true });
     await rm(join(globalHome, '.archon'), { recursive: true, force: true });
-    // workspaceArchonDir stands in for `~/.archon/workspaces/<owner>/<repo>/.archon`
-    // so its immediate children are `commands/`, `scripts/`, `workflows/` (no nested .archon).
-    await rm(join(workspaceArchonDir, 'commands'), { recursive: true, force: true });
+    await rm(join(workspaceSearchPath, '.archon'), { recursive: true, force: true });
   });
 
   it('loads a command found only in the workspace dir', async () => {
-    await mkdir(join(workspaceArchonDir, 'commands'), { recursive: true });
-    await writeFile(join(workspaceArchonDir, 'commands', 'ws-only.md'), 'workspace content');
+    await mkdir(join(workspaceSearchPath, '.archon', 'commands'), { recursive: true });
+    await writeFile(
+      join(workspaceSearchPath, '.archon', 'commands', 'ws-only.md'),
+      'workspace content'
+    );
 
     const result = await loadCommandPrompt(
       makeDeps(),
       repoCwd,
       'ws-only',
       undefined,
-      workspaceArchonDir
+      workspaceSearchPath
     );
 
     expect(result.success).toBe(true);
@@ -185,16 +188,16 @@ describe('loadCommandPrompt — workspace-in-userspace tier', () => {
 
   it('prefers repo over workspace when both exist', async () => {
     await mkdir(join(repoCwd, '.archon', 'commands'), { recursive: true });
-    await mkdir(join(workspaceArchonDir, 'commands'), { recursive: true });
+    await mkdir(join(workspaceSearchPath, '.archon', 'commands'), { recursive: true });
     await writeFile(join(repoCwd, '.archon', 'commands', 'dup.md'), 'from-repo');
-    await writeFile(join(workspaceArchonDir, 'commands', 'dup.md'), 'from-workspace');
+    await writeFile(join(workspaceSearchPath, '.archon', 'commands', 'dup.md'), 'from-workspace');
 
     const result = await loadCommandPrompt(
       makeDeps(),
       repoCwd,
       'dup',
       undefined,
-      workspaceArchonDir
+      workspaceSearchPath
     );
 
     expect(result.success).toBe(true);
@@ -204,9 +207,9 @@ describe('loadCommandPrompt — workspace-in-userspace tier', () => {
   });
 
   it('prefers workspace over user-global when both exist', async () => {
-    await mkdir(join(workspaceArchonDir, 'commands'), { recursive: true });
+    await mkdir(join(workspaceSearchPath, '.archon', 'commands'), { recursive: true });
     await mkdir(join(globalHome, '.archon', 'commands'), { recursive: true });
-    await writeFile(join(workspaceArchonDir, 'commands', 'mid.md'), 'from-workspace');
+    await writeFile(join(workspaceSearchPath, '.archon', 'commands', 'mid.md'), 'from-workspace');
     await writeFile(join(globalHome, '.archon', 'commands', 'mid.md'), 'from-global');
 
     const result = await loadCommandPrompt(
@@ -214,7 +217,7 @@ describe('loadCommandPrompt — workspace-in-userspace tier', () => {
       repoCwd,
       'mid',
       undefined,
-      workspaceArchonDir
+      workspaceSearchPath
     );
 
     expect(result.success).toBe(true);
@@ -223,10 +226,13 @@ describe('loadCommandPrompt — workspace-in-userspace tier', () => {
     }
   });
 
-  it('omitting workspaceArchonDir preserves two-tier behavior', async () => {
+  it('omitting workspaceSearchPath preserves two-tier behavior', async () => {
     // Stage a workspace command; omit the param so it should NOT be found
-    await mkdir(join(workspaceArchonDir, 'commands'), { recursive: true });
-    await writeFile(join(workspaceArchonDir, 'commands', 'hidden.md'), 'should not be loaded');
+    await mkdir(join(workspaceSearchPath, '.archon', 'commands'), { recursive: true });
+    await writeFile(
+      join(workspaceSearchPath, '.archon', 'commands', 'hidden.md'),
+      'should not be loaded'
+    );
 
     const result = await loadCommandPrompt(makeDeps(), repoCwd, 'hidden');
 
@@ -242,13 +248,13 @@ describe('loadCommandPrompt — workspace-in-userspace tier', () => {
       repoCwd,
       'nope',
       undefined,
-      workspaceArchonDir
+      workspaceSearchPath
     );
 
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.reason).toBe('not_found');
-      expect(result.message).toContain(workspaceArchonDir);
+      expect(result.message).toContain(workspaceSearchPath);
     }
   });
 });

--- a/packages/workflows/src/executor-shared-command-global.test.ts
+++ b/packages/workflows/src/executor-shared-command-global.test.ts
@@ -137,3 +137,118 @@ describe('loadCommandPrompt — user-global fallback', () => {
     }
   });
 });
+
+describe('loadCommandPrompt — workspace-in-userspace tier', () => {
+  let repoCwd: string;
+  let globalHome: string;
+  let workspaceArchonDir: string;
+
+  beforeAll(async () => {
+    repoCwd = await mkdtemp(join(tmpdir(), 'archon-wsr-repo-'));
+    globalHome = await mkdtemp(join(tmpdir(), 'archon-wsr-home-'));
+    workspaceArchonDir = await mkdtemp(join(tmpdir(), 'archon-wsr-workspace-'));
+    process.env.ARCHON_HOME = globalHome;
+  });
+
+  afterAll(async () => {
+    await rm(repoCwd, { recursive: true, force: true });
+    await rm(globalHome, { recursive: true, force: true });
+    await rm(workspaceArchonDir, { recursive: true, force: true });
+    delete process.env.ARCHON_HOME;
+  });
+
+  beforeEach(async () => {
+    await rm(join(repoCwd, '.archon'), { recursive: true, force: true });
+    await rm(join(globalHome, '.archon'), { recursive: true, force: true });
+    // workspaceArchonDir stands in for `~/.archon/workspaces/<owner>/<repo>/.archon`
+    // so its immediate children are `commands/`, `scripts/`, `workflows/` (no nested .archon).
+    await rm(join(workspaceArchonDir, 'commands'), { recursive: true, force: true });
+  });
+
+  it('loads a command found only in the workspace dir', async () => {
+    await mkdir(join(workspaceArchonDir, 'commands'), { recursive: true });
+    await writeFile(join(workspaceArchonDir, 'commands', 'ws-only.md'), 'workspace content');
+
+    const result = await loadCommandPrompt(
+      makeDeps(),
+      repoCwd,
+      'ws-only',
+      undefined,
+      workspaceArchonDir
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.content).toBe('workspace content');
+    }
+  });
+
+  it('prefers repo over workspace when both exist', async () => {
+    await mkdir(join(repoCwd, '.archon', 'commands'), { recursive: true });
+    await mkdir(join(workspaceArchonDir, 'commands'), { recursive: true });
+    await writeFile(join(repoCwd, '.archon', 'commands', 'dup.md'), 'from-repo');
+    await writeFile(join(workspaceArchonDir, 'commands', 'dup.md'), 'from-workspace');
+
+    const result = await loadCommandPrompt(
+      makeDeps(),
+      repoCwd,
+      'dup',
+      undefined,
+      workspaceArchonDir
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.content).toBe('from-repo');
+    }
+  });
+
+  it('prefers workspace over user-global when both exist', async () => {
+    await mkdir(join(workspaceArchonDir, 'commands'), { recursive: true });
+    await mkdir(join(globalHome, '.archon', 'commands'), { recursive: true });
+    await writeFile(join(workspaceArchonDir, 'commands', 'mid.md'), 'from-workspace');
+    await writeFile(join(globalHome, '.archon', 'commands', 'mid.md'), 'from-global');
+
+    const result = await loadCommandPrompt(
+      makeDeps(),
+      repoCwd,
+      'mid',
+      undefined,
+      workspaceArchonDir
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.content).toBe('from-workspace');
+    }
+  });
+
+  it('omitting workspaceArchonDir preserves two-tier behavior', async () => {
+    // Stage a workspace command; omit the param so it should NOT be found
+    await mkdir(join(workspaceArchonDir, 'commands'), { recursive: true });
+    await writeFile(join(workspaceArchonDir, 'commands', 'hidden.md'), 'should not be loaded');
+
+    const result = await loadCommandPrompt(makeDeps(), repoCwd, 'hidden');
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.reason).toBe('not_found');
+    }
+  });
+
+  it('not-found error message lists the workspace search paths', async () => {
+    const result = await loadCommandPrompt(
+      makeDeps(),
+      repoCwd,
+      'nope',
+      undefined,
+      workspaceArchonDir
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.reason).toBe('not_found');
+      expect(result.message).toContain(workspaceArchonDir);
+    }
+  });
+});

--- a/packages/workflows/src/executor-shared-command-global.test.ts
+++ b/packages/workflows/src/executor-shared-command-global.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for the user-global command fallback in loadCommandPrompt.
+ *
+ * Isolated in its own test file (and its own bun test invocation — see package.json)
+ * because it mocks @archon/paths differently than executor-shared.test.ts:
+ * this file needs getArchonHome + getCommandFolderSearchPaths to be present,
+ * whereas the other file only cares about createLogger. Two files cannot
+ * mock.module() the same path with different implementations in one batch.
+ */
+import { describe, it, expect, mock, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// Mock logger + paths BEFORE importing module under test
+const mockLogFn = mock(() => {});
+const mockLogger = {
+  info: mockLogFn,
+  warn: mockLogFn,
+  error: mockLogFn,
+  debug: mockLogFn,
+  trace: mockLogFn,
+  fatal: mockLogFn,
+  child: mock(() => mockLogger),
+  bindings: mock(() => ({ module: 'test' })),
+  isLevelEnabled: mock(() => true),
+  level: 'info',
+};
+
+// Hand-rolled partial mock of @archon/paths. Provides getArchonHome via the
+// test's ARCHON_HOME env and getCommandFolderSearchPaths as a static list,
+// mirroring the real implementations.
+mock.module('@archon/paths', () => ({
+  createLogger: mock(() => mockLogger),
+  getArchonHome: (): string => {
+    const envHome = process.env.ARCHON_HOME;
+    if (!envHome) throw new Error('ARCHON_HOME not set in test');
+    return envHome;
+  },
+  getCommandFolderSearchPaths: (configured?: string): string[] => {
+    const paths = ['.archon/commands', '.archon/commands/defaults'];
+    if (configured && !paths.includes(configured)) paths.push(configured);
+    return paths;
+  },
+  // No-op defaults path so the app-defaults branch never hits the real filesystem
+  getDefaultCommandsPath: (): string => '/dev/null/nonexistent',
+}));
+
+// Mock bundled-defaults to avoid loading the real binary build check
+mock.module('./defaults/bundled-defaults', () => ({
+  BUNDLED_COMMANDS: {},
+  isBinaryBuild: (): boolean => false,
+}));
+
+import { loadCommandPrompt } from './executor-shared';
+import type { WorkflowDeps } from './deps';
+
+// Minimal deps — loadCommandPrompt only uses deps.loadConfig
+const makeDeps = (loadDefaultCommands = true): WorkflowDeps =>
+  ({
+    loadConfig: async () => ({ defaults: { loadDefaultCommands } }),
+  }) as unknown as WorkflowDeps;
+
+describe('loadCommandPrompt — user-global fallback', () => {
+  let repoCwd: string;
+  let globalHome: string;
+
+  beforeAll(async () => {
+    repoCwd = await mkdtemp(join(tmpdir(), 'archon-test-repo-'));
+    globalHome = await mkdtemp(join(tmpdir(), 'archon-test-home-'));
+    process.env.ARCHON_HOME = globalHome;
+  });
+
+  afterAll(async () => {
+    await rm(repoCwd, { recursive: true, force: true });
+    await rm(globalHome, { recursive: true, force: true });
+    delete process.env.ARCHON_HOME;
+  });
+
+  beforeEach(async () => {
+    // Wipe contents between tests but keep the tmpdirs themselves
+    await rm(join(repoCwd, '.archon'), { recursive: true, force: true });
+    await rm(join(globalHome, '.archon'), { recursive: true, force: true });
+  });
+
+  it('loads a command only present in the user-global dir', async () => {
+    await mkdir(join(globalHome, '.archon', 'commands'), { recursive: true });
+    await writeFile(
+      join(globalHome, '.archon', 'commands', 'greet-global.md'),
+      'You are a greeter. Say hello!'
+    );
+
+    const result = await loadCommandPrompt(makeDeps(), repoCwd, 'greet-global');
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.content).toBe('You are a greeter. Say hello!');
+    }
+  });
+
+  it('prefers the repo-local copy over the global copy when both exist', async () => {
+    await mkdir(join(repoCwd, '.archon', 'commands'), { recursive: true });
+    await mkdir(join(globalHome, '.archon', 'commands'), { recursive: true });
+    await writeFile(join(repoCwd, '.archon', 'commands', 'shared.md'), 'repo version');
+    await writeFile(join(globalHome, '.archon', 'commands', 'shared.md'), 'global version');
+
+    const result = await loadCommandPrompt(makeDeps(), repoCwd, 'shared');
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.content).toBe('repo version');
+    }
+  });
+
+  it('returns empty_file when the global command file is empty', async () => {
+    await mkdir(join(globalHome, '.archon', 'commands'), { recursive: true });
+    await writeFile(join(globalHome, '.archon', 'commands', 'blank.md'), '   \n\n');
+
+    const result = await loadCommandPrompt(makeDeps(), repoCwd, 'blank');
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.reason).toBe('empty_file');
+      expect(result.message).toContain('global');
+    }
+  });
+
+  it('fails with not_found when absent in repo, global, and defaults', async () => {
+    const result = await loadCommandPrompt(makeDeps(), repoCwd, 'ghost-command');
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.reason).toBe('not_found');
+      // Message should mention both repo-relative and global paths
+      expect(result.message).toContain('.archon/commands');
+      expect(result.message).toContain(globalHome);
+    }
+  });
+});

--- a/packages/workflows/src/executor-shared.test.ts
+++ b/packages/workflows/src/executor-shared.test.ts
@@ -92,6 +92,36 @@ describe('substituteWorkflowVariables', () => {
     expect(prompt).toBe('Goal: add dark mode. Args: add dark mode');
   });
 
+  it('replaces $WORKSPACE_ARCHON_DIR with the provided path', () => {
+    const { prompt } = substituteWorkflowVariables(
+      'bun run "$WORKSPACE_ARCHON_DIR/scripts/foo.ts"',
+      'run-1',
+      'msg',
+      '/tmp',
+      'main',
+      'docs/',
+      undefined,
+      undefined,
+      undefined,
+      '/Users/test/.archon/workspaces/owner/repo/.archon'
+    );
+    expect(prompt).toBe(
+      'bun run "/Users/test/.archon/workspaces/owner/repo/.archon/scripts/foo.ts"'
+    );
+  });
+
+  it('replaces $WORKSPACE_ARCHON_DIR with empty string when omitted', () => {
+    const { prompt } = substituteWorkflowVariables(
+      'prefix=$WORKSPACE_ARCHON_DIR/x',
+      'run-1',
+      'msg',
+      '/tmp',
+      'main',
+      'docs/'
+    );
+    expect(prompt).toBe('prefix=/x');
+  });
+
   it('replaces $DOCS_DIR with configured path', () => {
     const { prompt } = substituteWorkflowVariables(
       'Check $DOCS_DIR for changes',

--- a/packages/workflows/src/executor-shared.ts
+++ b/packages/workflows/src/executor-shared.ts
@@ -125,7 +125,8 @@ export async function loadCommandPrompt(
   deps: WorkflowDeps,
   cwd: string,
   commandName: string,
-  configuredFolder?: string
+  configuredFolder?: string,
+  workspaceArchonDir?: string
 ): Promise<LoadCommandResult> {
   // Validate command name first
   if (!isValidCommandName(commandName)) {
@@ -192,6 +193,50 @@ export async function loadCommandPrompt(
         reason: 'read_error',
         message: `Error reading command ${commandName}.md: ${err.message}`,
       };
+    }
+  }
+
+  // Then search the workspace-in-userspace dir
+  // (~/.archon/workspaces/<owner>/<repo>/.archon/commands/) if provided.
+  // This tier lives between repo and global so precedence is
+  // repo > workspace > global > defaults.
+  if (workspaceArchonDir) {
+    for (const folder of searchPaths) {
+      const filePath = join(
+        workspaceArchonDir,
+        folder.replace(/^\.archon\//, ''),
+        `${commandName}.md`
+      );
+      try {
+        const content = await readFile(filePath, 'utf-8');
+        if (!content.trim()) {
+          getLog().error({ commandName, source: 'workspace' }, 'command_file_empty');
+          return {
+            success: false,
+            reason: 'empty_file',
+            message: `Command file is empty (workspace): ${commandName}.md`,
+          };
+        }
+        getLog().debug({ commandName, folder, source: 'workspace' }, 'command_loaded_workspace');
+        return { success: true, content };
+      } catch (error) {
+        const err = error as NodeJS.ErrnoException;
+        if (err.code === 'ENOENT') continue;
+        if (err.code === 'EACCES') {
+          getLog().error({ commandName, filePath }, 'command_file_permission_denied');
+          return {
+            success: false,
+            reason: 'permission_denied',
+            message: `Permission denied reading workspace command: ${commandName}.md`,
+          };
+        }
+        getLog().error({ err, commandName, filePath }, 'command_file_read_error');
+        return {
+          success: false,
+          reason: 'read_error',
+          message: `Error reading workspace command ${commandName}.md: ${err.message}`,
+        };
+      }
     }
   }
 
@@ -275,10 +320,13 @@ export async function loadCommandPrompt(
   }
 
   // Not found anywhere
+  const workspacePaths = workspaceArchonDir
+    ? searchPaths.map(p => `${workspaceArchonDir}/${p.replace(/^\.archon\//, '')}`)
+    : [];
   const globalPaths = searchPaths.map(p => `${archonHome}/${p}`);
   const allSearchPaths = loadDefaultCommands
-    ? [...searchPaths, ...globalPaths, 'app defaults']
-    : [...searchPaths, ...globalPaths];
+    ? [...searchPaths, ...workspacePaths, ...globalPaths, 'app defaults']
+    : [...searchPaths, ...workspacePaths, ...globalPaths];
   getLog().error({ commandName, searchPaths: allSearchPaths }, 'command_not_found');
   return {
     success: false,

--- a/packages/workflows/src/executor-shared.ts
+++ b/packages/workflows/src/executor-shared.ts
@@ -351,6 +351,11 @@ export const CONTEXT_VAR_PATTERN_STR = '\\$(?:CONTEXT|EXTERNAL_CONTEXT|ISSUE_CON
  * - $LOOP_USER_INPUT - User feedback from interactive loop approval. Only populated on the
  *   first iteration of a resumed interactive loop; empty string on all other iterations.
  * - $REJECTION_REASON - Reviewer feedback from approval node rejection (on_reject prompts only).
+ * - $WORKSPACE_ARCHON_DIR - The user-global workspace-tier `.archon` directory
+ *   (`~/.archon/workspaces/<owner>/<repo>/.archon`) when resolvable from the cwd,
+ *   empty string otherwise. Useful in bash/script nodes that wrap `bun run`
+ *   on named scripts — since worktrees may not contain `.archon/`, bash wrappers
+ *   need an absolute path into the workspace-tier scripts directory.
  *
  * When issueContext is undefined, context variables are replaced with empty string
  * to avoid sending literal "$CONTEXT" to the AI.
@@ -364,7 +369,8 @@ export function substituteWorkflowVariables(
   docsDir: string,
   issueContext?: string,
   loopUserInput?: string,
-  rejectionReason?: string
+  rejectionReason?: string,
+  workspaceArchonDir?: string
 ): { prompt: string; contextSubstituted: boolean } {
   // Fail fast if the prompt references $BASE_BRANCH but no base branch could be resolved
   if (!baseBranch && prompt.includes('$BASE_BRANCH')) {
@@ -386,7 +392,8 @@ export function substituteWorkflowVariables(
     .replace(/\$BASE_BRANCH/g, baseBranch)
     .replace(/\$DOCS_DIR/g, resolvedDocsDir)
     .replace(/\$LOOP_USER_INPUT/g, loopUserInput ?? '')
-    .replace(/\$REJECTION_REASON/g, rejectionReason ?? '');
+    .replace(/\$REJECTION_REASON/g, rejectionReason ?? '')
+    .replace(/\$WORKSPACE_ARCHON_DIR/g, workspaceArchonDir ?? '');
 
   // Check if context variables exist (use fresh regex to avoid lastIndex issues)
   const hasContextVariables = new RegExp(CONTEXT_VAR_PATTERN_STR).test(result);
@@ -432,7 +439,8 @@ export function buildPromptWithContext(
   baseBranch: string,
   docsDir: string,
   issueContext: string | undefined,
-  logLabel: string
+  logLabel: string,
+  workspaceArchonDir?: string
 ): string {
   const { prompt, contextSubstituted } = substituteWorkflowVariables(
     template,
@@ -441,7 +449,10 @@ export function buildPromptWithContext(
     artifactsDir,
     baseBranch,
     docsDir,
-    issueContext
+    issueContext,
+    undefined,
+    undefined,
+    workspaceArchonDir
   );
 
   if (issueContext && !contextSubstituted) {

--- a/packages/workflows/src/executor-shared.ts
+++ b/packages/workflows/src/executor-shared.ts
@@ -126,7 +126,7 @@ export async function loadCommandPrompt(
   cwd: string,
   commandName: string,
   configuredFolder?: string,
-  workspaceArchonDir?: string
+  workspaceSearchPath?: string
 ): Promise<LoadCommandResult> {
   // Validate command name first
   if (!isValidCommandName(commandName)) {
@@ -198,15 +198,13 @@ export async function loadCommandPrompt(
 
   // Then search the workspace-in-userspace dir
   // (~/.archon/workspaces/<owner>/<repo>/.archon/commands/) if provided.
+  // workspaceSearchPath is the PROJECT ROOT; append the same .archon-prefixed
+  // folder name used for repo-local and global searches.
   // This tier lives between repo and global so precedence is
   // repo > workspace > global > defaults.
-  if (workspaceArchonDir) {
+  if (workspaceSearchPath) {
     for (const folder of searchPaths) {
-      const filePath = join(
-        workspaceArchonDir,
-        folder.replace(/^\.archon\//, ''),
-        `${commandName}.md`
-      );
+      const filePath = join(workspaceSearchPath, folder, `${commandName}.md`);
       try {
         const content = await readFile(filePath, 'utf-8');
         if (!content.trim()) {
@@ -320,8 +318,8 @@ export async function loadCommandPrompt(
   }
 
   // Not found anywhere
-  const workspacePaths = workspaceArchonDir
-    ? searchPaths.map(p => `${workspaceArchonDir}/${p.replace(/^\.archon\//, '')}`)
+  const workspacePaths = workspaceSearchPath
+    ? searchPaths.map(p => `${workspaceSearchPath}/${p}`)
     : [];
   const globalPaths = searchPaths.map(p => `${archonHome}/${p}`);
   const allSearchPaths = loadDefaultCommands

--- a/packages/workflows/src/executor-shared.ts
+++ b/packages/workflows/src/executor-shared.ts
@@ -195,6 +195,46 @@ export async function loadCommandPrompt(
     }
   }
 
+  // Then search the user-global dir (~/.archon/.archon/commands/)
+  // Mirrors the global workflow discovery behavior so users can keep
+  // per-machine command libraries outside any repo.
+  const archonHome = archonPaths.getArchonHome();
+  for (const folder of searchPaths) {
+    const filePath = join(archonHome, folder, `${commandName}.md`);
+    try {
+      const content = await readFile(filePath, 'utf-8');
+      if (!content.trim()) {
+        getLog().error({ commandName, source: 'global' }, 'command_file_empty');
+        return {
+          success: false,
+          reason: 'empty_file',
+          message: `Command file is empty (global): ${commandName}.md`,
+        };
+      }
+      getLog().debug({ commandName, folder, source: 'global' }, 'command_loaded_global');
+      return { success: true, content };
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code === 'ENOENT') {
+        continue;
+      }
+      if (err.code === 'EACCES') {
+        getLog().error({ commandName, filePath }, 'command_file_permission_denied');
+        return {
+          success: false,
+          reason: 'permission_denied',
+          message: `Permission denied reading global command: ${commandName}.md`,
+        };
+      }
+      getLog().error({ err, commandName, filePath }, 'command_file_read_error');
+      return {
+        success: false,
+        reason: 'read_error',
+        message: `Error reading global command ${commandName}.md: ${err.message}`,
+      };
+    }
+  }
+
   // If not found in repo and app defaults enabled, search app defaults
   const loadDefaultCommands = config.defaults?.loadDefaultCommands ?? true;
   if (loadDefaultCommands) {
@@ -235,7 +275,10 @@ export async function loadCommandPrompt(
   }
 
   // Not found anywhere
-  const allSearchPaths = loadDefaultCommands ? [...searchPaths, 'app defaults'] : searchPaths;
+  const globalPaths = searchPaths.map(p => `${archonHome}/${p}`);
+  const allSearchPaths = loadDefaultCommands
+    ? [...searchPaths, ...globalPaths, 'app defaults']
+    : [...searchPaths, ...globalPaths];
   getLog().error({ commandName, searchPaths: allSearchPaths }, 'command_not_found');
   return {
     success: false,

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -116,6 +116,61 @@ nodes:
       expect(workflows[0].nodes[1].id).toBe('implement');
     });
 
+    it('should load workflows from workspaceSearchPath when absent from repo', async () => {
+      // workspaceSearchPath stands in for ~/.archon/workspaces/<owner>/<repo>/
+      // discoverWorkflows joins the workflow folder ('.archon/workflows') onto it.
+      const workspaceSearchPath = join(
+        tmpdir(),
+        `workspace-search-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      );
+      const wsWorkflowDir = join(workspaceSearchPath, '.archon', 'workflows');
+      await mkdir(wsWorkflowDir, { recursive: true });
+      const yaml = `name: ws-only\ndescription: workspace tier\nnodes:\n  - id: n\n    prompt: p\n`;
+      await writeFile(join(wsWorkflowDir, 'ws-only.yaml'), yaml);
+
+      try {
+        const result = await discoverWorkflows(testDir, {
+          loadDefaults: false,
+          workspaceSearchPath,
+        });
+        expect(result.workflows).toHaveLength(1);
+        expect(result.workflows[0].workflow.name).toBe('ws-only');
+      } finally {
+        await rm(workspaceSearchPath, { recursive: true, force: true });
+      }
+    });
+
+    it('repo workflow overrides workspace workflow with same filename', async () => {
+      const workspaceSearchPath = join(
+        tmpdir(),
+        `workspace-override-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      );
+      const wsWorkflowDir = join(workspaceSearchPath, '.archon', 'workflows');
+      await mkdir(wsWorkflowDir, { recursive: true });
+      await writeFile(
+        join(wsWorkflowDir, 'dup.yaml'),
+        `name: workspace-version\ndescription: ws\nnodes:\n  - id: n\n    prompt: p\n`
+      );
+
+      const repoWorkflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(repoWorkflowDir, { recursive: true });
+      await writeFile(
+        join(repoWorkflowDir, 'dup.yaml'),
+        `name: repo-version\ndescription: repo\nnodes:\n  - id: n\n    prompt: p\n`
+      );
+
+      try {
+        const result = await discoverWorkflows(testDir, {
+          loadDefaults: false,
+          workspaceSearchPath,
+        });
+        expect(result.workflows).toHaveLength(1);
+        expect(result.workflows[0].workflow.name).toBe('repo-version');
+      } finally {
+        await rm(workspaceSearchPath, { recursive: true, force: true });
+      }
+    });
+
     it('should return empty array for YAML missing name', async () => {
       const workflowDir = join(testDir, '.archon', 'workflows');
       await mkdir(workflowDir, { recursive: true });

--- a/packages/workflows/src/workflow-discovery.ts
+++ b/packages/workflows/src/workflow-discovery.ts
@@ -135,7 +135,11 @@ function loadBundledWorkflows(): DirLoadResult {
  */
 export async function discoverWorkflows(
   cwd: string,
-  options?: { globalSearchPath?: string; loadDefaults?: boolean }
+  options?: {
+    globalSearchPath?: string;
+    workspaceSearchPath?: string;
+    loadDefaults?: boolean;
+  }
 ): Promise<WorkflowLoadResult> {
   // Map of filename -> workflow+source for deduplication
   const workflowsByFile = new Map<string, WorkflowWithSource>();
@@ -207,6 +211,37 @@ export async function discoverWorkflows(
         getLog().warn({ err, globalWorkflowPath }, 'global_workflows_access_error');
       } else {
         getLog().debug({ globalWorkflowPath }, 'global_workflows_not_found');
+      }
+    }
+  }
+
+  // 2b. Load from the workspace-in-userspace path
+  //     (~/.archon/workspaces/<owner>/<repo>/.archon/workflows/).
+  //     This tier lives between global and repo so precedence is
+  //     repo > workspace > global > bundled. Overrides by exact filename.
+  if (options?.workspaceSearchPath) {
+    const [workflowFolderName] = archonPaths.getWorkflowFolderSearchPaths();
+    const workspaceWorkflowPath = join(options.workspaceSearchPath, workflowFolderName);
+    getLog().debug({ workspaceWorkflowPath }, 'searching_workspace_workflows');
+    try {
+      await access(workspaceWorkflowPath);
+      const workspaceResult = await loadWorkflowsFromDir(workspaceWorkflowPath);
+      for (const [filename, workflow] of workspaceResult.workflows) {
+        if (workflowsByFile.has(filename)) {
+          getLog().debug({ filename }, 'workspace_workflow_overrides_global');
+        }
+        // Same scope decision as global: classified as 'project' (not a separate
+        // 'workspace' source badge). Can be split later if the UI needs it.
+        workflowsByFile.set(filename, { workflow, source: 'project' });
+      }
+      allErrors.push(...workspaceResult.errors);
+      getLog().info({ count: workspaceResult.workflows.size }, 'workspace_workflows_loaded');
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code !== 'ENOENT') {
+        getLog().warn({ err, workspaceWorkflowPath }, 'workspace_workflows_access_error');
+      } else {
+        getLog().debug({ workspaceWorkflowPath }, 'workspace_workflows_not_found');
       }
     }
   }
@@ -291,7 +326,7 @@ export async function discoverWorkflows(
 export async function discoverWorkflowsWithConfig(
   cwd: string,
   loadConfig: (cwd: string) => Promise<{ defaults?: { loadDefaultWorkflows?: boolean } }>,
-  options?: { globalSearchPath?: string }
+  options?: { globalSearchPath?: string; workspaceSearchPath?: string }
 ): Promise<WorkflowLoadResult> {
   let loadDefaults = true;
   try {


### PR DESCRIPTION
## Summary

- **Problem:** Workflows already fall back from `<cwd>/.archon/workflows/` to `~/.archon/.archon/workflows/` (user-global), but **commands** and **scripts** are repo-local only — there's no way to keep a command library or named script outside a specific repo.
- **Why it matters:** (a) Cross-project automations can't live outside the repo. (b) **Per-project automations that a team doesn't want committed have no home at all** — gitignoring `.archon/` breaks worktree-based runs because `git worktree add` only copies tracked files.
- **What changed:** Symmetric three-tier fallback for scripts/commands/workflows (`repo > workspace > user-global > bundled`), plus a new `$WORKSPACE_ARCHON_DIR` substitution variable so bash/script nodes can reference workspace-tier helpers by absolute path.
- **What did NOT change:** No CLI flag changes, no schema changes, no DB migrations, no changes to `@archon/isolation` / `@archon/core` / `@archon/server` / `@archon/web`. All existing workflows see identical behavior.

## The fallback chain

Before this PR, only **workflows** had a user-global fallback. Commands and scripts were repo-local only, and there was no project-scoped tier at all.

| Tier | Location | Scope | Existed before |
|---|---|---|---|
| 1 — Repo-local | `<cwd>/.archon/{workflows,commands,scripts}/` | Team-shared, committed | ✅ all three |
| 2 — Workspace-in-userspace (**new**) | `~/.archon/workspaces/<owner>/<repo>/.archon/{workflows,commands,scripts}/` | Per-project, per-user | ❌ none |
| 3 — User-global | `~/.archon/.archon/{workflows,commands,scripts}/` | Per-user, applies to every project | 🟡 workflows only |
| 4 — Bundled defaults | App defaults (filesystem in Bun, embedded in binary) | Ship-with-app | ✅ all three |

**Precedence: most specific wins.** Repo beats workspace; workspace beats user-global; user-global beats bundled. Matches VSCode's workspace-settings-over-user-settings model and git-config precedence.

Tier 2 slots into the existing directory layout Archon already uses at `~/.archon/workspaces/<owner>/<repo>/` (which today houses `source/`, `worktrees/`, `artifacts/`, `logs/`). Owner/repo is derived from the git origin remote of `cwd`; if the derivation fails (bare dir, no remote, git missing), the workspace tier is silently skipped and two-tier behavior is preserved.

## Motivating use case

I hit this gap building a per-project automation against a team repo where `.archon/` is not welcome. Today the three available options are all bad:

1. **Commit to the team repo** → teammates see it, team doesn't want it.
2. **`.gitignore` it in the team repo** → `git worktree add` only copies tracked files, so worktree-based runs (`--branch foo`) fail with "workflow not found."
3. **Drop it in `~/.archon/.archon/`** → applies to every project, pollutes unrelated codebases.

Tier 2 is the missing option: per-project, per-user, zero team-repo footprint.

## Resolution flow

```mermaid
flowchart LR
    A[archon workflow run X] --> B{Tier 1<br/>repo-local<br/>&lt;cwd&gt;/.archon/X}
    B -- hit --> Z[run X]
    B -- miss --> C{Tier 2 NEW<br/>workspace<br/>~/.archon/workspaces/O/R/.archon/X}
    C -- hit --> Z
    C -- miss --> D{Tier 3<br/>user-global<br/>~/.archon/.archon/X}
    D -- hit --> Z
    D -- miss --> E{Tier 4<br/>bundled defaults}
    E -- hit --> Z
    E -- miss --> F[not found]
```

Same chain applies to workflow discovery, `loadCommandPrompt`, and `executeScriptNode`. Before this PR: only workflow discovery had steps B→D→E→F; commands and scripts were B→F.

## Architecture: files changed

```mermaid
flowchart TD
    subgraph CLI[packages/cli/src/commands/workflow.ts]
        CLI1[loadWorkflows] --> CLI2[resolveWorkspaceSearchPath ~NEW~]
    end

    subgraph GIT[packages/git/src/repo.ts]
        GIT1[parseOwnerRepoFromRemoteUrl ~NEW~ pure]
        GIT2[parseOwnerRepoFromGitRemote ~NEW~ async]
        GIT2 --> GIT1
    end

    subgraph PATHS[packages/paths/src/archon-paths.ts]
        PATHS1[getProjectArchonDir ~NEW~ one-liner]
    end

    subgraph WORKFLOWS[packages/workflows/src]
        WD[workflow-discovery<br/>~modified~ accepts workspaceSearchPath]
        ES[executor-shared::loadCommandPrompt<br/>~modified~ accepts workspaceSearchPath]
        DE[dag-executor::executeScriptNode<br/>~modified~ accepts workspaceSearchPath]
        SUB[substituteWorkflowVariables<br/>~modified~ emits $WORKSPACE_ARCHON_DIR]
    end

    CORE[packages/core/src/handlers/clone.ts<br/>~refactor~ drop inline parser]

    CLI2 --> GIT2
    CLI2 --> PATHS1
    CLI1 --> WD
    CORE --> GIT1
    DE --> SUB
    ES --> SUB
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `cli/commands/workflow` | `@archon/git::parseOwnerRepoFromGitRemote` | **new** | derives owner/repo once per run |
| `cli/commands/workflow` | `@archon/paths::getProjectRoot` | **new** | builds workspace search path |
| `cli/commands/workflow` | `discoverWorkflowsWithConfig` | modified | extra `workspaceSearchPath` option |
| `workflow-discovery` | fs `access()` | modified | probes one additional directory |
| `executor-shared::loadCommandPrompt` | fs `readFile` | modified | probes one additional directory |
| `dag-executor::executeScriptNode` | `discoverScripts` | modified | probes one additional directory |
| `core/handlers/clone.ts` | `@archon/git::parseOwnerRepoFromRemoteUrl` | **new** | replaces inline URL parser |
| `executor-shared::substituteWorkflowVariables` | `$WORKSPACE_ARCHON_DIR` emission | **new** | mirrors `$ARTIFACTS_DIR` / `$BASE_BRANCH` |

## `$WORKSPACE_ARCHON_DIR` — why the variable is needed

The tier-3 fallback covers script/command/workflow *resolution*, but `bash:` and `script:` nodes that wrap `bun run` on named helper scripts via relative paths don't benefit — the Archon-managed worktree may not contain `.archon/` at all. Example from the giraffe automation that exposed this gap:

```yaml
# Before — breaks when .archon/ is outside the team repo:
- id: save-plan
  bash: |
    PLAN_OUTPUT=$plan-cmd.output bun run .archon/scripts/save-plan.ts

# After — absolute path via the new variable:
- id: save-plan
  bash: |
    PLAN_OUTPUT=$plan-cmd.output bun run "$WORKSPACE_ARCHON_DIR/scripts/save-plan.ts"
```

The variable resolves to `~/.archon/workspaces/<owner>/<repo>/.archon` when the workspace tier is available, and is an empty string otherwise. Plumbed through `executeBashNode`, `executeScriptNode`, `executeLoopNode` (both the prompt and `until_bash`), `executeApprovalNode`'s `on_reject` prompt, and `executeNodeInternal` (via `buildPromptWithContext`).

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `workflows`
- Module: `workflows:discovery`, `workflows:executor-shared`, `workflows:dag-executor`, `git:repo`, `paths:archon-paths`, `cli:workflow`

## Change Metadata

- Change type: `feature`
- Primary scope: `workflows`

## Linked Issue

- Closes: (none — gap I hit while building a personal automation against a team repo that doesn't want `.archon/` committed)
- Related: N/A
- Depends on: N/A
- Supersedes: N/A

## Validation Evidence

```bash
bun run type-check   # ✓
bun run lint         # ✓ (--max-warnings 0)
bun run format:check # ✓
bun run test         # ✓
```

Per-package test results after rebase on latest `upstream/dev`:

| Package / file | Pass | New cases |
|---|---|---|
| `@archon/git/git.test.ts` | 147 | 11 (`parseOwnerRepoFromRemoteUrl` x8, `parseOwnerRepoFromGitRemote` x3) |
| `@archon/workflows/dag-executor.test.ts` | 150 | 1 (mock gains `getArchonHome`) |
| `@archon/workflows/dag-executor-script-global.test.ts` (new) | 6 | all new |
| `@archon/workflows/executor-shared-command-global.test.ts` (new) | 9 | all new |
| `@archon/workflows/executor-shared.test.ts` | 37 | 2 (`$WORKSPACE_ARCHON_DIR` substitution hit/miss) |
| `@archon/workflows/loader.test.ts` | 92 | 2 (workspace tier in workflow discovery) |

End-to-end manual validation against a real Jira ticket in a private repo: moved a real `.archon/` config (workflows + commands + scripts + bundled giraffe automation) from `~/.archon/.archon/` to `~/.archon/workspaces/HireArt/hireart_main/.archon/` and ran:

```
archon workflow run giraffe-tick --cwd ~/code/hireart/hireart --branch giraffe-EE-474
```

Logs show the expected three-tier behavior:

```
workflow.discovery             count=1  msg=workspace_workflows_loaded
cli.workflow                   path=.../worktrees/.../task-giraffe-ee-474  msg=worktree_reused
workflow.script-discovery      count=0  dir=.../worktrees/.../.archon/scripts
workflow.script-discovery      count=12 dir=.../.archon/workspaces/HireArt/hireart_main/.archon/scripts
save-plan                      Completed (42ms)   # via $WORKSPACE_ARCHON_DIR
Workflow completed successfully.
```

## Security Impact

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **Slightly**: workflow/command/script loading probes two additional directories under `~/.archon/` per run. Reads only — no new write paths, no new privileged operations.

## Compatibility / Migration

- Backward compatible? **Yes**. New options are optional; omission preserves existing behavior. No config changes, no env changes, no schema changes, no migrations.
- When the git-remote parser fails (bare dir, missing origin, git missing), the workspace tier is **silently skipped** — same graceful-degradation pattern as the existing user-global tier when `ARCHON_HOME` is unset.

## Human Verification

**Verified:**
- Moving a real `.archon/` config from user-global to workspace-tier and running `archon workflow run` picked up the workflow from the new tier without changing invocation. Script discovery fell back to the workspace tier. A bash node using `$WORKSPACE_ARCHON_DIR` successfully invoked `bun run` on a workspace-tier helper from inside a worktree that had no `.archon/` directory.
- Worktree reuse semantics unchanged: `--branch <name>` pinned the same physical worktree across multiple ticks (`worktree_reused` log line on every run after the first).
- `parseOwnerRepoFromRemoteUrl` via the `clone.ts` refactor: `/clone` produces the same owner/repo slug for registered codebases as before.
- Negative case: running `archon workflow run` from a plain tmpdir with no `git remote` silently skips the workspace tier (no error, no warn-level log).

**Edge cases:**
- HTTPS, SSH (`git@host:`), `ssh://` URL forms
- Trailing `.git` suffix
- GitLab subgroup URLs (two-level slug: last two path segments)
- Missing origin remote
- Non-git directory
- Empty remote URL
- Test files excluded from tsc don't block validate even with type drift (noted and addressed in a small follow-up commit after rebase)

**Not verified:**
- Binary-build path (I run from `bun` source). Should work since the new code only adds a fallback tier and doesn't touch bundled-defaults loading.

## Side Effects / Blast Radius

- **Affected subsystems:** `@archon/workflows` (workflow-discovery, executor-shared, dag-executor, variable substitution), `@archon/git` (new helpers), `@archon/paths` (one wrapper), `@archon/cli/commands/workflow` (one resolve call). `@archon/core/handlers/clone.ts` refactored to use the shared parser (functional parity with existing behavior).
- **Potential unintended effects:** A user with files staged at `~/.archon/workspaces/<owner>/<repo>/.archon/` could start seeing those take priority over their user-global copies. Intentional; worth a changelog mention.
- **Early detection:** New log events make it easy to see which tier a given resolution hit:
  - `workspace_workflows_loaded`
  - `dag.script_loaded_workspace`
  - `command_loaded_workspace`
  - `dag.workspace_search_path_resolved`
  - `dag.workspace_search_path_unavailable`

## Rollback Plan

- **Fast rollback:** Revert the 5 commits on this branch. No data migrations to undo. Users who had files under `~/.archon/workspaces/.../.archon/` would see those files stop being discovered; files remain on disk untouched.
- **Feature flags:** None. The workspace tier is always on when the git remote can be parsed. A kill switch could be added via config if there's demand, but that felt like YAGNI for a read-only fallback.
- **Observable failure symptoms:** `workflow.discovery` errors, "not found" messages mentioning additional search paths, test failures in any of the 4 new / updated test files.

## Risks and Mitigations

- **Risk:** `parseOwnerRepoFromGitRemote` misparses an exotic remote URL and routes files to the wrong directory.
  - **Mitigation:** 11 unit tests cover HTTPS, SSH, `ssh://`, trailing `.git`, GitLab subgroups, empty input, single-segment input, trailing slash, real git init happy path, no-origin case, and non-repo case. Returns `null` on any failure; callers silently skip the tier.

- **Risk:** Concurrent workflow runs in different directories re-run the git-remote lookup every time (no cross-run cache).
  - **Mitigation:** The helper is idempotent. Its result is memoized at the `executeDagWorkflow` scope (once per run, not once per node). The CLI layer also computes it once per invocation. No shared state.

- **Risk:** A user who genuinely wants a workspace-tier file to shadow a repo-local file will be confused by "repo wins" precedence.
  - **Mitigation:** Precedence is documented in the discovery modules and matches VSCode/git conventions. Inverting it would surprise a larger audience.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added workspace-tier configuration support: scripts and commands can now be organized across repo-local, workspace, and user-global levels
  * Implemented three-tier fallback resolution: scripts and commands now resolve repo-local first, then workspace, then user-global
  * Added `$WORKSPACE_ARCHON_DIR` variable for workflows to reference workspace configuration paths

* **Tests**
  * Added comprehensive test coverage for workspace-tier script and command resolution behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->