### PR TITLE
fix(server): persist Discord/Slack/Telegram messages to Web UI history

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -64,9 +64,15 @@ if [ -f scripts/build-binaries.sh ] && [ -f packages/cli/src/cli.ts ]; then
     packages/cli/src/cli.ts
 
   # Smoke test: the binary must start and exit 0 on a safe, non-interactive command.
-  # `version` or `--help` are both acceptable — pick one that does NOT touch the
-  # network, database, or require env vars.
-  if ! "$TMP_BINARY" version > /tmp/archon-preflight.log 2>&1; then
+  # Use `--help` (NOT `version`). The `version` command's compiled-binary code
+  # path depends on BUNDLED_IS_BINARY=true, which is set by scripts/build-binaries.sh
+  # — but we're doing a bare `bun build --compile` here to keep the smoke fast,
+  # so BUNDLED_IS_BINARY is still `false`. That sends `version` down the dev
+  # branch of version.ts which tries to read package.json from a path that only
+  # exists in node_modules, producing a false-positive ENOENT. `--help` has no
+  # such dev/binary branch and exercises the same module-init graph we're
+  # actually testing. Must NOT touch network, database, or require env vars.
+  if ! "$TMP_BINARY" --help > /tmp/archon-preflight.log 2>&1; then
     echo "ERROR: compiled binary crashed at startup"
     cat /tmp/archon-preflight.log
     echo ""

--- a/.claude/skills/test-release/SKILL.md
+++ b/.claude/skills/test-release/SKILL.md
@@ -79,6 +79,8 @@ About to test:
   Path:     brew (Homebrew tap on macOS)
   Version:  0.3.1 (expected)
   Cleanup:  will uninstall after tests (brew uninstall + untap)
+            If `archon-stable` symlink is detected in Phase 2, it will be
+            restored at the end of Phase 5 by reinstalling the tap formula.
 
 Proceed? (y/N)
 ```
@@ -111,6 +113,18 @@ gh release view v<version> --repo coleam00/Archon --json tagName,assets --jq '{t
 ```
 
 If the release does not exist or has no assets, abort with a clear message. Do not proceed to install a non-existent release.
+
+4. **Detect persistent `archon-stable` install (brew path only).** If the user has renamed a prior brew install to `archon-stable` (the dual-homebrew pattern — see `~/.config/fish/functions/brew-upgrade-archon.fish`), Phase 5's `brew uninstall` will wipe it. Capture the state so Phase 5b can restore it:
+
+```bash
+ARCHON_STABLE_WAS_INSTALLED=""
+if [ -L /opt/homebrew/bin/archon-stable ] || [ -L /usr/local/bin/archon-stable ]; then
+  ARCHON_STABLE_WAS_INSTALLED="yes"
+  echo "Detected persistent archon-stable — will restore after Phase 5 uninstall."
+fi
+```
+
+Export `ARCHON_STABLE_WAS_INSTALLED` into the environment used by Phase 5b. Only applies to the `brew` path — `curl-mac` and `curl-vps` don't go through brew and don't disturb `archon-stable`.
 
 ## Phase 3 — Install
 
