### PR TITLE
Pi provider: load user settings files as session baseline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,12 @@ CODEX_ACCOUNT_ID=
 # XAI_API_KEY=                 # Pi provider id: xai
 # OPENROUTER_API_KEY=          # Pi provider id: openrouter
 # HUGGINGFACE_API_KEY=         # Pi provider id: huggingface
+#
+# Docker (optional): Pi data (auth, models, settings, sessions) lives in the
+# container's ~/.pi/agent/ and is lost on rebuild. Set PI_CODING_AGENT_DIR to
+# a path inside /.archon/ so it lands on the persisted volume. Must be set
+# before the container starts (Pi reads it on each file path lookup).
+# PI_CODING_AGENT_DIR=/.archon/pi
 
 # Default AI Assistant (must match a registered provider, e.g. claude, codex, pi)
 # Used for new conversations when no codebase specified — errors on unknown values

--- a/packages/docs-web/src/content/docs/deployment/docker.md
+++ b/packages/docs-web/src/content/docs/deployment/docker.md
@@ -473,7 +473,7 @@ The container runs as `appuser` with `$HOME=/home/appuser`. The base compose mou
 |------|------------------|
 | `~/.claude/` | Claude Code skills, commands, agents, hooks, MCP config, projects (conversation history), memory, OAuth state, keybindings, file-history |
 | `~/.codex/` | Codex auth (`auth.json` from interactive `codex login`; the env-var path via `setup-auth` overwrites this on every container start) |
