### PR TITLE
fix(core): resolve default assistant via config + folder detection on every codebase registration

### DIFF
--- a/packages/adapters/src/community/forge/gitea/adapter.ts
+++ b/packages/adapters/src/community/forge/gitea/adapter.ts
@@ -33,7 +33,7 @@ import {
 } from '@archon/git';
 import * as db from '@archon/core/db/conversations';
 import * as codebaseDb from '@archon/core/db/codebases';
-import { resolveDefaultAssistant } from '@archon/core/config';
+import { resolveDefaultAssistant } from '@archon/core/config/resolve-assistant';
 import { parseAllowedUsers, isGiteaUserAuthorized } from './auth';
 import { splitIntoParagraphChunks } from '../../../utils/message-splitting';
 import type { WebhookEvent } from './types';

--- a/packages/adapters/src/community/forge/gitea/adapter.ts
+++ b/packages/adapters/src/community/forge/gitea/adapter.ts
@@ -33,6 +33,7 @@ import {
 } from '@archon/git';
 import * as db from '@archon/core/db/conversations';
 import * as codebaseDb from '@archon/core/db/codebases';
+import { resolveDefaultAssistant } from '@archon/core/config';
 import { parseAllowedUsers, isGiteaUserAuthorized } from './auth';
 import { splitIntoParagraphChunks } from '../../../utils/message-splitting';
 import type { WebhookEvent } from './types';
@@ -642,6 +643,7 @@ export class GiteaAdapter implements IPlatformAdapter {
       name: `${owner}/${repo}`,
       repository_url: repoUrlNoGit,
       default_cwd: canonicalPath,
+      ai_assistant_type: await resolveDefaultAssistant(canonicalPath),
     });
 
     getLog().info({ codebaseName: codebase.name, path: canonicalPath }, 'codebase_created');

--- a/packages/adapters/src/community/forge/gitlab/adapter.ts
+++ b/packages/adapters/src/community/forge/gitlab/adapter.ts
@@ -32,6 +32,7 @@ import {
 } from '@archon/git';
 import * as db from '@archon/core/db/conversations';
 import * as codebaseDb from '@archon/core/db/codebases';
+import { resolveDefaultAssistant } from '@archon/core/config';
 import { parseAllowedUsers, isGitLabUserAuthorized, verifyWebhookToken } from './auth';
 import { splitIntoParagraphChunks } from '../../../utils/message-splitting';
 import type { GitLabWebhookEvent, GitLabIssue, GitLabMergeRequest } from './types';
@@ -592,6 +593,7 @@ Use 'glab mr view ${String(mr.iid)}' for full details and 'glab mr diff ${String
       name: projectPath,
       repository_url: repoUrlNoGit,
       default_cwd: canonicalPath,
+      ai_assistant_type: await resolveDefaultAssistant(canonicalPath),
     });
 
     getLog().info({ codebaseName: codebase.name, path: canonicalPath }, 'gitlab.codebase_created');

--- a/packages/adapters/src/community/forge/gitlab/adapter.ts
+++ b/packages/adapters/src/community/forge/gitlab/adapter.ts
@@ -32,7 +32,7 @@ import {
 } from '@archon/git';
 import * as db from '@archon/core/db/conversations';
 import * as codebaseDb from '@archon/core/db/codebases';
-import { resolveDefaultAssistant } from '@archon/core/config';
+import { resolveDefaultAssistant } from '@archon/core/config/resolve-assistant';
 import { parseAllowedUsers, isGitLabUserAuthorized, verifyWebhookToken } from './auth';
 import { splitIntoParagraphChunks } from '../../../utils/message-splitting';
 import type { GitLabWebhookEvent, GitLabIssue, GitLabMergeRequest } from './types';

--- a/packages/adapters/src/forge/github/adapter.ts
+++ b/packages/adapters/src/forge/github/adapter.ts
@@ -32,7 +32,7 @@ import {
 } from '@archon/git';
 import * as db from '@archon/core/db/conversations';
 import * as codebaseDb from '@archon/core/db/codebases';
-import { resolveDefaultAssistant } from '@archon/core/config';
+import { resolveDefaultAssistant } from '@archon/core/config/resolve-assistant';
 import { createLogger } from '@archon/paths';
 import { parseAllowedUsers as parseGitHubAllowedUsers, isGitHubUserAuthorized } from './auth';
 import { splitIntoParagraphChunks } from '../../utils/message-splitting';

--- a/packages/adapters/src/forge/github/adapter.ts
+++ b/packages/adapters/src/forge/github/adapter.ts
@@ -32,6 +32,7 @@ import {
 } from '@archon/git';
 import * as db from '@archon/core/db/conversations';
 import * as codebaseDb from '@archon/core/db/codebases';
+import { resolveDefaultAssistant } from '@archon/core/config';
 import { createLogger } from '@archon/paths';
 import { parseAllowedUsers as parseGitHubAllowedUsers, isGitHubUserAuthorized } from './auth';
 import { splitIntoParagraphChunks } from '../../utils/message-splitting';
@@ -620,6 +621,7 @@ export class GitHubAdapter implements IPlatformAdapter {
       name: `${owner}/${repo}`,
       repository_url: repoUrlNoGit, // Store without .git for consistency
       default_cwd: canonicalPath,
+      ai_assistant_type: await resolveDefaultAssistant(canonicalPath),
     });
 
     getLog().info({ codebaseName: codebase.name, path: canonicalPath }, 'github.codebase_created');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
     "./orchestrator": "./src/orchestrator/orchestrator.ts",
     "./handlers": "./src/handlers/command-handler.ts",
     "./config": "./src/config/index.ts",
