### PR TITLE
docs(release-skill): warn against --ff-only and reset --hard for dev/main sync

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -255,6 +255,21 @@ git push origin dev
 > commit to dev — it does not bring the PR merge commit onto dev. This manual
 > `git pull origin main` is what ensures dev has the merge commit.
 
+> **Do NOT** use `git pull origin main --ff-only` or `git reset --hard origin/main`
+> for this sync. Fast-forward is impossible across a squash merge — main's squash
+> commit has a different SHA than dev's release commit, so dev is never
+> fast-forwardable to main. And resetting dev to main rewrites dev's history,
+> which severs every open PR's merge-base from its original commit and balloons
+> their diffs to thousands of lines (confirmed against v0.3.10's release: PRs
+> went from `+80/-1` to `+6626/-300` after a `git reset --hard origin/main` on
+> dev). The plain `git pull origin main` above creates a regular merge commit on
+> dev. The merge bubble in dev's `git log` is the right cost for preserving
+> open-PR sanity. If the merge produces a `homebrew/archon.rb` conflict during a
+> recovery flow, resolve with `git checkout origin/main -- homebrew/archon.rb`
+> (note: `origin/main`, NOT `main` — local main is often stale because the
+> release pushes via `git push origin dev:main` without fast-forwarding the local
+> branch).
+
 The GitHub Release is distinct from the git tag — without it, the release won't appear on the repository's Releases page. Always create it.
 
 If the user merges the PR themselves and comes back, still offer to tag, release, and sync.


### PR DESCRIPTION
## Summary

- **Problem**: The release SKILL's Step 9 already uses the correct primitive (`git pull origin main`, which creates a regular merge commit), but doesn't explicitly warn against the two trap doors that bit us during v0.3.10. A future maintainer (or AI agent) reading the SKILL might think "the merge commit is ugly, let me clean it up" and reach for `--ff-only` or `git reset --hard origin/main` — both are wrong.
- **Why it matters**: We hit both traps today and it cost real time:
  - The experimental `archon-release` workflow used `--ff-only` and aborted on every release run. Workflow-level fix is in #1490.
  - During v0.3.10 recovery I used `git reset --hard origin/main` to "clean up" the merge bubble. That severed every open PR's merge-base from its original commit and ballooned their diffs (PR #1444 went from `+80/-1` to `+6626/-300`). Recovered via a follow-up merge that re-attached the original commits.
- **What changed**: One file, 15 lines added. New `> **Do NOT**` callout under the existing "Important" callout in Step 9. Documents both anti-patterns and explains why each is wrong, plus the conflict-resolution gotcha (use `origin/main` not local `main` because local main is typically stale).
- **What did NOT change (scope boundary)**: No code, no workflows, no other docs. Pure documentation update to the release SKILL.

## Linked

- Companion to #1490 (workflow-level fix for the same problem)
- Related #1489 (the broader race condition with CI's update-homebrew job)

## Validation

- The new content is just prose. No commands to run.
- Manually verified the line numbers and existing callout flow remain coherent.

## Security Impact

None.

## Compatibility / Migration

Backward compatible — documentation only.

## Human Verification

I read the rendered SKILL section and the new callout reads naturally between the existing "Important" block and the GitHub Release explainer. No formatting issues.

## Side Effects / Blast Radius

Single file. No code paths affected.

## Rollback Plan

`git revert` if the new wording is wrong. The SKILL functions identically without it (just less explicit about the failure modes).

## Risks and Mitigations

None of substance. Worst case: the new wording is slightly awkward; revert and rephrase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release process documentation to clarify proper branch synchronization procedures and conflict resolution guidance after tagging releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->