### PR TITLE
fix(cli): pass codebaseName to worktree provider for project-scoped p…

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -476,6 +476,7 @@ export async function workflowRunCommand(
           ? git.toBranchName(options.fromBranch.trim())
           : undefined,
         codebaseId: codebase.id,
+        codebaseName: codebase.name,
         canonicalRepoPath: git.toRepoPath(codebase.default_cwd),
         description: `CLI workflow: ${workflowName}`,
       });


### PR DESCRIPTION
  Title:                                                                                                                                                                                                                                         
  fix(cli): pass codebaseName to worktree provider for project-scoped paths                                                                                                                                                                      
                                                                                                                                                                                                                                                 
  Description:                                                                                                                                                                                                                                   
  ## Summary                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                 
  Fixes CLI workflows creating worktrees in legacy global path instead of project-scoped path.                                                                                                                                                   
                                                                                                                                                                                                                                                 
  ## Problem                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                 
  When running workflows via CLI with `--branch`, worktrees were created at:                                                                                                                                                                     
  - `~/.archon/worktrees/owner/repo/branch` (legacy global)                                                                                                                                                                                      
                                                                                                                                                                                                                                                 
  But Web UI workflows created worktrees at:                                                                                                                                                                                                     
  - `~/.archon/workspaces/owner/repo/worktrees/branch` (project-scoped)                                                                                                                                                                          
                                                                                                                                                                                                                                                 
  This inconsistency occurred because the CLI's `provider.create()` call was missing the `codebaseName` field. The `getWorktreeBase()` function uses `codebaseName` to determine the path scheme - without it, it falls back to the legacy global
   path.                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                 
  ## Solution                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                 
  Add `codebaseName: codebase.name` to the `provider.create()` call in `workflowRunCommand`. The codebase object is already loaded from the database at this point, so the data is available.                                                    
                                                                                                                                                                                                                                                 
  ## Test Plan                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                 
  1. Register a codebase with name in `owner/repo` format                                                                                                                                                                                        
  2. Run CLI workflow with `--branch` flag                                                                                                                                                                                                       
  3. Verify worktree is created under `~/.archon/workspaces/owner/repo/worktrees/` (not `~/.archon/worktrees/`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced workflow management infrastructure with improved payload handling for codebase identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->