### PR TITLE
feat(cold-pass): universal checklist + reviewer command for independent PR review

### DIFF
--- a/.archon/checklists/cold-pass-default-checklist.md
+++ b/.archon/checklists/cold-pass-default-checklist.md
@@ -1,0 +1,63 @@
+# Cold-Pass Default Checklist (Universal)
+
+**Reviewer instruction:** Walk each `[ ]` item literally. Output PASS / FAIL / N/A
+with a file:line reference for every FAIL. Do not summarize. Do not skip.
+
+The #1 heuristic: **one-sided parity.** For every producer touched in the diff,
+identify its consumers. For every filter added, identify every sibling endpoint
+that needs matching behavior. Multi-agent reviewers miss this because they read
+files in isolation — your job is to read them together.
+
+---
+
+## ONE-SIDED PARITY (read/write drift)
+[ ] For every function the diff modifies, which other functions call it? Does
+    each call site still pass the correct arguments?
+[ ] For every new parameter or field: is it threaded through every path that
+    reaches the modified function, or only the one the PR author tested?
+[ ] For every writer touched: find its readers. Still in sync?
+[ ] For every reader touched: find its writers. Still in sync?
+[ ] "Sibling endpoint" parity: if PR adds filter/field on endpoint A, do
+    siblings (list, detail, count, summary, inventory) need matching behavior?
+
+## CROSS-FILE STATE MACHINES
+[ ] If the PR advances a state in one table/record, are all linked states
+    advanced together? (Approval workflows, order fulfillment, multi-step
+    transitions.)
+[ ] Are invariants maintained across the cross-table transition, or only
+    per-table?
+
+## MIGRATION / SCHEMA HYGIENE
+[ ] Migrations have explicit BEGIN/COMMIT wrappers or transaction guarantees?
+[ ] UPDATE-only migrations on existing rows: do they silent no-op on fresh DBs
+    where the rows don't exist yet?
+[ ] Numeric prefix / filename collisions with existing migrations?
+[ ] Schema changes referenced consistently across all code paths (ORM + raw
+    SQL + serializers)?
+
+## RESOURCE / FAILURE MODES
+[ ] `query[0]` / `.first()` on a multi-row query without ORDER BY
+    (non-deterministic on Postgres, MySQL, most engines)?
+[ ] New parameter handled for empty string, None/null, special characters,
+    very large input?
+[ ] Bypasses existing auth, rate-limit, or validation middleware?
+[ ] Error paths return the same shape as success paths? (Silent-200,
+    partial-failure hidden behind 200 OK.)
+
+## TEST COVERAGE BLIND SPOTS
+[ ] Every branch added in the diff maps to at least one test assertion?
+[ ] Tests exercise the REAL write path, not direct SQL insert / mock that
+    skips triggers, validators, or middleware?
+[ ] If the PR introduces multiple backends / modes / providers, does at least
+    one test cover each?
+
+## DOWNSTREAM CONSISTENCY
+[ ] If public API shape changes, are consumers updated or version-gated?
+[ ] Config, environment variables, feature flags: documented and plumbed
+    through all environments?
+
+## HARDCODED VALUES
+[ ] Hardcoded identifiers (IDs, names, keys, domains) that should be
+    config-driven?
+[ ] Defaults that only work for the author's happy path but break other
+    legitimate inputs?

