### PR TITLE
fix(workflows): support editing global workflows

### DIFF
--- a/packages/docs-web/src/content/docs/reference/api.md
+++ b/packages/docs-web/src/content/docs/reference/api.md
@@ -217,7 +217,7 @@ curl http://localhost:3090/api/workflows/archon-assist
 Query parameters:
 - `cwd` (optional) -- Working directory for project-specific lookup
 
-Returns `{ workflow, filename, source: "project" | "bundled" }`.
+Returns `{ workflow, filename, source: "project" | "global" | "bundled" }`. The endpoint auto-discovers across all three scopes in order (project → home-scoped → bundled). `source: "global"` is returned when the workflow comes from `~/.archon/workflows/`.
 
 #### Validate a Workflow
 
@@ -239,6 +239,7 @@ curl -X PUT http://localhost:3090/api/workflows/my-workflow \
 
 Query parameters:
 - `cwd` (optional) -- Target directory (must have `.archon/workflows/`)
+- `source` (optional, enum: `project` \| `global`) -- Scope to write the workflow to. Defaults to `project` (writes to `<cwd>/.archon/workflows/`). Pass `source=global` to write to the home-scoped location (`~/.archon/workflows/`). Returns `400 "Invalid workflow source"` if any other value is supplied.
 
 Validates the definition before saving. Returns the saved workflow.
 
@@ -247,6 +248,10 @@ Validates the definition before saving. Returns the saved workflow.
 ```bash
 curl -X DELETE http://localhost:3090/api/workflows/my-workflow
 ```
