### PR TITLE
fix(workflows): bun script nodes — use --env-file=<null> to actually suppress cwd .env auto-load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Docker: `git config --global --add safe.directory` in the entrypoint now de-duplicates entries before adding, preventing unbounded growth of `~/.gitconfig` now that `/home/appuser` is persisted (#1518).
 - Docker: `setup-auth` now warns at startup when `CODEX_*` env vars are absent but a persisted `~/.codex/auth.json` from a previous run still exists, so operators don't accidentally use stale or revoked credentials (#1518).
+- `script:` nodes (`runtime: bun`) now actually suppress Bun's cwd `.env` auto-load. The previous `--no-env-file` flag turns out to only disable explicit `--env-file=…` args — Bun still auto-loads `.env` from the script's execution directory regardless. Switched to `--env-file=/dev/null` (POSIX) / `--env-file=NUL` (Windows), which is the only argument form that actually short-circuits the auto-load. Verified empirically against bun 1.3.x. Resolves the previously-tolerated `bun script node does not leak repo .env from execution cwd` test under #1135 — the registration-time gate from #1169 was the primary protection; this is the defense-in-depth layer that is now also honest.
 
 ## [0.3.10] - 2026-04-29
 

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -6511,9 +6511,15 @@ describe('executeDagWorkflow -- script nodes', () => {
       { ...minimalConfig, envVars: { MY_SECRET: 'abc123' } }
     );
 
+    // The first arg suppresses Bun's cwd .env auto-load. `--no-env-file`
+    // doesn't actually do that — it only disables explicit `--env-file=…`
+    // args. The portable null-env-file value is `/dev/null` on POSIX and
+    // `NUL` on Windows; we accept either so the test runs on both.
+    const expectedNullEnvArg =
+      process.platform === 'win32' ? '--env-file=NUL' : '--env-file=/dev/null';
     expect(execSpy).toHaveBeenCalledWith(
       'bun',
-      ['--no-env-file', '-e', 'console.log("ok")'],
+      [expectedNullEnvArg, '-e', 'console.log("ok")'],
       expect.objectContaining({
         env: expect.objectContaining({ MY_SECRET: 'abc123' }),
       })

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -37,6 +37,7 @@ import {
   checkTriggerRule,
   substituteNodeOutputRefs,
   executeDagWorkflow,
+  BUN_NULL_ENV_FILE,
 } from './dag-executor';
 import { loadMcpConfig } from '@archon/providers/claude/provider';
 import type { DagNode, BashNode, ScriptNode, NodeOutput, WorkflowRun } from './schemas';
@@ -6514,12 +6515,10 @@ describe('executeDagWorkflow -- script nodes', () => {
     // The first arg suppresses Bun's cwd .env auto-load. `--no-env-file`
     // doesn't actually do that — it only disables explicit `--env-file=…`
     // args. The portable null-env-file value is `/dev/null` on POSIX and
-    // `NUL` on Windows; we accept either so the test runs on both.
-    const expectedNullEnvArg =
-      process.platform === 'win32' ? '--env-file=NUL' : '--env-file=/dev/null';
+    // `NUL` on Windows; the imported constant resolves to the right one.
     expect(execSpy).toHaveBeenCalledWith(
       'bun',
-      [expectedNullEnvArg, '-e', 'console.log("ok")'],
+      [`--env-file=${BUN_NULL_ENV_FILE}`, '-e', 'console.log("ok")'],
       expect.objectContaining({
         env: expect.objectContaining({ MY_SECRET: 'abc123' }),
       })

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1257,6 +1257,16 @@ async function executeNodeInternal(
 const SUBPROCESS_DEFAULT_TIMEOUT = 120_000;
 
 /**
+ * Empty file Bun is pointed at via `--env-file=` to suppress its
+ * cwd `.env` auto-load for `script:` nodes. `--no-env-file` only
+ * disables explicit `--env-file=…` args; the cwd auto-load survives
+ * unless we point Bun at a real (empty) file. `/dev/null` on POSIX,
+ * `NUL` on Windows. (Verified empirically against bun 1.3.x — see
+ * the regression test in `dag-executor.test.ts` for #1135.)
+ */
+const BUN_NULL_ENV_FILE = process.platform === 'win32' ? 'NUL' : '/dev/null';
+
+/**
  * Execute a bash (shell script) DAG node.
  * Runs the script via `bash -c`, captures stdout as node output.
  * No AI session is created — bash nodes are free/deterministic.
@@ -1498,10 +1508,13 @@ async function executeScriptNode(
       // Inline code execution
       if (node.runtime === 'bun') {
         cmd = 'bun';
-        // --no-env-file prevents Bun from auto-loading .env from the execution
-        // cwd (the target repo). Without this, repo .env leaks into the script
-        // subprocess despite Archon's parent process cleanup.
-        args = ['--no-env-file', '-e', finalScript];
+        // Suppress Bun's auto-load of `.env` from the execution cwd
+        // (the target repo). `--no-env-file` ONLY disables explicit
+        // `--env-file=…` args — it does NOT stop the cwd auto-load.
+        // The portable way to actually suppress the auto-load is to
+        // point Bun at an empty file: `/dev/null` on POSIX, `NUL` on
+        // Windows. Verified empirically against bun 1.3.x.
+        args = [`--env-file=${BUN_NULL_ENV_FILE}`, '-e', finalScript];
       } else {
         // uv run --with dep1 --with dep2 python -c <code>
         cmd = 'uv';
@@ -1509,7 +1522,8 @@ async function executeScriptNode(
         args = ['run', ...withFlags, 'python', '-c', finalScript];
       }
     } else {
-      // Named script — look up across repo and home scopes.
+      // Named script — look up across repo and home scopes. Same
+      // `--env-file=<null>` rationale as inline scripts above.
       // Precedence: <cwd>/.archon/scripts/ > ~/.archon/scripts/ (repo wins).
       // Wrap discovery in its own try/catch so a permission error on ~/.archon/scripts/
       // isn't mis-attributed by the outer catch's "permission denied (check cwd
@@ -1586,7 +1600,7 @@ async function executeScriptNode(
         args = ['run', ...withFlags, scriptDef.path];
       } else {
         cmd = 'bun';
-        args = ['--no-env-file', 'run', scriptDef.path];
+        args = [`--env-file=${BUN_NULL_ENV_FILE}`, 'run', scriptDef.path];
       }
     }
 

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1264,7 +1264,7 @@ const SUBPROCESS_DEFAULT_TIMEOUT = 120_000;
  * `NUL` on Windows. (Verified empirically against bun 1.3.x — see
  * the regression test in `dag-executor.test.ts` for #1135.)
  */
-const BUN_NULL_ENV_FILE = process.platform === 'win32' ? 'NUL' : '/dev/null';
+export const BUN_NULL_ENV_FILE = process.platform === 'win32' ? 'NUL' : '/dev/null';
 
 /**
  * Execute a bash (shell script) DAG node.

--- a/packages/workflows/src/script-node-deps.test.ts
+++ b/packages/workflows/src/script-node-deps.test.ts
@@ -287,7 +287,7 @@ describe('script node deps field — command construction', () => {
     expect(args).toEqual(['run', 'python', '-c', 'print("no deps")']);
   });
 
-  it('bun inline with deps uses bun --no-env-file -e (no extra dep flags — bun auto-installs)', async () => {
+  it('bun inline with deps uses bun --env-file=<null> -e (no extra dep flags — bun auto-installs)', async () => {
     const node: ScriptNode = {
       id: 'bun-with-deps',
       script: 'import { z } from "zod"; console.log(z.string().parse("hello"))',
@@ -316,13 +316,17 @@ describe('script node deps field — command construction', () => {
     expect(scriptCall).toBeDefined();
     const [cmd, args] = scriptCall as [string, string[]];
     expect(cmd).toBe('bun');
-    // --no-env-file prevents repo .env auto-load; no dep flags — bun auto-installs
-    expect(args).toEqual(['--no-env-file', '-e', node.script]);
+    // --env-file=<null> prevents Bun's cwd .env auto-load (--no-env-file
+    // only suppresses explicit --env-file=… args, not the auto-load).
+    // No dep flags — bun auto-installs.
+    const expectedNullEnvArg =
+      process.platform === 'win32' ? '--env-file=NUL' : '--env-file=/dev/null';
+    expect(args).toEqual([expectedNullEnvArg, '-e', node.script]);
     expect(args).not.toContain('--packages');
     expect(args).not.toContain('--with');
   });
 
-  it('bun inline without deps uses bun --no-env-file -e', async () => {
+  it('bun inline without deps uses bun --env-file=<null> -e', async () => {
     const node: ScriptNode = {
       id: 'bun-no-deps',
       script: 'console.log("hello")',
@@ -350,7 +354,9 @@ describe('script node deps field — command construction', () => {
     expect(scriptCall).toBeDefined();
     const [cmd, args] = scriptCall as [string, string[]];
     expect(cmd).toBe('bun');
-    expect(args).toEqual(['--no-env-file', '-e', 'console.log("hello")']);
+    const expectedNullEnvArg2 =
+      process.platform === 'win32' ? '--env-file=NUL' : '--env-file=/dev/null';
+    expect(args).toEqual([expectedNullEnvArg2, '-e', 'console.log("hello")']);
   });
 
   it('uv named script with deps uses uv run --with flags', async () => {

--- a/packages/workflows/src/script-node-deps.test.ts
+++ b/packages/workflows/src/script-node-deps.test.ts
@@ -45,7 +45,7 @@ mock.module('@archon/paths', () => ({
 }));
 
 // --- Imports (after all mock.module calls) ---
-import { executeDagWorkflow } from './dag-executor';
+import { executeDagWorkflow, BUN_NULL_ENV_FILE } from './dag-executor';
 import type { ScriptNode, WorkflowRun } from './schemas';
 import type { WorkflowDeps, IWorkflowPlatform, WorkflowConfig } from './deps';
 import type { IWorkflowStore } from './store';
@@ -319,9 +319,7 @@ describe('script node deps field — command construction', () => {
     // --env-file=<null> prevents Bun's cwd .env auto-load (--no-env-file
     // only suppresses explicit --env-file=… args, not the auto-load).
     // No dep flags — bun auto-installs.
-    const expectedNullEnvArg =
-      process.platform === 'win32' ? '--env-file=NUL' : '--env-file=/dev/null';
-    expect(args).toEqual([expectedNullEnvArg, '-e', node.script]);
+    expect(args).toEqual([`--env-file=${BUN_NULL_ENV_FILE}`, '-e', node.script]);
     expect(args).not.toContain('--packages');
     expect(args).not.toContain('--with');
   });
@@ -354,9 +352,7 @@ describe('script node deps field — command construction', () => {
     expect(scriptCall).toBeDefined();
     const [cmd, args] = scriptCall as [string, string[]];
     expect(cmd).toBe('bun');
-    const expectedNullEnvArg2 =
-      process.platform === 'win32' ? '--env-file=NUL' : '--env-file=/dev/null';
-    expect(args).toEqual([expectedNullEnvArg2, '-e', 'console.log("hello")']);
+    expect(args).toEqual([`--env-file=${BUN_NULL_ENV_FILE}`, '-e', 'console.log("hello")']);
   });
 
   it('uv named script with deps uses uv run --with flags', async () => {


### PR DESCRIPTION
## Summary

- **Problem**: The `script:` nodes (`runtime: bun`) tried to suppress Bun's cwd `.env` auto-load with `--no-env-file`, but that flag only disables explicit `--env-file=…` args — Bun still auto-loads `.env` from the script's execution directory regardless. The previously-tolerated regression-test (`bun script node does not leak repo .env from execution cwd`) under #1135 has been failing for that reason.
- **Why it matters**: Defense-in-depth security boundary. The user-facing protection comes from the registration-time gate landed in #1169 (refuses repos whose auto-loaded `.env` contains sensitive keys), but the in-process subprocess layer was silently a no-op.
- **What changed**: Switched both `script:` node call sites to `--env-file=/dev/null` (POSIX) / `--env-file=NUL` (Windows). Verified empirically against bun 1.3.x. Two test assertions updated to match. CHANGELOG entry under `[Unreleased] → Fixed`.
- **What did NOT change (scope boundary)**: Bash nodes (no Bun involvement), the registration-time gate from #1169, parent-process `stripCwdEnv()` boot protection, claude/codex provider env construction, no schema/migration/config changes.

## UX Journey

### Before

\`\`\`
User                   Archon                          script: subprocess
────                   ──────                          ──────────────────
runs workflow ──────▶  spawns:
                       bun --no-env-file -e <code>    bun starts in cwd
                       (intent: no .env auto-load)    auto-loads ./.env  ← LEAKS
                                                       process.env has
                                                       repo secrets
sees broken            (defense-in-depth gate
test                    silently bypassed)
\`\`\`

### After

\`\`\`
User                   Archon                              script: subprocess
────                   ──────                              ──────────────────
runs workflow ──────▶  spawns:
                       bun *--env-file=/dev/null* -e <c>  bun starts in cwd
                                                          *skips* ./.env auto-load
                                                          process.env clean
                                                          (only Archon-managed
                                                           envVars present)
\`\`\`

## Architecture Diagram

### Before

\`\`\`
packages/workflows/src/dag-executor.ts
       │
       │ spawnScript()
       ▼
   execFileAsync('bun', ['--no-env-file', '-e', code], {cwd, env})
                          │
                          └─ no-op for cwd auto-load (Bun bug/feature)
\`\`\`

### After

\`\`\`
packages/workflows/src/dag-executor.ts
       │ + BUN_NULL_ENV_FILE constant (POSIX: /dev/null, Win32: NUL)
       │
       │ spawnScript()
       ▼
   execFileAsync('bun', ['--env-file=' + BUN_NULL_ENV_FILE, '-e', code], {cwd, env})
                          │
                          └─ Bun reads empty file → skips cwd auto-load
\`\`\`

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| dag-executor.ts | bun subprocess | **modified** | flag changed; same call site |
| dag-executor.test.ts | spawn assertion | **modified** | matches new flag form |
| script-node-deps.test.ts | spawn assertion | **modified** | matches new flag form |
| dag-executor.ts | bash subprocess | unchanged | bash nodes never used the flag |

## Label Snapshot

- Risk: \`risk: low\`
- Size: \`size: XS\`
- Scope: \`workflows\`
- Module: \`workflows:dag-executor\`

## Change Metadata

- Change type: \`bug\` (defense-in-depth security boundary that was silently broken)
- Primary scope: \`workflows\`

## Linked Issue

- Closes #1135 (the test regression layer; the user-facing gate was already closed by #1169)

## Validation Evidence (required)

\`\`\`bash
$ bun run validate
# all packages: 0 fail across the suite
# (specifically: dag-executor.test.ts 206/206 pass; script-node-deps.test.ts 0 fail)
\`\`\`

- Evidence: full \`bun run validate\` exited 0 with no failures across all 14 test invocations
- Empirical verification of the flag form:
  \`\`\`
  with --no-env-file:        \"should_not_appear\"   ← still leaks
  with --env-file=/dev/null: \"CLEAN\"              ← actually works
  with BUN_DISABLE_DOTENV=1: \"should_not_appear\"   ← also doesn't help
  \`\`\`

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No** — this strengthens an existing boundary
- File system access scope changed? **No**
- Risk: this is a security strengthening, not a relaxation

## Compatibility / Migration

- Backward compatible? **Yes** — pure flag swap, no schema/config/API changes
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

- Verified scenarios:
  - Empirical leak reproduction with both flag forms (manual `bun -e` test)
  - Full \`bun run validate\` end-to-end
  - Three deterministic re-runs of dag-executor.test.ts (206/206 each time)
- Edge cases checked:
  - Inline script path (\`bun -e <code>\`) — line 1504 in dag-executor.ts
  - Named script path (\`bun run <path>\`) — line 1591 in dag-executor.ts
  - Both call sites use the same constant
- What was not verified:
  - Windows execution (no Windows machine handy) — used \`process.platform === 'win32' ? 'NUL' : '/dev/null'\` per Bun's documented Windows null-device support; unit-test assertion accommodates both forms

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: only \`script:\` DAG nodes with \`runtime: bun\` — bash nodes, prompt nodes, command nodes, claude_code nodes are untouched
- Potential unintended effects: if a user was *relying* on the leak (intentionally putting secrets in a target repo \`.env\` for their script to pick up), their workflow will now see those secrets missing. Per Archon's security model (#1135, #1169) this was never supported — they should use \`.archon/config.yaml env:\` or per-codebase env vars instead
- Guardrails/monitoring for early detection: the regression test now passes; CI catches any future flag regressions

## Rollback Plan (required)

- Fast rollback: revert this single commit; the previous (broken-but-tolerated) state returns
- Feature flags or config toggles: none required
- Observable failure symptoms: \`script:\` node fails to find an env var its inline code expects, where that env var was *previously* leaked from the cwd \`.env\`. (Indicates user was relying on the leak — not a bug to roll back, but worth a note in support.)

## Risks and Mitigations

- **Risk**: A user's existing script silently relied on the leak.
  - **Mitigation**: Migration path is documented in the existing \`.archon/config.yaml env:\` and per-codebase env-vars surfaces. The CHANGELOG entry frames the change as a security fix and points at the supported paths.
- **Risk**: Future Bun version changes the meaning of \`--env-file=/dev/null\`.
  - **Mitigation**: The two test assertions catch any flag-shape regression on every CI run; the empirical test embedded in the existing regression test (\`bun script node does not leak repo .env\`) catches behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended .env auto-loading when running scripts with Bun, ensuring scripts no longer inherit workspace cwd env variables.

* **Changed**
  * Bun script invocation now uses an explicit, cross-platform null env-file argument (POSIX and Windows) for more reliable environment isolation and test consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->