### PR TITLE
fix(orchestrator): clear stale assistant session ID on error_during_execution (#1280)

### DIFF
--- a/packages/core/src/db/sessions.test.ts
+++ b/packages/core/src/db/sessions.test.ts
@@ -175,6 +175,17 @@ describe('sessions', () => {
       expect(error).toBeInstanceOf(SessionNotFoundError);
       expect(error.message).toBe('Session not found: non-existent');
     });
+
+    test('clears assistant_session_id when passed null', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([], 1));
+
+      await updateSession('session-123', null);
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        'UPDATE remote_agent_sessions SET assistant_session_id = $1 WHERE id = $2',
+        [null, 'session-123']
+      );
+    });
   });
 
   describe('deactivateSession', () => {

--- a/packages/core/src/db/sessions.ts
+++ b/packages/core/src/db/sessions.ts
@@ -58,7 +58,7 @@ export async function createSession(data: {
   return result.rows[0];
 }
 
-export async function updateSession(id: string, sessionId: string): Promise<void> {
+export async function updateSession(id: string, sessionId: string | null): Promise<void> {
   const result = await pool.query(
     'UPDATE remote_agent_sessions SET assistant_session_id = $1 WHERE id = $2',
     [sessionId, id]

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -355,7 +355,7 @@ async function tryPersistSessionId(
     await sessionDb.updateSession(sessionId, assistantSessionId);
   } catch (error) {
     getLog().error(
-      { err: error as Error, sessionId, newSessionId: assistantSessionId },
+      { err: error as Error, sessionId, assistantSessionId },
       'session_id_persist_failed'
     );
   }

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -347,7 +347,10 @@ async function dispatchOrchestratorWorkflow(
 
 // ─── Session Helpers ────────────────────────────────────────────────────────
 
-async function tryPersistSessionId(sessionId: string, assistantSessionId: string): Promise<void> {
+async function tryPersistSessionId(
+  sessionId: string,
+  assistantSessionId: string | null
+): Promise<void> {
   try {
     await sessionDb.updateSession(sessionId, assistantSessionId);
   } catch (error) {
@@ -983,7 +986,9 @@ async function handleStreamMode(
         getLog().warn({ conversationId, errorSubtype: msg.errorSubtype }, 'ai_result_error');
         const syntheticError = new Error(msg.errorSubtype ?? 'AI result error');
         await platform.sendMessage(conversationId, classifyAndFormatError(syntheticError));
-        if (newSessionId) {
+        if (msg.errorSubtype === 'error_during_execution') {
+          await tryPersistSessionId(session.id, null);
+        } else if (newSessionId) {
           await tryPersistSessionId(session.id, newSessionId);
         }
         return;
@@ -1106,7 +1111,9 @@ async function handleBatchMode(
         getLog().warn({ conversationId, errorSubtype: msg.errorSubtype }, 'ai_result_error');
         const syntheticError = new Error(msg.errorSubtype ?? 'AI result error');
         await platform.sendMessage(conversationId, classifyAndFormatError(syntheticError));
-        if (newSessionId) {
+        if (msg.errorSubtype === 'error_during_execution') {
+          await tryPersistSessionId(session.id, null);
+        } else if (newSessionId) {
           await tryPersistSessionId(session.id, newSessionId);
         }
         return;


### PR DESCRIPTION
## Summary

- Problem: when the Anthropic SDK returns `error_during_execution` (commonly after a container restart invalidates the cached Claude session), the orchestrator was persisting the *failed* session ID coming back on the error result. Subsequent messages tried to resume that dead session and produced an infinite silent-failure loop — the UI just flickered and reverted to the last pre-restart message.
- Why it matters: user-facing — affected conversations were unrecoverable without manual DB editing. Closes #1280.
- What changed: streaming and batch `msg.isError` branches in `orchestrator-agent.ts` now persist `null` to `assistant_session_id` for `error_during_execution` specifically, clearing the stale ID so the next message starts a fresh session. `sessionDb.updateSession` and `tryPersistSessionId` widened to accept `string | null`.
- What did **not** change (scope boundary): other error subtypes (rate limits, tool-level errors) keep the existing "persist newSessionId if present" behaviour. Conversation history (`remote_agent_messages`) is untouched — the SDK rebuilds context from there on the next turn.

## UX Journey

### Before

```
  User              UI                Orchestrator           Claude SDK
  ────              ──                ────────────           ──────────
  sends message ─▶ stream chunks ◀── resume(stale_sid) ────▶ error_during_execution
                                      persists stale_sid ◀── (returns same dead sid)
                   (UI reverts) ◀──── stream ends silently
  retries ──────▶  same flow…         SAME dead sid reused ▶ same error
                                                              (infinite loop)
```

### After

```
  User              UI                Orchestrator           Claude SDK
  ────              ──                ────────────           ──────────
  sends message ─▶ stream chunks ◀── resume(stale_sid) ────▶ error_during_execution
                                      *persists NULL* ◀───── (returns dead sid, ignored)
                   (UI reverts) ◀──── stream ends
  retries ──────▶  fresh stream ◀──── *new session* ───────▶ rebuilds context from
                                       (history from DB)      remote_agent_messages
```

## Architecture Diagram

### Before

```
  orchestrator-agent.ts
    ├── streaming branch (msg.isError)
    │     └── tryPersistSessionId(session.id, newSessionId)   ← persists stale
    └── batch branch (msg.isError)
          └── tryPersistSessionId(session.id, newSessionId)   ← persists stale

  sessionDb.updateSession(id, { assistant_session_id: string })
```

### After

```
  orchestrator-agent.ts
    ├── streaming branch (msg.isError)
    │     ├── if subtype === 'error_during_execution'
    │     │     └── [~] tryPersistSessionId(session.id, null)
    │     └── else: existing behaviour (persist newSessionId if present)
    └── batch branch (msg.isError)
          ├── if subtype === 'error_during_execution'
          │     └── [~] tryPersistSessionId(session.id, null)
          └── else: existing behaviour

  [~] sessionDb.updateSession(id, { assistant_session_id: string | null })
  [~] tryPersistSessionId(sessionId, newSessionId: string | null)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| orchestrator-agent (isError branches) | tryPersistSessionId | modified | passes `null` on `error_during_execution` |
| tryPersistSessionId | sessionDb.updateSession | modified | type widened to `string \| null` |
| sessionDb.updateSession | SQL bind ($1) | unchanged | binds `null` → `NULL` natively (Postgres + SQLite) |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`
- Module: `core:orchestrator`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #1280
- Related #
- Depends on # — none
- Supersedes # — none

## Validation Evidence (required)

```bash
bun run type-check    # green across all 10 workspaces
bun run lint          # clean
bun run format:check  # clean
bun test sessions     # 29/29 pass (1 new test for null persistence)
bun test orchestrator # 98/98 pass (unchanged)
bun run validate      # exit 0
```

- Evidence provided: command names + pass counts above.
- Skipped commands: none.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Database migration needed? `No` — column is already nullable; SQL bind handles `null` natively.

## Human Verification (required)

- Verified scenarios: type-check / lint / format / tests pass; reviewed both `msg.isError` branches by diff; confirmed `remote_agent_messages` is the authoritative history source so dropping the cached session ID is lossless.
- Edge cases checked: non-`error_during_execution` errors (rate limit, tool error) follow the unchanged path and keep persisting `newSessionId`.
- What was not verified: end-to-end reproduction of the original container-restart bug — relied on the issue reporter's reproduction in #1280 plus the unit test covering the null-persist path.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: orchestrator session-resume path only.
- Potential unintended effects: an `error_during_execution` followed by an immediate retry will start a brand-new SDK session — minor prompt-cache miss on retry. Lossless for the user; history is reconstructed from DB.
- Guardrails / monitoring for early detection: existing `session_id_persist_failed` log fires on update failures; the new test asserts the null-persist call shape.

## Rollback Plan (required)

- Fast rollback: `git revert <merge-commit>` — single-commit revert is safe; the type widening is backward-compatible (callers can still pass `string`).
- Feature flags or config toggles: none — the change is unconditional inside the `error_during_execution` branch.
- Observable failure symptoms: if the fix regresses, `assistant_session_id` would stop being cleared — the original stuck-conversation bug would return. Detect via the #1280 reproduction.

## Risks and Mitigations

- Risk: clearing on `error_during_execution` is too aggressive if some subtype labelled that way actually preserves a usable session.
  - Mitigation: change is tightly scoped to `error_during_execution`; other subtypes untouched. Reporter and observed orchestrator behaviour both indicate the session is unusable in this case.
- Risk: callers of `tryPersistSessionId` / `updateSession` previously assumed `string` and might fail under `null`.
  - Mitigation: searched all callers — only the orchestrator paths construct the call; the SQL layer binds the value as-is and Postgres / SQLite both accept `null` without statement changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session handling improved to explicitly clear stored session identifiers when certain execution errors occur during AI result processing (batch and stream modes).

* **Tests**
  * Added unit test coverage verifying session updates correctly accept and persist null session identifier values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
