### PR TITLE
fix(docker): resolve Claude binary to glibc variant on Debian image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,13 +108,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm \
 # Point agent-browser to system Chromium (avoids ~400MB Chrome for Testing download)
 ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
 
-# Pre-configure the Claude Code SDK cli.js path for any consumer that runs
-# a compiled Archon binary inside (or extending) this image. In source mode
-# (the default `bun run start` ENTRYPOINT), BUNDLED_IS_BINARY is false and
-# this variable is ignored — the SDK resolves cli.js via node_modules. Kept
-# here so extenders don't need to rediscover the path.
-# Path matches the hoisted layout produced by `bun install --linker=hoisted`.
-ENV CLAUDE_BIN_PATH=/app/node_modules/@anthropic-ai/claude-agent-sdk/cli.js
+# CLAUDE_BIN_PATH is set at container startup (docker-entrypoint.sh).
+# The entrypoint pins the glibc variant to bypass the SDK's musl-first resolver.
 
 # Create non-root user for running Claude Code
 # Claude Code refuses to run with --dangerously-skip-permissions as root for security

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -44,10 +44,17 @@ fi
 # already provided one via docker run -e or docker-compose env_file.
 if [ -z "${CLAUDE_BIN_PATH:-}" ]; then
   case "$(uname -m)" in
-    x86_64)  export CLAUDE_BIN_PATH="/app/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude" ;;
-    aarch64) export CLAUDE_BIN_PATH="/app/node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64/claude" ;;
+    x86_64)  _CLAUDE_BIN_CANDIDATE="/app/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude" ;;
+    aarch64) _CLAUDE_BIN_CANDIDATE="/app/node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64/claude" ;;
     *) echo "WARN: Unsupported CPU architecture $(uname -m). Set CLAUDE_BIN_PATH manually if Claude fails to start." >&2 ;;
   esac
+  if [ -n "${_CLAUDE_BIN_CANDIDATE:-}" ]; then
+    if [ -f "$_CLAUDE_BIN_CANDIDATE" ]; then
+      export CLAUDE_BIN_PATH="$_CLAUDE_BIN_CANDIDATE"
+    else
+      echo "WARN: Pinned Claude binary not found at ${_CLAUDE_BIN_CANDIDATE}. SDK will use its default resolver — Claude may fail to start." >&2
+    fi
+  fi
 fi
 
 # Run setup-auth (exits after configuring Codex credentials), then exec the server

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -46,6 +46,7 @@ if [ -z "${CLAUDE_BIN_PATH:-}" ]; then
   case "$(uname -m)" in
     x86_64)  export CLAUDE_BIN_PATH="/app/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude" ;;
     aarch64) export CLAUDE_BIN_PATH="/app/node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64/claude" ;;
+    *) echo "WARN: Unsupported CPU architecture $(uname -m). Set CLAUDE_BIN_PATH manually if Claude fails to start." >&2 ;;
   esac
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -46,15 +46,18 @@ if [ -z "${CLAUDE_BIN_PATH:-}" ]; then
   case "$(uname -m)" in
     x86_64)  _CLAUDE_BIN_CANDIDATE="/app/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude" ;;
     aarch64) _CLAUDE_BIN_CANDIDATE="/app/node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64/claude" ;;
-    *) echo "WARN: Unsupported CPU architecture $(uname -m). Set CLAUDE_BIN_PATH manually if Claude fails to start." >&2 ;;
+    *)
+      echo "ERROR: Unsupported CPU architecture $(uname -m). Set CLAUDE_BIN_PATH manually to a glibc Claude binary." >&2
+      exit 1
+      ;;
   esac
-  if [ -n "${_CLAUDE_BIN_CANDIDATE:-}" ]; then
-    if [ -f "$_CLAUDE_BIN_CANDIDATE" ]; then
-      export CLAUDE_BIN_PATH="$_CLAUDE_BIN_CANDIDATE"
-    else
-      echo "WARN: Pinned Claude binary not found at ${_CLAUDE_BIN_CANDIDATE}. SDK will use its default resolver — Claude may fail to start." >&2
-    fi
+  if [ -x "$_CLAUDE_BIN_CANDIDATE" ]; then
+    export CLAUDE_BIN_PATH="$_CLAUDE_BIN_CANDIDATE"
+  else
+    echo "ERROR: Pinned Claude binary missing or non-executable at ${_CLAUDE_BIN_CANDIDATE}. The SDK package layout may have changed; set CLAUDE_BIN_PATH manually." >&2
+    exit 1
   fi
