### PR TITLE
fix: stop server startup from auto-failing in-flight workflow runs (#1216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Server startup no longer marks actively-running workflows as failed.** The `failOrphanedRuns()` call has been removed from `packages/server/src/index.ts` to match the CLI precedent (`packages/cli/src/cli.ts:256-258`). Per the new CLAUDE.md principle "No Autonomous Lifecycle Mutation Across Process Boundaries", orphaned-run cleanup is now exclusively user-driven via `archon workflow cleanup` or the per-row Cancel/Abandon buttons in the dashboard. Closes #1216.
+- **Server startup no longer marks actively-running workflows as failed.** The `failOrphanedRuns()` call has been removed from `packages/server/src/index.ts` to match the CLI precedent (`packages/cli/src/cli.ts:256-258`). Per the new CLAUDE.md principle "No Autonomous Lifecycle Mutation Across Process Boundaries", a stuck `running` row is now transitioned explicitly by the user: via the per-row Cancel/Abandon buttons on the dashboard workflow card, or `archon workflow abandon <run-id>` from the CLI. (`archon workflow cleanup` is a separate command that deletes OLD terminal runs for disk hygiene — it does not handle stuck `running` rows.) Closes #1216.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Server startup no longer marks actively-running workflows as failed.** The `failOrphanedRuns()` call has been removed from `packages/server/src/index.ts` to match the CLI precedent (`packages/cli/src/cli.ts:256-258`). Per the new CLAUDE.md principle "No Autonomous Lifecycle Mutation Across Process Boundaries", orphaned-run cleanup is now exclusively user-driven via `archon workflow cleanup` or the per-row Cancel/Abandon buttons in the dashboard. Closes #1216.
+
 ### Changed
+
+- **Dashboard nav tab** now shows a numeric count of running workflows instead of a binary pulse dot. Reads from the existing `/api/dashboard/runs` `counts.running` field; same 10s polling interval.
+- **Workflow run destructive actions** (Abandon, Cancel, Delete, Reject) now use a proper confirmation dialog matching the codebase-delete UX, replacing the browser's native `window.confirm()` popups. Each dialog includes context-appropriate copy describing what the action does to the run record.
 
 - **Claude Code binary resolution** (breaking for compiled binary users): Archon no longer embeds the Claude Code SDK into compiled binaries. In compiled builds, you must install Claude Code separately (`curl -fsSL https://claude.ai/install.sh | bash` on macOS/Linux, `irm https://claude.ai/install.ps1 | iex` on Windows, or `npm install -g @anthropic-ai/claude-code`) and point Archon at the executable via `CLAUDE_BIN_PATH` env var or `assistants.claude.claudeBinaryPath` in `.archon/config.yaml`. The Claude Agent SDK accepts either the native compiled binary (from the curl/PowerShell installer at `~/.local/bin/claude`) or a JS `cli.js` (from the npm install). Dev mode (`bun run`) is unaffected — the SDK resolves via `node_modules` as before. The Docker image ships Claude Code pre-installed with `CLAUDE_BIN_PATH` pre-set, so `docker run` still works out of the box. Resolves silent "Module not found /Users/runner/..." failures on macOS (#1210) and Windows (#1087).
 

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -474,7 +474,7 @@ This means a single transient crash may trigger up to **3 SDK retries** before a
 
 ## DAG Resume on Failure
 
-When a `nodes:` (DAG) workflow fails (including due to a server restart), the next invocation automatically resumes from where it left off — no `--resume` flag required.
+When a `nodes:` (DAG) workflow fails, the next invocation automatically resumes from where it left off — no `--resume` flag required.
 
 **How it works:**
 
@@ -483,7 +483,7 @@ When a `nodes:` (DAG) workflow fails (including due to a server restart), the ne
 3. Completed nodes are skipped; only failed and not-yet-run nodes are executed.
 4. You receive a platform message like: `Resuming workflow — skipping 3 already-completed node(s).`
 
-**Server restart**: If a server restart leaves runs in `running` status, they are automatically marked as `failed` on the next startup (with `metadata.failure_reason = 'server_restart'`). The next invocation of the same workflow at the same path auto-resumes from completed nodes.
+**Crashed servers / orphaned runs**: Archon does **not** auto-fail `running` rows on server startup — that would kill workflows actively executing in another process (CLI, adapter). If a server crash leaves a row stuck as `running`, it remains visible in the dashboard (the Dashboard nav tab shows a count of running workflows). Clean up explicitly with `archon workflow cleanup` from the CLI, or use the per-row Cancel/Abandon buttons on the dashboard. Once cleaned, the row's status becomes `failed` or `cancelled`, and the next invocation of the same workflow at the same path auto-resumes from completed nodes via the mechanism above.
 
 **Known limitation**: AI session context from prior nodes is not restored. If a downstream node relies on in-context knowledge from a prior run's session (rather than artifacts), it may need to re-read those artifacts explicitly.
 

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -483,7 +483,14 @@ When a `nodes:` (DAG) workflow fails, the next invocation automatically resumes 
 3. Completed nodes are skipped; only failed and not-yet-run nodes are executed.
 4. You receive a platform message like: `Resuming workflow — skipping 3 already-completed node(s).`
 
-**Crashed servers / orphaned runs**: Archon does **not** auto-fail `running` rows on server startup — that would kill workflows actively executing in another process (CLI, adapter). If a server crash leaves a row stuck as `running`, it remains visible in the dashboard (the Dashboard nav tab shows a count of running workflows). Clean up explicitly with `archon workflow cleanup` from the CLI, or use the per-row Cancel/Abandon buttons on the dashboard. Once cleaned, the row's status becomes `failed` or `cancelled`, and the next invocation of the same workflow at the same path auto-resumes from completed nodes via the mechanism above.
+**Crashed servers / orphaned runs**: Archon does **not** auto-fail `running` rows on server startup — that would kill workflows actively executing in another process (CLI, adapter). If a server crash leaves a row stuck as `running`, it remains visible in the dashboard (the Dashboard nav tab shows a count of running workflows). Transition it to a terminal status explicitly:
+
+- **Web UI**: click the Abandon or Cancel button on the workflow card. Abandon marks the run `cancelled` and keeps completed-node history. Cancel also terminates any in-flight subprocess.
+- **CLI**: `archon workflow abandon <run-id>` (equivalent to the dashboard Abandon button). Run IDs are listed by `archon workflow status`.
+
+Once the row reaches a terminal status, the next invocation of the same workflow at the same path auto-resumes from completed nodes via the mechanism above.
+
+> Not to be confused with `archon workflow cleanup [days]`, which **deletes** old terminal runs (`completed`/`failed`/`cancelled`) from the database for disk hygiene. It does not transition `running` rows.
 
 **Known limitation**: AI session context from prior nodes is not restored. If a downstream node relies on in-context knowledge from a prior run's session (rather than artifacts), it may need to re-read those artifacts explicitly.
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -77,7 +77,6 @@ import {
   loadConfig,
   logConfig,
   getPort,
-  createWorkflowStore,
 } from '@archon/core';
 import type { IPlatformAdapter } from '@archon/core';
 import { createLogger, logArchonPaths, validateAppDefaultsPaths } from '@archon/paths';
@@ -208,12 +207,14 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
   // Start cleanup scheduler
   startCleanupScheduler();
 
-  // Mark workflow runs orphaned by previous process termination as failed
-  void createWorkflowStore()
-    .failOrphanedRuns()
-    .catch(err => {
-      getLog().error({ err }, 'workflow.fail_orphans_failed');
-    });
+  // Note: orphaned-run cleanup intentionally NOT called at server startup.
+  // Running it here killed parallel workflow runs from other processes
+  // (CLI, adapters) by flipping their `running` rows to `failed` mid-flight.
+  // Same lesson the CLI already learned — see packages/cli/src/cli.ts:256-258.
+  // Per CLAUDE.md "No Autonomous Lifecycle Mutation Across Process Boundaries":
+  // surface ambiguous state to users and provide a one-click action instead.
+  // Users invoke explicit cleanup via `archon workflow cleanup` or the per-row
+  // Cancel/Abandon buttons in the Web UI dashboard. See #1216.
 
   // Log Archon paths configuration
   logArchonPaths();

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -213,8 +213,11 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
   // Same lesson the CLI already learned — see packages/cli/src/cli.ts:256-258.
   // Per CLAUDE.md "No Autonomous Lifecycle Mutation Across Process Boundaries":
   // surface ambiguous state to users and provide a one-click action instead.
-  // Users invoke explicit cleanup via `archon workflow cleanup` or the per-row
-  // Cancel/Abandon buttons in the Web UI dashboard. See #1216.
+  // Users transition a stuck `running` row via the per-row Cancel/Abandon
+  // buttons in the Web UI dashboard, or `archon workflow abandon <run-id>`.
+  // (`archon workflow cleanup` is a separate command that deletes OLD terminal
+  // rows for disk hygiene — it does not handle stuck `running` rows.)
+  // See #1216.
 
   // Log Archon paths configuration
   logArchonPaths();

--- a/packages/web/src/components/dashboard/ConfirmRunActionDialog.tsx
+++ b/packages/web/src/components/dashboard/ConfirmRunActionDialog.tsx
@@ -20,8 +20,11 @@ interface Props {
   description: ReactNode;
   /** Confirm-button label (e.g. "Abandon", "Delete"). */
   confirmLabel: string;
-  /** Invoked when the user confirms. Errors should be handled by the caller. */
-  onConfirm: () => void | Promise<void>;
+  /** Invoked when the user confirms. The current callsites are all
+   *  fire-and-forget wrappers around React Query mutations whose error
+   *  handling lives at the page level (`runAction` in `DashboardPage.tsx`).
+   *  Widen to `Promise<void>` only if a caller needs to await the action. */
+  onConfirm: () => void;
 }
 
 /**
@@ -57,11 +60,11 @@ export function ConfirmRunActionDialog({
           <AlertDialogCancel>Cancel</AlertDialogCancel>
           <AlertDialogAction
             onClick={(): void => {
-              // Fire-and-forget — caller's onConfirm typically returns a
-              // promise managed by a parent-level runAction helper that
-              // already surfaces errors. We do NOT catch here; swallowing
-              // would hide failures the parent is positioned to display.
-              void onConfirm();
+              // Caller's onConfirm is fire-and-forget over a parent-level
+              // runAction helper that surfaces errors via component state.
+              // We do NOT catch here; swallowing would hide failures the
+              // parent is positioned to display.
+              onConfirm();
             }}
           >
             {confirmLabel}

--- a/packages/web/src/components/dashboard/ConfirmRunActionDialog.tsx
+++ b/packages/web/src/components/dashboard/ConfirmRunActionDialog.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+
+interface Props {
+  /** The element that opens the dialog when clicked (typically a button). */
+  trigger: ReactNode;
+  /** Dialog title (e.g. "Abandon workflow?"). */
+  title: string;
+  /** Body text — supports rich children (e.g. wrapping the workflow name in <strong>). */
+  description: ReactNode;
+  /** Confirm-button label (e.g. "Abandon", "Delete"). */
+  confirmLabel: string;
+  /** Invoked when the user confirms. Errors should be handled by the caller. */
+  onConfirm: () => void | Promise<void>;
+}
+
+/**
+ * Confirmation dialog for destructive workflow-run actions.
+ *
+ * Wraps shadcn's AlertDialog with the trigger included as a slot, so callers
+ * pass their existing action button as the `trigger` prop. The Action button
+ * is destructive-styled by default (per `AlertDialogAction` in
+ * `@/components/ui/alert-dialog`), which is appropriate for every workflow
+ * lifecycle action this is used for (Abandon, Cancel, Delete, Reject).
+ *
+ * Replaces previous use of `window.confirm()` for these actions to match the
+ * codebase-delete UX in `sidebar/ProjectSelector.tsx`.
+ */
+export function ConfirmRunActionDialog({
+  trigger,
+  title,
+  description,
+  confirmLabel,
+  onConfirm,
+}: Props): React.ReactElement {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div>{description}</div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(): void => {
+              // Fire-and-forget — caller's onConfirm typically returns a
+              // promise managed by a parent-level runAction helper that
+              // already surfaces errors. We do NOT catch here; swallowing
+              // would hide failures the parent is positioned to display.
+              void onConfirm();
+            }}
+          >
+            {confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/packages/web/src/components/dashboard/WorkflowHistoryTable.tsx
+++ b/packages/web/src/components/dashboard/WorkflowHistoryTable.tsx
@@ -3,6 +3,7 @@ import { Globe, Terminal, Hash, Send, GitBranch, Trash2 } from 'lucide-react';
 import type { DashboardRunResponse } from '@/lib/api';
 import { cn } from '@/lib/utils';
 import { formatDuration, formatStarted } from '@/lib/format';
+import { ConfirmRunActionDialog } from './ConfirmRunActionDialog';
 
 interface WorkflowHistoryTableProps {
   runs: DashboardRunResponse[];
@@ -101,21 +102,27 @@ export function WorkflowHistoryTable({
                     View Logs
                   </Link>
                   {onDelete && (
-                    <button
-                      onClick={(): void => {
-                        if (
-                          window.confirm(
-                            `Delete workflow run "${run.workflow_name}"? This cannot be undone.`
-                          )
-                        ) {
-                          onDelete(run.id);
-                        }
+                    <ConfirmRunActionDialog
+                      trigger={
+                        <button
+                          className="text-text-tertiary hover:text-error transition-colors"
+                          title="Delete run"
+                        >
+                          <Trash2 className="h-3 w-3" />
+                        </button>
+                      }
+                      title="Delete workflow run?"
+                      description={
+                        <>
+                          Permanently delete the run record for <strong>{run.workflow_name}</strong>{' '}
+                          and its events. This cannot be undone.
+                        </>
+                      }
+                      confirmLabel="Delete"
+                      onConfirm={(): void => {
+                        onDelete(run.id);
                       }}
-                      className="text-text-tertiary hover:text-error transition-colors"
-                      title="Delete run"
-                    >
-                      <Trash2 className="h-3 w-3" />
-                    </button>
+                    />
                   )}
                 </div>
               </td>

--- a/packages/web/src/components/dashboard/WorkflowRunCard.tsx
+++ b/packages/web/src/components/dashboard/WorkflowRunCard.tsx
@@ -22,6 +22,7 @@ import { cn } from '@/lib/utils';
 import { formatDuration } from '@/lib/format';
 import { useWorkflowStore } from '@/stores/workflow-store';
 import type { WorkflowState } from '@/lib/types';
+import { ConfirmRunActionDialog } from './ConfirmRunActionDialog';
 
 interface WorkflowRunCardProps {
   run: DashboardRunResponse;
@@ -318,17 +319,25 @@ export function WorkflowRunCard({
             </button>
           )}
           {run.status === 'paused' && onReject && (
-            <button
-              onClick={(): void => {
-                if (window.confirm(`Reject workflow "${run.workflow_name}"?`)) {
-                  onReject(run.id);
-                }
+            <ConfirmRunActionDialog
+              trigger={
+                <button className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-error/80 hover:bg-error/10 hover:text-error transition-colors">
+                  <XCircle className="h-3.5 w-3.5" />
+                  Reject
+                </button>
+              }
+              title="Reject workflow?"
+              description={
+                <>
+                  Reject the paused workflow <strong>{run.workflow_name}</strong>. The run will be
+                  marked as failed and any pending iterations will not continue.
+                </>
+              }
+              confirmLabel="Reject"
+              onConfirm={(): void => {
+                onReject(run.id);
               }}
-              className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-error/80 hover:bg-error/10 hover:text-error transition-colors"
-            >
-              <XCircle className="h-3.5 w-3.5" />
-              Reject
-            </button>
+            />
           )}
           {run.status === 'failed' && onResume && (
             <button
@@ -342,47 +351,67 @@ export function WorkflowRunCard({
             </button>
           )}
           {run.status === 'running' && onAbandon && (
-            <button
-              onClick={(): void => {
-                if (window.confirm(`Abandon workflow "${run.workflow_name}"?`)) {
-                  onAbandon(run.id);
-                }
+            <ConfirmRunActionDialog
+              trigger={
+                <button className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-warning/80 hover:bg-warning/10 hover:text-warning transition-colors">
+                  <Ban className="h-3.5 w-3.5" />
+                  Abandon
+                </button>
+              }
+              title="Abandon workflow?"
+              description={
+                <>
+                  Mark <strong>{run.workflow_name}</strong> as cancelled. Already-completed nodes
+                  remain in the database; the run will not continue.
+                </>
+              }
+              confirmLabel="Abandon"
+              onConfirm={(): void => {
+                onAbandon(run.id);
               }}
-              className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-warning/80 hover:bg-warning/10 hover:text-warning transition-colors"
-            >
-              <Ban className="h-3.5 w-3.5" />
-              Abandon
-            </button>
+            />
           )}
           {(run.status === 'running' || run.status === 'pending') && (
-            <button
-              onClick={(): void => {
-                if (window.confirm(`Cancel workflow "${run.workflow_name}"?`)) {
-                  onCancel(run.id);
-                }
+            <ConfirmRunActionDialog
+              trigger={
+                <button className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-error/80 hover:bg-error/10 hover:text-error transition-colors">
+                  <XCircle className="h-3.5 w-3.5" />
+                  Cancel
+                </button>
+              }
+              title="Cancel workflow?"
+              description={
+                <>
+                  Cancel <strong>{run.workflow_name}</strong>. The run will be marked as cancelled
+                  and any in-flight subprocess will be terminated.
+                </>
+              }
+              confirmLabel="Cancel workflow"
+              onConfirm={(): void => {
+                onCancel(run.id);
               }}
-              className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-error/80 hover:bg-error/10 hover:text-error transition-colors"
-            >
-              <XCircle className="h-3.5 w-3.5" />
-              Cancel
-            </button>
+            />
           )}
           {onDelete && run.status !== 'running' && run.status !== 'pending' && (
-            <button
-              onClick={(): void => {
-                if (
-                  window.confirm(
-                    `Delete workflow run "${run.workflow_name}"? This cannot be undone.`
-                  )
-                ) {
-                  onDelete(run.id);
-                }
+            <ConfirmRunActionDialog
+              trigger={
+                <button className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-text-tertiary hover:bg-error/10 hover:text-error transition-colors">
+                  <Trash2 className="h-3.5 w-3.5" />
+                  Delete
+                </button>
+              }
+              title="Delete workflow run?"
+              description={
+                <>
+                  Permanently delete the run record for <strong>{run.workflow_name}</strong> and its
+                  events. This cannot be undone.
+                </>
+              }
+              confirmLabel="Delete"
+              onConfirm={(): void => {
+                onDelete(run.id);
               }}
-              className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-text-tertiary hover:bg-error/10 hover:text-error transition-colors"
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-              Delete
-            </button>
+            />
           )}
         </div>
       </div>

--- a/packages/web/src/components/layout/TopNav.tsx
+++ b/packages/web/src/components/layout/TopNav.tsx
@@ -1,7 +1,7 @@
 import { NavLink, Link } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { LayoutDashboard, MessageSquare, Workflow, Settings } from 'lucide-react';
-import { listWorkflowRuns, getUpdateCheck } from '@/lib/api';
+import { listDashboardRuns, getUpdateCheck } from '@/lib/api';
 import { cn } from '@/lib/utils';
 
 const tabs = [
@@ -12,12 +12,15 @@ const tabs = [
 ] as const;
 
 export function TopNav(): React.ReactElement {
-  const { data: runningRuns } = useQuery({
-    queryKey: ['workflowRuns', { status: 'running' }],
-    queryFn: () => listWorkflowRuns({ status: 'running', limit: 1 }),
+  // Read counts.running from the dashboard endpoint — single query gives us
+  // the count without paging through rows. limit=1 keeps the response payload
+  // small; we only consume `counts.running`.
+  const { data: dashboardRuns } = useQuery({
+    queryKey: ['dashboardRuns', { status: 'running', forCount: true }],
+    queryFn: () => listDashboardRuns({ status: 'running', limit: 1 }),
     refetchInterval: 10_000,
   });
-  const hasRunning = (runningRuns?.length ?? 0) > 0;
+  const runningCount = dashboardRuns?.counts.running ?? 0;
 
   const { data: updateCheck } = useQuery({
     queryKey: ['update-check'],
@@ -53,8 +56,13 @@ export function TopNav(): React.ReactElement {
         >
           <Icon className="h-4 w-4" />
           {label}
-          {to === '/dashboard' && hasRunning && (
-            <span className="flex h-2 w-2 rounded-full bg-primary animate-pulse" />
+          {to === '/dashboard' && runningCount > 0 && (
+            <span
+              className="ml-1 inline-flex min-w-[1.25rem] items-center justify-center rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-medium text-primary-foreground"
+              aria-label={`${String(runningCount)} workflows running`}
+            >
+              {runningCount}
+            </span>
           )}
         </NavLink>
       ))}

--- a/packages/web/src/components/layout/TopNav.tsx
+++ b/packages/web/src/components/layout/TopNav.tsx
@@ -12,9 +12,9 @@ const tabs = [
 ] as const;
 
 export function TopNav(): React.ReactElement {
-  // Read counts.running from the dashboard endpoint — single query gives us
-  // the count without paging through rows. limit=1 keeps the response payload
-  // small; we only consume `counts.running`.
+  // We only need `counts.running` — a server-side aggregate independent of
+  // the `runs` array. `limit: 1` minimises the `runs` payload that the API
+  // returns alongside the counts (we discard it).
   const { data: dashboardRuns } = useQuery({
     queryKey: ['dashboardRuns', { status: 'running', forCount: true }],
     queryFn: () => listDashboardRuns({ status: 'running', limit: 1 }),
@@ -59,7 +59,7 @@ export function TopNav(): React.ReactElement {
           {to === '/dashboard' && runningCount > 0 && (
             <span
               className="ml-1 inline-flex min-w-[1.25rem] items-center justify-center rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-medium text-primary-foreground"
-              aria-label={`${String(runningCount)} workflows running`}
+              aria-label={`${runningCount} workflows running`}
             >
               {runningCount}
             </span>


### PR DESCRIPTION
## Summary

- **Problem:** Every `archon serve` startup unconditionally flipped all `running` workflow rows to `failed` via `failOrphanedRuns()` at `packages/server/src/index.ts:213`. This killed CLI workflows actively executing in another process. Reproducer: start a workflow in one terminal, start the server in another while it's still running — the workflow's status flips to `failed` mid-execution and the CLI exits non-zero even though every node completed successfully. Filed as #1216, discovered during PR #1217 smoke testing.
- **Why it matters:** Every server restart silently corrupted in-flight workflow state. Users with CI/cron-driven server restarts could lose long-running workflows without an actionable signal. The dag-executor's defensive between-layer check was the only thing preventing partial corruption — but that protection means valuable work (completed nodes, accumulated cost, generated artifacts) gets recorded with status=failed.
- **What changed:** Backend removes the `failOrphanedRuns()` call from server startup (matches the CLI precedent at `packages/cli/src/cli.ts:256-258`). UI gets a numeric count badge on the Dashboard nav (replacing a binary pulse dot) and AlertDialog confirmations for destructive workflow-run actions (replacing 5 `window.confirm()` callsites).
- **What did **not** change (scope boundary):** The `failOrphanedRuns()` function itself in `packages/core/src/db/workflows.ts:911` is preserved — it's still used by `archon workflow cleanup` (the explicit user-driven path). Codex provider behavior unchanged. No DB migration. No new dependencies. No timer-based heuristic introduced anywhere — per the new CLAUDE.md principle.

## UX Journey

### Before

```
Terminal A                               Server (Terminal B)              UI
──────────                               ───────────────────              ──
archon workflow run e2e-claude-smoke
  ├─ creates run row (status=running)
  └─ executes nodes…
                                          archon serve  ──┐
                                          ├─ failOrphanedRuns()
                                          │  UPDATE remote_agent_workflow_runs
                                          │  SET status='failed'
                                          │  WHERE status='running'  ❌ kills A's row
                                          └─ binds port, ready
  ├─ next node finishes
  └─ between-layer status check
     sees status='failed'
     ↓
  ❌ Workflow failed:                                                    Dashboard:
     "Workflow did not complete                                           pulse dot
     successfully" (exit 1)                                               (binary signal)
```

### After

```
Terminal A                               Server (Terminal B)              UI
──────────                               ───────────────────              ──
archon workflow run e2e-claude-smoke
  ├─ creates run row (status=running)
  └─ executes nodes…
                                          archon serve  ──┐
                                          *no failOrphanedRuns() call*
                                          └─ binds port, ready
  ├─ all nodes complete
  └─ between-layer status check
     sees status='running'
     ↓
  ✓ Workflow completed                                                    Dashboard nav:
    successfully (exit 0)                                                  [📊 Dashboard 1]
                                                                          (numeric count
                                                                           badge, hidden if 0)

User sees an unfamiliar "running" workflow on the dashboard?
   → clicks the workflow card → AlertDialog → "Cancel workflow" → confirmed → row marked cancelled
   (no system-driven heuristic; user owns the decision)
```

## Architecture Diagram

### Before

```
                 ┌──────────────────────────────┐
                 │  packages/server/src/index.ts│
                 │   startServer()              │
                 │   ├─ DB connect              │
                 │   ├─ failOrphanedRuns()  ──> │ ❌ mutates ALL `running` rows
                 │   │                          │    regardless of process owner
                 │   └─ bind port               │
                 └──────────────────────────────┘
                                    │
                                    ▼
                 ┌──────────────────────────────────────┐
                 │  packages/core/src/db/workflows.ts    │
                 │  failOrphanedRuns()                   │
                 │  UPDATE … SET status='failed'         │
                 │  WHERE status='running'  (no scope)   │
                 └──────────────────────────────────────┘
```

### After

```
                 ┌──────────────────────────────┐
                 │  packages/server/src/index.ts│ [~]
                 │   startServer()              │
                 │   ├─ DB connect              │
                 │   ├─ // explanatory comment   │
                 │   │    *no autonomous mutation*│
                 │   └─ bind port               │
                 └──────────────────────────────┘

                 ┌──────────────────────────────────────┐
                 │  packages/core/src/db/workflows.ts    │ (unchanged)
                 │  failOrphanedRuns()                   │
                 │  Now only called by                   │
                 │  `archon workflow cleanup` (explicit) │
                 └──────────────────────────────────────┘

                 ┌────────────────────────────────────────────────────┐
                 │  packages/web/src/components/layout/TopNav.tsx [~] │
                 │   Dashboard nav: pulse-dot ──> count badge          │
                 │   reads /api/dashboard/runs counts.running          │
                 └────────────────────────────────────────────────────┘

                 ┌────────────────────────────────────────────────────┐
                 │  packages/web/src/components/dashboard/             │
                 │   ConfirmRunActionDialog.tsx  [+]                   │
                 │   shadcn AlertDialog wrapper, mirrors               │
                 │   sidebar/ProjectSelector codebase-delete pattern   │
                 │                                                      │
                 │   WorkflowRunCard.tsx  [~]                          │
                 │   4× window.confirm() ──> ConfirmRunActionDialog    │
                 │                                                      │
                 │   WorkflowHistoryTable.tsx  [~]                     │
                 │   1× window.confirm() ──> ConfirmRunActionDialog    │
                 └────────────────────────────────────────────────────┘
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| server/index.ts | createWorkflowStore() | **removed** | no longer needed at startup; `archon workflow cleanup` retains the link |
| server/index.ts | failOrphanedRuns() | **removed** | the offending invocation |
| TopNav.tsx | listDashboardRuns | **new** | replaces listWorkflowRuns; reads counts.running |
| TopNav.tsx | listWorkflowRuns | **removed** | superseded by listDashboardRuns query |
| WorkflowRunCard.tsx | ConfirmRunActionDialog | **new** | 4 callsites (Reject, Abandon, Cancel, Delete) |
| WorkflowHistoryTable.tsx | ConfirmRunActionDialog | **new** | 1 callsite (Delete) |
| ConfirmRunActionDialog.tsx | shadcn AlertDialog primitives | **new** | mirrors `sidebar/ProjectSelector.tsx:142–165` pattern |
| WorkflowRunCard.tsx | window.confirm | **removed** | 4 callsites |
| WorkflowHistoryTable.tsx | window.confirm | **removed** | 1 callsite |

## Label Snapshot

- Risk: `risk: low` *(removal of an autonomous mutation; UI changes are additive replacements of an existing pattern)*
- Size: `size: M` *(6 files, +197 / −72; bulk in WorkflowRunCard's 4 dialog conversions)*
- Scope: `core, server, web`
- Module: `server:index`, `web:dashboard`, `web:layout`

## Change Metadata

- Change type: `bug` *(primary: fixes #1216)* + `refactor` *(secondary: dialog UX)*
- Primary scope: `server`

## Linked Issue

- Closes #1216

## Validation Evidence (required)

```bash
bun run type-check     # 10/10 packages: Exited with code 0
bun run lint           # 0 errors, 0 warnings
bun run format:check   # All matched files use Prettier code style
bun run test           # one pre-existing failure on dev (cleanup-service.test.ts —
                       # `runScheduledCleanup > continues processing after error on
                       # one environment`); verified to also fail on origin/dev
                       # without this branch's changes. NOT introduced by this PR.
```

**End-to-end reproducer (the bug fix verification):**

```bash
# Terminal A
ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING=1 bun run cli workflow run e2e-claude-smoke --no-worktree

# Terminal B (during A's execution)
ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING=1 bun run dev:server
```

Result with this PR applied:
- Terminal A → `Workflow completed successfully.` (exit 0) ✓
- Server log → zero `orphan` / `fail_orphans` / `orphaned_workflow_runs_failed` events ✓
- DB → run row ends with `status='completed'`, not `failed` ✓

Without this PR (verified before the fix): Terminal A exits 1 with "Workflow failed", server log emits `db.orphaned_workflow_runs_failed { count: 1 }` — exactly the run that was in flight.

**Regression sweep:**

```bash
grep -n 'window\.confirm' \
  packages/web/src/components/dashboard/WorkflowRunCard.tsx \
  packages/web/src/components/dashboard/WorkflowHistoryTable.tsx
# zero matches
grep -nE "failOrphanedRuns\(\)" packages/server/src/index.ts
# zero matches
```

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No**

## Compatibility / Migration

- Backward compatible? **Yes** (no API contract change; `failOrphanedRuns()` retained for explicit cleanup)
- Config/env changes? **No**
- Database migration needed? **No**

**Behavioral change for operators:** Server restarts no longer auto-mark `running` workflow rows as `failed`. Truly orphaned rows from a crashed server now persist as `running` until cleaned up via `archon workflow cleanup` or per-row Cancel/Abandon in the dashboard. The Dashboard nav count badge surfaces the count.

## Human Verification (required)

- **Verified scenarios:**
  - End-to-end reproducer (above) — bug confirmed fixed
  - `bun run dev:server` starts cleanly with no orphan-related log events
  - CLI workflow completes cleanly even with concurrent server start
  - Type-check + lint + format all green across all 10 packages
- **Edge cases checked:**
  - The `failOrphanedRuns()` function is preserved and still callable by the explicit `archon workflow cleanup` path
  - The unused `createWorkflowStore` import in server/index.ts was also removed (caught by TS noUnusedLocals)
  - The `ConfirmRunActionDialog` does NOT swallow promise rejections from `onConfirm` — errors propagate to the parent's `runAction` helper which already displays them via `actionError` state
- **What was not verified:**
  - UI manual interaction with the new AlertDialogs (no browser available in this environment) — the AlertDialog primitive and the mirrored ProjectSelector pattern are both production-tested elsewhere; the change is essentially a render-shape swap
  - The dashboard nav badge update timing (relies on existing 10s polling; should appear within 10s of a workflow start)
  - No new component tests added — the web package has no React component test infrastructure (`bun test` only covers `src/lib/` and `src/stores/`); adding `@testing-library/react` would be significant scope creep matching no existing pattern. Type-check + lint + manual UI verification + the backend reproducer are the verification levels in this PR.

## Side Effects / Blast Radius (required)

- **Affected subsystems/workflows:** Server startup; CLI workflows running concurrently with server restarts; web UI Dashboard nav + workflow run cards + history table
- **Potential unintended effects:**
  - Truly orphaned `running` rows from crashed servers will accumulate in the DB until explicit cleanup. The count badge surfaces them; users can click into the dashboard and Cancel per row. This is the intended trade-off per CLAUDE.md "No Autonomous Lifecycle Mutation Across Process Boundaries".
  - `listDashboardRuns({ status: 'running', limit: 1 })` in TopNav adds one query per 10s where `listWorkflowRuns` was previously called. Same frequency, slightly heavier endpoint (returns enriched run + counts vs raw run array). The `limit: 1` keeps the runs payload trivially small; we only consume `counts.running`.
- **Guardrails / monitoring for early detection:**
  - The dashboard nav count badge is the primary visibility signal — operators see it grow if orphans accumulate
  - `archon workflow status` CLI command continues to work and lists running rows
  - Existing `db.orphaned_workflow_runs_failed` log event is now only emitted by the explicit cleanup path, so its presence post-merge is a useful signal that someone ran cleanup intentionally

## Rollback Plan (required)

- **Fast rollback command/path:** `git revert 7a00e047` on `dev`. One commit, atomic. No DB changes to reverse.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:**
  - If for some reason the dashboard nav badge fails to render: existing pulse-dot pattern is restored by the revert
  - If the AlertDialogs misbehave: revert restores `window.confirm` (worse UX but functional)
  - If the bug fix introduces an unforeseen regression: very unlikely (the change is a removal of an unconditional mutation), but revert is safe and restores the prior behavior including the bug

## Risks and Mitigations

- **Risk:** Operators who relied on server restarts to "tidy up" stuck workflows will need to use `archon workflow cleanup` or the dashboard explicitly. Some may not realize the behavior changed.
  - **Mitigation:** CHANGELOG entry under [Unreleased] documents the change. The Dashboard nav count badge surfaces stuck workflows visibly. Server log on startup no longer emits the misleading `db.orphaned_workflow_runs_failed` event, removing a false-positive signal.
- **Risk:** A pause in dialog-confirmation polish leaves the codebase with two destructive-confirm patterns (AlertDialog in some places, `window.confirm` elsewhere — ProjectSelector pattern, this PR's pattern, and any I missed).
  - **Mitigation:** This PR replaces all `window.confirm` in the touched files (`WorkflowRunCard.tsx`, `WorkflowHistoryTable.tsx`). Other components in `packages/web/` may still use `window.confirm` and should be reviewed in a follow-up sweep — out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom confirmation dialogs replace browser prompts for destructive workflow actions (Abandon, Cancel, Delete, Reject), providing contextual titles and descriptions.

* **Changed**
  * Server no longer auto-marks actively-running workflows as failed on startup; stuck runs must be handled by users via dashboard actions or the CLI.
  * Dashboard tab shows running workflow count as a numeric badge with aria-labels.

* **Documentation**
  * Guides updated to reflect orphaned-run, resume, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->