### PR TITLE
feat(maintainer): Pi/Minimax variant of maintainer-standup + dual-format persist

### DIFF
--- a/.archon/commands/maintainer-standup.md
+++ b/.archon/commands/maintainer-standup.md
@@ -11,6 +11,40 @@ You are producing a daily maintainer briefing for the Archon project. The user i
 
 ---
 
+## Output format (read this FIRST, follow exactly)
+
+Your response must be exactly two parts in order:
+
+1. **Brief markdown** — starting with the literal line `# Maintainer Standup — YYYY-MM-DD` and continuing through the brief.
+2. **State JSON block** — delimited by `ARCHON_STATE_JSON_BEGIN` and `ARCHON_STATE_JSON_END`, each on its own line, with valid JSON between them.
+
+**Hard rules:**
+
+- Start the response with the `#` heading. No prose preamble. No "Looking at the data...", no `<thinking>`, no analysis dump, no "Now I'll synthesize...".
+- Do NOT wrap the response in a JSON object. Specifically: do NOT output `{"brief_markdown": "...", "next_state": {...}}` — that is the OLD contract and is wrong.
+- Do NOT use markdown code fences around the `ARCHON_STATE_JSON_BEGIN`/`ARCHON_STATE_JSON_END` markers — the markers must be plain lines.
+- Nothing after the closing marker. The closing marker is the last line of your response.
+
+**Skeleton example** (illustrative — your actual brief uses real content):
+
+```
+# Maintainer Standup — 2026-04-29
+
+## Since last run
+- ...
+
+## P1 — Do today
+- **PR #N** — ...
+
+ARCHON_STATE_JSON_BEGIN
+{"last_run_at":"2026-04-29T07:00:00Z","last_dev_sha":"abc123","carry_over":[],"observed_prs":[{"number":1,"title":"x"}],"observed_issues":[],"direction_questions":[]}
+ARCHON_STATE_JSON_END
+```
+
+(In your real output the markers and JSON are NOT inside a code fence.)
+
+---
+
 ## Phase 1: LOAD INPUTS
 
 You have three sources of upstream context, all already gathered. Each is a JSON string that you should parse.
@@ -54,7 +88,7 @@ If `prior_state` is `null` and `recent_briefs` is empty, this is a **first run**
 When `prior_state` exists:
 
 - **Resolved since last run**: PRs in `prior_state.observed_prs` whose numbers do NOT appear in current `gh-data.output.all_open_prs` — they were closed or merged. Cross-reference against `gh-data.output.recently_closed_prs` to know whether they merged or were closed without merging. Same for issues.
-- **Carry-over revisited**: each item in `prior_state.carry_over` — is it still open? Did its status change? If resolved, mention briefly under "Resolved since last run" and DROP from `next_state.carry_over`. If still pending, keep with original `first_seen` date (so age is preserved).
+- **Carry-over revisited**: each item in `prior_state.carry_over` — is it still open? Did its status change? If resolved, mention briefly under "Resolved since last run" and DROP from the state JSON's `carry_over`. If still pending, keep with original `first_seen` date (so age is preserved).
 - **What you shipped**: `gh-data.output.my_recent_commits` lists the maintainer's commits since the last run. Summarize meaningfully — group by area, highlight notable ones. Don't just list shas.
 - **New since last run**: PRs in current `all_open_prs` whose numbers are NOT in `prior_state.observed_prs` are new this run. Same for issues.
 
@@ -83,7 +117,7 @@ Issues in `issues_assigned` and `recent_unlabeled_issues` follow the same P1-P4 
 
 ### 2f. Surface direction questions
 
-If any PR raises a "we don't have a stance on this" question that `direction.md` doesn't answer, surface it under **Direction questions raised**. These go into `next_state.direction_questions` so the maintainer can absorb them into `direction.md` over time.
+If any PR raises a "we don't have a stance on this" question that `direction.md` doesn't answer, surface it under **Direction questions raised**. These go into the state JSON's `direction_questions` so the maintainer can absorb them into `direction.md` over time.
 
 ### 2g. Carry-over aging
 
