### PR TITLE
feat(workflows): per-node settingSources override for Claude nodes

### DIFF
--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -609,7 +609,8 @@ function buildBaseClaudeOptions(
     permissionMode: 'bypassPermissions',
     allowDangerouslySkipPermissions: true,
     systemPrompt: requestOptions?.systemPrompt ?? { type: 'preset', preset: 'claude_code' },
-    settingSources: assistantDefaults.settingSources ?? ['project'],
+    settingSources: requestOptions?.nodeConfig?.settingSources ??
+      assistantDefaults.settingSources ?? ['project'],
     hooks: buildToolCaptureHooks(toolResultQueue),
     stderr: (data: string): void => {
       const output = data.trim();

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -209,6 +209,9 @@ export interface NodeConfig {
   output_format?: Record<string, unknown>;
   maxBudgetUsd?: number;
   systemPrompt?: string;
+  /** Per-node override for Claude Code's settingSources flag. Defaults to ['project']
+   *  in provider when not set. Use ['user'] to skip project CLAUDE.md auto-load. */
+  settingSources?: ('project' | 'user')[];
   fallbackModel?: string;
   idle_timeout?: number;
   [key: string]: unknown;

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -363,6 +363,7 @@ async function resolveNodeProviderAndModel(
     output_format: node.output_format,
     maxBudgetUsd: node.maxBudgetUsd,
     systemPrompt: node.systemPrompt,
+    settingSources: node.settingSources,
     fallbackModel: fb,
   };
 

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -160,6 +160,10 @@ export const dagNodeBaseSchema = z.object({
   thinking: thinkingConfigSchema.optional(),
   maxBudgetUsd: z.number().positive().optional(),
   systemPrompt: z.string().min(1).optional(),
+  /** Per-node override for Claude Code's settingSources flag. Defaults to ['project']
+   *  (loads project CLAUDE.md). Set to ['user'] to skip project context for lean
+   *  agents (reviewers, verifiers) that don't need codebase steering docs. */
+  settingSources: z.array(z.enum(['project', 'user'])).optional(),
   fallbackModel: z.string().min(1).optional(),
   betas: z.array(z.string().min(1)).nonempty("'betas' must be a non-empty array").optional(),
   sandbox: sandboxSettingsSchema.optional(),
@@ -337,6 +341,7 @@ export const BASH_NODE_AI_FIELDS: readonly string[] = [
   'thinking',
   'maxBudgetUsd',
   'systemPrompt',
+  'settingSources',
   'fallbackModel',
   'betas',
   'sandbox',
@@ -576,6 +581,7 @@ export const dagNodeSchema = dagNodeBaseSchema
       ...(data.thinking !== undefined ? { thinking: data.thinking } : {}),
       ...(data.maxBudgetUsd !== undefined ? { maxBudgetUsd: data.maxBudgetUsd } : {}),
       ...(data.systemPrompt !== undefined ? { systemPrompt: data.systemPrompt } : {}),
+      ...(data.settingSources !== undefined ? { settingSources: data.settingSources } : {}),
       ...(data.fallbackModel !== undefined ? { fallbackModel: data.fallbackModel } : {}),
       ...(data.betas !== undefined ? { betas: data.betas } : {}),
       ...(data.sandbox !== undefined ? { sandbox: data.sandbox } : {}),


### PR DESCRIPTION
## Problem

Every Claude DAG node currently loads the host project's `CLAUDE.md`
via the provider-level default `settingSources: ['project']` in
`packages/providers/src/claude/provider.ts`. That default is correct
for writer-style nodes that need codebase steering, but it is
wasteful for lean nodes — reviewers, verifiers, and contract agents —
that only consume structured upstream artifacts and emit short
structured output.

On a repository with a large `CLAUDE.md` (ours is ~6K tokens plus
memory imports), the auto-loaded context roughly doubles the wall
time of these lean nodes. In a recent internal workflow run, a single
contract node took 111 s against the project-loading default; the
same node with `settingSources: ['user']` took 56 s — a ~50 %
reduction attributable entirely to skipping project auto-load.

Today there is no way to disable that auto-load per node. The only
existing knob, `systemPrompt`, is a separate code path and does not
bypass project context (verified in `buildBaseClaudeOptions`).

## Solution

Add an optional `settingSources: ('project' | 'user')[]` field to the
DAG node schema and thread it through the executor into the Claude
provider. The provider resolves in this order:

1. `requestOptions.nodeConfig.settingSources` (new, per-node override)
2. `assistantDefaults.settingSources` (existing)
3. `['project']` (existing fallback)

Nodes that don't set the field behave exactly as before, so existing
workflows are unaffected.

## Code changes

| File | Change |
|------|--------|
| `packages/workflows/src/schemas/dag-node.ts` | Zod field on `dagNodeBaseSchema`; added to `BASH_NODE_AI_FIELDS`; spread in `aiOnly` branch of `dagNodeSchema` |
| `packages/providers/src/types.ts` | `settingSources?: ('project' \| 'user')[]` on `NodeConfig` |
| `packages/workflows/src/dag-executor.ts` | Copy `node.settingSources` into the `nodeConfig` passed to the provider |
| `packages/providers/src/claude/provider.ts` | Prefer `requestOptions?.nodeConfig?.settingSources` over `assistantDefaults.settingSources` and the `['project']` fallback |

Total: 4 files, +14/−1.

## Evidence

Measured on an internal orchestrator workflow run, same node
definition, same model, same inputs, only `settingSources` changed:

| Node | Default (`['project']`) | Override (`['user']`) | Delta |
|------|-------------------------|-----------------------|-------|
| contract | 111 s | 56 s | −49.5 % |

Result is consistent with stripping ~6K tokens of auto-loaded project
context on a short-output node.

## Backward compatibility

The new field is optional on the Zod schema, optional on `NodeConfig`,
and the provider falls through to the previous behaviour when it is
absent. Existing workflow YAMLs do not need to change. No migration
required.

## Test plan

Unit tests to add under
`packages/workflows/src/__tests__/dag-node-settingsources.test.ts`:

1. `nodeConfig.settingSources` propagates from YAML → executor → provider.
2. Omission falls back to the existing `['project']` default.
3. Invalid values (e.g. `['global']`) are rejected by the Zod schema.

Manual verification locally: `bun --filter '@archon/workflows'
--filter '@archon/providers' type-check` exits 0 with the changes
applied; `archon validate workflows <name>` passes on a YAML using
the new field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-node configuration option to control Claude settings sources. Users can now specify whether to load project-level or user-level Claude settings on a per-node basis, with project settings as the default for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->