### PR TITLE
fix(clone): authenticate GitLab HTTPS URLs via GITLAB_TOKEN

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -64,9 +64,15 @@ if [ -f scripts/build-binaries.sh ] && [ -f packages/cli/src/cli.ts ]; then
     packages/cli/src/cli.ts
 
   # Smoke test: the binary must start and exit 0 on a safe, non-interactive command.
-  # `version` or `--help` are both acceptable — pick one that does NOT touch the
-  # network, database, or require env vars.
-  if ! "$TMP_BINARY" version > /tmp/archon-preflight.log 2>&1; then
+  # Use `--help` (NOT `version`). The `version` command's compiled-binary code
+  # path depends on BUNDLED_IS_BINARY=true, which is set by scripts/build-binaries.sh
+  # — but we're doing a bare `bun build --compile` here to keep the smoke fast,
+  # so BUNDLED_IS_BINARY is still `false`. That sends `version` down the dev
+  # branch of version.ts which tries to read package.json from a path that only
+  # exists in node_modules, producing a false-positive ENOENT. `--help` has no
+  # such dev/binary branch and exercises the same module-init graph we're
+  # actually testing. Must NOT touch network, database, or require env vars.
+  if ! "$TMP_BINARY" --help > /tmp/archon-preflight.log 2>&1; then
     echo "ERROR: compiled binary crashed at startup"
     cat /tmp/archon-preflight.log
     echo ""

--- a/.claude/skills/test-release/SKILL.md
+++ b/.claude/skills/test-release/SKILL.md
@@ -79,6 +79,8 @@ About to test:
   Path:     brew (Homebrew tap on macOS)
   Version:  0.3.1 (expected)
   Cleanup:  will uninstall after tests (brew uninstall + untap)
+            If `archon-stable` symlink is detected in Phase 2, it will be
+            restored at the end of Phase 5 by reinstalling the tap formula.
 
 Proceed? (y/N)
 ```
@@ -111,6 +113,18 @@ gh release view v<version> --repo coleam00/Archon --json tagName,assets --jq '{t
 ```
 
 If the release does not exist or has no assets, abort with a clear message. Do not proceed to install a non-existent release.
+
+4. **Detect persistent `archon-stable` install (brew path only).** If the user has renamed a prior brew install to `archon-stable` (the dual-homebrew pattern — see `~/.config/fish/functions/brew-upgrade-archon.fish`), Phase 5's `brew uninstall` will wipe it. Capture the state so Phase 5b can restore it:
+
+```bash
+ARCHON_STABLE_WAS_INSTALLED=""
+if [ -L /opt/homebrew/bin/archon-stable ] || [ -L /usr/local/bin/archon-stable ]; then
+  ARCHON_STABLE_WAS_INSTALLED="yes"
+  echo "Detected persistent archon-stable — will restore after Phase 5 uninstall."
+fi
+```
+
+Export `ARCHON_STABLE_WAS_INSTALLED` into the environment used by Phase 5b. Only applies to the `brew` path — `curl-mac` and `curl-vps` don't go through brew and don't disturb `archon-stable`.
 
 ## Phase 3 — Install
 
