### PR TITLE
fix(workflows): add word boundary to context variable substitution regex

### DIFF
--- a/packages/workflows/src/executor-shared.test.ts
+++ b/packages/workflows/src/executor-shared.test.ts
@@ -167,6 +167,22 @@ describe('substituteWorkflowVariables', () => {
     expect(prompt).toBe('Issue: context-data. External: context-data');
   });
 
+  it('does not treat context variables as prefixes of longer identifiers', () => {
+    const { prompt, contextSubstituted } = substituteWorkflowVariables(
+      'Context: $CONTEXT. File: $CONTEXT_FILE. External path: $EXTERNAL_CONTEXT_PATH',
+      'run-1',
+      'msg',
+      '/tmp',
+      'main',
+      'docs/',
+      'context-data'
+    );
+    expect(prompt).toBe(
+      'Context: context-data. File: $CONTEXT_FILE. External path: $EXTERNAL_CONTEXT_PATH'
+    );
+    expect(contextSubstituted).toBe(true);
+  });
+
   it('clears context variables when issueContext is undefined', () => {
     const { prompt, contextSubstituted } = substituteWorkflowVariables(
       'Context: $CONTEXT here',

--- a/packages/workflows/src/executor-shared.test.ts
+++ b/packages/workflows/src/executor-shared.test.ts
@@ -169,7 +169,7 @@ describe('substituteWorkflowVariables', () => {
 
   it('does not treat context variables as prefixes of longer identifiers', () => {
     const { prompt, contextSubstituted } = substituteWorkflowVariables(
-      'Context: $CONTEXT. File: $CONTEXT_FILE. External path: $EXTERNAL_CONTEXT_PATH',
+      'Context: $CONTEXT. File: $CONTEXT_FILE. External path: $EXTERNAL_CONTEXT_PATH. IssueId: $ISSUE_CONTEXT_ID',
       'run-1',
       'msg',
       '/tmp',
@@ -178,9 +178,37 @@ describe('substituteWorkflowVariables', () => {
       'context-data'
     );
     expect(prompt).toBe(
-      'Context: context-data. File: $CONTEXT_FILE. External path: $EXTERNAL_CONTEXT_PATH'
+      'Context: context-data. File: $CONTEXT_FILE. External path: $EXTERNAL_CONTEXT_PATH. IssueId: $ISSUE_CONTEXT_ID'
     );
     expect(contextSubstituted).toBe(true);
+  });
+
+  it('does not substitute $ISSUE_CONTEXT when followed by identifier characters', () => {
+    const { prompt } = substituteWorkflowVariables(
+      'Issue: $ISSUE_CONTEXT. ID: $ISSUE_CONTEXT_ID. Type: $ISSUE_CONTEXT_TYPE',
+      'run-1',
+      'msg',
+      '/tmp',
+      'main',
+      'docs/',
+      'context-data'
+    );
+    expect(prompt).toBe('Issue: context-data. ID: $ISSUE_CONTEXT_ID. Type: $ISSUE_CONTEXT_TYPE');
+  });
+
+  it('does not set contextSubstituted when only suffix-extended context vars are present', () => {
+    const { prompt, contextSubstituted } = substituteWorkflowVariables(
+      'Path: $CONTEXT_FILE',
+      'run-1',
+      'msg',
+      '/tmp',
+      'main',
+      'docs/',
+      'context-data'
+    );
+    // $CONTEXT_FILE is not a context variable — should be left untouched
+    expect(prompt).toBe('Path: $CONTEXT_FILE');
+    expect(contextSubstituted).toBe(false);
   });
 
   it('clears context variables when issueContext is undefined', () => {

--- a/packages/workflows/src/executor-shared.ts
+++ b/packages/workflows/src/executor-shared.ts
@@ -242,7 +242,8 @@ export async function loadCommandPrompt(
 // ─── Variable Substitution ───────────────────────────────────────────────────
 
 /** Pattern string for context variables - used to create fresh regex instances */
-export const CONTEXT_VAR_PATTERN_STR = '\\$(?:CONTEXT|EXTERNAL_CONTEXT|ISSUE_CONTEXT)';
+export const CONTEXT_VAR_PATTERN_STR =
+  '\\$(?:CONTEXT|EXTERNAL_CONTEXT|ISSUE_CONTEXT)(?![A-Za-z0-9_])';
 
 /**
  * Substitute workflow variables in a prompt.


### PR DESCRIPTION
## Summary

- **Problem**: `substituteWorkflowVariables()` uses `CONTEXT_VAR_PATTERN_STR` with no word boundary or negative lookahead, causing `$CONTEXT_FILE` to match as `$CONTEXT` + `_FILE`, silently corrupting the variable to `_FILE` at runtime.
- **Why it matters**: Bash nodes using any shell variable whose name starts with `CONTEXT`, `EXTERNAL_CONTEXT`, or `ISSUE_CONTEXT` (e.g. `$CONTEXT_FILE`, `$ISSUE_CONTEXT_ID`) receive a mangled script — no error is thrown, the bash command runs with wrong variable names, and fallback defaults may hide the corruption entirely.
- **What changed**: Added `(?![A-Za-z0-9_])` negative lookahead to `CONTEXT_VAR_PATTERN_STR` in `executor-shared.ts`; added a regression test in `executor-shared.test.ts`.
- **What did not change**: All other variable substitutions (`$WORKFLOW_ID`, `$ARTIFACTS_DIR`, etc.) are unaffected; no changes to context fetching, storage, or any other module.

## UX Journey

### Before

```
User workflow YAML (bash node):
  CONTEXT_FILE=".planning/phases/$PHASE/CONTEXT.md"

substituteWorkflowVariables():
  Pattern: \$(?:CONTEXT|EXTERNAL_CONTEXT|ISSUE_CONTEXT)
  Match:   $CONTEXT  (prefix inside $CONTEXT_FILE)
  Result:  CONTEXT_FILE → _FILE  ← silent corruption

bash node receives: _FILE=".planning/phases/$PHASE/CONTEXT.md"
bash: grep: _FILE: No such file or directory
  (or silently produces wrong output if $CONTEXT had a value)
```

### After

```
User workflow YAML (bash node):
  CONTEXT_FILE=".planning/phases/$PHASE/CONTEXT.md"

substituteWorkflowVariables():
  Pattern: \$(?:CONTEXT|EXTERNAL_CONTEXT|ISSUE_CONTEXT)(?![A-Za-z0-9_])
  No match on $CONTEXT_FILE (followed by '_')
  $CONTEXT alone still matches correctly

bash node receives: CONTEXT_FILE=".planning/phases/$PHASE/CONTEXT.md"
  (correct — user-defined variable preserved)
```

## Architecture Diagram

### Before

```
executor-shared.ts
  CONTEXT_VAR_PATTERN_STR = \$(?:CONTEXT|EXTERNAL_CONTEXT|ISSUE_CONTEXT)
       |
       ▼
  substituteWorkflowVariables()  ← matches $CONTEXT_FILE as $CONTEXT + _FILE
       |
       ▼
  dag-executor.ts / executor.ts  ← receives corrupted prompt
       |
       ▼
  bash node subprocess  ← runs with mangled variable names
```

### After

```
executor-shared.ts
  CONTEXT_VAR_PATTERN_STR = \$(?:CONTEXT|EXTERNAL_CONTEXT|ISSUE_CONTEXT)(?![A-Za-z0-9_])
       |
       ▼
  substituteWorkflowVariables() [~]  ← only matches standalone context vars
       |
       ▼
  dag-executor.ts / executor.ts  ← receives correct prompt (unchanged)
       |
       ▼
  bash node subprocess  ← runs with correct variable names
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `CONTEXT_VAR_PATTERN_STR` | `substituteWorkflowVariables()` | **modified** | Negative lookahead added to pattern |
| `substituteWorkflowVariables()` | `buildPromptWithContext()` | unchanged | Picks up fix automatically |
| `buildPromptWithContext()` | `dag-executor.ts` / `executor.ts` | unchanged | |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `workflows`
- Module: `workflows:executor`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes #1112

## Validation Evidence (required)

```bash
bun run validate
# type-check: ✅ pass (all 10 packages)
# lint:       ✅ 0 errors, 0 warnings
# format:     ✅ all files formatted
# tests:      ✅ all packages passed, 0 failures
```

- Evidence provided: All four `bun run validate` checks passed on first run; new regression test added and passing.
- No commands skipped.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — the fix only prevents incorrect matches; all previously correct substitutions continue to work.
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: Regression test covers `$CONTEXT` (substituted) vs `$CONTEXT_FILE` (preserved) vs `$EXTERNAL_CONTEXT_PATH` (preserved) in a single call.
- Edge cases checked: `$CONTEXT` at end of string (no trailing char), followed by whitespace/newline/quote/colon — all still match. `$ISSUE_CONTEXT_ID` — now correctly left untouched.
- What was not verified: Live bash node execution with a real workflow run (validated via unit test instead).

## Side Effects / Blast Radius (required)

- Affected subsystems: `substituteWorkflowVariables()` in `@archon/workflows` — used by every prompt node (bash, command, prompt, loop, approval, script). Impact is purely corrective.
- Potential unintended effects: None — the lookahead is zero-width and only restricts matches where the pattern was already wrong.
- Guardrails: Regression test locks in correct behavior.

## Rollback Plan (required)

- Fast rollback: Revert commit `2b0adc24` (`git revert 2b0adc24`).
- Feature flags: None.
- Observable failure symptoms: Bash nodes using `$CONTEXT_FILE` or similar begin producing `_FILE`-style mangled variable names; no error thrown.

## Risks and Mitigations

- Risk: None. Change is a one-character regex tightening with a dedicated regression test. No architectural changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow variable substitution accuracy to prevent incorrect matching when context variable names appear as prefixes within longer identifiers (e.g., `$CONTEXT_FILE`).

* **Tests**
  * Added test coverage for edge cases around context variable name boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->