### PR TITLE
fix(web): URL-encode conversation IDs in PATCH/DELETE requests

### DIFF
--- a/packages/server/src/routes/api.conversations.test.ts
+++ b/packages/server/src/routes/api.conversations.test.ts
@@ -474,3 +474,69 @@ describe('GET /api/conversations/:id — forge platform IDs with encoded slashes
     expect(response.status).toBe(404);
   });
 });
+
+describe('DELETE /api/conversations/:id — forge platform IDs with encoded slashes', () => {
+  const FORGE_CONV = {
+    id: 'forge-internal-uuid',
+    platform_conversation_id: 'Solvation-BV/Archon#42',
+    title: 'fix: a thing',
+    created_at: new Date(),
+    updated_at: new Date(),
+    platform_type: 'github',
+    deleted_at: null,
+    codebase_id: null,
+  };
+
+  test('deletes forge conversation when ID contains encoded slash and hash', async () => {
+    mockFindConversationByPlatformId.mockImplementationOnce(async platformId => {
+      expect(platformId).toBe('Solvation-BV/Archon#42');
+      return FORGE_CONV;
+    });
+    mockSoftDeleteConversation.mockImplementationOnce(async () => {});
+
+    const app = new OpenAPIHono();
+    registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+    const response = await app.request('/api/conversations/Solvation-BV%2FArchon%2342', {
+      method: 'DELETE',
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { success: boolean };
+    expect(body).toEqual({ success: true });
+    expect(mockSoftDeleteConversation).toHaveBeenCalledWith('forge-internal-uuid');
+  });
+});
+
+describe('PATCH /api/conversations/:id — forge platform IDs with encoded slashes', () => {
+  const FORGE_CONV = {
+    id: 'forge-internal-uuid',
+    platform_conversation_id: 'Solvation-BV/Archon#42',
+    title: 'old title',
+    created_at: new Date(),
+    updated_at: new Date(),
+    platform_type: 'github',
+    deleted_at: null,
+    codebase_id: null,
+  };
+
+  test('updates forge conversation title when ID contains encoded slash and hash', async () => {
+    mockFindConversationByPlatformId.mockImplementationOnce(async platformId => {
+      expect(platformId).toBe('Solvation-BV/Archon#42');
+      return FORGE_CONV;
+    });
+    mockUpdateConversationTitle.mockImplementationOnce(async () => {});
+
+    const app = new OpenAPIHono();
+    registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+    const response = await app.request('/api/conversations/Solvation-BV%2FArchon%2342', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'New Title' }),
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { success: boolean };
+    expect(body).toEqual({ success: true });
+    expect(mockUpdateConversationTitle).toHaveBeenCalledWith('forge-internal-uuid', 'New Title');
+  });
+});

--- a/packages/server/src/routes/api.conversations.test.ts
+++ b/packages/server/src/routes/api.conversations.test.ts
@@ -530,3 +530,69 @@ describe('GET /api/conversations/:id — forge platform IDs with encoded slashes
     expect(response.status).toBe(404);
   });
 });
+
+describe('DELETE /api/conversations/:id — forge platform IDs with encoded slashes', () => {
+  const FORGE_CONV = {
+    id: 'forge-internal-uuid',
+    platform_conversation_id: 'Solvation-BV/Archon#42',
+    title: 'fix: a thing',
+    created_at: new Date(),
+    updated_at: new Date(),
+    platform_type: 'github',
+    deleted_at: null,
+    codebase_id: null,
+  };
+
+  test('deletes forge conversation when ID contains encoded slash and hash', async () => {
+    mockFindConversationByPlatformId.mockImplementationOnce(async platformId => {
+      expect(platformId).toBe('Solvation-BV/Archon#42');
+      return FORGE_CONV;
+    });
+    mockSoftDeleteConversation.mockImplementationOnce(async () => {});
+
+    const app = new OpenAPIHono();
+    registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+    const response = await app.request('/api/conversations/Solvation-BV%2FArchon%2342', {
+      method: 'DELETE',
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { success: boolean };
+    expect(body).toEqual({ success: true });
+    expect(mockSoftDeleteConversation).toHaveBeenCalledWith('forge-internal-uuid');
+  });
+});
+
+describe('PATCH /api/conversations/:id — forge platform IDs with encoded slashes', () => {
+  const FORGE_CONV = {
+    id: 'forge-internal-uuid',
+    platform_conversation_id: 'Solvation-BV/Archon#42',
+    title: 'old title',
+    created_at: new Date(),
+    updated_at: new Date(),
+    platform_type: 'github',
+    deleted_at: null,
+    codebase_id: null,
+  };
+
+  test('updates forge conversation title when ID contains encoded slash and hash', async () => {
+    mockFindConversationByPlatformId.mockImplementationOnce(async platformId => {
+      expect(platformId).toBe('Solvation-BV/Archon#42');
+      return FORGE_CONV;
+    });
+    mockUpdateConversationTitle.mockImplementationOnce(async () => {});
+
+    const app = new OpenAPIHono();
+    registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+    const response = await app.request('/api/conversations/Solvation-BV%2FArchon%2342', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'New Title' }),
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { success: boolean };
+    expect(body).toEqual({ success: true });
+    expect(mockUpdateConversationTitle).toHaveBeenCalledWith('forge-internal-uuid', 'New Title');
+  });
+});

--- a/packages/server/src/routes/api.conversations.test.ts
+++ b/packages/server/src/routes/api.conversations.test.ts
@@ -561,6 +561,36 @@ describe('DELETE /api/conversations/:id — forge platform IDs with encoded slas
     expect(body).toEqual({ success: true });
     expect(mockSoftDeleteConversation).toHaveBeenCalledWith('forge-internal-uuid');
   });