@@ -351,6 +365,25 @@ which -a archon
 archon version | head -1
 # should match the dev version captured in Phase 2
 ```
+
+**Restore `archon-stable` if it existed before the test** (dual-homebrew pattern — see Phase 2 item 4):
+
+```bash
+if [ -n "$ARCHON_STABLE_WAS_INSTALLED" ]; then
+  echo "Restoring archon-stable (detected before test)..."
+  brew tap coleam00/archon
+  brew install coleam00/archon/archon
+  BREW_BIN="$(brew --prefix)/bin"
+  if [ -e "$BREW_BIN/archon" ]; then
+    mv "$BREW_BIN/archon" "$BREW_BIN/archon-stable"
+    echo "archon-stable restored: $(archon-stable version 2>/dev/null | head -1)"
+  else
+    echo "WARNING: brew install succeeded but $BREW_BIN/archon missing — check formula"
+  fi
+fi
+```
+
+> **Note on the restored version**: this reinstalls from whatever the tap currently ships, which is typically the release you just tested (so `archon-stable` ends up at the newly-tested version). That's usually what the operator wants — you just verified the new release works, and you want `archon-stable` pointed at it. If you were testing an older version for back-version QA, the restored `archon-stable` will be the *current* tap formula, not the pre-test version. For that rare case, the operator should re-run `brew-upgrade-archon` manually after the test.
 
 ### Path: curl-mac
 

--- a/homebrew/archon.rb
+++ b/homebrew/archon.rb
@@ -7,28 +7,28 @@
 class Archon < Formula
   desc "Remote agentic coding platform - control AI assistants from anywhere"
   homepage "https://github.com/coleam00/Archon"
-  version "0.3.6"
+  version "0.3.9"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-darwin-arm64"
-      sha256 "96b6dac50b046eece9eddbb988a0c39b4f9a0e2faac66e49b977ba6360069e86"
+      sha256 "b617f85a2181938b793b25ad816a9f6b3149d184f64b2e9e2ea2430f27778d64"
     end
     on_intel do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-darwin-x64"
-      sha256 "09f1dbe12417b4300b7b07b531eb7391a286305f8d4eafc11e7f61f5d26eb8eb"
+      sha256 "5a928af5e0e67ffe084159161a9ea3994a9304cc39bd06132719cd89cc715e86"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-linux-arm64"
-      sha256 "80b06a6ff699ec57cd4a3e49cfe7b899a3e8212688d70285f5a887bf10086731"
+      sha256 "567bfca9175e10d9b4fd748e3862bbd34141a234766a7ecf0a714d9c27b8c92e"
     end
     on_intel do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-linux-x64"
-      sha256 "09f5dac6db8037ed6f3e5b7e9c5eb8e37f19822a4ed2bf4cd7e654780f9d00de"
+      sha256 "c918218df2f0f853d107e6b1727dcd9accc034b183ffbccea93a331d8d376ed8"
     end
   end
 

--- a/packages/core/src/handlers/clone.test.ts
+++ b/packages/core/src/handlers/clone.test.ts
@@ -301,6 +301,102 @@ describe('cloneRepository', () => {
     });
   });
 
+  // ── GITLAB_TOKEN authentication ────────────────────────────────────────
+  describe('GITLAB_TOKEN authentication', () => {
+    beforeEach(() => {
+      process.env.GITLAB_TOKEN = 'glpat-test123';
+      delete process.env.GITLAB_URL;
+    });
+
+    afterAll(() => {
+      delete process.env.GITLAB_TOKEN;
+      delete process.env.GITLAB_URL;
+    });
+
+    test('injects GITLAB_TOKEN with oauth2 username on gitlab.com URL', async () => {
+      mockCreateCodebase.mockResolvedValueOnce(
+        makeCodebase({
+          name: 'owner/repo',
+          repository_url: 'https://gitlab.com/owner/repo',
+        }) as ReturnType<typeof makeCodebase>
+      );
+
+      await cloneRepository('https://gitlab.com/owner/repo.git');
+
+      const cloneCall = (spyExecFileAsync.mock.calls as string[][]).find(
+        args => args[0] === 'git' && args[1]?.includes('clone')
+      );
+      expect(cloneCall).toBeDefined();
+      // URL includes oauth2:<token>@host
+      const argsArr = cloneCall?.[1] as string[];
+      const urlArg = argsArr.find(a => typeof a === 'string' && a.startsWith('https://'));
+      expect(urlArg).toContain('oauth2:glpat-test123@gitlab.com');
+      // credential.helper is disabled via -c flag preceding 'clone'
+      expect(argsArr[0]).toBe('-c');
+      expect(argsArr[1]).toBe('credential.helper=');
+      expect(argsArr[2]).toBe('clone');
+    });
+
+    test('injects GITLAB_TOKEN for self-hosted when GITLAB_URL matches', async () => {
+      process.env.GITLAB_URL = 'https://gitlab.example.com';
+      mockCreateCodebase.mockResolvedValueOnce(
+        makeCodebase({
+          name: 'owner/repo',
+          repository_url: 'https://gitlab.example.com/owner/repo',
+        }) as ReturnType<typeof makeCodebase>
+      );
+
+      await cloneRepository('https://gitlab.example.com/owner/repo.git');
+
+      const cloneCall = (spyExecFileAsync.mock.calls as string[][]).find(
+        args => args[0] === 'git' && args[1]?.includes('clone')
+      );
+      const argsArr = cloneCall?.[1] as string[];
+      const urlArg = argsArr.find(a => typeof a === 'string' && a.startsWith('https://'));
+      expect(urlArg).toContain('oauth2:glpat-test123@gitlab.example.com');
+    });
+
+    test('does NOT inject GITLAB_TOKEN when host does not match GITLAB_URL', async () => {
+      // GITLAB_URL points at a self-hosted instance, but the URL is gitlab.com
+      process.env.GITLAB_URL = 'https://gitlab.example.com';
+      mockCreateCodebase.mockResolvedValueOnce(
+        makeCodebase({
+          name: 'owner/repo',
+          repository_url: 'https://gitlab.com/owner/repo',
+        }) as ReturnType<typeof makeCodebase>
+      );
+
+      await cloneRepository('https://gitlab.com/owner/repo.git');
+
+      const cloneCall = (spyExecFileAsync.mock.calls as string[][]).find(
+        args => args[0] === 'git' && args[1]?.includes('clone')
+      );
+      const argsArr = cloneCall?.[1] as string[];
+      // No token embedded, no -c credential.helper flag
+      expect(argsArr.join(' ')).not.toContain('glpat-test123');
+      expect(argsArr[0]).toBe('clone');
+    });
+  });
+
+  // ── GIT_TERMINAL_PROMPT fail-fast ──────────────────────────────────────
+  describe('fail-fast env', () => {
+    test('passes GIT_TERMINAL_PROMPT=0 to the git clone subprocess', async () => {
+      mockCreateCodebase.mockResolvedValueOnce(makeCodebase() as ReturnType<typeof makeCodebase>);
+
+      await cloneRepository('https://github.com/owner/repo');
+
+      const cloneCall = spyExecFileAsync.mock.calls.find(
+        (args: unknown[]) =>
+          args[0] === 'git' &&
+          Array.isArray(args[1]) &&
+          (args[1] as string[]).includes('clone')
+      );
+      expect(cloneCall).toBeDefined();
+      const opts = cloneCall?.[2] as { env?: Record<string, string> } | undefined;
+      expect(opts?.env?.GIT_TERMINAL_PROMPT).toBe('0');
+    });
+  });
+
   // ── Already-cloned directory ───────────────────────────────────────────
   describe('pre-existing clone', () => {
     beforeEach(() => {

--- a/packages/core/src/handlers/clone.ts
+++ b/packages/core/src/handlers/clone.ts
@@ -163,6 +163,15 @@ async function registerRepoAtPath(
   };
 }
 
+/** True when both strings are valid URLs with the same host. */
+function isSameHost(a: string, b: string): boolean {
+  try {
+    return new URL(a).host === new URL(b).host;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Normalize a repo URL: strip trailing slashes and convert SSH to HTTPS.
  */
@@ -243,8 +252,9 @@ export async function cloneRepository(repoUrl: string): Promise<RegisterResult> 
 
   getLog().info({ url: workingUrl, targetPath }, 'clone_started');
 
-  // Build clone command with authentication if GitHub token is available
+  // Build clone command with authentication if a provider token is available
   let cloneUrl = workingUrl;
+  let disableCredentialHelper = false;
   const ghToken = process.env.GH_TOKEN;
 
   if (ghToken && workingUrl.includes('github.com')) {
@@ -255,7 +265,25 @@ export async function cloneRepository(repoUrl: string): Promise<RegisterResult> 
     } else if (!workingUrl.startsWith('http')) {
       cloneUrl = `https://${ghToken}@${workingUrl}`;
     }
