### PR TITLE
fix(adapters): bump telegramify-markdown to 1.3.3 for blockquote escaping

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,7 @@
         "@slack/bolt": "^4.6.0",
         "discord.js": "^14.16.0",
         "grammy": "^1.36.0",
-        "telegramify-markdown": "^1.3.0",
+        "telegramify-markdown": "^1.3.3",
       },
       "peerDependencies": {
         "typescript": "^5.0.0",
@@ -2584,7 +2584,7 @@
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
-    "telegramify-markdown": ["telegramify-markdown@1.3.2", "", { "dependencies": { "mdast-util-gfm-table": "^0.1.6", "mdast-util-to-markdown": "^0.6.2", "remark-gfm": "^1.0.0", "remark-parse": "^9.0.0", "remark-remove-comments": "^0.2.0", "remark-stringify": "^9.0.1", "unified": "^9.0.0", "unist-util-remove": "^2.0.1", "unist-util-visit": "^2.0.3" } }, "sha512-otv/SSjJD4MQGBYcRqkSchs84nYBYQoE2BqplQTIoIMN4nT0tDZgxbU5yjdBLkNxaQfkzYja27Hl/hcVJwewcg=="],
+    "telegramify-markdown": ["telegramify-markdown@1.3.3", "", { "dependencies": { "mdast-util-gfm-table": "^0.1.6", "mdast-util-to-markdown": "^0.6.2", "remark-gfm": "^1.0.0", "remark-parse": "^9.0.0", "remark-remove-comments": "^0.2.0", "remark-stringify": "^9.0.1", "unified": "^9.0.0", "unist-util-remove": "^2.0.1", "unist-util-visit": "^2.0.3" } }, "sha512-cyMqOrXFJfKzOrrUc1JlnfRwvC7HR+DzzlUItQs+I9bGTO9TSyvpgt27UQ9YXm2sXb3ltzBvvAq/IEWqdk6xkg=="],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -23,7 +23,7 @@
     "@slack/bolt": "^4.6.0",
     "discord.js": "^14.16.0",
     "grammy": "^1.36.0",
-    "telegramify-markdown": "^1.3.0"
+    "telegramify-markdown": "^1.3.3"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/packages/adapters/src/chat/telegram/markdown.test.ts
+++ b/packages/adapters/src/chat/telegram/markdown.test.ts
@@ -67,6 +67,16 @@ describe('telegram-markdown', () => {
       });
     });
 
