### PR TITLE
fix(marketplace-auto-review): validate-schema always exits 0

### DIFF
--- a/.archon/scripts/marketplace-validate-schema.ts
+++ b/.archon/scripts/marketplace-validate-schema.ts
@@ -63,4 +63,7 @@ for (const fullPath of yamlFiles) {
 
 const allValid = results.every((r) => r.valid);
 console.log(JSON.stringify({ valid: allValid, files: results }));
-if (!allValid) process.exit(1);
+// Always exit 0 — the decide node reads `valid` from the JSON output and
+// routes to `request_changes` if false. Exit 1 here would crash the DAG
+// before decide/act can post a useful review comment to the PR.
+process.exit(0);


### PR DESCRIPTION
Lets decide/act route schema-invalid submissions to request_changes with a comment instead of crashing the DAG. Fourth iteration of marketplace-auto-review end-to-end debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation workflow behavior to always complete successfully and pass results to downstream processing nodes, enabling them to handle validation outcomes and post validation feedback as PR comments instead of stopping early. Previously, validation failures would cause the entire workflow to crash without providing users with detailed feedback.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1643)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->