### PR TITLE
fix(marketplace-auto-review): use relative-path import for @archon/workflows/loader

### DIFF
--- a/.archon/scripts/marketplace-validate-schema.ts
+++ b/.archon/scripts/marketplace-validate-schema.ts
@@ -5,7 +5,10 @@
  */
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { resolve, relative } from 'node:path';
-import { parseWorkflow } from '@archon/workflows/loader';
+// Resolve workspace package via relative path: Bun's run-script context for
+// .archon/scripts/ doesn't reliably honor the @archon/workflows/loader subpath
+// export in CI. Direct file import avoids the resolution gap.
+import { parseWorkflow } from '../../packages/workflows/src/loader.ts';
 
 interface FileResult {
   name: string;


### PR DESCRIPTION
Third iteration on the marketplace auto-review end-to-end test. Bun's run-script context for .archon/scripts/ doesn't reliably honor the @archon/workflows/loader subpath export when invoked in CI via 'bun --no-env-file run abs-path'. Switching to a direct relative-path import bypasses the resolution gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build validation script to ensure consistent behavior across development and CI environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1642)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->