### PR TITLE
Fix #1531: long conversations no longer truncate to oldest 200 +  preserve SSE state on mid-session recovery

### DIFF
--- a/packages/core/src/db/messages.test.ts
+++ b/packages/core/src/db/messages.test.ts
@@ -113,11 +113,11 @@ describe('messages', () => {
 
       // Caller-visible order: oldest first (reversed from query result)
       expect(result).toEqual([...newestFirst].reverse());
+      // ORDER BY uses `id` as a deterministic tie-breaker for the LIMIT
+      // window — without it the cutoff can be unstable across calls when
+      // multiple rows share created_at.
       expect(mockQuery).toHaveBeenCalledWith(
-        `SELECT * FROM remote_agent_messages
-     WHERE conversation_id = $1
-     ORDER BY created_at DESC
-     LIMIT $2`,
+        expect.stringContaining('ORDER BY created_at DESC, id DESC'),
         ['conv-456', 200]
       );
     });

--- a/packages/core/src/db/messages.test.ts
+++ b/packages/core/src/db/messages.test.ts
@@ -100,20 +100,23 @@ describe('messages', () => {
   });
 
   describe('listMessages', () => {
-    test('returns rows from query result', async () => {
-      const messages: MessageRow[] = [
-        mockMessage,
+    test('queries newest-first then reverses to chronological order', async () => {
+      // DB returns DESC (newest first); listMessages reverses to oldest-first
+      // for display so callers see the natural reading order.
+      const newestFirst: MessageRow[] = [
         { ...mockMessage, id: 'msg-124', role: 'assistant', content: 'Hi!' },
+        mockMessage,
       ];
-      mockQuery.mockResolvedValueOnce(createQueryResult(messages));
+      mockQuery.mockResolvedValueOnce(createQueryResult(newestFirst));
 
       const result = await listMessages('conv-456');
 
-      expect(result).toEqual(messages);
+      // Caller-visible order: oldest first (reversed from query result)
+      expect(result).toEqual([...newestFirst].reverse());
       expect(mockQuery).toHaveBeenCalledWith(
         `SELECT * FROM remote_agent_messages
      WHERE conversation_id = $1
-     ORDER BY created_at ASC
+     ORDER BY created_at DESC
      LIMIT $2`,
         ['conv-456', 200]
       );

--- a/packages/core/src/db/messages.ts
+++ b/packages/core/src/db/messages.ts
@@ -63,9 +63,12 @@ export async function listMessages(
   limit = 200
 ): Promise<readonly MessageRow[]> {
   const result = await pool.query<MessageRow>(
+    // Tie-breaker on `id` keeps the LIMIT window deterministic when multiple
+    // rows share the same created_at — without it the cutoff can repeat or
+    // drop rows non-deterministically across calls.
     `SELECT * FROM remote_agent_messages
      WHERE conversation_id = $1
-     ORDER BY created_at DESC
+     ORDER BY created_at DESC, id DESC
      LIMIT $2`,
     [conversationId, limit]
   );

--- a/packages/core/src/db/messages.ts
+++ b/packages/core/src/db/messages.ts
@@ -48,7 +48,14 @@ export async function addMessage(
 }
 
 /**
- * List messages for a conversation, oldest first.
+ * List the most recent messages for a conversation, returned oldest-first.
+ *
+ * The DB query orders DESC and takes the top `limit` (i.e. the newest N), then
+ * reverses to oldest-first for the chronological-display contract callers
+ * expect. This matters for conversations with more than `limit` messages: the
+ * previous "ORDER BY created_at ASC" returned the *oldest* N, which made the
+ * latest messages invisible in the Web UI for any conversation past the cap.
+ *
  * conversationId is the database UUID (not platform_conversation_id).
  */
 export async function listMessages(
@@ -58,11 +65,13 @@ export async function listMessages(
   const result = await pool.query<MessageRow>(
     `SELECT * FROM remote_agent_messages
      WHERE conversation_id = $1
-     ORDER BY created_at ASC
+     ORDER BY created_at DESC
      LIMIT $2`,
     [conversationId, limit]
   );
-  return result.rows;
+  // Reverse to oldest-first so callers don't have to. (DB-side reverse via
+  // a subquery is also possible but adds a layer of indirection for no gain.)
+  return [...result.rows].reverse();
 }
 
 /**

--- a/packages/web/src/components/chat/ChatInterface.tsx
+++ b/packages/web/src/components/chat/ChatInterface.tsx
@@ -458,7 +458,27 @@ export function ChatInterface({ conversationId }: ChatInterfaceProps): React.Rea
             // long conversations whose tail wasn't in the server's window.
             setMessages(prev => {
               const hydratedIds = new Set(hydrated.map(m => m.id));
-              const clientOnly = prev.filter(m => !hydratedIds.has(m.id));
+              // Without a narrower filter, every prev message that lacks a
+              // hydrated counterpart is preserved — including stale
+              // `thinking-*` placeholders and optimistic `msg-*` entries that
+              // already have canonical hydrated rows under different ids,
+              // producing duplicate bubbles and stuck `isStreaming` flags.
+              // Keep only entries that carry SSE-only state (system messages,
+              // actively-streaming content, tool-calls) or arrived after the
+              // server's snapshot window (race-window protection).
+              const newestHydratedTs = hydrated.reduce(
+                (max, m) => Math.max(max, m.timestamp),
+                Number.NEGATIVE_INFINITY
+              );
+              const clientOnly = prev.filter(m => {
+                if (hydratedIds.has(m.id)) return false;
+                const preserveSseOnly =
+                  m.role === 'system' ||
+                  (m.isStreaming && m.content.length > 0) ||
+                  (m.toolCalls?.length ?? 0) > 0;
+                const newerThanSnapshot = m.timestamp > newestHydratedTs;
+                return preserveSseOnly || newerThanSnapshot;
+              });
               const merged = [...hydrated, ...clientOnly];
               merged.sort((a, b) => a.timestamp - b.timestamp);
               return merged;

--- a/packages/web/src/components/chat/ChatInterface.tsx
+++ b/packages/web/src/components/chat/ChatInterface.tsx
@@ -446,17 +446,21 @@ export function ChatInterface({ conversationId }: ChatInterfaceProps): React.Rea
           .then((rows: MessageResponse[]) => {
             if (rows.length === 0) return;
             const hydrated = rows.map(mapMessageRow);
-            // Preserve client-only system messages (e.g., sync status) when rehydrating
+            // Merge by id rather than replacing the whole list. Anything in the
+            // current React state that the DB snapshot doesn't contain is kept
+            // verbatim — that includes:
+            //   - client-only system messages (sync banners, errors)
+            //   - in-flight tool-call/streaming messages with synthetic
+            //     'msg-{timestamp}' IDs that never collide with DB IDs
+            //   - any messages newer than the server response (race window)
+            // The previous implementation replaced wholesale and only carried
+            // system messages forward, which silently dropped the live state of
+            // long conversations whose tail wasn't in the server's window.
             setMessages(prev => {
-              const systemMessages = prev.filter(m => m.role === 'system');
-              if (systemMessages.length === 0) return hydrated;
-              // Interleave system messages at their original positions by timestamp
-              const merged = [...hydrated];
-              for (const sys of systemMessages) {
-                const insertIdx = merged.findIndex(m => m.timestamp > sys.timestamp);
-                if (insertIdx === -1) merged.push(sys);
-                else merged.splice(insertIdx, 0, sys);
-              }
+              const hydratedIds = new Set(hydrated.map(m => m.id));
+              const clientOnly = prev.filter(m => !hydratedIds.has(m.id));
+              const merged = [...hydrated, ...clientOnly];
+              merged.sort((a, b) => a.timestamp - b.timestamp);
               return merged;
             });
           })


### PR DESCRIPTION
## Summary

- **Problem**: For any conversation with more than 200 persisted messages, the Web UI shows only the **oldest** 200 and silently drops everything newer. Three causes stack: DB query orders ASC + LIMIT, API has no pagination affordance, and the stuck-placeholder recovery in ChatInterface overwrites React state with the server snapshot — losing any client-only or post-snapshot messages.
- **Why it matters**: Long agent conversations (typical for non-trivial tasks) hit this silently — the user just stops seeing recent messages, with no error, no banner, no "load more" hint. Combined with the SSE noise from #1516's chat-tick reset bursts, mid-session recovery could also wipe live state.
- **What changed**: DB query switched to `ORDER BY DESC LIMIT N` then reversed to chronological — `listMessages` now returns the *newest* N in oldest-first order. Stuck-placeholder hydration in `ChatInterface` merges by message id instead of replacing — anything in React state that the snapshot doesn't include (system banners, in-flight tool-calls, post-snapshot SSE messages) survives.
- **What did not change** (scope boundary): The 200/500 server-side limit (followup if pagination is desired), the `ChatInterface` mount-time hydration path (already had a merge-by-id branch and isn't the source of mid-session loss), `getRecentWorkflowResultMessages` (different ordering contract — DESC + early termination, intentionally newest-first).

## UX Journey

### Before

```
Long conversation (>200 messages):
  user opens conversation ─────▶ getMessages(limit=200)
                                  └─▶ DB: ORDER BY ASC LIMIT 200
                                       returns oldest 200
  UI scroll-to-bottom        ◀─  rendered chronologically
                                  (last visible: msg #200, latest is #283)
  user sees                      "the conversation seems to end at the typo
                                   I asked about three days ago, even though
                                   I was just chatting yesterday"

Mid-session SSE recovery (any conversation):
  agent edits, commits, replies        — accumulating in React state
  brief SSE drop or workflow_status:completed
                                  └─▶ stuck-placeholder branch fires
                                       └─▶ getMessages(limit=200) refetch
                                            └─▶ setMessages(_ => hydrated)
  React state replaced with the (older) DB snapshot.
  Live messages and any tool-call/streaming state vanish silently.
```

### After

```
Long conversation (>200 messages):
  user opens conversation ─────▶ getMessages(limit=200)
                                  └─▶ DB: ORDER BY DESC LIMIT 200
                                       returns newest 200,
                                       reversed to chronological by listMessages
  UI scroll-to-bottom        ◀─  rendered chronologically
                                  (last visible: msg #283, the latest)

Mid-session SSE recovery:
  brief SSE drop or workflow_status:completed
                                  └─▶ stuck-placeholder branch fires
                                       └─▶ getMessages(limit=200) refetch
                                            └─▶ merge by id:
                                                  hydrated ∪ (client-only state)
                                                  sort by timestamp
  React state preserved — server's view + everything still in flight.
```

## Architecture Diagram

### Before

```
DB (PG/SQLite)
  └─▶ messages.ts:listMessages         ── ORDER BY ASC LIMIT 200 → oldest 200
       └─▶ api.ts /messages route       ── pass-through
            └─▶ web/api.ts:getMessages
                 └─▶ ChatInterface:
                      ├─ mount fetch         ── prev-empty path returns hydrated
                      └─ stuck-placeholder   ── setMessages(_ => hydrated)   [overwrite]
```

### After

```
DB (PG/SQLite)
  └─▶ messages.ts:listMessages         ── ORDER BY DESC LIMIT 200, reverse(); → newest 200, chronological  [~]
       └─▶ api.ts /messages route       ── pass-through (unchanged)
            └─▶ web/api.ts:getMessages
                 └─▶ ChatInterface:
                      ├─ mount fetch         ── unchanged
                      └─ stuck-placeholder   ── merge-by-id: prev ∪ hydrated, sort by ts   [~]
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `messages.ts:listMessages` | DB query | **modified** | DESC + reverse |
| `messages.ts:listMessages` | callers (api.ts) | unchanged contract | still oldest-first; just newest-N now |
| `ChatInterface:stuck-placeholder` | React state | **modified** | merge by id, sort by ts |
| `ChatInterface:mount-fetch` | React state | unchanged | already had merge-by-id path; not source of bug |
| `getRecentWorkflowResultMessages` | DB | unchanged | different contract, different sort |

## Label Snapshot

- Risk: `risk: low` — DB query change is order/limit only (no schema, no semantics shift); React change is purely additive (anything in DB still gets through).
- Size: `size: S`
- Scope: `core, web`
- Module: `core:db.messages`, `web:chat.ChatInterface`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi`

## Linked Issue

- Closes #1531
- Related #1516 (sync-burst SSE events made the mid-session manifestation observable; this PR fixes the symptom independently of #1516 but they overlap in user-visible behaviour)

## Validation Evidence (required)

```bash
bun run type-check                                      # clean across all 10 packages
bun --filter @archon/core test                          # 815 pass / 0 fail (incl. updated listMessages test fixture)
bun --filter @archon/web test                           # 158 pass / 0 fail
```

Per-commit: lint-staged (eslint --max-warnings 0 + prettier --write) clean on every staged file.

`messages.test.ts` test renamed and updated to assert DESC + reversal explicitly. No other fixtures needed update — the API and UI contracts (oldest-first as caller-visible order) are unchanged.

## Security Impact (required)

- New permissions/capabilities? **No**.
- New external network calls? **No**.
- Secrets/tokens handling changed? **No**.
- File system access scope changed? **No**.
- DB query change is read-only and bound by an integer `limit` argument exactly as before.

## Compatibility / Migration

- Backward compatible? **Yes**. Caller-visible contract of `listMessages` unchanged: returns oldest-first up to `limit` rows. The change is *which* up-to-limit rows are returned (newest N instead of oldest N).
- Config/env changes? **No**.
- Database migration needed? **No**.
- API contract: `GET /api/conversations/:id/messages?limit=N` is unchanged in shape — only the row selection rule differs. Existing client code that doesn't pass `limit` continues to work; for conversations under 200 messages, behaviour is identical.

## Human Verification (required)

- Verified scenarios:
  - `bun run type-check` clean.
  - `messages.test.ts` updated test passes (DESC ordering, reversed result).
  - Manual code-read of `ChatInterface.tsx` merge logic — `hydratedIds` set excludes DB-known ids, `clientOnly` filter retains the rest, sort by timestamp produces the natural chronological output.
- Edge cases checked:
  - Empty `prev` (mount-time): `clientOnly` is empty, merged === hydrated.
  - Empty `hydrated` (very early in fresh conversation): early return preserved (`if (rows.length === 0) return;`).
  - Conflicting ids (very unlikely given synthetic `msg-{ts}` IDs for SSE messages and DB UUIDs for persisted): hydrated wins (in the merged array first, but sort is stable and timestamps decide; the comment in ChatInterface explicitly relies on the `msg-{ts}` vs DB UUID disjunction, which this PR preserves).
- What was not verified: end-to-end UI test in a >200-message conversation reproducing the original symptom and confirming the latest 200 are now visible. Recommend a quick manual once the PR builds — left as a verification step for the reviewer/maintainer if desired.

## Side Effects / Blast Radius (required)

- Affected subsystems: `messages.ts:listMessages` is called only from one server route (`api.ts:/messages`) — verified via grep across `packages/`. The change there is "what subset of rows you get" without changing types or shape. Web `ChatInterface` change is contained to the stuck-placeholder branch.
- Potential unintended effects:
  - `getRecentWorkflowResultMessages` (in the same file) is **not** affected — different query, different ordering contract.
  - Workflow-driven workers using the conversations layer indirectly: they consume messages via different DB helpers; the listMessages change does not alter what they see.
  - Mid-session SSE recovery: previously dropped non-DB state silently — now preserves it. No code that depended on the wholesale-replace behaviour identified.
- Guardrails: existing logging/error paths unchanged.

## Rollback Plan (required)

- Fast rollback: `git revert` the two commits (`a498e788` + `5260d6bd`). One file each on the DB side, one on the UI side; no schema or persistent state to migrate.
- Feature flags: none.
- Observable failure symptoms: pre-PR symptom — long conversations show only oldest 200; SSE recovery wipes mid-session state.

## Risks and Mitigations

- **Risk**: A consumer somewhere expects `listMessages` to return *oldest* N rather than *newest* N (i.e. depends on the prior bug).
  - **Mitigation**: only one caller (`api.ts:/messages` route) consumes the function. The route serves the Web UI's chat-history fetch — newest N is what users would expect. No other consumer searched up via grep.
- **Risk**: Adding pagination later might require revisiting the API surface; this PR doesn't add `?before=<id>`.
  - **Mitigation**: explicitly out of scope here. Pagination is a separate, larger feature; the current change is the minimum to fix the user-visible symptom (latest messages invisible). Documented in the issue.
- **Risk**: ChatInterface merge-by-id depends on the invariant that SSE-only messages use synthetic `msg-{timestamp}` ids that never collide with DB UUIDs. The existing comment at the mount-fetch path explicitly notes this; this PR maintains it.
  - **Mitigation**: noted in the inline comment of the changed block; any future change that breaks the synthetic-id invariant would also break the existing merge logic, so the failure mode is shared, not new.

---

🤖 Investigation, write-up, and implementation produced with extensive back-and-forth using Claude — final code, naming choices, and architectural decisions reviewed and accepted by ztech-gthb.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Messages now consistently display oldest-first chronological order.
  * Improved recovery for stuck/streaming messages so client-only and server-hydrated messages merge correctly.
  * Fixed visibility issues where conversations exceeding the message limit could show the wrong set of messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->