### PR TITLE
fix(providers,workflows): treat Claude SDK stop_sequence success as success (#1425)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Claude `stop_sequence` terminations no longer fail as "SDK returned success"**: the Claude Agent SDK's `SDKResultSuccess` declares `is_error: boolean` (not literal `false`), and stop-sequence terminations carry `is_error: true` alongside `subtype: 'success'` — its encoding of "non-default termination, not a failure". The Claude provider now normalises this pair to a clean success at the provider boundary, with defense-in-depth guards in `dag-executor` (main + loop branches) and `orchestrator-agent` (direct chat) so a third-party `IAgentProvider` forwarding the raw SDK pair can't reintroduce the bug. Workflows using `output_format` (which implies a stop sequence) — including the `archon-fix-github-issue` `classify` → `synthesize` pipeline — now complete cleanly instead of throwing `Node 'X' failed: SDK returned success`. Closes #1425.
+
 ## [0.3.11] - 2026-05-12
 
 Workflow marketplace, expanded setup wizard, and broad Pi/workflow engine fixes.

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1814,6 +1814,41 @@ describe('stale session ID clearing on error_during_execution', () => {
 
     expect(mockUpdateSession).toHaveBeenCalledWith('session-1', null);
   });
+
+  test('does NOT surface error to user on stop_sequence success (#1425)', async () => {
+    // Regression test for #1425: stop_sequence terminations carry is_error:
+    // true + subtype: 'success' under the Claude SDK contract. The Claude
+    // provider normalises this so the orchestrator sees a clean MessageChunk
+    // (no isError). This test locks in that contract — if a future change to
+    // the orchestrator starts gating errors on stopReason itself, or if the
+    // provider regresses, direct-chat users would once again see "Error:
+    // success" surfaced via classifyAndFormatError.
+    mockSendQuery.mockImplementationOnce(async function* () {
+      yield { type: 'assistant', content: 'classified' };
+      // Post-fix shape from claude/provider.ts: isError absent, stopReason set.
+      yield {
+        type: 'result',
+        sessionId: 'sid-ok',
+        stopReason: 'stop_sequence',
+      };
+    });
+    mockTransitionSession.mockResolvedValueOnce({
+      id: 'session-1',
+      assistant_session_id: null,
+    });
+
+    const platform = makePlatform();
+    (platform.getStreamingMode as ReturnType<typeof mock>).mockReturnValue('stream');
+    await handleMessage(platform, 'conv-1', 'hello');
+
+    // Session id should persist normally — the error path was not taken.
+    expect(mockUpdateSession).toHaveBeenCalledWith('session-1', 'sid-ok');
+    // No user-facing error message should have been sent.
+    const sentMessages = (platform.sendMessage as ReturnType<typeof mock>).mock.calls.map(
+      (c: unknown[]) => c[1] as string
+    );
+    expect(sentMessages.some((m: string) => m.toLowerCase().includes('error'))).toBe(false);
+  });
 });
 
 // ─── Multi-chunk command accumulation regression ──────────────────────────────

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1849,6 +1849,38 @@ describe('stale session ID clearing on error_during_execution', () => {
     );
     expect(sentMessages.some((m: string) => m.toLowerCase().includes('error'))).toBe(false);
   });
