### PR TITLE
fix(paths): findMarkdownFilesRecursive follows symlinks

### DIFF
--- a/packages/paths/src/archon-paths.test.ts
+++ b/packages/paths/src/archon-paths.test.ts
@@ -36,7 +36,9 @@ import {
   resolveProjectRootFromCwd,
   ensureProjectStructure,
   createProjectSourceSymlink,
+  findMarkdownFilesRecursive,
 } from './archon-paths';
+import { symlink as fsSymlink } from 'fs/promises';
 
 /** All env vars that path functions depend on */
 const ENV_VARS = ['WORKSPACE_PATH', 'WORKTREE_BASE', 'ARCHON_HOME', 'ARCHON_DOCKER', 'HOME'];
@@ -774,5 +776,71 @@ describe('createProjectSourceSymlink', () => {
     const linkPath = getProjectSourcePath('acme', 'widget');
     const stats = await lstat(linkPath);
     expect(stats.isSymbolicLink()).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// findMarkdownFilesRecursive — symlink handling
+//
+// Regression tests for #1501: symlinked .md files (e.g. team-shared
+// commands made available via `~/.archon/commands/foo.md` → repo path)
+// must be discovered, not silently ignored.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe.skipIf(isWindows)('findMarkdownFilesRecursive — symlinks', () => {
+  let tempRoot: string;
+  let realRepo: string;
+
+  beforeEach(async () => {
+    const ts = Date.now() + Math.random();
+    tempRoot = join(tmpdir(), `archon-find-md-${ts}`);
+    realRepo = join(tmpdir(), `archon-find-md-source-${ts}`);
+    await mkdir(tempRoot, { recursive: true });
+    await mkdir(realRepo, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempRoot, { recursive: true, force: true });
+    await rm(realRepo, { recursive: true, force: true });
+  });
+
+  test('finds .md file reached via symlink in the search root', async () => {
+    // Real source file in a "team repo"-shaped location
+    await writeFile(join(realRepo, 'team-cmd.md'), '# team command');
+
+    // Symlink it into the search root (same shape as sync-to-archon.sh)
+    await fsSymlink(join(realRepo, 'team-cmd.md'), join(tempRoot, 'team-cmd.md'));
+
+    const found = await findMarkdownFilesRecursive(tempRoot);
+    expect(found.map(e => e.commandName)).toContain('team-cmd');
+  });
+
+  test('mixes regular files and symlinks in the same directory', async () => {
+    await writeFile(join(tempRoot, 'plain.md'), '# plain');
+    await writeFile(join(realRepo, 'linked.md'), '# linked');
+    await fsSymlink(join(realRepo, 'linked.md'), join(tempRoot, 'linked.md'));
+
+    const found = await findMarkdownFilesRecursive(tempRoot);
+    const names = found.map(e => e.commandName).sort();
+    expect(names).toEqual(['linked', 'plain']);
+  });
+
+  test('descends into a symlinked directory of .md files', async () => {
+    const realSubdir = join(realRepo, 'group');
+    await mkdir(realSubdir, { recursive: true });
+    await writeFile(join(realSubdir, 'inside.md'), '# inside');
+
+    await fsSymlink(realSubdir, join(tempRoot, 'group'));
+
+    const found = await findMarkdownFilesRecursive(tempRoot);
+    expect(found.map(e => e.commandName)).toContain('inside');
+  });
+
+  test('skips broken symlinks silently', async () => {
+    await writeFile(join(tempRoot, 'real.md'), '# real');
+    await fsSymlink(join(realRepo, 'gone.md'), join(tempRoot, 'broken.md'));
+
+    const found = await findMarkdownFilesRecursive(tempRoot);
+    expect(found.map(e => e.commandName)).toEqual(['real']);
   });
 });

--- a/packages/paths/src/archon-paths.test.ts
+++ b/packages/paths/src/archon-paths.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 import { existsSync } from 'fs';
-import { mkdir, rm, writeFile, lstat, readlink } from 'fs/promises';
+import { mkdir, rm, writeFile, lstat, readlink, symlink as fsSymlink } from 'fs/promises';
 
 const isWindows = process.platform === 'win32';
 
@@ -38,7 +38,6 @@ import {
   createProjectSourceSymlink,
   findMarkdownFilesRecursive,
 } from './archon-paths';
-import { symlink as fsSymlink } from 'fs/promises';
 
 /** All env vars that path functions depend on */
 const ENV_VARS = ['WORKSPACE_PATH', 'WORKTREE_BASE', 'ARCHON_HOME', 'ARCHON_DOCKER', 'HOME'];
