### PR TITLE
fix(workflows): export ARTIFACTS_DIR, LOG_DIR, BASE_BRANCH to bash nodes

### DIFF
--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1137,8 +1137,13 @@ async function executeBashNode(
   const finalScript = substituteNodeOutputRefs(substitutedScript, nodeOutputs, true);
 
   const timeout = node.timeout ?? SUBPROCESS_DEFAULT_TIMEOUT;
-  const subprocessEnv =
-    envVars && Object.keys(envVars).length > 0 ? { ...process.env, ...envVars } : undefined;
+  const subprocessEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    ARTIFACTS_DIR: artifactsDir,
+    LOG_DIR: logDir,
+    BASE_BRANCH: baseBranch,
+    ...(envVars ?? {}),
+  };
 
   try {
     const { stdout, stderr } = await execFileAsync('bash', ['-c', finalScript], {


### PR DESCRIPTION
# fix(workflows): export ARTIFACTS_DIR, LOG_DIR, BASE_BRANCH to bash nodes

## Problem

`executeBashNode` in `packages/workflows/src/dag-executor.ts` receives `artifactsDir`, `logDir`, and `baseBranch` as function parameters and uses them for **compile-time** substitution of `$ARTIFACTS_DIR`, `$LOG_DIR`, and `$BASE_BRANCH` in the script body (via `substituteWorkflowVariables`). However, the spawned bash subprocess never receives these values as environment variables.

Current code (line 1141):

```ts
const subprocessEnv =
  envVars && Object.keys(envVars).length > 0 ? { ...process.env, ...envVars } : undefined;
```

As a result, any script that relies on **shell-runtime** expansion of these variables — for example:

```bash
JSON_FILE="${ARTIFACTS_DIR}/foo.output.json"
```

inside a heredoc, an inherited helper script, a subshell, or a `bash -c` invocation, sees the variable unset and silently falls back to whatever default is written (typically `""` via `${ARTIFACTS_DIR:-}` or `.` via `${ARTIFACTS_DIR:-.}`).

### Observed symptom

In a downstream workflow that uses bash nodes to render verifier artifacts, scripts written against `"${ARTIFACTS_DIR}/<name>.output.md"` silently wrote their output to the current working directory instead of the configured artifacts directory. Because this workflow also enables `isolation: worktree`, the worktree teardown routine then deleted these files. The paired `.output.md` render files were consistently missing from the nominal artifacts directory.

The symptom was purely a bash-runtime expansion problem — the same script ran correctly as a standalone bash invocation against a shell with `ARTIFACTS_DIR` exported.

## Solution

Always construct `subprocessEnv` with the three well-known workflow directories, then allow explicit `envVars` passed from the node definition to override them.

```ts
const subprocessEnv: NodeJS.ProcessEnv = {
  ...process.env,
  ARTIFACTS_DIR: artifactsDir,
  LOG_DIR: logDir,
  BASE_BRANCH: baseBranch,
  ...(envVars ?? {}),
};
```

## Code change

Single hunk in `packages/workflows/src/dag-executor.ts`, inside `executeBashNode`, ~7 lines added, 2 removed.

See `diff.patch`.

## Backward compatibility

- **Compile-time substitution is unchanged.** Scripts that already work via `substituteWorkflowVariables` on `$ARTIFACTS_DIR` / `$LOG_DIR` / `$BASE_BRANCH` continue to work identically.
- **Scripts that don't reference these variables are unaffected.** They inherit a slightly larger environment, matching the shape of a normal bash subprocess.
- **User-supplied `envVars` still wins on conflict.** The spread order places `envVars` last, so a node that explicitly sets `env: { ARTIFACTS_DIR: "/custom" }` in its YAML gets its value honored.
- No change to `process.env` in the parent process; the subprocess env is built fresh per node invocation.
- No change to the function signature — all three values were already parameters.

Out of scope: `executeScriptNode` has the same pattern and is a reasonable follow-up, but it is kept out of this PR to keep the change minimal, auditable, and tightly scoped to the reported symptom.

## Test plan

Three new unit tests in `packages/workflows/src/dag-executor.test.ts` (co-located with existing tests following the package convention):

1. **Well-known vars exported by default.** A bash node with no `env:` entry runs `env | grep` for each of the three variables; the captured stdout contains each value as passed to `executeDagWorkflow(... artifactsDir, logDir, baseBranch ...)`.
2. **Explicit `envVars.ARTIFACTS_DIR` wins over the function arg.** When the node YAML sets `env: { ARTIFACTS_DIR: '/override' }`, the bash process sees `/override`, not the `artifactsDir` argument.
3. **`envVars` absent.** Node YAML omits `env:` entirely; the three variables are still present in the subprocess environment.

See `test-plan.md` for full test bodies.

Manual verification: in the Sanergy-side workflow that originally surfaced this, the `.output.md` render files now land under `${ARTIFACTS_DIR}` as configured, and survive worktree teardown because they are written outside the worktree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved inconsistencies in environment variable availability during workflow command execution, ensuring all workflow-critical variables are consistently passed to commands regardless of additional configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->