### PR TITLE
docs: clarify Windows symlink prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ bun install
 claude
 ```
 
+> **Windows note:** Archon creates symlinks under `~/.archon/workspaces/` for project registration and worktree isolation. On native Windows, enable Developer Mode or run your shell as Administrator before your first workflow. Developer Mode is the recommended one-time fix.
+
 Then say: **"Set up Archon"**
 
 The setup wizard walks you through everything: CLI installation, authentication, platform selection, and copies the Archon skill to your target repo.

--- a/packages/docs-web/src/content/docs/deployment/windows.md
+++ b/packages/docs-web/src/content/docs/deployment/windows.md
@@ -11,10 +11,12 @@ sidebar:
 
 Archon runs on Windows in two ways:
 
-- **Native Windows with Bun**: Works for basic usage (server, Web UI, simple workflows). No WSL2 required. Install [Bun for Windows](https://bun.sh), clone the repo, and run `bun install && bun run dev`.
+- **Native Windows with Bun**: Works for basic usage (server, Web UI, simple workflows). No WSL2 required. Install [Bun for Windows](https://bun.sh), clone the repo, and run `bun install && bun run dev`. Before your first workflow, enable Developer Mode or run your shell as Administrator so Archon can create the symlinks it uses under `~/.archon/workspaces/`. Developer Mode is the recommended one-time fix.
 - **WSL2 (recommended)**: Required for full compatibility, especially git worktree isolation, shell-based workflow steps, and CLI features that depend on Unix tooling.
 
 The rest of this guide covers the WSL2 setup for full compatibility.
+
+> **Native Windows prerequisite:** Archon registers projects and sets up isolated workspaces by creating symlinks under `~/.archon/workspaces/`. If Developer Mode is disabled and the shell is not elevated, those steps can fail with Windows permission errors.
 
 ## Why WSL2?
 

--- a/packages/docs-web/src/content/docs/getting-started/installation.md
+++ b/packages/docs-web/src/content/docs/getting-started/installation.md
@@ -47,6 +47,8 @@ bun install
 - [GitHub CLI](https://cli.github.com/) (`gh`)
 - [Claude Code](https://claude.ai/code) (`claude`)
 
+> **Windows note:** Native Windows source installs need symlink support before the first workflow run. Enable Developer Mode (recommended) or run your shell as Administrator because Archon creates symlinks under `~/.archon/workspaces/`. See [Windows Setup](/deployment/windows/) for the full Windows guidance.
+
 ## Verify Installation
 
 ```bash


### PR DESCRIPTION
## Summary

- add the missing native-Windows symlink prerequisite to the main setup docs
- document Developer Mode vs Administrator for `~/.archon/workspaces/` symlink creation
- keep the first Archon contribution scoped to documentation only

Fixes #1148

## Verification

- `bun x prettier --check README.md packages/docs-web/src/content/docs/getting-started/installation.md packages/docs-web/src/content/docs/deployment/windows.md`
- `bun run build:docs`