--- a/.archon/commands/defaults/archon-cold-pass-review.md
+++ b/.archon/commands/defaults/archon-cold-pass-review.md
@@ -1,0 +1,97 @@
+---
+description: Independent cold second-pass PR review — single reviewer, repo-local checklist
+argument-hint: (none — reads PR number from ARTIFACTS_DIR/.pr-number)
+---
+
+# Cold Pass Review
+
+## Your Role
+
+You are the **first reviewer** of this PR. That is not metaphor — for your purposes,
+no one has looked at this code before. You are walking through it fresh, with a
+checklist of structural concerns this repo's maintainers have learned to watch for.
+
+Archon's 5-agent review has already run and posted its findings as a PR comment.
+You will glance at those findings ONCE, at the end, for deduplication only. They
+must not shape where you look during your review. Correlated-attention blind spots
+are the entire reason you exist: if you let Archon's report anchor your search, you
+become a 6th Archon agent and add no value.
+
+## Phase 1: LOAD
+
+1. Read `$ARTIFACTS_DIR/.pr-number` → `PR`
+2. Read `$ARTIFACTS_DIR/.checklist-source` → `SOURCE` (`default` or `repo+default`)
+3. Read `$ARTIFACTS_DIR/cold-pass-checklist.md` → the layered checklist. It always contains the universal default; when `SOURCE=repo+default`, the repo-local extension is appended after a `---` separator. Walk both in order.
+4. `gh pr diff $PR` → the changes
+5. For every file in the diff, `cat <file>` in full (not just the diff context)
+6. Do NOT read Archon's artifacts. Do NOT read `$ARTIFACTS_DIR/review/*`.
+
+**Phase 1 checkpoint:**
+- [ ] PR number loaded
+- [ ] Checklist source loaded
+- [ ] Layered checklist loaded (universal default present; repo-local present if `SOURCE=repo+default`)
+- [ ] Diff read
+- [ ] All modified files read in full
+- [ ] Archon artifacts NOT consulted
+
+## Phase 2: ANALYZE
+
+Walk the checklist literally — check each `[ ]` box, one at a time, out loud.
+The literal walk is the discipline. Never summarize the checklist. Never skip
+an item because it "looks fine."
+
+For each item: `PASS` / `FAIL` / `N/A`. For every `FAIL`, include a file:line
+reference and a one-sentence explanation.
+
+**Special attention to one-sided parity.** For every producer/writer touched by
+the diff, identify its consumers/readers (grep the codebase if needed) and verify
+they are still in sync. This is the #1 shape to hunt for.
+
+**Phase 2 checkpoint:**
+- [ ] Every checklist item walked
+- [ ] FAILs have file:line refs
+- [ ] One-sided parity checks done for every modified writer
+
+## Phase 3: GENERATE
+
+Write `$ARTIFACTS_DIR/cold-pass-findings.md`:
+
+```
+# 🧊 COLD PASS: PR #<N>
+
+**Reviewer model:** <state the model you are, e.g., `gpt-5.3-codex` or `claude-opus-4.6` — name the actual model you run as>
+**Checklist source:** <`default` or `repo+default` — read from `$ARTIFACTS_DIR/.checklist-source`>
+**Verdict:** <APPROVE or REQUEST_CHANGES>
+
+## HIGH
+- <file:line> — <finding>
+
+## MEDIUM
+- <file:line> — <finding>
+
+## LOW
+- <file:line> — <finding>
+
+## Deduplication note
+
+After reading `gh pr view <PR> --comments`, I removed findings Archon already
+caught at the same or higher severity. Findings retained below are either new,
+or graded higher than Archon did (with reasoning).
+
+## Summary
+
+<One paragraph. If nothing beyond Archon, say: "No additional findings. APPROVE.">
+```
+
+**Phase 3 checkpoint:**
+- [ ] Findings file exists
+- [ ] Verdict line present
+- [ ] Dedup note present (even if empty)
+
+## Phase 4: VALIDATE
+
+Check that `cold-pass-findings.md`:
+- Has a Verdict line (APPROVE or REQUEST_CHANGES)
+- Has a Summary section
+- Has a Deduplication note
+- Uses file:line refs for all FAILs


### PR DESCRIPTION
## Context

Archon's `archon-comprehensive-pr-review` is excellent at catching per-file issues but has a documented correlated-attention blind spot for bugs that drift across files (producer/consumer parity, cross-file state, silent-200s). Running an independent cold second-pass after the 5-agent review catches these.

This PR adds two reusable artifacts that support the pattern — both pure markdown, no execution dependencies:

