### PR TITLE
feat(paths): add ARCHON_STORE_ARTIFACTS_IN_WORKTREE env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -214,6 +214,12 @@ GITEA_ALLOWED_USERS=
 # NOT read by Archon source code.
 # ARCHON_USER_HOME=/opt/archon-user-home
 
+# Store workflow artifacts in the repository worktree (tracked by git).
+# Default: false (artifacts stored in ~/.archon/workspaces/owner/repo/artifacts/)
+# Set to true to store artifacts in <repo>/.archon/artifacts/ instead.
+# Useful when you want workflow artifacts to be part of git history.
+# ARCHON_STORE_ARTIFACTS_IN_WORKTREE=false
+
 # Logging (optional)
 # Set log level: fatal | error | warn | info | debug | trace
 # Default: info

--- a/packages/docs-web/src/content/docs/guides/authoring-commands.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-commands.md
@@ -227,7 +227,7 @@ Archon replaces variables in command text before sending to the AI. The most com
 |----------|-------|
 | `$ARGUMENTS` / `$USER_MESSAGE` | User's input message |
 | `$1`, `$2`, `$3` | Positional arguments (direct invocation only) |
-| `$ARTIFACTS_DIR` | Pre-created artifacts directory for this workflow run |
+| `$ARTIFACTS_DIR` | Pre-created artifacts directory for this workflow run. Default: `~/.archon/workspaces/owner/repo/artifacts/runs/{run-id}/`. Opt-in via `ARCHON_STORE_ARTIFACTS_IN_WORKTREE=true` to use `<repo>/.archon/artifacts/runs/{run-id}/` instead. |
 | `$BASE_BRANCH` | Base branch (auto-detected or configured) |
 | `$DOCS_DIR` | Documentation directory path (default: `docs/`) |
 | `$WORKFLOW_ID` | Unique workflow run ID |

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -779,7 +779,7 @@ All workflows support variable substitution in prompts and commands. The most co
 |----------|-------------|
 | `$ARGUMENTS` / `$USER_MESSAGE` | The user's input message that triggered the workflow |
 | `$WORKFLOW_ID` | Unique ID for this workflow run |
-| `$ARTIFACTS_DIR` | Pre-created artifacts directory for this workflow run |
+| `$ARTIFACTS_DIR` | Pre-created artifacts directory for this workflow run. Default: `~/.archon/workspaces/owner/repo/artifacts/runs/{run-id}/`. When `ARCHON_STORE_ARTIFACTS_IN_WORKTREE=true`, points to `<repo>/.archon/artifacts/runs/{run-id}/` instead. |
 | `$BASE_BRANCH` | Base branch (auto-detected or configured) |
 | `$DOCS_DIR` | Documentation directory path (default: `docs/`) |
 | `$CONTEXT` | GitHub issue/PR context (if available) |

--- a/packages/docs-web/src/content/docs/reference/configuration.md
+++ b/packages/docs-web/src/content/docs/reference/configuration.md
@@ -224,6 +224,7 @@ Environment variables override all other configuration. They are organized by ca
 | Variable | Description | Default |
 | --- | --- | --- |
 | `ARCHON_HOME` | Base directory for all Archon-managed files. **Ignored in Docker** — the container always uses `/.archon`. | `~/.archon` |
+| `ARCHON_STORE_ARTIFACTS_IN_WORKTREE` | When set to `true` or `1`, workflow artifacts are written to `<repo>/.archon/artifacts/` (inside the repo, may be git-tracked depending on your `.gitignore`) instead of the default central workspace at `~/.archon/workspaces/owner/repo/artifacts/`. Useful when you want artifacts to travel with the repo. | -- |
 | `PORT` | HTTP server listen port | `3090` (auto-allocated in worktrees) |
 | `LOG_LEVEL` | Logging verbosity (`fatal`, `error`, `warn`, `info`, `debug`, `trace`) | `info` |
 | `BOT_DISPLAY_NAME` | Bot name shown in batch-mode "starting" messages | `Archon` |

