### PR TITLE
fix(homebrew): restore v0.3.10 formula on dev

### DIFF
--- a/homebrew/archon.rb
+++ b/homebrew/archon.rb
@@ -7,28 +7,28 @@
 class Archon < Formula
   desc "Remote agentic coding platform - control AI assistants from anywhere"
   homepage "https://github.com/coleam00/Archon"
-  version "0.3.6"
+  version "0.3.10"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-darwin-arm64"
-      sha256 "96b6dac50b046eece9eddbb988a0c39b4f9a0e2faac66e49b977ba6360069e86"
+      sha256 "ed43e9a5fe79c5046a7ae203586e5d68603bfb16885ffdd29bb9823ac21b07db"
     end
     on_intel do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-darwin-x64"
-      sha256 "09f1dbe12417b4300b7b07b531eb7391a286305f8d4eafc11e7f61f5d26eb8eb"
+      sha256 "d76f36ac7429d4e84a9a8a2c11fbdd16dc41d18d99adbc6fe9cfda06d9dbb826"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-linux-arm64"
-      sha256 "80b06a6ff699ec57cd4a3e49cfe7b899a3e8212688d70285f5a887bf10086731"
+      sha256 "ddea18be31d7eca523ebfa2152c8d279acde6362f1d66059d5a2a37ca373789d"
     end
     on_intel do
       url "https://github.com/coleam00/Archon/releases/download/v#{version}/archon-linux-x64"
-      sha256 "09f5dac6db8037ed6f3e5b7e9c5eb8e37f19822a4ed2bf4cd7e654780f9d00de"
+      sha256 "23084c4b0840294e1b40b7261106df03464a48e08a165d4b637ee2251c784350"
     end
   end
 


### PR DESCRIPTION
## Summary

- **Problem**: The recovery merge \`398afe05\` (Merge main into dev) resolved the \`homebrew/archon.rb\` conflict by running \`git checkout main -- homebrew/archon.rb\`. That uses the LOCAL \`main\` branch, which was stale: \`origin/main\` had advanced to \`fd6d75e7\` (the v0.3.10 formula commit) via \`git push origin dev:main\` earlier in the recovery, but local main was never fast-forwarded. Result: dev's \`homebrew/archon.rb\` got rewound to the old v0.3.6 state when the merge committed.
- **Why it matters**: dev's template now disagrees with reality. The published brew install path is fine (the \`coleam00/homebrew-archon\` tap repo was synced from a correct local state during release Step 11, and its \`Formula/archon.rb\` has the right v0.3.10 SHAs). But anyone reading dev expecting to see the current formula sees v0.3.6, which is misleading.
- **What changed**: \`git checkout origin/main -- homebrew/archon.rb\`, then commit. Single file, 5 lines changed (version + 4 SHAs).
- **What did NOT change (scope boundary)**: No code, no workflows, no CI. Pure data-restore.

## User impact

**Zero.** \`brew install coleam00/archon/archon\` reads from the tap repo, which has the correct v0.3.10 formula. \`scripts/update-homebrew.sh\` rewrites the file from scratch on every release, so this stale state would self-heal on the next release. This PR fixes the dev template proactively so the disagreement doesn't confuse a future maintainer.

## Validation

- \`git diff origin/main...HEAD\` shows zero diff for \`homebrew/archon.rb\` — dev now matches main.
- The four SHAs in this PR match the \`checksums.txt\` from the v0.3.10 GitHub release verbatim.

## Security Impact

None. No new permissions, network calls, secrets, or filesystem access.

## Compatibility / Migration

Backward compatible. No behavior change.

## Human Verification

- Verified that origin/main, the tap repo, and the published v0.3.10 release all agree on the formula SHAs.
- Verified that dev's pre-PR formula (v0.3.6) does not match anything currently published.

## Side Effects / Blast Radius

Single file. No code paths affected.

## Rollback Plan

\`git revert\` this commit. dev returns to the (broken) v0.3.6 template state. No real-world impact (users install from the tap, not this file).

## Risks and Mitigations

None of substance. The only conceivable risk is a future release somehow reading from this file at the wrong moment, which doesn't happen — \`scripts/update-homebrew.sh\` regenerates the file from scratch on every release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Homebrew formula to version 0.3.10 with refreshed binary checksums for macOS (arm64/x64) and Linux (arm64/x64) platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->