### PR TITLE
fix(marketplace): guard fetch-source against missing sourceUrl/sha

### DIFF
--- a/.archon/scripts/__tests__/marketplace-fetch-source.test.ts
+++ b/.archon/scripts/__tests__/marketplace-fetch-source.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'bun:test';
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+
+const SCRIPT = resolve(import.meta.dir, '../marketplace-fetch-source.ts');
+
+interface FetchOutput {
+  files: string[];
+  errors: string[];
+}
+
+function runFetch(entryJson: Record<string, unknown>): { output: FetchOutput; stderr: string; exitCode: number } {
+  const artifactsDir = mkdtempSync(join(tmpdir(), 'fetch-test-'));
+  try {
+    mkdirSync(join(artifactsDir, 'source'), { recursive: true });
+    writeFileSync(join(artifactsDir, 'entry.json'), JSON.stringify(entryJson));
+
+    const result = spawnSync('bun', [SCRIPT], {
+      env: { ...process.env, ARTIFACTS_DIR: artifactsDir },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const exitCode = result.status ?? 1;
+    const stdout = result.stdout?.toString() ?? '';
+    const stderr = result.stderr?.toString() ?? '';
+
+    let output: FetchOutput = { files: [], errors: [] };
+    if (stdout) {
+      try {
+        output = JSON.parse(stdout);
+      } catch {
+        // stdout wasn't JSON — return empty default
+      }
+    }
+
+    return { output, stderr, exitCode };
+  } finally {
+    rmSync(artifactsDir, { recursive: true, force: true });
+  }
+}
+
+describe('marketplace-fetch-source: guard for missing sourceUrl/sha', () => {
+  it('exits 0 with empty files when sourceUrl is missing', () => {
+    const { output, stderr, exitCode } = runFetch({ sha: 'abc123' });
+    expect(exitCode).toBe(0);
+    expect(output.files).toHaveLength(0);
+    expect(stderr).toContain('sourceUrl');
+    expect(output.errors.length).toBeGreaterThan(0);
+    expect(output.errors[0]).toContain('sourceUrl');
+  });
+
+  it('exits 0 with empty files when sha is missing', () => {
+    const { output, stderr, exitCode } = runFetch({ sourceUrl: 'https://github.com/owner/repo/blob/main/path' });
+    expect(exitCode).toBe(0);
+    expect(output.files).toHaveLength(0);
+    expect(stderr).toContain('sha');
+    expect(output.errors.length).toBeGreaterThan(0);
+    expect(output.errors[0]).toContain('sha');
+  });
+
+  it('exits 0 with empty files when both sourceUrl and sha are missing', () => {
+    const { output, stderr, exitCode } = runFetch({});
+    expect(exitCode).toBe(0);
+    expect(output.files).toHaveLength(0);
+    expect(stderr).toContain('sourceUrl');
+    expect(stderr).toContain('sha');
+    expect(output.errors.length).toBeGreaterThan(0);
+  });
+
+  it('does not trigger guard when entry.json has both sourceUrl and sha', () => {
+    // When both fields are present, the guard should NOT fire.
+    // The script proceeds past the guard to URL parsing and gh api calls.
+    // Since gh api will fail in the test env, we verify the guard didn't
+    // trigger by checking stderr does NOT contain the guard's signature message.
+    const { stderr, output } = runFetch({
+      sourceUrl: 'https://github.com/coleam00/Archon/blob/main/README.md',
+      sha: 'abc123def456',
+    });
+    expect(stderr).not.toContain('missing required field');
+    expect(output.files).toHaveLength(0); // no fetch possible in test env
+    // The script proceeds past the guard; gh api errors are expected.
+    expect(output.errors.length).toBeGreaterThan(0);
+    expect(output.errors.some((e) => e.includes('gh api'))).toBe(true);
+  });
+});
+
+describe('marketplace-fetch-source: missing entry.json', () => {
+  it('exits 1 when entry.json is absent', () => {
+    const artifactsDir = mkdtempSync(join(tmpdir(), 'fetch-test-'));
+    try {
+      // No entry.json created
+      const result = spawnSync('bun', [SCRIPT], {
+        env: { ...process.env, ARTIFACTS_DIR: artifactsDir },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      expect(result.status ?? 1).toBe(1);
+    } finally {
+      rmSync(artifactsDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/.archon/scripts/__tests__/marketplace-fetch-source.test.ts
+++ b/.archon/scripts/__tests__/marketplace-fetch-source.test.ts
@@ -30,9 +30,7 @@ function runFetch(entryJson: Record<string, unknown>): { output: FetchOutput; st
     if (stdout) {
       try {
         output = JSON.parse(stdout);
-      } catch {
-        // stdout wasn't JSON — return empty default
-      }
+      } catch {}
     }
 
     return { output, stderr, exitCode };
@@ -70,19 +68,14 @@ describe('marketplace-fetch-source: guard for missing sourceUrl/sha', () => {
   });
 
   it('does not trigger guard when entry.json has both sourceUrl and sha', () => {
-    // When both fields are present, the guard should NOT fire.
-    // The script proceeds past the guard to URL parsing and gh api calls.
-    // Since gh api will fail in the test env, we verify the guard didn't
-    // trigger by checking stderr does NOT contain the guard's signature message.
-    const { stderr, output } = runFetch({
-      sourceUrl: 'https://github.com/coleam00/Archon/blob/main/README.md',
+    // Unrecognized URL makes the script stop deterministically at URL validation — no network.
+    const { stderr, exitCode } = runFetch({
+      sourceUrl: 'https://example.com/not-a-github-url',
       sha: 'abc123def456',
     });
     expect(stderr).not.toContain('missing required field');
-    expect(output.files).toHaveLength(0); // no fetch possible in test env
-    // The script proceeds past the guard; gh api errors are expected.
-    expect(output.errors.length).toBeGreaterThan(0);
-    expect(output.errors.some((e) => e.includes('gh api'))).toBe(true);
+    expect(stderr).toContain('Unrecognized sourceUrl format');
+    expect(exitCode).toBe(1);
   });
 });
 
@@ -90,7 +83,6 @@ describe('marketplace-fetch-source: missing entry.json', () => {
   it('exits 1 when entry.json is absent', () => {
     const artifactsDir = mkdtempSync(join(tmpdir(), 'fetch-test-'));
     try {
-      // No entry.json created
       const result = spawnSync('bun', [SCRIPT], {
         env: { ...process.env, ARTIFACTS_DIR: artifactsDir },
         stdio: ['ignore', 'pipe', 'pipe'],

--- a/.archon/scripts/marketplace-fetch-source.ts
+++ b/.archon/scripts/marketplace-fetch-source.ts
@@ -34,9 +34,8 @@ mkdirSync(sourceDir, { recursive: true });
 const errors: string[] = [];
 const files: string[] = [];
 
-// Guard: sourceUrl and sha are required for fetching source files.
-// If either is missing (e.g., PR doesn't add a marketplace entry),
-// output an empty result so downstream nodes can proceed gracefully.
+// Guard: sourceUrl/sha are required. If missing, output empty result so
+// downstream nodes proceed gracefully (e.g., PR without a marketplace entry).
 if (!sourceUrl || !sha) {
   const missing: string[] = [];
   if (!sourceUrl) missing.push('sourceUrl');

--- a/.archon/scripts/marketplace-fetch-source.ts
+++ b/.archon/scripts/marketplace-fetch-source.ts
@@ -21,8 +21,8 @@ if (!existsSync(entryPath)) {
 }
 
 interface MarketplaceEntry {
-  sourceUrl: string;
-  sha: string;
+  sourceUrl?: string;
+  sha?: string;
 }
 
 const entry = JSON.parse(readFileSync(entryPath, 'utf8')) as MarketplaceEntry;
@@ -33,6 +33,22 @@ mkdirSync(sourceDir, { recursive: true });
 
 const errors: string[] = [];
 const files: string[] = [];
+
+// Guard: sourceUrl and sha are required for fetching source files.
+// If either is missing (e.g., PR doesn't add a marketplace entry),
+// output an empty result so downstream nodes can proceed gracefully.
+if (!sourceUrl || !sha) {
+  const missing: string[] = [];
+  if (!sourceUrl) missing.push('sourceUrl');
+  if (!sha) missing.push('sha');
+  const msg = `entry.json is missing required field(s): ${missing.join(', ')}. ` +
+    'This PR likely does not add a marketplace entry with source files. ' +
+    'Skipping source fetch.';
+  process.stderr.write(msg + '\n');
+  errors.push(msg);
+  console.log(JSON.stringify({ files, errors }));
+  process.exit(0);
+}
 
 // Parse GitHub blob/tree URL into owner/repo/path
 const blobMatch = sourceUrl.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/blob\/[^/]+\/(.+)$/);


### PR DESCRIPTION
## Summary

The `marketplace-fetch-source` script crashes with `TypeError: undefined is not an object (evaluating 'sourceUrl.match')`  when `sourceUrl` is undefined in `entry.json`. This happens on PRs that don't add a marketplace entry (no `sourceUrl` field), causing the marketplace-auto-review CI check to fail on every such PR.

## Problem

- `fetch-source` destructures `{ sourceUrl, sha }` from `entry.json` without null checks
- When a PR doesn't modify `marketplace.ts`, the `sourceUrl` field is `undefined`  
- Calling `.match()` on `undefined` throws `TypeError`, killing the entire workflow
- This caused CI failures on PRs #1685 and #1689 (and any PR not touching marketplace entries)

## What Changed

- Made `sourceUrl` and `sha` optional in the `MarketplaceEntry` interface
- Added an early-return guard: when either field is missing, log a clear warning and output an empty `{ files, errors }` result, then exit 0
- Downstream nodes (AI review) can now proceed without source files instead of the entire workflow crashing

## Validation

Note: wiring `.archon/scripts` tests into `bun run test`/CI lands separately via #2147 — not duplicated here.

- The fix is a null guard with `exit(0)` — no behavioral change when `sourceUrl` and `sha` are present (the happy path for marketplace entries)
- When fields are missing, the workflow continues with an empty source list instead of crashing

## Security Impact

None. This is a defensive null check that prevents a crash; no new data flows or permissions are introduced.

## Compatibility

Fully backward compatible. Existing marketplace entries with valid `sourceUrl`/`sha` are unaffected.

## Rollback Plan

Revert this commit to restore the previous behavior (crash on missing fields).

## Blast Radius

Single script: `.archon/scripts/marketplace-fetch-source.ts`. Only affects the `fetch-source` node in `marketplace-pr-review-and-merge.yaml`. No other workflows or scripts are impacted.

## Risks & Mitigations

- **Risk**: Downstream AI review runs without source files when fields are missing.
- **Mitigation**: The `bundle-source` node (from PR #1689) already handles surfacing available source content to the AI reviewer. When source files are empty, the reviewer works with what it has — this is preferable to the entire CI check crashing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of marketplace entries with missing required source details by reporting exactly which fields are absent, recording the error, returning no files, and exiting cleanly so downstream steps can continue.
* **Tests**
  * Added a Bun test suite covering exit codes and error messaging when source fields are missing or when the entry metadata is not present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
