### PR TITLE
fix: initialize options.hooks before merging YAML node hooks

### DIFF
--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -374,6 +374,9 @@ async function applyNodeConfig(
     if (Object.keys(builtHooks).length > 0) {
       // Merge with existing hooks (PostToolUse capture hook)
       const existingHooks = options.hooks as SDKHooksMap | undefined;
+      if (!options.hooks) {
+        (options as Record<string, unknown>).hooks = {};
+      }
       for (const [event, matchers] of Object.entries(builtHooks)) {
         if (!matchers) continue;
         const existing = existingHooks?.[event] as HookCallbackMatcher[] | undefined;


### PR DESCRIPTION
## Summary
- Fixes crash in `applyNodeConfig` when a workflow node defines hooks (PreToolUse/PostToolUse) in YAML but `options.hooks` is undefined
- Initializes `options.hooks` to `{}` before the merge loop to prevent `TypeError: undefined is not an object`

## Reproduction
```bash
archon workflow run archon-architect "..."
```

The `archon-architect` workflow uses per-node hooks extensively. The `analyze` node crashes immediately:
```
TypeError: undefined is not an object (evaluating 'options.hooks[event] = matchers')
    at applyNodeConfig (packages/providers/src/claude/provider.ts:386:20)
```

## Test plan
- [x] `archon workflow run archon-architect` no longer crashes at the `analyze` node
- [x] Lint and prettier pass (pre-commit hooks ran successfully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude provider reliability by enhancing configuration handling for event hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->