### PR TITLE
feat(workflows): add execution-evidence contract with terminal-success gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -713,6 +713,7 @@ async function createSession(conversationId: string, codebaseId: string) {
    - Provider inherited from `.archon/config.yaml` unless explicitly set; per-node `provider` and `model` overrides supported
    - Model and options can be set per workflow or inherited from config defaults
    - `interactive: true` at the workflow level forces foreground execution on web (required for approval-gate workflows in the web UI)
+   - `evidence_policy` (optional, workflow level) blocks terminal `completed` status unless `$ARTIFACTS_DIR/evidence.json` (path configurable) parses against the execution-evidence contract. `verify: 'shape'` (default) is hermetic; `verify: 'reality'` additionally checks commit SHA / pushed branch / PR URL via `git`/`gh`. On failure the run is marked `failed` and structured issues are persisted at `metadata.evidence_validation`. Defaults to absent (no gate) to preserve existing workflow behavior.
    - Model validation ensures provider/model compatibility at load time
    - Commands: `/workflow list`, `/workflow reload`, `/workflow status`, `/workflow cancel`, `/workflow resume <id>` (re-runs failed workflow, skipping completed nodes), `/workflow abandon <id>`, `/workflow cleanup [days]` (CLI only — deletes old run records)
    - Resilient loading: One broken YAML doesn't abort discovery; errors shown in `/workflow list`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,220 @@
+# Archon Upgrade Roadmap
+
+This roadmap is for the `shhaider/Archon` fork as a standalone product.
+
+Archon is the baseline product. SimpleAgent, AgentOS-NG, OpenSWE, and Emdash
+are reference or extraction candidates only. They are not architecture
+authorities for this repo unless a later task explicitly imports a specific
+module, workflow, UI surface, or design pattern.
+
+## Product Direction
+
+Archon should become the user-facing system for deterministic AI coding:
+
+- a user chats with one coordinating agent per project or workstream
+- the coordinator turns roadmap items into dependency-aware task graphs
+- independent work is farmed out to multiple isolated coding agents
+- each coding agent works in a branch/worktree sandbox
+- results are verified by tests, evidence checks, code review, commit, push,
+  and PR creation
+- failures, crashes, stuck runs, and bad outputs become Archon improvement
+  tasks instead of being treated as one-off operator cleanup
+
+## Source Authority
+
+1. This repo's runtime code and tests.
+2. This repo's `CLAUDE.md`, `README.md`, and public roadmap data in
+   `packages/docs-web/src/data/roadmap.ts`.
+3. Current upstream Archon docs at `https://archon.diy`.
+4. Sidecar source checkouts only when explicitly referenced by a task:
+   - Emdash for GUI, multi-agent chat, provider/worktree UX, and sandbox design.
+   - SimpleAgent and AgentOS-NG for enforceability, gate, memory, and prior
+     coding-harness ideas.
+   - OpenSWE for LangGraph/deep-agent coding harness patterns.
+
+## Near-Term Priority Order
+
+### P0 - Standalone Repo And Baseline
+
+Status: in progress.
+
+Goals:
+
+- Keep Archon in its own fork/repo: `shhaider/Archon`.
+- Treat upstream `coleam00/Archon` as the base product.
+- Do not rely on SimpleAgent's roadmap as an Archon roadmap.
+- Establish local validation commands for this repo.
+
+Acceptance:
+
+- dedicated Archon checkout exists
+- branch and PR target are Archon's `dev` branch
+- this roadmap is committed in the Archon repo
+- baseline CLI/workflow status is recorded
+
+### P1 - Local GUI Repair And Real-User Verification
+
+Goal: make the Archon web UI the local operator surface for dogfooding Archon
+on Archon.
+
+Tasks:
+
+- install/bootstrap dependencies in the Archon checkout
+- run the source web/server dev path, not only the binary cache
+- verify the Chat, Dashboard, Workflow Builder, and Workflow Execution views
+  load
+- run at least one real-user browser journey with Playwright or equivalent:
+  register the Archon repo, open a chat, start or inspect a workflow, and
+  confirm visible workflow state
+- record screenshots and console/network failures
+
+Acceptance:
+
+- `bun run dev` or an equivalent split server/web path starts cleanly
+- GUI test evidence exists
+- server and web logs identify the served source checkout
+- GUI failures become concrete bugs on this roadmap
+
+### P2 - Parallel Runtime Reliability
+
+Goal: Archon must safely run several instances at once.
+
+Initial observed bug:
+
+- On 2026-05-06, two concurrent read-only CLI calls against the installed
+  SQLite DB produced `Error: database is locked`.
+
+Tasks:
+
+- reproduce the lock with a deterministic test or script
+- harden SQLite access for concurrent CLI/server reads and writes
+- add busy timeout/WAL handling or retry policy where appropriate
+- ensure read-only status/list commands do not fail under normal concurrent
+  operation
+
+Acceptance:
+
+- a concurrency regression test fails before the fix and passes after
+- concurrent `archon workflow status` / `archon isolation list` style calls
+  do not fail with database lock errors
+- the fix does not silently mark active workflows failed/cancelled
+
+### P3 - Enforceable Real-Execution Proof
+
+Goal: Archon should never report a coding workflow complete when no real code
+was shipped.
+
+Tasks:
+
+- define a coding-result evidence contract:
+  changed files, diff, test commands, test output, commit SHA, pushed branch,
+  PR URL, and provider/run IDs
+- add validation hooks or workflow nodes that block success when required proof
+  is missing
+- distinguish planning artifacts from real external-coder execution
+- add negative tests for fake success and artifact-only success
+
+Acceptance:
+
+- a workflow can require real execution proof before terminal success
+- fake or incomplete proof fails deterministically
+- PR-producing workflows include evidence in their final summary
+
+### P4 - Multi-Root Coordinator Architecture
+
+Goal: support multiple root-level coordinator conversations, each capable of
+dispatching multiple coding workers.
+
+Architecture direction:
+
+- one project may have several root coordinators, each bound to a roadmap,
+  phase, or user chat window
+- each root coordinator owns a durable task graph with dependencies, claims,
+  worker slots, and evidence state
+- root coordinators may spawn child planning agents when prompt-pack creation
+  becomes the bottleneck
+- worker agents remain isolated in branch/worktree environments
+- merge and PR activity is serialized by dependency/ownership gates, not by
+  hidden chat memory
+
+Tasks:
+
+- model coordinator runs, roadmap tasks, dependencies, worker claims, and
+  evidence in the database
+- expose status and controls in CLI and Web UI
+- add max-parallel worker limits per root coordinator and per repo
+- support crash/restart/resume of coordinator-owned task graphs
+
+Acceptance:
+
+- one user can open multiple root chat windows against the same repo
+- each root can dispatch independent worker runs without clobbering another
+  root's claims
+- status surfaces show roots, child workers, dependencies, blockers, and PRs
+
+### P5 - Emdash Feature Evaluation And Selective Port
+
+Goal: borrow the useful Emdash product experience without making Emdash the
+backend authority.
+
+Evaluate:
+
+- multi-agent task/conversation UI
+- task branch/worktree creation UX
+- provider selection and provider status surfaces
+- diff, PR, and review UX
+- sandbox/worktree trust and cleanup behavior
+
+Decision options:
+
+- selective UI port into Archon's React web app
+- separate Emdash adapter/front-end shell for Archon backend APIs
+- no port, only extract UX patterns
+
+Acceptance:
+
+- architecture decision record documents import/port/no-port
+- any ported feature uses Archon's workflow/coordinator/evidence backend
+- no SimpleAgent-only bridge assumptions are imported as authority
+
+### P6 - Sidecar Extraction From SimpleAgent / AgentOS-NG / OpenSWE
+
+Goal: extract proven ideas only after Archon-native gaps are explicit.
+
+Candidate areas:
+
+- gate runner and evidence package patterns
+- standards/enforceability checks
+- memory/context compaction ideas
+- OpenSWE/LangGraph coding-harness lessons
+- Project OS style coordination ledgers
+
+Acceptance:
+
+- each extraction has a named Archon gap and a specific target module
+- no broad repo fusion happens without an ADR
+- LangGraph and YAML workflow designs are treated as separate orchestration
+  choices unless an adapter layer is explicitly designed
+
+## Operating Rule For Dogfooding
+
+Use Archon to upgrade Archon, with bounded parallelism.
+
+- run up to five Archon workflow instances at once
+- each instance owns an isolated branch/worktree
+- if Archon crashes, diagnose the Archon bug, fix it, and resume the blocked
+  task
+- mistakes made by Archon-generated workers become roadmap tasks or immediate
+  fixes depending on severity
+- do not close a task on prompt-pack generation alone; real code tasks require
+  real code, tests, commit, push, and PR evidence
+
+## Initial Worker Queue
+
+1. P2-A: reproduce and fix concurrent SQLite lock failures.
+2. P1-A: bootstrap source GUI and add a real-user GUI smoke journey.
+3. P3-A: design and implement real-execution proof validation for PR-producing
+   workflows.
+4. P4-A: design the coordinator/run/task/claim database model and API surface.
+5. P5-A: audit Emdash for GUI/worktree/conversation features worth porting.
+

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -217,4 +217,3 @@ Use Archon to upgrade Archon, with bounded parallelism.
    workflows.
 4. P4-A: design the coordinator/run/task/claim database model and API surface.
 5. P5-A: audit Emdash for GUI/worktree/conversation features worth porting.
-

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -130,6 +130,14 @@ tags: [GitLab, Review]           # Optional: explicit Web UI filter tags. Overri
                                  #   keyword-based tag inference. An empty list (`tags: []`)
                                  #   suppresses inference and shows no tags. Omit to fall
                                  #   back to inferred tags (the default).
+evidence_policy:                 # Optional: gate terminal `completed` on real-execution proof.
+  required: true                 #   When true, the run fails unless $ARTIFACTS_DIR/<path>
+                                 #   parses as ExecutionEvidence and (when verify: reality)
+                                 #   the commit SHA / pushed branch / PR URL are reachable.
+  verify: shape                  #   'shape' (default) = Zod + cross-field integrity, no I/O.
+                                 #   'reality'         = also check commit/branch/PR via git/gh.
+  path: evidence.json            #   Default. Relative to $ARTIFACTS_DIR. Absolute paths
+                                 #   and `..` segments are rejected.
 
 # Required for DAG-based
 nodes:
@@ -729,6 +737,92 @@ nodes:
 ```
 
 The workflow uses `opus` instead of the config default `haiku`, but other settings inherit from config.
+
+---
+
+## Evidence-Gated Workflows
+
+A workflow may require **real-execution proof** before it is allowed to reach terminal `completed` status. This is opt-in per workflow.
+
+### Why
+
+Without this gate, a workflow that only ran a planning prompt and never committed code can still report `completed`. Setting `evidence_policy.required: true` forces the workflow author (or a final node) to write a structured proof artifact at `$ARTIFACTS_DIR/evidence.json`. If the artifact is missing or invalid, the run is marked `failed` with structured issues at `metadata.evidence_validation`.
+
+### Schema
+
+```yaml
+evidence_policy:
+  required: true                 # default: false (omit to disable)
+  verify: shape                  # 'shape' | 'reality' (default: 'shape')
+  path: evidence.json            # relative to $ARTIFACTS_DIR (default: evidence.json)
+```
+
+### The `evidence.json` contract
+
+The file MUST be a JSON object matching one of the two `kind` shapes:
+
+**`kind: 'execution'`** (the only shape that passes the gate):
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `kind` | `'execution'` | discriminator |
+| `workflow_run_id` | string | non-empty |
+| `provider` | string | non-empty (`claude`, `codex`, `pi`, …) |
+| `provider_run_ids` | string[] | non-empty array of session IDs |
+| `changed_files` | string[] | non-empty list of paths |
+| `diff_command` | string | the command used to produce the diff |
+| `test_commands` | string[] | may be empty (doc-only PRs); MUST be present |
+| `test_output_summary` | string | may be empty; MUST be present |
+| `commit_sha` | string | exactly 40 lowercase hex chars |
+| `pushed_branch` | string | non-empty; protected names (`main`, `master`, `dev`, `develop`) are rejected |
+| `pr_url` | string | `https://github.com/<owner>/<repo>/pull/<number>` only |
+| `pr_number` | number | positive integer; must match `pr_url` when `verify: reality` |
+
+**`kind: 'planning'`** is parsed but explicitly rejected by the integrity layer with the hint to set `kind: 'execution'`. Authors MAY emit it to mark a run as planning-only when they do not want the gate to pass.
+
+### `verify` modes
+
+- `'shape'` (default) — Zod parse + cross-field integrity. No subprocess calls. Suitable for hermetic CI environments.
+- `'reality'` — additionally runs `git cat-file -e <sha>` (commit reachable), `git ls-remote origin <branch>` (branch pushed and tip SHA matches `commit_sha`), and `gh pr view <url> --json headRefName,number,headRefOid` (PR URL matches branch, number, AND `commit_sha === headRefOid`). Requires `gh` on PATH and authenticated. Failures produce structured issues, not exceptions.
+
+The `commit_sha` is bound to BOTH the branch tip on origin AND the PR `headRefOid` — fabricating evidence that pairs an arbitrary local SHA with an unrelated real PR will not pass.
+
+### Example: writing evidence.json from a final node
+
+```yaml
+nodes:
+  # … earlier nodes that commit, push, and open the PR …
+
+  - id: write-evidence
+    bash: |
+      cat > "$ARTIFACTS_DIR/evidence.json" <<EOF
+      {
+        "kind": "execution",
+        "workflow_run_id": "$WORKFLOW_ID",
+        "provider": "claude",
+        "provider_run_ids": ["${SESSION_ID}"],
+        "changed_files": $(git diff --name-only origin/dev...HEAD | jq -R -s -c 'split("\n") | map(select(. != ""))'),
+        "diff_command": "git diff --stat origin/dev...HEAD",
+        "test_commands": ["bun test"],
+        "test_output_summary": "all tests passed",
+        "commit_sha": "$(git rev-parse HEAD)",
+        "pushed_branch": "$(git rev-parse --abbrev-ref HEAD)",
+        "pr_url": "${PR_URL}",
+        "pr_number": ${PR_NUMBER}
+      }
+      EOF
+    depends_on: [open-pr]
+```
+
+### Failure shape
+
+When validation fails, `metadata.evidence_validation` is persisted with this shape:
+
+```json
+{ "ok": false, "issues": [{ "level": "error", "field": "commit_sha", "message": "...", "hint": "..." }] }
+```
+
+Operators can read it from the run record (CLI: `archon workflow status <id>`; SQL: `SELECT metadata->'evidence_validation' FROM remote_agent_workflow_runs WHERE id = ?`).
 
 ---
 

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -15,11 +15,12 @@
     "./command-validation": "./src/command-validation.ts",
     "./defaults": "./src/defaults/bundled-defaults.ts",
     "./validator": "./src/validator.ts",
+    "./evidence-validator": "./src/evidence-validator.ts",
     "./utils/tool-formatter": "./src/utils/tool-formatter.ts",
     "./test-utils": "./src/test-utils.ts"
   },
   "scripts": {
-    "test": "bun test src/dag-executor.test.ts && bun test src/loader.test.ts && bun test src/logger.test.ts && bun test src/condition-evaluator.test.ts && bun test src/event-emitter.test.ts && bun test src/executor-shared.test.ts && bun test src/load-command-prompt.test.ts && bun test src/executor.test.ts && bun test src/executor-preamble.test.ts && bun test src/defaults/ src/model-validation.test.ts src/router.test.ts src/utils/ src/hooks.test.ts && bun test src/validation-parser.test.ts src/schemas.test.ts src/command-validation.test.ts && bun test src/validator.test.ts && bun test src/script-discovery.test.ts && bun test src/runtime-check.test.ts && bun test src/script-node-deps.test.ts",
+    "test": "bun test src/dag-executor.test.ts && bun test src/loader.test.ts && bun test src/logger.test.ts && bun test src/condition-evaluator.test.ts && bun test src/event-emitter.test.ts && bun test src/executor-shared.test.ts && bun test src/load-command-prompt.test.ts && bun test src/executor.test.ts && bun test src/executor-preamble.test.ts && bun test src/defaults/ src/model-validation.test.ts src/router.test.ts src/utils/ src/hooks.test.ts && bun test src/validation-parser.test.ts src/schemas.test.ts src/command-validation.test.ts && bun test src/validator.test.ts && bun test src/evidence-validator.test.ts && bun test src/script-discovery.test.ts && bun test src/runtime-check.test.ts && bun test src/script-node-deps.test.ts",
     "type-check": "bun x tsc --noEmit"
   },
   "dependencies": {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -7034,7 +7034,7 @@ describe('executeDagWorkflow -- evidence_policy gate', () => {
       join(artifactsDir, 'evidence.json'),
       JSON.stringify({
         kind: 'execution',
-        workflow_run_id: 'run-1',
+        workflow_run_id: 'dag-evidence-run-2',
         provider: 'claude',
         provider_run_ids: ['session-abc'],
         changed_files: ['src/foo.ts'],
@@ -7089,6 +7089,56 @@ describe('executeDagWorkflow -- evidence_policy gate', () => {
       };
       expect(updates.metadata.evidence_validation.ok).toBe(true);
     }
+  });
+
+  it('evidence_policy.required + stale workflow_run_id -> failWorkflowRun', async () => {
+    await writeFile(
+      join(artifactsDir, 'evidence.json'),
+      JSON.stringify({
+        kind: 'execution',
+        workflow_run_id: 'other-run',
+        provider: 'claude',
+        provider_run_ids: ['session-abc'],
+        changed_files: ['src/foo.ts'],
+        diff_command: 'git diff --stat origin/dev...HEAD',
+        test_commands: ['bun test'],
+        test_output_summary: '15 passed',
+        commit_sha: 'a'.repeat(40),
+        pushed_branch: 'feature/foo',
+        pr_url: 'https://github.com/owner/repo/pull/42',
+        pr_number: 42,
+      })
+    );
+
+    const mockStore = createMockStore();
+    const mockDeps = createMockDeps(mockStore);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('dag-evidence-run-mismatch');
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-evidence',
+      testDir,
+      {
+        name: 'evidence-required-stale-run-id',
+        nodes: [{ id: 'work', bash: 'echo done' } as BashNode],
+        evidence_policy: { required: true, verify: 'shape', path: 'evidence.json' },
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      artifactsDir,
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    expect((mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+    expect((mockStore.completeWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+    const failCall = (mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls[0];
+    expect(failCall[1]).toContain('workflow_run_id');
   });
 
   it('regression guard: workflow without evidence_policy completes unchanged', async () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -6936,3 +6936,196 @@ describe('executeDagWorkflow -- final status derivation', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// executeDagWorkflow -- evidence_policy gate (P3-A)
+// ---------------------------------------------------------------------------
+//
+// These tests use `verify: 'shape'` so the validator never shells out to git
+// or gh — no execFileAsync mocking required. The third (no-policy) test is a
+// regression guard: workflows without `evidence_policy` MUST behave exactly
+// as before this change.
+
+describe('executeDagWorkflow -- evidence_policy gate', () => {
+  let testDir: string;
+  let artifactsDir: string;
+
+  beforeEach(async () => {
+    testDir = join(
+      tmpdir(),
+      `dag-evidence-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    artifactsDir = join(testDir, 'artifacts');
+    await mkdir(testDir, { recursive: true });
+    await mkdir(artifactsDir, { recursive: true });
+
+    mockSendQueryDag.mockClear();
+    mockGetAgentProviderDag.mockClear();
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'DAG AI response' };
+      yield { type: 'result', sessionId: 'dag-session-id' };
+    });
+    mockGetAgentProviderDag.mockImplementation(() => ({
+      sendQuery: mockSendQueryDag,
+      getType: () => 'claude',
+      getCapabilities: mockClaudeCapabilities,
+    }));
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(testDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it('evidence_policy.required + missing evidence.json -> failWorkflowRun (not completeWorkflowRun)', async () => {
+    const mockStore = createMockStore();
+    const mockDeps = createMockDeps(mockStore);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('dag-evidence-run-1');
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-evidence',
+      testDir,
+      {
+        name: 'evidence-required-missing',
+        nodes: [{ id: 'work', bash: 'echo done' } as BashNode],
+        evidence_policy: { required: true, verify: 'shape', path: 'evidence.json' },
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      artifactsDir,
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    // Must have failed, not completed.
+    expect((mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+    expect((mockStore.completeWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+
+    const failCall = (mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls[0];
+    expect(failCall[1]).toContain('evidence');
+
+    // Metadata write must include the structured issues.
+    const updateCalls = (mockStore.updateWorkflowRun as ReturnType<typeof mock>).mock.calls;
+    const evidenceUpdate = updateCalls.find((c: unknown[]) => {
+      const updates = c[1] as { metadata?: { evidence_validation?: { ok?: boolean } } };
+      return updates.metadata?.evidence_validation !== undefined;
+    });
+    expect(evidenceUpdate).toBeDefined();
+    if (evidenceUpdate) {
+      const updates = evidenceUpdate[1] as {
+        metadata: { evidence_validation: { ok: boolean; issues?: unknown[] } };
+      };
+      expect(updates.metadata.evidence_validation.ok).toBe(false);
+      expect(Array.isArray(updates.metadata.evidence_validation.issues)).toBe(true);
+    }
+  });
+
+  it('evidence_policy.required + valid evidence.json -> completeWorkflowRun', async () => {
+    await writeFile(
+      join(artifactsDir, 'evidence.json'),
+      JSON.stringify({
+        kind: 'execution',
+        workflow_run_id: 'run-1',
+        provider: 'claude',
+        provider_run_ids: ['session-abc'],
+        changed_files: ['src/foo.ts'],
+        diff_command: 'git diff --stat origin/dev...HEAD',
+        test_commands: ['bun test'],
+        test_output_summary: '15 passed',
+        commit_sha: 'a'.repeat(40),
+        pushed_branch: 'feature/foo',
+        pr_url: 'https://github.com/owner/repo/pull/42',
+        pr_number: 42,
+      })
+    );
+
+    const mockStore = createMockStore();
+    const mockDeps = createMockDeps(mockStore);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('dag-evidence-run-2');
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-evidence',
+      testDir,
+      {
+        name: 'evidence-required-valid',
+        nodes: [{ id: 'work', bash: 'echo done' } as BashNode],
+        evidence_policy: { required: true, verify: 'shape', path: 'evidence.json' },
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      artifactsDir,
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    expect((mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+    expect((mockStore.completeWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+
+    // Metadata write must include the success marker.
+    const updateCalls = (mockStore.updateWorkflowRun as ReturnType<typeof mock>).mock.calls;
+    const evidenceUpdate = updateCalls.find((c: unknown[]) => {
+      const updates = c[1] as { metadata?: { evidence_validation?: { ok?: boolean } } };
+      return updates.metadata?.evidence_validation !== undefined;
+    });
+    expect(evidenceUpdate).toBeDefined();
+    if (evidenceUpdate) {
+      const updates = evidenceUpdate[1] as {
+        metadata: { evidence_validation: { ok: boolean } };
+      };
+      expect(updates.metadata.evidence_validation.ok).toBe(true);
+    }
+  });
+
+  it('regression guard: workflow without evidence_policy completes unchanged', async () => {
+    const mockStore = createMockStore();
+    const mockDeps = createMockDeps(mockStore);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('dag-evidence-run-3');
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-evidence',
+      testDir,
+      {
+        name: 'evidence-no-policy',
+        nodes: [{ id: 'work', bash: 'echo done' } as BashNode],
+        // no evidence_policy field
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      artifactsDir,
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    expect((mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+    expect((mockStore.completeWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+
+    // No evidence-related metadata write should have occurred.
+    const updateCalls = (mockStore.updateWorkflowRun as ReturnType<typeof mock>).mock.calls;
+    const evidenceUpdate = updateCalls.find((c: unknown[]) => {
+      const updates = c[1] as { metadata?: { evidence_validation?: unknown } };
+      return updates.metadata?.evidence_validation !== undefined;
+    });
+    expect(evidenceUpdate).toBeUndefined();
+  });
+});

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3144,6 +3144,7 @@ export async function executeDagWorkflow(
     const evidenceResult = await validateEvidence({
       artifactsDir,
       cwd,
+      workflowRunId: workflowRun.id,
       policy: workflow.evidence_policy,
     });
     if (!evidenceResult.valid) {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3149,7 +3149,7 @@ export async function executeDagWorkflow(
     if (!evidenceResult.valid) {
       getLog().error(
         { workflowRunId: workflowRun.id, issues: evidenceResult.issues },
-        'evidence_validation_failed'
+        'workflow.evidence_validation_failed'
       );
       const issueLines = evidenceResult.issues
         .map(i => `  - ${i.field} — ${i.message}${i.hint ? ` (hint: ${i.hint})` : ''}`)
@@ -3166,7 +3166,7 @@ export async function executeDagWorkflow(
         .catch((dbErr: Error) => {
           getLog().error(
             { err: dbErr, workflowRunId: workflowRun.id },
-            'evidence_validation_metadata_persist_failed'
+            'workflow.evidence_metadata_persist_failed'
           );
         });
       await deps.store.failWorkflowRun(workflowRun.id, failMsg).catch((dbErr: Error) => {
@@ -3191,20 +3191,17 @@ export async function executeDagWorkflow(
       });
       return;
     }
-    // Evidence valid — persist the success marker alongside completion.
-    await deps.store
-      .updateWorkflowRun(workflowRun.id, {
-        metadata: {
-          ...workflowRun.metadata,
-          evidence_validation: { ok: true },
-        },
-      })
-      .catch((dbErr: Error) => {
-        getLog().error(
-          { err: dbErr, workflowRunId: workflowRun.id },
-          'evidence_validation_metadata_persist_failed'
-        );
-      });
+    // Evidence valid — persist the success marker BEFORE marking complete.
+    // We do NOT swallow this DB error: the marker is the durable proof that
+    // the gate ran. Logging-and-continuing would mark a run `completed`
+    // without provable validation, broadening the implied P3-A guarantee.
+    // Let the outer executor catch handle propagation.
+    await deps.store.updateWorkflowRun(workflowRun.id, {
+      metadata: {
+        ...workflowRun.metadata,
+        evidence_validation: { ok: true },
+      },
+    });
   }
 
   // Update DB and emit completion

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -40,7 +40,9 @@ import type {
   EffortLevel,
   ThinkingConfig,
   SandboxSettings,
+  EvidencePolicy,
 } from './schemas';
+import { validateEvidence } from './evidence-validator';
 import {
   isBashNode,
   isLoopNode,
@@ -2488,7 +2490,11 @@ export async function executeDagWorkflow(
   platform: IWorkflowPlatform,
   conversationId: string,
   cwd: string,
-  workflow: { name: string; nodes: readonly DagNode[] } & WorkflowLevelOptions,
+  workflow: {
+    name: string;
+    nodes: readonly DagNode[];
+    evidence_policy?: EvidencePolicy;
+  } & WorkflowLevelOptions,
   workflowRun: WorkflowRun,
   workflowProvider: string,
   workflowModel: string | undefined,
@@ -3128,6 +3134,78 @@ export async function executeDagWorkflow(
 
   // Check if status was changed externally (e.g. cancelled) before marking complete.
   if (await skipIfStatusChanged('dag.skip_complete_status_changed')) return;
+
+  // Real-execution proof gate (ROADMAP P3-A). When the workflow declares
+  // `evidence_policy.required: true`, refuse terminal `completed` unless
+  // $ARTIFACTS_DIR/<path> parses as ExecutionEvidence and (when verify ===
+  // 'reality') the claimed SHA/branch/PR are reachable. On failure, downgrade
+  // to `failed` with structured issues persisted at metadata.evidence_validation.
+  if (workflow.evidence_policy?.required === true) {
+    const evidenceResult = await validateEvidence({
+      artifactsDir,
+      cwd,
+      policy: workflow.evidence_policy,
+    });
+    if (!evidenceResult.valid) {
+      getLog().error(
+        { workflowRunId: workflowRun.id, issues: evidenceResult.issues },
+        'evidence_validation_failed'
+      );
+      const issueLines = evidenceResult.issues
+        .map(i => `  - ${i.field} — ${i.message}${i.hint ? ` (hint: ${i.hint})` : ''}`)
+        .join('\n');
+      const failMsg = `Real-execution evidence validation failed.\n${issueLines}`;
+      // Persist the structured issues at metadata.evidence_validation, then mark failed.
+      await deps.store
+        .updateWorkflowRun(workflowRun.id, {
+          metadata: {
+            ...workflowRun.metadata,
+            evidence_validation: { ok: false, issues: evidenceResult.issues },
+          },
+        })
+        .catch((dbErr: Error) => {
+          getLog().error(
+            { err: dbErr, workflowRunId: workflowRun.id },
+            'evidence_validation_metadata_persist_failed'
+          );
+        });
+      await deps.store.failWorkflowRun(workflowRun.id, failMsg).catch((dbErr: Error) => {
+        getLog().error({ err: dbErr, workflowRunId: workflowRun.id }, 'dag_db_fail_failed');
+      });
+      await logWorkflowError(logDir, workflowRun.id, failMsg).catch((logErr: Error) => {
+        getLog().error(
+          { err: logErr, workflowRunId: workflowRun.id },
+          'dag.workflow_error_log_write_failed'
+        );
+      });
+      const emitterForFail = getWorkflowEventEmitter();
+      emitterForFail.emit({
+        type: 'workflow_failed',
+        runId: workflowRun.id,
+        workflowName: workflow.name,
+        error: failMsg,
+      });
+      emitterForFail.unregisterRun(workflowRun.id);
+      await safeSendMessage(platform, conversationId, `❌ ${failMsg}`, {
+        workflowId: workflowRun.id,
+      });
+      return;
+    }
+    // Evidence valid — persist the success marker alongside completion.
+    await deps.store
+      .updateWorkflowRun(workflowRun.id, {
+        metadata: {
+          ...workflowRun.metadata,
+          evidence_validation: { ok: true },
+        },
+      })
+      .catch((dbErr: Error) => {
+        getLog().error(
+          { err: dbErr, workflowRunId: workflowRun.id },
+          'evidence_validation_metadata_persist_failed'
+        );
+      });
+  }
 
   // Update DB and emit completion
   try {

--- a/packages/workflows/src/evidence-validator.test.ts
+++ b/packages/workflows/src/evidence-validator.test.ts
@@ -1,0 +1,701 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { mkdir, writeFile, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// --- Mock logger BEFORE importing module under test ---
+
+const mockLogger = {
+  fatal: mock(() => undefined),
+  error: mock(() => undefined),
+  warn: mock(() => undefined),
+  info: mock(() => undefined),
+  debug: mock(() => undefined),
+  trace: mock(() => undefined),
+  child: mock(function () {
+    return mockLogger;
+  }),
+  bindings: mock(() => ({ module: 'test' })),
+  isLevelEnabled: mock(() => true),
+  level: 'info',
+};
+
+const realArchonPaths = await import('@archon/paths');
+mock.module('@archon/paths', () => ({
+  ...realArchonPaths,
+  createLogger: mock(() => mockLogger),
+}));
+
+// --- Mock @archon/git BEFORE importing module under test (Group C reality stubs) ---
+//
+// CLAUDE.md: mock.module() is process-global and irreversible. This file is
+// added as its own `bun test` invocation in package.json so this mock cannot
+// pollute other test files.
+
+interface ExecCall {
+  cmd: string;
+  args: string[];
+}
+
+const execFileCalls: ExecCall[] = [];
+let execFileImpl: (
+  cmd: string,
+  args: string[]
+) => Promise<{ stdout: string; stderr: string }> = () =>
+  Promise.resolve({ stdout: '', stderr: '' });
+
+mock.module('@archon/git', () => ({
+  execFileAsync: async (
+    cmd: string,
+    args: string[]
+  ): Promise<{ stdout: string; stderr: string }> => {
+    execFileCalls.push({ cmd, args });
+    return execFileImpl(cmd, args);
+  },
+}));
+
+// --- Imports (after mocks) ---
+
+import {
+  validateEvidence,
+  validateEvidenceShape,
+  validateEvidenceIntegrity,
+  verifyEvidenceReality,
+  loadEvidenceFromArtifacts,
+} from './evidence-validator';
+import type { ExecutionEvidence } from './schemas';
+
+// --- Fixtures ---
+
+function makeRealExecutionEvidence(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    kind: 'execution',
+    workflow_run_id: 'run-1',
+    provider: 'claude',
+    provider_run_ids: ['session-abc'],
+    changed_files: ['src/foo.ts'],
+    diff_command: 'git diff --stat origin/dev...HEAD',
+    test_commands: ['bun test'],
+    test_output_summary: '15 passed',
+    commit_sha: 'a'.repeat(40),
+    pushed_branch: 'feature/foo',
+    pr_url: 'https://github.com/owner/repo/pull/42',
+    pr_number: 42,
+    ...overrides,
+  };
+}
+
+function makePlanningEvidence(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    kind: 'planning',
+    workflow_run_id: 'run-1',
+    provider: 'claude',
+    summary: 'wrote plan.md',
+    ...overrides,
+  };
+}
+
+const REAL_EVIDENCE: ExecutionEvidence = {
+  kind: 'execution',
+  workflow_run_id: 'run-1',
+  provider: 'claude',
+  provider_run_ids: ['session-abc'],
+  changed_files: ['src/foo.ts'],
+  diff_command: 'git diff --stat origin/dev...HEAD',
+  test_commands: ['bun test'],
+  test_output_summary: '15 passed',
+  commit_sha: 'a'.repeat(40),
+  pushed_branch: 'feature/foo',
+  pr_url: 'https://github.com/owner/repo/pull/42',
+  pr_number: 42,
+};
+
+// =============================================================================
+// Group A — validateEvidenceShape
+// =============================================================================
+
+describe('validateEvidenceShape', () => {
+  it('positive: full execution evidence parses', () => {
+    const result = validateEvidenceShape(makeRealExecutionEvidence());
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.evidence.kind).toBe('execution');
+    }
+  });
+
+  it('positive: planning evidence parses (rejected later by integrity)', () => {
+    const result = validateEvidenceShape(makePlanningEvidence());
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.evidence.kind).toBe('planning');
+    }
+  });
+
+  it('negative: missing commit_sha emits error on commit_sha field', () => {
+    const raw = makeRealExecutionEvidence();
+    delete raw.commit_sha;
+    const result = validateEvidenceShape(raw);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.issues.some(i => i.field === 'commit_sha')).toBe(true);
+    }
+  });
+
+  it('negative: short commit_sha rejected', () => {
+    const result = validateEvidenceShape(makeRealExecutionEvidence({ commit_sha: 'abc1234' }));
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.issues.some(i => i.field === 'commit_sha')).toBe(true);
+    }
+  });
+
+  it('negative: uppercase commit_sha rejected (must be lowercase hex)', () => {
+    const result = validateEvidenceShape(makeRealExecutionEvidence({ commit_sha: 'A'.repeat(40) }));
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.issues.some(i => i.field === 'commit_sha')).toBe(true);
+    }
+  });
+
+  it('negative: non-hex commit_sha rejected', () => {
+    const result = validateEvidenceShape(makeRealExecutionEvidence({ commit_sha: 'z'.repeat(40) }));
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.issues.some(i => i.field === 'commit_sha')).toBe(true);
+    }
+  });
+
+  it('negative: http (not https) pr_url rejected', () => {
+    const result = validateEvidenceShape(
+      makeRealExecutionEvidence({ pr_url: 'http://github.com/owner/repo/pull/42' })
+    );
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.issues.some(i => i.field === 'pr_url')).toBe(true);
+    }
+  });
+
+  it('negative: non-github pr_url rejected', () => {
+    const result = validateEvidenceShape(
+      makeRealExecutionEvidence({ pr_url: 'https://gitlab.com/owner/repo/pull/42' })
+    );
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.issues.some(i => i.field === 'pr_url')).toBe(true);
+    }
+  });
+
+  it('negative: empty provider_run_ids array rejected', () => {
+    const result = validateEvidenceShape(makeRealExecutionEvidence({ provider_run_ids: [] }));
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.issues.some(i => i.field.startsWith('provider_run_ids'))).toBe(true);
+    }
+  });
+
+  it('negative: empty changed_files array rejected', () => {
+    const result = validateEvidenceShape(makeRealExecutionEvidence({ changed_files: [] }));
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.issues.some(i => i.field.startsWith('changed_files'))).toBe(true);
+    }
+  });
+
+  it("negative: { kind: 'execution' } only — many missing-field errors", () => {
+    const result = validateEvidenceShape({ kind: 'execution' });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      // commit_sha, pushed_branch, pr_url, pr_number, changed_files, etc.
+      expect(result.issues.length).toBeGreaterThan(3);
+    }
+  });
+
+  it('negative: malformed (string) raw value rejected', () => {
+    const result = validateEvidenceShape('{ "broken": json');
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('negative: null raw value rejected', () => {
+    const result = validateEvidenceShape(null);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('negative: array raw value rejected', () => {
+    const result = validateEvidenceShape(['some', 'array']);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('negative: number raw value rejected', () => {
+    const result = validateEvidenceShape(42);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('negative: missing kind field rejected', () => {
+    const raw = makeRealExecutionEvidence();
+    delete raw.kind;
+    const result = validateEvidenceShape(raw);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.issues.some(i => i.field === 'kind')).toBe(true);
+    }
+  });
+});
+
+// =============================================================================
+// Group B — validateEvidenceIntegrity
+// =============================================================================
+
+describe('validateEvidenceIntegrity', () => {
+  it('positive: well-formed execution evidence on feature branch returns []', () => {
+    const issues = validateEvidenceIntegrity(REAL_EVIDENCE);
+    expect(issues).toEqual([]);
+  });
+
+  it("negative: kind: 'planning' rejected with hint", () => {
+    const issues = validateEvidenceIntegrity({
+      kind: 'planning',
+      workflow_run_id: 'r',
+      provider: 'claude',
+      summary: 's',
+    });
+    expect(issues.length).toBe(1);
+    expect(issues[0].field).toBe('kind');
+  });
+
+  it("negative: pushed_branch === 'main' rejected", () => {
+    const issues = validateEvidenceIntegrity({ ...REAL_EVIDENCE, pushed_branch: 'main' });
+    expect(issues.some(i => i.field === 'pushed_branch')).toBe(true);
+  });
+
+  it("negative: pushed_branch === 'master' rejected", () => {
+    const issues = validateEvidenceIntegrity({ ...REAL_EVIDENCE, pushed_branch: 'master' });
+    expect(issues.some(i => i.field === 'pushed_branch')).toBe(true);
+  });
+
+  it("negative: pushed_branch === 'dev' rejected", () => {
+    const issues = validateEvidenceIntegrity({ ...REAL_EVIDENCE, pushed_branch: 'dev' });
+    expect(issues.some(i => i.field === 'pushed_branch')).toBe(true);
+  });
+
+  it("negative: pushed_branch === 'develop' rejected", () => {
+    const issues = validateEvidenceIntegrity({ ...REAL_EVIDENCE, pushed_branch: 'develop' });
+    expect(issues.some(i => i.field === 'pushed_branch')).toBe(true);
+  });
+
+  it('negative: zero-tree commit_sha rejected', () => {
+    const issues = validateEvidenceIntegrity({ ...REAL_EVIDENCE, commit_sha: '0'.repeat(40) });
+    expect(issues.some(i => i.field === 'commit_sha')).toBe(true);
+  });
+});
+
+// =============================================================================
+// Group C — verifyEvidenceReality
+// =============================================================================
+
+describe('verifyEvidenceReality', () => {
+  beforeEach(() => {
+    execFileCalls.length = 0;
+    execFileImpl = () => Promise.resolve({ stdout: '', stderr: '' });
+  });
+
+  it('positive: all 3 shells succeed and gh JSON matches → []', async () => {
+    execFileImpl = (cmd, args) => {
+      if (cmd === 'git' && args[0] === 'cat-file') {
+        return Promise.resolve({ stdout: '', stderr: '' });
+      }
+      if (cmd === 'git' && args[0] === 'ls-remote') {
+        return Promise.resolve({
+          stdout: `${'a'.repeat(40)}\trefs/heads/feature/foo\n`,
+          stderr: '',
+        });
+      }
+      if (cmd === 'gh') {
+        return Promise.resolve({
+          stdout: JSON.stringify({ headRefName: 'feature/foo', number: 42 }),
+          stderr: '',
+        });
+      }
+      return Promise.resolve({ stdout: '', stderr: '' });
+    };
+    const issues = await verifyEvidenceReality(REAL_EVIDENCE, '/repo');
+    expect(issues).toEqual([]);
+  });
+
+  it('negative: git cat-file exits non-zero → commit_sha error', async () => {
+    execFileImpl = (cmd, args) => {
+      if (cmd === 'git' && args[0] === 'cat-file') {
+        const err = Object.assign(new Error('command failed'), { stderr: 'fatal: bad object' });
+        return Promise.reject(err);
+      }
+      if (cmd === 'git' && args[0] === 'ls-remote') {
+        return Promise.resolve({
+          stdout: `${'a'.repeat(40)}\trefs/heads/feature/foo\n`,
+          stderr: '',
+        });
+      }
+      if (cmd === 'gh') {
+        return Promise.resolve({
+          stdout: JSON.stringify({ headRefName: 'feature/foo', number: 42 }),
+          stderr: '',
+        });
+      }
+      return Promise.resolve({ stdout: '', stderr: '' });
+    };
+    const issues = await verifyEvidenceReality(REAL_EVIDENCE, '/repo');
+    expect(issues.some(i => i.field === 'commit_sha')).toBe(true);
+  });
+
+  it('negative: git ls-remote returns empty → pushed_branch error', async () => {
+    execFileImpl = (cmd, args) => {
+      if (cmd === 'git' && args[0] === 'cat-file') {
+        return Promise.resolve({ stdout: '', stderr: '' });
+      }
+      if (cmd === 'git' && args[0] === 'ls-remote') {
+        return Promise.resolve({ stdout: '', stderr: '' });
+      }
+      if (cmd === 'gh') {
+        return Promise.resolve({
+          stdout: JSON.stringify({ headRefName: 'feature/foo', number: 42 }),
+          stderr: '',
+        });
+      }
+      return Promise.resolve({ stdout: '', stderr: '' });
+    };
+    const issues = await verifyEvidenceReality(REAL_EVIDENCE, '/repo');
+    expect(issues.some(i => i.field === 'pushed_branch')).toBe(true);
+  });
+
+  it('negative: gh headRefName mismatch → pr_url error', async () => {
+    execFileImpl = (cmd, args) => {
+      if (cmd === 'git' && args[0] === 'cat-file') {
+        return Promise.resolve({ stdout: '', stderr: '' });
+      }
+      if (cmd === 'git' && args[0] === 'ls-remote') {
+        return Promise.resolve({
+          stdout: `${'a'.repeat(40)}\trefs/heads/feature/foo\n`,
+          stderr: '',
+        });
+      }
+      if (cmd === 'gh') {
+        return Promise.resolve({
+          stdout: JSON.stringify({ headRefName: 'other-branch', number: 42 }),
+          stderr: '',
+        });
+      }
+      return Promise.resolve({ stdout: '', stderr: '' });
+    };
+    const issues = await verifyEvidenceReality(REAL_EVIDENCE, '/repo');
+    expect(issues.some(i => i.field === 'pr_url')).toBe(true);
+  });
+
+  it('negative: gh number mismatch → pr_number error', async () => {
+    execFileImpl = (cmd, args) => {
+      if (cmd === 'git' && args[0] === 'cat-file') {
+        return Promise.resolve({ stdout: '', stderr: '' });
+      }
+      if (cmd === 'git' && args[0] === 'ls-remote') {
+        return Promise.resolve({
+          stdout: `${'a'.repeat(40)}\trefs/heads/feature/foo\n`,
+          stderr: '',
+        });
+      }
+      if (cmd === 'gh') {
+        return Promise.resolve({
+          stdout: JSON.stringify({ headRefName: 'feature/foo', number: 99 }),
+          stderr: '',
+        });
+      }
+      return Promise.resolve({ stdout: '', stderr: '' });
+    };
+    const issues = await verifyEvidenceReality(REAL_EVIDENCE, '/repo');
+    expect(issues.some(i => i.field === 'pr_number')).toBe(true);
+  });
+
+  it('negative: gh binary missing (ENOENT) → pr_url error with install hint', async () => {
+    execFileImpl = (cmd, _args) => {
+      if (cmd === 'git') {
+        if (_args[0] === 'cat-file') return Promise.resolve({ stdout: '', stderr: '' });
+        if (_args[0] === 'ls-remote') {
+          return Promise.resolve({
+            stdout: `${'a'.repeat(40)}\trefs/heads/feature/foo\n`,
+            stderr: '',
+          });
+        }
+      }
+      if (cmd === 'gh') {
+        const err = Object.assign(new Error('spawn gh ENOENT'), { code: 'ENOENT' });
+        return Promise.reject(err);
+      }
+      return Promise.resolve({ stdout: '', stderr: '' });
+    };
+    const issues = await verifyEvidenceReality(REAL_EVIDENCE, '/repo');
+    expect(issues.some(i => i.field === 'pr_url' && i.hint?.includes('gh auth'))).toBe(true);
+  });
+
+  it('negative: gh non-JSON output → pr_url error', async () => {
+    execFileImpl = (cmd, _args) => {
+      if (cmd === 'git') {
+        if (_args[0] === 'cat-file') return Promise.resolve({ stdout: '', stderr: '' });
+        if (_args[0] === 'ls-remote') {
+          return Promise.resolve({
+            stdout: `${'a'.repeat(40)}\trefs/heads/feature/foo\n`,
+            stderr: '',
+          });
+        }
+      }
+      if (cmd === 'gh') {
+        return Promise.resolve({ stdout: 'not json at all', stderr: '' });
+      }
+      return Promise.resolve({ stdout: '', stderr: '' });
+    };
+    const issues = await verifyEvidenceReality(REAL_EVIDENCE, '/repo');
+    expect(issues.some(i => i.field === 'pr_url')).toBe(true);
+  });
+
+  it('negative: planning evidence rejected with kind error', async () => {
+    const planning = {
+      kind: 'planning' as const,
+      workflow_run_id: 'r',
+      provider: 'claude',
+      summary: 's',
+    };
+    const issues = await verifyEvidenceReality(planning, '/repo');
+    expect(issues.some(i => i.field === 'kind')).toBe(true);
+  });
+});
+
+// =============================================================================
+// Group D — loadEvidenceFromArtifacts
+// =============================================================================
+
+describe('loadEvidenceFromArtifacts', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = join(
+      tmpdir(),
+      `evidence-load-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(testDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it('returns { found: false } when file is missing', async () => {
+    const result = await loadEvidenceFromArtifacts(testDir);
+    expect(result.found).toBe(false);
+  });
+
+  it('returns parsed JSON when file present and valid', async () => {
+    await writeFile(join(testDir, 'evidence.json'), JSON.stringify(makeRealExecutionEvidence()));
+    const result = await loadEvidenceFromArtifacts(testDir);
+    expect(result.found).toBe(true);
+    if (result.found) {
+      expect(typeof result.raw).toBe('object');
+    }
+  });
+
+  it('returns raw string when file is malformed JSON (no throw)', async () => {
+    await writeFile(join(testDir, 'evidence.json'), '{ broken json');
+    const result = await loadEvidenceFromArtifacts(testDir);
+    expect(result.found).toBe(true);
+    if (result.found) {
+      expect(typeof result.raw).toBe('string');
+    }
+  });
+
+  it('absolute path rejected when piped through validateEvidence', async () => {
+    const result = await validateEvidence({
+      artifactsDir: testDir,
+      cwd: '/repo',
+      policy: { required: true, verify: 'shape', path: '/etc/passwd' },
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.issues.some(i => i.field === 'evidence_policy.path')).toBe(true);
+    }
+  });
+
+  it("'..'-segment path rejected when piped through validateEvidence", async () => {
+    const result = await validateEvidence({
+      artifactsDir: testDir,
+      cwd: '/repo',
+      policy: { required: true, verify: 'shape', path: '../escape.json' },
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.issues.some(i => i.field === 'evidence_policy.path')).toBe(true);
+    }
+  });
+});
+
+// =============================================================================
+// Group E — validateEvidence (orchestrator)
+// =============================================================================
+
+describe('validateEvidence (orchestrator)', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = join(
+      tmpdir(),
+      `evidence-orch-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    await mkdir(testDir, { recursive: true });
+    execFileCalls.length = 0;
+    execFileImpl = () => Promise.resolve({ stdout: '', stderr: '' });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(testDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it('missing file returns evidence_policy.path issue', async () => {
+    const result = await validateEvidence({
+      artifactsDir: testDir,
+      cwd: '/repo',
+      policy: { required: true, verify: 'shape', path: 'evidence.json' },
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.issues.some(i => i.field === 'evidence_policy.path')).toBe(true);
+    }
+  });
+
+  it('shape error returns at shape layer; reality stub never called', async () => {
+    await writeFile(
+      join(testDir, 'evidence.json'),
+      JSON.stringify(makeRealExecutionEvidence({ commit_sha: 'short' }))
+    );
+    let realityCalls = 0;
+    execFileImpl = () => {
+      realityCalls++;
+      return Promise.resolve({ stdout: '', stderr: '' });
+    };
+    const result = await validateEvidence({
+      artifactsDir: testDir,
+      cwd: '/repo',
+      policy: { required: true, verify: 'reality', path: 'evidence.json' },
+    });
+    expect(result.valid).toBe(false);
+    expect(realityCalls).toBe(0);
+  });
+
+  it('integrity error returns at integrity layer; reality stub never called', async () => {
+    await writeFile(
+      join(testDir, 'evidence.json'),
+      JSON.stringify(makeRealExecutionEvidence({ pushed_branch: 'main' }))
+    );
+    let realityCalls = 0;
+    execFileImpl = () => {
+      realityCalls++;
+      return Promise.resolve({ stdout: '', stderr: '' });
+    };
+    const result = await validateEvidence({
+      artifactsDir: testDir,
+      cwd: '/repo',
+      policy: { required: true, verify: 'reality', path: 'evidence.json' },
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.issues.some(i => i.field === 'pushed_branch')).toBe(true);
+    }
+    expect(realityCalls).toBe(0);
+  });
+
+  it("shape ok + integrity ok + verify: 'shape' returns valid without I/O", async () => {
+    await writeFile(join(testDir, 'evidence.json'), JSON.stringify(makeRealExecutionEvidence()));
+    let realityCalls = 0;
+    execFileImpl = () => {
+      realityCalls++;
+      return Promise.resolve({ stdout: '', stderr: '' });
+    };
+    const result = await validateEvidence({
+      artifactsDir: testDir,
+      cwd: '/repo',
+      policy: { required: true, verify: 'shape', path: 'evidence.json' },
+    });
+    expect(result.valid).toBe(true);
+    expect(realityCalls).toBe(0);
+  });
+
+  it("shape ok + integrity ok + verify: 'reality' + reality ok returns valid", async () => {
+    await writeFile(join(testDir, 'evidence.json'), JSON.stringify(makeRealExecutionEvidence()));
+    execFileImpl = (cmd, args) => {
+      if (cmd === 'git' && args[0] === 'cat-file') {
+        return Promise.resolve({ stdout: '', stderr: '' });
+      }
+      if (cmd === 'git' && args[0] === 'ls-remote') {
+        return Promise.resolve({
+          stdout: `${'a'.repeat(40)}\trefs/heads/feature/foo\n`,
+          stderr: '',
+        });
+      }
+      if (cmd === 'gh') {
+        return Promise.resolve({
+          stdout: JSON.stringify({ headRefName: 'feature/foo', number: 42 }),
+          stderr: '',
+        });
+      }
+      return Promise.resolve({ stdout: '', stderr: '' });
+    };
+    const result = await validateEvidence({
+      artifactsDir: testDir,
+      cwd: '/repo',
+      policy: { required: true, verify: 'reality', path: 'evidence.json' },
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('planning evidence rejected at integrity layer', async () => {
+    await writeFile(join(testDir, 'evidence.json'), JSON.stringify(makePlanningEvidence()));
+    const result = await validateEvidence({
+      artifactsDir: testDir,
+      cwd: '/repo',
+      policy: { required: true, verify: 'shape', path: 'evidence.json' },
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.issues.some(i => i.field === 'kind')).toBe(true);
+    }
+  });
+
+  it('custom path within artifactsDir is honored', async () => {
+    const customDir = join(testDir, 'sub');
+    await mkdir(customDir, { recursive: true });
+    await writeFile(
+      join(testDir, 'sub', 'proof.json'),
+      JSON.stringify(makeRealExecutionEvidence())
+    );
+    const result = await validateEvidence({
+      artifactsDir: testDir,
+      cwd: '/repo',
+      policy: { required: true, verify: 'shape', path: 'sub/proof.json' },
+    });
+    expect(result.valid).toBe(true);
+  });
+});

--- a/packages/workflows/src/evidence-validator.test.ts
+++ b/packages/workflows/src/evidence-validator.test.ts
@@ -610,6 +610,7 @@ describe('loadEvidenceFromArtifacts', () => {
     const result = await validateEvidence({
       artifactsDir: testDir,
       cwd: '/repo',
+      workflowRunId: 'run-1',
       policy: { required: true, verify: 'shape', path: '/etc/passwd' },
     });
     expect(result.valid).toBe(false);
@@ -622,6 +623,7 @@ describe('loadEvidenceFromArtifacts', () => {
     const result = await validateEvidence({
       artifactsDir: testDir,
       cwd: '/repo',
+      workflowRunId: 'run-1',
       policy: { required: true, verify: 'shape', path: '../escape.json' },
     });
     expect(result.valid).toBe(false);
@@ -660,6 +662,7 @@ describe('validateEvidence (orchestrator)', () => {
     const result = await validateEvidence({
       artifactsDir: testDir,
       cwd: '/repo',
+      workflowRunId: 'run-1',
       policy: { required: true, verify: 'shape', path: 'evidence.json' },
     });
     expect(result.valid).toBe(false);
@@ -681,9 +684,33 @@ describe('validateEvidence (orchestrator)', () => {
     const result = await validateEvidence({
       artifactsDir: testDir,
       cwd: '/repo',
+      workflowRunId: 'run-1',
       policy: { required: true, verify: 'reality', path: 'evidence.json' },
     });
     expect(result.valid).toBe(false);
+    expect(realityCalls).toBe(0);
+  });
+
+  it('stale workflow_run_id returns workflow_run_id issue; reality stub never called', async () => {
+    await writeFile(
+      join(testDir, 'evidence.json'),
+      JSON.stringify(makeRealExecutionEvidence({ workflow_run_id: 'other-run' }))
+    );
+    let realityCalls = 0;
+    execFileImpl = () => {
+      realityCalls++;
+      return Promise.resolve({ stdout: '', stderr: '' });
+    };
+    const result = await validateEvidence({
+      artifactsDir: testDir,
+      cwd: '/repo',
+      workflowRunId: 'run-1',
+      policy: { required: true, verify: 'reality', path: 'evidence.json' },
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.issues.some(i => i.field === 'workflow_run_id')).toBe(true);
+    }
     expect(realityCalls).toBe(0);
   });
 
@@ -700,6 +727,7 @@ describe('validateEvidence (orchestrator)', () => {
     const result = await validateEvidence({
       artifactsDir: testDir,
       cwd: '/repo',
+      workflowRunId: 'run-1',
       policy: { required: true, verify: 'reality', path: 'evidence.json' },
     });
     expect(result.valid).toBe(false);
@@ -719,6 +747,7 @@ describe('validateEvidence (orchestrator)', () => {
     const result = await validateEvidence({
       artifactsDir: testDir,
       cwd: '/repo',
+      workflowRunId: 'run-1',
       policy: { required: true, verify: 'shape', path: 'evidence.json' },
     });
     expect(result.valid).toBe(true);
@@ -752,6 +781,7 @@ describe('validateEvidence (orchestrator)', () => {
     const result = await validateEvidence({
       artifactsDir: testDir,
       cwd: '/repo',
+      workflowRunId: 'run-1',
       policy: { required: true, verify: 'reality', path: 'evidence.json' },
     });
     expect(result.valid).toBe(true);
@@ -762,6 +792,7 @@ describe('validateEvidence (orchestrator)', () => {
     const result = await validateEvidence({
       artifactsDir: testDir,
       cwd: '/repo',
+      workflowRunId: 'run-1',
       policy: { required: true, verify: 'shape', path: 'evidence.json' },
     });
     expect(result.valid).toBe(false);
@@ -780,6 +811,7 @@ describe('validateEvidence (orchestrator)', () => {
     const result = await validateEvidence({
       artifactsDir: testDir,
       cwd: '/repo',
+      workflowRunId: 'run-1',
       policy: { required: true, verify: 'shape', path: 'sub/proof.json' },
     });
     expect(result.valid).toBe(true);

--- a/packages/workflows/src/evidence-validator.test.ts
+++ b/packages/workflows/src/evidence-validator.test.ts
@@ -325,7 +325,11 @@ describe('verifyEvidenceReality', () => {
       }
       if (cmd === 'gh') {
         return Promise.resolve({
-          stdout: JSON.stringify({ headRefName: 'feature/foo', number: 42 }),
+          stdout: JSON.stringify({
+            headRefName: 'feature/foo',
+            number: 42,
+            headRefOid: 'a'.repeat(40),
+          }),
           stderr: '',
         });
       }
@@ -333,6 +337,68 @@ describe('verifyEvidenceReality', () => {
     };
     const issues = await verifyEvidenceReality(REAL_EVIDENCE, '/repo');
     expect(issues).toEqual([]);
+  });
+
+  it('negative: ls-remote tip SHA mismatches commit_sha → commit_sha error', async () => {
+    execFileImpl = (cmd, args) => {
+      if (cmd === 'git' && args[0] === 'cat-file') {
+        return Promise.resolve({ stdout: '', stderr: '' });
+      }
+      if (cmd === 'git' && args[0] === 'ls-remote') {
+        // Branch exists, but tip is a DIFFERENT commit than evidence claims.
+        return Promise.resolve({
+          stdout: `${'b'.repeat(40)}\trefs/heads/feature/foo\n`,
+          stderr: '',
+        });
+      }
+      if (cmd === 'gh') {
+        return Promise.resolve({
+          stdout: JSON.stringify({
+            headRefName: 'feature/foo',
+            number: 42,
+            headRefOid: 'a'.repeat(40),
+          }),
+          stderr: '',
+        });
+      }
+      return Promise.resolve({ stdout: '', stderr: '' });
+    };
+    const issues = await verifyEvidenceReality(REAL_EVIDENCE, '/repo');
+    expect(
+      issues.some(
+        i => i.field === 'commit_sha' && i.message.includes('does not match origin/feature/foo tip')
+      )
+    ).toBe(true);
+  });
+
+  it('negative: gh headRefOid mismatches commit_sha → commit_sha error', async () => {
+    execFileImpl = (cmd, args) => {
+      if (cmd === 'git' && args[0] === 'cat-file') {
+        return Promise.resolve({ stdout: '', stderr: '' });
+      }
+      if (cmd === 'git' && args[0] === 'ls-remote') {
+        return Promise.resolve({
+          stdout: `${'a'.repeat(40)}\trefs/heads/feature/foo\n`,
+          stderr: '',
+        });
+      }
+      if (cmd === 'gh') {
+        // PR HEAD is a DIFFERENT commit than evidence claims.
+        return Promise.resolve({
+          stdout: JSON.stringify({
+            headRefName: 'feature/foo',
+            number: 42,
+            headRefOid: 'c'.repeat(40),
+          }),
+          stderr: '',
+        });
+      }
+      return Promise.resolve({ stdout: '', stderr: '' });
+    };
+    const issues = await verifyEvidenceReality(REAL_EVIDENCE, '/repo');
+    expect(issues.some(i => i.field === 'commit_sha' && i.message.includes('headRefOid'))).toBe(
+      true
+    );
   });
 
   it('negative: git cat-file exits non-zero → commit_sha error', async () => {
@@ -349,7 +415,11 @@ describe('verifyEvidenceReality', () => {
       }
       if (cmd === 'gh') {
         return Promise.resolve({
-          stdout: JSON.stringify({ headRefName: 'feature/foo', number: 42 }),
+          stdout: JSON.stringify({
+            headRefName: 'feature/foo',
+            number: 42,
+            headRefOid: 'a'.repeat(40),
+          }),
           stderr: '',
         });
       }
@@ -369,7 +439,11 @@ describe('verifyEvidenceReality', () => {
       }
       if (cmd === 'gh') {
         return Promise.resolve({
-          stdout: JSON.stringify({ headRefName: 'feature/foo', number: 42 }),
+          stdout: JSON.stringify({
+            headRefName: 'feature/foo',
+            number: 42,
+            headRefOid: 'a'.repeat(40),
+          }),
           stderr: '',
         });
       }
@@ -392,7 +466,11 @@ describe('verifyEvidenceReality', () => {
       }
       if (cmd === 'gh') {
         return Promise.resolve({
-          stdout: JSON.stringify({ headRefName: 'other-branch', number: 42 }),
+          stdout: JSON.stringify({
+            headRefName: 'other-branch',
+            number: 42,
+            headRefOid: 'a'.repeat(40),
+          }),
           stderr: '',
         });
       }
@@ -415,7 +493,11 @@ describe('verifyEvidenceReality', () => {
       }
       if (cmd === 'gh') {
         return Promise.resolve({
-          stdout: JSON.stringify({ headRefName: 'feature/foo', number: 99 }),
+          stdout: JSON.stringify({
+            headRefName: 'feature/foo',
+            number: 99,
+            headRefOid: 'a'.repeat(40),
+          }),
           stderr: '',
         });
       }
@@ -657,7 +739,11 @@ describe('validateEvidence (orchestrator)', () => {
       }
       if (cmd === 'gh') {
         return Promise.resolve({
-          stdout: JSON.stringify({ headRefName: 'feature/foo', number: 42 }),
+          stdout: JSON.stringify({
+            headRefName: 'feature/foo',
+            number: 42,
+            headRefOid: 'a'.repeat(40),
+          }),
           stderr: '',
         });
       }

--- a/packages/workflows/src/evidence-validator.ts
+++ b/packages/workflows/src/evidence-validator.ts
@@ -317,6 +317,8 @@ export interface ValidateEvidenceArgs {
   artifactsDir: string;
   /** Working directory for git/gh reality checks (typically the run cwd). */
   cwd: string;
+  /** Active workflow run id. Evidence from any other run is stale and rejected. */
+  workflowRunId: string;
   /** Workflow-level evidence policy. */
   policy: EvidencePolicy;
 }
@@ -329,9 +331,9 @@ export interface ValidateEvidenceArgs {
 export async function validateEvidence(
   args: ValidateEvidenceArgs
 ): Promise<EvidenceValidationResult> {
-  const { artifactsDir, cwd, policy } = args;
+  const { artifactsDir, cwd, policy, workflowRunId } = args;
   getLog().info(
-    { artifactsDir, path: policy.path, verify: policy.verify },
+    { artifactsDir, path: policy.path, verify: policy.verify, workflowRunId },
     'workflow.evidence_validation_started'
   );
 
@@ -394,6 +396,19 @@ export async function validateEvidence(
   if (!shapeResult.valid) {
     getLog().error({ issues: shapeResult.issues }, 'workflow.evidence_validation_failed');
     return shapeResult;
+  }
+
+  if (shapeResult.evidence.workflow_run_id !== workflowRunId) {
+    const issues: EvidenceValidationIssue[] = [
+      {
+        level: 'error',
+        field: 'workflow_run_id',
+        message: `workflow_run_id '${shapeResult.evidence.workflow_run_id}' does not match active workflow run '${workflowRunId}'`,
+        hint: 'evidence.json appears to be stale or copied from another run',
+      },
+    ];
+    getLog().error({ issues }, 'workflow.evidence_validation_failed');
+    return { valid: false, issues };
   }
 
   // 2. INTEGRITY

--- a/packages/workflows/src/evidence-validator.ts
+++ b/packages/workflows/src/evidence-validator.ts
@@ -161,20 +161,33 @@ export async function verifyEvidenceReality(
     });
   }
 
-  // 2. pushed_branch present on origin
+  // 2. pushed_branch present on origin AND its tip SHA matches commit_sha
   try {
     const { stdout } = await execFileAsync(
       'git',
       ['ls-remote', '--heads', 'origin', evidence.pushed_branch],
       { cwd }
     );
-    if (stdout.trim().length === 0) {
+    const trimmed = stdout.trim();
+    if (trimmed.length === 0) {
       issues.push({
         level: 'error',
         field: 'pushed_branch',
         message: `git ls-remote --heads origin ${evidence.pushed_branch} returned empty; branch is not on origin`,
         hint: 'Did the workflow run `git push -u origin <branch>` after committing?',
       });
+    } else {
+      // Bind commit_sha to the branch tip on origin. Without this check, any
+      // locally-reachable SHA can be paired with any real branch and pass.
+      const remoteSha = trimmed.split(/\s+/)[0];
+      if (remoteSha !== evidence.commit_sha) {
+        issues.push({
+          level: 'error',
+          field: 'commit_sha',
+          message: `commit_sha=${evidence.commit_sha} does not match origin/${evidence.pushed_branch} tip=${remoteSha}`,
+          hint: 'evidence.json claims a commit that is not the tip of pushed_branch on origin',
+        });
+      }
     }
   } catch (err) {
     const e = err as Error & { stderr?: string };
@@ -185,21 +198,28 @@ export async function verifyEvidenceReality(
     });
   }
 
-  // 3. gh pr view confirms PR url maps to pushed_branch and pr_number
+  // 3. gh pr view confirms PR url maps to pushed_branch, pr_number, and commit_sha
   try {
     const { stdout } = await execFileAsync(
       'gh',
-      ['pr', 'view', evidence.pr_url, '--json', 'headRefName,number'],
+      ['pr', 'view', evidence.pr_url, '--json', 'headRefName,number,headRefOid'],
       { cwd }
     );
-    let parsed: { headRefName?: unknown; number?: unknown } | undefined;
+    let parsed: { headRefName?: unknown; number?: unknown; headRefOid?: unknown } | undefined;
     try {
-      parsed = JSON.parse(stdout) as { headRefName?: unknown; number?: unknown };
-    } catch {
+      parsed = JSON.parse(stdout) as {
+        headRefName?: unknown;
+        number?: unknown;
+        headRefOid?: unknown;
+      };
+    } catch (parseErr) {
+      const pe = parseErr instanceof Error ? parseErr : new Error(String(parseErr));
+      const stdoutPreview = stdout.length > 200 ? stdout.slice(0, 200) + '…' : stdout;
       issues.push({
         level: 'error',
         field: 'pr_url',
-        message: `gh pr view returned non-JSON output for ${evidence.pr_url}`,
+        message: `gh pr view returned non-JSON output for ${evidence.pr_url}: ${pe.message}`,
+        hint: `gh stdout (first 200 chars): ${JSON.stringify(stdoutPreview)}`,
       });
       return issues;
     }
@@ -216,6 +236,15 @@ export async function verifyEvidenceReality(
         level: 'error',
         field: 'pr_number',
         message: `gh pr view number=${String(parsed.number)} does not match pr_number=${evidence.pr_number}`,
+      });
+    }
+    // Bind commit_sha to the PR head — the strongest "real-execution proof" check.
+    if (parsed.headRefOid !== evidence.commit_sha) {
+      issues.push({
+        level: 'error',
+        field: 'commit_sha',
+        message: `gh pr view headRefOid='${String(parsed.headRefOid)}' does not match commit_sha='${evidence.commit_sha}'`,
+        hint: 'pr_url points to a PR whose HEAD is a different commit',
       });
     }
   } catch (err) {
@@ -303,7 +332,7 @@ export async function validateEvidence(
   const { artifactsDir, cwd, policy } = args;
   getLog().info(
     { artifactsDir, path: policy.path, verify: policy.verify },
-    'evidence_validation_started'
+    'workflow.evidence_validation_started'
   );
 
   // Path-traversal defense: reject absolute paths and any '..' segment before
@@ -316,7 +345,7 @@ export async function validateEvidence(
         message: `evidence_policy.path '${policy.path}' must be relative to $ARTIFACTS_DIR`,
       },
     ];
-    getLog().error({ issues }, 'evidence_validation_failed');
+    getLog().error({ issues }, 'workflow.evidence_validation_failed');
     return { valid: false, issues };
   }
   if (policy.path.split(/[\\/]/).some(seg => seg === '..')) {
@@ -327,7 +356,7 @@ export async function validateEvidence(
         message: `evidence_policy.path '${policy.path}' must not contain '..' segments`,
       },
     ];
-    getLog().error({ issues }, 'evidence_validation_failed');
+    getLog().error({ issues }, 'workflow.evidence_validation_failed');
     return { valid: false, issues };
   }
 
@@ -344,7 +373,7 @@ export async function validateEvidence(
         message: `failed to read evidence file '${policy.path}': ${e.message}`,
       },
     ];
-    getLog().error({ err, issues }, 'evidence_validation_failed');
+    getLog().error({ err, issues }, 'workflow.evidence_validation_failed');
     return { valid: false, issues };
   }
   if (!load.found) {
@@ -356,21 +385,21 @@ export async function validateEvidence(
         hint: 'PR-producing workflows must write evidence.json before completion',
       },
     ];
-    getLog().error({ issues }, 'evidence_validation_failed');
+    getLog().error({ issues }, 'workflow.evidence_validation_failed');
     return { valid: false, issues };
   }
 
   // 1. SHAPE
   const shapeResult = validateEvidenceShape(load.raw);
   if (!shapeResult.valid) {
-    getLog().error({ issues: shapeResult.issues }, 'evidence_validation_failed');
+    getLog().error({ issues: shapeResult.issues }, 'workflow.evidence_validation_failed');
     return shapeResult;
   }
 
   // 2. INTEGRITY
   const integrityIssues = validateEvidenceIntegrity(shapeResult.evidence);
   if (integrityIssues.length > 0) {
-    getLog().error({ issues: integrityIssues }, 'evidence_validation_failed');
+    getLog().error({ issues: integrityIssues }, 'workflow.evidence_validation_failed');
     return { valid: false, issues: integrityIssues };
   }
 
@@ -378,11 +407,11 @@ export async function validateEvidence(
   if (policy.verify === 'reality') {
     const realityIssues = await verifyEvidenceReality(shapeResult.evidence, cwd);
     if (realityIssues.length > 0) {
-      getLog().error({ issues: realityIssues }, 'evidence_validation_failed');
+      getLog().error({ issues: realityIssues }, 'workflow.evidence_validation_failed');
       return { valid: false, issues: realityIssues };
     }
   }
 
-  getLog().info({ kind: shapeResult.evidence.kind }, 'evidence_validation_completed');
+  getLog().info({ kind: shapeResult.evidence.kind }, 'workflow.evidence_validation_completed');
   return shapeResult;
 }

--- a/packages/workflows/src/evidence-validator.ts
+++ b/packages/workflows/src/evidence-validator.ts
@@ -1,0 +1,388 @@
+/**
+ * Real-execution proof validator (ROADMAP P3-A).
+ *
+ * Three layered checks, evaluated in order, returned as a single discriminated
+ * union via `validateEvidence(...)`:
+ *
+ *   1. SHAPE     — Zod parse against `executionEvidenceSchema`. Pure, no I/O.
+ *   2. INTEGRITY — Cross-field rules (planning rejected as execution; protected
+ *                  branches rejected; zero-tree SHA rejected). Pure, no I/O.
+ *   3. REALITY   — `git cat-file -e`, `git ls-remote --heads origin <branch>`,
+ *                  and `gh pr view <url> --json headRefName,number` confirm
+ *                  the claimed SHA, branch, and PR are real. Async I/O.
+ *                  Only runs when `policy.verify === 'reality'`.
+ *
+ * The orchestrator stops at the first layer that produces errors, so callers
+ * always see the most actionable diagnostic. No layer throws — every failure
+ * mode produces structured `EvidenceValidationIssue[]`. Throwing would skip
+ * the executor's evidence-failure → `failed` transition and surface as an
+ * unrelated runtime error.
+ */
+import { readFile } from 'fs/promises';
+import { isAbsolute, join } from 'path';
+import { execFileAsync } from '@archon/git';
+import { createLogger } from '@archon/paths';
+import { executionEvidenceSchema } from './schemas';
+import type {
+  ExecutionEvidence,
+  EvidencePolicy,
+  EvidenceValidationIssue,
+  EvidenceValidationResult,
+} from './schemas';
+
+/** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
+let cachedLog: ReturnType<typeof createLogger> | undefined;
+function getLog(): ReturnType<typeof createLogger> {
+  if (!cachedLog) cachedLog = createLogger('workflow.evidence-validator');
+  return cachedLog;
+}
+
+/** Branches that workers must NOT push directly to — feature-branch heuristic. */
+const PROTECTED_BRANCHES: readonly string[] = ['main', 'master', 'dev', 'develop'];
+
+/** Empty-tree zero SHA — well-known git constant; never a real commit. */
+const ZERO_SHA = '0000000000000000000000000000000000000000';
+
+// ---------------------------------------------------------------------------
+// SHAPE — Zod parse, no I/O
+// ---------------------------------------------------------------------------
+
+/**
+ * Pure Zod parse. Converts each Zod issue into a per-field
+ * `EvidenceValidationIssue`. Returns `{ valid: true, evidence }` on success.
+ */
+export function validateEvidenceShape(raw: unknown): EvidenceValidationResult {
+  const result = executionEvidenceSchema.safeParse(raw);
+  if (result.success) {
+    return { valid: true, evidence: result.data };
+  }
+  const issues: EvidenceValidationIssue[] = result.error.issues.map(issue => ({
+    level: 'error',
+    field: issue.path.length > 0 ? issue.path.join('.') : 'evidence',
+    message: issue.message,
+  }));
+  return { valid: false, issues };
+}
+
+// ---------------------------------------------------------------------------
+// INTEGRITY — cross-field rules, no I/O
+// ---------------------------------------------------------------------------
+
+/**
+ * Cross-field integrity checks. Returns `[]` if all pass. The schema already
+ * enforces individual field shapes; this layer enforces relationships and
+ * known-bad values that the schema cannot express directly.
+ */
+export function validateEvidenceIntegrity(evidence: ExecutionEvidence): EvidenceValidationIssue[] {
+  const issues: EvidenceValidationIssue[] = [];
+
+  if (evidence.kind === 'planning') {
+    issues.push({
+      level: 'error',
+      field: 'kind',
+      message:
+        "Planning evidence (kind: 'planning') cannot satisfy real-execution proof. " +
+        "Emit kind: 'execution' with the full set of execution fields.",
+      hint: 'Did the workflow actually commit, push, and open a PR?',
+    });
+    return issues;
+  }
+
+  // From here `evidence.kind === 'execution'`; narrow the type.
+  if (evidence.provider_run_ids.length === 0) {
+    issues.push({
+      level: 'error',
+      field: 'provider_run_ids',
+      message: 'provider_run_ids must contain at least one session id',
+    });
+  }
+
+  if (PROTECTED_BRANCHES.includes(evidence.pushed_branch)) {
+    issues.push({
+      level: 'error',
+      field: 'pushed_branch',
+      message: `pushed_branch '${evidence.pushed_branch}' is a protected branch; workers must commit to a feature branch`,
+      hint: `Disallowed: ${PROTECTED_BRANCHES.join(', ')}`,
+    });
+  }
+
+  if (evidence.commit_sha === ZERO_SHA) {
+    issues.push({
+      level: 'error',
+      field: 'commit_sha',
+      message: 'commit_sha is the empty-tree zero SHA; this is never a real commit',
+    });
+  }
+
+  return issues;
+}
+
+// ---------------------------------------------------------------------------
+// REALITY — async I/O against git and gh
+// ---------------------------------------------------------------------------
+
+/**
+ * Confirms the claimed SHA is reachable in `cwd`, the branch is on origin,
+ * and the PR URL maps to the same branch and pr_number. Reality checks are
+ * best-effort: any non-zero exit or shape mismatch becomes a structured
+ * `level: 'error'` issue. `gh` missing or unauthenticated produces a clean
+ * issue with a setup hint — never throws.
+ */
+export async function verifyEvidenceReality(
+  evidence: ExecutionEvidence,
+  cwd: string
+): Promise<EvidenceValidationIssue[]> {
+  if (evidence.kind !== 'execution') {
+    // Integrity layer already rejects planning; defensive guard so callers
+    // that skip integrity (none currently) still see a clean issue.
+    return [
+      {
+        level: 'error',
+        field: 'kind',
+        message: "verifyEvidenceReality requires kind: 'execution'",
+      },
+    ];
+  }
+
+  const issues: EvidenceValidationIssue[] = [];
+
+  // 1. commit_sha reachable in worktree
+  try {
+    await execFileAsync('git', ['cat-file', '-e', `${evidence.commit_sha}^{commit}`], { cwd });
+  } catch (err) {
+    const e = err as Error & { stderr?: string };
+    issues.push({
+      level: 'error',
+      field: 'commit_sha',
+      message: `git cat-file -e ${evidence.commit_sha}^{commit} failed: ${
+        e.stderr?.trim() || e.message
+      }`,
+      hint: 'commit_sha is not reachable in this checkout — fake SHA or wrong cwd',
+    });
+  }
+
+  // 2. pushed_branch present on origin
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['ls-remote', '--heads', 'origin', evidence.pushed_branch],
+      { cwd }
+    );
+    if (stdout.trim().length === 0) {
+      issues.push({
+        level: 'error',
+        field: 'pushed_branch',
+        message: `git ls-remote --heads origin ${evidence.pushed_branch} returned empty; branch is not on origin`,
+        hint: 'Did the workflow run `git push -u origin <branch>` after committing?',
+      });
+    }
+  } catch (err) {
+    const e = err as Error & { stderr?: string };
+    issues.push({
+      level: 'error',
+      field: 'pushed_branch',
+      message: `git ls-remote failed: ${e.stderr?.trim() || e.message}`,
+    });
+  }
+
+  // 3. gh pr view confirms PR url maps to pushed_branch and pr_number
+  try {
+    const { stdout } = await execFileAsync(
+      'gh',
+      ['pr', 'view', evidence.pr_url, '--json', 'headRefName,number'],
+      { cwd }
+    );
+    let parsed: { headRefName?: unknown; number?: unknown } | undefined;
+    try {
+      parsed = JSON.parse(stdout) as { headRefName?: unknown; number?: unknown };
+    } catch {
+      issues.push({
+        level: 'error',
+        field: 'pr_url',
+        message: `gh pr view returned non-JSON output for ${evidence.pr_url}`,
+      });
+      return issues;
+    }
+    if (parsed.headRefName !== evidence.pushed_branch) {
+      issues.push({
+        level: 'error',
+        field: 'pr_url',
+        message: `gh pr view headRefName='${String(parsed.headRefName)}' does not match pushed_branch='${evidence.pushed_branch}'`,
+        hint: 'pr_url points to a PR for a different branch',
+      });
+    }
+    if (parsed.number !== evidence.pr_number) {
+      issues.push({
+        level: 'error',
+        field: 'pr_number',
+        message: `gh pr view number=${String(parsed.number)} does not match pr_number=${evidence.pr_number}`,
+      });
+    }
+  } catch (err) {
+    const e = err as Error & { code?: string; stderr?: string };
+    if (e.code === 'ENOENT') {
+      issues.push({
+        level: 'error',
+        field: 'pr_url',
+        message: 'gh binary not found on PATH',
+        hint: "install gh and run 'gh auth status' (or set evidence_policy.verify: 'shape')",
+      });
+    } else {
+      issues.push({
+        level: 'error',
+        field: 'pr_url',
+        message: `gh pr view ${evidence.pr_url} failed: ${e.stderr?.trim() || e.message}`,
+        hint: "run 'gh auth status' to confirm authentication",
+      });
+    }
+  }
+
+  return issues;
+}
+
+// ---------------------------------------------------------------------------
+// LOAD — read evidence.json from artifacts dir
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of loading an evidence file. `raw` is the parsed JSON value when the
+ * file exists and parses; on JSON parse failure we still return `found: true`
+ * with `raw` as the original string so the shape validator can produce a
+ * clean issue (and never a thrown exception).
+ */
+export type LoadEvidenceResult = { found: false } | { found: true; raw: unknown };
+
+/**
+ * Read the evidence file at `<artifactsDir>/<path>`. On `ENOENT` returns
+ * `{ found: false }`; on JSON parse failure returns `{ found: true; raw:
+ * <original string> }` so the caller can surface a structured issue instead
+ * of a thrown error.
+ */
+export async function loadEvidenceFromArtifacts(
+  artifactsDir: string,
+  path = 'evidence.json'
+): Promise<LoadEvidenceResult> {
+  const fullPath = join(artifactsDir, path);
+  let contents: string;
+  try {
+    contents = await readFile(fullPath, 'utf8');
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code === 'ENOENT') return { found: false };
+    throw err;
+  }
+  try {
+    const parsed: unknown = JSON.parse(contents);
+    return { found: true, raw: parsed };
+  } catch {
+    return { found: true, raw: contents };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ORCHESTRATOR — public entry point
+// ---------------------------------------------------------------------------
+
+export interface ValidateEvidenceArgs {
+  /** Resolved artifacts directory ($ARTIFACTS_DIR for the run). */
+  artifactsDir: string;
+  /** Working directory for git/gh reality checks (typically the run cwd). */
+  cwd: string;
+  /** Workflow-level evidence policy. */
+  policy: EvidencePolicy;
+}
+
+/**
+ * Run the full evidence-validation pipeline. Loads, then SHAPE, then
+ * INTEGRITY, then (when `policy.verify === 'reality'`) REALITY. Stops at
+ * the first layer that produces errors. Never throws.
+ */
+export async function validateEvidence(
+  args: ValidateEvidenceArgs
+): Promise<EvidenceValidationResult> {
+  const { artifactsDir, cwd, policy } = args;
+  getLog().info(
+    { artifactsDir, path: policy.path, verify: policy.verify },
+    'evidence_validation_started'
+  );
+
+  // Path-traversal defense: reject absolute paths and any '..' segment before
+  // touching the filesystem.
+  if (isAbsolute(policy.path)) {
+    const issues: EvidenceValidationIssue[] = [
+      {
+        level: 'error',
+        field: 'evidence_policy.path',
+        message: `evidence_policy.path '${policy.path}' must be relative to $ARTIFACTS_DIR`,
+      },
+    ];
+    getLog().error({ issues }, 'evidence_validation_failed');
+    return { valid: false, issues };
+  }
+  if (policy.path.split(/[\\/]/).some(seg => seg === '..')) {
+    const issues: EvidenceValidationIssue[] = [
+      {
+        level: 'error',
+        field: 'evidence_policy.path',
+        message: `evidence_policy.path '${policy.path}' must not contain '..' segments`,
+      },
+    ];
+    getLog().error({ issues }, 'evidence_validation_failed');
+    return { valid: false, issues };
+  }
+
+  // 0. LOAD
+  let load: LoadEvidenceResult;
+  try {
+    load = await loadEvidenceFromArtifacts(artifactsDir, policy.path);
+  } catch (err) {
+    const e = err as Error;
+    const issues: EvidenceValidationIssue[] = [
+      {
+        level: 'error',
+        field: 'evidence_policy.path',
+        message: `failed to read evidence file '${policy.path}': ${e.message}`,
+      },
+    ];
+    getLog().error({ err, issues }, 'evidence_validation_failed');
+    return { valid: false, issues };
+  }
+  if (!load.found) {
+    const issues: EvidenceValidationIssue[] = [
+      {
+        level: 'error',
+        field: 'evidence_policy.path',
+        message: `evidence file not found at $ARTIFACTS_DIR/${policy.path}`,
+        hint: 'PR-producing workflows must write evidence.json before completion',
+      },
+    ];
+    getLog().error({ issues }, 'evidence_validation_failed');
+    return { valid: false, issues };
+  }
+
+  // 1. SHAPE
+  const shapeResult = validateEvidenceShape(load.raw);
+  if (!shapeResult.valid) {
+    getLog().error({ issues: shapeResult.issues }, 'evidence_validation_failed');
+    return shapeResult;
+  }
+
+  // 2. INTEGRITY
+  const integrityIssues = validateEvidenceIntegrity(shapeResult.evidence);
+  if (integrityIssues.length > 0) {
+    getLog().error({ issues: integrityIssues }, 'evidence_validation_failed');
+    return { valid: false, issues: integrityIssues };
+  }
+
+  // 3. REALITY (opt-in)
+  if (policy.verify === 'reality') {
+    const realityIssues = await verifyEvidenceReality(shapeResult.evidence, cwd);
+    if (realityIssues.length > 0) {
+      getLog().error({ issues: realityIssues }, 'evidence_validation_failed');
+      return { valid: false, issues: realityIssues };
+    }
+  }
+
+  getLog().info({ kind: shapeResult.evidence.kind }, 'evidence_validation_completed');
+  return shapeResult;
+}

--- a/packages/workflows/src/schemas.test.ts
+++ b/packages/workflows/src/schemas.test.ts
@@ -9,6 +9,9 @@ import {
   LOOP_NODE_AI_FIELDS,
   approvalOnRejectSchema,
   dagNodeSchema,
+  executionEvidenceSchema,
+  evidencePolicySchema,
+  workflowBaseSchema,
 } from './schemas';
 import type {
   WorkflowDefinition,
@@ -693,5 +696,68 @@ describe('LOOP_NODE_AI_FIELDS', () => {
     for (const field of expectedFields) {
       expect(LOOP_NODE_AI_FIELDS).toContain(field);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executionEvidenceSchema + evidencePolicySchema (P3-A)
+// ---------------------------------------------------------------------------
+
+describe('executionEvidenceSchema', () => {
+  const fullExecution = {
+    kind: 'execution',
+    workflow_run_id: 'run-1',
+    provider: 'claude',
+    provider_run_ids: ['session-abc'],
+    changed_files: ['src/foo.ts'],
+    diff_command: 'git diff --stat origin/dev...HEAD',
+    test_commands: ['bun test'],
+    test_output_summary: '15 passed',
+    commit_sha: 'a'.repeat(40),
+    pushed_branch: 'feature/foo',
+    pr_url: 'https://github.com/owner/repo/pull/42',
+    pr_number: 42,
+  };
+
+  const fullPlanning = {
+    kind: 'planning',
+    workflow_run_id: 'run-1',
+    provider: 'claude',
+    summary: 'wrote plan.md',
+  };
+
+  test('full execution fixture parses', () => {
+    expect(executionEvidenceSchema.safeParse(fullExecution).success).toBe(true);
+  });
+
+  test('full planning fixture parses', () => {
+    expect(executionEvidenceSchema.safeParse(fullPlanning).success).toBe(true);
+  });
+});
+
+describe('evidencePolicySchema', () => {
+  test('parse({ required: true }) applies defaults for verify and path', () => {
+    const parsed = evidencePolicySchema.parse({ required: true });
+    expect(parsed.required).toBe(true);
+    expect(parsed.verify).toBe('shape');
+    expect(parsed.path).toBe('evidence.json');
+  });
+
+  test('parse({}) leaves required undefined and applies defaults', () => {
+    const parsed = evidencePolicySchema.parse({});
+    expect(parsed.required).toBeUndefined();
+    expect(parsed.verify).toBe('shape');
+    expect(parsed.path).toBe('evidence.json');
+  });
+});
+
+describe('workflowBaseSchema accepts evidence_policy', () => {
+  test('parses workflow with evidence_policy.required: true', () => {
+    const result = workflowBaseSchema.safeParse({
+      name: 'x',
+      description: 'y',
+      evidence_policy: { required: true },
+    });
+    expect(result.success).toBe(true);
   });
 });

--- a/packages/workflows/src/schemas/evidence.ts
+++ b/packages/workflows/src/schemas/evidence.ts
@@ -106,9 +106,19 @@ export const evidencePolicySchema = z.object({
   /**
    * Path to the evidence JSON file, relative to `$ARTIFACTS_DIR`.
    * Absolute paths and `..` segments are rejected by the validator before
-   * any read occurs (path-traversal defense).
+   * any read occurs (path-traversal defense). Empty / directory-like values
+   * are rejected at parse time so author errors fail fast instead of
+   * surfacing as cryptic ENOENT/EISDIR runtime errors.
    */
-  path: z.string().default('evidence.json'),
+  path: z
+    .string()
+    .trim()
+    .min(1, 'evidence_policy.path cannot be empty')
+    .refine(
+      p => p !== '.' && !p.endsWith('/'),
+      'evidence_policy.path must be a file, not a directory'
+    )
+    .default('evidence.json'),
 });
 
 export type EvidencePolicy = z.infer<typeof evidencePolicySchema>;
@@ -118,7 +128,11 @@ export type EvidencePolicy = z.infer<typeof evidencePolicySchema>;
 // ---------------------------------------------------------------------------
 
 export const evidenceValidationIssueSchema = z.object({
-  level: z.enum(['error', 'warning']),
+  // Only 'error' is currently emitted. Add 'warning' here when a producer
+  // exists alongside an explicit gate-semantics decision (today the gate
+  // would treat warnings as failures because validateEvidence returns
+  // valid: false on any issue).
+  level: z.enum(['error']),
   field: z.string(),
   message: z.string(),
   hint: z.string().optional(),

--- a/packages/workflows/src/schemas/evidence.ts
+++ b/packages/workflows/src/schemas/evidence.ts
@@ -1,0 +1,144 @@
+/**
+ * Zod schemas for the real-execution proof contract (ROADMAP P3-A).
+ *
+ * `executionEvidenceSchema` is a discriminated union on `kind`:
+ *   - `kind: 'planning'`  — explicit marker that an artifact is planning-only.
+ *                           Schema parses this shape but the integrity validator
+ *                           rejects it; planning evidence MUST NEVER pass as
+ *                           execution proof.
+ *   - `kind: 'execution'` — full set of fields a PR-producing run leaves
+ *                           behind (commit SHA, pushed branch, PR URL, changed
+ *                           files, test commands/output, provider/run IDs).
+ *
+ * `evidencePolicySchema` is the workflow-level opt-in. When `required: true`,
+ * the engine refuses to mark the run `completed` unless `$ARTIFACTS_DIR/<path>`
+ * (default `evidence.json`) parses against `executionEvidenceSchema` and
+ * (when `verify === 'reality'`) the claimed SHA/branch/PR are reachable in
+ * git/origin/GitHub.
+ *
+ * `evidenceValidationIssueSchema` mirrors `ValidationIssue` from validator.ts.
+ * `evidenceValidationResultSchema` is a `valid`-discriminated union — callers
+ * narrow via `result.valid === true` to access `evidence`, or `false` to
+ * access `issues`.
+ */
+import { z } from '@hono/zod-openapi';
+
+// ---------------------------------------------------------------------------
+// ExecutionEvidence — discriminated union on `kind`
+// ---------------------------------------------------------------------------
+
+/**
+ * Planning-only artifact. Authors MAY emit this to explicitly mark a run as
+ * non-execution. The integrity check rejects it as execution proof.
+ */
+const planningEvidenceSchema = z.object({
+  kind: z.literal('planning'),
+  workflow_run_id: z.string().min(1),
+  provider: z.string().min(1),
+  summary: z.string().min(1),
+});
+
+/**
+ * Real-execution proof. Every field is required and structurally meaningful:
+ *   - `commit_sha` is canonical 40-char lowercase hex (git's only canonical form)
+ *   - `pr_url` is restricted to `https://github.com/<owner>/<repo>/pull/<number>`
+ *   - `provider_run_ids` and `changed_files` are non-empty (a run that produced
+ *     no session and changed no files cannot be claiming PR delivery)
+ *   - `test_commands` MAY be empty (some PRs are doc-only) but the field MUST
+ *     be present so absence is explicit, not implicit
+ */
+const realExecutionEvidenceSchema = z.object({
+  kind: z.literal('execution'),
+  workflow_run_id: z.string().min(1),
+  provider: z.string().min(1),
+  provider_run_ids: z.array(z.string().min(1)).nonempty(),
+  changed_files: z.array(z.string().min(1)).nonempty(),
+  diff_command: z.string().min(1),
+  test_commands: z.array(z.string().min(1)),
+  test_output_summary: z.string(),
+  commit_sha: z.string().regex(/^[0-9a-f]{40}$/, 'commit_sha must be 40-char lowercase hex'),
+  pushed_branch: z.string().min(1),
+  pr_url: z
+    .string()
+    .url()
+    .regex(
+      /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+$/,
+      'pr_url must be https://github.com/<owner>/<repo>/pull/<number>'
+    ),
+  pr_number: z.number().int().positive(),
+});
+
+export const executionEvidenceSchema = z.discriminatedUnion('kind', [
+  planningEvidenceSchema,
+  realExecutionEvidenceSchema,
+]);
+
+export type ExecutionEvidence = z.infer<typeof executionEvidenceSchema>;
+
+/**
+ * Field names required on the `kind: 'execution'` branch. Derived from the
+ * schema shape so the list cannot drift from the contract.
+ */
+export const EXECUTION_EVIDENCE_REQUIRED_FIELDS: readonly string[] = Object.freeze(
+  Object.keys(realExecutionEvidenceSchema.shape)
+);
+
+// ---------------------------------------------------------------------------
+// EvidencePolicy — workflow-level opt-in
+// ---------------------------------------------------------------------------
+
+export const evidencePolicySchema = z.object({
+  /**
+   * When `true`, the engine refuses to mark the workflow run `completed`
+   * unless evidence validation passes. Defaults to `false` when omitted at the
+   * workflow level so existing workflows without the flag remain unaffected.
+   */
+  required: z.boolean().optional(),
+  /**
+   * Validation depth:
+   *   - `'shape'`   — Zod parse + cross-field integrity (no I/O)
+   *   - `'reality'` — also verify commit SHA, pushed branch, and PR URL via
+   *                   git/gh. Requires `gh` on PATH and authenticated.
+   * Default `'shape'` keeps CI hermetic; operators opt in to reality per
+   * workflow.
+   */
+  verify: z.enum(['shape', 'reality']).default('shape'),
+  /**
+   * Path to the evidence JSON file, relative to `$ARTIFACTS_DIR`.
+   * Absolute paths and `..` segments are rejected by the validator before
+   * any read occurs (path-traversal defense).
+   */
+  path: z.string().default('evidence.json'),
+});
+
+export type EvidencePolicy = z.infer<typeof evidencePolicySchema>;
+
+// ---------------------------------------------------------------------------
+// EvidenceValidationIssue — actionable per-field error
+// ---------------------------------------------------------------------------
+
+export const evidenceValidationIssueSchema = z.object({
+  level: z.enum(['error', 'warning']),
+  field: z.string(),
+  message: z.string(),
+  hint: z.string().optional(),
+});
+
+export type EvidenceValidationIssue = z.infer<typeof evidenceValidationIssueSchema>;
+
+// ---------------------------------------------------------------------------
+// EvidenceValidationResult — discriminated union on `valid`
+// ---------------------------------------------------------------------------
+
+export const evidenceValidationResultSchema = z.discriminatedUnion('valid', [
+  z.object({
+    valid: z.literal(true),
+    evidence: executionEvidenceSchema,
+  }),
+  z.object({
+    valid: z.literal(false),
+    issues: z.array(evidenceValidationIssueSchema),
+  }),
+]);
+
+export type EvidenceValidationResult = z.infer<typeof evidenceValidationResultSchema>;

--- a/packages/workflows/src/schemas/index.ts
+++ b/packages/workflows/src/schemas/index.ts
@@ -107,6 +107,21 @@ export type {
   ApprovalContext,
 } from './workflow-run';
 
+// Evidence contract (P3-A real-execution proof)
+export {
+  executionEvidenceSchema,
+  evidencePolicySchema,
+  evidenceValidationIssueSchema,
+  evidenceValidationResultSchema,
+  EXECUTION_EVIDENCE_REQUIRED_FIELDS,
+} from './evidence';
+export type {
+  ExecutionEvidence,
+  EvidencePolicy,
+  EvidenceValidationIssue,
+  EvidenceValidationResult,
+} from './evidence';
+
 // Result types (non-schema hand-written types)
 export type {
   LoadCommandResult,

--- a/packages/workflows/src/schemas/workflow.ts
+++ b/packages/workflows/src/schemas/workflow.ts
@@ -9,6 +9,7 @@ import {
   thinkingConfigSchema,
   sandboxSettingsSchema,
 } from './dag-node';
+import { evidencePolicySchema } from './evidence';
 
 // ---------------------------------------------------------------------------
 // Shared enum schemas
@@ -68,6 +69,16 @@ export const workflowBaseSchema = z.object({
   betas: z.array(z.string().min(1)).nonempty("'betas' must be a non-empty array").optional(),
   sandbox: sandboxSettingsSchema.optional(),
   worktree: workflowWorktreePolicySchema.optional(),
+  /**
+   * Real-execution proof policy. When `required: true`, the engine refuses to
+   * mark this workflow `completed` unless `$ARTIFACTS_DIR/<path>` (default
+   * `evidence.json`) parses against `executionEvidenceSchema` and (when
+   * `verify === 'reality'`) the claimed commit/branch/PR are reachable in
+   * git/origin/GitHub. Failed validation downgrades the run to `failed` with
+   * structured issues stored at `metadata.evidence_validation`. When omitted,
+   * behavior is unchanged from before this PR.
+   */
+  evidence_policy: evidencePolicySchema.optional(),
   /**
    * When `false`, the engine skips the path-exclusive lock for this workflow,
    * allowing N concurrent runs on the same live checkout. The author asserts


### PR DESCRIPTION
## Summary

- **Problem**: PR-producing workflows can finish with `status='completed'` based only on a self-report ("I created the PR"), with no enforced contract proving the work actually happened. Planning artifacts, fabricated commit SHAs, unpushed branches, or unreachable PR URLs all pass undetected.
- **Why it matters**: Trust in autonomous workflow runs depends on a hard, machine-checkable boundary between "claimed completion" and "verified completion." Without one, downstream automation (auto-resume, run-history dashboards, governance gates) inherits unverifiable state.
- **What changed**: Added a typed evidence contract (`executionEvidenceSchema`, `evidencePolicySchema`) and a three-layer validator (`evidence-validator.ts`) inside `@archon/workflows`. The DAG executor now deterministically blocks terminal `completed` status when the workflow declares `evidence_policy.required: true` and `$ARTIFACTS_DIR/evidence.json` is missing, malformed, or fake. On failure the run is downgraded to `failed` with structured issues persisted at `metadata.evidence_validation`.
- **What did *not* change (scope boundary)**: No new node type, no bundled YAML changes, no CLI subcommand, no DB migration, no web UI, no provider/adapter changes, no AI-driven judging, no retroactive validation of prior runs. Reality I/O (`git ls-remote`, `gh pr view`) is opt-in via `verify: 'reality'`; default is `'shape'`.

## UX Journey

### Before

```
Workflow author        Archon executor              Operator
─────────────────      ───────────────              ────────
runs PR workflow ───▶  executes DAG nodes
                       last node completes
                       store.completeWorkflowRun()
                       status='completed' ─────────▶ sees ✅ completed
                                                     (no verification —
                                                      may be planning-only,
                                                      fake SHA, unpushed
                                                      branch, etc.)
```

### After

```
Workflow author              Archon executor                          Operator
─────────────────            ────────────────                          ────────
sets evidence_policy:        executes DAG nodes
  required: true             last node completes
  verify: 'shape'            [+] reads $ARTIFACTS_DIR/evidence.json
writes evidence.json     ──▶ [+] validateEvidence(): shape → integrity → reality
                                  │
                                  ├─ ok ──▶ store.completeWorkflowRun()
                                  │        status='completed'  ──────▶ ✅ completed
                                  │
                                  └─ fail ─▶ store.failWorkflowRun(msg)
                                            updateWorkflowRun({
                                              metadata.evidence_validation: {issues}
                                            })
                                            status='failed'  ────────▶ ❌ failed +
                                                                       actionable issues
```

## Architecture Diagram

### Before

```
@archon/workflows
├── schemas/
│   ├── workflow.ts          (workflowBaseSchema)
│   ├── workflow-run.ts
│   └── index.ts
├── dag-executor.ts          ──▶ store.completeWorkflowRun()  [single terminal-success]
├── store.ts                 (IWorkflowStore)
└── validator.ts             (workflow-definition validator)
```

### After

```
@archon/workflows
├── schemas/
│   ├── evidence.ts          [+]   executionEvidenceSchema (discriminated union on `kind`),
│   │                              evidencePolicySchema, evidenceValidationIssueSchema,
│   │                              evidenceValidationResultSchema
│   ├── workflow.ts          [~]   workflowBaseSchema gains optional `evidence_policy`
│   ├── workflow-run.ts
│   └── index.ts             [~]   re-exports new evidence schemas
├── evidence-validator.ts    [+]   validateEvidenceShape (Zod)
│                                  validateEvidenceIntegrity (cross-field)
│                                  verifyEvidenceReality (git/gh I/O, opt-in)
│                                  loadEvidenceFromArtifacts
│                                  validateEvidence (orchestrator)
├── dag-executor.ts          [~]   gates terminal-success on evidence_policy
│                                  === store.completeWorkflowRun()  (when valid)
│                                  === store.failWorkflowRun() + updateWorkflowRun(metadata)
│                                                                  (when invalid)
├── store.ts
└── validator.ts
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `dag-executor.ts` | `evidence-validator.ts::validateEvidence` | **new** | Called once at terminal-success boundary when `evidence_policy?.required === true` |
| `evidence-validator.ts` | `@archon/git` (`execFileAsync`) | **new** | Reality layer only; opt-in via `verify: 'reality'`. Stubbed in tests via isolated `mock.module()` invocation |
| `evidence-validator.ts` | `gh` CLI (subprocess) | **new** | Reality layer only; ENOENT/auth failures produce clean error issues, never throw |
| `schemas/index.ts` | `schemas/evidence.ts` | **new** | Re-export `executionEvidenceSchema`, `evidencePolicySchema`, derived types |
| `schemas/workflow.ts` | `schemas/evidence.ts` | **new** | `workflowBaseSchema.evidence_policy: evidencePolicySchema.optional()` |
| `dag-executor.ts` | `store.completeWorkflowRun` | unchanged | Still the single terminal-success transition |
| `dag-executor.ts` | `store.failWorkflowRun` | unchanged | Existing failure path — reused for evidence-validation failures |
| `dag-executor.ts` | `store.updateWorkflowRun` | unchanged | Used to persist `metadata.evidence_validation` after `failWorkflowRun` |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `workflows`
- Module: `workflows:executor`, `workflows:schemas`

## Change Metadata

- Change type: `feature`
- Primary scope: `workflows`

## Linked Issue

- Closes: _n/a — implements ROADMAP P3-A (`ROADMAP.md`)_
- Related: _n/a_
- Depends on: _none_
- Supersedes: _none_

## Validation Evidence (required)

```bash
bun run validate
```

All gates green on first invocation (no fixes required during validation):

- `check:bundled` — `bundled-defaults.generated.ts is up to date (36 commands, 20 workflows)`
- `check:bundled-skill` — `bundled-skill.ts is up to date (21 files)`
- `type-check` — all 10 packages exit 0
- `lint` — `bun x eslint . --cache --max-warnings 0` (0 errors, 0 warnings)
- `format:check` — `All matched files use Prettier code style!`
- `test` — all per-package tests pass (sprint-relevant: 43 evidence-validator + 6 schema + 3 dag-executor integration = 52 new tests)

Test breakdown:

| Test File | Tests | Coverage |
|-----------|-------|----------|
| `packages/workflows/src/evidence-validator.test.ts` (new) | 43 | All 5 groups: shape, integrity, reality, loader, orchestrator. Every Edge Case in plan covered. |
| `packages/workflows/src/schemas.test.ts` (extended) | +6 | `executionEvidenceSchema` parse (execution + planning), `evidencePolicySchema` defaults, `workflowBaseSchema` accepts policy |
| `packages/workflows/src/dag-executor.test.ts` (extended) | +3 | required + missing → `failed` + structured issues; required + valid → `completed`; no-policy → `completed` (regression guard) |

- Evidence provided: `validation.md` artifact (full per-package counts in `/Users/syedhaider/.archon/workspaces/shhaider/Archon/artifacts/runs/4c517fe4db197edb948e3f3d4adf9927/validation.md`)
- Skipped commands: none

## Security Impact (required)

- New permissions/capabilities? **No** — validator only reads `$ARTIFACTS_DIR/evidence.json` (workflow-owned) and runs read-only `git ls-remote` / `git cat-file -e` / `gh pr view` when reality checks are explicitly opted in.
- New external network calls? **Yes (opt-in only)** — `git ls-remote origin <branch>` and `gh pr view <url>` run only when `evidence_policy.verify === 'reality'`. Default is `'shape'` (no network). Tests stub `execFileAsync` via isolated `mock.module()`.
- Secrets/tokens handling changed? **No** — `gh` uses the operator's existing auth context; no token reading or logging in this PR.
- File system access scope changed? **No new scope** — validator reads only inside `$ARTIFACTS_DIR` (already workflow-owned). `evidence_policy.path` is rejected if absolute or contains `..` (path-traversal guard with explicit negative test).
- Risk and mitigation: Reality layer's git/gh subprocesses are wrapped in `try/catch`; failures produce structured `EvidenceValidationIssue` objects (never throw). `gh` ENOENT / auth failure produces a clean error issue with operator hint.

## Compatibility / Migration

- Backward compatible? **Yes** — `evidence_policy` is optional on `workflowBaseSchema`. Workflows that omit it have byte-identical behavior to before this PR (regression-tested in `dag-executor.test.ts`).
- Config/env changes? **No** — no new environment variables, no `.archon/config.yaml` keys.
- Database migration needed? **No** — evidence-validation issues are persisted via existing `WorkflowRun.metadata` (`z.record(z.unknown())`). No `migrations/` files modified.
- Upgrade steps: none. Existing workflows continue to work unchanged.

## Human Verification (required)

What was personally validated beyond CI:

- **Verified scenarios**:
  - `bun run validate` exits 0 from a clean checkout of this branch (no env tweaking).
  - `evidence-validator.test.ts` was confirmed to be isolated as its own `bun test` invocation in `packages/workflows/package.json` to prevent `mock.module('@archon/git', ...)` cross-pollution per CLAUDE.md mock-isolation rule.
  - `bun --filter @archon/workflows type-check` and full-monorepo `bun run type-check` both green.
  - The `discoverWorkflowsWithConfig` flow continues to load existing bundled workflows without `evidence_policy` (regression test).
- **Edge cases checked** (all in `evidence-validator.test.ts`):
  - Empty-tree zero SHA (`'0' * 40`)
  - Short SHA (`'abc1234'`)
  - Uppercase / non-hex SHA
  - Protected branches (`main`/`master`/`dev`/`develop`)
  - `pushed_branch` claimed but `git ls-remote` empty
  - `pr_url` claimed but `gh pr view` returns different `headRefName` or different `number`
  - `gh` ENOENT (binary missing) → clean error issue
  - `evidence_policy.path` absolute / `..` traversal
  - `evidence.json` missing / malformed JSON / `null` / string / array / number
  - `kind === 'planning'` rejected by integrity layer
- **What was not verified**:
  - End-to-end run of a real PR-producing workflow with `evidence_policy.required: true` enabled (no bundled YAML opts in yet — explicitly out of scope per plan; follow-up PR).
  - Reality layer against a live GitHub repo (covered by stubbed unit tests; live integration is a CI/staging concern beyond this PR).

## Side Effects / Blast Radius (required)

- **Affected subsystems/workflows**:
  - `@archon/workflows` (only) — schemas, validator, executor terminal-success transition.
  - No impact on `@archon/core`, `@archon/cli`, `@archon/server`, `@archon/web`, `@archon/adapters`, `@archon/providers`, `@archon/git`, `@archon/isolation`, `@archon/paths` (all type-check green; no exported surface touched).
  - Workflows that omit `evidence_policy` are unaffected (regression-guarded).
- **Potential unintended effects**:
  - If a workflow author opts in to `evidence_policy.required: true` but does not write `evidence.json`, runs will fail terminally. This is the intended contract — explicitly documented in the schema and surfaced via `metadata.evidence_validation.issues`.
  - Tests with `mock.module('@archon/git', ...)` could pollute other tests if the new test file weren't isolated. Mitigated by adding `bun test src/evidence-validator.test.ts` as a separate invocation in `package.json` per CLAUDE.md.
- **Guardrails / monitoring for early detection**:
  - `metadata.evidence_validation` is queryable from the API; failures surface as ordinary `failed` runs in run history.
  - Existing log events (`workflow.run_failed`) fire on validation failure, with structured issue payload.
  - Type-check + format + lint catch any author misuse of `evidence_policy` at workflow-load time.

## Rollback Plan (required)

- **Fast rollback command/path**: `git revert 55e39055 && git push origin dev` — single commit, additive only on the engine side. Reverting restores byte-identical pre-PR behavior because all bundled workflows still omit `evidence_policy`.
- **Feature flags or config toggles**: `evidence_policy.required` is itself the flag. Setting it to `false` (or omitting the field entirely) restores prior behavior per workflow.
- **Observable failure symptoms**: any spike in `failed` runs whose `metadata.evidence_validation.issues` is populated — unique signature distinguishing this gate's failures from other failure modes.

## Risks and Mitigations

- **Risk**: Reality I/O (`git ls-remote`, `gh pr view`) flakes in CI or sandboxed runners.
  - **Mitigation**: `verify: 'shape'` is the default. Reality is strictly opt-in. Validator tests stub `execFileAsync` via `mock.module()` in an isolated `bun test` invocation. ENOENT/auth/exit-non-zero produce structured error issues without throwing.
- **Risk**: `mock.module('@archon/git', ...)` in the new test file pollutes other workflow tests in the same `bun test` process.
  - **Mitigation**: New test file is registered as its own `bun test src/evidence-validator.test.ts` invocation in `packages/workflows/package.json`. Verified by passing test run.
- **Risk**: `evidence_policy.path` allows path traversal outside `$ARTIFACTS_DIR`.
  - **Mitigation**: Validator rejects absolute paths and `..` segments before reading. Negative test in Group D (`loader`) covers both.
- **Risk**: Plan called the terminal store method `updateWorkflowRun(...)` but the actual call site is `completeWorkflowRun(...)` / `failWorkflowRun(...)`.
  - **Mitigation**: Pre-flagged in `plan-confirmation.md`. Implementation gates the actual `completeWorkflowRun(...)` call at `dag-executor.ts:3134` (the single terminal-success transition); failure path uses the existing `failWorkflowRun(id, error)` plus a separate `updateWorkflowRun(...)` to persist `metadata.evidence_validation`. Plan intent — single-point gate, structured issues persisted to `metadata.evidence_validation` — fully preserved.

---

**Plan**: `/Users/syedhaider/.archon/workspaces/shhaider/Archon/artifacts/runs/4c517fe4db197edb948e3f3d4adf9927/plan.md`
**Workflow ID**: `4c517fe4db197edb948e3f3d4adf9927`
**ROADMAP entry**: P3-A — Real-Execution Proof Validation for PR-Producing Workflows


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional workflow-level evidence_policy that can block workflow completion until evidence passes shape/integrity and optional reality checks.

* **Tests**
  * Comprehensive unit and integration tests covering evidence validation and execution gating.

* **Documentation**
  * Roadmap and guides updated with evidence-gated workflows, schema examples, and failure behavior.

* **Chores**
  * Validator and related utilities exposed via package exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->