### PR TITLE
Feat/pi deferred extension model resolution

### DIFF
--- a/.archon/workflows/archon-test-pi.yaml
+++ b/.archon/workflows/archon-test-pi.yaml
@@ -8,7 +8,6 @@ model: kiro/minimax-m2-5
 
 nodes:
   - id: hello
-    model: kiro/minimax-m2-5
     prompt: |
       Who won the 1984 Major League Baseball World Series? Answer in one sentence.
 

--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -1,0 +1,20 @@
+# Prerequisites
+
+## Install Pi
+
+```bash
+npm install -g @mariozechner/pi-coding-agent
+```
+
+## Install Kiro provider and dependencies
+
+```bash
+pi install npm:pi-provider-kiro
+npm install -g @mariozechner/pi-tui @mariozechner/pi-ai
+```
+
+## Install MCP for Pi
+
+```bash
+pi install npm:pi-mcp-adapter
+```

--- a/examples/workflows/archon-test-pi.yaml
+++ b/examples/workflows/archon-test-pi.yaml
@@ -1,0 +1,23 @@
+name: archon-test-pi
+description: |
+  Simple test workflow to verify the pi provider works with Archon.
+  Triggers: "test pi", "test pi provider".
+
+provider: pi
+model: kiro/minimax-m2-5
+
+nodes:
+  - id: hello
+    prompt: |
+      Who won the 1984 Major League Baseball World Series? Answer in one sentence.
+
+  - id: verify
+    prompt: |
+      The previous node said:
+
+      $hello.output
+
+      If the answer mentions the Detroit Tigers, say "Pi provider verified ✅".
+      If not, say "Pi provider FAILED ❌ — wrong answer".
+      Say nothing else.
+    depends_on: [hello]

--- a/packages/providers/src/community/pi/event-bridge.ts
+++ b/packages/providers/src/community/pi/event-bridge.ts
@@ -158,6 +158,12 @@ export function buildResultChunk(messages: readonly unknown[]): MessageChunk {
         }
       : {}),
   };
+  if (isError) {
+    getLog().error(
+      { stopReason: last.stopReason, errorMessage: last.errorMessage, model: last.model },
+      'pi.event-bridge.result_error'
+    );
+  }
   return chunk;
 }
 

--- a/packages/providers/src/community/pi/event-bridge.ts
+++ b/packages/providers/src/community/pi/event-bridge.ts
@@ -159,9 +159,12 @@ export function buildResultChunk(messages: readonly unknown[]): MessageChunk {
       : {}),
   };
   if (isError) {
+    // Intentional design: error chunks are yielded, not thrown. isError:true in the chunk
+    // is the signal — callers (bridgeSession, dag-executor) check result.isError to classify
+    // failures and still receive full token/stopReason context from the same chunk.
     getLog().error(
-      { stopReason: last.stopReason, errorMessage: last.errorMessage, model: last.model },
-      'pi.event-bridge.result_error'
+      { stopReason: last.stopReason, errorMessage: last.errorMessage },
+      'pi.result_chunk_error'
     );
   }
   return chunk;

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -88,7 +88,7 @@ const mockModelRegistryFind = mock((provider: string, modelId: string) => {
   if (provider === 'nonexistent') return undefined;
   return { id: modelId, provider, name: `${provider}/${modelId}` };
 });
