### PR TITLE
fix(web): prevent IME enter from sending message

### DIFF
--- a/packages/web/src/components/chat/MessageInput.tsx
+++ b/packages/web/src/components/chat/MessageInput.tsx
@@ -131,6 +131,8 @@ const messageInput = forwardRef<MessageInputHandle, MessageInputProps>(function 
   const [fileError, setFileError] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const isComposingRef = useRef(false);
+  const ignoreNextEnterRef = useRef(false);
 
   useImperativeHandle(ref, () => ({
     focus: (): void => {
@@ -186,10 +188,31 @@ const messageInput = forwardRef<MessageInputHandle, MessageInputProps>(function 
   }, [value, disabled, onSend, files]);
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>): void => {
+    const nativeEvent = e.nativeEvent;
+    if (
+      e.key === 'Enter' &&
+      (isComposingRef.current || ignoreNextEnterRef.current || nativeEvent.isComposing)
+    ) {
+      ignoreNextEnterRef.current = false;
+      return;
+    }
+
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleSend();
     }
+  };
+
+  const handleCompositionStart = (): void => {
+    isComposingRef.current = true;
+  };
+
+  const handleCompositionEnd = (): void => {
+    isComposingRef.current = false;
+    ignoreNextEnterRef.current = true;
+    setTimeout(() => {
+      ignoreNextEnterRef.current = false;
+    }, 0);
   };
 
   const handleInput = (e: React.ChangeEvent<HTMLTextAreaElement>): void => {
@@ -310,6 +333,8 @@ const messageInput = forwardRef<MessageInputHandle, MessageInputProps>(function 
             value={value}
             onChange={handleInput}
             onKeyDown={handleKeyDown}
+            onCompositionStart={handleCompositionStart}
+            onCompositionEnd={handleCompositionEnd}
             onPaste={handlePaste}
             disabled={disabled}
             placeholder={dragging ? 'Drop files here...' : (disabledReason ?? 'Message Archon...')}


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: Pressing Enter while composing Chinese text in the Web UI chat box sends the message immediately.
- Why it matters: IME users expect Enter to confirm the in-progress composition, such as turning `ni hao` into committed text, before the message is sent.
- What changed: The chat textarea now tracks composition state and ignores Enter while composition is active or immediately finishing.
- What did **not** change (scope boundary): No server, API, persistence, workflow, or adapter behavior changed.

## UX Journey

### Before

```text
User                   Archon Web UI
────                   ─────────────
types Chinese pinyin ─▶ textarea stores draft
presses Enter ───────▶ sends message immediately
sees unfinished text   prompt is submitted too early
```

### After

```text
User                         Archon Web UI
────                         ─────────────
types Chinese pinyin ───────▶ textarea stores draft
presses Enter during IME ───▶ [IME confirms composition]
presses Enter after commit ─▶ sends message
```

## Architecture Diagram

### Before

```text
MessageInput textarea
  └─ onKeyDown Enter
       └─ handleSend()
```

### After

```text
[~] MessageInput textarea
  ├─ onCompositionStart/End === tracks IME state
  └─ onKeyDown Enter
       ├─ [composition active] === return without sending
       └─ [normal Enter] === handleSend()
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `MessageInput` textarea events | `handleKeyDown` | **modified** | Enter now checks IME composition state before sending. |
| `MessageInput` textarea events | `handleCompositionStart` / `handleCompositionEnd` | **new** | Tracks active or just-finished composition. |
| `handleKeyDown` | `handleSend` | unchanged | Normal Enter still sends after composition is complete. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `web`
- Module: `web:chat`

## Change Metadata

- Change type: `bug`
- Primary scope: `web`

## Linked Issue

- Closes # N/A
- Related # N/A
- Depends on # N/A
- Supersedes # N/A

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate
# Failed during lint before reaching this change: ESLint typed rule configuration error while linting .agents/skills/remotion-best-practices/rules/assets/charts-bar-chart.tsx.

bun --filter @archon/web type-check
# Passed

bun x eslint packages/web/src/components/chat/MessageInput.tsx --max-warnings 0
# Passed

bun x prettier --check packages/web/src/components/chat/MessageInput.tsx
# Passed
```

- Evidence provided (test/log/trace/screenshot): Targeted type-check, ESLint, and Prettier checks passed for the modified Web UI file.
- If any command is intentionally skipped, explain why: Full `bun run validate` was attempted, but stopped on an unrelated `.agents/skills/remotion-best-practices` lint configuration error before project lint/test completion.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: N/A

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Database migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Reviewed the `MessageInput` event flow to confirm normal Enter still sends, Shift+Enter remains unchanged, and IME Enter is ignored while composition is active.
- Edge cases checked: Browsers that report `nativeEvent.isComposing`; cases where `compositionend` fires immediately before Enter handling.
- What was not verified: Manual browser IME testing was not run in this environment.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Web chat input only.
- Potential unintended effects: A very fast Enter immediately after composition end may require one additional Enter to send, which is preferable to premature submission for IME users.
- Guardrails/monitoring for early detection: Existing Web type-check and targeted lint guard the changed component.

## Rollback Plan (required)

- Fast rollback command/path: Revert commit `39640f53`.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: Chat Enter behavior regresses, either sending during IME composition or failing to send after normal Enter.

## Risks and Mitigations

- Risk: The extra post-composition Enter guard could delay sending by one Enter in rare event-order cases.
  - Mitigation: The guard is cleared on the next tick and only applies around composition completion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where messages could be accidentally sent while using IME (Input Method Editor) composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->