### PR TITLE
fix(workflows): shellQuote handles newlines, script nodes use process.execPath

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -705,29 +705,29 @@ describe('substituteNodeOutputRefs -- shell escaping', () => {
 
   it('shell-quotes output when escapedForBash=true', () => {
     const outputs = new Map([['a', makeOutput('completed', 'hello world')]]);
-    expect(substituteNodeOutputRefs('echo $a.output', outputs, true)).toBe("echo 'hello world'");
+    expect(substituteNodeOutputRefs('echo $a.output', outputs, true)).toBe("echo $'hello world'");
   });
 
   it('escapes shell metacharacters when escapedForBash=true', () => {
     const outputs = new Map([['a', makeOutput('completed', 'hello; rm -rf /')]]);
     expect(substituteNodeOutputRefs('echo $a.output', outputs, true)).toBe(
-      "echo 'hello; rm -rf /'"
+      "echo $'hello; rm -rf /'"
     );
   });
 
   it('escapes single quotes inside output when escapedForBash=true', () => {
     const outputs = new Map([['a', makeOutput('completed', "it's alive")]]);
-    expect(substituteNodeOutputRefs('echo $a.output', outputs, true)).toBe("echo 'it'\\''s alive'");
+    expect(substituteNodeOutputRefs('echo $a.output', outputs, true)).toBe("echo $'it\\'s alive'");
   });
 
   it('missing ref becomes empty string when escapedForBash=true', () => {
     const outputs = new Map<string, NodeOutput>();
-    expect(substituteNodeOutputRefs('echo $missing.output', outputs, true)).toBe("echo ''");
+    expect(substituteNodeOutputRefs('echo $missing.output', outputs, true)).toBe("echo $''");
   });
 
   it('JSON field escapes shell metacharacters when escapedForBash=true', () => {
     const outputs = new Map([['a', makeOutput('completed', JSON.stringify({ cmd: 'foo; bar' }))]]);
-    expect(substituteNodeOutputRefs('echo $a.output.cmd', outputs, true)).toBe("echo 'foo; bar'");
+    expect(substituteNodeOutputRefs('echo $a.output.cmd', outputs, true)).toBe("echo $'foo; bar'");
   });
 
   it('numeric JSON field is not quoted (safe as-is)', () => {
@@ -742,23 +742,23 @@ describe('substituteNodeOutputRefs -- shell escaping', () => {
 
   it('empty string output becomes quoted empty string when escapedForBash=true', () => {
     const outputs = new Map([['a', makeOutput('completed', '')]]);
-    expect(substituteNodeOutputRefs('echo $a.output', outputs, true)).toBe("echo ''");
+    expect(substituteNodeOutputRefs('echo $a.output', outputs, true)).toBe("echo $''");
   });
 
   it('embedded newline in output is safe when escapedForBash=true', () => {
     const outputs = new Map([['a', makeOutput('completed', 'hello\nworld')]]);
-    // Single-quoted bash strings can contain literal newlines safely
-    expect(substituteNodeOutputRefs('echo $a.output', outputs, true)).toBe("echo 'hello\nworld'");
+    // $'...' ANSI-C quoting interprets \n as newline
+    expect(substituteNodeOutputRefs('echo $a.output', outputs, true)).toBe("echo $'hello\\nworld'");
   });
 
   it('object JSON field becomes quoted empty string when escapedForBash=true', () => {
     const outputs = new Map([['a', makeOutput('completed', JSON.stringify({ nested: { x: 1 } }))]]);
-    expect(substituteNodeOutputRefs('echo $a.output.nested', outputs, true)).toBe("echo ''");
+    expect(substituteNodeOutputRefs('echo $a.output.nested', outputs, true)).toBe("echo $''");
   });
 
   it('dot notation on invalid JSON returns quoted empty string when escapedForBash=true', () => {
     const outputs = new Map([['a', makeOutput('completed', 'not-json')]]);
-    expect(substituteNodeOutputRefs('$a.output.field', outputs, true)).toBe("''");
+    expect(substituteNodeOutputRefs('$a.output.field', outputs, true)).toBe("$''");
   });
 });
 
@@ -5812,8 +5812,9 @@ describe('executeDagWorkflow -- script nodes', () => {
       { ...minimalConfig, envVars: { MY_SECRET: 'abc123' } }
     );
 
+    // Script nodes use process.execPath to resolve the bun executable path
     expect(execSpy).toHaveBeenCalledWith(
-      'bun',
+      process.execPath,
       ['--no-env-file', '-e', 'console.log("ok")'],
       expect.objectContaining({
         env: expect.objectContaining({ MY_SECRET: 'abc123' }),

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -264,11 +264,19 @@ async function safeSendMessage(
 }
 
 /**
- * Single-quote a string for safe inline shell use.
- * Replaces each ' with '\'' (end quote, literal single-quote, re-open quote).
+ * Quote a string for safe inline shell use using $'...' ANSI-C quoting.
+ * This format supports escape sequences like \n, \r, \t, etc.
+ * Escapes backslashes first, then single quotes, then newlines/carriage returns.
  */
 function shellQuote(value: string): string {
-  return `'${value.replaceAll("'", "'\\''")}'`;
+  // Use $'...' quoting which interprets \n, \r, etc. as escape sequences
+  // Must escape: backslashes (first), single quotes, newlines, carriage returns
+  const escaped = value
+    .replaceAll('\\', '\\\\') // \ -> \\
+    .replaceAll("'", "\\'") // ' -> \'
+    .replaceAll('\n', '\\n') // newline -> \n
+    .replaceAll('\r', '\\r'); // carriage return -> \r
+  return `$'${escaped}'`;
 }
 
 /**
@@ -290,7 +298,7 @@ export function substituteNodeOutputRefs(
       const nodeOutput = nodeOutputs.get(nodeId);
       if (!nodeOutput) {
         getLog().warn({ nodeId, match }, 'dag_node_output_ref_unknown_node');
-        return escapedForBash ? "''" : '';
+        return escapedForBash ? shellQuote('') : '';
       }
       if (!field) {
         return escapedForBash ? shellQuote(nodeOutput.output) : nodeOutput.output;
@@ -303,13 +311,13 @@ export function substituteNodeOutputRefs(
         // JSON disallows NaN/Infinity, so String(number) contains only digits, sign, and '.'.
         // String(boolean) is 'true' or 'false' — no shell metacharacters.
         if (typeof value === 'number' || typeof value === 'boolean') return String(value);
-        return escapedForBash ? "''" : ''; // objects, null, undefined, symbol, bigint → empty
+        return escapedForBash ? shellQuote('') : ''; // objects, null, undefined, symbol, bigint → empty
       } catch (jsonErr) {
         getLog().warn(
           { nodeId, field, outputPreview: nodeOutput.output.slice(0, 100), err: jsonErr as Error },
           'dag_node_output_ref_json_parse_failed'
         );
-        return escapedForBash ? "''" : '';
+        return escapedForBash ? shellQuote('') : '';
       }
     }
   );
@@ -1428,7 +1436,8 @@ async function executeScriptNode(
     if (isInlineScript(finalScript)) {
       // Inline code execution
       if (node.runtime === 'bun') {
-        cmd = 'bun';
+        // Use process.execPath to get the absolute path to the bun executable.
+        cmd = process.execPath;
         // --no-env-file prevents Bun from auto-loading .env from the execution
         // cwd (the target repo). Without this, repo .env leaks into the script
         // subprocess despite Archon's parent process cleanup.
@@ -1516,7 +1525,8 @@ async function executeScriptNode(
         const withFlags = nodeDeps.flatMap(dep => ['--with', dep]);
         args = ['run', ...withFlags, scriptDef.path];
       } else {
-        cmd = 'bun';
+        // Use process.execPath to get the absolute path to the bun executable.
+        cmd = process.execPath;
         args = ['--no-env-file', 'run', scriptDef.path];
       }
     }

--- a/packages/workflows/src/script-node-deps.test.ts
+++ b/packages/workflows/src/script-node-deps.test.ts
@@ -312,10 +312,11 @@ describe('script node deps field — command construction', () => {
     );
 
     const calls = mockExecFileAsync.mock.calls;
-    const scriptCall = calls.find(c => (c[0] as string) === 'bun');
+    // Script nodes use process.execPath to resolve bun executable
+    const scriptCall = calls.find(c => (c[0] as string) === process.execPath);
     expect(scriptCall).toBeDefined();
     const [cmd, args] = scriptCall as [string, string[]];
-    expect(cmd).toBe('bun');
+    expect(cmd).toBe(process.execPath);
     // --no-env-file prevents repo .env auto-load; no dep flags — bun auto-installs
     expect(args).toEqual(['--no-env-file', '-e', node.script]);
     expect(args).not.toContain('--packages');
@@ -346,10 +347,11 @@ describe('script node deps field — command construction', () => {
     );
 
     const calls = mockExecFileAsync.mock.calls;
-    const scriptCall = calls.find(c => (c[0] as string) === 'bun');
+    // Script nodes use process.execPath to resolve bun executable
+    const scriptCall = calls.find(c => (c[0] as string) === process.execPath);
     expect(scriptCall).toBeDefined();
     const [cmd, args] = scriptCall as [string, string[]];
-    expect(cmd).toBe('bun');
+    expect(cmd).toBe(process.execPath);
     expect(args).toEqual(['--no-env-file', '-e', 'console.log("hello")']);
   });
 


### PR DESCRIPTION
## Summary

- Problem: e2e-pi-all-nodes-smoke workflow failed with two bugs in dag-executor.ts
- Why it matters: Bugs affect DAG workflows on Windows and multi-line AI output
- What changed: shellQuote() uses ANSI-C quoting; script nodes use process.execPath
- What did not change: Workflow YAML, other node types, provider code

## UX Journey

Before: script-bun-node ENOENT, downstream bash EOF error
After: Both nodes complete successfully

## Architecture

Before: shellQuote single quotes, executeScriptNode PATH lookup
After: shellQuote ANSI-C quoting, executeScriptNode process.execPath

## Label Snapshot

- Risk: low
- Size: S
- Scope: workflows

## Change Metadata

- Change type: bug
- Primary scope: workflows

## Validation Evidence

bun run validate - all tests pass

## Security Impact

No new permissions, network calls, or secrets changes.

## Compatibility

Backward compatible, no config or DB changes.

## Human Verification

e2e-opencode-all-nodes-smoke passes, multi-line output tested.

## Rollback

git revert commit-sha

## Risks

ANSI-C quoting requires bash - Archon already requires bash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell command escaping for better reliability in script execution environments.
  * Enhanced handling of empty values and special characters in workflow substitutions.
  * Fixed runtime executable resolution for improved consistency in script node execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->