### PR TITLE
fix(providers/pi): add missing providers to env-var forwarding map

### DIFF
--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -199,6 +199,7 @@ describe('PiProvider', () => {
     runtimeOverrides = {};
     delete process.env.GEMINI_API_KEY;
     delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.MINIMAX_API_KEY;
   });
 
   test('getType returns "pi"', () => {
@@ -329,6 +330,43 @@ describe('PiProvider', () => {
     // Runtime override is priority #1 in Pi's resolution chain, so getApiKey
     // returns 'from-request-env' (via our mock's runtimeOverrides map).
     expect(runtimeOverrides.google).toBe('from-request-env');
+  });
+
+  test('MINIMAX_API_KEY from codebase env is forwarded to setRuntimeApiKey', async () => {
+    // Regression: minimax used to fall through to Pi's internal getEnvApiKey
+    // (process.env only) because it wasn't in PI_PROVIDER_ENV_VARS. Without
+    // a whitelist entry, codebase-scoped env vars (.archon/config.yaml env:)
+    // never reached Pi. Adding 'minimax' to the map fixes that.
+    resetScript([
+      {
+        type: 'agent_end',
+        messages: [
+          {
+            role: 'assistant',
+            usage: {
+              input: 1,
+              output: 1,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 2,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: 'stop',
+            content: [],
+          },
+        ],
+      },
+    ]);
+
+    await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, {
+        model: 'minimax/MiniMax-M2.7',
+        env: { MINIMAX_API_KEY: 'sk-minimax-from-codebase' },
+      })
+    );
+
+    expect(mockSetRuntimeApiKey).toHaveBeenCalledWith('minimax', 'sk-minimax-from-codebase');
+    expect(runtimeOverrides.minimax).toBe('sk-minimax-from-codebase');
   });
 
   test('env var overrides auth.json api_key entry', async () => {

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -43,6 +43,10 @@ const PI_PROVIDER_ENV_VARS: Record<string, string> = {
   xai: 'XAI_API_KEY',
   openrouter: 'OPENROUTER_API_KEY',
   huggingface: 'HUGGINGFACE_API_KEY',
+  minimax: 'MINIMAX_API_KEY',
+  'minimax-cn': 'MINIMAX_CN_API_KEY',
+  zai: 'ZAI_API_KEY',
+  'vercel-ai-gateway': 'AI_GATEWAY_API_KEY',
 };
 
 let cachedLog: ReturnType<typeof createLogger> | undefined;


### PR DESCRIPTION
## Summary

- `PI_PROVIDER_ENV_VARS` acts as a whitelist that bridges codebase-scoped env
  vars (`.archon/config.yaml` `env:` section) into Pi's `setRuntimeApiKey`.
  Without an entry, the key is silently dropped — Pi falls through to its own
  `getEnvApiKey` which only reads `process.env`, so codebase-level config has
  no effect.
- Adds `minimax`, `minimax-cn`, `zai`, and `vercel-ai-gateway` to the map.

## Test plan

- [ ] `bun test packages/providers/src/community/pi/provider.test.ts` — new
  regression test covers the `minimax` case end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pi provider now supports environment variable overrides for Minimax, Minimax-CN, Zai, and Vercel AI Gateway credentials.

* **Tests**
  * Added regression test for credential configuration in Pi provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->