### PR TITLE
feat(maintainer-workflows): cross-workflow review memory + backfill

### DIFF
--- a/.archon/commands/maintainer-standup.md
+++ b/.archon/commands/maintainer-standup.md
@@ -37,7 +37,7 @@ Fields: `gh_handle`, `since_date`, `all_open_prs`, `review_requested`, `authored
 $read-context.output
 ```
 
-Fields: `direction` (markdown string), `profile` (markdown string), `prior_state` (object or null), `recent_briefs` (array of `{date, content}`).
+Fields: `direction` (markdown string), `profile` (markdown string), `prior_state` (object or null), `recent_briefs` (array of `{date, content}`), `today` (`YYYY-MM-DD`), `deadline_3d` (`YYYY-MM-DD`), `reviewed_prs` (map of PR number → `{ reviewed_at, gate_verdict, run_id }` recording past maintainer-review-pr runs — see Phase 2h).
 
 ---
 
@@ -86,6 +86,18 @@ If any PR raises a "we don't have a stance on this" question that `direction.md`
 ### 2g. Carry-over aging
 
 Items that have been in `prior_state.carry_over` for multiple runs (check `first_seen` dates) are higher priority — surface them prominently and consider escalating their P-level.
+
+### 2h. Review-history awareness (cross-workflow memory)
+
+`read-context.output.reviewed_prs` is a map of PR number → `{ reviewed_at, gate_verdict, run_id }` recording past maintainer-review-pr runs. When listing PRs in any P1-P4 (or Polite-decline) section, append a marker if the PR has an entry:
+
+- **Reviewed (review branch)**: `✓ reviewed Nd ago` — N is days between `read-context.output.today` and `reviewed_at` (`YYYY-MM-DD` slice). Use `0d` for today, `1d` for yesterday, etc.
+- **Declined (decline / needs_split branch)**: `✓ declined Nd ago` — same age math, distinct verb so the brief reads correctly when a PR was politely declined rather than reviewed.
+- **Unclear**: `✓ triaged Nd ago (unclear)` — for `gate_verdict: 'unclear'` runs.
+
+**Staleness check**: compare `reviewed_at` to the PR's `updatedAt` (in `gh-data.output.all_open_prs`). If `updatedAt > reviewed_at`, append `⚠ contributor pushed since` so the maintainer knows the prior review may need re-running. Only flag when the gap is real and meaningful — same-day commits don't need a warning.
+
+PRs not in `reviewed_prs` get no marker (their absence is itself the signal: "not yet reviewed via the workflow").
 
 ---
 

