### PR TITLE
fix(workflows): preserve longer context variable names

### DIFF
--- a/packages/workflows/src/executor-shared.test.ts
+++ b/packages/workflows/src/executor-shared.test.ts
@@ -167,6 +167,22 @@ describe('substituteWorkflowVariables', () => {
     expect(prompt).toBe('Issue: context-data. External: context-data');
   });
 
+  it('does not treat context variables as prefixes of longer identifiers', () => {
+    const { prompt, contextSubstituted } = substituteWorkflowVariables(
+      'Context: $CONTEXT. File: $CONTEXT_FILE. External path: $EXTERNAL_CONTEXT_PATH',
+      'run-1',
+      'msg',
+      '/tmp',
+      'main',
+      'docs/',
+      'context-data'
+    );
+    expect(prompt).toBe(
+      'Context: context-data. File: $CONTEXT_FILE. External path: $EXTERNAL_CONTEXT_PATH'
+    );
+    expect(contextSubstituted).toBe(true);
+  });
+
   it('clears context variables when issueContext is undefined', () => {
     const { prompt, contextSubstituted } = substituteWorkflowVariables(
       'Context: $CONTEXT here',

--- a/packages/workflows/src/executor-shared.ts
+++ b/packages/workflows/src/executor-shared.ts
@@ -247,7 +247,7 @@ export async function loadCommandPrompt(
 // ─── Variable Substitution ───────────────────────────────────────────────────
 
 /** Pattern string for context variables - used to create fresh regex instances */
-export const CONTEXT_VAR_PATTERN_STR = '\\$(?:CONTEXT|EXTERNAL_CONTEXT|ISSUE_CONTEXT)';
+export const CONTEXT_VAR_PATTERN_STR = '\\$(?:CONTEXT|EXTERNAL_CONTEXT|ISSUE_CONTEXT)(?![A-Za-z0-9_])';
 
 /**
  * Substitute workflow variables in a prompt.


### PR DESCRIPTION
Fixes #1112

This tightens context-variable substitution so standalone $CONTEXT aliases still resolve, while longer identifiers like $CONTEXT_FILE are left untouched.

It also adds a regression test for the prefix-match case in executor-shared.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed variable substitution behavior to correctly handle context variables. Previously, context variables were incorrectly replaced when appearing as prefixes in longer variable names. Now, substitution only occurs for exact standalone matches, improving workflow accuracy and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->