### PR TITLE
fix(providers/codex): drop attemptController.abort() from retry finally (#1735)

### DIFF
--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -1704,4 +1704,37 @@ describe('sendQuery decomposition behaviors', () => {
     expect(capturedSignal).not.toBe(callerController.signal);
     expect(capturedSignal?.aborted).toBe(true);
   }, 5_000);
+
+  // Regression for issue #1735.
+  // The retry loop's finally previously called attemptController.abort() as
+  // a "downstream cleanup" gesture. After a successful runStreamed completion,
+  // codex-sdk's own finally has already executed child.removeAllListeners()
+  // and child.kill(). Calling abort() afterwards trips Node's internal
+  // spawn({ signal }) listener (registered when the child was spawned), which
+  // calls abortChildProcess -> emitError on the now-listenerless child,
+  // surfacing as an uncaught process-level AbortError.
+  test('per-attempt signal is not aborted after a clean completion', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    mockRunStreamed.mockImplementation((_prompt: unknown, opts: { signal?: AbortSignal }) => {
+      capturedSignal = opts.signal;
+      return Promise.resolve({
+        events: (async function* () {
+          yield {
+            type: 'item.completed',
+            item: { type: 'agent_message', text: 'done', id: '1' },
+          };
+          yield { type: 'turn.completed', usage: defaultUsage };
+        })(),
+      });
+    });
+
+    const chunks = [];
+    for await (const chunk of client.sendQuery('test', '/workspace')) {
+      chunks.push(chunk);
+    }
+
+    expect(mockRunStreamed).toHaveBeenCalledTimes(1);
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal?.aborted).toBe(false);
+  }, 5_000);
 });

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -842,10 +842,6 @@ export class CodexProvider implements IAgentProvider {
         if (requestOptions?.abortSignal) {
           requestOptions.abortSignal.removeEventListener('abort', onCallerAbort);
         }
-        // Signal to any downstream consumers that this attempt is done.
-        // Next iteration creates a fresh controller; caller's signal state
-        // is unchanged.
-        attemptController.abort();
       }
     }
 


### PR DESCRIPTION
## Summary

- **Problem:** PR #1371's per-attempt `AbortController` cleanup (`attemptController.abort()` in the retry-loop `finally`) crashes every codex-provider workflow ~9–15 s into the first node. The abort fires Node's internal `spawn({ signal })` listener, which calls `abortChildProcess` → `emitError` on a child whose listeners codex-sdk has already torn down — surfacing as an uncaught process-level `AbortError`.
- **Why it matters:** 100% reproducible regression on any DAG workflow with a `provider: codex` node (`archon-comprehensive-pr-review`, `archon-smart-pr-review`, etc.). No workaround. Process-level uncaught exception bypasses surrounding try/catch.
- **What changed:** Removed `attemptController.abort()` (and its 3-line comment) from `packages/providers/src/codex/provider.ts` retry-loop `finally`. Added one regression test in `provider.test.ts`.
- **What did NOT change:** The fresh-`AbortController`-per-attempt mechanism from PR #1371 (the legitimate fix for #1266). Cancel propagation. `streamCodexEvents`. `buildTurnOptions`. The Claude provider. `@openai/codex-sdk` version.

## UX Journey

### Before

```
User                  Archon (web/CLI/adapters)          codex provider             codex-sdk + spawn()
────                  ─────────────────────────          ──────────────             ───────────────────
runs workflow ─────▶  schedules codex node  ──────────▶  sendQuery() retry loop ─▶  spawn(codex, { signal })
                                                         awaits runStreamed         child runs OK
                                                         ◀───────────────────────── SDK finally:
                                                                                      removeAllListeners()
                                                                                      child.kill()
                                                         finally:
                                                           attemptController.abort()
                                                           └─▶ Node onAbortListener fires
                                                                └─▶ abortChildProcess()
                                                                     └─▶ emitError on listenerless child
                                                                          └─▶ UNCAUGHT AbortError
                                                         ◀── workflow crashes ──
sees crash ◀──────── workflow run failed
```

### After

```
User                  Archon                              codex provider             codex-sdk + spawn()
────                  ──────                              ──────────────             ───────────────────
runs workflow ─────▶  schedules codex node  ──────────▶  sendQuery() retry loop ─▶  spawn(codex, { signal })
                                                         awaits runStreamed         child runs OK
                                                         ◀───────────────────────── SDK finally:
                                                                                      removeAllListeners()
                                                                                      child.kill()
                                                         finally:
                                                           removeEventListener(...)   [*unchanged*]
                                                           **(no abort)**             [-removed]
                                                         loop iteration ends; controller out of scope, GC'd
                                                         emits chunks ──────────────▶
sees output ◀────────  streams response
```

## Architecture Diagram

### Before

```
[caller]
  │ abortSignal
  ▼
[CodexProvider.sendQuery retry loop]
  ├── new AbortController() per attempt   [unchanged contract]
  ├── caller.addEventListener('abort', onCallerAbort, { once: true })
  ├── turnOptions.signal = attemptController.signal
  ├── thread.runStreamed(prompt, turnOptions)
  │      └─▶ [codex-sdk] spawn(codexBin, { signal })  ─── Node installs internal onAbortListener
  │             ...
  │             finally { rl.close(); child.removeAllListeners(); child.kill(); }
  └── finally {
        caller.removeEventListener('abort', onCallerAbort);   ── correct cleanup
        attemptController.abort();                            ── ✗ trips listenerless child via spawn-internal listener
      }
```

