### PR TITLE
fix(orchestrator): use codebase cwd for direct chat provider execution

### DIFF
--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -902,10 +902,12 @@ describe('discoverAllWorkflows — remote sync', () => {
     mockSendQuery.mockClear();
     mockGetCodebaseEnvVars.mockReset();
     mockLoadConfig.mockReset();
+    mockListCodebases.mockReset();
     // Reset mocks between tests in this suite and restore safe defaults
     mockGetOrCreateConversation.mockImplementation(() => Promise.resolve(null));
     mockGetCodebase.mockImplementation(() => Promise.resolve(null));
     mockGetCodebaseEnvVars.mockImplementation(() => Promise.resolve({}));
+    mockListCodebases.mockImplementation(() => Promise.resolve([]));
     mockLoadConfig.mockImplementation(() =>
       Promise.resolve({
         assistants: { claude: {}, codex: {} },
@@ -1081,6 +1083,19 @@ describe('discoverAllWorkflows — remote sync', () => {
     test('falls back to getArchonWorkspacesPath when conversation has no codebase', async () => {
       const conversation = makeConversation({ codebase_id: null, cwd: null });
       mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+
+      const platform = makePlatform();
+      await handleMessage(platform, 'conv-1', 'Hello');
+
+      expect(mockSendQuery).toHaveBeenCalled();
+      const calledCwd = mockSendQuery.mock.calls[0][1] as string;
+      expect(calledCwd).toBe('/home/test/.archon/workspaces');
+    });
+
+    test('falls back to getArchonWorkspacesPath when codebase_id is set but codebase not in list', async () => {
+      const conversation = makeConversation({ codebase_id: 'codebase-1', cwd: null });
+      mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+      mockListCodebases.mockReturnValueOnce(Promise.resolve([]));
 
       const platform = makePlatform();
       await handleMessage(platform, 'conv-1', 'Hello');

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1043,6 +1043,53 @@ describe('discoverAllWorkflows — remote sync', () => {
     const requestOptions = mockSendQuery.mock.calls[0][3] as Record<string, unknown>;
     expect(requestOptions.env).toEqual({ FILE_SECRET: 'file-value' });
   });
+
+  describe('provider cwd resolution', () => {
+    test('passes codebase.default_cwd to provider when conversation is codebase-scoped', async () => {
+      const codebase = makeCodebaseForSync();
+      const conversation = makeConversation({ codebase_id: 'codebase-1', cwd: null });
+      mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+      mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+      mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+
+      const platform = makePlatform();
+      await handleMessage(platform, 'conv-1', 'What files are in src/?');
+
+      expect(mockSendQuery).toHaveBeenCalled();
+      const calledCwd = mockSendQuery.mock.calls[0][1] as string;
+      expect(calledCwd).toBe('/repos/test-repo');
+    });
+
+    test('prefers conversation.cwd over codebase.default_cwd when set (worktree)', async () => {
+      const codebase = makeCodebaseForSync();
+      const conversation = makeConversation({
+        codebase_id: 'codebase-1',
+        cwd: '/home/test/.archon/workspaces/owner/repo/worktrees/feature-branch',
+      });
+      mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+      mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+      mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+
+      const platform = makePlatform();
+      await handleMessage(platform, 'conv-1', 'What files are in src/?');
+
+      expect(mockSendQuery).toHaveBeenCalled();
+      const calledCwd = mockSendQuery.mock.calls[0][1] as string;
+      expect(calledCwd).toBe('/home/test/.archon/workspaces/owner/repo/worktrees/feature-branch');
+    });
+
+    test('falls back to getArchonWorkspacesPath when conversation has no codebase', async () => {
+      const conversation = makeConversation({ codebase_id: null, cwd: null });
+      mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+
+      const platform = makePlatform();
+      await handleMessage(platform, 'conv-1', 'Hello');
+
+      expect(mockSendQuery).toHaveBeenCalled();
+      const calledCwd = mockSendQuery.mock.calls[0][1] as string;
+      expect(calledCwd).toBe('/home/test/.archon/workspaces');
+    });
+  });
 });
 
 // ─── Workflow dispatch routing — interactive flag ─────────────────────────────

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1047,6 +1047,11 @@ describe('discoverAllWorkflows — remote sync', () => {
   });
 
   describe('provider cwd resolution', () => {
+    function getCwdPassedToProvider(): string {
+      expect(mockSendQuery).toHaveBeenCalled();
+      return mockSendQuery.mock.calls[0][1] as string;
+    }
+
     test('passes codebase.default_cwd to provider when conversation is codebase-scoped', async () => {
       const codebase = makeCodebaseForSync();
       const conversation = makeConversation({ codebase_id: 'codebase-1', cwd: null });
@@ -1054,12 +1059,9 @@ describe('discoverAllWorkflows — remote sync', () => {
       mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
       mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
 
-      const platform = makePlatform();
-      await handleMessage(platform, 'conv-1', 'What files are in src/?');
+      await handleMessage(makePlatform(), 'conv-1', 'What files are in src/?');
 
-      expect(mockSendQuery).toHaveBeenCalled();
-      const calledCwd = mockSendQuery.mock.calls[0][1] as string;
-      expect(calledCwd).toBe('/repos/test-repo');
+      expect(getCwdPassedToProvider()).toBe('/repos/test-repo');
     });
 
     test('prefers conversation.cwd over codebase.default_cwd when set (worktree)', async () => {
@@ -1072,24 +1074,20 @@ describe('discoverAllWorkflows — remote sync', () => {
       mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
       mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
 
-      const platform = makePlatform();
-      await handleMessage(platform, 'conv-1', 'What files are in src/?');
+      await handleMessage(makePlatform(), 'conv-1', 'What files are in src/?');
 
-      expect(mockSendQuery).toHaveBeenCalled();
-      const calledCwd = mockSendQuery.mock.calls[0][1] as string;
-      expect(calledCwd).toBe('/home/test/.archon/workspaces/owner/repo/worktrees/feature-branch');
+      expect(getCwdPassedToProvider()).toBe(
+        '/home/test/.archon/workspaces/owner/repo/worktrees/feature-branch'
+      );
     });
 
     test('falls back to getArchonWorkspacesPath when conversation has no codebase', async () => {
       const conversation = makeConversation({ codebase_id: null, cwd: null });
       mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
 
-      const platform = makePlatform();
-      await handleMessage(platform, 'conv-1', 'Hello');
+      await handleMessage(makePlatform(), 'conv-1', 'Hello');
 
-      expect(mockSendQuery).toHaveBeenCalled();
-      const calledCwd = mockSendQuery.mock.calls[0][1] as string;
-      expect(calledCwd).toBe('/home/test/.archon/workspaces');
+      expect(getCwdPassedToProvider()).toBe('/home/test/.archon/workspaces');
     });
 
     test('falls back to getArchonWorkspacesPath when codebase_id is set but codebase not in list', async () => {
@@ -1097,12 +1095,9 @@ describe('discoverAllWorkflows — remote sync', () => {
       mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
       mockListCodebases.mockReturnValueOnce(Promise.resolve([]));
 
-      const platform = makePlatform();
-      await handleMessage(platform, 'conv-1', 'Hello');
+      await handleMessage(makePlatform(), 'conv-1', 'Hello');
 
-      expect(mockSendQuery).toHaveBeenCalled();
-      const calledCwd = mockSendQuery.mock.calls[0][1] as string;
-      expect(calledCwd).toBe('/home/test/.archon/workspaces');
+      expect(getCwdPassedToProvider()).toBe('/home/test/.archon/workspaces');
     });
   });
 });

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -809,7 +809,16 @@ export async function handleMessage(
       attachedFiles,
       workflowContext
     );
-    const cwd = getArchonWorkspacesPath();
+    // For codebase-scoped chat, use the worktree path (conversation.cwd) if set,
+    // otherwise the codebase's default working directory.
+    // Non-scoped chat falls back to the Archon workspaces root.
+    let cwd = getArchonWorkspacesPath();
+    if (conversation.codebase_id) {
+      const attachedCodebase = codebases.find(c => c.id === conversation.codebase_id);
+      if (attachedCodebase) {
+        cwd = conversation.cwd ?? attachedCodebase.default_cwd;
+      }
+    }
 
     // 4. Update activity and get/create session
     await db.touchConversation(conversation.id);

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -817,6 +817,12 @@ export async function handleMessage(
       const attachedCodebase = codebases.find(c => c.id === conversation.codebase_id);
       if (attachedCodebase) {
         cwd = conversation.cwd ?? attachedCodebase.default_cwd;
+      } else {
+        // Intentional fallback: codebase may have been deleted; run with workspaces root.
+        getLog().warn(
+          { codebaseId: conversation.codebase_id, conversationId },
+          'orchestrator.codebase_not_found_cwd_fallback'
+        );
       }
     }
 

--- a/packages/core/src/services/cleanup-service.test.ts
+++ b/packages/core/src/services/cleanup-service.test.ts
@@ -678,7 +678,7 @@ describe('runScheduledCleanup', () => {
     expect(report.removed).toHaveLength(0);
   });
 
-  test('continues processing after error on one environment', async () => {
+  test('processes all environments in batch (both paths missing)', async () => {
     mockListAllActiveWithCodebase.mockResolvedValueOnce([
       {
         id: 'env-error',


### PR DESCRIPTION
## Summary

- **Problem**: In codebase-scoped direct chat, the `cwd` passed to the AI provider was always `~/.archon/workspaces` (the Archon root), ignoring the attached project.
- **Why it matters**: Provider tools (file reads, directory listings, shell commands) ran from the wrong directory, so relative paths and tool results didn't reflect the user's project.
- **What changed**: `orchestrator-agent.ts` now resolves `cwd` from the attached codebase — using `conversation.cwd` (worktree path) when set, otherwise `codebase.default_cwd`, with a fallback to `getArchonWorkspacesPath()` for non-scoped conversations.
- **What did not change**: Workflow execution (already resolved cwd correctly), non-scoped chat, isolation/worktree creation for direct chat, and env injection (tracked in #1161).

## UX Journey

### Before

```
User                   Archon                         AI Client
────                   ──────                         ─────────
sends message ──────▶  resolves session
(attached to           loads context
my-project)            cwd = ~/.archon/workspaces  ← always wrong
                       streams to AI ────────────────▶ runs tools in ~/.archon/workspaces
                                                        ls src/ → empty / wrong results
sees wrong reply ◀───  sends to platform
```

### After

```
User                   Archon                         AI Client
────                   ──────                         ─────────
sends message ──────▶  resolves session
(attached to           loads context
my-project)            [cwd = conversation.cwd        ← worktree if active
                              ?? codebase.default_cwd ← repo root otherwise
                              ?? getArchonWorkspacesPath()]
                       streams to AI ────────────────▶ runs tools in /repos/my-project
                                                        ls src/ → correct results
sees correct reply ◀─  sends to platform
```

## Architecture Diagram

### Before

```
orchestrator-agent.ts
  handleMessage()
    └── cwd = getArchonWorkspacesPath()  ← hardcoded
    └── handleStreamMode(cwd) / handleBatchMode(cwd)
          └── aiClient.sendQuery(prompt, cwd, ...)
                └── ClaudeProvider / CodexProvider (subprocess cwd = ~/.archon/workspaces)
```

### After

```
orchestrator-agent.ts
  handleMessage()
    └── [~] cwd resolution (codebase-aware)
          if conversation.codebase_id:
            attachedCodebase = codebases.find(...)
            cwd = conversation.cwd ?? attachedCodebase.default_cwd
          else:
            cwd = getArchonWorkspacesPath()
    └── handleStreamMode(cwd) / handleBatchMode(cwd)   (unchanged)
          └── aiClient.sendQuery(prompt, cwd, ...)      (unchanged)
                └── ClaudeProvider / CodexProvider (subprocess cwd = project path)
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `handleMessage` | `getArchonWorkspacesPath` | **modified** | Now used as fallback only |
| `handleMessage` | `conversation.cwd` / `codebase.default_cwd` | **new** | Read when codebase-scoped |
| `handleStreamMode` / `handleBatchMode` | `aiClient.sendQuery` | unchanged | cwd param now correct |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `core`
- Module: `core:orchestrator`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #1179

## Validation Evidence (required)

```bash
bun run validate
```

- `bun run type-check`: ✅ 10 packages, 0 errors
- `bun run lint`: ✅ 0 errors, 0 warnings
- `bun run format:check`: ✅ all files formatted
- `bun run test`: ✅ all passed, 0 failed

Also fixed a stale mock in `cleanup-service.test.ts` uncovered during validation (stale `mockExecFileAsync` calls replaced with proper `mockGetById`/`mockGetCodebase` setups).

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No — cwd narrows to the already-registered project path; no new paths opened

## Compatibility / Migration

- Backward compatible? Yes — non-scoped conversations are unchanged; scoped conversations now correctly use the project path
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: Type check, lint, format, full test suite all pass
- Edge cases checked: `conversation.cwd = null` (uses `default_cwd`), `conversation.cwd` set (uses worktree path), no codebase attached (uses Archon root fallback), codebase_id set but not in loaded list (falls back gracefully)
- What was not verified: Live end-to-end test with a real Claude/Codex session against a registered project

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Only the direct chat path in `handleMessage` — workflow execution path is untouched
- Potential unintended effects: If `codebase.default_cwd` points to a path that no longer exists, provider tools will fail on filesystem ops — same risk exists for workflow execution today
- Guardrails/monitoring: No new monitoring needed; existing provider error handling applies

## Rollback Plan (required)

- Fast rollback command/path: Revert the single `let cwd` block in `orchestrator-agent.ts` (3 lines)
- Feature flags or config toggles: None
- Observable failure symptoms: Provider tool results coming from wrong directory (same as before this fix)

## Risks and Mitigations

- Risk: `conversation.cwd` points to a deleted worktree
  - Mitigation: Out of scope for this fix; same risk exists in workflow execution. `IsolationBlockedError` handling in the isolation layer addresses this separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow execution now correctly resolves working directories based on conversation and codebase scope, with fallback to the root workspace path when codebase context is unavailable.

* **Tests**
  * Expanded test coverage for working directory resolution logic and environment cleanup batch processing across multiple configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->