### PR TITLE
feat(harness): WO-HARNESS-BDC-DOCTRINE-UPDATE-YAML-01 — add doctrine-update workflow YAML

### DIFF
--- a/.archon/workflows/defaults/bdc-doctrine-update.yaml
+++ b/.archon/workflows/defaults/bdc-doctrine-update.yaml
@@ -1,0 +1,246 @@
+name: bdc-doctrine-update
+description: |
+  Use when: Executing a BDC doctrine-class Work Order from an approved spec.
+  Input: WO_ID in the environment or user message, plus repo context from Overlord.
+  Does: Reads the BDC WO spec, plans surgical doctrine edits, verifies via grep, commits and pushes directly to master, and builds a Captain CI manifest.
+  NOT for: Code-shipping WOs, feature development, infrastructure deploys, or bug-fix WOs with their own workflow.
+
+policyFile: BDC_XO/harness/policies/agent-behavior.md
+model: claude-sonnet-4-5
+
+nodes:
+  - id: read-spec
+    bash: |
+      set -euo pipefail
+      WO_ID="${WO_ID:-}"
+      if [ -z "$WO_ID" ]; then
+        WO_ID=$(printf '%s\n' "$USER_MESSAGE" | grep -Eo 'WO-[A-Z0-9-]+' | head -n 1 || true)
+      fi
+      if [ -z "$WO_ID" ]; then
+        echo "WO_ID missing. Provide WO_ID in environment or user message." >&2
+        exit 1
+      fi
+      SPEC_PATH="BDC_XO/docs/superpowers/specs/${WO_ID}.md"
+      if [ ! -f "$SPEC_PATH" ]; then
+        echo "Spec not found: $SPEC_PATH" >&2
+        exit 1
+      fi
+      printf 'WO_ID=%s\nSPEC_PATH=%s\n\n' "$WO_ID" "$SPEC_PATH"
+      cat "$SPEC_PATH"
+
+  - id: post-started
+    depends_on: [read-spec]
+    bash: |
+      set -euo pipefail
+      WO_ID=$(printf '%s\n' "$read-spec.output" | sed -n 's/^WO_ID=//p' | head -n 1)
+      curl -sS -X POST "https://n8n.bluedevilcollectibles.com/webhook/builder-status" \
+        -H "Content-Type: application/json" \
+        -d "{\"action\":\"started\",\"wo_id\":\"${WO_ID}\",\"builder\":\"Major Build\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}"
+
+  - id: plan
+    depends_on: [read-spec]
+    task_class: medium_work
+    prompt: |
+      Read the BDC doctrine Work Order spec below and produce a concise implementation plan.
+
+      ## Required Output
+      Return structured Markdown with these headings:
+      - WO ID
+      - Files to modify
+      - Files to create
+      - Files explicitly out of scope
+      - Grep verification checks (assertions to run on each modified file)
+      - Commit message
+      - Push policy
+
+      ## Doctrine WO Policy
+      Hardcoded Rule: doctrine-only WOs push directly to master. No feature branch. No PR gate.
+      This includes edits to: CLAUDE.md, skills, memory, wiki, policies, README, ATTRIBUTION.
+
+      ## Spec
+      $read-spec.output
+
+  - id: implement
+    depends_on: [plan]
+    task_class: medium_work
+    model: opus[1m]
+    loop:
+      prompt: |
+        Implement the approved plan for this BDC doctrine Work Order.
+
+        ## Spec
+        $read-spec.output
+
+        ## Plan
+        $plan.output
+
+        ## Execution Rules
+        - Modify only the files identified as in scope by the spec.
+        - Preserve all unrelated content; never reformat files outside the target edits.
+        - Do not deploy.
+        - Do not bypass approval gates.
+        - Stop and report a blocker if the spec is ambiguous or a needed source of truth is missing.
+
+        ## Completion Criteria
+        Output <promise>COMPLETE</promise> only when all spec stop conditions that can be run in this checkout have passed, or when a true blocker is identified with evidence.
+      until: COMPLETE
+      max_iterations: 3
+      fresh_context: true
+
+  - id: verify-greps
+    depends_on: [implement]
+    bash: |
+      set -euo pipefail
+      echo "Running grep verification checks on doctrine edits..."
+      # Extract grep checks from plan output
+      # Format: each line starting with "grep:" is a check
+      CHECKS=$(printf '%s\n' "$plan.output" | sed -n '/## Grep verification checks/,/^##/p' | sed '1d;$d' | grep -v '^$' || true)
+      if [ -z "$CHECKS" ]; then
+        echo "No grep checks defined in plan; skipping detailed verification."
+        exit 0
+      fi
+      FAILED=0
+      while IFS= read -r CHECK; do
+        if [ -z "$CHECK" ]; then
+          continue
+        fi
+        echo "Checking: $CHECK"
+        if eval "$CHECK"; then
+          echo "  PASS"
+        else
+          echo "  FAIL"
+          FAILED=$((FAILED + 1))
+        fi
+      done <<EOF
+      $CHECKS
+      EOF
+      if [ "$FAILED" -gt 0 ]; then
+        echo "Grep verification failed on $FAILED check(s)." >&2
+        exit 1
+      fi
+      echo "All grep checks passed."
+
+  - id: decide-push-target
+    depends_on: [verify-greps]
+    task_class: clerical
+    prompt: |
+      Confirm the push target for this BDC doctrine Work Order.
+
+      ## Inputs
+      Spec:
+      $read-spec.output
+
+      ## Doctrine WO Policy (LOCKED)
+      All doctrine-only Work Orders push directly to master.
+      No feature branch. No staging gate. No PR.
+
+      ## Required Output
+      Return:
+      push_target: master
+      pr_required: false
+
+  - id: commit-and-push
+    depends_on: [decide-push-target]
+    bash: |
+      set -euo pipefail
+      echo "$decide-push-target.output"
+      # Verify master direct decision
+      if ! printf '%s\n' "$decide-push-target.output" | grep -q '^push_target: master'; then
+        echo "Push target was not 'master direct'; this workflow applies only to doctrine WOs." >&2
+        exit 1
+      fi
+      # Get current branch (should be main or master depending on repo default)
+      CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+      echo "Currently on branch: $CURRENT_BRANCH"
+
+      git status --short
+      CHANGED_FILES=$(git status --porcelain | awk '{print substr($0,4)}')
+      if [ -z "$CHANGED_FILES" ]; then
+        echo "No changed files found; cannot commit." >&2
+        exit 1
+      fi
+
+      # Verify all changed files are in the plan
+      while IFS= read -r path; do
+        if [ -z "$path" ]; then
+          continue
+        fi
+        if ! printf '%s\n' "$plan.output" | grep -F -- "$path" >/dev/null; then
+          echo "Changed file was not listed in plan output: $path" >&2
+          exit 1
+        fi
+        git add -- "$path"
+      done <<EOF
+      $CHANGED_FILES
+      EOF
+
+      if git diff --cached --quiet; then
+        echo "No changes staged; cannot commit." >&2
+        exit 1
+      fi
+
+      COMMIT_MESSAGE=$(printf '%s\n' "$plan.output" | sed -n 's/^Commit message: //p' | head -n 1)
+      if [ -z "$COMMIT_MESSAGE" ]; then
+        WO_ID=$(printf '%s\n' "$read-spec.output" | sed -n 's/^WO_ID=//p' | head -n 1)
+        COMMIT_MESSAGE="docs(doctrine): ${WO_ID}"
+      fi
+
+      git commit -m "$COMMIT_MESSAGE"
+      git push origin "$CURRENT_BRANCH"
+
+  - id: build-manifest
+    depends_on: [commit-and-push]
+    task_class: clerical
+    prompt: |
+      Construct the Captain CI completion manifest for this BDC doctrine Work Order.
+
+      ## Inputs
+      Spec:
+      $read-spec.output
+
+      Plan:
+      $plan.output
+
+      Implementation:
+      $implement.output
+
+      Verification:
+      $verify-greps.output
+
+      ## Required Manifest Fields
+      - WO ID
+      - Files created
+      - Files modified
+      - Grep verification results
+      - Commit SHA
+      - Push target (master direct)
+
+      ## Format
+      Return as a structured block suitable for pasting into the Notion Notes field.
+
+  - id: post-completed
+    depends_on: [build-manifest]
+    bash: |
+      set -euo pipefail
+      WO_ID=$(printf '%s\n' "$read-spec.output" | sed -n 's/^WO_ID=//p' | head -n 1)
+      DETAIL=$(printf '%s\n' "$build-manifest.output" | python -c "import json,sys; print(json.dumps(sys.stdin.read()))")
+      curl -sS -X POST "https://n8n.bluedevilcollectibles.com/webhook/builder-status" \
+        -H "Content-Type: application/json" \
+        -d "{\"action\":\"completed\",\"wo_id\":\"${WO_ID}\",\"builder\":\"Major Build\",\"detail\":${DETAIL}}"
+
+  - id: flip-notion
+    depends_on: [post-completed]
+    task_class: clerical
+    prompt: |
+      Update the Notion Work Order page if Notion MCP is available in this runtime.
+
+      ## Required Notion Changes
+      - Claude Status: REVIEW
+      - Status: Review
+      - Add the Captain CI manifest as a page comment
+
+      ## Manifest
+      $build-manifest.output
+
+      If Notion MCP is not available inside the container, do not invent a workaround.
+      Output a TODO for XO to flip Notion manually with the manifest above.

