### PR TITLE
fix(workflows): surface condition_json_parse_failed as workflow error instead of silent skip (#1673)

### DIFF
--- a/packages/workflows/src/condition-evaluator.test.ts
+++ b/packages/workflows/src/condition-evaluator.test.ts
@@ -474,4 +474,41 @@ describe('evaluateCondition', () => {
     const outputs = new Map([['n', makeOutput('prose text', 'completed', { type: 'BUG' })]]);
     expect(evaluateCondition("$n.output == 'prose text'", outputs).result).toBe(true);
   });
+
+  // --- #1673: condition_json_parse_failed must surface as parsed:false ---
+
+  it('returns parsed:false when output text is not valid JSON and field is used', () => {
+    const outputs = new Map([
+      ['gate', makeOutput('Let me think...\n\nSure, here is my analysis.')],
+    ]);
+    const { result, parsed } = evaluateCondition("$gate.output.verdict == 'review'", outputs);
+    expect(result).toBe(false);
+    expect(parsed).toBe(false);
+  });
+
+  it('strips markdown fences and parses JSON inside them', () => {
+    const fenced = 'Let me analyze...\n\n```json\n{"verdict": "review"}\n```\n';
+    const outputs = new Map([['gate', makeOutput(fenced)]]);
+    expect(evaluateCondition("$gate.output.verdict == 'review'", outputs).result).toBe(true);
+    expect(evaluateCondition("$gate.output.verdict == 'review'", outputs).parsed).toBe(true);
+  });
+
+  it('strips plain ``` fences (no language tag) and parses JSON', () => {
+    const fenced = '```\n{"verdict": "approve"}\n```';
+    const outputs = new Map([['gate', makeOutput(fenced)]]);
+    expect(evaluateCondition("$gate.output.verdict == 'approve'", outputs).result).toBe(true);
+  });
+
+  it('parsed:false propagates through compound AND expressions', () => {
+    const outputs = new Map([
+      ['a', makeOutput('{"ok": "yes"}')],
+      ['b', makeOutput('not json at all')],
+    ]);
+    const { result, parsed } = evaluateCondition(
+      "$a.output.ok == 'yes' && $b.output.status == 'done'",
+      outputs
+    );
+    expect(result).toBe(false);
+    expect(parsed).toBe(false);
+  });
 });

--- a/packages/workflows/src/condition-evaluator.ts
+++ b/packages/workflows/src/condition-evaluator.ts
@@ -16,6 +16,14 @@
 import type { NodeOutput } from './schemas';
 import { createLogger } from '@archon/paths';
 