+  unset _CLAUDE_BIN_CANDIDATE
 fi
 
 # Run setup-auth (exits after configuring Codex credentials), then exec the server

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -37,6 +37,18 @@ if [ -n "$GH_TOKEN" ]; then
     '!f() { echo "username=x-access-token"; echo "password=${GH_TOKEN}"; }; f'
 fi
 
+# Pin the glibc Claude Code binary to bypass the SDK's musl-first resolver.
+# Bun's hoisted linker installs both glibc and musl optional-dep variants for
+# the current CPU arch; the SDK picks musl first, which fails to execute on
+# this Debian (glibc) image. Only sets CLAUDE_BIN_PATH if the user has not
+# already provided one via docker run -e or docker-compose env_file.
+if [ -z "${CLAUDE_BIN_PATH:-}" ]; then
+  case "$(uname -m)" in
+    x86_64)  export CLAUDE_BIN_PATH="/app/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude" ;;
+    aarch64) export CLAUDE_BIN_PATH="/app/node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64/claude" ;;
+  esac
+fi
+
 # Run setup-auth (exits after configuring Codex credentials), then exec the server
 # exec ensures bun is PID 1 and receives SIGTERM for graceful shutdown
 $RUNNER bun run setup-auth


### PR DESCRIPTION
## Summary

- **Problem**: All Claude SDK calls fail in Docker — `CLAUDE_BIN_PATH` pointed to the SDK 0.1.x `cli.js` path which no longer exists in SDK 0.2.x; and even without that env var, the SDK's resolver picks the musl binary first, which cannot execute on the Debian glibc base image.
- **Why it matters**: Blocker for all Docker users on current `dev` — Claude is the default provider and is completely non-functional.
- **What changed**: Removed the stale `ENV CLAUDE_BIN_PATH=.../cli.js` from `Dockerfile`; added runtime CPU arch detection in `docker-entrypoint.sh` that pins `CLAUDE_BIN_PATH` to the correct glibc package (`linux-x64` for x86_64, `linux-arm64` for aarch64) before starting the server.
- **What did not change**: No application code changes; `binary-resolver.ts` already handles `CLAUDE_BIN_PATH` correctly. Users can still override via `.env` or `docker run -e CLAUDE_BIN_PATH=...`.

## UX Journey

### Before

```
User                          Archon (Docker)               Claude SDK
────                          ───────────────                ──────────
POST /message ──────────────▶ orchestrator-agent
                              sendQuery() ────────────────▶ resolveClaudeBinaryPath
                                                            reads CLAUDE_BIN_PATH
                                                            (.../cli.js — does not exist)
                              error logged ◀───────────── throws "file does not exist"
500 ◀──────────────────────── orchestrator_message_failed

After removing stale ENV — SDK resolver picks musl binary:
                              sendQuery() ────────────────▶ SDK auto-resolves
                                                            picks musl variant first
                                                            spawn(<musl claude>)
                                                            [X] cannot execute (glibc host)
                              query_error ◀───────────── ENOENT (loader missing)
```

### After

```
User                          Archon (Docker)               Claude SDK
────                          ───────────────                ──────────
[entrypoint sets CLAUDE_BIN_PATH=/app/.../claude-agent-sdk-linux-{x64|arm64}/claude]
POST /message ──────────────▶ orchestrator-agent
                              sendQuery() ────────────────▶ resolveClaudeBinaryPath
                                                            reads CLAUDE_BIN_PATH (glibc binary)
                                                            [✓] file exists, source=env
                              streams response ◀────────── Claude executes
reply ◀──────────────────────  sends to platform
```

## Architecture Diagram

### Before

