### PR TITLE
fix(server,workflows,web): surface bundled defaults on /api/workflows when no project context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Workflow marketplace, expanded setup wizard, and broad Pi/workflow engine fixes.
 - **Pi concurrency + error surfacing**: SDK error messages now surface to the user instead of being masked, and Pi concurrency is capped to prevent cascade failures (#1572).
 - Chat hydration shows newest messages instead of oldest (#1532).
 - `GET /api/workflows/:name` now resolves home-scoped (`~/.archon/workflows/`) workflows that were previously invisible to the Web UI builder (#1405).
-- `GET /api/workflows` no longer returns an empty array when no `cwd` query param is provided and no codebases are registered — bundled and home-scoped workflows now surface correctly on first run (#1173).
+- `GET /api/workflows` no longer returns an empty array when no `cwd` query param is provided and no codebases are registered — bundled and home-scoped workflows now surface correctly on first run, making the workflow picker functional on first launch before any project is registered (#1173).
 - `archon workflow run` propagates `$ARTIFACTS_DIR`, `$LOG_DIR`, `$BASE_BRANCH` to script-node subprocesses (#1640).
 - `archon-assist` now runs in the live checkout (`worktree.enabled: false`) — closes #1546 (#1555).
 - Bundled `opus[1m]` implement nodes now set `provider: claude` explicitly (#1622).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Workflow marketplace, expanded setup wizard, and broad Pi/workflow engine fixes.
 - **Pi concurrency + error surfacing**: SDK error messages now surface to the user instead of being masked, and Pi concurrency is capped to prevent cascade failures (#1572).
 - Chat hydration shows newest messages instead of oldest (#1532).
 - `GET /api/workflows/:name` now resolves home-scoped (`~/.archon/workflows/`) workflows that were previously invisible to the Web UI builder (#1405).
+- `GET /api/workflows` no longer returns an empty array when no `cwd` query param is provided and no codebases are registered — bundled and home-scoped workflows now surface correctly on first run (#1173).
 - `archon workflow run` propagates `$ARTIFACTS_DIR`, `$LOG_DIR`, `$BASE_BRANCH` to script-node subprocesses (#1640).
 - `archon-assist` now runs in the live checkout (`worktree.enabled: false`) — closes #1546 (#1555).
 - Bundled `opus[1m]` implement nodes now set `provider: claude` explicitly (#1622).

--- a/packages/docs-web/src/content/docs/reference/api.md
+++ b/packages/docs-web/src/content/docs/reference/api.md
@@ -204,6 +204,8 @@ curl http://localhost:3090/api/workflows
 Query parameters:
 - `cwd` (optional) -- Working directory to discover project-specific workflows
 
+When `cwd` is omitted, Archon returns bundled default workflows and any from `~/.archon/workflows/` (home-scoped). Project-specific workflows require either the `cwd` query param or a registered codebase, so the endpoint is useful on first launch before any project is registered.
+
 Returns `{ workflows: [...], errors?: [...] }`. The `errors` array contains any YAML parsing failures encountered during discovery.
 
 #### Get a Workflow

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -1760,7 +1760,7 @@ export function registerApiRoutes(
   registerOpenApiRoute(getWorkflowsRoute, async c => {
     try {
       const cwd = c.req.query('cwd');
-      let workingDir = cwd;
+      let workingDir: string | undefined = cwd;
 
       // Validate caller-supplied cwd against registered codebase paths
       if (cwd) {
@@ -1775,11 +1775,11 @@ export function registerApiRoutes(
         }
       }
 
-      if (!workingDir) {
-        return c.json({ workflows: [] });
-      }
-
-      const result = await discoverWorkflowsWithConfig(workingDir, loadConfig);
+      // No project context (no cwd query param and no registered codebases) —
+      // pass null to discovery so it returns bundled + home-scoped workflows.
+      // This avoids a misleading empty state on first run, before any project
+      // is registered, when bundled defaults are present.
+      const result = await discoverWorkflowsWithConfig(workingDir ?? null, loadConfig);
       return c.json({
         workflows: result.workflows.map(ws => ({ workflow: ws.workflow, source: ws.source })),
         errors: result.errors.length > 0 ? result.errors : undefined,

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -1778,7 +1778,7 @@ export function registerApiRoutes(
       // No project context (no cwd query param and no registered codebases) —
       // pass null to discovery so it returns bundled + home-scoped workflows.
       // This avoids a misleading empty state on first run, before any project
-      // is registered, when bundled defaults are present.
+      // is registered, when bundled defaults are present
       const result = await discoverWorkflowsWithConfig(workingDir ?? null, loadConfig);
       return c.json({
         workflows: result.workflows.map(ws => ({ workflow: ws.workflow, source: ws.source })),

--- a/packages/server/src/routes/api.workflows.test.ts
+++ b/packages/server/src/routes/api.workflows.test.ts
@@ -13,7 +13,7 @@ function createTestApp(): OpenAPIHono {
   return new OpenAPIHono({ defaultHook: validationErrorHook });
 }
 
-const mockDiscoverWorkflows = mock(async (_cwd: string) => ({
+const mockDiscoverWorkflows = mock(async (_cwd: string | null) => ({
   workflows: [makeTestWorkflowWithSource({ name: 'deploy', description: 'Deploy app' }, 'bundled')],
   errors: [
     { filename: '/tmp/.archon/workflows/bad.md', error: 'invalid', errorType: 'parse_error' },

--- a/packages/server/src/routes/api.workflows.test.ts
+++ b/packages/server/src/routes/api.workflows.test.ts
@@ -126,7 +126,7 @@ describe('GET /api/workflows', () => {
     registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
 
     // No registered codebases → handler should call discovery with null cwd
-    // so bundled + home-scoped workflows still surface (issue #1173).
+    // so bundled + home-scoped workflows still surface.
     mockListCodebases.mockImplementationOnce(async () => []);
 
     const response = await app.request('/api/workflows');

--- a/packages/server/src/routes/api.workflows.test.ts
+++ b/packages/server/src/routes/api.workflows.test.ts
@@ -120,6 +120,30 @@ describe('GET /api/workflows', () => {
     expect(body.errors).toBeDefined();
     expect(Array.isArray(body.errors)).toBe(true);
   });
+
+  test('falls back to null cwd when no cwd query and no codebases registered', async () => {
+    const app = createTestApp();
+    registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+    // No registered codebases → handler should call discovery with null cwd
+    // so bundled + home-scoped workflows still surface (issue #1173).
+    mockListCodebases.mockImplementationOnce(async () => []);
+
+    const response = await app.request('/api/workflows');
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      workflows: Array<{ workflow: { name: string }; source: string }>;
+    };
+
+    // Discovery is invoked with null (not skipped), so bundled defaults can surface.
+    expect(mockDiscoverWorkflows).toHaveBeenLastCalledWith(null, expect.any(Function));
+    // The mocked discovery returns one bundled workflow regardless of cwd, so the
+    // response is non-empty — proving the handler no longer short-circuits on no-cwd.
+    expect(Array.isArray(body.workflows)).toBe(true);
+    expect(body.workflows.length).toBeGreaterThan(0);
+    expect(body.workflows[0]?.source).toBe('bundled');
+  });
 });
 
 describe('POST /api/workflows/validate', () => {

--- a/packages/web/src/components/workflows/WorkflowList.tsx
+++ b/packages/web/src/components/workflows/WorkflowList.tsx
@@ -174,8 +174,24 @@ export function WorkflowList(): React.ReactElement {
         {/* Workflow grid */}
         {!hasWorkflows ? (
           <div className="text-sm text-text-secondary">
-            No workflows found. Add workflow definitions to{' '}
-            <code className="text-xs bg-surface-inset px-1 py-0.5 rounded">.archon/workflows/</code>
+            {localProjectId ? (
+              <>
+                No workflows found in this project. Add workflow definitions to{' '}
+                <code className="text-xs bg-surface-inset px-1 py-0.5 rounded">
+                  .archon/workflows/
+                </code>{' '}
+                in the project root.
+              </>
+            ) : (
+              <>
+                No workflows are available. Bundled defaults should appear here automatically; if
+                they do not, check that{' '}
+                <code className="text-xs bg-surface-inset px-1 py-0.5 rounded">
+                  defaults.loadDefaultWorkflows
+                </code>{' '}
+                is enabled in your config.
+              </>
+            )}
           </div>
         ) : filteredWorkflows.length === 0 ? (
           <div className="text-sm text-text-secondary py-8 text-center">

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -2529,13 +2529,16 @@ nodes:
     });
 
     it('still loads bundled defaults when loadDefaults:true and cwd is null', async () => {
-      // Spy on the bundled-defaults loader to confirm it ran. The actual bundled
-      // map content depends on the build, so we assert via the resulting source label.
       const result = await discoverWorkflows(null, { loadDefaults: true });
 
       // No project-source entries (project step skipped).
       const projectSourced = result.workflows.filter(w => w.source === 'project');
       expect(projectSourced).toHaveLength(0);
+
+      // Bundled-source entries must surface — without this assertion the test
+      // would silently pass even if the bundled-defaults loader regressed.
+      const bundledSourced = result.workflows.filter(w => w.source === 'bundled');
+      expect(bundledSourced.length).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -2512,4 +2512,30 @@ nodes:
       expect(mockLogger.warn).toHaveBeenCalled();
     });
   });
+
+  describe('discoverWorkflows with null cwd (no project context)', () => {
+    it('skips project scope and returns no project-source workflows', async () => {
+      // Issue #1173: when no codebase is registered, the LIST endpoint passes
+      // null so bundled + home scopes still surface. Discovery must not attempt
+      // to read a cwd-derived path and must not produce project-source entries.
+      const result = await discoverWorkflows(null, { loadDefaults: false });
+
+      const projectSourced = result.workflows.filter(w => w.source === 'project');
+      expect(projectSourced).toHaveLength(0);
+
+      // No project-step file/dir read errors — we never tried to access a project path.
+      const readErrors = result.errors.filter(e => e.errorType === 'read_error');
+      expect(readErrors).toHaveLength(0);
+    });
+
+    it('still loads bundled defaults when loadDefaults:true and cwd is null', async () => {
+      // Spy on the bundled-defaults loader to confirm it ran. The actual bundled
+      // map content depends on the build, so we assert via the resulting source label.
+      const result = await discoverWorkflows(null, { loadDefaults: true });
+
+      // No project-source entries (project step skipped).
+      const projectSourced = result.workflows.filter(w => w.source === 'project');
+      expect(projectSourced).toHaveLength(0);
+    });
+  });
 });

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -2515,10 +2515,15 @@ nodes:
 
   describe('discoverWorkflows with null cwd (no project context)', () => {
     it('skips project scope and returns no project-source workflows', async () => {
-      // Issue #1173: when no codebase is registered, the LIST endpoint passes
-      // null so bundled + home scopes still surface. Discovery must not attempt
-      // to read a cwd-derived path and must not produce project-source entries.
+      // When no codebase is registered the LIST endpoint passes null so bundled
+      // + home scopes can still surface. Discovery must not attempt to read a
+      // cwd-derived path and must not produce project-source entries.
       const result = await discoverWorkflows(null, { loadDefaults: false });
+
+      // loadDefaults:false skips bundled and a clean test env has no home-
+      // scoped workflows, so the full result must be empty — without this the
+      // test would pass even if a stray project-path read were silently injected.
+      expect(result.workflows).toHaveLength(0);
 
       const projectSourced = result.workflows.filter(w => w.source === 'project');
       expect(projectSourced).toHaveLength(0);
@@ -2542,9 +2547,9 @@ nodes:
     });
 
     it('discoverWorkflowsWithConfig does not call loadConfig when cwd is null', async () => {
-      // Guards the `if (cwd !== null)` branch in workflow-discovery.ts.
-      // If that guard is removed in a future refactor, the per-project opt-out
-      // would silently start running with no project context.
+      // The per-project config opt-out must not be evaluated when there is no
+      // project context — running loadConfig with no cwd would silently apply
+      // home-dir or working-dir defaults to a request that has neither.
       const mockLoadConfig = mock(async () => ({ defaults: { loadDefaultWorkflows: true } }));
       await discoverWorkflowsWithConfig(null, mockLoadConfig);
       expect(mockLoadConfig).not.toHaveBeenCalled();

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -33,7 +33,7 @@ import { registerBuiltinProviders, clearRegistry } from '@archon/providers';
 clearRegistry();
 registerBuiltinProviders();
 
-import { discoverWorkflows } from './workflow-discovery';
+import { discoverWorkflows, discoverWorkflowsWithConfig } from './workflow-discovery';
 import { isBashNode, isCancelNode, isLoopNode } from './schemas';
 import * as bundledDefaults from './defaults/bundled-defaults';
 
@@ -2539,6 +2539,15 @@ nodes:
       // would silently pass even if the bundled-defaults loader regressed.
       const bundledSourced = result.workflows.filter(w => w.source === 'bundled');
       expect(bundledSourced.length).toBeGreaterThan(0);
+    });
+
+    it('discoverWorkflowsWithConfig does not call loadConfig when cwd is null', async () => {
+      // Guards the `if (cwd !== null)` branch in workflow-discovery.ts.
+      // If that guard is removed in a future refactor, the per-project opt-out
+      // would silently start running with no project context.
+      const mockLoadConfig = mock(async () => ({ defaults: { loadDefaultWorkflows: true } }));
+      await discoverWorkflowsWithConfig(null, mockLoadConfig);
+      expect(mockLoadConfig).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/workflows/src/workflow-discovery.ts
+++ b/packages/workflows/src/workflow-discovery.ts
@@ -367,9 +367,9 @@ export async function discoverWorkflows(
  * defaults.loadDefaultWorkflows, fall back to true on config load failure.
  * Logs config failures at warn level for observability.
  *
- * When `cwd` is `null` (no project context), config lookup is skipped and
- * defaults are always loaded — the per-project opt-out only makes sense when
- * a project is actually selected.
+ * When `cwd` is `null` (no project context), `loadConfig` is not invoked and
+ * `loadDefaults` keeps its initial value of `true`. The per-project opt-out
+ * is a project-scoped setting; without a project there is no config to read.
  */
 export async function discoverWorkflowsWithConfig(
   cwd: string | null,

--- a/packages/workflows/src/workflow-discovery.ts
+++ b/packages/workflows/src/workflow-discovery.ts
@@ -192,6 +192,8 @@ function loadBundledWorkflows(): DirLoadResult {
  *   2. Home-scoped `~/.archon/workflows/` — classified as `source: 'global'`.
  *      No caller option: every caller gets home-scoped discovery for free.
  *   3. Repo-scoped `<cwd>/.archon/workflows/` — classified as `source: 'project'`.
+ *      Skipped when `cwd` is `null` (no project context — e.g. fresh deployment
+ *      where no codebase has been registered yet).
  *
  * When running as a compiled binary, bundled defaults are loaded from embedded
  * content. In source/dev mode they're loaded from the filesystem.
@@ -201,7 +203,7 @@ function loadBundledWorkflows(): DirLoadResult {
  * location is not read — users must migrate manually.
  */
 export async function discoverWorkflows(
-  cwd: string,
+  cwd: string | null,
   options?: { loadDefaults?: boolean }
 ): Promise<WorkflowLoadResult> {
   // Map of filename -> workflow+source for deduplication
@@ -274,7 +276,18 @@ export async function discoverWorkflows(
     }
   }
 
-  // 3. Load from repo's workflow folder (overrides app defaults AND home scope by exact filename)
+  // 3. Load from repo's workflow folder (overrides app defaults AND home scope by exact filename).
+  // Skipped when cwd is null — surfaces bundled + home scopes only, which is the right answer
+  // for callers without a project context (e.g. UI listing workflows before any codebase is registered).
+  if (cwd === null) {
+    const workflows = Array.from(workflowsByFile.values());
+    getLog().info(
+      { count: workflows.length, errorCount: allErrors.length, scope: 'no_project_context' },
+      'workflows_discovery_completed'
+    );
+    return { workflows, errors: allErrors };
+  }
+
   const [workflowFolder] = archonPaths.getWorkflowFolderSearchPaths();
   const workflowPath = join(cwd, workflowFolder);
 
@@ -353,20 +366,26 @@ export async function discoverWorkflows(
  * Wraps discoverWorkflows with the standard pattern: try loadConfig to read
  * defaults.loadDefaultWorkflows, fall back to true on config load failure.
  * Logs config failures at warn level for observability.
+ *
+ * When `cwd` is `null` (no project context), config lookup is skipped and
+ * defaults are always loaded — the per-project opt-out only makes sense when
+ * a project is actually selected.
  */
 export async function discoverWorkflowsWithConfig(
-  cwd: string,
+  cwd: string | null,
   loadConfig: (cwd: string) => Promise<{ defaults?: { loadDefaultWorkflows?: boolean } }>
 ): Promise<WorkflowLoadResult> {
   let loadDefaults = true;
-  try {
-    const cfg = await loadConfig(cwd);
-    loadDefaults = cfg.defaults?.loadDefaultWorkflows ?? true;
-  } catch (error) {
-    getLog().warn(
-      { err: error as Error, cwd },
-      'config_load_failed_using_default_workflow_discovery'
-    );
+  if (cwd !== null) {
+    try {
+      const cfg = await loadConfig(cwd);
+      loadDefaults = cfg.defaults?.loadDefaultWorkflows ?? true;
+    } catch (error) {
+      getLog().warn(
+        { err: error as Error, cwd },
+        'config_load_failed_using_default_workflow_discovery'
+      );
+    }
   }
   return discoverWorkflows(cwd, { loadDefaults });
 }


### PR DESCRIPTION
## Summary

- **Problem**: `GET /api/workflows` returns `{"workflows":[]}` when there is no `cwd` query param and no registered codebase, even though bundled defaults exist on disk. The Workflows page then renders a misleading empty state telling users to add files to `.archon/workflows/`.
- **Why it matters**: First-run experience after a fresh deployment is broken — users see "no workflows" and a hint that suggests their installation is incomplete, when in fact the 20 bundled defaults are sitting at `/app/.archon/workflows/defaults/`.
- **What changed**: Threaded `cwd: string | null` through the discovery functions; the `null` case loads bundled + home scopes and skips the project step. The GET handler now passes `null` instead of returning `[]`. The empty-state copy in `WorkflowList` now distinguishes "no project selected" from "no workflows in this project".
- **What did not change (scope boundary)**: Single-workflow GET/PUT/DELETE handlers were already correct (they fall through to `BUNDLED_WORKFLOWS` on `name` lookup when there is no cwd). The separate `getArchonWorkspacesPath()` issue mentioned in the issue's follow-up comment is a chat-flow bug, not a workflow-list bug, and is left for another change.

## UX Journey

### Before

```
  User                     Workflows API                Discovery
  ────                     ─────────────                ─────────
  loads /workflows ──────▶ GET /api/workflows
                           cwd? no
                           registered codebases? none
                           [X] return { workflows: [] }
  sees empty UI ◀───────── "Add workflow definitions to .archon/workflows/"
  ❌ bundled defaults present on disk but never surfaced
```

### After

```
  User                     Workflows API                Discovery
  ────                     ─────────────                ─────────
  loads /workflows ──────▶ GET /api/workflows
                           cwd? no
                           registered codebases? none
                           workingDir = null      [~]
                           discoverWorkflowsWithConfig(null, ...)  ──▶
                                                                       step 1: bundled (loaded)
                                                                       step 2: home (loaded)
                                                                       step 3: project (skipped)
                           ◀── { workflows: [...bundled, ...home] }
  sees bundled list ◀───── 20 default workflows render

  When the list is genuinely empty (defaults disabled in config):
  - With project selected: "No workflows found in this project. Add definitions to .archon/workflows/."
  - Without project:       "No workflows are available. Bundled defaults should appear automatically;
                            check that defaults.loadDefaultWorkflows is enabled in your config."
```

## Architecture Diagram

### Before

```
api.ts (GET /api/workflows)
  └── if (!workingDir) return { workflows: [] }   [X] short-circuit

workflow-discovery.ts
  └── discoverWorkflows(cwd: string, ...)         [requires cwd]
       step 1: bundled
       step 2: home
       step 3: join(cwd, .archon/workflows)
```

### After

```
api.ts (GET /api/workflows)
  └── workingDir ?? null → discovery                [~]

workflow-discovery.ts
  └── discoverWorkflows(cwd: string | null, ...)    [~]
       step 1: bundled
       step 2: home
       step 3: if cwd === null → return early       [+]
                else → join(cwd, .archon/workflows)
  └── discoverWorkflowsWithConfig(cwd: string | null, ...)  [~]
       skips loadConfig when cwd === null

WorkflowList.tsx
  └── empty state                                    [~]
       branches on localProjectId
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `api.ts` GET handler | `discoverWorkflowsWithConfig` | **modified** | Passes `null` instead of returning `[]` early |
| `discoverWorkflows` | repo-scope project step | **modified** | Skipped when `cwd === null` |
| `discoverWorkflowsWithConfig` | `loadConfig(cwd)` | **modified** | Skipped when `cwd === null` (no per-project config) |
| `WorkflowList.tsx` | empty-state JSX | **modified** | Branches on `localProjectId` |
| `cli/commands/{validate,workflow}.ts` | discovery | unchanged | `string` is assignable to `string \| null` — no caller changes |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `server`, `workflows`, `web`
- Module: `server:routes/api`, `workflows:workflow-discovery`, `web:workflows`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi`

## Linked Issue

- Closes #1173

## Validation Evidence (required)

```bash
# Workflow discovery tests (loader.test.ts) — adds 2 new tests
$ bun test packages/workflows/src/loader.test.ts
 119 pass, 0 fail, 271 expect() calls

# Server route tests (api.workflows.test.ts) — adds 1 new test
$ bun test packages/server/src/routes/api.workflows.test.ts
 28 pass, 0 fail, 76 expect() calls

# Web tests + type-check
$ bun --filter @archon/web type-check
$ bun --filter @archon/web test
 30 pass, 0 fail (lib)
 13 pass, 0 fail (stores)

# Type-check across changed packages
$ bun --filter @archon/workflows type-check  → clean
$ bun --filter @archon/server type-check     → clean
$ bun --filter @archon/web type-check        → clean

# Format + lint
$ bun x prettier --check <changed files>     → all matched files use Prettier code style
$ bun x eslint . --cache --max-warnings 0    → clean

# Bundled checks
$ bun run check:bundled         → bundled-defaults.generated.ts is up to date (36 commands, 20 workflows)
$ bun run check:bundled-skill   → bundled-skill.ts is up to date (21 files)
```

- Evidence provided: test results, type-check, lint, format, bundled-defaults check.
- If any command is intentionally skipped, explain why: Pre-existing `cli/doctor.test.ts` `checkWorkspaceWritable` failures (2) and 1 `workflowRunCommand` flake (passes individually, fails in the full suite) reproduce on pristine `upstream/dev` without these changes — verified via `git stash` round-trip — so they are not caused by this PR.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No` — `null` cwd skips the only cwd-derived `fs.access` call (the project step), so file-system reach is reduced, not expanded.

## Compatibility / Migration

- Backward compatible? `Yes` — `cwd: string` is assignable to `cwd: string | null`. All existing callers in `cli/commands/validate.ts`, `cli/commands/workflow.ts`, and the rest of `api.ts` continue to pass concrete strings.
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios:
  - `GET /api/workflows` with no `cwd` and no registered codebases returns the bundled set with `source: 'bundled'` (new test).
  - `discoverWorkflows(null, { loadDefaults: false })` produces zero project-source entries and zero project-step read errors (new test).
  - `discoverWorkflows(null, { loadDefaults: true })` still loads bundled defaults and skips the project step (new test).
  - WorkflowList empty-state copy verified by inspection of the conditional render path (no project + no workflows → defaults-hint message; project + no workflows → project-hint message).
- Edge cases checked: caller-supplied `cwd=` still validates against registered codebases (unchanged 400 path); registered-codebases path still resolves to the first codebase's `default_cwd`; `discoverWorkflowsWithConfig` no longer calls `loadConfig` when `cwd === null` (per-project opt-out only makes sense when a project is actually selected).
- What was not verified: Multi-tenant deployment with custom `~/.archon/workflows/` overrides — the home-scope step is unchanged, so this should behave the same as before.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `GET /api/workflows` (handler), `discoverWorkflows` and `discoverWorkflowsWithConfig` (signature widening), `WorkflowList` empty-state copy.
- Potential unintended effects: A fresh deployment that previously saw `[]` now sees ~20 bundled defaults. That is the intended fix, but it does change the response shape for the no-project path.
- Guardrails/monitoring for early detection: Existing `workflows_discovery_completed` info-level log now includes `scope: 'no_project_context'` when the null path is taken, so dashboards can detect the new branch.

## Rollback Plan (required)

- Fast rollback command/path: Revert this PR. No schema changes, no migrations.
- Feature flags or config toggles: None new. Users who want the old "empty list when no project" behavior can set `defaults.loadDefaultWorkflows: false` per project, but the no-project path always loads bundled (this is the bug being fixed).
- Observable failure symptoms: Workflows page renders unexpected entries, or the existing `workflows_discovery_completed` log shows `scope: 'no_project_context'` more often than expected.

## Risks and Mitigations

- Risk: A test or downstream caller relied on `discoverWorkflows` requiring a non-null `cwd`.
  - Mitigation: Searched the repo for all call sites — `cli/commands/validate.ts:90`, `cli/commands/workflow.ts:176`, and the GET handler. All pass concrete strings. The signature widening is purely additive.
- Risk: A user with `defaults.loadDefaultWorkflows: false` per project expects the no-project path to also be empty.
  - Mitigation: The no-project path explicitly skips `loadConfig` because there is no project to read config from. This is documented in the function-level comment. If the user wants to suppress bundled defaults globally, the existing `isBinaryBuild()`/path mechanism already covers compiled-binary mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bundled and home-scoped workflows are discovered and shown even when no project is selected.

* **Bug Fixes**
  * API returns bundled/home workflows on first run when no project is registered.
  * Workflow list empty-state message now varies based on whether a project is selected.

* **Tests**
  * Added tests for discovery and API behavior in no-project context.

* **Documentation**
  * API reference and changelog updated to reflect discovery behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1618)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->