### PR TITLE
fix(workflows): make archon-adversarial-dev sed replacement macOS-safe based on #1155

### DIFF
--- a/.archon/workflows/defaults/archon-adversarial-dev.yaml
+++ b/.archon/workflows/defaults/archon-adversarial-dev.yaml
@@ -101,7 +101,9 @@ nodes:
         "status": "running"
       }
       STATEEOF
-      sed -i "s/SPRINT_COUNT_PLACEHOLDER/$SPRINT_COUNT/" "$ARTIFACTS/state.json"
+      STATE_TMP="$ARTIFACTS/state.json.tmp"
+      sed "s/SPRINT_COUNT_PLACEHOLDER/$SPRINT_COUNT/" "$ARTIFACTS/state.json" > "$STATE_TMP"
+      mv "$STATE_TMP" "$ARTIFACTS/state.json"
 
       echo "{\"totalSprints\": $SPRINT_COUNT, \"appDir\": \"$ARTIFACTS/app\", \"artifactsDir\": \"$ARTIFACTS\"}"
     timeout: 30000

--- a/packages/workflows/src/defaults/bundled-defaults.test.ts
+++ b/packages/workflows/src/defaults/bundled-defaults.test.ts
@@ -119,6 +119,16 @@ describe('bundled-defaults', () => {
       expect(content).toContain('workflow_name');
     });
 
+    it('archon-adversarial-dev init-workspace should avoid non-portable sed -i', () => {
+      const content = BUNDLED_WORKFLOWS['archon-adversarial-dev'];
+      expect(content).toContain('STATE_TMP="$ARTIFACTS/state.json.tmp"');
+      expect(content).toContain(
+        'sed "s/SPRINT_COUNT_PLACEHOLDER/$SPRINT_COUNT/" "$ARTIFACTS/state.json" > "$STATE_TMP"'
+      );
+      expect(content).toContain('mv "$STATE_TMP" "$ARTIFACTS/state.json"');
+      expect(content).not.toMatch(/\bsed\s+-i(?:\s*(?:''|\"\"|\S+))?\b/);
+    });
+
     it('should have valid YAML structure', () => {
       // Workflows are YAML files, should parse without error
       for (const [name, content] of Object.entries(BUNDLED_WORKFLOWS)) {


### PR DESCRIPTION
## Summary

Fixes the `archon-adversarial-dev` init-workspace step for macOS BSD `sed` compatibility.

Issue #1103 reports that `sed -i` fails on macOS because BSD sed requires a backup extension, while GNU sed accepts bare `-i`.

This PR replaces the non-portable in-place edit with a portable temp-file pattern:

- before: `sed -i s/.../.../ file`
- after: `sed s/.../.../ file > file.tmp && mv file.tmp file`

## Changes

- `.archon/workflows/defaults/archon-adversarial-dev.yaml`
  - Updated `init-workspace` to write `state.json` via temp file (`state.json.tmp`) and atomic move.
- `packages/workflows/src/defaults/bundled-defaults.test.ts`
  - Added regression test to assert the workflow uses portable temp-file sed and does not use bare `sed -i` for this replacement.

## Validation

- `bun test packages/workflows/src/defaults/bundled-defaults.test.ts`

Closes #1103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced workflow file handling for improved reliability and portability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->