### PR TITLE
fix(cli): lazy-import bundled skill so non-setup commands work without source files

### DIFF
--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -407,11 +407,11 @@ CODEX_ACCOUNT_ID=account1
   });
 
   describe('copyArchonSkill', () => {
-    it('should create skill files in target directory', () => {
+    it('should create skill files in target directory', async () => {
       const target = join(TEST_DIR, 'skill-target');
       mkdirSync(target, { recursive: true });
 
-      copyArchonSkill(target);
+      await copyArchonSkill(target);
 
       expect(existsSync(join(target, '.claude', 'skills', 'archon', 'SKILL.md'))).toBe(true);
       expect(existsSync(join(target, '.claude', 'skills', 'archon', 'guides', 'setup.md'))).toBe(
@@ -425,11 +425,11 @@ CODEX_ACCOUNT_ID=account1
       ).toBe(true);
     });
 
-    it('should write non-empty content to skill files', () => {
+    it('should write non-empty content to skill files', async () => {
       const target = join(TEST_DIR, 'skill-target-content');
       mkdirSync(target, { recursive: true });
 
-      copyArchonSkill(target);
+      await copyArchonSkill(target);
 
       const content = readFileSync(
         join(target, '.claude', 'skills', 'archon', 'SKILL.md'),
@@ -439,23 +439,23 @@ CODEX_ACCOUNT_ID=account1
       expect(content).toContain('archon');
     });
 
-    it('should overwrite existing skill files', () => {
+    it('should overwrite existing skill files', async () => {
       const target = join(TEST_DIR, 'skill-target-overwrite');
       const skillDir = join(target, '.claude', 'skills', 'archon');
       mkdirSync(skillDir, { recursive: true });
       writeFileSync(join(skillDir, 'SKILL.md'), 'old content');
 
-      copyArchonSkill(target);
+      await copyArchonSkill(target);
 
       const content = readFileSync(join(skillDir, 'SKILL.md'), 'utf-8');
       expect(content).not.toBe('old content');
     });
 
-    it('should create skill files even when target directory does not exist', () => {
+    it('should create skill files even when target directory does not exist', async () => {
       const target = join(TEST_DIR, 'non-existent-parent', 'skill-target-new');
       // Do NOT pre-create target — copyArchonSkill must handle it
 
-      copyArchonSkill(target);
+      await copyArchonSkill(target);
 
       expect(existsSync(join(target, '.claude', 'skills', 'archon', 'SKILL.md'))).toBe(true);
     });

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -35,7 +35,6 @@ import {
 import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync, chmodSync } from 'fs';
 import { parse as parseDotenv } from 'dotenv';
 import { join, dirname } from 'path';
-import { BUNDLED_SKILL_FILES } from '../bundled-skill';
 import { homedir } from 'os';
 import { randomBytes } from 'crypto';
 import { spawn, execSync, type ChildProcess } from 'child_process';
@@ -1448,8 +1447,18 @@ export function writeScopedEnv(
  * Copy the bundled Archon skill files to <targetPath>/.claude/skills/archon/
  *
  * Always overwrites existing files to ensure the latest skill version is installed.
+ *
+ * The `bundled-skill` module is dynamically imported here so that its 18 top-level
+ * `import … with { type: 'text' }` statements only execute when this function is
+ * actually called. Compiled binaries (`bun build --compile`) still statically
+ * analyze the literal-string `import()` and embed the chunk; linked-source
+ * installs (`bun link`) don't touch the source skill files unless the user runs
+ * `archon setup`. Without this indirection, every `archon` invocation —
+ * including `archon --help` — fails at module load when the source skill files
+ * are missing from disk.
  */
-export function copyArchonSkill(targetPath: string): void {
+export async function copyArchonSkill(targetPath: string): Promise<void> {
+  const { BUNDLED_SKILL_FILES } = await import('../bundled-skill');
   const skillRoot = join(targetPath, '.claude', 'skills', 'archon');
   for (const [relativePath, content] of Object.entries(BUNDLED_SKILL_FILES)) {
     const dest = join(skillRoot, relativePath);
@@ -1841,7 +1850,7 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
     const skillTarget = skillTargetRaw;
     s.start('Installing Archon skill...');
     try {
-      copyArchonSkill(skillTarget);
+      await copyArchonSkill(skillTarget);
     } catch (err) {
       s.stop('Archon skill installation failed');
       cancel(`Could not install skill: ${(err as NodeJS.ErrnoException).message}`);


### PR DESCRIPTION
## Summary

`bundled-skill.ts` does 18 top-level `import … with { type: 'text' }` statements that resolve at module load — build time for `bun build --compile` (content embedded in binary), but **every `archon` invocation** for `bun link` linked-source installs. If any of those source files are missing or moved, the CLI cannot start at all, even for commands like `archon --help` that don't touch the skill.

The skill content is data the binary *deploys* via `archon setup`, not data the CLI *reads at runtime*. The only production consumer of `BUNDLED_SKILL_FILES` is `copyArchonSkill()` in `setup.ts:1452`. Moving the import inside that function makes the linked-source install robust (only `archon setup` triggers the bundled-skill module load) while preserving compiled-binary behavior (Bun's bundler statically analyses literal-string `import()` and embeds the chunk).

## Verification

- `bun run type-check` — clean across all 10 packages
- `bun run lint`, `bun run format:check` — clean
- `bun test packages/cli/src/commands/setup.test.ts` — 38 pass, 1 skip, 0 fail
- `bun build --compile --minify --target=bun` — succeeds; the compiled binary still embeds the skill content (verified by grepping a known SKILL.md frontmatter string out of the 69M binary — found 1 match)
- Compiled binary smoke: `--help` runs cleanly, no module-load crash

## Repro the original bug

With a `bun link` install of `archon`:

```bash
mv .claude/skills/archon /tmp/  # simulate accidental move/delete
archon --help
# error: Cannot find module '../../../.claude/skills/archon/SKILL.md'
#   from '<repo>/packages/cli/src/bundled-skill.ts'
mv /tmp/archon .claude/skills/  # restore
```

After this fix, `archon --help` runs without the source files. `archon setup` still requires them (or the embedded chunk in compiled mode).

## Adjacent

Found while debugging a parallel agent's failing `archon` invocation during workshop prep. Same family as the four other DX issues filed today:

- #1389 — verbose error format
- #1390 — `approval.message` not variable-substituted
- #1391 — no way to invalidate cached node output
- #1392 — `archon workflow run` auto-resumes without `--resume`

This one is the cleanest — concrete bug, two-file diff, no API/UX change for users.

## Test plan

- [ ] Verify CI passes the full validate suite
- [ ] Manual smoke on a `bun link` install: temporarily move `.claude/skills/archon`, confirm `archon --help` and `archon workflow list` still work
- [ ] Manual smoke: `archon setup` against a temp dir, confirm skill files written

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the skill setup operation to handle asynchronous operations more effectively, with improved error handling integration during the installation process.

* **Tests**
  * Updated test suite to verify proper asynchronous behavior in skill installation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->