### PR TITLE
feat(git): support configurable git remote name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `worktree.remote` config option in `.archon/config.yaml` for repos using non-standard git remote names
+- `getDefaultRemote()` auto-detection: prefers `origin`, falls back to sole remote, errors on ambiguity
+
 ## [0.3.10] - 2026-04-29
 
 Maintainer workflow suite, loop output variables, and broad workflow engine fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ GitHub App auth for the bot, multi-user attribution, Slack UX overhaul, experime
 - **`safeSendMessage`** consolidated into `executor-shared` to remove duplication across executor variants (#1496).
 - **Direction docs**: community-providers policy section added (#1736).
 
+
+- `worktree.remote` config option in `.archon/config.yaml` for repos using non-standard git remote names
+- `getDefaultRemote()` auto-detection: prefers `origin`, falls back to sole remote, errors on ambiguity
+
 ### Fixed
 
 - **`workflow approve/resume/reject` no longer fail with "Workflow not found" when the run's working path is a worktree or workspace clone.** Resume, approve, and reject now use `codebase.default_cwd` for workflow YAML discovery, falling back to `working_path` when no codebase record is found. Fixes #1663 (#1743).

--- a/packages/core/src/config/config-loader.test.ts
+++ b/packages/core/src/config/config-loader.test.ts
@@ -382,6 +382,59 @@ worktree:
       expect(config.baseBranch).toBeUndefined();
     });
 
