### PR TITLE
docs(direction): commit forge-agnostic support as a maintained direction

### DIFF
--- a/.archon/maintainer-standup/direction.md
+++ b/.archon/maintainer-standup/direction.md
@@ -15,6 +15,7 @@ This file is **committed and shared by all maintainers**. Edit deliberately — 
 - **Type-safe.** Strict TypeScript everywhere. No `any` without justification.
 - **Composable.** Scripts in `.archon/scripts/`, commands in `.archon/commands/`, workflows compose them.
 - **Self-hostable.** Bun + TypeScript runtime. SQLite by default; PostgreSQL optional. Zero external service dependencies for core operation.
+- **Forge-agnostic.** GitHub is the primary forge, but Gitea and GitLab are community supported targets via community adapters at `packages/adapters/src/community/forge/`. Long-term home for outbound forge operations (PR/issue/review CRUD) is the same per-forge adapter that handles inbound webhooks. New forges land as new community adapters that implement the shared interface.
 
 ## What Archon is NOT
 


### PR DESCRIPTION
## Summary

- Adds a **Forge-agnostic** clause to `direction.md`: GitHub is primary; Gitea and GitLab are community-supported targets via the existing community adapters at `packages/adapters/src/community/forge/`.
- Resolves the open direction question that has been blocking #1104 (forge-agnostic workflow commands) for ~8 days.
- The architectural cleanup — migrating #1104's interim `forge-cli.ts` into the existing community adapters — is tracked as #1574 and is **not** a precondition for merging #1104.

## Why now

@truck0321's PR #1104 has been waiting on a maintainer direction call. The implementation is well-tested and clean; the only outstanding question was whether forge support beyond GitHub is in scope. The answer is yes — but as community-tier (matching how Pi is positioned vs. Claude/Codex), not first-class core support.

Filing this as a separate one-line PR so the direction call is its own auditable change, decoupled from any code that follows it.

## Test plan

- [ ] No code changes — pure docs.
- [ ] CI green (lint/format on the YAML/MD files only).
- [ ] Confirm \`bun run validate\` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that Archon is forge-agnostic, with GitHub as the primary platform and Gitea and GitLab supported via community adapters for PR, issue, and review operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->