### PR TITLE
fix(web): resume interactive loop workflows on approve

### DIFF
--- a/packages/server/src/adapters/web/workflow-bridge.ts
+++ b/packages/server/src/adapters/web/workflow-bridge.ts
@@ -140,6 +140,7 @@ export function mapWorkflowEvent(event: WorkflowEmitterEvent): string | null {
         approval: {
           nodeId: event.nodeId,
           message: event.message,
+          type: event.approvalType,
         },
       });
 

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -1955,33 +1955,44 @@ export function registerApiRoutes(
       if (!approval?.nodeId) {
         return apiError(c, 400, 'Workflow run is paused but missing approval context');
       }
-      // For interactive loops, do NOT write node_completed — the executor writes it when
-      // the AI emits the completion signal (actual loop exit). Writing it here would cause
-      // the resume to skip the loop node entirely via priorCompletedNodes.
-      if (approval.type !== 'interactive_loop') {
-        const nodeOutput = approval.captureResponse === true ? comment : '';
-        await workflowEventDb.createWorkflowEvent({
-          workflow_run_id: runId,
-          event_type: 'node_completed',
-          step_name: approval.nodeId,
-          data: { node_output: nodeOutput, approval_decision: 'approved' },
+
+      // For interactive loops, delegate to the orchestrator's natural-language approval
+      // path which handles events, status transition, AND resume in one atomic flow.
+      // Without this, the approve endpoint would set status='failed' but nothing would
+      // trigger the actual workflow resume.
+      if (approval.type === 'interactive_loop') {
+        const conv = await conversationDb.getConversationById(run.conversation_id);
+        if (!conv) {
+          return apiError(c, 404, 'Conversation not found for workflow run');
+        }
+        // Fire-and-forget: dispatch the comment as a message through the orchestrator,
+        // which detects the paused run and handles approval + resume.
+        dispatchToOrchestrator(conv.platform_conversation_id, comment).catch(err => {
+          getLog().error({ err, runId }, 'api.interactive_loop_resume_failed');
+        });
+        return c.json({
+          success: true,
+          message: `Resuming workflow: ${run.workflow_name}`,
         });
       }
+
+      // Standard approval gates: write node_completed so the executor skips the node on resume.
+      const nodeOutput = approval.captureResponse === true ? comment : '';
+      await workflowEventDb.createWorkflowEvent({
+        workflow_run_id: runId,
+        event_type: 'node_completed',
+        step_name: approval.nodeId,
+        data: { node_output: nodeOutput, approval_decision: 'approved' },
+      });
       await workflowEventDb.createWorkflowEvent({
         workflow_run_id: runId,
         event_type: 'approval_received',
         step_name: approval.nodeId,
         data: { decision: 'approved', comment },
       });
-      // For interactive loops, store user input; for standard approvals, mark as approved
-      // and clear any rejection state.
-      const metadataUpdate =
-        approval.type === 'interactive_loop'
-          ? { loop_user_input: comment }
-          : { approval_response: 'approved', rejection_reason: '', rejection_count: 0 };
       await workflowDb.updateWorkflowRun(runId, {
         status: 'failed',
-        metadata: metadataUpdate,
+        metadata: { approval_response: 'approved', rejection_reason: '', rejection_count: 0 },
       });
 
       // Auto-resume: dispatch to the orchestrator so the workflow continues

--- a/packages/web/src/components/chat/ChatInterface.tsx
+++ b/packages/web/src/components/chat/ChatInterface.tsx
@@ -489,7 +489,10 @@ export function ChatInterface({ conversationId }: ChatInterfaceProps): React.Rea
     if (
       status &&
       status !== prevStatus &&
-      (status === 'completed' || status === 'failed' || status === 'cancelled')
+      (status === 'completed' ||
+        status === 'failed' ||
+        status === 'cancelled' ||
+        status === 'paused')
     ) {
       onLockChange(false);
     }

--- a/packages/web/src/components/chat/WorkflowProgressCard.tsx
+++ b/packages/web/src/components/chat/WorkflowProgressCard.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { CheckCircle, ChevronRight, Loader2, Pause, XCircle } from 'lucide-react';
+import { CheckCircle, ChevronRight, Loader2, Pause, Send, XCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { approveWorkflowRun, getWorkflowRunByWorker, rejectWorkflowRun } from '@/lib/api';
 import { useWorkflowStore } from '@/stores/workflow-store';
@@ -83,9 +83,17 @@ export function WorkflowProgressCard({
     };
   }, [isRunning, startedAt]);
 
+  // Interactive loop response input
+  const [approvalComment, setApprovalComment] = useState('');
+  const isInteractiveLoop = approval?.type === 'interactive_loop';
+
   // Approve/reject mutations
   const approveMutation = useMutation({
-    mutationFn: () => approveWorkflowRun(runId ?? ''),
+    mutationFn: (comment?: string) => approveWorkflowRun(runId ?? '', comment),
+    onSuccess: () => {
+      setApprovalComment('');
+      refetch();
+    },
   });
   const rejectMutation = useMutation({
     mutationFn: (reason?: string) => rejectWorkflowRun(runId ?? '', reason),
@@ -210,45 +218,102 @@ export function WorkflowProgressCard({
                   {approval?.message ?? 'Waiting for approval'}
                 </p>
               </div>
-              <div className="flex items-center gap-2">
-                <button
-                  onClick={() => {
-                    approveMutation.mutate();
-                  }}
-                  disabled={!runId || approveMutation.isPending || rejectMutation.isPending}
-                  className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-success/80 hover:bg-success/10 hover:text-success transition-colors disabled:opacity-50"
-                >
-                  <CheckCircle className="h-3.5 w-3.5" />
-                  Approve
-                </button>
-                <ConfirmRunActionDialog
-                  trigger={
-                    <button
-                      disabled={!runId || approveMutation.isPending || rejectMutation.isPending}
-                      className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-error/80 hover:bg-error/10 hover:text-error transition-colors disabled:opacity-50"
-                    >
-                      <XCircle className="h-3.5 w-3.5" />
-                      Reject
-                    </button>
-                  }
-                  title="Reject workflow?"
-                  description={
-                    <>
-                      Reject the paused workflow <strong>{workflowName}</strong>. If the approval
-                      node defines an <code>on_reject</code> prompt, it runs with your reason as{' '}
-                      <code>$REJECTION_REASON</code>; otherwise the run is cancelled.
-                    </>
-                  }
-                  confirmLabel="Reject"
-                  reasonInput={{
-                    label: 'Reason (optional)',
-                    placeholder: 'Why are you rejecting? Visible to the on_reject prompt.',
-                  }}
-                  onConfirm={(reason): void => {
-                    rejectMutation.mutate(reason);
-                  }}
-                />
-              </div>
+              {isInteractiveLoop ? (
+                /* Interactive loop: text input + send button for user response */
+                <div className="flex items-center gap-1.5">
+                  <input
+                    type="text"
+                    value={approvalComment}
+                    onChange={e => {
+                      setApprovalComment(e.target.value);
+                    }}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter' && approvalComment.trim()) {
+                        approveMutation.mutate(approvalComment.trim());
+                      }
+                    }}
+                    placeholder="Type your response..."
+                    disabled={approveMutation.isPending}
+                    className="flex-1 rounded-md border border-border bg-surface-elevated px-2 py-1 text-xs text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50"
+                  />
+                  <button
+                    onClick={() => {
+                      approveMutation.mutate(approvalComment.trim() || undefined);
+                    }}
+                    disabled={!runId || approveMutation.isPending}
+                    className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-primary hover:bg-primary/10 transition-colors disabled:opacity-50"
+                  >
+                    <Send className="h-3.5 w-3.5" />
+                  </button>
+                  <ConfirmRunActionDialog
+                    trigger={
+                      <button
+                        disabled={!runId || rejectMutation.isPending}
+                        className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-error/80 hover:bg-error/10 hover:text-error transition-colors disabled:opacity-50"
+                      >
+                        <XCircle className="h-3.5 w-3.5" />
+                      </button>
+                    }
+                    title="Reject workflow?"
+                    description={
+                      <>
+                        Reject the paused workflow <strong>{workflowName}</strong>. If the approval
+                        node defines an <code>on_reject</code> prompt, it runs with your reason as{' '}
+                        <code>$REJECTION_REASON</code>; otherwise the run is cancelled.
+                      </>
+                    }
+                    confirmLabel="Reject"
+                    reasonInput={{
+                      label: 'Reason (optional)',
+                      placeholder: 'Why are you rejecting? Visible to the on_reject prompt.',
+                    }}
+                    onConfirm={(reason): void => {
+                      rejectMutation.mutate(reason);
+                    }}
+                  />
+                </div>
+              ) : (
+                /* Standard approval gate: approve/reject buttons */
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => {
+                      approveMutation.mutate(undefined);
+                    }}
+                    disabled={!runId || approveMutation.isPending || rejectMutation.isPending}
+                    className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-success/80 hover:bg-success/10 hover:text-success transition-colors disabled:opacity-50"
+                  >
+                    <CheckCircle className="h-3.5 w-3.5" />
+                    Approve
+                  </button>
+                  <ConfirmRunActionDialog
+                    trigger={
+                      <button
+                        disabled={!runId || approveMutation.isPending || rejectMutation.isPending}
+                        className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-error/80 hover:bg-error/10 hover:text-error transition-colors disabled:opacity-50"
+                      >
+                        <XCircle className="h-3.5 w-3.5" />
+                        Reject
+                      </button>
+                    }
+                    title="Reject workflow?"
+                    description={
+                      <>
+                        Reject the paused workflow <strong>{workflowName}</strong>. If the approval
+                        node defines an <code>on_reject</code> prompt, it runs with your reason as{' '}
+                        <code>$REJECTION_REASON</code>; otherwise the run is cancelled.
+                      </>
+                    }
+                    confirmLabel="Reject"
+                    reasonInput={{
+                      label: 'Reason (optional)',
+                      placeholder: 'Why are you rejecting? Visible to the on_reject prompt.',
+                    }}
+                    onConfirm={(reason): void => {
+                      rejectMutation.mutate(reason);
+                    }}
+                  />
+                </div>
+              )}
               {(approveMutation.isError || rejectMutation.isError) && (
                 <p className="text-xs text-error">
                   {mutationError instanceof Error

--- a/packages/web/src/components/workflows/WorkflowExecution.tsx
+++ b/packages/web/src/components/workflows/WorkflowExecution.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router';
-import { MessageSquare } from 'lucide-react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { CheckCircle, MessageSquare, Pause, Send, XCircle } from 'lucide-react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { DagNodeProgress } from './DagNodeProgress';
 import { StepLogs } from './StepLogs';
@@ -12,7 +12,14 @@ import { ChatInterface } from '@/components/chat/ChatInterface';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
 import { useWorkflowStore } from '@/stores/workflow-store';
-import { getWorkflowRun, getWorkflowRunByWorker, getCodebase, getWorkflow } from '@/lib/api';
+import {
+  getWorkflowRun,
+  getWorkflowRunByWorker,
+  getCodebase,
+  getWorkflow,
+  approveWorkflowRun,
+  rejectWorkflowRun,
+} from '@/lib/api';
 import { ensureUtc, formatDurationMs } from '@/lib/format';
 import { selectInitialNode } from '@/lib/select-initial-node';
 import type {
@@ -504,6 +511,43 @@ export function WorkflowExecution({ runId }: WorkflowExecutionProps): React.Reac
   const elapsed = startedAt ? Math.max(0, completedAt - startedAt) : 0;
 
   const isRunning = workflow.status === 'running' || workflow.status === 'pending';
+  const isPaused = workflow.status === 'paused';
+
+  // Approval context — prefer SSE live state, fall back to REST run metadata
+  const restApproval = useMemo((): { nodeId: string; message: string; type?: string } | null => {
+    if (!isPaused || !queryData) return null;
+    const events = queryData.events ?? [];
+    const approvalEvent = [...events].reverse().find(e => e.event_type === 'approval_requested');
+    if (!approvalEvent) return null;
+    // The approval type is not in the event — infer from loop_iteration events on the same node
+    const hasLoopEvents = events.some(
+      e => e.event_type === 'loop_iteration_started' && e.step_name === approvalEvent.step_name
+    );
+    return {
+      nodeId: approvalEvent.step_name ?? '',
+      message: (approvalEvent.data.message as string) ?? 'Waiting for approval',
+      type: hasLoopEvents ? 'interactive_loop' : 'approval',
+    };
+  }, [isPaused, queryData]);
+
+  const effectiveApproval = liveWorkflow?.approval ?? restApproval;
+  const isInteractiveLoop = effectiveApproval?.type === 'interactive_loop';
+
+  // Approval input and mutations
+  const [approvalComment, setApprovalComment] = useState('');
+  const approveMutation = useMutation({
+    mutationFn: (comment?: string) => approveWorkflowRun(runId, comment),
+    onSuccess: () => {
+      setApprovalComment('');
+      void queryClient.invalidateQueries({ queryKey: ['workflowRun', runId] });
+    },
+  });
+  const rejectMutation = useMutation({
+    mutationFn: () => rejectWorkflowRun(runId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['workflowRun', runId] });
+    },
+  });
 
   // Pick the platform ID for logs: worker takes precedence over conversation.
   const logsPlatformId = workerPlatformId ?? conversationPlatformId;
@@ -646,6 +690,91 @@ export function WorkflowExecution({ runId }: WorkflowExecutionProps): React.Reac
               )}
             </TabsList>
           </Tabs>
+        </div>
+      )}
+
+      {/* Approval banner — shown when workflow is paused */}
+      {isPaused && effectiveApproval && (
+        <div className="border-b border-border bg-warning/5 px-4 py-3 space-y-2">
+          <div className="flex items-start gap-2">
+            <Pause className="h-4 w-4 text-warning shrink-0 mt-0.5" />
+            <p className="text-sm text-text-secondary">{effectiveApproval.message}</p>
+          </div>
+          {isInteractiveLoop ? (
+            <div className="flex items-center gap-2 ml-6">
+              <input
+                type="text"
+                value={approvalComment}
+                onChange={(e): void => {
+                  setApprovalComment(e.target.value);
+                }}
+                onKeyDown={(e): void => {
+                  if (e.key === 'Enter' && approvalComment.trim()) {
+                    approveMutation.mutate(approvalComment.trim());
+                  }
+                }}
+                placeholder="Type your response..."
+                disabled={approveMutation.isPending}
+                className="flex-1 rounded-md border border-border bg-surface px-3 py-1.5 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50"
+              />
+              <button
+                onClick={(): void => {
+                  approveMutation.mutate(approvalComment.trim() || undefined);
+                }}
+                disabled={approveMutation.isPending}
+                className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-accent-hover transition-colors disabled:opacity-50"
+              >
+                <Send className="h-3.5 w-3.5" />
+                Send
+              </button>
+              <button
+                onClick={(): void => {
+                  if (window.confirm(`Reject workflow "${workflow.workflowName}"?`)) {
+                    rejectMutation.mutate();
+                  }
+                }}
+                disabled={rejectMutation.isPending}
+                className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm text-error/80 hover:bg-error/10 hover:text-error transition-colors disabled:opacity-50"
+              >
+                <XCircle className="h-3.5 w-3.5" />
+                Reject
+              </button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2 ml-6">
+              <button
+                onClick={(): void => {
+                  approveMutation.mutate(undefined);
+                }}
+                disabled={approveMutation.isPending || rejectMutation.isPending}
+                className="flex items-center gap-1.5 rounded-md bg-success/20 px-3 py-1.5 text-sm text-success hover:bg-success/30 transition-colors disabled:opacity-50"
+              >
+                <CheckCircle className="h-3.5 w-3.5" />
+                Approve
+              </button>
+              <button
+                onClick={(): void => {
+                  if (window.confirm(`Reject workflow "${workflow.workflowName}"?`)) {
+                    rejectMutation.mutate();
+                  }
+                }}
+                disabled={approveMutation.isPending || rejectMutation.isPending}
+                className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm text-error/80 hover:bg-error/10 hover:text-error transition-colors disabled:opacity-50"
+              >
+                <XCircle className="h-3.5 w-3.5" />
+                Reject
+              </button>
+            </div>
+          )}
+          {(approveMutation.isError || rejectMutation.isError) && (
+            <p className="text-sm text-error ml-6">
+              {approveMutation.error instanceof Error
+                ? approveMutation.error.message
+                : rejectMutation.error instanceof Error
+                  ? rejectMutation.error.message
+                  : 'Action failed — please try again'}
+            </p>
+          )}
         </div>
       )}
 

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -86,7 +86,7 @@ export interface WorkflowStatusEvent extends BaseSSEEvent {
   workflowName: string;
   status: ActiveWorkflowRunStatus;
   error?: string;
-  approval?: { nodeId: string; message: string };
+  approval?: { nodeId: string; message: string; type?: 'interactive_loop' | 'approval' };
 }
 
 // Loop iteration info (per-iteration state stored in DagNodeState)
@@ -271,7 +271,7 @@ export interface WorkflowState {
   completedAt?: number;
   error?: string;
   stale?: boolean;
-  approval?: { nodeId: string; message: string };
+  approval?: { nodeId: string; message: string; type?: 'interactive_loop' | 'approval' };
   currentTool?: {
     name: string;
     status: 'running' | 'completed';

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -2265,6 +2265,7 @@ async function executeLoopNode(
         runId: workflowRun.id,
         nodeId: node.id,
         message: loop.gate_message,
+        approvalType: 'interactive_loop',
       });
       // Return completed — the between-layer status check sees 'paused' and halts cleanly.
       // This mirrors the approval-node pattern, preventing false "DAG nodes failed" warnings
@@ -2467,6 +2468,7 @@ async function executeApprovalNode(
     runId: workflowRun.id,
     nodeId: node.id,
     message: renderedMessage,
+    approvalType: 'approval',
   });
 
   // Return completed — the between-layer status check will see 'paused' and break.

--- a/packages/workflows/src/event-emitter.ts
+++ b/packages/workflows/src/event-emitter.ts
@@ -133,6 +133,7 @@ interface ApprovalPendingEvent {
   runId: string;
   nodeId: string;
   message: string;
+  approvalType?: 'interactive_loop' | 'approval';
 }
 
 interface WorkflowCancelledEvent {


### PR DESCRIPTION
## Summary
- **Fix**: Interactive loop approve button now actually resumes the workflow instead of leaving it dead in `failed` status. The REST approve endpoint delegates to the orchestrator's natural-language approval handler which handles events, status transition, and resume atomically.
- **Fix**: Chat input no longer stays locked when a workflow pauses — `paused` status now triggers the safety-net lock release.
- **Feature**: Added approval banner with text input to the workflow detail/graph page, so users can respond to interactive loop gates without switching to the Chat view.
- **Plumbing**: Propagated approval type (`interactive_loop` vs `approval`) through SSE events so the frontend renders the appropriate UI (text input for loops, buttons for standard gates).

## Test plan
- [ ] Run a workflow with an interactive loop (e.g. `archon-piv-loop`) from the web UI
- [ ] Verify the approval banner appears on the workflow detail page when paused
- [ ] Submit a response via the text input — workflow should resume
- [ ] Verify the chat input is not locked when a workflow is paused
- [ ] Standard approval gates still show Approve/Reject buttons (not text input)
- [ ] Reject button still cancels the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive approval loops: submit free-text comments when a workflow is paused; sending a comment immediately registers the response while processing continues in the background.
  * Paused workflows show a prominent banner with appropriate controls (interactive reply input + Send + Reject, or Approve + Reject).

* **Improvements**
  * Approval notifications now indicate approval type (interactive vs standard).

* **Bug Fixes**
  * Paused status now reliably releases locks and finalizes streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->