### PR TITLE
feat(server): default to loopback bind + origin allowlist on /api/*

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,7 +134,18 @@ GITEA_ALLOWED_USERS=
 
 # Server
 PORT=3000
-# HOST=0.0.0.0  # Bind address (default: 0.0.0.0). Set to 127.0.0.1 to restrict to localhost only.
+# HOST=127.0.0.1  # Bind address (default: 127.0.0.1 / loopback only). Set to 0.0.0.0
+#                 # to expose on LAN — Archon has no in-app auth, so only do this
+#                 # behind a reverse proxy (Caddy basic-auth / form-auth profiles) or
+#                 # a firewall. Docker Compose sets this to 0.0.0.0 inside the container
+#                 # automatically; port forwarding on the host still needs explicit mapping.
+
+# ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
+#   Comma-separated list of browser origins allowed to call /api/*.
+#   Default: any loopback origin (localhost / 127.0.0.1 / ::1 on any port).
+#   Set to "*" to allow all origins (use only behind a trusted proxy).
+#   Supersedes the legacy WEB_UI_ORIGIN variable, which is still accepted for
+#   backward compatibility but only supports a single value.
 
 # Cloud Deployment (for --profile cloud with Caddy reverse proxy)
 # Set your domain and point DNS to your server — Caddy handles TLS automatically

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,10 @@ services:
     env_file: .env
     environment:
       ARCHON_DOCKER: "true"
+      # Bind to 0.0.0.0 inside the container so Docker port forwarding works.
+      # The server defaults to 127.0.0.1 for security; containers need all-interfaces
+      # binding because port mapping can't reach the container's loopback.
+      HOST: "0.0.0.0"
     ports:
       - "${PORT:-3000}:${PORT:-3000}"
     volumes:

--- a/packages/docs-web/src/content/docs/reference/configuration.md
+++ b/packages/docs-web/src/content/docs/reference/configuration.md
@@ -268,7 +268,9 @@ When `CLAUDE_USE_GLOBAL_AUTH` is unset, Archon auto-detects: it uses explicit to
 
 | Variable | Description | Default |
 | --- | --- | --- |
-| `WEB_UI_ORIGIN` | CORS origin for API routes (restrict when exposing publicly) | `*` (allow all) |
+| `HOST` | Server bind address. `0.0.0.0` to expose on LAN (requires reverse proxy — see Security). | `127.0.0.1` |
+| `ALLOWED_ORIGINS` | Comma-separated browser origin allowlist for `/api/*`. Set to `*` to disable filtering. | any loopback origin |
+| `WEB_UI_ORIGIN` | Legacy single-value form of `ALLOWED_ORIGINS`; still accepted but superseded. | -- |
 | `WEB_UI_DEV` | When set, skip serving static frontend (Vite dev server used instead) | -- |
 
 ### Worktree Management

--- a/packages/docs-web/src/content/docs/reference/security.md
+++ b/packages/docs-web/src/content/docs/reference/security.md
@@ -139,8 +139,13 @@ Archon's own env sources (`~/.archon/.env`, dev `.env`) are loaded after the CWD
 - `.archon/config.yaml` `env:` section (per-repo, checked into version control)
 - Web UI: Settings → Projects → Env Vars (per-codebase, stored in Archon DB)
 
-**CORS:**
-- API routes use `WEB_UI_ORIGIN` to restrict CORS. The default is `*` (allow all), which is appropriate for local single-developer use. Set a specific origin when exposing the server publicly.
+**Network binding and CORS:**
+
+- The server binds to `127.0.0.1` (loopback) by default. LAN access requires setting `HOST=0.0.0.0` explicitly — only do this behind a reverse proxy (see Caddy `--profile cloud` / `--profile auth`) or a firewall, because Archon has no in-app auth. Docker Compose sets `HOST=0.0.0.0` inside the container automatically; port forwarding on the host still needs explicit mapping.
+- API routes accept requests only from origins in the allowlist. The default allowlist is *any loopback origin* (localhost / 127.0.0.1 / ::1 on any port) — this matches the dev setup (Vite on 5173 talking to the server on 3090) without config.
+- Override via `ALLOWED_ORIGINS` (comma-separated list) when exposing publicly, or `ALLOWED_ORIGINS=*` to disable origin filtering (use only behind a trusted proxy).
+- The legacy `WEB_UI_ORIGIN` env var (single value, same semantics as `ALLOWED_ORIGINS=<value>`) is still accepted for backward compatibility.
+- Mutating requests (POST/PUT/PATCH/DELETE) whose `Origin` header is set to a non-allowlisted value are rejected with HTTP 403. Requests with no `Origin` header pass through — the 127.0.0.1 bind covers that case.
 
 **Docker deployments:**
 - `CLAUDE_USE_GLOBAL_AUTH=true` does not work in Docker (no local `claude` CLI). Provide `CLAUDE_CODE_OAUTH_TOKEN` or `CLAUDE_API_KEY` explicitly.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -576,7 +576,11 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
     app.get('*', serveStatic({ root: webDistPath, path: 'index.html' }));
   }
 
-  const hostname = process.env.HOST || '0.0.0.0';
+  // Bind to loopback by default. Archon currently has no in-app auth, so binding
+  // to non-loopback interfaces exposes the API (AI spend, repo access, workflow
+  // execution) to anyone on the network. Docker, LAN access, and cloud deployments
+  // must opt in explicitly via HOST env var.
+  const hostname = process.env.HOST || '127.0.0.1';
   const server = Bun.serve({
     fetch: app.fetch,
     hostname,
@@ -584,6 +588,12 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
     idleTimeout: 255, // Max value (seconds) - prevents SSE connections from being killed
   });
   getLog().info({ port: server.port, hostname }, 'server_listening');
+  if (hostname !== '127.0.0.1' && hostname !== 'localhost' && hostname !== '::1') {
+    getLog().warn(
+      { hostname },
+      'server.non_loopback_bind — Archon has no in-app auth; ensure a reverse proxy or firewall is in front'
+    );
+  }
 
   // Initialize Telegram adapter (conditional, skipped in CLI serve mode)
   let telegram: TelegramAdapter | null = null;

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -5,6 +5,7 @@
 import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
 import { streamSSE } from 'hono/streaming';
 import { cors } from 'hono/cors';
+import { getAllowlist, matchOrigin, MUTATING_METHODS } from '../security/origin';
 import type { WebAdapter } from '../adapters/web';
 import { rm, readFile, writeFile, unlink, mkdir } from 'fs/promises';
 import { readFileSync } from 'fs';
@@ -875,9 +876,34 @@ export function registerApiRoutes(
     });
   }
 
-  // CORS for Web UI — allow-all is fine for a single-developer tool.
-  // Override with WEB_UI_ORIGIN env var to restrict if exposing publicly.
-  app.use('/api/*', cors({ origin: process.env.WEB_UI_ORIGIN || '*' }));
+  // Origin gate for Web UI.
+  // The server binds to 127.0.0.1 by default (see packages/server/src/index.ts),
+  // which keeps non-browser traffic local. This adds a browser-side CSRF layer:
+  // only origins in the allowlist can talk to /api/*. Default allowlist = any
+  // loopback origin on any port. Override via ALLOWED_ORIGINS (comma-separated)
+  // or the legacy WEB_UI_ORIGIN single-value env var. Set either to "*" to
+  // restore the old allow-all behaviour when sitting behind a trusted proxy.
+  const originAllowlist = getAllowlist();
+  app.use(
+    '/api/*',
+    cors({
+      origin: origin => (matchOrigin(origin, originAllowlist) ? origin || '*' : null),
+      credentials: false,
+    })
+  );
+  // Defense in depth: CORS blocks cross-origin *preflight* responses, but a
+  // simple-form POST without preflight still reaches the handler. Reject
+  // mutating methods whose Origin header is set to a non-allowlisted value.
+  // Requests with no Origin header (curl, same-origin GET→POST on some browsers)
+  // pass through — the 127.0.0.1 bind covers those.
+  app.use('/api/*', async (c, next) => {
+    if (!MUTATING_METHODS.has(c.req.method)) return next();
+    const origin = c.req.header('origin');
+    if (origin && !matchOrigin(origin, originAllowlist)) {
+      return c.json({ error: 'Forbidden: origin not allowed' }, 403);
+    }
+    return next();
+  });
 
   // Shared lock/dispatch/error handling for message and workflow endpoints
   /** Maximum allowed upload size per file (10 MB) */

