### PR TITLE
feat(web): experimental console UI at /console

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@
 - Schema naming: camelCase, descriptive suffix (e.g., `workflowRunSchema`, `errorSchema`)
 - Type derivation: always use `z.infer<typeof schema>` — never write parallel hand-crafted interfaces
 - Import `z` from `@hono/zod-openapi` (not from `zod` directly)
-- All new/modified API routes must use `registerOpenApiRoute(createRoute({...}), handler)` — the local wrapper handles the TypedResponse bypass
+- All new/modified API routes must use `registerOpenApiRoute(createRoute({...}), handler)` — the local wrapper handles the TypedResponse bypass. Two narrow exceptions exist: (1) routes that serve raw non-JSON content (e.g. `/api/artifacts/:runId/*` returns `text/markdown`/`text/plain`) AND use wildcard path params that OpenAPI 3.0 can't represent, use `app.get(...)` with an explanatory comment; (2) multipart-or-JSON routes (e.g. `/api/conversations/:id/message`, `/api/workflows/:name/run`) register through `registerOpenApiRoute` but drop `request.body` from the route config so Zod doesn't validate multipart payloads against a JSON schema — the handler parses both content types manually.
 - Route schemas live in `packages/server/src/routes/schemas/` — one file per domain
 - Engine schemas live in `packages/workflows/src/schemas/` — one file per concern (dag-node, workflow, workflow-run, retry, loop, hooks); `index.ts` re-exports all
 - Engine schema naming: camelCase (e.g., `dagNodeSchema`, `workflowBaseSchema`, `nodeOutputSchema`)
@@ -357,6 +357,10 @@ packages/
         ├── lib/              # API client, types, utilities
         ├── stores/           # Zustand stores (workflow-store)
         ├── routes/           # Route pages (ChatPage, WorkflowsPage, WorkflowBuilderPage, etc.)
+        ├── experiments/      # Isolated in-repo spikes; lint-guarded against
+        │   │                 # importing production web modules. Drop-in or
+        │   │                 # delete cleanly. See experiments/README.md.
+        │   └── console/      # Run-centric console UI mounted at /console
         └── App.tsx           # Router + layout
 ```
 
@@ -805,6 +809,7 @@ Pattern: Use `classifyIsolationError()` (from `@archon/isolation`) to map git er
 - `GET /api/codebases/:id/environments` - List tracked isolation environments for a codebase
 
 **Artifact Files:**
+- `GET /api/runs/:runId/artifacts` - List artifact files for a run; walks the on-disk artifact directory (dotfiles skipped) and returns `{ files: [{ path, size, modifiedAt }] }`; 400 on invalid run id or path-escape attempt, 404 if the run does not exist
 - `GET /api/artifacts/:runId/*` - Serve a workflow artifact file by run ID and relative path; returns `text/markdown` for `.md` files, `text/plain` otherwise; 400 on path traversal (`..`), 404 if run or file not found
 
 **Command Listing:**

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -122,13 +122,7 @@ export default tseslint.config(
         {
           patterns: [
             {
-              group: [
-                '@/components/*',
-                '@/contexts/*',
-                '@/hooks/*',
-                '@/routes/*',
-                '@/stores/*',
-              ],
+              group: ['@/components/*', '@/contexts/*', '@/hooks/*', '@/routes/*', '@/stores/*'],
               message:
                 'The console spike must not import from production web UI modules. See packages/web/src/experiments/console/README.md.',
             },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -122,13 +122,23 @@ export default tseslint.config(
         {
           patterns: [
             {
-              group: ['@/components/*', '@/contexts/*', '@/hooks/*', '@/routes/*', '@/stores/*'],
+              // `**` matches nested paths too; the single `*` form let
+              // experiments couple to `@/components/layout/...` etc.
+              group: [
+                '@/components/**',
+                '@/contexts/**',
+                '@/hooks/**',
+                '@/routes/**',
+                '@/stores/**',
+              ],
               message:
                 'The console spike must not import from production web UI modules. See packages/web/src/experiments/console/README.md.',
             },
             {
+              // Block every named import from `@/lib/api` — only generated
+              // types from `@/lib/api.generated` are allowed (different
+              // module path, not matched by this glob).
               group: ['@/lib/api'],
-              importNames: ['default'],
               message:
                 'Import only types from @/lib/api.generated. Skill calls go through packages/web/src/experiments/console/skills/.',
             },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -109,5 +109,43 @@ export default tseslint.config(
       // Constructor style preference
       '@typescript-eslint/consistent-generic-constructors': 'off',
     },
+  },
+
+  // Console spike (packages/web/src/experiments/console/**) — isolation guard.
+  // This experiment must not couple to the production web UI's state/components
+  // so that it can be extracted or discarded cleanly.
+  {
+    files: ['packages/web/src/experiments/console/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: [
+                '@/components/*',
+                '@/contexts/*',
+                '@/hooks/*',
+                '@/routes/*',
+                '@/stores/*',
+              ],
+              message:
+                'The console spike must not import from production web UI modules. See packages/web/src/experiments/console/README.md.',
+            },
+            {
+              group: ['@/lib/api'],
+              importNames: ['default'],
+              message:
+                'Import only types from @/lib/api.generated. Skill calls go through packages/web/src/experiments/console/skills/.',
+            },
+            {
+              group: ['@tanstack/react-query'],
+              message:
+                'The console spike uses its own reactive store (store/cache.ts). No React Query.',
+            },
+          ],
+        },
+      ],
+    },
   }
 );

--- a/packages/docs-web/src/content/docs/reference/api.md
+++ b/packages/docs-web/src/content/docs/reference/api.md
@@ -259,9 +259,10 @@ Only user-defined workflows can be deleted. Bundled defaults cannot be removed.
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/api/workflows/{name}/run` | Run a workflow |
+| POST | `/api/workflows/{name}/run` | Run a workflow (JSON or multipart) |
 | GET | `/api/workflows/runs` | List workflow runs |
 | GET | `/api/workflows/runs/{runId}` | Get run details with events |
+| GET | `/api/runs/{runId}/artifacts` | List artifact files produced by a run |
 | GET | `/api/workflows/runs/by-worker/{platformId}` | Look up a run by worker conversation ID |
 | POST | `/api/workflows/runs/{runId}/cancel` | Cancel a running workflow |
 | POST | `/api/workflows/runs/{runId}/resume` | Resume a failed workflow |
@@ -273,10 +274,26 @@ Only user-defined workflows can be deleted. Bundled defaults cannot be removed.
 #### Run a Workflow
 
 ```bash
+# JSON (no attachments)
 curl -X POST http://localhost:3090/api/workflows/archon-assist/run \
   -H "Content-Type: application/json" \
   -d '{"message": "Explain the auth module", "conversationId": "conv-123"}'
+
+# multipart (with file attachments — max 5 files, ≤10 MB each)
+curl -X POST http://localhost:3090/api/workflows/archon-assist/run \
+  -F "conversationId=conv-123" \
+  -F "message=Investigate this trace" \
+  -F "files=@stacktrace.txt" \
+  -F "files=@screenshot.png"
 ```
+
+#### List Run Artifacts
+
+```bash
+curl http://localhost:3090/api/runs/{runId}/artifacts
+```
+
+Walks the run's on-disk artifact directory (dotfiles skipped) and returns `{ files: [{ path, size, modifiedAt }] }`. Used by the console UI's Artifacts tab. Returns `{ files: [] }` when the run has no codebase or the codebase name is not in `owner/repo` form; 400 on invalid run id or path-escape attempt, 404 if the run does not exist.
 
 #### Resume a Failed Run
 

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -89,6 +89,7 @@ import {
   workflowRunsQuerySchema,
   approveWorkflowRunBodySchema,
   rejectWorkflowRunBodySchema,
+  listArtifactsResponseSchema,
 } from './schemas/workflow.schemas';
 import {
   conversationListResponseSchema,
@@ -564,6 +565,29 @@ const runWorkflowRoute = createRoute({
       description: 'Accepted',
     },
     400: jsonError('Bad request'),
+    500: jsonError('Server error'),
+  },
+});
+
+const listRunArtifactsRoute = createRoute({
+  method: 'get',
+  path: '/api/runs/{runId}/artifacts',
+  tags: ['Workflows'],
+  summary: "List a run's artifact files",
+  description:
+    "Walks the run's artifact directory and returns relative file paths with size + " +
+    'mtime. Drives the console Artifacts tab. Returns `{ files: [] }` when the run ' +
+    'has no codebase or the codebase name is not in `owner/repo` form.',
+  request: {
+    params: z.object({ runId: z.string() }),
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: listArtifactsResponseSchema } },
+      description: 'OK',
+    },
+    400: jsonError('Bad request'),
+    404: jsonError('Not found'),
     500: jsonError('Server error'),
   },
 });
@@ -2734,14 +2758,14 @@ export function registerApiRoutes(
     }
   });
 
-  // GET /api/runs/:runId/artifacts - List artifact files for a run
+  // GET /api/runs/:runId/artifacts - List artifact files for a run.
   // Walks the run's artifact directory and returns relative file paths with
   // size + mtime. Used by the console's Artifacts tab; the existing
   // `workflow_artifact` event stream is too sparse (bash/script nodes write
   // straight to $ARTIFACTS_DIR without emitting an event) to drive a file
   // browser on its own.
-  app.get('/api/runs/:runId/artifacts', async c => {
-    const runId = c.req.param('runId');
+  registerOpenApiRoute(listRunArtifactsRoute, async c => {
+    const runId = c.req.param('runId') ?? '';
     if (!/^[A-Za-z0-9_-]+$/.test(runId)) {
       return apiError(c, 400, 'Invalid run id');
     }
@@ -2755,13 +2779,38 @@ export function registerApiRoutes(
     }
     if (!run) return apiError(c, 404, 'Workflow run not found');
 
-    const codebase = run.codebase_id ? await codebaseDb.getCodebase(run.codebase_id) : null;
+    let codebase: Awaited<ReturnType<typeof codebaseDb.getCodebase>> | null = null;
+    if (run.codebase_id) {
+      try {
+        codebase = await codebaseDb.getCodebase(run.codebase_id);
+      } catch (error) {
+        getLog().error(
+          { err: error, runId, codebaseId: run.codebase_id },
+          'artifacts.codebase_lookup_failed'
+        );
+        return apiError(c, 500, 'Failed to look up codebase');
+      }
+    }
     if (!codebase?.name) return c.json({ files: [] });
     const nameParts = codebase.name.split('/');
     if (nameParts.length < 2) return c.json({ files: [] });
-    const [owner, repo] = nameParts;
+    const owner = nameParts[0];
+    const repo = nameParts[1];
+    if (!owner || !repo) return c.json({ files: [] });
 
     const artifactDir = getRunArtifactsPath(owner, repo, runId);
+    // Defense-in-depth: even though registration sanitises codebase names,
+    // ensure the resolved dir stays inside ARCHON_HOME — a maliciously
+    // crafted owner/repo containing `..` would otherwise escape the tree.
+    const archonHome = getArchonHome();
+    const normalisedDir = normalize(artifactDir);
+    if (
+      !normalisedDir.startsWith(normalize(archonHome) + sep) &&
+      normalisedDir !== normalize(archonHome)
+    ) {
+      getLog().warn({ runId, artifactDir, archonHome }, 'artifacts.path_escape_blocked');
+      return apiError(c, 400, 'Invalid artifact path');
+    }
 
     interface FileEntry {
       path: string;
@@ -2793,8 +2842,13 @@ export function registerApiRoutes(
               size: s.size,
               modifiedAt: s.mtime.toISOString(),
             });
-          } catch {
-            /* skip unreadable entries */
+          } catch (err) {
+            // Race with deletion / permission flips: skip ENOENT / EACCES
+            // silently, surface anything else so we don't return a half-list
+            // with no diagnostic.
+            const code = (err as NodeJS.ErrnoException).code;
+            if (code === 'ENOENT' || code === 'EACCES') continue;
+            throw err;
           }
         }
       }

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -85,7 +85,6 @@ import {
   cancelWorkflowRunResponseSchema,
   workflowRunActionResponseSchema,
   dashboardRunsResponseSchema,
-  runWorkflowBodySchema,
   dashboardRunsQuerySchema,
   workflowRunsQuerySchema,
   approveWorkflowRunBodySchema,
@@ -543,17 +542,21 @@ const deleteEnvVarRoute = createRoute({
 // Workflow run route configs
 // =========================================================================
 
+// Body validation is handled manually in the handler (multipart vs JSON
+// branching), mirroring sendMessageRoute. The OpenAPI spec describes the
+// shapes via the description; declaring `request.body` would force JSON
+// validation to run on multipart payloads and reject them.
 const runWorkflowRoute = createRoute({
   method: 'post',
   path: '/api/workflows/{name}/run',
   tags: ['Workflows'],
-  summary: 'Run a workflow via the orchestrator',
+  summary: 'Run a workflow via the orchestrator (JSON or multipart with file uploads)',
+  description:
+    'Accepts `application/json` with `{ conversationId, message }` or ' +
+    '`multipart/form-data` with `conversationId`, `message`, and optional file ' +
+    'attachments (max 5 files, 10 MB each).',
   request: {
     params: z.object({ name: z.string() }),
-    body: {
-      content: { 'application/json': { schema: runWorkflowBodySchema } },
-      required: true,
-    },
   },
   responses: {
     200: {
@@ -966,6 +969,91 @@ export function registerApiRoutes(
       }
     }
     return false;
+  }
+
+  /**
+   * Persist multipart-uploaded files to the conversation's upload directory.
+   * Shared by /api/conversations/:id/message and /api/workflows/:name/run.
+   * Returns the saved file metadata + the directory chosen so the caller can
+   * pass both to dispatchToOrchestrator for cleanup inside the lock handler.
+   *
+   * Throws a Response-shaped error via the `errorResponse` callback when
+   * validation fails; the caller then short-circuits and returns it.
+   */
+  async function persistUploadedFiles(
+    conversationId: string,
+    fileEntries: File[]
+  ): Promise<
+    | { ok: true; savedFiles: AttachedFile[]; uploadDir: string }
+    | { ok: false; status: 400 | 500; error: string }
+  > {
+    if (fileEntries.length > MAX_FILES_PER_MESSAGE) {
+      return {
+        ok: false,
+        status: 400,
+        error: `Maximum ${MAX_FILES_PER_MESSAGE.toString()} files per message`,
+      };
+    }
+
+    const archonHome = getArchonHome();
+    const uploadDir = join(archonHome, 'artifacts', 'uploads', conversationId);
+    if (!uploadDir.startsWith(archonHome + sep)) {
+      return { ok: false, status: 400, error: 'Invalid conversation ID' };
+    }
+
+    // Validate all files before writing any to disk.
+    for (const entry of fileEntries) {
+      const displayName = basename(entry.name).replace(/[^a-zA-Z0-9._-]/g, '_');
+      if (!isAllowedUploadType(entry.type, entry.name)) {
+        return {
+          ok: false,
+          status: 400,
+          error: `File "${displayName}" has an unsupported type: ${entry.type}`,
+        };
+      }
+      if (entry.size > MAX_UPLOAD_BYTES) {
+        return {
+          ok: false,
+          status: 400,
+          error: `File "${displayName}" exceeds the 10 MB size limit`,
+        };
+      }
+    }
+
+    const savedFiles: AttachedFile[] = [];
+    try {
+      await mkdir(uploadDir, { recursive: true });
+      for (const entry of fileEntries) {
+        const fileId = randomUUID();
+        const safeName = basename(entry.name).replace(/[^a-zA-Z0-9._-]/g, '_');
+        const filePath = join(uploadDir, `${fileId}_${safeName}`);
+        await writeFile(filePath, Buffer.from(await entry.arrayBuffer()));
+        const normalizedMime =
+          entry.type.split(';')[0].trim().toLowerCase() || 'application/octet-stream';
+        savedFiles.push({
+          path: filePath,
+          name: safeName || fileId,
+          mimeType: normalizedMime,
+          size: entry.size,
+        });
+      }
+    } catch (writeErr: unknown) {
+      for (const f of savedFiles) {
+        await unlink(f.path).catch((err: NodeJS.ErrnoException) => {
+          if (err.code !== 'ENOENT') {
+            getLog().warn({ err, filePath: f.path, conversationId }, 'upload.rollback_failed');
+          }
+        });
+      }
+      getLog().error({ err: writeErr, conversationId }, 'upload.write_failed');
+      return {
+        ok: false,
+        status: 500,
+        error: 'Failed to save uploaded file. Check available disk space.',
+      };
+    }
+
+    return { ok: true, savedFiles, uploadDir };
   }
 
   async function dispatchToOrchestrator(
@@ -1796,14 +1884,89 @@ export function registerApiRoutes(
   });
 
   // POST /api/workflows/:name/run - Run a workflow via the orchestrator
+  //
+  // Accepts either:
+  //   - application/json: { conversationId, message }
+  //   - multipart/form-data: conversationId + message + files[] (≤5, ≤10MB each)
+  //
+  // Multipart matches /api/conversations/:id/message so the console's draft
+  // run input can attach screenshots / stack traces / paste-blobs the same
+  // way a freeform chat message can.
   registerOpenApiRoute(runWorkflowRoute, async c => {
     const workflowName = c.req.param('name') ?? '';
     if (!isValidCommandName(workflowName)) {
       return apiError(c, 400, 'Invalid workflow name');
     }
+
+    let message: string;
+    let conversationId: string;
+    let savedFiles: AttachedFile[] = [];
+    let uploadDir = '';
+
+    const contentType = c.req.header('content-type') ?? '';
+
+    if (contentType.includes('multipart/form-data')) {
+      let body: Record<string, string | File | (string | File)[]>;
+      try {
+        body = await c.req.parseBody({ all: true });
+      } catch (parseErr: unknown) {
+        getLog().warn({ err: parseErr }, 'run_workflow.multipart_parse_failed');
+        return apiError(c, 400, 'Invalid multipart form data');
+      }
+
+      const rawMessage = body.message;
+      const rawConv = body.conversationId;
+      if (typeof rawMessage !== 'string' || !rawMessage) {
+        return apiError(c, 400, 'message must be a non-empty string');
+      }
+      if (typeof rawConv !== 'string' || !rawConv || !/^[\w-]+$/.test(rawConv)) {
+        return apiError(c, 400, 'conversationId must be a non-empty alphanumeric string');
+      }
+      message = rawMessage;
+      conversationId = rawConv;
+
+      const rawFiles = body.files;
+      const fileList: (string | File)[] = Array.isArray(rawFiles)
+        ? rawFiles
+        : rawFiles !== undefined
+          ? [rawFiles]
+          : [];
+      const fileEntries = fileList.filter((e): e is File => e instanceof File);
+
+      if (fileEntries.length > 0) {
+        const result = await persistUploadedFiles(conversationId, fileEntries);
+        if (!result.ok) {
+          return apiError(c, result.status, result.error);
+        }
+        savedFiles = result.savedFiles;
+        uploadDir = result.uploadDir;
+        getLog().info(
+          { conversationId, fileCount: savedFiles.length, workflowName },
+          'run_workflow.files_uploaded'
+        );
+      }
+    } else {
+      let body: { conversationId?: unknown; message?: unknown };
+      try {
+        body = await c.req.json();
+      } catch (parseErr: unknown) {
+        getLog().warn({ err: parseErr }, 'run_workflow.json_parse_failed');
+        return apiError(c, 400, 'Invalid JSON in request body');
+      }
+      if (typeof body.conversationId !== 'string' || !body.conversationId) {
+        return apiError(c, 400, 'conversationId must be a non-empty string');
+      }
+      if (typeof body.message !== 'string' || !body.message) {
+        return apiError(c, 400, 'message must be a non-empty string');
+      }
+      conversationId = body.conversationId;
+      message = body.message;
+    }
+
     try {
-      const { conversationId, message } = getValidatedBody(c, runWorkflowBodySchema);
-      // Persist user message and register DB ID (same as message endpoint)
+      // Persist user message and register DB ID (same as message endpoint).
+      // File metadata (name/mime/size — no path, since the on-disk file is
+      // ephemeral) goes into message metadata when present.
       let conv: Awaited<ReturnType<typeof conversationDb.findConversationByPlatformId>> = null;
       try {
         conv = await conversationDb.findConversationByPlatformId(conversationId);
@@ -1811,13 +1974,16 @@ export function registerApiRoutes(
         getLog().error({ err: e, conversationId }, 'conversation_lookup_failed');
       }
       if (conv) {
+        const meta =
+          savedFiles.length > 0
+            ? { files: savedFiles.map(f => ({ name: f.name, mimeType: f.mimeType, size: f.size })) }
+            : undefined;
         try {
-          await messageDb.addMessage(conv.id, 'user', message);
+          await messageDb.addMessage(conv.id, 'user', message, meta);
         } catch (e: unknown) {
           getLog().error({ err: e, conversationId: conv.id }, 'message_persistence_failed');
         }
         webAdapter.setConversationDbId(conversationId, conv.id);
-        // Generate title for sidebar (fire-and-forget)
         if (!conv.title) {
           void generateAndSetTitle(
             conv.id,
@@ -1830,7 +1996,14 @@ export function registerApiRoutes(
       }
 
       const fullMessage = `/workflow run ${workflowName} ${message}`;
-      const result = await dispatchToOrchestrator(conversationId, fullMessage);
+      const extraContext = savedFiles.length > 0 ? { attachedFiles: savedFiles } : undefined;
+      const filesToCleanup = savedFiles.length > 0 ? { files: savedFiles, uploadDir } : undefined;
+      const result = await dispatchToOrchestrator(
+        conversationId,
+        fullMessage,
+        extraContext,
+        filesToCleanup
+      );
       return c.json(result);
     } catch (error) {
       getLog().error({ err: error }, 'run_workflow_failed');

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -1974,12 +1974,18 @@ export function registerApiRoutes(
         getLog().error({ err: e, conversationId }, 'conversation_lookup_failed');
       }
       if (conv) {
-        const meta =
-          savedFiles.length > 0
-            ? { files: savedFiles.map(f => ({ name: f.name, mimeType: f.mimeType, size: f.size })) }
-            : undefined;
         try {
-          await messageDb.addMessage(conv.id, 'user', message, meta);
+          // Only pass the metadata arg when files are present; keeps the
+          // signature 3-arg in the (common) JSON path so test fixtures don't
+          // need to know about the multipart-shaped 4th argument.
+          if (savedFiles.length > 0) {
+            const meta = {
+              files: savedFiles.map(f => ({ name: f.name, mimeType: f.mimeType, size: f.size })),
+            };
+            await messageDb.addMessage(conv.id, 'user', message, meta);
+          } else {
+            await messageDb.addMessage(conv.id, 'user', message);
+          }
         } catch (e: unknown) {
           getLog().error({ err: e, conversationId: conv.id }, 'message_persistence_failed');
         }

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -6,7 +6,7 @@ import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
 import { streamSSE } from 'hono/streaming';
 import { cors } from 'hono/cors';
 import type { WebAdapter } from '../adapters/web';
-import { rm, readFile, writeFile, unlink, mkdir } from 'fs/promises';
+import { rm, readFile, writeFile, unlink, mkdir, readdir, stat } from 'fs/promises';
 import { readFileSync } from 'fs';
 import { normalize, join, sep, basename } from 'path';
 import { randomUUID } from 'crypto';
@@ -2553,6 +2553,83 @@ export function registerApiRoutes(
       getLog().error({ err }, 'commands.list_failed');
       return apiError(c, 500, 'Failed to list commands');
     }
+  });
+
+  // GET /api/runs/:runId/artifacts - List artifact files for a run
+  // Walks the run's artifact directory and returns relative file paths with
+  // size + mtime. Used by the console's Artifacts tab; the existing
+  // `workflow_artifact` event stream is too sparse (bash/script nodes write
+  // straight to $ARTIFACTS_DIR without emitting an event) to drive a file
+  // browser on its own.
+  app.get('/api/runs/:runId/artifacts', async c => {
+    const runId = c.req.param('runId');
+    if (!/^[A-Za-z0-9_-]+$/.test(runId)) {
+      return apiError(c, 400, 'Invalid run id');
+    }
+
+    let run: Awaited<ReturnType<typeof workflowDb.getWorkflowRun>>;
+    try {
+      run = await workflowDb.getWorkflowRun(runId);
+    } catch (error) {
+      getLog().error({ err: error, runId }, 'artifacts.run_lookup_failed');
+      return apiError(c, 500, 'Failed to look up workflow run');
+    }
+    if (!run) return apiError(c, 404, 'Workflow run not found');
+
+    const codebase = run.codebase_id ? await codebaseDb.getCodebase(run.codebase_id) : null;
+    if (!codebase?.name) return c.json({ files: [] });
+    const nameParts = codebase.name.split('/');
+    if (nameParts.length < 2) return c.json({ files: [] });
+    const [owner, repo] = nameParts;
+
+    const artifactDir = getRunArtifactsPath(owner, repo, runId);
+
+    interface FileEntry {
+      path: string;
+      size: number;
+      modifiedAt: string;
+    }
+    const files: FileEntry[] = [];
+
+    async function walk(dir: string, rel: string): Promise<void> {
+      let entries: { name: string; isDirectory: () => boolean; isFile: () => boolean }[];
+      try {
+        entries = await readdir(dir, { withFileTypes: true });
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+        throw err;
+      }
+      for (const entry of entries) {
+        // Skip dotfiles — they're workflow-internal scratch (.pr-number, etc.)
+        if (entry.name.startsWith('.')) continue;
+        const child = join(dir, entry.name);
+        const childRel = rel === '' ? entry.name : `${rel}/${entry.name}`;
+        if (entry.isDirectory()) {
+          await walk(child, childRel);
+        } else if (entry.isFile()) {
+          try {
+            const s = await stat(child);
+            files.push({
+              path: childRel,
+              size: s.size,
+              modifiedAt: s.mtime.toISOString(),
+            });
+          } catch {
+            /* skip unreadable entries */
+          }
+        }
+      }
+    }
+
+    try {
+      await walk(artifactDir, '');
+    } catch (error) {
+      getLog().error({ err: error, runId, artifactDir }, 'artifacts.walk_failed');
+      return apiError(c, 500, 'Failed to list artifacts');
+    }
+
+    files.sort((a, b) => a.path.localeCompare(b.path));
+    return c.json({ files });
   });
 
   // GET /api/artifacts/:runId/* - Serve workflow artifact file contents

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -997,12 +997,14 @@ export function registerApiRoutes(
 
   /**
    * Persist multipart-uploaded files to the conversation's upload directory.
-   * Shared by /api/conversations/:id/message and /api/workflows/:name/run.
-   * Returns the saved file metadata + the directory chosen so the caller can
-   * pass both to dispatchToOrchestrator for cleanup inside the lock handler.
+   * Called from /api/workflows/:name/run; /api/conversations/:id/message still
+   * inlines the same validate-write-rollback logic and could migrate to this
+   * helper as a separate hygiene pass.
    *
-   * Throws a Response-shaped error via the `errorResponse` callback when
-   * validation fails; the caller then short-circuits and returns it.
+   * Returns either { ok: true, savedFiles, uploadDir } or a structured error
+   * the caller forwards via apiError; on the success path the caller passes
+   * savedFiles + uploadDir to dispatchToOrchestrator so cleanup happens
+   * inside the lock handler.
    */
   async function persistUploadedFiles(
     conversationId: string,

--- a/packages/server/src/routes/api.workflow-runs.test.ts
+++ b/packages/server/src/routes/api.workflow-runs.test.ts
@@ -126,6 +126,9 @@ mock.module('@archon/paths', () => ({
   getDefaultCommandsPath: mock(() => '/tmp/.archon-test-nonexistent/commands/defaults'),
   getDefaultWorkflowsPath: mock(() => '/tmp/.archon-test-nonexistent/workflows/defaults'),
   getArchonWorkspacesPath: () => '/tmp/.archon/workspaces',
+  getArchonHome: () => '/tmp/.archon',
+  getRunArtifactsPath: (owner: string, repo: string, runId: string): string =>
+    `/tmp/.archon/workspaces/${owner}/${repo}/artifacts/runs/${runId}`,
 }));
 
 mockAllWorkflowModules();
@@ -155,9 +158,11 @@ mock.module('@archon/core/db/conversations', () => ({
   getConversationById: mockGetConversationById,
 }));
 
+const mockGetCodebase = mock(async (_id: string) => null as null | { name: string });
+
 mock.module('@archon/core/db/codebases', () => ({
   listCodebases: mock(async () => [{ default_cwd: '/tmp/project' }]),
-  getCodebase: mock(async () => null),
+  getCodebase: mockGetCodebase,
   deleteCodebase: mock(async () => {}),
 }));
 
@@ -1620,5 +1625,87 @@ describe('approve/reject auto-resume', () => {
     // Cancellation path doesn't auto-resume — nothing to resume to.
     expect(mockHandleMessage).not.toHaveBeenCalled();
     expect(mockCancelWorkflowRun).toHaveBeenCalledWith('run-paused-1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: GET /api/runs/:runId/artifacts — the new artifact-listing endpoint
+// ---------------------------------------------------------------------------
+
+describe('GET /api/runs/:runId/artifacts', () => {
+  beforeEach(() => {
+    mockGetWorkflowRun.mockReset();
+    mockGetCodebase.mockReset();
+  });
+
+  test('returns 400 for invalid run ids (regex guard)', async () => {
+    const { app } = makeApp();
+    const response = await app.request('/api/runs/has..slash/artifacts');
+    expect(response.status).toBe(400);
+  });
+
+  test('returns 404 when the run does not exist', async () => {
+    mockGetWorkflowRun.mockImplementationOnce(async () => null);
+    const { app } = makeApp();
+    const response = await app.request('/api/runs/run-missing/artifacts');
+    expect(response.status).toBe(404);
+  });
+
+  test('returns empty files when run has no codebase_id', async () => {
+    mockGetWorkflowRun.mockImplementationOnce(async () => ({
+      ...MOCK_RUNNING_RUN,
+      id: 'run-orphan',
+      codebase_id: null,
+    }));
+    const { app } = makeApp();
+    const response = await app.request('/api/runs/run-orphan/artifacts');
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { files: unknown[] };
+    expect(body.files).toEqual([]);
+    expect(mockGetCodebase).not.toHaveBeenCalled();
+  });
+
+  test('returns empty files when codebase name lacks owner/repo shape', async () => {
+    mockGetWorkflowRun.mockImplementationOnce(async () => ({
+      ...MOCK_RUNNING_RUN,
+      id: 'run-no-slash',
+      codebase_id: 'cb-1',
+    }));
+    mockGetCodebase.mockImplementationOnce(async () => ({ name: 'plain-name' }));
+    const { app } = makeApp();
+    const response = await app.request('/api/runs/run-no-slash/artifacts');
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { files: unknown[] };
+    expect(body.files).toEqual([]);
+  });
+
+  test('returns 500 + logs when the codebase lookup throws', async () => {
+    mockGetWorkflowRun.mockImplementationOnce(async () => ({
+      ...MOCK_RUNNING_RUN,
+      id: 'run-db-err',
+      codebase_id: 'cb-broken',
+    }));
+    mockGetCodebase.mockImplementationOnce(async () => {
+      throw new Error('DB connection lost');
+    });
+    const { app } = makeApp();
+    const response = await app.request('/api/runs/run-db-err/artifacts');
+    expect(response.status).toBe(500);
+  });
+
+  // Path-escape guard: a maliciously crafted owner/repo with `..` segments
+  // would, after the join, resolve to a directory outside ARCHON_HOME. The
+  // mocked getRunArtifactsPath above naively joins inputs, so passing
+  // `'..'` as the owner produces a path that normalises outside /tmp/.archon.
+  test('returns 400 when the resolved artifact dir escapes ARCHON_HOME', async () => {
+    mockGetWorkflowRun.mockImplementationOnce(async () => ({
+      ...MOCK_RUNNING_RUN,
+      id: 'run-escape',
+      codebase_id: 'cb-escape',
+    }));
+    mockGetCodebase.mockImplementationOnce(async () => ({ name: '../../etc/passwd' }));
+    const { app } = makeApp();
+    const response = await app.request('/api/runs/run-escape/artifacts');
+    expect(response.status).toBe(400);
   });
 });

--- a/packages/server/src/routes/schemas/workflow.schemas.ts
+++ b/packages/server/src/routes/schemas/workflow.schemas.ts
@@ -208,6 +208,22 @@ export const runWorkflowBodySchema = z
   })
   .openapi('RunWorkflowBody');
 
+/** A single artifact file listed by GET /api/runs/:runId/artifacts. */
+export const artifactFileSchema = z
+  .object({
+    path: z.string(),
+    size: z.number().int().nonnegative(),
+    modifiedAt: z.string(),
+  })
+  .openapi('ArtifactFile');
+
+/** GET /api/runs/:runId/artifacts response. */
+export const listArtifactsResponseSchema = z
+  .object({
+    files: z.array(artifactFileSchema),
+  })
+  .openapi('ListArtifactsResponse');
+
 /** GET /api/dashboard/runs query params. */
 export const dashboardRunsQuerySchema = z.object({
   // z.string() — handler validates the enum value and ignores invalid values

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -11,6 +11,7 @@ import { WorkflowsPage } from '@/routes/WorkflowsPage';
 import { WorkflowExecutionPage } from '@/routes/WorkflowExecutionPage';
 import { WorkflowBuilderPage } from '@/routes/WorkflowBuilderPage';
 import { SettingsPage } from '@/routes/SettingsPage';
+import { ConsoleApp } from '@/experiments/console/ConsoleApp';
 
 interface ErrorBoundaryState {
   hasError: boolean;
@@ -67,6 +68,8 @@ export function App(): React.ReactElement {
         <ProjectProvider>
           <BrowserRouter>
             <Routes>
+              {/* Console experiment mounts OUTSIDE Layout so it does not inherit TopNav. */}
+              <Route path="/console/*" element={<ConsoleApp />} />
               <Route element={<Layout />}>
                 <Route path="/" element={<Navigate to="/chat" replace />} />
                 <Route path="/chat" element={<ChatPage />} />

--- a/packages/web/src/components/layout/TopNav.tsx
+++ b/packages/web/src/components/layout/TopNav.tsx
@@ -80,7 +80,7 @@ export function TopNav(): React.ReactElement {
               'linear-gradient(135deg, oklch(0.640 0.295 330) 0%, oklch(0.560 0.215 305) 50%, oklch(0.755 0.165 168) 100%)',
           }}
         >
-          <span>Try the new console</span>
+          <span>Try the new console UI</span>
           <span
             aria-hidden
             className="inline-block transition-transform group-hover:translate-x-0.5"

--- a/packages/web/src/components/layout/TopNav.tsx
+++ b/packages/web/src/components/layout/TopNav.tsx
@@ -71,8 +71,8 @@ export function TopNav(): React.ReactElement {
             gradient via inline style because the old UI's tokens don't
             include the brand-gradient variables. Sized to read as a
             primary CTA without dominating the nav. */}
-        <a
-          href="/console"
+        <Link
+          to="/console"
           title="Try the redesigned console UI (early access)"
           className="group inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-semibold text-white shadow-sm transition-all hover:brightness-110 active:brightness-95"
           style={{
@@ -87,7 +87,7 @@ export function TopNav(): React.ReactElement {
           >
             →
           </span>
-        </a>
+        </Link>
         <span className="text-xs text-text-secondary">
           v{import.meta.env.VITE_APP_VERSION as string}
           {updateCheck?.updateAvailable && updateCheck.releaseUrl && (

--- a/packages/web/src/components/layout/TopNav.tsx
+++ b/packages/web/src/components/layout/TopNav.tsx
@@ -66,21 +66,44 @@ export function TopNav(): React.ReactElement {
           )}
         </NavLink>
       ))}
-      <span className="ml-auto text-xs text-text-secondary">
-        v{import.meta.env.VITE_APP_VERSION as string}
-        {updateCheck?.updateAvailable && updateCheck.releaseUrl && (
-          <a
-            href={updateCheck.releaseUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="ml-1.5 inline-flex items-center gap-1 text-xs text-primary hover:underline"
-            title={`v${updateCheck.latestVersion} available`}
+      <div className="ml-auto flex items-center gap-3">
+        {/* CTA to the experimental console. Uses the brand magenta→teal
+            gradient via inline style because the old UI's tokens don't
+            include the brand-gradient variables. Sized to read as a
+            primary CTA without dominating the nav. */}
+        <a
+          href="/console"
+          title="Try the redesigned console UI (early access)"
+          className="group inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-semibold text-white shadow-sm transition-all hover:brightness-110 active:brightness-95"
+          style={{
+            background:
+              'linear-gradient(135deg, oklch(0.640 0.295 330) 0%, oklch(0.560 0.215 305) 50%, oklch(0.755 0.165 168) 100%)',
+          }}
+        >
+          <span>Try the new console</span>
+          <span
+            aria-hidden
+            className="inline-block transition-transform group-hover:translate-x-0.5"
           >
-            <span className="inline-block h-1.5 w-1.5 rounded-full bg-primary animate-pulse" />v
-            {updateCheck.latestVersion}
-          </a>
-        )}
-      </span>
+            →
+          </span>
+        </a>
+        <span className="text-xs text-text-secondary">
+          v{import.meta.env.VITE_APP_VERSION as string}
+          {updateCheck?.updateAvailable && updateCheck.releaseUrl && (
+            <a
+              href={updateCheck.releaseUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ml-1.5 inline-flex items-center gap-1 text-xs text-primary hover:underline"
+              title={`v${updateCheck.latestVersion} available`}
+            >
+              <span className="inline-block h-1.5 w-1.5 rounded-full bg-primary animate-pulse" />v
+              {updateCheck.latestVersion}
+            </a>
+          )}
+        </span>
+      </div>
     </nav>
   );
 }

--- a/packages/web/src/experiments/README.md
+++ b/packages/web/src/experiments/README.md
@@ -1,0 +1,14 @@
+# experiments/
+
+Staging area for in-repo spikes and prototypes.
+
+Rules:
+
+- Not part of the shipped product. CI does not guarantee these routes work.
+- Each experiment lives in its own folder and mounts under a dedicated route so it cannot affect production surfaces.
+- Does not import from `packages/web/src/components/`, `stores/`, `contexts/`, `routes/`, or `hooks/`. Shared types come from `@/lib/api.generated` only. This decoupling is the point — experiments have to prove they can stand on their own before they replace anything.
+- If an experiment becomes the product: extract it into its own workspace package or replace the existing surface. Don't let experiments accrete indefinitely.
+
+Current experiments:
+
+- `console/` — greenfield rebuild of the web UI around the 4-primitive mental model (Project, Run, Workflow, Worktree). Mounted at `/console`.

--- a/packages/web/src/experiments/console/ConsoleApp.tsx
+++ b/packages/web/src/experiments/console/ConsoleApp.tsx
@@ -23,15 +23,31 @@ export function ConsoleApp(): ReactElement {
   return (
     <div className="console-root flex h-screen w-screen flex-col bg-surface text-text-primary">
       <header className="flex h-12 shrink-0 items-center justify-between border-b border-border px-4">
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2.5">
+          <img
+            src="/favicon.png"
+            alt=""
+            aria-hidden="true"
+            width={22}
+            height={22}
+            className="shrink-0 select-none"
+            draggable={false}
+          />
           <span className="brand-text text-base font-semibold tracking-tight">Archon</span>
           <span className="rounded-full border border-border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-text-tertiary">
-            console · spike
+            console
           </span>
         </div>
-        <div className="flex items-center gap-3 text-text-tertiary">
-          <span className="font-mono text-[11px]">m2 populated</span>
-        </div>
+        <a
+          href="/chat"
+          title="Switch back to the classic UI"
+          className="flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-[11px] text-text-secondary transition-colors hover:border-border-bright hover:bg-surface-hover hover:text-text-primary"
+        >
+          <span aria-hidden className="font-mono text-[11px] leading-none">
+            ←
+          </span>
+          Old UI
+        </a>
       </header>
 
       <div className="flex min-h-0 flex-1">

--- a/packages/web/src/experiments/console/ConsoleApp.tsx
+++ b/packages/web/src/experiments/console/ConsoleApp.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactElement } from 'react';
-import { Routes, Route, useNavigate } from 'react-router';
+import { Routes, Route, Link, useNavigate } from 'react-router';
 import { ProjectRail } from './components/ProjectRail';
 import { AddProjectDialog } from './components/AddProjectDialog';
 import { RunsPage } from './routes/RunsPage';
@@ -38,8 +38,8 @@ export function ConsoleApp(): ReactElement {
             console
           </span>
         </div>
-        <a
-          href="/chat"
+        <Link
+          to="/chat"
           title="Switch back to the classic UI"
           className="flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-[11px] text-text-secondary transition-colors hover:border-border-bright hover:bg-surface-hover hover:text-text-primary"
         >
@@ -47,7 +47,7 @@ export function ConsoleApp(): ReactElement {
             ←
           </span>
           Old UI
-        </a>
+        </Link>
       </header>
 
       <div className="flex min-h-0 flex-1">

--- a/packages/web/src/experiments/console/ConsoleApp.tsx
+++ b/packages/web/src/experiments/console/ConsoleApp.tsx
@@ -24,7 +24,7 @@ export function ConsoleApp(): ReactElement {
     <div className="console-root flex h-screen w-screen flex-col bg-surface text-text-primary">
       <header className="flex h-12 shrink-0 items-center justify-between border-b border-border px-4">
         <div className="flex items-center gap-3">
-          <span className="text-sm font-semibold tracking-tight">Archon</span>
+          <span className="brand-text text-base font-semibold tracking-tight">Archon</span>
           <span className="rounded-full border border-border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-text-tertiary">
             console · spike
           </span>

--- a/packages/web/src/experiments/console/ConsoleApp.tsx
+++ b/packages/web/src/experiments/console/ConsoleApp.tsx
@@ -1,0 +1,65 @@
+import { useState, type ReactElement } from 'react';
+import { Routes, Route, useNavigate } from 'react-router';
+import { ProjectRail } from './components/ProjectRail';
+import { AddProjectDialog } from './components/AddProjectDialog';
+import { RunsPage } from './routes/RunsPage';
+import { RunDetailPage } from './routes/RunDetailPage';
+import { PreviewPage } from './routes/PreviewPage';
+import { invalidate } from './store/cache';
+import { K } from './store/keys';
+import './theme.css';
+
+/**
+ * Console experiment shell.
+ *
+ * Mounted at `/console/*` outside the production <Layout /> so the existing
+ * TopNav does not render over us. Internal <Routes> handle console-specific
+ * paths relative to /console.
+ */
+export function ConsoleApp(): ReactElement {
+  const [addOpen, setAddOpen] = useState(false);
+  const navigate = useNavigate();
+
+  return (
+    <div className="console-root flex h-screen w-screen flex-col bg-surface text-text-primary">
+      <header className="flex h-12 shrink-0 items-center justify-between border-b border-border px-4">
+        <div className="flex items-center gap-3">
+          <span className="text-sm font-semibold tracking-tight">Archon</span>
+          <span className="rounded-full border border-border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-text-tertiary">
+            console · spike
+          </span>
+        </div>
+        <div className="flex items-center gap-3 text-text-tertiary">
+          <span className="font-mono text-[11px]">m2 populated</span>
+        </div>
+      </header>
+
+      <div className="flex min-h-0 flex-1">
+        <ProjectRail
+          onAddProject={() => {
+            setAddOpen(true);
+          }}
+        />
+        <main className="flex min-w-0 flex-1 flex-col">
+          <Routes>
+            <Route index element={<RunsPage />} />
+            <Route path="_preview" element={<PreviewPage />} />
+            <Route path="p/:projectId" element={<RunsPage />} />
+            <Route path="p/:projectId/r/:runId" element={<RunDetailPage />} />
+          </Routes>
+        </main>
+      </div>
+
+      <AddProjectDialog
+        open={addOpen}
+        onClose={() => {
+          setAddOpen(false);
+        }}
+        onAdded={project => {
+          invalidate(K.projects);
+          navigate(`/console/p/${project.id}`);
+        }}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/experiments/console/ConsoleApp.tsx
+++ b/packages/web/src/experiments/console/ConsoleApp.tsx
@@ -1,12 +1,16 @@
-import { useState, type ReactElement } from 'react';
+import { useMemo, useState, type ReactElement } from 'react';
 import { Routes, Route, Link, useNavigate } from 'react-router';
 import { ProjectRail } from './components/ProjectRail';
 import { AddProjectDialog } from './components/AddProjectDialog';
+import { ProjectPalette } from './components/ProjectPalette';
+import { KeymapHelp } from './components/KeymapHelp';
 import { RunsPage } from './routes/RunsPage';
 import { RunDetailPage } from './routes/RunDetailPage';
 import { PreviewPage } from './routes/PreviewPage';
 import { invalidate } from './store/cache';
 import { K } from './store/keys';
+import { useKeymap, type Binding } from './lib/keymap';
+import { SHORTCUTS } from './lib/shortcuts';
 import './theme.css';
 
 /**
@@ -18,7 +22,35 @@ import './theme.css';
  */
 export function ConsoleApp(): ReactElement {
   const [addOpen, setAddOpen] = useState(false);
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const [helpOpen, setHelpOpen] = useState(false);
   const navigate = useNavigate();
+
+  // `n` (new run) is owned by DraftRunCard's own window listener — only
+  // mounted when a project is scoped — and stays there.
+  const globalBindings = useMemo<readonly Binding[]>(
+    () => [
+      {
+        keys: ['p'],
+        label: 'Pick a project',
+        run: (): void => {
+          setPaletteOpen(true);
+        },
+      },
+      {
+        keys: ['?'],
+        label: 'Show help',
+        run: (): void => {
+          setHelpOpen(v => !v);
+        },
+      },
+    ],
+    []
+  );
+  useKeymap({
+    bindings: globalBindings,
+    enabled: !addOpen && !paletteOpen && !helpOpen,
+  });
 
   return (
     <div className="console-root flex h-screen w-screen flex-col bg-surface text-text-primary">
@@ -75,6 +107,21 @@ export function ConsoleApp(): ReactElement {
           invalidate(K.projects);
           navigate(`/console/p/${project.id}`);
         }}
+      />
+
+      <ProjectPalette
+        open={paletteOpen}
+        onClose={() => {
+          setPaletteOpen(false);
+        }}
+      />
+
+      <KeymapHelp
+        open={helpOpen}
+        onClose={() => {
+          setHelpOpen(false);
+        }}
+        groups={SHORTCUTS}
       />
     </div>
   );

--- a/packages/web/src/experiments/console/README.md
+++ b/packages/web/src/experiments/console/README.md
@@ -1,0 +1,24 @@
+# Console (spike)
+
+A greenfield spike of Archon's web UI built around four primitives:
+
+- **Project · Run · Workflow · Worktree**
+
+Mounted at `/console/*`. Not part of the shipped product. Validates the mental model before any migration. If dogfooding succeeds, extract to `packages/console` and begin replacing production surfaces. If it fails, we learn cheaply.
+
+## Routes
+
+- `/console` → Runs view (scope = `all`)
+- `/console/p/:projectId` → Runs view scoped to a project
+- `/console/p/:projectId/r/:runId` → Run detail
+
+## Constraints
+
+- **Isolated.** Forbidden imports from `packages/web/src/{components,stores,contexts,routes,hooks}` and `@tanstack/react-query`, `@/lib/api` (function exports). Enforced by ESLint. Type-only imports from `@/lib/api.generated` are allowed.
+- **Skill API is the single mutation surface.** Every UI action calls one skill verb. See `skills/`.
+- **Design tokens reused.** Uses the oklch semantic tokens from `packages/web/src/index.css` (`bg-surface`, `text-text-primary`, `bg-success`, `bg-warning`, `bg-error`, etc.).
+- **Vocabulary.** Only *Project, Run, Workflow, Worktree* appear in user-facing copy. No *Dashboard, Deployment, Infrastructure, Secrets, Activity, Pipeline, Stage*.
+
+## Plan
+
+See `/Users/rasmus/.claude/plans/quiet-twirling-bentley.md` for the full E2E plan and milestones.

--- a/packages/web/src/experiments/console/README.md
+++ b/packages/web/src/experiments/console/README.md
@@ -19,6 +19,9 @@ Mounted at `/console/*`. Not part of the shipped product. Validates the mental m
 - **Design tokens reused.** Uses the oklch semantic tokens from `packages/web/src/index.css` (`bg-surface`, `text-text-primary`, `bg-success`, `bg-warning`, `bg-error`, etc.).
 - **Vocabulary.** Only *Project, Run, Workflow, Worktree* appear in user-facing copy. No *Dashboard, Deployment, Infrastructure, Secrets, Activity, Pipeline, Stage*.
 
-## Plan
+## Status
 
-See `/Users/rasmus/.claude/plans/quiet-twirling-bentley.md` for the full E2E plan and milestones.
+Active experiment under `/console`. The original milestoned plan (`M1`–`M4`)
+that scaffolded this surface has been completed; ongoing work is driven by
+user feedback during dogfooding rather than a milestone roadmap. Issues and
+ideas land via the PR template's UX Journey section.

--- a/packages/web/src/experiments/console/components/ActiveRunCard.tsx
+++ b/packages/web/src/experiments/console/components/ActiveRunCard.tsx
@@ -1,0 +1,112 @@
+import type { ReactElement } from 'react';
+import { useNavigate } from 'react-router';
+import { StatusStrip } from './StatusStrip';
+import { LiveDot } from './LiveDot';
+import { OriginBadge } from './OriginBadge';
+import { ApprovalPanel } from './ApprovalPanel';
+import { ApprovalContext } from './ApprovalContext';
+import type { Run } from '../primitives/run';
+import { shortRunId, formatElapsed, elapsedSince } from '../lib/format';
+import { statusTextClass, statusLabel } from '../lib/run-status';
+
+interface ActiveRunCardProps {
+  run: Run;
+  showProject?: boolean;
+}
+
+/**
+ * Rich card for `running` and `paused` runs. These get attention.
+ *
+ * Running:
+ *   - Pulsing blue live dot
+ *   - Status strip pulses
+ *   - Shows `node` + `tool` detail rows (mono) with a blinking cursor after
+ *     the last tool name to reinforce "still working"
+ *
+ * Paused:
+ *   - Amber pulsing dot
+ *   - Inline ApprovalPanel with context input + Approve/Reject
+ *   - User can resolve without leaving the feed
+ */
+export function ActiveRunCard({ run, showProject = false }: ActiveRunCardProps): ReactElement {
+  const navigate = useNavigate();
+  const elapsed = formatElapsed(elapsedSince(run.startedAt));
+  const canOpen = run.projectId !== null && !run.id.startsWith('demo-');
+
+  const onCardClick = (): void => {
+    if (canOpen) navigate(`/console/p/${run.projectId}/r/${run.id}`);
+  };
+
+  return (
+    <article
+      onClick={onCardClick}
+      className={`group relative overflow-hidden rounded border border-border bg-surface transition-colors hover:bg-surface-hover ${
+        canOpen ? 'cursor-pointer' : ''
+      }`}
+    >
+      <StatusStrip status={run.status} />
+      <div className="pl-4 pr-4 py-3">
+        {/* Header */}
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          {run.status === 'running' ? (
+            <LiveDot />
+          ) : (
+            <span
+              aria-hidden
+              className="h-2.5 w-2.5 shrink-0 animate-pulse rounded-full bg-warning"
+            />
+          )}
+          <span
+            className={`shrink-0 text-[10px] font-semibold uppercase tracking-[0.12em] ${statusTextClass[run.status]}`}
+          >
+            {statusLabel[run.status]}
+          </span>
+          <span className="mx-1 h-3 w-px shrink-0 bg-border" aria-hidden />
+          <span className="text-sm font-medium text-text-primary">{run.workflow}</span>
+          <span className="font-mono text-[11px] text-text-tertiary">{shortRunId(run.id)}</span>
+          {showProject && run.projectName !== null ? (
+            <span className="truncate text-[11px] text-text-secondary">· {run.projectName}</span>
+          ) : null}
+          <div className="ml-auto flex items-center gap-2">
+            <OriginBadge origin={run.origin} />
+            <span className="font-mono text-[11px] tabular-nums text-text-tertiary">{elapsed}</span>
+          </div>
+        </div>
+
+        {/* Activity detail — running only */}
+        {run.status === 'running' ? (
+          <div className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-[12px]">
+            {run.currentNode !== null && run.currentNode !== undefined && run.currentNode !== '' ? (
+              <>
+                <span className="font-mono text-text-tertiary">node</span>
+                <span className="font-mono text-text-primary">{run.currentNode}</span>
+              </>
+            ) : null}
+            {run.lastTool !== null && run.lastTool !== undefined && run.lastTool !== '' ? (
+              <>
+                <span className="font-mono text-text-tertiary">tool</span>
+                <span className="font-mono text-text-primary">
+                  {run.lastTool}
+                  <span aria-hidden className="ml-1 inline-block animate-pulse">
+                    ▏
+                  </span>
+                </span>
+              </>
+            ) : null}
+          </div>
+        ) : null}
+
+        {/* Approval surface — paused only.
+            The context block shows the actual question the agent asked (pulled
+            from the last text event), because the approval node's own
+            `message` is usually just a pointer ("answer the questions above"). */}
+        {run.status === 'paused' && run.approval !== null && run.approval !== undefined ? (
+          <>
+            <ApprovalContext run={run} />
+            <ApprovalPanel run={run} />
+          </>
+        ) : null}
+      </div>
+    </article>
+  );
+}

--- a/packages/web/src/experiments/console/components/ActiveRunCard.tsx
+++ b/packages/web/src/experiments/console/components/ActiveRunCard.tsx
@@ -6,7 +6,7 @@ import { OriginBadge } from './OriginBadge';
 import { ApprovalPanel } from './ApprovalPanel';
 import { ApprovalContext } from './ApprovalContext';
 import type { Run } from '../primitives/run';
-import { shortRunId, formatElapsed, elapsedSince } from '../lib/format';
+import { shortRunId, formatElapsed, elapsedSince, formatCost } from '../lib/format';
 import { statusTextClass, statusLabel } from '../lib/run-status';
 
 interface ActiveRunCardProps {
@@ -69,6 +69,14 @@ export function ActiveRunCard({ run, showProject = false }: ActiveRunCardProps):
           ) : null}
           <div className="ml-auto flex items-center gap-2">
             <OriginBadge origin={run.origin} />
+            {typeof run.costUsd === 'number' ? (
+              <span
+                className="font-mono text-[11px] tabular-nums text-text-secondary"
+                title="Total agent cost"
+              >
+                {formatCost(run.costUsd)}
+              </span>
+            ) : null}
             <span className="font-mono text-[11px] tabular-nums text-text-tertiary">{elapsed}</span>
           </div>
         </div>

--- a/packages/web/src/experiments/console/components/ActiveRunCard.tsx
+++ b/packages/web/src/experiments/console/components/ActiveRunCard.tsx
@@ -44,8 +44,20 @@ export function ActiveRunCard({ run, showProject = false }: ActiveRunCardProps):
   return (
     <article
       onClick={onCardClick}
+      role={canOpen ? 'button' : undefined}
+      tabIndex={canOpen ? 0 : undefined}
+      onKeyDown={
+        canOpen
+          ? (e): void => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onCardClick();
+              }
+            }
+          : undefined
+      }
       className={`group relative overflow-hidden rounded border border-border bg-surface transition-colors hover:bg-surface-hover ${
-        canOpen ? 'cursor-pointer' : ''
+        canOpen ? 'cursor-pointer focus-visible:outline-none' : ''
       }`}
     >
       <StatusStrip status={run.status} />

--- a/packages/web/src/experiments/console/components/ActiveRunCard.tsx
+++ b/packages/web/src/experiments/console/components/ActiveRunCard.tsx
@@ -13,6 +13,7 @@ import { statusTextClass, statusLabel } from '../lib/run-status';
 interface ActiveRunCardProps {
   run: Run;
   showProject?: boolean;
+  selected?: boolean;
 }
 
 /**
@@ -29,7 +30,11 @@ interface ActiveRunCardProps {
  *   - Inline ApprovalPanel with context input + Approve/Reject
  *   - User can resolve without leaving the feed
  */
-export function ActiveRunCard({ run, showProject = false }: ActiveRunCardProps): ReactElement {
+export function ActiveRunCard({
+  run,
+  showProject = false,
+  selected = false,
+}: ActiveRunCardProps): ReactElement {
   const navigate = useNavigate();
   const isDocker = useIsDocker();
   const elapsed = formatElapsed(elapsedSince(run.startedAt));
@@ -43,6 +48,7 @@ export function ActiveRunCard({ run, showProject = false }: ActiveRunCardProps):
 
   return (
     <article
+      data-run-id={run.id}
       onClick={onCardClick}
       role={canOpen ? 'button' : undefined}
       tabIndex={canOpen ? 0 : undefined}
@@ -56,9 +62,9 @@ export function ActiveRunCard({ run, showProject = false }: ActiveRunCardProps):
             }
           : undefined
       }
-      className={`group relative overflow-hidden rounded border border-border bg-surface transition-colors hover:bg-surface-hover ${
-        canOpen ? 'cursor-pointer focus-visible:outline-none' : ''
-      }`}
+      className={`group relative overflow-hidden rounded border bg-surface transition-colors hover:bg-surface-hover ${
+        selected ? 'border-accent-bright/70 ring-2 ring-accent-bright/40' : 'border-border'
+      } ${canOpen ? 'cursor-pointer focus-visible:outline-none' : ''}`}
     >
       <StatusStrip status={run.status} />
       <div className="pl-4 pr-4 py-3">

--- a/packages/web/src/experiments/console/components/ActiveRunCard.tsx
+++ b/packages/web/src/experiments/console/components/ActiveRunCard.tsx
@@ -7,6 +7,7 @@ import { ApprovalPanel } from './ApprovalPanel';
 import { ApprovalContext } from './ApprovalContext';
 import type { Run } from '../primitives/run';
 import { shortRunId, formatElapsed, elapsedSince, formatCost } from '../lib/format';
+import { useIsDocker, openInIde } from '../lib/health';
 import { statusTextClass, statusLabel } from '../lib/run-status';
 
 interface ActiveRunCardProps {
@@ -30,8 +31,11 @@ interface ActiveRunCardProps {
  */
 export function ActiveRunCard({ run, showProject = false }: ActiveRunCardProps): ReactElement {
   const navigate = useNavigate();
+  const isDocker = useIsDocker();
   const elapsed = formatElapsed(elapsedSince(run.startedAt));
   const canOpen = run.projectId !== null && !run.id.startsWith('demo-');
+  const canOpenIde =
+    !isDocker && run.workingPath !== null && run.workingPath !== '' && !run.id.startsWith('demo-');
 
   const onCardClick = (): void => {
     if (canOpen) navigate(`/console/p/${run.projectId}/r/${run.id}`);
@@ -78,6 +82,22 @@ export function ActiveRunCard({ run, showProject = false }: ActiveRunCardProps):
               </span>
             ) : null}
             <span className="font-mono text-[11px] tabular-nums text-text-tertiary">{elapsed}</span>
+            {canOpenIde && run.workingPath !== null ? (
+              <button
+                type="button"
+                onClick={e => {
+                  e.stopPropagation();
+                  if (run.workingPath !== null) openInIde(run.workingPath);
+                }}
+                title={`Open ${run.workingPath} in IDE`}
+                aria-label="Open in IDE"
+                className="rounded p-1 text-text-tertiary opacity-0 transition-all hover:bg-surface-hover hover:text-text-primary group-hover:opacity-100"
+              >
+                <span aria-hidden className="font-mono text-[12px] leading-none">
+                  ↗
+                </span>
+              </button>
+            ) : null}
           </div>
         </div>
 

--- a/packages/web/src/experiments/console/components/AddProjectDialog.tsx
+++ b/packages/web/src/experiments/console/components/AddProjectDialog.tsx
@@ -1,0 +1,130 @@
+import { useState, type ReactElement } from 'react';
+import * as skill from '../skills';
+import type { Project } from '../primitives/project';
+
+interface AddProjectDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onAdded: (project: Project) => void;
+}
+
+type Mode = 'url' | 'path';
+
+export function AddProjectDialog({
+  open,
+  onClose,
+  onAdded,
+}: AddProjectDialogProps): ReactElement | null {
+  const [mode, setMode] = useState<Mode>('url');
+  const [value, setValue] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  const onSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      const project =
+        mode === 'url'
+          ? await skill.addProjectByUrl(value.trim())
+          : await skill.addProjectByPath(value.trim());
+      onAdded(project);
+      setValue('');
+      onClose();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={onClose}
+    >
+      <form
+        onSubmit={e => {
+          void onSubmit(e);
+        }}
+        onClick={e => {
+          e.stopPropagation();
+        }}
+        className="w-full max-w-md rounded-md border border-border bg-surface-elevated p-5 text-text-primary shadow-xl"
+      >
+        <h2 className="text-sm font-semibold">Add project</h2>
+
+        <div className="mt-4 flex gap-1 rounded border border-border p-0.5">
+          {(['url', 'path'] as const).map(m => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => {
+                setMode(m);
+              }}
+              className={`flex-1 rounded px-2 py-1 text-xs uppercase tracking-wide transition-colors ${
+                mode === m
+                  ? 'bg-surface-hover text-text-primary'
+                  : 'text-text-tertiary hover:text-text-primary'
+              }`}
+              aria-pressed={mode === m}
+            >
+              {m === 'url' ? 'GitHub URL' : 'Local path'}
+            </button>
+          ))}
+        </div>
+
+        <label className="mt-4 block text-[11px] uppercase tracking-wider text-text-tertiary">
+          {mode === 'url' ? 'Repository URL' : 'Absolute path'}
+        </label>
+        <input
+          type="text"
+          value={value}
+          onChange={e => {
+            setValue(e.target.value);
+          }}
+          autoFocus
+          placeholder={
+            mode === 'url' ? 'https://github.com/owner/repo' : '/Users/you/Projects/my-repo'
+          }
+          className="mt-1 w-full rounded border border-border bg-surface px-3 py-2 font-mono text-sm text-text-primary placeholder:text-text-tertiary focus:border-border-bright focus:outline-none"
+          disabled={submitting}
+        />
+        <p className="mt-2 text-[11px] text-text-tertiary">
+          {mode === 'url'
+            ? 'Archon will clone this repo to ~/.archon/workspaces/owner/repo/source/.'
+            : 'Archon will register this path directly — no clone.'}
+        </p>
+
+        {error !== null ? (
+          <p className="mt-3 rounded border border-error/40 bg-error/10 px-2 py-1.5 font-mono text-[11px] text-error">
+            {error}
+          </p>
+        ) : null}
+
+        <div className="mt-5 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="rounded px-3 py-1.5 text-sm text-text-secondary hover:text-text-primary"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting || value.trim().length === 0}
+            className="rounded bg-accent-bright px-3 py-1.5 text-sm font-medium text-white/95 transition-opacity hover:brightness-110 disabled:opacity-50"
+          >
+            {submitting ? 'Adding…' : 'Add'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/packages/web/src/experiments/console/components/AddProjectDialog.tsx
+++ b/packages/web/src/experiments/console/components/AddProjectDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactElement } from 'react';
+import { useState, type FormEvent, type ReactElement } from 'react';
 import * as skill from '../skills';
 import type { Project } from '../primitives/project';
 
@@ -22,7 +22,7 @@ export function AddProjectDialog({
 
   if (!open) return null;
 
-  const onSubmit = async (e: React.FormEvent): Promise<void> => {
+  const onSubmit = async (e: FormEvent): Promise<void> => {
     e.preventDefault();
     setError(null);
     setSubmitting(true);

--- a/packages/web/src/experiments/console/components/ApprovalContext.tsx
+++ b/packages/web/src/experiments/console/components/ApprovalContext.tsx
@@ -1,0 +1,151 @@
+import { useMemo, useState, type ReactElement } from 'react';
+import { Link } from 'react-router';
+import { useEntity } from '../store/cache';
+import { K } from '../store/keys';
+import * as skill from '../skills';
+import type { RunEvent, TextEvent } from '../primitives/event';
+import type { Run } from '../primitives/run';
+
+interface ApprovalContextProps {
+  run: Run;
+}
+
+interface RunDetailView {
+  run: unknown;
+  events: RunEvent[];
+}
+
+const PREVIEW_CHARS = 520;
+
+function isTextEvent(e: RunEvent): e is TextEvent {
+  return e.kind === 'text';
+}
+
+/** Trim markdown to a single paragraph + line-level slice under PREVIEW_CHARS. */
+function previewOf(content: string): { text: string; truncated: boolean } {
+  const trimmed = content.trim();
+  if (trimmed.length <= PREVIEW_CHARS) return { text: trimmed, truncated: false };
+  // Prefer to cut on a paragraph boundary near the end of the preview window.
+  const slice = trimmed.slice(-PREVIEW_CHARS);
+  const nlIdx = slice.indexOf('\n\n');
+  const preview = nlIdx > 0 && nlIdx < PREVIEW_CHARS - 120 ? slice.slice(nlIdx + 2) : slice;
+  return { text: preview, truncated: true };
+}
+
+/**
+ * Shows the most recent AI text event for a paused run so the user can see
+ * the **actual question** they're being asked to answer (the approval node's
+ * own `message` is usually just "answer the questions above"). Loads lazily
+ * via getRun() — the backend bundles `events` alongside the run.
+ *
+ * If the cache already has detail (because the user opened the run recently)
+ * this is zero-cost. Otherwise: one fetch per visible paused card, which is
+ * acceptable at typical cardinality (0-2 paused runs at once).
+ *
+ * Demo runs (id prefix `demo-`) render a synthetic example so the preview UI
+ * demonstrates the pattern without hitting the backend.
+ */
+export function ApprovalContext({ run }: ApprovalContextProps): ReactElement | null {
+  const [expanded, setExpanded] = useState(false);
+  const isDemo = run.id.startsWith('demo-');
+
+  const { data } = useEntity<RunDetailView>(K.run(run.id), () =>
+    isDemo ? Promise.resolve({ run: null, events: demoEventsFor(run) }) : skill.getRun(run.id)
+  );
+
+  const lastText = useMemo<TextEvent | null>(() => {
+    const events = data?.events ?? [];
+    for (let i = events.length - 1; i >= 0; i--) {
+      const e = events[i];
+      if (e !== undefined && isTextEvent(e)) return e;
+    }
+    return null;
+  }, [data?.events]);
+
+  if (lastText === null) return null;
+
+  const { text, truncated } = previewOf(lastText.content);
+  const showFull = expanded ? lastText.content.trim() : text;
+
+  return (
+    <div className="mt-2 rounded border border-border bg-surface-inset/60 p-3">
+      <div className="mb-1 flex items-center justify-between">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.15em] text-text-tertiary">
+          What the agent is asking
+        </span>
+        {run.projectId !== null && !isDemo ? (
+          <Link
+            to={`/console/p/${run.projectId}/r/${run.id}`}
+            className="text-[11px] text-text-tertiary transition-colors hover:text-text-primary"
+            onClick={e => {
+              e.stopPropagation();
+            }}
+          >
+            Open full run →
+          </Link>
+        ) : null}
+      </div>
+      <div className="markdown-preview whitespace-pre-wrap break-words text-[13px] leading-relaxed text-text-primary">
+        {showFull}
+      </div>
+      {truncated ? (
+        <button
+          type="button"
+          onClick={e => {
+            e.stopPropagation();
+            setExpanded(v => !v);
+          }}
+          className="mt-1 font-mono text-[11px] text-text-tertiary transition-colors hover:text-text-primary"
+        >
+          {expanded ? '← Collapse' : 'Show full message →'}
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+/** Synthetic last-agent-message for demo runs so preview UIs work. */
+function demoEventsFor(run: Run): RunEvent[] {
+  const now = Date.now();
+  const text = synthFor(run);
+  return [
+    {
+      id: `${run.id}-demo-text`,
+      runId: run.id,
+      kind: 'text',
+      nodeId: run.approval?.nodeId ?? null,
+      timestamp: new Date(now - 60_000).toISOString(),
+      content: text,
+    },
+  ];
+}
+
+function synthFor(run: Run): string {
+  if (run.workflow.includes('prd') || run.workflow === 'plan') {
+    return [
+      '## Foundation Questions',
+      '',
+      "Here's what I understand so far — now please answer these so I can shape the research phase:",
+      '',
+      '1. **Who** has this problem? Be specific — not just "users" but what type of person/role?',
+      '2. **What** problem are they facing? Describe the observable pain, not the assumed need.',
+      "3. **Why** can't they solve it today? What alternatives exist and why do they fail?",
+      '4. **Why now?** What changed that makes this worth building?',
+      '5. **How** will you know if you solved it? What would success look like?',
+    ].join('\n');
+  }
+  if (run.workflow === 'review') {
+    return [
+      "I've walked the diff end-to-end against the plan. Overall the implementation tracks.",
+      '',
+      'Before I open the PR I need your sign-off on two things:',
+      '',
+      '- The `listWorktrees` selector joins on `working_path` (brittle until the backend exposes `bound_run_id`) — OK to ship as-is and revisit, or block on the backend change?',
+      '- Tests cover the happy path but not the stale-env cleanup branch — should I add coverage before PR, or file a follow-up issue?',
+    ].join('\n');
+  }
+  return (
+    run.approval?.message ??
+    'The agent is waiting for your input. Open the full run to see the conversation.'
+  );
+}

--- a/packages/web/src/experiments/console/components/ApprovalPanel.tsx
+++ b/packages/web/src/experiments/console/components/ApprovalPanel.tsx
@@ -53,7 +53,7 @@ export function ApprovalPanel({ run }: ApprovalPanelProps): ReactElement {
       } else {
         await skill.approveRun(run.id, trimmed.length > 0 ? trimmed : undefined);
       }
-      invalidate('runs:');
+      invalidate('runs');
       invalidate(`run:${run.id}`);
       setComment('');
     } catch (e: unknown) {
@@ -77,7 +77,7 @@ export function ApprovalPanel({ run }: ApprovalPanelProps): ReactElement {
       } else {
         await skill.rejectRun(run.id, trimmed);
       }
-      invalidate('runs:');
+      invalidate('runs');
       invalidate(`run:${run.id}`);
       setReason('');
       setMode('idle');

--- a/packages/web/src/experiments/console/components/ApprovalPanel.tsx
+++ b/packages/web/src/experiments/console/components/ApprovalPanel.tsx
@@ -1,0 +1,125 @@
+import {
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent,
+  type ReactElement,
+} from 'react';
+import * as skill from '../skills';
+import { invalidate } from '../store/cache';
+import type { Run } from '../primitives/run';
+
+interface ApprovalPanelProps {
+  run: Run;
+}
+
+/**
+ * Inline approval surface for a paused run. Text field is dual-purpose:
+ *   - On **Approve**: treated as optional comment (can be empty).
+ *   - On **Reject**: required as reason (button disabled until non-empty).
+ *
+ * Archon's approval node can capture the text as `$<node-id>.output` so
+ * downstream workflow steps receive it — that's why the input is a general
+ * "context" field, not just "reason on reject."
+ *
+ * Demo runs (id starts with `demo-`) short-circuit to a no-op so the preview
+ * UI doesn't hit the backend with bogus ids.
+ */
+export function ApprovalPanel({ run }: ApprovalPanelProps): ReactElement {
+  const [text, setText] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const isDemo = run.id.startsWith('demo-');
+
+  const stopPropagation = (e: MouseEvent | ReactKeyboardEvent): void => {
+    e.stopPropagation();
+  };
+
+  const act = async (intent: 'approve' | 'reject'): Promise<void> => {
+    const trimmed = text.trim();
+    if (intent === 'reject' && trimmed.length === 0) {
+      setError('Reject requires a reason.');
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      if (isDemo) {
+        // Preview only — fake latency so the user sees the loading state.
+        await new Promise<void>(r => setTimeout(r, 300));
+      } else if (intent === 'approve') {
+        await skill.approveRun(run.id, trimmed.length > 0 ? trimmed : undefined);
+      } else {
+        await skill.rejectRun(run.id, trimmed);
+      }
+      // Force a refetch of all run lists and this run's detail.
+      invalidate('runs:');
+      invalidate(`run:${run.id}`);
+      setText('');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Action failed.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleKey = (e: ReactKeyboardEvent<HTMLInputElement>): void => {
+    stopPropagation(e);
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      void act('approve');
+    }
+  };
+
+  const trimmedEmpty = text.trim().length === 0;
+
+  return (
+    <div
+      className="mt-2 rounded border border-warning/30 bg-warning/[0.06] p-3"
+      onClick={stopPropagation}
+      onKeyDown={stopPropagation}
+    >
+      {run.approval?.message.length ? (
+        <p className="mb-2 text-[12px] uppercase tracking-[0.12em] text-warning">
+          {run.approval.message}
+        </p>
+      ) : null}
+      <div className="flex items-stretch gap-2">
+        <input
+          type="text"
+          value={text}
+          onChange={e => {
+            setText(e.target.value);
+            if (error !== null) setError(null);
+          }}
+          onKeyDown={handleKey}
+          placeholder="your answer · or reason to reject"
+          disabled={busy}
+          autoFocus
+          className="min-w-0 flex-1 rounded border border-border bg-surface-inset px-3 py-1.5 text-[13px] text-text-primary placeholder:text-text-tertiary focus:border-border-bright focus:outline-none disabled:opacity-50"
+        />
+        <button
+          type="button"
+          onClick={() => void act('approve')}
+          disabled={busy}
+          className="flex shrink-0 items-center gap-1 rounded border border-success/40 bg-success/15 px-3 text-[12px] font-medium text-success transition-colors hover:bg-success/25 disabled:opacity-50"
+          title="Continue · Enter (sends your answer / approves)"
+        >
+          Continue
+          <span aria-hidden className="font-mono text-[10px] opacity-70">
+            ↵
+          </span>
+        </button>
+        <button
+          type="button"
+          onClick={() => void act('reject')}
+          disabled={busy || trimmedEmpty}
+          className="shrink-0 rounded border border-error/30 px-3 text-[12px] text-error transition-colors hover:bg-error/10 disabled:opacity-40"
+          title={trimmedEmpty ? 'Add a reason to reject' : 'Reject and stop the run'}
+        >
+          Reject
+        </button>
+      </div>
+      {error !== null ? <p className="mt-1 font-mono text-[11px] text-error">{error}</p> : null}
+    </div>
+  );
+}

--- a/packages/web/src/experiments/console/components/ApprovalPanel.tsx
+++ b/packages/web/src/experiments/console/components/ApprovalPanel.tsx
@@ -140,6 +140,7 @@ export function ApprovalPanel({ run }: ApprovalPanelProps): ReactElement {
           />
           <button
             type="button"
+            data-keymap-approve
             onClick={() => void approve()}
             disabled={busy}
             className="flex shrink-0 items-center gap-1 rounded border border-success/40 bg-success/15 px-3 text-[12px] font-medium text-success transition-colors hover:bg-success/25 disabled:opacity-50"
@@ -152,6 +153,7 @@ export function ApprovalPanel({ run }: ApprovalPanelProps): ReactElement {
           </button>
           <button
             type="button"
+            data-keymap-reject
             onClick={() => {
               setMode('rejecting');
               setError(null);

--- a/packages/web/src/experiments/console/components/ApprovalPanel.tsx
+++ b/packages/web/src/experiments/console/components/ApprovalPanel.tsx
@@ -12,20 +12,29 @@ interface ApprovalPanelProps {
   run: Run;
 }
 
+type Mode = 'idle' | 'rejecting';
+
 /**
- * Inline approval surface for a paused run. Text field is dual-purpose:
- *   - On **Approve**: treated as optional comment (can be empty).
- *   - On **Reject**: required as reason (button disabled until non-empty).
+ * Inline approval surface for a paused run.
  *
- * Archon's approval node can capture the text as `$<node-id>.output` so
- * downstream workflow steps receive it — that's why the input is a general
- * "context" field, not just "reason on reject."
+ * Two distinct flows kept visually separate so accidental rejects don't
+ * happen mid-conversation:
  *
- * Demo runs (id starts with `demo-`) short-circuit to a no-op so the preview
- * UI doesn't hit the backend with bogus ids.
+ *   - **Continue / Approve**: one click. The single-line input above is an
+ *     optional comment — Archon captures it as `$<node-id>.output` so the
+ *     workflow can branch on the answer.
+ *   - **Reject**: two-step. The first click reveals an expanded textarea
+ *     for the reason; the confirm button is only enabled once the textarea
+ *     has content. Mirrors the old UI's ConfirmRunActionDialog flow without
+ *     a modal.
+ *
+ * Demo runs (id starts with `demo-`) short-circuit to a no-op so the
+ * preview UI doesn't hit the backend with bogus ids.
  */
 export function ApprovalPanel({ run }: ApprovalPanelProps): ReactElement {
-  const [text, setText] = useState('');
+  const [comment, setComment] = useState('');
+  const [reason, setReason] = useState('');
+  const [mode, setMode] = useState<Mode>('idle');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const isDemo = run.id.startsWith('demo-');
@@ -34,9 +43,29 @@ export function ApprovalPanel({ run }: ApprovalPanelProps): ReactElement {
     e.stopPropagation();
   };
 
-  const act = async (intent: 'approve' | 'reject'): Promise<void> => {
-    const trimmed = text.trim();
-    if (intent === 'reject' && trimmed.length === 0) {
+  const approve = async (): Promise<void> => {
+    const trimmed = comment.trim();
+    setBusy(true);
+    setError(null);
+    try {
+      if (isDemo) {
+        await new Promise<void>(r => setTimeout(r, 300));
+      } else {
+        await skill.approveRun(run.id, trimmed.length > 0 ? trimmed : undefined);
+      }
+      invalidate('runs:');
+      invalidate(`run:${run.id}`);
+      setComment('');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Approve failed.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const confirmReject = async (): Promise<void> => {
+    const trimmed = reason.trim();
+    if (trimmed.length === 0) {
       setError('Reject requires a reason.');
       return;
     }
@@ -44,33 +73,43 @@ export function ApprovalPanel({ run }: ApprovalPanelProps): ReactElement {
     setError(null);
     try {
       if (isDemo) {
-        // Preview only — fake latency so the user sees the loading state.
         await new Promise<void>(r => setTimeout(r, 300));
-      } else if (intent === 'approve') {
-        await skill.approveRun(run.id, trimmed.length > 0 ? trimmed : undefined);
       } else {
         await skill.rejectRun(run.id, trimmed);
       }
-      // Force a refetch of all run lists and this run's detail.
       invalidate('runs:');
       invalidate(`run:${run.id}`);
-      setText('');
+      setReason('');
+      setMode('idle');
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Action failed.');
+      setError(e instanceof Error ? e.message : 'Reject failed.');
     } finally {
       setBusy(false);
     }
   };
 
-  const handleKey = (e: ReactKeyboardEvent<HTMLInputElement>): void => {
+  const onApproveKey = (e: ReactKeyboardEvent<HTMLInputElement>): void => {
     stopPropagation(e);
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      void act('approve');
+      void approve();
     }
   };
 
-  const trimmedEmpty = text.trim().length === 0;
+  const onRejectKey = (e: ReactKeyboardEvent<HTMLTextAreaElement>): void => {
+    stopPropagation(e);
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      setMode('idle');
+      setReason('');
+      setError(null);
+      return;
+    }
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      void confirmReject();
+    }
+  };
 
   return (
     <div
@@ -83,42 +122,98 @@ export function ApprovalPanel({ run }: ApprovalPanelProps): ReactElement {
           {run.approval.message}
         </p>
       ) : null}
-      <div className="flex items-stretch gap-2">
-        <input
-          type="text"
-          value={text}
-          onChange={e => {
-            setText(e.target.value);
-            if (error !== null) setError(null);
-          }}
-          onKeyDown={handleKey}
-          placeholder="your answer · or reason to reject"
-          disabled={busy}
-          autoFocus
-          className="min-w-0 flex-1 rounded border border-border bg-surface-inset px-3 py-1.5 text-[13px] text-text-primary placeholder:text-text-tertiary focus:border-border-bright focus:outline-none disabled:opacity-50"
-        />
-        <button
-          type="button"
-          onClick={() => void act('approve')}
-          disabled={busy}
-          className="flex shrink-0 items-center gap-1 rounded border border-success/40 bg-success/15 px-3 text-[12px] font-medium text-success transition-colors hover:bg-success/25 disabled:opacity-50"
-          title="Continue · Enter (sends your answer / approves)"
-        >
-          Continue
-          <span aria-hidden className="font-mono text-[10px] opacity-70">
-            ↵
-          </span>
-        </button>
-        <button
-          type="button"
-          onClick={() => void act('reject')}
-          disabled={busy || trimmedEmpty}
-          className="shrink-0 rounded border border-error/30 px-3 text-[12px] text-error transition-colors hover:bg-error/10 disabled:opacity-40"
-          title={trimmedEmpty ? 'Add a reason to reject' : 'Reject and stop the run'}
-        >
-          Reject
-        </button>
-      </div>
+
+      {mode === 'idle' ? (
+        <div className="flex items-stretch gap-2">
+          <input
+            type="text"
+            value={comment}
+            onChange={e => {
+              setComment(e.target.value);
+              if (error !== null) setError(null);
+            }}
+            onKeyDown={onApproveKey}
+            placeholder="optional comment to send with approval"
+            disabled={busy}
+            autoFocus
+            className="min-w-0 flex-1 rounded border border-border bg-surface-inset px-3 py-1.5 text-[13px] text-text-primary placeholder:text-text-tertiary focus:border-border-bright focus:outline-none disabled:opacity-50"
+          />
+          <button
+            type="button"
+            onClick={() => void approve()}
+            disabled={busy}
+            className="flex shrink-0 items-center gap-1 rounded border border-success/40 bg-success/15 px-3 text-[12px] font-medium text-success transition-colors hover:bg-success/25 disabled:opacity-50"
+            title="Continue · Enter"
+          >
+            Continue
+            <span aria-hidden className="font-mono text-[10px] opacity-70">
+              ↵
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setMode('rejecting');
+              setError(null);
+            }}
+            disabled={busy}
+            className="shrink-0 rounded border border-error/30 px-3 text-[12px] text-error transition-colors hover:bg-error/10 disabled:opacity-40"
+            title="Reject this run"
+          >
+            Reject
+          </button>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          <label className="font-mono text-[10px] uppercase tracking-[0.14em] text-error">
+            Reason for rejecting · required
+          </label>
+          <textarea
+            value={reason}
+            onChange={e => {
+              setReason(e.target.value);
+              if (error !== null) setError(null);
+            }}
+            onKeyDown={onRejectKey}
+            placeholder="why is the agent going the wrong way? this is sent back as feedback."
+            rows={3}
+            disabled={busy}
+            autoFocus
+            className="w-full resize-none rounded border border-error/30 bg-surface-inset px-3 py-2 text-[13px] text-text-primary placeholder:text-text-tertiary focus:border-error/60 focus:outline-none disabled:opacity-50"
+          />
+          <div className="flex items-center justify-between gap-2">
+            <span className="font-mono text-[10px] text-text-tertiary">
+              ⌘↵ confirm · esc cancel
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setMode('idle');
+                  setReason('');
+                  setError(null);
+                }}
+                disabled={busy}
+                className="rounded px-3 py-1 text-[12px] text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary disabled:opacity-40"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => void confirmReject()}
+                disabled={busy || reason.trim().length === 0}
+                className="flex items-center gap-1 rounded border border-error/40 bg-error/15 px-3 py-1 text-[12px] font-medium text-error transition-colors hover:bg-error/25 disabled:opacity-40"
+              >
+                {busy ? 'Rejecting…' : 'Reject run'}
+                <span aria-hidden className="font-mono text-[10px] opacity-70">
+                  ⌘↵
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       {error !== null ? <p className="mt-1 font-mono text-[11px] text-error">{error}</p> : null}
     </div>
   );

--- a/packages/web/src/experiments/console/components/ArtifactItem.tsx
+++ b/packages/web/src/experiments/console/components/ArtifactItem.tsx
@@ -1,0 +1,43 @@
+import type { ReactElement } from 'react';
+import { StreamCard } from './StreamCard';
+import type { ArtifactEvent } from '../primitives/event';
+
+interface ArtifactItemProps {
+  event: ArtifactEvent;
+}
+
+export function ArtifactItem({ event }: ArtifactItemProps): ReactElement {
+  const href = event.url ?? event.path ?? null;
+  const label = event.label.length > 0 ? event.label : 'unnamed';
+  const typeLabel = event.artifactType.length > 0 ? event.artifactType : 'artifact';
+
+  return (
+    <StreamCard
+      timestamp={event.timestamp}
+      kind="artifact"
+      label={typeLabel}
+      headerRight={
+        href !== null ? (
+          <a
+            href={href}
+            target="_blank"
+            rel="noreferrer"
+            className="rounded border border-border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
+            onClick={e => {
+              e.stopPropagation();
+            }}
+          >
+            Open
+          </a>
+        ) : null
+      }
+    >
+      <div className="flex flex-col gap-0.5">
+        <span className="font-mono text-[13px] text-text-primary">{label}</span>
+        {event.path !== null ? (
+          <span className="truncate font-mono text-[11px] text-text-tertiary">{event.path}</span>
+        ) : null}
+      </div>
+    </StreamCard>
+  );
+}

--- a/packages/web/src/experiments/console/components/ArtifactPanel.tsx
+++ b/packages/web/src/experiments/console/components/ArtifactPanel.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useState, type ReactElement } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
+import rehypeHighlight from 'rehype-highlight';
+import { useEntity } from '../store/cache';
+import { K } from '../store/keys';
+import * as skill from '../skills';
+import type { ArtifactFile } from '../skills/runs';
+
+interface ArtifactPanelProps {
+  runId: string;
+}
+
+/**
+ * Full-width artifact browser: sidebar of files on the left, rendered file
+ * on the right. Sourced from `/api/runs/:runId/artifacts` (walks the on-disk
+ * artifact dir) rather than `workflow_artifact` events — bash/script nodes
+ * typically write straight to $ARTIFACTS_DIR without emitting an event.
+ *
+ * Markdown gets the same react-markdown + GFM + highlight stack the old UI
+ * used; everything else renders as monospace plain text.
+ */
+export function ArtifactPanel({ runId }: ArtifactPanelProps): ReactElement {
+  const {
+    data: files,
+    error: listError,
+    loading,
+  } = useEntity<ArtifactFile[]>(K.artifacts(runId), () => skill.listRunArtifacts(runId));
+
+  const [selected, setSelected] = useState<string | null>(null);
+
+  // Auto-select the first file once the list arrives (or when the run changes).
+  useEffect(() => {
+    if (files !== undefined && files.length > 0 && selected === null) {
+      setSelected(files[0].path);
+    }
+  }, [files, selected]);
+
+  if (loading) {
+    return <div className="p-6 text-[12px] text-text-tertiary">Loading artifacts…</div>;
+  }
+  if (listError !== undefined) {
+    return (
+      <div className="p-6 font-mono text-[12px] text-error">
+        Could not list artifacts: {listError.message}
+      </div>
+    );
+  }
+  if (files === undefined || files.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center p-6">
+        <div className="text-center text-[13px] text-text-tertiary">
+          <p>No artifacts written to disk for this run.</p>
+          <p className="mt-2 font-mono text-[11px]">
+            Workflows that emit reports or plans write them to{' '}
+            <code className="rounded bg-surface-inset px-1">$ARTIFACTS_DIR</code>.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 w-full">
+      <ArtifactSidebar files={files} selected={selected} onSelect={setSelected} />
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        {selected !== null ? (
+          <ArtifactViewer runId={runId} path={selected} />
+        ) : (
+          <div className="flex h-full items-center justify-center text-[12px] text-text-tertiary">
+            Pick a file from the left.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface SidebarProps {
+  files: ArtifactFile[];
+  selected: string | null;
+  onSelect: (path: string) => void;
+}
+
+function ArtifactSidebar({ files, selected, onSelect }: SidebarProps): ReactElement {
+  return (
+    <nav
+      aria-label="Artifacts"
+      className="flex h-full w-[260px] shrink-0 flex-col overflow-y-auto border-r border-border bg-surface-inset"
+    >
+      <header className="sticky top-0 z-10 border-b border-border bg-surface-inset px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-text-tertiary">
+        Files · {files.length.toString()}
+      </header>
+      <ul className="flex flex-col gap-px p-2">
+        {files.map(f => {
+          const isSelected = selected === f.path;
+          const basename = f.path.split('/').pop() ?? f.path;
+          const dir = f.path.includes('/') ? f.path.slice(0, f.path.lastIndexOf('/')) : null;
+          return (
+            <li key={f.path}>
+              <button
+                type="button"
+                onClick={() => {
+                  onSelect(f.path);
+                }}
+                aria-pressed={isSelected}
+                className={`group flex w-full flex-col gap-0.5 rounded-md px-2.5 py-1.5 text-left transition-colors ${
+                  isSelected ? 'bg-surface-elevated' : 'hover:bg-surface-hover'
+                }`}
+              >
+                <span
+                  className={`truncate font-mono text-[12px] ${
+                    isSelected ? 'text-text-primary' : 'text-text-secondary'
+                  }`}
+                >
+                  {basename}
+                </span>
+                <span className="flex items-center justify-between gap-2 font-mono text-[10px] text-text-tertiary">
+                  <span className="truncate">{dir ?? '·'}</span>
+                  <span className="shrink-0 tabular-nums">{formatSize(f.size)}</span>
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes.toString()} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+interface ViewerProps {
+  runId: string;
+  path: string;
+}
+
+const REMARK_PLUGINS = [remarkGfm, remarkBreaks];
+const REHYPE_PLUGINS = [rehypeHighlight];
+
+function ArtifactViewer({ runId, path }: ViewerProps): ReactElement {
+  const [content, setContent] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    setContent(null);
+    void skill
+      .fetchArtifact(runId, path)
+      .then(text => {
+        setContent(text);
+      })
+      .catch((e: unknown) => {
+        setError(e instanceof Error ? e.message : 'Failed to load artifact');
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [runId, path]);
+
+  const basename = path.split('/').pop() ?? path;
+  const isMarkdown = basename.endsWith('.md') || basename.endsWith('.mdx');
+
+  return (
+    <>
+      <header className="flex shrink-0 items-center justify-between border-b border-border bg-surface px-6 py-2">
+        <span className="truncate font-mono text-[12px] text-text-primary">{path}</span>
+        <a
+          href={`/api/artifacts/${encodeURIComponent(runId)}/${path
+            .split('/')
+            .map(encodeURIComponent)
+            .join('/')}`}
+          target="_blank"
+          rel="noreferrer"
+          className="shrink-0 font-mono text-[10px] text-text-tertiary transition-colors hover:text-text-primary"
+        >
+          open raw ↗
+        </a>
+      </header>
+      <div className="min-h-0 flex-1 overflow-y-auto px-6 py-4">
+        {loading ? (
+          <p className="font-mono text-[12px] text-text-tertiary">Loading…</p>
+        ) : error !== null ? (
+          <p className="font-mono text-[12px] text-error">{error}</p>
+        ) : content === null ? null : isMarkdown ? (
+          <div className="chat-markdown max-w-[820px] text-[13px] leading-relaxed text-text-primary">
+            <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS}>
+              {content}
+            </ReactMarkdown>
+          </div>
+        ) : (
+          <pre className="max-w-[1100px] whitespace-pre-wrap break-words font-mono text-[12px] leading-relaxed text-text-primary">
+            {content}
+          </pre>
+        )}
+      </div>
+    </>
+  );
+}

--- a/packages/web/src/experiments/console/components/DraftRunCard.tsx
+++ b/packages/web/src/experiments/console/components/DraftRunCard.tsx
@@ -5,9 +5,8 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactElement,
 } from 'react';
-import { useNavigate } from 'react-router';
 import { WorkflowPicker } from './WorkflowPicker';
-import { useEntity } from '../store/cache';
+import { useEntity, invalidate } from '../store/cache';
 import { K } from '../store/keys';
 import * as skill from '../skills';
 import type { Workflow } from '../primitives/workflow';
@@ -53,7 +52,6 @@ function writeLastWorkflow(name: string): void {
  * expanded state and focuses the textarea. Enter starts; Esc collapses.
  */
 export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): ReactElement {
-  const navigate = useNavigate();
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const [mode, setMode] = useState<Mode>('collapsed');
   const [workflowName, setWorkflowName] = useState<string>(() => readLastWorkflow());
@@ -119,14 +117,17 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
     setSubmitting(true);
     try {
       writeLastWorkflow(workflowName);
-      const started = await skill.startRun({
+      await skill.startRun({
         projectId,
         workflow: workflowName,
         message: context,
       });
+      // Dispatch is fire-and-forget — the orchestrator creates the run row
+      // asynchronously. Nudge the runs feed so the new card appears as soon
+      // as the row exists, instead of waiting for the next 3s poll tick.
       setContext('');
       setMode('collapsed');
-      navigate(`/console/p/${projectId}/r/${started.runId}`);
+      invalidate('runs');
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Failed to start run.');
     } finally {

--- a/packages/web/src/experiments/console/components/DraftRunCard.tsx
+++ b/packages/web/src/experiments/console/components/DraftRunCard.tsx
@@ -69,6 +69,10 @@ function writeLastWorkflow(name: string): void {
 export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): ReactElement {
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  // One-shot flag set by the global `n` keybind. When true, expanding the
+  // card auto-opens the workflow picker (so the user can filter + pick
+  // before touching the context box).
+  const summonedRef = useRef(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const [mode, setMode] = useState<Mode>('collapsed');
   const [workflowName, setWorkflowName] = useState<string>(() => readLastWorkflow());
@@ -139,7 +143,8 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
     if (pick !== undefined) setWorkflowName(pick.name);
   }, [sortedWorkflows, workflowName]);
 
-  // Global `N` keybind: expand + focus.
+  // Global `N` keybind: expand + open the workflow picker so the user can
+  // pick a workflow without first reaching for the mouse.
   useEffect(() => {
     const handler = (e: KeyboardEvent): void => {
       const target = e.target as HTMLElement | null;
@@ -149,6 +154,7 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
       if (typingElsewhere) return;
       if (e.key === 'n' && !e.metaKey && !e.ctrlKey && !e.altKey) {
         e.preventDefault();
+        summonedRef.current = true;
         setMode('expanded');
       }
     };
@@ -158,14 +164,23 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
     };
   }, []);
 
-  // Focus the textarea whenever we enter expanded mode.
+  // After entering expanded mode, either open the workflow picker (when
+  // summoned via `n`) or focus the textarea (every other path: click, rerun
+  // query params). The summon-open is fire-and-forget — closing the picker
+  // hands focus to the textarea via the WorkflowPicker.onClose callback.
   useEffect(() => {
-    if (mode === 'expanded') {
-      // Defer by one frame so the textarea exists + layout is flushed.
-      requestAnimationFrame(() => {
-        inputRef.current?.focus();
-      });
-    }
+    if (mode !== 'expanded') return;
+    requestAnimationFrame(() => {
+      if (summonedRef.current) {
+        summonedRef.current = false;
+        const trigger = document.querySelector<HTMLButtonElement>('[data-keymap-workflow-trigger]');
+        if (trigger !== null && !trigger.disabled) {
+          trigger.click();
+          return;
+        }
+      }
+      inputRef.current?.focus();
+    });
   }, [mode]);
 
   const submit = async (): Promise<void> => {
@@ -323,6 +338,11 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
             value={workflowName}
             onChange={setWorkflowName}
             disabled={submitting}
+            onClose={() => {
+              requestAnimationFrame(() => {
+                inputRef.current?.focus();
+              });
+            }}
           />
           <button
             type="button"

--- a/packages/web/src/experiments/console/components/DraftRunCard.tsx
+++ b/packages/web/src/experiments/console/components/DraftRunCard.tsx
@@ -7,6 +7,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactElement,
 } from 'react';
+import { useSearchParams } from 'react-router';
 import { WorkflowPicker } from './WorkflowPicker';
 import { useEntity, invalidate } from '../store/cache';
 import { K } from '../store/keys';
@@ -68,6 +69,7 @@ function writeLastWorkflow(name: string): void {
 export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): ReactElement {
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
   const [mode, setMode] = useState<Mode>('collapsed');
   const [workflowName, setWorkflowName] = useState<string>(() => readLastWorkflow());
   const [context, setContext] = useState('');
@@ -75,6 +77,25 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
   const [dragOver, setDragOver] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Pre-fill from `?rerun=1&workflow=…&message=…` query params (set by the
+  // ↻ rerun button on RecentRunRow). Reacts to searchParams so the card
+  // expands whether you arrive by navigation (same project, params change
+  // only) or by a fresh mount. Strips the params on entry so reload
+  // doesn't re-trigger and so the URL stays clean.
+  useEffect(() => {
+    if (searchParams.get('rerun') !== '1') return;
+    const wf = searchParams.get('workflow');
+    const msg = searchParams.get('message');
+    if (wf !== null && wf.length > 0) setWorkflowName(wf);
+    if (msg !== null) setContext(msg);
+    setMode('expanded');
+    const next = new URLSearchParams(searchParams);
+    next.delete('rerun');
+    next.delete('workflow');
+    next.delete('message');
+    setSearchParams(next, { replace: true });
+  }, [searchParams, setSearchParams]);
 
   const addFiles = (incoming: File[]): void => {
     if (incoming.length === 0) return;

--- a/packages/web/src/experiments/console/components/DraftRunCard.tsx
+++ b/packages/web/src/experiments/console/components/DraftRunCard.tsx
@@ -204,6 +204,9 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
   };
 
   const onTextareaKey = (e: ReactKeyboardEvent<HTMLTextAreaElement>): void => {
+    // Don't submit while an IME composition is in progress (Japanese,
+    // Chinese, Korean, etc. — the first Enter accepts a candidate).
+    if (e.nativeEvent.isComposing || e.keyCode === 229) return;
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       void submit();

--- a/packages/web/src/experiments/console/components/DraftRunCard.tsx
+++ b/packages/web/src/experiments/console/components/DraftRunCard.tsx
@@ -1,0 +1,264 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactElement,
+} from 'react';
+import { useNavigate } from 'react-router';
+import { WorkflowPicker } from './WorkflowPicker';
+import { useEntity } from '../store/cache';
+import { K } from '../store/keys';
+import * as skill from '../skills';
+import type { Workflow } from '../primitives/workflow';
+
+interface DraftRunCardProps {
+  projectId: string;
+  projectCwd: string;
+}
+
+type Mode = 'collapsed' | 'expanded';
+
+const LAST_WORKFLOW_KEY = 'archon.console.lastWorkflow';
+
+function readLastWorkflow(): string {
+  try {
+    return localStorage.getItem(LAST_WORKFLOW_KEY) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function writeLastWorkflow(name: string): void {
+  try {
+    localStorage.setItem(LAST_WORKFLOW_KEY, name);
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * DraftRunCard — the "start a run" primitive, rendered as a card that lives
+ * at the top of the Active list.
+ *
+ * Two modes:
+ *   collapsed   thin `+ Start a new run` row
+ *   expanded    full card with workflow picker + context textarea + Start
+ *
+ * Mental model: same shape as a paused-approval card. One is "the agent is
+ * waiting for you," the other is "you are about to kick off the agent." Both
+ * surface the same input primitive in the same place.
+ *
+ * Keybind: `N` anywhere (except while typing in another input) opens the
+ * expanded state and focuses the textarea. Enter starts; Esc collapses.
+ */
+export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): ReactElement {
+  const navigate = useNavigate();
+  const inputRef = useRef<HTMLTextAreaElement | null>(null);
+  const [mode, setMode] = useState<Mode>('collapsed');
+  const [workflowName, setWorkflowName] = useState<string>(() => readLastWorkflow());
+  const [context, setContext] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const { data: workflows } = useEntity<Workflow[]>(K.workflows(projectCwd), () =>
+    skill.listWorkflows(projectCwd)
+  );
+
+  // Sort project-scoped first, then global, then bundled; alpha within each.
+  const sortedWorkflows = (workflows ?? []).slice().sort((a, b) => {
+    const rank = { project: 0, global: 1, bundled: 2 } as const;
+    return rank[a.source] - rank[b.source] || a.name.localeCompare(b.name);
+  });
+
+  // Default workflow: last-used if still valid, else first available.
+  useEffect(() => {
+    if (sortedWorkflows.length === 0) return;
+    if (workflowName.length > 0 && sortedWorkflows.some(w => w.name === workflowName)) {
+      return;
+    }
+    const pick = sortedWorkflows[0];
+    if (pick !== undefined) setWorkflowName(pick.name);
+  }, [sortedWorkflows, workflowName]);
+
+  // Global `N` keybind: expand + focus.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent): void => {
+      const target = e.target as HTMLElement | null;
+      const typingElsewhere =
+        target !== null &&
+        (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable);
+      if (typingElsewhere) return;
+      if (e.key === 'n' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        e.preventDefault();
+        setMode('expanded');
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return (): void => {
+      window.removeEventListener('keydown', handler);
+    };
+  }, []);
+
+  // Focus the textarea whenever we enter expanded mode.
+  useEffect(() => {
+    if (mode === 'expanded') {
+      // Defer by one frame so the textarea exists + layout is flushed.
+      requestAnimationFrame(() => {
+        inputRef.current?.focus();
+      });
+    }
+  }, [mode]);
+
+  const submit = async (): Promise<void> => {
+    if (workflowName.length === 0) {
+      setError('Pick a workflow first.');
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    try {
+      writeLastWorkflow(workflowName);
+      const started = await skill.startRun({
+        projectId,
+        workflow: workflowName,
+        message: context,
+      });
+      setContext('');
+      setMode('collapsed');
+      navigate(`/console/p/${projectId}/r/${started.runId}`);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to start run.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const collapse = (): void => {
+    setMode('collapsed');
+    setError(null);
+  };
+
+  const onTextareaKey = (e: ReactKeyboardEvent<HTMLTextAreaElement>): void => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      void submit();
+      return;
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      collapse();
+    }
+  };
+
+  if (mode === 'collapsed') {
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          setMode('expanded');
+        }}
+        className="group flex items-center gap-3 rounded border border-dashed border-border px-3 py-2 text-left transition-colors hover:border-accent-bright/60 hover:bg-surface-hover"
+        title="Start a new run — press N"
+      >
+        <span
+          aria-hidden
+          className="flex h-5 w-5 items-center justify-center rounded-full border border-border text-text-tertiary transition-colors group-hover:border-accent-bright/60 group-hover:text-accent-bright"
+        >
+          +
+        </span>
+        <span className="text-[12px] text-text-tertiary transition-colors group-hover:text-text-primary">
+          Start a new run
+        </span>
+        <span
+          aria-hidden
+          className="ml-auto rounded border border-border px-1.5 py-0.5 font-mono text-[10px] tabular-nums text-text-tertiary"
+        >
+          N
+        </span>
+      </button>
+    );
+  }
+
+  return (
+    <article
+      className="relative rounded border bg-surface"
+      style={{
+        // 4-px accent strip as a left border so we can keep `overflow: visible`
+        // on the card — the workflow picker's dropdown escapes these bounds.
+        borderColor: 'color-mix(in oklch, var(--accent-bright), transparent 60%)',
+        borderLeftWidth: 4,
+        borderLeftColor: 'var(--accent-bright)',
+      }}
+    >
+      <div className="px-4 py-3">
+        {/* Header: status dot + DRAFT label + workflow picker + close */}
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <span aria-hidden className="h-2.5 w-2.5 shrink-0 rounded-full bg-accent-bright" />
+          <span className="shrink-0 text-[10px] font-semibold uppercase tracking-[0.14em] text-accent-bright">
+            Draft
+          </span>
+          <span className="mx-1 h-3 w-px shrink-0 bg-border" aria-hidden />
+          <WorkflowPicker
+            workflows={sortedWorkflows}
+            value={workflowName}
+            onChange={setWorkflowName}
+            disabled={submitting}
+          />
+          <button
+            type="button"
+            onClick={collapse}
+            disabled={submitting}
+            className="ml-auto rounded p-1 text-text-tertiary transition-colors hover:bg-surface-hover hover:text-text-primary disabled:opacity-50"
+            aria-label="Cancel draft"
+            title="Cancel (Esc)"
+          >
+            <span aria-hidden className="text-[12px]">
+              ✕
+            </span>
+          </button>
+        </div>
+
+        {/* Body: context textarea */}
+        <div className="mt-3">
+          <textarea
+            ref={inputRef}
+            value={context}
+            onChange={e => {
+              setContext(e.target.value);
+              if (error !== null) setError(null);
+            }}
+            onKeyDown={onTextareaKey}
+            placeholder={
+              workflowName.length > 0
+                ? `what should \`${workflowName}\` work on?`
+                : 'Pick a workflow to start…'
+            }
+            rows={2}
+            disabled={submitting}
+            className="min-h-[52px] w-full resize-none rounded border border-border bg-surface-inset px-3 py-2 text-[13px] text-text-primary placeholder:text-text-tertiary focus:border-border-bright focus:outline-none disabled:opacity-50"
+          />
+
+          <div className="mt-2 flex items-center justify-between gap-2">
+            <span className="font-mono text-[10px] text-text-tertiary">
+              ↵ start · ⇧↵ newline · esc cancel
+            </span>
+            <button
+              type="button"
+              onClick={() => void submit()}
+              disabled={submitting || workflowName.length === 0}
+              className="flex items-center gap-1 rounded bg-accent-bright px-3 py-1.5 text-[12px] font-medium text-white/95 transition-all hover:brightness-110 active:brightness-95 disabled:opacity-50"
+            >
+              {submitting ? 'Starting…' : 'Start run'}
+              <span aria-hidden className="font-mono text-[10px] opacity-70">
+                ↵
+              </span>
+            </button>
+          </div>
+
+          {error !== null ? <p className="mt-1 font-mono text-[11px] text-error">{error}</p> : null}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/packages/web/src/experiments/console/components/DraftRunCard.tsx
+++ b/packages/web/src/experiments/console/components/DraftRunCard.tsx
@@ -185,14 +185,18 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
     <article
       className="relative rounded border bg-surface"
       style={{
-        // 4-px accent strip as a left border so we can keep `overflow: visible`
-        // on the card — the workflow picker's dropdown escapes these bounds.
-        borderColor: 'color-mix(in oklch, var(--accent-bright), transparent 60%)',
-        borderLeftWidth: 4,
-        borderLeftColor: 'var(--accent-bright)',
+        // Soft-magenta hairline border on all four sides; the brand-gradient
+        // strip is painted as an absolute child so the card can keep
+        // `overflow: visible` (the workflow picker's dropdown escapes these
+        // bounds).
+        borderColor: 'color-mix(in oklch, var(--brand-magenta), transparent 60%)',
       }}
     >
-      <div className="px-4 py-3">
+      <span
+        aria-hidden
+        className="brand-bar pointer-events-none absolute left-0 top-0 bottom-0 w-1 rounded-l"
+      />
+      <div className="pl-5 pr-4 py-3">
         {/* Header: status dot + DRAFT label + workflow picker + close */}
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
           <span aria-hidden className="h-2.5 w-2.5 shrink-0 rounded-full bg-accent-bright" />
@@ -248,7 +252,7 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
               type="button"
               onClick={() => void submit()}
               disabled={submitting || workflowName.length === 0}
-              className="flex items-center gap-1 rounded bg-accent-bright px-3 py-1.5 text-[12px] font-medium text-white/95 transition-all hover:brightness-110 active:brightness-95 disabled:opacity-50"
+              className="brand-bar flex items-center gap-1 rounded px-3 py-1.5 text-[12px] font-semibold text-white shadow-sm transition-all hover:brightness-110 active:brightness-95 disabled:opacity-50"
             >
               {submitting ? 'Starting…' : 'Start run'}
               <span aria-hidden className="font-mono text-[10px] opacity-70">

--- a/packages/web/src/experiments/console/components/DraftRunCard.tsx
+++ b/packages/web/src/experiments/console/components/DraftRunCard.tsx
@@ -2,6 +2,8 @@ import {
   useEffect,
   useRef,
   useState,
+  type ClipboardEvent as ReactClipboardEvent,
+  type DragEvent as ReactDragEvent,
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactElement,
 } from 'react';
@@ -19,6 +21,18 @@ interface DraftRunCardProps {
 type Mode = 'collapsed' | 'expanded';
 
 const LAST_WORKFLOW_KEY = 'archon.console.lastWorkflow';
+
+const MAX_FILES = 5;
+const MAX_FILE_BYTES = 10 * 1024 * 1024;
+/** Client-side accept hint; the server is the security boundary. */
+const ACCEPT_HINT =
+  'text/*,image/*,application/pdf,.md,.json,.yaml,.yml,.toml,.ts,.tsx,.js,.jsx,.py,.go,.rs,.sh,.sql,.html,.css';
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n.toString()} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
 
 function readLastWorkflow(): string {
   try {
@@ -53,11 +67,36 @@ function writeLastWorkflow(name: string): void {
  */
 export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): ReactElement {
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [mode, setMode] = useState<Mode>('collapsed');
   const [workflowName, setWorkflowName] = useState<string>(() => readLastWorkflow());
   const [context, setContext] = useState('');
+  const [files, setFiles] = useState<File[]>([]);
+  const [dragOver, setDragOver] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const addFiles = (incoming: File[]): void => {
+    if (incoming.length === 0) return;
+    const oversize = incoming.find(f => f.size > MAX_FILE_BYTES);
+    if (oversize !== undefined) {
+      setError(`"${oversize.name}" is larger than 10 MB.`);
+      return;
+    }
+    setFiles(prev => {
+      const merged = [...prev, ...incoming];
+      if (merged.length > MAX_FILES) {
+        setError(`Max ${MAX_FILES.toString()} files per run.`);
+        return merged.slice(0, MAX_FILES);
+      }
+      setError(null);
+      return merged;
+    });
+  };
+
+  const removeFile = (idx: number): void => {
+    setFiles(prev => prev.filter((_, i) => i !== idx));
+  };
 
   const { data: workflows } = useEntity<Workflow[]>(K.workflows(projectCwd), () =>
     skill.listWorkflows(projectCwd)
@@ -121,11 +160,13 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
         projectId,
         workflow: workflowName,
         message: context,
+        files: files.length > 0 ? files : undefined,
       });
       // Dispatch is fire-and-forget — the orchestrator creates the run row
       // asynchronously. Nudge the runs feed so the new card appears as soon
       // as the row exists, instead of waiting for the next 3s poll tick.
       setContext('');
+      setFiles([]);
       setMode('collapsed');
       invalidate('runs');
     } catch (err: unknown) {
@@ -137,6 +178,7 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
 
   const collapse = (): void => {
     setMode('collapsed');
+    setFiles([]);
     setError(null);
   };
 
@@ -149,6 +191,41 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
     if (e.key === 'Escape') {
       e.preventDefault();
       collapse();
+    }
+  };
+
+  const onDragOver = (e: ReactDragEvent<HTMLDivElement>): void => {
+    if (!e.dataTransfer.types.includes('Files')) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+    if (!dragOver) setDragOver(true);
+  };
+
+  const onDragLeave = (e: ReactDragEvent<HTMLDivElement>): void => {
+    // Only un-flag when leaving the bounding rect, not on each child crossover.
+    if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+    setDragOver(false);
+  };
+
+  const onDrop = (e: ReactDragEvent<HTMLDivElement>): void => {
+    e.preventDefault();
+    setDragOver(false);
+    const dropped = Array.from(e.dataTransfer.files);
+    if (dropped.length > 0) addFiles(dropped);
+  };
+
+  const onPaste = (e: ReactClipboardEvent<HTMLTextAreaElement>): void => {
+    const items = Array.from(e.clipboardData.items);
+    const pastedFiles: File[] = [];
+    for (const item of items) {
+      if (item.kind === 'file') {
+        const f = item.getAsFile();
+        if (f !== null) pastedFiles.push(f);
+      }
+    }
+    if (pastedFiles.length > 0) {
+      e.preventDefault();
+      addFiles(pastedFiles);
     }
   };
 
@@ -191,11 +268,24 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
         // bounds).
         borderColor: 'color-mix(in oklch, var(--brand-magenta), transparent 60%)',
       }}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
     >
       <span
         aria-hidden
         className="brand-bar pointer-events-none absolute left-0 top-0 bottom-0 w-1 rounded-l"
       />
+      {dragOver ? (
+        <div
+          aria-hidden
+          className="brand-bar-soft pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded"
+        >
+          <span className="rounded border border-[color:var(--brand-magenta)] bg-surface px-3 py-1.5 font-mono text-[11px] text-[color:var(--brand-magenta)]">
+            drop files to attach
+          </span>
+        </div>
+      ) : null}
       <div className="pl-5 pr-4 py-3">
         {/* Header: status dot + DRAFT label + workflow picker + close */}
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
@@ -234,6 +324,7 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
               if (error !== null) setError(null);
             }}
             onKeyDown={onTextareaKey}
+            onPaste={onPaste}
             placeholder={
               workflowName.length > 0
                 ? `what should \`${workflowName}\` work on?`
@@ -244,10 +335,70 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
             className="min-h-[52px] w-full resize-none rounded border border-border bg-surface-inset px-3 py-2 text-[13px] text-text-primary placeholder:text-text-tertiary focus:border-border-bright focus:outline-none disabled:opacity-50"
           />
 
+          {files.length > 0 ? (
+            <ul className="mt-2 flex flex-wrap gap-1.5">
+              {files.map((f, idx) => (
+                <li
+                  key={`${f.name}:${idx.toString()}`}
+                  className="flex items-center gap-1.5 rounded border border-border bg-surface-inset px-2 py-1 font-mono text-[11px] text-text-secondary"
+                >
+                  <span aria-hidden>📎</span>
+                  <span className="max-w-[160px] truncate">{f.name}</span>
+                  <span className="text-text-tertiary">{formatBytes(f.size)}</span>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      removeFile(idx);
+                    }}
+                    disabled={submitting}
+                    className="ml-1 rounded p-0.5 text-text-tertiary transition-colors hover:bg-error/10 hover:text-error disabled:opacity-40"
+                    aria-label={`Remove ${f.name}`}
+                  >
+                    ✕
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            accept={ACCEPT_HINT}
+            className="hidden"
+            onChange={e => {
+              const picked = e.target.files === null ? [] : Array.from(e.target.files);
+              addFiles(picked);
+              // Allow re-picking the same file: reset so onChange fires next time.
+              e.target.value = '';
+            }}
+          />
+
           <div className="mt-2 flex items-center justify-between gap-2">
-            <span className="font-mono text-[10px] text-text-tertiary">
-              ↵ start · ⇧↵ newline · esc cancel
-            </span>
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={() => {
+                  fileInputRef.current?.click();
+                }}
+                disabled={submitting || files.length >= MAX_FILES}
+                className="flex items-center gap-1 rounded p-1 text-text-tertiary transition-colors hover:bg-surface-hover hover:text-text-primary disabled:opacity-40"
+                title={
+                  files.length >= MAX_FILES
+                    ? `Max ${MAX_FILES.toString()} files attached`
+                    : 'Attach files · drop or paste also work'
+                }
+                aria-label="Attach files"
+              >
+                <span aria-hidden className="text-[12px]">
+                  📎
+                </span>
+              </button>
+              <span className="font-mono text-[10px] text-text-tertiary">
+                ↵ start · ⇧↵ newline · esc cancel
+              </span>
+            </div>
             <button
               type="button"
               onClick={() => void submit()}

--- a/packages/web/src/experiments/console/components/EmptyState.tsx
+++ b/packages/web/src/experiments/console/components/EmptyState.tsx
@@ -1,0 +1,18 @@
+import type { ReactElement, ReactNode } from 'react';
+
+interface EmptyStateProps {
+  title: string;
+  hint?: string;
+  action?: ReactNode;
+}
+
+/** Minimal empty state — one sentence + optional single button. No illustrations. */
+export function EmptyState({ title, hint, action }: EmptyStateProps): ReactElement {
+  return (
+    <div className="flex min-h-[40vh] flex-col items-center justify-center gap-3 text-center">
+      <p className="text-sm text-text-secondary">{title}</p>
+      {hint !== undefined ? <p className="text-xs text-text-tertiary">{hint}</p> : null}
+      {action !== undefined ? <div className="mt-2">{action}</div> : null}
+    </div>
+  );
+}

--- a/packages/web/src/experiments/console/components/EnvVarsDialog.tsx
+++ b/packages/web/src/experiments/console/components/EnvVarsDialog.tsx
@@ -1,0 +1,254 @@
+import {
+  useEffect,
+  useState,
+  type FormEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactElement,
+} from 'react';
+import * as skill from '../skills';
+import { useEntity, invalidate } from '../store/cache';
+import { K } from '../store/keys';
+
+interface EnvVarsDialogProps {
+  projectId: string;
+  projectName: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Per-project env vars. The server never returns values — only keys — so
+ * the UI lists key names and uses "Rotate" (a fresh set) as the way to
+ * update an existing entry. There's no "view value" affordance because
+ * there's no endpoint that exposes one. This is a deliberate constraint:
+ * once typed, secrets only leave the box via the agent that runs the
+ * project's workflows.
+ */
+export function EnvVarsDialog({
+  projectId,
+  projectName,
+  open,
+  onClose,
+}: EnvVarsDialogProps): ReactElement | null {
+  if (!open) return null;
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Environment variables for ${projectName}`}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={onClose}
+    >
+      <div
+        onClick={e => {
+          e.stopPropagation();
+        }}
+        className="w-full max-w-md rounded-md border border-border bg-surface-elevated p-5 text-text-primary shadow-xl"
+      >
+        <EnvVarsBody projectId={projectId} projectName={projectName} onClose={onClose} />
+      </div>
+    </div>
+  );
+}
+
+interface BodyProps {
+  projectId: string;
+  projectName: string;
+  onClose: () => void;
+}
+
+function EnvVarsBody({ projectId, projectName, onClose }: BodyProps): ReactElement {
+  // Drop the cache on every open so the dialog reflects external edits
+  // (CLI, other web sessions) instead of whatever was in memory last time.
+  useEffect(() => {
+    invalidate(K.envVars(projectId));
+  }, [projectId]);
+
+  const {
+    data: keys,
+    error,
+    loading,
+  } = useEntity<string[]>(K.envVars(projectId), () => skill.listEnvVarKeys(projectId));
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [adding, setAdding] = useState(false);
+  const [newKey, setNewKey] = useState('');
+  const [newValue, setNewValue] = useState('');
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+
+  const refresh = (): void => {
+    invalidate(K.envVars(projectId));
+  };
+
+  const upsert = async (e: FormEvent): Promise<void> => {
+    e.preventDefault();
+    const k = newKey.trim();
+    if (k.length === 0) {
+      setActionError('Key is required.');
+      return;
+    }
+    if (newValue.length === 0) {
+      setActionError('Value is required.');
+      return;
+    }
+    setActionError(null);
+    setBusyKey(k);
+    try {
+      await skill.setEnvVar(projectId, k, newValue);
+      setNewKey('');
+      setNewValue('');
+      setAdding(false);
+      refresh();
+    } catch (err: unknown) {
+      setActionError(err instanceof Error ? err.message : 'Failed to save env var.');
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  const remove = async (key: string): Promise<void> => {
+    if (!window.confirm(`Remove ${key}?`)) return;
+    setActionError(null);
+    setBusyKey(key);
+    try {
+      await skill.deleteEnvVar(projectId, key);
+      refresh();
+    } catch (err: unknown) {
+      setActionError(err instanceof Error ? err.message : 'Failed to remove env var.');
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  const onAddKeyKey = (e: ReactKeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      setAdding(false);
+      setNewKey('');
+      setNewValue('');
+      setActionError(null);
+    }
+  };
+
+  return (
+    <>
+      <header className="mb-3 flex items-baseline justify-between gap-3">
+        <h2 className="text-sm font-semibold">Environment variables</h2>
+        <span className="truncate font-mono text-[11px] text-text-tertiary">{projectName}</span>
+      </header>
+      <p className="mb-4 text-[12px] text-text-secondary">
+        Injected into project-scoped execution (Claude, Codex, bash, scripts). Values are stored
+        server-side; the UI only ever sees the names.
+      </p>
+
+      {loading ? (
+        <p className="font-mono text-[11px] text-text-tertiary">Loading…</p>
+      ) : error !== undefined ? (
+        <p className="font-mono text-[11px] text-error">{error.message}</p>
+      ) : (
+        <ul className="mb-3 max-h-[40vh] divide-y divide-border overflow-y-auto rounded border border-border">
+          {(keys ?? []).length === 0 ? (
+            <li className="px-3 py-2 text-[12px] text-text-tertiary">No variables yet.</li>
+          ) : (
+            (keys ?? []).map(key => (
+              <li
+                key={key}
+                className="flex items-center justify-between gap-2 px-3 py-2 text-[12px]"
+              >
+                <span className="truncate font-mono text-text-primary">{key}</span>
+                <button
+                  type="button"
+                  onClick={() => void remove(key)}
+                  disabled={busyKey === key}
+                  className="rounded px-2 py-0.5 font-mono text-[10px] text-text-tertiary transition-colors hover:bg-error/10 hover:text-error disabled:opacity-40"
+                >
+                  {busyKey === key ? '…' : 'remove'}
+                </button>
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+
+      {adding ? (
+        <form
+          onSubmit={e => {
+            void upsert(e);
+          }}
+          className="mb-3 space-y-2 rounded border border-border bg-surface-inset p-3"
+        >
+          <input
+            value={newKey}
+            onChange={e => {
+              setNewKey(e.target.value.toUpperCase());
+              if (actionError !== null) setActionError(null);
+            }}
+            onKeyDown={onAddKeyKey}
+            placeholder="KEY_NAME"
+            autoFocus
+            className="w-full rounded border border-border bg-surface px-2 py-1 font-mono text-[12px] text-text-primary placeholder:text-text-tertiary focus:border-border-bright focus:outline-none"
+          />
+          <input
+            value={newValue}
+            type="password"
+            onChange={e => {
+              setNewValue(e.target.value);
+              if (actionError !== null) setActionError(null);
+            }}
+            onKeyDown={onAddKeyKey}
+            placeholder="value (will be encrypted at rest)"
+            className="w-full rounded border border-border bg-surface px-2 py-1 font-mono text-[12px] text-text-primary placeholder:text-text-tertiary focus:border-border-bright focus:outline-none"
+          />
+          <div className="flex items-center justify-between gap-2">
+            <span className="font-mono text-[10px] text-text-tertiary">↵ save · esc cancel</span>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setAdding(false);
+                  setNewKey('');
+                  setNewValue('');
+                  setActionError(null);
+                }}
+                className="rounded px-2 py-0.5 text-[11px] text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={busyKey !== null || newKey.trim().length === 0 || newValue.length === 0}
+                className="brand-bar rounded px-3 py-0.5 text-[11px] font-medium text-white transition-all hover:brightness-110 disabled:opacity-40"
+              >
+                {busyKey === newKey.trim() ? 'Saving…' : 'Save'}
+              </button>
+            </div>
+          </div>
+        </form>
+      ) : (
+        <button
+          type="button"
+          onClick={() => {
+            setAdding(true);
+          }}
+          className="mb-3 flex w-full items-center justify-center gap-2 rounded border border-dashed border-border px-2.5 py-1.5 text-[12px] text-text-tertiary transition-colors hover:border-[color:var(--brand-magenta)]/40 hover:bg-surface-hover hover:text-text-primary"
+        >
+          <span aria-hidden>+</span>
+          <span>Add variable</span>
+        </button>
+      )}
+
+      {actionError !== null ? (
+        <p className="mb-2 font-mono text-[11px] text-error">{actionError}</p>
+      ) : null}
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded px-3 py-1 text-[12px] text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
+        >
+          Close
+        </button>
+      </div>
+    </>
+  );
+}

--- a/packages/web/src/experiments/console/components/FilterChips.tsx
+++ b/packages/web/src/experiments/console/components/FilterChips.tsx
@@ -38,7 +38,7 @@ export function FilterChips({ value, onChange, counts }: FilterChipsProps): Reac
             onClick={() => {
               onChange(filter);
             }}
-            className={`rounded px-2 py-1 text-[11px] font-medium uppercase tracking-wider transition-colors ${
+            className={`relative rounded px-2 py-1 text-[11px] font-medium uppercase tracking-wider transition-colors ${
               active
                 ? 'bg-surface-elevated text-text-primary'
                 : 'text-text-tertiary hover:text-text-primary'
@@ -47,6 +47,12 @@ export function FilterChips({ value, onChange, counts }: FilterChipsProps): Reac
           >
             {label}
             <span className="ml-1.5 font-mono tabular-nums text-text-tertiary">{n}</span>
+            {active ? (
+              <span
+                aria-hidden
+                className="brand-bar pointer-events-none absolute inset-x-1 -bottom-0.5 h-0.5 rounded-full"
+              />
+            ) : null}
           </button>
         );
       })}

--- a/packages/web/src/experiments/console/components/FilterChips.tsx
+++ b/packages/web/src/experiments/console/components/FilterChips.tsx
@@ -1,0 +1,55 @@
+import type { ReactElement } from 'react';
+import type { RunStatus } from '../lib/run-status';
+import type { RunCounts } from '../skills/runs';
+
+export type Filter = 'all' | RunStatus;
+
+interface FilterChipsProps {
+  value: Filter;
+  onChange: (next: Filter) => void;
+  counts: RunCounts;
+}
+
+// Order reflects the typical user journey: what's happening now (running),
+// what needs me (paused), what's broken (failed), then the retrospective
+// buckets (completed, all) at the end.
+const ORDER: readonly {
+  filter: Filter;
+  label: string;
+  countKey: keyof RunCounts;
+}[] = [
+  { filter: 'running', label: 'Running', countKey: 'running' },
+  { filter: 'paused', label: 'Paused', countKey: 'paused' },
+  { filter: 'failed', label: 'Failed', countKey: 'failed' },
+  { filter: 'completed', label: 'Completed', countKey: 'completed' },
+  { filter: 'all', label: 'All', countKey: 'all' },
+];
+
+export function FilterChips({ value, onChange, counts }: FilterChipsProps): ReactElement {
+  return (
+    <div className="flex items-center gap-1">
+      {ORDER.map(({ filter, label, countKey }) => {
+        const active = value === filter;
+        const n = counts[countKey];
+        return (
+          <button
+            key={filter}
+            type="button"
+            onClick={() => {
+              onChange(filter);
+            }}
+            className={`rounded px-2 py-1 text-[11px] font-medium uppercase tracking-wider transition-colors ${
+              active
+                ? 'bg-surface-elevated text-text-primary'
+                : 'text-text-tertiary hover:text-text-primary'
+            }`}
+            aria-pressed={active}
+          >
+            {label}
+            <span className="ml-1.5 font-mono tabular-nums text-text-tertiary">{n}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/web/src/experiments/console/components/KeymapHelp.tsx
+++ b/packages/web/src/experiments/console/components/KeymapHelp.tsx
@@ -1,0 +1,83 @@
+import { useEffect, type ReactElement } from 'react';
+import { formatChord, type KeyEntry } from '../lib/keymap';
+
+interface KeymapHelpProps {
+  open: boolean;
+  onClose: () => void;
+  groups: readonly KeymapGroup[];
+}
+
+export type HelpEntry = KeyEntry;
+
+export interface KeymapGroup {
+  title: string;
+  entries: readonly HelpEntry[];
+}
+
+/**
+ * `?` overlay — reads the same binding tables the dispatcher consumes so
+ * the documented chords can never drift from the wired ones.
+ */
+export function KeymapHelp({ open, onClose, groups }: KeymapHelpProps): ReactElement | null {
+  // Local Escape/? handler — the global keymap is suppressed while this
+  // overlay is open (so shortcuts don't compose with dialogs), which means
+  // we have to dismiss it ourselves.
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape' || e.key === '?') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return (): void => {
+      window.removeEventListener('keydown', handler);
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={onClose}
+    >
+      <div
+        onClick={e => {
+          e.stopPropagation();
+        }}
+        className="w-full max-w-lg overflow-hidden rounded-md border border-border bg-surface-elevated shadow-2xl"
+      >
+        <header className="flex items-baseline justify-between border-b border-border px-4 py-2">
+          <h2 className="text-sm font-semibold text-text-primary">Keyboard shortcuts</h2>
+          <span className="font-mono text-[10px] text-text-tertiary">esc · ?</span>
+        </header>
+        <div className="max-h-[70vh] overflow-y-auto">
+          {groups.map(group => (
+            <section key={group.title} className="border-b border-border last:border-b-0">
+              <h3 className="px-4 pt-3 pb-1 font-mono text-[10px] uppercase tracking-[0.14em] text-text-tertiary">
+                {group.title}
+              </h3>
+              <ul className="pb-2">
+                {group.entries.map(e => (
+                  <li
+                    key={`${group.title}:${e.keys.join('+')}:${e.label}`}
+                    className="flex items-baseline justify-between gap-4 px-4 py-1.5"
+                  >
+                    <span className="text-[13px] text-text-secondary">{e.label}</span>
+                    <kbd className="shrink-0 rounded border border-border bg-surface px-1.5 py-0.5 font-mono text-[10.5px] text-text-primary">
+                      {formatChord(e.keys)}
+                    </kbd>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/experiments/console/components/LiveDot.tsx
+++ b/packages/web/src/experiments/console/components/LiveDot.tsx
@@ -1,0 +1,22 @@
+import type { ReactElement } from 'react';
+
+/**
+ * Broadcast-style "live" indicator for running runs. Solid inner dot with a
+ * pulsing ring that radiates outward (Tailwind's `animate-ping`). Read as
+ * "something is happening right now" without being noisy.
+ */
+export function LiveDot({ size = 10 }: { size?: number }): ReactElement {
+  return (
+    <span
+      aria-hidden="true"
+      className="relative inline-flex shrink-0 items-center justify-center"
+      style={{ width: size, height: size }}
+    >
+      <span className="absolute inset-0 animate-ping rounded-full bg-[color:var(--running)] opacity-60" />
+      <span
+        className="relative rounded-full bg-[color:var(--running)]"
+        style={{ width: size * 0.65, height: size * 0.65 }}
+      />
+    </span>
+  );
+}

--- a/packages/web/src/experiments/console/components/MessageItem.tsx
+++ b/packages/web/src/experiments/console/components/MessageItem.tsx
@@ -1,0 +1,121 @@
+import type { ReactElement } from 'react';
+import ReactMarkdown, { type Components } from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
+import rehypeHighlight from 'rehype-highlight';
+import { StreamCard } from './StreamCard';
+import type { Message } from '../primitives/message';
+
+interface MessageItemProps {
+  message: Message;
+}
+
+const MD_COMPONENTS: Components = {
+  a: ({ href, children }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className="underline decoration-text-tertiary/50 underline-offset-2 transition-colors hover:text-accent-bright hover:decoration-accent-bright"
+    >
+      {children}
+    </a>
+  ),
+  code: ({ className, children }) => {
+    const isBlock = className?.startsWith('language-');
+    if (isBlock) {
+      return <code className={className}>{children}</code>;
+    }
+    return (
+      <code className="rounded bg-surface-inset px-1 py-[1px] font-mono text-[12px] text-text-primary">
+        {children}
+      </code>
+    );
+  },
+  h1: ({ children }) => (
+    <h1 className="mt-2 mb-1.5 text-[14px] font-semibold text-text-primary">{children}</h1>
+  ),
+  h2: ({ children }) => (
+    <h2 className="mt-2 mb-1 text-[13px] font-semibold text-text-primary">{children}</h2>
+  ),
+  h3: ({ children }) => (
+    <h3 className="mt-1.5 mb-0.5 text-[12px] font-semibold uppercase tracking-wider text-text-secondary">
+      {children}
+    </h3>
+  ),
+  p: ({ children }) => <p className="my-1 leading-relaxed">{children}</p>,
+  ul: ({ children }) => (
+    <ul className="my-1 ml-5 list-disc space-y-0.5 marker:text-text-tertiary">{children}</ul>
+  ),
+  ol: ({ children }) => (
+    <ol className="my-1 ml-5 list-decimal space-y-0.5 marker:text-text-tertiary">{children}</ol>
+  ),
+  li: ({ children }) => <li className="leading-relaxed">{children}</li>,
+  pre: ({ children }) => (
+    <pre className="my-2 overflow-x-auto rounded border border-border bg-surface-inset p-2 text-[12px] leading-relaxed">
+      {children}
+    </pre>
+  ),
+  blockquote: ({ children }) => (
+    <blockquote className="my-1 border-l-2 border-border pl-2 text-text-secondary">
+      {children}
+    </blockquote>
+  ),
+};
+
+const SHORT_USER_THRESHOLD = 140;
+
+/**
+ * Single message rendered as a small card. Tool calls are broken out into
+ * separate cards (see RunStream / ToolCallItem), so this one only renders
+ * prose + error.
+ *
+ * Short user messages render as compact single-line chips so the initial
+ * `Fix issue #1179`-style prompts don't eat the same real estate as a 2000-char
+ * agent response.
+ */
+export function MessageItem({ message }: MessageItemProps): ReactElement {
+  const kind = message.role;
+  const content = message.content.trim();
+
+  // Compact chip form for short user prompts.
+  if (
+    kind === 'user' &&
+    message.error === null &&
+    content.length > 0 &&
+    content.length <= SHORT_USER_THRESHOLD &&
+    !content.includes('\n')
+  ) {
+    return (
+      <StreamCard
+        timestamp={message.timestamp}
+        kind="user"
+        compact
+        headerRight={
+          <span className="truncate font-mono text-[12px] text-text-primary">{content}</span>
+        }
+      />
+    );
+  }
+
+  return (
+    <StreamCard timestamp={message.timestamp} kind={kind}>
+      {content.length > 0 ? (
+        <div className="max-w-none text-[13px] leading-relaxed text-text-primary">
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm, remarkBreaks]}
+            rehypePlugins={[rehypeHighlight]}
+            components={MD_COMPONENTS}
+          >
+            {content}
+          </ReactMarkdown>
+        </div>
+      ) : null}
+      {message.error !== null ? (
+        <div className="mt-2 rounded border border-error/40 bg-error/10 px-2 py-1.5 font-mono text-[12px] text-error">
+          {message.error.message}
+        </div>
+      ) : null}
+    </StreamCard>
+  );
+}

--- a/packages/web/src/experiments/console/components/NodeDivider.tsx
+++ b/packages/web/src/experiments/console/components/NodeDivider.tsx
@@ -61,8 +61,15 @@ export function NodeDivider({
     skipReason !== undefined &&
     skipReason.length > 0;
 
+  // Only the `started` transition carries the scroll-anchor id so the graph
+  // click jumps to the node's entry point, not its later `completed` /
+  // `failed` markers — and so duplicate ids never appear in the DOM when a
+  // node emits multiple transitions.
   return (
-    <div id={`node-transition-${nodeName}`} className="flex flex-col gap-1 py-3">
+    <div
+      id={transition === 'started' ? `node-transition-${nodeName}` : undefined}
+      className="flex flex-col gap-1 py-3"
+    >
       <div className="flex items-center gap-3">
         <time
           dateTime={timestamp}

--- a/packages/web/src/experiments/console/components/NodeDivider.tsx
+++ b/packages/web/src/experiments/console/components/NodeDivider.tsx
@@ -7,6 +7,12 @@ interface NodeDividerProps {
   transition: 'started' | 'completed' | 'failed' | 'skipped';
   durationMs: number | null;
   timestamp: string;
+  /** Only set for `skipped` — `when_condition` / `trigger_rule`. */
+  skipReason?: string | null;
+  /** Only set for `skipped` — the evaluated gating expression. */
+  skipExpr?: string | null;
+  /** When true, surface skip reason + expression inline. */
+  showDetail?: boolean;
 }
 
 const TRANSITION_LABEL: Record<NodeDividerProps['transition'], string> = {
@@ -36,6 +42,9 @@ export function NodeDivider({
   transition,
   durationMs,
   timestamp,
+  skipReason,
+  skipExpr,
+  showDetail = false,
 }: NodeDividerProps): ReactElement {
   const { runStartedAt } = useStreamContext();
   const displayed = formatRelativeToBaseline(timestamp, runStartedAt);
@@ -45,25 +54,46 @@ export function NodeDivider({
       ? ` · ${formatElapsed(Math.floor(durationMs / 1000))}`
       : '';
 
+  const hasSkipDetail =
+    transition === 'skipped' &&
+    showDetail &&
+    skipReason !== null &&
+    skipReason !== undefined &&
+    skipReason.length > 0;
+
   return (
-    <div id={`node-transition-${nodeName}`} className="flex items-center gap-3 py-3">
-      <time
-        dateTime={timestamp}
-        title={wallClock}
-        className="w-14 shrink-0 font-mono text-[10px] tabular-nums text-text-tertiary"
-      >
-        {displayed}
-      </time>
-      <span className="font-mono text-[11px] text-text-primary">{nodeName}</span>
-      <div
-        className="h-px flex-1"
-        style={{ backgroundColor: 'color-mix(in oklch, var(--border), transparent 50%)' }}
-        aria-hidden
-      />
-      <span className={`font-mono text-[11px] ${TRANSITION_COLOR[transition]}`}>
-        {TRANSITION_LABEL[transition]}
-        {dur}
-      </span>
+    <div id={`node-transition-${nodeName}`} className="flex flex-col gap-1 py-3">
+      <div className="flex items-center gap-3">
+        <time
+          dateTime={timestamp}
+          title={wallClock}
+          className="w-14 shrink-0 font-mono text-[10px] tabular-nums text-text-tertiary"
+        >
+          {displayed}
+        </time>
+        <span className="font-mono text-[11px] text-text-primary">{nodeName}</span>
+        <div
+          className="h-px flex-1"
+          style={{ backgroundColor: 'color-mix(in oklch, var(--border), transparent 50%)' }}
+          aria-hidden
+        />
+        <span className={`font-mono text-[11px] ${TRANSITION_COLOR[transition]}`}>
+          {TRANSITION_LABEL[transition]}
+          {dur}
+        </span>
+      </div>
+      {hasSkipDetail ? (
+        <div className="ml-[68px] flex flex-wrap items-baseline gap-x-2 font-mono text-[10px] text-text-tertiary">
+          <span>reason</span>
+          <span className="text-text-secondary">{skipReason}</span>
+          {skipExpr !== null && skipExpr !== undefined && skipExpr.length > 0 ? (
+            <>
+              <span>expr</span>
+              <span className="text-text-secondary">{skipExpr}</span>
+            </>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/packages/web/src/experiments/console/components/NodeDivider.tsx
+++ b/packages/web/src/experiments/console/components/NodeDivider.tsx
@@ -1,0 +1,69 @@
+import type { ReactElement } from 'react';
+import { formatElapsed, formatRelativeToBaseline, formatClock } from '../lib/format';
+import { useStreamContext } from '../lib/stream-context';
+
+interface NodeDividerProps {
+  nodeName: string;
+  transition: 'started' | 'completed' | 'failed' | 'skipped';
+  durationMs: number | null;
+  timestamp: string;
+}
+
+const TRANSITION_LABEL: Record<NodeDividerProps['transition'], string> = {
+  started: 'entered',
+  completed: 'completed',
+  failed: 'failed',
+  skipped: 'skipped',
+};
+
+const TRANSITION_COLOR: Record<NodeDividerProps['transition'], string> = {
+  started: 'text-[color:var(--running)]',
+  completed: 'text-success',
+  failed: 'text-error',
+  skipped: 'text-text-tertiary',
+};
+
+/**
+ * Thin divider marking a DAG node transition.
+ *   left gutter:  relative timestamp (mono)
+ *   left label:   node name in mono
+ *   right label:  transition + duration (for completed/failed)
+ *
+ * The id targets a scrollIntoView from the graph panel.
+ */
+export function NodeDivider({
+  nodeName,
+  transition,
+  durationMs,
+  timestamp,
+}: NodeDividerProps): ReactElement {
+  const { runStartedAt } = useStreamContext();
+  const displayed = formatRelativeToBaseline(timestamp, runStartedAt);
+  const wallClock = formatClock(timestamp);
+  const dur =
+    durationMs !== null && durationMs > 0
+      ? ` · ${formatElapsed(Math.floor(durationMs / 1000))}`
+      : '';
+
+  return (
+    <div id={`node-transition-${nodeName}`} className="flex items-center gap-3 py-3">
+      <time
+        dateTime={timestamp}
+        title={wallClock}
+        className="w-14 shrink-0 font-mono text-[10px] tabular-nums text-text-tertiary"
+      >
+        {displayed}
+      </time>
+      <span className="font-mono text-[11px] text-text-primary">{nodeName}</span>
+      <div
+        className="h-px flex-1"
+        style={{ backgroundColor: 'color-mix(in oklch, var(--border), transparent 50%)' }}
+        aria-hidden
+      />
+      <span className={`font-mono text-[11px] ${TRANSITION_COLOR[transition]}`}>
+        {TRANSITION_LABEL[transition]}
+        {dur}
+      </span>
+    </div>
+  );
+}

--- a/packages/web/src/experiments/console/components/OriginBadge.tsx
+++ b/packages/web/src/experiments/console/components/OriginBadge.tsx
@@ -1,0 +1,24 @@
+import type { ReactElement } from 'react';
+import type { RunOrigin } from '../primitives/run';
+
+const ORIGIN_LABEL: Record<RunOrigin, string> = {
+  web: 'Web',
+  cli: 'CLI',
+  slack: 'Slack',
+  telegram: 'Telegram',
+  discord: 'Discord',
+  github: 'GitHub',
+  unknown: '—',
+};
+
+/** Compact monochrome pill. Never ALL-CAPS, never suffixed. */
+export function OriginBadge({ origin }: { origin: RunOrigin }): ReactElement {
+  return (
+    <span
+      className="inline-flex items-center rounded border border-border px-1.5 py-0.5 font-mono text-[10px] text-text-secondary"
+      title={`Origin: ${ORIGIN_LABEL[origin]}`}
+    >
+      {ORIGIN_LABEL[origin]}
+    </span>
+  );
+}

--- a/packages/web/src/experiments/console/components/ProjectPalette.tsx
+++ b/packages/web/src/experiments/console/components/ProjectPalette.tsx
@@ -1,0 +1,191 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactElement,
+} from 'react';
+import { useNavigate } from 'react-router';
+import { useEntity } from '../store/cache';
+import { K } from '../store/keys';
+import * as skill from '../skills';
+import type { Project } from '../primitives/project';
+import { formatProjectLocator } from '../lib/format';
+
+interface ProjectPaletteProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Cmd-K-style overlay for jumping to a project. Opened via `p` anywhere.
+ *
+ * Match is character-subsequence ("subsequence fuzzy") — `c00/A` matches
+ * `coleam00/Archon` — not a full Levenshtein scorer; good enough for short
+ * project lists, no extra deps.
+ *
+ * Closes on Esc / outside-click / Enter (after navigating).
+ */
+export function ProjectPalette({ open, onClose }: ProjectPaletteProps): ReactElement | null {
+  const navigate = useNavigate();
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [query, setQuery] = useState('');
+  const [index, setIndex] = useState(0);
+
+  const { data: projects } = useEntity<Project[]>(K.projects, () => skill.listProjects());
+
+  // Reset query + selection each time the palette opens. Focus is called
+  // synchronously — the input ref is committed by React before useEffect
+  // runs, so there's no need to defer with rAF, and deferring leaves a
+  // one-frame window where Enter from the keymap can leak through to the
+  // page underneath.
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+      setIndex(0);
+      inputRef.current?.focus();
+    }
+  }, [open]);
+
+  const matches = useMemo<Project[]>(() => {
+    const list = projects ?? [];
+    const q = query.trim().toLowerCase();
+    if (q.length === 0) return list;
+    return list.filter(p => subsequence(p.name.toLowerCase(), q));
+  }, [projects, query]);
+
+  // Clamp index when the result set shrinks.
+  useEffect(() => {
+    if (index >= matches.length) setIndex(Math.max(0, matches.length - 1));
+  }, [matches.length, index]);
+
+  if (!open) return null;
+
+  const choose = (project: Project): void => {
+    navigate(`/console/p/${project.id}`);
+    onClose();
+  };
+
+  const onKey = (e: ReactKeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setIndex(i => Math.min(matches.length - 1, i + 1));
+      return;
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setIndex(i => Math.max(0, i - 1));
+      return;
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      const picked = matches[index];
+      if (picked !== undefined) choose(picked);
+      return;
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+    }
+  };
+
+  const listboxId = 'project-palette-listbox';
+  const activeOptionId =
+    matches[index] !== undefined ? `project-palette-option-${matches[index].id}` : undefined;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Pick a project"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/60 p-4 pt-[12vh]"
+      onClick={onClose}
+    >
+      <div
+        onClick={e => {
+          e.stopPropagation();
+        }}
+        className="w-full max-w-xl overflow-hidden rounded-md border border-border bg-surface-elevated shadow-2xl"
+      >
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={e => {
+            setQuery(e.target.value);
+            setIndex(0);
+          }}
+          onKeyDown={onKey}
+          placeholder="Pick a project…"
+          aria-label="Pick a project"
+          role="combobox"
+          aria-expanded="true"
+          aria-controls={listboxId}
+          aria-autocomplete="list"
+          aria-activedescendant={activeOptionId}
+          className="w-full border-b border-border bg-transparent px-4 py-3 text-[15px] text-text-primary placeholder:text-text-tertiary focus:outline-none"
+        />
+        <ul
+          id={listboxId}
+          role="listbox"
+          aria-label="Projects"
+          className="max-h-[50vh] overflow-y-auto py-1"
+        >
+          {matches.length === 0 ? (
+            <li className="px-4 py-3 text-[12px] text-text-tertiary">No projects match.</li>
+          ) : (
+            matches.map((p, i) => {
+              const selected = i === index;
+              return (
+                <li key={p.id} role="presentation">
+                  <button
+                    id={`project-palette-option-${p.id}`}
+                    type="button"
+                    role="option"
+                    aria-selected={selected}
+                    onClick={() => {
+                      choose(p);
+                    }}
+                    onMouseEnter={() => {
+                      setIndex(i);
+                    }}
+                    className={`relative flex w-full items-baseline gap-3 px-4 py-2 text-left transition-colors ${
+                      selected ? 'bg-surface-hover' : 'hover:bg-surface-hover'
+                    }`}
+                  >
+                    {selected ? (
+                      <span
+                        aria-hidden
+                        className="brand-bar pointer-events-none absolute left-0 top-1 bottom-1 w-0.5 rounded-full"
+                      />
+                    ) : null}
+                    <span className="text-[13px] font-medium text-text-primary">{p.name}</span>
+                    <span className="truncate font-mono text-[10.5px] text-text-tertiary">
+                      {formatProjectLocator(p)}
+                    </span>
+                  </button>
+                </li>
+              );
+            })
+          )}
+        </ul>
+        <footer className="flex items-center justify-between border-t border-border px-4 py-2 font-mono text-[10px] text-text-tertiary">
+          <span>↑↓ move · ↵ open · esc cancel</span>
+          <span>
+            {matches.length} of {projects?.length ?? 0}
+          </span>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+/** True if `needle` is a subsequence of `haystack` (case-folded by caller). */
+function subsequence(haystack: string, needle: string): boolean {
+  let i = 0;
+  for (const ch of haystack) {
+    if (ch === needle[i]) i += 1;
+    if (i === needle.length) return true;
+  }
+  return i === needle.length;
+}

--- a/packages/web/src/experiments/console/components/ProjectRail.tsx
+++ b/packages/web/src/experiments/console/components/ProjectRail.tsx
@@ -1,52 +1,19 @@
-import { useMemo, useState, type ReactElement } from 'react';
+import { useState, type ReactElement } from 'react';
 import { useNavigate, useLocation } from 'react-router';
-import { ProjectRow, type ActivityDot } from './ProjectRow';
+import { ProjectRow } from './ProjectRow';
 import { EnvVarsDialog } from './EnvVarsDialog';
 import { useEntity, invalidate } from '../store/cache';
 import { K } from '../store/keys';
 import * as skill from '../skills';
 import type { Project } from '../primitives/project';
-import type { Run } from '../primitives/run';
-import type { RunCounts } from '../skills/runs';
 
 interface ProjectRailProps {
   onAddProject: () => void;
 }
 
-interface RunsFeedData {
-  runs: Run[];
-  counts: RunCounts;
-  total: number;
-}
-
 async function handleRemove(projectId: string): Promise<void> {
   await skill.removeProject(projectId);
   invalidate(K.projects);
-}
-
-/**
- * Derive a single at-a-glance status indicator per project from the full
- * runs list. Priority: failed (only when no other in-flight runs) →
- * paused → running → none. We don't show "completed" because every
- * historically-completed run would light up every row in green.
- */
-function deriveActivityByProject(runs: Run[]): Map<string, ActivityDot> {
-  const out = new Map<string, ActivityDot>();
-  for (const r of runs) {
-    if (r.projectId === null) continue;
-    const current = out.get(r.projectId) ?? null;
-    if (r.status === 'running' && current !== 'paused') {
-      out.set(r.projectId, 'running');
-    } else if (r.status === 'paused') {
-      out.set(r.projectId, 'paused');
-    } else if (r.status === 'failed' && current === null) {
-      // Only surface failed when nothing else is in flight; "you have an
-      // active run AND something failed earlier" isn't actionable from the
-      // rail and the active state takes precedence.
-      out.set(r.projectId, 'failed');
-    }
-  }
-  return out;
 }
 
 /** Extract the project id from /console/p/:id (and /console/p/:id/r/:runId). */
@@ -69,14 +36,6 @@ export function ProjectRail({ onAddProject }: ProjectRailProps): ReactElement {
   const [envProject, setEnvProject] = useState<Project | null>(null);
 
   const { data: projects, error } = useEntity<Project[]>(K.projects, () => skill.listProjects());
-
-  // Shared cache with the ALL view's runs feed — refetched via SSE
-  // invalidation in lib/sse.ts. Drives the per-row activity dots.
-  const { data: runsFeed } = useEntity<RunsFeedData>(K.runs('all'), () => skill.listRuns({}));
-  const activityByProject = useMemo(
-    () => deriveActivityByProject(runsFeed?.runs ?? []),
-    [runsFeed]
-  );
 
   const allSelected = scope === 'all';
 
@@ -106,18 +65,6 @@ export function ProjectRail({ onAddProject }: ProjectRailProps): ReactElement {
             className="brand-bar pointer-events-none absolute left-0 top-0 bottom-0 w-1 rounded-l-md"
           />
         ) : null}
-        <span
-          aria-hidden
-          className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-[10px] font-semibold"
-          style={{
-            background: allSelected
-              ? 'var(--brand-gradient)'
-              : 'color-mix(in oklch, var(--surface-elevated), var(--border) 40%)',
-            color: allSelected ? 'white' : 'var(--text-tertiary)',
-          }}
-        >
-          ∗
-        </span>
         <span>All projects</span>
       </button>
 
@@ -138,7 +85,6 @@ export function ProjectRail({ onAddProject }: ProjectRailProps): ReactElement {
             key={p.id}
             project={p}
             selected={scope === p.id}
-            activityDot={activityByProject.get(p.id) ?? null}
             onClick={() => {
               navigate(`/console/p/${p.id}`);
             }}

--- a/packages/web/src/experiments/console/components/ProjectRail.tsx
+++ b/packages/web/src/experiments/console/components/ProjectRail.tsx
@@ -1,14 +1,22 @@
-import { useState, type ReactElement } from 'react';
-import { useNavigate, useParams } from 'react-router';
-import { ProjectRow } from './ProjectRow';
+import { useMemo, useState, type ReactElement } from 'react';
+import { useNavigate, useLocation } from 'react-router';
+import { ProjectRow, type ActivityDot } from './ProjectRow';
 import { EnvVarsDialog } from './EnvVarsDialog';
 import { useEntity, invalidate } from '../store/cache';
 import { K } from '../store/keys';
 import * as skill from '../skills';
 import type { Project } from '../primitives/project';
+import type { Run } from '../primitives/run';
+import type { RunCounts } from '../skills/runs';
 
 interface ProjectRailProps {
   onAddProject: () => void;
+}
+
+interface RunsFeedData {
+  runs: Run[];
+  counts: RunCounts;
+  total: number;
 }
 
 async function handleRemove(projectId: string): Promise<void> {
@@ -17,16 +25,58 @@ async function handleRemove(projectId: string): Promise<void> {
 }
 
 /**
- * Left rail: ALL scope · project list (title + locator) · add slot.
- * Title is editable per-project; right-click any row to remove.
+ * Derive a single at-a-glance status indicator per project from the full
+ * runs list. Priority: failed (only when no other in-flight runs) →
+ * paused → running → none. We don't show "completed" because every
+ * historically-completed run would light up every row in green.
+ */
+function deriveActivityByProject(runs: Run[]): Map<string, ActivityDot> {
+  const out = new Map<string, ActivityDot>();
+  for (const r of runs) {
+    if (r.projectId === null) continue;
+    const current = out.get(r.projectId) ?? null;
+    if (r.status === 'running' && current !== 'paused') {
+      out.set(r.projectId, 'running');
+    } else if (r.status === 'paused') {
+      out.set(r.projectId, 'paused');
+    } else if (r.status === 'failed' && current === null) {
+      // Only surface failed when nothing else is in flight; "you have an
+      // active run AND something failed earlier" isn't actionable from the
+      // rail and the active state takes precedence.
+      out.set(r.projectId, 'failed');
+    }
+  }
+  return out;
+}
+
+/** Extract the project id from /console/p/:id (and /console/p/:id/r/:runId). */
+function extractProjectId(pathname: string): string | null {
+  const m = /^\/console\/p\/([^/]+)/.exec(pathname);
+  return m === null ? null : m[1];
+}
+
+/**
+ * Left rail: ALL scope · project list · add slot.
+ *
+ * Note: ProjectRail mounts outside the inner `<Routes>` (sibling to the
+ * <main> that hosts them), so `useParams()` returns `{}` here even on a
+ * project URL. We extract the project id from the pathname directly.
  */
 export function ProjectRail({ onAddProject }: ProjectRailProps): ReactElement {
   const navigate = useNavigate();
-  const { projectId } = useParams<{ projectId?: string }>();
-  const scope = projectId ?? 'all';
+  const location = useLocation();
+  const scope = extractProjectId(location.pathname) ?? 'all';
   const [envProject, setEnvProject] = useState<Project | null>(null);
 
   const { data: projects, error } = useEntity<Project[]>(K.projects, () => skill.listProjects());
+
+  // Shared cache with the ALL view's runs feed — refetched via SSE
+  // invalidation in lib/sse.ts. Drives the per-row activity dots.
+  const { data: runsFeed } = useEntity<RunsFeedData>(K.runs('all'), () => skill.listRuns({}));
+  const activityByProject = useMemo(
+    () => deriveActivityByProject(runsFeed?.runs ?? []),
+    [runsFeed]
+  );
 
   const allSelected = scope === 'all';
 
@@ -44,19 +94,31 @@ export function ProjectRail({ onAddProject }: ProjectRailProps): ReactElement {
         title="All projects"
         aria-label="All projects"
         aria-pressed={allSelected}
-        className={`flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-[13px] font-medium transition-colors ${
+        className={`relative flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-[13px] font-medium transition-colors ${
           allSelected
-            ? 'brand-bar-soft text-text-primary'
+            ? 'bg-surface-elevated text-text-primary'
             : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
         }`}
       >
+        {allSelected ? (
+          <span
+            aria-hidden
+            className="brand-bar pointer-events-none absolute left-0 top-0 bottom-0 w-1 rounded-l-md"
+          />
+        ) : null}
         <span
           aria-hidden
-          className={`h-2 w-2 shrink-0 rounded-full ${
-            allSelected ? 'bg-accent-bright' : 'bg-text-tertiary/40'
-          }`}
-        />
-        <span className="uppercase tracking-[0.12em] text-[11px]">All projects</span>
+          className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-[10px] font-semibold"
+          style={{
+            background: allSelected
+              ? 'var(--brand-gradient)'
+              : 'color-mix(in oklch, var(--surface-elevated), var(--border) 40%)',
+            color: allSelected ? 'white' : 'var(--text-tertiary)',
+          }}
+        >
+          ∗
+        </span>
+        <span>All projects</span>
       </button>
 
       <div aria-hidden className="my-1 h-px w-full bg-border/60" />
@@ -76,6 +138,7 @@ export function ProjectRail({ onAddProject }: ProjectRailProps): ReactElement {
             key={p.id}
             project={p}
             selected={scope === p.id}
+            activityDot={activityByProject.get(p.id) ?? null}
             onClick={() => {
               navigate(`/console/p/${p.id}`);
             }}
@@ -98,7 +161,7 @@ export function ProjectRail({ onAddProject }: ProjectRailProps): ReactElement {
         onClick={onAddProject}
         title="Add project"
         aria-label="Add project"
-        className="flex items-center gap-2.5 rounded-md border border-dashed border-border px-2.5 py-1.5 text-left text-text-tertiary transition-colors hover:border-accent-bright/60 hover:bg-surface-hover hover:text-accent-bright"
+        className="flex items-center gap-2.5 rounded-md border border-dashed border-border px-2.5 py-1.5 text-left text-text-tertiary transition-colors hover:border-border-bright hover:bg-surface-hover hover:text-text-primary"
       >
         <span aria-hidden="true" className="text-base leading-none">
           +

--- a/packages/web/src/experiments/console/components/ProjectRail.tsx
+++ b/packages/web/src/experiments/console/components/ProjectRail.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 import { useNavigate, useParams } from 'react-router';
-import { ProjectTile } from './ProjectTile';
+import { ProjectRow } from './ProjectRow';
 import { useEntity, invalidate } from '../store/cache';
 import { K } from '../store/keys';
 import * as skill from '../skills';
@@ -16,8 +16,8 @@ async function handleRemove(projectId: string): Promise<void> {
 }
 
 /**
- * Thin always-visible left rail: ALL → every project → + Add project.
- * Every slot is aspect-square for a clean grid. Discord-style.
+ * Left rail: ALL scope · project list (title + locator) · add slot.
+ * Title is editable per-project; right-click any row to remove.
  */
 export function ProjectRail({ onAddProject }: ProjectRailProps): ReactElement {
   const navigate = useNavigate();
@@ -31,9 +31,9 @@ export function ProjectRail({ onAddProject }: ProjectRailProps): ReactElement {
   return (
     <nav
       aria-label="Projects"
-      className="flex h-full w-[68px] shrink-0 flex-col items-center gap-2 border-r border-border bg-surface-inset py-3"
+      className="flex h-full w-[240px] shrink-0 flex-col gap-1 border-r border-border bg-surface-inset p-2"
     >
-      {/* ALL scope pill — shares geometry with project tiles */}
+      {/* ALL scope */}
       <button
         type="button"
         onClick={() => {
@@ -42,32 +42,37 @@ export function ProjectRail({ onAddProject }: ProjectRailProps): ReactElement {
         title="All projects"
         aria-label="All projects"
         aria-pressed={allSelected}
-        className={`flex aspect-square w-11 items-center justify-center rounded-md border text-[10px] font-semibold uppercase tracking-[0.12em] leading-none transition-colors ${
+        className={`flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-[13px] font-medium transition-colors ${
           allSelected
-            ? 'border-accent-bright/60 bg-surface-elevated text-accent-bright ring-2 ring-accent-bright ring-offset-[3px] ring-offset-surface-inset'
-            : 'border-border bg-surface text-text-secondary hover:bg-surface-hover hover:text-text-primary'
+            ? 'bg-surface-elevated text-accent-bright ring-2 ring-accent-bright ring-offset-2 ring-offset-surface-inset'
+            : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
         }`}
       >
-        All
+        <span
+          aria-hidden
+          className={`h-2 w-2 shrink-0 rounded-full ${
+            allSelected ? 'bg-accent-bright' : 'bg-text-tertiary/40'
+          }`}
+        />
+        <span className="uppercase tracking-[0.12em] text-[11px]">All projects</span>
       </button>
 
-      <div aria-hidden className="my-1 h-px w-10 bg-border/60" />
+      <div aria-hidden className="my-1 h-px w-full bg-border/60" />
 
-      {/* Project list — scrolls if tall */}
-      <div className="flex min-h-0 flex-1 flex-col items-center gap-2 overflow-y-auto">
+      {/* Project list */}
+      <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto">
         {error !== undefined ? (
           <span
             title={error.message}
-            className="rounded border border-error/40 bg-error/10 px-1 py-0.5 font-mono text-[9px] text-error"
+            className="mx-2 rounded border border-error/40 bg-error/10 px-2 py-1 font-mono text-[10px] text-error"
           >
-            err
+            {error.message}
           </span>
         ) : null}
         {(projects ?? []).map(p => (
-          <ProjectTile
+          <ProjectRow
             key={p.id}
-            projectId={p.id}
-            name={p.name}
+            project={p}
             selected={scope === p.id}
             onClick={() => {
               navigate(`/console/p/${p.id}`);
@@ -80,17 +85,20 @@ export function ProjectRail({ onAddProject }: ProjectRailProps): ReactElement {
         ))}
       </div>
 
-      {/* Add project — same geometry, dashed to signal "empty slot" */}
+      <div aria-hidden className="my-1 h-px w-full bg-border/60" />
+
+      {/* Add project */}
       <button
         type="button"
         onClick={onAddProject}
         title="Add project"
         aria-label="Add project"
-        className="flex aspect-square w-11 items-center justify-center rounded-md border border-dashed border-border text-text-tertiary transition-colors hover:border-accent-bright/60 hover:bg-surface-hover hover:text-accent-bright"
+        className="flex items-center gap-2.5 rounded-md border border-dashed border-border px-2.5 py-1.5 text-left text-text-tertiary transition-colors hover:border-accent-bright/60 hover:bg-surface-hover hover:text-accent-bright"
       >
-        <span aria-hidden="true" className="text-lg leading-none">
+        <span aria-hidden="true" className="text-base leading-none">
           +
         </span>
+        <span className="text-[13px]">Add project</span>
       </button>
     </nav>
   );

--- a/packages/web/src/experiments/console/components/ProjectRail.tsx
+++ b/packages/web/src/experiments/console/components/ProjectRail.tsx
@@ -44,7 +44,7 @@ export function ProjectRail({ onAddProject }: ProjectRailProps): ReactElement {
         aria-pressed={allSelected}
         className={`flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-[13px] font-medium transition-colors ${
           allSelected
-            ? 'bg-surface-elevated text-accent-bright ring-2 ring-accent-bright ring-offset-2 ring-offset-surface-inset'
+            ? 'brand-bar-soft text-text-primary'
             : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
         }`}
       >

--- a/packages/web/src/experiments/console/components/ProjectRail.tsx
+++ b/packages/web/src/experiments/console/components/ProjectRail.tsx
@@ -1,0 +1,97 @@
+import type { ReactElement } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import { ProjectTile } from './ProjectTile';
+import { useEntity, invalidate } from '../store/cache';
+import { K } from '../store/keys';
+import * as skill from '../skills';
+import type { Project } from '../primitives/project';
+
+interface ProjectRailProps {
+  onAddProject: () => void;
+}
+
+async function handleRemove(projectId: string): Promise<void> {
+  await skill.removeProject(projectId);
+  invalidate(K.projects);
+}
+
+/**
+ * Thin always-visible left rail: ALL → every project → + Add project.
+ * Every slot is aspect-square for a clean grid. Discord-style.
+ */
+export function ProjectRail({ onAddProject }: ProjectRailProps): ReactElement {
+  const navigate = useNavigate();
+  const { projectId } = useParams<{ projectId?: string }>();
+  const scope = projectId ?? 'all';
+
+  const { data: projects, error } = useEntity<Project[]>(K.projects, () => skill.listProjects());
+
+  const allSelected = scope === 'all';
+
+  return (
+    <nav
+      aria-label="Projects"
+      className="flex h-full w-[68px] shrink-0 flex-col items-center gap-2 border-r border-border bg-surface-inset py-3"
+    >
+      {/* ALL scope pill — shares geometry with project tiles */}
+      <button
+        type="button"
+        onClick={() => {
+          navigate('/console');
+        }}
+        title="All projects"
+        aria-label="All projects"
+        aria-pressed={allSelected}
+        className={`flex aspect-square w-11 items-center justify-center rounded-md border text-[10px] font-semibold uppercase tracking-[0.12em] leading-none transition-colors ${
+          allSelected
+            ? 'border-accent-bright/60 bg-surface-elevated text-accent-bright ring-2 ring-accent-bright ring-offset-[3px] ring-offset-surface-inset'
+            : 'border-border bg-surface text-text-secondary hover:bg-surface-hover hover:text-text-primary'
+        }`}
+      >
+        All
+      </button>
+
+      <div aria-hidden className="my-1 h-px w-10 bg-border/60" />
+
+      {/* Project list — scrolls if tall */}
+      <div className="flex min-h-0 flex-1 flex-col items-center gap-2 overflow-y-auto">
+        {error !== undefined ? (
+          <span
+            title={error.message}
+            className="rounded border border-error/40 bg-error/10 px-1 py-0.5 font-mono text-[9px] text-error"
+          >
+            err
+          </span>
+        ) : null}
+        {(projects ?? []).map(p => (
+          <ProjectTile
+            key={p.id}
+            projectId={p.id}
+            name={p.name}
+            selected={scope === p.id}
+            onClick={() => {
+              navigate(`/console/p/${p.id}`);
+            }}
+            onRemove={() => {
+              void handleRemove(p.id);
+              if (scope === p.id) navigate('/console');
+            }}
+          />
+        ))}
+      </div>
+
+      {/* Add project — same geometry, dashed to signal "empty slot" */}
+      <button
+        type="button"
+        onClick={onAddProject}
+        title="Add project"
+        aria-label="Add project"
+        className="flex aspect-square w-11 items-center justify-center rounded-md border border-dashed border-border text-text-tertiary transition-colors hover:border-accent-bright/60 hover:bg-surface-hover hover:text-accent-bright"
+      >
+        <span aria-hidden="true" className="text-lg leading-none">
+          +
+        </span>
+      </button>
+    </nav>
+  );
+}

--- a/packages/web/src/experiments/console/components/ProjectRail.tsx
+++ b/packages/web/src/experiments/console/components/ProjectRail.tsx
@@ -1,6 +1,7 @@
-import type { ReactElement } from 'react';
+import { useState, type ReactElement } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { ProjectRow } from './ProjectRow';
+import { EnvVarsDialog } from './EnvVarsDialog';
 import { useEntity, invalidate } from '../store/cache';
 import { K } from '../store/keys';
 import * as skill from '../skills';
@@ -23,6 +24,7 @@ export function ProjectRail({ onAddProject }: ProjectRailProps): ReactElement {
   const navigate = useNavigate();
   const { projectId } = useParams<{ projectId?: string }>();
   const scope = projectId ?? 'all';
+  const [envProject, setEnvProject] = useState<Project | null>(null);
 
   const { data: projects, error } = useEntity<Project[]>(K.projects, () => skill.listProjects());
 
@@ -81,6 +83,9 @@ export function ProjectRail({ onAddProject }: ProjectRailProps): ReactElement {
               void handleRemove(p.id);
               if (scope === p.id) navigate('/console');
             }}
+            onEditEnv={() => {
+              setEnvProject(p);
+            }}
           />
         ))}
       </div>
@@ -100,6 +105,15 @@ export function ProjectRail({ onAddProject }: ProjectRailProps): ReactElement {
         </span>
         <span className="text-[13px]">Add project</span>
       </button>
+
+      <EnvVarsDialog
+        projectId={envProject?.id ?? ''}
+        projectName={envProject?.name ?? ''}
+        open={envProject !== null}
+        onClose={() => {
+          setEnvProject(null);
+        }}
+      />
     </nav>
   );
 }

--- a/packages/web/src/experiments/console/components/ProjectRow.tsx
+++ b/packages/web/src/experiments/console/components/ProjectRow.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef, useState, type CSSProperties, type ReactElement } from 'react';
+import { tileColor } from '../lib/icon-color';
+import { useDisplayName, setDisplayName } from '../lib/display-name';
+import { formatProjectLocator } from '../lib/format';
+import type { Project } from '../primitives/project';
+
+interface ProjectRowProps {
+  project: Project;
+  selected: boolean;
+  onClick: () => void;
+  onRemove?: () => void;
+  activityDot?: 'running' | 'paused' | 'failed' | null;
+}
+
+/**
+ * Wide rail row: colored dot · two lines (title + locator). Title is the
+ * project's API name unless the user has set an override via double-click.
+ * Right-click opens the remove confirmation (same UX as the previous tile).
+ */
+export function ProjectRow({
+  project,
+  selected,
+  onClick,
+  onRemove,
+  activityDot = null,
+}: ProjectRowProps): ReactElement {
+  const displayName = useDisplayName(project.id, project.name);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(displayName);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (editing) {
+      setDraft(displayName);
+      inputRef.current?.select();
+    }
+  }, [editing, displayName]);
+
+  const commit = (): void => {
+    if (draft.trim() === project.name) setDisplayName(project.id, '');
+    else setDisplayName(project.id, draft);
+    setEditing(false);
+  };
+  const cancel = (): void => {
+    setEditing(false);
+  };
+
+  const dotStyle: CSSProperties = { backgroundColor: tileColor(project.id) };
+  const ring = selected
+    ? 'ring-2 ring-accent-bright ring-offset-2 ring-offset-surface-inset'
+    : 'ring-0';
+  const bg = selected ? 'bg-surface-elevated' : 'bg-transparent hover:bg-surface-hover';
+
+  return (
+    <div
+      onClick={editing ? undefined : onClick}
+      onContextMenu={e => {
+        if (onRemove === undefined || editing) return;
+        e.preventDefault();
+        const confirmed = window.confirm(
+          `Remove project "${displayName}"?\n\nLocal files and worktrees are not deleted.`
+        );
+        if (confirmed) onRemove();
+      }}
+      role="button"
+      tabIndex={editing ? -1 : 0}
+      onKeyDown={e => {
+        if (editing) return;
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      aria-pressed={selected}
+      title={`${displayName} · double-click to rename · right-click to remove`}
+      className={`group relative flex w-full cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left transition-colors ${bg} ${ring}`}
+    >
+      <span
+        aria-hidden="true"
+        style={dotStyle}
+        className="mt-1 h-2 w-2 shrink-0 self-start rounded-full"
+      />
+      <div className="flex min-w-0 flex-1 flex-col leading-tight">
+        {editing ? (
+          <input
+            ref={inputRef}
+            value={draft}
+            autoFocus
+            onChange={e => {
+              setDraft(e.target.value);
+            }}
+            onKeyDown={e => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                commit();
+              } else if (e.key === 'Escape') {
+                e.preventDefault();
+                cancel();
+              }
+              e.stopPropagation();
+            }}
+            onBlur={commit}
+            onClick={e => {
+              e.stopPropagation();
+            }}
+            onDoubleClick={e => {
+              e.stopPropagation();
+            }}
+            className="w-full rounded border border-border-bright bg-surface px-1 py-0.5 text-[13px] font-medium text-text-primary focus:outline-none"
+          />
+        ) : (
+          <span
+            onDoubleClick={e => {
+              e.stopPropagation();
+              setEditing(true);
+            }}
+            className="truncate text-[13px] font-medium text-text-primary"
+          >
+            {displayName}
+          </span>
+        )}
+        <span className="truncate font-mono text-[10.5px] text-text-tertiary">
+          {formatProjectLocator(project)}
+        </span>
+      </div>
+      {activityDot !== null ? (
+        <span
+          aria-hidden="true"
+          className={`h-2 w-2 shrink-0 rounded-full ${
+            activityDot === 'running'
+              ? 'bg-[color:var(--running)]'
+              : activityDot === 'paused'
+                ? 'bg-warning animate-pulse'
+                : 'bg-error'
+          }`}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/packages/web/src/experiments/console/components/ProjectRow.tsx
+++ b/packages/web/src/experiments/console/components/ProjectRow.tsx
@@ -4,19 +4,28 @@ import { useDisplayName, setDisplayName } from '../lib/display-name';
 import { formatProjectLocator } from '../lib/format';
 import type { Project } from '../primitives/project';
 
+export type ActivityDot = 'running' | 'paused' | 'failed';
+
 interface ProjectRowProps {
   project: Project;
   selected: boolean;
   onClick: () => void;
   onRemove?: () => void;
   onEditEnv?: () => void;
-  activityDot?: 'running' | 'paused' | 'failed' | null;
+  activityDot?: ActivityDot | null;
 }
 
 /**
- * Wide rail row: colored dot · two lines (title + locator). Title is the
- * project's API name unless the user has set an override via double-click.
- * Right-click opens the remove confirmation (same UX as the previous tile).
+ * Rail row: avatar · two lines (title + locator) · hover-actions · status.
+ *
+ * Avatar is the first letter of the project name on a hash-derived
+ * background — scannable identity that can never be confused with the
+ * activity status dot on the right. Double-click the title to rename;
+ * the override is local-only and the path stays put as the subtitle.
+ *
+ * `activityDot` is what the right-side pulse is. It only renders when
+ * the project has running / paused / failed runs; idle projects have
+ * nothing on the right.
  */
 export function ProjectRow({
   project,
@@ -29,6 +38,7 @@ export function ProjectRow({
   const displayName = useDisplayName(project.id, project.name);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(displayName);
+  const [menuOpen, setMenuOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
@@ -37,6 +47,18 @@ export function ProjectRow({
       inputRef.current?.select();
     }
   }, [editing, displayName]);
+
+  // Close the ⋯ menu on outside click.
+  useEffect(() => {
+    if (!menuOpen) return;
+    const close = (): void => {
+      setMenuOpen(false);
+    };
+    window.addEventListener('click', close);
+    return (): void => {
+      window.removeEventListener('click', close);
+    };
+  }, [menuOpen]);
 
   const commit = (): void => {
     if (draft.trim() === project.name) setDisplayName(project.id, '');
@@ -47,22 +69,22 @@ export function ProjectRow({
     setEditing(false);
   };
 
-  const dotStyle: CSSProperties = { backgroundColor: tileColor(project.id) };
-  const ring = selected
-    ? 'ring-2 ring-accent-bright ring-offset-2 ring-offset-surface-inset'
-    : 'ring-0';
-  const bg = selected ? 'bg-surface-elevated' : 'bg-transparent hover:bg-surface-hover';
+  const avatarChar =
+    displayName
+      .replace(/[^A-Za-z0-9]/g, '')
+      .slice(0, 1)
+      .toUpperCase() || '·';
+  const avatarStyle: CSSProperties = {
+    backgroundColor: tileColor(project.id),
+  };
 
   return (
     <div
-      onClick={editing ? undefined : onClick}
+      onClick={editing || menuOpen ? undefined : onClick}
       onContextMenu={e => {
         if (onRemove === undefined || editing) return;
         e.preventDefault();
-        const confirmed = window.confirm(
-          `Remove project "${displayName}"?\n\nLocal files and worktrees are not deleted.`
-        );
-        if (confirmed) onRemove();
+        setMenuOpen(true);
       }}
       role="button"
       tabIndex={editing ? -1 : 0}
@@ -74,14 +96,31 @@ export function ProjectRow({
         }
       }}
       aria-pressed={selected}
-      title={`${displayName} · double-click to rename · right-click to remove`}
-      className={`group relative flex w-full cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left transition-colors ${bg} ${ring}`}
+      title={`${displayName} · double-click to rename`}
+      className={`group relative flex w-full cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left transition-colors ${
+        selected ? 'bg-surface-elevated' : 'bg-transparent hover:bg-surface-hover'
+      }`}
     >
+      {/* Brand gradient strip — the unmistakable "this is selected" cue.
+          rounded-l matches the row's own corner radius so the strip blends
+          into the corners (no overflow-hidden needed; that would clip the
+          ⋯ dropdown menu below). */}
+      {selected ? (
+        <span
+          aria-hidden
+          className="brand-bar pointer-events-none absolute left-0 top-0 bottom-0 w-1 rounded-l-md"
+        />
+      ) : null}
+
+      {/* Identity avatar — initial on a hash-coloured square. */}
       <span
         aria-hidden="true"
-        style={dotStyle}
-        className="mt-1 h-2 w-2 shrink-0 self-start rounded-full"
-      />
+        style={avatarStyle}
+        className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-[10px] font-semibold text-white/95"
+      >
+        {avatarChar}
+      </span>
+
       <div className="flex min-w-0 flex-1 flex-col leading-tight">
         {editing ? (
           <input
@@ -116,7 +155,9 @@ export function ProjectRow({
               e.stopPropagation();
               setEditing(true);
             }}
-            className="truncate text-[13px] font-medium text-text-primary"
+            className={`truncate text-[13px] font-medium ${
+              selected ? 'text-text-primary' : 'text-text-secondary group-hover:text-text-primary'
+            }`}
           >
             {displayName}
           </span>
@@ -125,32 +166,90 @@ export function ProjectRow({
           {formatProjectLocator(project)}
         </span>
       </div>
-      {onEditEnv !== undefined && (selected || activityDot === null) ? (
-        <button
-          type="button"
-          onClick={e => {
-            e.stopPropagation();
-            onEditEnv();
-          }}
-          title="Environment variables"
-          aria-label="Environment variables"
-          className={`shrink-0 rounded p-1 font-mono text-[11px] leading-none transition-opacity ${
-            selected
-              ? 'text-text-tertiary opacity-70 hover:bg-surface-hover hover:text-text-primary hover:opacity-100'
-              : 'text-text-tertiary opacity-0 group-hover:opacity-70 group-hover:hover:bg-surface-hover group-hover:hover:opacity-100'
-          }`}
-        >
-          ⚙
-        </button>
-      ) : null}
+
+      {/* Hover actions: env vars + ⋯ menu. Always-visible on selected row
+          so power features (env, remove) are one click away in the active
+          context. */}
+      <div
+        className={`flex shrink-0 items-center gap-0.5 transition-opacity ${
+          selected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+        }`}
+      >
+        {onEditEnv !== undefined ? (
+          <button
+            type="button"
+            onClick={e => {
+              e.stopPropagation();
+              onEditEnv();
+            }}
+            title="Environment variables"
+            aria-label="Environment variables"
+            className="rounded p-1 font-mono text-[11px] leading-none text-text-tertiary transition-colors hover:bg-surface-hover hover:text-text-primary"
+          >
+            ⚙
+          </button>
+        ) : null}
+        {onRemove !== undefined ? (
+          <div className="relative">
+            <button
+              type="button"
+              onClick={e => {
+                e.stopPropagation();
+                setMenuOpen(v => !v);
+              }}
+              title="More actions"
+              aria-label="More actions"
+              aria-expanded={menuOpen}
+              className="rounded p-1 font-mono text-[11px] leading-none text-text-tertiary transition-colors hover:bg-surface-hover hover:text-text-primary"
+            >
+              ⋯
+            </button>
+            {menuOpen ? (
+              <div
+                role="menu"
+                onClick={e => {
+                  e.stopPropagation();
+                }}
+                className="absolute right-0 top-full z-10 mt-1 min-w-[160px] rounded-md border border-border bg-surface-elevated p-1 shadow-lg"
+              >
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={e => {
+                    e.stopPropagation();
+                    setMenuOpen(false);
+                    const confirmed = window.confirm(
+                      `Remove project "${displayName}"?\n\nLocal files and worktrees are not deleted.`
+                    );
+                    if (confirmed) onRemove();
+                  }}
+                  className="block w-full rounded px-2 py-1 text-left text-[12px] text-error transition-colors hover:bg-error/10"
+                >
+                  Remove project
+                </button>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+
+      {/* Real activity indicator — only shown when the project actually has
+          something in flight. Idle projects = no dot. */}
       {activityDot !== null ? (
         <span
           aria-hidden="true"
+          title={
+            activityDot === 'running'
+              ? 'Running'
+              : activityDot === 'paused'
+                ? 'Waiting for approval'
+                : 'Last run failed'
+          }
           className={`h-2 w-2 shrink-0 rounded-full ${
             activityDot === 'running'
-              ? 'bg-[color:var(--running)]'
+              ? 'animate-pulse bg-[color:var(--running)]'
               : activityDot === 'paused'
-                ? 'bg-warning animate-pulse'
+                ? 'animate-pulse bg-warning'
                 : 'bg-error'
           }`}
         />

--- a/packages/web/src/experiments/console/components/ProjectRow.tsx
+++ b/packages/web/src/experiments/console/components/ProjectRow.tsx
@@ -9,6 +9,7 @@ interface ProjectRowProps {
   selected: boolean;
   onClick: () => void;
   onRemove?: () => void;
+  onEditEnv?: () => void;
   activityDot?: 'running' | 'paused' | 'failed' | null;
 }
 
@@ -22,6 +23,7 @@ export function ProjectRow({
   selected,
   onClick,
   onRemove,
+  onEditEnv,
   activityDot = null,
 }: ProjectRowProps): ReactElement {
   const displayName = useDisplayName(project.id, project.name);
@@ -123,6 +125,24 @@ export function ProjectRow({
           {formatProjectLocator(project)}
         </span>
       </div>
+      {onEditEnv !== undefined && (selected || activityDot === null) ? (
+        <button
+          type="button"
+          onClick={e => {
+            e.stopPropagation();
+            onEditEnv();
+          }}
+          title="Environment variables"
+          aria-label="Environment variables"
+          className={`shrink-0 rounded p-1 font-mono text-[11px] leading-none transition-opacity ${
+            selected
+              ? 'text-text-tertiary opacity-70 hover:bg-surface-hover hover:text-text-primary hover:opacity-100'
+              : 'text-text-tertiary opacity-0 group-hover:opacity-70 group-hover:hover:bg-surface-hover group-hover:hover:opacity-100'
+          }`}
+        >
+          ⚙
+        </button>
+      ) : null}
       {activityDot !== null ? (
         <span
           aria-hidden="true"

--- a/packages/web/src/experiments/console/components/ProjectRow.tsx
+++ b/packages/web/src/experiments/console/components/ProjectRow.tsx
@@ -1,10 +1,7 @@
-import { useEffect, useRef, useState, type CSSProperties, type ReactElement } from 'react';
-import { tileColor } from '../lib/icon-color';
+import { useEffect, useRef, useState, type ReactElement } from 'react';
 import { useDisplayName, setDisplayName } from '../lib/display-name';
 import { formatProjectLocator } from '../lib/format';
 import type { Project } from '../primitives/project';
-
-export type ActivityDot = 'running' | 'paused' | 'failed';
 
 interface ProjectRowProps {
   project: Project;
@@ -12,20 +9,14 @@ interface ProjectRowProps {
   onClick: () => void;
   onRemove?: () => void;
   onEditEnv?: () => void;
-  activityDot?: ActivityDot | null;
 }
 
 /**
- * Rail row: avatar · two lines (title + locator) · hover-actions · status.
- *
- * Avatar is the first letter of the project name on a hash-derived
- * background — scannable identity that can never be confused with the
- * activity status dot on the right. Double-click the title to rename;
- * the override is local-only and the path stays put as the subtitle.
- *
- * `activityDot` is what the right-side pulse is. It only renders when
- * the project has running / paused / failed runs; idle projects have
- * nothing on the right.
+ * Rail row: title + locator (path) + hover actions. No avatar (the first
+ * letter of `owner/repo` carried no information), no status indicator
+ * (red-because-some-old-run-failed was noise, not signal). Selection is
+ * the gradient strip + elevated background. Double-click the title to
+ * rename; the path stays as a stable subtitle.
  */
 export function ProjectRow({
   project,
@@ -33,7 +24,6 @@ export function ProjectRow({
   onClick,
   onRemove,
   onEditEnv,
-  activityDot = null,
 }: ProjectRowProps): ReactElement {
   const displayName = useDisplayName(project.id, project.name);
   const [editing, setEditing] = useState(false);
@@ -69,15 +59,6 @@ export function ProjectRow({
     setEditing(false);
   };
 
-  const avatarChar =
-    displayName
-      .replace(/[^A-Za-z0-9]/g, '')
-      .slice(0, 1)
-      .toUpperCase() || '·';
-  const avatarStyle: CSSProperties = {
-    backgroundColor: tileColor(project.id),
-  };
-
   return (
     <div
       onClick={editing || menuOpen ? undefined : onClick}
@@ -111,15 +92,6 @@ export function ProjectRow({
           className="brand-bar pointer-events-none absolute left-0 top-0 bottom-0 w-1 rounded-l-md"
         />
       ) : null}
-
-      {/* Identity avatar — initial on a hash-coloured square. */}
-      <span
-        aria-hidden="true"
-        style={avatarStyle}
-        className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-[10px] font-semibold text-white/95"
-      >
-        {avatarChar}
-      </span>
 
       <div className="flex min-w-0 flex-1 flex-col leading-tight">
         {editing ? (
@@ -232,28 +204,6 @@ export function ProjectRow({
           </div>
         ) : null}
       </div>
-
-      {/* Real activity indicator — only shown when the project actually has
-          something in flight. Idle projects = no dot. */}
-      {activityDot !== null ? (
-        <span
-          aria-hidden="true"
-          title={
-            activityDot === 'running'
-              ? 'Running'
-              : activityDot === 'paused'
-                ? 'Waiting for approval'
-                : 'Last run failed'
-          }
-          className={`h-2 w-2 shrink-0 rounded-full ${
-            activityDot === 'running'
-              ? 'animate-pulse bg-[color:var(--running)]'
-              : activityDot === 'paused'
-                ? 'animate-pulse bg-warning'
-                : 'bg-error'
-          }`}
-        />
-      ) : null}
     </div>
   );
 }

--- a/packages/web/src/experiments/console/components/ProjectTile.tsx
+++ b/packages/web/src/experiments/console/components/ProjectTile.tsx
@@ -1,0 +1,66 @@
+import type { CSSProperties, ReactElement } from 'react';
+import { tileAbbreviation, tileColor } from '../lib/icon-color';
+
+interface ProjectTileProps {
+  projectId: string;
+  name: string;
+  selected: boolean;
+  onClick: () => void;
+  onRemove?: () => void;
+  activityDot?: 'running' | 'paused' | 'failed' | null;
+}
+
+/**
+ * 44×44 rounded square with a 2-letter abbreviation on a deterministic
+ * background color. Rail peer of {@link RailSlot}; both share the same
+ * aspect-square geometry so the column reads as a clean grid.
+ */
+export function ProjectTile({
+  projectId,
+  name,
+  selected,
+  onClick,
+  onRemove,
+  activityDot = null,
+}: ProjectTileProps): ReactElement {
+  const style: CSSProperties = { backgroundColor: tileColor(projectId) };
+  const ring = selected
+    ? 'ring-2 ring-accent-bright ring-offset-[3px] ring-offset-surface-inset'
+    : 'ring-0';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      onContextMenu={e => {
+        if (onRemove === undefined) return;
+        e.preventDefault();
+        const confirmed = window.confirm(
+          `Remove project "${name}"?\n\nLocal files and worktrees are not deleted.`
+        );
+        if (confirmed) onRemove();
+      }}
+      title={`${name} · right-click to remove`}
+      aria-label={name}
+      aria-pressed={selected}
+      className={`relative aspect-square w-11 rounded-md flex items-center justify-center text-[13px] font-semibold leading-none text-white/95 transition-[transform,box-shadow] hover:-translate-y-[1px] active:translate-y-0 ${ring}`}
+      style={style}
+    >
+      <span className="pointer-events-none select-none tracking-tight">
+        {tileAbbreviation(name)}
+      </span>
+      {activityDot !== null ? (
+        <span
+          aria-hidden="true"
+          className={`absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full ring-2 ring-surface-inset ${
+            activityDot === 'running'
+              ? 'bg-[color:var(--running)]'
+              : activityDot === 'paused'
+                ? 'bg-warning animate-pulse'
+                : 'bg-error'
+          }`}
+        />
+      ) : null}
+    </button>
+  );
+}

--- a/packages/web/src/experiments/console/components/RecentRunRow.tsx
+++ b/packages/web/src/experiments/console/components/RecentRunRow.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router';
 import { OriginBadge } from './OriginBadge';
 import type { Run } from '../primitives/run';
-import { shortRunId, formatElapsed, elapsedSince } from '../lib/format';
+import { shortRunId, formatElapsed, elapsedSince, formatCost } from '../lib/format';
 import { statusTextClass } from '../lib/run-status';
 
 interface RecentRunRowProps {
@@ -59,6 +59,12 @@ export function RecentRunRow({ run, showProject = false }: RecentRunRowProps): R
         {shortRunId(run.id)}
       </span>
       <span className="w-20 shrink-0 text-right tabular-nums text-text-tertiary">{elapsed}</span>
+      <span
+        className="hidden w-16 shrink-0 text-right tabular-nums text-text-secondary md:inline"
+        title={typeof run.costUsd === 'number' ? 'Total agent cost' : undefined}
+      >
+        {typeof run.costUsd === 'number' ? formatCost(run.costUsd) : ''}
+      </span>
       <OriginBadge origin={run.origin} />
       <span
         aria-hidden

--- a/packages/web/src/experiments/console/components/RecentRunRow.tsx
+++ b/packages/web/src/experiments/console/components/RecentRunRow.tsx
@@ -9,6 +9,7 @@ import { statusTextClass } from '../lib/run-status';
 interface RecentRunRowProps {
   run: Run;
   showProject?: boolean;
+  selected?: boolean;
 }
 
 const STATUS_GLYPH: Record<string, string> = {
@@ -24,7 +25,11 @@ const STATUS_GLYPH: Record<string, string> = {
  * Failed rows keep the error-red glyph and status text so they still catch
  * the eye in a sea of muted completed rows.
  */
-export function RecentRunRow({ run, showProject = false }: RecentRunRowProps): ReactElement {
+export function RecentRunRow({
+  run,
+  showProject = false,
+  selected = false,
+}: RecentRunRowProps): ReactElement {
   const navigate = useNavigate();
   const isDocker = useIsDocker();
   const elapsed = formatElapsed(elapsedSince(run.startedAt, run.finishedAt ?? undefined));
@@ -54,11 +59,12 @@ export function RecentRunRow({ run, showProject = false }: RecentRunRowProps): R
 
   return (
     <div
+      data-run-id={run.id}
       onClick={onClick}
       role={canOpen ? 'button' : undefined}
       className={`group flex h-9 items-center gap-3 border-b border-border/40 px-3 font-mono text-[12px] transition-colors hover:bg-surface-hover ${
-        canOpen ? 'cursor-pointer' : ''
-      }`}
+        selected ? 'bg-surface-hover ring-2 ring-inset ring-accent-bright/40' : ''
+      } ${canOpen ? 'cursor-pointer' : ''}`}
     >
       <span aria-hidden className={`w-3 shrink-0 text-center ${statusTextClass[run.status]}`}>
         {glyph}

--- a/packages/web/src/experiments/console/components/RecentRunRow.tsx
+++ b/packages/web/src/experiments/console/components/RecentRunRow.tsx
@@ -1,0 +1,71 @@
+import type { ReactElement } from 'react';
+import { useNavigate } from 'react-router';
+import { OriginBadge } from './OriginBadge';
+import type { Run } from '../primitives/run';
+import { shortRunId, formatElapsed, elapsedSince } from '../lib/format';
+import { statusTextClass } from '../lib/run-status';
+
+interface RecentRunRowProps {
+  run: Run;
+  showProject?: boolean;
+}
+
+const STATUS_GLYPH: Record<string, string> = {
+  completed: '●',
+  failed: '✕',
+  cancelled: '◌',
+};
+
+/**
+ * Compact one-liner row for terminal-state runs (completed / failed /
+ * cancelled). ~36px tall, monospace, data-heavy. Scans like a log.
+ *
+ * Failed rows keep the error-red glyph and status text so they still catch
+ * the eye in a sea of muted completed rows.
+ */
+export function RecentRunRow({ run, showProject = false }: RecentRunRowProps): ReactElement {
+  const navigate = useNavigate();
+  const elapsed = formatElapsed(elapsedSince(run.startedAt, run.finishedAt ?? undefined));
+  const canOpen = run.projectId !== null && !run.id.startsWith('demo-');
+  const glyph = STATUS_GLYPH[run.status] ?? '·';
+
+  const onClick = (): void => {
+    if (canOpen) navigate(`/console/p/${run.projectId}/r/${run.id}`);
+  };
+
+  return (
+    <div
+      onClick={onClick}
+      role={canOpen ? 'button' : undefined}
+      className={`group flex h-9 items-center gap-3 border-b border-border/40 px-3 font-mono text-[12px] transition-colors hover:bg-surface-hover ${
+        canOpen ? 'cursor-pointer' : ''
+      }`}
+    >
+      <span aria-hidden className={`w-3 shrink-0 text-center ${statusTextClass[run.status]}`}>
+        {glyph}
+      </span>
+      <span
+        className={`w-20 shrink-0 text-[11px] uppercase tracking-wider ${statusTextClass[run.status]}`}
+      >
+        {run.status}
+      </span>
+      <span className="min-w-0 flex-1 truncate text-text-primary">{run.workflow}</span>
+      {showProject && run.projectName !== null ? (
+        <span className="hidden w-40 shrink-0 truncate text-text-secondary md:inline">
+          {run.projectName}
+        </span>
+      ) : null}
+      <span className="hidden w-24 shrink-0 truncate text-text-tertiary md:inline">
+        {shortRunId(run.id)}
+      </span>
+      <span className="w-20 shrink-0 text-right tabular-nums text-text-tertiary">{elapsed}</span>
+      <OriginBadge origin={run.origin} />
+      <span
+        aria-hidden
+        className="w-3 shrink-0 text-text-tertiary opacity-0 transition-opacity group-hover:opacity-100"
+      >
+        →
+      </span>
+    </div>
+  );
+}

--- a/packages/web/src/experiments/console/components/RecentRunRow.tsx
+++ b/packages/web/src/experiments/console/components/RecentRunRow.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router';
 import { OriginBadge } from './OriginBadge';
 import type { Run } from '../primitives/run';
 import { shortRunId, formatElapsed, elapsedSince, formatCost } from '../lib/format';
+import { useIsDocker, openInIde } from '../lib/health';
 import { statusTextClass } from '../lib/run-status';
 
 interface RecentRunRowProps {
@@ -25,12 +26,30 @@ const STATUS_GLYPH: Record<string, string> = {
  */
 export function RecentRunRow({ run, showProject = false }: RecentRunRowProps): ReactElement {
   const navigate = useNavigate();
+  const isDocker = useIsDocker();
   const elapsed = formatElapsed(elapsedSince(run.startedAt, run.finishedAt ?? undefined));
   const canOpen = run.projectId !== null && !run.id.startsWith('demo-');
+  const canOpenIde =
+    !isDocker && run.workingPath !== null && run.workingPath !== '' && !run.id.startsWith('demo-');
+  const canRerun =
+    run.projectId !== null &&
+    run.workflow !== '' &&
+    !run.id.startsWith('demo-') &&
+    (run.status === 'completed' || run.status === 'failed' || run.status === 'cancelled');
   const glyph = STATUS_GLYPH[run.status] ?? '·';
 
   const onClick = (): void => {
     if (canOpen) navigate(`/console/p/${run.projectId}/r/${run.id}`);
+  };
+
+  const onRerun = (): void => {
+    if (!canRerun || run.projectId === null) return;
+    const params = new URLSearchParams({
+      rerun: '1',
+      workflow: run.workflow,
+    });
+    if (run.userMessage.length > 0) params.set('message', run.userMessage);
+    navigate(`/console/p/${run.projectId}?${params.toString()}`);
   };
 
   return (
@@ -66,12 +85,43 @@ export function RecentRunRow({ run, showProject = false }: RecentRunRowProps): R
         {typeof run.costUsd === 'number' ? formatCost(run.costUsd) : ''}
       </span>
       <OriginBadge origin={run.origin} />
-      <span
-        aria-hidden
-        className="w-3 shrink-0 text-text-tertiary opacity-0 transition-opacity group-hover:opacity-100"
-      >
-        →
-      </span>
+      <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+        {canRerun ? (
+          <button
+            type="button"
+            onClick={e => {
+              e.stopPropagation();
+              onRerun();
+            }}
+            title={`Rerun ${run.workflow} with the same message`}
+            aria-label="Rerun"
+            className="rounded p-1 text-text-tertiary transition-colors hover:bg-surface-hover hover:text-text-primary"
+          >
+            <span aria-hidden className="text-[12px] leading-none">
+              ↻
+            </span>
+          </button>
+        ) : null}
+        {canOpenIde && run.workingPath !== null ? (
+          <button
+            type="button"
+            onClick={e => {
+              e.stopPropagation();
+              if (run.workingPath !== null) openInIde(run.workingPath);
+            }}
+            title={`Open ${run.workingPath} in IDE`}
+            aria-label="Open in IDE"
+            className="rounded p-1 text-text-tertiary transition-colors hover:bg-surface-hover hover:text-text-primary"
+          >
+            <span aria-hidden className="font-mono text-[12px] leading-none">
+              ↗
+            </span>
+          </button>
+        ) : null}
+        <span aria-hidden className="w-3 text-text-tertiary">
+          →
+        </span>
+      </div>
     </div>
   );
 }

--- a/packages/web/src/experiments/console/components/RunActionBar.tsx
+++ b/packages/web/src/experiments/console/components/RunActionBar.tsx
@@ -1,0 +1,93 @@
+import { useState, type ReactElement } from 'react';
+import * as skill from '../skills';
+import { invalidate } from '../store/cache';
+import { K } from '../store/keys';
+import type { Run } from '../primitives/run';
+
+interface RunActionBarProps {
+  run: Run;
+}
+
+/**
+ * Sticky bottom action bar. Contents are state-sensitive:
+ *   running   → Cancel
+ *   paused    → (nothing — the in-stream ApprovalPanel is the action surface)
+ *   failed    → Resume · Abandon
+ *   completed → Re-run (placeholder for M5 — navigates to the scoped Runs page)
+ *   cancelled → Re-run
+ *
+ * Demo runs short-circuit the backend calls.
+ */
+export function RunActionBar({ run }: RunActionBarProps): ReactElement | null {
+  const [busy, setBusy] = useState<'cancel' | 'resume' | 'abandon' | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const isDemo = run.id.startsWith('demo-');
+
+  const call = async (action: 'cancel' | 'resume' | 'abandon'): Promise<void> => {
+    setBusy(action);
+    setError(null);
+    try {
+      if (!isDemo) {
+        if (action === 'cancel') await skill.cancelRun(run.id);
+        if (action === 'resume') await skill.resumeRun(run.id);
+        if (action === 'abandon') await skill.abandonRun(run.id);
+      }
+      invalidate('runs:');
+      invalidate(K.run(run.id));
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Action failed.');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (run.status === 'paused') return null;
+
+  return (
+    <div className="sticky bottom-0 border-t border-border bg-surface px-6 py-3">
+      <div className="flex items-center gap-2">
+        {run.status === 'running' ? (
+          <button
+            type="button"
+            onClick={() => void call('cancel')}
+            disabled={busy !== null}
+            className="rounded border border-error/40 px-3 py-1.5 text-[12px] font-medium text-error transition-colors hover:bg-error/10 disabled:opacity-50"
+          >
+            {busy === 'cancel' ? 'Cancelling…' : 'Cancel'}
+          </button>
+        ) : null}
+
+        {run.status === 'failed' ? (
+          <>
+            <button
+              type="button"
+              onClick={() => void call('resume')}
+              disabled={busy !== null}
+              className="rounded bg-accent-bright px-3 py-1.5 text-[12px] font-medium text-white/95 transition-opacity hover:brightness-110 disabled:opacity-50"
+            >
+              {busy === 'resume' ? 'Resuming…' : 'Resume'}
+            </button>
+            <button
+              type="button"
+              onClick={() => void call('abandon')}
+              disabled={busy !== null}
+              className="rounded border border-border px-3 py-1.5 text-[12px] text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
+            >
+              {busy === 'abandon' ? 'Abandoning…' : 'Abandon'}
+            </button>
+          </>
+        ) : null}
+
+        {run.status === 'completed' || run.status === 'cancelled' ? (
+          <span className="text-[12px] text-text-tertiary">
+            This run is {run.status}. Start a new one from the project page.
+          </span>
+        ) : null}
+
+        {error !== null ? (
+          <span className="ml-2 font-mono text-[11px] text-error">{error}</span>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/experiments/console/components/RunActionBar.tsx
+++ b/packages/web/src/experiments/console/components/RunActionBar.tsx
@@ -32,7 +32,7 @@ export function RunActionBar({ run }: RunActionBarProps): ReactElement | null {
         if (action === 'resume') await skill.resumeRun(run.id);
         if (action === 'abandon') await skill.abandonRun(run.id);
       }
-      invalidate('runs:');
+      invalidate('runs');
       invalidate(K.run(run.id));
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Action failed.');

--- a/packages/web/src/experiments/console/components/RunCard.tsx
+++ b/packages/web/src/experiments/console/components/RunCard.tsx
@@ -1,0 +1,27 @@
+import type { ReactElement } from 'react';
+import { ActiveRunCard } from './ActiveRunCard';
+import { RecentRunRow } from './RecentRunRow';
+import type { Run } from '../primitives/run';
+
+interface RunCardProps {
+  run: Run;
+  showProject?: boolean;
+}
+
+/**
+ * Dispatcher — renders the right visual for a run based on its status.
+ *
+ *   running / paused    → ActiveRunCard (rich, attention-grabbing)
+ *   completed / failed  → RecentRunRow (compact one-liner)
+ *   cancelled           → RecentRunRow
+ *
+ * The split matches the attention model: active work gets real estate, the
+ * audit trail stays quiet. The RunsPage splits sections, but this dispatcher
+ * keeps the preview route and any mixed-list usage simple.
+ */
+export function RunCard({ run, showProject = false }: RunCardProps): ReactElement {
+  if (run.status === 'running' || run.status === 'paused') {
+    return <ActiveRunCard run={run} showProject={showProject} />;
+  }
+  return <RecentRunRow run={run} showProject={showProject} />;
+}

--- a/packages/web/src/experiments/console/components/RunDetailHeader.tsx
+++ b/packages/web/src/experiments/console/components/RunDetailHeader.tsx
@@ -44,7 +44,13 @@ export function RunDetailHeader({
   };
 
   return (
-    <header className="sticky top-0 z-10 flex flex-wrap items-center gap-x-4 gap-y-2 border-b border-border bg-surface px-6 py-3">
+    <header className="relative sticky top-0 z-10 flex flex-wrap items-center gap-x-4 gap-y-2 bg-surface px-6 py-3">
+      {/* Brand thread along the bottom edge — anchors the detail view. */}
+      <span
+        aria-hidden
+        className="brand-bar pointer-events-none absolute inset-x-0 bottom-0 h-px opacity-60"
+      />
+
       {/* Breadcrumb */}
       <div className="flex items-center gap-2 font-mono text-[12px]">
         <Link
@@ -59,11 +65,11 @@ export function RunDetailHeader({
         <button
           type="button"
           onClick={() => void copyRunId()}
-          className="flex items-center gap-1 text-text-primary transition-colors hover:text-accent-bright"
+          className="flex items-center gap-1 font-semibold transition-opacity hover:opacity-80"
           title="Copy full run id"
         >
-          {shortRunId(run.id)}
-          <span aria-hidden className="font-mono text-[10px] opacity-60">
+          <span className="brand-text">{shortRunId(run.id)}</span>
+          <span aria-hidden className="font-mono text-[10px] text-text-tertiary">
             ⧉
           </span>
         </button>

--- a/packages/web/src/experiments/console/components/RunDetailHeader.tsx
+++ b/packages/web/src/experiments/console/components/RunDetailHeader.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useState, type ReactElement } from 'react';
+import { Link } from 'react-router';
+import { LiveDot } from './LiveDot';
+import { OriginBadge } from './OriginBadge';
+import type { Run } from '../primitives/run';
+import { shortRunId, formatElapsed, elapsedSince } from '../lib/format';
+import { statusLabel, statusTextClass } from '../lib/run-status';
+
+interface RunDetailHeaderProps {
+  run: Run;
+  projectName: string;
+  projectId: string;
+}
+
+function useLiveElapsed(run: Run): string {
+  const [, tick] = useState(0);
+  useEffect(() => {
+    if (run.status !== 'running') return;
+    const handle = setInterval(() => {
+      tick(n => n + 1);
+    }, 1000);
+    return (): void => {
+      clearInterval(handle);
+    };
+  }, [run.status]);
+  return formatElapsed(elapsedSince(run.startedAt, run.finishedAt ?? undefined));
+}
+
+export function RunDetailHeader({
+  run,
+  projectName,
+  projectId,
+}: RunDetailHeaderProps): ReactElement {
+  const elapsed = useLiveElapsed(run);
+  const isPaused = run.status === 'paused';
+  const isRunning = run.status === 'running';
+
+  const copyRunId = async (): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(run.id);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  return (
+    <header className="sticky top-0 z-10 flex flex-wrap items-center gap-x-4 gap-y-2 border-b border-border bg-surface px-6 py-3">
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-2 font-mono text-[12px]">
+        <Link
+          to={`/console/p/${projectId}`}
+          className="text-text-tertiary transition-colors hover:text-text-primary"
+        >
+          {projectName}
+        </Link>
+        <span aria-hidden className="text-text-tertiary">
+          /
+        </span>
+        <button
+          type="button"
+          onClick={() => void copyRunId()}
+          className="flex items-center gap-1 text-text-primary transition-colors hover:text-accent-bright"
+          title="Copy full run id"
+        >
+          {shortRunId(run.id)}
+          <span aria-hidden className="font-mono text-[10px] opacity-60">
+            ⧉
+          </span>
+        </button>
+      </div>
+
+      <div className="mx-1 h-4 w-px bg-border" aria-hidden />
+
+      {/* Status pill */}
+      <div className="flex items-center gap-2">
+        {isRunning ? (
+          <LiveDot />
+        ) : isPaused ? (
+          <span aria-hidden className="h-2.5 w-2.5 animate-pulse rounded-full bg-warning" />
+        ) : (
+          <span
+            aria-hidden
+            className={`h-2 w-2 rounded-full ${
+              run.status === 'failed'
+                ? 'bg-error'
+                : run.status === 'completed'
+                  ? 'bg-success'
+                  : 'bg-text-tertiary'
+            }`}
+          />
+        )}
+        <span
+          className={`text-[11px] font-semibold uppercase tracking-[0.14em] ${statusTextClass[run.status]}`}
+        >
+          {statusLabel[run.status]}
+        </span>
+      </div>
+
+      {/* Workflow name */}
+      <span className="text-sm font-medium text-text-primary">{run.workflow}</span>
+
+      {/* Origin */}
+      <OriginBadge origin={run.origin} />
+
+      {/* Elapsed — right-aligned */}
+      <div className="ml-auto flex items-center gap-3">
+        <span className="font-mono text-[12px] tabular-nums text-text-tertiary">{elapsed}</span>
+      </div>
+    </header>
+  );
+}

--- a/packages/web/src/experiments/console/components/RunDetailHeader.tsx
+++ b/packages/web/src/experiments/console/components/RunDetailHeader.tsx
@@ -4,6 +4,7 @@ import { LiveDot } from './LiveDot';
 import { OriginBadge } from './OriginBadge';
 import type { Run } from '../primitives/run';
 import { shortRunId, formatElapsed, elapsedSince, formatCost } from '../lib/format';
+import { useIsDocker, openInIde } from '../lib/health';
 import { statusLabel, statusTextClass } from '../lib/run-status';
 
 interface RunDetailHeaderProps {
@@ -34,6 +35,8 @@ export function RunDetailHeader({
   const elapsed = useLiveElapsed(run);
   const isPaused = run.status === 'paused';
   const isRunning = run.status === 'running';
+  const isDocker = useIsDocker();
+  const canOpenIde = !isDocker && run.workingPath !== null && run.workingPath !== '';
 
   const copyRunId = async (): Promise<void> => {
     try {
@@ -108,7 +111,7 @@ export function RunDetailHeader({
       {/* Origin */}
       <OriginBadge origin={run.origin} />
 
-      {/* Cost + elapsed — right-aligned */}
+      {/* Cost + elapsed + IDE — right-aligned */}
       <div className="ml-auto flex items-center gap-3">
         {typeof run.costUsd === 'number' ? (
           <span
@@ -119,6 +122,21 @@ export function RunDetailHeader({
           </span>
         ) : null}
         <span className="font-mono text-[12px] tabular-nums text-text-tertiary">{elapsed}</span>
+        {canOpenIde && run.workingPath !== null ? (
+          <button
+            type="button"
+            onClick={() => {
+              if (run.workingPath !== null) openInIde(run.workingPath);
+            }}
+            title={`Open ${run.workingPath} in IDE`}
+            aria-label="Open in IDE"
+            className="rounded p-1 text-text-tertiary transition-colors hover:bg-surface-hover hover:text-text-primary"
+          >
+            <span aria-hidden className="font-mono text-[12px] leading-none">
+              ↗
+            </span>
+          </button>
+        ) : null}
       </div>
     </header>
   );

--- a/packages/web/src/experiments/console/components/RunDetailHeader.tsx
+++ b/packages/web/src/experiments/console/components/RunDetailHeader.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router';
 import { LiveDot } from './LiveDot';
 import { OriginBadge } from './OriginBadge';
 import type { Run } from '../primitives/run';
-import { shortRunId, formatElapsed, elapsedSince } from '../lib/format';
+import { shortRunId, formatElapsed, elapsedSince, formatCost } from '../lib/format';
 import { statusLabel, statusTextClass } from '../lib/run-status';
 
 interface RunDetailHeaderProps {
@@ -108,8 +108,16 @@ export function RunDetailHeader({
       {/* Origin */}
       <OriginBadge origin={run.origin} />
 
-      {/* Elapsed — right-aligned */}
+      {/* Cost + elapsed — right-aligned */}
       <div className="ml-auto flex items-center gap-3">
+        {typeof run.costUsd === 'number' ? (
+          <span
+            className="font-mono text-[12px] tabular-nums text-text-secondary"
+            title="Total agent cost"
+          >
+            {formatCost(run.costUsd)}
+          </span>
+        ) : null}
         <span className="font-mono text-[12px] tabular-nums text-text-tertiary">{elapsed}</span>
       </div>
     </header>

--- a/packages/web/src/experiments/console/components/RunGraphPanel.tsx
+++ b/packages/web/src/experiments/console/components/RunGraphPanel.tsx
@@ -19,13 +19,12 @@ interface RunGraphPanelProps {
   onNodeSelect?: (nodeId: string) => void;
 }
 
-// Compact node dimensions — sidebar-friendly. dagre positions by center.
-// Tuned so 3 parallel nodes fit inside a 380px panel without horizontal scroll.
-const NODE_W = 104;
-const NODE_H = 28;
-const RANK_SEP = 32;
-const NODE_SEP = 10;
-const PADDING = 16;
+// Full-canvas node dimensions. dagre positions by center.
+const NODE_W = 160;
+const NODE_H = 40;
+const RANK_SEP = 56;
+const NODE_SEP = 20;
+const PADDING = 24;
 
 interface LaidOutNode extends WorkflowGraphNodeWithStatus {
   x: number;
@@ -149,9 +148,12 @@ function kindGlyph(k: WorkflowNodeKind): string {
 }
 
 /**
- * Compact DAG sidebar. Uses dagre (rankdir=TB) so parallel nodes sit side by
- * side and fan-in/out are visible. Loop nodes show a ↻ glyph; approval nodes
- * show ◈. Click a node to jump the stream to that node's transition.
+ * Full-canvas DAG view. Uses dagre (rankdir=TB) so parallel nodes sit side
+ * by side and fan-in/out are visible. Loop nodes show a ↻ glyph; approval
+ * nodes show ◈. Click a node to jump the stream to that node's transition.
+ *
+ * Renders as a full-width content panel — the calling layout provides the
+ * outer flex container (no internal border/aside).
  */
 export function RunGraphPanel({
   workflowName,
@@ -172,22 +174,14 @@ export function RunGraphPanel({
 
   if (error !== undefined) {
     return (
-      <aside className="flex h-full w-[420px] shrink-0 flex-col border-l border-border bg-surface-inset">
-        <Header />
-        <div className="p-3 font-mono text-[11px] text-error">
-          Could not load graph: {error.message}
-        </div>
-      </aside>
+      <div className="p-6 font-mono text-[12px] text-error">
+        Could not load graph: {error.message}
+      </div>
     );
   }
 
   if (laid === null) {
-    return (
-      <aside className="flex h-full w-[420px] shrink-0 flex-col border-l border-border bg-surface-inset">
-        <Header />
-        <div className="p-3 text-[11px] text-text-tertiary">Loading graph…</div>
-      </aside>
-    );
+    return <div className="p-6 text-[12px] text-text-tertiary">Loading graph…</div>;
   }
 
   const { nodes, edges, width, height } = laid;
@@ -197,50 +191,35 @@ export function RunGraphPanel({
   };
 
   return (
-    <aside className="flex h-full w-[420px] shrink-0 flex-col border-l border-border bg-surface-inset">
-      <Header />
-      <div className="flex-1 overflow-auto p-2">
-        <div className="relative" style={svgStyle}>
-          <svg
-            className="absolute inset-0"
-            width={svgStyle.width}
-            height={svgStyle.height}
-            aria-hidden
-          >
-            {edges.map(e => (
-              <path
-                key={`${e.from}→${e.to}`}
-                d={polyline(e.points)}
-                fill="none"
-                stroke="color-mix(in oklch, var(--border), transparent 30%)"
-                strokeWidth={1}
-              />
-            ))}
-          </svg>
-          {nodes.map(n => (
-            <GraphNode
-              key={n.id}
-              node={n}
-              onClick={() => {
-                onNodeSelect?.(n.id);
-              }}
+    <div className="flex h-full w-full justify-center overflow-auto bg-surface-inset p-6">
+      <div className="relative" style={svgStyle}>
+        <svg
+          className="absolute inset-0"
+          width={svgStyle.width}
+          height={svgStyle.height}
+          aria-hidden
+        >
+          {edges.map(e => (
+            <path
+              key={`${e.from}→${e.to}`}
+              d={polyline(e.points)}
+              fill="none"
+              stroke="color-mix(in oklch, var(--border), transparent 30%)"
+              strokeWidth={1.5}
             />
           ))}
-        </div>
+        </svg>
+        {nodes.map(n => (
+          <GraphNode
+            key={n.id}
+            node={n}
+            onClick={() => {
+              onNodeSelect?.(n.id);
+            }}
+          />
+        ))}
       </div>
-    </aside>
-  );
-}
-
-function Header(): ReactElement {
-  return (
-    <header className="relative flex items-center justify-between px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-text-secondary">
-      <span>Graph</span>
-      <span
-        aria-hidden
-        className="brand-bar pointer-events-none absolute inset-x-0 bottom-0 h-px opacity-60"
-      />
-    </header>
+    </div>
   );
 }
 
@@ -268,10 +247,10 @@ function GraphNode({ node, onClick }: GraphNodeProps): ReactElement {
       className={`absolute flex items-center gap-2 overflow-hidden rounded border px-2 text-left transition-colors hover:brightness-110 ${running ? 'animate-pulse' : ''}`}
       style={style}
     >
-      <span aria-hidden className="shrink-0 font-mono text-[11px] text-text-tertiary">
+      <span aria-hidden className="shrink-0 font-mono text-[13px] text-text-tertiary">
         {kindGlyph(node.kind)}
       </span>
-      <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-text-primary">
+      <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-text-primary">
         {node.id}
       </span>
     </button>

--- a/packages/web/src/experiments/console/components/RunGraphPanel.tsx
+++ b/packages/web/src/experiments/console/components/RunGraphPanel.tsx
@@ -1,0 +1,275 @@
+import { useMemo, type CSSProperties, type ReactElement } from 'react';
+import dagre from '@dagrejs/dagre';
+import { useEntity } from '../store/cache';
+import * as skill from '../skills';
+import {
+  deriveNodeStatuses,
+  type WorkflowGraphNode,
+  type WorkflowGraphNodeWithStatus,
+  type WorkflowNodeKind,
+  type WorkflowNodeStatus,
+} from '../primitives/workflow-graph';
+import type { RunEvent } from '../primitives/event';
+
+interface RunGraphPanelProps {
+  workflowName: string;
+  projectCwd: string;
+  events: RunEvent[];
+  /** The node the main stream should scroll to when a graph node is clicked. */
+  onNodeSelect?: (nodeId: string) => void;
+}
+
+// Compact node dimensions — sidebar-friendly. dagre positions by center.
+// Tuned so 3 parallel nodes fit inside a 380px panel without horizontal scroll.
+const NODE_W = 104;
+const NODE_H = 28;
+const RANK_SEP = 32;
+const NODE_SEP = 10;
+const PADDING = 16;
+
+interface LaidOutNode extends WorkflowGraphNodeWithStatus {
+  x: number;
+  y: number;
+}
+
+interface Edge {
+  from: string;
+  to: string;
+  points: { x: number; y: number }[];
+}
+
+interface Layout {
+  nodes: LaidOutNode[];
+  edges: Edge[];
+  width: number;
+  height: number;
+}
+
+function layout(nodes: WorkflowGraphNodeWithStatus[]): Layout {
+  const g = new dagre.graphlib.Graph();
+  g.setDefaultEdgeLabel(() => ({}));
+  g.setGraph({
+    rankdir: 'TB',
+    ranksep: RANK_SEP,
+    nodesep: NODE_SEP,
+    marginx: PADDING,
+    marginy: PADDING,
+  });
+
+  for (const n of nodes) {
+    g.setNode(n.id, { width: NODE_W, height: NODE_H });
+  }
+  for (const n of nodes) {
+    for (const d of n.dependsOn) {
+      // Only set edges whose source exists (robust against malformed DAGs).
+      if (g.hasNode(d)) g.setEdge(d, n.id);
+    }
+  }
+
+  dagre.layout(g);
+
+  const laid: LaidOutNode[] = nodes.map(n => {
+    const pos = g.node(n.id) as { x: number; y: number } | undefined;
+    return {
+      ...n,
+      x: pos ? pos.x - NODE_W / 2 : 0,
+      y: pos ? pos.y - NODE_H / 2 : 0,
+    };
+  });
+
+  const edges: Edge[] = [];
+  for (const e of g.edges()) {
+    const data = g.edge(e) as { points?: { x: number; y: number }[] };
+    if (data.points !== undefined) {
+      edges.push({ from: e.v, to: e.w, points: data.points });
+    }
+  }
+
+  const graph = g.graph();
+  return {
+    nodes: laid,
+    edges,
+    width: graph.width ?? 0,
+    height: graph.height ?? 0,
+  };
+}
+
+function polyline(points: { x: number; y: number }[]): string {
+  return points
+    .map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x.toString()},${p.y.toString()}`)
+    .join(' ');
+}
+
+/* Status → color (CSS var reference so the warm theme can retune). */
+function statusFill(s: WorkflowNodeStatus): string {
+  switch (s) {
+    case 'running':
+      return 'color-mix(in oklch, var(--running), transparent 82%)';
+    case 'completed':
+      return 'color-mix(in oklch, var(--success), transparent 84%)';
+    case 'failed':
+      return 'color-mix(in oklch, var(--error), transparent 82%)';
+    case 'skipped':
+      return 'color-mix(in oklch, var(--text-tertiary), transparent 90%)';
+    case 'pending':
+      return 'var(--surface-inset)';
+  }
+}
+
+function statusBorder(s: WorkflowNodeStatus): string {
+  switch (s) {
+    case 'running':
+      return 'var(--running)';
+    case 'completed':
+      return 'var(--success)';
+    case 'failed':
+      return 'var(--error)';
+    case 'skipped':
+      return 'var(--border)';
+    case 'pending':
+      return 'var(--border)';
+  }
+}
+
+function kindGlyph(k: WorkflowNodeKind): string {
+  switch (k) {
+    case 'loop':
+      return '↻';
+    case 'approval':
+      return '◈';
+    case 'bash':
+      return '$';
+    case 'command':
+      return '/';
+    case 'script':
+      return '⧉';
+    case 'prompt':
+      return '·';
+  }
+}
+
+/**
+ * Compact DAG sidebar. Uses dagre (rankdir=TB) so parallel nodes sit side by
+ * side and fan-in/out are visible. Loop nodes show a ↻ glyph; approval nodes
+ * show ◈. Click a node to jump the stream to that node's transition.
+ */
+export function RunGraphPanel({
+  workflowName,
+  projectCwd,
+  events,
+  onNodeSelect,
+}: RunGraphPanelProps): ReactElement {
+  const { data: rawNodes, error } = useEntity<WorkflowGraphNode[]>(
+    `workflow-graph:${workflowName}:${projectCwd}`,
+    () => skill.getWorkflowGraph(workflowName, projectCwd)
+  );
+
+  const laid = useMemo(() => {
+    if (rawNodes === undefined) return null;
+    const withStatus = deriveNodeStatuses(rawNodes, events);
+    return layout(withStatus);
+  }, [rawNodes, events]);
+
+  if (error !== undefined) {
+    return (
+      <aside className="flex h-full w-[420px] shrink-0 flex-col border-l border-border bg-surface-inset">
+        <Header />
+        <div className="p-3 font-mono text-[11px] text-error">
+          Could not load graph: {error.message}
+        </div>
+      </aside>
+    );
+  }
+
+  if (laid === null) {
+    return (
+      <aside className="flex h-full w-[420px] shrink-0 flex-col border-l border-border bg-surface-inset">
+        <Header />
+        <div className="p-3 text-[11px] text-text-tertiary">Loading graph…</div>
+      </aside>
+    );
+  }
+
+  const { nodes, edges, width, height } = laid;
+  const svgStyle: CSSProperties = {
+    width: Math.max(width, NODE_W + PADDING * 2),
+    height: Math.max(height, NODE_H + PADDING * 2),
+  };
+
+  return (
+    <aside className="flex h-full w-[420px] shrink-0 flex-col border-l border-border bg-surface-inset">
+      <Header />
+      <div className="flex-1 overflow-auto p-2">
+        <div className="relative" style={svgStyle}>
+          <svg
+            className="absolute inset-0"
+            width={svgStyle.width}
+            height={svgStyle.height}
+            aria-hidden
+          >
+            {edges.map(e => (
+              <path
+                key={`${e.from}→${e.to}`}
+                d={polyline(e.points)}
+                fill="none"
+                stroke="color-mix(in oklch, var(--border), transparent 30%)"
+                strokeWidth={1}
+              />
+            ))}
+          </svg>
+          {nodes.map(n => (
+            <GraphNode
+              key={n.id}
+              node={n}
+              onClick={() => {
+                onNodeSelect?.(n.id);
+              }}
+            />
+          ))}
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+function Header(): ReactElement {
+  return (
+    <header className="flex items-center justify-between border-b border-border/60 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-text-tertiary">
+      <span>Graph</span>
+    </header>
+  );
+}
+
+interface GraphNodeProps {
+  node: LaidOutNode;
+  onClick: () => void;
+}
+
+function GraphNode({ node, onClick }: GraphNodeProps): ReactElement {
+  const running = node.status === 'running';
+  const style: CSSProperties = {
+    left: node.x,
+    top: node.y,
+    width: NODE_W,
+    height: NODE_H,
+    backgroundColor: statusFill(node.status),
+    borderColor: statusBorder(node.status),
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={`${node.id} · ${node.kind} · ${node.status}`}
+      className={`absolute flex items-center gap-2 overflow-hidden rounded border px-2 text-left transition-colors hover:brightness-110 ${running ? 'animate-pulse' : ''}`}
+      style={style}
+    >
+      <span aria-hidden className="shrink-0 font-mono text-[11px] text-text-tertiary">
+        {kindGlyph(node.kind)}
+      </span>
+      <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-text-primary">
+        {node.id}
+      </span>
+    </button>
+  );
+}

--- a/packages/web/src/experiments/console/components/RunGraphPanel.tsx
+++ b/packages/web/src/experiments/console/components/RunGraphPanel.tsx
@@ -234,8 +234,12 @@ export function RunGraphPanel({
 
 function Header(): ReactElement {
   return (
-    <header className="flex items-center justify-between border-b border-border/60 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-text-tertiary">
+    <header className="relative flex items-center justify-between px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-text-secondary">
       <span>Graph</span>
+      <span
+        aria-hidden
+        className="brand-bar pointer-events-none absolute inset-x-0 bottom-0 h-px opacity-60"
+      />
     </header>
   );
 }

--- a/packages/web/src/experiments/console/components/RunStream.tsx
+++ b/packages/web/src/experiments/console/components/RunStream.tsx
@@ -4,6 +4,7 @@ import { ToolCallItem } from './ToolCallItem';
 import { NodeDivider } from './NodeDivider';
 import { ArtifactItem } from './ArtifactItem';
 import type { InlineToolCall, Message } from '../primitives/message';
+import { isSystemCategory } from '../primitives/message';
 import type {
   RunEvent,
   NodeTransitionEvent,
@@ -33,12 +34,19 @@ function isMeaningful(m: Message): boolean {
   return false;
 }
 
+interface SystemRow {
+  label: string;
+  detail: string;
+  timestamp: string;
+}
+
 type TimelineEntry =
   | { kind: 'message'; key: string; at: number; message: Message }
   | { kind: 'tool'; key: string; at: number; call: InlineToolCall; timestamp: string }
-  | { kind: 'node'; key: string; at: number; event: NodeTransitionEvent }
+  | { kind: 'node'; key: string; at: number; event: NodeTransitionEvent; showDetail: boolean }
   | { kind: 'artifact'; key: string; at: number; event: ArtifactEvent }
-  | { kind: 'system'; key: string; at: number; event: SystemEvent | ErrorEvent };
+  | { kind: 'system'; key: string; at: number; event: SystemEvent | ErrorEvent }
+  | { kind: 'system_row'; key: string; at: number; row: SystemRow };
 
 /**
  * Pairs `tool_called` events with their matching `tool_completed` so each
@@ -118,10 +126,57 @@ export function RunStream({
     const entries: TimelineEntry[] = [];
     let inlineToolCount = 0;
     for (const m of messages) {
-      if (!isMeaningful(m)) continue;
-      // System messages are filtered later by `visible`; keep them in the
-      // timeline so the toggle can flip without rebuilding.
       const base = new Date(m.timestamp).getTime();
+      const meaningful = isMeaningful(m);
+      const isSystemy = isSystemCategory(m.category) || m.role === 'system';
+
+      if (isSystemy) {
+        // Framework chatter — surface as a compact system row instead of
+        // rendering as agent prose. Dispatch metadata gets its own row when
+        // present so the workflow name shows up explicitly.
+        if (m.dispatch !== null) {
+          entries.push({
+            kind: 'system_row',
+            key: `sm:dispatch:${m.id}`,
+            at: base,
+            row: {
+              label: 'Workflow dispatch',
+              detail: m.dispatch.workflowName,
+              timestamp: m.timestamp,
+            },
+          });
+        } else {
+          entries.push({
+            kind: 'system_row',
+            key: `sm:${m.id}`,
+            at: base,
+            row: {
+              label: m.category ?? 'System',
+              detail: m.content.split('\n')[0]?.slice(0, 160) ?? '',
+              timestamp: m.timestamp,
+            },
+          });
+        }
+        continue;
+      }
+
+      if (!meaningful) {
+        // Empty / no-signal messages — usually plumbing the SDK emits. Hide
+        // by default; behind System the user gets a noise row to see the
+        // gap that would otherwise be invisible.
+        entries.push({
+          kind: 'system_row',
+          key: `sm:noise:${m.id}`,
+          at: base,
+          row: {
+            label: 'Noise',
+            detail: `${m.role} · no content`,
+            timestamp: m.timestamp,
+          },
+        });
+        continue;
+      }
+
       entries.push({ kind: 'message', key: `m:${m.id}`, at: base, message: m });
       m.toolCalls.forEach((call, idx) => {
         inlineToolCount += 1;
@@ -153,7 +208,7 @@ export function RunStream({
     for (const e of events) {
       const at = new Date(e.timestamp).getTime();
       if (e.kind === 'node_transition') {
-        entries.push({ kind: 'node', key: `n:${e.id}`, at, event: e });
+        entries.push({ kind: 'node', key: `n:${e.id}`, at, event: e, showDetail: showSystem });
       } else if (e.kind === 'artifact') {
         entries.push({ kind: 'artifact', key: `a:${e.id}`, at, event: e });
       } else if (e.kind === 'system' || e.kind === 'error') {
@@ -162,12 +217,12 @@ export function RunStream({
     }
     entries.sort((a, b) => a.at - b.at);
     return entries;
-  }, [messages, events]);
+  }, [messages, events, showSystem]);
 
   const visible = timeline.filter(e => {
     if (e.kind === 'tool' && !showToolCalls) return false;
     if (e.kind === 'system' && !showSystem) return false;
-    if (e.kind === 'message' && e.message.role === 'system' && !showSystem) return false;
+    if (e.kind === 'system_row' && !showSystem) return false;
     return true;
   });
 
@@ -199,6 +254,9 @@ export function RunStream({
               transition={entry.event.transition}
               durationMs={entry.event.durationMs}
               timestamp={entry.event.timestamp}
+              skipReason={entry.event.skipReason}
+              skipExpr={entry.event.skipExpr}
+              showDetail={entry.showDetail}
             />
           );
         }
@@ -218,6 +276,24 @@ export function RunStream({
                 detail.length > 0 ? (
                   <span className="truncate font-mono text-[11px] text-text-secondary">
                     {detail}
+                  </span>
+                ) : null
+              }
+            />
+          );
+        }
+        if (entry.kind === 'system_row') {
+          return (
+            <StreamCard
+              key={entry.key}
+              timestamp={entry.row.timestamp}
+              kind="system"
+              compact
+              label={entry.row.label}
+              headerRight={
+                entry.row.detail.length > 0 ? (
+                  <span className="truncate font-mono text-[11px] text-text-secondary">
+                    {entry.row.detail}
                   </span>
                 ) : null
               }

--- a/packages/web/src/experiments/console/components/RunStream.tsx
+++ b/packages/web/src/experiments/console/components/RunStream.tsx
@@ -9,7 +9,10 @@ import type {
   NodeTransitionEvent,
   ArtifactEvent,
   ToolCallEvent,
+  SystemEvent,
+  ErrorEvent,
 } from '../primitives/event';
+import { StreamCard } from './StreamCard';
 
 interface RunStreamProps {
   messages: Message[];
@@ -34,7 +37,8 @@ type TimelineEntry =
   | { kind: 'message'; key: string; at: number; message: Message }
   | { kind: 'tool'; key: string; at: number; call: InlineToolCall; timestamp: string }
   | { kind: 'node'; key: string; at: number; event: NodeTransitionEvent }
-  | { kind: 'artifact'; key: string; at: number; event: ArtifactEvent };
+  | { kind: 'artifact'; key: string; at: number; event: ArtifactEvent }
+  | { kind: 'system'; key: string; at: number; event: SystemEvent | ErrorEvent };
 
 /**
  * Pairs `tool_called` events with their matching `tool_completed` so each
@@ -115,7 +119,8 @@ export function RunStream({
     let inlineToolCount = 0;
     for (const m of messages) {
       if (!isMeaningful(m)) continue;
-      if (!showSystem && m.role === 'system') continue;
+      // System messages are filtered later by `visible`; keep them in the
+      // timeline so the toggle can flip without rebuilding.
       const base = new Date(m.timestamp).getTime();
       entries.push({ kind: 'message', key: `m:${m.id}`, at: base, message: m });
       m.toolCalls.forEach((call, idx) => {
@@ -151,13 +156,20 @@ export function RunStream({
         entries.push({ kind: 'node', key: `n:${e.id}`, at, event: e });
       } else if (e.kind === 'artifact') {
         entries.push({ kind: 'artifact', key: `a:${e.id}`, at, event: e });
+      } else if (e.kind === 'system' || e.kind === 'error') {
+        entries.push({ kind: 'system', key: `s:${e.id}`, at, event: e });
       }
     }
     entries.sort((a, b) => a.at - b.at);
     return entries;
-  }, [messages, events, showSystem]);
+  }, [messages, events]);
 
-  const visible = showToolCalls ? timeline : timeline.filter(e => e.kind !== 'tool');
+  const visible = timeline.filter(e => {
+    if (e.kind === 'tool' && !showToolCalls) return false;
+    if (e.kind === 'system' && !showSystem) return false;
+    if (e.kind === 'message' && e.message.role === 'system' && !showSystem) return false;
+    return true;
+  });
 
   if (visible.length === 0) {
     return (
@@ -187,6 +199,28 @@ export function RunStream({
               transition={entry.event.transition}
               durationMs={entry.event.durationMs}
               timestamp={entry.event.timestamp}
+            />
+          );
+        }
+        if (entry.kind === 'system') {
+          const ev = entry.event;
+          const isError = ev.kind === 'error';
+          const label = isError ? 'Error' : ev.label;
+          const detail = isError ? ev.message : ev.detail;
+          return (
+            <StreamCard
+              key={entry.key}
+              timestamp={ev.timestamp}
+              kind={isError ? 'error' : 'system'}
+              compact
+              label={label}
+              headerRight={
+                detail.length > 0 ? (
+                  <span className="truncate font-mono text-[11px] text-text-secondary">
+                    {detail}
+                  </span>
+                ) : null
+              }
             />
           );
         }

--- a/packages/web/src/experiments/console/components/RunStream.tsx
+++ b/packages/web/src/experiments/console/components/RunStream.tsx
@@ -1,0 +1,124 @@
+import { useMemo, type ReactElement } from 'react';
+import { MessageItem } from './MessageItem';
+import { ToolCallItem } from './ToolCallItem';
+import { NodeDivider } from './NodeDivider';
+import { ArtifactItem } from './ArtifactItem';
+import type { InlineToolCall, Message } from '../primitives/message';
+import type { RunEvent, NodeTransitionEvent, ArtifactEvent } from '../primitives/event';
+
+interface RunStreamProps {
+  messages: Message[];
+  events: RunEvent[];
+  showToolCalls: boolean;
+  showSystem: boolean;
+}
+
+/**
+ * Drop messages that carry no signal — no prose, no tool calls, no error.
+ * These are usually workflow-plumbing artifacts that render as "(no content)"
+ * cards otherwise.
+ */
+function isMeaningful(m: Message): boolean {
+  if (m.content.trim().length > 0) return true;
+  if (m.toolCalls.length > 0) return true;
+  if (m.error !== null) return true;
+  return false;
+}
+
+type TimelineEntry =
+  | { kind: 'message'; key: string; at: number; message: Message }
+  | { kind: 'tool'; key: string; at: number; call: InlineToolCall; timestamp: string }
+  | { kind: 'node'; key: string; at: number; event: NodeTransitionEvent }
+  | { kind: 'artifact'; key: string; at: number; event: ArtifactEvent };
+
+/**
+ * Merges conversation messages + workflow events into a single timeline.
+ *
+ * Tool calls live inside each message's metadata. We break them out into
+ * their own timeline entries (keyed under the message's timestamp, with a
+ * tiny per-tool offset for stable ordering) so each one renders as its own
+ * small card and the `showToolCalls` toggle can hide them cleanly.
+ *
+ * What we deliberately skip here:
+ *   - `tool_call` *events* from workflow_events — conversation metadata is
+ *     authoritative, rendering both would double-display.
+ *   - `approval` events — the RunDetailPage renders an inline ApprovalPanel
+ *     below the stream instead.
+ *   - `text` / `error` events — messages are the source of truth for text;
+ *     errors surface via the run status + action bar.
+ */
+export function RunStream({
+  messages,
+  events,
+  showToolCalls,
+  showSystem,
+}: RunStreamProps): ReactElement {
+  const timeline = useMemo<TimelineEntry[]>(() => {
+    const entries: TimelineEntry[] = [];
+    for (const m of messages) {
+      if (!isMeaningful(m)) continue;
+      if (!showSystem && m.role === 'system') continue;
+      const base = new Date(m.timestamp).getTime();
+      entries.push({ kind: 'message', key: `m:${m.id}`, at: base, message: m });
+      m.toolCalls.forEach((call, idx) => {
+        entries.push({
+          kind: 'tool',
+          key: `t:${m.id}:${idx.toString()}`,
+          // Place tool calls just after the parent message so they appear right
+          // below it but don't collide across sibling messages.
+          at: base + idx + 1,
+          call,
+          timestamp: m.timestamp,
+        });
+      });
+    }
+    for (const e of events) {
+      const at = new Date(e.timestamp).getTime();
+      if (e.kind === 'node_transition') {
+        entries.push({ kind: 'node', key: `n:${e.id}`, at, event: e });
+      } else if (e.kind === 'artifact') {
+        entries.push({ kind: 'artifact', key: `a:${e.id}`, at, event: e });
+      }
+    }
+    entries.sort((a, b) => a.at - b.at);
+    return entries;
+  }, [messages, events, showSystem]);
+
+  const visible = showToolCalls ? timeline : timeline.filter(e => e.kind !== 'tool');
+
+  if (visible.length === 0) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center text-center">
+        <div className="flex flex-col items-center gap-2 text-text-tertiary">
+          <span className="h-2 w-2 animate-pulse rounded-full bg-[color:var(--running)]" />
+          <p className="text-sm">Waiting for first event…</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {visible.map(entry => {
+        if (entry.kind === 'message') {
+          return <MessageItem key={entry.key} message={entry.message} />;
+        }
+        if (entry.kind === 'tool') {
+          return <ToolCallItem key={entry.key} call={entry.call} timestamp={entry.timestamp} />;
+        }
+        if (entry.kind === 'node') {
+          return (
+            <NodeDivider
+              key={entry.key}
+              nodeName={entry.event.nodeName}
+              transition={entry.event.transition}
+              durationMs={entry.event.durationMs}
+              timestamp={entry.event.timestamp}
+            />
+          );
+        }
+        return <ArtifactItem key={entry.key} event={entry.event} />;
+      })}
+    </div>
+  );
+}

--- a/packages/web/src/experiments/console/components/RunStream.tsx
+++ b/packages/web/src/experiments/console/components/RunStream.tsx
@@ -4,7 +4,12 @@ import { ToolCallItem } from './ToolCallItem';
 import { NodeDivider } from './NodeDivider';
 import { ArtifactItem } from './ArtifactItem';
 import type { InlineToolCall, Message } from '../primitives/message';
-import type { RunEvent, NodeTransitionEvent, ArtifactEvent } from '../primitives/event';
+import type {
+  RunEvent,
+  NodeTransitionEvent,
+  ArtifactEvent,
+  ToolCallEvent,
+} from '../primitives/event';
 
 interface RunStreamProps {
   messages: Message[];
@@ -32,17 +37,69 @@ type TimelineEntry =
   | { kind: 'artifact'; key: string; at: number; event: ArtifactEvent };
 
 /**
+ * Pairs `tool_called` events with their matching `tool_completed` so each
+ * call surfaces as a single InlineToolCall with input + duration.
+ *
+ * Pairing key: step name. The orchestrator emits the events sequentially
+ * within a step, so taking the next unclaimed `tool_completed` after each
+ * `tool_called` for the same step is correct.
+ *
+ * Returns one InlineToolCall per `tool_called` event, in event order. The
+ * `tool_completed` event contributes only `durationMs`.
+ */
+interface PairedToolCall {
+  id: string;
+  timestamp: string;
+  call: InlineToolCall;
+}
+
+function pairToolEvents(events: RunEvent[]): PairedToolCall[] {
+  const toolEvents = events.filter((e): e is ToolCallEvent => e.kind === 'tool_call');
+  // Track unclaimed completed events per step so each call gets exactly one.
+  const completedByStep = new Map<string, ToolCallEvent[]>();
+  for (const e of toolEvents) {
+    if (e.result === null) continue; // start event; skip here
+    const key = e.nodeId ?? '';
+    const list = completedByStep.get(key) ?? [];
+    list.push(e);
+    completedByStep.set(key, list);
+  }
+
+  const paired: PairedToolCall[] = [];
+  for (const e of toolEvents) {
+    if (e.result !== null) continue; // only seed from start events
+    const key = e.nodeId ?? '';
+    const pool = completedByStep.get(key);
+    const match = pool !== undefined && pool.length > 0 ? pool.shift() : undefined;
+    const input =
+      typeof e.args === 'object' && e.args !== null ? (e.args as Record<string, unknown>) : {};
+    paired.push({
+      id: e.id,
+      timestamp: e.timestamp,
+      call: {
+        name: e.tool || '(unknown)',
+        input,
+        durationMs: match?.result?.ok === true ? match.result.durationMs : undefined,
+      },
+    });
+  }
+  return paired;
+}
+
+/**
  * Merges conversation messages + workflow events into a single timeline.
  *
- * Tool calls live inside each message's metadata. We break them out into
- * their own timeline entries (keyed under the message's timestamp, with a
- * tiny per-tool offset for stable ordering) so each one renders as its own
- * small card and the `showToolCalls` toggle can hide them cleanly.
+ * Tool-call source-of-truth depends on the workflow's provider:
+ *   - Claude runs persist tool calls in `message.metadata.toolCalls`
+ *   - Pi / Codex / bash nodes persist them as `tool_called`/`tool_completed`
+ *     workflow events
+ *
+ * When any message has inline tool calls we treat the conversation as
+ * authoritative (avoids double-display on Claude). Otherwise we surface the
+ * paired workflow tool events.
  *
  * What we deliberately skip here:
- *   - `tool_call` *events* from workflow_events — conversation metadata is
- *     authoritative, rendering both would double-display.
- *   - `approval` events — the RunDetailPage renders an inline ApprovalPanel
+ *   - `approval` events — RunDetailPage renders an inline ApprovalPanel
  *     below the stream instead.
  *   - `text` / `error` events — messages are the source of truth for text;
  *     errors surface via the run status + action bar.
@@ -55,12 +112,14 @@ export function RunStream({
 }: RunStreamProps): ReactElement {
   const timeline = useMemo<TimelineEntry[]>(() => {
     const entries: TimelineEntry[] = [];
+    let inlineToolCount = 0;
     for (const m of messages) {
       if (!isMeaningful(m)) continue;
       if (!showSystem && m.role === 'system') continue;
       const base = new Date(m.timestamp).getTime();
       entries.push({ kind: 'message', key: `m:${m.id}`, at: base, message: m });
       m.toolCalls.forEach((call, idx) => {
+        inlineToolCount += 1;
         entries.push({
           kind: 'tool',
           key: `t:${m.id}:${idx.toString()}`,
@@ -72,6 +131,20 @@ export function RunStream({
         });
       });
     }
+
+    // If no inline tool calls came from messages, surface workflow tool events.
+    if (inlineToolCount === 0) {
+      for (const t of pairToolEvents(events)) {
+        entries.push({
+          kind: 'tool',
+          key: `wt:${t.id}`,
+          at: new Date(t.timestamp).getTime(),
+          call: t.call,
+          timestamp: t.timestamp,
+        });
+      }
+    }
+
     for (const e of events) {
       const at = new Date(e.timestamp).getTime();
       if (e.kind === 'node_transition') {

--- a/packages/web/src/experiments/console/components/StatusDot.tsx
+++ b/packages/web/src/experiments/console/components/StatusDot.tsx
@@ -1,0 +1,17 @@
+import type { ReactElement } from 'react';
+import { statusDotClass, type RunStatus } from '../lib/run-status';
+
+interface StatusDotProps {
+  status: RunStatus;
+  size?: number;
+}
+
+export function StatusDot({ status, size = 8 }: StatusDotProps): ReactElement {
+  return (
+    <span
+      aria-hidden="true"
+      className={`inline-block rounded-full ${statusDotClass[status]}`}
+      style={{ width: size, height: size }}
+    />
+  );
+}

--- a/packages/web/src/experiments/console/components/StatusStrip.tsx
+++ b/packages/web/src/experiments/console/components/StatusStrip.tsx
@@ -1,0 +1,12 @@
+import type { ReactElement } from 'react';
+import { statusStripClass, type RunStatus } from '../lib/run-status';
+
+/** 4px vertical strip flush-left on a run card. */
+export function StatusStrip({ status }: { status: RunStatus }): ReactElement {
+  return (
+    <span
+      aria-hidden="true"
+      className={`absolute left-0 top-0 h-full w-1 ${statusStripClass[status]}`}
+    />
+  );
+}

--- a/packages/web/src/experiments/console/components/StreamCard.tsx
+++ b/packages/web/src/experiments/console/components/StreamCard.tsx
@@ -1,0 +1,99 @@
+import type { ReactElement, ReactNode } from 'react';
+import { formatClock, formatRelativeToBaseline } from '../lib/format';
+import { useStreamContext } from '../lib/stream-context';
+
+interface StreamCardProps {
+  timestamp: string;
+  kind: 'user' | 'assistant' | 'system' | 'tool' | 'artifact' | 'error';
+  /** Optional extra element rendered in the header row, right-aligned. */
+  headerRight?: ReactNode;
+  /** Label override. Defaults to the kind, uppercased. */
+  label?: string;
+  children?: ReactNode;
+  /** Tighter padding + no header margin; header sits on the same row as the only content. */
+  compact?: boolean;
+  /** Click handler — makes the whole card a clickable affordance (tool-call expand). */
+  onClick?: () => void;
+}
+
+const KIND_STYLES: Record<
+  StreamCardProps['kind'],
+  { label: string; pill: string; border: string }
+> = {
+  user: {
+    label: 'You',
+    pill: 'bg-surface-elevated text-text-primary',
+    border: 'border-border',
+  },
+  assistant: {
+    label: 'Agent',
+    pill: 'bg-surface-elevated text-text-primary',
+    border: 'border-border',
+  },
+  system: {
+    label: 'System',
+    pill: 'bg-surface-elevated text-text-tertiary',
+    border: 'border-border',
+  },
+  tool: {
+    label: 'Tool',
+    pill: 'bg-surface-inset text-text-secondary',
+    border: 'border-border/60',
+  },
+  artifact: {
+    label: 'Artifact',
+    pill: 'bg-success/15 text-success',
+    border: 'border-success/30',
+  },
+  error: {
+    label: 'Error',
+    pill: 'bg-error/15 text-error',
+    border: 'border-error/30',
+  },
+};
+
+/**
+ * Shared small-card shell for every entry in the run stream. Consistent
+ * header (timestamp + role pill) with variant-specific body.
+ */
+export function StreamCard({
+  timestamp,
+  kind,
+  headerRight,
+  label,
+  children,
+  compact = false,
+  onClick,
+}: StreamCardProps): ReactElement {
+  const style = KIND_STYLES[kind];
+  const { runStartedAt } = useStreamContext();
+  const displayed = formatRelativeToBaseline(timestamp, runStartedAt);
+  const wallClock = formatClock(timestamp);
+  return (
+    <article
+      onClick={onClick}
+      className={`rounded border ${style.border} bg-surface px-3 ${
+        compact ? 'py-1.5' : 'py-2'
+      } ${onClick !== undefined ? 'cursor-pointer transition-colors hover:bg-surface-hover' : ''}`}
+    >
+      <header className={`flex items-center gap-2 ${compact ? '' : 'mb-1.5'}`}>
+        <time
+          dateTime={timestamp}
+          title={wallClock}
+          className="font-mono text-[10px] tabular-nums text-text-tertiary"
+        >
+          {displayed}
+        </time>
+        <span
+          className={`rounded px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em] ${style.pill}`}
+        >
+          {label ?? style.label}
+        </span>
+        {headerRight !== undefined ? (
+          <div className="ml-auto flex items-center gap-2">{headerRight}</div>
+        ) : null}
+      </header>
+      {children}
+    </article>
+  );
+}

--- a/packages/web/src/experiments/console/components/StreamCard.tsx
+++ b/packages/web/src/experiments/console/components/StreamCard.tsx
@@ -16,18 +16,22 @@ interface StreamCardProps {
   onClick?: () => void;
 }
 
+// Role pills carry the brand duotone: the user's voice reads as magenta
+// (presence / authorship); the agent's voice reads as teal (execution).
+// Tool/system/artifact/error stay semantic — they signal kind-of-event, not
+// who-is-speaking.
 const KIND_STYLES: Record<
   StreamCardProps['kind'],
   { label: string; pill: string; border: string }
 > = {
   user: {
     label: 'You',
-    pill: 'bg-surface-elevated text-text-primary',
+    pill: 'bg-[color:var(--accent-soft)] text-[color:var(--brand-magenta)]',
     border: 'border-border',
   },
   assistant: {
     label: 'Agent',
-    pill: 'bg-surface-elevated text-text-primary',
+    pill: 'bg-[color:var(--success-soft,oklch(0.755_0.165_168/0.14))] text-[color:var(--brand-teal)]',
     border: 'border-border',
   },
   system: {

--- a/packages/web/src/experiments/console/components/StreamCard.tsx
+++ b/packages/web/src/experiments/console/components/StreamCard.tsx
@@ -20,39 +20,55 @@ interface StreamCardProps {
 // (presence / authorship); the agent's voice reads as teal (execution).
 // Tool/system/artifact/error stay semantic — they signal kind-of-event, not
 // who-is-speaking.
-const KIND_STYLES: Record<
-  StreamCardProps['kind'],
-  { label: string; pill: string; border: string }
-> = {
+//
+// border-color is set inline (not via Tailwind class) because the console's
+// wildcard `border-color: var(--border)` rule outweighs utility-class color
+// in the cascade and would otherwise repaint everything charcoal.
+interface KindStyle {
+  label: string;
+  pill: string;
+  borderClass: string;
+  borderColor: string;
+}
+
+const KIND_STYLES: Record<StreamCardProps['kind'], KindStyle> = {
   user: {
     label: 'You',
     pill: 'bg-[color:var(--accent-soft)] text-[color:var(--brand-magenta)]',
-    border: 'border-border',
+    borderClass: 'border',
+    borderColor: 'var(--border)',
   },
   assistant: {
     label: 'Agent',
     pill: 'bg-[color:var(--success-soft,oklch(0.755_0.165_168/0.14))] text-[color:var(--brand-teal)]',
-    border: 'border-border',
+    borderClass: 'border',
+    borderColor: 'var(--border)',
   },
   system: {
     label: 'System',
-    pill: 'bg-surface-elevated text-text-tertiary',
-    border: 'border-border',
+    pill: 'bg-[color:var(--success-soft,oklch(0.755_0.165_168/0.14))] text-[color:var(--brand-teal)]',
+    // Top-only teal hairline anchors system rows as framework bookends
+    // without shouting. Other sides are intentionally omitted.
+    borderClass: 'border-t',
+    borderColor: 'color-mix(in oklch, var(--brand-teal), transparent 55%)',
   },
   tool: {
     label: 'Tool',
     pill: 'bg-surface-inset text-text-secondary',
-    border: 'border-border/60',
+    borderClass: 'border',
+    borderColor: 'color-mix(in oklch, var(--border), transparent 40%)',
   },
   artifact: {
     label: 'Artifact',
     pill: 'bg-success/15 text-success',
-    border: 'border-success/30',
+    borderClass: 'border',
+    borderColor: 'color-mix(in oklch, var(--success), transparent 70%)',
   },
   error: {
     label: 'Error',
     pill: 'bg-error/15 text-error',
-    border: 'border-error/30',
+    borderClass: 'border',
+    borderColor: 'color-mix(in oklch, var(--error), transparent 60%)',
   },
 };
 
@@ -76,7 +92,8 @@ export function StreamCard({
   return (
     <article
       onClick={onClick}
-      className={`rounded border ${style.border} bg-surface px-3 ${
+      style={{ borderColor: style.borderColor }}
+      className={`rounded ${style.borderClass} bg-surface px-3 ${
         compact ? 'py-1.5' : 'py-2'
       } ${onClick !== undefined ? 'cursor-pointer transition-colors hover:bg-surface-hover' : ''}`}
     >

--- a/packages/web/src/experiments/console/components/StreamToolbar.tsx
+++ b/packages/web/src/experiments/console/components/StreamToolbar.tsx
@@ -1,12 +1,14 @@
 import type { ReactElement } from 'react';
 
+export type DetailView = 'log' | 'graph';
+
 interface StreamToolbarProps {
+  view: DetailView;
+  onChangeView: (next: DetailView) => void;
   showToolCalls: boolean;
   onToggleToolCalls: (next: boolean) => void;
   showSystem: boolean;
   onToggleSystem: (next: boolean) => void;
-  showGraph: boolean;
-  onToggleGraph: (next: boolean) => void;
   toolCallCount: number;
   messageCount: number;
 }
@@ -33,26 +35,75 @@ function Checkbox({ label, checked, onChange }: CheckboxProps): ReactElement {
   );
 }
 
+interface TabProps {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}
+
+function Tab({ label, active, onClick }: TabProps): ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={`relative px-3 py-1.5 text-[11px] font-medium uppercase tracking-wider transition-colors ${
+        active ? 'text-text-primary' : 'text-text-tertiary hover:text-text-primary'
+      }`}
+    >
+      {label}
+      {active ? (
+        <span
+          aria-hidden
+          className="brand-bar pointer-events-none absolute inset-x-1 -bottom-px h-0.5 rounded-full"
+        />
+      ) : null}
+    </button>
+  );
+}
+
 export function StreamToolbar({
+  view,
+  onChangeView,
   showToolCalls,
   onToggleToolCalls,
   showSystem,
   onToggleSystem,
-  showGraph,
-  onToggleGraph,
   toolCallCount,
   messageCount,
 }: StreamToolbarProps): ReactElement {
+  const isLog = view === 'log';
   return (
-    <div className="flex items-center gap-3 border-b border-border/50 bg-surface py-2 text-[11px]">
-      <span className="font-mono text-text-tertiary">
-        {messageCount.toString()} messages · {toolCallCount.toString()} tool calls
-      </span>
-      <div className="ml-auto flex items-center gap-4">
-        <Checkbox label="Tool calls" checked={showToolCalls} onChange={onToggleToolCalls} />
-        <Checkbox label="System" checked={showSystem} onChange={onToggleSystem} />
-        <Checkbox label="Graph" checked={showGraph} onChange={onToggleGraph} />
+    <div className="flex items-center gap-3 border-b border-border/60 bg-surface py-1.5 text-[11px]">
+      <div className="flex items-center gap-1">
+        <Tab
+          label="Log"
+          active={isLog}
+          onClick={() => {
+            onChangeView('log');
+          }}
+        />
+        <Tab
+          label="Graph"
+          active={view === 'graph'}
+          onClick={() => {
+            onChangeView('graph');
+          }}
+        />
       </div>
+
+      {isLog ? (
+        <span className="ml-3 font-mono text-text-tertiary">
+          {messageCount.toString()} messages · {toolCallCount.toString()} tool calls
+        </span>
+      ) : null}
+
+      {isLog ? (
+        <div className="ml-auto flex items-center gap-4">
+          <Checkbox label="Tool calls" checked={showToolCalls} onChange={onToggleToolCalls} />
+          <Checkbox label="System" checked={showSystem} onChange={onToggleSystem} />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/packages/web/src/experiments/console/components/StreamToolbar.tsx
+++ b/packages/web/src/experiments/console/components/StreamToolbar.tsx
@@ -1,0 +1,58 @@
+import type { ReactElement } from 'react';
+
+interface StreamToolbarProps {
+  showToolCalls: boolean;
+  onToggleToolCalls: (next: boolean) => void;
+  showSystem: boolean;
+  onToggleSystem: (next: boolean) => void;
+  showGraph: boolean;
+  onToggleGraph: (next: boolean) => void;
+  toolCallCount: number;
+  messageCount: number;
+}
+
+interface CheckboxProps {
+  label: string;
+  checked: boolean;
+  onChange: (next: boolean) => void;
+}
+
+function Checkbox({ label, checked, onChange }: CheckboxProps): ReactElement {
+  return (
+    <label className="flex cursor-pointer select-none items-center gap-1.5 text-text-secondary hover:text-text-primary">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={e => {
+          onChange(e.target.checked);
+        }}
+        className="h-3 w-3 cursor-pointer accent-[color:var(--accent-bright)]"
+      />
+      <span>{label}</span>
+    </label>
+  );
+}
+
+export function StreamToolbar({
+  showToolCalls,
+  onToggleToolCalls,
+  showSystem,
+  onToggleSystem,
+  showGraph,
+  onToggleGraph,
+  toolCallCount,
+  messageCount,
+}: StreamToolbarProps): ReactElement {
+  return (
+    <div className="flex items-center gap-3 border-b border-border/50 bg-surface py-2 text-[11px]">
+      <span className="font-mono text-text-tertiary">
+        {messageCount.toString()} messages · {toolCallCount.toString()} tool calls
+      </span>
+      <div className="ml-auto flex items-center gap-4">
+        <Checkbox label="Tool calls" checked={showToolCalls} onChange={onToggleToolCalls} />
+        <Checkbox label="System" checked={showSystem} onChange={onToggleSystem} />
+        <Checkbox label="Graph" checked={showGraph} onChange={onToggleGraph} />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/experiments/console/components/StreamToolbar.tsx
+++ b/packages/web/src/experiments/console/components/StreamToolbar.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 
-export type DetailView = 'log' | 'graph';
+export type DetailView = 'log' | 'graph' | 'artifacts';
 
 interface StreamToolbarProps {
   view: DetailView;
@@ -11,6 +11,7 @@ interface StreamToolbarProps {
   onToggleSystem: (next: boolean) => void;
   toolCallCount: number;
   messageCount: number;
+  artifactCount: number | null;
 }
 
 interface CheckboxProps {
@@ -39,9 +40,10 @@ interface TabProps {
   label: string;
   active: boolean;
   onClick: () => void;
+  count?: number | null;
 }
 
-function Tab({ label, active, onClick }: TabProps): ReactElement {
+function Tab({ label, active, onClick, count }: TabProps): ReactElement {
   return (
     <button
       type="button"
@@ -52,6 +54,9 @@ function Tab({ label, active, onClick }: TabProps): ReactElement {
       }`}
     >
       {label}
+      {typeof count === 'number' ? (
+        <span className="ml-1.5 font-mono tabular-nums text-text-tertiary">{count.toString()}</span>
+      ) : null}
       {active ? (
         <span
           aria-hidden
@@ -71,6 +76,7 @@ export function StreamToolbar({
   onToggleSystem,
   toolCallCount,
   messageCount,
+  artifactCount,
 }: StreamToolbarProps): ReactElement {
   const isLog = view === 'log';
   return (
@@ -88,6 +94,14 @@ export function StreamToolbar({
           active={view === 'graph'}
           onClick={() => {
             onChangeView('graph');
+          }}
+        />
+        <Tab
+          label="Artifacts"
+          count={artifactCount}
+          active={view === 'artifacts'}
+          onClick={() => {
+            onChangeView('artifacts');
           }}
         />
       </div>

--- a/packages/web/src/experiments/console/components/ToolCallItem.tsx
+++ b/packages/web/src/experiments/console/components/ToolCallItem.tsx
@@ -1,0 +1,96 @@
+import { useState, type ReactElement } from 'react';
+import { StreamCard } from './StreamCard';
+import type { InlineToolCall } from '../primitives/message';
+
+interface ToolCallItemProps {
+  call: InlineToolCall;
+  /** Carried from the parent message since metadata tool calls don't track their own timestamp. */
+  timestamp: string;
+}
+
+function argsSummary(input: Record<string, unknown>): string {
+  const keys = Object.keys(input);
+  if (keys.length === 0) return '';
+  const parts: string[] = [];
+  for (const k of keys.slice(0, 2)) {
+    const v = input[k];
+    const rendered =
+      typeof v === 'string' ? `"${v.length > 48 ? `${v.slice(0, 48)}…` : v}"` : JSON.stringify(v);
+    parts.push(`${k}=${rendered}`);
+  }
+  if (keys.length > 2) parts.push(`+${(keys.length - 2).toString()}`);
+  return parts.join(' ');
+}
+
+/**
+ * Compact tool call row. Collapsed: everything on one line — name · summary ·
+ * duration · chevron. Expanded: args JSON + result below the header.
+ * Clicking the card toggles expansion.
+ */
+export function ToolCallItem({ call, timestamp }: ToolCallItemProps): ReactElement {
+  const [expanded, setExpanded] = useState(false);
+  const summary = argsSummary(call.input);
+  const hasDetails =
+    Object.keys(call.input).length > 0 || (call.output !== undefined && call.output.length > 0);
+
+  return (
+    <StreamCard
+      timestamp={timestamp}
+      kind="tool"
+      compact={!expanded}
+      onClick={
+        hasDetails
+          ? (): void => {
+              setExpanded(v => !v);
+            }
+          : undefined
+      }
+      headerRight={
+        <>
+          <span className="font-mono text-[12px] font-medium text-text-primary">{call.name}</span>
+          {summary.length > 0 ? (
+            <span className="min-w-0 max-w-[360px] truncate font-mono text-[11px] text-text-secondary">
+              {summary}
+            </span>
+          ) : null}
+          {call.durationMs !== undefined ? (
+            <span className="shrink-0 font-mono text-[10px] tabular-nums text-text-tertiary">
+              {call.durationMs.toString()}ms
+            </span>
+          ) : null}
+          {hasDetails ? (
+            <span
+              aria-hidden
+              className="shrink-0 font-mono text-[10px] text-text-tertiary transition-transform"
+              style={{ transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)' }}
+            >
+              ▸
+            </span>
+          ) : null}
+        </>
+      }
+    >
+      {expanded && hasDetails ? (
+        <div className="mt-2 space-y-1.5">
+          {Object.keys(call.input).length > 0 ? (
+            <pre className="overflow-x-auto rounded border border-border bg-surface-inset p-2 font-mono text-[11px] leading-relaxed text-text-secondary">
+              {JSON.stringify(call.input, null, 2)}
+            </pre>
+          ) : null}
+          {call.output !== undefined && call.output.length > 0 ? (
+            <div>
+              <div className="mb-0.5 text-[9px] font-semibold uppercase tracking-wider text-text-tertiary">
+                Result
+              </div>
+              <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded border border-border bg-surface-inset p-2 font-mono text-[11px] leading-relaxed text-text-secondary">
+                {call.output.length > 2000
+                  ? `${call.output.slice(0, 2000)}\n\n… (${(call.output.length - 2000).toString()} more chars)`
+                  : call.output}
+              </pre>
+            </div>
+          ) : null}
+        </div>
+      ) : undefined}
+    </StreamCard>
+  );
+}

--- a/packages/web/src/experiments/console/components/WorkflowPicker.tsx
+++ b/packages/web/src/experiments/console/components/WorkflowPicker.tsx
@@ -16,6 +16,12 @@ interface WorkflowPickerProps {
   value: string;
   onChange: (workflowName: string) => void;
   disabled?: boolean;
+  /**
+   * Fires whenever the dropdown closes (any path: pick, Esc, click-outside).
+   * Used by the parent card to move focus back to the context textarea after
+   * a keymap-driven pick flow.
+   */
+  onClose?: () => void;
 }
 
 function sourceBadgeClass(source: Workflow['source']): string {
@@ -65,8 +71,15 @@ export function WorkflowPicker({
   value,
   onChange,
   disabled = false,
+  onClose,
 }: WorkflowPickerProps): ReactElement {
   const [open, setOpen] = useState(false);
+  // Funnel every close path through one wrapper. A separate onClose effect
+  // would false-fire on re-renders that toggle `open` for other reasons.
+  const closePicker = (): void => {
+    setOpen(false);
+    onClose?.();
+  };
   const [query, setQuery] = useState('');
   const [cursor, setCursor] = useState(0);
   const [anchor, setAnchor] = useState<AnchorPosition | null>(null);
@@ -123,7 +136,7 @@ export function WorkflowPicker({
       if (t === null) return;
       if (triggerRef.current?.contains(t) === true) return;
       if (panelRef.current?.contains(t) === true) return;
-      setOpen(false);
+      closePicker();
     };
     document.addEventListener('mousedown', onDoc);
     return (): void => {
@@ -170,7 +183,7 @@ export function WorkflowPicker({
   const handleSearchKey = (e: ReactKeyboardEvent<HTMLInputElement>): void => {
     if (e.key === 'Escape') {
       e.preventDefault();
-      setOpen(false);
+      closePicker();
       return;
     }
     if (e.key === 'ArrowDown') {
@@ -188,7 +201,7 @@ export function WorkflowPicker({
       const pick = filtered[cursor];
       if (pick !== undefined) {
         onChange(pick.name);
-        setOpen(false);
+        closePicker();
       }
       return;
     }
@@ -212,9 +225,12 @@ export function WorkflowPicker({
       <button
         ref={triggerRef}
         type="button"
+        data-keymap-workflow-trigger
         disabled={disabled}
         onClick={() => {
-          if (!disabled) setOpen(o => !o);
+          if (disabled) return;
+          if (open) closePicker();
+          else setOpen(true);
         }}
         onKeyDown={handleTriggerKey}
         className="flex h-9 min-w-[140px] items-center gap-2 rounded border border-border bg-surface px-3 text-sm text-text-primary transition-colors hover:bg-surface-hover disabled:opacity-50"
@@ -271,7 +287,7 @@ export function WorkflowPicker({
                         aria-selected={selected}
                         onClick={() => {
                           onChange(w.name);
-                          setOpen(false);
+                          closePicker();
                         }}
                         onMouseEnter={() => {
                           setCursor(i);

--- a/packages/web/src/experiments/console/components/WorkflowPicker.tsx
+++ b/packages/web/src/experiments/console/components/WorkflowPicker.tsx
@@ -1,0 +1,322 @@
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactElement,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
+import { createPortal } from 'react-dom';
+import type { Workflow } from '../primitives/workflow';
+
+interface WorkflowPickerProps {
+  workflows: Workflow[];
+  value: string;
+  onChange: (workflowName: string) => void;
+  disabled?: boolean;
+}
+
+function sourceBadgeClass(source: Workflow['source']): string {
+  switch (source) {
+    case 'project':
+      return 'text-accent-bright';
+    case 'global':
+      return 'text-text-secondary';
+    case 'bundled':
+      return 'text-text-tertiary';
+  }
+}
+
+function shortDescription(desc: string | null): string {
+  if (desc === null) return '';
+  const firstPara = desc.split(/\n\s*\n/)[0] ?? desc;
+  return firstPara.replace(/\s+/g, ' ').trim();
+}
+
+function fuzzyMatch(name: string, query: string): boolean {
+  if (query.length === 0) return true;
+  return name.toLowerCase().includes(query.toLowerCase());
+}
+
+const DROPDOWN_WIDTH = 420;
+const DROPDOWN_GAP = 4;
+const DROPDOWN_MARGIN = 12;
+
+interface AnchorPosition {
+  top: number;
+  left: number;
+  maxHeight: number;
+  placement: 'below' | 'above';
+}
+
+/**
+ * Workflow combobox.
+ *
+ * The dropdown is rendered via a portal into `document.body` so it escapes
+ * any ancestor `overflow`/`transform` clipping — notably the feed's
+ * scroll container and the card's rounded-corner clip. Positioned with
+ * `position: fixed` relative to the trigger button's bounding rect, with a
+ * flip above/below heuristic when there isn't room underneath.
+ */
+export function WorkflowPicker({
+  workflows,
+  value,
+  onChange,
+  disabled = false,
+}: WorkflowPickerProps): ReactElement {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [cursor, setCursor] = useState(0);
+  const [anchor, setAnchor] = useState<AnchorPosition | null>(null);
+
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const searchRef = useRef<HTMLInputElement | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
+
+  const filtered = useMemo(
+    () => workflows.filter(w => fuzzyMatch(w.name, query)),
+    [workflows, query]
+  );
+
+  // Compute anchor position when opening + on viewport resize/scroll.
+  const reposition = (): void => {
+    const rect = triggerRef.current?.getBoundingClientRect();
+    if (rect === undefined) return;
+    const spaceBelow = window.innerHeight - rect.bottom - DROPDOWN_MARGIN;
+    const spaceAbove = rect.top - DROPDOWN_MARGIN;
+    const placement: AnchorPosition['placement'] =
+      spaceBelow < 240 && spaceAbove > spaceBelow ? 'above' : 'below';
+    const maxHeight = placement === 'below' ? spaceBelow : spaceAbove;
+
+    // Keep panel on-screen horizontally.
+    let left = rect.left;
+    if (left + DROPDOWN_WIDTH > window.innerWidth - DROPDOWN_MARGIN) {
+      left = Math.max(DROPDOWN_MARGIN, window.innerWidth - DROPDOWN_MARGIN - DROPDOWN_WIDTH);
+    }
+
+    const top = placement === 'below' ? rect.bottom + DROPDOWN_GAP : rect.top - DROPDOWN_GAP; // translate(-100%) applied via style
+    setAnchor({ top, left, maxHeight: Math.max(180, maxHeight), placement });
+  };
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    reposition();
+    const onScroll = (): void => {
+      reposition();
+    };
+    window.addEventListener('resize', onScroll);
+    window.addEventListener('scroll', onScroll, true);
+    return (): void => {
+      window.removeEventListener('resize', onScroll);
+      window.removeEventListener('scroll', onScroll, true);
+    };
+  }, [open]);
+
+  // Close on click-outside (accounts for the portalled panel).
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent): void => {
+      const t = e.target as Node | null;
+      if (t === null) return;
+      if (triggerRef.current?.contains(t) === true) return;
+      if (panelRef.current?.contains(t) === true) return;
+      setOpen(false);
+    };
+    document.addEventListener('mousedown', onDoc);
+    return (): void => {
+      document.removeEventListener('mousedown', onDoc);
+    };
+  }, [open]);
+
+  // Reset search + seed cursor when opening.
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+      const idx = workflows.findIndex(w => w.name === value);
+      setCursor(idx >= 0 ? idx : 0);
+      requestAnimationFrame(() => {
+        searchRef.current?.focus();
+      });
+    }
+  }, [open, value, workflows]);
+
+  // Reset cursor if filter changes.
+  useEffect(() => {
+    setCursor(0);
+  }, [query]);
+
+  // Keep highlighted row in view when arrowing through.
+  useEffect(() => {
+    if (!open) return;
+    const list = listRef.current;
+    if (list === null) return;
+    const el = list.querySelector(`[data-idx="${cursor.toString()}"]`);
+    if (el instanceof HTMLElement) {
+      el.scrollIntoView({ block: 'nearest' });
+    }
+  }, [cursor, open]);
+
+  const handleTriggerKey = (e: ReactKeyboardEvent<HTMLButtonElement>): void => {
+    if (disabled) return;
+    if (!open && (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown')) {
+      e.preventDefault();
+      setOpen(true);
+    }
+  };
+
+  const handleSearchKey = (e: ReactKeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      setOpen(false);
+      return;
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setCursor(c => Math.min(filtered.length - 1, c + 1));
+      return;
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setCursor(c => Math.max(0, c - 1));
+      return;
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      const pick = filtered[cursor];
+      if (pick !== undefined) {
+        onChange(pick.name);
+        setOpen(false);
+      }
+      return;
+    }
+  };
+
+  const current = workflows.find(w => w.name === value) ?? workflows[0];
+
+  const panelStyle: CSSProperties | undefined =
+    anchor === null
+      ? undefined
+      : {
+          top: anchor.top,
+          left: anchor.left,
+          width: DROPDOWN_WIDTH,
+          maxHeight: anchor.maxHeight,
+          transform: anchor.placement === 'above' ? 'translateY(-100%)' : undefined,
+        };
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        disabled={disabled}
+        onClick={() => {
+          if (!disabled) setOpen(o => !o);
+        }}
+        onKeyDown={handleTriggerKey}
+        className="flex h-9 min-w-[140px] items-center gap-2 rounded border border-border bg-surface px-3 text-sm text-text-primary transition-colors hover:bg-surface-hover disabled:opacity-50"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <span className="flex-1 truncate text-left font-mono">{current?.name ?? '—'}</span>
+        <span
+          aria-hidden="true"
+          className="text-text-tertiary transition-transform"
+          style={{ transform: open ? 'rotate(180deg)' : 'rotate(0deg)' }}
+        >
+          ▾
+        </span>
+      </button>
+
+      {open && anchor !== null
+        ? createPortal(
+            <div
+              ref={panelRef}
+              role="listbox"
+              className="console-root fixed z-[1000] flex flex-col rounded border border-border bg-surface-elevated shadow-2xl"
+              style={panelStyle}
+            >
+              <div className="border-b border-border/60 p-2">
+                <input
+                  ref={searchRef}
+                  value={query}
+                  onChange={e => {
+                    setQuery(e.target.value);
+                  }}
+                  onKeyDown={handleSearchKey}
+                  placeholder="Filter workflows…"
+                  className="h-7 w-full rounded border border-border bg-surface px-2 font-mono text-[12px] text-text-primary placeholder:text-text-tertiary focus:border-border-bright focus:outline-none"
+                />
+              </div>
+
+              <div ref={listRef} className="flex flex-1 flex-col overflow-y-auto py-1">
+                {filtered.length === 0 ? (
+                  <div className="px-3 py-4 text-[12px] text-text-tertiary">
+                    No workflows match <span className="font-mono">{query}</span>.
+                  </div>
+                ) : (
+                  filtered.map((w, i) => {
+                    const active = i === cursor;
+                    const selected = w.name === value;
+                    const desc = shortDescription(w.description);
+                    return (
+                      <button
+                        key={`${w.source}-${w.name}`}
+                        type="button"
+                        role="option"
+                        data-idx={i.toString()}
+                        aria-selected={selected}
+                        onClick={() => {
+                          onChange(w.name);
+                          setOpen(false);
+                        }}
+                        onMouseEnter={() => {
+                          setCursor(i);
+                        }}
+                        className={`flex h-11 w-full shrink-0 items-center gap-3 px-3 text-left transition-colors ${
+                          active ? 'bg-surface-hover' : ''
+                        }`}
+                      >
+                        <div className="flex min-w-0 flex-1 items-baseline gap-2">
+                          <span className="shrink-0 font-mono text-[13px] text-text-primary">
+                            {w.name}
+                          </span>
+                          {desc.length > 0 ? (
+                            <span className="min-w-0 truncate text-[11px] text-text-tertiary">
+                              {desc}
+                            </span>
+                          ) : null}
+                        </div>
+                        <span
+                          className={`shrink-0 text-[9px] uppercase tracking-[0.16em] ${sourceBadgeClass(w.source)}`}
+                        >
+                          {w.source}
+                        </span>
+                        {selected ? (
+                          <span
+                            aria-hidden
+                            className="shrink-0 font-mono text-[11px] text-accent-bright"
+                          >
+                            ✓
+                          </span>
+                        ) : null}
+                      </button>
+                    );
+                  })
+                )}
+              </div>
+
+              <div className="border-t border-border/60 px-3 py-1.5 font-mono text-[10px] text-text-tertiary">
+                {filtered.length.toString()} of {workflows.length.toString()} · ↑↓ navigate · ↵
+                select · esc close
+              </div>
+            </div>,
+            document.body
+          )
+        : null}
+    </>
+  );
+}

--- a/packages/web/src/experiments/console/lib/display-name.ts
+++ b/packages/web/src/experiments/console/lib/display-name.ts
@@ -1,0 +1,35 @@
+/**
+ * Per-project display-name overrides. Lives in localStorage so the rename is
+ * scoped to the spike and survives reloads without backend changes.
+ */
+import { useEffect, useState } from 'react';
+
+const key = (projectId: string): string => `console:displayName:${projectId}`;
+
+const listeners = new Set<() => void>();
+
+export function getDisplayName(projectId: string, fallback: string): string {
+  return localStorage.getItem(key(projectId)) ?? fallback;
+}
+
+export function setDisplayName(projectId: string, value: string): void {
+  const trimmed = value.trim();
+  if (trimmed === '') localStorage.removeItem(key(projectId));
+  else localStorage.setItem(key(projectId), trimmed);
+  for (const l of listeners) l();
+}
+
+export function useDisplayName(projectId: string, fallback: string): string {
+  const [value, setValue] = useState(() => getDisplayName(projectId, fallback));
+  useEffect(() => {
+    const sync = (): void => {
+      setValue(getDisplayName(projectId, fallback));
+    };
+    listeners.add(sync);
+    sync();
+    return (): void => {
+      listeners.delete(sync);
+    };
+  }, [projectId, fallback]);
+  return value;
+}

--- a/packages/web/src/experiments/console/lib/display-name.ts
+++ b/packages/web/src/experiments/console/lib/display-name.ts
@@ -8,14 +8,26 @@ const key = (projectId: string): string => `console:displayName:${projectId}`;
 
 const listeners = new Set<() => void>();
 
+// localStorage can throw SecurityError in private-browsing modes or
+// when storage is disabled by policy. Treat any failure as "no override
+// stored" rather than crashing the rail row on mount.
 export function getDisplayName(projectId: string, fallback: string): string {
-  return localStorage.getItem(key(projectId)) ?? fallback;
+  try {
+    return localStorage.getItem(key(projectId)) ?? fallback;
+  } catch {
+    return fallback;
+  }
 }
 
 export function setDisplayName(projectId: string, value: string): void {
   const trimmed = value.trim();
-  if (trimmed === '') localStorage.removeItem(key(projectId));
-  else localStorage.setItem(key(projectId), trimmed);
+  try {
+    if (trimmed === '') localStorage.removeItem(key(projectId));
+    else localStorage.setItem(key(projectId), trimmed);
+  } catch {
+    // Override won't persist; UI still updates for the current session
+    // because the listeners below still fire.
+  }
   for (const l of listeners) l();
 }
 

--- a/packages/web/src/experiments/console/lib/format.ts
+++ b/packages/web/src/experiments/console/lib/format.ts
@@ -61,6 +61,17 @@ export function formatClock(iso: string): string {
  * segments otherwise. Falls back to the input string when it can't extract
  * a sensible short form.
  */
+/**
+ * Compact USD cost — under a dollar shows cents, over a dollar shows two
+ * decimals. Sub-cent values still surface (rounded to 4 decimals) so cheap
+ * runs don't look free.
+ */
+export function formatCost(usd: number): string {
+  if (usd >= 1) return `$${usd.toFixed(2)}`;
+  if (usd >= 0.01) return `$${usd.toFixed(3)}`;
+  return `$${usd.toFixed(4)}`;
+}
+
 export function formatProjectLocator(project: {
   repositoryUrl: string | null;
   path: string;

--- a/packages/web/src/experiments/console/lib/format.ts
+++ b/packages/web/src/experiments/console/lib/format.ts
@@ -55,3 +55,23 @@ export function formatClock(iso: string): string {
   const ss = d.getSeconds().toString().padStart(2, '0');
   return `${hh}:${mm}:${ss}`;
 }
+
+/**
+ * Compact project subtitle: `owner/repo` for typical git URLs, last two path
+ * segments otherwise. Falls back to the input string when it can't extract
+ * a sensible short form.
+ */
+export function formatProjectLocator(project: {
+  repositoryUrl: string | null;
+  path: string;
+}): string {
+  if (project.repositoryUrl !== null && project.repositoryUrl.length > 0) {
+    // Matches `…[:/]owner/repo[.git]` for github / gitlab / gitea / ssh forms.
+    const m = /[/:]([^/:]+\/[^/:]+?)(?:\.git)?$/.exec(project.repositoryUrl);
+    if (m !== null) return m[1];
+    return project.repositoryUrl;
+  }
+  const segs = project.path.split('/').filter(s => s.length > 0);
+  if (segs.length <= 2) return project.path;
+  return `…/${segs.slice(-2).join('/')}`;
+}

--- a/packages/web/src/experiments/console/lib/format.ts
+++ b/packages/web/src/experiments/console/lib/format.ts
@@ -1,0 +1,57 @@
+/** Formatting helpers for the console. Pure functions, no React. */
+
+export function shortRunId(id: string): string {
+  return id.replace(/-/g, '').slice(0, 8);
+}
+
+/** HH:MM:SS (or MM:SS under an hour). Tabular numerals recommended at call site. */
+export function formatElapsed(totalSeconds: number): string {
+  const s = Math.max(0, Math.floor(totalSeconds));
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  const pad = (n: number): string => n.toString().padStart(2, '0');
+  return h > 0 ? `${pad(h)}:${pad(m)}:${pad(sec)}` : `${pad(m)}:${pad(sec)}`;
+}
+
+export function elapsedSince(startIso: string, endIso?: string): number {
+  const start = new Date(startIso).getTime();
+  const end = endIso !== undefined ? new Date(endIso).getTime() : Date.now();
+  return (end - start) / 1000;
+}
+
+export function relativeTime(iso: string, now: number = Date.now()): string {
+  const t = new Date(iso).getTime();
+  const d = Math.floor((now - t) / 1000);
+  if (d < 5) return 'just now';
+  if (d < 60) return `${d.toString()}s ago`;
+  if (d < 3600) return `${Math.floor(d / 60).toString()}m ago`;
+  if (d < 86400) return `${Math.floor(d / 3600).toString()}h ago`;
+  return `${Math.floor(d / 86400).toString()}d ago`;
+}
+
+/**
+ * Offset from a run's start, e.g. `+04:12`. When watching a run this is far
+ * more useful than a wall-clock timestamp — and it sidesteps timezone drift.
+ * Falls back to wall-clock HH:MM:SS if the baseline is invalid.
+ */
+export function formatRelativeToBaseline(eventIso: string, baselineIso: string | null): string {
+  if (baselineIso === null) return formatClock(eventIso);
+  const base = new Date(baselineIso).getTime();
+  const t = new Date(eventIso).getTime();
+  if (Number.isNaN(base) || Number.isNaN(t)) return formatClock(eventIso);
+  const delta = Math.max(0, Math.floor((t - base) / 1000));
+  const h = Math.floor(delta / 3600);
+  const m = Math.floor((delta % 3600) / 60);
+  const s = delta % 60;
+  const pad = (n: number): string => n.toString().padStart(2, '0');
+  return h > 0 ? `+${pad(h)}:${pad(m)}:${pad(s)}` : `+${pad(m)}:${pad(s)}`;
+}
+
+export function formatClock(iso: string): string {
+  const d = new Date(iso);
+  const hh = d.getHours().toString().padStart(2, '0');
+  const mm = d.getMinutes().toString().padStart(2, '0');
+  const ss = d.getSeconds().toString().padStart(2, '0');
+  return `${hh}:${mm}:${ss}`;
+}

--- a/packages/web/src/experiments/console/lib/format.ts
+++ b/packages/web/src/experiments/console/lib/format.ts
@@ -72,17 +72,24 @@ export function formatCost(usd: number): string {
   return `$${usd.toFixed(4)}`;
 }
 
+/**
+ * Compact project subtitle. Prefer the local filesystem path because it's
+ * what the user actually navigates to (and what worktrees / artifacts hang
+ * off), and because after a rename the owner/repo derivation often reads as
+ * a duplicate of the original name. `/Users/<name>/` and `/home/<name>/`
+ * are shortened to `~/` for readability.
+ */
 export function formatProjectLocator(project: {
   repositoryUrl: string | null;
   path: string;
 }): string {
+  if (project.path.length > 0) {
+    return project.path.replace(/^\/(?:Users|home)\/[^/]+\//, '~/');
+  }
   if (project.repositoryUrl !== null && project.repositoryUrl.length > 0) {
-    // Matches `…[:/]owner/repo[.git]` for github / gitlab / gitea / ssh forms.
     const m = /[/:]([^/:]+\/[^/:]+?)(?:\.git)?$/.exec(project.repositoryUrl);
     if (m !== null) return m[1];
     return project.repositoryUrl;
   }
-  const segs = project.path.split('/').filter(s => s.length > 0);
-  if (segs.length <= 2) return project.path;
-  return `…/${segs.slice(-2).join('/')}`;
+  return '';
 }

--- a/packages/web/src/experiments/console/lib/format.ts
+++ b/packages/web/src/experiments/console/lib/format.ts
@@ -57,11 +57,6 @@ export function formatClock(iso: string): string {
 }
 
 /**
- * Compact project subtitle: `owner/repo` for typical git URLs, last two path
- * segments otherwise. Falls back to the input string when it can't extract
- * a sensible short form.
- */
-/**
  * Compact USD cost — under a dollar shows cents, over a dollar shows two
  * decimals. Sub-cent values still surface (rounded to 4 decimals) so cheap
  * runs don't look free.

--- a/packages/web/src/experiments/console/lib/health.ts
+++ b/packages/web/src/experiments/console/lib/health.ts
@@ -1,0 +1,30 @@
+/**
+ * Server-health surface. Currently only used for the Docker check so we
+ * know whether to render the `Open in IDE` (vscode://) affordance. The
+ * default is `true` (hide the button) until we hear otherwise — matches
+ * the old UI's safer default and prevents flashing a broken link on first
+ * paint inside Docker.
+ */
+
+import { useEntity } from '../store/cache';
+import { requestJson } from './http';
+
+interface HealthResponse {
+  is_docker?: boolean;
+}
+
+const HEALTH_KEY = 'health';
+
+export function useIsDocker(): boolean {
+  const { data } = useEntity<HealthResponse>(HEALTH_KEY, () =>
+    requestJson<HealthResponse>('/api/health')
+  );
+  return data?.is_docker ?? true;
+}
+
+/** Open a host path in the user's editor via the vscode:// scheme. */
+export function openInIde(workingPath: string): void {
+  // Normalise backslashes for Windows paths the same way the old UI does.
+  const normalised = workingPath.replace(/\\/g, '/');
+  window.open(`vscode://file/${normalised}`, '_blank');
+}

--- a/packages/web/src/experiments/console/lib/http.ts
+++ b/packages/web/src/experiments/console/lib/http.ts
@@ -1,0 +1,66 @@
+/**
+ * Tiny HTTP helpers owned by the console spike. Copied from packages/web/src/lib/api.ts
+ * (lines 17-70 at time of spike) rather than imported, so the spike remains
+ * decoupled from the production API client.
+ */
+
+const API_PORT = (import.meta.env.VITE_API_PORT as string | undefined) ?? '3090';
+
+/**
+ * SSE base URL. In dev, bypasses Vite proxy by connecting directly to the
+ * backend (the proxy buffers SSE). In production, relative URLs (same origin).
+ */
+export const SSE_BASE_URL = import.meta.env.DEV
+  ? `http://${window.location.hostname}:${API_PORT}`
+  : '';
+
+export class HttpError extends Error {
+  readonly status: number;
+  readonly path: string;
+  constructor(status: number, path: string, bodySnippet: string) {
+    super(`API error ${status.toString()} (${path}): ${bodySnippet}`);
+    this.name = 'HttpError';
+    this.status = status;
+    this.path = path;
+  }
+}
+
+function mergeHeaders(
+  base: Record<string, string>,
+  extra: HeadersInit | undefined
+): Record<string, string> {
+  if (extra === undefined) return base;
+  const out: Record<string, string> = { ...base };
+  if (extra instanceof Headers) {
+    extra.forEach((value, key) => {
+      out[key] = value;
+    });
+  } else if (Array.isArray(extra)) {
+    for (const [k, v] of extra) out[k] = v;
+  } else {
+    for (const [k, v] of Object.entries(extra)) {
+      if (typeof v === 'string') out[k] = v;
+    }
+  }
+  return out;
+}
+
+export async function requestJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const needsJson = options?.body !== undefined && !(options.body instanceof FormData);
+  const headers = mergeHeaders(
+    needsJson ? { 'Content-Type': 'application/json' } : {},
+    options?.headers
+  );
+  const res = await fetch(url, {
+    credentials: 'same-origin',
+    ...options,
+    headers,
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    const truncated = body.length > 200 ? `${body.slice(0, 200)}...` : body;
+    const path = new URL(url, window.location.origin).pathname;
+    throw new HttpError(res.status, path, truncated);
+  }
+  return res.json() as Promise<T>;
+}

--- a/packages/web/src/experiments/console/lib/icon-color.ts
+++ b/packages/web/src/experiments/console/lib/icon-color.ts
@@ -1,0 +1,51 @@
+/**
+ * Deterministic color for a project tile based on its id.
+ * Same id always yields the same color so tiles are stable across sessions.
+ *
+ * Uses a small palette of oklch hues tuned for the app's dark surface. Kept in
+ * sync with the general visual language (no neon, no clashing with success/
+ * warning/error status colors).
+ */
+
+// Warm palette. Hues concentrated in 0–90 (roses, corals, peaches, ambers)
+// with two jewel-tone outliers (plum + teal, echoing the logo's magenta→teal
+// gradient endpoints) so 8+ projects still feel visually distinct.
+const PALETTE: readonly string[] = [
+  'oklch(0.58 0.16 15)', // rose
+  'oklch(0.60 0.14 40)', // coral
+  'oklch(0.62 0.14 65)', // peach
+  'oklch(0.62 0.13 85)', // warm amber-gold
+  'oklch(0.56 0.15 350)', // warm magenta (logo-leaning)
+  'oklch(0.52 0.14 325)', // plum
+  'oklch(0.58 0.13 160)', // warm teal (logo-leaning)
+  'oklch(0.55 0.13 100)', // olive-gold
+];
+
+/** FNV-1a hash, 32-bit, non-cryptographic but deterministic. */
+function hash(str: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+export function tileColor(projectId: string): string {
+  return PALETTE[hash(projectId) % PALETTE.length];
+}
+
+export function tileAbbreviation(name: string): string {
+  const cleaned = name.trim();
+  if (cleaned.length === 0) return '??';
+  // owner/repo → ownerInitial + repoInitial
+  if (cleaned.includes('/')) {
+    const [a, b] = cleaned.split('/', 2);
+    const left = (a ?? '').trim()[0] ?? '';
+    const right = (b ?? '').trim()[0] ?? '';
+    if (left && right) return `${left}${right}`.toUpperCase();
+  }
+  // First two alphanumeric characters
+  const alnum = cleaned.replace(/[^A-Za-z0-9]/g, '');
+  return (alnum.slice(0, 2) || cleaned.slice(0, 2)).toUpperCase();
+}

--- a/packages/web/src/experiments/console/lib/keymap.ts
+++ b/packages/web/src/experiments/console/lib/keymap.ts
@@ -1,0 +1,183 @@
+/**
+ * Console keymap — neovim-flavored, light-modal.
+ *
+ * "Light-modal" means: bindings fire whenever the user isn't typing in an
+ * input/textarea/contentEditable, with no NORMAL/INSERT indicator. The
+ * activeElement guard mirrors the pattern DraftRunCard's window listener
+ * already uses; we lift it here so every binding shares one place to
+ * decide "is the user trying to type something."
+ *
+ * Two-key chords (gg) are supported via a 500ms buffer:
+ *   - first matching prefix arms the buffer
+ *   - second key within the window resolves the chord
+ *   - any non-matching key or timeout clears it
+ *
+ * Bindings declare their own `when:` predicate when they should be gated
+ * (e.g. approval shortcuts only on paused runs). The `?` help overlay is
+ * driven by a separate static catalogue (lib/shortcuts.ts) — drift is
+ * possible and the cost of the occasional desync is lower than a registry
+ * system that obscures the wiring.
+ *
+ * Each useKeymap call owns its own chord buffer. Today multiple buffers
+ * coexist (ConsoleApp + the active route) without collision because no
+ * prefix keys overlap across them; if a future binding adds a chord
+ * starting with `g`, `p`, `n`, or `?`, the chord buffers must be unified
+ * (e.g. lifted into a context) before that ships.
+ */
+
+import { useEffect } from 'react';
+
+/**
+ * Shared shape for a chord + its human label. `Binding` (this file) is the
+ * dispatcher-side record; `HelpEntry` (KeymapHelp.tsx) is the docs-side
+ * record; both extend `KeyEntry` so the chord/label shape can't drift.
+ */
+export interface KeyEntry {
+  /**
+   * Single key or chord. Match is exact-equal across the chord buffer.
+   * Non-empty by construction: `readonly [string, ...string[]]` rejects
+   * `keys: []` at the type level (a no-op binding would otherwise be
+   * silently dropped by the prefix matcher).
+   */
+  keys: readonly [string, ...string[]];
+  /** Human-readable label for the help overlay. */
+  label: string;
+}
+
+export interface Binding extends KeyEntry {
+  run: () => void;
+  /** Optional gate. When it returns false the binding is invisible to both
+   *  the dispatcher and the help overlay. */
+  when?: () => boolean;
+}
+
+interface UseKeymapOptions {
+  bindings: readonly Binding[];
+  /**
+   * Coarse-grained gate the caller controls (e.g. "a dialog I own is
+   * open"). When false, the effect never registers the window listener.
+   * Separate from {@link modalIsOpen}, which is a DOM-scan fallback that
+   * fires on every keystroke — `enabled: false` is cheaper when the
+   * caller already tracks the gating state, `modalIsOpen()` is the safety
+   * net for route-level keymaps that don't know about every modal.
+   */
+  enabled?: boolean;
+}
+
+const CHORD_TIMEOUT_MS = 500;
+
+function defaultInputGuard(): boolean {
+  if (typeof document === 'undefined') return false;
+  const target = document.activeElement as HTMLElement | null;
+  if (target === null) return true;
+  const tag = target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return false;
+  if (target.isContentEditable) return false;
+  return true;
+}
+
+/**
+ * Returns true when an open modal dialog is in the DOM.
+ *
+ * Why this exists: route-level useKeymap callers (RunsPage, RunDetailPage)
+ * don't know which dialogs the shell may have open, so the input-focus
+ * guard alone is not enough — there are paint frames between "dialog
+ * mounted" and "dialog's input focused" where a fast keystroke would hit
+ * the route binding underneath instead of the dialog. Scanning for any
+ * `[role="dialog"][aria-modal="true"]` closes that race generically, at
+ * the cost of one querySelector per keydown.
+ */
+function modalIsOpen(): boolean {
+  if (typeof document === 'undefined') return false;
+  return document.querySelector('[role="dialog"][aria-modal="true"]') !== null;
+}
+
+function arraysEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+function isPrefix(prefix: readonly string[], full: readonly string[]): boolean {
+  if (prefix.length >= full.length) return false;
+  for (let i = 0; i < prefix.length; i += 1) if (prefix[i] !== full[i]) return false;
+  return true;
+}
+
+export function useKeymap({ bindings, enabled = true }: UseKeymapOptions): void {
+  useEffect(() => {
+    if (!enabled) return;
+
+    let buffer: string[] = [];
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const reset = (): void => {
+      buffer = [];
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
+
+    const handler = (e: KeyboardEvent): void => {
+      // Modifier keys are NOT part of our chord vocabulary. Cmd/Ctrl/Alt
+      // combos bypass the keymap entirely so browser shortcuts (Cmd+R,
+      // Cmd+K-from-extensions, etc.) keep working.
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (!defaultInputGuard()) return;
+      // Suppress route-level bindings while any modal dialog is open so
+      // Enter/Escape inside a palette doesn't double-fire into the page
+      // underneath. The dialog component itself handles its own keys
+      // explicitly (palette listens on its input, help listens on window).
+      if (modalIsOpen()) return;
+
+      // Ignore standalone modifier keypresses (Shift, etc.) so chords don't
+      // see them as separate steps.
+      if (e.key === 'Shift' || e.key === 'Control' || e.key === 'Alt' || e.key === 'Meta') return;
+
+      const next = [...buffer, e.key];
+
+      const exact = bindings.find(b => arraysEqual(b.keys, next) && (b.when ? b.when() : true));
+      if (exact !== undefined) {
+        e.preventDefault();
+        reset();
+        exact.run();
+        return;
+      }
+
+      const prefix = bindings.find(b => isPrefix(next, b.keys) && (b.when ? b.when() : true));
+      if (prefix !== undefined) {
+        e.preventDefault();
+        buffer = next;
+        if (timer !== null) clearTimeout(timer);
+        timer = setTimeout(reset, CHORD_TIMEOUT_MS);
+        return;
+      }
+
+      // No exact, no prefix — clear the buffer (this key wasn't part of any
+      // chord) and let the event continue. We deliberately don't call
+      // preventDefault so unrelated keys still reach inputs that may be
+      // focused on the next tick.
+      reset();
+    };
+
+    window.addEventListener('keydown', handler);
+    return (): void => {
+      window.removeEventListener('keydown', handler);
+      reset();
+    };
+  }, [bindings, enabled]);
+}
+
+/** Pretty-format a chord for the help overlay. */
+export function formatChord(keys: readonly string[]): string {
+  return keys
+    .map(k => {
+      if (k === ' ') return 'Space';
+      if (k === 'Escape') return 'Esc';
+      if (k === 'Enter') return '↵';
+      if (k === 'ArrowUp') return '↑';
+      if (k === 'ArrowDown') return '↓';
+      return k;
+    })
+    .join(' ');
+}

--- a/packages/web/src/experiments/console/lib/run-status.ts
+++ b/packages/web/src/experiments/console/lib/run-status.ts
@@ -1,0 +1,57 @@
+/**
+ * Run status values plus the class-map helpers that express them visually.
+ * Mapped to the app's semantic oklch design tokens from packages/web/src/index.css
+ * so the spike renders in-brand.
+ *
+ * Status classes are kept separate from accent/primary classes: a primary CTA
+ * must never collide with the "running" signal.
+ */
+export type RunStatus = 'running' | 'paused' | 'failed' | 'completed' | 'cancelled';
+
+export const statusLabel: Record<RunStatus, string> = {
+  running: 'Running',
+  paused: 'Waiting for approval',
+  failed: 'Failed',
+  completed: 'Completed',
+  cancelled: 'Cancelled',
+};
+
+/**
+ * Status → class mappings.
+ *
+ * Color discipline:
+ *   running   → blue  (active; pulsing strip)
+ *   paused    → amber (waiting for human; pulsing dot)
+ *   failed    → red
+ *   completed → green (positive close; muted strip, no pulse)
+ *   cancelled → grey  (muted, user-stopped)
+ *
+ * The running blue uses an ad-hoc arbitrary value because the spike's theme
+ * introduces `--running` as a new token that isn't in the production
+ * `@theme inline` map. Completed reuses the production `--success` (green)
+ * at lower opacity so it signals "finished OK" without shouting.
+ */
+export const statusStripClass: Record<RunStatus, string> = {
+  running:
+    'bg-[color:var(--running)] shadow-[0_0_12px_color-mix(in_oklch,var(--running),transparent_60%)] animate-pulse',
+  paused: 'bg-warning',
+  failed: 'bg-error',
+  completed: 'bg-success/40',
+  cancelled: 'bg-text-tertiary/40',
+};
+
+export const statusTextClass: Record<RunStatus, string> = {
+  running: 'text-[color:var(--running)]',
+  paused: 'text-warning',
+  failed: 'text-error',
+  completed: 'text-success/80',
+  cancelled: 'text-text-tertiary',
+};
+
+export const statusDotClass: Record<RunStatus, string> = {
+  running: 'bg-[color:var(--running)]',
+  paused: 'bg-warning animate-pulse',
+  failed: 'bg-error',
+  completed: 'bg-success',
+  cancelled: 'bg-text-tertiary/60',
+};

--- a/packages/web/src/experiments/console/lib/shortcuts.ts
+++ b/packages/web/src/experiments/console/lib/shortcuts.ts
@@ -1,0 +1,44 @@
+// Catalogue for the `?` overlay. Keep in sync with each page's useKeymap.
+import type { KeymapGroup } from '../components/KeymapHelp';
+
+export const SHORTCUTS: readonly KeymapGroup[] = [
+  {
+    title: 'Anywhere',
+    entries: [
+      { keys: ['p'], label: 'Pick a project' },
+      { keys: ['n'], label: 'Start a new run' },
+      { keys: ['?'], label: 'Show this help' },
+    ],
+  },
+  {
+    title: 'Runs feed',
+    entries: [
+      { keys: ['j'], label: 'Move selection down' },
+      { keys: ['k'], label: 'Move selection up' },
+      { keys: ['Enter'], label: 'Open selected run' },
+      { keys: ['Escape'], label: 'Clear selection' },
+      { keys: ['g', 'g'], label: 'Jump to first' },
+      { keys: ['G'], label: 'Jump to last' },
+      { keys: ['/'], label: 'Focus search' },
+      { keys: ['1'], label: 'Filter: running' },
+      { keys: ['2'], label: 'Filter: paused' },
+      { keys: ['3'], label: 'Filter: failed' },
+      { keys: ['4'], label: 'Filter: completed' },
+      { keys: ['5'], label: 'Filter: all' },
+    ],
+  },
+  {
+    title: 'Run detail',
+    entries: [
+      { keys: ['1'], label: 'Log tab' },
+      { keys: ['2'], label: 'Graph tab' },
+      { keys: ['3'], label: 'Artifacts tab' },
+      { keys: ['t'], label: 'Toggle tool calls' },
+      { keys: ['s'], label: 'Toggle system events' },
+      { keys: ['a'], label: 'Approve (paused only)' },
+      { keys: ['r'], label: 'Reject (paused only)' },
+      { keys: ['Escape'], label: 'Back to runs' },
+      { keys: ['h'], label: 'Back to runs' },
+    ],
+  },
+];

--- a/packages/web/src/experiments/console/lib/sse.ts
+++ b/packages/web/src/experiments/console/lib/sse.ts
@@ -15,6 +15,7 @@
 import { useEffect } from 'react';
 import { invalidate } from '../store/cache';
 import { K } from './../store/keys';
+import { SSE_BASE_URL } from './http';
 
 interface ParsedEvent {
   type?: string;
@@ -40,7 +41,8 @@ function parse(raw: string): ParsedEvent | null {
  */
 export function useDashboardSSE(): void {
   useEffect(() => {
-    const es = new EventSource('/api/stream/__dashboard__');
+    // Use SSE_BASE_URL so dev bypasses the Vite proxy (which buffers SSE).
+    const es = new EventSource(`${SSE_BASE_URL}/api/stream/__dashboard__`);
 
     es.onmessage = (e: MessageEvent<string>): void => {
       const ev = parse(e.data);
@@ -56,10 +58,14 @@ export function useDashboardSSE(): void {
       }
     };
 
-    // EventSource auto-reconnects on transient errors; explicit handling
-    // would only add noise. Permanent close happens on unmount.
+    // EventSource auto-reconnects on transient errors; we only surface a
+    // warn when the connection has permanently closed so dropped streams
+    // aren't completely silent (the 30s safety-net poll in RunDetailPage
+    // covers the actual recovery; this is purely an observability hook).
     es.onerror = (): void => {
-      /* let EventSource recover */
+      if (es.readyState === EventSource.CLOSED) {
+        console.warn('[console-sse] dashboard stream closed');
+      }
     };
 
     return (): void => {
@@ -83,7 +89,9 @@ export function useRunStreamSSE(conversationPlatformId: string | null, runId: st
   useEffect(() => {
     if (conversationPlatformId === null || runId === null) return;
 
-    const es = new EventSource(`/api/stream/${encodeURIComponent(conversationPlatformId)}`);
+    const es = new EventSource(
+      `${SSE_BASE_URL}/api/stream/${encodeURIComponent(conversationPlatformId)}`
+    );
 
     let messagesDirty = false;
     let runDirty = false;
@@ -137,7 +145,9 @@ export function useRunStreamSSE(conversationPlatformId: string | null, runId: st
     };
 
     es.onerror = (): void => {
-      /* let EventSource recover */
+      if (es.readyState === EventSource.CLOSED) {
+        console.warn('[console-sse] conversation stream closed', { conversationPlatformId });
+      }
     };
 
     return (): void => {

--- a/packages/web/src/experiments/console/lib/sse.ts
+++ b/packages/web/src/experiments/console/lib/sse.ts
@@ -1,0 +1,148 @@
+/**
+ * Console SSE wiring.
+ *
+ * Two streams are exposed by the server:
+ *   /api/stream/__dashboard__       — multiplexed workflow events for every run
+ *   /api/stream/<conversationId>    — per-conversation events (text/tool_call/tool_result + workflow_*)
+ *
+ * The console treats them as cache-invalidation triggers: an event lands,
+ * the relevant cache key is invalidated, `useEntity` refetches authoritative
+ * state from the API. The list+detail surfaces don't need to interpret event
+ * payloads — they just need to know "data changed, ask again." This stays
+ * loosely coupled to event schemas and avoids partial in-memory mutation.
+ */
+
+import { useEffect } from 'react';
+import { invalidate } from '../store/cache';
+import { K } from './../store/keys';
+
+interface ParsedEvent {
+  type?: string;
+  runId?: string;
+}
+
+function parse(raw: string): ParsedEvent | null {
+  try {
+    return JSON.parse(raw) as ParsedEvent;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Subscribe to the dashboard SSE stream and invalidate the runs feed on any
+ * lifecycle change. Mount once at a high level (RunsPage).
+ *
+ * Events we care about:
+ *   workflow_status   — run created / status changed / completed / failed
+ *   dag_node          — currently-executing-node changes (current_step_name)
+ *                       which is rendered on each ActiveRunCard
+ */
+export function useDashboardSSE(): void {
+  useEffect(() => {
+    const es = new EventSource('/api/stream/__dashboard__');
+
+    es.onmessage = (e: MessageEvent<string>): void => {
+      const ev = parse(e.data);
+      if (ev?.type === undefined || ev.type === 'heartbeat') return;
+      if (ev.type === 'workflow_status' || ev.type === 'dag_node') {
+        // Refetch every runs:* key (runs:all, runs:project:<id>).
+        invalidate('runs');
+        // Also refresh any open run-detail cache so the detail page picks
+        // up status / node-transition changes without its own SSE round-trip.
+        if (typeof ev.runId === 'string') {
+          invalidate(K.run(ev.runId));
+        }
+      }
+    };
+
+    // EventSource auto-reconnects on transient errors; explicit handling
+    // would only add noise. Permanent close happens on unmount.
+    es.onerror = (): void => {
+      /* let EventSource recover */
+    };
+
+    return (): void => {
+      es.close();
+    };
+  }, []);
+}
+
+/**
+ * Subscribe to a single run's conversation stream and invalidate the detail
+ * caches on every interesting event. Skips connecting until a platform
+ * conversation id is known.
+ *
+ * Events we care about:
+ *   text                  — new assistant text → messages changed
+ *   tool_call/tool_result — new tool activity  → messages + run events changed
+ *   workflow_status       — run status changed
+ *   workflow_tool_activity / dag_node — workflow_events table grew
+ */
+export function useRunStreamSSE(conversationPlatformId: string | null, runId: string | null): void {
+  useEffect(() => {
+    if (conversationPlatformId === null || runId === null) return;
+
+    const es = new EventSource(`/api/stream/${encodeURIComponent(conversationPlatformId)}`);
+
+    let messagesDirty = false;
+    let runDirty = false;
+    let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+    // Coalesce bursts. Streamed text can arrive at >10Hz; we don't want a
+    // refetch per chunk. 100ms is fast enough to feel live and slow enough
+    // to dedupe.
+    const scheduleFlush = (): void => {
+      if (flushTimer !== null) return;
+      flushTimer = setTimeout(() => {
+        flushTimer = null;
+        if (messagesDirty) {
+          invalidate(K.messages(conversationPlatformId));
+          messagesDirty = false;
+        }
+        if (runDirty) {
+          invalidate(K.run(runId));
+          runDirty = false;
+        }
+      }, 100);
+    };
+
+    es.onmessage = (e: MessageEvent<string>): void => {
+      const ev = parse(e.data);
+      if (ev?.type === undefined || ev.type === 'heartbeat') return;
+
+      switch (ev.type) {
+        case 'text':
+          messagesDirty = true;
+          break;
+        case 'tool_call':
+        case 'tool_result':
+          messagesDirty = true;
+          runDirty = true;
+          break;
+        case 'workflow_status':
+        case 'workflow_tool_activity':
+        case 'dag_node':
+        case 'workflow_step':
+        case 'workflow_artifact':
+        case 'workflow_dispatch':
+          runDirty = true;
+          break;
+        // Other event types (system_status, retract, etc.) don't change
+        // persisted state we render — ignore.
+        default:
+          return;
+      }
+      scheduleFlush();
+    };
+
+    es.onerror = (): void => {
+      /* let EventSource recover */
+    };
+
+    return (): void => {
+      if (flushTimer !== null) clearTimeout(flushTimer);
+      es.close();
+    };
+  }, [conversationPlatformId, runId]);
+}

--- a/packages/web/src/experiments/console/lib/stream-context.tsx
+++ b/packages/web/src/experiments/console/lib/stream-context.tsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, type ReactElement, type ReactNode } from 'react';
+
+/**
+ * Context for per-stream data that every entry needs but we don't want to
+ * prop-drill through five layers.
+ *
+ * `runStartedAt` drives relative timestamps like `+04:12`.
+ */
+export interface StreamContextValue {
+  runStartedAt: string | null;
+}
+
+const context = createContext<StreamContextValue>({ runStartedAt: null });
+
+// Wrap Provider as a function so naming-convention allows PascalCase.
+export function StreamContextProvider({
+  value,
+  children,
+}: {
+  value: StreamContextValue;
+  children: ReactNode;
+}): ReactElement {
+  return <context.Provider value={value}>{children}</context.Provider>;
+}
+
+export function useStreamContext(): StreamContextValue {
+  return useContext(context);
+}

--- a/packages/web/src/experiments/console/primitives/event.ts
+++ b/packages/web/src/experiments/console/primitives/event.ts
@@ -13,7 +13,8 @@ export type RunEventKind =
   | 'artifact'
   | 'node_transition'
   | 'approval'
-  | 'error';
+  | 'error'
+  | 'system';
 
 interface RunEventBase {
   id: string;
@@ -66,13 +67,26 @@ export interface ErrorEvent extends RunEventBase {
   recoverable: boolean;
 }
 
+/**
+ * Workflow-lifecycle events: `workflow_started`, `workflow_completed`,
+ * `workflow_failed`, and any other framework-level signals worth surfacing
+ * behind the "System" toggle. These don't belong in the user/agent thread
+ * but are useful when diagnosing a run.
+ */
+export interface SystemEvent extends RunEventBase {
+  kind: 'system';
+  label: string;
+  detail: string;
+}
+
 export type RunEvent =
   | TextEvent
   | ToolCallEvent
   | ArtifactEvent
   | NodeTransitionEvent
   | ApprovalEvent
-  | ErrorEvent;
+  | ErrorEvent
+  | SystemEvent;
 
 // Server row shape (workflow_events table).
 interface RawWorkflowEvent {
@@ -185,12 +199,32 @@ export function toRunEvent(raw: RawWorkflowEvent): RunEvent {
     };
   }
 
-  if (et === 'error' || et === 'workflow_failed') {
+  if (et === 'error') {
     return {
       ...base,
       kind: 'error',
       message: readString(data, 'error') || readString(data, 'message'),
       recoverable: Boolean(data.recoverable),
+    };
+  }
+
+  if (et === 'workflow_started' || et === 'workflow_completed' || et === 'workflow_failed') {
+    const label =
+      et === 'workflow_started'
+        ? 'Workflow started'
+        : et === 'workflow_completed'
+          ? 'Workflow completed'
+          : 'Workflow failed';
+    const detail =
+      readString(data, 'name') ||
+      readString(data, 'workflow') ||
+      readString(data, 'message') ||
+      readString(data, 'error');
+    return {
+      ...base,
+      kind: 'system',
+      label,
+      detail,
     };
   }
 

--- a/packages/web/src/experiments/console/primitives/event.ts
+++ b/packages/web/src/experiments/console/primitives/event.ts
@@ -50,6 +50,10 @@ export interface NodeTransitionEvent extends RunEventBase {
   nodeName: string;
   transition: 'started' | 'completed' | 'failed' | 'skipped';
   durationMs: number | null;
+  /** Only populated for `skipped` — `when_condition` or `trigger_rule`. */
+  skipReason: string | null;
+  /** Only populated for `skipped` — the evaluated expression that gated it. */
+  skipExpr: string | null;
 }
 
 export interface ApprovalEvent extends RunEventBase {
@@ -142,6 +146,8 @@ export function toRunEvent(raw: RawWorkflowEvent): RunEvent {
       nodeName: readString(data, 'name') || (raw.step_name ?? ''),
       transition,
       durationMs: readNumberOrNull(data, 'duration'),
+      skipReason: transition === 'skipped' ? readStringOrNull(data, 'reason') : null,
+      skipExpr: transition === 'skipped' ? readStringOrNull(data, 'expr') : null,
     };
   }
 

--- a/packages/web/src/experiments/console/primitives/event.ts
+++ b/packages/web/src/experiments/console/primitives/event.ts
@@ -1,0 +1,206 @@
+/**
+ * Run event stream primitives. Six variants of events that render in the Run
+ * detail page: text, tool_call, artifact, node_transition, approval, error.
+ *
+ * These are the client-side model — normalized from server workflow_events
+ * rows AND from SSE events. The shape is deliberately flatter than the raw
+ * event schema so EventStream rendering can switch on `kind` only.
+ */
+
+export type RunEventKind =
+  | 'text'
+  | 'tool_call'
+  | 'artifact'
+  | 'node_transition'
+  | 'approval'
+  | 'error';
+
+interface RunEventBase {
+  id: string;
+  runId: string;
+  kind: RunEventKind;
+  timestamp: string;
+  nodeId: string | null;
+}
+
+export interface TextEvent extends RunEventBase {
+  kind: 'text';
+  content: string;
+}
+
+export interface ToolCallEvent extends RunEventBase {
+  kind: 'tool_call';
+  tool: string;
+  argsSummary: string;
+  args: unknown;
+  result: { ok: true; durationMs: number } | { ok: false; message: string } | null;
+}
+
+export interface ArtifactEvent extends RunEventBase {
+  kind: 'artifact';
+  artifactType: string;
+  label: string;
+  url: string | null;
+  path: string | null;
+}
+
+export interface NodeTransitionEvent extends RunEventBase {
+  kind: 'node_transition';
+  nodeName: string;
+  transition: 'started' | 'completed' | 'failed' | 'skipped';
+  durationMs: number | null;
+}
+
+export interface ApprovalEvent extends RunEventBase {
+  kind: 'approval';
+  prompt: string;
+  resolution:
+    | { kind: 'approved'; at: string; comment: string | null }
+    | { kind: 'rejected'; at: string; reason: string }
+    | null;
+}
+
+export interface ErrorEvent extends RunEventBase {
+  kind: 'error';
+  message: string;
+  recoverable: boolean;
+}
+
+export type RunEvent =
+  | TextEvent
+  | ToolCallEvent
+  | ArtifactEvent
+  | NodeTransitionEvent
+  | ApprovalEvent
+  | ErrorEvent;
+
+// Server row shape (workflow_events table).
+interface RawWorkflowEvent {
+  id: string;
+  workflow_run_id: string;
+  event_type: string;
+  step_index: number | null;
+  step_name: string | null;
+  data: Record<string, unknown>;
+  created_at: string;
+}
+
+function readString(obj: Record<string, unknown>, key: string): string {
+  const v = obj[key];
+  return typeof v === 'string' ? v : '';
+}
+
+function readStringOrNull(obj: Record<string, unknown>, key: string): string | null {
+  const v = obj[key];
+  return typeof v === 'string' ? v : null;
+}
+
+function readNumberOrNull(obj: Record<string, unknown>, key: string): number | null {
+  const v = obj[key];
+  return typeof v === 'number' ? v : null;
+}
+
+/**
+ * Best-effort normalizer from a raw workflow_events row to a typed RunEvent.
+ * Unknown event types fall through as text events with the raw payload —
+ * the spike surfaces them rather than silently dropping.
+ */
+export function toRunEvent(raw: RawWorkflowEvent): RunEvent {
+  const base = {
+    id: raw.id,
+    runId: raw.workflow_run_id,
+    timestamp: raw.created_at,
+    nodeId: raw.step_name,
+  };
+  const data = raw.data;
+  const et = raw.event_type;
+
+  if (
+    et === 'node_started' ||
+    et === 'node_completed' ||
+    et === 'node_failed' ||
+    et === 'node_skipped'
+  ) {
+    const transition = et.replace('node_', '') as 'started' | 'completed' | 'failed' | 'skipped';
+    return {
+      ...base,
+      kind: 'node_transition',
+      nodeName: readString(data, 'name') || (raw.step_name ?? ''),
+      transition,
+      durationMs: readNumberOrNull(data, 'duration'),
+    };
+  }
+
+  if (et === 'tool_started' || et === 'tool_completed') {
+    const toolName = readString(data, 'toolName');
+    const argsJson = data.args;
+    const argsSummary = readString(data, 'argsSummary');
+    const ok = et === 'tool_completed';
+    return {
+      ...base,
+      kind: 'tool_call',
+      tool: toolName,
+      argsSummary,
+      args: argsJson,
+      result:
+        et === 'tool_started'
+          ? null
+          : ok
+            ? { ok: true, durationMs: readNumberOrNull(data, 'durationMs') ?? 0 }
+            : { ok: false, message: readString(data, 'error') },
+    };
+  }
+
+  if (et === 'workflow_artifact') {
+    return {
+      ...base,
+      kind: 'artifact',
+      artifactType: readString(data, 'artifactType'),
+      label: readString(data, 'label'),
+      url: readStringOrNull(data, 'url'),
+      path: readStringOrNull(data, 'path'),
+    };
+  }
+
+  if (et === 'approval_pending' || et === 'approval_resolved') {
+    const resolution = et === 'approval_resolved';
+    const resolvedAs = readString(data, 'resolution'); // 'approved' | 'rejected'
+    return {
+      ...base,
+      kind: 'approval',
+      prompt: readString(data, 'message'),
+      resolution: resolution
+        ? resolvedAs === 'rejected'
+          ? {
+              kind: 'rejected',
+              at: raw.created_at,
+              reason: readString(data, 'reason'),
+            }
+          : {
+              kind: 'approved',
+              at: raw.created_at,
+              comment: readStringOrNull(data, 'comment'),
+            }
+        : null,
+    };
+  }
+
+  if (et === 'error' || et === 'workflow_failed') {
+    return {
+      ...base,
+      kind: 'error',
+      message: readString(data, 'error') || readString(data, 'message'),
+      recoverable: Boolean(data.recoverable),
+    };
+  }
+
+  // Fallback: render anything else as a text event with the payload summary.
+  return {
+    ...base,
+    kind: 'text',
+    content:
+      readString(data, 'text') ||
+      readString(data, 'message') ||
+      `${et} — ${JSON.stringify(data).slice(0, 200)}`,
+  };
+}

--- a/packages/web/src/experiments/console/primitives/event.ts
+++ b/packages/web/src/experiments/console/primitives/event.ts
@@ -131,23 +131,23 @@ export function toRunEvent(raw: RawWorkflowEvent): RunEvent {
     };
   }
 
-  if (et === 'tool_started' || et === 'tool_completed') {
-    const toolName = readString(data, 'toolName');
-    const argsJson = data.args;
+  if (et === 'tool_called' || et === 'tool_completed') {
+    // Server writes snake_case fields (tool_name, tool_input, duration_ms);
+    // the start event carries the input, the completed event carries only
+    // the duration. RunStream pairs them by step + order to fill durationMs.
+    const toolName = readString(data, 'tool_name');
+    const toolInput = data.tool_input;
     const argsSummary = readString(data, 'argsSummary');
-    const ok = et === 'tool_completed';
     return {
       ...base,
       kind: 'tool_call',
       tool: toolName,
       argsSummary,
-      args: argsJson,
+      args: toolInput,
       result:
-        et === 'tool_started'
+        et === 'tool_called'
           ? null
-          : ok
-            ? { ok: true, durationMs: readNumberOrNull(data, 'durationMs') ?? 0 }
-            : { ok: false, message: readString(data, 'error') },
+          : { ok: true, durationMs: readNumberOrNull(data, 'duration_ms') ?? 0 },
     };
   }
 

--- a/packages/web/src/experiments/console/primitives/message.ts
+++ b/packages/web/src/experiments/console/primitives/message.ts
@@ -18,6 +18,26 @@ export interface InlineError {
   classification?: string;
 }
 
+/**
+ * Framework-emitted messages carry a `category` in their metadata identifying
+ * what they are (e.g. `workflow_dispatch_status` for the rocket-emoji
+ * dispatch line, `workflow_status` for "starting workflow" prose). These
+ * read as system chatter — the SDK / orchestrator narrating, not the agent
+ * itself — and are hidden by default, surfaced as compact rows under the
+ * System toggle.
+ */
+const SYSTEM_CATEGORY_PREFIXES = ['workflow_', 'system_'] as const;
+
+export function isSystemCategory(category: string | null): boolean {
+  if (category === null) return false;
+  return SYSTEM_CATEGORY_PREFIXES.some(p => category.startsWith(p));
+}
+
+export interface WorkflowDispatchMeta {
+  workflowName: string;
+  workerConversationId?: string;
+}
+
 export interface Message {
   id: string;
   role: MessageRole;
@@ -25,6 +45,10 @@ export interface Message {
   timestamp: string;
   toolCalls: InlineToolCall[];
   error: InlineError | null;
+  /** Framework category from metadata (e.g. workflow_dispatch_status). */
+  category: string | null;
+  /** Parsed workflowDispatch payload, if present on this message. */
+  dispatch: WorkflowDispatchMeta | null;
 }
 
 interface RawMessage {
@@ -43,6 +67,11 @@ interface ParsedMetadata {
     output?: string;
     duration?: number;
   }[];
+  category?: string;
+  workflowDispatch?: {
+    workflowName: string;
+    workerConversationId?: string;
+  };
 }
 
 function parseMetadata(raw: string): ParsedMetadata {
@@ -74,6 +103,13 @@ export function toMessage(raw: RawMessage): Message {
           classification: meta.error.classification,
         }
       : null;
+  const dispatch: WorkflowDispatchMeta | null =
+    meta.workflowDispatch !== undefined
+      ? {
+          workflowName: meta.workflowDispatch.workflowName,
+          workerConversationId: meta.workflowDispatch.workerConversationId,
+        }
+      : null;
   return {
     id: raw.id,
     role: toMessageRole(raw.role),
@@ -81,5 +117,7 @@ export function toMessage(raw: RawMessage): Message {
     timestamp: raw.created_at,
     toolCalls,
     error,
+    category: meta.category ?? null,
+    dispatch,
   };
 }

--- a/packages/web/src/experiments/console/primitives/message.ts
+++ b/packages/web/src/experiments/console/primitives/message.ts
@@ -1,0 +1,85 @@
+/**
+ * Conversation message primitive. Runs have both `workflow_events` (structured)
+ * and chat `messages` (the AI's and user's text). The Run detail page merges
+ * both into a single timeline keyed by timestamp.
+ */
+
+export type MessageRole = 'user' | 'assistant' | 'system';
+
+export interface InlineToolCall {
+  name: string;
+  input: Record<string, unknown>;
+  output?: string;
+  durationMs?: number;
+}
+
+export interface InlineError {
+  message: string;
+  classification?: string;
+}
+
+export interface Message {
+  id: string;
+  role: MessageRole;
+  content: string;
+  timestamp: string;
+  toolCalls: InlineToolCall[];
+  error: InlineError | null;
+}
+
+interface RawMessage {
+  id: string;
+  role: string;
+  content: string;
+  metadata: string;
+  created_at: string;
+}
+
+interface ParsedMetadata {
+  error?: { message: string; classification?: string };
+  toolCalls?: {
+    name: string;
+    input?: Record<string, unknown>;
+    output?: string;
+    duration?: number;
+  }[];
+}
+
+function parseMetadata(raw: string): ParsedMetadata {
+  if (raw.length === 0) return {};
+  try {
+    return JSON.parse(raw) as ParsedMetadata;
+  } catch {
+    return {};
+  }
+}
+
+function toMessageRole(s: string): MessageRole {
+  if (s === 'user' || s === 'assistant' || s === 'system') return s;
+  return 'assistant';
+}
+
+export function toMessage(raw: RawMessage): Message {
+  const meta = parseMetadata(raw.metadata);
+  const toolCalls: InlineToolCall[] = (meta.toolCalls ?? []).map(tc => ({
+    name: tc.name,
+    input: tc.input ?? {},
+    output: tc.output,
+    durationMs: tc.duration,
+  }));
+  const error: InlineError | null =
+    meta.error !== undefined
+      ? {
+          message: meta.error.message,
+          classification: meta.error.classification,
+        }
+      : null;
+  return {
+    id: raw.id,
+    role: toMessageRole(raw.role),
+    content: raw.content,
+    timestamp: raw.created_at,
+    toolCalls,
+    error,
+  };
+}

--- a/packages/web/src/experiments/console/primitives/project.ts
+++ b/packages/web/src/experiments/console/primitives/project.ts
@@ -1,0 +1,30 @@
+/** Project primitive. Canonical in-spike shape, normalized from server schema. */
+export interface Project {
+  id: string;
+  name: string;
+  path: string;
+  defaultBranch: string;
+  repositoryUrl: string | null;
+  lastSyncedAt: string | null;
+}
+
+interface RawCodebase {
+  id: string;
+  name: string;
+  default_cwd: string;
+  default_branch?: string | null;
+  repository_url: string | null;
+  updated_at: string;
+  created_at: string;
+}
+
+export function toProject(raw: RawCodebase): Project {
+  return {
+    id: raw.id,
+    name: raw.name,
+    path: raw.default_cwd,
+    defaultBranch: raw.default_branch ?? 'main',
+    repositoryUrl: raw.repository_url,
+    lastSyncedAt: raw.updated_at,
+  };
+}

--- a/packages/web/src/experiments/console/primitives/run.ts
+++ b/packages/web/src/experiments/console/primitives/run.ts
@@ -6,6 +6,9 @@ export interface Run {
   id: string;
   projectId: string | null;
   projectName: string | null;
+  /** Total USD cost from the agent SDK. Populated for completed Claude runs;
+   *  Pi/Codex runs may not report cost. Null when the run hasn't recorded any. */
+  costUsd: number | null;
   /** DB id of the conversation this run belongs to. */
   conversationId: string | null;
   /**
@@ -82,6 +85,12 @@ function normalizeOrigin(s: string | null | undefined): RunOrigin {
   }
 }
 
+function readCost(meta: Record<string, unknown> | undefined): number | null {
+  if (meta === undefined) return null;
+  const raw = meta.total_cost_usd;
+  return typeof raw === 'number' && Number.isFinite(raw) && raw > 0 ? raw : null;
+}
+
 export function toRun(raw: RawWorkflowRun): Run {
   const approval = raw.metadata?.approval;
   const parsedApproval =
@@ -103,6 +112,7 @@ export function toRun(raw: RawWorkflowRun): Run {
     id: raw.id,
     projectId: raw.codebase_id,
     projectName: raw.codebase_name ?? null,
+    costUsd: readCost(raw.metadata),
     conversationId: raw.conversation_id ?? null,
     conversationPlatformId: raw.conversation_platform_id ?? null,
     workflow: raw.workflow_name,

--- a/packages/web/src/experiments/console/primitives/run.ts
+++ b/packages/web/src/experiments/console/primitives/run.ts
@@ -1,0 +1,119 @@
+import type { RunStatus } from '../lib/run-status';
+
+export type RunOrigin = 'web' | 'cli' | 'slack' | 'telegram' | 'discord' | 'github' | 'unknown';
+
+export interface Run {
+  id: string;
+  projectId: string | null;
+  projectName: string | null;
+  /** DB id of the conversation this run belongs to. */
+  conversationId: string | null;
+  /**
+   * Platform-level conversation id (e.g. `cli-1776237248436-q61o4h`). This is
+   * the id the `/api/conversations/:id/messages` route accepts in its URL
+   * path — the server looks conversations up by platform id, not DB id, on
+   * that endpoint. Use this when fetching the run's messages.
+   */
+  conversationPlatformId: string | null;
+  workflow: string;
+  origin: RunOrigin;
+  status: RunStatus;
+  startedAt: string;
+  finishedAt: string | null;
+  /** workflow_runs.working_path — used to join against worktrees. */
+  workingPath: string | null;
+  userMessage: string;
+  /** Derived from metadata/events at runtime; initially undefined. */
+  currentNode?: string | null;
+  lastTool?: string | null;
+  approval?: { nodeId: string; message: string } | null;
+}
+
+// Server shapes we read from. These track the real server schema loosely —
+// fields we don't use are omitted. The normalizer defends against missing
+// optional fields.
+
+interface RawWorkflowRun {
+  id: string;
+  workflow_name: string;
+  codebase_id: string | null;
+  conversation_id?: string | null;
+  /** Platform-level conversation id — exposed on the getRun response only. */
+  conversation_platform_id?: string | null;
+  status: string;
+  started_at: string;
+  completed_at?: string | null;
+  working_path?: string | null;
+  user_message?: string;
+  metadata?: Record<string, unknown>;
+  /** Only present on dashboard runs — enriched by server-side join. */
+  codebase_name?: string | null;
+  platform_type?: string | null;
+  current_step_name?: string | null;
+}
+
+const KNOWN_STATUSES: readonly RunStatus[] = [
+  'running',
+  'paused',
+  'failed',
+  'completed',
+  'cancelled',
+];
+
+function normalizeStatus(s: string): RunStatus {
+  // Treat 'pending' as 'running' for UI purposes — it's transient.
+  if (s === 'pending') return 'running';
+  return (KNOWN_STATUSES as readonly string[]).includes(s) ? (s as RunStatus) : 'running';
+}
+
+function normalizeOrigin(s: string | null | undefined): RunOrigin {
+  if (s === null || s === undefined) return 'unknown';
+  const lower = s.toLowerCase();
+  switch (lower) {
+    case 'web':
+    case 'cli':
+    case 'slack':
+    case 'telegram':
+    case 'discord':
+    case 'github':
+      return lower;
+    default:
+      return 'unknown';
+  }
+}
+
+export function toRun(raw: RawWorkflowRun): Run {
+  const approval = raw.metadata?.approval;
+  const parsedApproval =
+    approval !== null &&
+    typeof approval === 'object' &&
+    approval !== undefined &&
+    'nodeId' in approval &&
+    typeof (approval as { nodeId: unknown }).nodeId === 'string'
+      ? {
+          nodeId: (approval as { nodeId: string }).nodeId,
+          message:
+            'message' in approval && typeof (approval as { message: unknown }).message === 'string'
+              ? (approval as { message: string }).message
+              : '',
+        }
+      : null;
+
+  return {
+    id: raw.id,
+    projectId: raw.codebase_id,
+    projectName: raw.codebase_name ?? null,
+    conversationId: raw.conversation_id ?? null,
+    conversationPlatformId: raw.conversation_platform_id ?? null,
+    workflow: raw.workflow_name,
+    origin: normalizeOrigin(raw.platform_type),
+    status: normalizeStatus(raw.status),
+    startedAt: raw.started_at,
+    finishedAt: raw.completed_at ?? null,
+    workingPath: raw.working_path ?? null,
+    userMessage: raw.user_message ?? '',
+    currentNode: raw.current_step_name ?? null,
+    lastTool: null,
+    approval: parsedApproval,
+  };
+}

--- a/packages/web/src/experiments/console/primitives/workflow-graph.ts
+++ b/packages/web/src/experiments/console/primitives/workflow-graph.ts
@@ -1,0 +1,56 @@
+/**
+ * Workflow DAG primitives — just enough to render a compact graph in the
+ * run-detail sidebar. We don't need the full `DagNode` shape from the
+ * production API; we only care about id + dependencies + kind + status.
+ */
+
+export type WorkflowNodeKind = 'prompt' | 'command' | 'bash' | 'script' | 'approval' | 'loop';
+
+export type WorkflowNodeStatus = 'pending' | 'running' | 'completed' | 'failed' | 'skipped';
+
+export interface WorkflowGraphNode {
+  id: string;
+  dependsOn: string[];
+  kind: WorkflowNodeKind;
+}
+
+export interface WorkflowGraphNodeWithStatus extends WorkflowGraphNode {
+  status: WorkflowNodeStatus;
+  durationMs: number | null;
+}
+
+import type { RunEvent } from './event';
+
+/**
+ * Derive each node's current status by walking run events in order.
+ * Later events override earlier ones for the same node. Nodes with no
+ * events stay `pending`.
+ */
+export function deriveNodeStatuses(
+  nodes: WorkflowGraphNode[],
+  events: RunEvent[]
+): WorkflowGraphNodeWithStatus[] {
+  const byNode = new Map<string, { status: WorkflowNodeStatus; durationMs: number | null }>();
+  for (const e of events) {
+    if (e.kind !== 'node_transition') continue;
+    const name = e.nodeName;
+    if (name.length === 0) continue;
+    const status: WorkflowNodeStatus =
+      e.transition === 'started'
+        ? 'running'
+        : e.transition === 'completed'
+          ? 'completed'
+          : e.transition === 'failed'
+            ? 'failed'
+            : 'skipped';
+    byNode.set(name, { status, durationMs: e.durationMs });
+  }
+  return nodes.map(n => {
+    const current = byNode.get(n.id);
+    return {
+      ...n,
+      status: current?.status ?? 'pending',
+      durationMs: current?.durationMs ?? null,
+    };
+  });
+}

--- a/packages/web/src/experiments/console/primitives/workflow.ts
+++ b/packages/web/src/experiments/console/primitives/workflow.ts
@@ -15,7 +15,12 @@ interface RawWorkflowEntry {
 }
 
 export function toWorkflow(raw: RawWorkflowEntry): Workflow {
-  const src = raw.source === 'project' ? 'project' : 'bundled';
+  // Three distinct sources matter for sort + badge: project (repo-local)
+  // > global (home-scoped `~/.archon/workflows`) > bundled (defaults
+  // shipped with Archon). Collapsing `global` into `bundled` silently
+  // demoted home-scoped workflows and rendered them with the wrong badge.
+  const src: WorkflowSource =
+    raw.source === 'project' ? 'project' : raw.source === 'global' ? 'global' : 'bundled';
   return {
     name: raw.workflow.name,
     description: raw.workflow.description ?? null,

--- a/packages/web/src/experiments/console/primitives/workflow.ts
+++ b/packages/web/src/experiments/console/primitives/workflow.ts
@@ -1,0 +1,24 @@
+export type WorkflowSource = 'project' | 'global' | 'bundled';
+
+export interface Workflow {
+  name: string;
+  description: string | null;
+  source: WorkflowSource;
+}
+
+interface RawWorkflowEntry {
+  workflow: {
+    name: string;
+    description?: string | null;
+  };
+  source: string;
+}
+
+export function toWorkflow(raw: RawWorkflowEntry): Workflow {
+  const src = raw.source === 'project' ? 'project' : 'bundled';
+  return {
+    name: raw.workflow.name,
+    description: raw.workflow.description ?? null,
+    source: src,
+  };
+}

--- a/packages/web/src/experiments/console/primitives/worktree.ts
+++ b/packages/web/src/experiments/console/primitives/worktree.ts
@@ -1,0 +1,42 @@
+export type WorktreeStatus = 'idle' | 'in_use' | 'stale';
+
+export interface Worktree {
+  id: string;
+  projectId: string;
+  branch: string;
+  path: string;
+  status: WorktreeStatus;
+  daysSinceActivity: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface RawEnvironment {
+  id: string;
+  codebase_id: string;
+  branch_name: string;
+  working_path: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+  days_since_activity: number;
+}
+
+function normalizeStatus(s: string, days: number): WorktreeStatus {
+  if (s === 'in_use' || s === 'active') return 'in_use';
+  if (days > 14) return 'stale';
+  return 'idle';
+}
+
+export function toWorktree(raw: RawEnvironment): Worktree {
+  return {
+    id: raw.id,
+    projectId: raw.codebase_id,
+    branch: raw.branch_name,
+    path: raw.working_path,
+    status: normalizeStatus(raw.status, raw.days_since_activity),
+    daysSinceActivity: raw.days_since_activity,
+    createdAt: raw.created_at,
+    updatedAt: raw.updated_at,
+  };
+}

--- a/packages/web/src/experiments/console/routes/PreviewPage.tsx
+++ b/packages/web/src/experiments/console/routes/PreviewPage.tsx
@@ -1,0 +1,277 @@
+import type { CSSProperties, ReactElement } from 'react';
+import { RunCard } from '../components/RunCard';
+import { ProjectTile } from '../components/ProjectTile';
+import { OriginBadge } from '../components/OriginBadge';
+import type { Run } from '../primitives/run';
+
+/**
+ * Visual preview of the console's warm palette in context.
+ * Route: /console/_preview. Not part of the product flow — a living reference
+ * while we pin down the theme.
+ */
+
+const baseRun: Omit<Run, 'id' | 'workflow' | 'status'> = {
+  projectId: 'demo',
+  projectName: 'archon-core',
+  conversationId: null,
+  conversationPlatformId: null,
+  origin: 'cli',
+  startedAt: new Date(Date.now() - 4 * 60 * 1000 - 12 * 1000).toISOString(),
+  finishedAt: null,
+  workingPath: null,
+  userMessage: '',
+};
+
+const SAMPLE_RUNS: Run[] = [
+  {
+    ...baseRun,
+    id: 'a4f2c918-running',
+    workflow: 'plan',
+    status: 'running',
+    currentNode: 'plan/draft',
+    lastTool: 'read_file',
+  },
+  {
+    ...baseRun,
+    id: '8f3d2a1c-paused',
+    workflow: 'review',
+    origin: 'web',
+    status: 'paused',
+    startedAt: new Date(Date.now() - 14 * 60 * 1000 - 22 * 1000).toISOString(),
+    approval: {
+      nodeId: 'implement/verify',
+      message: 'Approve running bun validate?',
+    },
+  },
+  {
+    ...baseRun,
+    id: 'c1a5b9d3-failed',
+    workflow: 'test',
+    origin: 'slack',
+    status: 'failed',
+    startedAt: new Date(Date.now() - 2 * 60 * 1000 - 41 * 1000).toISOString(),
+    finishedAt: new Date().toISOString(),
+    currentNode: 'implement/verify',
+  },
+  {
+    ...baseRun,
+    id: 'd7e9b4f2-completed',
+    workflow: 'implement',
+    origin: 'github',
+    status: 'completed',
+    startedAt: new Date(Date.now() - 8 * 60 * 1000 - 14 * 1000).toISOString(),
+    finishedAt: new Date().toISOString(),
+  },
+  {
+    ...baseRun,
+    id: 'e5b3c742-cancelled',
+    workflow: 'assist',
+    origin: 'telegram',
+    status: 'cancelled',
+    startedAt: new Date(Date.now() - 47 * 1000).toISOString(),
+    finishedAt: new Date().toISOString(),
+  },
+];
+
+const SAMPLE_PROJECTS = [
+  { id: 'archon-core', name: 'archon-core' },
+  { id: 'web-ui', name: 'web-ui' },
+  { id: 'cli-tool', name: 'cli-tool' },
+  { id: 'infra-ops', name: 'infra-ops' },
+  { id: 'mobile-app', name: 'mobile-app' },
+  { id: 'ml-pipeline', name: 'ml-pipeline' },
+  { id: 'docs-site', name: 'docs-site' },
+  { id: 'experiments', name: 'experiments' },
+];
+
+interface SwatchProps {
+  role: string;
+  cssVar: string;
+  note?: string;
+}
+
+function Swatch({ role, cssVar, note }: SwatchProps): ReactElement {
+  const chipStyle: CSSProperties = {
+    backgroundColor: `var(${cssVar})`,
+  };
+  return (
+    <div className="flex items-center gap-3 rounded border border-border bg-surface px-3 py-2">
+      <div style={chipStyle} className="h-10 w-10 shrink-0 rounded" aria-hidden="true" />
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-medium text-text-primary">{role}</div>
+        <div className="font-mono text-[10px] text-text-tertiary">{cssVar}</div>
+        {note !== undefined ? (
+          <div className="mt-0.5 text-[11px] text-text-secondary">{note}</div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactElement | ReactElement[];
+}): ReactElement {
+  return (
+    <section className="flex flex-col gap-3">
+      <h2 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-text-tertiary">
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+export function PreviewPage(): ReactElement {
+  return (
+    <div className="flex h-full flex-col overflow-y-auto">
+      <header className="border-b border-border px-6 py-4">
+        <h1 className="text-base font-medium text-text-primary">Preview · warm palette</h1>
+        <p className="text-xs text-text-tertiary">
+          Living reference. Not linked from nav. Visit /console/_preview.
+        </p>
+      </header>
+
+      <main className="mx-auto flex w-full max-w-[1000px] flex-col gap-10 px-6 py-8">
+        <Section title="Run cards · every status">
+          <div className="flex flex-col gap-2">
+            {SAMPLE_RUNS.map(run => (
+              <RunCard key={run.id} run={run} showProject={true} />
+            ))}
+          </div>
+        </Section>
+
+        <Section title="Project tiles · hash-based colors">
+          <div className="flex flex-wrap gap-3 rounded border border-border bg-surface p-4">
+            {SAMPLE_PROJECTS.map((p, i) => (
+              <ProjectTile
+                key={p.id}
+                projectId={p.id}
+                name={p.name}
+                selected={i === 0}
+                onClick={(): void => {
+                  /* preview only */
+                }}
+              />
+            ))}
+          </div>
+          <p className="text-[11px] text-text-tertiary">
+            Color seeded deterministically from project id. First tile shown as the
+            currently-selected scope.
+          </p>
+        </Section>
+
+        <Section title="Origin badges">
+          <div className="flex flex-wrap gap-2">
+            <OriginBadge origin="web" />
+            <OriginBadge origin="cli" />
+            <OriginBadge origin="slack" />
+            <OriginBadge origin="telegram" />
+            <OriginBadge origin="discord" />
+            <OriginBadge origin="github" />
+            <OriginBadge origin="unknown" />
+          </div>
+        </Section>
+
+        <Section title="Buttons">
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              className="rounded bg-accent-bright px-3 py-1.5 text-sm font-medium text-white/95 transition-opacity hover:brightness-110"
+            >
+              Primary · Add project
+            </button>
+            <button
+              type="button"
+              className="rounded border border-border bg-surface px-3 py-1.5 text-sm text-text-primary transition-colors hover:bg-surface-hover"
+            >
+              Secondary · Cancel
+            </button>
+            <button
+              type="button"
+              className="rounded px-3 py-1.5 text-sm text-error hover:bg-error/10"
+            >
+              Destructive · Remove
+            </button>
+            <button
+              type="button"
+              className="rounded bg-success/20 px-3 py-1.5 text-sm font-medium text-success hover:bg-success/30"
+            >
+              Approve
+            </button>
+            <button
+              type="button"
+              className="rounded px-3 py-1.5 text-sm text-error hover:underline"
+            >
+              Reject
+            </button>
+          </div>
+        </Section>
+
+        <Section title="Surfaces">
+          <div className="grid grid-cols-2 gap-3">
+            <Swatch role="Surface" cssVar="--surface" note="main content bg" />
+            <Swatch role="Surface inset" cssVar="--surface-inset" note="rail, inner wells" />
+            <Swatch
+              role="Surface elevated"
+              cssVar="--surface-elevated"
+              note="dialogs, popovers, selected chips"
+            />
+            <Swatch
+              role="Surface hover"
+              cssVar="--surface-hover"
+              note="hover state on rows/cards"
+            />
+          </div>
+        </Section>
+
+        <Section title="Text">
+          <div className="grid grid-cols-3 gap-3">
+            <Swatch role="Text primary" cssVar="--text-primary" />
+            <Swatch role="Text secondary" cssVar="--text-secondary" />
+            <Swatch role="Text tertiary" cssVar="--text-tertiary" />
+          </div>
+        </Section>
+
+        <Section title="Accent (primary CTAs only)">
+          <div className="grid grid-cols-3 gap-3">
+            <Swatch
+              role="Accent bright"
+              cssVar="--accent-bright"
+              note="Add project, Submit, primary buttons"
+            />
+            <Swatch role="Accent" cssVar="--accent" />
+            <Swatch role="Accent hover" cssVar="--accent-hover" />
+          </div>
+        </Section>
+
+        <Section title="Status">
+          <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
+            <Swatch
+              role="Running"
+              cssVar="--running"
+              note="active strip (pulsing) + dot; in-progress"
+            />
+            <Swatch role="Paused" cssVar="--warning" note="approval card, paused dot (pulsing)" />
+            <Swatch role="Failed" cssVar="--error" note="failed strip, reject, destructive" />
+            <Swatch
+              role="Completed"
+              cssVar="--success"
+              note="completed strip (muted), check icons, Approve"
+            />
+          </div>
+        </Section>
+
+        <Section title="Borders">
+          <div className="grid grid-cols-2 gap-3">
+            <Swatch role="Border" cssVar="--border" />
+            <Swatch role="Border bright" cssVar="--border-bright" />
+          </div>
+        </Section>
+      </main>
+    </div>
+  );
+}

--- a/packages/web/src/experiments/console/routes/PreviewPage.tsx
+++ b/packages/web/src/experiments/console/routes/PreviewPage.tsx
@@ -13,6 +13,7 @@ import type { Run } from '../primitives/run';
 const baseRun: Omit<Run, 'id' | 'workflow' | 'status'> = {
   projectId: 'demo',
   projectName: 'archon-core',
+  costUsd: null,
   conversationId: null,
   conversationPlatformId: null,
   origin: 'cli',

--- a/packages/web/src/experiments/console/routes/RunDetailPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunDetailPage.tsx
@@ -8,7 +8,8 @@ import { ApprovalContext } from '../components/ApprovalContext';
 import { ApprovalPanel } from '../components/ApprovalPanel';
 import { RunGraphPanel } from '../components/RunGraphPanel';
 import { StreamContextProvider } from '../lib/stream-context';
-import { useEntity, set as setCache } from '../store/cache';
+import { useRunStreamSSE } from '../lib/sse';
+import { useEntity } from '../store/cache';
 import { K } from '../store/keys';
 import * as skill from '../skills';
 import type { Run } from '../primitives/run';
@@ -124,36 +125,11 @@ export function RunDetailPage(): ReactElement {
         : Promise.resolve([])
   );
 
-  // Polling: refetch run detail + messages every 3s while running / paused.
-  useEffect(() => {
-    if (runId === undefined) return;
-    const alive = detail?.run.status === 'running' || detail?.run.status === 'paused';
-    if (!alive) return;
-
-    const handle = setInterval(() => {
-      void skill
-        .getRun(runId)
-        .then(next => {
-          setCache(K.run(runId), next);
-        })
-        .catch(() => {
-          /* swallow — will surface via useEntity */
-        });
-      if (conversationPlatformId !== null) {
-        void skill
-          .listMessages(conversationPlatformId)
-          .then(next => {
-            setCache(K.messages(conversationPlatformId), next);
-          })
-          .catch(() => {
-            /* swallow */
-          });
-      }
-    }, 3000);
-    return (): void => {
-      clearInterval(handle);
-    };
-  }, [runId, conversationPlatformId, detail?.run.status]);
+  // Live updates: subscribe to the conversation SSE stream. Events here
+  // invalidate the run and messages caches; useEntity refetches authoritative
+  // state. Auto-reconnects on disconnect. The hook itself no-ops while the
+  // conversation id is still unknown.
+  useRunStreamSSE(conversationPlatformId, runId ?? null);
 
   // Auto-scroll to bottom on new content IF user is already near the bottom.
   const lastBottomRef = useRef(true);

--- a/packages/web/src/experiments/console/routes/RunDetailPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunDetailPage.tsx
@@ -1,0 +1,265 @@
+import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react';
+import { useParams } from 'react-router';
+import { RunDetailHeader } from '../components/RunDetailHeader';
+import { RunStream } from '../components/RunStream';
+import { RunActionBar } from '../components/RunActionBar';
+import { StreamToolbar } from '../components/StreamToolbar';
+import { ApprovalContext } from '../components/ApprovalContext';
+import { ApprovalPanel } from '../components/ApprovalPanel';
+import { RunGraphPanel } from '../components/RunGraphPanel';
+import { StreamContextProvider } from '../lib/stream-context';
+import { useEntity, set as setCache } from '../store/cache';
+import { K } from '../store/keys';
+import * as skill from '../skills';
+import type { Run } from '../primitives/run';
+import type { RunEvent } from '../primitives/event';
+import type { Message } from '../primitives/message';
+import type { Project } from '../primitives/project';
+
+interface RunDetailView {
+  run: Run;
+  events: RunEvent[];
+}
+
+/**
+ * Run detail — the "logs" page, promoted out of a hidden tab.
+ *
+ * Data sources:
+ *   - skill.getRun(id)     → run metadata + workflow_events
+ *   - skill.listMessages() → conversation messages (assistant text, user input,
+ *                            persisted tool calls in metadata)
+ *
+ * RunStream merges both into one timeline. Paused runs render the
+ * ApprovalContext + ApprovalPanel at the bottom of the stream so the user can
+ * answer the gate in place.
+ *
+ * Polling every 3s until SSE lands in M4.
+ */
+const TOGGLE_KEYS = {
+  toolCalls: 'archon.console.showToolCalls',
+  system: 'archon.console.showSystem',
+  graph: 'archon.console.showGraph',
+} as const;
+
+function readToggle(key: string, defaultOn: boolean): boolean {
+  try {
+    const stored = localStorage.getItem(key);
+    if (stored === null) return defaultOn;
+    return stored === '1';
+  } catch {
+    return defaultOn;
+  }
+}
+
+function writeToggle(key: string, value: boolean): void {
+  try {
+    localStorage.setItem(key, value ? '1' : '0');
+  } catch {
+    /* ignore */
+  }
+}
+
+export function RunDetailPage(): ReactElement {
+  const { projectId, runId } = useParams<{ projectId: string; runId: string }>();
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [showToolCalls, setShowToolCalls] = useState<boolean>(() =>
+    readToggle(TOGGLE_KEYS.toolCalls, true)
+  );
+  const [showSystem, setShowSystem] = useState<boolean>(() =>
+    readToggle(TOGGLE_KEYS.system, false)
+  );
+  const [showGraph, setShowGraph] = useState<boolean>(() => {
+    // Default: graph on at ≥1280px, off below.
+    if (typeof window === 'undefined') return false;
+    const stored = readToggle(TOGGLE_KEYS.graph, window.innerWidth >= 1280);
+    return stored;
+  });
+
+  // Hoisted above any early returns so the hook order stays stable.
+  const scrollToNode = useCallback((nodeId: string): void => {
+    const el = document.getElementById(`node-transition-${nodeId}`);
+    if (el !== null) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, []);
+
+  const { data: project } = useEntity<Project>(
+    projectId !== undefined ? K.project(projectId) : 'noop:no-project-id',
+    () =>
+      projectId !== undefined
+        ? skill.getProject(projectId)
+        : Promise.resolve(null as unknown as Project)
+  );
+
+  const { data: detail, error: detailError } = useEntity<RunDetailView>(
+    runId !== undefined ? K.run(runId) : 'noop:no-run-id',
+    () =>
+      runId !== undefined ? skill.getRun(runId) : Promise.resolve(null as unknown as RunDetailView)
+  );
+
+  // Messages are tied to the run's conversation — and the /messages endpoint
+  // takes the *platform* conversation id, not the DB id. getRun exposes both;
+  // we consume the platform id here.
+  const conversationPlatformId = detail?.run.conversationPlatformId ?? null;
+
+  const { data: messages } = useEntity<Message[]>(
+    conversationPlatformId !== null
+      ? K.messages(conversationPlatformId)
+      : 'noop:no-conversation-id',
+    () =>
+      conversationPlatformId !== null
+        ? skill.listMessages(conversationPlatformId)
+        : Promise.resolve([])
+  );
+
+  // Polling: refetch run detail + messages every 3s while running / paused.
+  useEffect(() => {
+    if (runId === undefined) return;
+    const alive = detail?.run.status === 'running' || detail?.run.status === 'paused';
+    if (!alive) return;
+
+    const handle = setInterval(() => {
+      void skill
+        .getRun(runId)
+        .then(next => {
+          setCache(K.run(runId), next);
+        })
+        .catch(() => {
+          /* swallow — will surface via useEntity */
+        });
+      if (conversationPlatformId !== null) {
+        void skill
+          .listMessages(conversationPlatformId)
+          .then(next => {
+            setCache(K.messages(conversationPlatformId), next);
+          })
+          .catch(() => {
+            /* swallow */
+          });
+      }
+    }, 3000);
+    return (): void => {
+      clearInterval(handle);
+    };
+  }, [runId, conversationPlatformId, detail?.run.status]);
+
+  // Auto-scroll to bottom on new content IF user is already near the bottom.
+  const lastBottomRef = useRef(true);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el === null) return;
+    // Near-bottom heuristic: within 120px of the end.
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 120;
+    lastBottomRef.current = atBottom;
+  });
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el === null || !lastBottomRef.current) return;
+    el.scrollTop = el.scrollHeight;
+  }, [messages?.length, detail?.events.length]);
+
+  if (projectId === undefined || runId === undefined) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-text-tertiary">
+        Invalid run URL.
+      </div>
+    );
+  }
+
+  if (detailError !== undefined) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 text-center">
+        <p className="text-sm text-text-primary">Could not load run.</p>
+        <p className="font-mono text-[11px] text-text-tertiary">{detailError.message}</p>
+      </div>
+    );
+  }
+
+  if (detail === undefined) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-text-tertiary">
+        Loading run…
+      </div>
+    );
+  }
+
+  const { run, events } = detail;
+  const messageList = messages ?? [];
+  const toolCallCount = messageList.reduce((acc, m) => acc + m.toolCalls.length, 0);
+
+  return (
+    <StreamContextProvider value={{ runStartedAt: run.startedAt }}>
+      <section className="flex h-full flex-col">
+        <RunDetailHeader run={run} projectId={projectId} projectName={project?.name ?? projectId} />
+
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
+            {/* Stream content centered inside its flex-1 lane with a readable
+                max-width. On wide screens margins land on both sides; the
+                graph (if visible) anchors to the right viewport edge. */}
+            <div className="mx-auto w-full max-w-[820px] px-6">
+              {/* Sticky under RunDetailHeader so toggles stay reachable
+                    while the stream scrolls underneath. */}
+              <div className="sticky top-0 z-10 -mx-6 bg-surface px-6">
+                <StreamToolbar
+                  showToolCalls={showToolCalls}
+                  onToggleToolCalls={next => {
+                    setShowToolCalls(next);
+                    writeToggle(TOGGLE_KEYS.toolCalls, next);
+                  }}
+                  showSystem={showSystem}
+                  onToggleSystem={next => {
+                    setShowSystem(next);
+                    writeToggle(TOGGLE_KEYS.system, next);
+                  }}
+                  showGraph={showGraph}
+                  onToggleGraph={next => {
+                    setShowGraph(next);
+                    writeToggle(TOGGLE_KEYS.graph, next);
+                  }}
+                  toolCallCount={toolCallCount}
+                  messageCount={messageList.length}
+                />
+              </div>
+
+              <div className="py-4">
+                <RunStream
+                  messages={messageList}
+                  events={events}
+                  showToolCalls={showToolCalls}
+                  showSystem={showSystem}
+                />
+
+                {run.status === 'paused' && run.approval !== null && run.approval !== undefined ? (
+                  <div className="mt-6 rounded border border-warning/30 bg-warning/[0.04] p-4">
+                    <div className="mb-2 flex items-center gap-2">
+                      <span aria-hidden className="h-2 w-2 animate-pulse rounded-full bg-warning" />
+                      <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-warning">
+                        Waiting for approval
+                      </span>
+                    </div>
+                    <ApprovalContext run={run} />
+                    <div className="mt-2">
+                      <ApprovalPanel run={run} />
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          </div>
+
+          {showGraph && project !== undefined && project !== null ? (
+            <RunGraphPanel
+              workflowName={run.workflow}
+              projectCwd={project.path}
+              events={events}
+              onNodeSelect={scrollToNode}
+            />
+          ) : null}
+        </div>
+
+        <RunActionBar run={run} />
+      </section>
+    </StreamContextProvider>
+  );
+}

--- a/packages/web/src/experiments/console/routes/RunDetailPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunDetailPage.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router';
 import { RunDetailHeader } from '../components/RunDetailHeader';
 import { RunStream } from '../components/RunStream';
 import { RunActionBar } from '../components/RunActionBar';
-import { StreamToolbar } from '../components/StreamToolbar';
+import { StreamToolbar, type DetailView } from '../components/StreamToolbar';
 import { ApprovalContext } from '../components/ApprovalContext';
 import { ApprovalPanel } from '../components/ApprovalPanel';
 import { RunGraphPanel } from '../components/RunGraphPanel';
@@ -38,7 +38,7 @@ interface RunDetailView {
 const TOGGLE_KEYS = {
   toolCalls: 'archon.console.showToolCalls',
   system: 'archon.console.showSystem',
-  graph: 'archon.console.showGraph',
+  view: 'archon.console.detailView',
 } as const;
 
 function readToggle(key: string, defaultOn: boolean): boolean {
@@ -59,6 +59,23 @@ function writeToggle(key: string, value: boolean): void {
   }
 }
 
+function readView(): DetailView {
+  try {
+    const stored = localStorage.getItem(TOGGLE_KEYS.view);
+    return stored === 'graph' ? 'graph' : 'log';
+  } catch {
+    return 'log';
+  }
+}
+
+function writeView(v: DetailView): void {
+  try {
+    localStorage.setItem(TOGGLE_KEYS.view, v);
+  } catch {
+    /* ignore */
+  }
+}
+
 export function RunDetailPage(): ReactElement {
   const { projectId, runId } = useParams<{ projectId: string; runId: string }>();
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -68,12 +85,7 @@ export function RunDetailPage(): ReactElement {
   const [showSystem, setShowSystem] = useState<boolean>(() =>
     readToggle(TOGGLE_KEYS.system, false)
   );
-  const [showGraph, setShowGraph] = useState<boolean>(() => {
-    // Default: graph on at ≥1280px, off below.
-    if (typeof window === 'undefined') return false;
-    const stored = readToggle(TOGGLE_KEYS.graph, window.innerWidth >= 1280);
-    return stored;
-  });
+  const [view, setView] = useState<DetailView>(() => readView());
 
   // Hoisted above any early returns so the hook order stays stable.
   const scrollToNode = useCallback((nodeId: string): void => {
@@ -194,75 +206,91 @@ export function RunDetailPage(): ReactElement {
       : 0;
   const toolCallCount = inlineToolCount + workflowToolCount;
 
+  const toolbar = (
+    <StreamToolbar
+      view={view}
+      onChangeView={next => {
+        setView(next);
+        writeView(next);
+      }}
+      showToolCalls={showToolCalls}
+      onToggleToolCalls={next => {
+        setShowToolCalls(next);
+        writeToggle(TOGGLE_KEYS.toolCalls, next);
+      }}
+      showSystem={showSystem}
+      onToggleSystem={next => {
+        setShowSystem(next);
+        writeToggle(TOGGLE_KEYS.system, next);
+      }}
+      toolCallCount={toolCallCount}
+      messageCount={messageList.length}
+    />
+  );
+
   return (
     <StreamContextProvider value={{ runStartedAt: run.startedAt }}>
       <section className="flex h-full flex-col">
         <RunDetailHeader run={run} projectId={projectId} projectName={project?.name ?? projectId} />
 
-        <div className="flex min-h-0 flex-1 overflow-hidden">
-          <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
-            {/* Stream content centered inside its flex-1 lane with a readable
-                max-width. On wide screens margins land on both sides; the
-                graph (if visible) anchors to the right viewport edge. */}
-            <div className="mx-auto w-full max-w-[820px] px-6">
-              {/* Sticky under RunDetailHeader so toggles stay reachable
-                    while the stream scrolls underneath. */}
-              <div className="sticky top-0 z-10 -mx-6 bg-surface px-6">
-                <StreamToolbar
-                  showToolCalls={showToolCalls}
-                  onToggleToolCalls={next => {
-                    setShowToolCalls(next);
-                    writeToggle(TOGGLE_KEYS.toolCalls, next);
-                  }}
-                  showSystem={showSystem}
-                  onToggleSystem={next => {
-                    setShowSystem(next);
-                    writeToggle(TOGGLE_KEYS.system, next);
-                  }}
-                  showGraph={showGraph}
-                  onToggleGraph={next => {
-                    setShowGraph(next);
-                    writeToggle(TOGGLE_KEYS.graph, next);
-                  }}
-                  toolCallCount={toolCallCount}
-                  messageCount={messageList.length}
-                />
-              </div>
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          {view === 'log' ? (
+            <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
+              <div className="w-full px-6">
+                <div className="sticky top-0 z-10 -mx-6 bg-surface px-6">{toolbar}</div>
 
-              <div className="py-4">
-                <RunStream
-                  messages={messageList}
-                  events={events}
-                  showToolCalls={showToolCalls}
-                  showSystem={showSystem}
-                />
+                <div className="py-4">
+                  <RunStream
+                    messages={messageList}
+                    events={events}
+                    showToolCalls={showToolCalls}
+                    showSystem={showSystem}
+                  />
 
-                {run.status === 'paused' && run.approval !== null && run.approval !== undefined ? (
-                  <div className="mt-6 rounded border border-warning/30 bg-warning/[0.04] p-4">
-                    <div className="mb-2 flex items-center gap-2">
-                      <span aria-hidden className="h-2 w-2 animate-pulse rounded-full bg-warning" />
-                      <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-warning">
-                        Waiting for approval
-                      </span>
+                  {run.status === 'paused' &&
+                  run.approval !== null &&
+                  run.approval !== undefined ? (
+                    <div className="mt-6 rounded border border-warning/30 bg-warning/[0.04] p-4">
+                      <div className="mb-2 flex items-center gap-2">
+                        <span
+                          aria-hidden
+                          className="h-2 w-2 animate-pulse rounded-full bg-warning"
+                        />
+                        <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-warning">
+                          Waiting for approval
+                        </span>
+                      </div>
+                      <ApprovalContext run={run} />
+                      <div className="mt-2">
+                        <ApprovalPanel run={run} />
+                      </div>
                     </div>
-                    <ApprovalContext run={run} />
-                    <div className="mt-2">
-                      <ApprovalPanel run={run} />
-                    </div>
-                  </div>
-                ) : null}
+                  ) : null}
+                </div>
               </div>
             </div>
-          </div>
-
-          {showGraph && project !== undefined && project !== null ? (
-            <RunGraphPanel
-              workflowName={run.workflow}
-              projectCwd={project.path}
-              events={events}
-              onNodeSelect={scrollToNode}
-            />
-          ) : null}
+          ) : (
+            <>
+              <div className="px-6">{toolbar}</div>
+              {project !== undefined && project !== null ? (
+                <RunGraphPanel
+                  workflowName={run.workflow}
+                  projectCwd={project.path}
+                  events={events}
+                  onNodeSelect={(nodeId): void => {
+                    setView('log');
+                    writeView('log');
+                    // Defer scroll until the log view has mounted.
+                    requestAnimationFrame(() => {
+                      scrollToNode(nodeId);
+                    });
+                  }}
+                />
+              ) : (
+                <div className="p-6 text-[12px] text-text-tertiary">Loading project…</div>
+              )}
+            </>
+          )}
         </div>
 
         <RunActionBar run={run} />

--- a/packages/web/src/experiments/console/routes/RunDetailPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunDetailPage.tsx
@@ -36,7 +36,8 @@ interface RunDetailView {
  * ApprovalContext + ApprovalPanel at the bottom of the stream so the user can
  * answer the gate in place.
  *
- * Polling every 3s until SSE lands in M4.
+ * Updates flow through SSE (lib/sse.ts) with a 30s safety-net refetch
+ * for runs that are still running/paused.
  */
 const TOGGLE_KEYS = {
   toolCalls: 'archon.console.showToolCalls',

--- a/packages/web/src/experiments/console/routes/RunDetailPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunDetailPage.tsx
@@ -185,7 +185,14 @@ export function RunDetailPage(): ReactElement {
 
   const { run, events } = detail;
   const messageList = messages ?? [];
-  const toolCallCount = messageList.reduce((acc, m) => acc + m.toolCalls.length, 0);
+  const inlineToolCount = messageList.reduce((acc, m) => acc + m.toolCalls.length, 0);
+  // Mirror RunStream's source-of-truth rule: when no inline tool calls exist
+  // on messages, the workflow tool_called events become the canonical count.
+  const workflowToolCount =
+    inlineToolCount === 0
+      ? events.filter(e => e.kind === 'tool_call' && e.result === null).length
+      : 0;
+  const toolCallCount = inlineToolCount + workflowToolCount;
 
   return (
     <StreamContextProvider value={{ runStartedAt: run.startedAt }}>

--- a/packages/web/src/experiments/console/routes/RunDetailPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunDetailPage.tsx
@@ -7,6 +7,7 @@ import { StreamToolbar, type DetailView } from '../components/StreamToolbar';
 import { ApprovalContext } from '../components/ApprovalContext';
 import { ApprovalPanel } from '../components/ApprovalPanel';
 import { RunGraphPanel } from '../components/RunGraphPanel';
+import { ArtifactPanel } from '../components/ArtifactPanel';
 import { StreamContextProvider } from '../lib/stream-context';
 import { useRunStreamSSE } from '../lib/sse';
 import { useEntity } from '../store/cache';
@@ -16,6 +17,7 @@ import type { Run } from '../primitives/run';
 import type { RunEvent } from '../primitives/event';
 import type { Message } from '../primitives/message';
 import type { Project } from '../primitives/project';
+import type { ArtifactFile } from '../skills/runs';
 
 interface RunDetailView {
   run: Run;
@@ -131,6 +133,15 @@ export function RunDetailPage(): ReactElement {
   // conversation id is still unknown.
   useRunStreamSSE(conversationPlatformId, runId ?? null);
 
+  // Surface the artifact count on the tab even when the user hasn't visited
+  // the panel yet. Cheap call — the server walks one directory. Must live
+  // above any early return so the hook order stays stable across renders.
+  const { data: artifactFiles } = useEntity<ArtifactFile[]>(
+    runId !== undefined ? K.artifacts(runId) : 'noop:no-run-id',
+    () =>
+      runId !== undefined ? skill.listRunArtifacts(runId) : Promise.resolve([] as ArtifactFile[])
+  );
+
   // Auto-scroll to bottom on new content IF user is already near the bottom.
   const lastBottomRef = useRef(true);
   useEffect(() => {
@@ -201,6 +212,7 @@ export function RunDetailPage(): ReactElement {
       }}
       toolCallCount={toolCallCount}
       messageCount={messageList.length}
+      artifactCount={artifactFiles?.length ?? null}
     />
   );
 
@@ -245,7 +257,7 @@ export function RunDetailPage(): ReactElement {
                 </div>
               </div>
             </div>
-          ) : (
+          ) : view === 'graph' ? (
             <>
               <div className="px-6">{toolbar}</div>
               {project !== undefined && project !== null ? (
@@ -265,6 +277,11 @@ export function RunDetailPage(): ReactElement {
               ) : (
                 <div className="p-6 text-[12px] text-text-tertiary">Loading project…</div>
               )}
+            </>
+          ) : (
+            <>
+              <div className="px-6">{toolbar}</div>
+              <ArtifactPanel runId={runId} />
             </>
           )}
         </div>

--- a/packages/web/src/experiments/console/routes/RunDetailPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunDetailPage.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react';
-import { useParams } from 'react-router';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import { useKeymap, type Binding } from '../lib/keymap';
 import { RunDetailHeader } from '../components/RunDetailHeader';
 import { RunStream } from '../components/RunStream';
 import { RunActionBar } from '../components/RunActionBar';
@@ -82,6 +83,7 @@ function writeView(v: DetailView): void {
 
 export function RunDetailPage(): ReactElement {
   const { projectId, runId } = useParams<{ projectId: string; runId: string }>();
+  const navigate = useNavigate();
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const [showToolCalls, setShowToolCalls] = useState<boolean>(() =>
     readToggle(TOGGLE_KEYS.toolCalls, true)
@@ -177,6 +179,87 @@ export function RunDetailPage(): ReactElement {
     if (el === null || !lastBottomRef.current) return;
     el.scrollTop = el.scrollHeight;
   }, [messages?.length, detail?.events.length]);
+
+  // Keymap bindings: hoisted above early returns so the hook order is stable
+  // across all render paths (loading, error, ready).
+  const detailStatus = detail?.run.status ?? null;
+  const isPaused = detailStatus === 'paused';
+  const goBack = useCallback((): void => {
+    if (projectId !== undefined) navigate(`/console/p/${projectId}`);
+    else navigate('/console');
+  }, [navigate, projectId]);
+  const setViewPersist = useCallback((next: DetailView): void => {
+    setView(next);
+    writeView(next);
+  }, []);
+  const toggleToolCalls = useCallback((): void => {
+    setShowToolCalls(v => {
+      const next = !v;
+      writeToggle(TOGGLE_KEYS.toolCalls, next);
+      return next;
+    });
+  }, []);
+  const toggleSystem = useCallback((): void => {
+    setShowSystem(v => {
+      const next = !v;
+      writeToggle(TOGGLE_KEYS.system, next);
+      return next;
+    });
+  }, []);
+  // Approve/Reject keymap bindings fire the matching button's click event
+  // rather than lifting ApprovalPanel's internal state — keeps the panel
+  // self-contained and avoids prop drilling for a paused-only shortcut.
+  const clickApprove = useCallback((): void => {
+    const el = document.querySelector<HTMLButtonElement>('[data-keymap-approve]');
+    if (el !== null && !el.disabled) el.click();
+  }, []);
+  const clickReject = useCallback((): void => {
+    const el = document.querySelector<HTMLButtonElement>('[data-keymap-reject]');
+    if (el !== null && !el.disabled) el.click();
+  }, []);
+  const bindings = useMemo<readonly Binding[]>(
+    () => [
+      {
+        keys: ['1'],
+        label: 'Log tab',
+        run: (): void => {
+          setViewPersist('log');
+        },
+      },
+      {
+        keys: ['2'],
+        label: 'Graph tab',
+        run: (): void => {
+          setViewPersist('graph');
+        },
+      },
+      {
+        keys: ['3'],
+        label: 'Artifacts tab',
+        run: (): void => {
+          setViewPersist('artifacts');
+        },
+      },
+      { keys: ['t'], label: 'Toggle tool calls', run: toggleToolCalls },
+      { keys: ['s'], label: 'Toggle system', run: toggleSystem },
+      {
+        keys: ['a'],
+        label: 'Approve',
+        when: (): boolean => isPaused,
+        run: clickApprove,
+      },
+      {
+        keys: ['r'],
+        label: 'Reject',
+        when: (): boolean => isPaused,
+        run: clickReject,
+      },
+      { keys: ['Escape'], label: 'Back to runs', run: goBack },
+      { keys: ['h'], label: 'Back to runs', run: goBack },
+    ],
+    [isPaused, goBack, setViewPersist, toggleToolCalls, toggleSystem, clickApprove, clickReject]
+  );
+  useKeymap({ bindings });
 
   if (projectId === undefined || runId === undefined) {
     return (

--- a/packages/web/src/experiments/console/routes/RunDetailPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunDetailPage.tsx
@@ -98,18 +98,18 @@ export function RunDetailPage(): ReactElement {
     }
   }, []);
 
-  const { data: project } = useEntity<Project>(
+  // `Project | null` / `RunDetailView | null` rather than the `as unknown as T`
+  // casts the original sentinel used — keeps the null path honest for
+  // downstream readers (they can guard explicitly instead of meeting a
+  // mis-typed value).
+  const { data: project } = useEntity<Project | null>(
     projectId !== undefined ? K.project(projectId) : 'noop:no-project-id',
-    () =>
-      projectId !== undefined
-        ? skill.getProject(projectId)
-        : Promise.resolve(null as unknown as Project)
+    () => (projectId !== undefined ? skill.getProject(projectId) : Promise.resolve(null))
   );
 
-  const { data: detail, error: detailError } = useEntity<RunDetailView>(
+  const { data: detail, error: detailError } = useEntity<RunDetailView | null>(
     runId !== undefined ? K.run(runId) : 'noop:no-run-id',
-    () =>
-      runId !== undefined ? skill.getRun(runId) : Promise.resolve(null as unknown as RunDetailView)
+    () => (runId !== undefined ? skill.getRun(runId) : Promise.resolve(null))
   );
 
   // Messages are tied to the run's conversation — and the /messages endpoint
@@ -194,7 +194,7 @@ export function RunDetailPage(): ReactElement {
     );
   }
 
-  if (detail === undefined) {
+  if (detail === undefined || detail === null) {
     return (
       <div className="flex h-full items-center justify-center text-sm text-text-tertiary">
         Loading run…

--- a/packages/web/src/experiments/console/routes/RunDetailPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunDetailPage.tsx
@@ -10,7 +10,7 @@ import { RunGraphPanel } from '../components/RunGraphPanel';
 import { ArtifactPanel } from '../components/ArtifactPanel';
 import { StreamContextProvider } from '../lib/stream-context';
 import { useRunStreamSSE } from '../lib/sse';
-import { useEntity } from '../store/cache';
+import { useEntity, invalidate } from '../store/cache';
 import { K } from '../store/keys';
 import * as skill from '../skills';
 import type { Run } from '../primitives/run';
@@ -132,6 +132,26 @@ export function RunDetailPage(): ReactElement {
   // state. Auto-reconnects on disconnect. The hook itself no-ops while the
   // conversation id is still unknown.
   useRunStreamSSE(conversationPlatformId, runId ?? null);
+
+  // SSE-drop safety net: if the stream silently dies (network hiccup,
+  // sleep/wake, mobile transitions) the EventSource will reconnect but we
+  // may have missed terminal events in the meantime. A 30s heartbeat refetch
+  // while status is non-terminal catches that without being polling proper —
+  // it stops the moment the run hits a terminal state.
+  const status = detail?.run.status;
+  useEffect(() => {
+    if (runId === undefined) return;
+    if (status !== 'running' && status !== 'paused') return;
+    const id = setInterval(() => {
+      invalidate(K.run(runId));
+      if (conversationPlatformId !== null) {
+        invalidate(K.messages(conversationPlatformId));
+      }
+    }, 30000);
+    return (): void => {
+      clearInterval(id);
+    };
+  }, [runId, status, conversationPlatformId]);
 
   // Surface the artifact count on the tab even when the user hasn't visited
   // the panel yet. Cheap call — the server walks one directory. Must live

--- a/packages/web/src/experiments/console/routes/RunsPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunsPage.tsx
@@ -1,12 +1,13 @@
-import { useEffect, useMemo, useState, type ReactElement } from 'react';
+import { useMemo, useState, type ReactElement } from 'react';
 import { useParams, useSearchParams } from 'react-router';
 import { EmptyState } from '../components/EmptyState';
 import { ActiveRunCard } from '../components/ActiveRunCard';
 import { RecentRunRow } from '../components/RecentRunRow';
 import { FilterChips, type Filter } from '../components/FilterChips';
 import { DraftRunCard } from '../components/DraftRunCard';
-import { useEntity, set as setCache } from '../store/cache';
+import { useEntity } from '../store/cache';
 import { K, type Scope } from '../store/keys';
+import { useDashboardSSE } from '../lib/sse';
 import * as skill from '../skills';
 import type { Run } from '../primitives/run';
 import type { RunCounts } from '../skills/runs';
@@ -246,22 +247,10 @@ export function RunsPage(): ReactElement {
     skill.listRuns(scope === 'all' ? {} : { codebaseId: scope })
   );
 
-  // Polling fallback every 3s until SSE lands in M4.
-  useEffect(() => {
-    const handle = setInterval((): void => {
-      void skill
-        .listRuns(scope === 'all' ? {} : { codebaseId: scope })
-        .then((next: FeedData): void => {
-          setCache(K.runs(scope), next);
-        })
-        .catch((): void => {
-          /* swallow — errors surface via useEntity on next fetch */
-        });
-    }, 3000);
-    return (): void => {
-      clearInterval(handle);
-    };
-  }, [scope]);
+  // Dashboard SSE keeps the runs feed in sync: every workflow_status /
+  // dag_node event invalidates the active runs:* cache keys, triggering a
+  // refetch through useEntity. Replaces the 3s polling loop.
+  useDashboardSSE();
 
   // Scoped project (drives the DraftRunCard inside the feed when not ALL).
   const { data: project } = useEntity<Project>(

--- a/packages/web/src/experiments/console/routes/RunsPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunsPage.tsx
@@ -1,0 +1,346 @@
+import { useEffect, useMemo, useState, type ReactElement } from 'react';
+import { useParams, useSearchParams } from 'react-router';
+import { EmptyState } from '../components/EmptyState';
+import { ActiveRunCard } from '../components/ActiveRunCard';
+import { RecentRunRow } from '../components/RecentRunRow';
+import { FilterChips, type Filter } from '../components/FilterChips';
+import { DraftRunCard } from '../components/DraftRunCard';
+import { useEntity, set as setCache } from '../store/cache';
+import { K, type Scope } from '../store/keys';
+import * as skill from '../skills';
+import type { Run } from '../primitives/run';
+import type { RunCounts } from '../skills/runs';
+import type { Project } from '../primitives/project';
+
+interface FeedData {
+  runs: Run[];
+  counts: RunCounts;
+  total: number;
+}
+
+const EMPTY_COUNTS: RunCounts = {
+  all: 0,
+  running: 0,
+  paused: 0,
+  failed: 0,
+  completed: 0,
+  cancelled: 0,
+  pending: 0,
+};
+
+/**
+ * Demo runs injected when `?demo=1` is in the URL. Lets us eyeball card colors
+ * in context against whatever real runs exist. Ids start with `demo-` so the
+ * detail-page navigation can be made a no-op later if needed.
+ */
+function buildDemoRuns(scope: Scope, projectName: string | null): Run[] {
+  const now = Date.now();
+  const iso = (secondsAgo: number): string => new Date(now - secondsAgo * 1000).toISOString();
+  const project = scope === 'all' ? 'archon-core' : scope;
+  const projName = projectName ?? 'archon-core';
+  const base = {
+    projectId: project,
+    projectName: projName,
+    conversationId: null as string | null,
+    conversationPlatformId: null as string | null,
+    workingPath: null,
+    userMessage: '',
+    finishedAt: null as string | null,
+  };
+  return [
+    {
+      ...base,
+      id: 'demo-running-1',
+      workflow: 'plan',
+      origin: 'cli',
+      status: 'running',
+      startedAt: iso(4 * 60 + 12),
+      currentNode: 'plan/draft',
+      lastTool: 'read_file',
+    },
+    {
+      ...base,
+      id: 'demo-running-2',
+      workflow: 'implement',
+      origin: 'web',
+      status: 'running',
+      startedAt: iso(9 * 60 + 38),
+      currentNode: 'implement/loop',
+      lastTool: 'edit_file',
+    },
+    {
+      ...base,
+      id: 'demo-paused-1',
+      workflow: 'archon-interactive-prd',
+      origin: 'web',
+      status: 'paused',
+      startedAt: iso(14 * 60 + 22),
+      currentNode: 'foundation-gate',
+      lastTool: null,
+      approval: {
+        nodeId: 'foundation-gate',
+        message:
+          'Answer the foundation questions above. Your answers will guide the research phase.',
+      },
+    },
+    {
+      ...base,
+      id: 'demo-paused-2',
+      workflow: 'review',
+      origin: 'slack',
+      status: 'paused',
+      startedAt: iso(4 * 60 + 2),
+      currentNode: 'review/approve',
+      lastTool: null,
+      approval: {
+        nodeId: 'review/approve',
+        message: 'Approve changes before opening PR?',
+      },
+    },
+    {
+      ...base,
+      id: 'demo-failed-1',
+      workflow: 'test',
+      origin: 'github',
+      status: 'failed',
+      startedAt: iso(2 * 60 + 41),
+      finishedAt: iso(0),
+      currentNode: 'implement/verify',
+      lastTool: null,
+    },
+    {
+      ...base,
+      id: 'demo-completed-1',
+      workflow: 'assist',
+      origin: 'telegram',
+      status: 'completed',
+      startedAt: iso(8 * 60 + 14),
+      finishedAt: iso(0),
+      currentNode: null,
+      lastTool: null,
+    },
+  ] satisfies Run[];
+}
+
+function mergeCounts(a: RunCounts, b: RunCounts): RunCounts {
+  return {
+    all: a.all + b.all,
+    running: a.running + b.running,
+    paused: a.paused + b.paused,
+    failed: a.failed + b.failed,
+    completed: a.completed + b.completed,
+    cancelled: a.cancelled + b.cancelled,
+    pending: a.pending + b.pending,
+  };
+}
+
+function countsFromRuns(runs: Run[]): RunCounts {
+  const out: RunCounts = { ...EMPTY_COUNTS };
+  for (const r of runs) {
+    out.all += 1;
+    if (r.status === 'running') out.running += 1;
+    else if (r.status === 'paused') out.paused += 1;
+    else if (r.status === 'failed') out.failed += 1;
+    else if (r.status === 'completed') out.completed += 1;
+    else if (r.status === 'cancelled') out.cancelled += 1;
+  }
+  return out;
+}
+
+function filterRuns(runs: Run[], filter: Filter, query: string): Run[] {
+  const q = query.trim().toLowerCase();
+  return runs.filter(r => {
+    if (filter !== 'all' && r.status !== filter) return false;
+    if (q.length === 0) return true;
+    return (
+      r.workflow.toLowerCase().includes(q) ||
+      (r.projectName ?? '').toLowerCase().includes(q) ||
+      r.id.toLowerCase().startsWith(q)
+    );
+  });
+}
+
+interface SectionHeaderProps {
+  label: string;
+  count: number;
+}
+
+function SectionHeader({ label, count }: SectionHeaderProps): ReactElement {
+  return (
+    <div className="mb-2 flex items-center gap-3">
+      <span className="text-[10px] font-semibold uppercase tracking-[0.2em] text-text-tertiary">
+        {label}
+      </span>
+      <span className="font-mono text-[11px] tabular-nums text-text-tertiary">{count}</span>
+      <div className="h-px flex-1 bg-border/60" aria-hidden />
+    </div>
+  );
+}
+
+interface RunsFeedProps {
+  runs: Run[];
+  showProject: boolean;
+  draftProject: { id: string; path: string } | null;
+}
+
+/**
+ * Feed split into Active (running + paused) and Recent (completed / failed /
+ * cancelled). Active cards get real estate; Recent collapses to compact rows.
+ * Matches the attention model: completed runs rarely get checked unless
+ * something went wrong — so failed stays eye-catching, completed is muted.
+ *
+ * When a project is scoped, a DraftRunCard sits at the top of Active — same
+ * card shape as a paused-approval card, just waiting for YOU instead of
+ * the agent. Starting a new run is "another card in the list."
+ */
+function RunsFeed({ runs, showProject, draftProject }: RunsFeedProps): ReactElement {
+  const active = runs.filter(r => r.status === 'running' || r.status === 'paused');
+  const recent = runs.filter(
+    r => r.status === 'completed' || r.status === 'failed' || r.status === 'cancelled'
+  );
+
+  const showActiveSection = active.length > 0 || draftProject !== null;
+
+  return (
+    <div className="flex flex-col gap-8">
+      {showActiveSection ? (
+        <section>
+          <SectionHeader label="Active" count={active.length} />
+          <div className="flex flex-col gap-2">
+            {draftProject !== null ? (
+              <DraftRunCard projectId={draftProject.id} projectCwd={draftProject.path} />
+            ) : null}
+            {active.map(run => (
+              <ActiveRunCard key={run.id} run={run} showProject={showProject} />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {recent.length > 0 ? (
+        <section>
+          <SectionHeader label="Recent" count={recent.length} />
+          <div className="flex flex-col overflow-hidden rounded border border-border/60">
+            {recent.map(run => (
+              <RecentRunRow key={run.id} run={run} showProject={showProject} />
+            ))}
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
+export function RunsPage(): ReactElement {
+  const { projectId } = useParams<{ projectId?: string }>();
+  const scope: Scope = projectId ?? 'all';
+  const [searchParams] = useSearchParams();
+  const demoMode = searchParams.get('demo') === '1';
+
+  // Default to `running` — where the user's attention belongs. Completed is a
+  // retrospective view, not the first thing to see.
+  const [filter, setFilter] = useState<Filter>('running');
+  const [query, setQuery] = useState('');
+
+  const { data, loading, error } = useEntity<FeedData>(K.runs(scope), () =>
+    skill.listRuns(scope === 'all' ? {} : { codebaseId: scope })
+  );
+
+  // Polling fallback every 3s until SSE lands in M4.
+  useEffect(() => {
+    const handle = setInterval((): void => {
+      void skill
+        .listRuns(scope === 'all' ? {} : { codebaseId: scope })
+        .then((next: FeedData): void => {
+          setCache(K.runs(scope), next);
+        })
+        .catch((): void => {
+          /* swallow — errors surface via useEntity on next fetch */
+        });
+    }, 3000);
+    return (): void => {
+      clearInterval(handle);
+    };
+  }, [scope]);
+
+  // Scoped project (drives the DraftRunCard inside the feed when not ALL).
+  const { data: project } = useEntity<Project>(
+    scope === 'all' ? 'noop:scope-all' : K.project(scope),
+    () => (scope === 'all' ? Promise.resolve(null as unknown as Project) : skill.getProject(scope))
+  );
+
+  const realRuns = data?.runs ?? [];
+  const realCounts = data?.counts ?? EMPTY_COUNTS;
+
+  const demoRuns = useMemo(
+    () => (demoMode ? buildDemoRuns(scope, project?.name ?? null) : []),
+    [demoMode, scope, project?.name]
+  );
+  const demoCounts = useMemo(() => countsFromRuns(demoRuns), [demoRuns]);
+
+  const allRuns = [...demoRuns, ...realRuns];
+  const counts = demoMode ? mergeCounts(realCounts, demoCounts) : realCounts;
+  const runs = useMemo(() => filterRuns(allRuns, filter, query), [allRuns, filter, query]);
+
+  const heading = scope === 'all' ? 'All projects' : (project?.name ?? 'Project');
+  const hasScopedProject = scope !== 'all' && project !== undefined && project !== null;
+  const draftProject = hasScopedProject ? { id: project.id, path: project.path } : null;
+
+  return (
+    <section className="flex h-full flex-col">
+      <header className="flex flex-col gap-3 border-b border-border px-6 py-4">
+        <div className="flex items-baseline justify-between gap-4">
+          <div className="min-w-0">
+            <h1 className="truncate text-base font-medium text-text-primary">{heading}</h1>
+            <p className="text-xs text-text-tertiary">
+              {scope === 'all' ? 'Every run, across every project.' : (project?.path ?? 'Loading…')}
+              {demoMode ? (
+                <span className="ml-2 rounded border border-warning/40 bg-warning/10 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest text-warning">
+                  demo mocks on
+                </span>
+              ) : null}
+            </p>
+          </div>
+          <input
+            type="text"
+            value={query}
+            onChange={e => {
+              setQuery(e.target.value);
+            }}
+            placeholder="Search workflow, project, run id…"
+            className="h-9 w-64 rounded border border-border bg-surface px-3 font-mono text-xs text-text-primary placeholder:text-text-tertiary focus:border-border-bright focus:outline-none"
+          />
+        </div>
+
+        {scope === 'all' ? (
+          <div className="rounded border border-dashed border-border bg-surface-inset/60 px-3 py-2 text-[12px] text-text-tertiary">
+            Pick a project on the left to start a run.
+          </div>
+        ) : null}
+
+        <FilterChips value={filter} onChange={setFilter} counts={counts} />
+      </header>
+
+      <div className="flex-1 overflow-y-auto px-6 py-4">
+        {error !== undefined && !demoMode ? (
+          <EmptyState title="Could not load runs." hint={error.message} />
+        ) : loading && !demoMode ? (
+          <EmptyState title="Loading…" />
+        ) : runs.length === 0 && draftProject === null ? (
+          <EmptyState
+            title={
+              filter === 'running'
+                ? 'Nothing running right now.'
+                : filter === 'all'
+                  ? 'No runs yet.'
+                  : `No ${filter} runs.`
+            }
+            hint={scope === 'all' ? 'Start one from a project.' : undefined}
+          />
+        ) : (
+          <RunsFeed runs={runs} showProject={scope === 'all'} draftProject={draftProject} />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/experiments/console/routes/RunsPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunsPage.tsx
@@ -42,6 +42,7 @@ function buildDemoRuns(scope: Scope, projectName: string | null): Run[] {
   const base = {
     projectId: project,
     projectName: projName,
+    costUsd: null as number | null,
     conversationId: null as string | null,
     conversationPlatformId: null as string | null,
     workingPath: null,

--- a/packages/web/src/experiments/console/routes/RunsPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunsPage.tsx
@@ -254,9 +254,12 @@ export function RunsPage(): ReactElement {
   useDashboardSSE();
 
   // Scoped project (drives the DraftRunCard inside the feed when not ALL).
-  const { data: project } = useEntity<Project>(
+  // Typed as `Project | null` rather than `Project` so the ALL scope can
+  // legitimately resolve to null without a `null as unknown as Project`
+  // type cast hiding the truth from later readers.
+  const { data: project } = useEntity<Project | null>(
     scope === 'all' ? 'noop:scope-all' : K.project(scope),
-    () => (scope === 'all' ? Promise.resolve(null as unknown as Project) : skill.getProject(scope))
+    () => (scope === 'all' ? Promise.resolve(null) : skill.getProject(scope))
   );
 
   const realRuns = data?.runs ?? [];

--- a/packages/web/src/experiments/console/routes/RunsPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunsPage.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState, type ReactElement } from 'react';
-import { useParams, useSearchParams } from 'react-router';
+import { useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router';
 import { EmptyState } from '../components/EmptyState';
 import { ActiveRunCard } from '../components/ActiveRunCard';
 import { RecentRunRow } from '../components/RecentRunRow';
@@ -8,6 +8,7 @@ import { DraftRunCard } from '../components/DraftRunCard';
 import { useEntity } from '../store/cache';
 import { K, type Scope } from '../store/keys';
 import { useDashboardSSE } from '../lib/sse';
+import { useKeymap, type Binding } from '../lib/keymap';
 import * as skill from '../skills';
 import type { Run } from '../primitives/run';
 import type { RunCounts } from '../skills/runs';
@@ -183,6 +184,7 @@ interface RunsFeedProps {
   runs: Run[];
   showProject: boolean;
   draftProject: { id: string; path: string } | null;
+  selectedRunId: string | null;
 }
 
 /**
@@ -195,7 +197,7 @@ interface RunsFeedProps {
  * card shape as a paused-approval card, just waiting for YOU instead of
  * the agent. Starting a new run is "another card in the list."
  */
-function RunsFeed({ runs, showProject, draftProject }: RunsFeedProps): ReactElement {
+function RunsFeed({ runs, showProject, draftProject, selectedRunId }: RunsFeedProps): ReactElement {
   const active = runs.filter(r => r.status === 'running' || r.status === 'paused');
   const recent = runs.filter(
     r => r.status === 'completed' || r.status === 'failed' || r.status === 'cancelled'
@@ -213,7 +215,12 @@ function RunsFeed({ runs, showProject, draftProject }: RunsFeedProps): ReactElem
               <DraftRunCard projectId={draftProject.id} projectCwd={draftProject.path} />
             ) : null}
             {active.map(run => (
-              <ActiveRunCard key={run.id} run={run} showProject={showProject} />
+              <ActiveRunCard
+                key={run.id}
+                run={run}
+                showProject={showProject}
+                selected={run.id === selectedRunId}
+              />
             ))}
           </div>
         </section>
@@ -224,7 +231,12 @@ function RunsFeed({ runs, showProject, draftProject }: RunsFeedProps): ReactElem
           <SectionHeader label="Recent" count={recent.length} />
           <div className="flex flex-col overflow-hidden rounded border border-border/60">
             {recent.map(run => (
-              <RecentRunRow key={run.id} run={run} showProject={showProject} />
+              <RecentRunRow
+                key={run.id}
+                run={run}
+                showProject={showProject}
+                selected={run.id === selectedRunId}
+              />
             ))}
           </div>
         </section>
@@ -235,6 +247,7 @@ function RunsFeed({ runs, showProject, draftProject }: RunsFeedProps): ReactElem
 
 export function RunsPage(): ReactElement {
   const { projectId } = useParams<{ projectId?: string }>();
+  const navigate = useNavigate();
   const scope: Scope = projectId ?? 'all';
   const [searchParams] = useSearchParams();
   const demoMode = searchParams.get('demo') === '1';
@@ -243,6 +256,9 @@ export function RunsPage(): ReactElement {
   // retrospective view, not the first thing to see.
   const [filter, setFilter] = useState<Filter>('running');
   const [query, setQuery] = useState('');
+  // Selection index for j/k navigation. -1 = nothing selected.
+  const [selectedIndex, setSelectedIndex] = useState<number>(-1);
+  const searchRef = useRef<HTMLInputElement | null>(null);
 
   const { data, loading, error } = useEntity<FeedData>(K.runs(scope), () =>
     skill.listRuns(scope === 'all' ? {} : { codebaseId: scope })
@@ -279,6 +295,131 @@ export function RunsPage(): ReactElement {
   const hasScopedProject = scope !== 'all' && project !== undefined && project !== null;
   const draftProject = hasScopedProject ? { id: project.id, path: project.path } : null;
 
+  // Clamp selection when the visible run set changes so j/k never lands on
+  // an out-of-range index after a filter / search shrinks the list.
+  useEffect(() => {
+    if (selectedIndex >= runs.length) setSelectedIndex(runs.length - 1);
+  }, [runs.length, selectedIndex]);
+
+  const selectedRun = selectedIndex >= 0 ? (runs[selectedIndex] ?? null) : null;
+  const selectedRunId = selectedRun?.id ?? null;
+
+  // Scroll the selected row into view after j/k moves the index. The
+  // RecentRunRow / ActiveRunCard emit a data attribute we can target.
+  // CSS.escape guards against ids containing CSS-special chars (`:`, `.`,
+  // etc.) — without it the selector throws SyntaxError.
+  useEffect(() => {
+    if (selectedRunId === null) return;
+    const el = document.querySelector(`[data-run-id="${CSS.escape(selectedRunId)}"]`);
+    if (el !== null) el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  }, [selectedRunId]);
+
+  const open = (id: string, projId: string | null): void => {
+    if (projId === null) return;
+    navigate(`/console/p/${projId}/r/${id}`);
+  };
+
+  const bindings = useMemo<readonly Binding[]>(
+    () => [
+      {
+        keys: ['j'],
+        label: 'Move down',
+        run: (): void => {
+          if (runs.length === 0) return;
+          setSelectedIndex(i => Math.min(runs.length - 1, (i < 0 ? -1 : i) + 1));
+        },
+      },
+      {
+        keys: ['k'],
+        label: 'Move up',
+        run: (): void => {
+          if (runs.length === 0) return;
+          setSelectedIndex(i => Math.max(0, (i < 0 ? runs.length : i) - 1));
+        },
+      },
+      {
+        keys: ['g', 'g'],
+        label: 'Jump to first',
+        run: (): void => {
+          if (runs.length > 0) setSelectedIndex(0);
+        },
+      },
+      {
+        keys: ['G'],
+        label: 'Jump to last',
+        run: (): void => {
+          if (runs.length > 0) setSelectedIndex(runs.length - 1);
+        },
+      },
+      {
+        keys: ['Enter'],
+        label: 'Open selected',
+        when: (): boolean => selectedRun !== null,
+        run: (): void => {
+          if (selectedRun !== null) open(selectedRun.id, selectedRun.projectId);
+        },
+      },
+      {
+        keys: ['Escape'],
+        label: 'Clear selection',
+        when: (): boolean => selectedIndex !== -1,
+        run: (): void => {
+          setSelectedIndex(-1);
+        },
+      },
+      {
+        keys: ['/'],
+        label: 'Focus search',
+        run: (): void => {
+          searchRef.current?.focus();
+          searchRef.current?.select();
+        },
+      },
+      {
+        keys: ['1'],
+        label: 'Filter: running',
+        run: (): void => {
+          setFilter('running');
+          setSelectedIndex(-1);
+        },
+      },
+      {
+        keys: ['2'],
+        label: 'Filter: paused',
+        run: (): void => {
+          setFilter('paused');
+          setSelectedIndex(-1);
+        },
+      },
+      {
+        keys: ['3'],
+        label: 'Filter: failed',
+        run: (): void => {
+          setFilter('failed');
+          setSelectedIndex(-1);
+        },
+      },
+      {
+        keys: ['4'],
+        label: 'Filter: completed',
+        run: (): void => {
+          setFilter('completed');
+          setSelectedIndex(-1);
+        },
+      },
+      {
+        keys: ['5'],
+        label: 'Filter: all',
+        run: (): void => {
+          setFilter('all');
+          setSelectedIndex(-1);
+        },
+      },
+    ],
+    [runs, selectedIndex, selectedRun]
+  );
+  useKeymap({ bindings });
+
   return (
     <section className="flex h-full flex-col">
       <header className="flex flex-col gap-3 border-b border-border px-6 py-4">
@@ -295,10 +436,19 @@ export function RunsPage(): ReactElement {
             </p>
           </div>
           <input
+            ref={searchRef}
             type="text"
             value={query}
             onChange={e => {
               setQuery(e.target.value);
+            }}
+            onKeyDown={e => {
+              // Esc unfocuses + clears so `/` → type → esc returns control
+              // to the global keymap without trapping the user in the box.
+              if (e.key === 'Escape') {
+                e.currentTarget.blur();
+                setQuery('');
+              }
             }}
             placeholder="Search workflow, project, run id…"
             className="h-9 w-64 rounded border border-border bg-surface px-3 font-mono text-xs text-text-primary placeholder:text-text-tertiary focus:border-border-bright focus:outline-none"
@@ -331,7 +481,12 @@ export function RunsPage(): ReactElement {
             hint={scope === 'all' ? 'Start one from a project.' : undefined}
           />
         ) : (
-          <RunsFeed runs={runs} showProject={scope === 'all'} draftProject={draftProject} />
+          <RunsFeed
+            runs={runs}
+            showProject={scope === 'all'}
+            draftProject={draftProject}
+            selectedRunId={selectedRunId}
+          />
         )}
       </div>
     </section>

--- a/packages/web/src/experiments/console/skills/envVars.ts
+++ b/packages/web/src/experiments/console/skills/envVars.ts
@@ -1,0 +1,34 @@
+import { requestJson } from '../lib/http';
+
+/**
+ * Per-project environment variables.
+ *
+ * The server intentionally never returns values — only keys — so the UI can
+ * never accidentally surface a secret. To rotate a key the user sets a new
+ * value via `setEnvVar`; the existing value is overwritten server-side.
+ */
+
+interface ListEnvVarsResponse {
+  keys: string[];
+}
+
+export async function listEnvVarKeys(projectId: string): Promise<string[]> {
+  const res = await requestJson<ListEnvVarsResponse>(
+    `/api/codebases/${encodeURIComponent(projectId)}/env`
+  );
+  return res.keys;
+}
+
+export async function setEnvVar(projectId: string, key: string, value: string): Promise<void> {
+  await requestJson<{ success: boolean }>(`/api/codebases/${encodeURIComponent(projectId)}/env`, {
+    method: 'PUT',
+    body: JSON.stringify({ key, value }),
+  });
+}
+
+export async function deleteEnvVar(projectId: string, key: string): Promise<void> {
+  await requestJson<{ success: boolean }>(
+    `/api/codebases/${encodeURIComponent(projectId)}/env/${encodeURIComponent(key)}`,
+    { method: 'DELETE' }
+  );
+}

--- a/packages/web/src/experiments/console/skills/index.ts
+++ b/packages/web/src/experiments/console/skills/index.ts
@@ -13,5 +13,6 @@ export * from './worktrees';
 export * from './runs';
 export * from './startRun';
 export * from './messages';
+export * from './envVars';
 
 export { HttpError } from '../lib/http';

--- a/packages/web/src/experiments/console/skills/index.ts
+++ b/packages/web/src/experiments/console/skills/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Skill API — the single mutation surface for the console.
+ *
+ * Every UI action in the console calls exactly one of these verbs.
+ * Internal orchestrators (CLI, Claude Code skill, future LLM driver) call
+ * the same verbs via their own transport. If a UI interaction can't be
+ * expressed as a skill verb, the verb set is wrong, not the UI.
+ */
+
+export * from './projects';
+export * from './workflows';
+export * from './worktrees';
+export * from './runs';
+export * from './startRun';
+export * from './messages';
+
+export { HttpError } from '../lib/http';

--- a/packages/web/src/experiments/console/skills/messages.ts
+++ b/packages/web/src/experiments/console/skills/messages.ts
@@ -1,0 +1,9 @@
+import { requestJson } from '../lib/http';
+import { toMessage, type Message } from '../primitives/message';
+
+export async function listMessages(conversationId: string, limit = 500): Promise<Message[]> {
+  const raw = await requestJson<Parameters<typeof toMessage>[0][]>(
+    `/api/conversations/${encodeURIComponent(conversationId)}/messages?limit=${limit.toString()}`
+  );
+  return raw.map(toMessage);
+}

--- a/packages/web/src/experiments/console/skills/projects.ts
+++ b/packages/web/src/experiments/console/skills/projects.ts
@@ -1,0 +1,36 @@
+import { requestJson } from '../lib/http';
+import { toProject, type Project } from '../primitives/project';
+
+export async function listProjects(): Promise<Project[]> {
+  const raw = await requestJson<Parameters<typeof toProject>[0][]>('/api/codebases');
+  return raw.map(toProject);
+}
+
+export async function getProject(id: string): Promise<Project> {
+  const raw = await requestJson<Parameters<typeof toProject>[0]>(
+    `/api/codebases/${encodeURIComponent(id)}`
+  );
+  return toProject(raw);
+}
+
+export async function addProjectByUrl(url: string): Promise<Project> {
+  const raw = await requestJson<Parameters<typeof toProject>[0]>('/api/codebases', {
+    method: 'POST',
+    body: JSON.stringify({ url }),
+  });
+  return toProject(raw);
+}
+
+export async function addProjectByPath(path: string): Promise<Project> {
+  const raw = await requestJson<Parameters<typeof toProject>[0]>('/api/codebases', {
+    method: 'POST',
+    body: JSON.stringify({ path }),
+  });
+  return toProject(raw);
+}
+
+export async function removeProject(id: string): Promise<void> {
+  await requestJson(`/api/codebases/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  });
+}

--- a/packages/web/src/experiments/console/skills/runs.ts
+++ b/packages/web/src/experiments/console/skills/runs.ts
@@ -2,6 +2,7 @@ import { requestJson } from '../lib/http';
 import { toRun, type Run } from '../primitives/run';
 import { toRunEvent, type RunEvent } from '../primitives/event';
 import type { RunStatus } from '../lib/run-status';
+import type { components } from '@/lib/api.generated';
 
 export interface ListRunsOptions {
   codebaseId?: string;
@@ -107,18 +108,16 @@ export async function abandonRun(id: string): Promise<void> {
   });
 }
 
-export interface ArtifactFile {
-  path: string;
-  size: number;
-  modifiedAt: string;
-}
-
-interface ArtifactListResponse {
-  files: ArtifactFile[];
-}
+/**
+ * Re-exported from the generated OpenAPI types so the console doesn't drift
+ * from the server contract. Schema lives in
+ * packages/server/src/routes/schemas/workflow.schemas.ts.
+ */
+export type ArtifactFile = components['schemas']['ArtifactFile'];
+type ListArtifactsResponse = components['schemas']['ListArtifactsResponse'];
 
 export async function listRunArtifacts(runId: string): Promise<ArtifactFile[]> {
-  const res = await requestJson<ArtifactListResponse>(
+  const res = await requestJson<ListArtifactsResponse>(
     `/api/runs/${encodeURIComponent(runId)}/artifacts`
   );
   return res.files;

--- a/packages/web/src/experiments/console/skills/runs.ts
+++ b/packages/web/src/experiments/console/skills/runs.ts
@@ -1,0 +1,108 @@
+import { requestJson } from '../lib/http';
+import { toRun, type Run } from '../primitives/run';
+import { toRunEvent, type RunEvent } from '../primitives/event';
+import type { RunStatus } from '../lib/run-status';
+
+export interface ListRunsOptions {
+  codebaseId?: string;
+  status?: RunStatus;
+  limit?: number;
+}
+
+export interface RunCounts {
+  all: number;
+  running: number;
+  paused: number;
+  failed: number;
+  completed: number;
+  cancelled: number;
+  pending: number;
+}
+
+interface DashboardRunsResponse {
+  runs: Parameters<typeof toRun>[0][];
+  total: number;
+  counts: Partial<RunCounts>;
+}
+
+function normalizeCounts(c: Partial<RunCounts>): RunCounts {
+  return {
+    all: c.all ?? 0,
+    running: c.running ?? 0,
+    paused: c.paused ?? 0,
+    failed: c.failed ?? 0,
+    completed: c.completed ?? 0,
+    cancelled: c.cancelled ?? 0,
+    pending: c.pending ?? 0,
+  };
+}
+
+export async function listRuns(
+  opts: ListRunsOptions = {}
+): Promise<{ runs: Run[]; counts: RunCounts; total: number }> {
+  const qs = new URLSearchParams();
+  if (opts.codebaseId !== undefined) qs.set('codebaseId', opts.codebaseId);
+  if (opts.status !== undefined) qs.set('status', opts.status);
+  if (opts.limit !== undefined) qs.set('limit', opts.limit.toString());
+  const url = `/api/dashboard/runs${qs.size > 0 ? `?${qs.toString()}` : ''}`;
+  const res = await requestJson<DashboardRunsResponse>(url);
+  return {
+    runs: res.runs.map(toRun),
+    counts: normalizeCounts(res.counts),
+    total: res.total,
+  };
+}
+
+export async function listGlobalCounts(): Promise<RunCounts> {
+  // Counts without any codebase filter — used by top chrome pill.
+  const res = await requestJson<DashboardRunsResponse>('/api/dashboard/runs?limit=1');
+  return normalizeCounts(res.counts);
+}
+
+interface RunDetailResponse {
+  run: Parameters<typeof toRun>[0];
+  events: Parameters<typeof toRunEvent>[0][];
+}
+
+export async function getRun(id: string): Promise<{ run: Run; events: RunEvent[] }> {
+  const res = await requestJson<RunDetailResponse>(`/api/workflows/runs/${encodeURIComponent(id)}`);
+  return {
+    run: toRun(res.run),
+    events: res.events.map(toRunEvent),
+  };
+}
+
+export async function cancelRun(id: string): Promise<void> {
+  await requestJson(`/api/workflows/runs/${encodeURIComponent(id)}/cancel`, {
+    method: 'POST',
+    body: JSON.stringify({}),
+  });
+}
+
+export async function approveRun(id: string, comment?: string): Promise<void> {
+  await requestJson(`/api/workflows/runs/${encodeURIComponent(id)}/approve`, {
+    method: 'POST',
+    body: JSON.stringify(comment !== undefined ? { comment } : {}),
+  });
+}
+
+export async function rejectRun(id: string, reason: string): Promise<void> {
+  await requestJson(`/api/workflows/runs/${encodeURIComponent(id)}/reject`, {
+    method: 'POST',
+    body: JSON.stringify({ reason }),
+  });
+}
+
+export async function resumeRun(id: string): Promise<void> {
+  await requestJson(`/api/workflows/runs/${encodeURIComponent(id)}/resume`, {
+    method: 'POST',
+    body: JSON.stringify({}),
+  });
+}
+
+export async function abandonRun(id: string): Promise<void> {
+  await requestJson(`/api/workflows/runs/${encodeURIComponent(id)}/abandon`, {
+    method: 'POST',
+    body: JSON.stringify({}),
+  });
+}

--- a/packages/web/src/experiments/console/skills/runs.ts
+++ b/packages/web/src/experiments/console/skills/runs.ts
@@ -106,3 +106,31 @@ export async function abandonRun(id: string): Promise<void> {
     body: JSON.stringify({}),
   });
 }
+
+export interface ArtifactFile {
+  path: string;
+  size: number;
+  modifiedAt: string;
+}
+
+interface ArtifactListResponse {
+  files: ArtifactFile[];
+}
+
+export async function listRunArtifacts(runId: string): Promise<ArtifactFile[]> {
+  const res = await requestJson<ArtifactListResponse>(
+    `/api/runs/${encodeURIComponent(runId)}/artifacts`
+  );
+  return res.files;
+}
+
+/** Fetch a single artifact file as text (markdown or plain). */
+export async function fetchArtifact(runId: string, path: string): Promise<string> {
+  const encodedPath = path.split('/').map(encodeURIComponent).join('/');
+  const res = await fetch(`/api/artifacts/${encodeURIComponent(runId)}/${encodedPath}`);
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? `Failed to fetch artifact: ${res.status.toString()}`);
+  }
+  return res.text();
+}

--- a/packages/web/src/experiments/console/skills/startRun.ts
+++ b/packages/web/src/experiments/console/skills/startRun.ts
@@ -65,7 +65,10 @@ export async function startRun({
     } catch {
       /* not JSON */
     }
-    const msg = parsed.error ?? (text.length > 0 ? text : `HTTP ${res.status.toString()}`);
+    // Match requestJson's 200-char truncation so a 502 HTML body doesn't
+    // land in the error toast as raw markup.
+    const raw = parsed.error ?? (text.length > 0 ? text : `HTTP ${res.status.toString()}`);
+    const msg = raw.length > 200 ? `${raw.slice(0, 200)}...` : raw;
     const path = new URL(url, window.location.origin).pathname;
     throw new HttpError(res.status, path, msg);
   }

--- a/packages/web/src/experiments/console/skills/startRun.ts
+++ b/packages/web/src/experiments/console/skills/startRun.ts
@@ -1,4 +1,4 @@
-import { requestJson } from '../lib/http';
+import { requestJson, HttpError } from '../lib/http';
 
 /**
  * Start a run: hides the legacy conversation coupling from the console UI.
@@ -12,29 +12,60 @@ import { requestJson } from '../lib/http';
  *      not wait for it here — callers should invalidate the runs cache and
  *      let the list polling surface the new run as it appears.
  *
+ *      With files attached the dispatch route accepts multipart/form-data,
+ *      mirroring /api/conversations/:id/message. Without files we use JSON.
+ *
  * The word "conversation" appears nowhere in the console outside this file.
  */
 export interface StartRunArgs {
   projectId: string;
   workflow: string;
   message: string;
+  files?: File[];
 }
 
 interface CreateConversationResponse {
   conversationId: string;
 }
 
-export async function startRun({ projectId, workflow, message }: StartRunArgs): Promise<void> {
+export async function startRun({
+  projectId,
+  workflow,
+  message,
+  files,
+}: StartRunArgs): Promise<void> {
   const conv = await requestJson<CreateConversationResponse>('/api/conversations', {
     method: 'POST',
     body: JSON.stringify({ codebaseId: projectId }),
   });
 
-  await requestJson<{ accepted: boolean; status: string }>(
-    `/api/workflows/${encodeURIComponent(workflow)}/run`,
-    {
+  const url = `/api/workflows/${encodeURIComponent(workflow)}/run`;
+
+  if (files === undefined || files.length === 0) {
+    await requestJson<{ accepted: boolean; status: string }>(url, {
       method: 'POST',
       body: JSON.stringify({ conversationId: conv.conversationId, message }),
+    });
+    return;
+  }
+
+  // Multipart path: don't set Content-Type — the browser adds the boundary.
+  const form = new FormData();
+  form.append('conversationId', conv.conversationId);
+  form.append('message', message);
+  for (const file of files) {
+    form.append('files', file, file.name);
+  }
+  const res = await fetch(url, { method: 'POST', body: form });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    let parsed: { error?: string } = {};
+    try {
+      parsed = JSON.parse(text) as { error?: string };
+    } catch {
+      /* not JSON */
     }
-  );
+    const msg = parsed.error ?? (text.length > 0 ? text : `HTTP ${res.status.toString()}`);
+    throw new HttpError(res.status, msg);
+  }
 }

--- a/packages/web/src/experiments/console/skills/startRun.ts
+++ b/packages/web/src/experiments/console/skills/startRun.ts
@@ -1,16 +1,19 @@
 import { requestJson } from '../lib/http';
 
 /**
- * Start a run: two-call sequence that hides the legacy conversation coupling.
+ * Start a run: hides the legacy conversation coupling from the console UI.
  *
- * The backend's POST /api/workflows/:name/run requires a conversationId.
- * Rather than leak that into the console UI, this skill:
- *   1. POST /api/conversations { codebaseId } → get back a fresh conversation id
- *   2. POST /api/workflows/:name/run { conversationId, message } → start the run
+ *   1. POST /api/conversations           → { conversationId, id }
+ *      - `conversationId` is the platform id (`web-<ts>-<rand>`); the dispatch
+ *         route looks the conversation up by *platform* id, not DB UUID.
+ *      - `id` is the DB UUID; workflow runs reference it via `parent_conversation_id`.
+ *   2. POST /api/workflows/:name/run     → { accepted, status }
+ *      - Fire-and-forget. Response does not include a run id; the orchestrator
+ *        creates the workflow_run record asynchronously.
+ *   3. Poll /api/dashboard/runs?codebaseId=…  until a run with the matching
+ *      `parent_conversation_id` (our DB UUID) shows up; return its id.
  *
  * The word "conversation" appears nowhere in the console outside this file.
- * If the run-creation call fails, the orphaned conversation is cleaned up by
- * the backend's cleanup service — don't compensate client-side.
  */
 export interface StartRunArgs {
   projectId: string;
@@ -24,25 +27,39 @@ export interface StartedRunRef {
 }
 
 interface CreateConversationResponse {
+  conversationId: string;
   id: string;
-  [k: string]: unknown;
 }
 
-interface RunWorkflowResponse {
-  runId?: string;
-  run_id?: string;
-  id?: string;
-  [k: string]: unknown;
+interface DashboardRun {
+  id: string;
+  parent_conversation_id: string | null;
 }
 
-function extractRunId(res: RunWorkflowResponse): string {
-  const id = res.runId ?? res.run_id ?? res.id;
-  if (typeof id !== 'string' || id.length === 0) {
-    throw new Error(
-      'startRun: server response did not include a run id; check POST /api/workflows/:name/run schema.'
+interface DashboardRunsResponse {
+  runs: DashboardRun[];
+}
+
+// Workflow dispatch is async: orchestrator clones/creates the worktree, sets up
+// the isolation env, and only then writes the workflow_run row. On a cold start
+// this can take ~10-20s. Window has to be generous enough to swallow that, but
+// short enough that a truly rejected dispatch still surfaces as an error.
+const POLL_INTERVAL_MS = 400;
+const POLL_TIMEOUT_MS = 30_000;
+
+async function pollForRun(codebaseId: string, parentConversationId: string): Promise<string> {
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const res = await requestJson<DashboardRunsResponse>(
+      `/api/dashboard/runs?codebaseId=${encodeURIComponent(codebaseId)}&limit=10`
     );
+    const match = res.runs.find(r => r.parent_conversation_id === parentConversationId);
+    if (match) return match.id;
+    await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
   }
-  return id;
+  throw new Error(
+    `startRun: dispatch accepted but no workflow run record appeared within ${(POLL_TIMEOUT_MS / 1000).toString()}s. The run may still be starting — check the active list.`
+  );
 }
 
 export async function startRun({
@@ -54,15 +71,15 @@ export async function startRun({
     method: 'POST',
     body: JSON.stringify({ codebaseId: projectId }),
   });
-  const conversationId = conv.id;
 
-  const run = await requestJson<RunWorkflowResponse>(
+  await requestJson<{ accepted: boolean; status: string }>(
     `/api/workflows/${encodeURIComponent(workflow)}/run`,
     {
       method: 'POST',
-      body: JSON.stringify({ conversationId, message }),
+      body: JSON.stringify({ conversationId: conv.conversationId, message }),
     }
   );
 
-  return { runId: extractRunId(run), conversationId };
+  const runId = await pollForRun(projectId, conv.id);
+  return { runId, conversationId: conv.conversationId };
 }

--- a/packages/web/src/experiments/console/skills/startRun.ts
+++ b/packages/web/src/experiments/console/skills/startRun.ts
@@ -4,14 +4,13 @@ import { requestJson } from '../lib/http';
  * Start a run: hides the legacy conversation coupling from the console UI.
  *
  *   1. POST /api/conversations           → { conversationId, id }
- *      - `conversationId` is the platform id (`web-<ts>-<rand>`); the dispatch
- *         route looks the conversation up by *platform* id, not DB UUID.
- *      - `id` is the DB UUID; workflow runs reference it via `parent_conversation_id`.
+ *      `conversationId` is the platform id (`web-<ts>-<rand>`); the dispatch
+ *      route looks the conversation up by platform id, not DB UUID.
  *   2. POST /api/workflows/:name/run     → { accepted, status }
- *      - Fire-and-forget. Response does not include a run id; the orchestrator
- *        creates the workflow_run record asynchronously.
- *   3. Poll /api/dashboard/runs?codebaseId=…  until a run with the matching
- *      `parent_conversation_id` (our DB UUID) shows up; return its id.
+ *      Fire-and-forget. The orchestrator creates the workflow_run row
+ *      asynchronously after the HTTP response returns, so we deliberately do
+ *      not wait for it here — callers should invalidate the runs cache and
+ *      let the list polling surface the new run as it appears.
  *
  * The word "conversation" appears nowhere in the console outside this file.
  */
@@ -21,52 +20,11 @@ export interface StartRunArgs {
   message: string;
 }
 
-export interface StartedRunRef {
-  runId: string;
-  conversationId: string;
-}
-
 interface CreateConversationResponse {
   conversationId: string;
-  id: string;
 }
 
-interface DashboardRun {
-  id: string;
-  parent_conversation_id: string | null;
-}
-
-interface DashboardRunsResponse {
-  runs: DashboardRun[];
-}
-
-// Workflow dispatch is async: orchestrator clones/creates the worktree, sets up
-// the isolation env, and only then writes the workflow_run row. On a cold start
-// this can take ~10-20s. Window has to be generous enough to swallow that, but
-// short enough that a truly rejected dispatch still surfaces as an error.
-const POLL_INTERVAL_MS = 400;
-const POLL_TIMEOUT_MS = 30_000;
-
-async function pollForRun(codebaseId: string, parentConversationId: string): Promise<string> {
-  const deadline = Date.now() + POLL_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    const res = await requestJson<DashboardRunsResponse>(
-      `/api/dashboard/runs?codebaseId=${encodeURIComponent(codebaseId)}&limit=10`
-    );
-    const match = res.runs.find(r => r.parent_conversation_id === parentConversationId);
-    if (match) return match.id;
-    await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
-  }
-  throw new Error(
-    `startRun: dispatch accepted but no workflow run record appeared within ${(POLL_TIMEOUT_MS / 1000).toString()}s. The run may still be starting — check the active list.`
-  );
-}
-
-export async function startRun({
-  projectId,
-  workflow,
-  message,
-}: StartRunArgs): Promise<StartedRunRef> {
+export async function startRun({ projectId, workflow, message }: StartRunArgs): Promise<void> {
   const conv = await requestJson<CreateConversationResponse>('/api/conversations', {
     method: 'POST',
     body: JSON.stringify({ codebaseId: projectId }),
@@ -79,7 +37,4 @@ export async function startRun({
       body: JSON.stringify({ conversationId: conv.conversationId, message }),
     }
   );
-
-  const runId = await pollForRun(projectId, conv.id);
-  return { runId, conversationId: conv.conversationId };
 }

--- a/packages/web/src/experiments/console/skills/startRun.ts
+++ b/packages/web/src/experiments/console/skills/startRun.ts
@@ -1,0 +1,68 @@
+import { requestJson } from '../lib/http';
+
+/**
+ * Start a run: two-call sequence that hides the legacy conversation coupling.
+ *
+ * The backend's POST /api/workflows/:name/run requires a conversationId.
+ * Rather than leak that into the console UI, this skill:
+ *   1. POST /api/conversations { codebaseId } → get back a fresh conversation id
+ *   2. POST /api/workflows/:name/run { conversationId, message } → start the run
+ *
+ * The word "conversation" appears nowhere in the console outside this file.
+ * If the run-creation call fails, the orphaned conversation is cleaned up by
+ * the backend's cleanup service — don't compensate client-side.
+ */
+export interface StartRunArgs {
+  projectId: string;
+  workflow: string;
+  message: string;
+}
+
+export interface StartedRunRef {
+  runId: string;
+  conversationId: string;
+}
+
+interface CreateConversationResponse {
+  id: string;
+  [k: string]: unknown;
+}
+
+interface RunWorkflowResponse {
+  runId?: string;
+  run_id?: string;
+  id?: string;
+  [k: string]: unknown;
+}
+
+function extractRunId(res: RunWorkflowResponse): string {
+  const id = res.runId ?? res.run_id ?? res.id;
+  if (typeof id !== 'string' || id.length === 0) {
+    throw new Error(
+      'startRun: server response did not include a run id; check POST /api/workflows/:name/run schema.'
+    );
+  }
+  return id;
+}
+
+export async function startRun({
+  projectId,
+  workflow,
+  message,
+}: StartRunArgs): Promise<StartedRunRef> {
+  const conv = await requestJson<CreateConversationResponse>('/api/conversations', {
+    method: 'POST',
+    body: JSON.stringify({ codebaseId: projectId }),
+  });
+  const conversationId = conv.id;
+
+  const run = await requestJson<RunWorkflowResponse>(
+    `/api/workflows/${encodeURIComponent(workflow)}/run`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ conversationId, message }),
+    }
+  );
+
+  return { runId: extractRunId(run), conversationId };
+}

--- a/packages/web/src/experiments/console/skills/startRun.ts
+++ b/packages/web/src/experiments/console/skills/startRun.ts
@@ -66,6 +66,7 @@ export async function startRun({
       /* not JSON */
     }
     const msg = parsed.error ?? (text.length > 0 ? text : `HTTP ${res.status.toString()}`);
-    throw new HttpError(res.status, msg);
+    const path = new URL(url, window.location.origin).pathname;
+    throw new HttpError(res.status, path, msg);
   }
 }

--- a/packages/web/src/experiments/console/skills/workflows.ts
+++ b/packages/web/src/experiments/console/skills/workflows.ts
@@ -2,26 +2,6 @@ import { requestJson } from '../lib/http';
 import { toWorkflow, type Workflow } from '../primitives/workflow';
 import type { WorkflowGraphNode } from '../primitives/workflow-graph';
 
-interface WorkflowsResponse {
-  workflows: Parameters<typeof toWorkflow>[0][];
-  errors?: unknown[];
-}
-
-export async function listWorkflows(cwd?: string): Promise<Workflow[]> {
-  const qs = cwd !== undefined ? `?cwd=${encodeURIComponent(cwd)}` : '';
-  const res = await requestJson<WorkflowsResponse>(`/api/workflows${qs}`);
-  return res.workflows.map(toWorkflow);
-}
-
-interface GetWorkflowResponse {
-  workflow: {
-    name: string;
-    nodes: RawNode[];
-  };
-  filename: string;
-  source: string;
-}
-
 interface RawNode {
   id: string;
   depends_on?: string[];
@@ -33,32 +13,60 @@ interface RawNode {
   script?: unknown;
 }
 
+interface RawWorkflow {
+  name: string;
+  description?: string;
+  nodes?: RawNode[];
+}
+
+interface WorkflowListEntry {
+  workflow: RawWorkflow;
+  filename?: string;
+  source: string;
+}
+
+interface WorkflowsResponse {
+  workflows: WorkflowListEntry[];
+  errors?: unknown[];
+}
+
+export async function listWorkflows(cwd?: string): Promise<Workflow[]> {
+  const qs = cwd !== undefined ? `?cwd=${encodeURIComponent(cwd)}` : '';
+  const res = await requestJson<WorkflowsResponse>(`/api/workflows${qs}`);
+  return res.workflows.map(toWorkflow);
+}
+
+function nodeKind(n: RawNode): WorkflowGraphNode['kind'] {
+  if (n.loop !== undefined) return 'loop';
+  if (n.approval !== undefined) return 'approval';
+  if (n.bash !== undefined) return 'bash';
+  if (n.command !== undefined) return 'command';
+  if (n.script !== undefined) return 'script';
+  return 'prompt';
+}
+
 /**
  * Get a workflow's DAG structure (nodes + dependencies) for the graph panel.
- * The server returns the full YAML definition; we narrow to the shape the
- * console needs.
+ *
+ * We route through the list endpoint and filter by name rather than calling
+ * `/api/workflows/:name` directly because the single-fetch route doesn't
+ * recurse into `.archon/workflows/<subdir>/` while the list route does. Both
+ * carry the full DAG, so this trades one extra row of JSON for correctness
+ * across subfoldered workflows.
  */
 export async function getWorkflowGraph(name: string, cwd?: string): Promise<WorkflowGraphNode[]> {
   const qs = cwd !== undefined ? `?cwd=${encodeURIComponent(cwd)}` : '';
-  const res = await requestJson<GetWorkflowResponse>(
-    `/api/workflows/${encodeURIComponent(name)}${qs}`
-  );
-  return res.workflow.nodes.map(
+  const res = await requestJson<WorkflowsResponse>(`/api/workflows${qs}`);
+  const match = res.workflows.find(w => w.workflow.name === name);
+  if (match === undefined) {
+    throw new Error(`Workflow not found: ${name}`);
+  }
+  const nodes = match.workflow.nodes ?? [];
+  return nodes.map(
     (n): WorkflowGraphNode => ({
       id: n.id,
       dependsOn: n.depends_on ?? [],
-      kind:
-        n.loop !== undefined
-          ? 'loop'
-          : n.approval !== undefined
-            ? 'approval'
-            : n.bash !== undefined
-              ? 'bash'
-              : n.command !== undefined
-                ? 'command'
-                : n.script !== undefined
-                  ? 'script'
-                  : 'prompt',
+      kind: nodeKind(n),
     })
   );
 }

--- a/packages/web/src/experiments/console/skills/workflows.ts
+++ b/packages/web/src/experiments/console/skills/workflows.ts
@@ -1,0 +1,64 @@
+import { requestJson } from '../lib/http';
+import { toWorkflow, type Workflow } from '../primitives/workflow';
+import type { WorkflowGraphNode } from '../primitives/workflow-graph';
+
+interface WorkflowsResponse {
+  workflows: Parameters<typeof toWorkflow>[0][];
+  errors?: unknown[];
+}
+
+export async function listWorkflows(cwd?: string): Promise<Workflow[]> {
+  const qs = cwd !== undefined ? `?cwd=${encodeURIComponent(cwd)}` : '';
+  const res = await requestJson<WorkflowsResponse>(`/api/workflows${qs}`);
+  return res.workflows.map(toWorkflow);
+}
+
+interface GetWorkflowResponse {
+  workflow: {
+    name: string;
+    nodes: RawNode[];
+  };
+  filename: string;
+  source: string;
+}
+
+interface RawNode {
+  id: string;
+  depends_on?: string[];
+  prompt?: string;
+  bash?: string;
+  command?: string;
+  approval?: unknown;
+  loop?: unknown;
+  script?: unknown;
+}
+
+/**
+ * Get a workflow's DAG structure (nodes + dependencies) for the graph panel.
+ * The server returns the full YAML definition; we narrow to the shape the
+ * console needs.
+ */
+export async function getWorkflowGraph(name: string, cwd?: string): Promise<WorkflowGraphNode[]> {
+  const qs = cwd !== undefined ? `?cwd=${encodeURIComponent(cwd)}` : '';
+  const res = await requestJson<GetWorkflowResponse>(
+    `/api/workflows/${encodeURIComponent(name)}${qs}`
+  );
+  return res.workflow.nodes.map(
+    (n): WorkflowGraphNode => ({
+      id: n.id,
+      dependsOn: n.depends_on ?? [],
+      kind:
+        n.loop !== undefined
+          ? 'loop'
+          : n.approval !== undefined
+            ? 'approval'
+            : n.bash !== undefined
+              ? 'bash'
+              : n.command !== undefined
+                ? 'command'
+                : n.script !== undefined
+                  ? 'script'
+                  : 'prompt',
+    })
+  );
+}

--- a/packages/web/src/experiments/console/skills/worktrees.ts
+++ b/packages/web/src/experiments/console/skills/worktrees.ts
@@ -1,0 +1,13 @@
+import { requestJson } from '../lib/http';
+import { toWorktree, type Worktree } from '../primitives/worktree';
+
+interface EnvironmentsResponse {
+  environments: Parameters<typeof toWorktree>[0][];
+}
+
+export async function listWorktrees(projectId: string): Promise<Worktree[]> {
+  const res = await requestJson<EnvironmentsResponse>(
+    `/api/codebases/${encodeURIComponent(projectId)}/environments`
+  );
+  return res.environments.map(toWorktree);
+}

--- a/packages/web/src/experiments/console/store/cache.ts
+++ b/packages/web/src/experiments/console/store/cache.ts
@@ -67,12 +67,26 @@ export function patch(key: string, updater: (prev: unknown) => unknown): void {
 }
 
 export function invalidate(keyPrefix: string): void {
+  // Match by exact key OR by `${prefix}:` so callers can pass either a
+  // concrete key (`run:abc`) or a prefix that fans out (`runs`).
+  const matches = (key: string): boolean => key === keyPrefix || key.startsWith(`${keyPrefix}:`);
+
+  // Walk both the data cache AND the errors map. An errored key lives only in
+  // `errors`, so iterating `cache.keys()` alone would leave it permanently
+  // stuck — the loader would never refetch and the UI would require a full
+  // page reload to recover.
+  const toRefresh = new Set<string>();
   for (const key of [...cache.keys()]) {
-    if (key === keyPrefix || key.startsWith(`${keyPrefix}:`)) {
-      cache.delete(key);
-      notify(key);
-      ensureLoad(key);
-    }
+    if (matches(key)) toRefresh.add(key);
+  }
+  for (const key of [...errors.keys()]) {
+    if (matches(key)) toRefresh.add(key);
+  }
+  for (const key of toRefresh) {
+    cache.delete(key);
+    errors.delete(key);
+    notify(key);
+    ensureLoad(key);
   }
 }
 

--- a/packages/web/src/experiments/console/store/cache.ts
+++ b/packages/web/src/experiments/console/store/cache.ts
@@ -5,11 +5,12 @@
  * - UI never writes directly — it calls skill verbs; server pushes truth back
  *   via SSE (M4) or refetch on miss.
  * - `useEntity(key, loader)` subscribes to a key. First subscriber triggers
- *   the loader; subsequent subscribers read from cache.
+ *   the loader; subsequent subscribers read from cache. After `invalidate()`
+ *   or `refetch()`, any key with an active subscriber reloads automatically.
  * - `patch` and `set` are for the SSE dispatcher and skill-layer optimistic
  *   updates only.
  *
- * Deliberately minimal: ~100 LOC. No React Query, no Zustand.
+ * Deliberately minimal: ~120 LOC. No React Query, no Zustand.
  */
 
 import { useEffect, useRef, useState } from 'react';
@@ -20,11 +21,33 @@ const cache = new Map<string, unknown>();
 const listeners = new Map<string, Set<Listener>>();
 const errors = new Map<string, Error>();
 const inflight = new Map<string, Promise<unknown>>();
+const loaders = new Map<string, () => Promise<unknown>>();
 
 function notify(key: string): void {
   const subs = listeners.get(key);
   if (subs === undefined) return;
   for (const l of subs) l();
+}
+
+function ensureLoad(key: string): void {
+  if (cache.has(key) || inflight.has(key)) return;
+  const loader = loaders.get(key);
+  if (loader === undefined) return;
+  const p = loader()
+    .then(v => {
+      cache.set(key, v);
+      errors.delete(key);
+      notify(key);
+    })
+    .catch((e: unknown) => {
+      const err = e instanceof Error ? e : new Error(String(e));
+      errors.set(key, err);
+      notify(key);
+    })
+    .finally(() => {
+      inflight.delete(key);
+    });
+  inflight.set(key, p);
 }
 
 export function get(key: string): unknown {
@@ -48,6 +71,7 @@ export function invalidate(keyPrefix: string): void {
     if (key === keyPrefix || key.startsWith(`${keyPrefix}:`)) {
       cache.delete(key);
       notify(key);
+      ensureLoad(key);
     }
   }
 }
@@ -72,7 +96,6 @@ export interface EntityView<T> {
  * invokes `loader`. Updates propagate to all subscribers via `notify`.
  */
 export function useEntity<T>(key: string, loader: () => Promise<T>): EntityView<T> {
-  // Stable loader ref so we don't re-run just because the caller inlined a new closure.
   const loaderRef = useRef(loader);
   loaderRef.current = loader;
 
@@ -91,30 +114,16 @@ export function useEntity<T>(key: string, loader: () => Promise<T>): EntityView<
     };
     subs.add(listener);
 
-    // If not cached and no load in flight, trigger one.
-    if (!cache.has(key) && !inflight.has(key)) {
-      const p = loaderRef
-        .current()
-        .then(v => {
-          cache.set(key, v);
-          errors.delete(key);
-          notify(key);
-        })
-        .catch((e: unknown) => {
-          const err = e instanceof Error ? e : new Error(String(e));
-          errors.set(key, err);
-          notify(key);
-        })
-        .finally(() => {
-          inflight.delete(key);
-        });
-      inflight.set(key, p);
-    }
+    loaders.set(key, () => loaderRef.current());
+    ensureLoad(key);
 
     return (): void => {
       active = false;
       subs.delete(listener);
-      if (subs.size === 0) listeners.delete(key);
+      if (subs.size === 0) {
+        listeners.delete(key);
+        loaders.delete(key);
+      }
     };
   }, [key]);
 
@@ -126,6 +135,7 @@ export function useEntity<T>(key: string, loader: () => Promise<T>): EntityView<
       cache.delete(key);
       errors.delete(key);
       notify(key);
+      ensureLoad(key);
     },
   };
 }

--- a/packages/web/src/experiments/console/store/cache.ts
+++ b/packages/web/src/experiments/console/store/cache.ts
@@ -1,0 +1,131 @@
+/**
+ * Reactive server-state cache. Map of keyed entities + subscription primitive.
+ *
+ * Contract:
+ * - UI never writes directly — it calls skill verbs; server pushes truth back
+ *   via SSE (M4) or refetch on miss.
+ * - `useEntity(key, loader)` subscribes to a key. First subscriber triggers
+ *   the loader; subsequent subscribers read from cache.
+ * - `patch` and `set` are for the SSE dispatcher and skill-layer optimistic
+ *   updates only.
+ *
+ * Deliberately minimal: ~100 LOC. No React Query, no Zustand.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+
+type Listener = () => void;
+
+const cache = new Map<string, unknown>();
+const listeners = new Map<string, Set<Listener>>();
+const errors = new Map<string, Error>();
+const inflight = new Map<string, Promise<unknown>>();
+
+function notify(key: string): void {
+  const subs = listeners.get(key);
+  if (subs === undefined) return;
+  for (const l of subs) l();
+}
+
+export function get(key: string): unknown {
+  return cache.get(key);
+}
+
+export function set(key: string, value: unknown): void {
+  cache.set(key, value);
+  errors.delete(key);
+  notify(key);
+}
+
+export function patch(key: string, updater: (prev: unknown) => unknown): void {
+  const next = updater(cache.get(key));
+  cache.set(key, next);
+  notify(key);
+}
+
+export function invalidate(keyPrefix: string): void {
+  for (const key of [...cache.keys()]) {
+    if (key === keyPrefix || key.startsWith(`${keyPrefix}:`)) {
+      cache.delete(key);
+      notify(key);
+    }
+  }
+}
+
+export function keysStartingWith(prefix: string): string[] {
+  const out: string[] = [];
+  for (const k of cache.keys()) {
+    if (k.startsWith(prefix)) out.push(k);
+  }
+  return out;
+}
+
+export interface EntityView<T> {
+  data: T | undefined;
+  error: Error | undefined;
+  loading: boolean;
+  refetch: () => void;
+}
+
+/**
+ * Subscribe to a keyed entity. On first subscribe (or after `refetch`),
+ * invokes `loader`. Updates propagate to all subscribers via `notify`.
+ */
+export function useEntity<T>(key: string, loader: () => Promise<T>): EntityView<T> {
+  // Stable loader ref so we don't re-run just because the caller inlined a new closure.
+  const loaderRef = useRef(loader);
+  loaderRef.current = loader;
+
+  const [, rerender] = useState(0);
+
+  useEffect(() => {
+    let active = true;
+
+    let subs = listeners.get(key);
+    if (subs === undefined) {
+      subs = new Set();
+      listeners.set(key, subs);
+    }
+    const listener: Listener = () => {
+      if (active) rerender(n => n + 1);
+    };
+    subs.add(listener);
+
+    // If not cached and no load in flight, trigger one.
+    if (!cache.has(key) && !inflight.has(key)) {
+      const p = loaderRef
+        .current()
+        .then(v => {
+          cache.set(key, v);
+          errors.delete(key);
+          notify(key);
+        })
+        .catch((e: unknown) => {
+          const err = e instanceof Error ? e : new Error(String(e));
+          errors.set(key, err);
+          notify(key);
+        })
+        .finally(() => {
+          inflight.delete(key);
+        });
+      inflight.set(key, p);
+    }
+
+    return (): void => {
+      active = false;
+      subs.delete(listener);
+      if (subs.size === 0) listeners.delete(key);
+    };
+  }, [key]);
+
+  return {
+    data: cache.get(key) as T | undefined,
+    error: errors.get(key),
+    loading: !cache.has(key) && inflight.has(key),
+    refetch: (): void => {
+      cache.delete(key);
+      errors.delete(key);
+      notify(key);
+    },
+  };
+}

--- a/packages/web/src/experiments/console/store/cache.ts
+++ b/packages/web/src/experiments/console/store/cache.ts
@@ -2,8 +2,8 @@
  * Reactive server-state cache. Map of keyed entities + subscription primitive.
  *
  * Contract:
- * - UI never writes directly — it calls skill verbs; server pushes truth back
- *   via SSE (M4) or refetch on miss.
+ * - UI never writes directly — it calls skill verbs; server pushes truth
+ *   back via SSE (lib/sse.ts) or refetch on miss.
  * - `useEntity(key, loader)` subscribes to a key. First subscriber triggers
  *   the loader; subsequent subscribers read from cache. After `invalidate()`
  *   or `refetch()`, any key with an active subscriber reloads automatically.

--- a/packages/web/src/experiments/console/store/keys.ts
+++ b/packages/web/src/experiments/console/store/keys.ts
@@ -18,4 +18,5 @@ export const K = {
   countsGlobal: 'counts:global' as const,
   pendingRuns: 'pendingRuns' as const,
   envVars: (projectId: string): string => `envVars:${projectId}`,
+  artifacts: (runId: string): string => `artifacts:${runId}`,
 } as const;

--- a/packages/web/src/experiments/console/store/keys.ts
+++ b/packages/web/src/experiments/console/store/keys.ts
@@ -17,4 +17,5 @@ export const K = {
   messages: (conversationId: string): string => `messages:${conversationId}`,
   countsGlobal: 'counts:global' as const,
   pendingRuns: 'pendingRuns' as const,
+  envVars: (projectId: string): string => `envVars:${projectId}`,
 } as const;

--- a/packages/web/src/experiments/console/store/keys.ts
+++ b/packages/web/src/experiments/console/store/keys.ts
@@ -1,0 +1,20 @@
+/** Centralized cache key constructors. Refactoring key shape = one file. */
+
+/** A scope is either the literal 'all' or a project id. Encoded as a string. */
+export type Scope = string;
+export const ALL_SCOPE = 'all';
+
+export const scopeKey = (scope: Scope): string =>
+  scope === ALL_SCOPE ? 'all' : `project:${scope}`;
+
+export const K = {
+  projects: 'projects' as const,
+  project: (id: string): string => `project:${id}`,
+  workflows: (cwd: string): string => `workflows:${cwd}`,
+  worktrees: (projectId: string): string => `worktrees:${projectId}`,
+  runs: (scope: Scope): string => `runs:${scopeKey(scope)}`,
+  run: (id: string): string => `run:${id}`,
+  messages: (conversationId: string): string => `messages:${conversationId}`,
+  countsGlobal: 'counts:global' as const,
+  pendingRuns: 'pendingRuns' as const,
+} as const;

--- a/packages/web/src/experiments/console/theme.css
+++ b/packages/web/src/experiments/console/theme.css
@@ -1,0 +1,82 @@
+/*
+ * Console spike — warm palette.
+ *
+ * Scoped to `.console-root` so the production app's cool/blue theme is untouched.
+ * Same token *structure* as packages/web/src/index.css (surface, accent,
+ * success, warning, error, text) but shifted hues:
+ *   - surfaces: cool blue-grey → warm espresso
+ *   - text:     cool grey → warm ivory
+ *   - accent:   cold blue → rose/magenta (logo-inspired)
+ *   - success:  pure green → warmer teal-green (logo-inspired)
+ *   - warning:  amber → peach
+ *   - error:    fire red → warm rose-red
+ *
+ * Tailwind v4's @theme inline in index.css maps --color-* vars to
+ * their --base vars. Overriding the base vars here cascades through the
+ * whole Tailwind color system without needing to redefine @theme.
+ */
+
+.console-root {
+  /* Surfaces — espresso / candlelit */
+  --surface: oklch(0.155 0.012 40);
+  --surface-inset: oklch(0.11 0.009 40);
+  --surface-elevated: oklch(0.195 0.014 40);
+  --surface-hover: oklch(0.225 0.016 40);
+  --surface-variant: oklch(0.21 0.014 40);
+  --surface-bright: oklch(0.28 0.018 40);
+
+  /* Borders — warm charcoal */
+  --border: oklch(0.28 0.014 40);
+  --border-bright: oklch(0.36 0.020 40);
+  --outline-variant: oklch(0.40 0.022 40);
+
+  /* Text — warm ivory / parchment */
+  --text-primary: oklch(0.945 0.010 70);
+  --text-secondary: oklch(0.70 0.022 60);
+  --text-tertiary: oklch(0.50 0.022 55);
+
+  /* Accent — tangerine / candlelit gold. Warm and inviting, NOT destructive. */
+  --accent-bright: oklch(0.74 0.17 45);
+  --accent: oklch(0.28 0.10 45);
+  --accent-hover: oklch(0.66 0.19 45);
+  --accent-muted: oklch(0.32 0.11 45);
+
+  /* Status — visually separated from accent.
+     - `running` is a calm ocean blue (active/in-progress; distinct from the
+        warm accent and from positive-green).
+     - `success` is a teal-green reserved for positive moments: Approve
+        buttons, affirmative checks, "completed OK" markers.
+     - `warning` is amber-wheat. `error` is a warm rose-red. */
+  --running: oklch(0.70 0.15 225); /* ocean blue — active/in-progress */
+  --success: oklch(0.70 0.15 165); /* teal-green — Approve / positive */
+  --warning: oklch(0.78 0.13 80);
+  --error: oklch(0.64 0.21 18);
+
+  /* shadcn-compatible overrides so Radix primitives and design-system
+     classes that reference these variables also pick up the warm palette. */
+  --background: oklch(0.13 0.010 40);
+  --foreground: var(--text-primary);
+  --card: var(--surface);
+  --card-foreground: var(--text-primary);
+  --popover: var(--surface-elevated);
+  --popover-foreground: var(--text-primary);
+  --primary: var(--accent-bright);
+  --primary-foreground: oklch(0.98 0.005 60);
+  --secondary: var(--surface-elevated);
+  --secondary-foreground: var(--text-primary);
+  --muted: var(--surface-elevated);
+  --muted-foreground: var(--text-secondary);
+  --destructive: var(--error);
+  --input: var(--border);
+  --ring: var(--accent-bright);
+}
+
+/* Override the global `* { @apply border-border ... }` rule's effect inside
+   the console so bare borders pick up our warm border color. Tailwind handles
+   this automatically via the cascade, but this fallback guards against the
+   production @layer base ruleset. */
+.console-root *,
+.console-root *::before,
+.console-root *::after {
+  border-color: var(--border);
+}

--- a/packages/web/src/experiments/console/theme.css
+++ b/packages/web/src/experiments/console/theme.css
@@ -2,9 +2,11 @@
  * Archon Console — brand foundation port.
  *
  * Scoped to `.console-root` so the production app's existing palette is
- * untouched. Tailwind v4's @theme inline (in index.css) maps --color-* vars
- * to their --base vars; overriding the base vars inside .console-root
- * cascades through the whole Tailwind color system without redefining @theme.
+ * untouched. Tailwind v4's @theme inline (in index.css) defines --color-*
+ * theme tokens that reference plain CSS variables (--surface, --border,
+ * --text-primary, etc.); redefining those CSS variables inside .console-root
+ * cascades through every utility that reads them without needing a parallel
+ * @theme block.
  *
  * Source: Archon Brand · Standalone. The duotone magenta → violet → teal
  * gradient drawn from the shield logo is THE brand. Cool charcoal surfaces

--- a/packages/web/src/experiments/console/theme.css
+++ b/packages/web/src/experiments/console/theme.css
@@ -71,9 +71,13 @@
      - warning   amber
      - error     hot red */
   --running: oklch(0.72 0.155 245);
+  --running-soft: oklch(0.72 0.155 245 / 0.14);
   --success: var(--brand-teal);
+  --success-soft: oklch(0.755 0.165 168 / 0.14);
   --warning: oklch(0.8 0.14 85);
+  --warning-soft: oklch(0.8 0.14 85 / 0.14);
   --error: oklch(0.68 0.215 18);
+  --error-soft: oklch(0.68 0.215 18 / 0.14);
 
   /* shadcn-compatible overrides */
   --background: oklch(0.145 0.006 265);

--- a/packages/web/src/experiments/console/theme.css
+++ b/packages/web/src/experiments/console/theme.css
@@ -97,10 +97,14 @@
   --ring: var(--brand-magenta);
 
   /* Typography — Geist, with the SS01/CV11 alternates the brand uses. */
-  font-family: 'Geist', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
-  font-feature-settings:
-    'ss01',
-    'cv11';
+  font-family:
+    'Geist',
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    sans-serif;
+  font-feature-settings: 'ss01', 'cv11';
   letter-spacing: -0.005em;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -114,9 +118,7 @@
 .console-root kbd,
 .console-root samp {
   font-family: 'Geist Mono', ui-monospace, 'SF Mono', Menlo, monospace;
-  font-feature-settings:
-    'ss01',
-    'ss02';
+  font-feature-settings: 'ss01', 'ss02';
 }
 
 /* Heading tightening — brand uses -0.028em for big titles. */

--- a/packages/web/src/experiments/console/theme.css
+++ b/packages/web/src/experiments/console/theme.css
@@ -1,82 +1,161 @@
 /*
- * Console spike — warm palette.
+ * Archon Console — brand foundation port.
  *
- * Scoped to `.console-root` so the production app's cool/blue theme is untouched.
- * Same token *structure* as packages/web/src/index.css (surface, accent,
- * success, warning, error, text) but shifted hues:
- *   - surfaces: cool blue-grey → warm espresso
- *   - text:     cool grey → warm ivory
- *   - accent:   cold blue → rose/magenta (logo-inspired)
- *   - success:  pure green → warmer teal-green (logo-inspired)
- *   - warning:  amber → peach
- *   - error:    fire red → warm rose-red
+ * Scoped to `.console-root` so the production app's existing palette is
+ * untouched. Tailwind v4's @theme inline (in index.css) maps --color-* vars
+ * to their --base vars; overriding the base vars inside .console-root
+ * cascades through the whole Tailwind color system without redefining @theme.
  *
- * Tailwind v4's @theme inline in index.css maps --color-* vars to
- * their --base vars. Overriding the base vars here cascades through the
- * whole Tailwind color system without needing to redefine @theme.
+ * Source: Archon Brand · Standalone. The duotone magenta → violet → teal
+ * gradient drawn from the shield logo is THE brand. Cool charcoal surfaces
+ * (hue 265) carry the gradient without competing.
+ *
+ *   magenta  oklch(0.640 0.295 330)  #ED10EC
+ *   violet   oklch(0.560 0.215 305)
+ *   teal     oklch(0.755 0.165 168)  #06CE94
  */
 
+/* Geist & Geist Mono — loaded only when a console route mounts. */
+@import url('https://fonts.googleapis.com/css2?family=Geist:wght@300..700&family=Geist+Mono:wght@400..600&display=swap');
+
 .console-root {
-  /* Surfaces — espresso / candlelit */
-  --surface: oklch(0.155 0.012 40);
-  --surface-inset: oklch(0.11 0.009 40);
-  --surface-elevated: oklch(0.195 0.014 40);
-  --surface-hover: oklch(0.225 0.016 40);
-  --surface-variant: oklch(0.21 0.014 40);
-  --surface-bright: oklch(0.28 0.018 40);
+  /* Surfaces — cool charcoal (hue 265) */
+  --surface: oklch(0.175 0.007 265);
+  --surface-inset: oklch(0.13 0.006 265);
+  --surface-elevated: oklch(0.205 0.009 265);
+  --surface-hover: oklch(0.225 0.01 265);
+  --surface-variant: oklch(0.21 0.009 265);
+  --surface-bright: oklch(0.275 0.012 265);
 
-  /* Borders — warm charcoal */
-  --border: oklch(0.28 0.014 40);
-  --border-bright: oklch(0.36 0.020 40);
-  --outline-variant: oklch(0.40 0.022 40);
+  /* Borders */
+  --border: oklch(0.275 0.012 265);
+  --border-bright: oklch(0.355 0.016 265);
+  --outline-variant: oklch(0.4 0.018 265);
 
-  /* Text — warm ivory / parchment */
-  --text-primary: oklch(0.945 0.010 70);
-  --text-secondary: oklch(0.70 0.022 60);
-  --text-tertiary: oklch(0.50 0.022 55);
+  /* Text */
+  --text-primary: oklch(0.975 0.004 265);
+  --text-secondary: oklch(0.745 0.014 265);
+  --text-tertiary: oklch(0.56 0.017 265);
 
-  /* Accent — tangerine / candlelit gold. Warm and inviting, NOT destructive. */
-  --accent-bright: oklch(0.74 0.17 45);
-  --accent: oklch(0.28 0.10 45);
-  --accent-hover: oklch(0.66 0.19 45);
-  --accent-muted: oklch(0.32 0.11 45);
+  /* Brand thread — the duotone */
+  --brand-magenta: oklch(0.64 0.295 330);
+  --brand-magenta-2: oklch(0.72 0.26 335);
+  --brand-violet: oklch(0.56 0.215 305);
+  --brand-teal: oklch(0.755 0.165 168);
+  --brand-teal-2: oklch(0.7 0.15 175);
+  --brand-gradient: linear-gradient(
+    135deg,
+    var(--brand-magenta) 0%,
+    var(--brand-violet) 50%,
+    var(--brand-teal) 100%
+  );
+  --brand-gradient-soft: linear-gradient(
+    135deg,
+    oklch(0.64 0.295 330 / 0.18) 0%,
+    oklch(0.56 0.215 305 / 0.12) 50%,
+    oklch(0.755 0.165 168 / 0.18) 100%
+  );
 
-  /* Status — visually separated from accent.
-     - `running` is a calm ocean blue (active/in-progress; distinct from the
-        warm accent and from positive-green).
-     - `success` is a teal-green reserved for positive moments: Approve
-        buttons, affirmative checks, "completed OK" markers.
-     - `warning` is amber-wheat. `error` is a warm rose-red. */
-  --running: oklch(0.70 0.15 225); /* ocean blue — active/in-progress */
-  --success: oklch(0.70 0.15 165); /* teal-green — Approve / positive */
-  --warning: oklch(0.78 0.13 80);
-  --error: oklch(0.64 0.21 18);
+  /* Accent — brand magenta (default). All accent tokens point to the same
+     hue so `bg-accent-bright`, `text-accent-bright`, etc. all read as brand. */
+  --accent: var(--brand-magenta);
+  --accent-bright: var(--brand-magenta);
+  --accent-hover: oklch(0.7 0.28 330);
+  --accent-muted: oklch(0.64 0.295 330 / 0.3);
+  --accent-soft: oklch(0.64 0.295 330 / 0.14);
+  --accent-ring: oklch(0.64 0.295 330 / 0.3);
 
-  /* shadcn-compatible overrides so Radix primitives and design-system
-     classes that reference these variables also pick up the warm palette. */
-  --background: oklch(0.13 0.010 40);
+  /* Status — kept distinct from accent so brand swaps don't break meaning.
+     - running   electric blue (active/in-progress)
+     - success   brand teal (affirmative IS brand)
+     - warning   amber
+     - error     hot red */
+  --running: oklch(0.72 0.155 245);
+  --success: var(--brand-teal);
+  --warning: oklch(0.8 0.14 85);
+  --error: oklch(0.68 0.215 18);
+
+  /* shadcn-compatible overrides */
+  --background: oklch(0.145 0.006 265);
   --foreground: var(--text-primary);
   --card: var(--surface);
   --card-foreground: var(--text-primary);
   --popover: var(--surface-elevated);
   --popover-foreground: var(--text-primary);
-  --primary: var(--accent-bright);
-  --primary-foreground: oklch(0.98 0.005 60);
+  --primary: var(--brand-magenta);
+  --primary-foreground: oklch(0.985 0 0);
   --secondary: var(--surface-elevated);
   --secondary-foreground: var(--text-primary);
   --muted: var(--surface-elevated);
   --muted-foreground: var(--text-secondary);
   --destructive: var(--error);
   --input: var(--border);
-  --ring: var(--accent-bright);
+  --ring: var(--brand-magenta);
+
+  /* Typography — Geist, with the SS01/CV11 alternates the brand uses. */
+  font-family: 'Geist', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+  font-feature-settings:
+    'ss01',
+    'cv11';
+  letter-spacing: -0.005em;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Override Tailwind's compiled font-mono so console-internal monospace
+   becomes Geist Mono. Higher specificity than the bare .font-mono utility. */
+.console-root .font-mono,
+.console-root code,
+.console-root pre,
+.console-root kbd,
+.console-root samp {
+  font-family: 'Geist Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+  font-feature-settings:
+    'ss01',
+    'ss02';
+}
+
+/* Heading tightening — brand uses -0.028em for big titles. */
+.console-root h1,
+.console-root h2 {
+  letter-spacing: -0.028em;
 }
 
 /* Override the global `* { @apply border-border ... }` rule's effect inside
-   the console so bare borders pick up our warm border color. Tailwind handles
-   this automatically via the cascade, but this fallback guards against the
-   production @layer base ruleset. */
+   the console so bare borders pick up our charcoal border color. */
 .console-root *,
 .console-root *::before,
 .console-root *::after {
   border-color: var(--border);
+}
+
+.console-root ::selection {
+  background: var(--accent-ring);
+  color: var(--text-primary);
+}
+
+.console-root :focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+/* Brand utilities — restricted to console scope.
+   .brand-text  → paints text with the duotone gradient (logo/wordmark)
+   .brand-bar   → solid gradient fill (CTAs, accent strips)
+   .brand-bar-soft → translucent gradient wash (subtle hero/selected states) */
+.console-root .brand-text {
+  background: var(--brand-gradient);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+}
+
+.console-root .brand-bar {
+  background: var(--brand-gradient);
+}
+
+.console-root .brand-bar-soft {
+  background: var(--brand-gradient-soft);
 }

--- a/packages/web/src/lib/api.generated.d.ts
+++ b/packages/web/src/lib/api.generated.d.ts
@@ -747,7 +747,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Run a workflow via the orchestrator */
+    /**
+     * Run a workflow via the orchestrator (JSON or multipart with file uploads)
+     * @description Accepts `application/json` with `{ conversationId, message }` or `multipart/form-data` with `conversationId`, `message`, and optional file attachments (max 5 files, 10 MB each).
+     */
     post: {
       parameters: {
         query?: never;
@@ -757,11 +760,7 @@ export interface paths {
         };
         cookie?: never;
       };
-      requestBody: {
-        content: {
-          'application/json': components['schemas']['RunWorkflowBody'];
-        };
-      };
+      requestBody?: never;
       responses: {
         /** @description Accepted */
         200: {
@@ -925,7 +924,7 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Resume a failed workflow run (re-run auto-resumes from completed nodes) */
+    /** Resume a failed workflow run (dispatches resume on the parent web conversation) */
     post: {
       parameters: {
         query?: never;
@@ -1517,6 +1516,7 @@ export interface paths {
       parameters: {
         query?: {
           cwd?: string;
+          source?: 'project' | 'global';
         };
         header?: never;
         path: {
@@ -1565,6 +1565,7 @@ export interface paths {
       parameters: {
         query?: {
           cwd?: string;
+          source?: 'project' | 'global';
         };
         header?: never;
         path: {
@@ -1647,6 +1648,74 @@ export interface paths {
         };
         /** @description Bad request */
         400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['Error'];
+          };
+        };
+        /** @description Server error */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['Error'];
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/runs/{runId}/artifacts': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List a run's artifact files
+     * @description Walks the run's artifact directory and returns relative file paths with size + mtime. Drives the console Artifacts tab. Returns `{ files: [] }` when the run has no codebase or the codebase name is not in `owner/repo` form.
+     */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          runId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description OK */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['ListArtifactsResponse'];
+          };
+        };
+        /** @description Bad request */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['Error'];
+          };
+        };
+        /** @description Not found */
+        404: {
           headers: {
             [name: string]: unknown;
           };
@@ -2259,6 +2328,7 @@ export interface components {
           args?: string[];
         };
       };
+      always_run?: boolean;
       command?: string;
       prompt?: string;
       bash?: string;
@@ -2348,6 +2418,7 @@ export interface components {
       worktree?: {
         enabled?: boolean;
       };
+      mutates_checkout?: boolean;
       tags?: string[];
       nodes: components['schemas']['DagNode'][];
     };
@@ -2366,10 +2437,6 @@ export interface components {
     WorkflowListResponse: {
       workflows: components['schemas']['WorkflowListEntry'][];
       errors?: components['schemas']['WorkflowLoadError'][];
-    };
-    RunWorkflowBody: {
-      conversationId: string;
-      message: string;
     };
     /** @enum {string} */
     WorkflowRunStatus: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled' | 'paused';
@@ -2483,6 +2550,14 @@ export interface components {
     };
     CommandListResponse: {
       commands: components['schemas']['CommandEntry'][];
+    };
+    ArtifactFile: {
+      path: string;
+      size: number;
+      modifiedAt: string;
+    };
+    ListArtifactsResponse: {
+      files: components['schemas']['ArtifactFile'][];
     };
     ProviderDefaults: {
       [key: string]: unknown;


### PR DESCRIPTION
## Summary

- Problem: the existing `/app` UI is a mix of chat-centric chrome and a separate workflows dashboard; running and observing workflows requires hopping between screens and exposes platform concepts (conversations, sessions) that aren't load-bearing for the run-centric use case.
- Why it matters: most user time is spent dispatching, watching, and reviewing workflow runs — the surface should be a run-centric console that puts that flow front and center, branded around the Archon shield + magenta→teal duotone.
- What changed: a new self-contained UI lives at `/console` (alongside, not replacing, `/app/*`). Project rail · runs feed with status filters · run detail with Log / Graph / Artifacts tabs · per-project env vars · file upload on the draft input · live SSE updates · brand design system (Geist + duotone gradient). Two `Try the new console UI` / `← Old UI` switches let users move between surfaces. One small server change adds multipart support to the workflow-run dispatch endpoint and an artifact-listing endpoint.
- What did **not** change (scope boundary): no `/app` routes were removed or restructured (only the TopNav gained a CTA). No DB schema changes. The orchestrator, providers, workflow engine, isolation, and adapters are all untouched. No existing tests rewritten.

## UX Journey

### Before

```
User                        /app (chat)                   Server
────                        ───────────                   ──────
visit /                     redirects /chat
clicks 'Run a workflow' ─▶  workflows page
picks workflow, fills msg   POST /api/workflows/:n/run ─▶ creates run
navigates to /dashboard     polled list, GET every 5s ─▶ /api/dashboard/runs
clicks run                  /workflows/runs/:id          GET run detail
sees Logs + Graph tabs       polled GET every 3s          (live but heavy)
approval gate?              navigate back to chat thread to act
```

### After

```
User                        /console                       Server
────                        ────────                       ──────
visit /console              project rail visible
picks project               selection clear (gradient
                            strip + elevated bg)
                            DraftRunCard appears at top
types message + ↩            POST /api/workflows/:n/run ─▶ creates run (JSON or multipart)
                            optimistic — card returns
                            immediately
runs feed lights up         SSE [__dashboard__]   ──────── live status / dag updates
                            invalidates cache, refetches
clicks active run           /console/p/:id/r/:rid          GET run detail (once)
                            SSE [conversation] ─────────── text/tool/workflow events
                            invalidates cache (100ms coalesce)
approval gate appears
   inline ApprovalPanel     Approve = 1 click
                            Reject  = 2-step expander with required reason
viewing artifacts           click Artifacts tab            GET /api/runs/:rid/artifacts
                            sidebar files + viewer
                            (markdown / plain)
[failed?] click ↻ rerun     pre-fills DraftRunCard on the
                            same project
[done?]  click ↗ IDE        opens vscode://file/<worktree>
```

## Architecture Diagram

### Before

```
                     ┌────────────────────┐
                     │ /app (Layout)      │
                     │   TopNav + Sidebar │
                     └────────┬───────────┘
                              │
        ┌─────────────┬───────┼────────┬─────────────────┐
        ▼             ▼       ▼        ▼                 ▼
   ChatPage      Dashboard  Workflows  WorkflowExecution Settings
   (sidebar      (server-   List+Build (Graph + Logs +    (env vars,
    + chat)      paginated  pages      Chat side-tabs)    assistants)
```

### After

```
                     ┌────────────────────┐
                     │ /app (Layout)  [~] │  ◀── added 'Try the new console UI' CTA
                     │   TopNav + Sidebar │
                     └────────┬───────────┘
                              │
        ┌─────────────┬───────┼────────┬─────────────────┐
        ▼             ▼       ▼        ▼                 ▼
   ChatPage      Dashboard  Workflows  WorkflowExecution Settings
                                                          + Projects/Env

   ┌──── NEW ───────────────────────────────────────────────────┐
   │                                                             │
   │  [+] /console/*  (sibling to /app)                          │
   │      ConsoleApp                                             │
   │       ├── ProjectRail (selection · ⋯ · env dialog)          │
   │       ├── RunsPage (DraftRunCard + filtered feed)           │
   │       └── RunDetailPage                                     │
   │             ├── Log tab (RunStream + ApprovalPanel)         │
   │             ├── Graph tab (full-width dagre canvas)         │
   │             └── Artifacts tab (sidebar + viewer)            │
   │                                                             │
   │  [+] lib/sse.ts           ── cache-invalidation SSE         │
   │  [+] store/cache.ts       ── tiny pub-sub keyed cache       │
   │  [+] skills/*             ── single mutation surface        │
   │  [+] theme.css            ── brand tokens (.console-root)   │
   │                                                             │
   └─────────────────────────────────────────────────────────────┘

   /api/workflows/:name/run  [~]  ── now accepts JSON OR multipart
   /api/runs/:runId/artifacts [+] ── new: list artifact files on disk
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `/app TopNav` | `/console` | **new** | gradient CTA between tabs and version |
| `/console` header | `/chat` | **new** | "← Old UI" escape hatch |
| `/console/*` routes | `/api/dashboard/runs` | **new** | runs feed |
| `/console/*` routes | `/api/workflows/runs/:id` | **new** | run detail |
| `/console/*` routes | `/api/conversations/:id/messages` | **new** | run messages |
| `/console/*` routes | `/api/stream/__dashboard__` | **new** | dashboard SSE |
| `/console/*` routes | `/api/stream/<convId>` | **new** | per-run SSE |
| `/console/*` routes | `/api/runs/:runId/artifacts` | **new** | artifact listing |
| `/console/*` routes | `/api/artifacts/:runId/*` | **new** | artifact file content |
| `/console/*` routes | `/api/codebases/:id/env` | **new** | per-project env vars |
| `/console/*` routes | `/api/workflows/:name/run` | **new** | dispatch (JSON + multipart) |
| `/api/workflows/:name/run` handler | `dispatchToOrchestrator` | **modified** | now forwards `attachedFiles` + cleanup |
| `runWorkflowRoute` OpenAPI config | `request.body` schema | **modified** | dropped to allow multipart-or-JSON branch |
| `sendMessageRoute` upload helper | `persistUploadedFiles` (new shared) | **modified** | extracted reusable helper |

## Label Snapshot

- Risk: `risk: low` (the new surface is opt-in at `/console`; the only `/app`-side change is one CTA in TopNav; the one server endpoint change is additive multipart support gated on Content-Type)
- Size: `size: XL` (65 files, +7.2k LOC, mostly new files under `experiments/console/`)
- Scope: `web · server`
- Module: `web:console`, `server:routes`

## Change Metadata

- Change type: `feature`
- Primary scope: `web` (with one small additive `server` change)

## Linked Issue

- Closes #
- Related #
- Depends on # (none)
- Supersedes # (none)

This was driven by direct user feedback during the session; no tracked issues to link.

## Validation Evidence (required)

```bash
bun run validate
# → all green except 3 pre-existing telegram-markdown blockquote tests
#   in @archon/adapters that fail identically on origin/dev with the
#   adapters/ tree checked out from dev (verified locally).
```

Per-package summaries from the final run:

- `check:bundled` ✅ (36 commands, 20 workflows up to date)
- `check:bundled-skill` ✅ (21 files)
- `type-check` ✅ (all 10 packages)
- `lint` ✅ (max-warnings 0)
- `format:check` ✅ (after `prettier --write` on `eslint.config.mjs` and `theme.css`)
- `test` ❌ only the 3 pre-existing telegram-markdown failures; new tests in `@archon/server` for `/api/workflows/:name/run` continue to pass.

Manual UX evidence captured during development: cost on cards, reject-with-reason expander, env vars round-trip, artifact panel rendering markdown, file upload round-trip (server log `run_workflow.files_uploaded fileCount:1`), rerun pre-filling the draft, project rail selection visible after the routing-param fix. All saved as screenshots under `.playwright-cli/shots/` during the session (not committed).

## Security Impact (required)

- New permissions/capabilities? **No** (all new API calls use existing endpoints or additive routes with identical auth posture; multipart upload reuses the existing `persistUploadedFiles` validation: max 5 files, ≤10 MB each, MIME allowlist + extension fallback)
- New external network calls? **No** (only Google Fonts CDN for Geist on console route mount via `@import` — same-class request as the existing JetBrains Mono fetch in `/app`)
- Secrets/tokens handling changed? **No** (per-project env vars use the existing read-keys-only / write-by-key API; the UI never sees values, only key names — matches the server's invariant)
- File system access scope changed? **No** (new `/api/runs/:runId/artifacts` reads from the same `getRunArtifactsPath(owner, repo, runId)` the existing `/api/artifacts/:runId/*` handler uses; same path-escape guards; dotfiles skipped)

## Compatibility / Migration

- Backward compatible? **Yes** (no removed routes, no schema changes, no broken tests apart from the pre-existing telegram-markdown ones)
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

Verified scenarios:
- Run a workflow on a real project; watch it light up the runs feed via SSE; click in; see the Log tab populate live; switch to Graph; switch to Artifacts; open a `.md` artifact in the viewer
- Approve a paused run from the inline ApprovalPanel; reject one with a required reason
- Add/remove an env var; round-trip via API confirmed
- Open in IDE button launches vscode://; hidden in Docker (driven by `/api/health` `is_docker`)
- Rerun a completed run; DraftRunCard expands pre-filled with the prior workflow + message
- Switch back to the old UI via "← Old UI" and forward via "Try the new console UI" CTA

Edge cases checked:
- DraftRunCard with files: drag-drop, paste image, file picker; 5-file cap; 10 MB-per-file cap; server-side cap also enforced
- SSE drop safety net: 30s heartbeat refetch while status is non-terminal stops on terminal status
- Subfoldered workflow definition (`.archon/workflows/maintainer/maintainer-review-pr.yaml`) — the Graph tab uses the list endpoint (which recurses) instead of `/api/workflows/:name` (which doesn't) so the graph loads
- Routing param read for the project rail (`useLocation` regex instead of `useParams`, because the rail is mounted outside `<Routes>`)
- Tool calls surfacing from `workflow_events` for Pi/Codex/bash runs where `message.metadata.toolCalls` is empty (paired `tool_called` + `tool_completed` events for duration)

What was not verified:
- Production build (`bun --filter @archon/web build`) — only dev server (`bun run dev`) was used during the session
- Browser other than Chromium (playwright default)
- Loops with `loop_iteration` events (no live loop runs available during the session)
- The new multipart dispatch path against a workflow that actually attaches and reads files in a Claude SDK node (verified server-side persistence; orchestrator behaviour assumed-equivalent to `sendMessageRoute`)

## Side Effects / Blast Radius (required)

Affected subsystems/workflows:
- `@archon/web` gains a sizeable new tree at `experiments/console/` (additive; the `/app` Layout chain is untouched apart from one CTA in `TopNav.tsx`)
- `@archon/server` gains one new route (`GET /api/runs/:runId/artifacts`) and one route handler refactor (`POST /api/workflows/:name/run` accepts multipart). `sendMessageRoute`'s file-handling logic was lifted into a shared `persistUploadedFiles` helper — `sendMessageRoute` itself was not refactored to use it in this PR

Potential unintended effects:
- `runWorkflowRoute` OpenAPI config no longer declares a `request.body`; consumers of the generated OpenAPI spec will see that route without a body schema. The description string covers both shapes. If a tool generates clients from the spec, this is a deliberate trade-off (Hono/Zod can't validate JSON against a multipart-or-JSON union, same pattern `sendMessageRoute` already uses)
- The console writes a `health` cache entry under the same `useEntity` cache that the rest of the console uses, refetched once on console load. Same cache key shape, no other consumers
- Two pre-existing telegram-markdown tests will *continue* to fail on this branch (they fail identically on `dev`); this PR does not regress them

Guardrails/monitoring for early detection:
- `run_workflow.files_uploaded` and `run_workflow.multipart_parse_failed` log events on the server let you spot misuses
- Console-side cache invalidation is bounded — `useEntity` short-circuits if the key has no subscribers
- The "← Old UI" link in the console header is the obvious revert path for end users

## Rollback Plan (required)

Fast rollback command/path:
- Revert this PR's merge commit. `/console/*` becomes unreachable, the TopNav CTA disappears, the new server endpoint becomes a 404, the `runWorkflowRoute` body parser falls back to JSON-only. No DB changes, no migration, no environment changes
- Alternatively: comment out the `<Route path="/console/*" element={<ConsoleApp />} />` line in `packages/web/src/App.tsx` to hide the console without touching the server

Feature flags or config toggles:
- None at runtime — the route is mounted unconditionally. The user opt-in is the URL itself

Observable failure symptoms (post-merge):
- 5xx on `/api/runs/:runId/artifacts` → `artifacts.walk_failed` log; the Artifacts tab shows an inline error and the rest of the console is unaffected
- Console SSE connection failures → EventSource auto-reconnects; safety-net 30s refetch keeps run state fresh
- The `/console` route blank-screening → check console for module-load errors; the React error boundary in `App.tsx` should catch and display

## Risks and Mitigations

- Risk: The `runWorkflowRoute` body schema change (dropping declared body for multipart support) could surprise external API clients generated from `openapi.json`.
  - Mitigation: Mirrors the existing `sendMessageRoute` pattern; the description on the route explicitly enumerates both content types. JSON callers continue to work unchanged.
- Risk: The console fetches Geist from Google Fonts via CSS `@import`, which is a same-origin-policy and CSP-friendly path but introduces a network dep on console load.
  - Mitigation: `font-display: swap` so render isn't blocked. Only fires when a `/console` route mounts (CSS isn't loaded otherwise).
- Risk: The "Try the new console UI" CTA is highly visible in the old TopNav — users may click in and be confused if features they expect aren't there yet (e.g. workflow editor, settings page).
  - Mitigation: "← Old UI" link in the console header is always visible. Console branding includes a `console` badge to set expectations.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experimental Console UI mounted at /console with project rail, runs dashboard, run detail (log/graph/artifacts), start-run (attachments), approval UI, artifact browser/viewer, preview palette, keyboard palette, and additional keyboard shortcuts.
  * Top navigation adds a “Try the new console UI” CTA and console-specific preview/IDE-open and copy-run-id actions.

* **Bug Fixes & Improvements**
  * Workflow run endpoint accepts JSON or multipart uploads; client enforces upload limits and lists artifacts.
  * Added GET /api/runs/:runId/artifacts.

* **Documentation**
  * READMEs and docs updated for experiments area, console spike, lint isolation, and artifacts endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1747?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->