### PR TITLE
fix(maintainer-review): address CodeRabbit findings on #1430 (date anchor, gate clarity, error surfacing)

### DIFF
--- a/.archon/commands/maintainer-review-gate.md
+++ b/.archon/commands/maintainer-review-gate.md
@@ -13,7 +13,7 @@ You are the **gatekeeper** for a single GitHub PR. Your job is to decide whether
 
 ## Phase 1: LOAD INPUTS
 
-Three sources of upstream context, all already gathered. Each is provided inline below — no extra tool calls needed to fetch them.
+Three sources of upstream context, all gathered for you below. **You may also `cat .github/PULL_REQUEST_TEMPLATE.md` if you need to compare the PR body's structure against the project's template** — that's the one allowed extra read; everything else lives in the inputs below.
 
 ### PR data (gh pr view JSON)
 
@@ -23,11 +23,11 @@ $fetch-pr.output
 
 ### PR diff (truncated to 2500 lines)
 
-```
+```text
 $fetch-diff.output
 ```
 
-### Maintainer context (direction.md, profile.md, prior state, recent briefs)
+### Maintainer context (direction.md, profile.md, prior state, recent briefs, clock)
 
 ```json
 $read-context.output
@@ -38,6 +38,8 @@ Inside `read-context.output`:
 - `profile` — the running maintainer's profile.md (role, scope, current focus)
 - `prior_state` — last morning-standup state.json (carry_over may already mention this PR)
 - `recent_briefs` — last 3 daily briefs (look here if this PR was previously flagged)
