### PR TITLE
chore(workflows): drop CHANGELOG.md from maintainer-review docs-impact scope

### DIFF
--- a/.archon/commands/maintainer-review-docs-impact.md
+++ b/.archon/commands/maintainer-review-docs-impact.md
@@ -52,7 +52,6 @@ For each user-facing change in the diff, identify the docs that should be update
 - **New surface**: is there a docs page describing it? Is it linked from a landing page or the relevant section?
 - **Changed surface**: are existing docs pages still accurate? Do they need updates?
 - **Removed surface**: are existing references stale? `grep` the docs site for old name.
-- **Migration**: does a breaking change need a migration note in CHANGELOG.md or docs?
 
 ### Specific places to check
 - `packages/docs-web/src/content/docs/getting-started/` — quickstart, install, concepts.
@@ -60,8 +59,9 @@ For each user-facing change in the diff, identify the docs that should be update
 - `packages/docs-web/src/content/docs/reference/` — CLI, variables, configuration.
 - `packages/docs-web/src/content/docs/adapters/` — Slack, Telegram, GitHub, Discord, Web.
 - `packages/docs-web/src/content/docs/deployment/` — Docker, cloud.
-- `CHANGELOG.md` — Keep-a-Changelog entry for user-visible changes.
 - `CLAUDE.md` — only if the change affects how *agents* working in this repo should behave.
+
+> **CHANGELOG.md is out of scope for this review.** The project's release process generates the changelog from squash-commit history at release time; contributors do not add CHANGELOG entries per PR. Do not flag a missing CHANGELOG entry under any severity.
 
 ---
 
@@ -89,7 +89,7 @@ Write `$ARTIFACTS_DIR/review/docs-impact-findings.md`:
 ### HIGH — stale docs from changed/removed surface
 - (same format)
 
-### MEDIUM — minor gaps (changelog entry, examples)
+### MEDIUM — minor gaps (examples, missing cross-link)
 - (same format)
 
 ### LOW — nice-to-have polish


### PR DESCRIPTION
## Summary

- **Problem:** The maintainer-review-pr workflow's docs-impact reviewer has been flagging "missing CHANGELOG entry" at MEDIUM (sometimes HIGH) on essentially every PR since we started using it. This project doesn't follow per-PR CHANGELOG maintenance — the \`/release\` skill generates entries from squash-commit history at release time, so contributors writing per-PR entries would duplicate work and create merge conflicts.
- **Why it matters:** Bogus blocker findings train both reviewers and contributors to treat HIGH/MEDIUM as noise. Removes recurring false-positive friction without losing real docs-impact coverage.
- **What changed:** Removed the "Migration → CHANGELOG.md" bullet from the per-change analysis checklist; removed \`CHANGELOG.md\` from the "specific places to check" enumeration; removed "changelog entry" from the MEDIUM severity heading; added an explicit one-line callout that CHANGELOG.md is out of scope with the reason (release-time generation).
- **What did not change (scope boundary):** All other docs-impact behavior is unchanged. Public APIs, CLI flags, env vars, config fields, user-facing behavior changes are still in scope across \`packages/docs-web/\` and \`CLAUDE.md\`. Project-local command file under \`.archon/commands/\`, loaded from disk on every workflow run, so the change takes effect on the next invocation.

## UX Journey

### Before

\`\`\`
Maintainer review run on a code-only PR
─────────────────────────────────────────
docs-impact reviewer
  ├── public API check ......... pass
  ├── CLI flag check ........... pass
  ├── env var check ............ pass
  └── CHANGELOG check .......... [X] FLAG MEDIUM "Missing CHANGELOG entry"
      → posted on PR
      → contributor confused (no CHANGELOG culture in repo)
      → maintainer ignores or skips merge waiting on a fix that wouldn't ship
\`\`\`

### After

\`\`\`
docs-impact reviewer
  ├── public API check ......... pass
  ├── CLI flag check ........... pass
  └── env var check ............ pass
  → no false-positive CHANGELOG flag
  → relevant findings stay visible against quieter background
\`\`\`

## Architecture Diagram

Single file edit; no architectural change. The maintainer-review-pr workflow continues to load \`.archon/commands/maintainer-review-docs-impact.md\` on each run; only the reviewer's checklist contents change.

| From | To | Status | Notes |
|------|----|--------|-------|
| maintainer-review-pr | docs-impact command | unchanged | command loads from disk per run |

## Label Snapshot

- Risk: \`risk: low\`
- Size: \`size: XS\` (one file, 3 insertions / 3 deletions plus 1-line callout)
- Scope: \`workflows\`
- Module: \`workflows:maintainer-review\`

## Change Metadata

- Change type: \`chore\`
- Primary scope: \`workflows\`

## Linked Issue

- Closes # _none_
- Related # _none_ — accumulated friction across ~30 maintainer-review runs this week.

## Validation Evidence (required)

\`\`\`bash
bun run cli validate workflows
# Results: 36 valid, 0 with errors
\`\`\`

- Evidence provided: markdown-only edits to a project-local command file. \`bun run cli validate workflows\` confirms the workflow itself still loads. Command files are not type-checked or lint-gated.
- If any command is intentionally skipped: \`bun run validate\` (full type-check/lint/test) is skipped because no source code changed.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes. Existing CHANGELOG.md entries are untouched; the \`/release\` skill still generates the changelog from commits at release time.
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios:
  - Today's #1722 maintainer-review run executed with the change in the working tree; docs-impact aspect did not flag a CHANGELOG entry.
  - Inspected the docs-impact command file end-to-end to confirm only the intended phrases were removed.
- Edge cases checked:
  - Real docs-impact findings (missing public-API page, stale env var docs) are still produced by other paragraphs in the command — only the CHANGELOG line is suppressed.
- What was not verified:
  - Did not re-run maintainer-review-pr on a PR that legitimately does change \`CHANGELOG.md\` to confirm those edits don't accidentally surface as a finding either. Acceptable risk — the reviewer enumerates surfaces, doesn't pattern-match on file paths.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: \`maintainer-review-pr\` only. Other workflows (\`maintainer-standup\`, \`marketplace-pr-review-and-merge\`, etc.) do not consume this command.
- Potential unintended effects: a future contributor who genuinely needs a CHANGELOG entry won't be reminded by the reviewer. Acceptable — CHANGELOG ownership lives with \`/release\` skill.
- Guardrails/monitoring for early detection: the \`/release\` skill is the canonical CHANGELOG owner; any release-time gap is caught there.

## Rollback Plan (required)

- Fast rollback command/path: \`git revert\` the squash commit. The prior \`.archon/commands/maintainer-review-docs-impact.md\` is restored verbatim.
- Feature flags or config toggles (if any): none — project workflow command file.
- Observable failure symptoms: docs-impact reviewer goes silent on missing-CHANGELOG findings (the change's intent). No way for it to fail more loudly.

## Risks and Mitigations

- Risk: a downstream consumer of this command file (cron, external automation) assumed the CHANGELOG line was there.
  - Mitigation: this is a project-internal Archon command file with no documented external consumers. The standup brief and \`/release\` skill don't import it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation review workflow to clarify scope and assessment criteria for documentation impact reviews.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1724?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->