+    test('propagates remote from repo worktree config', async () => {
+      const pathMatches = (path: string, pattern: string): boolean => {
+        const normalizedPath = path.replace(/\\/g, '/');
+        return normalizedPath.includes(pattern);
+      };
+
+      mockReadConfigFile.mockImplementation(async (path: string) => {
+        if (pathMatches(path, '/repo/.archon/config.yaml')) {
+          return `
+worktree:
+  remote: upstream
+`;
+        }
+        const error = new Error('ENOENT') as NodeJS.ErrnoException;
+        error.code = 'ENOENT';
+        throw error;
+      });
+
+      const config = await loadConfig('/test/repo');
+      expect(config.remote).toBe('upstream');
+    });
+
+    test('trims whitespace from remote', async () => {
+      const pathMatches = (path: string, pattern: string): boolean => {
+        const normalizedPath = path.replace(/\\/g, '/');
+        return normalizedPath.includes(pattern);
+      };
+
+      mockReadConfigFile.mockImplementation(async (path: string) => {
+        if (pathMatches(path, '/repo/.archon/config.yaml')) {
+          return `
+worktree:
+  remote: "  mar  "
+`;
+        }
+        const error = new Error('ENOENT') as NodeJS.ErrnoException;
+        error.code = 'ENOENT';
+        throw error;
+      });
+
+      const config = await loadConfig('/test/repo');
+      expect(config.remote).toBe('mar');
+    });
+
+    test('remote is undefined when not configured', async () => {
+      const error = new Error('ENOENT') as NodeJS.ErrnoException;
+      error.code = 'ENOENT';
+      mockReadConfigFile.mockRejectedValue(error);
+
+      const config = await loadConfig('/test/repo');
+      expect(config.remote).toBeUndefined();
+    });
+
     test('propagates docsPath from repo docs config', async () => {
       const pathMatches = (path: string, pattern: string): boolean => {
         const normalizedPath = path.replace(/\\/g, '/');

--- a/packages/core/src/config/config-loader.test.ts
+++ b/packages/core/src/config/config-loader.test.ts
@@ -388,7 +388,7 @@ worktree:
         return normalizedPath.includes(pattern);
       };
 
-      mockReadConfigFile.mockImplementation(async (path: string) => {
+      mockFsReadFile.mockImplementation(async (path: string) => {
         if (pathMatches(path, '/repo/.archon/config.yaml')) {
           return `
 worktree:
@@ -410,7 +410,7 @@ worktree:
         return normalizedPath.includes(pattern);
       };
 
-      mockReadConfigFile.mockImplementation(async (path: string) => {
+      mockFsReadFile.mockImplementation(async (path: string) => {
         if (pathMatches(path, '/repo/.archon/config.yaml')) {
           return `
 worktree:
@@ -429,7 +429,7 @@ worktree:
     test('remote is undefined when not configured', async () => {
       const error = new Error('ENOENT') as NodeJS.ErrnoException;
       error.code = 'ENOENT';
-      mockReadConfigFile.mockRejectedValue(error);
+      mockFsReadFile.mockRejectedValue(error);
 
       const config = await loadConfig('/test/repo');
       expect(config.remote).toBeUndefined();

--- a/packages/core/src/config/config-loader.ts
+++ b/packages/core/src/config/config-loader.ts
@@ -455,6 +455,11 @@ function mergeRepoConfig(merged: MergedConfig, repo: RepoConfig): MergedConfig {
     result.baseBranch = repo.worktree.baseBranch.trim();
   }
 
+  // Propagate git remote name for non-origin remote support
+  if (repo.worktree?.remote?.trim()) {
+    result.remote = repo.worktree.remote.trim();
+  }
+
   // Propagate docs path for $DOCS_DIR substitution in workflow commands
   if (repo.docs?.path !== undefined) {
     const trimmed = repo.docs.path.trim();

--- a/packages/core/src/config/config-loader.ts
+++ b/packages/core/src/config/config-loader.ts
@@ -457,6 +457,11 @@ function mergeRepoConfig(merged: MergedConfig, repo: RepoConfig): MergedConfig {
     result.baseBranch = repo.worktree.baseBranch.trim();
   }
 
+  // Propagate git remote name for non-origin remote support
+  if (repo.worktree?.remote?.trim()) {
+    result.remote = repo.worktree.remote.trim();
+  }
+
   // Propagate docs path for $DOCS_DIR substitution in workflow commands
   if (repo.docs?.path !== undefined) {
     const trimmed = repo.docs.path.trim();

--- a/packages/core/src/config/config-loader.ts
+++ b/packages/core/src/config/config-loader.ts
@@ -457,7 +457,7 @@ function mergeRepoConfig(merged: MergedConfig, repo: RepoConfig): MergedConfig {
     result.baseBranch = repo.worktree.baseBranch.trim();
   }
 
-  // Propagate git remote name for non-origin remote support
+  // Pass remote to callers for git fetch/push operations
   if (repo.worktree?.remote?.trim()) {
     result.remote = repo.worktree.remote.trim();
   }

--- a/packages/core/src/config/config-types.ts
+++ b/packages/core/src/config/config-types.ts
@@ -199,6 +199,22 @@ export interface RepoConfig {
      * @example '.worktrees'
      */
     path?: string;
+
+    /**
+     * Git remote name for fetch/push operations.
+     *
+     * Most repos use the standard 'origin' remote, but some (e.g. enterprise
+     * monorepos) use numbered or custom-named remotes. When set, all git
+     * operations (fetch, push, branch tracking) use this remote instead of
+     * 'origin'.
+     *
+     * When omitted, auto-detected: 'origin' if it exists, otherwise the sole
+     * remote if only one is configured. Fails with an actionable error if
+     * multiple non-origin remotes exist and none is named 'origin'.
+     *
+     * @example '264'
+     */
+    remote?: string;
   };
 
   /**
@@ -286,6 +302,11 @@ export interface MergedConfig {
    * When undefined, workflows referencing $BASE_BRANCH will fail with an error.
    */
   baseBranch?: string;
+  /**
+   * Git remote name from repo config (worktree.remote).
+   * When undefined, auto-detected at runtime via getDefaultRemote().
+   */
+  remote?: string;
   /**
    * Docs directory path from repo config (docs.path).
    * Used for $DOCS_DIR substitution in workflow commands.

--- a/packages/core/src/config/config-types.ts
+++ b/packages/core/src/config/config-types.ts
@@ -203,16 +203,16 @@ export interface RepoConfig {
     /**
      * Git remote name for fetch/push operations.
      *
-     * Most repos use the standard 'origin' remote, but some (e.g. enterprise
-     * monorepos) use numbered or custom-named remotes. When set, all git
-     * operations (fetch, push, branch tracking) use this remote instead of
-     * 'origin'.
+     * Most repos use the standard 'origin' remote, but some use custom-named
+     * remotes (e.g. 'jan', 'feb', 'mar' for release-based remotes). When set,
+     * all git operations (fetch, push, branch tracking) use this remote
+     * instead of 'origin'.
      *
      * When omitted, auto-detected: 'origin' if it exists, otherwise the sole
      * remote if only one is configured. Fails with an actionable error if
      * multiple non-origin remotes exist and none is named 'origin'.
      *
-     * @example '264'
+     * @example 'upstream'
      */
     remote?: string;
   };

--- a/packages/core/src/config/config-types.ts
+++ b/packages/core/src/config/config-types.ts
@@ -203,14 +203,12 @@ export interface RepoConfig {
     /**
      * Git remote name for fetch/push operations.
      *
-     * Most repos use the standard 'origin' remote, but some use custom-named
-     * remotes (e.g. 'jan', 'feb', 'mar' for release-based remotes). When set,
-     * all git operations (fetch, push, branch tracking) use this remote
-     * instead of 'origin'.
+     * When set, all git operations (fetch, push, branch tracking) use this
+     * remote instead of 'origin'. Useful for repos with multiple remotes or
+     * non-standard naming conventions.
      *
      * When omitted, auto-detected: 'origin' if it exists, otherwise the sole
-     * remote if only one is configured. Fails with an actionable error if
-     * multiple non-origin remotes exist and none is named 'origin'.
+     * remote if only one is configured.
      *
      * @example 'upstream'
      */

--- a/packages/core/src/config/config-types.ts
+++ b/packages/core/src/config/config-types.ts
@@ -205,16 +205,16 @@ export interface RepoConfig {
     /**
      * Git remote name for fetch/push operations.
      *
-     * Most repos use the standard 'origin' remote, but some (e.g. enterprise
-     * monorepos) use numbered or custom-named remotes. When set, all git
-     * operations (fetch, push, branch tracking) use this remote instead of
-     * 'origin'.
+     * Most repos use the standard 'origin' remote, but some use custom-named
+     * remotes (e.g. 'jan', 'feb', 'mar' for release-based remotes). When set,
+     * all git operations (fetch, push, branch tracking) use this remote
+     * instead of 'origin'.
      *
      * When omitted, auto-detected: 'origin' if it exists, otherwise the sole
      * remote if only one is configured. Fails with an actionable error if
      * multiple non-origin remotes exist and none is named 'origin'.
      *
-     * @example '264'
+     * @example 'upstream'
      */
     remote?: string;
   };

--- a/packages/core/src/config/config-types.ts
+++ b/packages/core/src/config/config-types.ts
@@ -205,14 +205,12 @@ export interface RepoConfig {
     /**
      * Git remote name for fetch/push operations.
      *
-     * Most repos use the standard 'origin' remote, but some use custom-named
-     * remotes (e.g. 'jan', 'feb', 'mar' for release-based remotes). When set,
-     * all git operations (fetch, push, branch tracking) use this remote
-     * instead of 'origin'.
+     * When set, all git operations (fetch, push, branch tracking) use this
+     * remote instead of 'origin'. Useful for repos with multiple remotes or
+     * non-standard naming conventions.
      *
      * When omitted, auto-detected: 'origin' if it exists, otherwise the sole
-     * remote if only one is configured. Fails with an actionable error if
-     * multiple non-origin remotes exist and none is named 'origin'.
+     * remote if only one is configured.
      *
      * @example 'upstream'
      */

--- a/packages/core/src/config/config-types.ts
+++ b/packages/core/src/config/config-types.ts
@@ -201,6 +201,22 @@ export interface RepoConfig {
      * @example '.worktrees'
      */
     path?: string;
+
+    /**
+     * Git remote name for fetch/push operations.
+     *
+     * Most repos use the standard 'origin' remote, but some (e.g. enterprise
+     * monorepos) use numbered or custom-named remotes. When set, all git
+     * operations (fetch, push, branch tracking) use this remote instead of
+     * 'origin'.
+     *
+     * When omitted, auto-detected: 'origin' if it exists, otherwise the sole
+     * remote if only one is configured. Fails with an actionable error if
+     * multiple non-origin remotes exist and none is named 'origin'.
+     *
+     * @example '264'
+     */
+    remote?: string;
   };
 
   /**
@@ -288,6 +304,11 @@ export interface MergedConfig {
    * When undefined, workflows referencing $BASE_BRANCH will fail with an error.
    */
   baseBranch?: string;
+  /**
+   * Git remote name from repo config (worktree.remote).
+   * When undefined, auto-detected at runtime via getDefaultRemote().
+   */
+  remote?: string;
   /**
    * Docs directory path from repo config (docs.path).
    * Used for $DOCS_DIR substitution in workflow commands.

--- a/packages/core/src/handlers/command-handler.ts
+++ b/packages/core/src/handlers/command-handler.ts
@@ -17,7 +17,7 @@ import {
   getWorktreeStatusBreakdown,
 } from '../services/cleanup-service';
 import { getArchonWorkspacesPath } from '@archon/paths';
-import { loadConfig } from '../config/config-loader';
+import { loadConfig, loadRepoConfig } from '../config/config-loader';
 import { discoverWorkflowsWithConfig } from '@archon/workflows/workflow-discovery';
 import { resolveWorkflowName } from '@archon/workflows/router';
 import type {
@@ -494,9 +494,11 @@ async function handleWorktreeCommand(
       }
 
       try {
+        const repoConf = await loadRepoConfig(mainPath);
+        const remote = repoConf.worktree?.remote?.trim() || undefined;
         let result;
         if (cleanupType === 'merged') {
-          result = await cleanupMergedWorktrees(conversation.codebase_id, mainPath);
+          result = await cleanupMergedWorktrees(conversation.codebase_id, mainPath, { remote });
         } else {
           result = await cleanupStaleWorktrees(conversation.codebase_id, mainPath);
         }
@@ -1034,7 +1036,13 @@ Talk naturally — the orchestrator routes your requests to the right workflow a
       // Add worktree breakdown if codebase is configured
       if (codebase) {
         try {
-          const breakdown = await getWorktreeStatusBreakdown(codebase.id, codebase.default_cwd);
+          const statusConf = await loadRepoConfig(codebase.default_cwd);
+          const statusRemote = statusConf.worktree?.remote?.trim() || undefined;
+          const breakdown = await getWorktreeStatusBreakdown(
+            codebase.id,
+            codebase.default_cwd,
+            statusRemote
+          );
           msg += `\n\nWorktrees: ${String(breakdown.total)} active`;
           if (breakdown.merged > 0 || breakdown.stale > 0) {
             if (breakdown.merged > 0) {

--- a/packages/core/src/operations/isolation-operations.ts
+++ b/packages/core/src/operations/isolation-operations.ts
@@ -168,7 +168,7 @@ export async function cleanupStaleEnvironments(
 export async function cleanupMergedEnvironments(
   codebaseId: string,
   mainPath: string,
-  options: { includeClosed?: boolean } = {}
+  options: { includeClosed?: boolean; remote?: string } = {}
 ): Promise<CleanupOperationResult> {
   return cleanupMergedWorktrees(codebaseId, mainPath, options);
 }

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -159,6 +159,7 @@ mock.module('../db/workflow-events', () => ({
 
 mock.module('../config/config-loader', () => ({
   loadConfig: mockLoadConfig,
+  loadRepoConfig: mock(() => Promise.resolve({})),
 }));
 
 mock.module('../services/title-generator', () => ({
@@ -204,6 +205,7 @@ mock.module('../utils/worktree-sync', () => ({
 }));
 
 mock.module('@archon/git', () => ({
+  getDefaultRemote: mock(() => Promise.resolve('origin')),
   syncWorkspace: mockSyncWorkspace,
   toRepoPath: mockToRepoPath,
 }));
@@ -986,9 +988,11 @@ describe('discoverAllWorkflows — remote sync', () => {
     await handleMessage(platform, 'conv-1', 'What is the latest commit?');
 
     // /repos/test-repo is NOT under ~/.archon/workspaces/ so resetAfterFetch=false
-    expect(mockSyncWorkspace).toHaveBeenCalledWith('/repos/test-repo', undefined, {
-      resetAfterFetch: false,
-    });
+    expect(mockSyncWorkspace).toHaveBeenCalledWith(
+      '/repos/test-repo',
+      undefined,
+      expect.objectContaining({ resetAfterFetch: false })
+    );
     // Regression guard: orchestrator must resolve cwd through the ensure variant
     // so the workspaces dir is created before the AI provider spawn (issue #1528).
     expect(mockEnsureArchonWorkspacesPath).toHaveBeenCalled();
@@ -1009,7 +1013,7 @@ describe('discoverAllWorkflows — remote sync', () => {
     expect(mockSyncWorkspace).toHaveBeenCalledWith(
       '/home/test/.archon/workspaces/owner/repo/source',
       undefined,
-      { resetAfterFetch: true }
+      expect.objectContaining({ resetAfterFetch: true })
     );
   });
 
@@ -1025,9 +1029,11 @@ describe('discoverAllWorkflows — remote sync', () => {
     await expect(
       handleMessage(platform, 'conv-1', 'What is the latest commit?')
     ).resolves.toBeUndefined();
-    expect(mockSyncWorkspace).toHaveBeenCalledWith('/repos/test-repo', undefined, {
-      resetAfterFetch: false,
-    });
+    expect(mockSyncWorkspace).toHaveBeenCalledWith(
+      '/repos/test-repo',
+      undefined,
+      expect.objectContaining({ resetAfterFetch: false })
+    );
   });
 
   test('does not call syncWorkspace when conversation has no codebase_id', async () => {

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -27,7 +27,7 @@ import { toError } from '../utils/error';
 import { getAgentProvider, getProviderCapabilities } from '@archon/providers';
 import { getArchonWorkspacesPath } from '@archon/paths';
 import { syncArchonToWorktree } from '../utils/worktree-sync';
-import { syncWorkspace, toRepoPath } from '@archon/git';
+import { getDefaultRemote, syncWorkspace, toRepoPath } from '@archon/git';
 import type { WorkspaceSyncResult } from '@archon/git';
 import { discoverWorkflowsWithConfig } from '@archon/workflows/workflow-discovery';
 import { findWorkflow } from '@archon/workflows/router';
@@ -38,7 +38,7 @@ import type {
   WorkflowLoadError,
 } from '@archon/workflows/schemas/workflow';
 import { createWorkflowDeps } from '../workflows/store-adapter';
-import { loadConfig } from '../config/config-loader';
+import { loadConfig, loadRepoConfig } from '../config/config-loader';
 import type { MergedConfig } from '../config/config-types';
 import { generateAndSetTitle } from '../services/title-generator';
 import { validateAndResolveIsolation, dispatchBackgroundWorkflow } from './orchestrator';
@@ -434,8 +434,13 @@ async function discoverAllWorkflows(conversation: Conversation): Promise<Discove
           const isManagedClone = codebase.default_cwd
             .replace(/\\/g, '/')
             .startsWith(getArchonWorkspacesPath().replace(/\\/g, '/'));
-          syncResult = await syncWorkspace(toRepoPath(codebase.default_cwd), undefined, {
+          const repoPath = toRepoPath(codebase.default_cwd);
+          const repoConf = await loadRepoConfig(codebase.default_cwd);
+          const remote =
+            repoConf.worktree?.remote?.trim() || (await getDefaultRemote(repoPath)) || undefined;
+          syncResult = await syncWorkspace(repoPath, undefined, {
             resetAfterFetch: isManagedClone,
+            remote,
           });
           getLog().debug(
             {

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -28,7 +28,7 @@ import { getAgentProvider, getProviderCapabilities } from '@archon/providers';
 import { buildManageRunTool } from './manage-run-tool';
 import { getArchonWorkspacesPath, ensureArchonWorkspacesPath } from '@archon/paths';
 import { syncArchonToWorktree } from '../utils/worktree-sync';
-import { syncWorkspace, toRepoPath } from '@archon/git';
+import { getDefaultRemote, syncWorkspace, toRepoPath } from '@archon/git';
 import type { WorkspaceSyncResult } from '@archon/git';
 import { discoverWorkflowsWithConfig } from '@archon/workflows/workflow-discovery';
 import { findWorkflow, resolveWorkflowName } from '@archon/workflows/router';
@@ -46,7 +46,7 @@ import type {
 import { isPerUserGitHubEnabled } from '../github-auth/config';
 import { getDecryptedAccessToken } from '../db/user-github-token-store';
 import { createWorkflowDeps } from '../workflows/store-adapter';
-import { loadConfig } from '../config/config-loader';
+import { loadConfig, loadRepoConfig } from '../config/config-loader';
 import type { MergedConfig } from '../config/config-types';
 import { generateAndSetTitle } from '../services/title-generator';
 import { validateAndResolveIsolation, dispatchBackgroundWorkflow } from './orchestrator';
@@ -614,8 +614,13 @@ async function discoverAllWorkflows(conversation: Conversation): Promise<Discove
           const isManagedClone = codebase.default_cwd
             .replace(/\\/g, '/')
             .startsWith(getArchonWorkspacesPath().replace(/\\/g, '/'));
-          syncResult = await syncWorkspace(toRepoPath(codebase.default_cwd), undefined, {
+          const repoPath = toRepoPath(codebase.default_cwd);
+          const repoConf = await loadRepoConfig(codebase.default_cwd);
+          const remote =
+            repoConf.worktree?.remote?.trim() || (await getDefaultRemote(repoPath)) || undefined;
+          syncResult = await syncWorkspace(repoPath, undefined, {
             resetAfterFetch: isManagedClone,
+            remote,
           });
           getLog().debug(
             {

--- a/packages/core/src/services/cleanup-service.ts
+++ b/packages/core/src/services/cleanup-service.ts
@@ -447,7 +447,8 @@ export interface CleanupOperationResult {
  */
 export async function getWorktreeStatusBreakdown(
   codebaseId: string,
-  mainRepoPath: string
+  mainRepoPath: string,
+  remote?: string
 ): Promise<WorktreeStatusBreakdown> {
   const environments = await isolationEnvDb.listByCodebaseWithAge(codebaseId);
 
@@ -462,7 +463,7 @@ export async function getWorktreeStatusBreakdown(
     activeEnvs: [],
   };
 
-  const mainBranch = await getDefaultBranch(repoPath);
+  const mainBranch = await getDefaultBranch(repoPath, remote);
 
   for (const env of environments) {
     // Skip Telegram (never shown as stale)
@@ -560,7 +561,8 @@ async function isSafeToRemove(
   branchName: BranchName,
   mainBranch: BranchName,
   prStateCache: Map<string, PrState>,
-  includeClosed: boolean
+  includeClosed: boolean,
+  remote?: string
 ): Promise<{ safe: boolean; openPr: boolean }> {
   // (a) Fast path — fast-forward / merge-commit ancestry
   if (await isBranchMerged(repoPath, branchName, mainBranch)) {
@@ -571,7 +573,7 @@ async function isSafeToRemove(
     return { safe: true, openPr: false };
   }
   // (c) GitHub PR state
-  const prState = await getPrState(branchName, repoPath, prStateCache);
+  const prState = await getPrState(branchName, repoPath, prStateCache, remote);
   if (prState === 'MERGED') return { safe: true, openPr: false };
   if (prState === 'CLOSED') return { safe: includeClosed, openPr: false };
   if (prState === 'OPEN') return { safe: false, openPr: true };
@@ -585,17 +587,16 @@ async function isSafeToRemove(
 export async function cleanupMergedWorktrees(
   codebaseId: string,
   mainRepoPath: string,
-  options: { includeClosed?: boolean } = {}
+  options: { includeClosed?: boolean; remote?: string } = {}
 ): Promise<CleanupOperationResult> {
   const result: CleanupOperationResult = { removed: [], skipped: [] };
   const environments = await isolationEnvDb.listByCodebase(codebaseId);
   const repoPath = toRepoPath(mainRepoPath);
-  const mainBranch = await getDefaultBranch(repoPath);
+  const mainBranch = await getDefaultBranch(repoPath, options.remote);
   const includeClosed = options.includeClosed ?? false;
   const prStateCache = new Map<string, PrState>();
 
   for (const env of environments) {
-    // Check if safe to remove via union of signals (skip env on unexpected errors)
     let safe = false;
     let openPr = false;
     try {
@@ -605,7 +606,8 @@ export async function cleanupMergedWorktrees(
         branchName,
         mainBranch,
         prStateCache,
-        includeClosed
+        includeClosed,
+        options.remote
       );
       safe = decision.safe;
       openPr = decision.openPr;

--- a/packages/core/src/services/cleanup-service.ts
+++ b/packages/core/src/services/cleanup-service.ts
@@ -23,6 +23,7 @@ import {
 import type { RepoPath, BranchName } from '@archon/git';
 import { createLogger } from '@archon/paths';
 import type { IsolationEnvironmentRow } from '@archon/isolation';
+import { loadRepoConfig } from '../config/config-loader';
 import { ConversationNotFoundError } from '../types';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
@@ -243,10 +244,10 @@ export async function removeEnvironment(
  */
 export async function cleanupToMakeRoom(
   codebaseId: string,
-  mainRepoPath: string
+  mainRepoPath: string,
+  options: { remote?: string } = {}
 ): Promise<CleanupOperationResult> {
-  // Reuse the merged cleanup logic
-  return cleanupMergedWorktrees(codebaseId, mainRepoPath);
+  return cleanupMergedWorktrees(codebaseId, mainRepoPath, options);
 }
 
 /**
@@ -308,7 +309,9 @@ export async function runScheduledCleanup(): Promise<CleanupReport> {
 
         // Check if branch is merged
         const mainRepoPath = toRepoPath(env.codebase_default_cwd);
-        const mainBranch = await getDefaultBranch(mainRepoPath);
+        const envRemote =
+          (await loadRepoConfig(env.codebase_default_cwd)).worktree?.remote?.trim() || undefined;
+        const mainBranch = await getDefaultBranch(mainRepoPath, envRemote);
         const merged = await isBranchMerged(
           mainRepoPath,
           toBranchName(env.branch_name),

--- a/packages/core/src/services/cleanup-service.ts
+++ b/packages/core/src/services/cleanup-service.ts
@@ -309,8 +309,16 @@ export async function runScheduledCleanup(): Promise<CleanupReport> {
 
         // Check if branch is merged
         const mainRepoPath = toRepoPath(env.codebase_default_cwd);
-        const envRemote =
-          (await loadRepoConfig(env.codebase_default_cwd)).worktree?.remote?.trim() || undefined;
+        let envRemote: string | undefined;
+        try {
+          envRemote =
+            (await loadRepoConfig(env.codebase_default_cwd)).worktree?.remote?.trim() || undefined;
+        } catch (configErr) {
+          getLog().warn(
+            { err: configErr as Error, cwd: env.codebase_default_cwd },
+            'cleanup.repo_config_load_failed'
+          );
+        }
         const mainBranch = await getDefaultBranch(mainRepoPath, envRemote);
         const merged = await isBranchMerged(
           mainRepoPath,
@@ -616,6 +624,10 @@ export async function cleanupMergedWorktrees(
       openPr = decision.openPr;
     } catch (error) {
       const err = error as Error;
+      getLog().warn(
+        { err, branchName: env.branch_name, repoPath: mainRepoPath },
+        'cleanup.is_safe_to_remove_failed'
+      );
       result.skipped.push({
         branchName: env.branch_name,
         reason: `merge check failed: ${err.message}`,

--- a/packages/docs-web/src/content/docs/reference/configuration.md
+++ b/packages/docs-web/src/content/docs/reference/configuration.md
@@ -133,6 +133,8 @@ worktree:
                         # <repoRoot>/.worktrees/<branch> instead of under
                         # ~/.archon/workspaces/<owner>/<repo>/worktrees/.
                         # Must be relative; no absolute, no `..` segments.
+  remote: origin        # Optional: git remote name for fetch/push. Auto-detected
+                        # when omitted (origin if exists, sole remote otherwise).
 
 # Documentation directory
 docs:
@@ -206,9 +208,14 @@ worktree:
 
 **Submodule behavior:** When a repo contains `.gitmodules`, submodules are initialized in new worktrees by default (git's `worktree add` does not do this). The check is a cheap filesystem probe — repos without submodules pay zero cost. Submodule init failure throws a classified error (credentials, network, timeout) rather than silently producing a worktree with empty submodule directories. Set `worktree.initSubmodules: false` to opt out.
 
+**Remote behavior:** By default, all git operations (fetch, push, branch tracking) use the `origin` remote. If your repo uses a different remote name, configure `worktree.remote`. Resolution order:
+1. If `worktree.remote` is set: Uses the configured remote name for all operations.
+2. If omitted: Auto-detects via `getDefaultRemote()` — returns `origin` if it exists, otherwise the sole remote if only one is configured.
+3. If multiple non-origin remotes exist and none is named `origin`: **Fails with an actionable error** listing the available remotes and suggesting the config fix.
+
 **Base branch behavior:** Before creating a worktree, the canonical workspace is synced to the latest code. Resolution order:
-1. If `worktree.baseBranch` is set: Uses the configured branch. **Fails with an error** if the branch doesn't exist on remote (no silent fallback).
-2. If omitted: Auto-detects the default branch via `git remote show origin`. Works without any config for standard repos.
+1. If `worktree.baseBranch` is set: Uses the configured branch. **Fails with an error** if the branch doesn't exist on the resolved remote (no silent fallback).
+2. If omitted: Auto-detects the default branch via symbolic-ref on the resolved remote. Works without any config for standard repos.
 3. If auto-detection fails and a workflow references `$BASE_BRANCH`: Fails with an error explaining the resolution chain.
 
 **Docs path behavior:** The `docs.path` setting controls where the `$DOCS_DIR` variable points. When not configured, `$DOCS_DIR` defaults to `docs/`. Unlike `$BASE_BRANCH`, this variable always has a safe default and never throws an error. Configure it when your documentation lives outside the standard `docs/` directory (e.g., `packages/docs-web/src/content/docs`).

--- a/packages/docs-web/src/content/docs/reference/configuration.md
+++ b/packages/docs-web/src/content/docs/reference/configuration.md
@@ -135,6 +135,8 @@ worktree:
                         # <repoRoot>/.worktrees/<branch> instead of under
                         # ~/.archon/workspaces/<owner>/<repo>/worktrees/.
                         # Must be relative; no absolute, no `..` segments.
+  remote: origin        # Optional: git remote name for fetch/push. Auto-detected
+                        # when omitted (origin if exists, sole remote otherwise).
 
 # Documentation directory
 docs:
@@ -208,9 +210,14 @@ worktree:
 
 **Submodule behavior:** When a repo contains `.gitmodules`, submodules are initialized in new worktrees by default (git's `worktree add` does not do this). The check is a cheap filesystem probe — repos without submodules pay zero cost. Submodule init failure throws a classified error (credentials, network, timeout) rather than silently producing a worktree with empty submodule directories. Set `worktree.initSubmodules: false` to opt out.
 
+**Remote behavior:** By default, all git operations (fetch, push, branch tracking) use the `origin` remote. If your repo uses a different remote name, configure `worktree.remote`. Resolution order:
+1. If `worktree.remote` is set: Uses the configured remote name for all operations.
+2. If omitted: Auto-detects via `getDefaultRemote()` — returns `origin` if it exists, otherwise the sole remote if only one is configured.
+3. If multiple non-origin remotes exist and none is named `origin`: **Fails with an actionable error** listing the available remotes and suggesting the config fix.
+
 **Base branch behavior:** Before creating a worktree, the canonical workspace is synced to the latest code. Resolution order:
-1. If `worktree.baseBranch` is set: Uses the configured branch. **Fails with an error** if the branch doesn't exist on remote (no silent fallback).
-2. If omitted: Auto-detects the default branch via `git remote show origin`. Works without any config for standard repos.
+1. If `worktree.baseBranch` is set: Uses the configured branch. **Fails with an error** if the branch doesn't exist on the resolved remote (no silent fallback).
+2. If omitted: Auto-detects the default branch via symbolic-ref on the resolved remote. Works without any config for standard repos.
 3. If auto-detection fails and a workflow references `$BASE_BRANCH`: Fails with an error explaining the resolution chain.
 
 **Docs path behavior:** The `docs.path` setting controls where the `$DOCS_DIR` variable points. When not configured, `$DOCS_DIR` defaults to `docs/`. Unlike `$BASE_BRANCH`, this variable always has a safe default and never throws an error. Configure it when your documentation lives outside the standard `docs/` directory (e.g., `packages/docs-web/src/content/docs`).

--- a/packages/git/src/branch.ts
+++ b/packages/git/src/branch.ts
@@ -14,23 +14,26 @@ function getLog(): ReturnType<typeof createLogger> {
  * Get the default branch name for a repository
  * Uses git symbolic-ref to get the remote HEAD reference
  *
- * Fallback chain: symbolic-ref -> origin/main -> throw
- * Note: Throws if neither origin/HEAD nor origin/main can be resolved.
+ * Fallback chain: symbolic-ref -> <remote>/main -> throw
+ * Note: Throws if neither <remote>/HEAD nor <remote>/main can be resolved.
  * Callers can set worktree.baseBranch in .archon/config.yaml as a manual override.
  *
  * Only falls back for expected git errors (ref not found, branch not found).
  * Throws for unexpected errors (permission denied, git corruption, etc.)
+ *
+ * @param repoPath - Path to the git repository
+ * @param remote - Remote name to check (default: 'origin')
  */
-export async function getDefaultBranch(repoPath: RepoPath): Promise<BranchName> {
+export async function getDefaultBranch(repoPath: RepoPath, remote = 'origin'): Promise<BranchName> {
   // Try to get from remote HEAD
   try {
     const { stdout } = await execFileAsync(
       'git',
-      ['-C', repoPath, 'symbolic-ref', 'refs/remotes/origin/HEAD', '--short'],
+      ['-C', repoPath, 'symbolic-ref', `refs/remotes/${remote}/HEAD`, '--short'],
       { timeout: 10000 }
     );
     // stdout is like "origin/main" - extract just the branch name
-    return toBranchName(stdout.trim().replace('origin/', ''));
+    return toBranchName(stdout.trim().replace(`${remote}/`, ''));
   } catch (error) {
     const err = error as Error & { stderr?: string };
     const errorText = `${err.message} ${err.stderr ?? ''}`;
@@ -40,17 +43,20 @@ export async function getDefaultBranch(repoPath: RepoPath): Promise<BranchName> 
       errorText.includes('not a symbolic ref') ||
       errorText.includes('No such file or directory')
     ) {
-      getLog().debug({ repoPath, err }, 'symbolic_ref_fallback');
+      getLog().debug({ repoPath, remote, err }, 'symbolic_ref_fallback');
     } else {
       // Unexpected error (permission denied, git corruption, etc.) - surface it
-      getLog().error({ repoPath, err, stderr: err.stderr }, 'default_branch_symbolic_ref_failed');
+      getLog().error(
+        { repoPath, remote, err, stderr: err.stderr },
+        'default_branch_symbolic_ref_failed'
+      );
       throw new Error(`Failed to get default branch for ${repoPath}: ${err.message}`);
     }
   }
 
-  // Fallback: check if origin/main exists, otherwise throw
+  // Fallback: check if <remote>/main exists, otherwise throw
   try {
-    await execFileAsync('git', ['-C', repoPath, 'rev-parse', '--verify', 'origin/main'], {
+    await execFileAsync('git', ['-C', repoPath, 'rev-parse', '--verify', `${remote}/main`], {
       timeout: 10000,
     });
     return toBranchName('main');
@@ -58,21 +64,21 @@ export async function getDefaultBranch(repoPath: RepoPath): Promise<BranchName> 
     const err = error as Error & { stderr?: string };
     const errorText = `${err.message} ${err.stderr ?? ''}`;
 
-    // Expected: origin/main doesn't exist — no safe default, fail fast
+    // Expected: <remote>/main doesn't exist — no safe default, fail fast
     if (
       errorText.includes('Not a valid object name') ||
       errorText.includes('Needed a single revision') ||
       errorText.includes('unknown revision')
     ) {
-      getLog().warn({ repoPath }, 'default_branch_detection_failed');
+      getLog().warn({ repoPath, remote }, 'default_branch_detection_failed');
       throw new Error(
-        `Cannot detect default branch for ${repoPath}: neither origin/HEAD nor origin/main exist. ` +
+        `Cannot detect default branch for ${repoPath}: neither ${remote}/HEAD nor ${remote}/main exist. ` +
           'Set worktree.baseBranch in .archon/config.yaml to specify the branch explicitly.'
       );
     }
 
     // Unexpected error - surface it
-    getLog().error({ repoPath, err, stderr: err.stderr }, 'verify_origin_main_failed');
+    getLog().error({ repoPath, remote, err, stderr: err.stderr }, 'verify_origin_main_failed');
     throw new Error(`Failed to get default branch for ${repoPath}: ${err.message}`);
   }
 }

--- a/packages/git/src/git.test.ts
+++ b/packages/git/src/git.test.ts
@@ -1499,11 +1499,11 @@ branch refs/heads/feature/auth
     test('uses custom remote when provided in options', async () => {
       execSpy.mockResolvedValue({ stdout: '', stderr: '' });
 
-      await git.syncWorkspace('/workspace/repo', 'main', { remote: '264' });
+      await git.syncWorkspace('/workspace/repo', 'main', { remote: 'mar' });
 
       expect(execSpy).toHaveBeenCalledWith(
         'git',
-        ['-C', '/workspace/repo', 'fetch', '264', 'main'],
+        ['-C', '/workspace/repo', 'fetch', 'mar', 'main'],
         expect.any(Object)
       );
 
@@ -1512,7 +1512,7 @@ branch refs/heads/feature/auth
         return args.includes('reset');
       });
       expect(resetCalls).toHaveLength(1);
-      expect(resetCalls[0][1]).toEqual(['-C', '/workspace/repo', 'reset', '--hard', '264/main']);
+      expect(resetCalls[0][1]).toEqual(['-C', '/workspace/repo', 'reset', '--hard', 'mar/main']);
     });
 
     test('passes custom remote to getDefaultBranch when baseBranch not provided', async () => {
@@ -1527,13 +1527,13 @@ branch refs/heads/feature/auth
     test('includes remote name in error message for custom remote', async () => {
       execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
         if (args.includes('fetch')) {
-          throw new Error("fatal: '264' does not appear to be a git repository");
+          throw new Error("fatal: 'mar' does not appear to be a git repository");
         }
         return { stdout: '', stderr: '' };
       });
 
-      await expect(git.syncWorkspace('/workspace/repo', 'main', { remote: '264' })).rejects.toThrow(
-        'Sync fetch from 264/main failed'
+      await expect(git.syncWorkspace('/workspace/repo', 'main', { remote: 'mar' })).rejects.toThrow(
+        'Sync fetch from mar/main failed'
       );
     });
   });
@@ -1557,14 +1557,14 @@ branch refs/heads/feature/auth
     });
 
     test('returns sole remote when only one is configured', async () => {
-      execSpy.mockResolvedValue({ stdout: '264\n', stderr: '' });
+      execSpy.mockResolvedValue({ stdout: 'mar\n', stderr: '' });
 
       const result = await git.getDefaultRemote('/workspace/repo');
-      expect(result).toBe('264');
+      expect(result).toBe('mar');
     });
 
     test('returns null when multiple non-origin remotes exist', async () => {
-      execSpy.mockResolvedValue({ stdout: '260\n262\n264\n', stderr: '' });
+      execSpy.mockResolvedValue({ stdout: 'jan\nfeb\nmar\n', stderr: '' });
 
       const result = await git.getDefaultRemote('/workspace/repo');
       expect(result).toBeNull();

--- a/packages/git/src/git.test.ts
+++ b/packages/git/src/git.test.ts
@@ -1577,11 +1577,17 @@ branch refs/heads/feature/auth
       expect(result).toBeNull();
     });
 
-    test('returns null on git error', async () => {
+    test('propagates git errors instead of swallowing them', async () => {
       execSpy.mockRejectedValue(new Error('not a git repository'));
 
+      await expect(git.getDefaultRemote('/workspace/repo')).rejects.toThrow('not a git repository');
+    });
+
+    test('handles CRLF line endings from git output', async () => {
+      execSpy.mockResolvedValue({ stdout: 'origin\r\nupstream\r\n', stderr: '' });
+
       const result = await git.getDefaultRemote('/workspace/repo');
-      expect(result).toBeNull();
+      expect(result).toBe('origin');
     });
   });
 

--- a/packages/git/src/git.test.ts
+++ b/packages/git/src/git.test.ts
@@ -1432,7 +1432,7 @@ branch refs/heads/feature/auth
         newHead: '',
         updated: false,
       });
-      expect(getDefaultBranchSpy).toHaveBeenCalledWith('/workspace/repo');
+      expect(getDefaultBranchSpy).toHaveBeenCalledWith('/workspace/repo', 'origin');
     });
 
     test('throws actionable error when configured branch not found on remote', async () => {
@@ -1494,6 +1494,94 @@ branch refs/heads/feature/auth
         return args.includes('reset');
       });
       expect(resetCalls).toHaveLength(0);
+    });
+
+    test('uses custom remote when provided in options', async () => {
+      execSpy.mockResolvedValue({ stdout: '', stderr: '' });
+
+      await git.syncWorkspace('/workspace/repo', 'main', { remote: '264' });
+
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        ['-C', '/workspace/repo', 'fetch', '264', 'main'],
+        expect.any(Object)
+      );
+
+      const resetCalls = execSpy.mock.calls.filter((call: unknown[]) => {
+        const args = call[1] as string[];
+        return args.includes('reset');
+      });
+      expect(resetCalls).toHaveLength(1);
+      expect(resetCalls[0][1]).toEqual(['-C', '/workspace/repo', 'reset', '--hard', '264/main']);
+    });
+
+    test('passes custom remote to getDefaultBranch when baseBranch not provided', async () => {
+      execSpy.mockResolvedValue({ stdout: '', stderr: '' });
+      getDefaultBranchSpy.mockResolvedValue('develop');
+
+      await git.syncWorkspace('/workspace/repo', undefined, { remote: 'upstream' });
+
+      expect(getDefaultBranchSpy).toHaveBeenCalledWith('/workspace/repo', 'upstream');
+    });
+
+    test('includes remote name in error message for custom remote', async () => {
+      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args.includes('fetch')) {
+          throw new Error("fatal: '264' does not appear to be a git repository");
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      await expect(git.syncWorkspace('/workspace/repo', 'main', { remote: '264' })).rejects.toThrow(
+        'Sync fetch from 264/main failed'
+      );
+    });
+  });
+
+  describe('getDefaultRemote', () => {
+    let execSpy: Mock<typeof git.execFileAsync>;
+
+    beforeEach(() => {
+      execSpy = spyOn(git, 'execFileAsync');
+    });
+
+    afterEach(() => {
+      execSpy.mockRestore();
+    });
+
+    test('returns origin when it exists among multiple remotes', async () => {
+      execSpy.mockResolvedValue({ stdout: 'origin\nupstream\n', stderr: '' });
+
+      const result = await git.getDefaultRemote('/workspace/repo');
+      expect(result).toBe('origin');
+    });
+
+    test('returns sole remote when only one is configured', async () => {
+      execSpy.mockResolvedValue({ stdout: '264\n', stderr: '' });
+
+      const result = await git.getDefaultRemote('/workspace/repo');
+      expect(result).toBe('264');
+    });
+
+    test('returns null when multiple non-origin remotes exist', async () => {
+      execSpy.mockResolvedValue({ stdout: '260\n262\n264\n', stderr: '' });
+
+      const result = await git.getDefaultRemote('/workspace/repo');
+      expect(result).toBeNull();
+    });
+
+    test('returns null when no remotes are configured', async () => {
+      execSpy.mockResolvedValue({ stdout: '', stderr: '' });
+
+      const result = await git.getDefaultRemote('/workspace/repo');
+      expect(result).toBeNull();
+    });
+
+    test('returns null on git error', async () => {
+      execSpy.mockRejectedValue(new Error('not a git repository'));
+
+      const result = await git.getDefaultRemote('/workspace/repo');
+      expect(result).toBeNull();
     });
   });
 

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -43,6 +43,7 @@ export {
 // Repository operations
 export {
   findRepoRoot,
+  getDefaultRemote,
   getRemoteUrl,
   syncWorkspace,
   cloneRepository,

--- a/packages/git/src/repo.ts
+++ b/packages/git/src/repo.ts
@@ -39,12 +39,40 @@ export async function findRepoRoot(startPath: string): Promise<RepoPath | null> 
 }
 
 /**
- * Get the remote URL for origin (if it exists)
- * Returns null if no remote is configured
+ * Detect the default remote name for a repository.
+ *
+ * Resolution order:
+ *   1. 'origin' — if it exists (standard Git convention)
+ *   2. The sole remote — if only one is configured
+ *   3. null — ambiguous (multiple non-origin remotes)
+ *
+ * Callers can override via `worktree.remote` in `.archon/config.yaml`.
  */
-export async function getRemoteUrl(repoPath: RepoPath): Promise<string | null> {
+export async function getDefaultRemote(repoPath: RepoPath): Promise<string | null> {
   try {
-    const { stdout } = await execFileAsync('git', ['-C', repoPath, 'remote', 'get-url', 'origin'], {
+    const { stdout } = await execFileAsync('git', ['-C', repoPath, 'remote'], { timeout: 10000 });
+    const remotes = stdout
+      .trim()
+      .split('\n')
+      .filter(r => r.length > 0);
+    if (remotes.length === 0) return null;
+    if (remotes.includes('origin')) return 'origin';
+    if (remotes.length === 1) return remotes[0];
+    return null;
+  } catch (error) {
+    const err = error as Error & { stderr?: string };
+    getLog().error({ repoPath, err, stderr: err.stderr }, 'get_default_remote_failed');
+    return null;
+  }
+}
+
+/**
+ * Get the remote URL for a remote (defaults to 'origin').
+ * Returns null if no remote is configured.
+ */
+export async function getRemoteUrl(repoPath: RepoPath, remote = 'origin'): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('git', ['-C', repoPath, 'remote', 'get-url', remote], {
       timeout: 10000,
     });
     return stdout.trim() || null;
@@ -52,7 +80,6 @@ export async function getRemoteUrl(repoPath: RepoPath): Promise<string | null> {
     const err = error as Error & { stderr?: string };
     const errorText = `${err.message} ${err.stderr ?? ''}`;
 
-    // Expected: no remote named origin
     if (
       errorText.includes('No such remote') ||
       errorText.includes('does not have a url configured')
@@ -60,9 +87,8 @@ export async function getRemoteUrl(repoPath: RepoPath): Promise<string | null> {
       return null;
     }
 
-    // Unexpected error - surface it
-    getLog().error({ repoPath, err, stderr: err.stderr }, 'get_remote_url_failed');
-    throw new Error(`Failed to get remote URL for ${repoPath}: ${err.message}`);
+    getLog().error({ repoPath, remote, err, stderr: err.stderr }, 'get_remote_url_failed');
+    throw new Error(`Failed to get remote URL for ${repoPath} (remote: ${remote}): ${err.message}`);
   }
 }
 
@@ -87,47 +113,46 @@ export async function getRemoteUrl(repoPath: RepoPath): Promise<string | null> {
  *
  * @param workspacePath - Path to the workspace (canonical repo, not worktree)
  * @param baseBranch - Optional base branch name (e.g., 'main', 'develop'). If omitted, auto-detects default branch
- * @param options - Optional settings. `resetAfterFetch` (default true) controls whether `git reset --hard` runs after fetch.
+ * @param options - Optional settings:
+ *   - `resetAfterFetch` (default true): controls whether `git reset --hard` runs after fetch
+ *   - `remote` (default 'origin'): git remote name to fetch from
  * @returns Branch used plus whether sync was performed
  * @throws Error with actionable message if configured branch doesn't exist
  */
 export async function syncWorkspace(
   workspacePath: RepoPath,
   baseBranch?: BranchName,
-  options?: { resetAfterFetch?: boolean }
+  options?: { resetAfterFetch?: boolean; remote?: string }
 ): Promise<WorkspaceSyncResult> {
   const shouldReset = options?.resetAfterFetch ?? true;
-  const branchToSync = baseBranch ?? (await getDefaultBranch(workspacePath));
+  const remote = options?.remote ?? 'origin';
+  const branchToSync = baseBranch ?? (await getDefaultBranch(workspacePath, remote));
 
-  // Fetch from origin to ensure origin/<branchToSync> is up-to-date
   try {
-    await execFileAsync('git', ['-C', workspacePath, 'fetch', 'origin', branchToSync], {
+    await execFileAsync('git', ['-C', workspacePath, 'fetch', remote, branchToSync], {
       timeout: 60000,
     });
   } catch (error) {
     const err = error as Error;
     const errorMessage = err.message.toLowerCase();
 
-    // If configured branch doesn't exist on remote, provide actionable error
     if (
       baseBranch &&
       (errorMessage.includes("couldn't find remote ref") || errorMessage.includes('not found'))
     ) {
       throw new Error(
-        `Configured base branch '${baseBranch}' not found on remote. ` +
+        `Configured base branch '${baseBranch}' not found on remote '${remote}'. ` +
           'Either create the branch, update worktree.baseBranch in .archon/config.yaml, ' +
           'or remove the setting to use the auto-detected default branch.'
       );
     }
-    throw new Error(`Sync fetch from origin/${branchToSync} failed: ${err.message}`);
+    throw new Error(`Sync fetch from ${remote}/${branchToSync} failed: ${err.message}`);
   }
 
   if (!shouldReset) {
-    // Fetch-only mode: safe for locally-registered repos with uncommitted changes
     return { branch: branchToSync, synced: true, previousHead: '', newHead: '', updated: false };
   }
 
-  // Capture HEAD before reset so we can report whether anything changed
   let previousHead = '';
   try {
     const { stdout } = await execFileAsync(
@@ -140,15 +165,15 @@ export async function syncWorkspace(
     // Non-fatal — fresh clone or detached HEAD edge case
   }
 
-  // Hard-reset local working tree to match origin — only safe for Archon-managed
-  // clones, never for a user's local working directory.
   try {
-    await execFileAsync('git', ['-C', workspacePath, 'reset', '--hard', `origin/${branchToSync}`], {
-      timeout: 30000,
-    });
+    await execFileAsync(
+      'git',
+      ['-C', workspacePath, 'reset', '--hard', `${remote}/${branchToSync}`],
+      { timeout: 30000 }
+    );
   } catch (error) {
     const err = error as Error;
-    throw new Error(`Reset to origin/${branchToSync} failed: ${err.message}`);
+    throw new Error(`Reset to ${remote}/${branchToSync} failed: ${err.message}`);
   }
 
   let newHead = '';
@@ -234,14 +259,15 @@ export async function cloneRepository(
  */
 export async function syncRepository(
   repoPath: RepoPath,
-  branch: BranchName
+  branch: BranchName,
+  remote = 'origin'
 ): Promise<GitResult<void>> {
   try {
-    await execFileAsync('git', ['fetch', 'origin'], { cwd: repoPath, timeout: 60000 });
+    await execFileAsync('git', ['fetch', remote], { cwd: repoPath, timeout: 60000 });
   } catch (error) {
     const err = error as Error & { stderr?: string };
     const errorText = `${err.message} ${err.stderr ?? ''}`.toLowerCase();
-    getLog().error({ err, repoPath, branch }, 'sync_repository_fetch_failed');
+    getLog().error({ err, repoPath, branch, remote }, 'sync_repository_fetch_failed');
 
     if (errorText.includes('not a git repository')) {
       return { ok: false, error: { code: 'not_a_repo', path: repoPath } };
@@ -256,7 +282,7 @@ export async function syncRepository(
   }
 
   try {
-    await execFileAsync('git', ['reset', '--hard', `origin/${branch}`], {
+    await execFileAsync('git', ['reset', '--hard', `${remote}/${branch}`], {
       cwd: repoPath,
       timeout: 30000,
     });
@@ -268,7 +294,7 @@ export async function syncRepository(
       return { ok: false, error: { code: 'branch_not_found', branch } };
     }
 
-    getLog().error({ err, repoPath, branch }, 'sync_repository_reset_failed');
+    getLog().error({ err, repoPath, branch, remote }, 'sync_repository_reset_failed');
     return { ok: false, error: { code: 'unknown', message: `Reset failed: ${err.message}` } };
   }
 

--- a/packages/git/src/repo.ts
+++ b/packages/git/src/repo.ts
@@ -49,21 +49,15 @@ export async function findRepoRoot(startPath: string): Promise<RepoPath | null> 
  * Callers can override via `worktree.remote` in `.archon/config.yaml`.
  */
 export async function getDefaultRemote(repoPath: RepoPath): Promise<string | null> {
-  try {
-    const { stdout } = await execFileAsync('git', ['-C', repoPath, 'remote'], { timeout: 10000 });
-    const remotes = stdout
-      .trim()
-      .split('\n')
-      .filter(r => r.length > 0);
-    if (remotes.length === 0) return null;
-    if (remotes.includes('origin')) return 'origin';
-    if (remotes.length === 1) return remotes[0];
-    return null;
-  } catch (error) {
-    const err = error as Error & { stderr?: string };
-    getLog().error({ repoPath, err, stderr: err.stderr }, 'get_default_remote_failed');
-    return null;
-  }
+  const { stdout } = await execFileAsync('git', ['-C', repoPath, 'remote'], { timeout: 10000 });
+  const remotes = stdout
+    .split(/\r?\n/)
+    .map(r => r.trim())
+    .filter(r => r.length > 0);
+  if (remotes.length === 0) return null;
+  if (remotes.includes('origin')) return 'origin';
+  if (remotes.length === 1) return remotes[0];
+  return null;
 }
 
 /**

--- a/packages/git/src/repo.ts
+++ b/packages/git/src/repo.ts
@@ -61,8 +61,8 @@ export async function getDefaultRemote(repoPath: RepoPath): Promise<string | nul
 }
 
 /**
- * Get the remote URL for a remote (defaults to 'origin').
- * Returns null if no remote is configured.
+ * Get the URL configured for a git remote.
+ * Returns null if the remote does not exist.
  */
 export async function getRemoteUrl(repoPath: RepoPath, remote = 'origin'): Promise<string | null> {
   try {

--- a/packages/isolation/src/pr-state.ts
+++ b/packages/isolation/src/pr-state.ts
@@ -30,17 +30,17 @@ export type PrState = 'MERGED' | 'CLOSED' | 'OPEN' | 'NONE';
 export async function getPrState(
   branch: BranchName,
   repoPath: RepoPath,
-  cache?: Map<string, PrState>
+  cache?: Map<string, PrState>,
+  remote = 'origin'
 ): Promise<PrState> {
   const cached = cache?.get(branch);
   if (cached !== undefined) {
     return cached;
   }
 
-  // Check whether the remote is on GitHub. Non-GitHub remotes are out of scope.
   let remoteUrl = '';
   try {
-    const { stdout } = await execFileAsync('git', ['-C', repoPath, 'remote', 'get-url', 'origin'], {
+    const { stdout } = await execFileAsync('git', ['-C', repoPath, 'remote', 'get-url', remote], {
       timeout: 10000,
     });
     remoteUrl = stdout.trim();

--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -2944,6 +2944,37 @@ describe('WorktreeProvider', () => {
       );
     });
 
+    test('uses fromBranch as start-point with custom remote (task workflow)', async () => {
+      const taskRequest: IsolationRequest = {
+        codebaseId: 'cb-123',
+        canonicalRepoPath: '/workspace/repo',
+        workflowType: 'task',
+        identifier: 'my-feature',
+        fromBranch: 'develop',
+      };
+
+      const customProvider = new WorktreeProvider(async () => ({
+        baseBranch: 'main',
+        remote: 'upstream',
+      }));
+
+      await customProvider.create(taskRequest);
+
+      // fromBranch overrides remote/baseBranch as start-point
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        expect.arrayContaining([
+          'worktree',
+          'add',
+          expect.any(String),
+          '-b',
+          'archon/task-my-feature',
+          'develop',
+        ]),
+        expect.any(Object)
+      );
+    });
+
     test('throws actionable error when remote is ambiguous', async () => {
       getDefaultRemoteSpy.mockResolvedValue(null);
       execSpy.mockImplementation(async (_cmd: string, args: string[]) => {

--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -2904,7 +2904,7 @@ describe('WorktreeProvider', () => {
     test('uses configured remote from worktree config', async () => {
       const customProvider = new WorktreeProvider(async () => ({
         baseBranch: 'main',
-        remote: '264',
+        remote: 'mar',
       }));
 
       await customProvider.create(baseRequest);
@@ -2913,10 +2913,10 @@ describe('WorktreeProvider', () => {
       expect(syncWorkspaceSpy).toHaveBeenCalledWith(
         '/workspace/repo',
         'main',
-        expect.objectContaining({ remote: '264' })
+        expect.objectContaining({ remote: 'mar' })
       );
 
-      // worktree add should use 264/main as start-point
+      // worktree add should use mar/main as start-point
       expect(execSpy).toHaveBeenCalledWith(
         'git',
         expect.arrayContaining([
@@ -2925,7 +2925,7 @@ describe('WorktreeProvider', () => {
           expect.any(String),
           '-b',
           'archon/issue-42',
-          '264/main',
+          'mar/main',
         ]),
         expect.any(Object)
       );
@@ -2948,7 +2948,7 @@ describe('WorktreeProvider', () => {
       getDefaultRemoteSpy.mockResolvedValue(null);
       execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
         if (args.includes('remote') && !args.includes('get-url')) {
-          return { stdout: '260\n262\n264\n', stderr: '' };
+          return { stdout: 'jan\nfeb\nmar\n', stderr: '' };
         }
         return { stdout: '', stderr: '' };
       });

--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -30,6 +30,7 @@ import type { IsolationRequest, PRIsolationRequest, RepoConfigLoader } from '../
 
 // Track sync function calls for testing
 let getDefaultBranchSpy: Mock<typeof git.getDefaultBranch>;
+let getDefaultRemoteSpy: Mock<typeof git.getDefaultRemote>;
 let syncWorkspaceSpy: Mock<typeof git.syncWorkspace>;
 
 // Mock fs.promises.access for destroy() existence check
@@ -64,6 +65,7 @@ describe('WorktreeProvider', () => {
     findWorktreeByBranchSpy = spyOn(git, 'findWorktreeByBranch');
     getCanonicalRepoPathSpy = spyOn(git, 'getCanonicalRepoPath');
     getDefaultBranchSpy = spyOn(git, 'getDefaultBranch');
+    getDefaultRemoteSpy = spyOn(git, 'getDefaultRemote');
     syncWorkspaceSpy = spyOn(git, 'syncWorkspace');
 
     // Default mocks
@@ -89,6 +91,7 @@ describe('WorktreeProvider', () => {
 
     // Default mocks for workspace sync
     getDefaultBranchSpy.mockResolvedValue('main');
+    getDefaultRemoteSpy.mockResolvedValue('origin');
     syncWorkspaceSpy.mockResolvedValue({
       branch: 'main',
       synced: true,
@@ -106,6 +109,7 @@ describe('WorktreeProvider', () => {
     findWorktreeByBranchSpy.mockRestore();
     getCanonicalRepoPathSpy.mockRestore();
     getDefaultBranchSpy.mockRestore();
+    getDefaultRemoteSpy.mockRestore();
     syncWorkspaceSpy.mockRestore();
     mockAccess.mockClear();
     mockReadFile.mockClear();
@@ -2261,6 +2265,7 @@ describe('WorktreeProvider', () => {
       // resetAfterFetch: false because test path is not a managed clone under ~/.archon/workspaces
       expect(syncWorkspaceSpy).toHaveBeenCalledWith('/workspace/owner/repo', undefined, {
         resetAfterFetch: false,
+        remote: 'origin',
       });
     });
 
@@ -2281,6 +2286,7 @@ describe('WorktreeProvider', () => {
       // fromBranch is the start-point for the branch, not for sync — sync auto-detects
       expect(syncWorkspaceSpy).toHaveBeenCalledWith('/workspace/owner/repo', undefined, {
         resetAfterFetch: false,
+        remote: 'origin',
       });
     });
 
@@ -2300,6 +2306,7 @@ describe('WorktreeProvider', () => {
 
       expect(syncWorkspaceSpy).toHaveBeenCalledWith('/workspace/owner/repo', 'main', {
         resetAfterFetch: false,
+        remote: 'origin',
       });
     });
 
@@ -2319,6 +2326,7 @@ describe('WorktreeProvider', () => {
       // fromBranch is ignored for non-task types, so syncWorkspace gets undefined → auto-detect
       expect(syncWorkspaceSpy).toHaveBeenCalledWith('/workspace/owner/repo', undefined, {
         resetAfterFetch: false,
+        remote: 'origin',
       });
     });
 
@@ -2333,6 +2341,7 @@ describe('WorktreeProvider', () => {
 
       expect(syncWorkspaceSpy).toHaveBeenCalledWith('/workspace/owner/repo', 'develop', {
         resetAfterFetch: false,
+        remote: 'origin',
       });
       expect(getDefaultBranchSpy).not.toHaveBeenCalled();
     });
@@ -2342,7 +2351,7 @@ describe('WorktreeProvider', () => {
       worktreeExistsSpy.mockResolvedValue(false);
 
       await expect(provider.create(baseRequest)).rejects.toThrow(
-        'Failed to fetch base branch from origin'
+        "Failed to fetch base branch from 'origin'"
       );
     });
 
@@ -2385,7 +2394,7 @@ describe('WorktreeProvider', () => {
       syncWorkspaceSpy.mockRejectedValue(new Error('Network timeout'));
 
       await expect(provider.create(baseRequest)).rejects.toThrow(
-        'Failed to fetch base branch from origin'
+        "Failed to fetch base branch from 'origin'"
       );
     });
   });
@@ -2881,6 +2890,154 @@ describe('WorktreeProvider', () => {
 
       // healthCheck wraps the path in toWorktreePath before calling worktreeExists
       expect(worktreeExistsSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('custom remote support', () => {
+    const baseRequest: IsolationRequest = {
+      codebaseId: 'cb-123',
+      canonicalRepoPath: '/workspace/repo',
+      workflowType: 'issue',
+      identifier: '42',
+    };
+
+    test('uses configured remote from worktree config', async () => {
+      const customProvider = new WorktreeProvider(async () => ({
+        baseBranch: 'main',
+        remote: '264',
+      }));
+
+      await customProvider.create(baseRequest);
+
+      // syncWorkspace should receive the custom remote
+      expect(syncWorkspaceSpy).toHaveBeenCalledWith(
+        '/workspace/repo',
+        'main',
+        expect.objectContaining({ remote: '264' })
+      );
+
+      // worktree add should use 264/main as start-point
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        expect.arrayContaining([
+          'worktree',
+          'add',
+          expect.any(String),
+          '-b',
+          'archon/issue-42',
+          '264/main',
+        ]),
+        expect.any(Object)
+      );
+    });
+
+    test('auto-detects remote when not configured', async () => {
+      getDefaultRemoteSpy.mockResolvedValue('upstream');
+      const autoProvider = new WorktreeProvider(async () => ({ baseBranch: 'main' }));
+
+      await autoProvider.create(baseRequest);
+
+      expect(syncWorkspaceSpy).toHaveBeenCalledWith(
+        '/workspace/repo',
+        'main',
+        expect.objectContaining({ remote: 'upstream' })
+      );
+    });
+
+    test('throws actionable error when remote is ambiguous', async () => {
+      getDefaultRemoteSpy.mockResolvedValue(null);
+      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args.includes('remote') && !args.includes('get-url')) {
+          return { stdout: '260\n262\n264\n', stderr: '' };
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      const ambiguousProvider = new WorktreeProvider(async () => ({ baseBranch: 'main' }));
+
+      await expect(ambiguousProvider.create(baseRequest)).rejects.toThrow(
+        /Cannot determine git remote.*Set worktree\.remote/
+      );
+    });
+
+    test('uses custom remote for same-repo PR fetch and tracking', async () => {
+      const prRequest: PRIsolationRequest = {
+        codebaseId: 'cb-123',
+        canonicalRepoPath: '/workspace/repo',
+        workflowType: 'pr',
+        identifier: '42',
+        prBranch: 'feature/auth',
+        isForkPR: false,
+      };
+
+      const customProvider = new WorktreeProvider(async () => ({
+        baseBranch: 'main',
+        remote: 'upstream',
+      }));
+
+      await customProvider.create(prRequest);
+
+      // Fetch should use custom remote
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        expect.arrayContaining(['-C', '/workspace/repo', 'fetch', 'upstream', 'feature/auth']),
+        expect.any(Object)
+      );
+
+      // Branch tracking should use custom remote
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        expect.arrayContaining(['branch', '--set-upstream-to', 'upstream/feature/auth']),
+        expect.any(Object)
+      );
+    });
+
+    test('uses custom remote for fork PR fetch', async () => {
+      const forkPrRequest: PRIsolationRequest = {
+        codebaseId: 'cb-123',
+        canonicalRepoPath: '/workspace/repo',
+        workflowType: 'pr',
+        identifier: '42',
+        prBranch: 'feature/auth',
+        isForkPR: true,
+      };
+
+      const customProvider = new WorktreeProvider(async () => ({
+        baseBranch: 'main',
+        remote: 'upstream',
+      }));
+
+      await customProvider.create(forkPrRequest);
+
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        expect.arrayContaining([
+          '-C',
+          '/workspace/repo',
+          'fetch',
+          'upstream',
+          'pull/42/head:pr-42-review',
+        ]),
+        expect.any(Object)
+      );
+    });
+
+    test('uses custom remote for remote branch deletion', async () => {
+      worktreeExistsSpy.mockResolvedValue(false);
+      mockAccess.mockResolvedValue(undefined);
+
+      await provider.destroy('worktree-path', {
+        branchName: 'archon/issue-42' as git.BranchName,
+        canonicalRepoPath: '/workspace/repo' as git.RepoPath,
+        deleteRemoteBranch: true,
+        remote: 'upstream',
+      });
+
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        ['-C', '/workspace/repo', 'push', 'upstream', '--delete', 'archon/issue-42'],
+        expect.any(Object)
+      );
     });
   });
 });

--- a/packages/isolation/src/providers/worktree.ts
+++ b/packages/isolation/src/providers/worktree.ts
@@ -13,6 +13,7 @@ import {
   execFileAsync,
   findWorktreeByBranch,
   getCanonicalRepoPath,
+  getDefaultRemote,
   getWorktreeBase,
   listWorktrees,
   mkdirAsync,
@@ -287,12 +288,12 @@ export class WorktreeProvider implements IIsolationProvider {
     if (options?.branchName) {
       result.branchDeleted = await this.deleteBranchTracked(repoPath, options.branchName, result);
 
-      // Delete remote branch if requested (e.g., after PR merge)
       if (options.deleteRemoteBranch) {
         result.remoteBranchDeleted = await this.deleteRemoteBranchTracked(
           repoPath,
           options.branchName,
-          result
+          result,
+          options.remote
         );
       }
     }
@@ -381,10 +382,11 @@ export class WorktreeProvider implements IIsolationProvider {
   private async deleteRemoteBranchTracked(
     repoPath: string,
     branchName: string,
-    result: DestroyResult
+    result: DestroyResult,
+    remote = 'origin'
   ): Promise<boolean> {
     try {
-      await execFileAsync('git', ['-C', repoPath, 'push', 'origin', '--delete', branchName], {
+      await execFileAsync('git', ['-C', repoPath, 'push', remote, '--delete', branchName], {
         timeout: GIT_OPERATION_TIMEOUT_MS,
       });
       getLog().debug({ repoPath, branchName }, 'remote_branch_deleted');
@@ -704,24 +706,27 @@ export class WorktreeProvider implements IIsolationProvider {
   ): Promise<{ warnings: string[] }> {
     const repoPath = request.canonicalRepoPath;
 
+    // Resolve git remote name: explicit config > auto-detect > 'origin' fallback
+    const remote = await this.resolveRemote(repoPath, worktreeConfig?.remote);
+
     // Sync uses only the configured base branch (or auto-detects via getDefaultBranch).
     // request.fromBranch is the start-point for worktree creation, not a sync target.
-    const baseBranch = await this.syncWorkspaceBeforeCreate(repoPath, worktreeConfig?.baseBranch);
+    const baseBranch = await this.syncWorkspaceBeforeCreate(
+      repoPath,
+      worktreeConfig?.baseBranch,
+      remote
+    );
 
     const override: WorktreeBaseOverride = {
       repoLocal: resolveRepoLocalOverride(worktreeConfig?.path, repoPath),
     };
     const { base: worktreeBase } = getWorktreeBase(repoPath, request.codebaseName, override);
-    // In both layouts the base already carries repo context — creating it
-    // recursively is enough.
     await mkdirAsync(worktreeBase, { recursive: true });
 
     if (isPRIsolationRequest(request)) {
-      // For PRs: fetch and checkout the PR branch (actual or synthetic)
-      await this.createFromPR(request, worktreePath);
+      await this.createFromPR(request, worktreePath, remote);
     } else {
-      // For issues, tasks, threads: create new branch
-      await this.createNewBranch(request, repoPath, worktreePath, branchName, baseBranch);
+      await this.createNewBranch(request, repoPath, worktreePath, branchName, baseBranch, remote);
     }
 
     // Initialize submodules unless explicitly opted out. The check is free
@@ -749,49 +754,74 @@ export class WorktreeProvider implements IIsolationProvider {
   }
 
   /**
-   * Sync workspace with remote before creating a new worktree
-   * Ensures new work starts from the latest code on the base branch.
+   * Resolve the git remote name to use for all fetch/push operations.
    *
-   * Branch resolution:
-   * - If configuredBaseBranch is provided: Uses that branch. Fails with actionable
-   *   error if the branch doesn't exist - no silent fallback to default.
-   * - If configuredBaseBranch is omitted: Auto-detects the default branch via git.
+   * Resolution order:
+   *   1. Explicit config (worktree.remote in .archon/config.yaml)
+   *   2. Auto-detect via getDefaultRemote() ('origin' if exists, sole remote, or null)
+   *   3. Fail with actionable error if ambiguous
+   */
+  private async resolveRemote(repoPath: RepoPath, configuredRemote?: string): Promise<string> {
+    if (configuredRemote) {
+      getLog().debug({ repoPath, remote: configuredRemote }, 'worktree.remote_from_config');
+      return configuredRemote;
+    }
+
+    const detected = await getDefaultRemote(repoPath);
+    if (detected) {
+      if (detected !== 'origin') {
+        getLog().info({ repoPath, remote: detected }, 'worktree.remote_auto_detected');
+      }
+      return detected;
+    }
+
+    // List remotes for actionable error message
+    let remoteList = '<unknown>';
+    try {
+      const { stdout } = await execFileAsync('git', ['-C', repoPath, 'remote'], { timeout: 10000 });
+      remoteList = stdout.trim().split('\n').join(', ');
+    } catch {
+      // Best-effort for error message
+    }
+
+    throw new Error(
+      `Cannot determine git remote for ${repoPath}: no 'origin' remote found and ` +
+        `multiple remotes exist (${remoteList}). ` +
+        'Set worktree.remote in .archon/config.yaml to specify which remote to use.'
+    );
+  }
+
+  /**
+   * Sync workspace with remote before creating a new worktree.
+   * Ensures new work starts from the latest code on the base branch.
    *
    * All sync failures are fatal — creating a worktree from an unknown
    * start-point risks branching from the wrong commit.
-   *
-   * Error classification (for user-facing messages):
-   * - Permission denied → file permission hint
-   * - Not a git repository → workspace integrity hint
-   * - Configured base branch missing → config fix hint
-   * - Network errors, timeouts → connectivity hint
    */
   private async syncWorkspaceBeforeCreate(
     repoPath: RepoPath,
-    configuredBaseBranch?: string
+    configuredBaseBranch?: string,
+    remote = 'origin'
   ): Promise<string> {
     try {
       getLog().debug(
-        { repoPath, branch: configuredBaseBranch ?? 'auto-detect' },
+        { repoPath, branch: configuredBaseBranch ?? 'auto-detect', remote },
         'workspace_sync_starting'
       );
-      // Only hard-reset for Archon-managed clones (under ~/.archon/workspaces/).
-      // Locally-registered repos get fetch-only to avoid destroying uncommitted work.
       const isManagedClone = repoPath
         .replace(/\\/g, '/')
         .startsWith(getArchonWorkspacesPath().replace(/\\/g, '/'));
       const { branch } = await syncWorkspace(
         repoPath,
         configuredBaseBranch ? toBranchName(configuredBaseBranch) : undefined,
-        { resetAfterFetch: isManagedClone }
+        { resetAfterFetch: isManagedClone, remote }
       );
-      getLog().debug({ repoPath, branch }, 'workspace_synced');
+      getLog().debug({ repoPath, branch, remote }, 'workspace_synced');
       return branch;
     } catch (error) {
       const err = error as Error & { code?: string };
       const errorMessage = err.message.toLowerCase();
 
-      // Fatal errors - throw to prevent confusing downstream failures
       if (err.code === 'EACCES' || errorMessage.includes('permission denied')) {
         throw new Error(
           `Permission denied accessing repository at ${repoPath}. ` +
@@ -803,13 +833,11 @@ export class WorktreeProvider implements IIsolationProvider {
             'Ensure the workspace was cloned correctly.'
         );
       } else if (errorMessage.includes('configured base branch')) {
-        // Configured branch errors are fatal - user needs to fix their config
         throw err;
       } else {
-        // Network errors, timeouts — cannot guarantee correct start-point
         throw new Error(
-          `Failed to fetch base branch from origin: ${err.message}. ` +
-            'Check your network connection and try again.'
+          `Failed to fetch base branch from '${remote}': ${err.message}. ` +
+            'Check your network connection and remote configuration.'
         );
       }
     }
@@ -890,8 +918,11 @@ export class WorktreeProvider implements IIsolationProvider {
    * When prSha is provided, the worktree is initially created at the specific
    * commit (detached HEAD), then a local tracking branch is created.
    */
-  private async createFromPR(request: PRIsolationRequest, worktreePath: string): Promise<void> {
-    // Clean up any orphan directory before creating worktree
+  private async createFromPR(
+    request: PRIsolationRequest,
+    worktreePath: string,
+    remote = 'origin'
+  ): Promise<void> {
     await this.cleanOrphanDirectoryIfExists(worktreePath);
 
     const repoPath = request.canonicalRepoPath;
@@ -899,15 +930,11 @@ export class WorktreeProvider implements IIsolationProvider {
 
     try {
       if (!request.isForkPR) {
-        // Same-repo PR: Use the actual branch so changes push directly to PR
-        await this.createFromSameRepoPR(repoPath, worktreePath, request.prBranch);
+        await this.createFromSameRepoPR(repoPath, worktreePath, request.prBranch, remote);
       } else {
-        // Fork PR: Use synthetic review branch
-        await this.createFromForkPR(repoPath, worktreePath, prNumber, request.prSha);
+        await this.createFromForkPR(repoPath, worktreePath, prNumber, remote, request.prSha);
       }
     } catch (error) {
-      // Clean up orphaned git-registered worktree from partial failure
-      // (e.g., worktree add succeeded but createBranchWithStaleRetry failed)
       await this.cleanOrphanWorktreeIfExists(repoPath, worktreePath);
       const err = error as Error;
       throw new Error(`Failed to create worktree for PR #${prNumber}: ${err.message}`);
@@ -920,24 +947,21 @@ export class WorktreeProvider implements IIsolationProvider {
   private async createFromSameRepoPR(
     repoPath: string,
     worktreePath: string,
-    prBranch: string
+    prBranch: string,
+    remote = 'origin'
   ): Promise<void> {
-    // Fetch the PR's actual branch
-    await execFileAsync('git', ['-C', repoPath, 'fetch', 'origin', prBranch], {
+    await execFileAsync('git', ['-C', repoPath, 'fetch', remote, prBranch], {
       timeout: GIT_OPERATION_TIMEOUT_MS,
     });
 
-    // Try to create worktree with the branch
     try {
-      // If branch doesn't exist locally, create it tracking remote
       await execFileAsync(
         'git',
-        ['-C', repoPath, 'worktree', 'add', worktreePath, '-b', prBranch, `origin/${prBranch}`],
+        ['-C', repoPath, 'worktree', 'add', worktreePath, '-b', prBranch, `${remote}/${prBranch}`],
         { timeout: GIT_OPERATION_TIMEOUT_MS }
       );
     } catch (error) {
       const err = error as Error & { stderr?: string };
-      // Branch already exists locally - use it directly
       if (err.stderr?.includes('already exists')) {
         await execFileAsync('git', ['-C', repoPath, 'worktree', 'add', worktreePath, prBranch], {
           timeout: GIT_OPERATION_TIMEOUT_MS,
@@ -947,16 +971,14 @@ export class WorktreeProvider implements IIsolationProvider {
       }
     }
 
-    // Set up tracking for push/pull (non-fatal - worktree is usable without it)
     try {
       await execFileAsync(
         'git',
-        ['-C', worktreePath, 'branch', '--set-upstream-to', `origin/${prBranch}`],
+        ['-C', worktreePath, 'branch', '--set-upstream-to', `${remote}/${prBranch}`],
         { timeout: GIT_OPERATION_TIMEOUT_MS }
       );
     } catch (trackingError) {
       getLog().warn({ err: trackingError, worktreePath, prBranch }, 'upstream_tracking_failed');
-      // Continue - the worktree was created successfully, tracking is just convenience
     }
   }
 
@@ -970,13 +992,13 @@ export class WorktreeProvider implements IIsolationProvider {
     repoPath: string,
     worktreePath: string,
     prNumber: string,
+    remote = 'origin',
     prSha?: string
   ): Promise<void> {
     const reviewBranch = `pr-${prNumber}-review`;
 
     if (prSha) {
-      // SHA provided: create at specific commit for reproducible reviews
-      await execFileAsync('git', ['-C', repoPath, 'fetch', 'origin', `pull/${prNumber}/head`], {
+      await execFileAsync('git', ['-C', repoPath, 'fetch', remote, `pull/${prNumber}/head`], {
         timeout: GIT_OPERATION_TIMEOUT_MS,
       });
 
@@ -984,7 +1006,6 @@ export class WorktreeProvider implements IIsolationProvider {
         timeout: GIT_OPERATION_TIMEOUT_MS,
       });
 
-      // Create a local tracking branch so it's not detached HEAD
       await this.createBranchWithStaleRetry(
         repoPath,
         () =>
@@ -994,13 +1015,12 @@ export class WorktreeProvider implements IIsolationProvider {
         reviewBranch
       );
     } else {
-      // No SHA: fetch and create review branch
       await this.createBranchWithStaleRetry(
         repoPath,
         () =>
           execFileAsync(
             'git',
-            ['-C', repoPath, 'fetch', 'origin', `pull/${prNumber}/head:${reviewBranch}`],
+            ['-C', repoPath, 'fetch', remote, `pull/${prNumber}/head:${reviewBranch}`],
             { timeout: GIT_OPERATION_TIMEOUT_MS }
           ),
         reviewBranch
@@ -1045,16 +1065,15 @@ export class WorktreeProvider implements IIsolationProvider {
     repoPath: string,
     worktreePath: string,
     branchName: string,
-    baseBranch: string
+    baseBranch: string,
+    remote = 'origin'
   ): Promise<void> {
-    // Clean up any orphan directory before creating worktree
     await this.cleanOrphanDirectoryIfExists(worktreePath);
 
-    // Determine start-point: explicit fromBranch overrides base branch
     const startPoint =
       request.workflowType === 'task' && request.fromBranch
         ? request.fromBranch
-        : `origin/${baseBranch}`;
+        : `${remote}/${baseBranch}`;
 
     try {
       // Try to create with new branch

--- a/packages/isolation/src/providers/worktree.ts
+++ b/packages/isolation/src/providers/worktree.ts
@@ -13,6 +13,7 @@ import {
   execFileAsync,
   findWorktreeByBranch,
   getCanonicalRepoPath,
+  getDefaultRemote,
   getWorktreeBase,
   listWorktrees,
   mkdirAsync,
@@ -287,12 +288,12 @@ export class WorktreeProvider implements IIsolationProvider {
     if (options?.branchName) {
       result.branchDeleted = await this.deleteBranchTracked(repoPath, options.branchName, result);
 
-      // Delete remote branch if requested (e.g., after PR merge)
       if (options.deleteRemoteBranch) {
         result.remoteBranchDeleted = await this.deleteRemoteBranchTracked(
           repoPath,
           options.branchName,
-          result
+          result,
+          options.remote
         );
       }
     }
@@ -381,10 +382,11 @@ export class WorktreeProvider implements IIsolationProvider {
   private async deleteRemoteBranchTracked(
     repoPath: string,
     branchName: string,
-    result: DestroyResult
+    result: DestroyResult,
+    remote = 'origin'
   ): Promise<boolean> {
     try {
-      await execFileAsync('git', ['-C', repoPath, 'push', 'origin', '--delete', branchName], {
+      await execFileAsync('git', ['-C', repoPath, 'push', remote, '--delete', branchName], {
         timeout: GIT_OPERATION_TIMEOUT_MS,
       });
       getLog().debug({ repoPath, branchName }, 'remote_branch_deleted');
@@ -704,24 +706,27 @@ export class WorktreeProvider implements IIsolationProvider {
   ): Promise<{ warnings: string[] }> {
     const repoPath = request.canonicalRepoPath;
 
+    // Resolve git remote name: explicit config > auto-detect > 'origin' fallback
+    const remote = await this.resolveRemote(repoPath, worktreeConfig?.remote);
+
     // Sync uses only the configured base branch (or auto-detects via getDefaultBranch).
     // request.fromBranch is the start-point for worktree creation, not a sync target.
-    const baseBranch = await this.syncWorkspaceBeforeCreate(repoPath, worktreeConfig?.baseBranch);
+    const baseBranch = await this.syncWorkspaceBeforeCreate(
+      repoPath,
+      worktreeConfig?.baseBranch,
+      remote
+    );
 
     const override: WorktreeBaseOverride = {
       repoLocal: resolveRepoLocalOverride(worktreeConfig?.path, repoPath),
     };
     const { base: worktreeBase } = getWorktreeBase(repoPath, request.codebaseName, override);
-    // In both layouts the base already carries repo context — creating it
-    // recursively is enough.
     await mkdirAsync(worktreeBase, { recursive: true });
 
     if (isPRIsolationRequest(request)) {
-      // For PRs: fetch and checkout the PR branch (actual or synthetic)
-      await this.createFromPR(request, worktreePath);
+      await this.createFromPR(request, worktreePath, remote);
     } else {
-      // For issues, tasks, threads: create new branch
-      await this.createNewBranch(request, repoPath, worktreePath, branchName, baseBranch);
+      await this.createNewBranch(request, repoPath, worktreePath, branchName, baseBranch, remote);
     }
 
     // Stamp the originating user's git identity on this worktree so workflow
@@ -781,49 +786,74 @@ export class WorktreeProvider implements IIsolationProvider {
   }
 
   /**
-   * Sync workspace with remote before creating a new worktree
-   * Ensures new work starts from the latest code on the base branch.
+   * Resolve the git remote name to use for all fetch/push operations.
    *
-   * Branch resolution:
-   * - If configuredBaseBranch is provided: Uses that branch. Fails with actionable
-   *   error if the branch doesn't exist - no silent fallback to default.
-   * - If configuredBaseBranch is omitted: Auto-detects the default branch via git.
+   * Resolution order:
+   *   1. Explicit config (worktree.remote in .archon/config.yaml)
+   *   2. Auto-detect via getDefaultRemote() ('origin' if exists, sole remote, or null)
+   *   3. Fail with actionable error if ambiguous
+   */
+  private async resolveRemote(repoPath: RepoPath, configuredRemote?: string): Promise<string> {
+    if (configuredRemote) {
+      getLog().debug({ repoPath, remote: configuredRemote }, 'worktree.remote_from_config');
+      return configuredRemote;
+    }
+
+    const detected = await getDefaultRemote(repoPath);
+    if (detected) {
+      if (detected !== 'origin') {
+        getLog().info({ repoPath, remote: detected }, 'worktree.remote_auto_detected');
+      }
+      return detected;
+    }
+
+    // List remotes for actionable error message
+    let remoteList = '<unknown>';
+    try {
+      const { stdout } = await execFileAsync('git', ['-C', repoPath, 'remote'], { timeout: 10000 });
+      remoteList = stdout.trim().split('\n').join(', ');
+    } catch {
+      // Best-effort for error message
+    }
+
+    throw new Error(
+      `Cannot determine git remote for ${repoPath}: no 'origin' remote found and ` +
+        `multiple remotes exist (${remoteList}). ` +
+        'Set worktree.remote in .archon/config.yaml to specify which remote to use.'
+    );
+  }
+
+  /**
+   * Sync workspace with remote before creating a new worktree.
+   * Ensures new work starts from the latest code on the base branch.
    *
    * All sync failures are fatal — creating a worktree from an unknown
    * start-point risks branching from the wrong commit.
-   *
-   * Error classification (for user-facing messages):
-   * - Permission denied → file permission hint
-   * - Not a git repository → workspace integrity hint
-   * - Configured base branch missing → config fix hint
-   * - Network errors, timeouts → connectivity hint
    */
   private async syncWorkspaceBeforeCreate(
     repoPath: RepoPath,
-    configuredBaseBranch?: string
+    configuredBaseBranch?: string,
+    remote = 'origin'
   ): Promise<string> {
     try {
       getLog().debug(
-        { repoPath, branch: configuredBaseBranch ?? 'auto-detect' },
+        { repoPath, branch: configuredBaseBranch ?? 'auto-detect', remote },
         'workspace_sync_starting'
       );
-      // Only hard-reset for Archon-managed clones (under ~/.archon/workspaces/).
-      // Locally-registered repos get fetch-only to avoid destroying uncommitted work.
       const isManagedClone = repoPath
         .replace(/\\/g, '/')
         .startsWith(getArchonWorkspacesPath().replace(/\\/g, '/'));
       const { branch } = await syncWorkspace(
         repoPath,
         configuredBaseBranch ? toBranchName(configuredBaseBranch) : undefined,
-        { resetAfterFetch: isManagedClone }
+        { resetAfterFetch: isManagedClone, remote }
       );
-      getLog().debug({ repoPath, branch }, 'workspace_synced');
+      getLog().debug({ repoPath, branch, remote }, 'workspace_synced');
       return branch;
     } catch (error) {
       const err = error as Error & { code?: string };
       const errorMessage = err.message.toLowerCase();
 
-      // Fatal errors - throw to prevent confusing downstream failures
       if (err.code === 'EACCES' || errorMessage.includes('permission denied')) {
         throw new Error(
           `Permission denied accessing repository at ${repoPath}. ` +
@@ -835,13 +865,11 @@ export class WorktreeProvider implements IIsolationProvider {
             'Ensure the workspace was cloned correctly.'
         );
       } else if (errorMessage.includes('configured base branch')) {
-        // Configured branch errors are fatal - user needs to fix their config
         throw err;
       } else {
-        // Network errors, timeouts — cannot guarantee correct start-point
         throw new Error(
-          `Failed to fetch base branch from origin: ${err.message}. ` +
-            'Check your network connection and try again.'
+          `Failed to fetch base branch from '${remote}': ${err.message}. ` +
+            'Check your network connection and remote configuration.'
         );
       }
     }
@@ -922,8 +950,11 @@ export class WorktreeProvider implements IIsolationProvider {
    * When prSha is provided, the worktree is initially created at the specific
    * commit (detached HEAD), then a local tracking branch is created.
    */
-  private async createFromPR(request: PRIsolationRequest, worktreePath: string): Promise<void> {
-    // Clean up any orphan directory before creating worktree
+  private async createFromPR(
+    request: PRIsolationRequest,
+    worktreePath: string,
+    remote = 'origin'
+  ): Promise<void> {
     await this.cleanOrphanDirectoryIfExists(worktreePath);
 
     const repoPath = request.canonicalRepoPath;
@@ -931,15 +962,11 @@ export class WorktreeProvider implements IIsolationProvider {
 
     try {
       if (!request.isForkPR) {
-        // Same-repo PR: Use the actual branch so changes push directly to PR
-        await this.createFromSameRepoPR(repoPath, worktreePath, request.prBranch);
+        await this.createFromSameRepoPR(repoPath, worktreePath, request.prBranch, remote);
       } else {
-        // Fork PR: Use synthetic review branch
-        await this.createFromForkPR(repoPath, worktreePath, prNumber, request.prSha);
+        await this.createFromForkPR(repoPath, worktreePath, prNumber, remote, request.prSha);
       }
     } catch (error) {
-      // Clean up orphaned git-registered worktree from partial failure
-      // (e.g., worktree add succeeded but createBranchWithStaleRetry failed)
       await this.cleanOrphanWorktreeIfExists(repoPath, worktreePath);
       const err = error as Error;
       throw new Error(`Failed to create worktree for PR #${prNumber}: ${err.message}`);
@@ -952,24 +979,21 @@ export class WorktreeProvider implements IIsolationProvider {
   private async createFromSameRepoPR(
     repoPath: string,
     worktreePath: string,
-    prBranch: string
+    prBranch: string,
+    remote = 'origin'
   ): Promise<void> {
-    // Fetch the PR's actual branch
-    await execFileAsync('git', ['-C', repoPath, 'fetch', 'origin', prBranch], {
+    await execFileAsync('git', ['-C', repoPath, 'fetch', remote, prBranch], {
       timeout: GIT_OPERATION_TIMEOUT_MS,
     });
 
-    // Try to create worktree with the branch
     try {
-      // If branch doesn't exist locally, create it tracking remote
       await execFileAsync(
         'git',
-        ['-C', repoPath, 'worktree', 'add', worktreePath, '-b', prBranch, `origin/${prBranch}`],
+        ['-C', repoPath, 'worktree', 'add', worktreePath, '-b', prBranch, `${remote}/${prBranch}`],
         { timeout: GIT_OPERATION_TIMEOUT_MS }
       );
     } catch (error) {
       const err = error as Error & { stderr?: string };
-      // Branch already exists locally - use it directly
       if (err.stderr?.includes('already exists')) {
         await execFileAsync('git', ['-C', repoPath, 'worktree', 'add', worktreePath, prBranch], {
           timeout: GIT_OPERATION_TIMEOUT_MS,
@@ -979,16 +1003,14 @@ export class WorktreeProvider implements IIsolationProvider {
       }
     }
 
-    // Set up tracking for push/pull (non-fatal - worktree is usable without it)
     try {
       await execFileAsync(
         'git',
-        ['-C', worktreePath, 'branch', '--set-upstream-to', `origin/${prBranch}`],
+        ['-C', worktreePath, 'branch', '--set-upstream-to', `${remote}/${prBranch}`],
         { timeout: GIT_OPERATION_TIMEOUT_MS }
       );
     } catch (trackingError) {
       getLog().warn({ err: trackingError, worktreePath, prBranch }, 'upstream_tracking_failed');
-      // Continue - the worktree was created successfully, tracking is just convenience
     }
   }
 
@@ -1002,13 +1024,13 @@ export class WorktreeProvider implements IIsolationProvider {
     repoPath: string,
     worktreePath: string,
     prNumber: string,
+    remote = 'origin',
     prSha?: string
   ): Promise<void> {
     const reviewBranch = `pr-${prNumber}-review`;
 
     if (prSha) {
-      // SHA provided: create at specific commit for reproducible reviews
-      await execFileAsync('git', ['-C', repoPath, 'fetch', 'origin', `pull/${prNumber}/head`], {
+      await execFileAsync('git', ['-C', repoPath, 'fetch', remote, `pull/${prNumber}/head`], {
         timeout: GIT_OPERATION_TIMEOUT_MS,
       });
 
@@ -1016,7 +1038,6 @@ export class WorktreeProvider implements IIsolationProvider {
         timeout: GIT_OPERATION_TIMEOUT_MS,
       });
 
-      // Create a local tracking branch so it's not detached HEAD
       await this.createBranchWithStaleRetry(
         repoPath,
         () =>
@@ -1026,13 +1047,12 @@ export class WorktreeProvider implements IIsolationProvider {
         reviewBranch
       );
     } else {
-      // No SHA: fetch and create review branch
       await this.createBranchWithStaleRetry(
         repoPath,
         () =>
           execFileAsync(
             'git',
-            ['-C', repoPath, 'fetch', 'origin', `pull/${prNumber}/head:${reviewBranch}`],
+            ['-C', repoPath, 'fetch', remote, `pull/${prNumber}/head:${reviewBranch}`],
             { timeout: GIT_OPERATION_TIMEOUT_MS }
           ),
         reviewBranch
@@ -1077,16 +1097,15 @@ export class WorktreeProvider implements IIsolationProvider {
     repoPath: string,
     worktreePath: string,
     branchName: string,
-    baseBranch: string
+    baseBranch: string,
+    remote = 'origin'
   ): Promise<void> {
-    // Clean up any orphan directory before creating worktree
     await this.cleanOrphanDirectoryIfExists(worktreePath);
 
-    // Determine start-point: explicit fromBranch overrides base branch
     const startPoint =
       request.workflowType === 'task' && request.fromBranch
         ? request.fromBranch
-        : `origin/${baseBranch}`;
+        : `${remote}/${baseBranch}`;
 
     try {
       // Try to create with new branch

--- a/packages/isolation/src/providers/worktree.ts
+++ b/packages/isolation/src/providers/worktree.ts
@@ -840,6 +840,8 @@ export class WorktreeProvider implements IIsolationProvider {
         { repoPath, branch: configuredBaseBranch ?? 'auto-detect', remote },
         'workspace_sync_starting'
       );
+      // Only hard-reset for Archon-managed clones (under ~/.archon/workspaces/).
+      // Locally-registered repos get fetch-only to avoid destroying uncommitted work.
       const isManagedClone = repoPath
         .replace(/\\/g, '/')
         .startsWith(getArchonWorkspacesPath().replace(/\\/g, '/'));
@@ -962,8 +964,10 @@ export class WorktreeProvider implements IIsolationProvider {
 
     try {
       if (!request.isForkPR) {
+        // Same-repo PR: use the actual branch so changes push directly to PR
         await this.createFromSameRepoPR(repoPath, worktreePath, request.prBranch, remote);
       } else {
+        // Fork PR: use synthetic review branch since we can't push to forks
         await this.createFromForkPR(repoPath, worktreePath, prNumber, remote, request.prSha);
       }
     } catch (error) {
@@ -1003,6 +1007,7 @@ export class WorktreeProvider implements IIsolationProvider {
       }
     }
 
+    // Set up tracking for push/pull (non-fatal — worktree is usable without it)
     try {
       await execFileAsync(
         'git',
@@ -1030,6 +1035,7 @@ export class WorktreeProvider implements IIsolationProvider {
     const reviewBranch = `pr-${prNumber}-review`;
 
     if (prSha) {
+      // SHA provided: create at specific commit for reproducible reviews
       await execFileAsync('git', ['-C', repoPath, 'fetch', remote, `pull/${prNumber}/head`], {
         timeout: GIT_OPERATION_TIMEOUT_MS,
       });
@@ -1038,6 +1044,7 @@ export class WorktreeProvider implements IIsolationProvider {
         timeout: GIT_OPERATION_TIMEOUT_MS,
       });
 
+      // Create a local tracking branch so it's not detached HEAD
       await this.createBranchWithStaleRetry(
         repoPath,
         () =>

--- a/packages/isolation/src/types.ts
+++ b/packages/isolation/src/types.ts
@@ -266,10 +266,9 @@ export interface WorktreeCreateConfig {
   /**
    * Git remote name to use for fetch/push operations.
    *
-   * Most repos use the standard 'origin' remote, but some use custom-named
-   * remotes (e.g. 'jan', 'feb', 'mar' for release-based remotes). When set,
-   * all git operations (fetch, push, branch tracking) use this remote
-   * instead of 'origin'.
+   * When set, all git operations (fetch, push, branch tracking) use this
+   * remote instead of 'origin'. Useful for repos with multiple remotes or
+   * non-standard naming conventions.
    *
    * When omitted, auto-detected via `getDefaultRemote()`:
    *   1. 'origin' if it exists

--- a/packages/isolation/src/types.ts
+++ b/packages/isolation/src/types.ts
@@ -136,6 +136,8 @@ export interface WorktreeDestroyOptions extends DestroyOptions {
   canonicalRepoPath?: RepoPath;
   /** Delete the remote branch (best-effort, e.g., after PR merge) */
   deleteRemoteBranch?: boolean;
+  /** Git remote name for remote branch deletion (default: 'origin') */
+  remote?: string;
 }
 
 /**
@@ -261,6 +263,22 @@ export interface WorktreeCreateConfig {
    * @example '.worktrees'
    */
   path?: string;
+  /**
+   * Git remote name to use for fetch/push operations.
+   *
+   * Most repos use the standard 'origin' remote, but some (e.g. Salesforce Core)
+   * use numbered or named remotes. When set, all git operations (fetch, push,
+   * branch tracking) use this remote instead of 'origin'.
+   *
+   * When omitted, auto-detected via `getDefaultRemote()`:
+   *   1. 'origin' if it exists
+   *   2. The sole remote if only one is configured
+   *   3. Fails with actionable error if ambiguous
+   *
+   * Sourced from `.archon/config.yaml > worktree.remote` in the repo.
+   * @example '264'
+   */
+  remote?: string;
 }
 
 export type RepoConfigLoader = (repoPath: string) => Promise<WorktreeCreateConfig | null>;

--- a/packages/isolation/src/types.ts
+++ b/packages/isolation/src/types.ts
@@ -266,9 +266,10 @@ export interface WorktreeCreateConfig {
   /**
    * Git remote name to use for fetch/push operations.
    *
-   * Most repos use the standard 'origin' remote, but some (e.g. Salesforce Core)
-   * use numbered or named remotes. When set, all git operations (fetch, push,
-   * branch tracking) use this remote instead of 'origin'.
+   * Most repos use the standard 'origin' remote, but some use custom-named
+   * remotes (e.g. 'jan', 'feb', 'mar' for release-based remotes). When set,
+   * all git operations (fetch, push, branch tracking) use this remote
+   * instead of 'origin'.
    *
    * When omitted, auto-detected via `getDefaultRemote()`:
    *   1. 'origin' if it exists
@@ -276,7 +277,7 @@ export interface WorktreeCreateConfig {
    *   3. Fails with actionable error if ambiguous
    *
    * Sourced from `.archon/config.yaml > worktree.remote` in the repo.
-   * @example '264'
+   * @example 'upstream'
    */
   remote?: string;
 }

--- a/packages/isolation/src/types.ts
+++ b/packages/isolation/src/types.ts
@@ -277,9 +277,10 @@ export interface WorktreeCreateConfig {
   /**
    * Git remote name to use for fetch/push operations.
    *
-   * Most repos use the standard 'origin' remote, but some (e.g. Salesforce Core)
-   * use numbered or named remotes. When set, all git operations (fetch, push,
-   * branch tracking) use this remote instead of 'origin'.
+   * Most repos use the standard 'origin' remote, but some use custom-named
+   * remotes (e.g. 'jan', 'feb', 'mar' for release-based remotes). When set,
+   * all git operations (fetch, push, branch tracking) use this remote
+   * instead of 'origin'.
    *
    * When omitted, auto-detected via `getDefaultRemote()`:
    *   1. 'origin' if it exists
@@ -287,7 +288,7 @@ export interface WorktreeCreateConfig {
    *   3. Fails with actionable error if ambiguous
    *
    * Sourced from `.archon/config.yaml > worktree.remote` in the repo.
-   * @example '264'
+   * @example 'upstream'
    */
   remote?: string;
 }

--- a/packages/isolation/src/types.ts
+++ b/packages/isolation/src/types.ts
@@ -277,10 +277,9 @@ export interface WorktreeCreateConfig {
   /**
    * Git remote name to use for fetch/push operations.
    *
-   * Most repos use the standard 'origin' remote, but some use custom-named
-   * remotes (e.g. 'jan', 'feb', 'mar' for release-based remotes). When set,
-   * all git operations (fetch, push, branch tracking) use this remote
-   * instead of 'origin'.
+   * When set, all git operations (fetch, push, branch tracking) use this
+   * remote instead of 'origin'. Useful for repos with multiple remotes or
+   * non-standard naming conventions.
    *
    * When omitted, auto-detected via `getDefaultRemote()`:
    *   1. 'origin' if it exists

--- a/packages/isolation/src/types.ts
+++ b/packages/isolation/src/types.ts
@@ -145,6 +145,8 @@ export interface WorktreeDestroyOptions extends DestroyOptions {
   canonicalRepoPath?: RepoPath;
   /** Delete the remote branch (best-effort, e.g., after PR merge) */
   deleteRemoteBranch?: boolean;
+  /** Git remote name for remote branch deletion (default: 'origin') */
+  remote?: string;
 }
 
 /**
@@ -272,6 +274,22 @@ export interface WorktreeCreateConfig {
    * @example '.worktrees'
    */
   path?: string;
+  /**
+   * Git remote name to use for fetch/push operations.
+   *
+   * Most repos use the standard 'origin' remote, but some (e.g. Salesforce Core)
+   * use numbered or named remotes. When set, all git operations (fetch, push,
+   * branch tracking) use this remote instead of 'origin'.
+   *
+   * When omitted, auto-detected via `getDefaultRemote()`:
+   *   1. 'origin' if it exists
+   *   2. The sole remote if only one is configured
+   *   3. Fails with actionable error if ambiguous
+   *
+   * Sourced from `.archon/config.yaml > worktree.remote` in the repo.
+   * @example '264'
+   */
+  remote?: string;
 }
 
 export type RepoConfigLoader = (repoPath: string) => Promise<WorktreeCreateConfig | null>;


### PR DESCRIPTION
## Summary

- **Problem:** Archon hardcodes `'origin'` as the git remote name in all fetch/push/reset operations, breaking repos with non-standard remotes.
- **Why it matters:** Organizations using custom-named remotes (e.g. `jan`, `feb`, `mar` for release-based workflows) cannot use Archon's worktree isolation at all.
- **What changed:** Added `worktree.remote` config option, `getDefaultRemote()` auto-detection, and threaded remote name through all git operations.
- **What did not change (scope boundary):** No changes to workflow execution, command parsing, adapter logic, or web UI. Only git/isolation plumbing.

## UX Journey

### Before

```
User                     Archon CLI                Git
────                     ──────────                ───
runs workflow ─────────▶ creates worktree
                         fetch origin <branch> ───▶ ERROR: 'origin' does not exist
                         ◀──────────────────────── fatal error
sees error ◀──────────── "Check network connection"
```

### After

```
User                     Archon CLI                     Git
────                     ──────────                     ───
configures .archon/      (reads worktree.remote)
runs workflow ─────────▶ [resolveRemote()] ─────────▶  git remote
                         ◀─────────────────────────── returns 'mar'
                         fetch mar <branch> ──────────▶ SUCCESS
                         creates worktree from mar/main
sees worktree ◀────────── isolation ready
```

## Architecture Diagram

### Before

```
┌──────────────┐     ┌───────────────┐     ┌──────────────┐
│  CLI / Orch  │────▶│  @archon/iso  │────▶│  @archon/git │
│              │     │  worktree.ts  │     │  repo.ts     │
│              │     │               │     │  branch.ts   │
└──────────────┘     └───────────────┘     └──────────────┘
                            │
                     ┌──────┴──────┐
                     │ config-loader│
                     │ (RepoConfig) │
                     └─────────────┘

All git calls hardcode 'origin'
```

### After

```
┌──────────────┐     ┌───────────────┐     ┌──────────────┐
│  CLI / Orch  │────▶│  @archon/iso  │────▶│  @archon/git │
│              │     │  worktree.ts  │     │ [~] repo.ts  │
│              │     │ [~] resolve   │     │ [~] branch.ts│
└──────────────┘     │    Remote()   │     │ [+] getDef.. │
                     └───────────────┘     └──────────────┘
                            │
                     ┌──────┴──────┐
                     │[~] config   │
                     │  +remote    │
                     └─────────────┘

All git calls use resolved remote name (config > auto-detect > error)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| WorktreeProvider | syncWorkspace | **modified** | Passes `remote` in options |
| WorktreeProvider | getDefaultRemote | **new** | Used by resolveRemote() |
| WorktreeProvider | execFileAsync | **modified** | Uses `${remote}/` instead of `origin/` |
| config-loader | MergedConfig | **modified** | Propagates `worktree.remote` |
| syncWorkspace | getDefaultBranch | **modified** | Passes `remote` param |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `git`, `isolation`, `config`
- Module: `git:repo`, `isolation:worktree`, `core:config`

## Change Metadata

- Change type: `feature`
- Primary scope: `multi` (git + isolation + core)

## Linked Issue

- Closes: N/A (no existing issue — discovered during use)
- Related: N/A

## Validation Evidence (required)

```bash
bun test packages/git/src/git.test.ts
# 151 pass, 0 fail

bun test packages/isolation/src/providers/worktree.test.ts
# 147 pass, 0 fail

bun test packages/core/src/config/config-loader.test.ts
# 38 pass, 0 fail

# TypeScript
npx tsc --noEmit --project packages/git/tsconfig.json      # clean
npx tsc --noEmit --project packages/isolation/tsconfig.json # clean
npx tsc --noEmit --project packages/core/tsconfig.json      # clean
```

- Evidence provided: All 336 tests pass, lint + prettier pass via pre-commit hooks
- If any command is intentionally skipped: None skipped

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No` (same git fetch/push, just configurable remote name)
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`
- If any `Yes`: N/A

## Compatibility / Migration

- Backward compatible? `Yes` — all new parameters have defaults matching prior behavior (`'origin'`)
- Config/env changes? `Yes` — new optional `worktree.remote` field in `.archon/config.yaml`
- Database migration needed? `No`
- If yes, exact upgrade steps: N/A. Existing configs without `worktree.remote` behave identically.

## Human Verification (required)

- Verified scenarios: Ran workflow against a repo with non-origin remotes; confirmed `getDefaultRemote()` correctly auto-detects sole remote; confirmed `worktree.remote` config is respected
- Edge cases checked: CRLF git output (Windows), multiple ambiguous remotes (actionable error), git failures propagating correctly, config absent (defaults to origin)
- What was not verified: Docker environment, actual Windows host (CRLF test uses mock)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Worktree creation, workspace sync, branch detection, remote branch deletion
- Potential unintended effects: None — all changes add an optional parameter with the existing `'origin'` default. No behavior change for repos that already use `origin`.
- Guardrails/monitoring: Existing tests cover all paths; the `resolveRemote()` method logs at info level when auto-detecting a non-origin remote

## Rollback Plan (required)

- Fast rollback command/path: Revert the single merge commit — all changes are additive with defaults, so reverting cleanly restores prior behavior
- Feature flags or config toggles: The `worktree.remote` config field is the toggle — removing it reverts to `origin` behavior
- Observable failure symptoms: "Failed to fetch base branch from '<remote>'" error during worktree creation

## Risks and Mitigations

- Risk: `getDefaultRemote()` now throws on git errors instead of returning null, which could surface unexpected errors in edge cases.
  - Mitigation: The function is only called inside `resolveRemote()` which is inside a `createWorktree()` try/catch that already surfaces errors with actionable messages. The error path is intentional — better to fail fast with the real error than mislead the user.

- Risk: CRLF handling via `/\r?\n/` regex could theoretically split differently on exotic git builds.
  - Mitigation: Git remote output is well-specified (one name per line). The regex handles both LF and CRLF, plus `.trim()` on each entry catches any trailing whitespace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repositories can specify a custom Git remote via worktree.remote; when omitted the remote is auto-detected (prefers "origin", else sole remote, else errors on ambiguity).
  * Workspace sync, PR worktree creation, branch creation/deletion, and cleanup now respect the configured or auto-detected remote.

* **Tests**
  * Added and updated tests covering custom-remote behavior, auto-detection, error messages, and sync/reset operations.

* **Documentation**
  * Configuration reference updated with remote selection and base-branch detection behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1548?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->