+
+  test('deletes gitea PR conversation with ! separator when ID is encoded', async () => {
+    const giteaPRConv = { ...FORGE_CONV, platform_conversation_id: 'owner/repo!42' };
+    mockFindConversationByPlatformId.mockImplementationOnce(async platformId => {
+      expect(platformId).toBe('owner/repo!42');
+      return giteaPRConv;
+    });
+    mockSoftDeleteConversation.mockImplementationOnce(async () => {});
+
+    const app = new OpenAPIHono();
+    registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+    const response = await app.request('/api/conversations/owner%2Frepo!42', {
+      method: 'DELETE',
+    });
+    expect(response.status).toBe(200);
+    expect(mockSoftDeleteConversation).toHaveBeenCalledWith('forge-internal-uuid');
+  });
+
+  test('returns 404 for unknown encoded forge conversation ID', async () => {
+    mockFindConversationByPlatformId.mockImplementationOnce(async () => null);
+
+    const app = new OpenAPIHono();
+    registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+    const response = await app.request('/api/conversations/unknown-org%2Funknown-repo%2399', {
+      method: 'DELETE',
+    });
+    expect(response.status).toBe(404);
+  });
 });
 
 describe('PATCH /api/conversations/:id — forge platform IDs with encoded slashes', () => {
@@ -594,5 +624,39 @@ describe('PATCH /api/conversations/:id — forge platform IDs with encoded slash
     const body = (await response.json()) as { success: boolean };
     expect(body).toEqual({ success: true });
     expect(mockUpdateConversationTitle).toHaveBeenCalledWith('forge-internal-uuid', 'New Title');
+  });
+
+  test('updates gitea PR conversation with ! separator when ID is encoded', async () => {
+    const giteaPRConv = { ...FORGE_CONV, platform_conversation_id: 'owner/repo!42' };
+    mockFindConversationByPlatformId.mockImplementationOnce(async platformId => {
+      expect(platformId).toBe('owner/repo!42');
+      return giteaPRConv;
+    });
+    mockUpdateConversationTitle.mockImplementationOnce(async () => {});
+
+    const app = new OpenAPIHono();
+    registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+    const response = await app.request('/api/conversations/owner%2Frepo!42', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'New Title' }),
+    });
+    expect(response.status).toBe(200);
+    expect(mockUpdateConversationTitle).toHaveBeenCalledWith('forge-internal-uuid', 'New Title');
+  });
+
+  test('returns 404 for unknown encoded forge conversation ID', async () => {
+    mockFindConversationByPlatformId.mockImplementationOnce(async () => null);
+
+    const app = new OpenAPIHono();
+    registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+    const response = await app.request('/api/conversations/unknown-org%2Funknown-repo%2399', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'New Title' }),
+    });
+    expect(response.status).toBe(404);
   });
 });