--- a/.archon/workflows/defaults/bdc-feature-development.yaml
+++ b/.archon/workflows/defaults/bdc-feature-development.yaml
@@ -39,6 +39,7 @@ nodes:
 
   - id: plan
     depends_on: [read-spec]
+    task_class: medium_work
     prompt: |
       Read the BDC Work Order spec below and produce a concise implementation plan.
 
@@ -68,6 +69,7 @@ nodes:
 
   - id: implement
     depends_on: [plan]
+    task_class: medium_work
     model: opus[1m]
     loop:
       prompt: |
@@ -134,6 +136,7 @@ nodes:
 
   - id: war-council-validator
     depends_on: [verify-build, verify-types, verify-tests]
+    task_class: medium_work
     prompt: |
       Invoke or emulate the war-council-validator review for this Work Order.
 
@@ -160,6 +163,7 @@ nodes:
 
   - id: decide-push-target
     depends_on: [war-council-validator]
+    task_class: clerical
     prompt: |
       Decide the push target for this BDC feature Work Order.
 
@@ -237,6 +241,7 @@ nodes:
 
   - id: open-pr-if-needed
     depends_on: [commit-and-push]
+    task_class: clerical
     bash: |
       set -euo pipefail
       if ! printf '%s\n' "$decide-push-target.output" | grep -q '^pr_required: true'; then