--- a/packages/server/src/security/origin.test.ts
+++ b/packages/server/src/security/origin.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  parseAllowlist,
+  isLoopbackOrigin,
+  matchOrigin,
+  MUTATING_METHODS,
+  type OriginAllowlist,
+} from './origin';
+
+describe('parseAllowlist', () => {
+  it('defaults to loopback when nothing configured', () => {
+    expect(parseAllowlist(undefined, undefined)).toEqual({ mode: 'loopback' });
+    expect(parseAllowlist('', '')).toEqual({ mode: 'loopback' });
+    expect(parseAllowlist('   ', undefined)).toEqual({ mode: 'loopback' });
+  });
+
+  it('recognises "*" as any-origin', () => {
+    expect(parseAllowlist('*', undefined)).toEqual({ mode: 'any' });
+    expect(parseAllowlist(undefined, '*')).toEqual({ mode: 'any' });
+  });
+
+  it('parses a comma-separated list', () => {
+    const result = parseAllowlist('https://a.example, https://b.example', undefined);
+    expect(result.mode).toBe('list');
+    if (result.mode !== 'list') throw new Error('mode mismatch');
+    expect(result.origins.has('https://a.example')).toBe(true);
+    expect(result.origins.has('https://b.example')).toBe(true);
+  });
+
+  it('trims whitespace and drops empty segments', () => {
+    const result = parseAllowlist(' https://a.example , , https://b.example ', undefined);
+    if (result.mode !== 'list') throw new Error('mode mismatch');
+    expect(result.origins.size).toBe(2);
+  });
+
+  it('prefers ALLOWED_ORIGINS over legacy WEB_UI_ORIGIN', () => {
+    const result = parseAllowlist('https://new.example', 'https://legacy.example');
+    if (result.mode !== 'list') throw new Error('mode mismatch');
+    expect(result.origins.has('https://new.example')).toBe(true);
+    expect(result.origins.has('https://legacy.example')).toBe(false);
+  });
+
+  it('falls back to WEB_UI_ORIGIN when ALLOWED_ORIGINS is empty', () => {
+    const result = parseAllowlist(undefined, 'https://legacy.example');
+    if (result.mode !== 'list') throw new Error('mode mismatch');
+    expect(result.origins.has('https://legacy.example')).toBe(true);
+  });
+});
+
+describe('isLoopbackOrigin', () => {
+  it('accepts localhost on any port', () => {
+    expect(isLoopbackOrigin('http://localhost')).toBe(true);
+    expect(isLoopbackOrigin('http://localhost:3090')).toBe(true);
+    expect(isLoopbackOrigin('http://localhost:5173')).toBe(true);
+    expect(isLoopbackOrigin('https://localhost:8443')).toBe(true);
+  });
+
+  it('accepts 127.0.0.1 on any port', () => {
+    expect(isLoopbackOrigin('http://127.0.0.1')).toBe(true);
+    expect(isLoopbackOrigin('http://127.0.0.1:3090')).toBe(true);
+  });
+
+  it('accepts IPv6 loopback', () => {
+    expect(isLoopbackOrigin('http://[::1]')).toBe(true);
+    expect(isLoopbackOrigin('http://[::1]:3090')).toBe(true);
+  });
+
+  it('rejects non-loopback origins', () => {
+    expect(isLoopbackOrigin('http://example.com')).toBe(false);
+    expect(isLoopbackOrigin('http://192.168.1.100:3090')).toBe(false);
+    expect(isLoopbackOrigin('http://localhost.evil.com')).toBe(false);
+    expect(isLoopbackOrigin('http://127.0.0.1.evil.com')).toBe(false);
+  });
+
+  it('rejects non-URL strings', () => {
+    expect(isLoopbackOrigin('localhost')).toBe(false);
+    expect(isLoopbackOrigin('')).toBe(false);
+    expect(isLoopbackOrigin('not-a-url')).toBe(false);
+  });
+});
+
+describe('matchOrigin', () => {
+  it('allows missing Origin header (same-origin / non-browser clients)', () => {
+    expect(matchOrigin(undefined, { mode: 'loopback' })).toBe(true);
+    expect(matchOrigin('', { mode: 'loopback' })).toBe(true);
+    expect(matchOrigin(undefined, { mode: 'any' })).toBe(true);
+  });
+
+  it('mode=any accepts everything', () => {
+    const allow: OriginAllowlist = { mode: 'any' };
+    expect(matchOrigin('http://example.com', allow)).toBe(true);
+    expect(matchOrigin('http://localhost:3090', allow)).toBe(true);
+  });
+
+  it('mode=loopback accepts only loopback origins', () => {
+    const allow: OriginAllowlist = { mode: 'loopback' };
+    expect(matchOrigin('http://localhost:5173', allow)).toBe(true);
+    expect(matchOrigin('http://127.0.0.1:3090', allow)).toBe(true);
+    expect(matchOrigin('http://[::1]:3090', allow)).toBe(true);
+    expect(matchOrigin('http://192.168.1.1:3090', allow)).toBe(false);
+    expect(matchOrigin('http://example.com', allow)).toBe(false);
+  });
+
+  it('mode=list accepts only exact matches', () => {
+    const allow: OriginAllowlist = {
+      mode: 'list',
+      origins: new Set(['https://app.example.com']),
+    };
+    expect(matchOrigin('https://app.example.com', allow)).toBe(true);
+    expect(matchOrigin('https://app.example.com:443', allow)).toBe(false); // port differs
+    expect(matchOrigin('http://app.example.com', allow)).toBe(false); // scheme differs
+    expect(matchOrigin('https://evil.example.com', allow)).toBe(false);
+  });
+});
+
+describe('MUTATING_METHODS', () => {
+  it('includes POST, PUT, PATCH, DELETE', () => {
+    expect(MUTATING_METHODS.has('POST')).toBe(true);
+    expect(MUTATING_METHODS.has('PUT')).toBe(true);
+    expect(MUTATING_METHODS.has('PATCH')).toBe(true);
+    expect(MUTATING_METHODS.has('DELETE')).toBe(true);
+  });
+
+  it('excludes safe methods', () => {
+    expect(MUTATING_METHODS.has('GET')).toBe(false);
+    expect(MUTATING_METHODS.has('HEAD')).toBe(false);
+    expect(MUTATING_METHODS.has('OPTIONS')).toBe(false);
+  });
+});

