### PR TITLE
fix(pi): surface SDK error messages and cap concurrency to stop cascade failures

### DIFF
--- a/packages/providers/src/community/pi/config.test.ts
+++ b/packages/providers/src/community/pi/config.test.ts
@@ -160,4 +160,17 @@ describe('parsePiConfig', () => {
       env: { PLANNOTATOR_REMOTE: '1' },
     });
   });
+
+  test('parses maxConcurrent as positive integer', () => {
+    expect(parsePiConfig({ maxConcurrent: 4 })).toEqual({ maxConcurrent: 4 });
+    expect(parsePiConfig({ maxConcurrent: 1 })).toEqual({ maxConcurrent: 1 });
+  });
+
+  test('drops invalid maxConcurrent values silently', () => {
+    expect(parsePiConfig({ maxConcurrent: 0 })).toEqual({});
+    expect(parsePiConfig({ maxConcurrent: -1 })).toEqual({});
+    expect(parsePiConfig({ maxConcurrent: 1.5 })).toEqual({});
+    expect(parsePiConfig({ maxConcurrent: 'four' })).toEqual({});
+    expect(parsePiConfig({ maxConcurrent: null })).toEqual({});
+  });
 });

--- a/packages/providers/src/community/pi/config.test.ts
+++ b/packages/providers/src/community/pi/config.test.ts
@@ -173,4 +173,18 @@ describe('parsePiConfig', () => {
     expect(parsePiConfig({ maxConcurrent: 'four' })).toEqual({});
     expect(parsePiConfig({ maxConcurrent: null })).toEqual({});
   });
+
+  test('combines maxConcurrent with model and other fields', () => {
+    expect(
+      parsePiConfig({
+        model: 'google/gemini-2.5-pro',
+        maxConcurrent: 4,
+        enableExtensions: true,
+      })
+    ).toEqual({
+      model: 'google/gemini-2.5-pro',
+      maxConcurrent: 4,
+      enableExtensions: true,
+    });
+  });
 });

--- a/packages/providers/src/community/pi/config.ts
+++ b/packages/providers/src/community/pi/config.ts
@@ -51,5 +51,13 @@ export function parsePiConfig(raw: Record<string, unknown>): PiProviderDefaults 
     }
   }
 
+  if (
+    typeof raw.maxConcurrent === 'number' &&
+    Number.isInteger(raw.maxConcurrent) &&
+    raw.maxConcurrent > 0
+  ) {
+    result.maxConcurrent = raw.maxConcurrent;
+  }
+
   return result;
 }

--- a/packages/providers/src/community/pi/event-bridge.test.ts
+++ b/packages/providers/src/community/pi/event-bridge.test.ts
@@ -178,13 +178,24 @@ describe('buildResultChunk', () => {
     }
   });
 
