### PR TITLE
feat(marketplace): add archon-smart-mr-review (GitLab counterpart)

### DIFF
--- a/packages/docs-web/src/data/marketplace.ts
+++ b/packages/docs-web/src/data/marketplace.ts
@@ -119,4 +119,16 @@ export const marketplaceEntries: MarketplaceEntry[] = [
     tags: ['planning', 'development'],
     archonVersionCompat: '>=0.3.0',
   },
+  {
+    slug: 'archon-smart-mr-review',
+    name: 'Smart GitLab MR Review',
+    author: 'lraphael',
+    description:
+      'GitLab counterpart to archon-smart-pr-review. Adaptive code review of a GitLab MR — Haiku classifies which review agents are relevant, runs them in parallel, posts resolvable Discussion threads, and auto-approves on 0 critical findings.',
+    sourceUrl:
+      'https://github.com/lraphael/archon-gitlab-workflows/tree/55ca73498f0ead87d86c22ef0efa67482b311700/archon-smart-mr-review',
+    sha: '55ca73498f0ead87d86c22ef0efa67482b311700',
+    tags: ['review', 'automation'],
+    archonVersionCompat: '>=0.3.0',
+  },
 ];


### PR DESCRIPTION
## Summary

- **Problem**: Archon ships GitHub-focused workflows (`gh` CLI); GitLab users have no parallel for the smart multi-agent PR review.
- **Why it matters**: GitLab teams want the same review automation — resolvable Discussion threads, auto-approval, reviewer assignment, `ai-code-review` commit status.
- **What changed**: Adds one marketplace entry pointing to `lraphael/archon-gitlab-workflows@55ca7349/archon-smart-mr-review` (workflow YAML + 9 commands using `glab`).
- **What did NOT change**: No code in Archon itself. Only `packages/docs-web/src/data/marketplace.ts` (+12 lines).

## Change Metadata

- Change type: `feature`
- Primary scope: docs (marketplace registry)

## Linked Issue

- None — community contribution

## Validation Evidence

```bash
bun run validate
# exit 0 (with isolated HOME=$(mktemp -d) to avoid local ~/.archon/workflows pollution
# of dag-executor.test.ts; the failure is pre-existing, not introduced by this PR)

bun run packages/docs-web/scripts/lint-marketplace.ts
# PASSED — all 7 entries valid, my new entry verified at SHA 55ca7349
#   ✓ [archon-smart-mr-review] directory verified at 55ca7349
```

## Security Impact

- New permissions/capabilities? **No** — workflow uses standard `glab` CLI
- New external network calls? Only `glab` API (already a standard tool for GitLab users)
- Secrets/tokens handling changed? **No** — uses existing `glab auth` session
- File system access scope changed? **No** — reads ` + '$ARTIFACTS_DIR' + `, writes review artifacts + comments via `glab`

**Self-attestation** (per CONTRIBUTING.md):
- [x] The workflow does not exfiltrate data, credentials, or secrets
- [x] The workflow does not execute destructive operations without user confirmation (no code changes, only review posting)
- [x] I have the right to share this workflow publicly (MIT licensed in source repo)
- [x] The pinned SHA points to a reviewed, stable version of the workflow

## Compatibility / Migration

- Backward compatible? **Yes** (additive entry)
- Config/env changes? Optional `ARCHON_GITLAB_REVIEWER` env var (default: `ai-agent`)
- Database migration needed? **No**

## Human Verification

- **Verified scenarios**: `lint-marketplace.ts` confirms source URL + SHA resolve; schema matches existing entries; entry renders identically to peer entries (`video-generic`, `archon-idea-to-wo`).
- **Edge cases checked**: tested with isolated HOME to confirm no test regression; ran full `bun run validate` cleanly.
- **What was not verified**: End-to-end run via the marketplace install flow (`archon workflow install <slug>`) — the workflow itself has been used in an adapted form internally; this is the cleaned, English-only, project-neutral version.

## Side Effects / Blast Radius

- **Affected subsystems**: marketplace registry only. No runtime code touched.
- **Potential unintended effects**: Users who install this workflow will run `glab` commands against their GitLab — same trust model as any community workflow.
- **Guardrails**: SHA pinning + automated marketplace-security-scan in CI.

## Rollback Plan

- Revert this commit (single-file addition). The source repo `lraphael/archon-gitlab-workflows` is independent.

## Risks and Mitigations

- **Risk**: Workflow could behave unexpectedly on first community use.
  - **Mitigation**: Source repo is MIT-licensed and pinned to commit SHA; issues can be filed against `lraphael/archon-gitlab-workflows`; the workflow itself is read-only on code (no self-fix step).
- **Risk**: GitLab API rate limits during multi-agent review.
  - **Mitigation**: All agents run via `$ARTIFACTS_DIR` files; only `synthesize-review` + `post-review` hit GitLab API.

## Source Repo

- Workflow + commands live at: https://github.com/lraphael/archon-gitlab-workflows
- Directory: [`archon-smart-mr-review/`](https://github.com/lraphael/archon-gitlab-workflows/tree/55ca73498f0ead87d86c22ef0efa67482b311700/archon-smart-mr-review)
- 1 workflow YAML + 9 commands (mr-fetch, review-scope, 5 review agents, synthesize-review, post-review)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Smart GitLab MR Review" to the marketplace, a new tool providing automated review capabilities for GitLab merge requests. Includes review and automation functionality. Requires compatibility with v0.3.0 or higher. Available for immediate marketplace access and integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1681)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->