### PR TITLE
fix(web): recognize loop and approval node types in DAG builder (closes #1336)

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -8,7 +8,7 @@
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "type-check": "tsc --noEmit",
-    "test": "bun test src/lib/ && bun test src/stores/ && bun test src/hooks/",
+    "test": "bun test src/lib/ && bun test src/stores/ && bun test src/hooks/ && bun test src/components/",
     "generate:types": "openapi-typescript http://localhost:3090/api/openapi.json -o src/lib/api.generated.d.ts"
   },
   "dependencies": {

--- a/packages/web/src/components/workflows/DagNodeComponent.test.ts
+++ b/packages/web/src/components/workflows/DagNodeComponent.test.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from 'bun:test';
+import { getContentPreview } from './DagNodeComponent';
+import type { DagNodeData } from './DagNodeComponent';
+
+describe('getContentPreview', () => {
+  test('loop node with multi-line prompt returns first line only', () => {
+    const data: DagNodeData = {
+      id: 'n1',
+      label: 'Loop',
+      nodeType: 'loop',
+      promptText: 'first line\nsecond line\nthird line',
+    };
+    expect(getContentPreview(data)).toBe('first line');
+  });
+
+  test('approval node returns empty string', () => {
+    const data: DagNodeData = {
+      id: 'n2',
+      label: 'Approval',
+      nodeType: 'approval',
+      approval: { message: 'Please approve' },
+    };
+    expect(getContentPreview(data)).toBe('');
+  });
+});

--- a/packages/web/src/components/workflows/DagNodeComponent.tsx
+++ b/packages/web/src/components/workflows/DagNodeComponent.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/lib/utils';
 export interface DagNodeData extends DagNode {
   /** For command nodes: the command name. For prompt nodes: display label ("Prompt"). For bash: display label ("Shell"). */
   label: string;
-  nodeType: 'command' | 'prompt' | 'bash';
+  nodeType: 'command' | 'prompt' | 'bash' | 'loop' | 'approval';
   promptText?: string;
   bashScript?: string;
   bashTimeout?: number;
@@ -36,6 +36,18 @@ const TYPE_CONFIG = {
     badgeBg: 'bg-node-bash/20',
     badgeText: 'text-node-bash',
   },
+  loop: {
+    badge: 'LOOP',
+    stripeColor: 'bg-node-loop',
+    badgeBg: 'bg-node-loop/20',
+    badgeText: 'text-node-loop',
+  },
+  approval: {
+    badge: 'APPROVAL',
+    stripeColor: 'bg-node-approval',
+    badgeBg: 'bg-node-approval/20',
+    badgeText: 'text-node-approval',
+  },
 } as const;
 
 function getContentPreview(data: DagNodeData): string {
@@ -43,9 +55,12 @@ function getContentPreview(data: DagNodeData): string {
     case 'command':
       return data.label;
     case 'prompt':
+    case 'loop':
       return data.promptText?.split('\n')[0] ?? '';
     case 'bash':
       return data.bashScript?.split('\n')[0] ?? '';
+    case 'approval':
+      return '';
   }
 }
 

--- a/packages/web/src/components/workflows/DagNodeComponent.tsx
+++ b/packages/web/src/components/workflows/DagNodeComponent.tsx
@@ -50,7 +50,7 @@ const TYPE_CONFIG = {
   },
 } as const;
 