-  test('flags isError for stopReason=error', () => {
+  test('flags isError for stopReason=error and surfaces errorMessage', () => {
     const chunk = buildResultChunk([
       { role: 'assistant', usage, stopReason: 'error', errorMessage: 'auth', content: [] },
     ]);
     if (chunk.type === 'result') {
       expect(chunk.isError).toBe(true);
       expect(chunk.errorSubtype).toBe('error');
+      expect(chunk.errors).toEqual(['auth']);
+    }
+  });
+
+  test('does not populate errors when errorMessage is absent', () => {
+    const chunk = buildResultChunk([
+      { role: 'assistant', usage, stopReason: 'error', content: [] },
+    ]);
+    if (chunk.type === 'result') {
+      expect(chunk.isError).toBe(true);
+      expect(chunk.errors).toBeUndefined();
     }
   });
 

--- a/packages/providers/src/community/pi/event-bridge.test.ts
+++ b/packages/providers/src/community/pi/event-bridge.test.ts
@@ -189,13 +189,22 @@ describe('buildResultChunk', () => {
     }
   });
 
-  test('does not populate errors when errorMessage is absent', () => {
-    const chunk = buildResultChunk([
+  test('does not populate errors when errorMessage is absent or empty', () => {
+    // undefined errorMessage
+    const chunk1 = buildResultChunk([
       { role: 'assistant', usage, stopReason: 'error', content: [] },
     ]);
-    if (chunk.type === 'result') {
-      expect(chunk.isError).toBe(true);
-      expect(chunk.errors).toBeUndefined();
+    if (chunk1.type === 'result') {
+      expect(chunk1.isError).toBe(true);
+      expect(chunk1.errors).toBeUndefined();
+    }
+    // empty string — also falsy, also excluded from errors[]
+    const chunk2 = buildResultChunk([
+      { role: 'assistant', usage, stopReason: 'error', errorMessage: '', content: [] },
+    ]);
+    if (chunk2.type === 'result') {
+      expect(chunk2.isError).toBe(true);
+      expect(chunk2.errors).toBeUndefined();
     }
   });
 

--- a/packages/providers/src/community/pi/event-bridge.ts
+++ b/packages/providers/src/community/pi/event-bridge.ts
@@ -146,7 +146,16 @@ export function buildResultChunk(messages: readonly unknown[]): MessageChunk {
     tokens,
     ...(tokens.cost !== undefined ? { cost: tokens.cost } : {}),
     ...(last.stopReason ? { stopReason: last.stopReason } : {}),
-    ...(isError ? { isError: true, errorSubtype: last.stopReason } : {}),
+    ...(isError
+      ? {
+          isError: true,
+          errorSubtype: last.stopReason,
+          // Surfacing errorMessage in errors[] is what makes the executor's
+          // transient-error classifier (which pattern-matches on the thrown
+          // message) able to retry Pi-side 429/overload failures.
+          ...(last.errorMessage ? { errors: [last.errorMessage] } : {}),
+        }
+      : {}),
   };
   return chunk;
 }

--- a/packages/providers/src/community/pi/event-bridge.ts
+++ b/packages/providers/src/community/pi/event-bridge.ts
@@ -92,7 +92,8 @@ export function serializeToolResult(result: unknown): string {
   if (typeof result === 'string') return result;
   try {
     return JSON.stringify(result);
-  } catch {
+  } catch (err) {
+    getLog().warn({ err }, 'pi.event-bridge.tool_result_serialize_failed');
     return String(result);
   }
 }

--- a/packages/providers/src/community/pi/event-bridge.ts
+++ b/packages/providers/src/community/pi/event-bridge.ts
@@ -280,17 +280,6 @@ export function mapPiEvent(event: AgentSessionEvent): MessageChunk[] {
 }
 
 /**
- * Bridge a Pi `AgentSession` into Archon's `AsyncGenerator<MessageChunk>` contract.
- *
- * Behavior:
- *  - subscribe before calling prompt, unsubscribe in finally
- *  - yield mapped events in order
- *  - complete on successful `session.prompt()` resolution
- *  - throw on `session.prompt()` rejection or listener-raised errors
- *  - forward `abortSignal` to `session.abort()` fire-and-forget
- *  - always `dispose()` the session to avoid listener accumulation
- */
-/**
  * Internal queue payload for `bridgeSession`. Exported at module scope
  * (not inside the generator) so unit tests can exercise each variant
  * independently without reaching into the generator's closure.
@@ -305,6 +294,17 @@ export interface BridgeNotifier {
   setEmitter(fn: ((chunk: MessageChunk) => void) | undefined): void;
 }
 
+/**
+ * Bridge a Pi `AgentSession` into Archon's `AsyncGenerator<MessageChunk>` contract.
+ *
+ * Behavior:
+ *  - subscribe before calling prompt, unsubscribe in finally
+ *  - yield mapped events in order
+ *  - complete on successful `session.prompt()` resolution
+ *  - throw on `session.prompt()` rejection or listener-raised errors
+ *  - forward `abortSignal` to `session.abort()` fire-and-forget
+ *  - always `dispose()` the session to avoid listener accumulation
+ */
 export async function* bridgeSession(
   session: AgentSession,
   prompt: string,

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -1530,4 +1530,38 @@ describe('PiProvider', () => {
       delete process.env.PI_TEST_SHELL_WINS;
     }
   });
+
+  // Semaphore tests run last — the module-level piSemaphore singleton persists
+  // across tests once initialized, so these must not affect tests that run before.
+  test('maxConcurrent initializes semaphore and logs pi.semaphore_initialized', async () => {
+    process.env.GEMINI_API_KEY = 'sk-test';
+    resetScript(scriptedAgentEnd());
+
+    await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, {
+        model: 'google/gemini-2.5-pro',
+        assistantConfig: { maxConcurrent: 2 },
+      })
+    );
+
+    expect(mockLogger.info).toHaveBeenCalledWith({ maxConcurrent: 2 }, 'pi.semaphore_initialized');
+    // Semaphore slot released: dispose fires on successful completion
+    expect(mockDispose).toHaveBeenCalledTimes(1);
+  });
+
+  test('semaphore is not initialized when maxConcurrent is absent', async () => {
+    process.env.GEMINI_API_KEY = 'sk-test';
+    resetScript(scriptedAgentEnd());
+
+    await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, {
+        model: 'google/gemini-2.5-pro',
+      })
+    );
+
+    const initCalls = (mockLogger.info.mock.calls as unknown[][]).filter(
+      c => c[1] === 'pi.semaphore_initialized'
+    );
+    expect(initCalls).toHaveLength(0);
+  });
 });

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -508,9 +508,13 @@ export class PiProvider implements IAgentProvider {
       getLog().info({ maxConcurrent }, 'pi.semaphore_initialized');
     }
 