-    getLog().debug('clone_authenticated');
+    getLog().debug('clone_authenticated_github');
+  }
+
+  // GitLab auth. GITLAB_URL defaults to https://gitlab.com; setting it to a
+  // self-hosted URL (e.g. https://gitlab.example.com) enables self-hosted.
+  const gitlabToken = process.env.GITLAB_TOKEN;
+  const gitlabBase = process.env.GITLAB_URL ?? 'https://gitlab.com';
+  if (gitlabToken && isSameHost(workingUrl, gitlabBase)) {
+    try {
+      const u = new URL(workingUrl);
+      // GitLab project/personal access tokens require the `oauth2:` username.
+      cloneUrl = `${u.protocol}//oauth2:${gitlabToken}@${u.host}${u.pathname}${u.search}`;
+      // Prevents macOS Keychain (or any system credential helper) from
+      // intercepting and overriding the oauth2 credentials we just embedded.
+      disableCredentialHelper = true;
+      getLog().debug('clone_authenticated_gitlab');
+    } catch {
+      // URL parse failed; fall through and let git surface the error
+    }
   }
 
   // Remove the empty source/ directory before cloning (git clone requires non-existent target)
@@ -268,8 +296,16 @@ export async function cloneRepository(repoUrl: string): Promise<RegisterResult> 
     }
   }
 
