### PR TITLE
feat(marketplace): add video-generic workflow

### DIFF
--- a/packages/docs-web/src/data/marketplace.ts
+++ b/packages/docs-web/src/data/marketplace.ts
@@ -95,4 +95,16 @@ export const marketplaceEntries: MarketplaceEntry[] = [
     archonVersionCompat: '>=0.3.0',
     featured: true,
   },
+  {
+    slug: 'video-generic',
+    name: 'Video Generic',
+    author: 'coleam00',
+    description:
+      'Turn a freeform prompt (URL, GitHub repo, release notes, topic) into a voiced + animated Remotion video. Three approval gates let you steer the spec, script, and live preview before render. Requires an ElevenLabs API key.',
+    sourceUrl:
+      'https://github.com/leex279/remotion-video-test/tree/4dac83c28d2e4a745b81520343101c402539b84f/.archon',
+    sha: '4dac83c28d2e4a745b81520343101c402539b84f',
+    tags: ['automation'],
+    archonVersionCompat: '>=0.3.0',
+  },
 ];


### PR DESCRIPTION
## Summary

- **Problem:** Marketplace v0 shipped with four seed entries, all sourced from `coleam00/Archon`'s bundled defaults. There was no end-to-end exercise of the **directory-format** install path from an **external** repo.
- **Why it matters:** Directory-install (yaml + `commands/` + `scripts/` fan-out, GitHub Contents API walk, SHA pinning) is the path third-party contributors will actually use. v0 lint and install code exist but haven't been smoke-tested against a real outside repo.
- **What changed:** Adds one entry to `packages/docs-web/src/data/marketplace.ts` for the `video-generic` Remotion workflow at `leex279/remotion-video-test/.archon` @ `4dac83c2`. Tagged `automation`.
- **What did *not* change:** No code, no lint script, no install logic, no CLI. Just a registry row.

## UX Journey

### Before

```
User                       archon.diy/workflows/             CLI
────                       ─────────────────────             ───
visits /workflows ───────▶ shows 4 seed entries (all
                           sourced from coleam00/Archon
                           defaults, single-file blob URLs)
```

### After

```
User                       archon.diy/workflows/             CLI
────                       ─────────────────────             ───
visits /workflows ───────▶ shows 5 entries — [video-generic
                           is the first directory-format
                           entry from an external repo]
                                                             [archon workflow install
                                                              video-generic — exercises
                                                              the GitHub Contents API
                                                              walk + subdir fan-out]
```

## Architecture Diagram

### Before / After

No module changes. Only `packages/docs-web/src/data/marketplace.ts` (data) is touched.

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `docs-web/marketplace.ts` | `lint-marketplace.ts` | unchanged | Lint passes against new entry |
| `docs-web/marketplace.ts` | `/workflows/` Astro pages | unchanged | New row renders automatically |
| `docs-web/marketplace.ts` | `workflows.json.ts` | unchanged | New row included in JSON |
| `cli/workflow install` | `leex279/remotion-video-test` | **new** | First external directory-format source |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `web`
- Module: `web:marketplace`

## Change Metadata

- Change type: `feature`
- Primary scope: `web`

## Linked Issue

- Closes #
- Related # (marketplace v0: #1624)

## Validation Evidence (required)

```
$ bun packages/docs-web/scripts/lint-marketplace.ts
Linting 5 marketplace entries...
Verifying sources exist at pinned SHAs...
  ✓ [archon-piv-loop] ...
  ✓ [archon-fix-github-issue] ...
  ✓ [archon-comprehensive-pr-review] ...
  ✓ [archon-ralph-dag] ...
  ✓ [video-generic] directory verified at 4dac83c2
Marketplace lint PASSED — all 5 entries valid.

$ bun run type-check
All 10 workspace packages: Exited with code 0

$ bun run --filter @archon/docs-web build
69 page(s) built in 10.27s

$ bunx prettier --check packages/docs-web/src/data/marketplace.ts
All matched files use Prettier code style!
```

