### PR TITLE
chore: fix broken docs links

### DIFF
--- a/packages/docs-web/src/content/docs/adapters/community/discord.md
+++ b/packages/docs-web/src/content/docs/adapters/community/discord.md
@@ -17,7 +17,7 @@ Connect Archon to Discord so you can interact with your AI coding assistant from
 
 ## Prerequisites
 
-- Archon server running (see [Getting Started](/getting-started/))
+- Archon server running (see [Getting Started](/getting-started/overview/))
 - A Discord account
 - "Manage Server" permission on the Discord server you want to add the bot to
 

--- a/packages/docs-web/src/content/docs/adapters/community/gitea.md
+++ b/packages/docs-web/src/content/docs/adapters/community/gitea.md
@@ -16,7 +16,7 @@ Connect Archon to a self-hosted Gitea instance so you can interact with your AI 
 
 ## Prerequisites
 
-- Archon server running (see [Getting Started](/getting-started/))
+- Archon server running (see [Getting Started](/getting-started/overview/))
 - A Gitea instance with API access enabled
 - A Gitea personal access token (or dedicated bot account token)
 - Public endpoint for webhooks (or a tunnel for local development)

--- a/packages/docs-web/src/content/docs/adapters/github.md
+++ b/packages/docs-web/src/content/docs/adapters/github.md
@@ -13,9 +13,9 @@ Connect Archon to GitHub so you can interact with your AI coding assistant from 
 
 ## Prerequisites
 
-- Archon server running (see [Getting Started](/getting-started/))
+- Archon server running (see [Getting Started](/getting-started/overview/))
 - GitHub repository with issues enabled
-- `GITHUB_TOKEN` set in your environment (see [Getting Started](/getting-started/))
+- `GITHUB_TOKEN` set in your environment (see [Getting Started](/getting-started/overview/))
 - Public endpoint for webhooks (see ngrok setup below for local development)
 
 ## Step 1: Generate Webhook Secret

--- a/packages/docs-web/src/content/docs/adapters/slack.md
+++ b/packages/docs-web/src/content/docs/adapters/slack.md
@@ -13,7 +13,7 @@ Connect Archon to Slack so you can interact with your AI coding assistant from a
 
 ## Prerequisites
 
-- Archon server running (see [Getting Started](/getting-started/))
+- Archon server running (see [Getting Started](/getting-started/overview/))
 - A Slack workspace where you have permission to install apps
 
 ## Overview

--- a/packages/docs-web/src/content/docs/adapters/telegram.md
+++ b/packages/docs-web/src/content/docs/adapters/telegram.md
@@ -13,7 +13,7 @@ Connect Archon to Telegram so you can interact with your AI coding assistant fro
 
 ## Prerequisites
 
-- Archon server running (see [Getting Started](/getting-started/))
+- Archon server running (see [Getting Started](/getting-started/overview/))
 - A Telegram account
 
 ## Create Telegram Bot

--- a/packages/docs-web/src/content/docs/contributing/new-developer-guide.md
+++ b/packages/docs-web/src/content/docs/contributing/new-developer-guide.md
@@ -652,7 +652,7 @@ Each conversation gets its own isolated copy of the repo:
 
 ## Next Steps
 
-1. **Read**: [Getting Started](/getting-started/) - Set up your first instance
+1. **Read**: [Getting Started](/getting-started/overview/) - Set up your first instance
 2. **Explore**: `.archon/workflows/` - See example workflows
 3. **Customize**: `.archon/commands/` - Create your own prompts
 4. **Configure**: `.archon/config.yaml` - Tweak settings


### PR DESCRIPTION
I noticed that the links to the getting started page was broken from the Slack adapters page.
Some other pages were affected too. This PR fixes the broken links.

Before:

```md
[Getting Started](/getting-started/)
```

After:

```md
[Getting Started](/getting-started/overview/)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Getting Started links across adapter documentation (Discord, Gitea, GitHub, Slack, and Telegram) to reference the dedicated overview page for improved user onboarding.
  * Updated developer guide documentation to point to the revised Getting Started overview page.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1633)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->