+    describe('blockquotes', () => {
+      // Regression: telegramify-markdown 1.3.2 escaped the `>` marker and
+      // double-escaped any other special character on the same line, which
+      // Telegram rejected with "Character '.' is reserved and must be
+      // escaped". 1.3.3 fixes both. See coleam00/Archon#1102.
+      test('escapes special chars exactly once inside blockquotes', () => {
+        expect(convertToTelegramMarkdown('> hi.')).toBe('> hi\\.\n');
+      });
+    });
+
     describe('edge cases', () => {
       test('handles empty string', () => {
         const result = convertToTelegramMarkdown('');

--- a/packages/adapters/src/chat/telegram/markdown.test.ts
+++ b/packages/adapters/src/chat/telegram/markdown.test.ts
@@ -75,6 +75,14 @@ describe('telegram-markdown', () => {
       test('escapes special chars exactly once inside blockquotes', () => {
         expect(convertToTelegramMarkdown('> hi.')).toBe('> hi\\.\n');
       });
+
+      test('escapes multiple special chars exactly once on the same blockquote line', () => {
+        expect(convertToTelegramMarkdown('> a.b-c!')).toBe('> a\\.b\\-c\\!\n');
+      });
+
+      test('preserves the `>` marker on every line of a multi-line blockquote', () => {
+        expect(convertToTelegramMarkdown('> first.\n> second?')).toBe('> first\\.\n> second?\n');
+      });
     });
 
     describe('edge cases', () => {

--- a/packages/adapters/src/chat/telegram/markdown.test.ts
+++ b/packages/adapters/src/chat/telegram/markdown.test.ts
@@ -68,10 +68,10 @@ describe('telegram-markdown', () => {
     });
 
     describe('blockquotes', () => {
-      // Regression: telegramify-markdown 1.3.2 escaped the `>` marker and
-      // double-escaped any other special character on the same line, which
+      // Regression: telegramify-markdown escaped the `>` blockquote marker
+      // and double-escaped special characters on the same line, which
       // Telegram rejected with "Character '.' is reserved and must be
-      // escaped". 1.3.3 fixes both. See coleam00/Archon#1102.
+      // escaped". See coleam00/Archon#1102.
       test('escapes special chars exactly once inside blockquotes', () => {
         expect(convertToTelegramMarkdown('> hi.')).toBe('> hi\\.\n');
       });


### PR DESCRIPTION
## Summary

- **Problem**: Telegram adapter crashes with `400: can't parse entities: Character '.' is reserved` on every blockquote that contains a MarkdownV2 special character on the same line. Bot retries as plain text, so users get the content, but every workflow-start banner that quotes a workflow's `description:` loses formatting and logs `telegram.markdownv2_failed`.
- **Why it matters**: Workflow notifications are how operators see what Archon is doing live; silently degraded formatting on every banner is bad UX and noisy in operator metrics.
- **What changed**: Bumped `telegramify-markdown` from `^1.3.0` (resolving to 1.3.2) to `^1.3.3` in `packages/adapters/package.json`; refreshed `bun.lock`; added a regression test in `packages/adapters/src/chat/telegram/markdown.test.ts`.
- **What did NOT change (scope boundary)**: No production code in `packages/adapters/` was modified. No other package was touched. No new dependencies, no exports changed.

## Root Cause

`packages/adapters` pinned `telegramify-markdown@^1.3.0`, resolving to `1.3.2`. That version escapes the `>` blockquote marker (Telegram MarkdownV2 supports `>` natively) **and** double-escapes any other special character on the same line:

```ts
import telegramify from 'telegramify-markdown';
telegramify('> blockquote.', 'escape');
// 1.3.2: "\\> blockquote\\\\.\n"   → literal: \> blockquote\\.   (rejected)
// 1.3.3: "> blockquote\\.\n"       → literal: > blockquote\.    (accepted)
```

Upstream fix: skitsanos/telegramify-markdown@1.3.3.

## UX Journey

### Before

```
Operator                            Archon                          Telegram API
────────                            ──────                          ────────────
runs workflow ─────────────────▶    builds banner with blockquote
                                    telegramify('> a.', 'escape')
                                    → "\\> a\\\\.\n"
                                    posts to Telegram ───────────▶  400: Character '.' reserved
                                    ◀───────────────────────────── (rejection)
                                    retries as plain text ───────▶  accepted (no formatting)
sees plain-text banner ◀──────────  notification arrives, formatting lost
```

### After

```
Operator                            Archon                          Telegram API
────────                            ──────                          ────────────
runs workflow ─────────────────▶    builds banner with blockquote
                                    telegramify('> a.', 'escape')
                                    → "> a\\.\n"          [1.3.3]
                                    posts to Telegram ───────────▶  200 OK
sees formatted banner ◀───────────  notification arrives, blockquote intact
```

## Architecture Diagram

No production module changes — dependency floor bump + regression test only.

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `packages/adapters` | `telegramify-markdown` (npm) | **modified** | floor bumped 1.3.0 → 1.3.3 in `package.json` + `bun.lock` |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `adapters`
- Module: `adapters:telegram`

## Change Metadata

- Change type: `bug`
- Primary scope: `adapters`

## Linked Issue

- Fixes #1102

## Validation Evidence (required)

```bash
bun test src/chat/telegram/markdown.test.ts   # 25 pass, 0 fail
bun run check:bundled                          # bundled-defaults.generated.ts is up to date
bun run type-check                             # all 10 packages: exit 0
bun run lint                                   # clean
bun x prettier --check .                       # All matched files use Prettier code style!
bun run --filter '*' test                      # all 10 packages: exit 0
```

- Evidence provided: stash-bisect verified — reverting the bump locally produces a failing assertion in the new regression test (`'> hi\\\\.\n'` returned vs `'> hi\\.\n'` expected).
- All commands run on the PR HEAD (d25252f).

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No**

## Compatibility / Migration

- Backward compatible? **Yes** — `telegramify-markdown` 1.3.2 → 1.3.3 is a patch release. Only the over-escape behaviour for `>`-prefixed lines changes; Telegram accepts the new (correct) output where it rejected the old.
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

- Verified scenarios:
  - `'> blockquote.'` → `'> blockquote\\.\n'` (single-char same-line)
  - `'> a.b-c!'` → `'> a\\.b\\-c\\!\n'` (multi-char same-line, broadened in d25252f)
  - `'> first.\n> second?'` → `'> first\\.\n> second?\n'` (multi-line; `?` correctly passes through, not in MarkdownV2's reserved set)
- Edge cases checked:
  - Blockquotes without special characters: output identical to 1.3.2; existing tests still pass.
  - Non-blockquote content with special characters: 1.3.3 changes only the `>`-line escaping path.
  - bun.lock floor: confirmed `telegramify-markdown@1.3.3` resolves under the new `^1.3.3` constraint with no transitive downgrade.
- What was not verified: live Telegram API send — I do not have a Telegram bot token available. Verified rendered string shape only; the upstream library tests verify Telegram acceptance.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `packages/adapters/src/chat/telegram` only — workflows that emit Telegram notifications (workflow-start banners, error notifications, run-summary messages).
- Potential unintended effects: any consumer that depended on the old over-escape behaviour would see different output. None expected — the old shape was rejected by Telegram, so any caller receiving it had to fall back to plain text already.
- Guardrails/monitoring for early detection: the new regression test asserts the 1.3.3 shape verbatim; if a future floor relaxation re-introduces the double-escape, CI fails.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge-commit-sha>` — single commit, three files (`package.json`, `bun.lock`, one test file).
- Feature flags or config toggles: none — telegramify-markdown is a direct dependency, no toggle layer.
- Observable failure symptoms: `telegram.markdownv2_failed` log lines reappear in operator metrics; blockquote-bearing notifications drop back to plain text.

## Risks and Mitigations

- Risk: a downstream consumer of `convertToTelegramMarkdown` may have been depending on the over-escaped output as a workaround.
  - Mitigation: the only in-tree consumer is the Telegram adapter's send path, which always sent the over-escaped output to Telegram (which rejected it). No callers of the function exist outside the adapter.
- Risk: telegramify-markdown 1.3.3 introduces a different bug.
  - Mitigation: floor pinned at 1.3.3 (caret allows future patch+minor); upstream changelog frames this as a targeted fix to the over-escape path. The new regression test asserts the exact expected output, so any future regression in the relevant code path is caught at CI time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency versions for improved compatibility and stability

* **Tests**
  * Enhanced test coverage for markdown conversion reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1340?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->