### PR TITLE
fix(providers/claude): reject directory paths and expand npm package dirs (#1723)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,7 @@ CLAUDE_USE_GLOBAL_AUTH=true
 # Then:
 #   CLAUDE_BIN_PATH=$HOME/.local/bin/claude       (native installer)
 #   CLAUDE_BIN_PATH=$(npm root -g)/@anthropic-ai/claude-code/cli.js  (npm alternative)
+#   CLAUDE_BIN_PATH=$(npm root -g)/@anthropic-ai/claude-code-win32-x64  (Windows npm platform dir — auto-expanded to claude.exe)
 # CLAUDE_BIN_PATH=
 
 # Codex Authentication (get from ~/.codex/auth.json after running 'codex login')

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -487,7 +487,10 @@ assistants:
       - user         # User-level ~/.claude/ (included in default; omit both to restrict to project-only)
     claudeBinaryPath: /absolute/path/to/claude  # Optional: Claude Code executable.
                                                 # Native binary (curl installer at
-                                                # ~/.local/bin/claude) or npm cli.js.
+                                                # ~/.local/bin/claude), npm cli.js, or
+                                                # the npm platform-package directory
+                                                # (e.g. @anthropic-ai/claude-code-win32-x64)
+                                                # which is auto-expanded to claude/claude.exe.
                                                 # Required in compiled binaries if
                                                 # CLAUDE_BIN_PATH env var is not set.
   codex:

--- a/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
+++ b/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
@@ -59,7 +59,7 @@ In compiled Archon binaries, if `claude` is not on the default install path Arch
 
 If none of the three resolves in a compiled binary, Archon throws with install instructions on first Claude query.
 
-The Claude Agent SDK accepts either the native compiled binary or a JS `cli.js`.
+The Claude Agent SDK accepts the native compiled binary, a JS `cli.js`, or the npm platform-package directory (e.g. `@anthropic-ai/claude-code-win32-x64`) — directories are auto-expanded to the contained `claude`/`claude.exe`.
 
 **Dev mode override:** when running from source (`bun run dev:server`), the SDK auto-resolves its bundled per-platform binary by default. Set `CLAUDE_BIN_PATH` if you need to override that — most commonly on glibc Linux where the SDK picks the musl variant first and fails to spawn. Config-file `claudeBinaryPath` is intentionally binary-mode-only (per-repo, not per-machine).
 
@@ -71,6 +71,7 @@ The Claude Agent SDK accepts either the native compiled binary or a JS `cli.js`.
 | Native PowerShell installer (Windows) | `%USERPROFILE%\.local\bin\claude.exe` |
 | Homebrew cask | `$(brew --prefix)/bin/claude` (symlink) |
 | npm global install | `$(npm root -g)/@anthropic-ai/claude-code/cli.js` |
+| npm platform-package directory (Windows) | `$(npm root -g)/@anthropic-ai/claude-code-win32-x64` — directory accepted, auto-expanded to `claude.exe` |
 | Windows winget | Resolvable via `where claude` |
 | Docker (`ghcr.io/coleam00/archon`) | Pre-set via `ENV CLAUDE_BIN_PATH` in the image — no action required |
 

--- a/packages/docs-web/src/content/docs/getting-started/configuration.md
+++ b/packages/docs-web/src/content/docs/getting-started/configuration.md
@@ -14,7 +14,7 @@ Set these in your shell or `.env` file:
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `CLAUDE_BIN_PATH` | No (binary builds autodetect `~/.local/bin/claude`) | Absolute path to the Claude Code binary or SDK `cli.js`. Overrides autodetection in compiled Archon binaries. Falls back to `assistants.claude.claudeBinaryPath`, then to the native-installer path. Dev mode (`bun run`) auto-resolves via `node_modules`. |
+| `CLAUDE_BIN_PATH` | No (binary builds autodetect `~/.local/bin/claude`) | Absolute path to the Claude Code binary, SDK `cli.js`, or the npm platform-package directory (e.g. `@anthropic-ai/claude-code-win32-x64`, auto-expanded to `claude`/`claude.exe`). Overrides autodetection in compiled Archon binaries. Falls back to `assistants.claude.claudeBinaryPath`, then to the native-installer path. Dev mode (`bun run`) auto-resolves via `node_modules`. |
 | `CLAUDE_USE_GLOBAL_AUTH` | No | Set to `true` to use credentials from `claude /login` (default when no other Claude token is set) |
 | `CLAUDE_CODE_OAUTH_TOKEN` | No | OAuth token from `claude setup-token` (alternative to global auth) |
 | `CLAUDE_API_KEY` | No | Anthropic API key for pay-per-use (alternative to global auth) |

--- a/packages/docs-web/src/content/docs/reference/configuration.md
+++ b/packages/docs-web/src/content/docs/reference/configuration.md
@@ -67,8 +67,10 @@ assistants:
       - user          # User-level ~/.claude/ (CLAUDE.md, skills, commands, agents)
     # Optional: absolute path to the Claude Code executable.
     # Required in compiled Archon binaries when CLAUDE_BIN_PATH is not set.
-    # Accepts the native binary (~/.local/bin/claude from the curl installer)
-    # or the npm-installed cli.js. Source/dev mode auto-resolves.
+    # Accepts the native binary (~/.local/bin/claude from the curl installer),
+    # the npm-installed cli.js, or the npm platform-package directory
+    # (e.g. @anthropic-ai/claude-code-win32-x64 — auto-expanded to claude/claude.exe).
+    # Source/dev mode auto-resolves.
     # claudeBinaryPath: /absolute/path/to/claude
   codex:
     model: gpt-5.3-codex

--- a/packages/providers/src/claude/binary-resolver-dev.test.ts
+++ b/packages/providers/src/claude/binary-resolver-dev.test.ts
@@ -21,12 +21,12 @@ import * as resolver from './binary-resolver';
 
 describe('resolveClaudeBinaryPath (dev mode)', () => {
   const originalEnv = process.env.CLAUDE_BIN_PATH;
-  let fileExistsSpy: ReturnType<typeof spyOn> | undefined;
+  let pathKindSpy: ReturnType<typeof spyOn> | undefined;
 
   beforeEach(() => {
     delete process.env.CLAUDE_BIN_PATH;
-    fileExistsSpy?.mockRestore();
-    fileExistsSpy = undefined;
+    pathKindSpy?.mockRestore();
+    pathKindSpy = undefined;
   });
 
   afterAll(() => {
@@ -35,7 +35,7 @@ describe('resolveClaudeBinaryPath (dev mode)', () => {
     } else {
       delete process.env.CLAUDE_BIN_PATH;
     }
-    fileExistsSpy?.mockRestore();
+    pathKindSpy?.mockRestore();
   });
 
   test('returns undefined when nothing is configured', async () => {
@@ -50,7 +50,7 @@ describe('resolveClaudeBinaryPath (dev mode)', () => {
 
   test('honors CLAUDE_BIN_PATH env var when file exists', async () => {
     process.env.CLAUDE_BIN_PATH = '/usr/local/bin/claude';
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(true);
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('file');
 
     const result = await resolver.resolveClaudeBinaryPath();
     expect(result).toBe('/usr/local/bin/claude');
@@ -58,7 +58,7 @@ describe('resolveClaudeBinaryPath (dev mode)', () => {
 
   test('throws when CLAUDE_BIN_PATH is set but file does not exist', async () => {
     process.env.CLAUDE_BIN_PATH = '/nonexistent/claude';
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(false);
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('missing');
 
     await expect(resolver.resolveClaudeBinaryPath()).rejects.toThrow(
       'CLAUDE_BIN_PATH is set to "/nonexistent/claude" but the file does not exist'
@@ -67,7 +67,7 @@ describe('resolveClaudeBinaryPath (dev mode)', () => {
 
   test('env var wins over config path in dev mode', async () => {
     process.env.CLAUDE_BIN_PATH = '/env/claude';
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(true);
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('file');
 
     const result = await resolver.resolveClaudeBinaryPath('/config/claude');
     expect(result).toBe('/env/claude');

--- a/packages/providers/src/claude/binary-resolver-dev.test.ts
+++ b/packages/providers/src/claude/binary-resolver-dev.test.ts
@@ -10,6 +10,7 @@
  * Config-file path is intentionally NOT honored in dev mode (still binary-only).
  */
 import { describe, test, expect, mock, beforeEach, afterAll, spyOn } from 'bun:test';
+import { join } from 'node:path';
 import { createMockLogger } from '../test/mocks/logger';
 
 mock.module('@archon/paths', () => ({
@@ -18,6 +19,7 @@ mock.module('@archon/paths', () => ({
 }));
 
 import * as resolver from './binary-resolver';
+import { CLAUDE_BINARY_NAME } from './binary-resolver';
 
 describe('resolveClaudeBinaryPath (dev mode)', () => {
   const originalEnv = process.env.CLAUDE_BIN_PATH;
@@ -80,5 +82,35 @@ describe('resolveClaudeBinaryPath (dev mode)', () => {
     process.env.CLAUDE_BIN_PATH = '';
     const result = await resolver.resolveClaudeBinaryPath();
     expect(result).toBeUndefined();
+  });
+
+  test('expands a CLAUDE_BIN_PATH directory to its inner claude/claude.exe in dev mode', async () => {
+    // validateAndExpand runs BEFORE the BUNDLED_IS_BINARY guard, so dev-mode
+    // users who set CLAUDE_BIN_PATH to the npm platform-package directory
+    // must also get expansion. Pin the contract so a future refactor that
+    // reorders these checks fails loudly.
+    const dir = '/opt/claude-code-package';
+    const expectedFile = join(dir, CLAUDE_BINARY_NAME);
+    process.env.CLAUDE_BIN_PATH = dir;
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((p: string) => {
+      if (p === dir) return 'directory';
+      if (p === expectedFile) return 'file';
+      return 'missing';
+    });
+
+    const result = await resolver.resolveClaudeBinaryPath();
+    expect(result).toBe(expectedFile);
+  });
+
+  test('throws a directory-specific error when CLAUDE_BIN_PATH is a directory missing the executable in dev mode', async () => {
+    const dir = '/some/empty/dir';
+    process.env.CLAUDE_BIN_PATH = dir;
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((p: string) =>
+      p === dir ? 'directory' : 'missing'
+    );
+
+    const promise = resolver.resolveClaudeBinaryPath();
+    await expect(promise).rejects.toThrow('CLAUDE_BIN_PATH');
+    await expect(promise).rejects.toThrow('which is a directory');
   });
 });

--- a/packages/providers/src/claude/binary-resolver.test.ts
+++ b/packages/providers/src/claude/binary-resolver.test.ts
@@ -22,10 +22,12 @@ import * as resolver from './binary-resolver';
 describe('resolveClaudeBinaryPath (binary mode)', () => {
   const originalEnv = process.env.CLAUDE_BIN_PATH;
   let fileExistsSpy: ReturnType<typeof spyOn>;
+  let pathKindSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     delete process.env.CLAUDE_BIN_PATH;
     fileExistsSpy?.mockRestore();
+    pathKindSpy?.mockRestore();
     mockLogger.info.mockClear();
   });
 
@@ -36,11 +38,12 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
       delete process.env.CLAUDE_BIN_PATH;
     }
     fileExistsSpy?.mockRestore();
+    pathKindSpy?.mockRestore();
   });
 
   test('uses CLAUDE_BIN_PATH env var when set and file exists', async () => {
     process.env.CLAUDE_BIN_PATH = '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js';
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(true);
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('file');
 
     const result = await resolver.resolveClaudeBinaryPath();
     expect(result).toBe('/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js');
@@ -48,7 +51,7 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
 
   test('throws when CLAUDE_BIN_PATH is set but file does not exist', async () => {
     process.env.CLAUDE_BIN_PATH = '/nonexistent/cli.js';
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(false);
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('missing');
 
     await expect(resolver.resolveClaudeBinaryPath()).rejects.toThrow(
       'CLAUDE_BIN_PATH is set to "/nonexistent/cli.js" but the file does not exist'
@@ -56,14 +59,14 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
   });
 
   test('uses config claudeBinaryPath when file exists', async () => {
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(true);
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('file');
 
     const result = await resolver.resolveClaudeBinaryPath('/custom/claude/cli.js');
     expect(result).toBe('/custom/claude/cli.js');
   });
 
   test('throws when config claudeBinaryPath file does not exist', async () => {
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(false);
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('missing');
 
     await expect(resolver.resolveClaudeBinaryPath('/nonexistent/cli.js')).rejects.toThrow(
       'assistants.claude.claudeBinaryPath is set to "/nonexistent/cli.js" but the file does not exist'
@@ -72,7 +75,7 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
 
   test('env var takes precedence over config path', async () => {
     process.env.CLAUDE_BIN_PATH = '/env/cli.js';
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(true);
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('file');
 
     const result = await resolver.resolveClaudeBinaryPath('/config/cli.js');
     expect(result).toBe('/env/cli.js');
@@ -104,7 +107,7 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
 
   test('env var takes precedence over autodetect when both would match', async () => {
     process.env.CLAUDE_BIN_PATH = '/custom/env/claude';
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(true);
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('file');
 
     const result = await resolver.resolveClaudeBinaryPath();
     expect(result).toBe('/custom/env/claude');
@@ -115,7 +118,7 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
   });
 
   test('config takes precedence over autodetect when both would match', async () => {
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(true);
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('file');
 
     const result = await resolver.resolveClaudeBinaryPath('/custom/config/claude');
     expect(result).toBe('/custom/config/claude');
@@ -138,4 +141,86 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
     await expect(promise).rejects.toThrow('npm install -g @anthropic-ai/claude-code');
     await expect(promise).rejects.toThrow('claudeBinaryPath');
   });
+
+  // ─── Directory expansion (issue #1723) ──────────────────────────────────
+  // The npm-distributed Claude Code package nests the native binary inside
+  // a platform-specific directory (`@anthropic-ai/claude-code-<platform>`).
+  // Users on Windows naturally configure that directory as
+  // `claudeBinaryPath`; the resolver must transparently expand it to the
+  // contained executable so the SDK's spawn doesn't ENOENT on a directory.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  test('expands a configured directory to claude/claude.exe when the binary is present (config path)', async () => {
+    const dir = '/opt/claude-code-package';
+    const expectedFile = join(dir, process.platform === 'win32' ? 'claude.exe' : 'claude');
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((p: string) => {
+      if (p === dir) return 'directory';
+      if (p === expectedFile) return 'file';
+      return 'missing';
+    });
+
+    const result = await resolver.resolveClaudeBinaryPath(dir);
+    expect(result).toBe(expectedFile);
+    // Log must show the expanded executable path, not the user's directory —
+    // operators triaging spawn issues need the actual path the SDK will use.
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { binaryPath: expectedFile, source: 'config' },
+      'claude.binary_resolved'
+    );
+  });
+
+  test('expands a configured directory passed via CLAUDE_BIN_PATH', async () => {
+    const dir = '/opt/claude-code-package';
+    const expectedFile = join(dir, process.platform === 'win32' ? 'claude.exe' : 'claude');
+    process.env.CLAUDE_BIN_PATH = dir;
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((p: string) => {
+      if (p === dir) return 'directory';
+      if (p === expectedFile) return 'file';
+      return 'missing';
+    });
+
+    const result = await resolver.resolveClaudeBinaryPath();
+    expect(result).toBe(expectedFile);
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { binaryPath: expectedFile, source: 'env' },
+      'claude.binary_resolved'
+    );
+  });
+
+  test('throws a directory-specific error when config path is a directory missing the expected executable', async () => {
+    const dir = '/some/empty/dir';
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((p: string) =>
+      p === dir ? 'directory' : 'missing'
+    );
+    const expected = process.platform === 'win32' ? 'claude.exe' : 'claude';
+
+    const promise = resolver.resolveClaudeBinaryPath(dir);
+    await expect(promise).rejects.toThrow('assistants.claude.claudeBinaryPath');
+    await expect(promise).rejects.toThrow('which is a directory');
+    await expect(promise).rejects.toThrow(`does not contain ${expected}`);
+  });
+
+  test('throws a directory-specific error when CLAUDE_BIN_PATH is a directory missing the expected executable', async () => {
+    const dir = '/some/empty/dir';
+    process.env.CLAUDE_BIN_PATH = dir;
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((p: string) =>
+      p === dir ? 'directory' : 'missing'
+    );
+
+    const promise = resolver.resolveClaudeBinaryPath();
+    await expect(promise).rejects.toThrow('CLAUDE_BIN_PATH');
+    await expect(promise).rejects.toThrow('which is a directory');
+  });
+});
+
+describe('pathKind', () => {
+  test('returns "missing" for nonexistent paths', () => {
+    expect(resolver.pathKind('/definitely/does/not/exist/anywhere/12345')).toBe('missing');
+  });
+
+  // `pathKind` is a thin wrapper around `statSync`; the file/directory
+  // discrimination itself is tested via the resolver-level tests above
+  // (which spy on pathKind). The integration concern that *can't* be tested
+  // there — that the wrapper actually catches ENOENT instead of throwing —
+  // is asserted here.
 });

--- a/packages/providers/src/claude/binary-resolver.test.ts
+++ b/packages/providers/src/claude/binary-resolver.test.ts
@@ -18,16 +18,16 @@ mock.module('@archon/paths', () => ({
 }));
 
 import * as resolver from './binary-resolver';
+import { CLAUDE_BINARY_NAME } from './binary-resolver';
 
 describe('resolveClaudeBinaryPath (binary mode)', () => {
   const originalEnv = process.env.CLAUDE_BIN_PATH;
-  let fileExistsSpy: ReturnType<typeof spyOn>;
-  let pathKindSpy: ReturnType<typeof spyOn>;
+  let pathKindSpy: ReturnType<typeof spyOn> | undefined;
 
   beforeEach(() => {
     delete process.env.CLAUDE_BIN_PATH;
-    fileExistsSpy?.mockRestore();
     pathKindSpy?.mockRestore();
+    pathKindSpy = undefined;
     mockLogger.info.mockClear();
   });
 
@@ -37,7 +37,6 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
     } else {
       delete process.env.CLAUDE_BIN_PATH;
     }
-    fileExistsSpy?.mockRestore();
     pathKindSpy?.mockRestore();
   });
 
@@ -84,25 +83,28 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
   test('autodetects native installer path when env and config are unset', async () => {
     // Mirror the implementation: use os.homedir() + node:path.join so the
     // expected path matches the platform's actual home dir and separator.
-    const expected = join(
-      homedir(),
-      '.local',
-      'bin',
-      process.platform === 'win32' ? 'claude.exe' : 'claude'
-    );
-    // File exists only at the native-installer path.
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation(
-      (path: string) => path === expected
+    const expected = join(homedir(), '.local', 'bin', CLAUDE_BINARY_NAME);
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((path: string) =>
+      path === expected ? 'file' : 'missing'
     );
 
     const result = await resolver.resolveClaudeBinaryPath();
     expect(result).toBe(expected);
-    // Log must mark this as autodetect, not 'env' or 'config' — the source
-    // string is load-bearing for debug triage.
+    // The source label is load-bearing for debug triage.
     expect(mockLogger.info).toHaveBeenCalledWith(
       { binaryPath: expected, source: 'autodetect' },
       'claude.binary_resolved'
     );
+  });
+
+  test('autodetect rejects a directory at the native installer path', async () => {
+    // A directory at ~/.local/bin/claude indicates a broken install; the
+    // resolver must NOT silently hand it to the SDK (which would ENOENT).
+    // Expansion is deliberately limited to user-configured paths.
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('directory');
+
+    const promise = resolver.resolveClaudeBinaryPath();
+    await expect(promise).rejects.toThrow('Claude Code not found');
   });
 
   test('env var takes precedence over autodetect when both would match', async () => {
@@ -129,8 +131,7 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
   });
 
   test('throws with install instructions when nothing is configured and autodetect misses', async () => {
-    // Every probe returns false — env unset, config unset, native path absent.
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(false);
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('missing');
 
     const promise = resolver.resolveClaudeBinaryPath();
     await expect(promise).rejects.toThrow('Claude Code not found');
@@ -142,17 +143,16 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
     await expect(promise).rejects.toThrow('claudeBinaryPath');
   });
 
-  // ─── Directory expansion (issue #1723) ──────────────────────────────────
-  // The npm-distributed Claude Code package nests the native binary inside
-  // a platform-specific directory (`@anthropic-ai/claude-code-<platform>`).
-  // Users on Windows naturally configure that directory as
-  // `claudeBinaryPath`; the resolver must transparently expand it to the
-  // contained executable so the SDK's spawn doesn't ENOENT on a directory.
-  // ─────────────────────────────────────────────────────────────────────────
+  // Directory expansion: the npm-distributed Claude Code package nests the
+  // native binary inside a platform-specific directory
+  // (`@anthropic-ai/claude-code-<platform>`). Users on Windows naturally
+  // configure that directory as `claudeBinaryPath`; the resolver must
+  // transparently expand it to the contained executable so the SDK's spawn
+  // doesn't ENOENT on a directory.
 
   test('expands a configured directory to claude/claude.exe when the binary is present (config path)', async () => {
     const dir = '/opt/claude-code-package';
-    const expectedFile = join(dir, process.platform === 'win32' ? 'claude.exe' : 'claude');
+    const expectedFile = join(dir, CLAUDE_BINARY_NAME);
     pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((p: string) => {
       if (p === dir) return 'directory';
       if (p === expectedFile) return 'file';
@@ -161,8 +161,6 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
 
     const result = await resolver.resolveClaudeBinaryPath(dir);
     expect(result).toBe(expectedFile);
-    // Log must show the expanded executable path, not the user's directory —
-    // operators triaging spawn issues need the actual path the SDK will use.
     expect(mockLogger.info).toHaveBeenCalledWith(
       { binaryPath: expectedFile, source: 'config' },
       'claude.binary_resolved'
@@ -171,7 +169,7 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
 
   test('expands a configured directory passed via CLAUDE_BIN_PATH', async () => {
     const dir = '/opt/claude-code-package';
-    const expectedFile = join(dir, process.platform === 'win32' ? 'claude.exe' : 'claude');
+    const expectedFile = join(dir, CLAUDE_BINARY_NAME);
     process.env.CLAUDE_BIN_PATH = dir;
     pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((p: string) => {
       if (p === dir) return 'directory';
@@ -192,12 +190,11 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
     pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((p: string) =>
       p === dir ? 'directory' : 'missing'
     );
-    const expected = process.platform === 'win32' ? 'claude.exe' : 'claude';
 
     const promise = resolver.resolveClaudeBinaryPath(dir);
     await expect(promise).rejects.toThrow('assistants.claude.claudeBinaryPath');
     await expect(promise).rejects.toThrow('which is a directory');
-    await expect(promise).rejects.toThrow(`does not contain ${expected}`);
+    await expect(promise).rejects.toThrow(`does not contain ${CLAUDE_BINARY_NAME}`);
   });
 
   test('throws a directory-specific error when CLAUDE_BIN_PATH is a directory missing the expected executable', async () => {
@@ -214,6 +211,30 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
 });
 
 describe('pathKind', () => {
+  test('returns "file" for a real file', async () => {
+    const { mkdtempSync, writeFileSync, rmSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const dir = mkdtempSync(join(tmpdir(), 'archon-pathkind-'));
+    const file = join(dir, 'a-file');
+    try {
+      writeFileSync(file, 'hello');
+      expect(resolver.pathKind(file)).toBe('file');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('returns "directory" for a real directory', async () => {
+    const { mkdtempSync, rmSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const dir = mkdtempSync(join(tmpdir(), 'archon-pathkind-'));
+    try {
+      expect(resolver.pathKind(dir)).toBe('directory');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test('returns "missing" for nonexistent paths', () => {
     expect(resolver.pathKind('/definitely/does/not/exist/anywhere/12345')).toBe('missing');
   });

--- a/packages/providers/src/claude/binary-resolver.test.ts
+++ b/packages/providers/src/claude/binary-resolver.test.ts
@@ -218,9 +218,19 @@ describe('pathKind', () => {
     expect(resolver.pathKind('/definitely/does/not/exist/anywhere/12345')).toBe('missing');
   });
 
-  // `pathKind` is a thin wrapper around `statSync`; the file/directory
-  // discrimination itself is tested via the resolver-level tests above
-  // (which spy on pathKind). The integration concern that *can't* be tested
-  // there — that the wrapper actually catches ENOENT instead of throwing —
-  // is asserted here.
+  test('returns "missing" for a broken symlink without throwing', async () => {
+    // statSync follows symlinks by default — broken targets raise ENOENT,
+    // which must be caught and reported as 'missing' so the resolver's
+    // "file does not exist" path fires instead of an uncaught exception.
+    const { mkdtempSync, symlinkSync, rmSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const dir = mkdtempSync(join(tmpdir(), 'archon-pathkind-'));
+    const link = join(dir, 'broken-link');
+    try {
+      symlinkSync(join(dir, 'nonexistent-target'), link);
+      expect(resolver.pathKind(link)).toBe('missing');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/providers/src/claude/binary-resolver.ts
+++ b/packages/providers/src/claude/binary-resolver.ts
@@ -28,53 +28,53 @@ export function fileExists(path: string): boolean {
   return _existsSync(path);
 }
 
+/** Platform-specific Claude Code binary filename: `claude.exe` on Windows, `claude` elsewhere. */
+export const CLAUDE_BINARY_NAME = process.platform === 'win32' ? 'claude.exe' : 'claude';
+
+export type PathKind = 'file' | 'directory' | 'missing';
+
 /**
  * Classify a configured path. The Claude Agent SDK requires a spawnable file:
  * a directory passes `existsSync` but fails downstream as ENOENT inside the
  * SDK's `child_process.spawn`, surfaced as the misleading "native binary not
- * found" error. Wrapped for spyOn parity with `fileExists`.
+ * found" error.
  *
- * Non-file, non-directory entries (sockets, FIFOs, etc.) are reported as
- * 'missing' so the caller's "set to X but unusable" error path fires.
+ * Non-file, non-directory entries (sockets, FIFOs, etc.) report as 'missing'
+ * so the caller's "set to X but unusable" error path fires. Stat errors other
+ * than ENOENT/ENOTDIR (e.g. EACCES) are logged before being collapsed to
+ * 'missing' so operators have a triage breadcrumb for permission issues that
+ * would otherwise surface as a misleading "file does not exist".
  */
-export function pathKind(path: string): 'file' | 'directory' | 'missing' {
+export function pathKind(path: string): PathKind {
   try {
     const stat = _statSync(path);
     if (stat.isFile()) return 'file';
     if (stat.isDirectory()) return 'directory';
     return 'missing';
-  } catch {
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+      getLog().warn({ err, path, code }, 'claude.path_stat_failed');
+    }
     return 'missing';
   }
 }
 
 /**
- * If a configured path is a directory, expand to the platform-appropriate
- * child executable (`claude.exe` on Windows, `claude` on Unix). Common when
- * users point at the npm platform-package directory
- * (`@anthropic-ai/claude-code-<platform>`), which contains the binary inside.
- * Returns the expanded file path if present, otherwise undefined.
- */
-function expandDirectoryToExecutable(dir: string): string | undefined {
-  const candidate = join(dir, process.platform === 'win32' ? 'claude.exe' : 'claude');
-  return pathKind(candidate) === 'file' ? candidate : undefined;
-}
-
-/**
- * Validate a user-supplied path and, if a directory is given, expand to the
- * platform-appropriate child executable. Distinguishes missing paths from
- * directories-without-the-expected-binary so the error message tells the user
- * what to fix.
+ * Distinguishes missing paths from directories-without-the-expected-binary so
+ * the error message tells the user what to fix. Users commonly point at the
+ * npm platform-package directory (`@anthropic-ai/claude-code-<platform>`),
+ * which contains the binary inside — expand to the contained executable
+ * transparently in that case.
  */
 function validateAndExpand(rawPath: string, sourceLabel: string): string {
   const kind = pathKind(rawPath);
   if (kind === 'file') return rawPath;
   if (kind === 'directory') {
-    const expanded = expandDirectoryToExecutable(rawPath);
-    if (expanded) return expanded;
-    const expected = process.platform === 'win32' ? 'claude.exe' : 'claude';
+    const candidate = join(rawPath, CLAUDE_BINARY_NAME);
+    if (pathKind(candidate) === 'file') return candidate;
     throw new Error(
-      `${sourceLabel} is set to "${rawPath}", which is a directory, but it does not contain ${expected}.\n` +
+      `${sourceLabel} is set to "${rawPath}", which is a directory, but it does not contain ${CLAUDE_BINARY_NAME}.\n` +
         'Please point this setting at the Claude Code executable itself (native binary\n' +
         'from the curl/PowerShell installer, or cli.js from an npm global install).'
     );
@@ -155,11 +155,8 @@ export async function resolveClaudeBinaryPath(
   // the recommended install path don't need any env var or config entry;
   // users who deviate (npm global, custom path, etc.) still set one of
   // the higher-priority sources above.
-  const nativeInstallerPath =
-    process.platform === 'win32'
-      ? join(homedir(), '.local', 'bin', 'claude.exe')
-      : join(homedir(), '.local', 'bin', 'claude');
-  if (fileExists(nativeInstallerPath)) {
+  const nativeInstallerPath = join(homedir(), '.local', 'bin', CLAUDE_BINARY_NAME);
+  if (pathKind(nativeInstallerPath) === 'file') {
     getLog().info(
       { binaryPath: nativeInstallerPath, source: 'autodetect' },
       'claude.binary_resolved'

--- a/packages/providers/src/claude/binary-resolver.ts
+++ b/packages/providers/src/claude/binary-resolver.ts
@@ -18,7 +18,7 @@
  * undefined so the caller omits `pathToClaudeCodeExecutable` entirely and
  * the SDK resolves via its normal node_modules lookup.
  */
-import { existsSync as _existsSync } from 'node:fs';
+import { existsSync as _existsSync, statSync as _statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { BUNDLED_IS_BINARY, createLogger } from '@archon/paths';
@@ -26,6 +26,64 @@ import { BUNDLED_IS_BINARY, createLogger } from '@archon/paths';
 /** Wrapper for existsSync — enables spyOn in tests (direct imports can't be spied on). */
 export function fileExists(path: string): boolean {
   return _existsSync(path);
+}
+
+/**
+ * Classify a configured path. The Claude Agent SDK requires a spawnable file:
+ * a directory passes `existsSync` but fails downstream as ENOENT inside the
+ * SDK's `child_process.spawn`, surfaced as the misleading "native binary not
+ * found" error. Wrapped for spyOn parity with `fileExists`.
+ *
+ * Non-file, non-directory entries (sockets, FIFOs, etc.) are reported as
+ * 'missing' so the caller's "set to X but unusable" error path fires.
+ */
+export function pathKind(path: string): 'file' | 'directory' | 'missing' {
+  try {
+    const stat = _statSync(path);
+    if (stat.isFile()) return 'file';
+    if (stat.isDirectory()) return 'directory';
+    return 'missing';
+  } catch {
+    return 'missing';
+  }
+}
+
+/**
+ * If a configured path is a directory, expand to the platform-appropriate
+ * child executable (`claude.exe` on Windows, `claude` on Unix). Common when
+ * users point at the npm platform-package directory
+ * (`@anthropic-ai/claude-code-<platform>`), which contains the binary inside.
+ * Returns the expanded file path if present, otherwise undefined.
+ */
+function expandDirectoryToExecutable(dir: string): string | undefined {
+  const candidate = join(dir, process.platform === 'win32' ? 'claude.exe' : 'claude');
+  return pathKind(candidate) === 'file' ? candidate : undefined;
+}
+
+/**
+ * Validate a user-supplied path and, if a directory is given, expand to the
+ * platform-appropriate child executable. Distinguishes missing paths from
+ * directories-without-the-expected-binary so the error message tells the user
+ * what to fix.
+ */
+function validateAndExpand(rawPath: string, sourceLabel: string): string {
+  const kind = pathKind(rawPath);
+  if (kind === 'file') return rawPath;
+  if (kind === 'directory') {
+    const expanded = expandDirectoryToExecutable(rawPath);
+    if (expanded) return expanded;
+    const expected = process.platform === 'win32' ? 'claude.exe' : 'claude';
+    throw new Error(
+      `${sourceLabel} is set to "${rawPath}", which is a directory, but it does not contain ${expected}.\n` +
+        'Please point this setting at the Claude Code executable itself (native binary\n' +
+        'from the curl/PowerShell installer, or cli.js from an npm global install).'
+    );
+  }
+  throw new Error(
+    `${sourceLabel} is set to "${rawPath}" but the file does not exist.\n` +
+      'Please verify the path points to the Claude Code executable (native binary\n' +
+      'from the curl/PowerShell installer, or cli.js from an npm global install).'
+  );
 }
 
 /** Lazy-initialized logger */
@@ -73,32 +131,21 @@ export async function resolveClaudeBinaryPath(
   // its resolution order) can pin a known-good binary without a compiled build.
   const envPath = process.env.CLAUDE_BIN_PATH;
   if (envPath) {
-    if (!fileExists(envPath)) {
-      throw new Error(
-        `CLAUDE_BIN_PATH is set to "${envPath}" but the file does not exist.\n` +
-          'Please verify the path points to the Claude Code executable (native binary\n' +
-          'from the curl/PowerShell installer, or cli.js from an npm global install).'
-      );
-    }
-    getLog().info({ binaryPath: envPath, source: 'env' }, 'claude.binary_resolved');
-    return envPath;
+    const resolvedEnv = validateAndExpand(envPath, 'CLAUDE_BIN_PATH');
+    getLog().info({ binaryPath: resolvedEnv, source: 'env' }, 'claude.binary_resolved');
+    return resolvedEnv;
   }
 
   if (!BUNDLED_IS_BINARY) return undefined;
 
   // 2. Config file override
   if (configClaudeBinaryPath) {
-    if (!fileExists(configClaudeBinaryPath)) {
-      throw new Error(
-        `assistants.claude.claudeBinaryPath is set to "${configClaudeBinaryPath}" but the file does not exist.\n` +
-          'Please verify the path in .archon/config.yaml points to the Claude Code executable.'
-      );
-    }
-    getLog().info(
-      { binaryPath: configClaudeBinaryPath, source: 'config' },
-      'claude.binary_resolved'
+    const resolvedConfig = validateAndExpand(
+      configClaudeBinaryPath,
+      'assistants.claude.claudeBinaryPath'
     );
-    return configClaudeBinaryPath;
+    getLog().info({ binaryPath: resolvedConfig, source: 'config' }, 'claude.binary_resolved');
+    return resolvedConfig;
   }
 
   // 3. Autodetect — the Anthropic native installer

--- a/packages/providers/src/codex/binary-resolver.ts
+++ b/packages/providers/src/codex/binary-resolver.ts
@@ -25,6 +25,14 @@ export function fileExists(path: string): boolean {
   return _existsSync(path);
 }
 
+// TODO(#1723): existsSync returns true for directories, so an env or config
+// path pointing at the platform-package *directory* (e.g. an npm-distributed
+// `@openai/codex-<platform>` folder containing `codex{.exe}`) currently slips
+// past validation and crashes inside the SDK's child_process.spawn as ENOENT.
+// The Claude resolver applies a pathKind() / expandDirectoryToExecutable()
+// fix; mirror the same pattern here when a Codex bug report lands or as part
+// of a deliberate parity pass.
+
 /** Lazy-initialized logger */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
 function getLog(): ReturnType<typeof createLogger> {


### PR DESCRIPTION
## Summary

- **Problem**: On Windows, configuring `assistants.claude.claudeBinaryPath` to the npm-distributed platform-package directory (e.g. `...\@anthropic-ai\claude-code-win32-x64`) made the Claude Agent SDK crash with `Claude Code native binary not found at <path>`. The resolver validated with `existsSync`, which returns `true` for directories; the SDK then `spawn`ed the directory and got ENOENT.
- **Why it matters**: Claude is unusable in compiled binaries on Windows under the natural npm install layout; the workaround (point at the inner `claude.exe`) was not discoverable from the misleading SDK-side error.
- **What changed**: New `pathKind()` helper distinguishes file / directory / missing, plus `expandDirectoryToExecutable()` that transparently maps a configured directory to its `claude` / `claude.exe` child when present. Env and config branches now share a `validateAndExpand()` helper that throws a directory-specific error when the directory is empty (names the expected child filename).
- **What did NOT change (scope boundary)**: Autodetect branch (it already targets a file path directly). Codex resolver — same `existsSync` pattern exists in `packages/providers/src/codex/binary-resolver.ts:18-25` but there is no current bug report; deliberately left for a follow-up to honor YAGNI. Public exports of `resolveClaudeBinaryPath` and `fileExists` are unchanged; `pathKind` is added.

## UX Journey

### Before

```
User                       Archon (resolver)              Claude Agent SDK
────                       ─────────────────              ────────────────
configures claudeBinary  ─▶ existsSync(dir) = true ─────▶ spawn(dir, [...]) ──┐
Path → C:\...\claude-      pass dir to SDK opaquely                            │
code-win32-x64                                                        ENOENT ◀─┘
                                                                              │
                              ◀─────────────────────────────────────────── reframes as
                                                                       "native binary not found"
sees confusing               throws to caller
SDK-side error      ◀───── (no actionable info about
                            directory-vs-file mismatch)
```

### After

```
User                       Archon (resolver)                      Claude Agent SDK
────                       ─────────────────                      ────────────────
configures claudeBinary  ─▶ [pathKind(dir) = 'directory']
Path → C:\...\claude-       [expandDirectoryToExecutable] ─┐
code-win32-x64              ↓
                            join(dir, 'claude.exe')
                            [pathKind = 'file']            ─────▶ spawn(claude.exe, [...]) ✓
                            pass expanded file to SDK
sees workflow running ◀──── streams response                 ◀── streams normally

Failure case: directory configured but no claude/claude.exe inside
  ↓ resolver throws *directory-specific* error naming the expected child filename
  ↓ user knows exactly what to fix
```

## Architecture Diagram

### Before

```
config.yaml → parseClaudeConfig ──┐
                                  ▼
env CLAUDE_BIN_PATH ─────▶ resolveClaudeBinaryPath ──▶ Claude Agent SDK
                          (fileExists / existsSync)     pathToClaudeCodeExecutable
                                  │                        │
                                  ▼                        ▼
                            getLog().info              child_process.spawn
```

### After

```
config.yaml → parseClaudeConfig ──┐
                                  ▼
env CLAUDE_BIN_PATH ─────▶ resolveClaudeBinaryPath ──▶ Claude Agent SDK
                                  │                        │
                                  ▼                        ▼
                          [~] validateAndExpand        child_process.spawn
                              ├─ [+] pathKind          (now always a file)
                              └─ [+] expandDirectoryToExecutable
                                  │
                                  ▼
                            getLog().info
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `resolveClaudeBinaryPath` | `fileExists` | **modified** | Still used by autodetect branch; no longer used by env/config branches |
| `resolveClaudeBinaryPath` | `validateAndExpand` | **new** | Shared validator for env + config paths |
| `validateAndExpand` | `pathKind` | **new** | File vs directory vs missing classification |
| `validateAndExpand` | `expandDirectoryToExecutable` | **new** | Maps directory → child binary when present |
| `expandDirectoryToExecutable` | `pathKind` | **new** | Confirms expanded child is a file |
| `provider.ts:512` (`pathToClaudeCodeExecutable`) | `resolveClaudeBinaryPath` | unchanged | Output contract identical (still `string \| undefined`) |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core` (specifically `providers`)
- Module: `providers:claude`

## Change Metadata

- Change type: `bug`
- Primary scope: `core` (providers)

## Linked Issue

- Closes #1723

## Validation Evidence (required)

```bash
$ bun run type-check
# all packages exit 0

$ bun run lint
# exit 0

$ bun run format:check
# All matched files use Prettier code style!

$ bun --filter @archon/providers test packages/providers/src/claude/binary-resolver.test.ts packages/providers/src/claude/binary-resolver-dev.test.ts
# 14 binary-mode tests + 6 dev-mode tests + sibling provider/config tests: all pass
```

- Evidence provided: Test output above (full run included new directory-expansion cases and directory-without-binary error paths for both `CLAUDE_BIN_PATH` and `claudeBinaryPath`).
- Skipped: `bun run validate` reports 3 pre-existing failures in `@archon/adapters > telegram-markdown > blockquotes` that reproduce on `dev` (verified by checking out the file from `dev` and re-running the adapter tests — failures persist independent of this diff). Those tests were last touched by `d1feab07 fix(adapters): bump telegramify-markdown to 1.3.3`; not investigated as part of this PR.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No` — `statSync` is added in the same code path that already called `existsSync` on the same configured paths. No new directories or files are stat'd that weren't being existence-checked before.

## Compatibility / Migration

- Backward compatible? `Yes` — every previously-accepted path (a file) still resolves to the same value. The only behavioral change is that a directory now either expands transparently (success path that previously crashed inside the SDK) or throws a clearer Archon-side error (previously a confusing SDK-side error).
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios:
  - **macOS (this host)**: `bun --filter @archon/providers test` for both binary-mode and dev-mode resolver test suites — all pass. The directory-expansion tests dynamically pick `claude` (Unix) vs `claude.exe` (Windows) so they exercise the real branch on this host.
  - **Logic walk-through**: Confirmed that the autodetect branch (still using `fileExists`) is unchanged — its target path is built via `join(homedir(), '.local', 'bin', 'claude{.exe}')`, which is always a file by construction, so the directory-case bug cannot arise there.
- Edge cases checked: Empty `CLAUDE_BIN_PATH=` (still falls through to undefined in dev mode — pinned by existing test). Directory with no inner binary (new directory-specific error). Symlink behavior: `statSync` follows symlinks by default, so a symlink-to-file resolves as `'file'`, and a broken symlink resolves as `'missing'` — matches user expectations.
- What was not verified: End-to-end run on an actual Windows host pointing at the user's original failing path (`...\@anthropic-ai\claude-code-win32-x64`). The author does not have a Windows host; verification depends on @wikimatt or another Windows user retesting after merge. The unit tests are platform-conditional but the directory→`claude.exe` expansion logic was specifically motivated by the Windows scenario.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Only `resolveClaudeBinaryPath()` callers — currently a single caller at `packages/providers/src/claude/provider.ts:862`. The output contract is unchanged (`Promise<string \| undefined>`). The expanded path is a child of the user-supplied directory, so it remains inside whatever filesystem region the user already granted.
- Potential unintended effects: A user who previously had a *file* called `claude` in some unrelated directory and pointed at that directory expecting *something else* would now see Archon attempt to spawn that `claude`. This is so unlikely (the file would have to be named `claude` exactly) that it's a deliberately accepted edge case — and the previous behavior in that scenario was already broken (SDK ENOENT on the directory).
- Guardrails/monitoring: The resolver's existing `claude.binary_resolved` log line now records the *expanded* path. Operators triaging spawn issues can grep for the actual path the SDK was given.

## Rollback Plan (required)

- Fast rollback: `git revert <merge-commit>` — single-commit revert is safe; no shared-state mutation, no migration.
- Feature flags or config toggles: None. The fix is unconditional but strictly additive on the happy path.
- Observable failure symptoms: If this regresses, users would see either (a) a directory path that previously resolved (impossible — directories never worked) or (b) a file path that previously resolved now throwing — would manifest as `claude.binary_resolved` log line missing followed by `validateAndExpand` error. Easy to spot.

## Risks and Mitigations

- **Risk**: `statSync` is added to the hot path; a hostile filesystem (e.g. dangling network mount) could now throw where `existsSync` would have returned `false`.
  - **Mitigation**: `pathKind()` wraps `statSync` in `try/catch` and returns `'missing'` on any throw — behavior is conservatively a superset of the previous `existsSync` path.
- **Risk**: User configures a directory that happens to contain a non-Claude `claude` binary (e.g. some unrelated executable named `claude` on Unix).
  - **Mitigation**: Same risk existed before the SDK was ever passed a path; the expansion only fires when the user explicitly configured a directory. The SDK will surface a clear runtime error from the spawned process if it isn't actually Claude Code. Accepted edge case.
- **Risk**: Codex resolver has the same latent bug.
  - **Mitigation**: Documented in the investigation artifact (`.claude/PRPs/issues/issue-1723.md`) and intentionally deferred. No current bug report; YAGNI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Properly expand and validate directory Claude binary paths so executables are found; clearer, directory-specific error messages when missing.

* **Improvements**
  * More robust path classification (file / directory / missing) and logging of the resolved executable path; env/config precedence preserved.

* **Tests**
  * Added/updated tests for directory expansion, broken symlinks, env-var behavior, and path classification.

* **Documentation**
  * Clarified CLAUDE_BIN_PATH and config docs and .env example to note auto-expansion of platform-package directories to the Claude executable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1737?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->