### PR TITLE
fix(providers/pi): install PI_PACKAGE_DIR shim so Pi workflows run in a compiled binary

### DIFF
--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -209,6 +209,21 @@ describe('PiProvider', () => {
     expect(new PiProvider().getCapabilities()).toEqual(PI_CAPABILITIES);
   });
 
+  test('sendQuery installs PI_PACKAGE_DIR shim before Pi SDK loads', async () => {
+    // Runtime-safety regression: Pi's config.js reads `getPackageJsonPath()` at
+    // its module init, which resolves to a non-existent path inside compiled
+    // archon binaries. The shim writes a stub package.json to tmpdir and sets
+    // PI_PACKAGE_DIR so Pi's short-circuit kicks in. Must run BEFORE the
+    // dynamic imports in sendQuery — we verify by calling the fast-fail "no
+    // model" path (which returns before any Pi SDK logic executes) and
+    // asserting the env var was set regardless.
+    delete process.env.PI_PACKAGE_DIR;
+    expect(process.env.PI_PACKAGE_DIR).toBeUndefined();
+    await consume(new PiProvider().sendQuery('hi', '/tmp'));
+    expect(process.env.PI_PACKAGE_DIR).toBeDefined();
+    expect(process.env.PI_PACKAGE_DIR).toContain('archon-pi-shim');
+  });
+
   test('throws when no model is configured', async () => {
     const { error } = await consume(new PiProvider().sendQuery('hi', '/tmp'));
     expect(error?.message).toContain('Pi provider requires a model');

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -1,3 +1,7 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { createLogger } from '@archon/paths';
 import type { Api, Model } from '@mariozechner/pi-ai';
 
@@ -24,6 +28,44 @@ import { parsePiModelRef } from './model-ref';
 // All Pi SDK value bindings and Pi-dependent helper modules are dynamically
 // imported inside `sendQuery()` below, which runs only when a Pi workflow is
 // actually invoked. Type-only imports above are fine — TS erases them.
+//
+// Lazy-loading defers the crash from boot-time to sendQuery-time — but the
+// crash still happens when Pi is actually used. `ensurePiPackageDirShim()`
+// (see below) fixes the *runtime* half: before any dynamic Pi import in
+// sendQuery, write a stub package.json to tmpdir and point Pi at it via
+// its own documented `PI_PACKAGE_DIR` escape hatch.
+
+/**
+ * Write a minimal package.json to a stable tmpdir and set `PI_PACKAGE_DIR`
+ * so Pi's `config.js` short-circuits its `dirname(process.execPath)` walk
+ * (which fails inside a compiled archon binary). Pi only reads three
+ * optional fields from that package.json — `piConfig.name`, `piConfig.configDir`,
+ * and `version` — so the stub is genuinely minimal. Idempotent: the file is
+ * only written once per host (existsSync check), and the env var is set on
+ * every call so multiple PiProvider instances stay consistent.
+ *
+ * Done on each sendQuery rather than at module load so (a) the file write
+ * is paid only when Pi is actually used, and (b) the env var can't get
+ * clobbered between registration and invocation.
+ */
+function ensurePiPackageDirShim(): void {
+  const shimDir = join(tmpdir(), 'archon-pi-shim');
+  const shimPkgJson = join(shimDir, 'package.json');
+  if (!existsSync(shimPkgJson)) {
+    mkdirSync(shimDir, { recursive: true });
+    // `piConfig: {}` is explicit so Pi's defaults (`name: 'pi'`,
+    // `configDir: '.pi'`) kick in — matches Pi's standalone behavior.
+    writeFileSync(
+      shimPkgJson,
+      JSON.stringify({
+        name: 'archon-pi-shim',
+        version: '0.0.0',
+        piConfig: {},
+      })
+    );
+  }
+  process.env.PI_PACKAGE_DIR = shimDir;
+}
 
 /**
  * Map Pi provider id → env var name used by pi-ai's getEnvApiKey().
@@ -115,6 +157,13 @@ export class PiProvider implements IAgentProvider {
     resumeSessionId?: string,
     requestOptions?: SendQueryOptions
   ): AsyncGenerator<MessageChunk> {
+    // Install the PI_PACKAGE_DIR shim BEFORE the dynamic imports below: Pi's
+    // config.js runs `readFileSync(getPackageJsonPath())` at its own module
+    // init, and getPackageJsonPath() checks process.env.PI_PACKAGE_DIR first.
+    // Without this, the dynamic import below would crash with ENOENT on
+    // `dirname(process.execPath)/package.json` inside a compiled binary.
+    ensurePiPackageDirShim();
+
     // Lazy-load Pi SDK and all Pi-dependent helper modules here. Must not move
     // these imports to module scope — see the header comment for the failure
     // mode (archon compiled binary crashes at startup when Pi's config.js


### PR DESCRIPTION
## Summary

v0.3.9 made Pi boot-safe (lazy-load moved the crash out of archon startup) but not **runtime-safe**: the moment `PiProvider.sendQuery()` triggers the dynamic import, Pi's \`config.js\` fires its own module-init \`readFileSync(getPackageJsonPath())\` and we hit the exact same ENOENT the lazy-load was supposed to prevent. Discovered today by running an actual Pi workflow against a locally-compiled 0.3.9 binary; \`/test-release\` missed this because it only exercised \`archon-assist\` (Claude).

Boot-safe ≠ runtime-safe. The \`provider-lazy-load.test.ts\` regression test I added in #1355 covers only the former — this PR covers the latter.

## Change

Before the dynamic \`import('@mariozechner/pi-coding-agent')\` in \`sendQuery()\`, install a \`PI_PACKAGE_DIR\` shim. Pi's \`config.js\` short-circuits the \`dirname(process.execPath)\` walk when that env var is set, so it reads from our stub instead. The stub is a minimal \`{name, version, piConfig:{}}\` JSON written once to \`tmpdir()/archon-pi-shim/package.json\` (idempotent existsSync check). Pi only reads \`piConfig.name\`, \`piConfig.configDir\`, and \`version\` from that file — all optional — so the surface is genuinely minimal.

Localized to \`PiProvider\`. No global state, no upstream fork, no mutation of shared config. Claude and Codex providers are unaffected (their SDKs don't have this class of init-time side effect).

## E2E verification

Before patch, on a compiled 0.3.9 binary:
\`\`\`
[main] Failed: ENOENT: no such file or directory,
       open '/private/tmp/package.json'
    at readFileSync (unknown)
    at init_config
\`\`\`

After patch, same compiled binary running \`archon workflow run test-pi --no-worktree\` against a workflow with \`provider: pi\` + \`model: anthropic/claude-haiku-4-5\`:
\`\`\`
{"module":"provider.pi","piProvider":"anthropic","modelId":"claude-haiku-4-5","msg":"pi.session_started"}
hi
Workflow completed successfully.
\`\`\`

## Regression test

Added a unit test that deletes \`process.env.PI_PACKAGE_DIR\`, calls \`sendQuery()\` via the fast-fail "no model" path (returns before any Pi SDK work), and asserts the shim still ran and set the env var. Paired with the existing boot-safety test, both halves of the bug are now covered.

## Test plan

- [ ] \`bun run validate\` green
- [ ] Manual: \`bun build --compile --minify --target=bun-darwin-arm64\` + \`archon workflow run <pi-workflow>\` returns a response
- [ ] Before cutting next release: \`/test-release\` should run a Pi workflow end-to-end, not just Claude (separate follow-up)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Pi provider initialization by ensuring proper package directory configuration before dynamic imports in compiled environments.

* **Tests**
  * Added regression test to verify Pi provider's package directory setup occurs before SDK initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->