### PR TITLE
fix(workflow): substitute $nodeId.output refs in approval messages

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -4787,6 +4787,86 @@ describe('executeDagWorkflow -- approval node', () => {
       1
     );
   });
+
+  it('approval message substitutes $nodeId.output.field references from upstream structured output', async () => {
+    // Repro for: approval gates were rendering literal "$gather-context.output.repo_name"
+    // instead of resolved values, breaking interactive workflows like atlas-onboard.
+    // Parity: prompt/bash/loop/cancel nodes already get substituteNodeOutputRefs;
+    // approval.message must too so the human sees concrete values.
+    const structuredJson = {
+      repo_name: 'hcr-els',
+      app_code: 'CCELS',
+      frontend_port: 3012,
+    };
+
+    const commandsDir = join(testDir, '.archon', 'commands');
+    await mkdir(commandsDir, { recursive: true });
+    await writeFile(join(commandsDir, 'gather-context.md'), 'Gather context: $USER_MESSAGE');
+
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: JSON.stringify(structuredJson) };
+      yield { type: 'result', sessionId: 'sid-approval-sub', structuredOutput: structuredJson };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('approval-sub-run');
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-approval-sub',
+      testDir,
+      {
+        name: 'approval-sub-test',
+        nodes: [
+          {
+            id: 'gather-context',
+            command: 'gather-context',
+            output_format: {
+              type: 'object',
+              properties: {
+                repo_name: { type: 'string' },
+                app_code: { type: 'string' },
+                frontend_port: { type: 'number' },
+              },
+            },
+          },
+          {
+            id: 'confirm',
+            depends_on: ['gather-context'],
+            approval: {
+              message:
+                'Repo: $gather-context.output.repo_name | App: $gather-context.output.app_code | Port: $gather-context.output.frontend_port',
+            },
+          },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    // gather-context AI call ran once; approval node does NOT call AI
+    expect(mockSendQueryDag.mock.calls.length).toBe(1);
+
+    // pauseWorkflowRun should receive the SUBSTITUTED message, not the literal placeholders
+    const pauseCalls = (
+      store.pauseWorkflowRun as Mock<(id: string, ctx: Record<string, unknown>) => Promise<void>>
+    ).mock.calls;
+    expect(pauseCalls.length).toBe(1);
+    expect(pauseCalls[0][1]).toMatchObject({
+      type: 'approval',
+      nodeId: 'confirm',
+      message: 'Repo: hcr-els | App: CCELS | Port: 3012',
+    });
+  });
 });
 describe('executeDagWorkflow -- env var injection', () => {
   let testDir: string;

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -4866,6 +4866,32 @@ describe('executeDagWorkflow -- approval node', () => {
       nodeId: 'confirm',
       message: 'Repo: hcr-els | App: CCELS | Port: 3012',
     });
+
+    // The fix touches FOUR emission sites (safeSendMessage / createWorkflowEvent /
+    // pauseWorkflowRun / event-emitter). Assert the other two reachable surfaces too —
+    // a future regression at any one of them would otherwise pass this test silently.
+    // (Per CodeRabbit review of PR coleam00/Archon#1426.)
+
+    // (a) The chat-surface prompt emitted via platform.sendMessage must contain the
+    //     substituted message and must NOT contain literal $gather-context.output refs.
+    const sentMessages = (
+      platform.sendMessage as Mock<(...args: unknown[]) => Promise<void>>
+    ).mock.calls.map((c: unknown[]) => c[1] as string);
+    expect(sentMessages.some(m => m.includes('Repo: hcr-els | App: CCELS | Port: 3012'))).toBe(
+      true
+    );
+    expect(sentMessages.some(m => m.includes('$gather-context.output'))).toBe(false);
+
+    // (b) The persisted approval_requested workflow event's data.message must be substituted.
+    const approvalRequestedEvents = (
+      store.createWorkflowEvent as Mock<() => Promise<void>>
+    ).mock.calls.filter(
+      (c: unknown[]) => (c[0] as { event_type: string }).event_type === 'approval_requested'
+    );
+    expect(approvalRequestedEvents.length).toBe(1);
+    expect((approvalRequestedEvents[0][0] as { data: { message: string } }).data.message).toBe(
+      'Repo: hcr-els | App: CCELS | Port: 3012'
+    );
   });
 });
 describe('executeDagWorkflow -- env var injection', () => {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -2294,9 +2294,12 @@ async function executeApprovalNode(
     // Fall through to re-pause at the approval gate
   }
 
-  // Standard approval gate — send message and pause
+  // Standard approval gate — send message and pause.
+  // Resolve $nodeId.output[.field] references so the human sees concrete values
+  // (parity with prompt/bash/loop/cancel nodes, which all run the same substitution).
+  const renderedMessage = substituteNodeOutputRefs(node.approval.message, nodeOutputs);
   const approvalMsg =
-    `⏸ **Approval required**: ${node.approval.message}\n\n` +
+    `⏸ **Approval required**: ${renderedMessage}\n\n` +
     `Run ID: \`${workflowRun.id}\`\n` +
     `Approve: \`/workflow approve ${workflowRun.id}\` | Reject: \`/workflow reject ${workflowRun.id}\``;
   await safeSendMessage(platform, conversationId, approvalMsg, msgContext);
@@ -2306,7 +2309,7 @@ async function executeApprovalNode(
       workflow_run_id: workflowRun.id,
       event_type: 'approval_requested',
       step_name: node.id,
-      data: { message: node.approval.message },
+      data: { message: renderedMessage },
     })
     .catch((err: Error) => {
       getLog().error(
@@ -2316,7 +2319,7 @@ async function executeApprovalNode(
     });
 
   await deps.store.pauseWorkflowRun(workflowRun.id, {
-    message: node.approval.message,
+    message: renderedMessage,
     nodeId: node.id,
     type: 'approval',
     captureResponse: node.approval.capture_response,
@@ -2328,7 +2331,7 @@ async function executeApprovalNode(
     type: 'approval_pending',
     runId: workflowRun.id,
     nodeId: node.id,
-    message: node.approval.message,
+    message: renderedMessage,
   });
 
   // Return completed — the between-layer status check will see 'paused' and break.


### PR DESCRIPTION
Closes #1390 (independently reported by @Wirasm Apr 24 with the same root-cause diagnosis at the same file:line — this PR is the implementation).

---

## Bug

Approval node messages are emitted as raw strings, bypassing the `substituteNodeOutputRefs()` pass that prompt/bash/loop/cancel nodes all run. This makes interactive workflows that reference upstream node outputs in their approval messages display literal placeholders to humans at HITL gates.

### Repro

Any workflow with an approval node whose `message:` references `$nodeId.output[.field]`. Observed in the wild on `atlas-onboard.yaml`'s `confirm-context` HITL gate, which expected to show the resolved repo / app / port / etc. but instead showed:

```
Repo:          $gather-context.output.repo_org/$gather-context.output.repo_name
Template:      $gather-context.output.repo_template
App:           $gather-context.output.app_name ($gather-context.output.app_code)
Ports:         $gather-context.output.frontend_port / $gather-context.output.backend_port
```

The upstream `gather-context` node had emitted correct StructuredOutput (visible in the run's `.jsonl` log):

```json
{"app_name":"Emergency Leak Service","app_code":"CCELS","repo_org":"atlas-intelligence-io","repo_name":"hcr-els","frontend_port":3012,"backend_port":8010, ...}
```

The substitution just never ran on the approval message.

## Root Cause

`packages/workflows/src/dag-executor.ts` `executeApprovalNode()` emits `node.approval.message` raw at four sites (lines 2299, 2309, 2319, 2331):

- `safeSendMessage` (chat surface)
- `createWorkflowEvent` (audit trail)
- `pauseWorkflowRun` (DB persistence — surfaces in web UI approval card)
- `getWorkflowEventEmitter().emit({type: 'approval_pending', ...})` (event bus consumers)

`substituteNodeOutputRefs()` is exported from the same file and used everywhere else (prompt @665, bash @1261/1415/1999, loop @1779, synthetic prompt @2255, cancel @2655) — approval was the only node type missing the substitution pass.

## Fix

Compute the substituted message once at the top of the standard approval gate path, then use the resolved string in all 4 emission sites. `nodeOutputs` is already in scope at `executeApprovalNode`'s parameter list (L2187).

```ts
const renderedMessage = substituteNodeOutputRefs(node.approval.message, nodeOutputs);
```

8 insertions, 5 deletions in `dag-executor.ts`.

## Test

New test in `dag-executor.test.ts` — `executeDagWorkflow -- approval node` describe block — wires a structured-output upstream node into an approval node and asserts `pauseWorkflowRun` receives the substituted message (`"Repo: hcr-els | App: CCELS | Port: 3012"`) rather than the literal placeholders.

All 193 existing dag-executor tests still pass.

## After this lands

Same workflow on patched build now renders cleanly:

```
Repo:          atlas-intelligence-io/hcr-els
Template:      atlas-intelligence-io/fleet-spoke-template
App:           Emergency Leak Service (CCELS)
Ports:         3012 / 8010
Domain:        hcr-els.atlas-intelligence.cloud
```

Adam can approve a gate showing real values instead of placeholders.

## Test plan

- [x] New test `approval message substitutes \$nodeId.output.field references from upstream structured output` passes
- [x] All 7 existing approval-node tests still pass
- [x] All 193 dag-executor.test.ts tests pass
- [x] Smoke test on real workflow (atlas-onboard.yaml, confirm-context gate) shows resolved values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Approval gate messages now substitute upstream node output references (e.g., `$node.output.field`) with resolved values across prompts, persisted events, and pause messages.

* **Tests**
  * Added regression test to verify message substitution is applied and propagated to the platform chat, persisted event data, and pause workflow context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
