### PR TITLE
fix(web): surface workflow-def fetch error in execution graph (#1683)

### DIFF
--- a/packages/web/src/components/workflows/WorkflowExecution.tsx
+++ b/packages/web/src/components/workflows/WorkflowExecution.tsx
@@ -282,13 +282,22 @@ export function WorkflowExecution({ runId }: WorkflowExecutionProps): React.Reac
   // Only gated on workflowName — codebaseCwd is optional; when absent the server tries the
   // first registered codebase before falling back to bundled defaults (handles CLI runs and
   // "No project" web runs).
-  const { data: workflowDef } = useQuery({
+  const {
+    data: workflowDef,
+    error: workflowDefError,
+    isPending: workflowDefPending,
+  } = useQuery({
     queryKey: ['workflowDefinition', initialData?.workflowName, codebaseCwd],
     queryFn: () => getWorkflow(initialData?.workflowName ?? '', codebaseCwd ?? undefined),
     enabled: !!initialData?.workflowName,
     staleTime: Infinity,
   });
   const dagDefinitionNodes = workflowDef?.workflow?.nodes ?? null;
+  const dagDefinitionErrorMessage = workflowDefError
+    ? workflowDefError instanceof Error
+      ? workflowDefError.message
+      : String(workflowDefError)
+    : null;
   // Use workflow definition when available, fall back to dagNodes from run state.
   const isDag = dagDefinitionNodes !== null || (initialData?.dagNodes.length ?? 0) > 0;
 
@@ -552,10 +561,19 @@ export function WorkflowExecution({ runId }: WorkflowExecutionProps): React.Reac
                 selectedNodeId={selectedDagNode}
                 onNodeClick={handleNodeClick}
               />
-            ) : (
+            ) : dagDefinitionErrorMessage ? (
+              <div className="flex flex-col items-center justify-center h-full text-text-secondary px-4 text-center">
+                <p className="text-error mb-1">Failed to load workflow graph</p>
+                <p className="text-xs">{dagDefinitionErrorMessage}</p>
+              </div>
+            ) : workflowDefPending ? (
               <div className="flex items-center justify-center h-full text-text-secondary">
                 <span className="inline-block h-5 w-5 animate-spin rounded-full border-2 border-accent border-t-transparent mr-2" />
                 Loading graph...
+              </div>
+            ) : (
+              <div className="flex items-center justify-center h-full text-text-secondary px-4 text-center">
+                <p>Workflow graph unavailable for this run.</p>
               </div>
             )}
           </ResizablePanel>

--- a/packages/web/src/components/workflows/WorkflowExecution.tsx
+++ b/packages/web/src/components/workflows/WorkflowExecution.tsx
@@ -564,7 +564,18 @@ export function WorkflowExecution({ runId }: WorkflowExecutionProps): React.Reac
             ) : dagDefinitionErrorMessage ? (
               <div className="flex flex-col items-center justify-center h-full text-text-secondary px-4 text-center">
                 <p className="text-error mb-1">Failed to load workflow graph</p>
-                <p className="text-xs">{dagDefinitionErrorMessage}</p>
+                <p className="text-xs mb-3">{dagDefinitionErrorMessage}</p>
+                <button
+                  type="button"
+                  onClick={(): void => {
+                    void queryClient.invalidateQueries({
+                      queryKey: ['workflowDefinition', initialData?.workflowName, codebaseCwd],
+                    });
+                  }}
+                  className="text-xs text-primary hover:text-accent-bright transition-colors"
+                >
+                  Retry
+                </button>
               </div>
             ) : workflowDefPending ? (
               <div className="flex items-center justify-center h-full text-text-secondary">

--- a/packages/web/src/components/workflows/WorkflowExecution.tsx
+++ b/packages/web/src/components/workflows/WorkflowExecution.tsx
@@ -568,9 +568,16 @@ export function WorkflowExecution({ runId }: WorkflowExecutionProps): React.Reac
                 <button
                   type="button"
                   onClick={(): void => {
-                    void queryClient.invalidateQueries({
-                      queryKey: ['workflowDefinition', initialData?.workflowName, codebaseCwd],
-                    });
+                    queryClient
+                      .resetQueries({
+                        queryKey: ['workflowDefinition', initialData?.workflowName, codebaseCwd],
+                      })
+                      .catch((err: unknown) => {
+                        console.error('[WorkflowExecution] Retry resetQueries failed', {
+                          workflowName: initialData?.workflowName,
+                          error: err instanceof Error ? err.message : err,
+                        });
+                      });
                   }}
                   className="text-xs text-primary hover:text-accent-bright transition-colors"
                 >
@@ -583,6 +590,8 @@ export function WorkflowExecution({ runId }: WorkflowExecutionProps): React.Reac
                 Loading graph...
               </div>
             ) : (
+              // Final fallback: query resolved with no nodes and no error.
+              // Covers older runs whose stored workflow has no DAG.
               <div className="flex items-center justify-center h-full text-text-secondary px-4 text-center">
                 <p>Workflow graph unavailable for this run.</p>
               </div>


### PR DESCRIPTION
## Summary

- **Problem:** `WorkflowExecution` calls `useQuery` for the workflow definition but only destructures `data`; when the fetch rejects, the right-pane graph stays on "Loading graph..." forever (issue #1683).
- **Why it matters:** Users land on the run detail page with no way to tell whether the graph is loading, errored, or empty for this run. They wait, refresh, or refile the bug.
- **What changed:** The same `useQuery` now also surfaces `error` and `isPending`. The fallback splits into three branches: error message, spinner, empty-state copy.
- **What did not change:** Happy path (graph available → `WorkflowDagViewer`), the run query, the right-rail metadata, the API shape, the query key, the `enabled` gate.

## UX Journey

### Before

```
User                            WorkflowExecution                 server
────                            ─────────────────                 ──────
opens /workflow/runs/<id> ────▶ run query ───────────────────────▶ 200 OK
                                workflow-def query ──────────────▶ 4xx/5xx
                                isPending → false, data → undefined
                                renders spinner unconditionally
sees "Loading graph..." ◀───── (loops forever, no error path)
```

### After

```
User                            WorkflowExecution                 server
────                            ─────────────────                 ──────
opens /workflow/runs/<id> ────▶ run query ───────────────────────▶ 200 OK
                                workflow-def query ──────────────▶ 4xx/5xx
                                [error captured]
                                [renders: "Failed to load workflow
                                 graph" + message string]
sees error UI ◀───────────────  (or spinner while pending, or
                                 "Workflow graph unavailable for
                                 this run." when neither nodes
                                 nor error are present)
```

## Architecture Diagram

### Before

```
packages/web/src/components/workflows/WorkflowExecution.tsx
  │
  ├─[useQuery: runQuery]─────▶ getWorkflowRun(runId)
  │     captures: data, error, isPending  ✓
  │
  ├─[useQuery: workflowDefQuery]─▶ getWorkflow(name, cwd?)
  │     captures: data only       ✗  error/pending discarded
  │
  └─render
        if (dagDefinitionNodes) → <WorkflowDagViewer />
        else → spinner (no error path)
```

### After

```
packages/web/src/components/workflows/WorkflowExecution.tsx
  │
  ├─[useQuery: runQuery]─────▶ getWorkflowRun(runId)        [unchanged]
  │
  ├─[useQuery: workflowDefQuery]─▶ getWorkflow(name, cwd?)
  │     captures: data, [~] error, [~] isPending
  │     [+] dagDefinitionErrorMessage derived from error
  │
  └─render
        if (dagDefinitionNodes)         → <WorkflowDagViewer />
        else if (errorMessage)          → [+] error UI
        else if (workflowDefPending)    → spinner (now gated)
        else                            → [+] "unavailable for this run"
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| WorkflowExecution | getWorkflow (api.ts) | unchanged | same call, same args |
| WorkflowExecution | WorkflowDagViewer | unchanged | only renders when nodes present |
| WorkflowExecution.workflowDefQuery | render fallback | **modified** | now consumes error + isPending |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `web`
- Module: `web:workflows-execution`

## Change Metadata

- Change type: `bug`
- Primary scope: `web`

## Linked Issue

- Closes #1683

## Validation Evidence (required)

```bash
bun --cwd packages/web run type-check    # PASS (tsc --noEmit, no errors)
bun x eslint packages/web/src/components/workflows/WorkflowExecution.tsx --max-warnings 0  # PASS (no output)
bun x prettier --check packages/web/src/components/workflows/WorkflowExecution.tsx  # PASS ("All matched files use Prettier code style!")
bun --cwd packages/web run test          # PASS (158 tests across lib/stores/hooks)
bun --cwd packages/web run build         # PASS (tsc + vite, 7.48s)
```

Component tests are not currently in scope of `packages/web`'s test runner (`bun test src/lib/ && bun test src/stores/ && bun test src/hooks/`), so no `.test.tsx` was added. Verified through the manual scenarios below.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No**

## Compatibility / Migration

- Backward compatible? **Yes** — render fallback only fires when previous behavior was "spinner forever"; happy path unchanged.
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

- **Verified scenarios:**
  - Happy path: open an existing successful run; graph renders as before. (`<WorkflowDagViewer />` branch.)
  - Error path (manual reproduction): point a run at a deleted workflow definition or unreachable codebase cwd; the panel now reads "Failed to load workflow graph" with the underlying message instead of spinning forever.
  - Pending path: brief spinner during the initial `getWorkflow` call still shows "Loading graph..."
  - Empty path: when neither nodes nor an error are present (older runs whose `getWorkflow` returned no nodes), the panel reads "Workflow graph unavailable for this run." instead of spinning indefinitely.
- **Edge cases checked:**
  - Non-`Error` rejections (e.g. plain strings) are stringified via `String(workflowDefError)` to avoid `[object Object]`.
  - `enabled: !!initialData?.workflowName` still gates the query, so no spurious spinner before the run query resolves.
- **What was not verified:**
  - Server-side error shapes beyond what `fetchJSON` in `packages/web/src/lib/api.ts` already produces (it throws `Error` with the response body, captured by React Query).

## Side Effects / Blast Radius (required)

- **Affected subsystems/workflows:** Workflow run detail page right-pane graph. No effect on left rail, run timeline, approval gates, or any non-web code path.
- **Potential unintended effects:** None expected — added paths only fire when prior code displayed a spinner.
- **Guardrails/monitoring for early detection:** Existing React Query devtools surface the same error; no new telemetry added.

## Rollback Plan (required)

- **Fast rollback command/path:** Revert this single-file commit; the previous `const { data: workflowDef }` destructure plus single-branch fallback returns.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** Empty-state copy would render on a run that DID have a workflow definition. The fallback chain orders nodes first, so this only happens if `workflow.nodes` was unexpectedly nullish.

## Risks and Mitigations

- **Risk:** Empty-state copy renders on legitimately-pending late-arriving requests if `isPending` becomes false before data arrives (React Query v5 timing edge).
  - **Mitigation:** v5's `isPending` documentation guarantees `isPending === true` until either `data` or `error` is populated for an enabled query. The fallback order (nodes → error → pending → empty) means even if the empty branch were hit transiently, it would resolve to nodes on the very next render. No flicker risk in practice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow graph panel now shows clear loading, error, and empty states: a loading spinner while fetching, a specific error screen with the failure message and a Retry button, and a clear "Workflow graph unavailable for this run" fallback when no graph is present.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->