### PR TITLE
fix(providers/pi): suppress text_delta streaming, emit assembled text at agent_end

### DIFF
--- a/packages/providers/src/community/pi/event-bridge.test.ts
+++ b/packages/providers/src/community/pi/event-bridge.test.ts
@@ -670,11 +670,10 @@ describe('streaming tail completion', () => {
     } as unknown as AgentSessionEvent;
   }
 
-  test('emits corrective assistant chunk when streaming truncated', async () => {
+  test('emits assembled text from agent_end when streaming differs', async () => {
     const streamed = 'The repo is cloned. Let me register it.\n\n/register-project';
     const full =
       'The repo is cloned. Let me register it.\n\n/register-project SaberEngine "/path/to/repo"';
-    const tail = full.slice(streamed.length);
 
     let listener: ((event: AgentSessionEvent) => void) | undefined;
     const mockSession = {
@@ -684,7 +683,6 @@ describe('streaming tail completion', () => {
         return () => {};
       },
       prompt: async () => {
-        listener?.({ type: 'turn_start' } as AgentSessionEvent);
         listener?.(makeTextDeltaEvent(streamed));
         listener?.(makeAgentEndEvent(full));
       },
@@ -697,14 +695,14 @@ describe('streaming tail completion', () => {
       chunks.push(chunk);
     }
 
+    // text_deltas are suppressed; assembled text emitted at agent_end
     const assistantChunks = chunks.filter(c => c.type === 'assistant');
-    expect(assistantChunks).toHaveLength(2);
-    expect(assistantChunks[0].content).toBe(streamed);
-    expect(assistantChunks[1].content).toBe(tail);
+    expect(assistantChunks).toHaveLength(1);
+    expect(assistantChunks[0].content).toBe(full);
     expect(chunks[chunks.length - 1].type).toBe('result');
   });
 
-  test('does not emit corrective chunk when streaming is complete', async () => {
+  test('emits assembled text once when streaming matches', async () => {
     const full = 'complete text no truncation';
 
     let listener: ((event: AgentSessionEvent) => void) | undefined;
@@ -715,7 +713,6 @@ describe('streaming tail completion', () => {
         return () => {};
       },
       prompt: async () => {
-        listener?.({ type: 'turn_start' } as AgentSessionEvent);
         listener?.(makeTextDeltaEvent(full));
         listener?.(makeAgentEndEvent(full));
       },
@@ -733,7 +730,7 @@ describe('streaming tail completion', () => {
     expect(assistantChunks[0].content).toBe(full);
   });
 
-  test('does not emit corrective chunk when assembled text does not start with streamed (mismatch)', async () => {
+  test('emits assembled text even when it differs from streamed text', async () => {
     let listener: ((event: AgentSessionEvent) => void) | undefined;
     const mockSession = {
       sessionId: 'session-1',
@@ -742,7 +739,6 @@ describe('streaming tail completion', () => {
         return () => {};
       },
       prompt: async () => {
-        listener?.({ type: 'turn_start' } as AgentSessionEvent);
         listener?.(makeTextDeltaEvent('different content'));
         listener?.(makeAgentEndEvent('assembled is completely different'));
       },
@@ -757,10 +753,11 @@ describe('streaming tail completion', () => {
 
     const assistantChunks = chunks.filter(c => c.type === 'assistant');
     expect(assistantChunks).toHaveLength(1);
-    expect(assistantChunks[0].content).toBe('different content');
+    // Assembled text replaces streamed text
+    expect(assistantChunks[0].content).toBe('assembled is completely different');
   });
 
-  test('resets per-turn text on turn_start so only final turn is checked', async () => {
+  test('emits final assembled text from multi-turn session', async () => {
     let listener: ((event: AgentSessionEvent) => void) | undefined;
     const mockSession = {
       sessionId: 'session-1',
@@ -769,11 +766,9 @@ describe('streaming tail completion', () => {
         return () => {};
       },
       prompt: async () => {
-        listener?.({ type: 'turn_start' } as AgentSessionEvent);
         listener?.(makeTextDeltaEvent('turn one text'));
-        listener?.({ type: 'turn_start' } as AgentSessionEvent); // second turn resets counter
         listener?.(makeTextDeltaEvent('turn two'));
-        listener?.(makeAgentEndEvent('turn two')); // last assistant msg matches turn 2
+        listener?.(makeAgentEndEvent('turn two')); // last assistant msg
       },
       abort: async () => {},
       dispose: () => {},
@@ -784,13 +779,13 @@ describe('streaming tail completion', () => {
       chunks.push(chunk);
     }
 
+    // text_deltas suppressed; only assembled text emitted
     const assistantChunks = chunks.filter(c => c.type === 'assistant');
-    expect(assistantChunks).toHaveLength(2);
-    expect(assistantChunks[0].content).toBe('turn one text');
-    expect(assistantChunks[1].content).toBe('turn two');
+    expect(assistantChunks).toHaveLength(1);
+    expect(assistantChunks[0].content).toBe('turn two');
   });
 
-  test('corrective chunk is added to assistantBuffer when wantsStructured', async () => {
+  test('assembled text is used for structured output parsing', async () => {
     const streamed = '{"partial":';
     const full = '{"partial":true}';
 
@@ -802,7 +797,6 @@ describe('streaming tail completion', () => {
         return () => {};
       },
       prompt: async () => {
-        listener?.({ type: 'turn_start' } as AgentSessionEvent);
         listener?.(makeTextDeltaEvent(streamed));
         listener?.(makeAgentEndEvent(full));
       },

--- a/packages/providers/src/community/pi/event-bridge.ts
+++ b/packages/providers/src/community/pi/event-bridge.ts
@@ -307,10 +307,6 @@ export async function* bridgeSession(
   // passes through untouched.
   const wantsStructured = jsonSchema !== undefined;
   let assistantBuffer = '';
-  // Track text streamed via text_delta for the current assistant turn.
-  // Reset at each turn_start so only the final turn's text is compared
-  // against finalAssembledText (see streaming-tail completion below).
-  let currentTurnText = '';
   // Assembled text of the final assistant message from agent_end.messages.
   // Set synchronously inside the subscribe callback before the result chunk
   // is pushed to the queue, so it is always ready when the yield loop
@@ -319,18 +315,28 @@ export async function* bridgeSession(
 
   const unsubscribe = session.subscribe((event: AgentSessionEvent) => {
     try {
-      if (event.type === 'turn_start') {
-        currentTurnText = '';
-      }
       if (event.type === 'agent_end') {
         finalAssembledText = extractLastAssistantText(event.messages);
+        // Always reset assistantBuffer on agent_end to prevent stale
+        // text_delta content from being parsed as structured output.
+        if (wantsStructured) {
+          assistantBuffer = finalAssembledText ?? '';
+        }
+      }
+      // On agent_end, emit the full assembled text BEFORE the result chunk
+      // so callers receive assistant text before the terminal result.
+      if (event.type === 'agent_end' && finalAssembledText) {
+        queue.push({ kind: 'chunk', chunk: { type: 'assistant', content: finalAssembledText } });
       }
       for (const chunk of mapPiEvent(event)) {
-        if (chunk.type === 'assistant') {
-          currentTurnText += chunk.content;
-        }
         if (wantsStructured && chunk.type === 'assistant') {
           assistantBuffer += chunk.content;
+        }
+        // Suppress text_delta chunks — Pi's streaming can drop newlines and
+        // spaces. Instead, emit the full assembled text at agent_end (below).
+        // Tool calls, tool results, system messages, and thinking chunks pass through.
+        if (chunk.type === 'assistant') {
+          continue; // will be emitted as assembledText at agent_end
         }
         queue.push({ kind: 'chunk', chunk });
       }
@@ -374,42 +380,12 @@ export async function* bridgeSession(
       // it unconditionally and let the caller decide whether resume is
       // meaningful (capability-gated at the registry level).
       if (item.chunk.type === 'result') {
-        // Streaming tail completion: Pi occasionally fails to flush the last
-        // characters of an assistant turn as text_delta events, leaving them
-        // present only in agent_end.messages. Detect the gap and emit the
-        // missing suffix as a corrective assistant chunk so the orchestrator's
-        // allMessages accumulator receives the full command text.
-        // Condition: assembled text is strictly longer, starts with what was
-        // streamed (ensuring we emit an extension, not a replacement), and is
-        // not undefined (no assistant message in transcript — treated as clean).
-        if (
-          finalAssembledText !== undefined &&
-          finalAssembledText.length > currentTurnText.length &&
-          finalAssembledText.startsWith(currentTurnText)
-        ) {
-          const tail = finalAssembledText.slice(currentTurnText.length);
-          yield { type: 'assistant', content: tail };
-          if (wantsStructured) {
-            assistantBuffer += tail;
-          }
-          getLog().warn(
-            {
-              streamedLen: currentTurnText.length,
-              assembledLen: finalAssembledText.length,
-              tailLen: tail.length,
-            },
-            'pi.event-bridge.streaming_tail_completed'
-          );
-        }
         let terminal: MessageChunk = item.chunk;
         if (session.sessionId) {
           terminal = { ...terminal, sessionId: session.sessionId };
         }
         // Best-effort structured output: parse the accumulated assistant
-        // transcript as JSON and attach. On parse failure, leave it off —
-        // the dag-executor's existing dag.structured_output_missing path
-        // warns and downstream $node.output.field refs degrade to '' instead
-        // of propagating bogus data.
+        // transcript as JSON and attach.
         if (wantsStructured) {
           const parsed = tryParseStructuredOutput(assistantBuffer);
           if (parsed !== undefined) {


### PR DESCRIPTION
## Summary

- **Problem:** Pi SDK (via z.ai GLM models) emits token-level `text_delta` events that drop newlines and spaces. Each token becomes a separate chat-platform message, and the concatenated result has mangled formatting (missing newlines between headings, lists, and body text).
- **Why it matters:** Chat platforms (Telegram batch mode, Slack, GitHub issues) become unusable with Pi-based reasoning models — responses arrive as dozens of single-character messages with broken markdown, plus `filterToolIndicators()` in `orchestrator-agent.ts:457` joins chunks with `\n\n---\n\n` separators that leak as literal horizontal rules in user-visible output.
- **What changed:** Suppress text_delta-derived assistant chunks in `event-bridge.ts`. Emit the full assembled text from `agent_end.messages` as a single chunk. Reset `assistantBuffer` on `agent_end` to prevent stale text_delta content from being parsed as structured output. Remove the now-redundant streaming-tail completion logic.

## Scope reset

This PR was previously a bundled change (theme toggle + Telegram buffered mode + Pi event-bridge). The bundle caused merge conflicts and confused reviewers. Force-pushed to **only** contain the Pi event-bridge fix — the user-visible root cause that no other PR addresses.

- **Theme toggle** is tracked separately in #1715 (clean, focused).
- **Telegram buffered mode** is unnecessary once the Pi event-bridge is fixed: with a single assembled chunk, `batch` mode produces clean output without per-token spam.
- **`TELEGRAM_STREAMING_MODE=buffered`** env var (introduced in earlier revision) is dropped — `stream | batch` is enough.

## Why not #1581?

PR #1581 (b1skit, merged) fixed a *related* but different bug: orchestrator-side accumulation for multi-chunk command parsing (`/invoke-workflow`, `/register-project`). It did **not** address:
- the user-visible token-spam symptom on chat platforms, or
- the `\n\n---\n\n` separator leak from `filterToolIndicators()`.

This PR is the missing piece. Tested alongside #1581 — they compose cleanly.

## UX Journey

### Before

```
Pi emits text_delta "H" → Telegram message "H"
Pi emits text_delta "e" → Telegram message "e"
Pi emits text_delta "llo" → Telegram message "llo"
... 80+ messages for a single response, newlines dropped, markdown broken
filterToolIndicators() injects "---" separators between chunks → user sees horizontal rules
```

### After

```
Pi emits text_deltas (suppressed in event-bridge)
Pi agent_end fires → assembled text emitted as single chunk
filterToolIndicators() sees one chunk → no separators
Telegram batch mode sends one clean message
```

## Architecture Diagram

| From | To | Status | Notes |
|---|---|---|---|
| Pi text_delta | event-bridge | **suppressed** | No longer forwarded as assistant chunks |
| Pi agent_end | event-bridge | **modified** | Emits full assembled text as single chunk before result |
| event-bridge | orchestrator | unchanged interface | Single chunk instead of many |
| Orchestrator | chat adapters | unchanged | Sees one assistant message, no `---` separators |

## Validation Evidence

```bash
bun test packages/providers/src/community/pi/event-bridge.test.ts
# 51 pass, 0 fail, 85 expect() calls
```

- Manual testing: Pi/z.ai GLM-5.2 via Telegram in batch mode. Verified single clean message delivery instead of 80+ token-level chunks. Verified markdown rendering (bold, italic, code blocks, headings, lists) preserved.

## Security Impact

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? **Yes** — behavior change is transparent. Output is cleaner for all Pi providers; non-Pi providers (Claude, Codex) are untouched.
- Config/env changes? None
- Database migration needed? No

## Side Effects / Blast Radius

- Affected subsystems: Pi event bridge (`bridgeSession`) only
- Potential unintended effects: Pi streaming no longer provides real-time token-by-token output. Acceptable tradeoff — Pi's streaming was already broken (mangled formatting); correct single-message output is strictly better.
- Guardrails: Non-Pi providers' streaming is unchanged.

## Rollback Plan

- Fast rollback: revert this PR
- Observable failure: token-level spam returns on Pi-backed chat platforms

## Risks and Mitigations

- Risk: Pi assembled text may drop content in edge cases
  - Mitigation: `extractLastAssistantText` reads from the full transcript, which is the authoritative source
- Risk: Loss of streaming feel for short responses
  - Mitigation: Acceptable — Pi's streaming was already broken; correct output > fast wrong output
