### PR TITLE
feat(marketplace): add archon-idea-to-wo workflow (originally by @lamachine, #1647)

### DIFF
--- a/packages/docs-web/src/data/marketplace.ts
+++ b/packages/docs-web/src/data/marketplace.ts
@@ -107,4 +107,16 @@ export const marketplaceEntries: MarketplaceEntry[] = [
     tags: ['automation'],
     archonVersionCompat: '>=0.3.0',
   },
+  {
+    slug: 'archon-idea-to-wo',
+    name: 'Idea to Work Orders',
+    author: 'lamachine',
+    description:
+      'Interactive 8-node workflow that turns a raw idea into BKM-format Work Orders through four AI phases with approval gates between each: understand the idea, scope and approach, risk and decomposition, generate WOs. Output is a directory of self-contained WO files ready to hand to archon-piv-loop.',
+    sourceUrl:
+      'https://github.com/coleam00/archon-idea-to-wo/tree/3b0d5d828a4cb375d50bb1252f5e016c44242d01/.archon',
+    sha: '3b0d5d828a4cb375d50bb1252f5e016c44242d01',
+    tags: ['planning', 'development'],
+    archonVersionCompat: '>=0.3.0',
+  },
 ];


### PR DESCRIPTION
## Summary

- **Problem**: PR #1647 proposed `archon-idea-to-wo` (an idea → Work Orders interactive workflow) as a bundled default. With the marketplace shipped (#1624), the contributor flow is now SHA-pinned external repos — not in-tree TypeScript regeneration.
- **Why it matters**: It is the first community-authored workflow to land via the new marketplace path. Validates the directory-format submission flow end-to-end against the auto-review pipeline, and unblocks community contributions without waiting for Archon releases.
- **What changed**: Adds one entry to `packages/docs-web/src/data/marketplace.ts` for `archon-idea-to-wo`. The workflow + commands now live at [`coleam00/archon-idea-to-wo`](https://github.com/coleam00/archon-idea-to-wo) — content is byte-identical to the original PR #1647 (verified by matching blob SHAs), repackaged into the `.archon/<slug>.yaml` + `.archon/commands/` layout the installer expects.
- **What did *not* change**: No code, no schema, no lint script, no install logic, no CLI surface. Just a registry row. The original PR #1647's TypeScript change (`bundled-defaults.generated.ts`) is intentionally excluded — that path only applies to in-tree defaults, not marketplace entries.

## Credit

Workflow design, prompts, BKM Work Order template — all **[@lamachine](https://github.com/lamachine)** ([PR #1647](https://github.com/coleam00/Archon/pull/1647)). This PR is a packaging adaptation that moves the workflow from "bundled default" to "marketplace entry" so it can ship through the community channel.

## UX Journey

### Before

```
User wants to plan a feature
  │
  ▼
Reads PR #1647 description, sees the workflow proposed
  │
  ▼
Waits for Archon release + bundled-defaults regen + merge to dev → main
  │
  ▼
Eventually: archon workflow run archon-idea-to-wo  (only after release)
```

### After

```
User wants to plan a feature
  │
  ▼
Visits archon.diy/workflows/ → sees archon-idea-to-wo entry
  │
  ▼
archon workflow install archon-idea-to-wo   ← directory walk @ pinned SHA
  │                                            (.archon/<slug>.yaml + commands/)
  ▼
archon workflow run archon-idea-to-wo "<idea>"
  │
  ▼
4 AI phases × 4 approval gates → Work Orders land in $ARTIFACTS_DIR/work-orders/
```

## Architecture Diagram

### Before / After

No module changes. Only `packages/docs-web/src/data/marketplace.ts` (data) is touched.

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `docs-web/marketplace.ts` | `lint-marketplace.ts` | unchanged | Lint passes against new entry (6/6) |
| `docs-web/marketplace.ts` | `/workflows/` Astro pages | unchanged | New detail page renders automatically |
| `docs-web/marketplace.ts` | `workflows.json.ts` | unchanged | New row included in JSON endpoint |
| `cli/workflow install` | `coleam00/archon-idea-to-wo` | **new** | Second external directory-format source after `leex279/remotion-video-test` |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `web`
- Module: `web:marketplace`

## Change Metadata

- Change type: `feature`
- Primary scope: `web`

## Linked Issue

- Closes #1647 (supersedes — same workflow, marketplace-native path instead of bundled-default)
- Related # (marketplace v0: #1624, video-generic precedent: #1639, auto-review workflow: #1638)

## Validation Evidence (required)

```
$ bun packages/docs-web/scripts/lint-marketplace.ts
Linting 6 marketplace entries...
Verifying sources exist at pinned SHAs...
  ✓ [archon-piv-loop] ...
  ✓ [archon-fix-github-issue] ...
  ✓ [archon-comprehensive-pr-review] ...
  ✓ [archon-ralph-dag] ...
  ✓ [video-generic] directory verified at 4dac83c2
  ✓ [archon-idea-to-wo] directory verified at 3b0d5d82
Marketplace lint PASSED — all 6 entries valid.

$ bunx prettier --check packages/docs-web/src/data/marketplace.ts
All matched files use Prettier code style!

$ ARTIFACTS_DIR=.tmp bun .archon/scripts/marketplace-validate-schema.ts
{"valid":true,"files":[{"name":"archon-idea-to-wo.yaml","valid":true,"errors":[]}]}

$ ARTIFACTS_DIR=.tmp bun .archon/scripts/marketplace-security-scan.ts
{"severity":"none","finding_count":0,"findings":[]}
```

- Evidence: marketplace-lint passed; schema validator parses the workflow YAML (8 nodes); deterministic security scanner reports zero findings across the workflow + all four command files at the pinned SHA.
- Skipped: `bun run test` and `bun run lint` — no code paths touched, only a static data row.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No** (the workflow uses `command:` nodes only — no scripts, no `bash:` nodes invoking external services)
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No** (workflow writes to `$ARTIFACTS_DIR/work-orders/` only — pre-created by executor)

The new entry points at a third-party-style external GitHub repo (`coleam00/archon-idea-to-wo`). At install time, the CLI fetches files from the pinned SHA via the existing `installDirectory` path (host allowlist, `isSafePathComponent`, slug regex). Self-attestation per CONTRIBUTING.md: workflow does not exfiltrate, does not run destructive ops, and the SHA pins a reviewed state.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

- **Verified scenarios:**
  - GitHub Contents API resolves `https://api.github.com/repos/coleam00/archon-idea-to-wo/contents/.archon?ref=3b0d5d82...` → 200 OK with `archon-idea-to-wo.yaml` (file) + `commands` (dir).
  - Workflow YAML parses against `@archon/workflows/loader` — 8 nodes, no errors.
  - Deterministic security scanner against the source dir → severity `none`, 0 findings.
  - Blob SHAs in the new repo match the original PR #1647 byte-for-byte (5 files): workflow YAML + 4 command markdowns.
- **Edge cases checked:**
  - Directory install layout — `.archon/<slug>.yaml` at root matches the installer's "named-after-slug or only-YAML" rule.
  - Commands subdir contains only the 4 referenced markdowns — installer fan-out walks one level deep, no nesting needed.
- **What was not verified:**
  - End-to-end `archon workflow install archon-idea-to-wo` on a fresh repo — install code path was eyeballed against `installDirectory()` in `packages/cli/src/commands/workflow.ts`.
  - End-to-end `archon workflow run archon-idea-to-wo` against a real idea — all four approval-gate node types parse, but a full run-through with live AI was not performed.

## Side Effects / Blast Radius (required)

- **Affected subsystems/workflows:**
  - `docs-web` build (new detail page generated by `getStaticPaths`).
  - `workflows.json` endpoint (one more row).
  - `archon workflow search/install` CLI (one more discoverable slug).
  - `marketplace-auto-review` will fire on this PR — expected decision: `auto_merge` once flipped out of draft (scan clean, schema valid, scope clean).
- **Potential unintended effects:**
  - If `coleam00/archon-idea-to-wo` is deleted, the Contents API lookup at install time will 404. SHA pinning protects content immutability but not repo availability.
- **Guardrails / monitoring for early detection:**
  - `marketplace-lint.yml` runs on every PR touching `marketplace.ts`. A future stale SHA is caught by the directory existence check.

## Rollback Plan (required)

- **Fast rollback:** Revert this PR. Single-file change, no migrations.
- **Feature flags / config toggles:** None.
- **Observable failure symptoms:** lint failure on a future PR's CI run, or `archon workflow install archon-idea-to-wo` returning a 404.

## Risks and Mitigations

- **Risk:** Source repo `coleam00/archon-idea-to-wo` goes private or is deleted.
  - **Mitigation:** Owned under the same account as Archon itself; low risk. If it ever disappears, revert this entry.
- **Risk:** Bob updates the original workflow in #1647 and the marketplace entry drifts behind.
  - **Mitigation:** SHA pin is intentional. Future improvements ship as new marketplace PRs bumping the SHA — explicit, reviewable.
- **Risk:** `author: 'lamachine'` is the actual workflow author but the PR is opened by `coleam00`. Auto-review trust model assumes nothing about that mismatch.
  - **Mitigation:** None needed for auto-merge logic (decision branches on scan severity + AI recommendation, not on author match). Listed here for transparency.

---

**Draft until ready** — this PR is opened in draft so the auto-review workflow fires `request_changes` (per the workflow's draft check) without auto-merging. Will be flipped to ready-for-review on the marketplace launch livestream as the first community-authored merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Idea to Work Orders" marketplace entry with planning and development capabilities (requires Archon v0.3.0+).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1678)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->