### PR TITLE
fix: web UI approval/reject auto-resume for workflow gates

### DIFF
--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -274,7 +274,10 @@ async function dispatchOrchestratorWorkflow(
         workflow,
         userMessage,
         conversation.id,
-        codebase.id
+        codebase.id,
+        undefined,
+        undefined,
+        conversation.id
       );
     } else if (workflow.interactive) {
       // Interactive workflows run in foreground so output stays in the user's conversation
@@ -286,7 +289,10 @@ async function dispatchOrchestratorWorkflow(
         workflow,
         userMessage,
         conversation.id,
-        codebase.id
+        codebase.id,
+        undefined,
+        undefined,
+        conversation.id
       );
     } else {
       await dispatchBackgroundWorkflow(

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -1972,9 +1972,37 @@ export function registerApiRoutes(
         status: 'failed',
         metadata: metadataUpdate,
       });
+
+      // Auto-resume: dispatch to the orchestrator so the workflow continues
+      // without requiring the user to send a follow-up message.
+      // Mirror what the CLI does in workflowApproveCommand.
+      if (run.parent_conversation_id) {
+        try {
+          const parentConv = await conversationDb.getConversationById(run.parent_conversation_id);
+          if (parentConv?.platform_conversation_id) {
+            const resumeMessage = `/workflow run ${run.workflow_name} ${run.user_message}`;
+            void dispatchToOrchestrator(parentConv.platform_conversation_id, resumeMessage);
+            getLog().info(
+              {
+                runId,
+                workflowName: run.workflow_name,
+                parentConvId: parentConv.platform_conversation_id,
+              },
+              'api.workflow_approve_auto_resume_dispatched'
+            );
+          }
+        } catch (resumeErr) {
+          // Non-fatal — the approval was recorded, user can still resume manually
+          getLog().warn(
+            { err: resumeErr as Error, runId },
+            'api.workflow_approve_auto_resume_failed'
+          );
+        }
+      }
+
       return c.json({
         success: true,
-        message: `Workflow approved: ${run.workflow_name}. Send a message to continue the workflow.`,
+        message: `Workflow approved: ${run.workflow_name}. Resuming workflow.`,
       });
     } catch (error) {
       getLog().error({ err: error, runId }, 'api.workflow_run_approve_failed');
@@ -2018,9 +2046,35 @@ export function registerApiRoutes(
           status: 'failed',
           metadata: { rejection_reason: reason, rejection_count: currentCount + 1 },
         });
+
+        // Auto-resume: dispatch to the orchestrator so the on_reject prompt runs
+        // without requiring the user to send a follow-up message.
+        if (run.parent_conversation_id) {
+          try {
+            const parentConv = await conversationDb.getConversationById(run.parent_conversation_id);
+            if (parentConv?.platform_conversation_id) {
+              const resumeMessage = `/workflow run ${run.workflow_name} ${run.user_message}`;
+              void dispatchToOrchestrator(parentConv.platform_conversation_id, resumeMessage);
+              getLog().info(
+                {
+                  runId,
+                  workflowName: run.workflow_name,
+                  parentConvId: parentConv.platform_conversation_id,
+                },
+                'api.workflow_reject_auto_resume_dispatched'
+              );
+            }
+          } catch (resumeErr) {
+            getLog().warn(
+              { err: resumeErr as Error, runId },
+              'api.workflow_reject_auto_resume_failed'
+            );
+          }
+        }
+
         return c.json({
           success: true,
-          message: `Workflow rejected: ${run.workflow_name}. On-reject prompt will run on resume.`,
+          message: `Workflow rejected: ${run.workflow_name}. Running on-reject prompt.`,
         });
       }
 

--- a/packages/web/src/components/chat/WorkflowProgressCard.tsx
+++ b/packages/web/src/components/chat/WorkflowProgressCard.tsx
@@ -226,7 +226,8 @@ export function WorkflowProgressCard({
                       `Reject workflow "${workflowName}"?\n\nProvide a reason (or leave empty):`
                     );
                     if (reason !== null) {
-                      rejectMutation.mutate(reason || undefined);
+                      const trimmed = reason.trim();
+                      rejectMutation.mutate(trimmed === '' ? undefined : trimmed);
                     }
                   }}
                   disabled={!runId || approveMutation.isPending || rejectMutation.isPending}

--- a/packages/web/src/components/chat/WorkflowProgressCard.tsx
+++ b/packages/web/src/components/chat/WorkflowProgressCard.tsx
@@ -87,7 +87,7 @@ export function WorkflowProgressCard({
     mutationFn: () => approveWorkflowRun(runId ?? ''),
   });
   const rejectMutation = useMutation({
-    mutationFn: () => rejectWorkflowRun(runId ?? ''),
+    mutationFn: (reason?: string) => rejectWorkflowRun(runId ?? '', reason),
   });
   const mutationError = approveMutation.error ?? rejectMutation.error;
 
