### PR TITLE
fix(setup): align PORT default on 3090 across .env.example, wizard, and JSDoc (#1152)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,7 +133,7 @@ GITEA_ALLOWED_USERS=
 # GITEA_BOT_MENTION=archon
 
 # Server
-PORT=3000
+# PORT=3090  # Default: 3090. Uncomment to override — must match between server and Vite proxy.
 # HOST=0.0.0.0  # Bind address (default: 0.0.0.0). Set to 127.0.0.1 to restrict to localhost only.
 
 # Cloud Deployment (for --profile cloud with Caddy reverse proxy)

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -46,7 +46,7 @@ TELEGRAM_BOT_TOKEN=123456789:ABC...
 # ============================================
 # Optional
 # ============================================
-PORT=3000
+PORT=3000  # Docker deployment default (the included compose/Caddy configs target :3000). For local dev (no Docker), omit PORT — server and Vite proxy both default to 3090.
 # TELEGRAM_STREAMING_MODE=stream
 # DISCORD_STREAMING_MODE=batch
 

--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -150,7 +150,9 @@ CODEX_ACCOUNT_ID=account1
       expect(content).toContain('# Using SQLite (default)');
       expect(content).toContain('CLAUDE_USE_GLOBAL_AUTH=true');
       expect(content).toContain('DEFAULT_AI_ASSISTANT=claude');
-      expect(content).toContain('PORT=3000');
+      // PORT is intentionally commented out — server and Vite both default to 3090 when unset (#1152).
+      expect(content).toContain('# PORT=3090');
+      expect(content).not.toMatch(/^PORT=/m);
       expect(content).not.toContain('DATABASE_URL=');
     });
 

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -1290,8 +1290,12 @@ export function generateEnvContent(config: SetupConfig): string {
   }
 
   // Server
+  // PORT is intentionally omitted: both the Hono server (packages/core/src/utils/port-allocation.ts)
+  // and the Vite dev proxy (packages/web/vite.config.ts) default to 3090 when unset, which keeps
+  // them in sync. Writing a fixed PORT here risked a mismatch if ~/.archon/.env leaks a PORT that
+  // the Vite proxy (which only reads repo-local .env) never sees — see #1152.
   lines.push('# Server');
-  lines.push('PORT=3000');
+  lines.push('# PORT=3090  # Default: 3090. Uncomment to override.');
   lines.push('');
 
   // Concurrency
