### PR TITLE
fix: make env-integration test cross-platform (Windows CI)

### DIFF
--- a/packages/paths/src/env-integration.test.ts
+++ b/packages/paths/src/env-integration.test.ts
@@ -132,9 +132,11 @@ describe('env isolation integration', () => {
     expect(subprocessEnv.ANTHROPIC_API_KEY).toBeUndefined();
     // Archon key present
     expect(subprocessEnv.ARCHON_ONLY_KEY).toBe('trusted');
-    // Shell-inherited keys present
-    expect(subprocessEnv.PATH).toBeDefined();
-    expect(subprocessEnv.HOME).toBeDefined();
+    // Shell-inherited keys present (Windows uses "Path" casing and USERPROFILE instead of HOME)
+    const hasPath = subprocessEnv.PATH ?? subprocessEnv.Path;
+    expect(hasPath).toBeDefined();
+    const hasHome = subprocessEnv.HOME ?? subprocessEnv.USERPROFILE;
+    expect(hasHome).toBeDefined();
   });
 
   it('scenario 4: same key in both CWD and archon env — archon value wins', () => {

--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -473,8 +473,13 @@ describe('ClaudeProvider', () => {
 
       const callArgs = mockQuery.mock.calls[0][0] as { options: { env: NodeJS.ProcessEnv } };
       expect(callArgs.options.env.CUSTOM_USER_KEY).toBe('user-trusted-value');
-      expect(callArgs.options.env.PATH).toBe(process.env.PATH);
-      expect(callArgs.options.env.HOME).toBe(process.env.HOME);
+      // Windows uses "Path" casing in spread objects and USERPROFILE instead of HOME
+      const envPath = callArgs.options.env.PATH ?? callArgs.options.env.Path;
+      const processPath = process.env.PATH ?? process.env.Path;
+      expect(envPath).toBe(processPath);
+      const envHome = callArgs.options.env.HOME ?? callArgs.options.env.USERPROFILE;
+      const processHome = process.env.HOME ?? process.env.USERPROFILE;
+      expect(envHome).toBe(processHome);
 
       // Cleanup
       if (originalKey !== undefined) process.env.CUSTOM_USER_KEY = originalKey;


### PR DESCRIPTION
## Summary

- Check for Windows env var equivalents (`Path` instead of `PATH`, `USERPROFILE` instead of `HOME`) in scenario 3 assertions
- On Windows, spreading `process.env` into a plain object preserves the OS-native casing (`Path`), and `HOME` doesn't exist (`USERPROFILE` is the equivalent)

Closes #1128

## Test plan

- [ ] Windows CI passes on this PR
- [ ] Ubuntu/Docker CI still green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Made environment-variable assertions tolerant of platform differences in casing and key names (e.g., Windows vs. Unix), using fallbacks when needed.
  * Improves cross-platform test reliability so CI and local runs on Windows, macOS, and Linux consistently validate shell-inherited variables without false failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->