-| `~/.pi/agent/` | Pi `auth.json` from interactive `pi /login` (Archon's Pi adapter reads this on every request) |
+| `~/.pi/agent/` | Pi `auth.json` from interactive `pi /login`, plus `models.json`, global settings (`~/.pi/agent/settings.json`), and sessions (Archon's Pi adapter reads `auth.json` and `settings.json` on every request) |
 | `~/.gitconfig` | Author identity, signing config, custom aliases, plus the `safe.directory` entries baked into the image |
 | `~/.bash_history` | Shell history when you `docker compose exec app bash` |
 | `~/.config/gh/` | GitHub CLI auth from interactive `gh auth login` (the `GH_TOKEN` env-var path works without it) |
@@ -498,6 +498,17 @@ Bind-mount paths do **not** inherit the image's baked `~/.gitconfig` (Docker onl
 :::
 
 If `ARCHON_USER_HOME` is not set, Docker manages the volume automatically (`archon_user_home`) — config persists across restarts and rebuilds but lives inside Docker's storage. To wipe it: `docker compose down && docker volume rm archon_archon_user_home`.
+
+#### Relocating Pi data to the ARCHON_DATA volume (optional)
+
+By default Pi's data directory (`~/.pi/agent/`) is persisted via the `archon_user_home` volume above. If you'd rather keep Pi data alongside the rest of `/.archon/` (e.g. to back it up with the same volume), set `PI_CODING_AGENT_DIR` in `.env` to redirect it:
+
+```ini
+# Optional — only needed if you want Pi data on the ARCHON_DATA volume instead
+PI_CODING_AGENT_DIR=/.archon/pi
+```
+
+This must be set before the container starts; the Pi SDK reads the variable on each file path lookup.
 
 ### GitHub CLI Authentication
 

--- a/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
+++ b/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
@@ -279,6 +279,19 @@ assistants:
 
 Archon logs an info-level `pi.auth_missing` event when no credentials are found and continues — Pi's SDK then connects directly to the local endpoint defined in `models.json`. If the provider does require auth (a less-common cloud backend not in the env-var table) the SDK call fails downstream; the `pi.auth_missing` breadcrumb in the log lets you trace it back to a missing env-var mapping.
 
+### Pi settings (baseline behaviour)
+
+Archon reads your Pi settings files as the starting point for every session:
+
+- **`~/.pi/agent/settings.json`** — global Pi preferences (retry counts, transport, compaction strategy, thinking budgets, default model, etc.)
+- **`<repo>/.pi/settings.json`** — project-level overrides on top of global
+
+All settings flow in automatically. You do not need to re-state them in Archon's `config.yaml`. To configure baseline Pi settings, edit `~/.pi/agent/settings.json` directly.
+
+Archon never writes back to these files — `~/.pi/agent/settings.json` is read-only from Archon's perspective. Session-level changes (model switches, thinking-level adjustments) are held in memory only and discarded when the session ends, matching Claude and Codex behaviour.
+
+If Pi settings files do not exist (Docker, first-time setup, compiled binary with no Pi home directory), Archon falls back to Pi SDK defaults. Parse errors in the settings files are logged as warnings (`pi.settings_load_error`) and never prevent the session from starting.
+
 ### Extensions (on by default)
 
 A major reason to pick Pi is its **extension ecosystem**: community packages (installed via `pi install npm:<package>`) and your own local ones that hook into the agent's lifecycle. Extensions can intercept tool calls, gate execution on human review, post to external systems, render UIs — anything the Pi extension API exposes.

--- a/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
+++ b/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
@@ -279,7 +279,7 @@ assistants:
 
 Archon logs an info-level `pi.auth_missing` event when no credentials are found and continues — Pi's SDK then connects directly to the local endpoint defined in `models.json`. If the provider does require auth (a less-common cloud backend not in the env-var table) the SDK call fails downstream; the `pi.auth_missing` breadcrumb in the log lets you trace it back to a missing env-var mapping.
 
-### Pi settings (baseline behaviour)
+### Pi settings (baseline behavior)
 
 Archon reads your Pi settings files as the starting point for every session:
 

--- a/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
+++ b/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
@@ -288,7 +288,7 @@ Archon reads your Pi settings files as the starting point for every session:
 
 All settings flow in automatically. You do not need to re-state them in Archon's `config.yaml`. To configure baseline Pi settings, edit `~/.pi/agent/settings.json` directly.
 
-Archon never writes back to these files — `~/.pi/agent/settings.json` is read-only from Archon's perspective. Session-level changes (model switches, thinking-level adjustments) are held in memory only and discarded when the session ends, matching Claude and Codex behaviour.
+Archon never writes back to these files — `~/.pi/agent/settings.json` is read-only from Archon's perspective. Session-level changes (model switches, thinking-level adjustments) are held in memory only and discarded when the session ends, matching Claude and Codex behavior.
 
 If Pi settings files do not exist (Docker, first-time setup, compiled binary with no Pi home directory), Archon falls back to Pi SDK defaults. Parse errors in the settings files are logged as warnings (`pi.settings_load_error`) and never prevent the session from starting.
 

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -210,9 +210,12 @@ describe('PiProvider', () => {
     mockSessionList.mockImplementation(async () => []);
     mockSettingsManagerInMemory.mockClear();
     mockSettingsManagerCreate.mockClear();
-    mockSettingsManagerDrainErrors.mockClear();
-    mockSettingsManagerGetGlobalSettings.mockClear();
-    mockSettingsManagerGetProjectSettings.mockClear();
+    mockSettingsManagerDrainErrors.mockReset();
+    mockSettingsManagerDrainErrors.mockImplementation(() => []);
+    mockSettingsManagerGetGlobalSettings.mockReset();
+    mockSettingsManagerGetGlobalSettings.mockImplementation(() => ({}));
+    mockSettingsManagerGetProjectSettings.mockReset();
+    mockSettingsManagerGetProjectSettings.mockImplementation(() => ({}));
     capturedListener = undefined;
     scriptedEvents.length = 0;
     fileCreds = {};

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -1609,6 +1609,44 @@ describe('PiProvider', () => {
     expect(mockSettingsManagerInMemory).toHaveBeenCalledWith({ retry: { enabled: true } });
   });
 
+  test('settings: object values are shallow-merged one level deep, while primitives and arrays override', async () => {
+    process.env.GEMINI_API_KEY = 'sk-test';
+    resetScript(scriptedAgentEnd());
+    mockSettingsManagerGetGlobalSettings.mockImplementation(() => ({
+      retry: {
+        enabled: false,
+        attempts: 1,
+        nested: { source: 'global', keep: true },
+      },
+      timeoutMs: 1000,
+      allow: ['global'],
+    }));
+    mockSettingsManagerGetProjectSettings.mockImplementation(() => ({
+      retry: {
+        enabled: true,
+        backoff: 'exp',
+        nested: { source: 'project' },
+      },
+      timeoutMs: 2000,
+      allow: ['project'],
+    }));
+
+    await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, { model: 'google/gemini-2.5-pro' })
+    );
+
+    expect(mockSettingsManagerInMemory).toHaveBeenCalledWith({
+      retry: {
+        enabled: true,
+        attempts: 1,
+        backoff: 'exp',
+        nested: { source: 'project' }, // nested objects are NOT recursively merged — one level deep only
+      },
+      timeoutMs: 2000,
+      allow: ['project'],
+    });
+  });
+
   test('settings: parse errors logged as warnings, session still proceeds', async () => {
     process.env.GEMINI_API_KEY = 'sk-test';
     resetScript(scriptedAgentEnd());

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -99,7 +99,15 @@ const mockSessionList = mock(
   async (_cwd: string) => [] as { id: string; path: string; cwd: string }[]
 );
 
-const mockSettingsManagerInMemory = mock(() => ({}));
+const mockSettingsManagerDrainErrors = mock(() => []);
+const mockSettingsManagerGetGlobalSettings = mock(() => ({}));
+const mockSettingsManagerGetProjectSettings = mock(() => ({}));
+const mockSettingsManagerCreate = mock(() => ({
+  drainErrors: mockSettingsManagerDrainErrors,
+  getGlobalSettings: mockSettingsManagerGetGlobalSettings,
+  getProjectSettings: mockSettingsManagerGetProjectSettings,
+}));
+const mockSettingsManagerInMemory = mock((_settings?: unknown) => ({}));
 const mockResourceLoaderReload = mock(async () => undefined);
 // Return-style constructor: bun's mock() wraps the function such that the
 // `this`-binding doesn't reliably propagate to `new` call sites. Returning a
@@ -128,7 +136,10 @@ mock.module('@mariozechner/pi-coding-agent', () => ({
     open: mockSessionOpen,
     list: mockSessionList,
   },
-  SettingsManager: { inMemory: mockSettingsManagerInMemory },
+  SettingsManager: {
+    create: mockSettingsManagerCreate,
+    inMemory: mockSettingsManagerInMemory,
+  },
   DefaultResourceLoader: MockDefaultResourceLoader,
   createReadTool: mockCreateReadTool,
   createBashTool: mockCreateBashTool,
@@ -197,6 +208,11 @@ describe('PiProvider', () => {
     mockSessionOpen.mockClear();
     mockSessionList.mockClear();
     mockSessionList.mockImplementation(async () => []);
+    mockSettingsManagerInMemory.mockClear();
+    mockSettingsManagerCreate.mockClear();
+    mockSettingsManagerDrainErrors.mockClear();
+    mockSettingsManagerGetGlobalSettings.mockClear();
+    mockSettingsManagerGetProjectSettings.mockClear();
     capturedListener = undefined;
     scriptedEvents.length = 0;
     fileCreds = {};
@@ -1563,5 +1579,52 @@ describe('PiProvider', () => {
       c => c[1] === 'pi.semaphore_initialized'
     );
     expect(initCalls).toHaveLength(0);
+  });
+
+  test('settings: create(cwd) called, inMemory seeded with pre-merged global+project (empty project → just global)', async () => {
+    process.env.GEMINI_API_KEY = 'sk-test';
+    resetScript(scriptedAgentEnd());
+    mockSettingsManagerGetGlobalSettings.mockImplementation(() => ({ defaultProvider: 'google' }));
+    mockSettingsManagerGetProjectSettings.mockImplementation(() => ({}));
+
+    await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, { model: 'google/gemini-2.5-pro' })
+    );
+
+    expect(mockSettingsManagerCreate).toHaveBeenCalledTimes(1);
+    expect(mockSettingsManagerCreate).toHaveBeenCalledWith('/tmp');
+    expect(mockSettingsManagerInMemory).toHaveBeenCalledWith({ defaultProvider: 'google' });
+  });
+
+  test('settings: inMemory seeded with project settings merged on top of global', async () => {
+    process.env.GEMINI_API_KEY = 'sk-test';
+    resetScript(scriptedAgentEnd());
+    mockSettingsManagerGetGlobalSettings.mockImplementation(() => ({}));
+    mockSettingsManagerGetProjectSettings.mockImplementation(() => ({ retry: { enabled: true } }));
+
+    await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, { model: 'google/gemini-2.5-pro' })
+    );
+
+    expect(mockSettingsManagerInMemory).toHaveBeenCalledWith({ retry: { enabled: true } });
+  });
+
+  test('settings: parse errors logged as warnings, session still proceeds', async () => {
+    process.env.GEMINI_API_KEY = 'sk-test';
+    resetScript(scriptedAgentEnd());
+    const loadError = new Error('bad JSON');
+    mockSettingsManagerDrainErrors.mockImplementation(() => [
+      { scope: 'global', error: loadError },
+    ]);
+
+    const { error } = await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, { model: 'google/gemini-2.5-pro' })
+    );
+
+    expect(error).toBeUndefined();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: 'global', err: loadError }),
+      'pi.settings_load_error'
+    );
   });
 });

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -400,12 +400,58 @@ export class PiProvider implements IAgentProvider {
       };
     }
 
