### PR TITLE
fix(cli): pass codebaseName when creating worktree from CLI

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -570,6 +570,7 @@ export async function workflowRunCommand(
           ? git.toBranchName(options.fromBranch.trim())
           : undefined,
         codebaseId: codebase.id,
+        codebaseName: codebase.name,
         canonicalRepoPath: git.toRepoPath(codebase.default_cwd),
         description: `CLI workflow: ${workflowName}`,
       });


### PR DESCRIPTION
## Summary

- **Problem**: Running `archon workflow run` from a locally-registered repo whose checkout path is *not* under `~/.archon/workspaces/` (e.g. `~/Projects/<repo>`) creates a malformed worktree at `~/.archon/workspaces/<parent-dir>/<repo>/worktrees/...` instead of `~/.archon/workspaces/<owner>/<repo>/worktrees/...`. The run reaches `status: running` but stalls with `current_step_index` permanently `null`.
- **Why it matters**: All CLI dispatches from a locally-registered repo outside `~/.archon/workspaces/` silently break. The web adapter is unaffected, so the bug looks intermittent (works from web, hangs from CLI on the same repo).
- **What changed**: One line in `packages/cli/src/commands/workflow.ts`. The CLI now passes `codebaseName: codebase.name` into the `IsolationRequest`, matching what the resolver/web path already does.
- **What did not change**: Web/Slack/Telegram/GitHub dispatch paths (they already passed `codebaseName` via `IsolationResolver` — see `packages/isolation/src/resolver.ts:329,374`). No isolation-engine changes. No new flags or config.

## Root cause

`IsolationRequestBase.codebaseName` is documented as: "When present, used to resolve the project-scoped worktree path directly, even for locally-registered repos whose path doesn't start with workspacesPath."

The CLI's `workflowRunCommand` was building the request without it:

```ts
const isolatedEnv = await provider.create({
  workflowType: 'task',
  identifier: branchIdentifier,
  fromBranch: ...,
  codebaseId: codebase.id,
  // codebaseName missing
  canonicalRepoPath: git.toRepoPath(codebase.default_cwd),
  description: `CLI workflow: ${workflowName}`,
});
```

With `codebaseName` undefined, `getWorktreeBase()` (in `packages/git/src/worktree.ts`) only succeeds via the path-prefix branch when `repoPath.startsWith(workspacesPath)`. For locally-registered repos at arbitrary paths the prefix check fails, and `extractOwnerRepo()` then takes the last two path segments — yielding `Projects/<repo>` for a repo at `~/Projects/<repo>`, etc.

The downstream `mkdirAsync` creates the wrong path, the worktree gets registered there, but Claude SDK then can't locate expected files relative to the broken path and the run never advances past startup.

## Repro

1. Register a codebase whose `default_cwd` is *not* under `~/.archon/workspaces/` (e.g. an existing local clone at `~/Projects/myrepo`).
2. Run `archon workflow run <workflow> "..."` from that directory.
3. Inspect the resulting run: `working_path` will contain the literal parent dir (e.g. `Projects/myrepo`) where `<owner>/myrepo` should be. `current_step_index` stays `null`, `last_activity_at` doesn't advance.

After this fix the worktree path correctly resolves to `~/.archon/workspaces/<owner>/<repo>/worktrees/...` and the workflow proceeds normally.

## Verification

- `bun --filter @archon/cli type-check` — ✅
- `bun --filter @archon/cli test` — ✅ (all 131 tests pass)
- `bun x eslint packages/cli/src/commands/workflow.ts` — ✅ clean
- `bun x prettier --check packages/cli/src/commands/workflow.ts` — ✅ formatted
- End-to-end repro: built `dist/binaries/archon-darwin-arm64` from this branch, dispatched a workflow from a local repo at `~/Projects/<repo>`. Worktree path now `~/.archon/workspaces/<owner>/<repo>/worktrees/archon/task-...` (was `~/.archon/workspaces/Projects/<repo>/worktrees/...` before).

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `cli`
- Module: `cli:workflow`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced workflow execution metadata tracking by including additional codebase identification information when creating worktrees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->