### PR TITLE
fix(providers): MCP env var expansion supports ${VAR} brace syntax

### DIFF
--- a/packages/docs-web/src/content/docs/guides/mcp-servers.md
+++ b/packages/docs-web/src/content/docs/guides/mcp-servers.md
@@ -128,7 +128,7 @@ expanded from `process.env` at execution time.
     "command": "npx",
     "args": ["-y", "@mcp/server-postgres"],
     "env": {
-      "DATABASE_URL": "$DATABASE_URL",
+      "DATABASE_URL": "${DATABASE_URL}",
       "POOL_SIZE": "$DB_POOL_SIZE"
     }
   }

--- a/packages/docs-web/src/content/docs/guides/mcp-servers.md
+++ b/packages/docs-web/src/content/docs/guides/mcp-servers.md
@@ -119,7 +119,7 @@ Connects to an SSE endpoint.
 
 ## Environment Variable Expansion
 
-Values in `env` and `headers` fields support `$VAR_NAME` references that are
+Values in `env` and `headers` fields support `$VAR_NAME` and `${VAR_NAME}` references that are
 expanded from `process.env` at execution time.
 
 ```json
@@ -136,7 +136,7 @@ expanded from `process.env` at execution time.
 ```
 
 **Rules:**
-- Pattern: `$UPPER_CASE_VAR` (matches `[A-Z_][A-Z0-9_]*`)
+- Patterns: `$UPPER_CASE_VAR` and `${UPPER_CASE_VAR}` (matches `[A-Z_][A-Z0-9_]*`)
 - Only `env` and `headers` values are expanded — `command`, `args`, `url` are left untouched
 - Undefined vars are replaced with empty string and a warning is shown:
   `Warning: Node 'X' MCP config references undefined env vars: VAR_NAME`

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -206,7 +206,7 @@ export function getProcessUid(): number | undefined {
 // ─── MCP Config Loading (absorbed from dag-executor) ───────────────────────
 
 /**
- * Expand $VAR_NAME references in string-valued records from process.env.
+ * Expand $VAR_NAME and ${VAR_NAME} references in string-valued records from process.env.
  */
 function expandEnvVarsInRecord(
   record: Record<string, unknown>,
@@ -219,13 +219,18 @@ function expandEnvVarsInRecord(
       result[key] = String(val);
       continue;
     }
-    result[key] = val.replace(/\$([A-Z_][A-Z0-9_]*)/g, (_, varName: string) => {
-      const envVal = process.env[varName];
-      if (envVal === undefined) {
-        missingVars.push(varName);
+    result[key] = val.replace(
+      /\$(?:\{([A-Z_][A-Z0-9_]*)\}|([A-Z_][A-Z0-9_]*))/g,
+      (_, braced: string | undefined, bare: string | undefined) => {
+        const varName = braced ?? bare;
+        if (varName === undefined) return '';
+        const envVal = process.env[varName];
+        if (envVal === undefined) {
+          missingVars.push(varName);
+        }
+        return envVal ?? '';
       }
-      return envVal ?? '';
-    });
+    );
   }
   return result;
 }

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -223,6 +223,7 @@ function expandEnvVarsInRecord(
       /\$(?:\{([A-Z_][A-Z0-9_]*)\}|([A-Z_][A-Z0-9_]*))/g,
       (_, braced: string | undefined, bare: string | undefined) => {
         const varName = braced ?? bare;
+        // varName is always string — regex alternation guarantees one group matches
         if (varName === undefined) return '';
         const envVal = process.env[varName];
         if (envVal === undefined) {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -2398,13 +2398,15 @@ describe('loadMcpConfig', () => {
 
   it('does not expand vars in command or args fields', async () => {
     process.env.TEST_CMD_445 = 'should-not-expand';
-    const config = { svc: { command: '$TEST_CMD_445', args: ['$TEST_CMD_445'] } };
+    const config = {
+      svc: { command: '$TEST_CMD_445', args: ['$TEST_CMD_445', '${TEST_CMD_445}'] },
+    };
     await writeFile(join(testDir, 'mcp.json'), JSON.stringify(config));
 
     const result = await loadMcpConfig('mcp.json', testDir);
     const server = result.servers.svc as Record<string, unknown>;
     expect(server.command).toBe('$TEST_CMD_445');
-    expect(server.args).toEqual(['$TEST_CMD_445']);
+    expect(server.args).toEqual(['$TEST_CMD_445', '${TEST_CMD_445}']);
 
     delete process.env.TEST_CMD_445;
   });

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -2303,6 +2303,70 @@ describe('loadMcpConfig', () => {
     delete process.env.TEST_MCP_TOKEN_445;
   });
 
+  it('expands ${VAR} brace syntax in env values', async () => {
+    process.env.TEST_MCP_BRACE_TOKEN_1612 = 'secret-brace';
+    const config = {
+      github: { command: 'npx', env: { TOKEN: '${TEST_MCP_BRACE_TOKEN_1612}' } },
+    };
+    await writeFile(join(testDir, 'mcp.json'), JSON.stringify(config));
+
+    const result = await loadMcpConfig('mcp.json', testDir);
+    const server = result.servers.github as Record<string, unknown>;
+    expect(server.env).toEqual({ TOKEN: 'secret-brace' });
+
+    delete process.env.TEST_MCP_BRACE_TOKEN_1612;
+  });
+
+  it('expands mixed $VAR and ${VAR} syntax in the same string', async () => {
+    process.env.TEST_MCP_HOST_1612 = 'localhost';
+    process.env.TEST_MCP_PORT_1612 = '5432';
+    const config = {
+      db: {
+        command: 'npx',
+        env: { URL: 'postgresql://$TEST_MCP_HOST_1612:${TEST_MCP_PORT_1612}/mydb' },
+      },
+    };
+    await writeFile(join(testDir, 'mcp.json'), JSON.stringify(config));
+
+    const result = await loadMcpConfig('mcp.json', testDir);
+    const server = result.servers.db as Record<string, unknown>;
+    expect(server.env).toEqual({ URL: 'postgresql://localhost:5432/mydb' });
+
+    delete process.env.TEST_MCP_HOST_1612;
+    delete process.env.TEST_MCP_PORT_1612;
+  });
+
+  it('reports missing vars for ${VAR} brace syntax', async () => {
+    delete process.env.NONEXISTENT_BRACE_VAR_1612;
+    const config = {
+      svc: { command: 'npx', env: { KEY: '${NONEXISTENT_BRACE_VAR_1612}' } },
+    };
+    await writeFile(join(testDir, 'mcp.json'), JSON.stringify(config));
+
+    const result = await loadMcpConfig('mcp.json', testDir);
+    const server = result.servers.svc as Record<string, unknown>;
+    expect(server.env).toEqual({ KEY: '' });
+    expect(result.missingVars).toContain('NONEXISTENT_BRACE_VAR_1612');
+  });
+
+  it('expands ${VAR} brace syntax in headers values', async () => {
+    process.env.TEST_MCP_BRACE_KEY_1612 = 'bearer-token';
+    const config = {
+      api: {
+        type: 'http',
+        url: 'https://example.com',
+        headers: { Authorization: 'Bearer ${TEST_MCP_BRACE_KEY_1612}' },
+      },
+    };
+    await writeFile(join(testDir, 'mcp.json'), JSON.stringify(config));
+
+    const result = await loadMcpConfig('mcp.json', testDir);
+    const server = result.servers.api as Record<string, unknown>;
+    expect(server.headers).toEqual({ Authorization: 'Bearer bearer-token' });
+
+    delete process.env.TEST_MCP_BRACE_KEY_1612;
+  });
+
   it('expands $VAR_NAME in headers values', async () => {
     process.env.TEST_API_KEY_445 = 'key456';
     const config = {


### PR DESCRIPTION
## Summary

- **Problem:** `expandEnvVarsInRecord` in `packages/providers/src/claude/provider.ts` only matched the bare `$VAR_NAME` form. The `${VAR_NAME}` brace syntax — standard in shell, Docker Compose, and MCP server documentation — was silently passed through unexpanded, causing MCP servers to receive literal `${...}` strings instead of resolved secrets.
- **Why it matters:** Users copy MCP config examples from official tooling that uses `${VAR}` form. The silent failure (no error, garbage value) makes this particularly hard to debug.
- **What changed:** Extended the regex in `expandEnvVarsInRecord` to a two-branch alternation that handles both `$VAR` and `${VAR}` in a single pass; added 4 new test cases; updated the MCP servers guide to document both forms.
- **What did not change (scope boundary):** `command`, `args`, and `url` fields are intentionally not expanded (security boundary). Lowercase variable names remain unsupported. No other env expansion systems (workflow variable substitution) were touched.

## UX Journey

### Before

```
User writes MCP config:
  { "env": { "API_KEY": "${MY_API_KEY}" } }

  User                    Archon                   MCP Server
  ────                    ──────                   ──────────
  sets MY_API_KEY=secret
  runs workflow ────────▶ loads mcp.json
                          expandEnvVarsInRecord()
                          regex: /\$([A-Z_][A-Z0-9_]*)/g
                          "${MY_API_KEY}" → no match
                          passes literal through ──────────▶ receives "${MY_API_KEY}"
                                                              (broken — auth fails silently)
```

### After

```
User writes MCP config:
  { "env": { "API_KEY": "${MY_API_KEY}" } }

  User                    Archon                   MCP Server
  ────                    ──────                   ──────────
  sets MY_API_KEY=secret
  runs workflow ────────▶ loads mcp.json
                          expandEnvVarsInRecord()
                          [~] regex: /\$(?:\{([A-Z_][A-Z0-9_]*)\}|([A-Z_][A-Z0-9_]*))/g
                          "${MY_API_KEY}" → matches brace branch → "secret"
                          passes resolved value ───────────▶ receives "secret" ✓
```

## Architecture Diagram

### Before

```
dag-executor.ts
    └── loadMcpConfig()
            └── expandEnvVars()
                    └── expandEnvVarsInRecord()
                            └── /\$([A-Z_][A-Z0-9_]*)/g
                                (only matches bare $VAR)
```

### After

```
dag-executor.ts
    └── loadMcpConfig()
            └── expandEnvVars()
                    └── expandEnvVarsInRecord()
                            [~] └── /\$(?:\{([A-Z_][A-Z0-9_]*)\}|([A-Z_][A-Z0-9_]*))/g
                                    (matches both $VAR and ${VAR})
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `dag-executor.ts` | `loadMcpConfig` | unchanged | call site unchanged |
| `loadMcpConfig` | `expandEnvVars` | unchanged | call site unchanged |
| `expandEnvVars` | `expandEnvVarsInRecord` | unchanged | call site unchanged |
| `expandEnvVarsInRecord` | regex engine | **modified** | alternation regex added |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `providers`
- Module: `providers:claude`

## Change Metadata

- Change type: `bug`
- Primary scope: `providers`

## Linked Issue

- Closes #1612
- Supersedes #1621 (archon/task-fix-issue-1612-v2 — had merge conflicts with dev; this is an equivalent, conflict-free implementation)

## Validation Evidence (required)

```bash
bun run type-check   # ✅ All 10 packages pass
bun run lint         # ✅ 0 errors, 0 warnings (zero-tolerance policy)
bun run format:check # ✅ Pass
bun run test         # ✅ ~3,538 tests pass across all packages, 0 failures
```

- **Evidence:** All 4 new tests for `${VAR}` brace syntax are in `packages/workflows/src/dag-executor.test.ts` and pass. The targeted run `bun test packages/workflows/src/dag-executor.test.ts --test-name-pattern "loadMcpConfig"` shows 15/15 pass (11 existing + 4 new).
- **No commands skipped.**

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **Yes** — the fix correctly resolves env var references that were previously passed as literals. MCP servers that use `${VAR}` syntax will now receive the actual secret value instead of the unexpanded string. This is the intended behavior; the prior behavior was a bug.
- File system access scope changed? **No**

The expansion is scoped to `env` and `headers` fields only — same as before. `command`, `args`, and `url` are intentionally excluded (security boundary, unchanged).

## Compatibility / Migration

- Backward compatible? **Yes** — `$VAR` expansion is unchanged; `${VAR}` previously passed through as-is (broken), now resolves correctly.
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

- **Verified scenarios:**
  - `${VAR}` in env values expands to the env value
  - `$VAR` and `${VAR}` mixed in the same string both expand correctly in one pass
  - `${MISSING_VAR}` is reported in `missingVars` and replaced with `''`
  - `${VAR}` in `headers` values expands correctly
  - All pre-existing `$VAR` tests continue to pass (no regression)
- **Edge cases checked:** missing var in brace form; mixed syntax in single string value
- **What was not verified:** manual end-to-end test with a live MCP server (automated tests cover the expansion logic thoroughly)

## Side Effects / Blast Radius (required)

- **Affected subsystems/workflows:** Only `expandEnvVarsInRecord` in `@archon/providers`. Called only from `expandEnvVars` → `loadMcpConfig` → `dag-executor.ts`. No other call sites.
- **Potential unintended effects:** None identified. The regex change is additive — it adds a new matching branch before the existing one; the existing `$VAR` branch behavior is preserved exactly.
- **Guardrails:** The 4 new tests serve as regression guards. `missingVars` reporting is unchanged for both forms.

## Rollback Plan (required)

- **Fast rollback:** `git revert c9c8c88f` — single commit, no migrations, no config changes.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** MCP servers receiving `${VAR_NAME}` literal strings instead of resolved values; auth failures in MCP-dependent workflow nodes.

## Risks and Mitigations

- **Risk:** Regex alternation introduces subtle precedence issue where brace form is matched when bare form was intended.
  - **Mitigation:** The brace branch is `\{([A-Z_][A-Z0-9_]*)\}` — it requires a closing `}`, so `${VAR` (unclosed) won't match either branch and passes through unchanged (same behavior as before). Test coverage includes both forms.
