### PR TITLE
fix(web/chat): wrap long unbreakable strings in chat message bubbles (fixes #1738)

### DIFF
--- a/packages/web/src/components/chat/MessageBubble.tsx
+++ b/packages/web/src/components/chat/MessageBubble.tsx
@@ -175,7 +175,7 @@ function MessageBubbleRaw({ message }: MessageBubbleProps): React.ReactElement {
           {isUser ? (
             <div className="flex flex-col gap-1.5">
               <div className="flex items-start gap-2">
-                <p className="text-sm text-text-primary whitespace-pre-wrap flex-1">
+                <p className="text-sm text-text-primary whitespace-pre-wrap break-words min-w-0 flex-1">
                   {message.content}
                 </p>
                 <button

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -183,6 +183,13 @@ body {
 .chat-markdown p {
   margin-top: 0.5em;
   margin-bottom: 0.5em;
+  overflow-wrap: break-word;
+}
+
+.chat-markdown li,
+.chat-markdown td,
+.chat-markdown a {
+  overflow-wrap: break-word;
 }
 
 .chat-markdown p:first-child {


### PR DESCRIPTION
## Summary

- **Problem:** Long unbreakable strings (URLs, hashes, tokens) in chat messages overflow the message-bubble container. User bubbles use `max-w-[70%]` and assistant content lives inside a `chat-markdown` block, but neither path sets `overflow-wrap: break-word`, so a single long word punches through the layout.
- **Why it matters:** Issue #1738 reports this as a UI break — long content escapes the bubble and disrupts surrounding layout for both user and assistant messages.
- **What changed:** Two surgical CSS fixes. User-bubble `<p>` gets `break-words` + `min-w-0` (so the flex child can shrink below intrinsic width). The hand-rolled `.chat-markdown` typography rules now declare `overflow-wrap: break-word` on `p`, `li`, `td`, and `a`.
- **What did NOT change:** Code blocks (`<pre>`) still use `overflow-x-auto` and are deliberately excluded — horizontal scroll is the right behavior for code. No layout, color, spacing, or component structure changes.

## UX Journey

### Before

```
User pastes long URL ──▶  message bubble        ──▶ <p> renders with no break rule
                          max-w-[70%]               ↓
                                                    ❌ URL extends past bubble edge,
                                                       pushes layout sideways
```

### After

```
User pastes long URL ──▶  message bubble        ──▶ <p> with break-words + min-w-0
                          max-w-[70%]               ↓
                                                    ✅ URL wraps at character boundary
                                                       inside the bubble
```

Same fix applied to assistant markdown content via `.chat-markdown` rules.

## Architecture Diagram

### Before

```
MessageBubble.tsx
  ├─ user branch:  <p className="text-sm ... flex-1">  (no break rule)
  └─ assistant:    <div className="chat-markdown ...">
                     └─ ReactMarkdown → <p>, <li>, <a>, <td>  (no break rule)
```

### After

```
MessageBubble.tsx
  ├─ user branch:  <p className="... break-words min-w-0 flex-1">  [~]
  └─ assistant:    <div className="chat-markdown ...">
                     └─ ReactMarkdown → <p>, <li>, <a>, <td>
                                        ↑ now inherit overflow-wrap: break-word [~]
                                        via index.css .chat-markdown rules
```

**Connection inventory:**

| From | To | Status | Notes |
|------|-----|--------|-------|
| MessageBubble user `<p>` | flex layout | [~] adds `break-words min-w-0` so flex child can wrap |
| `.chat-markdown p` | typography | [~] adds `overflow-wrap: break-word` |
| `.chat-markdown li, td, a` | typography | [+] new rule, same property |
| `.chat-markdown pre` | code blocks | unchanged — keeps `overflow-x-auto` (intentional) |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `web`
- Module: `web:chat`

## Change Metadata

- Change type: `bug`
- Primary scope: `web`

## Linked Issue

- Closes #1738

## Validation Evidence

```bash
bun run type-check    # clean (tsc --noEmit)
# lint + prettier ran via lint-staged on commit, both green
```

Manual verification: pasted a 200-char URL (`https://example.com/foo/bar/baz?` + 150 random chars) into a chat message and confirmed it now wraps inside the user bubble instead of overflowing. Repeated with a long markdown link in an assistant response — wraps inside `.chat-markdown`. Code blocks still scroll horizontally as before.

## Security Impact

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — pure CSS, no API or data shape changes.
- Config/env changes? No
- Database migration needed? No

## Human Verification

- Verified scenarios: long URL in user bubble wraps; long URL in assistant markdown wraps; code block still scrolls horizontally; existing short messages unchanged.
- Edge cases checked: long token without spaces, long markdown link `[text](very-long-url)`, mixed text + long URL, table cell with long token.
- What was not verified: cross-browser beyond Chromium 130. `overflow-wrap: break-word` is supported in all evergreen browsers per MDN.

## Side Effects / Blast Radius

- Affected subsystems/workflows: chat UI only (`packages/web/src/components/chat/MessageBubble.tsx` + `.chat-markdown` rules in `index.css`).
- Potential unintended effects: text that previously rendered on one line might now wrap if the container is narrower than the content. This is the intended fix; no other layout reads from these rules.
- Guardrails/monitoring: visual regression caught at build/dev time.

## Rollback Plan

- Fast rollback: `git revert <commit>` — pure CSS revert, no state or schema impact.
- Feature flags: none required.
- Observable failure symptoms: text would resume escaping the bubble.

## Risks and Mitigations

- Risk: A consumer of `.chat-markdown` outside the chat surface expected text not to wrap.
  - Mitigation: grepped the codebase for `chat-markdown` — only used in `MessageBubble.tsx`. No other call sites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text wrapping in chat messages to properly handle long unbroken content (such as URLs) for better readability and consistent display across all message types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1742?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->