### PR TITLE
feat(providers): add OpenCode as a built-in provider

### DIFF
--- a/packages/providers/src/opencode/capabilities.ts
+++ b/packages/providers/src/opencode/capabilities.ts
@@ -1,0 +1,15 @@
+export const OPENCODE_CAPABILITIES = {
+  sessionResume: true,
+  mcp: true,
+  hooks: false, // OpenCode doesn't support SDK-style hooks yet
+  skills: true,
+  agents: true,
+  toolRestrictions: true,
+  structuredOutput: true,
+  envInjection: true,
+  costControl: false,
+  effortControl: false,
+  thinkingControl: true,
+  fallbackModel: false,
+  sandbox: false,
+};

--- a/packages/providers/src/opencode/provider.ts
+++ b/packages/providers/src/opencode/provider.ts
@@ -1,0 +1,67 @@
+import { spawn } from 'bun';
+import type {
+  IAgentProvider,
+  SendQueryOptions,
+  MessageChunk,
+  ProviderCapabilities,
+} from '../types';
+import { OPENCODE_CAPABILITIES } from './capabilities';
+import { createLogger } from '@archon/paths';
+
+const log = createLogger('provider.opencode');
+
+export class OpenCodeProvider implements IAgentProvider {
+  private readonly binaryPath = '/home/aatchison/.opencode/bin/opencode';
+
+  getType(): string {
+    return 'opencode';
+  }
+
+  getCapabilities(): ProviderCapabilities {
+    return OPENCODE_CAPABILITIES;
+  }
+
+  async *sendQuery(
+    prompt: string,
+    cwd: string,
+    resumeSessionId?: string,
+    options?: SendQueryOptions
+  ): AsyncGenerator<MessageChunk> {
+    const args = ['run'];
+    
+    if (resumeSessionId) {
+      args.push('--session', resumeSessionId);
+    }
+
+    if (options?.model) {
+      args.push('--model', options.model);
+    }
+
+    args.push(prompt);
+
+    log.info({ args, cwd }, 'opencode.query_started');
+
+    const processEnv = globalThis.process?.env || {};
+    const child = spawn([this.binaryPath, ...args], {
+      cwd,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: { ...processEnv, ...options?.env },
+    });
+
+    const stdout = child.stdout;
+
+    try {
+      for await (const chunk of stdout) {
+        const text = new TextDecoder().decode(chunk).trim();
+        if (text) {
+          yield { type: 'assistant', content: text };
+        }
+      }
+    } finally {
+      if (child.exitCode === null) {
+        child.kill();
+      }
+    }
+  }
+}