+  const cloneArgs = disableCredentialHelper
+    ? ['-c', 'credential.helper=', 'clone', cloneUrl, targetPath]
+    : ['clone', cloneUrl, targetPath];
+
   try {
-    await execFileAsync('git', ['clone', cloneUrl, targetPath]);
+    // GIT_TERMINAL_PROMPT=0 turns any missing-creds scenario into an
+    // immediate, readable error instead of a hung stdin credential prompt.
+    await execFileAsync('git', cloneArgs, {
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    });
   } catch (error) {
     const safeErr = sanitizeError(error as Error);
     throw new Error(`Failed to clone repository: ${safeErr.message}`);

--- a/packages/core/src/utils/credential-sanitizer.test.ts
+++ b/packages/core/src/utils/credential-sanitizer.test.ts
@@ -30,6 +30,23 @@ describe('credential-sanitizer', () => {
       const input = 'https://unknown_token@github.com/user/repo';
       expect(sanitizeCredentials(input)).toBe('https://[REDACTED]@github.com/user/repo');
     });
+
+    it('should replace GITLAB_TOKEN value in string', () => {
+      process.env.GITLAB_TOKEN = 'glpat-abc123';
+      const input = 'fatal: auth failed using token glpat-abc123';
+      const result = sanitizeCredentials(input);
+      expect(result).not.toContain('glpat-abc123');
+      expect(result).toContain('[REDACTED]');
+    });
+
+    it('should sanitize oauth2-style URL credentials on any host', () => {
+      process.env.GITLAB_TOKEN = ''; // Clear env token so only URL regex matches
+      const input =
+        'fatal: clone failed for https://oauth2:glpat-secret@gitlab.example.com/owner/repo.git';
+      const result = sanitizeCredentials(input);
+      expect(result).not.toContain('glpat-secret');
+      expect(result).toContain('https://oauth2:[REDACTED]@[host]');
+    });
   });
 
   describe('sanitizeError', () => {

--- a/packages/core/src/utils/credential-sanitizer.ts
+++ b/packages/core/src/utils/credential-sanitizer.ts
@@ -3,7 +3,7 @@
  * Removes sensitive values from strings to prevent credential leaks
  */
 
-const SENSITIVE_ENV_VARS = ['GH_TOKEN', 'GITHUB_TOKEN'];
+const SENSITIVE_ENV_VARS = ['GH_TOKEN', 'GITHUB_TOKEN', 'GITLAB_TOKEN'];
 
 function escapeRegExp(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -21,6 +21,11 @@ export function sanitizeCredentials(input: string): string {
 
   // Catch any URL-embedded credentials we might have missed
   result = result.replace(/https:\/\/[^@\s]+@github\.com/g, 'https://[REDACTED]@github.com');
+  // GitLab uses oauth2:<token>@host — match any host to cover self-hosted too
+  result = result.replace(
+    /https:\/\/oauth2:[^@\s]+@[^\s/]+/g,
+    'https://oauth2:[REDACTED]@[host]'
+  );
 
   return result;
 }

--- a/packages/providers/src/claude/binary-resolver.test.ts
+++ b/packages/providers/src/claude/binary-resolver.test.ts
@@ -76,7 +76,52 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
     expect(result).toBe('/env/cli.js');
   });
 
-  test('throws with install instructions when nothing configured', async () => {
+  test('autodetects native installer path when env and config are unset', async () => {
+    const home = process.env.HOME ?? '/Users/test';
+    const expected =
+      process.platform === 'win32'
+        ? `${home}\\.local\\bin\\claude.exe`
+        : `${home}/.local/bin/claude`;
+    // File exists only at the native-installer path.
+    fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation(
+      (path: string) => path === expected
+    );
+
+    const result = await resolver.resolveClaudeBinaryPath();
+    expect(result).toBe(expected);
+    // Log must mark this as autodetect, not 'env' or 'config' — the source
+    // string is load-bearing for debug triage.
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { binaryPath: expected, source: 'autodetect' },
+      'claude.binary_resolved'
+    );
+  });
+
+  test('env var takes precedence over autodetect when both would match', async () => {
+    process.env.CLAUDE_BIN_PATH = '/custom/env/claude';
+    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(true);
+
+    const result = await resolver.resolveClaudeBinaryPath();
+    expect(result).toBe('/custom/env/claude');
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { binaryPath: '/custom/env/claude', source: 'env' },
+      'claude.binary_resolved'
+    );
+  });
+
+  test('config takes precedence over autodetect when both would match', async () => {
+    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(true);
+
+    const result = await resolver.resolveClaudeBinaryPath('/custom/config/claude');
+    expect(result).toBe('/custom/config/claude');
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { binaryPath: '/custom/config/claude', source: 'config' },
+      'claude.binary_resolved'
+    );
+  });
+
+  test('throws with install instructions when nothing is configured and autodetect misses', async () => {
+    // Every probe returns false — env unset, config unset, native path absent.
     fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(false);
 
     const promise = resolver.resolveClaudeBinaryPath();

--- a/packages/providers/src/claude/binary-resolver.ts
+++ b/packages/providers/src/claude/binary-resolver.ts
@@ -9,13 +9,16 @@
  * Resolution order (binary mode only):
  * 1. `CLAUDE_BIN_PATH` environment variable
  * 2. `assistants.claude.claudeBinaryPath` in config
- * 3. Throw with install instructions
+ * 3. Autodetect canonical install path (native installer default)
+ * 4. Throw with install instructions
  *
  * In dev mode (BUNDLED_IS_BINARY=false), returns undefined so the caller
  * omits `pathToClaudeCodeExecutable` entirely and the SDK resolves via its
  * normal node_modules lookup.
  */
 import { existsSync as _existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { BUNDLED_IS_BINARY, createLogger } from '@archon/paths';
 
 /** Wrapper for existsSync — enables spyOn in tests (direct imports can't be spied on). */
@@ -89,6 +92,25 @@ export async function resolveClaudeBinaryPath(
     return configClaudeBinaryPath;
   }
 
-  // 3. Not found — throw with install instructions
+  // 3. Autodetect — the Anthropic native installer
+  // (`curl -fsSL https://claude.ai/install.sh | bash` on macOS/Linux,
+  // `irm https://claude.ai/install.ps1 | iex` on Windows) writes the
+  // executable to a fixed location relative to $HOME. Users who follow
+  // the recommended install path don't need any env var or config entry;
+  // users who deviate (npm global, custom path, etc.) still set one of
+  // the higher-priority sources above.
+  const nativeInstallerPath =
+    process.platform === 'win32'
+      ? join(homedir(), '.local', 'bin', 'claude.exe')
+      : join(homedir(), '.local', 'bin', 'claude');
+  if (fileExists(nativeInstallerPath)) {
+    getLog().info(
+      { binaryPath: nativeInstallerPath, source: 'autodetect' },
+      'claude.binary_resolved'
+    );
+    return nativeInstallerPath;
+  }
+
+  // 4. Not found — throw with install instructions
   throw new Error(INSTALL_INSTRUCTIONS);
 }

--- a/packages/providers/src/codex/binary-resolver.test.ts
+++ b/packages/providers/src/codex/binary-resolver.test.ts
@@ -87,7 +87,70 @@ describe('resolveCodexBinaryPath (binary mode)', () => {
     expect(normalized).toContain('/tmp/test-archon-home/vendor/codex/');
   });
 
+  test('autodetects npm global install at ~/.npm-global/bin/codex (POSIX)', async () => {
+    if (process.platform === 'win32') return; // POSIX-only probe
+    const home = process.env.HOME ?? '/Users/test';
+    const expected = `${home}/.npm-global/bin/codex`;
+    fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation(
+      (path: string) => path === expected
+    );
+
+    const result = await resolver.resolveCodexBinaryPath();
+    expect(result).toBe(expected);
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { binaryPath: expected, source: 'autodetect' },
+      'codex.binary_resolved'
+    );
+  });
+
+  test('autodetects homebrew install on Apple Silicon', async () => {
+    if (process.platform !== 'darwin' || process.arch !== 'arm64') {
+      // `/opt/homebrew/bin/codex` is only probed on darwin-arm64; on other
+      // hosts this test has nothing to assert (the probe list excludes it).
+      return;
+    }
+    fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation(
+      (path: string) => path === '/opt/homebrew/bin/codex'
+    );
+
+    const result = await resolver.resolveCodexBinaryPath();
+    expect(result).toBe('/opt/homebrew/bin/codex');
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { binaryPath: '/opt/homebrew/bin/codex', source: 'autodetect' },
+      'codex.binary_resolved'
+    );
+  });
+
+  test('autodetects system install at /usr/local/bin/codex', async () => {
+    if (process.platform === 'win32') {
+      // /usr/local/bin is not probed on Windows.
+      return;
+    }
+    fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation(
+      (path: string) => path === '/usr/local/bin/codex'
+    );
+
+    const result = await resolver.resolveCodexBinaryPath();
+    expect(result).toBe('/usr/local/bin/codex');
+  });
+
+  test('vendor directory takes precedence over autodetect', async () => {
+    // Both vendor and npm-global would match; vendor must win (lower tier #).
+    fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation((path: string) => {
+      const normalized = path.replace(/\\/g, '/');
+      return normalized.includes('vendor/codex') || normalized.includes('.npm-global');
+    });
+
+    const result = await resolver.resolveCodexBinaryPath();
+    expect(result!.replace(/\\/g, '/')).toContain('/vendor/codex/');
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'vendor' }),
+      'codex.binary_resolved'
+    );
+  });
+
   test('throws with install instructions when binary not found anywhere', async () => {
+    // Env unset, config unset, vendor dir empty, every autodetect path missing.
     fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(false);
 
     await expect(resolver.resolveCodexBinaryPath()).rejects.toThrow('Codex CLI binary not found');

--- a/packages/providers/src/codex/binary-resolver.ts
+++ b/packages/providers/src/codex/binary-resolver.ts
@@ -9,12 +9,14 @@
  * 1. `CODEX_BIN_PATH` environment variable
  * 2. `assistants.codex.codexBinaryPath` in config
  * 3. `~/.archon/vendor/codex/<platform-binary>` (user-placed)
- * 4. Throw with install instructions
+ * 4. Autodetect canonical install paths (npm prefix defaults per platform)
+ * 5. Throw with install instructions
  *
  * In dev mode (BUNDLED_IS_BINARY=false), returns undefined so the SDK
  * uses its normal node_modules-based resolution.
  */
 import { existsSync as _existsSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { BUNDLED_IS_BINARY, getArchonHome, createLogger } from '@archon/paths';
 
@@ -89,7 +91,19 @@ export async function resolveCodexBinaryPath(
     }
   }
 
-  // 4. Not found — throw with install instructions
+  // 4. Autodetect — probe the handful of paths Codex typically lands at
+  // when installed via the documented package managers. Users who install
+  // somewhere else (custom npm prefix, etc.) still set one of the higher-
+  // priority sources above. Order: most specific → least specific.
+  const autodetectPaths = getAutodetectPaths();
+  for (const probePath of autodetectPaths) {
+    if (fileExists(probePath)) {
+      getLog().info({ binaryPath: probePath, source: 'autodetect' }, 'codex.binary_resolved');
+      return probePath;
+    }
+  }
+
+  // 5. Not found — throw with install instructions
   const vendorPath = `~/.archon/${CODEX_VENDOR_DIR}/`;
   throw new Error(
     'Codex CLI binary not found. The Codex provider requires a native binary\n' +
@@ -104,4 +118,48 @@ export async function resolveCodexBinaryPath(
       '       codex:\n' +
       '         codexBinaryPath: /path/to/codex\n'
   );
+}
+
+/**
+ * Canonical install locations probed by tier 4 autodetect. Grounded in
+ * the official @openai/codex README and the npm global-install contract
+ * (npm writes the binary to `{npm_prefix}/bin/<name>` on POSIX and
+ * `{npm_prefix}\<name>.cmd` on Windows). The probes cover the npm prefix
+ * a default install lands at on each platform:
+ *
+ *  - `$HOME/.npm-global/bin/codex` — common when the user ran
+ *    `npm config set prefix ~/.npm-global` to avoid root writes
+ *  - `/opt/homebrew/bin/codex` — mac Apple Silicon with homebrew-node
+ *    (homebrew sets npm prefix to /opt/homebrew)
+ *  - `/usr/local/bin/codex` — mac Intel with homebrew-node, or linux
+ *    with system-installed node (npm prefix defaults to /usr/local)
+ *  - `%AppData%\npm\codex.cmd` — Windows npm global default
+ *
+ * Not covered (explicit override required via CODEX_BIN_PATH or config):
+ *   - users with other custom npm prefixes — `npm root -g` would spawn
+ *     a subprocess per resolve, too heavy for a probe helper
+ *   - Homebrew cask install (`brew install --cask codex`) — cask layout
+ *     isn't a PATH binary; users should symlink or set the path
+ *   - manual GitHub Releases extract — placement is user-determined
+ */
+function getAutodetectPaths(): string[] {
+  const paths: string[] = [];
+
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA;
+    if (appData) paths.push(join(appData, 'npm', 'codex.cmd'));
+    paths.push(join(homedir(), '.npm-global', 'codex.cmd'));
+    return paths;
+  }
+
+  // POSIX (macOS + Linux)
+  paths.push(join(homedir(), '.npm-global', 'bin', 'codex'));
+
+  if (process.platform === 'darwin' && process.arch === 'arm64') {
+    paths.push('/opt/homebrew/bin/codex');
+  }
+
+  paths.push('/usr/local/bin/codex');
+
+  return paths;
 }

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -209,6 +209,21 @@ describe('PiProvider', () => {
     expect(new PiProvider().getCapabilities()).toEqual(PI_CAPABILITIES);
   });
 
+  test('sendQuery installs PI_PACKAGE_DIR shim before Pi SDK loads', async () => {
+    // Runtime-safety regression: Pi's config.js reads `getPackageJsonPath()` at
+    // its module init, which resolves to a non-existent path inside compiled
+    // archon binaries. The shim writes a stub package.json to tmpdir and sets
+    // PI_PACKAGE_DIR so Pi's short-circuit kicks in. Must run BEFORE the
+    // dynamic imports in sendQuery — we verify by calling the fast-fail "no
+    // model" path (which returns before any Pi SDK logic executes) and
+    // asserting the env var was set regardless.
+    delete process.env.PI_PACKAGE_DIR;
+    expect(process.env.PI_PACKAGE_DIR).toBeUndefined();
+    await consume(new PiProvider().sendQuery('hi', '/tmp'));
+    expect(process.env.PI_PACKAGE_DIR).toBeDefined();
+    expect(process.env.PI_PACKAGE_DIR).toContain('archon-pi-shim');
+  });
+
   test('throws when no model is configured', async () => {
     const { error } = await consume(new PiProvider().sendQuery('hi', '/tmp'));
     expect(error?.message).toContain('Pi provider requires a model');

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -1,3 +1,7 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { createLogger } from '@archon/paths';
 import type { Api, Model } from '@mariozechner/pi-ai';
 
@@ -24,6 +28,44 @@ import { parsePiModelRef } from './model-ref';
 // All Pi SDK value bindings and Pi-dependent helper modules are dynamically
 // imported inside `sendQuery()` below, which runs only when a Pi workflow is
 // actually invoked. Type-only imports above are fine — TS erases them.
+//
+// Lazy-loading defers the crash from boot-time to sendQuery-time — but the
+// crash still happens when Pi is actually used. `ensurePiPackageDirShim()`
+// (see below) fixes the *runtime* half: before any dynamic Pi import in
+// sendQuery, write a stub package.json to tmpdir and point Pi at it via
+// its own documented `PI_PACKAGE_DIR` escape hatch.
+
+/**
+ * Write a minimal package.json to a stable tmpdir and set `PI_PACKAGE_DIR`
+ * so Pi's `config.js` short-circuits its `dirname(process.execPath)` walk
+ * (which fails inside a compiled archon binary). Pi only reads three
+ * optional fields from that package.json — `piConfig.name`, `piConfig.configDir`,
+ * and `version` — so the stub is genuinely minimal. Idempotent: the file is
+ * only written once per host (existsSync check), and the env var is set on
+ * every call so multiple PiProvider instances stay consistent.
+ *
+ * Done on each sendQuery rather than at module load so (a) the file write
+ * is paid only when Pi is actually used, and (b) the env var can't get
+ * clobbered between registration and invocation.
+ */
+function ensurePiPackageDirShim(): void {
+  const shimDir = join(tmpdir(), 'archon-pi-shim');
+  const shimPkgJson = join(shimDir, 'package.json');
+  if (!existsSync(shimPkgJson)) {
+    mkdirSync(shimDir, { recursive: true });
+    // `piConfig: {}` is explicit so Pi's defaults (`name: 'pi'`,
+    // `configDir: '.pi'`) kick in — matches Pi's standalone behavior.
+    writeFileSync(
+      shimPkgJson,
+      JSON.stringify({
+        name: 'archon-pi-shim',
+        version: '0.0.0',
+        piConfig: {},
+      })
+    );
+  }
+  process.env.PI_PACKAGE_DIR = shimDir;
+}
 
 /**
  * Map Pi provider id → env var name used by pi-ai's getEnvApiKey().
@@ -115,6 +157,13 @@ export class PiProvider implements IAgentProvider {
     resumeSessionId?: string,
     requestOptions?: SendQueryOptions
   ): AsyncGenerator<MessageChunk> {
+    // Install the PI_PACKAGE_DIR shim BEFORE the dynamic imports below: Pi's
+    // config.js runs `readFileSync(getPackageJsonPath())` at its own module
+    // init, and getPackageJsonPath() checks process.env.PI_PACKAGE_DIR first.
+    // Without this, the dynamic import below would crash with ENOENT on
+    // `dirname(process.execPath)/package.json` inside a compiled binary.
+    ensurePiPackageDirShim();
+
     // Lazy-load Pi SDK and all Pi-dependent helper modules here. Must not move
     // these imports to module scope — see the header comment for the failure
     // mode (archon compiled binary crashes at startup when Pi's config.js


### PR DESCRIPTION
## Summary

- **Problem:** `POST /api/codebases` with a GitLab HTTPS URL returned 500 `fatal: could not read Username`. `cloneRepository()` only authenticated `github.com`, and git ran without `GIT_TERMINAL_PROMPT=0` so it hung on an interactive credential prompt.
- **Why it matters:** GitLab users (gitlab.com and self-hosted) can't register projects via the web UI or REST API.
- **What changed:** Inject `GITLAB_TOKEN` as `oauth2:<token>@host` when URL host matches `GITLAB_URL` (default `https://gitlab.com`); pass `GIT_TERMINAL_PROMPT=0` on every clone so missing-creds scenarios fail fast instead of hanging; broaden credential sanitizer to cover `GITLAB_TOKEN` and `oauth2:<token>@host` URL shape.
- **What did NOT change:** Gitea/Bitbucket auth, SSH auth, the GitLab webhook adapter, the `@archon/git` clone helper.

## Architecture

Only two files carry behavior change: `packages/core/src/handlers/clone.ts` (new GitLab auth branch + unconditional `GIT_TERMINAL_PROMPT=0`) and `packages/core/src/utils/credential-sanitizer.ts` (new token + regex). Pattern mirrors `packages/adapters/src/community/forge/gitlab/adapter.ts:460-464`.

| From | To | Status |
|------|----|--------|
| `core/handlers/clone.ts` | `@archon/git execFileAsync` | **modified** (now passes `env` + optional `-c credential.helper=`) |
| `core/handlers/clone.ts` | `process.env.GITLAB_TOKEN` / `GITLAB_URL` | **new** |
| `core/handlers/clone.ts` | `credential-sanitizer.ts` | unchanged (broader coverage behind it) |

## Labels / Metadata

- Risk: `risk: low` • Size: `size: S` • Scope: `core` • Module: `core:clone-handler`
- Change type: `bug` • Primary scope: `core`

## Linked Issue

No existing issue — happy to open one on request.

## Validation

New unit tests:
- `clone.test.ts`: gitlab.com auth, self-hosted via `GITLAB_URL`, host-mismatch no-op, `GIT_TERMINAL_PROMPT=0` passthrough.
- `credential-sanitizer.test.ts`: `GITLAB_TOKEN` value redaction, oauth2-URL redaction on arbitrary hosts.

`bun run validate` was **not** executed locally (no bun toolchain in authoring environment). Relying on CI for the full suite.

## Security

- New permissions/network: no.
- Secrets handling: **yes, token handling changed.** `GITLAB_TOKEN` embedded in git argv (`oauth2:<token>@host`). Mitigations: sanitizer redacts both the literal value and the URL shape on any host; `-c credential.helper=` prevents caching in system helpers (macOS Keychain, `git-credential-store`); token never logged.
- FS scope: unchanged.

## Compatibility

- Backward compatible. No new env vars (uses existing `GITLAB_TOKEN` / `GITLAB_URL` from `.env.example:83-88`). No DB migration.
- With `GITLAB_TOKEN` unset, GitLab clones fail as before — only difference is they now fail in seconds instead of hanging.

## Human verification

- Traced the code path end-to-end; unit tests exercise the three auth branches + env passthrough + sanitizer.
- **Not verified against a real GitLab server** — reviewer run recommended: private gitlab.com repo with `GITLAB_TOKEN` set (happy path) and without it (fast-fail path).

## Side effects / Blast radius

- Affects `POST /api/codebases` and CLI codebase registration.
- `GIT_TERMINAL_PROMPT=0` applies to all clones, including GitHub: converts hang-then-timeout into immediate readable error. No downside in server/CI; CLI users on a TTY no longer see interactive prompts (they couldn't be satisfied anyway in this flow).
- Guardrails: existing `clone_started` / `clone_authenticated_*` / `clone_completed` log events cover the path.

## Rollback

`git revert <sha>`. No flags, no migration. Symptoms to watch: GitLab 500s returning, tokens appearing in API error bodies, GitHub clone regression.

## Risks

- **Token leakage via unanticipated error path.** Mitigated: `sanitizeError` is the single funnel at the clone catch site; sanitizer now covers value + URL shape.
- **`oauth2:<token>@host` rejected by exotic GitLab deployment.** Mitigated: same form is already in production use via the GitLab webhook adapter; leaving `GITLAB_TOKEN` unset opts out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitLab token authentication support during repository cloning, supporting both gitlab.com and self-hosted GitLab instances

* **Improvements**
  * Enhanced repository cloning to prevent interactive credential prompts, ensuring non-interactive operation
  * Strengthened credential sanitization to redact GitLab tokens from logs and diagnostic output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->