-function getContentPreview(data: DagNodeData): string {
+export function getContentPreview(data: DagNodeData): string {
   switch (data.nodeType) {
     case 'command':
       return data.label;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -28,6 +28,8 @@
   --node-command: oklch(0.62 0.18 250);
   --node-prompt: oklch(0.58 0.19 290);
   --node-bash: oklch(0.75 0.15 75);
+  --node-loop: oklch(0.62 0.18 170);
+  --node-approval: oklch(0.72 0.17 40);
 
   /* shadcn variables mapped to dark theme */
   --radius: 0.625rem;
@@ -86,6 +88,8 @@
   --color-node-command: var(--node-command);
   --color-node-prompt: var(--node-prompt);
   --color-node-bash: var(--node-bash);
+  --color-node-loop: var(--node-loop);
+  --color-node-approval: var(--node-approval);
   --font-sans: 'Inter', ui-sans-serif, system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, monospace;
 

--- a/packages/web/src/lib/dag-layout.test.ts
+++ b/packages/web/src/lib/dag-layout.test.ts
@@ -1,0 +1,60 @@
+import { describe, test, expect } from 'bun:test';
+import { resolveNodeDisplay, dagNodesToReactFlow } from './dag-layout';
+import type { DagNode } from '@/lib/api';
+
+describe('resolveNodeDisplay', () => {
+  test('loop node returns label Loop, nodeType loop, and promptText from loop.prompt', () => {
+    const dn: DagNode = {
+      id: 'n1',
+      loop: {
+        prompt: 'process each item',
+        until: 'done',
+        max_iterations: 5,
+        fresh_context: false,
+      },
+    };
+    expect(resolveNodeDisplay(dn)).toEqual({
+      label: 'Loop',
+      nodeType: 'loop',
+      promptText: 'process each item',
+    });
+  });
+
+  test('approval node returns label Approval and nodeType approval', () => {
+    const dn: DagNode = {
+      id: 'n2',
+      approval: { message: 'Please approve' },
+    };
+    expect(resolveNodeDisplay(dn)).toEqual({
+      label: 'Approval',
+      nodeType: 'approval',
+    });
+  });
+});
+
+describe('dagNodesToReactFlow', () => {
+  test('loop and approval nodes produce correct nodeType in ReactFlow output', () => {
+    const loopNode: DagNode = {
+      id: 'loop-1',
+      loop: {
+        prompt: 'iterate over results',
+        until: 'complete',
+        max_iterations: 10,
+        fresh_context: true,
+      },
+    };
+    const approvalNode: DagNode = {
+      id: 'approval-1',
+      depends_on: ['loop-1'],
+      approval: { message: 'Review and approve' },
+    };
+
+    const { nodes } = dagNodesToReactFlow([loopNode, approvalNode]);
+
+    expect(nodes).toHaveLength(2);
+    const loopFlowNode = nodes.find(n => n.id === 'loop-1');
+    const approvalFlowNode = nodes.find(n => n.id === 'approval-1');
+    expect(loopFlowNode?.data.nodeType).toBe('loop');
+    expect(approvalFlowNode?.data.nodeType).toBe('approval');
+  });
+});

--- a/packages/web/src/lib/dag-layout.ts
+++ b/packages/web/src/lib/dag-layout.ts
@@ -45,7 +45,7 @@ export function layoutWithDagre(
 
 export function resolveNodeDisplay(dn: DagNode): {
   label: string;
-  nodeType: 'command' | 'prompt' | 'bash';
+  nodeType: 'command' | 'prompt' | 'bash' | 'loop' | 'approval';
   promptText?: string;
   bashScript?: string;
   bashTimeout?: number;
@@ -60,6 +60,12 @@ export function resolveNodeDisplay(dn: DagNode): {
   }
   if ('command' in dn && dn.command) {
     return { label: dn.command, nodeType: 'command' };
+  }
+  if ('loop' in dn && dn.loop) {
+    return { label: 'Loop', nodeType: 'loop', promptText: dn.loop.prompt };
+  }
+  if ('approval' in dn && dn.approval) {
+    return { label: 'Approval', nodeType: 'approval' };
   }
   return {
     label: 'Prompt',


### PR DESCRIPTION
## Problem

`resolveNodeDisplay()` in `dag-layout.ts` only handled `bash` and `command` node types, falling through to a `prompt` fallback for everything else. This meant **loop** and **approval** nodes were assigned `nodeType: 'prompt'` with no `promptText`, triggering a false-positive validation error in `useBuilderValidation.ts`:

> `Node "analyze-and-fix": prompt cannot be empty`
> `Node "confirm-push": prompt cannot be empty`

The YAML is valid — these nodes correctly use `loop:` and `approval:` — but the web UI builder raised errors and rendered them incorrectly.

Closes #1336.

## Root Cause

```
// dag-layout.ts — before
resolveNodeDisplay(dn):
  bash   → nodeType: 'bash'    ✓
  command → nodeType: 'command' ✓
  *      → nodeType: 'prompt'  ✗ loop and approval fall here
```

`useBuilderValidation.ts` then checked `nodeType === 'prompt' && !promptText?.trim()` and fired for both misclassified node types.

## Fix

### `dag-layout.ts`
Added explicit `loop` and `approval` cases to `resolveNodeDisplay()`. Loop nodes receive `nodeType: 'loop'` with `promptText` set to `loop.prompt` (used for content preview). Approval nodes receive `nodeType: 'approval'`.

### `DagNodeComponent.tsx`
- Extended `DagNodeData.nodeType` union: `'command' | 'prompt' | 'bash' | 'loop' | 'approval'`
- Added `TYPE_CONFIG` entries (teal badge for LOOP, amber for APPROVAL)
- Updated `getContentPreview` switch to handle both new types

### `index.css`
Added `--node-loop` (teal, `oklch(0.62 0.18 170)`) and `--node-approval` (amber, `oklch(0.72 0.17 40)`) CSS custom properties and `@theme inline` mappings.

## Before / After

**Before**: Any workflow with a `loop:` or `approval:` node showed errors in the Problems panel and rendered the node with a purple PROMPT badge and an empty prompt preview.

```
Problems panel (before):
  ● Node "analyze-and-fix": prompt cannot be empty
  ● Node "confirm-push": prompt cannot be empty
```

**After**: Loop and approval nodes render with distinct colored badges (LOOP in teal, APPROVAL in amber), no validation errors, and the loop prompt text is shown as a content preview.

```
Problems panel (after):
  (empty — 0 errors)

DAG graph (after):
  [LOOP analyze-and-fix]    ← teal badge, shows first line of loop.prompt
  [APPROVAL confirm-push]   ← amber badge
```

## Testing

1. Open any workflow containing a `loop:` or `approval:` node in the builder
2. Verify the Problems panel shows no false-positive "prompt cannot be empty" errors
3. Verify the node renders with the correct LOOP / APPROVAL badge and color stripe