### PR TITLE
fix(providers/claude): initialize options.hooks before per-node hook merge

### DIFF
--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -866,6 +866,34 @@ describe('ClaudeProvider', () => {
       expect(callArgs.options.sandbox).toEqual(sandbox);
     });
 
+    test('initializes options.hooks when nodeConfig provides hooks and options.hooks is undefined', async () => {
+      // Regression: applyNodeConfig previously assumed options.hooks was
+      // already an object when per-node hooks were declared, causing
+      // "undefined is not an object" at runtime for any workflow using
+      // per-node hooks (e.g. archon-architect, archon-refactor-safely).
+      mockQuery.mockImplementation(async function* () {
+        yield { type: 'result', session_id: 'sid' };
+      });
+
+      for await (const _ of client.sendQuery('test', '/tmp', undefined, {
+        nodeConfig: {
+          hooks: {
+            PostToolUse: [{ matcher: 'Write', response: { continue: true } }],
+          },
+        },
+      })) {
+        // consume
+      }
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const callArgs = mockQuery.mock.calls[0][0] as {
+        options: { hooks?: Record<string, Array<{ matcher?: string }>> };
+      };
+      expect(callArgs.options.hooks).toBeDefined();
+      expect(callArgs.options.hooks?.PostToolUse).toBeDefined();
+      expect(callArgs.options.hooks?.PostToolUse?.[0]?.matcher).toBe('Write');
+    });
+
     test('ignores empty text blocks', async () => {
       mockQuery.mockImplementation(async function* () {
         yield {

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -382,6 +382,7 @@ async function applyNodeConfig(
     if (Object.keys(builtHooks).length > 0) {
       // Merge with existing hooks (PostToolUse capture hook)
       const existingHooks = options.hooks as SDKHooksMap | undefined;
+      options.hooks ??= {};
       for (const [event, matchers] of Object.entries(builtHooks)) {
         if (!matchers) continue;
         const existing = existingHooks?.[event] as HookCallbackMatcher[] | undefined;


### PR DESCRIPTION
## Summary

`applyNodeConfig` writes into `options.hooks[event]` without guaranteeing the hooks map is initialized. Any workflow that declares per-node `hooks` (e.g. `archon-architect`, `archon-refactor-safely`) crashes at runtime with:

\`\`\`
TypeError: undefined is not an object (evaluating 'options.hooks[event] = matchers')
  at applyNodeConfig (packages/providers/src/claude/provider.ts:394)
  at sendQuery (packages/providers/src/claude/provider.ts:934)
\`\`\`

The function explicitly acknowledges `options.hooks` may be undefined one line above (`existingHooks` typed as `SDKHooksMap | undefined`), so the fix is to materialize the object before the write loop runs.

## Reproduction (pre-fix)

Run any workflow with per-node hooks against the Claude provider — the first AI node crashes in `applyNodeConfig`. Real-world impact: `archon-architect` dies on the `analyze` node; `archon-refactor-safely` fails identically.

## Fix

```ts
if (Object.keys(builtHooks).length > 0) {
  const existingHooks = options.hooks as SDKHooksMap | undefined;
  options.hooks ??= {};   // ← added
  for (const [event, matchers] of Object.entries(builtHooks)) { ... }
}
```

## Why this is safe

- **Minimal**: one line, landing after the `existingHooks` capture so the read semantics are preserved.
- **Idempotent when `options.hooks` exists**: `??=` is a no-op; the merge-with-existing path runs identically.
- **Fixes the crash path**: when `options.hooks` is undefined, it becomes `{}`, then the loop populates it — exactly what the original code was trying to do.
- **Downstream contract unchanged**: existing tests already use optional chaining (`args.options.hooks?.PostToolUse` in `provider.test.ts:1113`), so callers already handle a potentially-absent `hooks`.

## Alternatives considered

- Initializing `options.hooks = {}` at the top of `applyNodeConfig` — changes the contract when `nodeConfig.hooks` is absent (currently leaves `options.hooks` untouched).
- Refactoring the cast-based assignment pattern into typed narrowing — larger scope, better as a follow-up.

## Test plan

- [x] New regression test in `provider.test.ts` drives `sendQuery` with `nodeConfig.hooks` and asserts the SDK receives `options.hooks` populated. The test **fails with the original TypeError on unpatched code** (verified by stashing the fix and rerunning).
- [x] Full suite — `bun run test` for `packages/providers`: 69 pass, 0 fail.
- [x] `bun run type-check` — all 10 packages pass.
- [x] `bun run lint` — clean.
- [x] `bun run format` — no changes required.

Happy to adjust wording or expand tests — this surfaced while running `archon-architect` against an unrelated repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced hook configuration initialization to ensure reliable setup and prevent potential undefined access errors when merging node-specific hooks with provider configurations.

* **Tests**
  * Added regression test validating that hook configurations are properly initialized and preserved during the merging of node-specific hooks with provider options, even when initial state is undefined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->