### PR TITLE
fix(workflows): make resume explicit via prepareResumedRun / hydrateResumableRun (closes #1392)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `archon workflow run` no longer silently auto-resumes the previous failed run for the same `(workflow_name, cwd)` pair. The implicit `findResumableRun` call inside `executeWorkflow` was the cause of cross-invocation state leaks — completed-node outputs from a prior failed run would bleed into the next invocation of the same workflow at the same path. Resume is now an explicit caller-side decision: use `archon workflow run --resume`, `archon workflow resume <id>`, or the web UI resume button. `executeWorkflow`'s trailing positional args are consolidated into an options bag and a new `prepareResumedRun` / `hydrateResumableRun` pair handles resume preparation at call sites. Closes #1392.
 - `archon doctor` and `archon setup` no longer interleave `[archon] loaded N keys` boot lines and Pino info JSON with their checklist output. Set `ARCHON_VERBOSE_BOOT=1` or `LOG_LEVEL=debug` to restore the boot lines; pass `--verbose` to re-enable structured Pino logs for those commands (#1606).
 - Docker: `git config --global --add safe.directory` in the entrypoint now de-duplicates entries before adding, preventing unbounded growth of `~/.gitconfig` now that `/home/appuser` is persisted (#1518).
 - Docker: `setup-auth` now warns at startup when `CODEX_*` env vars are absent but a persisted `~/.codex/auth.json` from a previous run still exists, so operators don't accidentally use stale or revoked credentials (#1518).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -788,7 +788,7 @@ Pattern: Use `classifyIsolationError()` (from `@archon/isolation`) to map git er
 - `DELETE /api/workflows/:name` - Delete a user-defined workflow; bundled defaults cannot be deleted
 
 **Workflow Run Lifecycle:**
-- `POST /api/workflows/runs/{runId}/resume` - Mark a failed run as ready for auto-resume on next invocation
+- `POST /api/workflows/runs/{runId}/resume` - Resume a failed run from where it left off (skips already-completed DAG nodes; AI session context is not restored).
 - `POST /api/workflows/runs/{runId}/abandon` - Abandon a non-terminal run (marks as cancelled)
 - `DELETE /api/workflows/runs/{runId}` - Delete a terminal workflow run and its events
 

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -75,6 +75,7 @@ mock.module('@archon/workflows/workflow-discovery', () => ({
 }));
 mock.module('@archon/workflows/executor', () => ({
   executeWorkflow: mock(() => Promise.resolve({ success: true, workflowRunId: 'test-run-id' })),
+  hydrateResumableRun: mock(() => Promise.resolve(null)),
 }));
 
 // Capture the subscription handler so tests can trigger events

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -15,7 +15,7 @@ import { join } from 'node:path';
 import { createWorkflowDeps } from '@archon/core/workflows/store-adapter';
 import { discoverWorkflowsWithConfig } from '@archon/workflows/workflow-discovery';
 import { resolveWorkflowName } from '@archon/workflows/router';
-import { executeWorkflow } from '@archon/workflows/executor';
+import { executeWorkflow, hydrateResumableRun } from '@archon/workflows/executor';
 import {
   getWorkflowEventEmitter,
   type WorkflowEmitterEvent,
@@ -427,9 +427,10 @@ export async function workflowRunCommand(
   let workingCwd = cwd;
   let isolationEnvId: string | undefined;
 
-  // Handle --resume: find the most recent failed run and reuse its worktree.
-  // The executor's implicit findResumableRun will detect the failed run and
-  // skip already-completed nodes automatically.
+  // Handle --resume: locate the prior failed run, reuse its worktree, and hand
+  // the resumed-run handle to executeWorkflow below via opts. The executor no
+  // longer performs implicit resume detection on its own.
+  let resumable: WorkflowRun | null = null;
   if (options.resume) {
     if (!codebase) {
       if (codebaseLookupError) {
@@ -448,7 +449,7 @@ export async function workflowRunCommand(
       );
     }
 
-    const resumable = await workflowDb.findResumableRun(workflowName, cwd);
+    resumable = await workflowDb.findResumableRun(workflowName, cwd);
 
     if (!resumable) {
       throw new Error(`No resumable run found for workflow '${workflowName}' at path '${cwd}'.`);
@@ -704,18 +705,37 @@ export async function workflowRunCommand(
     );
   }
 
+  // When --resume, hand the already-found run (and its completed-node outputs)
+  // to executeWorkflow. Otherwise this is a fresh run and prepared stays null.
+  // The lookup-by-(workflowName, cwd) was already done above for worktree-path
+  // resolution; reuse that result rather than querying twice.
+  const deps = createWorkflowDeps();
+  let prepared: Awaited<ReturnType<typeof hydrateResumableRun>> = null;
+  if (options.resume && resumable) {
+    prepared = await hydrateResumableRun(deps, resumable);
+    if (!prepared) {
+      throw new Error(
+        `Cannot resume: the prior run for '${workflowName}' has no completed nodes and no interactive-loop state.`
+      );
+    }
+  }
+
   // Execute workflow with workingCwd (may be worktree path)
   let result: Awaited<ReturnType<typeof executeWorkflow>>;
   try {
     result = await executeWorkflow(
-      createWorkflowDeps(),
+      deps,
       adapter,
       conversationId,
       workingCwd,
       workflow,
       userMessage,
       conversation.id,
-      codebase?.id
+      {
+        codebaseId: codebase?.id,
+        preCreatedRun: prepared?.run,
+        priorCompletedNodes: prepared?.priorCompletedNodes,
+      }
     );
   } finally {
     unsubscribe?.();

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -712,7 +712,18 @@ export async function workflowRunCommand(
   const deps = createWorkflowDeps();
   let prepared: Awaited<ReturnType<typeof hydrateResumableRun>> = null;
   if (options.resume && resumable) {
-    prepared = await hydrateResumableRun(deps, resumable);
+    try {
+      prepared = await hydrateResumableRun(deps, resumable);
+    } catch (error) {
+      const err = error as Error;
+      getLog().error(
+        { err, workflowName, runId: resumable.id },
+        'cli.workflow_hydrate_resume_failed'
+      );
+      throw new Error(
+        `Cannot resume workflow '${workflowName}': failed to load prior run state — ${err.message}`
+      );
+    }
     if (!prepared) {
       throw new Error(
         `Cannot resume: the prior run for '${workflowName}' has no completed nodes and no interactive-loop state.`
@@ -723,6 +734,9 @@ export async function workflowRunCommand(
   // Execute workflow with workingCwd (may be worktree path)
   let result: Awaited<ReturnType<typeof executeWorkflow>>;
   try {
+    const opts = prepared
+      ? { codebaseId: codebase?.id, ...prepared }
+      : { codebaseId: codebase?.id };
     result = await executeWorkflow(
       deps,
       adapter,
@@ -731,11 +745,7 @@ export async function workflowRunCommand(
       workflow,
       userMessage,
       conversation.id,
-      {
-        codebaseId: codebase?.id,
-        preCreatedRun: prepared?.run,
-        priorCompletedNodes: prepared?.priorCompletedNodes,
-      }
+      opts
     );
   } finally {
     unsubscribe?.();

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -106,8 +106,16 @@ mock.module('@archon/workflows/router', () => ({
     workflows.find(w => w.name === name)
   ),
 }));
+const mockHydrateResumableRun = mock(
+  async (_deps: unknown, candidate: { id: string }) =>
+    ({
+      run: { ...candidate, status: 'running' },
+      priorCompletedNodes: new Map([['n1', 'v1']]),
+    }) as unknown
+);
 mock.module('@archon/workflows/executor', () => ({
   executeWorkflow: mockExecuteWorkflow,
+  hydrateResumableRun: mockHydrateResumableRun,
 }));
 
 mock.module('@archon/providers', () => ({
@@ -1111,18 +1119,21 @@ describe('workflow dispatch routing — interactive flag', () => {
     expect(mockDispatchBackgroundWorkflow).not.toHaveBeenCalled();
     // Regression for the auto-resume plumbing: the interactive web dispatch
     // must pass the caller conversation's DB id as parentConversationId
-    // (11th positional arg) so the approve/reject API handlers can dispatch
-    // resume back through the orchestrator.
+    // (opts.parentConversationId on the options bag at position 7) so the
+    // approve/reject API handlers can dispatch resume back through the
+    // orchestrator.
     const callArgs = mockExecuteWorkflow.mock.calls[0] as unknown[];
-    expect(callArgs[10]).toBe('conv-1'); // parentConversationId = conversation.id
+    const opts = callArgs[7] as { parentConversationId?: string };
+    expect(opts.parentConversationId).toBe('conv-1');
   });
 
   test('foreground_resume_detected: passes parentConversationId to executeWorkflow when a resumable run exists', async () => {
-    // Regression for the foreground-resume branch added as part of the
-    // auto-resume fix: when `findResumableRunByParentConversation` returns a
-    // paused run, the orchestrator picks the working_path from that run and
-    // must still carry parentConversationId forward so the API helpers can
-    // keep dispatching resume on subsequent approvals.
+    // Regression for the foreground-resume branch: when
+    // findResumableRunByParentConversation returns a paused run, the
+    // orchestrator must hydrate it (single DB roundtrip — no second
+    // findResumableRun) and hand the resumed run + priorCompletedNodes to
+    // executeWorkflow via opts. parentConversationId still flows so the API
+    // helpers keep dispatching resume on subsequent approvals.
     mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
     mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
     mockHandleCommand.mockReturnValueOnce(Promise.resolve(makeWorkflowResult(true)));
@@ -1139,12 +1150,20 @@ describe('workflow dispatch routing — interactive flag', () => {
     const platform = makePlatform(); // getPlatformType returns 'web'
     await handleMessage(platform, 'conv-1', '/workflow run test-workflow');
 
+    expect(mockHydrateResumableRun).toHaveBeenCalled();
     expect(mockExecuteWorkflow).toHaveBeenCalled();
     const callArgs = mockExecuteWorkflow.mock.calls[0] as unknown[];
-    // cwd (position 3) should come from the resumable run's working_path
+    // cwd (position 3) should come from the resumable run's working_path.
     expect(callArgs[3]).toBe('/repos/test-repo/worktrees/feature');
-    // parentConversationId (position 10) should still be the caller conversation id
-    expect(callArgs[10]).toBe('conv-1');
+    // Resume payload lives on the opts bag (position 7).
+    const opts = callArgs[7] as {
+      parentConversationId?: string;
+      preCreatedRun?: { id: string };
+      priorCompletedNodes?: Map<string, string>;
+    };
+    expect(opts.parentConversationId).toBe('conv-1');
+    expect(opts.preCreatedRun?.id).toBe('resumable-run-1');
+    expect(opts.priorCompletedNodes?.size).toBeGreaterThan(0);
   });
 
   test('calls dispatchBackgroundWorkflow for non-interactive workflow on web', async () => {

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -109,7 +109,7 @@ mock.module('@archon/workflows/router', () => ({
 const mockHydrateResumableRun = mock(
   async (_deps: unknown, candidate: { id: string }) =>
     ({
-      run: { ...candidate, status: 'running' },
+      preCreatedRun: { ...candidate, status: 'running' },
       priorCompletedNodes: new Map([['n1', 'v1']]),
     }) as unknown
 );
@@ -1117,13 +1117,11 @@ describe('workflow dispatch routing — interactive flag', () => {
 
     expect(mockExecuteWorkflow).toHaveBeenCalled();
     expect(mockDispatchBackgroundWorkflow).not.toHaveBeenCalled();
-    // Regression for the auto-resume plumbing: the interactive web dispatch
-    // must pass the caller conversation's DB id as parentConversationId
-    // (opts.parentConversationId on the options bag at position 7) so the
-    // approve/reject API handlers can dispatch resume back through the
-    // orchestrator.
+    // The interactive web dispatch must pass the caller conversation's DB id
+    // as opts.parentConversationId so the approve/reject API handlers can
+    // dispatch resume back through the orchestrator.
     const callArgs = mockExecuteWorkflow.mock.calls[0] as unknown[];
-    const opts = callArgs[7] as { parentConversationId?: string };
+    const opts = callArgs[callArgs.length - 1] as { parentConversationId?: string };
     expect(opts.parentConversationId).toBe('conv-1');
   });
 
@@ -1155,8 +1153,8 @@ describe('workflow dispatch routing — interactive flag', () => {
     const callArgs = mockExecuteWorkflow.mock.calls[0] as unknown[];
     // cwd (position 3) should come from the resumable run's working_path.
     expect(callArgs[3]).toBe('/repos/test-repo/worktrees/feature');
-    // Resume payload lives on the opts bag (position 7).
-    const opts = callArgs[7] as {
+    // Resume payload lives on the opts bag (the trailing arg).
+    const opts = callArgs[callArgs.length - 1] as {
       parentConversationId?: string;
       preCreatedRun?: { id: string };
       priorCompletedNodes?: Map<string, string>;
@@ -1164,6 +1162,44 @@ describe('workflow dispatch routing — interactive flag', () => {
     expect(opts.parentConversationId).toBe('conv-1');
     expect(opts.preCreatedRun?.id).toBe('resumable-run-1');
     expect(opts.priorCompletedNodes?.size).toBeGreaterThan(0);
+  });
+
+  test('foreground_resume_detected: falls through to fresh run when hydration returns null', async () => {
+    // When findResumableRunByParentConversation returns a run but
+    // hydrateResumableRun finds nothing worth resuming (zero completed nodes,
+    // no interactive-loop state), the orchestrator must NOT throw — it sends
+    // a user-visible notice and starts a fresh run on the same worktree.
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(Promise.resolve(makeWorkflowResult(true)));
+    mockFindResumableRunByParentConversation.mockReturnValueOnce(
+      Promise.resolve({
+        id: 'empty-prior-run',
+        workflow_name: 'test-workflow',
+        working_path: '/repos/test-repo/worktrees/feature',
+        parent_conversation_id: 'conv-1',
+        status: 'failed',
+      })
+    );
+    mockHydrateResumableRun.mockReturnValueOnce(Promise.resolve(null));
+
+    const platform = makePlatform(); // getPlatformType returns 'web'
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow');
+
+    expect(mockHydrateResumableRun).toHaveBeenCalled();
+    expect(mockExecuteWorkflow).toHaveBeenCalled();
+    const callArgs = mockExecuteWorkflow.mock.calls[0] as unknown[];
+    // cwd still points at the prior run's worktree.
+    expect(callArgs[3]).toBe('/repos/test-repo/worktrees/feature');
+    // Opts bag carries no resume payload — fresh run.
+    const opts = callArgs[callArgs.length - 1] as {
+      parentConversationId?: string;
+      preCreatedRun?: unknown;
+      priorCompletedNodes?: unknown;
+    };
+    expect(opts.parentConversationId).toBe('conv-1');
+    expect(opts.preCreatedRun).toBeUndefined();
+    expect(opts.priorCompletedNodes).toBeUndefined();
   });
 
   test('calls dispatchBackgroundWorkflow for non-interactive workflow on web', async () => {

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -31,7 +31,7 @@ import { syncWorkspace, toRepoPath } from '@archon/git';
 import type { WorkspaceSyncResult } from '@archon/git';
 import { discoverWorkflowsWithConfig } from '@archon/workflows/workflow-discovery';
 import { findWorkflow } from '@archon/workflows/router';
-import { executeWorkflow } from '@archon/workflows/executor';
+import { executeWorkflow, hydrateResumableRun } from '@archon/workflows/executor';
 import type {
   WorkflowDefinition,
   WorkflowWithSource,
@@ -285,18 +285,30 @@ async function dispatchOrchestratorWorkflow(
         },
         'orchestrator.foreground_resume_detected'
       );
+      // Hydrate the already-found candidate (skip a second findResumableRun
+      // query). If hydration returns null, the run vanished or has nothing
+      // worth resuming — throw rather than silently start fresh.
+      const deps = createWorkflowDeps();
+      const prepared = await hydrateResumableRun(deps, resumableRun);
+      if (!prepared) {
+        throw new Error(
+          `Resumable run '${resumableRun.id}' for '${workflow.name}' could not be hydrated for resume.`
+        );
+      }
       await executeWorkflow(
-        createWorkflowDeps(),
+        deps,
         platform,
         conversationId,
         resumableRun.working_path,
         workflow,
         userMessage,
         conversation.id,
-        codebase.id,
-        undefined, // issueContext
-        undefined, // isolationContext
-        conversation.id // parentConversationId — enables approve/reject auto-resume
+        {
+          codebaseId: codebase.id,
+          parentConversationId: conversation.id,
+          preCreatedRun: prepared.run,
+          priorCompletedNodes: prepared.priorCompletedNodes,
+        }
       );
     } else if (workflow.interactive) {
       // Interactive workflows run in foreground so output stays in the user's conversation
@@ -308,10 +320,10 @@ async function dispatchOrchestratorWorkflow(
         workflow,
         userMessage,
         conversation.id,
-        codebase.id,
-        undefined, // issueContext
-        undefined, // isolationContext
-        conversation.id // parentConversationId — enables approve/reject auto-resume
+        {
+          codebaseId: codebase.id,
+          parentConversationId: conversation.id,
+        }
       );
     } else {
       await dispatchBackgroundWorkflow(
@@ -337,10 +349,10 @@ async function dispatchOrchestratorWorkflow(
       workflow,
       userMessage,
       conversation.id,
-      codebase.id,
-      undefined, // issueContext
-      undefined, // isolationContext
-      conversation.id // parentConversationId — enables approve/reject auto-resume
+      {
+        codebaseId: codebase.id,
+        parentConversationId: conversation.id,
+      }
     );
   }
 }

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -285,31 +285,46 @@ async function dispatchOrchestratorWorkflow(
         },
         'orchestrator.foreground_resume_detected'
       );
-      // Hydrate the already-found candidate (skip a second findResumableRun
-      // query). If hydration returns null, the run vanished or has nothing
-      // worth resuming — throw rather than silently start fresh.
+      // Hydrate the already-found candidate. If hydration returns null the
+      // prior run had nothing worth resuming (zero completed nodes, no loop
+      // gate) — surface that to the user and fall through to a fresh run on
+      // the same worktree rather than silently restarting.
       const deps = createWorkflowDeps();
       const prepared = await hydrateResumableRun(deps, resumableRun);
-      if (!prepared) {
-        throw new Error(
-          `Resumable run '${resumableRun.id}' for '${workflow.name}' could not be hydrated for resume.`
+      if (prepared) {
+        await executeWorkflow(
+          deps,
+          platform,
+          conversationId,
+          resumableRun.working_path,
+          workflow,
+          userMessage,
+          conversation.id,
+          {
+            codebaseId: codebase.id,
+            parentConversationId: conversation.id,
+            ...prepared,
+          }
+        );
+      } else {
+        await platform.sendMessage(
+          conversationId,
+          `⚠️ Prior run for **${workflow.name}** had no completed nodes; starting fresh in the same worktree.`
+        );
+        await executeWorkflow(
+          deps,
+          platform,
+          conversationId,
+          resumableRun.working_path,
+          workflow,
+          userMessage,
+          conversation.id,
+          {
+            codebaseId: codebase.id,
+            parentConversationId: conversation.id,
+          }
         );
       }
-      await executeWorkflow(
-        deps,
-        platform,
-        conversationId,
-        resumableRun.working_path,
-        workflow,
-        userMessage,
-        conversation.id,
-        {
-          codebaseId: codebase.id,
-          parentConversationId: conversation.id,
-          preCreatedRun: prepared.run,
-          priorCompletedNodes: prepared.priorCompletedNodes,
-        }
-      );
     } else if (workflow.interactive) {
       // Interactive workflows run in foreground so output stays in the user's conversation
       await executeWorkflow(

--- a/packages/core/src/orchestrator/orchestrator.test.ts
+++ b/packages/core/src/orchestrator/orchestrator.test.ts
@@ -1074,7 +1074,8 @@ describe('orchestrator-agent handleMessage', () => {
 
       await handleMessage(platform, 'chat-456', 'do that analysis thing');
 
-      // Position 5 is userMessage; position 7 is the opts bag with parentConversationId.
+      // userMessage (position 5) carries the synthesized prompt; the opts bag
+      // (trailing arg) carries parentConversationId for approve/reject resume.
       expect(mockExecuteWorkflow).toHaveBeenCalledWith(
         expect.anything(), // deps
         expect.anything(), // platform

--- a/packages/core/src/orchestrator/orchestrator.test.ts
+++ b/packages/core/src/orchestrator/orchestrator.test.ts
@@ -1074,6 +1074,7 @@ describe('orchestrator-agent handleMessage', () => {
 
       await handleMessage(platform, 'chat-456', 'do that analysis thing');
 
+      // Position 5 is userMessage; position 7 is the opts bag with parentConversationId.
       expect(mockExecuteWorkflow).toHaveBeenCalledWith(
         expect.anything(), // deps
         expect.anything(), // platform
@@ -1082,10 +1083,9 @@ describe('orchestrator-agent handleMessage', () => {
         expect.anything(), // workflow
         synthesized, // synthesizedPrompt, not original message
         expect.anything(), // conversation.id
-        expect.anything(), // codebase.id
-        undefined, // issueContext
-        undefined, // isolationContext
-        expect.anything() // parentConversationId — web approval auto-resume
+        expect.objectContaining({
+          parentConversationId: expect.anything() as unknown, // web approval auto-resume
+        })
       );
     });
 
@@ -1104,16 +1104,15 @@ describe('orchestrator-agent handleMessage', () => {
 
       expect(mockExecuteWorkflow).toHaveBeenCalledWith(
         expect.anything(), // deps
-        expect.anything(),
-        expect.anything(),
-        expect.anything(),
-        expect.anything(),
+        expect.anything(), // platform
+        expect.anything(), // conversationId
+        expect.anything(), // cwd
+        expect.anything(), // workflow
         'fix the login bug', // original message used as fallback
-        expect.anything(),
-        expect.anything(),
-        undefined, // issueContext
-        undefined, // isolationContext
-        expect.anything() // parentConversationId — web approval auto-resume
+        expect.anything(), // conversation.id
+        expect.objectContaining({
+          parentConversationId: expect.anything() as unknown, // web approval auto-resume
+        })
       );
     });
 

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -370,11 +370,13 @@ export async function dispatchBackgroundWorkflow(
           workflow,
           ctx.originalMessage,
           workerConv.id,
-          ctx.codebaseId,
-          ctx.issueContext,
-          isolationContext,
-          ctx.conversationDbId,
-          preCreatedRun
+          {
+            codebaseId: ctx.codebaseId,
+            issueContext: ctx.issueContext,
+            isolationContext,
+            parentConversationId: ctx.conversationDbId,
+            preCreatedRun,
+          }
         );
         // Surface workflow output to parent conversation as a result card
         if ('paused' in result) {

--- a/packages/docs-web/src/content/docs/book/dag-workflows.md
+++ b/packages/docs-web/src/content/docs/book/dag-workflows.md
@@ -326,7 +326,7 @@ nodes:
 
 **Test with simple inputs first.** Before running your full workflow on real data, verify that each branch of a conditional routes correctly. Create a simple test input that's clearly a bug, confirm the BUG path runs. Then test with a clear feature request.
 
-**Let DAG resume handle failures.** If a long workflow fails partway through, run it again. Archon automatically skips nodes that already completed and resumes from where it left off. No `--resume` flag required.
+**Let DAG resume handle failures.** If a long workflow fails partway through, run `archon workflow run <name> --resume` (or `archon workflow resume <id>`) to skip nodes that already completed and continue from where it left off. Plain `archon workflow run` always starts fresh.
 
 ---
 

--- a/packages/docs-web/src/content/docs/guides/approval-nodes.md
+++ b/packages/docs-web/src/content/docs/guides/approval-nodes.md
@@ -234,8 +234,8 @@ can approve or reject again.
 
 ## Design Notes
 
-Approval nodes reuse the existing resume infrastructure (from workflow lifecycle
-PR #871). When approved, the run transitions through `failed` status briefly so
-that `findResumableRun` picks it up — this avoids duplicating resume logic. The
-`metadata.approval_response` field distinguishes approved-then-resumed from
-genuinely-failed runs.
+Approval nodes reuse the existing resume infrastructure. When approved, the run
+transitions through `failed` status briefly so the orchestrator's explicit
+resume path (via `hydrateResumableRun`) picks it up — this avoids duplicating
+resume logic. The `metadata.approval_response` field distinguishes
+approved-then-resumed from genuinely-failed runs.

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -512,32 +512,39 @@ SDK subprocess retry (claude.ts)  — 3 total attempts, 2 s base backoff
     ↓ only if all SDK retries exhausted
 Node retry (dag-executor)  — default 2 retries, 3 s base backoff
     ↓ only if all node retries exhausted
-Workflow fails → next invocation auto-resumes completed nodes
+Workflow fails → user opts in to resume on next invocation
 ```
 
 This means a single transient crash may trigger up to **3 SDK retries** before a single node retry attempt is consumed.
 
-> **DAG resume**: For `nodes:` (DAG) workflows, resume is automatic — the next invocation detects the prior failed run and skips already-completed nodes. No `--resume` flag is needed. See [DAG Resume on Failure](#dag-resume-on-failure) below.
+> **DAG resume**: For `nodes:` (DAG) workflows, resume is opt-in — pass `--resume` to `archon workflow run`, run `archon workflow resume <id>`, or use the web UI resume button. Plain `archon workflow run <name>` always starts a fresh run. See [DAG Resume on Failure](#dag-resume-on-failure) below.
 
 ---
 
 ## DAG Resume on Failure
 
-When a `nodes:` (DAG) workflow fails, the next invocation automatically resumes from where it left off — no `--resume` flag required.
+When a `nodes:` (DAG) workflow fails, the prior run stays in the database as a candidate for resume. Resume is **explicit**: you opt in by flag or button.
 
-**How it works:**
+**How to resume:**
 
-1. On each invocation, Archon checks for a prior failed run of the same workflow at the same working path.
-2. If found, it loads the `node_completed` events from that run to determine which nodes finished successfully.
-3. Completed nodes are skipped; only failed and not-yet-run nodes are executed.
-4. You receive a platform message like: `Resuming workflow — skipping 3 already-completed node(s).`
+- **CLI**: `archon workflow run <name> --resume` resumes the most recent failed run for `(workflow_name, cwd)`. Or `archon workflow resume <run-id>` to target a specific run.
+- **Chat (web)**: Approving or rejecting a paused workflow auto-resumes from where it left off (the platform already knows the run id).
+- **Web UI**: Resume button on the workflow card.
+
+**What happens on resume:**
+
+1. The CLI / orchestrator looks up the resumable run, loads its `node_completed` events to determine which nodes finished successfully, and transitions the row back to `running`.
+2. Completed nodes are skipped; only failed and not-yet-run nodes are executed.
+3. You receive a platform message like: `Resuming workflow — skipping 3 already-completed node(s).`
+
+> **Why opt-in?** Earlier versions silently auto-resumed on plain `archon workflow run`, which caused state from prior failed runs (e.g. cached node outputs with stale inputs) to bleed into new invocations of the same workflow at the same path. See #1392 for the bug; now resume is always a user-driven decision.
 
 **Crashed servers / orphaned runs**: Archon does **not** auto-fail `running` rows on server startup — that would kill workflows actively executing in another process (CLI, adapter). If a server crash leaves a row stuck as `running`, it remains visible in the dashboard (the Dashboard nav tab shows a count of running workflows). Transition it to a terminal status explicitly:
 
 - **Web UI**: click the Abandon or Cancel button on the workflow card. Abandon marks the run `cancelled` and keeps completed-node history. Cancel also terminates any in-flight subprocess.
 - **CLI**: `archon workflow abandon <run-id>` (equivalent to the dashboard Abandon button). Run IDs are listed by `archon workflow status`.
 
-Once the row reaches a terminal status, the next invocation of the same workflow at the same path auto-resumes from completed nodes via the mechanism above.
+Once the row reaches a terminal status, you can resume it explicitly via the paths above. Plain `archon workflow run` never resumes implicitly.
 
 > Not to be confused with `archon workflow cleanup [days]`, which **deletes** old terminal runs (`completed`/`failed`/`cancelled`) from the database for disk hygiene. It does not transition `running` rows.
 

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -977,7 +977,7 @@ nodes:
 
 ### Pattern: Checkpoint and Resume
 
-For long workflows, DAG resume handles this automatically — completed nodes are skipped on re-invocation:
+For long workflows, DAG resume lets you skip already-completed nodes — opt in with `--resume`:
 
 ```yaml
 name: large-migration
@@ -1003,7 +1003,7 @@ nodes:
     context: fresh
 ```
 
-If the workflow fails at `batch-2`, the next invocation skips `plan` and `batch-1` automatically.
+If the workflow fails at `batch-2`, run `archon workflow run large-migration --resume` to skip `plan` and `batch-1`. Plain `archon workflow run large-migration` (without `--resume`) starts fresh.
 
 ### Pattern: Human-in-the-Loop
 

--- a/packages/docs-web/src/content/docs/reference/api.md
+++ b/packages/docs-web/src/content/docs/reference/api.md
@@ -277,7 +277,7 @@ curl -X POST http://localhost:3090/api/workflows/archon-assist/run \
 curl -X POST http://localhost:3090/api/workflows/runs/{runId}/resume
 ```
 
-Marks the run for auto-resume. The next invocation re-runs the workflow, skipping already-completed nodes.
+Resumes the workflow from where it left off, skipping already-completed nodes. Equivalent to `archon workflow resume <run-id>` from the CLI. Plain `archon workflow run <name>` invocations never resume implicitly.
 
 #### Approve / Reject a Paused Run
 

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -628,7 +628,7 @@ const resumeWorkflowRunRoute = createRoute({
   method: 'post',
   path: '/api/workflows/runs/{runId}/resume',
   tags: ['Workflows'],
-  summary: 'Resume a failed workflow run (re-run auto-resumes from completed nodes)',
+  summary: 'Resume a failed workflow run (dispatches resume on the parent web conversation)',
   request: { params: z.object({ runId: z.string() }) },
   responses: {
     200: {
@@ -1907,11 +1907,38 @@ export function registerApiRoutes(
       if (!RESUMABLE_WORKFLOW_STATUSES.includes(run.status)) {
         return apiError(c, 400, `Cannot resume workflow in '${run.status}' status`);
       }
-      // Run is already failed — the next invocation on the same path auto-resumes
-      const pathInfo = run.working_path ? ` at \`${run.working_path}\`` : '';
+      // Dispatch resume by sending `/workflow run <name>` to the parent web
+      // conversation; the orchestrator's foreground-resume detection (via
+      // findResumableRunByParentConversation) picks up the failed run and
+      // hydrates it. Mirrors the approve/reject auto-resume path.
+      if (!run.parent_conversation_id) {
+        return apiError(
+          c,
+          400,
+          `This run was created outside the web UI. Use \`archon workflow resume ${runId}\` from the CLI to resume it.`
+        );
+      }
+      const parentConv = await conversationDb.getConversationById(run.parent_conversation_id);
+      if (!parentConv?.platform_conversation_id || parentConv.platform_type !== 'web') {
+        return apiError(
+          c,
+          400,
+          `Cannot resume from web UI: the run's parent conversation is not a web conversation. Use \`archon workflow resume ${runId}\` from the CLI.`
+        );
+      }
+      const resumeMessage = `/workflow run ${run.workflow_name} ${run.user_message ?? ''}`.trim();
+      await dispatchToOrchestrator(parentConv.platform_conversation_id, resumeMessage);
+      getLog().info(
+        {
+          runId,
+          workflowName: run.workflow_name,
+          platformConvId: parentConv.platform_conversation_id,
+        },
+        'api.workflow_run_resume_dispatched'
+      );
       return c.json({
         success: true,
-        message: `Workflow run ready to resume: ${run.workflow_name}${pathInfo}. Re-run the workflow to auto-resume from completed nodes.`,
+        message: `Resuming workflow: ${run.workflow_name}`,
       });
     } catch (error) {
       getLog().error({ err: error, runId }, 'api.workflow_run_resume_failed');

--- a/packages/server/src/routes/api.workflow-runs.test.ts
+++ b/packages/server/src/routes/api.workflow-runs.test.ts
@@ -1029,6 +1029,8 @@ describe('GET /api/workflows/runs/by-worker/:platformId', () => {
 describe('POST /api/workflows/runs/:runId/resume', () => {
   beforeEach(() => {
     mockGetWorkflowRun.mockReset();
+    mockGetConversationById.mockReset();
+    mockHandleMessage.mockReset();
   });
 
   test('returns 404 when run not found', async () => {
@@ -1051,16 +1053,90 @@ describe('POST /api/workflows/runs/:runId/resume', () => {
     expect(body.error).toContain('Cannot resume');
   });
 
-  test('returns 200 with message when run is failed', async () => {
-    mockGetWorkflowRun.mockResolvedValueOnce(MOCK_FAILED_RUN);
+  test('returns 400 with CLI hint when run has no parent_conversation_id', async () => {
+    // CLI-created runs cannot be resumed from the web dashboard — the API
+    // surfaces the equivalent CLI command rather than silently doing nothing.
+    mockGetWorkflowRun.mockResolvedValueOnce({
+      ...MOCK_FAILED_RUN,
+      parent_conversation_id: null,
+    });
     const { app } = makeApp();
     const response = await app.request('/api/workflows/runs/run-uuid-4/resume', {
       method: 'POST',
     });
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toContain('archon workflow resume run-uuid-4');
+    expect(mockHandleMessage).not.toHaveBeenCalled();
+  });
+
+  test('returns 400 when parent conversation no longer exists', async () => {
+    mockGetWorkflowRun.mockResolvedValueOnce({
+      ...MOCK_FAILED_RUN,
+      parent_conversation_id: 'deleted-conv-uuid',
+    });
+    mockGetConversationById.mockResolvedValueOnce(null);
+    const { app } = makeApp();
+    const response = await app.request('/api/workflows/runs/run-uuid-4/resume', {
+      method: 'POST',
+    });
+    expect(response.status).toBe(400);
+    expect(mockHandleMessage).not.toHaveBeenCalled();
+  });
+
+  test('returns 400 when parent conversation is non-web', async () => {
+    // Slack/Telegram/GitHub-sourced runs cannot route through the web
+    // adapter — the dispatcher is wired to webAdapter + lockManager.
+    mockGetWorkflowRun.mockResolvedValueOnce({
+      ...MOCK_FAILED_RUN,
+      parent_conversation_id: 'slack-parent-uuid',
+    });
+    mockGetConversationById.mockResolvedValueOnce({
+      id: 'slack-parent-uuid',
+      platform_conversation_id: '1234567890.123456',
+      platform_type: 'slack',
+    });
+    const { app } = makeApp();
+    const response = await app.request('/api/workflows/runs/run-uuid-4/resume', {
+      method: 'POST',
+    });
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toContain('archon workflow resume run-uuid-4');
+    expect(mockHandleMessage).not.toHaveBeenCalled();
+  });
+
+  test('returns 200 and dispatches resume when parent is a web conversation', async () => {
+    mockGetWorkflowRun.mockResolvedValueOnce({
+      ...MOCK_FAILED_RUN,
+      parent_conversation_id: 'parent-conv-uuid',
+      user_message: 'Run the deploy',
+    });
+    mockGetConversationById.mockResolvedValueOnce({
+      id: 'parent-conv-uuid',
+      platform_conversation_id: 'web-plat-abc',
+      platform_type: 'web',
+    });
+
+    const { app } = makeApp();
+    const response = await app.request('/api/workflows/runs/run-uuid-4/resume', {
+      method: 'POST',
+    });
+
     expect(response.status).toBe(200);
     const body = (await response.json()) as { success: boolean; message: string };
     expect(body.success).toBe(true);
-    expect(body.message).toContain('ready to resume');
+    expect(body.message).toContain('Resuming workflow');
+
+    // dispatchToOrchestrator → lockManager → handleMessage
+    expect(mockHandleMessage).toHaveBeenCalled();
+    const [, platformConvId, dispatchedMessage] = mockHandleMessage.mock.calls[0] as [
+      unknown,
+      string,
+      string,
+    ];
+    expect(platformConvId).toBe('web-plat-abc');
+    expect(dispatchedMessage).toBe('/workflow run deploy Run the deploy');
   });
 });
 

--- a/packages/workflows/src/executor-preamble.test.ts
+++ b/packages/workflows/src/executor-preamble.test.ts
@@ -318,10 +318,9 @@ describe('executeWorkflow preamble', () => {
 
   describe('workflow resume', () => {
     it('uses caller-supplied preCreatedRun + priorCompletedNodes without re-querying the store', async () => {
-      // The caller has already run prepareResumedRun / hydrateResumableRun and
-      // hands the result to executeWorkflow. The executor must NOT touch
-      // findResumableRun on its own (regression for the #1392 auto-resume
-      // cross-invocation bug).
+      // The caller has already run hydrateResumableRun and hands the result
+      // to executeWorkflow. The executor must NOT touch findResumableRun on
+      // its own — that decision lives at the caller.
       const resumedRun = makeRun({ id: 'prior-run', status: 'running' });
       const priorCompletedNodes = new Map([['node-a', 'output from node-a']]);
 
@@ -341,7 +340,7 @@ describe('executeWorkflow preamble', () => {
         { preCreatedRun: resumedRun, priorCompletedNodes }
       );
 
-      // Executor never queries findResumableRun (caller did it via prepareResumedRun).
+      // Executor never queries findResumableRun (caller did it via hydrateResumableRun).
       expect(findSpy).not.toHaveBeenCalled();
       // No createWorkflowRun — caller supplied the resumed run.
       expect((store.createWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);

--- a/packages/workflows/src/executor-preamble.test.ts
+++ b/packages/workflows/src/executor-preamble.test.ts
@@ -317,16 +317,16 @@ describe('executeWorkflow preamble', () => {
   // -------------------------------------------------------------------------
 
   describe('workflow resume', () => {
-    it('resumes a prior failed DAG run when completed nodes exist', async () => {
-      const failedRun = makeRun({ id: 'prior-run', status: 'failed' });
-      const priorNodes = new Map([['node-a', 'output from node-a']]);
+    it('uses caller-supplied preCreatedRun + priorCompletedNodes without re-querying the store', async () => {
+      // The caller has already run prepareResumedRun / hydrateResumableRun and
+      // hands the result to executeWorkflow. The executor must NOT touch
+      // findResumableRun on its own (regression for the #1392 auto-resume
+      // cross-invocation bug).
       const resumedRun = makeRun({ id: 'prior-run', status: 'running' });
+      const priorCompletedNodes = new Map([['node-a', 'output from node-a']]);
 
-      const store = makeStore({
-        findResumableRun: mock(async () => failedRun),
-        getCompletedDagNodeOutputs: mock(async () => priorNodes),
-        resumeWorkflowRun: mock(async () => resumedRun),
-      });
+      const findSpy = mock(async () => null);
+      const store = makeStore({ findResumableRun: findSpy });
       const deps = makeDeps(store);
       const platform = makePlatform();
 
@@ -337,36 +337,27 @@ describe('executeWorkflow preamble', () => {
         '/tmp',
         makeWorkflow(),
         'User message',
-        'db-conv-id'
+        'db-conv-id',
+        { preCreatedRun: resumedRun, priorCompletedNodes }
       );
 
-      // No createWorkflowRun — resume used existing run
+      // Executor never queries findResumableRun (caller did it via prepareResumedRun).
+      expect(findSpy).not.toHaveBeenCalled();
+      // No createWorkflowRun — caller supplied the resumed run.
       expect((store.createWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
-
-      // resumeWorkflowRun was called with the prior run ID
-      const resumeCalls = (store.resumeWorkflowRun as ReturnType<typeof mock>).mock.calls;
-      expect(resumeCalls.length).toBe(1);
-      expect(resumeCalls[0][0]).toBe('prior-run');
-
-      // Resume notification was sent to user
+      // Resume notification was sent to user with the completed-node count.
       const resumeMsg = findMessage(platform, 'Resuming');
       expect(resumeMsg).toBeDefined();
       expect((resumeMsg as unknown[])[1]).toContain('1 already-completed node(s)');
-
-      // Workflow run ID should be from the resumed run
+      // Workflow run ID is the resumed run.
       expect(result.workflowRunId).toBe('prior-run');
     });
 
-    it('auto-resumes a prior failed DAG run when completed nodes exist (second test)', async () => {
-      const interruptedRun = makeRun({ id: 'prior-int', status: 'failed' });
-      const priorNodes = new Map([['node-a', 'output from node-a']]);
-      const resumedRun = makeRun({ id: 'prior-int', status: 'running' });
+    it('sends interactive-loop notification when priorCompletedNodes is empty (paused approval gate)', async () => {
+      const resumedRun = makeRun({ id: 'paused-loop-run', status: 'running' });
+      const priorCompletedNodes = new Map<string, string>();
 
-      const store = makeStore({
-        findResumableRun: mock(async () => interruptedRun),
-        getCompletedDagNodeOutputs: mock(async () => priorNodes),
-        resumeWorkflowRun: mock(async () => resumedRun),
-      });
+      const store = makeStore();
       const deps = makeDeps(store);
       const platform = makePlatform();
 
@@ -377,39 +368,21 @@ describe('executeWorkflow preamble', () => {
         '/tmp',
         makeWorkflow(),
         'User message',
-        'db-conv-id'
+        'db-conv-id',
+        { preCreatedRun: resumedRun, priorCompletedNodes }
       );
 
-      // No createWorkflowRun — resume used existing run
-      expect((store.createWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
-
-      // resumeWorkflowRun was called with the prior run ID
-      const resumeCalls = (store.resumeWorkflowRun as ReturnType<typeof mock>).mock.calls;
-      expect(resumeCalls.length).toBe(1);
-      expect(resumeCalls[0][0]).toBe('prior-int');
-
-      // Resume notification was sent to user
-      const resumeMsg = findMessage(platform, 'Resuming');
+      const resumeMsg = findMessage(platform, 'continuing interactive loop');
       expect(resumeMsg).toBeDefined();
-
-      // Workflow run ID should be from the resumed run
-      expect(result.workflowRunId).toBe('prior-int');
+      expect(result.workflowRunId).toBe('paused-loop-run');
     });
 
-    it('returns error when DAG resumeWorkflowRun throws', async () => {
-      const failedRun = makeRun({ id: 'prior-run', status: 'failed' });
-      const priorNodes = new Map([['node1', 'output1']]);
-      const store = makeStore({
-        findResumableRun: mock(async () => failedRun),
-        getCompletedDagNodeOutputs: mock(async () => priorNodes),
-        resumeWorkflowRun: mock(async () => {
-          throw new Error('Resume DB error');
-        }),
-      });
+    it('does NOT send a Resuming notification on a fresh run (no preCreatedRun)', async () => {
+      const store = makeStore();
       const deps = makeDeps(store);
       const platform = makePlatform();
 
-      const result = await executeWorkflow(
+      await executeWorkflow(
         deps,
         platform,
         'conv-123',
@@ -419,15 +392,11 @@ describe('executeWorkflow preamble', () => {
         'db-conv-id'
       );
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('Database error resuming');
-
-      // Error message sent to user
-      const errorMsg = findMessage(platform, 'could not activate it');
-      expect(errorMsg).toBeDefined();
-
-      // No new run was created
-      expect((store.createWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+      // Fresh runs must not trigger the resume copy.
+      const resumeMsg = findMessage(platform, 'Resuming');
+      expect(resumeMsg).toBeUndefined();
+      // A fresh run is created.
+      expect((store.createWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
     });
   });
 });

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -60,7 +60,7 @@ clearRegistry();
 registerBuiltinProviders();
 
 // --- Import after mocks ---
-import { executeWorkflow, hydrateResumableRun, prepareResumedRun } from './executor';
+import { executeWorkflow, hydrateResumableRun } from './executor';
 import type { WorkflowDeps, IWorkflowPlatform, WorkflowConfig } from './deps';
 import type { IWorkflowStore } from './store';
 import type { WorkflowDefinition, WorkflowRun } from './schemas';
@@ -371,14 +371,9 @@ describe('executeWorkflow', () => {
   // Resume orphan cleanup
   // -------------------------------------------------------------------------
 
-  // The "resume orphan cleanup" suite was removed: with the explicit-resume
-  // refactor (#1392 follow-up) the executor no longer does its own
-  // findResumableRun lookup, so there is no separate pre-created row to
-  // orphan when resume takes over. The caller now hands a single resumed
-  // run via opts.preCreatedRun + opts.priorCompletedNodes (obtained from
-  // prepareResumedRun / hydrateResumableRun). Resume-pipeline coverage now
-  // lives in the "prepareResumedRun" and "hydrateResumableRun" suites at
-  // the bottom of this file.
+  // Resume-pipeline coverage lives in the "hydrateResumableRun" suite at the
+  // bottom of this file (executor no longer queries findResumableRun on its
+  // own, so there is no orphan to clean up).
 
   // -------------------------------------------------------------------------
   // Model/provider resolution
@@ -514,13 +509,10 @@ describe('executeWorkflow', () => {
   // -------------------------------------------------------------------------
 
   describe('resume logic', () => {
-    it('does NOT call findResumableRun on its own (regression: #1392)', async () => {
+    it('does NOT call findResumableRun on its own', async () => {
       // Two back-to-back executions of the same workflow at the same cwd
-      // must not cross-leak. Before this refactor, the executor's implicit
-      // findResumableRun would silently auto-resume a prior failed run
-      // (including its cached extract-pr-number output) into the next
-      // invocation. With explicit resume, the executor never touches
-      // findResumableRun — that decision lives at the caller.
+      // must not cross-leak. Resume detection lives at the caller; the
+      // executor must never touch findResumableRun on its own.
       const findSpy = mock(async () => makeRun({ id: 'stale-prior', status: 'failed' }));
       const store = makeStore({ findResumableRun: findSpy });
       const deps = makeDeps(store);
@@ -556,8 +548,7 @@ describe('executeWorkflow', () => {
         'db-conv-1',
         { preCreatedRun: resumed, priorCompletedNodes }
       );
-      // dag-executor receives the priorCompletedNodes map (arg index 14 — same
-      // slot the old internal-resume path filled in via dagPriorCompletedNodes).
+      // dag-executor receives the priorCompletedNodes map at arg index 15.
       // dag-executor signature: deps, platform, conversationId, cwd, workflow,
       // workflowRun, provider, model, artifactsDir, logDir, baseBranch,
       // docsDir, config, configuredCommandFolder, issueContext, priorCompletedNodes
@@ -707,12 +698,8 @@ describe('executeWorkflow', () => {
   // -------------------------------------------------------------------------
 
   describe('lock cleanup on failure paths', () => {
-    // The "cancels pre-created row when resumeWorkflowRun throws" test was
-    // removed alongside the executor-internal resume code. Database errors
-    // during resumeWorkflowRun now surface from prepareResumedRun /
-    // hydrateResumableRun (they throw, with no silent fallback), which the
-    // caller handles before invoking executeWorkflow. Coverage lives in the
-    // hydrateResumableRun suite at the bottom of this file.
+    // resumeWorkflowRun DB-error coverage lives in the hydrateResumableRun
+    // suite — those errors surface at the caller now, not in the executor.
 
     it('cancels workflowRun when guard query throws (no zombie row)', async () => {
       const updateSpy = mock(async () => {});
@@ -873,13 +860,13 @@ describe('finally backstop', () => {
 });
 
 // ───────────────────────────────────────────────────────────────────────────
-// hydrateResumableRun + prepareResumedRun
+// hydrateResumableRun
 //
-// The executor no longer queries findResumableRun on its own (the cause of
-// the #1392 cross-invocation bug). Resume preparation is a caller-side
-// primitive: callers either look up the run themselves and call
-// hydrateResumableRun, or use prepareResumedRun for the canonical (workflow,
-// cwd) lookup. The executor only consumes what these return.
+// Resume preparation is a caller-side primitive: callers look up the
+// candidate themselves (via findResumableRun or
+// findResumableRunByParentConversation) and call hydrateResumableRun to
+// turn it into the form executeWorkflow expects. The executor only consumes
+// what this returns.
 // ───────────────────────────────────────────────────────────────────────────
 
 describe('hydrateResumableRun', () => {
@@ -894,7 +881,7 @@ describe('hydrateResumableRun', () => {
     const deps = makeDeps(store);
     const result = await hydrateResumableRun(deps, candidate);
     expect(result).not.toBeNull();
-    expect(result?.run).toBe(resumed);
+    expect(result?.preCreatedRun).toBe(resumed);
     expect(result?.priorCompletedNodes).toBe(priorNodes);
     expect(store.resumeWorkflowRun).toHaveBeenCalledWith('prior-failed');
   });
@@ -950,39 +937,5 @@ describe('hydrateResumableRun', () => {
     });
     const deps = makeDeps(store);
     await expect(hydrateResumableRun(deps, candidate)).rejects.toThrow('DB write failed');
-  });
-});
-
-describe('prepareResumedRun', () => {
-  it('returns null when findResumableRun returns null', async () => {
-    const store = makeStore({ findResumableRun: mock(async () => null) });
-    const deps = makeDeps(store);
-    const result = await prepareResumedRun(deps, makeWorkflow(), '/tmp');
-    expect(result).toBeNull();
-  });
-
-  it('hydrates the candidate returned by findResumableRun', async () => {
-    const candidate = makeRun({ id: 'prior', status: 'failed' });
-    const resumed = makeRun({ id: 'prior', status: 'running' });
-    const store = makeStore({
-      findResumableRun: mock(async () => candidate),
-      getCompletedDagNodeOutputs: mock(async () => new Map([['n', 'v']])),
-      resumeWorkflowRun: mock(async () => resumed),
-    });
-    const deps = makeDeps(store);
-    const result = await prepareResumedRun(deps, makeWorkflow(), '/tmp');
-    expect(result).not.toBeNull();
-    expect(result?.run).toBe(resumed);
-    expect(result?.priorCompletedNodes.get('n')).toBe('v');
-  });
-
-  it('propagates findResumableRun errors (no silent fallback)', async () => {
-    const store = makeStore({
-      findResumableRun: mock(async () => {
-        throw new Error('lookup failed');
-      }),
-    });
-    const deps = makeDeps(store);
-    await expect(prepareResumedRun(deps, makeWorkflow(), '/tmp')).rejects.toThrow('lookup failed');
   });
 });

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -60,7 +60,7 @@ clearRegistry();
 registerBuiltinProviders();
 
 // --- Import after mocks ---
-import { executeWorkflow } from './executor';
+import { executeWorkflow, hydrateResumableRun, prepareResumedRun } from './executor';
 import type { WorkflowDeps, IWorkflowPlatform, WorkflowConfig } from './deps';
 import type { IWorkflowStore } from './store';
 import type { WorkflowDefinition, WorkflowRun } from './schemas';
@@ -371,82 +371,14 @@ describe('executeWorkflow', () => {
   // Resume orphan cleanup
   // -------------------------------------------------------------------------
 
-  describe('resume orphan cleanup', () => {
-    it('cancels orphaned pre-created row when resume activates', async () => {
-      // Orchestrator dispatched and pre-created this row before resume
-      // detection ran. Once resume takes over (using resumableRun instead),
-      // the pre-created row is a stale lock-token that would block the
-      // user's next back-to-back resume.
-      const preCreated = makeRun({ id: 'pre-created-orphan', status: 'pending' });
-      const resumable = makeRun({ id: 'failed-prior-run', status: 'failed' });
-      const updateSpy = mock(async () => {});
-      const store = makeStore({
-        findResumableRun: mock(async () => resumable),
-        getCompletedDagNodeOutputs: mock(async () => new Map([['node1', 'output1']])),
-        resumeWorkflowRun: mock(async () => makeRun({ id: 'failed-prior-run', status: 'running' })),
-        updateWorkflowRun: updateSpy,
-      });
-      const deps = makeDeps(store);
-
-      await executeWorkflow(
-        deps,
-        makePlatform(),
-        'conv-1',
-        '/tmp',
-        makeWorkflow(),
-        'test message',
-        'db-conv-1',
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        preCreated
-      );
-
-      // Find the orphan-cancellation call (there may be other updateWorkflowRun
-      // calls during normal execution flow, e.g., status transitions).
-      const orphanCancelCall = updateSpy.mock.calls.find(
-        (call: unknown[]) =>
-          call[0] === 'pre-created-orphan' &&
-          (call[1] as { status?: string })?.status === 'cancelled'
-      );
-      expect(orphanCancelCall).toBeDefined();
-    });
-
-    it('proceeds with resume even if orphan cancellation fails (best-effort)', async () => {
-      const preCreated = makeRun({ id: 'pre-created-orphan', status: 'pending' });
-      const resumable = makeRun({ id: 'failed-prior-run', status: 'failed' });
-      const updateSpy = mock(async (id: string) => {
-        if (id === 'pre-created-orphan') throw new Error('DB busy');
-      });
-      const store = makeStore({
-        findResumableRun: mock(async () => resumable),
-        getCompletedDagNodeOutputs: mock(async () => new Map([['node1', 'output1']])),
-        resumeWorkflowRun: mock(async () => makeRun({ id: 'failed-prior-run', status: 'running' })),
-        updateWorkflowRun: updateSpy,
-      });
-      const deps = makeDeps(store);
-
-      const result = await executeWorkflow(
-        deps,
-        makePlatform(),
-        'conv-1',
-        '/tmp',
-        makeWorkflow(),
-        'test message',
-        'db-conv-1',
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        preCreated
-      );
-
-      // Resume must still complete — the 5-min stale-pending window is the
-      // safety net for cleanup failures here.
-      expect(result.workflowRunId).toBe('failed-prior-run');
-    });
-  });
+  // The "resume orphan cleanup" suite was removed: with the explicit-resume
+  // refactor (#1392 follow-up) the executor no longer does its own
+  // findResumableRun lookup, so there is no separate pre-created row to
+  // orphan when resume takes over. The caller now hands a single resumed
+  // run via opts.preCreatedRun + opts.priorCompletedNodes (obtained from
+  // prepareResumedRun / hydrateResumableRun). Resume-pipeline coverage now
+  // lives in the "prepareResumedRun" and "hydrateResumableRun" suites at
+  // the bottom of this file.
 
   // -------------------------------------------------------------------------
   // Model/provider resolution
@@ -582,12 +514,17 @@ describe('executeWorkflow', () => {
   // -------------------------------------------------------------------------
 
   describe('resume logic', () => {
-    it('starts fresh run when findResumableRun returns null', async () => {
-      const store = makeStore({
-        findResumableRun: mock(async () => null),
-      });
+    it('does NOT call findResumableRun on its own (regression: #1392)', async () => {
+      // Two back-to-back executions of the same workflow at the same cwd
+      // must not cross-leak. Before this refactor, the executor's implicit
+      // findResumableRun would silently auto-resume a prior failed run
+      // (including its cached extract-pr-number output) into the next
+      // invocation. With explicit resume, the executor never touches
+      // findResumableRun — that decision lives at the caller.
+      const findSpy = mock(async () => makeRun({ id: 'stale-prior', status: 'failed' }));
+      const store = makeStore({ findResumableRun: findSpy });
       const deps = makeDeps(store);
-      const result = await executeWorkflow(
+      await executeWorkflow(
         deps,
         makePlatform(),
         'conv-1',
@@ -596,74 +533,40 @@ describe('executeWorkflow', () => {
         'test message',
         'db-conv-1'
       );
-      expect(store.createWorkflowRun).toHaveBeenCalledTimes(1);
-      expect(result.workflowRunId).toBe('run-123');
-    });
-
-    it('starts fresh run when findResumableRun throws', async () => {
-      const store = makeStore({
-        findResumableRun: mock(async () => {
-          throw new Error('DB error');
-        }),
-      });
-      const deps = makeDeps(store);
-      const result = await executeWorkflow(
-        deps,
-        makePlatform(),
-        'conv-1',
-        '/tmp',
-        makeWorkflow(),
-        'test message',
-        'db-conv-1'
-      );
-      // Should fall back to creating a fresh run
-      expect(store.createWorkflowRun).toHaveBeenCalledTimes(1);
-      expect(result.workflowRunId).toBe('run-123');
-    });
-
-    it('starts fresh run when prior run has 0 completed nodes', async () => {
-      const failedRun = makeRun({ id: 'prior-run', status: 'failed' });
-      const store = makeStore({
-        findResumableRun: mock(async () => failedRun),
-        getCompletedDagNodeOutputs: mock(async () => new Map()),
-      });
-      const deps = makeDeps(store);
-      const result = await executeWorkflow(
-        deps,
-        makePlatform(),
-        'conv-1',
-        '/tmp',
-        makeWorkflow(),
-        'test message',
-        'db-conv-1'
-      );
-      // Should skip resume and create a fresh run
-      expect(store.createWorkflowRun).toHaveBeenCalledTimes(1);
+      expect(findSpy).not.toHaveBeenCalled();
       expect(store.resumeWorkflowRun).not.toHaveBeenCalled();
+      expect(store.createWorkflowRun).toHaveBeenCalledTimes(1);
     });
 
-    it('returns error when resumeWorkflowRun throws', async () => {
-      const failedRun = makeRun({ id: 'prior-run', status: 'failed' });
-      const priorNodes = new Map([['node1', 'output1']]);
-      const store = makeStore({
-        findResumableRun: mock(async () => failedRun),
-        getCompletedDagNodeOutputs: mock(async () => priorNodes),
-        resumeWorkflowRun: mock(async () => {
-          throw new Error('Resume DB error');
-        }),
-      });
+    it('runs the dag-executor with priorCompletedNodes when caller supplies them', async () => {
+      const resumed = makeRun({ id: 'resumed-run', status: 'running' });
+      const priorCompletedNodes = new Map([
+        ['node-a', 'a-output'],
+        ['node-b', 'b-output'],
+      ]);
+      const store = makeStore();
       const deps = makeDeps(store);
-      const result = await executeWorkflow(
+      await executeWorkflow(
         deps,
         makePlatform(),
         'conv-1',
         '/tmp',
         makeWorkflow(),
         'test message',
-        'db-conv-1'
+        'db-conv-1',
+        { preCreatedRun: resumed, priorCompletedNodes }
       );
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('Database error resuming');
+      // dag-executor receives the priorCompletedNodes map (arg index 14 — same
+      // slot the old internal-resume path filled in via dagPriorCompletedNodes).
+      // dag-executor signature: deps, platform, conversationId, cwd, workflow,
+      // workflowRun, provider, model, artifactsDir, logDir, baseBranch,
+      // docsDir, config, configuredCommandFolder, issueContext, priorCompletedNodes
+      const passedPriors = mockExecuteDagWorkflow.mock.calls[0]?.[15] as
+        | Map<string, string>
+        | undefined;
+      expect(passedPriors).toBe(priorCompletedNodes);
+      // No fresh row created when a preCreatedRun is supplied.
+      expect(store.createWorkflowRun).not.toHaveBeenCalled();
     });
   });
 
@@ -728,11 +631,7 @@ describe('executeWorkflow', () => {
         makeWorkflow(),
         'test message',
         'db-conv-1',
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        preRun
+        { preCreatedRun: preRun }
       );
       // Guards still run (no bypass)
       expect(store.getActiveWorkflowRunByPath).toHaveBeenCalled();
@@ -769,7 +668,7 @@ describe('executeWorkflow', () => {
         makeWorkflow(),
         'test message',
         'db-conv-1',
-        'codebase-1'
+        { codebaseId: 'codebase-1' }
       );
 
       // DB env vars should have been fetched for the codebaseId
@@ -808,43 +707,12 @@ describe('executeWorkflow', () => {
   // -------------------------------------------------------------------------
 
   describe('lock cleanup on failure paths', () => {
-    it('cancels pre-created row when resumeWorkflowRun throws', async () => {
-      const preCreated = makeRun({ id: 'pre-created-orphan', status: 'pending' });
-      const resumable = makeRun({ id: 'failed-prior-run', status: 'failed' });
-      const updateSpy = mock(async () => {});
-      const store = makeStore({
-        findResumableRun: mock(async () => resumable),
-        getCompletedDagNodeOutputs: mock(async () => new Map([['node1', 'out1']])),
-        resumeWorkflowRun: mock(async () => {
-          throw new Error('DB blew up during resume activation');
-        }),
-        updateWorkflowRun: updateSpy,
-      });
-      const deps = makeDeps(store);
-
-      const result = await executeWorkflow(
-        deps,
-        makePlatform(),
-        'conv-1',
-        '/tmp',
-        makeWorkflow(),
-        'test',
-        'db-conv-1',
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        preCreated
-      );
-
-      expect(result.success).toBe(false);
-      const cancelCall = updateSpy.mock.calls.find(
-        (call: unknown[]) =>
-          call[0] === 'pre-created-orphan' &&
-          (call[1] as { status?: string })?.status === 'cancelled'
-      );
-      expect(cancelCall).toBeDefined();
-    });
+    // The "cancels pre-created row when resumeWorkflowRun throws" test was
+    // removed alongside the executor-internal resume code. Database errors
+    // during resumeWorkflowRun now surface from prepareResumedRun /
+    // hydrateResumableRun (they throw, with no silent fallback), which the
+    // caller handles before invoking executeWorkflow. Coverage lives in the
+    // hydrateResumableRun suite at the bottom of this file.
 
     it('cancels workflowRun when guard query throws (no zombie row)', async () => {
       const updateSpy = mock(async () => {});
@@ -1001,5 +869,120 @@ describe('finally backstop', () => {
       c => typeof c[1] === 'string' && (c[1] as string).includes('exited without finalizing')
     );
     expect(backstopCall).toBeUndefined();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// hydrateResumableRun + prepareResumedRun
+//
+// The executor no longer queries findResumableRun on its own (the cause of
+// the #1392 cross-invocation bug). Resume preparation is a caller-side
+// primitive: callers either look up the run themselves and call
+// hydrateResumableRun, or use prepareResumedRun for the canonical (workflow,
+// cwd) lookup. The executor only consumes what these return.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('hydrateResumableRun', () => {
+  it('returns hydrated run + prior outputs for a candidate with completed nodes', async () => {
+    const candidate = makeRun({ id: 'prior-failed', status: 'failed' });
+    const resumed = makeRun({ id: 'prior-failed', status: 'running' });
+    const priorNodes = new Map([['n1', 'out1']]);
+    const store = makeStore({
+      getCompletedDagNodeOutputs: mock(async () => priorNodes),
+      resumeWorkflowRun: mock(async () => resumed),
+    });
+    const deps = makeDeps(store);
+    const result = await hydrateResumableRun(deps, candidate);
+    expect(result).not.toBeNull();
+    expect(result?.run).toBe(resumed);
+    expect(result?.priorCompletedNodes).toBe(priorNodes);
+    expect(store.resumeWorkflowRun).toHaveBeenCalledWith('prior-failed');
+  });
+
+  it('returns null when candidate has no completed nodes and no interactive-loop state', async () => {
+    const candidate = makeRun({ id: 'empty-prior', status: 'failed' });
+    const store = makeStore({
+      getCompletedDagNodeOutputs: mock(async () => new Map()),
+    });
+    const deps = makeDeps(store);
+    const result = await hydrateResumableRun(deps, candidate);
+    expect(result).toBeNull();
+    // Must not transition the run — there is nothing to resume.
+    expect(store.resumeWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  it('returns hydrated run when interactive-loop state is present even with zero completed nodes', async () => {
+    const candidate = makeRun({
+      id: 'paused-loop',
+      status: 'paused',
+      metadata: { approval: { type: 'interactive_loop', nodeId: 'loop-1', iteration: 2 } },
+    });
+    const resumed = makeRun({ id: 'paused-loop', status: 'running' });
+    const store = makeStore({
+      getCompletedDagNodeOutputs: mock(async () => new Map()),
+      resumeWorkflowRun: mock(async () => resumed),
+    });
+    const deps = makeDeps(store);
+    const result = await hydrateResumableRun(deps, candidate);
+    expect(result).not.toBeNull();
+    expect(result?.priorCompletedNodes.size).toBe(0);
+    expect(store.resumeWorkflowRun).toHaveBeenCalledWith('paused-loop');
+  });
+
+  it('propagates DB errors from getCompletedDagNodeOutputs (no silent fallback)', async () => {
+    const candidate = makeRun({ id: 'prior-failed', status: 'failed' });
+    const store = makeStore({
+      getCompletedDagNodeOutputs: mock(async () => {
+        throw new Error('DB read failed');
+      }),
+    });
+    const deps = makeDeps(store);
+    await expect(hydrateResumableRun(deps, candidate)).rejects.toThrow('DB read failed');
+  });
+
+  it('propagates DB errors from resumeWorkflowRun (no silent fallback)', async () => {
+    const candidate = makeRun({ id: 'prior-failed', status: 'failed' });
+    const store = makeStore({
+      getCompletedDagNodeOutputs: mock(async () => new Map([['n1', 'v1']])),
+      resumeWorkflowRun: mock(async () => {
+        throw new Error('DB write failed');
+      }),
+    });
+    const deps = makeDeps(store);
+    await expect(hydrateResumableRun(deps, candidate)).rejects.toThrow('DB write failed');
+  });
+});
+
+describe('prepareResumedRun', () => {
+  it('returns null when findResumableRun returns null', async () => {
+    const store = makeStore({ findResumableRun: mock(async () => null) });
+    const deps = makeDeps(store);
+    const result = await prepareResumedRun(deps, makeWorkflow(), '/tmp');
+    expect(result).toBeNull();
+  });
+
+  it('hydrates the candidate returned by findResumableRun', async () => {
+    const candidate = makeRun({ id: 'prior', status: 'failed' });
+    const resumed = makeRun({ id: 'prior', status: 'running' });
+    const store = makeStore({
+      findResumableRun: mock(async () => candidate),
+      getCompletedDagNodeOutputs: mock(async () => new Map([['n', 'v']])),
+      resumeWorkflowRun: mock(async () => resumed),
+    });
+    const deps = makeDeps(store);
+    const result = await prepareResumedRun(deps, makeWorkflow(), '/tmp');
+    expect(result).not.toBeNull();
+    expect(result?.run).toBe(resumed);
+    expect(result?.priorCompletedNodes.get('n')).toBe('v');
+  });
+
+  it('propagates findResumableRun errors (no silent fallback)', async () => {
+    const store = makeStore({
+      findResumableRun: mock(async () => {
+        throw new Error('lookup failed');
+      }),
+    });
+    const deps = makeDeps(store);
+    await expect(prepareResumedRun(deps, makeWorkflow(), '/tmp')).rejects.toThrow('lookup failed');
   });
 });

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -211,15 +211,25 @@ async function resolveProjectPaths(
 }
 
 /**
+ * Resume payload. `priorCompletedNodes` may only appear together with
+ * `preCreatedRun` — passing completed-node outputs without the resumed row
+ * would silently inject node-skip state into a freshly-created run. Lock-token
+ * rows (used by `dispatchBackgroundWorkflow`) supply `preCreatedRun` alone.
+ */
+type ResumePayload =
+  | { preCreatedRun: WorkflowRun; priorCompletedNodes?: Map<string, string> }
+  | { preCreatedRun?: undefined; priorCompletedNodes?: undefined };
+
+/**
  * Optional parameters for {@link executeWorkflow}. All trailing args live here
  * so call sites stay readable as new options accrue.
  *
- * Resume semantics: pass `preCreatedRun` plus `priorCompletedNodes` to resume.
- * Obtain both from {@link prepareResumedRun} — the only supported way to look
- * up a resumable run. The executor never queries the store for a prior run on
+ * To resume a prior run, obtain `preCreatedRun` + `priorCompletedNodes` from
+ * {@link hydrateResumableRun} (or look up via `findResumableRun` and hydrate)
+ * and spread them in. The executor never queries the store for a prior run on
  * its own; that decision belongs at the call site.
  */
-export interface ExecuteWorkflowOptions {
+export type ExecuteWorkflowOptions = ResumePayload & {
   /** Codebase ID for env vars + isolation context. */
   codebaseId?: string;
   /**
@@ -239,36 +249,25 @@ export interface ExecuteWorkflowOptions {
   };
   /** Parent conversation ID — enables approve/reject auto-resume from chat. */
   parentConversationId?: string;
-  /**
-   * Pre-created `WorkflowRun` row. When omitted, the executor creates a fresh
-   * row. When resuming, this must be the row returned by `prepareResumedRun`
-   * (already in `running` status).
-   */
-  preCreatedRun?: WorkflowRun;
-  /**
-   * Completed-node outputs from a prior run, supplied by `prepareResumedRun`
-   * when resuming. When omitted, all nodes run from scratch.
-   */
-  priorCompletedNodes?: Map<string, string>;
-}
+};
 
 /**
  * Hydrate an already-located resumable `WorkflowRun` candidate into the form
  * {@link executeWorkflow} expects. Returns `null` when the candidate has no
  * completed nodes and no interactive-loop gate state — nothing worth resuming.
  *
- * Use this from callers that have already done their own lookup (e.g. the
- * orchestrator's `findResumableRunByParentConversation` path, or the CLI's
- * `--resume` flow which finds the run for worktree-path resolution).
+ * The return shape is spread-compatible with {@link ExecuteWorkflowOptions}
+ * so callers can write `executeWorkflow(..., { ...hydrated, codebaseId })`.
  *
  * Throws on database errors; callers decide whether to surface or fall
- * through. Silent fallback inside the executor was the original #1392 bug,
- * so it stays out.
+ * through. The executor itself never performs this lookup — silent fallback
+ * inside the executor was the cross-invocation auto-resume bug, so it stays
+ * at the call site.
  */
 export async function hydrateResumableRun(
   deps: WorkflowDeps,
   candidate: WorkflowRun
-): Promise<{ run: WorkflowRun; priorCompletedNodes: Map<string, string> } | null> {
+): Promise<{ preCreatedRun: WorkflowRun; priorCompletedNodes: Map<string, string> } | null> {
   const priorCompletedNodes = await deps.store.getCompletedDagNodeOutputs(candidate.id);
   const hasInteractiveLoopState =
     candidate.metadata?.approval !== undefined &&
@@ -280,31 +279,12 @@ export async function hydrateResumableRun(
     );
     return null;
   }
-  const run = await deps.store.resumeWorkflowRun(candidate.id);
+  const preCreatedRun = await deps.store.resumeWorkflowRun(candidate.id);
   getLog().info(
-    { workflowRunId: run.id, priorCompletedCount: priorCompletedNodes.size },
+    { workflowRunId: preCreatedRun.id, priorCompletedCount: priorCompletedNodes.size },
     'workflow.dag_resuming'
   );
-  return { run, priorCompletedNodes };
-}
-
-/**
- * Look up the most recent resumable run for `(workflow.name, cwd)` via
- * `findResumableRun` and hydrate it. Returns `null` when no resumable run
- * exists or when the found run has nothing worth resuming.
- *
- * This is the canonical CLI-style lookup-and-prepare. Callers that already
- * hold a candidate (e.g. via `findResumableRunByParentConversation`) should
- * use {@link hydrateResumableRun} instead to avoid a duplicate query.
- */
-export async function prepareResumedRun(
-  deps: WorkflowDeps,
-  workflow: WorkflowDefinition,
-  cwd: string
-): Promise<{ run: WorkflowRun; priorCompletedNodes: Map<string, string> } | null> {
-  const candidate = await deps.store.findResumableRun(workflow.name, cwd);
-  if (!candidate) return null;
-  return hydrateResumableRun(deps, candidate);
+  return { preCreatedRun, priorCompletedNodes };
 }
 
 /**
@@ -312,9 +292,8 @@ export async function prepareResumedRun(
  *
  * Required positional args carry identity and dependencies. Everything else
  * lives in `opts` ({@link ExecuteWorkflowOptions}). To resume a prior run,
- * call {@link prepareResumedRun} first and pass its result via
- * `opts.preCreatedRun` + `opts.priorCompletedNodes` — the executor does not
- * perform resume detection on its own.
+ * call {@link hydrateResumableRun} first and spread its result into `opts` —
+ * the executor does not perform resume detection on its own.
  */
 export async function executeWorkflow(
   deps: WorkflowDeps,
@@ -395,7 +374,7 @@ export async function executeWorkflow(
   }
 
   // Workflow run + resume state. Caller decides whether to resume by passing
-  // preCreatedRun (from prepareResumedRun) + priorCompletedNodes via opts.
+  // preCreatedRun (from hydrateResumableRun) + priorCompletedNodes via opts.
   // When both are absent the executor creates a fresh row below.
   const dagPriorCompletedNodes = priorCompletedNodes;
   let workflowRun: WorkflowRun | undefined = preCreatedRun;

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -211,21 +211,110 @@ async function resolveProjectPaths(
 }
 
 /**
+ * Optional parameters for {@link executeWorkflow}. All trailing args live here
+ * so call sites stay readable as new options accrue.
+ *
+ * Resume semantics: pass `preCreatedRun` plus `priorCompletedNodes` to resume.
+ * Obtain both from {@link prepareResumedRun} — the only supported way to look
+ * up a resumable run. The executor never queries the store for a prior run on
+ * its own; that decision belongs at the call site.
+ */
+export interface ExecuteWorkflowOptions {
+  /** Codebase ID for env vars + isolation context. */
+  codebaseId?: string;
+  /**
+   * GitHub issue/PR context. When provided:
+   * - Stored in `WorkflowRun.metadata` as `{ github_context }`
+   * - Substituted into `$CONTEXT` / `$EXTERNAL_CONTEXT` / `$ISSUE_CONTEXT` variables
+   * - Appended to prompts that reference none of those variables
+   * Expected format: Markdown with title, author, labels, and body.
+   */
+  issueContext?: string;
+  /** Worktree / branch metadata for isolation-aware nodes. */
+  isolationContext?: {
+    branchName?: string;
+    isPrReview?: boolean;
+    prSha?: string;
+    prBranch?: string;
+  };
+  /** Parent conversation ID — enables approve/reject auto-resume from chat. */
+  parentConversationId?: string;
+  /**
+   * Pre-created `WorkflowRun` row. When omitted, the executor creates a fresh
+   * row. When resuming, this must be the row returned by `prepareResumedRun`
+   * (already in `running` status).
+   */
+  preCreatedRun?: WorkflowRun;
+  /**
+   * Completed-node outputs from a prior run, supplied by `prepareResumedRun`
+   * when resuming. When omitted, all nodes run from scratch.
+   */
+  priorCompletedNodes?: Map<string, string>;
+}
+
+/**
+ * Hydrate an already-located resumable `WorkflowRun` candidate into the form
+ * {@link executeWorkflow} expects. Returns `null` when the candidate has no
+ * completed nodes and no interactive-loop gate state — nothing worth resuming.
+ *
+ * Use this from callers that have already done their own lookup (e.g. the
+ * orchestrator's `findResumableRunByParentConversation` path, or the CLI's
+ * `--resume` flow which finds the run for worktree-path resolution).
+ *
+ * Throws on database errors; callers decide whether to surface or fall
+ * through. Silent fallback inside the executor was the original #1392 bug,
+ * so it stays out.
+ */
+export async function hydrateResumableRun(
+  deps: WorkflowDeps,
+  candidate: WorkflowRun
+): Promise<{ run: WorkflowRun; priorCompletedNodes: Map<string, string> } | null> {
+  const priorCompletedNodes = await deps.store.getCompletedDagNodeOutputs(candidate.id);
+  const hasInteractiveLoopState =
+    candidate.metadata?.approval !== undefined &&
+    (candidate.metadata.approval as Record<string, unknown>).type === 'interactive_loop';
+  if (priorCompletedNodes.size === 0 && !hasInteractiveLoopState) {
+    getLog().info(
+      { resumableRunId: candidate.id },
+      'workflow.dag_resume_skipped_no_completed_nodes'
+    );
+    return null;
+  }
+  const run = await deps.store.resumeWorkflowRun(candidate.id);
+  getLog().info(
+    { workflowRunId: run.id, priorCompletedCount: priorCompletedNodes.size },
+    'workflow.dag_resuming'
+  );
+  return { run, priorCompletedNodes };
+}
+
+/**
+ * Look up the most recent resumable run for `(workflow.name, cwd)` via
+ * `findResumableRun` and hydrate it. Returns `null` when no resumable run
+ * exists or when the found run has nothing worth resuming.
+ *
+ * This is the canonical CLI-style lookup-and-prepare. Callers that already
+ * hold a candidate (e.g. via `findResumableRunByParentConversation`) should
+ * use {@link hydrateResumableRun} instead to avoid a duplicate query.
+ */
+export async function prepareResumedRun(
+  deps: WorkflowDeps,
+  workflow: WorkflowDefinition,
+  cwd: string
+): Promise<{ run: WorkflowRun; priorCompletedNodes: Map<string, string> } | null> {
+  const candidate = await deps.store.findResumableRun(workflow.name, cwd);
+  if (!candidate) return null;
+  return hydrateResumableRun(deps, candidate);
+}
+
+/**
  * Execute a complete DAG-based workflow.
  *
- * @param deps - Workflow dependencies (store, assistant client factory, config loader)
- * @param platform - The platform adapter for sending messages
- * @param conversationId - The platform-specific conversation ID
- * @param cwd - The working directory for command execution
- * @param workflow - The workflow definition to execute
- * @param userMessage - The user's trigger message
- * @param conversationDbId - The database conversation ID
- * @param codebaseId - Optional codebase ID for context
- * @param issueContext - Optional GitHub issue/PR context. When provided:
- *   - Stored in WorkflowRun.metadata as { github_context: issueContext }
- *   - Used to substitute $CONTEXT, $EXTERNAL_CONTEXT, $ISSUE_CONTEXT variables in prompts
- *   - Appended to prompts if no context variables are present (to ensure AI receives context)
- *   Expected format: Markdown with issue title, author, labels, and body
+ * Required positional args carry identity and dependencies. Everything else
+ * lives in `opts` ({@link ExecuteWorkflowOptions}). To resume a prior run,
+ * call {@link prepareResumedRun} first and pass its result via
+ * `opts.preCreatedRun` + `opts.priorCompletedNodes` — the executor does not
+ * perform resume detection on its own.
  */
 export async function executeWorkflow(
   deps: WorkflowDeps,
@@ -235,17 +324,16 @@ export async function executeWorkflow(
   workflow: WorkflowDefinition,
   userMessage: string,
   conversationDbId: string,
-  codebaseId?: string,
-  issueContext?: string,
-  isolationContext?: {
-    branchName?: string;
-    isPrReview?: boolean;
-    prSha?: string;
-    prBranch?: string;
-  },
-  parentConversationId?: string,
-  preCreatedRun?: WorkflowRun
+  opts: ExecuteWorkflowOptions = {}
 ): Promise<WorkflowExecutionResult> {
+  const {
+    codebaseId,
+    issueContext,
+    isolationContext,
+    parentConversationId,
+    preCreatedRun,
+    priorCompletedNodes,
+  } = opts;
   // Load config once for the entire workflow execution
   const fileConfig = await deps.loadConfig(cwd);
   const dbEnvVars = codebaseId ? await deps.store.getCodebaseEnvVars(codebaseId) : {};
@@ -306,138 +394,18 @@ export async function executeWorkflow(
     getLog().debug({ configuredCommandFolder }, 'command_folder_configured');
   }
 
-  // Resume detection and concurrent-run checks
-  let dagPriorCompletedNodes: Map<string, string> | undefined;
+  // Workflow run + resume state. Caller decides whether to resume by passing
+  // preCreatedRun (from prepareResumedRun) + priorCompletedNodes via opts.
+  // When both are absent the executor creates a fresh row below.
+  const dagPriorCompletedNodes = priorCompletedNodes;
   let workflowRun: WorkflowRun | undefined = preCreatedRun;
 
-  // Resume detection: check for prior failed run on same workflow + worktree
-  {
-    // Step 1: Find prior failed run — non-critical, fall through on DB error
-    let resumableRun: Awaited<ReturnType<typeof deps.store.findResumableRun>> = null;
-    try {
-      resumableRun = await deps.store.findResumableRun(workflow.name, cwd);
-    } catch (error) {
-      const err = error as Error;
-      getLog().error(
-        { err, workflowName: workflow.name, cwd, errorType: err.constructor.name },
-        'workflow_resume_check_failed'
-      );
-      // Non-critical: fall through to create a new run; notify user so they know resume was skipped
-      // (workflowName is already captured in the warn log above for correlation)
-      await safeSendMessage(
-        platform,
-        conversationId,
-        '⚠️ Could not check for a prior run to resume (database error). Starting a fresh run instead.'
-      );
-    }
-
-    // Step 2: Activate the resume — propagate as error if this fails
-    if (resumableRun) {
-      // Load completed node outputs from the prior run's events.
-      let priorNodes: Map<string, string>;
-      try {
-        priorNodes = await deps.store.getCompletedDagNodeOutputs(resumableRun.id);
-      } catch (error) {
-        const err = error as Error;
-        getLog().warn(
-          {
-            err,
-            workflowName: workflow.name,
-            resumableRunId: resumableRun.id,
-            errorType: err.constructor.name,
-          },
-          'workflow.dag_resume_node_outputs_failed'
-        );
-        // Intentional: fall back to empty map (fresh start) if prior node outputs can't be loaded.
-        // getCompletedDagNodeOutputs threw unexpectedly — safe to degrade rather than abort the run.
-        priorNodes = new Map();
-        await safeSendMessage(
-          platform,
-          conversationId,
-          '⚠️ Could not load prior node outputs for resume (database error). Starting a fresh run instead.'
-        );
-      }
-      // Resume if there are completed nodes OR if the run has interactive loop state
-      // (a paused interactive loop may have no completed nodes yet — just the loop itself pausing)
-      const hasInteractiveLoopState =
-        resumableRun.metadata?.approval &&
-        (resumableRun.metadata.approval as Record<string, unknown>).type === 'interactive_loop';
-      if (priorNodes.size > 0 || hasInteractiveLoopState) {
-        try {
-          // Capture the orphan BEFORE replacing workflowRun. The orchestrator's
-          // pre-created row was a lock-token claim on this path; once resume
-          // takes over, that claim is redundant. Without releasing it, a
-          // back-to-back resume would block on its own ghost lock until the
-          // 5-minute stale-pending window in getActiveWorkflowRunByPath.
-          const orphanPreCreated =
-            preCreatedRun && preCreatedRun.id !== resumableRun.id ? preCreatedRun : null;
-
-          workflowRun = await deps.store.resumeWorkflowRun(resumableRun.id);
-          dagPriorCompletedNodes = priorNodes;
-
-          if (orphanPreCreated) {
-            await deps.store
-              .updateWorkflowRun(orphanPreCreated.id, { status: 'cancelled' })
-              .catch((cleanupErr: Error) => {
-                // Best-effort: log and continue. The 5-min stale-pending
-                // window is the safety net if this fails.
-                getLog().warn(
-                  {
-                    err: cleanupErr,
-                    orphanId: orphanPreCreated.id,
-                    resumedRunId: workflowRun?.id,
-                  },
-                  'workflow.resume_orphan_cleanup_failed'
-                );
-              });
-          }
-
-          getLog().info(
-            {
-              workflowRunId: workflowRun.id,
-              priorCompletedCount: priorNodes.size,
-            },
-            'workflow.dag_resuming'
-          );
-          const resumeMsg =
-            priorNodes.size > 0
-              ? `▶️ **Resuming** workflow \`${workflow.name}\` — skipping ${String(priorNodes.size)} already-completed node(s).\n\nNote: AI session context from prior nodes is not restored. Nodes that depend on prior context may need to re-read artifacts.`
-              : `▶️ **Resuming** workflow \`${workflow.name}\` — continuing interactive loop.`;
-          await safeSendMessage(platform, conversationId, resumeMsg);
-        } catch (error) {
-          const err = error as Error;
-          getLog().error(
-            { err, workflowName: workflow.name, resumableRunId: resumableRun.id },
-            'workflow_resume_activate_failed'
-          );
-          // Release the pre-created lock token. Without this, preCreatedRun
-          // sits as `pending` and blocks the path until the 5-min stale
-          // window — the user would see "in use by self" on retry.
-          if (preCreatedRun) {
-            await deps.store
-              .updateWorkflowRun(preCreatedRun.id, { status: 'cancelled' })
-              .catch((cleanupErr: Error) => {
-                getLog().warn(
-                  { err: cleanupErr, preCreatedRunId: preCreatedRun.id },
-                  'workflow.resume_failure_cleanup_failed'
-                );
-              });
-          }
-          await sendCriticalMessage(
-            platform,
-            conversationId,
-            '❌ **Workflow failed**: Found a prior run to resume but could not activate it (database error). Please try again later.'
-          );
-          return { success: false, error: 'Database error resuming workflow run' };
-        }
-      } else {
-        // Found prior failed DAG run but no nodes completed — not worth resuming
-        getLog().info(
-          { workflowRunId: resumableRun.id },
-          'workflow.dag_resume_skipped_no_completed_nodes'
-        );
-      }
-    }
+  if (preCreatedRun && priorCompletedNodes !== undefined) {
+    const resumeMsg =
+      priorCompletedNodes.size > 0
+        ? `▶️ **Resuming** workflow \`${workflow.name}\` — skipping ${String(priorCompletedNodes.size)} already-completed node(s).\n\nNote: AI session context from prior nodes is not restored. Nodes that depend on prior context may need to re-read artifacts.`
+        : `▶️ **Resuming** workflow \`${workflow.name}\` — continuing interactive loop.`;
+    await safeSendMessage(platform, conversationId, resumeMsg);
   }
 
   if (!workflowRun) {


### PR DESCRIPTION
## Summary

- **Problem:** `executeWorkflow` silently auto-resumed the most recent failed run for the same `(workflow_name, cwd)` pair. The `--resume` CLI flag was documented as opt-in but had no causal effect on this code path; it only steered worktree selection. We reproduced the live failure mode in PR #1282's review queue — `extract-pr-number`'s cached output "1634" leaked into every subsequent invocation of `archon workflow run maintainer-review-pr <N>` for the same `cwd`.
- **Why it matters:** Users who changed inputs or wanted a fresh start silently got a cached resume instead — visible as wrong outputs, ghost state across "unrelated" runs, and behaviour that contradicted the docs.
- **What changed:** Moves the resume decision out of `executeWorkflow` and into the caller. Two new helpers (`hydrateResumableRun`, `prepareResumedRun`) cover the two real lookup shapes. Trailing positional args consolidate into a single `ExecuteWorkflowOptions` bag — fixes the `undefined, undefined, undefined, undefined, true` smell at call sites. Orphan-cleanup code deletes outright.
- **What did NOT change (scope boundary):** Approve/reject auto-resume from chat (still works — orchestrator now calls `hydrateResumableRun` directly with the run row it already found). Web UI resume button. `archon workflow resume <id>` semantics. DB schema. Platform adapters.

## UX Journey

### Before

```
User                          CLI                        executeWorkflow
────                          ───                        ───────────────
archon workflow run foo "x"   ─────────────────────────▶ findResumableRun()  ← fires always
                                                         found prior failed run
                                                         ▶ silently resumes (wrong inputs!)
```

### After

```
User                          CLI                        executeWorkflow
────                          ───                        ───────────────
archon workflow run foo "x"   ─────────────────────────▶ no internal lookup
                                                         ▶ creates fresh run ✓

archon workflow run foo "x" --resume
                              looks up + hydrates  ───▶  executes resumed run ✓

archon workflow resume <id>   → workflowRunCommand({resume: true})
                              looks up + hydrates  ───▶  executes resumed run ✓
```

## Architecture Diagram

### Before

```
executor.ts
  findResumableRun() ← unconditional, internal
    │
    └─→ if found: resumeWorkflowRun + load priors
        else:     use preCreatedRun or create fresh

CLI workflow.ts (--resume)
  workflowDb.findResumableRun()  ← used only for worktree path selection
  executeWorkflow(...positionals)  ← executor re-discovers via its own findResumableRun

orchestrator-agent.ts (foreground-resume)
  findResumableRunByParentConversation()  ← used only for working_path
  executeWorkflow(...positionals)  ← executor re-discovers via its own findResumableRun
```

### After

```
@archon/workflows/executor (NEW)
  prepareResumedRun(deps, workflow, cwd)
    └── findResumableRun → hydrateResumableRun
  hydrateResumableRun(deps, candidate)
    ├── getCompletedDagNodeOutputs
    ├── return null if 0 nodes + no interactive-loop state
    └── resumeWorkflowRun → { run, priorCompletedNodes }
  executeWorkflow(..., opts: ExecuteWorkflowOptions)
    ├── opts.preCreatedRun ? use it : createWorkflowRun
    ├── opts.priorCompletedNodes → flows to dag-executor
    └── NO store lookups

CLI workflow.ts (--resume)
  workflowDb.findResumableRun()  ← path resolution + candidate
  hydrateResumableRun(deps, candidate)  ← new
  executeWorkflow(..., { preCreatedRun, priorCompletedNodes })

orchestrator-agent.ts (foreground-resume)
  findResumableRunByParentConversation()  ← path resolution + candidate
  hydrateResumableRun(deps, candidate)  ← new
  executeWorkflow(..., { preCreatedRun, priorCompletedNodes })
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `executor.ts` | `findResumableRun` | **removed** | Executor no longer queries the store for prior runs |
| `executor.ts` | `prepareResumedRun` / `hydrateResumableRun` | **new exports** | Caller-invoked resume preparation |
| `executor.ts` | `ExecuteWorkflowOptions` | **new export** | All trailing optional args (codebaseId, issueContext, isolationContext, parentConversationId, preCreatedRun, priorCompletedNodes) |
| `cli/workflow.ts` | `hydrateResumableRun` | **new** | Reuses the candidate already found for worktree-path resolution |
| `orchestrator.ts` | `executeWorkflow` | **call shape** | Trailing args → opts bag |
| `orchestrator-agent.ts` foreground-resume | `hydrateResumableRun` | **new** | Was relying on executor internal auto-resume |
| `orchestrator-agent.ts` interactive | `executeWorkflow` | **call shape** | Trailing args → opts bag |
| Orphan-cleanup code in `executor.ts` (~120 lines) | — | **removed** | No `preCreatedRun` to orphan now that resume flows through opts |

## Label Snapshot

- Risk: `risk: low` — closes #1392; behaviour now matches documented `--resume` semantics; smaller diff than #1396.
- Size: `size: M`
- Scope: `workflows`, `cli`, `core`
- Module: `workflows:executor`, `cli:workflow`, `core:orchestrator`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

Closes #1392. Supersedes #1396.

## Validation Evidence (required)

```bash
bun run validate  # ✅ exit 0
```

- `check:bundled`, `check:bundled-skill`, `type-check`, `lint --max-warnings 0`, `format:check`, all per-package test batches — green.
- 72 test batches passed, 0 failures. New / changed tests:
  - `prepareResumedRun` suite (`null` when no resumable, hydrates candidate, propagates DB errors)
  - `hydrateResumableRun` suite (hydrate, return null on zero+no-loop, paused-loop hydration, DB error propagation on both `getCompletedDagNodeOutputs` and `resumeWorkflowRun`)
  - **Regression test for #1392 cross-invocation leak**: asserts the executor does NOT call `findResumableRun` on its own
  - `executor.test.ts` "uses caller-supplied preCreatedRun + priorCompletedNodes" — asserts opts flow into dag-executor at the right slot
  - Updated orchestrator + orchestrator-agent tests to assert resume payload on the opts bag

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? **No for `executeWorkflow` callers (API)**, **yes for users of documented CLI/UI surfaces**.
  - The signature change is breaking for any external caller of `executeWorkflow`. There are no public extension points that call it directly; in-tree callers are migrated in this commit.
  - User-facing behaviour: `archon workflow run <name>` always starts fresh (matches docs); resume requires `--resume`, `archon workflow resume <id>`, the web UI button, or approve/reject in chat (unchanged).
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

What was personally validated beyond CI:

- **Verified scenarios:** Full validate suite passes; manually ran the failing reproduction from the standup queue (back-to-back `archon workflow run maintainer-review-pr <N>` for different `<N>`) — confirms each invocation now creates a fresh run, no `dag.node_skipped_prior_success` leak.
- **Edge cases checked:**
  - Plain run with no prior failed run — fresh run created.
  - Plain run when a prior failed run exists for `(workflow, cwd)` — fresh run created (no implicit resume). This is the bug-fix.
  - `--resume` with a resumable prior run — resumes and skips completed nodes.
  - `--resume` with no resumable prior run — clear error, no fresh run.
  - Orchestrator foreground-resume (approve/reject from chat) — `hydrateResumableRun` succeeds and resume continues.
- **What was not verified:**
  - Live end-to-end web UI resume button flow (the bridge call path is unchanged; only positional → opts call shape).

## Side Effects / Blast Radius (required)

- **Affected subsystems:** Workflow executor (`packages/workflows/src/executor.ts`), CLI `workflow run` / `workflow resume`, orchestrator chat dispatch (background + foreground-resume + interactive paths). No DB schema or adapter changes.
- **Potential unintended effects:** Anyone scripting against the previous undocumented implicit auto-resume behaviour will now get fresh runs. This matches docs.
- **Guardrails:** Existing tests for `--resume`, approve/reject, foreground-resume, and concurrent-run-guard are all updated and pass. A new regression test pins down the cross-invocation leak from #1392.

## Rollback Plan (required)

- **Fast rollback:** Revert the commit.
- **Feature flags:** None.
- **Observable failure symptoms:** Users reporting "`--resume` does not resume" (would indicate a positional/opts wiring bug). The fix has zero observable change for invocations that don't use `--resume` — they always start fresh, as documented.

## Risks and Mitigations

- **Risk:** Users who depended on the undocumented implicit auto-resume will now get a fresh run.
  - Mitigation: This matches the documented behaviour. The `--resume` flag and `/workflow resume <id>` command are the explicit paths. CHANGELOG entry calls this out.
- **Risk:** Test-mock divergence on `@archon/workflows/executor` for callers that mock it.
  - Mitigation: Updated all in-tree mocks. The new `hydrateResumableRun` export is part of the module signature, so consumers needing tighter test-mocks now know the surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow run no longer auto-resumes on re-run; resume is explicit via CLI `--resume`, `archon workflow resume <id>`, or Web UI resume. Web resume now validates a parent web conversation and dispatches a resume message.

* **Documentation**
  * Clarified resume mechanics across guides and API docs: resuming skips already-completed steps and is opt-in.

* **Tests**
  * Expanded tests to cover resume paths and error conditions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1646)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->