### PR TITLE
fix: route canonical path failures through blocked classification

### DIFF
--- a/packages/isolation/src/resolver.test.ts
+++ b/packages/isolation/src/resolver.test.ts
@@ -987,4 +987,50 @@ describe('IsolationResolver', () => {
       }
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Canonical path resolution failures
+  //
+  // getCanonicalRepoPath() runs early in resolve() (before any adoption path)
+  // because every downstream step needs the canonical repo root. Failures
+  // must mirror createNewEnvironment's contract: known infrastructure errors
+  // become a `blocked` result; unknown errors propagate as crashes.
+  // -------------------------------------------------------------------------
+  describe('canonical path resolution failure handling', () => {
+    test('known infrastructure error returns blocked with classified user message', async () => {
+      const eaccesError = new Error('EACCES: permission denied') as NodeJS.ErrnoException;
+      eaccesError.code = 'EACCES';
+      getCanonicalSpy.mockRejectedValue(eaccesError);
+
+      const resolver = createResolver();
+
+      const result = await resolver.resolve({
+        existingEnvId: null,
+        codebase: defaultCodebase,
+        platformType: 'web',
+      });
+
+      expect(result.status).toBe('blocked');
+      if (result.status === 'blocked') {
+        expect(result.reason).toBe('creation_failed');
+        expect(result.userMessage).toMatch(/Permission denied/);
+        expect(result.userMessage).toMatch(/Execution blocked/);
+      }
+    });
+
+    test('unknown error propagates as crash (programming bug visibility)', async () => {
+      // Deliberately not a known isolation pattern so isKnownIsolationError returns false
+      getCanonicalSpy.mockRejectedValue(new Error('Internal invariant violation: foo'));
+
+      const resolver = createResolver();
+
+      await expect(
+        resolver.resolve({
+          existingEnvId: null,
+          codebase: defaultCodebase,
+          platformType: 'web',
+        })
+      ).rejects.toThrow(/Internal invariant violation/);
+    });
+  });
 });

--- a/packages/isolation/src/resolver.ts
+++ b/packages/isolation/src/resolver.ts
@@ -108,13 +108,16 @@ export class IsolationResolver {
 
     // Compute canonical repo path once — paths 3-6 all need it either for
     // ownership verification (cross-clone guard) or for worktree creation.
-    // Wrap failures so they classify as known isolation errors with actionable
-    // messages instead of propagating as unclassified crashes.
+    // Mirror createNewEnvironment's contract: known infrastructure failures
+    // (permission denied, ENOENT, malformed worktree pointer, etc.) become
+    // a `blocked` result with an actionable user message; unknown failures
+    // propagate so they surface as crashes rather than silent isolation
+    // failures.
     let canonicalPath: RepoPath;
     try {
       canonicalPath = await getCanonicalRepoPath(codebase.defaultCwd);
     } catch (error) {
-      const err = error as Error;
+      const err = error instanceof Error ? error : new Error(String(error));
       getLog().error(
         {
           err,
@@ -124,10 +127,19 @@ export class IsolationResolver {
         },
         'isolation.canonical_repo_path_resolution_failed'
       );
-      throw new Error(
-        `Cannot determine canonical repo path for ${codebase.defaultCwd}: ${err.message}`,
-        { cause: err }
-      );
+
+      if (!isKnownIsolationError(err)) {
+        throw err;
+      }
+
+      const userMessage = classifyIsolationError(err);
+      return {
+        status: 'blocked',
+        reason: 'creation_failed',
+        userMessage:
+          userMessage +
+          ' Execution blocked to prevent changes to shared codebase. Please resolve the issue and try again.',
+      };
     }
 
     // 3. Check for existing environment with same workflow


### PR DESCRIPTION
## Summary

Follow-up to the CodeRabbit review on #1206. The early \`getCanonicalRepoPath()\` wrap in \`IsolationResolver.resolve()\` threw directly, bypassing the classification flow that \`createNewEnvironment\` uses. Permission errors, ENOENT, malformed worktree pointers, etc. would surface as unclassified crashes instead of becoming an actionable \`blocked\` result.

## Change

Mirror \`createNewEnvironment\`'s contract:

- \`isKnownIsolationError(err)\` → \`{ status: 'blocked', reason: 'creation_failed', userMessage: classifyIsolationError(err) + ' Execution blocked...' }\`
- Unknown errors → throw (programming bugs stay visible as crashes, not silent isolation failures)

Single file behavior change in \`packages/isolation/src/resolver.ts:114\`. Two tests added in \`resolver.test.ts\`:

- EACCES classifies to "Permission denied" blocked message
- Unknown error propagates as throw

## Testing

- [x] \`bun run type-check\` — clean
- [x] \`bun run lint\` — zero warnings
- [x] \`bun test packages/isolation/src/resolver.test.ts\` — 36 pass (2 new)
- [x] Full test suite green

## Review reference

[CodeRabbit comment on #1206](https://github.com/coleam00/Archon/pull/1206) — "Canonical-path failures still escape resolve() as thrown exceptions."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during repository path resolution. When infrastructure-related issues prevent execution, users now receive a clear "blocked" status with descriptive messaging instead of an exception.

* **Tests**
  * Added comprehensive test coverage for repository path resolution failure scenarios, validating the system's handling of both infrastructure-related and unexpected errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->