### PR TITLE
fix: prevent worktree isolation bypass via prompt and git-level adoption

### DIFF
--- a/.archon/commands/defaults/archon-fix-issue.md
+++ b/.archon/commands/defaults/archon-fix-issue.md
@@ -131,28 +131,30 @@ git status
 
 ### 3.2 Decision Tree
 
-```
+```text
 ┌─ IN WORKTREE?
-│  └─ YES → Use it (assume it's for this work)
-│           Log: "Using worktree at {path}"
+│  └─ YES → Use current branch AS-IS. Do NOT switch branches. Do NOT create
+│           new branches. The isolation system has already set up the correct
+│           branch; any deviation operates on the wrong code.
+│           Log: "Using worktree at {path} on branch {branch}"
 │
-├─ ON MAIN/MASTER?
+├─ ON $BASE_BRANCH? (main, master, or configured base branch)
 │  └─ Q: Working directory clean?
 │     ├─ YES → Create branch: fix/issue-{number}-{slug}
 │     │        git checkout -b fix/issue-{number}-{slug}
-│     └─ NO  → Warn user:
-│              "Working directory has uncommitted changes.
-│               Please commit or stash before proceeding."
-│              STOP
+│     │        (only applies outside a worktree — e.g., manual CLI usage)
+│     └─ NO  → STOP: "Uncommitted changes on $BASE_BRANCH.
+│              Please commit or stash before proceeding."
 │
-├─ ON FEATURE/FIX BRANCH?
-│  └─ Use it (assume it's for this work)
+├─ ON OTHER BRANCH?
+│  └─ Use it AS-IS (assume it was set up for this work).
+│     Do NOT switch to another branch (e.g., one shown by `git branch` but
+│     not currently checked out).
 │     If branch name doesn't contain issue number:
 │       Warn: "Branch '{name}' may not be for issue #{number}"
 │
 └─ DIRTY STATE?
-   └─ Warn and suggest: git stash or git commit
-      STOP
+   └─ STOP: "Uncommitted changes. Please commit or stash first."
 ```
 
 ### 3.3 Ensure Up-to-Date

--- a/.archon/commands/defaults/archon-implement-issue.md
+++ b/.archon/commands/defaults/archon-implement-issue.md
@@ -132,28 +132,30 @@ git status
 
 ### 3.2 Decision Tree
 
-```
+```text
 ┌─ IN WORKTREE?
-│  └─ YES → Use it (assume it's for this work)
-│           Log: "Using worktree at {path}"
+│  └─ YES → Use current branch AS-IS. Do NOT switch branches. Do NOT create
+│           new branches. The isolation system has already set up the correct
+│           branch; any deviation operates on the wrong code.
+│           Log: "Using worktree at {path} on branch {branch}"
 │
-├─ ON MAIN/MASTER?
+├─ ON $BASE_BRANCH? (main, master, or configured base branch)
 │  └─ Q: Working directory clean?
 │     ├─ YES → Create branch: fix/issue-{number}-{slug}
 │     │        git checkout -b fix/issue-{number}-{slug}
-│     └─ NO  → Warn user:
-│              "Working directory has uncommitted changes.
-│               Please commit or stash before proceeding."
-│              STOP
+│     │        (only applies outside a worktree — e.g., manual CLI usage)
+│     └─ NO  → STOP: "Uncommitted changes on $BASE_BRANCH.
+│              Please commit or stash before proceeding."
 │
-├─ ON FEATURE/FIX BRANCH?
-│  └─ Use it (assume it's for this work)
+├─ ON OTHER BRANCH?
+│  └─ Use it AS-IS (assume it was set up for this work).
+│     Do NOT switch to another branch (e.g., one shown by `git branch` but
+│     not currently checked out).
 │     If branch name doesn't contain issue number:
 │       Warn: "Branch '{name}' may not be for issue #{number}"
 │
 └─ DIRTY STATE?
-   └─ Warn and suggest: git stash or git commit
-      STOP
+   └─ STOP: "Uncommitted changes. Please commit or stash first."
 ```
 
 ### 3.3 Ensure Up-to-Date

--- a/.archon/commands/defaults/archon-implement.md
+++ b/.archon/commands/defaults/archon-implement.md
@@ -106,20 +106,22 @@ git status --porcelain
 
 ### 2.2 Branch Decision
 
-**IMPORTANT: Never switch branches or create new branches. The isolation system has already set up the correct branch for this worktree. Work on whatever branch you are currently on.**
-
-```
+```text
 ┌─ IN WORKTREE?
-│  └─ YES → Use current branch as-is
+│  └─ YES → Use current branch AS-IS. Do NOT switch branches. Do NOT create
+│           new branches. The isolation system has already set up the correct
+│           branch; any deviation operates on the wrong code.
 │           Log: "Using worktree at {path} on branch {branch}"
 │
 ├─ ON $BASE_BRANCH? (main, master, or configured base branch)
 │  └─ Q: Working directory clean?
 │     ├─ YES → Create branch: git checkout -b feature/{plan-slug}
+│     │        (only applies outside a worktree — e.g., manual CLI usage)
 │     └─ NO  → STOP: "Stash or commit changes first"
 │
 ├─ ON OTHER BRANCH?
-│  └─ Use it (assume it was set up for this work)
+│  └─ Use it AS-IS. Do NOT switch to another branch (e.g., one shown by
+│     `git branch` but not currently checked out).
 │     Log: "Using existing branch {name}"
 │
 └─ DIRTY STATE?

--- a/.archon/commands/defaults/archon-implement.md
+++ b/.archon/commands/defaults/archon-implement.md
@@ -93,19 +93,38 @@ Provide a valid plan path or GitHub issue containing the plan.
 ### 2.1 Check Current State
 
 ```bash
+# What branch are we on?
 git branch --show-current
-git status --porcelain
+
+# Are we in a worktree?
+git rev-parse --show-toplevel
 git worktree list
+
+# Is working directory clean?
+git status --porcelain
 ```
 
 ### 2.2 Branch Decision
 
-| Current State     | Action                                               |
-| ----------------- | ---------------------------------------------------- |
-| In worktree       | Use it (log: "Using worktree")                       |
-| On base branch, clean    | Create branch: `git checkout -b feature/{plan-slug}` |
-| On base branch, dirty    | STOP: "Stash or commit changes first"                |
-| On feature branch | Use it (log: "Using existing branch")                |
+**IMPORTANT: Never switch branches or create new branches. The isolation system has already set up the correct branch for this worktree. Work on whatever branch you are currently on.**
+
+```
+┌─ IN WORKTREE?
+│  └─ YES → Use current branch as-is
+│           Log: "Using worktree at {path} on branch {branch}"
+│
+├─ ON $BASE_BRANCH? (main, master, or configured base branch)
+│  └─ Q: Working directory clean?
+│     ├─ YES → Create branch: git checkout -b feature/{plan-slug}
+│     └─ NO  → STOP: "Stash or commit changes first"
+│
+├─ ON OTHER BRANCH?
+│  └─ Use it (assume it was set up for this work)
+│     Log: "Using existing branch {name}"
+│
+└─ DIRTY STATE?
+   └─ STOP: "Stash or commit changes first"
+```
 
 ### 2.3 Sync with Remote
 
@@ -116,7 +135,7 @@ git pull --rebase origin $BASE_BRANCH 2>/dev/null || true
 
 **PHASE_2_CHECKPOINT:**
 
-- [ ] On correct branch (not base branch with uncommitted work)
+- [ ] On correct branch (not $BASE_BRANCH with uncommitted work)
 - [ ] Working directory ready
 - [ ] Up to date with remote
 

--- a/.archon/commands/defaults/archon-plan-setup.md
+++ b/.archon/commands/defaults/archon-plan-setup.md
@@ -112,13 +112,26 @@ gh repo view --json nameWithOwner -q .nameWithOwner
 
 ### 2.3 Branch Decision
 
-| Current State | Action |
-|---------------|--------|
-| Already on correct feature branch | Use it, log "Using existing branch: {name}" |
-| On base branch, clean working directory | Create and checkout: `git checkout -b {branch-name}` |
-| On base branch, dirty working directory | STOP with error: "Uncommitted changes on base branch. Stash or commit first." |
-| On different feature branch | STOP with error: "On branch {X}, expected {Y}. Switch branches or adjust plan." |
-| In a worktree | Use the worktree's branch, log "Using worktree branch: {name}" |
+Evaluate in order (first matching case wins):
+
+```text
+┌─ IN WORKTREE?
+│  └─ YES → Use current branch AS-IS. Do NOT switch branches. Do NOT create
+│           new branches. The isolation system has already set up the correct
+│           branch; any deviation operates on the wrong code.
+│           Log: "Using worktree branch: {name}"
+│
+├─ ON $BASE_BRANCH? (main, master, or configured base branch)
+│  └─ Q: Working directory clean?
+│     ├─ YES → Create and checkout: `git checkout -b {branch-name}`
+│     │        (only applies outside a worktree — e.g., manual CLI usage)
+│     └─ NO  → STOP: "Uncommitted changes on $BASE_BRANCH. Stash or commit first."
+│
+└─ ON OTHER BRANCH?
+   └─ Q: Does it match the expected branch for this plan?
+      ├─ YES → Use it, log "Using existing branch: {name}"
+      └─ NO  → STOP: "On branch {X}, expected {Y}. Switch branches or adjust plan."
+```
 
 ### 2.4 Sync with Remote
 

--- a/packages/isolation/src/errors.ts
+++ b/packages/isolation/src/errors.ts
@@ -68,6 +68,24 @@ export function classifyIsolationError(err: Error): string {
         '**Error:** No base branch configured. Set `worktree.baseBranch` in `.archon/config.yaml` ' +
         'or use the `--from` flag to select a branch (e.g., `--from dev`).',
     },
+    {
+      pattern: 'belongs to a different clone',
+      message:
+        '**Error:** A worktree at the target path was created by a different local clone. ' +
+        'Remove it from that clone, or register this codebase from the same local path.',
+    },
+    {
+      pattern: 'cannot verify worktree ownership',
+      message:
+        '**Error:** Cannot verify ownership of an existing worktree at the target path. ' +
+        'Check file system permissions and remove any unrelated git directories at that path.',
+    },
+    {
+      pattern: 'cannot adopt',
+      message:
+        '**Error:** Refused to adopt an existing directory at the worktree path. ' +
+        'Remove it or choose a different branch/codebase registration.',
+    },
   ];
 
   for (const { pattern, message } of errorPatterns) {
@@ -99,6 +117,9 @@ export function isKnownIsolationError(err: Error): boolean {
     'not a git repository',
     'branch not found',
     'no base branch configured',
+    'belongs to a different clone',
+    'cannot verify worktree ownership',
+    'cannot adopt',
   ];
 
   return knownPatterns.some(pattern => errorLower.includes(pattern));

--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -34,8 +34,12 @@ let syncWorkspaceSpy: Mock<typeof git.syncWorkspace>;
 
 // Mock fs.promises.access for destroy() existence check
 const mockAccess = mock(() => Promise.resolve());
+const mockReadFile = mock(() => Promise.reject(new Error('ENOENT')));
+const mockRm = mock(() => Promise.resolve());
 mock.module('node:fs/promises', () => ({
   access: mockAccess,
+  readFile: mockReadFile,
+  rm: mockRm,
 }));
 
 import { WorktreeProvider } from './worktree';
@@ -70,6 +74,8 @@ describe('WorktreeProvider', () => {
     findWorktreeByBranchSpy.mockResolvedValue(null);
     getCanonicalRepoPathSpy.mockImplementation(async path => path);
     mockAccess.mockResolvedValue(undefined); // Path exists by default
+    mockReadFile.mockRejectedValue(new Error('ENOENT')); // .git file not readable by default
+    mockRm.mockResolvedValue(undefined);
 
     // Default mocks for workspace sync
     getDefaultBranchSpy.mockResolvedValue('main');
@@ -297,15 +303,16 @@ describe('WorktreeProvider', () => {
       );
     });
 
-    test('reuses existing branch when it already exists and no fromBranch', async () => {
+    test('resets and reuses existing branch when it already exists and no fromBranch', async () => {
       const alreadyExistsError = new Error('fatal: branch already exists') as Error & {
         stderr: string;
       };
       alreadyExistsError.stderr =
         "fatal: a branch named 'archon/task-test-adapters' already exists";
 
-      // First call fails, second succeeds (fallback)
+      // First call fails (worktree add -b), second succeeds (branch -f), third succeeds (worktree add)
       execSpy.mockRejectedValueOnce(alreadyExistsError);
+      execSpy.mockResolvedValueOnce({ stdout: '', stderr: '' });
       execSpy.mockResolvedValueOnce({ stdout: '', stderr: '' });
 
       const request: IsolationRequest = {
@@ -315,6 +322,13 @@ describe('WorktreeProvider', () => {
       };
 
       await provider.create(request);
+
+      // Verify branch was reset to start-point
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        ['-C', '/workspace/repo', 'branch', '-f', 'archon/task-test-adapters', 'origin/main'],
+        expect.any(Object)
+      );
 
       // Fallback call should not include a start-point
       expect(execSpy).toHaveBeenCalledWith(
@@ -508,6 +522,46 @@ describe('WorktreeProvider', () => {
       expect(addCalls).toHaveLength(0);
     });
 
+    test('skips adoption when worktree belongs to different repo root', async () => {
+      worktreeExistsSpy.mockResolvedValueOnce(true); // worktree exists at expected path
+
+      // .git file points to a different repo root
+      mockReadFile.mockResolvedValueOnce(
+        'gitdir: /different/repo/.git/worktrees/archon/issue-42\n'
+      );
+
+      const env = await provider.create(baseRequest);
+
+      // Should NOT adopt — should create a new worktree instead
+      expect(env.metadata).toHaveProperty('adopted', false);
+    });
+
+    test('adopts worktree when repo root matches', async () => {
+      worktreeExistsSpy.mockResolvedValueOnce(true); // worktree exists at expected path
+
+      // .git file points to the same repo root as the request
+      mockReadFile.mockResolvedValueOnce(
+        'gitdir: /workspace/repo/.git/worktrees/archon/issue-42\n'
+      );
+
+      const env = await provider.create(baseRequest);
+
+      expect(env.metadata).toHaveProperty('adopted', true);
+      expect(env.workingPath).toContain('issue-42');
+    });
+
+    test('adopts worktree when .git file unreadable (backward compat)', async () => {
+      worktreeExistsSpy.mockResolvedValueOnce(true); // worktree exists at expected path
+
+      // .git file read fails (e.g., not a worktree, corrupt, missing)
+      mockReadFile.mockRejectedValueOnce(new Error('ENOENT: no such file'));
+
+      const env = await provider.create(baseRequest);
+
+      // Should still adopt — backward compat when we can't determine repo root
+      expect(env.metadata).toHaveProperty('adopted', true);
+    });
+
     test('adopts worktree by PR branch name (skill symbiosis)', async () => {
       const request: PRIsolationRequest = {
         codebaseId: 'cb-123',
@@ -537,7 +591,7 @@ describe('WorktreeProvider', () => {
       expect(addCalls).toHaveLength(0);
     });
 
-    test('reuses existing branch if it already exists', async () => {
+    test('resets stale branch to start-point when it already exists', async () => {
       let callCount = 0;
       execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
         callCount++;
@@ -571,7 +625,14 @@ describe('WorktreeProvider', () => {
         expect.any(Object)
       );
 
-      // Verify second call used existing branch
+      // Verify branch was reset to start-point before checkout
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        ['-C', '/workspace/repo', 'branch', '-f', 'archon/issue-42', 'origin/main'],
+        expect.any(Object)
+      );
+
+      // Verify final call used existing (reset) branch
       expect(execSpy).toHaveBeenCalledWith(
         'git',
         expect.arrayContaining([

--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -98,6 +98,8 @@ describe('WorktreeProvider', () => {
     getDefaultBranchSpy.mockRestore();
     syncWorkspaceSpy.mockRestore();
     mockAccess.mockClear();
+    mockReadFile.mockClear();
+    mockRm.mockClear();
   });
 
   describe('generateBranchName', () => {
@@ -506,8 +508,10 @@ describe('WorktreeProvider', () => {
       );
     });
 
-    test('adopts existing worktree if found', async () => {
+    test('adopts existing worktree when repo ownership matches', async () => {
       worktreeExistsSpy.mockResolvedValue(true);
+      // .git file points to the same repo root as the request
+      mockReadFile.mockResolvedValue('gitdir: /workspace/repo/.git/worktrees/archon/issue-42\n');
 
       const env = await provider.create(baseRequest);
 
@@ -522,43 +526,53 @@ describe('WorktreeProvider', () => {
       expect(addCalls).toHaveLength(0);
     });
 
-    test('skips adoption when worktree belongs to different repo root', async () => {
-      worktreeExistsSpy.mockResolvedValueOnce(true); // worktree exists at expected path
+    test('throws when worktree belongs to different repo root (cross-checkout)', async () => {
+      worktreeExistsSpy.mockResolvedValue(true);
+      mockReadFile.mockResolvedValue('gitdir: /different/repo/.git/worktrees/archon/issue-42\n');
 
-      // .git file points to a different repo root
-      mockReadFile.mockResolvedValueOnce(
-        'gitdir: /different/repo/.git/worktrees/archon/issue-42\n'
-      );
-
-      const env = await provider.create(baseRequest);
-
-      // Should NOT adopt — should create a new worktree instead
-      expect(env.metadata).toHaveProperty('adopted', false);
+      await expect(provider.create(baseRequest)).rejects.toThrow(/belongs to a different clone/);
     });
 
-    test('adopts worktree when repo root matches', async () => {
-      worktreeExistsSpy.mockResolvedValueOnce(true); // worktree exists at expected path
+    test('throws when .git is a directory (full checkout, not a worktree)', async () => {
+      worktreeExistsSpy.mockResolvedValue(true);
+      const eisdirError = new Error('EISDIR') as NodeJS.ErrnoException;
+      eisdirError.code = 'EISDIR';
+      mockReadFile.mockRejectedValue(eisdirError);
 
-      // .git file points to the same repo root as the request
-      mockReadFile.mockResolvedValueOnce(
-        'gitdir: /workspace/repo/.git/worktrees/archon/issue-42\n'
+      await expect(provider.create(baseRequest)).rejects.toThrow(
+        /path contains a full git checkout/
       );
-
-      const env = await provider.create(baseRequest);
-
-      expect(env.metadata).toHaveProperty('adopted', true);
-      expect(env.workingPath).toContain('issue-42');
     });
 
-    test('adopts worktree when .git file unreadable (backward compat)', async () => {
-      worktreeExistsSpy.mockResolvedValueOnce(true); // worktree exists at expected path
+    test('throws when .git file cannot be read (permission denied)', async () => {
+      worktreeExistsSpy.mockResolvedValue(true);
+      const eaccesError = new Error('EACCES: permission denied') as NodeJS.ErrnoException;
+      eaccesError.code = 'EACCES';
+      mockReadFile.mockRejectedValue(eaccesError);
 
-      // .git file read fails (e.g., not a worktree, corrupt, missing)
-      mockReadFile.mockRejectedValueOnce(new Error('ENOENT: no such file'));
+      await expect(provider.create(baseRequest)).rejects.toThrow(
+        /Cannot verify worktree ownership/
+      );
+    });
 
-      const env = await provider.create(baseRequest);
+    test('throws when .git pointer is not a git-worktree reference (e.g., submodule)', async () => {
+      worktreeExistsSpy.mockResolvedValue(true);
+      mockReadFile.mockResolvedValue('gitdir: /workspace/repo/.git/modules/submodule-name\n');
 
-      // Should still adopt — backward compat when we can't determine repo root
+      await expect(provider.create(baseRequest)).rejects.toThrow(/not a git-worktree reference/);
+    });
+
+    test('adopts across path normalization differences (trailing slash)', async () => {
+      const request: IsolationRequest = {
+        ...baseRequest,
+        canonicalRepoPath: '/workspace/repo/' as IsolationRequest['canonicalRepoPath'],
+      };
+      worktreeExistsSpy.mockResolvedValue(true);
+      // .git file has no trailing slash — resolve() should normalize
+      mockReadFile.mockResolvedValue('gitdir: /workspace/repo/.git/worktrees/archon/issue-42\n');
+
+      const env = await provider.create(request);
+
       expect(env.metadata).toHaveProperty('adopted', true);
     });
 
@@ -645,6 +659,42 @@ describe('WorktreeProvider', () => {
         ]),
         expect.any(Object)
       );
+    });
+
+    test('propagates error if branch -f reset fails (protected branch, etc.)', async () => {
+      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
+        // First worktree add call fails (branch exists)
+        if (args.includes('worktree') && args.includes('add') && args.includes('-b')) {
+          const error = new Error(
+            'fatal: A branch named archon/issue-42 already exists.'
+          ) as Error & { stderr?: string };
+          error.stderr = 'fatal: A branch named archon/issue-42 already exists.';
+          throw error;
+        }
+        // Reset call fails (e.g., branch checked out elsewhere, update hook refused)
+        if (args.includes('branch') && args.includes('-f')) {
+          const error = new Error('fatal: cannot force update the branch') as Error & {
+            stderr?: string;
+          };
+          error.stderr = "fatal: cannot force update the current branch 'archon/issue-42'";
+          throw error;
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      await expect(provider.create(baseRequest)).rejects.toThrow(/cannot force update/);
+
+      // Verify we did NOT retry the worktree add after reset failure
+      const secondWorktreeAdd = execSpy.mock.calls.filter((call: unknown[]) => {
+        const args = call[1] as string[];
+        return (
+          args.includes('worktree') &&
+          args.includes('add') &&
+          !args.includes('-b') &&
+          args.includes('archon/issue-42')
+        );
+      });
+      expect(secondWorktreeAdd).toHaveLength(0);
     });
 
     test('throws error if PR fetch fails (same-repo PR)', async () => {
@@ -1535,6 +1585,9 @@ describe('WorktreeProvider', () => {
 
     test('does not copy files when adopting existing worktree', async () => {
       worktreeExistsSpy.mockResolvedValue(true);
+      mockReadFile.mockResolvedValue(
+        'gitdir: /.archon/workspaces/owner/repo/.git/worktrees/archon/issue-42\n'
+      );
       const configLoader: RepoConfigLoader = async () => ({
         copyFiles: ['.env.example -> .env'],
       });
@@ -1684,6 +1737,7 @@ describe('WorktreeProvider', () => {
       // Simulate valid worktree: directory exists and IS a valid worktree
       accessSpy.mockResolvedValue(undefined); // Directory exists
       worktreeExistsSpy.mockResolvedValue(true); // And IS a valid worktree (will be adopted)
+      mockReadFile.mockResolvedValue('gitdir: /workspace/repo/.git/worktrees/archon/issue-999\n');
 
       await provider.create(request);
 
@@ -1979,6 +2033,9 @@ describe('WorktreeProvider', () => {
     test('does not sync workspace when adopting existing worktree', async () => {
       // Worktree exists - triggers adoption path (skips createWorktree)
       worktreeExistsSpy.mockResolvedValue(true);
+      mockReadFile.mockResolvedValue(
+        'gitdir: /workspace/owner/repo/.git/worktrees/archon/issue-42\n'
+      );
 
       await provider.create(baseRequest);
 

--- a/packages/isolation/src/providers/worktree.ts
+++ b/packages/isolation/src/providers/worktree.ts
@@ -5,7 +5,7 @@
  */
 
 import { createHash } from 'crypto';
-import { access, rm } from 'fs/promises';
+import { access, readFile, rm } from 'fs/promises';
 import { join } from 'path';
 
 import { createLogger } from '@archon/paths';
@@ -484,6 +484,24 @@ export class WorktreeProvider implements IIsolationProvider {
   ): Promise<WorktreeEnvironment | null> {
     // Check if worktree already exists at expected path
     if (await worktreeExists(toWorktreePath(worktreePath))) {
+      // Verify the existing worktree belongs to the same repo root.
+      // Two clones of the same remote resolve to the same worktree base dir,
+      // so a worktree created from clone A is visible from clone B. Without
+      // this check, clone B would silently adopt clone A's environment.
+      const existingRepo = await this.getWorktreeSourceRepo(worktreePath);
+      if (existingRepo && existingRepo !== request.canonicalRepoPath) {
+        getLog().warn(
+          {
+            worktreePath,
+            branchName,
+            existingRepo,
+            requestRepo: request.canonicalRepoPath,
+          },
+          'worktree_adoption_skipped_cross_checkout'
+        );
+        return null;
+      }
+
       getLog().info({ worktreePath, branchName }, 'worktree_adopted');
       return this.buildAdoptedEnvironment(worktreePath, branchName, request);
     }
@@ -504,6 +522,21 @@ export class WorktreeProvider implements IIsolationProvider {
     }
 
     return null;
+  }
+
+  /**
+   * Read the source repo root from a worktree's .git file.
+   * Returns null if the worktree .git file can't be read (non-fatal).
+   */
+  private async getWorktreeSourceRepo(worktreePath: string): Promise<string | null> {
+    try {
+      const gitContent = await readFile(join(worktreePath, '.git'), 'utf-8');
+      // gitdir: /path/to/repo/.git/worktrees/branch-name
+      const match = /gitdir: (.+)\/\.git\/worktrees\//.exec(gitContent);
+      return match ? match[1] : null;
+    } catch {
+      return null;
+    }
   }
 
   private buildAdoptedEnvironment(
@@ -899,7 +932,7 @@ export class WorktreeProvider implements IIsolationProvider {
       );
     } catch (error) {
       const err = error as Error & { stderr?: string };
-      // Branch already exists - use existing branch
+      // Branch already exists - reset to intended start-point and use it
       if (err.stderr?.includes('already exists')) {
         const taskFromBranch = request.workflowType === 'task' ? request.fromBranch : undefined;
         if (taskFromBranch) {
@@ -910,6 +943,17 @@ export class WorktreeProvider implements IIsolationProvider {
               'Either choose a different --branch name or omit --from.'
           );
         }
+
+        // Branch exists but no explicit start-point override — reset it to the
+        // intended start-point before checking out, so we don't inherit stale
+        // commits from a previous run or external tool.
+        getLog().warn(
+          { branchName, startPoint, repoPath },
+          'worktree.branch_exists_resetting_to_start_point'
+        );
+        await execFileAsync('git', ['-C', repoPath, 'branch', '-f', branchName, startPoint], {
+          timeout: 10000,
+        });
         await execFileAsync('git', ['-C', repoPath, 'worktree', 'add', worktreePath, branchName], {
           timeout: 30000,
         });

--- a/packages/isolation/src/providers/worktree.ts
+++ b/packages/isolation/src/providers/worktree.ts
@@ -6,7 +6,7 @@
 
 import { createHash } from 'crypto';
 import { access, readFile, rm } from 'fs/promises';
-import { join } from 'path';
+import { join, resolve } from 'path';
 
 import { createLogger } from '@archon/paths';
 import {
@@ -484,23 +484,13 @@ export class WorktreeProvider implements IIsolationProvider {
   ): Promise<WorktreeEnvironment | null> {
     // Check if worktree already exists at expected path
     if (await worktreeExists(toWorktreePath(worktreePath))) {
-      // Verify the existing worktree belongs to the same repo root.
-      // Two clones of the same remote resolve to the same worktree base dir,
-      // so a worktree created from clone A is visible from clone B. Without
-      // this check, clone B would silently adopt clone A's environment.
-      const existingRepo = await this.getWorktreeSourceRepo(worktreePath);
-      if (existingRepo && existingRepo !== request.canonicalRepoPath) {
-        getLog().warn(
-          {
-            worktreePath,
-            branchName,
-            existingRepo,
-            requestRepo: request.canonicalRepoPath,
-          },
-          'worktree_adoption_skipped_cross_checkout'
-        );
-        return null;
-      }
+      // Verify the existing worktree belongs to the same repo root before
+      // adopting. Two clones of the same remote resolve to the same worktree
+      // base dir, so a worktree created from clone A is visible from clone B.
+      // Throws on cross-checkout or unverifiable state — surfacing the problem
+      // is safer than falling through to createNewBranch (which would report
+      // a confusing "branch already exists" cascade) or silently adopting.
+      await this.verifyWorktreeOwnership(worktreePath, request.canonicalRepoPath, branchName);
 
       getLog().info({ worktreePath, branchName }, 'worktree_adopted');
       return this.buildAdoptedEnvironment(worktreePath, branchName, request);
@@ -525,17 +515,65 @@ export class WorktreeProvider implements IIsolationProvider {
   }
 
   /**
-   * Read the source repo root from a worktree's .git file.
-   * Returns null if the worktree .git file can't be read (non-fatal).
+   * Verify that the worktree at the given path belongs to the expected repo.
+   *
+   * Throws if the worktree's parent repo doesn't match the request, or if
+   * ownership cannot be determined. The caller relies on the throw-or-return
+   * contract: a successful return means the caller may safely adopt the
+   * worktree. This is intentionally strict — a permissive fallback here
+   * would re-introduce the cross-checkout bug this guard exists to prevent.
+   *
+   * Note: string comparison uses `resolve()` to normalize trailing slashes
+   * and relative components. Symlinked paths (where canonical vs registered
+   * paths differ by symlink resolution) are not equated — callers should
+   * register codebases with consistent path forms.
    */
-  private async getWorktreeSourceRepo(worktreePath: string): Promise<string | null> {
+  private async verifyWorktreeOwnership(
+    worktreePath: string,
+    expectedRepo: string,
+    branchName: string
+  ): Promise<void> {
+    let gitContent: string;
     try {
-      const gitContent = await readFile(join(worktreePath, '.git'), 'utf-8');
-      // gitdir: /path/to/repo/.git/worktrees/branch-name
-      const match = /gitdir: (.+)\/\.git\/worktrees\//.exec(gitContent);
-      return match ? match[1] : null;
-    } catch {
-      return null;
+      gitContent = await readFile(join(worktreePath, '.git'), 'utf-8');
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      // EISDIR: .git is a directory — path holds a full checkout, not a
+      // worktree. Refusing adoption prevents accidentally treating an
+      // unrelated repo at this path as ours.
+      if (err.code === 'EISDIR') {
+        throw new Error(
+          `Cannot adopt ${worktreePath}: path contains a full git checkout, not a worktree.`
+        );
+      }
+      // ENOENT: .git file missing despite worktreeExists() reporting true —
+      // a TOCTOU race or filesystem corruption. Fail fast.
+      // EACCES/EIO/etc.: cannot verify ownership — fail fast rather than
+      // defaulting to permissive adoption.
+      throw new Error(`Cannot verify worktree ownership at ${worktreePath}: ${err.message}`);
+    }
+
+    // gitdir: /path/to/repo/.git/worktrees/branch-name
+    const match = /gitdir: (.+)\/\.git\/worktrees\//.exec(gitContent);
+    if (!match) {
+      // Not a git-worktree pointer (e.g., submodule pointer, or malformed).
+      // We cannot confirm this is our worktree, so refuse adoption.
+      throw new Error(
+        `Cannot adopt ${worktreePath}: .git pointer is not a git-worktree reference.`
+      );
+    }
+
+    const existingRepo = resolve(match[1]);
+    const expectedResolved = resolve(expectedRepo);
+    if (existingRepo !== expectedResolved) {
+      getLog().warn(
+        { worktreePath, branchName, existingRepo, expectedRepo: expectedResolved },
+        'worktree_adoption_refused_cross_checkout'
+      );
+      throw new Error(
+        `Worktree at ${worktreePath} belongs to a different clone (${existingRepo}). ` +
+          'Remove it from that clone or use a different codebase registration.'
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes two compounding bugs that cause workflow runs to silently operate on the wrong branch:

- **Prompt-level** (#1193): `archon-implement` command's branch decision table is ambiguous — AI can adopt unrelated pre-existing branches instead of using its assigned worktree
- **Code-level** (#1188): `WorktreeProvider.findExisting()` adopts any worktree at the computed path regardless of which clone created it, and `createNewBranch()` silently inherits stale branch commits

## Changes

| File | Change |
|------|--------|
| `.archon/commands/defaults/archon-implement.md` | Replace flat branch table with decision tree; add "never switch branches" guard; use `$BASE_BRANCH` explicitly |
| `packages/isolation/src/providers/worktree.ts` | `findExisting()`: verify worktree parent repo matches request before adopting |
| `packages/isolation/src/providers/worktree.ts` | `createNewBranch()`: `git branch -f` stale orphan branches to intended start-point before checkout |
| `packages/isolation/src/providers/worktree.test.ts` | Tests for cross-checkout rejection, repo-root matching, backward compat, and stale branch reset |

## Root Cause

**Prompt**: The `archon-implement` command's Phase 2.2 used a flat table with "On feature branch → Use it" which the AI could interpret as "use any existing feature branch." The other implement commands (`archon-fix-issue`, `archon-implement-issue`) already use a proper decision tree with `IN WORKTREE?` as the first check.

**Code**: `findExisting()` checks only `worktreeExists(path)` — two clones of the same remote resolve to the same worktree base directory, so clone B adopts clone A's worktree. `createNewBranch()` falls back to `git worktree add path branch` (without `-b`) when the branch exists, inheriting whatever stale commits were on it.

## Testing

- [x] Type check passes
- [x] All 123 isolation tests pass (3 new tests added)
- [x] Lint passes
- [x] Full test suite passes

Fixes #1193
Supersedes #1186 (thanks to @halindrome for the initial framing and scoping — their PR identified the root cause class and explicitly flagged this provider-layer gap as a known limitation, which directly shaped #1198's approach).
Relates to #1188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked Git-state decision flow: clearer checks, show current branch and repo root, forbid switching/creating branches inside worktrees, and tightened STOP messages for uncommitted work.

* **Bug Fixes**
  * Refused adoption of worktrees that belong to a different repository; added branch reset-before-reuse when a branch already exists; surfaced clearer isolation/worktree error messages.

* **Tests**
  * Broadened tests for worktree adoption, ownership verification, branch-reset and error propagation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->