### PR TITLE
Phase 1: scaffold packages/symphony

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
     },
     "packages/adapters": {
       "name": "@archon/adapters",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "dependencies": {
         "@archon/core": "workspace:*",
         "@archon/git": "workspace:*",
@@ -41,7 +41,7 @@
     },
     "packages/cli": {
       "name": "@archon/cli",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "bin": {
         "archon": "./src/cli.ts",
       },
@@ -63,7 +63,7 @@
     },
     "packages/core": {
       "name": "@archon/core",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "dependencies": {
         "@archon/git": "workspace:*",
         "@archon/isolation": "workspace:*",
@@ -83,7 +83,7 @@
     },
     "packages/docs-web": {
       "name": "@archon/docs-web",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "dependencies": {
         "@astrojs/starlight": "^0.38.0",
         "astro": "^6.1.0",
@@ -92,7 +92,7 @@
     },
     "packages/git": {
       "name": "@archon/git",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "dependencies": {
         "@archon/paths": "workspace:*",
       },
@@ -102,7 +102,7 @@
     },
     "packages/isolation": {
       "name": "@archon/isolation",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "dependencies": {
         "@archon/git": "workspace:*",
         "@archon/paths": "workspace:*",
@@ -113,7 +113,7 @@
     },
     "packages/paths": {
       "name": "@archon/paths",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "dependencies": {
         "dotenv": "^17",
         "pino": "^9",
@@ -126,7 +126,7 @@
     },
     "packages/providers": {
       "name": "@archon/providers",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.121",
         "@archon/paths": "workspace:*",
@@ -144,7 +144,7 @@
     },
     "packages/server": {
       "name": "@archon/server",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "dependencies": {
         "@archon/adapters": "workspace:*",
         "@archon/core": "workspace:*",
@@ -161,9 +161,20 @@
         "@types/node": "^22.0.0",
       },
     },
+    "packages/symphony": {
+      "name": "@archon/symphony",
+      "version": "0.3.10",
+      "dependencies": {
+        "@archon/core": "workspace:*",
+        "@archon/paths": "workspace:*",
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0",
+      },
+    },
     "packages/web": {
       "name": "@archon/web",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "dependencies": {
         "@dagrejs/dagre": "^2.0.4",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -215,7 +226,7 @@
     },
     "packages/workflows": {
       "name": "@archon/workflows",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "dependencies": {
         "@archon/git": "workspace:*",
         "@archon/paths": "workspace:*",
@@ -276,6 +287,8 @@
     "@archon/providers": ["@archon/providers@workspace:packages/providers"],
 
     "@archon/server": ["@archon/server@workspace:packages/server"],
+
+    "@archon/symphony": ["@archon/symphony@workspace:packages/symphony"],
 
     "@archon/web": ["@archon/web@workspace:packages/web"],
 

--- a/migrations/000_combined.sql
+++ b/migrations/000_combined.sql
@@ -1,8 +1,8 @@
 -- Remote Coding Agent - Combined Schema
--- Version: Combined (final state after migrations 001-020)
+-- Version: Combined (final state after migrations 001-022)
 -- Description: Complete database schema (idempotent - safe to run multiple times)
 --
--- 8 Tables:
+-- 9 Tables:
 --   1. remote_agent_codebases
 --   1b. remote_agent_codebase_env_vars
 --   2. remote_agent_conversations
@@ -11,6 +11,7 @@
 --   5. remote_agent_workflow_runs
 --   6. remote_agent_workflow_events
 --   7. remote_agent_messages
+--   8. symphony_dispatches
 --
 -- Dropped tables (via migrations):
 --   - remote_agent_command_templates (017)
@@ -312,3 +313,34 @@ ALTER TABLE remote_agent_sessions
 -- From migration 021: allow_env_keys on codebases
 ALTER TABLE remote_agent_codebases
   ADD COLUMN IF NOT EXISTS allow_env_keys BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- ============================================================================
+-- Table 8: Symphony dispatches (from migration 022)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS symphony_dispatches (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  issue_id        TEXT NOT NULL,
+  identifier      TEXT NOT NULL,
+  tracker         TEXT NOT NULL CHECK (tracker IN ('linear', 'github')),
+  dispatch_key    TEXT NOT NULL UNIQUE,
+  codebase_id     UUID NULL REFERENCES remote_agent_codebases(id) ON DELETE SET NULL,
+  workflow_name   TEXT NOT NULL,
+  workflow_run_id UUID NULL REFERENCES remote_agent_workflow_runs(id) ON DELETE SET NULL,
+  attempt         INTEGER NOT NULL,
+  dispatched_at   TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  status          TEXT NOT NULL,
+  last_error      TEXT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_symphony_dispatches_tracker_issue
+  ON symphony_dispatches (tracker, issue_id);
+CREATE INDEX IF NOT EXISTS idx_symphony_dispatches_identifier
+  ON symphony_dispatches (identifier);
+CREATE INDEX IF NOT EXISTS idx_symphony_dispatches_workflow_run
+  ON symphony_dispatches (workflow_run_id);
+CREATE INDEX IF NOT EXISTS idx_symphony_dispatches_codebase
+  ON symphony_dispatches (codebase_id);
+
+COMMENT ON TABLE symphony_dispatches IS
+  'Symphony tracker-issue → Archon workflow-run join. One row per dispatch attempt; keyed by dispatch_key for source-aware uniqueness.';

--- a/migrations/022_symphony_dispatches.sql
+++ b/migrations/022_symphony_dispatches.sql
@@ -1,0 +1,37 @@
+-- 022_symphony_dispatches.sql
+-- Joins Symphony tracker issues to Archon workflow runs.
+-- Version: 22.0
+-- Description: One row per (tracker, issue) dispatch attempt. The orchestrator
+--   keys its in-memory state by `dispatch_key` (e.g. "linear:<issue_id>" or
+--   "github:<owner>/<repo>#<number>") so the same raw issue id from two trackers
+--   does not collide. `workflow_run_id` is null until the dispatcher pre-creates
+--   or launches the Archon workflow run; on terminal status the orchestrator
+--   updates `status` (running | completed | failed | cancelled) and (on failure)
+--   `last_error`.
+
+CREATE TABLE IF NOT EXISTS symphony_dispatches (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  issue_id        TEXT NOT NULL,
+  identifier      TEXT NOT NULL,
+  tracker         TEXT NOT NULL CHECK (tracker IN ('linear', 'github')),
+  dispatch_key    TEXT NOT NULL UNIQUE,
+  codebase_id     UUID NULL REFERENCES remote_agent_codebases(id) ON DELETE SET NULL,
+  workflow_name   TEXT NOT NULL,
+  workflow_run_id UUID NULL REFERENCES remote_agent_workflow_runs(id) ON DELETE SET NULL,
+  attempt         INTEGER NOT NULL,
+  dispatched_at   TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  status          TEXT NOT NULL,
+  last_error      TEXT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_symphony_dispatches_tracker_issue
+  ON symphony_dispatches (tracker, issue_id);
+CREATE INDEX IF NOT EXISTS idx_symphony_dispatches_identifier
+  ON symphony_dispatches (identifier);
+CREATE INDEX IF NOT EXISTS idx_symphony_dispatches_workflow_run
+  ON symphony_dispatches (workflow_run_id);
+CREATE INDEX IF NOT EXISTS idx_symphony_dispatches_codebase
+  ON symphony_dispatches (codebase_id);
+
+COMMENT ON TABLE symphony_dispatches IS
+  'Symphony tracker-issue → Archon workflow-run join. One row per dispatch attempt; keyed by dispatch_key for source-aware uniqueness.';

--- a/packages/core/src/db/adapters/sqlite.ts
+++ b/packages/core/src/db/adapters/sqlite.ts
@@ -346,6 +346,23 @@ export class SqliteAdapter implements IDatabase {
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
       );
 
+      -- Symphony dispatches table (from PG migration 022): joins Symphony tracker
+      -- issues to Archon workflow runs. Keyed by source-aware dispatch_key.
+      CREATE TABLE IF NOT EXISTS symphony_dispatches (
+        id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+        issue_id TEXT NOT NULL,
+        identifier TEXT NOT NULL,
+        tracker TEXT NOT NULL CHECK (tracker IN ('linear', 'github')),
+        dispatch_key TEXT NOT NULL UNIQUE,
+        codebase_id TEXT REFERENCES remote_agent_codebases(id) ON DELETE SET NULL,
+        workflow_name TEXT NOT NULL,
+        workflow_run_id TEXT REFERENCES remote_agent_workflow_runs(id) ON DELETE SET NULL,
+        attempt INTEGER NOT NULL,
+        dispatched_at TEXT NOT NULL DEFAULT (datetime('now')),
+        status TEXT NOT NULL,
+        last_error TEXT
+      );
+
       -- Indexes
       CREATE INDEX IF NOT EXISTS idx_codebase_env_vars_codebase_id ON remote_agent_codebase_env_vars(codebase_id);
       CREATE INDEX IF NOT EXISTS idx_conversations_platform ON remote_agent_conversations(platform_type, platform_conversation_id);
@@ -375,6 +392,16 @@ export class SqliteAdapter implements IDatabase {
         ON remote_agent_sessions(parent_session_id);
       CREATE INDEX IF NOT EXISTS idx_sessions_conversation_started
         ON remote_agent_sessions(conversation_id, started_at DESC);
+
+      -- From PG migration 022: symphony dispatches lookup paths
+      CREATE INDEX IF NOT EXISTS idx_symphony_dispatches_tracker_issue
+        ON symphony_dispatches(tracker, issue_id);
+      CREATE INDEX IF NOT EXISTS idx_symphony_dispatches_identifier
+        ON symphony_dispatches(identifier);
+      CREATE INDEX IF NOT EXISTS idx_symphony_dispatches_workflow_run
+        ON symphony_dispatches(workflow_run_id);
+      CREATE INDEX IF NOT EXISTS idx_symphony_dispatches_codebase
+        ON symphony_dispatches(codebase_id);
     `);
     getLog().info('db.sqlite_schema_initialized');
   }

--- a/packages/symphony/package.json
+++ b/packages/symphony/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@archon/symphony",
+  "version": "0.3.10",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./db/dispatches": "./src/db/dispatches.ts"
+  },
+  "scripts": {
+    "test": "bun test src/",
+    "type-check": "bun x tsc --noEmit"
+  },
+  "dependencies": {
+    "@archon/core": "workspace:*",
+    "@archon/paths": "workspace:*"
+  },
+  "peerDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/symphony/src/db/dispatches.test.ts
+++ b/packages/symphony/src/db/dispatches.test.ts
@@ -1,0 +1,206 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { unlinkSync } from 'fs';
+import { join } from 'path';
+import { SqliteAdapter } from '@archon/core/db/adapters/sqlite';
+import {
+  insertDispatch,
+  getDispatchByDispatchKey,
+  getDispatchById,
+  updateStatus,
+  attachWorkflowRun,
+  type InsertDispatchInput,
+} from './dispatches';
+
+let dbPath = '';
+let db: SqliteAdapter;
+
+async function insertCodebase(adapter: SqliteAdapter, id: string): Promise<void> {
+  await adapter.query(
+    'INSERT INTO remote_agent_codebases (id, name, default_cwd) VALUES ($1, $2, $3)',
+    [id, `cb-${id}`, '/tmp/test-cwd']
+  );
+}
+
+async function insertConversation(adapter: SqliteAdapter, id: string): Promise<void> {
+  await adapter.query(
+    `INSERT INTO remote_agent_conversations
+       (id, platform_type, platform_conversation_id)
+     VALUES ($1, $2, $3)`,
+    [id, 'symphony', `convo-${id}`]
+  );
+}
+
+async function insertWorkflowRun(
+  adapter: SqliteAdapter,
+  id: string,
+  conversationId: string
+): Promise<void> {
+  await adapter.query(
+    `INSERT INTO remote_agent_workflow_runs
+       (id, conversation_id, workflow_name, user_message, status)
+     VALUES ($1, $2, $3, $4, $5)`,
+    [id, conversationId, 'archon-feature-development', 'kick off', 'running']
+  );
+}
+
+function baseInput(over: Partial<InsertDispatchInput> = {}): InsertDispatchInput {
+  return {
+    issue_id: 'issue-id-1',
+    identifier: 'APP-291',
+    tracker: 'linear',
+    dispatch_key: 'linear:issue-id-1',
+    codebase_id: null,
+    workflow_name: 'archon-feature-development',
+    workflow_run_id: null,
+    attempt: 1,
+    status: 'pending',
+    last_error: null,
+    ...over,
+  };
+}
+
+describe('symphony_dispatches CRUD', () => {
+  beforeEach(() => {
+    dbPath = join(
+      import.meta.dir,
+      `.test-dispatches-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
+    );
+    db = new SqliteAdapter(dbPath);
+  });
+
+  afterEach(async () => {
+    await db.close();
+    for (const suffix of ['', '-wal', '-shm']) {
+      try {
+        unlinkSync(dbPath + suffix);
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  test('insertDispatch round-trips via getDispatchByDispatchKey', async () => {
+    const inserted = await insertDispatch(db, baseInput());
+    expect(inserted.id).toBeTruthy();
+    expect(inserted.issue_id).toBe('issue-id-1');
+    expect(inserted.identifier).toBe('APP-291');
+    expect(inserted.tracker).toBe('linear');
+    expect(inserted.dispatch_key).toBe('linear:issue-id-1');
+    expect(inserted.workflow_name).toBe('archon-feature-development');
+    expect(inserted.workflow_run_id).toBeNull();
+    expect(inserted.attempt).toBe(1);
+    expect(inserted.status).toBe('pending');
+    expect(inserted.last_error).toBeNull();
+    expect(inserted.dispatched_at).toBeTruthy();
+
+    const fetched = await getDispatchByDispatchKey(db, 'linear:issue-id-1');
+    expect(fetched).not.toBeNull();
+    expect(fetched?.id).toBe(inserted.id);
+  });
+
+  test('dispatch_key UNIQUE constraint rejects duplicates across trackers', async () => {
+    await insertDispatch(db, baseInput({ dispatch_key: 'linear:dup' }));
+    let threw = false;
+    try {
+      await insertDispatch(
+        db,
+        baseInput({ tracker: 'github', dispatch_key: 'linear:dup', issue_id: 'other' })
+      );
+    } catch (e) {
+      threw = true;
+      expect((e as Error).message.toLowerCase()).toContain('unique');
+    }
+    expect(threw).toBe(true);
+  });
+
+  test('same raw issue_id from two trackers does NOT collide when dispatch_key differs', async () => {
+    const linear = await insertDispatch(
+      db,
+      baseInput({ tracker: 'linear', dispatch_key: 'linear:shared-id' })
+    );
+    const github = await insertDispatch(
+      db,
+      baseInput({
+        tracker: 'github',
+        dispatch_key: 'github:owner/repo#shared-id',
+        identifier: 'owner/repo#42',
+      })
+    );
+    expect(linear.id).not.toBe(github.id);
+    expect((await getDispatchByDispatchKey(db, 'linear:shared-id'))?.id).toBe(linear.id);
+    expect((await getDispatchByDispatchKey(db, 'github:owner/repo#shared-id'))?.id).toBe(github.id);
+  });
+
+  test('updateStatus mutates status and last_error only', async () => {
+    const inserted = await insertDispatch(db, baseInput());
+    await updateStatus(db, inserted.id, 'failed', 'turn_timeout');
+
+    const after = await getDispatchById(db, inserted.id);
+    expect(after?.status).toBe('failed');
+    expect(after?.last_error).toBe('turn_timeout');
+    // unchanged fields
+    expect(after?.dispatch_key).toBe(inserted.dispatch_key);
+    expect(after?.attempt).toBe(inserted.attempt);
+    expect(after?.workflow_run_id).toBe(inserted.workflow_run_id);
+  });
+
+  test('updateStatus clears last_error when omitted', async () => {
+    const inserted = await insertDispatch(db, baseInput({ last_error: 'old' }));
+    await updateStatus(db, inserted.id, 'running');
+    const after = await getDispatchById(db, inserted.id);
+    expect(after?.status).toBe('running');
+    expect(after?.last_error).toBeNull();
+  });
+
+  test('attachWorkflowRun sets workflow_run_id and is idempotent for the same id', async () => {
+    await insertCodebase(db, 'cb-1');
+    await insertConversation(db, 'conv-1');
+    await insertWorkflowRun(db, 'wfr-1', 'conv-1');
+
+    const inserted = await insertDispatch(db, baseInput({ codebase_id: 'cb-1' }));
+    await attachWorkflowRun(db, inserted.id, 'wfr-1');
+    const after1 = await getDispatchById(db, inserted.id);
+    expect(after1?.workflow_run_id).toBe('wfr-1');
+
+    // idempotent — same id is a no-op
+    await attachWorkflowRun(db, inserted.id, 'wfr-1');
+    const after2 = await getDispatchById(db, inserted.id);
+    expect(after2?.workflow_run_id).toBe('wfr-1');
+  });
+
+  test('attachWorkflowRun rejects switching to a different workflow_run_id', async () => {
+    await insertCodebase(db, 'cb-2');
+    await insertConversation(db, 'conv-2');
+    await insertWorkflowRun(db, 'wfr-a', 'conv-2');
+    await insertWorkflowRun(db, 'wfr-b', 'conv-2');
+
+    const inserted = await insertDispatch(
+      db,
+      baseInput({ dispatch_key: 'linear:swap-test', codebase_id: 'cb-2' })
+    );
+    await attachWorkflowRun(db, inserted.id, 'wfr-a');
+
+    let threw = false;
+    try {
+      await attachWorkflowRun(db, inserted.id, 'wfr-b');
+    } catch (e) {
+      threw = true;
+      expect((e as Error).message).toContain('already attached');
+    }
+    expect(threw).toBe(true);
+
+    const after = await getDispatchById(db, inserted.id);
+    expect(after?.workflow_run_id).toBe('wfr-a');
+  });
+
+  test('attachWorkflowRun throws for unknown dispatch id', async () => {
+    let threw = false;
+    try {
+      await attachWorkflowRun(db, 'does-not-exist', 'wfr-x');
+    } catch (e) {
+      threw = true;
+      expect((e as Error).message).toContain('not found');
+    }
+    expect(threw).toBe(true);
+  });
+});

--- a/packages/symphony/src/db/dispatches.ts
+++ b/packages/symphony/src/db/dispatches.ts
@@ -1,0 +1,139 @@
+/**
+ * Symphony dispatches: typed CRUD for the symphony_dispatches table.
+ *
+ * Each row records one (tracker, issue) → Archon workflow-run dispatch attempt.
+ * The orchestrator (Phase 2) keys its in-memory state on `dispatch_key` so the
+ * same raw issue id from two trackers (e.g. Linear + GitHub) cannot collide.
+ *
+ * Functions accept the `IDatabase` handle explicitly rather than reaching for
+ * the `pool` singleton. Phase 2 will use `getDatabase()` from `@archon/core/db`
+ * at call sites; tests pass a freshly-constructed `SqliteAdapter` against a
+ * temp file (see ./dispatches.test.ts).
+ */
+import type { IDatabase } from '@archon/core/db';
+import { createLogger } from '@archon/paths';
+
+let cachedLog: ReturnType<typeof createLogger> | undefined;
+function getLog(): ReturnType<typeof createLogger> {
+  if (!cachedLog) cachedLog = createLogger('symphony.dispatches');
+  return cachedLog;
+}
+
+export type DispatchTracker = 'linear' | 'github';
+export type DispatchStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
+
+export interface DispatchRow {
+  id: string;
+  issue_id: string;
+  identifier: string;
+  tracker: DispatchTracker;
+  dispatch_key: string;
+  codebase_id: string | null;
+  workflow_name: string;
+  workflow_run_id: string | null;
+  attempt: number;
+  dispatched_at: string;
+  status: DispatchStatus;
+  last_error: string | null;
+}
+
+export interface InsertDispatchInput {
+  issue_id: string;
+  identifier: string;
+  tracker: DispatchTracker;
+  dispatch_key: string;
+  codebase_id?: string | null;
+  workflow_name: string;
+  workflow_run_id?: string | null;
+  attempt: number;
+  status: DispatchStatus;
+  last_error?: string | null;
+}
+
+export async function insertDispatch(
+  db: IDatabase,
+  input: InsertDispatchInput
+): Promise<DispatchRow> {
+  const result = await db.query<DispatchRow>(
+    `INSERT INTO symphony_dispatches
+       (issue_id, identifier, tracker, dispatch_key, codebase_id, workflow_name,
+        workflow_run_id, attempt, status, last_error)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+     RETURNING *`,
+    [
+      input.issue_id,
+      input.identifier,
+      input.tracker,
+      input.dispatch_key,
+      input.codebase_id ?? null,
+      input.workflow_name,
+      input.workflow_run_id ?? null,
+      input.attempt,
+      input.status,
+      input.last_error ?? null,
+    ]
+  );
+  if (!result.rows[0]) {
+    throw new Error('insertDispatch: INSERT succeeded but no row returned');
+  }
+  return result.rows[0];
+}
+
+export async function getDispatchByDispatchKey(
+  db: IDatabase,
+  dispatchKey: string
+): Promise<DispatchRow | null> {
+  const result = await db.query<DispatchRow>(
+    'SELECT * FROM symphony_dispatches WHERE dispatch_key = $1',
+    [dispatchKey]
+  );
+  return result.rows[0] ?? null;
+}
+
+export async function getDispatchById(db: IDatabase, id: string): Promise<DispatchRow | null> {
+  const result = await db.query<DispatchRow>('SELECT * FROM symphony_dispatches WHERE id = $1', [
+    id,
+  ]);
+  return result.rows[0] ?? null;
+}
+
+export async function updateStatus(
+  db: IDatabase,
+  id: string,
+  status: DispatchStatus,
+  lastError?: string | null
+): Promise<void> {
+  await db.query('UPDATE symphony_dispatches SET status = $1, last_error = $2 WHERE id = $3', [
+    status,
+    lastError ?? null,
+    id,
+  ]);
+}
+
+export async function attachWorkflowRun(
+  db: IDatabase,
+  id: string,
+  workflowRunId: string
+): Promise<void> {
+  const existing = await getDispatchById(db, id);
+  if (!existing) {
+    throw new Error(`attachWorkflowRun: dispatch ${id} not found`);
+  }
+  if (existing.workflow_run_id && existing.workflow_run_id !== workflowRunId) {
+    getLog().warn(
+      {
+        dispatch_id: id,
+        existing: existing.workflow_run_id,
+        attempted: workflowRunId,
+      },
+      'symphony.attach_workflow_run_conflict'
+    );
+    throw new Error(
+      `attachWorkflowRun: dispatch ${id} already attached to workflow_run ${existing.workflow_run_id}`
+    );
+  }
+  await db.query('UPDATE symphony_dispatches SET workflow_run_id = $1 WHERE id = $2', [
+    workflowRunId,
+    id,
+  ]);
+}

--- a/packages/symphony/src/index.ts
+++ b/packages/symphony/src/index.ts
@@ -1,0 +1,11 @@
+// @archon/symphony — autonomous Linear+GitHub tracker dispatch on top of Archon workflows.
+// Phase 1 scaffolding only. See docs/superpowers/plans/2026-04-30-archon-symphony-consolidation.md
+// in the symphoney-codex repo for the consolidation roadmap.
+//
+// Phase 2 will add the orchestrator (ported from symphoney-codex/src/orchestrator/).
+// Phase 3 will add workflow-bridge dispatcher.
+//
+// For now this package owns only the DB schema for symphony_dispatches and a typed
+// CRUD module under ./db/dispatches.
+
+export type { DispatchRow, DispatchStatus, DispatchTracker } from './db/dispatches';

--- a/packages/symphony/tsconfig.json
+++ b/packages/symphony/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}


### PR DESCRIPTION
Phase 1 of the archon-symphony consolidation, per `docs/superpowers/plans/2026-04-30-archon-symphony-consolidation.md` in `Ddell12/symphoney-codex`.

## Summary

Empty-but-buildable `@archon/symphony` workspace package + the DB schema Phase 2's orchestrator will need. No runtime behavior yet.

- `packages/symphony/{package.json,tsconfig.json,src/index.ts}` — new workspace package (mirrors `packages/git`). Deps: `@archon/core`, `@archon/paths`.
- `migrations/022_symphony_dispatches.sql` — PostgreSQL migration. UUID FKs to `remote_agent_codebases` and `remote_agent_workflow_runs`. Indexes on `(tracker, issue_id)`, `identifier`, `workflow_run_id`, `codebase_id`. `dispatch_key UNIQUE` so the same raw issue id from two trackers (Linear + GitHub) cannot collide.
- `migrations/000_combined.sql` — table appended to the fresh-Postgres bootstrap snapshot.
- `packages/core/src/db/adapters/sqlite.ts` — SQLite-equivalent `symphony_dispatches` + indexes added to `createSchema()`. TEXT IDs / `datetime('now')` per SQLite convention.
- `packages/symphony/src/db/dispatches.ts` — typed CRUD. Functions accept `IDatabase` explicitly so tests pass a fresh `SqliteAdapter` against a temp file (Phase 2 will switch call sites to the pool singleton).
- `packages/symphony/src/db/dispatches.test.ts` — 8 round-trip tests against real SQLite: insert/get, `dispatch_key` UNIQUE, multi-tracker non-collision, `updateStatus` mutation, `attachWorkflowRun` idempotency / conflict rejection / missing-id error.

## Verification

```
bun install && bun run validate
# check:bundled && type-check && lint --max-warnings 0 && format:check && test
```

All 11 packages green. `@archon/symphony` contributes 8 passing tests. No regressions in `@archon/core`'s SQLite adapter tests.

## Out of scope (Phase 2+)

- Tracker / orchestrator / dispatch loop port from symphoney-codex.
- `~/.archon/symphony.yaml` config schema.
- Workflow-bridge dispatcher (Phase 3) → connects `dispatch_key` rows to `remote_agent_workflow_runs.id`.
- `/symphony` page in `@archon/web` (Phase 4).

## Draft

Marked draft until the Phase 2 work lands and we can validate the schema against real orchestrator code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)