### PR TITLE
fix(web): use node id as label for bash nodes in DAG graph

### DIFF
--- a/packages/web/src/lib/dag-layout.ts
+++ b/packages/web/src/lib/dag-layout.ts
@@ -52,7 +52,7 @@ export function resolveNodeDisplay(dn: DagNode): {
 } {
   if ('bash' in dn && dn.bash) {
     return {
-      label: 'Shell',
+      label: dn.id,
       nodeType: 'bash',
       bashScript: dn.bash,
       bashTimeout: dn.timeout,


### PR DESCRIPTION
## Fix: Bash node graph labels show 'BASH Shell' instead of node id

**Problem:** Bash nodes in the workflow DAG graph always display 'Shell' as their label, making it impossible to distinguish between different bash nodes without counting positions.

**Solution:** In `resolveNodeDisplay()` (`packages/web/src/lib/dag-layout.ts`), return `dn.id` as the label for bash nodes instead of the hardcoded string 'Shell'.

**Before:** `BASH Shell 2.0m | BASH Shell 2.2m | BASH Shell 2.0m`  
**After:** `security-review 2.0m | architecture-review 2.2m | synthesise 5.6m`

Fixes #1321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bash nodes in the DAG view now display their unique identifiers instead of generic labels for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->