--- a/packages/server/src/security/origin.ts
+++ b/packages/server/src/security/origin.ts
@@ -1,0 +1,73 @@
+/**
+ * Origin allowlist for the Web UI and API.
+ *
+ * Archon has no in-app auth. The server binds to 127.0.0.1 by default, which
+ * prevents LAN access. This module adds a second layer: restrict which browser
+ * origins can make requests to /api/*, protecting against CSRF from malicious
+ * tabs on the same machine.
+ *
+ * Config precedence (highest first):
+ *   1. ALLOWED_ORIGINS (comma-separated list, or "*")
+ *   2. WEB_UI_ORIGIN   (legacy single-value form)
+ *   3. default: any loopback origin (localhost / 127.0.0.1 / ::1 on any port)
+ */
+
+export type OriginAllowlist =
+  | { mode: 'any' }
+  | { mode: 'loopback' }
+  | { mode: 'list'; origins: ReadonlySet<string> };
+
+/**
+ * Parse the allowlist from environment variables.
+ * Exported for testing; call `getAllowlist()` for the runtime-config version.
+ */
+export function parseAllowlist(
+  allowedOrigins: string | undefined,
+  webUiOrigin: string | undefined
+): OriginAllowlist {
+  const raw = (allowedOrigins ?? webUiOrigin ?? '').trim();
+  if (raw === '') return { mode: 'loopback' };
+  if (raw === '*') return { mode: 'any' };
+  const origins = raw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+  if (origins.length === 0) return { mode: 'loopback' };
+  return { mode: 'list', origins: new Set(origins) };
+}
+
+/** Compute the runtime allowlist from process.env. */
+export function getAllowlist(): OriginAllowlist {
+  return parseAllowlist(process.env.ALLOWED_ORIGINS, process.env.WEB_UI_ORIGIN);
+}
+
+/**
+ * True when the given origin resolves to the loopback interface on any port.
+ * Handles IPv4 (127.0.0.1), IPv6 (::1), and the `localhost` alias.
+ */
+export function isLoopbackOrigin(origin: string): boolean {
+  try {
+    const u = new URL(origin);
+    // URL parser wraps IPv6 literals in brackets. Strip them for comparison.
+    const host = u.hostname.startsWith('[') ? u.hostname.slice(1, -1) : u.hostname;
+    return host === 'localhost' || host === '127.0.0.1' || host === '::1';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether the origin is accepted by the allowlist.
+ * `undefined`/empty origins always pass — same-origin requests often omit the
+ * header, and non-browser clients (curl, node scripts) do too. The 127.0.0.1
+ * bind is what keeps those non-browser clients local.
+ */
+export function matchOrigin(origin: string | undefined, allowlist: OriginAllowlist): boolean {
+  if (!origin) return true;
+  if (allowlist.mode === 'any') return true;
+  if (allowlist.mode === 'loopback') return isLoopbackOrigin(origin);
+  return allowlist.origins.has(origin);
+}
+
+/** HTTP methods that can mutate server state. */
+export const MUTATING_METHODS: ReadonlySet<string> = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);


### PR DESCRIPTION
## Summary

- **Problem:** Archon has no in-app auth, and the server binds to `0.0.0.0` with CORS `origin: "*"`. Anyone on the LAN can read repos, trigger AI spend, and invoke workflows. Anyone on the same machine can also CSRF the API from a malicious browser tab.
- **Why it matters:** The upcoming terminal feature (see roadmap below) widens that blast radius from "read your stuff" to "arbitrary shell." This PR tightens the baseline *before* adding that surface, so the terminal inherits safer defaults.
- **What changed:** Server now binds to `127.0.0.1` by default (HOST env still overrides; docker-compose sets `HOST=0.0.0.0` inside the container automatically). `/api/*` now enforces an Origin allowlist — default is any loopback origin on any port — with a mutation-guard middleware that rejects POST/PUT/PATCH/DELETE whose Origin is non-allowlisted. Webhook endpoints are unaffected (they have their own HMAC/token signature auth).
- **What did NOT change (scope boundary):** No new auth system, no shared-secret token, no login page. No changes to webhook signature verification. No changes to platform-adapter auth (Slack/Telegram/Discord/GitHub). No SSE/WebSocket changes (WS comes in PR #2). Legacy `WEB_UI_ORIGIN` env var still honored for backward compatibility.

## Context: Terminal Feature Roadmap

This is **PR #1 of a stacked series** that brings a WebTerm-inspired slide-out terminal into Archon's Web UI. Planned PRs:

1. **This PR — auth baseline** (grounds-layer hardening, no terminal code yet)
2. WebSocket infra in `@archon/server` + `@archon/pty-host` Node sidecar (node-pty doesn't work under Bun on Windows — spike confirmed; Node child over stdio JSON-lines handles PTY I/O)
3. Frontend terminal core: slide-out drawer, xterm.js, context-aware cwd, `Ctrl+`` ` shortcut
4. Multiple tabs
5. Broadcast across tabs
6. Workflow tail (live stdout of running bash nodes, read-only)

The auth baseline is written so PR #2 can import `getAllowlist()` / `matchOrigin()` directly to gate the WebSocket upgrade — no rework needed.

## UX Journey

### Before

```
Attacker on LAN                 Archon (0.0.0.0)              User's repos / AI
─────────────────               ─────────────────             ─────────────────
  curl http://192.168.1.x:3000/api/codebases
  ────────────────────────────▶ [no auth] ──────────────────▶ enumerated
  curl -X POST ... /workflows/run
  ────────────────────────────▶ [no auth] ──────────────────▶ AI spend triggered

Browser tab on evil.site
──────────────────────
  <form action="http://localhost:3000/api/..." method=POST>
  auto-submit on load ─────────▶ [origin: "*"] ──────────────▶ state changed
```

### After

```
Attacker on LAN                 Archon (127.0.0.1)            Outcome
─────────────────               ───────────────────           ───────
  curl http://192.168.1.x:3000/... ────▶ connection refused  ✓ blocked

Browser tab on evil.site
──────────────────────
  <form ... POST /api/...>      [Origin: https://evil.site]
  ─────────────────────────▶    ─────────────────────────▶   403 Forbidden

Legitimate dev flow
───────────────────
  Vite (5173) ──▶ Archon (3090) [Origin: http://localhost:5173]
                                 loopback allowlist match     ✓ allowed
```

## Architecture Diagram

### Before

```
browser ──▶ [Hono app]
              ├─ cors({origin: "*"})  ◀── permissive
              └─ /api/*, /webhooks/*

server bind: 0.0.0.0 (all interfaces)
```

### After

```
browser ──▶ [Hono app]
              ├─ cors({origin: allowlist-fn})       ◀── [~modified]
              ├─ mutation-guard middleware          ◀── [+new]
              ├─ /api/*                             
              └─ /webhooks/*                        ◀── unaffected
                                                        (own HMAC auth)
                      ▲
                      │
                 [origin.ts]                        ◀── [+new module]
                  getAllowlist()
                  matchOrigin()
                  MUTATING_METHODS

server bind: 127.0.0.1 (loopback)                   ◀── [~modified default]
```

**Connection inventory:**

| From | To | Status | Notes |
|---|---|---|---|
| `api.ts` | `security/origin.ts` | **new** | Imports `getAllowlist`, `matchOrigin`, `MUTATING_METHODS` |
| Hono `cors` middleware | origin allowlist fn | **modified** | Was static `"*"`, now dynamic match |
| Mutation guard middleware | `/api/*` | **new** | Rejects POST/PUT/PATCH/DELETE from non-allowlisted Origin |
| All other edges | | unchanged | |

## Label Snapshot

- Risk: `risk: medium` (changes default bind + adds middleware; breaking for anyone relying on 0.0.0.0 default)
- Size: `size: S`
- Scope: `server`, `config`, `docs`
- Module: `server:security`, `server:routes`, `config:docker-compose`

## Change Metadata

- Change type: `security`
- Primary scope: `server`

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #

(No linked issue — design-level feature work discussed in offline chat; details in the Context section above.)

## Validation Evidence (required)

```bash
bun run type-check   # ✓ all 10 packages exit 0
bun run lint         # ✓ 0 warnings, 0 errors
bun run format:check # ✓ all files use Prettier style
bun run test         # ✓ all packages exit 0
# Or all at once:
bun run validate     # ✓ clean
```

New test file `packages/server/src/security/origin.test.ts` — **17 tests, 48 expect() calls, 100% pass**:
- `parseAllowlist`: default / "*" / CSV / whitespace / precedence / legacy fallback
- `isLoopbackOrigin`: localhost / 127.0.0.1 / ::1 / non-loopback / malformed
- `matchOrigin`: missing header / any / loopback / exact list / port/scheme sensitivity
- `MUTATING_METHODS` set contents

## Security Impact (required)

- New permissions/capabilities? **Reduces** — removes default LAN exposure and default CSRF-able CORS.
- New external network calls? **No.**
- Secrets/tokens handling changed? **No.**
- File system access scope changed? **No.**

**Risk & mitigation:** This is a breaking change for anyone who was relying on the `0.0.0.0` default (e.g. running Archon on a server and pointing a browser from another machine). Mitigation: `HOST=0.0.0.0` still works and is documented in `.env.example` and `reference/security.md`. Docker users are unaffected — the compose file sets this automatically. The migration path is explicit and surfaced.

## Compatibility / Migration

- Backward compatible? **Mostly** — breaking for non-Docker users who were running on `0.0.0.0` without realizing it. Migration: add `HOST=0.0.0.0` to `.env` and (strongly recommended) put Archon behind Caddy basic-auth / form-auth via the existing `--profile cloud` / `--profile auth` Docker setups.
- Config/env changes? **Yes — defaults changed**: `HOST` now defaults to `127.0.0.1`; CORS now defaults to loopback-only.
- Database migration needed? **No.**
- Legacy env var `WEB_UI_ORIGIN` still honored — no config rewrite needed for users who were restricting CORS.

## Human Verification (required)

- **Verified scenarios:**
  - Type-check, lint, format, full test suite all clean.
  - 17 unit tests cover the Origin helper surface.
  - Confirmed middleware registration order: `cors()` and mutation-guard are installed in `registerApiRoutes` before any route handler (line 887 / 899 vs first handler at 1062).
  - Confirmed webhook routes are registered in `index.ts` *outside* `registerApiRoutes` and therefore not covered by the Origin middleware — preserves existing HMAC signature auth path.
- **Edge cases checked:**
  - Missing Origin header on a POST → allowed (covers curl / same-origin)
  - Non-loopback `Origin: http://example.com` on POST → 403
  - Port-sensitive exact list match (`https://a.example` ≠ `https://a.example:443`) — tested
  - IPv6 loopback (`http://[::1]:3090`) — tested
  - Legacy `WEB_UI_ORIGIN` fallback when `ALLOWED_ORIGINS` is unset — tested
- **What was not verified:** manual smoke (server startup, browser round-trip) on Docker; running behind Caddy. Defaults were chosen to keep existing Docker + Caddy workflows working without config changes.

## Side Effects / Blast Radius (required)

- **Affected subsystems/workflows:** the web API and its consumers (Web UI, CLI `archon serve`, any external client hitting `/api/*`). Platform adapters (Slack/Telegram/Discord/GitHub) are not on this surface — they dial out, not in.
- **Potential unintended effects:** if a user has scripts that hit the API from a different machine on the LAN, those will now fail to connect. Migration note in `.env.example` + docs.
- **Guardrails/monitoring for early detection:** server startup logs `hostname` in the `server_listening` event (already present) and logs a `server.non_loopback_bind` warning if running on a non-loopback interface.

## Rollback Plan (required)

- **Fast rollback command/path:** `git revert <merge-sha>`. No data, no migrations, no cache to clear.
- **Feature flags or config toggles:** Users can get pre-PR behaviour with `HOST=0.0.0.0 ALLOWED_ORIGINS=*` in their `.env`.
- **Observable failure symptoms:** clients from other machines get connection-refused; browser dev-tools shows a CORS / 403 error for cross-origin POST attempts.

## Risks and Mitigations

- **Risk:** Non-Docker LAN users are silently broken after upgrade.
  - **Mitigation:** Explicit documentation of the change in `.env.example` and `reference/security.md`. The server logs a warning *if* `HOST` is set to non-loopback, drawing attention to the auth posture.
- **Risk:** The loopback-default allowlist is too permissive — any local tab can still hit `/api/*` (any local origin is allow-listed).
  - **Mitigation:** Accepted for a single-developer tool running on localhost. A follow-up PR can add an `ARCHON_AUTH_TOKEN` shared secret if tighter control is needed; the module is designed to compose with token auth, not replace it.
- **Risk:** CORS `origin: fn` behaviour differs from prior `"*"` in edge cases (e.g. requests with no Origin).
  - **Mitigation:** Function returns `'*'` for no-Origin requests (same as before) and the allowlisted origin (echoed back) otherwise. Tests cover the branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