@@ -842,5 +841,26 @@ describe.skipIf(isWindows)('findMarkdownFilesRecursive — symlinks', () => {
 
     const found = await findMarkdownFilesRecursive(tempRoot);
     expect(found.map(e => e.commandName)).toEqual(['real']);
+  });
+
+  test('does not recurse infinitely on a self-referential symlink cycle', async () => {
+    // Symlink that points at the search root itself — the classic infinite
+    // loop trap. Walk must terminate and report only the real file.
+    await writeFile(join(tempRoot, 'top.md'), '# top');
+    await fsSymlink(tempRoot, join(tempRoot, 'loop'));
+
+    const found = await findMarkdownFilesRecursive(tempRoot);
+    expect(found.map(e => e.commandName)).toEqual(['top']);
+  });
+
+  test('does not recurse infinitely on a multi-level symlink cycle', async () => {
+    // tempRoot/a/back → tempRoot (loop via a sibling subdirectory).
+    const subA = join(tempRoot, 'a');
+    await mkdir(subA, { recursive: true });
+    await writeFile(join(subA, 'inside.md'), '# inside');
+    await fsSymlink(tempRoot, join(subA, 'back'));
+
+    const found = await findMarkdownFilesRecursive(tempRoot);
+    expect(found.map(e => e.commandName).sort()).toEqual(['inside']);
   });
 });

--- a/packages/paths/src/archon-paths.ts
+++ b/packages/paths/src/archon-paths.ts
@@ -16,7 +16,7 @@
 
 import { join, dirname, normalize, basename } from 'path';
 import { homedir } from 'os';
-import { access, mkdir, symlink, lstat, readdir, readlink, rm } from 'fs/promises';
+import { access, mkdir, symlink, lstat, readdir, readlink, rm, stat } from 'fs/promises';
 import { createLogger } from './logger';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
@@ -238,7 +238,28 @@ export async function findMarkdownFilesRecursive(
       continue;
     }
 
