### PR TITLE
feat(pi): Use ModelRegistry & allow empty auth to support custom models/providers.

### DIFF
--- a/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
+++ b/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
@@ -229,7 +229,7 @@ DEFAULT_AI_ASSISTANT=codex
 
 ## Pi (Community Provider)
 
-**One adapter, ~20 LLM backends.** Pi (`@mariozechner/pi-coding-agent`) is a community-maintained coding-agent harness that Archon integrates as the first community provider. It unlocks Anthropic, OpenAI, Google (Gemini + Vertex), Groq, Mistral, Cerebras, xAI, OpenRouter, Hugging Face, and more under a single `provider: pi` entry.
+**One adapter, ~20 LLM backends.** Pi (`@mariozechner/pi-coding-agent`) is a community-maintained coding-agent harness that Archon integrates as the first community provider. It unlocks Anthropic, OpenAI, Google (Gemini + Vertex), Groq, Mistral, Cerebras, xAI, OpenRouter, Hugging Face, and local inference (LM Studio, ollama, llamacpp, custom OpenAI-compatible endpoints registered in `~/.pi/agent/models.json`) under a single `provider: pi` entry.
 
 Pi is registered as `builtIn: false` — it validates the community-provider seam rather than being a core-team-maintained option. If it proves stable and valuable it may be promoted to `builtIn: true` later.
 
@@ -262,7 +262,20 @@ Pi supports both OAuth subscriptions and API keys. Archon's adapter reads your e
 | `openrouter` | `OPENROUTER_API_KEY` |
 | `huggingface` | `HUGGINGFACE_API_KEY` |
 
-Additional Pi backends exist (Azure, Bedrock, Vertex, etc.) — file an issue if you need them wired.
+Additional cloud backends exist (Azure, Bedrock, Vertex, etc.) — file an issue if you need an env-var shortcut wired for them.
+
+**Local / custom providers (no credentials needed):**
+
+Providers that aren't in the env-var table above (LM Studio, ollama, llamacpp, custom OpenAI-compatible endpoints) work without any Archon-side configuration. Register them in `~/.pi/agent/models.json` per Pi's own docs and reference them as `<pi-provider-id>/<model-id>`:
+
+```yaml
+# .archon/config.yaml
+assistants:
+  pi:
+    model: lm-studio/qwen2.5-coder-14b   # whatever ID you registered with Pi
+```
+
+Archon logs an info-level `pi.auth_missing` event when no credentials are found and continues — Pi's SDK then connects directly to the local endpoint defined in `models.json`. If the provider does require auth (a less-common cloud backend not in the env-var table) the SDK call fails downstream; the `pi.auth_missing` breadcrumb in the log lets you trace it back to a missing env-var mapping.
 
 ### Extensions (on by default)
 

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -81,7 +81,14 @@ const mockAuthCreate = mock(() => ({
   setRuntimeApiKey: mockSetRuntimeApiKey,
   getApiKey: mockGetApiKey,
 }));
-const mockModelRegistryInMemory = mock(() => ({}));
+
+const mockModelRegistryFind = mock((provider: string, modelId: string) => {
+  if (provider === 'nonexistent') return undefined;
+  return { id: modelId, provider, name: `${provider}/${modelId}` };
+});
+const mockModelRegistryCreate = mock(() => ({
+  find: mockModelRegistryFind,
+}));
 
 // SessionManager mocks. Each returns a tagged session-manager stub so tests
 // can assert whether resume resolved to an existing session or fell through
