### PR TITLE
feat: support GitHub Enterprise Server via GITHUB_HOST and GITHUB_API_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,12 @@ GITHUB_TOKEN=  # Same as GH_TOKEN, used by adapter
 # GitHub Webhooks
 WEBHOOK_SECRET=
 
+# GitHub Enterprise Server (optional)
+# Point Archon at a self-hosted GitHub Enterprise instance. Both vars must be
+# set for full GHE support; defaults preserve public github.com behavior.
+# GITHUB_HOST=ghe.example.com           # used for clone URLs and the credential helper
+# GITHUB_API_URL=https://ghe.example.com/api/v3   # Octokit baseUrl for the GitHub adapter
+
 # GitHub User Whitelist (optional - comma-separated usernames)
 # When set, only listed GitHub users can trigger webhook processing
 # When empty/unset, webhooks are processed for all users

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Optional `GITHUB_HOST` and `GITHUB_API_URL` environment variables for running Archon against a self-hosted GitHub Enterprise Server. `GITHUB_HOST` (default `github.com`) is used when injecting `GH_TOKEN` into clone URLs, when rewriting SSH URLs to HTTPS, and by the docker entrypoint when registering the git credential helper. `GITHUB_API_URL` (no default) is forwarded to Octokit as `baseUrl` for the GitHub adapter — leave it unset on public github.com to keep Octokit's existing default. Operator setup (App registration on the GHE host, webhook reachability) lives outside Archon (#1593).
 - Docker: `/home/appuser` is now persisted by default via the `archon_user_home` named volume, so user-installed Claude Code skills/commands/agents/hooks, Codex/Pi auth, `~/.gitconfig`, and shell history survive container rebuilds. Set `ARCHON_USER_HOME=/host/path` in `.env` to bind-mount a host path instead (#1517, #1518).
 
 ### Changed

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -54,10 +54,12 @@ find /.archon -name ".git" -prune -print 2>/dev/null | while IFS= read -r git_di
   fi
 done
 
-# Configure git to use GH_TOKEN for HTTPS clones via credential helper
-# Uses a helper function so the token stays in the environment, not in ~/.gitconfig
+# Configure git to use GH_TOKEN for HTTPS clones via credential helper.
+# Uses a helper function so the token stays in the environment, not in ~/.gitconfig.
+# GITHUB_HOST overrides the default (`github.com`) for GitHub Enterprise Server users.
 if [ -n "$GH_TOKEN" ]; then
-  $RUNNER git config --global credential."https://github.com".helper \
+  GITHUB_HOST_RESOLVED="${GITHUB_HOST:-github.com}"
+  $RUNNER git config --global credential."https://${GITHUB_HOST_RESOLVED}".helper \
     '!f() { echo "username=x-access-token"; echo "password=${GH_TOKEN}"; }; f'
 fi
 

--- a/packages/adapters/src/forge/github/adapter.test.ts
+++ b/packages/adapters/src/forge/github/adapter.test.ts
@@ -153,6 +153,26 @@ describe('GitHubAdapter', () => {
     });
   });
 