+
+Query parameters:
+- `cwd` (optional) -- Target directory (must have `.archon/workflows/`)
+- `source` (optional, enum: `project` \| `global`) -- Scope to delete from. Defaults to `project`. Pass `source=global` to delete from `~/.archon/workflows/`. Returns `400 "Invalid workflow source"` if any other value is supplied.
 
 Only user-defined workflows can be deleted. Bundled defaults cannot be removed.
 

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -37,6 +37,7 @@ import {
   getDefaultWorkflowsPath,
   getArchonWorkspacesPath,
   getHomeCommandsPath,
+  getHomeWorkflowsPath,
   getRunArtifactsPath,
   getArchonHome,
   isDocker,
@@ -155,6 +156,9 @@ function jsonError(description: string): {
 }
 
 const cwdQuerySchema = z.object({ cwd: z.string().optional() });
+const workflowTargetQuerySchema = cwdQuerySchema.extend({
+  source: z.enum(['project', 'global']).optional(),
+});
 
 const getWorkflowsRoute = createRoute({
   method: 'get',
@@ -220,7 +224,7 @@ const saveWorkflowRoute = createRoute({
   summary: 'Save (create or update) a workflow',
   request: {
     params: z.object({ name: z.string() }),
-    query: cwdQuerySchema,
+    query: workflowTargetQuerySchema,
     body: { content: { 'application/json': { schema: saveWorkflowBodySchema } }, required: true },
   },
   responses: {
@@ -240,7 +244,7 @@ const deleteWorkflowRoute = createRoute({
   summary: 'Delete a user-defined workflow',
   request: {
     params: z.object({ name: z.string() }),
-    query: cwdQuerySchema,
+    query: workflowTargetQuerySchema,
   },
   responses: {
     200: {
@@ -2260,7 +2264,29 @@ export function registerApiRoutes(
         }
       }
 
-      // 2. Fall back to bundled defaults (binary: embedded map; dev: also check filesystem)
+      // 2. Try home-scoped workflows (~/.archon/workflows). List discovery
+      // includes these as source:global, so the detail/edit endpoint must
+      // resolve them too.
+      const globalFilePath = join(getHomeWorkflowsPath(), filename);
+      try {
+        const content = await readFile(globalFilePath, 'utf-8');
+        const result = parseWorkflow(content, filename);
+        if (result.error) {
+          return apiError(c, 500, `Global workflow is invalid: ${result.error.error}`);
+        }
+        return c.json({
+          workflow: result.workflow,
+          filename,
+          source: 'global' as WorkflowSource,
+        });
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+          getLog().error({ err, name }, 'workflow.fetch_global_failed');
+          return apiError(c, 500, 'Failed to read global workflow');
+        }
+      }
+
+      // 3. Fall back to bundled defaults (binary: embedded map; dev: also check filesystem)
       if (Object.hasOwn(BUNDLED_WORKFLOWS, name)) {
         const bundledContent = BUNDLED_WORKFLOWS[name];
         const result = parseWorkflow(bundledContent, filename);
@@ -2306,9 +2332,16 @@ export function registerApiRoutes(
       return apiError(c, 400, 'Invalid workflow name');
     }
 
+    const targetSource = c.req.query('source');
+    if (targetSource && targetSource !== 'project' && targetSource !== 'global') {
+      return apiError(c, 400, 'Invalid workflow source');
+    }
+
     const cwd = c.req.query('cwd');
     let workingDir = cwd;
-    if (cwd) {
+    if (targetSource === 'global') {
+      workingDir = undefined;
+    } else if (cwd) {
       if (!(await validateCwd(cwd))) {
         return apiError(c, 400, 'Invalid cwd: must match a registered codebase path');
       }
@@ -2338,15 +2371,18 @@ export function registerApiRoutes(
     }
 
     try {
-      const [workflowFolder] = getWorkflowFolderSearchPaths();
-      const dirPath = join(workingDir, workflowFolder);
+      const source: WorkflowSource = targetSource === 'global' ? 'global' : 'project';
+      const dirPath =
+        source === 'global'
+          ? getHomeWorkflowsPath()
+          : join(workingDir, getWorkflowFolderSearchPaths()[0]);
       await mkdir(dirPath, { recursive: true });
       const filePath = join(dirPath, `${name}.yaml`);
       await writeFile(filePath, yamlContent, 'utf-8');
       return c.json({
         workflow: parsed.workflow,
         filename: `${name}.yaml`,
-        source: 'project' as WorkflowSource,
+        source,
       });
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
@@ -2362,14 +2398,21 @@ export function registerApiRoutes(
       return apiError(c, 400, 'Invalid workflow name');
     }
 
+    const targetSource = c.req.query('source');
+    if (targetSource && targetSource !== 'project' && targetSource !== 'global') {
+      return apiError(c, 400, 'Invalid workflow source');
+    }
+
     // Refuse to delete bundled defaults
-    if (Object.hasOwn(BUNDLED_WORKFLOWS, name)) {
+    if (targetSource !== 'global' && Object.hasOwn(BUNDLED_WORKFLOWS, name)) {
       return apiError(c, 400, `Cannot delete bundled default workflow: ${name}`);
     }
 
     const cwd = c.req.query('cwd');
     let workingDir = cwd;
-    if (cwd) {
+    if (targetSource === 'global') {
+      workingDir = undefined;
+    } else if (cwd) {
       if (!(await validateCwd(cwd))) {
         return apiError(c, 400, 'Invalid cwd: must match a registered codebase path');
       }
@@ -2381,8 +2424,10 @@ export function registerApiRoutes(
       workingDir = getArchonHome();
     }
 
-    const [workflowFolder] = getWorkflowFolderSearchPaths();
-    const filePath = join(workingDir, workflowFolder, `${name}.yaml`);
+    const filePath =
+      targetSource === 'global'
+        ? join(getHomeWorkflowsPath(), `${name}.yaml`)
+        : join(workingDir, getWorkflowFolderSearchPaths()[0], `${name}.yaml`);
 
     try {
       await unlink(filePath);

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -156,6 +156,9 @@ function jsonError(description: string): {
 }
 
 const cwdQuerySchema = z.object({ cwd: z.string().optional() });
+const workflowTargetQuerySchema = cwdQuerySchema.extend({
+  source: z.enum(['project', 'global']).optional(),
+});
 
 const getWorkflowsRoute = createRoute({
   method: 'get',
@@ -221,7 +224,7 @@ const saveWorkflowRoute = createRoute({
   summary: 'Save (create or update) a workflow',
   request: {
     params: z.object({ name: z.string() }),
-    query: cwdQuerySchema,
+    query: workflowTargetQuerySchema,
     body: { content: { 'application/json': { schema: saveWorkflowBodySchema } }, required: true },
   },
   responses: {
@@ -241,7 +244,7 @@ const deleteWorkflowRoute = createRoute({
   summary: 'Delete a user-defined workflow',
   request: {
     params: z.object({ name: z.string() }),
-    query: cwdQuerySchema,
+    query: workflowTargetQuerySchema,
   },
   responses: {
     200: {
@@ -2357,9 +2360,16 @@ export function registerApiRoutes(
       return apiError(c, 400, 'Invalid workflow name');
     }
 
+    const targetSource = c.req.query('source');
+    if (targetSource && targetSource !== 'project' && targetSource !== 'global') {
+      return apiError(c, 400, 'Invalid workflow source');
+    }
+
     const cwd = c.req.query('cwd');
     let workingDir = cwd;
-    if (cwd) {
+    if (targetSource === 'global') {
+      workingDir = undefined;
+    } else if (cwd) {
       if (!(await validateCwd(cwd))) {
         return apiError(c, 400, 'Invalid cwd: must match a registered codebase path');
       }
@@ -2389,15 +2399,18 @@ export function registerApiRoutes(
     }
 
     try {
-      const [workflowFolder] = getWorkflowFolderSearchPaths();
-      const dirPath = join(workingDir, workflowFolder);
+      const source: WorkflowSource = targetSource === 'global' ? 'global' : 'project';
+      const dirPath =
+        source === 'global'
+          ? getHomeWorkflowsPath()
+          : join(workingDir, getWorkflowFolderSearchPaths()[0]);
       await mkdir(dirPath, { recursive: true });
       const filePath = join(dirPath, `${name}.yaml`);
       await writeFile(filePath, yamlContent, 'utf-8');
       return c.json({
         workflow: parsed.workflow,
         filename: `${name}.yaml`,
-        source: 'project' as WorkflowSource,
+        source,
       });
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
@@ -2413,14 +2426,21 @@ export function registerApiRoutes(
       return apiError(c, 400, 'Invalid workflow name');
     }
 
+    const targetSource = c.req.query('source');
+    if (targetSource && targetSource !== 'project' && targetSource !== 'global') {
+      return apiError(c, 400, 'Invalid workflow source');
+    }
+
     // Refuse to delete bundled defaults
-    if (Object.hasOwn(BUNDLED_WORKFLOWS, name)) {
+    if (targetSource !== 'global' && Object.hasOwn(BUNDLED_WORKFLOWS, name)) {
       return apiError(c, 400, `Cannot delete bundled default workflow: ${name}`);
     }
 
     const cwd = c.req.query('cwd');
     let workingDir = cwd;
-    if (cwd) {
+    if (targetSource === 'global') {
+      workingDir = undefined;
+    } else if (cwd) {
       if (!(await validateCwd(cwd))) {
         return apiError(c, 400, 'Invalid cwd: must match a registered codebase path');
       }
@@ -2432,8 +2452,10 @@ export function registerApiRoutes(
       workingDir = getArchonHome();
     }
 
-    const [workflowFolder] = getWorkflowFolderSearchPaths();
-    const filePath = join(workingDir, workflowFolder, `${name}.yaml`);
+    const filePath =
+      targetSource === 'global'
+        ? join(getHomeWorkflowsPath(), `${name}.yaml`)
+        : join(workingDir, getWorkflowFolderSearchPaths()[0], `${name}.yaml`);
 
     try {
       await unlink(filePath);

--- a/packages/server/src/routes/api.workflows.test.ts
+++ b/packages/server/src/routes/api.workflows.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, mock } from 'bun:test';
 import { OpenAPIHono } from '@hono/zod-openapi';
 import type { ConversationLockManager } from '@archon/core';
 import type { WebAdapter } from '../adapters/web';
-import { mkdir, rm, writeFile } from 'fs/promises';
+import { mkdir, readFile, rm, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { validationErrorHook } from './openapi-defaults';
@@ -253,6 +253,37 @@ describe('GET /api/workflows/:name', () => {
     }
   });
 
+  test('returns global workflow with source:global when file exists in ARCHON_HOME', async () => {
+    const testArchonHome = join(tmpdir(), `archon-home-get-global-${Date.now()}`);
+    const workflowDir = join(testArchonHome, 'workflows');
+    process.env.ARCHON_HOME = testArchonHome;
+    await mkdir(workflowDir, { recursive: true });
+    await writeFile(
+      join(workflowDir, 'global-workflow.yaml'),
+      'name: global-workflow\ndescription: Global workflow\nnodes:\n  - id: plan\n    command: plan\n'
+    );
+
+    try {
+      const app = createTestApp();
+      registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+      mockListCodebases.mockImplementationOnce(async () => []);
+      const response = await app.request('/api/workflows/global-workflow');
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        source: string;
+        filename: string;
+        workflow: { name: string };
+      };
+      expect(body.source).toBe('global');
+      expect(body.filename).toBe('global-workflow.yaml');
+      expect(body.workflow).toBeDefined();
+    } finally {
+      delete process.env.ARCHON_HOME;
+      await rm(testArchonHome, { recursive: true, force: true });
+    }
+  });
+
   test('returns WorkflowDefinition shape with expected top-level fields', async () => {
     const app = createTestApp();
     registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
@@ -403,6 +434,47 @@ describe('PUT /api/workflows/:name', () => {
       expect(body.source).toBe('project');
     } finally {
       await rm(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test('saves valid workflow to ARCHON_HOME workflows when source=global', async () => {
+    const testArchonHome = join(tmpdir(), `archon-home-put-global-${Date.now()}`);
+    process.env.ARCHON_HOME = testArchonHome;
+
+    try {
+      const app = createTestApp();
+      registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+      const response = await app.request('/api/workflows/global-workflow?source=global', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          definition: {
+            name: 'global-workflow',
+            description: 'Global workflow',
+            nodes: [{ id: 'plan', command: 'plan' }],
+          },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        workflow: { name: string };
+        filename: string;
+        source: string;
+      };
+      expect(body.workflow).toBeDefined();
+      expect(body.filename).toBe('global-workflow.yaml');
+      expect(body.source).toBe('global');
+
+      const saved = await readFile(
+        join(testArchonHome, 'workflows', 'global-workflow.yaml'),
+        'utf-8'
+      );
+      expect(saved).toContain('name: global-workflow');
+    } finally {
+      delete process.env.ARCHON_HOME;
+      await rm(testArchonHome, { recursive: true, force: true });
     }
   });
 });

--- a/packages/server/src/routes/api.workflows.test.ts
+++ b/packages/server/src/routes/api.workflows.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, mock, spyOn } from 'bun:test';
 import { OpenAPIHono } from '@hono/zod-openapi';
 import type { ConversationLockManager } from '@archon/core';
 import type { WebAdapter } from '../adapters/web';
-import { mkdir, rm, writeFile } from 'fs/promises';
+import { mkdir, readFile, rm, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { validationErrorHook } from './openapi-defaults';
@@ -547,6 +547,47 @@ describe('PUT /api/workflows/:name', () => {
       expect(body.source).toBe('project');
     } finally {
       await rm(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test('saves valid workflow to ARCHON_HOME workflows when source=global', async () => {
+    const testArchonHome = join(tmpdir(), `archon-home-put-global-${Date.now()}`);
+    process.env.ARCHON_HOME = testArchonHome;
+
+    try {
+      const app = createTestApp();
+      registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+      const response = await app.request('/api/workflows/global-workflow?source=global', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          definition: {
+            name: 'global-workflow',
+            description: 'Global workflow',
+            nodes: [{ id: 'plan', command: 'plan' }],
+          },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        workflow: { name: string };
+        filename: string;
+        source: string;
+      };
+      expect(body.workflow).toBeDefined();
+      expect(body.filename).toBe('global-workflow.yaml');
+      expect(body.source).toBe('global');
+
+      const saved = await readFile(
+        join(testArchonHome, 'workflows', 'global-workflow.yaml'),
+        'utf-8'
+      );
+      expect(saved).toContain('name: global-workflow');
+    } finally {
+      delete process.env.ARCHON_HOME;
+      await rm(testArchonHome, { recursive: true, force: true });
     }
   });
 });

--- a/packages/server/src/routes/api.workflows.test.ts
+++ b/packages/server/src/routes/api.workflows.test.ts
@@ -590,6 +590,24 @@ describe('PUT /api/workflows/:name', () => {
       await rm(testArchonHome, { recursive: true, force: true });
     }
   });
+
+  test('returns 400 when source is not project or global', async () => {
+    const app = createTestApp();
+    registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+    const response = await app.request('/api/workflows/some-workflow?source=bundled', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        definition: {
+          name: 'some-workflow',
+          description: 'x',
+          nodes: [{ id: 'a', command: 'a' }],
+        },
+      }),
+    });
+    expect(response.status).toBe(400);
+  });
 });
 
 describe('DELETE /api/workflows/:name', () => {
@@ -655,6 +673,52 @@ describe('DELETE /api/workflows/:name', () => {
     } finally {
       await rm(testDir, { recursive: true, force: true });
     }
+  });
+
+  test('removes home-scoped workflow file when source=global', async () => {
+    const testArchonHome = join(tmpdir(), `archon-home-del-global-${Date.now()}`);
+    const workflowDir = join(testArchonHome, 'workflows');
+    await mkdir(workflowDir, { recursive: true });
+    await writeFile(
+      join(workflowDir, 'home-to-delete.yaml'),
+      'name: home-to-delete\ndescription: y\nnodes:\n  - id: z\n    command: z\n'
+    );
+
+    const prevArchonHome = process.env.ARCHON_HOME;
+    process.env.ARCHON_HOME = testArchonHome;
+    try {
+      const app = createTestApp();
+      registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+      const response = await app.request('/api/workflows/home-to-delete?source=global', {
+        method: 'DELETE',
+      });
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { deleted: boolean; name: string };
+      expect(body.deleted).toBe(true);
+      expect(body.name).toBe('home-to-delete');
+
+      // Confirm the file is gone from the home-scoped location.
+      const fsPromises = await import('fs/promises');
+      await expect(fsPromises.access(join(workflowDir, 'home-to-delete.yaml'))).rejects.toThrow();
+    } finally {
+      if (prevArchonHome === undefined) {
+        delete process.env.ARCHON_HOME;
+      } else {
+        process.env.ARCHON_HOME = prevArchonHome;
+      }
+      await rm(testArchonHome, { recursive: true, force: true });
+    }
+  });
+
+  test('returns 400 when source is not project or global', async () => {
+    const app = createTestApp();
+    registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+    const response = await app.request('/api/workflows/some-workflow?source=bundled', {
+      method: 'DELETE',
+    });
+    expect(response.status).toBe(400);
   });
 });
 

--- a/packages/web/src/components/workflows/WorkflowBuilder.tsx
+++ b/packages/web/src/components/workflows/WorkflowBuilder.tsx
@@ -3,7 +3,7 @@ import { useSearchParams, useNavigate } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { ReactFlowProvider, useNodesState, useEdgesState, useViewport } from '@xyflow/react';
 import type { Edge } from '@xyflow/react';
-import type { WorkflowDefinition } from '@/lib/api';
+import type { WorkflowDefinition, WorkflowSource } from '@/lib/api';
 
 import { useProject } from '@/contexts/ProjectContext';
 import {
@@ -129,6 +129,7 @@ function WorkflowBuilderInner(): React.ReactElement {
   const [workflowDescription, setWorkflowDescription] = useState('');
   const [provider, setProvider] = useState<string | undefined>(undefined);
   const [model, setModel] = useState<string | undefined>(undefined);
+  const [workflowSource, setWorkflowSource] = useState<WorkflowSource | undefined>(undefined);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [validationErrors, setValidationErrors] = useState<string[]>([]);
 
@@ -201,11 +202,12 @@ function WorkflowBuilderInner(): React.ReactElement {
   const loadWorkflow = useCallback(
     async (name: string): Promise<void> => {
       try {
-        const { workflow } = await getWorkflow(name, cwd);
+        const { workflow, source } = await getWorkflow(name, cwd);
         setWorkflowName(workflow.name);
         setWorkflowDescription(workflow.description);
         setProvider(workflow.provider);
         setModel(workflow.model);
+        setWorkflowSource(source);
         setValidationErrors([]);
 
         const { nodes: rfNodes, edges: rfEdges } = dagNodesToReactFlow(workflow.nodes);
@@ -296,7 +298,7 @@ function WorkflowBuilderInner(): React.ReactElement {
         return;
       }
       setValidationErrors([]);
-      await saveWorkflow(workflowName.trim(), def, cwd);
+      await saveWorkflow(workflowName.trim(), def, cwd, workflowSource);
       setHasUnsavedChanges(false);
     } catch (err) {
       const error = err instanceof Error ? err : new Error('Unknown error');
@@ -304,7 +306,7 @@ function WorkflowBuilderInner(): React.ReactElement {
       setValidationErrors([`Save failed: ${error.message}`]);
       setValidationPanelOpen(true);
     }
-  }, [buildDefinition, workflowName, cwd]);
+  }, [buildDefinition, workflowName, cwd, workflowSource]);
 
   const handleRun = useCallback(async (): Promise<void> => {
     if (!workflowName.trim() || hasUnsavedChanges) return;

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -424,9 +424,13 @@ export async function getWorkflow(name: string, cwd?: string): Promise<GetWorkfl
 export async function saveWorkflow(
   name: string,
   definition: WorkflowDefinition,
-  cwd?: string
+  cwd?: string,
+  source?: WorkflowSource
 ): Promise<GetWorkflowResponse> {
-  const params = cwd ? `?cwd=${encodeURIComponent(cwd)}` : '';
+  const query = new URLSearchParams();
+  if (cwd) query.set('cwd', cwd);
+  if (source === 'global') query.set('source', source);
+  const params = query.toString() ? `?${query.toString()}` : '';
   return fetchJSON(`/api/workflows/${encodeURIComponent(name)}${params}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
@@ -436,9 +440,13 @@ export async function saveWorkflow(
 
 export async function deleteWorkflow(
   name: string,
-  cwd?: string
+  cwd?: string,
+  source?: WorkflowSource
 ): Promise<{ deleted: boolean; name: string }> {
-  const params = cwd ? `?cwd=${encodeURIComponent(cwd)}` : '';
+  const query = new URLSearchParams();
+  if (cwd) query.set('cwd', cwd);
+  if (source === 'global') query.set('source', source);
+  const params = query.toString() ? `?${query.toString()}` : '';
   return fetchJSON(`/api/workflows/${encodeURIComponent(name)}${params}`, {
     method: 'DELETE',
   });

--- a/packages/web/src/lib/command-categories.ts
+++ b/packages/web/src/lib/command-categories.ts
@@ -66,6 +66,7 @@ function findCategory(name: string): string {
  */
 export function categorizeCommands(commands: CommandEntry[]): CommandCategory[] {
   const projectCommands = commands.filter(c => c.source === 'project');
+  const globalCommands = commands.filter(c => c.source === 'global');
   const bundledCommands = commands.filter(c => c.source === 'bundled');
 
   // Group bundled commands by category
@@ -85,6 +86,10 @@ export function categorizeCommands(commands: CommandEntry[]): CommandCategory[] 
   // Project commands first
   if (projectCommands.length > 0) {
     result.push({ name: 'Project', commands: projectCommands });
+  }
+
+  if (globalCommands.length > 0) {
+    result.push({ name: 'Global', commands: globalCommands });
   }
 
   // Named categories in definition order, then Utilities last


### PR DESCRIPTION
## Summary

- Problem: Global workflows from `~/.archon/workflows` are listed in the Web UI but cannot reliably be opened in the workflow builder because the detail endpoint does not resolve global workflow files.
- Why it matters: Users who keep reusable workflows globally can see them in the list but cannot view or edit the DAG from the Web UI.
- What changed: The workflow detail endpoint now resolves global workflows, save/delete can target global workflow scope with `source=global`, the builder preserves loaded workflow source on save, and global commands appear in the builder command library.
- What did **not** change (scope boundary): Project workflow editing remains unchanged. Bundled/default workflows are still not edited in place.

## UX Journey

### Before

```text
User                         Web UI                       Server
────                         ──────                       ──────
opens workflow list ──────▶  GET /api/workflows ───────▶ discover project/global/bundled
sees global workflow ◀─────  source: global returned ◀── global workflow included
clicks edit ──────────────▶  GET /api/workflows/:name ─▶ checks project + bundled only
sees load error ◀──────────  Workflow not found ◀─────── global workflow not resolved
```

### After

```text
User                         Web UI                          Server
────                         ──────                          ──────
opens workflow list ──────▶  GET /api/workflows ──────────▶ discover project/global/bundled
sees global workflow ◀─────  source: global returned ◀───── global workflow included
clicks edit ──────────────▶  GET /api/workflows/:name ────▶ [checks ~/.archon/workflows]
views DAG ◀────────────────  workflow + source: global ◀── global workflow parsed
saves edits ──────────────▶  PUT ?source=global ─────────▶ [writes ~/.archon/workflows]
```

## Architecture Diagram

### Before

```text
packages/workflows/src/workflow-discovery.ts
  └─ GET /api/workflows
      └─ includes project + global + bundled workflows

packages/server/src/routes/api.ts
  └─ GET /api/workflows/:name
      ├─ project lookup
      └─ bundled/default lookup
          --x-- no global lookup

packages/web/src/components/workflows/WorkflowBuilder.tsx
  └─ load by name only, save without preserving source

packages/web/src/lib/command-categories.ts
  └─ project + bundled command groups only
      --x-- global commands dropped from grouped library view
```

### After

```text
packages/workflows/src/workflow-discovery.ts
  └─ GET /api/workflows
      └─ includes project + global + bundled workflows

[~] packages/server/src/routes/api.ts
  ├─ GET /api/workflows/:name
  │   ├─ project lookup
  │   ├─ [global lookup: ~/.archon/workflows/<name>.yaml]
  │   └─ bundled/default lookup
  ├─ PUT /api/workflows/:name?source=global
  │   └─ [writes ~/.archon/workflows/<name>.yaml]
  └─ DELETE /api/workflows/:name?source=global
      └─ [deletes ~/.archon/workflows/<name>.yaml]

[~] packages/web/src/components/workflows/WorkflowBuilder.tsx
  └─ preserves loaded workflow source and passes it on save

[~] packages/web/src/lib/command-categories.ts
  └─ includes Global command group
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `GET /api/workflows` | workflow discovery | unchanged | List already included global workflows. |
| `GET /api/workflows/:name` | `~/.archon/workflows` | **new** | Detail/edit loading now resolves global workflows. |
| Web workflow builder | workflow detail response | **modified** | Builder now stores returned workflow source. |
| Web workflow builder | `PUT /api/workflows/:name` | **modified** | Save includes `source=global` when editing a global workflow. |
| Command library grouping | global command list entries | **modified** | Global commands are now shown in the grouped builder library. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `server|web|tests`
- Module: `workflows:builder`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi`

## Linked Issue

- Closes #1556
- Related #1556
- Depends on # none
- Supersedes # none

## Validation Evidence (required)

Commands and result summary:

```bash
bun test packages/server/src/routes/api.workflows.test.ts
# Result: 29 pass, 0 fail

bun run type-check
# Result: @archon/paths, @archon/git, @archon/providers, @archon/isolation,
# @archon/web, @archon/workflows, @archon/core, @archon/adapters,
# @archon/server, and @archon/cli type-check exited with code 0
```

- Evidence provided (test/log/trace/screenshot): Server route tests for global workflow load/save plus full monorepo type-check output.
- If any command is intentionally skipped, explain why: Full test suite was not run because this is a scoped API/Web UI workflow-builder fix; targeted route coverage and full type-check were run.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`Yes`)
- If any `Yes`, describe risk and mitigation: The existing workflow edit API can now explicitly target Archon's home-scoped workflow directory when `source=global` is supplied. The workflow name still passes existing command-name validation, and writes are constrained to `getHomeWorkflowsPath()` with a fixed `.yaml` filename.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: Not applicable.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Clean branch created from `origin/dev`; only this feature fix is included; route tests cover loading from `ARCHON_HOME/workflows` and saving with `source=global`.
- Edge cases checked: Invalid workflow names remain rejected; invalid `source` query values are rejected; project save path remains the default when no global source is supplied.
- What was not verified: Manual browser screenshot of the workflow builder loading a real global workflow was not captured.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Web UI workflow builder, workflow REST API, command library grouping.
- Potential unintended effects: A caller that sends `source=global` can update a same-named global workflow instead of creating a project workflow.
- Guardrails/monitoring for early detection: Existing workflow route tests plus new global workflow load/save tests; OpenAPI query validation for allowed source values.

## Rollback Plan (required)

- Fast rollback command/path: Revert this PR commit.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: Global workflows again appear in the list but fail to open in the builder, or saving a global workflow writes to the wrong scope.

## Risks and Mitigations

- Risk: Source-aware save behavior could be confusing if users expect global workflows to become project-local copies.
  - Mitigation: The builder preserves the source returned by the API, matching the loaded workflow's listed scope.
- Risk: Global workflow writes broaden the existing edit API's file target scope.
  - Mitigation: The write path is constrained to Archon's configured home workflows directory and validated workflow names.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflows can be saved or deleted as project-scoped or global/home-scoped via a new source option; fetching now resolves project → global → bundled defaults.
  * The web UI preserves and submits workflow source; client calls include the source so save/delete target the chosen scope.
  * Command lists are grouped into Project, Global, then bundled categories with stable ordering.

* **Tests**
  * Added tests covering global/home workflow save, fetch, delete, and invalid-source validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1557)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->