### PR TITLE
fix(server): GET /api/workflows/:name missed home-scoped workflows

### DIFF
--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -37,6 +37,7 @@ import {
   getDefaultWorkflowsPath,
   getArchonWorkspacesPath,
   getHomeCommandsPath,
+  getHomeWorkflowsPath,
   getRunArtifactsPath,
   getArchonHome,
   isDocker,
@@ -2237,7 +2238,7 @@ export function registerApiRoutes(
 
       const filename = `${name}.yaml`;
 
-      // 1. Try user-defined workflow in cwd
+      // 1. Try user-defined workflow in cwd (project scope)
       if (workingDir) {
         const [workflowFolder] = getWorkflowFolderSearchPaths();
         const filePath = join(workingDir, workflowFolder, filename);
@@ -2260,7 +2261,33 @@ export function registerApiRoutes(
         }
       }
 
-      // 2. Fall back to bundled defaults (binary: embedded map; dev: also check filesystem)
+      // 2. Fall back to home-scoped workflow (`~/.archon/workflows/`).
+      // Mirrors the discovery order in `discoverWorkflowsWithConfig` — this
+      // endpoint previously skipped the home scope, so global workflows were
+      // invisible to the web UI builder (it loads via this single-workflow
+      // endpoint) even though `GET /api/workflows` (list) returned them.
+      {
+        const homeFilePath = join(getHomeWorkflowsPath(), filename);
+        try {
+          const content = await readFile(homeFilePath, 'utf-8');
+          const result = parseWorkflow(content, filename);
+          if (result.error) {
+            return apiError(c, 500, `Home workflow file is invalid: ${result.error.error}`);
+          }
+          return c.json({
+            workflow: result.workflow,
+            filename,
+            source: 'global' as WorkflowSource,
+          });
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+            getLog().error({ err, name }, 'workflow.fetch_home_failed');
+            return apiError(c, 500, 'Failed to read home-scoped workflow');
+          }
+        }
+      }
+
+      // 3. Fall back to bundled defaults (binary: embedded map; dev: also check filesystem)
       if (Object.hasOwn(BUNDLED_WORKFLOWS, name)) {
         const bundledContent = BUNDLED_WORKFLOWS[name];
         const result = parseWorkflow(bundledContent, filename);

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -2238,7 +2238,7 @@ export function registerApiRoutes(
 
       const filename = `${name}.yaml`;
 
-      // 1. Try user-defined workflow in cwd (project scope)
+      // 1. Try user-defined workflow in cwd.
       if (workingDir) {
         const [workflowFolder] = getWorkflowFolderSearchPaths();
         const filePath = join(workingDir, workflowFolder, filename);
@@ -2262,10 +2262,7 @@ export function registerApiRoutes(
       }
 
       // 2. Fall back to home-scoped workflow (`~/.archon/workflows/`).
-      // Mirrors the discovery order in `discoverWorkflowsWithConfig` — this
-      // endpoint previously skipped the home scope, so global workflows were
-      // invisible to the web UI builder (it loads via this single-workflow
-      // endpoint) even though `GET /api/workflows` (list) returned them.
+      // Mirrors the discovery order in `discoverWorkflowsWithConfig`.
       {
         const homeFilePath = join(getHomeWorkflowsPath(), filename);
         try {
@@ -2287,7 +2284,7 @@ export function registerApiRoutes(
         }
       }
 
-      // 3. Fall back to bundled defaults (binary: embedded map; dev: also check filesystem)
+      // 3. Fall back to bundled defaults.
       if (Object.hasOwn(BUNDLED_WORKFLOWS, name)) {
         const bundledContent = BUNDLED_WORKFLOWS[name];
         const result = parseWorkflow(bundledContent, filename);

--- a/packages/server/src/routes/api.workflows.test.ts
+++ b/packages/server/src/routes/api.workflows.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock } from 'bun:test';
+import { describe, test, expect, mock, spyOn } from 'bun:test';
 import { OpenAPIHono } from '@hono/zod-openapi';
 import type { ConversationLockManager } from '@archon/core';
 import type { WebAdapter } from '../adapters/web';
@@ -306,6 +306,12 @@ describe('GET /api/workflows/:name', () => {
       'name: shared\ndescription: home version\nnodes:\n  - id: plan\n    command: plan\n'
     );
 
+    // Spy on readFile to prove home-scope is not even attempted when project
+    // hit succeeds. `parseWorkflow` is globally mocked, so asserting on
+    // `body.source` alone can't catch a regression that opens both files.
+    const fsPromises = await import('fs/promises');
+    const readFileSpy = spyOn(fsPromises, 'readFile');
+
     const prevArchonHome = process.env.ARCHON_HOME;
     process.env.ARCHON_HOME = tmpHome;
     try {
@@ -318,7 +324,12 @@ describe('GET /api/workflows/:name', () => {
       const body = (await response.json()) as { source: string };
       // Project must shadow home — home lookup should not even be attempted.
       expect(body.source).toBe('project');
+
+      const homePath = join(homeWorkflowsDir, 'shared.yaml');
+      const homeWasRead = readFileSpy.mock.calls.some(args => String(args[0]) === homePath);
+      expect(homeWasRead).toBe(false);
     } finally {
+      readFileSpy.mockRestore();
       if (prevArchonHome === undefined) {
         delete process.env.ARCHON_HOME;
       } else {

--- a/packages/server/src/routes/api.workflows.test.ts
+++ b/packages/server/src/routes/api.workflows.test.ts
@@ -253,6 +253,81 @@ describe('GET /api/workflows/:name', () => {
     }
   });
 
+  test('returns home-scoped workflow with source:global when project/bundled miss', async () => {
+    const tmpHome = join(tmpdir(), `wf-home-test-${Date.now()}`);
+    const homeWorkflowsDir = join(tmpHome, 'workflows');
+    await mkdir(homeWorkflowsDir, { recursive: true });
+    await writeFile(
+      join(homeWorkflowsDir, 'home-only.yaml'),
+      'name: home-only\ndescription: Home-scoped workflow\nnodes:\n  - id: plan\n    command: plan\n'
+    );
+
+    const prevArchonHome = process.env.ARCHON_HOME;
+    process.env.ARCHON_HOME = tmpHome;
+    try {
+      const app = createTestApp();
+      registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+      // No registered codebase → skips project-scope, falls through to home-scope
+      mockListCodebases.mockImplementationOnce(async () => []);
+      const response = await app.request('/api/workflows/home-only');
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        source: string;
+        filename: string;
+        workflow: unknown;
+      };
+      expect(body.source).toBe('global');
+      expect(body.filename).toBe('home-only.yaml');
+      expect(body.workflow).toBeDefined();
+    } finally {
+      if (prevArchonHome === undefined) {
+        delete process.env.ARCHON_HOME;
+      } else {
+        process.env.ARCHON_HOME = prevArchonHome;
+      }
+      await rm(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  test('project-scope shadows home-scope when same filename exists in both', async () => {
+    const testDir = join(tmpdir(), `wf-shadow-test-${Date.now()}`);
+    const projectDir = join(testDir, '.archon', 'workflows');
+    const tmpHome = join(testDir, 'home');
+    const homeWorkflowsDir = join(tmpHome, 'workflows');
+    await mkdir(projectDir, { recursive: true });
+    await mkdir(homeWorkflowsDir, { recursive: true });
+    await writeFile(
+      join(projectDir, 'shared.yaml'),
+      'name: shared\ndescription: project version\nnodes:\n  - id: plan\n    command: plan\n'
+    );
+    await writeFile(
+      join(homeWorkflowsDir, 'shared.yaml'),
+      'name: shared\ndescription: home version\nnodes:\n  - id: plan\n    command: plan\n'
+    );
+
+    const prevArchonHome = process.env.ARCHON_HOME;
+    process.env.ARCHON_HOME = tmpHome;
+    try {
+      const app = createTestApp();
+      registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+      mockListCodebases.mockImplementationOnce(async () => [{ default_cwd: testDir }]);
+      const response = await app.request(`/api/workflows/shared?cwd=${testDir}`);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { source: string };
+      // Project must shadow home — home lookup should not even be attempted.
+      expect(body.source).toBe('project');
+    } finally {
+      if (prevArchonHome === undefined) {
+        delete process.env.ARCHON_HOME;
+      } else {
+        process.env.ARCHON_HOME = prevArchonHome;
+      }
+      await rm(testDir, { recursive: true, force: true });
+    }
+  });
+
   test('returns WorkflowDefinition shape with expected top-level fields', async () => {
     const app = createTestApp();
     registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);

--- a/packages/server/src/routes/api.workflows.test.ts
+++ b/packages/server/src/routes/api.workflows.test.ts
@@ -290,6 +290,40 @@ describe('GET /api/workflows/:name', () => {
     }
   });
 
+  test('returns 500 when home-scoped workflow file is malformed YAML', async () => {
+    const tmpHome = join(tmpdir(), `wf-home-invalid-test-${Date.now()}`);
+    const homeWorkflowsDir = join(tmpHome, 'workflows');
+    await mkdir(homeWorkflowsDir, { recursive: true });
+    await writeFile(join(homeWorkflowsDir, 'broken.yaml'), 'invalid: [yaml');
+
+    const prevArchonHome = process.env.ARCHON_HOME;
+    process.env.ARCHON_HOME = tmpHome;
+    try {
+      const app = createTestApp();
+      registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+      // No registered codebase → project scope skipped → home scope attempted.
+      mockListCodebases.mockImplementationOnce(async () => []);
+      // Force parseWorkflow to surface a parse error for the home file.
+      mockParseWorkflow.mockReturnValueOnce({
+        workflow: null,
+        error: { filename: 'broken.yaml', error: 'unexpected token', errorType: 'parse_error' },
+      });
+
+      const response = await app.request('/api/workflows/broken');
+      expect(response.status).toBe(500);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toContain('Home workflow file is invalid');
+    } finally {
+      if (prevArchonHome === undefined) {
+        delete process.env.ARCHON_HOME;
+      } else {
+        process.env.ARCHON_HOME = prevArchonHome;
+      }
+      await rm(tmpHome, { recursive: true, force: true });
+    }
+  });
+
   test('project-scope shadows home-scope when same filename exists in both', async () => {
     const testDir = join(tmpdir(), `wf-shadow-test-${Date.now()}`);
     const projectDir = join(testDir, '.archon', 'workflows');


### PR DESCRIPTION
## Summary

- Problem: `GET /api/workflows/:name` skipped the home scope (`~/.archon/workflows/`), making global workflows invisible to the Web UI builder (which loads through this endpoint).
- Why it matters: After #1315 the list endpoint + CLI discover home-scoped workflows correctly, but the single-workflow endpoint wasn't updated → inconsistent behavior, 404 in the UI even though the workflow exists.
- What changed: Added a home-scope lookup between project-scope and bundled defaults, mirroring the discovery order of `discoverWorkflowsWithConfig`. Returns `source: 'global'` (already in the `WorkflowSource` union).
- What did **not** change (scope boundary): LIST endpoint, bundled/default fallback order, command discovery, any client-facing shape beyond the new `source: 'global'` case.

## UX Journey

### Before

```
User                       Archon Server                        Web UI
────                       ─────────────                        ──────
places workflow in
  ~/.archon/workflows/
opens /workflows/builder
  ?edit=<name>      ─────▶ GET /api/workflows/:name
                           ├─ project scope?  miss
                           └─ bundled default? miss
                           ◀──────────── 404 Not Found
                                                                "Failed to load
                                                                  workflow (404)"
```

### After

```
User                       Archon Server                              Web UI
────                       ─────────────                              ──────
places workflow in
  ~/.archon/workflows/
opens /workflows/builder
  ?edit=<name>      ─────▶ GET /api/workflows/:name
                           ├─ project scope?    miss
                           ├─ [+ home scope?    HIT  → source:'global']
                           └─ bundled default?  (skipped)
                           ◀──────────── 200 { workflow, source:'global' }
                                                                builder renders
                                                                  12-node DAG,
                                                                  green "Valid"
```

## Architecture Diagram

### Before

```
                ┌──────────────────────────────────┐
                │  GET /api/workflows/:name        │
                │  (packages/server/.../api.ts)    │
                └─────────────┬────────────────────┘
                              │
              ┌───────────────┴───────────────┐
              ▼                               ▼
   ┌────────────────────┐        ┌────────────────────────┐
   │ project scope      │        │ bundled defaults       │
   │ <cwd>/.archon/...  │        │ packages/server/.../   │
   │ (readFile + parse) │        │   defaults/*.yaml      │
   └────────────────────┘        └────────────────────────┘

   home scope           ── NOT REACHED ──   getHomeWorkflowsPath()
   ~/.archon/workflows/                     (already used by LIST + CLI)
```

### After

```
                ┌──────────────────────────────────┐
                │  GET /api/workflows/:name  [~]   │
                │  (packages/server/.../api.ts)    │
                └─────────────┬────────────────────┘
                              │
              ┌───────────────┼───────────────┬─────────────────────┐
              ▼               ▼               ▼                     ▼
   ┌──────────────────┐  ┌─────────────────────────┐   ┌────────────────────────┐
   │ project scope    │══│ [+ home scope]          │══▶│ bundled defaults       │
   │ <cwd>/.archon/.. │  │ ~/.archon/workflows/    │   │ defaults/*.yaml        │
   │ (unchanged)      │  │ getHomeWorkflowsPath()  │   │ (unchanged)            │
   │                  │  │ readFile + parseWorkflow│   │                        │
   │                  │  │ source: 'global'        │   │                        │
   └──────────────────┘  └─────────────────────────┘   └────────────────────────┘
                                       │
                                       └─ ENOENT → fall through
                                          parse error → 500
                                          (workflow.fetch_home_failed)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `GET /api/workflows/:name` handler | project-scope `readFile` | unchanged | first lookup, same as before |
| `GET /api/workflows/:name` handler | `getHomeWorkflowsPath()` | **new** | imported from existing helper, already used by LIST + CLI |
| `GET /api/workflows/:name` handler | home-scope `readFile` | **new** | `~/.archon/workflows/<sanitized-name>.yaml` |
| `GET /api/workflows/:name` handler | `parseWorkflow` (home YAML) | **new** | reuses existing parser |
| `GET /api/workflows/:name` handler | bundled defaults | **modified** | now reached only after project + home miss |
| `isValidCommandName` guard | request handler | unchanged | still fires first, blocks path traversal |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S` (+116 / -3, two files)
- Scope: `server`
- Module: `server:workflows`

## Change Metadata

- Change type: `bug`
- Primary scope: `server`

## Linked Issue

- Related #1138
- Follows #1315

## Validation Evidence (required)

```bash
# Server suite — full test run
cd packages/server && bun run test
# → all 9 test files pass (224 tests / 0 fails)

# Type-check
cd packages/server && bun run type-check
# → clean (bun x tsc --noEmit, no output = no errors)

# Targeted run for the changed test file
bun test packages/server/src/routes/api.workflows.test.ts
# → 29 pass / 0 fail (includes 2 new tests: home-scope hit, shadow precedence)
```

Evidence provided:
- Added two integration tests (`api.workflows.test.ts`): home-scope hit (`source: 'global'`) and project-over-home shadow precedence with `spyOn(readFile)` proving the home path is never opened when project wins.
- Manual reproduction on `dev`: placed a workflow in `~/.archon/workflows/`, hit `/workflows/builder?edit=<name>` in the UI. Before patch: "Failed to load workflow (404)". After patch: 12-node DAG renders, `Valid` badge green.

## Security Impact (required)

- New permissions/capabilities? No — same `readFile` on `.yaml` files, different path.
- New external network calls? No.
- Secrets/tokens handling changed? No.
- File system access scope changed? Yes, but narrowly: one additional `readFile` of `~/.archon/workflows/<sanitized-name>.yaml`. The name is already validated by `isValidCommandName` (path-traversal guard, covered by test at line 189). No directory traversal or user-controlled paths beyond the existing guard.

## Compatibility / Migration

- Backward compatible? Yes — purely additive. A workflow that only existed as `bundled` or `project` before keeps the same `source` value and body.
- Config/env changes? No.
- Database migration needed? No.

## Human Verification (required)

Verified scenarios:
- Workflow only in `~/.archon/workflows/` → API returns `source: 'global'`, UI builder loads it.
- Same filename in project + home → project wins, home `readFile` is never called (spy-asserted).
- Bundled default (`archon-assist`) still returns `source: 'bundled'` when no project/home match.
- Invalid name (path traversal like `..secret`) still 400 before any `readFile` (existing test at line 189, still passes).

Edge cases checked:
- Home directory missing → `ENOENT` falls through to bundled (no 500).
- Home YAML exists but unparseable → 500 with "Home workflow file is invalid: ..." (dedicated error branch).

What was not verified:
- Docker path (`/.archon`) — only verified the macOS homedir path. `getHomeWorkflowsPath()` already handles both via `getArchonHome()`, so this should be inherited correctly.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: only `GET /api/workflows/:name` (single-workflow fetch). No change to LIST, PUT, or any workflow-run path.
- Potential unintended effects: if a user has a `~/.archon/workflows/<name>.yaml` file with the same name as a bundled default, the home version now takes precedence over bundled (but still loses to project). This matches `discoverWorkflowsWithConfig` and the LIST endpoint — users already rely on this precedence for the list view, so it aligns the two views.
- Guardrails/monitoring for early detection: existing name validation (`isValidCommandName`) still fires first; parse errors return 500 with a distinct log key (`workflow.fetch_home_failed`).

## Rollback Plan (required)

- Fast rollback command/path: revert the commit on `api.ts` (28 lines); the test additions are non-breaking and can stay or be reverted together.
- Feature flags or config toggles: none — this is a straight bug fix, behavior-additive for anyone not using the home scope.
- Observable failure symptoms: unexpected 500s with `workflow.fetch_home_failed` in logs would indicate malformed YAML in a home workflow — user-recoverable by fixing the file.

## Risks and Mitigations

- Risk: None significant. The change is ~28 lines, structurally identical to the existing project-scope branch, with dedicated test coverage and file-read-spy verification of shadow precedence.
  - Mitigation: dedicated 500 branch with `workflow.fetch_home_failed` log key; existing `isValidCommandName` guard unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discover workflows from the user home directory (returned as source: "global"); project-scoped workflows continue to take precedence over home, which falls back to bundled defaults.

* **Bug Fixes**
  * Malformed or unreadable home workflow files now produce a 500 error instead of silent failure.

* **Tests**
  * Added tests covering home-scope discovery, malformed-home handling, precedence (project vs home), and avoiding unnecessary home-file reads.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1405)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->