@@ -1769,7 +1773,7 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
   // Additional options note
   note(
     'Other settings you can customize in ~/.archon/.env:\n' +
-      '  - PORT (default: 3000)\n' +
+      '  - PORT (default: 3090)\n' +
       '  - MAX_CONCURRENT_CONVERSATIONS (default: 10)\n' +
       '  - *_STREAMING_MODE (stream | batch per platform)\n\n' +
       'These defaults work well for most users.',

--- a/packages/core/src/utils/port-allocation.ts
+++ b/packages/core/src/utils/port-allocation.ts
@@ -30,7 +30,7 @@ export function calculatePortOffset(path: string): number {
  * Get the port for the Hono server
  * - If PORT env var is set: use it (explicit override, validated)
  * - If running in worktree: auto-allocate deterministic port based on path hash
- * - Otherwise: use default 3000
+ * - Otherwise: use default 3090 (matches the Vite proxy fallback in packages/web/vite.config.ts)
  *
  * Note: Exits process with code 1 if PORT env var is set but invalid (not 1-65535)
  */


### PR DESCRIPTION
## Summary

- **Problem**: Fresh installs can land in a silent port mismatch — server and Vite proxy reading different PORT sources end up on different ports. Web UI shows `Failed to load conversations/projects` with `ECONNREFUSED` in the Vite log. Reported in #1152.
- **Why it matters**: First-run DX on a clean machine is broken with no visible error pointing at PORT. The issue's RCA landed on the wrong root cause (claimed the server defaults to 3000 in code — it actually defaults to 3090 since the Hono migration in #318). Fixing the wrong layer re-introduces the bug; see #1159 for a concrete example.
- **What changed**: Drop the hardcoded `PORT=3000` from the wizard-generated `.env`, comment it out in `.env.example`, fix the stale JSDoc `"default 3000"` in `port-allocation.ts`, and update the wizard's "Additional Options" note. `deploy/.env.example` keeps `PORT=3000` (Docker compose/Caddy target it) but now carries a comment so someone copying it for local dev won't be silently misled.
- **What did NOT change (scope boundary)**: No change to `basePort` (still 3090, the current code default), no change to Vite's fallback (already 3090, correct), no change to the Hono server's dual-`.env` loading (`repo/.env` + `~/.archon/.env` with `override: true`). The underlying asymmetry (Hono reads both, Vite reads only repo-local) is discussed but intentionally left alone — narrowing the fix to the three drift points that are safe to align.

## UX Journey

### Before

```
Fresh clone, no .env, no prior `archon setup`:
  getPort()          → 3090 (code default)
  Vite loadEnv(...)  → 3090 (fallback)
                       → match  (the issue's described break case actually works here)

After `archon setup` (which writes PORT=3000 to ~/.archon/.env):
  User                  Hono server                Vite proxy
  ────                  ───────────                ──────────
  bun run dev ─────▶    loads repo/.env (missing)
                        loads ~/.archon/.env ─▶ PORT=3000 wins
                        binds :3000
                                                   loadEnv(repo) → no PORT
                                                   fallback → :3090
                                                   proxies /api → :3090
                        listening :3000 ◀─ X ── proxies /api → :3090 (ECONNREFUSED)
  "Failed to load conversations/projects" ◀──────── API 500s
```

### After

```
Fresh clone, no .env, post-fix:
  getPort()          → 3090  (code default, unchanged)
  Vite loadEnv(...)  → 3090  (fallback, unchanged)
                       → match

After `archon setup`, post-fix:
  User                  Hono server                Vite proxy
  ────                  ───────────                ──────────
  bun run dev ─────▶    loads repo/.env  [no PORT line now]
                        loads ~/.archon/.env  [no PORT line now]
                        getPort() → 3090
                        binds :3090
                                                   loadEnv(repo) → no PORT
                                                   fallback → :3090
                                                   proxies /api → :3090
                        listening :3090 ◀────────── proxies /api → :3090
  Web UI loads ◀──────── API 200
```

## Architecture Diagram

### Before

```
.env.example ────────── PORT=3000 ─────────┐
                                            │ (four independent
setup wizard ──── writes PORT=3000 ────────┤  "default PORT" sources,
                    into .env + ~/.archon/ │  free to drift)
                                            │
port-allocation.ts ── basePort = 3090 ─────┤
                    JSDoc says "3000"       │
                                            │
vite.config.ts ── fallback '3090' ─────────┘
```

### After

```
port-allocation.ts ── basePort = 3090   (AUTHORITATIVE)
                    JSDoc says "3090"   [~]

.env.example ─────────── # PORT=3090    [~] (commented, defers to code)
setup wizard (.env)  ─── # PORT=3090    [~] (commented, defers to code)
vite.config.ts ──────── fallback '3090'     (unchanged)
deploy/.env.example ──── PORT=3000          (Docker-only, now annotated) [~]
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| .env.example | user `.env` | **modified** | PORT line commented out |
| setup wizard | generated `.env` (repo + ~/.archon) | **modified** | no longer writes PORT= |
| setup wizard | "Additional Options" note | **modified** | says 3090 instead of 3000 |
| port-allocation.ts JSDoc | reader expectations | **modified** | 3000 → 3090 |
| deploy/.env.example | Docker compose/Caddy | unchanged | still 3000, now documented why |
| vite.config.ts | `apiPort` | unchanged | fallback stays 3090 |
| port-allocation.ts | `getPort()` | unchanged | basePort stays 3090 |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `cli` `config` `docs`
- Module: `cli:setup`, `core:port-allocation`

## Change Metadata

- Change type: `bug`
- Primary scope: `cli`

## Linked Issue

- Closes #1152
- Related #1159 (alternative direction — takes the opposite approach and has a confirmed regression; see the review on that PR)
- Related #318 (Hono migration — when `basePort` became 3090)

## Validation Evidence (required)

```bash
bun run type-check                  # all 10 packages pass
bun run lint --max-warnings 0       # pass
bun run format:check                # pass
bun --filter @archon/cli test       # 79 pass, 0 fail
bun --filter @archon/core test      # all pass
```

**E2E verified on this branch** (with `.env` temporarily removed, fresh-clone scenario):

```
Server log:  {"port":3090,"msg":"server_listening"}
             {"port":3090,"msg":"default_port_selected"}
Vite log:    VITE v6.4.1  ready on http://localhost:5173/

$ curl http://localhost:3090/api/health       → 200
$ curl http://localhost:5173/api/health       → 200  (proxy reached server)
```

Pre-existing failing test in `packages/workflows/src/defaults/bundled-defaults.test.ts` is unrelated — caused by an untracked `.archon/workflows/defaults/archon-feedback.yaml` in my local working tree, not by any change in this PR.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes` — existing users with `PORT=3000` explicitly set in their `.env` keep that behavior (explicit PORT always wins at server and Vite). Only unset/new installs switch to 3090.
- Config/env changes? `Yes` — `.env.example` default commented out. Existing `.env` files on disk are untouched.
- Database migration needed? `No`
- Upgrade steps: none required. Users with stale `~/.archon/.env` from an earlier `archon setup` continue to work; the explicit `PORT=3000` there still takes effect. To move onto the 3090 default they can delete the `PORT=` line.

## Human Verification (required)

- **Verified scenarios**:
  - Fresh clone, no `.env` anywhere: server binds 3090, Vite proxies 5173 → 3090, `/api/health` returns 200 through the proxy.
  - `@archon/cli` tests pass with the updated `generateEnvContent` assertions.
  - Diffed the three edits against the Hono-migration commit (#318) to confirm 3090 has been the authoritative default since that change landed.
- **Edge cases checked**:
  - User with explicit `PORT=3000` in `.env` — unchanged (explicit value wins at both server and Vite).
  - User copies `deploy/.env.example` to repo root — now sees the comment explaining it is a Docker default.
- **What was NOT verified**:
  - Full `bun run validate` was blocked by a pre-existing bundled-defaults drift unrelated to this change (an untracked file in my local tree); the individual validation steps all pass.
  - No Docker E2E run (out of scope — `deploy/.env.example` is a text-only change).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows:
  - `archon setup` wizard output (`.env` generation) — no longer writes an explicit PORT line by default.
  - Local dev first-run on a fresh clone — now defaults cleanly on 3090.
  - `.env.example` read by anyone copying it as a starting point — they no longer start on 3000 unless they uncomment.
- Potential unintended effects:
  - A user who was relying on the wizard defaulting to 3000 without noticing will now default to 3090 on new generations. Explicit users are unaffected.
- Guardrails/monitoring for early detection:
  - The updated `setup.test.ts` asserts both positive (`# PORT=3090` present) and negative (no uncommented `PORT=` line) conditions — catches any regression that reintroduces a hardcoded PORT.

## Rollback Plan (required)

- Fast rollback: `git revert <merge-sha>` — commit is small and self-contained.
- Feature flags: none.
- Observable failure symptoms: if any user reports a post-rollback port mismatch after a recent `archon setup`, check whether their `~/.archon/.env` still has `PORT=3000` written by a pre-revert wizard run.

## Risks and Mitigations

- **Risk**: Users with an existing stale `~/.archon/.env` containing `PORT=3000` (from a prior wizard run) continue to see server bind on 3000 while Vite proxies to 3090 — the original bug persists for them.
  - **Mitigation**: Called out explicitly in the issue follow-up and in the migration section above. A dedicated wizard migration could rewrite stale globals but would need to modify user files during a read-mostly run — not justified for this scope. The current fix stops the *flow* from creating new broken installs; existing broken installs can remove the `PORT=` line from their global `.env`.

- **Risk**: Downstream docs might still reference `:3000` as "the" default.
  - **Mitigation**: Scanned the repo — `packages/docs-web/src/content/docs/` already documents the 3090-local / 3000-Docker split correctly (via #318 follow-ups). No further doc changes needed in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default server port from 3000 to 3090. Users without explicit `PORT` configuration will automatically use the new default. If you previously relied on port 3000, you may need to adjust your environment configuration or explicitly set `PORT=3000` in your `.env` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->