### PR TITLE
fix(claude): stop passing --no-env-file to native binary in dev mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`$LOOP_PREV_OUTPUT` workflow variable (loop nodes only)** — exposes the previous iteration's cleaned output (after `<promise>` tag stripping) to the current iteration's prompt. Empty on the first iteration and on the first iteration after resuming from an interactive approval gate. Enables `fresh_context: true` loops to reference what the prior pass said or did without carrying full session history. (#1367)
 
+### Fixed
+
+- **Claude provider crashed in dev mode with `error: unknown option '--no-env-file'`.** The Claude Agent SDK switched from shipping `cli.js` to per-platform native binaries (via optional deps) in the 0.2.x series. Archon's `shouldPassNoEnvFile` predicate kept emitting the Bun-only `--no-env-file` flag in dev mode (when the SDK resolves its bundled binary), which the native binary rejects. Tightened the predicate to only emit the flag for explicitly-configured Bun-runnable JS entry points (`.js`/`.mjs`/`.cjs`). Target-repo `.env` isolation is unchanged — `stripCwdEnv()` at process boot remains the primary guard, and the native Claude binary does not auto-load `.env` from its cwd. (#1461)
+
 ## [0.3.9] - 2026-04-22
 
 First release with working compiled binaries since v0.3.6. Both v0.3.7 and v0.3.8 were tagged but neither shipped release assets — v0.3.7 was blocked by two genuine binary-runtime bugs (Pi SDK's module-init crash + Bun `--bytecode` producing broken output), and v0.3.8 was blocked by an unrelated CI smoke-test regression where `release.yml`'s Claude resolver test required an `origin` remote that the fresh `git init` test repo didn't have. Both superseded tags remain for history; their GitHub Releases were deleted at the time of tagging so `releases/latest` fell back to v0.3.6 throughout, keeping `install.sh` and Homebrew safe. v0.3.9 is what users actually install.

--- a/packages/docs-web/src/content/docs/reference/security.md
+++ b/packages/docs-web/src/content/docs/reference/security.md
@@ -128,8 +128,8 @@ The GitHub and Gitea adapters verify webhook signatures to ensure payloads origi
 
 Archon prevents target repo `.env` from leaking into subprocesses through structural protection:
 
-1. **Boot cleanup:** `stripCwdEnv()` removes Bun-auto-loaded CWD `.env` keys from `process.env` before any application code runs.
-2. **Claude Code subprocess:** `executableArgs: ['--no-env-file']` prevents Bun from auto-loading `.env` in the Claude Code subprocess CWD.
+1. **Boot cleanup:** `stripCwdEnv()` removes Bun-auto-loaded CWD `.env` keys from `process.env` before any application code runs. **This is the primary guard** — every subprocess Archon spawns inherits from the already-cleaned `process.env`.
+2. **Claude Code subprocess:** when the SDK is configured to spawn a Bun-runnable JS entry point (legacy npm-installed `cli.js`/`cli.mjs`/`cli.cjs`), Archon also passes `executableArgs: ['--no-env-file']` so Bun skips its env autoload inside the spawned process. SDK 0.2.x ships per-platform native binaries instead — those don't auto-load `.env` from cwd, so the flag is unnecessary and is omitted.
 3. **Bun script nodes:** `bun --no-env-file` prevents script node subprocesses from loading target repo `.env`.
 4. **Bash nodes:** Not affected — bash does not auto-load `.env` files.
 

--- a/packages/providers/src/claude/binary-resolver.ts
+++ b/packages/providers/src/claude/binary-resolver.ts
@@ -53,9 +53,12 @@ const INSTALL_INSTRUCTIONS =
   'See: https://archon.diy/docs/reference/configuration#claude';
 
 /**
- * Resolve the path to the Claude Code SDK's cli.js.
+ * Resolve the path to the Claude Code executable (native binary in SDK 0.2.x;
+ * legacy `cli.js` is still accepted for operators pinned to npm-installed
+ * SDKs that ship a JS entry point).
  *
- * In dev mode: returns undefined (let SDK resolve via node_modules).
+ * In dev mode: returns undefined (let SDK resolve from its bundled per-platform
+ * native binary in `@anthropic-ai/claude-agent-sdk-<platform>`).
  * In binary mode: resolves from env/config, or throws with install instructions.
  */
 export async function resolveClaudeBinaryPath(

--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -18,6 +18,7 @@ mock.module('@anthropic-ai/claude-agent-sdk', () => ({
 
 import { ClaudeProvider, shouldPassNoEnvFile } from './provider';
 import * as claudeModule from './provider';
+import * as binaryResolver from './binary-resolver';
 
 describe('shouldPassNoEnvFile', () => {
   test('returns false when cliPath is undefined (dev mode — SDK 0.2.x resolves a native binary)', () => {
@@ -33,6 +34,19 @@ describe('shouldPassNoEnvFile', () => {
     expect(
       shouldPassNoEnvFile('/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js')
     ).toBe(true);
+  });
+
+  test('returns true for .mjs and .cjs paths (also Bun-runnable JS entry points)', () => {
+    expect(shouldPassNoEnvFile('/path/to/cli.mjs')).toBe(true);
+    expect(shouldPassNoEnvFile('/path/to/cli.cjs')).toBe(true);
+  });
+
+  test('returns false for non-Bun-runnable JS-adjacent extensions', () => {
+    // `.ts`/`.tsx`/`.jsx` are deliberately excluded — the SDK never shipped
+    // those as entry points, so accepting them would only widen misconfiguration.
+    expect(shouldPassNoEnvFile('/path/to/cli.ts')).toBe(false);
+    expect(shouldPassNoEnvFile('/path/to/cli.tsx')).toBe(false);
+    expect(shouldPassNoEnvFile('/path/to/cli.jsx')).toBe(false);
   });
 
   test('returns false for a native binary path (curl installer, SDK execs directly)', () => {
@@ -526,6 +540,37 @@ describe('ClaudeProvider', () => {
       // Cleanup
       if (originalKey !== undefined) process.env.CUSTOM_USER_KEY = originalKey;
       else delete process.env.CUSTOM_USER_KEY;
+    });
+
+    test('passes executableArgs: [--no-env-file] when cliPath ends in a Bun-runnable JS extension', async () => {
+      // Belt-and-suspenders integration check: the dev-mode path is exercised
+      // in the test above (executableArgs: undefined). This test exercises the
+      // legacy explicit-cli.js path through the real buildBaseClaudeOptions
+      // codepath, so a regression in the conditional spread would be caught.
+      const spy = spyOn(binaryResolver, 'resolveClaudeBinaryPath').mockResolvedValue(
+        '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js'
+      );
+
+      mockQuery.mockImplementation(async function* () {
+        // empty
+      });
+
+      for await (const _ of client.sendQuery('test', '/workspace')) {
+        // consume
+      }
+
+      const callArgs = mockQuery.mock.calls[0][0] as {
+        options: {
+          executableArgs?: string[];
+          pathToClaudeCodeExecutable?: string;
+        };
+      };
+      expect(callArgs.options.executableArgs).toEqual(['--no-env-file']);
+      expect(callArgs.options.pathToClaudeCodeExecutable).toBe(
+        '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js'
+      );
+
+      spy.mockRestore();
     });
 
     test('classifies exit code errors as crash and retries up to 3 times', async () => {

--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -20,11 +20,16 @@ import { ClaudeProvider, shouldPassNoEnvFile } from './provider';
 import * as claudeModule from './provider';
 
 describe('shouldPassNoEnvFile', () => {
-  test('returns true when cliPath is undefined (dev mode — SDK spawns cli.js via Bun)', () => {
-    expect(shouldPassNoEnvFile(undefined)).toBe(true);
+  test('returns false when cliPath is undefined (dev mode — SDK 0.2.x resolves a native binary)', () => {
+    // Pre-0.2.x the SDK shipped cli.js and dev mode = JS. Since 0.2.x the
+    // SDK ships per-platform native binaries via optional deps. The flag
+    // (a Bun runtime option) is meaningless to native binaries and gets
+    // rejected as `error: unknown option '--no-env-file'`. CWD .env leak
+    // protection comes from stripCwdEnv() at entry, not from this flag.
+    expect(shouldPassNoEnvFile(undefined)).toBe(false);
   });
 
-  test('returns true for an explicit cli.js path (npm-installed, SDK spawns via Bun/Node)', () => {
+  test('returns true for an explicit cli.js path (legacy npm-installed cli.js, SDK spawns via Bun)', () => {
     expect(
       shouldPassNoEnvFile('/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js')
     ).toBe(true);
@@ -505,8 +510,10 @@ describe('ClaudeProvider', () => {
       const callArgs = mockQuery.mock.calls[0][0] as {
         options: { env: NodeJS.ProcessEnv; executableArgs?: string[] };
       };
-      // --no-env-file prevents Bun from auto-loading .env in subprocess CWD
-      expect(callArgs.options.executableArgs).toEqual(['--no-env-file']);
+      // executableArgs is omitted when cliPath is undefined (dev mode, SDK
+      // 0.2.x resolves a native binary). CWD .env leak protection comes
+      // from stripCwdEnv() at entry, not from the --no-env-file flag.
+      expect(callArgs.options.executableArgs).toBeUndefined();
       expect(callArgs.options.env.CUSTOM_USER_KEY).toBe('user-trusted-value');
       // Windows uses "Path" casing in spread objects and USERPROFILE instead of HOME
       const envPath = callArgs.options.env.PATH ?? callArgs.options.env.Path;

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -538,28 +538,33 @@ interface ToolResultEntry {
 /**
  * Decide whether the Claude subprocess should be spawned with `--no-env-file`.
  *
- * `--no-env-file` is a Bun flag that prevents auto-loading `.env` from the
- * target repo cwd into the spawned process. It only applies when the SDK
- * spawns the executable via Bun/Node — i.e. when the executable is a `.js`
- * file (dev mode resolves cli.js, npm-installed resolves cli.js). For a
- * native Claude Code binary (curl/PowerShell installer at
- * `~/.local/bin/claude`), the SDK execs the binary directly and the flag
- * gets passed to the native binary, which rejects unknown options and
- * exits code 1.
+ * `--no-env-file` is a Bun flag (consumed by the Bun runtime, not by Claude
+ * Code itself) that prevents auto-loading `.env` from the target repo cwd
+ * into the spawned process. It only does anything when the SDK spawns a
+ * `.js` file via `bun cli.js …` — Bun parses the flag and skips its env
+ * autoload. For native Claude Code binaries the flag is meaningless and,
+ * worse, gets handed to the binary which rejects unknown options.
  *
- * Returning `false` for native binaries is verified safe — the native
- * binary does not auto-load `.env` from CWD (probed end-to-end with
- * sentinel `.env` and `.env.local` in the workflow CWD; both arrived
- * UNSET in the spawned bash tool). The first-layer protection —
- * `stripCwdEnv()` in `@archon/paths` (#1067) — removes CWD env keys from
- * the parent process before spawn, so the subprocess inherits a clean
- * env regardless of executable type.
+ * The dev-mode `cliPath === undefined` path used to imply "JS executable"
+ * because the SDK shipped `cli.js` inside its package. SDK 0.2.x switched
+ * to per-platform native binaries (e.g. `@anthropic-ai/claude-agent-sdk-darwin-arm64/claude`),
+ * so dev mode now resolves to a native executable and the historical
+ * `undefined → true` heuristic is unsafe. Only return `true` when we have
+ * an explicit `.js` path — i.e. when the operator pointed Archon at a
+ * legacy Bun/Node-runnable cli.js. Otherwise return `false`.
+ *
+ * Safety: target-repo `.env` leaks are prevented by `stripCwdEnv()` in
+ * `@archon/paths` (#1067), which deletes CWD `.env` keys from
+ * `process.env` at every Archon entry point before any subprocess is
+ * spawned. The native Claude binary does not auto-load `.env` from its
+ * cwd either (verified end-to-end with sentinel keys). `--no-env-file`
+ * was belt-and-suspenders for the JS-via-Bun case only.
  *
  * Exported so the decision can be unit-tested without needing to mock
  * `BUNDLED_IS_BINARY` or run the full provider sendQuery pathway.
  */
 export function shouldPassNoEnvFile(cliPath: string | undefined): boolean {
-  return cliPath === undefined || cliPath.endsWith('.js');
+  return cliPath?.endsWith('.js') ?? false;
 }
 
 /**

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -15,8 +15,12 @@
  * Binary resolution:
  * - In compiled binaries, `pathToClaudeCodeExecutable` is resolved from
  *   `CLAUDE_BIN_PATH` env or `assistants.claude.claudeBinaryPath` config;
- *   see ./binary-resolver.ts. In dev mode the SDK resolves cli.js itself
- *   from node_modules.
+ *   see ./binary-resolver.ts. In dev mode the resolver returns undefined
+ *   and the SDK picks its bundled per-platform native binary (Mach-O/ELF/PE
+ *   from `@anthropic-ai/claude-agent-sdk-<platform>` optional dep). Pre-0.2.x
+ *   SDKs shipped `cli.js` in the package and dev mode resolved that JS file;
+ *   the SDK switched to native binaries in the 0.2.x series. See
+ *   `shouldPassNoEnvFile` for the implications on the `--no-env-file` flag.
  */
 import {
   query,
@@ -535,23 +539,29 @@ interface ToolResultEntry {
   toolCallId?: string;
 }
 
+/** Bun-runnable JS extensions. `.ts`/`.tsx`/`.jsx` are excluded — the SDK has
+ * never shipped those as entry points, so accepting them would only widen the
+ * surface for misconfiguration. */
+const BUN_JS_EXTENSIONS = ['.js', '.mjs', '.cjs'] as const;
+
 /**
  * Decide whether the Claude subprocess should be spawned with `--no-env-file`.
  *
  * `--no-env-file` is a Bun flag (consumed by the Bun runtime, not by Claude
  * Code itself) that prevents auto-loading `.env` from the target repo cwd
  * into the spawned process. It only does anything when the SDK spawns a
- * `.js` file via `bun cli.js …` — Bun parses the flag and skips its env
- * autoload. For native Claude Code binaries the flag is meaningless and,
- * worse, gets handed to the binary which rejects unknown options.
+ * Bun-runnable JS file via `bun cli.js …` — Bun parses the flag and skips
+ * its env autoload. For native Claude Code binaries the flag is meaningless
+ * and, worse, gets handed to the binary which rejects unknown options.
  *
  * The dev-mode `cliPath === undefined` path used to imply "JS executable"
  * because the SDK shipped `cli.js` inside its package. SDK 0.2.x switched
  * to per-platform native binaries (e.g. `@anthropic-ai/claude-agent-sdk-darwin-arm64/claude`),
  * so dev mode now resolves to a native executable and the historical
  * `undefined → true` heuristic is unsafe. Only return `true` when we have
- * an explicit `.js` path — i.e. when the operator pointed Archon at a
- * legacy Bun/Node-runnable cli.js. Otherwise return `false`.
+ * an explicit Bun-runnable JS path (`.js`/`.mjs`/`.cjs`) — i.e. when the
+ * operator pointed Archon at a legacy Bun/Node-runnable cli script.
+ * Otherwise return `false`.
  *
  * Safety: target-repo `.env` leaks are prevented by `stripCwdEnv()` in
  * `@archon/paths` (#1067), which deletes CWD `.env` keys from
@@ -564,7 +574,8 @@ interface ToolResultEntry {
  * `BUNDLED_IS_BINARY` or run the full provider sendQuery pathway.
  */
 export function shouldPassNoEnvFile(cliPath: string | undefined): boolean {
-  return cliPath?.endsWith('.js') ?? false;
+  if (cliPath === undefined) return false;
+  return BUN_JS_EXTENSIONS.some(ext => cliPath.endsWith(ext));
 }
 
 /**
@@ -582,10 +593,7 @@ function buildBaseClaudeOptions(
   cliPath: string | undefined
 ): Options {
   const isJsExecutable = shouldPassNoEnvFile(cliPath);
-  getLog().debug(
-    { cliPath: cliPath ?? null, isJsExecutable, passesNoEnvFile: isJsExecutable },
-    'claude.subprocess_env_file_flag'
-  );
+  getLog().debug({ cliPath: cliPath ?? null, isJsExecutable }, 'claude.subprocess_env_file_flag');
 
   return {
     cwd,


### PR DESCRIPTION
## Summary

- **Problem:** Every Claude SDK call from a dev-mode Archon (e.g. \`bun run cli\`, \`bun run dev\`) crashes the SDK subprocess with \`error: unknown option '--no-env-file'\`. Surfaced while smoke-testing #1460 — \`e2e-claude-smoke\` failed before the redesign branch could be validated against Claude.
- **Why it matters:** Dev mode is unusable for any Claude workflow today. CI smoke tests, the title-generator background service, and direct \`/workflow run\` invocations all hit it.
- **What changed:** Tighten \`shouldPassNoEnvFile\` so it only returns true when the resolved executable path explicitly ends in \`.js\`. The historical \`cliPath === undefined → true\` heuristic was based on the SDK shipping \`cli.js\` inside the package; SDK 0.2.x switched to per-platform native binaries (e.g. \`@anthropic-ai/claude-agent-sdk-darwin-arm64/claude\`) and dev mode now resolves to one of those. Native binaries reject \`--no-env-file\`.
- **What did NOT change:** CWD \`.env\` leak protection is unaffected. \`stripCwdEnv()\` in \`@archon/paths\` is the actual guard — it deletes Bun-auto-loaded \`.env\`/\`.env.local\`/\`.env.development\`/\`.env.production\` keys from \`process.env\` at every Archon entry point before any subprocess is spawned. The native Claude binary doesn't auto-load \`.env\` from its cwd either (verified end-to-end with sentinel keys). \`--no-env-file\` was belt-and-suspenders for the JS-via-Bun case only.

## UX Journey

### Before

\`\`\`
$ bun run cli workflow run e2e-claude-smoke --no-worktree "smoke"
[simple] Started
{...,"stderr":"error: unknown option '--no-env-file'"...,"msg":"subprocess_error"}
{...,"err":...,"errorClass":"crash","attempt":3,"maxRetries":3,"msg":"query_error"}
[simple] Failed: Claude Code crash: ... (stderr: error: unknown option '--no-env-file')
❌ DAG workflow 'e2e-claude-smoke' completed with no successful nodes.
\`\`\`

### After

\`\`\`
$ bun run cli workflow run e2e-claude-smoke --no-worktree "smoke"
[archon] stripped 23 keys from /Users/rasmus/Projects/cole/Archon (.env, .env.local)
[simple] Started
4
[simple] Completed (2.4s)
[assert] Started
[assert] Completed (6ms)
PASS: simple='4', no sentinel leak

Workflow completed successfully.
\`\`\`

## Architecture Diagram

No architectural change — single-function predicate fix in the Claude provider. The two-layer leak-defense model is unchanged:

\`\`\`
                                      ┌────────────────────────────────────┐
                                      │ Layer 1 — Archon process boot      │
  bun run cli  ────────────────▶      │ stripCwdEnv() deletes CWD .env     │
                                      │ keys from process.env              │
                                      └─────────────────┬──────────────────┘
                                                        │
                                                        ▼
                                      ┌────────────────────────────────────┐
                                      │ Layer 2 — subprocess spawn         │
                                      │ (was: --no-env-file for Bun-run    │
                                      │  cli.js; SDK no longer ships JS,   │
                                      │  so layer 2 is a no-op for dev)    │
                                      └─────────────────┬──────────────────┘
                                                        │
                                                        ▼
                                      ┌────────────────────────────────────┐
                                      │ Claude Code subprocess             │
                                      │ inherits already-cleaned env       │
                                      └────────────────────────────────────┘
\`\`\`

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| \`shouldPassNoEnvFile\` | SDK \`executableArgs\` | unchanged | only the predicate body changed |
| \`stripCwdEnv()\` | Archon \`process.env\` | unchanged | still the actual leak guard |

## Label Snapshot

- Risk: \`risk: low\`
- Size: \`size: XS\`
- Scope: \`providers\` (claude)
- Module: \`providers:claude\`

## Change Metadata

- Change type: \`bug\`
- Primary scope: \`providers\` (claude)

## Linked Issue

- Closes #
- Related: #1460 (the SDK bump that surfaced this regression)

## Validation Evidence (required)

\`\`\`bash
bun run validate
# EXIT=0
\`\`\`

All five gates pass — \`check:bundled\`, \`type-check\` (10 packages), \`lint --max-warnings 0\`, \`format:check\`, \`test\` (every package, every file \`0 fail\`).

End-to-end probe:

1. Added a unique sentinel \`ARCHON_LEAK_SENTINEL_\$\$=...\` to Archon's \`.env\`.
2. Extended \`e2e-claude-smoke\`'s bash assert node to grep \`env\` for any \`ARCHON_LEAK_SENTINEL_\` key in the spawned subprocess.
3. Ran \`bun packages/cli/src/cli.ts workflow run e2e-claude-smoke --no-worktree\`.
4. stderr: \`[archon] stripped 23 keys from /Users/rasmus/Projects/cole/Archon (.env, .env.local) to prevent target repo env from leaking into Archon processes\`.
5. Bash node: \`PASS: simple='4', no sentinel leak\`.
6. Workflow completes cleanly with no \`unknown option\` rejection.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No** (the leak guard is unchanged; this commit just stops emitting an unsupported flag).
- File system access scope changed? **No**

## Compatibility / Migration

- Backward compatible? **Yes** — existing configs that point at native installer binaries already had \`shouldPassNoEnvFile === false\` and continue to behave identically. Configs that explicitly point at a \`cli.js\` (legacy npm-installed SDK) still get \`--no-env-file\` (the predicate accepts \`.js\` paths). The only behavioral change is for dev mode where \`cliPath\` is \`undefined\`, which now correctly omits the flag.
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

- **Verified scenarios:** Reproduced the SDK rejection by invoking the bundled native binary directly with \`--no-env-file --print "hi"\` — confirmed \`error: unknown option '--no-env-file'\`. Ran the e2e-claude-smoke after the fix; \`[simple] Completed (2.4s)\` and the workflow exits successfully. Title-generator background service also went from \`title.generate_failed\` → \`title.generate_completed\` in the same run.
- **Edge cases checked:** Provider tests for the predicate cover undefined, explicit cli.js, native binary paths (Linux/macOS/Windows/Homebrew symlink), and suffix edge cases (\`cli.json\`, \`cli.js.bak\`).
- **What was not verified:** Behavior on a host that explicitly configures \`claudeBinaryPath: /path/to/cli.js\` (legacy npm-installed SDK with the JS entry point) — the predicate still returns true for those, but I don't have a JS-cli installation to manually exercise.

## Side Effects / Blast Radius (required)

- **Affected subsystems/workflows:** Any code path that calls \`ClaudeProvider.sendQuery\` in dev mode (\`bun run cli\`, \`bun run dev\`, every workflow with a Claude node, the title-generator background service).
- **Potential unintended effects:** Configurations where users had wrapped Bun/Node around a JS Claude entry point may have been relying on the prior \`undefined → true\` heuristic. With this change, those configs need an explicit \`claudeBinaryPath: /path/to/cli.js\` so the predicate matches the \`.js\` suffix. Stop-gap is one config line; the SDK no longer ships such an entry point in its own package, so this combination is rare.
- **Guardrails/monitoring for early detection:** Existing \`claude.subprocess_env_file_flag\` debug log records the decision per request; \`subprocess_error\` log fires on rejection.

## Rollback Plan (required)

- **Fast rollback:** \`git revert <merge-sha>\`. No data, config, or schema changes.
- **Feature flags or config toggles:** None — pure predicate fix.
- **Observable failure symptoms:** Any reintroduction of the prior bug surfaces as \`error: unknown option '--no-env-file'\` in \`subprocess_error\` logs and \`Claude Code process exited with code 1\` from the SDK retry loop.

## Risks and Mitigations

- **Risk:** A user explicitly configured \`claudeBinaryPath\` to a wrapper that needs \`--no-env-file\` and relied on the dev-mode default to provide it.
  - **Mitigation:** Such users only need to ensure the configured path ends in \`.js\` (which is the standard for the legacy npm cli.js entry point anyway). Documented in the updated comment on \`shouldPassNoEnvFile\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed subprocess env-file flag behavior so the flag is only applied for legacy Bun-runnable JS CLI entrypoints; native dev-mode binaries no longer receive the unsupported flag.

* **Tests**
  * Expanded tests to cover JS/TS entrypoint permutations and added an integration-style test verifying when the flag is passed.

* **Documentation / Changelog**
  * Clarified subprocess .env isolation and updated docs/changelog to reflect native-binary handling in SDK 0.2.x.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->