### PR TITLE
refactor(providers/pi): drop rot-prone file:line refs from Pi comments

### DIFF
--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -118,12 +118,11 @@ export class PiProvider implements IAgentProvider {
     //    the file directly (api_key entries) is picked up transparently.
     //
     //    Per-request env vars override the file via setRuntimeApiKey — this
-    //    mirrors Claude's `{...subprocessEnv, ...requestOptions.env}` pattern
-    //    at packages/providers/src/claude/provider.ts:889-890 and ensures
-    //    codebase-scoped env vars (from .archon/config.yaml `env:`) win over
-    //    the user's global Pi login.
+    //    mirrors Claude's process-env + request-env merge pattern and
+    //    ensures codebase-scoped env vars (from .archon/config.yaml `env:`)
+    //    win over the user's global Pi login.
     //
-    //    Pi's internal resolution order (auth-storage.ts:424-485):
+    //    Pi's internal resolution order:
     //      1. runtime override  (our setRuntimeApiKey below)
     //      2. auth.json api_key entry
     //      3. auth.json oauth entry  (auto-refreshes expired tokens)
@@ -200,8 +199,8 @@ export class PiProvider implements IAgentProvider {
     //    returns a SessionManager bound to either a new session (no resume
     //    id) or an existing session (resume id matches a file); if the id
     //    was provided but not found, it falls through to a new session and
-    //    the caller surfaces a resume_failed warning (matches Codex pattern
-    //    at packages/providers/src/codex/provider.ts:553-558).
+    //    the caller surfaces a resume_failed warning (matches the Codex
+    //    provider's fallback pattern for the same condition).
     const { sessionManager, resumeFailed } = await resolvePiSession(cwd, resumeSessionId);
     if (resumeFailed) {
       yield {

--- a/packages/providers/src/community/pi/session-resolver.ts
+++ b/packages/providers/src/community/pi/session-resolver.ts
@@ -9,8 +9,8 @@ export interface ResolvedSession {
   /**
    * True when a resumeSessionId was provided but no matching session file
    * was found — caller should surface a system warning before the new
-   * session starts (mirrors Codex's resume_thread_failed fallback at
-   * packages/providers/src/codex/provider.ts:553-558).
+   * session starts. Mirrors the `resume_thread_failed` fallback pattern
+   * the Codex provider uses.
    */
   resumeFailed: boolean;
 }


### PR DESCRIPTION
## Summary

Follow-up to #1270. The multi-agent review on #1271 flagged the CLAUDE.md comment rule ("don't embed paths/callers that rot as the codebase evolves"). The rule applies equally to three spots in the just-merged Pi provider that embed `packages/.../provider.ts:N-M` line ranges.

## Changes

Three inline comments in \`packages/providers/src/community/pi/\`:
- \`session-resolver.ts\` — ResolvedSession's \`resumeFailed\` JSDoc
- \`provider.ts\` — Claude auth-merge reference (line ~122)
- \`provider.ts\` — Codex fallback reference (line ~204)
- \`provider.ts\` — upstream Pi \`auth-storage.ts:424-485\` ref

Each drops the fragile line numbers and file paths while keeping the conceptual cross-reference ("mirrors Claude's process-env + request-env merge pattern", "matches the Codex provider's fallback pattern", etc.) — that's the load-bearing part of the comment.

## Why

Line numbers drift the moment the referenced files change. The Claude and Codex providers are both under active evolution; the Pi provider doesn't benefit from pinning line ranges at a specific snapshot.

## Test plan

- [x] \`bun run validate\` passes (no behavior change; comment-only refactor).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation comments for the Pi provider to clarify environment variable merge patterns and credential resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->