### PR TITLE
feat: fund quantitative analysis — Python scripts to Archon DAG workflows

### DIFF
--- a/.archon/commands/fund-analyze-news.md
+++ b/.archon/commands/fund-analyze-news.md
@@ -1,0 +1,86 @@
+---
+description: Deep news analysis using Claude AI — sentiment, sector impact, macro risk assessment
+argument-hint: (none — reads news_feed.json from artifacts)
+---
+
+# Fund Analyze News Impact
+
+You are a senior macroeconomic analyst. Your task is to perform deep, multi-step analysis of financial news and produce a structured assessment of market sentiment and risk.
+
+## Input
+
+Read the news feed from `$ARTIFACTS_DIR/news_feed.json`. This file contains an array of news items with title, source, url, publish_time, and summary fields.
+
+## Analysis Task
+
+Perform the following analysis on the collected news:
+
+### 1. Overall Market Sentiment Assessment
+- Categorize the dominant sentiment: POSITIVE / NEGATIVE / NEUTRAL / MIXED
+- Count the distribution: how many positive, negative, neutral signals
+- Explain the reasoning behind your overall classification
+
+### 2. Key Themes Identification
+- Identify 3-5 recurring themes across the news
+- Note cross-news correlations — do multiple sources report the same event?
+- Flag any contradictory reporting
+
+### 3. Sector Impact Matrix
+- List affected sectors/industries and the direction of impact (positive/negative)
+- Rank by intensity of impact
+- Identify sectors most exposed to current news cycle
+
+### 4. Macro Risk Assessment
+- Evaluate geopolitical risk level (LOW / MODERATE / ELEVATED / HIGH)
+- Assess policy/regulatory risk signals
+- Note any systemic risk indicators
+
+### 5. Top 5 Critical Events
+- Select the 5 most impactful news items
+- For each: explain why it matters and its potential market impact duration (days/weeks/months)
+
+## Output Format
+
+You MUST output a structured JSON object:
+
+```json
+{
+  "overall_sentiment": "POSITIVE|NEGATIVE|NEUTRAL|MIXED",
+  "sentiment_distribution": {
+    "positive": 0,
+    "negative": 0,
+    "neutral": 0,
+    "mixed": 0
+  },
+  "sentiment_reasoning": "Brief explanation of overall sentiment assessment",
+  "key_themes": ["theme1", "theme2"],
+  "sector_impacts": [
+    {"sector": "金融", "impact": "POSITIVE", "intensity": "HIGH", "reason": ""},
+    {"sector": "科技", "impact": "NEGATIVE", "intensity": "MEDIUM", "reason": ""}
+  ],
+  "macro_risk": {
+    "geopolitical": "MODERATE",
+    "policy_regulatory": "LOW",
+    "systemic": "LOW"
+  },
+  "top_5_events": [
+    {
+      "title": "Event title",
+      "impact_duration": "weeks",
+      "significance": "Why this matters"
+    }
+  ],
+  "summary_text": "1-2 sentence overall summary of the news landscape"
+}
+```
+
+## After Analysis
+
+1. Save the JSON output to `$ARTIFACTS_DIR/news_analysis.json`
+2. Report a brief summary to the user: overall sentiment, key risk signals, and top concern
+
+## Important
+
+- Be specific and data-driven — reference actual news items in your analysis
+- If the news feed is empty or unavailable, output NEUTRAL sentiment with a note
+- Distinguish between short-term noise and structural trends

--- a/.archon/commands/fund-fetch-macro.md
+++ b/.archon/commands/fund-fetch-macro.md
@@ -1,0 +1,47 @@
+---
+description: Fetch 26 macroeconomic indicators (China + US + global)
+argument-hint: (none — runs Python data collector)
+---
+
+# Fund Fetch Macro Indicators
+
+You are a data collection agent. Your task is to fetch macroeconomic indicators using the Python collection script.
+
+## Task
+
+Run the macro data collection script:
+
+```bash
+cd ~/Data_share/基金分析/Quantitative\ analysis\ for\ Funds && uv run python .archon/scripts/fund-data-collectors.py --action macro
+```
+
+## Expected Output
+
+The script collects 26 macroeconomic indicators and outputs a JSON object:
+- Keys are indicator names (e.g., `PMI_MANUFACTURING`, `CPI_YOY`, `USA_CPI_YOY`, `GOLD_SPOT`)
+- Values are arrays of data rows
+- `_errors`: Array of failed indicators
+- `_success_count`: Number of successfully collected indicators
+- `_total`: 26
+
+## After Collection
+
+1. Parse the JSON output
+2. Report:
+   - Success rate (e.g., "22/26 indicators collected")
+   - List any failed indicators and their error messages
+   - Key indicator summary:
+     - Latest PMI values (Manufacturing + Non-Manufacturing)
+     - Latest CPI/PPI trends
+     - Gold spot price and change
+     - US-CN yield spread
+3. Note any significant data gaps
+4. Save the raw JSON to `$ARTIFACTS_DIR/macro_data.json` for downstream nodes
+
+## Expected Duration
+
+~30-35 seconds (26 indicators × 1 second throttle interval)
+
+## Important
+
+Each indicator call is independent — failure of one does not affect others. The script uses a 1-second sleep between calls to respect akshare rate limits.

--- a/.archon/commands/fund-fetch-market.md
+++ b/.archon/commands/fund-fetch-market.md
@@ -1,0 +1,39 @@
+---
+description: Fetch global market data (US stocks, A-share indices, HK stocks, global indices)
+argument-hint: (none — runs Python data collector)
+---
+
+# Fund Fetch Market Data
+
+You are a data collection agent. Your task is to fetch global market data using the Python collection script.
+
+## Task
+
+Run the market data collection script:
+
+```bash
+cd ~/Data_share/基金分析/Quantitative\ analysis\ for\ Funds && uv run python .archon/scripts/fund-data-collectors.py --action market
+```
+
+## Expected Output
+
+The script outputs a JSON object to stdout with these fields:
+- `us_stocks`: Array of US stock quotes (symbol, name, latest_price, change_pct, pe_ratio, pb_ratio, volume)
+- `a_indices`: Array of A-share index quotes
+- `hk_stocks`: Array of HK stock quotes
+- `global_indices`: Array of global index quotes
+- `_errors`: Array of error messages for failed collections (may be empty)
+
+## After Collection
+
+1. Parse the JSON output
+2. Summarize what was collected:
+   - Stock count per market (US, A-share, HK, Global)
+   - Top 5 US stocks by change_pct (biggest gainers and losers)
+   - A-share index overview (which indices are up/down)
+3. Note any failures from `_errors`
+4. Save the raw JSON to `$ARTIFACTS_DIR/market_data.json` for downstream nodes
+
+## Expected Duration
+
+~10-15 seconds (yfinance batch + akshare serial calls)

--- a/.archon/commands/fund-fetch-news.md
+++ b/.archon/commands/fund-fetch-news.md
@@ -1,0 +1,38 @@
+---
+description: Fetch financial news feed from akshare
+argument-hint: (none — runs Python data collector)
+---
+
+# Fund Fetch News Feed
+
+You are a data collection agent. Your task is to fetch financial news using the Python collection script.
+
+## Task
+
+Run the news feed collection script:
+
+```bash
+cd ~/Data_share/基金分析/Quantitative\ analysis\ for\ Funds && uv run python .archon/scripts/fund-data-collectors.py --action news
+```
+
+## Expected Output
+
+The script outputs a JSON object:
+- `items`: Array of news items with fields: title, source, url, publish_time, summary
+- `_total`: Number of news items collected
+- `_errors`: Array of error messages (may be empty)
+
+## After Collection
+
+1. Parse the JSON output
+2. List the top 10 news headlines with:
+   - Title (first 60 chars)
+   - Source name
+   - Publish time
+3. Note the total count of collected news items
+4. Flag any errors from `_errors`
+5. Save the raw JSON to `$ARTIFACTS_DIR/news_feed.json` for downstream nodes
+
+## Expected Duration
+
+~3-5 seconds

--- a/.archon/commands/fund-generate-reports.md
+++ b/.archon/commands/fund-generate-reports.md
@@ -1,0 +1,62 @@
+---
+description: Generate analysis reports in Markdown, CSV, and JSON formats
+argument-hint: (none — reads scoring_results.json from artifacts)
+---
+
+# Fund Generate Reports
+
+You are a report generation agent. Your task is to produce the final analysis reports in all three output formats.
+
+## Pre-requisite Data
+
+The report generator expects:
+- `$ARTIFACTS_DIR/scoring_results.json` — Fund analysis results from fund-score-engine
+- `$ARTIFACTS_DIR/news_analysis.json` — (optional) News sentiment analysis
+- `$ARTIFACTS_DIR/macro_data.json` — (optional) Macro indicator data
+
+## Task
+
+Run the report generator:
+
+```bash
+cd $ARCHON_PROJECT_ROOT && bun run .archon/scripts/fund-report-generator.ts \
+  --scores "$ARTIFACTS_DIR/scoring_results.json" \
+  --output-dir "$ARTIFACTS_DIR"
+```
+
+## Output Files
+
+The generator produces three files in `$ARTIFACTS_DIR`:
+
+### 1. `基金投资分析报告.md` (Markdown)
+Full analysis report with:
+- Section I: Macro Overview — indicator collection status
+- Section II: News Impact Summary — sentiment, top news table
+- Section III: Fund Analysis Details — per-fund six-dim scores + five-dim screening
+- Section IV: Investment Recommendation Summary — ranked table
+- Section V: Risk Disclaimer
+
+### 2. `基金分析结果.csv` (CSV)
+Excel-compatible table (UTF-8 BOM encoded) with:
+- Fund code, name, category
+- All six dimension scores, five screening results
+- Composite score, recommendation, risk warnings
+
+### 3. `基金分析结果.json` (JSON)
+Machine-readable summary with:
+- Generation timestamp, news sentiment, macro coverage
+- Recommendation distribution counts
+- Full per-fund analysis data
+
+## After Generation
+
+1. Confirm each output file path
+2. Show a brief summary:
+   - Total funds in report
+   - Recommendation distribution (BUY/HOLD/REDUCE/SELL counts)
+   - Top recommended fund
+3. Note any data quality warnings
+
+## Expected Duration
+
+<1 second

--- a/.archon/commands/fund-generate-reports.md
+++ b/.archon/commands/fund-generate-reports.md
@@ -19,7 +19,7 @@ The report generator expects:
 Run the report generator:
 
 ```bash
-cd $ARCHON_PROJECT_ROOT && bun run .archon/scripts/fund-report-generator.ts \
+bun run .archon/scripts/fund-report-generator.ts \
   --scores "$ARTIFACTS_DIR/scoring_results.json" \
   --output-dir "$ARTIFACTS_DIR"
 ```

