### PR TITLE
fix(ci): --no-worktree on release-smoke archon-assist invocations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,8 +138,12 @@ jobs:
 
           # Run without CLAUDE_BIN_PATH set. Expect a clean resolver error.
           # Capture both stdout and stderr; we only care that the resolver message is present.
+          # --no-worktree skips isolation: this test exercises the Claude resolver
+          # path, not worktree setup. Without it we hit the worktree auto-sync added
+          # in #1310 first and fail on "neither origin/HEAD nor origin/main exist"
+          # because the fresh `git init` tmp repo has no origin configured.
           set +e
-          OUTPUT=$(env -u CLAUDE_BIN_PATH "$BIN" workflow run archon-assist "hello" 2>&1)
+          OUTPUT=$(env -u CLAUDE_BIN_PATH "$BIN" workflow run archon-assist --no-worktree "hello" 2>&1)
           EXIT_CODE=$?
           set -e
           echo "$OUTPUT"
@@ -181,8 +185,10 @@ jobs:
           git init -q
           git -c user.email=ci@example.com -c user.name=ci commit --allow-empty -q -m init
 
+          # --no-worktree: same rationale as the negative-case test above — this
+          # test exercises the Claude subprocess spawn path, not worktree setup.
           set +e
-          OUTPUT=$(CLAUDE_BIN_PATH="$CLI_PATH" "$BIN" workflow run archon-assist "hello" 2>&1)
+          OUTPUT=$(CLAUDE_BIN_PATH="$CLI_PATH" "$BIN" workflow run archon-assist --no-worktree "hello" 2>&1)
           EXIT_CODE=$?
           set -e
           echo "$OUTPUT"


### PR DESCRIPTION
## Summary

v0.3.8's release CI failed deterministically on this step:

> `Smoke-test Claude binary-path resolver (negative case)` — expected "Claude Code not found" in output; got "Failed to fetch base branch from origin: Cannot detect default branch ... neither origin/HEAD nor origin/main exist" instead.

The test creates a fresh `git init` tempdir **with no `origin` remote** and runs `archon workflow run archon-assist "hello"`. As of #1310's worktree-policy changes, default isolation auto-syncs the worktree with origin before creation; with no origin, that sync fails — **before** the Claude resolver is even reached — so the assertion never matches and the whole linux-x64 build aborts (fail-fast kills the other matrix entries).

## Change

Add `--no-worktree` to both invocations (negative + positive cases). The tests exercise the Claude resolver / subprocess-spawn path, not worktree setup, so skipping isolation is the right answer. This short-circuits `validateAndResolveIsolation` and never touches origin. Matches the documented usage pattern in `CLAUDE.md`:

> `archon workflow run quick-fix --no-worktree "Fix typo"`

## Not this PR

- Binaries themselves are fine. The v0.3.7 Pi-lazy-load regression (#1355) is fixed on dev; local `bun build --compile --minify` produces a working binary; the repo's new Step 1.5 pre-flight smoke passes with `--help`. The only thing broken was the CI assertion, not what it asserts against.
- Not reusing the v0.3.8 tag. v0.3.8's GitHub Release has been deleted (`releases/latest` falls back to v0.3.6); next release will be v0.3.9 with this fix applied.

## Test plan

- [ ] CI green on `bun run validate` (no source changes, should be trivial)
- [ ] v0.3.9 release workflow gets past both resolver smoke tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal GitHub Actions workflow configuration for testing procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->