### PR TITLE
feat: open PRs as ready by default + pr-maintenance draft promotion

### DIFF
--- a/.archon/workflows/defaults/archon-fix-github-issue.yaml
+++ b/.archon/workflows/defaults/archon-fix-github-issue.yaml
@@ -169,7 +169,7 @@ nodes:
       4. Check if a PR already exists for this branch: `gh pr list --head $(git branch --show-current)`
          - If PR exists, skip creation and capture its number
       5. Look for the project's PR template at `.github/pull_request_template.md`, `.github/PULL_REQUEST_TEMPLATE.md`, or `docs/PULL_REQUEST_TEMPLATE.md`. Read whichever one exists.
-      6. Create a DRAFT PR: `gh pr create --draft --base $BASE_BRANCH`
+      6. Create a PR: `gh pr create --base $BASE_BRANCH`
          - Title: concise, imperative mood, under 70 chars
          - Body: if a PR template was found, fill in **every section** with details from the artifacts. Don't skip sections or leave placeholders. If no template, write a body with summary, changes, validation evidence, and `Fixes #...`.
          - Link to issue: include `Fixes #...` or `Closes #...`

--- a/.archon/workflows/defaults/archon-piv-loop.yaml
+++ b/.archon/workflows/defaults/archon-piv-loop.yaml
@@ -734,7 +734,7 @@ nodes:
       cat .github/pull_request_template.md 2>/dev/null || echo "NO_TEMPLATE"
       ```
 
-      Create with `gh pr create --draft --base $BASE_BRANCH`:
+      Create with `gh pr create --base $BASE_BRANCH`:
       - Title from the plan's feature name
       - Body summarizing the implementation
       - Use a HEREDOC for the body

--- a/.archon/workflows/defaults/archon-ralph-dag.yaml
+++ b/.archon/workflows/defaults/archon-ralph-dag.yaml
@@ -528,7 +528,7 @@ nodes:
 
            If no template was found, write a summary with: problem, what changed, stories table, and validation evidence.
 
-        3. **Create a draft PR** using `gh pr create --draft --base $BASE_BRANCH --title "feat: {PRD feature name}"` with the filled-in template as the body. Use a HEREDOC for the body.
+        3. **Create a PR** using `gh pr create --base $BASE_BRANCH --title "feat: {PRD feature name}"` with the filled-in template as the body. Use a HEREDOC for the body.
 
         4. **Output completion signal:**
            ```

--- a/homebrew/archon.rb
+++ b/homebrew/archon.rb
@@ -7,28 +7,28 @@
 class Archon < Formula
   desc "Remote agentic coding platform - control AI assistants from anywhere"
   homepage "https://github.com/coleam00/Archon"
-  version "0.3.5"
+  version "0.3.6"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-darwin-arm64"
-      sha256 "2c2065e580a085baaea02504cb5451be3f68e0d9fdb13a364cd45194d5b22de1"
+      sha256 "96b6dac50b046eece9eddbb988a0c39b4f9a0e2faac66e49b977ba6360069e86"
     end
     on_intel do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-darwin-x64"
-      sha256 "515aca3b2bc30d3b5d4dfb67c04648f70b66e8ed345ea6ab039e76e6578e82fe"
+      sha256 "09f1dbe12417b4300b7b07b531eb7391a286305f8d4eafc11e7f61f5d26eb8eb"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-linux-arm64"
-      sha256 "96920d98ae0d4dc7ef78e6de4f9018a9ba2031b9c2b010fd5d748d9513c49f60"
+      sha256 "80b06a6ff699ec57cd4a3e49cfe7b899a3e8212688d70285f5a887bf10086731"
     end
     on_intel do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-linux-x64"
-      sha256 "80e7d115da424d5ee47b7db773382c9b8d0db728408f9815c05081872da6b74f"
+      sha256 "09f5dac6db8037ed6f3e5b7e9c5eb8e37f19822a4ed2bf4cd7e654780f9d00de"
     end
   end
 

