### PR TITLE
fix(orchestrator): check for resumable workflow run on all platforms (closes #1741)

### DIFF
--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -373,7 +373,6 @@ async function dispatchOrchestratorWorkflow(
       {
         workflowName: workflow.name,
         resumableRunId: resumableRun.id,
-        workingPath: resumableRun.working_path,
       },
       'orchestrator.foreground_resume_detected'
     );

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -361,65 +361,65 @@ async function dispatchOrchestratorWorkflow(
     }
   }
 
-  // Dispatch workflow
-  if (platform.getPlatformType() === 'web') {
-    // Check for a resumable run from a prior dispatch (e.g. approved approval gate).
-    // A new background dispatch would create a new worker conversation and never find
-    // the prior run's worktree. Execute in foreground to reuse the original working path.
-    const resumableRun = await workflowDb.findResumableRunByParentConversation(
-      workflow.name,
-      conversation.id
+  // Check for a resumable run from a prior dispatch (e.g. approved approval gate).
+  // All platforms need this — without it, non-web platforms start a fresh run
+  // instead of resuming where the approval/loop gate paused.
+  const resumableRun = await workflowDb.findResumableRunByParentConversation(
+    workflow.name,
+    conversation.id
+  );
+  if (resumableRun?.working_path) {
+    getLog().info(
+      {
+        workflowName: workflow.name,
+        resumableRunId: resumableRun.id,
+        workingPath: resumableRun.working_path,
+      },
+      'orchestrator.foreground_resume_detected'
     );
-    if (resumableRun?.working_path) {
-      getLog().info(
+    // Hydrate the already-found candidate. If hydration returns null the
+    // prior run had nothing worth resuming (zero completed nodes, no loop
+    // gate) — surface that to the user and fall through to a fresh run on
+    // the same worktree rather than silently restarting.
+    const deps = createWorkflowDeps();
+    const prepared = await hydrateResumableRun(deps, resumableRun);
+    if (prepared) {
+      await executeWorkflow(
+        deps,
+        platform,
+        conversationId,
+        resumableRun.working_path,
+        workflow,
+        userMessage,
+        conversation.id,
         {
-          workflowName: workflow.name,
-          resumableRunId: resumableRun.id,
-          workingPath: resumableRun.working_path,
-        },
-        'orchestrator.foreground_resume_detected'
+          codebaseId: codebase.id,
+          parentConversationId: conversation.id,
+          ...prepared,
+        }
       );
-      // Hydrate the already-found candidate. If hydration returns null the
-      // prior run had nothing worth resuming (zero completed nodes, no loop
-      // gate) — surface that to the user and fall through to a fresh run on
-      // the same worktree rather than silently restarting.
-      const deps = createWorkflowDeps();
-      const prepared = await hydrateResumableRun(deps, resumableRun);
-      if (prepared) {
-        await executeWorkflow(
-          deps,
-          platform,
-          conversationId,
-          resumableRun.working_path,
-          workflow,
-          userMessage,
-          conversation.id,
-          {
-            codebaseId: codebase.id,
-            parentConversationId: conversation.id,
-            ...prepared,
-          }
-        );
-      } else {
-        await platform.sendMessage(
-          conversationId,
-          `⚠️ Prior run for **${workflow.name}** had no completed nodes; starting fresh in the same worktree.`
-        );
-        await executeWorkflow(
-          deps,
-          platform,
-          conversationId,
-          resumableRun.working_path,
-          workflow,
-          userMessage,
-          conversation.id,
-          {
-            codebaseId: codebase.id,
-            parentConversationId: conversation.id,
-          }
-        );
-      }
-    } else if (workflow.interactive) {
+    } else {
+      await platform.sendMessage(
+        conversationId,
+        `⚠️ Prior run for **${workflow.name}** had no completed nodes; starting fresh in the same worktree.`
+      );
+      await executeWorkflow(
+        deps,
+        platform,
+        conversationId,
+        resumableRun.working_path,
+        workflow,
+        userMessage,
+        conversation.id,
+        {
+          codebaseId: codebase.id,
+          parentConversationId: conversation.id,
+        }
+      );
+    }
+  } else if (platform.getPlatformType() === 'web') {
+    // Dispatch workflow
+    if (workflow.interactive) {
       // Interactive workflows run in foreground so output stays in the user's conversation
       await executeWorkflow(
         createWorkflowDeps(),


### PR DESCRIPTION
## Summary

- **Problem:** Chat platforms (Slack, Telegram, Discord, GitHub) never resume approval-gate or interactive-loop workflows. Each user answer starts a fresh run at node 0 instead of resuming where the gate paused.
- **Why it matters:** Approval gates and interactive loops are unusable on non-web platforms — the workflow re-asks the same questions indefinitely.
- **What changed:** Lifted the `findResumableRunByParentConversation` check out of the `platform.getPlatformType() === "web"` conditional so it runs for **all** platforms before dispatch.
- **What did not change (scope boundary):** Web-specific dispatch logic (interactive foreground vs background) remains unchanged. The resume/hydrate behavior is identical — it just now triggers for non-web platforms too.

## UX Journey

### Before

```
  User (Slack)           Archon                   Workflow Engine
  ────────────           ──────                   ───────────────
  triggers workflow ──▶  dispatches fresh run
                         hits approval gate ─────▶ pauses, asks user
  approves ───────────▶  dispatches NEW fresh run  (ignores paused run)
                         hits approval gate ─────▶ pauses, asks user again
  (infinite loop)
```

### After

```
  User (Slack)           Archon                   Workflow Engine
  ────────────           ──────                   ───────────────
  triggers workflow ──▶  dispatches fresh run
                         hits approval gate ─────▶ pauses, asks user
  approves ───────────▶  finds resumable run ────▶ hydrates + resumes
                         continues past gate ────▶ completes workflow
  sees result ◀────────  sends completion
```

## Architecture Diagram

### Before

```
dispatchOrchestratorWorkflow()
├─ if (platform === web)
│  ├─ findResumableRun()  ← resume check ONLY here
│  ├─ if resumable → hydrate + execute
│  ├─ elif interactive → foreground execute
│  └─ else → background dispatch
└─ else (chat platforms)
   └─ executeWorkflow()   ← NO resume check, always fresh
```

### After

```
dispatchOrchestratorWorkflow()
├─ findResumableRun()     ← resume check for ALL platforms
├─ if resumable → hydrate + execute (any platform)
├─ elif (platform === web)
│  ├─ if interactive → foreground execute
│  └─ else → background dispatch
└─ else (chat platforms)
   └─ executeWorkflow()   ← only reached when nothing to resume
```

## Validation

- `bun run test` — all tests pass
- Reviewed `findResumableRunByParentConversation` query: uses `workflow_name` + `parent_conversation_id` (DB fields), both populated identically for web and chat platforms
- Net diff: 56 insertions, 56 deletions (pure restructuring, no new logic)

Closes #1741

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow resumption now available across all platforms, letting users continue interrupted workflows from their last completed step.
  * If a previous run is detected, the workflow resumes from the detected working path; if no resumable state is found, a warning is shown and the workflow restarts in the same working path.
  * Web behavior preserved: interactive workflows run in foreground; non-interactive workflows continue as background runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1749?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->