### PR TITLE
fix: lock workflow runs by working_path (#1036, #1188 part 2)

### DIFF
--- a/packages/core/src/db/adapters/sqlite.test.ts
+++ b/packages/core/src/db/adapters/sqlite.test.ts
@@ -135,4 +135,46 @@ describe('SqliteAdapter', () => {
       ).rejects.toThrow('does not support RETURNING clause on UPDATE/DELETE');
     });
   });
+
+  describe('datetime() chronological vs lexical comparison', () => {
+    // Documents the SQLite-specific bug fixed in getActiveWorkflowRunByPath.
+    // `started_at` is TEXT in "YYYY-MM-DD HH:MM:SS" format. Comparing it
+    // directly to an ISO param "YYYY-MM-DDTHH:MM:SS.mmmZ" with `<` is
+    // LEXICAL: char 11 is space (0x20) in the column vs T (0x54) in the
+    // param, so every column value lex-sorts before every ISO param,
+    // making the comparison ALWAYS true regardless of actual time.
+    //
+    // Wrapping both sides in datetime() forces chronological comparison.
+
+    test('lexical comparison gives wrong answer for SQLite stored format vs ISO param', async () => {
+      db = createTestDb();
+      // Column-format value (afternoon) is chronologically AFTER the ISO
+      // param (morning), but lex compares char-11 (space < T) → wrong.
+      const result = await db.query<{ broken: number }>(
+        `SELECT ('2026-04-14 12:00:00' < $1) AS broken`,
+        ['2026-04-14T10:00:00.000Z']
+      );
+      // Expected by chronology: FALSE. Lex says: TRUE.
+      expect(result.rows[0].broken).toBe(1);
+    });
+
+    test('datetime() wrap on both sides gives chronological comparison', async () => {
+      db = createTestDb();
+      const result = await db.query<{ correct: number }>(
+        `SELECT (datetime('2026-04-14 12:00:00') < datetime($1)) AS correct`,
+        ['2026-04-14T10:00:00.000Z']
+      );
+      // 12:00 < 10:00 is FALSE — datetime() comparison agrees with reality.
+      expect(result.rows[0].correct).toBe(0);
+    });
+
+    test('datetime() handles equality across formats', async () => {
+      db = createTestDb();
+      const result = await db.query<{ equal: number }>(
+        `SELECT (datetime('2026-04-14 10:00:00') = datetime($1)) AS equal`,
+        ['2026-04-14T10:00:00.000Z']
+      );
+      expect(result.rows[0].equal).toBe(1);
+    });
+  });
 });

