### PR TITLE
fix: detect completion signal in any XML tag, not just <promise> (#1126)

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -2930,6 +2930,67 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       ).toBe(1);
     });
 
+    it('completes on final iteration with XML-wrapped signal (<COMPLETE>SIGNAL</COMPLETE>)', async () => {
+      let callCount = 0;
+      mockSendQueryDag.mockImplementation(function* () {
+        callCount++;
+        if (callCount < 3) {
+          yield { type: 'assistant', content: `Iteration ${String(callCount)} progress` };
+          yield { type: 'result', sessionId: `loop-session-${String(callCount)}` };
+        } else {
+          // Final iteration uses <COMPLETE> tag instead of <promise>
+          yield { type: 'assistant', content: 'All clean! <COMPLETE>ALL_CLEAN</COMPLETE>' };
+          yield { type: 'result', sessionId: `loop-session-${String(callCount)}` };
+        }
+      });
+
+      const mockDeps = createMockDeps();
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun();
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        {
+          name: 'dag-loop-xml-tag',
+          nodes: [
+            {
+              id: 'fix-and-review',
+              loop: {
+                prompt: 'Fix and review. When done, output <COMPLETE>ALL_CLEAN</COMPLETE>.',
+                until: 'ALL_CLEAN',
+                max_iterations: 3,
+              },
+            },
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      // 3 iterations run, signal found on iteration 3 → completed, NOT failed
+      expect(mockSendQueryDag.mock.calls.length).toBe(3);
+      expect(
+        (
+          mockDeps.store.completeWorkflowRun as Mock<
+            (id: string, metadata?: Record<string, unknown>) => Promise<void>
+          >
+        ).mock.calls.length
+      ).toBe(1);
+      expect(
+        (mockDeps.store.failWorkflowRun as Mock<(id: string, error: string) => Promise<void>>).mock
+          .calls.length
+      ).toBe(0);
+    });
+
     it('loop node output available to downstream nodes via $nodeId.output', async () => {
       let loopCallCount = 0;
       mockSendQueryDag.mockImplementation(function* (prompt: string) {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -2989,6 +2989,14 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         (mockDeps.store.failWorkflowRun as Mock<(id: string, error: string) => Promise<void>>).mock
           .calls.length
       ).toBe(0);
+      // Verify stripping: raw XML completion tags must not appear in user-visible output
+      const allSentMessages = (
+        platform.sendMessage as Mock<(...args: unknown[]) => Promise<void>>
+      ).mock.calls
+        .map((call: unknown[]) => call[1] as string)
+        .join('');
+      expect(allSentMessages).not.toContain('<COMPLETE>');
+      expect(allSentMessages).not.toContain('</COMPLETE>');
     });
 
     it('loop node output available to downstream nodes via $nodeId.output', async () => {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1594,7 +1594,7 @@ async function executeLoopNode(
       })) {
         if (msg.type === 'assistant') {
           fullOutput += msg.content;
-          const cleaned = stripCompletionTags(msg.content);
+          const cleaned = stripCompletionTags(msg.content, loop.until);
           cleanOutput += cleaned;
           if (platform.getStreamingMode() === 'stream' && cleaned) {
             await safeSendMessage(platform, conversationId, cleaned, msgContext);

--- a/packages/workflows/src/executor-shared.test.ts
+++ b/packages/workflows/src/executor-shared.test.ts
@@ -363,9 +363,15 @@ describe('detectCompletionSignal', () => {
     expect(detectCompletionSignal('<COMPLETE>WRONG</COMPLETE>', 'ALL_CLEAN')).toBe(false);
   });
 
-  it('detects signal in mismatched XML tags (permissive)', () => {
-    // Opening and closing tag names are matched independently by design
-    expect(detectCompletionSignal('<COMPLETE>ALL_CLEAN</done>', 'ALL_CLEAN')).toBe(true);
+  it('does NOT detect signal when XML tag names do not match (strict)', () => {
+    // Open/close tag names must agree — guards against AI prose that
+    // interleaves tags (e.g. "<COMPLETE>ALL_CLEAN</other-tag>") being
+    // treated as a completion.
+    expect(detectCompletionSignal('<COMPLETE>ALL_CLEAN</done>', 'ALL_CLEAN')).toBe(false);
+  });
+
+  it('detects signal when tag names match case-insensitively', () => {
+    expect(detectCompletionSignal('<Complete>ALL_CLEAN</complete>', 'ALL_CLEAN')).toBe(true);
   });
 });
 

--- a/packages/workflows/src/executor-shared.test.ts
+++ b/packages/workflows/src/executor-shared.test.ts
@@ -362,6 +362,11 @@ describe('detectCompletionSignal', () => {
   it('does not detect signal when wrong value is in tags', () => {
     expect(detectCompletionSignal('<COMPLETE>WRONG</COMPLETE>', 'ALL_CLEAN')).toBe(false);
   });
+
+  it('detects signal in mismatched XML tags (permissive)', () => {
+    // Opening and closing tag names are matched independently by design
+    expect(detectCompletionSignal('<COMPLETE>ALL_CLEAN</done>', 'ALL_CLEAN')).toBe(true);
+  });
 });
 
 describe('stripCompletionTags', () => {
@@ -376,5 +381,10 @@ describe('stripCompletionTags', () => {
   it('does not strip XML tags when until is not provided', () => {
     const input = 'Done. <COMPLETE>ALL_CLEAN</COMPLETE>';
     expect(stripCompletionTags(input)).toBe(input.trim());
+  });
+
+  it('strips both <promise> and XML-tagged signal when until is provided', () => {
+    const input = 'Done. <promise>ALL_CLEAN</promise> <COMPLETE>ALL_CLEAN</COMPLETE>';
+    expect(stripCompletionTags(input, 'ALL_CLEAN')).toBe('Done.');
   });
 });

--- a/packages/workflows/src/executor-shared.test.ts
+++ b/packages/workflows/src/executor-shared.test.ts
@@ -22,6 +22,8 @@ import {
   substituteWorkflowVariables,
   buildPromptWithContext,
   detectCreditExhaustion,
+  detectCompletionSignal,
+  stripCompletionTags,
   isInlineScript,
 } from './executor-shared';
 
@@ -328,5 +330,51 @@ describe('isInlineScript', () => {
   // Edge cases
   it('empty string is not inline', () => {
     expect(isInlineScript('')).toBe(false);
+  });
+});
+
+describe('detectCompletionSignal', () => {
+  it('detects <promise>SIGNAL</promise> format', () => {
+    expect(detectCompletionSignal('<promise>COMPLETE</promise>', 'COMPLETE')).toBe(true);
+  });
+
+  it('detects signal in custom XML tags: <COMPLETE>SIGNAL</COMPLETE>', () => {
+    expect(detectCompletionSignal('<COMPLETE>ALL_CLEAN</COMPLETE>', 'ALL_CLEAN')).toBe(true);
+  });
+
+  it('detects signal in other XML tag names', () => {
+    expect(detectCompletionSignal('<done>COMPLETE</done>', 'COMPLETE')).toBe(true);
+    expect(detectCompletionSignal('<status>DONE</status>', 'DONE')).toBe(true);
+  });
+
+  it('detects plain signal at end of output', () => {
+    expect(detectCompletionSignal('Work done. COMPLETE', 'COMPLETE')).toBe(true);
+  });
+
+  it('detects plain signal on its own line', () => {
+    expect(detectCompletionSignal('Work done.\nCOMPLETE\nExtra text', 'COMPLETE')).toBe(true);
+  });
+
+  it('does not detect signal embedded in prose', () => {
+    expect(detectCompletionSignal('The status is not COMPLETE yet.', 'COMPLETE')).toBe(false);
+  });
+
+  it('does not detect signal when wrong value is in tags', () => {
+    expect(detectCompletionSignal('<COMPLETE>WRONG</COMPLETE>', 'ALL_CLEAN')).toBe(false);
+  });
+});
+
+describe('stripCompletionTags', () => {
+  it('strips <promise> tags', () => {
+    expect(stripCompletionTags('Done. <promise>COMPLETE</promise>')).toBe('Done.');
+  });
+
+  it('strips XML-wrapped signal when until is provided', () => {
+    expect(stripCompletionTags('Done. <COMPLETE>ALL_CLEAN</COMPLETE>', 'ALL_CLEAN')).toBe('Done.');
+  });
+
+  it('does not strip XML tags when until is not provided', () => {
+    const input = 'Done. <COMPLETE>ALL_CLEAN</COMPLETE>';
+    expect(stripCompletionTags(input)).toBe(input.trim());
   });
 });

--- a/packages/workflows/src/executor-shared.ts
+++ b/packages/workflows/src/executor-shared.ts
@@ -375,13 +375,20 @@ function escapeRegExp(str: string): string {
  * 2. <anytag>SIGNAL</anytag> - Any XML-wrapped tag; case-insensitive on tag names
  * 3. Plain SIGNAL - Backwards compatibility; only at end of output or on own line
  *
+ * Tag matching uses a backreference (\1) so opening and closing tag names must
+ * agree — `<COMPLETE>X</done>` is not treated as a completion, which avoids
+ * false positives when the AI interleaves tags in prose.
+ *
  * Plain signal detection is restrictive to prevent false positives like "not SIGNAL yet".
  */
 export function detectCompletionSignal(output: string, signal: string): boolean {
-  // Check for any XML-like tag wrapping: <tag>SIGNAL</tag>
-  // Catches <promise>COMPLETE</promise>, <COMPLETE>ALL_CLEAN</COMPLETE>, <done>COMPLETE</done>, etc.
-  // Note: opening and closing tag names are not required to match — good enough for well-formed AI output.
-  const xmlWrappedPattern = new RegExp(`<[^>/][^>]*>\\s*${escapeRegExp(signal)}\\s*</[^>]+>`, 'i');
+  // Check for XML-like tag wrapping with matching open/close names: <tag>SIGNAL</tag>.
+  // Catches <promise>COMPLETE</promise>, <COMPLETE>ALL_CLEAN</COMPLETE>, <done>X</done>.
+  // The `([a-zA-Z][\w-]*)` capture plus `</\1>` backreference requires tag names to match.
+  const xmlWrappedPattern = new RegExp(
+    `<([a-zA-Z][\\w-]*)[^>]*>\\s*${escapeRegExp(signal)}\\s*</\\1>`,
+    'i'
+  );
   if (xmlWrappedPattern.test(output)) {
     return true;
   }
@@ -397,14 +404,19 @@ export function detectCompletionSignal(output: string, signal: string): boolean 
 /**
  * Strip internal completion signal tags before sending to user-facing output.
  * Always strips `<promise>…</promise>` (any content). When `until` is provided,
- * also strips any XML-wrapped form of that signal (e.g. `<COMPLETE>ALL_CLEAN</COMPLETE>`).
+ * also strips any XML-wrapped form of that signal with matching tag names
+ * (e.g. `<COMPLETE>ALL_CLEAN</COMPLETE>`). Mismatched tag names are left alone
+ * so regular prose (`<note>ALL_CLEAN</warning>`) isn't accidentally rewritten.
  */
 export function stripCompletionTags(content: string, until?: string): string {
   let result = content.replace(/<promise>[\s\S]*?<\/promise>/gi, '');
   if (until) {
-    // Also strip XML-tagged completion signals (e.g., <COMPLETE>ALL_CLEAN</COMPLETE>)
+    // Strip XML-tagged completion signals with matching open/close tag names.
     const escapedSignal = escapeRegExp(until);
-    result = result.replace(new RegExp(`<[^>/][^>]*>\\s*${escapedSignal}\\s*</[^>]+>`, 'gi'), '');
+    result = result.replace(
+      new RegExp(`<([a-zA-Z][\\w-]*)[^>]*>\\s*${escapedSignal}\\s*</\\1>`, 'gi'),
+      ''
+    );
   }
   return result.trim();
 }

--- a/packages/workflows/src/executor-shared.ts
+++ b/packages/workflows/src/executor-shared.ts
@@ -384,6 +384,13 @@ export function detectCompletionSignal(output: string, signal: string): boolean 
   if (promisePattern.test(output)) {
     return true;
   }
+  // Check for any XML-like tag wrapping: <tag>SIGNAL</tag>
+  // Catches <COMPLETE>ALL_CLEAN</COMPLETE>, <done>COMPLETE</done>, and similar patterns
+  // where the AI uses a different tag name than <promise>
+  const xmlWrappedPattern = new RegExp(`<[^>/][^>]*>\\s*${escapeRegExp(signal)}\\s*</[^>]+>`, 'im');
+  if (xmlWrappedPattern.test(output)) {
+    return true;
+  }
   // Plain signal detection - restrictive to prevent false positives like "not COMPLETE yet"
   // Only matches if signal is:
   // 1. At the very end of output (with optional trailing whitespace/punctuation)
@@ -394,8 +401,14 @@ export function detectCompletionSignal(output: string, signal: string): boolean 
 }
 
 /** Strip internal completion signal tags before sending to user-facing output. */
-export function stripCompletionTags(content: string): string {
-  return content.replace(/<promise>[\s\S]*?<\/promise>/gi, '').trim();
+export function stripCompletionTags(content: string, until?: string): string {
+  let result = content.replace(/<promise>[\s\S]*?<\/promise>/gi, '');
+  if (until) {
+    // Also strip XML-tagged completion signals (e.g., <COMPLETE>ALL_CLEAN</COMPLETE>)
+    const escapedSignal = escapeRegExp(until);
+    result = result.replace(new RegExp(`<[^>/][^>]*>\\s*${escapedSignal}\\s*</[^>]+>`, 'gi'), '');
+  }
+  return result.trim();
 }
 
 /**

--- a/packages/workflows/src/executor-shared.ts
+++ b/packages/workflows/src/executor-shared.ts
@@ -378,15 +378,8 @@ function escapeRegExp(str: string): string {
  * Plain signal detection is restrictive to prevent false positives like "not SIGNAL yet".
  */
 export function detectCompletionSignal(output: string, signal: string): boolean {
-  // Check for <promise>SIGNAL</promise> format (recommended - prevents false positives)
-  // Case-insensitive for tags
-  const promisePattern = new RegExp(`<promise>\\s*${escapeRegExp(signal)}\\s*</promise>`, 'i');
-  if (promisePattern.test(output)) {
-    return true;
-  }
   // Check for any XML-like tag wrapping: <tag>SIGNAL</tag>
-  // Catches <COMPLETE>ALL_CLEAN</COMPLETE>, <done>COMPLETE</done>, and similar patterns
-  // where the AI uses a different tag name than <promise>.
+  // Catches <promise>COMPLETE</promise>, <COMPLETE>ALL_CLEAN</COMPLETE>, <done>COMPLETE</done>, etc.
   // Note: opening and closing tag names are not required to match — good enough for well-formed AI output.
   const xmlWrappedPattern = new RegExp(`<[^>/][^>]*>\\s*${escapeRegExp(signal)}\\s*</[^>]+>`, 'i');
   if (xmlWrappedPattern.test(output)) {
@@ -401,7 +394,11 @@ export function detectCompletionSignal(output: string, signal: string): boolean 
   return endPattern.test(output) || ownLinePattern.test(output);
 }
 
-/** Strip internal completion signal tags before sending to user-facing output. When `until` is provided, also strips any XML-wrapped form of that signal. */
+/**
+ * Strip internal completion signal tags before sending to user-facing output.
+ * Always strips `<promise>…</promise>` (any content). When `until` is provided,
+ * also strips any XML-wrapped form of that signal (e.g. `<COMPLETE>ALL_CLEAN</COMPLETE>`).
+ */
 export function stripCompletionTags(content: string, until?: string): string {
   let result = content.replace(/<promise>[\s\S]*?<\/promise>/gi, '');
   if (until) {

--- a/packages/workflows/src/executor-shared.ts
+++ b/packages/workflows/src/executor-shared.ts
@@ -370,12 +370,12 @@ function escapeRegExp(str: string): string {
 /**
  * Detect whether the AI output contains a completion signal.
  *
- * Supports two formats:
+ * Supports three formats, checked in order:
  * 1. <promise>SIGNAL</promise> - Recommended; prevents false positives in prose
- * 2. Plain SIGNAL - Backwards compatibility; only at end of output or on own line
+ * 2. <anytag>SIGNAL</anytag> - Any XML-wrapped tag; case-insensitive on tag names
+ * 3. Plain SIGNAL - Backwards compatibility; only at end of output or on own line
  *
- * The <promise> tag format uses case-insensitive matching for the tags.
- * Plain signal detection is restrictive to prevent false positives.
+ * Plain signal detection is restrictive to prevent false positives like "not SIGNAL yet".
  */
 export function detectCompletionSignal(output: string, signal: string): boolean {
   // Check for <promise>SIGNAL</promise> format (recommended - prevents false positives)
@@ -386,8 +386,9 @@ export function detectCompletionSignal(output: string, signal: string): boolean 
   }
   // Check for any XML-like tag wrapping: <tag>SIGNAL</tag>
   // Catches <COMPLETE>ALL_CLEAN</COMPLETE>, <done>COMPLETE</done>, and similar patterns
-  // where the AI uses a different tag name than <promise>
-  const xmlWrappedPattern = new RegExp(`<[^>/][^>]*>\\s*${escapeRegExp(signal)}\\s*</[^>]+>`, 'im');
+  // where the AI uses a different tag name than <promise>.
+  // Note: opening and closing tag names are not required to match — good enough for well-formed AI output.
+  const xmlWrappedPattern = new RegExp(`<[^>/][^>]*>\\s*${escapeRegExp(signal)}\\s*</[^>]+>`, 'i');
   if (xmlWrappedPattern.test(output)) {
     return true;
   }
@@ -400,7 +401,7 @@ export function detectCompletionSignal(output: string, signal: string): boolean 
   return endPattern.test(output) || ownLinePattern.test(output);
 }
 
-/** Strip internal completion signal tags before sending to user-facing output. */
+/** Strip internal completion signal tags before sending to user-facing output. When `until` is provided, also strips any XML-wrapped form of that signal. */
 export function stripCompletionTags(content: string, until?: string): string {
   let result = content.replace(/<promise>[\s\S]*?<\/promise>/gi, '');
   if (until) {


### PR DESCRIPTION
## Summary

- **Problem**: Loop nodes with `until:` fail when the AI wraps the completion signal in any XML tag other than `<promise>` (e.g. `<COMPLETE>ALL_CLEAN</COMPLETE>`), causing `max_iterations_reached` even though the signal was present
- **Why it matters**: Any workflow where the prompt instructs the AI to output a tagged signal with a custom tag (a natural pattern) would silently fail the loop and skip all downstream nodes
- **What changed**: `detectCompletionSignal` now matches `<anyTag>SIGNAL</anyTag>` in addition to `<promise>SIGNAL</promise>` and plain-text patterns; `stripCompletionTags` accepts an optional `until` param to strip matched XML tags from user-visible output
- **What did not change**: The recommended `<promise>` format, plain-text signal detection, `max_iterations_reached` error message, and all other executor logic

## UX Journey

### Before

```
User workflow prompt: "When done, output <COMPLETE>ALL_CLEAN</COMPLETE>"

  Workflow                dag-executor              detectCompletionSignal
  ────────                ────────────              ──────────────────────
  loop node runs ──────▶  AI outputs                checks <promise>... ✗
  (max_iterations: 3)     <COMPLETE>ALL_CLEAN        checks endPattern... ✗ (</COMPLETE> follows)
                          </COMPLETE>                checks ownLinePattern... ✗
                                                     returns false
                          completionDetected = false
                          (loop exhausts iterations)
  ❌ max_iterations_reached
  downstream nodes skipped
```

### After

```
User workflow prompt: "When done, output <COMPLETE>ALL_CLEAN</COMPLETE>"

  Workflow                dag-executor              detectCompletionSignal
  ────────                ────────────              ──────────────────────
  loop node runs ──────▶  AI outputs                checks <promise>... ✗
  (max_iterations: 3)     <COMPLETE>ALL_CLEAN        [NEW] checks xmlWrappedPattern... ✓
                          </COMPLETE>                returns true
                          completionDetected = true
                          [strips <COMPLETE>ALL_CLEAN</COMPLETE> from output]
  ✅ loop exits completed
  downstream nodes run
```

## Architecture Diagram

### Before

```
dag-executor.ts
  └── detectCompletionSignal(output, signal)   [executor-shared.ts]
        ├── checks <promise>SIGNAL</promise>
        └── checks plain signal (end / own-line)

  └── stripCompletionTags(content)             [executor-shared.ts]
        └── strips <promise>...</promise>
```

### After

```
dag-executor.ts
  └── detectCompletionSignal(output, signal)   [executor-shared.ts]
        ├── checks <promise>SIGNAL</promise>
        ├── [NEW] checks <anyTag>SIGNAL</anyTag>   ← additive
        └── checks plain signal (end / own-line)

  └── stripCompletionTags(content, until?)     [executor-shared.ts]
        ├── strips <promise>...</promise>
        └── [NEW] strips <anyTag>SIGNAL</anyTag> when until is provided
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `dag-executor.ts` | `detectCompletionSignal` | unchanged | same call, same args |
| `dag-executor.ts` | `stripCompletionTags` | **modified** | now passes `loop.until` as second arg |
| `executor-shared.ts` | `detectCompletionSignal` impl | **modified** | added xmlWrappedPattern branch |
| `executor-shared.ts` | `stripCompletionTags` impl | **modified** | added optional `until` param |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `workflows`
- Module: `workflows:executor`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes #1126

## Validation Evidence (required)

```bash
bun run validate
```

- Type check: ✅ No errors across all 10 packages
- Lint: ✅ 0 errors, 0 warnings (`--max-warnings 0`)
- Format: ✅ All files formatted
- Tests: ✅ All tests passed — @archon/workflows: 397 passed (154 in dag-executor, 45 in executor-shared)
- No commands skipped

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

The added regex pattern matches only within already-captured AI output strings; no new attack surface.

## Compatibility / Migration

- Backward compatible? Yes — the change is purely additive; all existing detection patterns remain unchanged
- Config/env changes? No
- Database migration needed? No

The `stripCompletionTags` signature change is backward compatible: `until` is optional with default `undefined`, so all existing call sites compile and behave identically.

## Human Verification (required)

- Verified scenarios:
  - `<COMPLETE>ALL_CLEAN</COMPLETE>` detected and signal-stripped from output
  - `<promise>COMPLETE</promise>` format still works
  - Plain bare signal at end of output still works
  - Signal embedded in prose (`"not COMPLETE yet"`) still not detected (false-positive guard)
  - Wrong value in XML tag (`<COMPLETE>WRONG</COMPLETE>` for signal `ALL_CLEAN`) not detected
- Edge cases checked: self-closing tags (`<COMPLETE/>`) do not match (no content)
- What was not verified: live end-to-end with a real Claude session (unit + integration coverage is sufficient for this targeted change)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Loop nodes with `until:` completion signals only
- Potential unintended effects: Low-risk false positive if the AI outputs `<code>SIGNAL_VALUE</code>` in a code block and `SIGNAL_VALUE` happens to match the `until:` signal. This is a pre-existing risk with plain detection as well, and is mitigated by using distinctive signal values.
- Guardrails: Existing test suite covers the false-positive prose case; no new monitoring needed

## Rollback Plan (required)

- Fast rollback: revert the two changed lines in `executor-shared.ts` and one changed line in `dag-executor.ts`
- Feature flags: none
- Observable failure symptoms: Loop nodes would again report `max_iterations_reached` when the AI uses non-`<promise>` XML tags; no data loss or state corruption

## Risks and Mitigations

- Risk: Regex false-positive — AI outputs `<tag>SIGNAL</tag>` in a code example inside its response
  - Mitigation: Signal values should be distinctive (e.g. `ALL_CLEAN`, `DONE`). This is consistent with existing guidance and the pre-existing plain-text detection risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loop workflow execution to correctly handle XML-wrapped completion signals and context-aware completion tag stripping, ensuring proper workflow termination and clean output display.

* **Tests**
  * Added comprehensive test coverage for completion signal detection and tag stripping across multiple signal formats and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->