### PR TITLE
fix(codex): normalize output schemas for OpenAI Structured Outputs compliance

### DIFF
--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -682,7 +682,13 @@ describe('CodexProvider', () => {
 
       expect(mockRunStreamed).toHaveBeenCalledWith(
         'test prompt',
-        expect.objectContaining({ outputSchema: schema })
+        expect.objectContaining({
+          outputSchema: {
+            ...schema,
+            additionalProperties: false,
+            required: ['summary'],
+          },
+        })
       );
     });
 

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -337,6 +337,59 @@ function buildTurnOptions(requestOptions?: SendQueryOptions): {
   return { turnOptions, hasOutputFormat };
 }
 
+/**
+ * Extract the last valid JSON object from a string that may contain multiple
+ * concatenated JSON objects (common when Codex streams progress updates).
+ *
+ * Forward-scans to find top-level `{…}` blocks using brace-depth tracking
+ * (respecting quoted strings), tries JSON.parse on each, and returns the
+ * last successfully parsed object.
+ */
+function extractLastJsonObject(text: string): unknown {
+  let lastParsed: unknown;
+  let i = 0;
+  while (i < text.length) {
+    if (text[i] !== '{') {
+      i++;
+      continue;
+    }
+    let depth = 0;
+    let inString = false;
+    let escape = false;
+    let j = i;
+    for (; j < text.length; j++) {
+      const ch = text[j];
+      if (escape) {
+        escape = false;
+        continue;
+      }
+      if (ch === '\\' && inString) {
+        escape = true;
+        continue;
+      }
+      if (ch === '"') {
+        inString = !inString;
+        continue;
+      }
+      if (inString) continue;
+      if (ch === '{') depth++;
+      if (ch === '}') {
+        depth--;
+        if (depth === 0) {
+          try {
+            lastParsed = JSON.parse(text.slice(i, j + 1));
+          } catch {
+            // matched braces but not valid JSON — skip
+          }
+          break;
+        }
+      }
+    }
+    i = depth === 0 ? j + 1 : text.length;
+  }
+  return lastParsed;
+}
+
 // ─── Stream Normalizer ───────────────────────────────────────────────────
 
 /** State maintained across Codex event stream normalization. */
@@ -580,22 +633,33 @@ async function* streamCodexEvents(
       // Codex returns structured output inline in agent_message text.
       // Normalize: parse as JSON and put on structuredOutput so the
       // dag-executor can handle all providers uniformly.
+      //
+      // Codex may stream multiple intermediate JSON objects as separate
+      // agent_message items (progress updates). accumulatedText is the
+      // concatenation of all of them, which isn't valid JSON. When a
+      // straight parse fails, extract the last complete JSON object —
+      // that's the authoritative final answer.
       let structuredOutput: unknown;
       if (hasOutputFormat && accumulatedText) {
         try {
           structuredOutput = JSON.parse(accumulatedText);
           getLog().debug('codex.structured_output_parsed');
         } catch {
-          getLog().warn(
-            { outputPreview: accumulatedText.slice(0, 200) },
-            'codex.structured_output_not_json'
-          );
-          yield {
-            type: 'system',
-            content:
-              '⚠️ Structured output requested but Codex returned non-JSON text. ' +
-              'Downstream $nodeId.output.field references may not evaluate correctly.',
-          };
+          structuredOutput = extractLastJsonObject(accumulatedText);
+          if (structuredOutput !== undefined) {
+            getLog().debug('codex.structured_output_parsed_last_object');
+          } else {
+            getLog().warn(
+              { outputPreview: accumulatedText.slice(0, 200) },
+              'codex.structured_output_not_json'
+            );
+            yield {
+              type: 'system',
+              content:
+                '⚠️ Structured output requested but Codex returned non-JSON text. ' +
+                'Downstream $nodeId.output.field references may not evaluate correctly.',
+            };
+          }
         }
       }
 

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -267,6 +267,50 @@ function extractUsageFromCodexEvent(event: TurnCompletedEvent): TokenUsage {
   };
 }
 
