### PR TITLE
fix(workflow):  prompt user on resume of failed run + allow abandoning failed + add --force flag

### DIFF
--- a/packages/core/src/db/workflows.ts
+++ b/packages/core/src/db/workflows.ts
@@ -337,6 +337,11 @@ export async function findResumableRun(
  * Find a resumable (failed/paused) run for a workflow by parent conversation ID.
  * Used by the web orchestrator to detect approved runs that need foreground resume
  * (background dispatch would create a new worktree and lose the resumable run).
+ *
+ * The orchestrator wraps the result: `paused` runs auto-resume (approval gate
+ * intent); `failed` runs trigger a user-prompt instead of silent resume so a
+ * fresh /workflow run with new args is not hijacked by the failed run's stale
+ * persisted user_message. See orchestrator-agent.ts dispatchOrchestratorWorkflow.
  */
 export async function findResumableRunByParentConversation(
   workflowName: string,

--- a/packages/core/src/handlers/command-handler.test.ts
+++ b/packages/core/src/handlers/command-handler.test.ts
@@ -1335,7 +1335,18 @@ describe('CommandHandler', () => {
     });
 
     describe('/workflow resume', () => {
-      test('should indicate failed run is ready to resume', async () => {
+      // Helper: stub a discovered workflow with the given name so the
+      // resume handler's `workflows.find(w => w.workflow.name === ...)` lookup
+      // resolves. The default mock returns an empty workflows array; tests
+      // that exercise the success path of resume must seed the discovery.
+      function stubDiscoveredWorkflow(name: string): void {
+        spyDiscoverWorkflows.mockResolvedValueOnce({
+          workflows: [makeTestWorkflowWithSource({ name })],
+          errors: [],
+        });
+      }
+
+      test('should indicate failed run is ready to resume and signal dispatch with resumeRunId', async () => {
         const run = {
           id: 'run-123',
           workflow_name: 'implement',
@@ -1351,12 +1362,17 @@ describe('CommandHandler', () => {
           working_path: '/workspace/wt',
         };
         mockGetWorkflowRun.mockResolvedValueOnce(run);
+        stubDiscoveredWorkflow('implement');
 
         const result = await handleCommand(baseConversation, '/workflow resume run-123');
 
         expect(result.success).toBe(true);
-        expect(result.message).toContain('ready to resume');
+        expect(result.message).toContain('Resuming workflow');
         expect(result.message).toContain('implement');
+        // Resume now dispatches directly so the orchestrator doesn't loop
+        // through the V2a prompt — see PR #1551.
+        expect(result.workflow?.resumeRunId).toBe('run-123');
+        expect(result.workflow?.definition.name).toBe('implement');
       });
 
       test('should accept already-failed run without status change', async () => {
@@ -1375,6 +1391,7 @@ describe('CommandHandler', () => {
           working_path: null,
         };
         mockGetWorkflowRun.mockResolvedValueOnce(run);
+        stubDiscoveredWorkflow('plan');
 
         const result = await handleCommand(baseConversation, '/workflow resume run-456');
 

--- a/packages/core/src/handlers/command-handler.ts
+++ b/packages/core/src/handlers/command-handler.ts
@@ -692,18 +692,50 @@ async function handleWorkflowCommand(
             'Usage: /workflow resume <id>\n\nResumes a failed workflow from completed nodes.',
         };
       }
+      let run;
       try {
-        const run = await resumeWorkflow(runId);
-        const pathInfo = run.working_path ? `\nPath: \`${run.working_path}\`` : '';
-        return {
-          success: true,
-          message: `Workflow run \`${run.workflow_name}\` (${runId}) is ready to resume.${pathInfo}\nRun the same workflow again to auto-resume from completed nodes.`,
-        };
+        run = await resumeWorkflow(runId);
       } catch (error) {
         const err = error as Error;
         getLog().error({ err, runId }, 'cmd.workflow_resume_failed');
         return { success: false, message: `Failed to resume workflow run: ${err.message}` };
       }
+
+      // Resolve the workflow definition so the orchestrator can dispatch
+      // immediately. Without this, the user would have to re-type
+      // `/workflow run <name> "<args>"`, which (with the failed-run prompt
+      // introduced alongside this change) would just show the prompt again
+      // and leave them in an explicit-resume loop.
+      let workflowEntries: readonly WorkflowWithSource[];
+      try {
+        const result = await discoverWorkflowsWithConfig(workflowCwd, loadConfig);
+        workflowEntries = result.workflows;
+      } catch (error) {
+        const err = error as Error;
+        getLog().error({ err, runId }, 'cmd.workflow_resume_discover_failed');
+        return {
+          success: false,
+          message: `Resume validated but failed to load workflow definitions: ${err.message}`,
+        };
+      }
+      const workflow = workflowEntries.find(w => w.workflow.name === run.workflow_name)?.workflow;
+      if (!workflow) {
+        return {
+          success: false,
+          message: `Resume validated but workflow \`${run.workflow_name}\` is no longer present on disk. Restore the YAML and try again.`,
+        };
+      }
+
+      const pathInfo = run.working_path ? `\nPath: \`${run.working_path}\`` : '';
+      return {
+        success: true,
+        message: `Resuming workflow \`${run.workflow_name}\` (${runId})…${pathInfo}`,
+        workflow: {
+          definition: workflow,
+          args: run.user_message ?? '',
+          resumeRunId: runId,
+        },
+      };
     }
 
     case 'abandon': {

--- a/packages/core/src/handlers/command-handler.ts
+++ b/packages/core/src/handlers/command-handler.ts
@@ -817,15 +817,15 @@ async function handleWorkflowCommand(
     case 'run': {
       // Directly invoke a workflow by name (bypasses AI router)
       const workflowName = args[1];
-      // Extract optional `--force` flag from anywhere in the user's args
-      // (most natural at position 2, but be lenient: `/workflow run X "..." --force`
-      // and `/workflow run X --force "..."` both work).
+      // Extract optional `--force` flag — only when it's the first bareword
+      // after the workflow name (flag-position). A previous "lenient" version
+      // matched `--force` anywhere in restArgs, but `parseCommand` already
+      // splits quoted strings into a single arg, so a user-supplied `--force`
+      // bareword can only appear in flag-position; matching anywhere risked
+      // accidental stripping when a future caller composes args differently.
       const restArgs = args.slice(2);
-      const forceIndex = restArgs.findIndex(a => a === '--force');
-      const force = forceIndex >= 0;
-      const workflowArgs = (force ? restArgs.filter((_, i) => i !== forceIndex) : restArgs).join(
-        ' '
-      );
+      const force = restArgs[0] === '--force';
+      const workflowArgs = (force ? restArgs.slice(1) : restArgs).join(' ');
 
       if (!workflowName) {
         return {

--- a/packages/core/src/handlers/command-handler.ts
+++ b/packages/core/src/handlers/command-handler.ts
@@ -785,7 +785,15 @@ async function handleWorkflowCommand(
     case 'run': {
       // Directly invoke a workflow by name (bypasses AI router)
       const workflowName = args[1];
-      const workflowArgs = args.slice(2).join(' ');
+      // Extract optional `--force` flag from anywhere in the user's args
+      // (most natural at position 2, but be lenient: `/workflow run X "..." --force`
+      // and `/workflow run X --force "..."` both work).
+      const restArgs = args.slice(2);
+      const forceIndex = restArgs.findIndex(a => a === '--force');
+      const force = forceIndex >= 0;
+      const workflowArgs = (force ? restArgs.filter((_, i) => i !== forceIndex) : restArgs).join(
+        ' '
+      );
 
       if (!workflowName) {
         return {
@@ -874,6 +882,7 @@ async function handleWorkflowCommand(
         workflow: {
           definition: workflow,
           args: workflowArgs,
+          force,
         },
       };
     }

--- a/packages/core/src/operations/workflow-operations.ts
+++ b/packages/core/src/operations/workflow-operations.ts
@@ -7,7 +7,6 @@
 import { createLogger } from '@archon/paths';
 import {
   RESUMABLE_WORKFLOW_STATUSES,
-  TERMINAL_WORKFLOW_STATUSES,
   isApprovalContext,
 } from '@archon/workflows/schemas/workflow-run';
 import type { WorkflowRun, ApprovalContext } from '@archon/workflows/schemas/workflow-run';
@@ -101,11 +100,18 @@ export async function resumeWorkflow(runId: string): Promise<WorkflowRun> {
 }
 
 /**
- * Abandon a non-terminal workflow run (marks it as cancelled).
+ * Abandon a workflow run that the user no longer wants in the resume pool.
+ * Marks the run as `cancelled` (still terminal — the audit-trail row stays).
+ *
+ * Accepts running, paused, AND failed runs. Failed runs are deliberately
+ * abandonable: they're terminal in the "no further automated execution"
+ * sense, but a user discarding a failed run is a legitimate operation that
+ * the system would otherwise have no way to express. Already-completed and
+ * already-cancelled runs are rejected — there is nothing to abandon.
  */
 export async function abandonWorkflow(runId: string): Promise<WorkflowRun> {
   const run = await getRunOrThrow(runId, 'operations.workflow_abandon_lookup_failed');
-  if (TERMINAL_WORKFLOW_STATUSES.includes(run.status)) {
+  if (run.status === 'completed' || run.status === 'cancelled') {
     throw new Error(`Cannot abandon run with status '${run.status}'. Run is already terminal.`);
   }
   try {

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1091,6 +1091,11 @@ describe('workflow dispatch routing — interactive flag', () => {
     mockGetOrCreateConversation.mockImplementation(() => Promise.resolve(null));
     mockGetCodebase.mockReset();
     mockGetCodebase.mockImplementation(() => Promise.resolve(null));
+    // Reset resumable-run lookups so a queued mockReturnValueOnce in one test
+    // doesn't bleed into the next (e.g. --force tests queue a value but skip
+    // the call, leaving the mock primed for the following test).
+    mockFindResumableRunByParentConversation.mockReset();
+    mockFindResumableRunByParentConversation.mockImplementation(() => Promise.resolve(null));
   });
 
   test('calls executeWorkflow (not dispatchBackground) for interactive workflow on web', async () => {
@@ -1111,12 +1116,15 @@ describe('workflow dispatch routing — interactive flag', () => {
     expect(callArgs[10]).toBe('conv-1'); // parentConversationId = conversation.id
   });
 
-  test('foreground_resume_detected: passes parentConversationId to executeWorkflow when a resumable run exists', async () => {
-    // Regression for the foreground-resume branch added as part of the
-    // auto-resume fix: when `findResumableRunByParentConversation` returns a
-    // paused run, the orchestrator picks the working_path from that run and
-    // must still carry parentConversationId forward so the API helpers can
-    // keep dispatching resume on subsequent approvals.
+  test('foreground_resume_detected: passes parentConversationId to executeWorkflow when a paused run exists', async () => {
+    // Regression for the foreground-resume branch: when
+    // findResumableRunByParentConversation returns a paused run, the
+    // orchestrator picks the working_path from that run and must still
+    // carry parentConversationId forward so the API helpers can keep
+    // dispatching resume on subsequent approvals.
+    //
+    // Only `paused` runs auto-resume; `failed` runs prompt the user
+    // (covered in the next two tests).
     mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
     mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
     mockHandleCommand.mockReturnValueOnce(Promise.resolve(makeWorkflowResult(true)));
@@ -1126,7 +1134,7 @@ describe('workflow dispatch routing — interactive flag', () => {
         workflow_name: 'test-workflow',
         working_path: '/repos/test-repo/worktrees/feature',
         parent_conversation_id: 'conv-1',
-        status: 'failed',
+        status: 'paused',
       })
     );
 
@@ -1139,6 +1147,70 @@ describe('workflow dispatch routing — interactive flag', () => {
     expect(callArgs[3]).toBe('/repos/test-repo/worktrees/feature');
     // parentConversationId (position 10) should still be the caller conversation id
     expect(callArgs[10]).toBe('conv-1');
+  });
+
+  test('failed_resume_user_prompted: failed runs are NOT auto-resumed, user gets a prompt with three options', async () => {
+    // A prior failed run with the same workflow + parent conversation must
+    // NOT trigger a silent foreground resume. The user is prompted with
+    // three copy-pasteable options (resume / abandon-then-rerun /
+    // force-rerun) and the workflow does not execute until the user makes
+    // a choice.
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(Promise.resolve(makeWorkflowResult(true)));
+    mockFindResumableRunByParentConversation.mockReturnValueOnce(
+      Promise.resolve({
+        id: 'failed-run-42',
+        workflow_name: 'test-workflow',
+        working_path: '/repos/test-repo/worktrees/feature',
+        parent_conversation_id: 'conv-1',
+        status: 'failed',
+      })
+    );
+
+    const platform = makePlatform(); // getPlatformType returns 'web'
+    const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow do the thing');
+
+    // No execution happens
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+    expect(mockDispatchBackgroundWorkflow).not.toHaveBeenCalled();
+
+    // User is prompted with all three commands using the failed run's id
+    const allSends = sendMessage.mock.calls.map(c => (c as unknown[])[1] as string);
+    const prompt = allSends.find(s => s.includes('/workflow resume failed-run-42'));
+    expect(prompt).toBeDefined();
+    expect(prompt).toContain('/workflow abandon failed-run-42');
+    expect(prompt).toContain('/workflow run test-workflow');
+    expect(prompt).toContain('--force');
+  });
+
+  test('--force flag: skips resume detection and dispatches a fresh run even if a failed run exists', async () => {
+    // /workflow run X --force "..." must bypass findResumableRun and start
+    // a clean execution, leaving any prior failed run untouched in the DB.
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    const result = makeWorkflowResult(undefined); // non-interactive
+    (result.workflow as { force?: boolean }).force = true;
+    mockHandleCommand.mockReturnValueOnce(Promise.resolve(result));
+    // Even if a failed run exists, --force must skip the lookup entirely.
+    mockFindResumableRunByParentConversation.mockReturnValueOnce(
+      Promise.resolve({
+        id: 'failed-run-99',
+        workflow_name: 'test-workflow',
+        working_path: '/repos/test-repo/worktrees/old',
+        parent_conversation_id: 'conv-1',
+        status: 'failed',
+      })
+    );
+
+    const platform = makePlatform(); // getPlatformType returns 'web'
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow --force do the thing');
+
+    // findResumable should not even be consulted (skipped by force)
+    expect(mockFindResumableRunByParentConversation).not.toHaveBeenCalled();
+    // Background dispatch fires for the fresh run (non-interactive on web)
+    expect(mockDispatchBackgroundWorkflow).toHaveBeenCalled();
   });
 
   test('calls dispatchBackgroundWorkflow for non-interactive workflow on web', async () => {

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1185,6 +1185,66 @@ describe('workflow dispatch routing — interactive flag', () => {
     expect(prompt).toContain('--force');
   });
 
+  test('failed_resume_user_prompted: prompt includes a preview of the failed run user_message so users can recognize stale runs', async () => {
+    // Without a preview, Option 1 ("Resume that run") looks like it continues
+    // the user's CURRENT request — but it actually re-runs the failed run's
+    // ORIGINAL stored args, which can be a totally different topic if the
+    // failed run is hours/days old. The preview makes the mismatch visible.
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(Promise.resolve(makeWorkflowResult(true)));
+    mockFindResumableRunByParentConversation.mockReturnValueOnce(
+      Promise.resolve({
+        id: 'failed-run-99',
+        workflow_name: 'test-workflow',
+        working_path: '/repos/test-repo/worktrees/feature',
+        parent_conversation_id: 'conv-1',
+        status: 'failed',
+        user_message: 'Edit foo.py: restore editable input fields in `api_key_and_analyse_button`',
+      })
+    );
+
+    const platform = makePlatform();
+    const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow do the new thing');
+
+    const allSends = sendMessage.mock.calls.map(c => (c as unknown[])[1] as string);
+    const prompt = allSends.find(s => s.includes('/workflow resume failed-run-99'));
+    expect(prompt).toBeDefined();
+    // Preview rendered as Markdown blockquote with the failed run's stored message
+    expect(prompt).toContain('> Edit foo.py: restore editable input fields');
+    // Option 1 wording disambiguates resume vs current message
+    expect(prompt).toContain('not your current message');
+  });
+
+  test('failed_resume_user_prompted: long user_message is truncated with ellipsis in the preview', async () => {
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(Promise.resolve(makeWorkflowResult(true)));
+    const longMsg = 'x'.repeat(500);
+    mockFindResumableRunByParentConversation.mockReturnValueOnce(
+      Promise.resolve({
+        id: 'failed-run-long',
+        workflow_name: 'test-workflow',
+        working_path: '/repos/test-repo/worktrees/feature',
+        parent_conversation_id: 'conv-1',
+        status: 'failed',
+        user_message: longMsg,
+      })
+    );
+
+    const platform = makePlatform();
+    const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow do the thing');
+
+    const allSends = sendMessage.mock.calls.map(c => (c as unknown[])[1] as string);
+    const prompt = allSends.find(s => s.includes('/workflow resume failed-run-long'));
+    expect(prompt).toBeDefined();
+    expect(prompt).toContain('…'); // ellipsis present
+    // Truncated preview must not contain the full string
+    expect(prompt).not.toContain(longMsg);
+  });
+
   test('resumeRunId option: failed run DOES auto-resume when CommandResult.workflow.resumeRunId matches', async () => {
     // Regression for the `/workflow resume <id>` path (and the natural-language
     // approval flow that transitions a paused run to 'failed' before

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1185,6 +1185,45 @@ describe('workflow dispatch routing — interactive flag', () => {
     expect(prompt).toContain('--force');
   });
 
+  test('resumeRunId option: failed run DOES auto-resume when CommandResult.workflow.resumeRunId matches', async () => {
+    // Regression for the `/workflow resume <id>` path (and the natural-language
+    // approval flow that transitions a paused run to 'failed' before
+    // dispatching). Without this bypass, the V2a prompt would fire on every
+    // explicit-resume attempt because failed runs stay 'failed' — the user
+    // would be told to resume a run that they JUST asked to resume, in an
+    // infinite loop.
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    const result = makeWorkflowResult(true); // interactive — uses executeWorkflow path
+    (result.workflow as { resumeRunId?: string }).resumeRunId = 'failed-run-7';
+    mockHandleCommand.mockReturnValueOnce(Promise.resolve(result));
+    mockFindResumableRunByParentConversation.mockReturnValueOnce(
+      Promise.resolve({
+        id: 'failed-run-7',
+        workflow_name: 'test-workflow',
+        working_path: '/repos/test-repo/worktrees/feature',
+        parent_conversation_id: 'conv-1',
+        status: 'failed',
+      })
+    );
+
+    const platform = makePlatform();
+    const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
+    await handleMessage(platform, 'conv-1', '/workflow resume failed-run-7');
+
+    // Auto-resumes via the existing paused-run code path
+    expect(mockExecuteWorkflow).toHaveBeenCalled();
+    const callArgs = mockExecuteWorkflow.mock.calls[0] as unknown[];
+    expect(callArgs[3]).toBe('/repos/test-repo/worktrees/feature');
+    expect(callArgs[10]).toBe('conv-1');
+
+    // The V2a prompt MUST NOT have been emitted — that would mean the
+    // explicit-resume request was ignored.
+    const allSends = sendMessage.mock.calls.map(c => (c as unknown[])[1] as string);
+    const promptedAnyway = allSends.some(s => s.includes('Found a prior failed run'));
+    expect(promptedAnyway).toBe(false);
+  });
+
   test('--force flag: skips resume detection and dispatches a fresh run even if a failed run exists', async () => {
     // /workflow run X --force "..." must bypass findResumableRun and start
     // a clean execution, leaving any prior failed run untouched in the DB.

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -315,7 +315,11 @@ async function dispatchOrchestratorWorkflow(
         );
       } else {
         // Failed (or other non-paused unfinished) run — surface four choices.
-        const escapedMsg = userMessage.replace(/"/g, '\\"');
+        // Escape backslash, double-quote, and backtick so the suggested
+        // command renders cleanly even when the original userMessage
+        // contained any of them — without the backtick escape, three
+        // consecutive backticks would close our Markdown code-fence early.
+        const escapedMsg = userMessage.replace(/[\\"`]/g, '\\$&');
         const baseCmd = `/workflow run ${workflow.name}`;
         const promptText = [
           `Found a prior failed run of **${workflow.name}** (run \`${resumableRun.id}\`).`,

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -222,7 +222,7 @@ async function dispatchOrchestratorWorkflow(
   workflow: WorkflowDefinition,
   userMessage: string,
   isolationHints?: HandleMessageContext['isolationHints'],
-  options?: { force?: boolean }
+  options?: { force?: boolean; resumeRunId?: string }
 ): Promise<void> {
   // Auto-attach project to conversation
   await db.updateConversation(conversation.id, {
@@ -282,10 +282,16 @@ async function dispatchOrchestratorWorkflow(
       ? null
       : await workflowDb.findResumableRunByParentConversation(workflow.name, conversation.id);
     if (resumableRun?.working_path) {
-      // Auto-resume only for paused runs (= awaiting approval). Failed runs
-      // hold the previous run's persisted user_message; silently resuming
-      // would hijack a fresh /workflow run with stale args. Prompt the user.
-      if (resumableRun.status === 'paused') {
+      // Auto-resume is safe in two cases:
+      //   1. status === 'paused' — awaiting approval; the user's next
+      //      message is a continuation by definition.
+      //   2. options.resumeRunId === resumableRun.id — caller explicitly
+      //      asked to resume this run. Set by `/workflow resume <id>` and
+      //      by the natural-language approval handler so they bypass the
+      //      prompt that would otherwise loop them indefinitely.
+      // For any other failed run we prompt the user instead of silently
+      // resuming with stale args.
+      if (resumableRun.status === 'paused' || resumableRun.id === options?.resumeRunId) {
         getLog().info(
           {
             workflowName: workflow.name,
@@ -713,7 +719,11 @@ export async function handleMessage(
             codebase,
             workflow,
             pausedRun.user_message,
-            isolationHints
+            isolationHints,
+            // approveWorkflow has just transitioned the run to 'failed' so
+            // findResumableRun picks it up here. Pass resumeRunId so the
+            // V2a-prompt branch is bypassed and the run actually resumes.
+            { resumeRunId: pausedRun.id }
           );
           getLog().info(
             { conversationId, workflowRunId: pausedRun.id, workflowName: pausedRun.workflow_name },
@@ -784,7 +794,10 @@ export async function handleMessage(
             result.workflow.definition,
             result.workflow.args ?? message,
             isolationHints,
-            { force: result.workflow.force ?? false }
+            {
+              force: result.workflow.force ?? false,
+              resumeRunId: result.workflow.resumeRunId,
+            }
           );
         }
         return;
@@ -1496,7 +1509,7 @@ async function handleWorkflowRunCommand(
   workflow: WorkflowDefinition,
   userMessage: string,
   isolationHints?: HandleMessageContext['isolationHints'],
-  options?: { force?: boolean }
+  options?: { force?: boolean; resumeRunId?: string }
 ): Promise<void> {
   // Check if conversation has a project
   if (conversation.codebase_id) {

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -321,17 +321,37 @@ async function dispatchOrchestratorWorkflow(
         // consecutive backticks would close our Markdown code-fence early.
         const escapedMsg = userMessage.replace(/[\\"`]/g, '\\$&');
         const baseCmd = `/workflow run ${workflow.name}`;
+        // Show a preview of the failed run's stored user_message so the user
+        // can tell whether Option 1 (resume) actually matches their current
+        // intent. Without this, Option 1 silently re-runs whatever the prior
+        // run was about — which can be a totally different topic if the
+        // failed run is hours/days old.
+        const PREVIEW_MAX = 160;
+        const priorMessage = (resumableRun.user_message ?? '').replace(/\s+/g, ' ').trim();
+        const priorPreview = priorMessage
+          ? priorMessage.length > PREVIEW_MAX
+            ? `${priorMessage.slice(0, PREVIEW_MAX)}…`
+            : priorMessage
+          : '(no message stored)';
         const promptText = [
+          '---',
+          '',
           `Found a prior failed run of **${workflow.name}** (run \`${resumableRun.id}\`).`,
           '',
-          'Choose how to proceed:',
+          '**Run prompt was:**',
           '',
-          '**1. Resume from where it failed:**',
+          `> ${priorPreview}`,
+          '',
+          '---',
+          '',
+          '**Choose how to proceed:**',
+          '',
+          '**1. Resume that run** (re-runs the prompt shown above, not your current message):',
           '```',
           `/workflow resume ${resumableRun.id}`,
           '```',
           '',
-          '**2. Discard the failed run, then start fresh:**',
+          '**2. Discard the failed run, then start fresh with your current message:**',
           '```',
           `/workflow abandon ${resumableRun.id}`,
           '```',
@@ -340,7 +360,7 @@ async function dispatchOrchestratorWorkflow(
           `${baseCmd} "${escapedMsg}"`,
           '```',
           '',
-          '**3. Start fresh, leave the failed run as-is** (skips the resume check):',
+          '**3. Start fresh with your current message, leave the failed run as-is** (skips the resume check):',
           '```',
           `${baseCmd} --force "${escapedMsg}"`,
           '```',

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -221,7 +221,8 @@ async function dispatchOrchestratorWorkflow(
   codebase: Codebase,
   workflow: WorkflowDefinition,
   userMessage: string,
-  isolationHints?: HandleMessageContext['isolationHints']
+  isolationHints?: HandleMessageContext['isolationHints'],
+  options?: { force?: boolean }
 ): Promise<void> {
   // Auto-attach project to conversation
   await db.updateConversation(conversation.id, {
@@ -272,32 +273,79 @@ async function dispatchOrchestratorWorkflow(
     // Check for a resumable run from a prior dispatch (e.g. approved approval gate).
     // A new background dispatch would create a new worker conversation and never find
     // the prior run's worktree. Execute in foreground to reuse the original working path.
-    const resumableRun = await workflowDb.findResumableRunByParentConversation(
-      workflow.name,
-      conversation.id
-    );
+    //
+    // The `--force` flag (set in command-handler when the user types
+    // `/workflow run X --force "..."`) skips this lookup entirely so a user
+    // who knows about a stale failed run can intentionally start fresh
+    // without abandoning it.
+    const resumableRun = options?.force
+      ? null
+      : await workflowDb.findResumableRunByParentConversation(workflow.name, conversation.id);
     if (resumableRun?.working_path) {
-      getLog().info(
-        {
-          workflowName: workflow.name,
-          resumableRunId: resumableRun.id,
-          workingPath: resumableRun.working_path,
-        },
-        'orchestrator.foreground_resume_detected'
-      );
-      await executeWorkflow(
-        createWorkflowDeps(),
-        platform,
-        conversationId,
-        resumableRun.working_path,
-        workflow,
-        userMessage,
-        conversation.id,
-        codebase.id,
-        undefined, // issueContext
-        undefined, // isolationContext
-        conversation.id // parentConversationId — enables approve/reject auto-resume
-      );
+      // Auto-resume only for paused runs (= awaiting approval). Failed runs
+      // hold the previous run's persisted user_message; silently resuming
+      // would hijack a fresh /workflow run with stale args. Prompt the user.
+      if (resumableRun.status === 'paused') {
+        getLog().info(
+          {
+            workflowName: workflow.name,
+            resumableRunId: resumableRun.id,
+            workingPath: resumableRun.working_path,
+          },
+          'orchestrator.foreground_resume_detected'
+        );
+        await executeWorkflow(
+          createWorkflowDeps(),
+          platform,
+          conversationId,
+          resumableRun.working_path,
+          workflow,
+          userMessage,
+          conversation.id,
+          codebase.id,
+          undefined, // issueContext
+          undefined, // isolationContext
+          conversation.id // parentConversationId — enables approve/reject auto-resume
+        );
+      } else {
+        // Failed (or other non-paused unfinished) run — surface four choices.
+        const escapedMsg = userMessage.replace(/"/g, '\\"');
+        const baseCmd = `/workflow run ${workflow.name}`;
+        const promptText = [
+          `Found a prior failed run of **${workflow.name}** (run \`${resumableRun.id}\`).`,
+          '',
+          'Choose how to proceed:',
+          '',
+          '**1. Resume from where it failed:**',
+          '```',
+          `/workflow resume ${resumableRun.id}`,
+          '```',
+          '',
+          '**2. Discard the failed run, then start fresh:**',
+          '```',
+          `/workflow abandon ${resumableRun.id}`,
+          '```',
+          'then re-run your command:',
+          '```',
+          `${baseCmd} "${escapedMsg}"`,
+          '```',
+          '',
+          '**3. Start fresh, leave the failed run as-is** (skips the resume check):',
+          '```',
+          `${baseCmd} --force "${escapedMsg}"`,
+          '```',
+        ].join('\n');
+        await platform.sendMessage(conversationId, promptText);
+        getLog().info(
+          {
+            workflowName: workflow.name,
+            failedRunId: resumableRun.id,
+            status: resumableRun.status,
+          },
+          'orchestrator.failed_resume_user_prompted'
+        );
+        return;
+      }
     } else if (workflow.interactive) {
       // Interactive workflows run in foreground so output stays in the user's conversation
       await executeWorkflow(
@@ -735,7 +783,8 @@ export async function handleMessage(
             conversation,
             result.workflow.definition,
             result.workflow.args ?? message,
-            isolationHints
+            isolationHints,
+            { force: result.workflow.force ?? false }
           );
         }
         return;
@@ -1446,7 +1495,8 @@ async function handleWorkflowRunCommand(
   conversation: Conversation,
   workflow: WorkflowDefinition,
   userMessage: string,
-  isolationHints?: HandleMessageContext['isolationHints']
+  isolationHints?: HandleMessageContext['isolationHints'],
+  options?: { force?: boolean }
 ): Promise<void> {
   // Check if conversation has a project
   if (conversation.codebase_id) {
@@ -1466,7 +1516,8 @@ async function handleWorkflowRunCommand(
       codebase,
       workflow,
       userMessage,
-      isolationHints
+      isolationHints,
+      options
     );
     return;
   }
@@ -1543,7 +1594,8 @@ async function handleWorkflowRunCommand(
       codebase,
       resolvedWorkflow,
       userMessage,
-      isolationHints
+      isolationHints,
+      options
     );
     return;
   }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -103,6 +103,13 @@ export interface CommandResult {
      * leaving any prior failed run untouched.
      */
     force?: boolean;
+    /**
+     * If set, the orchestrator dispatches in foreground using this run's
+     * working_path even when the run is `failed` (skips the user-prompt
+     * branch). Set by `/workflow resume <id>` so that explicit resume
+     * commands actually resume instead of triggering the V2a prompt.
+     */
+    resumeRunId?: string;
   };
 }
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -96,6 +96,13 @@ export interface CommandResult {
     // If set, orchestrator should execute this workflow
     definition: WorkflowDefinition;
     args: string;
+    /**
+     * If true, skip the resume-detection lookup in
+     * dispatchOrchestratorWorkflow. Set when the user types
+     * `/workflow run <name> --force "..."` to start a fresh run while
+     * leaving any prior failed run untouched.
+     */
+    force?: boolean;
   };
 }
 


### PR DESCRIPTION
## Summary

- Problem: `/workflow run X "task B"` silently auto-resumes a prior failed run of `X` in the same chat, executing in the failed run's sub-worktree with the failed run's persisted `user_message` (= "task A"). The new prompt is discarded with no UI/log indication.
- Why it matters: confident-but-wrong reports of work the user didn't ask for. Trust-corroding silent data loss; users debug nonexistent problems while the assistant runs the same stale task repeatedly.
- What changed: failed runs now emit a 3-option prompt (resume / abandon-then-rerun / `--force`) instead of silently auto-resuming. `/workflow abandon` accepts failed runs (transitions them to `cancelled`). New `--force` flag bypasses the resume-detection lookup for callers who explicitly want a fresh run while keeping the failed audit row.
- What did **not** change: paused-run auto-resume (PR #914 approval-gate path) is unchanged; `/workflow resume <id>` still accepts failed runs; DB schema unchanged; no migrations.

## UX Journey

### Before

```
User                          Archon orchestrator           DB
────                          ───────────────────           ──
runs /workflow run X "A" ───▶ findResumable... → null
                              dispatch fresh run        ───▶ run-A row (failed)

runs /workflow run X "B" ───▶ findResumable... → run-A
                              [silent foreground resume]
                              executeWorkflow(working_path=
                                  thread-of-run-A,
                                  userMessage="B"
                                  ↑ ignored: scripts read
                                  $ARTIFACTS_DIR/.X persisted
                                  from run-A)             ───▶ "completed" on
                                                                task A again

sees positive report ◀──── reports task A as success
   (still confused about
    why task B didn't happen)
```

### After

```
User                          Archon orchestrator           DB
────                          ───────────────────           ──
runs /workflow run X "A" ───▶ findResumable... → null
                              dispatch fresh run        ───▶ run-A row (failed)

runs /workflow run X "B" ───▶ findResumable... → run-A
                              status === 'paused'?
                                no → emit 3-option prompt    [no new run]
                                     **return** (no dispatch)
sees prompt with: ◀────
  /workflow resume <id>           [option 1]
  /workflow abandon <id>          [option 2: works on failed now]
   then re-run command
  /workflow run X --force "B"     [option 3: keep run-A as-is]
```

## Architecture Diagram

### Before

```
                   ┌─ command-handler.ts (parses /workflow run)
                   │     │ args.slice(2).join(' ') = "..."
                   │     ▼
                   │  CommandResult.workflow = { definition, args }
                   │     │
orchestrator-      │     ▼
agent.ts ──────────┴─ handleWorkflowRunCommand
                         │
                         ▼
                      dispatchOrchestratorWorkflow
                         │
                         ▼
                      findResumableRunByParentConversation
                      (status IN ['failed','paused'])
                         │
                         ▼
                      resumableRun? → executeWorkflow [silent]
                                     (auto-resume regardless of status)


workflow-operations.ts: abandonWorkflow rejects ALL terminal statuses
  (= completed | failed | cancelled) — failed runs un-abandonable
```

### After

```
                   ┌─ command-handler.ts (parses /workflow run)
                   │     │ NEW: also parses --force from args
                   │     ▼
                   │  CommandResult.workflow = { definition, args, force? } [~]
                   │     │
orchestrator-      │     ▼
agent.ts ──────────┴─ handleWorkflowRunCommand(..., options={force}) [~]
                         │
                         ▼
                      dispatchOrchestratorWorkflow(..., options) [~]
                         │
                         ▼
                      options.force? null : findResumableRun(...) [+]
                         │
                         ▼
                      resumableRun?
                         ├─ status==='paused' → executeWorkflow [unchanged]
                         └─ else (failed/...)
                              → platform.sendMessage(3-option prompt) [+]
                              → return [+]


workflow-operations.ts: abandonWorkflow rejects only completed | cancelled [~]
  (failed → cancelled is the user's discard action; row stays in DB)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `command-handler.ts:case 'run'` | `args.findIndex('--force')` | **new** | flag parsing |
| `command-handler.ts` | `CommandResult.workflow.force` | **new** | type-level pass-through |
| `orchestrator-agent.ts:handleWorkflowRunCommand` | `dispatchOrchestratorWorkflow` | **modified** | new `options` param |
| `dispatchOrchestratorWorkflow` | `findResumableRunByParentConversation` | **modified** | guarded by `options.force` |
| `dispatchOrchestratorWorkflow` | `platform.sendMessage` (3-option prompt) | **new** | failed-run user prompt |
| `dispatchOrchestratorWorkflow` | `executeWorkflow` (paused branch) | unchanged | PR #914 path preserved |
| `abandonWorkflow` | `TERMINAL_WORKFLOW_STATUSES` check | **removed** | replaced with explicit `completed/cancelled` |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `core`
- Module: `core:orchestrator`, `core:operations`, `core:db`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #1549
- Related #1546 — `archon-assist` persistence; same UX class (silent edit loss), independent mechanism
- Builds on #914 — `fix: foreground resume for interactive workflows + chat auto-resume` introduced the `findResumableRunByParentConversation` lookup this PR refines

## Validation Evidence (required)

```bash
bun run type-check    # clean across all 10 packages
bun --filter @archon/core test
# 102 pass / 0 fail
# - foreground_resume_detected: existing test, fixture switched 'failed' → 'paused'
# - failed_resume_user_prompted: new (asserts no executeWorkflow, prompt text contains all 3 commands)
# - --force flag: new (asserts findResumable not consulted, dispatchBackground fires)

bun run lint          # clean for all touched files
bun run format:check  # clean
```

End-to-end manual verification on a real chat thread (2026-05-03):

1. Existing failed run `32c786ef…` from prior session stayed `failed` in DB.
2. `/workflow run ztech-marimo-edit "..."` produced the 3-option prompt. No silent dispatch, no `executeWorkflow` call observed in workflow logs.
3. `/workflow run ztech-marimo-edit --force "..."` dispatched fresh, completed `success: true` with new feature branch (`wf/marimo-edit-1777809446`). Original `32c786ef…` row untouched.
4. `/workflow abandon 32c786ef…` transitioned the row `failed → cancelled`, `completed_at` populated. Subsequent `/workflow run` in the same chat no longer triggered the prompt.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No**

The prompt text is constructed via plain string concatenation; the `userMessage`'s embedded quotes are escaped (`\"`) when interpolated into the suggested re-run command block. No new untrusted-input parsing path.

## Compatibility / Migration

- Backward compatible? **Yes** for the `paused`-run auto-resume path (PR #914), `/workflow resume <id>` for failed runs, `/workflow run` callers without `--force`. The only behavior change is: failed-run-on-fresh-`/workflow run` now prompts instead of silently auto-resuming — the prior behavior was silent data loss, so this is the intended fix, not a regression.
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

Verified scenarios:
- Failed-run prompt fires for status='failed' resumable, three commands appear with correct IDs interpolated.
- `--force` skips the resume lookup entirely (verified via `mockFindResumableRunByParentConversation.not.toHaveBeenCalled()` in test, plus end-to-end real run).
- `/workflow abandon` on a failed run transitions to `cancelled` (DB confirmed).
- After abandon, `/workflow run` in the same conversation no longer prompts (cancelled is excluded from the resume lookup).
- `paused`-status auto-resume continues to work in the existing test fixture.

Edge cases checked:
- `--force` token recognized at any position in args (not just immediately after workflow name).
- `userMessage` with embedded `"` is escaped in the option-3 suggested command block.

What was not verified:
- A workflow that legitimately wants to retry a transient `failed` run silently (if such a case exists, this PR makes it require either `/workflow resume <id>` or `--force`). No such workflow has been identified in the default workflows.

## Side Effects / Blast Radius (required)

- Affected subsystems: `core:orchestrator` dispatch path, `core:operations` abandon validation, `core:handlers` workflow command parsing, types.
- Potential unintended effects: a workflow author who depended on the silent failed-run auto-resume as a "retry on flaky steps" mechanism will see the new prompt. The prompt's first option (`/workflow resume <id>`) preserves that capability with one extra step.
- Guardrails: the new `orchestrator.failed_resume_user_prompted` log event lets operators detect users hitting this path. The existing `orchestrator.foreground_resume_detected` log fires only on the (unchanged) paused branch.

## Rollback Plan (required)

- Fast rollback: revert this commit. Behavior returns to silent auto-resume of failed runs and abandon-rejection. No data migration needed.
- Feature flags: none. The behavior change is unconditional but additive (`--force` is opt-in for the override case, and the prompt itself emits one user-visible message).
- Observable failure symptoms if rollback is needed: users complaining the prompt is too noisy (would suggest making the prompt suppressible per-workflow), or workflows expecting silent retry-on-failure breaking (would suggest a per-workflow `auto_resume_failed` flag). Neither has been observed in testing.

## Risks and Mitigations

- Risk: a workflow author relied on silent auto-resume of failed runs as a retry mechanism.
  - Mitigation: the prompt's first option offers `/workflow resume <id>` as a copy-pasteable command; the retry capability is preserved with one extra user step.
- Risk: `--force` is recognized as a token anywhere in args. A user passing `--force` as part of literal description text (`"... change the --force flag handling ..."`) could accidentally trigger force.
  - Mitigation: known pattern in CLI tools without `--` separator support. If literal collision becomes a real problem, a `--` separator could be added in a follow-up. Not a regression: the flag didn't exist before, no existing input pattern is broken.
- Risk: hand-maintained 3-option prompt drifts from the actual command-handler behavior over time.
  - Mitigation: the new test (`failed_resume_user_prompted`) asserts the three command strings are present in the prompt; CI catches accidental removal. A future PR could derive the prompt from command-handler metadata, but is premature given the small surface area.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global --force option to start a fresh workflow run, skipping resume detection.
  * `/workflow resume <id>` now returns workflow details (including optional resumeRunId and force) to trigger immediate foreground resumption.

* **Bug Fixes**
  * Paused runs auto-resume; failed runs prompt users with clear choices: resume, abandon+retry, or start fresh.
  * Abandon now accepts running, paused, and failed runs.
  * Clear error shown when a resumed workflow definition is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->