--- a/.archon/scripts/maintainer-standup-backfill-reviews.ts
+++ b/.archon/scripts/maintainer-standup-backfill-reviews.ts
@@ -1,0 +1,180 @@
+#!/usr/bin/env bun
+/**
+ * One-shot: scan the maintainer's recent GitHub comments and populate
+ * .archon/maintainer-standup/reviewed-prs.json with `{ reviewed_at,
+ * gate_verdict, run_id }` entries inferred from comment-body patterns.
+ *
+ * Use case: after adopting the cross-workflow memory feature, today's
+ * morning brief should already mark "✓ reviewed Nd ago" for the PRs that
+ * were reviewed before the writer node existed. Without backfill, those
+ * markers only appear for runs going forward.
+ *
+ * Inference patterns (from the maintainer-review-pr output):
+ *  - Body contains "## Review Summary"           → gate_verdict: review
+ *  - Body contains "isn't a direction we're"     → gate_verdict: decline
+ *    OR "Conflicts with `direction.md"
+ *  - Body contains "Could you split this"        → gate_verdict: needs_split
+ *    OR "split into <N> focused PRs"
+ *
+ * Behavior:
+ *  - Fetches the maintainer's comments authored in the last 7 days.
+ *  - Per PR, takes the LATEST matching comment (newer comments win).
+ *  - Existing entries (from real workflow runs) take precedence over
+ *    backfilled ones — the writer-node record is more authoritative.
+ *  - Idempotent: re-running adds nothing new if no new pattern-matching
+ *    comments have been authored since.
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+type GhComment = {
+  user?: { login?: string };
+  created_at?: string;
+  body?: string;
+  issue_url?: string;
+};
+
+type ReviewedEntry = {
+  reviewed_at: string;
+  gate_verdict: 'review' | 'decline' | 'needs_split' | 'unclear';
+  run_id?: string;
+  source?: 'workflow' | 'backfill';
+};
+
+const baseDir = resolve(process.cwd(), '.archon/maintainer-standup');
+
+// ── Read gh handle from profile ──
+const profilePath = resolve(baseDir, 'profile.md');
+if (!existsSync(profilePath)) {
+  console.error('No profile.md found — run from repo root, with .archon/maintainer-standup/profile.md present.');
+  process.exit(1);
+}
+const ghHandleMatch = readFileSync(profilePath, 'utf8').match(/^gh_handle:\s*(\S+)/m);
+if (!ghHandleMatch) {
+  console.error('No gh_handle in profile.md frontmatter');
+  process.exit(1);
+}
+const ghHandle = ghHandleMatch[1];
+
+// ── Resolve owner/repo from the origin remote ──
+const remote = execFileSync('git', ['remote', 'get-url', 'origin'], {
+  stdio: ['ignore', 'pipe', 'pipe'],
+})
+  .toString()
+  .trim();
+const repoMatch = remote.match(/[:/]([^:/]+)\/([^/]+?)(?:\.git)?$/);
+if (!repoMatch) {
+  console.error(`Could not parse owner/repo from origin remote: ${remote}`);
+  process.exit(1);
+}
+const [, owner, repo] = repoMatch;
+
+// ── Fetch issue/PR conversation comments since 7 days ago ──
+const sevenDaysAgo = new Date();
+sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+const since = sevenDaysAgo.toISOString();
+
+console.log(`Scanning ${ghHandle}'s comments on ${owner}/${repo} since ${since}...`);
+
+// Default maxBuffer is 1MB which 7 days of paginated comments easily exceeds
+// in an active repo (1k+ comments → multi-MB JSON). 64MB is generous and
+// well below available memory; if the repo grows past that, switch to
+// streaming the gh process and parsing line-by-line.
+const allComments = JSON.parse(
+  execFileSync(
+    'gh',
+    [
+      'api',
+      `repos/${owner}/${repo}/issues/comments?since=${since}&per_page=100`,
+      '--paginate',
+    ],
+    { stdio: ['ignore', 'pipe', 'pipe'], maxBuffer: 64 * 1024 * 1024 },
+  ).toString(),
+) as GhComment[];
+
+// ── Pattern-match the maintainer's own review/decline comments ──
+function inferVerdict(body: string): ReviewedEntry['gate_verdict'] | null {
+  if (body.includes('## Review Summary')) return 'review';
+  if (
+    body.includes("isn't a direction we're") ||
+    body.includes('Conflicts with `direction.md') ||
+    body.includes('direction.md §')
+  )
+    return 'decline';
+  if (
+    body.includes('Could you split this') ||
+    body.includes('Could you two coordinate') ||
+    /split into \d+ focused PRs/.test(body)
+  )
+    return 'needs_split';
+  return null;
+}
+
+function extractPrNumber(issueUrl: string | undefined): string | null {
+  if (!issueUrl) return null;
+  const m = issueUrl.match(/\/(\d+)$/);
+  return m ? m[1] : null;
+}
+
+const inferred: Record<string, ReviewedEntry> = {};
+let scanned = 0;
+let mineMatching = 0;
+
+for (const c of allComments) {
+  scanned++;
+  const author = c.user?.login;
+  if (!author || author.toLowerCase() !== ghHandle.toLowerCase()) continue;
+  const body = c.body ?? '';
+  const verdict = inferVerdict(body);
+  if (!verdict) continue;
+  const prNumber = extractPrNumber(c.issue_url);
+  if (!prNumber) continue;
+  const createdAt = c.created_at ?? '';
+  // Latest comment per PR wins (newer reviews supersede older).
+  if (!inferred[prNumber] || createdAt > inferred[prNumber].reviewed_at) {
+    inferred[prNumber] = {
+      reviewed_at: createdAt,
+      gate_verdict: verdict,
+      source: 'backfill',
+    };
+  }
+  mineMatching++;
+}
+
+console.log(
+  `Scanned ${scanned} comments. ${mineMatching} authored by ${ghHandle} matched a review/decline pattern. Unique PRs: ${Object.keys(inferred).length}.`,
+);
+
+// ── Merge with existing reviewed-prs.json ──
+// Existing entries (especially those without source: 'backfill', i.e. written
+// by the workflow's record-review node) take precedence — they're more
+// authoritative than pattern-matched bodies.
+if (!existsSync(baseDir)) mkdirSync(baseDir, { recursive: true });
+const outPath = resolve(baseDir, 'reviewed-prs.json');
+let existing: Record<string, ReviewedEntry> = {};
+if (existsSync(outPath)) {
+  try {
+    existing = JSON.parse(readFileSync(outPath, 'utf8'));
+  } catch {
+    existing = {};
+  }
+}
+
+let added = 0;
+let skipped = 0;
+for (const [num, entry] of Object.entries(inferred)) {
+  if (existing[num]) {
+    skipped++;
+    continue;
+  }
+  existing[num] = entry;
+  added++;
+}
+
+writeFileSync(outPath, JSON.stringify(existing, null, 2) + '\n');
+
+console.log(
+  `Backfilled ${added} new entries (skipped ${skipped} that already had workflow-recorded entries). Total tracked: ${Object.keys(existing).length}.`,
+);
+console.log(`Written to: ${outPath}`);

--- a/.archon/scripts/maintainer-standup-read-context.ts
+++ b/.archon/scripts/maintainer-standup-read-context.ts
@@ -55,6 +55,20 @@ const deadlineDate = new Date(todayDate);
 deadlineDate.setDate(deadlineDate.getDate() + 3);
 const deadline_3d = deadlineDate.toLocaleDateString('sv-SE');
 
+// Cross-workflow memory: which PRs has maintainer-review-pr already triaged?
+// Written by maintainer-review-pr's `record-review` node; surfaced here so
+// the standup synthesizer can mark "✓ reviewed Nd ago" next to P1-P4 entries
+// and flag staleness when the contributor pushes after a prior review.
+const reviewedPrsPath = resolve(baseDir, 'reviewed-prs.json');
+let reviewedPrs: unknown = {};
+if (existsSync(reviewedPrsPath)) {
+  try {
+    reviewedPrs = JSON.parse(readFileSync(reviewedPrsPath, 'utf8'));
+  } catch {
+    reviewedPrs = {};
+  }
+}
+
 console.log(
   JSON.stringify({
     direction,
@@ -63,5 +77,6 @@ console.log(
     recent_briefs: recentBriefs,
     today,
     deadline_3d,
+    reviewed_prs: reviewedPrs,
   }),
 );

--- a/.archon/workflows/maintainer/maintainer-review-pr.yaml
+++ b/.archon/workflows/maintainer/maintainer-review-pr.yaml
@@ -323,11 +323,61 @@ nodes:
     when: "$gate.output.verdict == 'unclear'"
 
   # ═══════════════════════════════════════════════════════════════
-  # PHASE 5: FINAL REPORT (whichever branch ran)
+  # PHASE 5: RECORD REVIEW IN SHARED STATE
+  # ═══════════════════════════════════════════════════════════════
+
+  # Append this run's PR number + verdict + timestamp to
+  # .archon/maintainer-standup/reviewed-prs.json so the morning standup
+  # brief can mark "✓ reviewed Nd ago" next to PRs that have already
+  # been triaged. Cross-workflow memory; gitignored, per-maintainer.
+  #
+  # Runs deterministically (no AI) after whichever branch fired. Inline
+  # script for the same reason persist is inline in maintainer-standup:
+  # JSON is valid JS expression syntax so $gate.output substitutes
+  # directly without a String.raw template literal. Records the gate
+  # verdict (review / decline / needs_split / unclear), not the
+  # synthesis verdict — keeps the contract narrow.
+  - id: record-review
+    runtime: bun
+    timeout: 10000
+    depends_on: [post-review, post-decline, approve-unclear]
+    trigger_rule: one_success
+    script: |
+      import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+      import { resolve } from 'node:path';
+
+      const gate = $gate.output;
+
+      const baseDir = resolve(process.cwd(), '.archon/maintainer-standup');
+      if (!existsSync(baseDir)) mkdirSync(baseDir, { recursive: true });
+
+      const prPath = resolve(process.cwd(), '$ARTIFACTS_DIR/.pr-number');
+      const prNumber = readFileSync(prPath, 'utf8').trim();
+
+      const reviewedPath = resolve(baseDir, 'reviewed-prs.json');
+      let reviewed = {};
+      if (existsSync(reviewedPath)) {
+        try {
+          reviewed = JSON.parse(readFileSync(reviewedPath, 'utf8'));
+        } catch {
+          reviewed = {};
+        }
+      }
+
+      reviewed[prNumber] = {
+        reviewed_at: new Date().toISOString(),
+        gate_verdict: gate.verdict,
+        run_id: '$WORKFLOW_ID',
+      };
+
+      writeFileSync(reviewedPath, JSON.stringify(reviewed, null, 2) + '\n');
+      console.log(`Recorded review of PR #${prNumber} (gate: ${gate.verdict})`);
+
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 6: FINAL REPORT (whichever branch ran)
   # ═══════════════════════════════════════════════════════════════
 
   - id: report
     command: maintainer-review-report
-    depends_on: [post-review, post-decline, approve-unclear]
-    trigger_rule: one_success
+    depends_on: [record-review]
     context: fresh

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ e2e-screenshots/
 .archon/maintainer-standup/profile.md
 .archon/maintainer-standup/state.json
 .archon/maintainer-standup/briefs/
+.archon/maintainer-standup/reviewed-prs.json
 
 # Agent artifacts (generated, local only)
 .agents/


### PR DESCRIPTION
## Summary

- **Problem**: maintainer-standup briefs had no awareness of which PRs had already been triaged via `maintainer-review-pr`. Reviewed PRs kept re-appearing in P1-P4 with no marker, leading the maintainer to re-skim the same items each morning.
- **Why it matters**: when a PR is reviewed and the contributor pushes new commits in response, the maintainer needs to know: (a) I already weighed in, (b) but the diff has moved since — re-review may be warranted. Today the brief gives neither signal.
- **What changed**: new gitignored state file `.archon/maintainer-standup/reviewed-prs.json` shared between the two workflows. Writer node in `maintainer-review-pr.yaml` records each run; standup's read-context loads it; standup synthesizer prompt surfaces "✓ reviewed Nd ago" markers in P1-P4 with a staleness flag when the contributor pushed since.
- **What did NOT change (scope boundary)**: no engine code, no new YAML schema, no schema migrations. Pure `.archon/` user content + a small inline persist node + a one-shot backfill script. Other workflows untouched.

## Three pieces

### 1. Writer — `maintainer-review-pr.yaml` `record-review` node

Inline bun script that runs after whichever branch fires (`post-review` / `post-decline` / `approve-unclear`) with `trigger_rule: one_success`. Reads `$gate.output.verdict`, the PR number from `$ARTIFACTS_DIR/.pr-number`, and the workflow run ID; upserts an entry into `reviewed-prs.json`. The `report` node's dependency moved from `[post-review, post-decline, approve-unclear]` to `[record-review]` so the state-write happens before the run terminates.

### 2. Reader — `maintainer-standup-read-context.ts`

Loads `reviewed-prs.json` into a new `reviewed_prs` field on the standup gather output. Same pattern as `prior_state` and `recent_briefs`. Empty object on first run / missing file.

### 3. Surface — `maintainer-standup.md` Phase 2h

New rule appended to Phase 2 instructing the synthesizer to mark PRs:

- Reviewed (review branch) → `✓ reviewed Nd ago`
- Declined (decline / needs_split) → `✓ declined Nd ago`
- Triaged inconclusively → `✓ triaged Nd ago (unclear)`

And a **staleness check**: compare `reviewed_at` to the PR's `updatedAt`; if the contributor pushed since, append `⚠ contributor pushed since` so the maintainer knows the prior review may need re-running.

## Plus: one-shot backfill script

`.archon/scripts/maintainer-standup-backfill-reviews.ts` scans the maintainer's GitHub comments in the last 7 days, pattern-matches `## Review Summary` / direction-clause-citation / split-up wording, and populates `reviewed-prs.json` from history. Idempotent — workflow-recorded entries take precedence over backfilled ones (the writer node is authoritative; pattern-matching is a best-effort historical reconstruction). Uses 64MB `maxBuffer` on the gh exec because `--paginate` over 7 days easily exceeds Node's default 1MB.

## Validation Evidence (required)

```bash
archon validate workflows maintainer-review-pr   # → ok
archon validate workflows maintainer-standup     # → ok
bun run format:check                             # → clean
bun run lint                                     # → clean

# Backfill verified end-to-end:
$ bun run .archon/scripts/maintainer-standup-backfill-reviews.ts
Scanning wirasm's comments on coleam00/Archon since 2026-04-21T...
Scanned 363 comments. 18 authored by wirasm matched a review/decline pattern.
Unique PRs: 17.
Backfilled 17 new entries (skipped 0 that already had workflow-recorded entries).
Total tracked: 17.

$ jq '. | to_entries | map({pr: .key, verdict: .value.gate_verdict})' \
  .archon/maintainer-standup/reviewed-prs.json
[
  {"pr":"1426","verdict":"review"},
  {"pr":"1420","verdict":"review"},
  {"pr":"1414","verdict":"review"},
  ...
]
```

17 PRs populated — exactly matches the count from yesterday's review session (14 reviews + 1 decline + 2 retries = 17 unique PRs). Spot-checked the entries against the actual workflow runs.

## Security Impact (required)

- **New permissions/capabilities?** No.
- **New external network calls?** Backfill script only — `gh api repos/.../issues/comments`. Same scope as existing standup gather; uses the same `gh` auth.
- **Secrets/tokens handling?** Unchanged.
- **File system access?** Writes one new file under `.archon/maintainer-standup/` (gitignored, run-scoped path).

## Compatibility / Migration

- **Backward compatible?** Yes. `reviewed-prs.json` is purely additive; absent file → empty object → no markers in the brief (current behavior). Existing maintainer-review-pr runs continue to work; the new `record-review` node only adds a state-write. The `report` node's dependency change (`[post-review, post-decline, approve-unclear]` → `[record-review]`) is internal — the report content is unchanged.
- **Config/env changes?** No.
- **Database migration?** No.
- **One-time backfill** — opt-in. Run `bun .archon/scripts/maintainer-standup-backfill-reviews.ts` to seed the file from the last 7 days of comments. Without it, the file populates from new runs going forward.

## Human Verification (required)

- **Verified scenarios**:
  - Backfill on real comments → 17 PRs correctly populated, verdicts inferred correctly (15 review, 1 decline, 1 needs_split based on the actual content of yesterday's posted comments).
  - First-run / missing file behavior — `read-context.ts` returns `reviewed_prs: {}`; standup brief shows no markers (correct: no prior runs to surface).
  - Workflow YAML validation — both `maintainer-review-pr` and `maintainer-standup` validate cleanly from the subfolder.
  - Idempotency — running backfill twice doesn't duplicate entries (existing keys are preserved when source: 'workflow', and pattern-matched entries upsert latest-wins).
- **Edge cases checked**:
  - Repo without an `origin` remote — backfill script exits with a clear error before any work.
  - 7-day comment volume on an active repo — confirmed 363 comments parse cleanly with 64MB maxBuffer; default 1MB would have ENOBUFS'd, which is why the explicit cap was added.
  - Body-text patterns that overlap (`Conflicts with direction.md` could appear in non-decline contexts) — pattern-match is best-effort by design; workflow-recorded entries supersede backfilled ones via `existing[num]` check on merge.
- **What was not verified**:
  - The synthesizer actually rendering the markers in tomorrow's brief (need a real morning run with `reviewed_prs` populated). Today's standup already ran before this PR was authored, so the next run will be the first to read the new field.
  - Staleness signal end-to-end — depends on the synthesizer comparing two timestamps; the prompt instructions are explicit but the LLM may render imperfectly on first runs.

## Side Effects / Blast Radius (required)

- **Affected subsystems**: `maintainer-review-pr` (new node + dependency reorder), `maintainer-standup` (new field in gather + new rendering rule). No engine code touched.
- **Potential unintended effects**:
  - The `report` node now depends on `record-review` instead of the three branch-end nodes directly. If `record-review` fails (file write error, JSON parse on corrupt existing file), `report` would skip. Mitigation: the writer try/catches the JSON parse and falls back to `reviewed = {}`; the only realistic failure is a permission error on the .archon dir, which would be diagnosable from the bash node's stderr.
  - Backfill script is run-once but technically re-runnable. Idempotent merge logic means re-runs don't duplicate, only update timestamps for backfilled entries.
- **Guardrails**: workflow validation runs in CI; the new state file is gitignored, so it can't accidentally land in commits.

## Rollback Plan (required)

- **Fast rollback**: `git revert <merge-sha>` — single commit, 5 files. The new state file remains on disk locally but goes unused (no reader, no writer); cleanup is `rm .archon/maintainer-standup/reviewed-prs.json` if the user wants tidy disk.
- **Feature flags**: none.
- **Observable failure symptoms**: workflow validation failure (CI catches), or `record-review` failing → `report` skipped → workflow status `failed`. Either is loud and resumable.

## Risks and Mitigations

- **Risk**: `record-review` runs after the public-facing `gh pr comment`. If recording fails after the comment posted, the comment is on GitHub but the standup forgets it ever happened — same morning re-skim problem the feature was meant to solve.
  - **Mitigation**: writer uses defensive parsing (try/catch on existing file read); only realistic failure is a write-permission error on `.archon/maintainer-standup/`, which is rare. Future improvement: also stash a copy in `$ARTIFACTS_DIR/` so it can be replayed if the canonical file is unwritable.
- **Risk**: backfill pattern-matching produces false positives — a comment containing "## Review Summary" that wasn't actually a maintainer review (e.g., quoted in a thread).
  - **Mitigation**: filter is pinned to `author == ghHandle`. False positives only possible when the maintainer themselves authored a non-review comment containing the marker text — unlikely but possible. Mitigation if it surfaces: tighten the regex to also require the maintainer-review-pr footer line `Reviewed via maintainer-review-pr workflow`.
- **Risk**: staleness signal is subjective. "Pushed since" includes label changes / draft toggles, not just commits — could produce false alarms.
  - **Mitigation**: synthesizer prompt instructs to flag staleness only when the gap is "real and meaningful," letting the LLM use judgment. If false alarms become a pattern, easy to tighten by checking only the `headRefOid` or commit-only push events via a more specific gh query.

## Linked Issue

- Closes # (no associated issue — implementation came directly from this morning's standup conversation)
- Related: parent #1428 (maintainer-standup), #1430 (maintainer-review-pr), #1457 (replies-since-last-run feature, sibling cross-workflow signal)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced PR review tracking to persist review history with timestamps and verdicts
  * Added automatic detection to flag when contributors push changes after a PR review
  * Introduced backfill capability to recover historical review data from recent comments

* **Chores**
  * Updated configuration to exclude internal review metadata from version control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->