-    if (entry.isDirectory()) {
+    // Resolve the entry's actual type, following symlinks so that team-shared
+    // command/workflow files made available via symlink (e.g. `~/.archon/commands/foo.md`
+    // → `/path/to/team-repo/commands/foo.md`) are picked up. `Dirent.isFile()` /
+    // `Dirent.isDirectory()` both return false for symlinks, so without the
+    // stat() they would be silently skipped.
+    let isDir: boolean;
+    let isFile: boolean;
+    if (entry.isSymbolicLink()) {
+      try {
+        const targetStat = await stat(join(fullPath, entry.name));
+        isDir = targetStat.isDirectory();
+        isFile = targetStat.isFile();
+      } catch {
+        // Broken symlink — skip silently
+        continue;
+      }
+    } else {
+      isDir = entry.isDirectory();
+      isFile = entry.isFile();
+    }
+
+    if (isDir) {
       // Skip descending if we're already at the depth cap — files at deeper
       // levels are silently ignored (matches the convention that `.archon/*/`
       // folders support one level of grouping like `defaults/`).
@@ -249,7 +270,7 @@ export async function findMarkdownFilesRecursive(
         options
       );
       results.push(...subResults);
-    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+    } else if (isFile && entry.name.endsWith('.md')) {
       results.push({
         commandName: basename(entry.name, '.md'),
         relativePath: join(relativePath, entry.name),

--- a/packages/paths/src/archon-paths.ts
+++ b/packages/paths/src/archon-paths.ts
@@ -16,7 +16,7 @@
 
 import { join, dirname, normalize, basename } from 'path';
 import { homedir } from 'os';
-import { access, mkdir, symlink, lstat, readdir, readlink, rm, stat } from 'fs/promises';
+import { access, mkdir, symlink, lstat, readdir, readlink, realpath, rm, stat } from 'fs/promises';
 import { createLogger } from './logger';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
@@ -219,10 +219,31 @@ export async function findMarkdownFilesRecursive(
   relativePath = '',
   options?: { maxDepth?: number }
 ): Promise<{ commandName: string; relativePath: string }[]> {
+  return findMarkdownFilesRecursiveImpl(rootPath, relativePath, options, new Set<string>());
+}
+
+async function findMarkdownFilesRecursiveImpl(
+  rootPath: string,
+  relativePath: string,
+  options: { maxDepth?: number } | undefined,
+  visitedRealPaths: Set<string>
+): Promise<{ commandName: string; relativePath: string }[]> {
   const maxDepth = options?.maxDepth ?? Infinity;
   const currentDepth = relativePath ? relativePath.split(/[/\\]/).filter(Boolean).length : 0;
   const results: { commandName: string; relativePath: string }[] = [];
   const fullPath = join(rootPath, relativePath);
+
+  // Seed visited-set on first entry so a symlink that points back at the
+  // search root itself is detected as a cycle on the first descent.
+  if (visitedRealPaths.size === 0) {
+    try {
+      visitedRealPaths.add(await realpath(fullPath));
+    } catch (e) {
+      const err = e as NodeJS.ErrnoException;
+      if (err.code === 'ENOENT') return results;
+      throw err;
+    }
+  }
 
   let entries;
   try {
@@ -264,10 +285,24 @@ export async function findMarkdownFilesRecursive(
       // levels are silently ignored (matches the convention that `.archon/*/`
       // folders support one level of grouping like `defaults/`).
       if (currentDepth >= maxDepth) continue;
-      const subResults = await findMarkdownFilesRecursive(
+
+      // Resolve the child directory's real path before descending. A symlink
+      // pointing back at an ancestor (or any already-visited target) would
+      // otherwise recurse forever.
+      let realChild: string;
+      try {
+        realChild = await realpath(join(fullPath, entry.name));
+      } catch {
+        continue;
+      }
+      if (visitedRealPaths.has(realChild)) continue;
+      visitedRealPaths.add(realChild);
+
+      const subResults = await findMarkdownFilesRecursiveImpl(
         rootPath,
         join(relativePath, entry.name),
-        options
+        options,
+        visitedRealPaths
       );
       results.push(...subResults);
     } else if (isFile && entry.name.endsWith('.md')) {

--- a/packages/workflows/src/validator.test.ts
+++ b/packages/workflows/src/validator.test.ts
@@ -22,13 +22,36 @@ import type { WorkflowDefinition, DagNode } from './schemas';
 // =============================================================================
 
 let tmpDir: string;
+// Isolated ARCHON_HOME so home-scoped command/workflow discovery never sees
+// the developer's real ~/.archon/. Without this, tests that assert "no
+// commands found" fail on machines where the user has personal commands in
+// their home dir.
+let tmpHomeDir: string;
+let originalArchonHome: string | undefined;
+let originalArchonDocker: string | undefined;
 
 beforeEach(async () => {
   tmpDir = await mkdtemp(join(tmpdir(), 'validator-test-'));
+  tmpHomeDir = await mkdtemp(join(tmpdir(), 'validator-home-'));
+  originalArchonHome = process.env.ARCHON_HOME;
+  originalArchonDocker = process.env.ARCHON_DOCKER;
+  process.env.ARCHON_HOME = tmpHomeDir;
+  delete process.env.ARCHON_DOCKER;
 });
 
 afterEach(async () => {
   await rm(tmpDir, { recursive: true, force: true });
+  await rm(tmpHomeDir, { recursive: true, force: true });
+  if (originalArchonHome === undefined) {
+    delete process.env.ARCHON_HOME;
+  } else {
+    process.env.ARCHON_HOME = originalArchonHome;
+  }
+  if (originalArchonDocker === undefined) {
+    delete process.env.ARCHON_DOCKER;
+  } else {
+    process.env.ARCHON_DOCKER = originalArchonDocker;
+  }
 });
 
 function makeWorkflow(name: string, nodes: DagNode[], provider?: string): WorkflowDefinition {


### PR DESCRIPTION
## Summary

- **Problem**: Commands placed into `~/.archon/commands/` (or `<repo>/.archon/commands/`) as symlinks are silently ignored. A workflow node `command: foo` fails with `Command prompt not found: foo.md` even though the symlink target is a perfectly readable `.md` file.
- **Why it matters**: Blocks any team-shared commands setup where a checkout of a shared repo is exposed to Archon via symlinks (the natural pattern). Discovered while building team-wide command sharing for the data-factory team — workflow YAMLs work via symlink, but commands silently don't.
- **What changed**: `findMarkdownFilesRecursive` in `@archon/paths` now follows symlinks via `stat()` per Dirent (matching what `loadWorkflowsFromDir` in `workflow-discovery.ts` already does), so symlinked `.md` files are discovered like regular files. Broken symlinks are skipped silently.
- **What did *not* change**: Behavior for regular files and real directories is unchanged. No call-site changes — every consumer of the function automatically benefits.

## UX Journey

### Before

```
Developer                Workflow Engine            findMarkdownFilesRecursive
─────────                ───────────────            ──────────────────────────
ln -s …/foo.md ~/.archon/commands/foo.md
runs `archon /workflow run` ────▶  resolves `command: foo`
                                   walks ~/.archon/commands/
                                                              readdir + entry.isFile() == false (symlink)
                                                              → entry skipped
                                   not found in any scope
                                   ↳ "Command prompt not found: foo.md" [X]
```

### After

```
Developer                Workflow Engine            findMarkdownFilesRecursive
─────────                ───────────────            ──────────────────────────
ln -s …/foo.md ~/.archon/commands/foo.md
runs `archon /workflow run` ────▶  resolves `command: foo`
                                   walks ~/.archon/commands/
                                                              readdir → entry is symlink
                                                              [stat() follows link] → isFile=true
                                                              → entry included
                                   found, prompt loaded [+]
```

## Architecture Diagram

### Before

```
@archon/workflows ──▶ executor-shared ──▶ findMarkdownFilesRecursive
                                          (rejects symlinked .md files)
```

### After

```
@archon/workflows ──▶ executor-shared ──▶ findMarkdownFilesRecursive [~]
                                          (stat() per entry, accepts symlinked
                                           .md files, skips broken symlinks)
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `findMarkdownFilesRecursive` | `fs/promises.stat` | **new** | per-entry stat call when Dirent is a symlink |
| every existing caller of `findMarkdownFilesRecursive` | (unchanged) | unchanged | call signatures + return values unchanged |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `paths`
- Module: `paths:archon-paths`

## Change Metadata

- Change type: `bug`
- Primary scope: `paths`

## Linked Issue

- Closes #1501

## Validation Evidence

```bash
bun --filter @archon/paths test
# 174 pass, 0 fail (4 new tests for the symlink branch)

bun run type-check
# All packages: Exited with code 0

NODE_OPTIONS=--max-old-space-size=8192 bun x eslint packages/paths/src/archon-paths.ts
# Clean, no errors
```

The four new tests in `archon-paths.test.ts` exercise:

1. Symlinked `.md` file in the search root (the canonical case from the bug).
2. Mixed regular + symlinked entries in the same directory.
3. Symlinked subdirectory containing `.md` files.
4. Broken symlink — skipped silently rather than crashing the walk.

All `describe.skipIf(isWindows)` for portability of the symlink syscalls.

## Security Impact

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No** — still walks the same directories the function already walked, just now follows symlinks within them. Symlinks were always traversable to consumers via `readFile()`; the discovery layer was simply missing them.

## Compatibility / Migration

- Backward compatible? **Yes** — purely additive (more files discovered, never fewer).
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification

- Verified scenarios:
  - Symlinked command in `~/.archon/commands/` is now resolved by a workflow `command: <name>` reference (was the failing scenario from #1501).
  - Real-file commands still resolve as before (regression check).
- Edge cases checked:
  - Broken symlink in the directory doesn't break the walk.
  - Symlinked subdirectory is traversed.
- What was not verified: Windows behavior (test suite skips on Windows because the test creates POSIX symlinks; consistent with the rest of the file).

## Side Effects / Blast Radius

- Affected subsystems/workflows: any Archon path code that calls `findMarkdownFilesRecursive` — that's the command resolver in `@archon/workflows/executor-shared.ts` and a couple of bundled-defaults helpers. None of them care whether the source is a regular file or a symlink (they just `readFile()` the result).
- Potential unintended effects: a directory containing symlinks to non-`.md` files won't include them (filter is filename-based, unchanged). A symlinked directory whose name happens to end in `.md` would now be entered as a directory rather than ignored — extremely unusual but worth noting.
- Guardrails: existing tests for the function's regular-file and directory-walk paths still pass.

## Rollback Plan

- Fast rollback: `git revert <this commit>` — single-package, two-file change.
- Feature flags or config toggles: none introduced.
- Observable failure symptoms (if rolled back): symlinked commands silently ignored again, same as today.

## Risks and Mitigations

- Risk: extra `stat()` per Dirent adds I/O overhead in directories with many entries.
  - Mitigation: only paid when the Dirent IS a symlink (regular files / dirs short-circuit on the original `Dirent.is*()` calls). For typical `.archon/commands/` directories this is at most a handful of extra syscalls per workflow run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Markdown discovery now follows symlinked files and directories, skips broken symlinks, and avoids infinite recursion caused by symlink cycles, improving scan reliability.
* **Tests**
  * Added regression tests for symlinked markdown files, symlinked subdirectories, mixed regular/symlinked contents, broken symlinks, and termination cases (some skipped on incompatible platforms).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->