### PR TITLE
feat(web): add light/dark theme toggle

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -12,12 +12,31 @@
       rel="stylesheet"
     />
     <style>
-      body {
+      /* Prevent flash: apply theme before React hydrates */
+      html:not(.dark) body {
+        background-color: #f9f9fb;
+      }
+      html.dark body {
         background-color: #0f1117;
       }
     </style>
   </head>
   <body>
+    <script>
+      // Apply saved theme before React renders to prevent flash
+      (function () {
+        try {
+          var theme = localStorage.getItem('archon-theme');
+          if (theme === 'light') {
+            document.documentElement.classList.remove('dark');
+          } else {
+            document.documentElement.classList.add('dark');
+          }
+        } catch (_) {
+          document.documentElement.classList.add('dark');
+        }
+      })();
+    </script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/packages/web/src/components/layout/TopNav.tsx
+++ b/packages/web/src/components/layout/TopNav.tsx
@@ -1,9 +1,18 @@
 import { NavLink, Link, useNavigate } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
-import { LayoutDashboard, MessageSquare, Workflow, Settings, LogOut } from 'lucide-react';
+import {
+  LayoutDashboard,
+  MessageSquare,
+  Workflow,
+  Settings,
+  LogOut,
+  Sun,
+  Moon,
+} from 'lucide-react';
 import { listDashboardRuns, getUpdateCheck, getAuthStatus } from '@/lib/api';
 import { useSession, signOut } from '@/lib/auth-client';
 import { cn } from '@/lib/utils';
+import { useTheme } from '@/hooks/useTheme';
 
 const tabs = [
   { to: '/legacy/chat', end: false, icon: MessageSquare, label: 'Chat' },
@@ -14,6 +23,7 @@ const tabs = [
 
 export function TopNav(): React.ReactElement {
   const navigate = useNavigate();
+  const { theme, toggleTheme } = useTheme();
 
   // Web-auth identity strip (only shown when auth is enabled).
   const { data: authStatus } = useQuery({
@@ -86,6 +96,14 @@ export function TopNav(): React.ReactElement {
         </NavLink>
       ))}
       <div className="ml-auto flex items-center gap-3">
+        <button
+          onClick={toggleTheme}
+          className="rounded-md p-1.5 text-text-secondary hover:text-text-primary hover:bg-surface-hover transition-colors"
+          title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+          aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+        >
+          {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+        </button>
         {/* CTA to the experimental console. Uses the brand magenta→teal
             gradient via inline style because the old UI's tokens don't
             include the brand-gradient variables. Sized to read as a

--- a/packages/web/src/hooks/useTheme.ts
+++ b/packages/web/src/hooks/useTheme.ts
@@ -1,0 +1,40 @@
+import { useState, useEffect, useCallback } from 'react';
+
+type Theme = 'light' | 'dark';
+
+const STORAGE_KEY = 'archon-theme';
+
+function getInitialTheme(): Theme {
+  if (typeof window === 'undefined') return 'dark';
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === 'light' || stored === 'dark') return stored;
+  } catch {
+    // localStorage unavailable (Safari private mode, Firefox privacy settings)
+  }
+  return 'dark';
+}
+
+export function useTheme(): { theme: Theme; toggleTheme: () => void } {
+  const [theme, setTheme] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    try {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } catch {
+      // Storage unavailable or quota exceeded — theme state persists in memory
+    }
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
+  }, []);
+
+  return { theme, toggleTheme };
+}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -6,8 +6,66 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* Dark-only theme - uses our custom palette as root defaults */
-:root {
+/* Light theme (default when no .dark class) */
+:root:not(.dark) {
+  /* App-specific colors */
+  --surface: oklch(0.97 0.005 260);
+  --surface-elevated: oklch(1 0 0);
+  --border-bright: oklch(0.78 0.005 260);
+  --text-primary: oklch(0.15 0.01 260);
+  --text-secondary: oklch(0.42 0.01 260);
+  --text-tertiary: oklch(0.6 0.01 260);
+  --accent-hover: oklch(0.52 0.18 250);
+  --accent-muted: oklch(0.88 0.06 250);
+  --surface-inset: oklch(0.93 0.005 260);
+  --surface-hover: oklch(0.94 0.005 260);
+  --accent-bright: oklch(0.45 0.18 250);
+  --success: oklch(0.45 0.17 155);
+  --warning: oklch(0.55 0.18 75);
+  --error: oklch(0.5 0.2 25);
+
+  /* Node type colors */
+  --node-command: oklch(0.45 0.18 250);
+  --node-prompt: oklch(0.42 0.19 290);
+  --node-bash: oklch(0.55 0.18 75);
+
+  /* shadcn variables mapped to light theme */
+  --radius: 0.625rem;
+  --background: oklch(0.985 0.002 260);
+  --foreground: oklch(0.15 0.01 260);
+  --card: oklch(0.97 0.005 260);
+  --card-foreground: oklch(0.15 0.01 260);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.15 0.01 260);
+  --primary: oklch(0.45 0.18 250);
+  --primary-foreground: oklch(0.98 0.005 260);
+  --secondary: oklch(0.94 0.005 260);
+  --secondary-foreground: oklch(0.15 0.01 260);
+  --muted: oklch(0.94 0.005 260);
+  --muted-foreground: oklch(0.42 0.01 260);
+  --accent: oklch(0.92 0.03 250);
+  --accent-foreground: oklch(0.15 0.01 260);
+  --destructive: oklch(0.5 0.2 25);
+  --border: oklch(0.88 0.005 260);
+  --input: oklch(0.88 0.005 260);
+  --ring: oklch(0.45 0.18 250);
+  --chart-1: oklch(0.45 0.18 250);
+  --chart-2: oklch(0.45 0.17 155);
+  --chart-3: oklch(0.55 0.18 75);
+  --chart-4: oklch(0.5 0.2 25);
+  --chart-5: oklch(0.42 0.18 250);
+  --sidebar: oklch(0.97 0.005 260);
+  --sidebar-foreground: oklch(0.15 0.01 260);
+  --sidebar-primary: oklch(0.45 0.18 250);
+  --sidebar-primary-foreground: oklch(0.98 0.005 260);
+  --sidebar-accent: oklch(0.92 0.03 250);
+  --sidebar-accent-foreground: oklch(0.15 0.01 260);
+  --sidebar-border: oklch(0.88 0.005 260);
+  --sidebar-ring: oklch(0.45 0.18 250);
+}
+
+/* Dark theme */
+:root.dark {
   /* App-specific colors */
   --surface: oklch(0.18 0.008 260);
   --surface-elevated: oklch(0.22 0.01 260);
@@ -150,7 +208,7 @@ body {
   font-family: var(--font-sans);
 }
 
-/* Scrollbar styling for dark theme */
+/* Scrollbar styling */
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;


### PR DESCRIPTION
## Summary

- **Problem:** Web UI is dark-only. Users on light-mode-preferred setups (default OS theme, accessibility needs, bright environments) get a dark interface they can't change.
- **Why it matters:** Theme preference is a basic UX expectation. Archon's web UI tokens already support both palettes conceptually, but only dark was wired up.
- **What changed:** Complete light/dark theme system — `useTheme` hook + localStorage persistence, TopNav toggle button, pre-hydration script to prevent flash, CSS restructure so `:root:not(.dark)` carries the light palette.

## Files

| File | Change |
|---|---|
| `packages/web/src/hooks/useTheme.ts` (new) | Theme state + localStorage (`archon-theme`) + toggle, applies `dark` class on `documentElement`. localStorage wrapped in try-catch for restricted contexts. |
| `packages/web/src/components/layout/TopNav.tsx` | Sun/Moon icon button wired to `useTheme`. Conflicts with dev's auth strip + console CTA resolved by merging all three side-by-side. |
| `packages/web/index.html` | Inline CSS + script apply theme pre-hydration to prevent FOUC. Falls back to dark on error. |
| `packages/web/src/index.css` | Light palette moved to `:root:not(.dark)`, dark palette under `:root.dark`. |

## UX Journey

### Before

```
User opens Archon → dark theme always
OS light-mode users → no option to match
Accessibility needs (contrast sensitivity) → no option
```

### After

```
User opens Archon → defaults to dark (matches prior behavior)
User clicks Sun/Moon toggle in top nav → switches to light, persisted
Page reload → saved theme applied pre-hydration, no flash
localStorage unavailable (private browsing) → falls back to dark, no crash
```

## Scope reset (2026-07-07)

Force-pushed clean. Previous revision had two commits (`feat` + `localStorage try-catch fix`) on top of an outdated base — caused CONFLICTING state. Now one focused commit on current `dev`. Behavior is identical to the previous revision; conflicts against dev's TopNav.tsx (auth strip, console CTA) resolved by merging all three concerns side-by-side.

## Validation Evidence

```bash
bun --filter @archon/web type-check   # Exited 0
bun --filter @archon/web build        # Built in 9s, no errors
```

Manual testing:
- Toggle switches theme instantly
- Page reload preserves theme (localStorage `archon-theme`)
- Fresh load with no preference defaults to dark
- Broken localStorage value falls back to dark
- Private-browsing mode (localStorage disabled) doesn't crash

## Security Impact

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? **Yes** — default behavior (dark) is unchanged; light is opt-in via toggle.
- Config/env changes? None
- Database migration needed? No

## Side Effects / Blast Radius

- Affected subsystems: Web UI only (`packages/web`)
- Potential unintended effects: None — feature is opt-in, CSS variable names unchanged
- Guardrails: Default theme matches prior behavior (dark); no breaking changes to token system

## Rollback Plan

- Fast rollback: revert this PR
- Observable failure: Sun/Moon button missing from top nav; CSS not applied

## Risks and Mitigations

- Risk: Future CSS variable additions assume `:root` is dark
  - Mitigation: Document that light palette goes under `:root:not(.dark)` — comment added to index.css
- Risk: localStorage race on first paint
  - Mitigation: Pre-hydration script in index.html runs before React renders
