### PR TITLE
fix(docker): create /.archon subdirs in entrypoint for bind mounts (#1260)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# Ensure required subdirectories exist.
+# Named volumes inherit these from the image layer on first run; bind mounts do not,
+# which causes the Claude subprocess to fail silently when spawned with a missing cwd.
+mkdir -p /.archon/workspaces /.archon/worktrees
+
 # Determine if we need to use gosu for privilege dropping
 if [ "$(id -u)" = "0" ]; then
   # Running as root: fix volume permissions, then drop to appuser


### PR DESCRIPTION
## Summary

Fixes #1260 — Docker bind mounts break startup because `/.archon/workspaces` does not exist inside the container, causing the Claude subprocess to spawn with a missing cwd and silently time out after 60s.

## Root Cause

- The Dockerfile creates `/.archon/workspaces` and `/.archon/worktrees` via `RUN mkdir -p` (Dockerfile:125).
- Named volumes inherit these directories from the image layer on first run, so the app works out of the box.
- Bind mounts replace the image-layer content with the host directory, so the subdirectories are never created — `orchestrator-agent.ts` then spawns Claude with a non-existent cwd and the SDK fails silently.

## Fix

Add `mkdir -p /.archon/workspaces /.archon/worktrees` at the top of `docker-entrypoint.sh` (before the `chown`). This is:
- **Idempotent** — no-op on named volumes where the dirs already exist
- **Minimal** — 1 line of behavior, 3 lines of comment explaining the why
- **Correct timing** — runs before `chown -Rh appuser:appuser /.archon`, so freshly-created dirs get the right ownership

## Test Plan

- [ ] `docker compose up -d` with `ARCHON_DATA` unset (named volume): app starts, messages get responses (no regression)
- [ ] `docker compose up -d` with `ARCHON_DATA=/some/empty/host/path` (bind mount): app starts, sending "hi" in the Web UI gets a response (previously timed out)
- [ ] Verify `/.archon/workspaces` and `/.archon/worktrees` exist inside the container and are owned by `appuser` in both cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker startup initialization to ensure proper directory structure creation before application startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->