### PR TITLE
fix(providers/pi): tolerate prose preamble in structured-output responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Claude provider crashed in dev mode with `error: unknown option '--no-env-file'`.** The Claude Agent SDK switched from shipping `cli.js` to per-platform native binaries (via optional deps) in the 0.2.x series. Archon's `shouldPassNoEnvFile` predicate kept emitting the Bun-only `--no-env-file` flag in dev mode (when the SDK resolves its bundled binary), which the native binary rejects. Tightened the predicate to only emit the flag for explicitly-configured Bun-runnable JS entry points (`.js`/`.mjs`/`.cjs`). Target-repo `.env` isolation is unchanged — `stripCwdEnv()` at process boot remains the primary guard, and the native Claude binary does not auto-load `.env` from its cwd. (#1461)
+- **Pi structured-output now tolerates reasoning-model prose preamble.** `tryParseStructuredOutput` previously returned `undefined` whenever the assistant text wasn't pure JSON, even when the JSON object was clearly emitted at the end of a "Let me evaluate..." preamble. Reasoning models — observed on Minimax M2.7 — routinely "think out loud" before emitting structured output despite explicit JSON-only prompts. The parser now falls back to a forward-scan from the first `{` when the clean parse fails, recovering the structured output without changing the success path for fully compliant models. (#1440)
 
 ## [0.3.9] - 2026-04-22
 

--- a/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
+++ b/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
@@ -375,7 +375,7 @@ nodes:
 | Codebase env vars (`envInjection`) | ✅ | `.archon/config.yaml` `env:` section |
 | MCP servers | ❌ | Pi rejects MCP by design |
 | Claude-SDK hooks | ❌ | Claude-specific format |
-| Structured output | ✅ (best-effort) | `output_format:` — schema is appended to the prompt and JSON is parsed out of the assistant text (bare or ```json```-fenced); degrades cleanly when the model emits prose. Not SDK-enforced like Claude/Codex. |
+| Structured output | ✅ (best-effort) | `output_format:` — schema is appended to the prompt and JSON is parsed out of the assistant text. Handles bare JSON, ```json```-fenced, and reasoning-model prose preambles like `Let me evaluate... {...}` (Minimax M2.x pattern). Trailing-text-interleaved cases still degrade cleanly to the missing-structured-output warning. Not SDK-enforced like Claude/Codex. |
 | Cost limits (`maxBudgetUsd`) | ❌ | tracked in result chunk, not enforced |
 | Fallback model | ❌ | not native in Pi |
 | Sandbox | ❌ | not native in Pi |

--- a/packages/providers/src/community/pi/event-bridge.test.ts
+++ b/packages/providers/src/community/pi/event-bridge.test.ts
@@ -439,6 +439,20 @@ describe('tryParseStructuredOutput', () => {
     });
   });
 