+- `today` — today's local date as `YYYY-MM-DD` (deterministic, set by the gather script)
+- `deadline_3d` — today + 3 calendar days, `YYYY-MM-DD` (precomputed for the decline comment's reply window)
 
 ---
 
@@ -74,7 +76,7 @@ Was `.github/PULL_REQUEST_TEMPLATE.md` filled in?
 - **partial**: Template structure present but several sections empty or perfunctory ("N/A", "TBD", or single-word answers where prose is expected).
 - **empty**: No template, or template skeleton with all sections blank.
 
-The PR body is in `pr_data.body`. The template lives at `.github/PULL_REQUEST_TEMPLATE.md` — read it if needed to compare structure.
+The PR body is in `pr_data.body`. If you need the template's expected structure for comparison, that's the one allowed extra read: `cat .github/PULL_REQUEST_TEMPLATE.md`.
 
 ---
 
@@ -152,7 +154,9 @@ Adapt the wording. Don't paste the templates verbatim if the situation is more n
 
 ### Compute DATE-3-DAYS-OUT
 
-Today is the date in `read-context.output.prior_state.last_run_at` if available, otherwise today's actual date. Add 3 calendar days. Format as `YYYY-MM-DD` (e.g. `2026-04-30`).
+Use `read-context.output.deadline_3d` directly — it's already today-plus-three-calendar-days in `YYYY-MM-DD` form, computed deterministically by the gather script (sv-SE locale → ISO date in local time). Do **not** anchor to `prior_state.last_run_at`; that field can be days or weeks stale and would produce a deadline already in the past.
+
+If for any reason `deadline_3d` is missing or empty, abort the comment draft and surface this to the maintainer in the gate-decision artifact rather than guessing.
 
 ---
 
@@ -211,12 +215,12 @@ If verdict is `decline` or `needs_split`, write the drafted comment in markdown 
 Allowed output shapes (Pi's parser handles either):
 
 1. **Bare JSON** — preferred:
-   ```
+   ```json
    {"verdict":"review","direction_alignment":"aligned",...}
    ```
 
 2. **Fenced JSON** — also fine:
-   ````
+   ````markdown
    ```json
    {"verdict":"review","direction_alignment":"aligned",...}
    ```

--- a/.archon/commands/maintainer-review-report.md
+++ b/.archon/commands/maintainer-review-report.md
@@ -57,7 +57,7 @@ Write `$ARTIFACTS_DIR/final-report.md`:
 - Cited direction clauses: <list>
 - Comment posted to PR: yes
 - Reply window: <YYYY-MM-DD>
-- Awaiting-author label added: yes/no
+- Awaiting-author label added: read `$ARTIFACTS_DIR/.label-applied` — value is `applied` or `skipped`. If `skipped`, surface why by reading `$ARTIFACTS_DIR/.label-error` (gh stderr) and include a one-line explanation. **Do not say `yes` if the file says `skipped`** — say `no, label add failed: <reason>` so the maintainer can decide whether to add it manually.
 
 ### If unclear branch:
 - Gate could not classify confidently.

--- a/.archon/scripts/maintainer-standup-read-context.ts
+++ b/.archon/scripts/maintainer-standup-read-context.ts
@@ -45,11 +45,23 @@ if (existsSync(briefsDir)) {
   }
 }
 
+// Deterministic clock — emit today's local date + a precomputed 3-day-out
+// deadline so downstream prompts don't have to do calendar arithmetic
+// (LLMs are unreliable at it) and don't anchor to stale prior_state.last_run_at
+// (which can produce past deadlines on long gaps between runs).
+const todayDate = new Date();
+const today = todayDate.toLocaleDateString('sv-SE'); // YYYY-MM-DD local
+const deadlineDate = new Date(todayDate);
+deadlineDate.setDate(deadlineDate.getDate() + 3);
+const deadline_3d = deadlineDate.toLocaleDateString('sv-SE');
+
 console.log(
   JSON.stringify({
     direction,
     profile,
     prior_state: priorState,
     recent_briefs: recentBriefs,
+    today,
+    deadline_3d,
   }),
 );

--- a/.archon/workflows/maintainer/maintainer-review-pr.yaml
+++ b/.archon/workflows/maintainer/maintainer-review-pr.yaml
@@ -65,8 +65,19 @@ nodes:
   - id: fetch-diff
     bash: |
       PR_NUM=$(cat "$ARTIFACTS_DIR/.pr-number")
+      # Don't redirect stderr — let auth / network / deleted-PR failures surface
+      # as a node failure rather than feeding an empty diff to the gate (which
+      # would produce a confident verdict on no evidence).
+      if ! diff_output=$(gh pr diff "$PR_NUM"); then
+        echo "ERROR: gh pr diff failed for PR #$PR_NUM" >&2
+        exit 1
+      fi
       # Cap at 2500 lines to keep prompt size bounded; gate cares about shape, not every line.
-      gh pr diff "$PR_NUM" 2>/dev/null | head -2500
+      if [ -z "$diff_output" ]; then
+        echo "(empty diff — PR has no changes)"
+      else
+        echo "$diff_output" | head -2500
+      fi
     depends_on: [fetch-pr]
     timeout: 30000
 
@@ -274,8 +285,19 @@ nodes:
         exit 1
       fi
       gh pr comment "$PR_NUM" --body-file "$ARTIFACTS_DIR/decline-comment.md"
-      # Optional: tag the PR so the morning brief can surface "awaiting author"
-      gh pr edit "$PR_NUM" --add-label awaiting-author 2>/dev/null || true
+
+      # Tag the PR so the morning brief can surface "awaiting author".
+      # Failure (label not present in repo, permissions, etc.) is non-fatal,
+      # but record the actual outcome so the report node doesn't claim the
+      # label was applied when it wasn't.
+      if gh pr edit "$PR_NUM" --add-label awaiting-author 2>"$ARTIFACTS_DIR/.label-error"; then
+        echo "applied" > "$ARTIFACTS_DIR/.label-applied"
+        rm -f "$ARTIFACTS_DIR/.label-error"
+      else
+        echo "skipped" > "$ARTIFACTS_DIR/.label-applied"
+        echo "WARN: gh pr edit --add-label failed; see $ARTIFACTS_DIR/.label-error" >&2
+      fi
+
       echo "Posted decline comment to PR #$PR_NUM"
     depends_on: [approve-decline]
     timeout: 30000
@@ -290,8 +312,12 @@ nodes:
         Gate could not classify this PR confidently. Read the raw gate output
         and any artifacts in $ARTIFACTS_DIR/, then decide manually.
 
-        Approve = workflow ends here (no comment posted, no review run).
-        Reject = same outcome but log your reasoning in the run record.
+        Approve (with optional comment) = workflow ends here (no comment posted,
+        no review run). Your comment is captured as $approve-unclear.output and
+        the report node will include it.
+        Reject (with reason) = workflow is cancelled; reasoning is recorded in
+        the run.
+      capture_response: true
     depends_on: [gate]
     when: "$gate.output.verdict == 'unclear'"
 


### PR DESCRIPTION
## Summary

- **Problem**: CodeRabbit posted 5 actionable findings (2 major, 3 minor) + 1 nitpick on #1430 after merge. Two are real bugs (conflicting prompt instructions, stale-date-anchor risk).
- **Why it matters**: The stale-date-anchor in particular could post a decline comment with a deadline already in the past — bad UX for the contributor.
- **What changed**: Six surgical fixes across the gate command, the read-context script, the workflow YAML, and the report command. Total diff: 4 files, +55/-13.
- **What did NOT change (scope boundary)**: No engine code touched. No new workflows, no new commands. Pure fixups to the maintainer-review-pr workflow shipped in #1430.

## Findings addressed (mapped 1:1 to CodeRabbit)

| # | CodeRabbit severity | File | Fix |
|---|---------------------|------|-----|
| 1 | 🟠 Major | `gate.md` L17 vs L77 — conflicting "all inline" vs "read template if needed" instructions | Phase 1 now declares one allowed extra read (`cat .github/PULL_REQUEST_TEMPLATE.md`); Gate C wording matches |
| 2 | 🟡 Minor | `gate.md` fences missing language identifiers (MD040) | Added `text`, `json`, `markdown` on lines 26 / 214 / 219 |
| 3 | 🟠 Major | `gate.md` L155 — 3-day deadline anchored to stale `prior_state.last_run_at` | Moved `today` + `deadline_3d` into `read-context.ts` (computed deterministically via `sv-SE` locale); gate now uses `$read-context.output.deadline_3d` directly |
| 4 | 🟡 Minor | `maintainer-review-pr.yaml` `fetch-diff` — `gh pr diff 2>/dev/null` swallows failures, feeds empty diff to gate | Dropped `2>/dev/null`; check exit; emit explicit `(empty diff — PR has no changes)` marker only when gh succeeded with empty output |
| 5 | 🟡 Minor | `maintainer-review-pr.yaml` `approve-unclear` missing `capture_response: true` | Added `capture_response: true` + clarified message about reject vs approve outcomes |
| 6 | 🪧 Nitpick | `post-decline` swallows label-add failures with `\|\| true`; report claims label applied regardless | Capture `applied`/`skipped` to `$ARTIFACTS_DIR/.label-applied`; capture gh stderr to `.label-error`; report reads both and reports the actual outcome |

## Validation Evidence (required)

```bash
archon validate workflows maintainer-review-pr     # → ok
archon validate workflows maintainer-standup       # → ok (read-context script change is backward-compatible)
bun run lint                                       # → clean
bun run format:check                               # → "All matched files use Prettier code style!"

# Smoke-tested the new read-context fields:
bun --no-env-file run .archon/scripts/maintainer-standup-read-context.ts | jq '{today, deadline_3d}'
# → { "today": "2026-04-27", "deadline_3d": "2026-04-30" }
```

- **Skipped commands and why**: `bun run test` skipped — pure `.archon/` user-content + tiny TS script change. No engine code modified, no test coverage at risk.

## Security Impact (required)

- **New permissions/capabilities?** No.
- **New external network calls?** No (the post-decline node already called `gh pr edit`; this PR only changes how the result is captured).
- **Secrets/tokens handling changed?** No.
- **File system access scope changed?** Marginal — `post-decline` now writes `.label-applied` and (on failure) `.label-error` under `$ARTIFACTS_DIR/`. Both are run-scoped, no access outside the existing artifacts dir.

## Compatibility / Migration

- **Backward compatible?** Yes. The read-context script gains two new fields (`today`, `deadline_3d`); existing consumers (the maintainer-standup synthesizer) ignore them. Workflow names and IDs unchanged.
- **Config/env changes?** No.
- **Database migration?** No.

## Human Verification (required)

- **Verified scenarios**:
  - Both workflows validate from their subfolder paths.
  - `read-context.ts` smoke-tested directly — emits today=`2026-04-27` and deadline_3d=`2026-04-30`, matching today + 3 calendar days.
  - Gate command file edits are localized and don't change the JSON output_format schema, so existing run artifacts and downstream condition expressions remain compatible.
- **Edge cases checked**:
  - `today`/`deadline_3d` use sv-SE locale → ISO date in local time, so a maintainer running at 23:50 local doesn't get tomorrow's UTC date as the deadline anchor.
  - `fetch-diff` empty-but-successful path now produces an explicit marker the gate can read; failure path now exits the node so the gate doesn't run on no evidence.
  - `post-decline` label-applied/skipped paths both leave the workflow in a consistent state (decline comment posted regardless; only the label tagging is best-effort).
- **What was not verified**:
  - Live end-to-end re-run on a real PR — these are surgical fixes verified via static checks; the fix risk is low enough that I haven't burned compute on another full workflow run. Happy to do one if reviewers want it.

## Side Effects / Blast Radius (required)

- **Affected subsystems/workflows**: `maintainer-review-pr` (target of all changes); `maintainer-standup` (read-context script change is additive and ignored by the standup synthesizer).
- **Potential unintended effects**: if any external script reads `read-context.output` and is strict about field shape (rejects unknown keys), the new fields could trip it. No such consumers exist in this repo.
- **Guardrails / monitoring**: workflow validation runs in CI; the read-context smoke is captured in this PR's evidence.

## Rollback Plan (required)

- **Fast rollback**: `git revert <merge-sha>` — single commit, all surgical edits. No deletions, no renames, fully reversible.
- **Feature flags**: none — opt-in by workflow invocation.
- **Observable failure symptoms**: workflow validation failure (CI catches); runtime issues surface in workflow logs as before.

## Risks and Mitigations

- **Risk**: `read-context.ts` change is shared with the maintainer-standup workflow; if I broke its JSON shape, the morning brief would fail.
  - **Mitigation**: Change is purely additive (two new fields); existing fields untouched. Smoke-tested the script standalone.
- **Risk**: The new `fetch-diff` exit-on-failure could fail the workflow on transient gh hiccups that previously produced an empty-and-suspicious-but-still-parseable run.
  - **Mitigation**: This is the intended behavior — better to fail loud than to feed an empty diff to the gate. Workflow is auto-resumable.

## Linked Issue

- Closes #
- Related #1430 (this is the follow-up to CodeRabbit's review on #1430)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection and reporting for pull request diff processing.
  * Enhanced status tracking for label operations with explicit error capture.

* **Chores**
  * Refined maintainer review workflow processes with better date handling and deadline tracking.
  * Updated review reporting to include more precise operational status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->