-    // Settings stay in-memory — only sessions persist, to match Claude/Codex.
-    // Resource loader still suppresses filesystem except for explicitly-passed
-    // skill paths and — when piConfig.enableExtensions is true — Pi's community
-    // extension ecosystem (tools + lifecycle hooks from ~/.pi/agent/extensions/
-    // and packages installed via `pi install npm:<pkg>`).
-    const settingsManager = piCodingAgent.SettingsManager.inMemory();
+    // Load user's Pi settings from disk (~/.pi/agent/settings.json for global,
+    // <cwd>/.pi/settings.json for project) as the starting point, then seed an
+    // in-memory instance. The in-memory instance guarantees no write-back to
+    // the user's settings files — AgentSession setter calls (setModel, etc.)
+    // write only to the in-process InMemorySettingsStorage object.
+    //
+    // NOTE: fileSettings is used only for the initial load; it is NOT passed to
+    // DefaultResourceLoader or AgentSession. DefaultResourceLoader creates its own
+    // file-backed SettingsManager internally for extension discovery. Sharing this
+    // instance is unsafe: DefaultResourceLoader.reload() calls
+    // settingsManager.reload(), which resets InMemorySettingsStorage to {} (the
+    // storage's global/project fields are undefined after inMemory() construction,
+    // so reload() produces empty settings, wiping all loaded user preferences).
+    const fileSettings = piCodingAgent.SettingsManager.create(cwd);
+
+    // Drain and log any settings file parse errors (malformed JSON, etc.) — non-fatal.
+    const settingsErrors = fileSettings.drainErrors();
+    for (const { scope, error: err } of settingsErrors) {
+      getLog().warn({ scope, err }, 'pi.settings_load_error');
+    }
+
+    // Pre-merge global + project settings before seeding inMemory().
+    // NOTE: Using applyOverrides() after construction is unsafe due to Pi SDK internals:
+    // SettingsManager.save() (dist/core/settings-manager.js) recalculates
+    //   this.settings = deepMergeSettings(this.globalSettings, this.projectSettings)
+    // wiping any applyOverrides() work, because inMemory() always constructs with
+    // this.projectSettings = {}. save() is called by setDefaultModelAndProvider()
+    // (dist/core/settings-manager.js), which AgentSession.setModel() calls
+    // (dist/core/agent-session.js) whenever an extension switches models in an
+    // interactive session — silently wiping project overrides mid-session.
+    // deepMergeSettings is not exported from the Pi SDK; replicate its one-level-deep
+    // semantics (nested objects merged one level deep, primitives/arrays override).
+    const globalSettings = fileSettings.getGlobalSettings();
+    const projectSettings = fileSettings.getProjectSettings();
+    const seedSettings: Record<string, unknown> = { ...globalSettings };
+    for (const key of Object.keys(projectSettings)) {
+      const pv = (projectSettings as Record<string, unknown>)[key];
+      if (pv === undefined) continue;
+      const gv = seedSettings[key];
+      seedSettings[key] =
+        typeof pv === 'object' &&
+        pv !== null &&
+        !Array.isArray(pv) &&
+        typeof gv === 'object' &&
+        gv !== null &&
+        !Array.isArray(gv)
+          ? { ...(gv as Record<string, unknown>), ...(pv as Record<string, unknown>) }
+          : pv;
+    }
+    const settingsManager = piCodingAgent.SettingsManager.inMemory(
+      seedSettings as ReturnType<typeof fileSettings.getGlobalSettings>
+    );
     // Default ON: extensions (community packages like @plannotator/pi-extension
     // or your own local ones) are a core reason users run Pi. Opt out with
     // `assistants.pi.enableExtensions: false` (or `interactive: false`) in