+    "./config/resolve-assistant": "./src/config/resolve-assistant.ts",
     "./utils/*": "./src/utils/*.ts",
     "./services/*": "./src/services/*.ts",
     "./state/*": "./src/state/*.ts"

--- a/packages/core/src/config/config-loader.test.ts
+++ b/packages/core/src/config/config-loader.test.ts
@@ -15,16 +15,16 @@ mock.module('@archon/paths', () => ({
   getDefaultWorkflowsPath: mock(() => '/app/.archon/workflows/defaults'),
 }));
 
-// Mock for reading/writing config files (replaces fs/promises mock)
-const mockReadConfigFile = mock(() => Promise.resolve(''));
-const mockWriteConfigFile = mock(() => Promise.resolve());
+// Mock fs/promises so that readConfigFile/writeConfigFile (which call fsReadFile/writeFile
+// internally) are intercepted regardless of Bun version mock.module semantics.
+const mockFsReadFile = mock(() => Promise.resolve(''));
+const mockFsWriteFile = mock(() => Promise.resolve());
+const mockFsMkdir = mock(() => Promise.resolve(undefined));
 
-// Import real config-loader to spread its exports, then override readConfigFile/writeConfigFile
-import * as realConfigLoader from './config-loader';
-mock.module('./config-loader', () => ({
-  ...realConfigLoader,
-  readConfigFile: mockReadConfigFile,
-  writeConfigFile: mockWriteConfigFile,
+mock.module('fs/promises', () => ({
+  readFile: mockFsReadFile,
+  writeFile: mockFsWriteFile,
+  mkdir: mockFsMkdir,
 }));
 
 import {
@@ -51,8 +51,8 @@ describe('config-loader', () => {
 
   beforeEach(() => {
     clearConfigCache();
-    mockReadConfigFile.mockReset();
-    mockWriteConfigFile.mockReset();
+    mockFsReadFile.mockReset();
+    mockFsWriteFile.mockReset();
 
     // Save original env vars
     envVars.forEach(key => {
@@ -71,23 +71,23 @@ describe('config-loader', () => {
       }
     });
 
-    // No need to restore - we're mocking at config-loader level, not fs/promises
-    mockReadConfigFile.mockClear();
-    mockWriteConfigFile.mockClear();
+    // Clear mock state between tests
+    mockFsReadFile.mockClear();
+    mockFsWriteFile.mockClear();
   });
 
   describe('loadGlobalConfig', () => {
     test('returns empty object when file does not exist', async () => {
       const error = new Error('ENOENT') as NodeJS.ErrnoException;
       error.code = 'ENOENT';
-      mockReadConfigFile.mockRejectedValue(error);
+      mockFsReadFile.mockRejectedValue(error);
 
       const config = await loadGlobalConfig();
       expect(config).toEqual({});
     });
 
     test('parses valid YAML config', async () => {
-      mockReadConfigFile.mockResolvedValue(`
+      mockFsReadFile.mockResolvedValue(`
 defaultAssistant: codex
 streaming:
   telegram: batch
@@ -102,22 +102,22 @@ concurrency:
     });
 
     test('caches config on subsequent calls', async () => {
-      mockReadConfigFile.mockResolvedValue('defaultAssistant: claude');
+      mockFsReadFile.mockResolvedValue('defaultAssistant: claude');
 
       await loadGlobalConfig();
       await loadGlobalConfig();
 
       // Should only read file once
-      expect(mockReadConfigFile).toHaveBeenCalledTimes(1);
+      expect(mockFsReadFile).toHaveBeenCalledTimes(1);
     });
 
     test('reloads config when forceReload is true', async () => {
-      mockReadConfigFile.mockResolvedValue('defaultAssistant: claude');
+      mockFsReadFile.mockResolvedValue('defaultAssistant: claude');
 
       await loadGlobalConfig();
       await loadGlobalConfig(true);
 
-      expect(mockReadConfigFile).toHaveBeenCalledTimes(2);
+      expect(mockFsReadFile).toHaveBeenCalledTimes(2);
     });
 
     test('logs error for invalid YAML syntax', async () => {
@@ -125,7 +125,7 @@ concurrency:
 
       // Simulate YAML parse error (SyntaxError has no .code property)
       const syntaxError = new SyntaxError('YAML Parse error: Multiline implicit key');
-      mockReadConfigFile.mockRejectedValue(syntaxError);
+      mockFsReadFile.mockRejectedValue(syntaxError);
 
       const config = await loadGlobalConfig();
 
@@ -144,7 +144,7 @@ concurrency:
 
       const permError = new Error('Permission denied') as NodeJS.ErrnoException;
       permError.code = 'EACCES';
-      mockReadConfigFile.mockRejectedValue(permError);
+      mockFsReadFile.mockRejectedValue(permError);
 
       const config = await loadGlobalConfig();
 
@@ -161,7 +161,7 @@ concurrency:
 
   describe('loadRepoConfig', () => {
     test('loads from .archon/config.yaml', async () => {
-      mockReadConfigFile.mockResolvedValue('assistant: codex');
+      mockFsReadFile.mockResolvedValue('assistant: codex');
 
       const config = await loadRepoConfig('/test/repo');
       expect(config.assistant).toBe('codex');
@@ -170,7 +170,7 @@ concurrency:
     test('returns empty object when no config found', async () => {
       const error = new Error('ENOENT') as NodeJS.ErrnoException;
       error.code = 'ENOENT';
-      mockReadConfigFile.mockRejectedValue(error);
+      mockFsReadFile.mockRejectedValue(error);
 
       const config = await loadRepoConfig('/test/repo');
       expect(config).toEqual({});
@@ -181,7 +181,7 @@ concurrency:
 
       // Simulate YAML parse error (SyntaxError has no .code property)
       const syntaxError = new SyntaxError('YAML Parse error: Multiline implicit key');
-      mockReadConfigFile.mockRejectedValue(syntaxError);
+      mockFsReadFile.mockRejectedValue(syntaxError);
 
       const config = await loadRepoConfig('/test/repo');
 
@@ -200,7 +200,7 @@ concurrency:
 
       const permError = new Error('Permission denied') as NodeJS.ErrnoException;
       permError.code = 'EACCES';
-      mockReadConfigFile.mockRejectedValue(permError);
+      mockFsReadFile.mockRejectedValue(permError);
 
       const config = await loadRepoConfig('/test/repo');
 
@@ -219,7 +219,7 @@ concurrency:
     test('returns defaults when no configs exist', async () => {
       const error = new Error('ENOENT') as NodeJS.ErrnoException;
       error.code = 'ENOENT';
-      mockReadConfigFile.mockRejectedValue(error);
+      mockFsReadFile.mockRejectedValue(error);
 
       const config = await loadConfig();
 
@@ -234,7 +234,7 @@ concurrency:
     });
 
     test('env vars override config files', async () => {
-      mockReadConfigFile.mockResolvedValue(`
+      mockFsReadFile.mockResolvedValue(`
 defaultAssistant: claude
 streaming:
   telegram: stream
@@ -250,20 +250,20 @@ streaming:
     });
 
     test('throws on unknown DEFAULT_AI_ASSISTANT env var', async () => {
-      mockReadConfigFile.mockResolvedValue('');
+      mockFsReadFile.mockResolvedValue('');
       process.env.DEFAULT_AI_ASSISTANT = 'nonexistent-provider';
 
       await expect(loadConfig()).rejects.toThrow(/not a registered provider/);
     });
 
     test('throws on unknown defaultAssistant in global config', async () => {
-      mockReadConfigFile.mockResolvedValue('defaultAssistant: nonexistent-provider');
+      mockFsReadFile.mockResolvedValue('defaultAssistant: nonexistent-provider');
 
       await expect(loadConfig()).rejects.toThrow(/not a registered provider/);
     });
 
     test('throws on unknown assistant in repo config', async () => {
-      mockReadConfigFile.mockImplementation(async (path: string) => {
+      mockFsReadFile.mockImplementation(async (path: string) => {
         const normalized = path.replace(/\\/g, '/');
         if (normalized.includes('/tmp/test-repo/.archon/config.yaml')) {
           return 'assistant: nonexistent-provider';
@@ -282,7 +282,7 @@ streaming:
       };
 
       let globalConfigRead = false;
-      mockReadConfigFile.mockImplementation(async (path: string) => {
+      mockFsReadFile.mockImplementation(async (path: string) => {
         // First check for repo-specific config path (contains /repo/.archon/)
         if (pathMatches(path, '/repo/.archon/config.yaml')) {
           return 'assistant: codex';
@@ -308,7 +308,7 @@ streaming:
       };
 
       let globalConfigRead = false;
-      mockReadConfigFile.mockImplementation(async (path: string) => {
+      mockFsReadFile.mockImplementation(async (path: string) => {
         if (pathMatches(path, '/repo/.archon/config.yaml')) {
           return `assistants:\n  codex:\n    webSearchMode: live\n    additionalDirectories:\n      - /repo\n`;
         }
@@ -335,7 +335,7 @@ streaming:
         return normalizedPath.includes(pattern);
       };
 
-      mockReadConfigFile.mockImplementation(async (path: string) => {
+      mockFsReadFile.mockImplementation(async (path: string) => {
         if (pathMatches(path, '/repo/.archon/config.yaml')) {
           return `
 worktree:
@@ -357,7 +357,7 @@ worktree:
         return normalizedPath.includes(pattern);
       };
 
-      mockReadConfigFile.mockImplementation(async (path: string) => {
+      mockFsReadFile.mockImplementation(async (path: string) => {
         if (pathMatches(path, '/repo/.archon/config.yaml')) {
           return `
 worktree:
@@ -376,7 +376,7 @@ worktree:
     test('baseBranch is undefined when not configured', async () => {
       const error = new Error('ENOENT') as NodeJS.ErrnoException;
       error.code = 'ENOENT';
-      mockReadConfigFile.mockRejectedValue(error);
+      mockFsReadFile.mockRejectedValue(error);
 
       const config = await loadConfig('/test/repo');
       expect(config.baseBranch).toBeUndefined();
@@ -388,7 +388,7 @@ worktree:
         return normalizedPath.includes(pattern);
       };
 
-      mockReadConfigFile.mockImplementation(async (path: string) => {
+      mockFsReadFile.mockImplementation(async (path: string) => {
         if (pathMatches(path, '/repo/.archon/config.yaml')) {
           return `
 docs:
@@ -410,7 +410,7 @@ docs:
         return normalizedPath.includes(pattern);
       };
 
-      mockReadConfigFile.mockImplementation(async (path: string) => {
+      mockFsReadFile.mockImplementation(async (path: string) => {
         if (pathMatches(path, '/repo/.archon/config.yaml')) {
           return `
 docs:
@@ -429,7 +429,7 @@ docs:
     test('docsPath is undefined when docs config is absent', async () => {
       const error = new Error('ENOENT') as NodeJS.ErrnoException;
       error.code = 'ENOENT';
-      mockReadConfigFile.mockRejectedValue(error);
+      mockFsReadFile.mockRejectedValue(error);
 
       const config = await loadConfig('/test/repo');
       expect(config.docsPath).toBeUndefined();
@@ -439,7 +439,7 @@ docs:
       const pathMatches = (path: string, pattern: string): boolean =>
         path.replace(/\\/g, '/').includes(pattern);
 
-      mockReadConfigFile.mockImplementation(async (path: string) => {
+      mockFsReadFile.mockImplementation(async (path: string) => {
         if (pathMatches(path, '/repo/.archon/config.yaml')) {
           return `
 env:
@@ -459,7 +459,7 @@ env:
     test('envVars is undefined when repo config has no env section', async () => {
       const error = new Error('ENOENT') as NodeJS.ErrnoException;
       error.code = 'ENOENT';
-      mockReadConfigFile.mockRejectedValue(error);
+      mockFsReadFile.mockRejectedValue(error);
 
       const config = await loadConfig('/test/repo');
       expect(config.envVars).toBeUndefined();
@@ -468,7 +468,7 @@ env:
     test('paths use archon defaults', async () => {
       const error = new Error('ENOENT') as NodeJS.ErrnoException;
       error.code = 'ENOENT';
-      mockReadConfigFile.mockRejectedValue(error);
+      mockFsReadFile.mockRejectedValue(error);
 
       const config = await loadConfig();
 
@@ -479,7 +479,7 @@ env:
 
   describe('settingSources config', () => {
     test('merges settingSources from global config', async () => {
-      mockReadConfigFile.mockResolvedValue(`
+      mockFsReadFile.mockResolvedValue(`
 assistants:
   claude:
     settingSources:
@@ -491,7 +491,7 @@ assistants:
     });
 
     test('defaults to undefined settingSources when not configured', async () => {
-      mockReadConfigFile.mockResolvedValue('');
+      mockFsReadFile.mockResolvedValue('');
       const config = await loadConfig();
       expect(config.assistants.claude.settingSources).toBeUndefined();
     });
@@ -503,7 +503,7 @@ assistants:
       };
 
       let globalConfigRead = false;
-      mockReadConfigFile.mockImplementation(async (path: string) => {
+      mockFsReadFile.mockImplementation(async (path: string) => {
         if (pathMatches(path, '/repo/.archon/config.yaml')) {
           return `assistants:\n  claude:\n    settingSources:\n      - project\n`;
         }
@@ -521,7 +521,7 @@ assistants:
     });
 
     test('toSafeConfig does not expose settingSources (server-internal field)', async () => {
-      mockReadConfigFile.mockResolvedValue(`
+      mockFsReadFile.mockResolvedValue(`
 assistants:
   claude:
     settingSources:
@@ -536,7 +536,7 @@ assistants:
 
   describe('updateGlobalConfig', () => {
     test('merges assistant config into existing file', async () => {
-      mockReadConfigFile.mockResolvedValue(`
+      mockFsReadFile.mockResolvedValue(`
 defaultAssistant: claude
 assistants:
   claude:
@@ -547,13 +547,13 @@ assistants:
         assistants: { claude: { model: 'opus' } },
       });
 
-      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
-      const writtenContent = mockWriteConfigFile.mock.calls[0]?.[1] as string;
+      expect(mockFsWriteFile).toHaveBeenCalledTimes(1);
+      const writtenContent = mockFsWriteFile.mock.calls[0]?.[1] as string;
       expect(writtenContent).toContain('opus');
     });
 
     test('preserves existing non-updated fields', async () => {
-      mockReadConfigFile.mockResolvedValue(`
+      mockFsReadFile.mockResolvedValue(`
 defaultAssistant: codex
 botName: MyBot
 assistants:
@@ -566,8 +566,8 @@ assistants:
         defaultAssistant: 'claude',
       });
 
-      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
-      const writtenContent = mockWriteConfigFile.mock.calls[0]?.[1] as string;
+      expect(mockFsWriteFile).toHaveBeenCalledTimes(1);
+      const writtenContent = mockFsWriteFile.mock.calls[0]?.[1] as string;
       expect(writtenContent).toContain('claude');
       expect(writtenContent).toContain('MyBot');
     });
@@ -575,22 +575,22 @@ assistants:
     test('creates config when file does not exist', async () => {
       const error = new Error('ENOENT') as NodeJS.ErrnoException;
       error.code = 'ENOENT';
-      mockReadConfigFile.mockRejectedValue(error);
+      mockFsReadFile.mockRejectedValue(error);
 
       await updateGlobalConfig({
         defaultAssistant: 'codex',
       });
 
-      expect(mockWriteConfigFile).toHaveBeenCalled();
-      const writtenContent = mockWriteConfigFile.mock.calls[0]?.[1] as string;
+      expect(mockFsWriteFile).toHaveBeenCalled();
+      const writtenContent = mockFsWriteFile.mock.calls[0]?.[1] as string;
       expect(writtenContent).toContain('codex');
     });
 
     test('throws on permission errors', async () => {
-      mockReadConfigFile.mockResolvedValue('');
+      mockFsReadFile.mockResolvedValue('');
       const permError = new Error('Permission denied') as NodeJS.ErrnoException;
       permError.code = 'EACCES';
-      mockWriteConfigFile.mockRejectedValue(permError);
+      mockFsWriteFile.mockRejectedValue(permError);
 
       await expect(updateGlobalConfig({ defaultAssistant: 'codex' })).rejects.toThrow(
         'Permission denied'
@@ -600,21 +600,21 @@ assistants:
 
   describe('toSafeConfig', () => {
     test('strips paths from MergedConfig', async () => {
-      mockReadConfigFile.mockResolvedValue('');
+      mockFsReadFile.mockResolvedValue('');
       const config = await loadConfig();
       const safe = toSafeConfig(config);
       expect(safe).not.toHaveProperty('paths');
     });
 
     test('strips entire commands object from MergedConfig', async () => {
-      mockReadConfigFile.mockResolvedValue('');
+      mockFsReadFile.mockResolvedValue('');
       const config = await loadConfig();
       const safe = toSafeConfig(config);
       expect(safe).not.toHaveProperty('commands');
     });
 
     test('strips additionalDirectories from assistants.codex', async () => {
-      mockReadConfigFile.mockResolvedValue(`
+      mockFsReadFile.mockResolvedValue(`
 assistants:
   codex:
     additionalDirectories:
@@ -626,7 +626,7 @@ assistants:
     });
 
     test('preserves non-sensitive fields', async () => {
-      mockReadConfigFile.mockResolvedValue('defaultAssistant: codex');
+      mockFsReadFile.mockResolvedValue('defaultAssistant: codex');
       const config = await loadConfig();
       const safe = toSafeConfig(config);
       expect(typeof safe.botName).toBe('string');

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -4,3 +4,4 @@
 
 export * from './config-types';
 export * from './config-loader';
+export * from './resolve-assistant';

--- a/packages/core/src/config/resolve-assistant.test.ts
+++ b/packages/core/src/config/resolve-assistant.test.ts
@@ -67,6 +67,8 @@ describe('resolveDefaultAssistant', () => {
     >);
 
     expect(await resolveDefaultAssistant('/repo')).toBe('pi');
+    // Contract: must pass repoPath so the repo's own .archon/config.yaml is merged.
+    expect(spyLoadConfig).toHaveBeenCalledWith('/repo');
   });
 
   test('falls back to first built-in provider when loadConfig fails and no SDK folder exists', async () => {

--- a/packages/core/src/config/resolve-assistant.test.ts
+++ b/packages/core/src/config/resolve-assistant.test.ts
@@ -1,0 +1,106 @@
+import { describe, test, expect, beforeEach, afterAll, spyOn, mock } from 'bun:test';
+import * as fsPromises from 'fs/promises';
+import * as providers from '@archon/providers';
+import * as configLoader from './config-loader';
+import { createMockLogger } from '../test/mocks/logger';
+
+const mockLogger = createMockLogger();
+mock.module('@archon/paths', () => ({
+  createLogger: () => mockLogger,
+}));
+
+import { resolveDefaultAssistant } from './resolve-assistant';
+
+let spyAccess: ReturnType<typeof spyOn>;
+let spyProviders: ReturnType<typeof spyOn>;
+let spyLoadConfig: ReturnType<typeof spyOn>;
+
+function enoent(): Error {
+  return Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+}
+
+beforeEach(() => {
+  spyAccess?.mockRestore();
+  spyAccess = spyOn(fsPromises, 'access').mockRejectedValue(enoent());
+
+  spyProviders?.mockRestore();
+  spyProviders = spyOn(providers, 'getRegisteredProviders').mockReturnValue([]);
+
+  spyLoadConfig?.mockRestore();
+  spyLoadConfig = spyOn(configLoader, 'loadConfig').mockResolvedValue({
+    assistant: 'claude',
+  } as Awaited<ReturnType<typeof configLoader.loadConfig>>);
+});
+
+afterAll(() => {
+  spyAccess?.mockRestore();
+  spyProviders?.mockRestore();
+  spyLoadConfig?.mockRestore();
+});
+
+describe('resolveDefaultAssistant', () => {
+  test('returns codex when .codex folder exists', async () => {
+    spyAccess.mockImplementation((p: string) =>
+      p.endsWith('.codex') ? Promise.resolve(undefined) : Promise.reject(enoent())
+    );
+
+    expect(await resolveDefaultAssistant('/repo')).toBe('codex');
+  });
+
+  test('returns claude when .claude folder exists and .codex does not', async () => {
+    spyAccess.mockImplementation((p: string) =>
+      p.endsWith('.claude') ? Promise.resolve(undefined) : Promise.reject(enoent())
+    );
+
+    expect(await resolveDefaultAssistant('/repo')).toBe('claude');
+  });
+
+  test('.codex wins over .claude when both folders exist', async () => {
+    spyAccess.mockResolvedValue(undefined);
+
+    expect(await resolveDefaultAssistant('/repo')).toBe('codex');
+  });
+
+  test('uses configured assistant when no SDK folder exists', async () => {
+    spyLoadConfig.mockResolvedValue({ assistant: 'pi' } as Awaited<
+      ReturnType<typeof configLoader.loadConfig>
+    >);
+
+    expect(await resolveDefaultAssistant('/repo')).toBe('pi');
+  });
+
+  test('falls back to first built-in provider when loadConfig fails and no SDK folder exists', async () => {
+    spyLoadConfig.mockRejectedValue(new Error('no config'));
+    spyProviders.mockReturnValue([
+      { id: 'pi', builtIn: true },
+      { id: 'codex', builtIn: true },
+    ]);
+
+    expect(await resolveDefaultAssistant('/repo')).toBe('pi');
+  });
+
+  test('falls back to claude when loadConfig fails and registry is empty', async () => {
+    spyLoadConfig.mockRejectedValue(new Error('no config'));
+    spyProviders.mockReturnValue([]);
+
+    expect(await resolveDefaultAssistant('/repo')).toBe('claude');
+  });
+
+  test('falls back to claude when config returns no assistant and registry has only community providers', async () => {
+    spyLoadConfig.mockResolvedValue({} as Awaited<ReturnType<typeof configLoader.loadConfig>>);
+    spyProviders.mockReturnValue([{ id: 'oh-my-pi', builtIn: false }]);
+
+    expect(await resolveDefaultAssistant('/repo')).toBe('claude');
+  });
+
+  test('SDK folder detection bypasses config — checked-in .codex wins over configured claude', async () => {
+    spyLoadConfig.mockResolvedValue({ assistant: 'claude' } as Awaited<
+      ReturnType<typeof configLoader.loadConfig>
+    >);
+    spyAccess.mockImplementation((p: string) =>
+      p.endsWith('.codex') ? Promise.resolve(undefined) : Promise.reject(enoent())
+    );
+
+    expect(await resolveDefaultAssistant('/repo')).toBe('codex');
+  });
+});

--- a/packages/core/src/config/resolve-assistant.ts
+++ b/packages/core/src/config/resolve-assistant.ts
@@ -1,7 +1,6 @@
 import { access } from 'fs/promises';
 import { join } from 'path';
 import { createLogger } from '@archon/paths';
-import { loadConfig } from './config-loader';
 
 let cachedLog: ReturnType<typeof createLogger> | undefined;
 function getLog(): ReturnType<typeof createLogger> {
@@ -39,7 +38,14 @@ export async function resolveDefaultAssistant(repoPath: string): Promise<string>
     // fall through
   }
 
+  // Lazy-load config-loader and @archon/providers so this module doesn't eagerly
+  // pull in their chains at every import site. config-loader.ts eagerly imports
+  // @archon/providers, which transitively pulls in claude/codex binary-resolver
+  // and their BUNDLED_IS_BINARY dependency on @archon/paths — that breaks adapter
+  // tests on Linux that mock @archon/paths without BUNDLED_IS_BINARY. The original
+  // clone.ts logic used dynamic imports for exactly this reason.
   try {
+    const { loadConfig } = await import('./config-loader');
     const config = await loadConfig();
     if (config.assistant) {
       getLog().debug({ provider: config.assistant }, 'assistant_default_from_config');
@@ -49,10 +55,6 @@ export async function resolveDefaultAssistant(repoPath: string): Promise<string>
     getLog().warn({ err }, 'config_load_failed_using_builtin_default');
   }
 
-  // Lazy-load @archon/providers so this module doesn't eagerly pull in provider
-  // SDK chains (and their @archon/paths BUNDLED_IS_BINARY dependency) at every
-  // import site. The original clone.ts logic also used a dynamic import for
-  // exactly this reason.
   const { getRegisteredProviders } = await import('@archon/providers');
   return getRegisteredProviders().find(p => p.builtIn)?.id ?? 'claude';
 }

--- a/packages/core/src/config/resolve-assistant.ts
+++ b/packages/core/src/config/resolve-assistant.ts
@@ -46,7 +46,10 @@ export async function resolveDefaultAssistant(repoPath: string): Promise<string>
   // clone.ts logic used dynamic imports for exactly this reason.
   try {
     const { loadConfig } = await import('./config-loader');
-    const config = await loadConfig();
+    // Pass repoPath so the repo's own .archon/config.yaml is merged on top of
+    // the global config — without it, a repo-level `assistant: pi` would be
+    // silently ignored during registration.
+    const config = await loadConfig(repoPath);
     if (config.assistant) {
       getLog().debug({ provider: config.assistant }, 'assistant_default_from_config');
       return config.assistant;

--- a/packages/core/src/config/resolve-assistant.ts
+++ b/packages/core/src/config/resolve-assistant.ts
@@ -1,0 +1,58 @@
+import { access } from 'fs/promises';
+import { join } from 'path';
+import { createLogger } from '@archon/paths';
+import { loadConfig } from './config-loader';
+
+let cachedLog: ReturnType<typeof createLogger> | undefined;
+function getLog(): ReturnType<typeof createLogger> {
+  if (!cachedLog) cachedLog = createLogger('config.resolve-assistant');
+  return cachedLog;
+}
+
+/**
+ * Resolve the default AI assistant for a newly registered codebase.
+ *
+ * Precedence: SDK folder detection (`.codex` / `.claude` in repo) → configured
+ * `assistant` from `.archon/config.yaml` → first built-in provider in the
+ * registry → hardcoded `'claude'`.
+ *
+ * Folder detection wins over config because a checked-in `.codex` or `.claude`
+ * directory is an explicit per-repo signal from the user.
+ */
+export async function resolveDefaultAssistant(repoPath: string): Promise<string> {
+  const codexFolder = join(repoPath, '.codex');
+  const claudeFolder = join(repoPath, '.claude');
+
+  try {
+    await access(codexFolder);
+    getLog().debug({ path: codexFolder }, 'assistant_detected_codex');
+    return 'codex';
+  } catch {
+    // fall through
+  }
+
+  try {
+    await access(claudeFolder);
+    getLog().debug({ path: claudeFolder }, 'assistant_detected_claude');
+    return 'claude';
+  } catch {
+    // fall through
+  }
+
+  try {
+    const config = await loadConfig();
+    if (config.assistant) {
+      getLog().debug({ provider: config.assistant }, 'assistant_default_from_config');
+      return config.assistant;
+    }
+  } catch (err) {
+    getLog().warn({ err }, 'config_load_failed_using_builtin_default');
+  }
+
+  // Lazy-load @archon/providers so this module doesn't eagerly pull in provider
+  // SDK chains (and their @archon/paths BUNDLED_IS_BINARY dependency) at every
+  // import site. The original clone.ts logic also used a dynamic import for
+  // exactly this reason.
+  const { getRegisteredProviders } = await import('@archon/providers');
+  return getRegisteredProviders().find(p => p.builtIn)?.id ?? 'claude';
+}

--- a/packages/core/src/handlers/clone.test.ts
+++ b/packages/core/src/handlers/clone.test.ts
@@ -60,6 +60,12 @@ mock.module('@archon/paths', () => ({
   }),
 }));
 
+// ── config-loader mock ──────────────────────────────────────────────────────
+const mockLoadConfig = mock(() => Promise.resolve({ assistant: 'claude' }));
+mock.module('../config/config-loader', () => ({
+  loadConfig: mockLoadConfig,
+}));
+
 // ── utils/commands mock ─────────────────────────────────────────────────────
 const mockFindMarkdownFilesRecursive = mock(() => Promise.resolve([]));
 mock.module('../utils/commands', () => ({
@@ -103,6 +109,8 @@ function clearMocks(): void {
   mockFindCodebaseByName.mockReset();
   mockUpdateCodebase.mockReset();
   mockFindMarkdownFilesRecursive.mockReset();
+  mockLoadConfig.mockReset();
+  mockLoadConfig.mockResolvedValue({ assistant: 'claude' });
   mockLogger.info.mockClear();
   mockLogger.debug.mockClear();
   mockLogger.warn.mockClear();
@@ -769,6 +777,32 @@ describe('cloneRepository', () => {
     });
 
     test('defaults to claude when neither .codex nor .claude folder exists', async () => {
+      spyFsAccess.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+      mockCreateCodebase.mockResolvedValueOnce(
+        makeCodebase({ ai_assistant_type: 'claude' }) as ReturnType<typeof makeCodebase>
+      );
+
+      await cloneRepository('https://github.com/owner/repo');
+
+      const createCall = mockCreateCodebase.mock.calls[0] as [{ ai_assistant_type: string }];
+      expect(createCall[0].ai_assistant_type).toBe('claude');
+    });
+
+    test('uses configured provider when no .codex or .claude folder exists', async () => {
+      mockLoadConfig.mockResolvedValue({ assistant: 'pi' });
+      spyFsAccess.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+      mockCreateCodebase.mockResolvedValueOnce(
+        makeCodebase({ ai_assistant_type: 'pi' }) as ReturnType<typeof makeCodebase>
+      );
+
+      await cloneRepository('https://github.com/owner/repo');
+
+      const createCall = mockCreateCodebase.mock.calls[0] as [{ ai_assistant_type: string }];
+      expect(createCall[0].ai_assistant_type).toBe('pi');
+    });
+
+    test('falls back to claude when loadConfig fails', async () => {
+      mockLoadConfig.mockRejectedValue(new Error('config load failed'));
       spyFsAccess.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
       mockCreateCodebase.mockResolvedValueOnce(
         makeCodebase({ ai_assistant_type: 'claude' }) as ReturnType<typeof makeCodebase>

--- a/packages/core/src/handlers/clone.ts
+++ b/packages/core/src/handlers/clone.ts
@@ -17,6 +17,7 @@ import {
 } from '@archon/paths';
 import { findMarkdownFilesRecursive } from '../utils/commands';
 import { createLogger } from '@archon/paths';
+import { resolveDefaultAssistant } from '../config/resolve-assistant';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
@@ -138,28 +139,7 @@ async function registerRepoAtPath(
   name: string,
   repositoryUrl: string | null
 ): Promise<RegisterResult> {
-  // Auto-detect assistant type based on SDK folder conventions.
-  // Built-in providers use well-known folders (.claude/, .codex/).
-  // Falls back to first registered built-in provider if no folder detected.
-  const { getRegisteredProviders } = await import('@archon/providers');
-  const defaultProvider = getRegisteredProviders().find(p => p.builtIn)?.id ?? 'claude';
-  let suggestedAssistant = defaultProvider;
-  const codexFolder = join(targetPath, '.codex');
-  const claudeFolder = join(targetPath, '.claude');
-
-  try {
-    await access(codexFolder);
-    suggestedAssistant = 'codex';
-    getLog().debug({ path: codexFolder }, 'assistant_detected_codex');
-  } catch {
-    try {
-      await access(claudeFolder);
-      suggestedAssistant = 'claude';
-      getLog().debug({ path: claudeFolder }, 'assistant_detected_claude');
-    } catch {
-      getLog().debug({ provider: defaultProvider }, 'assistant_default_from_registry');
-    }
-  }
+  const suggestedAssistant = await resolveDefaultAssistant(targetPath);
 
   // Check if a codebase with this name already exists (dedup by project identity)
   const existing = await codebaseDb.findCodebaseByName(name);


### PR DESCRIPTION
## Summary

- **Problem:** New codebases registered via the GitHub / GitLab / Gitea forge adapters were silently created with `ai_assistant_type='claude'` regardless of the user's configured assistant. `clone.ts` already did the right resolution (config + SDK folder detection), but the three forge `createCodebase` call sites passed no `ai_assistant_type` at all. Issue #1580.
- **Why it matters:** A user with `assistant: pi` in `.archon/config.yaml` who first interacted with Archon by `@archon`-mentioning on a GitHub PR would get claude bound to that codebase forever, with no UI surface to discover or fix the mismatch.
- **What changed:** Extracted a `resolveDefaultAssistant(repoPath)` helper into `packages/core/src/config/resolve-assistant.ts` with the precedence used by `clone.ts` (`.codex` / `.claude` folder → `loadConfig().assistant` → first built-in provider → `'claude'`). `clone.ts` and the three forge adapters now call the helper.
- **What did not change (scope boundary):** `createCodebase` stays a thin DB function with the simple `?? 'claude'` fallback — no dynamic-import config-loading inside the DB layer. The orchestrator path (which already resolved via `loadConfig` before calling `createCodebase`) is untouched.

## UX Journey

### Before

\`\`\`
User                       Forge adapter              DB
────                       ─────────────              ──
@archon on PR ────────────▶ createCodebase({
                              name, repo_url,
                              default_cwd
                            }) ────────────────────▶ INSERT ai_assistant_type='claude'  ← always

(silently ignores config.assistant)
\`\`\`

### After

\`\`\`
User                       Forge adapter              resolve-assistant            DB
────                       ─────────────              ─────────────────            ──
@archon on PR ────────────▶ resolveDefaultAssistant ─▶ .codex? .claude?
                                                       loadConfig().assistant?
                                                       first builtIn provider?     ai_assistant_type=resolved  ← respects user config
                              createCodebase({          'claude'
                                ai_assistant_type:    ─▶
                                  resolved
                              }) ─────────────────────────────────────────────▶ INSERT
\`\`\`

## Architecture Diagram

### Before

\`\`\`
clone.ts ─── inline 27-line block ──▶ getRegisteredProviders + loadConfig + access(.codex/.claude)
github/adapter.ts ───────────────────▶ createCodebase (no ai_assistant_type)
gitlab/adapter.ts ───────────────────▶ createCodebase (no ai_assistant_type)
gitea/adapter.ts  ───────────────────▶ createCodebase (no ai_assistant_type)
\`\`\`

### After

\`\`\`
clone.ts ──────────────────[~]──▶ resolveDefaultAssistant() ─[+]──▶ createCodebase({ ai_assistant_type })
github/adapter.ts ─────────[~]──▶ resolveDefaultAssistant() ─[+]──▶ createCodebase({ ai_assistant_type })
gitlab/adapter.ts ─────────[~]──▶ resolveDefaultAssistant() ─[+]──▶ createCodebase({ ai_assistant_type })
gitea/adapter.ts  ─────────[~]──▶ resolveDefaultAssistant() ─[+]──▶ createCodebase({ ai_assistant_type })
                                  resolve-assistant.ts [+]
                                  resolve-assistant.test.ts [+]
\`\`\`

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `clone.ts` | `resolveDefaultAssistant` | **new** | replaces 27-line inline block |
| `forge/github/adapter.ts` | `resolveDefaultAssistant` | **new** | previously passed no `ai_assistant_type` |
| `community/forge/gitlab/adapter.ts` | `resolveDefaultAssistant` | **new** | same as github |
| `community/forge/gitea/adapter.ts` | `resolveDefaultAssistant` | **new** | same as github |
| `resolve-assistant.ts` | `@archon/providers` | **new (lazy)** | dynamic import inside function body to avoid eager SDK chain load at adapter import time |
| `db/codebases.ts` | `@archon/providers` | unchanged | reverted to dev's simple `?? 'claude'` fallback |
| `db/codebases.ts` | `config-loader` | unchanged | reverted; no dynamic import in DB layer |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `core`
- Module: `core:config`, `adapters:github`, `adapters:gitlab`, `adapters:gitea`

## Test plan

\`\`\`bash
bun run type-check    # clean
bun run lint          # clean (--max-warnings 0)
bun run format:check  # clean
bun run test          # only pre-existing macOS telegram-markdown failures (unrelated, present on dev)
\`\`\`

- Evidence: exact CI batch \`bun test src/db/adapters/sqlite.test.ts src/db/codebases.test.ts ... src/config/ src/state/\` → 366 pass / 0 fail
- 8 new unit tests in `resolve-assistant.test.ts` cover: SDK folder detection, config preference, registry fallback, hardcoded `'claude'` fallback, folder-vs-config precedence

## Security Impact

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No (same `access()` calls on `.codex` / `.claude` that clone.ts already did)

## Compatibility / Migration

- Backward compatible? Yes — codebases already in the DB are unchanged; only NEW codebases pick the resolved assistant.
- Config/env changes? No
- Database migration needed? No

## Human Verification

- Verified scenarios: ran the exact CI batched test invocation locally on macOS (366 pass / 0 fail); manually traced the import chain that broke adapter tests on Linux (`BUNDLED_IS_BINARY` missing from mocked `@archon/paths`) and confirmed the dynamic-import fix preserves the original `clone.ts` lazy-loading pattern.
- Edge cases: empty registry + loadConfig failure → hardcoded `'claude'`; SDK folder always wins over configured assistant; community-only registry → `'claude'`.
- What was not verified: actual forge-adapter end-to-end (no GitHub PR test fixture in this repo), but the helper is exercised by the existing `clone.test.ts` integration tests.

## Side Effects / Blast Radius

- Affected subsystems/workflows: codebase registration on first contact (clone + 3 forge adapters).
- Potential unintended effects: a user who had a `.codex` folder in their forge-cloned repo but `assistant: claude` in config will now get codex (the folder wins). This matches existing `clone.ts` behavior; the forge paths just lacked the resolution entirely.
- Guardrails: existing log lines (\`assistant_detected_codex\`, \`assistant_default_from_config\`) surface which branch fired.

## Rollback Plan

- Fast rollback: revert this commit. The forge adapters return to silently defaulting to `'claude'` (the pre-existing #1580 behavior). No data migration needed.

## Risks and Mitigations

- **Risk:** Tests in the same `bun test` batch that mock `@archon/paths` could be affected by the new `@archon/providers` import chain.
  - **Mitigation:** Resolved by lazy-loading `@archon/providers` inside the helper function body (matching the original `clone.ts` pattern). Verified locally that `@archon/adapters` and `@archon/server` test packages run clean.

## Credit

This work supersedes #1700 (closed). Thanks to @kagura-agent for the initial investigation and the diagnosis that surfaced the underlying mock.module pollution on Linux. The `config-loader.test.ts` switch to mocking `fs/promises` (instead of `mock.module('./config-loader')`) is preserved from their work — it's a real cross-platform improvement.

Closes #1580.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic default AI assistant resolution when registering or creating repositories; adapters now apply the resolved assistant to new codebases.
  * Assistant resolution prioritizes repository SDK markers (if present) and falls back to config or built-in providers.

* **Configuration**
  * Added and re-exported a shared assistant-resolution utility for consistent behavior across flows.

* **Tests**
  * New and updated tests covering assistant resolution, SDK-folder detection, and config-file behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1729?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->