### PR TITLE
fix(marketplace-auto-review): multi-line diff parsing + glibc Claude binary pin

### DIFF
--- a/.archon/workflows/maintainer/marketplace-pr-review-and-merge.yaml
+++ b/.archon/workflows/maintainer/marketplace-pr-review-and-merge.yaml
@@ -90,8 +90,14 @@ nodes:
       }
 
       const diff = readFileSync(resolve(artifactsDir, 'pr-diff.txt'), 'utf8');
-      // Only look at added lines (+ prefix, not +++ file header)
-      const addedLines = diff.split('\n').filter((l) => l.startsWith('+') && !l.startsWith('+++')).join('\n');
+      // Only look at added lines (+ prefix, not +++ file header). Strip the leading
+      // '+' so multi-line values (Prettier wraps long strings) match across newlines —
+      // \s* skips whitespace including \n, but cannot skip the '+' diff prefix.
+      const addedLines = diff
+        .split('\n')
+        .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+        .map((l) => l.slice(1))
+        .join('\n');
 
       const slug = addedLines.match(/slug:\s*'([^']+)'/)?.[1] ?? '';
       const name = addedLines.match(/name:\s*'([^']+)'/)?.[1] ?? '';

--- a/.github/workflows/marketplace-auto-review.yml
+++ b/.github/workflows/marketplace-auto-review.yml
@@ -23,6 +23,28 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Pin Claude binary to glibc variant
+        # Bun installs both glibc and musl optional-dep variants; the SDK resolver
+        # picks musl first, which fails on glibc Ubuntu runners. Mirror the docker
+        # entrypoint fix (PR #1521) by pointing CLAUDE_BIN_PATH at the glibc binary.
+        run: |
+          ARCH=$(uname -m)
+          case "$ARCH" in
+            x86_64)  SUFFIX="linux-x64" ;;
+            aarch64) SUFFIX="linux-arm64" ;;
+            *) echo "ERROR: Unsupported arch $ARCH for Claude binary pinning" >&2; exit 1 ;;
+          esac
+          CLAUDE_BIN=$(find node_modules -type f -name claude -path "*claude-agent-sdk-${SUFFIX}/*" -not -path "*musl*" 2>/dev/null | head -1)
+          if [ -x "$CLAUDE_BIN" ]; then
+            ABS_PATH=$(realpath "$CLAUDE_BIN")
+            echo "CLAUDE_BIN_PATH=$ABS_PATH" >> "$GITHUB_ENV"
+            echo "Pinned Claude binary: $ABS_PATH"
+          else
+            echo "ERROR: glibc Claude binary not found under node_modules for $SUFFIX" >&2
+            find node_modules -type d -name "claude-agent-sdk-*" 2>/dev/null | head -10 >&2
+            exit 1
+          fi
+
       - name: Run marketplace auto-review workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Two bugs surfaced when the marketplace-pr-review-and-merge workflow ran against PR #1639:

1. **parse-entry regex couldn't match multi-line values.** Prettier wraps long sourceUrl values to a new line. Each line in the diff carries a '+' prefix; \s* matches whitespace across newlines but cannot skip the '+'. **Fix:** strip the '+' prefix from added lines before regex matching.

2. **Claude binary musl/glibc mismatch on Ubuntu runners.** Bun installs both glibc and musl optional-dep variants; the Claude Agent SDK resolver picks musl first, which fails on glibc Ubuntu. **Fix:** mirror PR #1521's docker-entrypoint approach — locate the glibc binary under node_modules and export CLAUDE_BIN_PATH before invoking the workflow.

## Verification

End-to-end test is re-running the auto-review against PR #1639 once this lands on dev.

## Test plan
- [ ] Merge to dev
- [ ] Trigger fresh synchronize event on PR #1639
- [ ] Confirm parse-entry extracts all 5 fields including sourceUrl
- [ ] Confirm ai-review node successfully calls Haiku via the pinned glibc binary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined marketplace entry parsing logic in automated workflows to improve handling of multi-line values
  * Enhanced CI/CD pipeline with binary pinning support for platform-specific binary compatibility, including CPU architecture detection and fallback diagnostics

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1641)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->