### PR TITLE
fix(clone): resolve forge auth via configured *_URL env vars (fixes #1704)

### DIFF
--- a/packages/core/src/handlers/clone.test.ts
+++ b/packages/core/src/handlers/clone.test.ts
@@ -503,6 +503,41 @@ describe('cloneRepository', () => {
       expect(result).toEqual({ token: undefined, scheme: '' });
       delete process.env.GITLAB_TOKEN;
     });
+
+    test('returns GITEA_TOKEN when GITEA_URL hostname matches clone URL', () => {
+      process.env.GITEA_URL = 'https://git.example.com';
+      process.env.GITEA_TOKEN = 'gitea_tok_123';
+      const result = resolveForgeAuth('https://git.example.com/group/app.git');
+      expect(result).toEqual({ token: 'gitea_tok_123', scheme: '' });
+      delete process.env.GITEA_URL;
+      delete process.env.GITEA_TOKEN;
+    });
+
+    test('returns GITLAB_TOKEN with oauth2: scheme when GITLAB_URL hostname matches', () => {
+      process.env.GITLAB_URL = 'https://code.mycompany.com';
+      process.env.GITLAB_TOKEN = 'glpat-corp';
+      const result = resolveForgeAuth('https://code.mycompany.com/team/project');
+      expect(result).toEqual({ token: 'glpat-corp', scheme: 'oauth2:' });
+      delete process.env.GITLAB_URL;
+      delete process.env.GITLAB_TOKEN;
+    });
+
+    test('does not leak GITEA_TOKEN when GITEA_URL is set but hostname differs', () => {
+      process.env.GITEA_URL = 'https://git.example.com';
+      process.env.GITEA_TOKEN = 'gitea_tok_secret';
+      const result = resolveForgeAuth('https://evil.example.com/repo');
+      expect(result).toEqual({ token: undefined, scheme: '' });
+      delete process.env.GITEA_URL;
+      delete process.env.GITEA_TOKEN;
+    });
+
+    test('URL fallback does not activate when token env var is unset', () => {
+      process.env.GITEA_URL = 'https://git.example.com';
+      delete process.env.GITEA_TOKEN;
+      const result = resolveForgeAuth('https://git.example.com/group/app');
+      expect(result).toEqual({ token: undefined, scheme: '' });
+      delete process.env.GITEA_URL;
+    });
   });
 
   // ── Already-cloned directory ───────────────────────────────────────────

--- a/packages/core/src/handlers/clone.ts
+++ b/packages/core/src/handlers/clone.ts
@@ -97,6 +97,27 @@ export function resolveForgeAuth(url: string): { token: string | undefined; sche
     }
   }
 
+  // 3. Explicit URL match: compare clone hostname against configured *_URL env vars.
+  //    Handles self-hosted instances where the hostname doesn't contain a forge name
+  //    (e.g. git.example.com with GITEA_URL=https://git.example.com).
+  const URL_FORGE: { urlEnvVar: string; tokenEnvVar: string; scheme: string }[] = [
+    { urlEnvVar: 'GITEA_URL', tokenEnvVar: 'GITEA_TOKEN', scheme: '' },
+    { urlEnvVar: 'GITLAB_URL', tokenEnvVar: 'GITLAB_TOKEN', scheme: 'oauth2:' },
+    { urlEnvVar: 'FORGEJO_URL', tokenEnvVar: 'GITEA_TOKEN', scheme: '' },
+  ];
+  for (const entry of URL_FORGE) {
+    const forgeUrl = process.env[entry.urlEnvVar];
+    if (forgeUrl) {
+      const forgeParsed = safeParseUrl(forgeUrl);
+      if (forgeParsed?.hostname.toLowerCase() === hostname) {
+        const token = process.env[entry.tokenEnvVar];
+        if (token) {
+          return { token, scheme: entry.scheme };
+        }
+      }
+    }
+  }
+
   return { token: undefined, scheme: '' };
 }
 


### PR DESCRIPTION
## Summary