### PR DESCRIPTION
Previously, the Pi provider created an empty `SettingsManager.inMemory()` on every query, ignoring the user's Pi settings files entirely. This meant user preferences in `~/.pi/agent/settings.json` (retry counts, transport, compaction strategy, thinking budgets, default model, etc.) and per-repo overrides in `<cwd>/.pi/settings.json` had no effect on Archon-driven sessions.

## Summary

- Problem: Archon's Pi provider initialized each query with a fresh in-memory settings manager, so global and per-repository Pi settings were ignored.
- Why it matters: Users configuring Pi directly expect those settings to apply consistently when Pi is launched through Archon, especially for model defaults, retries, transports, compaction behavior, and thinking budgets.
- What changed: The Pi provider now loads the user's Pi settings files into the session baseline before running queries, with test coverage for global settings, repo overrides, and fallback behavior.
- What did **not** change (scope boundary): This PR does not change Pi's settings schema, Archon's provider interface, the query/session lifecycle, or any non-Pi assistant provider behavior.

## UX Journey

### Before

```
  User                         Archon                         Pi Provider / AI Client
  ────                         ──────                         ──────────────────────
  configures ~/.pi settings
  configures repo .pi settings
  sends message ─────────────▶ resolves assistant=pi
                                creates query/session
                                creates empty SettingsManager
                                ignores user/repo Pi settings
                                streams to Pi ───────────────▶ runs with defaults
  sees reply ◀─────────────── streams response
```

