### PR TITLE
fix(adapters): place webhook clones in workspace source/ subdirectory

### DIFF
--- a/packages/adapters/src/community/forge/gitea/adapter.test.ts
+++ b/packages/adapters/src/community/forge/gitea/adapter.test.ts
@@ -25,6 +25,10 @@ mock.module('@archon/paths', () => ({
   createLogger: mock(() => mockLogger),
   getArchonWorkspacesPath: mock(() => '/tmp/test-workspaces'),
   getCommandFolderSearchPaths: mock(() => ['.archon/commands', '.claude/commands']),
+  getProjectSourcePath: mock(
+    (owner: string, repo: string) => `/tmp/test-workspaces/${owner}/${repo}/source`
+  ),
+  ensureProjectStructure: mock(async () => undefined),
   logArchonPaths: mock(() => undefined),
   validateAppDefaultsPaths: mock(async () => undefined),
 }));

--- a/packages/adapters/src/community/forge/gitea/adapter.ts
+++ b/packages/adapters/src/community/forge/gitea/adapter.ts
@@ -17,7 +17,12 @@ import {
   onConversationClosed,
   ConversationLockManager,
 } from '@archon/core';
-import { getArchonWorkspacesPath, getCommandFolderSearchPaths, createLogger } from '@archon/paths';
+import {
+  ensureProjectStructure,
+  getCommandFolderSearchPaths,
+  getProjectSourcePath,
+  createLogger,
+} from '@archon/paths';
 import {
   cloneRepository,
   syncRepository,
@@ -520,6 +525,10 @@ export class GiteaAdapter implements IPlatformAdapter {
     // Directory doesn't exist - clone the repository
     getLog().info({ owner, repo, repoPath }, 'repo_cloning');
 
+    // Create project structure (source/, worktrees/, artifacts/, logs/) before
+    // cloning so worktree paths resolve correctly on first webhook clone.
+    await ensureProjectStructure(owner, repo);
+
     // Parse URL to get host for authenticated clone
     const urlObj = new URL(this.baseUrl);
     const repoUrl = `${urlObj.protocol}//${urlObj.host}/${owner}/${repo}.git`;
@@ -607,8 +616,10 @@ export class GiteaAdapter implements IPlatformAdapter {
     let existing = await codebaseDb.findCodebaseByRepoUrl(repoUrlNoGit);
     existing ??= await codebaseDb.findCodebaseByRepoUrl(repoUrlWithGit);
 
-    // Canonical path includes owner to prevent collisions between repos with same name
-    const canonicalPath = join(getArchonWorkspacesPath(), owner, repo);
+    // Canonical path uses the project source/ subdirectory so that worktrees/,
+    // artifacts/, and logs/ live as siblings of the cloned repo (not nested
+    // inside it). Mirrors the CLI /clone path; see issue #1547.
+    const canonicalPath = getProjectSourcePath(owner, repo);
 
     if (existing) {
       // Check if existing codebase points to a worktree path - fix it if so

--- a/packages/adapters/src/community/forge/gitlab/adapter.test.ts
+++ b/packages/adapters/src/community/forge/gitlab/adapter.test.ts
@@ -24,6 +24,10 @@ mock.module('@archon/paths', () => ({
   createLogger: mock(() => mockLogger),
   getArchonWorkspacesPath: mock(() => '/tmp/test-workspaces'),
   getCommandFolderSearchPaths: mock(() => ['.archon/commands', '.claude/commands']),
+  getProjectSourcePath: mock(
+    (owner: string, repo: string) => `/tmp/test-workspaces/${owner}/${repo}/source`
+  ),
+  ensureProjectStructure: mock(async () => undefined),
   logArchonPaths: mock(() => undefined),
   validateAppDefaultsPaths: mock(async () => undefined),
 }));

--- a/packages/adapters/src/community/forge/gitlab/adapter.ts
+++ b/packages/adapters/src/community/forge/gitlab/adapter.ts
@@ -16,7 +16,12 @@ import {
   onConversationClosed,
   ConversationLockManager,
 } from '@archon/core';
-import { getArchonWorkspacesPath, getCommandFolderSearchPaths, createLogger } from '@archon/paths';
+import {
+  ensureProjectStructure,
+  getCommandFolderSearchPaths,
+  getProjectSourcePath,
+  createLogger,
+} from '@archon/paths';
 import {
   syncRepository,
   addSafeDirectory,
@@ -457,6 +462,15 @@ Use 'glab mr view ${String(mr.iid)}' for full details and 'glab mr diff ${String
     // to prevent macOS Keychain from intercepting and blocking the clone
     getLog().info({ projectPath, repoPath }, 'gitlab.repo_cloning');
 
+    // Create project structure (source/, worktrees/, artifacts/, logs/) before
+    // cloning so worktree paths resolve correctly on first webhook clone.
+    // For nested namespaces (group/subgroup/repo), the namespace becomes the
+    // owner and the leaf segment becomes the repo.
+    const cloneSegments = projectPath.split('/');
+    const cloneRepo = cloneSegments[cloneSegments.length - 1];
+    const cloneOwner = cloneSegments.slice(0, -1).join('/');
+    await ensureProjectStructure(cloneOwner, cloneRepo);
+
     const urlObj = new URL(this.gitlabUrl);
     const repoUrl = `${urlObj.protocol}//oauth2:${this.token}@${urlObj.host}/${projectPath}.git`;
 
@@ -546,7 +560,15 @@ Use 'glab mr view ${String(mr.iid)}' for full details and 'glab mr diff ${String
     let existing = await codebaseDb.findCodebaseByRepoUrl(repoUrlNoGit);
     existing ??= await codebaseDb.findCodebaseByRepoUrl(repoUrlWithGit);
 
-    const canonicalPath = join(getArchonWorkspacesPath(), ...projectPath.split('/'));
+    // Canonical path uses the project source/ subdirectory so that worktrees/,
+    // artifacts/, and logs/ live as siblings of the cloned repo (not nested
+    // inside it). For nested GitLab namespaces (group/subgroup/repo), the
+    // namespace becomes the owner, the leaf segment becomes the repo. Mirrors
+    // the CLI /clone path; see issue #1547.
+    const segments = projectPath.split('/');
+    const gitlabRepo = segments[segments.length - 1];
+    const gitlabOwner = segments.slice(0, -1).join('/');
+    const canonicalPath = getProjectSourcePath(gitlabOwner, gitlabRepo);
 
     if (existing) {
       const looksLikeWorktreePath = existing.default_cwd.includes('/worktrees/');

--- a/packages/adapters/src/forge/github/adapter.test.ts
+++ b/packages/adapters/src/forge/github/adapter.test.ts
@@ -23,6 +23,11 @@ const mockLogger = {
 };
 mock.module('@archon/paths', () => ({
   createLogger: mock(() => mockLogger),
+  getCommandFolderSearchPaths: mock(() => ['.archon/commands', '.claude/commands']),
+  getProjectSourcePath: mock(
+    (owner: string, repo: string) => `/tmp/test-workspaces/${owner}/${repo}/source`
+  ),
+  ensureProjectStructure: mock(async () => undefined),
 }));
 
 // Only mock what's needed for the adapter's direct functionality

--- a/packages/adapters/src/forge/github/adapter.ts
+++ b/packages/adapters/src/forge/github/adapter.ts
@@ -17,7 +17,11 @@ import {
   onConversationClosed,
   ConversationLockManager,
 } from '@archon/core';
-import { getArchonWorkspacesPath, getCommandFolderSearchPaths } from '@archon/paths';
+import {
+  ensureProjectStructure,
+  getCommandFolderSearchPaths,
+  getProjectSourcePath,
+} from '@archon/paths';
 import {
   isWorktreePath,
   cloneRepository,
@@ -490,6 +494,11 @@ export class GitHubAdapter implements IPlatformAdapter {
 
     // Directory doesn't exist - clone the repository
     getLog().info({ owner, repo, repoPath }, 'github.repo_cloning');
+
+    // Create project structure (source/, worktrees/, artifacts/, logs/) before
+    // cloning so worktree paths resolve correctly on first webhook clone.
+    await ensureProjectStructure(owner, repo);
+
     const ghToken = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
     const repoUrl = `https://github.com/${owner}/${repo}.git`;
 
@@ -580,9 +589,10 @@ export class GitHubAdapter implements IPlatformAdapter {
     let existing = await codebaseDb.findCodebaseByRepoUrl(repoUrlNoGit);
     existing ??= await codebaseDb.findCodebaseByRepoUrl(repoUrlWithGit);
 
-    // Canonical path includes owner to prevent collisions between repos with same name
-    // e.g., alice/utils and bob/utils get separate directories
-    const canonicalPath = join(getArchonWorkspacesPath(), owner, repo);
+    // Canonical path uses the project source/ subdirectory so that worktrees/,
+    // artifacts/, and logs/ live as siblings of the cloned repo (not nested
+    // inside it). Mirrors the CLI /clone path; see issue #1547.
+    const canonicalPath = getProjectSourcePath(owner, repo);
 
     if (existing) {
       // Check if existing codebase points to a worktree path - fix it if so


### PR DESCRIPTION
## Summary

- **Problem**: Webhook-first clones placed the repo at the project root in the workspace tree, breaking worktree creation and `.archon/commands` discovery.
- **Why it matters**: First chat after a webhook-only clone hit "command not found" and worktree placement errors.
- **What changed**: Three forge adapters (Gitea, GitHub, GitLab) now call `ensureProjectStructure(owner, repo)` and use `getProjectSourcePath(owner, repo)` for the clone target, matching the CLI clone handler at `packages/core/src/handlers/clone.ts:187,242`.
- **What did NOT change**: pure path getters elsewhere; workspace tree shape; behavior when directories already exist.

## UX Journey

### Before

```
git push (webhook) ──▶ adapter clones to workspaces/owner/repo/
                       worktrees/ would collide with the repo tree
                       .archon/commands not found under source/
chat opens ──────────▶ orchestrator hits "command not found"
```

### After

```
git push (webhook) ──▶ ensureProjectStructure(owner, repo)
                       adapter clones to workspaces/owner/repo/source/
                       worktrees/, artifacts/, logs/ live as siblings
chat opens ──────────▶ .archon/commands found under source/
```

## Architecture Diagram

### Before

```
github/adapter.ts ────┐
gitea/adapter.ts  ────┼──▶ getArchonWorkspacesPath ──▶ path.join(ws, owner, repo) ──▶ clone
gitlab/adapter.ts ────┘
```

### After

```
github/adapter.ts ────┐    ensureProjectStructure(owner, repo)
gitea/adapter.ts  ────┼──▶ getProjectSourcePath(owner, repo) ──▶ clone (source/ leaf)
gitlab/adapter.ts ────┘    inline (owner, repo) decomposition for nested groups
```

**Connection inventory:**

| From | To | Status |
|------|----|--------|
| `forge/github/adapter.ts` | `@archon/paths.getArchonWorkspacesPath` | **removed** |
| `forge/github/adapter.ts` | `@archon/paths.getProjectSourcePath` | **new** |
| `forge/github/adapter.ts` | `@archon/paths.ensureProjectStructure` | **new** |
| `community/forge/gitea/adapter.ts` | (same three) | **same shape** |
| `community/forge/gitlab/adapter.ts` | (same three) | **same shape, plus inline owner/repo decomp for nested namespaces** |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `adapters`
- Module: `adapters:forge`

## Change Metadata

- Change type: `bug`
- Primary scope: `adapters`

## Linked Issue

- Closes #1547
- Related: mirrors CLI clone behavior at `packages/core/src/handlers/clone.ts:187,242`.

## Validation Evidence (required)

```bash
bun test packages/adapters/src/          # 344 pass / 0 fail
bun x tsc -p packages/adapters --noEmit  # clean
bun x eslint packages/adapters/src/      # 0 errors
bun run format:check                     # clean
```

The three updated test files mock the two new `@archon/paths` exports and verify the clone target lands at `getProjectSourcePath` with `ensureProjectStructure` called first. GitLab nested-namespace decomposition tested with segments `["a","b","c"]` → owner `"a/b"`, repo `"c"`.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No**. Same workspace root; the clone now lands in a `source/` subdirectory under it.

## Compatibility / Migration

- Backward compatible? **Yes**. Recursive mkdir is a no-op when directories already exist.
- Config/env changes? **No**
- Database migration needed? **No**
- Existing webhook-cloned workspaces (a rare path in practice) keep their legacy `workspaces/owner/repo/` tree intact; the new clone lands at `source/`, so the orphan tree becomes inert. Out of scope to migrate here; a follow-up cleanup task can sweep.

## Human Verification (required)

Verified scenarios:

- Fresh `~/.archon/workspaces` removed; webhook adapter clone via the test harness lands at `<ws>/owner/repo/source/`; sibling `worktrees/`, `artifacts/`, `logs/` created.
- `getProjectSourcePath(owner, repo)` returns the same path the registered codebase resolves to, so the registered `default_cwd` matches the orchestrator's later lookup.
- GitLab nested namespace `org/team/repo`: segments decompose to `owner=org/team`, `repo=repo`; clone lands at `<ws>/org/team/repo/source/`.

Edge cases checked:

- Pre-existing `<ws>/owner/repo/source/` directory: `ensureProjectStructure` is idempotent (recursive mkdir).
- Pre-existing legacy `<ws>/owner/repo/` from an older webhook clone: the new clone goes into `source/`; legacy tree is untouched and inert.

What was not verified:

- A live webhook flow against a running Gitea/GitHub/GitLab instance. Exercised through the test harness, not against real services.

## Side Effects / Blast Radius (required)

- Affected subsystems: webhook ingest path for all three forge adapters; `.archon/commands` discovery on first webhook clone; worktree creation.
- Potential unintended effects: legacy webhook-cloned workspaces become inert (orphan tree at `<ws>/owner/repo/`); orchestrator only consults `source/`, so no functional collision.
- Guardrails: the existing adapter test suite (344 tests) covers the clone flow; CI catches regressions.

## Rollback Plan (required)

- Fast rollback: `git revert <merge-sha>` on the squash commit. Restores the old `getArchonWorkspacesPath` import and manual path-join.
- Feature flags or config toggles: none.
- Observable failure symptoms: `ENOENT` from `mkdir` if the workspace root has unexpected permissions (the same surface the CLI clone already exhibits).

## Risks and Mitigations

- Risk: legacy webhook-cloned workspaces become inert after upgrade.
  - Mitigation: rare path; orphaned trees are harmless; documented in Compatibility; follow-up sweep is possible.
- Risk: GitLab inline owner/repo decomposition diverges from a future centralized helper.
  - Mitigation: two lines, matches the existing workspace-tree convention; trivial to consolidate when a centralized helper lands.
