### PR TITLE
fix(providers): init options.hooks before merging node hooks

### DIFF
--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -865,6 +865,35 @@ describe('ClaudeProvider', () => {
       expect(callArgs.options.sandbox).toEqual(sandbox);
     });
 
+    test('passes hooks to SDK via nodeConfig without crashing on warning extraction', async () => {
+      // Regression for a TypeError that surfaced whenever a workflow node declared
+      // `hooks:` in its nodeConfig: applyNodeConfig ran twice — once against a
+      // throwaway Options `{}` for warning extraction, and once against the real
+      // Options — and the first pass crashed because it wrote into an undefined
+      // `options.hooks` map.
+      mockQuery.mockImplementation(async function* () {
+        yield { type: 'result', session_id: 'sid' };
+      });
+
+      for await (const _ of client.sendQuery('test', '/tmp', undefined, {
+        nodeConfig: {
+          hooks: {
+            PreToolUse: [{ matcher: 'Write', response: { decision: 'approve' } }],
+          },
+        },
+      })) {
+        // consume
+      }
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const callArgs = mockQuery.mock.calls[0][0] as {
+        options: { hooks?: Record<string, Array<{ matcher?: string }>> };
+      };
+      // Node hooks land alongside the provider's own PostToolUse capture hook.
+      expect(callArgs.options.hooks?.PreToolUse?.[0]?.matcher).toBe('Write');
+      expect(callArgs.options.hooks?.PostToolUse).toBeDefined();
+    });
+
     test('ignores empty text blocks', async () => {
       mockQuery.mockImplementation(async function* () {
         yield {

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -381,6 +381,12 @@ async function applyNodeConfig(
     if (Object.keys(builtHooks).length > 0) {
       // Merge with existing hooks (PostToolUse capture hook)
       const existingHooks = options.hooks as SDKHooksMap | undefined;
+      // sendQuery's warning-extraction path passes `{} as Options` (no `hooks`
+      // field), so direct property assignment below would crash with
+      // "undefined is not an object". Ensure the map exists before writing.
+      if (!options.hooks) {
+        options.hooks = {} as SDKHooksMap;
+      }
       for (const [event, matchers] of Object.entries(builtHooks)) {
         if (!matchers) continue;
         const existing = existingHooks?.[event] as HookCallbackMatcher[] | undefined;


### PR DESCRIPTION
# fix(providers): init options.hooks before merging node hooks

## Summary

`applyNodeConfig` is called twice in `sendQuery`:

1. Once against a throwaway `{} as Options` to extract provider warnings (line 898).
2. Once against the real `Options` built by `buildBaseClaudeOptions`, which pre-seeds `hooks` with the PostToolUse tool-capture hook (line 941).

The first call crashed whenever a node declared `hooks:` in its `nodeConfig`, because the merge loop wrote directly into `options.hooks` without checking it existed. This blocks every DAG workflow that uses per-node hooks (e.g. the `analyze` node of `archon-architect`) at the very first AI layer.

## Error reproduced

```
TypeError: undefined is not an object (evaluating 'options.hooks[event] = matchers')
    at applyNodeConfig (packages/providers/src/claude/provider.ts:393:20)
    at sendQuery (packages/providers/src/claude/provider.ts:899:34)
    at processTicksAndRejections (native:7:39)
```

Before:
<img width="1456" height="656" alt="image" src="https://github.com/user-attachments/assets/4c576aba-9086-4d3c-a0f2-f006dc880808" />

After:
<img width="981" height="421" alt="image" src="https://github.com/user-attachments/assets/e71d6b74-0c45-45ce-865f-2d476fc32f30" />

Reproduction: run any DAG workflow whose first AI node defines `hooks:` in its YAML. The stock `archon-architect` workflow (`analyze` node with `PreToolUse`/`PostToolUse` hooks) hits it deterministically — `scan-metrics` completes in ~100 ms, then `analyze` fails instantly with the TypeError and the remaining 5 nodes are skipped.

## Fix

Initialize `options.hooks = {}` before the merge loop so the subsequent `options.hooks[event] = ...` assignments are safe regardless of whether the caller pre-populated the hooks map. The second call path (line 941) is unaffected because its `options.hooks` is already populated by `buildBaseClaudeOptions`.

## Test plan

- [x] New regression test in `provider.test.ts` exercises `sendQuery` with `nodeConfig.hooks` and asserts both the node hook and the provider's PostToolUse capture hook land on the SDK options. Fails on `dev` without the patch, passes with it.
- [x] `bun run type-check` — all packages pass
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `bun run test` — all packages pass (64 tests in `@archon/providers` alone)
- [x] Manually retried `archon-architect` end-to-end after the patch: `analyze` node streams normally for minutes instead of crashing at ~1 ms.
