### PR TITLE
fix(providers): preserve native tools when skills are set without allowed_tools (fixes #1605)

### DIFF
--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -1347,6 +1347,52 @@ describe('sendQuery decomposition behaviors', () => {
       );
     });
 
+    test('skills without allowed_tools omits tools field so SDK defaults apply', async () => {
+      mockQuery.mockImplementation(async function* () {
+        yield { type: 'result', session_id: 'sid' };
+      });
+
+      for await (const _ of client.sendQuery('test', '/workspace', undefined, {
+        nodeConfig: {
+          skills: ['agent-browser'],
+          // no allowed_tools → options.tools is undefined
+        },
+      })) {
+        // consume
+      }
+
+      const callArgs = mockQuery.mock.calls[0][0] as { options: Record<string, unknown> };
+      const outAgents = callArgs.options.agents as Record<
+        string,
+        { description: string; tools?: string[] }
+      >;
+      // tools should NOT be set — lets SDK provide all default native tools
+      expect(outAgents['dag-node-skills'].tools).toBeUndefined();
+    });
+
+    test('skills with allowed_tools includes Skill in the tools list', async () => {
+      mockQuery.mockImplementation(async function* () {
+        yield { type: 'result', session_id: 'sid' };
+      });
+
+      for await (const _ of client.sendQuery('test', '/workspace', undefined, {
+        nodeConfig: {
+          skills: ['agent-browser'],
+          allowed_tools: ['Bash', 'Read'],
+        },
+      })) {
+        // consume
+      }
+
+      const callArgs = mockQuery.mock.calls[0][0] as { options: Record<string, unknown> };
+      const outAgents = callArgs.options.agents as Record<
+        string,
+        { description: string; tools?: string[] }
+      >;
+      // tools should include the explicit list plus Skill
+      expect(outAgents['dag-node-skills'].tools).toEqual(['Bash', 'Read', 'Skill']);
+    });
+
     test('does NOT warn when inline agents do not collide with the skills wrapper', async () => {
       mockQuery.mockImplementation(async function* () {
         yield { type: 'result', session_id: 'sid' };

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -436,19 +436,20 @@ async function applyNodeConfig(
   if (nodeConfig.skills) {
     const skills = nodeConfig.skills;
     const agentId = 'dag-node-skills';
-    const agentTools = options.tools ? [...(options.tools as string[]), 'Skill'] : ['Skill'];
     const agentDef: {
       description: string;
       prompt: string;
       skills: string[];
-      tools: string[];
+      tools?: string[];
       model?: string;
     } = {
       description: 'DAG node with skills',
       prompt: `You have preloaded skills: ${skills.join(', ')}. Use them when relevant.`,
       skills,
-      tools: agentTools,
     };
+    if (options.tools) {
+      agentDef.tools = [...(options.tools as string[]), 'Skill'];
+    }
     if (options.model) agentDef.model = options.model;
     options.agents = { [agentId]: agentDef };
     options.agent = agentId;


### PR DESCRIPTION
## Problem

When a DAG workflow node has `skills:` but no explicit `allowed_tools:`, the AgentDefinition wrapper defaults `tools` to `["Skill"]` only, stripping all native Claude Code tools (`Read`, `Bash`, `Write`, `Edit`, `Grep`, `Glob`, etc.).

This silently breaks any node whose prompt expects native tool access — including the bundled `archon-create-issue.yaml` `reproduce` node, which uses `agent-browser` via `Bash` commands.

**Root cause:** `provider.ts:439` — when `options.tools` is undefined (no `allowed_tools` in YAML), `agentTools` defaults to `["Skill"]`, and the AgentDefinition `tools` field restricts the sub-agent to only `Skill`.

## Fix

Omit the `tools` field on AgentDefinition when `options.tools` is undefined, letting the SDK provide its full default tool set. When `allowed_tools` is explicitly set, `Skill` is still appended to the explicit list (existing behavior preserved).

This is **Option B** from the issue — the cleanest approach since it defers to SDK default-tool resolution without hardcoding a tool list that needs maintenance.

## Changes

- `packages/providers/src/claude/provider.ts` — Make `tools` optional on the AgentDefinition type; only set it when `options.tools` is defined
- `packages/providers/src/claude/provider.test.ts` — Add 2 tests:
  - Skills without `allowed_tools` → `tools` field is undefined (SDK defaults apply)
  - Skills with `allowed_tools` → `tools` includes explicit list + `Skill`

## Validation

- `bun test packages/providers/src/claude/provider.test.ts` — 74 pass, 0 fail
- `bun run type-check` — all packages clean
- lint-staged clean on commit

---

## UX Journey

**Before:** Node with `skills: [agent-browser]` but no `allowed_tools` → AI sees only `Skill` tool → "Cannot do task. No Bash tool available."

**After:** Node with `skills: [agent-browser]` → AI sees all default native tools + `Skill` → executes `agent-browser` via Bash as expected.

## Architecture Diagram

```
nodeConfig.skills present
├── allowed_tools defined → agentDef.tools = [...allowed_tools, "Skill"]
└── allowed_tools NOT defined → agentDef.tools omitted (SDK defaults apply)
```

## Label Snapshot

`fix`, `providers`, `workflows`

## Change Metadata

- **Scope:** `packages/providers/src/claude/provider.ts`
- **Lines changed:** +50 / -3

## Linked Issue

Closes #1605

## Validation Evidence

All 74 provider tests pass including 2 new regression tests.

## Security Impact

None — this change only affects which tools are available to sub-agents, and only makes the behavior match what users would expect (all default tools available unless explicitly restricted).

## Compatibility/Migration

Fully backward compatible. Nodes with explicit `allowed_tools` behave identically. Only nodes with `skills` + no `allowed_tools` are affected (they now get SDK defaults instead of `Skill`-only).

## Human Verification

- [x] Diff reviewed line-by-line
- [x] Tests pass
- [x] Type check clean

## Risks and Mitigations

**Risk:** SDK default tool set might change in future versions.
**Mitigation:** This is the intended behavior — deferring to SDK defaults is more maintainable than hardcoding a tool list.

## Side Effects/Blast Radius

Only affects DAG nodes with `skills:` and no `allowed_tools:`. No impact on other code paths.

## Rollback Plan

Revert the single commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tools configuration handling for agent skills. The tools field is now conditionally set based on provided options, enabling SDK defaults to properly apply when configuration is not explicitly specified.

* **Tests**
  * Added test coverage validating tools configuration behavior in two important scenarios: when allowed_tools parameters are provided and when they are not specified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1661)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->