+
+  test('does NOT surface error when a provider forwards raw SDK pair (defense-in-depth)', async () => {
+    // Defense-in-depth: a third-party IAgentProvider that does not normalise
+    // the SDK's stop_sequence-success pattern would yield isError: true +
+    // errorSubtype: 'success'. The orchestrator guard must skip the error
+    // path on subtype === 'success' so a non-Claude provider can't surface a
+    // spurious error to the user via direct chat.
+    mockSendQuery.mockImplementationOnce(async function* () {
+      yield { type: 'assistant', content: 'classified' };
+      yield {
+        type: 'result',
+        sessionId: 'sid-ok',
+        isError: true,
+        errorSubtype: 'success',
+        stopReason: 'stop_sequence',
+      };
+    });
+    mockTransitionSession.mockResolvedValueOnce({
+      id: 'session-1',
+      assistant_session_id: null,
+    });
+
+    const platform = makePlatform();
+    (platform.getStreamingMode as ReturnType<typeof mock>).mockReturnValue('stream');
+    await handleMessage(platform, 'conv-1', 'hello');
+
+    expect(mockUpdateSession).toHaveBeenCalledWith('session-1', 'sid-ok');
+    const sentMessages = (platform.sendMessage as ReturnType<typeof mock>).mock.calls.map(
+      (c: unknown[]) => c[1] as string
+    );
+    expect(sentMessages.some((m: string) => m.toLowerCase().includes('error'))).toBe(false);
+  });
 });
 
 // ─── Multi-chunk command accumulation regression ──────────────────────────────

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -1124,7 +1124,14 @@ async function handleStreamMode(
       } else if (msg.sessionId) {
         newSessionId = msg.sessionId;
       }