- **`.archon/checklists/cold-pass-default-checklist.md`** — universal checklist of correlated-attention blind spots (one-sided parity, cross-file state machines, migration hygiene, resource/failure modes, test coverage, downstream consistency, hardcoded values). 23 literal checklist items.
- **`.archon/commands/defaults/archon-cold-pass-review.md`** — the reviewer command with a 4-phase walk (LOAD → ANALYZE → GENERATE → VALIDATE). Enforces "first reviewer" framing: Archon's existing findings are consumed ONLY at the end for deduplication, never as an attention anchor up front.

## What this is NOT

- Not an automation. These are reusable artifacts; automation lives in the consuming repo's own tooling.
- Not a workflow YAML. An earlier design proposed a full auto-spawn workflow that would call `archon workflow run` from inside a bash node. Empirical testing (fundedullc-dev/email-pipeline-dev#75, Wave 1 probe findings) showed the current bash-node execution model blocks this approach: `archon` binary is not on PATH inside bash nodes, bash stdout is silenced on success, and Windows `$ARTIFACTS_DIR` substitution produces broken paths when spliced into bash strings. A cold-pass workflow YAML can land once those execution concerns are addressed upstream; in the meantime these markdown artifacts are useful as standalone reference material for any reviewer (agentic or human) that wants to walk the checklist.

## Cold-pass precedents

Real bugs caught by manual cold-pass on PRs that Archon's 5-agent review had already approved:

- `fundedullc-dev/fundedu-hive` PR #4 — UPDATE-only migration silently no-op'd on fresh DBs
- `fundedullc-dev/fundedu-hive` PR #46 — `track_data_file()` write path drifted from `get_state_files()` read path across three storage backends
- `fundedullc-dev/email-pipeline-dev` issue #80 — `retry_failed_contacts` doesn't pass `force_override_emails` to presend gate (one-sided parity with two sibling send paths)

These are the bug shapes the checklist is engineered to surface, specifically the `ONE-SIDED PARITY` section.

## Validation evidence

Smoke-tested 2026-04-16 against email-pipeline-dev PR #66 using a consumer-side slash command that reads these artifacts and invokes Codex (gpt-5 family) on the PR diff. Cold-pass successfully:

1. Re-caught the canonical cross-file parity finding from issue #80 (recursive validation)
2. Surfaced two additional MEDIUM test-coverage findings the 5-agent review missed
3. Walked the checklist literally, producing PASS/FAIL/N/A for each of the 23+ items with file:line refs on FAILs

Evidence comment: https://github.com/fundedullc-dev/email-pipeline-dev/pull/66#issuecomment-4262997447

## Design spec

Full spec + architectural rationale + Wave 1 probe findings: https://github.com/fundedullc-dev/email-pipeline-dev/tree/main/docs/superpowers

Key design principles:

1. **Independence is the active ingredient.** A cold-pass that shares context with Archon's reviewers becomes a 6th Archon agent and adds nothing. Run a different provider, different session, different attention.
2. **Structural separation over discipline.** Rely on separate invocations, not operator memory.
3. **Single focused reviewer, not a DAG.** The 5-agent pattern fragments attention; cold-pass reunifies it.
4. **Repo-local hard rules layered over universal patterns.** Universal default is always first; repos extend (never replace) with their own canonical bug shapes.

## Files changed

- `.archon/checklists/cold-pass-default-checklist.md` (new, 2.9 KB, 23 checklist items)
- `.archon/commands/defaults/archon-cold-pass-review.md` (new, 3.5 KB, 4-phase walk)

No existing files modified. Additive only.

## Questions welcomed

- If `.archon/checklists/` is the wrong path for bundled-default artifacts (Archon's shipped workflows live in `packages/workflows/src/defaults/bundled-defaults.ts` — perhaps the checklist + command should be similarly bundled), happy to relocate.
- If you'd like these to eventually ship as a workflow YAML, that's blocked on the three bash-node execution concerns mentioned above. Happy to collaborate on fixes or design alternatives.

Authored by @fundedullc-dev. Validation done in https://github.com/fundedullc-dev/email-pipeline-dev/issues/75.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive code review checklist defining coverage areas including state machine consistency, migration/schema hygiene, error handling, test coverage, and API compatibility.
  * Added a code review workflow process specifying a four-phase review approach with explicit verdict and findings documentation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->