--- a/packages/web/src/lib/api.conversations.test.ts
+++ b/packages/web/src/lib/api.conversations.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect, afterEach, spyOn } from 'bun:test';
+import { updateConversation, deleteConversation } from './api';
+
+// Regression tests for URL-encoding of platform conversation IDs in the web API
+// client. Forge platform IDs (GitHub/Gitea) contain `/` and `#` characters
+// (e.g. "owner/repo#42"); updateConversation and deleteConversation must encode
+// them so the request hits /api/conversations/:id instead of splitting the path
+// and 404ing. These exercise the CLIENT (the fetch URL), complementing the
+// server-side decoding tests in packages/server/src/routes/api.conversations.test.ts.
+// Ref: https://github.com/coleam00/Archon/issues/476
+
+const FORGE_ID = 'Solvation-BV/Archon#42';
+const ENCODED_URL = '/api/conversations/Solvation-BV%2FArchon%2342';
+
+function mockFetchSuccess() {
+  return spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  );
+}
+
+let fetchSpy: ReturnType<typeof mockFetchSuccess> | undefined;
+
+afterEach(() => {
+  fetchSpy?.mockRestore();
+  fetchSpy = undefined;
+});
+
+describe('updateConversation — forge platform IDs with slashes and hashes', () => {
+  test('PATCHes the URL-encoded conversation ID with the title body', async () => {
+    fetchSpy = mockFetchSuccess();
+
+    const result = await updateConversation(FORGE_ID, { title: 'New Title' });
+
+    expect(result).toEqual({ success: true });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      ENCODED_URL,
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ title: 'New Title' }),
+      })
+    );
+  });
+});
+
+describe('deleteConversation — forge platform IDs with slashes and hashes', () => {
+  test('DELETEs the URL-encoded conversation ID', async () => {
+    fetchSpy = mockFetchSuccess();
+
+    const result = await deleteConversation(FORGE_ID);
+
+    expect(result).toEqual({ success: true });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      ENCODED_URL,
+      expect.objectContaining({ method: 'DELETE' })
+    );
+  });
+});

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -155,7 +155,7 @@ export async function updateConversation(
   id: string,
   updates: { title?: string }
 ): Promise<{ success: boolean }> {
-  return fetchJSON(`/api/conversations/${id}`, {
+  return fetchJSON(`/api/conversations/${encodeURIComponent(id)}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(updates),
@@ -163,7 +163,7 @@ export async function updateConversation(
 }
 
 export async function deleteConversation(id: string): Promise<{ success: boolean }> {
-  return fetchJSON(`/api/conversations/${id}`, { method: 'DELETE' });
+  return fetchJSON(`/api/conversations/${encodeURIComponent(id)}`, { method: 'DELETE' });
 }
 
 export async function sendMessage(

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -138,7 +138,7 @@ export async function updateConversation(
   id: string,
   updates: { title?: string }
 ): Promise<{ success: boolean }> {
-  return fetchJSON(`/api/conversations/${id}`, {
+  return fetchJSON(`/api/conversations/${encodeURIComponent(id)}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(updates),
@@ -146,7 +146,7 @@ export async function updateConversation(
 }
 
 export async function deleteConversation(id: string): Promise<{ success: boolean }> {
-  return fetchJSON(`/api/conversations/${id}`, { method: 'DELETE' });
+  return fetchJSON(`/api/conversations/${encodeURIComponent(id)}`, { method: 'DELETE' });
 }
 
 export async function sendMessage(


### PR DESCRIPTION
## Summary

- **Problem**: `updateConversation` and `deleteConversation` in `packages/web/src/lib/api.ts` built request URLs with raw template interpolation (`/api/conversations/${id}`). Platform conversation IDs containing slashes (GitHub/Gitea forge format `owner/repo#issue`) split the path and missed the route, returning 404.
- **Why it matters**: Users with GitHub-style conversation IDs cannot rename or delete those conversations from the Web UI.
- **What changed**: Apply `encodeURIComponent(id)` to the PATCH and DELETE URLs, matching what `sendMessage` and `getMessages` already do.
- **What did not change**: No backend changes. No other callers touched. No type changes.

## UX Journey

### Before

```
User              Web UI                  Server
────              ──────                  ──────
rename convo ──▶  PATCH /api/conversations/owner/repo#123
                  (raw template)
                                       ──▶ route mismatch → 404
sees error ◀──────────────────────────────
```

### After

```
User              Web UI                            Server
────              ──────                            ──────
rename convo ──▶  PATCH /api/conversations/owner%2Frepo%23123
                  (encodeURIComponent)
                                                 ──▶ route matches → 200 OK
sees updated title ◀──────────────────────────────
```

## Architecture Diagram

Single-file frontend change in `packages/web/src/lib/api.ts`; route-layer regression tests added in `packages/server/src/routes/api.conversations.test.ts`.

## Change Metadata

- Change type: `bug`
- Primary scope: `web`
- Risk: `low`
- Size: `XS`

## Linked Issue

- N/A — drive-by fix discovered while using the Web UI against a GitHub-sourced conversation.

## Validation Evidence

- Added regression tests at `packages/server/src/routes/api.conversations.test.ts` covering encoded-slash + hash IDs for both PATCH and DELETE.
- `sendMessage`/`getMessages` already encode IDs the same way; this brings PATCH/DELETE in line with the established pattern.

## Notes

Submitted from a downstream fork. Happy to adjust to match the standard template more precisely if preferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed proper URL encoding of conversation identifiers containing special characters (e.g., forward slashes, hash symbols) when performing update and delete operations through the API.

* **Tests**
  * Added regression tests for conversation deletion and update endpoints to ensure reliable handling of conversation identifiers containing special characters.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1657)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->