### PR TITLE
fix: prevent worktree reuse across different local clones

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -94,6 +94,7 @@ mock.module('@archon/workflows/event-emitter', () => ({
 
 mock.module('@archon/git', () => ({
   findRepoRoot: mock(() => Promise.resolve(null)),
+  getCanonicalRepoPath: mock(() => Promise.reject(new Error('not a git repo'))),
   getRemoteUrl: mock(() => Promise.resolve(null)),
   checkout: mock(() => Promise.resolve()),
   toRepoPath: mock((path: string) => path),
@@ -1006,7 +1007,7 @@ describe('workflowRunCommand', () => {
       metadata: { source_repo_root: '/clone-a' },
     });
     // Current cwd resolves to /clone-b
-    (gitModule.findRepoRoot as ReturnType<typeof mock>).mockResolvedValueOnce('/clone-b');
+    (gitModule.getCanonicalRepoPath as ReturnType<typeof mock>).mockResolvedValueOnce('/clone-b');
     (conversationDb.updateConversation as ReturnType<typeof mock>).mockResolvedValueOnce(undefined);
     (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
       success: true,
@@ -1052,7 +1053,7 @@ describe('workflowRunCommand', () => {
       workflow_id: 'my-feature',
       metadata: {},
     });
-    (gitModule.findRepoRoot as ReturnType<typeof mock>).mockResolvedValueOnce('/clone-a');
+    (gitModule.getCanonicalRepoPath as ReturnType<typeof mock>).mockResolvedValueOnce('/clone-a');
     (conversationDb.updateConversation as ReturnType<typeof mock>).mockResolvedValueOnce(undefined);
     (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
       success: true,
@@ -1098,7 +1099,7 @@ describe('workflowRunCommand', () => {
       workflow_id: 'my-feature',
       metadata: { source_repo_root: '/clone-a' },
     });
-    (gitModule.findRepoRoot as ReturnType<typeof mock>).mockResolvedValueOnce('/clone-a');
+    (gitModule.getCanonicalRepoPath as ReturnType<typeof mock>).mockResolvedValueOnce('/clone-a');
     (conversationDb.updateConversation as ReturnType<typeof mock>).mockResolvedValueOnce(undefined);
     (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
       success: true,
@@ -1115,7 +1116,7 @@ describe('workflowRunCommand', () => {
     expect(provider.create).not.toHaveBeenCalled();
   });
 
-  it('allows reuse with warning when findRepoRoot returns null but env has source_repo_root', async () => {
+  it('allows reuse with warning when getCanonicalRepoPath fails but env has source_repo_root', async () => {
     const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
     const { executeWorkflow } = await import('@archon/workflows/executor');
     const conversationDb = await import('@archon/core/db/conversations');
@@ -1144,8 +1145,7 @@ describe('workflowRunCommand', () => {
       workflow_id: 'my-feature',
       metadata: { source_repo_root: '/clone-a' },
     });
-    // findRepoRoot returns null (git unavailable or cwd changed)
-    (gitModule.findRepoRoot as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+    // getCanonicalRepoPath throws (git unavailable) — default mock rejects, producing null
     (conversationDb.updateConversation as ReturnType<typeof mock>).mockResolvedValueOnce(undefined);
     (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
       success: true,

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -1114,6 +1114,53 @@ describe('workflowRunCommand', () => {
     };
     expect(provider.create).not.toHaveBeenCalled();
   });
+
+  it('allows reuse with warning when findRepoRoot returns null but env has source_repo_root', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    const conversationDb = await import('@archon/core/db/conversations');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    const isolationDb = await import('@archon/core/db/isolation-environments');
+    const gitModule = await import('@archon/git');
+    const isolation = await import('@archon/isolation');
+
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'assist', description: 'Help' })],
+      errors: [],
+    });
+    (conversationDb.getOrCreateConversation as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'conv-123',
+    });
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'cb-123',
+      default_cwd: '/clone-a',
+    });
+    // Env has a known source_repo_root
+    (isolationDb.findActiveByWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'env-1',
+      working_path: '/worktrees/feat',
+      branch_name: 'my-feature',
+      workflow_type: 'task',
+      workflow_id: 'my-feature',
+      metadata: { source_repo_root: '/clone-a' },
+    });
+    // findRepoRoot returns null (git unavailable or cwd changed)
+    (gitModule.findRepoRoot as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+    (conversationDb.updateConversation as ReturnType<typeof mock>).mockResolvedValueOnce(undefined);
+    (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
+      success: true,
+      workflowRunId: 'run-123',
+    });
+
+    await workflowRunCommand('/clone-a', 'assist', 'hello', { branchName: 'my-feature' });
+
+    // Should NOT have created a new worktree — fallback allows reuse when root undetectable
+    const getIsolationProviderMock = isolation.getIsolationProvider as ReturnType<typeof mock>;
+    const provider = getIsolationProviderMock.mock.results.at(-1)?.value as {
+      create: ReturnType<typeof mock>;
+    };
+    expect(provider.create).not.toHaveBeenCalled();
+  });
 });
 
 describe('workflowStatusCommand', () => {

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -975,6 +975,145 @@ describe('workflowRunCommand', () => {
       consoleWarnSpy.mockRestore();
     }
   });
+
+  it('skips reuse when existing env has different source_repo_root (GH-1183)', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    const conversationDb = await import('@archon/core/db/conversations');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    const isolationDb = await import('@archon/core/db/isolation-environments');
+    const gitModule = await import('@archon/git');
+    const isolation = await import('@archon/isolation');
+
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'assist', description: 'Help' })],
+      errors: [],
+    });
+    (conversationDb.getOrCreateConversation as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'conv-123',
+    });
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'cb-123',
+      default_cwd: '/clone-b',
+    });
+    // Existing env was created from /clone-a
+    (isolationDb.findActiveByWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'env-1',
+      working_path: '/worktrees/feat',
+      branch_name: 'my-feature',
+      workflow_type: 'task',
+      workflow_id: 'my-feature',
+      metadata: { source_repo_root: '/clone-a' },
+    });
+    // Current cwd resolves to /clone-b
+    (gitModule.findRepoRoot as ReturnType<typeof mock>).mockResolvedValueOnce('/clone-b');
+    (conversationDb.updateConversation as ReturnType<typeof mock>).mockResolvedValueOnce(undefined);
+    (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
+      success: true,
+      workflowRunId: 'run-123',
+    });
+
+    await workflowRunCommand('/clone-b', 'assist', 'hello', { branchName: 'my-feature' });
+
+    // Should have created a new worktree instead of reusing
+    const getIsolationProviderMock = isolation.getIsolationProvider as ReturnType<typeof mock>;
+    const provider = getIsolationProviderMock.mock.results.at(-1)?.value as {
+      create: ReturnType<typeof mock>;
+    };
+    expect(provider.create).toHaveBeenCalled();
+  });
+
+  it('reuses existing env when source_repo_root is absent (backward compat)', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    const conversationDb = await import('@archon/core/db/conversations');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    const isolationDb = await import('@archon/core/db/isolation-environments');
+    const gitModule = await import('@archon/git');
+    const isolation = await import('@archon/isolation');
+
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'assist', description: 'Help' })],
+      errors: [],
+    });
+    (conversationDb.getOrCreateConversation as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'conv-123',
+    });
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'cb-123',
+      default_cwd: '/clone-a',
+    });
+    // Existing env has no source_repo_root (pre-existing)
+    (isolationDb.findActiveByWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'env-1',
+      working_path: '/worktrees/feat',
+      branch_name: 'my-feature',
+      workflow_type: 'task',
+      workflow_id: 'my-feature',
+      metadata: {},
+    });
+    (gitModule.findRepoRoot as ReturnType<typeof mock>).mockResolvedValueOnce('/clone-a');
+    (conversationDb.updateConversation as ReturnType<typeof mock>).mockResolvedValueOnce(undefined);
+    (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
+      success: true,
+      workflowRunId: 'run-123',
+    });
+
+    await workflowRunCommand('/clone-a', 'assist', 'hello', { branchName: 'my-feature' });
+
+    // Should NOT have created a new worktree — reuse path taken
+    const getIsolationProviderMock = isolation.getIsolationProvider as ReturnType<typeof mock>;
+    const provider = getIsolationProviderMock.mock.results.at(-1)?.value as {
+      create: ReturnType<typeof mock>;
+    };
+    expect(provider.create).not.toHaveBeenCalled();
+  });
+
+  it('reuses existing env when source_repo_root matches current root', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    const conversationDb = await import('@archon/core/db/conversations');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    const isolationDb = await import('@archon/core/db/isolation-environments');
+    const gitModule = await import('@archon/git');
+    const isolation = await import('@archon/isolation');
+
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'assist', description: 'Help' })],
+      errors: [],
+    });
+    (conversationDb.getOrCreateConversation as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'conv-123',
+    });
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'cb-123',
+      default_cwd: '/clone-a',
+    });
+    // Existing env was created from same checkout
+    (isolationDb.findActiveByWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'env-1',
+      working_path: '/worktrees/feat',
+      branch_name: 'my-feature',
+      workflow_type: 'task',
+      workflow_id: 'my-feature',
+      metadata: { source_repo_root: '/clone-a' },
+    });
+    (gitModule.findRepoRoot as ReturnType<typeof mock>).mockResolvedValueOnce('/clone-a');
+    (conversationDb.updateConversation as ReturnType<typeof mock>).mockResolvedValueOnce(undefined);
+    (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
+      success: true,
+      workflowRunId: 'run-123',
+    });
+
+    await workflowRunCommand('/clone-a', 'assist', 'hello', { branchName: 'my-feature' });
+
+    // Should NOT have created a new worktree — same checkout, reuse is safe
+    const getIsolationProviderMock = isolation.getIsolationProvider as ReturnType<typeof mock>;
+    const provider = getIsolationProviderMock.mock.results.at(-1)?.value as {
+      create: ReturnType<typeof mock>;
+    };
+    expect(provider.create).not.toHaveBeenCalled();
+  });
 });
 
 describe('workflowStatusCommand', () => {

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -1006,7 +1006,8 @@ describe('workflowRunCommand', () => {
       workflow_id: 'my-feature',
       metadata: { source_repo_root: '/clone-a' },
     });
-    // Current cwd resolves to /clone-b
+    // Current cwd resolves to /clone-b (findRepoRoot → getCanonicalRepoPath chain)
+    (gitModule.findRepoRoot as ReturnType<typeof mock>).mockResolvedValueOnce('/clone-b');
     (gitModule.getCanonicalRepoPath as ReturnType<typeof mock>).mockResolvedValueOnce('/clone-b');
     (conversationDb.updateConversation as ReturnType<typeof mock>).mockResolvedValueOnce(undefined);
     (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
@@ -1053,6 +1054,7 @@ describe('workflowRunCommand', () => {
       workflow_id: 'my-feature',
       metadata: {},
     });
+    (gitModule.findRepoRoot as ReturnType<typeof mock>).mockResolvedValueOnce('/clone-a');
     (gitModule.getCanonicalRepoPath as ReturnType<typeof mock>).mockResolvedValueOnce('/clone-a');
     (conversationDb.updateConversation as ReturnType<typeof mock>).mockResolvedValueOnce(undefined);
     (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
@@ -1099,6 +1101,7 @@ describe('workflowRunCommand', () => {
       workflow_id: 'my-feature',
       metadata: { source_repo_root: '/clone-a' },
     });
+    (gitModule.findRepoRoot as ReturnType<typeof mock>).mockResolvedValueOnce('/clone-a');
     (gitModule.getCanonicalRepoPath as ReturnType<typeof mock>).mockResolvedValueOnce('/clone-a');
     (conversationDb.updateConversation as ReturnType<typeof mock>).mockResolvedValueOnce(undefined);
     (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
@@ -1116,7 +1119,7 @@ describe('workflowRunCommand', () => {
     expect(provider.create).not.toHaveBeenCalled();
   });
 
-  it('allows reuse with warning when getCanonicalRepoPath fails but env has source_repo_root', async () => {
+  it('allows reuse with warning when repo root is undetectable but env has source_repo_root', async () => {
     const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
     const { executeWorkflow } = await import('@archon/workflows/executor');
     const conversationDb = await import('@archon/core/db/conversations');
@@ -1145,7 +1148,8 @@ describe('workflowRunCommand', () => {
       workflow_id: 'my-feature',
       metadata: { source_repo_root: '/clone-a' },
     });
-    // getCanonicalRepoPath throws (git unavailable) — default mock rejects, producing null
+    // findRepoRoot returns null by default (not a git repo) — currentRepoRoot stays null
+    mockLogger.warn.mockClear();
     (conversationDb.updateConversation as ReturnType<typeof mock>).mockResolvedValueOnce(undefined);
     (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
       success: true,
@@ -1160,6 +1164,11 @@ describe('workflowRunCommand', () => {
       create: ReturnType<typeof mock>;
     };
     expect(provider.create).not.toHaveBeenCalled();
+    // Verify the warning was actually logged
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ envSourceRoot: '/clone-a' }),
+      'worktree.reuse_root_undetectable'
+    );
   });
 });
 

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -428,13 +428,26 @@ export async function workflowRunCommand(
     // (derived from the remote URL), so findActiveByWorkflow can return an
     // environment that belongs to a sibling checkout. Compare the repo root that
     // was recorded at creation time with the current working directory's repo root.
+    // Resolve repo root lazily: needed both for the reuse guard and for metadata storage
     const currentRepoRoot = await git.findRepoRoot(cwd);
     const envSourceRoot =
       existingEnv && typeof existingEnv.metadata?.source_repo_root === 'string'
         ? existingEnv.metadata.source_repo_root
         : undefined;
+
+    // Intentional: when currentRepoRoot or envSourceRoot is unavailable, fall back
+    // to allowing reuse. This preserves backward compat for pre-existing envs and
+    // avoids blocking workflows when git is temporarily unavailable. Risk: could
+    // allow cross-checkout reuse in edge cases — logged as a warning below.
     const reuseSameCheckout =
       !existingEnv || !envSourceRoot || !currentRepoRoot || envSourceRoot === currentRepoRoot;
+
+    if (existingEnv && envSourceRoot && !currentRepoRoot) {
+      getLog().warn(
+        { path: existingEnv.working_path, envSourceRoot },
+        'worktree.reuse_root_undetectable'
+      );
+    }
 
     if (
       existingEnv &&

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -426,10 +426,15 @@ export async function workflowRunCommand(
     // Guard: skip reuse if the existing environment was created from a different
     // local clone of the same remote (GH-1183). Two clones share one codebase_id
     // (derived from the remote URL), so findActiveByWorkflow can return an
-    // environment that belongs to a sibling checkout. Compare the repo root that
-    // was recorded at creation time with the current working directory's repo root.
-    // Resolve repo root lazily: needed both for the reuse guard and for metadata storage
-    const currentRepoRoot = await git.findRepoRoot(cwd);
+    // environment that belongs to a sibling checkout. Compare the canonical repo
+    // path (stable across linked worktrees) recorded at creation time with the
+    // current working directory's canonical path.
+    let currentRepoRoot: string | null = null;
+    try {
+      currentRepoRoot = await git.getCanonicalRepoPath(cwd);
+    } catch {
+      // Non-fatal: cwd may not be a git repo (handled later) or git unavailable
+    }
     const envSourceRoot =
       existingEnv && typeof existingEnv.metadata?.source_repo_root === 'string'
         ? existingEnv.metadata.source_repo_root

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -431,9 +431,15 @@ export async function workflowRunCommand(
     // current working directory's canonical path.
     let currentRepoRoot: string | null = null;
     try {
-      currentRepoRoot = await git.getCanonicalRepoPath(cwd);
-    } catch {
-      // Non-fatal: cwd may not be a git repo (handled later) or git unavailable
+      // Resolve subdirectory to repo top-level first, then canonicalize to handle
+      // linked worktrees (getCanonicalRepoPath doesn't resolve subdirs itself).
+      const repoRoot = await git.findRepoRoot(cwd);
+      currentRepoRoot = repoRoot ? await git.getCanonicalRepoPath(repoRoot) : null;
+    } catch (error) {
+      // findRepoRoot returns null for non-git dirs (expected), but both functions
+      // throw on unexpected errors (permissions, I/O). Log and fall through —
+      // the guard will allow reuse when currentRepoRoot is null.
+      getLog().debug({ err: error, cwd }, 'worktree.reuse_root_detection_failed');
     }
     const envSourceRoot =
       existingEnv && typeof existingEnv.metadata?.source_repo_root === 'string'

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -423,7 +423,24 @@ export async function workflowRunCommand(
       ? await isolationDb.findActiveByWorkflow(codebase.id, 'task', options.branchName)
       : undefined;
 
-    if (existingEnv && (await provider.healthCheck(existingEnv.working_path))) {
+    // Guard: skip reuse if the existing environment was created from a different
+    // local clone of the same remote (GH-1183). Two clones share one codebase_id
+    // (derived from the remote URL), so findActiveByWorkflow can return an
+    // environment that belongs to a sibling checkout. Compare the repo root that
+    // was recorded at creation time with the current working directory's repo root.
+    const currentRepoRoot = await git.findRepoRoot(cwd);
+    const envSourceRoot =
+      existingEnv && typeof existingEnv.metadata?.source_repo_root === 'string'
+        ? existingEnv.metadata.source_repo_root
+        : undefined;
+    const reuseSameCheckout =
+      !existingEnv || !envSourceRoot || !currentRepoRoot || envSourceRoot === currentRepoRoot;
+
+    if (
+      existingEnv &&
+      reuseSameCheckout &&
+      (await provider.healthCheck(existingEnv.working_path))
+    ) {
       if (options.fromBranch) {
         getLog().warn(
           { path: existingEnv.working_path, fromBranch: options.fromBranch },
@@ -463,6 +480,14 @@ export async function workflowRunCommand(
       workingCwd = existingEnv.working_path;
       isolationEnvId = existingEnv.id;
     } else {
+      // Log when skipping reuse due to cross-checkout mismatch (GH-1183)
+      if (existingEnv && !reuseSameCheckout) {
+        getLog().warn(
+          { path: existingEnv.working_path, envSourceRoot, currentRepoRoot },
+          'worktree.reuse_different_checkout'
+        );
+      }
+
       // Create new worktree
       getLog().info(
         { branch: branchIdentifier, fromBranch: options.fromBranch },
@@ -489,7 +514,7 @@ export async function workflowRunCommand(
         working_path: isolatedEnv.workingPath,
         branch_name: isolatedEnv.branchName,
         created_by_platform: 'cli',
-        metadata: {},
+        metadata: { ...(currentRepoRoot ? { source_repo_root: currentRepoRoot } : {}) },
       });
 
       workingCwd = isolatedEnv.workingPath;


### PR DESCRIPTION
## Summary

Fixes #1183

- Store `source_repo_root` in isolation environment metadata when creating worktrees via the CLI
- Before reusing an existing worktree (`--branch` flag), verify the stored repo root matches the current `cwd`'s repo root
- Skip reuse with a log warning when the roots differ (falls through to create a new worktree)
- Backward-compatible: environments without `source_repo_root` (pre-existing) are reused as before

## Root Cause

The `remote_agent_codebases` table derives codebase identity from the remote URL. Two local clones of the same remote (e.g., `~/project-a` and `~/project-b`) resolve to the same `codebase_id`. `findActiveByWorkflow` then returns isolation environments from the wrong local clone since it only filters on `codebase_id + workflow_type + workflow_id`.

## Approach

Rather than changing the database schema or codebase identity model, this fix adds a guard at the reuse check site in `workflow.ts`. The current repo root is stored in the existing `metadata` JSONB column at creation time, and compared at reuse time. This is the minimal change with the smallest blast radius.

## Known Limitations

- Only guards the CLI workflow path (the reported bug). The `IsolationResolver` (Slack/Telegram/GitHub/Web) has the same theoretical gap but lower risk since server-side paths don't involve multiple local clones.
- Does not guard git-level worktree adoption in `WorktreeProvider.findExisting()`, which checks filesystem paths that are shared across clones of the same remote.
- Submodule initialization in worktrees is a separate gap (tracked separately).

## Test plan

- [x] `bun run type-check` — all packages pass
- [x] `bun run lint` — zero warnings
- [x] `bun run test` — all tests pass
- [x] Manual verification: existing environments without `source_repo_root` metadata are still reused (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents reusing an environment from a different local checkout by persisting detected repo-root in environment metadata; reuse is now conditional and the app emits warnings when reuse is undetectable or skipped due to a checkout mismatch.

* **Tests**
  * Added tests validating reuse vs. recreation when repo-root metadata is present, missing, mismatched, or undetectable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->