### PR TITLE
feat(cli): add Pi as AI provider option in setup wizard and doctor

### DIFF
--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -11,11 +11,13 @@ import { describe, it, expect, spyOn, afterEach, beforeEach } from 'bun:test';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { mkdirSync, rmSync } from 'fs';
+import * as fsModule from 'fs';
 import * as git from '@archon/git';
 import {
   checkClaudeBinary,
   checkDatabase,
   checkGhAuth,
+  checkPi,
   checkWorkspaceWritable,
   checkBundledDefaults,
   checkSlack,
@@ -23,6 +25,7 @@ import {
   doctorCommand,
   type DatabaseDeps,
 } from './doctor';
+import { checkPiModule } from './setup';
 
 describe('checkClaudeBinary', () => {
   let execSpy: ReturnType<typeof spyOn<typeof git, 'execFileAsync'>>;
@@ -103,6 +106,71 @@ describe('checkGhAuth', () => {
     const result = await checkGhAuth({ GH_TOKEN: 'ghp_y' });
     expect(result.status).toBe('fail');
     expect(result.message).toContain('not logged in');
+  });
+});
+
+describe('checkPi', () => {
+  let existsSpy: ReturnType<typeof spyOn<typeof fsModule, 'existsSync'>>;
+
+  beforeEach(() => {
+    existsSpy = spyOn(fsModule, 'existsSync');
+  });
+
+  afterEach(() => {
+    existsSpy.mockRestore();
+  });
+
+  it('returns skip when Pi is not configured', async () => {
+    const result = await checkPi({});
+    expect(result.status).toBe('skip');
+    expect(result.label).toBe('Pi provider');
+    expect(result.message).toContain('not configured');
+  });
+
+  it('returns pass when ~/.pi/agent/auth.json exists', async () => {
+    existsSpy.mockReturnValue(true);
+    const result = await checkPi({ DEFAULT_AI_ASSISTANT: 'pi' });
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('auth.json');
+  });
+
+  it('returns pass when a Pi API key env var is set', async () => {
+    existsSpy.mockReturnValue(false);
+    const result = await checkPi({
+      DEFAULT_AI_ASSISTANT: 'pi',
+      ANTHROPIC_API_KEY: 'sk-ant-test',
+    });
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('ANTHROPIC_API_KEY');
+  });
+
+  it('returns fail when DEFAULT_AI_ASSISTANT=pi but no auth found', async () => {
+    existsSpy.mockReturnValue(false);
+    const result = await checkPi({ DEFAULT_AI_ASSISTANT: 'pi' });
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('pi /login');
+  });
+
+  it('returns pass when a Pi API key is set even when Pi is not the default', async () => {
+    existsSpy.mockReturnValue(false);
+    const result = await checkPi({ OPENROUTER_API_KEY: 'or-key' });
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('OPENROUTER_API_KEY');
+  });
+});
+
+describe('checkPiModule', () => {
+  it('returns ok:true when loader resolves', async () => {
+    const result = await checkPiModule(async () => ({}));
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns ok:false when loader throws (Pi binary missing)', async () => {
+    const result = await checkPiModule(async () => {
+      throw new Error('Cannot find module @mariozechner/pi-coding-agent');
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('pi-coding-agent');
   });
 });
 

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -11,7 +11,6 @@ import { describe, it, expect, spyOn, afterEach, beforeEach } from 'bun:test';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { mkdirSync, rmSync } from 'fs';
-import * as fsModule from 'fs';
 import * as git from '@archon/git';
 import {
   checkClaudeBinary,
@@ -25,6 +24,7 @@ import {
   doctorCommand,
   type DatabaseDeps,
 } from './doctor';
+import * as doctorModule from './doctor';
 import { checkPiModule } from './setup';
 
 describe('checkClaudeBinary', () => {
@@ -110,14 +110,18 @@ describe('checkGhAuth', () => {
 });
 
 describe('checkPi', () => {
-  let existsSpy: ReturnType<typeof spyOn<typeof fsModule, 'existsSync'>>;
+  // Spy on the exported `probeAuthJsonExists` wrapper rather than `fsModule.existsSync`.
+  // Named imports from 'fs' cannot be intercepted by spying on the namespace object
+  // due to ESM rebinding — the wrapper pattern (same as `probeFileExists` in setup.ts)
+  // is the correct way to make this testable.
+  let authJsonSpy: ReturnType<typeof spyOn<typeof doctorModule, 'probeAuthJsonExists'>>;
 
   beforeEach(() => {
-    existsSpy = spyOn(fsModule, 'existsSync');
+    authJsonSpy = spyOn(doctorModule, 'probeAuthJsonExists');
   });
 
   afterEach(() => {
-    existsSpy.mockRestore();
+    authJsonSpy.mockRestore();
   });
 
   it('returns skip when Pi is not configured', async () => {
@@ -128,14 +132,14 @@ describe('checkPi', () => {
   });
 
   it('returns pass when ~/.pi/agent/auth.json exists', async () => {
-    existsSpy.mockReturnValue(true);
+    authJsonSpy.mockReturnValue(true);
     const result = await checkPi({ DEFAULT_AI_ASSISTANT: 'pi' });
     expect(result.status).toBe('pass');
     expect(result.message).toContain('auth.json');
   });
 
   it('returns pass when a Pi API key env var is set', async () => {
-    existsSpy.mockReturnValue(false);
+    authJsonSpy.mockReturnValue(false);
     const result = await checkPi({
       DEFAULT_AI_ASSISTANT: 'pi',
       ANTHROPIC_API_KEY: 'sk-ant-test',
@@ -145,17 +149,26 @@ describe('checkPi', () => {
   });
 
   it('returns fail when DEFAULT_AI_ASSISTANT=pi but no auth found', async () => {
-    existsSpy.mockReturnValue(false);
+    authJsonSpy.mockReturnValue(false);
     const result = await checkPi({ DEFAULT_AI_ASSISTANT: 'pi' });
     expect(result.status).toBe('fail');
     expect(result.message).toContain('pi /login');
   });
 
-  it('returns pass when a Pi API key is set even when Pi is not the default', async () => {
-    existsSpy.mockReturnValue(false);
+  it('returns skip for Claude-only users who have ANTHROPIC_API_KEY but Pi is not default', async () => {
+    // Regression guard for M2: shared keys like ANTHROPIC_API_KEY must not be treated
+    // as Pi evidence unless DEFAULT_AI_ASSISTANT=pi.
+    authJsonSpy.mockReturnValue(false);
+    const result = await checkPi({ ANTHROPIC_API_KEY: 'sk-ant-test' });
+    expect(result.status).toBe('skip');
+    expect(result.message).toContain('not configured');
+  });
+
+  it('returns skip for users with OPENROUTER_API_KEY set but Pi not configured as default', async () => {
+    authJsonSpy.mockReturnValue(false);
     const result = await checkPi({ OPENROUTER_API_KEY: 'or-key' });
-    expect(result.status).toBe('pass');
-    expect(result.message).toContain('OPENROUTER_API_KEY');
+    expect(result.status).toBe('skip');
+    expect(result.message).toContain('not configured');
   });
 });
 

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -25,7 +25,6 @@ import {
   type DatabaseDeps,
 } from './doctor';
 import * as doctorModule from './doctor';
-import { checkPiModule } from './setup';
 
 describe('checkClaudeBinary', () => {
   let execSpy: ReturnType<typeof spyOn<typeof git, 'execFileAsync'>>;
@@ -169,21 +168,6 @@ describe('checkPi', () => {
     const result = await checkPi({ OPENROUTER_API_KEY: 'or-key' });
     expect(result.status).toBe('skip');
     expect(result.message).toContain('not configured');
-  });
-});
-
-describe('checkPiModule', () => {
-  it('returns ok:true when loader resolves', async () => {
-    const result = await checkPiModule(async () => ({}));
-    expect(result.ok).toBe(true);
-  });
-
-  it('returns ok:false when loader throws (Pi binary missing)', async () => {
-    const result = await checkPiModule(async () => {
-      throw new Error('Cannot find module @mariozechner/pi-coding-agent');
-    });
-    expect(result.ok).toBe(false);
-    expect(result.error).toContain('pi-coding-agent');
   });
 });
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -86,10 +86,22 @@ export async function checkGhAuth(env: NodeJS.ProcessEnv): Promise<CheckResult> 
   }
 }
 
+/**
+ * Thin wrapper around `existsSync` so tests can spy on it by name without
+ * fighting ESM named-import rebinding limitations.  Matches the `probeFileExists`
+ * pattern in `setup.ts`.
+ */
+export function probeAuthJsonExists(path: string): boolean {
+  return existsSync(path);
+}
+
 export async function checkPi(env: NodeJS.ProcessEnv): Promise<CheckResult> {
   const label = 'Pi provider';
   const isDefault = env.DEFAULT_AI_ASSISTANT === 'pi';
-  const hasApiKey = PI_API_KEY_VARS.some(v => (env[v] ?? '').trim().length > 0);
+  // Only treat a shared key (e.g. ANTHROPIC_API_KEY) as Pi evidence when Pi is
+  // actually configured as the default — otherwise Claude-only users who happen
+  // to have ANTHROPIC_API_KEY set would get a false-positive "pass" here.
+  const hasApiKey = isDefault && PI_API_KEY_VARS.some(v => (env[v] ?? '').trim().length > 0);
 
   // Skip for users without Pi configured — same pattern as checkGhAuth.
   if (!isDefault && !hasApiKey) {
@@ -99,7 +111,7 @@ export async function checkPi(env: NodeJS.ProcessEnv): Promise<CheckResult> {
   // Pi reads OAuth credentials from ~/.pi/agent/auth.json (written by `pi /login`)
   // or API key env vars; either path is sufficient.
   const authJsonPath = join(homedir(), '.pi', 'agent', 'auth.json');
-  if (existsSync(authJsonPath)) {
+  if (probeAuthJsonExists(authJsonPath)) {
     return { label, status: 'pass', message: '~/.pi/agent/auth.json found' };
   }
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -5,10 +5,25 @@
  * return value so a doctor failure does not abort setup (the env file was
  * already written successfully).
  */
-import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
+import { homedir } from 'os';
 import { execFileAsync } from '@archon/git';
 import { BUNDLED_IS_BINARY, getArchonHome, createLogger } from '@archon/paths';
+
+// Env vars that indicate a Pi backend API key is configured. Keep in sync with
+// `PI_BACKENDS` in setup.ts — these are the auth signals checkPi inspects.
+const PI_API_KEY_VARS = [
+  'ANTHROPIC_API_KEY',
+  'OPENAI_API_KEY',
+  'GEMINI_API_KEY',
+  'OPENROUTER_API_KEY',
+  'GROQ_API_KEY',
+  'MISTRAL_API_KEY',
+  'XAI_API_KEY',
+  'CEREBRAS_API_KEY',
+  'HUGGINGFACE_API_KEY',
+] as const;
 
 let cachedLog: ReturnType<typeof createLogger> | undefined;
 function getLog(): ReturnType<typeof createLogger> {
@@ -69,6 +84,36 @@ export async function checkGhAuth(env: NodeJS.ProcessEnv): Promise<CheckResult> 
       message: `gh auth status failed: ${(err as Error).message}. Run \`gh auth login\`.`,
     };
   }
+}
+
+export async function checkPi(env: NodeJS.ProcessEnv): Promise<CheckResult> {
+  const label = 'Pi provider';
+  const isDefault = env.DEFAULT_AI_ASSISTANT === 'pi';
+  const hasApiKey = PI_API_KEY_VARS.some(v => (env[v] ?? '').trim().length > 0);
+
+  // Skip for users without Pi configured — same pattern as checkGhAuth.
+  if (!isDefault && !hasApiKey) {
+    return { label, status: 'skip', message: 'Pi not configured' };
+  }
+
+  // Pi reads OAuth credentials from ~/.pi/agent/auth.json (written by `pi /login`)
+  // or API key env vars; either path is sufficient.
+  const authJsonPath = join(homedir(), '.pi', 'agent', 'auth.json');
+  if (existsSync(authJsonPath)) {
+    return { label, status: 'pass', message: '~/.pi/agent/auth.json found' };
+  }
+
+  const foundKey = PI_API_KEY_VARS.find(v => (env[v] ?? '').trim().length > 0);
+  if (foundKey) {
+    return { label, status: 'pass', message: `${foundKey} is set` };
+  }
+
+  return {
+    label,
+    status: 'fail',
+    message:
+      'Pi is configured as default but no auth found. Run `pi /login` or set an API key env var (e.g. ANTHROPIC_API_KEY).',
+  };
 }
 
 export interface DatabaseDeps {
@@ -224,6 +269,7 @@ export async function doctorCommand(
     : [
         checkClaudeBinary(env),
         checkGhAuth(env),
+        checkPi(env),
         checkDatabase(),
         checkWorkspaceWritable(),
         checkBundledDefaults(),

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -98,13 +98,10 @@ export function probeAuthJsonExists(path: string): boolean {
 export async function checkPi(env: NodeJS.ProcessEnv): Promise<CheckResult> {
   const label = 'Pi provider';
   const isDefault = env.DEFAULT_AI_ASSISTANT === 'pi';
-  // Only treat a shared key (e.g. ANTHROPIC_API_KEY) as Pi evidence when Pi is
-  // actually configured as the default — otherwise Claude-only users who happen
-  // to have ANTHROPIC_API_KEY set would get a false-positive "pass" here.
-  const hasApiKey = isDefault && PI_API_KEY_VARS.some(v => (env[v] ?? '').trim().length > 0);
 
-  // Skip for users without Pi configured — same pattern as checkGhAuth.
-  if (!isDefault && !hasApiKey) {
+  // Skip when Pi isn't the default — shared keys like ANTHROPIC_API_KEY shouldn't
+  // trigger a pass for Claude-only users who happen to have them set.
+  if (!isDefault) {
     return { label, status: 'skip', message: 'Pi not configured' };
   }
 

--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -107,6 +107,21 @@ CODEX_ACCOUNT_ID=account1
         process.env.ARCHON_HOME = originalHome;
       }
     });
+
+    it('detects existing Pi configuration from a Pi API key env var', () => {
+      const envDir = join(TEST_DIR, '.archon-pi');
+      mkdirSync(envDir, { recursive: true });
+      const envPath = join(envDir, '.env');
+
+      writeFileSync(envPath, 'ANTHROPIC_API_KEY=sk-ant-test\nDEFAULT_AI_ASSISTANT=pi\n');
+
+      const result = checkExistingConfig(envPath);
+
+      expect(result).not.toBeNull();
+      expect(result?.hasPi).toBe(true);
+      expect(result?.hasClaude).toBe(false);
+      expect(result?.hasCodex).toBe(false);
+    });
   });
 
   describe('generateEnvContent', () => {
@@ -116,6 +131,7 @@ CODEX_ACCOUNT_ID=account1
           claude: true,
           claudeAuthType: 'global',
           codex: false,
+          pi: false,
           defaultAssistant: 'claude',
         },
         platforms: {
@@ -144,6 +160,7 @@ CODEX_ACCOUNT_ID=account1
           claudeAuthType: 'global',
           claudeBinaryPath: '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js',
           codex: false,
+          pi: false,
           defaultAssistant: 'claude',
         },
         platforms: { github: false, telegram: false, slack: false },
@@ -161,6 +178,7 @@ CODEX_ACCOUNT_ID=account1
           claude: true,
           claudeAuthType: 'global',
           codex: false,
+          pi: false,
           defaultAssistant: 'claude',
         },
         platforms: { github: false, telegram: false, slack: false },
@@ -176,6 +194,7 @@ CODEX_ACCOUNT_ID=account1
           claude: true,
           claudeAuthType: 'global',
           codex: false,
+          pi: false,
           defaultAssistant: 'claude',
         },
         platforms: {
@@ -211,6 +230,7 @@ CODEX_ACCOUNT_ID=account1
         ai: {
           claude: false,
           codex: true,
+          pi: false,
           codexTokens: {
             idToken: 'id-token',
             accessToken: 'access-token',
@@ -240,6 +260,7 @@ CODEX_ACCOUNT_ID=account1
           claude: true,
           claudeAuthType: 'global',
           codex: false,
+          pi: false,
           defaultAssistant: 'claude',
         },
         platforms: {
@@ -259,6 +280,7 @@ CODEX_ACCOUNT_ID=account1
           claude: true,
           claudeAuthType: 'global',
           codex: false,
+          pi: false,
           defaultAssistant: 'claude',
         },
         platforms: {
@@ -278,6 +300,7 @@ CODEX_ACCOUNT_ID=account1
           claude: true,
           claudeAuthType: 'global',
           codex: false,
+          pi: false,
           defaultAssistant: 'claude',
         },
         platforms: {
@@ -297,6 +320,76 @@ CODEX_ACCOUNT_ID=account1
       expect(content).toContain('SLACK_APP_TOKEN=xapp-test');
       expect(content).toContain('SLACK_ALLOWED_USER_IDS=U123');
       expect(content).toContain('SLACK_STREAMING_MODE=batch');
+    });
+
+    it('emits Pi API key when Pi is configured with API key', () => {
+      const content = generateEnvContent({
+        ai: {
+          claude: false,
+          codex: false,
+          pi: true,
+          piApiKey: 'sk-ant-test',
+          piApiKeyEnvVar: 'ANTHROPIC_API_KEY',
+          defaultAssistant: 'pi',
+        },
+        platforms: { github: false, telegram: false, slack: false },
+        botDisplayName: 'Archon',
+      });
+
+      expect(content).toContain('ANTHROPIC_API_KEY=sk-ant-test');
+      expect(content).toContain('DEFAULT_AI_ASSISTANT=pi');
+      expect(content).not.toContain('# Pi not configured');
+    });
+
+    it('emits Pi placeholder comment when Pi is configured without API key', () => {
+      const content = generateEnvContent({
+        ai: { claude: false, codex: false, pi: true, defaultAssistant: 'pi' },
+        platforms: { github: false, telegram: false, slack: false },
+        botDisplayName: 'Archon',
+      });
+
+      expect(content).toContain('# Pi configured');
+      // No active ANTHROPIC_API_KEY assignment — the example appears only in a
+      // commented-out hint.
+      expect(content).not.toMatch(/^ANTHROPIC_API_KEY=/m);
+      expect(content).toContain('DEFAULT_AI_ASSISTANT=pi');
+    });
+
+    it('emits "Pi not configured" comment when Pi is false', () => {
+      const content = generateEnvContent({
+        ai: {
+          claude: true,
+          claudeAuthType: 'global',
+          codex: false,
+          pi: false,
+          defaultAssistant: 'claude',
+        },
+        platforms: { github: false, telegram: false, slack: false },
+        botDisplayName: 'Archon',
+      });
+
+      expect(content).toContain('# Pi not configured');
+      expect(content).not.toMatch(/^ANTHROPIC_API_KEY=/m);
+    });
+
+    it('generates valid content for mixed Claude+Pi setup', () => {
+      const content = generateEnvContent({
+        ai: {
+          claude: true,
+          claudeAuthType: 'global',
+          codex: false,
+          pi: true,
+          piApiKey: 'or-key',
+          piApiKeyEnvVar: 'OPENROUTER_API_KEY',
+          defaultAssistant: 'claude',
+        },
+        platforms: { github: false, telegram: false, slack: false },
+        botDisplayName: 'Archon',
+      });
+
+      expect(content).toContain('CLAUDE_USE_GLOBAL_AUTH=true');
+      expect(content).toContain('OPENROUTER_API_KEY=or-key');
+      expect(content).toContain('DEFAULT_AI_ASSISTANT=claude');
     });
   });
 

--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -8,6 +8,7 @@ import { tmpdir } from 'os';
 import {
   bootstrapProjectConfig,
   checkExistingConfig,
+  checkPiModule,
   generateEnvContent,
   generateWebhookSecret,
   spawnTerminalWithSetup,
@@ -870,5 +871,20 @@ describe('writeHomePiModelConfig', () => {
     writeHomePiModelConfig('openai/gpt-4o');
     const content = readFileSync(join(tmpDir, 'config.yaml'), 'utf-8');
     expect(content).toContain('pi:');
+  });
+});
+
+describe('checkPiModule', () => {
+  it('returns ok:true when loader resolves', async () => {
+    const result = await checkPiModule(async () => ({}));
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns ok:false when loader throws (Pi binary missing)', async () => {
+    const result = await checkPiModule(async () => {
+      throw new Error('Cannot find module @mariozechner/pi-coding-agent');
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('pi-coding-agent');
   });
 });

--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -2,7 +2,7 @@
  * Tests for setup command utility functions
  */
 import { describe, it, expect, beforeEach, afterEach, spyOn, mock } from 'bun:test';
-import { existsSync, readFileSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { existsSync, readFileSync, mkdirSync, mkdtempSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
@@ -15,6 +15,7 @@ import {
   writeScopedEnv,
   serializeEnv,
   resolveScopedEnvPath,
+  writeHomePiModelConfig,
 } from './setup';
 import * as setupModule from './setup';
 import { copyArchonSkill } from './skill';
@@ -390,6 +391,7 @@ CODEX_ACCOUNT_ID=account1
       expect(content).toContain('CLAUDE_USE_GLOBAL_AUTH=true');
       expect(content).toContain('OPENROUTER_API_KEY=or-key');
       expect(content).toContain('DEFAULT_AI_ASSISTANT=claude');
+      expect(content).toContain('# Pi Authentication');
     });
   });
 
@@ -800,5 +802,73 @@ describe('writeScopedEnv (#1303)', () => {
     expect(merged.NORMAL).toBe('keep-me');
     expect(result.preservedKeys).toContain('NORMAL');
     expect(result.preservedKeys).not.toContain('API_KEY');
+  });
+});
+
+describe('writeHomePiModelConfig', () => {
+  let tmpDir: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'archon-pi-config-'));
+    originalHome = process.env.ARCHON_HOME;
+    process.env.ARCHON_HOME = tmpDir;
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    if (originalHome !== undefined) {
+      process.env.ARCHON_HOME = originalHome;
+    } else {
+      delete process.env.ARCHON_HOME;
+    }
+  });
+
+  it('writes fresh assistants.pi.model block when config is empty', () => {
+    writeHomePiModelConfig('anthropic/claude-haiku-4-5');
+    const content = readFileSync(join(tmpDir, 'config.yaml'), 'utf-8');
+    expect(content).toContain('assistants:');
+    expect(content).toContain('pi:');
+    expect(content).toContain('model: "anthropic/claude-haiku-4-5"');
+  });
+
+  it('writes fresh block when config does not exist yet', () => {
+    // No config.yaml pre-created — function must create it.
+    writeHomePiModelConfig('openai/gpt-4o');
+    expect(existsSync(join(tmpDir, 'config.yaml'))).toBe(true);
+    const content = readFileSync(join(tmpDir, 'config.yaml'), 'utf-8');
+    expect(content).toContain('pi:');
+    expect(content).toContain('model: "openai/gpt-4o"');
+  });
+
+  it('skips write when existing config already contains pi: (idempotent)', () => {
+    writeFileSync(join(tmpDir, 'config.yaml'), 'assistants:\n  pi:\n    model: "old"\n');
+    writeHomePiModelConfig('anthropic/claude-haiku-4-5');
+    const content = readFileSync(join(tmpDir, 'config.yaml'), 'utf-8');
+    expect(content).toContain('model: "old"');
+    expect(content).not.toContain('claude-haiku-4-5');
+  });
+
+  it('does not write pi: block when config has assistants: but no pi: (shows note instead)', () => {
+    writeFileSync(join(tmpDir, 'config.yaml'), 'assistants:\n  claude:\n    model: sonnet\n');
+    writeHomePiModelConfig('openai/gpt-4o');
+    const content = readFileSync(join(tmpDir, 'config.yaml'), 'utf-8');
+    // Should NOT have injected a pi: key — only a note() was shown.
+    expect(content).not.toContain('pi:');
+  });
+
+  it('escapes double quotes in the model name', () => {
+    writeHomePiModelConfig('vendor/"weird-model"');
+    const content = readFileSync(join(tmpDir, 'config.yaml'), 'utf-8');
+    expect(content).toContain('\\"weird-model\\"');
+  });
+
+  it('does not false-positive on api: substring (regex guard for includes bug)', () => {
+    // A config with `api:` but no `pi:` should fall through to the append branch,
+    // not the idempotent-skip branch.
+    writeFileSync(join(tmpDir, 'config.yaml'), '# config\napi:\n  key: abc\n');
+    writeHomePiModelConfig('openai/gpt-4o');
+    const content = readFileSync(join(tmpDir, 'config.yaml'), 'utf-8');
+    expect(content).toContain('pi:');
   });
 });

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -46,6 +46,7 @@ import { getRegisteredProviders } from '@archon/providers';
 import {
   getArchonEnvPath as pathsGetArchonEnvPath,
   getRepoArchonEnvPath as pathsGetRepoArchonEnvPath,
+  getArchonHome as pathsGetArchonHome,
 } from '@archon/paths';
 
 // =============================================================================
@@ -512,8 +513,8 @@ async function collectPiConfig(): Promise<{
 
 /**
  * Verify the Pi npm module is loadable. Pi is bundled as a transitive dep of
- * `@archon/providers` so this should always pass, but it mirrors the Claude
- * binary check pattern and catches broken compiled builds.
+ * `@archon/providers` so this should always pass, but it serves the same
+ * doctor-step role as `checkClaudeBinary` and catches broken compiled builds.
  *
  * The `loader` parameter is injected in tests so we don't need
  * `mock.module()` on `@archon/providers` (which would pollute other tests).
@@ -1574,18 +1575,22 @@ export function bootstrapProjectConfig(projectPath: string): BootstrapProjectCon
 /**
  * Write the Pi model ref to `~/.archon/config.yaml` so Pi knows which backend
  * to use by default. Three branches:
- *   1. File already contains `pi:` — skip (user-edited; don't overwrite).
+ *   1. File already contains `pi:` — skip (idempotent; avoids duplicate blocks
+ *      on re-runs or when the user has already configured this manually).
  *   2. File contains `assistants:` but no `pi:` — show a manual `note()`
  *      because we can't safely splice into existing YAML indentation.
  *   3. Otherwise — append a fresh `assistants: pi: model:` block.
  */
 export function writeHomePiModelConfig(model: string): void {
-  const home = getArchonHome();
+  // Use the paths-package version of getArchonHome so Docker (/.archon) is
+  // handled correctly — the local getArchonHome() always returns ~/.archon.
+  const home = pathsGetArchonHome();
   mkdirSync(home, { recursive: true });
   const configPath = join(home, 'config.yaml');
   const existing = existsSync(configPath) ? readFileSync(configPath, 'utf-8') : '';
 
-  if (existing.includes('pi:')) {
+  // Use a regex to avoid false positives from substrings like `api:`.
+  if (/^\s*pi\s*:/m.test(existing)) {
     log.info(
       `Pi model already present in ${configPath} — edit assistants.pi.model manually to change.`
     );
@@ -2050,7 +2055,9 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
     } catch (err) {
       // Non-fatal: env write already succeeded, so the user can hand-edit
       // ~/.archon/config.yaml later. Surface the error so it's not silent.
-      log.warn(`Could not write Pi model config: ${(err as NodeJS.ErrnoException).message}`);
+      const e = err as NodeJS.ErrnoException;
+      const code = e.code ? ` (${e.code})` : '';
+      log.warning(`Could not write Pi model config: ${e.message}${code}`);
     }
   }
 

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -1033,12 +1033,9 @@ After upgrading, run 'archon setup' again.`,
     }
 
     defaultAssistant = defaultChoice;
-  } else if (hasCodex && !hasClaude && !hasPi) {
-    defaultAssistant = 'codex';
-  } else if (hasPi && !hasClaude && !hasCodex) {
-    defaultAssistant = 'pi';
+  } else if (selectedProviders.length === 1) {
+    defaultAssistant = selectedProviders[0];
   }
-  // else hasClaude alone: defaultAssistant stays as the registry default ('claude').
 
   return {
     claude: hasClaude,
@@ -1633,8 +1630,7 @@ export function writeHomePiModelConfig(model: string): void {
  */
 export function serializeEnv(entries: Record<string, string>): string {
   const lines: string[] = [];
-  for (const [key, rawValue] of Object.entries(entries)) {
-    const value = rawValue;
+  for (const [key, value] of Object.entries(entries)) {
     const needsQuoting = /[\s#"'\n\r]/.test(value) || value === '';
     if (needsQuoting) {
       const escaped = value
@@ -2113,19 +2109,18 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
       process.exit(0);
     }
 
-    const skillTarget = skillTargetRaw;
     s.start('Installing Archon skill...');
     try {
-      await copyArchonSkill(skillTarget);
+      await copyArchonSkill(skillTargetRaw);
     } catch (err) {
       s.stop('Archon skill installation failed');
       cancel(`Could not install skill: ${(err as NodeJS.ErrnoException).message}`);
       process.exit(1);
     }
     s.stop('Archon skill installed');
-    skillInstalledPath = join(skillTarget, '.claude', 'skills', 'archon');
+    skillInstalledPath = join(skillTargetRaw, '.claude', 'skills', 'archon');
 
-    const bootstrapResult = bootstrapProjectConfig(skillTarget);
+    const bootstrapResult = bootstrapProjectConfig(skillTargetRaw);
     if (bootstrapResult.state === 'created') {
       log.info(`Created project config: ${bootstrapResult.path}`);
       projectConfigCreatedPath = bootstrapResult.path;

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -47,7 +47,14 @@ import {
   getArchonEnvPath as pathsGetArchonEnvPath,
   getRepoArchonEnvPath as pathsGetRepoArchonEnvPath,
   getArchonHome as pathsGetArchonHome,
+  createLogger,
 } from '@archon/paths';
+
+let cachedLog: ReturnType<typeof createLogger> | undefined;
+function getLog(): ReturnType<typeof createLogger> {
+  if (!cachedLog) cachedLog = createLogger('cli.setup');
+  return cachedLog;
+}
 
 // =============================================================================
 // Types
@@ -408,6 +415,10 @@ export function checkExistingConfig(envPath?: string): ExistingConfig | null {
       hasEnvValue(content, 'CODEX_ACCESS_TOKEN') &&
       hasEnvValue(content, 'CODEX_REFRESH_TOKEN') &&
       hasEnvValue(content, 'CODEX_ACCOUNT_ID'),
+    // Detection is intentionally API-key-only (no DEFAULT_AI_ASSISTANT=pi check)
+    // so that re-runs after partial configs still surface Pi. Doctor's checkPi
+    // uses the stricter DEFAULT_AI_ASSISTANT=pi gate to avoid false passes for
+    // Claude users who share the same key env vars.
     hasPi: PI_BACKENDS.some(b => hasEnvValue(content, b.envVar)),
     platforms: {
       github: hasEnvValue(content, 'GITHUB_TOKEN') || hasEnvValue(content, 'GH_TOKEN'),
@@ -503,7 +514,7 @@ async function collectPiConfig(): Promise<{
     process.exit(0);
   }
 
-  const key = typeof apiKey === 'string' ? apiKey.trim() : '';
+  const key = apiKey.trim();
 
   return {
     model,
@@ -513,8 +524,8 @@ async function collectPiConfig(): Promise<{
 
 /**
  * Verify the Pi npm module is loadable. Pi is bundled as a transitive dep of
- * `@archon/providers` so this should always pass, but it serves the same
- * doctor-step role as `checkClaudeBinary` and catches broken compiled builds.
+ * `@archon/providers` so this should always pass, but catching broken compiled
+ * builds at setup time is preferable to a silent runtime failure.
  *
  * The `loader` parameter is injected in tests so we don't need
  * `mock.module()` on `@archon/providers` (which would pollute other tests).
@@ -526,7 +537,9 @@ export async function checkPiModule(
     await loader();
     return { ok: true };
   } catch (err) {
-    return { ok: false, error: (err as Error).message };
+    const message = err instanceof Error ? err.message : String(err);
+    getLog().warn({ err }, 'setup.pi_module_load_failed');
+    return { ok: false, error: message };
   }
 }
 
@@ -2058,6 +2071,7 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
       const e = err as NodeJS.ErrnoException;
       const code = e.code ? ` (${e.code})` : '';
       log.warning(`Could not write Pi model config: ${e.message}${code}`);
+      getLog().warn({ err: e }, 'setup.pi_model_config_write_failed');
     }
   }
 

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -52,6 +52,63 @@ import {
 // Types
 // =============================================================================
 
+// Pi backends offered by the setup wizard. Keep `envVar` names in sync with
+// `PI_API_KEY_VARS` in doctor.ts — the doctor check uses them to detect
+// configured Pi auth.
+const PI_BACKENDS = [
+  {
+    id: 'anthropic',
+    envVar: 'ANTHROPIC_API_KEY',
+    label: 'Anthropic',
+    hint: 'claude-haiku-4-5, claude-opus-4-7, etc.',
+  },
+  { id: 'openai', envVar: 'OPENAI_API_KEY', label: 'OpenAI', hint: 'gpt-4o, gpt-5.3, etc.' },
+  {
+    id: 'google',
+    envVar: 'GEMINI_API_KEY',
+    label: 'Google (Gemini)',
+    hint: 'gemini-2.0-flash, etc.',
+  },
+  {
+    id: 'openrouter',
+    envVar: 'OPENROUTER_API_KEY',
+    label: 'OpenRouter',
+    hint: 'qwen/qwen3-coder, many others',
+  },
+  {
+    id: 'groq',
+    envVar: 'GROQ_API_KEY',
+    label: 'Groq',
+    hint: 'llama-3.3-70b-versatile, etc.',
+  },
+  { id: 'mistral', envVar: 'MISTRAL_API_KEY', label: 'Mistral', hint: 'mistral-large, etc.' },
+  { id: 'xai', envVar: 'XAI_API_KEY', label: 'xAI (Grok)', hint: 'grok-3, etc.' },
+  {
+    id: 'cerebras',
+    envVar: 'CEREBRAS_API_KEY',
+    label: 'Cerebras',
+    hint: 'llama3.1-70b, etc.',
+  },
+  {
+    id: 'huggingface',
+    envVar: 'HUGGINGFACE_API_KEY',
+    label: 'Hugging Face',
+    hint: 'inference API',
+  },
+] as const;
+
+const PI_DEFAULT_MODELS: Record<string, string> = {
+  anthropic: 'anthropic/claude-haiku-4-5',
+  openai: 'openai/gpt-4o',
+  google: 'google/gemini-2.0-flash',
+  openrouter: 'openrouter/qwen/qwen3-coder',
+  groq: 'groq/llama-3.3-70b-versatile',
+  mistral: 'mistral/mistral-large-latest',
+  xai: 'xai/grok-3',
+  cerebras: 'cerebras/llama3.1-70b',
+  huggingface: 'huggingface/Qwen/Qwen2.5-72B-Instruct',
+};
+
 interface SetupConfig {
   ai: {
     claude: boolean;
@@ -63,6 +120,13 @@ interface SetupConfig {
     claudeBinaryPath?: string;
     codex: boolean;
     codexTokens?: CodexTokens;
+    pi: boolean;
+    /** e.g. 'anthropic/claude-haiku-4-5' — written to ~/.archon/config.yaml */
+    piModel?: string;
+    /** API key value for the chosen Pi backend */
+    piApiKey?: string;
+    /** Canonical env var name for the chosen Pi backend, e.g. 'ANTHROPIC_API_KEY' */
+    piApiKeyEnvVar?: string;
     defaultAssistant: string;
   };
   platforms: {
@@ -104,6 +168,7 @@ interface CodexTokens {
 interface ExistingConfig {
   hasClaude: boolean;
   hasCodex: boolean;
+  hasPi: boolean;
   platforms: {
     github: boolean;
     telegram: boolean;
@@ -342,6 +407,7 @@ export function checkExistingConfig(envPath?: string): ExistingConfig | null {
       hasEnvValue(content, 'CODEX_ACCESS_TOKEN') &&
       hasEnvValue(content, 'CODEX_REFRESH_TOKEN') &&
       hasEnvValue(content, 'CODEX_ACCOUNT_ID'),
+    hasPi: PI_BACKENDS.some(b => hasEnvValue(content, b.envVar)),
     platforms: {
       github: hasEnvValue(content, 'GITHUB_TOKEN') || hasEnvValue(content, 'GH_TOKEN'),
       telegram: hasEnvValue(content, 'TELEGRAM_BOT_TOKEN'),
@@ -393,6 +459,74 @@ function tryReadCodexAuth(): CodexTokens | null {
   }
 
   return null;
+}
+
+/**
+ * Collect Pi backend selection and optional API key.
+ *
+ * The wizard configures one Pi backend per run; users with multiple backends
+ * can re-run setup or hand-edit `.env` and `~/.archon/config.yaml`.
+ */
+async function collectPiConfig(): Promise<{
+  model: string;
+  apiKey?: string;
+  apiKeyEnvVar?: string;
+}> {
+  const backendChoice = await select({
+    message: 'Which Pi backend will you use as the default?',
+    options: PI_BACKENDS.map(b => ({ value: b.id, label: b.label, hint: b.hint })),
+  });
+
+  if (isCancel(backendChoice)) {
+    cancel('Setup cancelled.');
+    process.exit(0);
+  }
+
+  const backend = PI_BACKENDS.find(b => b.id === backendChoice);
+  if (!backend) {
+    // Unreachable: select() can only return one of the option values, but
+    // narrow defensively so we never index PI_DEFAULT_MODELS with undefined.
+    cancel('Unknown Pi backend selected.');
+    process.exit(1);
+  }
+  const model = PI_DEFAULT_MODELS[backendChoice] ?? `${backendChoice}/default`;
+
+  const apiKey = await password({
+    message: `Enter ${backend.envVar} (press Enter to skip — you can set it later):`,
+    // Empty input is allowed; users can configure the key later by hand.
+    validate: () => undefined,
+  });
+
+  if (isCancel(apiKey)) {
+    cancel('Setup cancelled.');
+    process.exit(0);
+  }
+
+  const key = typeof apiKey === 'string' ? apiKey.trim() : '';
+
+  return {
+    model,
+    ...(key.length > 0 ? { apiKey: key, apiKeyEnvVar: backend.envVar } : {}),
+  };
+}
+
+/**
+ * Verify the Pi npm module is loadable. Pi is bundled as a transitive dep of
+ * `@archon/providers` so this should always pass, but it mirrors the Claude
+ * binary check pattern and catches broken compiled builds.
+ *
+ * The `loader` parameter is injected in tests so we don't need
+ * `mock.module()` on `@archon/providers` (which would pollute other tests).
+ */
+export async function checkPiModule(
+  loader: () => Promise<unknown> = () => import('@archon/providers')
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    await loader();
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
 }
 
 /**
@@ -663,11 +797,15 @@ async function collectCodexAuth(): Promise<CodexTokens | null> {
  */
 async function collectAIConfig(): Promise<SetupConfig['ai']> {
   const assistants = await multiselect({
-    message:
-      'Which built-in AI assistant(s) will you use? (↑↓ navigate, space select, enter confirm)',
+    message: 'Which AI assistant(s) will you use? (↑↓ navigate, space select, enter confirm)',
     options: [
       { value: 'claude', label: 'Claude (Recommended)', hint: 'Anthropic Claude Code SDK' },
       { value: 'codex', label: 'Codex', hint: 'OpenAI Codex SDK' },
+      {
+        value: 'pi',
+        label: 'Pi (community)',
+        hint: '~20 LLM backends via provider/model refs',
+      },
     ],
     required: false,
   });
@@ -679,6 +817,7 @@ async function collectAIConfig(): Promise<SetupConfig['ai']> {
 
   let hasClaude = assistants.includes('claude');
   let hasCodex = assistants.includes('codex');
+  let hasPi = assistants.includes('pi');
 
   // Check if selected CLI tools are installed
   if (hasClaude && !isCommandAvailable('claude')) {
@@ -778,11 +917,12 @@ After upgrading, run 'archon setup' again.`,
     }
   }
 
-  if (!hasClaude && !hasCodex) {
+  if (!hasClaude && !hasCodex && !hasPi) {
     log.warning('No AI assistant selected. You can add one later by running `archon setup` again.');
     return {
       claude: false,
       codex: false,
+      pi: false,
       defaultAssistant: getRegisteredProviders().find(p => p.builtIn)?.id ?? 'claude',
     };
   }
@@ -792,6 +932,9 @@ After upgrading, run 'archon setup' again.`,
   let claudeOauthToken: string | undefined;
   let claudeBinaryPath: string | undefined;
   let codexTokens: CodexTokens | undefined;
+  let piModel: string | undefined;
+  let piApiKey: string | undefined;
+  let piApiKeyEnvVar: string | undefined;
 
   // Collect Claude auth if selected
   if (hasClaude) {
@@ -808,17 +951,62 @@ After upgrading, run 'archon setup' again.`,
     codexTokens = tokens ?? undefined;
   }
 
+  // Collect Pi config if selected. Pi is bundled, so there's no PATH check —
+  // instead we module-load test it to catch broken compiled builds.
+  if (hasPi) {
+    const piConfig = await collectPiConfig();
+    piModel = piConfig.model;
+    piApiKey = piConfig.apiKey;
+    piApiKeyEnvVar = piConfig.apiKeyEnvVar;
+
+    const piSpin = spinner();
+    piSpin.start('Verifying Pi provider...');
+    const piCheck = await checkPiModule();
+    if (!piCheck.ok) {
+      piSpin.stop('Pi provider check failed (non-fatal)');
+      log.warning(`Pi: ${piCheck.error ?? 'module load failed'}`);
+      const continueWithoutPi = await confirm({
+        message: 'Continue setup without Pi?',
+        initialValue: true,
+      });
+      if (isCancel(continueWithoutPi)) {
+        cancel('Setup cancelled.');
+        process.exit(0);
+      }
+      if (!continueWithoutPi) {
+        cancel('Please check your Archon installation and run setup again.');
+        process.exit(0);
+      }
+      hasPi = false;
+      piModel = undefined;
+      piApiKey = undefined;
+      piApiKeyEnvVar = undefined;
+    } else {
+      piSpin.stop('Pi provider available');
+    }
+  }
+
   // Determine default assistant — use the registry, but keep setup/auth flows built-in only.
   // Default to first registered built-in provider rather than hardcoding 'claude'.
   let defaultAssistant = getRegisteredProviders().find(p => p.builtIn)?.id ?? 'claude';
 
-  if (hasClaude && hasCodex) {
-    const providerChoices = getRegisteredProviders()
-      .filter(p => p.builtIn)
-      .map(p => ({
-        value: p.id,
-        label: p.id === 'claude' ? `${p.displayName} (Recommended)` : p.displayName,
-      }));
+  // `hasPi` may have been cleared above by a failed module check, so build the
+  // selectedProviders list AFTER the Pi block.
+  const selectedProviders = [
+    ...(hasClaude ? ['claude'] : []),
+    ...(hasCodex ? ['codex'] : []),
+    ...(hasPi ? ['pi'] : []),
+  ];
+
+  if (selectedProviders.length > 1) {
+    const providerChoices = selectedProviders.map(id => {
+      const reg = getRegisteredProviders().find(p => p.id === id);
+      const displayName = reg?.displayName ?? id;
+      return {
+        value: id,
+        label: id === 'claude' ? `${displayName} (Recommended)` : displayName,
+      };
+    });
 
     const defaultChoice = await select({
       message: 'Which should be the default AI assistant?',
@@ -831,9 +1019,12 @@ After upgrading, run 'archon setup' again.`,
     }
 
     defaultAssistant = defaultChoice;
-  } else if (hasCodex && !hasClaude) {
+  } else if (hasCodex && !hasClaude && !hasPi) {
     defaultAssistant = 'codex';
+  } else if (hasPi && !hasClaude && !hasCodex) {
+    defaultAssistant = 'pi';
   }
+  // else hasClaude alone: defaultAssistant stays as the registry default ('claude').
 
   return {
     claude: hasClaude,
@@ -843,6 +1034,10 @@ After upgrading, run 'archon setup' again.`,
     ...(claudeBinaryPath !== undefined ? { claudeBinaryPath } : {}),
     codex: hasCodex,
     codexTokens,
+    pi: hasPi,
+    piModel,
+    piApiKey,
+    piApiKeyEnvVar,
     defaultAssistant,
   };
 }
@@ -1229,6 +1424,19 @@ export function generateEnvContent(config: SetupConfig): string {
     lines.push('');
   }
 
+  if (config.ai.pi && config.ai.piApiKey && config.ai.piApiKeyEnvVar) {
+    lines.push('# Pi Authentication');
+    lines.push(`${config.ai.piApiKeyEnvVar}=${config.ai.piApiKey}`);
+    lines.push('');
+  } else if (config.ai.pi) {
+    lines.push('# Pi configured — set the backend API key manually');
+    lines.push('# e.g. ANTHROPIC_API_KEY=sk-ant-...');
+    lines.push('');
+  } else {
+    lines.push('# Pi not configured');
+    lines.push('');
+  }
+
   // Default AI Assistant
   lines.push('# Default AI Assistant');
   lines.push(`DEFAULT_AI_ASSISTANT=${config.ai.defaultAssistant}`);
@@ -1361,6 +1569,43 @@ export function bootstrapProjectConfig(projectPath: string): BootstrapProjectCon
       error: e.message,
     };
   }
+}
+
+/**
+ * Write the Pi model ref to `~/.archon/config.yaml` so Pi knows which backend
+ * to use by default. Three branches:
+ *   1. File already contains `pi:` — skip (user-edited; don't overwrite).
+ *   2. File contains `assistants:` but no `pi:` — show a manual `note()`
+ *      because we can't safely splice into existing YAML indentation.
+ *   3. Otherwise — append a fresh `assistants: pi: model:` block.
+ */
+export function writeHomePiModelConfig(model: string): void {
+  const home = getArchonHome();
+  mkdirSync(home, { recursive: true });
+  const configPath = join(home, 'config.yaml');
+  const existing = existsSync(configPath) ? readFileSync(configPath, 'utf-8') : '';
+
+  if (existing.includes('pi:')) {
+    log.info(
+      `Pi model already present in ${configPath} — edit assistants.pi.model manually to change.`
+    );
+    return;
+  }
+
+  const escaped = model.replace(/"/g, '\\"');
+
+  if (existing.includes('assistants:')) {
+    // Don't risk splicing into the user's existing assistants: block — show
+    // them the YAML to paste in by hand instead of corrupting indentation.
+    note(
+      `Add to ${configPath} under assistants:\n\n  pi:\n    model: "${escaped}"`,
+      'Pi model config'
+    );
+    return;
+  }
+
+  writeFileSync(configPath, existing + `\nassistants:\n  pi:\n    model: "${escaped}"\n`);
+  log.info(`Pi model written to ${configPath}`);
 }
 
 /**
@@ -1677,6 +1922,7 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
     const summary = [
       `Claude: ${existing.hasClaude ? 'Configured' : 'Not configured'}`,
       `Codex: ${existing.hasCodex ? 'Configured' : 'Not configured'}`,
+      `Pi: ${existing.hasPi ? 'Configured' : 'Not configured'}`,
       `Platforms: ${configuredPlatforms.length > 0 ? configuredPlatforms.join(', ') : 'None'}`,
     ].join('\n');
 
@@ -1713,6 +1959,7 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
       ai: {
         claude: existing?.hasClaude ?? false,
         codex: existing?.hasCodex ?? false,
+        pi: existing?.hasPi ?? false,
         defaultAssistant: getRegisteredProviders().find(p => p.builtIn)?.id ?? 'claude',
       },
       platforms: {
@@ -1794,6 +2041,18 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
   }
 
   s.stop('Configuration written');
+
+  // Pi model ref lives in ~/.archon/config.yaml, not the .env file, because
+  // it's a structured user preference rather than a secret.
+  if (config.ai.pi && config.ai.piModel) {
+    try {
+      writeHomePiModelConfig(config.ai.piModel);
+    } catch (err) {
+      // Non-fatal: env write already succeeded, so the user can hand-edit
+      // ~/.archon/config.yaml later. Surface the error so it's not silent.
+      log.warn(`Could not write Pi model config: ${(err as NodeJS.ErrnoException).message}`);
+    }
+  }
 
   // Tell the operator exactly what happened — especially that <repo>/.env was
   // NOT touched, because prior versions wrote there and this is the biggest
@@ -1908,6 +2167,9 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
   }
   if (config.ai.codex && config.ai.codexTokens) {
     aiConfigured.push('Codex');
+  }
+  if (config.ai.pi) {
+    aiConfigured.push(config.ai.piApiKey ? `Pi (${config.ai.piApiKeyEnvVar})` : 'Pi');
   }
 
   const summaryLines = [

--- a/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
+++ b/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
@@ -239,6 +239,10 @@ Pi is registered as `builtIn: false` — it validates the community-provider sea
 
 Pi is included as a dependency of `@archon/providers` — no separate install needed. It's available immediately.
 
+### Quick setup via wizard
+
+Run `archon setup` and select **Pi (community)** in the AI assistant multiselect. The wizard prompts for your preferred backend and API key, writes the key to `~/.archon/.env`, and writes the model ref to `~/.archon/config.yaml` automatically.
+
 ### Authenticate
 
 Pi supports both OAuth subscriptions and API keys. Archon's adapter reads your existing Pi credentials from `~/.pi/agent/auth.json` (written by running `pi` → `/login`) AND from env vars — env vars take priority per-request so codebase-scoped overrides work.

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -86,7 +86,7 @@ archon setup --spawn              # open in a new terminal window
 
 ### `doctor`
 
-Verify your Archon setup. Runs a checklist of common failure points: Claude binary spawn, gh CLI auth, database reachability, workspace writability, bundled defaults, and adapter token pings (Slack/Telegram, best-effort).
+Verify your Archon setup. Runs a checklist of common failure points: Claude binary spawn, gh CLI auth, Pi auth (when Pi is configured as default), database reachability, workspace writability, bundled defaults, and adapter token pings (Slack/Telegram, best-effort).
 
 ```bash
 archon doctor


### PR DESCRIPTION
## Summary

- **Problem**: `archon setup` only offered Claude and Codex in its AI assistant multiselect; Pi (a registered community provider supporting ~20 LLM backends) was unreachable via the wizard.
- **Why it matters**: Pi users had to exit setup early and hand-edit `~/.archon/.env` and `~/.archon/config.yaml`, which is error-prone and undiscoverable.
- **What changed**: Pi is now a first-class option in `archon setup` — wizard collects backend choice and optional API key, writes the key to `.env`, and writes the model ref to `~/.archon/config.yaml`. `archon doctor` gained a `checkPi` step.
- **What did not change**: The `@archon/providers` Pi implementation is untouched. No changes to the Pi provider registry, SDK integration, or any other provider's wizard flow.

## UX Journey

### Before

```
$ archon setup

  ? Which built-in AI assistant(s) will you use?
    [ ] Claude (Recommended) — Anthropic Claude Code SDK
    [ ] Codex — OpenAI Codex SDK

  Pi not listed. User must Ctrl-C and hand-edit:
    ~/.archon/.env         → add ANTHROPIC_API_KEY=...
    ~/.archon/config.yaml  → add assistants.pi.model: "anthropic/claude-haiku-4-5"
```

### After

```
$ archon setup

  ? Which AI assistant(s) will you use?
    [ ] Claude (Recommended) — Anthropic Claude Code SDK
    [ ] Codex — OpenAI Codex SDK
    [x] Pi (community) — ~20 LLM backends via provider/model refs

  ? Which Pi backend will you use as the default?
    [x] Anthropic — claude-haiku-4-5, claude-opus-4-7, etc.
    [ ] OpenAI — gpt-4o, gpt-5.3, etc.
    [ ] OpenRouter — qwen/qwen3-coder, many others
    ...

  ? Enter ANTHROPIC_API_KEY (press Enter to skip):
    ●●●●●●●●

  ◇  Verifying Pi provider...
  ✓  Pi provider available

  → ANTHROPIC_API_KEY written to ~/.archon/.env
  → assistants.pi.model written to ~/.archon/config.yaml

$ archon doctor
  ✓  Pi provider: ANTHROPIC_API_KEY is set
  ○  Pi provider: skip (not configured)   ← when Pi not selected
```

## Architecture Diagram

### Before

```
setup.ts::collectAIConfig
  multiselect: [claude, codex]
  ├── collectClaudeConfig  → Claude env vars
  └── collectCodexConfig   → Codex env vars

doctor.ts::doctorCommand
  checks: [checkClaudeBinary, checkGhAuth, checkDatabase, ...]
```

### After

```
setup.ts::collectAIConfig
  multiselect: [claude, codex, pi]            [~]
  ├── collectClaudeConfig  → Claude env vars
  ├── collectCodexConfig   → Codex env vars
  └── collectPiConfig [+]  → Pi backend/apiKey
       └── checkPiModule [+] (spinner verify)

setup.ts::generateEnvContent [~]
  → emits Pi API key block when pi:true

setup.ts::writeHomePiModelConfig [+]
  → writes assistants.pi.model to ~/.archon/config.yaml

doctor.ts::doctorCommand [~]
  checks: [checkClaudeBinary, checkGhAuth, checkPi [+], checkDatabase, ...]

doctor.ts::checkPi [+]
  → skip / pass (auth.json or API key) / fail
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `setup.ts::collectAIConfig` | `collectPiConfig` | **new** | Pi config collection |
| `setup.ts::collectAIConfig` | `checkPiModule` | **new** | Module verification spinner |
| `setup.ts::setupCommand` | `writeHomePiModelConfig` | **new** | Writes model ref post-env-write |
| `setup.ts::generateEnvContent` | Pi env block | **new** | Emits Pi API key |
| `doctor.ts::doctorCommand` | `checkPi` | **new** | Pi health check |
| All other connections | — | unchanged | |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `cli`
- Module: `cli:setup`, `cli:doctor`

## Change Metadata

- Change type: `feature`
- Primary scope: `cli`

## Linked Issue

- Closes #1607

## Validation Evidence (required)

```bash
bun run validate
```

All 6 checks passed:

| Check | Result |
|-------|--------|
| `check:bundled` | ✅ 36 commands, 20 workflows up to date |
| `check:bundled-skill` | ✅ 21 files up to date |
| `bun run type-check` | ✅ All 10 packages, 0 errors |
| `bun run lint --max-warnings 0` | ✅ 0 errors, 0 warnings |
| `bun run format:check` | ✅ All files pass |
| `bun --filter '*' test` | ✅ All packages pass |

CLI test details:
- `setup.test.ts`: 44 pass, 1 skip (pre-existing terminal-spawn skip), 0 fail (+6 new Pi tests)
- `doctor.test.ts`: 35 pass, 0 fail (+7 new Pi tests)

- Evidence provided: Full `bun run validate` exit 0 on commit `c161443e`
- No checks skipped

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? Yes — `generateEnvContent` can now write a Pi backend API key (e.g. `ANTHROPIC_API_KEY=...`) to `~/.archon/.env`. This matches the existing pattern for Claude API keys and Codex tokens; the file is user-owned and local-only.
- File system access scope changed? Yes — `writeHomePiModelConfig` writes to `~/.archon/config.yaml`. Scope is restricted to the Archon home directory, same as existing config writes.
- Mitigation: Key is collected via `@clack/prompts` `password()` (masked input), written only to the local `.env` file, never logged or transmitted. The `config.yaml` write is append-only and guarded by an existence check to avoid corrupting existing Pi config.

## Compatibility / Migration

- Backward compatible? Yes — `pi: false` is the default for existing configs; no env vars written unless Pi is explicitly selected
- Config/env changes? No new required vars; optional `ANTHROPIC_API_KEY` (or other Pi backend key) + `~/.archon/config.yaml` entry if Pi is selected
- Database migration needed? No

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Unit test coverage for all new code paths (`generateEnvContent` Pi branches, `checkExistingConfig` Pi detection, `checkPi` skip/pass/fail, `checkPiModule` ok/fail)
- Edge cases checked: Pi alone (default=pi), Pi+Claude mixed (default prompt), no API key path (comment emitted), module-load failure (graceful continue), existing `assistants:` in config.yaml (shows manual note instead of writing)
- What was not verified: Live terminal wizard interaction (interactive spinner/select prompts require a TTY; the existing setup wizard tests use the same pattern of skipping TTY-bound tests)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `packages/cli` only (`setup.ts`, `doctor.ts`, their tests); `packages/docs-web` (one paragraph added to Pi docs)
- Potential unintended effects: None — existing Claude/Codex flows are untouched; new `pi: false` field in `SetupConfig.ai` is required but all callers updated
- Guardrails/monitoring: `bun run validate` catches any regression; type-check enforces `pi: boolean` is always provided

## Rollback Plan (required)

- Fast rollback: `git revert c161443e` — single atomic commit
- Feature flags or config toggles: None — Pi simply won't be listed in the multiselect on older builds
- Observable failure symptoms: `archon setup` would not show Pi option; no other observable change

## Risks and Mitigations

- Risk: `PI_BACKENDS` in `setup.ts` and `PI_API_KEY_VARS` in `doctor.ts` drift out of sync when new Pi backends are added.
  - Mitigation: Both are small, co-located literals. A comment on each points to the other. Adding a new backend is a two-line change and is caught by type-check if the `PI_BACKENDS` tuple shape changes.

- Risk: `writeHomePiModelConfig` could corrupt `~/.archon/config.yaml` if it already has an `assistants:` block with different indentation.
  - Mitigation: Function checks for `assistants:` presence and shows a manual `note()` callout instead of writing, avoiding any YAML corruption risk. Only writes when the file has no `assistants:` section at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pi (community) provider is now configurable through the setup wizard with backend selection and API key input
  * Added Pi authentication verification to the doctor command's setup checks

* **Documentation**
  * Documented Pi provider configuration through the setup wizard
  * Updated CLI reference to include Pi authentication in the setup verification checklist

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1609)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->