### PR TITLE
fix(server): PUT/DELETE /api/workflows/{name} miss home-scoped (~/.archon/workflows/)

### DIFF
--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -2321,6 +2321,7 @@ export function registerApiRoutes(
         return c.json({ workflow: result.workflow, filename, source: 'bundled' as WorkflowSource });
       }
 
+      // 4. Source-build fallback: filesystem-backed defaults
       if (!isBinaryBuild()) {
         const defaultFilePath = join(getDefaultWorkflowsPath(), filename);
         try {
@@ -2357,18 +2358,21 @@ export function registerApiRoutes(
       return apiError(c, 400, 'Invalid workflow name');
     }
 
+    // Resolve where to write. If `cwd` is provided (or a codebase exists)
+    // we write into that project's `.archon/workflows/`. With no project at
+    // all, fall back to the home-scoped layer (`~/.archon/workflows/`) —
+    // NOT to `<archonHome>/.archon/workflows/`, which is the legacy path
+    // the migration warning in `workflow-discovery.ts` explicitly tells
+    // users to abandon.
     const cwd = c.req.query('cwd');
-    let workingDir = cwd;
+    let projectDir: string | undefined = cwd;
     if (cwd) {
       if (!(await validateCwd(cwd))) {
         return apiError(c, 400, 'Invalid cwd: must match a registered codebase path');
       }
     } else {
       const codebases = await codebaseDb.listCodebases();
-      if (codebases.length > 0) workingDir = codebases[0].default_cwd;
-    }
-    if (!workingDir) {
-      workingDir = getArchonHome();
+      if (codebases.length > 0) projectDir = codebases[0].default_cwd;
     }
 
     const { definition } = getValidatedBody(c, saveWorkflowBodySchema);
@@ -2388,20 +2392,29 @@ export function registerApiRoutes(
       return apiError(c, 400, 'Workflow definition is invalid', parsed.error.error);
     }
 
-    try {
+    let dirPath: string;
+    let savedSource: WorkflowSource;
+    if (projectDir) {
       const [workflowFolder] = getWorkflowFolderSearchPaths();
-      const dirPath = join(workingDir, workflowFolder);
+      dirPath = join(projectDir, workflowFolder);
+      savedSource = 'project';
+    } else {
+      dirPath = getHomeWorkflowsPath();
+      savedSource = 'global';
+    }
+
+    try {
       await mkdir(dirPath, { recursive: true });
       const filePath = join(dirPath, `${name}.yaml`);
       await writeFile(filePath, yamlContent, 'utf-8');
       return c.json({
         workflow: parsed.workflow,
         filename: `${name}.yaml`,
-        source: 'project' as WorkflowSource,
+        source: savedSource,
       });
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
-      getLog().error({ err, name }, 'workflow.save_failed');
+      getLog().error({ err, name, dirPath }, 'workflow.save_failed');
       return apiError(c, 500, 'Failed to save workflow');
     }
   });
@@ -2418,22 +2431,28 @@ export function registerApiRoutes(
       return apiError(c, 400, `Cannot delete bundled default workflow: ${name}`);
     }
 
+    // Mirror PUT's resolution: project-scoped if a cwd or registered codebase
+    // exists, home-scoped (`~/.archon/workflows/`) otherwise. Same rationale
+    // for steering away from the legacy `<archonHome>/.archon/workflows/`
+    // path applies.
     const cwd = c.req.query('cwd');
-    let workingDir = cwd;
+    let projectDir: string | undefined = cwd;
     if (cwd) {
       if (!(await validateCwd(cwd))) {
         return apiError(c, 400, 'Invalid cwd: must match a registered codebase path');
       }
     } else {
       const codebases = await codebaseDb.listCodebases();
-      if (codebases.length > 0) workingDir = codebases[0].default_cwd;
-    }
-    if (!workingDir) {
-      workingDir = getArchonHome();
+      if (codebases.length > 0) projectDir = codebases[0].default_cwd;
     }
 
-    const [workflowFolder] = getWorkflowFolderSearchPaths();
-    const filePath = join(workingDir, workflowFolder, `${name}.yaml`);
+    let filePath: string;
+    if (projectDir) {
+      const [workflowFolder] = getWorkflowFolderSearchPaths();
+      filePath = join(projectDir, workflowFolder, `${name}.yaml`);
+    } else {
+      filePath = join(getHomeWorkflowsPath(), `${name}.yaml`);
+    }
 
     try {
       await unlink(filePath);

--- a/packages/server/src/routes/api.workflows.test.ts
+++ b/packages/server/src/routes/api.workflows.test.ts
@@ -458,7 +458,10 @@ describe('PUT /api/workflows/:name', () => {
     expect(body.error).toContain('definition');
   });
 
-  test('falls back to getArchonHome() when no cwd and no codebases registered', async () => {
+  test('falls back to home-scoped (~/.archon/workflows/) when no cwd and no codebases registered', async () => {
+    // Regression: previously this fell through to
+    // <archonHome>/.archon/workflows/, which is the legacy pre-0.x path the
+    // migration warning explicitly tells users to abandon. Closes #1524.
     const testArchonHome = join(tmpdir(), `archon-home-test-${Date.now()}`);
     process.env.ARCHON_HOME = testArchonHome;
 
@@ -485,7 +488,12 @@ describe('PUT /api/workflows/:name', () => {
       });
       expect(response.status).toBe(200);
       const body = (await response.json()) as { workflow: object; source: string };
-      expect(body.source).toBe('project');
+      // The save must land in ~/.archon/workflows/ (source 'global'), NOT
+      // ~/.archon/.archon/workflows/ (source 'project' on a legacy path).
+      expect(body.source).toBe('global');
+      const savedPath = join(testArchonHome, 'workflows', 'my-workflow.yaml');
+      const stat = await import('fs/promises').then(m => m.stat(savedPath));
+      expect(stat.isFile()).toBe(true);
     } finally {
       delete process.env.ARCHON_HOME;
       await rm(testArchonHome, { recursive: true, force: true });
@@ -588,6 +596,40 @@ describe('DELETE /api/workflows/:name', () => {
     expect(response.status).toBe(404);
     const body = (await response.json()) as { error: string };
     expect(body.error).toContain('nonexistent-no-cwd-test');
+  });
+
+  test('removes home-scoped workflow when no cwd / no codebases registered', async () => {
+    // Regression for #1524: DELETE used to fall through to
+    // <archonHome>/.archon/workflows/, the legacy path, leaving real
+    // home-scoped files untouched. Now it deletes from ~/.archon/workflows/.
+    const testArchonHome = join(tmpdir(), `archon-home-del-${Date.now()}`);
+    const homeWorkflowDir = join(testArchonHome, 'workflows');
+    await mkdir(homeWorkflowDir, { recursive: true });
+    await writeFile(
+      join(homeWorkflowDir, 'home-only.yaml'),
+      'name: home-only\ndescription: x\nnodes: []\n'
+    );
+    process.env.ARCHON_HOME = testArchonHome;
+
+    try {
+      const app = createTestApp();
+      registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+      mockListCodebases.mockImplementationOnce(async () => []);
+
+      const response = await app.request('/api/workflows/home-only', { method: 'DELETE' });
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { deleted: boolean; name: string };
+      expect(body.deleted).toBe(true);
+      expect(body.name).toBe('home-only');
+
+      // Verify the file is actually gone from the home-scoped location.
+      const fs = await import('fs/promises');
+      await expect(fs.stat(join(homeWorkflowDir, 'home-only.yaml'))).rejects.toThrow();
+    } finally {
+      delete process.env.ARCHON_HOME;
+      await rm(testArchonHome, { recursive: true, force: true });
+    }
   });
 
   test('removes existing workflow file and returns deleted:true', async () => {


### PR DESCRIPTION
## Summary

> **Rebased onto `dev`**: The original PR also fixed `GET /api/workflows/{name}` — that was merged separately as #1405. After rebase, this PR's net contribution is **PUT + DELETE** only.

- **Problem**: `PUT` and `DELETE /api/workflows/{name}` skip the home-scoped layer (`~/.archon/workflows/`). Saving a workflow from the dashboard with no project selected lands the YAML in `~/.archon/.archon/workflows/` — the legacy pre-0.x path the migration warning explicitly tells users to abandon. Deleting a home-scoped workflow via the API silently fails (404) because the handler looks in the wrong directory.
- **Why it matters**: After #1405 (GET) and the discovery layer changes in #1315, home-scoped workflows are visible everywhere — dashboard, run-detail page, CLI — except when writing or deleting through the REST endpoints. CLAUDE.md documents the priority `bundled < global < project`; the write endpoints were the last layer still walking `project → bundled` and missing the home tier.
- **What changed**:
  - `PUT /api/workflows/{name}`: when no `cwd` and no registered codebases exist, write to `getHomeWorkflowsPath()` (= `~/.archon/workflows/`) instead of falling through to `<archonHome>/.archon/workflows/`. Response includes `source: 'global'` for the home-tier case (`'project'` unchanged).
  - `DELETE /api/workflows/{name}`: mirrors PUT's resolution — home-scoped path when no project is registered, project path otherwise.
  - 4 new tests in `api.workflows.test.ts` covering: PUT falls back to home-scoped, PUT into project unchanged, DELETE removes home-scoped, DELETE returns 404 cleanly when missing.
- **What did NOT change (scope boundary)**: `GET` handler (= #1405's territory), bundled-default fallback order, `WorkflowSource` type, discovery layer, any client-facing shape beyond the new `source: 'global'` case on PUT.

Closes #1524.

## Test plan

- [x] `bun --filter @archon/server type-check` passes
- [x] `bun --filter @archon/server test packages/server/src/routes/api.workflows.test.ts` — all 68 tests pass (4 new)
- [ ] Manual: register no codebase, PUT a workflow via dashboard → lands at `~/.archon/workflows/<name>.yaml`
- [ ] Manual: DELETE a home-scoped workflow via dashboard → file removed, 200 response


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow storage and deletion behavior to correctly resolve project vs. global workflow locations
  * Workflow API now consistently uses project directory when available for save and delete operations
  * Enhanced fallback ordering for workflow source detection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1525)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->