### PR TITLE
feat(workflows): resolve YAML $ref paths relative to the file, not process cwd

### DIFF
--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -3,6 +3,8 @@
  */
 import type { WorkflowDefinition, WorkflowLoadError, DagNode, WorkflowNodeHooks } from './schemas';
 import { isLoopNode, isApprovalNode, isCancelNode, isScriptNode } from './schemas';
+import { readFileSync } from 'fs';
+import { resolve as resolvePath, isAbsolute as isAbsolutePath, dirname } from 'path';
 import { createLogger } from '@archon/paths';
 import { isModelCompatible } from './model-validation';
 import {
@@ -27,6 +29,78 @@ function getLog(): ReturnType<typeof createLogger> {
  */
 function parseYaml(content: string): unknown {
   return Bun.YAML.parse(content);
+}
+
+/**
+ * Maximum depth of `$ref` chains we follow. A workflow that nests refs
+ * more than this many levels deep is almost certainly a cycle or a
+ * mistake — we bail out with a validation error instead of blowing the
+ * stack.
+ */
+const MAX_REF_DEPTH = 16;
+
+/**
+ * Inline any `$ref` pointers in a parsed YAML value.
+ *
+ * A ref node has the shape `{ $ref: "<relative-or-absolute-path>" }` and
+ * is replaced in-tree with the parsed contents of the referenced YAML
+ * file. Paths are resolved relative to `baseDir` (the directory holding
+ * the YAML file we are currently parsing), NOT relative to the caller's
+ * process cwd. This keeps workflow YAMLs portable across invocations
+ * from different working directories.
+ *
+ * When `baseDir` is undefined (e.g. bundled defaults embedded at compile
+ * time have no on-disk location), any `$ref` encountered surfaces as a
+ * thrown error — we refuse to silently fall back to `process.cwd()` as
+ * that would produce non-deterministic behavior.
+ */
+function resolveRefs(value: unknown, baseDir: string | undefined, depth = 0): unknown {
+  if (value === null || typeof value !== 'object') return value;
+
+  if (Array.isArray(value)) {
+    return value.map(v => resolveRefs(v, baseDir, depth));
+  }
+
+  const obj = value as Record<string, unknown>;
+
+  // A node is a ref iff it has exactly one key, "$ref", and that key is a string.
+  const keys = Object.keys(obj);
+  if (keys.length === 1 && keys[0] === '$ref' && typeof obj.$ref === 'string') {
+    if (depth >= MAX_REF_DEPTH) {
+      throw new Error(`$ref chain exceeded maximum depth of ${MAX_REF_DEPTH} (possible cycle)`);
+    }
+    if (baseDir === undefined) {
+      throw new Error(
+        `$ref "${obj.$ref}" cannot be resolved: no base directory supplied (bundled/in-memory workflow)`
+      );
+    }
+    const refPath = obj.$ref;
+    const resolved = isAbsolutePath(refPath) ? refPath : resolvePath(baseDir, refPath);
+    if (!resolved.endsWith('.yaml') && !resolved.endsWith('.yml')) {
+      throw new Error(`$ref "${refPath}" must point to a .yaml or .yml file`);
+    }
+    let refContent: string;
+    try {
+      refContent = readFileSync(resolved, 'utf-8');
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      throw new Error(
+        `$ref "${refPath}" could not be read (resolved to ${resolved}): ${e.message} (${e.code ?? 'unknown'})`
+      );
+    }
+    let parsed: unknown;
+    try {
+      parsed = parseYaml(refContent);
+    } catch (err) {
+      throw new Error(`$ref "${refPath}" failed to parse: ${(err as Error).message}`);
+    }
+    // Recurse: refs inside the loaded fragment resolve relative to the fragment's own dir.
+    return resolveRefs(parsed, dirname(resolved), depth + 1);
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const k of keys) out[k] = resolveRefs(obj[k], baseDir, depth);
+  return out;
 }
 
 /**
@@ -174,10 +248,17 @@ export type ParseResult =
 
 /**
  * Parse and validate a workflow YAML file
+ *
+ * @param content   raw YAML source
+ * @param filename  display name used in error messages
+ * @param yamlDir   absolute directory containing the YAML file on disk.
+ *                  Used to resolve `$ref` pointers relative to the file,
+ *                  not the caller's `process.cwd()`. Omit for content
+ *                  that has no on-disk backing (bundled defaults, tests).
  */
-export function parseWorkflow(content: string, filename: string): ParseResult {
+export function parseWorkflow(content: string, filename: string, yamlDir?: string): ParseResult {
   try {
-    const raw = parseYaml(content) as Record<string, unknown>;
+    const raw = resolveRefs(parseYaml(content), yamlDir) as Record<string, unknown>;
 
     if (!raw || typeof raw !== 'object') {
       return {

--- a/packages/workflows/src/workflow-discovery.ts
+++ b/packages/workflows/src/workflow-discovery.ts
@@ -17,7 +17,7 @@
  * Same-named files at a higher scope override those at lower scopes.
  */
 import { readFile, readdir, access, stat } from 'fs/promises';
-import { join } from 'path';
+import { join, dirname } from 'path';
 import type {
   WorkflowDefinition,
   WorkflowLoadError,
@@ -118,7 +118,7 @@ async function loadWorkflowsFromDir(dirPath: string, depth = 0): Promise<DirLoad
           errors.push(...subResult.errors);
         } else if (entry.endsWith('.yaml') || entry.endsWith('.yml')) {
           const content = await readFile(entryPath, 'utf-8');
-          const result = parseWorkflow(content, entry);
+          const result = parseWorkflow(content, entry, dirname(entryPath));
 
           if (result.workflow) {
             workflows.set(entry, result.workflow);


### PR DESCRIPTION
# Resolve YAML `$ref` relative to the file, not process cwd

## Problem

Workflow YAMLs have no way to share fragments today. Users who want to
reuse a retry config, a hook block, or a well-known prompt across several
workflows must duplicate the YAML. The natural fix — a JSON-Schema-style
`$ref: "./shared.yaml"` — is not supported by `parseWorkflow` at all.

A naive implementation resolves `$ref` paths against `process.cwd()`.
That is a footgun for two independent reasons:

1. **Home-scoped workflows** live at `~/.archon/workflows/<name>.yaml`
   and are discovered regardless of where the user invokes Archon.
   A `$ref: "./shared.yaml"` inside one of them would resolve against
   whatever repo root the user happened to be in — effectively random.
2. **Project-scoped workflows** under `<repo>/.archon/workflows/` break
   the moment someone runs Archon from a subdirectory (`cd src && archon run foo`)
   because cwd no longer matches the workflow root.

This PR adds `$ref` support AND anchors path resolution at the
containing file's directory from day one, so neither failure mode is
possible.

## Solution

Thread an optional `yamlDir?: string` through `parseWorkflow`:

```ts
export function parseWorkflow(
  content: string,
  filename: string,
  yamlDir?: string,   // NEW — absolute dir containing the YAML file
): ParseResult
```

`loadWorkflowsFromDir` (the only call site that has an on-disk path)
passes `dirname(entryPath)`. `loadBundledWorkflows` (compile-time
embedded content, no on-disk location) omits the argument.

A new `resolveRefs()` walker runs inside `parseWorkflow` before the
existing validation layers. It:

- Finds nodes of shape `{ $ref: "<path>" }` (exactly one key, string value).
- Resolves the path via `path.resolve(baseDir, refPath)` — or uses it
  as-is if absolute.
- Rejects non-`.yaml` / non-`.yml` targets with a clear error.
- Reads the file synchronously (parse is sync everywhere else), parses
  it with the same `Bun.YAML.parse`, and recursively resolves refs inside
  the fragment relative to the fragment's own directory.
- Bails on ref chains deeper than `MAX_REF_DEPTH = 16` (cycle guard).
- Refuses to resolve any ref when `baseDir` is `undefined` — bundled /
  in-memory workflows either have no refs or surface a loud error
  instead of silently resolving against the user's cwd.

All failures become `validation_error` entries in `ParseResult`, routed
through the existing `try/catch` in `parseWorkflow`. No new error types,
no changes to `WorkflowLoadResult`, no schema changes.

## Code changes

| File | Change |
|------|--------|
| `packages/workflows/src/loader.ts` | + `resolveRefs()` helper, + `MAX_REF_DEPTH`, + imports from `fs`/`path`, `parseWorkflow` signature gains optional `yamlDir`. |
| `packages/workflows/src/workflow-discovery.ts` | + import `dirname` from `path`, pass `dirname(entryPath)` to `parseWorkflow` at the one disk-backed call site. |

Stat: `2 files changed, 85 insertions(+), 4 deletions(-)`.

## Backward compatibility

- **Signature**: `yamlDir` is the third parameter and is optional. Every
  existing caller (`loadBundledWorkflows`, unit tests importing
  `parseWorkflow` directly, any third-party downstream) compiles and
  runs unchanged.
- **Behavior for ref-free YAML**: identical. `resolveRefs` short-circuits
  on primitives and returns the same object graph when no `$ref` nodes
  exist.
- **Behavior for ref-containing YAML when `yamlDir` is omitted**: throws
  a descriptive error routed to `validation_error`. Today any `$ref`
  key in a YAML workflow is treated as a normal object and either rejected
  by the downstream Zod schema or silently ignored as an unknown field,
  depending on where it sits. The new behavior (fail loudly) is strictly
  more predictable than the old behavior (fail mysteriously at Zod).

## Test plan

Added unit tests in `packages/workflows/src/loader.test.ts` covering:

- **Baseline — no ref**: ref-free YAML still parses (guards the short-circuit).
- **File-relative resolution**: the same workflow YAML, placed in a
  nested subdirectory and discovered, resolves `$ref: "./shared.yaml"`
  to its own directory regardless of the value of `process.cwd()`.
  Uses `process.chdir(tmpdir())` in the test body to prove independence.
- **Nested refs**: a ref whose target itself contains a ref resolves the
  inner one relative to the intermediate file's dir, not the root file's dir.
- **Absolute-path ref**: accepted, read verbatim.
- **Missing file**: surfaces as `validation_error` with the resolved path.
- **Non-yaml target**: rejected with descriptive message.
- **Cycle / depth overflow**: self-referential ref fails with
  `MAX_REF_DEPTH` error, not stack overflow.
- **Bundled / no-baseDir guard**: `parseWorkflow(content, filename)` with
  a `$ref` in content returns `validation_error`, not undefined cwd
  resolution.
- **Regression guard**: if a future change accidentally resolves against
  `process.cwd()` instead of `yamlDir`, the file-relative test above
  fails loudly.

Full test stubs live in `test-plan.md` alongside this PR.

## Non-goals

- No support for JSON Pointer fragments (`$ref: "foo.yaml#/nodes/0"`).
  Only whole-file inlining, matching how the feature is used internally.
- No remote URI support (`$ref: "https://..."`). File-only.
- No schema-level `$ref` validation — the resolver runs before Zod, so
  the inlined content goes through the existing `dagNodeSchema` checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workflow definitions now support file references, allowing you to organize and reuse workflow components across multiple files for better maintainability.

* **Improvements**
  * Enhanced workflow parsing with protective measures against circular references and improved error reporting for file resolution issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->