### PR TITLE
Fix pr-maintenance cron — prepend user bins to PATH so archon is found

### DIFF
--- a/scripts/pr-maintenance-cron.sh
+++ b/scripts/pr-maintenance-cron.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# pr-maintenance-cron.sh — Run from cron every 15 minutes.
+# Zero AI cost when nothing to do. Processes one PR per project per run.
+#
+# Usage:
+#   ./scripts/pr-maintenance-cron.sh                    # all projects
+#   ./scripts/pr-maintenance-cron.sh cosmic-match reli  # specific projects
+#
+# Crontab entry:
+#   */15 * * * * /mnt/ext-fast/archon/scripts/pr-maintenance-cron.sh >> /tmp/pr-maintenance.log 2>&1
+
+set -euo pipefail
+
+# Cron runs with a minimal PATH (/usr/bin:/bin). archon, gh, bun, git
+# often live in user-local bins; prepend them so the script works from
+# both cron and an interactive shell.
+export PATH="$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin:$PATH"
+
+# --- Configuration ---
+DEFAULT_PROJECTS=(cosmic-match word-coach-annie filmduel reli beads)
+BASE_DIR="/mnt/ext-fast"
+LOG_PREFIX="[pr-maintenance]"
+
+# Use arguments if provided, otherwise all projects
+if [ $# -gt 0 ]; then
+  PROJECTS=("$@")
+else
+  PROJECTS=("${DEFAULT_PROJECTS[@]}")
+fi
+
+log() { echo "$(date -Is) $LOG_PREFIX $*"; }
+
+for PROJECT in "${PROJECTS[@]}"; do
+  REPO_DIR="$BASE_DIR/$PROJECT"
+
+  if [ ! -d "$REPO_DIR/.git" ]; then
+    log "$PROJECT: not a git repo, skipping"
+    continue
+  fi
+
+  cd "$REPO_DIR"
+
+  # --- Phase 1: Merge CLEAN PRs directly (bash only, zero AI cost) ---
+  CLEAN_PRS=$(gh pr list --state open --json number,mergeStateStatus,isDraft \
+    --jq '[.[] | select(.isDraft == false and .mergeStateStatus == "CLEAN")] | .[].number' 2>/dev/null || true)
+
+  for PR in $CLEAN_PRS; do
+    log "$PROJECT: PR #$PR is CLEAN — merging directly"
+    gh pr merge "$PR" --squash --auto --delete-branch 2>/dev/null \
+      || gh pr merge "$PR" --squash --delete-branch 2>/dev/null \
+      || log "$PROJECT: PR #$PR — could not merge, skipping"
+  done
+
+  # --- Phase 2: Check for one PR needing AI attention ---
+  ACTIONABLE=$(gh pr list --state open --json number,mergeStateStatus,isDraft \
+    --jq '[.[] | select(.isDraft == false and (.mergeStateStatus == "BEHIND" or .mergeStateStatus == "DIRTY" or .mergeStateStatus == "UNSTABLE" or .mergeStateStatus == "UNKNOWN"))] | .[0].number // empty' 2>/dev/null || true)
+
+  if [ -z "$ACTIONABLE" ]; then
+    log "$PROJECT: no PRs need AI maintenance"
+    continue
+  fi
+
+  log "$PROJECT: PR #$ACTIONABLE needs maintenance — launching archon"
+  archon workflow run archon-pr-maintenance --cwd "$REPO_DIR" "PR #$ACTIONABLE" &
+
+done
+
+# Wait for any background archon runs to complete
+wait
+log "Done"


### PR DESCRIPTION
## Summary
Cron runs with a minimal PATH (`/usr/bin:/bin`). The PR-maintenance script tries to invoke `archon` (installed at `~/.bun/bin/archon`) and dies with:
```
/mnt/ext-fast/archon/scripts/pr-maintenance-cron.sh: line 59: archon: command not found
```

Every maintenance run silently failed to launch archon on DIRTY / BEHIND / UNKNOWN PRs. Backlog in cosmic-match grew to 16+ open PRs because nothing was resolving conflicts.

Fix: prepend `$HOME/.bun/bin`, `$HOME/.local/bin`, and `/usr/local/bin` to `PATH` at the top of the script.

## Test plan
- [ ] `crontab -e` → let the existing `*/15 * * * *` trigger run once.
- [ ] `/tmp/pr-maintenance.log` no longer contains `command not found`.
- [ ] Archon runs start picking up DIRTY PRs again; `ps aux | grep archon-pr-maintenance` shows activity after a cron fire.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Archon CLI Homebrew formula to version 0.3.6 with updated binary checksums for macOS (ARM64, Intel) and Linux (ARM64, x64) platforms.
  * Added new operational tooling for pull request maintenance automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->