### After

```
  User                         Archon                         Pi Provider / AI Client
  ────                         ──────                         ──────────────────────
  configures ~/.pi settings
  configures repo .pi settings
  sends message ─────────────▶ resolves assistant=pi
                                creates query/session
                                [loads Pi settings baseline]
                                [applies user + repo settings]
                                streams to Pi ───────────────▶ runs with configured settings
  sees reply ◀─────────────── streams response
```

## Architecture Diagram

### Before

```
  Archon assistant routing
          |
          v
  packages/providers/src/community/pi/provider.ts
          |
          v
  SettingsManager.inMemory()
          |
          v
  Pi query/session execution
          |
          v
  AI client response stream


  Docs / config examples
      .env.example
      docs/deployment/docker.md
      docs/getting-started/ai-assistants.md

  Tests
      packages/providers/src/community/pi/provider.test.ts
```

### After

```
  Archon assistant routing
          |
          v
  [~] packages/providers/src/community/pi/provider.ts
          |
          ===
  [+] Pi settings baseline loading
          |
          +------------------------------+
          |                              |
          v                              v
  [+] ~/.pi/agent/settings.json     [+] <cwd>/.pi/settings.json
          |                              |
          +--------------+---------------+
                         |
                         v
  Pi query/session execution with configured settings
                         |
                         v
  AI client response stream


  [~] Docs / config examples
      [~] .env.example
      [~] docs/deployment/docker.md
      [~] docs/getting-started/ai-assistants.md

  [~] Tests
      [~] packages/providers/src/community/pi/provider.test.ts
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| Archon assistant routing | `packages/providers/src/community/pi/provider.ts` | unchanged | Archon still selects the Pi provider through the existing assistant/provider flow. |
| `packages/providers/src/community/pi/provider.ts` | `SettingsManager.inMemory()` | **modified** | The provider no longer relies only on an empty in-memory settings manager for every query. |
| `packages/providers/src/community/pi/provider.ts` | `~/.pi/agent/settings.json` | **new** | Global user Pi settings are now loaded into the session baseline. |
| `packages/providers/src/community/pi/provider.ts` | `<cwd>/.pi/settings.json` | **new** | Per-repository Pi settings can now override or supplement the global baseline. |
| Loaded Pi settings baseline | Pi query/session execution | **new** | Query execution now receives the user/repo settings context instead of defaults only. |
| Pi query/session execution | AI client response stream | unchanged | Streaming behavior and response handling remain unchanged. |
| `packages/providers/src/community/pi/provider.test.ts` | Pi provider settings behavior | **modified** | Adds coverage for settings loading and fallback behavior. |
| `.env.example` | Pi provider configuration docs | **modified** | Documents relevant Pi settings behavior/configuration. |
| `docs/deployment/docker.md` | Pi provider documentation | **modified** | Updates Docker/deployment guidance for Pi settings. |
| `docs/getting-started/ai-assistants.md` | Pi provider documentation | **modified** | Updates assistant setup guidance for Pi settings. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `config|docs|tests`
- Module: `config:pi-provider`

## Change Metadata

- Change type: `bug`
- Primary scope: `config`

## Linked Issue

- Closes # https://github.com/issues/created?issue=coleam00%7CArchon%7C1558
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check
bun run lint
bun run format:check
bun run test
# Or all at once:
bun run validate
```

