### PR TITLE
[codex] surface stale workspace registration failures

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -867,6 +867,41 @@ describe('workflowRunCommand', () => {
     expect(createCallsAfter).toBe(createCallsBefore);
   });
 
+  it('surfaces auto-registration failures instead of claiming the repo is invalid', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const { registerRepository } = await import('@archon/core');
+    const conversationDb = await import('@archon/core/db/conversations');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    const gitModule = await import('@archon/git');
+
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'assist', description: 'Help' })],
+      errors: [],
+    });
+    (conversationDb.getOrCreateConversation as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'conv-123',
+    });
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+    (gitModule.findRepoRoot as ReturnType<typeof mock>).mockResolvedValueOnce('/test/path');
+    (registerRepository as ReturnType<typeof mock>).mockRejectedValueOnce(
+      new Error(
+        'Source symlink at /home/test/.archon/workspaces/acme/widget/source already points to ' +
+          '/home/test/.archon/workspaces/widget, expected /test/path'
+      )
+    );
+
+    const error = await workflowRunCommand('/test/path', 'assist', 'hello', {}).catch(
+      err => err as Error
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toContain('Cannot create worktree: repository registration failed.');
+    expect(error.message).toContain(
+      'Remove the stale workspace entry at /home/test/.archon/workspaces/acme/widget and retry'
+    );
+    expect(error.message).not.toContain('not in a git repository');
+  });
+
   it('throws when isolation cannot be created due to missing codebase', async () => {
     const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
     const conversationDb = await import('@archon/core/db/conversations');

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -21,6 +21,7 @@ import {
 } from '@archon/workflows/event-emitter';
 import type { WorkflowLoadResult } from '@archon/workflows/schemas/workflow';
 import type { WorkflowRun } from '@archon/workflows/schemas/workflow-run';
+import { join } from 'node:path';
 import {
   approveWorkflow,
   rejectWorkflow,
@@ -75,6 +76,31 @@ function generateConversationId(): string {
   const timestamp = Date.now();
   const random = Math.random().toString(36).substring(2, 8);
   return `cli-${String(timestamp)}-${random}`;
+}
+
+function extractStaleWorkspaceEntry(message: string): string | null {
+  const prefix = 'Source symlink at ';
+  const delimiter = ' already points to ';
+  if (!message.startsWith(prefix)) return null;
+
+  const remainder = message.slice(prefix.length);
+  const delimiterIndex = remainder.indexOf(delimiter);
+  if (delimiterIndex === -1) return null;
+
+  const sourcePath = remainder.slice(0, delimiterIndex).trim();
+  const lastSeparator = Math.max(sourcePath.lastIndexOf('/'), sourcePath.lastIndexOf('\\'));
+  return lastSeparator === -1 ? null : sourcePath.slice(0, lastSeparator);
+}
+
+function buildRegistrationFailureError(action: string, error: Error): Error {
+  const staleWorkspaceEntry = extractStaleWorkspaceEntry(error.message);
+  const hint = staleWorkspaceEntry
+    ? `Hint: Remove the stale workspace entry at ${staleWorkspaceEntry} and retry, or use --no-worktree to skip isolation.`
+    : `Hint: Check your Archon workspace registration under ${join(getArchonHome(), 'workspaces')} and retry, or use --no-worktree to skip isolation.`;
+
+  return new Error(
+    `Cannot ${action}: repository registration failed.\n` + `Error: ${error.message}\n` + hint
+  );
 }
 
 /** Render a workflow event to stderr as a progress line. Called only when --quiet is not set. */
@@ -285,6 +311,7 @@ export async function workflowRunCommand(
   // Try to find a codebase for this directory
   let codebase = null;
   let codebaseLookupError: Error | null = null;
+  let codebaseRegistrationError: Error | null = null;
   try {
     codebase = await codebaseDb.findCodebaseByDefaultCwd(cwd);
   } catch (error) {
@@ -330,6 +357,7 @@ export async function workflowRunCommand(
         }
       } catch (error) {
         const err = error as Error;
+        codebaseRegistrationError = err;
         getLog().warn(
           { err, errorType: err.constructor.name, repoRoot },
           'cli.codebase_auto_registration_failed'
@@ -353,6 +381,9 @@ export async function workflowRunCommand(
             `Error: ${codebaseLookupError.message}\n` +
             'Hint: Check your database connection before using --resume.'
         );
+      }
+      if (codebaseRegistrationError) {
+        throw buildRegistrationFailureError('resume', codebaseRegistrationError);
       }
       throw new Error(
         'Cannot resume: Not in a git repository.\n' +
@@ -506,6 +537,9 @@ export async function workflowRunCommand(
           `Error: ${codebaseLookupError.message}\n` +
           'Hint: Check your database connection, or use --no-worktree to skip isolation.'
       );
+    }
+    if (codebaseRegistrationError) {
+      throw buildRegistrationFailureError('create worktree', codebaseRegistrationError);
     }
     throw new Error(
       'Cannot create worktree: not in a git repository.\n' +


### PR DESCRIPTION
This draft fixes the misleading CLI failure reported in #1146 when Archon auto-registration trips over a stale `~/.archon/workspaces/.../source` link.

Closes #1146

Today `workflowRunCommand()` will attempt auto-registration, log `cli.codebase_auto_registration_failed`, and then fall through to the generic `Cannot create worktree: not in a git repository` error. That secondary message is false for the reported case: the repository is valid, but registration already failed earlier in the chain.

This branch keeps the original registration exception, carries it forward, and turns it into a truthful CLI error. When the failure matches the stale source-symlink pattern from `createProjectSourceSymlink()`, the CLI now includes a concrete cleanup hint that points at the stale workspace entry instead of sending the user down the wrong git-detection path. The same preserved error path is also used for `--resume`, so resume no longer collapses into the same misleading "not in a git repository" fallback.

I added a focused regression test around the stale-registration path in `packages/cli/src/commands/workflow.test.ts` so we lock the user-facing behavior down. While verifying this on Windows, local validation also surfaced two unrelated test assumptions that hard-coded POSIX-style `PATH` / `HOME` environment keys even though Bun on Windows may expose `Path` / `USERPROFILE`. I made those assertions platform-safe in `packages/paths/src/env-integration.test.ts` and `packages/core/src/providers/claude.test.ts` so the touched validation surfaces behave correctly on this machine too.

Validation used for this branch:

- `bun test src/commands/workflow.test.ts` in `packages/cli`
- `bun test src/env-integration.test.ts` in `packages/paths`
- `bun test src/providers/claude.test.ts` in `packages/core`
- `bun x prettier --check packages/cli/src/commands/workflow.ts packages/cli/src/commands/workflow.test.ts packages/paths/src/env-integration.test.ts packages/core/src/providers/claude.test.ts`

I also re-ran `bun run validate` from the repo root. It now gets past the Windows env-key assertion failures above, but it still stops in unrelated `@archon/workflows` script-node tests on this Windows worktree (`inline bun script output available for downstream substitution`, `stderr output is sent to the user`, and `$WORKFLOW_ID and $ARTIFACTS_DIR are substituted into script text`). I left those failures out of this branch because they are outside the stale-registration fix itself.