### PR TITLE
fix(release-workflow): use regular merge for dev/main sync after squash-merge

### DIFF
--- a/.archon/workflows/experimental/archon-release.yaml
+++ b/.archon/workflows/experimental/archon-release.yaml
@@ -632,12 +632,26 @@ nodes:
     bash: |
       set -euo pipefail
 
-      # Ensure dev contains the merge commit from main so they don't diverge.
+      # After squash-merge, dev and main contain the same content but have
+      # divergent commit histories. The previous `--ff-only` strategy fails
+      # because main's squash commit has a different SHA than dev's release
+      # commit, so dev is never fast-forwardable to main.
+      #
+      # Resetting dev to main was tried but BLOWS UP open PRs targeting dev:
+      # rewriting dev's history shifts every PR's merge-base to a much older
+      # commit, and their diffs balloon to include thousands of lines of
+      # release content as "missing from base". Don't do this.
+      #
+      # Instead use a regular merge (matches the /release SKILL's Step 9):
+      # `git pull origin main` brings main's squash into dev as a merge
+      # commit. Open PRs' merge-bases stay at their original commits, their
+      # diffs stay small, no history is rewritten. The merge commit shows
+      # up in dev's `git log`, which is the cost of preserving open-PR sanity.
       git checkout dev
-      git pull origin main --ff-only --quiet
+      git pull origin main --no-edit
       git push origin dev
 
-      echo "dev fast-forwarded to include main's merge commit"
+      echo "dev synced to main via merge commit"
     timeout: 60000
     depends_on: [tag-and-release]
     when: "$parse-args.output.dryRun == 'false'"
@@ -816,18 +830,29 @@ nodes:
 
       ver=$bump-version.output.newVersion
 
+      # fetch-and-update-formula left the formula change uncommitted on dev.
+      # `git checkout main` refuses while ANY tracked file is dirty (not just
+      # the formula — e.g. an in-progress workflow-yaml edit during recovery
+      # would block too), so stash everything → checkout → pop carries the
+      # change across. Then commit only the formula (any other restored dirt
+      # stays uncommitted) and push on main.
+      git stash push -m "release-commit-formula-pending"
+      git fetch origin --quiet
       git checkout main
       git pull origin main --ff-only --quiet
+      git stash pop
       git add homebrew/archon.rb
       git commit -m "chore(homebrew): update formula to v$ver"
       git push origin main
 
-      # Sync dev with main so the formula update is on both branches
+      # Sync dev with main so the formula update is on both branches.
+      # Use a regular merge (not reset --hard) for the same reason as
+      # sync-dev-with-main: rewriting dev's history blows up open PRs.
       git checkout dev
-      git pull origin main --ff-only --quiet
+      git pull origin main --no-edit
       git push origin dev
 
-      echo "Formula committed to main and synced to dev"
+      echo "Formula committed to main and synced to dev via merge commit"
     timeout: 90000
     depends_on: [fetch-and-update-formula, bump-version]
     when: "$parse-args.output.dryRun == 'false' && $check-homebrew.output == 'true'"


### PR DESCRIPTION
## Summary

- **Problem**: The experimental `archon-release` workflow's `sync-dev-with-main` and `commit-formula` steps both used `git pull origin main --ff-only` to bring dev in line with main after the squash-merge. Fast-forward is impossible across a squash merge (main's squash commit has a different SHA than the release commit on dev), so the workflow aborted at `sync-dev-with-main` on every release run. `commit-formula` had a second bug: `git checkout main` refused while `homebrew/archon.rb` was still dirty from the prior step.
- **Why it matters**: The experimental workflow can't complete an end-to-end release. v0.3.10 hit both bugs today.
- **What changed**:
  - Replace `--ff-only` in both steps with a regular merge: `git pull origin main --no-edit` (matches the `/release` SKILL's Step 9). This creates a merge commit on dev that ties main's squash into dev's history without rewriting anything.
  - Add `git stash push` to `commit-formula` before its `git checkout main` so the dirty `homebrew/archon.rb` (and any in-progress recovery edits to other tracked files) gets carried across the branch switch instead of blocking it.
- **What did NOT change (scope boundary)**: The workflow's `fetch-and-update-formula` and `commit-formula` steps still duplicate CI's `update-homebrew` job — see #1489 for the full analysis. This PR addresses the mechanical bugs that prevented the workflow from completing at all; the architectural duplication is fixed in #1489.

## Why not a "rewrite dev to match main" approach

The first iteration of this fix replaced `--ff-only` with `git reset --hard origin/main && git push --lease`. It "worked" in that the workflow completed, but rewriting dev's history broke every open PR targeting dev. Their merge-bases shifted to much older commits, and their diffs ballooned with the release content. Confirmed today on PRs that went from +80/-1 to +6626/-300 across many files. Don't do that.

The regular-merge approach preserves history, costs only a merge bubble in dev's log, and is what the SKILL has always done.

## Linked Issue

- Related #1489 — workflow duplicates CI's formula update; the architectural fix.

## Validation Evidence

- The v0.3.10 release ran today with the buggy version. Both `sync-dev-with-main` and `commit-formula` failed with the exact errors this PR fixes.
- v0.3.10 ultimately shipped via manual Step 10 + Step 11 from the `/release` SKILL, then verified with `/test-release brew 0.3.10` and `/test-release curl-mac 0.3.10`. All 8 e2e smoke tests also pass on the brew-installed v0.3.10 binary (`archon-stable`).
- This PR has not been validated by an end-to-end clean release run; that requires the next release to actually exercise it.

## Security Impact

- **No new permissions/capabilities/network/secrets/fs-scope.** Same git operations against the same remotes as before.

## Compatibility / Migration

- Backward compatible — applies only to the experimental release workflow YAML, no engine changes.
- No config/env changes, no DB migration.

## Human Verification

- **Verified scenarios**: `git pull origin main --no-edit` was used during today's recovery to merge main into dev cleanly. The `git stash push` pattern was applied during recovery as well.
- **What was not verified**: a clean end-to-end release run with these exact YAML changes in place. v0.3.10 was a recovery, not a clean run.

## Side Effects / Blast Radius

- **Affected**: only `.archon/workflows/experimental/archon-release.yaml`. No other workflows, no engine, no docs.
- **Potential unintended effects**: the new `git stash push` in `commit-formula` will carry across any tracked-file edits the operator has in flight when the workflow runs. They reappear after `git stash pop` and remain uncommitted; only `homebrew/archon.rb` is staged for the formula commit.
- **Guardrails**: `set -euo pipefail` in both steps means any sub-command failure aborts the step.

## Rollback Plan

- Fast rollback: `git revert` this commit. The workflow goes back to its pre-PR state, which was already broken.
- No feature flags or schema changes.
- Observable failure symptom: same as today — `sync-dev-with-main` fails with "Not possible to fast-forward".

## Risks and Mitigations

- **Risk**: dev's `git log` will accumulate merge bubbles after each release. Some teams prefer linear dev history.
  - **Mitigation**: the cost is purely cosmetic; rewriting history is strictly worse for open PRs.
- **Risk**: the duplication with CI's `update-homebrew` documented in #1489 still exists.
  - **Mitigation**: the inline comment now explicitly warns about this and points at #1489.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow stability by switching from fast-forward to merge-based pulls, resolving branch synchronization issues during multi-branch operations.
  * Enhanced Homebrew formula update process with explicit state management to prevent checkout failures and ensure proper formula commit handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->