### PR TITLE
fix(orchestrator): create ~/.archon/workspaces before AI provider spawn

### DIFF
--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -54,6 +54,7 @@ const mockLogger = createMockLogger();
 mock.module('@archon/paths', () => ({
   createLogger: mock(() => mockLogger),
   getArchonWorkspacesPath: mock(() => '/home/test/.archon/workspaces'),
+  ensureArchonWorkspacesPath: mock(() => Promise.resolve('/home/test/.archon/workspaces')),
   getArchonHome: mock(() => '/home/test/.archon'),
 }));
 

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -51,10 +51,11 @@ const mockLoadConfig = mock(() =>
 
 const mockLogger = createMockLogger();
 
+const mockEnsureArchonWorkspacesPath = mock(() => Promise.resolve('/home/test/.archon/workspaces'));
 mock.module('@archon/paths', () => ({
   createLogger: mock(() => mockLogger),
   getArchonWorkspacesPath: mock(() => '/home/test/.archon/workspaces'),
-  ensureArchonWorkspacesPath: mock(() => Promise.resolve('/home/test/.archon/workspaces')),
+  ensureArchonWorkspacesPath: mockEnsureArchonWorkspacesPath,
   getArchonHome: mock(() => '/home/test/.archon'),
 }));
 
@@ -907,6 +908,7 @@ describe('discoverAllWorkflows — remote sync', () => {
     mockSendQuery.mockClear();
     mockGetCodebaseEnvVars.mockReset();
     mockLoadConfig.mockReset();
+    mockEnsureArchonWorkspacesPath.mockClear();
     // Reset mocks between tests in this suite and restore safe defaults
     mockGetOrCreateConversation.mockImplementation(() => Promise.resolve(null));
     mockGetCodebase.mockImplementation(() => Promise.resolve(null));
@@ -932,6 +934,9 @@ describe('discoverAllWorkflows — remote sync', () => {
     expect(mockSyncWorkspace).toHaveBeenCalledWith('/repos/test-repo', undefined, {
       resetAfterFetch: false,
     });
+    // Regression guard: orchestrator must resolve cwd through the ensure variant
+    // so the workspaces dir is created before the AI provider spawn (issue #1528).
+    expect(mockEnsureArchonWorkspacesPath).toHaveBeenCalled();
   });
 
   test('passes resetAfterFetch=true for managed clones', async () => {

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -25,7 +25,7 @@ import { formatToolCall } from '@archon/workflows/utils/tool-formatter';
 import { classifyAndFormatError } from '../utils/error-formatter';
 import { toError } from '../utils/error';
 import { getAgentProvider, getProviderCapabilities } from '@archon/providers';
-import { getArchonWorkspacesPath } from '@archon/paths';
+import { getArchonWorkspacesPath, ensureArchonWorkspacesPath } from '@archon/paths';
 import { syncArchonToWorktree } from '../utils/worktree-sync';
 import { syncWorkspace, toRepoPath } from '@archon/git';
 import type { WorkspaceSyncResult } from '@archon/git';
@@ -821,7 +821,7 @@ export async function handleMessage(
       attachedFiles,
       workflowContext
     );
-    const cwd = getArchonWorkspacesPath();
+    const cwd = await ensureArchonWorkspacesPath();
 
     // 4. Update activity and get/create session
     await db.touchConversation(conversation.id);

--- a/packages/core/src/orchestrator/orchestrator-isolation.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-isolation.test.ts
@@ -10,6 +10,7 @@ const mockLogger = createMockLogger();
 mock.module('@archon/paths', () => ({
   createLogger: mock(() => mockLogger),
   getArchonWorkspacesPath: mock(() => '/home/test/.archon/workspaces'),
+  ensureArchonWorkspacesPath: mock(() => Promise.resolve('/home/test/.archon/workspaces')),
   getArchonHome: mock(() => '/home/test/.archon'),
 }));
 

--- a/packages/core/src/orchestrator/orchestrator.test.ts
+++ b/packages/core/src/orchestrator/orchestrator.test.ts
@@ -12,6 +12,7 @@ const mockLogger = createMockLogger();
 mock.module('@archon/paths', () => ({
   createLogger: mock(() => mockLogger),
   getArchonWorkspacesPath: mock(() => '/home/test/.archon/workspaces'),
+  ensureArchonWorkspacesPath: mock(() => Promise.resolve('/home/test/.archon/workspaces')),
   getArchonHome: mock(() => '/home/test/.archon'),
 }));
 

--- a/packages/paths/src/archon-paths.test.ts
+++ b/packages/paths/src/archon-paths.test.ts
@@ -10,6 +10,7 @@ import {
   isDocker,
   getArchonHome,
   getArchonWorkspacesPath,
+  ensureArchonWorkspacesPath,
   getArchonWorktreesPath,
   getArchonConfigPath,
   getHomeWorkflowsPath,
@@ -628,6 +629,43 @@ describe('ensureProjectStructure', () => {
 
     const sourcePath = getProjectSourcePath('acme', 'widget');
     expect((await lstat(sourcePath)).isDirectory()).toBe(true);
+  });
+});
+
+describe('ensureArchonWorkspacesPath', () => {
+  let tempArchonHome: string;
+  useEnvSnapshot();
+
+  beforeEach(async () => {
+    delete process.env.WORKSPACE_PATH;
+    delete process.env.ARCHON_DOCKER;
+    tempArchonHome = join(
+      tmpdir(),
+      `archon-paths-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    process.env.ARCHON_HOME = tempArchonHome;
+  });
+
+  afterEach(async () => {
+    await rm(tempArchonHome, { recursive: true, force: true });
+  });
+
+  test('creates the workspaces directory when missing', async () => {
+    const expected = getArchonWorkspacesPath();
+    expect(existsSync(expected)).toBe(false);
+
+    const returned = await ensureArchonWorkspacesPath();
+
+    expect(returned).toBe(expected);
+    expect((await lstat(expected)).isDirectory()).toBe(true);
+  });
+
+  test('is idempotent - safe to call twice', async () => {
+    await ensureArchonWorkspacesPath();
+    await ensureArchonWorkspacesPath();
+
+    const expected = getArchonWorkspacesPath();
+    expect((await lstat(expected)).isDirectory()).toBe(true);
   });
 });
 

--- a/packages/paths/src/archon-paths.ts
+++ b/packages/paths/src/archon-paths.ts
@@ -81,6 +81,16 @@ export function getArchonWorkspacesPath(): string {
 }
 
 /**
+ * Ensure the workspaces directory exists and return its path.
+ * Safe to call on a fresh install before any workspace is registered.
+ */
+export async function ensureArchonWorkspacesPath(): Promise<string> {
+  const path = getArchonWorkspacesPath();
+  await mkdir(path, { recursive: true });
+  return path;
+}
+
+/**
  * Get the global worktrees directory (~/.archon/worktrees/).
  * Used as the legacy fallback for repos not registered under workspaces/.
  * New project registrations use getProjectWorktreesPath(owner, repo) instead.

--- a/packages/paths/src/index.ts
+++ b/packages/paths/src/index.ts
@@ -4,6 +4,7 @@ export {
   isDocker,
   getArchonHome,
   getArchonWorkspacesPath,
+  ensureArchonWorkspacesPath,
   getArchonWorktreesPath,
   getArchonConfigPath,
   getArchonEnvPath,


### PR DESCRIPTION
Closes #1528.

## Summary

On a fresh install, `~/.archon/workspaces` doesn't exist yet. The orchestrator passes that path as `cwd` to the AI provider, the provider calls `spawn()`, and Node throws `ENOENT` on the cwd option. The SDK's error handler matches any `ENOENT` from the spawn event to the binary-path branch and surfaces the misleading "Claude Code native binary not found" message. The binary is fine; the directory is missing.

## Cause

`packages/core/src/orchestrator/orchestrator-agent.ts:824`:

```typescript
const cwd = getArchonWorkspacesPath();
```

`getArchonWorkspacesPath()` is a pure path getter (`packages/paths/src/archon-paths.ts:79-81`). It returns `~/.archon/workspaces` whether or not the directory exists. On first chat with no codebase registered, that path has never been created.

## Fix

Add a sibling helper `ensureArchonWorkspacesPath()` in `@archon/paths` that mkdir -p's the directory and returns its path. Use it at the orchestrator's spawn-cwd site.

```typescript
export async function ensureArchonWorkspacesPath(): Promise<string> {
  const path = getArchonWorkspacesPath();
  await mkdir(path, { recursive: true });
  return path;
}
```

The other three callers of `getArchonWorkspacesPath` in the orchestrator (workflow discovery at line 417, path-prefix `startsWith` at line 436, and a workflow-deps argument at line 570) only consume the path string and don't need the directory to exist; they keep using the pure getter. Pattern mirrors the existing `ensureProjectStructure(owner, repo)` helper in the same file.

## Validation Evidence

- `bun run check:bundled` clean
- `bun run type-check` clean across all 10 workspaces
- `bun run lint` clean (with bumped Node heap; default 2G OOMs on this VM unrelated to the diff)
- `bun run format:check` clean
- `bun run test` in `@archon/paths`: 172 pass / 0 fail (170 baseline + 2 new tests)
- `bun run test` in `@archon/core`: all packages pass, including the three orchestrator test files (`orchestrator.test.ts` 68 pass, `orchestrator-agent.test.ts` 100 pass, `orchestrator-isolation.test.ts` 2 pass)

New tests in `packages/paths/src/archon-paths.test.ts`:

- `creates the workspaces directory when missing` — sets `ARCHON_HOME` to a fresh tmpdir, asserts the workspaces path doesn't exist, calls the helper, asserts it now does and the helper returned the same path.
- `is idempotent - safe to call twice` — mirrors the existing `ensureProjectStructure` idempotence test.

The three test files that mock `@archon/paths` (`orchestrator.test.ts`, `orchestrator-agent.test.ts`, `orchestrator-isolation.test.ts`) gained one mock entry each:

```typescript
ensureArchonWorkspacesPath: mock(() => Promise.resolve('/home/test/.archon/workspaces')),
```

## Side Effects / Blast Radius

- New export from `@archon/paths`. Backward compatible with all existing callers.
- One call site changed in `orchestrator-agent.ts` (line 824). The call now awaits an mkdir; the directory creation is a one-time cost on first message, idempotent thereafter.
- No behavior change when the directory already exists (recursive mkdir is a no-op).
- Other consumers of `getArchonWorkspacesPath` are untouched.

## Rollback Plan

Revert the single commit. `getArchonWorkspacesPath` keeps its existing semantics; `ensureArchonWorkspacesPath` was additive.

## Human Verification

1. On a machine without `~/.archon/workspaces`: `rm -rf ~/.archon/workspaces`
2. `bun run dev` (or `archon serve`)
3. Open web UI, send a chat message without registering a codebase
4. Before this PR: "Claude Code native binary not found at …"
5. After this PR: chat reaches the AI provider; the directory has been created at `~/.archon/workspaces`.

Closes #1528

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a utility that ensures the Archon workspaces directory exists and returns its path.
  * Orchestrator now waits for the workspaces directory to be initialized before proceeding.

* **Tests**
  * Updated mocks across multiple suites to support the new utility.
  * Added filesystem tests verifying directory creation and idempotent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
