### PR TITLE
fix(server): surface CLI resume command in web approve/reject responses

### DIFF
--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -2027,7 +2027,7 @@ export function registerApiRoutes(
         success: true,
         message: autoResumed
           ? `Workflow approved: ${run.workflow_name}. Resuming workflow.`
-          : `Workflow approved: ${run.workflow_name}. Send a message to continue.`,
+          : `Workflow approved: ${run.workflow_name}. Run \`archon workflow resume ${runId}\` from the CLI to continue, or send a new message in the originating conversation.`,
       });
     } catch (error) {
       getLog().error({ err: error, runId }, 'api.workflow_run_approve_failed');
@@ -2082,7 +2082,7 @@ export function registerApiRoutes(
           success: true,
           message: autoResumed
             ? `Workflow rejected: ${run.workflow_name}. Running on-reject prompt.`
-            : `Workflow rejected: ${run.workflow_name}. On-reject prompt will run on resume.`,
+            : `Workflow rejected: ${run.workflow_name}. On-reject prompt will run when the run resumes — run \`archon workflow resume ${runId}\` from the CLI to trigger it.`,
         });
       }
 

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -2024,7 +2024,7 @@ export function registerApiRoutes(
         success: true,
         message: autoResumed
           ? `Workflow approved: ${run.workflow_name}. Resuming workflow.`
-          : `Workflow approved: ${run.workflow_name}. Send a message to continue.`,
+          : `Workflow approved: ${run.workflow_name}. Run \`archon workflow resume ${runId}\` from the CLI to continue, or send a new message in the originating conversation.`,
       });
     } catch (error) {
       getLog().error({ err: error, runId }, 'api.workflow_run_approve_failed');
@@ -2079,7 +2079,7 @@ export function registerApiRoutes(
           success: true,
           message: autoResumed
             ? `Workflow rejected: ${run.workflow_name}. Running on-reject prompt.`
-            : `Workflow rejected: ${run.workflow_name}. On-reject prompt will run on resume.`,
+            : `Workflow rejected: ${run.workflow_name}. On-reject prompt will run when the run resumes — run \`archon workflow resume ${runId}\` from the CLI to trigger it.`,
         });
       }
 

--- a/packages/server/src/routes/api.workflow-runs.test.ts
+++ b/packages/server/src/routes/api.workflow-runs.test.ts
@@ -1506,7 +1506,7 @@ describe('approve/reject auto-resume', () => {
 
     expect(response.status).toBe(200);
     const body = (await response.json()) as { message: string };
-    expect(body.message).toContain('Send a message to continue');
+    expect(body.message).toContain('archon workflow resume run-paused-1');
     expect(mockHandleMessage).not.toHaveBeenCalled();
     expect(mockGetConversationById).not.toHaveBeenCalled();
   });
@@ -1527,7 +1527,7 @@ describe('approve/reject auto-resume', () => {
 
     expect(response.status).toBe(200);
     const body = (await response.json()) as { message: string };
-    expect(body.message).toContain('Send a message to continue');
+    expect(body.message).toContain('archon workflow resume run-paused-1');
     expect(mockHandleMessage).not.toHaveBeenCalled();
   });
 
@@ -1555,8 +1555,8 @@ describe('approve/reject auto-resume', () => {
 
     expect(response.status).toBe(200);
     const body = (await response.json()) as { message: string };
-    // Same fallback text as no-parent case — user re-runs from the originating platform.
-    expect(body.message).toContain('Send a message to continue');
+    // Surfaces the exact CLI command so the web-UI user has a concrete next step.
+    expect(body.message).toContain('archon workflow resume run-paused-1');
     expect(mockHandleMessage).not.toHaveBeenCalled();
   });
 