@@ -351,6 +365,25 @@ which -a archon
 archon version | head -1
 # should match the dev version captured in Phase 2
 ```
+
+**Restore `archon-stable` if it existed before the test** (dual-homebrew pattern — see Phase 2 item 4):
+
+```bash
+if [ -n "$ARCHON_STABLE_WAS_INSTALLED" ]; then
+  echo "Restoring archon-stable (detected before test)..."
+  brew tap coleam00/archon
+  brew install coleam00/archon/archon
+  BREW_BIN="$(brew --prefix)/bin"
+  if [ -e "$BREW_BIN/archon" ]; then
+    mv "$BREW_BIN/archon" "$BREW_BIN/archon-stable"
+    echo "archon-stable restored: $(archon-stable version 2>/dev/null | head -1)"
+  else
+    echo "WARNING: brew install succeeded but $BREW_BIN/archon missing — check formula"
+  fi
+fi
+```
+
+> **Note on the restored version**: this reinstalls from whatever the tap currently ships, which is typically the release you just tested (so `archon-stable` ends up at the newly-tested version). That's usually what the operator wants — you just verified the new release works, and you want `archon-stable` pointed at it. If you were testing an older version for back-version QA, the restored `archon-stable` will be the *current* tap formula, not the pre-test version. For that rare case, the operator should re-run `brew-upgrade-archon` manually after the test.
 
 ### Path: curl-mac
 

--- a/homebrew/archon.rb
+++ b/homebrew/archon.rb
@@ -7,28 +7,28 @@
 class Archon < Formula
   desc "Remote agentic coding platform - control AI assistants from anywhere"
   homepage "https://github.com/coleam00/Archon"
-  version "0.3.6"
+  version "0.3.9"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-darwin-arm64"
-      sha256 "96b6dac50b046eece9eddbb988a0c39b4f9a0e2faac66e49b977ba6360069e86"
+      sha256 "b617f85a2181938b793b25ad816a9f6b3149d184f64b2e9e2ea2430f27778d64"
     end
     on_intel do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-darwin-x64"
-      sha256 "09f1dbe12417b4300b7b07b531eb7391a286305f8d4eafc11e7f61f5d26eb8eb"
+      sha256 "5a928af5e0e67ffe084159161a9ea3994a9304cc39bd06132719cd89cc715e86"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-linux-arm64"
-      sha256 "80b06a6ff699ec57cd4a3e49cfe7b899a3e8212688d70285f5a887bf10086731"
+      sha256 "567bfca9175e10d9b4fd748e3862bbd34141a234766a7ecf0a714d9c27b8c92e"
     end
     on_intel do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-linux-x64"
-      sha256 "09f5dac6db8037ed6f3e5b7e9c5eb8e37f19822a4ed2bf4cd7e654780f9d00de"
+      sha256 "c918218df2f0f853d107e6b1727dcd9accc034b183ffbccea93a331d8d376ed8"
     end
   end
 

--- a/packages/docs-web/src/content/docs/adapters/community/discord.md
+++ b/packages/docs-web/src/content/docs/adapters/community/discord.md
@@ -40,6 +40,14 @@ Connect Archon to Discord so you can interact with your AI coding assistant from
 2. Enable **"Message Content Intent"** (required for the bot to read messages)
 3. Save changes
 
+:::caution
+Skipping this step causes Discord to reject the bot's connection with
+`Used disallowed intents`. Archon will log
+`discord.start_failed_continuing_without_adapter` and keep the rest of
+the server running, but the Discord adapter will be unavailable until
+the intent is enabled and the server is restarted.
+:::
+
 ## Invite Bot to Your Server
 
 1. Go to "OAuth2" > "URL Generator" in the left sidebar

--- a/packages/providers/src/claude/binary-resolver.test.ts
+++ b/packages/providers/src/claude/binary-resolver.test.ts
@@ -76,7 +76,52 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
     expect(result).toBe('/env/cli.js');
   });
 
-  test('throws with install instructions when nothing configured', async () => {
+  test('autodetects native installer path when env and config are unset', async () => {
+    const home = process.env.HOME ?? '/Users/test';
+    const expected =
+      process.platform === 'win32'
+        ? `${home}\\.local\\bin\\claude.exe`
+        : `${home}/.local/bin/claude`;
+    // File exists only at the native-installer path.
+    fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation(
+      (path: string) => path === expected
+    );
+
+    const result = await resolver.resolveClaudeBinaryPath();
+    expect(result).toBe(expected);
+    // Log must mark this as autodetect, not 'env' or 'config' — the source
+    // string is load-bearing for debug triage.
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { binaryPath: expected, source: 'autodetect' },
+      'claude.binary_resolved'
+    );
+  });
+
+  test('env var takes precedence over autodetect when both would match', async () => {
+    process.env.CLAUDE_BIN_PATH = '/custom/env/claude';
+    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(true);
+
+    const result = await resolver.resolveClaudeBinaryPath();
+    expect(result).toBe('/custom/env/claude');
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { binaryPath: '/custom/env/claude', source: 'env' },
+      'claude.binary_resolved'
+    );
+  });
+
+  test('config takes precedence over autodetect when both would match', async () => {
+    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(true);
+
+    const result = await resolver.resolveClaudeBinaryPath('/custom/config/claude');
+    expect(result).toBe('/custom/config/claude');
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { binaryPath: '/custom/config/claude', source: 'config' },
+      'claude.binary_resolved'
+    );
+  });
+
+  test('throws with install instructions when nothing is configured and autodetect misses', async () => {
+    // Every probe returns false — env unset, config unset, native path absent.
     fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(false);
 
     const promise = resolver.resolveClaudeBinaryPath();

--- a/packages/providers/src/claude/binary-resolver.test.ts
+++ b/packages/providers/src/claude/binary-resolver.test.ts
@@ -5,6 +5,8 @@
  * with BUNDLED_IS_BINARY=true, which conflicts with other test files.
  */
 import { describe, test, expect, mock, beforeEach, afterAll, spyOn } from 'bun:test';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { createMockLogger } from '../test/mocks/logger';
 
 const mockLogger = createMockLogger();
@@ -77,11 +79,14 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
   });
 
   test('autodetects native installer path when env and config are unset', async () => {
-    const home = process.env.HOME ?? '/Users/test';
-    const expected =
-      process.platform === 'win32'
-        ? `${home}\\.local\\bin\\claude.exe`
-        : `${home}/.local/bin/claude`;
+    // Mirror the implementation: use os.homedir() + node:path.join so the
+    // expected path matches the platform's actual home dir and separator.
+    const expected = join(
+      homedir(),
+      '.local',
+      'bin',
+      process.platform === 'win32' ? 'claude.exe' : 'claude'
+    );
     // File exists only at the native-installer path.
     fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation(
       (path: string) => path === expected

--- a/packages/providers/src/claude/binary-resolver.ts
+++ b/packages/providers/src/claude/binary-resolver.ts
@@ -9,13 +9,16 @@
  * Resolution order (binary mode only):
  * 1. `CLAUDE_BIN_PATH` environment variable
  * 2. `assistants.claude.claudeBinaryPath` in config
- * 3. Throw with install instructions
+ * 3. Autodetect canonical install path (native installer default)
+ * 4. Throw with install instructions
  *
  * In dev mode (BUNDLED_IS_BINARY=false), returns undefined so the caller
  * omits `pathToClaudeCodeExecutable` entirely and the SDK resolves via its
  * normal node_modules lookup.
  */
 import { existsSync as _existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { BUNDLED_IS_BINARY, createLogger } from '@archon/paths';
 
 /** Wrapper for existsSync — enables spyOn in tests (direct imports can't be spied on). */
@@ -89,6 +92,25 @@ export async function resolveClaudeBinaryPath(
     return configClaudeBinaryPath;
   }
 
-  // 3. Not found — throw with install instructions
+  // 3. Autodetect — the Anthropic native installer
+  // (`curl -fsSL https://claude.ai/install.sh | bash` on macOS/Linux,
+  // `irm https://claude.ai/install.ps1 | iex` on Windows) writes the
+  // executable to a fixed location relative to $HOME. Users who follow
+  // the recommended install path don't need any env var or config entry;
+  // users who deviate (npm global, custom path, etc.) still set one of
+  // the higher-priority sources above.
+  const nativeInstallerPath =
+    process.platform === 'win32'
+      ? join(homedir(), '.local', 'bin', 'claude.exe')
+      : join(homedir(), '.local', 'bin', 'claude');
+  if (fileExists(nativeInstallerPath)) {
+    getLog().info(
+      { binaryPath: nativeInstallerPath, source: 'autodetect' },
+      'claude.binary_resolved'
+    );
+    return nativeInstallerPath;
+  }
+
+  // 4. Not found — throw with install instructions
   throw new Error(INSTALL_INSTRUCTIONS);
 }

