### PR TITLE
docs(direction): add community-providers policy section

### DIFF
--- a/.archon/maintainer-standup/direction.md
+++ b/.archon/maintainer-standup/direction.md
@@ -26,6 +26,24 @@ This file is **committed and shared by all maintainers**. Edit deliberately — 
 - **Not opinionated about the dev environment.** No mandatory editor integrations, framework lock-in, or Docker requirement beyond what users opt into.
 - **Not a workflow marketplace.** Bundled workflows are reference patterns; Archon is not aiming to be a hub for third-party workflow distribution.
 
+## Community providers
+
+Archon ships built-in providers for Claude (`@anthropic-ai/claude-agent-sdk`) and Codex (`@openai/codex-sdk`). Pi (`@mariozechner/pi-coding-agent`) is the reference community provider and sets the pattern others should follow.
+
+**Acceptance criteria** for new community providers:
+
+- **Coding-agent SDK only.** The provider must wrap an existing coding-agent SDK — one that handles file edits, tool use, multi-turn sessions, and planning. Raw LLM API integrations (`chat.completions`-style) are out of scope. Pi already covers ~20 LLM backends via one harness, so single-model wrappers duplicate work that is already done.
+- **Match the Pi pattern.** Structure mirrors `packages/providers/src/community/pi/` — provider class implementing `IAgentProvider`, options translator, event bridge, capability matrix, registered with `builtIn: false`. Tests at parity with the Pi suite (config, options-translator, event-bridge, provider, session-resolver as the baseline).
+- **Docs page.** Add the provider to `packages/docs-web/src/content/docs/getting-started/ai-assistants.md` with setup, capability matrix, and supported config keys.
+
+**Maintenance policy:**
+
+- We accept any provider that meets the criteria above. There is no cap.
+- The contributor and the community maintain the provider. Archon maintainers do not own upstream-SDK breaks for community providers.
+- A community provider that goes non-functional — CI broken, upstream SDK gone, no maintainer response — is marked deprecated and removed in the next minor release unless someone from the community submits a fix.
+
+When citing this policy in a PR comment: `direction.md §community-providers`.
+
 ## Open questions (no stance yet)
 
 These are direction calls we haven't made. PRs that touch these areas should surface the question for explicit decision rather than be silently accepted or rejected. The workflow may add to this list as new questions appear.


### PR DESCRIPTION
## Summary

- **Problem:** Every community-provider PR review (#1505 Copilot, #1384 OpenCode, #1545 Oh My Pi, previously #1351/#1648) has stalled on the same meta-question: *should this match Pi or not, what's the acceptance bar, who maintains it, when do we remove it?* No documented policy meant each review devolved into ad-hoc debate.
- **Why it matters:** Carry-over direction question marked **day 23+ overdue** in the standup brief. Three queued community-provider PRs are blocked on the missing decision. New contributors have no rubric to write to.
- **What changed:** New \`§community-providers\` section in \`.archon/maintainer-standup/direction.md\` captures the acceptance criteria, the architectural constraint (coding-agent SDK only, not raw \`chat.completions\` wrappers), and the maintenance policy (community-owned; deprecate-and-remove non-functional providers).
- **What did not change:** No code changes. No tests changed. \`direction.md\` is a maintainer-facing triage doc, not user docs.

## Label Snapshot

- Risk: \`risk: low\`
- Size: \`size: XS\`
- Scope: \`docs\`
- Module: \`docs:direction\`

## Test plan

No tests — this is a maintainer-facing direction doc.

## Security Impact

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes (text-only)
- Config/env changes? No
- Database migration needed? No

## Human Verification

- The policy reflects an explicit maintainer decision: Pi-pattern as the bar, coding-agent SDK only, community-maintained with a documented removal pathway.
- Verified the section heading produces the citable slug \`§community-providers\` consistent with how other clauses are cited in PR comments.

## Side Effects / Blast Radius

- Affects PR triage going forward — community-provider PRs can now be evaluated against a concrete rubric instead of meta-debate.
- Unblocks the final-review pass on #1505 (Copilot) which has been waiting on this decision.

## Rollback Plan

- Revert the commit. Triage reverts to the previous ad-hoc state.

## Risks and Mitigations

- **Risk:** Policy may need refinement as more community providers land.
  - **Mitigation:** \`direction.md\` is explicitly designed to evolve — the \"How to evolve this doc\" section already covers updating clauses as decisions get made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established comprehensive guidelines for community AI coding-agent providers, defining acceptance criteria including SDK-only scope, Pi pattern alignment, test parity validation, and documentation requirements.
  * Introduced maintenance and deprecation policy for community-contributed providers with PR triage citation guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1736?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->