### PR TITLE
fix(orchestrator): parse split workflow invocations

### DIFF
--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -941,6 +941,7 @@ async function handleStreamMode(
   const allMessages: string[] = [];
   let newSessionId: string | undefined;
   let commandDetected = false;
+  let commandResponseSnapshot: string | undefined;
 
   for await (const msg of aiClient.sendQuery(
     fullPrompt,
@@ -949,16 +950,22 @@ async function handleStreamMode(
     requestOptions
   )) {
     if (msg.type === 'assistant' && msg.content) {
+      allMessages.push(msg.content);
+      const accumulated = allMessages.join('');
+      const hasOrchestratorCommand =
+        /^\/invoke-workflow\s/m.test(accumulated) || /^\/register-project\s/m.test(accumulated);
+      if (hasOrchestratorCommand) {
+        const parsedCommands = parseOrchestratorCommands(accumulated, codebases, workflows);
+        if (parsedCommands.workflowInvocation || parsedCommands.projectRegistration) {
+          commandResponseSnapshot = accumulated;
+        }
+      }
       if (!commandDetected) {
-        allMessages.push(msg.content);
-        const accumulated = allMessages.join('');
         // Check for orchestrator commands BEFORE streaming to frontend.
-        // If detected, suppress this chunk and all future chunks — the full
-        // response will be parsed post-loop and the command dispatched there.
-        if (
-          /^\/invoke-workflow\s/m.test(accumulated) ||
-          /^\/register-project\s/m.test(accumulated)
-        ) {
+        // If detected, suppress this chunk and future chunks from the UI, but
+        // keep accumulating assistant text so providers that split after
+        // "/invoke-workflow " still produce a parseable final command.
+        if (hasOrchestratorCommand) {
           commandDetected = true;
         } else {
           await platform.sendMessage(conversationId, msg.content);
@@ -1027,7 +1034,7 @@ async function handleStreamMode(
     return;
   }
 
-  const fullResponse = allMessages.join('');
+  const fullResponse = commandResponseSnapshot ?? allMessages.join('');
   const commands = parseOrchestratorCommands(fullResponse, codebases, workflows);
 
   if (commands.workflowInvocation) {
@@ -1092,6 +1099,7 @@ async function handleBatchMode(
   let totalChunksTruncated = false;
   let newSessionId: string | undefined;
   let commandDetected = false;
+  let commandResponseSnapshot: string | undefined;
 
   for await (const msg of aiClient.sendQuery(
     fullPrompt,
@@ -1100,19 +1108,24 @@ async function handleBatchMode(
     requestOptions
   )) {
     if (msg.type === 'assistant' && msg.content) {
+      assistantMessages.push(msg.content);
+      const accumulated = assistantMessages.join('');
+      const hasOrchestratorCommand =
+        /^\/invoke-workflow\s/m.test(accumulated) || /^\/register-project\s/m.test(accumulated);
+      if (hasOrchestratorCommand) {
+        const parsedCommands = parseOrchestratorCommands(accumulated, codebases, workflows);
+        if (parsedCommands.workflowInvocation || parsedCommands.projectRegistration) {
+          commandResponseSnapshot = accumulated;
+        }
+      }
       if (!commandDetected) {
-        assistantMessages.push(msg.content);
         allChunks.push({ type: 'assistant', content: msg.content });
 
         if (assistantMessages.length > MAX_BATCH_ASSISTANT_CHUNKS) {
           assistantMessages.shift();
           assistantChunksTruncated = true;
         }
-        const accumulated = assistantMessages.join('');
-        if (
-          /^\/invoke-workflow\s/m.test(accumulated) ||
-          /^\/register-project\s/m.test(accumulated)
-        ) {
+        if (hasOrchestratorCommand) {
           commandDetected = true;
         }
       }
@@ -1185,8 +1198,11 @@ async function handleBatchMode(
     'batch_mode_chunks_received'
   );
 
-  // Filter tool indicators and build final message
-  const finalMessage = filterToolIndicators(assistantMessages);
+  // Filter tool indicators for normal prose. For orchestrator commands, parse
+  // the raw stream text; batch-mode separators would corrupt split commands.
+  const finalMessage = commandDetected
+    ? (commandResponseSnapshot ?? assistantMessages.join(''))
+    : filterToolIndicators(assistantMessages);
 
   if (!finalMessage) {
     getLog().debug({ conversationId }, 'no_ai_response');

--- a/packages/core/src/orchestrator/orchestrator.test.ts
+++ b/packages/core/src/orchestrator/orchestrator.test.ts
@@ -924,6 +924,29 @@ describe('orchestrator-agent handleMessage', () => {
       // Workflow is still dispatched
       expect(mockValidateAndResolveIsolation).toHaveBeenCalled();
     });
+
+    test('dispatches workflow when command body arrives after /invoke-workflow detection', async () => {
+      mockListCodebases.mockResolvedValue([mockCodebase]);
+      mockDiscoverWorkflows.mockResolvedValue({ workflows: testWorkflows, errors: [] });
+      mockFindWorkflow.mockImplementation(
+        (name: string, workflows: readonly WorkflowDefinition[]) =>
+          workflows.find(w => w.name === name)
+      );
+
+      mockClient.sendQuery.mockImplementation(async function* () {
+        yield { type: 'assistant', content: '/invoke-workflow ' };
+        yield { type: 'assistant', content: 'fix-bug ' };
+        yield { type: 'assistant', content: '--project test-project' };
+        yield { type: 'result', sessionId: 'session-id' };
+      });
+
+      await handleMessage(platform, 'chat-456', 'fix the bug');
+
+      expect(platform.sendMessage).not.toHaveBeenCalledWith('chat-456', '/invoke-workflow ');
+      expect(platform.sendMessage).not.toHaveBeenCalledWith('chat-456', 'fix-bug ');
+      expect(platform.sendMessage).not.toHaveBeenCalledWith('chat-456', '--project test-project');
+      expect(mockValidateAndResolveIsolation).toHaveBeenCalled();
+    });
   });
 
   // ─── Batch Mode ────────────────────────────────────────────────────────
@@ -1057,6 +1080,24 @@ describe('orchestrator-agent handleMessage', () => {
       await handleMessage(platform, 'chat-456', 'fix the bug');
 
       expect(mockValidateAndResolveIsolation).toHaveBeenCalled();
+    });
+
+    test('batch mode dispatches workflow when command body arrives after detection', async () => {
+      platform.getStreamingMode.mockReturnValue('batch');
+      mockClient.sendQuery.mockImplementation(async function* () {
+        yield { type: 'assistant', content: '/invoke-workflow ' };
+        yield { type: 'assistant', content: 'fix-bug ' };
+        yield { type: 'assistant', content: '--project test-project' };
+        yield { type: 'result', sessionId: 'session-id' };
+      });
+
+      await handleMessage(platform, 'chat-456', 'fix the bug');
+
+      expect(mockValidateAndResolveIsolation).toHaveBeenCalled();
+      expect(platform.sendMessage).not.toHaveBeenCalledWith(
+        'chat-456',
+        expect.stringContaining('/invoke-workflow')
+      );
     });
 
     test('passes synthesizedPrompt to workflow dispatch instead of original message', async () => {

--- a/packages/core/src/orchestrator/orchestrator.test.ts
+++ b/packages/core/src/orchestrator/orchestrator.test.ts
@@ -934,6 +934,32 @@ describe('orchestrator-agent handleMessage', () => {
       // Workflow is still dispatched
       expect(mockValidateAndResolveIsolation).toHaveBeenCalled();
     });
+
+    test('dispatches workflow when command body arrives after /invoke-workflow detection', async () => {
+      mockListCodebases.mockResolvedValue([mockCodebase]);
+      mockDiscoverWorkflows.mockResolvedValue({ workflows: testWorkflows, errors: [] });
+      mockFindWorkflow.mockImplementation(
+        (name: string, workflows: readonly WorkflowDefinition[]) =>
+          workflows.find(w => w.name === name)
+      );
+
+      mockClient.sendQuery.mockImplementation(async function* () {
+        yield { type: 'assistant', content: '/invoke-workflow ' };
+        yield { type: 'assistant', content: 'fix-bug ' };
+        yield { type: 'assistant', content: '--project test-project' };
+        yield { type: 'result', sessionId: 'session-id' };
+      });
+
+      await handleMessage(platform, 'chat-456', 'fix the bug');
+
+      expect(
+        platform.sendMessage.mock.calls.some(
+          ([id, content]) =>
+            id === 'chat-456' && typeof content === 'string' && content.includes('/invoke-workflow')
+        )
+      ).toBe(false);
+      expect(mockValidateAndResolveIsolation).toHaveBeenCalled();
+    });
   });
 
   // ─── Batch Mode ────────────────────────────────────────────────────────
@@ -1067,6 +1093,26 @@ describe('orchestrator-agent handleMessage', () => {
       await handleMessage(platform, 'chat-456', 'fix the bug');
 
       expect(mockValidateAndResolveIsolation).toHaveBeenCalled();
+    });
+
+    test('batch mode dispatches workflow when command body arrives after detection', async () => {
+      platform.getStreamingMode.mockReturnValue('batch');
+      mockClient.sendQuery.mockImplementation(async function* () {
+        yield { type: 'assistant', content: '/invoke-workflow ' };
+        yield { type: 'assistant', content: 'fix-bug ' };
+        yield { type: 'assistant', content: '--project test-project' };
+        yield { type: 'result', sessionId: 'session-id' };
+      });
+
+      await handleMessage(platform, 'chat-456', 'fix the bug');
+
+      expect(mockValidateAndResolveIsolation).toHaveBeenCalled();
+      expect(
+        platform.sendMessage.mock.calls.some(
+          ([id, content]) =>
+            id === 'chat-456' && typeof content === 'string' && content.includes('/invoke-workflow')
+        )
+      ).toBe(false);
     });
 
     test('passes synthesizedPrompt to workflow dispatch instead of original message', async () => {


### PR DESCRIPTION
## Summary

- Problem: Some providers can emit `/invoke-workflow` across multiple assistant chunks, so Archon detects the command prefix before the full command body has arrived.
- Why it matters: The web orchestrator can acknowledge a workflow dispatch in chat while never actually running the workflow.
- What changed: The orchestrator now keeps collecting command chunks after detection, suppresses command text from user-visible output, preserves the latest parseable command snapshot, and parses raw batch output instead of formatted prose.
- What did **not** change (scope boundary): This does not change workflow routing semantics, workflow execution, provider APIs, command syntax, or any Web UI behavior outside orchestrator command parsing.

## UX Journey

### Before

```text
User                   Archon Web Chat                AI Provider
────                   ───────────────                ───────────
sends request ──────▶  sends prompt to provider ────▶ streams response
                       detects "/invoke-workflow"
                       stops collecting command body
sees assistant text ◀  may render acknowledgement
                       workflow dispatch parse fails or is incomplete
                       workflow does not run
```

### After

```text
User                   Archon Web Chat                      AI Provider
────                   ───────────────                      ───────────
sends request ──────▶  sends prompt to provider ─────────▶ streams response
                       detects "/invoke-workflow"
                       [continues collecting command chunks]
                       [suppresses command text from chat output]
                       [parses latest valid command snapshot]
sees dispatch state ◀  invokes requested workflow
```

## Architecture Diagram

### Before

```text
packages/core/src/orchestrator/orchestrator-agent.ts
  ├─ handleStreamMode()
  │   └─ command prefix detection stopped useful accumulation too early
  └─ handleBatchMode()
      └─ parsed formatted assistant output, including non-command text

packages/core/src/orchestrator/orchestrator.test.ts
  └─ covered normal command dispatch, but not split command bodies
```

### After

```text
[~] packages/core/src/orchestrator/orchestrator-agent.ts
  ├─ handleStreamMode()
  │   === accumulates command response after prefix detection
  │   === tracks latest parseable command snapshot
  │   === suppresses command chunks from UI text
  └─ handleBatchMode()
      === parses raw concatenated assistant content for commands

[~] packages/core/src/orchestrator/orchestrator.test.ts
  └─ adds regression coverage for split stream and batch command dispatch
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| AI provider stream chunks | `handleStreamMode()` | **modified** | Command chunks continue accumulating after prefix detection. |
| AI provider batch output | `handleBatchMode()` | **modified** | Raw assistant text is used for command parsing. |
| Orchestrator command parser | Workflow dispatch path | unchanged | Existing command parser and dispatch contract are preserved. |
| Orchestrator tests | Split command behavior | **new** | Adds regression tests for stream and batch modes. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core|tests`
- Module: `core:orchestrator`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Fixes #1541
- Related #1541
- Depends on # none
- Supersedes # none

## Validation Evidence (required)

Commands and result summary:

```bash
bun test packages/core/src/orchestrator/orchestrator.test.ts
# Result: 70 pass, 0 fail

bun test packages/core/src/orchestrator/orchestrator-agent.test.ts
# Result: 100 pass, 0 fail
```

- Evidence provided (test/log/trace/screenshot): Targeted unit test results for orchestrator dispatch and agent behavior.
- If any command is intentionally skipped, explain why: Full validation was not run for this narrow fix. Running both orchestrator test files in one Bun invocation exposed pre-existing mock-state leakage in unrelated logger assertion tests; both files pass independently.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation: Not applicable.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: Not applicable.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Split `/invoke-workflow` command chunks are parsed in stream mode; split command text is parsed in batch mode; trailing non-command text does not corrupt the preserved command snapshot.
- Edge cases checked: Command detection before complete command body, command text suppression from user-visible output, batch parsing from raw assistant text.
- What was not verified: Browser-level manual workflow launch through the Web UI was not re-run for this PR body update.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Core orchestrator command dispatch for `/invoke-workflow` and `/register-project` detection paths.
- Potential unintended effects: Assistant messages containing command-looking text could be suppressed once command dispatch is detected.
- Guardrails/monitoring for early detection: Existing command dispatch tests plus new split-command regressions should catch parsing regressions.

## Rollback Plan (required)

- Fast rollback command/path: Revert this PR commit.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: Workflow dispatch no longer starts from AI-generated `/invoke-workflow` output, or command text appears unexpectedly in chat output.

## Risks and Mitigations

- Risk: Providers may emit additional natural language after a command.
  - Mitigation: The implementation preserves the latest parseable command snapshot so trailing prose does not corrupt dispatch.
- Risk: Command chunks could leak into chat output.
  - Mitigation: Command chunks are suppressed once command detection begins.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for stream and batch mode scenarios to ensure workflow isolation validation executes correctly while preventing unintended message propagation during command processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1542?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->