### PR TITLE
fix(marketplace-auto-review): filter to workflow-shaped YAMLs + register providers

### DIFF
--- a/.archon/scripts/marketplace-validate-schema.ts
+++ b/.archon/scripts/marketplace-validate-schema.ts
@@ -10,6 +10,7 @@ import { resolve, relative } from 'node:path';
 // export in CI. Direct file import avoids the resolution gap.
 import { setLogLevel } from '../../packages/paths/src/logger.ts';
 import { parseWorkflow } from '../../packages/workflows/src/loader.ts';
+import { registerBuiltinProviders, registerCommunityProviders } from '../../packages/providers/src/registry.ts';
 
 // Silence the loader's Pino warnings (workflow_missing_description, etc).
 // parseWorkflow logs to stdout by default; the decide node substitutes our
@@ -17,6 +18,23 @@ import { parseWorkflow } from '../../packages/workflows/src/loader.ts';
 // loader's child logger is lazy-initialized, so setting the root level
 // before the first parseWorkflow call propagates correctly.
 setLogLevel('fatal');
+
+// parseWorkflow checks `provider:` against the runtime providers registry.
+// The CLI populates it at startup; this standalone script must do the same
+// or every workflow with `provider: claude` gets a false-positive
+// "Unknown provider" error.
+registerBuiltinProviders();
+registerCommunityProviders();
+
+/**
+ * Decide whether a YAML file is shaped like an Archon workflow definition
+ * (top-level `nodes:` block). Marketplace directory submissions commonly
+ * include non-workflow YAML like brand.yaml, config.yaml, or template
+ * scaffolds — those should not be validated against the workflow schema.
+ */
+function looksLikeWorkflow(yamlContent: string): boolean {
+  return /^nodes\s*:/m.test(yamlContent);
+}
 
 interface FileResult {
   name: string;
@@ -56,9 +74,20 @@ if (yamlFiles.length === 0) {
   process.exit(0);
 }
 
+// Pre-filter to only workflow-shaped YAMLs. Directory submissions commonly
+// ship non-workflow YAML alongside the workflow (brand metadata, Archon
+// per-repo config, template scaffolds). Validating those as workflows
+// produces false-positive errors and tanks legitimate submissions.
+const workflowFiles = yamlFiles.filter((p) => looksLikeWorkflow(readFileSync(p, 'utf8')));
+
+if (workflowFiles.length === 0) {
+  console.log(JSON.stringify({ valid: true, files: [], note: 'no workflow yaml files (no top-level nodes:)' }));
+  process.exit(0);
+}
+
 const results: FileResult[] = [];
 
-for (const fullPath of yamlFiles) {
+for (const fullPath of workflowFiles) {
   const relName = relative(sourceDir, fullPath);
   const content = readFileSync(fullPath, 'utf8');
   const result = parseWorkflow(content, relName);


### PR DESCRIPTION
Two false-positive sources surfaced when running auto-review against PR #1639. (1) Provider registry empty when parseWorkflow runs standalone — every 'provider: claude' workflow got rejected. (2) Non-workflow YAMLs (brand.yaml, config.yaml, template scaffolds) were validated against the workflow schema. Filter to YAMLs with a top-level nodes: block; register providers before parseWorkflow. Tested locally against PR #1639 submission: now returns valid:true with only video-generic.yaml validated. Sixth iteration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved marketplace workflow schema validation to reduce false-positive errors for non-workflow YAML files through smarter detection logic.
  * Enhanced provider registration to properly validate workflows using both community and builtin providers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1645)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->