@@ -264,6 +269,7 @@ nodes:
 
   - id: build-manifest
     depends_on: [open-pr-if-needed]
+    task_class: clerical
     prompt: |
       Construct the Captain CI completion manifest for this BDC feature Work Order.
 
@@ -314,6 +320,7 @@ nodes:
 
   - id: flip-notion
     depends_on: [post-completed]
+    task_class: clerical
     prompt: |
       Update the Notion Work Order page if Notion MCP is available in this runtime.
 

--- a/.archon/workflows/defaults/bdc-feature-development.yaml
+++ b/.archon/workflows/defaults/bdc-feature-development.yaml
@@ -1,0 +1,329 @@
+name: bdc-feature-development
+description: |
+  Use when: Executing a BDC feature-class Work Order from an approved spec.
+  Input: WO_ID in the environment or user message, plus repo context from Overlord.
+  Does: Reads the BDC WO spec, plans surgical implementation, verifies, commits, pushes, opens PRs, and builds a Captain CI manifest.
+  NOT for: Doctrine-only updates, cleanup sweeps, infrastructure deploys, or bug-fix WOs with their own workflow.
+
+policyFile: BDC_XO/harness/policies/agent-behavior.md
+model: claude-sonnet-4-5
+
+nodes:
+  - id: read-spec
+    bash: |
+      set -euo pipefail
+      WO_ID="${WO_ID:-}"
+      if [ -z "$WO_ID" ]; then
+        WO_ID=$(printf '%s\n' "$USER_MESSAGE" | grep -Eo 'WO-[A-Z0-9-]+' | head -n 1 || true)
+      fi
+      if [ -z "$WO_ID" ]; then
+        echo "WO_ID missing. Provide WO_ID in environment or user message." >&2
+        exit 1
+      fi
+      SPEC_PATH="BDC_XO/docs/superpowers/specs/${WO_ID}.md"
+      if [ ! -f "$SPEC_PATH" ]; then
+        echo "Spec not found: $SPEC_PATH" >&2
+        exit 1
+      fi
+      printf 'WO_ID=%s\nSPEC_PATH=%s\n\n' "$WO_ID" "$SPEC_PATH"
+      cat "$SPEC_PATH"
+
+  - id: post-started
+    depends_on: [read-spec]
+    bash: |
+      set -euo pipefail
+      WO_ID=$(printf '%s\n' "$read-spec.output" | sed -n 's/^WO_ID=//p' | head -n 1)
+      curl -sS -X POST "https://n8n.bluedevilcollectibles.com/webhook/builder-status" \
+        -H "Content-Type: application/json" \
+        -d "{\"action\":\"started\",\"wo_id\":\"${WO_ID}\",\"builder\":\"Major Build\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}"
+
+  - id: plan
+    depends_on: [read-spec]
+    prompt: |
+      Read the BDC Work Order spec below and produce a concise implementation plan.
+
+      ## Required Output
+      Return structured Markdown with these headings:
+      - WO ID
+      - Files to modify
+      - Files to create
+      - Files explicitly out of scope
+      - Verification commands
+      - Commit message
+      - Push policy
+      - Staging gate required
+
+      ## BDC Push Policy
+      Hardcoded Rule 20 staging-gate repos:
+      - bluedevilcollectibles/lspro-react
+      - bluedevilcollectibles/shopops-storefront
+      - bluedevilcollectibles/shopops/
+
+      For those repos, use a feature branch plus PR and require the staging gate.
+      For bdc-xo non-doctrine code and any other repo, use feature branch plus PR without staging gate.
+      Doc-only and doctrine-only WOs are out of scope for this workflow.
+
+      ## Spec
+      $read-spec.output
+
+  - id: implement
+    depends_on: [plan]
+    model: opus[1m]
+    loop:
+      prompt: |
+        Implement the approved plan for this BDC feature Work Order.
+
+        ## Spec
+        $read-spec.output
+
+        ## Plan
+        $plan.output
+
+        ## Execution Rules
+        - Modify only the files identified as in scope by the spec.
+        - Prefer existing repo patterns and helpers.
+        - Do not reformat unrelated code.
+        - Do not deploy.
+        - Do not bypass approval gates.
+        - Stop and report a blocker if the spec is ambiguous or a needed source of truth is missing.
+
+        ## Completion Criteria
+        Output <promise>COMPLETE</promise> only when all spec stop conditions that can be run in this checkout have passed, or when a true blocker is identified with evidence.
+      until: COMPLETE
+      max_iterations: 5
+      fresh_context: true
+
+  - id: verify-build
+    depends_on: [implement]
+    bash: |
+      set -euo pipefail
+      if [ -f package.json ]; then
+        if node -e "const p=require('./package.json'); process.exit(p.scripts && p.scripts.build ? 0 : 1)"; then
+          npm run build
+        else
+          echo "No npm build script; skipping build."
+        fi
+      elif [ -f tests/run_all.js ]; then
+        node tests/run_all.js
+      else
+        echo "No recognized build command; record as not applicable in manifest."
+      fi
+
+  - id: verify-types
+    depends_on: [implement]
+    bash: |
+      set -euo pipefail
+      if [ -f tsconfig.json ]; then
+        npx tsc --noEmit
+      else
+        echo "No tsconfig.json; skipping TypeScript check."
+      fi
+
+  - id: verify-tests
+    depends_on: [implement]
+    bash: |
+      set -euo pipefail
+      if [ -f package.json ] && node -e "const p=require('./package.json'); process.exit(p.scripts && p.scripts.test ? 0 : 1)"; then
+        npm test
+      elif find . -path ./.git -prune -o \( -name '*test*' -o -name '*spec*' \) -type f -print -quit | grep -q .; then
+        echo "Test files detected but no npm test script was found." >&2
+        exit 1
+      else
+        echo "No test files detected; record as not applicable in manifest."
+      fi
+
+  - id: war-council-validator
+    depends_on: [verify-build, verify-types, verify-tests]
+    prompt: |
+      Invoke or emulate the war-council-validator review for this Work Order.
+
+      ## Validator Agent
+      war-council-validator
+
+      ## Inputs
+      Spec:
+      $read-spec.output
+
+      Plan:
+      $plan.output
+
+      Implementation output:
+      $implement.output
+
+      Git diff:
+      Run `git diff --stat` and `git diff --check`, then inspect the relevant changed files.
+
+      ## Required Output
+      Return either:
+      - satisfied: with evidence that the spec deliverables and stop conditions were met
+      - needs_revision: with exact file/path/behavior findings
+
+  - id: decide-push-target
+    depends_on: [war-council-validator]
+    prompt: |
+      Decide the push target for this BDC feature Work Order.
+
+      ## Inputs
+      Spec:
+      $read-spec.output
+
+      Validator:
+      $war-council-validator.output
+
+      ## Required Repo Policy
+      Read the git remote URL and match it against this hardcoded staging-gate list:
+      - bluedevilcollectibles/lspro-react
+      - bluedevilcollectibles/shopops-storefront
+      - bluedevilcollectibles/shopops/
+
+      If the repo matches one of those entries, output:
+      push_target: feature-branch:<spec-derived-branch-name>
+      pr_required: true
+      staging_gate_required: true
+
+      If the repo is bdc-xo non-doctrine code or another code repo, output:
+      push_target: feature-branch:<spec-derived-branch-name>
+      pr_required: true
+      staging_gate_required: false
+
+      If this is doc-only or doctrine-only, output:
+      out_of_scope: true
+      reason: use bdc-doctrine-update.yaml
+
+  - id: commit-and-push
+    depends_on: [decide-push-target]
+    bash: |
+      set -euo pipefail
+      echo "$decide-push-target.output"
+      if printf '%s\n' "$decide-push-target.output" | grep -q '^out_of_scope: true'; then
+        echo "Out of scope for bdc-feature-development; failing closed." >&2
+        exit 1
+      fi
+      BRANCH=$(printf '%s\n' "$decide-push-target.output" | sed -n 's/^push_target: feature-branch://p' | head -n 1)
+      if [ -z "$BRANCH" ]; then
+        echo "No feature branch target found in decide-push-target output." >&2
+        exit 1
+      fi
+      git checkout -B "$BRANCH"
+      git status --short
+      CHANGED_FILES=$(git status --porcelain | awk '{print substr($0,4)}')
+      if [ -z "$CHANGED_FILES" ]; then
+        echo "No changed files found; cannot commit." >&2
+        exit 1
+      fi
+      while IFS= read -r path; do
+        if [ -z "$path" ]; then
+          continue
+        fi
+        if ! printf '%s\n' "$plan.output" | grep -F -- "$path" >/dev/null; then
+          echo "Changed file was not listed in plan output: $path" >&2
+          exit 1
+        fi
+        git add -- "$path"
+      done <<EOF
+      $CHANGED_FILES
+      EOF
+      if git diff --cached --quiet; then
+        echo "No changes staged; cannot commit." >&2
+        exit 1
+      fi
+      COMMIT_MESSAGE=$(printf '%s\n' "$plan.output" | sed -n 's/^Commit message: //p' | head -n 1)
+      if [ -z "$COMMIT_MESSAGE" ]; then
+        WO_ID=$(printf '%s\n' "$read-spec.output" | sed -n 's/^WO_ID=//p' | head -n 1)
+        COMMIT_MESSAGE="feat: ${WO_ID} implementation"
+      fi
+      git commit -m "$COMMIT_MESSAGE"
+      git push -u origin "$BRANCH"
+
+  - id: open-pr-if-needed
+    depends_on: [commit-and-push]
+    bash: |
+      set -euo pipefail
+      if ! printf '%s\n' "$decide-push-target.output" | grep -q '^pr_required: true'; then
+        echo "PR not required; skipping."
+        exit 0
+      fi
+      TITLE=$(printf '%s\n' "$plan.output" | sed -n 's/^Commit message: //p' | head -n 1)
+      if [ -z "$TITLE" ]; then
+        TITLE="BDC feature Work Order implementation"
+      fi
+      BODY_FILE=$(mktemp)
+      {
+        echo "## Summary"
+        echo "$plan.output"
+        echo
+        echo "## Validation"
+        echo "$verify-build.output"
+        echo "$verify-types.output"
+        echo "$verify-tests.output"
+        echo
+        echo "## Validator"
+        echo "$war-council-validator.output"
+      } > "$BODY_FILE"
+      gh pr create --title "$TITLE" --body-file "$BODY_FILE"
+
+  - id: build-manifest
+    depends_on: [open-pr-if-needed]
+    prompt: |
+      Construct the Captain CI completion manifest for this BDC feature Work Order.
+
+      ## Inputs
+      Spec:
+      $read-spec.output
+
+      Plan:
+      $plan.output
+
+      Implementation:
+      $implement.output
+
+      Verification:
+      Build:
+      $verify-build.output
+
+      Types:
+      $verify-types.output
+
+      Tests:
+      $verify-tests.output
+
+      Validator:
+      $war-council-validator.output
+
+      ## Required Manifest Fields
+      - WO ID
+      - Files created
+      - Files modified
+      - Routes added
+      - Migrations
+      - Tests
+      - Commit SHA
+      - Validation evidence by WO class
+      - PR URL, if opened
+      - Staging gate status, if required
+
+  - id: post-completed
+    depends_on: [build-manifest]
+    bash: |
+      set -euo pipefail
+      WO_ID=$(printf '%s\n' "$read-spec.output" | sed -n 's/^WO_ID=//p' | head -n 1)
+      DETAIL=$(printf '%s\n' "$build-manifest.output" | python -c "import json,sys; print(json.dumps(sys.stdin.read()))")
+      curl -sS -X POST "https://n8n.bluedevilcollectibles.com/webhook/builder-status" \
+        -H "Content-Type: application/json" \
+        -d "{\"action\":\"completed\",\"wo_id\":\"${WO_ID}\",\"builder\":\"Major Build\",\"detail\":${DETAIL}}"
+
+  - id: flip-notion
+    depends_on: [post-completed]
+    prompt: |
+      Update the Notion Work Order page if Notion MCP is available in this runtime.
+
+      ## Required Notion Changes
+      - Claude Status: REVIEW
+      - Status: Review
+      - Add the Captain CI manifest as a page comment
+
+      ## Manifest
+      $build-manifest.output
+
+      If Notion MCP is not available inside the container, do not invent a workaround.
+      Output a TODO for XO to flip Notion manually with the manifest above.

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -9,6 +9,8 @@ Fork point: `f4f27255` (coleam00/Archon dev branch, 2026-05-09)
 - `packages/workflows/src/executor-shared.ts`: added `${run.id}` substitution in bash blocks
 - `packages/workflows/src/schemas/loop.ts`: changed `fresh_context` default from `false` to `true`
 - `packages/workflows/src/executor.ts`: added `claude-sonnet-4-5` as fallback model default