- Evidence provided: lint output (above) confirms GitHub API resolved the directory tree at the pinned SHA.
- Skipped: `bun run test` and `bun run lint` — no code paths touched, only a static data row. Pre-commit lint-staged hooks ran eslint + prettier on the change successfully.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No** (the workflow itself calls ElevenLabs, but that's the user's choice at install time, not at registry time)
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No**

The new entry points at a third-party GitHub repo (`leex279/remotion-video-test`). At install time, the CLI fetches files from a pinned SHA via the existing `installDirectory` path (`isSafePathComponent` regex, slug regex, host allowlist). Self-attestation per CONTRIBUTING.md: workflow does not exfiltrate data, does not run destructive ops without confirmation, and the SHA pins a reviewed state.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Database migration needed? **No**

End users who install `video-generic` need `ELEVENLABS_API_KEY` in their `.archon/.env` to actually run it — but that's the workflow's own requirement, not an Archon-side change.

## Human Verification (required)

- **Verified scenarios:**
  - Lint script resolved `https://api.github.com/repos/leex279/remotion-video-test/contents/.archon?ref=4dac83c2...` → 200 OK.
  - `bun run build` on `docs-web` produced all 69 pages including `/workflows/` index + new detail page.
  - Branch on the source repo (`leex279/remotion-video-test`) was reshaped so the workflow YAML lives at `.archon/` root, matching the install layout the v0 directory-install code expects (yaml at sourceUrl root + sibling subdirs).
- **Edge cases checked:**
  - Tried using a branch name with `/` in the URL first (`tree/feat/marketplace-install-layout/.archon`) — lint regex (`tree/[^/]+/`) only matches single-segment refs, so I switched to SHA-in-URL. Worth noting in CLI docs that branch names with slashes don't round-trip through the lint regex; SHA is the safer convention.
- **What was not verified:**
  - End-to-end `archon workflow install video-generic` on a fresh repo — install logic was eyeballed against `installDirectory()` in `packages/cli/src/commands/workflow.ts`. The workflow's `templates/claude-code-version/` (nested directory) won't install because the fan-out only walks one level deep; only top-level files in each subdir are picked up. Documenting as a known v0 limitation.
  - Did not run the workflow itself post-install.

## Side Effects / Blast Radius (required)

- **Affected subsystems/workflows:**
  - `docs-web` build (new detail page generated by `getStaticPaths`)
  - `workflows.json` endpoint (one more row)
  - `archon workflow search/install` CLI surface (one more discoverable slug)
- **Potential unintended effects:**
  - If `leex279/remotion-video-test` is deleted or made private, the GitHub Contents API lookup at install time will 404. SHA pinning means the *content* is immutable at GitHub's storage level, but availability depends on the source repo's continued existence.
- **Guardrails / monitoring for early detection:**
  - `lint-marketplace.ts` runs on every PR touching `marketplace.ts` (existing `.github/workflows/marketplace-lint.yml`), so a future stale SHA is caught by HEAD/GET.

## Rollback Plan (required)

- **Fast rollback:** Revert this PR. Single-file change, no migrations, no state.
- **Feature flags / config toggles:** None.
- **Observable failure symptoms:** lint failure on a future PR's CI run, or `archon workflow install video-generic` returning a 404 from the GitHub API.

## Risks and Mitigations

- **Risk:** Source repo (`leex279/remotion-video-test`) goes private or is deleted, breaking install.
  - **Mitigation:** SHA-pinned, but availability isn't guaranteed. If it disappears we can revert or migrate the entry to a fork under `coleam00/`.
- **Risk:** `templates/claude-code-version/` (nested dir in the workflow source) silently won't install — users opting into `TEMPLATE=claude-code-version` after install will hit a missing-file error.
  - **Mitigation:** Document as a known v0 limitation; followup work in the install fan-out to walk nested dirs would address this for all directory-format entries, not just this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new marketplace item for video generation that converts text prompts into animated videos with voice synthesis.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1639)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->