### PR TITLE
fix(core): use runtime workspacesPath in orchestrator prompts instead of hardcoded paths

### DIFF
--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -489,9 +489,11 @@ function buildFullPrompt(
     ? codebases.find(c => c.id === conversation.codebase_id)
     : undefined;
 
+  const workspacesPath = getArchonWorkspacesPath();
+
   const systemPrompt = scopedCodebase
-    ? buildProjectScopedPrompt(scopedCodebase, codebases, workflows)
-    : buildOrchestratorPrompt(codebases, workflows);
+    ? buildProjectScopedPrompt(scopedCodebase, codebases, workflows, workspacesPath)
+    : buildOrchestratorPrompt(codebases, workflows, workspacesPath);
 
   const contextSuffix = issueContext ? '\n\n---\n\n## Additional Context\n\n' + issueContext : '';
 

--- a/packages/core/src/orchestrator/orchestrator.test.ts
+++ b/packages/core/src/orchestrator/orchestrator.test.ts
@@ -618,7 +618,11 @@ describe('orchestrator-agent handleMessage', () => {
       await handleMessage(platform, 'chat-456', 'help me');
 
       expect(mockListCodebases).toHaveBeenCalled();
-      expect(mockBuildOrchestratorPrompt).toHaveBeenCalledWith([mockCodebase], expect.any(Array));
+      expect(mockBuildOrchestratorPrompt).toHaveBeenCalledWith(
+        [mockCodebase],
+        expect.any(Array),
+        expect.any(String)
+      );
     });
 
     test('builds project-scoped prompt when conversation has codebase_id', async () => {
@@ -635,7 +639,8 @@ describe('orchestrator-agent handleMessage', () => {
       expect(mockBuildProjectScopedPrompt).toHaveBeenCalledWith(
         mockCodebase,
         [mockCodebase],
-        expect.any(Array)
+        expect.any(Array),
+        expect.any(String)
       );
     });
 

--- a/packages/core/src/orchestrator/orchestrator.test.ts
+++ b/packages/core/src/orchestrator/orchestrator.test.ts
@@ -621,7 +621,7 @@ describe('orchestrator-agent handleMessage', () => {
       expect(mockBuildOrchestratorPrompt).toHaveBeenCalledWith(
         [mockCodebase],
         expect.any(Array),
-        expect.any(String)
+        '/home/test/.archon/workspaces'
       );
     });
 
@@ -640,7 +640,7 @@ describe('orchestrator-agent handleMessage', () => {
         mockCodebase,
         [mockCodebase],
         expect.any(Array),
-        expect.any(String)
+        '/home/test/.archon/workspaces'
       );
     });
 

--- a/packages/core/src/orchestrator/prompt-builder.test.ts
+++ b/packages/core/src/orchestrator/prompt-builder.test.ts
@@ -30,6 +30,12 @@ describe('buildRoutingRulesWithProject', () => {
 
     expect(rules).toContain('NO knowledge of the conversation history');
   });
+
+  test('clone instruction uses provided workspacesPath', () => {
+    const rules = buildRoutingRulesWithProject(undefined, '/.archon/workspaces');
+    expect(rules).toContain('/.archon/workspaces');
+    expect(rules).not.toContain('~/.archon');
+  });
 });
 
 describe('formatWorkflowContextSection', () => {

--- a/packages/core/src/orchestrator/prompt-builder.test.ts
+++ b/packages/core/src/orchestrator/prompt-builder.test.ts
@@ -3,21 +3,21 @@ import { buildRoutingRulesWithProject, formatWorkflowContextSection } from './pr
 
 describe('buildRoutingRulesWithProject', () => {
   test('routing rules include --prompt in invocation format', () => {
-    const rules = buildRoutingRulesWithProject();
+    const rules = buildRoutingRulesWithProject(undefined, '/test/.archon/workspaces');
 
     expect(rules).toContain('--prompt');
     expect(rules).toContain('self-contained task description');
   });
 
   test('routing rules include --prompt with project-scoped prompt', () => {
-    const rules = buildRoutingRulesWithProject('my-project');
+    const rules = buildRoutingRulesWithProject('my-project', '/test/.archon/workspaces');
 
     expect(rules).toContain('--prompt');
     expect(rules).toContain('my-project');
   });
 
   test('invocation format line includes exact --prompt flag syntax', () => {
-    const rules = buildRoutingRulesWithProject();
+    const rules = buildRoutingRulesWithProject(undefined, '/test/.archon/workspaces');
 
     // The format template must include --prompt as part of the command, not just in prose
     expect(rules).toContain(
@@ -26,7 +26,7 @@ describe('buildRoutingRulesWithProject', () => {
   });
 
   test('rules state prompt must be self-contained with no conversation knowledge', () => {
-    const rules = buildRoutingRulesWithProject();
+    const rules = buildRoutingRulesWithProject(undefined, '/test/.archon/workspaces');
 
     expect(rules).toContain('NO knowledge of the conversation history');
   });

--- a/packages/core/src/orchestrator/prompt-builder.test.ts
+++ b/packages/core/src/orchestrator/prompt-builder.test.ts
@@ -35,6 +35,7 @@ describe('buildRoutingRulesWithProject', () => {
     const rules = buildRoutingRulesWithProject(undefined, '/.archon/workspaces');
     expect(rules).toContain('/.archon/workspaces');
     expect(rules).not.toContain('~/.archon');
+    expect(rules).not.toContain('/home/user/.archon/workspaces');
   });
 });
 

--- a/packages/core/src/orchestrator/prompt-builder.ts
+++ b/packages/core/src/orchestrator/prompt-builder.ts
@@ -68,15 +68,18 @@ export function formatWorkflowContextSection(results: readonly WorkflowResultCon
 /**
  * Build the routing rules section of the prompt.
  */
-export function buildRoutingRules(): string {
-  return buildRoutingRulesWithProject();
+export function buildRoutingRules(workspacesPath: string): string {
+  return buildRoutingRulesWithProject(undefined, workspacesPath);
 }
 
 /**
  * Build the routing rules section, optionally scoped to a specific project.
  * When projectName is provided, rule #4 defaults to that project instead of asking.
  */
-export function buildRoutingRulesWithProject(projectName?: string): string {
+export function buildRoutingRulesWithProject(
+  projectName: string | undefined,
+  workspacesPath: string
+): string {
   const rule4 = projectName
     ? `4. If ambiguous which project → use **${projectName}** (the active project)`
     : '4. If ambiguous which project → ask the user';
@@ -118,13 +121,13 @@ Response: "Adding dark mode would involve... [answer the question]. If you'd lik
 ## Project Setup
 
 When a user asks to add a new project:
-1. Clone the repository into ~/.archon/workspaces/:
-   git clone https://github.com/{owner}/{repo} ~/.archon/workspaces/{owner}/{repo}/source
+1. Clone the repository into ${workspacesPath}/:
+   git clone https://github.com/{owner}/{repo} ${workspacesPath}/{owner}/{repo}/source
 2. Register it by emitting this command on its own line:
    /register-project {project-name} {path-to-source}
 
 Example:
-   /register-project my-new-app /home/user/.archon/workspaces/user/my-new-app/source
+   /register-project my-new-app ${workspacesPath}/user/my-new-app/source
 
 To update a project's path:
    /update-project {project-name} {new-path}
@@ -132,7 +135,7 @@ To update a project's path:
 To remove a registered project:
    /remove-project {project-name}
 
-IMPORTANT: Always clone into ~/.archon/workspaces/{owner}/{repo}/source unless the user specifies a different location.`;
+IMPORTANT: Always clone into ${workspacesPath}/{owner}/{repo}/source unless the user specifies a different location.`;
 }
 
 /**
@@ -141,12 +144,13 @@ IMPORTANT: Always clone into ~/.archon/workspaces/{owner}/{repo}/source unless t
  */
 export function buildOrchestratorPrompt(
   codebases: readonly Codebase[],
-  workflows: readonly WorkflowDefinition[]
+  workflows: readonly WorkflowDefinition[],
+  workspacesPath: string
 ): string {
   let prompt = `# Archon Orchestrator
 
 You are Archon, an intelligent coding assistant that manages multiple projects.
-Your working directory is ~/.archon/workspaces/ where all projects live.
+Your working directory is ${workspacesPath}/ where all projects live.
 You can answer questions directly or invoke workflows for structured development tasks.
 
 ## Registered Projects
@@ -166,7 +170,7 @@ You can answer questions directly or invoke workflows for structured development
   prompt += '## Available Workflows\n\n';
   prompt += formatWorkflowSection(workflows);
 
-  prompt += buildRoutingRules();
+  prompt += buildRoutingRules(workspacesPath);
 
   return prompt;
 }
@@ -179,14 +183,15 @@ You can answer questions directly or invoke workflows for structured development
 export function buildProjectScopedPrompt(
   scopedCodebase: Codebase,
   allCodebases: readonly Codebase[],
-  workflows: readonly WorkflowDefinition[]
+  workflows: readonly WorkflowDefinition[],
+  workspacesPath: string
 ): string {
   const otherCodebases = allCodebases.filter(c => c.id !== scopedCodebase.id);
 
   let prompt = `# Archon Orchestrator
 
 You are Archon, an intelligent coding assistant that manages multiple projects.
-Your working directory is ~/.archon/workspaces/ where all projects live.
+Your working directory is ${workspacesPath}/ where all projects live.
 You can answer questions directly or invoke workflows for structured development tasks.
 
 This conversation is scoped to **${scopedCodebase.name}**. Use this project for all workflow invocations unless the user explicitly mentions a different project.
@@ -207,7 +212,7 @@ ${formatProjectSection(scopedCodebase)}
   prompt += '## Available Workflows\n\n';
   prompt += formatWorkflowSection(workflows);
 
-  prompt += buildRoutingRulesWithProject(scopedCodebase.name);
+  prompt += buildRoutingRulesWithProject(scopedCodebase.name, workspacesPath);
 
   return prompt;
 }

--- a/packages/core/src/orchestrator/prompt-builder.ts
+++ b/packages/core/src/orchestrator/prompt-builder.ts
@@ -121,13 +121,13 @@ Response: "Adding dark mode would involve... [answer the question]. If you'd lik
 ## Project Setup
 
 When a user asks to add a new project:
-1. Clone the repository into ${workspacesPath}/:
-   git clone https://github.com/{owner}/{repo} ${workspacesPath}/{owner}/{repo}/source
+1. Clone the repository into "${workspacesPath}/":
+   git clone https://github.com/{owner}/{repo} "${workspacesPath}/{owner}/{repo}/source"
 2. Register it by emitting this command on its own line:
    /register-project {project-name} {path-to-source}
 
 Example:
-   /register-project my-new-app ${workspacesPath}/user/my-new-app/source
+   /register-project my-new-app "${workspacesPath}/user/my-new-app/source"
 
 To update a project's path:
    /update-project {project-name} {new-path}
@@ -135,7 +135,7 @@ To update a project's path:
 To remove a registered project:
    /remove-project {project-name}
 
-IMPORTANT: Always clone into ${workspacesPath}/{owner}/{repo}/source unless the user specifies a different location.`;
+IMPORTANT: Always clone into "${workspacesPath}/{owner}/{repo}/source" unless the user specifies a different location.`;
 }
 
 /**


### PR DESCRIPTION
fix(core): use runtime workspacesPath in orchestrator prompts instead of hardcoded paths

## Summary

- **Problem:** `prompt-builder.ts` contained 6 hardcoded `~/.archon/workspaces` and `/home/user/.archon/workspaces` literals embedded in AI-facing system prompts (clone instructions and working-directory preamble).
- **Why it matters:** In Docker deployments `getArchonWorkspacesPath()` returns `/.archon/workspaces`, not `~/.archon/workspaces`. The AI was therefore instructing users to clone repositories into the wrong location inside the container — making cloned projects invisible to the host-mounted volume.
- **What changed:** `workspacesPath: string` is now a required parameter on four prompt-builder functions; it is resolved once in `buildFullPrompt` via the already-imported `getArchonWorkspacesPath()`, which returns the correct path for both Docker and non-Docker deployments.
- **What did not change:** No behavioral change for non-Docker users. No new imports, no schema/DB/config changes, no external callers affected.

---

## UX Journey

### Before

```
User (Docker)          Archon                    AI
─────────────          ──────                    ──
sends message ───────▶ builds prompt
                       hardcoded ~/.archon/
                       workspaces in prompt ────▶ reads prompt
                                                  tells user:
                                                  "clone to ~/.archon/workspaces/…"
                                        ◀──────── (wrong path — invisible to volume)
sees wrong path ◀────── streams reply
```

### After

```
User (Docker)          Archon                    AI
─────────────          ──────                    ──
sends message ───────▶ builds prompt
                       [getArchonWorkspacesPath()
                        → /.archon/workspaces] ──▶ reads prompt
                                                   tells user:
                                                   "clone to /.archon/workspaces/…"
                                         ◀──────── (correct Docker path)
sees correct path ◀──── streams reply
```

---

## Architecture Diagram

### Before

```
orchestrator-agent.ts
  └─▶ buildFullPrompt()
        ├─▶ buildProjectScopedPrompt(scopedCodebase, codebases, workflows)
        │     └── hardcoded "~/.archon/workspaces" in preamble string
        └─▶ buildOrchestratorPrompt(codebases, workflows)
              └── buildRoutingRulesWithProject()
                    └── hardcoded "~/.archon/workspaces" ×4 in clone instructions
```

### After

```
orchestrator-agent.ts
  └─▶ buildFullPrompt()
        [~] workspacesPath = getArchonWorkspacesPath()   ← single resolution point
        ├─▶ buildProjectScopedPrompt(scopedCodebase, codebases, workflows, workspacesPath)
        │     └── uses workspacesPath in preamble string
        └─▶ buildOrchestratorPrompt(codebases, workflows, workspacesPath)
              └── buildRoutingRulesWithProject(projectName, workspacesPath)
                    └── uses workspacesPath ×4 in clone instructions
```

Connection inventory:

| From | To | Change |
|---|---|---|
| `orchestrator-agent.ts` → `buildProjectScopedPrompt` | passes `workspacesPath` | modified |
| `orchestrator-agent.ts` → `buildOrchestratorPrompt` | passes `workspacesPath` | modified |
| `buildOrchestratorPrompt` → `buildRoutingRulesWithProject` | passes `workspacesPath` | modified |
| `buildRoutingRulesWithProject` → `buildRoutingRules` | passes `workspacesPath` | modified |

---

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`
- Module: `core:orchestrator`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

---

## Linked Issue

- Closes # https://github.com/coleam00/Archon/issues/1237
- Closes # https://github.com/coleam00/Archon/issues/1452

---

## Validation Evidence (required)

```
bun run validate
```

All five checks passed: `check:bundled`, `type-check`, `lint`, `format:check`, `test` (0 failures across all packages).

- Evidence provided: CI-equivalent local validation passed

---

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

---

## Compatibility / Migration

- Backward compatible? Yes — `getArchonWorkspacesPath()` returns `~/.archon/workspaces` on non-Docker hosts, identical to the previous hardcoded value
- Config/env changes? No
- Database migration needed? No

---

## Human Verification (required)

- Verified scenarios: `bun run validate` passes clean; all existing prompt-builder and orchestrator tests pass with updated signatures
- Edge cases checked: Confirmed no external callers of the four changed functions exist outside `@archon/core` (full grep across all packages)
- What was not verified: Live Docker deployment smoke test (no Docker environment available locally)

---

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `@archon/core` orchestrator prompt builder only
- Potential unintended effects: None — the returned string from `getArchonWorkspacesPath()` is identical to the old hardcoded value on non-Docker hosts
- Guardrails/monitoring: Existing orchestrator and prompt-builder unit tests cover call-site correctness

---

## Rollback Plan (required)

- Fast rollback: `git revert <sha>` — four files changed, no migrations, no external API changes
- Feature flags: None
- Observable failure symptoms: AI clone instructions show wrong path; `/register-project` example paths look incorrect in Slack/Telegram/web UI

---

## Risks and Mitigations

- Risk: `getArchonWorkspacesPath()` could theoretically return an unexpected path on a novel deployment target
  - Mitigation: The function is deterministic (`isDocker()` check → `/.archon` or `~/.archon`), unchanged by this PR, and already used everywhere else in the codebase for path resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Orchestrator prompts and routing rules now use a caller-supplied workspaces path instead of a hardcoded location, and the prompts reflect that working-directory value for more accurate instructions.
* **Tests**
  * Updated tests to provide and verify the new workspaces path in prompt generation and routing-rule scenarios, ensuring prompts and clone/register instructions reference the supplied path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->