### PR TITLE
fix(core): parse non-GitHub SSH remote URLs correctly in registerRepo…

### DIFF
--- a/packages/core/src/handlers/clone.test.ts
+++ b/packages/core/src/handlers/clone.test.ts
@@ -706,6 +706,32 @@ describe('registerRepository', () => {
     expect(createArg.name).toBe('acme/backend');
   });
 
+  test('builds owner/repo name from non-GitHub SSH remote URL without colon in name', async () => {
+    // GitLab / self-hosted SSH URLs: git@host:org/repo — the host must NOT appear in
+    // the codebase name or worktree path because colons break Java classpaths on Unix.
+    spyExecFileAsync.mockImplementation((cmd: string, args: string[]) => {
+      if (args.includes('rev-parse')) return Promise.resolve({ stdout: '.git', stderr: '' });
+      if (args.includes('get-url'))
+        return Promise.resolve({
+          stdout: 'git@gitlab.example.com:myorg/myproject.git',
+          stderr: '',
+        });
+      return Promise.resolve({ stdout: '', stderr: '' });
+    });
+    mockFindCodebaseByDefaultCwd.mockResolvedValueOnce(null);
+    mockCreateCodebase.mockResolvedValueOnce(
+      makeCodebase({ name: 'myorg/myproject' }) as ReturnType<typeof makeCodebase>
+    );
+
+    await registerRepository('/home/user/myproject');
+
+    const createArg = mockCreateCodebase.mock.calls[0]?.[0] as { name: string };
+    // Must be plain owner/repo — no SSH host, no colon
+    expect(createArg.name).toBe('myorg/myproject');
+    expect(createArg.name).not.toContain(':');
+    expect(createArg.name).not.toContain('@');
+  });
+
   // ── Command auto-loading ───────────────────────────────────────────────
   test('auto-loads markdown commands found in .archon/commands', async () => {
     spyExecFileAsync.mockImplementation((cmd: string, args: string[]) => {

--- a/packages/core/src/handlers/clone.ts
+++ b/packages/core/src/handlers/clone.ts
@@ -328,16 +328,20 @@ export async function registerRepository(localPath: string): Promise<RegisterRes
   let ownerName = '_local';
   if (remoteUrl) {
     const cleaned = remoteUrl.replace(/\.git$/, '').replace(/\/+$/, '');
-    let workingRemote = cleaned;
-    if (cleaned.startsWith('git@github.com:')) {
-      workingRemote = cleaned.replace('git@github.com:', 'https://github.com/');
-    }
-    const parts = workingRemote.split('/');
-    const r = parts.pop();
-    const o = parts.pop();
-    if (o && r) {
-      name = `${o}/${r}`;
-      ownerName = o;
+    // Handle any SSH git URL (git@host:owner/repo) by extracting just owner/repo.
+    // This avoids colons in worktree paths, which break Java classpaths on Unix.
+    const sshMatch = /^git@[^:]+:([^/]+)\/(.+)$/.exec(cleaned);
+    if (sshMatch) {
+      name = `${sshMatch[1]}/${sshMatch[2]}`;
+      ownerName = sshMatch[1];
+    } else {
+      const parts = cleaned.split('/');
+      const r = parts.pop();
+      const o = parts.pop();
+      if (o && r) {
+        name = `${o}/${r}`;
+        ownerName = o;
+      }
     }
   }
 


### PR DESCRIPTION
---
  Summary

  - Problem: registerRepository only normalized git@github.com: SSH URLs. Any other SSH host (GitLab, self-hosted) fell through to a generic path
  split, embedding the full SSH host (e.g. git@gitlab.example.com:org) as the codebase owner.
  - Why it matters: The colon in the stored name caused parseOwnerRepo() to return null (SAFE_NAME regex rejects @/:), making resolveProjectPaths()
  fall back to writing artifacts inside the worktree. The server then couldn't serve them → Web UI always showed "Artifact file not found". The same
  colon in the worktree path also breaks Java/Maven/Gradle classpath resolution on Unix.
  - What changed: registerRepository now matches any git@host:owner/repo SSH URL with a single regex, extracting only owner/repo and discarding the
  host. HTTPS and other URL formats use the existing path-split fallback unchanged.
  - What did not change: Existing codebase records in the DB are not migrated. Repos already registered with the broken name need a one-time manual
  UPDATE (documented in migration steps below).

  ---
  UX Journey

  Before

  User                    CLI / Server             DB / Filesystem
  ────                    ────────────             ───────────────
  registers repo ───────▶ registerRepository()
    (SSH URL)              splits on '/' only
                           owner = "git@host:org"  ──▶ name stored as
                                                        "git@host:org/repo"
  runs workflow ────────▶ resolveProjectPaths()
                           parseOwnerRepo() ──────▶ returns null (SAFE_NAME fails)
                           uses fallback path ─────▶ artifacts written to
                                                     {worktree}/.archon/artifacts/
  clicks artifact ──────▶ GET /api/artifacts/…
                           parseOwnerRepo() ──────▶ returns null
                           404 response ◀──────────
  sees "Artifact ◀───────
    file not found"

  (Java builds also fail: colon in worktree path acts as classpath separator)

  After

  User                    CLI / Server             DB / Filesystem
  ────                    ────────────             ───────────────
  registers repo ───────▶ registerRepository()
    (SSH URL)             [matches git@host:o/r]
                           owner = "org"           ──▶ name stored as
                                                        "org/repo"  ✓
  runs workflow ────────▶ resolveProjectPaths()
                           parseOwnerRepo() ──────▶ returns {owner, repo}  ✓
                           uses canonical path ────▶ artifacts written to
                                                     ~/.archon/workspaces/
                                                     org/repo/artifacts/  ✓
  clicks artifact ──────▶ GET /api/artifacts/…
                           parseOwnerRepo() ──────▶ returns {owner, repo}  ✓
                           reads file ────────────▶ 200 OK
  sees artifact ◀────────

  (Java builds work: no colon in worktree path)

  ---
  Architecture Diagram

  Before

  registerRepository()  ──▶  split('/') only
                              owner = "git@host:org"  ──▶  DB: name = "git@host:org/repo"
                                                                 │
                                                 ┌───────────────┘
                                                 ▼
  resolveProjectPaths()  ──▶  parseOwnerRepo("git@host:org/repo")  ──▶  null
                               fallback: {worktree}/.archon/artifacts/

  GET /api/artifacts/    ──▶  parseOwnerRepo("git@host:org/repo")  ──▶  null  ──▶  404

  After

  registerRepository()  ──▶  [~] regex: /^git@[^:]+:([^/]+)\/(.+)$/
                              owner = "org"  ──▶  DB: name = "org/repo"
                                                          │
                                          ┌───────────────┘
                                          ▼
  resolveProjectPaths()  ──▶  parseOwnerRepo("org/repo")  ──▶  {owner, repo}
                               canonical: ~/.archon/workspaces/org/repo/artifacts/  ✓

  GET /api/artifacts/    ──▶  parseOwnerRepo("org/repo")  ──▶  {owner, repo}  ──▶  200  ✓

  Connection inventory:

  ┌─────────────────────┬────────────────┬───────────┬───────────────────────────────────────┐
  │        From         │       To       │  Status   │                 Notes                 │
  ├─────────────────────┼────────────────┼───────────┼───────────────────────────────────────┤
  │ registerRepository  │ parseOwnerRepo │ unchanged │ now receives valid input              │
  ├─────────────────────┼────────────────┼───────────┼───────────────────────────────────────┤
  │ registerRepository  │ SSH URL regex  │ new       │ replaces GitHub-only special case     │
  ├─────────────────────┼────────────────┼───────────┼───────────────────────────────────────┤
  │ resolveProjectPaths │ parseOwnerRepo │ unchanged │ no longer hits fallback for SSH repos │
  ├─────────────────────┼────────────────┼───────────┼───────────────────────────────────────┤
  │ GET /api/artifacts  │ parseOwnerRepo │ unchanged │ no longer returns 404 for SSH repos   │
  └─────────────────────┴────────────────┴───────────┴───────────────────────────────────────┘

  ---
  Label Snapshot

  - Risk: risk: low
  - Size: size: XS
  - Scope: core
  - Module: core:clone

  ---
  Change Metadata

  - Change type: bug
  - Primary scope: core

  ---
  Linked Issue

  N/A

  ---
  Validation Evidence

  bun run type-check   ✓  all packages pass
  bun run lint         ✓  0 warnings
  bun run format:check ✓  no formatting issues
  bun run test         ✓  new test added and passes (45/45 in clone.test.ts)
                          3 pre-existing failures in core:connection (mock
                          pollution in full suite; pass in isolation — unrelated
                          to this change)

  Evidence: New regression test registerRepository > builds owner/repo name from non-GitHub SSH remote URL without colon in name — written to fail
  first, then fixed.

  ---
  Security Impact

  - New permissions/capabilities? No
  - New external network calls? No
  - Secrets/tokens handling changed? No
  - File system access scope changed? No

  ---
  Compatibility / Migration

  - Backward compatible? Yes — HTTPS URLs and git@github.com: SSH URLs are unaffected.
  - Config/env changes? No
  - Database migration needed? Yes, for repos already registered with the broken name.

  Upgrade steps for affected repos:

  -- Find affected records (name contains '@' or ':')
  SELECT id, name FROM remote_agent_codebases WHERE name LIKE '%@%' OR name LIKE '%:%';

  -- Fix each one (replace with correct owner/repo):
  UPDATE remote_agent_codebases
    SET name = '<org>/<repo>'
    WHERE id = '<id>';

  ---
  Human Verification

  - Confirmed file at {worktree}/.archon/artifacts/runs/{id}/issues/file.md was the fallback path for an SSH-registered repo
  - Confirmed parseOwnerRepo returned null for the stored name by tracing the SAFE_NAME regex
  - Confirmed the 3 connection test failures are pre-existing by running connection.test.ts in isolation (5 pass, 0 fail)

  Verified scenarios:
  - git@gitlab.example.com:myorg/myproject.git → name myorg/myproject ✓
  - git@github.com:acme/backend.git → name acme/backend (existing behaviour preserved) ✓
  - HTTPS URLs unchanged ✓

  Not verified: Re-registration flow after applying the DB migration on a live instance.

  ---
  Side Effects / Blast Radius

  - Affected subsystems: registerRepository only — called on first registration and auto-registration from CLI.
  - Potential unintended effects: Repos with a custom SSH host that intentionally used the full host as a namespace would get a different name on
  re-registration. No known case of this.
  - Guardrails: parseOwnerRepo continues to enforce SAFE_NAME — any name that can't be parsed falls back gracefully (no throw).

  ---
  Rollback Plan

  - Fast rollback: revert the single commit (git revert 4e4982e4)
  - Feature flags: none
  - Observable failure symptoms: codebase names containing @ or : in DB; "Artifact file not found" in Web UI for SSH-registered repos; Java build
  failures with classpath errors mentioning .archon/workspaces/

  ---
  Risks and Mitigations

  - Risk: Existing DB records with the broken name are not auto-migrated — affected users still see the bug until they run the SQL update.
  - Mitigation: Manual migration is simple and surgical (one UPDATE per affected codebase); documented above.