--- a/packages/paths/src/archon-paths.test.ts
+++ b/packages/paths/src/archon-paths.test.ts
@@ -8,6 +8,7 @@ const isWindows = process.platform === 'win32';
 
 import {
   isDocker,
+  shouldStoreArtifactsInWorktree,
   getArchonHome,
   getArchonWorkspacesPath,
   ensureArchonWorkspacesPath,
@@ -39,7 +40,14 @@ import {
 } from './archon-paths';
 
 /** All env vars that path functions depend on */
-const ENV_VARS = ['WORKSPACE_PATH', 'WORKTREE_BASE', 'ARCHON_HOME', 'ARCHON_DOCKER', 'HOME'];
+const ENV_VARS = [
+  'WORKSPACE_PATH',
+  'WORKTREE_BASE',
+  'ARCHON_HOME',
+  'ARCHON_DOCKER',
+  'ARCHON_STORE_ARTIFACTS_IN_WORKTREE',
+  'HOME',
+];
 
 /**
  * Save and restore environment variables around each test.
@@ -101,6 +109,43 @@ describe('archon-paths', () => {
       delete process.env.ARCHON_DOCKER;
       process.env.HOME = homedir();
       expect(isDocker()).toBe(false);
+    });
+  });
+
+  describe('shouldStoreArtifactsInWorktree', () => {
+    test('returns false by default (env var not set)', () => {
+      delete process.env.ARCHON_STORE_ARTIFACTS_IN_WORKTREE;
+      expect(shouldStoreArtifactsInWorktree()).toBe(false);
+    });
+
+    test('returns true when env var is "true"', () => {
+      process.env.ARCHON_STORE_ARTIFACTS_IN_WORKTREE = 'true';
+      expect(shouldStoreArtifactsInWorktree()).toBe(true);
+    });
+
+    test('returns true when env var is "TRUE" (case insensitive)', () => {
+      process.env.ARCHON_STORE_ARTIFACTS_IN_WORKTREE = 'TRUE';
+      expect(shouldStoreArtifactsInWorktree()).toBe(true);
+    });
+
+    test('returns true when env var is "1"', () => {
+      process.env.ARCHON_STORE_ARTIFACTS_IN_WORKTREE = '1';
+      expect(shouldStoreArtifactsInWorktree()).toBe(true);
+    });
+
+    test('returns false when env var is "false"', () => {
+      process.env.ARCHON_STORE_ARTIFACTS_IN_WORKTREE = 'false';
+      expect(shouldStoreArtifactsInWorktree()).toBe(false);
+    });
+
+    test('returns false when env var is "0"', () => {
+      process.env.ARCHON_STORE_ARTIFACTS_IN_WORKTREE = '0';
+      expect(shouldStoreArtifactsInWorktree()).toBe(false);
+    });
+
+    test('returns false for any other value', () => {
+      process.env.ARCHON_STORE_ARTIFACTS_IN_WORKTREE = 'yes';
+      expect(shouldStoreArtifactsInWorktree()).toBe(false);
     });
   });
 

--- a/packages/paths/src/archon-paths.ts
+++ b/packages/paths/src/archon-paths.ts
@@ -49,6 +49,16 @@ export function isDocker(): boolean {
 }
 
 /**
+ * Check if artifacts should be stored in the worktree (repo) instead of central location.
+ * When true, artifacts go to <repo>/.archon/artifacts/ (tracked by git).
+ * When false (default), artifacts go to ~/.archon/workspaces/owner/repo/artifacts/.
+ */
+export function shouldStoreArtifactsInWorktree(): boolean {
+  const value = process.env.ARCHON_STORE_ARTIFACTS_IN_WORKTREE?.toLowerCase();
+  return value === 'true' || value === '1';
+}
+
+/**
  * Get the Archon home directory
  * - Docker: /.archon
  * - Local: ~/.archon (or ARCHON_HOME env var)

--- a/packages/paths/src/index.ts
+++ b/packages/paths/src/index.ts
@@ -33,6 +33,7 @@ export {
   createProjectSourceSymlink,
   findMarkdownFilesRecursive,
   getWebDistDir,
+  shouldStoreArtifactsInWorktree,
 } from './archon-paths';
 
 // Env loader

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -175,6 +175,9 @@ async function sendCriticalMessage(
  * Resolve the artifacts and log directories for a workflow run.
  * Looks up the codebase by ID once, parses owner/repo, and returns project-scoped paths.
  * Falls back to cwd-based paths for unregistered repos.
+ *
+ * When ARCHON_STORE_ARTIFACTS_IN_WORKTREE=true, artifacts are stored in the repo's
+ * .archon/artifacts/ directory (tracked by git) instead of the central location.
  */
 async function resolveProjectPaths(
   deps: WorkflowDeps,
@@ -182,6 +185,14 @@ async function resolveProjectPaths(
   workflowRunId: string,
   codebaseId?: string
 ): Promise<{ artifactsDir: string; logDir: string }> {
+  // Check env var for artifact location preference
+  if (archonPaths.shouldStoreArtifactsInWorktree()) {
+    return {
+      artifactsDir: join(cwd, '.archon', 'artifacts', 'runs', workflowRunId),
+      logDir: join(cwd, '.archon', 'logs'),
+    };
+  }
+
   if (codebaseId) {
     try {
       const codebase = await deps.store.getCodebase(codebaseId);


### PR DESCRIPTION
Add environment variable to opt-in to storing workflow artifacts in the repository worktree (<repo>/.archon/artifacts/) instead of the central location (~/.archon/workspaces/owner/repo/artifacts/).

This is useful when users want workflow artifacts to be part of git history.

- Add shouldStoreArtifactsInWorktree() function to archon-paths
- Modify resolveProjectPaths() in executor.ts to check the env var
- Document new env var in .env.example
- Add comprehensive tests for the new function


## Summary

- **Problem:** Archon stores workflow artifacts in `~/.archon/workspaces/` for registered codebases, but some users want artifacts tracked in git
- **Why it matters:** Users who want workflow artifacts as part of git history have no way to opt-in
- **What changed:** Added `ARCHON_STORE_ARTIFACTS_IN_WORKTREE` env var to store artifacts in `<repo>/.archon/artifacts/` instead
- **What did not change:** Default behavior unchanged (artifacts still go to central location unless env var is set)

## UX Journey

### Before

```
User                   Archon CLI
────                   ──────────
runs workflow ───────▶ resolveProjectPaths()
                       checks codebaseId
                       → artifacts go to ~/.archon/workspaces/owner/repo/artifacts/
                       (no option to store in repo)
```

### After

```
User                   Archon CLI
────                   ──────────
sets env var           ARCHON_STORE_ARTIFACTS_IN_WORKTREE=true
runs workflow ───────▶ resolveProjectPaths()
                       [checks env var FIRST]
                       → artifacts go to <repo>/.archon/artifacts/runs/
```

## Architecture Diagram

### Before

```
executor.ts
    │
    └─▶ resolveProjectPaths()
            │
            ├─▶ codebaseId exists? → ~/.archon/workspaces/.../artifacts/
            └─▶ fallback → <cwd>/.archon/artifacts/
```

### After

```
executor.ts
    │
    └─▶ resolveProjectPaths()
            │
            ├─▶ [+] shouldStoreArtifactsInWorktree()? → <cwd>/.archon/artifacts/
            ├─▶ codebaseId exists? → ~/.archon/workspaces/.../artifacts/
            └─▶ fallback → <cwd>/.archon/artifacts/
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| executor.ts | archon-paths.ts | **new** | imports shouldStoreArtifactsInWorktree |
| index.ts | archon-paths.ts | **modified** | exports new function |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `paths`, `workflows`
- Module: `paths:archon-paths`, `workflows:executor`

## Change Metadata

- Change type: `feature`
- Primary scope: `multi` (paths + workflows)

## Linked Issue

- Closes # (none - new feature request)

## Validation Evidence (required)

```bash
bun test packages/paths/src/archon-paths.test.ts
# 86 pass, 0 fail
```

- Evidence provided: All 86 tests pass including 7 new tests for `shouldStoreArtifactsInWorktree()`
- Type-check has pre-existing failures (posthog-node, grammy, pi-coding-agent) unrelated to this PR

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No` (artifacts can already go to repo via fallback path)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes` - new optional env var `ARCHON_STORE_ARTIFACTS_IN_WORKTREE`
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios: Set env var, ran workflow, confirmed artifacts appeared in `<repo>/.archon/artifacts/runs/`
- Edge cases checked: env var values (true, TRUE, 1, false, 0, unset)
- What was not verified: Interaction with codebase registration flow

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Only `resolveProjectPaths()` in executor.ts
- Potential unintended effects: None - opt-in only, default unchanged
- Guardrails: Env var must be explicitly set to `true` or `1`

## Rollback Plan (required)

- Fast rollback command: Unset or set `ARCHON_STORE_ARTIFACTS_IN_WORKTREE=false`
- Feature flags: The env var itself acts as a feature flag
- Observable failure symptoms: Artifacts appearing in wrong location

## Risks and Mitigations

- Risk: Users may not realize artifacts in repo will be tracked by git
  - Mitigation: Documented in `.env.example` that this makes artifacts part of git history




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ARCHON_STORE_ARTIFACTS_IN_WORKTREE` option to choose repo-local (.archon/artifacts/) vs. default home-based artifact storage.

* **Documentation**
  * Updated guides and configuration reference to document the new option and `$ARTIFACTS_DIR` behavior and defaults.

* **Tests**
  * Added tests covering the new storage option’s on/off parsing and behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1664)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->