### PR TITLE
feat(marketplace): add archon-comprehensive-mr-review (GitLab counterpart)

### DIFF
--- a/packages/docs-web/src/data/marketplace.ts
+++ b/packages/docs-web/src/data/marketplace.ts
@@ -131,4 +131,16 @@ export const marketplaceEntries: MarketplaceEntry[] = [
     tags: ['review', 'automation'],
     archonVersionCompat: '>=0.3.0',
   },
+  {
+    slug: 'archon-comprehensive-mr-review',
+    name: 'Comprehensive GitLab MR Review',
+    author: 'lraphael',
+    description:
+      'GitLab counterpart to archon-comprehensive-pr-review. Full code review of a GitLab MR — all 5 review agents (code-review, error-handling, test-coverage, comment-quality, docs-impact) run in parallel, posts resolvable Discussion threads, auto-approves on 0 critical findings.',
+    sourceUrl:
+      'https://github.com/lraphael/archon-gitlab-workflows/tree/6e39b359e1b02329ebf63f7d1699e6bbc8cb001f/archon-comprehensive-mr-review',
+    sha: '6e39b359e1b02329ebf63f7d1699e6bbc8cb001f',
+    tags: ['review', 'automation'],
+    archonVersionCompat: '>=0.3.0',
+  },
 ];


### PR DESCRIPTION
## Summary

- **Problem**: Archon ships `archon-comprehensive-pr-review` for GitHub. GitLab users need the same exhaustive multi-agent review for their MRs.
- **Why it matters**: Complement to the already-merged `archon-smart-mr-review` (#1681). Smart variant skips agents based on complexity; this one always runs all 5 — useful when reviewers want exhaustive coverage regardless of MR size.
- **What changed**: Adds one marketplace entry pointing to `lraphael/archon-gitlab-workflows@6e39b359/archon-comprehensive-mr-review` (workflow YAML + 9 commands using `glab`).
- **What did NOT change**: No code in Archon itself. Only `packages/docs-web/src/data/marketplace.ts` (+12 lines).

## Change Metadata

- Change type: `feature`
- Primary scope: docs (marketplace registry)

## Linked Issue

- None — community contribution. Sibling to the merged `archon-smart-mr-review` (#1681).

## Validation Evidence

```bash
bun run validate
# exit 0 (with isolated HOME to avoid local ~/.archon/workflows pollution
# of dag-executor.test.ts — pre-existing issue, not introduced by this PR)

bun run packages/docs-web/scripts/lint-marketplace.ts
# PASSED — all 8 entries valid; new entry verified at SHA 6e39b359
#   ✓ [archon-comprehensive-mr-review] directory verified at 6e39b359
```

## Security Impact

- New permissions/capabilities? **No** — uses standard `glab` CLI
- New external network calls? Only `glab` API
- Secrets/tokens handling changed? **No** — uses existing `glab auth` session
- File system access scope changed? **No**

**Self-attestation** (per CONTRIBUTING.md):
- [x] The workflow does not exfiltrate data, credentials, or secrets
- [x] The workflow does not execute destructive operations without user confirmation (no code changes, only review posting)
- [x] I have the right to share this workflow publicly (MIT licensed)
- [x] The pinned SHA points to a reviewed, stable version

## Compatibility / Migration

- Backward compatible? **Yes** (additive entry)
- Config/env changes? Optional `ARCHON_GITLAB_REVIEWER` env var (default: `ai-agent`)
- Database migration needed? **No**

## Human Verification

- **Verified**: `lint-marketplace.ts` confirms source URL + SHA resolve; schema matches existing entries.
- **Edge cases**: full `bun run validate` clean with isolated HOME.
- **What was not verified**: End-to-end run via marketplace install flow — workflow logic is closely parallel to `archon-smart-mr-review` (already merged, #1681); only difference is no Haiku-classify step (all 5 agents run unconditionally).

## Side Effects / Blast Radius

- **Affected subsystems**: marketplace registry only.
- **Potential unintended effects**: Same trust model as any community workflow.
- **Guardrails**: SHA pinning + automated `marketplace-security-scan` in CI.

## Rollback Plan

- Revert this commit (single-file addition). The source repo `lraphael/archon-gitlab-workflows` is independent.

## Risks and Mitigations

- **Risk**: GitLab API rate limits when all 5 agents post Discussion threads.
  - **Mitigation**: Only `synthesize-review` + `post-review` hit GitLab API; the 5 review agents work on `$ARTIFACTS_DIR` files locally.

## Source Repo

- https://github.com/lraphael/archon-gitlab-workflows
- Directory: [`archon-comprehensive-mr-review/`](https://github.com/lraphael/archon-gitlab-workflows/tree/6e39b359e1b02329ebf63f7d1699e6bbc8cb001f/archon-comprehensive-mr-review)
- 1 workflow YAML + 9 commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Comprehensive GitLab MR Review" workflow to the marketplace, enabling automated code review and automation capabilities for GitLab merge requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1686)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->