+- `packages/workflows/src/executor.ts`: added `policyFile` workflow field for BDC doctrine policy loading
+- `packages/workflows/src/dag-executor.ts`: forwards policy-loaded `systemPrompt` to loop nodes
 - `README.md`: rebranded to bdc-harness, credited upstream
 
 ## Original license

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -1,0 +1,16 @@
+# Attribution
+
+bdc-harness is a fork of [coleam00/Archon](https://github.com/coleam00/Archon), used under the MIT License.
+
+Fork point: `f4f27255` (coleam00/Archon dev branch, 2026-05-09)
+
+## BDC-specific changes
+
+- `packages/workflows/src/executor-shared.ts`: added `${run.id}` substitution in bash blocks
+- `packages/workflows/src/schemas/loop.ts`: changed `fresh_context` default from `false` to `true`
+- `packages/workflows/src/executor.ts`: added `claude-sonnet-4-5` as fallback model default
+- `README.md`: rebranded to bdc-harness, credited upstream
+
+## Original license
+
+MIT License — Copyright (c) coleam00. Full license text: [LICENSE](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
   <img src="assets/logo.png" alt="Archon" width="160" />
 </p>
 
-<h1 align="center">Archon</h1>
+<h1 align="center">bdc-harness</h1>
 
 <p align="center">
-  The first open-source harness builder for AI coding. Make AI coding deterministic and repeatable.
+  Blue Devil Collectibles' AI build harness. Forked from <a href="https://github.com/coleam00/Archon">coleam00/Archon</a> (MIT).
+  BDC-specific extensions: ${run.id} substitution fix, fresh_context default, sonnet model default.
 </p>
 
 <p align="center">

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -3182,6 +3182,50 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       });
     });
 
