### PR TITLE
feat: add OpenCode community provider (PoC)

### DIFF
--- a/packages/providers/src/community/opencode/capabilities.ts
+++ b/packages/providers/src/community/opencode/capabilities.ts
@@ -1,0 +1,23 @@
+import type { ProviderCapabilities } from '../../types';
+
+/**
+ * OpenCode capabilities — all false for the PoC.
+ * The first iteration doesn't implement session resume, MCP, hooks, skills,
+ * agents, tool restrictions, structured output, env injection, cost control,
+ * effort control, thinking control, fallback model, or sandbox.
+ */
+export const OPENCODE_CAPABILITIES: ProviderCapabilities = {
+  sessionResume: false,
+  mcp: false,
+  hooks: false,
+  skills: false,
+  agents: false,
+  toolRestrictions: false,
+  structuredOutput: false,
+  envInjection: false,
+  costControl: false,
+  effortControl: false,
+  thinkingControl: false,
+  fallbackModel: false,
+  sandbox: false,
+};

--- a/packages/providers/src/community/opencode/index.ts
+++ b/packages/providers/src/community/opencode/index.ts
@@ -1,0 +1,3 @@
+export { OPENCODE_CAPABILITIES } from './capabilities';
+export { OpenCodeProvider } from './provider';
+export { registerOpenCodeProvider } from './registration';

--- a/packages/providers/src/community/opencode/provider.ts
+++ b/packages/providers/src/community/opencode/provider.ts
@@ -8,7 +8,11 @@ import type {
   SendQueryOptions,
 } from '../../types';
 
+import { createLogger } from '@archon/paths';
+
 import { OPENCODE_CAPABILITIES } from './capabilities';
