### PR TITLE
fix(workflows): approval gate bypass after reject-with-redraft on resume

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -4730,22 +4730,18 @@ describe('executeDagWorkflow -- approval node', () => {
     // subsequent resume would find the event via getCompletedDagNodeOutputs and
     // skip the approval gate entirely, bypassing the human gate.
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
-    const nodeCompletedForApprovalGate = eventCalls.filter(
-      (call: unknown[]) =>
-        (call[0] as Record<string, unknown>).event_type === 'node_completed' &&
-        (call[0] as Record<string, unknown>).step_name === 'review'
+    const nodeCompletedEvents = eventCalls.filter(
+      (call: unknown[]) => (call[0] as Record<string, unknown>).event_type === 'node_completed'
     );
-    expect(nodeCompletedForApprovalGate.length).toBe(0);
+    const completedStepNames = nodeCompletedEvents.map(
+      (call: unknown[]) => (call[0] as Record<string, unknown>).step_name
+    );
+    expect(completedStepNames).not.toContain('review');
 
     // The synthetic on_reject node MUST produce a node_completed event with the
     // distinct ID 'review:on_reject'. This ensures the synthetic node itself is
     // recorded as completed so it is not re-run on a subsequent resume.
-    const nodeCompletedForSyntheticNode = eventCalls.filter(
-      (call: unknown[]) =>
-        (call[0] as Record<string, unknown>).event_type === 'node_completed' &&
-        (call[0] as Record<string, unknown>).step_name === 'review:on_reject'
-    );
-    expect(nodeCompletedForSyntheticNode.length).toBe(1);
+    expect(completedStepNames.filter((n: unknown) => n === 'review:on_reject').length).toBe(1);
   });
 
   it('on_reject cancels when max_attempts exhausted', async () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -4736,6 +4736,16 @@ describe('executeDagWorkflow -- approval node', () => {
         (call[0] as Record<string, unknown>).step_name === 'review'
     );
     expect(nodeCompletedForApprovalGate.length).toBe(0);
+
+    // The synthetic on_reject node MUST produce a node_completed event with the
+    // distinct ID 'review:on_reject'. This ensures the synthetic node itself is
+    // recorded as completed so it is not re-run on a subsequent resume.
+    const nodeCompletedForSyntheticNode = eventCalls.filter(
+      (call: unknown[]) =>
+        (call[0] as Record<string, unknown>).event_type === 'node_completed' &&
+        (call[0] as Record<string, unknown>).step_name === 'review:on_reject'
+    );
+    expect(nodeCompletedForSyntheticNode.length).toBe(1);
   });
 
   it('on_reject cancels when max_attempts exhausted', async () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -4674,6 +4674,70 @@ describe('executeDagWorkflow -- approval node', () => {
     expect(pauseCalls.length).toBe(1);
   });
 
+  it('on_reject does not write node_completed for the approval gate node ID', async () => {
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'Fixed based on feedback' };
+      yield { type: 'result', sessionId: 'reject-no-poison-session' };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+
+    const workflowRun = makeWorkflowRun('reject-no-poison-run', {
+      metadata: {
+        approval: {
+          type: 'approval',
+          nodeId: 'review',
+          message: 'Approve this plan?',
+          onRejectPrompt: 'Fix based on: $REJECTION_REASON',
+          onRejectMaxAttempts: 3,
+        },
+        rejection_reason: 'Missing edge case handling',
+        rejection_count: 1,
+      },
+    });
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-approval',
+      testDir,
+      {
+        name: 'approval-no-poison',
+        nodes: [
+          {
+            id: 'review',
+            approval: {
+              message: 'Approve this plan?',
+              on_reject: { prompt: 'Fix based on: $REJECTION_REASON', max_attempts: 3 },
+            },
+          },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    // The on_reject synthetic node must NOT produce a node_completed event with
+    // step_name equal to the approval gate's own ID ('review'). If it did, a
+    // subsequent resume would find the event via getCompletedDagNodeOutputs and
+    // skip the approval gate entirely, bypassing the human gate.
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+    const nodeCompletedForApprovalGate = eventCalls.filter(
+      (call: unknown[]) =>
+        (call[0] as Record<string, unknown>).event_type === 'node_completed' &&
+        (call[0] as Record<string, unknown>).step_name === 'review'
+    );
+    expect(nodeCompletedForApprovalGate.length).toBe(0);
+  });
+
   it('on_reject cancels when max_attempts exhausted', async () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -2254,6 +2254,14 @@ async function executeApprovalNode(
     // does not collide with the approval gate's own ID in getCompletedDagNodeOutputs.
     // If we used node.id here, a resumed run would find the event and treat the
     // approval gate as already completed, bypassing the human gate entirely.
+    //
+    // Note: executeNodeInternal also emits node_started/node_completed WorkflowEmitterEvents
+    // with nodeId = `${node.id}:on_reject`. These flow through SSE into the web UI, where
+    // WorkflowExecution.tsx builds its nodeMap from all node_* events unconditionally.
+    // This means a transient `${node.id}:on_reject` phantom entry may appear in the UI's
+    // execution view during an on_reject cycle. This is cosmetic-only — the approval gate
+    // still re-presents correctly and the human gate contract is preserved. A follow-up can
+    // filter synthetic `:on_reject` IDs from the UI's nodeMap if needed.
     const syntheticNode: PromptNode = {
       id: `${node.id}:on_reject`,
       prompt: substituteNodeOutputRefs(substitutedPrompt, nodeOutputs),

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -2249,9 +2249,13 @@ async function executeApprovalNode(
       rejectionReason
     );
 
-    // Build a synthetic PromptNode to reuse executeNodeInternal
+    // Build a synthetic PromptNode to reuse executeNodeInternal.
+    // Use a distinct ID so the node_completed event written by executeNodeInternal
+    // does not collide with the approval gate's own ID in getCompletedDagNodeOutputs.
+    // If we used node.id here, a resumed run would find the event and treat the
+    // approval gate as already completed, bypassing the human gate entirely.
     const syntheticNode: PromptNode = {
-      id: node.id,
+      id: `${node.id}:on_reject`,
       prompt: substituteNodeOutputRefs(substitutedPrompt, nodeOutputs),
       ...(node.depends_on ? { depends_on: node.depends_on } : {}),
       ...(node.idle_timeout ? { idle_timeout: node.idle_timeout } : {}),


### PR DESCRIPTION
## Summary

- **Problem**: After an approval node is rejected with `on_reject.prompt`, the auto-resume runs the on_reject AI prompt and re-pauses. During that run, `executeNodeInternal` writes a `node_completed` event with `step_name = node.id` — the approval gate's own ID. On the next `archon workflow run` invocation, `getCompletedDagNodeOutputs` finds this event and treats the gate as already completed, skipping the human approval entirely and allowing downstream destructive nodes (e.g. `gh pr comment`, auto-merge) to fire without user sign-off.
- **Why it matters**: The approval gate is the documented human-in-the-loop safety mechanism. Bypassing it silently on resume is a high-severity contract violation that creates a foot-gun for destructive workflows.
- **What changed**: In `executeApprovalNode`, the synthetic `PromptNode` built to run the on_reject prompt now uses `id: \`${node.id}:on_reject\`` instead of `id: node.id`. This gives the `node_completed` event a distinct `step_name` that won't collide with the gate's slot in `priorCompletedNodes`.
- **What did not change**: `approveWorkflow()` in `workflow-operations.ts` still writes the legitimate `node_completed` for the approval gate ID on genuine approval. The auto-resume behavior in `workflowRejectCommand` is unchanged. The query in `getCompletedDagNodeOutputs` is unchanged.

## UX Journey

### Before

```
User                           CLI/Executor
────                           ────────────
archon workflow reject <id>    sets status=failed, writes rejection_reason
  (auto-resumes immediately)   executeNodeInternal runs on_reject prompt
                               writes node_completed(step_name='approve-decline')
                               pauseWorkflowRun → status=paused
archon workflow run <name> …   resumes run
                               getCompletedDagNodeOutputs finds 'approve-decline' → skips gate
                               downstream 'post-decline' node fires WITHOUT re-asking user  ← BUG
```

### After

```
User                           CLI/Executor
────                           ────────────
archon workflow reject <id>    sets status=failed, writes rejection_reason
  (auto-resumes immediately)   executeNodeInternal runs on_reject prompt
                               writes node_completed(step_name='approve-decline:on_reject')
                               pauseWorkflowRun → status=paused
archon workflow run <name> …   resumes run
                               getCompletedDagNodeOutputs does NOT find 'approve-decline'
                               [approval gate re-evaluated] → "Approval required" sent to user
```

## Architecture Diagram

### Before

```
executeApprovalNode
  └─ syntheticNode = { id: node.id, ... }   ← collides with gate ID
       └─ executeNodeInternal
            └─ createWorkflowEvent(node_completed, step_name='approve-decline')
                                                    ↑
getCompletedDagNodeOutputs ────────────── finds 'approve-decline' → skips gate on next resume
```

### After

```
executeApprovalNode
  └─ syntheticNode = { id: `${node.id}:on_reject`, ... }   [~] distinct ID
       └─ executeNodeInternal
            └─ createWorkflowEvent(node_completed, step_name='approve-decline:on_reject')
                                                    ↑
getCompletedDagNodeOutputs ────────────── no match for 'approve-decline' → gate re-evaluated
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `executeApprovalNode` | `executeNodeInternal` | **modified** | synthetic node ID changed |
| `executeNodeInternal` | `createWorkflowEvent` | unchanged | writes whatever `node.id` it receives |
| `getCompletedDagNodeOutputs` | `priorCompletedNodes` | unchanged | query unchanged; now correctly misses the on_reject event |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `workflows`
- Module: `workflows:dag-executor`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes #1429

## Validation Evidence (required)

```bash
bun test packages/workflows/src/dag-executor.test.ts  # 193 pass, 0 fail
bun run type-check                                     # 0 errors
bun run lint                                           # 0 errors, 0 warnings
```

- New regression test added: `'on_reject does not write node_completed for the approval gate node ID'`
- All 193 dag-executor tests pass including the new test
- Type-check and lint clean

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — existing approval gate and on_reject behavior is unchanged for all paths except the ID of the synthetic internal event; no user-visible change on the happy path
- Config/env changes? No
- Database migration needed? No — existing `node_completed` events with `step_name = 'approve-decline'` written by prior versions are legitimate (written by `approveWorkflow`); new `:on_reject` events are simply never found by `priorCompletedNodes.has(node.id)`

## Human Verification (required)

- Verified scenarios: code review of full data flow from `workflowRejectCommand` → `executeApprovalNode` → `executeNodeInternal` → `createWorkflowEvent` → `getCompletedDagNodeOutputs` → `priorCompletedNodes`
- Edge cases checked: abort controller tracking uses in-memory maps (process-local, cleaned up on completion) — using a different ID has no cross-run effect; event emitter fires `node_completed` with `review:on_reject` which is more accurate
- What was not verified: end-to-end manual CLI run with a real approval workflow (no live Claude binary in this env)

## Side Effects / Blast Radius (required)

- Affected subsystems: `dag-executor.ts` only — 2 lines changed (the ID assignment + comment)
- Potential unintended effects: SSE consumers will now see a `node_completed` event for `review:on_reject` instead of `review` during on_reject execution. This is more accurate but clients should handle unknown node IDs gracefully.
- Guardrails: regression test will catch any future regression where the synthetic node ID reverts to the gate ID

## Rollback Plan (required)

- Fast rollback: revert the one-line ID change in `dag-executor.ts`
- Feature flags: none
- Observable failure symptoms: approval gate is skipped on post-reject resume; downstream nodes run without user approval

## Risks and Mitigations

- Risk: The `:` character in the synthetic node ID is an unusual format for node IDs.
  - Mitigation: Synthetic nodes are internal-only; the ID is used only for event `step_name`, logging, and process-local abort-controller maps. No external schema constraint on synthetic node IDs. The colon makes the intent self-documenting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed approval gate handling in workflows to correctly preserve state when rejections are resumed, ensuring approval gates are not bypassed and rejection handlers do not rerun on subsequent workflow resumptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->