--- a/packages/providers/src/codex/binary-resolver.test.ts
+++ b/packages/providers/src/codex/binary-resolver.test.ts
@@ -87,7 +87,70 @@ describe('resolveCodexBinaryPath (binary mode)', () => {
     expect(normalized).toContain('/tmp/test-archon-home/vendor/codex/');
   });
 
+  test('autodetects npm global install at ~/.npm-global/bin/codex (POSIX)', async () => {
+    if (process.platform === 'win32') return; // POSIX-only probe
+    const home = process.env.HOME ?? '/Users/test';
+    const expected = `${home}/.npm-global/bin/codex`;
+    fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation(
+      (path: string) => path === expected
+    );
+
+    const result = await resolver.resolveCodexBinaryPath();
+    expect(result).toBe(expected);
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { binaryPath: expected, source: 'autodetect' },
+      'codex.binary_resolved'
+    );
+  });
+
+  test('autodetects homebrew install on Apple Silicon', async () => {
+    if (process.platform !== 'darwin' || process.arch !== 'arm64') {
+      // `/opt/homebrew/bin/codex` is only probed on darwin-arm64; on other
+      // hosts this test has nothing to assert (the probe list excludes it).
+      return;
+    }
+    fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation(
+      (path: string) => path === '/opt/homebrew/bin/codex'
+    );
+
+    const result = await resolver.resolveCodexBinaryPath();
+    expect(result).toBe('/opt/homebrew/bin/codex');
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { binaryPath: '/opt/homebrew/bin/codex', source: 'autodetect' },
+      'codex.binary_resolved'
+    );
+  });
+
+  test('autodetects system install at /usr/local/bin/codex', async () => {
+    if (process.platform === 'win32') {
+      // /usr/local/bin is not probed on Windows.
+      return;
+    }
+    fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation(
+      (path: string) => path === '/usr/local/bin/codex'
+    );
+
+    const result = await resolver.resolveCodexBinaryPath();
+    expect(result).toBe('/usr/local/bin/codex');
+  });
+
+  test('vendor directory takes precedence over autodetect', async () => {
+    // Both vendor and npm-global would match; vendor must win (lower tier #).
+    fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation((path: string) => {
+      const normalized = path.replace(/\\/g, '/');
+      return normalized.includes('vendor/codex') || normalized.includes('.npm-global');
+    });
+
+    const result = await resolver.resolveCodexBinaryPath();
+    expect(result!.replace(/\\/g, '/')).toContain('/vendor/codex/');
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'vendor' }),
+      'codex.binary_resolved'
+    );
+  });
+
   test('throws with install instructions when binary not found anywhere', async () => {
+    // Env unset, config unset, vendor dir empty, every autodetect path missing.
     fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(false);
 
     await expect(resolver.resolveCodexBinaryPath()).rejects.toThrow('Codex CLI binary not found');

--- a/packages/providers/src/codex/binary-resolver.ts
+++ b/packages/providers/src/codex/binary-resolver.ts
@@ -9,12 +9,14 @@
  * 1. `CODEX_BIN_PATH` environment variable
  * 2. `assistants.codex.codexBinaryPath` in config
  * 3. `~/.archon/vendor/codex/<platform-binary>` (user-placed)
- * 4. Throw with install instructions
+ * 4. Autodetect canonical install paths (npm prefix defaults per platform)
+ * 5. Throw with install instructions
  *
  * In dev mode (BUNDLED_IS_BINARY=false), returns undefined so the SDK
  * uses its normal node_modules-based resolution.
  */
 import { existsSync as _existsSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { BUNDLED_IS_BINARY, getArchonHome, createLogger } from '@archon/paths';
 
@@ -89,7 +91,19 @@ export async function resolveCodexBinaryPath(
     }
   }
 
-  // 4. Not found — throw with install instructions
+  // 4. Autodetect — probe the handful of paths Codex typically lands at
+  // when installed via the documented package managers. Users who install
+  // somewhere else (custom npm prefix, etc.) still set one of the higher-
+  // priority sources above. Order: most specific → least specific.
+  const autodetectPaths = getAutodetectPaths();
+  for (const probePath of autodetectPaths) {
+    if (fileExists(probePath)) {
+      getLog().info({ binaryPath: probePath, source: 'autodetect' }, 'codex.binary_resolved');
+      return probePath;
+    }
+  }
+
+  // 5. Not found — throw with install instructions
   const vendorPath = `~/.archon/${CODEX_VENDOR_DIR}/`;
   throw new Error(
     'Codex CLI binary not found. The Codex provider requires a native binary\n' +
@@ -104,4 +118,48 @@ export async function resolveCodexBinaryPath(
       '       codex:\n' +
       '         codexBinaryPath: /path/to/codex\n'
   );
+}
+
+/**
+ * Canonical install locations probed by tier 4 autodetect. Grounded in
+ * the official @openai/codex README and the npm global-install contract
+ * (npm writes the binary to `{npm_prefix}/bin/<name>` on POSIX and
+ * `{npm_prefix}\<name>.cmd` on Windows). The probes cover the npm prefix
+ * a default install lands at on each platform:
+ *
+ *  - `$HOME/.npm-global/bin/codex` — common when the user ran
+ *    `npm config set prefix ~/.npm-global` to avoid root writes
+ *  - `/opt/homebrew/bin/codex` — mac Apple Silicon with homebrew-node
+ *    (homebrew sets npm prefix to /opt/homebrew)
+ *  - `/usr/local/bin/codex` — mac Intel with homebrew-node, or linux
+ *    with system-installed node (npm prefix defaults to /usr/local)
+ *  - `%AppData%\npm\codex.cmd` — Windows npm global default
+ *
+ * Not covered (explicit override required via CODEX_BIN_PATH or config):
+ *   - users with other custom npm prefixes — `npm root -g` would spawn
+ *     a subprocess per resolve, too heavy for a probe helper
+ *   - Homebrew cask install (`brew install --cask codex`) — cask layout
+ *     isn't a PATH binary; users should symlink or set the path
+ *   - manual GitHub Releases extract — placement is user-determined
+ */
+function getAutodetectPaths(): string[] {
+  const paths: string[] = [];
+
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA;
+    if (appData) paths.push(join(appData, 'npm', 'codex.cmd'));
+    paths.push(join(homedir(), '.npm-global', 'codex.cmd'));
+    return paths;
+  }
+
+  // POSIX (macOS + Linux)
+  paths.push(join(homedir(), '.npm-global', 'bin', 'codex'));
+
+  if (process.platform === 'darwin' && process.arch === 'arm64') {
+    paths.push('/opt/homebrew/bin/codex');
+  }
+
+  paths.push('/usr/local/bin/codex');
+
+  return paths;
 }

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -209,6 +209,21 @@ describe('PiProvider', () => {
     expect(new PiProvider().getCapabilities()).toEqual(PI_CAPABILITIES);
   });
 
+  test('sendQuery installs PI_PACKAGE_DIR shim before Pi SDK loads', async () => {
+    // Runtime-safety regression: Pi's config.js reads `getPackageJsonPath()` at
+    // its module init, which resolves to a non-existent path inside compiled
+    // archon binaries. The shim writes a stub package.json to tmpdir and sets
+    // PI_PACKAGE_DIR so Pi's short-circuit kicks in. Must run BEFORE the
+    // dynamic imports in sendQuery — we verify by calling the fast-fail "no
+    // model" path (which returns before any Pi SDK logic executes) and
+    // asserting the env var was set regardless.
+    delete process.env.PI_PACKAGE_DIR;
+    expect(process.env.PI_PACKAGE_DIR).toBeUndefined();
+    await consume(new PiProvider().sendQuery('hi', '/tmp'));
+    expect(process.env.PI_PACKAGE_DIR).toBeDefined();
+    expect(process.env.PI_PACKAGE_DIR).toContain('archon-pi-shim');
+  });
+
   test('throws when no model is configured', async () => {
     const { error } = await consume(new PiProvider().sendQuery('hi', '/tmp'));
     expect(error?.message).toContain('Pi provider requires a model');

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -1,3 +1,7 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { createLogger } from '@archon/paths';
 import type { Api, Model } from '@mariozechner/pi-ai';
 
@@ -24,6 +28,44 @@ import { parsePiModelRef } from './model-ref';
 // All Pi SDK value bindings and Pi-dependent helper modules are dynamically
 // imported inside `sendQuery()` below, which runs only when a Pi workflow is
 // actually invoked. Type-only imports above are fine — TS erases them.
+//
+// Lazy-loading defers the crash from boot-time to sendQuery-time — but the
+// crash still happens when Pi is actually used. `ensurePiPackageDirShim()`
+// (see below) fixes the *runtime* half: before any dynamic Pi import in
+// sendQuery, write a stub package.json to tmpdir and point Pi at it via
+// its own documented `PI_PACKAGE_DIR` escape hatch.
+
+/**
+ * Write a minimal package.json to a stable tmpdir and set `PI_PACKAGE_DIR`
+ * so Pi's `config.js` short-circuits its `dirname(process.execPath)` walk
+ * (which fails inside a compiled archon binary). Pi only reads three
+ * optional fields from that package.json — `piConfig.name`, `piConfig.configDir`,
+ * and `version` — so the stub is genuinely minimal. Idempotent: the file is
+ * only written once per host (existsSync check), and the env var is set on
+ * every call so multiple PiProvider instances stay consistent.
+ *
+ * Done on each sendQuery rather than at module load so (a) the file write
+ * is paid only when Pi is actually used, and (b) the env var can't get
+ * clobbered between registration and invocation.
+ */
+function ensurePiPackageDirShim(): void {
+  const shimDir = join(tmpdir(), 'archon-pi-shim');
+  const shimPkgJson = join(shimDir, 'package.json');
+  if (!existsSync(shimPkgJson)) {
+    mkdirSync(shimDir, { recursive: true });
+    // `piConfig: {}` is explicit so Pi's defaults (`name: 'pi'`,
+    // `configDir: '.pi'`) kick in — matches Pi's standalone behavior.
+    writeFileSync(
+      shimPkgJson,
+      JSON.stringify({
+        name: 'archon-pi-shim',
+        version: '0.0.0',
+        piConfig: {},
+      })
+    );
+  }
+  process.env.PI_PACKAGE_DIR = shimDir;
+}
 
 /**
  * Map Pi provider id → env var name used by pi-ai's getEnvApiKey().
@@ -115,6 +157,13 @@ export class PiProvider implements IAgentProvider {
     resumeSessionId?: string,
     requestOptions?: SendQueryOptions
   ): AsyncGenerator<MessageChunk> {
+    // Install the PI_PACKAGE_DIR shim BEFORE the dynamic imports below: Pi's
+    // config.js runs `readFileSync(getPackageJsonPath())` at its own module
+    // init, and getPackageJsonPath() checks process.env.PI_PACKAGE_DIR first.
+    // Without this, the dynamic import below would crash with ENOENT on
+    // `dirname(process.execPath)/package.json` inside a compiled binary.
+    ensurePiPackageDirShim();
+
     // Lazy-load Pi SDK and all Pi-dependent helper modules here. Must not move
     // these imports to module scope — see the header comment for the failure
     // mode (archon compiled binary crashes at startup when Pi's config.js

--- a/packages/server/src/adapters/platform-persistence.ts
+++ b/packages/server/src/adapters/platform-persistence.ts
@@ -1,0 +1,96 @@
+/**
+ * Persistence wrapper for non-web platform adapters (Discord, Slack, Telegram).
+ *
+ * The Web UI reads conversation history from remote_agent_messages. Incoming
+ * user messages from chat platforms and outgoing assistant replies were never
+ * written there — so Web UI threads appeared empty even though the Discord
+ * thread had the full exchange. This wrapper persists both sides.
+ */
+import type { IPlatformAdapter, MessageMetadata } from '@archon/core';
+import { messageDb } from '@archon/core';
+import type { MessageChunk } from '@archon/providers/types';
+import { createLogger } from '@archon/paths';
+
+let cachedLog: ReturnType<typeof createLogger> | undefined;
+function getLog(): ReturnType<typeof createLogger> {
+  if (!cachedLog) cachedLog = createLogger('adapter.platform-persistence');
+  return cachedLog;
+}
+
+/**
+ * Wrap a platform adapter so every sendMessage also persists as an 'assistant'
+ * row in remote_agent_messages. Persistence failures are logged but never
+ * propagate — sending to the platform is always the source of truth.
+ *
+ * dbId is the conversation UUID from remote_agent_conversations.id (not the
+ * platform conversation id / thread id).
+ */
+export function wrapAdapterWithPersistence(
+  adapter: IPlatformAdapter,
+  dbId: string
+): IPlatformAdapter {
+  const wrapped: IPlatformAdapter = {
+    async sendMessage(
+      conversationId: string,
+      message: string,
+      metadata?: MessageMetadata
+    ): Promise<void> {
+      await adapter.sendMessage(conversationId, message, metadata);
+      if (!message) return;
+      try {
+        const md: Record<string, unknown> | undefined = metadata ? { ...metadata } : undefined;
+        await messageDb.addMessage(dbId, 'assistant', message, md);
+      } catch (err) {
+        getLog().error(
+          { err, dbId, platform: adapter.getPlatformType() },
+          'platform_message_persist_failed'
+        );
+      }
+    },
+    ensureThread: (originalConversationId, messageContext) =>
+      adapter.ensureThread(originalConversationId, messageContext),
+    getStreamingMode: () => adapter.getStreamingMode(),
+    getPlatformType: () => adapter.getPlatformType(),
+    start: () => adapter.start(),
+    stop: (): void => {
+      adapter.stop();
+    },
+  };
+
+  // Forward optional methods only when the underlying adapter implements them,
+  // so feature-detection (e.g. `if (platform.sendStructuredEvent)`) in the
+  // orchestrator still works correctly.
+  if (adapter.sendStructuredEvent) {
+    const send = adapter.sendStructuredEvent.bind(adapter);
+    wrapped.sendStructuredEvent = async (
+      conversationId: string,
+      event: MessageChunk
+    ): Promise<void> => {
+      await send(conversationId, event);
+    };
+  }
+  if (adapter.emitRetract) {
+    const retract = adapter.emitRetract.bind(adapter);
+    wrapped.emitRetract = async (conversationId: string): Promise<void> => {
+      await retract(conversationId);
+    };
+  }
+
+  return wrapped;
+}
+
+/**
+ * Persist an incoming user message. Logged but not thrown on failure — we want
+ * the orchestrator to still respond even if history persistence fails.
+ */
+export async function persistUserMessage(
+  dbId: string,
+  platformType: string,
+  content: string
+): Promise<void> {
+  try {
+    await messageDb.addMessage(dbId, 'user', content);
+  } catch (err) {
+    getLog().error({ err, dbId, platformType }, 'platform_user_message_persist_failed');
+  }
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -73,8 +73,10 @@ import {
   loadConfig,
   logConfig,
   getPort,
+  conversationDb,
 } from '@archon/core';
 import type { IPlatformAdapter } from '@archon/core';
+import { wrapAdapterWithPersistence, persistUserMessage } from './adapters/platform-persistence';
 import {
   createLogger,
   logArchonPaths,
@@ -373,16 +375,28 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
           parentConversationId = discordAdapter.getParentChannelId(message) ?? undefined;
         }
 
+        // Resolve conversation DB row so Web UI history reads find the messages.
+        // handleMessage calls getOrCreateConversation internally; doing it here
+        // is idempotent and gives us the dbId needed for persistence.
+        const conv = await conversationDb.getOrCreateConversation(
+          discordAdapter.getPlatformType(),
+          conversationId,
+          undefined,
+          parentConversationId
+        );
+        await persistUserMessage(conv.id, discordAdapter.getPlatformType(), content);
+        const persistingAdapter = wrapAdapterWithPersistence(discordAdapter, conv.id);
+
         // Fire-and-forget: handler returns immediately, processing happens async
         lockManager
           .acquireLock(conversationId, async () => {
-            await handleMessage(discordAdapter, conversationId, content, {
+            await handleMessage(persistingAdapter, conversationId, content, {
               threadContext,
               parentConversationId,
               isolationHints: { workflowType: 'thread', workflowId: conversationId },
             });
           })
-          .catch(createMessageErrorHandler('Discord', discordAdapter, conversationId));
+          .catch(createMessageErrorHandler('Discord', persistingAdapter, conversationId));
       });
 
       // Don't let a Discord login failure (bad token, missing privileged
@@ -445,16 +459,25 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
           parentConversationId = slackAdapter.getParentConversationId(event) ?? undefined;
         }
 
+        const conv = await conversationDb.getOrCreateConversation(
+          slackAdapter.getPlatformType(),
+          conversationId,
+          undefined,
+          parentConversationId
+        );
+        await persistUserMessage(conv.id, slackAdapter.getPlatformType(), content);
+        const persistingAdapter = wrapAdapterWithPersistence(slackAdapter, conv.id);
+
         // Fire-and-forget: handler returns immediately, processing happens async
         lockManager
           .acquireLock(conversationId, async () => {
-            await handleMessage(slackAdapter, conversationId, content, {
+            await handleMessage(persistingAdapter, conversationId, content, {
               threadContext,
               parentConversationId,
               isolationHints: { workflowType: 'thread', workflowId: conversationId },
             });
           })
-          .catch(createMessageErrorHandler('Slack', slackAdapter, conversationId));
+          .catch(createMessageErrorHandler('Slack', persistingAdapter, conversationId));
       });
 
       await slack.start();
@@ -621,14 +644,21 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
 
     // Register message handler (auth is handled internally by adapter)
     telegramAdapter.onMessage(async ({ conversationId, message }) => {
+      const conv = await conversationDb.getOrCreateConversation(
+        telegramAdapter.getPlatformType(),
+        conversationId
+      );
+      await persistUserMessage(conv.id, telegramAdapter.getPlatformType(), message);
+      const persistingAdapter = wrapAdapterWithPersistence(telegramAdapter, conv.id);
+
       // Fire-and-forget: handler returns immediately, processing happens async
       lockManager
         .acquireLock(conversationId, async () => {
-          await handleMessage(telegramAdapter, conversationId, message, {
+          await handleMessage(persistingAdapter, conversationId, message, {
             isolationHints: { workflowType: 'thread', workflowId: conversationId },
           });
         })
-        .catch(createMessageErrorHandler('Telegram', telegramAdapter, conversationId));
+        .catch(createMessageErrorHandler('Telegram', persistingAdapter, conversationId));
     });
 
     try {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -385,8 +385,24 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
           .catch(createMessageErrorHandler('Discord', discordAdapter, conversationId));
       });
 
-      await discord.start();
-      activePlatforms.push('Discord');
+      // Don't let a Discord login failure (bad token, missing privileged
+      // intents, etc.) bring down the whole server — users running
+      // `archon serve` for the web UI shouldn't lose it because of an
+      // unrelated bot misconfiguration. See #1365.
+      try {
+        await discord.start();
+        activePlatforms.push('Discord');
+      } catch (error) {
+        const err = error as Error;
+        const isPrivilegedIntentError = err.message?.includes('disallowed intents');
+        const hint = isPrivilegedIntentError
+          ? 'Enable "Message Content Intent" in the Discord Developer Portal ' +
+            '(your application > Bot > Privileged Gateway Intents) and restart, ' +
+            'or unset DISCORD_BOT_TOKEN if you do not want the Discord adapter.'
+          : 'Verify DISCORD_BOT_TOKEN is valid, or unset it to disable the Discord adapter.';
+        getLog().error({ err, hint }, 'discord.start_failed_continuing_without_adapter');
+        discord = null;
+      }
     } else {
       getLog().info('discord_adapter_skipped');
     }


### PR DESCRIPTION
## Summary

- Chat platform adapters (Discord, Slack, Telegram) created conversation rows via `getOrCreateConversation` but never wrote messages to `remote_agent_messages`. Web UI threads showed the conversation shell with no content, even though the full exchange was visible inside Discord/Slack/Telegram.
- Adds `packages/server/src/adapters/platform-persistence.ts` — a thin adapter wrapper that persists every `sendMessage` call as an `'assistant'` row, plus a `persistUserMessage` helper for the incoming turn.
- Wires it into the three handler branches in `packages/server/src/index.ts`: resolve the conversation DB UUID (idempotent, orchestrator does the same), persist the user message, then call `handleMessage` with the wrapped adapter so replies flow into history.

Web adapter persistence is untouched — it has its own streaming segment-based path in `adapters/web/persistence.ts`. The wrapper only activates on non-web platforms.

## Why

The orchestrator's `handleMessage` is the single entry point for all platforms but doesn't persist on its own. The web path persists via the web adapter; the chat platforms had no equivalent, so their history was effectively write-only to the platform itself. This made the Web UI's project/conversation views unusable for anyone driving Archon from Discord — you could see *that* you had a conversation but not *what* was said.

## Test plan

- [x] `bun --filter @archon/server type-check` passes
- [x] `bun --filter @archon/server test` — all suites pass
- [x] `bun x eslint` — clean on changed files
- [ ] Manual: send a message in a Discord thread, confirm both the user turn and Archon's reply appear in the Web UI thread view (verified locally on my instance)
- [ ] Slack + Telegram parity (same code path, not manually verified)

## Notes

- Persistence failures are logged but never propagated — sending to the chat platform remains the source of truth.
- No schema changes; uses existing `remote_agent_messages` / `remote_agent_conversations`.
- No backfill: only messages after this lands are persisted. A one-shot import script over `fetchThreadHistory()` output could retroactively seed older threads if desired, but that's out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * User and assistant messages from Discord, Slack, and Telegram conversations are now automatically recorded and persisted, enabling complete conversation histories.

* **Improvements**
  * Messaging reliability enhanced with improved error handling across supported platforms, ensuring uninterrupted message delivery even when issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->