### PR TITLE
fix(build): drop --bytecode from compiled-binary build

### DIFF
--- a/scripts/build-binaries.sh
+++ b/scripts/build-binaries.sh
@@ -75,17 +75,13 @@ for target_pair in "${TARGETS[@]}"; do
   IFS=':' read -r target outfile <<< "$target_pair"
   echo "Building $target → $outfile"
 
-  # --bytecode excluded for Windows cross-compile (inconsistent Bun support)
-  BYTECODE_FLAG=""
-  if [[ "$target" != *windows* ]]; then
-    BYTECODE_FLAG="--bytecode"
-  fi
-
-  # Always --minify to match release parity
+  # --bytecode disabled: Bun 1.3.11 produces broken bytecode for our module graph
+  # (likely triggered by @mariozechner/pi-coding-agent's CJS/ESM interop shape) —
+  # "TypeError: Expected CommonJS module to have a function wrapper" at runtime.
+  # Always --minify to match release parity.
   bun build \
     --compile \
     --minify \
-    $BYTECODE_FLAG \
     --target="$target" \
     --outfile="$outfile" \
     packages/cli/src/cli.ts


### PR DESCRIPTION
## Summary

Bun 1.3.11's bytecode generation produces broken output for our module graph. At build time, it logs `error: Failed to generate bytecode for ./cli.js` and proceeds without bytecode; the resulting binary then crashes at module instantiation with:

\`\`\`
TypeError: Expected CommonJS module to have a function wrapper.
If you weren't messing around with Bun's internals, this is a bug in Bun.
\`\`\`

This reproduces on every target (darwin-arm64, darwin-x64, linux-x64, linux-arm64) — verified natively on darwin-arm64. Without the flag, the compile succeeds cleanly and the binary runs.

Windows was already excluded from `--bytecode`; this change just aligns every other target with that behaviour.

## Why it wasn't caught before

The flag was only failing loudly once our module graph included `@mariozechner/pi-coding-agent` (0.3.7 via #1270). Earlier releases happened to tree-shake to something Bun's bytecode step could handle.

## Surfaced by

Found while building the v0.3.7 release locally after the release CI failed with the same error. Still doesn't make v0.3.7 binaries viable on its own — the Pi SDK separately crashes at module init with an ENOENT on `package.json` — but this change is correct independent of that and unblocks the compile step.

## Test plan

- [ ] `bun run validate` passes
- [ ] `bash scripts/build-binaries.sh` completes without the "Failed to generate bytecode" error on all targets
- [ ] `./dist/binaries/archon-darwin-arm64 version` runs (on macOS) — not blocked by bytecode, at least; downstream Pi issue tracked separately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build script to consistently exclude bytecode compilation from all binary builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->