### PR TITLE
fix(scripts): handle duplicate ARCHON_STATE_JSON_BEGIN blocks in persist

### DIFF
--- a/.archon/scripts/maintainer-standup-persist.test.ts
+++ b/.archon/scripts/maintainer-standup-persist.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+/**
+ * Runs the persist script with the given stdin content in a temp directory.
+ * Returns { exitCode, stdout, stderr }.
+ */
+async function runPersist(stdin: string) {
+  const cwd = mkdtempSync(join(tmpdir(), 'persist-test-'));
+  try {
+    const proc = Bun.spawn(
+      ['bun', 'run', join(import.meta.dir, 'maintainer-standup-persist.ts')],
+      { cwd, stdin: new Response(stdin).body!, stdout: 'pipe', stderr: 'pipe' },
+    );
+    const [stdout, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    const exitCode = await proc.exited;
+    let stateParsed: unknown = null;
+    let briefContent: string | null = null;
+    if (exitCode === 0) {
+      const meta = JSON.parse(stdout.trim());
+      const statePath = join(cwd, meta.state_path);
+      const briefPath = join(cwd, meta.brief_path);
+      stateParsed = JSON.parse(readFileSync(statePath, 'utf8'));
+      briefContent = readFileSync(briefPath, 'utf8');
+    }
+    return { exitCode, stdout: stdout.trim(), stderr, stateParsed, briefContent };
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+}
+
+describe('maintainer-standup-persist', () => {
+  test('single BEGIN/END block succeeds', async () => {
+    const input = [
+      '# Maintainer Standup — 2026-05-14',
+      'All systems operational.',
+      'ARCHON_STATE_JSON_BEGIN',
+      '{"version": 1}',
+      'ARCHON_STATE_JSON_END',
+    ].join('\n');
+    const result = await runPersist(input);
+    expect(result.exitCode).toBe(0);
+    expect(result.stateParsed).toEqual({ version: 1 });
+    expect(result.briefContent).toContain('All systems operational.');
+  });
+
+  test('duplicate BEGIN blocks — takes last complete block (fixes #1674)', async () => {
+    const input = [
+      '# Maintainer Standup — 2026-05-14',
+      'Brief content here.',
+      'ARCHON_STATE_JSON_BEGIN',
+      '{"truncated": true, "partial',  // truncated first emission
+      '',
+      'ARCHON_STATE_JSON_BEGIN',
+      '{"version": 2, "complete": true}',
+      'ARCHON_STATE_JSON_END',
+    ].join('\n');
+    const result = await runPersist(input);
+    expect(result.exitCode).toBe(0);
+    expect(result.stateParsed).toEqual({ version: 2, complete: true });
+    expect(result.briefContent).toContain('Brief content here.');
+  });
+
+  test('JSON-wrapper fallback works', async () => {
+    const input = JSON.stringify({
+      brief_markdown: '# Standup\nAll good.',
+      next_state: { version: 3 },
+    });
+    const result = await runPersist(input);
+    expect(result.exitCode).toBe(0);
+    expect(result.stateParsed).toEqual({ version: 3 });
+    expect(result.briefContent).toContain('All good.');
+  });
+
+  test('no valid format exits 1', async () => {
+    const result = await runPersist('just some random text with no markers');
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('PERSIST FAILED');
+  });
+});

--- a/.archon/scripts/maintainer-standup-persist.ts
+++ b/.archon/scripts/maintainer-standup-persist.ts
@@ -33,13 +33,15 @@ let source: 'delimiter' | 'json-wrapper' | null = null;
 // ── Tier 1: delimiter-based extraction ──
 const BEGIN = 'ARCHON_STATE_JSON_BEGIN';
 const END = 'ARCHON_STATE_JSON_END';
-const beginIdx = raw.indexOf(BEGIN);
-const endIdx = raw.indexOf(END);
+const beginIdx = raw.lastIndexOf(BEGIN);
+const endIdx = raw.indexOf(END, beginIdx);
 if (beginIdx !== -1 && endIdx !== -1 && endIdx > beginIdx) {
   const stateText = raw.slice(beginIdx + BEGIN.length, endIdx).trim();
   try {
     state = JSON.parse(stateText) as State;
-    brief = raw.slice(0, beginIdx).trim();
+    // Brief is everything before the first BEGIN marker (includes any
+    // truncated earlier emission, which we strip via the heading filter below).
+    brief = raw.slice(0, raw.indexOf(BEGIN)).trim();
     source = 'delimiter';
   } catch (err) {
     process.stderr.write(


### PR DESCRIPTION
## Summary

- **Problem:** `maintainer-standup-persist.ts` fails when the synthesize node emits duplicate `ARCHON_STATE_JSON_BEGIN` blocks (e.g. a truncated emission followed by a complete one after mid-output restart). `indexOf(BEGIN)` pairs the first (partial) BEGIN with the first END, slicing across both blocks → `JSON.parse` fails → exit 1, no brief/state written.
- **Why it matters:** Standup workflow reports failure even though a usable state was produced. Requires manual log extraction.
- **What changed:** Tier 1 extraction uses `lastIndexOf(BEGIN)` to find the last (complete) block, then searches for `END` only after that position. Brief boundary uses `indexOf(BEGIN)` (first occurrence) so preamble including truncated content is captured and cleaned by the existing heading filter.
- **What did not change:** Tier 2 JSON-wrapper fallback, file output paths, heading-strip logic, error reporting.

## UX Journey

### Before

```
User                       Archon synthesize           persist script
────                       ──────────────────          ──────────────
runs maintainer-standup ──▶ emits partial state ──┐
                            restarts mid-output    │──▶ reads stdin
                            emits complete state   │    indexOf(BEGIN) → first (partial)
                                                   │    indexOf(END)  → only one
                                                   ▼    slice spans both blocks
                                                        JSON.parse fails
                                                        exits 1
sees "Workflow failed" ◀── no brief, no state.json
```

### After

```
User                       Archon synthesize           persist script
────                       ──────────────────          ──────────────
runs maintainer-standup ──▶ emits partial state ──┐
                            restarts mid-output    │──▶ reads stdin
                            emits complete state   │    lastIndexOf(BEGIN) → last (complete)
                                                   │    indexOf(END, lastBegin) → correct END
                                                   ▼    slice contains only complete JSON
                                                        JSON.parse succeeds
sees standup brief     ◀── brief + state.json written ✅
```

## Architecture Diagram

### Before & After

```
synthesize node ──stdin──▶ [~] maintainer-standup-persist.ts ──▶ .archon/maintainer-standup/
                                                                    ├── state.json
                                                                    └── briefs/YYYY-MM-DD.md
```

Only the persist script is modified. No new modules, no changed connections.

**Connection inventory:**

| From | To | Status | Notes |
|---|---|---|---|
| synthesize node | persist script | Unchanged | stdin pipe |
| persist script | filesystem | Unchanged | writes state.json + brief |

## Label Snapshot

| Label | Value |
|---|---|
| Type | Bug fix |
| Scope | `.archon/scripts/` |
| Risk | Low — isolated script, no runtime imports |

## Change Metadata

| Metric | Value |
|---|---|
| Files changed | 1 (+ 1 test file) |
| Insertions | ~90 |
| Deletions | 3 |
| New dependencies | None |
| DB migrations | None |

## Linked Issue

Closes #1674

## Validation Evidence

```
$ bun test ./.archon/scripts/maintainer-standup-persist.test.ts

 4 pass, 0 fail
 - single BEGIN/END block succeeds
 - duplicate BEGIN blocks — takes last complete block (fixes #1674)
 - JSON-wrapper fallback works
 - no valid format exits 1
```

Lint-staged (eslint + prettier) passed on commit.

## Security Impact

None — no auth, no network, no user input beyond stdin from a trusted workflow node.

## Compatibility/Migration

Fully backward compatible. Single-block inputs behave identically (`lastIndexOf` == `indexOf` when there is only one occurrence).

## Human Verification

- [x] Read the issue repro steps
- [x] Traced `indexOf` → `lastIndexOf` logic manually with duplicate-block input
- [x] Confirmed brief boundary uses first BEGIN (captures preamble for heading filter)
- [x] Test covers exact repro scenario from #1674

## Risks and Mitigations

| Risk | Mitigation |
|---|---|
| Multiple END markers | `indexOf(END, beginIdx)` finds first END after last BEGIN — correct pairing |
| Brief includes truncated JSON | Existing heading filter (`lines.findIndex(l => l.startsWith("# "))`) strips preamble prose |

## Side Effects/Blast Radius

None. The persist script is standalone — no imports from packages/, no runtime callers beyond the bash node in the standup workflow.

## Rollback Plan

Revert this commit. Previous behavior (crash on duplicate blocks) is restored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for maintainer standup persistence, covering standard and alternate input formats.

* **Bug Fixes**
  * Enhanced JSON block parsing to reliably locate correct blocks when duplicate markers are present.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1676)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->