### PR TITLE
feat(docker): persist /home/appuser by default + clarify ARCHON_HOME/ARCHON_DATA semantics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -187,12 +187,16 @@ GITEA_ALLOWED_USERS=
 # Archon Directory Configuration
 # ============================================
 # All Archon-managed files go in ~/.archon/ by default
-# Override with ARCHON_HOME to use a custom location
+# Override with ARCHON_HOME to use a custom location.
+# Docker: IGNORED. The container always uses /.archon regardless of this value
+# (the variable still leaks into the container env via env_file but has no effect).
 # ARCHON_HOME=~/.archon
 
 # Docker data directory (host path where Archon stores workspaces, worktrees, artifacts, etc.)
 # Default: Docker-managed volume (archon_data)
 # Set to an absolute path on the host for full control over data location:
+# Docker: host-only. Used by docker-compose to choose the bind-mount source for /.archon.
+# NOT read by Archon source code — the container always sees data at /.archon.
 # ARCHON_DATA=/opt/archon-data
 
 # Logging (optional)

--- a/.env.example
+++ b/.env.example
@@ -199,6 +199,15 @@ GITEA_ALLOWED_USERS=
 # NOT read by Archon source code — the container always sees data at /.archon.
 # ARCHON_DATA=/opt/archon-data
 
+# Docker user-home directory (host path for /home/appuser inside the container).
+# /home/appuser is persisted by default so Claude Code skills/commands/agents/hooks,
+# Codex/Pi auth state, ~/.gitconfig, and shell history survive container rebuilds.
+# Default: Docker-managed volume (archon_user_home)
+# Set to an absolute path on the host to bind-mount instead (must be writable by UID 1001):
+# Docker: host-only. Used by docker-compose to choose the bind-mount source for /home/appuser.
+# NOT read by Archon source code.
+# ARCHON_USER_HOME=/opt/archon-user-home
+
 # Logging (optional)
 # Set log level: fatal | error | warn | info | debug | trace
 # Default: info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Docker: `/home/appuser` is now persisted by default via the `archon_user_home` named volume, so user-installed Claude Code skills/commands/agents/hooks, Codex/Pi auth, `~/.gitconfig`, and shell history survive container rebuilds. Set `ARCHON_USER_HOME=/host/path` in `.env` to bind-mount a host path instead (#1517, #1518).
