### PR TITLE
fix(workflows): prevent zombie workflow runs from hung Pi cleanup

### DIFF
--- a/packages/providers/src/community/pi/event-bridge.test.ts
+++ b/packages/providers/src/community/pi/event-bridge.test.ts
@@ -476,12 +476,18 @@ describe('tryParseStructuredOutput', () => {
 
 describe('bridgeSession cleanup', () => {
   // Regression for #1561: when the consumer throws mid-iteration, bridgeSession's
-  // finally block calls session.dispose() then awaits the prompt promise. If
-  // dispose() does not cause prompt() to settle, the await hangs forever, the
-  // consumer's catch never runs, Bun drains its event loop, and the workflow
-  // run is left zombie in 'running'. The fix wraps the await in Promise.race
-  // against a 10 s timeout so cleanup always completes.
-  test('completes within ~10s when session.prompt() never settles after dispose()', async () => {
+  // finally block calls session.dispose() and used to await the prompt promise
+  // for a "settle so callers see no dangling work" guarantee. That guarantee
+  // was illusory — the queue is closed before the await, so a settled prompt
+  // pushes into a closed queue (no-op). The await only existed to suppress
+  // unhandled rejections, and it caused #1561: when Pi's prompt() hung after
+  // dispose(), the await blocked forever, the consumer's catch never ran, and
+  // Bun drained its event loop and exited with code 0 mid-workflow.
+  //
+  // The fix is to not await at all — attach a fire-and-forget .catch() so a
+  // late rejection doesn't crash the process. Cleanup is non-blocking
+  // regardless of whether prompt() settles.
+  test('cleanup does not block when session.prompt() hangs forever after dispose()', async () => {
     const neverSettles = new Promise<void>(() => {
       /* intentionally never resolves */
     });
@@ -533,22 +539,29 @@ describe('bridgeSession cleanup', () => {
 
     expect(receivedChunk).toBe(true);
     expect(caught?.message).toBe('simulated consumer abort');
-    // Timeout fires at 10 s; allow 1 s of slack for scheduling overhead.
-    expect(elapsed).toBeLessThan(11_000);
-  }, 15_000);
+    // Cleanup must return immediately — no timer, no waiting on prompt().
+    // 200ms is generous for scheduling overhead while still catching any
+    // future regression that re-introduces an await on promptPromise.
+    expect(elapsed).toBeLessThan(200);
+  }, 5_000);
 
-  test('completes quickly when session.prompt() settles promptly after dispose()', async () => {
-    let resolvePrompt!: () => void;
+  test('a late prompt() rejection does not become an unhandled rejection', async () => {
+    // The .then() handlers in bridgeSession should preclude promptPromise
+    // ever rejecting (both fulfillment and rejection paths convert to queue
+    // pushes). The fire-and-forget .catch() is belt-and-suspenders in case
+    // of a synchronous throw inside the handlers. This test verifies that
+    // belt holds: a late rejection doesn't crash the test process.
+    let rejectPrompt!: (err: Error) => void;
     let listenerRef: ((e: AgentSessionEvent) => void) | undefined;
 
     const mockSession = {
       sessionId: 'test-session-id',
       prompt: () =>
-        new Promise<void>(r => {
-          resolvePrompt = r;
+        new Promise<void>((_, reject) => {
+          rejectPrompt = reject;
         }),
       dispose: () => {
-        resolvePrompt();
+        /* noop */
       },
       subscribe: (l: (e: AgentSessionEvent) => void) => {
         listenerRef = l;
@@ -570,16 +583,18 @@ describe('bridgeSession cleanup', () => {
       } as unknown as AgentSessionEvent);
     });
 
-    const start = Date.now();
     try {
       for await (const _chunk of gen) {
         throw new Error('simulated consumer abort');
       }
     } catch {}
-    const elapsed = Date.now() - start;
 
-    // If the timeout is not cleared after promptPromise wins, the process would
-    // hang for up to 10 s — catching that regression here.
-    expect(elapsed).toBeLessThan(1_000);
+    // Reject prompt() AFTER cleanup has run. If the .catch() weren't
+    // attached, this would propagate as an unhandled rejection. Bun would
+    // log it; we can't assert on the absence directly, but the test simply
+    // continuing to completion (and not failing the suite) is the assertion.
+    rejectPrompt(new Error('late pi error'));
+    // Yield to let the microtask queue drain so the .catch() runs.
+    await new Promise(resolve => setTimeout(resolve, 10));
   }, 5_000);
 });

--- a/packages/providers/src/community/pi/event-bridge.test.ts
+++ b/packages/providers/src/community/pi/event-bridge.test.ts
@@ -536,4 +536,50 @@ describe('bridgeSession cleanup', () => {
     // Timeout fires at 10 s; allow 1 s of slack for scheduling overhead.
     expect(elapsed).toBeLessThan(11_000);
   }, 15_000);
+
+  test('completes quickly when session.prompt() settles promptly after dispose()', async () => {
+    let resolvePrompt!: () => void;
+    let listenerRef: ((e: AgentSessionEvent) => void) | undefined;
+
+    const mockSession = {
+      sessionId: 'test-session-id',
+      prompt: () =>
+        new Promise<void>(r => {
+          resolvePrompt = r;
+        }),
+      dispose: () => {
+        resolvePrompt();
+      },
+      subscribe: (l: (e: AgentSessionEvent) => void) => {
+        listenerRef = l;
+        return () => {
+          listenerRef = undefined;
+        };
+      },
+      abort: async () => {},
+    } as unknown as AgentSession;
+
+    const gen = bridgeSession(mockSession, 'test prompt');
+
+    queueMicrotask(() => {
+      listenerRef?.({
+        type: 'tool_execution_start',
+        toolName: 'echo',
+        toolCallId: 'tc1',
+        args: {},
+      } as unknown as AgentSessionEvent);
+    });
+
+    const start = Date.now();
+    try {
+      for await (const _chunk of gen) {
+        throw new Error('simulated consumer abort');
+      }
+    } catch {}
+    const elapsed = Date.now() - start;
+
+    // If the timeout is not cleared after promptPromise wins, the process would
+    // hang for up to 10 s — catching that regression here.
+    expect(elapsed).toBeLessThan(1_000);
+  }, 5_000);
 });

--- a/packages/providers/src/community/pi/event-bridge.test.ts
+++ b/packages/providers/src/community/pi/event-bridge.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'bun:test';
+import type { AgentSession, AgentSessionEvent } from '@mariozechner/pi-coding-agent';
 
 import {
   AsyncQueue,
+  bridgeSession,
   buildResultChunk,
   mapPiEvent,
   serializeToolResult,
@@ -468,4 +470,70 @@ describe('tryParseStructuredOutput', () => {
     const withBackticks = '{"code":"run `npm test`"}';
     expect(tryParseStructuredOutput(withBackticks)).toEqual({ code: 'run `npm test`' });
   });
+});
+
+// ─── bridgeSession cleanup ─────────────────────────────────────────────────
+
+describe('bridgeSession cleanup', () => {
+  // Regression for #1561: when the consumer throws mid-iteration, bridgeSession's
+  // finally block calls session.dispose() then awaits the prompt promise. If
+  // dispose() does not cause prompt() to settle, the await hangs forever, the
+  // consumer's catch never runs, Bun drains its event loop, and the workflow
+  // run is left zombie in 'running'. The fix wraps the await in Promise.race
+  // against a 10 s timeout so cleanup always completes.
+  test('completes within ~10s when session.prompt() never settles after dispose()', async () => {
+    const neverSettles = new Promise<void>(() => {
+      /* intentionally never resolves */
+    });
+    let listenerRef: ((e: AgentSessionEvent) => void) | undefined;
+
+    const mockSession = {
+      sessionId: 'test-session-id',
+      prompt: () => neverSettles,
+      dispose: () => {
+        /* synchronous noop — does NOT settle prompt() */
+      },
+      subscribe: (l: (e: AgentSessionEvent) => void) => {
+        listenerRef = l;
+        return () => {
+          listenerRef = undefined;
+        };
+      },
+      abort: async () => {
+        /* noop */
+      },
+    } as unknown as AgentSession;
+
+    const gen = bridgeSession(mockSession, 'test prompt');
+
+    // Push an event after the generator subscribes so the for-await unblocks
+    // with a chunk. Then the test consumer throws to simulate the dag-executor
+    // throwing on `isError: true`.
+    queueMicrotask(() => {
+      listenerRef?.({
+        type: 'tool_execution_start',
+        toolName: 'echo',
+        toolCallId: 'tc1',
+        args: {},
+      } as unknown as AgentSessionEvent);
+    });
+
+    const start = Date.now();
+    let receivedChunk = false;
+    let caught: Error | undefined;
+    try {
+      for await (const _chunk of gen) {
+        receivedChunk = true;
+        throw new Error('simulated consumer abort');
+      }
+    } catch (err) {
+      caught = err as Error;
+    }
+    const elapsed = Date.now() - start;
+
+    expect(receivedChunk).toBe(true);
+    expect(caught?.message).toBe('simulated consumer abort');
+    // Timeout fires at 10 s; allow 1 s of slack for scheduling overhead.
+    expect(elapsed).toBeLessThan(11_000);
+  }, 15_000);
 });

--- a/packages/providers/src/community/pi/event-bridge.ts
+++ b/packages/providers/src/community/pi/event-bridge.ts
@@ -402,25 +402,19 @@ export async function* bridgeSession(
       // debug so SDK regressions surface without polluting normal output.
       getLog().debug({ err }, 'pi.event-bridge.dispose_failed');
     }
-    // Ensure the prompt promise settles so callers see no dangling work.
-    // Safety net: if Pi's session.prompt() doesn't settle within 10 s after
-    // dispose(), give up rather than hanging forever. Without this, a Pi
-    // session that never rejects/resolves after dispose() keeps the caller's
-    // generator.return() suspended indefinitely. Bun then drains its event
-    // loop (no remaining I/O sources) and exits with code 0 — leaving the
-    // workflow run zombie in 'running' (#1561).
-    let cleanupTimeoutId: ReturnType<typeof setTimeout> | undefined;
-    await Promise.race([
-      promptPromise.catch((err: unknown) => {
-        // Errors from prompt() during normal iteration are already surfaced through
-        // the queue. Any rejection here is a secondary cleanup-phase error from the
-        // Pi SDK — log at debug so SDK regressions surface without polluting output.
-        getLog().debug({ err }, 'pi.event-bridge.prompt_rejected_during_cleanup');
-      }),
-      new Promise<void>(resolve => {
-        cleanupTimeoutId = setTimeout(resolve, 10_000);
-      }),
-    ]);
-    clearTimeout(cleanupTimeoutId);
+    // Don't await promptPromise. The queue is closed above (line 392), and the
+    // .then() handlers attached at construction (line 344) only push to that
+    // queue — closed pushes are no-ops. There's nothing the caller is waiting
+    // for; whether prompt() resolves in 1ms or never, no observable behavior
+    // changes. Awaiting it is what caused #1561: Pi's session.prompt() can
+    // hang indefinitely after dispose(), keeping generator.return() suspended,
+    // draining Bun's event loop, and exiting with code 0 mid-workflow.
+    //
+    // Attach .catch() defensively so a stray async rejection (the .then()
+    // handlers should preclude this, but belt-and-suspenders) doesn't bubble
+    // up as an unhandled-rejection process exit.
+    promptPromise.catch((err: unknown) => {
+      getLog().debug({ err }, 'pi.event-bridge.prompt_rejected_after_close');
+    });
   }
 }

--- a/packages/providers/src/community/pi/event-bridge.ts
+++ b/packages/providers/src/community/pi/event-bridge.ts
@@ -409,13 +409,18 @@ export async function* bridgeSession(
     // generator.return() suspended indefinitely. Bun then drains its event
     // loop (no remaining I/O sources) and exits with code 0 — leaving the
     // workflow run zombie in 'running' (#1561).
+    let cleanupTimeoutId: ReturnType<typeof setTimeout> | undefined;
     await Promise.race([
-      promptPromise.catch(() => {
-        /* errors already surfaced through the queue */
+      promptPromise.catch((err: unknown) => {
+        // Errors from prompt() during normal iteration are already surfaced through
+        // the queue. Any rejection here is a secondary cleanup-phase error from the
+        // Pi SDK — log at debug so SDK regressions surface without polluting output.
+        getLog().debug({ err }, 'pi.event-bridge.prompt_rejected_during_cleanup');
       }),
       new Promise<void>(resolve => {
-        setTimeout(resolve, 10_000);
+        cleanupTimeoutId = setTimeout(resolve, 10_000);
       }),
     ]);
+    clearTimeout(cleanupTimeoutId);
   }
 }

--- a/packages/providers/src/community/pi/event-bridge.ts
+++ b/packages/providers/src/community/pi/event-bridge.ts
@@ -403,8 +403,19 @@ export async function* bridgeSession(
       getLog().debug({ err }, 'pi.event-bridge.dispose_failed');
     }
     // Ensure the prompt promise settles so callers see no dangling work.
-    await promptPromise.catch(() => {
-      /* errors already surfaced through the queue */
-    });
+    // Safety net: if Pi's session.prompt() doesn't settle within 10 s after
+    // dispose(), give up rather than hanging forever. Without this, a Pi
+    // session that never rejects/resolves after dispose() keeps the caller's
+    // generator.return() suspended indefinitely. Bun then drains its event
+    // loop (no remaining I/O sources) and exits with code 0 — leaving the
+    // workflow run zombie in 'running' (#1561).
+    await Promise.race([
+      promptPromise.catch(() => {
+        /* errors already surfaced through the queue */
+      }),
+      new Promise<void>(resolve => {
+        setTimeout(resolve, 10_000);
+      }),
+    ]);
   }
 }

--- a/packages/workflows/src/executor-preamble.test.ts
+++ b/packages/workflows/src/executor-preamble.test.ts
@@ -94,6 +94,7 @@ function makeStore(overrides: Partial<IWorkflowStore> = {}): IWorkflowStore {
     updateWorkflowRun: mock(async () => {}),
     failWorkflowRun: mock(async () => {}),
     getWorkflowRun: mock(async () => ({ ...makeRun(), status: 'completed' as const })),
+    getWorkflowRunStatus: mock(async () => 'completed' as const),
     createWorkflowEvent: mock(async () => {}),
     findResumableRun: mock(async () => null),
     getCompletedDagNodeOutputs: mock(async () => new Map<string, string>()),

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -953,3 +953,53 @@ describe('executeWorkflow', () => {
     });
   });
 });
