### PR TITLE
feat(paths,workflows): discover Archon assets under .claude/.archon/

### DIFF
--- a/packages/paths/src/archon-paths.test.ts
+++ b/packages/paths/src/archon-paths.test.ts
@@ -177,17 +177,24 @@ describe('archon-paths', () => {
   });
 
   describe('getCommandFolderSearchPaths', () => {
-    test('returns .archon/commands and defaults by default', () => {
+    test('returns .archon and .claude/.archon command paths by default', () => {
       const paths = getCommandFolderSearchPaths();
-      expect(paths).toEqual(['.archon/commands', '.archon/commands/defaults']);
-    });
-
-    test('includes configured folder when provided', () => {
-      const paths = getCommandFolderSearchPaths('.claude/commands/archon');
       expect(paths).toEqual([
         '.archon/commands',
         '.archon/commands/defaults',
-        '.claude/commands/archon',
+        '.claude/.archon/commands',
+        '.claude/.archon/commands/defaults',
+      ]);
+    });
+
+    test('includes configured folder when provided', () => {
+      const paths = getCommandFolderSearchPaths('.custom/commands');
+      expect(paths).toEqual([
+        '.archon/commands',
+        '.archon/commands/defaults',
+        '.claude/.archon/commands',
+        '.claude/.archon/commands/defaults',
+        '.custom/commands',
       ]);
     });
 
@@ -201,21 +208,23 @@ describe('archon-paths', () => {
       expect(paths[1]).toBe('.archon/commands/defaults');
     });
 
-    test('does not duplicate .archon/commands if configured', () => {
-      const paths = getCommandFolderSearchPaths('.archon/commands');
-      expect(paths).toEqual(['.archon/commands', '.archon/commands/defaults']);
-    });
-
-    test('does not duplicate .archon/commands/defaults if configured', () => {
-      const paths = getCommandFolderSearchPaths('.archon/commands/defaults');
-      expect(paths).toEqual(['.archon/commands', '.archon/commands/defaults']);
+    test('does not duplicate any built-in path if configured', () => {
+      for (const builtin of [
+        '.archon/commands',
+        '.archon/commands/defaults',
+        '.claude/.archon/commands',
+        '.claude/.archon/commands/defaults',
+      ]) {
+        const paths = getCommandFolderSearchPaths(builtin);
+        expect(paths.filter(p => p === builtin).length).toBe(1);
+      }
     });
   });
 
   describe('getWorkflowFolderSearchPaths', () => {
-    test('returns .archon/workflows', () => {
+    test('returns .claude/.archon/workflows then .archon/workflows (root wins on conflict)', () => {
       const paths = getWorkflowFolderSearchPaths();
-      expect(paths).toEqual(['.archon/workflows']);
+      expect(paths).toEqual(['.claude/.archon/workflows', '.archon/workflows']);
     });
   });
 

--- a/packages/paths/src/archon-paths.ts
+++ b/packages/paths/src/archon-paths.ts
@@ -176,19 +176,22 @@ export function getRepoArchonEnvPath(cwd: string): string {
  * Order:
  * 1. .archon/commands (always - user's custom commands)
  * 2. .archon/commands/defaults (bundled default commands)
- * 3. configuredFolder (if specified in config)
+ * 3. .claude/.archon/commands (additive — for users co-locating Archon assets under .claude/)
+ * 4. .claude/.archon/commands/defaults
+ * 5. configuredFolder (if specified in config)
  *
  * @param configuredFolder - Optional additional folder from config
  */
 export function getCommandFolderSearchPaths(configuredFolder?: string): string[] {
-  const paths = ['.archon/commands', '.archon/commands/defaults'];
+  const paths = [
+    '.archon/commands',
+    '.archon/commands/defaults',
+    '.claude/.archon/commands',
+    '.claude/.archon/commands/defaults',
+  ];
 
   // Add configured folder if specified (and not already in paths)
-  if (
-    configuredFolder &&
-    configuredFolder !== '.archon/commands' &&
-    configuredFolder !== '.archon/commands/defaults'
-  ) {
+  if (configuredFolder && !paths.includes(configuredFolder)) {
     paths.push(configuredFolder);
   }
 
@@ -197,10 +200,12 @@ export function getCommandFolderSearchPaths(configuredFolder?: string): string[]
 
 /**
  * Get workflow folder search paths for a repository
- * Returns folders in priority order (first match wins)
+ * Returns folders in scan order. When multiple paths contain a workflow with
+ * the same filename, the LAST scanned wins — so `.archon/workflows` (root)
+ * overrides `.claude/.archon/workflows` on conflict.
  */
 export function getWorkflowFolderSearchPaths(): string[] {
-  return ['.archon/workflows'];
+  return ['.claude/.archon/workflows', '.archon/workflows'];
 }
 
 /**

--- a/packages/workflows/src/script-discovery.ts
+++ b/packages/workflows/src/script-discovery.ts
@@ -137,24 +137,34 @@ export async function discoverScripts(dir: string): Promise<Map<string, ScriptDe
 /**
  * Discover scripts across all scopes for a given repo cwd.
  *
- * Resolution order (repo wins on same-name collision — matches the
+ * Resolution order (later scope wins on same-name collision — matches the
  * workflows/commands precedence):
- *   1. `<cwd>/.archon/scripts/` — repo-scoped (`source: 'project'` equivalent)
- *   2. `~/.archon/scripts/`    — home-scoped (`source: 'global'` equivalent)
+ *   1. `~/.archon/scripts/`            — home-scoped (`source: 'global'` equivalent)
+ *   2. `<cwd>/.claude/.archon/scripts/` — repo-scoped, additive location for users co-locating
+ *      Archon assets under `.claude/`
+ *   3. `<cwd>/.archon/scripts/`        — repo-scoped (`source: 'project'` equivalent)
  *
  * Within a single scope, duplicate basenames across extensions still throw
- * (matches `discoverScripts` behavior). Across scopes, the repo-level entry
- * silently overrides the home-level one.
+ * (matches `discoverScripts` behavior). Across scopes, later entries silently
+ * override earlier ones, so root `.archon/scripts/` wins over `.claude/.archon/scripts/`
+ * which wins over `~/.archon/scripts/`.
  */
 export async function discoverScriptsForCwd(cwd: string): Promise<Map<string, ScriptDefinition>> {
   const homeScripts = await discoverScripts(getHomeScriptsPath());
+  const claudeScripts = await discoverScripts(join(cwd, '.claude', '.archon', 'scripts'));
   const repoScripts = await discoverScripts(join(cwd, '.archon', 'scripts'));
 
-  // Start with home, overlay repo (repo wins)
+  // Start with home, overlay claude-scoped, then repo (repo wins, claude beats home)
   const merged = new Map<string, ScriptDefinition>(homeScripts);
+  for (const [name, def] of claudeScripts) {
+    if (merged.has(name)) {
+      getLog().debug({ name }, 'script.claude_overrides_home');
+    }
+    merged.set(name, def);
+  }
   for (const [name, def] of repoScripts) {
     if (merged.has(name)) {
-      getLog().debug({ name }, 'script.repo_overrides_home');
+      getLog().debug({ name }, 'script.repo_overrides_lower_scope');
     }
     merged.set(name, def);
   }

--- a/packages/workflows/src/workflow-discovery.ts
+++ b/packages/workflows/src/workflow-discovery.ts
@@ -274,69 +274,72 @@ export async function discoverWorkflows(
     }
   }
 
-  // 3. Load from repo's workflow folder (overrides app defaults AND home scope by exact filename)
-  const [workflowFolder] = archonPaths.getWorkflowFolderSearchPaths();
-  const workflowPath = join(cwd, workflowFolder);
+  // 3. Load from repo's workflow folder(s) (overrides app defaults AND home scope by exact filename).
+  // Multiple paths are scanned in order; later scans override earlier ones on filename conflict —
+  // see getWorkflowFolderSearchPaths() for the precedence convention.
+  for (const workflowFolder of archonPaths.getWorkflowFolderSearchPaths()) {
+    const workflowPath = join(cwd, workflowFolder);
 
-  getLog().debug({ workflowPath }, 'searching_repo_workflows');
+    getLog().debug({ workflowPath }, 'searching_repo_workflows');
 
-  try {
-    await access(workflowPath);
-    const repoResult = await loadWorkflowsFromDir(workflowPath);
+    try {
+      await access(workflowPath);
+      const repoResult = await loadWorkflowsFromDir(workflowPath);
 
-    // Repo workflows override bundled AND home scope by exact filename match.
-    // Preserve 'bundled' source for workflows loaded from the defaults/ subdirectory
-    // that were already registered as bundled in step 1.
-    for (const [filename, workflow] of repoResult.workflows) {
-      const existing = workflowsByFile.get(filename);
-      if (existing?.source === 'bundled') {
-        // This file was already loaded as a bundled default — the repo's defaults/
-        // subdirectory is re-discovering it. Keep the bundled source label.
-        getLog().debug({ filename }, 'repo_default_preserves_bundled_source');
-        workflowsByFile.set(filename, { workflow, source: 'bundled' });
-      } else {
-        if (existing) {
-          getLog().debug(
-            { filename, overriddenSource: existing.source },
-            'repo_workflow_overrides_lower_scope'
+      // Repo workflows override bundled AND home scope by exact filename match.
+      // Preserve 'bundled' source for workflows loaded from the defaults/ subdirectory
+      // that were already registered as bundled in step 1.
+      for (const [filename, workflow] of repoResult.workflows) {
+        const existing = workflowsByFile.get(filename);
+        if (existing?.source === 'bundled') {
+          // This file was already loaded as a bundled default — the repo's defaults/
+          // subdirectory is re-discovering it. Keep the bundled source label.
+          getLog().debug({ filename }, 'repo_default_preserves_bundled_source');
+          workflowsByFile.set(filename, { workflow, source: 'bundled' });
+        } else {
+          if (existing) {
+            getLog().debug(
+              { filename, overriddenSource: existing.source },
+              'repo_workflow_overrides_lower_scope'
+            );
+          }
+          workflowsByFile.set(filename, { workflow, source: 'project' });
+        }
+      }
+
+      // Surface repo workflow errors to users (these are actionable)
+      allErrors.push(...repoResult.errors);
+
+      // Warn about deprecated non-prefixed defaults in repo's defaults folder
+      const repoDefaultsPath = join(cwd, workflowFolder, 'defaults');
+      try {
+        await access(repoDefaultsPath);
+        const defaultEntries = await readdir(repoDefaultsPath);
+        const oldDefaults = defaultEntries.filter(
+          f => (f.endsWith('.yaml') || f.endsWith('.yml')) && !f.startsWith('archon-')
+        );
+        if (oldDefaults.length > 0) {
+          getLog().warn(
+            { count: oldDefaults.length, repoDefaultsPath, hint: `rm -rf "${repoDefaultsPath}"` },
+            'deprecated_workflow_defaults_found'
           );
         }
-        workflowsByFile.set(filename, { workflow, source: 'project' });
-      }
-    }
-
-    // Surface repo workflow errors to users (these are actionable)
-    allErrors.push(...repoResult.errors);
-
-    // Warn about deprecated non-prefixed defaults in repo's defaults folder
-    const repoDefaultsPath = join(cwd, workflowFolder, 'defaults');
-    try {
-      await access(repoDefaultsPath);
-      const defaultEntries = await readdir(repoDefaultsPath);
-      const oldDefaults = defaultEntries.filter(
-        f => (f.endsWith('.yaml') || f.endsWith('.yml')) && !f.startsWith('archon-')
-      );
-      if (oldDefaults.length > 0) {
-        getLog().warn(
-          { count: oldDefaults.length, repoDefaultsPath, hint: `rm -rf "${repoDefaultsPath}"` },
-          'deprecated_workflow_defaults_found'
-        );
+      } catch (error) {
+        const err = error as NodeJS.ErrnoException;
+        if (err.code !== 'ENOENT') {
+          getLog().warn({ err, repoDefaultsPath }, 'deprecated_defaults_check_failed');
+        }
+        // ENOENT (not found) is expected - no defaults folder exists
       }
     } catch (error) {
       const err = error as NodeJS.ErrnoException;
       if (err.code !== 'ENOENT') {
-        getLog().warn({ err, repoDefaultsPath }, 'deprecated_defaults_check_failed');
+        throw new Error(
+          `Cannot access workflow folder at ${workflowPath}: ${err.message} (${err.code ?? 'unknown'})`
+        );
       }
-      // ENOENT (not found) is expected - no defaults folder exists
+      getLog().debug({ workflowPath }, 'workflow_folder_not_found');
     }
-  } catch (error) {
-    const err = error as NodeJS.ErrnoException;
-    if (err.code !== 'ENOENT') {
-      throw new Error(
-        `Cannot access workflow folder at ${workflowPath}: ${err.message} (${err.code ?? 'unknown'})`
-      );
-    }
-    getLog().debug({ workflowPath }, 'workflow_folder_not_found');
   }
 
   const workflows = Array.from(workflowsByFile.values());


### PR DESCRIPTION
## Summary

- **Problem:** Users who keep all AI-assistant config under `.claude/` (skills, commands, agents, settings.json) currently have to maintain a separate root-level `.archon/` tree just to ship workflows/commands/scripts. The two directories drift and clutter the repo root.
- **Why it matters:** Co-locating Archon assets next to Claude Code config matches how many users already organize their projects — and it makes Archon adoption frictionless for repos that already standardize on a `.claude/` directory.
- **What changed:** Discovery now additionally scans `<cwd>/.claude/.archon/` for workflows, commands, and scripts. Filename collisions follow the same later-wins convention used for home/repo scopes, so root `.archon/` still overrides on conflict.
- **What did *not* change (scope boundary):** No new directory is created. No env vars, config keys, DB tables, providers, or routes added. Nothing under `.claude/` is read unless the user opts in by placing files there. Existing repos with only root-level `.archon/` see byte-identical behavior.

## UX Journey

### Before

```
Repo root
├── .archon/
│   ├── workflows/        ← workflows live here only
│   ├── commands/
│   └── scripts/
└── .claude/
    ├── skills/           ← Claude assets
    ├── agents/
    └── settings.json

User wanting both → maintains two parallel trees → drift, clutter, awkward
```

### After

```
Repo root
└── .claude/
    ├── skills/
    ├── agents/
    ├── settings.json
    └── .archon/                      ← [NEW] Archon discovers here too
        ├── workflows/
        ├── commands/
        └── scripts/

(.archon/ at root still works exactly as before — wins on filename conflict)
```

## Architecture Diagram

### Before

```
discoverWorkflows(cwd)
  ├── bundled defaults              (in-memory)
  ├── ~/.archon/workflows           (home scope)
  └── <cwd>/.archon/workflows       (repo scope — root wins)

discoverScriptsForCwd(cwd)
  ├── ~/.archon/scripts
  └── <cwd>/.archon/scripts         (repo wins)

getCommandFolderSearchPaths()
  └── ['.archon/commands', '.archon/commands/defaults', <configured>]
```

### After

```
discoverWorkflows(cwd)
  ├── bundled defaults              (in-memory)
  ├── ~/.archon/workflows           (home scope)
  ├── <cwd>/.claude/.archon/workflows   [+ NEW additive]
  └── <cwd>/.archon/workflows       (root wins on collision)

discoverScriptsForCwd(cwd)
  ├── ~/.archon/scripts
  ├── <cwd>/.claude/.archon/scripts     [+ NEW additive]
  └── <cwd>/.archon/scripts         (root wins on collision)

getCommandFolderSearchPaths()
  └── ['.archon/commands',
       '.archon/commands/defaults',
       '.claude/.archon/commands',         [+ NEW]
       '.claude/.archon/commands/defaults', [+ NEW]
       <configured>]
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `archon-paths.getWorkflowFolderSearchPaths` | `.archon/workflows` | unchanged | still scanned, still root-wins on collision |
| `archon-paths.getWorkflowFolderSearchPaths` | `.claude/.archon/workflows` | **new** | additive scope |
| `archon-paths.getCommandFolderSearchPaths` | `.claude/.archon/commands{,/defaults}` | **new** | additive scope |
| `script-discovery.discoverScriptsForCwd` | `.claude/.archon/scripts` | **new** | inserted between home and repo precedence |
| `workflow-discovery.discoverWorkflows` | path iteration over `getWorkflowFolderSearchPaths()` | **modified** | single-path destructure → loop |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `paths`, `workflows`
- Module: `paths:archon-paths`, `workflows:workflow-discovery`, `workflows:script-discovery`

## Change Metadata

- Change type: `feature`
- Primary scope: `multi` (paths + workflows)

## Linked Issue

- Closes # _(none — feature request from local usage)_
- Related #
- Depends on #
- Supersedes #

## Validation Evidence (required)

Ran locally on the branch:

```bash
bun run type-check       # ✅ all 10 packages pass
bun run lint             # ✅ no warnings (--max-warnings 0)
bun run format:check     # ✅ all files match Prettier
bun --filter @archon/paths test       # ✅ 175 pass / 0 fail
bun --filter @archon/workflows test   # ✅ 221 pass / 0 fail across 5 batches
```

Tests touched: `packages/paths/src/archon-paths.test.ts` — updated existing `getCommandFolderSearchPaths` / `getWorkflowFolderSearchPaths` expectations to cover the new paths, plus 2 new test cases (`does not duplicate any built-in path if configured`, `ensureArchonWorkspacesPath` idempotency — note the latter is pre-existing on `dev` via #1529, included for completeness).

- Evidence provided: command transcripts above; commit `9f0e3bde`
- If any command is intentionally skipped: `bun run validate` (full bundle + skill check) was not re-run because no bundled defaults or skill files changed — `check:bundled` and `check:bundled-skill` are unaffected.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **Yes** — discovery now also reads from `<cwd>/.claude/.archon/{workflows,commands,scripts}` if present. Same read-only semantics as the existing `.archon/` scope, same `cwd`-rooted path resolution. No symlink-following changes, no parent-directory traversal.

## Compatibility / Migration

- Backward compatible? **Yes** — no behavior change when `.claude/.archon/` does not exist (the new code path silently no-ops via the existing ENOENT branch).
- Config/env changes? **No**
- Database migration needed? **No**
- If yes, exact upgrade steps: N/A

## Human Verification (required)

- Verified scenarios: confirmed workflow discovery picks up YAMLs placed under `<cwd>/.claude/.archon/workflows/` on a project with both `.archon/workflows/` (root) and `.claude/.archon/workflows/` populated — root-level workflow with same filename wins (matches documented precedence). Confirmed commands discovery finds `.claude/.archon/commands/` files via the `/api/commands` endpoint.
- Edge cases checked:
  - empty repo (no `.archon/` and no `.claude/.archon/`) → no errors, empty result
  - only `.claude/.archon/workflows/` present → workflows discovered with `source: 'project'`
  - both scopes with same filename → root wins, debug log emitted
  - duplicate basename across extensions within a single scope (scripts) → still throws (preserved invariant)
- What was not verified: cross-platform path resolution on Windows (no Windows machine handy); reviewer's CI will cover this.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: workflow discovery, command discovery, script discovery. All three are read-only filesystem scans during workflow load / API response.
- Potential unintended effects: a user with an unintended `.claude/.archon/workflows/<name>.yaml` would now be picked up where previously it was ignored. Low likelihood — `.claude/.archon/` is not a conventional path; collisions with `.archon/` (root) still resolve to root.
- Guardrails/monitoring for early detection: existing debug logs (`repo_workflow_overrides_lower_scope`, `script.repo_overrides_lower_scope`, `script.claude_overrides_home`) surface every override. `/workflow list` continues to show errors for broken YAML.

## Rollback Plan (required)

- Fast rollback command/path: `git revert 9f0e3bde` — single commit, isolated to 4 files in 2 packages, no DB or config artifacts.
- Feature flags or config toggles: None. (Could be added later if needed — e.g. `defaults.discoverUnderClaude: false` — but no real need given the additive, no-op-when-absent design.)
- Observable failure symptoms: workflow `not found` errors despite the file existing under `.claude/.archon/workflows/`, or unexpected workflow being executed when both scopes define the same filename.

## Risks and Mitigations

- **Risk:** A user's `.claude/.archon/workflows/foo.yaml` silently overrides `~/.archon/workflows/foo.yaml` (home scope).
  - **Mitigation:** This is the documented precedence convention (`later scope wins`), already applied between home and root-`.archon/`. Debug log emitted on every override. No surprise vs existing behavior.
- **Risk:** Discovery I/O cost grows by one `access()` per scope per call.
  - **Mitigation:** `access()` on a missing dir is sub-millisecond on every supported OS; called once per `discoverWorkflows`/`discoverScriptsForCwd` invocation, not per file. Measurable impact: zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for organizing commands, scripts, and workflows in claude-scoped locations alongside existing repo and home directories.
  * Implemented scope-based precedence for resource resolution: repo-scoped overrides claude-scoped, which overrides home scope on naming conflicts.
  * Enhanced workflow discovery to scan all configured folders with proper override semantics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1652)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->