@@ -1601,6 +1601,41 @@ describe('approve/reject auto-resume', () => {
     ];
     expect(platformConvId).toBe('web-plat-xyz');
     expect(dispatchedMessage).toBe('/workflow run deploy Review PR');
+  });
+
+  test('reject: surfaces CLI resume hint when on_reject configured but parent is non-web', async () => {
+    mockGetWorkflowRun.mockResolvedValueOnce({
+      ...MOCK_PAUSED_RUN,
+      id: 'run-reject-non-web',
+      parent_conversation_id: 'slack-parent-conv-uuid',
+      metadata: {
+        approval: {
+          type: 'approval',
+          nodeId: 'review-gate',
+          message: 'Approve?',
+          onRejectPrompt: 'Fix: $REJECTION_REASON',
+          onRejectMaxAttempts: 3,
+        },
+        rejection_count: 0,
+      },
+    });
+    mockGetConversationById.mockResolvedValueOnce({
+      id: 'slack-parent-conv-uuid',
+      platform_conversation_id: '1234567890.123456',
+      platform_type: 'slack',
+    });
+
+    const { app } = makeApp();
+    const response = await app.request('/api/workflows/runs/run-reject-non-web/reject', {
+      method: 'POST',
+      body: JSON.stringify({ reason: 'tests missing' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { message: string };
+    expect(body.message).toContain('archon workflow resume run-reject-non-web');
+    expect(mockHandleMessage).not.toHaveBeenCalled();
   });
 
   test('reject: does NOT dispatch when the run is being cancelled (no on_reject configured)', async () => {


### PR DESCRIPTION
## Summary

- **Problem**: When a workflow run is approved/rejected via the Web UI but `tryAutoResumeAfterGate` skips dispatch — because there is no `parent_conversation_id`, the parent conversation is gone, or the parent sits on a non-web platform (Slack/Telegram/GitHub/CLI) — the success message said only `"Send a message to continue"` / `"On-reject prompt will run on resume"`. A web-UI user whose run originated from a terminal has no obvious next step from that text; the run sits in `failed` status with `metadata.rejection_reason` populated and the user has to read the DB schema to discover `archon workflow resume <id>` exists.
- **Why it matters**: Reproduced locally with a CLI-started run that was then rejected from the dashboard. Recovery required reading source.
- **What changed**: Both approve and reject (on_reject branch) now include the exact `archon workflow resume <runId>` command in the non-auto-resumed response. The auto-resume happy path is unchanged.
- **What did NOT change**: Dispatch decision logic, the `parent_conversation_id`-based cross-adapter guard, log events, DB writes, and the no-on_reject cancellation path are byte-identical. The Resume endpoint's CLI hints (`/api/workflows/runs/:runId/resume`) are covered by #1329 and are not touched here.

## Scope History

This PR was rebased after #1329 (web approval auto-resume + cross-adapter guard) and #1646 (explicit resume pipeline) merged into `dev`. Both eliminated the original PR's larger surface (discriminated-union refactor of `tryAutoResumeAfterGate` and Resume-endpoint hint additions). Scope reduced on rebase to only the gate-time messaging delta that remains uncovered.

## Linked Issue

- Closes #1522

## Validation Evidence

```bash
bun x prettier --check packages/server/src/routes/{api.ts,api.workflow-runs.test.ts}
# All matched files use Prettier code style

bun x eslint --max-warnings 0 --no-warn-ignored \
  packages/server/src/routes/api.ts packages/server/src/routes/api.workflow-runs.test.ts
# clean

bun --filter @archon/server test packages/server/src/routes/api.workflow-runs.test.ts
# 14/14 pass (one new regression test for reject + on_reject + non-web parent)
```

The four pre-existing approve auto-resume-skipped tests had their substring assertion updated from `"Send a message to continue"` to `"archon workflow resume run-paused-1"`. One new test covers the symmetric reject case (on_reject + non-web parent).

## Security Impact

- New permissions/capabilities? **No**.
- New external network calls? **No**.
- Secrets/tokens handling changed? **No**.
- File system access scope changed? **No**.

## Compatibility / Migration

- Backward compatible? **Yes** — response shape unchanged, only the human-readable `message` text differs in the non-auto-resumed branches.
- Config/env changes? **No**.
- Database migration needed? **No**.

## Rollback Plan

- Fast rollback: revert this commit. Two files, ~40 lines net.
- Feature flags: none.
- Observable failure symptom on rollback: web-UI users seeing the old vague text again — the auto-resume happy path is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resume endpoints now explain when auto-resume was skipped (missing parent, deleted parent, or non-web parent) and include a clear CLI fallback hint: archon workflow resume <runId>. Wording differs for approve vs. reject flows (approve suggests CLI or replying in the original conversation; reject clarifies the on-reject prompt will run when resumed).
* **Tests**
  * Tests updated to assert the explicit CLI hints and added a reject-case covering non-web parent scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1523?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->