### PR TITLE
fix(server/workflows): resolve project workflows with .yml extension

### DIFF
--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -3577,6 +3577,25 @@ export function registerApiRoutes(
       return apiError(c, 400, 'Invalid workflow name');
     }
 
+    // Workflow files may use `.yaml` or `.yml` (the discovery scanner accepts
+    // both — `workflow-discovery.ts`'s readdir filter at line 119). Mirror
+    // that here so the by-name lookup doesn't 404 on `.yml` files like
+    // `phase-0-spike.yml` that the list endpoint already returns.
+    const tryReadWorkflowAt = async (
+      dir: string
+    ): Promise<{ filename: string; content: string } | null> => {
+      for (const ext of ['yaml', 'yml']) {
+        const filename = `${name}.${ext}`;
+        try {
+          const content = await readFile(join(dir, filename), 'utf-8');
+          return { filename, content };
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+        }
+      }
+      return null;
+    };
+
     try {
       const cwd = c.req.query('cwd');
       let workingDir = cwd;
@@ -3589,82 +3608,80 @@ export function registerApiRoutes(
         if (codebases.length > 0) workingDir = codebases[0].default_cwd;
       }
 
-      const filename = `${name}.yaml`;
-
       // 1. Try user-defined workflow in cwd.
       if (workingDir) {
         const [workflowFolder] = getWorkflowFolderSearchPaths();
-        const filePath = join(workingDir, workflowFolder, filename);
         try {
-          const content = await readFile(filePath, 'utf-8');
-          const result = parseWorkflow(content, filename);
-          if (result.error) {
-            return apiError(c, 500, `Workflow file is invalid: ${result.error.error}`);
+          const hit = await tryReadWorkflowAt(join(workingDir, workflowFolder));
+          if (hit) {
+            const result = parseWorkflow(hit.content, hit.filename);
+            if (result.error) {
+              return apiError(c, 500, `Workflow file is invalid: ${result.error.error}`);
+            }
+            return c.json({
+              workflow: result.workflow,
+              filename: hit.filename,
+              source: 'project' as WorkflowSource,
+            });
           }
-          return c.json({
-            workflow: result.workflow,
-            filename,
-            source: 'project' as WorkflowSource,
-          });
         } catch (err) {
-          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
-            getLog().error({ err, name }, 'workflow.fetch_failed');
-            return apiError(c, 500, 'Failed to read workflow');
-          }
+          getLog().error({ err, name }, 'workflow.fetch_failed');
+          return apiError(c, 500, 'Failed to read workflow');
         }
       }
 
       // 2. Fall back to home-scoped workflow (`~/.archon/workflows/`).
       // Mirrors the discovery order in `discoverWorkflowsWithConfig`.
-      {
-        const homeFilePath = join(getHomeWorkflowsPath(), filename);
-        try {
-          const content = await readFile(homeFilePath, 'utf-8');
-          const result = parseWorkflow(content, filename);
+      try {
+        const hit = await tryReadWorkflowAt(getHomeWorkflowsPath());
+        if (hit) {
+          const result = parseWorkflow(hit.content, hit.filename);
           if (result.error) {
             return apiError(c, 500, `Home workflow file is invalid: ${result.error.error}`);
           }
           return c.json({
             workflow: result.workflow,
-            filename,
+            filename: hit.filename,
             source: 'global' as WorkflowSource,
           });
-        } catch (err) {
-          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
-            getLog().error({ err, name }, 'workflow.fetch_home_failed');
-            return apiError(c, 500, 'Failed to read home-scoped workflow');
-          }
         }
+      } catch (err) {
+        getLog().error({ err, name }, 'workflow.fetch_home_failed');
+        return apiError(c, 500, 'Failed to read home-scoped workflow');
       }
 
       // 3. Fall back to bundled defaults.
       if (Object.hasOwn(BUNDLED_WORKFLOWS, name)) {
+        const bundledFilename = `${name}.yaml`;
         const bundledContent = BUNDLED_WORKFLOWS[name];
-        const result = parseWorkflow(bundledContent, filename);
+        const result = parseWorkflow(bundledContent, bundledFilename);
         if (result.error) {
           return apiError(c, 500, `Bundled workflow is invalid: ${result.error.error}`);
         }
-        return c.json({ workflow: result.workflow, filename, source: 'bundled' as WorkflowSource });
+        return c.json({
+          workflow: result.workflow,
+          filename: bundledFilename,
+          source: 'bundled' as WorkflowSource,
+        });
       }
 
       if (!isBinaryBuild()) {
-        const defaultFilePath = join(getDefaultWorkflowsPath(), filename);
         try {
-          const content = await readFile(defaultFilePath, 'utf-8');
-          const result = parseWorkflow(content, filename);
-          if (result.error) {
-            return apiError(c, 500, `Default workflow is invalid: ${result.error.error}`);
+          const hit = await tryReadWorkflowAt(getDefaultWorkflowsPath());
+          if (hit) {
+            const result = parseWorkflow(hit.content, hit.filename);
+            if (result.error) {
+              return apiError(c, 500, `Default workflow is invalid: ${result.error.error}`);
+            }
+            return c.json({
+              workflow: result.workflow,
+              filename: hit.filename,
+              source: 'bundled' as WorkflowSource,
+            });
           }
-          return c.json({
-            workflow: result.workflow,
-            filename,
-            source: 'bundled' as WorkflowSource,
-          });
         } catch (err) {
-          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
-            getLog().error({ err, name }, 'workflow.fetch_default_failed');
-            return apiError(c, 500, 'Failed to read default workflow');
-          }
+          getLog().error({ err, name }, 'workflow.fetch_default_failed');
+          return apiError(c, 500, 'Failed to read default workflow');
         }
       }
 
@@ -3775,21 +3792,24 @@ export function registerApiRoutes(
       workingDir = getArchonHome();
     }
 
-    const filePath =
+    const dir =
       targetSource === 'global'
-        ? join(getHomeWorkflowsPath(), `${name}.yaml`)
-        : join(workingDir, getWorkflowFolderSearchPaths()[0], `${name}.yaml`);
+        ? getHomeWorkflowsPath()
+        : join(workingDir, getWorkflowFolderSearchPaths()[0]);
 
-    try {
-      await unlink(filePath);
-      return c.json({ deleted: true, name });
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-        return apiError(c, 404, `Workflow not found: ${name}`);
+    // Try both `.yaml` and `.yml` extensions to match discovery semantics.
+    for (const ext of ['yaml', 'yml']) {
+      const filePath = join(dir, `${name}.${ext}`);
+      try {
+        await unlink(filePath);
+        return c.json({ deleted: true, name });
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+        getLog().error({ err, name }, 'workflow.delete_failed');
+        return apiError(c, 500, 'Failed to delete workflow');
       }
-      getLog().error({ err, name }, 'workflow.delete_failed');
-      return apiError(c, 500, 'Failed to delete workflow');
     }
+    return apiError(c, 404, `Workflow not found: ${name}`);
   });
 
   // GET /api/commands - List available command names for the workflow node palette

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -3577,10 +3577,9 @@ export function registerApiRoutes(
       return apiError(c, 400, 'Invalid workflow name');
     }
 
-    // Workflow files may use `.yaml` or `.yml` (the discovery scanner accepts
-    // both — `workflow-discovery.ts`'s readdir filter at line 119). Mirror
-    // that here so the by-name lookup doesn't 404 on `.yml` files like
-    // `phase-0-spike.yml` that the list endpoint already returns.
+    // Try `.yaml` then `.yml`, mirroring `loadWorkflowsFromDir` in
+    // workflow-discovery.ts so by-name lookup matches the list endpoint.
+    // Returns null if neither extension exists (caller tries the next source).
     const tryReadWorkflowAt = async (
       dir: string
     ): Promise<{ filename: string; content: string } | null> => {
@@ -3797,17 +3796,22 @@ export function registerApiRoutes(
         ? getHomeWorkflowsPath()
         : join(workingDir, getWorkflowFolderSearchPaths()[0]);
 
-    // Try both `.yaml` and `.yml` extensions to match discovery semantics.
+    // Remove both `.yaml` and `.yml` variants (discovery accepts either), so a
+    // twin file can't stay active after a reported deletion.
+    let deleted = false;
     for (const ext of ['yaml', 'yml']) {
       const filePath = join(dir, `${name}.${ext}`);
       try {
         await unlink(filePath);
-        return c.json({ deleted: true, name });
+        deleted = true;
       } catch (err) {
         if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
         getLog().error({ err, name }, 'workflow.delete_failed');
         return apiError(c, 500, 'Failed to delete workflow');
       }
+    }
+    if (deleted) {
+      return c.json({ deleted: true, name });
     }
     return apiError(c, 404, `Workflow not found: ${name}`);
   });

--- a/packages/server/src/routes/api.workflows.test.ts
+++ b/packages/server/src/routes/api.workflows.test.ts
@@ -323,6 +323,35 @@ describe('GET /api/workflows/:name', () => {
     }
   });
 
