### PR TITLE
fix(db): read defaultAssistant from config in createCodebase (fixes #1703)

### DIFF
--- a/packages/core/src/db/codebases.test.ts
+++ b/packages/core/src/db/codebases.test.ts
@@ -78,7 +78,8 @@ describe('codebases', () => {
       );
     });
 
-    test('defaults ai_assistant_type to claude', async () => {
+    test('defaults ai_assistant_type to claude when no env var set', async () => {
+      delete process.env.DEFAULT_AI_ASSISTANT;
       mockQuery.mockResolvedValueOnce(createQueryResult([mockCodebase]));
 
       await createCodebase({
@@ -90,6 +91,37 @@ describe('codebases', () => {
         expect.any(String),
         expect.arrayContaining(['claude'])
       );
+    });
+
+    test('reads DEFAULT_AI_ASSISTANT env var when ai_assistant_type omitted', async () => {
+      process.env.DEFAULT_AI_ASSISTANT = 'codex';
+      mockQuery.mockResolvedValueOnce(
+        createQueryResult([{ ...mockCodebase, ai_assistant_type: 'codex' }])
+      );
+
+      await createCodebase({
+        name: 'test-project',
+        default_cwd: '/workspace/test-project',
+      });
+
+      expect(mockQuery).toHaveBeenCalledWith(expect.any(String), expect.arrayContaining(['codex']));
+      delete process.env.DEFAULT_AI_ASSISTANT;
+    });
+
+    test('explicit ai_assistant_type takes priority over env var', async () => {
+      process.env.DEFAULT_AI_ASSISTANT = 'codex';
+      mockQuery.mockResolvedValueOnce(
+        createQueryResult([{ ...mockCodebase, ai_assistant_type: 'pi' }])
+      );
+
+      await createCodebase({
+        name: 'test-project',
+        default_cwd: '/workspace/test-project',
+        ai_assistant_type: 'pi',
+      });
+
+      expect(mockQuery).toHaveBeenCalledWith(expect.any(String), expect.arrayContaining(['pi']));
+      delete process.env.DEFAULT_AI_ASSISTANT;
     });
   });
 

--- a/packages/core/src/db/codebases.ts
+++ b/packages/core/src/db/codebases.ts
@@ -18,7 +18,7 @@ export async function createCodebase(data: {
   default_cwd: string;
   ai_assistant_type?: string;
 }): Promise<Codebase> {
-  const assistantType = data.ai_assistant_type ?? 'claude';
+  const assistantType = data.ai_assistant_type ?? process.env.DEFAULT_AI_ASSISTANT ?? 'claude';
   const result = await pool.query<Codebase>(
     'INSERT INTO remote_agent_codebases (name, repository_url, default_cwd, ai_assistant_type) VALUES ($1, $2, $3, $4) RETURNING *',
     [data.name, data.repository_url ?? null, data.default_cwd, assistantType]


### PR DESCRIPTION
## Summary

- **Problem:** `createCodebase()` hardcoded `'claude'` as the fallback when `ai_assistant_type` was not provided, ignoring the user's configured `defaultAssistant`.
- **Why it matters:** Users who set a non-claude default assistant (via `DEFAULT_AI_ASSISTANT` env var or `~/.archon/config.yaml`) still got `claude` for every new project registration.
- **What changed:** `createCodebase()` now checks `process.env.DEFAULT_AI_ASSISTANT` before falling back to `'claude'`, consistent with how `getOrCreateConversation()` resolves the default assistant.
- **What did not change:** Explicit `ai_assistant_type` values are used directly. No API schema changes. No new imports.

## UX Journey

### Before

```
User                         Archon
────                         ──────
sets DEFAULT_AI_ASSISTANT=codex
registers project ──────────▶ createCodebase({name, cwd})
                              ai_assistant_type = 'claude' (hardcoded)
sees project uses claude ◀── env var ignored
```

### After

```
User                         Archon
────                         ──────
sets DEFAULT_AI_ASSISTANT=codex
registers project ──────────▶ createCodebase({name, cwd})
                              ai_assistant_type = process.env.DEFAULT_AI_ASSISTANT → 'codex'
sees project uses codex ◀─── respects user's configured default
```

## Architecture Diagram

No architectural changes. Single fallback chain updated: `data.ai_assistant_type ?? process.env.DEFAULT_AI_ASSISTANT ?? 'claude'`.

## Label Snapshot

| Label | Value |
|-------|-------|
| Area | `db` |
| Type | Bug fix |
| Scope | `packages/core/src/db/codebases.ts` |

## Change Metadata

| Metric | Value |
|--------|-------|
| Files changed | 2 |
| Lines added | ~34 |
| Lines removed | ~2 |
| New dependencies | None |

## Linked Issue

Closes #1703

## Validation Evidence

- `bun test packages/core/src/db/codebases.test.ts` → 31 pass, 0 fail
- `bun run test` (full suite) → 0 fail across all packages
- `eslint` + `prettier` via lint-staged → clean

**New tests:**
1. Reads `DEFAULT_AI_ASSISTANT` env var when `ai_assistant_type` omitted → uses `codex`
2. Falls back to `claude` when no env var set
3. Explicit `ai_assistant_type` takes priority over env var

## Security Impact

None. Reads an existing env var that the server already uses elsewhere.

## Compatibility/Migration

Backward compatible. Behavior is identical when `DEFAULT_AI_ASSISTANT` is unset (falls back to `'claude'`).

## Human Verification

- [x] Tested with `bun test` (per-file and full suite)
- [x] Lint-staged passed

## Risks and Mitigations

| Risk | Mitigation |
|------|------------|
| Env var not set | Falls back to `'claude'` (same as before) |

## Side Effects/Blast Radius

None. Only affects the default assistant assignment in `createCodebase()`.

## Rollback Plan

Revert the single commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assistant type selection now prefers an explicit value, then the DEFAULT_AI_ASSISTANT environment setting, and falls back to 'claude'.

* **Tests**
  * Expanded tests to cover: env unset (falls back to 'claude'), env set (uses DEFAULT_AI_ASSISTANT when omitted), and explicit value overriding the env setting; environment isolation added to prevent cross-test leakage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1746?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->