--- a/packages/core/src/db/workflows.test.ts
+++ b/packages/core/src/db/workflows.test.ts
@@ -596,7 +596,8 @@ describe('workflows database', () => {
       // race where two timestamps land in the same millisecond.
       expect(query).toContain('started_at < $3');
       expect(query).toContain('started_at = $3 AND id < $2');
-      expect(params).toEqual(['/repo/path', 'self-id', selfStartedAt]);
+      // selfStartedAt serialized to ISO — bun:sqlite rejects Date bindings.
+      expect(params).toEqual(['/repo/path', 'self-id', selfStartedAt.toISOString()]);
     });
 
     test('omits tiebreaker clause when selfStartedAt is provided without excludeId', async () => {

--- a/packages/core/src/db/workflows.test.ts
+++ b/packages/core/src/db/workflows.test.ts
@@ -559,6 +559,67 @@ describe('workflows database', () => {
       expect(params).toEqual(['/repo/path']);
     });
 
+    test('includes pending rows within the stale-pending age window', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([]));
+
+      await getActiveWorkflowRunByPath('/repo/path');
+
+      const [query] = mockQuery.mock.calls[0] as [string, unknown[]];
+      // Fresh `pending` counts as active so the lock is held immediately
+      // after pre-create — without this, two near-simultaneous dispatches
+      // both pass the guard.
+      expect(query).toContain("status = 'pending'");
+      // Age window cutoff prevents orphaned pending rows (from crashed
+      // dispatches) from permanently blocking a path.
+      expect(query).toMatch(/started_at >.*INTERVAL.*milliseconds/);
+    });
+
+    test('excludes self by id when excludeId is provided', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([]));
+
+      await getActiveWorkflowRunByPath('/repo/path', 'self-id');
+
+      const [query, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+      expect(query).toContain('id != $2');
+      expect(params).toEqual(['/repo/path', 'self-id']);
+    });
+
+    test('applies older-wins tiebreaker when both excludeId and selfStartedAt are provided', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([]));
+      const selfStartedAt = new Date('2026-04-14T10:00:00Z');
+
+      await getActiveWorkflowRunByPath('/repo/path', 'self-id', selfStartedAt);
+
+      const [query, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+      // Total order on (started_at, id) — the newer dispatch sees the older
+      // row and aborts; the older sees nothing. Eliminates the both-abort
+      // race where two timestamps land in the same millisecond.
+      expect(query).toContain('started_at < $3');
+      expect(query).toContain('started_at = $3 AND id < $2');
+      expect(params).toEqual(['/repo/path', 'self-id', selfStartedAt]);
+    });
+
+    test('omits tiebreaker clause when selfStartedAt is provided without excludeId', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([]));
+
+      await getActiveWorkflowRunByPath('/repo/path', undefined, new Date('2026-04-14T10:00:00Z'));
+
+      const [query, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+      // Tiebreaker requires both id and started_at to be meaningful; without
+      // an id to exclude, the started_at param would be dangling.
+      expect(query).not.toContain('started_at <');
+      expect(params).toEqual(['/repo/path']);
+    });
+
+    test('orders by (started_at ASC, id ASC) so older-wins is deterministic', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([]));
+
+      await getActiveWorkflowRunByPath('/repo/path');
+
+      const [query] = mockQuery.mock.calls[0] as [string, unknown[]];
+      expect(query).toContain('ORDER BY started_at ASC, id ASC');
+    });
+
     test('returns null when no active run on path', async () => {
       mockQuery.mockResolvedValueOnce(createQueryResult([]));
 

--- a/packages/core/src/db/workflows.test.ts
+++ b/packages/core/src/db/workflows.test.ts
@@ -574,40 +574,32 @@ describe('workflows database', () => {
       expect(query).toMatch(/started_at >.*INTERVAL.*milliseconds/);
     });
 
-    test('excludes self by id when excludeId is provided', async () => {
+    test('excludes self and applies older-wins tiebreaker when self is provided', async () => {
       mockQuery.mockResolvedValueOnce(createQueryResult([]));
+      const startedAt = new Date('2026-04-14T10:00:00Z');
 
-      await getActiveWorkflowRunByPath('/repo/path', 'self-id');
+      await getActiveWorkflowRunByPath('/repo/path', { id: 'self-id', startedAt });
 
       const [query, params] = mockQuery.mock.calls[0] as [string, unknown[]];
       expect(query).toContain('id != $2');
-      expect(params).toEqual(['/repo/path', 'self-id']);
-    });
-
-    test('applies older-wins tiebreaker when both excludeId and selfStartedAt are provided', async () => {
-      mockQuery.mockResolvedValueOnce(createQueryResult([]));
-      const selfStartedAt = new Date('2026-04-14T10:00:00Z');
-
-      await getActiveWorkflowRunByPath('/repo/path', 'self-id', selfStartedAt);
-
-      const [query, params] = mockQuery.mock.calls[0] as [string, unknown[]];
-      // Total order on (started_at, id) — the newer dispatch sees the older
-      // row and aborts; the older sees nothing. Eliminates the both-abort
-      // race where two timestamps land in the same millisecond.
-      expect(query).toContain('started_at < $3');
-      expect(query).toContain('started_at = $3 AND id < $2');
+      // PostgreSQL branch: explicit `::timestamptz` cast on the param so
+      // the comparison is chronological, not lexical. SQLite branch wraps
+      // both sides in datetime() — covered by tests in adapters/sqlite.test.ts
+      // because this suite mocks getDatabaseType as 'postgresql'.
+      expect(query).toContain('started_at < $3::timestamptz');
+      expect(query).toContain('started_at = $3::timestamptz AND id < $2');
       // selfStartedAt serialized to ISO — bun:sqlite rejects Date bindings.
-      expect(params).toEqual(['/repo/path', 'self-id', selfStartedAt.toISOString()]);
+      expect(params).toEqual(['/repo/path', 'self-id', startedAt.toISOString()]);
     });
 
-    test('omits tiebreaker clause when selfStartedAt is provided without excludeId', async () => {
+    test('skips self exclusion + tiebreaker when self is omitted (no caller context)', async () => {
       mockQuery.mockResolvedValueOnce(createQueryResult([]));
 
-      await getActiveWorkflowRunByPath('/repo/path', undefined, new Date('2026-04-14T10:00:00Z'));
+      await getActiveWorkflowRunByPath('/repo/path');
 
       const [query, params] = mockQuery.mock.calls[0] as [string, unknown[]];
-      // Tiebreaker requires both id and started_at to be meaningful; without
-      // an id to exclude, the started_at param would be dangling.
+      // Without `self`, neither the id-exclusion nor the tiebreaker apply.
+      expect(query).not.toContain('id !=');
       expect(query).not.toContain('started_at <');
       expect(params).toEqual(['/repo/path']);
     });

--- a/packages/core/src/db/workflows.test.ts
+++ b/packages/core/src/db/workflows.test.ts
@@ -733,6 +733,22 @@ describe('workflows database', () => {
       expect(selectParams).toEqual(['workflow-run-123']);
     });
 
+    test('refreshes started_at to NOW so resumed row competes fairly in the path-lock tiebreaker', async () => {
+      // Without this refresh, a resumed row carries its original (potentially
+      // hours-old) started_at and sorts ahead of any currently-active holder
+      // in the older-wins tiebreaker — slipping past the lock and causing
+      // two active workflows on the same working_path.
+      mockQuery.mockResolvedValueOnce(createQueryResult([], 1));
+      mockQuery.mockResolvedValueOnce(
+        createQueryResult([{ ...mockWorkflowRun, status: 'running' as const }])
+      );
+
+      await resumeWorkflowRun('workflow-run-123');
+
+      const [updateQuery] = mockQuery.mock.calls[0] as [string, unknown[]];
+      expect(updateQuery).toContain('started_at = NOW()');
+    });
+
     test('throws when no row matched (run not found)', async () => {
       // UPDATE returns rowCount 0
       mockQuery.mockResolvedValueOnce(createQueryResult([], 0));

--- a/packages/core/src/db/workflows.ts
+++ b/packages/core/src/db/workflows.ts
@@ -184,13 +184,65 @@ export async function getPausedWorkflowRun(conversationId: string): Promise<Work
   }
 }
 
-export async function getActiveWorkflowRunByPath(workingPath: string): Promise<WorkflowRun | null> {
+/**
+ * Find the workflow run currently holding the lock on `workingPath`.
+ *
+ * The lock is held by any row in `(running, paused)` or `pending` younger
+ * than `STALE_PENDING_AGE_MS` (orphaned pre-creates beyond that window are
+ * ignored — they're from crashed or resume-replaced dispatches).
+ *
+ * When called from a dispatch that already pre-created its own row, pass
+ * `excludeId` and `selfStartedAt` so:
+ *   1. Self is never returned.
+ *   2. If two dispatches both have rows, the deterministic older-wins
+ *      tiebreaker `(started_at, id)` ensures both agree on which is "first."
+ *      The newer dispatch sees the older row and aborts; the older dispatch
+ *      sees nothing.
+ *
+ * Returns the holding row, or null if the path is free.
+ */
+export const STALE_PENDING_AGE_MS = 5 * 60 * 1000; // 5 minutes
+
+export async function getActiveWorkflowRunByPath(
+  workingPath: string,
+  excludeId?: string,
+  selfStartedAt?: Date
+): Promise<WorkflowRun | null> {
+  const isPostgres = getDatabaseType() === 'postgresql';
+  const stalePendingCutoff = isPostgres
+    ? `NOW() - INTERVAL '${String(STALE_PENDING_AGE_MS)} milliseconds'`
+    : `datetime('now', '-${String(Math.floor(STALE_PENDING_AGE_MS / 1000))} seconds')`;
+
+  // Build params + clauses dynamically — null/undefined for $2/$3 doesn't
+  // play well with type inference across both dialects, so structure the
+  // WHERE so each optional param is always-positional when present.
+  const params: unknown[] = [workingPath];
+  const clauses: string[] = [
+    'working_path = $1',
+    `(status IN ('running', 'paused') OR (status = 'pending' AND started_at > ${stalePendingCutoff}))`,
+  ];
+  if (excludeId !== undefined) {
+    params.push(excludeId);
+    clauses.push(`id != $${String(params.length)}`);
+  }
+  if (selfStartedAt !== undefined && excludeId !== undefined) {
+    // Older-wins tiebreaker. (started_at, id) is a total order so both
+    // dispatches always agree on which is "first." Without this, two rows
+    // with similar timestamps could mutually see each other and both abort.
+    params.push(selfStartedAt);
+    const startedAtParam = `$${String(params.length)}`;
+    const idParam = `$${String(params.length - 1)}`;
+    clauses.push(
+      `(started_at < ${startedAtParam} OR (started_at = ${startedAtParam} AND id < ${idParam}))`
+    );
+  }
+
   try {
     const result = await pool.query<WorkflowRun>(
       `SELECT * FROM remote_agent_workflow_runs
-       WHERE working_path = $1 AND status IN ('running', 'paused')
-       ORDER BY started_at DESC LIMIT 1`,
-      [workingPath]
+       WHERE ${clauses.join(' AND ')}
+       ORDER BY started_at ASC, id ASC LIMIT 1`,
+      params
     );
     const row = result.rows[0];
     return row ? normalizeWorkflowRun(row) : null;

--- a/packages/core/src/db/workflows.ts
+++ b/packages/core/src/db/workflows.ts
@@ -365,9 +365,23 @@ export async function resumeWorkflowRun(id: string): Promise<WorkflowRun> {
   // Each phase has its own try/catch to avoid string-sniffing own errors in a shared catch.
   let updateResult: Awaited<ReturnType<typeof pool.query>>;
   try {
+    // Refresh started_at to NOW so the resumed row competes fairly with
+    // currently-active rows in getActiveWorkflowRunByPath's older-wins
+    // tiebreaker. Without this, a resumed row carries its original
+    // (potentially hours-old) started_at and would sort ahead of any
+    // currently-running holder, slipping past the path lock and causing
+    // two active workflows on the same working_path.
+    //
+    // We accept losing the original creation time here — `started_at` for
+    // an active row semantically means "when did this active phase start."
+    // The original creation time can be recovered from workflow_events
+    // history if needed for analytics.
     updateResult = await pool.query(
       `UPDATE remote_agent_workflow_runs
-       SET status = 'running', completed_at = NULL, last_activity_at = ${dialect.now()}
+       SET status = 'running',
+           completed_at = NULL,
+           started_at = ${dialect.now()},
+           last_activity_at = ${dialect.now()}
        WHERE id = $1`,
       [id]
     );

--- a/packages/core/src/db/workflows.ts
+++ b/packages/core/src/db/workflows.ts
@@ -205,40 +205,47 @@ export const STALE_PENDING_AGE_MS = 5 * 60 * 1000; // 5 minutes
 
 export async function getActiveWorkflowRunByPath(
   workingPath: string,
-  excludeId?: string,
-  selfStartedAt?: Date
+  self?: { id: string; startedAt: Date }
 ): Promise<WorkflowRun | null> {
   const isPostgres = getDatabaseType() === 'postgresql';
   const stalePendingCutoff = isPostgres
     ? `NOW() - INTERVAL '${String(STALE_PENDING_AGE_MS)} milliseconds'`
     : `datetime('now', '-${String(Math.floor(STALE_PENDING_AGE_MS / 1000))} seconds')`;
 
-  // Build params + clauses dynamically — null/undefined for $2/$3 doesn't
-  // play well with type inference across both dialects, so structure the
-  // WHERE so each optional param is always-positional when present.
+  // Build params + clauses dynamically. Self exclusion + tiebreaker travel
+  // together — the tiebreaker references both ids and timestamps.
   const params: unknown[] = [workingPath];
   const clauses: string[] = [
     'working_path = $1',
     `(status IN ('running', 'paused') OR (status = 'pending' AND started_at > ${stalePendingCutoff}))`,
   ];
-  if (excludeId !== undefined) {
-    params.push(excludeId);
+  if (self !== undefined) {
+    params.push(self.id);
     clauses.push(`id != $${String(params.length)}`);
   }
-  if (selfStartedAt !== undefined && excludeId !== undefined) {
+  if (self !== undefined) {
     // Older-wins tiebreaker. (started_at, id) is a total order so both
     // dispatches always agree on which is "first." Without this, two rows
     // with similar timestamps could mutually see each other and both abort.
     //
-    // Serialize Date to ISO string — bun:sqlite rejects Date bindings, and
-    // PostgreSQL accepts ISO timestamps for `< / =` comparison against
-    // TIMESTAMPTZ columns.
-    params.push(selfStartedAt.toISOString());
+    // Serialize Date to ISO string — bun:sqlite rejects Date bindings.
+    //
+    // Format-aware comparison:
+    //   PostgreSQL: started_at is TIMESTAMPTZ; cast the ISO param to
+    //     timestamptz so the comparison is chronological, not lexical.
+    //   SQLite: started_at is TEXT in "YYYY-MM-DD HH:MM:SS" format. Our
+    //     ISO param has "YYYY-MM-DDTHH:MM:SS.mmmZ". Lexical comparison is
+    //     WRONG: char 11 is space (0x20) in the column vs T (0x54) in the
+    //     param, so every column value lex-sorts before every ISO param —
+    //     making `started_at < $param` always TRUE regardless of actual
+    //     time. Wrap both sides in datetime() to force chronological
+    //     comparison via SQLite's date/time functions.
+    params.push(self.startedAt.toISOString());
     const startedAtParam = `$${String(params.length)}`;
     const idParam = `$${String(params.length - 1)}`;
-    clauses.push(
-      `(started_at < ${startedAtParam} OR (started_at = ${startedAtParam} AND id < ${idParam}))`
-    );
+    const colExpr = isPostgres ? 'started_at' : 'datetime(started_at)';
+    const paramExpr = isPostgres ? `${startedAtParam}::timestamptz` : `datetime(${startedAtParam})`;
+    clauses.push(`(${colExpr} < ${paramExpr} OR (${colExpr} = ${paramExpr} AND id < ${idParam}))`);
   }
 
   try {

--- a/packages/core/src/db/workflows.ts
+++ b/packages/core/src/db/workflows.ts
@@ -229,7 +229,11 @@ export async function getActiveWorkflowRunByPath(
     // Older-wins tiebreaker. (started_at, id) is a total order so both
     // dispatches always agree on which is "first." Without this, two rows
     // with similar timestamps could mutually see each other and both abort.
-    params.push(selfStartedAt);
+    //
+    // Serialize Date to ISO string — bun:sqlite rejects Date bindings, and
+    // PostgreSQL accepts ISO timestamps for `< / =` comparison against
+    // TIMESTAMPTZ columns.
+    params.push(selfStartedAt.toISOString());
     const startedAtParam = `$${String(params.length)}`;
     const idParam = `$${String(params.length - 1)}`;
     clauses.push(

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -171,7 +171,7 @@ archon workflow resume <run-id>
 
 ### `workflow abandon`
 
-Discard a workflow run (marks it as failed). Use this to unblock a worktree when you don't want to resume.
+Discard a workflow run (marks it as `cancelled`). Use this to unblock a worktree when you don't want to resume — the path lock is released immediately so a new workflow can start.
 
 ```bash
 archon workflow abandon <run-id>

--- a/packages/docs-web/src/content/docs/reference/database.md
+++ b/packages/docs-web/src/content/docs/reference/database.md
@@ -142,7 +142,7 @@ The database has 8 tables, all prefixed with `remote_agent_`:
 
 5. **`remote_agent_workflow_runs`** - Workflow execution tracking
    - Tracks active workflows per conversation
-   - Prevents concurrent workflow execution
+   - Locks concurrent execution per `working_path`: a second dispatch on a path with an active run (status `pending`/`running`/`paused`) is auto-cancelled with an actionable message. Stale `pending` rows older than 5 minutes are treated as orphaned and ignored.
    - Stores workflow state, step progress, and parent conversation linkage
 
 6. **`remote_agent_workflow_events`** - Step-level workflow event log

--- a/packages/workflows/src/executor-preamble.test.ts
+++ b/packages/workflows/src/executor-preamble.test.ts
@@ -196,7 +196,7 @@ describe('executeWorkflow preamble', () => {
       );
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('already running');
+      expect(result.error).toContain('already active');
 
       // Actionable rejection message was sent (mentions worktree-in-use,
       // workflow name, and concrete next-action commands)

--- a/packages/workflows/src/executor-preamble.test.ts
+++ b/packages/workflows/src/executor-preamble.test.ts
@@ -177,8 +177,10 @@ describe('executeWorkflow preamble', () => {
         started_at: recentTime,
         status: 'running',
       });
+      const updateSpy = mock(async () => {});
       const store = makeStore({
         getActiveWorkflowRunByPath: mock(async () => activeRun),
+        updateWorkflowRun: updateSpy,
       });
       const deps = makeDeps(store);
       const platform = makePlatform();
@@ -196,12 +198,23 @@ describe('executeWorkflow preamble', () => {
       expect(result.success).toBe(false);
       expect(result.error).toContain('already running');
 
-      // Rejection message was sent
-      const blockMsg = findMessage(platform, 'Workflow already running');
-      expect(blockMsg).toBeDefined();
+      // Actionable rejection message was sent (mentions worktree-in-use,
+      // workflow name, and concrete next-action commands)
+      const blockCall = findMessage(platform, 'in use');
+      expect(blockCall).toBeDefined();
+      const blockMsg = blockCall?.[1] as string;
+      expect(blockMsg).toContain('active-workflow');
+      expect(blockMsg).toContain('/workflow cancel');
 
-      // No new workflow was created
-      expect((store.createWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+      // The guard now runs AFTER the row is created (so it always has a
+      // self-ID to exclude). On guard fire, the just-created row is marked
+      // cancelled — preventing zombie pending rows that would block future
+      // dispatches.
+      expect((store.createWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+      const cancelCall = updateSpy.mock.calls.find(
+        (call: unknown[]) => (call[1] as { status?: string })?.status === 'cancelled'
+      );
+      expect(cancelCall).toBeDefined();
     });
   });
 
@@ -278,8 +291,10 @@ describe('executeWorkflow preamble', () => {
       expect(result.success).toBe(false);
       expect(result.error).toContain('Database error');
 
-      // No new workflow was created
-      expect((store.createWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+      // The row is created BEFORE the guard runs (so the guard can exclude
+      // self). When the lock query throws, we abort early — the just-created
+      // row stays as 'pending' and falls out via the 5-min stale window.
+      expect((store.createWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
 
       // Error message was sent
       const errorMsg =

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -228,7 +228,10 @@ describe('executeWorkflow', () => {
         'db-conv-1'
       );
 
-      expect(getActiveSpy).toHaveBeenCalledWith('/tmp', 'self-run-789', expect.any(Date));
+      expect(getActiveSpy).toHaveBeenCalledWith(
+        '/tmp',
+        expect.objectContaining({ id: 'self-run-789', startedAt: expect.any(Date) })
+      );
     });
 
     it('marks self as cancelled when guard fires (no zombie pending row)', async () => {
@@ -293,6 +296,36 @@ describe('executeWorkflow', () => {
       expect(sentMessage).toContain('/workflow status');
       expect(sentMessage).toContain('/workflow cancel abc12345');
       expect(sentMessage).toContain('--branch');
+    });
+
+    it('still returns failure when guard self-cancel update throws (best-effort)', async () => {
+      const selfRun = makeRun({ id: 'self-run', status: 'pending' });
+      const otherRun = makeRun({ id: 'other-run', status: 'running' });
+      const updateSpy = mock(async (id: string) => {
+        // Self-cancel attempt fails — must not crash, must still surface
+        // the "in use" failure to the user.
+        if (id === 'self-run') throw new Error('Update failed');
+      });
+      const store = makeStore({
+        createWorkflowRun: mock(async () => selfRun),
+        getActiveWorkflowRunByPath: mock(async () => otherRun),
+        updateWorkflowRun: updateSpy,
+      });
+      const deps = makeDeps(store);
+
+      const result = await executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-1',
+        '/tmp',
+        makeWorkflow(),
+        'test',
+        'db-conv-1'
+      );
+
+      // Cleanup failure must not mask the "in use" outcome.
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('already active');
     });
   });
 

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -203,7 +203,7 @@ describe('executeWorkflow', () => {
         'db-conv-1'
       );
       expect(result.success).toBe(false);
-      expect(result.error).toContain('already running');
+      expect(result.error).toContain('already active');
     });
 
     it('passes self-id and started_at to the lock query so self is excluded', async () => {
@@ -705,6 +705,160 @@ describe('executeWorkflow', () => {
       );
 
       expect(store.getCodebaseEnvVars).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Lock-token cleanup on pre-DAG failure paths (review #1)
+  //
+  // Any failure between row creation and DAG start that returns early must
+  // release the lock token. Without this, ghost pending/running rows block
+  // the path until the 5-min stale window or manual intervention.
+  // -------------------------------------------------------------------------
+
+  describe('lock cleanup on failure paths', () => {
+    it('cancels pre-created row when resumeWorkflowRun throws', async () => {
+      const preCreated = makeRun({ id: 'pre-created-orphan', status: 'pending' });
+      const resumable = makeRun({ id: 'failed-prior-run', status: 'failed' });
+      const updateSpy = mock(async () => {});
+      const store = makeStore({
+        findResumableRun: mock(async () => resumable),
+        getCompletedDagNodeOutputs: mock(async () => new Map([['node1', 'out1']])),
+        resumeWorkflowRun: mock(async () => {
+          throw new Error('DB blew up during resume activation');
+        }),
+        updateWorkflowRun: updateSpy,
+      });
+      const deps = makeDeps(store);
+
+      const result = await executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-1',
+        '/tmp',
+        makeWorkflow(),
+        'test',
+        'db-conv-1',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        preCreated
+      );
+
+      expect(result.success).toBe(false);
+      const cancelCall = updateSpy.mock.calls.find(
+        (call: unknown[]) =>
+          call[0] === 'pre-created-orphan' &&
+          (call[1] as { status?: string })?.status === 'cancelled'
+      );
+      expect(cancelCall).toBeDefined();
+    });
+
+    it('cancels workflowRun when guard query throws (no zombie row)', async () => {
+      const updateSpy = mock(async () => {});
+      const store = makeStore({
+        getActiveWorkflowRunByPath: mock(async () => {
+          throw new Error('DB connection lost during guard');
+        }),
+        updateWorkflowRun: updateSpy,
+      });
+      const deps = makeDeps(store);
+
+      const result = await executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-1',
+        '/tmp',
+        makeWorkflow(),
+        'test',
+        'db-conv-1'
+      );
+
+      expect(result.success).toBe(false);
+      const cancelCall = updateSpy.mock.calls.find(
+        (call: unknown[]) => (call[1] as { status?: string })?.status === 'cancelled'
+      );
+      expect(cancelCall).toBeDefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Status-aware blocking message (review #3)
+  //
+  // The lock query returns running, paused, AND fresh-pending rows.
+  // Telling a user to "wait" when the holder is `paused` is misleading —
+  // they need to approve/reject to unblock it.
+  // -------------------------------------------------------------------------
+
+  describe('blocking message status awareness', () => {
+    it('uses paused-specific copy when blocker is paused', async () => {
+      const pausedRun = makeRun({
+        id: 'paused-run-id',
+        workflow_name: 'archon-implement',
+        status: 'paused',
+        started_at: new Date(Date.now() - 10000).toISOString(),
+      });
+      const sendMessageSpy = mock(async () => {});
+      const platform = {
+        sendMessage: sendMessageSpy,
+        getPlatformType: mock(() => 'test' as const),
+      } as unknown as IWorkflowPlatform;
+      const store = makeStore({ getActiveWorkflowRunByPath: mock(async () => pausedRun) });
+      const deps = makeDeps(store);
+
+      await executeWorkflow(deps, platform, 'conv-1', '/tmp', makeWorkflow(), 'test', 'db-conv-1');
+
+      const msg = (sendMessageSpy.mock.calls[0] as [string, string])[1];
+      // Wrong action ("wait for it to finish") would let users sit forever
+      // on a workflow waiting for their own approval.
+      expect(msg).toContain('paused');
+      expect(msg).toContain('/workflow approve');
+      expect(msg).toContain('/workflow reject');
+      expect(msg).not.toContain('Wait for it to finish');
+    });
+
+    it('uses pending-specific copy when blocker is just starting', async () => {
+      const pendingRun = makeRun({
+        id: 'pending-run',
+        workflow_name: 'archon-implement',
+        status: 'pending',
+        started_at: new Date(Date.now() - 500).toISOString(),
+      });
+      const sendMessageSpy = mock(async () => {});
+      const platform = {
+        sendMessage: sendMessageSpy,
+        getPlatformType: mock(() => 'test' as const),
+      } as unknown as IWorkflowPlatform;
+      const store = makeStore({ getActiveWorkflowRunByPath: mock(async () => pendingRun) });
+      const deps = makeDeps(store);
+
+      await executeWorkflow(deps, platform, 'conv-1', '/tmp', makeWorkflow(), 'test', 'db-conv-1');
+
+      const msg = (sendMessageSpy.mock.calls[0] as [string, string])[1];
+      expect(msg).toContain('starting');
+    });
+
+    it('uses running copy by default', async () => {
+      const runningRun = makeRun({
+        id: 'running-run',
+        workflow_name: 'archon-implement',
+        status: 'running',
+        started_at: new Date(Date.now() - 60000).toISOString(),
+      });
+      const sendMessageSpy = mock(async () => {});
+      const platform = {
+        sendMessage: sendMessageSpy,
+        getPlatformType: mock(() => 'test' as const),
+      } as unknown as IWorkflowPlatform;
+      const store = makeStore({ getActiveWorkflowRunByPath: mock(async () => runningRun) });
+      const deps = makeDeps(store);
+
+      await executeWorkflow(deps, platform, 'conv-1', '/tmp', makeWorkflow(), 'test', 'db-conv-1');
+
+      const msg = (sendMessageSpy.mock.calls[0] as [string, string])[1];
+      expect(msg).toContain('running 1m');
+      expect(msg).toContain('Wait for it to finish');
     });
   });
 });

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -185,6 +185,7 @@ describe('executeWorkflow', () => {
 
     it('blocks workflow when another is actively running', async () => {
       const activeRun = makeRun({
+        id: 'other-run-456',
         status: 'running',
         started_at: new Date().toISOString(), // Recent — not stale
       });
@@ -203,6 +204,176 @@ describe('executeWorkflow', () => {
       );
       expect(result.success).toBe(false);
       expect(result.error).toContain('already running');
+    });
+
+    it('passes self-id and started_at to the lock query so self is excluded', async () => {
+      // The guard runs AFTER workflowRun is finalized so we always have
+      // a self-ID. Without these args, the dispatch's own row would match
+      // and falsely trigger the guard.
+      const selfRun = makeRun({ id: 'self-run-789', started_at: '2026-04-14T10:00:00.000Z' });
+      const getActiveSpy = mock(async () => null);
+      const store = makeStore({
+        createWorkflowRun: mock(async () => selfRun),
+        getActiveWorkflowRunByPath: getActiveSpy,
+      });
+      const deps = makeDeps(store);
+
+      await executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-1',
+        '/tmp',
+        makeWorkflow(),
+        'test message',
+        'db-conv-1'
+      );
+
+      expect(getActiveSpy).toHaveBeenCalledWith('/tmp', 'self-run-789', expect.any(Date));
+    });
+
+    it('marks self as cancelled when guard fires (no zombie pending row)', async () => {
+      const selfRun = makeRun({ id: 'self-run-789' });
+      const otherRun = makeRun({ id: 'other-run-456', status: 'running' });
+      const updateSpy = mock(async () => {});
+      const store = makeStore({
+        createWorkflowRun: mock(async () => selfRun),
+        getActiveWorkflowRunByPath: mock(async () => otherRun),
+        updateWorkflowRun: updateSpy,
+      });
+      const deps = makeDeps(store);
+
+      await executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-1',
+        '/tmp',
+        makeWorkflow(),
+        'test message',
+        'db-conv-1'
+      );
+
+      // Without this, every guard-blocked dispatch would leak a `pending`
+      // row that briefly blocks future dispatches via the lock query.
+      expect(updateSpy).toHaveBeenCalledWith('self-run-789', { status: 'cancelled' });
+    });
+
+    it('uses the actionable "in use" message format with workflow name, duration, and short id', async () => {
+      const otherRun = makeRun({
+        id: 'abc12345-rest-of-uuid',
+        workflow_name: 'archon-implement',
+        status: 'running',
+        started_at: new Date(Date.now() - 125000).toISOString(), // 2m 5s ago
+      });
+      const sendMessageSpy = mock(async () => {});
+      const platform = {
+        sendMessage: sendMessageSpy,
+        getPlatformType: mock(() => 'test' as const),
+      } as unknown as IWorkflowPlatform;
+      const store = makeStore({
+        getActiveWorkflowRunByPath: mock(async () => otherRun),
+      });
+      const deps = makeDeps(store);
+
+      await executeWorkflow(
+        deps,
+        platform,
+        'conv-1',
+        '/tmp',
+        makeWorkflow(),
+        'test message',
+        'db-conv-1'
+      );
+
+      expect(sendMessageSpy).toHaveBeenCalled();
+      const sentMessage = (sendMessageSpy.mock.calls[0] as [string, string])[1];
+      expect(sentMessage).toContain('archon-implement');
+      expect(sentMessage).toContain('abc12345');
+      expect(sentMessage).toContain('2m 5s');
+      // Concrete next actions — every line tells the user something to do.
+      expect(sentMessage).toContain('/workflow status');
+      expect(sentMessage).toContain('/workflow cancel abc12345');
+      expect(sentMessage).toContain('--branch');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Resume orphan cleanup
+  // -------------------------------------------------------------------------
+
+  describe('resume orphan cleanup', () => {
+    it('cancels orphaned pre-created row when resume activates', async () => {
+      // Orchestrator dispatched and pre-created this row before resume
+      // detection ran. Once resume takes over (using resumableRun instead),
+      // the pre-created row is a stale lock-token that would block the
+      // user's next back-to-back resume.
+      const preCreated = makeRun({ id: 'pre-created-orphan', status: 'pending' });
+      const resumable = makeRun({ id: 'failed-prior-run', status: 'failed' });
+      const updateSpy = mock(async () => {});
+      const store = makeStore({
+        findResumableRun: mock(async () => resumable),
+        getCompletedDagNodeOutputs: mock(async () => new Map([['node1', 'output1']])),
+        resumeWorkflowRun: mock(async () => makeRun({ id: 'failed-prior-run', status: 'running' })),
+        updateWorkflowRun: updateSpy,
+      });
+      const deps = makeDeps(store);
+
+      await executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-1',
+        '/tmp',
+        makeWorkflow(),
+        'test message',
+        'db-conv-1',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        preCreated
+      );
+
+      // Find the orphan-cancellation call (there may be other updateWorkflowRun
+      // calls during normal execution flow, e.g., status transitions).
+      const orphanCancelCall = updateSpy.mock.calls.find(
+        (call: unknown[]) =>
+          call[0] === 'pre-created-orphan' &&
+          (call[1] as { status?: string })?.status === 'cancelled'
+      );
+      expect(orphanCancelCall).toBeDefined();
+    });
+
+    it('proceeds with resume even if orphan cancellation fails (best-effort)', async () => {
+      const preCreated = makeRun({ id: 'pre-created-orphan', status: 'pending' });
+      const resumable = makeRun({ id: 'failed-prior-run', status: 'failed' });
+      const updateSpy = mock(async (id: string) => {
+        if (id === 'pre-created-orphan') throw new Error('DB busy');
+      });
+      const store = makeStore({
+        findResumableRun: mock(async () => resumable),
+        getCompletedDagNodeOutputs: mock(async () => new Map([['node1', 'output1']])),
+        resumeWorkflowRun: mock(async () => makeRun({ id: 'failed-prior-run', status: 'running' })),
+        updateWorkflowRun: updateSpy,
+      });
+      const deps = makeDeps(store);
+
+      const result = await executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-1',
+        '/tmp',
+        makeWorkflow(),
+        'test message',
+        'db-conv-1',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        preCreated
+      );
+
+      // Resume must still complete — the 5-min stale-pending window is the
+      // safety net for cleanup failures here.
+      expect(result.workflowRunId).toBe('failed-prior-run');
     });
   });
 

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -418,6 +418,19 @@ export async function executeWorkflow(
             { err, workflowName: workflow.name, resumableRunId: resumableRun.id },
             'workflow_resume_activate_failed'
           );
+          // Release the pre-created lock token. Without this, preCreatedRun
+          // sits as `pending` and blocks the path until the 5-min stale
+          // window — the user would see "in use by self" on retry.
+          if (preCreatedRun) {
+            await deps.store
+              .updateWorkflowRun(preCreatedRun.id, { status: 'cancelled' })
+              .catch((cleanupErr: Error) => {
+                getLog().warn(
+                  { err: cleanupErr, preCreatedRunId: preCreatedRun.id },
+                  'workflow.resume_failure_cleanup_failed'
+                );
+              });
+          }
           await sendCriticalMessage(
             platform,
             conversationId,
@@ -490,23 +503,55 @@ export async function executeWorkflow(
       const elapsedMs = Date.now() - parseDbTimestamp(activeWorkflow.started_at);
       const duration = formatDuration(elapsedMs);
       const shortId = activeWorkflow.id.slice(0, 8);
+
+      // Status-aware copy. The lock query returns running, paused, and
+      // fresh-pending rows — telling the user to "wait for it to finish"
+      // is wrong for `paused` (waiting on user action via approve/reject).
+      let stateLine: string;
+      let actionLines: string;
+      if (activeWorkflow.status === 'paused') {
+        stateLine = `paused waiting for user input (${duration} since started, run \`${shortId}\`)`;
+        actionLines =
+          `• Approve it: \`/workflow approve ${shortId}\`\n` +
+          `• Reject it: \`/workflow reject ${shortId}\`\n` +
+          `• Cancel it: \`/workflow cancel ${shortId}\`\n` +
+          '• Use a different branch: `--branch <other>`';
+      } else {
+        const verb = activeWorkflow.status === 'pending' ? 'starting' : 'running';
+        stateLine = `${verb} ${duration}, run \`${shortId}\``;
+        actionLines =
+          '• Wait for it to finish: `/workflow status`\n' +
+          `• Cancel it: \`/workflow cancel ${shortId}\`\n` +
+          '• Use a different branch: `--branch <other>`';
+      }
       await sendCriticalMessage(
         platform,
         conversationId,
         `❌ **This worktree is in use** by \`${activeWorkflow.workflow_name}\` ` +
-          `(running ${duration}, run \`${shortId}\`).\n` +
-          '• Wait for it to finish: `/workflow status`\n' +
-          `• Cancel it: \`/workflow cancel ${shortId}\`\n` +
-          '• Use a different branch: `--branch <other>`'
+          `(${stateLine}).\n${actionLines}`
       );
       return {
         success: false,
-        error: `Workflow already running on this path: ${activeWorkflow.workflow_name}`,
+        error: `Workflow already active on this path (${activeWorkflow.status}): ${activeWorkflow.workflow_name}`,
       };
     }
   } catch (error) {
     const err = error as Error;
     getLog().error({ err, conversationId, cwd }, 'db_active_workflow_check_failed');
+    // Release the lock token. workflowRun is finalized at this point
+    // (pre-created or resumed or freshly created) and would otherwise sit
+    // as pending/running, blocking the path. For pending the 5-min stale
+    // window would clear it eventually; for a row already promoted to
+    // running (e.g., resumed), nothing would clear it without manual
+    // intervention.
+    await deps.store
+      .updateWorkflowRun(workflowRun.id, { status: 'cancelled' })
+      .catch((cleanupErr: Error) => {
+        getLog().warn(
+          { err: cleanupErr, workflowRunId: workflowRun?.id },
+          'workflow.guard_query_failure_cleanup_failed'
+        );
+      });
     await sendCriticalMessage(
       platform,
       conversationId,

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -483,19 +483,21 @@ export async function executeWorkflow(
   // as orphaned, so leaks from crashed dispatches or resume orphans don't
   // permanently block the path.
   try {
-    const activeWorkflow = await deps.store.getActiveWorkflowRunByPath(
-      cwd,
-      workflowRun.id,
-      new Date(parseDbTimestamp(workflowRun.started_at))
-    );
+    const activeWorkflow = await deps.store.getActiveWorkflowRunByPath(cwd, {
+      id: workflowRun.id,
+      startedAt: new Date(parseDbTimestamp(workflowRun.started_at)),
+    });
     if (activeWorkflow) {
-      // We acquired the lock via createWorkflowRun, but lost the older-wins
-      // tiebreaker. Release immediately so we don't sit as a zombie pending.
+      // The lock query found another active row that wins the older-wins
+      // tiebreaker. Mark our own row terminal so it falls out of the
+      // active set immediately — without this, our row sits as
+      // pending/running and blocks the path until the 5-min stale window
+      // (or never, if we'd already promoted it to running via resume).
       await deps.store
         .updateWorkflowRun(workflowRun.id, { status: 'cancelled' })
         .catch((cleanupErr: Error) => {
           getLog().warn(
-            { err: cleanupErr, workflowRunId: workflowRun?.id },
+            { err: cleanupErr, workflowRunId: workflowRun?.id, cwd },
             'workflow.guard_self_cancel_failed'
           );
         });
@@ -537,7 +539,10 @@ export async function executeWorkflow(
     }
   } catch (error) {
     const err = error as Error;
-    getLog().error({ err, conversationId, cwd }, 'db_active_workflow_check_failed');
+    getLog().error(
+      { err, conversationId, cwd, pendingRunId: workflowRun.id },
+      'db_active_workflow_check_failed'
+    );
     // Release the lock token. workflowRun is finalized at this point
     // (pre-created or resumed or freshly created) and would otherwise sit
     // as pending/running, blocking the path. For pending the 5-min stale

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -11,6 +11,7 @@ import { getDefaultBranch, toRepoPath } from '@archon/git';
 import type { WorkflowDefinition, WorkflowRun, WorkflowExecutionResult } from './schemas';
 import { executeDagWorkflow } from './dag-executor';
 import { logWorkflowStart, logWorkflowError } from './logger';
+import { formatDuration } from './utils/duration';
 import { getWorkflowEventEmitter } from './event-emitter';
 import { inferProviderFromModel, isModelCompatible } from './model-validation';
 import { classifyError } from './executor-shared';
@@ -317,29 +318,6 @@ export async function executeWorkflow(
   let dagPriorCompletedNodes: Map<string, string> | undefined;
   let workflowRun: WorkflowRun | undefined = preCreatedRun;
 
-  // Check for concurrent workflow execution on the same path
-  try {
-    const activeWorkflow = await deps.store.getActiveWorkflowRunByPath(cwd);
-    if (activeWorkflow) {
-      const startedAt = new Date(activeWorkflow.started_at).toLocaleString();
-      await sendCriticalMessage(
-        platform,
-        conversationId,
-        `❌ **Workflow already running**: \`${activeWorkflow.workflow_name}\` has been running since ${startedAt}. Please wait for it to complete or use \`/workflow cancel\` to stop it.`
-      );
-      return { success: false, error: `Workflow already running: ${activeWorkflow.workflow_name}` };
-    }
-  } catch (error) {
-    const err = error as Error;
-    getLog().error({ err, conversationId }, 'db_active_workflow_check_failed');
-    await sendCriticalMessage(
-      platform,
-      conversationId,
-      '❌ **Workflow blocked**: Unable to verify if another workflow is running (database error). Please try again in a moment.'
-    );
-    return { success: false, error: 'Database error checking for active workflow' };
-  }
-
   // Resume detection: check for prior failed run on same workflow + worktree
   {
     // Step 1: Find prior failed run — non-critical, fall through on DB error
@@ -394,8 +372,34 @@ export async function executeWorkflow(
         (resumableRun.metadata.approval as Record<string, unknown>).type === 'interactive_loop';
       if (priorNodes.size > 0 || hasInteractiveLoopState) {
         try {
+          // Capture the orphan BEFORE replacing workflowRun. The orchestrator's
+          // pre-created row was a lock-token claim on this path; once resume
+          // takes over, that claim is redundant. Without releasing it, a
+          // back-to-back resume would block on its own ghost lock until the
+          // 5-minute stale-pending window in getActiveWorkflowRunByPath.
+          const orphanPreCreated =
+            preCreatedRun && preCreatedRun.id !== resumableRun.id ? preCreatedRun : null;
+
           workflowRun = await deps.store.resumeWorkflowRun(resumableRun.id);
           dagPriorCompletedNodes = priorNodes;
+
+          if (orphanPreCreated) {
+            await deps.store
+              .updateWorkflowRun(orphanPreCreated.id, { status: 'cancelled' })
+              .catch((cleanupErr: Error) => {
+                // Best-effort: log and continue. The 5-min stale-pending
+                // window is the safety net if this fails.
+                getLog().warn(
+                  {
+                    err: cleanupErr,
+                    orphanId: orphanPreCreated.id,
+                    resumedRunId: workflowRun?.id,
+                  },
+                  'workflow.resume_orphan_cleanup_failed'
+                );
+              });
+          }
+
           getLog().info(
             {
               workflowRunId: workflowRun.id,
@@ -456,6 +460,59 @@ export async function executeWorkflow(
       );
       return { success: false, error: 'Database error creating workflow run' };
     }
+  }
+
+  // Path-lock guard: ensure no other workflow run holds this working_path.
+  //
+  // Runs after workflowRun is finalized (pre-created, resumed, or freshly
+  // created) so we always have self-ID + started_at for the deterministic
+  // older-wins tiebreaker. The query treats `pending` rows older than 5 min
+  // as orphaned, so leaks from crashed dispatches or resume orphans don't
+  // permanently block the path.
+  try {
+    const activeWorkflow = await deps.store.getActiveWorkflowRunByPath(
+      cwd,
+      workflowRun.id,
+      new Date(workflowRun.started_at)
+    );
+    if (activeWorkflow) {
+      // We acquired the lock via createWorkflowRun, but lost the older-wins
+      // tiebreaker. Release immediately so we don't sit as a zombie pending.
+      await deps.store
+        .updateWorkflowRun(workflowRun.id, { status: 'cancelled' })
+        .catch((cleanupErr: Error) => {
+          getLog().warn(
+            { err: cleanupErr, workflowRunId: workflowRun?.id },
+            'workflow.guard_self_cancel_failed'
+          );
+        });
+
+      const elapsedMs = Date.now() - new Date(activeWorkflow.started_at).getTime();
+      const duration = formatDuration(elapsedMs);
+      const shortId = activeWorkflow.id.slice(0, 8);
+      await sendCriticalMessage(
+        platform,
+        conversationId,
+        `❌ **This worktree is in use** by \`${activeWorkflow.workflow_name}\` ` +
+          `(running ${duration}, run \`${shortId}\`).\n` +
+          '• Wait for it to finish: `/workflow status`\n' +
+          `• Cancel it: \`/workflow cancel ${shortId}\`\n` +
+          '• Use a different branch: `--branch <other>`'
+      );
+      return {
+        success: false,
+        error: `Workflow already running on this path: ${activeWorkflow.workflow_name}`,
+      };
+    }
+  } catch (error) {
+    const err = error as Error;
+    getLog().error({ err, conversationId, cwd }, 'db_active_workflow_check_failed');
+    await sendCriticalMessage(
+      platform,
+      conversationId,
+      '❌ **Workflow blocked**: Unable to verify if another workflow is running (database error). Please try again in a moment.'
+    );
+    return { success: false, error: 'Database error checking for active workflow' };
   }
 
   // Resolve external artifact and log directories

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -11,7 +11,7 @@ import { getDefaultBranch, toRepoPath } from '@archon/git';
 import type { WorkflowDefinition, WorkflowRun, WorkflowExecutionResult } from './schemas';
 import { executeDagWorkflow } from './dag-executor';
 import { logWorkflowStart, logWorkflowError } from './logger';
-import { formatDuration } from './utils/duration';
+import { formatDuration, parseDbTimestamp } from './utils/duration';
 import { getWorkflowEventEmitter } from './event-emitter';
 import { inferProviderFromModel, isModelCompatible } from './model-validation';
 import { classifyError } from './executor-shared';
@@ -473,7 +473,7 @@ export async function executeWorkflow(
     const activeWorkflow = await deps.store.getActiveWorkflowRunByPath(
       cwd,
       workflowRun.id,
-      new Date(workflowRun.started_at)
+      new Date(parseDbTimestamp(workflowRun.started_at))
     );
     if (activeWorkflow) {
       // We acquired the lock via createWorkflowRun, but lost the older-wins
@@ -487,7 +487,7 @@ export async function executeWorkflow(
           );
         });
 
-      const elapsedMs = Date.now() - new Date(activeWorkflow.started_at).getTime();
+      const elapsedMs = Date.now() - parseDbTimestamp(activeWorkflow.started_at);
       const duration = formatDuration(elapsedMs);
       const shortId = activeWorkflow.id.slice(0, 8);
       await sendCriticalMessage(

--- a/packages/workflows/src/store.ts
+++ b/packages/workflows/src/store.ts
@@ -46,10 +46,14 @@ export interface IWorkflowStore {
   /**
    * Find the workflow run currently holding the lock on `workingPath`.
    *
-   * Pass `excludeId` and `selfStartedAt` from the calling dispatch so:
-   *   1. Self is never returned.
+   * Pass `self` from the calling dispatch so:
+   *   1. Self is never returned (excluded by `id != self.id`).
    *   2. Two near-simultaneous dispatches deterministically agree on which
    *      is "first" via the `(started_at, id)` tiebreaker — newer aborts.
+   *
+   * `id` and `startedAt` must travel together — the tiebreaker requires
+   * both. Bundling them as a single optional struct makes the
+   * paired-or-nothing invariant structural rather than a doc-only contract.
    *
    * Stale `pending` rows (older than ~5 minutes) are treated as orphaned
    * and ignored, so leaks from crashed dispatches don't permanently block
@@ -57,8 +61,7 @@ export interface IWorkflowStore {
    */
   getActiveWorkflowRunByPath(
     workingPath: string,
-    excludeId?: string,
-    selfStartedAt?: Date
+    self?: { id: string; startedAt: Date }
   ): Promise<WorkflowRun | null>;
   findResumableRun(workflowName: string, workingPath: string): Promise<WorkflowRun | null>;
   failOrphanedRuns(): Promise<{ count: number }>;

--- a/packages/workflows/src/store.ts
+++ b/packages/workflows/src/store.ts
@@ -43,7 +43,23 @@ export interface IWorkflowStore {
     parent_conversation_id?: string;
   }): Promise<WorkflowRun>;
   getWorkflowRun(id: string): Promise<WorkflowRun | null>;
-  getActiveWorkflowRunByPath(workingPath: string): Promise<WorkflowRun | null>;
+  /**
+   * Find the workflow run currently holding the lock on `workingPath`.
+   *
+   * Pass `excludeId` and `selfStartedAt` from the calling dispatch so:
+   *   1. Self is never returned.
+   *   2. Two near-simultaneous dispatches deterministically agree on which
+   *      is "first" via the `(started_at, id)` tiebreaker — newer aborts.
+   *
+   * Stale `pending` rows (older than ~5 minutes) are treated as orphaned
+   * and ignored, so leaks from crashed dispatches don't permanently block
+   * a path.
+   */
+  getActiveWorkflowRunByPath(
+    workingPath: string,
+    excludeId?: string,
+    selfStartedAt?: Date
+  ): Promise<WorkflowRun | null>;
   findResumableRun(workflowName: string, workingPath: string): Promise<WorkflowRun | null>;
   failOrphanedRuns(): Promise<{ count: number }>;
   resumeWorkflowRun(id: string): Promise<WorkflowRun>;

--- a/packages/workflows/src/utils/duration.test.ts
+++ b/packages/workflows/src/utils/duration.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect } from 'bun:test';
+import { formatDuration } from './duration';
+
+describe('formatDuration', () => {
+  test('returns "0s" for 0 ms', () => {
+    expect(formatDuration(0)).toBe('0s');
+  });
+
+  test('rounds sub-second to "1s" so display never reads "0s" for an active run', () => {
+    expect(formatDuration(500)).toBe('1s');
+    expect(formatDuration(999)).toBe('1s');
+  });
+
+  test('formats whole seconds', () => {
+    expect(formatDuration(1000)).toBe('1s');
+    expect(formatDuration(45000)).toBe('45s');
+  });
+
+  test('formats minutes with seconds remainder', () => {
+    expect(formatDuration(60000)).toBe('1m');
+    expect(formatDuration(65000)).toBe('1m 5s');
+    expect(formatDuration(125000)).toBe('2m 5s');
+  });
+
+  test('formats hours with minutes remainder', () => {
+    expect(formatDuration(3600000)).toBe('1h');
+    expect(formatDuration(3660000)).toBe('1h 1m');
+    expect(formatDuration(7320000)).toBe('2h 2m');
+  });
+
+  test('drops seconds at the hour level so display stays compact', () => {
+    expect(formatDuration(3661000)).toBe('1h 1m'); // not "1h 1m 1s"
+  });
+
+  test('clamps negative values to "0s"', () => {
+    expect(formatDuration(-1)).toBe('0s');
+    expect(formatDuration(-10000)).toBe('0s');
+  });
+
+  test('clamps non-finite values to "0s"', () => {
+    expect(formatDuration(NaN)).toBe('0s');
+    expect(formatDuration(Infinity)).toBe('0s');
+  });
+});

--- a/packages/workflows/src/utils/duration.test.ts
+++ b/packages/workflows/src/utils/duration.test.ts
@@ -2,8 +2,10 @@ import { describe, test, expect } from 'bun:test';
 import { formatDuration, parseDbTimestamp } from './duration';
 
 describe('formatDuration', () => {
-  test('returns "0s" for 0 ms', () => {
-    expect(formatDuration(0)).toBe('0s');
+  test('rounds 0ms up to "1s" — a run that just started should not display "0s"', () => {
+    // 0ms in practice means started_at and now are in the same DB second.
+    // Display should show "1s" (active, just started), not the misleading "0s".
+    expect(formatDuration(0)).toBe('1s');
   });
 
   test('rounds sub-second to "1s" so display never reads "0s" for an active run', () => {

--- a/packages/workflows/src/utils/duration.test.ts
+++ b/packages/workflows/src/utils/duration.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { formatDuration } from './duration';
+import { formatDuration, parseDbTimestamp } from './duration';
 
 describe('formatDuration', () => {
   test('returns "0s" for 0 ms', () => {
@@ -40,5 +40,33 @@ describe('formatDuration', () => {
   test('clamps non-finite values to "0s"', () => {
     expect(formatDuration(NaN)).toBe('0s');
     expect(formatDuration(Infinity)).toBe('0s');
+  });
+});
+
+describe('parseDbTimestamp', () => {
+  test('returns Date.getTime() unchanged for Date inputs (PG driver path)', () => {
+    const date = new Date('2026-04-14T10:00:00.000Z');
+    expect(parseDbTimestamp(date)).toBe(date.getTime());
+  });
+
+  test('treats SQLite "YYYY-MM-DD HH:MM:SS" as UTC, not local', () => {
+    // Reproduces the live bug — SQLite returns datetimes without `Z`,
+    // and `new Date('2026-04-14 10:00:00')` parses as local time, making
+    // the duration display hours off depending on the user's TZ.
+    const sqliteFormat = '2026-04-14 10:00:00';
+    expect(parseDbTimestamp(sqliteFormat)).toBe(new Date('2026-04-14T10:00:00Z').getTime());
+  });
+
+  test('respects explicit Z suffix (ISO UTC)', () => {
+    expect(parseDbTimestamp('2026-04-14T10:00:00.000Z')).toBe(
+      new Date('2026-04-14T10:00:00Z').getTime()
+    );
+  });
+
+  test('respects explicit timezone offset (+/-HH:MM)', () => {
+    // 10:00 UTC = 12:00+02:00
+    expect(parseDbTimestamp('2026-04-14T12:00:00+02:00')).toBe(
+      new Date('2026-04-14T10:00:00Z').getTime()
+    );
   });
 });

--- a/packages/workflows/src/utils/duration.ts
+++ b/packages/workflows/src/utils/duration.ts
@@ -1,4 +1,20 @@
 /**
+ * Parse a timestamp value that may be either a Date (PG driver) or a string
+ * (SQLite returns datetimes as strings without timezone). SQLite's CURRENT_TIMESTAMP
+ * stores UTC but the returned string has no `Z` suffix, so plain `new Date(str)`
+ * would parse it as local time — appearing hours off depending on the user's TZ.
+ *
+ * Returns ms since epoch.
+ */
+export function parseDbTimestamp(value: Date | string): number {
+  if (value instanceof Date) return value.getTime();
+  // Heuristic: if the string already encodes a timezone (Z, +HH:MM, -HH:MM
+  // after the time portion), trust it. Otherwise treat as UTC.
+  const hasTimezone = /[zZ]$|[+-]\d{2}:?\d{2}$/.test(value);
+  return new Date(hasTimezone ? value : `${value.replace(' ', 'T')}Z`).getTime();
+}
+
+/**
  * Format a millisecond duration as a short human-readable string.
  *
  * Examples:

--- a/packages/workflows/src/utils/duration.ts
+++ b/packages/workflows/src/utils/duration.ts
@@ -28,9 +28,10 @@ export function parseDbTimestamp(value: Date | string): number {
  * hour-level.
  */
 export function formatDuration(ms: number): string {
-  if (!Number.isFinite(ms) || ms <= 0) return '0s';
+  if (!Number.isFinite(ms) || ms < 0) return '0s';
 
-  // Round sub-second up to 1s so an active run never displays "0s".
+  // Round sub-second (including ms === 0 — treated as a just-started run
+  // rather than literal zero) up to 1s so an active run never displays "0s".
   const totalSeconds = Math.max(1, Math.floor(ms / 1000));
   const hours = Math.floor(totalSeconds / 3600);
   const minutes = Math.floor((totalSeconds % 3600) / 60);

--- a/packages/workflows/src/utils/duration.ts
+++ b/packages/workflows/src/utils/duration.ts
@@ -1,0 +1,30 @@
+/**
+ * Format a millisecond duration as a short human-readable string.
+ *
+ * Examples:
+ *   500 → "1s" (sub-second rounded up to avoid showing "0s")
+ *   1500 → "1s"
+ *   65000 → "1m 5s"
+ *   3700000 → "1h 1m"
+ *
+ * Negative values are clamped to 0 ("0s"). Designed for UI display, not
+ * precise time deltas — drops sub-second precision and seconds at the
+ * hour-level.
+ */
+export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '0s';
+
+  // Round sub-second up to 1s so an active run never displays "0s".
+  const totalSeconds = Math.max(1, Math.floor(ms / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return minutes > 0 ? `${String(hours)}h ${String(minutes)}m` : `${String(hours)}h`;
+  }
+  if (minutes > 0) {
+    return seconds > 0 ? `${String(minutes)}m ${String(seconds)}s` : `${String(minutes)}m`;
+  }
+  return `${String(seconds)}s`;
+}


### PR DESCRIPTION
## Summary

Both #1036 (concurrent-run guard TOCTOU) and #1188 part 2 (parallel worktree collision) reduce to the same primitive: there's no enforced lock on \`working_path\`, so two dispatches that resolve to the same filesystem location can race.

This PR treats the workflow_runs row as a lock token. \`pending / running / paused\` = lock held; terminal statuses release.

Fixes #1036
Fixes #1188 (part 2)

## What changed

| File | Change |
|------|--------|
| \`packages/core/src/db/workflows.ts\` | \`getActiveWorkflowRunByPath\` includes \`pending\` (with 5-min stale-orphan age window), accepts \`excludeId\` + \`selfStartedAt\`, orders by \`(started_at ASC, id ASC)\` for deterministic older-wins tiebreaker |
| \`packages/workflows/src/store.ts\` | Updated \`IWorkflowStore.getActiveWorkflowRunByPath\` interface |
| \`packages/workflows/src/executor.ts\` | Moved guard to AFTER \`workflowRun\` is finalized (so we always have self-ID); on guard fire, mark self as \`cancelled\` (no zombie rows); new actionable error message; resume orphan cancellation |
| \`packages/workflows/src/utils/duration.ts\` | New \`formatDuration\` helper for the error message |
| \`packages/core/src/db/workflows.test.ts\` | 5 new tests for query semantics |
| \`packages/workflows/src/executor.test.ts\` | 5 new tests for guard placement, self-cancellation, message format, resume orphan |
| \`packages/workflows/src/executor-preamble.test.ts\` | Updated 2 existing tests for new structural behavior |
| \`packages/workflows/src/utils/duration.test.ts\` | 8 new tests |

## Design — why this approach

**First-principles framing:** the resource being protected is the filesystem (\`working_path\`), not workflow run identity. The DB row is the lock token.

**Why the older-wins tiebreaker matters:** without ordering by \`(started_at, id)\`, two dispatches with similar timestamps could mutually see each other and BOTH abort. With the total order, both always agree which is "first" — only the newer aborts.

**Why the 5-min stale window:** orphaned \`pending\` rows from crashed dispatches or resume-replaced rows would otherwise permanently block a path. The window is conservative — workflows transition pending→running in seconds.

**Why move the guard:** the old guard ran BEFORE \`workflowRun\` was finalized (no self-ID to exclude). Moving it after lets us pass self-ID + started_at to the query, eliminating "self-detection" false positives and enabling the tiebreaker.

**Resume orphan fix:** when executor activates resume (\`resumableRun\` replaces \`workflowRun\`), the orchestrator's pre-created row is now redundant. Without releasing it, the user's back-to-back resume would block on its own ghost lock until the 5-min window. Best-effort cancellation; if it fails, the stale-pending window is the safety net.

**New error message:**

\`\`\`
❌ This worktree is in use by \`archon-implement\` (running 2m 5s, run \`abc12345\`).
   • Wait for it to finish: \`/workflow status\`
   • Cancel it: \`/workflow cancel abc12345\`
   • Use a different branch: \`--branch <other>\`
\`\`\`

Every line is a concrete next action.

## Deferred (intentional)

- **Worktree-layer advisory lockfile** for the residual #1188.2 microsecond race where both dispatches reach \`provider.create()\` before either's row commits. Bounded by git's own atomicity for \`worktree add\` ("path already exists" error). Add a \`.archon/.lock\` later if real users hit it.
- **Startup cleanup of pre-existing stale pending rows.** The 5-min age window makes them harmless.
- **DB partial UNIQUE constraint migration.** Code-only is sufficient and avoids migrating leaked stale rows in user DBs.

## Testing

- [x] \`bun run type-check\` clean
- [x] \`bun run lint\` zero warnings
- [x] All existing \`db/workflows\` and \`executor\` tests pass with updates where structural behavior changed
- [x] 23 new tests covering query semantics, guard placement, self-cancellation, message format, resume orphan, duration formatting
- [x] Full test suite green

## Manual reproduction (recommended verification)

\`\`\`bash
# #1036 reproduction
ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING=1 bun run cli workflow run e2e-claude-smoke --no-worktree "run1" &
ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING=1 bun run cli workflow run e2e-claude-smoke --no-worktree "run2" &
wait
# Expected: one succeeds; the other shows the new "in use" message

# #1188.2 reproduction
ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING=1 bun run cli workflow run e2e-claude-smoke --branch test/collide "a" &
ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING=1 bun run cli workflow run e2e-claude-smoke --branch test/collide "b" &
wait

# Resume regression (back-to-back resume must NOT be blocked)
# 1. Run a failing workflow
# 2. Resume it
# 3. Immediately resume again → must succeed
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent workflow detection with deterministic lock ordering to avoid race races, clearer actionable "in use" messages, and automatic cancellation of conflicting runs.
  * Cleanup of orphan/stale pending workflow rows during resume and on failure to prevent indefinite blocking.

* **New Features**
  * Status messages now include human-readable elapsed time and state-aware instructions.

* **Tests**
  * Added tests for concurrency guards, timestamp parsing, and duration/duration-formatting.

* **Documentation**
  * Updated CLI and database docs to reflect abandon behavior and path-lock semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->