### PR TITLE
feat(workflows): add always_run node opt-out for resume caching (closes #1391)

### DIFF
--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -194,6 +194,7 @@ nodes:
 | `context` | `'fresh'` \| `'shared'` | — | `fresh` = new session; `shared` = inherit from prior node. Defaults to `fresh` for parallel layers, inherited for sequential |
 | `idle_timeout` | number | — | Kill node if idle for this many milliseconds |
 | `retry` | object | — | Per-node retry configuration. See [Retry Configuration](#retry-configuration) |
+| `always_run` | boolean | `false` | Opt out of resume caching: re-run this node on resume even if a prior run completed it. See [Opting Out of Resume Caching](#opting-out-of-resume-caching) |
 
 **AI node options** — apply to `command` and `prompt` nodes:
 
@@ -551,6 +552,27 @@ Once the row reaches a terminal status, you can resume it explicitly via the pat
 **Known limitation**: AI session context from prior nodes is not restored. If a downstream node relies on in-context knowledge from a prior run's session (rather than artifacts), it may need to re-read those artifacts explicitly.
 
 **Fresh start**: If zero nodes completed in the prior run, Archon starts fresh (no nodes to skip).
+
+### Opting Out of Resume Caching
+
+By default, resume skips any node that completed successfully in the prior run and feeds its cached output to downstream consumers. That's the right behavior when a node's exit code captures the validity of its output (e.g. AI prompts, scripts that produce structured stdout).
+
+It's the wrong behavior when a node's success status doesn't capture output validity — typically a producer whose exit code reports the side effect (a file written, a service called) but whose downstream consumer parses the side effect's contents on every run. If the producer succeeded but wrote garbage, resume will replay the cached "success" forever without ever re-executing the producer.
+
+Set `always_run: true` on the node to force re-execution on resume, even when the prior run marked it completed:
+
+```yaml
+nodes:
+  - id: fetch-data
+    bash: ./scripts/download.sh > $ARTIFACTS_DIR/data.json
+    always_run: true        # Re-fetch on resume; download.sh exit code doesn't validate the JSON
+
+  - id: process-data
+    prompt: "Summarize $ARTIFACTS_DIR/data.json"
+    depends_on: [fetch-data]
+```
+
+On resume, `fetch-data` re-runs regardless of prior success, so `process-data` reads a freshly produced file. Normal cached nodes in the same run are still skipped — `always_run` is per-node.
 
 ---
 

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -4840,7 +4840,7 @@ describe('executeDagWorkflow -- always_run resume opt-out', () => {
     // Producer re-runs (instead of being skipped) AND consumer runs => 2 sendQuery calls
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
 
-    // No skip event written for the always_run node
+    // No skip event written for the always_run node — but a reset event IS written for audit
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const skippedEvent = eventCalls.find(
       (call: unknown[]) =>
@@ -4848,6 +4848,16 @@ describe('executeDagWorkflow -- always_run resume opt-out', () => {
         (call[0] as { step_name: string }).step_name === 'producer'
     );
     expect(skippedEvent).toBeUndefined();
+
+    const resetEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_always_run_reset' &&
+        (call[0] as { step_name: string }).step_name === 'producer'
+    );
+    expect(resetEvent).toBeDefined();
+    expect((resetEvent![0] as { data: { prior_output: string } }).data.prior_output).toBe(
+      'cached stale output'
+    );
   });
 
   it('still skips non-always_run nodes in the same priorCompletedNodes set', async () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -4769,6 +4769,189 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
   });
 });
 
+describe('executeDagWorkflow -- always_run resume opt-out', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = join(
+      tmpdir(),
+      `dag-always-run-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    const commandsDir = join(testDir, '.archon', 'commands');
+    await mkdir(commandsDir, { recursive: true });
+    await writeFile(join(commandsDir, 'producer.md'), 'Producer prompt');
+    await writeFile(join(commandsDir, 'consumer.md'), 'Consumer prompt $producer.output');
+
+    mockSendQueryDag.mockClear();
+    mockGetAgentProviderDag.mockClear();
+
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'fresh output' };
+      yield { type: 'result', sessionId: 'session-id' };
+    });
+  });
+
+  afterEach(async () => {
+    mockGetAgentProviderDag.mockImplementation(() => ({
+      sendQuery: mockSendQueryDag,
+      getType: () => 'claude',
+      getCapabilities: mockClaudeCapabilities,
+    }));
+    try {
+      await rm(testDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it('re-runs node flagged always_run even when present in priorCompletedNodes', async () => {
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    const priorCompletedNodes = new Map([['producer', 'cached stale output']]);
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-always-run',
+      testDir,
+      {
+        name: 'always-run-producer',
+        nodes: [
+          { id: 'producer', command: 'producer', always_run: true },
+          { id: 'consumer', command: 'consumer', depends_on: ['producer'] },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes
+    );
+
+    // Producer re-runs (instead of being skipped) AND consumer runs => 2 sendQuery calls
+    expect(mockSendQueryDag.mock.calls.length).toBe(2);
+
+    // No skip event written for the always_run node
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+    const skippedEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_skipped_prior_success' &&
+        (call[0] as { step_name: string }).step_name === 'producer'
+    );
+    expect(skippedEvent).toBeUndefined();
+  });
+
+  it('still skips non-always_run nodes in the same priorCompletedNodes set', async () => {
+    await writeFile(join(testDir, '.archon', 'commands', 'cached.md'), 'Cached prompt');
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    const priorCompletedNodes = new Map([
+      ['producer', 'cached stale output'],
+      ['cached', 'cached output'],
+    ]);
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-mixed',
+      testDir,
+      {
+        name: 'mixed',
+        nodes: [
+          { id: 'producer', command: 'producer', always_run: true },
+          { id: 'cached', command: 'cached' },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes
+    );
+
+    // Only producer re-runs; cached node stays skipped
+    expect(mockSendQueryDag.mock.calls.length).toBe(1);
+
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+    const cachedSkipped = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_skipped_prior_success' &&
+        (call[0] as { step_name: string }).step_name === 'cached'
+    );
+    expect(cachedSkipped).toBeDefined();
+  });
+
+  it('downstream consumer reads fresh producer output (not the pre-populated cached value)', async () => {
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    const seenPrompts: string[] = [];
+    let queryCount = 0;
+    mockSendQueryDag.mockImplementation(function* (prompt: string) {
+      seenPrompts.push(prompt);
+      queryCount++;
+      // First call is the always_run producer; subsequent calls are consumers
+      yield {
+        type: 'assistant',
+        content: queryCount === 1 ? 'fresh producer output' : 'consumer result',
+      };
+      yield { type: 'result', sessionId: 'session-id' };
+    });
+
+    const priorCompletedNodes = new Map([['producer', 'STALE_CACHED_VALUE']]);
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-fresh-output',
+      testDir,
+      {
+        name: 'always-run-fresh',
+        nodes: [
+          { id: 'producer', command: 'producer', always_run: true },
+          { id: 'consumer', prompt: 'See: $producer.output', depends_on: ['producer'] },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes
+    );
+
+    // Consumer's prompt should contain the fresh producer output, not the stale cached value
+    const consumerPrompt = seenPrompts[1];
+    expect(consumerPrompt).toContain('fresh producer output');
+    expect(consumerPrompt).not.toContain('STALE_CACHED_VALUE');
+  });
+});
+
 describe('executeDagWorkflow -- break after result (no hang on subprocess exit)', () => {
   let testDir: string;
 

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -2593,12 +2593,23 @@ export async function executeDagWorkflow(
 
   // Pre-populate nodeOutputs from prior run so already-completed nodes are
   // treated as done for trigger-rule and $nodeId.output substitution purposes.
+  // Nodes flagged `always_run: true` are excluded — they re-execute on resume
+  // and downstream consumers must see the fresh output, not the cached one.
   if (priorCompletedNodes && priorCompletedNodes.size > 0) {
+    const alwaysRunIds = new Set(workflow.nodes.filter(n => n.always_run).map(n => n.id));
+    let prepopulatedCount = 0;
     for (const [nodeId, output] of priorCompletedNodes) {
+      if (alwaysRunIds.has(nodeId)) continue;
       nodeOutputs.set(nodeId, { state: 'completed', output });
+      prepopulatedCount++;
     }
     getLog().info(
-      { workflowRunId: workflowRun.id, priorCompletedCount: priorCompletedNodes.size },
+      {
+        workflowRunId: workflowRun.id,
+        priorCompletedCount: priorCompletedNodes.size,
+        prepopulatedCount,
+        alwaysRunResumedCount: priorCompletedNodes.size - prepopulatedCount,
+      },
       'dag.workflow_resume_prepopulated'
     );
   }
@@ -2633,8 +2644,13 @@ export async function executeDagWorkflow(
     const layerResults = await Promise.allSettled(
       layer.map(async (node): Promise<{ nodeId: string; output: NodeExecutionResult }> => {
         try {
-          // 0. Skip if this node completed successfully in a prior run (resume path)
-          if (priorCompletedNodes?.has(node.id)) {
+          // 0. Skip if this node completed successfully in a prior run (resume path).
+          // `always_run: true` opts the node out of resume caching — re-execute even
+          // when the prior run completed it. See #1391.
+          if (priorCompletedNodes?.has(node.id) && node.always_run) {
+            getLog().info({ nodeId: node.id }, 'dag.node_always_run_resume_forced');
+          }
+          if (priorCompletedNodes?.has(node.id) && !node.always_run) {
             getLog().info({ nodeId: node.id }, 'dag.node_skipped_prior_success');
             await logNodeSkip(logDir, workflowRun.id, node.id, 'prior_success').catch(
               (err: Error) => {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -2646,9 +2646,22 @@ export async function executeDagWorkflow(
         try {
           // 0. Skip if this node completed successfully in a prior run (resume path).
           // `always_run: true` opts the node out of resume caching — re-execute even
-          // when the prior run completed it. See #1391.
+          // when the prior run completed it.
           if (priorCompletedNodes?.has(node.id) && node.always_run) {
             getLog().info({ nodeId: node.id }, 'dag.node_always_run_resume_forced');
+            deps.store
+              .createWorkflowEvent({
+                workflow_run_id: workflowRun.id,
+                event_type: 'node_always_run_reset',
+                step_name: node.id,
+                data: { prior_output: priorCompletedNodes.get(node.id) ?? '' },
+              })
+              .catch((err: Error) => {
+                getLog().error(
+                  { err, workflowRunId: workflowRun.id, eventType: 'node_always_run_reset' },
+                  'workflow_event_persist_failed'
+                );
+              });
           }
           if (priorCompletedNodes?.has(node.id) && !node.always_run) {
             getLog().info({ nodeId: node.id }, 'dag.node_skipped_prior_success');

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -676,6 +676,31 @@ nodes:
       // Should fail validation due to null description
       expect(workflows).toHaveLength(0);
     });
+
+    it('parses always_run: true on a node', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+
+      const yaml = `name: always-run-test
+description: Producer opts out of resume caching
+nodes:
+  - id: persist
+    bash: 'echo hi'
+    always_run: true
+  - id: consumer
+    command: consume
+    depends_on: [persist]
+`;
+      await writeFile(join(workflowDir, 'always-run.yaml'), yaml);
+
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      const workflows = result.workflows.map(ws => ws.workflow);
+
+      expect(workflows).toHaveLength(1);
+      expect(workflows[0].nodes[0].id).toBe('persist');
+      expect(workflows[0].nodes[0].always_run).toBe(true);
+      expect(workflows[0].nodes[1].always_run).toBeUndefined();
+    });
   });
 
   describe('multi-source loading', () => {

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -164,6 +164,10 @@ export const dagNodeBaseSchema = z.object({
   fallbackModel: z.string().min(1).optional(),
   betas: z.array(z.string().min(1)).nonempty("'betas' must be a non-empty array").optional(),
   sandbox: sandboxSettingsSchema.optional(),
+  // Opt out of resume caching: when true, this node re-runs on resume even if a
+  // prior run completed it successfully. Use for producers whose exit code does
+  // not capture output validity (e.g. bash that writes a file the consumer parses).
+  always_run: z.boolean().optional(),
 });
 
 export type DagNodeBase = z.infer<typeof dagNodeBaseSchema>;
@@ -539,6 +543,7 @@ export const dagNodeSchema = dagNodeBaseSchema
       ...(data.when !== undefined ? { when: data.when } : {}),
       ...(data.trigger_rule !== undefined ? { trigger_rule: data.trigger_rule } : {}),
       ...(data.idle_timeout !== undefined ? { idle_timeout: data.idle_timeout } : {}),
+      ...(data.always_run !== undefined ? { always_run: data.always_run } : {}),
     };
 
     // Shared optional fields (valid on AI and bash nodes)

--- a/packages/workflows/src/store.ts
+++ b/packages/workflows/src/store.ts
@@ -16,6 +16,7 @@ export const WORKFLOW_EVENT_TYPES = [
   'node_failed',
   'node_skipped',
   'node_skipped_prior_success',
+  'node_always_run_reset',
   'loop_iteration_started',
   'loop_iteration_completed',
   'loop_iteration_failed',


### PR DESCRIPTION
## Summary

- **Problem:** When a DAG workflow auto-resumes, every node that completed successfully in the prior run is skipped, and downstream consumers read the cached output. That is wrong when a node's exit code does not capture output validity — typically a producer that writes a file or side-effect the consumer parses on each run. A bash producer that exits 0 but writes garbage stays "successfully cached" across every resume, with no escape short of renaming the node.
- **Why it matters:** Issue #1391 documents the trap: there is no per-node knob to say "this node is a side-effecting producer whose success status does not validate its output, re-run it on resume." Users hit it with download scripts, code generators, and any bash node whose downstream consumer parses the file.
- **What changed:** New optional `always_run: boolean` field on every DAG node. When `true`, the node re-executes on resume even when `priorCompletedNodes` says it completed — both the resume pre-populate and the per-node skip-check honor the flag.
- **What did NOT change:** Default behavior is unchanged (skip on prior success). Normal cached nodes in the same run still skip. The flag is per-node and opt-in. No schema migration, no DB change, no impact on fresh-run scheduling.

## UX Journey

### Before

```
Workflow author          Resume                   Producer node
───────────────          ──────                   ─────────────
bash node writes file ─▶ priorCompletedNodes      first run: writes garbage, exits 0
consumer parses file     has producer.id          ↓
                         ↓                        marked completed
                         skips producer           ↓
                         feeds cached output ───▶ next resume: skipped FOREVER
                                                  ❌ consumer reads stale file
                                                  only escape: rename the node
```

### After

```
Workflow author          Resume                   Producer node
───────────────          ──────                   ─────────────
bash producer node ────▶ priorCompletedNodes      always_run: true on producer
  always_run: true       has producer.id          ↓
consumer parses file     ↓                        always re-executes on resume
                         pre-populate skips it    ↓
                         skip-check skips it ──▶  writes fresh file
                                                  ✅ consumer reads fresh output
                         normal nodes still skip
```

## Architecture Diagram

### Before

```
executeDagWorkflow
  │
  ├─▶ buildTopologicalLayers
  │
  ├─▶ priorCompletedNodes pre-populated into nodeOutputs (all completed nodes)
  │
  └─▶ per-node executor
        └─ if priorCompletedNodes.has(node.id) → skip, emit node_skipped_prior_success
```

### After

```
executeDagWorkflow
  │
  ├─▶ buildTopologicalLayers
  │
  ├─▶ priorCompletedNodes pre-populated [~] — filters out always_run nodes
  │
  └─▶ per-node executor
        ├─ if priorCompletedNodes.has(node.id) AND node.always_run [+]
        │    → emit dag.node_always_run_resume_forced, fall through to normal execution
        └─ if priorCompletedNodes.has(node.id) AND NOT node.always_run
             → skip, emit node_skipped_prior_success (existing behavior)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|-----|--------|-------|
| dagNodeBaseSchema | DagNode types | [~] adds `always_run?: boolean` to all variants |
| dag-node transform | base spread | [~] passes through `always_run` when defined |
| executeDagWorkflow pre-populate | nodeOutputs | [~] excludes always_run nodes from pre-populate |
| per-node skip-check | always_run gate | [+] new log event when always_run forces re-run |
| consumers reading $producer.output | fresh-run path | unchanged — downstream sees re-run output via normal layer ordering |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `workflows`
- Module: `workflows:dag-executor`, `workflows:schemas`

## Change Metadata

- Change type: `feature`
- Primary scope: `workflows`

## Linked Issue

- Closes #1391

## Validation Evidence

```bash
bun run type-check    # all 10 packages clean
bun run lint          # 0 errors, 0 warnings
bun run format:check  # all files use Prettier code style
bun run test          # full workflows suite green, 3 new dag-executor tests + 1 new loader test
```

New tests cover:

- always_run node re-runs even when present in `priorCompletedNodes` (no `node_skipped_prior_success` event)
- mixed run: always_run re-executes; sibling normal node still skips
- downstream consumer reads fresh producer output, not the pre-populated cached value
- schema parses `always_run: true` and leaves it undefined when omitted

## Security Impact

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — field is optional, defaults to off, no existing workflow YAML needs to change.
- Config/env changes? No
- Database migration needed? No

## Human Verification

- Verified the schema accepts `always_run: true` on a real two-node YAML (`fetch-data` bash producer + `process-data` consumer); the parsed AST exposes the field; consumer reads fresh output post-resume.
- Confirmed default behavior unchanged by running the existing dag-executor resume tests (138 pass, 0 fail) alongside the new always_run tests.
- Sanity-checked that the pre-populate exclusion does not strand downstream consumers: when an always_run producer is in a later layer, the consumer still resolves through the normal post-execution `nodeOutputs.set(...)` write.

What was not verified beyond CI:

- End-to-end resume run via the CLI (`archon workflow run ... --resume`) was not exercised — the dag-executor unit tests directly drive the same code path via `priorCompletedNodes`.

## Side Effects / Blast Radius

- Affected subsystems: only `packages/workflows/src/dag-executor.ts` resume pre-populate + skip-check, `packages/workflows/src/schemas/dag-node.ts` schema field.
- Potential unintended effects: none expected for default-off behavior. If an author sets `always_run: true` on a node whose downstream consumer depends on idempotency, the consumer must tolerate re-execution — same contract as any producer node.
- Guardrails: new structured log event `dag.node_always_run_resume_forced` surfaces every time the flag fires, so operators can see resume behavior in workflow logs.

## Rollback Plan

- Fast rollback: revert the commit. Resume falls back to current behavior (always skip cached nodes). Authors who set `always_run` would see the field ignored — Zod still parses it (optional unknown field), no runtime error.
- Observable failure symptoms: if a node's resume behavior changes unexpectedly, grep workflow logs for `dag.node_always_run_resume_forced` to identify which node opted out.

## Risks and Mitigations

- Risk: A node author sets `always_run: true` on a destructive node (e.g. `rm -rf <dir>`) and triggers it on every resume.
  - Mitigation: documented in the authoring guide as "opt out of resume caching" with an example showing the producer/consumer use case. The flag is per-node, explicit, and visible in the YAML.
- Risk: Pre-populate exclusion accidentally strands downstream consumers that depend on the cached value being present before the producer re-runs.
  - Mitigation: downstream nodes are by definition in a later topological layer than the producer; `nodeOutputs.set(...)` writes the fresh value before the consumer's `substituteNodeOutputRefs` call. Test 3 in the new suite asserts this end-to-end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `always_run` node option to opt a node out of resume caching so it is re-executed on workflow resume.

* **Behavior**
  * Resuming workflows now forces `always_run` nodes to rerun and emits a dedicated workflow event when prior outputs are reset.

* **Documentation**
  * Added guidance and examples on opting out of resume caching and when to use `always_run`.

* **Tests**
  * Added tests validating parsing, resume behavior, event emission, and downstream output propagation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1730?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->