+  describe('GitHub Enterprise (apiBaseUrl)', () => {
+    type OctokitWithEndpoint = {
+      request: { endpoint: { DEFAULTS: { baseUrl: string } } };
+    };
+
+    test('uses Octokit default baseUrl when apiBaseUrl is not provided', () => {
+      const a = new GitHubAdapter('token', 'secret', mockLockManager);
+      const octokit = (a as unknown as { octokit: OctokitWithEndpoint }).octokit;
+      expect(octokit.request.endpoint.DEFAULTS.baseUrl).toBe('https://api.github.com');
+    });
+
+    test('passes apiBaseUrl through to Octokit when provided', () => {
+      const a = new GitHubAdapter('token', 'secret', mockLockManager, undefined, {
+        apiBaseUrl: 'https://ghe.example.com/api/v3',
+      });
+      const octokit = (a as unknown as { octokit: OctokitWithEndpoint }).octokit;
+      expect(octokit.request.endpoint.DEFAULTS.baseUrl).toBe('https://ghe.example.com/api/v3');
+    });
+  });
+
   describe('lifecycle methods', () => {
     test('should start without errors', async () => {
       await expect(adapter.start()).resolves.toBeUndefined();

--- a/packages/adapters/src/forge/github/adapter.ts
+++ b/packages/adapters/src/forge/github/adapter.ts
@@ -58,9 +58,16 @@ export class GitHubAdapter implements IPlatformAdapter {
     webhookSecret: string,
     lockManager: ConversationLockManager,
     botMention?: string,
-    options?: { retryDelayMs?: (attempt: number) => number }
+    options?: { retryDelayMs?: (attempt: number) => number; apiBaseUrl?: string }
   ) {
-    this.octokit = new Octokit({ auth: token });
+    // Pass `baseUrl` to Octokit only when explicitly provided so the public
+    // github.com default is preserved unchanged for users who don't set
+    // GITHUB_API_URL.
+    const octokitOptions: { auth: string; baseUrl?: string } = { auth: token };
+    if (options?.apiBaseUrl) {
+      octokitOptions.baseUrl = options.apiBaseUrl;
+    }
+    this.octokit = new Octokit(octokitOptions);
     this.webhookSecret = webhookSecret;
     this.lockManager = lockManager;
     this.botMention = botMention ?? 'Archon';

--- a/packages/core/src/handlers/clone.test.ts
+++ b/packages/core/src/handlers/clone.test.ts
@@ -7,7 +7,7 @@
  *   to avoid process-global mock.module pollution that would break git.test.ts
  * - Lazy logger pattern means @archon/paths mock must be set up before the module import
  */
-import { describe, test, expect, mock, beforeEach, afterAll, spyOn } from 'bun:test';
+import { describe, test, expect, mock, beforeEach, afterAll, afterEach, spyOn } from 'bun:test';
 import * as fsPromises from 'fs/promises';
 import * as gitUtils from '@archon/git';
 import { createMockLogger } from '../test/mocks/logger';
@@ -67,7 +67,7 @@ mock.module('../utils/commands', () => ({
 }));
 
 // ── Import module under test AFTER mocks are registered ────────────────────
-import { cloneRepository, registerRepository } from './clone';
+import { cloneRepository, registerRepository, normalizeRepoUrl } from './clone';
 
 // ── Spies for fs/promises and @archon/git ──────────────────────────────────
 let spyFsAccess: ReturnType<typeof spyOn>;
@@ -298,6 +298,93 @@ describe('cloneRepository', () => {
         args => args[0] === 'git' && args[1]?.[0] === 'clone'
       );
       expect(cloneCall?.[1]?.[1]).toContain('ghp_testtoken123@github.com');
+    });
+
+    // ── GitHub Enterprise Server (GITHUB_HOST override) ──────────────────
+    describe('with GITHUB_HOST override', () => {
+      beforeEach(() => {
+        process.env.GITHUB_HOST = 'ghe.example.com';
+      });
+
+      afterAll(() => {
+        delete process.env.GITHUB_HOST;
+      });
+
+      test('injects GH_TOKEN into HTTPS clone URL on the configured host', async () => {
+        mockCreateCodebase.mockResolvedValueOnce(
+          makeCodebase({
+            name: 'owner/repo',
+            repository_url: 'https://ghe.example.com/owner/repo',
+          }) as ReturnType<typeof makeCodebase>
+        );
+
+        await cloneRepository('https://ghe.example.com/owner/repo');
+
+        const cloneCall = (spyExecFileAsync.mock.calls as string[][]).find(
+          args => args[0] === 'git' && args[1]?.[0] === 'clone'
+        );
+        expect(cloneCall?.[1]?.[1]).toContain('ghp_testtoken123@ghe.example.com');
+      });
+
+      test('converts SSH to HTTPS for the configured host and injects GH_TOKEN', async () => {
+        mockCreateCodebase.mockResolvedValueOnce(
+          makeCodebase({
+            name: 'owner/repo',
+            repository_url: 'https://ghe.example.com/owner/repo',
+          }) as ReturnType<typeof makeCodebase>
+        );
+
+        await cloneRepository('git@ghe.example.com:owner/repo.git');
+
+        const cloneCall = (spyExecFileAsync.mock.calls as string[][]).find(
+          args => args[0] === 'git' && args[1]?.[0] === 'clone'
+        );
+        expect(cloneCall?.[1]?.[1]).toContain('ghp_testtoken123@ghe.example.com');
+      });
+
+      test('does NOT inject GH_TOKEN into github.com URLs when GITHUB_HOST points elsewhere', async () => {
+        mockCreateCodebase.mockResolvedValueOnce(makeCodebase() as ReturnType<typeof makeCodebase>);
+
+        await cloneRepository('https://github.com/owner/repo');
+
+        const cloneCall = (spyExecFileAsync.mock.calls as string[][]).find(
+          args => args[0] === 'git' && args[1]?.[0] === 'clone'
+        );
+        expect(cloneCall?.[1]?.[1]).not.toContain('ghp_testtoken123');
+      });
+    });
+  });
+
+  // ── normalizeRepoUrl (host-aware) ──────────────────────────────────────
+  describe('normalizeRepoUrl', () => {
+    afterEach(() => {
+      delete process.env.GITHUB_HOST;
+    });
+
+    test('rewrites git@github.com: to https://github.com/ by default', () => {
+      const r = normalizeRepoUrl('git@github.com:owner/repo.git');
+      expect(r.workingUrl).toBe('https://github.com/owner/repo.git');
+      expect(r.ownerName).toBe('owner');
+      expect(r.repoName).toBe('repo');
+    });
+
+    test('rewrites git@<GITHUB_HOST>: to https://<GITHUB_HOST>/', () => {
+      process.env.GITHUB_HOST = 'ghe.example.com';
+      const r = normalizeRepoUrl('git@ghe.example.com:owner/repo.git');
+      expect(r.workingUrl).toBe('https://ghe.example.com/owner/repo.git');
+      expect(r.ownerName).toBe('owner');
+      expect(r.repoName).toBe('repo');
+    });
+
+    test('leaves other SSH hosts untouched (no implicit rewrite)', () => {
+      process.env.GITHUB_HOST = 'ghe.example.com';
+      const r = normalizeRepoUrl('git@gitlab.com:owner/repo.git');
+      expect(r.workingUrl).toBe('git@gitlab.com:owner/repo.git');
+    });
+
+    test('strips trailing slashes', () => {
+      const r = normalizeRepoUrl('https://github.com/owner/repo///');
+      expect(r.workingUrl).toBe('https://github.com/owner/repo');
     });
   });
 

--- a/packages/core/src/handlers/clone.ts
+++ b/packages/core/src/handlers/clone.ts
@@ -16,6 +16,7 @@ import {
   parseOwnerRepo,
 } from '@archon/paths';
 import { findMarkdownFilesRecursive } from '../utils/commands';
+import { getGitHubHost } from '../utils/github-host';
 import { createLogger } from '@archon/paths';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
@@ -164,19 +165,26 @@ async function registerRepoAtPath(
 }
 
 /**
- * Normalize a repo URL: strip trailing slashes and convert SSH to HTTPS.
+ * Normalize a repo URL: strip trailing slashes and convert SSH to HTTPS for
+ * the configured GitHub host (default `github.com`). Other hosts are left
+ * untouched so they can be cloned over SSH if the operator has configured it.
+ *
+ * Exported so that host-aware parsing can be unit-tested without invoking the
+ * full `cloneRepository` filesystem path.
  */
-function normalizeRepoUrl(rawUrl: string): {
+export function normalizeRepoUrl(rawUrl: string): {
   workingUrl: string;
   ownerName: string;
   repoName: string;
   targetPath: string;
 } {
   const normalizedUrl = rawUrl.replace(/\/+$/, '');
+  const host = getGitHubHost();
+  const sshPrefix = `git@${host}:`;
 
   let workingUrl = normalizedUrl;
-  if (normalizedUrl.startsWith('git@github.com:')) {
-    workingUrl = normalizedUrl.replace('git@github.com:', 'https://github.com/');
+  if (normalizedUrl.startsWith(sshPrefix)) {
+    workingUrl = `https://${host}/${normalizedUrl.slice(sshPrefix.length)}`;
   }
 
   const urlParts = workingUrl.replace(/\.git$/, '').split('/');
@@ -243,15 +251,17 @@ export async function cloneRepository(repoUrl: string): Promise<RegisterResult> 
 
   getLog().info({ url: workingUrl, targetPath }, 'clone_started');
 
-  // Build clone command with authentication if GitHub token is available
+  // Build clone command with authentication if GitHub token is available.
+  // Token is injected for the configured GITHUB_HOST (defaults to github.com).
   let cloneUrl = workingUrl;
   const ghToken = process.env.GH_TOKEN;
+  const host = getGitHubHost();
 
-  if (ghToken && workingUrl.includes('github.com')) {
-    if (workingUrl.startsWith('https://github.com')) {
-      cloneUrl = workingUrl.replace('https://github.com', `https://${ghToken}@github.com`);
-    } else if (workingUrl.startsWith('http://github.com')) {
-      cloneUrl = workingUrl.replace('http://github.com', `https://${ghToken}@github.com`);
+  if (ghToken && workingUrl.toLowerCase().includes(host)) {
+    if (workingUrl.startsWith(`https://${host}`)) {
+      cloneUrl = workingUrl.replace(`https://${host}`, `https://${ghToken}@${host}`);
+    } else if (workingUrl.startsWith(`http://${host}`)) {
+      cloneUrl = workingUrl.replace(`http://${host}`, `https://${ghToken}@${host}`);
     } else if (!workingUrl.startsWith('http')) {
       cloneUrl = `https://${ghToken}@${workingUrl}`;
     }
@@ -328,9 +338,11 @@ export async function registerRepository(localPath: string): Promise<RegisterRes
   let ownerName = '_local';
   if (remoteUrl) {
     const cleaned = remoteUrl.replace(/\.git$/, '').replace(/\/+$/, '');
+    const host = getGitHubHost();
+    const sshPrefix = `git@${host}:`;
     let workingRemote = cleaned;
-    if (cleaned.startsWith('git@github.com:')) {
-      workingRemote = cleaned.replace('git@github.com:', 'https://github.com/');
+    if (cleaned.startsWith(sshPrefix)) {
+      workingRemote = `https://${host}/${cleaned.slice(sshPrefix.length)}`;
     }
     const parts = workingRemote.split('/');
     const r = parts.pop();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -139,6 +139,9 @@ export { sanitizeCredentials, sanitizeError } from './utils/credential-sanitizer
 // GitHub GraphQL
 export { getLinkedIssueNumbers } from './utils/github-graphql';
 
+// GitHub host configuration (GitHub.com / GitHub Enterprise Server)
+export { getGitHubHost, getGitHubApiUrl, isPublicGitHub } from './utils/github-host';
+
 // Path validation
 export { isPathWithinWorkspace, validateAndResolvePath } from './utils/path-validation';
 

--- a/packages/core/src/utils/github-host.test.ts
+++ b/packages/core/src/utils/github-host.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { getGitHubHost, getGitHubApiUrl, isPublicGitHub } from './github-host';
+
+describe('github-host helpers', () => {
+  let originalHost: string | undefined;
+  let originalApiUrl: string | undefined;
+
+  beforeEach(() => {
+    originalHost = process.env.GITHUB_HOST;
+    originalApiUrl = process.env.GITHUB_API_URL;
+    delete process.env.GITHUB_HOST;
+    delete process.env.GITHUB_API_URL;
+  });
+
+  afterEach(() => {
+    if (originalHost === undefined) delete process.env.GITHUB_HOST;
+    else process.env.GITHUB_HOST = originalHost;
+    if (originalApiUrl === undefined) delete process.env.GITHUB_API_URL;
+    else process.env.GITHUB_API_URL = originalApiUrl;
+  });
+
+  describe('getGitHubHost', () => {
+    test('defaults to github.com when unset', () => {
+      expect(getGitHubHost()).toBe('github.com');
+    });
+
+    test('returns the configured host', () => {
+      process.env.GITHUB_HOST = 'ghe.example.com';
+      expect(getGitHubHost()).toBe('ghe.example.com');
+    });
+
+    test('lowercases the host', () => {
+      process.env.GITHUB_HOST = 'GHE.Example.COM';
+      expect(getGitHubHost()).toBe('ghe.example.com');
+    });
+
+    test('strips a leading scheme', () => {
+      process.env.GITHUB_HOST = 'https://ghe.example.com';
+      expect(getGitHubHost()).toBe('ghe.example.com');
+    });
+
+    test('strips trailing slashes', () => {
+      process.env.GITHUB_HOST = 'ghe.example.com/';
+      expect(getGitHubHost()).toBe('ghe.example.com');
+    });
+
+    test('treats whitespace-only as unset', () => {
+      process.env.GITHUB_HOST = '   ';
+      expect(getGitHubHost()).toBe('github.com');
+    });
+  });
+
+  describe('getGitHubApiUrl', () => {
+    test('returns undefined when unset (so Octokit uses its default)', () => {
+      expect(getGitHubApiUrl()).toBeUndefined();
+    });
+
+    test('returns the configured URL verbatim', () => {
+      process.env.GITHUB_API_URL = 'https://ghe.example.com/api/v3';
+      expect(getGitHubApiUrl()).toBe('https://ghe.example.com/api/v3');
+    });
+
+    test('strips trailing slashes', () => {
+      process.env.GITHUB_API_URL = 'https://ghe.example.com/api/v3/';
+      expect(getGitHubApiUrl()).toBe('https://ghe.example.com/api/v3');
+    });
+
+    test('treats whitespace-only as unset', () => {
+      process.env.GITHUB_API_URL = '  ';
+      expect(getGitHubApiUrl()).toBeUndefined();
+    });
+  });
+
+  describe('isPublicGitHub', () => {
+    test('true when host is github.com', () => {
+      expect(isPublicGitHub()).toBe(true);
+    });
+
+    test('false when host is GHE', () => {
+      process.env.GITHUB_HOST = 'ghe.example.com';
+      expect(isPublicGitHub()).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/utils/github-host.ts
+++ b/packages/core/src/utils/github-host.ts
@@ -1,0 +1,51 @@
+/**
+ * GitHub host configuration helpers.
+ *
+ * Reads `GITHUB_HOST` and `GITHUB_API_URL` from the environment with sensible
+ * defaults so callers don't sprinkle `process.env.*` reads across the codebase.
+ *
+ * - `GITHUB_HOST` is the user-facing hostname used for clone URLs and the git
+ *   credential helper (e.g. `github.com`, `ghe.example.com`). Lowercased and
+ *   stripped of any leading scheme/trailing slash.
+ * - `GITHUB_API_URL` is the REST API base URL passed to Octokit (e.g.
+ *   `https://api.github.com`, `https://ghe.example.com/api/v3`). Trailing
+ *   slashes are stripped; left undefined when unset so Octokit applies its own
+ *   default.
+ */
+
+const DEFAULT_GITHUB_HOST = 'github.com';
+
+/**
+ * Return the configured GitHub host, defaulting to `github.com`.
+ * The result is lowercase and contains no scheme or trailing slash.
+ */
+export function getGitHubHost(): string {
+  const raw = process.env.GITHUB_HOST?.trim();
+  if (!raw) return DEFAULT_GITHUB_HOST;
+  return raw
+    .replace(/^https?:\/\//i, '')
+    .replace(/\/+$/, '')
+    .toLowerCase();
+}
+
+/**
+ * Return the configured GitHub REST API URL, or `undefined` when the user
+ * hasn't set `GITHUB_API_URL`. Returning `undefined` (rather than
+ * `https://api.github.com`) lets Octokit fall back to its own default and
+ * keeps the public github.com behavior identical to versions that predate
+ * this option.
+ */
+export function getGitHubApiUrl(): string | undefined {
+  const raw = process.env.GITHUB_API_URL?.trim();
+  if (!raw) return undefined;
+  return raw.replace(/\/+$/, '');
+}
+
+/**
+ * Convenience: true when the configured host is the public github.com.
+ * Useful for code paths that only need to know whether they're in
+ * Enterprise mode (e.g. to skip features that don't make sense off-public).
+ */
+export function isPublicGitHub(): boolean {
+  return getGitHubHost() === DEFAULT_GITHUB_HOST;
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -73,6 +73,7 @@ import {
   loadConfig,
   logConfig,
   getPort,
+  getGitHubApiUrl,
 } from '@archon/core';
 import type { IPlatformAdapter } from '@archon/core';
 import {
@@ -282,11 +283,15 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
     if (process.env.GITHUB_TOKEN && process.env.WEBHOOK_SECRET) {
       const botMention =
         process.env.GITHUB_BOT_MENTION || process.env.BOT_DISPLAY_NAME || config.botName;
+      // Pass `apiBaseUrl` only when the user has explicitly set GITHUB_API_URL
+      // so Octokit's public github.com default is preserved otherwise.
+      const apiBaseUrl = getGitHubApiUrl();
       github = new GitHubAdapter(
         process.env.GITHUB_TOKEN,
         process.env.WEBHOOK_SECRET,
         lockManager,
-        botMention
+        botMention,
+        apiBaseUrl ? { apiBaseUrl } : undefined
       );
       await github.start();
       activePlatforms.push('GitHub');


### PR DESCRIPTION
Closes #1593.

Today the GitHub host is hardcoded to `github.com` / `api.github.com` in three places, which makes Archon unusable against a self-hosted GitHub Enterprise Server (GHE) without forking. This PR adds two optional environment variables that mirror the existing `GITEA_URL` precedent so the GHE path is config-only — defaults preserve public github.com behavior bit-for-bit.

## What changes

| Variable | Default | Used by |
|---|---|---|
| `GITHUB_HOST` | `github.com` | `cloneRepository` (`GH_TOKEN` injection), `normalizeRepoUrl` (SSH→HTTPS rewrite), `docker-entrypoint.sh` (git credential helper) |
| `GITHUB_API_URL` | _(unset → Octokit default)_ | `GitHubAdapter` (forwarded to Octokit as `baseUrl`) |

Both env reads are centralized in `packages/core/src/utils/github-host.ts` (`getGitHubHost`, `getGitHubApiUrl`) so future call sites don't have to re-implement env parsing / lowercase / trailing-slash normalization.

`GITHUB_API_URL` returns `undefined` when unset (rather than `https://api.github.com`) so Octokit applies its own default — that keeps the existing initialization path identical for users who don't opt in.

## What this does NOT change

- **No protocol or behavior change for github.com users.** When neither env var is set, `cloneRepository`, the entrypoint script, and the adapter all behave exactly as before.
- **No provider abstraction.** A unified Provider interface across GitHub/GHE/Gitea is a sensible next step but deliberately out of scope here to keep the diff reviewable. Happy to follow up if you'd like.
- **No GHE-specific operator handholding.** App registration on the GHE host, webhook reachability, and the decision between an App or PAT for `GITHUB_TOKEN` are operator concerns documented in `.env.example` and the CHANGELOG entry; Archon stays opaque to the token's origin (Octokit just sets `Authorization: Bearer ...`).

## Files touched

- `packages/core/src/utils/github-host.ts` _(new)_ — host/api-url helpers.
- `packages/core/src/utils/github-host.test.ts` _(new)_ — unit tests for defaults, scheme/slash stripping, lowercase, whitespace handling.
- `packages/core/src/handlers/clone.ts` — `normalizeRepoUrl` is now host-aware (SSH-to-HTTPS rewrites only the configured host) and exported for testing; `GH_TOKEN` injection uses `getGitHubHost()` instead of literal `github.com`. `registerRepository`'s remote-URL parsing uses the same helper.
- `packages/core/src/handlers/clone.test.ts` — added a `GITHUB_HOST` override block under `GH_TOKEN authentication` (token injection on the configured host, SSH→HTTPS rewrite on that host, and a guard that `github.com` URLs do _not_ get the token when `GITHUB_HOST` points elsewhere) plus host-aware `normalizeRepoUrl` tests.
- `packages/core/src/index.ts` — re-exports the helpers.
- `packages/adapters/src/forge/github/adapter.ts` — `apiBaseUrl?` added to the existing `options` constructor argument; passed through to Octokit as `baseUrl` only when set.
- `packages/adapters/src/forge/github/adapter.test.ts` — asserts `octokit.request.endpoint.DEFAULTS.baseUrl` matches what the user passed (and the Octokit default when nothing is passed).
- `packages/server/src/index.ts` — reads `getGitHubApiUrl()` and forwards `apiBaseUrl` into the `GitHubAdapter` constructor.
- `docker-entrypoint.sh` — credential helper line uses `${GITHUB_HOST:-github.com}` instead of a literal `https://github.com`.
- `.env.example` — documents the new vars under the GitHub section.
- `CHANGELOG.md` — `[Unreleased] → Added` entry.

## Test plan

- [x] `bun --filter @archon/core test` — new helper + clone + normalizeRepoUrl tests pass; pre-existing tests unchanged.
- [x] `bun --filter @archon/adapters test` — new GitHubAdapter `apiBaseUrl` tests pass; pre-existing tests unchanged.
- [x] `bun run type-check` — clean across all 10 packages.
- [x] `bun run lint` — clean.
- [x] `bun run format:check` — clean.
- [x] Manual sanity: with neither env var set, the rendered Octokit `baseUrl` is `https://api.github.com` and the credential helper line in the entrypoint is identical to before.