-      if (msg.isError) {
+      // Defense-in-depth: errorSubtype === 'success' is the Claude SDK's marker
+      // for a clean stop_sequence termination (the SDK sets is_error: true
+      // alongside subtype: 'success' to encode "non-default termination, not a
+      // failure"). The Claude provider already filters this; the guard here
+      // defends against a third-party IAgentProvider that forwards the SDK
+      // pair raw — without it, direct chat would surface a spurious error to
+      // the user and drop the actual conversation output.
+      if (msg.isError && msg.errorSubtype !== 'success') {
         getLog().warn(
           {
             conversationId,
@@ -1295,7 +1302,14 @@ async function handleBatchMode(
       } else if (msg.sessionId) {
         newSessionId = msg.sessionId;
       }
-      if (msg.isError) {
+      // Defense-in-depth: errorSubtype === 'success' is the Claude SDK's marker
+      // for a clean stop_sequence termination (the SDK sets is_error: true
+      // alongside subtype: 'success' to encode "non-default termination, not a
+      // failure"). The Claude provider already filters this; the guard here
+      // defends against a third-party IAgentProvider that forwards the SDK
+      // pair raw — without it, direct chat would surface a spurious error to
+      // the user and drop the actual conversation output.
+      if (msg.isError && msg.errorSubtype !== 'success') {
         getLog().warn(
           {
             conversationId,

--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -1278,6 +1278,10 @@ describe('sendQuery decomposition behaviors', () => {
     expect(chunks[0]).not.toHaveProperty('errorSubtype');
     expect(chunks[0]).not.toHaveProperty('errors');
     expect(mockLogger.error).not.toHaveBeenCalledWith(expect.anything(), 'claude.result_is_error');
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'sid-stop-seq', stopReason: 'stop_sequence' }),
+      'claude.result_success_validated'
+    );
   });
 
   describe('inline agents (nodeConfig.agents)', () => {

--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -1246,6 +1246,40 @@ describe('sendQuery decomposition behaviors', () => {
     );
   });
 
+  test('treats is_error: true + subtype: success as clean success (stop_sequence)', async () => {
+    // Claude Agent SDK's SDKResultSuccess explicitly types is_error as boolean
+    // (not literal false). When a model is configured with stop sequences (e.g.
+    // via output_format / json_schema enforcement) the SDK reports is_error:
+    // true alongside subtype: 'success' and stop_reason: 'stop_sequence' — its
+    // way of signalling "non-default termination, but not a failure".
+    // Regression test for #1425.
+    mockQuery.mockImplementation(async function* () {
+      yield {
+        type: 'result',
+        session_id: 'sid-stop-seq',
+        is_error: true,
+        subtype: 'success',
+        stop_reason: 'stop_sequence',
+      };
+    });
+
+    const chunks = [];
+    for await (const chunk of client.sendQuery('test', '/workspace')) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toMatchObject({
+      type: 'result',
+      sessionId: 'sid-stop-seq',
+      stopReason: 'stop_sequence',
+    });
+    expect(chunks[0]).not.toHaveProperty('isError');
+    expect(chunks[0]).not.toHaveProperty('errorSubtype');
+    expect(chunks[0]).not.toHaveProperty('errors');
+    expect(mockLogger.error).not.toHaveBeenCalledWith(expect.anything(), 'claude.result_is_error');
+  });
+
   describe('inline agents (nodeConfig.agents)', () => {
     test('passes inline agents map through to SDK options.agents', async () => {
       mockQuery.mockImplementation(async function* () {

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -800,9 +800,8 @@ async function* streamClaudeMessages(
       // model terminates via a configured stop sequence (stop_reason ===
       // 'stop_sequence') the SDK can set is_error: true while keeping
       // subtype: 'success' — its encoding of "non-default termination, not a
-      // failure". Treat that pair as a clean success so dag-executor and
-      // orchestrator-agent (which gate failure on isError) don't misclassify
-      // it (#1425).
+      // failure". Treat that pair as a clean success so downstream consumers
+      // (which gate failure on isError) don't misclassify it.
       const isRealError = resultMsg.is_error === true && resultMsg.subtype !== 'success';
       if (isRealError) {
         getLog().error(
@@ -820,7 +819,7 @@ async function* streamClaudeMessages(
             sessionId: resultMsg.session_id,
             stopReason: resultMsg.stop_reason,
           },
-          'claude.result_success_stop_sequence'
+          'claude.result_success_validated'
         );
       }
       yield {

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -796,7 +796,15 @@ async function* streamClaudeMessages(
       };
       const tokens = normalizeClaudeUsage(resultMsg.usage);
       const sdkErrors = Array.isArray(resultMsg.errors) ? resultMsg.errors : undefined;
-      if (resultMsg.is_error) {
+      // SDKResultSuccess declares `is_error: boolean` (not literal false). When a
+      // model terminates via a configured stop sequence (stop_reason ===
+      // 'stop_sequence') the SDK can set is_error: true while keeping
+      // subtype: 'success' — its encoding of "non-default termination, not a
+      // failure". Treat that pair as a clean success so dag-executor and
+      // orchestrator-agent (which gate failure on isError) don't misclassify
+      // it (#1425).
+      const isRealError = resultMsg.is_error === true && resultMsg.subtype !== 'success';
+      if (isRealError) {
         getLog().error(
           {
             sessionId: resultMsg.session_id,
@@ -806,6 +814,14 @@ async function* streamClaudeMessages(
           },
           'claude.result_is_error'
         );
+      } else if (resultMsg.is_error === true && resultMsg.subtype === 'success') {
+        getLog().debug(
+          {
+            sessionId: resultMsg.session_id,
+            stopReason: resultMsg.stop_reason,
+          },
+          'claude.result_success_stop_sequence'
+        );
       }
       yield {
         type: 'result',
@@ -814,8 +830,8 @@ async function* streamClaudeMessages(
         ...(resultMsg.structured_output !== undefined
           ? { structuredOutput: resultMsg.structured_output }
           : {}),
-        ...(resultMsg.is_error ? { isError: true, errorSubtype: resultMsg.subtype } : {}),
-        ...(resultMsg.is_error && sdkErrors?.length ? { errors: sdkErrors } : {}),
+        ...(isRealError ? { isError: true, errorSubtype: resultMsg.subtype } : {}),
+        ...(isRealError && sdkErrors?.length ? { errors: sdkErrors } : {}),
         ...(resultMsg.total_cost_usd !== undefined ? { cost: resultMsg.total_cost_usd } : {}),
         ...(resultMsg.stop_reason != null ? { stopReason: resultMsg.stop_reason } : {}),
         ...(resultMsg.num_turns !== undefined ? { numTurns: resultMsg.num_turns } : {}),

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -4329,6 +4329,64 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect(failedData.error).toContain('Subprocess crashed mid-turn');
     });
 
+    it('loop iteration does NOT fail on isError: true + errorSubtype: success', async () => {
+      // Regression test for #1425 (loop-branch counterpart of the main-path
+      // test). Stop_sequence terminations carry is_error: true + subtype:
+      // 'success' under the Claude SDK contract; previously, the loop branch
+      // threw "SDK returned success" and aborted the iteration even though
+      // the AI had completed its work correctly.
+      mockSendQueryDag.mockImplementation(function* () {
+        yield { type: 'assistant', content: 'Done. DONE.' };
+        yield {
+          type: 'result',
+          isError: true,
+          errorSubtype: 'success',
+          stopReason: 'stop_sequence',
+          sessionId: 'sid-loop-stop',
+        };
+      });
+
+      const store = createMockStore();
+      const mockDeps = createMockDeps(store);
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun();
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        {
+          name: 'loop-success-stop-seq-test',
+          nodes: [
+            {
+              id: 'work',
+              loop: {
+                prompt: 'Do the work. Say DONE.',
+                until: 'DONE',
+                max_iterations: 3,
+              },
+            },
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+      const failedEvents = eventCalls.filter((call: unknown[]) => {
+        const evt = (call[0] as Record<string, unknown>).event_type as string;
+        return evt === 'node_failed' || evt === 'loop_iteration_failed';
+      });
+      expect(failedEvents).toHaveLength(0);
+    });
+
     it('non-interactive loop is unaffected (no pause)', async () => {
       mockSendQueryDag.mockImplementation(function* () {
         yield { type: 'assistant', content: 'Still working...' };
@@ -5695,6 +5753,57 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     >;
     expect(failedData.error).toContain('error_during_execution');
     expect(failedData.error).toContain('permission denied');
+  });
+
+  it('does NOT fail node when SDK returns isError: true + errorSubtype: success', async () => {
+    // Regression test for #1425: stop_sequence terminations under the Claude
+    // SDK contract carry is_error: true + subtype: 'success'. The provider
+    // normalises this, but the executor keeps an explicit guard so a future
+    // provider regression or a third-party IAgentProvider that forwards the
+    // SDK pair raw cannot reintroduce the "SDK returned success" false-failure.
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'classified output' };
+      yield {
+        type: 'result',
+        isError: true,
+        errorSubtype: 'success',
+        stopReason: 'stop_sequence',
+        sessionId: 'sid-stop',
+      };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-dag',
+      testDir,
+      {
+        name: 'success-stop-seq-test',
+        nodes: [{ id: 'classify', command: 'my-cmd' }],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+    const nodeFailedEvents = eventCalls.filter(
+      (call: unknown[]) => (call[0] as Record<string, unknown>).event_type === 'node_failed'
+    );
+    expect(nodeFailedEvents).toHaveLength(0);
+
+    const completeCalls = (store.completeWorkflowRun as ReturnType<typeof mock>).mock.calls;
+    expect(completeCalls.length).toBeGreaterThan(0);
   });
 
   it('forwards workflow-level effort to node when no per-node override', async () => {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -904,7 +904,12 @@ async function executeNodeInternal(
         // Fail loudly on any other SDK error result. Previously we broke out of
         // the stream silently, producing empty/partial output without signaling
         // failure — which let failed iterations masquerade as successes (#1208).
-        if (msg.isError) {
+        // Exception: errorSubtype === 'success' is the Claude SDK's marker for a
+        // clean stop_sequence termination. The provider already filters this
+        // out, but the guard here keeps a third-party IAgentProvider that
+        // forwards the SDK pair raw from producing a "SDK returned success"
+        // false failure (#1425).
+        if (msg.isError && msg.errorSubtype !== 'success') {
           const subtype = msg.errorSubtype ?? 'unknown';
           const errorsDetail = msg.errors?.length ? ` — ${msg.errors.join('; ')}` : '';
           getLog().error(
@@ -1929,7 +1934,10 @@ async function executeLoopNode(
           // silently, producing empty output and continuing to the next iteration —
           // which made `error_during_execution` on resumed interactive loops look
           // like a "5-second crash" that kept burning iterations (#1208).
-          if (msg.isError) {
+          // Exception: errorSubtype === 'success' is the Claude SDK's marker for a
+          // clean stop_sequence termination — see the corresponding guard in the
+          // main node path above (#1425).
+          if (msg.isError && msg.errorSubtype !== 'success') {
             const subtype = msg.errorSubtype ?? 'unknown';
             const errorsDetail = msg.errors?.length ? ` — ${msg.errors.join('; ')}` : '';
             getLog().error(

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -903,12 +903,12 @@ async function executeNodeInternal(
         }
         // Fail loudly on any other SDK error result. Previously we broke out of
         // the stream silently, producing empty/partial output without signaling
-        // failure — which let failed iterations masquerade as successes (#1208).
+        // failure — which let failed iterations masquerade as successes.
         // Exception: errorSubtype === 'success' is the Claude SDK's marker for a
-        // clean stop_sequence termination. The provider already filters this
-        // out, but the guard here keeps a third-party IAgentProvider that
+        // clean stop_sequence termination. The Claude provider already filters
+        // this out, but the guard here keeps a third-party IAgentProvider that
         // forwards the SDK pair raw from producing a "SDK returned success"
-        // false failure (#1425).
+        // false failure.
         if (msg.isError && msg.errorSubtype !== 'success') {
           const subtype = msg.errorSubtype ?? 'unknown';
           const errorsDetail = msg.errors?.length ? ` — ${msg.errors.join('; ')}` : '';
@@ -1933,10 +1933,12 @@ async function executeLoopNode(
           // Fail the iteration loudly on SDK error results. Previously we broke
           // silently, producing empty output and continuing to the next iteration —
           // which made `error_during_execution` on resumed interactive loops look
-          // like a "5-second crash" that kept burning iterations (#1208).
+          // like a "5-second crash" that kept burning iterations.
           // Exception: errorSubtype === 'success' is the Claude SDK's marker for a
-          // clean stop_sequence termination — see the corresponding guard in the
-          // main node path above (#1425).
+          // clean stop_sequence termination (the SDK sets is_error: true alongside
+          // subtype: 'success' to encode "non-default termination, not a failure").
+          // The Claude provider already filters this; the guard here defends
+          // against a third-party IAgentProvider that forwards the SDK pair raw.
           if (msg.isError && msg.errorSubtype !== 'success') {
             const subtype = msg.errorSubtype ?? 'unknown';
             const errorsDetail = msg.errors?.length ? ` — ${msg.errors.join('; ')}` : '';


### PR DESCRIPTION
## Summary

- **Problem**: Claude Agent SDK's `SDKResultSuccess` declares `is_error: boolean` (not literal false). Stop_sequence terminations carry `is_error: true` + `subtype: 'success'` — the SDK's encoding of "non-default termination, but not a failure". The claude provider forwarded this to `MessageChunk.isError` verbatim, so three downstream consumers (dag-executor main, dag-executor loop, orchestrator-agent direct chat) misclassified clean terminations as node failures with the contradictory user-hostile error `"Node '<X>' failed: SDK returned success"` — even though the AI had completed correctly and written its output.
- **Why it matters**: Three reporters across v0.3.9 and v0.3.11 (latest 2026-05-13). Review-classify and synthesis pipelines, plus loop-back wrapper workflows, hard-fail and skip downstream trigger-rule joins (`synthesize`, `self-fix`, `simplify`, `report`). Users blocked unless they fork+patch+rebuild; archon's workflow schema does not expose `stop_sequences` and disabling `output_format` would break downstream `when:` conditions.
- **What changed**: Provider boundary normalises `is_error: true` + `subtype: 'success'` as a clean success — no `isError` propagation downstream; debug-level `claude.result_success_stop_sequence` log preserves observability. Defense-in-depth `errorSubtype !== 'success'` guards added to `dag-executor.ts` main path and loop branch so a future third-party `IAgentProvider` forwarding the SDK pair raw can't reintroduce the bug. Regression tests for provider, DAG main, DAG loop, and orchestrator direct chat; guard test ensures real error subtypes (`error_max_turns`) still propagate.
- **What did NOT change (scope boundary)**: No change to `MessageChunk` type shape in `packages/providers/src/types.ts` (contract semantics tighten, type signature unchanged). No change to Codex `turn.failed` path (Bug A in the issue is already resolved by commit `4c6ddd99` + the current Codex `turn.failed` handler at `codex/provider.ts:235-247`). No change to `orchestrator-agent.ts` code (the provider-level fix covers direct chat transparently). No retry/auth-precheck behavioural improvements. No touch on related but separate bugs #1208, #1266.

## UX Journey

### Before

```
User                          Archon                                Claude SDK
────                          ──────                                ──────────
runs workflow with        ──▶  classify node executes
output_format: json_schema     SDK returns {is_error: true,
(implies stop_sequence)        subtype: 'success',
                               stop_reason: 'stop_sequence'}  ◀──── completes via stop sequence
                               provider forwards isError verbatim
                               dag-executor.ts:921 throws:
                                 "Node 'classify' failed:
                                  SDK returned success"
                               workflow exits with failure
                               trigger-rule joins skip
                               (synthesize/self-fix/simplify/report)
sees ❌ on a run whose  ◀──── output was written to disk;
classify output is valid       review pipeline produces nothing
```

### After

```
User                          Archon                                Claude SDK
────                          ──────                                ──────────
runs workflow with        ──▶  classify node executes
output_format: json_schema     SDK returns {is_error: true,
                               subtype: 'success',
                               stop_reason: 'stop_sequence'}  ◀──── completes via stop sequence
                               [+] provider normalises:
                                   is_error + 'success' subtype
                                   ⇒ clean result, no isError
                                   [+] debug log: claude.result_success_stop_sequence
                               dag-executor.ts:921 guard:
                                   `isError && errorSubtype !== 'success'` ⇒ skip throw
                               node completes normally
                               trigger-rule joins fire
                               downstream nodes run on real output
sees ✅ classify output      ◀── review pipeline writes findings
```

## Architecture Diagram

### Before

```
@archon/providers
└── claude/provider.ts
    └── result handler: forwards SDK is_error verbatim
        ──▶ MessageChunk { isError: true, errorSubtype: 'success' }
                                            │
                                            ▼
@archon/workflows                @archon/core
├── dag-executor.ts              orchestrator-agent.ts
│   ├── main path:921             ├── handleStreamMode:1142
│   │   throws unconditionally    │   sends classifyAndFormatError("success")
│   │   on isError                │
│   └── loop branch:1947          └── handleBatchMode:1298
│       same throw                    same surface
```

### After

```
@archon/providers
└── claude/provider.ts
    [~] result handler: normalises is_error + subtype: 'success'
        ──▶ MessageChunk { /* no isError when subtype === 'success' */ }
            [+] debug log: claude.result_success_stop_sequence
                                            │
                                            ▼
@archon/workflows                @archon/core
├── dag-executor.ts              orchestrator-agent.ts
│   ├── main path:921             ├── handleStreamMode:1142
│   │   [~] && errorSubtype       │   transparently fixed (chunk clean)
│   │       !== 'success'         │
│   └── loop branch:1947          └── handleBatchMode:1298
│       [~] same carve-out            transparently fixed (chunk clean)
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `claude/provider.ts` result handler | `MessageChunk.isError` | **modified** | No longer emits `isError: true` when `subtype === 'success'` |
| `claude/provider.ts` result handler | logger | **modified** | New debug-level `claude.result_success_stop_sequence` event |
| `dag-executor.ts:907-922` (main) | `throw new Error(...)` | **modified** | New `errorSubtype !== 'success'` carve-out |
| `dag-executor.ts:1932-1948` (loop) | `throw new Error(...)` | **modified** | Same carve-out mirrored |
| `orchestrator-agent.ts:1127, 1298` | `MessageChunk` | unchanged | Transparently fixed via provider normalisation |
| Existing `error_max_budget_usd` carve-out at `dag-executor.ts:894-903` | — | unchanged | Pattern mirrored for new carve-out |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `workflows`, `core` (tests)
- Module: `providers:claude`, `workflows:executor`, `core:orchestrator` (test)

## Change Metadata

- Change type: `bug`
- Primary scope: `multi` (providers + workflows + core tests)

## Linked Issue

- Closes #1425
- Related: #1208 (parent fix this regression rode on top of), #1266 (separate Codex AbortSignal bug — not addressed), #1601 (broader evidence-contract PR — orthogonal)
- Depends on: none
- Supersedes: none

## Validation Evidence (required)

```bash
bun run validate   # ✅ exit 0
```

All six gates green on first invocation (after one prettier auto-format pass on the new provider test):

- `check:bundled` — `bundled-defaults.generated.ts is up to date (36 commands, 20 workflows)`
- `check:bundled-skill` — `bundled-skill.ts is up to date (21 files)`
- `type-check` — all 10 packages exit 0
- `lint` — 0 errors, 0 warnings
- `format:check` — all files Prettier-clean
- `test` — all per-package suites pass; new tests:
  - `@archon/providers claude/provider.test.ts`: +1 test (success-via-stop-sequence) → 26 → 27 in `sendQuery decomposition behaviors`
  - `@archon/workflows dag-executor.test.ts`: +2 tests (DAG main + loop branch) → 218 in the test file
  - `@archon/core orchestrator-agent.test.ts`: +1 test (direct chat contract) → 116 → 117

Skipped commands: none.

## Security Impact (required)

- New permissions/capabilities? **No** — only changes the conditional emission of an existing field on an existing chunk type, and a log level for one event.
- New external network calls? **No**.
- Secrets/tokens handling changed? **No**.
- File system access scope changed? **No**.
- Risk and mitigation: n/a.

## Compatibility / Migration

- Backward compatible? **Yes** — workflows that previously failed with `"SDK returned success"` will now complete cleanly. No workflow YAML changes required. Workflows that produced real errors (e.g. `error_max_turns`, `error_during_execution`, `error_max_budget_usd`) continue to fail loudly; the guard is subtype-scoped to `'success'` only.
- Config/env changes? **No**.
- Database migration needed? **No**.
- Upgrade steps: none.

## Human Verification (required)

- **Verified scenarios**:
  - `bun run validate` exits 0 on a clean checkout of this branch (after one prettier auto-format on the new test).
  - Individual per-package test runs: provider 74 pass, workflows dag-executor 218 pass, core orchestrator-agent 117 pass.
  - SDK type signature personally inspected at `@anthropic-ai/claude-agent-sdk@0.2.121/sdk.d.ts:3117-3158` — `SDKResultSuccess.is_error: boolean` (not literal false), confirming the bug mechanism described in the investigation artifact.
  - Provider's `else if (resultMsg.is_error === true && resultMsg.subtype === 'success')` branch verified to fire on the new test case (asserted via `not.toHaveBeenCalledWith(..., 'claude.result_is_error')`).
- **Edge cases checked**:
  - Real error subtype (`error_max_turns`) still propagates `isError: true` and fires the `claude.result_is_error` error log — guarded by the existing test at `provider.test.ts:1223` which continues to pass.
  - Codex provider's `turn.failed` path (`codex/provider.ts:235-247`) audited — emits `errorSubtype: 'codex_turn_failed'`, never `'success'`. Unaffected.
  - Pi provider's `event-bridge.ts:160,164,173` audited — emits `'missing_assistant_message'` or `last.stopReason ∈ {'error','aborted'}`, never `'success'`. Unaffected.
  - Empty-output guard at `dag-executor.ts:1126` audited — still triggers if any node produces zero output AND no structured output. Defence-in-depth for Bug A (issue #1425) remains intact.
- **What was not verified**:
  - End-to-end live run against `archon-fix-github-issue` on a real Claude `output_format: json_schema` node. The unit tests synthesise the exact `(is_error, subtype, stop_reason)` triple the SDK emits in this case, so behavioural coverage is equivalent.
  - Behaviour on Claude Agent SDK versions older than 0.2.121. The `SDKResultSuccess.is_error: boolean` type signature has been stable across the 0.2.x line (verified in 0.2.74 and 0.2.89 lockfile entries).

## Side Effects / Blast Radius (required)

- **Affected subsystems**:
  - `@archon/providers` — Claude provider only. Codex/Pi unaffected.
  - `@archon/workflows` — DAG executor's main and loop branches only.
  - `@archon/core` — orchestrator direct chat transparently fixed; no code change to orchestrator-agent.ts.
- **Potential unintended effects**:
  - Stop_sequence-terminated runs that previously failed loudly with `"SDK returned success"` will now complete. This is the intended behaviour, but operators who monitored those failures as alerts will see them disappear. Logs preserve a debug-level `claude.result_success_stop_sequence` event for ops dashboards.
  - The `claude.result_is_error` error-level log no longer fires for `subtype === 'success'`. The new debug event is a clean replacement.
- **Guardrails / monitoring for early detection**:
  - `claude.result_success_stop_sequence` log (debug) shows where the new code path fires.
  - `claude.result_is_error` log (error) continues to fire for genuine error subtypes — alert on this if a real regression slips through.
  - Type-check + lint + format catch any author misuse of the guard pattern at change time.

## Rollback Plan (required)

- **Fast rollback path**: `git revert <merge-commit-sha> && git push origin dev` — single commit, additive only. Reverting restores the pre-PR throw behaviour on stop_sequence terminations (re-introducing #1425's bug for affected users).
- **Feature flags / config toggles**: None. The fix is unconditional and non-configurable — there's no scenario in which surfacing `subtype === 'success'` as a failure is correct.
- **Observable failure symptoms** post-merge:
  - If a user reports a workflow that completes when it should fail: check `claude.result_is_error` logs — should fire for real errors.
  - If a user reports the original #1425 symptom returning: check the new `&& msg.errorSubtype !== 'success'` guards in `dag-executor.ts` lines ~915 and ~1940 are still present; check `claude/provider.ts:807-826` `isRealError` derivation is intact.

## Risks and Mitigations

- **Risk**: The provider's success normalisation hides a future SDK regression where `subtype: 'success'` actually does indicate a failure.
  - **Mitigation**: Very unlikely given the SDK's explicit discriminated union (`SDKResultMessage = SDKResultSuccess | SDKResultError`) and the `error_*` subtype enum. If the SDK ever changes semantics, the executor's defense-in-depth guard would still emit a less-confusing error (the node would complete rather than throw with a contradictory message). The guard scope is subtype-equality on the string literal `'success'`, not a broader pattern.
- **Risk**: A third-party `IAgentProvider` implementation copies the SDK pattern and starts emitting `isError: true, errorSubtype: 'success'`.
  - **Mitigation**: Defense-in-depth guards at `dag-executor.ts:915` and `:1940` already cover this — the executor will not throw on such a chunk regardless of which provider emitted it.

---

**Investigation artifact**: `.claude/PRPs/issues/issue-1425.md` (local-only, gitignored per repo policy)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Claude stop-sequence terminations that indicate clean completion are no longer misclassified as errors; sessions persist and no false error messages are shown.

* **Tests**
  * Added regression tests across provider, orchestrator, and workflow layers to prevent reintroduction of the misclassification and ensure workflows complete correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1662)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->