@@ -222,8 +222,11 @@ export function WorkflowProgressCard({
                 </button>
                 <button
                   onClick={() => {
-                    if (window.confirm(`Reject workflow "${workflowName}"?`)) {
-                      rejectMutation.mutate();
+                    const reason = window.prompt(
+                      `Reject workflow "${workflowName}"?\n\nProvide a reason (or leave empty):`
+                    );
+                    if (reason !== null) {
+                      rejectMutation.mutate(reason || undefined);
                     }
                   }}
                   disabled={!runId || approveMutation.isPending || rejectMutation.isPending}

--- a/packages/web/src/components/dashboard/WorkflowRunCard.tsx
+++ b/packages/web/src/components/dashboard/WorkflowRunCard.tsx
@@ -324,7 +324,8 @@ export function WorkflowRunCard({
                   `Reject workflow "${run.workflow_name}"?\n\nProvide a reason (or leave empty):`
                 );
                 if (reason !== null) {
-                  onReject(run.id, reason || undefined);
+                  const trimmed = reason.trim();
+                  onReject(run.id, trimmed === '' ? undefined : trimmed);
                 }
               }}
               className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-error/80 hover:bg-error/10 hover:text-error transition-colors"

--- a/packages/web/src/components/dashboard/WorkflowRunCard.tsx
+++ b/packages/web/src/components/dashboard/WorkflowRunCard.tsx
@@ -31,7 +31,7 @@ interface WorkflowRunCardProps {
   onAbandon?: (runId: string) => void;
   onDelete?: (runId: string) => void;
   onApprove?: (runId: string) => void;
-  onReject?: (runId: string) => void;
+  onReject?: (runId: string, reason?: string) => void;
 }
 
 const PLATFORM_ICONS: Record<string, React.ReactElement> = {
@@ -320,8 +320,11 @@ export function WorkflowRunCard({
           {run.status === 'paused' && onReject && (
             <button
               onClick={(): void => {
-                if (window.confirm(`Reject workflow "${run.workflow_name}"?`)) {
-                  onReject(run.id);
+                const reason = window.prompt(
+                  `Reject workflow "${run.workflow_name}"?\n\nProvide a reason (or leave empty):`
+                );
+                if (reason !== null) {
+                  onReject(run.id, reason || undefined);
                 }
               }}
               className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-error/80 hover:bg-error/10 hover:text-error transition-colors"

--- a/packages/web/src/components/dashboard/WorkflowRunGroup.tsx
+++ b/packages/web/src/components/dashboard/WorkflowRunGroup.tsx
@@ -12,7 +12,7 @@ interface WorkflowRunGroupProps {
   onAbandon?: (runId: string) => void;
   onDelete?: (runId: string) => void;
   onApprove?: (runId: string) => void;
-  onReject?: (runId: string) => void;
+  onReject?: (runId: string, reason?: string) => void;
 }
 
 export function WorkflowRunGroup({

--- a/packages/web/src/routes/DashboardPage.tsx
+++ b/packages/web/src/routes/DashboardPage.tsx
@@ -293,8 +293,8 @@ export function DashboardPage(): React.ReactElement {
     runAction(deleteWorkflowRun, runId, 'Failed to delete workflow run');
   const handleApprove = (runId: string): Promise<void> =>
     runAction(approveWorkflowRun, runId, 'Failed to approve workflow');
-  const handleReject = (runId: string): Promise<void> =>
-    runAction(rejectWorkflowRun, runId, 'Failed to reject workflow');
+  const handleReject = (runId: string, reason?: string): Promise<void> =>
+    runAction(id => rejectWorkflowRun(id, reason), runId, 'Failed to reject workflow');
 
   const totalPages = Math.ceil(total / pageSize);
   const hasMore = page + 1 < totalPages;

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -866,7 +866,7 @@ async function executeNodeInternal(
         lastNodeCancelCheck.set(nodeKey, tickNow);
         try {
           const streamStatus = await deps.store.getWorkflowRunStatus(workflowRun.id);
-          if (streamStatus === null || streamStatus !== 'running') {
+          if (streamStatus === null || (streamStatus !== 'running' && streamStatus !== 'paused')) {
             getLog().info(
               { workflowRunId: workflowRun.id, nodeId: node.id, status: streamStatus ?? 'deleted' },
               'dag.stop_detected_during_streaming'
@@ -2909,6 +2909,8 @@ export async function executeDagWorkflow(
   }
 
   // Helper: bail out if the run was transitioned externally (cancelled, deleted, etc.)
+  // Also bail on 'paused' — the approval gate owns the lifecycle from here;
+  // attempting to mark a paused run as completed/failed would violate the DB constraint.
   async function skipIfStatusChanged(logEvent: string): Promise<boolean> {
     const status = await deps.store.getWorkflowRunStatus(workflowRun.id);
     if (status === null || status !== 'running') {


### PR DESCRIPTION
## Summary

- **Problem:** Interactive workflows with approval gates cannot resume after the user approves or rejects via the web UI
- **Why it matters:** Approval gates are unusable from the web UI — the approval is recorded but the workflow never continues, forcing users to manually re-run or use the CLI
- **What changed:** Pass `parentConversationId` for foreground web dispatches, auto-dispatch resume from approve/reject API endpoints, guard during-streaming status check against `paused`, and add rejection reason prompt to the web UI
- **What did not change (scope boundary):** CLI approval flow (already works), GitHub adapter flow, approval node schema, DB schema

## UX Journey

### Before

```
User                   Web UI                  Server                  DAG Executor
────                   ──────                  ──────                  ────────────
runs workflow ───────▶ dispatches ───────────▶ creates run
                                               (parent_conv_id=NULL) ──▶ executes nodes
                                                                        pauses at gate
sees "Approve" ──────▶ POST /approve ────────▶ records approval
                                               status → 'failed'
                                               returns "Send a message"
sees "failed" ◀──────  shows error             (workflow never resumes)
```

### After

```
User                   Web UI                  Server                  DAG Executor
────                   ──────                  ──────                  ────────────
runs workflow ───────▶ dispatches ───────────▶ creates run
                                               [parent_conv_id=conv.id] ▶ executes nodes
                                                                         pauses at gate
sees "Approve" ──────▶ POST /approve ────────▶ records approval
                                               status → 'failed'
                                               [dispatches resume] ────▶ finds resumable run
                                                                        skips completed nodes
sees progress ◀──────  streams events           continues from gate
```

## Architecture Diagram

### After

```
orchestrator-agent.ts [~]
  └── executeWorkflow(..., parentConversationId=conversation.id)

api.ts [~]
  ├── POST /approve → approveWorkflow() → [dispatchToOrchestrator()]
  └── POST /reject  → rejectWorkflow()  → [dispatchToOrchestrator()] (on_reject only)

dag-executor.ts [~]
  └── during-streaming check: allow 'paused' status (don't abort node)

WorkflowProgressCard.tsx [~]  ── reject: window.confirm → [window.prompt]
WorkflowRunCard.tsx [~]       ── reject: window.confirm → [window.prompt]
DashboardPage.tsx [~]         ── handleReject: pass reason through
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| approve endpoint | dispatchToOrchestrator | **new** | auto-resume after approval |
| reject endpoint | dispatchToOrchestrator | **new** | auto-resume for on_reject flows |
| orchestrator | executeWorkflow | **modified** | passes parentConversationId |
| dag-executor streaming check | abort controller | **modified** | skips abort on paused |
| WorkflowRunCard | rejectWorkflowRun | **modified** | passes reason string |
| WorkflowProgressCard | rejectWorkflowRun | **modified** | passes reason string |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`, `server`, `web`, `workflows`
- Module: `core:orchestrator`, `server:api`, `workflows:dag-executor`, `web:workflow-cards`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi`

## Linked Issue

- Closes #1131

## Validation Evidence (required)

```bash
bun run type-check  # pre-existing failure in strip-cwd-env.ts (not our files)
bun run lint        # pre-existing failure in strip-cwd-env.ts (not our files)
bun run build       # ✅ passes
# lint-staged pre-commit hook passed on commit
```

- Evidence provided: Manual testing of all approval/reject flows via web UI
- `type-check` and `lint` failures are pre-existing in `packages/paths/src/strip-cwd-env.ts` — unrelated to this PR

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

Verified scenarios:
- Run workflow with approval gate from web UI → approve → workflow resumes and completes
- Run workflow with approval gate → reject with reason → on_reject prompt runs with $REJECTION_REASON → re-pauses
- Reject at max_attempts → workflow cancels
- Approve after reject-rework cycle → workflow continues to next node

Edge cases checked:
- Rejection without on_reject configured → workflow cancels (unchanged behavior)
- Empty rejection reason → defaults to "Rejected"
- parentConversationId correctly set on new runs (verified via DB query)

What was not verified:
- GitHub adapter approval flow (not affected by these changes)
- CLI approval flow (already works, not changed)

## Side Effects / Blast Radius (required)

- Affected subsystems: Web UI approval/reject buttons, orchestrator foreground dispatch, DAG executor streaming check
- Potential unintended effects: The `void dispatchToOrchestrator()` in the approve/reject endpoints is fire-and-forget — if it fails, the approval is still recorded and user can manually resume
- Guardrails: Resume dispatch failures are logged as warnings, not errors; approval recording is atomic and independent of resume

## Rollback Plan (required)

- Fast rollback: revert this commit — approval flow returns to previous "Send a message to continue" behavior
- Feature flags: none needed — the auto-resume is additive
- Observable failure symptoms: workflows stuck in 'failed' status after approval (same as current behavior)

## Risks and Mitigations

- Risk: `dispatchToOrchestrator` could create a duplicate conversation if the parent lookup fails
  - Mitigation: guarded by `if (run.parent_conversation_id)` and `if (parentConv?.platform_conversation_id)` — both null-safe, and failures are logged but non-fatal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflows now auto-resume after approval without manual follow-up.
  * On-reject prompts run immediately after rejection (no follow-up needed).
  * Reject actions now let users provide an optional textual reason via a prompt.

* **Bug Fixes**
  * Paused workflows are now handled correctly during execution streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->