+/** Thrown when a $nodeId.output.field reference cannot parse the node's output text as JSON. */
+class OutputRefParseError extends Error {
+  constructor(nodeId: string, field: string) {
+    super(`Cannot parse output of node '${nodeId}' as JSON for field '${field}'`);
+    this.name = 'OutputRefParseError';
+  }
+}
+
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
 function getLog(): ReturnType<typeof createLogger> {
@@ -65,8 +73,14 @@ function resolveOutputRef(
   // Fallback: parse output text. Backward-compatible path for older NodeOutput rows or
   // providers that don't emit a structured payload on the result chunk.
   if (!nodeOutput.output) return '';
+
+  // Strip common markdown fences that LLMs (Pi/Minimax) wrap around JSON.
+  let text = nodeOutput.output;
+  const fenceMatch = /^[\s\S]*?```(?:json)?\s*\n([\s\S]*?)\n\s*```[\s\S]*$/.exec(text);
+  if (fenceMatch?.[1]) text = fenceMatch[1];
+
   try {
-    const parsed = JSON.parse(nodeOutput.output) as Record<string, unknown>;
+    const parsed = JSON.parse(text) as Record<string, unknown>;
     const value = parsed[field];
     if (typeof value === 'string') return value;
     if (typeof value === 'number' || typeof value === 'boolean') return String(value);
@@ -77,7 +91,7 @@ function resolveOutputRef(
       { nodeId, field, outputPreview: nodeOutput.output.slice(0, 100) },
       'condition_json_parse_failed'
     );
-    return '';
+    throw new OutputRefParseError(nodeId, field);
   }
 }
 
@@ -132,7 +146,15 @@ function evaluateAtom(
     return { result: false, parsed: false };
   }
 
-  const actual = resolveOutputRef(nodeId, field, nodeOutputs);
+  let actual: string;
+  try {
+    actual = resolveOutputRef(nodeId, field, nodeOutputs);
+  } catch (err) {
+    if (err instanceof OutputRefParseError) {
+      return { result: false, parsed: false };
+    }
+    throw err;
+  }
 
   let result: boolean;
   if (operator === '==' || operator === '!=') {


### PR DESCRIPTION
## Summary

- Problem: When a `when:` condition references `$nodeId.output.field` and the node output is not valid JSON (e.g. Pi/Minimax wrapping JSON in markdown fences or prepending reasoning prose), the condition evaluator returns `parsed: true` with `result: false`. The DAG executor treats this as a legitimate "condition not met" skip. The workflow exits 0 — no error, no review posted, silent failure.
- Why it matters: A 5-minute workflow "succeeds" without doing the work. Users have no way to detect the failure from the CLI exit code. This violates the "Fail Fast + Explicit Errors" principle. Observed in ~17% of `maintainer-review-pr` runs with Pi.
- What changed: `resolveOutputRef()` now throws `OutputRefParseError` when JSON parse fails (instead of returning empty string). `evaluateAtom()` catches it and returns `{parsed: false}`. Also strips common markdown fences (`\x60\x60\x60json` blocks) before attempting `JSON.parse`.
- What did **not** change (scope boundary): No changes to `dag-executor.ts` — it already correctly handles `parsed: false` (surfaces error message, logs properly, exits non-zero). No changes to `structuredOutput` paths — they are unaffected since the JSON parse fallback is only reached when structured output is absent.

## UX Journey

### Before

```
User                       Archon                       Pi
────                       ──────                       ──
runs maintainer-review-pr ▶ executes gate node ────────▶ returns "Let me think...\n\x60\x60\x60json\n{...}\n\x60\x60\x60"
                            condition_json_parse_failed (warn log only)
                            $gate.output.verdict == 'review' → false (parsed: true)
                            every downstream node → Skipped (when_condition)
sees "Workflow completed   ◀── exit 0, no review posted
successfully" (WRONG)
```

### After

```
User                       Archon                       Pi
────                       ──────                       ──
runs maintainer-review-pr ▶ executes gate node ────────▶ returns "Let me think...\n\x60\x60\x60json\n{...}\n\x60\x60\x60"
                            strips markdown fences ✓
                            JSON.parse succeeds ✓
                            $gate.output.verdict == 'review' → true
                            downstream nodes execute normally ✓
sees review posted         ◀── exit 0, review posted (CORRECT)

--- If JSON is truly unparseable (no fences, just prose): ---

runs maintainer-review-pr ▶ executes gate node ────────▶ returns "Sure, here is my analysis..."
                            fence strip: no fences found
                            JSON.parse fails
                            condition_json_parse_failed (warn log)
                            resolveOutputRef throws OutputRefParseError
                            evaluateAtom returns {parsed: false}
sees "⚠️ Node 'gate':  ◀── exit non-zero, error surfaced (CORRECT)
unparseable when: ..."
```

## Architecture Diagram

### Before

```
evaluateAtom → resolveOutputRef → JSON.parse fails → returns ""
     ↓                                                    ↓
  actual="" vs expected="review" → {result: false, parsed: true}
     ↓
  DAG: legitimate skip → exit 0  ← WRONG
```

### After

```
evaluateAtom → resolveOutputRef → strip fences → JSON.parse
     ↓                                              ↓ success → return value
     ↓                                              ↓ fail → throw OutputRefParseError
  catch OutputRefParseError → {result: false, parsed: false}
     ↓
  DAG: when_condition_parse_error → surface message → exit non-zero  ← CORRECT
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| evaluateAtom | resolveOutputRef | **modified** | Now catches OutputRefParseError |
| resolveOutputRef | JSON.parse | **modified** | Strips fences first; throws on failure |
| dag-executor | evaluateCondition | unchanged | Already handles parsed:false correctly |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `workflows`
- Module: `workflows:condition-evaluator`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes #1673

## Validation Evidence (required)

```bash
bun run test    # 54 pass, 0 fail (condition-evaluator.test.ts)
bun run type-check  # all 5 packages pass
# lint-staged ran eslint + prettier on commit
```

- Evidence provided: All 54 condition evaluator tests pass, including 4 new tests for the fix.
- If any command is intentionally skipped: `bun run format:check` covered by lint-staged on commit.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Partially — workflows that previously "succeeded silently" will now surface an error and exit non-zero. This is the intended fix; the silent success was a bug.
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: (1) Invalid JSON output → parsed:false returned (2) Markdown-fenced JSON → fences stripped, parsed correctly (3) Compound AND with one unparseable atom → parsed:false propagates (4) All 50 existing tests still pass (no regressions)
- Edge cases checked: Plain \x60\x60\x60 fences (no language tag), prose before/after fences, multiple fence blocks (first match used)
- What was not verified: Live Pi/Minimax output (no access to those providers locally)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Any workflow with `when:` clauses referencing `$node.output.field` where the producing node is an LLM
- Potential unintended effects: Workflows that relied on the silent-skip behavior will now error out. This is correct — the silent skip was masking failures.
- Guardrails/monitoring: The `condition_json_parse_failed` warn log already exists; the new behavior just escalates it from "silent skip" to "error + exit non-zero"

## Rollback Plan (required)

- Fast rollback command/path: Revert the commit (single file change)
- Feature flags or config toggles: None needed — the change is in the condition evaluator return contract
- Observable failure symptoms: Workflows that previously "completed successfully" with skipped nodes will now show `when_condition_parse_error` messages

## Risks and Mitigations

- Risk: Workflows with noisy LLM outputs may fail more frequently
  - Mitigation: The fence-stripping logic handles the most common Pi/Minimax pattern. For truly unparseable output, the correct behavior IS to fail and retry, not to silently skip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for JSON parsing failures in condition evaluation, ensuring errors are properly reported rather than silently ignored.
  * Added support for JSON values wrapped in markdown code fences.
  * Enhanced error propagation through compound conditions when JSON parsing fails.

* **Tests**
  * Added test coverage for JSON parsing failures and markdown code fence handling in condition evaluation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1694)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->