### PR TITLE
fix(workflows): pass ARTIFACTS_DIR/LOG_DIR/BASE_BRANCH to script node subprocesses

### DIFF
--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1484,8 +1484,13 @@ async function executeScriptNode(
   const finalScript = substituteNodeOutputRefs(substitutedScript, nodeOutputs, false);
 
   const timeout = node.timeout ?? SUBPROCESS_DEFAULT_TIMEOUT;
-  const subprocessEnv =
-    envVars && Object.keys(envVars).length > 0 ? { ...process.env, ...envVars } : undefined;
+  const subprocessEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    ARTIFACTS_DIR: artifactsDir,
+    LOG_DIR: logDir,
+    BASE_BRANCH: baseBranch,
+    ...(envVars ?? {}),
+  };
 
   // Build the command and args based on runtime and inline vs named
   let cmd = '';


### PR DESCRIPTION
## Summary

Script nodes weren't getting `ARTIFACTS_DIR`, `LOG_DIR`, or `BASE_BRANCH` in their subprocess environment, while bash nodes were. This caused the marketplace-pr-review-and-merge workflow's `parse-entry` script node to fail with ENOENT in CI when trying to read `.scope-result` from artifacts.

## Root cause

`dag-executor.ts:1320-1326` (bash node) sets all three vars on `subprocessEnv`. `dag-executor.ts:1487-1488` (script node) only conditionally forwards caller-supplied envVars and never sets these three. Locally the issue was masked because some local shells happened to have ARTIFACTS_DIR inherited from prior runs.

## Fix

Mirror the bash node env construction in the script node executor.

## Verification

- Type-check passes (all 10 packages)
- Pre-existing 32 test failures in the workflows package suite are unchanged — they are state-pollution issues in the test runner (script-node-deps tests pass in isolation, same failure count on baseline dev)
- Will be validated end-to-end by the marketplace auto-review re-running on PR #1639 after merge

## Test plan
- [ ] Merge to dev
- [ ] Re-run Marketplace Auto-Review action on PR #1639
- [ ] Confirm parse-entry node reaches its file reads successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment variable handling in workflow script execution to ensure consistent and explicit setup for all subprocess calls.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1640)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->