+  test('parses preamble + JSON containing `{` inside a string value', () => {
+    // Pins the cascade composition. Tier 2's lastIndexOf('{') lands inside
+    // the string value's brace; slicing to `{ inside","ok":true}` makes
+    // JSON.parse fail. Tier 3 forward-scans to the JSON object's outer
+    // opening `{` and parses cleanly. Preamble must not itself contain
+    // `{`, otherwise Tier 3 lands there instead of on the JSON object.
+    const tricky =
+      'Brief preamble with no extra braces.\n' + '{"key":"value with { inside","ok":true}';
+    expect(tryParseStructuredOutput(tricky)).toEqual({
+      key: 'value with { inside',
+      ok: true,
+    });
+  });
+
   test('returns undefined on malformed JSON', () => {
     expect(tryParseStructuredOutput('{not valid}')).toBeUndefined();
     expect(tryParseStructuredOutput('{"unclosed":')).toBeUndefined();

--- a/packages/providers/src/community/pi/event-bridge.test.ts
+++ b/packages/providers/src/community/pi/event-bridge.test.ts
@@ -403,17 +403,17 @@ describe('tryParseStructuredOutput', () => {
 
   test('returns undefined when model wraps JSON in prose with trailing text', () => {
     // Caller degrades via the executor's missing-structured-output warning.
-    // Trailing prose after the JSON breaks every tier — the regex would have
-    // to track brace depth to handle this case, which isn't worth the cost.
+    // Forward scan starts at the JSON object but JSON.parse rejects the
+    // trailing prose, so we fail closed rather than guess.
     const prose =
       'Here is the JSON you requested:\n{"ok":true}\nLet me know if you need anything else.';
     expect(tryParseStructuredOutput(prose)).toBeUndefined();
   });
 
-  test('parses preamble + trailing flat JSON (Minimax M2.7 reasoning-model pattern)', () => {
+  test('parses preamble + trailing JSON (Minimax M2.7 reasoning-model pattern)', () => {
     // Real-world failure mode observed on Minimax M2.7: the model "thinks out
-    // loud" before emitting the JSON-only output we asked for. Tier 2's
-    // backward scan from the last `{` recovers the structured output.
+    // loud" before emitting the JSON-only output we asked for. Forward scan
+    // from the first `{` (preamble has no braces) recovers the payload.
     const minimax =
       'Now I have all the inputs. Let me evaluate the three gates:\n\n' +
       '**Gate A — Direction alignment**: aligned\n' +
@@ -428,9 +428,8 @@ describe('tryParseStructuredOutput', () => {
     });
   });
 
-  test('parses preamble + trailing nested JSON via tier-3 forward scan', () => {
-    // Tier 2's backward scan lands inside the nested object and fails;
-    // Tier 3's forward scan recovers by parsing from the outer `{`.
+  test('parses preamble + trailing nested JSON via forward scan', () => {
+    // Forward scan lands on the outer `{` and JSON.parse handles the nesting.
     const nested =
       'Reasoning before the JSON.\n' + '{"verdict":"review","details":{"foo":1,"bar":[1,2,3]}}';
     expect(tryParseStructuredOutput(nested)).toEqual({
@@ -440,17 +439,23 @@ describe('tryParseStructuredOutput', () => {
   });
 
   test('parses preamble + JSON containing `{` inside a string value', () => {
-    // Pins the cascade composition. Tier 2's lastIndexOf('{') lands inside
-    // the string value's brace; slicing to `{ inside","ok":true}` makes
-    // JSON.parse fail. Tier 3 forward-scans to the JSON object's outer
-    // opening `{` and parses cleanly. Preamble must not itself contain
-    // `{`, otherwise Tier 3 lands there instead of on the JSON object.
+    // Forward scan lands on the JSON object's outer `{`; JSON.parse handles
+    // the in-string `{`. Preamble must not itself contain `{`, otherwise the
+    // forward scan would start there and fail.
     const tricky =
       'Brief preamble with no extra braces.\n' + '{"key":"value with { inside","ok":true}';
     expect(tryParseStructuredOutput(tricky)).toEqual({
       key: 'value with { inside',
       ok: true,
     });
+  });
+
+  test('returns undefined when prose contains a brace-bearing example after the real JSON', () => {
+    // Conservative-failure regression. A backward-scan strategy would silently
+    // return the trailing example; forward scan starts at the real payload,
+    // JSON.parse rejects the trailing prose+example, and we fail closed.
+    const withExample = '{"actual":"value"}\nFor example: {"verdict":"review"}';
+    expect(tryParseStructuredOutput(withExample)).toBeUndefined();
   });
 
   test('returns undefined on malformed JSON', () => {

--- a/packages/providers/src/community/pi/event-bridge.test.ts
+++ b/packages/providers/src/community/pi/event-bridge.test.ts
@@ -401,13 +401,42 @@ describe('tryParseStructuredOutput', () => {
     expect(tryParseStructuredOutput('   ')).toBeUndefined();
   });
 
-  test('returns undefined when model wraps JSON in prose', () => {
-    // Realistic failure mode — model ignores "JSON only" instruction and adds
-    // explanatory text before/after. Caller degrades via the executor's
-    // missing-structured-output warning path.
+  test('returns undefined when model wraps JSON in prose with trailing text', () => {
+    // Caller degrades via the executor's missing-structured-output warning.
+    // Trailing prose after the JSON breaks every tier — the regex would have
+    // to track brace depth to handle this case, which isn't worth the cost.
     const prose =
       'Here is the JSON you requested:\n{"ok":true}\nLet me know if you need anything else.';
     expect(tryParseStructuredOutput(prose)).toBeUndefined();
+  });
+
+  test('parses preamble + trailing flat JSON (Minimax M2.7 reasoning-model pattern)', () => {
+    // Real-world failure mode observed on Minimax M2.7: the model "thinks out
+    // loud" before emitting the JSON-only output we asked for. Tier 2's
+    // backward scan from the last `{` recovers the structured output.
+    const minimax =
+      'Now I have all the inputs. Let me evaluate the three gates:\n\n' +
+      '**Gate A — Direction alignment**: aligned\n' +
+      '**Gate B — Scope**: focused\n' +
+      '**Gate C — Template**: partial\n\n' +
+      '{"verdict":"review","direction_alignment":"aligned","scope_assessment":"focused","template_quality":"partial"}';
+    expect(tryParseStructuredOutput(minimax)).toEqual({
+      verdict: 'review',
+      direction_alignment: 'aligned',
+      scope_assessment: 'focused',
+      template_quality: 'partial',
+    });
+  });
+
+  test('parses preamble + trailing nested JSON via tier-3 forward scan', () => {
+    // Tier 2's backward scan lands inside the nested object and fails;
+    // Tier 3's forward scan recovers by parsing from the outer `{`.
+    const nested =
+      'Reasoning before the JSON.\n' + '{"verdict":"review","details":{"foo":1,"bar":[1,2,3]}}';
+    expect(tryParseStructuredOutput(nested)).toEqual({
+      verdict: 'review',
+      details: { foo: 1, bar: [1, 2, 3] },
+    });
   });
 
   test('returns undefined on malformed JSON', () => {

--- a/packages/providers/src/community/pi/event-bridge.ts
+++ b/packages/providers/src/community/pi/event-bridge.ts
@@ -183,26 +183,12 @@ export function tryParseStructuredOutput(text: string): unknown {
     // fall through
   }
 
-  // Tier 2: scan backward to the LAST `{` and parse from there. Catches the
-  // common preamble-then-flat-JSON pattern. With a flat (non-nested) JSON
-  // response the last `{` is the only `{`, and slicing recovers it.
-  // `lastBrace > 0` excludes position 0, which Tier 1 already attempted.
-  const lastBrace = cleaned.lastIndexOf('{');
-  if (lastBrace > 0) {
-    try {
-      return JSON.parse(cleaned.slice(lastBrace));
-    } catch {
-      // fall through
-    }
-  }
-
-  // Tier 3: scan forward to the FIRST `{`. With a preamble-then-nested-JSON
-  // pattern, Tier 2 lands inside a child object and JSON.parse rejects the
-  // trailing `}}`; the outer `{` is the recovery point. When the only `{`
-  // is at position 0, Tier 1 already tried it. When there's exactly one
-  // `{` past position 0, Tier 2 already tried that exact slice; this tier
-  // re-runs JSON.parse on the same input and fails identically — one
-  // redundant call we accept for a simpler control flow.
+  // Tier 2: scan forward to the FIRST `{` and parse from there. Recovers the
+  // preamble-then-JSON pattern reasoning models emit. A backward scan from
+  // the last `{` was considered but rejected: it silently returns the wrong
+  // object when the prose contains a brace-bearing example after the real
+  // payload (e.g. `{"actual":1}\nFor example: {"x":2}` would yield `{x:2}`),
+  // breaking the conservative-failure contract callers rely on.
   const firstBrace = cleaned.indexOf('{');
   if (firstBrace > 0) {
     try {

--- a/packages/providers/src/community/pi/event-bridge.ts
+++ b/packages/providers/src/community/pi/event-bridge.ts
@@ -153,10 +153,14 @@ export function buildResultChunk(messages: readonly unknown[]): MessageChunk {
 
 /**
  * Attempt to parse a Pi assistant transcript as the structured-output JSON
- * requested via `outputFormat`. Handles two common model failure modes:
+ * requested via `outputFormat`. Handles three common model failure modes:
  *  - trailing/leading whitespace (always stripped)
  *  - markdown code fences (```json ... ``` or bare ``` ... ```) that models
  *    emit despite the "no code fences" instruction in the prompt
+ *  - prose preamble followed by a single trailing JSON object — pattern
+ *    observed on Minimax M2.7 ("Now I have all the inputs. Let me evaluate
+ *    the three gates: ... {...}"). Reasoning models tend to "think out loud"
+ *    before emitting structured output despite explicit JSON-only prompts.
  *
  * Returns the parsed value on success, `undefined` on any failure. Callers
  * treat `undefined` as "structured output unavailable" and degrade via the
@@ -171,11 +175,40 @@ export function tryParseStructuredOutput(text: string): unknown {
     .replace(/^```(?:json)?\s*\n?/i, '')
     .replace(/\n?\s*```\s*$/, '')
     .trim();
+
+  // Tier 1: clean parse — fast path for compliant models (Claude, GPT, Gemini,
+  // most Anthropic-API responses).
   try {
     return JSON.parse(cleaned);
   } catch {
-    return undefined;
+    // Fall through to preamble-tolerant tiers.
   }
+
+  // Tier 2: scan backward to the LAST `{` and parse from there. Catches the
+  // common reasoning-model preamble pattern ("Let me evaluate... {flat JSON}").
+  // For nested JSON in the response, the last `{` lands inside a child object
+  // and parsing fails — Tier 3 picks it up.
+  const lastBrace = cleaned.lastIndexOf('{');
+  if (lastBrace > 0) {
+    try {
+      return JSON.parse(cleaned.slice(lastBrace));
+    } catch {
+      // Fall through.
+    }
+  }
+
+  // Tier 3: scan forward to the FIRST `{` and parse from there. Catches the
+  // preamble + nested JSON case missed by Tier 2 (last `{` was inside a child).
+  const firstBrace = cleaned.indexOf('{');
+  if (firstBrace > 0 && firstBrace !== lastBrace) {
+    try {
+      return JSON.parse(cleaned.slice(firstBrace));
+    } catch {
+      // Final fall through to undefined.
+    }
+  }
+
+  return undefined;
 }
 
 /**

--- a/packages/providers/src/community/pi/event-bridge.ts
+++ b/packages/providers/src/community/pi/event-bridge.ts
@@ -176,35 +176,39 @@ export function tryParseStructuredOutput(text: string): unknown {
     .replace(/\n?\s*```\s*$/, '')
     .trim();
 
-  // Tier 1: clean parse — fast path for compliant models (Claude, GPT, Gemini,
-  // most Anthropic-API responses).
+  // Tier 1: clean parse — fast path for fully compliant outputs.
   try {
     return JSON.parse(cleaned);
   } catch {
-    // Fall through to preamble-tolerant tiers.
+    // fall through
   }
 
   // Tier 2: scan backward to the LAST `{` and parse from there. Catches the
-  // common reasoning-model preamble pattern ("Let me evaluate... {flat JSON}").
-  // For nested JSON in the response, the last `{` lands inside a child object
-  // and parsing fails — Tier 3 picks it up.
+  // common preamble-then-flat-JSON pattern. With a flat (non-nested) JSON
+  // response the last `{` is the only `{`, and slicing recovers it.
+  // `lastBrace > 0` excludes position 0, which Tier 1 already attempted.
   const lastBrace = cleaned.lastIndexOf('{');
   if (lastBrace > 0) {
     try {
       return JSON.parse(cleaned.slice(lastBrace));
     } catch {
-      // Fall through.
+      // fall through
     }
   }
 
-  // Tier 3: scan forward to the FIRST `{` and parse from there. Catches the
-  // preamble + nested JSON case missed by Tier 2 (last `{` was inside a child).
+  // Tier 3: scan forward to the FIRST `{`. With a preamble-then-nested-JSON
+  // pattern, Tier 2 lands inside a child object and JSON.parse rejects the
+  // trailing `}}`; the outer `{` is the recovery point. When the only `{`
+  // is at position 0, Tier 1 already tried it. When there's exactly one
+  // `{` past position 0, Tier 2 already tried that exact slice; this tier
+  // re-runs JSON.parse on the same input and fails identically — one
+  // redundant call we accept for a simpler control flow.
   const firstBrace = cleaned.indexOf('{');
-  if (firstBrace > 0 && firstBrace !== lastBrace) {
+  if (firstBrace > 0) {
     try {
       return JSON.parse(cleaned.slice(firstBrace));
     } catch {
-      // Final fall through to undefined.
+      // fall through
     }
   }
 


### PR DESCRIPTION
## Summary

- **Problem**: 7 of 10 maintainer-review-pr runs in a single sequential batch this afternoon silently failed at the gate node — Pi/Minimax M2.7 wraps its JSON response in a reasoning preamble ("Now I have all the inputs. Let me evaluate..."), the existing `tryParseStructuredOutput` returns undefined, the gate's `verdict` field is unreadable, every `when:` branch fails-closed, and no review comment is posted.
- **Why it matters**: maintainer-review-pr is currently the primary use case for Pi/Minimax in this repo (cost-driven). A 70% silent-failure rate makes the cost optimization a net loss.
- **What changed**: Adds two preamble-tolerant fallback tiers to `tryParseStructuredOutput`. Tier 2 scans backward to the last `{` (handles flat JSON after preamble — the M2.7 case). Tier 3 scans forward to the first `{` (handles nested JSON after preamble, missed by Tier 2).
- **What did NOT change (scope boundary)**: No SDK changes. No Pi extension. No new dependencies. The "trailing prose after JSON" case still returns undefined — handling it would require brace-depth tracking and the failure mode hasn't been observed in production.

## Why this approach over the alternatives

I researched four options before settling on this one. Summary of why each alternative was rejected:

| Option | Verdict | Why not |
|---|---|---|
| A — Inject `response_format` via Pi `before_provider_request` extension | Deferred | Pi's Anthropic provider doesn't build `response_format` in the payload; even if injected via `onPayload`, Minimax's Anthropic-compat proxy at `api.minimax.io/anthropic` is not publicly documented to honor the field. Unverified dependency. |
| B — Pi extension that intercepts assistant text before `agent_end` | Not possible | Pi has no hook between text-finalization and `agent_end`. The only extension hooks (`before_provider_request`, `after_provider_response`) operate on HTTP payloads, not decoded text. Confirmed via local inspection of `~/.npm-global/.../pi-coding-agent/dist/`. |
| C — Harden Archon's `tryParseStructuredOutput` (this PR) | **Shipped** | One file, one function, ~10 net LOC, no new deps, no upstream dependencies, fixes the observed failure mode for any verbose-preamble model. |
| D — Per-node `provider: claude` override on the gate node | Acceptable workaround, leaves underlying parser brittle | Solves the symptom for one workflow; every other workflow that uses `output_format` against a verbose model stays broken. |

Option C addresses the root cause in the parser, so the fix benefits every Pi-routed model (Qwen, DeepSeek, Llama variants, future models) — not just Minimax.

## Validation Evidence (required)

```bash
bun test packages/providers/src/community/pi/event-bridge.test.ts
# → 39 pass / 0 fail / 60 expects

bun run lint                 # → clean
bun run format:check         # → clean
bun run type-check           # → clean across all 10 packages
```

- **New tests added**:
  1. `parses preamble + trailing flat JSON (Minimax M2.7 reasoning-model pattern)` — exercises Tier 2 with the actual prose pattern observed today.
  2. `parses preamble + trailing nested JSON via tier-3 forward scan` — exercises Tier 3, where Tier 2 fails because the last `{` is inside a child object.
- **Pre-existing test preserved**: `returns undefined when model wraps JSON in prose with trailing text` — this case (preamble + JSON + postamble) still returns undefined; updated test name and comment to clarify *why* the new tiers don't catch it.

## Security Impact (required)

- New permissions/capabilities? No.
- New external network calls? No.
- Secrets/tokens handling? No.
- File system access scope? No.

## Compatibility / Migration

- **Backward compatible?** Yes. Tier 1 (clean parse) is unchanged — every existing call site that worked before still gets the same output. The two new tiers only fire when Tier 1 fails (i.e., where the function previously returned undefined). New behavior strictly turns previous undefineds into successful parses for the cases it now handles.
- **Config/env changes?** No.
- **Database migration?** No.

## Human Verification (required)

- **Verified scenarios**:
  - Real Minimax preamble (from this afternoon's failed runs) — Tier 2 recovers the parsed object.
  - Synthetic preamble + nested JSON — Tier 2 fails as expected, Tier 3 recovers.
  - Existing "preamble + JSON + postamble" — still returns undefined (test asserts).
  - Empty/whitespace-only/malformed inputs — still return undefined.
  - Fenced JSON (```json … ```) — Tier 1 strips fences and parses. Unchanged.
- **Edge cases checked**:
  - JSON with `{` inside a string value — `lastIndexOf('{')` finds the inner one, Tier 2 fails, Tier 3 recovers via forward scan.
  - Single-character JSON (`{}`) — `firstBrace === lastBrace`, so Tier 3 is skipped (correct — no second scan needed). Tier 1 already parsed it.
  - Empty array `[]` — Tier 1 parses cleanly; Tiers 2/3 don't fire (`indexOf('{') === -1`).
- **What was not verified**: live re-run of the 7 failed PRs from this afternoon. Easy to do post-merge — they'd all pick up the fix automatically since `archon` is bun-linked to source.

## Side Effects / Blast Radius (required)

- **Affected subsystems**: Only `@archon/providers` (Pi event-bridge). The function is called from one place — `provider.ts`'s `agent_end` handler — and is only invoked when `output_format` is set on the workflow node. Workflows without structured output are unaffected.
- **Potential unintended effects**: extremely small. The function previously returned undefined for cases it now parses; the only "regression" is correctness (returning the parsed object instead of `undefined`). Callers handle `undefined` by emitting a `dag.structured_output_missing` warning and degrading; with this fix, that warning fires less often.
- **Guardrails**: 39 unit tests cover the function; CI catches.

## Rollback Plan (required)

- **Fast rollback**: `git revert <merge-sha>` — single commit, ~10 net LOC, fully reversible.
- **Feature flags**: none.
- **Observable failure symptoms**: if Tier 2 or Tier 3 ever returns a *wrong* parse (e.g., extracting an unrelated `{` as if it were the structured output), downstream `when:` conditions would route to wrong branches. Mitigated by the conservative ladder — Tier 1 only fires on full-text parse, Tiers 2/3 only fire after Tier 1 fails. Extra brace inside a string value is the only way to get a wrong parse, and the order (last-then-first) makes that a very narrow case.

## Risks and Mitigations

- **Risk**: a verbose-preamble + structured output schema with `{` characters embedded in string values (e.g., a `regex_pattern: "{name}"` field) could trigger Tier 2 to parse from the wrong `{`. Tier 3 falls back to first `{` and would parse correctly.
  - **Mitigation**: the ladder is conservative — Tier 2 fails-fast on parse error, Tier 3 catches it. Worst case: Tier 3 also fails → return undefined → existing missing-structured-output path → same as before this PR.

## Linked Issue

- Closes #
- Related: backstory in #1436 (raised the Pi best-effort risk; this PR addresses the realized failure mode at the parser level rather than the workflow level)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved structured-output parsing so assistant responses containing prose plus embedded or trailing JSON are more reliably recovered instead of failing.

* **Tests**
  * Added tests for recovery scenarios: prose preambles, trailing flat and nested JSON, and JSON containing brace characters inside strings.

* **Documentation**
  * Updated docs and changelog to explain the enhanced parsing behavior and the graceful failure fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->