-    if (piSemaphore !== undefined) {
+    // Snapshot before the first await — if a concurrent call initializes the
+    // module-level piSemaphore after this point, sem stays undefined and the
+    // finally block correctly skips release (we never acquired).
+    const sem = piSemaphore;
+    if (sem !== undefined) {
       getLog().debug('pi.semaphore_acquiring');
-      await piSemaphore.acquire();
+      await sem.acquire();
       getLog().debug('pi.semaphore_acquired');
     }
     try {
@@ -526,7 +530,7 @@ export class PiProvider implements IAgentProvider {
       getLog().error({ err, piProvider: parsed.provider }, 'pi.prompt_failed');
       throw err;
     } finally {
-      piSemaphore?.release();
+      sem?.release();
     }
   }
 

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -34,6 +34,45 @@ import { parsePiModelRef } from './model-ref';
 // sendQuery, write a stub package.json to tmpdir and point Pi at it via
 // its own documented `PI_PACKAGE_DIR` escape hatch.
 
+// ─── Concurrency throttle ────────────────────────────────────────────────────
+
+/**
+ * Simple counting semaphore for capping concurrent Pi `session.prompt()` calls.
+ * Pi/Minimax has no built-in SDK-level throttling; without this, large parallel
+ * workflow batches (e.g. 10+ concurrent review PRs × 5 aspects each) hit rate
+ * limits and cascade-fail. Module-level so it's shared across all PiProvider
+ * instances within a process — Pi concurrency is global (one upstream backend).
+ */
+class Semaphore {
+  private available: number;
+  private readonly waiters: (() => void)[] = [];
+
+  constructor(count: number) {
+    this.available = count;
+  }
+
+  acquire(): Promise<void> {
+    if (this.available > 0) {
+      this.available--;
+      return Promise.resolve();
+    }
+    return new Promise<void>(resolve => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  release(): void {
+    const next = this.waiters.shift();
+    if (next) {
+      next();
+    } else {
+      this.available++;
+    }
+  }
+}
+
+let piSemaphore: Semaphore | undefined;
+
 /**
  * Write a minimal package.json to a stable tmpdir and set `PI_PACKAGE_DIR`
  * so Pi's `config.js` short-circuits its `dirname(process.execPath)` walk
@@ -458,6 +497,22 @@ export class PiProvider implements IAgentProvider {
     //    bridgeSession owns dispose() and abort wiring. When `interactive`
     //    is on, it also binds/unbinds the UI stub's emitter so extension
     //    notifications land on the same queue as Pi events.
+    //
+    //    The module-level semaphore is initialized lazily from the first
+    //    config that sets maxConcurrent and reused for the lifetime of the
+    //    process — this is a known v1 tradeoff. Pi concurrency is global
+    //    (one upstream backend) so a process-wide cap is the right scope.
+    const maxConcurrent = piConfig.maxConcurrent;
+    if (maxConcurrent !== undefined && piSemaphore === undefined) {
+      piSemaphore = new Semaphore(maxConcurrent);
+      getLog().info({ maxConcurrent }, 'pi.semaphore_initialized');
+    }
+
+    if (piSemaphore !== undefined) {
+      getLog().debug('pi.semaphore_acquiring');
+      await piSemaphore.acquire();
+      getLog().debug('pi.semaphore_acquired');
+    }
     try {
       yield* bridgeSession(
         session,
@@ -470,6 +525,8 @@ export class PiProvider implements IAgentProvider {
     } catch (err) {
       getLog().error({ err, piProvider: parsed.provider }, 'pi.prompt_failed');
       throw err;
+    } finally {
+      piSemaphore?.release();
     }
   }
 

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -65,9 +65,9 @@ class Semaphore {
     const next = this.waiters.shift();
     if (next) {
       next();
-    } else {
-      this.available++;
+      return;
     }
+    this.available++;
   }
 }
 

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -91,8 +91,8 @@ export interface PiProviderDefaults {
    * (unlike the Claude SDK), so this prevents cascading 429/rate-limit failures
    * when many parallel workflow nodes invoke Pi simultaneously.
    *
-   * Set to a value that matches your Pi API tier's concurrency limit.
-   * Omit or set to 0 for unlimited (not recommended for production batches).
+   * Set to a positive integer matching your Pi API tier's concurrency limit.
+   * Omit for unlimited (not recommended for production batches).
    * @default undefined (unlimited)
    */
   maxConcurrent?: number;

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -84,6 +84,18 @@ export interface PiProviderDefaults {
    * @default undefined
    */
   env?: Record<string, string>;
+  /**
+   * Maximum number of concurrent Pi `session.prompt()` calls allowed.
+   * When this limit is reached, additional calls queue and wait rather than
+   * fail. Pi/Minimax does not throttle concurrent requests at the SDK layer
+   * (unlike the Claude SDK), so this prevents cascading 429/rate-limit failures
+   * when many parallel workflow nodes invoke Pi simultaneously.
+   *
+   * Set to a value that matches your Pi API tier's concurrency limit.
+   * Omit or set to 0 for unlimited (not recommended for production batches).
+   * @default undefined (unlimited)
+   */
+  maxConcurrent?: number;
 }
 
 /** Generic per-provider defaults bag used by config surfaces and UI. */

--- a/packages/workflows/src/executor-shared.test.ts
+++ b/packages/workflows/src/executor-shared.test.ts
@@ -26,6 +26,7 @@ import {
   stripCompletionTags,
   isInlineScript,
   formatSubprocessFailure,
+  classifyError,
 } from './executor-shared';
 
 describe('substituteWorkflowVariables', () => {
@@ -563,5 +564,31 @@ describe('formatSubprocessFailure', () => {
     const { userMessage } = formatSubprocessFailure({ stderr: 'diagnostic' }, "Script node 'n1'");
     expect(userMessage).not.toContain('[exit');
     expect(userMessage).toContain('diagnostic');
+  });
+});
+
+describe('classifyError', () => {
+  it('classifies 429 as TRANSIENT', () => {
+    expect(classifyError(new Error('rate limit: 429 too many requests'))).toBe('TRANSIENT');
+  });
+
+  it('classifies 529 as TRANSIENT', () => {
+    expect(classifyError(new Error('HTTP 529 service overloaded'))).toBe('TRANSIENT');
+  });
+
+  it('classifies overloaded messages as TRANSIENT', () => {
+    expect(classifyError(new Error('Minimax: overloaded, try again later'))).toBe('TRANSIENT');
+  });
+
+  it('classifies 401 as FATAL', () => {
+    expect(classifyError(new Error('401 unauthorized'))).toBe('FATAL');
+  });
+
+  it('FATAL takes priority over TRANSIENT when both match', () => {
+    expect(classifyError(new Error('unauthorized: exited with code 1'))).toBe('FATAL');
+  });
+
+  it('classifies unknown errors as UNKNOWN', () => {
+    expect(classifyError(new Error('something completely unexpected happened'))).toBe('UNKNOWN');
   });
 });

--- a/packages/workflows/src/executor-shared.ts
+++ b/packages/workflows/src/executor-shared.ts
@@ -50,6 +50,8 @@ export const TRANSIENT_PATTERNS = [
   '429',
   '503',
   '502',
+  '529', // Anthropic HTTP 529 = service overloaded
+  'overloaded', // Anthropic/Minimax overload message text
   'network error',
   'socket hang up',
   'exited with code',

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -100,7 +100,7 @@ async function safeSendMessage(
       unknownErrorTracker.count++;
       if (unknownErrorTracker.count >= UNKNOWN_ERROR_THRESHOLD) {
         throw new Error(
-          `${String(UNKNOWN_ERROR_THRESHOLD)} consecutive unrecognized errors - aborting workflow: ${err.message}`
+          `${UNKNOWN_ERROR_THRESHOLD} consecutive unrecognized errors - aborting workflow: ${err.message}`
         );
       }
     }


### PR DESCRIPTION
## Summary

- **Problem**: Pi/Minimax sessions running concurrently would cascade failures — one overloaded session polluted others because SDK error messages were swallowed and the retry classifier never matched Pi-specific 529/overload signals.
- **Why it matters**: Operators running >1 Pi workflow at the same time saw all sessions fail together with opaque errors; retries were silently skipped because `errors[]` was always empty.
- **What changed**: (1) Surface `AssistantMessage.errorMessage` in the result chunk's `errors[]` field so the retry classifier sees it; (2) add a module-level semaphore in `PiProvider.sendQuery()` to cap concurrent Pi SDK calls; (3) extend `TRANSIENT_PATTERNS` with `'529'` and `'overloaded'` so those errors trigger retries.
- **What did not change**: No changes to the DAG executor retry loop, no changes to other providers (Claude, Codex), no database schema changes.

## UX Journey

### Before

```
User triggers 10 concurrent Pi workflow nodes
  ────────────────────────────────────────────
  Node 1 calls Pi SDK ──────▶ Pi returns 529 overloaded
                               errorMessage set on AssistantMessage
                               event-bridge ignores errorMessage
                               result chunk errors: []          ← empty
                               dag-executor sees no transient error
                               node marked FAILED (no retry)
  Nodes 2–10 pile into SDK ─▶ same cascade: all fail immediately
  User sees: 10 failed nodes, no retry, no useful error detail
```

### After

```
User triggers 10 concurrent Pi workflow nodes
  ────────────────────────────────────────────
  Node 1–N calls Pi SDK ──▶ semaphore limits to maxConcurrent=3
  Admitted node calls SDK ─▶ Pi returns 529 overloaded
                              errorMessage set on AssistantMessage
                              [event-bridge now surfaces errorMessage]
                              result chunk errors: ['529 overloaded'] ← populated
                              dag-executor.isTransientNodeError()
                              matches '529' / 'overloaded' pattern    ← NEW
                              node retried with backoff
  Queue drains as slots free ▶ nodes complete successfully
  User sees: transient failures retried, not cascaded
```

## Architecture Diagram

### Before

```
PiProvider.sendQuery()
  └─▶ pi-sdk.createSession() / sendQuery()
        └─▶ event-bridge.buildResultChunk()
              └─▶ errors: []   (errorMessage dropped)
                    └─▶ dag-executor errorsDetail = ""
                          └─▶ isTransientNodeError() → no match
```

### After

```
PiProvider.sendQuery()
  └─▶ [Semaphore.acquire()]                  ← NEW
        └─▶ pi-sdk.createSession() / sendQuery()
              └─▶ event-bridge.buildResultChunk()
                    └─▶ [errors: [errorMessage]]  ← NEW
                          └─▶ dag-executor errorsDetail = "529 overloaded"
                                └─▶ isTransientNodeError()
                                      matches '529' / 'overloaded' ← NEW
                                      → retry with backoff
        └─▶ [Semaphore.release()]             ← NEW
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `PiProvider` | `Semaphore` (internal) | **new** | Module-level, initialized from `piConfig.maxConcurrent` |
| `event-bridge.buildResultChunk` | `errors[]` | **modified** | Now spreads `errorMessage` when present |
| `executor-shared.TRANSIENT_PATTERNS` | retry loop | **modified** | Added `'529'` and `'overloaded'` entries |
| `parsePiConfig` | `PiProviderDefaults.maxConcurrent` | **new** | Parses positive int, drops invalid |
| `dag-executor` → `errorsDetail` → `isTransientNodeError` | `executor-shared` | unchanged | Existing path, now receives Pi error strings |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `providers`
- Module: `providers:pi`

## Change Metadata

- Change type: `bug`
- Primary scope: `providers`

## Linked Issue

- Closes #1569

## Validation Evidence (required)

```bash
bun run validate
# → type-check: PASS (all 10 packages)
# → lint: PASS (0 errors, 0 warnings, --max-warnings 0)
# → format:check: PASS
# → test: PASS (all packages, 0 failures)
# → check:bundled: PASS
```

Targeted test run before full suite:
```bash
bun test packages/providers/src/community/pi/event-bridge.test.ts packages/providers/src/community/pi/config.test.ts
# 69 tests, 107 expect() calls — all green
```

- Evidence provided: full `bun run validate` exit 0; lint-staged on commit reported no additional modifications.
- No commands intentionally skipped.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — `maxConcurrent` is optional; if omitted, no semaphore is applied (existing behavior preserved).
- Config/env changes? Yes — new optional field `assistants.pi.maxConcurrent` in `.archon/config.yaml`. No action required; omitting it leaves behavior unchanged.
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: Unit tests cover `errorMessage` surfacing (present and absent), `parsePiConfig` accepts positive integers and drops 0/negatives/floats/strings/null. Type-check confirms the `maxConcurrent` field flows correctly through all types.
- Edge cases checked: `maxConcurrent: 0`, negative values, floats, strings, null — all silently dropped (no semaphore applied).
- What was not verified: Live end-to-end smoke test with a real Pi API key and 10+ concurrent workflows (requires operator environment with Pi credentials).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Pi provider only; Claude and Codex providers are untouched. The `TRANSIENT_PATTERNS` change in `executor-shared.ts` affects all providers' retry classification but only adds new patterns — existing patterns are unchanged.
- Potential unintended effects: If a non-Pi error message happens to contain the substring `'529'` or `'overloaded'`, it will now be classified as transient and retried. This is the desired behavior for any provider returning those signals.
- Guardrails: Semaphore prevents more than `maxConcurrent` Pi SDK calls from being in-flight; queue drains naturally. No timeout on the semaphore queue (v1 tradeoff — documented in code comment).

## Rollback Plan (required)

- Fast rollback: `git revert bd2a1d20` — single commit, no schema changes, no migrations.
- Feature flags: `maxConcurrent` can be omitted from config to disable the semaphore without reverting code.
- Observable failure symptoms: Pi workflows failing with `errors: []` (empty) and no retry attempts would indicate the `errorMessage` surfacing regressed.

## Risks and Mitigations

- Risk: Semaphore queue has no timeout — if `maxConcurrent` slots are permanently held by stuck sessions, queued nodes wait indefinitely.
  - Mitigation: Pi session cleanup (introduced in #1563) removes zombie runs; the semaphore queue will drain once stuck sessions are cleaned up. A per-acquire timeout can be added in a follow-up if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional concurrency limit configuration for Pi provider to queue excess concurrent requests and manage request throughput.

* **Bug Fixes**
  * Improved error detection to recognize additional system overload indicators (HTTP 529 and overloaded messages).
  * Enhanced error logging to capture diagnostic information when stream operations or serialization fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->