### PR TITLE
chore(ci): bump docker/build-push-action to @v6 in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
             latest=auto
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary

- Problem: `docker/build-push-action` was pinned at `@v5` in `publish.yml` while `test.yml` already used `@v6`, creating an inconsistency. Issue #127 (Dependabot) flagged outdated CI action versions.
- Why it matters: Inconsistent action versions across workflows make CI harder to reason about and may expose the publish pipeline to fixed bugs/CVEs addressed in `@v6`.
- What changed: Bumped `docker/build-push-action` from `@v5` to `@v6` in `.github/workflows/publish.yml` (1-line change).
- What did **not** change: `actions/setup-python` is not present in any workflow file in the current codebase (the Dependabot PR targeted an older version of Archon that used Python in CI directly); no source code was modified.

## UX Journey

### Before

```
CI (publish.yml)         CI (test.yml)
────────────────         ─────────────
docker/build-push-action@v5   docker/build-push-action@v6
        ▲ stale                        ▲ current
```

### After

```
CI (publish.yml)         CI (test.yml)
────────────────         ─────────────
docker/build-push-action@v6   docker/build-push-action@v6
        ▲ consistent                   ▲ consistent
```

## Architecture Diagram

### Before

```
.github/workflows/
├── publish.yml   uses docker/build-push-action@v5   ← stale
└── test.yml      uses docker/build-push-action@v6
```

### After

```
.github/workflows/
├── publish.yml   uses docker/build-push-action@v6   ← [~] bumped
└── test.yml      uses docker/build-push-action@v6
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| publish.yml | docker/build-push-action | **modified** | v5 → v6 |
| test.yml | docker/build-push-action | unchanged | already @v6 |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `ci`
- Module: `ci:publish`

## Change Metadata

- Change type: `chore`
- Primary scope: `ci`

## Linked Issue

- Closes #127

## Validation Evidence (required)

```bash
bun run validate
# All 6 checks passed:
# ✅ check:bundled     — 36 commands, 20 workflows up to date
# ✅ check:bundled-skill — 21 files up to date
# ✅ type-check        — 0 errors across all 10 packages
# ✅ lint              — 0 errors, 0 warnings
# ✅ format:check      — all files formatted
# ✅ test              — 3,533+ tests passed, 0 failed

grep "build-push-action" .github/workflows/*.yml
# .github/workflows/publish.yml:      uses: docker/build-push-action@v6
# .github/workflows/test.yml:         uses: docker/build-push-action@v6

grep -r "setup-python" .github/
# (no output — action is absent from all workflows)
```

- Evidence provided: All checks passed in the worktree.
- No commands intentionally skipped.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — `docker/build-push-action@v6` is a drop-in replacement for `@v5` for the inputs used in this workflow (`context`, `push`, `load`, `tags`, `labels`, `cache-from`, `cache-to`).
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: Confirmed `grep` output shows `@v6` in both workflow files; confirmed `setup-python` is absent from all `.github/` files.
- Edge cases checked: No other workflows reference `build-push-action`; the single occurrence in `publish.yml` is the only change.
- What was not verified: Live CI run (cannot trigger on upstream without merge).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `.github/workflows/publish.yml` only — the Docker image publish pipeline.
- Potential unintended effects: None expected; `@v6` is in active use by `test.yml` without issues.
- Guardrails/monitoring: CI pass/fail on the PR; Docker publish run on merge.

## Rollback Plan (required)

- Fast rollback command/path: Revert the single-line change (`@v6` → `@v5`) in `publish.yml`.
- Feature flags or config toggles: None.
- Observable failure symptoms: Docker image build step fails in the publish workflow; error would be visible in the GitHub Actions run log.

## Risks and Mitigations

- Risk: `docker/build-push-action@v6` introduces a breaking change in an input used by `publish.yml`.
  - Mitigation: `test.yml` already uses `@v6` with the same inputs (`context`, `push`, `load`) without issue. The `publish.yml` inputs (`tags`, `labels`, `cache-from`, `cache-to`) are all stable across v5→v6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Docker image publishing workflow to use the latest build and push action version.
  * Existing image platforms, tags, caching, and push behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->