### PR TITLE
feat(cli): setup overhaul + archon doctor + complete bundled skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ bun run format:check
 bun run validate
 ```
 
-This runs `check:bundled`, type-check, lint, format check, and tests. All five must pass for CI to succeed.
+This runs `check:bundled`, `check:bundled-skill`, type-check, lint, format check, and tests. All six must pass for CI to succeed.
 
 ### ESLint Guidelines
 
@@ -256,6 +256,9 @@ bun run cli serve --download-only  # Download without starting
 # Install the bundled Archon skill into a project
 bun run cli skill install
 bun run cli skill install /path/to/project
+
+# Verify your Archon setup (Claude binary, gh auth, DB, adapters)
+bun run cli doctor
 
 # Show version
 bun run cli version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -726,7 +726,7 @@ async function createSession(conversationId: string, codebaseId: string) {
 - Source builds: Loaded from filesystem at runtime
 - Merged with repo-specific commands/workflows (repo overrides defaults by name)
 - Opt-out: Set `defaults.loadDefaultCommands: false` or `defaults.loadDefaultWorkflows: false` in `.archon/config.yaml`
-- **After adding, removing, or editing a default file, run `bun run generate:bundled`** to refresh the embedded bundle. `bun run validate` (and CI) run `check:bundled` and will fail loudly if the generated file is stale.
+- **After adding, removing, or editing a default file, run `bun run generate:bundled`** to refresh the embedded bundle. `bun run validate` (and CI) run `check:bundled` and `check:bundled-skill` and will fail loudly if either generated file is stale.
 
 **Home-scoped ("global") workflows, commands, and scripts** (user-level, applies to every project):
 - Workflows: `~/.archon/workflows/` (or `$ARCHON_HOME/workflows/`)

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build:checksums": "bash scripts/checksums.sh",
     "generate:bundled": "bun run scripts/generate-bundled-defaults.ts",
     "check:bundled": "bun run scripts/generate-bundled-defaults.ts --check",
+    "check:bundled-skill": "bun run scripts/check-bundled-skill.ts --check",
     "test": "bun --filter '*' --parallel test",
     "test:watch": "bun --filter @archon/server test:watch",
     "type-check": "bun --filter '*' type-check && bun x tsc --noEmit -p scripts/tsconfig.json",
@@ -27,7 +28,7 @@
     "build:web": "bun --filter @archon/web build",
     "dev:docs": "bun --filter @archon/docs-web dev",
     "build:docs": "bun --filter @archon/docs-web build",
-    "validate": "bun run check:bundled && bun run type-check && bun run lint --max-warnings 0 && bun run format:check && bun run test",
+    "validate": "bun run check:bundled && bun run check:bundled-skill && bun run type-check && bun run lint --max-warnings 0 && bun run format:check && bun run test",
     "prepare": "husky",
     "setup-auth": "bun --filter @archon/server setup-auth"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "cli": "bun src/cli.ts",
-    "test": "bun test src/commands/version.test.ts src/commands/setup.test.ts src/commands/skill.test.ts && bun test src/commands/workflow.test.ts && bun test src/commands/isolation.test.ts && bun test src/commands/chat.test.ts && bun test src/commands/serve.test.ts",
+    "test": "bun test src/commands/version.test.ts src/commands/setup.test.ts src/commands/skill.test.ts src/commands/doctor.test.ts && bun test src/commands/workflow.test.ts && bun test src/commands/isolation.test.ts && bun test src/commands/chat.test.ts && bun test src/commands/serve.test.ts",
     "type-check": "bun x tsc --noEmit"
   },
   "dependencies": {

--- a/packages/cli/src/bundled-skill.ts
+++ b/packages/cli/src/bundled-skill.ts
@@ -9,7 +9,7 @@
  */
 
 // =============================================================================
-// Skill Files (18 total)
+// Skill Files (21 total)
 // =============================================================================
 
 import skillMd from '../../../.claude/skills/archon/SKILL.md' with { type: 'text' };
@@ -26,8 +26,11 @@ import telegramGuide from '../../../.claude/skills/archon/guides/telegram.md' wi
 import authoringCommands from '../../../.claude/skills/archon/references/authoring-commands.md' with { type: 'text' };
 import cliCommands from '../../../.claude/skills/archon/references/cli-commands.md' with { type: 'text' };
 import dagAdvanced from '../../../.claude/skills/archon/references/dag-advanced.md' with { type: 'text' };
+import goodPractices from '../../../.claude/skills/archon/references/good-practices.md' with { type: 'text' };
 import interactiveWorkflows from '../../../.claude/skills/archon/references/interactive-workflows.md' with { type: 'text' };
+import parameterMatrix from '../../../.claude/skills/archon/references/parameter-matrix.md' with { type: 'text' };
 import repoInit from '../../../.claude/skills/archon/references/repo-init.md' with { type: 'text' };
+import troubleshooting from '../../../.claude/skills/archon/references/troubleshooting.md' with { type: 'text' };
 import variables from '../../../.claude/skills/archon/references/variables.md' with { type: 'text' };
 import workflowDag from '../../../.claude/skills/archon/references/workflow-dag.md' with { type: 'text' };
 
@@ -53,8 +56,11 @@ export const BUNDLED_SKILL_FILES: Record<string, string> = {
   'references/authoring-commands.md': authoringCommands,
   'references/cli-commands.md': cliCommands,
   'references/dag-advanced.md': dagAdvanced,
+  'references/good-practices.md': goodPractices,
   'references/interactive-workflows.md': interactiveWorkflows,
+  'references/parameter-matrix.md': parameterMatrix,
   'references/repo-init.md': repoInit,
+  'references/troubleshooting.md': troubleshooting,
   'references/variables.md': variables,
   'references/workflow-dag.md': workflowDag,
 };

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -65,6 +65,7 @@ import { setupCommand } from './commands/setup';
 import { skillInstallCommand } from './commands/skill';
 import { validateWorkflowsCommand, validateCommandsCommand } from './commands/validate';
 import { serveCommand } from './commands/serve';
+import { doctorCommand } from './commands/doctor';
 import { closeDatabase } from '@archon/core';
 import {
   setLogLevel,
@@ -611,7 +612,6 @@ async function main(): Promise<number> {
       }
 
       case 'doctor': {
-        const { doctorCommand } = await import('./commands/doctor');
         return await doctorCommand();
       }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -106,6 +106,7 @@ Commands:
   complete <branch> [...]    Complete branch lifecycle (remove worktree + branches)
   serve                      Start the web UI server (downloads web UI on first run)
   skill install [path]       Install the bundled Archon skill into .claude/skills/archon
+  doctor                     Verify your Archon setup (Claude binary, gh auth, DB, adapters)
   validate workflows [name]  Validate workflow definitions and their references
   validate commands [name]   Validate command files
   version, --version, -V     Show version info (also -v when used alone)
@@ -267,7 +268,16 @@ async function main(): Promise<number> {
   const subcommand = positionals[1];
 
   // Commands that don't require git repo validation
-  const noGitCommands = ['version', 'help', 'setup', 'chat', 'continue', 'serve', 'skill'];
+  const noGitCommands = [
+    'version',
+    'help',
+    'setup',
+    'chat',
+    'continue',
+    'serve',
+    'skill',
+    'doctor',
+  ];
   const requiresGitRepo = !noGitCommands.includes(command ?? '');
 
   try {
@@ -598,6 +608,11 @@ async function main(): Promise<number> {
         const servePort = values.port !== undefined ? Number(values.port) : undefined;
         const downloadOnly = Boolean(values['download-only']);
         return await serveCommand({ port: servePort, downloadOnly });
+      }
+
+      case 'doctor': {
+        const { doctorCommand } = await import('./commands/doctor');
+        return await doctorCommand();
       }
 
       case 'skill': {

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for `archon doctor` check functions.
+ *
+ * Uses spyOn for `@archon/git.execFileAsync` and `@archon/paths.BUNDLED_IS_BINARY`
+ * indirection. Avoids `mock.module()` because it is process-global and
+ * irreversible in Bun, which would pollute other test files in this package.
+ */
+import { describe, it, expect, spyOn, afterEach, beforeEach } from 'bun:test';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import * as git from '@archon/git';
+import {
+  checkClaudeBinary,
+  checkGhAuth,
+  checkWorkspaceWritable,
+  checkSlack,
+  checkTelegram,
+} from './doctor';
+
+describe('checkClaudeBinary', () => {
+  let execSpy: ReturnType<typeof spyOn<typeof git, 'execFileAsync'>>;
+
+  beforeEach(() => {
+    execSpy = spyOn(git, 'execFileAsync');
+  });
+
+  afterEach(() => {
+    execSpy.mockRestore();
+  });
+
+  it('returns skip in dev mode (BUNDLED_IS_BINARY=false)', async () => {
+    // The default test environment has BUNDLED_IS_BINARY=false (set by
+    // packages/paths/src/bundled-build.ts and only flipped during the binary
+    // build). No spy needed — we exercise the dev-mode branch.
+    const result = await checkClaudeBinary({});
+    expect(result.status).toBe('skip');
+    expect(result.label).toBe('Claude binary');
+  });
+});
+
+describe('checkGhAuth', () => {
+  let execSpy: ReturnType<typeof spyOn<typeof git, 'execFileAsync'>>;
+
+  beforeEach(() => {
+    execSpy = spyOn(git, 'execFileAsync');
+  });
+
+  afterEach(() => {
+    execSpy.mockRestore();
+  });
+
+  it('returns skip when no GitHub token is set', async () => {
+    const result = await checkGhAuth({});
+    expect(result.status).toBe('skip');
+    expect(result.message).toContain('GitHub not configured');
+    // Should NOT have called execFileAsync — skip is short-circuit.
+    expect(execSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns pass when gh auth status succeeds', async () => {
+    execSpy.mockResolvedValue({ stdout: 'Logged in as @user', stderr: '' });
+    const result = await checkGhAuth({ GITHUB_TOKEN: 'ghp_x' });
+    expect(result.status).toBe('pass');
+    expect(execSpy).toHaveBeenCalledWith('gh', ['auth', 'status'], expect.any(Object));
+  });
+
+  it('returns fail when gh auth status throws', async () => {
+    execSpy.mockRejectedValue(new Error('not logged in'));
+    const result = await checkGhAuth({ GH_TOKEN: 'ghp_y' });
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('not logged in');
+  });
+});
+
+describe('checkWorkspaceWritable', () => {
+  const TMP = join(tmpdir(), 'archon-doctor-test-' + Date.now());
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    mkdirSync(TMP, { recursive: true });
+    originalHome = process.env.ARCHON_HOME;
+    process.env.ARCHON_HOME = TMP;
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) {
+      delete process.env.ARCHON_HOME;
+    } else {
+      process.env.ARCHON_HOME = originalHome;
+    }
+    try {
+      rmSync(TMP, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it('returns pass when directory is writable', async () => {
+    const result = await checkWorkspaceWritable();
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('writable');
+  });
+
+  it('returns pass when directory does not exist (creates it)', async () => {
+    rmSync(TMP, { recursive: true, force: true });
+    const result = await checkWorkspaceWritable();
+    expect(result.status).toBe('pass');
+  });
+});
+
+describe('checkSlack', () => {
+  it('returns skip when SLACK_BOT_TOKEN not set', async () => {
+    const result = await checkSlack({});
+    expect(result.status).toBe('skip');
+    expect(result.message).toContain('SLACK_BOT_TOKEN');
+  });
+});
+
+describe('checkTelegram', () => {
+  it('returns skip when TELEGRAM_BOT_TOKEN not set', async () => {
+    const result = await checkTelegram({});
+    expect(result.status).toBe('skip');
+    expect(result.message).toContain('TELEGRAM_BOT_TOKEN');
+  });
+});

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1,23 +1,27 @@
 /**
  * Tests for `archon doctor` check functions.
  *
- * Uses spyOn for `@archon/git.execFileAsync`. BUNDLED_IS_BINARY is not spied —
- * it is false in dev builds, so the dev-mode branch is exercised directly.
- * Avoids `mock.module()` because it is process-global and irreversible in Bun,
- * which would pollute other test files in this package.
+ * Uses spyOn for `@archon/git.execFileAsync` and `globalThis.fetch`.
+ * `BUNDLED_IS_BINARY` is a static const re-export and cannot be spied at
+ * runtime — `checkClaudeBinary` accepts it as an injectable parameter for
+ * testability. Avoids `mock.module()` because it is process-global and
+ * irreversible in Bun, which would pollute other test files in this package.
  */
 import { describe, it, expect, spyOn, afterEach, beforeEach } from 'bun:test';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { mkdirSync, rmSync } from 'fs';
 import * as git from '@archon/git';
 import {
   checkClaudeBinary,
+  checkDatabase,
   checkGhAuth,
   checkWorkspaceWritable,
   checkBundledDefaults,
   checkSlack,
   checkTelegram,
+  doctorCommand,
+  type DatabaseDeps,
 } from './doctor';
 
 describe('checkClaudeBinary', () => {
@@ -31,13 +35,34 @@ describe('checkClaudeBinary', () => {
     execSpy.mockRestore();
   });
 
-  it('returns skip in dev mode (BUNDLED_IS_BINARY=false)', async () => {
-    // The default test environment has BUNDLED_IS_BINARY=false (set by
-    // packages/paths/src/bundled-build.ts and only flipped during the binary
-    // build). No spy needed — we exercise the dev-mode branch.
-    const result = await checkClaudeBinary({});
+  it('returns skip when not in binary mode', async () => {
+    const result = await checkClaudeBinary({}, false);
     expect(result.status).toBe('skip');
     expect(result.label).toBe('Claude binary');
+    expect(execSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns fail in binary mode when CLAUDE_BIN_PATH is unset', async () => {
+    const result = await checkClaudeBinary({}, true);
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('CLAUDE_BIN_PATH');
+    expect(execSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns pass in binary mode when binary spawns successfully', async () => {
+    execSpy.mockResolvedValue({ stdout: '1.0.0', stderr: '' });
+    const result = await checkClaudeBinary({ CLAUDE_BIN_PATH: '/opt/claude' }, true);
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('/opt/claude');
+    expect(execSpy).toHaveBeenCalledWith('/opt/claude', ['--version'], expect.any(Object));
+  });
+
+  it('returns fail in binary mode when spawn throws', async () => {
+    execSpy.mockRejectedValue(new Error('ENOENT'));
+    const result = await checkClaudeBinary({ CLAUDE_BIN_PATH: '/opt/claude' }, true);
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('did not spawn');
+    expect(result.message).toContain('ENOENT');
   });
 });
 
@@ -56,8 +81,14 @@ describe('checkGhAuth', () => {
     const result = await checkGhAuth({});
     expect(result.status).toBe('skip');
     expect(result.message).toContain('GitHub not configured');
-    // Should NOT have called execFileAsync — skip is short-circuit.
     expect(execSpy).not.toHaveBeenCalled();
+  });
+
+  it('runs gh auth check when only GH_TOKEN is set', async () => {
+    execSpy.mockResolvedValue({ stdout: 'Logged in as @user', stderr: '' });
+    const result = await checkGhAuth({ GH_TOKEN: 'ghp_y' });
+    expect(result.status).toBe('pass');
+    expect(execSpy).toHaveBeenCalledWith('gh', ['auth', 'status'], expect.any(Object));
   });
 
   it('returns pass when gh auth status succeeds', async () => {
@@ -72,6 +103,52 @@ describe('checkGhAuth', () => {
     const result = await checkGhAuth({ GH_TOKEN: 'ghp_y' });
     expect(result.status).toBe('fail');
     expect(result.message).toContain('not logged in');
+  });
+});
+
+describe('checkDatabase', () => {
+  it('returns pass when query succeeds', async () => {
+    const deps: DatabaseDeps = {
+      pool: { query: async () => undefined },
+      getDatabaseType: () => 'sqlite',
+    };
+    const result = await checkDatabase(async () => deps);
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('sqlite');
+  });
+
+  it('reports postgres dbType when configured', async () => {
+    const deps: DatabaseDeps = {
+      pool: { query: async () => undefined },
+      getDatabaseType: () => 'postgres',
+    };
+    const result = await checkDatabase(async () => deps);
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('postgres');
+  });
+
+  it('returns fail with "not reachable" when query throws', async () => {
+    const deps: DatabaseDeps = {
+      pool: {
+        query: async () => {
+          throw new Error('connection refused');
+        },
+      },
+      getDatabaseType: () => 'postgres',
+    };
+    const result = await checkDatabase(async () => deps);
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('not reachable');
+    expect(result.message).toContain('connection refused');
+  });
+
+  it('returns fail with "failed to load" when module load throws', async () => {
+    const result = await checkDatabase(async () => {
+      throw new Error('Cannot find module @archon/core');
+    });
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('failed to load database module');
+    expect(result.message).toContain('Cannot find module');
   });
 });
 
@@ -122,17 +199,144 @@ describe('checkBundledDefaults', () => {
 });
 
 describe('checkSlack', () => {
+  let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, 'fetch'>>;
+
+  beforeEach(() => {
+    fetchSpy = spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
   it('returns skip when SLACK_BOT_TOKEN not set', async () => {
     const result = await checkSlack({});
     expect(result.status).toBe('skip');
     expect(result.message).toContain('SLACK_BOT_TOKEN');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns pass when auth.test responds ok', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }) as unknown as Response
+    );
+    const result = await checkSlack({ SLACK_BOT_TOKEN: 'xoxb-x' });
+    expect(result.status).toBe('pass');
+  });
+
+  it('returns fail when auth.test rejects with body.ok=false', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ ok: false, error: 'invalid_auth' }), {
+        status: 200,
+      }) as unknown as Response
+    );
+    const result = await checkSlack({ SLACK_BOT_TOKEN: 'xoxb-x' });
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('invalid_auth');
+  });
+
+  it('returns skip on network error (best-effort by design)', async () => {
+    fetchSpy.mockRejectedValue(new Error('ECONNREFUSED'));
+    const result = await checkSlack({ SLACK_BOT_TOKEN: 'xoxb-x' });
+    expect(result.status).toBe('skip');
+    expect(result.message).toContain('ECONNREFUSED');
   });
 });
 
 describe('checkTelegram', () => {
+  let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, 'fetch'>>;
+
+  beforeEach(() => {
+    fetchSpy = spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
   it('returns skip when TELEGRAM_BOT_TOKEN not set', async () => {
     const result = await checkTelegram({});
     expect(result.status).toBe('skip');
     expect(result.message).toContain('TELEGRAM_BOT_TOKEN');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns pass when getMe responds ok', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }) as unknown as Response
+    );
+    const result = await checkTelegram({ TELEGRAM_BOT_TOKEN: '123:abc' });
+    expect(result.status).toBe('pass');
+  });
+
+  it('returns fail when getMe responds ok=false', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ ok: false, description: 'Unauthorized' }), {
+        status: 401,
+      }) as unknown as Response
+    );
+    const result = await checkTelegram({ TELEGRAM_BOT_TOKEN: '123:abc' });
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('Unauthorized');
+  });
+
+  it('returns skip on network error (best-effort by design)', async () => {
+    fetchSpy.mockRejectedValue(new Error('ETIMEDOUT'));
+    const result = await checkTelegram({ TELEGRAM_BOT_TOKEN: '123:abc' });
+    expect(result.status).toBe('skip');
+    expect(result.message).toContain('ETIMEDOUT');
+  });
+});
+
+describe('doctorCommand', () => {
+  let logSpy: ReturnType<typeof spyOn<Console, 'log'>>;
+
+  beforeEach(() => {
+    logSpy = spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  const passing = (label: string) => async () =>
+    ({ label, status: 'pass', message: 'ok' }) as const;
+  const failing = (label: string) => async () =>
+    ({ label, status: 'fail', message: 'broken' }) as const;
+  const skipping = (label: string) => async () =>
+    ({ label, status: 'skip', message: 'no token' }) as const;
+  const throwing = (label: string) => async (): Promise<never> => {
+    throw new Error(`${label} blew up`);
+  };
+
+  it('returns 0 when every check passes', async () => {
+    const exit = await doctorCommand([passing('A'), passing('B')]);
+    expect(exit).toBe(0);
+  });
+
+  it('returns 0 when checks are pass + skip (skip is not a failure)', async () => {
+    const exit = await doctorCommand([passing('A'), skipping('B')]);
+    expect(exit).toBe(0);
+  });
+
+  it('returns 1 when any check fails', async () => {
+    const exit = await doctorCommand([passing('A'), failing('B')]);
+    expect(exit).toBe(1);
+  });
+
+  it('counts a thrown check as a failure (allSettled rejection branch)', async () => {
+    const exit = await doctorCommand([passing('A'), throwing('B')]);
+    expect(exit).toBe(1);
+  });
+
+  it('continues after a thrown check (Promise.allSettled does not short-circuit)', async () => {
+    const exit = await doctorCommand([throwing('A'), passing('B'), failing('C')]);
+    // 1 throw + 1 fail = 2 failures, but exit code is still 1.
+    expect(exit).toBe(1);
+    // Verify all three were rendered (one per ✓/✗/unknown line).
+    const renderedLines = logSpy.mock.calls
+      .map(args => String(args[0] ?? ''))
+      .filter(s => s.startsWith('✓') || s.startsWith('✗') || s.startsWith('○'));
+    expect(renderedLines.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1,9 +1,10 @@
 /**
  * Tests for `archon doctor` check functions.
  *
- * Uses spyOn for `@archon/git.execFileAsync` and `@archon/paths.BUNDLED_IS_BINARY`
- * indirection. Avoids `mock.module()` because it is process-global and
- * irreversible in Bun, which would pollute other test files in this package.
+ * Uses spyOn for `@archon/git.execFileAsync`. BUNDLED_IS_BINARY is not spied —
+ * it is false in dev builds, so the dev-mode branch is exercised directly.
+ * Avoids `mock.module()` because it is process-global and irreversible in Bun,
+ * which would pollute other test files in this package.
  */
 import { describe, it, expect, spyOn, afterEach, beforeEach } from 'bun:test';
 import { tmpdir } from 'os';
@@ -14,6 +15,7 @@ import {
   checkClaudeBinary,
   checkGhAuth,
   checkWorkspaceWritable,
+  checkBundledDefaults,
   checkSlack,
   checkTelegram,
 } from './doctor';
@@ -106,6 +108,16 @@ describe('checkWorkspaceWritable', () => {
     rmSync(TMP, { recursive: true, force: true });
     const result = await checkWorkspaceWritable();
     expect(result.status).toBe('pass');
+  });
+});
+
+describe('checkBundledDefaults', () => {
+  it('returns pass with workflow and command counts in dev mode', async () => {
+    const result = await checkBundledDefaults();
+    expect(result.status).toBe('pass');
+    expect(result.label).toBe('Bundled defaults');
+    expect(result.message).toMatch(/\d+ workflow/);
+    expect(result.message).toMatch(/\d+ command/);
   });
 });
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,0 +1,225 @@
+/**
+ * Doctor command - Verifies the local Archon setup.
+ *
+ * Runs a green/red checklist that probes the things `archon setup` configures:
+ * Claude binary spawn, gh CLI auth (only if GitHub is configured), database
+ * connectivity, workspace dir writability, bundled defaults loadability, and
+ * adapter token pings (Slack/Telegram, best-effort).
+ *
+ * Returns an exit code: 0 if all checks pass (or are skipped), 1 if any
+ * critical check fails. Adapter token pings that fail because of network
+ * issues degrade to `skip`, never `fail`, so a flaky network does not flip
+ * the overall result red.
+ *
+ * Re-runnable at any time. Also invoked from the end of `archon setup`; the
+ * setup wizard discards the return value so a doctor failure does not abort
+ * setup (the env file was already written successfully).
+ */
+import { existsSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { execFileAsync } from '@archon/git';
+import { BUNDLED_IS_BINARY, getArchonHome, createLogger } from '@archon/paths';
+
+let cachedLog: ReturnType<typeof createLogger> | undefined;
+function getLog(): ReturnType<typeof createLogger> {
+  if (!cachedLog) cachedLog = createLogger('cli.doctor');
+  return cachedLog;
+}
+
+export interface CheckResult {
+  label: string;
+  status: 'pass' | 'fail' | 'skip';
+  message: string;
+}
+
+export async function checkClaudeBinary(env: NodeJS.ProcessEnv): Promise<CheckResult> {
+  const label = 'Claude binary';
+  // In dev mode the SDK resolves Claude via node_modules; the env var is unused.
+  if (!BUNDLED_IS_BINARY) {
+    return { label, status: 'skip', message: 'dev mode (SDK resolves via node_modules)' };
+  }
+  const path = env.CLAUDE_BIN_PATH;
+  if (!path) {
+    return {
+      label,
+      status: 'fail',
+      message: 'CLAUDE_BIN_PATH is not set. Run `archon setup` to configure.',
+    };
+  }
+  if (!existsSync(path)) {
+    return { label, status: 'fail', message: `${path} does not exist` };
+  }
+  try {
+    await execFileAsync(path, ['--version'], { timeout: 5000 });
+    return { label, status: 'pass', message: `${path} (spawns OK)` };
+  } catch (err) {
+    return {
+      label,
+      status: 'fail',
+      message: `${path} did not spawn: ${(err as Error).message}`,
+    };
+  }
+}
+
+export async function checkGhAuth(env: NodeJS.ProcessEnv): Promise<CheckResult> {
+  const label = 'gh CLI';
+  // Skip silently for users without GitHub configured — gh auth is irrelevant
+  // to a CLI-only or Slack/Telegram setup, so reporting fail would be noise.
+  if (!env.GITHUB_TOKEN && !env.GH_TOKEN) {
+    return { label, status: 'skip', message: 'GitHub not configured (no GITHUB_TOKEN)' };
+  }
+  try {
+    await execFileAsync('gh', ['auth', 'status'], { timeout: 10_000 });
+    return { label, status: 'pass', message: 'authenticated' };
+  } catch (err) {
+    return {
+      label,
+      status: 'fail',
+      message: `gh auth status failed: ${(err as Error).message}. Run \`gh auth login\`.`,
+    };
+  }
+}
+
+export async function checkDatabase(): Promise<CheckResult> {
+  const label = 'Database';
+  try {
+    // Lazy import so doctor doesn't pull in the full @archon/core graph just
+    // to print --help or run a different check.
+    const { pool, getDatabaseType } = await import('@archon/core');
+    const dbType = getDatabaseType();
+    await pool.query('SELECT 1');
+    return { label, status: 'pass', message: `reachable (${dbType})` };
+  } catch (err) {
+    return { label, status: 'fail', message: `not reachable: ${(err as Error).message}` };
+  }
+}
+
+export async function checkWorkspaceWritable(): Promise<CheckResult> {
+  const label = 'Workspace';
+  const home = getArchonHome();
+  try {
+    mkdirSync(home, { recursive: true });
+    const probe = join(home, `.doctor-probe-${process.pid}-${Date.now()}`);
+    writeFileSync(probe, 'ok');
+    rmSync(probe, { force: true });
+    return { label, status: 'pass', message: `${home} is writable` };
+  } catch (err) {
+    return { label, status: 'fail', message: `${home} not writable: ${(err as Error).message}` };
+  }
+}
+
+export async function checkBundledDefaults(): Promise<CheckResult> {
+  const label = 'Bundled defaults';
+  try {
+    const { BUNDLED_COMMANDS, BUNDLED_WORKFLOWS } = await import('@archon/workflows/defaults');
+    const commands = Object.keys(BUNDLED_COMMANDS).length;
+    const workflows = Object.keys(BUNDLED_WORKFLOWS).length;
+    return {
+      label,
+      status: 'pass',
+      message: `${workflows} workflow(s), ${commands} command(s) loaded`,
+    };
+  } catch (err) {
+    return { label, status: 'fail', message: `failed to load: ${(err as Error).message}` };
+  }
+}
+
+export async function checkSlack(env: NodeJS.ProcessEnv): Promise<CheckResult> {
+  const label = 'Slack';
+  const token = env.SLACK_BOT_TOKEN;
+  if (!token) {
+    return { label, status: 'skip', message: 'no SLACK_BOT_TOKEN set' };
+  }
+  try {
+    const res = await fetch('https://slack.com/api/auth.test', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(5000),
+    });
+    const body = (await res.json()) as { ok?: boolean; error?: string };
+    if (body.ok) {
+      return { label, status: 'pass', message: 'auth.test OK' };
+    }
+    return { label, status: 'fail', message: `auth.test rejected: ${body.error ?? 'unknown'}` };
+  } catch (err) {
+    // Network errors → skip, not fail — best-effort by design.
+    return {
+      label,
+      status: 'skip',
+      message: `ping skipped (network error: ${(err as Error).message})`,
+    };
+  }
+}
+
+export async function checkTelegram(env: NodeJS.ProcessEnv): Promise<CheckResult> {
+  const label = 'Telegram';
+  const token = env.TELEGRAM_BOT_TOKEN;
+  if (!token) {
+    return { label, status: 'skip', message: 'no TELEGRAM_BOT_TOKEN set' };
+  }
+  try {
+    const res = await fetch(`https://api.telegram.org/bot${token}/getMe`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    const body = (await res.json()) as { ok?: boolean; description?: string };
+    if (body.ok) {
+      return { label, status: 'pass', message: 'getMe OK' };
+    }
+    return {
+      label,
+      status: 'fail',
+      message: `getMe rejected: ${body.description ?? 'unknown'}`,
+    };
+  } catch (err) {
+    return {
+      label,
+      status: 'skip',
+      message: `ping skipped (network error: ${(err as Error).message})`,
+    };
+  }
+}
+
+function renderResult(r: CheckResult): string {
+  const icon = r.status === 'pass' ? '✓' : r.status === 'fail' ? '✗' : '○';
+  return `${icon} ${r.label}: ${r.message}`;
+}
+
+export async function doctorCommand(): Promise<number> {
+  console.log('archon doctor — verifying your setup\n');
+  getLog().info('doctor.run_started');
+  const env = process.env;
+
+  // Promise.allSettled so one rejection (e.g. a thrown SDK error) doesn't
+  // skip the remaining checks. Each check function already catches its own
+  // errors and returns a CheckResult — allSettled is belt-and-braces.
+  const settled = await Promise.allSettled([
+    checkClaudeBinary(env),
+    checkGhAuth(env),
+    checkDatabase(),
+    checkWorkspaceWritable(),
+    checkBundledDefaults(),
+    checkSlack(env),
+    checkTelegram(env),
+  ]);
+
+  let failures = 0;
+  for (const s of settled) {
+    if (s.status === 'rejected') {
+      failures++;
+      console.log(`✗ unknown: check threw: ${(s.reason as Error).message}`);
+      continue;
+    }
+    if (s.value.status === 'fail') failures++;
+    console.log(renderResult(s.value));
+  }
+
+  console.log('');
+  if (failures === 0) {
+    console.log('All checks passed.');
+    getLog().info('doctor.run_completed');
+    return 0;
+  }
+  console.log(`${failures} check(s) failed. Run \`archon setup\` to reconfigure.`);
+  getLog().warn({ failures }, 'doctor.run_failed');
+  return 1;
+}

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,21 +1,11 @@
 /**
  * Doctor command - Verifies the local Archon setup.
  *
- * Runs a green/red checklist that probes the things `archon setup` configures:
- * Claude binary spawn, gh CLI auth (only if GitHub is configured), database
- * connectivity, workspace dir writability, bundled defaults loadability, and
- * adapter token pings (Slack/Telegram, best-effort).
- *
- * Returns an exit code: 0 if all checks pass (or are skipped), 1 if any
- * critical check fails. Adapter token pings that fail because of network
- * issues degrade to `skip`, never `fail`, so a flaky network does not flip
- * the overall result red.
- *
- * Re-runnable at any time. Also invoked from the end of `archon setup`; the
- * setup wizard discards the return value so a doctor failure does not abort
- * setup (the env file was already written successfully).
+ * Also invoked from the end of `archon setup`; the setup wizard discards the
+ * return value so a doctor failure does not abort setup (the env file was
+ * already written successfully).
  */
-import { existsSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { execFileAsync } from '@archon/git';
 import { BUNDLED_IS_BINARY, getArchonHome, createLogger } from '@archon/paths';
@@ -45,9 +35,6 @@ export async function checkClaudeBinary(env: NodeJS.ProcessEnv): Promise<CheckRe
       status: 'fail',
       message: 'CLAUDE_BIN_PATH is not set. Run `archon setup` to configure.',
     };
-  }
-  if (!existsSync(path)) {
-    return { label, status: 'fail', message: `${path} does not exist` };
   }
   try {
     await execFileAsync(path, ['--version'], { timeout: 5000 });
@@ -193,9 +180,7 @@ export async function doctorCommand(): Promise<number> {
   getLog().info('doctor.run_started');
   const env = process.env;
 
-  // Promise.allSettled so one rejection (e.g. a thrown SDK error) doesn't
-  // skip the remaining checks. Each check function already catches its own
-  // errors and returns a CheckResult — allSettled is belt-and-braces.
+  // Promise.allSettled so one unexpected rejection doesn't skip remaining checks.
   const settled = await Promise.allSettled([
     checkClaudeBinary(env),
     checkGhAuth(env),

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -63,7 +63,7 @@ export async function checkClaudeBinary(env: NodeJS.ProcessEnv): Promise<CheckRe
 
 export async function checkGhAuth(env: NodeJS.ProcessEnv): Promise<CheckResult> {
   const label = 'gh CLI';
-  // Skip silently for users without GitHub configured — gh auth is irrelevant
+  // Skip for users without GitHub configured — gh auth is irrelevant
   // to a CLI-only or Slack/Telegram setup, so reporting fail would be noise.
   if (!env.GITHUB_TOKEN && !env.GH_TOKEN) {
     return { label, status: 'skip', message: 'GitHub not configured (no GITHUB_TOKEN)' };
@@ -97,15 +97,19 @@ export async function checkDatabase(): Promise<CheckResult> {
 export async function checkWorkspaceWritable(): Promise<CheckResult> {
   const label = 'Workspace';
   const home = getArchonHome();
+  const probe = join(home, `.doctor-probe-${process.pid}-${Date.now()}`);
   try {
     mkdirSync(home, { recursive: true });
-    const probe = join(home, `.doctor-probe-${process.pid}-${Date.now()}`);
     writeFileSync(probe, 'ok');
-    rmSync(probe, { force: true });
-    return { label, status: 'pass', message: `${home} is writable` };
   } catch (err) {
     return { label, status: 'fail', message: `${home} not writable: ${(err as Error).message}` };
   }
+  try {
+    rmSync(probe, { force: true });
+  } catch {
+    // Deletion failure is cosmetic — the write succeeded, so the dir is writable.
+  }
+  return { label, status: 'pass', message: `${home} is writable` };
 }
 
 export async function checkBundledDefaults(): Promise<CheckResult> {
@@ -146,7 +150,7 @@ export async function checkSlack(env: NodeJS.ProcessEnv): Promise<CheckResult> {
     return {
       label,
       status: 'skip',
-      message: `ping skipped (network error: ${(err as Error).message})`,
+      message: `ping skipped (${(err as Error).message})`,
     };
   }
 }
@@ -174,7 +178,7 @@ export async function checkTelegram(env: NodeJS.ProcessEnv): Promise<CheckResult
     return {
       label,
       status: 'skip',
-      message: `ping skipped (network error: ${(err as Error).message})`,
+      message: `ping skipped (${(err as Error).message})`,
     };
   }
 }
@@ -206,7 +210,9 @@ export async function doctorCommand(): Promise<number> {
   for (const s of settled) {
     if (s.status === 'rejected') {
       failures++;
-      console.log(`✗ unknown: check threw: ${(s.reason as Error).message}`);
+      const msg = s.reason instanceof Error ? s.reason.message : String(s.reason);
+      console.log(`✗ unknown: check threw: ${msg}`);
+      getLog().error({ reason: s.reason }, 'doctor.check_threw_unexpectedly');
       continue;
     }
     if (s.value.status === 'fail') failures++;

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -22,10 +22,14 @@ export interface CheckResult {
   message: string;
 }
 
-export async function checkClaudeBinary(env: NodeJS.ProcessEnv): Promise<CheckResult> {
+export async function checkClaudeBinary(
+  env: NodeJS.ProcessEnv,
+  // Injected so tests can drive the binary-mode branch — `BUNDLED_IS_BINARY`
+  // is a static const re-export and cannot be spied at runtime.
+  isBinary: boolean = BUNDLED_IS_BINARY
+): Promise<CheckResult> {
   const label = 'Claude binary';
-  // In dev mode the SDK resolves Claude via node_modules; the env var is unused.
-  if (!BUNDLED_IS_BINARY) {
+  if (!isBinary) {
     return { label, status: 'skip', message: 'dev mode (SDK resolves via node_modules)' };
   }
   const path = env.CLAUDE_BIN_PATH;
@@ -67,18 +71,46 @@ export async function checkGhAuth(env: NodeJS.ProcessEnv): Promise<CheckResult> 
   }
 }
 
-export async function checkDatabase(): Promise<CheckResult> {
+export interface DatabaseDeps {
+  pool: { query: (sql: string) => Promise<unknown> };
+  getDatabaseType: () => string;
+}
+
+export async function checkDatabase(
+  // Injected so tests can drive both code paths without mocking the dynamic
+  // import. Falls back to the lazy `@archon/core` import in production.
+  loadDeps: () => Promise<DatabaseDeps> = defaultLoadDatabaseDeps
+): Promise<CheckResult> {
   const label = 'Database';
+  let deps: DatabaseDeps;
   try {
-    // Lazy import so doctor doesn't pull in the full @archon/core graph just
-    // to print --help or run a different check.
-    const { pool, getDatabaseType } = await import('@archon/core');
-    const dbType = getDatabaseType();
-    await pool.query('SELECT 1');
+    deps = await loadDeps();
+  } catch (err) {
+    // Distinguish module-load failure from query failure — surfacing
+    // "not reachable" for an import error misleads the user into running
+    // `archon setup` when the real fix is a binary rebuild.
+    getLog().error({ err }, 'doctor.db_module_load_failed');
+    return {
+      label,
+      status: 'fail',
+      message: `failed to load database module: ${(err as Error).message}`,
+    };
+  }
+  try {
+    const dbType = deps.getDatabaseType();
+    await deps.pool.query('SELECT 1');
     return { label, status: 'pass', message: `reachable (${dbType})` };
   } catch (err) {
+    getLog().error({ err }, 'doctor.db_query_failed');
     return { label, status: 'fail', message: `not reachable: ${(err as Error).message}` };
   }
+}
+
+async function defaultLoadDatabaseDeps(): Promise<DatabaseDeps> {
+  // Lazy import so doctor doesn't pull in the full @archon/core graph just to
+  // print --help or run a different check.
+  const { pool, getDatabaseType } = await import('@archon/core');
+  return { pool, getDatabaseType };
 }
 
 export async function checkWorkspaceWritable(): Promise<CheckResult> {
@@ -93,8 +125,11 @@ export async function checkWorkspaceWritable(): Promise<CheckResult> {
   }
   try {
     rmSync(probe, { force: true });
-  } catch {
-    // Deletion failure is cosmetic — the write succeeded, so the dir is writable.
+  } catch (err) {
+    // Deletion failure is cosmetic — the write succeeded, so the dir is
+    // writable. Log so repeated failures leave a diagnostic trace instead of
+    // silently accumulating .doctor-probe-* files in ARCHON_HOME.
+    getLog().warn({ probe, err }, 'doctor.workspace_probe_delete_failed');
   }
   return { label, status: 'pass', message: `${home} is writable` };
 }
@@ -175,21 +210,29 @@ function renderResult(r: CheckResult): string {
   return `${icon} ${r.label}: ${r.message}`;
 }
 
-export async function doctorCommand(): Promise<number> {
+export async function doctorCommand(
+  // Injected so tests can drive the exit-code contract and the
+  // Promise.allSettled rejection branch with synthetic checks.
+  checks?: (() => Promise<CheckResult>)[]
+): Promise<number> {
   console.log('archon doctor — verifying your setup\n');
   getLog().info('doctor.run_started');
   const env = process.env;
 
+  const promises = checks
+    ? checks.map(fn => fn())
+    : [
+        checkClaudeBinary(env),
+        checkGhAuth(env),
+        checkDatabase(),
+        checkWorkspaceWritable(),
+        checkBundledDefaults(),
+        checkSlack(env),
+        checkTelegram(env),
+      ];
+
   // Promise.allSettled so one unexpected rejection doesn't skip remaining checks.
-  const settled = await Promise.allSettled([
-    checkClaudeBinary(env),
-    checkGhAuth(env),
-    checkDatabase(),
-    checkWorkspaceWritable(),
-    checkBundledDefaults(),
-    checkSlack(env),
-    checkTelegram(env),
-  ]);
+  const settled = await Promise.allSettled(promises);
 
   let failures = 0;
   for (const s of settled) {

--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -99,30 +99,6 @@ CODEX_ACCOUNT_ID=account1
       expect(result?.platforms.telegram).toBe(true);
       expect(result?.platforms.github).toBe(false);
       expect(result?.platforms.slack).toBe(false);
-      expect(result?.platforms.discord).toBe(false);
-      expect(result?.hasDatabase).toBe(false);
-
-      if (originalHome === undefined) {
-        delete process.env.ARCHON_HOME;
-      } else {
-        process.env.ARCHON_HOME = originalHome;
-      }
-    });
-
-    it('should detect PostgreSQL database configuration', () => {
-      const envDir = join(TEST_DIR, '.archon2');
-      mkdirSync(envDir, { recursive: true });
-      const envPath = join(envDir, '.env');
-
-      writeFileSync(envPath, 'DATABASE_URL=postgresql://localhost:5432/test');
-
-      const originalHome = process.env.ARCHON_HOME;
-      process.env.ARCHON_HOME = envDir;
-
-      const result = checkExistingConfig();
-
-      expect(result).not.toBeNull();
-      expect(result?.hasDatabase).toBe(true);
 
       if (originalHome === undefined) {
         delete process.env.ARCHON_HOME;
@@ -135,7 +111,6 @@ CODEX_ACCOUNT_ID=account1
   describe('generateEnvContent', () => {
     it('should generate valid .env content for SQLite configuration', () => {
       const content = generateEnvContent({
-        database: { type: 'sqlite' },
         ai: {
           claude: true,
           claudeAuthType: 'global',
@@ -146,7 +121,6 @@ CODEX_ACCOUNT_ID=account1
           github: false,
           telegram: false,
           slack: false,
-          discord: false,
         },
         botDisplayName: 'Archon',
       });
@@ -157,36 +131,13 @@ CODEX_ACCOUNT_ID=account1
       // PORT is intentionally commented out — server and Vite both default to 3090 when unset (#1152).
       expect(content).toContain('# PORT=3090');
       expect(content).not.toMatch(/^PORT=/m);
-      expect(content).not.toContain('DATABASE_URL=');
-    });
-
-    it('should generate valid .env content for PostgreSQL configuration', () => {
-      const content = generateEnvContent({
-        database: { type: 'postgresql', url: 'postgresql://localhost:5432/archon' },
-        ai: {
-          claude: true,
-          claudeAuthType: 'apiKey',
-          claudeApiKey: 'sk-test-key',
-          codex: false,
-          defaultAssistant: 'claude',
-        },
-        platforms: {
-          github: false,
-          telegram: false,
-          slack: false,
-          discord: false,
-        },
-        botDisplayName: 'Archon',
-      });
-
-      expect(content).toContain('DATABASE_URL=postgresql://localhost:5432/archon');
-      expect(content).toContain('CLAUDE_USE_GLOBAL_AUTH=false');
-      expect(content).toContain('CLAUDE_API_KEY=sk-test-key');
+      // Sanity: never emit an active DATABASE_URL line. The "# Set DATABASE_URL=..."
+      // hint is a comment and is fine — only an unprefixed assignment would be wrong.
+      expect(content).not.toMatch(/^DATABASE_URL=/m);
     });
 
     it('emits CLAUDE_BIN_PATH when claudeBinaryPath is configured', () => {
       const content = generateEnvContent({
-        database: { type: 'sqlite' },
         ai: {
           claude: true,
           claudeAuthType: 'global',
@@ -194,7 +145,7 @@ CODEX_ACCOUNT_ID=account1
           codex: false,
           defaultAssistant: 'claude',
         },
-        platforms: { github: false, telegram: false, slack: false, discord: false },
+        platforms: { github: false, telegram: false, slack: false },
         botDisplayName: 'Archon',
       });
 
@@ -205,14 +156,13 @@ CODEX_ACCOUNT_ID=account1
 
     it('omits CLAUDE_BIN_PATH when not configured', () => {
       const content = generateEnvContent({
-        database: { type: 'sqlite' },
         ai: {
           claude: true,
           claudeAuthType: 'global',
           codex: false,
           defaultAssistant: 'claude',
         },
-        platforms: { github: false, telegram: false, slack: false, discord: false },
+        platforms: { github: false, telegram: false, slack: false },
         botDisplayName: 'Archon',
       });
 
@@ -221,7 +171,6 @@ CODEX_ACCOUNT_ID=account1
 
     it('should include platform configurations', () => {
       const content = generateEnvContent({
-        database: { type: 'sqlite' },
         ai: {
           claude: true,
           claudeAuthType: 'global',
@@ -232,7 +181,6 @@ CODEX_ACCOUNT_ID=account1
           github: true,
           telegram: true,
           slack: false,
-          discord: false,
         },
         github: {
           token: 'ghp_testtoken',
@@ -259,7 +207,6 @@ CODEX_ACCOUNT_ID=account1
 
     it('should include Codex tokens when configured', () => {
       const content = generateEnvContent({
-        database: { type: 'sqlite' },
         ai: {
           claude: false,
           codex: true,
@@ -275,7 +222,6 @@ CODEX_ACCOUNT_ID=account1
           github: false,
           telegram: false,
           slack: false,
-          discord: false,
         },
         botDisplayName: 'Archon',
       });
@@ -289,7 +235,6 @@ CODEX_ACCOUNT_ID=account1
 
     it('should include custom bot display name', () => {
       const content = generateEnvContent({
-        database: { type: 'sqlite' },
         ai: {
           claude: true,
           claudeAuthType: 'global',
@@ -300,7 +245,6 @@ CODEX_ACCOUNT_ID=account1
           github: false,
           telegram: false,
           slack: false,
-          discord: false,
         },
         botDisplayName: 'MyCustomBot',
       });
@@ -310,7 +254,6 @@ CODEX_ACCOUNT_ID=account1
 
     it('should not include bot display name when default', () => {
       const content = generateEnvContent({
-        database: { type: 'sqlite' },
         ai: {
           claude: true,
           claudeAuthType: 'global',
@@ -321,7 +264,6 @@ CODEX_ACCOUNT_ID=account1
           github: false,
           telegram: false,
           slack: false,
-          discord: false,
         },
         botDisplayName: 'Archon',
       });
@@ -331,7 +273,6 @@ CODEX_ACCOUNT_ID=account1
 
     it('should include Slack configuration', () => {
       const content = generateEnvContent({
-        database: { type: 'sqlite' },
         ai: {
           claude: true,
           claudeAuthType: 'global',
@@ -342,7 +283,6 @@ CODEX_ACCOUNT_ID=account1
           github: false,
           telegram: false,
           slack: true,
-          discord: false,
         },
         slack: {
           botToken: 'xoxb-test',
@@ -356,33 +296,6 @@ CODEX_ACCOUNT_ID=account1
       expect(content).toContain('SLACK_APP_TOKEN=xapp-test');
       expect(content).toContain('SLACK_ALLOWED_USER_IDS=U123');
       expect(content).toContain('SLACK_STREAMING_MODE=batch');
-    });
-
-    it('should include Discord configuration', () => {
-      const content = generateEnvContent({
-        database: { type: 'sqlite' },
-        ai: {
-          claude: true,
-          claudeAuthType: 'global',
-          codex: false,
-          defaultAssistant: 'claude',
-        },
-        platforms: {
-          github: false,
-          telegram: false,
-          slack: false,
-          discord: true,
-        },
-        discord: {
-          botToken: 'discord-bot-token-test',
-          allowedUserIds: '123456789',
-        },
-        botDisplayName: 'Archon',
-      });
-
-      expect(content).toContain('DISCORD_BOT_TOKEN=discord-bot-token-test');
-      expect(content).toContain('DISCORD_ALLOWED_USER_IDS=123456789');
-      expect(content).toContain('DISCORD_STREAMING_MODE=batch');
     });
   });
 

--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -6,6 +6,7 @@ import { existsSync, readFileSync, mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
+  bootstrapProjectConfig,
   checkExistingConfig,
   generateEnvContent,
   generateWebhookSecret,
@@ -371,6 +372,65 @@ CODEX_ACCOUNT_ID=account1
       await copyArchonSkill(target);
 
       expect(existsSync(join(target, '.claude', 'skills', 'archon', 'SKILL.md'))).toBe(true);
+    });
+  });
+
+  describe('bootstrapProjectConfig', () => {
+    it('creates .archon/config.yaml when it does not exist', () => {
+      const target = join(TEST_DIR, 'bootstrap-target');
+      mkdirSync(target, { recursive: true });
+
+      const result = bootstrapProjectConfig(target);
+
+      expect(result.state).toBe('created');
+      expect(result.path).toBe(join(target, '.archon', 'config.yaml'));
+      expect(existsSync(result.path)).toBe(true);
+      const content = readFileSync(result.path, 'utf-8');
+      // Must be valid YAML — comment lines only — so loaders treat it as empty.
+      expect(content.split('\n').every(line => line === '' || line.startsWith('#'))).toBe(true);
+      expect(content).toContain('Project-scoped Archon config');
+      expect(content).toContain('archon.diy/reference/configuration');
+    });
+
+    it('creates the .archon directory if missing (idempotent on parent)', () => {
+      const target = join(TEST_DIR, 'bootstrap-no-archon-dir');
+      mkdirSync(target, { recursive: true });
+      // Do NOT pre-create .archon — bootstrap must create it
+
+      const result = bootstrapProjectConfig(target);
+
+      expect(result.state).toBe('created');
+      expect(existsSync(join(target, '.archon'))).toBe(true);
+    });
+
+    it('is idempotent — leaves an existing config untouched', () => {
+      const target = join(TEST_DIR, 'bootstrap-existing');
+      const archonDir = join(target, '.archon');
+      mkdirSync(archonDir, { recursive: true });
+      const userContent = '# my custom config\nassistants:\n  claude:\n    model: opus\n';
+      writeFileSync(join(archonDir, 'config.yaml'), userContent);
+
+      const result = bootstrapProjectConfig(target);
+
+      expect(result.state).toBe('existed');
+      const after = readFileSync(join(archonDir, 'config.yaml'), 'utf-8');
+      expect(after).toBe(userContent);
+    });
+
+    it('returns failed state without throwing when the target path is unwritable', () => {
+      // Pointing at a path inside a non-existent parent that mkdirSync can
+      // create succeeds. Use a deeply-nested path inside a regular file
+      // (which fs cannot mkdir into) to force a real failure.
+      const blocker = join(TEST_DIR, 'blocker-file');
+      writeFileSync(blocker, 'not a directory');
+      // mkdir under a file path fails with ENOTDIR — that's the failure mode
+      // we want to model (read-only FS, permission denied, etc.).
+      const result = bootstrapProjectConfig(blocker);
+
+      expect(result.state).toBe('failed');
+      if (result.state === 'failed') {
+        expect(result.error.length).toBeGreaterThan(0);
+      }
     });
   });
 });

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -396,15 +396,6 @@ function tryReadCodexAuth(): CodexTokens | null {
 }
 
 /**
- * Collect Claude authentication method
- */
-/**
- * Resolve the Claude Code executable path for CLAUDE_BIN_PATH.
- * Auto-detects common install locations and falls back to prompting the user.
- * Returns undefined if the user declines to configure (setup continues; the
- * compiled binary will error with clear instructions on first Claude query).
- */
-/**
  * Try to spawn the Claude binary with `--version` to confirm it actually runs.
  * Returns true on success, false on any spawn or non-zero exit. Bounded to 5s
  * so a hung process can't stall setup.
@@ -418,6 +409,12 @@ async function probeClaudeBinarySpawns(path: string): Promise<boolean> {
   }
 }
 
+/**
+ * Resolve the Claude Code executable path for CLAUDE_BIN_PATH.
+ * Auto-detects common install locations and falls back to prompting the user.
+ * Returns undefined if the user declines to configure (setup continues; the
+ * compiled binary will error with clear instructions on first Claude query).
+ */
 async function collectClaudeBinaryPath(): Promise<string | undefined> {
   const detected = detectClaudeExecutablePath();
 
@@ -478,6 +475,9 @@ async function collectClaudeBinaryPath(): Promise<string | undefined> {
   return trimmed;
 }
 
+/**
+ * Collect Claude authentication method (API key, OAuth token, or global auth).
+ */
 async function collectClaudeAuth(): Promise<{
   authType: 'global' | 'apiKey' | 'oauthToken';
   apiKey?: string;
@@ -909,18 +909,24 @@ async function collectGitHubConfig(): Promise<GitHubConfig> {
   const ghSpin = spinner();
   ghSpin.start('Checking gh CLI authentication...');
   let ghAuthOk = false;
+  let ghAuthError: string | undefined;
   try {
     await execFileAsync('gh', ['auth', 'status'], { timeout: 10_000 });
     ghAuthOk = true;
     ghSpin.stop('gh CLI is authenticated');
-  } catch {
-    ghSpin.stop('gh CLI is not authenticated');
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    ghAuthError =
+      e.code === 'ENOENT'
+        ? 'gh not found in PATH — install it first (https://cli.github.com)'
+        : (e.message ?? 'unknown error');
+    ghSpin.stop('gh CLI check failed');
   }
 
   if (!ghAuthOk) {
     log.warning(
-      'gh auth status failed. Workflows using `gh` shell commands will fail until you authenticate.\n' +
-        'Run: gh auth login'
+      `gh auth check failed: ${ghAuthError}\n` +
+        (ghAuthError?.includes('not found') ? '' : 'Run: gh auth login')
     );
     // gh auth login is an interactive OAuth flow — only offer it from a TTY.
     if (process.stdout.isTTY) {
@@ -930,7 +936,13 @@ async function collectGitHubConfig(): Promise<GitHubConfig> {
       });
       if (!isCancel(runGhLogin) && runGhLogin) {
         // spawnSync with inherited stdio so the OAuth prompt reaches the terminal.
-        spawnSync('gh', ['auth', 'login'], { stdio: 'inherit' });
+        const ghLoginResult = spawnSync('gh', ['auth', 'login'], { stdio: 'inherit' });
+        if (ghLoginResult.error) {
+          log.warning(
+            `Could not run gh auth login: ${ghLoginResult.error.message}. ` +
+              'Install the gh CLI from https://cli.github.com/ and run it manually.'
+          );
+        }
       }
     }
   }

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -397,15 +397,18 @@ function tryReadCodexAuth(): CodexTokens | null {
 
 /**
  * Try to spawn the Claude binary with `--version` to confirm it actually runs.
- * Returns true on success, false on any spawn or non-zero exit. Bounded to 5s
- * so a hung process can't stall setup.
+ * Returns `{ ok: true }` on success or `{ ok: false, reason }` with the spawn
+ * error message so the caller can show it to the user. Bounded to 5s so a hung
+ * process can't stall setup.
  */
-async function probeClaudeBinarySpawns(path: string): Promise<boolean> {
+async function probeClaudeBinarySpawns(
+  path: string
+): Promise<{ ok: true } | { ok: false; reason: string }> {
   try {
     await execFileAsync(path, ['--version'], { timeout: 5000 });
-    return true;
-  } catch {
-    return false;
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, reason: (err as Error).message };
   }
 }
 
@@ -419,8 +422,8 @@ async function collectClaudeBinaryPath(): Promise<string | undefined> {
   const detected = detectClaudeExecutablePath();
 
   if (detected) {
-    const spawnsOk = await probeClaudeBinarySpawns(detected);
-    const suffix = spawnsOk ? '(spawns OK)' : '(could not spawn — verify it works)';
+    const probe = await probeClaudeBinarySpawns(detected);
+    const suffix = probe.ok ? '(spawns OK)' : `(could not spawn: ${probe.reason})`;
     const useDetected = await confirm({
       message: `Found Claude Code at ${detected} ${suffix}. Write this to CLAUDE_BIN_PATH?`,
       initialValue: true,
@@ -466,10 +469,10 @@ async function collectClaudeBinaryPath(): Promise<string | undefined> {
     return trimmed;
   }
 
-  const spawnsOk = await probeClaudeBinarySpawns(trimmed);
-  if (!spawnsOk) {
+  const probe = await probeClaudeBinarySpawns(trimmed);
+  if (!probe.ok) {
     log.warning(
-      `Could not spawn ${trimmed} --version. Saving anyway — verify the binary works (try running it directly).`
+      `Could not spawn ${trimmed} --version: ${probe.reason}. Saving anyway — verify the binary works (try running it directly).`
     );
   }
   return trimmed;
@@ -942,6 +945,14 @@ async function collectGitHubConfig(): Promise<GitHubConfig> {
             `Could not run gh auth login: ${ghLoginResult.error.message}. ` +
               'Install the gh CLI from https://cli.github.com/ and run it manually.'
           );
+        } else if (ghLoginResult.status !== 0) {
+          // gh exited non-zero (user cancelled, OAuth callback failed, etc.).
+          // .error is only set on spawn failure, so without this the wizard
+          // would proceed as if auth succeeded.
+          log.warning(
+            `gh auth login exited with code ${ghLoginResult.status ?? 'null'}. ` +
+              'Authentication may not have completed — re-run `gh auth login` manually if needed.'
+          );
         }
       }
     }
@@ -1317,11 +1328,10 @@ export type BootstrapProjectConfigResult =
 export function bootstrapProjectConfig(projectPath: string): BootstrapProjectConfigResult {
   const archonDir = join(projectPath, '.archon');
   const configPath = join(archonDir, 'config.yaml');
-  if (existsSync(configPath)) {
-    return { state: 'existed', path: configPath };
-  }
   try {
     mkdirSync(archonDir, { recursive: true });
+    // `wx` flag = exclusive create. Atomic against a concurrent create between
+    // a check and a write, so an in-flight user edit is never overwritten.
     writeFileSync(
       configPath,
       [
@@ -1337,14 +1347,18 @@ export function bootstrapProjectConfig(projectPath: string): BootstrapProjectCon
         '#     path: docs',
         '',
       ].join('\n'),
-      { mode: 0o644 }
+      { mode: 0o644, flag: 'wx' }
     );
     return { state: 'created', path: configPath };
   } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code === 'EEXIST') {
+      return { state: 'existed', path: configPath };
+    }
     return {
       state: 'failed',
       path: configPath,
-      error: (err as NodeJS.ErrnoException).message,
+      error: e.message,
     };
   }
 }
@@ -1733,7 +1747,6 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
       config.slack = await collectSlackConfig();
     }
   } else {
-    // Fresh or update mode - collect everything (SQLite is implicit; no DB prompt)
     const ai = await collectAIConfig();
     const platforms = await collectPlatforms();
 
@@ -1936,7 +1949,6 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
     'Additional Options'
   );
 
-  // Update instructions — always shown so users know how to upgrade.
   note(
     'To update Archon:\n' +
       '  Homebrew:  brew upgrade coleam00/archon/archon\n' +
@@ -1945,8 +1957,6 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
     'Update Instructions'
   );
 
-  // Offer to verify with `archon doctor`. Failures inside doctor don't abort
-  // setup — the wizard already wrote the env file successfully.
   const runDoctor = await confirm({
     message: 'Run `archon doctor` now to verify your setup?',
     initialValue: true,

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -1296,6 +1296,60 @@ export function resolveScopedEnvPath(scope: 'home' | 'project', repoPath: string
 }
 
 /**
+ * Result of attempting to bootstrap project-scoped Archon config.
+ *  - `created`: `.archon/config.yaml` did not exist; we wrote a starter.
+ *  - `existed`: file already present; left untouched (idempotent re-run).
+ *  - `failed`: mkdir or write failed (permissions, read-only FS, etc.).
+ *    Setup continues — the user can hand-create the file later.
+ */
+export type BootstrapProjectConfigResult =
+  | { state: 'created'; path: string }
+  | { state: 'existed'; path: string }
+  | { state: 'failed'; path: string; error: string };
+
+/**
+ * Create `<projectPath>/.archon/config.yaml` with a commented-out template if
+ * absent. Pairs with the skill install — gives the user a place to put
+ * per-project overrides without manual mkdir. Workflows/commands/scripts
+ * subdirs are intentionally not created; empty directories would clutter
+ * users' trees and Archon's loaders handle their absence cleanly.
+ */
+export function bootstrapProjectConfig(projectPath: string): BootstrapProjectConfigResult {
+  const archonDir = join(projectPath, '.archon');
+  const configPath = join(archonDir, 'config.yaml');
+  if (existsSync(configPath)) {
+    return { state: 'existed', path: configPath };
+  }
+  try {
+    mkdirSync(archonDir, { recursive: true });
+    writeFileSync(
+      configPath,
+      [
+        '# Project-scoped Archon config',
+        '# Inherits defaults from ~/.archon/config.yaml.',
+        '# Reference: https://archon.diy/reference/configuration/',
+        '#',
+        '# Examples:',
+        '#   assistants:',
+        '#     claude:',
+        '#       model: sonnet',
+        '#   docs:',
+        '#     path: docs',
+        '',
+      ].join('\n'),
+      { mode: 0o644 }
+    );
+    return { state: 'created', path: configPath };
+  } catch (err) {
+    return {
+      state: 'failed',
+      path: configPath,
+      error: (err as NodeJS.ErrnoException).message,
+    };
+  }
+}
+
+/**
  * Serialize a key/value map back to `KEY=value` lines. Values with whitespace,
  * `#`, `"`, `'`, `\n`, or `\r` are double-quoted with `\\`, `"`, `\n`, `\r`
  * escaped so round-tripping through dotenv.parse is stable.
@@ -1752,6 +1806,7 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
   }
 
   let skillInstalledPath: string | null = null;
+  let projectConfigCreatedPath: string | null = null;
 
   if (shouldCopySkill) {
     const skillTargetRaw = await text({
@@ -1776,6 +1831,16 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
     }
     s.stop('Archon skill installed');
     skillInstalledPath = join(skillTarget, '.claude', 'skills', 'archon');
+
+    const bootstrapResult = bootstrapProjectConfig(skillTarget);
+    if (bootstrapResult.state === 'created') {
+      log.info(`Created project config: ${bootstrapResult.path}`);
+      projectConfigCreatedPath = bootstrapResult.path;
+    } else if (bootstrapResult.state === 'failed') {
+      // Non-fatal — log so silent permission errors don't masquerade as a
+      // successful setup. The user can hand-create the file later.
+      log.warn(`Could not create ${bootstrapResult.path}: ${bootstrapResult.error}`);
+    }
   }
 
   // Optional: configure docs directory
@@ -1852,6 +1917,11 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
     summaryLines.push('');
     summaryLines.push('Archon skill installed:');
     summaryLines.push(`  ${skillInstalledPath}`);
+    if (projectConfigCreatedPath) {
+      summaryLines.push('');
+      summaryLines.push('Project config created:');
+      summaryLines.push(`  ${projectConfigCreatedPath}`);
+    }
   }
 
   note(summaryLines.join('\n'), 'Configuration Complete');

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -2,9 +2,11 @@
  * Setup command - Interactive CLI wizard for Archon credential configuration
  *
  * Guides users through configuring:
- * - Database (SQLite default vs PostgreSQL)
  * - AI assistants (Claude and/or Codex)
- * - Platform connections (GitHub, Telegram, Slack, Discord)
+ * - Platform connections (GitHub, Telegram, Slack — all skippable)
+ *
+ * SQLite is the implicit default; no database prompt. PostgreSQL users set
+ * DATABASE_URL by hand (documented separately).
  *
  * Writes configuration to one archon-owned env file, chosen by --scope:
  *   - 'home'    (default)  → ~/.archon/.env
@@ -38,7 +40,8 @@ import { join, dirname } from 'path';
 import { copyArchonSkill } from './skill';
 import { homedir } from 'os';
 import { randomBytes } from 'crypto';
-import { spawn, execSync, type ChildProcess } from 'child_process';
+import { spawn, execSync, spawnSync, type ChildProcess } from 'child_process';
+import { execFileAsync } from '@archon/git';
 import { getRegisteredProviders } from '@archon/providers';
 import {
   getArchonEnvPath as pathsGetArchonEnvPath,
@@ -50,10 +53,6 @@ import {
 // =============================================================================
 
 interface SetupConfig {
-  database: {
-    type: 'sqlite' | 'postgresql';
-    url?: string;
-  };
   ai: {
     claude: boolean;
     claudeAuthType?: 'global' | 'apiKey' | 'oauthToken';
@@ -70,12 +69,10 @@ interface SetupConfig {
     github: boolean;
     telegram: boolean;
     slack: boolean;
-    discord: boolean;
   };
   github?: GitHubConfig;
   telegram?: TelegramConfig;
   slack?: SlackConfig;
-  discord?: DiscordConfig;
   botDisplayName: string;
 }
 
@@ -97,11 +94,6 @@ interface SlackConfig {
   allowedUserIds: string;
 }
 
-interface DiscordConfig {
-  botToken: string;
-  allowedUserIds: string;
-}
-
 interface CodexTokens {
   idToken: string;
   accessToken: string;
@@ -110,14 +102,12 @@ interface CodexTokens {
 }
 
 interface ExistingConfig {
-  hasDatabase: boolean;
   hasClaude: boolean;
   hasCodex: boolean;
   platforms: {
     github: boolean;
     telegram: boolean;
     slack: boolean;
-    discord: boolean;
   };
 }
 
@@ -343,7 +333,6 @@ export function checkExistingConfig(envPath?: string): ExistingConfig | null {
   const content = readFileSync(path, 'utf-8');
 
   return {
-    hasDatabase: hasEnvValue(content, 'DATABASE_URL'),
     hasClaude:
       hasEnvValue(content, 'CLAUDE_API_KEY') ||
       hasEnvValue(content, 'CLAUDE_CODE_OAUTH_TOKEN') ||
@@ -357,7 +346,6 @@ export function checkExistingConfig(envPath?: string): ExistingConfig | null {
       github: hasEnvValue(content, 'GITHUB_TOKEN') || hasEnvValue(content, 'GH_TOKEN'),
       telegram: hasEnvValue(content, 'TELEGRAM_BOT_TOKEN'),
       slack: hasEnvValue(content, 'SLACK_BOT_TOKEN') && hasEnvValue(content, 'SLACK_APP_TOKEN'),
-      discord: hasEnvValue(content, 'DISCORD_BOT_TOKEN'),
     },
   };
 }
@@ -365,53 +353,6 @@ export function checkExistingConfig(envPath?: string): ExistingConfig | null {
 // =============================================================================
 // Data Collection Functions
 // =============================================================================
-
-/**
- * Collect database configuration
- */
-async function collectDatabaseConfig(): Promise<SetupConfig['database']> {
-  const dbType = await select({
-    message: 'Which database do you want to use?',
-    options: [
-      {
-        value: 'sqlite',
-        label: 'SQLite (default - no setup needed)',
-        hint: 'Recommended for single user',
-      },
-      { value: 'postgresql', label: 'PostgreSQL', hint: 'For server deployments' },
-    ],
-  });
-
-  if (isCancel(dbType)) {
-    cancel('Setup cancelled.');
-    process.exit(0);
-  }
-
-  if (dbType === 'postgresql') {
-    const url = await text({
-      message: 'Enter your PostgreSQL connection string:',
-      placeholder: 'postgresql://user:pass@localhost:5432/archon',
-      validate: value => {
-        if (!value) {
-          return 'Connection string is required';
-        }
-        if (!value.startsWith('postgresql://') && !value.startsWith('postgres://')) {
-          return 'Must be a valid PostgreSQL URL (postgresql:// or postgres://)';
-        }
-        return undefined;
-      },
-    });
-
-    if (isCancel(url)) {
-      cancel('Setup cancelled.');
-      process.exit(0);
-    }
-
-    return { type: 'postgresql', url };
-  }
-
-  return { type: 'sqlite' };
-}
 
 /**
  * Try to read Codex tokens from ~/.codex/auth.json
@@ -463,12 +404,28 @@ function tryReadCodexAuth(): CodexTokens | null {
  * Returns undefined if the user declines to configure (setup continues; the
  * compiled binary will error with clear instructions on first Claude query).
  */
+/**
+ * Try to spawn the Claude binary with `--version` to confirm it actually runs.
+ * Returns true on success, false on any spawn or non-zero exit. Bounded to 5s
+ * so a hung process can't stall setup.
+ */
+async function probeClaudeBinarySpawns(path: string): Promise<boolean> {
+  try {
+    await execFileAsync(path, ['--version'], { timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function collectClaudeBinaryPath(): Promise<string | undefined> {
   const detected = detectClaudeExecutablePath();
 
   if (detected) {
+    const spawnsOk = await probeClaudeBinarySpawns(detected);
+    const suffix = spawnsOk ? '(spawns OK)' : '(could not spawn — verify it works)';
     const useDetected = await confirm({
-      message: `Found Claude Code at ${detected}. Write this to CLAUDE_BIN_PATH?`,
+      message: `Found Claude Code at ${detected} ${suffix}. Write this to CLAUDE_BIN_PATH?`,
       initialValue: true,
     });
     if (isCancel(useDetected)) {
@@ -508,6 +465,14 @@ async function collectClaudeBinaryPath(): Promise<string | undefined> {
   if (!existsSync(trimmed)) {
     log.warning(
       `Path does not exist: ${trimmed}. Saving anyway — the compiled binary will error on first use until this is correct.`
+    );
+    return trimmed;
+  }
+
+  const spawnsOk = await probeClaudeBinarySpawns(trimmed);
+  if (!spawnsOk) {
+    log.warning(
+      `Could not spawn ${trimmed} --version. Saving anyway — verify the binary works (try running it directly).`
     );
   }
   return trimmed;
@@ -884,12 +849,12 @@ After upgrading, run 'archon setup' again.`,
  */
 async function collectPlatforms(): Promise<SetupConfig['platforms']> {
   const platforms = await multiselect({
-    message: 'Which platforms do you want to connect? (↑↓ navigate, space select, enter confirm)',
+    message:
+      'Which chat adapters do you want to connect? (all optional — Archon works as CLI + skill without any)\n(↑↓ navigate, space select, enter confirm)',
     options: [
       { value: 'github', label: 'GitHub', hint: 'Respond to issues/PRs via webhooks' },
       { value: 'telegram', label: 'Telegram', hint: 'Chat bot via BotFather' },
       { value: 'slack', label: 'Slack', hint: 'Workspace app with Socket Mode' },
-      { value: 'discord', label: 'Discord', hint: 'Server bot' },
     ],
     required: false,
   });
@@ -903,7 +868,6 @@ async function collectPlatforms(): Promise<SetupConfig['platforms']> {
     github: platforms.includes('github'),
     telegram: platforms.includes('telegram'),
     slack: platforms.includes('slack'),
-    discord: platforms.includes('discord'),
   };
 }
 
@@ -937,6 +901,38 @@ async function collectGitHubConfig(): Promise<GitHubConfig> {
   if (isCancel(token)) {
     cancel('Setup cancelled.');
     process.exit(0);
+  }
+
+  // Probe `gh` CLI auth — workflows that shell out to `gh` (e.g. `gh issue
+  // create`, `gh pr edit`) need this even if the PAT is set, because they call
+  // the local `gh` binary, not the API directly.
+  const ghSpin = spinner();
+  ghSpin.start('Checking gh CLI authentication...');
+  let ghAuthOk = false;
+  try {
+    await execFileAsync('gh', ['auth', 'status'], { timeout: 10_000 });
+    ghAuthOk = true;
+    ghSpin.stop('gh CLI is authenticated');
+  } catch {
+    ghSpin.stop('gh CLI is not authenticated');
+  }
+
+  if (!ghAuthOk) {
+    log.warning(
+      'gh auth status failed. Workflows using `gh` shell commands will fail until you authenticate.\n' +
+        'Run: gh auth login'
+    );
+    // gh auth login is an interactive OAuth flow — only offer it from a TTY.
+    if (process.stdout.isTTY) {
+      const runGhLogin = await confirm({
+        message: 'Run `gh auth login` now?',
+        initialValue: true,
+      });
+      if (!isCancel(runGhLogin) && runGhLogin) {
+        // spawnSync with inherited stdio so the OAuth prompt reaches the terminal.
+        spawnSync('gh', ['auth', 'login'], { stdio: 'inherit' });
+      }
+    }
   }
 
   const allowedUsers = await text({
@@ -995,17 +991,22 @@ async function collectGitHubConfig(): Promise<GitHubConfig> {
  */
 async function collectTelegramConfig(): Promise<TelegramConfig> {
   note(
+    'SECURITY: Telegram bots are public by default — anyone can DM your bot.\n' +
+      'Set TELEGRAM_ALLOWED_USER_IDS to restrict access to your user ID only.\n\n' +
+      'To find your user ID:\n' +
+      '1. Open Telegram and search for @userinfobot\n' +
+      '2. Send any message — it replies with your user ID (a number)',
+    'Telegram Security'
+  );
+
+  note(
     'Telegram Bot Setup\n\n' +
       'Step 1: Create your bot\n' +
       '1. Open Telegram and search for @BotFather\n' +
       '2. Send /newbot\n' +
       '3. Choose a display name (e.g., "My Archon Bot")\n' +
       '4. Choose a username (must end in "bot")\n' +
-      '5. Copy the token BotFather gives you\n\n' +
-      'Step 2: Get your user ID\n' +
-      '1. Search for @userinfobot on Telegram\n' +
-      '2. Send any message\n' +
-      '3. It will reply with your user ID (a number)',
+      '5. Copy the token BotFather gives you',
     'Telegram Setup'
   );
 
@@ -1024,14 +1025,24 @@ async function collectTelegramConfig(): Promise<TelegramConfig> {
     process.exit(0);
   }
 
+  // Do NOT set required: true — clack's text() blocks the enter key when
+  // required is true and the value is empty, which traps the user. Validate
+  // post-hoc with a warning instead.
   const allowedUserIds = await text({
-    message: 'Enter allowed Telegram user IDs (comma-separated, or leave empty for all):',
+    message: 'Enter allowed Telegram user IDs (comma-separated):',
     placeholder: '123456789,987654321',
   });
 
   if (isCancel(allowedUserIds)) {
     cancel('Setup cancelled.');
     process.exit(0);
+  }
+
+  if (!allowedUserIds?.trim()) {
+    log.warning(
+      'No allowlist set — your Telegram bot will accept messages from ANYONE.\n' +
+        'Add TELEGRAM_ALLOWED_USER_IDS to ~/.archon/.env after setup to restrict access.'
+    );
   }
 
   return {
@@ -1111,58 +1122,6 @@ async function collectSlackConfig(): Promise<SlackConfig> {
 }
 
 /**
- * Collect Discord credentials
- */
-async function collectDiscordConfig(): Promise<DiscordConfig> {
-  note(
-    'Discord Bot Setup\n\n' +
-      '1. Go to discord.com/developers/applications\n' +
-      '2. Click "New Application" and name it\n' +
-      '3. Go to "Bot" in sidebar:\n' +
-      '   - Click "Reset Token" and copy it\n' +
-      '   - Enable "MESSAGE CONTENT INTENT"\n' +
-      '4. Go to "OAuth2" -> "URL Generator":\n' +
-      '   - Select scope: bot\n' +
-      '   - Select permissions: Send Messages, Read Message History\n' +
-      '   - Open generated URL to add bot to your server\n\n' +
-      'Get your user ID:\n' +
-      '- Discord Settings -> Advanced -> Enable Developer Mode\n' +
-      '- Right-click yourself -> Copy User ID',
-    'Discord Setup'
-  );
-
-  const botToken = await password({
-    message: 'Enter your Discord Bot Token:',
-    validate: value => {
-      if (!value || value.length < 50) {
-        return 'Please enter a valid Discord bot token';
-      }
-      return undefined;
-    },
-  });
-
-  if (isCancel(botToken)) {
-    cancel('Setup cancelled.');
-    process.exit(0);
-  }
-
-  const allowedUserIds = await text({
-    message: 'Enter allowed Discord user IDs (comma-separated, or leave empty for all):',
-    placeholder: '123456789012345678,987654321098765432',
-  });
-
-  if (isCancel(allowedUserIds)) {
-    cancel('Setup cancelled.');
-    process.exit(0);
-  }
-
-  return {
-    botToken,
-    allowedUserIds: allowedUserIds || '',
-  };
-}
-
-/**
  * Collect bot display name
  */
 async function collectBotDisplayName(): Promise<string> {
@@ -1213,11 +1172,8 @@ export function generateEnvContent(config: SetupConfig): string {
 
   // Database
   lines.push('# Database');
-  if (config.database.type === 'postgresql' && config.database.url) {
-    lines.push(`DATABASE_URL=${config.database.url}`);
-  } else {
-    lines.push('# Using SQLite (default) - no DATABASE_URL needed');
-  }
+  lines.push('# Using SQLite (default) - no DATABASE_URL needed');
+  lines.push('# Set DATABASE_URL=postgresql://... to use PostgreSQL instead.');
   lines.push('');
 
   // AI Assistants
@@ -1290,17 +1246,6 @@ export function generateEnvContent(config: SetupConfig): string {
       lines.push(`SLACK_ALLOWED_USER_IDS=${config.slack.allowedUserIds}`);
     }
     lines.push('SLACK_STREAMING_MODE=batch');
-    lines.push('');
-  }
-
-  // Discord
-  if (config.platforms.discord && config.discord) {
-    lines.push('# Discord');
-    lines.push(`DISCORD_BOT_TOKEN=${config.discord.botToken}`);
-    if (config.discord.allowedUserIds) {
-      lines.push(`DISCORD_ALLOWED_USER_IDS=${config.discord.allowedUserIds}`);
-    }
-    lines.push('DISCORD_STREAMING_MODE=batch');
     lines.push('');
   }
 
@@ -1648,10 +1593,8 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
     if (existing.platforms.github) configuredPlatforms.push('GitHub');
     if (existing.platforms.telegram) configuredPlatforms.push('Telegram');
     if (existing.platforms.slack) configuredPlatforms.push('Slack');
-    if (existing.platforms.discord) configuredPlatforms.push('Discord');
 
     const summary = [
-      `Database: ${existing.hasDatabase ? 'PostgreSQL' : 'SQLite'}`,
       `Claude: ${existing.hasClaude ? 'Configured' : 'Not configured'}`,
       `Codex: ${existing.hasCodex ? 'Configured' : 'Not configured'}`,
       `Platforms: ${configuredPlatforms.length > 0 ? configuredPlatforms.join(', ') : 'None'}`,
@@ -1687,7 +1630,6 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
 
     // Read existing config values - for simplicity, start with defaults and merge
     config = {
-      database: { type: 'sqlite' },
       ai: {
         claude: existing?.hasClaude ?? false,
         codex: existing?.hasCodex ?? false,
@@ -1697,7 +1639,6 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
         github: existing?.platforms.github ?? false,
         telegram: existing?.platforms.telegram ?? false,
         slack: existing?.platforms.slack ?? false,
-        discord: existing?.platforms.discord ?? false,
       },
       botDisplayName: 'Archon',
     };
@@ -1713,7 +1654,6 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
       github: config.platforms.github || newPlatforms.github,
       telegram: config.platforms.telegram || newPlatforms.telegram,
       slack: config.platforms.slack || newPlatforms.slack,
-      discord: config.platforms.discord || newPlatforms.discord,
     };
 
     // Collect credentials for new platforms only
@@ -1726,17 +1666,12 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
     if (newPlatforms.slack && !existing?.platforms.slack) {
       config.slack = await collectSlackConfig();
     }
-    if (newPlatforms.discord && !existing?.platforms.discord) {
-      config.discord = await collectDiscordConfig();
-    }
   } else {
-    // Fresh or update mode - collect everything
-    const database = await collectDatabaseConfig();
+    // Fresh or update mode - collect everything (SQLite is implicit; no DB prompt)
     const ai = await collectAIConfig();
     const platforms = await collectPlatforms();
 
     config = {
-      database,
       ai,
       platforms,
       botDisplayName: 'Archon',
@@ -1751,9 +1686,6 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
     }
     if (platforms.slack) {
       config.slack = await collectSlackConfig();
-    }
-    if (platforms.discord) {
-      config.discord = await collectDiscordConfig();
     }
 
     // Collect bot display name
@@ -1873,7 +1805,6 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
   if (config.platforms.github) configuredPlatforms.push('GitHub');
   if (config.platforms.telegram) configuredPlatforms.push('Telegram');
   if (config.platforms.slack) configuredPlatforms.push('Slack');
-  if (config.platforms.discord) configuredPlatforms.push('Discord');
 
   const aiConfigured: string[] = [];
   if (config.ai.claude) {
@@ -1890,10 +1821,9 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
   }
 
   const summaryLines = [
-    `Database: ${config.database.type === 'postgresql' ? 'PostgreSQL' : 'SQLite (default)'}`,
     `AI: ${aiConfigured.length > 0 ? aiConfigured.join(', ') : 'None configured'}`,
     `Default: ${config.ai.defaultAssistant}`,
-    `Platforms: ${configuredPlatforms.length > 0 ? configuredPlatforms.join(', ') : 'None'}`,
+    `Platforms: ${configuredPlatforms.length > 0 ? configuredPlatforms.join(', ') : 'None (CLI + skill only)'}`,
     '',
     `File written (${scope} scope):`,
     `  ${writeResult.targetPath}`,
@@ -1924,5 +1854,25 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
     'Additional Options'
   );
 
-  outro('Setup complete! Run `archon version` to verify.');
+  // Update instructions — always shown so users know how to upgrade.
+  note(
+    'To update Archon:\n' +
+      '  Homebrew:  brew upgrade coleam00/archon/archon\n' +
+      '  curl:      curl -fsSL https://raw.githubusercontent.com/coleam00/Archon/main/scripts/install.sh | bash\n' +
+      '  Docker:    docker pull ghcr.io/coleam00/archon:latest',
+    'Update Instructions'
+  );
+
+  // Offer to verify with `archon doctor`. Failures inside doctor don't abort
+  // setup — the wizard already wrote the env file successfully.
+  const runDoctor = await confirm({
+    message: 'Run `archon doctor` now to verify your setup?',
+    initialValue: true,
+  });
+  if (!isCancel(runDoctor) && runDoctor) {
+    const { doctorCommand } = await import('./doctor');
+    await doctorCommand();
+  }
+
+  outro('Setup complete!');
 }

--- a/packages/docs-web/src/content/docs/getting-started/overview.md
+++ b/packages/docs-web/src/content/docs/getting-started/overview.md
@@ -304,6 +304,7 @@ archon workflow run <name> --cwd /path/to/repo "<message>"
 |---------|-------------|
 | `archon chat <message>` | Send a message to the orchestrator |
 | `archon setup` | Interactive setup wizard for credentials and config |
+| `archon doctor` | Verify your setup (Claude binary, gh auth, DB, adapters) |
 | `archon workflow list` | List available workflows |
 | `archon workflow run <name> [msg]` | Run a workflow |
 | `archon workflow status` | Show running workflows |

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -84,6 +84,18 @@ archon setup --spawn              # open in a new terminal window
 
 **Write safety**: `archon setup` never writes to `<cwd>/.env` — that file belongs to you. The wizard always targets one archon-owned file chosen by `--scope`, merges into existing content (so user-added keys survive), and writes a timestamped backup before every rewrite (e.g. `~/.archon/.env.archon-backup-2026-04-20T09-28-11-000Z`).
 
+### `doctor`
+
+Verify your Archon setup. Runs a checklist of common failure points: Claude binary spawn, gh CLI auth, database reachability, workspace writability, bundled defaults, and adapter token pings (Slack/Telegram, best-effort).
+
+```bash
+archon doctor
+```
+
+Exit code 0 if all checks pass or are skipped; 1 if any critical check fails. Adapter pings degrade to `skip` on network errors — a flaky connection does not flip the result red.
+
+Also runs automatically at the end of `archon setup` (optional).
+
 ### `workflow list`
 
 List workflows available in target directory.

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -50,7 +50,7 @@ archon workflow run plan --cwd /path/to/repo --branch feature-auth "Add OAuth su
 archon workflow run assist --cwd /path/to/repo --no-worktree "Quick question"
 ```
 
-**Note:** Workflow and isolation commands require running from within a git repository. Running from subdirectories automatically resolves to the repo root. The `version`, `help`, `chat`, `setup`, and `serve` commands work anywhere.
+**Note:** Workflow and isolation commands require running from within a git repository. Running from subdirectories automatically resolves to the repo root. The `version`, `help`, `chat`, `setup`, `serve`, and `doctor` commands work anywhere.
 
 ## Commands
 

--- a/packages/docs-web/src/content/docs/reference/troubleshooting.md
+++ b/packages/docs-web/src/content/docs/reference/troubleshooting.md
@@ -311,7 +311,7 @@ assistants:
     claudeBinaryPath: /absolute/path/to/claude
 ```
 
-`archon setup` auto-detects and writes `CLAUDE_BIN_PATH` for you. Docker users do not need to do anything — the image pre-sets the variable.
+`archon setup` auto-detects and writes `CLAUDE_BIN_PATH` for you. After setup, run `archon doctor` to confirm the binary actually spawns. Docker users do not need to do anything — the image pre-sets the variable.
 
 See the [AI Assistants → Binary path configuration](/getting-started/ai-assistants/#binary-path-configuration-compiled-binaries-only) guide for the full install matrix.
 

--- a/scripts/check-bundled-skill.ts
+++ b/scripts/check-bundled-skill.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env bun
+/**
+ * Verifies that packages/cli/src/bundled-skill.ts embeds every file from
+ * .claude/skills/archon/. The bundled-skill.ts file is hand-maintained
+ * (uses Bun's `with { type: 'text' }` import attributes, which the
+ * generator approach in scripts/generate-bundled-defaults.ts cannot
+ * reproduce for the binary build). This script is the safety net.
+ *
+ * Usage:
+ *   bun run scripts/check-bundled-skill.ts          # exit 1 if missing
+ *   bun run scripts/check-bundled-skill.ts --check  # exit 2 if missing (CI)
+ *
+ * Exit codes:
+ *   0  bundled-skill.ts covers every file under .claude/skills/archon/
+ *   1  missing files (default mode)
+ *   2  missing files (--check mode, used by `bun run validate`)
+ */
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative, resolve } from 'path';
+
+const REPO_ROOT = resolve(import.meta.dir, '..');
+const SKILL_ROOT = join(REPO_ROOT, '.claude', 'skills', 'archon');
+const BUNDLED_SKILL_PATH = join(REPO_ROOT, 'packages', 'cli', 'src', 'bundled-skill.ts');
+
+const CHECK_ONLY = process.argv.includes('--check');
+
+function listSkillFiles(dir: string, base: string = dir): string[] {
+  return readdirSync(dir).flatMap(entry => {
+    const full = join(dir, entry);
+    return statSync(full).isDirectory() ? listSkillFiles(full, base) : [relative(base, full)];
+  });
+}
+
+const skillFiles = listSkillFiles(SKILL_ROOT).sort();
+const bundledSrc = readFileSync(BUNDLED_SKILL_PATH, 'utf-8');
+const missing = skillFiles.filter(f => !bundledSrc.includes(f));
+
+if (missing.length > 0) {
+  console.error(
+    `bundled-skill.ts is missing these files:\n${missing.map(f => `  - ${f}`).join('\n')}\n\n` +
+      `Add a corresponding import + BUNDLED_SKILL_FILES entry to\n  ${relative(REPO_ROOT, BUNDLED_SKILL_PATH)}`
+  );
+  process.exit(CHECK_ONLY ? 2 : 1);
+}
+
+console.log(`bundled-skill.ts is up to date (${skillFiles.length} files).`);

--- a/scripts/check-bundled-skill.ts
+++ b/scripts/check-bundled-skill.ts
@@ -33,6 +33,9 @@ function listSkillFiles(dir: string, base: string = dir): string[] {
 
 const skillFiles = listSkillFiles(SKILL_ROOT).sort();
 const bundledSrc = readFileSync(BUNDLED_SKILL_PATH, 'utf-8');
+// NOTE: This is a substring check — a filename that appears in a comment or
+// stale string literal will also pass. It's a safety net against missing imports,
+// not a structural verification of the export map.
 const missing = skillFiles.filter(f => !bundledSrc.includes(f));
 
 if (missing.length > 0) {


### PR DESCRIPTION
## Summary

- **Problem**: `bundled-skill.ts` only embeds 18 of 21 skill files; no CI check catches regressions. The setup wizard presents a database prompt (irrelevant — SQLite only), Discord (community-gated), and all platform adapters as mandatory, inflating setup from ~2 required steps to 8+. No `archon doctor` command exists.
- **Why it matters**: Binary users silently get an incomplete skill. New users abandon setup before finishing because the flow looks overwhelming. There's no canonical "is my setup healthy?" answer after setup.
- **What changed**: Fixed `bundled-skill.ts` to embed all 21 files + added `check:bundled-skill` CI guard. Rewrote `archon setup` to remove DB step, remove Discord, make each adapter skippable with explicit "Archon works without this" messaging, validate Claude binary via spawn test, add `gh auth status` check for GitHub, add security note for Telegram, and show update instructions + doctor offer at the end. Added `archon doctor` command with a green/red checklist.
- **What did not change**: Docs reframe (README, installation.md, overview.md) is scoped to a separate PR per the issue. PostgreSQL setup wizard, GitHub App support, and per-platform webhook automation are explicitly out of scope.

## UX Journey

### Before

```
archon setup
│
├─ Step 1: AI provider (Claude / Codex)           ← no spawn validation
├─ Step 2: Database (SQLite vs Postgres)           ← irrelevant, confusing
├─ Step 3: Platform multiselect (GitHub/Telegram/Slack/Discord)
│          └─ Feels mandatory; no "skip = OK" messaging
├─ Step 4: Per-platform credential collection
│          └─ Telegram: no security warning on empty allowlist
│          └─ GitHub: no gh auth status check
├─ Step 5: Skill copy (optional)
└─ outro "Setup complete!"

PAIN POINTS:
- CLAUDE_BIN_PATH saved unverified → fails silently at first workflow run
- Telegram bot is wide open to the public if user leaves allowlist empty
- No "did this work?" answer; no update path shown
- Binary users: bundled-skill.ts missing 3 files (good-practices.md,
  parameter-matrix.md, troubleshooting.md)
- No archon doctor command
```

### After

```
archon setup
│
├─ Step 1: AI provider — validates binary via spawn test before saving
├─ Step 2: GitHub (skippable) — runs gh auth status, offers gh auth login
├─ Step 3: Slack (skippable) — "Archon works as CLI + skill without this"
├─ Step 4: Telegram (skippable) — security note + allowlist warning if empty
├─ Step 5: Skill copy (skippable)
├─ Step 6: [Update Instructions note — always shown]
├─ Step 7: Offer to run archon doctor
└─ outro "Setup complete!"

archon doctor  (new command, re-runnable at any time)
├─ ✓ Claude binary: ~/.local/bin/claude (spawns OK)
├─ ✓ gh CLI: authenticated (or ○ skipped — no GITHUB_TOKEN)
├─ ✓ Database: reachable (SQLite at ~/.archon/archon.db)
├─ ✓ Workspace: ~/.archon/ is writable
├─ ✓ Bundled defaults: workflows + commands loaded
└─ ○ Slack/Telegram: no tokens set (skipped)

bundled-skill.ts: 21/21 files embedded; CI check prevents regression
```

## Architecture Diagram

### Before

```
packages/cli/src/
├─ bundled-skill.ts        (18/21 files — missing 3)
├─ commands/
│   └─ setup.ts            (wizard with DB step + Discord + no spawn validation)
└─ cli.ts                  (no doctor case)

scripts/
└─ generate-bundled-defaults.ts   (check:bundled guard for defaults)
    (no equivalent for bundled-skill)
```

### After

```
packages/cli/src/
├─ bundled-skill.ts        [~] (21/21 files)
├─ commands/
│   ├─ setup.ts            [~] (no DB, no Discord, spawn-validate, gh auth, Telegram note, doctor offer)
│   ├─ doctor.ts           [+] (new archon doctor command)
│   └─ doctor.test.ts      [+] (tests)
└─ cli.ts                  [~] (doctor case registered, noGitCommands updated)

scripts/
├─ generate-bundled-defaults.ts   (unchanged)
└─ check-bundled-skill.ts  [+] (mirrors check:bundled pattern for bundled-skill.ts)

package.json (root)        [~] (check:bundled-skill added, validate updated)
packages/cli/package.json  [~] (doctor.test.ts added to test batch)
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `cli.ts` | `commands/doctor.ts` | **new** | Dynamic import `case 'doctor':` |
| `commands/setup.ts` | `commands/doctor.ts` | **new** | Dynamic import for doctor offer at wizard end |
| `commands/doctor.ts` | `@archon/paths` | **new** | `BUNDLED_IS_BINARY`, `getArchonHome` |
| `commands/doctor.ts` | `@archon/git` | **new** | `execFileAsync` for binary + gh probes |
| `commands/doctor.ts` | `@archon/core/db` | **new** | Lazy import for DB reachability check |
| `commands/setup.ts` | `@archon/git` | **new** | `execFileAsync` for spawn test + gh auth |
| `scripts/check-bundled-skill.ts` | `.claude/skills/archon/` | **new** | Reads skill files to verify coverage |
| `package.json` validate script | `check-bundled-skill` | **new** | Added to pipeline |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `cli`
- Module: `cli:setup`, `cli:doctor`, `cli:bundled-skill`

## Change Metadata

- Change type: `feature`
- Primary scope: `cli`

## Linked Issue

- Closes #1494

## Validation Evidence (required)

```bash
bun run validate
```

All five checks passed (EXIT=0):

| Check | Result |
|-------|--------|
| `bun run check:bundled` | ✅ 36 commands, 20 workflows up to date |
| `bun run check:bundled-skill` | ✅ 21 files up to date |
| `bun run type-check` (all 10 packages) | ✅ no errors |
| `bun run lint --max-warnings 0` | ✅ 0 errors, 0 warnings |
| `bun run format:check` | ✅ all files formatted |
| `bun run test` (all packages) | ✅ 131 CLI tests pass, 0 failures |

Smoke test:
```bash
bun --cwd packages/cli src/cli.ts doctor
# Output: 5 ✓ checks, 4 ○ skips, 0 ✗ failures
```

- Evidence provided: full `bun run validate` run with exit 0; smoke test of `archon doctor` in dev mode
- No commands skipped

## Security Impact (required)

- New permissions/capabilities? **Yes** — `archon doctor` makes optional network probes (Slack `auth.test`, Telegram `getMe`) using existing configured tokens. No new token collection.
- New external network calls? **Yes** — `archon doctor` optionally pings Slack/Telegram APIs (best-effort, degrade to `skip` on failure; only run when tokens are already in env)
- Secrets/tokens handling changed? **No** — tokens read from env only, never logged
- File system access scope changed? **No** — doctor writes a temp file in `ARCHON_HOME` then immediately deletes it (writable check)
- Mitigation: All adapter pings are guarded by `Promise.allSettled` — network failures produce `skip` not `fail`. `gh auth login` is TTY-gated (`process.stdout.isTTY`) to prevent hangs in CI.

## Compatibility / Migration

- Backward compatible? **Yes** — wizard changes are purely UX (fewer prompts, not different behavior). Existing `.env` files are untouched.
- Config/env changes? **No** — no new env vars required. `check:bundled-skill` is a new script but not user-facing config.
- Database migration needed? **No**

## Human Verification (required)

- Verified scenarios: `bun run cli doctor` in dev context (5 ✓ checks, 4 ○ skips); full `bun run validate` suite passing; type-check across all 10 packages
- Edge cases checked: `BUNDLED_IS_BINARY = false` → Claude check skips cleanly; `GITHUB_TOKEN` not set → gh auth check skips; empty Telegram allowlist path in setup confirmed to show warning via code review
- What was not verified: interactive `archon setup` end-to-end in a fresh install (requires a real binary build); `gh auth login` interactive flow (TTY-gated code path)

## Side Effects / Blast Radius (required)

- Affected subsystems: `@archon/cli` (setup, doctor, bundled-skill), root `package.json`, `scripts/`
- Potential unintended effects: `bun run validate` now takes slightly longer due to `check:bundled-skill` step (negligible — file scan only). Removing `collectDatabaseConfig` from setup means any code path that relied on `SetupConfig.database` will fail to compile — all such paths were updated.
- Guardrails: `check:bundled-skill` in CI catches any future `bundled-skill.ts` drift immediately

## Rollback Plan (required)

- Fast rollback: `git revert b1c49a53` — reverts all changes in this PR atomically
- Feature flags: none — no feature flags used
- Observable failure symptoms: `archon setup` showing database prompt or Discord = rollback needed; `check:bundled-skill` exiting 2 = bundled-skill.ts out of sync

## Risks and Mitigations

- Risk: `setup.ts` type errors after removing `database` from `SetupConfig` cascade to `generateEnvContent` and `checkExistingConfig`
  - Mitigation: All downstream references updated; `bun run type-check` passes clean across all 10 packages

- Risk: `spawnSync('gh', ['auth', 'login'])` hangs in non-TTY environments (CI, piped shells)
  - Mitigation: Offer gated on `process.stdout.isTTY` — the `gh auth login` call is never reached in non-TTY contexts

- Risk: Adapter pings (Slack, Telegram) fail in environments with restricted outbound network access
  - Mitigation: All pings use `Promise.allSettled`; network errors produce `skip` not `fail` in doctor output


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `archon doctor` command to diagnose environment setup (Claude binary, authentication, database, adapters).
  * Enhanced setup wizard with binary validation and GitHub authentication checks.
  * Setup wizard now auto-generates project configuration when missing.
  * Expanded bundled resources with additional reference guides.

* **Documentation**
  * Updated CLI documentation with `doctor` command details.
  * Updated troubleshooting guide with diagnostic reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->