### PR TITLE
feat(api): per-request runtime override on POST /api/workflows/:name/run

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ export {
   ConversationNotFoundError,
   type Conversation,
   type HandleMessageContext,
+  type RuntimeOverride,
   type AttachedFile,
   type Codebase,
   type Session,

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -221,8 +221,31 @@ async function dispatchOrchestratorWorkflow(
   codebase: Codebase,
   workflow: WorkflowDefinition,
   userMessage: string,
-  isolationHints?: HandleMessageContext['isolationHints']
+  isolationHints?: HandleMessageContext['isolationHints'],
+  runtimeOverride?: HandleMessageContext['runtimeOverride']
 ): Promise<void> {
+  // Apply per-request runtime override (from POST /api/workflows/:name/run).
+  // Mutates the in-memory workflow object — safe because the workflow is
+  // freshly loaded per-run and discarded after dispatch (does not persist
+  // back to the YAML on disk). When set, takes precedence over
+  // workflow.provider / workflow.model in executor.ts resolution.
+  if (runtimeOverride) {
+    if (runtimeOverride.provider) {
+      workflow.provider = runtimeOverride.provider;
+    }
+    if (runtimeOverride.model) {
+      workflow.model = runtimeOverride.model;
+    }
+    getLog().info(
+      {
+        workflowName: workflow.name,
+        provider: runtimeOverride.provider,
+        model: runtimeOverride.model,
+      },
+      'workflow.runtime_override_applied'
+    );
+  }
+
   // Auto-attach project to conversation
   await db.updateConversation(conversation.id, {
     codebase_id: codebase.id,
@@ -542,8 +565,14 @@ export async function handleMessage(
   message: string,
   context?: HandleMessageContext
 ): Promise<void> {
-  const { issueContext, threadContext, parentConversationId, isolationHints, attachedFiles } =
-    context ?? {};
+  const {
+    issueContext,
+    threadContext,
+    parentConversationId,
+    isolationHints,
+    attachedFiles,
+    runtimeOverride,
+  } = context ?? {};
   try {
     getLog().debug({ conversationId }, 'orchestrator_message_received');
 
@@ -665,7 +694,8 @@ export async function handleMessage(
             codebase,
             workflow,
             pausedRun.user_message,
-            isolationHints
+            isolationHints,
+            runtimeOverride
           );
           getLog().info(
             { conversationId, workflowRunId: pausedRun.id, workflowName: pausedRun.workflow_name },
@@ -735,7 +765,8 @@ export async function handleMessage(
             conversation,
             result.workflow.definition,
             result.workflow.args ?? message,
-            isolationHints
+            isolationHints,
+            runtimeOverride
           );
         }
         return;
@@ -1278,7 +1309,8 @@ async function handleWorkflowInvocationResult(
       codebase,
       workflow,
       workflowPrompt,
-      isolationHints
+      isolationHints,
+      runtimeOverride
     );
     return;
   }
@@ -1446,7 +1478,8 @@ async function handleWorkflowRunCommand(
   conversation: Conversation,
   workflow: WorkflowDefinition,
   userMessage: string,
-  isolationHints?: HandleMessageContext['isolationHints']
+  isolationHints?: HandleMessageContext['isolationHints'],
+  runtimeOverride?: HandleMessageContext['runtimeOverride']
 ): Promise<void> {
   // Check if conversation has a project
   if (conversation.codebase_id) {
@@ -1466,7 +1499,8 @@ async function handleWorkflowRunCommand(
       codebase,
       workflow,
       userMessage,
-      isolationHints
+      isolationHints,
+      runtimeOverride
     );
     return;
   }
@@ -1543,7 +1577,8 @@ async function handleWorkflowRunCommand(
       codebase,
       resolvedWorkflow,
       userMessage,
-      isolationHints
+      isolationHints,
+      runtimeOverride
     );
     return;
   }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -45,12 +45,29 @@ export interface AttachedFile {
   size: number;
 }
 
+/** Per-request runtime override for workflow dispatch.
+ *
+ * When set, takes precedence over `workflow.provider` / `workflow.model`
+ * and the global assistant defaults. Threaded from the route handler
+ * through dispatchToOrchestrator → orchestrator-agent so an external
+ * caller (e.g. an orchestration platform like OperationsCenter) can bind
+ * a specific runtime per dispatch without registering new workflow YAML.
+ *
+ * Both fields are optional; supplying only one (e.g. just `model`) keeps
+ * the other resolution chain intact.
+ */
+export interface RuntimeOverride {
+  readonly provider?: string;
+  readonly model?: string;
+}
+
 export interface HandleMessageContext {
   readonly issueContext?: string;
   readonly threadContext?: string;
   readonly parentConversationId?: string;
   readonly isolationHints?: IsolationHints;
   readonly attachedFiles?: AttachedFile[];
+  readonly runtimeOverride?: RuntimeOverride;
 }
 
 export interface Codebase {

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -1798,7 +1798,12 @@ export function registerApiRoutes(
       return apiError(c, 400, 'Invalid workflow name');
     }
     try {
-      const { conversationId, message } = getValidatedBody(c, runWorkflowBodySchema);
+      const {
+        conversationId,
+        message,
+        provider: providerOverride,
+        model: modelOverride,
+      } = getValidatedBody(c, runWorkflowBodySchema);
       // Persist user message and register DB ID (same as message endpoint)
       let conv: Awaited<ReturnType<typeof conversationDb.findConversationByPlatformId>> = null;
       try {
@@ -1826,7 +1831,18 @@ export function registerApiRoutes(
       }
 
       const fullMessage = `/workflow run ${workflowName} ${message}`;
-      const result = await dispatchToOrchestrator(conversationId, fullMessage);
+      // Build extraContext only when an override is present so existing
+      // dispatch paths (CLI, Slack, Telegram, GitHub, Discord) stay unchanged.
+      const extraContext =
+        providerOverride || modelOverride
+          ? {
+              runtimeOverride: {
+                ...(providerOverride ? { provider: providerOverride } : {}),
+                ...(modelOverride ? { model: modelOverride } : {}),
+              },
+            }
+          : undefined;
+      const result = await dispatchToOrchestrator(conversationId, fullMessage, extraContext);
       return c.json(result);
     } catch (error) {
       getLog().error({ err: error }, 'run_workflow_failed');

--- a/packages/server/src/routes/api.workflow-runs.test.ts
+++ b/packages/server/src/routes/api.workflow-runs.test.ts
@@ -364,6 +364,103 @@ describe('POST /api/workflows/:name/run', () => {
     );
   });
 
+  test('passes runtimeOverride context when provider/model are in body', async () => {
+    mockFindConversationByPlatformId.mockImplementationOnce(async () => MOCK_CONV);
+    mockAddMessage.mockImplementationOnce(async () => ({
+      id: 'msg-1',
+      conversation_id: MOCK_CONV.id,
+      role: 'user' as const,
+      content: 'go',
+      metadata: '{}',
+      created_at: NOW,
+    }));
+    mockHandleMessage.mockImplementationOnce(async () => {});
+
+    const { app } = makeApp();
+    const response = await app.request('/api/workflows/deploy/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        conversationId: 'web-test-abc',
+        message: 'go',
+        provider: 'claude',
+        model: 'opus',
+      }),
+    });
+    expect(response.status).toBe(200);
+
+    expect(mockHandleMessage).toHaveBeenCalledWith(
+      expect.anything(),
+      'web-test-abc',
+      '/workflow run deploy go',
+      expect.objectContaining({
+        runtimeOverride: { provider: 'claude', model: 'opus' },
+      })
+    );
+  });
+
+  test('omits runtimeOverride from context when neither provider nor model is provided', async () => {
+    mockFindConversationByPlatformId.mockImplementationOnce(async () => MOCK_CONV);
+    mockAddMessage.mockImplementationOnce(async () => ({
+      id: 'msg-1',
+      conversation_id: MOCK_CONV.id,
+      role: 'user' as const,
+      content: 'go',
+      metadata: '{}',
+      created_at: NOW,
+    }));
+    mockHandleMessage.mockImplementationOnce(async () => {});
+
+    const { app } = makeApp();
+    await app.request('/api/workflows/deploy/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ conversationId: 'web-test-abc', message: 'go' }),
+    });
+
+    // dispatchToOrchestrator always passes a context object (with isolationHints).
+    // The override should simply be absent — preserves the existing dispatch path
+    // for CLI/Slack/Telegram/etc. so they continue to behave unchanged.
+    expect(mockHandleMessage).toHaveBeenCalled();
+    const callArgs = mockHandleMessage.mock.calls[0];
+    const ctx = callArgs?.[3] as Record<string, unknown> | undefined;
+    expect(ctx).toBeDefined();
+    expect(ctx).not.toHaveProperty('runtimeOverride');
+  });
+
+  test('passes runtimeOverride with only provider (model omitted)', async () => {
+    mockFindConversationByPlatformId.mockImplementationOnce(async () => MOCK_CONV);
+    mockAddMessage.mockImplementationOnce(async () => ({
+      id: 'msg-1',
+      conversation_id: MOCK_CONV.id,
+      role: 'user' as const,
+      content: 'go',
+      metadata: '{}',
+      created_at: NOW,
+    }));
+    mockHandleMessage.mockImplementationOnce(async () => {});
+
+    const { app } = makeApp();
+    await app.request('/api/workflows/deploy/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        conversationId: 'web-test-abc',
+        message: 'go',
+        provider: 'codex',
+      }),
+    });
+
+    expect(mockHandleMessage).toHaveBeenCalledWith(
+      expect.anything(),
+      'web-test-abc',
+      '/workflow run deploy go',
+      expect.objectContaining({
+        runtimeOverride: { provider: 'codex' },
+      })
+    );
+  });
+
   test('persists user message to DB when conversation found', async () => {
     mockFindConversationByPlatformId.mockImplementationOnce(async () => MOCK_CONV);
     mockAddMessage.mockImplementationOnce(async () => ({

--- a/packages/server/src/routes/schemas/workflow.schemas.ts
+++ b/packages/server/src/routes/schemas/workflow.schemas.ts
@@ -200,11 +200,20 @@ export const dashboardRunsResponseSchema = z
   })
   .openapi('DashboardRunsResponse');
 
-/** POST /api/workflows/:name/run request body. */
+/** POST /api/workflows/:name/run request body.
+ *
+ * `provider` / `model` are optional per-request runtime overrides. When
+ * present they take precedence over the workflow YAML's top-level
+ * `provider` / `model` and the global assistant config. Used by external
+ * orchestrators (e.g. Velascat/OperationsCenter) to bind a specific
+ * runtime per dispatch without registering a new workflow YAML.
+ */
 export const runWorkflowBodySchema = z
   .object({
     conversationId: z.string(),
     message: z.string(),
+    provider: z.string().optional(),
+    model: z.string().optional(),
   })
   .openapi('RunWorkflowBody');
 


### PR DESCRIPTION
## Summary

Adds optional \`provider\` / \`model\` fields to \`runWorkflowBodySchema\` so external orchestrators (e.g. [Velascat/OperationsCenter](https://github.com/Velascat/OperationsCenter)) can bind a specific runtime per dispatch without registering a new workflow YAML or mutating \`.archon/config.yaml\`.

This is the **Velascat-fork patch** that lets OC's HTTP-mode Archon dispatcher honor \`RuntimeBinding\` per request. Without it, every HTTP dispatch inherits the workflow YAML's baked-in \`provider\`/\`model\` and OC's per-request runtime guarantee is lost the moment work crosses the wire.

## Wire change

\`\`\`
POST /api/workflows/:name/run
  body: {
    conversationId: string,
    message: string,
    provider?: string,    // NEW
    model?: string,       // NEW
  }
\`\`\`

Both fields independent — sending only \`model\` keeps the provider resolution chain intact. Override takes precedence over \`workflow.provider\` / \`workflow.model\` and the global assistant config.

## Threading

- \`runWorkflowBodySchema\` accepts the new optional fields
- Route handler builds \`extraContext\` only when set (preserves existing dispatch path for stock channels)
- \`HandleMessageContext\` gains \`runtimeOverride?: { provider?, model? }\` (readonly)
- \`dispatchOrchestratorWorkflow\` applies it by mutating \`workflow.provider\` / \`workflow.model\` before any \`executeWorkflow\` call. Safe — workflow is freshly loaded per-run, discarded after dispatch (does not persist to disk).

## Backward compatibility

- Stock dispatch paths (CLI / Slack / Telegram / GitHub / Discord) never set \`runtimeOverride\` → behave unchanged.
- New schema fields are optional → old clients still validate.

## Test plan

- [x] 3 new tests in \`api.workflow-runs.test.ts\`: \`passes runtimeOverride context when provider/model are in body\`, \`omits runtimeOverride from context when neither provider nor model is provided\`, \`passes runtimeOverride with only provider (model omitted)\`
- [x] Full file suite: 71 pass, 0 fail
- [x] Live-validated against built-from-source container (\`workstation-archon\`): schema accepts the fields, dispatch fires \`cmd.workflow_starting\`, mutation applies before executeWorkflow

## Upstream intent

This is a fork patch tracked at \`Velascat/OperationsCenter/patches/archon/PATCH-001.yaml\`. Upstream PR to coleam00/Archon will follow once OC has weeks of real usage in the dispatch path to back the API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-request provider and model overrides when executing workflows through the API, enabling flexible runtime configuration at invocation time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->