@@ -115,7 +122,7 @@ const mockCreateLsTool = mock((_cwd: string) => ({ __piTool: 'ls' }));
 mock.module('@mariozechner/pi-coding-agent', () => ({
   createAgentSession: mockCreateAgentSession,
   AuthStorage: { create: mockAuthCreate },
-  ModelRegistry: { inMemory: mockModelRegistryInMemory },
+  ModelRegistry: { create: mockModelRegistryCreate },
   SessionManager: {
     create: mockSessionCreate,
     open: mockSessionOpen,
@@ -130,16 +137,6 @@ mock.module('@mariozechner/pi-coding-agent', () => ({
   createGrepTool: mockCreateGrepTool,
   createFindTool: mockCreateFindTool,
   createLsTool: mockCreateLsTool,
-}));
-
-// getModel is imported from pi-ai. Return a fake model for known refs and
-// undefined for unknown refs so the provider's not-found branch is testable.
-const mockGetModel = mock((provider: string, modelId: string) => {
-  if (provider === 'nonexistent') return undefined;
-  return { id: modelId, provider, name: `${provider}/${modelId}` };
-});
-mock.module('@mariozechner/pi-ai', () => ({
-  getModel: mockGetModel,
 }));
 
 // Import AFTER mocks are set — module resolution freezes the mocks.
@@ -169,6 +166,12 @@ function resetScript(events: FakeEvent[]): void {
 
 describe('PiProvider', () => {
   beforeEach(() => {
+    mockLogger.fatal.mockClear();
+    mockLogger.error.mockClear();
+    mockLogger.warn.mockClear();
+    mockLogger.info.mockClear();
+    mockLogger.debug.mockClear();
+    mockLogger.trace.mockClear();
     mockPrompt.mockClear();
     mockAbort.mockClear();
     mockDispose.mockClear();
@@ -177,8 +180,9 @@ describe('PiProvider', () => {
     mockSetFlagValue.mockClear();
     mockResourceLoaderReload.mockClear();
     mockCreateAgentSession.mockClear();
-    mockGetModel.mockClear();
     mockAuthCreate.mockClear();
+    mockModelRegistryCreate.mockClear();
+    mockModelRegistryFind.mockClear();
     mockSetRuntimeApiKey.mockClear();
     mockGetApiKey.mockClear();
     MockDefaultResourceLoader.mockClear();
@@ -236,15 +240,21 @@ describe('PiProvider', () => {
     expect(error?.message).toContain('Invalid Pi model ref');
   });
 
-  test('throws when Pi provider id is unknown AND no creds available', async () => {
-    // No env var, no auth.json entry → fail-fast with hint about env-var table
+  test('logs credential hint when Pi provider id is unknown AND no creds available', async () => {
+    // No env var, no auth.json entry → log hint, but continue, to support custom providers that don't use credentials or that use non-Pi means of providing credentials.
+    resetScript(scriptedAgentEnd());
     const { error } = await consume(
       new PiProvider().sendQuery('hi', '/tmp', undefined, {
         model: 'unknownprovider/some-model',
       })
     );
-    expect(error?.message).toContain("no credentials for provider 'unknownprovider'");
-    expect(error?.message).toContain("not in the Archon adapter's env-var table");
+
+    expect(error).toBeUndefined();
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { piProvider: 'unknownprovider' },
+      expect.stringContaining("not in the Archon adapter's env-var table")
+    );
+    expect(mockCreateAgentSession).toHaveBeenCalledTimes(1);
   });
 
   test('throws when env var missing AND auth.json has no entry', async () => {
@@ -295,13 +305,13 @@ describe('PiProvider', () => {
     expect(mockGetApiKey).toHaveBeenCalledWith('anthropic');
   });
 
-  test('throws when getModel returns undefined', async () => {
+  test('throws when ModelRegistry.find returns undefined', async () => {
     process.env.GEMINI_API_KEY = 'sk-test';
-    // 'nonexistent' is handled in mockGetModel to return undefined, but
-    // the adapter rejects unknown providers before getModel. To exercise
+    // 'nonexistent' is handled in mockModelRegistryFind to return undefined, but
+    // the adapter rejects unknown providers. To exercise
     // the not-found branch, use a known provider but unknown modelId by
-    // temporarily swapping mockGetModel to always return undefined.
-    mockGetModel.mockImplementationOnce(() => undefined);
+    // temporarily swapping mockModelRegistryFind to always return undefined.
+    mockModelRegistryFind.mockImplementationOnce(() => undefined);
     const { error } = await consume(
       new PiProvider().sendQuery('hi', '/tmp', undefined, {
         model: 'google/unknown-model-id',

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -253,11 +253,89 @@ describe('PiProvider', () => {
     expect(mockLogger.info).toHaveBeenCalledWith(
       {
         piProvider: 'unknownprovider',
-        msg: expect.stringContaining("not in the Archon adapter's env-var table"),
+        envHint: expect.stringContaining("not in the Archon adapter's env-var table"),
+        loginHint: expect.stringContaining('/login'),
       },
       'pi.auth_missing'
     );
     expect(mockCreateAgentSession).toHaveBeenCalledTimes(1);
+  });
+
+  test('ModelRegistry.create receives the AuthStorage instance', async () => {
+    // Headline-fix wiring: ModelRegistry.create must receive the same
+    // AuthStorage instance returned by AuthStorage.create(), so registry
+    // lookups can resolve user-configured custom models from
+    // ~/.pi/agent/models.json (LM Studio, ollama, llamacpp, etc.). Without
+    // this wiring the registry only sees the static built-in catalog.
+    process.env.GEMINI_API_KEY = 'sk-test';
+    resetScript(scriptedAgentEnd());
+
+    await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, {
+        model: 'google/gemini-2.5-pro',
+      })
+    );
+
+    expect(mockAuthCreate).toHaveBeenCalledTimes(1);
+    expect(mockModelRegistryCreate).toHaveBeenCalledTimes(1);
+    const authInstance = mockAuthCreate.mock.results[0]?.value;
+    expect(mockModelRegistryCreate).toHaveBeenCalledWith(authInstance);
+  });
+
+  test('AuthStorage.create() throwing surfaces a contextualized error', async () => {
+    // Both AuthStorage.create() and ModelRegistry.create() read from disk
+    // and can throw on malformed JSON or filesystem errors. Wrap with
+    // try/catch and surface a Pi-framed error so operators see the cause
+    // rather than a raw SDK stack trace.
+    mockAuthCreate.mockImplementationOnce(() => {
+      throw new Error('Unexpected token } in JSON at position 42');
+    });
+
+    const { error } = await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, {
+        model: 'google/gemini-2.5-pro',
+      })
+    );
+
+    expect(error).toBeDefined();
+    expect(error?.message).toContain('Pi auth storage init failed');
+    expect(error?.message).toContain('Unexpected token');
+    expect(error?.message).toContain('~/.pi/agent/auth.json');
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ piProvider: 'google' }),
+      'pi.auth_storage_init_failed'
+    );
+  });
+
+  test('Pi model not found includes models.json load error when registry reports one', async () => {
+    // ModelRegistry swallows models.json parse/validation errors into an
+    // internal loadError. When find() returns undefined we surface that
+    // error in both the structured log and the throw message so users
+    // debugging a custom-provider config see the actual reason.
+    process.env.GEMINI_API_KEY = 'sk-test';
+    mockModelRegistryFind.mockImplementationOnce(() => undefined);
+    mockModelRegistryCreate.mockImplementationOnce(() => ({
+      find: mockModelRegistryFind,
+      getError: () => 'Provider lm-studio: "baseUrl" is required when defining custom models.',
+    }));
+
+    const { error } = await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, {
+        model: 'lm-studio/some-model',
+      })
+    );
+
+    expect(error?.message).toContain('Pi model not found');
+    expect(error?.message).toContain('models.json failed to load');
+    expect(error?.message).toContain('"baseUrl" is required');
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        piProvider: 'lm-studio',
+        modelId: 'some-model',
+        loadError: expect.stringContaining('"baseUrl" is required'),
+      }),
+      'pi.model_not_found'
+    );
   });
 
   test('throws when env var missing AND auth.json has no entry', async () => {

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -251,8 +251,11 @@ describe('PiProvider', () => {
 
     expect(error).toBeUndefined();
     expect(mockLogger.info).toHaveBeenCalledWith(
-      { piProvider: 'unknownprovider' },
-      expect.stringContaining("not in the Archon adapter's env-var table")
+      {
+        piProvider: 'unknownprovider',
+        msg: expect.stringContaining("not in the Archon adapter's env-var table"),
+      },
+      'pi.auth_missing'
     );
     expect(mockCreateAgentSession).toHaveBeenCalledTimes(1);
   });

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -140,15 +140,7 @@ ${JSON.stringify(schema, null, 2)}`;
 /**
  * Pi community provider — wraps `@mariozechner/pi-coding-agent`'s full
  * coding-agent harness. Each `sendQuery()` call creates a fresh session
- * (no reuse) with in-memory auth/session/settings, so the server never
- * touches `~/.pi/` and concurrent calls don't collide.
- *
- * Capabilities (see `capabilities.ts` for the canonical list): Pi declares
- * `sessionResume`, `skills`, `toolRestrictions`, `structuredOutput`,
- * `envInjection`, `effortControl`, and `thinkingControl`. Features Pi does
- * not currently support through Archon (`mcp`, `hooks`, `agents`,
- * `costControl`, `fallbackModel`, `sandbox`) stay off; the dag-executor
- * surfaces a warning for any unsupported nodeConfig field.
+ * (no reuse) so concurrent calls don't collide.
  */
 export class PiProvider implements IAgentProvider {
   async *sendQuery(
@@ -174,7 +166,6 @@ export class PiProvider implements IAgentProvider {
     // destructured PascalCase bindings trip eslint's naming-convention rule.
     const [
       piCodingAgent,
-      piAi,
       { bridgeSession },
       { resolvePiSkills, resolvePiThinkingLevel, resolvePiTools },
       { createNoopResourceLoader },
@@ -182,7 +173,6 @@ export class PiProvider implements IAgentProvider {
       { createArchonUIBridge, createArchonUIContext },
     ] = await Promise.all([
       import('@mariozechner/pi-coding-agent'),
-      import('@mariozechner/pi-ai'),
       import('./event-bridge'),
       import('./options-translator'),
       import('./resource-loader'),
@@ -227,10 +217,12 @@ export class PiProvider implements IAgentProvider {
       );
     }
 
-    // 2. Look up the Model via Pi's static catalog. `lookupPiModel` returns
+    const authStorage = piCodingAgent.AuthStorage.create();
+    const modelRegistry = piCodingAgent.ModelRegistry.create(authStorage);
+    // 2. Look up the Model via Pi's Registry. `lookupPiModel` returns
     //    undefined when not found; we guard explicitly below.
     // Cast to the runtime-string-friendly shape — see `lookupPiModel`'s docblock.
-    const model = lookupPiModel(piAi.getModel as GetModelFn, parsed.provider, parsed.modelId);
+    const model = lookupPiModel(modelRegistry.find as GetModelFn, parsed.provider, parsed.modelId);
     if (!model) {
       throw new Error(
         `Pi model not found: provider='${parsed.provider}' model='${parsed.modelId}'. ` +
@@ -258,7 +250,6 @@ export class PiProvider implements IAgentProvider {
     //    OAuth refresh note: Pi refreshes expired access tokens against the
     //    provider's OAuth server and rewrites ~/.pi/agent/auth.json under a
     //    file lock (same mechanism pi CLI uses — safe for concurrent access).
-    const authStorage = piCodingAgent.AuthStorage.create();
 
     const envVarName = PI_PROVIDER_ENV_VARS[parsed.provider];
     const envOverride = envVarName
@@ -268,16 +259,22 @@ export class PiProvider implements IAgentProvider {
       authStorage.setRuntimeApiKey(parsed.provider, envOverride);
     }
 
-    // Fail-fast: resolve creds synchronously before spinning up a session.
-    // Matches Claude's auth-error fast-fail pattern (no retry on auth failures).
     const resolvedKey = await authStorage.getApiKey(parsed.provider);
     if (!resolvedKey) {
-      const envHint = envVarName
-        ? `Set ${envVarName} in the environment or codebase env vars (.archon/config.yaml env: section).`
-        : `Provider '${parsed.provider}' is not in the Archon adapter's env-var table — file an issue if you want a shortcut env var for it.`;
+      if (envVarName) {
+        const envHint = `Set ${envVarName} in the environment or codebase env vars (.archon/config.yaml env: section).`;
+        const loginHint = `Or run \`pi\` and type \`/login\` locally to authenticate '${parsed.provider}' via OAuth; credentials land in ~/.pi/agent/auth.json and are picked up automatically.`;
+        throw new Error(
+          `Pi auth: no credentials for provider '${parsed.provider}'. ${envHint} ${loginHint}`
+        );
+      }
+
+      const envHint = `Provider '${parsed.provider}' is not in the Archon adapter's env-var table — file an issue if you want a shortcut env var for it.`;
       const loginHint = `Or run \`pi\` and type \`/login\` locally to authenticate '${parsed.provider}' via OAuth; credentials land in ~/.pi/agent/auth.json and are picked up automatically.`;
-      throw new Error(
-        `Pi auth: no credentials for provider '${parsed.provider}'. ${envHint} ${loginHint}`
+      // No credentials for unmapped providers is not necessarily a problem, e.g., local models.
+      getLog().info(
+        { piProvider: parsed.provider },
+        `No Pi credentials found for provider. ${envHint} ${loginHint}`
       );
     }
 
@@ -343,13 +340,12 @@ export class PiProvider implements IAgentProvider {
       };
     }
 
-    // ModelRegistry + settings stay in-memory — only sessions persist, to
-    // match Claude/Codex. Resource loader still suppresses filesystem
-    // discovery by default, except for explicitly-passed skill paths and —
+    // Settings stay in-memory — only sessions persist, to match Claude/Codex.
+    // Resource loader still suppresses filesystem and —
     // when piConfig.enableExtensions is true — Pi's community extension
     // ecosystem (tools + lifecycle hooks from ~/.pi/agent/extensions/ and
     // packages installed via `pi install npm:<pkg>`).
-    const modelRegistry = piCodingAgent.ModelRegistry.inMemory(authStorage);
+    // discovery except for explicitly-passed skill paths.
     const settingsManager = piCodingAgent.SettingsManager.inMemory();
     // Default ON: extensions (community packages like @plannotator/pi-extension
     // or your own local ones) are a core reason users run Pi. Opt out with

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -198,39 +198,74 @@ export class PiProvider implements IAgentProvider {
       );
     }
 
-    const authStorage = piCodingAgent.AuthStorage.create();
-    const modelRegistry = piCodingAgent.ModelRegistry.create(authStorage);
-    // 2. Look up the Model via Pi's Registry. `modelRegistry.find` returns
-    //    undefined when not found; we guard explicitly below.
+    // 2. Build AuthStorage + ModelRegistry. Both `create()` calls read from
+    //    disk: AuthStorage reads ~/.pi/agent/auth.json (or
+    //    $PI_CODING_AGENT_DIR/auth.json), and ModelRegistry reads
+    //    ~/.pi/agent/models.json — the user's per-host config including
+    //    custom models for local providers (LM Studio, ollama, llamacpp,
+    //    custom OpenAI-compatible endpoints). Reads are synchronous and
+    //    happen on every sendQuery; we don't cache because the user can
+    //    edit either file between calls and expects pickup without restart
+    //    (Pi's `/login` flow rewrites auth.json under a file lock).
+    //    ModelRegistry captures any models.json load/parse error in its
+    //    internal loadError rather than throwing — surfaced below if the
+    //    requested model is then not found.
+    let authStorage: ReturnType<typeof piCodingAgent.AuthStorage.create>;
+    let modelRegistry: ReturnType<typeof piCodingAgent.ModelRegistry.create>;
+    try {
+      authStorage = piCodingAgent.AuthStorage.create();
+      modelRegistry = piCodingAgent.ModelRegistry.create(authStorage);
+    } catch (err) {
+      const e = err as Error;
+      getLog().error({ err: e, piProvider: parsed.provider }, 'pi.auth_storage_init_failed');
+      throw new Error(
+        `Pi auth storage init failed: ${e.message}. Check that ~/.pi/agent/auth.json ` +
+          '(or $PI_CODING_AGENT_DIR/auth.json) is valid JSON and readable.'
+      );
+    }
+
+    // 3. Look up the model. find() returns undefined when not found; if
+    //    models.json itself failed to load (e.g. a custom provider entry
+    //    missing baseUrl/apiKey), surface the load error so users debugging
+    //    custom-provider configs see the actual reason.
     const model = modelRegistry.find(parsed.provider, parsed.modelId);
     if (!model) {
+      const loadError = modelRegistry.getError?.();
+      const loadErrorHint = loadError
+        ? ` ~/.pi/agent/models.json failed to load: ${loadError}`
+        : '';
+      getLog().error(
+        {
+          piProvider: parsed.provider,
+          modelId: parsed.modelId,
+          loadError: loadError ?? null,
+        },
+        'pi.model_not_found'
+      );
       throw new Error(
-        `Pi model not found: provider='${parsed.provider}' model='${parsed.modelId}'. ` +
+        `Pi model not found: provider='${parsed.provider}' model='${parsed.modelId}'.${loadErrorHint} ` +
           'See https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/models.generated.ts for the Pi model catalog.'
       );
     }
 
-    // 3. Build AuthStorage. `AuthStorage.create()`, above, read ~/.pi/agent/auth.json
-    //    (or $PI_CODING_AGENT_DIR/auth.json), so any credentials the user has
-    //    populated via `pi` → `/login` (OAuth subscriptions: Claude Pro/Max,
-    //    ChatGPT Plus, GitHub Copilot, Gemini CLI, Antigravity) or by editing
-    //    the file directly (api_key entries) are picked up transparently.
-    //
-    //    Per-request env vars override the file via setRuntimeApiKey — this
-    //    mirrors Claude's process-env + request-env merge pattern and
-    //    ensures codebase-scoped env vars (from .archon/config.yaml `env:`)
-    //    win over the user's global Pi login.
+    // 4. Resolve credentials. authStorage already loaded ~/.pi/agent/auth.json
+    //    so any creds populated via `pi` → `/login` (OAuth subscriptions:
+    //    Claude Pro/Max, ChatGPT Plus, GitHub Copilot, Gemini CLI,
+    //    Antigravity) or by hand-edited api_key entries are picked up
+    //    transparently. Per-request env vars override via setRuntimeApiKey —
+    //    mirrors Claude's process-env + request-env merge so codebase-scoped
+    //    env vars (.archon/config.yaml `env:`) win over the user's global
+    //    Pi login.
     //
     //    Pi's internal resolution order:
     //      1. runtime override  (our setRuntimeApiKey below)
     //      2. auth.json api_key entry
     //      3. auth.json oauth entry  (auto-refreshes expired tokens)
-    //      4. env var fallback  (Pi's getEnvApiKey, e.g. ANTHROPIC_API_KEY)
+    //      4. env var fallback     (Pi's getEnvApiKey, e.g. ANTHROPIC_API_KEY)
     //
     //    OAuth refresh note: Pi refreshes expired access tokens against the
     //    provider's OAuth server and rewrites ~/.pi/agent/auth.json under a
     //    file lock (same mechanism pi CLI uses — safe for concurrent access).
-
     const envVarName = PI_PROVIDER_ENV_VARS[parsed.provider];
     const envOverride = envVarName
       ? (requestOptions?.env?.[envVarName] ?? process.env[envVarName])
@@ -249,13 +284,16 @@ export class PiProvider implements IAgentProvider {
         );
       }
 
-      const envHint = `Provider '${parsed.provider}' is not in the Archon adapter's env-var table — file an issue if you want a shortcut env var for it.`;
-      const loginHint = `Or run \`pi\` and type \`/login\` locally to authenticate '${parsed.provider}' via OAuth; credentials land in ~/.pi/agent/auth.json and are picked up automatically.`;
-      // No credentials for unmapped providers is not necessarily a problem, e.g., local models.
+      // Unmapped providers (LM Studio, ollama, llamacpp, custom
+      // OpenAI-compatible endpoints) often don't need credentials at all —
+      // log + continue rather than failing fast so local models work without
+      // ceremony. If the SDK call later fails for a provider that *does*
+      // need creds, the auth_missing breadcrumb is searchable in the log.
       getLog().info(
         {
           piProvider: parsed.provider,
-          msg: `No Pi credentials found for provider. ${envHint} ${loginHint}`,
+          envHint: `Provider '${parsed.provider}' is not in the Archon adapter's env-var table — file an issue if you want a shortcut env var for it.`,
+          loginHint: `Or run \`pi\` and type \`/login\` locally to authenticate '${parsed.provider}' via OAuth; credentials land in ~/.pi/agent/auth.json and are picked up automatically.`,
         },
         'pi.auth_missing'
       );

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -3,7 +3,6 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { createLogger } from '@archon/paths';
-import type { Api, Model } from '@mariozechner/pi-ai';
 
 import type {
   IAgentProvider,
@@ -93,24 +92,6 @@ let cachedLog: ReturnType<typeof createLogger> | undefined;
 function getLog(): ReturnType<typeof createLogger> {
   if (!cachedLog) cachedLog = createLogger('provider.pi');
   return cachedLog;
-}
-
-/**
- * Typed wrapper around Pi's `getModel` for a runtime-string provider/model
- * pair. Pi's getModel signature constrains `TModelId` to
- * `keyof MODELS[TProvider]`, which isn't knowable from a runtime string —
- * the local `GetModelFn` alias is the narrowest shape that still lets us
- * bypass that constraint. Isolating the escape hatch behind one searchable
- * name keeps it auditable. Takes `getModel` as a parameter because the Pi
- * SDK is loaded dynamically (see the header comment on this file for why).
- */
-type GetModelFn = (provider: string, modelId: string) => Model<Api> | undefined;
-function lookupPiModel(
-  getModel: GetModelFn,
-  provider: string,
-  modelId: string
-): Model<Api> | undefined {
-  return getModel(provider, modelId);
 }
 
 /**
@@ -219,10 +200,9 @@ export class PiProvider implements IAgentProvider {
 
     const authStorage = piCodingAgent.AuthStorage.create();
     const modelRegistry = piCodingAgent.ModelRegistry.create(authStorage);
-    // 2. Look up the Model via Pi's Registry. `lookupPiModel` returns
+    // 2. Look up the Model via Pi's Registry. `modelRegistry.find` returns
     //    undefined when not found; we guard explicitly below.
-    // Cast to the runtime-string-friendly shape — see `lookupPiModel`'s docblock.
-    const model = lookupPiModel(modelRegistry.find as GetModelFn, parsed.provider, parsed.modelId);
+    const model = modelRegistry.find(parsed.provider, parsed.modelId);
     if (!model) {
       throw new Error(
         `Pi model not found: provider='${parsed.provider}' model='${parsed.modelId}'. ` +

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -253,8 +253,11 @@ export class PiProvider implements IAgentProvider {
       const loginHint = `Or run \`pi\` and type \`/login\` locally to authenticate '${parsed.provider}' via OAuth; credentials land in ~/.pi/agent/auth.json and are picked up automatically.`;
       // No credentials for unmapped providers is not necessarily a problem, e.g., local models.
       getLog().info(
-        { piProvider: parsed.provider },
-        `No Pi credentials found for provider. ${envHint} ${loginHint}`
+        {
+          piProvider: parsed.provider,
+          msg: `No Pi credentials found for provider. ${envHint} ${loginHint}`,
+        },
+        'pi.auth_missing'
       );
     }
 

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -210,11 +210,11 @@ export class PiProvider implements IAgentProvider {
       );
     }
 
-    // 3. Build AuthStorage. `AuthStorage.create()` reads ~/.pi/agent/auth.json
-    //    (or $PI_CODING_AGENT_DIR/auth.json), so any credential the user has
+    // 3. Build AuthStorage. `AuthStorage.create()`, above, read ~/.pi/agent/auth.json
+    //    (or $PI_CODING_AGENT_DIR/auth.json), so any credentials the user has
     //    populated via `pi` → `/login` (OAuth subscriptions: Claude Pro/Max,
     //    ChatGPT Plus, GitHub Copilot, Gemini CLI, Antigravity) or by editing
-    //    the file directly (api_key entries) is picked up transparently.
+    //    the file directly (api_key entries) are picked up transparently.
     //
     //    Per-request env vars override the file via setRuntimeApiKey — this
     //    mirrors Claude's process-env + request-env merge pattern and
@@ -321,11 +321,10 @@ export class PiProvider implements IAgentProvider {
     }
 
     // Settings stay in-memory — only sessions persist, to match Claude/Codex.
-    // Resource loader still suppresses filesystem and —
-    // when piConfig.enableExtensions is true — Pi's community extension
-    // ecosystem (tools + lifecycle hooks from ~/.pi/agent/extensions/ and
-    // packages installed via `pi install npm:<pkg>`).
-    // discovery except for explicitly-passed skill paths.
+    // Resource loader still suppresses filesystem except for explicitly-passed
+    // skill paths and — when piConfig.enableExtensions is true — Pi's community
+    // extension ecosystem (tools + lifecycle hooks from ~/.pi/agent/extensions/
+    // and packages installed via `pi install npm:<pkg>`).
     const settingsManager = piCodingAgent.SettingsManager.inMemory();
     // Default ON: extensions (community packages like @plannotator/pi-extension
     // or your own local ones) are a core reason users run Pi. Opt out with


### PR DESCRIPTION
## Summary

Closes #1096 

Describe this PR in 2-5 bullets:

- Problem: Pi Provider can't find custom models or providers (in the 'pi' sense) that have been configured for Pi.
- Why it matters: This is necessary to use, e.g., offline model via ollama, etc, or to use any provider or model that is not predefined in PI's static catalog. It also allows you to override some model configuration values.
- What changed: Removed the use of pi-ai package getModel function, which only checks static catalog, and instead we use the `find()` method of the ModelRegistry that we have to construct anyway, which will load the user's Pi model configurations.
This also has the side benefit of removing the lookupPiModel method which was doing some weird backflips to get type casting that ModelRegistry.find already does.
- What did **not** change (scope boundary): Anything outside of the pi/provider.ts.
There was a comment about not hitting `~/.pi`, but this was always a lie, because we had to read auth.json. If we want to minimize disk reads by caching the 2 disk reads, I suggest we address that in a follow-up task unless we have actual evidence that this change introduces significant performance burden to existing use cases.

## UX Journey

### Context
User has Pi configured to use custom models, perhaps fine-tuned models on a major cloud provider, perhaps standard models on a less known but compatible cloud provider, or perhaps a model running locally via ollama, llamacpp, mlx, or similar.

### Before

 This works fine for Pi, but when Archon is configured to use the Pi provider, with the same model, Archon reports the model as not found.

### After

Now this works fine in Archon too.




## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `adapters`
- Module: `providers:community.pi`

## Change Metadata

- Change type: `bug|feature`
- Primary scope: `adapters`


## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check
bun run lint
bun run format:check
bun run test
# Or all at once:
bun run validate
```

- Evidence provided (test/log/trace/screenshot):

```
Archon % bun run validate
$ bun run check:bundled && bun run type-check && bun run lint --max-warnings 0 && bun run format:check && bun run test
$ bun run scripts/generate-bundled-defaults.ts --check
bundled-defaults.generated.ts is up to date (36 commands, 20 workflows).
$ bun --filter '*' type-check && bun x tsc --noEmit -p scripts/tsconfig.json
@archon/isolation type-check $ bun x tsc --noEmit
└─ Done in 531 ms
@archon/isolation type-check $ bun x tsc --noEmit
└─ Done in 531 ms
@archon/isolation type-check $ bun x tsc --noEmit
└─ Done in 531 ms
@archon/adapters type-check $ bun x tsc --noEmit
└─ Done in 1.99 s
@archon/git type-check $ bun x tsc --noEmit
└─ Done in 447 ms
@archon/providers type-check $ bun x tsc --noEmit
└─ Done in 810 ms
@archon/web type-check $ tsc --noEmit
└─ Done in 2.30 s
@archon/paths type-check $ bun x tsc --noEmit
└─ Done in 378 ms
@archon/workflows type-check $ bun x tsc --noEmit
└─ Done in 1.25 s
@archon/core type-check $ bun x tsc --noEmit
└─ Done in 1.25 s
@archon/cli type-check $ bun x tsc --noEmit
│ src/search_esc.ts(9,40): error TS2339: Property 'promises' does not exist on type 'Promise<{ default: typeof import("fs"); rename: typeof rename; renameSync(oldPath: PathLike, newPath: PathLike): void; truncate: typeof truncate; truncateSync(path: PathLike, len?: number | undefined): void; ... 95 more ...; constants: typeof constants; }>'.
│ src/search_esc.ts(15,30): error TS2345: Argument of type 'Buffer<ArrayBuffer>' is not assignable to parameter of type 'string'.
└─ Exited with code 2
@archon/server type-check $ bun x tsc --noEmit
└─ Done in 2.14 s
```
- If any command is intentionally skipped, explain why:
n/a

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation:
n/a

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps:
n/a

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Ran a workflow using custom provider and model.
- Edge cases checked: n/a
- What was not verified: Custom provider requiring authentication

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: n/a
- Potential unintended effects: A command may now try to run without valid credentials because we must allow for the possibility of providers that do not require any credentials.
- Guardrails/monitoring for early detection: Log message.

## Rollback Plan (required)

- Fast rollback command/path: git revert
- Feature flags or config toggles (if any): No
- Observable failure symptoms: n/a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unmapped Pi providers now log an informational message (with an env-var hint) when credentials are missing instead of throwing; env-mapped providers still fail fast with a login hint. Model-not-found errors now surface clearer diagnostics.

* **Refactor**
  * Streamlined per-request model resolution and authentication lifecycle so credential checks and model lookup share the same storage and error handling.

* **Tests**
  * Tests updated to use registry-based model lookup, remove the old model mock, and clear logger/registry mocks between tests.

* **Documentation**
  * Docs updated to describe local/custom inference paths, supported local backends, model naming, and auth-missing runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->