### PR TITLE
feat(web): improve streaming chat continuity readability

### DIFF
--- a/packages/web/src/components/chat/ChatInterface.tsx
+++ b/packages/web/src/components/chat/ChatInterface.tsx
@@ -29,6 +29,7 @@ import type {
   WorkflowDispatchEvent,
 } from '@/lib/types';
 import { applyOnText } from '@/lib/chat-message-reducer';
+import { applySystemStatus } from '@/lib/system-status-reducer';
 import {
   getCachedMessages,
   setCachedMessages,
@@ -548,15 +549,7 @@ export function ChatInterface({ conversationId }: ChatInterfaceProps): React.Rea
   );
 
   const onSystemStatus = useCallback((content: string): void => {
-    setMessages(prev => [
-      ...prev,
-      {
-        id: nextId(),
-        role: 'system' as const,
-        content,
-        timestamp: Date.now(),
-      },
-    ]);
+    setMessages(prev => applySystemStatus(prev, content, nextId));
   }, []);
 
   const { connected } = useSSE(isNewChat ? null : conversationId, {

--- a/packages/web/src/components/chat/MessageBubble.tsx
+++ b/packages/web/src/components/chat/MessageBubble.tsx
@@ -209,16 +209,20 @@ function MessageBubbleRaw({ message }: MessageBubbleProps): React.ReactElement {
           ) : (
             <div className="chat-markdown max-w-none text-sm text-text-primary">
               {isThinking && (
-                <div className="flex items-center gap-1.5 py-1">
-                  <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-text-tertiary" />
-                  <span
-                    className="h-1.5 w-1.5 animate-pulse rounded-full bg-text-tertiary"
-                    style={{ animationDelay: '0.2s' }}
-                  />
-                  <span
-                    className="h-1.5 w-1.5 animate-pulse rounded-full bg-text-tertiary"
-                    style={{ animationDelay: '0.4s' }}
-                  />
+                <div className="flex items-center gap-2 py-1 text-sm text-text-tertiary">
+                  <span className="sr-only">Thinking</span>
+                  <span className="font-medium">Thinking</span>
+                  <div className="flex items-center gap-1.5" aria-hidden="true">
+                    <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-text-tertiary" />
+                    <span
+                      className="h-1.5 w-1.5 animate-pulse rounded-full bg-text-tertiary"
+                      style={{ animationDelay: '0.2s' }}
+                    />
+                    <span
+                      className="h-1.5 w-1.5 animate-pulse rounded-full bg-text-tertiary"
+                      style={{ animationDelay: '0.4s' }}
+                    />
+                  </div>
                 </div>
               )}
               {isJsonString(message.content) ? (

--- a/packages/web/src/components/chat/ToolCallCard.tsx
+++ b/packages/web/src/components/chat/ToolCallCard.tsx
@@ -34,6 +34,11 @@ export function ToolCallCard({ tool }: ToolCallCardProps): React.ReactElement {
   const outputLines = tool.output?.split('\n') ?? [];
   const isLongOutput = outputLines.length > 20;
   const displayOutput = showAllOutput ? tool.output : outputLines.slice(0, 20).join('\n');
+  const outputPreview = outputLines
+    .map(line => line.trim())
+    .find(line => line.length > 0)
+    ?.slice(0, 80);
+  const statusLabel = isRunning ? 'Running' : tool.output !== undefined ? 'Complete' : 'Done';
 
   return (
     <div
@@ -61,7 +66,14 @@ export function ToolCallCard({ tool }: ToolCallCardProps): React.ReactElement {
           <Terminal className="h-3.5 w-3.5 shrink-0 text-text-secondary" />
         )}
         <span className="truncate font-mono text-xs text-text-secondary">{tool.name}</span>
-        {summaryText && <span className="truncate text-xs text-text-tertiary">{summaryText}</span>}
+        <span className="shrink-0 rounded-full bg-surface-elevated px-2 py-0.5 text-[10px] text-text-secondary">
+          {statusLabel}
+        </span>
+        {summaryText ? (
+          <span className="truncate text-xs text-text-tertiary">{summaryText}</span>
+        ) : outputPreview ? (
+          <span className="truncate text-xs text-text-tertiary">{outputPreview}</span>
+        ) : null}
         <span className="ml-auto shrink-0">
           {isRunning && elapsed > 0 ? (
             <span className="rounded-full bg-primary/20 px-2 py-0.5 text-[10px] text-primary">

--- a/packages/web/src/lib/system-status-reducer.test.ts
+++ b/packages/web/src/lib/system-status-reducer.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test';
+import { applySystemStatus } from './system-status-reducer';
+import type { ChatMessage } from './types';
+
+let idCounter = 0;
+function makeId(): string {
+  idCounter++;
+  return `msg-${String(idCounter)}`;
+}
+
+const NOW = 1000;
+
+describe('applySystemStatus', () => {
+  test('appends a new system message when previous message is not system', () => {
+    const prev: ChatMessage[] = [{ id: 'u1', role: 'user', content: 'hi', timestamp: NOW }];
+    const result = applySystemStatus(prev, 'Connecting…', makeId, NOW + 1);
+
+    expect(result).toHaveLength(2);
+    expect(result[1]).toEqual({
+      id: 'msg-1',
+      role: 'system',
+      content: 'Connecting…',
+      timestamp: NOW + 1,
+    });
+  });
+
+  test('coalesces consecutive system status updates into one row', () => {
+    const prev: ChatMessage[] = [
+      { id: 'sys-1', role: 'system', content: 'Connecting…', timestamp: NOW },
+    ];
+    const result = applySystemStatus(prev, 'Waiting for tools…', makeId, NOW + 2);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: 'sys-1',
+      role: 'system',
+      content: 'Waiting for tools…',
+      timestamp: NOW + 2,
+    });
+  });
+
+  test('preserves earlier non-system history when coalescing', () => {
+    const prev: ChatMessage[] = [
+      { id: 'u1', role: 'user', content: 'run it', timestamp: NOW },
+      { id: 'sys-1', role: 'system', content: 'Starting…', timestamp: NOW + 1 },
+    ];
+    const result = applySystemStatus(prev, 'Streaming…', makeId, NOW + 3);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(prev[0]);
+    expect(result[1].content).toBe('Streaming…');
+    expect(result[1].timestamp).toBe(NOW + 3);
+  });
+});

--- a/packages/web/src/lib/system-status-reducer.ts
+++ b/packages/web/src/lib/system-status-reducer.ts
@@ -1,0 +1,37 @@
+import type { ChatMessage } from './types';
+
+/**
+ * Append a system-status line to the chat while coalescing consecutive status updates.
+ *
+ * Continuity goal: when multiple transient status updates arrive back-to-back,
+ * keep a single evolving system row instead of stacking flickery one-line rows.
+ */
+export function applySystemStatus(
+  prev: ChatMessage[],
+  content: string,
+  makeId: () => string = () => `msg-${String(Date.now())}`,
+  now: number = Date.now()
+): ChatMessage[] {
+  const last = prev[prev.length - 1];
+
+  if (last?.role === 'system') {
+    return [
+      ...prev.slice(0, -1),
+      {
+        ...last,
+        content,
+        timestamp: now,
+      },
+    ];
+  }
+
+  return [
+    ...prev,
+    {
+      id: makeId(),
+      role: 'system',
+      content,
+      timestamp: now,
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: transient system-status rows, tool-call rows, and thinking placeholders were readable individually but still felt flickery/ambiguous during live streaming.
- Why it matters: users need continuity while a response is still unfolding, especially before assistant text lands or when tools are actively running.
- What changed: coalesced consecutive system status rows into one evolving line; added clearer collapsed tool-call status/preview treatment; labeled the live thinking placeholder explicitly.
- What did **not** change (scope boundary): no backend/SSE protocol changes, no workflow-engine changes, no provider/Rust semantic changes, no new visibility-mode settings yet.

## UX Journey

### Before

```
User                      Archon Web Chat
────                      ───────────────
sends message ─────────▶  adds blank thinking dots
                          appends multiple system status rows as they arrive
                          shows collapsed tool rows with little context
                          streams assistant text when available
sees flicker/ambiguity ◀─ especially before text arrives or between tool events
```

### After

```
User                      Archon Web Chat
────                      ───────────────
sends message ─────────▶  adds [Thinking + dots] placeholder
                          [coalesces] consecutive system status updates into one evolving row
                          shows tool rows with [status chip] + [preview text]
                          streams assistant text when available
sees steadier continuity ◀─ with clearer interim state before/during tool activity
```

## Architecture Diagram

### Before

```
ChatInterface.tsx -> useSSE
ChatInterface.tsx -> chat-message-reducer.ts
ChatInterface.tsx -> MessageList.tsx
MessageList.tsx -> MessageBubble.tsx
MessageList.tsx -> ToolCallCard.tsx
```

### After

```
[~] ChatInterface.tsx -> useSSE
[~] ChatInterface.tsx ===> [+] system-status-reducer.ts
ChatInterface.tsx -> chat-message-reducer.ts
ChatInterface.tsx -> MessageList.tsx
MessageList.tsx -> [~] MessageBubble.tsx
MessageList.tsx -> [~] ToolCallCard.tsx
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| ChatInterface.tsx | useSSE | unchanged | SSE event source remains the same |
| ChatInterface.tsx | chat-message-reducer.ts | unchanged | text streaming segmentation unchanged |
| ChatInterface.tsx | system-status-reducer.ts | **new** | system status rows now coalesce before render |
| ChatInterface.tsx | MessageList.tsx | unchanged | message list wiring unchanged |
| MessageList.tsx | MessageBubble.tsx | **modified** | thinking placeholder presentation clarified |
| MessageList.tsx | ToolCallCard.tsx | **modified** | collapsed tool readability improved |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `web`
- Module: `web:chat`

## Change Metadata

- Change type: `feature`
- Primary scope: `web`

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #
- Related knosence/vela#54

## Validation Evidence (required)

Commands and result summary:

```bash
bun --filter @archon/web type-check
bun --filter @archon/web test
```

- Evidence provided (test/log/trace/screenshot): local type-check + web package tests passed
- If any command is intentionally skipped, explain why: full `bun run validate` was skipped because this PR is a bounded web-only UI slice and the touched surface is covered by package-local validation.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation:

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps:

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: consecutive system status updates now collapse into one evolving row; collapsed tool rows show a clearer status/preview; thinking placeholder now has an explicit label.
- Edge cases checked: type-check still passes; package-local web tests still pass; no protocol/schema changes required.
- What was not verified: browser-side visual QA in a running dev session.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: web chat rendering only (`ChatInterface`, `MessageBubble`, `ToolCallCard`)
- Potential unintended effects: users accustomed to multiple stacked status lines will now see a single evolving line instead.
- Guardrails/monitoring for early detection: isolated reducer tests for status coalescing, package-local type-check/test coverage.

## Rollback Plan (required)

- Fast rollback command/path: revert commits `5f23b691` and `f4c732c4`, or revert the PR merge on `dev`
- Feature flags or config toggles (if any): none
- Observable failure symptoms: missing system status row updates, tool rows losing preview/status clarity, thinking placeholder rendering regressions

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: coalescing system rows could hide a status transition a user wanted to see as a separate line.
  - Mitigation: scope is limited to consecutive `system` rows only; assistant/tool messages remain separate and ordered.
- Risk: collapsed tool preview could surface noisy first-line output for some tools.
  - Mitigation: preview is fallback-only when no input summary exists; full expandable output remains unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added status badges to tool calls (Running, Complete, Done).
  * Added output preview display in tool call headers.

* **Style**
  * Improved "Thinking" indicator UI with enhanced spacing and accessibility label.

* **Tests**
  * Added comprehensive test coverage for system message coalescing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->