### PR TITLE
fix(web): align no-.env API proxy fallback with server default

### DIFF
--- a/packages/web/src/lib/api-port.test.ts
+++ b/packages/web/src/lib/api-port.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test';
+import { DEFAULT_API_PORT, resolveApiPort } from './api-port';
+
+describe('resolveApiPort', () => {
+  test('uses the server default when PORT is undefined', () => {
+    expect(resolveApiPort(undefined)).toBe(DEFAULT_API_PORT);
+  });
+
+  test('uses the server default when PORT is blank', () => {
+    expect(resolveApiPort('')).toBe(DEFAULT_API_PORT);
+    expect(resolveApiPort('   ')).toBe(DEFAULT_API_PORT);
+  });
+
+  test('uses PORT from env when provided', () => {
+    expect(resolveApiPort('3090')).toBe('3090');
+  });
+});

--- a/packages/web/src/lib/api-port.ts
+++ b/packages/web/src/lib/api-port.ts
@@ -1,0 +1,10 @@
+export const DEFAULT_API_PORT = '3000';
+
+/**
+ * Resolves the API proxy port from environment values used by Vite.
+ * Falls back to the server default when PORT is unset or blank.
+ */
+export function resolveApiPort(port: string | undefined): string {
+  const value = port?.trim();
+  return value ? value : DEFAULT_API_PORT;
+}

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -4,11 +4,12 @@ import { readFileSync } from 'fs';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import { defineConfig, loadEnv } from 'vite';
+import { resolveApiPort } from './src/lib/api-port';
 
 export default defineConfig(({ mode }) => {
   // Load env from repo root so PORT from .env is available
   const env = loadEnv(mode, path.resolve(__dirname, '../..'), '');
-  const apiPort = env.PORT ?? '3090';
+  const apiPort = resolveApiPort(env.PORT);
 
   // Read version from root package.json
   const rootPkgPath = path.resolve(__dirname, '../../package.json');


### PR DESCRIPTION
## Summary
- fix the Vite dev proxy fallback to use the same default port as `@archon/server` (`3000`), so fresh installs without `.env` no longer proxy to `:3090`
- centralize API port fallback logic in `packages/web/src/lib/api-port.ts`
- add regression tests for undefined/blank/env-provided PORT resolution

## Why
Issue #1152 reports a no-`.env` install path where server binds `:3000` but Vite proxies `/api` to `:3090`, causing `ECONNREFUSED` and a broken web UI.

## Testing
- `bun test packages/web/src/lib/api-port.test.ts`
- `bun test packages/web/src/lib/`

Closes #1152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for API port resolution logic.

* **Chores**
  * Centralized API port configuration handling.
  * Default API port is now 3000.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->