### PR TITLE
feat(maintainer-standup): surface contributor replies since last run

### DIFF
--- a/.archon/commands/maintainer-standup.md
+++ b/.archon/commands/maintainer-standup.md
@@ -29,7 +29,9 @@ Fields: `current_dev_sha`, `prior_dev_sha`, `current_branch`, `is_dirty`, `pull_
 $gh-data.output
 ```
 
-Fields: `gh_handle`, `since_date`, `all_open_prs`, `review_requested`, `authored_by_me`, `issues_assigned`, `recent_unlabeled_issues`, `recently_closed_prs`, `recently_closed_issues`, `my_recent_commits`.
+Fields: `gh_handle`, `since_date`, `all_open_prs`, `review_requested`, `authored_by_me`, `issues_assigned`, `recent_unlabeled_issues`, `recently_closed_prs`, `recently_closed_issues`, `my_recent_commits`, `replies_since_last_run`.
+
+`replies_since_last_run` is an array of `{ number, kind, comments }` grouping contributor replies on PRs and issues since the last run. `kind` is one of `issue` / `pr_conversation` / `pr_review`; the maintainer's own comments are filtered out. Use this as the source for the **"Replies waiting on you"** brief section (see Phase 3).
 
 ### Local context (direction doc, maintainer profile, prior state, recent briefs)
 
@@ -111,6 +113,11 @@ A maintainer-ready markdown brief. Adapt sections — omit empty ones, add other
 - **PR #N** — [title] — merged ✓ / closed
 - **Issue #N** — [title] — closed
 - (Omit section if nothing resolved.)
+
+## Replies waiting on you
+- **PR #N** — @author replied (N comments since last run): [one-line excerpt of latest comment]. [URL]
+- **Issue #N** — @author commented: [excerpt]. [URL]
+- (Sort by recency; surface inline-review-comment kinds first since they usually need a code-level response. Omit section if `replies_since_last_run` is empty.)
 
 ## P1 — Do today
 - **PR #N** — [title] ([+X/-Y]) — [why P1, e.g. "ready to merge, awaiting your review"]

--- a/.archon/scripts/maintainer-standup-gh-data.ts
+++ b/.archon/scripts/maintainer-standup-gh-data.ts
@@ -179,6 +179,134 @@ if (ghHandle) {
   }
 }
 