--- a/scripts/pr-maintenance-cron.sh
+++ b/scripts/pr-maintenance-cron.sh
@@ -17,7 +17,8 @@ set -euo pipefail
 export PATH="$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin:$PATH"
 
 # --- Configuration ---
-DEFAULT_PROJECTS=(cosmic-match word-coach-annie filmduel reli beads)
+source /home/asiri/gt/mayor/scripts/lib/archon-projects.sh
+load_archon_projects DEFAULT_PROJECTS
 BASE_DIR="/mnt/ext-fast"
 LOG_PREFIX="[pr-maintenance]"
 
@@ -40,15 +41,34 @@ for PROJECT in "${PROJECTS[@]}"; do
 
   cd "$REPO_DIR"
 
+  # --- Phase 0: Promote CLEAN draft PRs to ready-for-review ---
+  # Archon workflows create PRs as drafts by default. When CI is green the
+  # draft has nothing left to gate on, but the Phase 1 merge filter skips
+  # drafts — so left alone a green draft sits forever. Flip it to ready so
+  # Phase 1 can merge it on this same tick.
+  GREEN_DRAFTS=$(gh pr list --state open --json number,mergeStateStatus,isDraft \
+    --jq '[.[] | select(.isDraft == true and .mergeStateStatus == "CLEAN")] | .[].number' 2>/dev/null || true)
+
+  for PR in $GREEN_DRAFTS; do
+    log "$PROJECT: promoting draft PR #$PR to ready (CI CLEAN)"
+    if ! gh pr ready "$PR" 2>>"/tmp/pr-maintenance-errors.log"; then
+      log "$PROJECT: PR #$PR — could not mark ready (see /tmp/pr-maintenance-errors.log)"
+    fi
+  done
+
   # --- Phase 1: Merge CLEAN PRs directly (bash only, zero AI cost) ---
   CLEAN_PRS=$(gh pr list --state open --json number,mergeStateStatus,isDraft \
     --jq '[.[] | select(.isDraft == false and .mergeStateStatus == "CLEAN")] | .[].number' 2>/dev/null || true)
 
   for PR in $CLEAN_PRS; do
     log "$PROJECT: PR #$PR is CLEAN — merging directly"
-    gh pr merge "$PR" --squash --auto --delete-branch 2>/dev/null \
-      || gh pr merge "$PR" --squash --delete-branch 2>/dev/null \
-      || log "$PROJECT: PR #$PR — could not merge, skipping"
+    # Surface stderr to the cron log so actual failures (permissions, branch
+    # protection, etc.) are diagnosable on the next tick instead of vanishing.
+    if ! gh pr merge "$PR" --squash --auto --delete-branch 2>&1; then
+      if ! gh pr merge "$PR" --squash --delete-branch 2>&1; then
+        log "$PROJECT: PR #$PR — could not merge, skipping"
+      fi
+    fi
   done
 
   # --- Phase 2: Check for one PR needing AI attention ---

