### PR TITLE
fix(workflows): narrow findResumableRun by user_message on auto-resume

### DIFF
--- a/packages/core/src/db/workflows.test.ts
+++ b/packages/core/src/db/workflows.test.ts
@@ -490,7 +490,9 @@ describe('workflows database', () => {
       expect(query).not.toContain('conversation_id');
       expect(query).toContain('ORDER BY started_at DESC');
       expect(query).not.toMatch(/--.*\$\d/); // regression guard for #999: $N in SQL comments breaks convertPlaceholders
-      expect(params).toEqual(['feature-development', '/repo/path', 1]);
+      // userMessage omitted -> no $3 predicate, params length 2
+      expect(query).not.toContain('user_message = $3');
+      expect(params).toEqual(['feature-development', '/repo/path']);
     });
 
     test('returns a stale running run (no activity for >1 day)', async () => {
@@ -509,7 +511,7 @@ describe('workflows database', () => {
       const [query, params] = mockQuery.mock.calls[0] as [string, unknown[]];
       expect(query).toContain("status = 'running'");
       expect(query).toContain('last_activity_at');
-      expect(params).toEqual(['feature-development', '/repo/path', 1]);
+      expect(params).toEqual(['feature-development', '/repo/path']);
     });
 
     test('returns a running run with null last_activity_at (never recorded activity)', async () => {
@@ -542,6 +544,53 @@ describe('workflows database', () => {
       await expect(findResumableRun('test', '/path')).rejects.toThrow(
         'Failed to find resumable run: Connection refused'
       );
+    });
+
+    test('narrows by user_message when provided (auto-resume path)', async () => {
+      const failedRun = {
+        ...mockWorkflowRun,
+        status: 'failed' as const,
+        working_path: '/repo/path',
+        user_message: 'plan-A.md',
+      };
+      mockQuery.mockResolvedValueOnce(createQueryResult([failedRun]));
+
+      const result = await findResumableRun('feature-development', '/repo/path', 'plan-A.md');
+
+      expect(result).toEqual(failedRun);
+      const [query, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+      expect(query).toContain('user_message = $3');
+      expect(params).toEqual(['feature-development', '/repo/path', 'plan-A.md']);
+    });
+
+    test('does NOT cross-resume a failed run for a different user_message', async () => {
+      // Empty result means SQL filtered it out — the bug fix.
+      mockQuery.mockResolvedValueOnce(createQueryResult([]));
+
+      const result = await findResumableRun('feature-development', '/repo/path', 'plan-B.md');
+
+      expect(result).toBeNull();
+      const [query, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+      expect(query).toContain('user_message = $3');
+      expect(params).toEqual(['feature-development', '/repo/path', 'plan-B.md']);
+    });
+
+    test('explicit --resume (no user_message) falls back to workflow+path match', async () => {
+      // Caller is CLI --resume path; user is asking to reuse whatever the
+      // prior failed run was. user_message predicate must NOT be added.
+      const failedRun = {
+        ...mockWorkflowRun,
+        status: 'failed' as const,
+        working_path: '/repo/path',
+      };
+      mockQuery.mockResolvedValueOnce(createQueryResult([failedRun]));
+
+      const result = await findResumableRun('feature-development', '/repo/path');
+
+      expect(result).toEqual(failedRun);
+      const [query, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+      expect(query).not.toContain('user_message = $3');
+      expect(params).toEqual(['feature-development', '/repo/path']);
     });
   });
 

--- a/packages/core/src/db/workflows.ts
+++ b/packages/core/src/db/workflows.ts
@@ -305,21 +305,34 @@ export async function getRunningWorkflows(): Promise<
 
 export async function findResumableRun(
   workflowName: string,
-  workingPath: string
+  workingPath: string,
+  userMessage?: string
 ): Promise<WorkflowRun | null> {
   const dialect = getDialect();
+  // When userMessage is provided (auto-resume from executor.ts where the
+  // caller knows the current invocation's input), narrow the match so a
+  // failed run for a DIFFERENT plan/description on the same workflow+path
+  // is not silently picked up. When omitted (explicit `--resume` from the
+  // CLI, where the user is asking to reuse whatever the prior run was),
+  // fall back to the original workflow_name + working_path match.
+  const narrowByUserMessage = userMessage !== undefined;
+  const userMessagePredicate = narrowByUserMessage ? 'AND user_message = $3' : '';
+  const params: unknown[] = narrowByUserMessage
+    ? [workflowName, workingPath, userMessage]
+    : [workflowName, workingPath];
   try {
     const result = await pool.query<WorkflowRun>(
       `SELECT * FROM remote_agent_workflow_runs
        WHERE workflow_name = $1
          AND working_path = $2
+         ${userMessagePredicate}
          AND (
            status IN ('failed', 'paused')
            OR (status = 'running' AND (last_activity_at IS NULL OR last_activity_at < ${dialect.nowMinusDays(3)}))
          )
        ORDER BY started_at DESC
        LIMIT 1`,
-      [workflowName, workingPath, 1]
+      params
     );
     const row = result.rows[0];
     return row ? normalizeWorkflowRun(row) : null;

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -315,7 +315,11 @@ export async function executeWorkflow(
     // Step 1: Find prior failed run — non-critical, fall through on DB error
     let resumableRun: Awaited<ReturnType<typeof deps.store.findResumableRun>> = null;
     try {
-      resumableRun = await deps.store.findResumableRun(workflow.name, cwd);
+      // Pass userMessage so a failed run for a DIFFERENT plan/description on
+      // the same (workflow_name, working_path) is not silently picked up.
+      // Especially load-bearing for workflows with `worktree.enabled: false`,
+      // where every invocation shares cwd.
+      resumableRun = await deps.store.findResumableRun(workflow.name, cwd, userMessage);
     } catch (error) {
       const err = error as Error;
       getLog().error(

--- a/packages/workflows/src/store.ts
+++ b/packages/workflows/src/store.ts
@@ -63,7 +63,11 @@ export interface IWorkflowStore {
     workingPath: string,
     self?: { id: string; startedAt: Date }
   ): Promise<WorkflowRun | null>;
-  findResumableRun(workflowName: string, workingPath: string): Promise<WorkflowRun | null>;
+  findResumableRun(
+    workflowName: string,
+    workingPath: string,
+    userMessage?: string
+  ): Promise<WorkflowRun | null>;
   failOrphanedRuns(): Promise<{ count: number }>;
   resumeWorkflowRun(id: string): Promise<WorkflowRun>;
   updateWorkflowRun(


### PR DESCRIPTION
## Summary

Auto-resume from `executor.ts` previously matched only on `(workflow_name, working_path)`. For workflows with `worktree.enabled: false`, every invocation from the same checkout shares `cwd`, so a failed run for plan A is silently picked up by the next invocation passing plan B.

This bit a downstream user (CHIP400 LMS project) on `lms-phase-pipeline`: a Phase 4a sprint failed with `status='failed'`, then a kick for a completely different initiative (`module-pipeline-authoring-upgrade`) with a different plan path resumed Phase 4a's run, ran the wrong generator against the wrong worktree, and burned 6+ minutes of LLM time on contaminated state before failing.

## Fix

Add an optional third argument `userMessage?: string` to `findResumableRun`. When provided (called from `executor.ts:322` where the caller knows the current invocation's input), narrow the SELECT with `AND user_message = \$3`. When omitted (called from `cli/commands/workflow.ts:451` for `--resume`, where the user is explicitly asking to reuse whatever the prior run was), keep the original two-key match — preserving existing `--resume` semantics.

The CLI `--resume` site is untouched on purpose: `--resume` means "pick up the last failed run on this workflow at this path, whatever its input was." That's the right semantics there; it's only the implicit auto-resume during a normal `workflow run` invocation that needs the narrower match.

Also removes a pre-existing dead trailing `1` parameter from the params array — the SQL only ever referenced `\$1` and `\$2`.

## Diff scope

- \`packages/core/src/db/workflows.ts\` — function signature + SQL
- \`packages/workflows/src/store.ts\` — interface declaration
- \`packages/workflows/src/executor.ts\` — pass \`userMessage\` from the auto-resume path
- \`packages/core/src/db/workflows.test.ts\` — 3 new regression cases + update 2 existing param-equality assertions

## Test plan

- [x] \`bun test packages/core/src/db/workflows.test.ts\` → 69/69 pass (includes the 3 new cases)
- [x] \`bun test packages/workflows/src/executor.test.ts packages/workflows/src/executor-preamble.test.ts packages/cli/src/commands/workflow.test.ts\` → 131/131 pass (no caller-side regressions)
- [x] \`bun run type-check\` → all packages clean
- [x] Manual reproducer in a downstream repo: pre-fix \`lms-phase-pipeline\` invocations with different plan paths collide; post-fix they get distinct runs

## Notes

- Backward compatible: the new param is optional and existing callers compile unchanged.
- The CLI \`--resume\` path is intentionally unchanged. Explicit-resume semantics retain the original two-key match because the user is asking for "whatever ran last here, pick it up."
- Mock signatures in the workflow-deps test fixtures already accept any args, so no test-fixture updates were needed beyond the new assertions in \`workflows.test.ts\`.

## Related

The downstream user worked around this with a shell-level guard that abandons cross-plan resumable rows before \`archon workflow run\`. With this PR merged and a release cut, the workaround can be retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved workflow resumption to more accurately match previous runs by considering user context, preventing incorrect resumption of unrelated workflow variants in the same directory.

* **Tests**
  * Added comprehensive test coverage for workflow resumption scenarios with and without user message filtering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1714?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->