### After

```
[caller]
  │ abortSignal
  ▼
[CodexProvider.sendQuery retry loop]
  ├── new AbortController() per attempt           [~unchanged]
  ├── caller.addEventListener('abort', onCallerAbort, { once: true })
  ├── turnOptions.signal = attemptController.signal
  ├── thread.runStreamed(prompt, turnOptions)
  │      └─▶ [codex-sdk] spawn(codexBin, { signal })
  │             finally { rl.close(); child.removeAllListeners(); child.kill(); }
  └── finally {
        caller.removeEventListener('abort', onCallerAbort);   ── retained
        [- attemptController.abort()]                         ── REMOVED
      }
  (attemptController falls out of lexical scope at iteration end → GC eligible)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|-----|--------|-------|
| `CodexProvider.sendQuery` retry-loop `finally` | `attemptController.abort()` | **removed** | Eliminates the abort that trips the spawn-internal listener after the SDK has cleaned up the child. |
| Caller's `abortSignal` | `attemptController` (via `onCallerAbort`) | unchanged | Still chained while the attempt is active; cancel propagation unaffected. |
| `attemptController.signal` | `thread.runStreamed` / `streamCodexEvents` | unchanged | Per-attempt signal still passed; `streamCodexEvents` only reads `aborted`. |
| `caller.abortSignal` listener | `onCallerAbort` | unchanged | `removeEventListener` still detaches it in `finally`. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `core` (provider — `@archon/providers`)
- Module: `providers:codex`

## Change Metadata

- Change type: `bug`
- Primary scope: `core` (provider package)

## Linked Issue

- Closes #1735
- Related #1371 (introduced the regression)
- Related #1266 (the original fix that #1371 implemented; this PR keeps that fix intact)

## Validation Evidence (required)

```bash
bun run type-check    # all packages: Exited with code 0
bun run lint          # eslint --cache: clean, no warnings (max-warnings 0 enforced)
bun run format:check  # All matched files use Prettier code style!
bun test packages/providers/src/codex/provider.test.ts
# 59 pass / 0 fail / 130 expect() calls / 250ms
bun --filter @archon/providers test
# 67 + 1 + ... — 0 fail across the @archon/providers split
```

- Evidence provided: full `bun run validate` run locally. The codex provider's 59 tests (including the new regression test) all pass; the only failures in the full suite are 3 pre-existing `@archon/adapters` `telegram-markdown > blockquotes` tests that also fail on unmodified `origin/dev` (`253321b2`) — unrelated to this PR.
- Skipped commands: none.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes` — removes a destructive call inside a try-block `finally`; no public API change.
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios:
  - Pre-fix repro behavior (per issue reporter `melowllc`): `archon workflow run archon-comprehensive-pr-review --no-worktree "Review PR #<any>"` crashes ~9–15 s in on the first codex node with the `AbortError` stack frame at `provider.ts:848`.
  - Post-fix: reporter verified locally that the same workflow completes end-to-end (review posted, auto-fix commits pushed).
  - All 59 codex provider unit tests pass on this branch (including the new regression test and the two pre-existing #1266 regression tests that prove cancel propagation and fresh-signal-per-attempt still work).
- Edge cases checked:
  - Caller abort mid-attempt → still propagates via `onCallerAbort` once-listener (existing test `caller abort forwards into the active per-attempt signal` confirms).
  - Retry after crash → still gets a fresh, non-aborted signal (existing test `retry after crash receives a fresh (non-aborted) AbortSignal` confirms).
  - Clean completion → per-attempt signal stays non-aborted (new test asserts).
- What was not verified by me directly: end-to-end live `codex` execution against a real binary (reporter validated; CI mocks the SDK).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `@archon/providers` codex retry loop only.
- Potential unintended effects: none expected. The `AbortController` is local-scoped and unobservable from outside the loop body; removing its terminal `.abort()` cannot affect anything we don't already control.
- Guardrails/monitoring for early detection: the new regression test fails if the abort is reintroduced. Live workflows surface the crash immediately (uncaught exception), so reintroduction would be visible within minutes.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge-commit>` on `dev`. Single-file, 4-line additive revert; no migrations.
- Feature flags or config toggles: none — the abort was unconditional.
- Observable failure symptoms: codex-provider DAG workflows crashing within ~15 s of starting the first codex node with `AbortError ... at sendQuery (.../codex/provider.ts:NNN:27)`.

## Risks and Mitigations

- Risk: A future caller of `streamCodexEvents` or another downstream consumer could begin to rely on the per-attempt signal being aborted at iteration boundary.
  - Mitigation: there are no such consumers today (`streamCodexEvents` only reads `aborted`; `runStreamed` is the only external consumer and the SDK's own `finally` has already completed by this point). The new regression test pins the behavior. If a future consumer needs signal teardown, it should subscribe to its own lifecycle, not piggyback on a local controller.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where internal operation signals were being unintentionally terminated after successful query completion. This resolves potential system instability and prevents negative cascading impacts on subsequent operations and requests.

* **Tests**
  * Added regression test to ensure operation signals are properly maintained in their correct state following successful query completion, without unintended termination or interruption.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1740?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->