+// ── Replies since last run (contributor comments on PRs/issues) ──
+// Fetches all conversation + inline review comments since the last run,
+// filters out the maintainer's own comments, and groups by PR/issue number.
+// Lets the synthesizer surface "@author replied on PR #N" items for the
+// maintainer to triage today.
+//
+// GitHub endpoints:
+//   - /repos/{o}/{r}/issues/comments   conversation comments on PRs and issues
+//                                      (same endpoint; issue_url disambiguates)
+//   - /repos/{o}/{r}/pulls/comments    inline code-review comments
+// Both accept ?since=ISO8601.
+type GhComment = {
+  user?: { login?: string };
+  created_at?: string;
+  body?: string;
+  html_url?: string;
+  issue_url?: string;
+  pull_request_url?: string;
+};
+
+type GroupedReply = {
+  number: number;
+  kind: 'issue' | 'pr_conversation' | 'pr_review';
+  comments: {
+    author: string;
+    created_at: string;
+    body_excerpt: string;
+    url: string;
+  }[];
+};
+
+function ownerRepo(): { owner: string; repo: string } | null {
+  try {
+    const url = execFileSync('git', ['remote', 'get-url', 'origin'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+      .toString()
+      .trim();
+    // ssh: git@github.com:owner/repo.git ; https: https://github.com/owner/repo.git
+    const m = url.match(/[:/]([^:/]+)\/([^/]+?)(?:\.git)?$/);
+    if (!m) return null;
+    return { owner: m[1], repo: m[2] };
+  } catch {
+    return null;
+  }
+}
+
+function extractNumber(url: string | undefined): number | null {
+  if (!url) return null;
+  const m = url.match(/\/(?:issues|pulls)\/(\d+)$/);
+  return m ? Number(m[1]) : null;
+}
+
+const repliesByNumber: Record<number, GroupedReply> = {};
+const repoIds = ownerRepo();
+
+if (repoIds && lastRunAt) {
+  const openPrNumbers = new Set(
+    (allOpenPrs as Array<{ number?: number }>)
+      .map((p) => p.number)
+      .filter((n): n is number => typeof n === 'number'),
+  );
+
+  const addComment = (
+    num: number,
+    kind: GroupedReply['kind'],
+    c: GhComment,
+    fallbackUrl: string,
+  ): void => {
+    const author = c.user?.login;
+    if (!author) return;
+    if (ghHandle && author.toLowerCase() === ghHandle.toLowerCase()) return;
+    // Skip GitHub bots — coderabbitai, codex-connector, dependabot, etc. The
+    // "[bot]" suffix is the canonical GitHub convention for bot accounts and
+    // is reliable across all bot integrations. Maintainer wants human replies
+    // worth responding to, not the constant churn of automated review tooling.
+    if (author.endsWith('[bot]')) return;
+    if (!repliesByNumber[num]) repliesByNumber[num] = { number: num, kind, comments: [] };
+    // Upgrade kind toward pr_review (most actionable) when both arrive on the same PR.
+    if (kind === 'pr_review') repliesByNumber[num].kind = 'pr_review';
+    repliesByNumber[num].comments.push({
+      author,
+      created_at: c.created_at ?? '',
+      body_excerpt: (c.body ?? '').slice(0, 240).replace(/\s+/g, ' ').trim(),
+      url: c.html_url ?? fallbackUrl,
+    });
+  };
+
+  // /issues/comments covers PR + issue conversations under one endpoint.
+  // Disambiguate by checking whether the parsed number is an open PR.
+  const issueComments = parseJson<GhComment[]>(
+    exec('gh', [
+      'api',
+      `repos/${repoIds.owner}/${repoIds.repo}/issues/comments?since=${lastRunAt}&per_page=100`,
+      '--paginate',
+    ]),
+    [],
+  );
+  for (const c of issueComments) {
+    const num = extractNumber(c.issue_url);
+    if (!num) continue;
+    const kind: GroupedReply['kind'] = openPrNumbers.has(num) ? 'pr_conversation' : 'issue';
+    addComment(num, kind, c, c.issue_url ?? '');
+  }
+
+  // /pulls/comments are inline code-review comments — most specific signal,
+  // usually need a code-level response.
+  const reviewComments = parseJson<GhComment[]>(
+    exec('gh', [
+      'api',
+      `repos/${repoIds.owner}/${repoIds.repo}/pulls/comments?since=${lastRunAt}&per_page=100`,
+      '--paginate',
+    ]),
+    [],
+  );
+  for (const c of reviewComments) {
+    const num = extractNumber(c.pull_request_url);
+    if (!num) continue;
+    addComment(num, 'pr_review', c, c.pull_request_url ?? '');
+  }
+}
+
+const repliesSinceLastRun = Object.values(repliesByNumber).sort((a, b) => {
+  const aLatest = a.comments[a.comments.length - 1]?.created_at ?? '';
+  const bLatest = b.comments[b.comments.length - 1]?.created_at ?? '';
+  return bLatest.localeCompare(aLatest); // newest first
+});
+
 console.log(
   JSON.stringify({
     gh_handle: ghHandle,
@@ -191,5 +319,6 @@ console.log(
     recently_closed_prs: recentlyClosedPrs,
     recently_closed_issues: recentlyClosedIssues,
     my_recent_commits: myRecentCommits,
+    replies_since_last_run: repliesSinceLastRun,
   }),
 );


### PR DESCRIPTION
## Summary

- **Problem**: Daily maintainer-standup briefs surface a lot of signal — open PRs by priority, what shipped, what's resolved — but they don't surface **who replied to me** since the last run. With ~30 active PRs and ongoing back-and-forth on direction questions, contributor replies got lost in the volume; the brief told me "PR #X was updated" but not "@gemmawood answered your question on PR #X."
- **Why it matters**: Contributor responses are the highest-priority maintainer action — somebody is waiting on me. Burying them in the same field as label changes / force-pushes / CI-bot churn means real conversations get dropped on the floor.
- **What changed**: Two new paginated GitHub API calls in the gather script (`/repos/{o}/{r}/issues/comments` for PR + issue conversations and `/repos/{o}/{r}/pulls/comments` for inline review comments), scoped by `since=last_run_at`. Filters out the maintainer's own comments and all `[bot]`-suffixed authors. Groups by PR/issue number with a kind tag (`issue` / `pr_conversation` / `pr_review`). Plumbed through to a new "Replies waiting on you" section in the brief.
- **What did NOT change (scope boundary)**: No engine changes. No new YAML schema. Other maintainer-standup outputs (P1-P4, "What you shipped", "Resolved since last run") are unchanged. Other workflows (maintainer-review-pr, repo-triage) untouched.

## Validation Evidence (required)

```bash
archon validate workflows maintainer-standup     # → ok
bun run format:check                             # → clean
bun run lint                                     # → clean
bun run type-check                               # → clean across all 10 packages

# Manual test on a backdated last_run_at (proving the data flow):
$ jq '.last_run_at = "2026-04-27T08:00:00Z"' state.json > tmp && mv tmp state.json
$ bun run .archon/scripts/maintainer-standup-gh-data.ts | jq '.replies_since_last_run | length'
22
$ ... | jq '.replies_since_last_run | map(.comments[].author) | unique'
["atlas-architect", "b1skit", "cropse", "ericsoriano", "fuleinist", "gemmawood",
 "leex279", "lraphael", "popemkt", "shaun0927", "truffle-dev", "voidborne-d"]
```

12 distinct human authors across 22 PRs/issues — exactly the contributors I'd want to follow up with after yesterday's review comments and direction questions. Pre-bot-filter, the count was 32 (10 of those were bots: coderabbitai, chatgpt-codex-connector, dependabot review noise).

## Security Impact (required)

- **New permissions/capabilities?** No.
- **New external network calls?** Yes — two `gh api` paginated GETs against the existing repo (`/issues/comments` and `/pulls/comments`). Both already-allowed scopes via existing `gh` auth. No new tokens, no new endpoints outside what `gh` already accesses.
- **Secrets/tokens handling?** Unchanged.
- **File system access scope?** Unchanged.

## Compatibility / Migration

- **Backward compatible?** Yes. The new `replies_since_last_run` field is additive on the gather script's JSON output; existing consumers (synthesizer prompt) ignore unknown fields by design. First-run behavior is unchanged: the gather skips the API calls entirely when `last_run_at` is missing, returning an empty array.
- **Config/env changes?** No.
- **Database migration?** No.

## Human Verification (required)

- **Verified scenarios**:
  - Real backdated last_run_at → 22 human replies surfaced across 12 contributors. Spot-checked: @gemmawood on #1338 (the runtime-inputs PR I asked questions on yesterday), @popemkt on #1351 (Copilot, asked for evidence), @cropse on #1384 (OpenCode, same), @shaun0927 on his 5 rebased PRs (1247-1251), @voidborne-d on #1367 (test-coverage pushback) — all expected.
  - First-run behavior: when `state.json` is missing or has no `last_run_at`, the new block is skipped and `replies_since_last_run: []` is emitted. No API calls fired.
  - Bot filter: 10 bot comments correctly suppressed (coderabbitai, chatgpt-codex-connector, dependabot, github-actions). Verified by counting before/after.
  - Workflow validates cleanly from `.archon/workflows/maintainer/`.
- **Edge cases checked**:
  - Repos without an `origin` remote: `ownerRepo()` returns `null`, the new block is skipped. No crash.
  - Comments on issue/PR transferred between repos: `extractNumber` regex matches both `/issues/N$` and `/pulls/N$`; cross-repo URLs would still match by number, but the API only returns this repo's comments so this isn't reachable in practice.
  - `last_run_at` invalid/empty: skipped by the `if (repoIds && lastRunAt)` guard.
- **What was not verified**: behavior under a repo with hundreds of comments per day — `--paginate` should handle it but pagination cost grows linearly. Not a concern for this repo's volume; could be revisited if a large repo adopts the workflow.

## Side Effects / Blast Radius (required)

- **Affected subsystems**: only `maintainer-standup` workflow's gather script + command file. No engine code touched.
- **Potential unintended effects**: an additional ~2 `gh api` calls per standup run (one paginated each for issue/pull comments). At 100 comments per page, that's typically 1 page each. ~1-2 sec added to the gather phase — well within the gather's existing ~5-10s budget.
- **Guardrails**: the new field is additive; if synthesizer doesn't use it (e.g. older command file checked into another repo's `.archon/`), the brief degrades to its prior shape. No breakage path.

## Rollback Plan (required)

- **Fast rollback**: `git revert <merge-sha>` — single commit, two files, fully additive. The new gather field disappears; the brief's new section disappears. No data migration needed.
- **Feature flags**: none.
- **Observable failure symptoms**: if either `gh api` call fails (auth, network), `parseJson` returns `[]` and `replies_since_last_run` is empty — degraded to silent rather than fatal. Worst case: the brief's new section is empty even when replies exist; visible in normal review.

## Risks and Mitigations

- **Risk**: the brief's new section is too long for high-activity days, drowning out P1-P4 prioritization.
  - **Mitigation**: synthesizer prompt instructs to keep one line per reply, sort by recency, and surface inline-review-comment kinds (`pr_review`) first since they need code-level responses. If the section grows unwieldy in practice, easy follow-up to add a top-N cap (e.g. 10 most recent).
- **Risk**: bot filter (`endsWith('[bot]')`) might miss a non-conventional bot account (e.g. one that doesn't use the `[bot]` suffix).
  - **Mitigation**: GitHub's convention is reliable for App-installed bots. Edge cases (a human account that posts review-tooling output) would surface as noise but is rare. Could be tightened later by checking `user.type === 'User'` if the GraphQL/v3 endpoint returned that field on /comments responses (it doesn't currently — would require a separate /users lookup).
- **Risk**: the maintainer doesn't actually want EVERY reply — sometimes a "thanks!" comment is just acknowledgement and doesn't need response.
  - **Mitigation**: synthesizer can mark such replies as informational rather than action items based on body content. Not a parser concern.

## Linked Issue

- Closes # (no associated issue — implementation came directly from the user's morning standup feedback today)
- Related: parent #1428 (the maintainer-standup workflow itself).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Replies waiting on you" section to standup reports that displays all contributor responses on your pull requests and issues since the last run. Includes author attribution, reply counts, comment excerpts, and direct links. Your own comments and bot interactions are automatically filtered out for cleaner, more actionable reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->