- Evidence provided (test/log/trace/screenshot):
  - Ran `bun run validate`.
  - Result: passed.
  - Validation covered: bundled defaults check, TypeScript type-check, ESLint with zero warnings, Prettier format check, and all package tests.

- If any command is intentionally skipped, explain why:
  - None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `Yes`
- If any `Yes`, describe risk and mitigation:
  - The Pi provider now reads Pi's existing user and repository settings files so Archon-driven Pi sessions match normal Pi behavior.
  - Mitigation: access is limited to expected Pi configuration paths (`~/.pi/agent/settings.json` and `<cwd>/.pi/settings.json`), and missing files fall back gracefully instead of failing the session.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Database migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps:
  - No migration required.
  - Existing users without Pi settings files continue using the existing fallback behavior.
  - Existing users with Pi settings files should now see those settings respected by Archon-driven Pi sessions.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
Verified  a Pi session launched through Archon respects `~/.pi/agent/settings.json`.
Verified`<cwd>/.pi/settings.json` is applied for a project/repository session.
Verified missing settings files do not break Pi provider execution.

- Edge cases checked:
  - Missing global settings file.
  - Missing repository settings file.
  - Repository settings present alongside global settings.
  - 
- What was not verified:
  - N/A

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows:
  - Pi assistant provider sessions.
  - Pi provider tests.
  - Pi setup/configuration documentation.
- Potential unintended effects:
  - A malformed or unexpected Pi settings file could affect Archon-driven Pi sessions in the same way it affects direct Pi usage.
  - Users who previously saw Archon ignore Pi settings may observe changed behavior once their existing settings are respected.
- Guardrails/monitoring for early detection:
  - Provider tests cover settings loading and fallback behavior.
  - Manual validation should check both configured and unconfigured Pi environments.
  - User-visible symptoms should be limited to Pi provider session startup/configuration behavior.

## Rollback Plan (required)

- Fast rollback command/path:
  - Revert this PR to restore the previous in-memory-only Pi provider behavior.
- Feature flags or config toggles (if any):
  - None.
- Observable failure symptoms:
  - Pi provider sessions fail to start when settings files are present.
  - Pi provider sessions ignore expected user/repo settings.
  - Pi provider sessions behave differently from direct Pi sessions for the same project.

## Risks and Mitigations

- Risk: Existing Pi settings files may now affect Archon-driven sessions where they were previously ignored.
  - Mitigation: This is the intended behavior; documentation was updated so users understand that Archon respects Pi's settings files.

- Risk: Missing settings files could cause provider startup failures if not handled correctly.
  - Mitigation: Tests cover fallback behavior so users without Pi settings files continue to work.

- Risk: Repository-level settings may override user-level expectations.
  - Mitigation: This follows the expected global-plus-repo settings model and is documented as part of the Pi provider setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pi provider now loads and pre-merges user and project Pi settings into session memory with a one-level-deep merge; parse/load issues are logged as warnings and do not block startup.

* **Documentation**
  * Added Pi settings baseline docs and Docker guidance showing how to persist Pi agent data (set PI_CODING_AGENT_DIR before startup).

* **Tests**
  * Expanded tests covering settings loading, merge behavior, and error logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->