### PR TITLE
fix(docker): register safe.directory for all repos on bind-mount restart

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,6 +19,17 @@ else
   RUNNER=""
 fi
 
+# Register all git repositories under /.archon as safe directories.
+# Git 2.35.2+ (CVE-2022-24765) rejects repos owned by a different UID.
+# On macOS bind mounts (VirtioFS), host UIDs don't map to appuser (1001),
+# so git prints "dubious ownership" and refuses all operations.
+# The Dockerfile RUN-layer registers fixed paths, but that gitconfig lives
+# in the image layer — bind mounts don't inherit it on restart, and
+# worktrees are nested at arbitrary depths unknown at build time.
+find /.archon -name ".git" 2>/dev/null | while read -r git_dir; do
+  $RUNNER git config --global --add safe.directory "$(dirname "$git_dir")"
+done
+
 # Configure git to use GH_TOKEN for HTTPS clones via credential helper
 # Uses a helper function so the token stays in the environment, not in ~/.gitconfig
 if [ -n "$GH_TOKEN" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -26,7 +26,7 @@ fi
 # The Dockerfile RUN-layer registers fixed paths, but that gitconfig lives
 # in the image layer — bind mounts don't inherit it on restart, and
 # worktrees are nested at arbitrary depths unknown at build time.
-find /.archon -name ".git" 2>/dev/null | while read -r git_dir; do
+find /.archon -name ".git" -prune -print 2>/dev/null | while IFS= read -r git_dir; do
   $RUNNER git config --global --add safe.directory "$(dirname "$git_dir")"
 done
 


### PR DESCRIPTION
## Summary

- **Problem:** On macOS Docker Desktop (VirtioFS), bind-mount deployments break after every container restart — all git operations fail with "dubious ownership" errors
- **Why it matters:** Blocks every Archon workflow that touches a project after a container restart on macOS
- **What changed:** Added a `find` loop in `docker-entrypoint.sh` that dynamically discovers `.git` directories under `/.archon` and registers them as `safe.directory` on each container start
- **What did not change (scope boundary):** Dockerfile build-time git config unchanged; no changes to git operations themselves, only the safe.directory registration

## Problem

On macOS with Docker Desktop (VirtioFS), bind-mount deployments break after every container restart. All git operations inside the container fail with:

```
fatal: detected dubious ownership in repository at '/.archon/workspaces/…'
```

This blocks every Archon workflow that touches a project.

## Root Cause

Git 2.35.2+ (CVE-2022-24765) rejects repos where the directory owner differs from the running user. On macOS bind mounts, host UIDs (e.g. 501) do not map to the container's `appuser` (1001). The Dockerfile `RUN git config --global --add safe.directory ...` registers fixed paths at build time, but:

1. On bind mounts, `/home/appuser/.gitconfig` is not inherited from the image layer on restart
2. Worktrees are created at arbitrary nesting depths unknown at build time

## Fix

Add a `find` loop in `docker-entrypoint.sh` that dynamically discovers every `.git` directory under `/.archon` and registers its parent as a `safe.directory` on each container start. This runs after the `chown` block, is idempotent, and handles:

- Main source clones under `/.archon/workspaces/owner/repo/source/`
- Git worktrees at any nesting depth
- Non-root containers (`--user` flag or Kubernetes)

## UX Journey

### Before

```
  User                   Docker                   Archon Container
  ────                   ──────                   ────────────────
  docker compose up ──▶  starts container
                         bind-mounts /.archon
                         runs entrypoint ────────▶ chown + credential setup
                                                   (no safe.directory registration)
  uses Archon ─────────────────────────────────────▶ git operation
                                                   ✗ "fatal: dubious ownership"
  stuck — must rebuild image or manually fix
```

### After

```
  User                   Docker                   Archon Container
  ────                   ──────                   ────────────────
  docker compose up ──▶  starts container
                         bind-mounts /.archon
                         runs entrypoint ────────▶ chown + credential setup
                                                   [find .git dirs → register safe.directory]
  uses Archon ─────────────────────────────────────▶ git operation
                                                   ✓ works normally
```

## Architecture Diagram

### Before

```
  docker-entrypoint.sh
  ├── UID detection (root vs non-root)
  ├── chown /.archon
  ├── GH_TOKEN credential helper setup
  └── exec main process
```

### After

```
  docker-entrypoint.sh
  ├── UID detection (root vs non-root)
  ├── chown /.archon
  ├── [+] find /.archon -name ".git" → register safe.directory
  ├── GH_TOKEN credential helper setup
  └── exec main process
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| docker-entrypoint.sh | git config --global | **new** | Registers safe.directory for discovered repos |
| docker-entrypoint.sh | find (/.archon) | **new** | Discovers .git dirs under bind mount |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `config`
- Module: `config:docker-entrypoint`

## Change Metadata

- Change type: `bug`
- Primary scope: `config`
- Files changed: 1 (`docker-entrypoint.sh`)
- Lines added: ~11

## Linked Issue

- Closes #1279

## Validation Evidence (required)

- Verified script logic handles both root (gosu) and non-root paths
- `find ... -name ".git"` correctly discovers nested worktrees
- Duplicate `safe.directory` entries are harmless per git docs
- Shell syntax validated (POSIX-compatible `find | while read`)

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No` — only reads `.git` directory names under the existing `/.archon` mount, then writes to git global config

## Compatibility / Migration

- Backward compatible? `Yes` — additive only, no behavior change for non-bind-mount deployments
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios: macOS Docker Desktop with VirtioFS bind mounts; container restart cycle
- Edge cases checked: no `.git` dirs found (loop is a no-op), deeply nested worktrees, non-root container user
- What was not verified: Linux overlay2 (expected no-op since UIDs match)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Container startup only — adds ~0.1s to entrypoint execution
- Potential unintended effects: None expected — `safe.directory` entries are additive and idempotent; duplicate entries are harmless per git documentation
- Guardrails/monitoring for early detection: If `find` fails (e.g. `/.archon` doesn't exist), `2>/dev/null` suppresses errors and the loop simply doesn't execute

## Rollback Plan (required)

- Fast rollback command/path: Revert this commit; the entrypoint change is self-contained in one block
- Feature flags or config toggles: None needed — the fix is unconditional but idempotent
- Observable failure symptoms: If rollback is needed, users will see "dubious ownership" errors on macOS bind-mount restarts (the original bug)

## Risks and Mitigations

- Risk: `find` scanning a very large `/.archon` tree could slow container startup
  - Mitigation: `find` uses `-prune` on `.git` matches, preventing descent into git internals; typical repos have < 10 `.git` dirs
- Risk: Running `git config --global` as root could write to wrong user's gitconfig
  - Mitigation: The `$RUNNER` variable (set to `gosu appuser` when running as root) ensures config is written to the correct user's gitconfig

Closes #1279
