### PR TITLE
fix(orchestrator): clear stale session ID on error_during_execution to prevent infinite failure loop

### DIFF
--- a/packages/core/src/db/sessions.test.ts
+++ b/packages/core/src/db/sessions.test.ts
@@ -168,7 +168,18 @@ describe('sessions', () => {
       );
     });
 
-    test('throws SessionNotFoundError when session does not exist', async () => {
+    test('sets assistant_session_id to NULL when called with null', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([], 1));
+
+      await updateSession('session-123', null);
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        'UPDATE remote_agent_sessions SET assistant_session_id = $1 WHERE id = $2',
+        [null, 'session-123']
+      );
+    });
+
+    test('throws SessionNotFoundError when session does not exist (updateSession)', async () => {
       mockQuery.mockResolvedValueOnce(createQueryResult([], 0)); // rowCount = 0
 
       const error = await updateSession('non-existent', 'new-session-id').catch(e => e);

--- a/packages/core/src/db/sessions.ts
+++ b/packages/core/src/db/sessions.ts
@@ -58,7 +58,7 @@ export async function createSession(data: {
   return result.rows[0];
 }
 
-export async function updateSession(id: string, sessionId: string): Promise<void> {
+export async function updateSession(id: string, sessionId: string | null): Promise<void> {
   const result = await pool.query(
     'UPDATE remote_agent_sessions SET assistant_session_id = $1 WHERE id = $2',
     [sessionId, id]

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -72,10 +72,14 @@ mock.module('../db/codebases', () => ({
   createCodebase: mock(() => Promise.resolve({ id: 'new-codebase-id' })),
 }));
 
+const mockUpdateSession = mock(() => Promise.resolve());
+const mockTransitionSession = mock(() =>
+  Promise.resolve({ id: 'session-1', assistant_session_id: null })
+);
 mock.module('../db/sessions', () => ({
   getActiveSession: mock(() => Promise.resolve(null)),
-  updateSession: mock(() => Promise.resolve()),
-  transitionSession: mock(() => Promise.resolve({ id: 'session-1', assistant_session_id: null })),
+  updateSession: mockUpdateSession,
+  transitionSession: mockTransitionSession,
 }));
 
 const mockParseCommand = mock(
@@ -1600,5 +1604,75 @@ describe('handleMessage — workflow context injection', () => {
 
     // Non-critical path — must not block message handling
     await expect(handleMessage(platform, 'conv-1', 'Hello')).resolves.toBeUndefined();
+  });
+});
+
+// ─── Stale session ID clearing on error_during_execution ────────────────────
+
+describe('stale session ID clearing on error_during_execution', () => {
+  beforeEach(() => {
+    mockUpdateSession.mockClear();
+    mockTransitionSession.mockClear();
+    mockGetOrCreateConversation.mockReset();
+    mockGetCodebase.mockReset();
+    mockSendQuery.mockReset();
+    mockLogger.warn.mockClear();
+    mockGetRecentWorkflowResultMessages.mockReset();
+    mockGetRecentWorkflowResultMessages.mockImplementation(() => Promise.resolve([]));
+    mockDiscoverWorkflowsWithConfig.mockReset();
+    mockDiscoverWorkflowsWithConfig.mockImplementation(() =>
+      Promise.resolve({ workflows: [], errors: [] })
+    );
+    mockGetOrCreateConversation.mockImplementation(() => Promise.resolve(makeConversation()));
+    mockGetCodebase.mockImplementation(() => Promise.resolve(null));
+    mockListCodebases.mockReset();
+    mockListCodebases.mockImplementation(() => Promise.resolve([]));
+  });
+
+  test('handleStreamMode: clears session ID on error_during_execution result', async () => {
+    // Simulate AI returning error_during_execution with a stale session ID
+    mockSendQuery.mockImplementationOnce(async function* () {
+      yield {
+        type: 'result',
+        isError: true,
+        errorSubtype: 'error_during_execution',
+        sessionId: 'stale-session-id',
+      };
+    });
+    // transitionSession returns a session with an existing assistant_session_id
+    mockTransitionSession.mockResolvedValueOnce({
+      id: 'session-1',
+      assistant_session_id: 'stale-session-id',
+    });
+
+    const platform = makePlatform();
+    // Use streaming mode
+    (platform.getStreamingMode as ReturnType<typeof mock>).mockReturnValue('stream');
+    await handleMessage(platform, 'conv-1', 'hello');
+
+    // updateSession should be called with null to clear the stale session ID
+    expect(mockUpdateSession).toHaveBeenCalledWith('session-1', null);
+  });
+
+  test('handleBatchMode: clears session ID on error_during_execution result', async () => {
+    mockSendQuery.mockImplementationOnce(async function* () {
+      yield {
+        type: 'result',
+        isError: true,
+        errorSubtype: 'error_during_execution',
+        sessionId: 'stale-session-id',
+      };
+    });
+    mockTransitionSession.mockResolvedValueOnce({
+      id: 'session-1',
+      assistant_session_id: 'stale-session-id',
+    });
+
+    const platform = makePlatform();
+    // batch is the default from makePlatform, but be explicit
+    (platform.getStreamingMode as ReturnType<typeof mock>).mockReturnValue('batch');
+    await handleMessage(platform, 'conv-1', 'hello');
+
+    expect(mockUpdateSession).toHaveBeenCalledWith('session-1', null);
   });
 });

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -355,7 +355,7 @@ async function tryPersistSessionId(
     await sessionDb.updateSession(sessionId, assistantSessionId);
   } catch (error) {
     getLog().error(
-      { err: error as Error, sessionId, newSessionId: assistantSessionId },
+      { err: error as Error, sessionId, persistedValue: assistantSessionId },
       'session_id_persist_failed'
     );
   }
@@ -981,7 +981,13 @@ async function handleStreamMode(
     } else if (msg.type === 'result') {
       if (msg.isError && msg.errorSubtype === 'error_during_execution') {
         getLog().warn(
-          { conversationId, errorSubtype: msg.errorSubtype },
+          {
+            conversationId,
+            errorSubtype: msg.errorSubtype,
+            staleSessionId: msg.sessionId,
+            errors: msg.errors,
+            stopReason: msg.stopReason,
+          },
           'clearing_stale_session_id'
         );
         await tryPersistSessionId(session.id, null);
@@ -990,7 +996,15 @@ async function handleStreamMode(
         newSessionId = msg.sessionId;
       }
       if (msg.isError) {
-        getLog().warn({ conversationId, errorSubtype: msg.errorSubtype }, 'ai_result_error');
+        getLog().warn(
+          {
+            conversationId,
+            errorSubtype: msg.errorSubtype,
+            errors: msg.errors,
+            stopReason: msg.stopReason,
+          },
+          'ai_result_error'
+        );
         const syntheticError = new Error(msg.errorSubtype ?? 'AI result error');
         await platform.sendMessage(conversationId, classifyAndFormatError(syntheticError));
         if (newSessionId) {
@@ -1111,7 +1125,13 @@ async function handleBatchMode(
     } else if (msg.type === 'result') {
       if (msg.isError && msg.errorSubtype === 'error_during_execution') {
         getLog().warn(
-          { conversationId, errorSubtype: msg.errorSubtype },
+          {
+            conversationId,
+            errorSubtype: msg.errorSubtype,
+            staleSessionId: msg.sessionId,
+            errors: msg.errors,
+            stopReason: msg.stopReason,
+          },
           'clearing_stale_session_id'
         );
         await tryPersistSessionId(session.id, null);
@@ -1120,7 +1140,15 @@ async function handleBatchMode(
         newSessionId = msg.sessionId;
       }
       if (msg.isError) {
-        getLog().warn({ conversationId, errorSubtype: msg.errorSubtype }, 'ai_result_error');
+        getLog().warn(
+          {
+            conversationId,
+            errorSubtype: msg.errorSubtype,
+            errors: msg.errors,
+            stopReason: msg.stopReason,
+          },
+          'ai_result_error'
+        );
         const syntheticError = new Error(msg.errorSubtype ?? 'AI result error');
         await platform.sendMessage(conversationId, classifyAndFormatError(syntheticError));
         if (newSessionId) {

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -347,7 +347,10 @@ async function dispatchOrchestratorWorkflow(
 
 // ─── Session Helpers ────────────────────────────────────────────────────────
 
-async function tryPersistSessionId(sessionId: string, assistantSessionId: string): Promise<void> {
+async function tryPersistSessionId(
+  sessionId: string,
+  assistantSessionId: string | null
+): Promise<void> {
   try {
     await sessionDb.updateSession(sessionId, assistantSessionId);
   } catch (error) {
@@ -976,7 +979,14 @@ async function handleStreamMode(
         await platform.sendStructuredEvent(conversationId, msg);
       }
     } else if (msg.type === 'result') {
-      if (msg.sessionId) {
+      if (msg.isError && msg.errorSubtype === 'error_during_execution') {
+        getLog().warn(
+          { conversationId, errorSubtype: msg.errorSubtype },
+          'clearing_stale_session_id'
+        );
+        await tryPersistSessionId(session.id, null);
+        newSessionId = undefined;
+      } else if (msg.sessionId) {
         newSessionId = msg.sessionId;
       }
       if (msg.isError) {
@@ -1099,7 +1109,14 @@ async function handleBatchMode(
         getLog().debug({ toolName: msg.toolName }, 'tool_call');
       }
     } else if (msg.type === 'result') {
-      if (msg.sessionId) {
+      if (msg.isError && msg.errorSubtype === 'error_during_execution') {
+        getLog().warn(
+          { conversationId, errorSubtype: msg.errorSubtype },
+          'clearing_stale_session_id'
+        );
+        await tryPersistSessionId(session.id, null);
+        newSessionId = undefined;
+      } else if (msg.sessionId) {
         newSessionId = msg.sessionId;
       }
       if (msg.isError) {


### PR DESCRIPTION
## Summary

- **Problem:** After container restart, sending a message in an existing conversation silently fails and enters an infinite failure loop — the expired Claude API session ID is persisted even on error
- **Why it matters:** Users are stuck with broken conversations after any restart, with no recovery path except manual DB intervention
- **What changed:** `updateSession()` and `tryPersistSessionId()` now accept `string | null`; both `handleStreamMode` and `handleBatchMode` clear session ID on `error_during_execution`
- **What did not change:** Conversation history (`remote_agent_messages`), session creation flow, normal (non-error) session persistence

## UX Journey

### Before

```
User                   Archon                   Claude API
────                   ──────                   ─────────
sends message ──────▶  loads stale session ID
                       tries Claude API ──────▶  rejects (expired)
                       persists SAME stale ID
  sees error ◀──────── returns error
sends again ─────────▶ loads SAME stale ID
                       tries Claude API ──────▶  rejects again
  (infinite loop)      never recovers
```

### After

```
User                   Archon                   Claude API
────                   ──────                   ─────────
sends message ──────▶  loads stale session ID
                       tries Claude API ──────▶  rejects (expired)
                       [clears session ID → NULL]
  sees error ◀──────── returns error
sends again ─────────▶ [no stored ID → creates new session]
                       tries Claude API ──────▶  accepts (fresh)
  sees reply ◀──────── streams response
```

## Architecture Diagram

### Before

```
handleStreamMode / handleBatchMode
    │
    ▼
error_during_execution ──▶ updateSession(sessionId)  ──▶ DB (stale ID persisted)
```

### After

```
handleStreamMode / handleBatchMode
    │
    ▼
error_during_execution ──▶ [updateSession(null)]  ──▶ DB (ID cleared)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| handleStreamMode | updateSession | **modified** | Now passes `null` on error |
| handleBatchMode | tryPersistSessionId | **modified** | Now passes `null` on error |
| updateSession | DB | **modified** | Accepts `string \| null` |
| tryPersistSessionId | DB | **modified** | Accepts `string \| null` |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`
- Module: `core:orchestrator`

## Security Impact

No security impact. This change only affects internal session state management — no auth, no user data exposure, no new inputs.

## Human Verification

- Verified by restarting container and sending message to existing conversation — session recovers automatically
- All 89 orchestrator-agent tests pass
- All 28 sessions DB tests pass
- TypeScript type-check clean (`tsc --noEmit`)

## Side Effects / Blast Radius

- Only affects error recovery path (`error_during_execution`)
- Normal session flow is unchanged
- Worst case: session is cleared unnecessarily, resulting in a fresh session (no data loss, just context reload)

## Rollback Plan

Revert the single commit. The only behavioral change is in the error handler — reverting restores original (broken) behavior of persisting stale IDs.

Closes #1280

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced session management to automatically clear invalid sessions when execution errors occur, improving reliability.
  * Expanded error logging to include additional details for better troubleshooting of result processing failures.

* **Tests**
  * Added comprehensive test coverage for session state clearing during error recovery scenarios.
  * Improved test structure with named mock utilities for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->