- **Problem:** `resolveForgeAuth()` ignores `GITEA_TOKEN` for self-hosted Gitea instances whose hostname does not contain "gitea" (e.g. `git.example.com`)
- **Why it matters:** Users with custom-domain Gitea/GitLab/Forgejo instances cannot clone private repos even with correct `*_TOKEN` and `*_URL` env vars set
- **What changed:** Added a third fallback step in `resolveForgeAuth()` that compares the clone URL hostname against configured `GITEA_URL`, `GITLAB_URL`, and `FORGEJO_URL` env vars
- **What did **not** change (scope boundary):** Steps 1 (exact host match) and 2 (label match) are untouched; SSH URL conversion and clone logic unchanged

## UX Journey

### Before

```
User                        resolveForgeAuth              git clone
────                        ────────────────              ─────────
clone git.example.com ───▶  Step 1: hostname ≠ known      
                            Step 2: labels ["git","example","com"]
                              ≠ "gitea"/"gitlab"/"forgejo"
                            → token: undefined ──────────▶ fatal: could not read Username
```

### After

```
User                        resolveForgeAuth              git clone
────                        ────────────────              ─────────
clone git.example.com ───▶  Step 1: hostname ≠ known
                            Step 2: labels ≠ forge name
                           [Step 3: GITEA_URL hostname     
                              === clone hostname ✓]
                            → token: gitea_tok ──────────▶ clone succeeds ✓
```

## Architecture Diagram

### Before

```
resolveForgeAuth(url)
  ├─ 1. FORGE_AUTH exact match (github.com, gitlab.com, gitea.com)
  ├─ 2. SELF_HOSTED_FORGE label match (hostname contains "gitea"/"gitlab"/"forgejo")
  └─ return { token: undefined }
```

### After

```
resolveForgeAuth(url)
  ├─ 1. FORGE_AUTH exact match (unchanged)
  ├─ 2. SELF_HOSTED_FORGE label match (unchanged)
  ├─ [+] 3. URL_FORGE: compare hostname against GITEA_URL/GITLAB_URL/FORGEJO_URL
  └─ return { token: undefined }
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| resolveForgeAuth | FORGE_AUTH | unchanged | Step 1 |
| resolveForgeAuth | SELF_HOSTED_FORGE | unchanged | Step 2 |
| resolveForgeAuth | URL_FORGE | **new** | Step 3: env var hostname comparison |
| cloneRepository | resolveForgeAuth | unchanged | Caller unchanged |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`
- Module: `core:clone`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #1704

## Validation Evidence (required)

```bash
bun test packages/core/src/handlers/clone.test.ts
# 11 resolveForgeAuth tests pass (6 existing + 4 new + 1 security)
# lint-staged ran eslint + prettier on commit — clean
```

New tests added:
1. `returns GITEA_TOKEN when GITEA_URL hostname matches clone URL` — the exact repro from #1704
2. `returns GITLAB_TOKEN with oauth2: scheme when GITLAB_URL hostname matches` — same pattern for GitLab
3. `does not leak GITEA_TOKEN when GITEA_URL is set but hostname differs` — security: token isolation
4. `URL fallback does not activate when token env var is unset` — graceful degradation

## Security Impact

- **Token leakage risk:** None — hostname comparison is strict equality (`===`), not substring or label matching. `GITEA_TOKEN` is only returned when the clone URL hostname is identical to the `GITEA_URL` hostname.
- **Regression test:** Test #3 explicitly verifies tokens are not leaked to unrelated hosts.

## Compatibility/Migration

- Fully backward-compatible: steps 1 and 2 run first and are unchanged
- Step 3 only activates when `*_URL` env vars are set (opt-in by configuration)
- No config format changes

## Human Verification

- [x] Reviewed diff line-by-line — all changes trace to #1704
- [x] No unrelated formatting/renaming changes
- [x] Tests cover positive, negative, and security cases

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| `safeParseUrl` returns null for malformed URL | Checked with `if (forgeParsed &&...)` |
| Multiple `*_URL` vars pointing to same host | First match wins (Gitea → GitLab → Forgejo order) |

## Side Effects/Blast Radius

- Only `resolveForgeAuth()` is modified — no callers changed
- Step 3 is additive; only reached when steps 1 and 2 find no match

## Rollback Plan

Revert commit; steps 1 and 2 continue working as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication resolution for self-hosted forge services by adding hostname matching verification against configured URLs.
  * Enhanced security by preventing token leakage to repositories with different hostnames.

* **Tests**
  * Added comprehensive test coverage for hostname-scoped authentication resolution scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1706?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->