### PR TITLE
feat: add live vs backtest parity enforcer module

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,7 +43,7 @@ export default tseslint.config(
 
   // Project-specific settings
   {
-    files: ['packages/*/src/**/*.{ts,tsx}', 'scripts/**/*.ts'],
+    files: ['packages/*/src/**/*.{ts,tsx}', 'scripts/**/*.ts', 'src/**/*.ts'],
     languageOptions: {
       parserOptions: {
         projectService: true,

--- a/src/parity-enforcer/__tests__/auto-responder.test.ts
+++ b/src/parity-enforcer/__tests__/auto-responder.test.ts
@@ -104,4 +104,48 @@ describe('AutoResponder', () => {
     responder.resetHalt();
     expect(responder.isHalted()).toBe(false);
   });
+
+  it('halt() sets halted state without invoking handler', () => {
+    let handlerCalled = false;
+    const responder = new AutoResponder(defaultActions, () => {
+      handlerCalled = true;
+    });
+
+    responder.halt();
+    expect(responder.isHalted()).toBe(true);
+    expect(handlerCalled).toBe(false);
+  });
+
+  it('calls onError handler when action handler throws', async () => {
+    const handlerError = new Error('handler broke');
+    let receivedError: unknown = null;
+    let receivedAction: DriftAction | null = null;
+
+    const responder = new AutoResponder(defaultActions, () => {
+      throw handlerError;
+    });
+    responder.onError((error, action) => {
+      receivedError = error;
+      receivedAction = action;
+    });
+
+    const report = makeDriftReport('LOW');
+    await responder.respond('LOW', report);
+
+    expect(receivedError).toBe(handlerError);
+    expect(receivedAction).toBe('alert');
+  });
+
+  it('does not crash when onError handler itself throws', async () => {
+    const responder = new AutoResponder(defaultActions, () => {
+      throw new Error('handler error');
+    });
+    responder.onError(() => {
+      throw new Error('error handler also broken');
+    });
+
+    const report = makeDriftReport('LOW');
+    const action = await responder.respond('LOW', report);
+    expect(action).toBe('alert');
+  });
 });

--- a/src/parity-enforcer/__tests__/auto-responder.test.ts
+++ b/src/parity-enforcer/__tests__/auto-responder.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'bun:test';
+import { AutoResponder } from '../auto-responder';
+import type { ActionConfig, DriftAction, DriftReport, Severity, Timestamp } from '../types';
+
+const defaultActions: ActionConfig = {
+  LOW: 'alert',
+  MEDIUM: 'reduce_position',
+  HIGH: 'stop_trading',
+};
+
+function makeDriftReport(severity: Severity): DriftReport {
+  return {
+    drift: true,
+    severity,
+    reason: 'test',
+    actionTaken: 'none',
+    timestamp: Date.now() as Timestamp,
+    tradeComparisons: [],
+    rollingMetrics: null,
+    flags: [],
+  };
+}
+
+describe('AutoResponder', () => {
+  it('maps LOW severity to alert', () => {
+    const responder = new AutoResponder(defaultActions);
+    expect(responder.getAction('LOW')).toBe('alert');
+  });
+
+  it('maps MEDIUM severity to reduce_position', () => {
+    const responder = new AutoResponder(defaultActions);
+    expect(responder.getAction('MEDIUM')).toBe('reduce_position');
+  });
+
+  it('maps HIGH severity to stop_trading', () => {
+    const responder = new AutoResponder(defaultActions);
+    expect(responder.getAction('HIGH')).toBe('stop_trading');
+  });
+
+  it('calls handler with correct arguments', async () => {
+    let receivedAction: DriftAction | null = null;
+    let receivedReport: DriftReport | null = null;
+
+    const responder = new AutoResponder(defaultActions, (action, report) => {
+      receivedAction = action;
+      receivedReport = report;
+    });
+
+    const report = makeDriftReport('MEDIUM');
+    await responder.respond('MEDIUM', report);
+
+    expect(receivedAction).not.toBeNull();
+    expect(receivedAction!).toBe('reduce_position');
+    expect(receivedReport).not.toBeNull();
+    expect(receivedReport!).toEqual(report);
+  });
+
+  it('does not crash when handler throws', async () => {
+    const responder = new AutoResponder(defaultActions, () => {
+      throw new Error('handler error');
+    });
+
+    const report = makeDriftReport('LOW');
+    const action = await responder.respond('LOW', report);
+    expect(action).toBe('alert');
+  });
+
+  it('works without a handler', async () => {
+    const responder = new AutoResponder(defaultActions);
+    const report = makeDriftReport('MEDIUM');
+    const action = await responder.respond('MEDIUM', report);
+    expect(action).toBe('reduce_position');
+  });
+
+  it('sets halted state on stop_trading', async () => {
+    const responder = new AutoResponder(defaultActions);
+    expect(responder.isHalted()).toBe(false);
+
+    const report = makeDriftReport('HIGH');
+    await responder.respond('HIGH', report);
+
+    expect(responder.isHalted()).toBe(true);
+  });
+
+  it('allows setting handler after construction', async () => {
+    const responder = new AutoResponder(defaultActions);
+    let called = false;
+
+    responder.onAction(() => {
+      called = true;
+    });
+
+    const report = makeDriftReport('LOW');
+    await responder.respond('LOW', report);
+    expect(called).toBe(true);
+  });
+
+  it('resetHalt clears halted state', async () => {
+    const responder = new AutoResponder(defaultActions);
+    const report = makeDriftReport('HIGH');
+    await responder.respond('HIGH', report);
+    expect(responder.isHalted()).toBe(true);
+
+    responder.resetHalt();
+    expect(responder.isHalted()).toBe(false);
+  });
+});

--- a/src/parity-enforcer/__tests__/comparison-engine.test.ts
+++ b/src/parity-enforcer/__tests__/comparison-engine.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'bun:test';
+import { compareTrade, compareTrades } from '../comparison-engine';
+import { createTrade } from './helpers';
+
+describe('compareTrade', () => {
+  it('returns zero deviations for identical trades', () => {
+    const trade = createTrade({ entryPrice: 100, exitPrice: 110, pnl: 10, quantity: 1 });
+    const result = compareTrade(trade, trade);
+
+    expect(result.entryDeviation).toBe(0);
+    expect(result.entryDeviationPct).toBe(0);
+    expect(result.exitDeviation).toBe(0);
+    expect(result.exitDeviationPct).toBe(0);
+    expect(result.pnlDiff).toBe(0);
+    expect(result.pnlDiffPct).toBe(0);
+  });
+
+  it('computes correct entry deviation', () => {
+    const expected = createTrade({ entryPrice: 100, exitPrice: 110, pnl: 10, quantity: 1 });
+    const actual = createTrade({ entryPrice: 100.5, exitPrice: 110, pnl: 9.5, quantity: 1 });
+    const result = compareTrade(expected, actual);
+
+    expect(result.entryDeviation).toBeCloseTo(0.5, 5);
+    expect(result.entryDeviationPct).toBeCloseTo(0.005, 5);
+  });
+
+  it('computes correct PnL deviation', () => {
+    const expected = createTrade({ pnl: 1000 });
+    const actual = createTrade({ pnl: 900 });
+    const result = compareTrade(expected, actual);
+
+    expect(result.pnlDiff).toBe(-100);
+    expect(result.pnlDiffPct).toBeCloseTo(-0.1, 5);
+  });
+
+  it('handles expected PnL = 0 with actual != 0', () => {
+    const expected = createTrade({ pnl: 0 });
+    const actual = createTrade({ pnl: 50 });
+    const result = compareTrade(expected, actual);
+
+    expect(result.pnlDiffPct).toBe(Infinity);
+  });
+
+  it('handles expected PnL = 0 and actual = 0', () => {
+    const expected = createTrade({ pnl: 0 });
+    const actual = createTrade({ pnl: 0 });
+    const result = compareTrade(expected, actual);
+
+    expect(result.pnlDiffPct).toBe(0);
+  });
+
+  it('computes slippage diff', () => {
+    const expected = createTrade({ entryPrice: 100, exitPrice: 105, quantity: 2 });
+    const actual = createTrade({ entryPrice: 100, exitPrice: 106, quantity: 2 });
+    const result = compareTrade(expected, actual);
+
+    // Expected slippage: |105-100|*2 = 10, Actual slippage: |106-100|*2 = 12
+    expect(result.slippageDiff).toBeCloseTo(2, 5);
+  });
+
+  it('handles negative PnL trades', () => {
+    const expected = createTrade({ pnl: -500 });
+    const actual = createTrade({ pnl: -700 });
+    const result = compareTrade(expected, actual);
+
+    expect(result.pnlDiff).toBe(-200);
+    expect(result.pnlDiffPct).toBeCloseTo(-0.4, 5);
+  });
+
+  it('returns empty flags array', () => {
+    const trade = createTrade();
+    const result = compareTrade(trade, trade);
+    expect(result.flags).toEqual([]);
+  });
+});
+
+describe('compareTrades', () => {
+  it('handles batch comparison', () => {
+    const pairs = [
+      { expected: createTrade({ pnl: 100 }), actual: createTrade({ pnl: 90 }) },
+      { expected: createTrade({ pnl: 200 }), actual: createTrade({ pnl: 180 }) },
+    ];
+
+    const results = compareTrades(pairs);
+    expect(results).toHaveLength(2);
+    expect(results[0].pnlDiff).toBe(-10);
+    expect(results[1].pnlDiff).toBe(-20);
+  });
+});

--- a/src/parity-enforcer/__tests__/config.test.ts
+++ b/src/parity-enforcer/__tests__/config.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'bun:test';
+import { validateConfig, createDefaultConfig, mergeConfig } from '../config';
+import { ThresholdConfigError } from '../types';
+
+describe('validateConfig', () => {
+  it('returns valid config with defaults when no overrides', () => {
+    const config = validateConfig({});
+    const defaults = createDefaultConfig();
+    expect(config).toEqual(defaults);
+  });
+
+  it('rejects zero threshold value', () => {
+    expect(() =>
+      validateConfig({ thresholds: { ...createDefaultConfig().thresholds, priceDeviationPct: 0 } })
+    ).toThrow(ThresholdConfigError);
+  });
+
+  it('rejects negative threshold value', () => {
+    expect(() =>
+      validateConfig({ thresholds: { ...createDefaultConfig().thresholds, pnlDeviationPct: -0.5 } })
+    ).toThrow(ThresholdConfigError);
+  });
+
+  it('rejects each invalid threshold field individually', () => {
+    const fields = [
+      'priceDeviationPct',
+      'pnlDeviationPct',
+      'winrateDriftPct',
+      'sharpeDriftThreshold',
+      'drawdownDriftPct',
+      'frequencyDriftPct',
+    ] as const;
+
+    for (const field of fields) {
+      expect(() =>
+        validateConfig({ thresholds: { ...createDefaultConfig().thresholds, [field]: -1 } })
+      ).toThrow(ThresholdConfigError);
+    }
+  });
+
+  it('includes field name and value in error message', () => {
+    try {
+      validateConfig({
+        thresholds: { ...createDefaultConfig().thresholds, priceDeviationPct: -0.01 },
+      });
+      expect.unreachable('should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ThresholdConfigError);
+      expect((error as ThresholdConfigError).message).toContain('priceDeviationPct');
+      expect((error as ThresholdConfigError).message).toContain('-0.01');
+    }
+  });
+});
+
+describe('mergeConfig', () => {
+  it('preserves base values when no overrides given', () => {
+    const base = createDefaultConfig();
+    const merged = mergeConfig(base, {});
+    expect(merged).toEqual(base);
+  });
+
+  it('overrides only specified fields', () => {
+    const base = createDefaultConfig();
+    const merged = mergeConfig(base, { rollingWindowSize: 100 });
+    expect(merged.rollingWindowSize).toBe(100);
+    expect(merged.thresholds).toEqual(base.thresholds);
+    expect(merged.actions).toEqual(base.actions);
+  });
+});

--- a/src/parity-enforcer/__tests__/enforcer.test.ts
+++ b/src/parity-enforcer/__tests__/enforcer.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { ParityEnforcer } from '../enforcer';
+import { createTrade, createTestConfig, resetIdCounter } from './helpers';
+import type { DriftReport, Timestamp } from '../types';
+
+describe('ParityEnforcer', () => {
+  let enforcer: ParityEnforcer;
+
+  beforeEach(() => {
+    resetIdCounter();
+    enforcer = new ParityEnforcer(createTestConfig());
+  });
+
+  it('returns null when no match found', () => {
+    const trade = createTrade({ symbol: 'BTC/USD' });
+    const result = enforcer.addActualTrade(trade);
+    expect(result).toBeNull();
+  });
+
+  it('returns a DriftReport when a match is found', () => {
+    const now = Date.now() as Timestamp;
+    const expected = createTrade({ symbol: 'BTC/USD', entryTime: now as Timestamp });
+    const actual = createTrade({ symbol: 'BTC/USD', entryTime: (now + 1000) as Timestamp });
+
+    enforcer.addExpectedTrade(expected);
+    const report = enforcer.addActualTrade(actual);
+
+    expect(report).not.toBeNull();
+    expect(report!.tradeComparisons).toHaveLength(1);
+  });
+
+  it('reports no drift for identical trades', () => {
+    const now = Date.now() as Timestamp;
+    const trade = createTrade({
+      symbol: 'BTC/USD',
+      entryTime: now as Timestamp,
+      entryPrice: 100,
+      exitPrice: 110,
+      pnl: 10,
+      quantity: 1,
+    });
+
+    enforcer.addExpectedTrade(trade);
+    // Same trade data, different ID for actual
+    const actual = createTrade({
+      symbol: 'BTC/USD',
+      entryTime: (now + 100) as Timestamp,
+      entryPrice: 100,
+      exitPrice: 110,
+      pnl: 10,
+      quantity: 1,
+    });
+    const report = enforcer.addActualTrade(actual);
+
+    expect(report).not.toBeNull();
+    expect(report!.drift).toBe(false);
+    expect(report!.actionTaken).toBe('none');
+  });
+
+  it('detects drift and triggers auto-response', () => {
+    const now = Date.now() as Timestamp;
+    // Big PnL deviation → HIGH → stop_trading
+    const expected = createTrade({
+      symbol: 'BTC/USD',
+      entryTime: now as Timestamp,
+      pnl: 1000,
+    });
+    const actual = createTrade({
+      symbol: 'BTC/USD',
+      entryTime: (now + 1000) as Timestamp,
+      pnl: 500, // 50% PnL deviation, way above 2% threshold
+    });
+
+    enforcer.addExpectedTrade(expected);
+    const report = enforcer.addActualTrade(actual);
+
+    expect(report).not.toBeNull();
+    expect(report!.drift).toBe(true);
+    expect(report!.severity).toBe('HIGH');
+    expect(report!.actionTaken).toBe('stop_trading');
+  });
+
+  it('halts after stop_trading is triggered', () => {
+    const now = Date.now() as Timestamp;
+    const expected = createTrade({ symbol: 'BTC/USD', entryTime: now as Timestamp, pnl: 1000 });
+    const actual = createTrade({
+      symbol: 'BTC/USD',
+      entryTime: (now + 1000) as Timestamp,
+      pnl: 500,
+    });
+
+    enforcer.addExpectedTrade(expected);
+    enforcer.addActualTrade(actual);
+
+    expect(enforcer.isHalted()).toBe(true);
+
+    // New trades after halt
+    const newTrade = createTrade({ symbol: 'BTC/USD', entryTime: (now + 5000) as Timestamp });
+    const haltedReport = enforcer.addActualTrade(newTrade);
+
+    expect(haltedReport).not.toBeNull();
+    expect(haltedReport!.severity).toBe('HIGH');
+    expect(haltedReport!.reason).toContain('halted');
+  });
+
+  it('reset clears halted state and trade data', () => {
+    const now = Date.now() as Timestamp;
+    const expected = createTrade({ symbol: 'BTC/USD', entryTime: now as Timestamp, pnl: 1000 });
+    const actual = createTrade({
+      symbol: 'BTC/USD',
+      entryTime: (now + 1000) as Timestamp,
+      pnl: 500,
+    });
+
+    enforcer.addExpectedTrade(expected);
+    enforcer.addActualTrade(actual);
+    expect(enforcer.isHalted()).toBe(true);
+
+    enforcer.reset();
+    expect(enforcer.isHalted()).toBe(false);
+  });
+
+  it('config can be updated at runtime', () => {
+    const original = enforcer.getConfig();
+    enforcer.updateConfig({ rollingWindowSize: 100 });
+    expect(enforcer.getConfig().rollingWindowSize).toBe(100);
+    expect(enforcer.getConfig().thresholds).toEqual(original.thresholds);
+  });
+
+  it('returns null metrics when window not full', () => {
+    expect(enforcer.getMetrics()).toBeNull();
+  });
+
+  it('calls onDrift listener when drift detected', () => {
+    let receivedReport: DriftReport | null = null;
+    enforcer.onDrift(report => {
+      receivedReport = report;
+    });
+
+    const now = Date.now() as Timestamp;
+    const expected = createTrade({ symbol: 'BTC/USD', entryTime: now as Timestamp, pnl: 1000 });
+    const actual = createTrade({
+      symbol: 'BTC/USD',
+      entryTime: (now + 1000) as Timestamp,
+      pnl: 500,
+    });
+
+    enforcer.addExpectedTrade(expected);
+    enforcer.addActualTrade(actual);
+
+    expect(receivedReport).not.toBeNull();
+    expect(receivedReport!.drift).toBe(true);
+  });
+
+  it('calls onAction handler when drift triggers response', async () => {
+    let actionCalled = false;
+    enforcer.onAction(() => {
+      actionCalled = true;
+    });
+
+    const now = Date.now() as Timestamp;
+    const expected = createTrade({ symbol: 'BTC/USD', entryTime: now as Timestamp, pnl: 1000 });
+    const actual = createTrade({
+      symbol: 'BTC/USD',
+      entryTime: (now + 1000) as Timestamp,
+      pnl: 500,
+    });
+
+    enforcer.addExpectedTrade(expected);
+    enforcer.addActualTrade(actual);
+
+    // Allow async handler to fire
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(actionCalled).toBe(true);
+  });
+
+  it('check() returns no-drift report when no new matches', () => {
+    const report = enforcer.check();
+    expect(report.drift).toBe(false);
+    expect(report.actionTaken).toBe('none');
+  });
+});

--- a/src/parity-enforcer/__tests__/enforcer.test.ts
+++ b/src/parity-enforcer/__tests__/enforcer.test.ts
@@ -179,4 +179,49 @@ describe('ParityEnforcer', () => {
     expect(report.drift).toBe(false);
     expect(report.actionTaken).toBe('none');
   });
+
+  it('calls onError handler when action handler throws', async () => {
+    let errorReceived = false;
+    enforcer.onAction(() => {
+      throw new Error('action failed');
+    });
+    enforcer.onError(() => {
+      errorReceived = true;
+    });
+
+    const now = Date.now() as Timestamp;
+    const expected = createTrade({ symbol: 'BTC/USD', entryTime: now as Timestamp, pnl: 1000 });
+    const actual = createTrade({
+      symbol: 'BTC/USD',
+      entryTime: (now + 1000) as Timestamp,
+      pnl: 500,
+    });
+
+    enforcer.addExpectedTrade(expected);
+    enforcer.addActualTrade(actual);
+
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(errorReceived).toBe(true);
+  });
+
+  it('fires action handler exactly once per drift event', async () => {
+    let callCount = 0;
+    enforcer.onAction(() => {
+      callCount++;
+    });
+
+    const now = Date.now() as Timestamp;
+    const expected = createTrade({ symbol: 'BTC/USD', entryTime: now as Timestamp, pnl: 1000 });
+    const actual = createTrade({
+      symbol: 'BTC/USD',
+      entryTime: (now + 1000) as Timestamp,
+      pnl: 500,
+    });
+
+    enforcer.addExpectedTrade(expected);
+    enforcer.addActualTrade(actual);
+
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(callCount).toBe(1);
+  });
 });

--- a/src/parity-enforcer/__tests__/helpers.ts
+++ b/src/parity-enforcer/__tests__/helpers.ts
@@ -1,0 +1,116 @@
+import type { Trade, TradeId, EnforcerConfig } from '../types';
+import { createDefaultConfig, mergeConfig } from '../config';
+
+let idCounter = 0;
+
+function nextId(): TradeId {
+  return `trade-${++idCounter}` as TradeId;
+}
+
+export function resetIdCounter(): void {
+  idCounter = 0;
+}
+
+export function createTrade(overrides?: Partial<Trade>): Trade {
+  const now = Date.now();
+  return {
+    id: nextId(),
+    symbol: 'BTC/USD',
+    side: 'long',
+    entryPrice: 50000,
+    exitPrice: 51000,
+    entryTime: now,
+    exitTime: now + 3600_000,
+    quantity: 1,
+    pnl: 1000,
+    ...overrides,
+  } as Trade;
+}
+
+export function createTradePair(opts?: {
+  symbol?: string;
+  entryDeviation?: number;
+  pnlDeviation?: number;
+  timeOffset?: number;
+}): { expected: Trade; actual: Trade } {
+  const { symbol = 'BTC/USD', entryDeviation = 0, pnlDeviation = 0, timeOffset = 0 } = opts ?? {};
+
+  const now = Date.now();
+  const basePrice = 50000;
+  const basePnl = 1000;
+
+  const expected = createTrade({
+    symbol,
+    entryPrice: basePrice,
+    exitPrice: basePrice + basePnl,
+    entryTime: now,
+    pnl: basePnl,
+  });
+
+  const actual = createTrade({
+    symbol,
+    entryPrice: basePrice + entryDeviation,
+    exitPrice: basePrice + basePnl + entryDeviation,
+    entryTime: now + timeOffset,
+    pnl: basePnl + pnlDeviation,
+  });
+
+  return { expected, actual };
+}
+
+export function createTradeSeries(
+  count: number,
+  opts?: {
+    basePrice?: number;
+    driftAfter?: number;
+    driftMagnitude?: number;
+  }
+): { expected: Trade; actual: Trade }[] {
+  const { basePrice = 50000, driftAfter = count, driftMagnitude = 0 } = opts ?? {};
+  const pairs: { expected: Trade; actual: Trade }[] = [];
+  const baseTime = Date.now();
+
+  for (let i = 0; i < count; i++) {
+    const isDrifted = i >= driftAfter;
+    const entryTime = baseTime + i * 60_000;
+    const pnl = (i % 3 === 0 ? -100 : 200) + (isDrifted ? -driftMagnitude : 0);
+
+    const expected = createTrade({
+      symbol: 'BTC/USD',
+      entryPrice: basePrice + i * 10,
+      exitPrice: basePrice + i * 10 + (i % 3 === 0 ? -100 : 200),
+      entryTime,
+      exitTime: entryTime + 3600_000,
+      pnl: i % 3 === 0 ? -100 : 200,
+    });
+
+    const actual = createTrade({
+      symbol: 'BTC/USD',
+      entryPrice: basePrice + i * 10 + (isDrifted ? driftMagnitude * 0.01 : 0),
+      exitPrice: basePrice + i * 10 + (i % 3 === 0 ? -100 : 200),
+      entryTime: entryTime + 1000,
+      exitTime: entryTime + 3600_000 + 1000,
+      pnl,
+    });
+
+    pairs.push({ expected, actual });
+  }
+
+  return pairs;
+}
+
+export function createTestConfig(overrides?: Partial<EnforcerConfig>): EnforcerConfig {
+  const tighter: Partial<EnforcerConfig> = {
+    thresholds: {
+      priceDeviationPct: 0.001,
+      pnlDeviationPct: 0.02,
+      winrateDriftPct: 0.05,
+      sharpeDriftThreshold: 0.3,
+      drawdownDriftPct: 0.03,
+      frequencyDriftPct: 0.1,
+    },
+    rollingWindowSize: 10,
+  };
+
+  return mergeConfig(createDefaultConfig(), { ...tighter, ...overrides });
+}

--- a/src/parity-enforcer/__tests__/math-utils.test.ts
+++ b/src/parity-enforcer/__tests__/math-utils.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  mean,
+  standardDeviation,
+  sharpeRatio,
+  maxDrawdown,
+  winRate,
+  tradeFrequency,
+} from '../math-utils';
+
+describe('mean', () => {
+  it('returns 0 for empty array', () => {
+    expect(mean([])).toBe(0);
+  });
+
+  it('returns the value for single element', () => {
+    expect(mean([5])).toBe(5);
+  });
+
+  it('computes mean of known values', () => {
+    expect(mean([1, 2, 3, 4, 5])).toBe(3);
+  });
+
+  it('handles negative values', () => {
+    expect(mean([-10, 10])).toBe(0);
+  });
+});
+
+describe('standardDeviation', () => {
+  it('returns 0 for empty array', () => {
+    expect(standardDeviation([])).toBe(0);
+  });
+
+  it('returns 0 for single value', () => {
+    expect(standardDeviation([42])).toBe(0);
+  });
+
+  it('computes correct stddev for known set', () => {
+    // [2, 4, 4, 4, 5, 5, 7, 9] → mean=5, sample stddev≈2.138
+    const result = standardDeviation([2, 4, 4, 4, 5, 5, 7, 9]);
+    expect(result).toBeCloseTo(2.138, 2);
+  });
+
+  it('returns 0 for identical values', () => {
+    expect(standardDeviation([3, 3, 3, 3])).toBe(0);
+  });
+});
+
+describe('sharpeRatio', () => {
+  it('returns 0 for empty array', () => {
+    expect(sharpeRatio([])).toBe(0);
+  });
+
+  it('returns 0 when stddev is 0', () => {
+    expect(sharpeRatio([0.01, 0.01, 0.01])).toBe(0);
+  });
+
+  it('computes positive Sharpe for positive returns', () => {
+    const returns = [0.01, 0.02, 0.015, 0.012, 0.018];
+    const result = sharpeRatio(returns);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('computes negative Sharpe for negative returns', () => {
+    const returns = [-0.01, -0.02, -0.015, -0.012, -0.018];
+    const result = sharpeRatio(returns);
+    expect(result).toBeLessThan(0);
+  });
+
+  it('accounts for risk-free rate', () => {
+    const returns = [0.01, 0.02, 0.015, 0.012, 0.018];
+    const withRf = sharpeRatio(returns, 0.01);
+    const withoutRf = sharpeRatio(returns, 0);
+    expect(withRf).toBeLessThan(withoutRf);
+  });
+});
+
+describe('maxDrawdown', () => {
+  it('returns 0 for empty array', () => {
+    expect(maxDrawdown([])).toBe(0);
+  });
+
+  it('returns 0 for monotonically increasing curve', () => {
+    expect(maxDrawdown([1, 2, 3, 4, 5])).toBe(0);
+  });
+
+  it('computes known drawdown', () => {
+    // Peak at 100, trough at 60 → DD = 40%
+    const curve = [80, 100, 90, 60, 70, 80];
+    expect(maxDrawdown(curve)).toBeCloseTo(0.4, 5);
+  });
+
+  it('handles all losses', () => {
+    const curve = [100, 80, 60, 40, 20];
+    expect(maxDrawdown(curve)).toBeCloseTo(0.8, 5);
+  });
+});
+
+describe('winRate', () => {
+  it('returns 0 for empty array', () => {
+    expect(winRate([])).toBe(0);
+  });
+
+  it('returns 1 for all wins', () => {
+    expect(winRate([10, 20, 30])).toBe(1);
+  });
+
+  it('returns 0 for all losses', () => {
+    expect(winRate([-10, -20, -30])).toBe(0);
+  });
+
+  it('computes correct mixed rate', () => {
+    expect(winRate([10, -5, 20, -10])).toBe(0.5);
+  });
+
+  it('does not count zero as a win', () => {
+    expect(winRate([0, 0, 10])).toBeCloseTo(1 / 3, 5);
+  });
+});
+
+describe('tradeFrequency', () => {
+  it('returns 0 for fewer than 2 timestamps', () => {
+    expect(tradeFrequency([], 1000)).toBe(0);
+    expect(tradeFrequency([100], 1000)).toBe(0);
+  });
+
+  it('computes frequency for regular intervals', () => {
+    // 5 trades over 4000ms span, window = 4000ms → 5 trades per window
+    const timestamps = [1000, 2000, 3000, 4000, 5000];
+    const result = tradeFrequency(timestamps, 4000);
+    expect(result).toBe(5);
+  });
+
+  it('returns 0 for zero window', () => {
+    expect(tradeFrequency([1000, 2000], 0)).toBe(0);
+  });
+});

--- a/src/parity-enforcer/__tests__/rolling-drift.test.ts
+++ b/src/parity-enforcer/__tests__/rolling-drift.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'bun:test';
+import { computeRollingDrift } from '../rolling-drift';
+// helpers used for other test files; this file creates trades inline
+import type { Trade, TradeId, Timestamp } from '../types';
+
+function makeTrades(pnls: number[], baseTime = 1000): Trade[] {
+  return pnls.map((pnl, i) => ({
+    id: `t-${i}` as TradeId,
+    symbol: 'BTC/USD',
+    side: 'long' as const,
+    entryPrice: 100,
+    exitPrice: 100 + pnl,
+    entryTime: (baseTime + i * 60_000) as Timestamp,
+    exitTime: (baseTime + i * 60_000 + 3600_000) as Timestamp,
+    quantity: 1,
+    pnl,
+  }));
+}
+
+describe('computeRollingDrift', () => {
+  it('returns null when window not full', () => {
+    const expected = makeTrades([10, 20, 30]);
+    const actual = makeTrades([10, 20, 30]);
+    const result = computeRollingDrift(expected, actual, 5);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when actual has fewer trades than window', () => {
+    const expected = makeTrades([10, 20, 30, 40, 50]);
+    const actual = makeTrades([10, 20, 30]);
+    const result = computeRollingDrift(expected, actual, 5);
+    expect(result).toBeNull();
+  });
+
+  it('returns zero drift for identical trades', () => {
+    const trades = makeTrades([10, -5, 20, -10, 15, 8, -3, 12, 7, -2]);
+    const result = computeRollingDrift(trades, trades, 10);
+    expect(result).not.toBeNull();
+    expect(result!.sharpeDrift).toBe(0);
+    expect(result!.drawdownDrift).toBe(0);
+    expect(result!.winrateDrift).toBe(0);
+  });
+
+  it('detects Sharpe drift', () => {
+    const expected = makeTrades([10, 10, 10, 10, 10, 10, 10, 10, 10, 10]);
+    const actual = makeTrades([10, -20, 30, -15, 10, -25, 40, -10, 5, -30]);
+    const result = computeRollingDrift(expected, actual, 10);
+    expect(result).not.toBeNull();
+    expect(result!.sharpeDrift).toBeGreaterThan(0);
+  });
+
+  it('detects drawdown drift', () => {
+    const expected = makeTrades([10, 10, 10, 10, 10, 10, 10, 10, 10, 10]);
+    const actual = makeTrades([10, 10, -50, -50, 10, 10, 10, 10, 10, 10]);
+    const result = computeRollingDrift(expected, actual, 10);
+    expect(result).not.toBeNull();
+    expect(result!.drawdownDrift).toBeGreaterThan(0);
+  });
+
+  it('detects winrate drift', () => {
+    const expected = makeTrades([10, 10, 10, 10, 10, 10, 10, 10, 10, 10]); // 100% win
+    const actual = makeTrades([10, -5, 10, -5, 10, -5, 10, -5, 10, -5]); // 50% win
+    const result = computeRollingDrift(expected, actual, 10);
+    expect(result).not.toBeNull();
+    expect(result!.winrateDrift).toBeCloseTo(0.5, 2);
+  });
+
+  it('uses most recent N trades (not first N)', () => {
+    // 15 trades, window=10 → should use last 10
+    const expected = makeTrades([1, 2, 3, 4, 5, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10]);
+    const actual = makeTrades([1, 2, 3, 4, 5, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10]);
+    const result = computeRollingDrift(expected, actual, 10);
+    expect(result).not.toBeNull();
+    expect(result!.windowSize).toBe(10);
+  });
+
+  it('reports correct window size', () => {
+    const trades = makeTrades([1, 2, 3, 4, 5]);
+    const result = computeRollingDrift(trades, trades, 5);
+    expect(result).not.toBeNull();
+    expect(result!.windowSize).toBe(5);
+  });
+});

--- a/src/parity-enforcer/__tests__/threshold-flagger.test.ts
+++ b/src/parity-enforcer/__tests__/threshold-flagger.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'bun:test';
+import { flagComparison, flagRollingDrift, determineSeverity } from '../threshold-flagger';
+import type { TradeComparison, RollingDriftMetrics, TradeFlag } from '../types';
+import { createDefaultConfig } from '../config';
+
+const defaultThresholds = createDefaultConfig().thresholds;
+
+function makeComparison(overrides?: Partial<TradeComparison>): TradeComparison {
+  return {
+    tradeId: 'test-1' as never,
+    symbol: 'BTC/USD',
+    entryDeviation: 0,
+    entryDeviationPct: 0,
+    exitDeviation: 0,
+    exitDeviationPct: 0,
+    slippageDiff: 0,
+    pnlDiff: 0,
+    pnlDiffPct: 0,
+    flags: [],
+    ...overrides,
+  };
+}
+
+describe('flagComparison', () => {
+  it('returns no flags when within thresholds', () => {
+    const comparison = makeComparison({
+      entryDeviationPct: 0.001, // below 0.002
+      exitDeviationPct: 0.001,
+      pnlDiffPct: 0.01, // below 0.05
+    });
+    const flags = flagComparison(comparison, defaultThresholds);
+    expect(flags).toHaveLength(0);
+  });
+
+  it('flags entry price deviation', () => {
+    const comparison = makeComparison({ entryDeviationPct: 0.005 });
+    const flags = flagComparison(comparison, defaultThresholds);
+    expect(flags).toHaveLength(1);
+    expect(flags[0].metric).toBe('entryDeviationPct');
+    expect(flags[0].severity).toBe('MEDIUM');
+  });
+
+  it('flags exit price deviation', () => {
+    const comparison = makeComparison({ exitDeviationPct: 0.005 });
+    const flags = flagComparison(comparison, defaultThresholds);
+    expect(flags).toHaveLength(1);
+    expect(flags[0].metric).toBe('exitDeviationPct');
+    expect(flags[0].severity).toBe('MEDIUM');
+  });
+
+  it('flags PnL deviation as HIGH', () => {
+    const comparison = makeComparison({ pnlDiffPct: 0.1 });
+    const flags = flagComparison(comparison, defaultThresholds);
+    expect(flags).toHaveLength(1);
+    expect(flags[0].metric).toBe('pnlDiffPct');
+    expect(flags[0].severity).toBe('HIGH');
+  });
+
+  it('flags Infinity pnlDiffPct as HIGH', () => {
+    const comparison = makeComparison({ pnlDiffPct: Infinity });
+    const flags = flagComparison(comparison, defaultThresholds);
+    expect(flags).toHaveLength(1);
+    expect(flags[0].severity).toBe('HIGH');
+  });
+
+  it('produces multiple flags', () => {
+    const comparison = makeComparison({
+      entryDeviationPct: 0.005,
+      exitDeviationPct: 0.005,
+      pnlDiffPct: 0.1,
+    });
+    const flags = flagComparison(comparison, defaultThresholds);
+    expect(flags).toHaveLength(3);
+  });
+});
+
+describe('flagRollingDrift', () => {
+  it('flags sharpe drift as MEDIUM', () => {
+    const metrics: RollingDriftMetrics = {
+      windowSize: 50,
+      sharpeDrift: 0.8,
+      drawdownDrift: 0,
+      frequencyDrift: 0,
+      winrateDrift: 0,
+    };
+    const flags = flagRollingDrift(metrics, defaultThresholds);
+    expect(flags).toHaveLength(1);
+    expect(flags[0].severity).toBe('MEDIUM');
+  });
+
+  it('flags drawdown drift as HIGH', () => {
+    const metrics: RollingDriftMetrics = {
+      windowSize: 50,
+      sharpeDrift: 0,
+      drawdownDrift: 0.1,
+      frequencyDrift: 0,
+      winrateDrift: 0,
+    };
+    const flags = flagRollingDrift(metrics, defaultThresholds);
+    expect(flags).toHaveLength(1);
+    expect(flags[0].severity).toBe('HIGH');
+  });
+
+  it('flags frequency drift as LOW', () => {
+    const metrics: RollingDriftMetrics = {
+      windowSize: 50,
+      sharpeDrift: 0,
+      drawdownDrift: 0,
+      frequencyDrift: 0.3,
+      winrateDrift: 0,
+    };
+    const flags = flagRollingDrift(metrics, defaultThresholds);
+    expect(flags).toHaveLength(1);
+    expect(flags[0].severity).toBe('LOW');
+  });
+
+  it('flags winrate drift as HIGH', () => {
+    const metrics: RollingDriftMetrics = {
+      windowSize: 50,
+      sharpeDrift: 0,
+      drawdownDrift: 0,
+      frequencyDrift: 0,
+      winrateDrift: 0.15,
+    };
+    const flags = flagRollingDrift(metrics, defaultThresholds);
+    expect(flags).toHaveLength(1);
+    expect(flags[0].severity).toBe('HIGH');
+  });
+});
+
+describe('determineSeverity', () => {
+  it('returns LOW for no flags', () => {
+    expect(determineSeverity([])).toBe('LOW');
+  });
+
+  it('returns the severity of a single flag', () => {
+    const flags: TradeFlag[] = [
+      { metric: 'test', threshold: 0, actual: 1, severity: 'MEDIUM', message: 'test' },
+    ];
+    expect(determineSeverity(flags)).toBe('MEDIUM');
+  });
+
+  it('returns HIGH when any flag is HIGH', () => {
+    const flags: TradeFlag[] = [
+      { metric: 'a', threshold: 0, actual: 1, severity: 'LOW', message: 'a' },
+      { metric: 'b', threshold: 0, actual: 1, severity: 'HIGH', message: 'b' },
+      { metric: 'c', threshold: 0, actual: 1, severity: 'MEDIUM', message: 'c' },
+    ];
+    expect(determineSeverity(flags)).toBe('HIGH');
+  });
+
+  it('returns MEDIUM when highest is MEDIUM', () => {
+    const flags: TradeFlag[] = [
+      { metric: 'a', threshold: 0, actual: 1, severity: 'LOW', message: 'a' },
+      { metric: 'b', threshold: 0, actual: 1, severity: 'MEDIUM', message: 'b' },
+    ];
+    expect(determineSeverity(flags)).toBe('MEDIUM');
+  });
+});

--- a/src/parity-enforcer/__tests__/trade-store.test.ts
+++ b/src/parity-enforcer/__tests__/trade-store.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { TradeStore } from '../trade-store';
+import { createTrade, resetIdCounter } from './helpers';
+import type { Timestamp } from '../types';
+
+describe('TradeStore', () => {
+  let store: TradeStore;
+
+  beforeEach(() => {
+    store = new TradeStore(60_000); // 60s tolerance
+    resetIdCounter();
+  });
+
+  it('stores expected and actual trades', () => {
+    store.addExpectedTrade(createTrade());
+    store.addActualTrade(createTrade());
+    expect(store.size().expected).toBe(1);
+    expect(store.size().actual).toBe(1);
+  });
+
+  it('matches trades by symbol and closest time within tolerance', () => {
+    const now = Date.now() as Timestamp;
+    const expected = createTrade({ symbol: 'BTC/USD', entryTime: now as Timestamp });
+    const actual = createTrade({ symbol: 'BTC/USD', entryTime: (now + 5000) as Timestamp });
+
+    store.addExpectedTrade(expected);
+    store.addActualTrade(actual);
+
+    const pairs = store.getMatchedPairs();
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].expected.id).toBe(expected.id);
+    expect(pairs[0].actual.id).toBe(actual.id);
+  });
+
+  it('does not match trades outside tolerance window', () => {
+    const now = Date.now() as Timestamp;
+    const expected = createTrade({ symbol: 'BTC/USD', entryTime: now as Timestamp });
+    const actual = createTrade({ symbol: 'BTC/USD', entryTime: (now + 120_000) as Timestamp });
+
+    store.addExpectedTrade(expected);
+    store.addActualTrade(actual);
+
+    expect(store.getMatchedPairs()).toHaveLength(0);
+  });
+
+  it('does not cross-match different symbols', () => {
+    const now = Date.now() as Timestamp;
+    const expected = createTrade({ symbol: 'BTC/USD', entryTime: now as Timestamp });
+    const actual = createTrade({ symbol: 'ETH/USD', entryTime: now as Timestamp });
+
+    store.addExpectedTrade(expected);
+    store.addActualTrade(actual);
+
+    expect(store.getMatchedPairs()).toHaveLength(0);
+  });
+
+  it('matches closest time when multiple expected trades exist', () => {
+    const now = Date.now() as Timestamp;
+    const expected1 = createTrade({ symbol: 'BTC/USD', entryTime: now as Timestamp });
+    const expected2 = createTrade({ symbol: 'BTC/USD', entryTime: (now + 30_000) as Timestamp });
+    const actual = createTrade({ symbol: 'BTC/USD', entryTime: (now + 28_000) as Timestamp });
+
+    store.addExpectedTrade(expected1);
+    store.addExpectedTrade(expected2);
+    store.addActualTrade(actual);
+
+    const pairs = store.getMatchedPairs();
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].expected.id).toBe(expected2.id);
+  });
+
+  it('filters trades by symbol', () => {
+    store.addExpectedTrade(createTrade({ symbol: 'BTC/USD' }));
+    store.addExpectedTrade(createTrade({ symbol: 'ETH/USD' }));
+
+    expect(store.getExpectedTrades('BTC/USD')).toHaveLength(1);
+    expect(store.getExpectedTrades('ETH/USD')).toHaveLength(1);
+    expect(store.getExpectedTrades()).toHaveLength(2);
+  });
+
+  it('clear removes all data', () => {
+    store.addExpectedTrade(createTrade());
+    store.addActualTrade(createTrade());
+    store.clear();
+
+    const size = store.size();
+    expect(size.expected).toBe(0);
+    expect(size.actual).toBe(0);
+    expect(size.matched).toBe(0);
+  });
+
+  it('maintains matched pairs in insertion order', () => {
+    const now = Date.now() as Timestamp;
+    const e1 = createTrade({ symbol: 'BTC/USD', entryTime: now as Timestamp });
+    const e2 = createTrade({ symbol: 'BTC/USD', entryTime: (now + 60_000) as Timestamp });
+    const a1 = createTrade({ symbol: 'BTC/USD', entryTime: (now + 1000) as Timestamp });
+    const a2 = createTrade({ symbol: 'BTC/USD', entryTime: (now + 61_000) as Timestamp });
+
+    store.addExpectedTrade(e1);
+    store.addExpectedTrade(e2);
+    store.addActualTrade(a1);
+    store.addActualTrade(a2);
+
+    const pairs = store.getMatchedPairs();
+    expect(pairs).toHaveLength(2);
+    expect(pairs[0].expected.id).toBe(e1.id);
+    expect(pairs[1].expected.id).toBe(e2.id);
+  });
+});

