### PR TITLE
chore(release-skill): use --help (not version) for Step 1.5 smoke probe

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -64,9 +64,15 @@ if [ -f scripts/build-binaries.sh ] && [ -f packages/cli/src/cli.ts ]; then
     packages/cli/src/cli.ts
 
   # Smoke test: the binary must start and exit 0 on a safe, non-interactive command.
-  # `version` or `--help` are both acceptable — pick one that does NOT touch the
-  # network, database, or require env vars.
-  if ! "$TMP_BINARY" version > /tmp/archon-preflight.log 2>&1; then
+  # Use `--help` (NOT `version`). The `version` command's compiled-binary code
+  # path depends on BUNDLED_IS_BINARY=true, which is set by scripts/build-binaries.sh
+  # — but we're doing a bare `bun build --compile` here to keep the smoke fast,
+  # so BUNDLED_IS_BINARY is still `false`. That sends `version` down the dev
+  # branch of version.ts which tries to read package.json from a path that only
+  # exists in node_modules, producing a false-positive ENOENT. `--help` has no
+  # such dev/binary branch and exercises the same module-init graph we're
+  # actually testing. Must NOT touch network, database, or require env vars.
+  if ! "$TMP_BINARY" --help > /tmp/archon-preflight.log 2>&1; then
     echo "ERROR: compiled binary crashed at startup"
     cat /tmp/archon-preflight.log
     echo ""


### PR DESCRIPTION
## Summary

Fixes a false positive in the /release skill's Step 1.5 pre-flight binary smoke — hit during the 0.3.8 release attempt, where the smoke aborted despite the actual binary being healthy.

## Root cause

Step 1.5 does a bare \`bun build --compile\` for speed — it deliberately skips \`scripts/build-binaries.sh\`, so \`packages/paths/src/bundled-build.ts\` keeps its dev defaults, including \`BUNDLED_IS_BINARY = false\`.

\`version.ts\` branches on that constant: when \`true\` it returns the embedded version string, when \`false\` it calls \`getDevVersion()\`, which reads \`SCRIPT_DIR/../../../../package.json\`. Inside a compiled binary \`SCRIPT_DIR\` resolves under \`\$bunfs/root/\`, the walk produces a CWD-relative path that doesn't exist, and we get \"Failed to read version: package.json not found (bad installation?)\".

The skill even said "version or --help are both acceptable" — which isn't true for this project.

## Change

Use \`--help\` instead. It exercises the same module-init graph (so it still catches the real failure modes the skill calls out: Pi package.json init crash, Bun --bytecode output bugs, CJS wrapper issues, circular imports under minify) but has no dev/binary branch, so no false positive. Expanded the comment block to explain why, so this doesn't get "normalized" back to \`version\` by a future drive-by.

## Verification

- Ran the updated Step 1.5 locally against current dev: \`Pre-flight binary smoke: PASSED\` (was falsely failing on \`version\` earlier this session)
- The "runtime error despite exit 0" grep block still fires for the patterns it was designed to catch — no semantic change to what's checked, only what command is run

## Test plan

- [ ] Next \`/release\` invocation runs Step 1.5 cleanly without modifying \`bundled-build.ts\`
- [ ] If anyone reintroduces a module-init bug like v0.3.7's Pi SDK crash, \`--help\` still fails at startup and Step 1.5 catches it pre-tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated smoke testing procedure to use alternative command invocation for improved test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->