### PR TITLE
fix(providers/codex): remove stale attemptController.abort() that crashes after SDK cleanup

### DIFF
--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -1704,4 +1704,46 @@ describe('sendQuery decomposition behaviors', () => {
     expect(capturedSignal).not.toBe(callerController.signal);
     expect(capturedSignal?.aborted).toBe(true);
   }, 5_000);
+
+  // Regression for issue #1735.
+  // After the codex-sdk's finally calls child.removeAllListeners() + child.kill(),
+  // calling attemptController.abort() would fire Node's internal spawn-signal
+  // abort listener on the now-listenerless child, surfacing an uncaught AbortError.
+  // The fix removes the explicit abort() — the per-attempt controller is short-lived
+  // and goes out of scope naturally.
+  test('successful attempt does not throw from stale abort cleanup (#1735)', async () => {
+    mockRunStreamed.mockImplementation((_prompt, opts: { signal?: AbortSignal }) => {
+      return Promise.resolve({
+        events: (async function* () {
+          yield {
+            type: 'item.completed',
+            item: { type: 'agent_message', text: 'done', id: '1' },
+          };
+          yield { type: 'turn.completed', usage: defaultUsage };
+        })(),
+      });
+    });
+
+    // Listen for uncaught errors that would surface from the stale abort.
+    const uncaughtErrors: Error[] = [];
+    const handler = (err: Error): void => {
+      uncaughtErrors.push(err);
+    };
+    process.on('uncaughtException', handler);
+
+    try {
+      const chunks = [];
+      for await (const chunk of client.sendQuery('test', '/workspace')) {
+        chunks.push(chunk);
+      }
+
+      // Give the event loop a tick for any deferred error events.
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      expect(chunks.length).toBeGreaterThan(0);
+      expect(uncaughtErrors).toHaveLength(0);
+    } finally {
+      process.removeListener('uncaughtException', handler);
+    }
+  }, 5_000);
 });

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -842,10 +842,12 @@ export class CodexProvider implements IAgentProvider {
         if (requestOptions?.abortSignal) {
           requestOptions.abortSignal.removeEventListener('abort', onCallerAbort);
         }
-        // Signal to any downstream consumers that this attempt is done.
-        // Next iteration creates a fresh controller; caller's signal state
-        // is unchanged.
-        attemptController.abort();
+        // The per-attempt AbortController is short-lived and goes out of
+        // scope at iteration end — no explicit abort() cleanup needed.
+        // Calling abort() here would race with the codex-sdk's own finally
+        // (which calls child.removeAllListeners() + child.kill()), firing
+        // Node's internal spawn-signal abort listener on a listenerless
+        // child and surfacing an uncaught AbortError.  See #1735.
       }
     }
 


### PR DESCRIPTION
## Problem

Closes #1735

The fix in #1371 added `attemptController.abort()` in the retry loop's `finally` block. By the time this runs, the codex-sdk's own finally has already called `child.removeAllListeners()` + `child.kill()`. The subsequent `abort()` fires Node's internal spawn-signal abort listener on the now-listenerless child, emitting an uncaught `AbortError` that bypasses any surrounding try/catch.

100% reproducible — crashes the workflow ~9-15s into the first codex node.

## Fix

Remove `attemptController.abort()` from the finally block. The per-attempt `AbortController` is short-lived and goes out of scope at iteration end — no explicit cleanup needed. Caller signal cancellation is unaffected (`removeEventListener` for the caller's abort listener is retained in the same finally block).

## Changes

- `packages/providers/src/codex/provider.ts`: Remove `attemptController.abort()` from finally, add explanatory comment referencing #1735
- `packages/providers/src/codex/provider.test.ts`: Add regression test verifying successful attempts don't throw from stale abort cleanup

## Validation

- `bun test packages/providers/src/codex/provider.test.ts` — 59 pass, 0 fail
- New regression test `successful attempt does not throw from stale abort cleanup (#1735)` passes
- Provider coverage at 99.67%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved uncaught errors occurring in sendQuery operations caused by abort signal cleanup race conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->