--- a/src/parity-enforcer/auto-responder.ts
+++ b/src/parity-enforcer/auto-responder.ts
@@ -1,0 +1,46 @@
+import type { ActionConfig, ActionHandler, DriftAction, DriftReport, Severity } from './types';
+
+export class AutoResponder {
+  private readonly config: ActionConfig;
+  private handler: ActionHandler | null;
+  private halted = false;
+
+  constructor(config: ActionConfig, handler?: ActionHandler) {
+    this.config = config;
+    this.handler = handler ?? null;
+  }
+
+  onAction(handler: ActionHandler): void {
+    this.handler = handler;
+  }
+
+  async respond(severity: Severity, report: DriftReport): Promise<DriftAction> {
+    const action = this.getAction(severity);
+
+    if (action === 'stop_trading') {
+      this.halted = true;
+    }
+
+    if (this.handler) {
+      try {
+        await this.handler(action, report);
+      } catch {
+        // Handler errors are caught — never crash the enforcer
+      }
+    }
+
+    return action;
+  }
+
+  getAction(severity: Severity): DriftAction {
+    return this.config[severity];
+  }
+
+  isHalted(): boolean {
+    return this.halted;
+  }
+
+  resetHalt(): void {
+    this.halted = false;
+  }
+}

--- a/src/parity-enforcer/auto-responder.ts
+++ b/src/parity-enforcer/auto-responder.ts
@@ -3,15 +3,25 @@ import type { ActionConfig, ActionHandler, DriftAction, DriftReport, Severity } 
 export class AutoResponder {
   private readonly config: ActionConfig;
   private handler: ActionHandler | null;
+  private errorHandler: ((error: unknown, action: DriftAction, report: DriftReport) => void) | null;
   private halted = false;
 
   constructor(config: ActionConfig, handler?: ActionHandler) {
     this.config = config;
     this.handler = handler ?? null;
+    this.errorHandler = null;
   }
 
   onAction(handler: ActionHandler): void {
     this.handler = handler;
+  }
+
+  onError(handler: (error: unknown, action: DriftAction, report: DriftReport) => void): void {
+    this.errorHandler = handler;
+  }
+
+  halt(): void {
+    this.halted = true;
   }
 
   async respond(severity: Severity, report: DriftReport): Promise<DriftAction> {
@@ -24,8 +34,14 @@ export class AutoResponder {
     if (this.handler) {
       try {
         await this.handler(action, report);
-      } catch {
-        // Handler errors are caught — never crash the enforcer
+      } catch (error: unknown) {
+        if (this.errorHandler) {
+          try {
+            this.errorHandler(error, action, report);
+          } catch {
+            // Error handler itself failed — nothing more we can do
+          }
+        }
       }
     }
 

--- a/src/parity-enforcer/comparison-engine.ts
+++ b/src/parity-enforcer/comparison-engine.ts
@@ -7,6 +7,7 @@ export function compareTrade(expected: Trade, actual: Trade): TradeComparison {
   const exitDeviation = Math.abs(actual.exitPrice - expected.exitPrice);
   const exitDeviationPct = expected.exitPrice !== 0 ? exitDeviation / expected.exitPrice : 0;
 
+  // Gross price range (|exit - entry| * qty), not market slippage vs expected fill
   const expectedSlippage = Math.abs(expected.exitPrice - expected.entryPrice) * expected.quantity;
   const actualSlippage = Math.abs(actual.exitPrice - actual.entryPrice) * actual.quantity;
   const slippageDiff = actualSlippage - expectedSlippage;

--- a/src/parity-enforcer/comparison-engine.ts
+++ b/src/parity-enforcer/comparison-engine.ts
@@ -1,0 +1,38 @@
+import type { Trade, TradeComparison } from './types';
+
+export function compareTrade(expected: Trade, actual: Trade): TradeComparison {
+  const entryDeviation = Math.abs(actual.entryPrice - expected.entryPrice);
+  const entryDeviationPct = expected.entryPrice !== 0 ? entryDeviation / expected.entryPrice : 0;
+
+  const exitDeviation = Math.abs(actual.exitPrice - expected.exitPrice);
+  const exitDeviationPct = expected.exitPrice !== 0 ? exitDeviation / expected.exitPrice : 0;
+
+  const expectedSlippage = Math.abs(expected.exitPrice - expected.entryPrice) * expected.quantity;
+  const actualSlippage = Math.abs(actual.exitPrice - actual.entryPrice) * actual.quantity;
+  const slippageDiff = actualSlippage - expectedSlippage;
+
+  const pnlDiff = actual.pnl - expected.pnl;
+  let pnlDiffPct: number;
+  if (expected.pnl === 0) {
+    pnlDiffPct = actual.pnl !== 0 ? Infinity : 0;
+  } else {
+    pnlDiffPct = pnlDiff / Math.abs(expected.pnl);
+  }
+
+  return {
+    tradeId: expected.id,
+    symbol: expected.symbol,
+    entryDeviation,
+    entryDeviationPct,
+    exitDeviation,
+    exitDeviationPct,
+    slippageDiff,
+    pnlDiff,
+    pnlDiffPct,
+    flags: [],
+  };
+}
+
+export function compareTrades(pairs: { expected: Trade; actual: Trade }[]): TradeComparison[] {
+  return pairs.map(({ expected, actual }) => compareTrade(expected, actual));
+}

--- a/src/parity-enforcer/config.ts
+++ b/src/parity-enforcer/config.ts
@@ -1,0 +1,60 @@
+import type { EnforcerConfig, ThresholdConfig } from './types';
+import { ThresholdConfigError } from './types';
+
+export function createDefaultConfig(): EnforcerConfig {
+  return {
+    thresholds: {
+      priceDeviationPct: 0.002,
+      pnlDeviationPct: 0.05,
+      winrateDriftPct: 0.1,
+      sharpeDriftThreshold: 0.5,
+      drawdownDriftPct: 0.05,
+      frequencyDriftPct: 0.2,
+    },
+    actions: {
+      LOW: 'alert',
+      MEDIUM: 'reduce_position',
+      HIGH: 'stop_trading',
+    },
+    rollingWindowSize: 50,
+    enabled: true,
+  };
+}
+
+function validateThresholds(thresholds: ThresholdConfig): void {
+  const fields: (keyof ThresholdConfig)[] = [
+    'priceDeviationPct',
+    'pnlDeviationPct',
+    'winrateDriftPct',
+    'sharpeDriftThreshold',
+    'drawdownDriftPct',
+    'frequencyDriftPct',
+  ];
+
+  for (const field of fields) {
+    const value = thresholds[field];
+    if (value <= 0) {
+      throw new ThresholdConfigError(field, value);
+    }
+  }
+}
+
+export function validateConfig(config: Partial<EnforcerConfig>): EnforcerConfig {
+  const merged = mergeConfig(createDefaultConfig(), config);
+  validateThresholds(merged.thresholds);
+  return merged;
+}
+
+export function mergeConfig(
+  base: EnforcerConfig,
+  overrides: Partial<EnforcerConfig>
+): EnforcerConfig {
+  return {
+    thresholds: overrides.thresholds
+      ? { ...base.thresholds, ...overrides.thresholds }
+      : base.thresholds,
+    actions: overrides.actions ? { ...base.actions, ...overrides.actions } : base.actions,
+    rollingWindowSize: overrides.rollingWindowSize ?? base.rollingWindowSize,
+    enabled: overrides.enabled ?? base.enabled,
+  };
+}

--- a/src/parity-enforcer/enforcer.ts
+++ b/src/parity-enforcer/enforcer.ts
@@ -1,5 +1,6 @@
 import type {
   ActionHandler,
+  DriftAction,
   DriftReport,
   EnforcerConfig,
   RollingDriftMetrics,
@@ -75,6 +76,10 @@ export class ParityEnforcer {
     this.responder.onAction(handler);
   }
 
+  onError(handler: (error: unknown, action: DriftAction, report: DriftReport) => void): void {
+    this.responder.onError(handler);
+  }
+
   onDrift(handler: (report: DriftReport) => void): void {
     this.driftListeners.push(handler);
   }
@@ -136,11 +141,9 @@ export class ParityEnforcer {
 
     let actionTaken: DriftReport['actionTaken'] = 'none';
     if (drift) {
-      // Synchronous wrapper — respond is async only for handler callback
       const action = this.responder.getAction(severity);
       if (action === 'stop_trading') {
-        // Mark halted synchronously to prevent race
-        void this.responder.respond(severity, null as unknown as DriftReport);
+        this.responder.halt();
       }
       actionTaken = action;
     }
@@ -157,7 +160,6 @@ export class ParityEnforcer {
     };
 
     if (drift) {
-      // Fire async handler (non-blocking)
       void this.responder.respond(severity, report);
       this.emitDrift(report);
     }

--- a/src/parity-enforcer/enforcer.ts
+++ b/src/parity-enforcer/enforcer.ts
@@ -1,0 +1,208 @@
+import type {
+  ActionHandler,
+  DriftReport,
+  EnforcerConfig,
+  RollingDriftMetrics,
+  Trade,
+  TradeComparison,
+  TradeFlag,
+} from './types';
+import { validateConfig, mergeConfig } from './config';
+import { TradeStore } from './trade-store';
+import { compareTrades } from './comparison-engine';
+import { flagComparison, flagRollingDrift, determineSeverity } from './threshold-flagger';
+import { computeRollingDrift } from './rolling-drift';
+import { AutoResponder } from './auto-responder';
+
+export class ParityEnforcer {
+  private config: EnforcerConfig;
+  private store: TradeStore;
+  private responder: AutoResponder;
+  private lastMatchedCount = 0;
+  private driftListeners: ((report: DriftReport) => void)[] = [];
+
+  constructor(config?: Partial<EnforcerConfig>) {
+    this.config = validateConfig(config ?? {});
+    this.store = new TradeStore();
+    this.responder = new AutoResponder(this.config.actions);
+  }
+
+  addExpectedTrade(trade: Trade): void {
+    this.store.addExpectedTrade(trade);
+  }
+
+  addActualTrade(trade: Trade): DriftReport | null {
+    this.store.addActualTrade(trade);
+
+    if (this.responder.isHalted()) {
+      const report = this.buildHaltedReport();
+      this.emitDrift(report);
+      return report;
+    }
+
+    const pairs = this.store.getMatchedPairs();
+    if (pairs.length === this.lastMatchedCount) {
+      return null;
+    }
+
+    const newPairs = pairs.slice(this.lastMatchedCount);
+    this.lastMatchedCount = pairs.length;
+
+    return this.processNewPairs(newPairs, pairs);
+  }
+
+  check(): DriftReport {
+    if (this.responder.isHalted()) {
+      return this.buildHaltedReport();
+    }
+
+    const pairs = this.store.getMatchedPairs();
+    if (pairs.length === 0) {
+      return this.buildNoDriftReport();
+    }
+
+    const newPairs = pairs.slice(this.lastMatchedCount);
+    this.lastMatchedCount = pairs.length;
+
+    if (newPairs.length === 0) {
+      return this.buildNoDriftReport();
+    }
+
+    return this.processNewPairs(newPairs, pairs);
+  }
+
+  onAction(handler: ActionHandler): void {
+    this.responder.onAction(handler);
+  }
+
+  onDrift(handler: (report: DriftReport) => void): void {
+    this.driftListeners.push(handler);
+  }
+
+  getMetrics(): RollingDriftMetrics | null {
+    const pairs = this.store.getMatchedPairs();
+    return computeRollingDrift(
+      pairs.map(p => p.expected),
+      pairs.map(p => p.actual),
+      this.config.rollingWindowSize
+    );
+  }
+
+  getConfig(): EnforcerConfig {
+    return this.config;
+  }
+
+  isHalted(): boolean {
+    return this.responder.isHalted();
+  }
+
+  reset(): void {
+    this.store.clear();
+    this.lastMatchedCount = 0;
+    this.responder.resetHalt();
+  }
+
+  updateConfig(overrides: Partial<EnforcerConfig>): void {
+    this.config = mergeConfig(this.config, overrides);
+    this.responder = new AutoResponder(this.config.actions);
+  }
+
+  private processNewPairs(
+    newPairs: { expected: Trade; actual: Trade }[],
+    allPairs: { expected: Trade; actual: Trade }[]
+  ): DriftReport {
+    const comparisons = compareTrades(newPairs);
+
+    const allFlags: TradeFlag[] = [];
+    const flaggedComparisons: TradeComparison[] = comparisons.map(c => {
+      const flags = flagComparison(c, this.config.thresholds);
+      allFlags.push(...flags);
+      return { ...c, flags };
+    });
+
+    const rollingMetrics = computeRollingDrift(
+      allPairs.map(p => p.expected),
+      allPairs.map(p => p.actual),
+      this.config.rollingWindowSize
+    );
+
+    if (rollingMetrics) {
+      const rollingFlags = flagRollingDrift(rollingMetrics, this.config.thresholds);
+      allFlags.push(...rollingFlags);
+    }
+
+    const severity = allFlags.length > 0 ? determineSeverity(allFlags) : 'LOW';
+    const drift = allFlags.length > 0;
+
+    let actionTaken: DriftReport['actionTaken'] = 'none';
+    if (drift) {
+      // Synchronous wrapper — respond is async only for handler callback
+      const action = this.responder.getAction(severity);
+      if (action === 'stop_trading') {
+        // Mark halted synchronously to prevent race
+        void this.responder.respond(severity, null as unknown as DriftReport);
+      }
+      actionTaken = action;
+    }
+
+    const report: DriftReport = {
+      drift,
+      severity,
+      reason: drift ? this.buildReason(allFlags) : 'No drift detected',
+      actionTaken,
+      timestamp: Date.now(),
+      tradeComparisons: flaggedComparisons,
+      rollingMetrics,
+      flags: allFlags,
+    };
+
+    if (drift) {
+      // Fire async handler (non-blocking)
+      void this.responder.respond(severity, report);
+      this.emitDrift(report);
+    }
+
+    return report;
+  }
+
+  private buildHaltedReport(): DriftReport {
+    return {
+      drift: true,
+      severity: 'HIGH',
+      reason: 'Trading halted — stop_trading was triggered',
+      actionTaken: 'stop_trading',
+      timestamp: Date.now(),
+      tradeComparisons: [],
+      rollingMetrics: null,
+      flags: [],
+    };
+  }
+
+  private buildNoDriftReport(): DriftReport {
+    return {
+      drift: false,
+      severity: 'LOW',
+      reason: 'No drift detected',
+      actionTaken: 'none',
+      timestamp: Date.now(),
+      tradeComparisons: [],
+      rollingMetrics: null,
+      flags: [],
+    };
+  }
+
+  private buildReason(flags: TradeFlag[]): string {
+    if (flags.length === 1) return flags[0].message;
+    return `${flags.length} drift flags detected: ${flags[0].message} (and ${flags.length - 1} more)`;
+  }
+
+  private emitDrift(report: DriftReport): void {
+    for (const listener of this.driftListeners) {
+      try {
+        listener(report);
+      } catch {
+        // Listener errors never crash the enforcer
+      }
+    }
+  }
+}

--- a/src/parity-enforcer/index.ts
+++ b/src/parity-enforcer/index.ts
@@ -1,0 +1,32 @@
+// Main class
+export { ParityEnforcer } from './enforcer';
+
+// Types (re-export all)
+export type {
+  Trade,
+  TradeId,
+  Timestamp,
+  Severity,
+  DriftAction,
+  TradeComparison,
+  TradeFlag,
+  RollingDriftMetrics,
+  DriftReport,
+  ThresholdConfig,
+  ActionConfig,
+  EnforcerConfig,
+  ActionHandler,
+} from './types';
+
+// Error classes
+export { ParityEnforcerError, ThresholdConfigError } from './types';
+
+// Config helpers
+export { createDefaultConfig, validateConfig } from './config';
+
+// Individual engines (for advanced usage)
+export { TradeStore } from './trade-store';
+export { compareTrade, compareTrades } from './comparison-engine';
+export { flagComparison, determineSeverity, flagRollingDrift } from './threshold-flagger';
+export { computeRollingDrift } from './rolling-drift';
+export { AutoResponder } from './auto-responder';

--- a/src/parity-enforcer/math-utils.ts
+++ b/src/parity-enforcer/math-utils.ts
@@ -1,0 +1,56 @@
+export function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  let sum = 0;
+  for (const v of values) sum += v;
+  return sum / values.length;
+}
+
+export function standardDeviation(values: number[]): number {
+  if (values.length <= 1) return 0;
+  const avg = mean(values);
+  let sumSqDiff = 0;
+  for (const v of values) {
+    const diff = v - avg;
+    sumSqDiff += diff * diff;
+  }
+  return Math.sqrt(sumSqDiff / (values.length - 1));
+}
+
+export function sharpeRatio(returns: number[], riskFreeRate = 0): number {
+  if (returns.length === 0) return 0;
+  const avg = mean(returns);
+  const std = standardDeviation(returns);
+  if (std === 0) return 0;
+  return ((avg - riskFreeRate) / std) * Math.sqrt(252);
+}
+
+export function maxDrawdown(equityCurve: number[]): number {
+  if (equityCurve.length === 0) return 0;
+  let peak = equityCurve[0];
+  let worstDrawdown = 0;
+  for (const value of equityCurve) {
+    if (value > peak) peak = value;
+    const drawdown = peak > 0 ? (peak - value) / peak : 0;
+    if (drawdown > worstDrawdown) worstDrawdown = drawdown;
+  }
+  return worstDrawdown;
+}
+
+export function winRate(pnls: number[]): number {
+  if (pnls.length === 0) return 0;
+  let wins = 0;
+  for (const pnl of pnls) {
+    if (pnl > 0) wins++;
+  }
+  return wins / pnls.length;
+}
+
+export function tradeFrequency(timestamps: Timestamp[], windowMs: number): number {
+  if (timestamps.length <= 1 || windowMs <= 0) return 0;
+  const sorted = [...timestamps].sort((a, b) => a - b);
+  const span = sorted[sorted.length - 1] - sorted[0];
+  if (span === 0) return 0;
+  return (timestamps.length / span) * windowMs;
+}
+
+type Timestamp = number;

--- a/src/parity-enforcer/math-utils.ts
+++ b/src/parity-enforcer/math-utils.ts
@@ -1,3 +1,5 @@
+import type { Timestamp } from './types';
+
 export function mean(values: number[]): number {
   if (values.length === 0) return 0;
   let sum = 0;
@@ -21,6 +23,7 @@ export function sharpeRatio(returns: number[], riskFreeRate = 0): number {
   const avg = mean(returns);
   const std = standardDeviation(returns);
   if (std === 0) return 0;
+  // Annualize assuming daily returns (252 trading days/year)
   return ((avg - riskFreeRate) / std) * Math.sqrt(252);
 }
 
@@ -52,5 +55,3 @@ export function tradeFrequency(timestamps: Timestamp[], windowMs: number): numbe
   if (span === 0) return 0;
   return (timestamps.length / span) * windowMs;
 }
-
-type Timestamp = number;

--- a/src/parity-enforcer/rolling-drift.ts
+++ b/src/parity-enforcer/rolling-drift.ts
@@ -1,0 +1,69 @@
+import type { RollingDriftMetrics, Trade } from './types';
+import { maxDrawdown, sharpeRatio, tradeFrequency, winRate } from './math-utils';
+
+export function computeRollingDrift(
+  expectedTrades: Trade[],
+  actualTrades: Trade[],
+  windowSize: number
+): RollingDriftMetrics | null {
+  if (expectedTrades.length < windowSize || actualTrades.length < windowSize) {
+    return null;
+  }
+
+  const expectedWindow = expectedTrades.slice(-windowSize);
+  const actualWindow = actualTrades.slice(-windowSize);
+
+  const expectedReturns = expectedWindow.map(t => t.pnl);
+  const actualReturns = actualWindow.map(t => t.pnl);
+
+  const sharpeDrift = computeSharpeDrift(expectedReturns, actualReturns);
+  const drawdownDrift = computeDrawdownDrift(expectedReturns, actualReturns);
+  const frequencyDrift = computeFrequencyDrift(
+    expectedWindow.map(t => t.entryTime),
+    actualWindow.map(t => t.entryTime),
+    expectedWindow[expectedWindow.length - 1].entryTime - expectedWindow[0].entryTime
+  );
+  const expectedWinRate = winRate(expectedReturns);
+  const actualWinRate = winRate(actualReturns);
+  const winrateDrift = Math.abs(actualWinRate - expectedWinRate);
+
+  return {
+    windowSize,
+    sharpeDrift,
+    drawdownDrift,
+    frequencyDrift,
+    winrateDrift,
+  };
+}
+
+function computeSharpeDrift(expectedReturns: number[], actualReturns: number[]): number {
+  return Math.abs(sharpeRatio(actualReturns) - sharpeRatio(expectedReturns));
+}
+
+function computeDrawdownDrift(expectedPnls: number[], actualPnls: number[]): number {
+  const expectedEquity = cumulativeSum(expectedPnls);
+  const actualEquity = cumulativeSum(actualPnls);
+  return Math.abs(maxDrawdown(actualEquity) - maxDrawdown(expectedEquity));
+}
+
+function computeFrequencyDrift(
+  expectedTimes: number[],
+  actualTimes: number[],
+  windowMs: number
+): number {
+  if (windowMs <= 0) return 0;
+  const expectedFreq = tradeFrequency(expectedTimes, windowMs);
+  if (expectedFreq === 0) return 0;
+  const actualFreq = tradeFrequency(actualTimes, windowMs);
+  return Math.abs(actualFreq - expectedFreq) / expectedFreq;
+}
+
+function cumulativeSum(values: number[]): number[] {
+  const result: number[] = [];
+  let sum = 0;
+  for (const v of values) {
+    sum += v;
+    result.push(sum);
+  }
+  return result;
+}

--- a/src/parity-enforcer/threshold-flagger.ts
+++ b/src/parity-enforcer/threshold-flagger.ts
@@ -1,0 +1,113 @@
+import type {
+  RollingDriftMetrics,
+  Severity,
+  TradeComparison,
+  TradeFlag,
+  ThresholdConfig,
+} from './types';
+
+export function flagComparison(comparison: TradeComparison, config: ThresholdConfig): TradeFlag[] {
+  const flags: TradeFlag[] = [];
+
+  if (comparison.entryDeviationPct > config.priceDeviationPct) {
+    flags.push({
+      metric: 'entryDeviationPct',
+      threshold: config.priceDeviationPct,
+      actual: comparison.entryDeviationPct,
+      severity: 'MEDIUM',
+      message: `Entry price deviation ${(comparison.entryDeviationPct * 100).toFixed(3)}% exceeds threshold ${(config.priceDeviationPct * 100).toFixed(3)}%`,
+    });
+  }
+
+  if (comparison.exitDeviationPct > config.priceDeviationPct) {
+    flags.push({
+      metric: 'exitDeviationPct',
+      threshold: config.priceDeviationPct,
+      actual: comparison.exitDeviationPct,
+      severity: 'MEDIUM',
+      message: `Exit price deviation ${(comparison.exitDeviationPct * 100).toFixed(3)}% exceeds threshold ${(config.priceDeviationPct * 100).toFixed(3)}%`,
+    });
+  }
+
+  if (
+    comparison.pnlDiffPct !== Infinity &&
+    Math.abs(comparison.pnlDiffPct) > config.pnlDeviationPct
+  ) {
+    flags.push({
+      metric: 'pnlDiffPct',
+      threshold: config.pnlDeviationPct,
+      actual: Math.abs(comparison.pnlDiffPct),
+      severity: 'HIGH',
+      message: `PnL deviation ${(Math.abs(comparison.pnlDiffPct) * 100).toFixed(2)}% exceeds threshold ${(config.pnlDeviationPct * 100).toFixed(2)}%`,
+    });
+  } else if (comparison.pnlDiffPct === Infinity) {
+    flags.push({
+      metric: 'pnlDiffPct',
+      threshold: config.pnlDeviationPct,
+      actual: Infinity,
+      severity: 'HIGH',
+      message: 'PnL deviation is infinite (expected PnL was zero)',
+    });
+  }
+
+  return flags;
+}
+
+export function flagRollingDrift(
+  metrics: RollingDriftMetrics,
+  config: ThresholdConfig
+): TradeFlag[] {
+  const flags: TradeFlag[] = [];
+
+  if (metrics.sharpeDrift > config.sharpeDriftThreshold) {
+    flags.push({
+      metric: 'sharpeDrift',
+      threshold: config.sharpeDriftThreshold,
+      actual: metrics.sharpeDrift,
+      severity: 'MEDIUM',
+      message: `Sharpe drift ${metrics.sharpeDrift.toFixed(3)} exceeds threshold ${config.sharpeDriftThreshold}`,
+    });
+  }
+
+  if (metrics.drawdownDrift > config.drawdownDriftPct) {
+    flags.push({
+      metric: 'drawdownDrift',
+      threshold: config.drawdownDriftPct,
+      actual: metrics.drawdownDrift,
+      severity: 'HIGH',
+      message: `Drawdown drift ${(metrics.drawdownDrift * 100).toFixed(2)}% exceeds threshold ${(config.drawdownDriftPct * 100).toFixed(2)}%`,
+    });
+  }
+
+  if (metrics.frequencyDrift > config.frequencyDriftPct) {
+    flags.push({
+      metric: 'frequencyDrift',
+      threshold: config.frequencyDriftPct,
+      actual: metrics.frequencyDrift,
+      severity: 'LOW',
+      message: `Trade frequency drift ${(metrics.frequencyDrift * 100).toFixed(2)}% exceeds threshold ${(config.frequencyDriftPct * 100).toFixed(2)}%`,
+    });
+  }
+
+  if (metrics.winrateDrift > config.winrateDriftPct) {
+    flags.push({
+      metric: 'winrateDrift',
+      threshold: config.winrateDriftPct,
+      actual: metrics.winrateDrift,
+      severity: 'HIGH',
+      message: `Win rate drift ${(metrics.winrateDrift * 100).toFixed(2)}% exceeds threshold ${(config.winrateDriftPct * 100).toFixed(2)}%`,
+    });
+  }
+
+  return flags;
+}
+
+export function determineSeverity(flags: TradeFlag[]): Severity {
+  if (flags.length === 0) return 'LOW';
+  let highest: Severity = 'LOW';
+  for (const flag of flags) {
+    if (flag.severity === 'HIGH') return 'HIGH';
+    if (flag.severity === 'MEDIUM') highest = 'MEDIUM';
+  }
+  return highest;
+}

--- a/src/parity-enforcer/trade-store.ts
+++ b/src/parity-enforcer/trade-store.ts
@@ -1,0 +1,83 @@
+import type { Trade, TradeId } from './types';
+
+export class TradeStore {
+  private readonly expected = new Map<TradeId, Trade>();
+  private readonly actual = new Map<TradeId, Trade>();
+  private readonly matchedPairs: { expected: Trade; actual: Trade }[] = [];
+  private readonly matchedExpectedIds = new Set<TradeId>();
+  private readonly matchedActualIds = new Set<TradeId>();
+  private readonly toleranceMs: number;
+
+  constructor(toleranceMs = 60_000) {
+    this.toleranceMs = toleranceMs;
+  }
+
+  addExpectedTrade(trade: Trade): void {
+    this.expected.set(trade.id, trade);
+  }
+
+  addActualTrade(trade: Trade): void {
+    this.actual.set(trade.id, trade);
+    this.tryMatch(trade);
+  }
+
+  private tryMatch(actualTrade: Trade): void {
+    if (this.matchedActualIds.has(actualTrade.id)) return;
+
+    let bestMatch: Trade | null = null;
+    let bestTimeDiff = Infinity;
+
+    for (const [id, expectedTrade] of this.expected) {
+      if (this.matchedExpectedIds.has(id)) continue;
+      if (expectedTrade.symbol !== actualTrade.symbol) continue;
+
+      const timeDiff = Math.abs(actualTrade.entryTime - expectedTrade.entryTime);
+      if (timeDiff <= this.toleranceMs && timeDiff < bestTimeDiff) {
+        bestMatch = expectedTrade;
+        bestTimeDiff = timeDiff;
+      }
+    }
+
+    if (bestMatch) {
+      this.matchedExpectedIds.add(bestMatch.id);
+      this.matchedActualIds.add(actualTrade.id);
+      this.matchedPairs.push({ expected: bestMatch, actual: actualTrade });
+    }
+  }
+
+  getUnmatchedPairs(): { expected: Trade; actual: Trade }[] {
+    // Return newly matched pairs that haven't been processed yet
+    // For simplicity, return all matched pairs (caller tracks what's new)
+    return [...this.matchedPairs];
+  }
+
+  getExpectedTrades(symbol?: string): Trade[] {
+    const trades = [...this.expected.values()];
+    return symbol ? trades.filter(t => t.symbol === symbol) : trades;
+  }
+
+  getActualTrades(symbol?: string): Trade[] {
+    const trades = [...this.actual.values()];
+    return symbol ? trades.filter(t => t.symbol === symbol) : trades;
+  }
+
+  getMatchedPairs(): { expected: Trade; actual: Trade }[] {
+    return [...this.matchedPairs];
+  }
+
+  clear(): void {
+    this.expected.clear();
+    this.actual.clear();
+    this.matchedPairs.length = 0;
+    this.matchedExpectedIds.clear();
+    this.matchedActualIds.clear();
+  }
+
+  size(): { expected: number; actual: number; matched: number } {
+    return {
+      expected: this.expected.size,
+      actual: this.actual.size,
+      matched: this.matchedPairs.length,
+    };
+  }
+}

--- a/src/parity-enforcer/tsconfig.json
+++ b/src/parity-enforcer/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noEmit": true,
+    "types": ["bun-types"]
+  },
+  "include": ["./**/*.ts"]
+}

--- a/src/parity-enforcer/types.ts
+++ b/src/parity-enforcer/types.ts
@@ -1,0 +1,109 @@
+// Branded types
+export type TradeId = string & { readonly __brand: 'TradeId' };
+export type Timestamp = number; // Unix milliseconds
+
+// Severity levels
+export type Severity = 'LOW' | 'MEDIUM' | 'HIGH';
+
+// Auto-response actions
+export type DriftAction = 'reduce_position' | 'switch_paper' | 'alert' | 'stop_trading';
+
+// Core trade interface
+export interface Trade {
+  readonly id: TradeId;
+  readonly symbol: string;
+  readonly side: 'long' | 'short';
+  readonly entryPrice: number;
+  readonly exitPrice: number;
+  readonly entryTime: Timestamp;
+  readonly exitTime: Timestamp;
+  readonly quantity: number;
+  readonly pnl: number;
+}
+
+// Per-trade comparison result
+export interface TradeComparison {
+  readonly tradeId: TradeId;
+  readonly symbol: string;
+  readonly entryDeviation: number;
+  readonly entryDeviationPct: number;
+  readonly exitDeviation: number;
+  readonly exitDeviationPct: number;
+  readonly slippageDiff: number;
+  readonly pnlDiff: number;
+  readonly pnlDiffPct: number;
+  readonly flags: TradeFlag[];
+}
+
+// Flag from threshold check
+export interface TradeFlag {
+  readonly metric: string;
+  readonly threshold: number;
+  readonly actual: number;
+  readonly severity: Severity;
+  readonly message: string;
+}
+
+// Rolling drift metrics
+export interface RollingDriftMetrics {
+  readonly windowSize: number;
+  readonly sharpeDrift: number;
+  readonly drawdownDrift: number;
+  readonly frequencyDrift: number;
+  readonly winrateDrift: number;
+}
+
+// Structured output format (primary API output)
+export interface DriftReport {
+  readonly drift: boolean;
+  readonly severity: Severity;
+  readonly reason: string;
+  readonly actionTaken: DriftAction | 'none';
+  readonly timestamp: Timestamp;
+  readonly tradeComparisons: TradeComparison[];
+  readonly rollingMetrics: RollingDriftMetrics | null;
+  readonly flags: TradeFlag[];
+}
+
+// Threshold configuration
+export interface ThresholdConfig {
+  readonly priceDeviationPct: number;
+  readonly pnlDeviationPct: number;
+  readonly winrateDriftPct: number;
+  readonly sharpeDriftThreshold: number;
+  readonly drawdownDriftPct: number;
+  readonly frequencyDriftPct: number;
+}
+
+// Severity → action mapping
+export interface ActionConfig {
+  readonly LOW: DriftAction;
+  readonly MEDIUM: DriftAction;
+  readonly HIGH: DriftAction;
+}
+
+// Full enforcer config
+export interface EnforcerConfig {
+  readonly thresholds: ThresholdConfig;
+  readonly actions: ActionConfig;
+  readonly rollingWindowSize: number;
+  readonly enabled: boolean;
+}
+
+// Action handler callback type
+export type ActionHandler = (action: DriftAction, report: DriftReport) => void | Promise<void>;
+
+// Custom error classes
+export class ParityEnforcerError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ParityEnforcerError';
+  }
+}
+
+export class ThresholdConfigError extends ParityEnforcerError {
+  constructor(field: string, value: number) {
+    super(`Invalid threshold: ${field} = ${value}`);
+    this.name = 'ThresholdConfigError';
+  }
+}


### PR DESCRIPTION
## Summary

- Problem: No mechanism to detect drift between backtested trade expectations and live execution
- Why it matters: Undetected live/backtest divergence leads to silent losses; paranoid design stops trading when drift exceeds thresholds
- What changed: Added standalone `src/parity-enforcer/` TypeScript module with comparison engine, rolling drift detection, threshold flagging, and auto-response actions
- What did **not** change (scope boundary): No database, no HTTP/WS server, no exchange integration, no UI — this is a library consumed via API

## UX Journey

### Before

```
No parity enforcement exists. Users have no automated way to compare
live trading results against backtest expectations.
```

### After

```
Consumer code              Parity Enforcer
──────────────             ───────────────
addExpectedTrade() ──────▶ stores expected trade
addActualTrade()   ──────▶ stores actual trade
                           matches by time-proximity
                           computes per-trade deviation
                           checks rolling drift window
                           flags threshold violations
check()            ◀────── returns DriftReport
                           (metrics, flags, severity, actions)
onDrift callback   ◀────── fires on threshold breach
onAction callback  ◀────── fires auto-response action
                           (reduce_size / stop_trading / alert_only)
```

## Architecture Diagram

### Before

```
(No parity enforcement module existed)
```

### After

```
┌─────────────────────────────────────────────────┐
│                 src/parity-enforcer/             │
│                                                  │
│  types.ts ◄──── config.ts                        │
│     ▲              ▲                             │
│     │              │                             │
│  math-utils.ts     │                             │
│     ▲              │                             │
│     │              │                             │
│  trade-store.ts    │                             │
│     ▲              │                             │
│     │              │                             │
│  comparison-engine.ts                            │
│     ▲                                            │
│     ├── threshold-flagger.ts                     │
│     ├── rolling-drift.ts                         │
│     └── auto-responder.ts                        │
│              ▲                                   │
│              │                                   │
│         enforcer.ts  ──── [+] main orchestrator  │
│              ▲                                   │
│              │                                   │
│         index.ts     ──── [+] public API         │
└─────────────────────────────────────────────────┘
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| enforcer.ts | trade-store.ts | **new** | Stores expected/actual trades |
| enforcer.ts | comparison-engine.ts | **new** | Per-trade comparison |
| enforcer.ts | threshold-flagger.ts | **new** | Flag generation |
| enforcer.ts | rolling-drift.ts | **new** | Rolling window analysis |
| enforcer.ts | auto-responder.ts | **new** | Action dispatch |
| enforcer.ts | config.ts | **new** | Configuration |
| comparison-engine.ts | math-utils.ts | **new** | Statistical calculations |
| rolling-drift.ts | math-utils.ts | **new** | Statistical calculations |
| eslint.config.mjs | src/**/*.ts | **modified** | Added glob for module linting |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: L`
- Scope: `tests`
- Module: `standalone:parity-enforcer`

## Change Metadata

- Change type: `feature`
- Primary scope: `multi` (new standalone module + eslint config)

## Linked Issue

- Closes # N/A (standalone module, no linked issue)

## Validation Evidence (required)

```bash
tsc --noEmit -p src/parity-enforcer/tsconfig.json  # ✅ No errors
eslint src/parity-enforcer/ --max-warnings 0        # ✅ 0 errors, 0 warnings
prettier --check src/parity-enforcer/               # ✅ All formatted
bun test src/parity-enforcer/__tests__/              # ✅ 84 passed, 0 failed, 142 assertions, 36ms
```

- Evidence provided: All four validation commands pass cleanly
- If any command is intentionally skipped, explain why: `bun run validate` not run because this standalone module is outside the monorepo packages structure; module-local validation commands used instead

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes` — entirely additive, no existing code modified (except eslint config glob)
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios: All 84 unit tests cover core workflows (trade matching, deviation calculation, threshold flagging, rolling drift, auto-response, halt state)
- Edge cases checked: PnL=0 division, empty trade stores, window-not-full returns null, halt prevents further actions, config hot-reload
- What was not verified: Integration with actual trading systems (out of scope — this is a library)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: None — standalone module under `src/`, no imports from `packages/`
- Potential unintended effects: ESLint config change adds `src/**/*.ts` glob which would lint any future `src/` files
- Guardrails/monitoring for early detection: Module has its own `tsconfig.json`; test suite is self-contained

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit-sha>` — single commit, clean removal
- Feature flags or config toggles: None needed — module is opt-in via import
- Observable failure symptoms: N/A — no runtime integration, purely a library

## Risks and Mitigations

- Risk: ESLint config glob `src/**/*.ts` may inadvertently lint unrelated future files in `src/`
  - Mitigation: The glob is intentional and correct; any future `src/` TypeScript should be linted

---

**Workflow ID**: `7a20de7736a15be963c35006114b5c29`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parity drift detection added: monitors deviations across Sharpe, drawdown, win rate, frequency, price and PnL with rolling-window analytics and configurable tolerance/window.
  * Automatic, severity-based responses: alert, reduce position, or halt trading; halt state can be reset.

* **Documentation / Public API**
  * New config utilities and public types for configuring thresholds and actions.

* **Tests**
  * Extensive test coverage added for comparisons, metrics, flagging, store, responder, config, and rolling-drift logic.

* **Chore**
  * Linting now includes additional TypeScript source files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->