+// ─── Schema Normalizer (OpenAI Structured Outputs compliance) ────────────
+
+/**
+ * Recursively normalize a JSON schema for OpenAI Structured Outputs compliance.
+ *
+ * OpenAI requires two things Claude doesn't:
+ *   1. Every object must have `additionalProperties: false`.
+ *   2. Every object must have a `required` array listing ALL property keys.
+ *
+ * Workflow authors writing provider-agnostic YAML typically omit both.
+ */
+function normalizeSchemaForOpenAI(schema: Record<string, unknown>): Record<string, unknown> {
+  const out = { ...schema };
+
+  if (out.type === 'object') {
+    if (!('additionalProperties' in out)) {
+      out.additionalProperties = false;
+    }
+    if (typeof out.properties === 'object' && out.properties !== null) {
+      const props = out.properties as Record<string, Record<string, unknown>>;
+      const propKeys = Object.keys(props);
+
+      const existingRequired = Array.isArray(out.required) ? (out.required as string[]) : [];
+      const missingRequired = propKeys.filter(k => !existingRequired.includes(k));
+      if (missingRequired.length > 0) {
+        out.required = [...existingRequired, ...missingRequired];
+      }
+
+      const normalized: Record<string, Record<string, unknown>> = {};
+      for (const [key, value] of Object.entries(props)) {
+        normalized[key] =
+          typeof value === 'object' && value !== null ? normalizeSchemaForOpenAI(value) : value;
+      }
+      out.properties = normalized;
+    }
+  }
+
+  if (out.type === 'array' && typeof out.items === 'object' && out.items !== null) {
+    out.items = normalizeSchemaForOpenAI(out.items as Record<string, unknown>);
+  }
+
+  return out;
+}
+
 // ─── Turn Options Builder ────────────────────────────────────────────────
 
 /**
@@ -282,10 +326,10 @@ function buildTurnOptions(requestOptions?: SendQueryOptions): {
     requestOptions?.outputFormat ?? requestOptions?.nodeConfig?.output_format
   );
   if (requestOptions?.outputFormat) {
-    turnOptions.outputSchema = requestOptions.outputFormat.schema;
+    turnOptions.outputSchema = normalizeSchemaForOpenAI(requestOptions.outputFormat.schema);
   }
   if (requestOptions?.nodeConfig?.output_format && !requestOptions?.outputFormat) {
-    turnOptions.outputSchema = requestOptions.nodeConfig.output_format;
+    turnOptions.outputSchema = normalizeSchemaForOpenAI(requestOptions.nodeConfig.output_format);
   }
   if (requestOptions?.abortSignal) {
     turnOptions.signal = requestOptions.abortSignal;


### PR DESCRIPTION
## Summary

When using `provider: codex` in workflow definitions, nodes with `output_format` fail with `invalid_json_schema` errors because OpenAI's Structured Outputs API has stricter schema requirements than Claude:

1. Every `type: "object"` node must have `additionalProperties: false`
2. Every `type: "object"` node must have a `required` array listing **all** property keys

Workflow authors writing provider-agnostic YAML typically omit both since Claude doesn't require them — breaking Codex workflows.

## Changes

- Added `normalizeSchemaForOpenAI()` in the Codex provider (`packages/providers/src/codex/provider.ts`) that recursively walks the output schema tree and fills in the missing constraints before passing to the SDK
- Applied it in `buildTurnOptions()` for both `outputFormat.schema` and `nodeConfig.output_format` paths
- Updated the existing test to expect the normalized schema

## Test plan

- [x] All 56 existing provider tests pass
- [x] Type-check passes (`tsc --noEmit`)
- [x] Lint + prettier pass (verified via pre-commit hooks)
- [x] Tested end-to-end with the `remotion-idea-to-video` workflow using `provider: codex` / `model: gpt-5.3-codex` — both `fetch-source` and `qa-review` output_format schemas accepted by OpenAI API (previously both failed with 400)

## Error before fix

```
Invalid schema for response_format 'codex_output_schema':
In context=(), 'additionalProperties' is required to be supplied and to be false.
```

```
Invalid schema for response_format 'codex_output_schema':
In context=('properties', 'modes'), 'required' is required to be supplied
and to be an array including every key in properties. Missing 'voiced'.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON schema normalization and enforcement for Codex structured outputs, making schema-based responses more reliable and preventing extra properties.
  * More robust parsing of streamed/concatenated output with a fallback extractor, reducing false "non-JSON" warnings.

* **Tests**
  * Updated tests to verify schema normalization and the improved parsing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1727?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->