@@ -105,9 +139,11 @@ PRs not in `reviewed_prs` get no marker (their absence is itself the signal: "no
 
 ## Phase 3: GENERATE OUTPUT
 
-Return a JSON object matching the workflow's `output_format` schema. Do not write any files yourself — the workflow's `persist` node handles disk writes from your structured response.
+Output the brief as plain markdown FIRST, then a state JSON block at the end with EXACT delimiters. The persist node parses your output by splitting on those delimiters — do not return a JSON object wrapping the brief, and do not write any files yourself.
 
-### `brief_markdown` (string)
+**No prose preamble.** Start the response with the `# Maintainer Standup` heading. **No content after the closing state marker.**
+
+### Brief markdown (first)
 
 A maintainer-ready markdown brief. Adapt sections — omit empty ones, add others if useful. Keep entries to one line each. The brief should be readable on a single screen.
 
@@ -153,9 +189,30 @@ A maintainer-ready markdown brief. Adapt sections — omit empty ones, add other
 - (Omit section if nothing carried over.)
 ```
 
-### `next_state` (object)
+### State JSON block (LAST)
 
-Carry-over state for tomorrow's run. Schema:
+Immediately after the brief, emit a state JSON block with these EXACT delimiter lines (each on its own line, no surrounding code fences, no leading/trailing whitespace, no markdown formatting around them):
+
+```
+ARCHON_STATE_JSON_BEGIN
+{
+  "last_run_at": "<ISO-8601 timestamp>",
+  "last_dev_sha": "<git-status.output.current_dev_sha>",
+  "carry_over": [
+    { "kind": "pr|issue|task|direction_question", "id": "<PR/issue number as string>", "note": "<why carried>", "first_seen": "<YYYY-MM-DD>" }
+  ],
+  "observed_prs": [
+    { "number": <num>, "title": "<title>" }
+  ],
+  "observed_issues": [
+    { "number": <num>, "title": "<title>" }
+  ],
+  "direction_questions": ["<surfaced question>"]
+}
+ARCHON_STATE_JSON_END
+```
+
+State schema rules:
 
 - `last_run_at`: current ISO-8601 timestamp (use the actual timestamp at synthesis time).
 - `last_dev_sha`: value from `git-status.output.current_dev_sha`.
@@ -164,17 +221,23 @@ Carry-over state for tomorrow's run. Schema:
 - `observed_issues`: same for assigned + unlabeled issues.
 - `direction_questions`: new direction questions surfaced this run (string array).
 
+The block must be valid JSON between the markers. Use empty arrays `[]` for sections with no entries — do not omit fields.
+
 ### PHASE_3_CHECKPOINT
 
+- [ ] Response starts with the `# Maintainer Standup` heading (no prose preamble).
+- [ ] State block uses the exact `ARCHON_STATE_JSON_BEGIN` / `ARCHON_STATE_JSON_END` markers, each on its own line.
+- [ ] State block is valid JSON between the markers (no trailing commas, all required fields present).
+- [ ] Nothing follows the closing marker.
 - [ ] Every PR in `all_open_prs` is either classified into P1-P4 OR included in `observed_prs` (no PR silently dropped).
 - [ ] All P4 entries cite a specific `direction.md §clause`.
 - [ ] Carry-over items still pending have their original `first_seen` preserved.
-- [ ] Resolved-since-last-run items are surfaced in the brief AND removed from `next_state.carry_over`.
-- [ ] `next_state.last_dev_sha` is set from `git-status.output.current_dev_sha`.
-- [ ] `next_state.observed_prs` includes ALL currently-open PRs.
+- [ ] Resolved-since-last-run items are surfaced in the brief AND removed from `state.carry_over`.
+- [ ] `state.last_dev_sha` is set from `git-status.output.current_dev_sha`.
+- [ ] `state.observed_prs` includes ALL currently-open PRs.
 
 ---
 
 ## Phase 4: REPORT
 
-Return the JSON object only. The workflow's `persist` node writes `brief_markdown` to `.archon/maintainer-standup/briefs/<date>.md` and `next_state` to `.archon/maintainer-standup/state.json`. Do not write files yourself.
+Output the brief markdown then the delimited state block — nothing else. The persist node writes the brief markdown (everything before `ARCHON_STATE_JSON_BEGIN`) to `.archon/maintainer-standup/briefs/<date>.md` and the state JSON (between the markers) to `.archon/maintainer-standup/state.json`. Do not write files yourself.

--- a/.archon/scripts/maintainer-standup-persist.ts
+++ b/.archon/scripts/maintainer-standup-persist.ts
@@ -1,0 +1,114 @@
+#!/usr/bin/env bun
+/**
+ * Reads raw synthesize-node output on stdin and writes the brief markdown +
+ * state.json to .archon/maintainer-standup/. Handles two formats:
+ *
+ *   Preferred — delimited markers:
+ *     # Maintainer Standup — YYYY-MM-DD
+ *     ...brief...
+ *     ARCHON_STATE_JSON_BEGIN
+ *     {...state json...}
+ *     ARCHON_STATE_JSON_END
+ *
+ *   Fallback — JSON-wrapped (what Pi/Minimax tends to emit):
+ *     [optional prose preamble]
+ *     {"brief_markdown": "...", "next_state": {...}}
+ *
+ * The fallback path is here because Pi/Minimax M2.7 ignores the delimiter
+ * directive and emits the JSON-wrapper format consistently. JSON.parse can
+ * still recover it provided the model escaped newlines/quotes correctly.
+ *
+ * Output: one line of JSON to stdout: {"date","state_path","brief_path"}.
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const raw = await Bun.stdin.text();
+
+type State = Record<string, unknown>;
+let brief: string | null = null;
+let state: State | null = null;
+let source: 'delimiter' | 'json-wrapper' | null = null;
+
+// ── Tier 1: delimiter-based extraction ──
+const BEGIN = 'ARCHON_STATE_JSON_BEGIN';
+const END = 'ARCHON_STATE_JSON_END';
+const beginIdx = raw.indexOf(BEGIN);
+const endIdx = raw.indexOf(END);
+if (beginIdx !== -1 && endIdx !== -1 && endIdx > beginIdx) {
+  const stateText = raw.slice(beginIdx + BEGIN.length, endIdx).trim();
+  try {
+    state = JSON.parse(stateText) as State;
+    brief = raw.slice(0, beginIdx).trim();
+    source = 'delimiter';
+  } catch (err) {
+    process.stderr.write(
+      `Delimiter found but state JSON parse failed: ${(err as Error).message}\n`,
+    );
+  }
+}
+
+// ── Tier 2: JSON-wrapper fallback ({brief_markdown, next_state}) ──
+if (state === null) {
+  const firstBrace = raw.indexOf('{');
+  if (firstBrace !== -1) {
+    const candidate = raw.slice(firstBrace);
+    try {
+      const parsed = JSON.parse(candidate) as Record<string, unknown>;
+      if (
+        typeof parsed.brief_markdown === 'string' &&
+        typeof parsed.next_state === 'object' &&
+        parsed.next_state !== null
+      ) {
+        brief = parsed.brief_markdown;
+        state = parsed.next_state as State;
+        source = 'json-wrapper';
+        process.stderr.write(
+          'Synth output used JSON-wrapper format (delimiter contract not followed); recovered via fallback.\n',
+        );
+      }
+    } catch (err) {
+      process.stderr.write(
+        `JSON-wrapper fallback parse failed: ${(err as Error).message}\n`,
+      );
+    }
+  }
+}
+
+if (state === null || brief === null) {
+  process.stderr.write(
+    'PERSIST FAILED: could not extract brief and state from synth output (neither delimiter nor JSON-wrapper format matched).\n',
+  );
+  process.stderr.write('--- BEGIN raw output (recoverable from logs) ---\n');
+  process.stderr.write(raw + '\n');
+  process.stderr.write('--- END raw output ---\n');
+  process.exit(1);
+}
+
+// Strip leading prose preamble — keep from the first '# ' heading onward.
+const lines = brief.split('\n');
+const headingIdx = lines.findIndex((l) => l.startsWith('# '));
+if (headingIdx > 0) {
+  brief = lines.slice(headingIdx).join('\n');
+}
+brief = brief.trim();
+
+const date = new Date().toLocaleDateString('sv-SE'); // local YYYY-MM-DD
+const baseDir = resolve(process.cwd(), '.archon/maintainer-standup');
+const briefsDir = resolve(baseDir, 'briefs');
+mkdirSync(briefsDir, { recursive: true });
+
+const statePath = resolve(baseDir, 'state.json');
+const briefPath = resolve(briefsDir, `${date}.md`);
+
+writeFileSync(statePath, JSON.stringify(state, null, 2) + '\n');
+writeFileSync(briefPath, brief + '\n');
+
+process.stdout.write(
+  JSON.stringify({
+    date,
+    source,
+    state_path: '.archon/maintainer-standup/state.json',
+    brief_path: `.archon/maintainer-standup/briefs/${date}.md`,
+  }) + '\n',
+);

--- a/.archon/workflows/maintainer/maintainer-standup-minimax.yaml
+++ b/.archon/workflows/maintainer/maintainer-standup-minimax.yaml
@@ -1,21 +1,15 @@
-name: maintainer-standup
+name: maintainer-standup-minimax
 description: |
-  Use when: Maintainer wants their morning briefing — what changed on dev,
-  what's in the review queue, what to focus on today across PRs and issues.
-  Triggers: "morning standup", "maintainer standup", "what's new today",
-            "daily brief", "morning brief", "what should i work on today",
-            "start my day".
-  Does: Pulls latest dev, fetches all open PRs and assigned issues, cross-
-        references against direction.md to flag polite-decline candidates,
-        compares against prior run state to surface progress (merged, closed,
-        what you shipped), produces a prioritized P1-P4 brief. Saves dated
-        brief + state for next-run continuity.
-  NOT for: Fixing issues (use archon-fix-github-issue), reviewing a specific
-           PR (use archon-comprehensive-pr-review), repo-wide triage automation
-           (use repo-triage).
+  Minimax variant of maintainer-standup. Identical workflow shape — same
+  gather scripts, same synthesizer command, same persist node — but the
+  synthesize node runs on Pi/Minimax M2.7 instead of Claude Sonnet.
+  Use when: nested-Claude-Code session hangs (#1067) block the Claude variant,
+            or when you'd rather not spend Claude tokens on the daily brief.
+  Triggers: "morning standup minimax", "standup minimax", "daily brief minimax".
+  NOT for: First-time setup — run the Claude variant first to validate state.
 
-provider: claude
-model: sonnet
+provider: pi
+model: minimax/MiniMax-M2.7
 
 worktree:
   enabled: false   # Live checkout — needs to git pull and read .archon/maintainer-standup/


### PR DESCRIPTION
## Summary

- **Problem**: The original maintainer-standup workflow uses Claude SDK-enforced `output_format` (one big JSON wrapping a ~12KB markdown brief plus state). It works on Claude Sonnet but hangs in nested Claude Code sessions (#1067), and Pi/Minimax can't reliably emit a 30KB JSON wrapper around markdown content (parser failures, prose preamble interference).
- **Why it matters**: Maintainer wants a fallback path when the Claude variant is unavailable or when burning Claude tokens on a daily ~5-min synth isn't the right trade-off. Without a Pi-compatible standup, the daily brief silently fails on nested-session days.
- **What changed**:
  - Drop `output_format` from the synthesize node.
  - New output contract: brief markdown emitted plain, followed by an `ARCHON_STATE_JSON_BEGIN` / `ARCHON_STATE_JSON_END` delimited state JSON block.
  - Replace the `script:` persist node with a `bash:` node that pipes raw synth output into a new `.archon/scripts/maintainer-standup-persist.ts`. The script tries the delimiter format first; falls back to extracting `{brief_markdown, next_state}` from a JSON wrapper (the format Pi/Minimax stubbornly emits regardless of prompt instructions). Either format yields the same files on disk.
  - Add `.archon/workflows/maintainer/maintainer-standup-minimax.yaml` — a 1:1 copy of the Claude variant but with `provider: pi`, `model: minimax/MiniMax-M2.7`.
  - Strengthen synthesizer-prompt format directive (top-of-file, with negative example "do not wrap in JSON object").
- **What did NOT change (scope boundary)**: No engine changes. No bundled-default changes. No user-facing surface — these are maintainer-side tooling files under `.archon/` that don't ship with Archon binaries.

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `core`
- Module: `tools:maintainer-standup`

## Change Metadata

- Change type: `feature`
- Primary scope: `core`

## Linked Issue

- Related #1067 (the nested-Claude-Code hang that motivates a Pi fallback)

## Validation Evidence (required)

```
$ bun run validate
(passes — no engine changes, no test files modified)
```

End-to-end behavioral test: ran `archon workflow run maintainer-standup-minimax` against today's payload (60+ open PRs, 19 open issues). Synthesize node emitted prose-preamble + JSON-wrapper format despite prompt instructions; persist script recovered via the fallback path and wrote `.archon/maintainer-standup/briefs/2026-04-29.md` (17KB) + `state.json`. Logged `Synth output used JSON-wrapper format (delimiter contract not followed); recovered via fallback.` to stderr as designed.

- Evidence provided: end-to-end run on the maintainer's live payload.
- If any command is intentionally skipped: `bun run generate:bundled` not needed (no bundled-default files touched).

## Security Impact (required)

- New permissions/capabilities? **No** — same surface as existing standup workflow.
- New external network calls? **No** — same `gh api` calls and Pi/Claude provider calls as today.
- Secrets/tokens handling changed? **No**.
- File system access scope changed? **No** — same `.archon/maintainer-standup/` writes.

## Compatibility / Migration

- Backward compatible? **Yes** — the Claude variant still works (the synthesizer prompt change is a strict improvement; the dual-format persist accepts both old and new shapes).
- Config/env changes? **No**.
- Database migration needed? **No**.

## Human Verification (required)

- **Verified scenarios**:
  - Pi/Minimax variant: `archon workflow run maintainer-standup-minimax` end-to-end on macOS arm64; brief + state both written; verdict logging shows `source: 'json-wrapper'` (fallback path).
  - Resume behavior: a prior failed synth was re-used by a later run, only persist re-executed (36ms) and produced the brief.
- **Edge cases checked**:
  - Synth output containing markdown code fences (backticks): handled because persist no longer uses `String.raw` template substitution; raw text is shell-quoted by the framework's bash substitution.
  - Synth output with prose preamble before the first heading: stripped by the script's "keep from first `# ` heading onward" pass.
  - Synth output that uses the delimiter format correctly (Claude path): handled by Tier 1 of the dual-format parser.
- **What was not verified**:
  - Claude variant on the new contract — Claude was hanging (#1067) at time of testing, so the new prompt was only validated through the Pi fallback path. Claude-side: the dual-format parser explicitly handles both formats, so even if Claude follows the new contract perfectly, persist works.

## Side Effects / Blast Radius (required)

- **Affected subsystems/workflows**: `maintainer-standup` and `maintainer-standup-minimax` only. No other workflow consumes the synthesizer command file. No engine changes.
- **Potential unintended effects**: A future Claude run will see the new prompt directive and may emit the delimiter format instead of the JSON wrapper; persist handles either, so this is a no-op semantically.
- **Guardrails/monitoring for early detection**: persist logs which path it took (`source: 'delimiter'` vs `'json-wrapper'`) to stdout, and stderr-logs the fallback case. If the fallback ever stops working, the maintainer sees a `PERSIST FAILED` error with the raw output dumped for log recovery.

## Rollback Plan (required)

- **Fast rollback**: revert the single commit. Files are scoped to `.archon/`; no engine impact.
- **Feature flags or config toggles**: none — keep both yaml variants if you want to be able to A/B between providers.
- **Observable failure symptoms**: `PERSIST FAILED: could not extract brief and state from synth output` in stderr if both extraction paths fail.

## Risks and Mitigations

- **Risk**: Future Pi/Minimax SDK or model updates change the output format such that neither delimiter nor JSON-wrapper matches.
  - **Mitigation**: persist dumps the raw output to stderr on failure; the brief is then recoverable from logs. Adding a Tier 3 path is a one-line addition to the script.
- **Risk**: A real-world synth output happens to contain `ARCHON_STATE_JSON_BEGIN` literally inside the brief markdown.
  - **Mitigation**: extremely unlikely (specific marker name), and Tier 1 only matches when both BEGIN and END markers appear with valid JSON between — a false positive would fail JSON.parse and fall through to Tier 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added maintainer-standup-minimax workflow with MiniMax AI model support

* **Refactor**
  * Restructured maintainer standup output format to use delimited JSON blocks for improved clarity
  * Enhanced output persistence with robust multi-format parsing and fallback handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->