### PR TITLE
fix(core,web): show newest messages instead of oldest on hydration

### DIFF
--- a/packages/core/src/db/messages.test.ts
+++ b/packages/core/src/db/messages.test.ts
@@ -100,12 +100,13 @@ describe('messages', () => {
   });
 
   describe('listMessages', () => {
-    test('returns rows from query result', async () => {
+    test('returns rows from query result in chronological order', async () => {
       const messages: MessageRow[] = [
         mockMessage,
         { ...mockMessage, id: 'msg-124', role: 'assistant', content: 'Hi!' },
       ];
-      mockQuery.mockResolvedValueOnce(createQueryResult(messages));
+      // DB returns newest-first (DESC); listMessages reverses to chronological
+      mockQuery.mockResolvedValueOnce(createQueryResult([...messages].reverse()));
 
       const result = await listMessages('conv-456');
 
@@ -113,7 +114,7 @@ describe('messages', () => {
       expect(mockQuery).toHaveBeenCalledWith(
         `SELECT * FROM remote_agent_messages
      WHERE conversation_id = $1
-     ORDER BY created_at ASC
+     ORDER BY created_at DESC
      LIMIT $2`,
         ['conv-456', 200]
       );

--- a/packages/core/src/db/messages.ts
+++ b/packages/core/src/db/messages.ts
@@ -49,6 +49,8 @@ export async function addMessage(
 
 /**
  * List messages for a conversation, oldest first.
+ * Fetches the newest `limit` messages so that the most recent history is always
+ * returned, then reverses to preserve chronological (oldest-first) order.
  * conversationId is the database UUID (not platform_conversation_id).
  */
 export async function listMessages(
@@ -58,11 +60,11 @@ export async function listMessages(
   const result = await pool.query<MessageRow>(
     `SELECT * FROM remote_agent_messages
      WHERE conversation_id = $1
-     ORDER BY created_at ASC
+     ORDER BY created_at DESC
      LIMIT $2`,
     [conversationId, limit]
   );
-  return result.rows;
+  return [...result.rows].reverse();
 }
 
 /**

--- a/packages/web/src/components/chat/ChatInterface.tsx
+++ b/packages/web/src/components/chat/ChatInterface.tsx
@@ -446,16 +446,19 @@ export function ChatInterface({ conversationId }: ChatInterfaceProps): React.Rea
           .then((rows: MessageResponse[]) => {
             if (rows.length === 0) return;
             const hydrated = rows.map(mapMessageRow);
-            // Preserve client-only system messages (e.g., sync status) when rehydrating
+            // Merge hydrated DB messages with client-only state (system, live SSE) to
+            // avoid losing messages that exist only on the client.
             setMessages(prev => {
-              const systemMessages = prev.filter(m => m.role === 'system');
-              if (systemMessages.length === 0) return hydrated;
-              // Interleave system messages at their original positions by timestamp
+              const hydratedIds = new Set(hydrated.map(m => m.id));
+              // Keep any client-only messages (system, SSE-only) not present in hydrated set
+              const clientOnly = prev.filter(m => !hydratedIds.has(m.id));
+              if (clientOnly.length === 0) return hydrated;
+              // Interleave client-only messages at their original positions by timestamp
               const merged = [...hydrated];
-              for (const sys of systemMessages) {
-                const insertIdx = merged.findIndex(m => m.timestamp > sys.timestamp);
-                if (insertIdx === -1) merged.push(sys);
-                else merged.splice(insertIdx, 0, sys);
+              for (const msg of clientOnly) {
+                const insertIdx = merged.findIndex(m => m.timestamp > msg.timestamp);
+                if (insertIdx === -1) merged.push(msg);
+                else merged.splice(insertIdx, 0, msg);
               }
               return merged;
             });

--- a/packages/web/src/components/chat/ChatInterface.tsx
+++ b/packages/web/src/components/chat/ChatInterface.tsx
@@ -450,8 +450,20 @@ export function ChatInterface({ conversationId }: ChatInterfaceProps): React.Rea
             // avoid losing messages that exist only on the client.
             setMessages(prev => {
               const hydratedIds = new Set(hydrated.map(m => m.id));
-              // Keep any client-only messages (system, SSE-only) not present in hydrated set
-              const clientOnly = prev.filter(m => !hydratedIds.has(m.id));
+              // Keep only meaningful client-only messages not present in hydrated set.
+              // Exclude optimistic user rows and empty thinking placeholders.
+              const clientOnly = prev.filter(m => {
+                if (hydratedIds.has(m.id)) return false;
+                if (m.role === 'system') return true;
+                if (m.role !== 'assistant') return false;
+                return (
+                  Boolean(m.content) ||
+                  Boolean(m.error) ||
+                  Boolean(m.workflowDispatch) ||
+                  Boolean(m.workflowResult) ||
+                  Boolean(m.toolCalls?.length)
+                );
+              });
               if (clientOnly.length === 0) return hydrated;
               // Interleave client-only messages at their original positions by timestamp
               const merged = [...hydrated];


### PR DESCRIPTION
## Summary

- **Problem:** Two defects combine to silently lose recent chat messages in long conversations (>200 messages)
- **Why it matters:** Users lose their most recent messages after page refresh or SSE recovery — the opposite of expected chat behavior
- **What changed:** DB query fetches newest N messages (DESC + reverse); stuck-placeholder recovery merges by ID instead of only keeping system messages
- **What did not change (scope boundary):** The `limit=200` default, API max `500`, cursor-based pagination (future work), and DB schema are all unchanged

## UX Journey

### Before

```
  User                        Archon DB                      UI
  ────                        ─────────                      ──
  has 300 messages
  refreshes page ──────────▶  SELECT ... ORDER BY ASC LIMIT 200
                              returns messages 1-200 (oldest)
  sees old messages ◀──────── renders messages 1-200
  ❌ messages 201-300 GONE

  During SSE reconnect:
  live SSE messages ─────────────────────────────────────────▶ in client state
  stuck-placeholder fires ───▶ rehydrate from DB
  ❌ only system msgs kept ◀── SSE-only assistant msgs DROPPED
```

### After

```
  User                        Archon DB                      UI
  ────                        ─────────                      ──
  has 300 messages
  refreshes page ──────────▶  SELECT ... ORDER BY DESC LIMIT 200
                              returns messages 101-300 (newest)
                              .reverse() → chronological
  sees recent messages ◀───── renders messages 101-300
  ✅ most recent history shown

  During SSE reconnect:
  live SSE messages ─────────────────────────────────────────▶ in client state
  stuck-placeholder fires ───▶ rehydrate from DB
  ✅ merge by ID ◀───────────── client-only msgs PRESERVED
```

## Architecture Diagram

### Before

```
  ChatInterface.tsx                  messages.ts (DB)
  ┌──────────────────┐               ┌──────────────────┐
  │ setMessages(prev) │               │ listMessages()   │
  │  filter system    │◀──────────────│ ORDER BY ASC     │
  │  msgs only        │  hydrated     │ LIMIT 200        │
  └──────────────────┘               └──────────────────┘
```

### After

```
  ChatInterface.tsx [~]              messages.ts (DB) [~]
  ┌──────────────────┐               ┌──────────────────┐
  │ setMessages(prev) │               │ listMessages()   │
  │  merge ALL client │◀──────────────│ ORDER BY DESC    │
  │  msgs by ID       │  hydrated     │ LIMIT 200        │
  └──────────────────┘               │ .reverse()       │
                                     └──────────────────┘
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| ChatInterface.tsx | messages.ts (via API) | **modified** | Recovery now merges by ID instead of system-only filter |
| messages.ts | PostgreSQL | **modified** | Query order changed from ASC to DESC |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`, `web`
- Module: `core:messages`, `web:chat`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi`

## Linked Issue

- Closes #1531

## Validation Evidence (required)

```bash
# All 14 messages.test.ts tests pass (including updated ordering test)
bun run test -- packages/core/src/db/messages.test.ts  # ✅ 14 pass
bun run type-check  # ✅ clean across all packages
# lint-staged (eslint + prettier) passed on commit
```

- Evidence provided: test results, type-check clean
- If any command is intentionally skipped, explain why: Full `bun run validate` not run locally; CI covers remaining checks

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes` — public contract ("returns messages in chronological order") is preserved
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios: Messages load newest-first after refresh with >200 messages; SSE-streamed assistant messages survive stuck-placeholder recovery
- Edge cases checked: Empty conversation, exactly 200 messages, system-only messages
- What was not verified: Production database with high message volume

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `listMessages()` consumers now get newest-N instead of oldest-N; stuck-placeholder recovery is more permissive
- Potential unintended effects: Any code relying on getting the **oldest** messages from `listMessages()` would need updating
- Guardrails/monitoring for early detection: Existing test suite validates chronological ordering contract

## Rollback Plan (required)

- Fast rollback command/path: Revert the commit. No schema changes.
- Feature flags or config toggles: None
- Observable failure symptoms: Messages appearing out of order or missing after refresh

## Risks and Mitigations

- Risk: Code elsewhere assumes `listMessages()` returns oldest-N
  - Mitigation: The chronological ordering contract is preserved; only which N messages are returned changed. Searched codebase for callers — all expect "recent messages."