### PR TITLE
fix(marketplace-auto-review): silence loader Pino logs in validate-schema

### DIFF
--- a/.archon/scripts/marketplace-validate-schema.ts
+++ b/.archon/scripts/marketplace-validate-schema.ts
@@ -8,7 +8,15 @@ import { resolve, relative } from 'node:path';
 // Resolve workspace package via relative path: Bun's run-script context for
 // .archon/scripts/ doesn't reliably honor the @archon/workflows/loader subpath
 // export in CI. Direct file import avoids the resolution gap.
+import { setLogLevel } from '../../packages/paths/src/logger.ts';
 import { parseWorkflow } from '../../packages/workflows/src/loader.ts';
+
+// Silence the loader's Pino warnings (workflow_missing_description, etc).
+// parseWorkflow logs to stdout by default; the decide node substitutes our
+// stdout into a TS expression, so any log noise breaks that parse. The
+// loader's child logger is lazy-initialized, so setting the root level
+// before the first parseWorkflow call propagates correctly.
+setLogLevel('fatal');
 
 interface FileResult {
   name: string;


### PR DESCRIPTION
validate-schema stdout was being polluted by parseWorkflow's Pino warnings (workflow_missing_description, etc.) which then broke the decide node's substitution. Set log level to fatal before any parseWorkflow call. Fifth iteration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced log verbosity in the marketplace schema validation script to prevent warning noise from disrupting parsing output while maintaining validation accuracy.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1644)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->