```
Dockerfile
  └── ENV CLAUDE_BIN_PATH=.../claude-agent-sdk/cli.js   [stale — SDK 0.1.x path]

docker-entrypoint.sh
  └── exec gosu appuser bun run start

binary-resolver.ts
  └── reads CLAUDE_BIN_PATH → file missing → throws
```

### After

```
Dockerfile
  └── (comment only — no ENV CLAUDE_BIN_PATH)           [~]

docker-entrypoint.sh
  └── if [ -z "$CLAUDE_BIN_PATH" ]; then                [+]
        uname -m → x86_64|aarch64
        export CLAUDE_BIN_PATH=.../linux-x64|arm64/claude
      fi
  └── exec gosu appuser bun run start

binary-resolver.ts (unchanged)
  └── reads CLAUDE_BIN_PATH → glibc binary → returns path
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `Dockerfile` | image ENV | **modified** | Removed stale `CLAUDE_BIN_PATH` |
| `docker-entrypoint.sh` | `CLAUDE_BIN_PATH` env var | **new** | Runtime arch detection, respects user override |
| `binary-resolver.ts` | `CLAUDE_BIN_PATH` | unchanged | Already reads env var correctly |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `ci`
- Module: `docker:entrypoint`

## Change Metadata

- Change type: `bug`
- Primary scope: `ci`

## Linked Issue

- Closes #1519

## Validation Evidence (required)

```bash
bun run validate
```

No TypeScript/JS code changed — only `Dockerfile` (comment replacement) and `docker-entrypoint.sh` (shell script). Type-check, lint, format, and test suites are unaffected. Docker build validation requires a live Docker daemon.

The fix follows the same pattern described in issue #1519 and verified by the issue author on linux/arm64. This PR extends that fix to handle x86_64→x64 arch mapping correctly (the issue's suggested `ARG TARGETARCH` approach would have silently produced a wrong path on amd64 builds).

- Evidence provided: Issue author verified glibc binary executes successfully; `claude.binary_resolved` log shows `source=env`
- Intentionally skipped: Docker build smoke test (no Docker daemon in CI)

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — users who already set `CLAUDE_BIN_PATH` in `.env` are unaffected (the entrypoint skips the auto-detection when `CLAUDE_BIN_PATH` is already set)
- Config/env changes? No — existing `.env` files work unchanged
- Database migration needed? No

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Traced the execution path in `binary-resolver.ts` — env var is read at step 1, before `BUNDLED_IS_BINARY` check, so it works in both source and binary mode
- Edge cases checked: User-provided `CLAUDE_BIN_PATH` in `.env` is preserved; unknown arch (e.g. riscv64) silently skips the auto-detection, falling through to SDK's default resolution
- What was not verified: Live Docker build and container run (no Docker daemon available in this environment)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Docker deployment only — no impact on local dev, CLI, or platform adapters
- Potential unintended effects: If a future SDK version changes the binary location within its optional-dep package, the hardcoded path would need updating (same maintenance burden as before)
- Guardrails/monitoring for early detection: `binary-resolver.ts` logs `claude.binary_resolved` with `source=env` and the resolved path — visible in container logs

## Rollback Plan (required)

- Fast rollback command/path: Revert this commit; set `CLAUDE_BIN_PATH` manually in `.env` as a workaround
- Feature flags or config toggles: Users can override `CLAUDE_BIN_PATH` in `.env` at any time
- Observable failure symptoms: `orchestrator_message_failed` / `title.generate_failed` in container logs; `CLAUDE_BIN_PATH is set to "..." but the file does not exist` error

## Risks and Mitigations

- Risk: Hardcoded path breaks if SDK reorganizes its package structure in a future version
  - Mitigation: Path is set only as a default; the `binary-resolver.ts` file-existence check will surface a clear error immediately if the path becomes stale; users can override via `CLAUDE_BIN_PATH`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Container startup now auto-selects and exports an architecture-appropriate executable, improving libc compatibility and preventing runtime failures when a pinned binary is present.

* **Documentation**
  * Clarified that the executable path is determined at container startup (not at build time) and added a runtime error message for unsupported architectures or missing/non-executable pinned binaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->