### PR TITLE
feat(codex): support workflow skills

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "cli": "bun src/cli.ts",
-    "test": "bun test src/commands/version.test.ts src/commands/setup.test.ts src/commands/skill.test.ts && bun test src/commands/workflow.test.ts && bun test src/commands/isolation.test.ts && bun test src/commands/chat.test.ts && bun test src/commands/serve.test.ts",
+    "test": "bun test src/commands/version.test.ts src/commands/setup.test.ts src/commands/skill.test.ts src/commands/validate.test.ts && bun test src/commands/workflow.test.ts && bun test src/commands/isolation.test.ts && bun test src/commands/chat.test.ts && bun test src/commands/serve.test.ts",
     "type-check": "bun x tsc --noEmit"
   },
   "dependencies": {

--- a/packages/cli/src/commands/validate.test.ts
+++ b/packages/cli/src/commands/validate.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { clearConfigCache } from '@archon/core';
+import { validateWorkflowsCommand } from './validate';
+
+const tempDirs: string[] = [];
+let consoleLogSpy: ReturnType<typeof spyOn>;
+let originalArchonHome: string | undefined;
+let originalDefaultAssistant: string | undefined;
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+beforeEach(async () => {
+  originalArchonHome = process.env.ARCHON_HOME;
+  originalDefaultAssistant = process.env.DEFAULT_AI_ASSISTANT;
+  process.env.ARCHON_HOME = await makeTempDir('archon-cli-home-');
+  delete process.env.DEFAULT_AI_ASSISTANT;
+  clearConfigCache();
+  consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  consoleLogSpy.mockRestore();
+  if (originalArchonHome === undefined) {
+    delete process.env.ARCHON_HOME;
+  } else {
+    process.env.ARCHON_HOME = originalArchonHome;
+  }
+  if (originalDefaultAssistant === undefined) {
+    delete process.env.DEFAULT_AI_ASSISTANT;
+  } else {
+    process.env.DEFAULT_AI_ASSISTANT = originalDefaultAssistant;
+  }
+  clearConfigCache();
+  for (const dir of tempDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe('validateWorkflowsCommand', () => {
+  test('uses configured Codex skillRoots for workflows that rely on the default provider', async () => {
+    const repo = await makeTempDir('archon-validate-skills-');
+    const skillRoot = join(repo, 'custom-skills');
+    await mkdir(join(skillRoot, 'alpha'), { recursive: true });
+    await writeFile(join(skillRoot, 'alpha', 'SKILL.md'), '# Alpha\n');
+    await mkdir(join(repo, '.archon', 'workflows'), { recursive: true });
+    await writeFile(
+      join(repo, '.archon', 'workflows', 'codex-skills.yaml'),
+      `
+name: codex-skills
+description: test
+nodes:
+  - id: review
+    prompt: Review
+    skills: [alpha]
+`
+    );
+    await writeFile(
+      join(repo, '.archon', 'config.yaml'),
+      `
+assistant: codex
+assistants:
+  codex:
+    skillRoots:
+      - ${skillRoot}
+defaults:
+  loadDefaultCommands: false
+  loadDefaultWorkflows: false
+`
+    );
+
+    const exitCode = await validateWorkflowsCommand(repo, undefined, true);
+
+    expect(exitCode).toBe(0);
+    expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+    const output = JSON.parse(consoleLogSpy.mock.calls[0]?.[0] as string) as {
+      summary: { errors: number };
+    };
+    expect(output.summary.errors).toBe(0);
+  });
+});

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -41,6 +41,24 @@ async function buildValidationConfig(cwd: string): Promise<ValidationConfig> {
   }
 }
 
+function buildSkillRootsByProvider(
+  assistants: Record<string, Record<string, unknown>>
+): Record<string, string[]> {
+  const result: Record<string, string[]> = {};
+
+  for (const [providerId, defaults] of Object.entries(assistants)) {
+    const roots = defaults.skillRoots;
+    if (!Array.isArray(roots)) continue;
+
+    const stringRoots = roots.filter((root): root is string => typeof root === 'string');
+    if (stringRoots.length > 0) {
+      result[providerId] = stringRoots;
+    }
+  }
+
+  return result;
+}
+
 // =============================================================================
 // Output formatting
 // =============================================================================
@@ -86,6 +104,7 @@ export async function validateWorkflowsCommand(
 ): Promise<number> {
   const config = await buildValidationConfig(cwd);
   const mergedConfig = await loadConfig(cwd);
+  config.skillRootsByProvider = buildSkillRootsByProvider(mergedConfig.assistants);
   const defaultProvider = mergedConfig.assistant;
   const { workflows: workflowEntries, errors: loadErrors } = await discoverWorkflowsWithConfig(
     cwd,

--- a/packages/core/src/config/config-loader.test.ts
+++ b/packages/core/src/config/config-loader.test.ts
@@ -310,7 +310,7 @@ streaming:
       let globalConfigRead = false;
       mockReadConfigFile.mockImplementation(async (path: string) => {
         if (pathMatches(path, '/repo/.archon/config.yaml')) {
-          return `assistants:\n  codex:\n    webSearchMode: live\n    additionalDirectories:\n      - /repo\n`;
+          return `assistants:\n  codex:\n    webSearchMode: live\n    additionalDirectories:\n      - /repo\n    skillRoots:\n      - /repo/.agents/skills\n`;
         }
         if (pathMatches(path, '.archon/config.yaml') && !globalConfigRead) {
           globalConfigRead = true;
@@ -327,6 +327,7 @@ streaming:
       expect(config.assistants.codex.modelReasoningEffort).toBe('medium');
       expect(config.assistants.codex.webSearchMode).toBe('live');
       expect(config.assistants.codex.additionalDirectories).toEqual(['/repo']);
+      expect(config.assistants.codex.skillRoots).toEqual(['/repo/.agents/skills']);
     });
 
     test('propagates baseBranch from repo worktree config', async () => {
@@ -613,16 +614,19 @@ assistants:
       expect(safe).not.toHaveProperty('commands');
     });
 
-    test('strips additionalDirectories from assistants.codex', async () => {
+    test('strips local path fields from assistants.codex', async () => {
       mockReadConfigFile.mockResolvedValue(`
 assistants:
   codex:
     additionalDirectories:
       - /sensitive/path
+    skillRoots:
+      - /sensitive/skills
 `);
       const config = await loadConfig();
       const safe = toSafeConfig(config);
       expect(safe.assistants.codex).not.toHaveProperty('additionalDirectories');
+      expect(safe.assistants.codex).not.toHaveProperty('skillRoots');
     });
 
     test('preserves non-sensitive fields', async () => {

--- a/packages/core/src/config/config-loader.ts
+++ b/packages/core/src/config/config-loader.ts
@@ -161,6 +161,8 @@ const DEFAULT_CONFIG_CONTENT = `# Archon Global Configuration
 #     webSearchMode: disabled
 #     additionalDirectories:
 #       - /absolute/path/to/other/repo
+#     skillRoots:
+#       - /absolute/path/to/skills
 
 # Streaming mode per platform (stream or batch)
 # streaming:

--- a/packages/docs-web/src/content/docs/book/quick-reference.md
+++ b/packages/docs-web/src/content/docs/book/quick-reference.md
@@ -141,7 +141,7 @@ All nodes share these base fields:
 | `retry` | No | object | Retry configuration for transient failures (see Retry Options). **Hard error on loop nodes** |
 | `hooks` | No | object | SDK hook callbacks (Claude only; see Hook Schema) |
 | `mcp` | No | string | Path to MCP server config JSON file (Claude only) |
-| `skills` | No | string[] | Skill names to preload into this node's context (Claude only) |
+| `skills` | No | string[] | Skill names to preload into this node's context (Claude, Codex, and Pi) |
 | `agents` | No | object | Inline sub-agent definitions keyed by kebab-case ID. Claude only |
 
 **Script-specific fields** (required when `script:` is set):

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -166,7 +166,7 @@ nodes:
     model: haiku                 # Per-node model override
     # hooks:                     # Optional: per-node SDK hook callbacks (Claude only) — see hooks guide
     # mcp: .archon/mcp/servers.json  # Optional: per-node MCP servers (Claude only)
-    # skills: [remotion-best-practices]  # Optional: per-node skills (Claude only) — see skills guide
+    # skills: [remotion-best-practices]  # Optional: per-node skills — see skills guide
 ```
 
 ### Node Fields
@@ -206,7 +206,7 @@ nodes:
 | `denied_tools` | string[] | — | Tools to remove. Applied after `allowed_tools`. Claude only |
 | `hooks` | object | — | Per-node SDK hook callbacks. Claude only. See [Hooks](/guides/hooks/) |
 | `mcp` | string | — | Path to MCP server config JSON file. Claude only. See [MCP Servers](/guides/mcp-servers/) |
-| `skills` | string[] | — | Skills to preload. Claude only. See [Skills](/guides/skills/) |
+| `skills` | string[] | — | Skills to preload. Supported by Claude, Codex, and Pi with provider-specific mechanics. See [Skills](/guides/skills/) |
 | `agents` | object | — | Inline sub-agent definitions keyed by kebab-case ID. Claude only. See [Inline sub-agents](#inline-sub-agents) |
 | `effort` | `'low'`\|`'medium'`\|`'high'`\|`'max'` | — | Reasoning depth. Claude only. Also settable at workflow level |
 | `thinking` | string \| object | — | Thinking mode: `'adaptive'`, `'disabled'`, or `{type:'enabled', budgetTokens:N}`. Claude only. Also settable at workflow level |
@@ -218,7 +218,7 @@ nodes:
 
 ### Claude SDK Advanced Options
 
-These fields map directly to Claude Agent SDK options. All are Claude-only — Codex nodes emit a warning and ignore them. They can be set **per-node** or at the **workflow level** as defaults (per-node takes precedence). `maxBudgetUsd` and `systemPrompt` are per-node only.
+Except for `skills`, these fields map directly to Claude Agent SDK options. Claude-only fields emit a warning and are ignored by providers that do not support them. They can be set **per-node** or at the **workflow level** as defaults (per-node takes precedence). `maxBudgetUsd` and `systemPrompt` are per-node only.
 
 **effort** — reasoning depth:
 
@@ -1174,7 +1174,7 @@ Before deploying a workflow:
 9. **`retry:`** — auto-retries transient errors (default: 2 retries / 3 total attempts, 3 s backoff); customize per node
 10. **`hooks`** — attach SDK hook callbacks to Claude nodes for tool control and context injection
 11. **`mcp:`** — attach per-node MCP servers via JSON config (Claude only)
-12. **`skills:`** — preload skills into Claude nodes for domain expertise
+12. **`skills:`** — preload selected skills into supported provider nodes for domain expertise
 13. **`agents:`** — inline Claude sub-agent definitions invokable via the `Task` tool
 14. **`effort` / `thinking`** — control reasoning depth and thinking mode per node or workflow (Claude only)
 15. **`maxBudgetUsd`** — set a USD cost cap per node; fails with error if exceeded (Claude only)

--- a/packages/docs-web/src/content/docs/guides/index.md
+++ b/packages/docs-web/src/content/docs/guides/index.md
@@ -22,11 +22,14 @@ How-to guides for building and running AI coding workflows with Archon.
 - [Approval Nodes](/guides/approval-nodes/) — Human review gates with optional AI rework on rejection
 - [Script Nodes](/guides/script-nodes/) — TypeScript/JavaScript (bun) or Python (uv) as a deterministic DAG node, without AI
 
-## Node Features (Claude only)
+## Node Features
+
+- [Per-Node Skills](/guides/skills/) — Preload specialized knowledge into node agents
+
+## Claude-Only Node Features
 
 - [Per-Node Hooks](/guides/hooks/) — Attach Claude SDK hooks for tool control, context injection, and input modification
 - [Per-Node MCP Servers](/guides/mcp-servers/) — Connect external tools (GitHub, Postgres, etc.) to individual nodes
-- [Per-Node Skills](/guides/skills/) — Preload specialized knowledge into node agents
 
 ## Bundled Workflows
 

--- a/packages/docs-web/src/content/docs/guides/skills.md
+++ b/packages/docs-web/src/content/docs/guides/skills.md
@@ -1,6 +1,6 @@
 ---
 title: Per-Node Skills
-description: Preload specialized knowledge into individual workflow nodes using the Claude Agent SDK skills system.
+description: Preload specialized knowledge into individual workflow nodes.
 category: guides
 area: workflows
 audience: [user]
@@ -13,8 +13,6 @@ DAG workflow nodes support a `skills` field that preloads named skills into the
 node's agent context. Each node gets specialized procedural knowledge — code review
 patterns, Remotion best practices, testing conventions — without polluting other nodes.
 
-**Claude only** — Codex nodes will warn and ignore the `skills` field.
-
 ## Quick Start
 
 1. Install a skill (e.g., the official Remotion skill):
@@ -24,6 +22,7 @@ npx skills add remotion-dev/skills
 ```
 
 This places SKILL.md files in `.claude/skills/remotion-best-practices/`.
+Codex-style skills can also live in `.agents/skills/`.
 
 2. Reference it in your workflow:
 
@@ -43,8 +42,14 @@ gotchas) without the user having to paste instructions into the prompt.
 
 ## How It Works
 
-When a node has `skills: [name, ...]`, the executor wraps it in an
-[AgentDefinition](https://platform.claude.com/docs/en/agent-sdk/subagents) — the
+When a node has `skills: [name, ...]`, Archon resolves each selected skill before
+the node runs. Missing or unreadable skills fail validation with the searched
+paths.
+
+### Claude
+
+For Claude nodes, the executor wraps the node in an
+[AgentDefinition](https://platform.claude.com/docs/en/agent-sdk/subagents), the
 Claude Agent SDK mechanism for scoping skills to subagents.
 
 ```
@@ -65,6 +70,22 @@ Agent executes with full skill knowledge available
 
 The `Skill` tool is automatically added to `allowedTools` so the agent can invoke
 skills. You don't need to add it manually.
+
+### Codex
+
+For Codex nodes, Archon resolves the selected `SKILL.md` files and prepends them
+to the Codex turn as explicit workflow-selected skill context. This makes
+`skills:` deterministic even when the skill lives outside Codex's native
+auto-discovery roots.
+
+Codex can also use its native `$skill-name` invocation for skills installed under
+`.agents/skills/` or user/admin/system Codex roots. The workflow `skills:` field
+is for selecting exactly which skills a node should receive.
+
+### Pi
+
+For Pi nodes, Archon resolves skill names to skill directories and passes them to
+Pi as additional skill paths.
 
 ## Installing Skills
 
@@ -101,10 +122,11 @@ npx skills add git@github.com:org/private-skills.git
 
 ### Manual
 
-Create a directory in `.claude/skills/` with a `SKILL.md` file:
+Create a directory in `.claude/skills/` or `.agents/skills/` with a `SKILL.md`
+file:
 
 ```
-.claude/skills/my-skill/
+.agents/skills/my-skill/
 └── SKILL.md
 ```
 
@@ -123,16 +145,35 @@ Step-by-step content here. The agent loads this when the skill activates.
 
 ## Skill Discovery
 
-Skills are discovered from these locations (via `settingSources: ['project']`
-set in ClaudeProvider):
+Skills are discovered from these default locations:
 
 | Location | Scope |
 |----------|-------|
+| `.agents/skills/` (in cwd) | Project-level, Codex/Pi convention |
+| `.codex/skills/` (in cwd) | Project-level, Codex convention |
 | `.claude/skills/` (in cwd) | Project-level |
+| `~/.agents/skills/` | User-level Codex/Pi convention |
+| `~/.codex/skills/` | User-level Codex convention |
 | `~/.claude/skills/` | User-level (all projects) |
+| `/etc/codex/skills/` | Admin/system Codex convention |
 
-Skills installed via `npx skills add` land in `.claude/skills/` by default.
-Use `-g` for global installation to `~/.claude/skills/`.
+Codex nodes can add extra roots in config:
+
+```yaml
+assistants:
+  codex:
+    skillRoots:
+      - /absolute/path/to/team-skills
+```
+
+Skill entries can also be explicit paths to a skill directory or a `SKILL.md`
+file:
+
+```yaml
+skills:
+  - /absolute/path/to/team-skills/release-checklist
+  - ./.agents/skills/local-skill/SKILL.md
+```
 
 ## Scoping: Installed vs Active
 
@@ -205,32 +246,26 @@ produce better results than either alone.
 
 ## Codex Compatibility
 
-Codex nodes with `skills` log a warning and continue without the skills:
-
-```
-Warning: Node 'review' has skills set but uses Codex — per-node skills
-are not supported for Codex.
-```
-
-To use skills, ensure the node uses Claude (the default provider, or set
-`provider: claude` explicitly).
+Codex supports `skills:` on workflow prompt and command nodes. Archon injects the
+resolved skill content into the Codex turn, so missing skills fail before the
+model runs instead of being silently ignored.
 
 ## Limitations
 
 - **Pre-installation required** — skills must exist on disk before the workflow runs.
   There is no on-demand fetching (yet).
-- **Claude only** — the SDK's `AgentDefinition.skills` field is Claude-specific.
 - **Full injection** — skill content is fully injected at startup, not progressively
   disclosed. Keep skills concise.
-- **No validation** — if a named skill doesn't exist, the SDK may fail silently.
-  Verify skills are installed with `npx skills list`.
+- **Provider mechanics differ** — Claude uses SDK `AgentDefinition.skills`, Codex
+  receives explicit skill context in the turn prompt, and Pi receives additional
+  skill paths.
 
 ## Troubleshooting
 
 | Problem | Cause | Fix |
 |---------|-------|-----|
 | Skill not found | Not installed | Run `npx skills add <source>` |
-| Skill ignored | Node uses Codex provider | Set `provider: claude` on the node |
+| Skill not found in custom location | Root not configured | Add `assistants.codex.skillRoots` or reference the skill by explicit path |
 | Too many skills | Context budget exceeded | Reduce to 2-3 most relevant skills per node |
 | Skill has no effect | Description too vague | Rewrite SKILL.md with specific, actionable instructions |
 

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -13,12 +13,13 @@
     "./codex/provider": "./src/codex/provider.ts",
     "./codex/config": "./src/codex/config.ts",
     "./codex/binary-resolver": "./src/codex/binary-resolver.ts",
+    "./skills": "./src/skills.ts",
     "./community/pi": "./src/community/pi/index.ts",
     "./errors": "./src/errors.ts",
     "./registry": "./src/registry.ts"
   },
   "scripts": {
-    "test": "bun test src/claude/provider.test.ts && bun test src/codex/provider.test.ts && bun test src/registry.test.ts && bun test src/codex/binary-guard.test.ts && bun test src/codex/binary-resolver.test.ts && bun test src/codex/binary-resolver-dev.test.ts && bun test src/claude/binary-resolver.test.ts && bun test src/claude/binary-resolver-dev.test.ts && bun test src/community/pi/model-ref.test.ts && bun test src/community/pi/config.test.ts && bun test src/community/pi/event-bridge.test.ts && bun test src/community/pi/options-translator.test.ts && bun test src/community/pi/session-resolver.test.ts && bun test src/community/pi/provider.test.ts && bun test src/community/pi/provider-lazy-load.test.ts",
+    "test": "bun test src/skills.test.ts && bun test src/claude/provider.test.ts && bun test src/codex/provider.test.ts && bun test src/registry.test.ts && bun test src/codex/binary-guard.test.ts && bun test src/codex/binary-resolver.test.ts && bun test src/codex/binary-resolver-dev.test.ts && bun test src/claude/binary-resolver.test.ts && bun test src/claude/binary-resolver-dev.test.ts && bun test src/community/pi/model-ref.test.ts && bun test src/community/pi/config.test.ts && bun test src/community/pi/event-bridge.test.ts && bun test src/community/pi/options-translator.test.ts && bun test src/community/pi/session-resolver.test.ts && bun test src/community/pi/provider.test.ts && bun test src/community/pi/provider-lazy-load.test.ts",
     "type-check": "bun x tsc --noEmit"
   },
   "dependencies": {

--- a/packages/providers/src/codex/capabilities.ts
+++ b/packages/providers/src/codex/capabilities.ts
@@ -4,7 +4,7 @@ export const CODEX_CAPABILITIES: ProviderCapabilities = {
   sessionResume: true,
   mcp: false,
   hooks: false,
-  skills: false,
+  skills: true,
   agents: false,
   toolRestrictions: false,
   structuredOutput: true,

--- a/packages/providers/src/codex/config.ts
+++ b/packages/providers/src/codex/config.ts
@@ -38,6 +38,10 @@ export function parseCodexConfig(raw: Record<string, unknown>): CodexProviderDef
     );
   }
 
+  if (Array.isArray(raw.skillRoots)) {
+    result.skillRoots = raw.skillRoots.filter((d): d is string => typeof d === 'string');
+  }
+
   if (typeof raw.codexBinaryPath === 'string') {
     result.codexBinaryPath = raw.codexBinaryPath;
   }

--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -1,4 +1,7 @@
 import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { createMockLogger } from '../test/mocks/logger';
 
 const mockLogger = createMockLogger();
@@ -74,7 +77,7 @@ describe('CodexProvider', () => {
         sessionResume: true,
         mcp: false,
         hooks: false,
-        skills: false,
+        skills: true,
         agents: false,
         toolRestrictions: false,
         structuredOutput: true,
@@ -655,6 +658,70 @@ describe('CodexProvider', () => {
           additionalDirectories: ['/other/repo'],
         })
       );
+    });
+
+    test('prepends workflow skills resolved from configured roots to Codex prompt', async () => {
+      const testDir = await mkdtemp(join(tmpdir(), 'codex-provider-skills-'));
+      const skillRoot = join(testDir, 'skills');
+      const skillDir = join(skillRoot, 'alpha');
+
+      try {
+        await mkdir(skillDir, { recursive: true });
+        await writeFile(
+          join(skillDir, 'SKILL.md'),
+          '---\nname: alpha\ndescription: Test skill\n---\n\n# Alpha\n\nReturn ALPHA_SENTINEL.\n'
+        );
+
+        mockRunStreamed.mockResolvedValue({
+          events: (async function* () {
+            yield { type: 'turn.completed', usage: defaultUsage };
+          })(),
+        });
+
+        for await (const _ of client.sendQuery('test prompt', testDir, undefined, {
+          nodeConfig: { skills: ['alpha'] },
+          assistantConfig: { skillRoots: [skillRoot] },
+        })) {
+          // consume
+        }
+
+        const promptArg = mockRunStreamed.mock.calls[0]?.[0] as string;
+        expect(promptArg).toContain('BEGIN SKILL alpha');
+        expect(promptArg).toContain('Return ALPHA_SENTINEL.');
+        expect(promptArg).toContain('--- USER PROMPT ---\ntest prompt');
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          {
+            skills: ['alpha'],
+            skillPaths: [join(skillDir, 'SKILL.md')],
+          },
+          'codex.skills_loaded'
+        );
+      } finally {
+        await rm(testDir, { recursive: true, force: true });
+      }
+    });
+
+    test('throws clear error when workflow skill cannot be resolved', async () => {
+      const testDir = await mkdtemp(join(tmpdir(), 'codex-provider-missing-skill-'));
+
+      try {
+        let caught: Error | undefined;
+        try {
+          for await (const _ of client.sendQuery('test prompt', testDir, undefined, {
+            nodeConfig: { skills: ['missing-skill'] },
+          })) {
+            // consume
+          }
+        } catch (error) {
+          caught = error as Error;
+        }
+
+        expect(caught).toBeDefined();
+        expect(caught?.message).toContain("Skill 'missing-skill' not found or not readable");
+        expect(mockRunStreamed).not.toHaveBeenCalled();
+      } finally {
+        await rm(testDir, { recursive: true, force: true });
+      }
     });
 
     test('passes outputFormat schema as outputSchema in TurnOptions', async () => {

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -19,6 +19,12 @@ import { parseCodexConfig } from './config';
 import { CODEX_CAPABILITIES } from './capabilities';
 import { resolveCodexBinaryPath } from './binary-resolver';
 import { createLogger } from '@archon/paths';
+import {
+  formatMissingSkills,
+  loadResolvedSkills,
+  resolveSkillReferences,
+  type LoadedSkill,
+} from '../skills';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
@@ -85,6 +91,25 @@ function buildCodexEnv(requestEnv: Record<string, string>): Record<string, strin
   );
   // Managed project env intentionally overrides inherited process env for project-scoped execution.
   return { ...baseEnv, ...requestEnv };
+}
+
+function buildCodexSkillContext(skills: readonly LoadedSkill[]): string {
+  const blocks = skills.map(
+    skill =>
+      `--- BEGIN SKILL ${skill.name} (${skill.skillPath}) ---\n${skill.content.trim()}\n--- END SKILL ${skill.name} ---`
+  );
+
+  return [
+    'The following Archon workflow skills were explicitly selected for this Codex turn.',
+    'Treat their SKILL.md contents as active task instructions and use them when relevant.',
+    '',
+    ...blocks,
+  ].join('\n');
+}
+
+function prependCodexSkillContext(prompt: string, skills: readonly LoadedSkill[]): string {
+  if (skills.length === 0) return prompt;
+  return `${buildCodexSkillContext(skills)}\n\n--- USER PROMPT ---\n${prompt}`;
 }
 
 const CODEX_MODEL_FALLBACKS: Record<string, string> = {
@@ -545,6 +570,26 @@ export class CodexProvider implements IAgentProvider {
   ): AsyncGenerator<MessageChunk> {
     const assistantConfig = requestOptions?.assistantConfig ?? {};
     const codexConfig = parseCodexConfig(assistantConfig);
+    let effectivePrompt = prompt;
+
+    if (requestOptions?.nodeConfig?.skills && requestOptions.nodeConfig.skills.length > 0) {
+      const result = await resolveSkillReferences(cwd, requestOptions.nodeConfig.skills, {
+        skillRoots: codexConfig.skillRoots,
+      });
+      if (result.missing.length > 0) {
+        throw new Error(formatMissingSkills(result.missing));
+      }
+
+      const loadedSkills = await loadResolvedSkills(result.resolved);
+      effectivePrompt = prependCodexSkillContext(prompt, loadedSkills);
+      getLog().info(
+        {
+          skills: loadedSkills.map(skill => skill.name),
+          skillPaths: loadedSkills.map(skill => skill.skillPath),
+        },
+        'codex.skills_loaded'
+      );
+    }
 
     // 1. Initialize SDK and build thread options
     const codex = await this.createCodexClient(codexConfig.codexBinaryPath, requestOptions?.env);
@@ -618,7 +663,7 @@ export class CodexProvider implements IAgentProvider {
 
       try {
         // 4. Run streamed turn
-        const result = await thread.runStreamed(prompt, turnOptions);
+        const result = await thread.runStreamed(effectivePrompt, turnOptions);
 
         // 5. Stream normalized events (fresh state per attempt to avoid dedup leaks)
         yield* streamCodexEvents(

--- a/packages/providers/src/community/pi/options-translator.ts
+++ b/packages/providers/src/community/pi/options-translator.ts
@@ -1,5 +1,4 @@
 import { existsSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 import {
@@ -25,6 +24,7 @@ import type { ThinkingLevel } from '@mariozechner/pi-ai';
 type PiTool = (typeof codingTools)[number];
 
 import type { NodeConfig } from '../../types';
+import { getAgentSkillRoots } from '../../skills';
 
 // ─── Thinking level ────────────────────────────────────────────────────────
 
@@ -272,17 +272,7 @@ export interface ResolvedSkills {
  * skills win when Archon runs out of a subdirectory.
  */
 function skillSearchRoots(cwd: string): string[] {
-  // Prefer `HOME` env var when set — Bun's os.homedir() bypasses `HOME` and
-  // reads from the system uid lookup, which is correct in production but
-  // makes tests using staged temp homes impossible. The fallback to
-  // homedir() keeps behavior identical in non-test contexts.
-  const home = process.env.HOME ?? homedir();
-  return [
-    join(cwd, '.agents', 'skills'),
-    join(cwd, '.claude', 'skills'),
-    join(home, '.agents', 'skills'),
-    join(home, '.claude', 'skills'),
-  ];
+  return getAgentSkillRoots(cwd);
 }
 
 /**

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -45,8 +45,10 @@ export { parseCodexConfig, type CodexProviderDefaults } from './codex/config';
 export { resetCodexSingleton } from './codex/provider';
 export {
   getDefaultSkillRoots,
+  getAgentSkillRoots,
   getSkillSearchRoots,
   resolveSkillReferences,
+  resolveProviderSkillReferences,
   loadResolvedSkills,
   formatMissingSkills,
   type SkillResolutionOptions,

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -43,6 +43,18 @@ export { parseCodexConfig, type CodexProviderDefaults } from './codex/config';
 
 // Utilities (needed by consumers)
 export { resetCodexSingleton } from './codex/provider';
+export {
+  getDefaultSkillRoots,
+  getSkillSearchRoots,
+  resolveSkillReferences,
+  loadResolvedSkills,
+  formatMissingSkills,
+  type SkillResolutionOptions,
+  type SkillResolutionResult,
+  type ResolvedSkill,
+  type MissingSkill,
+  type LoadedSkill,
+} from './skills';
 export { resolveCodexBinaryPath, fileExists as codexFileExists } from './codex/binary-resolver';
 export { resolveClaudeBinaryPath, fileExists as claudeFileExists } from './claude/binary-resolver';
 

--- a/packages/providers/src/registry.test.ts
+++ b/packages/providers/src/registry.test.ts
@@ -115,6 +115,7 @@ describe('registry', () => {
       expect(codexCaps.mcp).toBe(false);
       expect(claudeCaps.hooks).toBe(true);
       expect(codexCaps.hooks).toBe(false);
+      expect(codexCaps.skills).toBe(true);
     });
   });
 
@@ -130,6 +131,7 @@ describe('registry', () => {
       const caps = getProviderCapabilities('codex');
       expect(caps.mcp).toBe(false);
       expect(caps.hooks).toBe(false);
+      expect(caps.skills).toBe(true);
       expect(caps.envInjection).toBe(true);
     });
 

--- a/packages/providers/src/skills.test.ts
+++ b/packages/providers/src/skills.test.ts
@@ -1,0 +1,93 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { loadResolvedSkills, resolveSkillReferences } from './skills';
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'archon-skills-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeSkill(root: string, name: string, content = 'Instructions'): Promise<string> {
+  const dir = join(root, name);
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    join(dir, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: Test skill\n---\n\n# ${name}\n\n${content}\n`
+  );
+  return dir;
+}
+
+afterEach(async () => {
+  for (const dir of tempDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe('skill resolution', () => {
+  test('resolves skill names from configured roots before defaults', async () => {
+    const cwd = await makeTempDir();
+    const configuredRoot = join(cwd, 'custom-skills');
+    const skillDir = await writeSkill(configuredRoot, 'alpha');
+
+    const result = await resolveSkillReferences(cwd, ['alpha'], {
+      skillRoots: [configuredRoot],
+    });
+
+    expect(result.missing).toEqual([]);
+    expect(result.resolved).toEqual([
+      {
+        ref: 'alpha',
+        name: 'alpha',
+        dirPath: skillDir,
+        skillPath: join(skillDir, 'SKILL.md'),
+      },
+    ]);
+  });
+
+  test('resolves explicit directories and SKILL.md paths', async () => {
+    const cwd = await makeTempDir();
+    const skillsRoot = join(cwd, 'skills');
+    const alphaDir = await writeSkill(skillsRoot, 'alpha');
+    const bravoDir = await writeSkill(skillsRoot, 'bravo');
+
+    const result = await resolveSkillReferences(cwd, [alphaDir, join(bravoDir, 'SKILL.md')]);
+
+    expect(result.missing).toEqual([]);
+    expect(result.resolved.map(skill => skill.skillPath)).toEqual([
+      join(alphaDir, 'SKILL.md'),
+      join(bravoDir, 'SKILL.md'),
+    ]);
+  });
+
+  test('reports searched paths for missing skills', async () => {
+    const cwd = await makeTempDir();
+    const configuredRoot = join(cwd, 'custom-skills');
+
+    const result = await resolveSkillReferences(cwd, ['missing'], {
+      skillRoots: [configuredRoot],
+    });
+
+    expect(result.resolved).toEqual([]);
+    expect(result.missing).toHaveLength(1);
+    expect(result.missing[0]?.ref).toBe('missing');
+    expect(result.missing[0]?.searchedPaths[0]).toBe(join(configuredRoot, 'missing', 'SKILL.md'));
+  });
+
+  test('loads skill content and frontmatter name', async () => {
+    const cwd = await makeTempDir();
+    const skillDir = await writeSkill(join(cwd, '.agents', 'skills'), 'alpha', 'Use alpha.');
+    const result = await resolveSkillReferences(cwd, ['alpha']);
+
+    const loaded = await loadResolvedSkills(result.resolved);
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]?.name).toBe('alpha');
+    expect(loaded[0]?.content).toContain('Use alpha.');
+    expect(loaded[0]?.skillPath).toBe(join(skillDir, 'SKILL.md'));
+  });
+});

--- a/packages/providers/src/skills.test.ts
+++ b/packages/providers/src/skills.test.ts
@@ -1,8 +1,13 @@
 import { describe, test, expect, afterEach } from 'bun:test';
-import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { loadResolvedSkills, resolveSkillReferences } from './skills';
+import {
+  getSkillSearchRoots,
+  loadResolvedSkills,
+  resolveProviderSkillReferences,
+  resolveSkillReferences,
+} from './skills';
 
 const tempDirs: string[] = [];
 
@@ -76,6 +81,51 @@ describe('skill resolution', () => {
     expect(result.missing).toHaveLength(1);
     expect(result.missing[0]?.ref).toBe('missing');
     expect(result.missing[0]?.searchedPaths[0]).toBe(join(configuredRoot, 'missing', 'SKILL.md'));
+  });
+
+  test('stops when a higher-precedence skill exists but is unreadable', async () => {
+    const cwd = await makeTempDir();
+    const configuredRoot = join(cwd, 'custom-skills');
+    const configuredSkillDir = await writeSkill(configuredRoot, 'alpha');
+    await writeSkill(join(cwd, '.agents', 'skills'), 'alpha', 'Lower precedence.');
+    await chmod(join(configuredSkillDir, 'SKILL.md'), 0o000);
+
+    const result = await resolveSkillReferences(cwd, ['alpha'], {
+      skillRoots: [configuredRoot],
+    });
+
+    expect(result.resolved).toEqual([]);
+    expect(result.missing).toHaveLength(1);
+    expect(result.missing[0]?.reason).toContain('Cannot read');
+    expect(result.missing[0]?.searchedPaths[0]).toBe(join(configuredSkillDir, 'SKILL.md'));
+  });
+
+  test('uses provider-specific roots for Claude and Pi skill names', async () => {
+    const cwd = await makeTempDir();
+    await writeSkill(join(cwd, '.codex', 'skills'), 'alpha');
+
+    const piResult = await resolveProviderSkillReferences('pi', cwd, ['alpha']);
+    const claudeResult = await resolveProviderSkillReferences('claude', cwd, ['alpha']);
+    const codexResult = await resolveProviderSkillReferences('codex', cwd, ['alpha']);
+
+    expect(piResult.resolved).toEqual([]);
+    expect(claudeResult.resolved).toEqual([]);
+    expect(codexResult.missing).toEqual([]);
+    expect(codexResult.resolved[0]?.skillPath).toBe(
+      join(cwd, '.codex', 'skills', 'alpha', 'SKILL.md')
+    );
+  });
+
+  test('expands configured relative roots and removes duplicate roots', async () => {
+    const cwd = await makeTempDir();
+    const root = join(cwd, 'skills');
+
+    const roots = getSkillSearchRoots(cwd, {
+      skillRoots: ['skills', root],
+    });
+
+    expect(roots[0]).toBe(root);
+    expect(roots.filter(candidate => candidate === root)).toHaveLength(1);
   });
 
   test('loads skill content and frontmatter name', async () => {

--- a/packages/providers/src/skills.ts
+++ b/packages/providers/src/skills.ts
@@ -1,0 +1,185 @@
+import { access, readFile } from 'fs/promises';
+import { constants } from 'fs';
+import { basename, dirname, isAbsolute, join, resolve, sep } from 'path';
+import { homedir } from 'os';
+
+export interface SkillResolutionOptions {
+  skillRoots?: string[];
+}
+
+export interface ResolvedSkill {
+  ref: string;
+  name: string;
+  dirPath: string;
+  skillPath: string;
+}
+
+export interface MissingSkill {
+  ref: string;
+  searchedPaths: string[];
+}
+
+export interface SkillResolutionResult {
+  resolved: ResolvedSkill[];
+  missing: MissingSkill[];
+  searchRoots: string[];
+}
+
+export interface LoadedSkill extends ResolvedSkill {
+  content: string;
+}
+
+function expandRoot(root: string, cwd: string): string {
+  if (root === '~') return homedir();
+  if (root.startsWith(`~${sep}`)) return join(homedir(), root.slice(2));
+  return isAbsolute(root) ? root : resolve(cwd, root);
+}
+
+export function getDefaultSkillRoots(cwd: string): string[] {
+  const home = process.env.HOME ?? homedir();
+  return [
+    join(cwd, '.agents', 'skills'),
+    join(cwd, '.codex', 'skills'),
+    join(cwd, '.claude', 'skills'),
+    join(home, '.agents', 'skills'),
+    join(home, '.codex', 'skills'),
+    join(home, '.claude', 'skills'),
+    '/etc/codex/skills',
+  ];
+}
+
+export function getSkillSearchRoots(cwd: string, options: SkillResolutionOptions = {}): string[] {
+  const roots = [
+    ...(options.skillRoots ?? []).map(root => expandRoot(root, cwd)),
+    ...getDefaultSkillRoots(cwd),
+  ];
+
+  const seen = new Set<string>();
+  return roots.filter(root => {
+    if (seen.has(root)) return false;
+    seen.add(root);
+    return true;
+  });
+}
+
+function looksLikePath(ref: string): boolean {
+  return (
+    isAbsolute(ref) ||
+    ref.startsWith('.') ||
+    ref.includes('/') ||
+    ref.includes('\\') ||
+    ref.endsWith('.md')
+  );
+}
+
+async function canReadFile(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function skillPathForRef(ref: string, cwd: string): { dirPath: string; skillPath: string } {
+  const absolutePath = isAbsolute(ref) ? ref : resolve(cwd, ref);
+  const skillPath =
+    basename(absolutePath) === 'SKILL.md' ? absolutePath : join(absolutePath, 'SKILL.md');
+  const dirPath = basename(skillPath) === 'SKILL.md' ? dirname(skillPath) : absolutePath;
+  return { dirPath, skillPath };
+}
+
+function skillNameFromPath(skillPath: string): string {
+  return basename(dirname(skillPath));
+}
+
+function parseFrontmatterName(content: string): string | undefined {
+  if (!content.startsWith('---\n')) return undefined;
+  const end = content.indexOf('\n---', 4);
+  if (end === -1) return undefined;
+  const frontmatter = content.slice(4, end);
+  for (const line of frontmatter.split('\n')) {
+    const match = /^name:\s*["']?([^"'\n]+)["']?\s*$/.exec(line.trim());
+    if (match?.[1]) return match[1].trim();
+  }
+  return undefined;
+}
+
+export async function resolveSkillReferences(
+  cwd: string,
+  skillRefs: readonly string[] | undefined,
+  options: SkillResolutionOptions = {}
+): Promise<SkillResolutionResult> {
+  const searchRoots = getSkillSearchRoots(cwd, options);
+  const resolved: ResolvedSkill[] = [];
+  const missing: MissingSkill[] = [];
+  const seenRefs = new Set<string>();
+  const seenPaths = new Set<string>();
+
+  for (const rawRef of skillRefs ?? []) {
+    const ref = rawRef.trim();
+    if (ref.length === 0 || seenRefs.has(ref)) continue;
+    seenRefs.add(ref);
+
+    if (looksLikePath(ref)) {
+      const candidate = skillPathForRef(ref, cwd);
+      if (await canReadFile(candidate.skillPath)) {
+        if (!seenPaths.has(candidate.skillPath)) {
+          seenPaths.add(candidate.skillPath);
+          resolved.push({
+            ref,
+            name: skillNameFromPath(candidate.skillPath),
+            dirPath: candidate.dirPath,
+            skillPath: candidate.skillPath,
+          });
+        }
+      } else {
+        missing.push({ ref, searchedPaths: [candidate.skillPath] });
+      }
+      continue;
+    }
+
+    const searchedPaths = searchRoots.map(root => join(root, ref, 'SKILL.md'));
+    let skillPath: string | undefined;
+    for (const candidate of searchedPaths) {
+      if (await canReadFile(candidate)) {
+        skillPath = candidate;
+        break;
+      }
+    }
+
+    if (skillPath) {
+      const dirPath = dirname(skillPath);
+      if (!seenPaths.has(skillPath)) {
+        seenPaths.add(skillPath);
+        resolved.push({ ref, name: ref, dirPath, skillPath });
+      }
+    } else {
+      missing.push({ ref, searchedPaths });
+    }
+  }
+
+  return { resolved, missing, searchRoots };
+}
+
+export async function loadResolvedSkills(skills: readonly ResolvedSkill[]): Promise<LoadedSkill[]> {
+  const loaded: LoadedSkill[] = [];
+  for (const skill of skills) {
+    const content = await readFile(skill.skillPath, 'utf-8');
+    loaded.push({
+      ...skill,
+      name: parseFrontmatterName(content) ?? skill.name,
+      content,
+    });
+  }
+  return loaded;
+}
+
+export function formatMissingSkills(missing: readonly MissingSkill[]): string {
+  return missing
+    .map(skill => {
+      const searched = skill.searchedPaths.map(path => `  - ${path}`).join('\n');
+      return `Skill '${skill.ref}' not found or not readable. Searched:\n${searched}`;
+    })
+    .join('\n\n');
+}

--- a/packages/providers/src/skills.ts
+++ b/packages/providers/src/skills.ts
@@ -5,6 +5,8 @@ import { homedir } from 'os';
 
 export interface SkillResolutionOptions {
   skillRoots?: string[];
+  defaultRoots?: string[];
+  allowPathRefs?: boolean;
 }
 
 export interface ResolvedSkill {
@@ -17,6 +19,7 @@ export interface ResolvedSkill {
 export interface MissingSkill {
   ref: string;
   searchedPaths: string[];
+  reason?: string;
 }
 
 export interface SkillResolutionResult {
@@ -29,14 +32,24 @@ export interface LoadedSkill extends ResolvedSkill {
   content: string;
 }
 
+type SkillCandidateStatus =
+  | { status: 'readable'; path: string }
+  | { status: 'missing'; path: string }
+  | { status: 'unreadable'; path: string; code?: string; message: string };
+
+function getHomeDir(): string {
+  return process.env.HOME ?? homedir();
+}
+
 function expandRoot(root: string, cwd: string): string {
-  if (root === '~') return homedir();
-  if (root.startsWith(`~${sep}`)) return join(homedir(), root.slice(2));
+  const home = getHomeDir();
+  if (root === '~') return home;
+  if (root.startsWith(`~${sep}`)) return join(home, root.slice(2));
   return isAbsolute(root) ? root : resolve(cwd, root);
 }
 
 export function getDefaultSkillRoots(cwd: string): string[] {
-  const home = process.env.HOME ?? homedir();
+  const home = getHomeDir();
   return [
     join(cwd, '.agents', 'skills'),
     join(cwd, '.codex', 'skills'),
@@ -48,10 +61,20 @@ export function getDefaultSkillRoots(cwd: string): string[] {
   ];
 }
 
+export function getAgentSkillRoots(cwd: string): string[] {
+  const home = getHomeDir();
+  return [
+    join(cwd, '.agents', 'skills'),
+    join(cwd, '.claude', 'skills'),
+    join(home, '.agents', 'skills'),
+    join(home, '.claude', 'skills'),
+  ];
+}
+
 export function getSkillSearchRoots(cwd: string, options: SkillResolutionOptions = {}): string[] {
   const roots = [
     ...(options.skillRoots ?? []).map(root => expandRoot(root, cwd)),
-    ...getDefaultSkillRoots(cwd),
+    ...(options.defaultRoots ?? getDefaultSkillRoots(cwd)),
   ];
 
   const seen = new Set<string>();
@@ -72,12 +95,16 @@ function looksLikePath(ref: string): boolean {
   );
 }
 
-async function canReadFile(path: string): Promise<boolean> {
+async function checkSkillCandidate(path: string): Promise<SkillCandidateStatus> {
   try {
     await access(path, constants.R_OK);
-    return true;
-  } catch {
-    return false;
+    return { status: 'readable', path };
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
+      return { status: 'missing', path };
+    }
+    return { status: 'unreadable', path, code: err.code, message: err.message };
   }
 }
 
@@ -111,6 +138,7 @@ export async function resolveSkillReferences(
   options: SkillResolutionOptions = {}
 ): Promise<SkillResolutionResult> {
   const searchRoots = getSkillSearchRoots(cwd, options);
+  const allowPathRefs = options.allowPathRefs ?? true;
   const resolved: ResolvedSkill[] = [];
   const missing: MissingSkill[] = [];
   const seenRefs = new Set<string>();
@@ -123,7 +151,17 @@ export async function resolveSkillReferences(
 
     if (looksLikePath(ref)) {
       const candidate = skillPathForRef(ref, cwd);
-      if (await canReadFile(candidate.skillPath)) {
+      if (!allowPathRefs) {
+        missing.push({
+          ref,
+          searchedPaths: [candidate.skillPath],
+          reason: 'Path-based skill references are not supported by this provider',
+        });
+        continue;
+      }
+
+      const status = await checkSkillCandidate(candidate.skillPath);
+      if (status.status === 'readable') {
         if (!seenPaths.has(candidate.skillPath)) {
           seenPaths.add(candidate.skillPath);
           resolved.push({
@@ -134,16 +172,28 @@ export async function resolveSkillReferences(
           });
         }
       } else {
-        missing.push({ ref, searchedPaths: [candidate.skillPath] });
+        missing.push({
+          ref,
+          searchedPaths: [candidate.skillPath],
+          ...(status.status === 'unreadable'
+            ? { reason: `Cannot read ${status.path}: ${status.message}` }
+            : {}),
+        });
       }
       continue;
     }
 
     const searchedPaths = searchRoots.map(root => join(root, ref, 'SKILL.md'));
     let skillPath: string | undefined;
+    let failureReason: string | undefined;
     for (const candidate of searchedPaths) {
-      if (await canReadFile(candidate)) {
+      const status = await checkSkillCandidate(candidate);
+      if (status.status === 'readable') {
         skillPath = candidate;
+        break;
+      }
+      if (status.status === 'unreadable') {
+        failureReason = `Cannot read ${status.path}: ${status.message}`;
         break;
       }
     }
@@ -155,11 +205,27 @@ export async function resolveSkillReferences(
         resolved.push({ ref, name: ref, dirPath, skillPath });
       }
     } else {
-      missing.push({ ref, searchedPaths });
+      missing.push({ ref, searchedPaths, ...(failureReason ? { reason: failureReason } : {}) });
     }
   }
 
   return { resolved, missing, searchRoots };
+}
+
+export async function resolveProviderSkillReferences(
+  provider: string | undefined,
+  cwd: string,
+  skillRefs: readonly string[] | undefined,
+  options: SkillResolutionOptions = {}
+): Promise<SkillResolutionResult> {
+  if (provider === 'claude' || provider === 'pi') {
+    return resolveSkillReferences(cwd, skillRefs, {
+      defaultRoots: getAgentSkillRoots(cwd),
+      allowPathRefs: false,
+    });
+  }
+
+  return resolveSkillReferences(cwd, skillRefs, options);
 }
 
 export async function loadResolvedSkills(skills: readonly ResolvedSkill[]): Promise<LoadedSkill[]> {
@@ -179,7 +245,8 @@ export function formatMissingSkills(missing: readonly MissingSkill[]): string {
   return missing
     .map(skill => {
       const searched = skill.searchedPaths.map(path => `  - ${path}`).join('\n');
-      return `Skill '${skill.ref}' not found or not readable. Searched:\n${searched}`;
+      const reason = skill.reason ? `${skill.reason}. ` : '';
+      return `Skill '${skill.ref}' not found or not readable. ${reason}Searched:\n${searched}`;
     })
     .join('\n\n');
 }

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -27,6 +27,8 @@ export interface CodexProviderDefaults {
   /** Structurally matches @archon/workflows WebSearchMode */
   webSearchMode?: 'disabled' | 'cached' | 'live';
   additionalDirectories?: string[];
+  /** Additional skill root directories searched for workflow `skills:` refs. */
+  skillRoots?: string[];
   /** Path to the Codex CLI binary. Overrides auto-detection in compiled Archon builds. */
   codexBinaryPath?: string;
 }

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -120,7 +120,7 @@ const mockCodexCapabilities = () => ({
   sessionResume: true,
   mcp: false,
   hooks: false,
-  skills: false,
+  skills: true,
   agents: false,
   toolRestrictions: false,
   structuredOutput: true,
@@ -2439,7 +2439,7 @@ describe('executeDagWorkflow -- skills options', () => {
     expect(nodeConfig?.allowed_tools).toEqual(['Read', 'Grep']);
   });
 
-  it('warns user when Codex DAG node has skills and does not pass agents', async () => {
+  it('passes skills to Codex sendQuery nodeConfig without unsupported-capability warning', async () => {
     mockGetAgentProviderDag.mockReturnValue({
       sendQuery: mockSendQueryDag,
       getType: () => 'codex',
@@ -2471,11 +2471,16 @@ describe('executeDagWorkflow -- skills options', () => {
       { ...minimalConfig, assistant: 'codex' }
     );
 
-    // Warning sent to user
+    expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
+    const optionsArg = mockSendQueryDag.mock.calls[0]?.[3] as Record<string, unknown>;
+    const nodeConfig = optionsArg?.nodeConfig as Record<string, unknown>;
+    expect(nodeConfig?.skills).toEqual(['codebase-search']);
+
+    // No unsupported-capability warning is sent for Codex skills now.
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
     const warning = messages.find(m => m.includes('skills') && m.includes('codex'));
-    expect(warning).toBeDefined();
+    expect(warning).toBeUndefined();
   });
 
   it('passes agents to sendQuery nodeConfig when node has inline agents', async () => {
@@ -2612,6 +2617,21 @@ nodes:
     skills: []
 `;
     const result = parseWorkflow(yaml, 'empty.yaml');
+    expect(result.error).not.toBeNull();
+    expect(result.error!.error).toContain('skills');
+  });
+
+  it('rejects blank skill names after trimming', () => {
+    const yaml = `
+name: blank-skills
+description: test
+nodes:
+  - id: review
+    prompt: "Review"
+    skills:
+      - "   "
+`;
+    const result = parseWorkflow(yaml, 'blank.yaml');
     expect(result.error).not.toBeNull();
     expect(result.error!.error).toContain('skills');
   });

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -24,6 +24,11 @@ mock.module('@archon/paths', () => ({
     return paths;
   },
   getDefaultCommandsPath: () => '/nonexistent/defaults',
+  getWorkflowFolderSearchPaths: () => ['.archon/workflows'],
+  getDefaultWorkflowsPath: () => '/nonexistent/default-workflows',
+  getHomeWorkflowsPath: () => '/nonexistent/home-workflows',
+  getLegacyHomeWorkflowsPath: () => '/nonexistent/legacy-home-workflows',
+  getArchonHome: () => '/nonexistent/archon-home',
 }));
 
 // --- Bootstrap provider registry (after path mocks, before dag-executor import) ---

--- a/packages/workflows/src/deps.ts
+++ b/packages/workflows/src/deps.ts
@@ -94,6 +94,7 @@ export interface WorkflowConfig {
       modelReasoningEffort?: ModelReasoningEffort;
       webSearchMode?: WebSearchMode;
       additionalDirectories?: string[];
+      skillRoots?: string[];
     };
   };
 }

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -39,10 +39,13 @@ import * as bundledDefaults from './defaults/bundled-defaults';
 
 describe('Workflow Loader', () => {
   let testDir: string;
+  let originalArchonHome: string | undefined;
 
   beforeEach(async () => {
     // Create unique temp directory for each test
+    originalArchonHome = process.env.ARCHON_HOME;
     testDir = join(tmpdir(), `workflow-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    process.env.ARCHON_HOME = join(testDir, 'archon-home');
     await mkdir(testDir, { recursive: true });
   });
 
@@ -52,6 +55,11 @@ describe('Workflow Loader', () => {
       await rm(testDir, { recursive: true, force: true });
     } catch {
       // Ignore cleanup errors
+    }
+    if (originalArchonHome === undefined) {
+      delete process.env.ARCHON_HOME;
+    } else {
+      process.env.ARCHON_HOME = originalArchonHome;
     }
   });
 

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -145,7 +145,7 @@ export const dagNodeBaseSchema = z.object({
   hooks: workflowNodeHooksSchema.optional(),
   mcp: z.string().min(1, "'mcp' must be a non-empty string path").optional(),
   skills: z
-    .array(z.string().min(1, 'each skill must be a non-empty string'))
+    .array(z.string().trim().min(1, 'each skill must be a non-empty string'))
     .nonempty("'skills' must be a non-empty array")
     .optional(),
   agents: z

--- a/packages/workflows/src/validator.test.ts
+++ b/packages/workflows/src/validator.test.ts
@@ -46,6 +46,15 @@ async function createCommandFile(name: string, content = '# Do something'): Prom
   await writeFile(join(dir, `${name}.md`), content);
 }
 
+async function createSkill(root: string, name: string): Promise<void> {
+  const dir = join(root, name);
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    join(dir, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: Test skill\n---\n\n# ${name}\n`
+  );
+}
+
 // =============================================================================
 // levenshtein
 // =============================================================================
@@ -224,6 +233,58 @@ describe('validateWorkflowResources — MCP validation', () => {
     const mcpWarnings = issues.filter(i => i.field === 'mcp' && i.level === 'warning');
     expect(mcpWarnings).toHaveLength(1);
     expect(mcpWarnings[0].message).toContain('not supported by provider');
+  });
+});
+
+// =============================================================================
+// validateWorkflowResources — skills validation
+// =============================================================================
+
+describe('validateWorkflowResources — skills validation', () => {
+  test('no issue when skill exists in default project roots', async () => {
+    await createSkill(join(tmpDir, '.claude', 'skills'), 'alpha');
+    const workflow = makeWorkflow('test', [
+      { id: 'step1', prompt: 'do stuff', skills: ['alpha'] } as unknown as DagNode,
+    ]);
+
+    const issues = await validateWorkflowResources(workflow, tmpDir);
+
+    expect(issues.filter(i => i.field === 'skills')).toHaveLength(0);
+  });
+
+  test('resolves skill names from provider configured roots', async () => {
+    const skillRoot = join(tmpDir, 'custom-skills');
+    await createSkill(skillRoot, 'alpha');
+    const workflow = makeWorkflow(
+      'test',
+      [
+        {
+          id: 'step1',
+          prompt: 'do stuff',
+          provider: 'codex',
+          skills: ['alpha'],
+        } as unknown as DagNode,
+      ],
+      'codex'
+    );
+
+    const issues = await validateWorkflowResources(workflow, tmpDir, {
+      skillRootsByProvider: { codex: [skillRoot] },
+    });
+
+    expect(issues.filter(i => i.field === 'skills')).toHaveLength(0);
+  });
+
+  test('errors when skill is missing', async () => {
+    const workflow = makeWorkflow('test', [
+      { id: 'step1', prompt: 'do stuff', skills: ['missing'] } as unknown as DagNode,
+    ]);
+
+    const issues = await validateWorkflowResources(workflow, tmpDir);
+    const skillErrors = issues.filter(i => i.field === 'skills' && i.level === 'error');
+
+    expect(skillErrors).toHaveLength(1);
+    expect(skillErrors[0].message).toContain("Skill 'missing' not found");
   });
 });
 

--- a/packages/workflows/src/validator.test.ts
+++ b/packages/workflows/src/validator.test.ts
@@ -275,6 +275,28 @@ describe('validateWorkflowResources — skills validation', () => {
     expect(issues.filter(i => i.field === 'skills')).toHaveLength(0);
   });
 
+  test('uses provider-specific skill roots when validating non-Codex providers', async () => {
+    await createSkill(join(tmpDir, '.codex', 'skills'), 'alpha');
+    const workflow = makeWorkflow(
+      'test',
+      [
+        {
+          id: 'step1',
+          prompt: 'do stuff',
+          provider: 'pi',
+          skills: ['alpha'],
+        } as unknown as DagNode,
+      ],
+      'pi'
+    );
+
+    const issues = await validateWorkflowResources(workflow, tmpDir);
+    const skillErrors = issues.filter(i => i.field === 'skills' && i.level === 'error');
+
+    expect(skillErrors).toHaveLength(1);
+    expect(skillErrors[0].hint).not.toContain(join(tmpDir, '.codex', 'skills'));
+  });
+
   test('errors when skill is missing', async () => {
     const workflow = makeWorkflow('test', [
       { id: 'step1', prompt: 'do stuff', skills: ['missing'] } as unknown as DagNode,

--- a/packages/workflows/src/validator.ts
+++ b/packages/workflows/src/validator.ts
@@ -10,7 +10,6 @@
  */
 
 import { join, resolve, isAbsolute } from 'path';
-import { homedir } from 'os';
 import { access, readFile } from 'fs/promises';
 import {
   createLogger,
@@ -23,6 +22,7 @@ import { execFileAsync } from '@archon/git';
 import { BUNDLED_COMMANDS, isBinaryBuild } from './defaults/bundled-defaults';
 import { isValidCommandName } from './command-validation';
 import { getProviderCapabilities, isRegisteredProvider } from '@archon/providers';
+import { resolveSkillReferences } from '@archon/providers/skills';
 
 /** Lazy-initialized logger */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
@@ -83,6 +83,7 @@ export interface CommandValidationResult {
 export interface ValidationConfig {
   loadDefaultCommands?: boolean;
   commandFolder?: string;
+  skillRootsByProvider?: Record<string, string[]>;
 }
 
 // =============================================================================
@@ -407,22 +408,16 @@ export async function validateWorkflowResources(
 
     // --- Skills nodes: check skill directories exist ---
     if ('skills' in node && Array.isArray(node.skills)) {
-      for (const skillName of node.skills) {
-        const projectSkillPath = join(cwd, '.claude', 'skills', skillName, 'SKILL.md');
-        const userSkillPath = join(homedir(), '.claude', 'skills', skillName, 'SKILL.md');
-
-        const projectExists = await fileExists(projectSkillPath);
-        const userExists = await fileExists(userSkillPath);
-
-        if (!projectExists && !userExists) {
-          issues.push({
-            level: 'warning',
-            nodeId: node.id,
-            field: 'skills',
-            message: `Skill '${skillName}' not found in .claude/skills/ or ~/.claude/skills/`,
-            hint: `Install with: npx skills add <repo> — or create manually at .claude/skills/${skillName}/SKILL.md`,
-          });
-        }
+      const skillRoots = provider ? config?.skillRootsByProvider?.[provider] : undefined;
+      const skillResolution = await resolveSkillReferences(cwd, node.skills, { skillRoots });
+      for (const missingSkill of skillResolution.missing) {
+        issues.push({
+          level: 'error',
+          nodeId: node.id,
+          field: 'skills',
+          message: `Skill '${missingSkill.ref}' not found or not readable`,
+          hint: `Searched:\n${missingSkill.searchedPaths.map(path => `  - ${path}`).join('\n')}`,
+        });
       }
 
       // Warn if using skills with a provider that doesn't support them

--- a/packages/workflows/src/validator.ts
+++ b/packages/workflows/src/validator.ts
@@ -22,7 +22,7 @@ import { execFileAsync } from '@archon/git';
 import { BUNDLED_COMMANDS, isBinaryBuild } from './defaults/bundled-defaults';
 import { isValidCommandName } from './command-validation';
 import { getProviderCapabilities, isRegisteredProvider } from '@archon/providers';
-import { resolveSkillReferences } from '@archon/providers/skills';
+import { resolveProviderSkillReferences } from '@archon/providers/skills';
 
 /** Lazy-initialized logger */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
@@ -406,21 +406,8 @@ export async function validateWorkflowResources(
       }
     }
 
-    // --- Skills nodes: check skill directories exist ---
+    // --- Skills nodes: check provider-supported skill references exist ---
     if ('skills' in node && Array.isArray(node.skills)) {
-      const skillRoots = provider ? config?.skillRootsByProvider?.[provider] : undefined;
-      const skillResolution = await resolveSkillReferences(cwd, node.skills, { skillRoots });
-      for (const missingSkill of skillResolution.missing) {
-        issues.push({
-          level: 'error',
-          nodeId: node.id,
-          field: 'skills',
-          message: `Skill '${missingSkill.ref}' not found or not readable`,
-          hint: `Searched:\n${missingSkill.searchedPaths.map(path => `  - ${path}`).join('\n')}`,
-        });
-      }
-
-      // Warn if using skills with a provider that doesn't support them
       if (provider && isRegisteredProvider(provider)) {
         const caps = getProviderCapabilities(provider);
         if (!caps.skills) {
@@ -431,7 +418,23 @@ export async function validateWorkflowResources(
             message: `Skills are not supported by provider '${provider}' — this will be ignored`,
             hint: 'Remove the skills field or switch to a provider that supports skills',
           });
+          continue;
         }
+      }
+
+      const skillRoots = provider ? config?.skillRootsByProvider?.[provider] : undefined;
+      const skillResolution = await resolveProviderSkillReferences(provider, cwd, node.skills, {
+        skillRoots,
+      });
+      for (const missingSkill of skillResolution.missing) {
+        const reason = missingSkill.reason ? `${missingSkill.reason}\n` : '';
+        issues.push({
+          level: 'error',
+          nodeId: node.id,
+          field: 'skills',
+          message: `Skill '${missingSkill.ref}' not found or not readable`,
+          hint: `${reason}Searched:\n${missingSkill.searchedPaths.map(path => `  - ${path}`).join('\n')}`,
+        });
       }
     }
 


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: Codex workflow nodes could not explicitly preload Archon skills, even though local Codex sessions already have a skill model and workflows can declare `skills:`.
- Why it matters: workflows that rely on provider-specific domain instructions need deterministic validation and runtime behavior; missing or silently ignored skills make agent runs hard to reproduce.
- What changed: added provider-level skill resolution/loading for Codex, exposed `assistants.codex.skillRoots`, enabled Codex `skills` capability, wired workflow validation/CLI validation to provider-specific roots, and updated docs/tests.
- What did **not** change (scope boundary): no MCP behavior is changed; this PR intentionally excludes the separate MCP workflow fixes and only touches skills/config/validation/docs/tests.

## UX Journey

### Before

```text
User                   Archon workflow             Codex provider
────                   ───────────────             ──────────────
runs workflow ───────▶ node has skills: [...]
                       validates generic refs
                       sends prompt ─────────────▶ no workflow skill context loaded
reply ◀─────────────── Codex responds without selected SKILL.md instructions
```

### After

```text
User                   Archon workflow             Codex provider
────                   ───────────────             ──────────────
runs workflow ───────▶ node has skills: [...]
                       validates provider-specific refs
                       sends node config ────────▶ resolves SKILL.md
                                                  loads selected skill content
                                                  prepends skill context
reply ◀─────────────── Codex responds with selected skill instructions active
```

## Architecture Diagram

### Before

```text
workflow YAML
  └─ skills: [...]
       └─ validator.ts ──> generic filesystem check

CodexProvider
  └─ sendQuery(prompt) ──> Codex SDK

config-loader.ts
  └─ assistants.codex (model/search/additionalDirectories only)
```

### After

```text
workflow YAML
  └─ skills: [...]
       ├─ validator.ts [~]
       │    ═══> resolveProviderSkillReferences() [+]
       └─ CodexProvider.sendQuery() [~]
            ═══> resolveSkillReferences() [+]
            ═══> loadResolvedSkills() [+]
            ═══> prepend skill context before Codex SDK turn

config-loader.ts [~]
  └─ assistants.codex.skillRoots [+]

@archon/providers/skills [+]
  ├─ default roots: repo/home .agents/.codex/.claude skills
  ├─ explicit path refs for Codex
  └─ fail-fast unreadable higher-precedence candidates
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| workflow `skills:` schema | workflow validator | **modified** | trims/validates non-empty skill refs |
| workflow validator | `@archon/providers/skills` | **new** | validates refs with provider-specific roots |
| Codex provider | `@archon/providers/skills` | **new** | resolves and loads selected `SKILL.md` files at runtime |
| core config loader | Codex assistant defaults | **modified** | carries `skillRoots` into provider defaults |
| CLI validate command | workflow validator | **modified** | passes default provider and Codex skill roots into workflow validation |
| docs | workflow authoring / skills guides | **modified** | documents Codex/Pi/Claude support and Codex roots |

## Label Snapshot

- Risk: `risk: medium`
- Size: `size: M`
- Scope: `workflows|providers|cli|config|docs|tests|skills`
- Module: `providers:codex`, `providers:skills`, `workflows:validator`, `cli:validate`

## Change Metadata

- Change type: `feature`
- Primary scope: `workflows|providers`

## Linked Issue

- Closes #
- Related #
- Depends on # none
- Supersedes # none

## Validation Evidence (required)

Commands and result summary:

```bash
ARCHON_HOME=$(mktemp -d) bun run validate
```

Result: passed. This ran bundled-default checks, type-check, lint with `--max-warnings 0`, format check, and the per-package isolated test suite.

Additional targeted checks run during development:

```bash
bun test packages/providers/src/skills.test.ts
bun test packages/providers/src/codex/provider.test.ts
bun test packages/workflows/src/validator.test.ts
bun test packages/core/src/config/config-loader.test.ts
ARCHON_HOME=$(mktemp -d) bun test packages/workflows/src/dag-executor.test.ts
```

Real Archon workflow E2E skill smokes:

```text
0cfc3bee6be6fc5cef42cff370d628ac  e2e-codex-skill-explicit-smoke
  PASS: Codex loaded explicit /tmp/.../SKILL.md via workflow skills:
  returned ARCHON_E2E_EXPLICIT_SKILL_20260502

6dbe0c731e4dad5f4dffb0e15401b7a1  e2e-codex-skill-name-smoke
  PASS: Codex resolved archon-e2e-global-skill from ~/.codex/skills
  returned ARCHON_E2E_GLOBAL_SKILL_20260502

72b0fbbb505c2e1ec8b5847b76285f48  e2e-codex-dollar-skill-smoke
  PASS: native Codex $skill discovery still works inside an Archon workflow
  returned ARCHON_E2E_DOLLAR_SKILL_20260502
```

- Evidence provided: tests plus real workflow run IDs and sentinel outputs from Codex.
- If any command is intentionally skipped, explain why: none.

## Security Impact (required)

- New permissions/capabilities? `Yes`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `Yes`

Codex nodes can now explicitly load local `SKILL.md` files selected by workflow `skills:`. The file read scope is limited to explicit skill path refs and documented skill roots, with validation errors for missing or unreadable skills. The resolver now fails fast when a higher-precedence candidate exists but cannot be read, avoiding silent fallback to unintended lower-precedence instructions.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes`
- Database migration needed? `No`

Existing workflows without `skills:` are unchanged. `assistants.codex.skillRoots` is optional; default roots still work. No upgrade steps are required unless a user wants custom skill roots:

```yaml
assistants:
  codex:
    skillRoots:
      - ./.codex/skills
      - ~/.codex/skills
```

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
  - workflow-declared `skills:` using an explicit absolute skill directory;
  - workflow-declared `skills:` using a skill name resolved from `~/.codex/skills`;
  - native Codex `$skill` discovery inside an Archon workflow;
  - missing skill validation emits actionable searched paths.
- Edge cases checked:
  - blank skill refs are rejected by schema validation;
  - provider-specific validation does not let Pi pass on Codex-only `.codex/skills` roots;
  - unreadable higher-precedence skill candidates stop resolution instead of silently falling through.
- What was not verified:
  - live Pi skill runtime success, because local Pi auth/API key for `minimax/MiniMax-M2.7` was unavailable; validation did reach `skillCount: 1` / `missingSkillCount: 0` before provider auth failure.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Codex provider execution, workflow validation, CLI workflow validation, config loading, docs, and provider capability metadata.
- Potential unintended effects: workflows with invalid or unreadable skills now fail earlier instead of running without the expected instructions.
- Guardrails/monitoring for early detection: validation errors include searched paths; Codex runtime logs `codex.skills_loaded` with loaded skill names and paths.

## Rollback Plan (required)

- Fast rollback command/path: revert the two commits on this branch.
- Feature flags or config toggles (if any): none. Removing `skills:` from affected workflows restores prior Codex behavior for those nodes.
- Observable failure symptoms: workflow validation errors for skills, or Codex responses missing expected skill-specific sentinel/behavior in smoke workflows.

## Risks and Mitigations

- Risk: local skill content can materially steer Codex behavior.
  - Mitigation: skills must be explicitly declared by workflow/config path or name, and validation fails on missing/unreadable candidates.
- Risk: provider search roots diverge and validation drifts from runtime behavior.
  - Mitigation: provider-aware validation is covered by tests, including non-Codex root behavior.
- Risk: docs imply broader support than a provider actually gives.
  - Mitigation: docs now call out provider-specific mechanics and link to the skills guide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills support extended to Codex and Pi providers (in addition to Claude)
  * New configurable skill root directories for custom skill locations
  * Enhanced workflow skill validation with multi-provider support

* **Documentation**
  * Updated guides and references to document skills support across Claude, Codex, and Pi

* **Tests**
  * Added comprehensive test coverage for skill resolution and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->