+  test('returns project workflow when file uses .yml extension (matches discovery)', async () => {
+    const testDir = join(tmpdir(), `wf-yml-test-${Date.now()}`);
+    const workflowDir = join(testDir, '.archon', 'workflows');
+    await mkdir(workflowDir, { recursive: true });
+    await writeFile(
+      join(workflowDir, 'phase-0-spike.yml'),
+      'name: phase-0-spike\ndescription: Spike\nnodes:\n  - id: plan\n    command: plan\n'
+    );
+
+    try {
+      const app = createTestApp();
+      registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+      mockListCodebases.mockImplementationOnce(async () => [{ default_cwd: testDir }]);
+      const response = await app.request(`/api/workflows/phase-0-spike?cwd=${testDir}`);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        source: string;
+        filename: string;
+        workflow: { name: string };
+      };
+      expect(body.source).toBe('project');
+      expect(body.filename).toBe('phase-0-spike.yml');
+      expect(body.workflow).toBeDefined();
+    } finally {
+      await rm(testDir, { recursive: true, force: true });
+    }
+  });
+
   test('returns home-scoped workflow with source:global when project/bundled miss', async () => {
     const tmpHome = join(tmpdir(), `wf-home-test-${Date.now()}`);
     const homeWorkflowsDir = join(tmpHome, 'workflows');

--- a/packages/server/src/routes/api.workflows.test.ts
+++ b/packages/server/src/routes/api.workflows.test.ts
@@ -2,9 +2,10 @@ import { describe, test, expect, mock, spyOn } from 'bun:test';
 import { OpenAPIHono } from '@hono/zod-openapi';
 import type { ConversationLockManager } from '@archon/core';
 import type { WebAdapter } from '../adapters/web';
-import { mkdir, readFile, rm, writeFile, symlink as fsSymlink } from 'fs/promises';
+import { access, mkdir, readFile, rm, writeFile, symlink as fsSymlink } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import * as archonPaths from '@archon/paths';
 import { validationErrorHook } from './openapi-defaults';
 import { makeTestWorkflow, makeTestWorkflowWithSource } from '@archon/workflows/test-utils';
 
@@ -348,6 +349,85 @@ describe('GET /api/workflows/:name', () => {
       expect(body.filename).toBe('phase-0-spike.yml');
       expect(body.workflow).toBeDefined();
     } finally {
+      await rm(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test('returns home-scoped workflow when file uses .yml extension', async () => {
+    const tmpHome = join(tmpdir(), `wf-home-yml-test-${Date.now()}`);
+    const homeWorkflowsDir = join(tmpHome, 'workflows');
+    await mkdir(homeWorkflowsDir, { recursive: true });
+    await writeFile(
+      join(homeWorkflowsDir, 'home-yml-only.yml'),
+      'name: home-yml-only\ndescription: Home-scoped .yml workflow\nnodes:\n  - id: plan\n    command: plan\n'
+    );
+
+    const prevArchonHome = process.env.ARCHON_HOME;
+    process.env.ARCHON_HOME = tmpHome;
+    try {
+      const app = createTestApp();
+      registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+      // No registered codebase → skips project-scope, falls through to home-scope
+      mockListCodebases.mockImplementationOnce(async () => []);
+      const response = await app.request('/api/workflows/home-yml-only');
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        source: string;
+        filename: string;
+        workflow: unknown;
+      };
+      expect(body.source).toBe('global');
+      expect(body.filename).toBe('home-yml-only.yml');
+      expect(body.workflow).toBeDefined();
+    } finally {
+      if (prevArchonHome === undefined) {
+        delete process.env.ARCHON_HOME;
+      } else {
+        process.env.ARCHON_HOME = prevArchonHome;
+      }
+      await rm(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  test('returns source-build default workflow when file uses .yml extension', async () => {
+    const testDir = join(tmpdir(), `wf-defaults-yml-test-${Date.now()}`);
+    const defaultsDir = join(testDir, 'workflows', 'defaults');
+    await mkdir(defaultsDir, { recursive: true });
+    await writeFile(
+      join(defaultsDir, 'default-yml-wf.yml'),
+      'name: default-yml-wf\ndescription: Default .yml workflow\nnodes:\n  - id: plan\n    command: plan\n'
+    );
+
+    // Point the defaults lookup at the temp dir; keep home-scope at a
+    // nonexistent path so the handler falls through to the defaults source.
+    const defaultsPathSpy = spyOn(archonPaths, 'getDefaultWorkflowsPath').mockReturnValue(
+      defaultsDir
+    );
+    const prevArchonHome = process.env.ARCHON_HOME;
+    process.env.ARCHON_HOME = join(testDir, 'nonexistent-home');
+    try {
+      const app = createTestApp();
+      registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+      mockListCodebases.mockImplementationOnce(async () => []);
+      const response = await app.request('/api/workflows/default-yml-wf');
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        source: string;
+        filename: string;
+        workflow: unknown;
+      };
+      expect(body.source).toBe('bundled');
+      expect(body.filename).toBe('default-yml-wf.yml');
+      expect(body.workflow).toBeDefined();
+    } finally {
+      defaultsPathSpy.mockRestore();
+      if (prevArchonHome === undefined) {
+        delete process.env.ARCHON_HOME;
+      } else {
+        process.env.ARCHON_HOME = prevArchonHome;
+      }
       await rm(testDir, { recursive: true, force: true });
     }
   });
@@ -747,6 +827,91 @@ describe('DELETE /api/workflows/:name', () => {
       expect(body.name).toBe('to-delete');
     } finally {
       await rm(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test('removes workflow stored only as .yml and returns deleted:true', async () => {
+    const testDir = join(tmpdir(), `wf-del-yml-test-${Date.now()}`);
+    const workflowDir = join(testDir, '.archon', 'workflows');
+    await mkdir(workflowDir, { recursive: true });
+    const ymlPath = join(workflowDir, 'to-delete-yml.yml');
+    await writeFile(ymlPath, 'name: x\ndescription: y\nnodes:\n  - id: z\n    command: z\n');
+
+    try {
+      const app = createTestApp();
+      registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+      mockListCodebases.mockImplementationOnce(async () => [{ default_cwd: testDir }]);
+      const response = await app.request(`/api/workflows/to-delete-yml?cwd=${testDir}`, {
+        method: 'DELETE',
+      });
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { deleted: boolean; name: string };
+      expect(body.deleted).toBe(true);
+      expect(body.name).toBe('to-delete-yml');
+      await expect(access(ymlPath)).rejects.toThrow();
+    } finally {
+      await rm(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test('removes both .yaml and .yml twins so neither stays discoverable', async () => {
+    const testDir = join(tmpdir(), `wf-del-twin-test-${Date.now()}`);
+    const workflowDir = join(testDir, '.archon', 'workflows');
+    await mkdir(workflowDir, { recursive: true });
+    const yamlPath = join(workflowDir, 'twin.yaml');
+    const ymlPath = join(workflowDir, 'twin.yml');
+    await writeFile(yamlPath, 'name: twin\ndescription: yaml\nnodes:\n  - id: z\n    command: z\n');
+    await writeFile(ymlPath, 'name: twin\ndescription: yml\nnodes:\n  - id: z\n    command: z\n');
+
+    try {
+      const app = createTestApp();
+      registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+      mockListCodebases.mockImplementationOnce(async () => [{ default_cwd: testDir }]);
+      const response = await app.request(`/api/workflows/twin?cwd=${testDir}`, {
+        method: 'DELETE',
+      });
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { deleted: boolean; name: string };
+      expect(body.deleted).toBe(true);
+      expect(body.name).toBe('twin');
+      // Both variants must be gone — a surviving twin would stay active.
+      await expect(access(yamlPath)).rejects.toThrow();
+      await expect(access(ymlPath)).rejects.toThrow();
+    } finally {
+      await rm(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test('removes home-scoped .yml workflow when source=global', async () => {
+    const testArchonHome = join(tmpdir(), `archon-home-del-yml-${Date.now()}`);
+    const workflowDir = join(testArchonHome, 'workflows');
+    await mkdir(workflowDir, { recursive: true });
+    const ymlPath = join(workflowDir, 'home-yml-delete.yml');
+    await writeFile(ymlPath, 'name: x\ndescription: y\nnodes:\n  - id: z\n    command: z\n');
+
+    const prevArchonHome = process.env.ARCHON_HOME;
+    process.env.ARCHON_HOME = testArchonHome;
+    try {
+      const app = createTestApp();
+      registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+      const response = await app.request('/api/workflows/home-yml-delete?source=global', {
+        method: 'DELETE',
+      });
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { deleted: boolean; name: string };
+      expect(body.deleted).toBe(true);
+      expect(body.name).toBe('home-yml-delete');
+      await expect(access(ymlPath)).rejects.toThrow();
+    } finally {
+      if (prevArchonHome === undefined) {
+        delete process.env.ARCHON_HOME;
+      } else {
+        process.env.ARCHON_HOME = prevArchonHome;
+      }
+      await rm(testArchonHome, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
## Summary
`GET /api/workflows/:name` and `DELETE /api/workflows/:name` only probed `${name}.yaml` on disk, but the discovery scanner that backs `GET /api/workflows` accepts both `.yaml` and `.yml`. A project workflow named `phase-0-spike.yml` therefore appeared in the list endpoint but 404'd on the detail endpoint and could not be deleted via the API.

## Repro
1. In a project's `.archon/workflows/`, create `phase-0-spike.yml` (note the extension) with any valid workflow.
2. `GET /api/workflows?cwd=<project>` — workflow appears in the list.
3. `GET /api/workflows/phase-0-spike?cwd=<project>` — 404.
4. The Archon UI's run-detail page (`/workflows/runs/<id>`) fetches this endpoint and renders broken for any run whose workflow file uses `.yml`.

## Fix
- `GET /api/workflows/:name` now probes `${name}.yaml` then `${name}.yml` in each scope (project, home, default). Extracted as a small inline helper to avoid duplicating the same logic three times.
- `DELETE /api/workflows/:name` probes both extensions before returning 404.
- `PUT` (save) is unchanged — writes continue to use `.yaml` as the canonical extension for newly-created workflows. Existing `.yml` files remain readable and deletable.
- Bundled defaults still key on `${name}.yaml` (synthetic in-memory key, not a filesystem path).

## Tests
- Added regression test: `phase-0-spike.yml` returns 200 with \`source: project\` and \`filename: phase-0-spike.yml\`.
- 36/36 tests in `api.workflows.test.ts` pass (was 35).
- \`tsc --noEmit\` on \`packages/server\` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow retrieval and deletion operations now support both `.yaml` and `.yml` file extensions, providing greater flexibility in file naming conventions.

* **Tests**
  * Added test coverage verifying proper discovery and serving of workflow files with `.yml` extensions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->