--- a/scripts/pr-maintenance-cron.sh
+++ b/scripts/pr-maintenance-cron.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# pr-maintenance-cron.sh — Run from cron every 15 minutes.
+# Zero AI cost when nothing to do. Processes one PR per project per run.
+#
+# Usage:
+#   ./scripts/pr-maintenance-cron.sh                    # all projects
+#   ./scripts/pr-maintenance-cron.sh cosmic-match reli  # specific projects
+#
+# Crontab entry:
+#   */15 * * * * /mnt/ext-fast/archon/scripts/pr-maintenance-cron.sh >> /tmp/pr-maintenance.log 2>&1
+
+set -euo pipefail
+
+# Cron runs with a minimal PATH (/usr/bin:/bin). archon, gh, bun, git
+# often live in user-local bins; prepend them so the script works from
+# both cron and an interactive shell.
+export PATH="$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin:$PATH"
+
+# --- Configuration ---
+DEFAULT_PROJECTS=(cosmic-match word-coach-annie filmduel reli beads)
+BASE_DIR="/mnt/ext-fast"
+LOG_PREFIX="[pr-maintenance]"
+
+# Use arguments if provided, otherwise all projects
+if [ $# -gt 0 ]; then
+  PROJECTS=("$@")
+else
+  PROJECTS=("${DEFAULT_PROJECTS[@]}")
+fi
+
+log() { echo "$(date -Is) $LOG_PREFIX $*"; }
+
+for PROJECT in "${PROJECTS[@]}"; do
+  REPO_DIR="$BASE_DIR/$PROJECT"
+
+  if [ ! -d "$REPO_DIR/.git" ]; then
+    log "$PROJECT: not a git repo, skipping"
+    continue
+  fi
+
+  cd "$REPO_DIR"
+
+  # --- Phase 1: Merge CLEAN PRs directly (bash only, zero AI cost) ---
+  CLEAN_PRS=$(gh pr list --state open --json number,mergeStateStatus,isDraft \
+    --jq '[.[] | select(.isDraft == false and .mergeStateStatus == "CLEAN")] | .[].number' 2>/dev/null || true)
+
+  for PR in $CLEAN_PRS; do
+    log "$PROJECT: PR #$PR is CLEAN — merging directly"
+    gh pr merge "$PR" --squash --auto --delete-branch 2>/dev/null \
+      || gh pr merge "$PR" --squash --delete-branch 2>/dev/null \
+      || log "$PROJECT: PR #$PR — could not merge, skipping"
+  done
+
+  # --- Phase 2: Check for one PR needing AI attention ---
+  ACTIONABLE=$(gh pr list --state open --json number,mergeStateStatus,isDraft \
+    --jq '[.[] | select(.isDraft == false and (.mergeStateStatus == "BEHIND" or .mergeStateStatus == "DIRTY" or .mergeStateStatus == "UNSTABLE" or .mergeStateStatus == "UNKNOWN"))] | .[0].number // empty' 2>/dev/null || true)
+
+  if [ -z "$ACTIONABLE" ]; then
+    log "$PROJECT: no PRs need AI maintenance"
+    continue
+  fi
+
+  log "$PROJECT: PR #$ACTIONABLE needs maintenance — launching archon"
+  archon workflow run archon-pr-maintenance --cwd "$REPO_DIR" "PR #$ACTIONABLE" &
+
+done
+
+# Wait for any background archon runs to complete
+wait
+log "Done"


### PR DESCRIPTION
## Summary

- Removes `--draft` from all three unconditional `gh pr create` invocations in archon workflow YAMLs so new PRs open ready-for-review.
- Commits the in-tree `scripts/pr-maintenance-cron.sh` additions: Phase 0 promotes CLEAN draft PRs to ready, and stderr on `gh pr merge` is now surfaced to the cron log.

Together these close the "green draft sitting idle" failure mode — new PRs default to ready so pr-maintenance Phase 1 can merge them immediately, and the Phase 0 promoter handles any legacy/external drafts.

## Files changed

- `.archon/workflows/defaults/archon-fix-github-issue.yaml` — drop `--draft` from step 6
- `.archon/workflows/defaults/archon-piv-loop.yaml` — drop `--draft` from PR-create instruction
- `.archon/workflows/defaults/archon-ralph-dag.yaml` — drop `--draft` from Phase 6 PR-create instruction
- `scripts/pr-maintenance-cron.sh` — Phase 0 draft-promotion + `2>&1` error surfacing on merge

## Test plan

- [ ] CI green on this PR (meta-test: this PR itself opens ready, not draft)
- [ ] Next archon workflow run opens PR without `--draft`
- [ ] pr-maintenance cron promotes any lingering CLEAN drafts on next tick

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated PR maintenance system for streamlined pull request management.

* **Chores**
  * Updated version to 0.3.6 with refreshed package checksums.
  * Modified workflows to create regular pull requests instead of drafts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->