### PR TITLE
fix: use configured default provider for ai_assistant_type when registering projects

### DIFF
--- a/packages/adapters/src/community/forge/gitea/adapter.ts
+++ b/packages/adapters/src/community/forge/gitea/adapter.ts
@@ -16,6 +16,7 @@ import {
   toError,
   onConversationClosed,
   ConversationLockManager,
+  loadConfig,
 } from '@archon/core';
 import { getArchonWorkspacesPath, getCommandFolderSearchPaths, createLogger } from '@archon/paths';
 import {
@@ -627,10 +628,12 @@ export class GiteaAdapter implements IPlatformAdapter {
     }
 
     // Include owner in name to distinguish repos with same name from different owners
+    const config = await loadConfig(canonicalPath);
     const codebase = await codebaseDb.createCodebase({
       name: `${owner}/${repo}`,
       repository_url: repoUrlNoGit,
       default_cwd: canonicalPath,
+      ai_assistant_type: config.assistant,
     });
 
     getLog().info({ codebaseName: codebase.name, path: canonicalPath }, 'codebase_created');

--- a/packages/adapters/src/community/forge/gitlab/adapter.test.ts
+++ b/packages/adapters/src/community/forge/gitlab/adapter.test.ts
@@ -57,6 +57,7 @@ mock.module('@archon/core', () => ({
   toError: mock((e: unknown) => (e instanceof Error ? e : new Error(String(e)))),
   onConversationClosed: mockOnConversationClosed,
   ConversationNotFoundError: class extends Error {},
+  loadConfig: mock(async () => ({ assistant: 'claude' })),
   ConversationLockManager: class {
     async acquireLock(_id: string, fn: () => Promise<void>): Promise<void> {
       await fn();

--- a/packages/adapters/src/community/forge/gitlab/adapter.ts
+++ b/packages/adapters/src/community/forge/gitlab/adapter.ts
@@ -15,6 +15,7 @@ import {
   toError,
   onConversationClosed,
   ConversationLockManager,
+  loadConfig,
 } from '@archon/core';
 import { getArchonWorkspacesPath, getCommandFolderSearchPaths, createLogger } from '@archon/paths';
 import {
@@ -566,10 +567,12 @@ Use 'glab mr view ${String(mr.iid)}' for full details and 'glab mr diff ${String
       return { codebase: existing, repoPath: existing.default_cwd, isNew: false };
     }
 
+    const config = await loadConfig(canonicalPath);
     const codebase = await codebaseDb.createCodebase({
       name: projectPath,
       repository_url: repoUrlNoGit,
       default_cwd: canonicalPath,
+      ai_assistant_type: config.assistant,
     });
 
     getLog().info({ codebaseName: codebase.name, path: canonicalPath }, 'gitlab.codebase_created');

--- a/packages/adapters/src/forge/github/adapter.ts
+++ b/packages/adapters/src/forge/github/adapter.ts
@@ -16,6 +16,7 @@ import {
   getLinkedIssueNumbers,
   onConversationClosed,
   ConversationLockManager,
+  loadConfig,
 } from '@archon/core';
 import { getArchonWorkspacesPath, getCommandFolderSearchPaths } from '@archon/paths';
 import {
@@ -606,10 +607,12 @@ export class GitHubAdapter implements IPlatformAdapter {
 
     // Include owner in name to distinguish repos with same name from different owners
     // resolve() converts relative paths to absolute (cross-platform)
+    const config = await loadConfig(canonicalPath);
     const codebase = await codebaseDb.createCodebase({
       name: `${owner}/${repo}`,
       repository_url: repoUrlNoGit, // Store without .git for consistency
       default_cwd: canonicalPath,
+      ai_assistant_type: config.assistant,
     });
 
     getLog().info({ codebaseName: codebase.name, path: canonicalPath }, 'github.codebase_created');

--- a/packages/adapters/src/forge/github/context.test.ts
+++ b/packages/adapters/src/forge/github/context.test.ts
@@ -63,6 +63,7 @@ mock.module('@archon/core', () => ({
   onConversationClosed: mock(async () => {}),
   getArchonWorkspacesPath: () => '/workspace',
   getCommandFolderSearchPaths: () => [],
+  loadConfig: mock(async () => ({ assistant: 'claude' })),
   ConversationLockManager: class {
     async acquireLock(_id: string, handler: () => Promise<void>): Promise<void> {
       await handler();

--- a/packages/core/src/db/codebases.test.ts
+++ b/packages/core/src/db/codebases.test.ts
@@ -69,6 +69,7 @@ describe('codebases', () => {
       const result = await createCodebase({
         name: 'test-project',
         default_cwd: '/workspace/test-project',
+        ai_assistant_type: 'claude',
       });
 
       expect(result).toEqual(codebaseWithoutOptional);
@@ -78,17 +79,33 @@ describe('codebases', () => {
       );
     });
 
-    test('defaults ai_assistant_type to claude', async () => {
-      mockQuery.mockResolvedValueOnce(createQueryResult([mockCodebase]));
+    test('throws when ai_assistant_type is omitted', async () => {
+      await expect(
+        createCodebase({
+          name: 'test-project',
+          default_cwd: '/workspace/test-project',
+        } as Parameters<typeof createCodebase>[0])
+      ).rejects.toThrow('createCodebase: ai_assistant_type is required');
 
-      await createCodebase({
+      // DB must NOT be called when validation fails
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    test('persists non-default ai_assistant_type value', async () => {
+      const piCodebase: Codebase = { ...mockCodebase, ai_assistant_type: 'pi' };
+      mockQuery.mockResolvedValueOnce(createQueryResult([piCodebase]));
+
+      const result = await createCodebase({
         name: 'test-project',
+        repository_url: 'https://github.com/user/repo',
         default_cwd: '/workspace/test-project',
+        ai_assistant_type: 'pi',
       });
 
+      expect(result.ai_assistant_type).toBe('pi');
       expect(mockQuery).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.arrayContaining(['claude'])
+        'INSERT INTO remote_agent_codebases (name, repository_url, default_cwd, ai_assistant_type) VALUES ($1, $2, $3, $4) RETURNING *',
+        ['test-project', 'https://github.com/user/repo', '/workspace/test-project', 'pi']
       );
     });
   });

--- a/packages/core/src/db/codebases.test.ts
+++ b/packages/core/src/db/codebases.test.ts
@@ -91,6 +91,18 @@ describe('codebases', () => {
       expect(mockQuery).not.toHaveBeenCalled();
     });
 
+    test('throws when ai_assistant_type is whitespace-only', async () => {
+      await expect(
+        createCodebase({
+          name: 'test-project',
+          default_cwd: '/workspace/test-project',
+          ai_assistant_type: '   ',
+        })
+      ).rejects.toThrow('createCodebase: ai_assistant_type is required');
+
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
     test('persists non-default ai_assistant_type value', async () => {
       const piCodebase: Codebase = { ...mockCodebase, ai_assistant_type: 'pi' };
       mockQuery.mockResolvedValueOnce(createQueryResult([piCodebase]));

--- a/packages/core/src/db/codebases.ts
+++ b/packages/core/src/db/codebases.ts
@@ -18,12 +18,13 @@ export async function createCodebase(data: {
   default_cwd: string;
   ai_assistant_type: string;
 }): Promise<Codebase> {
-  if (!data.ai_assistant_type?.trim()) {
+  const aiAssistantType = data.ai_assistant_type?.trim();
+  if (!aiAssistantType) {
     throw new Error('createCodebase: ai_assistant_type is required');
   }
   const result = await pool.query<Codebase>(
     'INSERT INTO remote_agent_codebases (name, repository_url, default_cwd, ai_assistant_type) VALUES ($1, $2, $3, $4) RETURNING *',
-    [data.name, data.repository_url ?? null, data.default_cwd, data.ai_assistant_type]
+    [data.name, data.repository_url ?? null, data.default_cwd, aiAssistantType]
   );
   if (!result.rows[0]) {
     throw new Error('Failed to create codebase: INSERT succeeded but no row returned');

--- a/packages/core/src/db/codebases.ts
+++ b/packages/core/src/db/codebases.ts
@@ -18,7 +18,7 @@ export async function createCodebase(data: {
   default_cwd: string;
   ai_assistant_type: string;
 }): Promise<Codebase> {
-  if (!data.ai_assistant_type) {
+  if (!data.ai_assistant_type?.trim()) {
     throw new Error('createCodebase: ai_assistant_type is required');
   }
   const result = await pool.query<Codebase>(

--- a/packages/core/src/db/codebases.ts
+++ b/packages/core/src/db/codebases.ts
@@ -16,12 +16,14 @@ export async function createCodebase(data: {
   name: string;
   repository_url?: string;
   default_cwd: string;
-  ai_assistant_type?: string;
+  ai_assistant_type: string;
 }): Promise<Codebase> {
-  const assistantType = data.ai_assistant_type ?? 'claude';
+  if (!data.ai_assistant_type) {
+    throw new Error('createCodebase: ai_assistant_type is required');
+  }
   const result = await pool.query<Codebase>(
     'INSERT INTO remote_agent_codebases (name, repository_url, default_cwd, ai_assistant_type) VALUES ($1, $2, $3, $4) RETURNING *',
-    [data.name, data.repository_url ?? null, data.default_cwd, assistantType]
+    [data.name, data.repository_url ?? null, data.default_cwd, data.ai_assistant_type]
   );
   if (!result.rows[0]) {
     throw new Error('Failed to create codebase: INSERT succeeded but no row returned');

--- a/packages/core/src/db/codebases.ts
+++ b/packages/core/src/db/codebases.ts
@@ -18,6 +18,7 @@ export async function createCodebase(data: {
   default_cwd: string;
   ai_assistant_type: string;
 }): Promise<Codebase> {
+  // `?.` handles runtime-undefined (tests cast omitted field via `as`); trim normalizes whitespace.
   const aiAssistantType = data.ai_assistant_type?.trim();
   if (!aiAssistantType) {
     throw new Error('createCodebase: ai_assistant_type is required');

--- a/packages/core/src/handlers/clone.test.ts
+++ b/packages/core/src/handlers/clone.test.ts
@@ -66,6 +66,13 @@ mock.module('../utils/commands', () => ({
   findMarkdownFilesRecursive: mockFindMarkdownFilesRecursive,
 }));
 
+// ── config-loader mock ───────────────────────────────────────────────────────
+// Must be registered before importing clone.ts so loadConfig() is intercepted.
+const mockLoadConfig = mock(() => Promise.resolve({ assistant: 'pi' }));
+mock.module('../config/config-loader', () => ({
+  loadConfig: mockLoadConfig,
+}));
+
 // ── Import module under test AFTER mocks are registered ────────────────────
 import { cloneRepository, registerRepository } from './clone';
 
@@ -529,16 +536,16 @@ describe('cloneRepository', () => {
       expect(createCall[0].ai_assistant_type).toBe('codex');
     });
 
-    test('defaults to claude when neither .codex nor .claude folder exists', async () => {
+    test('uses config.assistant as default when neither .codex nor .claude nor .pi folder exists', async () => {
       spyFsAccess.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
       mockCreateCodebase.mockResolvedValueOnce(
-        makeCodebase({ ai_assistant_type: 'claude' }) as ReturnType<typeof makeCodebase>
+        makeCodebase({ ai_assistant_type: 'pi' }) as ReturnType<typeof makeCodebase>
       );
 
       await cloneRepository('https://github.com/owner/repo');
 
       const createCall = mockCreateCodebase.mock.calls[0] as [{ ai_assistant_type: string }];
-      expect(createCall[0].ai_assistant_type).toBe('claude');
+      expect(createCall[0].ai_assistant_type).toBe('pi');
     });
 
     test('detects claude assistant when .claude folder exists but .codex does not', async () => {
@@ -732,6 +739,50 @@ describe('registerRepository', () => {
 
     expect(result.commandCount).toBe(1);
     expect(mockUpdateCodebaseCommands.mock.calls.length).toBe(1);
+  });
+
+  // ── Provider auto-detection ───────────────────────────────────────────
+  test('uses config.assistant as ai_assistant_type when no SDK folder detected', async () => {
+    // mockLoadConfig returns { assistant: 'pi' } by default
+    spyExecFileAsync.mockImplementation((cmd: string, args: string[]) => {
+      if (args.includes('rev-parse')) return Promise.resolve({ stdout: '.git', stderr: '' });
+      if (args.includes('get-url'))
+        return Promise.resolve({ stdout: 'https://github.com/owner/repo', stderr: '' });
+      return Promise.resolve({ stdout: '', stderr: '' });
+    });
+    // All access() calls fail — no .codex, .claude, or .pi folder
+    spyFsAccess.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    mockFindCodebaseByDefaultCwd.mockResolvedValueOnce(null);
+    mockCreateCodebase.mockResolvedValueOnce(makeCodebase() as ReturnType<typeof makeCodebase>);
+
+    await registerRepository('/home/user/myrepo');
+
+    const createArg = mockCreateCodebase.mock.calls[0]?.[0] as { ai_assistant_type: string };
+    expect(createArg.ai_assistant_type).toBe('pi');
+  });
+
+  test('detects .pi/ folder and sets ai_assistant_type to pi', async () => {
+    // config default is 'pi', but this test verifies the folder-detection path directly
+    mockLoadConfig.mockResolvedValueOnce({ assistant: 'claude' });
+    spyExecFileAsync.mockImplementation((cmd: string, args: string[]) => {
+      if (args.includes('rev-parse')) return Promise.resolve({ stdout: '.git', stderr: '' });
+      if (args.includes('get-url'))
+        return Promise.resolve({ stdout: 'https://github.com/owner/repo', stderr: '' });
+      return Promise.resolve({ stdout: '', stderr: '' });
+    });
+    // Only .pi/ folder exists (not .codex or .claude)
+    spyFsAccess.mockImplementation((path: string) => {
+      const normalized = typeof path === 'string' ? path.replace(/\\/g, '/') : '';
+      if (normalized.endsWith('/.pi')) return Promise.resolve(undefined);
+      return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    });
+    mockFindCodebaseByDefaultCwd.mockResolvedValueOnce(null);
+    mockCreateCodebase.mockResolvedValueOnce(makeCodebase() as ReturnType<typeof makeCodebase>);
+
+    await registerRepository('/home/user/myrepo');
+
+    const createArg = mockCreateCodebase.mock.calls[0]?.[0] as { ai_assistant_type: string };
+    expect(createArg.ai_assistant_type).toBe('pi');
   });
 });
 

--- a/packages/core/src/handlers/clone.test.ts
+++ b/packages/core/src/handlers/clone.test.ts
@@ -110,6 +110,7 @@ function clearMocks(): void {
   mockFindCodebaseByName.mockReset();
   mockUpdateCodebase.mockReset();
   mockFindMarkdownFilesRecursive.mockReset();
+  mockLoadConfig.mockReset();
   mockLogger.info.mockClear();
   mockLogger.debug.mockClear();
   mockLogger.warn.mockClear();
@@ -123,6 +124,7 @@ function clearMocks(): void {
   mockFindCodebaseByName.mockResolvedValue(null);
   mockUpdateCodebase.mockResolvedValue(undefined);
   mockFindMarkdownFilesRecursive.mockResolvedValue([]);
+  mockLoadConfig.mockResolvedValue({ assistant: 'pi' });
 }
 
 afterAll(() => {
@@ -759,11 +761,11 @@ describe('registerRepository', () => {
 
     const createArg = mockCreateCodebase.mock.calls[0]?.[0] as { ai_assistant_type: string };
     expect(createArg.ai_assistant_type).toBe('pi');
+    expect(mockLoadConfig).toHaveBeenCalledTimes(1);
   });
 
   test('detects .pi/ folder and sets ai_assistant_type to pi', async () => {
-    // config default is 'pi', but this test verifies the folder-detection path directly
-    mockLoadConfig.mockResolvedValueOnce({ assistant: 'claude' });
+    // loadConfig must NOT be called when a known SDK folder is detected (deferred I/O)
     spyExecFileAsync.mockImplementation((cmd: string, args: string[]) => {
       if (args.includes('rev-parse')) return Promise.resolve({ stdout: '.git', stderr: '' });
       if (args.includes('get-url'))
@@ -783,6 +785,7 @@ describe('registerRepository', () => {
 
     const createArg = mockCreateCodebase.mock.calls[0]?.[0] as { ai_assistant_type: string };
     expect(createArg.ai_assistant_type).toBe('pi');
+    expect(mockLoadConfig).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/handlers/clone.ts
+++ b/packages/core/src/handlers/clone.ts
@@ -45,9 +45,8 @@ async function registerRepoAtPath(
 ): Promise<RegisterResult> {
   // Auto-detect assistant type based on SDK folder conventions.
   // Known SDK folders: .codex/ (Codex), .claude/ (Claude), .pi/ (Pi).
-  // Falls back to the configured default provider if no SDK folder detected.
-  const config = await loadConfig(targetPath);
-  let suggestedAssistant = config.assistant;
+  // loadConfig is deferred: only called when no SDK folder is detected.
+  let suggestedAssistant: string;
   const codexFolder = join(targetPath, '.codex');
   const claudeFolder = join(targetPath, '.claude');
   const piFolder = join(targetPath, '.pi');
@@ -67,6 +66,8 @@ async function registerRepoAtPath(
         suggestedAssistant = 'pi';
         getLog().debug({ path: piFolder }, 'assistant_detected_pi');
       } catch {
+        const config = await loadConfig(targetPath);
+        suggestedAssistant = config.assistant;
         getLog().debug({ provider: config.assistant }, 'assistant_default_from_config');
       }
     }

--- a/packages/core/src/handlers/clone.ts
+++ b/packages/core/src/handlers/clone.ts
@@ -17,6 +17,7 @@ import {
 } from '@archon/paths';
 import { findMarkdownFilesRecursive } from '../utils/commands';
 import { createLogger } from '@archon/paths';
+import { loadConfig } from '../config/config-loader';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
@@ -43,13 +44,13 @@ async function registerRepoAtPath(
   repositoryUrl: string | null
 ): Promise<RegisterResult> {
   // Auto-detect assistant type based on SDK folder conventions.
-  // Built-in providers use well-known folders (.claude/, .codex/).
-  // Falls back to first registered built-in provider if no folder detected.
-  const { getRegisteredProviders } = await import('@archon/providers');
-  const defaultProvider = getRegisteredProviders().find(p => p.builtIn)?.id ?? 'claude';
-  let suggestedAssistant = defaultProvider;
+  // Known SDK folders: .codex/ (Codex), .claude/ (Claude), .pi/ (Pi).
+  // Falls back to the configured default provider if no SDK folder detected.
+  const config = await loadConfig(targetPath);
+  let suggestedAssistant = config.assistant;
   const codexFolder = join(targetPath, '.codex');
   const claudeFolder = join(targetPath, '.claude');
+  const piFolder = join(targetPath, '.pi');
 
   try {
     await access(codexFolder);
@@ -61,7 +62,13 @@ async function registerRepoAtPath(
       suggestedAssistant = 'claude';
       getLog().debug({ path: claudeFolder }, 'assistant_detected_claude');
     } catch {
-      getLog().debug({ provider: defaultProvider }, 'assistant_default_from_registry');
+      try {
+        await access(piFolder);
+        suggestedAssistant = 'pi';
+        getLog().debug({ path: piFolder }, 'assistant_detected_pi');
+      } catch {
+        getLog().debug({ provider: config.assistant }, 'assistant_default_from_config');
+      }
     }
   }
 

--- a/packages/core/src/handlers/command-handler.test.ts
+++ b/packages/core/src/handlers/command-handler.test.ts
@@ -26,6 +26,7 @@ const mockCreateCodebase = mock(() => Promise.resolve(null));
 const mockGetCodebaseCommands = mock(() => Promise.resolve({}));
 const mockUpdateCodebaseCommands = mock(() => Promise.resolve());
 const mockDeleteCodebase = mock(() => Promise.resolve());
+const mockListCodebases = mock(() => Promise.resolve([]));
 const mockGetActiveSession = mock(() => Promise.resolve(null));
 const mockDeactivateSession = mock(() => Promise.resolve());
 
@@ -73,6 +74,7 @@ mock.module('../db/codebases', () => ({
   getCodebaseCommands: mockGetCodebaseCommands,
   updateCodebaseCommands: mockUpdateCodebaseCommands,
   deleteCodebase: mockDeleteCodebase,
+  listCodebases: mockListCodebases,
 }));
 
 mock.module('../db/sessions', () => ({
@@ -218,6 +220,7 @@ function clearAllMocks(): void {
   mockGetCodebaseCommands.mockClear();
   mockUpdateCodebaseCommands.mockClear();
   mockDeleteCodebase.mockClear();
+  mockListCodebases.mockClear();
   mockGetActiveSession.mockClear();
   mockDeactivateSession.mockClear();
   // Workflow db mocks

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -1359,7 +1359,7 @@ async function handleRegisterProject(
   }
 
   // Use config default provider instead of hardcoding 'claude'
-  const config = await loadConfig();
+  const config = await loadConfig(projectPath);
   const codebase = await codebaseDb.createCodebase({
     name: projectName,
     default_cwd: projectPath,


### PR DESCRIPTION
## Summary

- **Problem:** All project registration paths hardcoded `ai_assistant_type = 'claude'` (or fell back to the first built-in provider) regardless of the configured default assistant. A Pi-configured instance would silently register every project as Claude.
- **Why it matters:** The orchestrator injects `AI Provider: <ai_assistant_type>` into the system prompt. A wrong value makes the agent believe Claude is configured, causing incorrect routing, tool selection, and user-facing misinformation — always reproducible, no workaround except a manual DB edit.
- **What changed:** `createCodebase` now requires `ai_assistant_type` (removed the `?? 'claude'` default). All five call sites — `clone.ts`, `orchestrator-agent.ts`, and the GitHub, GitLab, and Gitea adapters — resolve the value via `loadConfig(projectPath)` so the configured default (global config → repo config → env) is used. `.pi/` folder detection added alongside `.codex/` and `.claude/` in `clone.ts`. Tests updated to cover Pi as the default and the new throw-on-omission contract.
- **What did not change:** Existing registered projects are unaffected. No DB migration. No changes to how `ai_assistant_type` is consumed (orchestrator prompt, session creation, provider resolution).

## UX Journey

### Before

```
  User                   Archon                   DB
  ────                   ──────                   ──
  configures Pi ───────▶ DEFAULT_AI_ASSISTANT=pi
  registers project ───▶ clone.ts: no .codex/.claude found
                         falls back to first built-in provider
                         stores ai_assistant_type='claude' [X]
  opens Web chat ──────▶ orchestrator builds prompt
                         injects "AI Provider: claude"
  asks config question ◀─ agent reports Claude is configured [X]
```

### After

```
  User                   Archon                   DB
  ────                   ──────                   ──
  configures Pi ───────▶ DEFAULT_AI_ASSISTANT=pi
  registers project ───▶ clone.ts: no .codex/.claude/.pi found
                        [loadConfig(projectPath) → assistant='pi']
                         stores ai_assistant_type='pi' [✓]
  opens Web chat ──────▶ orchestrator builds prompt
                         injects "AI Provider: pi"
  asks config question ◀─ agent reports Pi is configured [✓]
```

## Architecture Diagram

### Before

```
  clone.ts ──────────────────────────────────────────▶ codebaseDb.createCodebase
                                                        (ai_assistant_type ?? 'claude')

  orchestrator-agent.ts (handleRegisterProject) ─────▶ codebaseDb.createCodebase
                                                        (loadConfig() — no path)

  github/adapter.ts ─────────────────────────────────▶ codebaseDb.createCodebase
                                                        (no ai_assistant_type field)

  gitlab/adapter.ts ─────────────────────────────────▶ codebaseDb.createCodebase
                                                        (no ai_assistant_type field)

  gitea/adapter.ts ──────────────────────────────────▶ codebaseDb.createCodebase
                                                        (no ai_assistant_type field)
```

### After

```
  clone.ts ──────▶ [loadConfig(targetPath)] ─────────▶ codebaseDb.createCodebase
                                                        (ai_assistant_type: required)

  orchestrator-agent.ts ──▶ [loadConfig(projectPath)] ▶ codebaseDb.createCodebase
                                                         (ai_assistant_type: required)

  github/adapter.ts ──▶ [loadConfig(canonicalPath)] ──▶ codebaseDb.createCodebase
                                                         (ai_assistant_type: required)

  gitlab/adapter.ts ──▶ [loadConfig(canonicalPath)] ──▶ codebaseDb.createCodebase
                                                         (ai_assistant_type: required)

  gitea/adapter.ts ───▶ [loadConfig(canonicalPath)] ──▶ codebaseDb.createCodebase
                                                         (ai_assistant_type: required)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `clone.ts` | `config-loader.loadConfig` | **new** | replaces dynamic `@archon/providers` import |
| `orchestrator-agent.ts` | `config-loader.loadConfig` | **modified** | now passes `projectPath` |
| `github/adapter.ts` | `config-loader.loadConfig` | **new** | passes `canonicalPath` |
| `gitlab/adapter.ts` | `config-loader.loadConfig` | **new** | passes `canonicalPath` |
| `gitea/adapter.ts` | `config-loader.loadConfig` | **new** | passes `canonicalPath` |
| `clone.ts` | `codebaseDb.createCodebase` | **modified** | `ai_assistant_type` now required |
| `github/adapter.ts` | `codebaseDb.createCodebase` | **modified** | `ai_assistant_type` now required |
| `gitlab/adapter.ts` | `codebaseDb.createCodebase` | **modified** | `ai_assistant_type` now required |
| `gitea/adapter.ts` | `codebaseDb.createCodebase` | **modified** | `ai_assistant_type` now required |
| `orchestrator-agent.ts` | `codebaseDb.createCodebase` | **modified** | `ai_assistant_type` now required |
| `clone.ts` | `@archon/providers.getRegisteredProviders` | **removed** | no longer needed |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`, `adapters`
- Module: `core:db/codebases`, `core:handlers/clone`, `core:orchestrator`, `adapters:github`, `adapters:gitlab`, `adapters:gitea`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi`

## Linked Issue

- Closes #1580

## Validation Evidence (required)

```bash
bun run validate
```

- All checks pass: `check:bundled`, `check:bundled-skill`, `type-check`, `lint`, `format:check`, `test` — 0 failures, 0 warnings.
- Evidence provided: `bun run validate` exits 0 across all packages.
- No commands skipped.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No — `loadConfig(path)` reads `.archon/config.yaml` within paths already accessible to the process; ENOENT is handled gracefully.

## Compatibility / Migration

- Backward compatible? Yes — `ai_assistant_type` already existed in the schema and was always persisted; only the value written changes.
- Config/env changes? No
- Database migration needed? No — existing rows retain their stored value. A manual update (`UPDATE remote_agent_codebases SET ai_assistant_type = 'pi' WHERE ...`) is the workaround for already-affected projects, but no automated migration is required.

## Human Verification (required)

- Verified scenarios: `bun run validate` passes clean. `loadRepoConfig` gracefully handles missing paths (ENOENT returns `{}`), confirmed in source. All five `createCodebase` call sites pass `ai_assistant_type`. TypeScript type enforces the field is required at compile time.
- Edge cases checked: pre-clone paths (forge adapters call `loadConfig(canonicalPath)` before the repo exists — safe due to ENOENT handling); empty-string guard in `createCodebase` catches runtime bypass of the type system.
- What was not verified: end-to-end Pi provider registration via a live webhook event; manual DB inspection of the stored value after registration.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: project registration via clone, register, and all three forge adapter webhooks. Orchestrator prompt content for newly registered projects.
- Potential unintended effects: None. Existing projects are unaffected. The value written for Claude/Codex-configured instances is unchanged.
- Guardrails: TypeScript now rejects any call to `createCodebase` that omits `ai_assistant_type`; the runtime guard throws before hitting the DB.

## Rollback Plan (required)

- Fast rollback: revert the commit; `createCodebase` reverts to `?? 'claude'` default.
- Feature flags or config toggles: None.
- Observable failure symptoms: Projects registered in non-Claude instances get `ai_assistant_type = 'claude'`; orchestrator prompt reports wrong provider.

## Risks and Mitigations

- Risk: `loadConfig(canonicalPath)` in forge adapters reads the path before the repo is cloned there — if `loadRepoConfig` did not handle ENOENT the call would throw.
  - Mitigation: Confirmed `loadRepoConfig` returns `{}` on ENOENT; behavior is identical to passing no path. Same pattern used in `clone.ts` (path is wiped with `rm` before clone).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-repository AI assistant config is now loaded and used when registering/creating codebases; local SDK folders remain preferred.

* **Bug Fixes**
  * Codebase creation requires and persists a non-empty assistant type; whitespace-only values are rejected.

* **Tests**
  * Tests updated to mock per-repo config, assert configured fallbacks, and validate the new assistant-type requirements and detection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->