-const mockModelRegistryInMemory = mock(() => ({
+const mockModelRegistryCreate = mock(() => ({
   find: mockModelRegistryFind,
 }));
 
@@ -132,7 +132,7 @@ const mockCreateLsTool = mock((_cwd: string) => ({ __piTool: 'ls' }));
 mock.module('@mariozechner/pi-coding-agent', () => ({
   createAgentSession: mockCreateAgentSession,
   AuthStorage: { create: mockAuthCreate },
-  ModelRegistry: { inMemory: mockModelRegistryInMemory },
+  ModelRegistry: { create: mockModelRegistryCreate },
   SessionManager: {
     create: mockSessionCreate,
     open: mockSessionOpen,
@@ -195,7 +195,7 @@ describe('PiProvider', () => {
     mockResourceLoaderReload.mockClear();
     mockCreateAgentSession.mockClear();
     mockAuthCreate.mockClear();
-    mockModelRegistryInMemory.mockClear();
+    mockModelRegistryCreate.mockClear();
     mockModelRegistryFind.mockClear();
     mockSetRuntimeApiKey.mockClear();
     mockGetApiKey.mockClear();
@@ -283,8 +283,8 @@ describe('PiProvider', () => {
     expect(mockCreateAgentSession).toHaveBeenCalledTimes(1);
   });
 
-  test('ModelRegistry.inMemory receives the AuthStorage instance', async () => {
-    // ModelRegistry.inMemory must receive the same AuthStorage instance
+  test('ModelRegistry.create receives the AuthStorage instance', async () => {
+    // ModelRegistry.create must receive the same AuthStorage instance
     // returned by AuthStorage.create(), so extension providers can resolve
     // credentials and register models during bindExtensions().
     process.env.GEMINI_API_KEY = 'sk-test';
@@ -297,9 +297,9 @@ describe('PiProvider', () => {
     );
 
     expect(mockAuthCreate).toHaveBeenCalledTimes(1);
-    expect(mockModelRegistryInMemory).toHaveBeenCalledTimes(1);
+    expect(mockModelRegistryCreate).toHaveBeenCalledTimes(1);
     const authInstance = mockAuthCreate.mock.results[0]?.value;
-    expect(mockModelRegistryInMemory).toHaveBeenCalledWith(authInstance);
+    expect(mockModelRegistryCreate).toHaveBeenCalledWith(authInstance);
   });
 
   test('AuthStorage.create() throwing surfaces a contextualized error', async () => {
@@ -328,16 +328,12 @@ describe('PiProvider', () => {
   });
 
   test('Pi model not found includes models.json load error when registry reports one', async () => {
-    // ModelRegistry swallows models.json parse/validation errors into an
-    // internal loadError. When find() returns undefined at step 3, we log
-    // the warning and defer to extension resolution. If still not found
-    // after bindExtensions(), the provider throws.
     process.env.GEMINI_API_KEY = 'sk-test';
-    // find() is called twice: step 3 (static catalog) and step 4g (after
-    // bindExtensions). Both must return undefined to trigger the error.
+    // find() is called twice — first on the static catalog, then again after bindExtensions()
+    // resolves extension providers. Both must return undefined to trigger the error.
     mockModelRegistryFind.mockImplementationOnce(() => undefined);
     mockModelRegistryFind.mockImplementationOnce(() => undefined);
-    mockModelRegistryInMemory.mockImplementationOnce(() => ({
+    mockModelRegistryCreate.mockImplementationOnce(() => ({
       find: mockModelRegistryFind,
       getError: () => 'Provider lm-studio: "baseUrl" is required when defining custom models.',
     }));
@@ -411,8 +407,8 @@ describe('PiProvider', () => {
 
   test('throws when ModelRegistry.find returns undefined', async () => {
     process.env.GEMINI_API_KEY = 'sk-test';
-    // find() is called twice: step 3 (static catalog) and step 4g (after
-    // bindExtensions). Both must return undefined to trigger the error.
+    // find() is called twice — first on the static catalog, then again after bindExtensions()
+    // resolves extension providers. Both must return undefined to trigger the error.
     mockModelRegistryFind.mockImplementationOnce(() => undefined);
     mockModelRegistryFind.mockImplementationOnce(() => undefined);
     resetScript(scriptedAgentEnd());

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -43,6 +43,7 @@ const mockSetFlagValue = mock((_name: string, _value: boolean | string) => undef
 const mockExtensionRunner = {
   setFlagValue: mockSetFlagValue,
 };
+const mockSetModel = mock(async (_model: unknown) => undefined);
 const mockSession = {
   subscribe: mockSubscribe,
   prompt: mockPrompt,
@@ -50,6 +51,7 @@ const mockSession = {
   dispose: mockDispose,
   bindExtensions: mockBindExtensions,
   extensionRunner: mockExtensionRunner,
+  setModel: mockSetModel,
   isStreaming: false,
   sessionId: 'mock-session-uuid',
 };
@@ -86,7 +88,7 @@ const mockModelRegistryFind = mock((provider: string, modelId: string) => {
   if (provider === 'nonexistent') return undefined;
   return { id: modelId, provider, name: `${provider}/${modelId}` };
 });
-const mockModelRegistryCreate = mock(() => ({
+const mockModelRegistryInMemory = mock(() => ({
   find: mockModelRegistryFind,
 }));
 
@@ -130,7 +132,7 @@ const mockCreateLsTool = mock((_cwd: string) => ({ __piTool: 'ls' }));
 mock.module('@mariozechner/pi-coding-agent', () => ({
   createAgentSession: mockCreateAgentSession,
   AuthStorage: { create: mockAuthCreate },
-  ModelRegistry: { create: mockModelRegistryCreate },
+  ModelRegistry: { inMemory: mockModelRegistryInMemory },
   SessionManager: {
     create: mockSessionCreate,
     open: mockSessionOpen,
@@ -188,11 +190,12 @@ describe('PiProvider', () => {
     mockDispose.mockClear();
     mockSubscribe.mockClear();
     mockBindExtensions.mockClear();
+    mockSetModel.mockClear();
     mockSetFlagValue.mockClear();
     mockResourceLoaderReload.mockClear();
     mockCreateAgentSession.mockClear();
     mockAuthCreate.mockClear();
-    mockModelRegistryCreate.mockClear();
+    mockModelRegistryInMemory.mockClear();
     mockModelRegistryFind.mockClear();
     mockSetRuntimeApiKey.mockClear();
     mockGetApiKey.mockClear();
@@ -280,12 +283,10 @@ describe('PiProvider', () => {
     expect(mockCreateAgentSession).toHaveBeenCalledTimes(1);
   });
 
-  test('ModelRegistry.create receives the AuthStorage instance', async () => {
-    // Headline-fix wiring: ModelRegistry.create must receive the same
-    // AuthStorage instance returned by AuthStorage.create(), so registry
-    // lookups can resolve user-configured custom models from
-    // ~/.pi/agent/models.json (LM Studio, ollama, llamacpp, etc.). Without
-    // this wiring the registry only sees the static built-in catalog.
+  test('ModelRegistry.inMemory receives the AuthStorage instance', async () => {
+    // ModelRegistry.inMemory must receive the same AuthStorage instance
+    // returned by AuthStorage.create(), so extension providers can resolve
+    // credentials and register models during bindExtensions().
     process.env.GEMINI_API_KEY = 'sk-test';
     resetScript(scriptedAgentEnd());
 
@@ -296,9 +297,9 @@ describe('PiProvider', () => {
     );
 
     expect(mockAuthCreate).toHaveBeenCalledTimes(1);
-    expect(mockModelRegistryCreate).toHaveBeenCalledTimes(1);
+    expect(mockModelRegistryInMemory).toHaveBeenCalledTimes(1);
     const authInstance = mockAuthCreate.mock.results[0]?.value;
-    expect(mockModelRegistryCreate).toHaveBeenCalledWith(authInstance);
+    expect(mockModelRegistryInMemory).toHaveBeenCalledWith(authInstance);
   });
 
   test('AuthStorage.create() throwing surfaces a contextualized error', async () => {
@@ -328,16 +329,20 @@ describe('PiProvider', () => {
 
   test('Pi model not found includes models.json load error when registry reports one', async () => {
     // ModelRegistry swallows models.json parse/validation errors into an
-    // internal loadError. When find() returns undefined we surface that
-    // error in both the structured log and the throw message so users
-    // debugging a custom-provider config see the actual reason.
+    // internal loadError. When find() returns undefined at step 3, we log
+    // the warning and defer to extension resolution. If still not found
+    // after bindExtensions(), the provider throws.
     process.env.GEMINI_API_KEY = 'sk-test';
+    // find() is called twice: step 3 (static catalog) and step 4g (after
+    // bindExtensions). Both must return undefined to trigger the error.
     mockModelRegistryFind.mockImplementationOnce(() => undefined);
-    mockModelRegistryCreate.mockImplementationOnce(() => ({
+    mockModelRegistryFind.mockImplementationOnce(() => undefined);
+    mockModelRegistryInMemory.mockImplementationOnce(() => ({
       find: mockModelRegistryFind,
       getError: () => 'Provider lm-studio: "baseUrl" is required when defining custom models.',
     }));
 
+    resetScript(scriptedAgentEnd());
     const { error } = await consume(
       new PiProvider().sendQuery('hi', '/tmp', undefined, {
         model: 'lm-studio/some-model',
@@ -345,15 +350,14 @@ describe('PiProvider', () => {
     );
 
     expect(error?.message).toContain('Pi model not found');
-    expect(error?.message).toContain('models.json failed to load');
-    expect(error?.message).toContain('"baseUrl" is required');
-    expect(mockLogger.error).toHaveBeenCalledWith(
+    expect(error?.message).toContain('provider extension');
+    expect(mockLogger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
         piProvider: 'lm-studio',
         modelId: 'some-model',
         loadError: expect.stringContaining('"baseUrl" is required'),
       }),
-      'pi.model_not_found'
+      'pi.model_registry_load_error'
     );
   });
 
@@ -407,17 +411,18 @@ describe('PiProvider', () => {
 
   test('throws when ModelRegistry.find returns undefined', async () => {
     process.env.GEMINI_API_KEY = 'sk-test';
-    // 'nonexistent' is handled in mockModelRegistryFind to return undefined, but
-    // the adapter rejects unknown providers. To exercise
-    // the not-found branch, use a known provider but unknown modelId by
-    // temporarily swapping mockModelRegistryFind to always return undefined.
+    // find() is called twice: step 3 (static catalog) and step 4g (after
+    // bindExtensions). Both must return undefined to trigger the error.
     mockModelRegistryFind.mockImplementationOnce(() => undefined);
+    mockModelRegistryFind.mockImplementationOnce(() => undefined);
+    resetScript(scriptedAgentEnd());
     const { error } = await consume(
       new PiProvider().sendQuery('hi', '/tmp', undefined, {
         model: 'google/unknown-model-id',
       })
     );
     expect(error?.message).toContain('Pi model not found');
+    expect(error?.message).toContain('provider extension');
   });
 
   test('request env (codebase env vars) overrides process.env via setRuntimeApiKey', async () => {

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -421,6 +421,31 @@ describe('PiProvider', () => {
     expect(error?.message).toContain('provider extension');
   });
 
+  test('deferred resolution: calls session.setModel when find() resolves after bindExtensions', async () => {
+    // Phase 1: model not in static catalog (extension provider path).
+    // Phase 2: extension registers the model during bindExtensions() and find() succeeds.
+    mockModelRegistryFind.mockImplementationOnce(() => undefined);
+    mockModelRegistryFind.mockImplementationOnce(() => ({
+      id: 'custom-model',
+      provider: 'extension-provider',
+      name: 'extension-provider/custom-model',
+    }));
+    resetScript(scriptedAgentEnd());
+
+    const { error } = await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, {
+        model: 'extension-provider/custom-model',
+      })
+    );
+
+    expect(error).toBeUndefined();
+    expect(mockModelRegistryFind).toHaveBeenCalledTimes(2);
+    expect(mockSetModel).toHaveBeenCalledTimes(1);
+    expect(mockSetModel).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'custom-model', provider: 'extension-provider' })
+    );
+  });
+
   test('request env (codebase env vars) overrides process.env via setRuntimeApiKey', async () => {
     process.env.GEMINI_API_KEY = 'from-process-env';
     resetScript([

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -237,22 +237,10 @@ export class PiProvider implements IAgentProvider {
       );
     }
 
-    // 2. Build AuthStorage + ModelRegistry.
-    //
-    //    AuthStorage.create() reads ~/.pi/agent/auth.json (or
-    //    $PI_CODING_AGENT_DIR/auth.json) — credentials populated via
-    //    `pi` → `/login` or hand-edited api_key entries.
-    //
-    //    ModelRegistry.create() loads both the built-in static catalog AND
-    //    custom providers from ~/.pi/agent/models.json (e.g. ollama, LM
-    //    Studio). Despite the earlier assumption, create() returns the same
-    //    ModelRegistry class as inMemory() — registerProvider() works on
-    //    both, so extension providers (e.g. pi-provider-kiro) can still
-    //    register their models dynamically during session.bindExtensions().
-    //
-    //    Both reads are synchronous and happen on every sendQuery; we don't
-    //    cache because the user can edit auth.json between calls and expects
-    //    pickup without restart.
+    // 2. Build AuthStorage + ModelRegistry. Both read on every sendQuery —
+    //    user edits to auth.json or models.json take effect without restart.
+    //    ModelRegistry.create() is mutable: extension providers can call registerProvider()
+    //    on it during bindExtensions() to add their models (phase 2 resolution).
     let authStorage: ReturnType<typeof piCodingAgent.AuthStorage.create>;
     let modelRegistry: ReturnType<typeof piCodingAgent.ModelRegistry.create>;
     try {
@@ -267,17 +255,8 @@ export class PiProvider implements IAgentProvider {
       );
     }
 
-    // 3. First-pass model lookup (phase 1 of 2).
-    //
-    //    modelRegistry.find() checks Pi's built-in static catalog (google,
-    //    anthropic, openai, etc.). For these providers, the model is
-    //    resolved immediately and we can fail-fast on missing credentials.
-    //
-    //    Extension-registered providers (e.g. pi-provider-kiro for Kiro API
-    //    models) are NOT in the static catalog — they register their models
-    //    on the ModelRegistry during session.bindExtensions() (step 4f).
-    //    When find() returns undefined here, we defer resolution to step 4g
-    //    (phase 2) which runs after bindExtensions().
+    // 3. [LOOKUP-1] Check the static catalog first (phase 1 of 2).
+    //    Extension providers (e.g. kiro) aren't in the catalog — defer to LOOKUP-2 after bindExtensions().
     let model = modelRegistry.find(parsed.provider, parsed.modelId);
     if (!model) {
       // Surface any models.json load error as a warning — helps debug
@@ -297,24 +276,8 @@ export class PiProvider implements IAgentProvider {
       );
     }
 
-    // 4. Resolve credentials. authStorage already loaded ~/.pi/agent/auth.json
-    //    so any creds populated via `pi` → `/login` (OAuth subscriptions:
-    //    Claude Pro/Max, ChatGPT Plus, GitHub Copilot, Gemini CLI,
-    //    Antigravity) or by hand-edited api_key entries are picked up
-    //    transparently. Per-request env vars override via setRuntimeApiKey —
-    //    mirrors Claude's process-env + request-env merge so codebase-scoped
-    //    env vars (.archon/config.yaml `env:`) win over the user's global
-    //    Pi login.
-    //
-    //    Pi's internal resolution order:
-    //      1. runtime override  (our setRuntimeApiKey below)
-    //      2. auth.json api_key entry
-    //      3. auth.json oauth entry  (auto-refreshes expired tokens)
-    //      4. env var fallback     (Pi's getEnvApiKey, e.g. ANTHROPIC_API_KEY)
-    //
-    //    OAuth refresh note: Pi refreshes expired access tokens against the
-    //    provider's OAuth server and rewrites ~/.pi/agent/auth.json under a
-    //    file lock (same mechanism pi CLI uses — safe for concurrent access).
+    // 4. Resolve credentials. Per-request env vars override auth.json entries via
+    //    setRuntimeApiKey — codebase-scoped env vars win over the user's global Pi login.
     const envVarName = PI_PROVIDER_ENV_VARS[parsed.provider];
     const envOverride = envVarName
       ? (requestOptions?.env?.[envVarName] ?? process.env[envVarName])
@@ -323,17 +286,9 @@ export class PiProvider implements IAgentProvider {
       authStorage.setRuntimeApiKey(parsed.provider, envOverride);
     }
 
-    // Auth fail-fast — only when the model was found in the static catalog.
-    //
-    // Built-in providers (google, anthropic, openai, etc.) use Pi's
-    // AuthStorage for credentials, so we can validate early and give a
-    // clear error message with env-var and /login hints.
-    //
-    // Extension-registered providers (like kiro) manage their own
-    // credentials entirely outside Pi's AuthStorage (e.g. kiro uses
-    // AWS SSO/OIDC via ~/.aws/sso/cache/). Checking Pi's AuthStorage
-    // for them would always fail, so we skip the check and let the
-    // extension handle auth during its own streaming flow.
+    // Auth validation deferred for extension providers — they manage credentials
+    // outside Pi's AuthStorage (e.g. kiro uses AWS SSO/OIDC via ~/.aws/sso/cache/).
+    // Only validate early for static-catalog models where we can give actionable hints.
     if (model) {
       const resolvedKey = await authStorage.getApiKey(parsed.provider);
       if (!resolvedKey) {
@@ -528,10 +483,7 @@ export class PiProvider implements IAgentProvider {
       ...(filteredTools !== undefined ? { tools: filteredTools } : {}),
     });
 
-    // Suppress the model fallback warning when we're doing deferred
-    // resolution (model is null). Pi's session restore can't find extension
-    // models in the static catalog and emits a misleading "Could not restore
-    // model X, using Y" message. We'll set the correct model in step 4g.
+    // Extension models aren't in the static catalog — skip the fallback warning.
     if (modelFallbackMessage && model) {
       yield { type: 'system', content: `⚠️ ${modelFallbackMessage}` };
     }
@@ -547,18 +499,9 @@ export class PiProvider implements IAgentProvider {
       }
     }
 
-    // 4f. Bind UI context (so ctx.hasUI is true and ctx.ui.notify() forwards
-    //     into the chunk stream) or fire session_start with no UI. Must run
-    //     after flag pass-through above.
-    //
-    //     IMPORTANT: bindExtensions() is the trigger that causes extension
-    //     providers to register their models. Internally, Pi wires
-    //     providerActions into the ExtensionRunner, which fires each
-    //     extension's session_start handler. Extensions like pi-provider-kiro
-    //     call pi.registerProvider("kiro", ...) during session_start, which
-    //     adds their models to our modelRegistry instance. This is why
-    //     ModelRegistry.inMemory() is required (step 2) — create() returns
-    //     an immutable registry that registerProvider() can't modify.
+    // 4f. Bind UI context or fire session_start with no UI. Must run after flag pass-through above.
+    //     Extension providers register their models during bindExtensions() — this is the trigger
+    //     for LOOKUP-2: they call registerProvider() on our modelRegistry during session_start.
     const uiBridge = interactive ? createArchonUIBridge() : undefined;
     if (uiBridge) {
       const uiContext = createArchonUIContext(uiBridge);
@@ -567,19 +510,12 @@ export class PiProvider implements IAgentProvider {
       await session.bindExtensions({});
     }
 
-    // 4g. Deferred model resolution (phase 2 of 2) for extension providers.
-    //
-    //     After bindExtensions(), extension providers have registered their
-    //     models on our modelRegistry. Now modelRegistry.find() can resolve
-    //     models that weren't in the static catalog at step 3.
-    //
-    //     session.setModel() switches the session to the resolved model.
-    //     This is safe because no prompt has been sent yet — the session was
-    //     created without a model (or with a fallback) and we're replacing
-    //     it before the first prompt() call.
+    // 4g. [LOOKUP-2] Re-check the registry after bindExtensions() for extension-registered models.
+    //     Safe to call session.setModel() here — no prompt has been sent yet.
     if (!model) {
       model = modelRegistry.find(parsed.provider, parsed.modelId);
       if (!model) {
+        session.dispose();
         throw new Error(
           `Pi model not found: provider='${parsed.provider}' model='${parsed.modelId}'. ` +
             'The model was not found in the static catalog or via any installed extension. ' +
@@ -587,7 +523,12 @@ export class PiProvider implements IAgentProvider {
             'and `enableExtensions: true` is set in .archon/config.yaml.'
         );
       }
-      await session.setModel(model);
+      try {
+        await session.setModel(model);
+      } catch (err) {
+        session.dispose();
+        throw err;
+      }
     }
 
     // 5. Structured output (best-effort). Pi has no SDK-level JSON schema

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -243,22 +243,21 @@ export class PiProvider implements IAgentProvider {
     //    $PI_CODING_AGENT_DIR/auth.json) — credentials populated via
     //    `pi` → `/login` or hand-edited api_key entries.
     //
-    //    ModelRegistry.inMemory() is used instead of ModelRegistry.create()
-    //    for a critical reason: create() reads ~/.pi/agent/models.json and
-    //    returns an immutable registry — fine for static/custom models, but
-    //    extension providers (e.g. pi-provider-kiro) register their models
-    //    dynamically during session.bindExtensions(). inMemory() creates a
-    //    mutable registry that extensions can call registerProvider() on,
-    //    while still exposing the built-in static model catalog via find().
+    //    ModelRegistry.create() loads both the built-in static catalog AND
+    //    custom providers from ~/.pi/agent/models.json (e.g. ollama, LM
+    //    Studio). Despite the earlier assumption, create() returns the same
+    //    ModelRegistry class as inMemory() — registerProvider() works on
+    //    both, so extension providers (e.g. pi-provider-kiro) can still
+    //    register their models dynamically during session.bindExtensions().
     //
     //    Both reads are synchronous and happen on every sendQuery; we don't
     //    cache because the user can edit auth.json between calls and expects
     //    pickup without restart.
     let authStorage: ReturnType<typeof piCodingAgent.AuthStorage.create>;
-    let modelRegistry: ReturnType<typeof piCodingAgent.ModelRegistry.inMemory>;
+    let modelRegistry: ReturnType<typeof piCodingAgent.ModelRegistry.create>;
     try {
       authStorage = piCodingAgent.AuthStorage.create();
-      modelRegistry = piCodingAgent.ModelRegistry.inMemory(authStorage);
+      modelRegistry = piCodingAgent.ModelRegistry.create(authStorage);
     } catch (err) {
       const e = err as Error;
       getLog().error({ err: e, piProvider: parsed.provider }, 'pi.auth_storage_init_failed');

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -237,23 +237,28 @@ export class PiProvider implements IAgentProvider {
       );
     }
 
-    // 2. Build AuthStorage + ModelRegistry. Both `create()` calls read from
-    //    disk: AuthStorage reads ~/.pi/agent/auth.json (or
-    //    $PI_CODING_AGENT_DIR/auth.json), and ModelRegistry reads
-    //    ~/.pi/agent/models.json — the user's per-host config including
-    //    custom models for local providers (LM Studio, ollama, llamacpp,
-    //    custom OpenAI-compatible endpoints). Reads are synchronous and
-    //    happen on every sendQuery; we don't cache because the user can
-    //    edit either file between calls and expects pickup without restart
-    //    (Pi's `/login` flow rewrites auth.json under a file lock).
-    //    ModelRegistry captures any models.json load/parse error in its
-    //    internal loadError rather than throwing — surfaced below if the
-    //    requested model is then not found.
+    // 2. Build AuthStorage + ModelRegistry.
+    //
+    //    AuthStorage.create() reads ~/.pi/agent/auth.json (or
+    //    $PI_CODING_AGENT_DIR/auth.json) — credentials populated via
+    //    `pi` → `/login` or hand-edited api_key entries.
+    //
+    //    ModelRegistry.inMemory() is used instead of ModelRegistry.create()
+    //    for a critical reason: create() reads ~/.pi/agent/models.json and
+    //    returns an immutable registry — fine for static/custom models, but
+    //    extension providers (e.g. pi-provider-kiro) register their models
+    //    dynamically during session.bindExtensions(). inMemory() creates a
+    //    mutable registry that extensions can call registerProvider() on,
+    //    while still exposing the built-in static model catalog via find().
+    //
+    //    Both reads are synchronous and happen on every sendQuery; we don't
+    //    cache because the user can edit auth.json between calls and expects
+    //    pickup without restart.
     let authStorage: ReturnType<typeof piCodingAgent.AuthStorage.create>;
-    let modelRegistry: ReturnType<typeof piCodingAgent.ModelRegistry.create>;
+    let modelRegistry: ReturnType<typeof piCodingAgent.ModelRegistry.inMemory>;
     try {
       authStorage = piCodingAgent.AuthStorage.create();
-      modelRegistry = piCodingAgent.ModelRegistry.create(authStorage);
+      modelRegistry = piCodingAgent.ModelRegistry.inMemory(authStorage);
     } catch (err) {
       const e = err as Error;
       getLog().error({ err: e, piProvider: parsed.provider }, 'pi.auth_storage_init_failed');
@@ -263,27 +268,33 @@ export class PiProvider implements IAgentProvider {
       );
     }
 
-    // 3. Look up the model. find() returns undefined when not found; if
-    //    models.json itself failed to load (e.g. a custom provider entry
-    //    missing baseUrl/apiKey), surface the load error so users debugging
-    //    custom-provider configs see the actual reason.
-    const model = modelRegistry.find(parsed.provider, parsed.modelId);
+    // 3. First-pass model lookup (phase 1 of 2).
+    //
+    //    modelRegistry.find() checks Pi's built-in static catalog (google,
+    //    anthropic, openai, etc.). For these providers, the model is
+    //    resolved immediately and we can fail-fast on missing credentials.
+    //
+    //    Extension-registered providers (e.g. pi-provider-kiro for Kiro API
+    //    models) are NOT in the static catalog — they register their models
+    //    on the ModelRegistry during session.bindExtensions() (step 4f).
+    //    When find() returns undefined here, we defer resolution to step 4g
+    //    (phase 2) which runs after bindExtensions().
+    let model = modelRegistry.find(parsed.provider, parsed.modelId);
     if (!model) {
+      // Surface any models.json load error as a warning — helps debug
+      // custom-provider configs (e.g. missing baseUrl in models.json).
       const loadError = modelRegistry.getError?.();
-      const loadErrorHint = loadError
-        ? ` ~/.pi/agent/models.json failed to load: ${loadError}`
-        : '';
-      getLog().error(
-        {
-          piProvider: parsed.provider,
-          modelId: parsed.modelId,
-          loadError: loadError ?? null,
-        },
-        'pi.model_not_found'
-      );
-      throw new Error(
-        `Pi model not found: provider='${parsed.provider}' model='${parsed.modelId}'.${loadErrorHint} ` +
-          'See https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/models.generated.ts for the Pi model catalog.'
+      if (loadError) {
+        getLog().warn(
+          { piProvider: parsed.provider, modelId: parsed.modelId, loadError },
+          'pi.model_registry_load_error'
+        );
+      }
+      // Not an error yet — extension providers will register during
+      // bindExtensions(). Log at info so the deferral is visible in logs.
+      getLog().info(
+        { piProvider: parsed.provider, modelId: parsed.modelId },
+        'pi.model_not_in_static_catalog_deferring'
       );
     }
 
@@ -313,29 +324,42 @@ export class PiProvider implements IAgentProvider {
       authStorage.setRuntimeApiKey(parsed.provider, envOverride);
     }
 
-    const resolvedKey = await authStorage.getApiKey(parsed.provider);
-    if (!resolvedKey) {
-      if (envVarName) {
-        const envHint = `Set ${envVarName} in the environment or codebase env vars (.archon/config.yaml env: section).`;
-        const loginHint = `Or run \`pi\` and type \`/login\` locally to authenticate '${parsed.provider}' via OAuth; credentials land in ~/.pi/agent/auth.json and are picked up automatically.`;
-        throw new Error(
-          `Pi auth: no credentials for provider '${parsed.provider}'. ${envHint} ${loginHint}`
+    // Auth fail-fast — only when the model was found in the static catalog.
+    //
+    // Built-in providers (google, anthropic, openai, etc.) use Pi's
+    // AuthStorage for credentials, so we can validate early and give a
+    // clear error message with env-var and /login hints.
+    //
+    // Extension-registered providers (like kiro) manage their own
+    // credentials entirely outside Pi's AuthStorage (e.g. kiro uses
+    // AWS SSO/OIDC via ~/.aws/sso/cache/). Checking Pi's AuthStorage
+    // for them would always fail, so we skip the check and let the
+    // extension handle auth during its own streaming flow.
+    if (model) {
+      const resolvedKey = await authStorage.getApiKey(parsed.provider);
+      if (!resolvedKey) {
+        if (envVarName) {
+          const envHint = `Set ${envVarName} in the environment or codebase env vars (.archon/config.yaml env: section).`;
+          const loginHint = `Or run \`pi\` and type \`/login\` locally to authenticate '${parsed.provider}' via OAuth; credentials land in ~/.pi/agent/auth.json and are picked up automatically.`;
+          throw new Error(
+            `Pi auth: no credentials for provider '${parsed.provider}'. ${envHint} ${loginHint}`
+          );
+        }
+
+        // Unmapped providers (LM Studio, ollama, llamacpp, custom
+        // OpenAI-compatible endpoints) often don't need credentials at all —
+        // log + continue rather than failing fast so local models work without
+        // ceremony. If the SDK call later fails for a provider that *does*
+        // need creds, the auth_missing breadcrumb is searchable in the log.
+        getLog().info(
+          {
+            piProvider: parsed.provider,
+            envHint: `Provider '${parsed.provider}' is not in the Archon adapter's env-var table — file an issue if you want a shortcut env var for it.`,
+            loginHint: `Or run \`pi\` and type \`/login\` locally to authenticate '${parsed.provider}' via OAuth; credentials land in ~/.pi/agent/auth.json and are picked up automatically.`,
+          },
+          'pi.auth_missing'
         );
       }
-
-      // Unmapped providers (LM Studio, ollama, llamacpp, custom
-      // OpenAI-compatible endpoints) often don't need credentials at all —
-      // log + continue rather than failing fast so local models work without
-      // ceremony. If the SDK call later fails for a provider that *does*
-      // need creds, the auth_missing breadcrumb is searchable in the log.
-      getLog().info(
-        {
-          piProvider: parsed.provider,
-          envHint: `Provider '${parsed.provider}' is not in the Archon adapter's env-var table — file an issue if you want a shortcut env var for it.`,
-          loginHint: `Or run \`pi\` and type \`/login\` locally to authenticate '${parsed.provider}' via OAuth; credentials land in ~/.pi/agent/auth.json and are picked up automatically.`,
-        },
-        'pi.auth_missing'
-      );
     }
 
     // 4. Translate Archon nodeConfig to Pi SDK options. All three translations
@@ -492,7 +516,10 @@ export class PiProvider implements IAgentProvider {
 
     const { session, modelFallbackMessage } = await createAgentSession({
       cwd,
-      model,
+      // model is omitted when not yet resolved (extension provider path).
+      // createAgentSession accepts this — the model will be set via
+      // session.setModel() after bindExtensions() resolves it (step 4g).
+      ...(model ? { model } : {}),
       authStorage,
       modelRegistry,
       sessionManager,
@@ -502,7 +529,11 @@ export class PiProvider implements IAgentProvider {
       ...(filteredTools !== undefined ? { tools: filteredTools } : {}),
     });
 
-    if (modelFallbackMessage) {
+    // Suppress the model fallback warning when we're doing deferred
+    // resolution (model is null). Pi's session restore can't find extension
+    // models in the static catalog and emits a misleading "Could not restore
+    // model X, using Y" message. We'll set the correct model in step 4g.
+    if (modelFallbackMessage && model) {
       yield { type: 'system', content: `⚠️ ${modelFallbackMessage}` };
     }
 
@@ -520,12 +551,44 @@ export class PiProvider implements IAgentProvider {
     // 4f. Bind UI context (so ctx.hasUI is true and ctx.ui.notify() forwards
     //     into the chunk stream) or fire session_start with no UI. Must run
     //     after flag pass-through above.
+    //
+    //     IMPORTANT: bindExtensions() is the trigger that causes extension
+    //     providers to register their models. Internally, Pi wires
+    //     providerActions into the ExtensionRunner, which fires each
+    //     extension's session_start handler. Extensions like pi-provider-kiro
+    //     call pi.registerProvider("kiro", ...) during session_start, which
+    //     adds their models to our modelRegistry instance. This is why
+    //     ModelRegistry.inMemory() is required (step 2) — create() returns
+    //     an immutable registry that registerProvider() can't modify.
     const uiBridge = interactive ? createArchonUIBridge() : undefined;
     if (uiBridge) {
       const uiContext = createArchonUIContext(uiBridge);
       await session.bindExtensions({ uiContext });
     } else if (enableExtensions) {
       await session.bindExtensions({});
+    }
+
+    // 4g. Deferred model resolution (phase 2 of 2) for extension providers.
+    //
+    //     After bindExtensions(), extension providers have registered their
+    //     models on our modelRegistry. Now modelRegistry.find() can resolve
+    //     models that weren't in the static catalog at step 3.
+    //
+    //     session.setModel() switches the session to the resolved model.
+    //     This is safe because no prompt has been sent yet — the session was
+    //     created without a model (or with a fallback) and we're replacing
+    //     it before the first prompt() call.
+    if (!model) {
+      model = modelRegistry.find(parsed.provider, parsed.modelId);
+      if (!model) {
+        throw new Error(
+          `Pi model not found: provider='${parsed.provider}' model='${parsed.modelId}'. ` +
+            'The model was not found in the static catalog or via any installed extension. ' +
+            'Ensure the provider extension is installed (e.g. `pi install npm:pi-provider-kiro`) ' +
+            'and `enableExtensions: true` is set in .archon/config.yaml.'
+        );
+      }
+      await session.setModel(model);
     }
 
     // 5. Structured output (best-effort). Pi has no SDK-level JSON schema


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: Extension providers (e.g. `pi-provider-kiro`) register their models on the `ModelRegistry` during `session.bindExtensions()`, but the current code calls `modelRegistry.find()` *before* `bindExtensions()` and throws immediately when the model isn't found — blocking all extension-registered models.
- Why it matters: Enables Archon users to access 20 free models (Claude, DeepSeek, Qwen, Kimi, MiniMax, etc.) through the Kiro API via the [pi-provider-kiro](https://github.com/mikeyobrien/pi-provider-kiro) extension. Without this change, `provider: pi` + `model: kiro/claude-sonnet-4-6` always throws "Pi model not found."
- What changed: Two-phase model resolution — phase 1 checks the static catalog before `bindExtensions()`, phase 2 retries after `bindExtensions()` when extension providers have registered their models. Also switches `ModelRegistry.create()` → `ModelRegistry.inMemory()` so extensions can call `registerProvider()` on a mutable registry.
- What did **not** change (scope boundary): Built-in providers (google, anthropic, openai, etc.) follow the exact same code path as before — phase 1 resolves them immediately. The `ensurePiPackageDirShim()` for compiled binary support is preserved. No changes to any other provider, the registry, config, or the DAG executor.

## UX Journey

### Before

```
 User                    Archon Pi Provider         Pi SDK
 ────                    ──────────────────         ──────
 sets model:             modelRegistry.find()
 kiro/claude-sonnet-4-6  → returns undefined
                         ✖ throws "Pi model
                           not found"
                         (workflow fails)
```

### After

```
 User                    Archon Pi Provider         Pi SDK / Extension
 ────                    ──────────────────         ──────────────────
 sets model:             modelRegistry.find()
 kiro/claude-sonnet-4-6  → returns undefined
                         [logs: deferring to
                          extension resolution]
                         createAgentSession()
                          (no model arg)
                         bindExtensions()  ──────▶  pi-provider-kiro calls
                                                    registerProvider("kiro")
                         [modelRegistry.find()      on mutable registry
                          → returns kiro model]
                         session.setModel() ──────▶ switches to kiro model
                         session.prompt()   ──────▶ streams via Kiro API
 sees response ◀──────── yields chunks
```

## Architecture Diagram

### Before

```
 workflow YAML (provider: pi, model: kiro/...)
       │
       ▼
 PiProvider.sendQuery()
       │
       ├─ ModelRegistry.create(authStorage)  ← immutable, reads models.json
       │       │
       │       ▼
       │  registry.find(kiro, claude-sonnet-4-6)
       │       │
       │       ▼
       │  ✖ NOT FOUND → throw Error
       │
       ├─ (never reached) createAgentSession()
       ├─ (never reached) bindExtensions()
       └─ (never reached) session.prompt()
```

### After

```
 workflow YAML (provider: pi, model: kiro/...)
       │
       ▼
 [~] PiProvider.sendQuery()
       │
       ├─ [~] ModelRegistry.inMemory(authStorage)  ← mutable registry
       │       │
       │       ▼
       │  registry.find(kiro, claude-sonnet-4-6)
       │       │
       │       ▼
       │  NOT FOUND → log info, defer
       │
       ├─ createAgentSession(no model)
       │
       ├─ bindExtensions()
       │       │
       │       ▼
       │  [+] pi-provider-kiro registers models on modelRegistry
       │
       ├─ [+] registry.find(kiro, claude-sonnet-4-6) → FOUND
       ├─ [+] session.setModel(kiroModel)
       │
       └─ session.prompt() → streams response
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| PiProvider | ModelRegistry | **modified** | `create()` → `inMemory()` for mutable registry |
| PiProvider | createAgentSession | **modified** | model arg now conditional (omitted for extension path) |
| PiProvider | session.setModel | **new** | deferred model switch after bindExtensions |
| PiProvider | session.bindExtensions | unchanged | still called in same position |
| PiProvider | AuthStorage | unchanged | |
| PiProvider | event-bridge | unchanged | |
| PiProvider | options-translator | unchanged | |
| pi-provider-kiro extension | ModelRegistry | **new** (runtime) | registers provider during bindExtensions |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `providers`
- Module: `providers:community/pi`

## Change Metadata

- Change type: `feature`
- Primary scope: `providers`

## Linked Issue

- Related #1284 (ModelRegistry support for custom models — this PR extends it to extension-registered models)
- Related #1096 (original custom model support request)

## Validation Evidence (required)

Commands and result summary:

```bash
bun x tsc --noEmit -p packages/providers/tsconfig.json  # ✅ clean
bun test src/community/pi/provider.test.ts               # ✅ 59 pass, 0 fail
bun test src/registry.test.ts                             # ✅ 32 pass, 0 fail
```

- Evidence provided: All 59 Pi provider tests pass. Type-check clean. End-to-end workflow tested with two different Kiro models (see Human Verification below).
- If any command is intentionally skipped, explain why: `bun run validate` not run at monorepo root — only the `packages/providers` package is affected. Full CI will cover the rest.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No` (extension providers make their own calls; this PR doesn't add any)
- Secrets/tokens handling changed? `No` (auth fail-fast is now conditional — skipped for extension providers that manage their own credentials — but no new secret handling)
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes` — built-in providers follow the identical code path. `ModelRegistry.inMemory()` exposes the same `find()` interface as `create()`.
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
  - `archon workflow run archon-test-pi` with `kiro/claude-sonnet-4-6` — ✅ correct factual answer + verification node passes
  - `archon workflow run archon-test-pi` with `kiro/minimax-m2-5` — ✅ correct factual answer + verification node passes
  - Built-in model `google/gemini-2.5-pro` — ✅ still works (no regression)
  - Model not found in static catalog AND not found after bindExtensions — ✅ throws clear error with extension install hint
- Edge cases checked:
  - Session resume on second node (verify node) — no misleading "Could not restore model" warning (suppressed for deferred resolution path)
  - `enableExtensions: false` — extension models correctly fail with "not found" error
  - `models.json` load error — warning logged, deferred resolution still attempted
- What was not verified: `ModelRegistry.inMemory()` behavior with `~/.pi/agent/models.json` custom models (LM Studio, ollama) — no local setup to test, but `inMemory()` still exposes the static catalog via `find()` per Pi SDK docs.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Only `packages/providers/src/community/pi/provider.ts` — the Pi community provider's `sendQuery()` method.
- Potential unintended effects: `ModelRegistry.inMemory()` may not load `~/.pi/agent/models.json` custom models the way `ModelRegistry.create()` does. Users relying on custom models.json entries should verify after upgrade. The static built-in catalog is unaffected.
- Guardrails/monitoring for early detection: `pi.model_not_in_static_catalog_deferring` log event fires whenever phase 1 misses — searchable in logs. `pi.model_registry_load_error` warns on models.json issues.

## Rollback Plan (required)

- Fast rollback command/path: Revert this single commit — change `inMemory` back to `create`, remove the `if (!model)` deferred resolution block, restore hard-fail in step 3.
- Feature flags or config toggles (if any): `enableExtensions: false` in `~/.archon/config.yaml` disables extension loading entirely, which effectively disables the deferred resolution path.
- Observable failure symptoms: If rollback is needed, users will see "Pi model not found" errors for extension-registered models (kiro/*). Built-in models are unaffected.

## Risks and Mitigations

- Risk: `ModelRegistry.inMemory()` may not discover custom models from `~/.pi/agent/models.json` that `ModelRegistry.create()` loaded.
  - Mitigation: The static built-in catalog (google, anthropic, openai, etc.) is still available via `find()`. Custom models.json is a niche feature added in #1284 — if regression is confirmed, a follow-up can merge both approaches (call `create()` then copy entries into an `inMemory()` instance).

- Risk: `session.setModel()` called after `createAgentSession()` but before `prompt()` — relies on Pi SDK allowing model switch mid-session.
  - Mitigation: Validated end-to-end with two different Kiro models. Pi SDK's `setModel()` is a documented API. No prompt has been sent yet when `setModel()` is called, so the session state is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added example workflows that run parallel Pi and Ollama prompts with a verification step emitting one of four fixed verification statuses.

* **Documentation**
  * Added a README with installation and CLI/provider setup for running Pi-based example workflows.

* **Bug Fixes**
  * Improved Pi provider model resolution, deferred resolution until extensions bind, reduced false auth failures, and added clearer error logging.

* **Tests**
  * Updated tests to reflect revised model-resolution and session behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1509)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->