### PR TITLE
fix(workflows): persist structuredOutput on NodeOutput so $node.output.field works for Pi

### DIFF
--- a/packages/workflows/src/condition-evaluator.test.ts
+++ b/packages/workflows/src/condition-evaluator.test.ts
@@ -21,6 +21,12 @@ mock.module('@archon/paths', () => ({
 import { evaluateCondition } from './condition-evaluator';
 import type { NodeOutput } from './schemas';
 
+/**
+ * Build a NodeOutput fixture for condition tests.
+ * Omits `structuredOutput` when undefined so the field's `'structuredOutput' in nodeOutput`
+ * presence check in resolveOutputRef matches real producer behavior (only Pi/Codex/Claude
+ * paths populate it; older providers leave it off).
+ */
 function makeOutput(
   output: string,
   state: 'completed' | 'failed' | 'skipped' = 'completed',

--- a/packages/workflows/src/condition-evaluator.test.ts
+++ b/packages/workflows/src/condition-evaluator.test.ts
@@ -23,10 +23,15 @@ import type { NodeOutput } from './schemas';
 
 function makeOutput(
   output: string,
-  state: 'completed' | 'failed' | 'skipped' = 'completed'
+  state: 'completed' | 'failed' | 'skipped' = 'completed',
+  structuredOutput?: unknown
 ): NodeOutput {
-  if (state === 'failed') return { state, output, error: 'error' };
-  return { state, output };
+  if (state === 'failed')
+    return structuredOutput !== undefined
+      ? { state, output, error: 'error', structuredOutput }
+      : { state, output, error: 'error' };
+  if (state === 'skipped') return { state, output };
+  return structuredOutput !== undefined ? { state, output, structuredOutput } : { state, output };
 }
 
 describe('evaluateCondition', () => {
@@ -357,5 +362,110 @@ describe('evaluateCondition', () => {
     const res = evaluateCondition("$n.output == 'A||B'", outputs);
     expect(res.result).toBe(true);
     expect(res.parsed).toBe(true);
+  });
+
+  // --- structuredOutput preference (Pi/Minimax fence-wrapped JSON, Codex/Claude output_format) ---
+
+  it('structuredOutput: prefers structuredOutput.field over JSON.parse(output)', () => {
+    // Pi-shape: prose output with structuredOutput populated by tryParseStructuredOutput.
+    // If we fell back to JSON.parse(output) we would read 'WRONG'; structuredOutput says 'BUG'.
+    const outputs = new Map([
+      [
+        'classify',
+        makeOutput('Here is the classification: {"type":"WRONG"}', 'completed', {
+          type: 'BUG',
+          confidence: 0.9,
+        }),
+      ],
+    ]);
+    expect(evaluateCondition("$classify.output.type == 'BUG'", outputs).result).toBe(true);
+    expect(evaluateCondition("$classify.output.type == 'WRONG'", outputs).result).toBe(false);
+  });
+
+  it('structuredOutput: falls back to JSON.parse(output) when structuredOutput is absent', () => {
+    // Claude/Codex backward-compat: no structuredOutput on the NodeOutput, JSON in `output`.
+    const outputs = new Map([['classify', makeOutput(JSON.stringify({ type: 'BUG' }))]]);
+    expect(evaluateCondition("$classify.output.type == 'BUG'", outputs).result).toBe(true);
+  });
+
+  it('structuredOutput: coerces numeric field to string', () => {
+    const outputs = new Map([['score', makeOutput('', 'completed', { confidence: 0.95 })]]);
+    expect(evaluateCondition("$score.output.confidence == '0.95'", outputs).result).toBe(true);
+    expect(evaluateCondition("$score.output.confidence >= '0.9'", outputs).result).toBe(true);
+  });
+
+  it('structuredOutput: coerces boolean field to string', () => {
+    const outputs = new Map([['n', makeOutput('', 'completed', { valid: true })]]);
+    expect(evaluateCondition("$n.output.valid == 'true'", outputs).result).toBe(true);
+  });
+
+  it('structuredOutput: JSON-stringifies object/array fields', () => {
+    const outputs = new Map([
+      ['n', makeOutput('', 'completed', { items: ['a', 'b'], nested: { x: 1 } })],
+    ]);
+    const expectedItems = JSON.stringify(['a', 'b']);
+    expect(evaluateCondition("$n.output.items == '" + expectedItems + "'", outputs).result).toBe(
+      true
+    );
+    const expectedNested = JSON.stringify({ x: 1 });
+    expect(evaluateCondition("$n.output.nested == '" + expectedNested + "'", outputs).result).toBe(
+      true
+    );
+  });
+
+  it('structuredOutput: null field value JSON-stringifies to "null"', () => {
+    // Matches existing JSON.parse-path behavior: typeof null === 'object' so null → "null".
+    const outputs = new Map([['n', makeOutput('', 'completed', { type: null })]]);
+    expect(evaluateCondition("$n.output.type == 'null'", outputs).result).toBe(true);
+  });
+
+  it('structuredOutput: works with empty output text (Pi-only-structured case)', () => {
+    // structuredOutput populated, output text empty — dot-access should still work.
+    const outputs = new Map([['classify', makeOutput('', 'completed', { type: 'BUG' })]]);
+    expect(evaluateCondition("$classify.output.type == 'BUG'", outputs).result).toBe(true);
+  });
+
+  it('structuredOutput: null at top level falls through to JSON.parse fallback', () => {
+    // structuredOutput === null is not an object → must skip the preference branch and use output.
+    const outputs = new Map([
+      ['n', makeOutput(JSON.stringify({ type: 'BUG' }), 'completed', null)],
+    ]);
+    expect(evaluateCondition("$n.output.type == 'BUG'", outputs).result).toBe(true);
+  });
+
+  it('structuredOutput: top-level array falls through to JSON.parse fallback', () => {
+    // structuredOutput is array → ambiguous semantics for `.field` access, fall through.
+    const outputs = new Map([
+      ['n', makeOutput(JSON.stringify({ type: 'BUG' }), 'completed', [1, 2, 3])],
+    ]);
+    expect(evaluateCondition("$n.output.type == 'BUG'", outputs).result).toBe(true);
+  });
+
+  it('structuredOutput: primitive at top level falls through to JSON.parse fallback', () => {
+    const outputs = new Map([
+      ['n', makeOutput(JSON.stringify({ type: 'BUG' }), 'completed', 'just-a-string')],
+    ]);
+    expect(evaluateCondition("$n.output.type == 'BUG'", outputs).result).toBe(true);
+  });
+
+  it('structuredOutput: missing field resolves to empty string (no JSON.parse retry)', () => {
+    // When structuredOutput is a usable object but the field is missing, we do NOT retry
+    // JSON.parse(output) — the structuredOutput is authoritative.
+    const outputs = new Map([
+      [
+        'classify',
+        makeOutput(JSON.stringify({ type: 'BUG' }), 'completed', {
+          /* no `type` key */ confidence: 0.9,
+        }),
+      ],
+    ]);
+    expect(evaluateCondition("$classify.output.type == ''", outputs).result).toBe(true);
+    expect(evaluateCondition("$classify.output.type == 'BUG'", outputs).result).toBe(false);
+  });
+
+  it('structuredOutput: unfielded $node.output reference still uses output text', () => {
+    // The preference applies to dot-notation only. Bare `$n.output` falls back to output text.
+    const outputs = new Map([['n', makeOutput('prose text', 'completed', { type: 'BUG' })]]);
+    expect(evaluateCondition("$n.output == 'prose text'", outputs).result).toBe(true);
   });
 });

--- a/packages/workflows/src/condition-evaluator.ts
+++ b/packages/workflows/src/condition-evaluator.ts
@@ -38,11 +38,33 @@ function resolveOutputRef(
     getLog().warn({ nodeId }, 'condition_output_ref_unknown_node');
     return '';
   }
+  if (!field) {
+    // For unfielded ref, structuredOutput shape is opaque — defer to output text (which is
+    // empty for failed nodes, matching the historical fail-closed contract).
+    if (!nodeOutput.output) return '';
+    return nodeOutput.output;
+  }
+
+  // Dot notation: prefer the provider-supplied parsed object when present. This avoids
+  // JSON.parse on fence-wrapped/preamble-prefixed payloads (Pi/Minimax) and on output text
+  // that has already been overridden by structuredOutput (Claude/Codex with output_format).
+  const structured = 'structuredOutput' in nodeOutput ? nodeOutput.structuredOutput : undefined;
+  if (
+    structured !== undefined &&
+    structured !== null &&
+    typeof structured === 'object' &&
+    !Array.isArray(structured)
+  ) {
+    const value = (structured as Record<string, unknown>)[field];
+    if (typeof value === 'string') return value;
+    if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+    if (Array.isArray(value) || typeof value === 'object') return JSON.stringify(value);
+    return ''; // null, undefined, symbol, bigint → empty
+  }
+
+  // Fallback: parse output text. Backward-compatible path for older NodeOutput rows or
+  // providers that don't emit a structured payload on the result chunk.
   if (!nodeOutput.output) return '';
-
-  if (!field) return nodeOutput.output;
-
-  // Dot notation: parse JSON and access field
   try {
     const parsed = JSON.parse(nodeOutput.output) as Record<string, unknown>;
     const value = parsed[field];

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -182,9 +182,22 @@ function node(id: string, depends_on?: string[], opts?: Partial<DagNode>): DagNo
   return { id, command: id, ...(depends_on?.length ? { depends_on } : {}), ...opts };
 }
 
-function makeOutput(state: NodeOutput['state'], output = ''): NodeOutput {
-  if (state === 'failed') return { state, output, error: 'error' };
-  return { state, output } as NodeOutput;
+function makeOutput(
+  state: NodeOutput['state'],
+  output = '',
+  structuredOutput?: unknown
+): NodeOutput {
+  if (state === 'failed') {
+    return structuredOutput !== undefined
+      ? { state, output, error: 'error', structuredOutput }
+      : { state, output, error: 'error' };
+  }
+  if (state === 'pending' || state === 'skipped') {
+    return { state, output } as NodeOutput;
+  }
+  return structuredOutput !== undefined
+    ? ({ state, output, structuredOutput } as NodeOutput)
+    : ({ state, output } as NodeOutput);
 }
 
 function makeWorkflowRun(id = 'dag-test-run-id', overrides?: Partial<WorkflowRun>): WorkflowRun {
@@ -801,6 +814,101 @@ describe('substituteNodeOutputRefs -- shell escaping', () => {
   it('dot notation on invalid JSON returns quoted empty string when escapedForBash=true', () => {
     const outputs = new Map([['a', makeOutput('completed', 'not-json')]]);
     expect(substituteNodeOutputRefs('$a.output.field', outputs, true)).toBe("''");
+  });
+});
+
+describe('substituteNodeOutputRefs -- structuredOutput preference', () => {
+  it('prefers structuredOutput.field over JSON.parse(output)', () => {
+    // Pi-shape: prose output text with structuredOutput populated by tryParseStructuredOutput.
+    const outputs = new Map([
+      [
+        'classify',
+        makeOutput('completed', 'Here is the classification: {"type":"WRONG"}', {
+          type: 'BUG',
+          confidence: 0.9,
+        }),
+      ],
+    ]);
+    expect(substituteNodeOutputRefs('Fix $classify.output.type issue', outputs)).toBe(
+      'Fix BUG issue'
+    );
+  });
+
+  it('falls back to JSON.parse(output) when structuredOutput is absent', () => {
+    // Claude/Codex backward-compat regression: no structuredOutput, JSON in `output`.
+    const outputs = new Map([
+      ['classify', makeOutput('completed', JSON.stringify({ type: 'BUG' }))],
+    ]);
+    expect(substituteNodeOutputRefs('Fix $classify.output.type issue', outputs)).toBe(
+      'Fix BUG issue'
+    );
+  });
+
+  it('coerces structuredOutput numeric field to string', () => {
+    const outputs = new Map([['score', makeOutput('completed', '', { confidence: 0.95 })]]);
+    expect(substituteNodeOutputRefs('score=$score.output.confidence', outputs)).toBe('score=0.95');
+  });
+
+  it('coerces structuredOutput boolean field to string', () => {
+    const outputs = new Map([['n', makeOutput('completed', '', { ok: true })]]);
+    expect(substituteNodeOutputRefs('[ $n.output.ok ]', outputs)).toBe('[ true ]');
+  });
+
+  it('JSON-stringifies object structuredOutput field', () => {
+    const outputs = new Map([['n', makeOutput('completed', '', { nested: { x: 1 } })]]);
+    expect(substituteNodeOutputRefs('$n.output.nested', outputs)).toBe('{"x":1}');
+  });
+
+  it('JSON-stringifies array structuredOutput field', () => {
+    const outputs = new Map([['n', makeOutput('completed', '', { items: ['todo', 'fix'] })]]);
+    expect(substituteNodeOutputRefs('$n.output.items', outputs)).toBe('["todo","fix"]');
+  });
+
+  it('works with empty output text (Pi-only-structured case)', () => {
+    // structuredOutput populated, output text empty → dot-access still works.
+    const outputs = new Map([['classify', makeOutput('completed', '', { type: 'BUG' })]]);
+    expect(substituteNodeOutputRefs('Fix $classify.output.type issue', outputs)).toBe(
+      'Fix BUG issue'
+    );
+  });
+
+  it('null structuredOutput falls through to JSON.parse fallback', () => {
+    const outputs = new Map([
+      ['n', makeOutput('completed', JSON.stringify({ type: 'BUG' }), null)],
+    ]);
+    expect(substituteNodeOutputRefs('$n.output.type', outputs)).toBe('BUG');
+  });
+
+  it('top-level-array structuredOutput falls through to JSON.parse fallback', () => {
+    const outputs = new Map([
+      ['n', makeOutput('completed', JSON.stringify({ type: 'BUG' }), [1, 2, 3])],
+    ]);
+    expect(substituteNodeOutputRefs('$n.output.type', outputs)).toBe('BUG');
+  });
+
+  it('primitive structuredOutput falls through to JSON.parse fallback', () => {
+    const outputs = new Map([
+      ['n', makeOutput('completed', JSON.stringify({ type: 'BUG' }), 'just-a-string')],
+    ]);
+    expect(substituteNodeOutputRefs('$n.output.type', outputs)).toBe('BUG');
+  });
+
+  it('missing field in structuredOutput resolves to empty string (no JSON.parse retry)', () => {
+    // structuredOutput is authoritative; if the field is missing, do not retry output.
+    const outputs = new Map([
+      ['classify', makeOutput('completed', JSON.stringify({ type: 'BUG' }), { confidence: 0.9 })],
+    ]);
+    expect(substituteNodeOutputRefs('Fix $classify.output.type issue', outputs)).toBe('Fix  issue');
+  });
+
+  it('bare $node.output reference (no field) uses output text, not structuredOutput', () => {
+    const outputs = new Map([['n', makeOutput('completed', 'prose text', { type: 'BUG' })]]);
+    expect(substituteNodeOutputRefs('Got: $n.output', outputs)).toBe('Got: prose text');
+  });
+
+  it('structuredOutput field is shell-quoted when escapedForBash=true', () => {
+    const outputs = new Map([['n', makeOutput('completed', '', { cmd: 'foo; bar' })]]);
+    expect(substituteNodeOutputRefs('echo $n.output.cmd', outputs, true)).toBe("echo 'foo; bar'");
   });
 });
 

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -182,6 +182,12 @@ function node(id: string, depends_on?: string[], opts?: Partial<DagNode>): DagNo
   return { id, command: id, ...(depends_on?.length ? { depends_on } : {}), ...opts };
 }
 
+/**
+ * Build a NodeOutput fixture for substitution tests.
+ * Omits `structuredOutput` when undefined so the `'structuredOutput' in nodeOutput` presence
+ * check in substituteNodeOutputRefs matches real producer behavior (Pi/Codex/Claude populate
+ * it; older providers and the pending/skipped states leave it off).
+ */
 function makeOutput(
   state: NodeOutput['state'],
   output = '',

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -299,6 +299,26 @@ export function substituteNodeOutputRefs(
       if (!field) {
         return escapedForBash ? shellQuote(nodeOutput.output) : nodeOutput.output;
       }
+      // Prefer the provider-supplied structured payload when present. Providers that emit
+      // fence-wrapped or preamble-prefixed JSON (Pi/Minimax) parse it onto the result chunk
+      // via tryParseStructuredOutput; consuming that object directly avoids re-parsing prose
+      // here. Falls back to JSON.parse on output for providers that don't normalize
+      // (or for older NodeOutput rows from before this field existed).
+      const structured = 'structuredOutput' in nodeOutput ? nodeOutput.structuredOutput : undefined;
+      if (
+        structured !== undefined &&
+        structured !== null &&
+        typeof structured === 'object' &&
+        !Array.isArray(structured)
+      ) {
+        const value = (structured as Record<string, unknown>)[field];
+        if (typeof value === 'string') return escapedForBash ? shellQuote(value) : value;
+        if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+        if (Array.isArray(value) || typeof value === 'object') {
+          return escapedForBash ? shellQuote(JSON.stringify(value)) : JSON.stringify(value);
+        }
+        return escapedForBash ? "''" : '';
+      }
       try {
         const parsed = JSON.parse(nodeOutput.output) as Record<string, unknown>;
         const value = parsed[field];
@@ -1205,6 +1225,7 @@ async function executeNodeInternal(
       output: nodeOutputText,
       sessionId: newSessionId,
       costUsd: nodeCostUsd,
+      ...(structuredOutput !== undefined ? { structuredOutput } : {}),
     };
   } catch (error) {
     const err = error as Error;
@@ -1775,6 +1796,7 @@ async function executeLoopNode(
     : '';
 
   let lastIterationOutput = '';
+  let lastIterationStructuredOutput: unknown;
   let loopTotalCostUsd: number | undefined;
   let loopFinalStopReason: string | undefined;
   let loopTotalNumTurns: number | undefined;
@@ -1924,6 +1946,9 @@ async function executeLoopNode(
           if (msg.stopReason !== undefined) loopFinalStopReason = msg.stopReason;
           if (msg.numTurns !== undefined) {
             loopTotalNumTurns = (loopTotalNumTurns ?? 0) + msg.numTurns;
+          }
+          if (msg.structuredOutput !== undefined) {
+            lastIterationStructuredOutput = msg.structuredOutput;
           }
           // Fail the iteration loudly on SDK error results. Previously we broke
           // silently, producing empty output and continuing to the next iteration —
@@ -2225,6 +2250,9 @@ async function executeLoopNode(
         output: lastIterationOutput,
         sessionId: currentSessionId,
         costUsd: loopTotalCostUsd,
+        ...(lastIterationStructuredOutput !== undefined
+          ? { structuredOutput: lastIterationStructuredOutput }
+          : {}),
       };
     }
 

--- a/packages/workflows/src/schemas/workflow-run.ts
+++ b/packages/workflows/src/schemas/workflow-run.ts
@@ -62,18 +62,24 @@ export type NodeState = z.infer<typeof nodeStateSchema>;
  * `output` is the concatenated assistant text (or JSON-encoded string from the SDK
  * when output_format is set). Empty string for failed/skipped nodes.
  * `error` is required when state is 'failed', absent on all other states.
+ * `structuredOutput` carries the provider's parsed structured payload (set by Pi/Codex/Claude
+ * when the result chunk includes one). Downstream `$nodeId.output.field` substitution and
+ * `when:` conditions prefer this object over re-parsing `output`, so providers that emit
+ * fence-wrapped or preamble-prefixed JSON (Pi/Minimax) survive the round-trip.
  */
 export const nodeOutputSchema = z.discriminatedUnion('state', [
   z.object({
     state: z.enum(['completed', 'running']),
     output: z.string(),
     sessionId: z.string().optional(),
+    structuredOutput: z.unknown().optional(),
   }),
   z.object({
     state: z.literal('failed'),
     output: z.string(),
     sessionId: z.string().optional(),
     error: z.string(),
+    structuredOutput: z.unknown().optional(),
   }),
   z.object({
     state: z.enum(['pending', 'skipped']),


### PR DESCRIPTION
Re-target of #1637 onto `dev` per @Wirasm. No code change; rebased onto upstream/dev. Branch tip: `fcb33ed4` (ED25519 signed). All Validation Evidence below re-run on the rebased branch.

---

---


## Summary

- Problem: When a provider parses fence-wrapped or preamble-prefixed JSON onto the result chunk (Pi/Minimax via `tryParseStructuredOutput`), the DAG executor captures it into a local variable but never persists it onto `NodeOutput`. Downstream `$node.output.field` substitution and `when:` conditions then try `JSON.parse(output)` on the original prose-prefixed text, throw, and resolve to empty.
- Why it matters: every Pi/Minimax workflow with a downstream node that reads `$classifier.output.type` (or any other field) silently routes to the wrong branch or drops the value.
- What changed: `structuredOutput?: unknown` added to the completed/running and failed NodeOutput branches; producer call sites persist it; consumers (`substituteNodeOutputRefs`, `condition-evaluator.resolveOutputRef`) prefer it over `JSON.parse(output)` and fall back to the existing path when absent.
- What did **not** change: bare `$node.output` (unfielded) still reads `output` text. Cross-resume rehydration from `event_data` is out of scope (resumed runs that re-execute downstream nodes fall through to JSON.parse). Providers that already overwrite `output` with a JSON.stringify of structuredOutput (Claude/Codex with `output_format`) are unaffected because their `output` is already JSON.

## UX Journey

### Before

```
Pi/Minimax DAG with downstream $.field reads

  classify (provider=pi, prompt asks for JSON)
    ├─ raw chunk:        "Here is the classification:\n{\"type\":\"BUG\"}"
    ├─ tryParseStructuredOutput → { type: "BUG" }
    ├─ stored:           NodeOutput.output = raw text, structuredOutput = DROPPED
    │
  triage (depends_on: classify, when: $classify.output.type == 'BUG')
    └─ resolveOutputRef:
         JSON.parse("Here is the classification:\n{...}")  ── throws
         returns ''
         condition: '' == 'BUG' → false → SKIPPED  ❌
```

### After

```
Pi/Minimax DAG with downstream $.field reads

  classify (provider=pi, prompt asks for JSON)
    ├─ raw chunk:        "Here is the classification:\n{\"type\":\"BUG\"}"
    ├─ tryParseStructuredOutput → { type: "BUG" }
    ├─ stored:           NodeOutput.output = raw text,
                         [NodeOutput.structuredOutput = { type: "BUG" }]
    │
  triage (depends_on: classify, when: $classify.output.type == 'BUG')
    └─ resolveOutputRef:
         [prefers NodeOutput.structuredOutput.type]  → "BUG"
         condition: 'BUG' == 'BUG' → true → RUNS  ✓
```

## Architecture Diagram

### Before

```
   ┌───────────────────────────┐
   │  providers (pi/minimax)   │
   │  emits result chunk with  │
   │  structuredOutput field   │
   └───────────┬───────────────┘
               │
               ▼
   ┌───────────────────────────┐
   │     dag-executor.ts       │
   │   captures msg.struct-    │
   │   uredOutput in local     │
   │   var (line ~913)         │
   │                           │
   │   on success return:      │
   │   { state, output,        │
   │     sessionId, costUsd }  │── structuredOutput dropped
   └───────────┬───────────────┘
               │
               ▼
   ┌───────────────────────────┐    ┌───────────────────────────┐
   │ substituteNodeOutputRefs  │    │   condition-evaluator     │
   │   JSON.parse(output)      │    │   JSON.parse(output)      │
   │   throws on prose preamble│    │   throws on prose preamble│
   └───────────────────────────┘    └───────────────────────────┘
```

### After

```
   ┌───────────────────────────┐
   │  providers (pi/minimax)   │
   │  emits result chunk with  │
   │  structuredOutput field   │
   └───────────┬───────────────┘
               │
               ▼
   ┌───────────────────────────┐
   │     dag-executor.ts       │
   │   captures msg.struct-    │
   │   uredOutput in local     │
   │   var (line ~913)         │
   │                           │
   │   on success return:      │
   │   { state, output,        │
   │     sessionId, costUsd,   │
   │  [~ structuredOutput ] }  │── persisted
   └───────────┬───────────────┘
               │
               ▼
   ┌───────────────────────────┐    ┌───────────────────────────┐
   │ substituteNodeOutputRefs  │    │   condition-evaluator     │
   │ [~ prefer structuredOut]  │    │ [~ prefer structuredOut]  │
   │   falls back to           │    │   falls back to           │
   │   JSON.parse(output)      │    │   JSON.parse(output)      │
   └───────────────────────────┘    └───────────────────────────┘
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `dag-executor` (single-shot success return) | `NodeOutput.structuredOutput` | **new** | spread when defined |
| `dag-executor` (loop terminal-iteration return) | `NodeOutput.structuredOutput` | **new** | new `lastIterationStructuredOutput` local |
| `substituteNodeOutputRefs` | `NodeOutput.structuredOutput` | **new** | preferred over JSON.parse |
| `condition-evaluator.resolveOutputRef` | `NodeOutput.structuredOutput` | **new** | preferred over JSON.parse |
| `nodeOutputSchema` (completed/running, failed) | `z.unknown().optional()` | **new** field | back-compat |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `workflows`
- Module: `workflows:executor`, `workflows:condition-evaluator`, `workflows:schemas`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes #1571

## Validation Evidence (required)

```bash
bun run --filter @archon/workflows test       # all green (workflows package)
bun --filter '*' test                          # all packages green
bun run --filter @archon/workflows type-check  # 0 errors
bun run type-check                             # full repo, 0 errors
bun run format:check                           # All matched files use Prettier code style!
bun x eslint .                                 # 0 errors
bun run check:bundled                          # up to date
bun run check:bundled-skill                    # up to date
```

New tests added:
- `condition-evaluator.test.ts`: 12 new tests covering structuredOutput preference, Claude/Codex JSON.parse fallback regression, numeric/boolean/object/array field coercion, null/top-level-array/primitive fall-through, missing-field semantics, and bare `$node.output` (no field) still uses output text.
- `dag-executor.test.ts`: 13 new tests for `substituteNodeOutputRefs` covering the same matrix plus shell-escaping safety on structuredOutput fields.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes`. `structuredOutput` is optional on the schema; producers populate it only when the provider emits one; consumers fall through to the existing `JSON.parse(output)` path when it is absent. Workflows that depend on the JSON.parse path keep working unchanged.
- Config/env changes? `No`
- Database migration needed? `No`. NodeOutput is stored inline in workflow event data; older rows without `structuredOutput` deserialize as `undefined` and hit the JSON.parse fallback.
- Resume note: on a paused-then-resumed workflow run, downstream nodes that re-execute against an already-completed upstream will rehydrate `NodeOutput` from `event_data`. If the original run was on this version, the field is preserved; if older, it is absent and the JSON.parse fallback runs. Cross-version resume of Pi workflows that previously routed wrong will route correctly once the upstream re-runs on the new version.

## Human Verification (required)

- Verified scenarios:
  - Pi-shape: prose output + populated structuredOutput → dot-access reads structuredOutput.
  - Claude/Codex output_format-shape: empty/JSON output, no structuredOutput → JSON.parse fallback still works.
  - Loop terminal iteration: structuredOutput from the final iteration is what survives onto NodeOutput.
  - Bare `$node.output` (no field) ignores structuredOutput and reads output text.
  - Missing field on structuredOutput → empty string (does not silently retry JSON.parse).
  - null / top-level-array / primitive structuredOutput → falls through to JSON.parse (matches existing edge-case semantics).
  - Shell-escaping path (`escapedForBash=true`) wraps structuredOutput strings/objects in single quotes; numbers/booleans stay unquoted.
- Edge cases checked: empty output text combined with populated structuredOutput (Pi-only-structured case) still resolves the field correctly because the empty-output early-return was moved inward.
- What was not verified by hand: end-to-end Pi workflow against the live provider (the change is verifiable via unit tests against the consumer call sites and the producer return shape).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: any DAG workflow with a `$node.output.field` substitution or a `when:` expression that uses dot notation.
- Potential unintended effects: a workflow author who currently relies on `JSON.parse(output)` returning a *different* shape than what the provider's parsed structuredOutput contains (e.g. provider parses one JSON object out of multiple in the prose) would see a behavior change. In practice the providers that emit `structuredOutput` are emitting the canonical structured payload that the prompt asked for, so the change is the intended fix, not a surprise.
- Guardrails: existing log lines (`condition_json_parse_failed`, `dag_node_output_ref_json_parse_failed`) still fire on the fallback path; no new error paths introduced.

## Rollback Plan (required)

- Fast rollback: revert the single commit on this PR. Schema field is optional and writing it on new rows does not break readers that don't know about it.
- Feature flags: none. The change is mechanical and small enough that flagging it would add more risk than it removes.
- Observable failure symptoms (if regression slipped through): `$node.output.field` would resolve to JSON-stringified content where it previously resolved to a plain string (would surface as condition mismatches or wrongly-formatted prompts on Claude/Codex output_format workflows).

## Risks and Mitigations

- Risk: a workflow that historically saw an empty string for a `$node.output.field` on a Pi/Minimax node (because the JSON.parse failed) might now see the resolved value and take a previously-unreachable branch. This is the intended behavior change for #1571 but could surprise authors who built around the bug.
  - Mitigation: workflow authors who want the old empty-string behavior can keep relying on missing-field semantics (the new code returns `''` when the structuredOutput object doesn't contain the requested key). The fix only changes the case where the provider actually parsed the structured payload the prompt requested.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nodes can include provider-supplied structured output; condition checks and $node.output.field lookups prefer structured data when present.
  * AI-node and loop completions now surface structured output alongside plain text output.

* **Behavior Changes**
  * Field substitutions handle numbers/booleans as strings and serialize objects/arrays; bare $node.output still uses raw text when applicable.

* **Tests**
  * Added coverage for structuredOutput precedence, fallbacks, missing fields, and bash-escaped substitutions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1654)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->