### PR TITLE
fix(workflows): write large node outputs to temp file to prevent bash substitution corruption (fixes #1717)

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -828,6 +828,56 @@ describe('substituteNodeOutputRefs -- shell escaping', () => {
   });
 });
 
+describe('substituteNodeOutputRefs -- large output file substitution', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `archon-test-large-output-${Date.now()}`);
+    await mkdir(tempDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('inlines small output even when outputFileDir is provided', () => {
+    const outputs = new Map([['a', makeOutput('completed', 'small')]]);
+    const result = substituteNodeOutputRefs('echo $a.output', outputs, true, tempDir);
+    expect(result).toBe("echo 'small'");
+  });
+
+  it('writes large output (>=32KB) to file and returns $(cat ...) reference', async () => {
+    const largeOutput = 'x'.repeat(33_000);
+    const outputs = new Map([['a', makeOutput('completed', largeOutput)]]);
+    const result = substituteNodeOutputRefs('echo $a.output', outputs, true, tempDir);
+    expect(result).toContain('$(cat ');
+    expect(result).toContain('a.nodeoutput');
+    // Verify file was written with correct content
+    const { readFile: readFileAsync } = await import('fs/promises');
+    const written = await readFileAsync(join(tempDir, 'a.nodeoutput'), 'utf-8');
+    expect(written).toBe(largeOutput);
+  });
+
+  it('writes large field value to file with field name in filename', async () => {
+    const largeValue = 'y'.repeat(33_000);
+    const outputs = new Map([['a', makeOutput('completed', JSON.stringify({ data: largeValue }))]]);
+    const result = substituteNodeOutputRefs('echo $a.output.data', outputs, true, tempDir);
+    expect(result).toContain('$(cat ');
+    expect(result).toContain('a.data.nodeoutput');
+    const { readFile: readFileAsync } = await import('fs/promises');
+    const written = await readFileAsync(join(tempDir, 'a.data.nodeoutput'), 'utf-8');
+    expect(written).toBe(largeValue);
+  });
+
+  it('does not write to file when escapedForBash=false even for large output', () => {
+    const largeOutput = 'x'.repeat(33_000);
+    const outputs = new Map([['a', makeOutput('completed', largeOutput)]]);
+    const result = substituteNodeOutputRefs('echo $a.output', outputs, false, tempDir);
+    expect(result).toBe(`echo ${largeOutput}`);
+    expect(result).not.toContain('$(cat ');
+  });
+});
+
 describe('substituteNodeOutputRefs -- structuredOutput preference', () => {
   it('prefers structuredOutput.field over JSON.parse(output)', () => {
     // Pi-shape: prose output text with structuredOutput populated by tryParseStructuredOutput.

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -876,6 +876,17 @@ describe('substituteNodeOutputRefs -- large output file substitution', () => {
     expect(result).toBe(`echo ${largeOutput}`);
     expect(result).not.toContain('$(cat ');
   });
+
+  it('falls back to shell-quoting when file write fails', () => {
+    const largeOutput = 'x'.repeat(33_000);
+    const outputs = new Map([['a', makeOutput('completed', largeOutput)]]);
+    // Use a non-existent directory to trigger writeFileSync failure
+    const badDir = '/nonexistent-path-that-does-not-exist';
+    const result = substituteNodeOutputRefs('echo $a.output', outputs, true, badDir);
+    // Should fall back to inline shell-quoting instead of crashing
+    expect(result).not.toContain('$(cat ');
+    expect(result).toBe(`echo '${largeOutput}'`);
+  });
 });
 
 describe('substituteNodeOutputRefs -- structuredOutput preference', () => {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -247,8 +247,17 @@ function shellQuoteOrFile(
   if (outputFileDir && value.length > NODE_OUTPUT_FILE_THRESHOLD) {
     const filename = field ? `${nodeId}.${field}.nodeoutput` : `${nodeId}.nodeoutput`;
     const filePath = joinPath(outputFileDir, filename);
-    writeFileSync(filePath, value);
-    return `$(cat ${shellQuote(filePath)})`;
+    try {
+      writeFileSync(filePath, value);
+      return `$(cat ${shellQuote(filePath)})`;
+    } catch (fileErr) {
+      const err = fileErr as Error;
+      getLog().error(
+        { err, nodeId, field, valueSize: value.length, filePath },
+        'dag.large_output_file_write_failed'
+      );
+      return shellQuote(value); // fallback: inline (pre-file-spill behavior)
+    }
   }
   return shellQuote(value);
 }

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -5,8 +5,9 @@
  * Independent nodes within the same layer run concurrently via Promise.allSettled.
  * Captures all assistant output regardless of streaming mode for $node_id.output substitution.
  */
+import { writeFileSync } from 'fs';
 import { readFile } from 'fs/promises';
-import { isAbsolute, resolve as resolvePath } from 'path';
+import { isAbsolute, join as joinPath, resolve as resolvePath } from 'path';
 import { execFileAsync } from '@archon/git';
 import { discoverScriptsForCwd } from './script-discovery';
 import type {
@@ -234,6 +235,25 @@ function shellQuote(value: string): string {
 }
 
 /**
+ * Shell-quote a value for bash, or write it to a file and return a $(cat ...) reference
+ * when the value exceeds the inline size threshold.
+ */
+function shellQuoteOrFile(
+  value: string,
+  nodeId: string,
+  field: string | undefined,
+  outputFileDir: string | undefined
+): string {
+  if (outputFileDir && value.length > NODE_OUTPUT_FILE_THRESHOLD) {
+    const filename = field ? `${nodeId}.${field}.nodeoutput` : `${nodeId}.nodeoutput`;
+    const filePath = joinPath(outputFileDir, filename);
+    writeFileSync(filePath, value);
+    return `$(cat ${shellQuote(filePath)})`;
+  }
+  return shellQuote(value);
+}
+
+/**
  * Substitute $node_id.output and $node_id.output.field references in a prompt.
  * Called AFTER the standard substituteWorkflowVariables pass.
  *
@@ -244,7 +264,8 @@ function shellQuote(value: string): string {
 export function substituteNodeOutputRefs(
   prompt: string,
   nodeOutputs: Map<string, NodeOutput>,
-  escapedForBash = false
+  escapedForBash = false,
+  outputFileDir?: string
 ): string {
   return prompt.replace(
     /\$([a-zA-Z_][a-zA-Z0-9_-]*)\.output(?:\.([a-zA-Z_][a-zA-Z0-9_]*))?/g,
@@ -255,7 +276,9 @@ export function substituteNodeOutputRefs(
         return escapedForBash ? "''" : '';
       }
       if (!field) {
-        return escapedForBash ? shellQuote(nodeOutput.output) : nodeOutput.output;
+        return escapedForBash
+          ? shellQuoteOrFile(nodeOutput.output, nodeId, undefined, outputFileDir)
+          : nodeOutput.output;
       }
       // Prefer the provider-supplied structured payload when present. Providers that emit
       // fence-wrapped or preamble-prefixed JSON (Pi/Minimax) parse it onto the result chunk
@@ -270,17 +293,20 @@ export function substituteNodeOutputRefs(
         !Array.isArray(structured)
       ) {
         const value = (structured as Record<string, unknown>)[field];
-        if (typeof value === 'string') return escapedForBash ? shellQuote(value) : value;
+        if (typeof value === 'string')
+          return escapedForBash ? shellQuoteOrFile(value, nodeId, field, outputFileDir) : value;
         if (typeof value === 'number' || typeof value === 'boolean') return String(value);
         if (Array.isArray(value) || typeof value === 'object') {
-          return escapedForBash ? shellQuote(JSON.stringify(value)) : JSON.stringify(value);
+          const json = JSON.stringify(value);
+          return escapedForBash ? shellQuoteOrFile(json, nodeId, field, outputFileDir) : json;
         }
         return escapedForBash ? "''" : '';
       }
       try {
         const parsed = JSON.parse(nodeOutput.output) as Record<string, unknown>;
         const value = parsed[field];
-        if (typeof value === 'string') return escapedForBash ? shellQuote(value) : value;
+        if (typeof value === 'string')
+          return escapedForBash ? shellQuoteOrFile(value, nodeId, field, outputFileDir) : value;
         // numbers and booleans from JSON.parse are shell-safe without quoting:
         // JSON disallows NaN/Infinity, so String(number) contains only digits, sign, and '.'.
         // String(boolean) is 'true' or 'false' — no shell metacharacters.
@@ -288,7 +314,8 @@ export function substituteNodeOutputRefs(
         // arrays and objects: JSON-stringify. Bash passes substitution as a single
         // argument, so downstream tools (jq, etc.) receive a JSON literal they can parse.
         if (Array.isArray(value) || typeof value === 'object') {
-          return escapedForBash ? shellQuote(JSON.stringify(value)) : JSON.stringify(value);
+          const json = JSON.stringify(value);
+          return escapedForBash ? shellQuoteOrFile(json, nodeId, field, outputFileDir) : json;
         }
         return escapedForBash ? "''" : ''; // undefined, symbol, bigint → empty (null is caught above by typeof check)
       } catch (jsonErr) {
@@ -1240,6 +1267,10 @@ async function executeNodeInternal(
 /** Default timeout for subprocess nodes (bash, script): 2 minutes */
 const SUBPROCESS_DEFAULT_TIMEOUT = 120_000;
 
+/** Threshold (bytes) above which $nodeId.output values are written to a temp file
+ *  instead of inlined as bash -c arguments, to avoid silent data corruption. */
+const NODE_OUTPUT_FILE_THRESHOLD = 32_768;
+
 /**
  * Execute a bash (shell script) DAG node.
  * Runs the script via `bash -c`, captures stdout as node output.
@@ -1302,7 +1333,7 @@ async function executeBashNode(
     undefined,
     { shellSafe: true }
   );
-  const finalScript = substituteNodeOutputRefs(substitutedScript, nodeOutputs, true);
+  const finalScript = substituteNodeOutputRefs(substitutedScript, nodeOutputs, true, logDir);
 
   const timeout = node.timeout ?? SUBPROCESS_DEFAULT_TIMEOUT;
   const subprocessEnv: NodeJS.ProcessEnv = {
@@ -2142,7 +2173,8 @@ async function executeLoopNode(
         const substitutedBash = substituteNodeOutputRefs(
           bashPrompt,
           nodeOutputs,
-          true // escapedForBash
+          true, // escapedForBash
+          logDir
         );
         await execFileAsync('bash', ['-c', substitutedBash], {
           cwd,


### PR DESCRIPTION
## Summary

- **Problem:** When a bash node references `$nodeId.output` from an upstream LLM node whose output is large (~42KB+), the substituted value is silently corrupted because the full text is inlined as a `bash -c` argument, hitting process argument passing limits.
- **Why it matters:** The `maintainer-standup` workflow (and any workflow with large intermediate outputs) fails silently — the downstream consumer gets garbled data and raises parse errors, despite working fine with the same input directly.
- **What changed:** Added a size threshold (`NODE_OUTPUT_FILE_THRESHOLD = 32KB`). Outputs below this continue to be shell-quoted inline (existing behavior). Outputs at or above this are written to a temp file in `logDir` and substituted with `$(cat '<path>')` — bash reads the value at runtime via command substitution, bypassing the argv size issue entirely.
- **What did NOT change:** Non-bash substitution paths (AI prompts, command nodes) are unaffected — they pass `escapedForBash=false` and never hit the file path. Small outputs (<32KB) still inline as before.

## UX Journey

### Before

```
Workflow              DAG Executor           bash -c
────────              ────────────           ───────
runs synthesize ───▶  captures 42KB output
runs persist node     substituteNodeOutputRefs
                      shellQuote(42KB) ─────▶ bash -c '<42KB inline>'
                                              ❌ data corrupted silently
                                              downstream parse fails
```

### After

```
Workflow              DAG Executor           bash -c
────────              ────────────           ───────
runs synthesize ───▶  captures 42KB output
runs persist node     substituteNodeOutputRefs
                      output > 32KB → write to logDir/synthesize.nodeoutput
                      substitute with $(cat path) ─▶ bash -c '...$(cat /path)...'
                                                      ✅ cat reads full file at runtime
                                                      downstream parse succeeds
```

## Architecture Diagram

### Before

```
substituteNodeOutputRefs(prompt, nodeOutputs, escapedForBash)
      │
      └─▶ shellQuote(nodeOutput.output)  ← always inline, regardless of size
            │
            └─▶ embedded in bash -c argv
```

### After

```
substituteNodeOutputRefs(prompt, nodeOutputs, escapedForBash, outputFileDir?)
      │
      ├─▶ output < 32KB: shellQuote(value)  ← existing behavior
      │
      └─▶ output >= 32KB AND outputFileDir:
            shellQuoteOrFile(value, nodeId, field, dir) [+]
              │
              ├─▶ writeFileSync(logDir/nodeId.nodeoutput, value)
              └─▶ returns $(cat '<path>')
```

**Connection inventory:**

| From | To | Status | Notes |
|------|-----|--------|-------|
| executeBashNode | substituteNodeOutputRefs | [~] passes logDir as 4th arg |
| executeLoopNode (until_bash) | substituteNodeOutputRefs | [~] passes logDir as 4th arg |
| substituteNodeOutputRefs | shellQuoteOrFile | [+] new helper for size-aware quoting |
| shellQuoteOrFile | writeFileSync + shellQuote | [+] writes file when threshold exceeded |
| Other callers (AI nodes, approval, cancel) | substituteNodeOutputRefs | unchanged (no outputFileDir) |

## Validation Evidence

- `bun test packages/workflows/src/dag-executor.test.ts` — **236 pass, 0 fail**
- `bun run type-check` — all 5 packages clean
- lint-staged passed on commit (eslint + prettier)
- New tests cover: small output still inlines, large output writes to file, field access with large value, non-bash paths unaffected

## Security Impact

- Temp files are written to the existing `logDir` (already under the run's artifact directory) — no new paths introduced
- Files contain workflow intermediate outputs (same data that was previously in argv) — no escalation of access
- `shellQuote` is used on the file path in the `$(cat ...)` command to prevent path injection

## Compatibility/Migration

- Fully backward compatible: existing small outputs behave identically
- No config changes or environment variables needed
- Temp files use `.nodeoutput` extension and are scoped to the run's logDir

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Disk write failure | writeFileSync will throw, caught by existing executeBashNode try/catch → node fails with clear error |
| File not cleaned up | Files live in logDir which is already managed by run lifecycle cleanup |
| $(cat) timing | File is written synchronously before exec, guaranteed to exist when bash reads it |

## Rollback Plan

Revert the commit — the only behavioral change is the file-based path for >32KB outputs.

Closes #1717

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bash-based workflow steps now handle very large node outputs by writing them to files and referencing them, preventing oversized inline values from breaking scripts.

* **Bug Fixes**
  * Improved fallback behavior when file-based substitution fails — shell-quoting is used to keep scripts robust.
  * Option to force full inlining preserved for cases that require it.

* **Tests**
  * Added tests covering small vs. large output handling, structured-field file naming, no-file inlining option, and file-write failure fallback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1718?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->