### PR TITLE
docs(pi): publish Pi docs from dev

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,7 +2,7 @@ name: Deploy Docs
 
 on:
   push:
-    branches: [main]
+    branches: [dev]
     paths: ['packages/docs-web/**']
   workflow_dispatch:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+Read @CLAUDE.md

--- a/packages/docs-web/astro.config.mjs
+++ b/packages/docs-web/astro.config.mjs
@@ -20,7 +20,7 @@ export default defineConfig({
       ],
       social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/coleam00/Archon' }],
       editLink: {
-        baseUrl: 'https://github.com/coleam00/Archon/edit/main/packages/docs-web/',
+        baseUrl: 'https://github.com/coleam00/Archon/edit/dev/packages/docs-web/',
       },
       sidebar: [
         {

--- a/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
+++ b/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
@@ -227,7 +227,7 @@ If you want Codex to be the default AI assistant for new conversations without c
 DEFAULT_AI_ASSISTANT=codex
 ```
 
-## Pi (Community Provider)
+## Pi (Community Provider / pi.dev)
 
 **One adapter, ~20 LLM backends.** Pi (`@mariozechner/pi-coding-agent`) is a community-maintained coding-agent harness that Archon integrates as the first community provider. It unlocks Anthropic, OpenAI, Google (Gemini + Vertex), Groq, Mistral, Cerebras, xAI, OpenRouter, Hugging Face, and more under a single `provider: pi` entry.
 
@@ -235,11 +235,26 @@ Pi is registered as `builtIn: false` — it validates the community-provider sea
 
 ### Install
 
-Pi is included as a dependency of `@archon/providers` — no separate install needed. It's available immediately.
+Archon's Pi provider is included as a dependency of `@archon/providers` — no separate Archon plugin is needed.
+
+If you want to use Pi's own login flow, manage Pi packages/extensions, or populate `~/.pi/agent/auth.json` locally, install the upstream `pi` CLI too:
+
+```bash
+npm install -g @mariozechner/pi-coding-agent
+```
+
+Official docs live at [pi.dev](https://pi.dev).
 
 ### Authenticate
 
-Pi supports both OAuth subscriptions and API keys. Archon's adapter reads your existing Pi credentials from `~/.pi/agent/auth.json` (written by running `pi` → `/login`) AND from env vars — env vars take priority per-request so codebase-scoped overrides work.
+Pi supports both OAuth subscriptions and API keys. Archon's adapter reads your existing Pi credentials from `~/.pi/agent/auth.json` (written by running `pi`, then `/login`) AND from env vars — env vars take priority per-request so codebase-scoped overrides work.
+
+If you want subscription-backed auth, install the upstream CLI above, then run:
+
+```bash
+pi
+# then type: /login
+```
 
 **OAuth subscriptions (run `pi /login` locally):**
 - Anthropic Claude Pro/Max
@@ -371,6 +386,7 @@ Unsupported YAML fields trigger a visible warning from the dag-executor when the
 
 ### See also
 
+- [pi.dev](https://pi.dev) — official docs.
 - [Adding a Community Provider](../contributing/adding-a-community-provider/) — the contributor-facing guide for extending Archon with your own provider.
 - [Pi on GitHub](https://github.com/badlogic/pi-mono) — upstream project.
 

--- a/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
+++ b/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
@@ -256,7 +256,7 @@ pi
 # then type: /login
 ```
 
-**OAuth subscriptions (run `pi /login` locally):**
+**OAuth subscriptions (run `pi`, then type `/login` locally):**
 - Anthropic Claude Pro/Max
 - OpenAI ChatGPT Plus/Pro
 - GitHub Copilot

--- a/packages/docs-web/src/content/docs/getting-started/quick-start.md
+++ b/packages/docs-web/src/content/docs/getting-started/quick-start.md
@@ -10,9 +10,9 @@ sidebar:
 ## Prerequisites
 
 1. [Install Archon](/getting-started/installation/)
-2. [Install Claude Code](/getting-started/ai-assistants/#claude-code) — Archon orchestrates it but does not bundle it
-3. Authenticate with Claude: run `claude /login` (uses your existing Claude Pro/Max subscription)
-4. In compiled Archon binaries, set `CLAUDE_BIN_PATH` (see [Binary path configuration](/getting-started/ai-assistants/#binary-path-configuration-compiled-binaries-only))
+2. [Set up an AI assistant](/getting-started/ai-assistants/) — Claude Code, Codex, and pi.dev are supported
+3. Authenticate the assistant you plan to use
+4. If you use compiled Archon binaries with Claude Code, set `CLAUDE_BIN_PATH` (see [Binary path configuration](/getting-started/ai-assistants/#binary-path-configuration-compiled-binaries-only))
 5. Navigate to any git repository
 
 ## Run Your First Workflow

--- a/packages/docs-web/src/content/docs/index.mdx
+++ b/packages/docs-web/src/content/docs/index.mdx
@@ -61,6 +61,6 @@ Archon is a **workflow engine for AI coding agents**. Define multi-step developm
     Chain nodes into DAGs with dependencies, loops, and conditional logic
   </Card>
   <Card title="Multi-provider" icon="rocket">
-    Works with Claude Code SDK and Codex SDK
+    Works with Claude Code, Codex, and pi.dev
   </Card>
 </CardGrid>


### PR DESCRIPTION
Closes #1324

## Summary
- add the missing pi.dev / upstream `pi` CLI install and `/login` guidance to the Pi assistant docs
- update stale getting-started copy that still implied only Claude Code and Codex support
- publish docs from `dev` and point docs edit links at `dev`, which is where Pi support/docs currently live

## Why
The public docs site was stale because Pi support already exists on `dev`, but the Pages workflow was still deploying `main`. That left `archon.diy/getting-started/ai-assistants/` missing the Pi section even though the repo and README already referenced Pi support.

## Verification
- `bun run build:docs`
- `bun run lint`
- `bun run type-check`
- `bun run format:check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added pi.dev as a supported AI assistant alongside Claude Code and Codex
  * Expanded Quick Start to cover multiple AI assistants and clarified authentication flows
  * Enhanced Pi provider docs with optional CLI setup and credential guidance; added a “See also” link
  * Minor doc text updates and a cross-reference added to agent guidance

* **Chores**
  * Documentation deployment now tracks the development branch instead of the main branch
<!-- end of auto-generated comment: release notes by coderabbit.ai -->