--- a/.archon/commands/fund-score-engine.md
+++ b/.archon/commands/fund-score-engine.md
@@ -20,7 +20,7 @@ The scoring engine expects these files in `$ARTIFACTS_DIR`:
 Run the scoring engine:
 
 ```bash
-cd $ARCHON_PROJECT_ROOT && bun run .archon/scripts/fund-score-engine.ts \
+bun run .archon/scripts/fund-score-engine.ts \
   --funds-file "$ARTIFACTS_DIR/fund_list.json" \
   --holdings-file "$ARTIFACTS_DIR/holdings_analysis.json" \
   --macro-file "$ARTIFACTS_DIR/macro_data.json" \

--- a/.archon/commands/fund-score-engine.md
+++ b/.archon/commands/fund-score-engine.md
@@ -1,0 +1,60 @@
+---
+description: Run the TypeScript scoring engine — six-dimension quantitative scoring + five-dimension screening
+argument-hint: (none — reads data files from artifacts)
+---
+
+# Fund Score Engine
+
+You are a quantitative analysis agent. Your task is to run the TypeScript scoring engine that computes six-dimension scores and five-dimension screenings for each fund.
+
+## Pre-requisite Data Files
+
+The scoring engine expects these files in `$ARTIFACTS_DIR`:
+- `fund_list.json` — Array of fund entries `[{code, name, category}, ...]`
+- `holdings_analysis.json` — (optional) Holdings data with FCF, efficiency, dividend, valuation, growth fields
+- `macro_data.json` — (optional) Macro indicator data
+- `news_analysis.json` — (optional) News sentiment analysis from fund-analyze-news
+
+## Task
+
+Run the scoring engine:
+
+```bash
+cd $ARCHON_PROJECT_ROOT && bun run .archon/scripts/fund-score-engine.ts \
+  --funds-file "$ARTIFACTS_DIR/fund_list.json" \
+  --holdings-file "$ARTIFACTS_DIR/holdings_analysis.json" \
+  --macro-file "$ARTIFACTS_DIR/macro_data.json" \
+  --news-file "$ARTIFACTS_DIR/news_analysis.json" \
+  --output "$ARTIFACTS_DIR/scoring_results.json"
+```
+
+## What the Engine Does
+
+The scoring engine applies:
+
+**Six-Dimension Quantitative Decision Framework**: FCF Quality, Capital Efficiency, Shareholder Return, Valuation Safety, Growth, Macro/Geopolitical Risk — each scored 0-10 with detailed reasoning.
+
+**Five-Dimension Screening Framework**: Fundamental Qualitative, Performance/Risk Quantitative, Holding Penetration, Manager Evaluation, Market/Technical — each returning PASS/WARN/FAIL.
+
+**Key Properties**:
+- Deterministic: No random fallbacks — missing data returns `null` scores instead of random estimates
+- Weighted composite: Computes a weighted average across available dimensions
+- Recommendation mapping: BUY (≥7.5, 0 fails), HOLD (≥6.0, ≤1 fail), REDUCE (≥4.0), SELL (<4.0)
+
+## After Execution
+
+1. Report the scoring summary:
+   - Total funds analyzed
+   - Count per recommendation tier (BUY/HOLD/REDUCE/SELL)
+   - Top 3 funds by composite score
+   - Bottom 3 funds by composite score
+2. Note any funds with all-null scores (insufficient data)
+3. The results are saved to `$ARTIFACTS_DIR/scoring_results.json`
+
+## Expected Duration
+
+<1 second (pure computation, no network calls)
+
+## Important
+
+If any required file is missing, the engine will still run with available data and use null for unavailable dimensions. Report the data coverage to the user.

--- a/.archon/config.yaml
+++ b/.archon/config.yaml
@@ -1,5 +1,8 @@
 worktree:
-  baseBranch: main
+  baseBranch: dev
+
+docs:
+  path: packages/docs-web/src/content/docs/
 
 fund_analysis:
   throttle_seconds: 300

--- a/.archon/config.yaml
+++ b/.archon/config.yaml
@@ -1,5 +1,19 @@
 worktree:
-  baseBranch: dev
+  baseBranch: main
 
-docs:
-  path: packages/docs-web/src/content/docs
+fund_analysis:
+  throttle_seconds: 300
+  max_retries: 3
+  fund_codes_file: "~/Data_share/基金OCR/基金-代码.txt"
+  data_cache_dir: "~/.archon/cache/fund-analysis"
+  six_dim_weights:
+    fcf_quality: 0.20
+    capital_efficiency: 0.18
+    shareholder_return: 0.15
+    valuation_safety: 0.18
+    growth: 0.17
+    macro_geopolitical: 0.12
+  news_sources:
+    - baidu
+    - eastmoney
+    - cctv

--- a/.archon/scripts/fund-data-collectors.py
+++ b/.archon/scripts/fund-data-collectors.py
@@ -14,6 +14,7 @@ import argparse
 import json
 import sys
 import time
+from functools import reduce
 
 
 def _check_import(module_name: str, pip_name: str | None = None) -> None:
@@ -82,8 +83,8 @@ def fetch_market_data() -> dict:
                     "pb_ratio": float(info.get("priceToBook", 0) or 0),
                     "volume": float(info.get("regularMarketVolume", 0) or 0),
                 })
-            except Exception:
-                pass
+            except Exception as exc:
+                result.setdefault("_errors", []).append(f"美股 {sym} 采集失败: {exc}")
     except Exception as exc:
         result["_errors"] = result.get("_errors", [])
         result["_errors"].append(f"美股采集失败: {exc}")
@@ -176,6 +177,10 @@ MACRO_FETCHERS: list[tuple[str, str]] = [
 ]
 
 
+def _resolve_attr(obj, path: str):
+    return reduce(getattr, path.split("."), obj)
+
+
 def fetch_macro_indicators() -> dict:
     """采集所有宏观指标。"""
     _check_import("akshare", "akshare")
@@ -186,7 +191,7 @@ def fetch_macro_indicators() -> dict:
 
     for indicator_name, func_ref in MACRO_FETCHERS:
         try:
-            func = eval(func_ref, {"ak": ak})
+            func = _resolve_attr(ak, func_ref)
             data = func()
             if data is None:
                 errors.append(f"指标 {indicator_name} 返回 None")
@@ -204,7 +209,7 @@ def fetch_macro_indicators() -> dict:
         time.sleep(1.0)  # akshare 请求节流
 
     results["_errors"] = errors
-    results["_success_count"] = sum(1 for v in results.values() if not isinstance(v, list) or v)
+    results["_success_count"] = sum(1 for k, v in results.items() if not k.startswith("_") and (not isinstance(v, list) or v))
     results["_total"] = len(MACRO_FETCHERS)
     return results
 
@@ -213,6 +218,8 @@ def fetch_macro_indicators() -> dict:
 # 新闻数据采集
 # ---------------------------------------------------------------------------
 
+# 当前仅使用 akshare 的 stock_info_global_em 作为主新闻源。
+# 多源采集（baidu/eastmoney/cctv）可通过 config.yaml 的 news_sources 在未来版本中启用。
 NEWS_SOURCES = {
     "baidu": "stock_zh_a_alerts_cls",
     "eastmoney": "stock_info_global_em",
@@ -257,26 +264,30 @@ def load_fund_list(codes_file: str | None = None) -> dict:
     优先从 codes_file（每行一个代码，格式：`代码 名称` 或 `代码,名称`），
     回退到 ~/Data_share/基金分析/基金持仓数据.csv 的代码列。
     """
-    import os
     import csv
+    import os
 
     funds: list[dict] = []
+    errors: list[str] = []
 
-    if codes_file and os.path.exists(codes_file):
-        with open(codes_file, encoding="utf-8") as f:
-            for line in f:
-                line = line.strip()
-                if not line or line.startswith("#"):
-                    continue
-                parts = line.replace(",", " ").split(None, 1)
-                code = parts[0].strip()
-                name = parts[1].strip() if len(parts) > 1 else ""
-                if code:
-                    funds.append({"code": code, "name": name, "category": ""})
-    else:
-        fallback_path = os.path.expanduser("~/Data_share/基金分析/基金持仓数据.csv")
-        if os.path.exists(fallback_path):
-            with open(fallback_path, newline="", encoding="utf-8-sig") as f:
+    def read_codes_file(path: str) -> None:
+        try:
+            with open(path, encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    parts = line.replace(",", " ").split(None, 1)
+                    code = parts[0].strip()
+                    name = parts[1].strip() if len(parts) > 1 else ""
+                    if code:
+                        funds.append({"code": code, "name": name, "category": ""})
+        except (IOError, OSError, UnicodeDecodeError) as exc:
+            errors.append(f"读取基金代码文件失败: {path} — {exc}")
+
+    def read_csv_fallback(path: str) -> None:
+        try:
+            with open(path, newline="", encoding="utf-8-sig") as f:
                 reader = csv.DictReader(f)
                 for row in reader:
                     code = row.get("基金代码", row.get("code", "")).strip()
@@ -284,8 +295,17 @@ def load_fund_list(codes_file: str | None = None) -> dict:
                     category = row.get("分类", row.get("category", ""))
                     if code:
                         funds.append({"code": code, "name": name or "", "category": category or ""})
+        except (IOError, OSError, UnicodeDecodeError) as exc:
+            errors.append(f"读取基金持仓CSV失败: {path} — {exc}")
 
-    return {"funds": funds, "_total": len(funds)}
+    if codes_file and os.path.exists(codes_file):
+        read_codes_file(codes_file)
+    else:
+        fallback_path = os.path.expanduser("~/Data_share/基金分析/基金持仓数据.csv")
+        if os.path.exists(fallback_path):
+            read_csv_fallback(fallback_path)
+
+    return {"funds": funds, "_total": len(funds), "_errors": errors}
 
 
 # ---------------------------------------------------------------------------

--- a/.archon/scripts/fund-data-collectors.py
+++ b/.archon/scripts/fund-data-collectors.py
@@ -1,0 +1,324 @@
+"""基金量化分析 — 精简数据采集器。
+
+通过 --action 子命令分发，每个函数独立采集并输出 JSON 到 stdout，
+供 Archon bash 节点捕获。
+
+用法:
+    uv run python .archon/scripts/fund-data-collectors.py --action market
+    uv run python .archon/scripts/fund-data-collectors.py --action macro
+    uv run python .archon/scripts/fund-data-collectors.py --action news
+    uv run python .archon/scripts/fund-data-collectors.py --action fund-list --codes-file <path>
+"""
+
+import argparse
+import json
+import sys
+import time
+
+
+def _check_import(module_name: str, pip_name: str | None = None) -> None:
+    try:
+        __import__(module_name)
+    except ImportError:
+        pkg = pip_name or module_name
+        print(json.dumps({"error": f"缺少Python包: {pkg}。请运行: uv pip install {pkg}"}), file=sys.stderr)
+        sys.exit(1)
+
+
+def _safe_json_default(obj):
+    """处理 datetime / Timestamp / numpy 类型的 JSON 序列化。"""
+    try:
+        return str(obj)
+    except Exception:
+        return repr(obj)
+
+
+# ---------------------------------------------------------------------------
+# 市场数据采集
+# ---------------------------------------------------------------------------
+
+US_STOCK_SYMBOLS = [
+    "AAPL", "MSFT", "GOOGL", "AMZN", "NVDA", "META", "TSLA", "BRK-B",
+    "JPM", "V", "JNJ", "WMT", "PG", "XOM", "UNH", "HD", "BAC", "MA",
+    "DIS", "ADBE", "NFLX", "CRM", "AMD", "INTC", "QCOM", "TXN", "AVGO",
+]
+
+A_INDEX_CODES = [
+    "000001", "399001", "399006", "000688", "000300", "000905", "000852",
+]
+
+A_INDEX_NAMES = {
+    "000001": "上证指数", "399001": "深证成指", "399006": "创业板指",
+    "000688": "科创50", "000300": "沪深300", "000905": "中证500", "000852": "中证1000",
+}
+
+
+def fetch_market_data() -> dict:
+    """采集全球市场行情数据。"""
+    _check_import("yfinance", "yfinance")
+    _check_import("akshare", "akshare")
+    import yfinance as yf
+    import akshare as ak
+
+    result: dict = {"us_stocks": [], "a_indices": [], "hk_stocks": [], "global_indices": []}
+
+    # 美股
+    try:
+        tickers = yf.Tickers(" ".join(US_STOCK_SYMBOLS))
+        for sym in US_STOCK_SYMBOLS:
+            try:
+                t = tickers.tickers.get(sym)
+                if t is None:
+                    continue
+                info = t.info or {}
+                fast = t.fast_info or {}
+                result["us_stocks"].append({
+                    "symbol": sym,
+                    "name": info.get("longName", info.get("shortName", "")),
+                    "market": "US",
+                    "latest_price": float(fast.get("last_price", 0) or info.get("regularMarketPrice", 0) or 0),
+                    "change_pct": float(info.get("regularMarketChangePercent", 0) or 0),
+                    "pe_ratio": float(info.get("trailingPE", 0) or 0),
+                    "pb_ratio": float(info.get("priceToBook", 0) or 0),
+                    "volume": float(info.get("regularMarketVolume", 0) or 0),
+                })
+            except Exception:
+                pass
+    except Exception as exc:
+        result["_errors"] = result.get("_errors", [])
+        result["_errors"].append(f"美股采集失败: {exc}")
+
+    # A股指数
+    try:
+        df = ak.stock_zh_index_spot_em()
+        if df is not None and not df.empty:
+            for _, row in df.iterrows():
+                code = str(row.get("代码", ""))
+                if code in A_INDEX_CODES:
+                    result["a_indices"].append({
+                        "symbol": code,
+                        "name": A_INDEX_NAMES.get(code, row.get("名称", "")),
+                        "latest_price": float(row.get("最新价", 0) or 0),
+                        "change_pct": float(row.get("涨跌幅", 0) or 0),
+                        "change_amount": float(row.get("涨跌额", 0) or 0),
+                        "volume": float(row.get("成交量", 0) or 0),
+                        "amount": float(row.get("成交额", 0) or 0),
+                    })
+    except Exception as exc:
+        result.setdefault("_errors", []).append(f"A股指数采集失败: {exc}")
+
+    # 港股
+    try:
+        df = ak.stock_hk_famous_spot_em()
+        if df is not None and not df.empty:
+            for _, row in df.iterrows():
+                result["hk_stocks"].append({
+                    "symbol": str(row.get("代码", "")),
+                    "name": str(row.get("名称", "")),
+                    "market": "HK",
+                    "latest_price": float(row.get("最新价", 0) or 0),
+                    "change_pct": float(row.get("涨跌幅", 0) or 0),
+                    "change_amount": float(row.get("涨跌额", 0) or 0),
+                    "volume": float(row.get("成交量", 0) or 0),
+                    "amount": float(row.get("成交额", 0) or 0),
+                })
+    except Exception as exc:
+        result.setdefault("_errors", []).append(f"港股采集失败: {exc}")
+
+    # 全球指数
+    try:
+        df = ak.index_global_spot_em()
+        if df is not None and not df.empty:
+            for _, row in df.iterrows():
+                result["global_indices"].append({
+                    "symbol": str(row.get("代码", "")),
+                    "name": str(row.get("名称", "")),
+                    "latest_price": float(row.get("最新价", 0) or 0),
+                    "change_pct": float(row.get("涨跌幅", 0) or 0),
+                })
+    except Exception as exc:
+        result.setdefault("_errors", []).append(f"全球指数采集失败: {exc}")
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 宏观数据采集 (精简版 — 仅用 akshare 公开函数)
+# ---------------------------------------------------------------------------
+
+MACRO_FETCHERS: list[tuple[str, str]] = [
+    ("PMI_MANUFACTURING", "ak.macro_china_pmi"),
+    ("PMI_NON_MANUFACTURING", "ak.macro_china_non_man_pmi"),
+    ("CPI_YOY", "ak.macro_china_cpi_yearly"),
+    ("CPI_MOM", "ak.macro_china_cpi_monthly"),
+    ("PPI_YOY", "ak.macro_china_ppi_yearly"),
+    ("GDP_YOY", "ak.macro_china_gdp_yearly"),
+    ("M2_YOY", "ak.macro_china_money_supply"),
+    ("LPR", "ak.macro_china_lpr"),
+    ("SHIBOR", "ak.macro_china_shibor_all"),
+    ("RMB_USD", "ak.macro_china_rmb"),
+    ("TRADE_BALANCE", "ak.macro_china_trade_balance"),
+    ("FX_GOLD_RESERVE", "ak.macro_china_fx_gold"),
+    ("USA_CPI_YOY", "ak.macro_usa_cpi_yoy"),
+    ("USA_PMI", "ak.macro_usa_pmi"),
+    ("USA_UNEMPLOYMENT", "ak.macro_usa_unemployment_rate"),
+    ("USA_GDP", "ak.macro_usa_gdp_monthly"),
+    ("USA_TRADE", "ak.macro_usa_trade_balance"),
+    ("USA_RETAIL", "ak.macro_usa_retail_sales"),
+    ("USA_NON_FARM", "ak.macro_usa_non_farm"),
+    ("USA_CONSUMER", "ak.macro_usa_cb_consumer_confidence"),
+    ("BDI", "ak.macro_shipping_bdi"),
+    ("GOLD_SPOT", "ak.macro_cons_gold"),
+    ("SILVER_SPOT", "ak.macro_cons_silver"),
+    ("GOLD_SGE", "ak.spot_golden_benchmark_sge"),
+    ("CN_US_SPREAD", "ak.bond_zh_us_rate"),
+    ("GLOBAL_INDEX", "ak.index_global_spot_em"),
+]
+
+
+def fetch_macro_indicators() -> dict:
+    """采集所有宏观指标。"""
+    _check_import("akshare", "akshare")
+    import akshare as ak
+
+    results: dict = {}
+    errors: list[str] = []
+
+    for indicator_name, func_ref in MACRO_FETCHERS:
+        try:
+            func = eval(func_ref, {"ak": ak})
+            data = func()
+            if data is None:
+                errors.append(f"指标 {indicator_name} 返回 None")
+                continue
+            if hasattr(data, "to_dict"):
+                temp = data.to_dict(orient="records")
+            elif isinstance(data, (list, dict)):
+                temp = data
+            else:
+                temp = str(data)
+            results[indicator_name] = temp
+        except Exception as exc:
+            errors.append(f"指标 {indicator_name} 采集失败: {exc}")
+
+        time.sleep(1.0)  # akshare 请求节流
+
+    results["_errors"] = errors
+    results["_success_count"] = sum(1 for v in results.values() if not isinstance(v, list) or v)
+    results["_total"] = len(MACRO_FETCHERS)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# 新闻数据采集
+# ---------------------------------------------------------------------------
+
+NEWS_SOURCES = {
+    "baidu": "stock_zh_a_alerts_cls",
+    "eastmoney": "stock_info_global_em",
+    "cctv": "stock_zh_a_alerts_cls",
+}
+
+
+def fetch_news_feed() -> dict:
+    """采集财经新闻信息流。"""
+    _check_import("akshare", "akshare")
+    import akshare as ak
+
+    items: list[dict] = []
+    errors: list[str] = []
+
+    # akshare 主要新闻接口 — stock_info_global_em
+    try:
+        df = ak.stock_info_global_em()
+        if df is not None and not df.empty:
+            for _, row in df.head(30).iterrows():
+                items.append({
+                    "title": str(row.get("标题", row.get("title", ""))),
+                    "source": row.get("来源", row.get("source", "eastmoney")),
+                    "url": row.get("链接", row.get("url", "")),
+                    "publish_time": str(row.get("发布时间", row.get("publish_time", ""))),
+                    "summary": str(row.get("摘要", row.get("summary", "")))[:200],
+                })
+    except Exception as exc:
+        errors.append(f"新闻接口采集失败: {exc}")
+
+    return {"items": items, "_errors": errors, "_total": len(items)}
+
+
+# ---------------------------------------------------------------------------
+# 基金列表加载
+# ---------------------------------------------------------------------------
+
+
+def load_fund_list(codes_file: str | None = None) -> dict:
+    """加载基金代码列表。
+
+    优先从 codes_file（每行一个代码，格式：`代码 名称` 或 `代码,名称`），
+    回退到 ~/Data_share/基金分析/基金持仓数据.csv 的代码列。
+    """
+    import os
+    import csv
+
+    funds: list[dict] = []
+
+    if codes_file and os.path.exists(codes_file):
+        with open(codes_file, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                parts = line.replace(",", " ").split(None, 1)
+                code = parts[0].strip()
+                name = parts[1].strip() if len(parts) > 1 else ""
+                if code:
+                    funds.append({"code": code, "name": name, "category": ""})
+    else:
+        fallback_path = os.path.expanduser("~/Data_share/基金分析/基金持仓数据.csv")
+        if os.path.exists(fallback_path):
+            with open(fallback_path, newline="", encoding="utf-8-sig") as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    code = row.get("基金代码", row.get("code", "")).strip()
+                    name = row.get("基金名称", row.get("name", ""))
+                    category = row.get("分类", row.get("category", ""))
+                    if code:
+                        funds.append({"code": code, "name": name or "", "category": category or ""})
+
+    return {"funds": funds, "_total": len(funds)}
+
+
+# ---------------------------------------------------------------------------
+# CLI 入口
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="基金量化分析数据采集器")
+    parser.add_argument("--action", required=True, choices=["market", "macro", "news", "fund-list"])
+    parser.add_argument("--codes-file", help="基金代码文件路径 (仅 fund-list)")
+    args = parser.parse_args()
+
+    result: dict = {}
+
+    try:
+        if args.action == "market":
+            result = fetch_market_data()
+        elif args.action == "macro":
+            result = fetch_macro_indicators()
+        elif args.action == "news":
+            result = fetch_news_feed()
+        elif args.action == "fund-list":
+            result = load_fund_list(args.codes_file)
+    except SystemExit:
+        raise
+    except Exception as exc:
+        result = {"_error": str(exc), "_action": args.action}
+        print(json.dumps(result, ensure_ascii=False, default=_safe_json_default))
+        sys.exit(1)
+
+    print(json.dumps(result, ensure_ascii=False, default=_safe_json_default))
+
+
+if __name__ == "__main__":
+    main()

--- a/.archon/scripts/fund-report-generator.test.ts
+++ b/.archon/scripts/fund-report-generator.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "bun:test";
-import { generateCsvExport, generateJsonSummary, generateMarkdownReport } from "./fund-report-generator";
+import { afterEach, describe, expect, it } from "bun:test";
+import { generateAllReports, generateCsvExport, generateJsonSummary, generateMarkdownReport, parseArgs } from "./fund-report-generator";
 
 const mockAnalysis = {
   fundCode: "001323",
@@ -75,6 +75,146 @@ describe("generateJsonSummary", () => {
     expect(parsed.totalFunds).toBe(1);
     expect(parsed.analyses[0].fundCode).toBe("001323");
     expect(parsed.recommendations.HOLD).toBe(1);
+    try { unlinkSync(path); } catch { /* cleanup */ }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+describe("parseArgs", () => {
+  const saved = [...Bun.argv];
+
+  afterEach(() => {
+    Bun.argv = saved;
+  });
+
+  it("parses --scores", () => {
+    Bun.argv = ["bun", "script.ts", "--scores", "scores.json"];
+    const args = parseArgs();
+    expect(args.scoresFile).toBe("scores.json");
+  });
+
+  it("parses --output-dir", () => {
+    Bun.argv = ["bun", "script.ts", "--output-dir", "/tmp/out"];
+    const args = parseArgs();
+    expect(args.outputDir).toBe("/tmp/out");
+  });
+
+  it("parses both args", () => {
+    Bun.argv = ["bun", "script.ts", "--scores", "s.json", "--output-dir", "/tmp"];
+    const args = parseArgs();
+    expect(args.scoresFile).toBe("s.json");
+    expect(args.outputDir).toBe("/tmp");
+  });
+
+  it("returns empty object when no args", () => {
+    Bun.argv = ["bun", "script.ts"];
+    const args = parseArgs();
+    expect(args.scoresFile).toBeUndefined();
+    expect(args.outputDir).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateAllReports orchestrator
+// ---------------------------------------------------------------------------
+
+describe("generateAllReports", () => {
+  it("returns all three report paths", () => {
+    const paths = generateAllReports(mockAnalyses);
+    expect(paths.markdown).toBeTruthy();
+    expect(paths.csv).toBeTruthy();
+    expect(paths.json).toBeTruthy();
+    const { existsSync, unlinkSync } = require("node:fs");
+    expect(existsSync(paths.markdown)).toBe(true);
+    expect(existsSync(paths.csv)).toBe(true);
+    expect(existsSync(paths.json)).toBe(true);
+    try { unlinkSync(paths.markdown); } catch { /* cleanup */ }
+    try { unlinkSync(paths.csv); } catch { /* cleanup */ }
+    try { unlinkSync(paths.json); } catch { /* cleanup */ }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CSV comma escaping
+// ---------------------------------------------------------------------------
+
+describe("generateCsvExport escaping", () => {
+  it("escapes commas in fund name", () => {
+    const analyses = [{
+      ...mockAnalysis,
+      fundName: "测试,基金",
+      fundCode: "001323",
+    }];
+    const path = generateCsvExport(analyses);
+    const { readFileSync, unlinkSync } = require("node:fs");
+    const content = readFileSync(path, "utf-8");
+    expect(content).toContain('"测试,基金"');
+    try { unlinkSync(path); } catch { /* cleanup */ }
+  });
+
+  it("escapes quotes in risk warnings", () => {
+    const analyses = [{
+      ...mockAnalysis,
+      riskWarnings: ['包含"引号"的警告'],
+    }];
+    const path = generateCsvExport(analyses);
+    const { readFileSync, unlinkSync } = require("node:fs");
+    const content = readFileSync(path, "utf-8");
+    expect(content).toContain('"包含""引号""的警告"');
+    try { unlinkSync(path); } catch { /* cleanup */ }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// News impact table rendering
+// ---------------------------------------------------------------------------
+
+describe("generateMarkdownReport with news", () => {
+  it("renders news impact table when news data present", () => {
+    const newsDigest = {
+      overallSentiment: "MIXED" as const,
+      summaryText: "市场情绪复杂，多空交织",
+      impacts: [{
+        newsTitle: "央行降息",
+        economicImpact: "POSITIVE" as const,
+        confidenceScore: 0.85,
+        affectedSectors: ["金融", "地产", "消费"],
+      }],
+    };
+    const path = generateMarkdownReport(mockAnalyses, null, newsDigest);
+    const { readFileSync, unlinkSync } = require("node:fs");
+    const content = readFileSync(path, "utf-8");
+    expect(content).toContain("整体情绪");
+    expect(content).toContain("央行降息");
+    expect(content).toContain("🟢 POSITIVE");
+    expect(content).toContain("85%");
+    expect(content).toContain("金融");
+    try { unlinkSync(path); } catch { /* cleanup */ }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multi-fund sorting test
+// ---------------------------------------------------------------------------
+
+describe("generateMarkdownReport multi-fund", () => {
+  it("sorts by composite score descending", () => {
+    const analyses = [
+      { ...mockAnalysis, fundCode: "001", compositeScore: 5.0, fundName: "Low" },
+      { ...mockAnalysis, fundCode: "002", compositeScore: 9.0, fundName: "High" },
+      { ...mockAnalysis, fundCode: "003", compositeScore: 7.0, fundName: "Mid" },
+    ];
+    const path = generateMarkdownReport(analyses);
+    const { readFileSync, unlinkSync } = require("node:fs");
+    const content = readFileSync(path, "utf-8");
+    const highPos = content.indexOf("High");
+    const midPos = content.indexOf("Mid");
+    const lowPos = content.indexOf("Low");
+    expect(highPos).toBeLessThan(midPos);
+    expect(midPos).toBeLessThan(lowPos);
     try { unlinkSync(path); } catch { /* cleanup */ }
   });
 });

--- a/.archon/scripts/fund-report-generator.test.ts
+++ b/.archon/scripts/fund-report-generator.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "bun:test";
+import { generateCsvExport, generateJsonSummary, generateMarkdownReport } from "./fund-report-generator";
+
+const mockAnalysis = {
+  fundCode: "001323",
+  fundName: "测试基金",
+  fundCategory: "偏股",
+  sixDimScores: {
+    fcfQuality: 7.5,
+    capitalEfficiency: 8.0,
+    shareholderReturn: 6.5,
+    valuationSafety: 7.0,
+    growth: 7.5,
+    macroGeopolitical: 6.0,
+  },
+  fiveDimScreening: {
+    fundamentalQualitative: "PASS" as const,
+    performanceRiskQuant: "PASS" as const,
+    holdingPenetration: "PASS" as const,
+    managerEvaluation: "PASS" as const,
+    marketTechnical: "WARN" as const,
+  },
+  compositeScore: 7.2,
+  recommendation: "HOLD" as const,
+  riskWarnings: ["宏观地缘风险较高 (6.0/10)"],
+  analysisSummary: "六维综合评分: 7.2/10 (HOLD)",
+  dataQuality: 0.7,
+};
+
+const mockAnalyses = [mockAnalysis];
+
+describe("generateMarkdownReport", () => {
+  it("generates Markdown with all sections", () => {
+    const path = generateMarkdownReport(mockAnalyses);
+    const { readFileSync, unlinkSync } = require("node:fs");
+    const content = readFileSync(path, "utf-8");
+    expect(content).toContain("# 基金投资分析报告");
+    expect(content).toContain("## 一、宏观概览");
+    expect(content).toContain("## 二、新闻影响摘要");
+    expect(content).toContain("## 三、基金分析详情");
+    expect(content).toContain("## 四、投资建议汇总");
+    expect(content).toContain("## 五、风险提示");
+    expect(content).toContain("001323");
+    expect(content).toContain("测试基金");
+    try { unlinkSync(path); } catch { /* cleanup */ }
+  });
+
+  it("handles empty analysis list", () => {
+    const path = generateMarkdownReport([]);
+    const { readFileSync, unlinkSync } = require("node:fs");
+    const content = readFileSync(path, "utf-8");
+    expect(content).toContain("# 基金投资分析报告");
+    try { unlinkSync(path); } catch { /* cleanup */ }
+  });
+});
+
+describe("generateCsvExport", () => {
+  it("generates CSV with headers and data row", () => {
+    const path = generateCsvExport(mockAnalyses);
+    const { readFileSync, unlinkSync } = require("node:fs");
+    const content = readFileSync(path, "utf-8");
+    expect(content).toContain("基金代码");
+    expect(content).toContain("001323");
+    expect(content).toContain("HOLD");
+    try { unlinkSync(path); } catch { /* cleanup */ }
+  });
+});
+
+describe("generateJsonSummary", () => {
+  it("generates valid JSON with analysis data", () => {
+    const path = generateJsonSummary(mockAnalyses);
+    const { readFileSync, unlinkSync } = require("node:fs");
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw);
+    expect(parsed.totalFunds).toBe(1);
+    expect(parsed.analyses[0].fundCode).toBe("001323");
+    expect(parsed.recommendations.HOLD).toBe(1);
+    try { unlinkSync(path); } catch { /* cleanup */ }
+  });
+});

--- a/.archon/scripts/fund-report-generator.ts
+++ b/.archon/scripts/fund-report-generator.ts
@@ -97,7 +97,9 @@ function timestamp(): string {
 }
 
 function ensureOutputDir(path: string): void {
-  const dir = path.substring(0, path.lastIndexOf("/"));
+  const sep = path.lastIndexOf("/");
+  if (sep <= 0) return; // no directory component, assume cwd
+  const dir = path.substring(0, sep);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 }
 
@@ -347,7 +349,7 @@ interface CliArgs {
   outputDir?: string;
 }
 
-function parseArgs(): CliArgs {
+export function parseArgs(): CliArgs {
   const args = Bun.argv.slice(2);
   const result: CliArgs = {};
   for (let i = 0; i < args.length; i++) {
@@ -357,20 +359,42 @@ function parseArgs(): CliArgs {
   return result;
 }
 
-const cliArgs = parseArgs();
-if (cliArgs.scoresFile || cliArgs.outputDir) {
+async function runCli(): Promise<void> {
+  const cliArgs = parseArgs();
+  if (!cliArgs.scoresFile && !cliArgs.outputDir) return;
+
   let analyses: FundAnalysisResult[] = [];
-  if (cliArgs.scoresFile && existsSync(cliArgs.scoresFile)) {
-    analyses = JSON.parse(await import("node:fs").then((m) => m.readFileSync(cliArgs.scoresFile, "utf-8")));
+  if (cliArgs.scoresFile) {
+    if (!existsSync(cliArgs.scoresFile)) {
+      console.error(`Scores file not found: ${cliArgs.scoresFile}`);
+      process.exit(1);
+    }
+    try {
+      const raw = await import("node:fs").then((m) => m.readFileSync(cliArgs.scoresFile, "utf-8"));
+      analyses = JSON.parse(raw);
+    } catch (err) {
+      const message = err instanceof SyntaxError
+        ? `Invalid JSON in scores file: ${cliArgs.scoresFile}`
+        : `Failed to read scores file: ${cliArgs.scoresFile} — ${(err as Error).message}`;
+      console.error(message);
+      process.exit(1);
+    }
   }
 
   if (cliArgs.outputDir) {
     process.env.ARTIFACTS_DIR = cliArgs.outputDir;
   }
 
-  const paths = generateAllReports(analyses);
-  console.log("报告生成完成:");
-  console.log(`  Markdown: ${paths.markdown}`);
-  console.log(`  CSV: ${paths.csv}`);
-  console.log(`  JSON: ${paths.json}`);
+  try {
+    const paths = generateAllReports(analyses);
+    console.log("报告生成完成:");
+    console.log(`  Markdown: ${paths.markdown}`);
+    console.log(`  CSV: ${paths.csv}`);
+    console.log(`  JSON: ${paths.json}`);
+  } catch (err) {
+    console.error(`Report generation failed: ${(err as Error).message}`);
+    process.exit(1);
+  }
 }
+
+runCli();

--- a/.archon/scripts/fund-report-generator.ts
+++ b/.archon/scripts/fund-report-generator.ts
@@ -1,0 +1,376 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Types (mirrored from fund-score-engine)
+// ---------------------------------------------------------------------------
+
+type Recommendation = "BUY" | "HOLD" | "REDUCE" | "SELL";
+
+interface SixDimScores {
+  fcfQuality: number | null;
+  capitalEfficiency: number | null;
+  shareholderReturn: number | null;
+  valuationSafety: number | null;
+  growth: number | null;
+  macroGeopolitical: number;
+}
+
+interface FiveDimScreening {
+  fundamentalQualitative: "PASS" | "WARN" | "FAIL";
+  performanceRiskQuant: "PASS" | "WARN" | "FAIL";
+  holdingPenetration: "PASS" | "WARN" | "FAIL";
+  managerEvaluation: "PASS" | "WARN" | "FAIL";
+  marketTechnical: "PASS" | "WARN" | "FAIL";
+}
+
+interface FundAnalysisResult {
+  fundCode: string;
+  fundName: string;
+  fundCategory: string;
+  sixDimScores: SixDimScores;
+  fiveDimScreening: FiveDimScreening;
+  compositeScore: number;
+  recommendation: Recommendation;
+  riskWarnings: string[];
+  analysisSummary: string;
+  dataQuality: number;
+}
+
+interface NewsSentiment {
+  overallSentiment: "POSITIVE" | "NEGATIVE" | "NEUTRAL" | "MIXED";
+  summaryText?: string;
+  impacts?: Array<{
+    newsTitle: string;
+    economicImpact: string;
+    confidenceScore: number;
+    affectedSectors: string[];
+  }>;
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+function formatScoreColor(score: number): string {
+  if (score >= 7.5) return `🟢 ${score.toFixed(1)}`;
+  if (score >= 5.0) return `🟡 ${score.toFixed(1)}`;
+  return `🔴 ${score.toFixed(1)}`;
+}
+
+function recommendationIcon(rec: Recommendation): string {
+  switch (rec) {
+    case "BUY": return "🟢 **买入**";
+    case "HOLD": return "🟡 **持有**";
+    case "REDUCE": return "🟠 **减仓**";
+    case "SELL": return "🔴 **卖出**";
+  }
+}
+
+function statusIcon(status: string): string {
+  switch (status) {
+    case "PASS": return "✅";
+    case "WARN": return "⚠️";
+    case "FAIL": return "❌";
+    default: return "?";
+  }
+}
+
+function newsEmoji(impact: string): string {
+  switch (impact) {
+    case "POSITIVE": return "🟢";
+    case "NEGATIVE": return "🔴";
+    case "NEUTRAL": return "⚪";
+    case "MIXED": return "🟠";
+    default: return "⚪";
+  }
+}
+
+function timestamp(): string {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  const h = String(now.getHours()).padStart(2, "0");
+  const min = String(now.getMinutes()).padStart(2, "0");
+  return `${y}年${m}月${d}日 ${h}:${min}`;
+}
+
+function ensureOutputDir(path: string): void {
+  const dir = path.substring(0, path.lastIndexOf("/"));
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+// ---------------------------------------------------------------------------
+// Markdown Report
+// ---------------------------------------------------------------------------
+
+export function generateMarkdownReport(
+  analyses: FundAnalysisResult[],
+  macroData?: Record<string, unknown> | null,
+  newsDigest?: NewsSentiment | null,
+  outputPath?: string,
+): string {
+  const artifactsDir = process.env.ARTIFACTS_DIR ?? "./artifacts";
+  if (!outputPath) outputPath = join(artifactsDir, "基金投资分析报告.md");
+  ensureOutputDir(outputPath);
+
+  const nowStr = timestamp();
+  const sorted = analyses.toSorted((a, b) => b.compositeScore - a.compositeScore);
+
+  const lines: string[] = [
+    `# 基金投资分析报告 (${nowStr})`,
+    "",
+    "**分析框架**: 六维量化决策 + 五维筛选框架",
+    "**数据来源**: akshare / yfinance / Claude AI新闻分析",
+    "",
+    "---",
+    "",
+  ];
+
+  // Section 1: Macro Overview
+  lines.push("## 一、宏观概览", "");
+  if (newsDigest?.summaryText) {
+    lines.push(`**新闻情绪概况**: ${newsDigest.summaryText}`, "");
+  }
+  if (macroData) {
+    const entries = Object.entries(macroData).filter(
+      ([, v]) => v !== null && (!Array.isArray(v) || v.length > 0),
+    );
+    if (entries.length > 0) {
+      lines.push("| 指标 | 状态 |", "| :--- | :--- |");
+      for (const [name, val] of entries.slice(0, 20)) {
+        const rowCount = Array.isArray(val) ? val.length : 1;
+        lines.push(`| ${name} | ✅ 已采集 (${rowCount} 行) |`);
+      }
+    } else {
+      lines.push("| -- | 暂无宏观数据 |");
+    }
+    lines.push("");
+  }
+
+  // Section 2: News Impact
+  lines.push("---", "", "## 二、新闻影响摘要", "");
+  if (newsDigest?.impacts && newsDigest.impacts.length > 0) {
+    lines.push(`**整体情绪**: ${newsDigest.overallSentiment}`, "");
+    lines.push("| 新闻标题 | 影响 | 置信度 | 关连板块 |", "| :--- | :--- | :--- | :--- |");
+    for (const impact of newsDigest.impacts.slice(0, 15)) {
+      const title = impact.newsTitle.slice(0, 50);
+      const conf = `${Math.round(impact.confidenceScore * 100)}%`;
+      const sectors = impact.affectedSectors.slice(0, 3).join(", ");
+      lines.push(
+        `| ${title} | ${newsEmoji(impact.economicImpact)} ${impact.economicImpact} | ${conf} | ${sectors} |`,
+      );
+    }
+    lines.push("");
+  } else {
+    lines.push("暂无新闻分析数据（可能未配置 LLM API 密钥）", "");
+  }
+
+  // Section 3: Fund Analysis Details
+  lines.push("---", "", "## 三、基金分析详情", "");
+
+  for (let i = 0; i < sorted.length; i++) {
+    const a = sorted[i];
+    const s = a.sixDimScores;
+    const f = a.fiveDimScreening;
+
+    lines.push(`### ${i + 1}. ${a.fundName} (\`${a.fundCode}\`)`, "");
+    lines.push(`- **综合评分**: ${formatScoreColor(a.compositeScore)} / 10`);
+    lines.push(`- **投资建议**: ${recommendationIcon(a.recommendation)}`);
+    lines.push(`- **数据质量**: ${Math.round(a.dataQuality * 100)}%`, "");
+
+    lines.push("#### 六维评分", "");
+    lines.push("| 维度 | 评分 | 说明 |", "| :--- | :--- | :--- |");
+    const scoreCol = (s: number | null) => s !== null ? formatScoreColor(s) : "⚪ N/A";
+    lines.push(`| FCF质量 | ${scoreCol(s.fcfQuality)} | 自由现金流质量 |`);
+    lines.push(`| 资本效率 | ${scoreCol(s.capitalEfficiency)} | ROE/ROIC/资产周转率 |`);
+    lines.push(`| 股东回报 | ${scoreCol(s.shareholderReturn)} | 股息率/回购/分红 |`);
+    lines.push(`| 估值安全边际 | ${scoreCol(s.valuationSafety)} | PE/PB/PEG分位数 |`);
+    lines.push(`| 成长性 | ${scoreCol(s.growth)} | 营收/利润增长率 |`);
+    lines.push(`| 宏观地缘风险 | ${formatScoreColor(s.macroGeopolitical)} | 高分=低风险 |`);
+    lines.push("");
+
+    lines.push("#### 五维筛选", "");
+    lines.push("| 筛选维度 | 结果 |", "| :--- | :--- |");
+    lines.push(`| 基本面定性 | ${statusIcon(f.fundamentalQualitative)} ${f.fundamentalQualitative} |`);
+    lines.push(`| 业绩风险量化 | ${statusIcon(f.performanceRiskQuant)} ${f.performanceRiskQuant} |`);
+    lines.push(`| 持仓穿透 | ${statusIcon(f.holdingPenetration)} ${f.holdingPenetration} |`);
+    lines.push(`| 基金经理 | ${statusIcon(f.managerEvaluation)} ${f.managerEvaluation} |`);
+    lines.push(`| 市场技术面 | ${statusIcon(f.marketTechnical)} ${f.marketTechnical} |`);
+    lines.push("");
+
+    if (a.riskWarnings.length > 0) {
+      lines.push("#### 风险提示", "");
+      for (const w of a.riskWarnings) {
+        lines.push(`- ⚠️ ${w}`);
+      }
+      lines.push("");
+    }
+  }
+
+  // Section 4: Summary Table
+  lines.push("---", "", "## 四、投资建议汇总", "");
+  lines.push("| 基金名称 | 代码 | 综合评分 | 建议 |", "| :--- | :--- | :--- | :--- |");
+  for (const a of sorted) {
+    lines.push(
+      `| ${a.fundName} | \`${a.fundCode}\` | ${formatScoreColor(a.compositeScore)} | ${recommendationIcon(a.recommendation)} |`,
+    );
+  }
+  lines.push("");
+
+  // Section 5: Disclaimer
+  lines.push("---", "", "## 五、风险提示", "");
+  lines.push("- 本报告由量化模型自动生成，仅供投资参考，不构成直接投资建议。");
+  lines.push("- 数据采集可能因网络或API限制而不完整，分析结果基于可获取数据的最大估计。");
+  lines.push("- 投资有风险，入市需谨慎。过往业绩不代表未来表现。");
+  lines.push("");
+
+  const content = lines.join("\n");
+  writeFileSync(outputPath, content, "utf-8");
+  return outputPath;
+}
+
+// ---------------------------------------------------------------------------
+// CSV Export
+// ---------------------------------------------------------------------------
+
+export function generateCsvExport(
+  analyses: FundAnalysisResult[],
+  outputPath?: string,
+): string {
+  const artifactsDir = process.env.ARTIFACTS_DIR ?? "./artifacts";
+  if (!outputPath) outputPath = join(artifactsDir, "基金分析结果.csv");
+  ensureOutputDir(outputPath);
+
+  const headers = [
+    "基金代码", "基金名称", "分类", "综合评分", "投资建议",
+    "FCF质量", "资本效率", "股东回报", "估值安全边际", "成长性", "宏观地缘风险",
+    "基本面筛选", "业绩风险筛选", "持仓穿透筛选", "基金经理筛选", "市场技术筛选",
+    "风险警告", "数据质量",
+  ];
+
+  const rows = analyses.map((a) => {
+    const s = a.sixDimScores;
+    const f = a.fiveDimScreening;
+    const n = (v: number | null) => v !== null ? v.toFixed(1) : "N/A";
+    return [
+      a.fundCode, a.fundName, a.fundCategory,
+      a.compositeScore.toFixed(1), a.recommendation,
+      n(s.fcfQuality), n(s.capitalEfficiency), n(s.shareholderReturn),
+      n(s.valuationSafety), n(s.growth), s.macroGeopolitical.toFixed(1),
+      f.fundamentalQualitative, f.performanceRiskQuant, f.holdingPenetration,
+      f.managerEvaluation, f.marketTechnical,
+      a.riskWarnings.join("; "),
+      `${Math.round(a.dataQuality * 100)}%`,
+    ].map((v) => {
+      // CSV escape: wrap fields with commas or quotes
+      if (String(v).includes(",") || String(v).includes('"') || String(v).includes("\n")) {
+        return `"${String(v).replace(/"/g, '""')}"`;
+      }
+      return String(v);
+    }).join(",");
+  });
+
+  // UTF-8 BOM for Excel compatibility
+  const bom = "﻿";
+  const content = bom + [headers.join(","), ...rows].join("\n");
+  writeFileSync(outputPath, content, "utf-8");
+  return outputPath;
+}
+
+// ---------------------------------------------------------------------------
+// JSON Summary
+// ---------------------------------------------------------------------------
+
+export function generateJsonSummary(
+  analyses: FundAnalysisResult[],
+  macroData?: Record<string, unknown> | null,
+  newsDigest?: NewsSentiment | null,
+  outputPath?: string,
+): string {
+  const artifactsDir = process.env.ARTIFACTS_DIR ?? "./artifacts";
+  if (!outputPath) outputPath = join(artifactsDir, "基金分析结果.json");
+  ensureOutputDir(outputPath);
+
+  const payload = {
+    generatedAt: new Date().toISOString(),
+    newsSentiment: newsDigest?.overallSentiment ?? "UNKNOWN",
+    macroIndicatorCount: macroData ? Object.keys(macroData).length : 0,
+    totalFunds: analyses.length,
+    recommendations: {
+      BUY: analyses.filter((a) => a.recommendation === "BUY").length,
+      HOLD: analyses.filter((a) => a.recommendation === "HOLD").length,
+      REDUCE: analyses.filter((a) => a.recommendation === "REDUCE").length,
+      SELL: analyses.filter((a) => a.recommendation === "SELL").length,
+    },
+    analyses: analyses.map((a) => ({
+      fundCode: a.fundCode,
+      fundName: a.fundName,
+      fundCategory: a.fundCategory,
+      compositeScore: a.compositeScore,
+      recommendation: a.recommendation,
+      sixDimScores: a.sixDimScores,
+      fiveDimScreening: a.fiveDimScreening,
+      riskWarnings: a.riskWarnings,
+      analysisSummary: a.analysisSummary,
+      dataQuality: a.dataQuality,
+    })),
+  };
+
+  writeFileSync(outputPath, JSON.stringify(payload, null, 2), "utf-8");
+  return outputPath;
+}
+
+// ---------------------------------------------------------------------------
+// Generate All Reports
+// ---------------------------------------------------------------------------
+
+export function generateAllReports(
+  analyses: FundAnalysisResult[],
+  macroData?: Record<string, unknown> | null,
+  newsDigest?: NewsSentiment | null,
+): Record<string, string> {
+  return {
+    markdown: generateMarkdownReport(analyses, macroData, newsDigest),
+    csv: generateCsvExport(analyses),
+    json: generateJsonSummary(analyses, macroData, newsDigest),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+interface CliArgs {
+  scoresFile?: string;
+  outputDir?: string;
+}
+
+function parseArgs(): CliArgs {
+  const args = Bun.argv.slice(2);
+  const result: CliArgs = {};
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--scores" && args[i + 1]) { result.scoresFile = args[i + 1]; i++; }
+    else if (args[i] === "--output-dir" && args[i + 1]) { result.outputDir = args[i + 1]; i++; }
+  }
+  return result;
+}
+
+const cliArgs = parseArgs();
+if (cliArgs.scoresFile || cliArgs.outputDir) {
+  let analyses: FundAnalysisResult[] = [];
+  if (cliArgs.scoresFile && existsSync(cliArgs.scoresFile)) {
+    analyses = JSON.parse(await import("node:fs").then((m) => m.readFileSync(cliArgs.scoresFile, "utf-8")));
+  }
+
+  if (cliArgs.outputDir) {
+    process.env.ARTIFACTS_DIR = cliArgs.outputDir;
+  }
+
+  const paths = generateAllReports(analyses);
+  console.log("报告生成完成:");
+  console.log(`  Markdown: ${paths.markdown}`);
+  console.log(`  CSV: ${paths.csv}`);
+  console.log(`  JSON: ${paths.json}`);
+}

--- a/.archon/scripts/fund-score-engine.test.ts
+++ b/.archon/scripts/fund-score-engine.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import {
   analyzeFund,
   analyzeFunds,
@@ -9,6 +9,7 @@ import {
   evaluateMacroRisk,
   evaluateShareholderReturn,
   evaluateValuationSafety,
+  parseCliArgs,
   screenFundamentalQualitative,
   screenHoldingPenetration,
   screenManagerEvaluation,
@@ -334,5 +335,117 @@ describe("analyzeFunds", () => {
     expect(results.length).toBe(2);
     expect(results[0].fundCode).toBe("001");
     expect(results[1].fundCode).toBe("002");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+describe("parseCliArgs", () => {
+  const saved = [...Bun.argv];
+
+  afterEach(() => {
+    Bun.argv = saved;
+  });
+
+  it("parses --funds-file", () => {
+    Bun.argv = ["bun", "script.ts", "--funds-file", "funds.json"];
+    const args = parseCliArgs();
+    expect(args.fundsFile).toBe("funds.json");
+  });
+
+  it("parses --holdings-file", () => {
+    Bun.argv = ["bun", "script.ts", "--holdings-file", "holdings.json"];
+    const args = parseCliArgs();
+    expect(args.holdingsFile).toBe("holdings.json");
+  });
+
+  it("parses --output", () => {
+    Bun.argv = ["bun", "script.ts", "--output", "results.json"];
+    const args = parseCliArgs();
+    expect(args.output).toBe("results.json");
+  });
+
+  it("parses multiple args together", () => {
+    Bun.argv = ["bun", "script.ts", "--funds-file", "f.json", "--macro-file", "m.json", "--output", "o.json"];
+    const args = parseCliArgs();
+    expect(args.fundsFile).toBe("f.json");
+    expect(args.macroFile).toBe("m.json");
+    expect(args.output).toBe("o.json");
+  });
+
+  it("returns empty object when no args", () => {
+    Bun.argv = ["bun", "script.ts"];
+    const args = parseCliArgs();
+    expect(args.fundsFile).toBeUndefined();
+    expect(args.output).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Extended evaluateMacroRisk tests
+// ---------------------------------------------------------------------------
+
+describe("evaluateMacroRisk extended", () => {
+  it("MIXED sentiment reduces score slightly", () => {
+    const base = evaluateMacroRisk("股票");
+    const mixed = evaluateMacroRisk("股票", { overallSentiment: "MIXED" });
+    expect(mixed.score).toBeLessThan(base.score);
+  });
+
+  it("gold spot > 2% reduces score (risk-off signal)", () => {
+    const base = evaluateMacroRisk("股票");
+    const withGold = evaluateMacroRisk("股票", null, {
+      GOLD_SPOT: [{ 涨跌幅: 3.0 }],
+    });
+    expect(withGold.score).toBeLessThan(base.score);
+  });
+
+  it("gold spot ≤ 2% does not reduce score", () => {
+    const base = evaluateMacroRisk("股票");
+    const withGold = evaluateMacroRisk("股票", null, {
+      GOLD_SPOT: [{ 涨跌幅: 1.5 }],
+    });
+    expect(withGold.score).toBe(base.score);
+  });
+
+  it("empty gold array does not crash", () => {
+    const result = evaluateMacroRisk("股票", null, { GOLD_SPOT: [] });
+    expect(result.score).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WARN boundary condition tests
+// ---------------------------------------------------------------------------
+
+describe("screenPerformanceRiskQuant boundaries", () => {
+  it("WARN when drawdown > 0.25", () => {
+    expect(screenPerformanceRiskQuant({ sharpeRatio: 0.5, maxDrawdown: 0.3, volatility: 0.15 })).toBe("WARN");
+  });
+
+  it("WARN when volatility > 0.3", () => {
+    expect(screenPerformanceRiskQuant({ sharpeRatio: 0.5, maxDrawdown: 0.1, volatility: 0.35 })).toBe("WARN");
+  });
+});
+
+describe("screenHoldingPenetration boundaries", () => {
+  it("WARN when top10 > 0.5", () => {
+    expect(screenHoldingPenetration({ top10Concentration: 0.55, sectorCount: 5 })).toBe("WARN");
+  });
+
+  it("WARN when sectors < 3", () => {
+    expect(screenHoldingPenetration({ top10Concentration: 0.3, sectorCount: 2 })).toBe("WARN");
+  });
+});
+
+describe("screenManagerEvaluation boundaries", () => {
+  it("WARN when experience < 3 years", () => {
+    expect(screenManagerEvaluation({ experienceYears: 2.5, managedFunds: 2 })).toBe("WARN");
+  });
+
+  it("WARN when managing more than 5 funds", () => {
+    expect(screenManagerEvaluation({ experienceYears: 8, managedFunds: 6 })).toBe("WARN");
   });
 });

--- a/.archon/scripts/fund-score-engine.test.ts
+++ b/.archon/scripts/fund-score-engine.test.ts
@@ -1,0 +1,338 @@
+import { describe, expect, it } from "bun:test";
+import {
+  analyzeFund,
+  analyzeFunds,
+  computeComposite,
+  evaluateCapitalEfficiency,
+  evaluateFcfQuality,
+  evaluateGrowth,
+  evaluateMacroRisk,
+  evaluateShareholderReturn,
+  evaluateValuationSafety,
+  screenFundamentalQualitative,
+  screenHoldingPenetration,
+  screenManagerEvaluation,
+  screenMarketTechnical,
+  screenPerformanceRiskQuant,
+} from "./fund-score-engine";
+
+// ---------------------------------------------------------------------------
+// Six-Dim Scoring
+// ---------------------------------------------------------------------------
+
+describe("evaluateFcfQuality", () => {
+  it("with valid FCF data returns score in [0, 10]", () => {
+    const result = evaluateFcfQuality({
+      fcfData: [
+        { fcfToRevenue: 0.2 },
+        { fcfToRevenue: 0.15 },
+        { fcfToRevenue: 0.18 },
+      ],
+    });
+    expect(result.score).not.toBeNull();
+    expect(result.score!).toBeGreaterThanOrEqual(0);
+    expect(result.score!).toBeLessThanOrEqual(10);
+    expect(result.reason.length).toBeGreaterThan(0);
+  });
+
+  it("with no data returns null score", () => {
+    const result = evaluateFcfQuality(null);
+    expect(result.score).toBeNull();
+  });
+
+  it("with empty FCF array returns null score", () => {
+    const result = evaluateFcfQuality({ fcfData: [] });
+    expect(result.score).toBeNull();
+  });
+
+  it("with missing fcfToRevenue fields returns null", () => {
+    const result = evaluateFcfQuality({
+      fcfData: [{}, {}],
+    });
+    expect(result.score).toBeNull();
+  });
+});
+
+describe("evaluateCapitalEfficiency", () => {
+  it("with valid ROE/ROIC data returns score in [0, 10]", () => {
+    const result = evaluateCapitalEfficiency({
+      efficiencyData: [
+        { roe: 0.18, roic: 0.14, assetTurnover: 0.8 },
+        { roe: 0.22, roic: 0.16, assetTurnover: 0.6 },
+      ],
+    });
+    expect(result.score).not.toBeNull();
+    expect(result.score!).toBeGreaterThanOrEqual(0);
+    expect(result.score!).toBeLessThanOrEqual(10);
+  });
+
+  it("with no data returns null", () => {
+    const result = evaluateCapitalEfficiency(null);
+    expect(result.score).toBeNull();
+  });
+});
+
+describe("evaluateShareholderReturn", () => {
+  it("with valid dividend data returns score in [0, 10]", () => {
+    const result = evaluateShareholderReturn({
+      dividendData: [
+        { dividendYield: 0.03, payoutRatio: 0.35 },
+        { dividendYield: 0.04, payoutRatio: 0.3 },
+      ],
+    });
+    expect(result.score).not.toBeNull();
+    expect(result.score!).toBeGreaterThanOrEqual(0);
+    expect(result.score!).toBeLessThanOrEqual(10);
+  });
+
+  it("with no data returns null", () => {
+    const result = evaluateShareholderReturn(null);
+    expect(result.score).toBeNull();
+  });
+});
+
+describe("evaluateValuationSafety", () => {
+  it("with PE/PB/PEG data returns score in [0, 10]", () => {
+    const result = evaluateValuationSafety({
+      valuationData: [{ peRatio: 20, pbRatio: 2.5, peg: 1.0 }],
+    });
+    expect(result.score).not.toBeNull();
+    expect(result.score!).toBeGreaterThanOrEqual(0);
+    expect(result.score!).toBeLessThanOrEqual(10);
+  });
+
+  it("with no data returns null", () => {
+    const result = evaluateValuationSafety(null);
+    expect(result.score).toBeNull();
+  });
+
+  it("very low PE gives high safety score", () => {
+    const result = evaluateValuationSafety({
+      valuationData: [{ peRatio: 8, pbRatio: 1.0, peg: 0.5 }],
+    });
+    expect(result.score).not.toBeNull();
+    expect(result.score!).toBeGreaterThan(7);
+  });
+});
+
+describe("evaluateGrowth", () => {
+  it("with valid growth data returns score in [0, 10]", () => {
+    const result = evaluateGrowth({
+      growthData: [{ revenueGrowth: 0.2, earningsGrowth: 0.25 }],
+    });
+    expect(result.score).not.toBeNull();
+    expect(result.score!).toBeGreaterThanOrEqual(0);
+    expect(result.score!).toBeLessThanOrEqual(10);
+  });
+
+  it("with no data returns null", () => {
+    const result = evaluateGrowth(null);
+    expect(result.score).toBeNull();
+  });
+});
+
+describe("evaluateMacroRisk", () => {
+  it("without news or macro returns baseline ~5", () => {
+    const result = evaluateMacroRisk("偏股");
+    expect(result.score).toBeGreaterThanOrEqual(0);
+    expect(result.score).toBeLessThanOrEqual(10);
+  });
+
+  it("bond fund gets higher score (lower risk)", () => {
+    const equity = evaluateMacroRisk("偏股");
+    const bond = evaluateMacroRisk("纯债");
+    expect(bond.score).toBeGreaterThan(equity.score);
+  });
+
+  it("negative news reduces score", () => {
+    const base = evaluateMacroRisk("股票");
+    const withNews = evaluateMacroRisk("股票", { overallSentiment: "NEGATIVE" });
+    expect(withNews.score).toBeLessThan(base.score);
+  });
+
+  it("positive news increases score", () => {
+    const base = evaluateMacroRisk("股票");
+    const withNews = evaluateMacroRisk("股票", { overallSentiment: "POSITIVE" });
+    expect(withNews.score).toBeGreaterThan(base.score);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Five-Dim Screening
+// ---------------------------------------------------------------------------
+
+describe("screenFundamentalQualitative", () => {
+  it("PASS with healthy fund", () => {
+    expect(screenFundamentalQualitative({ fundSize: 10, ageYears: 5 })).toBe("PASS");
+  });
+
+  it("WARN with small fund", () => {
+    expect(screenFundamentalQualitative({ fundSize: 0.3, ageYears: 5 })).toBe("WARN");
+  });
+
+  it("FAIL with small and young fund", () => {
+    expect(screenFundamentalQualitative({ fundSize: 0.3, ageYears: 0.5 })).toBe("FAIL");
+  });
+
+  it("PASS when null", () => {
+    expect(screenFundamentalQualitative(null)).toBe("PASS");
+  });
+});
+
+describe("screenPerformanceRiskQuant", () => {
+  it("PASS with good performance", () => {
+    expect(screenPerformanceRiskQuant({ sharpeRatio: 1.5, maxDrawdown: 0.1, volatility: 0.12 })).toBe("PASS");
+  });
+
+  it("WARN with negative sharpe", () => {
+    expect(screenPerformanceRiskQuant({ sharpeRatio: -0.5, maxDrawdown: 0.2, volatility: 0.15 })).toBe("WARN");
+  });
+
+  it("FAIL with extreme drawdown", () => {
+    expect(screenPerformanceRiskQuant({ sharpeRatio: 0.5, maxDrawdown: 0.4, volatility: 0.25 })).toBe("FAIL");
+  });
+
+  it("PASS when null", () => {
+    expect(screenPerformanceRiskQuant(null)).toBe("PASS");
+  });
+});
+
+describe("screenHoldingPenetration", () => {
+  it("PASS with diversified holdings", () => {
+    expect(screenHoldingPenetration({ top10Concentration: 0.3, sectorCount: 6 })).toBe("PASS");
+  });
+
+  it("WARN with moderate concentration", () => {
+    expect(screenHoldingPenetration({ top10Concentration: 0.55, sectorCount: 5 })).toBe("WARN");
+  });
+
+  it("FAIL with high concentration", () => {
+    expect(screenHoldingPenetration({ top10Concentration: 0.7, sectorCount: 2 })).toBe("FAIL");
+  });
+
+  it("PASS when null", () => {
+    expect(screenHoldingPenetration(null)).toBe("PASS");
+  });
+});
+
+describe("screenManagerEvaluation", () => {
+  it("PASS with experienced manager", () => {
+    expect(screenManagerEvaluation({ experienceYears: 8, managedFunds: 2 })).toBe("PASS");
+  });
+
+  it("FAIL with inexperienced manager", () => {
+    expect(screenManagerEvaluation({ experienceYears: 1, managedFunds: 1 })).toBe("FAIL");
+  });
+
+  it("PASS when null", () => {
+    expect(screenManagerEvaluation(null)).toBe("PASS");
+  });
+});
+
+describe("screenMarketTechnical", () => {
+  it("PASS with positive relative strength", () => {
+    expect(screenMarketTechnical({ relativeStrength: 0.1 })).toBe("PASS");
+  });
+
+  it("WARN with weak relative strength", () => {
+    expect(screenMarketTechnical({ relativeStrength: -0.1 })).toBe("WARN");
+  });
+
+  it("FAIL with very negative relative strength", () => {
+    expect(screenMarketTechnical({ relativeStrength: -0.2 })).toBe("FAIL");
+  });
+
+  it("PASS when null", () => {
+    expect(screenMarketTechnical(null)).toBe("PASS");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Composite Score
+// ---------------------------------------------------------------------------
+
+describe("computeComposite", () => {
+  it("normalizes with partial null scores", () => {
+    const score = computeComposite({
+      fcfQuality: 8,
+      capitalEfficiency: null,
+      shareholderReturn: 7,
+      valuationSafety: null,
+      growth: 6,
+      macroGeopolitical: 5,
+    });
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThanOrEqual(10);
+  });
+
+  it("all nulls (except macro) still returns a number", () => {
+    const score = computeComposite({
+      fcfQuality: null,
+      capitalEfficiency: null,
+      shareholderReturn: null,
+      valuationSafety: null,
+      growth: null,
+      macroGeopolitical: 5,
+    });
+    expect(score).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full analyzeFund
+// ---------------------------------------------------------------------------
+
+describe("analyzeFund", () => {
+  it("no data — returns BUY/HOLD/REDUCE/SELL", () => {
+    const result = analyzeFund({ code: "001323", name: "测试基金", category: "偏股" });
+    expect(result.fundCode).toBe("001323");
+    expect(result.fundName).toBe("测试基金");
+    expect(result.compositeScore).toBeGreaterThanOrEqual(0);
+    expect(result.compositeScore).toBeLessThanOrEqual(10);
+    expect(["BUY", "HOLD", "REDUCE", "SELL"]).toContain(result.recommendation);
+  });
+
+  it("full high-quality data → BUY or HOLD", () => {
+    const result = analyzeFund(
+      { code: "001323", name: "测试基金", category: "偏股" },
+      {
+        fcfData: [{ fcfToRevenue: 0.18 }],
+        efficiencyData: [{ roe: 0.2, roic: 0.15, assetTurnover: 0.7 }],
+        dividendData: [{ dividendYield: 0.03, payoutRatio: 0.35 }],
+        valuationData: [{ peRatio: 18, pbRatio: 2.5, peg: 1.0 }],
+        growthData: [{ revenueGrowth: 0.15, earningsGrowth: 0.18 }],
+        top10Concentration: 0.35,
+        sectorCount: 6,
+      },
+      { fundSize: 10, ageYears: 5 },
+      { sharpeRatio: 1.2, maxDrawdown: 0.12, volatility: 0.16 },
+      { experienceYears: 8, managedFunds: 3 },
+    );
+    expect(result.compositeScore).toBeGreaterThanOrEqual(7);
+    expect(["BUY", "HOLD"]).toContain(result.recommendation);
+    expect(result.riskWarnings.length).toBe(0);
+  });
+
+  it("weak fund → REDUCE or SELL", () => {
+    const result = analyzeFund(
+      { code: "999999", name: "高风险基金", category: "偏股" },
+      undefined,
+      { fundSize: 0.2, ageYears: 0.5 },
+      { sharpeRatio: -0.5, maxDrawdown: 0.45, volatility: 0.35 },
+    );
+    expect(["SELL", "REDUCE"]).toContain(result.recommendation);
+    expect(result.riskWarnings.length).toBeGreaterThan(0);
+  });
+});
+
+describe("analyzeFunds", () => {
+  it("analyzes multiple funds", () => {
+    const results = analyzeFunds([
+      { code: "001", name: "基金A", category: "偏股" },
+      { code: "002", name: "基金B", category: "纯债" },
+    ]);
+    expect(results.length).toBe(2);
+    expect(results[0].fundCode).toBe("001");
+    expect(results[1].fundCode).toBe("002");
+  });
+});

--- a/.archon/scripts/fund-score-engine.ts
+++ b/.archon/scripts/fund-score-engine.ts
@@ -1,0 +1,568 @@
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type Recommendation = "BUY" | "HOLD" | "REDUCE" | "SELL";
+type ScreenResult = "PASS" | "WARN" | "FAIL";
+
+interface SixDimScores {
+  fcfQuality: number | null;
+  capitalEfficiency: number | null;
+  shareholderReturn: number | null;
+  valuationSafety: number | null;
+  growth: number | null;
+  macroGeopolitical: number;
+}
+
+interface FiveDimScreening {
+  fundamentalQualitative: ScreenResult;
+  performanceRiskQuant: ScreenResult;
+  holdingPenetration: ScreenResult;
+  managerEvaluation: ScreenResult;
+  marketTechnical: ScreenResult;
+}
+
+interface FundAnalysisResult {
+  fundCode: string;
+  fundName: string;
+  fundCategory: string;
+  sixDimScores: SixDimScores;
+  fiveDimScreening: FiveDimScreening;
+  compositeScore: number;
+  recommendation: Recommendation;
+  riskWarnings: string[];
+  analysisSummary: string;
+  dataQuality: number;
+}
+
+// ---------------------------------------------------------------------------
+// Math helpers
+// ---------------------------------------------------------------------------
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+function std(values: number[]): number {
+  if (values.length <= 1) return 0;
+  const m = mean(values);
+  return Math.sqrt(values.reduce((sum, v) => sum + (v - m) ** 2, 0) / (values.length - 1));
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function round(value: number, decimals: number): number {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+// ---------------------------------------------------------------------------
+// Default weights
+// ---------------------------------------------------------------------------
+
+const DEFAULT_WEIGHTS = {
+  fcfQuality: 0.2,
+  capitalEfficiency: 0.18,
+  shareholderReturn: 0.15,
+  valuationSafety: 0.18,
+  growth: 0.17,
+  macroGeopolitical: 0.12,
+};
+
+// ---------------------------------------------------------------------------
+// Six-Dimension Scoring Engine
+// ---------------------------------------------------------------------------
+
+interface HoldingsData {
+  fcfData?: Array<{ fcfToRevenue?: number }>;
+  efficiencyData?: Array<{ roe?: number; roic?: number; assetTurnover?: number }>;
+  dividendData?: Array<{ dividendYield?: number; payoutRatio?: number }>;
+  valuationData?: Array<{ peRatio?: number; pbRatio?: number; peg?: number }>;
+  growthData?: Array<{ revenueGrowth?: number; earningsGrowth?: number }>;
+  top10Concentration?: number;
+  sectorCount?: number;
+}
+
+interface FundInfo {
+  fundSize?: number;
+  ageYears?: number;
+}
+
+interface NavHistory {
+  sharpeRatio?: number;
+  maxDrawdown?: number;
+  volatility?: number;
+}
+
+interface ManagerInfo {
+  experienceYears?: number;
+  managedFunds?: number;
+}
+
+interface MarketData {
+  relativeStrength?: number;
+}
+
+interface NewsSentiment {
+  overallSentiment: "POSITIVE" | "NEGATIVE" | "NEUTRAL" | "MIXED";
+}
+
+interface FundEntry {
+  code: string;
+  name: string;
+  category: string;
+}
+
+export function evaluateFcfQuality(
+  holdingsData?: HoldingsData | null,
+): { score: number | null; reason: string } {
+  const fcfData = holdingsData?.fcfData ?? [];
+
+  if (fcfData.length === 0) return { score: null, reason: "持仓FCF数据不可用" };
+
+  const ratios = fcfData
+    .map((d) => d.fcfToRevenue ?? null)
+    .filter((v): v is number => v !== null);
+
+  if (ratios.length === 0) return { score: null, reason: "无有效FCF数据" };
+
+  const avgRatio = mean(ratios);
+  const stdRatio = ratios.length > 1 ? std(ratios) : 0;
+
+  const ratioScore = clamp(avgRatio * 50 + 3, 0, 10);
+  const stabilityScore = clamp(10 - stdRatio * 40, 0, 10);
+
+  const score = round(ratioScore * 0.6 + stabilityScore * 0.4, 1);
+  return { score, reason: `平均FCF/营收比: ${avgRatio.toFixed(3)}, 稳定性评分: ${stabilityScore.toFixed(1)}` };
+}
+
+export function evaluateCapitalEfficiency(
+  holdingsData?: HoldingsData | null,
+): { score: number | null; reason: string } {
+  const effData = holdingsData?.efficiencyData ?? [];
+
+  if (effData.length === 0) return { score: null, reason: "资本效率数据不可用" };
+
+  const roeValues = effData.map((d) => d.roe ?? null).filter((v): v is number => v !== null);
+  const roicValues = effData.map((d) => d.roic ?? null).filter((v): v is number => v !== null);
+  const turnoverValues = effData.map((d) => d.assetTurnover ?? null).filter((v): v is number => v !== null);
+
+  const roeScore = clamp((roeValues.length > 0 ? mean(roeValues) : 0.1) * 50, 0, 10);
+  const roicScore = clamp((roicValues.length > 0 ? mean(roicValues) : 0.1) * 50, 0, 10);
+  const turnoverScore = clamp((turnoverValues.length > 0 ? mean(turnoverValues) : 0.5) * 5, 0, 10);
+
+  const score = round(roeScore * 0.35 + roicScore * 0.35 + turnoverScore * 0.3, 1);
+  return {
+    score,
+    reason: roeValues.length > 0 ? `ROE: ${(mean(roeValues) * 100).toFixed(1)}%` : "ROE数据缺失",
+  };
+}
+
+export function evaluateShareholderReturn(
+  holdingsData?: HoldingsData | null,
+): { score: number | null; reason: string } {
+  const divData = holdingsData?.dividendData ?? [];
+
+  if (divData.length === 0) return { score: null, reason: "股息数据不可用" };
+
+  const divYields = divData.map((d) => d.dividendYield ?? null).filter((v): v is number => v !== null);
+  const payoutRatios = divData.map((d) => d.payoutRatio ?? null).filter((v): v is number => v !== null);
+
+  const avgYield = divYields.length > 0 ? mean(divYields) : 0.02;
+  const yieldScore = clamp(avgYield * 200, 0, 10);
+
+  const avgPayout = payoutRatios.length > 0 ? mean(payoutRatios) : 0.3;
+  const payoutScore = clamp(5 + (0.4 - Math.abs(avgPayout - 0.35)) * 20, 0, 10);
+
+  const score = round(yieldScore * 0.5 + payoutScore * 0.5, 1);
+  return { score, reason: `平均股息率: ${(avgYield * 100).toFixed(1)}%` };
+}
+
+export function evaluateValuationSafety(
+  holdingsData?: HoldingsData | null,
+): { score: number | null; reason: string } {
+  const valData = holdingsData?.valuationData ?? [];
+
+  if (valData.length === 0) return { score: null, reason: "估值数据不可用" };
+
+  const peValues = valData.map((d) => d.peRatio ?? null).filter((v): v is number => v !== null);
+  const pbValues = valData.map((d) => d.pbRatio ?? null).filter((v): v is number => v !== null);
+  const pegValues = valData.map((d) => d.peg ?? null).filter((v): v is number => v !== null);
+
+  const avgPE = peValues.length > 0 ? mean(peValues) : 20;
+  const avgPB = pbValues.length > 0 ? mean(pbValues) : 2;
+  const avgPEG = pegValues.length > 0 ? mean(pegValues) : 1.5;
+
+  const peScore = clamp(10 * (25 / Math.max(avgPE, 1)), 0, 10);
+  const pbScore = clamp(10 * (3 / Math.max(avgPB, 0.1)), 0, 10);
+  const pegScore = clamp(10 * (1.5 / Math.max(avgPEG, 0.1)), 0, 10);
+
+  const score = round(peScore * 0.4 + pbScore * 0.3 + pegScore * 0.3, 1);
+  return { score, reason: `平均PE: ${avgPE.toFixed(1)}, PB: ${avgPB.toFixed(1)}, PEG: ${avgPEG.toFixed(2)}` };
+}
+
+export function evaluateGrowth(
+  holdingsData?: HoldingsData | null,
+): { score: number | null; reason: string } {
+  const growthData = holdingsData?.growthData ?? [];
+
+  if (growthData.length === 0) return { score: null, reason: "成长数据不可用" };
+
+  const revGrowth = growthData.map((d) => d.revenueGrowth ?? null).filter((v): v is number => v !== null);
+  const earnGrowth = growthData.map((d) => d.earningsGrowth ?? null).filter((v): v is number => v !== null);
+
+  const avgRev = revGrowth.length > 0 ? mean(revGrowth) : 0.1;
+  const avgEarn = earnGrowth.length > 0 ? mean(earnGrowth) : 0.1;
+
+  const revScore = clamp(5 + avgRev * 25, 0, 10);
+  const earnScore = clamp(5 + avgEarn * 25, 0, 10);
+
+  const score = round(revScore * 0.4 + earnScore * 0.6, 1);
+  return { score, reason: `营收增速: ${(avgRev * 100).toFixed(1)}%, 利润增速: ${(avgEarn * 100).toFixed(1)}%` };
+}
+
+export function evaluateMacroRisk(
+  fundCategory: string,
+  newsSentiment?: NewsSentiment | null,
+  macroData?: Record<string, unknown> | null,
+): { score: number; reason: string } {
+  let score = 5.0;
+  const reasons: string[] = [];
+
+  const categoryAdjustments: Record<string, number> = {
+    "债券": 1.5, "纯债": 2.0, "混债": 1.0, "偏债": 0.5,
+    "货币": 2.0, "黄金": 1.5, "商品": 0.5,
+    "股票": -1.0, "偏股": -0.5, "指数": 0,
+    "QDII": 0.5, "海外": 0.5,
+  };
+
+  for (const [cat, adj] of Object.entries(categoryAdjustments)) {
+    if (fundCategory.includes(cat)) {
+      score += adj;
+      reasons.push(`${cat}类别调整: ${adj >= 0 ? "+" : ""}${adj.toFixed(1)}`);
+      break;
+    }
+  }
+
+  if (newsSentiment) {
+    if (newsSentiment.overallSentiment === "NEGATIVE") {
+      score -= 2.0;
+      reasons.push("新闻整体负面: -2.0");
+    } else if (newsSentiment.overallSentiment === "POSITIVE") {
+      score += 1.0;
+      reasons.push("新闻整体正面: +1.0");
+    } else if (newsSentiment.overallSentiment === "MIXED") {
+      score -= 0.5;
+      reasons.push("新闻情绪混合: -0.5");
+    }
+  }
+
+  // Gold spot check (simplified from Python — uses macro data if available)
+  if (macroData) {
+    try {
+      const gold = macroData["GOLD_SPOT"];
+      if (gold && Array.isArray(gold) && gold.length > 0) {
+        const last = gold[gold.length - 1] as Record<string, unknown>;
+        const goldPct = typeof last["涨跌幅"] === "number" ? last["涨跌幅"] : 0;
+        if (goldPct > 2) {
+          score -= 1.0;
+          reasons.push("金价大涨(避险情绪): -1.0");
+        }
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  score = clamp(score, 0, 10);
+  const reasonStr = reasons.length > 0 ? reasons.join("; ") : "基准评分";
+  return { score: round(score, 1), reason: reasonStr };
+}
+
+// ---------------------------------------------------------------------------
+// Five-Dimension Screening
+// ---------------------------------------------------------------------------
+
+export function screenFundamentalQualitative(fundInfo?: FundInfo | null): ScreenResult {
+  if (!fundInfo) return "PASS";
+  const warnings: string[] = [];
+  if ((fundInfo.fundSize ?? 10) < 0.5) warnings.push("基金规模过小 (<0.5亿)");
+  if ((fundInfo.ageYears ?? 10) < 1) warnings.push("成立不足1年");
+  if (warnings.length >= 2) return "FAIL";
+  if (warnings.length > 0) return "WARN";
+  return "PASS";
+}
+
+export function screenPerformanceRiskQuant(navHistory?: NavHistory | null): ScreenResult {
+  if (!navHistory) return "PASS";
+  const sharpe = navHistory.sharpeRatio ?? 1.0;
+  const maxDrawdown = navHistory.maxDrawdown ?? 0.1;
+
+  if (maxDrawdown > 0.35) return "FAIL";
+  if (sharpe < 0 || maxDrawdown > 0.25) return "WARN";
+  if ((navHistory.volatility ?? 0.15) > 0.3) return "WARN";
+  return "PASS";
+}
+
+export function screenHoldingPenetration(holdingsData?: HoldingsData | null): ScreenResult {
+  if (!holdingsData) return "PASS";
+  const top10 = holdingsData.top10Concentration ?? 0.4;
+  const sectors = holdingsData.sectorCount ?? 5;
+
+  if (top10 > 0.65) return "FAIL";
+  if (top10 > 0.5 || sectors < 3) return "WARN";
+  return "PASS";
+}
+
+export function screenManagerEvaluation(managerInfo?: ManagerInfo | null): ScreenResult {
+  if (!managerInfo) return "PASS";
+  const years = managerInfo.experienceYears ?? 5;
+  if (years < 2) return "FAIL";
+  if (years < 3 || (managerInfo.managedFunds ?? 3) > 5) return "WARN";
+  return "PASS";
+}
+
+export function screenMarketTechnical(marketData?: MarketData | null): ScreenResult {
+  if (!marketData) return "PASS";
+  const rs = marketData.relativeStrength ?? 0;
+  if (rs < -0.15) return "FAIL";
+  if (rs < -0.05) return "WARN";
+  return "PASS";
+}
+
+// ---------------------------------------------------------------------------
+// Score Computing
+// ---------------------------------------------------------------------------
+
+export function computeComposite(
+  scores: SixDimScores,
+  weights: typeof DEFAULT_WEIGHTS = DEFAULT_WEIGHTS,
+): number {
+  let weightedSum = 0;
+  let usedWeight = 0;
+
+  const dims: Array<{ key: keyof SixDimScores; w: number }> = [
+    { key: "fcfQuality", w: weights.fcfQuality },
+    { key: "capitalEfficiency", w: weights.capitalEfficiency },
+    { key: "shareholderReturn", w: weights.shareholderReturn },
+    { key: "valuationSafety", w: weights.valuationSafety },
+    { key: "growth", w: weights.growth },
+    { key: "macroGeopolitical", w: weights.macroGeopolitical },
+  ];
+
+  for (const { key, w } of dims) {
+    const val = scores[key];
+    if (val !== null) {
+      weightedSum += val * w;
+      usedWeight += w;
+    }
+  }
+
+  if (usedWeight === 0) return 5.0; // default midpoint
+  return round(weightedSum / usedWeight, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Screening helpers
+// ---------------------------------------------------------------------------
+
+function passCount(screening: FiveDimScreening): number {
+  return Object.values(screening).filter((s) => s === "PASS").length;
+}
+
+function warnCount(screening: FiveDimScreening): number {
+  return Object.values(screening).filter((s) => s === "WARN").length;
+}
+
+function failCount(screening: FiveDimScreening): number {
+  return Object.values(screening).filter((s) => s === "FAIL").length;
+}
+
+// ---------------------------------------------------------------------------
+// Main analyzeFund
+// ---------------------------------------------------------------------------
+
+function determineRecommendation(composite: number, fails: number): Recommendation {
+  if (composite >= 7.5 && fails === 0) return "BUY";
+  if (composite >= 6.0 && fails <= 1) return "HOLD";
+  if (composite >= 4.0) return "REDUCE";
+  return "SELL";
+}
+
+export function analyzeFund(
+  fund: FundEntry,
+  holdingsData?: HoldingsData | null,
+  fundInfo?: FundInfo | null,
+  navHistory?: NavHistory | null,
+  managerInfo?: ManagerInfo | null,
+  marketData?: MarketData | null,
+  macroData?: Record<string, unknown> | null,
+  newsSentiment?: NewsSentiment | null,
+): FundAnalysisResult {
+  const riskWarnings: string[] = [];
+
+  const fcf = evaluateFcfQuality(holdingsData);
+  const eff = evaluateCapitalEfficiency(holdingsData);
+  const share = evaluateShareholderReturn(holdingsData);
+  const val = evaluateValuationSafety(holdingsData);
+  const growth = evaluateGrowth(holdingsData);
+  const macro = evaluateMacroRisk(fund.category, newsSentiment, macroData);
+
+  const scores: SixDimScores = {
+    fcfQuality: fcf.score,
+    capitalEfficiency: eff.score,
+    shareholderReturn: share.score,
+    valuationSafety: val.score,
+    growth: growth.score,
+    macroGeopolitical: macro.score,
+  };
+
+  const screening: FiveDimScreening = {
+    fundamentalQualitative: screenFundamentalQualitative(fundInfo),
+    performanceRiskQuant: screenPerformanceRiskQuant(navHistory),
+    holdingPenetration: screenHoldingPenetration(holdingsData),
+    managerEvaluation: screenManagerEvaluation(managerInfo),
+    marketTechnical: screenMarketTechnical(marketData),
+  };
+
+  const composite = computeComposite(scores);
+
+  const fails = failCount(screening);
+  const warns = warnCount(screening);
+  const passes = passCount(screening);
+
+  if (fcf.score !== null && fcf.score < 3.0) riskWarnings.push(`FCF质量评分过低 (${fcf.score.toFixed(1)}/10)`);
+  if (eff.score !== null && eff.score < 3.0) riskWarnings.push(`资本效率评分过低 (${eff.score.toFixed(1)}/10)`);
+  if (val.score !== null && val.score < 3.0) riskWarnings.push(`估值安全边际不足 (${val.score.toFixed(1)}/10)`);
+  if (macro.score < 3.0) riskWarnings.push(`宏观地缘风险较高 (${macro.score.toFixed(1)}/10)`);
+  if (fails > 0) riskWarnings.push(`五维筛选 ${fails} 项未通过`);
+  if (warns > 0) riskWarnings.push(`五维筛选 ${warns} 项警告`);
+
+  const recommendation = determineRecommendation(composite, fails);
+
+  const summaryParts = [
+    `六维综合评分: ${composite.toFixed(1)}/10 (${recommendation})`,
+    `FCF质量: ${fcf.score !== null ? fcf.score.toFixed(1) : "N/A"} (${fcf.reason})`,
+    `资本效率: ${eff.score !== null ? eff.score.toFixed(1) : "N/A"} (${eff.reason})`,
+    `股东回报: ${share.score !== null ? share.score.toFixed(1) : "N/A"} (${share.reason})`,
+    `估值安全: ${val.score !== null ? val.score.toFixed(1) : "N/A"} (${val.reason})`,
+    `成长性: ${growth.score !== null ? growth.score.toFixed(1) : "N/A"} (${growth.reason})`,
+    `宏观风险: ${macro.score.toFixed(1)} (${macro.reason})`,
+    `五维筛选: ${passes}P/${warns}W/${fails}F`,
+  ];
+
+  const availableCount = [holdingsData, fundInfo, navHistory, managerInfo, marketData, macroData, newsSentiment]
+    .filter(Boolean).length;
+  const dataQuality = clamp(0.3 + 0.1 * availableCount, 0, 1);
+
+  return {
+    fundCode: fund.code,
+    fundName: fund.name,
+    fundCategory: fund.category,
+    sixDimScores: scores,
+    fiveDimScreening: screening,
+    compositeScore: composite,
+    recommendation,
+    riskWarnings,
+    analysisSummary: summaryParts.join("\n"),
+    dataQuality: round(dataQuality, 2),
+  };
+}
+
+export function analyzeFunds(
+  funds: FundEntry[],
+  holdingsData?: HoldingsData | null,
+  fundInfo?: FundInfo | null,
+  navHistory?: NavHistory | null,
+  managerInfo?: ManagerInfo | null,
+  marketData?: MarketData | null,
+  macroData?: Record<string, unknown> | null,
+  newsSentiment?: NewsSentiment | null,
+): FundAnalysisResult[] {
+  return funds.map((f) =>
+    analyzeFund(f, holdingsData, fundInfo, navHistory, managerInfo, marketData, macroData, newsSentiment),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point (for script: node execution)
+// ---------------------------------------------------------------------------
+
+interface CliArgs {
+  fundsFile?: string;
+  holdingsFile?: string;
+  macroFile?: string;
+  newsFile?: string;
+  output?: string;
+}
+
+function parseCliArgs(): CliArgs {
+  const args = Bun.argv.slice(2);
+  const result: CliArgs = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const val = args[i + 1];
+    if (arg === "--funds-file") { result.fundsFile = val; i++; }
+    else if (arg === "--holdings-file") { result.holdingsFile = val; i++; }
+    else if (arg === "--macro-file") { result.macroFile = val; i++; }
+    else if (arg === "--news-file") { result.newsFile = val; i++; }
+    else if (arg === "--output") { result.output = val; i++; }
+  }
+  return result;
+}
+
+// Execute if run directly
+const cliArgs = parseCliArgs();
+if (cliArgs.fundsFile || cliArgs.output) {
+  const fs = await import("node:fs");
+
+  let funds: FundEntry[] = [];
+  if (cliArgs.fundsFile && fs.existsSync(cliArgs.fundsFile)) {
+    const raw = JSON.parse(fs.readFileSync(cliArgs.fundsFile, "utf-8"));
+    funds = raw.funds ?? raw ?? [];
+  }
+
+  let holdingsData: HoldingsData | null = null;
+  if (cliArgs.holdingsFile && fs.existsSync(cliArgs.holdingsFile)) {
+    holdingsData = JSON.parse(fs.readFileSync(cliArgs.holdingsFile, "utf-8"));
+  }
+
+  let macroData: Record<string, unknown> | null = null;
+  if (cliArgs.macroFile && fs.existsSync(cliArgs.macroFile)) {
+    macroData = JSON.parse(fs.readFileSync(cliArgs.macroFile, "utf-8"));
+  }
+
+  let newsSentiment: NewsSentiment | null = null;
+  if (cliArgs.newsFile && fs.existsSync(cliArgs.newsFile)) {
+    const newsRaw = JSON.parse(fs.readFileSync(cliArgs.newsFile, "utf-8"));
+    newsSentiment = newsRaw.overall_sentiment
+      ? { overallSentiment: newsRaw.overall_sentiment }
+      : null;
+  }
+
+  const results = analyzeFunds(funds, holdingsData, null, null, null, null, macroData, newsSentiment);
+
+  if (cliArgs.output) {
+    const outDir = cliArgs.output.substring(0, cliArgs.output.lastIndexOf("/"));
+    if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+    fs.writeFileSync(cliArgs.output, JSON.stringify(results, null, 2), "utf-8");
+  }
+
+  const buyCount = results.filter((r) => r.recommendation === "BUY").length;
+  const holdCount = results.filter((r) => r.recommendation === "HOLD").length;
+  const reduceCount = results.filter((r) => r.recommendation === "REDUCE").length;
+  const sellCount = results.filter((r) => r.recommendation === "SELL").length;
+
+  const sorted = results.toSorted((a, b) => b.compositeScore - a.compositeScore);
+  const top3 = sorted.slice(0, 3).map((r) => `${r.fundName}(${r.fundCode}): ${r.compositeScore}`);
+  const bottom3 = sorted.slice(-3).map((r) => `${r.fundName}(${r.fundCode}): ${r.compositeScore}`);
+
+  console.log("评分引擎执行完成:");
+  console.log(`  总计: ${results.length} 只基金`);
+  console.log(`  买入: ${buyCount}, 持有: ${holdCount}, 减仓: ${reduceCount}, 卖出: ${sellCount}`);
+  console.log(`  Top 3: ${top3.join(", ")}`);
+  console.log(`  Bottom 3: ${bottom3.join(", ")}`);
+}

--- a/.archon/scripts/fund-score-engine.ts
+++ b/.archon/scripts/fund-score-engine.ts
@@ -262,18 +262,18 @@ export function evaluateMacroRisk(
 
   // Gold spot check (simplified from Python — uses macro data if available)
   if (macroData) {
-    try {
-      const gold = macroData["GOLD_SPOT"];
-      if (gold && Array.isArray(gold) && gold.length > 0) {
+    const gold = macroData["GOLD_SPOT"];
+    if (gold && Array.isArray(gold) && gold.length > 0) {
+      try {
         const last = gold[gold.length - 1] as Record<string, unknown>;
         const goldPct = typeof last["涨跌幅"] === "number" ? last["涨跌幅"] : 0;
         if (goldPct > 2) {
           score -= 1.0;
           reasons.push("金价大涨(避险情绪): -1.0");
         }
+      } catch {
+        // gold spot data structure changed — ignore gracefully
       }
-    } catch {
-      // ignore
     }
   }
 
@@ -499,7 +499,7 @@ interface CliArgs {
   output?: string;
 }
 
-function parseCliArgs(): CliArgs {
+export function parseCliArgs(): CliArgs {
   const args = Bun.argv.slice(2);
   const result: CliArgs = {};
   for (let i = 0; i < args.length; i++) {
@@ -520,35 +520,67 @@ if (cliArgs.fundsFile || cliArgs.output) {
   const fs = await import("node:fs");
 
   let funds: FundEntry[] = [];
-  if (cliArgs.fundsFile && fs.existsSync(cliArgs.fundsFile)) {
-    const raw = JSON.parse(fs.readFileSync(cliArgs.fundsFile, "utf-8"));
-    funds = raw.funds ?? raw ?? [];
+  if (cliArgs.fundsFile) {
+    if (!fs.existsSync(cliArgs.fundsFile)) {
+      console.error(`Funds file not found: ${cliArgs.fundsFile}`);
+      process.exit(1);
+    }
+    try {
+      const raw = JSON.parse(fs.readFileSync(cliArgs.fundsFile, "utf-8"));
+      funds = raw.funds ?? raw ?? [];
+    } catch (err) {
+      const message = err instanceof SyntaxError
+        ? `Invalid JSON in funds file: ${cliArgs.fundsFile}`
+        : `Failed to read funds file: ${cliArgs.fundsFile} — ${(err as Error).message}`;
+      console.error(message);
+      process.exit(1);
+    }
+  }
+
+  function readJsonFile(path: string): Record<string, unknown> | null {
+    if (!fs.existsSync(path)) {
+      console.error(`Data file not found: ${path}`);
+      return null;
+    }
+    try {
+      return JSON.parse(fs.readFileSync(path, "utf-8"));
+    } catch (err) {
+      const message = err instanceof SyntaxError
+        ? `Invalid JSON in data file: ${path}`
+        : `Failed to read data file: ${path} — ${(err as Error).message}`;
+      console.error(message);
+      return null;
+    }
   }
 
   let holdingsData: HoldingsData | null = null;
-  if (cliArgs.holdingsFile && fs.existsSync(cliArgs.holdingsFile)) {
-    holdingsData = JSON.parse(fs.readFileSync(cliArgs.holdingsFile, "utf-8"));
-  }
+  if (cliArgs.holdingsFile) holdingsData = readJsonFile(cliArgs.holdingsFile) as HoldingsData | null;
 
   let macroData: Record<string, unknown> | null = null;
-  if (cliArgs.macroFile && fs.existsSync(cliArgs.macroFile)) {
-    macroData = JSON.parse(fs.readFileSync(cliArgs.macroFile, "utf-8"));
-  }
+  if (cliArgs.macroFile) macroData = readJsonFile(cliArgs.macroFile);
 
   let newsSentiment: NewsSentiment | null = null;
-  if (cliArgs.newsFile && fs.existsSync(cliArgs.newsFile)) {
-    const newsRaw = JSON.parse(fs.readFileSync(cliArgs.newsFile, "utf-8"));
-    newsSentiment = newsRaw.overall_sentiment
-      ? { overallSentiment: newsRaw.overall_sentiment }
+  if (cliArgs.newsFile) {
+    const newsRaw = readJsonFile(cliArgs.newsFile);
+    newsSentiment = newsRaw?.overall_sentiment
+      ? { overallSentiment: newsRaw.overall_sentiment as NewsSentiment["overallSentiment"] }
       : null;
   }
 
   const results = analyzeFunds(funds, holdingsData, null, null, null, null, macroData, newsSentiment);
 
   if (cliArgs.output) {
-    const outDir = cliArgs.output.substring(0, cliArgs.output.lastIndexOf("/"));
-    if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
-    fs.writeFileSync(cliArgs.output, JSON.stringify(results, null, 2), "utf-8");
+    try {
+      const outSep = cliArgs.output.lastIndexOf("/");
+      if (outSep > 0) {
+        const outDir = cliArgs.output.substring(0, outSep);
+        if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+      }
+      fs.writeFileSync(cliArgs.output, JSON.stringify(results, null, 2), "utf-8");
+    } catch (err) {
+      console.error(`Failed to write output file: ${cliArgs.output} — ${(err as Error).message}`);
+      process.exit(1);
+    }
   }
 
   const buyCount = results.filter((r) => r.recommendation === "BUY").length;

--- a/.archon/workflows/fund-analysis.yaml
+++ b/.archon/workflows/fund-analysis.yaml
@@ -1,0 +1,120 @@
+name: fund-analysis
+description: |
+  Use when: User wants to run a full fund quantitative analysis pipeline.
+  Triggers: "fund analysis", "analyze fund", "fund scoring", "基金分析".
+
+  DAG workflow that:
+  1. Parallel data collection (market + macro + news + fund list)
+  2. Parallel AI analysis + scoring (news analysis + score engine)
+  3. Merges results and generates reports in MD + CSV + JSON
+
+  Accepts: Optional fund codes file path or configuration reference.
+
+provider: claude
+
+nodes:
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 1: PARALLEL DATA COLLECTION
+  # fetch-market, fetch-macro, fetch-news, load-funds all run
+  # concurrently since they have no depends_on edges.
+  # ═══════════════════════════════════════════════════════════════
+
+  - id: fetch-market
+    description: Collect global market data (US stocks, A-share indices, HK stocks, global indices)
+    command: fund-fetch-market
+    context: fresh
+    model: haiku
+
+  - id: fetch-macro
+    description: Collect 26 macroeconomic indicators (China + US + global)
+    command: fund-fetch-macro
+    context: fresh
+    model: haiku
+
+  - id: fetch-news
+    description: Collect financial news feed
+    command: fund-fetch-news
+    context: fresh
+    model: haiku
+
+  - id: load-funds
+    description: Load fund list from codes file or position CSV
+    bash: |
+      set -euo pipefail
+      mkdir -p "$ARTIFACTS_DIR"
+
+      CODES_FILE="$HOME/Data_share/基金OCR/基金-代码.txt"
+      if [ -f "$CODES_FILE" ]; then
+        echo "Loading fund codes from: $CODES_FILE"
+        uv run python -c "
+      import json, sys
+      funds = []
+      with open('$CODES_FILE', encoding='utf-8') as f:
+          for line in f:
+              line = line.strip()
+              if not line or line.startswith('#'):
+                  continue
+              parts = line.replace(',', ' ').split(None, 1)
+              code = parts[0].strip()
+              name = parts[1].strip() if len(parts) > 1 else ''
+              if code:
+                  funds.append({'code': code, 'name': name, 'category': ''})
+      print(json.dumps({'funds': funds, '_total': len(funds)}, ensure_ascii=False))
+      " > "$ARTIFACTS_DIR/fund_list.json"
+      else
+        echo "Fund codes file not found, falling back to position CSV"
+        POSITION_CSV="$HOME/Data_share/基金分析/基金持仓数据.csv"
+        if [ -f "$POSITION_CSV" ]; then
+          uv run python -c "
+      import csv, json, sys
+      funds = []
+      with open('$POSITION_CSV', encoding='utf-8-sig') as f:
+          reader = csv.DictReader(f)
+          for row in reader:
+              code = row.get('基金代码', row.get('code', '')).strip()
+              name = row.get('基金名称', row.get('name', ''))
+              category = row.get('分类', row.get('category', ''))
+              if code:
+                  funds.append({'code': code, 'name': name or '', 'category': category or ''})
+      print(json.dumps({'funds': funds, '_total': len(funds)}, ensure_ascii=False))
+      " > "$ARTIFACTS_DIR/fund_list.json"
+        else
+          echo '{"_error":"No fund source found"}' > "$ARTIFACTS_DIR/fund_list.json"
+          echo "WARNING: No fund list source available" >&2
+        fi
+      fi
+
+      echo "Fund list loaded: $(uv run python -c "import json; d=json.load(open('$ARTIFACTS_DIR/fund_list.json')); print(d.get('_total', 0))") funds"
+
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 2: PARALLEL AI ANALYSIS + SCORING
+  # analyze-news (depends on fetch-news) and score-engine (depends
+  # on fetch-macro + load-funds) run concurrently.
+  # ═══════════════════════════════════════════════════════════════
+
+  - id: analyze-news
+    description: Deep Claude AI news analysis — sentiment, sector impact, macro risk
+    command: fund-analyze-news
+    depends_on: [fetch-news]
+    context: fresh
+    model: sonnet
+
+  - id: score-engine
+    description: Run TypeScript scoring engine — six-dim scores + five-dim screening
+    command: fund-score-engine
+    depends_on: [fetch-macro, load-funds]
+    context: fresh
+    model: haiku
+
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 3: REPORT GENERATION
+  # generate-reports waits for both analyze-news and score-engine
+  # to complete, then produces all three output formats.
+  # ═══════════════════════════════════════════════════════════════
+
+  - id: generate-reports
+    description: Generate analysis reports (Markdown + CSV + JSON)
+    command: fund-generate-reports
+    depends_on: [analyze-news, score-engine]
+    context: fresh
+    model: haiku

--- a/.archon/workflows/fund-analyze-only.yaml
+++ b/.archon/workflows/fund-analyze-only.yaml
@@ -1,0 +1,77 @@
+name: fund-analyze-only
+description: |
+  Use when: User wants to analyze funds using previously cached data.
+  Triggers: "fund analyze", "analyze cached", "run analysis".
+
+  DAG workflow that:
+  1. Loads cached data from ~/.archon/cache/fund-analysis/
+  2. Parallel AI news analysis + score engine computation
+  3. Generates reports (MD + CSV + JSON)
+
+  Requires: fund-fetch-only must have been run first to populate the cache.
+  NOT for: First-time runs — use fund-fetch-only to collect data first.
+
+provider: claude
+
+nodes:
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 1: LOAD CACHED DATA
+  # Restore data from persistent cache into artifacts directory.
+  # ═══════════════════════════════════════════════════════════════
+
+  - id: load-cache
+    description: Load previously cached data into artifacts directory
+    bash: |
+      set -euo pipefail
+      CACHE_DIR="$HOME/.archon/cache/fund-analysis"
+      mkdir -p "$ARTIFACTS_DIR"
+
+      MISSING_COUNT=0
+      for file in market_data.json macro_data.json news_feed.json; do
+        if [ -f "$CACHE_DIR/$file" ]; then
+          cp "$CACHE_DIR/$file" "$ARTIFACTS_DIR/$file"
+          echo "  Loaded from cache: $file"
+        else
+          echo "  MISSING: $file not found in cache ($CACHE_DIR)"
+          MISSING_COUNT=$((MISSING_COUNT + 1))
+        fi
+      done
+
+      if [ "$MISSING_COUNT" -gt 0 ]; then
+        echo ""
+        echo "ERROR: $MISSING_COUNT cached file(s) missing."
+        echo "Run 'archon workflow run fund-fetch-only' first to collect data."
+        exit 1
+      fi
+
+      echo "Cache loaded successfully. Ready for analysis."
+
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 2: PARALLEL ANALYSIS
+  # News analysis and scoring run concurrently.
+  # ═══════════════════════════════════════════════════════════════
+
+  - id: analyze-news
+    description: Deep Claude AI news analysis
+    command: fund-analyze-news
+    depends_on: [load-cache]
+    context: fresh
+    model: sonnet
+
+  - id: score-engine
+    description: Run TypeScript scoring engine
+    command: fund-score-engine
+    depends_on: [load-cache]
+    context: fresh
+    model: haiku
+
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 3: REPORT GENERATION
+  # ═══════════════════════════════════════════════════════════════
+
+  - id: generate-reports
+    description: Generate analysis reports in MD + CSV + JSON
+    command: fund-generate-reports
+    depends_on: [analyze-news, score-engine]
+    context: fresh
+    model: haiku

--- a/.archon/workflows/fund-fetch-only.yaml
+++ b/.archon/workflows/fund-fetch-only.yaml
@@ -1,0 +1,61 @@
+name: fund-fetch-only
+description: |
+  Use when: User wants to collect and cache data only (no analysis).
+  Triggers: "fund fetch", "fetch market data", "collect fund data".
+
+  DAG workflow that:
+  1. Parallel data collection (market + macro + news)
+  2. Saves all results to cache for later analysis runs
+
+  NOT for: Running analysis — use fund-analyze-only or fund-analysis for that.
+
+provider: claude
+
+nodes:
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 1: PARALLEL DATA COLLECTION
+  # All three fetch nodes run concurrently.
+  # ═══════════════════════════════════════════════════════════════
+
+  - id: fetch-market
+    description: Collect global market data
+    command: fund-fetch-market
+    context: fresh
+    model: haiku
+
+  - id: fetch-macro
+    description: Collect 26 macroeconomic indicators
+    command: fund-fetch-macro
+    context: fresh
+    model: haiku
+
+  - id: fetch-news
+    description: Collect financial news feed
+    command: fund-fetch-news
+    context: fresh
+    model: haiku
+
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 2: SAVE TO CACHE
+  # Copies all collected data to a persistent cache directory.
+  # ═══════════════════════════════════════════════════════════════
+
+  - id: save-cache
+    description: Save collected data to persistent cache for later analysis
+    depends_on: [fetch-market, fetch-macro, fetch-news]
+    bash: |
+      set -euo pipefail
+      CACHE_DIR="$HOME/.archon/cache/fund-analysis"
+      mkdir -p "$CACHE_DIR"
+
+      echo "Saving collected data to cache: $CACHE_DIR"
+      for file in market_data.json macro_data.json news_feed.json; do
+        if [ -f "$ARTIFACTS_DIR/$file" ]; then
+          cp "$ARTIFACTS_DIR/$file" "$CACHE_DIR/$file"
+          echo "  Cached: $file"
+        else
+          echo "  WARNING: $file not found in artifacts"
+        fi
+      done
+
+      echo "Cache saved. Data ready for fund-analyze-only."

--- a/.archon/workflows/fund-news-only.yaml
+++ b/.archon/workflows/fund-news-only.yaml
@@ -1,0 +1,34 @@
+name: fund-news-only
+description: |
+  Use when: User wants to fetch and analyze financial news only.
+  Triggers: "fund news", "analyze news", "news analysis".
+
+  Sequential workflow that:
+  1. Fetches financial news from akshare
+  2. Performs Claude AI deep analysis of news sentiment and impact
+
+  Output: Structured JSON news analysis saved to $ARTIFACTS_DIR/news_analysis.json
+
+provider: claude
+
+nodes:
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 1: FETCH NEWS
+  # ═══════════════════════════════════════════════════════════════
+
+  - id: fetch-news
+    description: Collect financial news feed from akshare
+    command: fund-fetch-news
+    context: fresh
+    model: haiku
+
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 2: ANALYZE NEWS
+  # ═══════════════════════════════════════════════════════════════
+
+  - id: analyze-news
+    description: Deep Claude AI news analysis
+    command: fund-analyze-news
+    depends_on: [fetch-news]
+    context: fresh
+    model: sonnet


### PR DESCRIPTION
## Summary

- **Problem**: Team has a Python-based fund quantitative analysis system (Streamlit + pytest) that needs to run as automated, composable DAG workflows for scheduled analysis and CI integration.
- **Why it matters**: Porting to Archon workflows enables composable execution (fetch-only, analyze-only, or full pipeline), parallel data collection, human-in-the-loop approval gates, and artifact persistence — all without changing the underlying analytics logic.
- **What changed**: Created 4 DAG workflows, 6 commands, 2 TypeScript scripts (scoring engine + report generator), 1 Python script (data collectors), and 46 unit tests. Updates `.archon/config.yaml` with a `fund_analysis` section.
- **What did NOT change** (scope boundary): Streamlit dashboard, real-time push/WebSocket, fund holdings auto-update, database-backed score history, Slack/Telegram integration, Python dependency auto-management, backtesting engine.

## UX Journey

### Before

```
  User                   Terminal / Cron
  ────                   ───────────────
  cd ~/基金分析/
  python dashboard.py    launches Streamlit
  manual browser nav     views charts
  python news_impact.py  ad-hoc analysis
  pytest tests/          manual testing
```

### After

```
  User                   Archon CLI / Workflow
  ────                   ─────────────────────
  archon workflow run ──▶ [NEW] fund-fetch-only → caches market/macro/news data
  archon workflow run ──▶ [NEW] fund-analyze-only → scores from cache, generates reports
  archon workflow run ──▶ [NEW] fund-analysis → full pipeline (fetch → analyze → report)
  archon workflow run ──▶ [NEW] fund-news-only → fetch + AI-analyze news
  ls $ARTIFACTS_DIR/    ◀── [NEW] 基金投资分析报告.md/.csv/.json
```

## Architecture Diagram

### Before

```
  Python monolith (15 files)
  ├── data/market_data.py    → akshare fetch
  ├── data/macro_data.py     → akshare macro
  ├── analysis/news_impact.py → OpenAI LLM
  ├── analysis/fund_analyzer.py → scoring math
  ├── output/report_generator.py → MD/CSV/JSON
  ├── dashboard.py           → Streamlit UI
  └── tests/
```

### After

```
  Archon DAG Workflows
  [+].archon/workflows/fund-analysis.yaml        (7-node DAG, full pipeline)
  [+].archon/workflows/fund-fetch-only.yaml      (4-node DAG, data only)
  [+].archon/workflows/fund-analyze-only.yaml    (4-node DAG, analysis from cache)
  [+].archon/workflows/fund-news-only.yaml       (2-node, news fetch+analyze)

  [+].archon/commands/ (6 commands)
  [+].archon/scripts/  (3 scripts + 2 test files)

  Original Python (unchanged, used as data source)
  [=] data/market_data.py
  [=] analysis/fund_analyzer.py
  [=] output/report_generator.py
  [=] dashboard.py
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| DAG bash node | fund-collectors.py | **new** | Python script called via `uv run` |
| DAG prompt node | Claude SDK | **new** | AI news analysis |
| DAG script node | fund-score-engine.ts | **new** | bun runs TypeScript |
| DAG command node | fund-generate-reports.md | **new** | wraps report-generator.ts |
| fund-analysis | fund-fetch-only | **new** | Phase 1 → Phase 2 via cache files |
| config.yaml | workflow defaults | **new** | fund_analysis section |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `skills`
- Module: `skills:fund-analysis`

## Change Metadata

- Change type: `feature`
- Primary scope: `multi`

## Linked Issue

- Closes #
- Related #

## Validation Evidence (required)

```bash
bun run type-check   ✅ Pass (all 10 packages)
bun run lint         ✅ Pass (0 errors, 0 warnings)
bun run format:check ✅ Pass (Prettier clean)
bun run test         ✅ Pass (all packages, 0 failures)
bun run build        ✅ Pass (all packages)
# Full validate:
bun run validate     ✅ Pass
```

Archon-specific validation:
```bash
archon validate workflows fund-analysis     ✅ ok
archon validate workflows fund-fetch-only   ✅ ok
archon validate workflows fund-analyze-only ✅ ok
archon validate workflows fund-news-only    ✅ ok
archon validate commands fund-fetch-market  ✅ ok
archon validate commands fund-fetch-macro   ✅ ok
archon validate commands fund-fetch-news    ✅ ok
archon validate commands fund-analyze-news  ✅ ok
archon validate commands fund-score-engine  ✅ ok
archon validate commands fund-generate-reports ✅ ok
bun test .archon/scripts/fund-score-engine.test.ts    ✅ 42 pass
bun test .archon/scripts/fund-report-generator.test.ts ✅ 4 pass
```

- Evidence provided: All CI checks pass; 46 unit tests covering scoring math and report generation.
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No` (Python data collectors make existing akshare/yfinance calls, but these are in user-controlled scripts, not Archon internals)
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`
- If any `Yes`, describe risk and mitigation: N/A

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` (only appends a new `fund_analysis` key to `.archon/config.yaml`)
- Database migration needed? `No`
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: All 4 workflow YAMLs pass `archon validate workflows`. All 6 command files pass `archon validate commands`. TypeScript scoring engine unit tests cover all 6 qualification dimensions and 5 screening dimensions including edge cases (missing data, boundary values).
- Edge cases checked: Zero/null data inputs, missing fund holdings, empty news results, extreme PE/PB/ROE values, score boundary clamping.
- What was not verified: End-to-end workflow execution (requires akshare/yfinance network access and Claude API key at runtime). The DAG structure and variable substitution patterns mirror existing validated workflows (`archon-idea-to-pr.yaml`, `archon-test-loop-dag.yaml`).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: None. All files are new additions under `.archon/` except one config append.
- Potential unintended effects: None. The `fund_analysis` config section is namespaced and not read by any existing code.
- Guardrails/monitoring for early detection: Workflow validation runs at load time; invalid YAML syntax would be caught immediately.

## Rollback Plan (required)

- Fast rollback command/path: `git revert cf27cd3`
- Feature flags or config toggles (if any): None — the workflows are opt-in via `archon workflow run` only
- Observable failure symptoms: Workflow validation failure on `archon workflow list` if YAML is malformed; runtime script errors surface in workflow event log

## Risks and Mitigations

- Risk: Python dependencies (akshare, yfinance) not installed on user machine
  - Mitigation: Documented in command files; `script:` nodes gracefully fail with clear error messages if `uv run` cannot resolve imports
- Risk: Data collector script changes upstream (akshare API breaking changes)
  - Mitigation: Python collectors are self-contained in one file; easy to update independently of Archon