+
+const log = createLogger('opencode');
 
 export class OpenCodeProvider implements IAgentProvider {
   async *sendQuery(
@@ -20,6 +24,8 @@ export class OpenCodeProvider implements IAgentProvider {
     const binaryPath = this.resolveBinaryPath(requestOptions);
     const args = ['run', '--format', 'json', '--dir', cwd, prompt];
 
+    log.info({ binaryPath, cwd, promptLength: prompt.length }, 'opencode.send_query_started');
+
     let childProcess: ChildProcess;
     try {
       childProcess = spawn(binaryPath, args, {
@@ -30,18 +36,32 @@ export class OpenCodeProvider implements IAgentProvider {
     } catch (err) {
       const e = err as NodeJS.ErrnoException;
       if (e.code === 'ENOENT') {
+        log.error({ binaryPath, err: e }, 'opencode.binary_not_found');
         yield {
           type: 'system',
           content: `OpenCode binary not found: ${binaryPath}. Install opencode or set OPENCODE_BIN_PATH.`,
         };
-      } else {
+      } else if (e.code === 'EACCES') {
+        log.error({ binaryPath, err: e }, 'opencode.binary_permission_denied');
         yield {
           type: 'system',
-          content: `Failed to start OpenCode: ${e.message}`,
+          content: `Permission denied executing OpenCode: ${binaryPath}. Check file permissions.`,
+        };
+      } else {
+        const message = e.message ?? String(e);
+        log.error({ binaryPath, err: e }, 'opencode.spawn_failed');
+        yield {
+          type: 'system',
+          content: `Failed to start OpenCode: ${message}`,
         };
       }
       return;
     }
+
+    let processError = null as Error | null;
+    childProcess.on('error', err => {
+      processError = err;
+    });
 
     const stdErrStream = childProcess.stderr;
     let stderr = '';
@@ -53,6 +73,8 @@ export class OpenCodeProvider implements IAgentProvider {
 
     const stdoutStream = childProcess.stdout;
     if (!stdoutStream) {
+      log.error({ binaryPath, cwd }, 'opencode.stdout_null');
+      childProcess.kill();
       yield { type: 'system', content: 'Failed to read OpenCode output.' };
       return;
     }
@@ -68,8 +90,12 @@ export class OpenCodeProvider implements IAgentProvider {
         const event = JSON.parse(line) as Record<string, unknown>;
         const chunk = this.mapEventToChunk(event);
         if (chunk) yield chunk;
-      } catch {
-        // Skip non-JSON lines (e.g. stderr interleaved with stdout)
+      } catch (err) {
+        if (err instanceof SyntaxError) {
+          log.debug({ line: line.slice(0, 200) }, 'opencode.non_json_line');
+        } else {
+          log.warn({ err, line: line.slice(0, 200) }, 'opencode.line_processing_error');
+        }
       }
     }
 
@@ -82,10 +108,26 @@ export class OpenCodeProvider implements IAgentProvider {
       });
     }
 
-    if (lineCount === 0 && childProcess.exitCode !== 0) {
+    if (childProcess.exitCode !== 0) {
+      log.warn(
+        { lineCount, exitCode: childProcess.exitCode, stderr: stderr.slice(0, 500) },
+        'opencode.non_zero_exit'
+      );
       yield {
         type: 'system',
-        content: stderr || `OpenCode exited with code ${childProcess.exitCode}.`,
+        content: stderr
+          ? `OpenCode error (exit ${childProcess.exitCode}): ${stderr.slice(0, 1000)}`
+          : `OpenCode exited with code ${childProcess.exitCode}.`,
+      };
+    } else {
+      log.info({ lineCount, exitCode: childProcess.exitCode }, 'opencode.send_query_completed');
+    }
+
+    if (processError) {
+      log.warn({ err: processError }, 'opencode.process_error_event');
+      yield {
+        type: 'system',
+        content: `OpenCode process error: ${processError.message}`,
       };
     }
   }
@@ -108,7 +150,7 @@ export class OpenCodeProvider implements IAgentProvider {
 
   private mapEventToChunk(event: Record<string, unknown>): MessageChunk | null {
     // Map known OpenCode JSON event fields to MessageChunk.
-    // The actual event schema is validated at runtime; this is a best-effort mapping.
+    // The actual event schema is NOT validated; this is a best-effort mapping.
     const content = event.content ?? event.text ?? event.data ?? event.message;
     if (typeof content === 'string' && content.length > 0) {
       return { type: 'assistant', content };

--- a/packages/providers/src/community/opencode/provider.ts
+++ b/packages/providers/src/community/opencode/provider.ts
@@ -1,0 +1,118 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { createInterface } from 'node:readline';
+
+import type {
+  IAgentProvider,
+  MessageChunk,
+  ProviderCapabilities,
+  SendQueryOptions,
+} from '../../types';
+
+import { OPENCODE_CAPABILITIES } from './capabilities';
+
+export class OpenCodeProvider implements IAgentProvider {
+  async *sendQuery(
+    prompt: string,
+    cwd: string,
+    _resumeSessionId?: string,
+    requestOptions?: SendQueryOptions
+  ): AsyncGenerator<MessageChunk> {
+    const binaryPath = this.resolveBinaryPath(requestOptions);
+    const args = ['run', '--format', 'json', '--dir', cwd, prompt];
+
+    let childProcess: ChildProcess;
+    try {
+      childProcess = spawn(binaryPath, args, {
+        cwd,
+        env: { ...process.env },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      if (e.code === 'ENOENT') {
+        yield {
+          type: 'system',
+          content: `OpenCode binary not found: ${binaryPath}. Install opencode or set OPENCODE_BIN_PATH.`,
+        };
+      } else {
+        yield {
+          type: 'system',
+          content: `Failed to start OpenCode: ${e.message}`,
+        };
+      }
+      return;
+    }
+
+    const stdErrStream = childProcess.stderr;
+    let stderr = '';
+    if (stdErrStream) {
+      stdErrStream.on('data', data => {
+        stderr += String(data);
+      });
+    }
+
+    const stdoutStream = childProcess.stdout;
+    if (!stdoutStream) {
+      yield { type: 'system', content: 'Failed to read OpenCode output.' };
+      return;
+    }
+    const rl = createInterface({
+      input: stdoutStream,
+      crlfDelay: Infinity,
+    });
+
+    let lineCount = 0;
+    for await (const line of rl) {
+      lineCount++;
+      try {
+        const event = JSON.parse(line) as Record<string, unknown>;
+        const chunk = this.mapEventToChunk(event);
+        if (chunk) yield chunk;
+      } catch {
+        // Skip non-JSON lines (e.g. stderr interleaved with stdout)
+      }
+    }
+
+    // Wait for process to fully close
+    if (childProcess.exitCode === null) {
+      await new Promise<void>(resolve => {
+        childProcess.once('close', () => {
+          resolve();
+        });
+      });
+    }
+
+    if (lineCount === 0 && childProcess.exitCode !== 0) {
+      yield {
+        type: 'system',
+        content: stderr || `OpenCode exited with code ${childProcess.exitCode}.`,
+      };
+    }
+  }
+
+  getType(): string {
+    return 'opencode';
+  }
+
+  getCapabilities(): ProviderCapabilities {
+    return OPENCODE_CAPABILITIES;
+  }
+
+  private resolveBinaryPath(requestOptions?: SendQueryOptions): string {
+    const configPath = requestOptions?.assistantConfig?.opencodeBinaryPath;
+    if (typeof configPath === 'string' && configPath.length > 0) {
+      return configPath;
+    }
+    return process.env.OPENCODE_BIN_PATH || 'opencode';
+  }
+
+  private mapEventToChunk(event: Record<string, unknown>): MessageChunk | null {
+    // Map known OpenCode JSON event fields to MessageChunk.
+    // The actual event schema is validated at runtime; this is a best-effort mapping.
+    const content = event.content ?? event.text ?? event.data ?? event.message;
+    if (typeof content === 'string' && content.length > 0) {
+      return { type: 'assistant', content };
+    }
+    return null;
+  }
+}

--- a/packages/providers/src/community/opencode/registration.ts
+++ b/packages/providers/src/community/opencode/registration.ts
@@ -1,0 +1,21 @@
+import { isRegisteredProvider, registerProvider } from '../../registry';
+
+import { OPENCODE_CAPABILITIES } from './capabilities';
+import { OpenCodeProvider } from './provider';
+
+/**
+ * Register the OpenCode community provider.
+ *
+ * Idempotent — safe to call multiple times, so process entrypoints (CLI,
+ * server, config-loader) can each call it without coordination.
+ */
+export function registerOpenCodeProvider(): void {
+  if (isRegisteredProvider('opencode')) return;
+  registerProvider({
+    id: 'opencode',
+    displayName: 'OpenCode (community)',
+    factory: () => new OpenCodeProvider(),
+    capabilities: OPENCODE_CAPABILITIES,
+    builtIn: false,
+  });
+}

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -53,3 +53,4 @@ export {
   registerPiProvider,
   type PiProviderDefaults,
 } from './community/pi';
+export { OpenCodeProvider, registerOpenCodeProvider } from './community/opencode';

--- a/packages/providers/src/registry.test.ts
+++ b/packages/providers/src/registry.test.ts
@@ -252,9 +252,8 @@ describe('registry', () => {
   describe('registerCommunityProviders (aggregator)', () => {
     test('registers all bundled community providers', () => {
       registerCommunityProviders();
-      // Pi is currently the only community provider bundled. When more are
-      // added, they should appear here automatically.
       expect(isRegisteredProvider('pi')).toBe(true);
+      expect(isRegisteredProvider('opencode')).toBe(true);
     });
 
     test('is idempotent', () => {
@@ -262,6 +261,8 @@ describe('registry', () => {
       expect(() => registerCommunityProviders()).not.toThrow();
       const piCount = getRegisteredProviders().filter(p => p.id === 'pi').length;
       expect(piCount).toBe(1);
+      const opencodeCount = getRegisteredProviders().filter(p => p.id === 'opencode').length;
+      expect(opencodeCount).toBe(1);
     });
   });
 

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -17,6 +17,7 @@ import { ClaudeProvider } from './claude/provider';
 import { CodexProvider } from './codex/provider';
 import { CLAUDE_CAPABILITIES } from './claude/capabilities';
 import { CODEX_CAPABILITIES } from './codex/capabilities';
+import { registerOpenCodeProvider } from './community/opencode/registration';
 import { registerPiProvider } from './community/pi/registration';
 import { UnknownProviderError } from './errors';
 import { createLogger } from '@archon/paths';
@@ -153,6 +154,7 @@ export function registerBuiltinProviders(): void {
  */
 export function registerCommunityProviders(): void {
   registerPiProvider();
+  registerOpenCodeProvider();
 }
 
 /** @internal Test-only — clears the registry. Not for production use. */


### PR DESCRIPTION
## Summary

- **Problem**: Archon lacks an OpenCode community provider, limiting user choice in AI backends.
- **Why it matters**: Adding OpenCode as a community provider demonstrates the extensibility of Archon's provider architecture and gives users access to OpenCode's CLI-based AI capabilities.
- **What changed**: New `OpenCodeProvider` implementing `IAgentProvider` via `opencode run --format json` subprocess calls, registered as a community provider (`builtIn: false`).
- **What did **not** change (scope boundary)**: No session resume, MCP, hooks, skills, agents, tool restrictions, structured output, env injection, cost control, effort control, thinking control, fallback model, or sandbox. No config-file parsing. No tests (PoC phase, manual CLI validation only).

## UX Journey

### Before

```
  User                   Archon                   AI Client
  ────                   ──────                   ─────────
  runs workflow ──────▶  resolves provider
                         picks claude/codex/pi ───▶ processes prompt
                         streams back ◀──────────── streams response
  sees reply ◀─────────  sends to platform
```

### After

```
  User                   Archon                   AI Client
  ────                   ──────                   ─────────
  runs workflow ──────▶  resolves provider
                         picks [opencode] ────────▶ processes prompt
                         streams back ◀──────────── streams response
  sees reply ◀─────────  sends to platform
```

*OpenCode now available as a provider choice alongside claude, codex, and pi.*

## Architecture Diagram

### Before

```
  registry.ts          index.ts
  ┌──────────┐         ┌──────────┐
  │ register │◄────────│ exports  │
  │ Builtin  │         │          │
  │ register │         │          │
  │ Community│         │          │
  └──────────┘         └──────────┘
       │
       ├── claude/
       ├── codex/
       └── community/pi/
```

### After

```
  registry.ts          index.ts
  ┌──────────┐         ┌──────────┐
  │ register │◄────────│ exports  │
  │ Builtin  │         │          │
  │ register │         │          │
  │ Community│         │          │
  └──────────┘         └──────────┘
       │
       ├── claude/
       ├── codex/
       ├── community/pi/
[+]    └── community/opencode/  [+]
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| registry.ts | community/opencode/registration | **new** | `registerOpenCodeProvider()` called by `registerCommunityProviders()` |
| index.ts | community/opencode | **new** | Re-exports `OpenCodeProvider`, `registerOpenCodeProvider` |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `providers`
- Module: `providers:opencode`

## Change Metadata

- Change type: `feature`
- Primary scope: `providers`

## Linked Issue

- Closes N/A (PoC, no issue)
- Related N/A
- Depends on N/A
- Supersedes N/A

## Validation Evidence (required)

```bash
bun run type-check   # ✅ Pass — no errors
bun run lint         # ✅ Pass — 0 errors, 0 warnings
bun run format:check # ✅ Pass (after auto-fix of 2 files)
bun run test         # ✅ Pass — 0 failures, existing tests unaffected
bun run validate     # ✅ Pass (except pre-existing check:bundled-skill on base commit)
```

- Evidence provided: Full validation output at artifacts/runs/b562d3d7384498ebfeb609b61302d8ad/validation.md
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? `No` (all capabilities disabled)
- New external network calls? `No` (spawns `opencode` subprocess; network calls are OpenCode's responsibility)
- Secrets/tokens handling changed? `No` (no auth config; users configure OpenCode externally)
- File system access scope changed? `No` (runs in existing worktree cwd)
- If any `Yes`, describe risk and mitigation: N/A

## Compatibility / Migration

- Backward compatible? `Yes` (additive change only)
- Config/env changes? `No`
- Database migration needed? `No`
- If yes, exact upgrade steps: N/A

## Human Verification (required)

- Verified scenarios: `bun run type-check`, `bun run lint`, `bun run test`, `bun run validate` all pass
- Edge cases checked: ESLint non-null assertion replacements, void expression lints
- What was not verified: End-to-end `opencode run` invocation (requires OpenCode CLI installed)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: None — purely additive, no existing code modified beyond registry/index export chains
- Potential unintended effects: None expected
- Guardrails/monitoring for early detection: `bun run validate` in CI catches regressions

## Rollback Plan (required)

- Fast rollback command/path: Revert commit `816ec32c` — removes 4 new files + 2 one-line registry/index changes
- Feature flags or config toggles (if any): None
- Observable failure symptoms: OpenCode provider unavailable in provider list; no other impact

## Risks and Mitigations

- Risk: Provider crashes or hangs if OpenCode CLI is not installed
  - Mitigation: `getType()` returns `'opencode'`; `getCapabilities()` returns all-false; provider is `builtIn: false` so users must explicitly configure it. Only activated if a workflow explicitly sets `provider: opencode`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenCode as a community provider that runs the OpenCode CLI and streams its output for interactive responses.
  * Provider auto-detects the OpenCode binary and reports startup or runtime issues to users.
  * Marked as a proof-of-concept with limited capabilities; fallback/error messages are surfaced when unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->