+    it('passes loop node systemPrompt to the agent provider', async () => {
+      mockSendQueryDag.mockImplementation(function* () {
+        yield { type: 'assistant', content: 'Did the task. <promise>COMPLETE</promise>' };
+        yield { type: 'result', sessionId: 'loop-session-1' };
+      });
+
+      const mockDeps = createMockDeps();
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun();
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        {
+          name: 'dag-loop-system-prompt',
+          nodes: [
+            {
+              id: 'my-loop',
+              systemPrompt: 'TEST POLICY CONTENT',
+              loop: {
+                prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
+                until: 'COMPLETE',
+                max_iterations: 5,
+              },
+            },
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      expect(mockSendQueryDag.mock.calls.length).toBe(1);
+      const options = mockSendQueryDag.mock.calls[0][3] as { systemPrompt?: string };
+      expect(options.systemPrompt).toBe('TEST POLICY CONTENT');
+    });
+
     it('completes after multiple iterations', async () => {
       let callCount = 0;
       mockSendQueryDag.mockImplementation(function* () {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1692,6 +1692,7 @@ async function executeScriptNode(
  * Uses the same nodeConfig + assistantConfig pattern as resolveNodeProviderAndModel.
  */
 function buildLoopNodeOptions(
+  node: LoopNode,
   provider: string,
   model: string | undefined,
   config: WorkflowConfig,
@@ -1702,6 +1703,7 @@ function buildLoopNodeOptions(
   if (config.envVars && Object.keys(config.envVars).length > 0) {
     options.env = config.envVars;
   }
+  if (node.systemPrompt !== undefined) options.systemPrompt = node.systemPrompt;
   options.assistantConfig = config.assistants[provider] ?? {};
   // Pass workflow-level options as nodeConfig so providers can apply them
   if (workflowLevelOptions) {
@@ -1774,6 +1776,7 @@ async function executeLoopNode(
   let loopFinalStopReason: string | undefined;
   let loopTotalNumTurns: number | undefined;
   const resolvedOptions = buildLoopNodeOptions(
+    node,
     workflowProvider,
     workflowModel,
     config,

--- a/packages/workflows/src/executor-shared.ts
+++ b/packages/workflows/src/executor-shared.ts
@@ -388,6 +388,7 @@ export function substituteWorkflowVariables(
   // Substitute basic variables
   let result = prompt
     .replace(/\$WORKFLOW_ID/g, workflowId)
+    .replace(/\$\{run\.id\}/g, workflowId)
     .replace(/\$USER_MESSAGE/g, userMessage)
     .replace(/\$ARGUMENTS/g, userMessage)
     .replace(/\$ARTIFACTS_DIR/g, artifactsDir)

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -4,6 +4,9 @@
  * that the inner dag-executor.test.ts cannot reach.
  */
 import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 // --- Mock logger ---
 const mockLogFn = mock(() => {});
@@ -132,6 +135,10 @@ function makeRun(overrides: Partial<WorkflowRun> = {}): WorkflowRun {
     metadata: {},
     ...overrides,
   };
+}
+
+function getExecutedWorkflow(): WorkflowDefinition {
+  return mockExecuteDagWorkflow.mock.calls[0]?.[4] as WorkflowDefinition;
 }
 
 describe('executeWorkflow', () => {
@@ -707,6 +714,125 @@ describe('executeWorkflow', () => {
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.summary).toBeUndefined();
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // policyFile
+  // -------------------------------------------------------------------------
+
+  describe('policyFile', () => {
+    it('loads policyFile content into prompt node systemPrompt', async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'archon-policy-'));
+      try {
+        await writeFile(join(cwd, 'policy.md'), 'TEST POLICY CONTENT');
+        const deps = makeDeps();
+
+        const result = await executeWorkflow(
+          deps,
+          makePlatform(),
+          'conv-1',
+          cwd,
+          makeWorkflow({
+            policyFile: 'policy.md',
+            nodes: [
+              { id: 'node1', prompt: 'Do something' },
+              { id: 'loop1', loop: { prompt: 'Iterate', until: 'DONE', max_iterations: 2 } },
+            ],
+          }),
+          'test',
+          'db-conv-1'
+        );
+
+        expect(result.success).toBe(true);
+        expect(mockExecuteDagWorkflow).toHaveBeenCalledTimes(1);
+        const executedWorkflow = getExecutedWorkflow();
+        expect(executedWorkflow.nodes[0]).toMatchObject({
+          systemPrompt: 'TEST POLICY CONTENT',
+        });
+        expect(executedWorkflow.nodes[1]).toMatchObject({
+          systemPrompt: 'TEST POLICY CONTENT',
+        });
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    });
+
+    it('fails closed when policyFile is missing', async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'archon-policy-'));
+      try {
+        const deps = makeDeps();
+
+        const result = await executeWorkflow(
+          deps,
+          makePlatform(),
+          'conv-1',
+          cwd,
+          makeWorkflow({ policyFile: 'missing-policy.md' }),
+          'test',
+          'db-conv-1'
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('policyFile not found');
+        expect(mockExecuteDagWorkflow).not.toHaveBeenCalled();
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    });
+
+    it('fails closed when policyFile is empty', async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'archon-policy-'));
+      try {
+        await writeFile(join(cwd, 'empty-policy.md'), '');
+        const deps = makeDeps();
+
+        const result = await executeWorkflow(
+          deps,
+          makePlatform(),
+          'conv-1',
+          cwd,
+          makeWorkflow({ policyFile: 'empty-policy.md' }),
+          'test',
+          'db-conv-1'
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('policyFile is empty');
+        expect(mockExecuteDagWorkflow).not.toHaveBeenCalled();
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    });
+
+    it('prepends policyFile content before an existing prompt node systemPrompt', async () => {
+      const cwd = await mkdtemp(join(tmpdir(), 'archon-policy-'));
+      try {
+        await writeFile(join(cwd, 'policy.md'), 'TEST POLICY CONTENT');
+        const deps = makeDeps();
+
+        const result = await executeWorkflow(
+          deps,
+          makePlatform(),
+          'conv-1',
+          cwd,
+          makeWorkflow({
+            policyFile: 'policy.md',
+            nodes: [{ id: 'node1', prompt: 'Do something', systemPrompt: 'NODE-SPECIFIC' }],
+          }),
+          'test',
+          'db-conv-1'
+        );
+
+        expect(result.success).toBe(true);
+        expect(mockExecuteDagWorkflow).toHaveBeenCalledTimes(1);
+        const executedWorkflow = getExecutedWorkflow();
+        expect(executedWorkflow.nodes[0]).toMatchObject({
+          systemPrompt: 'TEST POLICY CONTENT\n\nNODE-SPECIFIC',
+        });
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
       }
     });
   });

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -290,7 +290,7 @@ export async function executeWorkflow(
     );
   }
   const assistantDefaults = config.assistants[resolvedProvider];
-  const resolvedModel = workflow.model ?? (assistantDefaults?.model as string | undefined);
+  const resolvedModel = workflow.model ?? (assistantDefaults?.model as string | undefined) ?? "claude-sonnet-4-5";
 
   getLog().info(
     {

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -1,8 +1,8 @@
 /**
  * Workflow Executor - runs DAG-based workflows
  */
-import { mkdir } from 'fs/promises';
-import { join } from 'path';
+import { mkdir, readFile } from 'fs/promises';
+import { join, resolve } from 'path';
 import type { IWorkflowPlatform, WorkflowMessageMetadata } from './deps';
 import type { WorkflowDeps, WorkflowConfig } from './deps';
 import * as archonPaths from '@archon/paths';
@@ -210,6 +210,46 @@ async function resolveProjectPaths(
   };
 }
 
+async function applyWorkflowPolicyFile(
+  workflow: WorkflowDefinition,
+  cwd: string
+): Promise<WorkflowDefinition> {
+  if (!workflow.policyFile) {
+    return workflow;
+  }
+
+  const policyPath = resolve(cwd, workflow.policyFile);
+  let policyContent: string;
+  try {
+    policyContent = await readFile(policyPath, 'utf-8');
+  } catch {
+    throw new Error(`policyFile not found: ${workflow.policyFile} (resolved to ${policyPath})`);
+  }
+
+  if (!policyContent.trim()) {
+    throw new Error(`policyFile is empty: ${workflow.policyFile}`);
+  }
+
+  return {
+    ...workflow,
+    nodes: workflow.nodes.map(node => {
+      const isAiPromptNode =
+        ('prompt' in node && node.prompt !== undefined) ||
+        ('loop' in node && node.loop !== undefined);
+      if (!isAiPromptNode) {
+        return node;
+      }
+
+      return {
+        ...node,
+        systemPrompt: node.systemPrompt
+          ? `${policyContent}\n\n${node.systemPrompt}`
+          : policyContent,
+      };
+    }),
+  };
+}
+
 /**
  * Execute a complete DAG-based workflow.
  *
@@ -290,7 +330,8 @@ export async function executeWorkflow(
     );
   }
   const assistantDefaults = config.assistants[resolvedProvider];
-  const resolvedModel = workflow.model ?? (assistantDefaults?.model as string | undefined) ?? "claude-sonnet-4-5";
+  const resolvedModel =
+    workflow.model ?? (assistantDefaults?.model as string | undefined) ?? 'claude-sonnet-4-5';
 
   getLog().info(
     {
@@ -597,16 +638,19 @@ export async function executeWorkflow(
 
   // Wrap execution in try-catch to ensure workflow is marked as failed on any error
   try {
+    // BDC patch: load policyFile if specified and inject as systemPrompt for all prompt nodes.
+    const executableWorkflow = await applyWorkflowPolicyFile(workflow, cwd);
+
     getLog().info(
       {
-        workflowName: workflow.name,
+        workflowName: executableWorkflow.name,
         workflowRunId: workflowRun.id,
         hasIssueContext: !!issueContext,
         issueContextLength: issueContext?.length ?? 0,
       },
       'workflow_starting'
     );
-    await logWorkflowStart(logDir, workflowRun.id, workflow.name, userMessage);
+    await logWorkflowStart(logDir, workflowRun.id, executableWorkflow.name, userMessage);
 
     // Register run with emitter and emit workflow_started
     const emitter = getWorkflowEventEmitter();
@@ -615,7 +659,7 @@ export async function executeWorkflow(
     emitter.emit({
       type: 'workflow_started',
       runId: workflowRun.id,
-      workflowName: workflow.name,
+      workflowName: executableWorkflow.name,
       conversationId: conversationDbId,
     });
 
@@ -623,8 +667,8 @@ export async function executeWorkflow(
     // description (authored by the user in their YAML) + platform + version.
     // Opt out via ARCHON_TELEMETRY_DISABLED=1 or DO_NOT_TRACK=1.
     captureWorkflowInvoked({
-      workflowName: workflow.name,
-      workflowDescription: workflow.description,
+      workflowName: executableWorkflow.name,
+      workflowDescription: executableWorkflow.description,
       platform: platform.getPlatformType(),
       archonVersion: BUNDLED_VERSION,
     });
@@ -632,7 +676,7 @@ export async function executeWorkflow(
       .createWorkflowEvent({
         workflow_run_id: workflowRun.id,
         event_type: 'workflow_started',
-        data: { workflowName: workflow.name },
+        data: { workflowName: executableWorkflow.name },
       })
       .catch((err: Error) => {
         getLog().error(
@@ -701,7 +745,7 @@ export async function executeWorkflow(
 
     // Add workflow start message (step details omitted from text notification)
     // Strip routing metadata from description (Use when:, Handles:, NOT for:, Capability:, Triggers:)
-    const cleanDescription = (workflow.description ?? '')
+    const cleanDescription = (executableWorkflow.description ?? '')
       .split('\n')
       .filter(
         line =>
@@ -709,8 +753,8 @@ export async function executeWorkflow(
       )
       .join('\n')
       .trim();
-    const descriptionText = cleanDescription || workflow.name;
-    startupMessage += `🚀 **Starting workflow**: \`${workflow.name}\`\n\n> ${descriptionText}`;
+    const descriptionText = cleanDescription || executableWorkflow.name;
+    startupMessage += `🚀 **Starting workflow**: \`${executableWorkflow.name}\`\n\n> ${descriptionText}`;
 
     // Send consolidated message - use critical send with limited retries (1 retry max)
     // to avoid blocking workflow execution while still catching transient failures
@@ -736,7 +780,7 @@ export async function executeWorkflow(
       platform,
       conversationId,
       cwd,
-      workflow,
+      executableWorkflow,
       workflowRun,
       resolvedProvider,
       resolvedModel,

--- a/packages/workflows/src/schemas.test.ts
+++ b/packages/workflows/src/schemas.test.ts
@@ -9,6 +9,7 @@ import {
   LOOP_NODE_AI_FIELDS,
   approvalOnRejectSchema,
   dagNodeSchema,
+  workflowDefinitionSchema,
 } from './schemas';
 import type {
   WorkflowDefinition,
@@ -35,6 +36,26 @@ const dagWorkflow: WorkflowDefinition = {
   description: 'DAG execution',
   nodes: [commandNode, promptNode, bashNode],
 };
+
+// ---------------------------------------------------------------------------
+// workflowDefinitionSchema
+// ---------------------------------------------------------------------------
+
+describe('workflowDefinitionSchema', () => {
+  test('accepts policyFile on workflow definitions', () => {
+    const result = workflowDefinitionSchema.safeParse({
+      name: 'policy-workflow',
+      description: 'Policy workflow',
+      policyFile: '/tmp/test-policy.md',
+      nodes: [{ id: 'node1', prompt: 'Do something' }],
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.policyFile).toBe('/tmp/test-policy.md');
+    }
+  });
+});
 
 // ---------------------------------------------------------------------------
 // isBashNode

--- a/packages/workflows/src/schemas/loop.ts
+++ b/packages/workflows/src/schemas/loop.ts
@@ -11,8 +11,8 @@ export const loopNodeConfigSchema = z
     until: z.string().min(1, "loop node requires 'loop.until' (completion signal string)"),
     /** Maximum iterations allowed; exceeding this fails the node. */
     max_iterations: z.number().int().positive("'loop.max_iterations' must be a positive integer"),
-    /** Whether to start fresh session each iteration (default: false). */
-    fresh_context: z.boolean().default(false),
+    /** Whether to start fresh session each iteration (default: true). */
+    fresh_context: z.boolean().default(true),
     /** Optional bash script run after each iteration; exit 0 = complete. */
     until_bash: z.string().optional(),
     /** When true, pause between iterations for user input via /workflow approve. */

--- a/packages/workflows/src/schemas/workflow.ts
+++ b/packages/workflows/src/schemas/workflow.ts
@@ -68,6 +68,8 @@ export const workflowBaseSchema = z.object({
   betas: z.array(z.string().min(1)).nonempty("'betas' must be a non-empty array").optional(),
   sandbox: sandboxSettingsSchema.optional(),
   worktree: workflowWorktreePolicySchema.optional(),
+  /** Path to file whose content is loaded as systemPrompt for all prompt nodes. BDC patch. */
+  policyFile: z.string().optional(),
   /**
    * When `false`, the engine skips the path-exclusive lock for this workflow,
    * allowing N concurrent runs on the same live checkout. The author asserts


### PR DESCRIPTION
## Summary

Add bdc-doctrine-update.yaml — sister workflow to bdc-feature-development.yaml, specialized for BDC doctrine-only WOs (CLAUDE.md edits, skills, memory, policies).

**Key Differences from Feature Development:**
- Push policy: master direct (no feature branch, no PR gate)
- No build/type-check/test loop (doctrine is markdown, not code)
- Manifest: file-presence + grep checks instead of test counts

**Nodes:**
1. read-spec — Extract WO spec
2. post-started — Builder status webhook
3. plan — Identify files and grep checks
4. implement — Apply doctrine edits (loop, max 3 iterations)
5. verify-greps — Run grep assertions
6. decide-push-target — Confirm 'master direct'
7. commit-and-push — Push directly to master
8. build-manifest — Captain CI manifest
9. post-completed — Webhook notification
10. flip-notion — Update Notion WO status

**Validation:**
- SC-1: YAML parses ✓
- SC-2: Discoverable workflow name ✓
- SC-3: Push target hardcoded to master ✓
- SC-4: task_class on all LLM nodes ✓
- SC-5: policyFile at root ✓
- SC-6: Git commit with WO-ID ✓

Closes #WO-HARNESS-BDC-DOCTRINE-UPDATE-YAML-01

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dedicated workflows for BDC doctrine-only and feature-class work orders with end-to-end execution orchestration.
  * Added support for policy files to inject system prompts across workflow nodes.
  * Added `${run.id}` variable substitution support.

* **Improvements**
  * Loop nodes now propagate system prompt settings.
  * Default LLM model updated to Claude Sonnet 4.5.
  * Loop context now defaults to fresh context mode.

* **Documentation**
  * Updated project branding and attribution for BDC-harness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1627)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->