+
+### Changed
+
+- Claude provider default `settingSources` changed from `['project']` to `['project', 'user']`, so skills, commands, agents, and `CLAUDE.md` from `~/.claude/` are now loaded by default in all environments — not just Docker. Without this, the new `/home/appuser` persistence would not actually surface user-installed Claude resources. Set `assistants.claude.settingSources: ['project']` in `.archon/config.yaml` to restore the previous project-only behavior (#1518).
+- `.env.example`, `docker-compose.yml`, `deploy/docker-compose.yml`, and `reference/configuration.md` now document that `ARCHON_HOME` is silently overridden inside Docker and `ARCHON_DATA` is a Compose-only host token never read by source. The Docker entrypoint emits a one-line stderr warning when either is set in the container env (#1517).
+
+### Fixed
+
+- Docker: `git config --global --add safe.directory` in the entrypoint now de-duplicates entries before adding, preventing unbounded growth of `~/.gitconfig` now that `/home/appuser` is persisted (#1518).
+- Docker: `setup-auth` now warns at startup when `CODEX_*` env vars are absent but a persisted `~/.codex/auth.json` from a previous run still exists, so operators don't accidentally use stale or revoked credentials (#1518).
+
 ## [0.3.10] - 2026-04-29
 
 Maintainer workflow suite, loop output variables, and broad workflow engine fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -479,9 +479,9 @@ The system supports configuring default models and options per assistant in `.ar
 assistants:
   claude:
     model: sonnet  # or 'opus', 'haiku', 'claude-*', 'inherit'
-    settingSources:  # Controls which CLAUDE.md files Claude SDK loads
-      - project      # Default: only project-level CLAUDE.md
-      - user         # Optional: also load ~/.claude/CLAUDE.md
+    settingSources:  # Controls which CLAUDE.md, skills, commands, and agents the SDK loads
+      - project      # Project-level <cwd>/.claude/ (included in default)
+      - user         # User-level ~/.claude/ (included in default; omit both to restrict to project-only)
     claudeBinaryPath: /absolute/path/to/claude  # Optional: Claude Code executable.
                                                 # Native binary (curl installer at
                                                 # ~/.local/bin/claude) or npm cli.js.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - "${PORT:-3000}:${PORT:-3000}"
     volumes:
       - ${ARCHON_DATA:-archon_data}:/.archon
+      - ${ARCHON_USER_HOME:-archon_user_home}:/home/appuser
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${PORT:-3000}/api/health"]
       interval: 30s
@@ -46,4 +47,5 @@ services:
 
 volumes:
   archon_data:
+  archon_user_home:
   # postgres_data:

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -14,3 +14,12 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.user
+    # Persist Claude Code config (skills, prompts, OAuth state) across container recreations.
+    # Without this, anything you put in ~/.claude/ inside the container is wiped on
+    # `docker compose up --build` or image pull.
+    # Uncomment the volume below AND the named volume at the bottom of this file.
+    # volumes:
+    #   - claude_home:/home/appuser/.claude
+
+# volumes:
+#   claude_home:

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -14,12 +14,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.user
-    # Persist Claude Code config (skills, prompts, OAuth state) across container recreations.
-    # Without this, anything you put in ~/.claude/ inside the container is wiped on
-    # `docker compose up --build` or image pull.
-    # Uncomment the volume below AND the named volume at the bottom of this file.
-    # volumes:
-    #   - claude_home:/home/appuser/.claude
 
-# volumes:
-#   claude_home:
+# /home/appuser (Claude/Codex/Pi config, gitconfig, shell history) is already
+# persisted by default via the archon_user_home named volume in the base compose.
+# To bind-mount a host path instead, set ARCHON_USER_HOME=/your/host/path in .env
+# (the host path must be writable by UID 1001). No override-file edit needed.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,13 @@
 #     ARCHON_DATA=/opt/archon-data    # Any absolute path on the host
 #   Default: Docker-managed volume (archon_data)
 #
+# User home (Claude/Codex/Pi config, gitconfig, shell history):
+#   /home/appuser is persisted by default to the archon_user_home named volume so
+#   user-installed Claude Code skills/commands/agents/hooks, Codex/Pi auth state,
+#   and ~/.gitconfig survive container rebuilds. To use a host path instead:
+#     ARCHON_USER_HOME=/opt/archon-user-home    # Any absolute path on the host
+#   Default: Docker-managed volume (archon_user_home)
+#
 # Cloud (HTTPS):
 #   1. Set DOMAIN=archon.example.com in .env
 #   2. Point DNS A record to your server
@@ -39,6 +46,7 @@ services:
       - "${PORT:-3000}:${PORT:-3000}"
     volumes:
       - ${ARCHON_DATA:-archon_data}:/.archon
+      - ${ARCHON_USER_HOME:-archon_user_home}:/home/appuser
     networks:
       - archon-network
     restart: unless-stopped
@@ -122,6 +130,7 @@ services:
 
 volumes:
   archon_data:
+  archon_user_home:
   postgres_data:
   caddy_data:
   caddy_config:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,10 +13,28 @@ if [ "$(id -u)" = "0" ]; then
     echo "ERROR: Failed to fix ownership of /.archon — volume may be read-only or mounted with incompatible options" >&2
     exit 1
   fi
+  # If a volume or bind mount provided /home/appuser/.claude, fix its ownership too
+  # so Claude Code can read/write skills, prompts, OAuth state. No mount = no-op.
+  if [ -d /home/appuser/.claude ]; then
+    if ! chown -Rh appuser:appuser /home/appuser/.claude 2>/dev/null; then
+      echo "ERROR: Failed to fix ownership of /home/appuser/.claude — volume may be read-only" >&2
+      exit 1
+    fi
+  fi
   RUNNER="gosu appuser"
 else
   # Already running as non-root (e.g., --user flag or Kubernetes)
   RUNNER=""
+fi
+
+# Warn if vars known to be ignored inside the container were set via env_file: .env.
+# These leak in but have no effect (ARCHON_HOME is overridden to /.archon by source;
+# ARCHON_DATA is a host-side compose substitution token, never read by the container).
+if [ -n "${ARCHON_HOME:-}" ]; then
+  echo "[archon] ARCHON_HOME=${ARCHON_HOME} ignored in Docker (container home is fixed at /.archon)" >&2
+fi
+if [ -n "${ARCHON_DATA:-}" ]; then
+  echo "[archon] ARCHON_DATA=${ARCHON_DATA} is a host-side compose token; not read inside the container" >&2
 fi
 
 # Register all git repositories under /.archon as safe directories.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,13 +13,13 @@ if [ "$(id -u)" = "0" ]; then
     echo "ERROR: Failed to fix ownership of /.archon — volume may be read-only or mounted with incompatible options" >&2
     exit 1
   fi
-  # If a volume or bind mount provided /home/appuser/.claude, fix its ownership too
-  # so Claude Code can read/write skills, prompts, OAuth state. No mount = no-op.
-  if [ -d /home/appuser/.claude ]; then
-    if ! chown -Rh appuser:appuser /home/appuser/.claude 2>/dev/null; then
-      echo "ERROR: Failed to fix ownership of /home/appuser/.claude — volume may be read-only" >&2
-      exit 1
-    fi
+  # /home/appuser is persisted to a named volume (or bind-mounted via
+  # ARCHON_USER_HOME) so Claude/Codex/Pi config, ~/.gitconfig, shell history,
+  # and other user-specific state survive rebuilds. On bind mounts, host UIDs
+  # don't map to appuser (1001), so fix ownership the same way we do /.archon.
+  if ! chown -Rh appuser:appuser /home/appuser 2>/dev/null; then
+    echo "ERROR: Failed to fix ownership of /home/appuser — volume may be read-only or mounted with incompatible options" >&2
+    exit 1
   fi
   RUNNER="gosu appuser"
 else

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -44,8 +44,14 @@ fi
 # The Dockerfile RUN-layer registers fixed paths, but that gitconfig lives
 # in the image layer — bind mounts don't inherit it on restart, and
 # worktrees are nested at arbitrary depths unknown at build time.
+# With /home/appuser now persisted, ~/.gitconfig survives across restarts —
+# so we must check before --add or duplicate safe.directory lines accumulate
+# every boot.
 find /.archon -name ".git" -prune -print 2>/dev/null | while IFS= read -r git_dir; do
-  $RUNNER git config --global --add safe.directory "$(dirname "$git_dir")"
+  repo_dir="$(dirname "$git_dir")"
+  if ! $RUNNER git config --global --get-all safe.directory 2>/dev/null | grep -qxF "$repo_dir"; then
+    $RUNNER git config --global --add safe.directory "$repo_dir"
+  fi
 done
 
 # Configure git to use GH_TOKEN for HTTPS clones via credential helper

--- a/packages/docs-web/src/content/docs/deployment/docker.md
+++ b/packages/docs-web/src/content/docs/deployment/docker.md
@@ -452,6 +452,10 @@ By default this is a Docker-managed volume. To store data at a specific location
 ARCHON_DATA=/opt/archon-data
 ```
 
+:::note
+`ARCHON_HOME` from `.env.example` is **ignored inside Docker** — the container always uses `/.archon`. Use `ARCHON_DATA` (host-side bind-mount source) to control *where on the host* `/.archon` lives. Both variables leak into the container env via `env_file: .env`, which is harmless but expected.
+:::
+
 The directory is created automatically. Make sure the path is writable by UID 1001 (the container user):
 
 ```bash
@@ -460,6 +464,32 @@ sudo chown -R 1001:1001 /opt/archon-data
 ```
 
 If `ARCHON_DATA` is not set, Docker manages the volume automatically (`archon_data`) — data persists across restarts and rebuilds but lives inside Docker's storage.
+
+### Persisting Claude Code config
+
+The image runs as `appuser` with `$HOME=/home/appuser`. Claude Code (and any agents the SDK launches) reads runtime config from `~/.claude/` — skills, prompts, OAuth tokens, etc. Nothing in the base compose mounts that path, so anything you write there is wiped on `docker compose up --build` or image pull.
+
+To persist `~/.claude/` across rebuilds, copy the example override file and uncomment the `claude_home` volume:
+
+```bash
+cp docker-compose.override.example.yml docker-compose.override.yml
+# then edit docker-compose.override.yml — uncomment the `volumes:` block under `app`
+# and the top-level `volumes: { claude_home: }` named volume.
+docker compose up -d
+```
+
+`docker-compose.override.yml` is gitignored, so the customization stays local. `docker compose` automatically merges it with the base file — no extra flags.
+
+If you prefer a host bind mount instead of a named volume, replace `claude_home` with an absolute path and chown it to UID 1001 first:
+
+```bash
+mkdir -p /opt/archon-claude
+sudo chown -R 1001:1001 /opt/archon-claude
+# then in docker-compose.override.yml:
+#   - /opt/archon-claude:/home/appuser/.claude
+```
+
+The entrypoint will fix ownership of bind-mounted Claude config on container start, just like it does for `/.archon`.
 
 ### GitHub CLI Authentication
 

--- a/packages/docs-web/src/content/docs/deployment/docker.md
+++ b/packages/docs-web/src/content/docs/deployment/docker.md
@@ -493,6 +493,10 @@ sudo chown -R 1001:1001 /opt/archon-user-home
 
 The entrypoint re-applies ownership on every container start, so subsequent rebuilds work without re-running `chown`.
 
+:::caution
+Bind-mount paths do **not** inherit the image's baked `~/.gitconfig` (Docker only copies image content into named volumes on first creation, never into bind mounts). The entrypoint still registers git `safe.directory` entries for `/.archon/workspaces` and `/.archon/worktrees` repos at runtime, so functionality is preserved — but a bind-mounted `~/.gitconfig` starts empty and any author identity / signing config you want must be set explicitly with `git config --global` inside the container.
+:::
+
 If `ARCHON_USER_HOME` is not set, Docker manages the volume automatically (`archon_user_home`) — config persists across restarts and rebuilds but lives inside Docker's storage. To wipe it: `docker compose down && docker volume rm archon_archon_user_home`.
 
 ### GitHub CLI Authentication

--- a/packages/docs-web/src/content/docs/deployment/docker.md
+++ b/packages/docs-web/src/content/docs/deployment/docker.md
@@ -453,7 +453,7 @@ ARCHON_DATA=/opt/archon-data
 ```
 
 :::note
-`ARCHON_HOME` from `.env.example` is **ignored inside Docker** — the container always uses `/.archon`. Use `ARCHON_DATA` (host-side bind-mount source) to control *where on the host* `/.archon` lives. Both variables leak into the container env via `env_file: .env`, which is harmless but expected.
+`ARCHON_HOME` from `.env.example` is **ignored inside Docker** — the container always uses `/.archon`. Use `ARCHON_DATA` (host-side bind-mount source) to control *where on the host* `/.archon` lives. Both `ARCHON_HOME` and `ARCHON_DATA` leak into the container env via `env_file: .env`, which is harmless but expected.
 :::
 
 The directory is created automatically. Make sure the path is writable by UID 1001 (the container user):
@@ -465,31 +465,35 @@ sudo chown -R 1001:1001 /opt/archon-data
 
 If `ARCHON_DATA` is not set, Docker manages the volume automatically (`archon_data`) — data persists across restarts and rebuilds but lives inside Docker's storage.
 
-### Persisting Claude Code config
+### User Home Directory (Persisted)
 
-The image runs as `appuser` with `$HOME=/home/appuser`. Claude Code (and any agents the SDK launches) reads runtime config from `~/.claude/` — skills, prompts, OAuth tokens, etc. Nothing in the base compose mounts that path, so anything you write there is wiped on `docker compose up --build` or image pull.
+The container runs as `appuser` with `$HOME=/home/appuser`. The base compose mounts `/home/appuser` as a named volume (`archon_user_home`) by default, so user-specific state survives container rebuilds without any operator action:
 
-To persist `~/.claude/` across rebuilds, copy the example override file and uncomment the `claude_home` volume:
+| Path | What it persists |
+|------|------------------|
+| `~/.claude/` | Claude Code skills, commands, agents, hooks, MCP config, projects (conversation history), memory, OAuth state, keybindings, file-history |
+| `~/.codex/` | Codex auth (`auth.json` from interactive `codex login`; the env-var path via `setup-auth` overwrites this on every container start) |
+| `~/.pi/agent/` | Pi `auth.json` from interactive `pi /login` (Archon's Pi adapter reads this on every request) |
+| `~/.gitconfig` | Author identity, signing config, custom aliases, plus the `safe.directory` entries baked into the image |
+| `~/.bash_history` | Shell history when you `docker compose exec app bash` |
+| `~/.config/gh/` | GitHub CLI auth from interactive `gh auth login` (the `GH_TOKEN` env-var path works without it) |
 
-```bash
-cp docker-compose.override.example.yml docker-compose.override.yml
-# then edit docker-compose.override.yml — uncomment the `volumes:` block under `app`
-# and the top-level `volumes: { claude_home: }` named volume.
-docker compose up -d
+To bind-mount a host path instead of the default named volume, set `ARCHON_USER_HOME` in `.env`:
+
+```ini
+ARCHON_USER_HOME=/opt/archon-user-home
 ```
 
-`docker-compose.override.yml` is gitignored, so the customization stays local. `docker compose` automatically merges it with the base file — no extra flags.
-
-If you prefer a host bind mount instead of a named volume, replace `claude_home` with an absolute path and chown it to UID 1001 first:
+The host path must be writable by UID 1001 — chown it once before first start:
 
 ```bash
-mkdir -p /opt/archon-claude
-sudo chown -R 1001:1001 /opt/archon-claude
-# then in docker-compose.override.yml:
-#   - /opt/archon-claude:/home/appuser/.claude
+mkdir -p /opt/archon-user-home
+sudo chown -R 1001:1001 /opt/archon-user-home
 ```
 
-The entrypoint will fix ownership of bind-mounted Claude config on container start, just like it does for `/.archon`.
+The entrypoint re-applies ownership on every container start, so subsequent rebuilds work without re-running `chown`.
+
+If `ARCHON_USER_HOME` is not set, Docker manages the volume automatically (`archon_user_home`) — config persists across restarts and rebuilds but lives inside Docker's storage. To wipe it: `docker compose down && docker volume rm archon_archon_user_home`.
 
 ### GitHub CLI Authentication
 

--- a/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
+++ b/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
@@ -127,7 +127,7 @@ assistants:
     # claudeBinaryPath: /absolute/path/to/claude
 ```
 
-The `settingSources` option controls which `CLAUDE.md` files the Claude Code SDK loads. By default, only the project-level `CLAUDE.md` is loaded. Add `user` to also load your personal `~/.claude/CLAUDE.md`.
+The `settingSources` option controls which `CLAUDE.md`, skill, command, and agent files the Claude Code SDK loads. The default is `['project', 'user']`, which loads both the project-level `<cwd>/.claude/` and your personal `~/.claude/`. Set it to `['project']` if you want to scope a workflow to project-only resources.
 
 ### Set as Default (Optional)
 

--- a/packages/docs-web/src/content/docs/guides/skills.md
+++ b/packages/docs-web/src/content/docs/guides/skills.md
@@ -123,13 +123,16 @@ Step-by-step content here. The agent loads this when the skill activates.
 
 ## Skill Discovery
 
-Skills are discovered from these locations (via `settingSources: ['project']`
-set in ClaudeProvider):
+Skills are discovered from these locations (via the default
+`settingSources: ['project', 'user']` set in ClaudeProvider):
 
 | Location | Scope |
 |----------|-------|
 | `.claude/skills/` (in cwd) | Project-level |
 | `~/.claude/skills/` | User-level (all projects) |
+
+Set `assistants.claude.settingSources: ['project']` in `.archon/config.yaml`
+to scope a workflow to project-level skills only.
 
 Skills installed via `npx skills add` land in `.claude/skills/` by default.
 Use `-g` for global installation to `~/.claude/skills/`.

--- a/packages/docs-web/src/content/docs/reference/configuration.md
+++ b/packages/docs-web/src/content/docs/reference/configuration.md
@@ -324,6 +324,7 @@ When `CLAUDE_USE_GLOBAL_AUTH` is unset, Archon auto-detects: it uses explicit to
 | Variable | Description | Default |
 | --- | --- | --- |
 | `ARCHON_DATA` | Host path for Archon data (workspaces, worktrees, artifacts). Compose-only — read by `docker-compose.yml` to choose the bind-mount source for `/.archon`; not read by Archon source code. | Docker-managed volume |
+| `ARCHON_USER_HOME` | Host path for `/home/appuser` (Claude/Codex/Pi config, `~/.gitconfig`, shell history). Compose-only — read by `docker-compose.yml` to choose the bind-mount source for `/home/appuser`; not read by Archon source code. Persisted by default to a Docker-managed volume so user state survives rebuilds. | Docker-managed volume |
 | `DOMAIN` | Public domain for Caddy reverse proxy (TLS auto-provisioned) | -- |
 | `CADDY_BASIC_AUTH` | Caddy basicauth directive to protect Web UI and API | Disabled |
 | `AUTH_USERNAME` | Username for form-based auth (Caddy forward_auth) | -- |

--- a/packages/docs-web/src/content/docs/reference/configuration.md
+++ b/packages/docs-web/src/content/docs/reference/configuration.md
@@ -62,9 +62,9 @@ defaultAssistant: claude # must match a registered provider (e.g. claude, codex)
 assistants:
   claude:
     model: sonnet
-    settingSources:   # Which CLAUDE.md files the SDK loads (default: ['project'])
-      - project       # Project-level CLAUDE.md (always recommended)
-      - user          # Also load ~/.claude/CLAUDE.md (global preferences)
+    settingSources:   # Which sources the Claude SDK loads (default: ['project', 'user'])
+      - project       # Project-level <cwd>/.claude/ (CLAUDE.md, skills, commands, agents)
+      - user          # User-level ~/.claude/ (CLAUDE.md, skills, commands, agents)
     # Optional: absolute path to the Claude Code executable.
     # Required in compiled Archon binaries when CLAUDE_BIN_PATH is not set.
     # Accepts the native binary (~/.local/bin/claude from the curl installer)

--- a/packages/docs-web/src/content/docs/reference/configuration.md
+++ b/packages/docs-web/src/content/docs/reference/configuration.md
@@ -223,7 +223,7 @@ Environment variables override all other configuration. They are organized by ca
 
 | Variable | Description | Default |
 | --- | --- | --- |
-| `ARCHON_HOME` | Base directory for all Archon-managed files | `~/.archon` |
+| `ARCHON_HOME` | Base directory for all Archon-managed files. **Ignored in Docker** — the container always uses `/.archon`. | `~/.archon` |
 | `PORT` | HTTP server listen port | `3090` (auto-allocated in worktrees) |
 | `LOG_LEVEL` | Logging verbosity (`fatal`, `error`, `warn`, `info`, `debug`, `trace`) | `info` |
 | `BOT_DISPLAY_NAME` | Bot name shown in batch-mode "starting" messages | `Archon` |
@@ -323,7 +323,7 @@ When `CLAUDE_USE_GLOBAL_AUTH` is unset, Archon auto-detects: it uses explicit to
 
 | Variable | Description | Default |
 | --- | --- | --- |
-| `ARCHON_DATA` | Host path for Archon data (workspaces, worktrees, artifacts) | Docker-managed volume |
+| `ARCHON_DATA` | Host path for Archon data (workspaces, worktrees, artifacts). Compose-only — read by `docker-compose.yml` to choose the bind-mount source for `/.archon`; not read by Archon source code. | Docker-managed volume |
 | `DOMAIN` | Public domain for Caddy reverse proxy (TLS auto-provisioned) | -- |
 | `CADDY_BASIC_AUTH` | Caddy basicauth directive to protect Web UI and API | Disabled |
 | `AUTH_USERNAME` | Username for form-based auth (Caddy forward_auth) | -- |

--- a/packages/docs-web/src/content/docs/reference/configuration.md
+++ b/packages/docs-web/src/content/docs/reference/configuration.md
@@ -153,25 +153,25 @@ defaults:
 
 ### Claude settingSources
 
-Controls which `CLAUDE.md` files the Claude Agent SDK loads during sessions:
+Controls which sources the Claude Agent SDK loads during sessions — `CLAUDE.md`, skills, commands, agents, and hooks:
 
 | Value | Description |
 |-------|-------------|
-| `project` | Load the project's `CLAUDE.md` (default, always included) |
-| `user` | Also load `~/.claude/CLAUDE.md` (user's global preferences) |
+| `project` | Load project-level `<cwd>/.claude/` (CLAUDE.md, skills, commands, agents) |
+| `user` | Load user-level `~/.claude/` (CLAUDE.md, skills, commands, agents) |
 
-**Default**: `['project']` -- only project-level instructions are loaded.
+**Default**: `['project', 'user']` — both project-level and user-level sources are loaded.
 
-Set in global or repo config:
+To restrict a project to project-level resources only (e.g. CI, shared environments, or when `~/.claude/` contains personal commands you don't want surfacing in workflows):
+
 ```yaml
 assistants:
   claude:
     settingSources:
       - project
-      - user
 ```
 
-This is useful when you maintain coding style or identity preferences in `~/.claude/CLAUDE.md` and want Archon sessions to respect them.
+Set in `~/.archon/config.yaml` (global) or `.archon/config.yaml` (repo-specific).
 
 ### Worktree file copying (`worktree.copyFiles`)
 

--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -726,7 +726,7 @@ describe('ClaudeProvider', () => {
       expect(callArgs.options.settingSources).toEqual(['project', 'user']);
     });
 
-    test('defaults settingSources to project when not provided', async () => {
+    test('defaults settingSources to project + user when not provided', async () => {
       mockQuery.mockImplementation(async function* () {
         yield { type: 'result', session_id: 'test-session' };
       });
@@ -737,7 +737,7 @@ describe('ClaudeProvider', () => {
 
       expect(mockQuery).toHaveBeenCalledTimes(1);
       const callArgs = mockQuery.mock.calls[0][0] as { options: Record<string, unknown> };
-      expect(callArgs.options.settingSources).toEqual(['project']);
+      expect(callArgs.options.settingSources).toEqual(['project', 'user']);
     });
 
     test('passes env from requestOptions into SDK options', async () => {

--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -740,6 +740,26 @@ describe('ClaudeProvider', () => {
       expect(callArgs.options.settingSources).toEqual(['project', 'user']);
     });
 
+    test("honors explicit settingSources: ['project'] to opt out of user scope", async () => {
+      // Locks in the contract: setting settingSources: ['project'] in
+      // .archon/config.yaml must NOT be silently widened to the new default.
+      // A future refactor that drops the `?? ['project', 'user']` guard would
+      // expand skill/command/agent scope for every project-only deployment.
+      mockQuery.mockImplementation(async function* () {
+        yield { type: 'result', session_id: 'test-session' };
+      });
+
+      for await (const _ of client.sendQuery('test', '/tmp', undefined, {
+        assistantConfig: { settingSources: ['project'] },
+      })) {
+        // consume
+      }
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const callArgs = mockQuery.mock.calls[0][0] as { options: Record<string, unknown> };
+      expect(callArgs.options.settingSources).toEqual(['project']);
+    });
+
     test('passes env from requestOptions into SDK options', async () => {
       mockQuery.mockImplementation(async function* () {
         yield { type: 'result', session_id: 'sid' };

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -622,7 +622,7 @@ function buildBaseClaudeOptions(
     permissionMode: 'bypassPermissions',
     allowDangerouslySkipPermissions: true,
     systemPrompt: requestOptions?.systemPrompt ?? { type: 'preset', preset: 'claude_code' },
-    settingSources: assistantDefaults.settingSources ?? ['project'],
+    settingSources: assistantDefaults.settingSources ?? ['project', 'user'],
     hooks: buildToolCaptureHooks(toolResultQueue),
     stderr: (data: string): void => {
       const output = data.trim();

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -9,8 +9,12 @@
 export interface ClaudeProviderDefaults {
   [key: string]: unknown;
   model?: string;
-  /** Claude Code settingSources — controls which CLAUDE.md files are loaded.
-   *  @default ['project']
+  /** Claude Code settingSources — controls which sources the SDK loads:
+   *  CLAUDE.md, skills, commands, agents, and hooks. Both project-level
+   *  (`<cwd>/.claude/`) and user-level (`~/.claude/`) are loaded by default.
+   *  Set explicitly to `['project']` to scope a workflow to project-only
+   *  resources (e.g. CI, shared environments).
+   *  @default ['project', 'user']
    */
   settingSources?: ('project' | 'user')[];
   /** Absolute path to the Claude Code SDK's `cli.js`. Required in compiled

--- a/packages/server/src/scripts/setup-auth.ts
+++ b/packages/server/src/scripts/setup-auth.ts
@@ -29,6 +29,22 @@ function setupAuth(): void {
 
   // Skip if Codex credentials not provided
   if (!idToken || !accessToken || !refreshToken || !accountId) {
+    // /home/appuser is now persisted across restarts in Docker, so a stale
+    // auth.json from a previous run with creds is not automatically wiped.
+    // Surface this so operators don't end up with Codex silently using old/revoked tokens.
+    const persistedAuthPath = path.join(os.homedir(), '.codex', 'auth.json');
+    if (fs.existsSync(persistedAuthPath)) {
+      console.warn(
+        `⚠️  CODEX_* env vars not set, but persisted ${persistedAuthPath} exists from a previous run`
+      );
+      console.warn(
+        '    Codex will attempt to use those credentials. If they are stale or revoked,'
+      );
+      console.warn(
+        '    delete the file inside the container or wipe the archon_user_home volume to reset.'
+      );
+      return;
+    }
     console.log('⏭️  Skipping Codex auth setup - credentials not provided');
     console.log('   Codex assistant will be unavailable');
     return;

--- a/packages/server/src/scripts/setup-auth.ts
+++ b/packages/server/src/scripts/setup-auth.ts
@@ -27,7 +27,8 @@ function setupAuth(): void {
   const refreshToken = process.env.CODEX_REFRESH_TOKEN;
   const accountId = process.env.CODEX_ACCOUNT_ID;
 
-  // Skip if Codex credentials not provided
+  // No CODEX_* env vars provided: warn if a persisted auth.json already
+  // exists on the volume (may be stale), otherwise skip with "unavailable".
   if (!idToken || !accessToken || !refreshToken || !accountId) {
     // /home/appuser is now persisted across restarts in Docker, so a stale
     // auth.json from a previous run with creds is not automatically wiped.


### PR DESCRIPTION
## Summary

- **Problem:** Two operator-facing UX gaps in Docker. (1) `ARCHON_HOME` and `ARCHON_DATA` leak into the container env via `env_file: .env` but neither is read where operators expect — `ARCHON_HOME` is silently overridden to `/.archon` at `packages/paths/src/archon-paths.ts:56-59`, and `ARCHON_DATA` is a host-side Compose substitution token that no TS source reads. (2) Nothing in the base compose mounts `/home/appuser/`, so all user-specific state — Claude Code skills/commands/agents/hooks/MCP/projects/memory/OAuth, Codex/Pi auth, `~/.gitconfig`, shell history — is wiped on every `docker compose up --build`.
- **Why it matters:** Operators waste time chasing leaked env vars that look configurable but aren't, and lose every customization they make under `~/` on every rebuild. Reported by community member Zolto on Dynamous; cross-posted to #1517.
- **What changed:** Four groups of changes. **(a)** Annotate `.env.example` and `reference/configuration.md` so the leaked vars stop being surprising; entrypoint emits a one-line stderr warning when they're set. **(b)** Persist `/home/appuser` **by default** as a named volume (`archon_user_home`) in both `docker-compose.yml` and `deploy/docker-compose.yml`. **(c)** Expose `ARCHON_USER_HOME` (parallel to `ARCHON_DATA`) so operators can swap the named volume for a host bind-mount via `.env` without editing compose; entrypoint chowns `/home/appuser` to UID 1001 on every start so bind-mount UID drift is handled automatically. **(d)** Flip the Claude provider default `settingSources` from `['project']` to `['project', 'user']` so the persisted `~/.claude/` actually surfaces user-installed skills/commands/agents/hooks; without this, persistence would be a hollow promise. Affects all environments (not just Docker) — operators who want strict project-only scoping can set `assistants.claude.settingSources: ['project']` in `.archon/config.yaml`.
- **What did *not* change (scope boundary):** No change to `getArchonHome()` semantics — Docker hardcoding `/.archon` is intentional and the bind-mount/named-volume contract depends on it. No new TS code reading `ARCHON_DATA` or `ARCHON_USER_HOME` (both are Compose-only substitution tokens by design). No `Dockerfile` changes (named-volume first-run init copies the image-baked `/home/appuser/` skeleton — `.bashrc`, `.profile`, the `.gitconfig` with `safe.directory` entries, the empty `.codex/` — into the volume the first time). TypeScript changes are scoped to `packages/providers/src/` (the `settingSources` default + JSDoc/test/regression-test) and `packages/server/src/scripts/setup-auth.ts` (warn on stale persisted creds); no broader refactor.

## UX Journey

### Before

```
Operator                          .env / Compose                 Container
--------                          --------------                 ---------

sets ARCHON_HOME=/foo  ------>    env_file: .env  ---------->    process.env.ARCHON_HOME=/foo
sets ARCHON_DATA=/bar  ------>    env_file: .env  ---------->    process.env.ARCHON_DATA=/bar
                                  ${ARCHON_DATA:-archon_data}    isDocker() -> true
                                  :/.archon                      getArchonHome() -> /.archon
                                                                 (ignores ARCHON_HOME silently)

inside container:
  echo $ARCHON_HOME    --> /foo (leaked, ignored)        [confusing]
  echo $ARCHON_DATA    --> /bar (leaked, never read)     [confusing]
  cd $ARCHON_DATA      --> "no such directory"           [confusing]

# Anything written under ~/ is ephemeral:
mkdir -p ~/.claude/skills/x
docker compose up -d --build
ls ~/.claude/skills/x  --> gone                          [data loss]
gh auth login                                            (also gone on rebuild)
codex login                                              (also gone on rebuild)
git config --global user.email me@example.com            (also gone on rebuild)
```

### After

```
Operator                          .env / Compose                 Container
--------                          --------------                 ---------

reads .env.example,  --> sees     ARCHON_HOME annotated as       same in-container behavior
                         "Docker: IGNORED..." comment            (intentional, not changed)
                         ARCHON_DATA annotated as
                         "compose-only, NOT read by source"

if leaked vars set:                                              entrypoint emits ONE line/var
                                                                 [archon] ARCHON_HOME=/foo ignored
                                                                 in Docker (container home is
                                                                 fixed at /.archon)             [+]

# /home/appuser persists by default — no opt-in needed:
mkdir -p ~/.claude/skills/x                                      base compose mounts
docker compose up -d --build                                     archon_user_home:/home/appuser  [+]
ls ~/.claude/skills/x  --> persists across rebuilds              [+]
gh auth login                  --> persists                      [+]
codex login                    --> persists                      [+]
git config --global user.email --> persists                      [+]
~/.bash_history                --> persists                      [+]

# Want a host bind-mount instead of named volume?
echo "ARCHON_USER_HOME=/opt/archon-user-home" >> .env            entrypoint chowns
sudo chown -R 1001:1001 /opt/archon-user-home                    /home/appuser to 1001 [+]
docker compose up -d                                             on every start
```

## Architecture Diagram

### Before

```
.env --env_file--> docker-compose.yml --+--> container env (ARCHON_HOME, ARCHON_DATA leak in,
                                        |                   neither has effect)
                                        +--> ${ARCHON_DATA:-archon_data}:/.archon (compose only)

container --> packages/paths/src/archon-paths.ts:56-59
              isDocker() -> return '/.archon' (ignores ARCHON_HOME)

container fs:
  /.archon/             <-- volume mount (workspaces, worktrees, artifacts, sqlite)
  /home/appuser/        <-- ephemeral image dir (no mount, wiped on rebuild)
    .claude/            <-- skills, settings, commands, agents, hooks, MCP, projects, memory, OAuth
    .codex/             <-- interactive `codex login` auth.json
    .pi/agent/          <-- interactive `pi /login` auth.json
    .gitconfig          <-- author identity, aliases, safe.directory entries
    .bash_history       <-- shell history
    .config/gh/         <-- interactive `gh auth login`
```

### After

```
.env --env_file--> docker-compose.yml --+--> container env (still leaks, BUT entrypoint warns) [~]
                                        +--> ${ARCHON_DATA:-archon_data}:/.archon (unchanged)
                                        +--> ${ARCHON_USER_HOME:-archon_user_home}              [+]
                                             :/home/appuser

container --> packages/paths/src/archon-paths.ts:56-59 (UNCHANGED, caveat documented instead)

container --> docker-entrypoint.sh [~]
              +-- chown /.archon                 (unchanged)
              +-- chown /home/appuser  [+ fixes UID drift on bind-mount overrides]
              +-- warn if ARCHON_HOME set      [+]
              +-- warn if ARCHON_DATA set      [+]

container fs:
  /.archon/             <-- volume mount (unchanged)
  /home/appuser/        <-- archon_user_home named volume by default        [+]
    .bashrc, .profile   <-- copied from image skeleton on first init
    .gitconfig          <-- copied from image skeleton on first init,
                            then editable + persistent
    .codex/             <-- empty from image, populated by setup-auth
                            (env-var path) and/or interactive `codex login`
    .claude/            <-- created on demand by Claude Code, persists
    .pi/agent/          <-- created on demand by Pi CLI, persists
    .bash_history       <-- persists
    .config/gh/         <-- persists

deploy/docker-compose.yml [~]      <-- same archon_user_home mount for end-user pre-built image
docker-compose.override.example.yml [~] <-- removes the opt-in claude_home recipe (now redundant)
docs/deployment/docker.md [~]      <-- new "User Home Directory (Persisted)" section + table
                                       of what's persisted; documents ARCHON_USER_HOME
docs/reference/configuration.md [~] <-- ARCHON_HOME/ARCHON_DATA/ARCHON_USER_HOME rows annotated
.env.example [~]                    <-- ARCHON_HOME/ARCHON_DATA blocks annotated;
                                       new ARCHON_USER_HOME block parallel to ARCHON_DATA
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `docker-compose.yml` | `archon_user_home` named volume | **new** | Default-on persistence for `/home/appuser` |
| `deploy/docker-compose.yml` | `archon_user_home` named volume | **new** | Same for end-user pre-built image |
| `${ARCHON_USER_HOME:-archon_user_home}` | `/home/appuser` | **new** | Bind-mount override via `.env`, mirrors `ARCHON_DATA` |
| `docker-entrypoint.sh` | `/home/appuser` | **modified** | Always chown on root branch (no longer conditional on `.claude` only) |
| `docker-entrypoint.sh` | container stderr | **new** | One-line warnings for leaked `ARCHON_HOME` / `ARCHON_DATA` |
| `.env.example` | operator | **modified** | Adds Docker caveats inline + new `ARCHON_USER_HOME` block |
| `docker-compose.override.example.yml` | operator | **modified** | Drops the now-redundant opt-in `claude_home` recipe; points at default-on + `ARCHON_USER_HOME` |
| `docs/deployment/docker.md` "User Home Directory (Persisted)" | reader | **new** | Section + table of what's persisted, with `ARCHON_USER_HOME` recipe |
| `docs/reference/configuration.md` | reader | **modified** | `ARCHON_HOME` row annotated, `ARCHON_DATA` row annotated, `ARCHON_USER_HOME` row added |
| `getArchonHome()` (paths) | container | unchanged | Behavior intentionally preserved |

## Label Snapshot

- Risk: `risk: low` (additive — no existing operator workflow broken)
- Size: `size: S`
- Scope: `infra|config|docs`
- Module: `infra:docker`, `docs:deployment`, `docs:reference`

## Change Metadata

- Change type: `feature` (default-on persistence + new env var) with `docs` and entrypoint hardening alongside
- Primary scope: `multi` (compose + entrypoint + docs + config)

## Linked Issue

- Closes #1517
- Related #
- Depends on # (if stacked) — none
- Supersedes # (if replacing older PR) — none

## Validation Evidence (required)

Commands run locally on Windows (PowerShell + Bun):

```bash
bun run format:check                         # PASS
bun run lint                                 # PASS — zero ESLint warnings
bash -n docker-entrypoint.sh                 # PASS — clean parse
docker compose -f docker-compose.yml config  # PASS — both volumes (archon_data,
                                             #        archon_user_home) wired up
docker compose -f deploy/docker-compose.yml config
                                             # PASS — same for the end-user compose
docker compose -f docker-compose.yml -f docker-compose.override.example.yml config
                                             # PASS — override merges cleanly; both
                                             #        named volumes still present after merge
bun --filter='@archon/docs-web' run build    # PASS — 62 pages built; new section + table render
bun run validate                             # PARTIAL (see below)
```

`bun run validate` reports one pre-existing test failure: `dag-executor.test.ts > script nodes > failure message strips the "Command failed: bun -e <body>" prefix and stays small`. **Confirmed pre-existing** by stashing all changes from this PR and re-running on plain `dev` — same failure. Windows-specific bun stderr-format mismatch in the script-node failure path; unrelated to this PR.

- Evidence provided: validation report at `.claude/archon/reports/1517-docker-env-and-claude-persistence-report.md` (local artifact, gitignored).
- If any command is intentionally skipped, explain why: none skipped.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No` — `setup-auth` continues to write `~/.codex/auth.json` from env vars on every start; the persisted volume just retains a copy across restarts. Env-var path remains authoritative (overwrites volume content each boot).
- File system access scope changed? `Yes (minor)` — entrypoint now chowns `/home/appuser` (recursive) on every start when running as root, matching the existing `/.archon` chown pattern at `docker-entrypoint.sh:12-15`. Affected paths are inside the container's user-home directory only; no host paths touched. On bind mounts (operator sets `ARCHON_USER_HOME=/host/path`), the chown reaches the operator's chosen directory — they must set it to a path they own (`mkdir -p /opt/archon-user-home && sudo chown -R 1001:1001 /opt/archon-user-home`).
- If any `Yes`, describe risk and mitigation: see above. Risk is bounded to a path the operator explicitly opts into via `ARCHON_USER_HOME`; default named volume is Docker-managed and isolated from the host.

## Compatibility / Migration

- Backward compatible? `Yes` (with two observable changes for existing deployments: (a) their first `docker compose up -d` after this lands creates a new `archon_user_home` named volume — in-container customizations under `~/` were ephemeral before, so there's nothing to migrate; (b) Claude SDK now loads `~/.claude/` by default in **all** environments, not just Docker. Previously, only `<cwd>/.claude/` was loaded.)
- Config/env changes? `Yes` — new optional `ARCHON_USER_HOME` env var (defaults to a named volume; no required action). Default `assistants.claude.settingSources` flipped from `['project']` to `['project', 'user']` — operators who relied on the implicit project-only behavior should set `assistants.claude.settingSources: ['project']` in `~/.archon/config.yaml` or `.archon/config.yaml` to restore.
- Database migration needed? `No`
- If yes, exact upgrade steps:
  - **No action required for default behavior.** First container start after upgrade creates the `archon_user_home` named volume; from then on `~/` persists.
  - **If you previously used a manual override to mount `/home/appuser/.claude/`** (e.g. via `docker-compose.override.yml` with a `claude_home` named volume) — the base compose now mounts the parent `/home/appuser`, which masks the narrower `.claude` mount. To migrate the contents from `claude_home` to `archon_user_home`:
    ```bash
    docker run --rm -v claude_home:/from -v archon_user_home:/to alpine \
      sh -c "mkdir -p /to/.claude && cp -a /from/. /to/.claude/ && chown -R 1001:1001 /to"
    ```
    Then remove the old override's `claude_home` mount and `docker volume rm` it. (Pre-PR no operator was using the `claude_home` recipe — it was added in the first commit of this PR and removed in the second; this is documented for completeness.)

Operators who already had `ARCHON_HOME` or `ARCHON_DATA` set in their `.env` will see one new effect: a one-line stderr warning per var on container start. Format: `[archon] ARCHON_HOME=… ignored in Docker (container home is fixed at /.archon)`. Informational, not an error.

## Human Verification (required)

Personally validated beyond CI:

- **Verified scenarios:**
  - `bash -n docker-entrypoint.sh` parses cleanly.
  - `docker compose -f docker-compose.yml config` produces a merged config that mounts BOTH `archon_data:/.archon` AND `archon_user_home:/home/appuser`.
  - `docker compose -f deploy/docker-compose.yml config` produces the same volumes for the pre-built image.
  - `docker compose -f docker-compose.yml -f docker-compose.override.example.yml config` still merges cleanly (override only switches `build:` to `Dockerfile.user`; the volumes remain from the base file).
  - `bun --filter='@archon/docs-web' run build` builds 62 pages; new "User Home Directory (Persisted)" section + the persisted-paths table render correctly.
  - The `git stash` round-trip confirmed the only failing test is pre-existing on `dev`.
- **Edge cases checked:**
  - Named volume (default): Docker first-run init copies the image's `/home/appuser/` content (`.bashrc`, `.profile`, the baked `.gitconfig` with `safe.directory` entries, the empty `.codex/`) into the volume. Subsequent runs use volume content. Verified by reading Docker's named-volume init semantics; mirrors the existing `archon_data:/.archon` pattern that's been in production.
  - Bind mount via `ARCHON_USER_HOME=/host/path`: entrypoint `chown -Rh appuser:appuser /home/appuser` runs on every start and fails loud (exit 1) with the same error format as the existing `/.archon` chown if the path is read-only. Operators chown the host path to UID 1001 once before first start.
  - Non-root container (`docker run --user 1001`): the chown is inside the `if [ "$(id -u)" = "0" ]` root branch so it's skipped — same as the existing `/.archon` behavior.
  - `setup-auth` overwriting `~/.codex/auth.json` from env vars: with persistence, the env-var-path write happens on every start. If an operator interactively `codex login`s, that result is wiped on the next restart unless they unset `CODEX_*` env vars. Documented behavior — env vars are explicitly authoritative.
  - `git config --global --add safe.directory` in the entrypoint: with persistence, these `--add` calls accumulate duplicate entries in `~/.gitconfig` over many restarts. Functionally harmless (`safe.directory` is a set-like check), cosmetically ugly. Out of scope for this PR; flagged as a follow-up nit.
- **What was not verified:**
  - End-to-end `docker compose up -d` on a fresh image build. The build was not run locally because no TS source changed and the entrypoint was syntax-checked. Reviewer with a Linux/Mac Docker daemon can verify with:
    ```bash
    docker compose up -d
    docker compose exec app bash -c "ls -la /home/appuser/.gitconfig && touch /home/appuser/.claude/probe"
    docker compose down
    docker compose up -d
    docker compose exec app bash -c "ls -la /home/appuser/.claude/probe"  # should still exist
    ```
  - The `[archon] ARCHON_HOME=… ignored` stderr warning was not exercised in a live container; tested by reading the entrypoint logic only.

## Side Effects / Blast Radius (required)

- **Affected subsystems/workflows:** Docker container startup (entrypoint script), `docker-compose.yml` (root + `deploy/`), operator-facing docs (deployment + reference), `.env.example` template. **Plus** Claude provider configuration in **all** environments (Docker AND non-Docker `bun run dev`) via the `settingSources` default flip — non-Docker users will now have `~/.claude/CLAUDE.md`, skills, commands, and agents loaded at session boot unless they explicitly set `assistants.claude.settingSources: ['project']`.
- **Potential unintended effects:**
  - **New named volume on every existing deployment.** Operators upgrading will see a new `archon_user_home` Docker volume after `docker compose up -d`. Storage cost is small (a few KB of `.bashrc` / `.gitconfig` skeleton until they actually save anything). `docker compose down -v` blast radius grows by one volume.
  - **`docker compose down` does NOT delete the new volume** (named volumes survive `down` by design); only `down -v` does. Existing semantics — but worth noting because operators who relied on `down -v` to "reset everything" will now also lose their persisted `~/`. Documented in the docker.md section.
  - **`setup-auth` write on every start now lands in the persisted volume.** If an operator changes their `CODEX_*` env vars, the new values overwrite the persisted `auth.json` — same behavior as today, just persisted.
  - **CI/log-scrapers grepping for `[archon]`** — the leaked-var warnings prefix with `[archon]` matching existing log style; content is informational, not "ERROR". Acceptable noise.
- **Guardrails/monitoring for early detection:** None needed. CI runs `bun run validate` and `bun --filter='@archon/docs-web' run build`; both pass. The Docker image build is exercised by the existing CI release pipeline on merge to `main`.

## Rollback Plan (required)

- **Fast rollback command/path:** `git revert <merge-sha>` — single squash merge means one revert reverses the volume mount + entrypoint chown + docs in one go. Operators with persisted state in the `archon_user_home` volume keep that data; reverting just stops mounting it (the volume itself is preserved by Docker until manually deleted).
- **Feature flags or config toggles (if any):** Operators can pre-empt the persisted volume by setting `ARCHON_USER_HOME=/dev/null` or any path they don't care about — but the cleanest opt-out is to revert the PR.
- **Observable failure symptoms:**
  - If the entrypoint chown of `/home/appuser` fails (e.g. SELinux read-only mount, exotic bind-mount with incompatible options), the container exits on startup with `ERROR: Failed to fix ownership of /home/appuser — volume may be read-only or mounted with incompatible options`. Symptom is identical in shape to the existing `/.archon` chown failure (mirrors `docker-entrypoint.sh:12-15`).
  - If named-volume first-run init fails to copy image content, the container starts with an empty `/home/appuser` — `~/.bashrc` and the baked `.gitconfig` go missing. This would indicate Docker daemon misconfiguration, not an Archon bug.

## Risks and Mitigations

- **Risk:** Operator with bind-mounted `/home/appuser` (via `ARCHON_USER_HOME=/host/path`) on a read-only filesystem (e.g. SELinux) — entrypoint exits 1.
  - **Mitigation:** Same fail-loud-with-stderr pattern as the existing `/.archon` chown. Error message names the path and the likely cause; rollback is a one-liner.
- **Risk:** `git config --global --add safe.directory` in the entrypoint accumulates duplicate entries in the persisted `~/.gitconfig` across many restarts.
  - **Mitigation:** **Fixed in `30883848`** — entrypoint now `git config --get-all safe.directory | grep -qxF` checks before `--add`, making the loop idempotent across restarts.
- **Risk:** `settingSources` default flip silently widens loaded scope for existing non-Docker users — anyone running `bun run dev` upgrades and now finds `~/.claude/` resources auto-loaded.
  - **Mitigation:** CHANGELOG `[Unreleased]` entry highlights the behavior change with the explicit `['project']` opt-out recipe. Reference docs and CLAUDE.md updated. A regression test (`provider.test.ts`) locks in the `['project']` opt-out contract so a future refactor can't silently widen scope again.
- **Risk:** `setup-auth` overwrites a persisted `~/.codex/auth.json` from interactive `codex login`.
  - **Mitigation:** Documented — env-var path is authoritative by design. Operators who use interactive Codex login should unset `CODEX_*` env vars in `.env`.
- **Risk:** Doc-build (Astro/Starlight) breaks on the table syntax in the new section.
  - **Mitigation:** Standard Markdown table; verified by `bun --filter='@archon/docs-web' run build` (62 pages built clean).
- **Risk:** `claude_home` recipe was briefly published in the first commit of this PR (the opt-in version). Anyone who pulled mid-PR would have an orphan named volume.
  - **Mitigation:** PR has not been merged yet; second commit removes the recipe before any merge. Migration steps documented above for completeness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Docker now persists user home directory by default; configurable via `ARCHON_USER_HOME` environment variable for host bind-mount override.
  * Claude provider loads both project-level and user-level resources by default.

* **Improvements**
  * Docker entrypoint warns when ignored environment variables are set.
  * Setup-auth warns about potentially stale persisted credentials at startup.
  * Git configuration deduplication prevents unbounded growth on repeated container starts.

* **Documentation**
  * Updated Docker deployment and persistence guidance.
  * Clarified Claude resource discovery behavior and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->