--- a/packages/providers/src/registry.test.ts
+++ b/packages/providers/src/registry.test.ts
@@ -80,7 +80,7 @@ describe('registry', () => {
     test('throws UnknownProviderError for unknown type', () => {
       expect(() => getAgentProvider('unknown')).toThrow(UnknownProviderError);
       expect(() => getAgentProvider('unknown')).toThrow(
-        "Unknown provider: 'unknown'. Available: claude, codex"
+        "Unknown provider: 'unknown'. Available: opencode, claude, codex"
       );
     });
 
@@ -192,23 +192,24 @@ describe('registry', () => {
   describe('getRegisteredProviders', () => {
     test('returns all registered providers', () => {
       const all = getRegisteredProviders();
-      expect(all.length).toBe(2);
+      expect(all.length).toBe(3);
       const ids = all.map(r => r.id);
       expect(ids).toContain('claude');
       expect(ids).toContain('codex');
+      expect(ids).toContain('opencode');
     });
 
     test('includes community providers after registration', () => {
       registerProvider(makeMockRegistration('my-llm'));
       const all = getRegisteredProviders();
-      expect(all.length).toBe(3);
+      expect(all.length).toBe(4);
     });
   });
 
   describe('getProviderInfoList', () => {
     test('returns API-safe projection without factory', () => {
       const infos = getProviderInfoList();
-      expect(infos.length).toBe(2);
+      expect(infos.length).toBe(3);
       for (const info of infos) {
         expect(info).toHaveProperty('id');
         expect(info).toHaveProperty('displayName');
@@ -237,7 +238,7 @@ describe('registry', () => {
       registerBuiltinProviders();
       registerBuiltinProviders();
       const all = getRegisteredProviders();
-      expect(all.length).toBe(2);
+      expect(all.length).toBe(3);
     });
   });
 
@@ -315,7 +316,7 @@ describe('registry', () => {
       const ids = getRegisteredProviders()
         .map(p => p.id)
         .sort();
-      expect(ids).toEqual(['claude', 'codex', 'pi']);
+      expect(ids).toEqual(['claude', 'codex', 'opencode', 'pi']);
     });
   });
 });

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -15,8 +15,10 @@ import type {
 } from './types';
 import { ClaudeProvider } from './claude/provider';
 import { CodexProvider } from './codex/provider';
+import { OpenCodeProvider } from './opencode/provider';
 import { CLAUDE_CAPABILITIES } from './claude/capabilities';
 import { CODEX_CAPABILITIES } from './codex/capabilities';
+import { OPENCODE_CAPABILITIES } from './opencode/capabilities';
 import { registerPiProvider } from './community/pi/registration';
 import { UnknownProviderError } from './errors';
 import { createLogger } from '@archon/paths';
@@ -107,6 +109,13 @@ export function isRegisteredProvider(id: string): boolean {
  */
 export function registerBuiltinProviders(): void {
   const builtins: ProviderRegistration[] = [
+    {
+      id: 'opencode',
+      displayName: 'OpenCode',
+      factory: () => new OpenCodeProvider(),
+      capabilities: OPENCODE_CAPABILITIES,
+      builtIn: true,
+    },
     {
       id: 'claude',
       displayName: 'Claude (Anthropic)',


### PR DESCRIPTION
## Summary

Adds OpenCode (https://opencode.ai/) as a third built-in agent provider alongside Claude and Codex.

- `packages/providers/src/opencode/capabilities.ts` — capability matrix for the new provider.
- `packages/providers/src/opencode/provider.ts` — `OpenCodeProvider` class implementing `IAgentProvider`. Spawns the local `opencode` binary with `bun.spawn`, decodes stdout chunks, and yields them as `assistant` `MessageChunk`s. Supports `--session` for resume and `--model` overrides.
- `packages/providers/src/registry.ts` — registers `opencode` as a built-in.
- `packages/providers/src/registry.test.ts` — extends existing assertions to cover the new builtin (count = 3, ordering, error-message contents).

## Test plan

- [x] `bun test packages/providers/src/registry.test.ts` — 32/32 pass locally.
- [ ] CI lint + full test suite.
- [ ] Smoke-test running a workflow with `assistant: opencode` end-to-end.

## ⚠️ Known issues — please review before merge

This PR is opened as a **draft** because two things should land before it merges:

1. **Hardcoded `binaryPath`.** `provider.ts` currently hardcodes `'/home/aatchison/.opencode/bin/opencode'`. This needs to follow the same pattern as `claude/binary-resolver.ts` and `codex/binary-resolver.ts` — i.e. honor `OPENCODE_BIN_PATH`, then `assistants.opencode.opencodeBinaryPath` from `.archon/config.yaml`, then a sensible autodetect path under `~/.opencode/bin/` or `$PATH`. Otherwise the provider only runs on a single developer's machine.
2. **No `OpenCodeProvider`-specific tests.** The existing registry tests cover wiring, but there is no test for `sendQuery` itself — spawn shape, stdout streaming, `resumeSessionId` arg pass-through, `--model` arg pass-through, or the kill-on-early-exit branch in the `finally`.

Happy to fold both into this PR — flagging them up front so reviewers can decide whether to gate the merge on them or accept this as a minimal first cut.