### PR TITLE
fix(workflows): surface Claude usage-limit diagnostics

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -5490,6 +5490,71 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     expect(failedData.error).toContain('permission denied');
   });
 
+  it('uses rejected Claude usage-limit details instead of SDK success subtype', async () => {
+    let callCount = 0;
+    mockSendQueryDag.mockImplementation(function* () {
+      callCount++;
+      if (callCount === 1) {
+        yield { type: 'assistant', content: 'ok' };
+        yield { type: 'result', sessionId: 'sid-ok' };
+        return;
+      }
+      yield {
+        type: 'rate_limit',
+        rateLimitInfo: {
+          status: 'rejected',
+          resetsAt: Math.floor(Date.now() / 1000) + 3600,
+          rateLimitType: 'weekly',
+          overageStatus: 'rejected',
+        },
+      };
+      yield {
+        type: 'result',
+        isError: true,
+        errorSubtype: 'success',
+        sessionId: 'sid-rate-limit',
+      };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-dag',
+      testDir,
+      {
+        name: 'rate-limit-test',
+        nodes: [
+          { id: 'ok', prompt: 'first step' },
+          { id: 'step1', command: 'my-cmd', depends_on: ['ok'] },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const failCalls = (store.failWorkflowRun as Mock<(id: string, msg: string) => Promise<void>>)
+      .mock.calls;
+    expect(failCalls.length).toBeGreaterThan(0);
+
+    const failureMessage = failCalls[0][1];
+    expect(failureMessage).toContain('Claude usage limit hit');
+    expect(failureMessage).toContain('weekly');
+    expect(failureMessage).toContain('resets at');
+    expect(failureMessage).toContain('overage rejected');
+    expect(failureMessage).not.toContain('SDK returned success');
+  });
+
   it('forwards workflow-level effort to node when no per-node override', async () => {
     const mockDeps = createMockDeps();
     const platform = createMockPlatform();

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -81,6 +81,47 @@ function getLog(): ReturnType<typeof createLogger> {
 
 const MCP_FAILURE_PREFIX = 'MCP server connection failed: ';
 
+function formatUtcTimestamp(seconds: number): string {
+  return new Date(seconds * 1000).toISOString().replace(/\.000Z$/, 'Z');
+}
+
+function formatRateLimitReset(rateLimitInfo: Record<string, unknown>): string {
+  const resetsAt = typeof rateLimitInfo.resetsAt === 'number' ? rateLimitInfo.resetsAt : undefined;
+  if (resetsAt === undefined) return 'reset time unknown';
+
+  const remainingMs = resetsAt * 1000 - Date.now();
+  const remainingMinutes = Math.max(0, Math.ceil(remainingMs / 60000));
+  return `resets at ${formatUtcTimestamp(resetsAt)} (${remainingMinutes} min remaining)`;
+}
+
+function isRejectedRateLimit(
+  rateLimitInfo: Record<string, unknown> | undefined
+): rateLimitInfo is Record<string, unknown> {
+  return rateLimitInfo?.status === 'rejected';
+}
+
+function formatSdkErrorMessage(
+  subject: string,
+  subtype: string,
+  errors: string[] | undefined,
+  lastRateLimitInfo: Record<string, unknown> | undefined
+): string {
+  if (isRejectedRateLimit(lastRateLimitInfo)) {
+    const limitType =
+      typeof lastRateLimitInfo.rateLimitType === 'string'
+        ? ` (${lastRateLimitInfo.rateLimitType})`
+        : '';
+    const overage =
+      typeof lastRateLimitInfo.overageStatus === 'string'
+        ? `; overage ${lastRateLimitInfo.overageStatus}`
+        : '';
+    return `${subject} failed: Claude usage limit hit${limitType}; ${formatRateLimitReset(lastRateLimitInfo)}${overage}.`;
+  }
+
+  const errorsDetail = errors?.length ? ` — ${errors.join('; ')}` : '';
+  return `${subject} failed: SDK returned ${subtype}${errorsDetail}`;
+}
+
 /** A failed MCP server entry parsed from the SDK message. `segment` is the
  *  original substring (e.g. `"telegram (disconnected)"`) so callers can
  *  reconstruct a filtered message without losing the status detail. */
@@ -675,6 +716,7 @@ async function executeNodeInternal(
   let nodeStopReason: string | undefined;
   let nodeNumTurns: number | undefined;
   let nodeModelUsage: Record<string, unknown> | undefined;
+  let lastRateLimitInfo: Record<string, unknown> | undefined;
   const batchMessages: string[] = [];
 
   // Create per-node abort controller for idle timeout cleanup
@@ -893,21 +935,35 @@ async function executeNodeInternal(
         // failure — which let failed iterations masquerade as successes (#1208).
         if (msg.isError) {
           const subtype = msg.errorSubtype ?? 'unknown';
-          const errorsDetail = msg.errors?.length ? ` — ${msg.errors.join('; ')}` : '';
+          const errorMessage = formatSdkErrorMessage(
+            `Node '${node.id}'`,
+            subtype,
+            msg.errors,
+            lastRateLimitInfo
+          );
           getLog().error(
             {
               nodeId: node.id,
               errorSubtype: subtype,
               errors: msg.errors,
+              rateLimitInfo: lastRateLimitInfo,
               sessionId: msg.sessionId,
               stopReason: msg.stopReason,
               durationMs: Date.now() - nodeStartTime,
             },
             'dag.node_sdk_error_result'
           );
-          throw new Error(`Node '${node.id}' failed: SDK returned ${subtype}${errorsDetail}`);
+          throw new Error(errorMessage);
         }
         break; // Result is the "I'm done" signal — don't wait for subprocess to exit
+      } else if (msg.type === 'rate_limit') {
+        lastRateLimitInfo = msg.rateLimitInfo;
+        if (isRejectedRateLimit(lastRateLimitInfo)) {
+          getLog().warn(
+            { nodeId: node.id, rateLimitInfo: lastRateLimitInfo },
+            'dag.node_rate_limit_rejected'
+          );
+        }
       } else if (msg.type === 'system' && msg.content) {
         // Providers yield system chunks for user-actionable issues (missing env
         // vars, Haiku+MCP, structured output failures, etc.). MCP-failure
@@ -969,7 +1025,8 @@ async function executeNodeInternal(
           );
         }
       }
-      // rate_limit chunks: already log.warn'd in claude.ts; not surfaced to SSE per design
+      // rate_limit chunks are surfaced through SDK error formatting when they
+      // reject the request. Warnings remain provider-log-only.
     }
 
     // When output_format is set and the provider returned structured_output,
@@ -1764,6 +1821,7 @@ async function executeLoopNode(
     // Stream AI response for this iteration
     let fullOutput = ''; // raw, for signal detection
     let cleanOutput = ''; // stripped, for platform display
+    let lastRateLimitInfo: Record<string, unknown> | undefined;
     let iterationIdleTimedOut = false;
     const iterationAbortController = new AbortController();
 
@@ -1855,23 +1913,35 @@ async function executeLoopNode(
           // like a "5-second crash" that kept burning iterations (#1208).
           if (msg.isError) {
             const subtype = msg.errorSubtype ?? 'unknown';
-            const errorsDetail = msg.errors?.length ? ` — ${msg.errors.join('; ')}` : '';
+            const errorMessage = formatSdkErrorMessage(
+              `Loop '${node.id}' iteration ${String(i)}`,
+              subtype,
+              msg.errors,
+              lastRateLimitInfo
+            );
             getLog().error(
               {
                 nodeId: node.id,
                 iteration: i,
                 errorSubtype: subtype,
                 errors: msg.errors,
+                rateLimitInfo: lastRateLimitInfo,
                 sessionId: msg.sessionId,
                 stopReason: msg.stopReason,
               },
               'loop_node.iteration_sdk_error'
             );
-            throw new Error(
-              `Loop '${node.id}' iteration ${String(i)} failed: SDK returned ${subtype}${errorsDetail}`
-            );
+            throw new Error(errorMessage);
           }
           break; // Result is the "I'm done" signal — don't wait for subprocess to exit
+        } else if (msg.type === 'rate_limit') {
+          lastRateLimitInfo = msg.rateLimitInfo;
+          if (isRejectedRateLimit(lastRateLimitInfo)) {
+            getLog().warn(
+              { nodeId: node.id, iteration: i, rateLimitInfo: lastRateLimitInfo },
+              'loop_node.iteration_rate_limit_rejected'
+            );
+          }
         } else if (msg.type === 'tool' && msg.toolName) {
           const now = Date.now();
 
@@ -1941,7 +2011,8 @@ async function executeLoopNode(
         } else if (msg.type === 'tool_result' && platform.sendStructuredEvent) {
           await platform.sendStructuredEvent(conversationId, msg);
         }
-        // rate_limit chunks: already log.warn'd in claude.ts; not surfaced to SSE per design
+        // rate_limit chunks are surfaced through SDK error formatting when they
+        // reject the request. Warnings remain provider-log-only.
       }
     } catch (error) {
       const err = error as Error;


### PR DESCRIPTION
## Summary

- Problem: when the Claude SDK emits a rejected usage-limit event, the DAG executor drops that event and later reports the final SDK result as `SDK returned success`.
- Why it matters: users who have exhausted their Claude usage quota see a contradictory workflow failure instead of the reset time / quota status they can act on.
- What changed: DAG node and loop-node streaming now remember the latest rejected Claude `rate_limit` event and use it to format the later SDK error result as `Claude usage limit hit`, including reset time and optional SDK `rateLimitType` / overage status.
- What did **not** change (scope boundary): no retry policy change, no provider API change, no context-limit / prompt-too-long handling, no Codex/Pi provider changes, and no hardcoded assumption about a five-hour limit.

## UX Journey

### Before

```
User                         Archon DAG executor                  Claude SDK
────                         ───────────────────                  ──────────
runs workflow ────────────▶  streams node ─────────────────────▶  quota exhausted
                             receives rate_limit event ◀───────  rejected usage limit
                             drops event
                             receives result.isError ◀─────────  subtype: success
sees confusing failure ◀───  "SDK returned success"
```

### After

```
User                         Archon DAG executor                  Claude SDK
────                         ───────────────────                  ──────────
runs workflow ────────────▶  streams node ─────────────────────▶  quota exhausted
                             receives rate_limit event ◀───────  rejected usage limit
                             [stores rejected usage-limit detail]
                             receives result.isError ◀─────────  subtype: success
sees actionable failure ◀──  ["Claude usage limit hit; resets at ..."]
```

## Architecture Diagram

### Before

```
ClaudeProvider
  └─ yields MessageChunk { type: 'rate_limit', rateLimitInfo }
       └─ dag-executor node stream
            ├─ ignores rate_limit chunks
            └─ on result.isError throws "SDK returned <subtype>"

ClaudeProvider
  └─ yields MessageChunk { type: 'rate_limit', rateLimitInfo }
       └─ dag-executor loop stream
            ├─ ignores rate_limit chunks
            └─ on result.isError throws "SDK returned <subtype>"
```

### After

```
ClaudeProvider
  └─ yields MessageChunk { type: 'rate_limit', rateLimitInfo }
       === [~] dag-executor node stream
            ├─ [+] stores last rejected usage-limit info
            └─ [~] on result.isError formats usage-limit diagnostics

ClaudeProvider
  └─ yields MessageChunk { type: 'rate_limit', rateLimitInfo }
       === [~] dag-executor loop stream
            ├─ [+] stores last rejected usage-limit info per iteration
            └─ [~] on result.isError formats usage-limit diagnostics
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `packages/providers/src/claude/provider.ts` | `packages/workflows/src/dag-executor.ts` | unchanged | Claude provider already emits `rate_limit` chunks. |
| DAG command/prompt node stream | SDK error formatter | **modified** | Rejected usage-limit info now overrides misleading `SDK returned success`. |
| DAG loop-node stream | SDK error formatter | **modified** | Same handling per loop iteration. |
| `packages/workflows/src/dag-executor.test.ts` | DAG executor behavior | **modified** | Adds regression coverage for rejected usage-limit events. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `workflows`
- Module: `workflows:executor`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes #
- Related #1439 and #1425 (same misleading `SDK returned success` symptom, different underlying causes)
- Depends on #
- Supersedes #1464 (same patch, reopened with repository-style branch name and PR template)

## Validation Evidence (required)

```bash
bun test packages/workflows/src/dag-executor.test.ts -t "uses rejected Claude usage-limit details"
bun --filter @archon/workflows type-check
bun x prettier --check packages/workflows/src/dag-executor.ts packages/workflows/src/dag-executor.test.ts
```

- Evidence provided: targeted regression test passes, workflow package type-check passes, and formatting check passes.
- Full file note: `bun test packages/workflows/src/dag-executor.test.ts` currently reports 195 pass / 3 fail. The 3 failures are pre-existing loader-discovery expectations where `discoverWorkflows(..., { loadDefaults: false })` returns 2 workflows instead of 1; the new usage-limit regression passes.
- If any command is intentionally skipped, explain why: full repository `bun run validate` skipped because the focused executor file already has unrelated pre-existing failures in this checkout.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`
- If any `Yes`, describe risk and mitigation: N/A

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Database migration needed? `No`
- If yes, exact upgrade steps: N/A

## Human Verification (required)

- Verified scenarios: simulated Claude SDK stream with rejected usage-limit event followed by `result.isError` + `errorSubtype: success`; workflow failure message contains `Claude usage limit hit`, reset detail, and SDK limit type.
- Edge cases checked: test uses a non-five-hour `rateLimitType` value to verify the implementation passes through SDK-provided type generically rather than hardcoding a specific quota window.
- What was not verified: live Claude usage-limit exhaustion against a real account; this is covered by the normalized SDK event shape already emitted by the Claude provider.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: DAG workflow executor error reporting for Claude-backed command/prompt nodes and loop iterations.
- Potential unintended effects: if a rejected usage-limit event appears earlier in a stream and a different SDK error follows, the usage-limit message will take precedence for that node/iteration. That matches the observed SDK behavior where the final result subtype can be misleading.
- Guardrails/monitoring for early detection: regression test asserts the final workflow failure does not contain `SDK returned success` for rejected usage-limit streams.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge-commit-sha>`.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: users again see `SDK returned success` instead of `Claude usage limit hit` when Claude quota is exhausted.

## Risks and Mitigations

- Risk: wording could be confused with context-window failures.
  - Mitigation: user-facing text says `Claude usage limit hit`, not context or token limit; PR scope explicitly excludes prompt-too-long/context-limit handling.
- Risk: future SDKs may omit `resetsAt` or `rateLimitType`.
  - Mitigation: reset formatting falls back to `reset time unknown`; limit type is optional.
