### PR TITLE
fix(test): update stale mocks in cleanup-service 'continues processing' test

### DIFF
--- a/packages/core/src/services/cleanup-service.test.ts
+++ b/packages/core/src/services/cleanup-service.test.ts
@@ -709,10 +709,33 @@ describe('runScheduledCleanup', () => {
         metadata: {},
       },
     ]);
-    // First env: internal worktreeExists returns false
-    mockExecFileAsync.mockRejectedValueOnce(new Error('not a git repo'));
-    // Second env: internal worktreeExists returns false
-    mockExecFileAsync.mockRejectedValueOnce(new Error('not a git repo'));
+    // worktreeExists returns false for both (already default)
+    // env-error: removeEnvironment needs getById + getCodebase
+    mockGetById.mockResolvedValueOnce({
+      id: 'env-error',
+      codebase_id: 'codebase-1',
+      working_path: '/bad/path',
+      branch_name: 'bad-branch',
+      status: 'active',
+    });
+    mockGetCodebase.mockResolvedValueOnce({
+      id: 'codebase-1',
+      name: 'test-repo',
+      default_cwd: '/workspace/repo',
+    });
+    // env-good: removeEnvironment needs getById + getCodebase
+    mockGetById.mockResolvedValueOnce({
+      id: 'env-good',
+      codebase_id: 'codebase-1',
+      working_path: '/workspace/repo/worktrees/pr-1',
+      branch_name: 'pr-1',
+      status: 'active',
+    });
+    mockGetCodebase.mockResolvedValueOnce({
+      id: 'codebase-1',
+      name: 'test-repo',
+      default_cwd: '/workspace/repo',
+    });
 
     const report = await runScheduledCleanup();
 


### PR DESCRIPTION
## Summary

- **Problem**: `runScheduledCleanup > continues processing after error on one environment` test fails on `dev` with `expected ['env-error (path missing)'] but got []`
- **Why it matters**: Blocks all PRs from merging to `dev` (CI gate failure introduced by regression in PR #1034)
- **What changed**: Updated test mock setup in `cleanup-service.test.ts` — replaced two stale `mockExecFileAsync.mockRejectedValueOnce` calls with proper `mockGetById` + `mockGetCodebase` return values for both test environments
- **What did not change**: No runtime behavior changed; `cleanup-service.ts` is untouched

## UX Journey

### Before

```
(No user-facing change — test-only fix)
```

### After

```
(Same — test-only fix, no UX change)
```

## Architecture Diagram

### Before

```
cleanup-service.test.ts
  └── continues processing after error
        ├── mockExecFileAsync.mockRejectedValueOnce(...)  [stale — exec no longer used for worktree check]
        └── mockExecFileAsync.mockRejectedValueOnce(...)  [stale]
```

### After

```
cleanup-service.test.ts
  └── continues processing after error
        ├── mockGetById.mockResolvedValueOnce({ id: 'env-error', ... })   [~] new mock target
        ├── mockGetCodebase.mockResolvedValueOnce({ id: 'codebase-1', ... })  [+]
        ├── mockGetById.mockResolvedValueOnce({ id: 'env-good', ... })    [~]
        └── mockGetCodebase.mockResolvedValueOnce({ id: 'codebase-1', ... })  [+]
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `cleanup-service.test.ts` | `mockExecFileAsync` | **removed** | Was targeting exec-based worktree check; no longer relevant |
| `cleanup-service.test.ts` | `mockGetById` | **modified** | Now provides env records for both test envs |
| `cleanup-service.test.ts` | `mockGetCodebase` | **modified** | Now provides codebase records for both test envs |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `tests`
- Module: `core:cleanup-service`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #1230

## Validation Evidence (required)

```bash
bun run validate
```

- Type check: ✅ Pass (all 10 packages)
- Lint: ✅ Pass (0 errors, 0 warnings)
- Format: ✅ Pass
- Tests: ✅ Pass (3045 passed, 0 failed)

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: `bun run validate` passes cleanly; the previously-failing test now passes
- Edge cases checked: Confirmed other tests in the same describe block that call `removeEnvironment` via paths where `pathExists=true` are unaffected (they don't hit the `getById` early-return)
- What was not verified: No manual runtime testing needed — this is a test-only fix with no production code changes

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `@archon/core` test suite only
- Potential unintended effects: None — no runtime code changed
- Guardrails/monitoring for early detection: CI will confirm

## Rollback Plan (required)

- Fast rollback command/path: `git revert HEAD` — single commit
- Feature flags or config toggles: None
- Observable failure symptoms: The same test assertion failure as described in #1230

## Risks and Mitigations

None — test-only change with no production code impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for environment cleanup operations by refining mock data dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->