+
+describe('finally backstop', () => {
+  it('calls failWorkflowRun when run is still running at finally', async () => {
+    const failSpy = mock(async () => {});
+    const store = makeStore({
+      getWorkflowRunStatus: mock(async () => 'running' as const),
+      failWorkflowRun: failSpy,
+    });
+    const deps = makeDeps(store);
+
+    await executeWorkflow(
+      deps,
+      makePlatform(),
+      'conv-1',
+      '/tmp',
+      makeWorkflow(),
+      'test',
+      'db-conv-1'
+    );
+
+    const call = (failSpy.mock.calls as unknown[][]).find(
+      c => typeof c[1] === 'string' && (c[1] as string).includes('exited without finalizing')
+    );
+    expect(call).toBeDefined();
+  });
+
+  it('does not call failWorkflowRun when run already completed', async () => {
+    const failSpy = mock(async () => {});
+    const store = makeStore({
+      getWorkflowRunStatus: mock(async () => 'completed' as const),
+      failWorkflowRun: failSpy,
+    });
+    const deps = makeDeps(store);
+
+    await executeWorkflow(
+      deps,
+      makePlatform(),
+      'conv-1',
+      '/tmp',
+      makeWorkflow(),
+      'test',
+      'db-conv-1'
+    );
+
+    const backstopCall = (failSpy.mock.calls as unknown[][]).find(
+      c => typeof c[1] === 'string' && (c[1] as string).includes('exited without finalizing')
+    );
+    expect(backstopCall).toBeUndefined();
+  });
+});

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -75,6 +75,7 @@ function makeStore(overrides: Partial<IWorkflowStore> = {}): IWorkflowStore {
     updateWorkflowRun: mock(async () => {}),
     failWorkflowRun: mock(async () => {}),
     getWorkflowRun: mock(async () => ({ ...makeRun(), status: 'completed' as const })),
+    getWorkflowRunStatus: mock(async () => 'completed' as const),
     createWorkflowEvent: mock(async () => {}),
     findResumableRun: mock(async () => null),
     getCompletedDagNodeOutputs: mock(async () => new Map()),

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -838,6 +838,7 @@ export async function executeWorkflow(
       const runId = workflowRun.id;
       const backstopStatus = await deps.store.getWorkflowRunStatus(runId).catch(() => null);
       if (backstopStatus === 'running') {
+        getLog().warn({ workflowRunId: runId }, 'executor.backstop_triggered');
         await deps.store
           .failWorkflowRun(runId, 'Workflow exited without finalizing — see logs')
           .catch((err: Error) => {

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -841,7 +841,7 @@ export async function executeWorkflow(
         getLog().warn({ workflowRunId: runId }, 'executor.backstop_triggered');
         await deps.store
           .failWorkflowRun(runId, 'Workflow exited without finalizing — see logs')
-          .catch((err: Error) => {
+          .catch((err: unknown) => {
             getLog().error({ err, workflowRunId: runId }, 'executor.backstop_fail_failed');
           });
       }

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -827,5 +827,23 @@ export async function executeWorkflow(
     }
     // Return failure result instead of re-throwing
     return { success: false, workflowRunId: workflowRun.id, error: err.message };
+  } finally {
+    // Defensive backstop: if the workflow run is still 'running' after all
+    // normal and exceptional code paths, flip it to 'failed' to prevent zombie
+    // accumulation. Guards against any future code path that exits without
+    // calling failWorkflowRun (e.g. a generator cleanup that exits without
+    // throwing). Only fires when the process stays alive long enough to run
+    // this finally — see #1561 for the originating zombie-state incident.
+    if (workflowRun) {
+      const runId = workflowRun.id;
+      const backstopStatus = await deps.store.getWorkflowRunStatus(runId).catch(() => null);
+      if (backstopStatus === 'running') {
+        await deps.store
+          .failWorkflowRun(runId, 'Workflow exited without finalizing — see logs')
+          .catch((err: Error) => {
+            getLog().error({ err, workflowRunId: runId }, 'executor.backstop_fail_failed');
+          });
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- **Problem**: When a Pi DAG node receives an SDK error result, the thrown error never reaches the executor's catch block because the async generator cleanup in `bridgeSession` hangs forever — `session.dispose()` closes Pi's I/O handles but doesn't settle `session.prompt()`. Bun drains its event loop and exits with code 0, leaving the workflow run stuck in `status = 'running'` indefinitely.
- **Why it matters**: Zombie runs block all subsequent runs on the same worktree path (path-lock) and require manual `abandon`. No automatic recovery exists.
- **What changed**: (C1) `bridgeSession` post-dispose `await` now races against a 10 s timeout so the event loop is never left with zero anchors; (C2) `executeWorkflow` gets a `finally` backstop that flips any still-`running` run to `failed` after all code paths complete; (C3) regression test added that intentionally passes a never-settling `prompt()` mock.
- **What did NOT change**: Claude and Codex providers, `withIdleTimeout` timing, DAG execution logic, process signal handling, and all existing behaviour on successful runs.

## UX Journey

### Before

```
User                    Archon CLI               Pi Provider
────                    ──────────               ───────────
archon workflow run ──▶ starts DAG run
                        (status = 'running')
                        streams to Pi ─────────▶ returns isError: true
                        dag-executor throws
                        [for-await calls .return()]
                        bridgeSession.finally:
                          session.dispose()
                          await promptPromise   ← hangs forever
                                                  (Bun event loop drains)
                        [process exits code 0]
                                                  catch block: NEVER RUNS
                                                  status stays 'running'
User sees:              $ (prompt returns, status = 'running' in DB)
archon workflow status  shows run stuck 'running' — zombie forever
archon workflow run ... "worktree is in use" error on next run
```

### After

```
User                    Archon CLI               Pi Provider
────                    ──────────               ───────────
archon workflow run ──▶ starts DAG run
                        (status = 'running')
                        streams to Pi ─────────▶ returns isError: true
                        dag-executor throws
                        [for-await calls .return()]
                        bridgeSession.finally:
                          session.dispose()
                          [Promise.race: prompt vs 10s timeout]
                          timeout wins after 10s  ← event loop stays alive
                        throw propagates to catch
                        dag_node_failed logged
                        executeWorkflow catch runs
                        [finally backstop checks status]
                        status → 'failed'
User sees:              run status = 'failed' (not 'running')
archon workflow status  shows correct terminal state
archon workflow run ... next run proceeds normally
```

## Architecture Diagram

### Before

```
dag-executor.ts
  executeNodeInternal()
    for await (msg of withIdleTimeout(aiClient.sendQuery()))
      if (msg.isError) throw Error          ← throws
        [.return() called on withIdleTimeout]
          idle-timeout.ts finally:
            await generator.return(undefined)
              event-bridge.ts finally:
                session.dispose()           ← synchronous
                await promptPromise.catch() ← HANGS FOREVER (Pi bug)
                                              process exits, catch never runs
```

### After

```
dag-executor.ts
  executeNodeInternal()
    for await (msg of withIdleTimeout(aiClient.sendQuery()))
      if (msg.isError) throw Error          ← throws
        [.return() called on withIdleTimeout]
          idle-timeout.ts finally:
            await generator.return(undefined)
              event-bridge.ts finally:      [~MODIFIED]
                session.dispose()
                [Promise.race([promptPromise, 10s timeout])]
                                            ← resolves within 10s
                throw propagates upward
  executor.ts executeWorkflow catch:
    failWorkflowRun(...)                    ← status = 'failed'
  executor.ts executeWorkflow finally:      [+NEW]
    if status still 'running': flip to 'failed'  ← backstop
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `dag-executor.ts` | `event-bridge.ts` (via `withIdleTimeout` → `generator.return`) | unchanged | Throw propagation path |
| `event-bridge.ts` `bridgeSession` finally | `promptPromise` | **modified** | Now `Promise.race` with 10 s timeout |
| `executor.ts` `executeWorkflow` | `IWorkflowStore.getWorkflowRunStatus` | **new** | Backstop reads current status in `finally` |
| `executor.ts` `executeWorkflow` | `IWorkflowStore.failWorkflowRun` | **new** | Backstop flips zombie to `failed` in `finally` |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `workflows`, `providers`
- Module: `workflows:executor`, `providers:pi`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi` (workflows + providers)

## Linked Issue

- Closes #1561

## Validation Evidence (required)

```bash
bun run validate
```

All checks passed:
- `bun run check:bundled` — PASS (bundled-defaults.generated.ts up to date, 36 commands, 20 workflows)
- `bun run type-check` — PASS (all 10 packages clean)
- `bun run lint --max-warnings 0` — PASS (0 errors, 0 warnings)
- `bun run format:check` — PASS
- `bun run test` — PASS (full suite green; new `bridgeSession` timeout test passes in ~10.04s, dominated by the intentional 10s timeout it exercises)

The new regression test in `event-bridge.test.ts` directly validates the fix: a mock session whose `prompt()` returns a never-settling promise no longer hangs cleanup — the consumer's thrown error propagates within ~10 s. Without the fix, this test would hang indefinitely (caught by the 15 s test-level timeout).

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — existing Claude and Codex workflows are completely unaffected; the `bridgeSession` change is Pi-specific; the `finally` backstop in `executor.ts` is a no-op on runs that already finalize correctly
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: Full `bun run validate` suite passed (type-check, lint, format, tests, bundled-defaults check)
- Edge cases checked: (C1) `getWorkflowRunStatus` throw in backstop is caught and swallowed; (C2) `failWorkflowRun` throw in backstop is caught and logged; (C3) `workflowRun` undefined guard prevents backstop from running on run-creation failure; (C4) timeout fires after 10 s in the test, not sooner
- What was not verified: Live end-to-end run against a real Pi/Minimax provider (requires external API key)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Pi provider cleanup path only; `executor.ts` `finally` backstop is universal but fires only when a run is still `running` post-execution (should be rare/never on non-Pi paths)
- Potential unintended effects: The 10 s post-dispose wait only affects already-errored Pi sessions; normal successful runs complete and close the generator cleanly before `bridgeSession`'s finally is triggered for cleanup, so the race resolves immediately (prompt already settled)
- Guardrails: New `executor.backstop_fail_failed` log event emitted if the backstop's own `failWorkflowRun` call fails

## Rollback Plan (required)

- Fast rollback command/path: Revert commit `853f491d` (`git revert 853f491d`)
- Feature flags or config toggles: None
- Observable failure symptoms: Workflow runs stuck in `running` after a Pi SDK error; `archon workflow status` shows `running` indefinitely; subsequent runs on same worktree blocked with "worktree is in use"

## Risks and Mitigations

- Risk: 10 s post-dispose timeout could delay test suite if many Pi tests use never-settling mocks
  - Mitigation: The single regression test is intentional and already accounts for this (~10 s). No other tests use never-settling `prompt()` mocks. Isolated in its own `bun test` invocation via the existing `@archon/providers` test batch configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup behavior to prevent blocking on unresolved operations.
  * Added safeguards to properly handle workflows that unexpectedly exit while still running, ensuring they are marked as failed and logged appropriately.

* **Tests**
  * Added regression tests validating cleanup resilience and workflow failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->