### PR TITLE
fix(isolation): raise worktree git-operation timeout to 5m (supersedes #1029, closes #1119)

### DIFF
--- a/packages/isolation/src/providers/worktree.ts
+++ b/packages/isolation/src/providers/worktree.ts
@@ -49,6 +49,13 @@ function getLog(): ReturnType<typeof createLogger> {
   return cachedLog;
 }
 
+/**
+ * Ceiling for a single git subprocess in worktree operations (create/fetch/checkout/remove/branch-delete).
+ * Generous enough for repos with heavy post-checkout hooks (lint/install) while still catching genuine
+ * hangs (e.g. credential prompts in non-TTY, stalled network fetches). See #1119, #1029.
+ */
+const GIT_OPERATION_TIMEOUT_MS = 5 * 60 * 1000;
+
 export class WorktreeProvider implements IIsolationProvider {
   readonly providerType = 'worktree';
 
@@ -150,7 +157,7 @@ export class WorktreeProvider implements IIsolationProvider {
       gitArgs.push(worktreePath);
 
       try {
-        await execFileAsync('git', gitArgs, { timeout: 30000 });
+        await execFileAsync('git', gitArgs, { timeout: GIT_OPERATION_TIMEOUT_MS });
         result.worktreeRemoved = true;
       } catch (error) {
         if (!this.isWorktreeMissingError(error)) {
@@ -266,7 +273,9 @@ export class WorktreeProvider implements IIsolationProvider {
     result: DestroyResult
   ): Promise<boolean> {
     try {
-      await execFileAsync('git', ['-C', repoPath, 'branch', '-D', branchName], { timeout: 30000 });
+      await execFileAsync('git', ['-C', repoPath, 'branch', '-D', branchName], {
+        timeout: GIT_OPERATION_TIMEOUT_MS,
+      });
       getLog().debug({ repoPath, branchName }, 'branch_deleted');
       return true;
     } catch (error) {
@@ -301,7 +310,7 @@ export class WorktreeProvider implements IIsolationProvider {
   ): Promise<boolean> {
     try {
       await execFileAsync('git', ['-C', repoPath, 'push', 'origin', '--delete', branchName], {
-        timeout: 30000,
+        timeout: GIT_OPERATION_TIMEOUT_MS,
       });
       getLog().debug({ repoPath, branchName }, 'remote_branch_deleted');
       return true;
@@ -850,7 +859,7 @@ export class WorktreeProvider implements IIsolationProvider {
   ): Promise<void> {
     // Fetch the PR's actual branch
     await execFileAsync('git', ['-C', repoPath, 'fetch', 'origin', prBranch], {
-      timeout: 30000,
+      timeout: GIT_OPERATION_TIMEOUT_MS,
     });
 
     // Try to create worktree with the branch
@@ -859,14 +868,14 @@ export class WorktreeProvider implements IIsolationProvider {
       await execFileAsync(
         'git',
         ['-C', repoPath, 'worktree', 'add', worktreePath, '-b', prBranch, `origin/${prBranch}`],
-        { timeout: 30000 }
+        { timeout: GIT_OPERATION_TIMEOUT_MS }
       );
     } catch (error) {
       const err = error as Error & { stderr?: string };
       // Branch already exists locally - use it directly
       if (err.stderr?.includes('already exists')) {
         await execFileAsync('git', ['-C', repoPath, 'worktree', 'add', worktreePath, prBranch], {
-          timeout: 30000,
+          timeout: GIT_OPERATION_TIMEOUT_MS,
         });
       } else {
         throw error;
@@ -878,7 +887,7 @@ export class WorktreeProvider implements IIsolationProvider {
       await execFileAsync(
         'git',
         ['-C', worktreePath, 'branch', '--set-upstream-to', `origin/${prBranch}`],
-        { timeout: 30000 }
+        { timeout: GIT_OPERATION_TIMEOUT_MS }
       );
     } catch (trackingError) {
       getLog().warn({ err: trackingError, worktreePath, prBranch }, 'upstream_tracking_failed');
@@ -903,11 +912,11 @@ export class WorktreeProvider implements IIsolationProvider {
     if (prSha) {
       // SHA provided: create at specific commit for reproducible reviews
       await execFileAsync('git', ['-C', repoPath, 'fetch', 'origin', `pull/${prNumber}/head`], {
-        timeout: 30000,
+        timeout: GIT_OPERATION_TIMEOUT_MS,
       });
 
       await execFileAsync('git', ['-C', repoPath, 'worktree', 'add', worktreePath, prSha], {
-        timeout: 30000,
+        timeout: GIT_OPERATION_TIMEOUT_MS,
       });
 
       // Create a local tracking branch so it's not detached HEAD
@@ -915,7 +924,7 @@ export class WorktreeProvider implements IIsolationProvider {
         repoPath,
         () =>
           execFileAsync('git', ['-C', worktreePath, 'checkout', '-b', reviewBranch, prSha], {
-            timeout: 30000,
+            timeout: GIT_OPERATION_TIMEOUT_MS,
           }),
         reviewBranch
       );
@@ -927,13 +936,13 @@ export class WorktreeProvider implements IIsolationProvider {
           execFileAsync(
             'git',
             ['-C', repoPath, 'fetch', 'origin', `pull/${prNumber}/head:${reviewBranch}`],
-            { timeout: 30000 }
+            { timeout: GIT_OPERATION_TIMEOUT_MS }
           ),
         reviewBranch
       );
 
       await execFileAsync('git', ['-C', repoPath, 'worktree', 'add', worktreePath, reviewBranch], {
-        timeout: 30000,
+        timeout: GIT_OPERATION_TIMEOUT_MS,
       });
     }
   }
@@ -954,7 +963,7 @@ export class WorktreeProvider implements IIsolationProvider {
       if (err.stderr?.includes('already exists')) {
         getLog().debug({ repoPath, branchName }, 'stale_branch_retry');
         await execFileAsync('git', ['-C', repoPath, 'branch', '-D', branchName], {
-          timeout: 30000,
+          timeout: GIT_OPERATION_TIMEOUT_MS,
         });
         await createCommand();
       } else {
@@ -988,7 +997,7 @@ export class WorktreeProvider implements IIsolationProvider {
         'git',
         ['-C', repoPath, 'worktree', 'add', worktreePath, '-b', branchName, startPoint],
         {
-          timeout: 30000,
+          timeout: GIT_OPERATION_TIMEOUT_MS,
         }
       );
     } catch (error) {
@@ -1016,7 +1025,7 @@ export class WorktreeProvider implements IIsolationProvider {
           timeout: 10000,
         });
         await execFileAsync('git', ['-C', repoPath, 'worktree', 'add', worktreePath, branchName], {
-          timeout: 30000,
+          timeout: GIT_OPERATION_TIMEOUT_MS,
         });
       } else {
         throw error;


### PR DESCRIPTION
## Summary

- **Problem:** All 15 git-subprocess call sites in `WorktreeProvider` hardcoded `timeout: 30000`. Repos with heavy post-checkout hooks (lint, dependency install, submodule init) exceed that budget and fail worktree creation.
- **Why it matters:** Worktree isolation is unusable for such repos — an agent run dies at setup with no path forward.
- **What changed:** Consolidated all 15 timeouts onto a single `GIT_OPERATION_TIMEOUT_MS = 5 * 60 * 1000` constant at the top of `worktree.ts`. 5 min is generous enough to cover realistic hook workloads while still catching genuine hangs (credential prompts in non-TTY, stalled fetches).
- **What did _not_ change (scope boundary):** No new config key, no new env var, no changes to `@archon/git`, `MergedConfig`, or `GlobalConfig`. Other `timeout:` usages outside `WorktreeProvider` are untouched.

### Why this instead of a config key (supersedes #1029)

#1029 proposed a `.archon/config.yaml` `worktree.timeout` option. That approach:
- Adds permanent config surface (doc + maintenance cost) for a problem reported by a single user
- Half-measures the fix: 11 of 15 hardcoded sites become configurable, 4 stay hardcoded
- Introduces user-facing choice where a sensible default removes the need

Raising the default covers the reported case with zero API surface. If 5 min later turns out to also be too tight in real-world use, the config key stays an option on the table.

## UX Journey

### Before

```
  User                 WorktreeProvider              git subprocess
  ────                 ────────────────              ──────────────
  runs workflow ─────▶ worktree.add ────────────────▶ runs post-checkout hook
                       (30s timeout)                  (lint/install: 45s)
                                                      ↳ TIMEOUT ❌
                       surfaces error ◀──────────────
  sees failure ◀──────
```

### After

```
  User                 WorktreeProvider              git subprocess
  ────                 ────────────────              ──────────────
  runs workflow ─────▶ worktree.add ────────────────▶ runs post-checkout hook
                       *(5m timeout)*                 (lint/install: 45s)
                                                      ↳ completes ✅
                       returns env ◀──────────────────
  workflow runs ◀─────
```

## Architecture Diagram

### Before

```
WorktreeProvider
├─ 15× execFileAsync('git', ..., { timeout: 30000 })
└─ no shared constant
```

### After

```
WorktreeProvider
├─ [+] const GIT_OPERATION_TIMEOUT_MS = 5 * 60 * 1000
└─ 15× execFileAsync('git', ..., { timeout: GIT_OPERATION_TIMEOUT_MS })
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `GIT_OPERATION_TIMEOUT_MS` (new local const) | 15× `execFileAsync` call sites in `worktree.ts` | **new** | Single source of truth |

No inter-module connections changed.

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `isolation`
- Module: `isolation:worktree-provider`

## Change Metadata

- Change type: `fix`
- Primary scope: `isolation`

## Linked Issue

- Closes #1119
- Supersedes #1029

## Validation Evidence (required)

```bash
bun run type-check   # ✅ all 10 packages
bun run lint         # ✅ 0 errors, 0 warnings
bun --filter @archon/isolation test  # ✅ 244 tests pass
```

- Evidence: type-check/lint/test runs locally, green.
- Nothing intentionally skipped.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes` — behavior change is strictly "waits longer before timing out"
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios: Type-check, lint, isolation test suite all pass locally.
- Edge cases checked: Constant is applied consistently to all 15 call sites (creation, PR fetch/checkout, branch delete, worktree remove). No stray hardcoded `30000` remains in `worktree.ts`.
- What was not verified: Live repro against a repo with a >30s post-checkout hook. The change is mechanical — raising a ceiling — and the runtime behavior is directly implied by the constant value.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Any workflow using worktree isolation (i.e. the default path). All other isolation modes untouched.
- Potential unintended effects: A truly hung git subprocess (e.g. credential prompt in non-TTY) now takes 5 min instead of 30s to surface. Acceptable tradeoff — still surfaces, just later.
- Guardrails/monitoring for early detection: Existing `'worktree.*_failed'` log events fire on timeout-derived errors. No new monitoring needed.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>` — single-file, single-constant change.
- Feature flags or config toggles: N/A.
- Observable failure symptoms: Worktree operations time out at 5 min instead of 30s (prior behavior). If even 5 min proves too tight, revisit with #1029's config-key approach.

## Risks and Mitigations

- Risk: A truly stuck git subprocess now takes 5× longer to surface (30s → 5m).
  - Mitigation: The prior 30s ceiling was often too low to be diagnostic (failures masked as "hooks slow" vs. "actually hung"). 5 min is still a bounded ceiling and the user can always abort.

---

Credit to @norbinsh for raising #1119 and scoping the problem clearly in #1029.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code consistency for internal git timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->