### PR TITLE
feat(adapters): Jira task-management adapter — talk to Archon inside a ticket

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,7 +95,7 @@ GITLAB_WEBHOOK_SECRET=  # Secret token set in GitLab webhook configuration
 # GITLAB_BOT_MENTION=archon  # Optional: @mention name for detection (default: BOT_DISPLAY_NAME)
 
 # Jira (Community Task-Management Adapter)
-# JIRA_BASE_URL=https://yourorg.atlassian.net
+# JIRA_DOMAIN=yourorg.atlassian.net   # your Atlassian site domain (https:// optional, auto-added)
 JIRA_EMAIL=          # Atlassian account email for Basic auth
 JIRA_API_TOKEN=      # Atlassian API token (not your password) — create at https://id.atlassian.com/manage-profile/security/api-tokens
 JIRA_WEBHOOK_SECRET= # Secret token appended to the Jira webhook URL as ?secret=

--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,14 @@ GITLAB_WEBHOOK_SECRET=  # Secret token set in GitLab webhook configuration
 # GITLAB_ALLOWED_USERS=  # Optional: comma-separated GitLab usernames
 # GITLAB_BOT_MENTION=archon  # Optional: @mention name for detection (default: BOT_DISPLAY_NAME)
 
+# Jira (Community Task-Management Adapter)
+# JIRA_BASE_URL=https://yourorg.atlassian.net
+JIRA_EMAIL=          # Atlassian account email for Basic auth
+JIRA_API_TOKEN=      # Atlassian API token (not your password) — create at https://id.atlassian.com/manage-profile/security/api-tokens
+JIRA_WEBHOOK_SECRET= # Secret token appended to the Jira webhook URL as ?secret=
+JIRA_BOT_MENTION=    # Required: bot's Jira accountId (used for @mention detection and self-trigger guard)
+# JIRA_ALLOWED_ACCOUNT_IDS=  # Optional: comma-separated Jira accountIds; when set, only these users can trigger the bot
+
 # Platforms - set the tokens for the ones you want to use
 # Telegram - <get token from @BotFather>
 TELEGRAM_BOT_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -99,7 +99,7 @@ GITLAB_WEBHOOK_SECRET=  # Secret token set in GitLab webhook configuration
 JIRA_EMAIL=          # Atlassian account email for Basic auth
 JIRA_API_TOKEN=      # Atlassian API token (not your password) — create at https://id.atlassian.com/manage-profile/security/api-tokens
 JIRA_WEBHOOK_SECRET= # Secret token appended to the Jira webhook URL as ?secret=
-JIRA_BOT_MENTION=    # Required: bot's Jira accountId (used for @mention detection and self-trigger guard)
+# JIRA_BOT_MENTION=Archon  # Optional: display name for @mention detection; case-insensitive (default: Archon)
 # JIRA_ALLOWED_ACCOUNT_IDS=  # Optional: comma-separated Jira accountIds; when set, only these users can trigger the bot
 
 # Platforms - set the tokens for the ones you want to use

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -8,10 +8,11 @@
     ".": "./src/index.ts",
     "./*": "./src/*",
     "./community/forge/gitea": "./src/community/forge/gitea/index.ts",
-    "./community/forge/gitlab": "./src/community/forge/gitlab/index.ts"
+    "./community/forge/gitlab": "./src/community/forge/gitlab/index.ts",
+    "./community/task-management/jira": "./src/community/task-management/jira/index.ts"
   },
   "scripts": {
-    "test": "bun test src/chat/ src/community/chat/ src/community/forge/gitlab/auth.test.ts src/forge/github/auth.test.ts src/utils/ && bun test src/forge/github/adapter.test.ts && bun test src/forge/github/context.test.ts && bun test src/community/forge/gitea/adapter.test.ts && bun test src/community/forge/gitlab/adapter.test.ts",
+    "test": "bun test src/chat/ src/community/chat/ src/community/forge/gitlab/auth.test.ts src/forge/github/auth.test.ts src/utils/ && bun test src/forge/github/adapter.test.ts && bun test src/forge/github/context.test.ts && bun test src/community/forge/gitea/adapter.test.ts && bun test src/community/forge/gitlab/adapter.test.ts && bun test src/community/task-management/jira/adapter.test.ts",
     "type-check": "bun x tsc --noEmit"
   },
   "dependencies": {

--- a/packages/adapters/src/community/task-management/README.md
+++ b/packages/adapters/src/community/task-management/README.md
@@ -1,0 +1,17 @@
+# Task-Management Community Adapters
+
+Adapters in this category connect Archon to project/ticket management platforms (e.g., Jira).
+
+## Conventions
+
+- **conversationId**: Issue key (e.g. `DF-123`, `PROJ-42`). Globally unique per Jira instance.
+- **No codebase/repo management**: Unlike forge adapters, task-management adapters do not clone repos or manage codebases. Conversation semantics match the chat family.
+- **Auth**: Shared secret delivered as URL query param `?secret=` (Jira's native webhook mechanism — no HMAC).
+- **Message format**: Atlassian Document Format (ADF) for Jira Cloud REST API v3 comment bodies.
+- **Trigger**: Comment containing an ADF mention node matching the bot's accountId.
+
+## Adapters
+
+| Adapter | Package subpath |
+|---------|----------------|
+| Jira Cloud | `@archon/adapters/community/task-management/jira` |

--- a/packages/adapters/src/community/task-management/jira/adapter.test.ts
+++ b/packages/adapters/src/community/task-management/jira/adapter.test.ts
@@ -1,0 +1,399 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+// Mock @archon/paths
+const mockLogger = {
+  fatal: mock(() => undefined),
+  error: mock(() => undefined),
+  warn: mock(() => undefined),
+  info: mock(() => undefined),
+  debug: mock(() => undefined),
+  trace: mock(() => undefined),
+  child: mock(function (this: unknown) {
+    return this;
+  }),
+  bindings: mock(() => ({ module: 'test' })),
+  isLevelEnabled: mock(() => true),
+  level: 'info',
+};
+mock.module('@archon/paths', () => ({
+  createLogger: mock(() => mockLogger),
+  getArchonWorkspacesPath: mock(() => '/tmp/test-workspaces'),
+  getCommandFolderSearchPaths: mock(() => ['.archon/commands']),
+  getProjectSourcePath: mock(
+    (owner: string, repo: string) => `/tmp/test-workspaces/${owner}/${repo}/source`
+  ),
+  ensureProjectStructure: mock(async () => undefined),
+  logArchonPaths: mock(() => undefined),
+  validateAppDefaultsPaths: mock(async () => undefined),
+}));
+
+// Mock @archon/core/db modules
+mock.module('@archon/core/db/conversations', () => ({
+  getOrCreateConversation: mock(async () => {
+    throw new Error('DB not mocked in tests');
+  }),
+  updateConversation: mock(async () => {
+    throw new Error('DB not mocked in tests');
+  }),
+  getConversation: mock(async () => null),
+}));
+
+// Mock @archon/core
+const mockHandleMessage = mock(async () => undefined);
+mock.module('@archon/core', () => ({
+  handleMessage: mockHandleMessage,
+  classifyAndFormatError: mock((err: Error) => err.message),
+  toError: mock((e: unknown) => (e instanceof Error ? e : new Error(String(e)))),
+  ConversationLockManager: class {
+    async acquireLock(_id: string, fn: () => Promise<void>): Promise<void> {
+      await fn();
+    }
+  },
+}));
+
+// Mock @archon/isolation (type-only import in adapter, but Bun resolves all modules)
+mock.module('@archon/isolation', () => ({
+  IsolationHints: {},
+}));
+
+// Mock global fetch
+const mockFetch = mock(() =>
+  Promise.resolve(new Response(JSON.stringify({ comments: [] }), { status: 200 }))
+);
+globalThis.fetch = mockFetch as typeof globalThis.fetch;
+
+// Now import the adapter (after all mocks)
+const { JiraAdapter } = await import('./adapter');
+const { ConversationLockManager } = await import('@archon/core');
+
+const TEST_BOT_ACCOUNT_ID = '5b10a2844c20165700ede21g';
+const TEST_BASE_URL = 'https://test.atlassian.net';
+const TEST_EMAIL = 'bot@example.com';
+const TEST_API_TOKEN = 'test-api-token';
+const TEST_WEBHOOK_SECRET = 'test-webhook-secret';
+
+function createAdapter(): InstanceType<typeof JiraAdapter> {
+  const lockManager = new ConversationLockManager();
+  return new JiraAdapter(
+    TEST_BASE_URL,
+    TEST_EMAIL,
+    TEST_API_TOKEN,
+    TEST_WEBHOOK_SECRET,
+    lockManager as never,
+    TEST_BOT_ACCOUNT_ID
+  );
+}
+
+function adfWithMention(botId: string, extraText?: string): unknown {
+  const content: unknown[] = [
+    {
+      type: 'paragraph',
+      content: [
+        { type: 'mention', attrs: { id: botId, text: '@bot' } },
+        ...(extraText ? [{ type: 'text', text: ` ${extraText}` }] : []),
+      ],
+    },
+  ];
+  return { version: 1, type: 'doc', content };
+}
+
+function adfTextOnly(text: string): unknown {
+  return {
+    version: 1,
+    type: 'doc',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+  };
+}
+
+function createCommentPayload(overrides?: {
+  commentBody?: unknown;
+  authorAccountId?: string;
+  issueKey?: string;
+  issueSummary?: string;
+  webhookEvent?: string;
+}): string {
+  return JSON.stringify({
+    webhookEvent: overrides?.webhookEvent ?? 'comment_created',
+    comment: {
+      id: '10001',
+      author: {
+        accountId: overrides?.authorAccountId ?? 'user-account-123',
+        displayName: 'Test User',
+      },
+      body: overrides?.commentBody ?? adfWithMention(TEST_BOT_ACCOUNT_ID, 'hello'),
+      created: '2024-01-01T00:00:00.000+0000',
+      updated: '2024-01-01T00:00:00.000+0000',
+    },
+    issue: {
+      id: '10000',
+      key: overrides?.issueKey ?? 'DF-123',
+      fields: {
+        summary: overrides?.issueSummary ?? 'Test Issue Summary',
+        description: null,
+        status: { name: 'Open' },
+        priority: { name: 'Medium' },
+        labels: ['bug'],
+      },
+    },
+  });
+}
+
+describe('JiraAdapter', () => {
+  beforeEach(() => {
+    mockHandleMessage.mockClear();
+    mockFetch.mockClear();
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response(JSON.stringify({ comments: [] }), { status: 200 }))
+    );
+    delete process.env.JIRA_ALLOWED_ACCOUNT_IDS;
+  });
+
+  describe('basic interface', () => {
+    test('returns batch streaming mode', () => {
+      const adapter = createAdapter();
+      expect(adapter.getStreamingMode()).toBe('batch');
+    });
+
+    test('returns jira platform type', () => {
+      const adapter = createAdapter();
+      expect(adapter.getPlatformType()).toBe('jira');
+    });
+
+    test('start and stop without error', async () => {
+      const adapter = createAdapter();
+      await adapter.start();
+      adapter.stop();
+    });
+
+    test('ensureThread returns original id', async () => {
+      const adapter = createAdapter();
+      const id = await adapter.ensureThread('DF-1');
+      expect(id).toBe('DF-1');
+    });
+  });
+
+  describe('constructor validation', () => {
+    const lockManager = new ConversationLockManager();
+
+    test('throws if botAccountId is empty', () => {
+      expect(
+        () =>
+          new JiraAdapter(
+            TEST_BASE_URL,
+            TEST_EMAIL,
+            TEST_API_TOKEN,
+            TEST_WEBHOOK_SECRET,
+            lockManager as never,
+            ''
+          )
+      ).toThrow('botAccountId');
+    });
+
+    test('throws if baseUrl is empty', () => {
+      expect(
+        () =>
+          new JiraAdapter(
+            '',
+            TEST_EMAIL,
+            TEST_API_TOKEN,
+            TEST_WEBHOOK_SECRET,
+            lockManager as never,
+            TEST_BOT_ACCOUNT_ID
+          )
+      ).toThrow('baseUrl');
+    });
+
+    test('throws if email is empty', () => {
+      expect(
+        () =>
+          new JiraAdapter(
+            TEST_BASE_URL,
+            '',
+            TEST_API_TOKEN,
+            TEST_WEBHOOK_SECRET,
+            lockManager as never,
+            TEST_BOT_ACCOUNT_ID
+          )
+      ).toThrow('email');
+    });
+
+    test('throws if apiToken is empty', () => {
+      expect(
+        () =>
+          new JiraAdapter(
+            TEST_BASE_URL,
+            TEST_EMAIL,
+            '',
+            TEST_WEBHOOK_SECRET,
+            lockManager as never,
+            TEST_BOT_ACCOUNT_ID
+          )
+      ).toThrow('apiToken');
+    });
+
+    test('throws if webhookSecret is empty', () => {
+      expect(
+        () =>
+          new JiraAdapter(
+            TEST_BASE_URL,
+            TEST_EMAIL,
+            TEST_API_TOKEN,
+            '',
+            lockManager as never,
+            TEST_BOT_ACCOUNT_ID
+          )
+      ).toThrow('webhookSecret');
+    });
+  });
+
+  describe('webhook secret verification', () => {
+    test('rejects with wrong secret', async () => {
+      const adapter = createAdapter();
+      await adapter.handleWebhook(createCommentPayload(), 'wrong-secret');
+      expect(mockHandleMessage).not.toHaveBeenCalled();
+    });
+
+    test('rejects with empty secret', async () => {
+      const adapter = createAdapter();
+      await adapter.handleWebhook(createCommentPayload(), '');
+      expect(mockHandleMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('JSON parse errors', () => {
+    test('handles malformed JSON gracefully', async () => {
+      const adapter = createAdapter();
+      await adapter.handleWebhook('not-valid-json', TEST_WEBHOOK_SECRET);
+      expect(mockHandleMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('event type filtering', () => {
+    test('ignores comment_updated event', async () => {
+      const adapter = createAdapter();
+      const payload = createCommentPayload({ webhookEvent: 'comment_updated' });
+      await adapter.handleWebhook(payload, TEST_WEBHOOK_SECRET);
+      expect(mockHandleMessage).not.toHaveBeenCalled();
+    });
+
+    test('ignores issue_created event', async () => {
+      const adapter = createAdapter();
+      const payload = createCommentPayload({ webhookEvent: 'issue_created' });
+      await adapter.handleWebhook(payload, TEST_WEBHOOK_SECRET);
+      expect(mockHandleMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('self-trigger guard', () => {
+    test('ignores comments authored by botAccountId', async () => {
+      const adapter = createAdapter();
+      const payload = createCommentPayload({ authorAccountId: TEST_BOT_ACCOUNT_ID });
+      await adapter.handleWebhook(payload, TEST_WEBHOOK_SECRET);
+      expect(mockHandleMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('accountId allowlist', () => {
+    test('rejects unauthorized accountId when allowlist is set', async () => {
+      process.env.JIRA_ALLOWED_ACCOUNT_IDS = 'allowed-user-1,allowed-user-2';
+      const adapter = createAdapter();
+      const payload = createCommentPayload({ authorAccountId: 'unauthorized-user' });
+      await adapter.handleWebhook(payload, TEST_WEBHOOK_SECRET);
+      expect(mockHandleMessage).not.toHaveBeenCalled();
+    });
+
+    test('allows authorized accountId when allowlist is set', async () => {
+      process.env.JIRA_ALLOWED_ACCOUNT_IDS = 'allowed-user-1,user-account-123';
+      const adapter = createAdapter();
+      const payload = createCommentPayload();
+      await adapter.handleWebhook(payload, TEST_WEBHOOK_SECRET);
+      expect(mockHandleMessage).toHaveBeenCalledTimes(1);
+    });
+
+    test('allows all when allowlist is empty', async () => {
+      const adapter = createAdapter();
+      const payload = createCommentPayload();
+      await adapter.handleWebhook(payload, TEST_WEBHOOK_SECRET);
+      expect(mockHandleMessage).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('ADF mention detection', () => {
+    test('ignores comment with no mention node', async () => {
+      const adapter = createAdapter();
+      const payload = createCommentPayload({ commentBody: adfTextOnly('just text, no mention') });
+      await adapter.handleWebhook(payload, TEST_WEBHOOK_SECRET);
+      expect(mockHandleMessage).not.toHaveBeenCalled();
+    });
+
+    test('ignores comment mentioning a different accountId', async () => {
+      const adapter = createAdapter();
+      const payload = createCommentPayload({
+        commentBody: adfWithMention('different-account-id', 'hello'),
+      });
+      await adapter.handleWebhook(payload, TEST_WEBHOOK_SECRET);
+      expect(mockHandleMessage).not.toHaveBeenCalled();
+    });
+
+    test('processes comment with ADF mention matching botAccountId', async () => {
+      const adapter = createAdapter();
+      const payload = createCommentPayload();
+      await adapter.handleWebhook(payload, TEST_WEBHOOK_SECRET);
+      expect(mockHandleMessage).toHaveBeenCalledTimes(1);
+      expect(mockHandleMessage).toHaveBeenCalledWith(
+        adapter,
+        'DF-123',
+        expect.any(String),
+        expect.objectContaining({
+          issueContext: expect.stringContaining('Jira Issue Context'),
+          isolationHints: { workflowType: 'thread', workflowId: 'DF-123' },
+        })
+      );
+    });
+  });
+
+  describe('sendMessage', () => {
+    test('short message calls fetch once', async () => {
+      const adapter = createAdapter();
+      await adapter.sendMessage('DF-1', 'Hello from Archon');
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('https://test.atlassian.net/rest/api/3/issue/DF-1/comment');
+      expect(options.method).toBe('POST');
+    });
+
+    test('long message calls fetch multiple times', async () => {
+      const adapter = createAdapter();
+      const paragraphs = Array.from(
+        { length: 40 },
+        (_, i) => `Paragraph ${String(i)}: ${'x'.repeat(990)}`
+      );
+      const longMessage = paragraphs.join('\n\n');
+      await adapter.sendMessage('DF-1', longMessage);
+
+      expect(mockFetch.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    test('POST body contains ADF structure', async () => {
+      const adapter = createAdapter();
+      await adapter.sendMessage('DF-1', 'Test message');
+
+      const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(options.body as string) as {
+        body: { type: string; version: number };
+      };
+      expect(body.body.type).toBe('doc');
+      expect(body.body.version).toBe(1);
+    });
+
+    test('uses Basic auth header', async () => {
+      const adapter = createAdapter();
+      await adapter.sendMessage('DF-1', 'Test');
+
+      const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const headers = options.headers as Record<string, string>;
+      expect(headers.Authorization).toMatch(/^Basic /);
+    });
+  });
+});

--- a/packages/adapters/src/community/task-management/jira/adapter.test.ts
+++ b/packages/adapters/src/community/task-management/jira/adapter.test.ts
@@ -66,7 +66,10 @@ globalThis.fetch = mockFetch as typeof globalThis.fetch;
 const { JiraAdapter } = await import('./adapter');
 const { ConversationLockManager } = await import('@archon/core');
 
-const TEST_BOT_ACCOUNT_ID = '5b10a2844c20165700ede21g';
+// Matches SELF_TRIGGER_MARKER in adapter.ts
+const SELF_TRIGGER_MARKER = '​​​';
+
+const TEST_BOT_MENTION = 'Archon';
 const TEST_BASE_URL = 'https://test.atlassian.net';
 const TEST_EMAIL = 'bot@example.com';
 const TEST_API_TOKEN = 'test-api-token';
@@ -80,21 +83,37 @@ function createAdapter(): InstanceType<typeof JiraAdapter> {
     TEST_API_TOKEN,
     TEST_WEBHOOK_SECRET,
     lockManager as never,
-    TEST_BOT_ACCOUNT_ID
+    TEST_BOT_MENTION
   );
 }
 
-function adfWithMention(botId: string, extraText?: string): unknown {
+// ADF mention node using display name (as Jira sends for a real @mentioned user)
+function adfWithNameMention(botName: string, extraText?: string): unknown {
   const content: unknown[] = [
     {
       type: 'paragraph',
       content: [
-        { type: 'mention', attrs: { id: botId, text: '@bot' } },
+        { type: 'mention', attrs: { text: `@${botName}`, displayName: botName } },
         ...(extraText ? [{ type: 'text', text: ` ${extraText}` }] : []),
       ],
     },
   ];
   return { version: 1, type: 'doc', content };
+}
+
+// Plain text node containing @name (no real Jira user object)
+function adfWithTextMention(mention: string, extraText?: string): unknown {
+  const atMention = mention.startsWith('@') ? mention : `@${mention}`;
+  return {
+    version: 1,
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: extraText ? `${atMention} ${extraText}` : atMention }],
+      },
+    ],
+  };
 }
 
 function adfTextOnly(text: string): unknown {
@@ -120,7 +139,7 @@ function createCommentPayload(overrides?: {
         accountId: overrides?.authorAccountId ?? 'user-account-123',
         displayName: 'Test User',
       },
-      body: overrides?.commentBody ?? adfWithMention(TEST_BOT_ACCOUNT_ID, 'hello'),
+      body: overrides?.commentBody ?? adfWithNameMention(TEST_BOT_MENTION, 'hello'),
       created: '2024-01-01T00:00:00.000+0000',
       updated: '2024-01-01T00:00:00.000+0000',
     },
@@ -129,6 +148,43 @@ function createCommentPayload(overrides?: {
       key: overrides?.issueKey ?? 'DF-123',
       fields: {
         summary: overrides?.issueSummary ?? 'Test Issue Summary',
+        description: null,
+        status: { name: 'Open' },
+        priority: { name: 'Medium' },
+        labels: ['bug'],
+      },
+    },
+  });
+}
+
+// Payload that simulates Jira echoing back a comment the adapter posted
+function createMarkedCommentPayload(): string {
+  return JSON.stringify({
+    webhookEvent: 'comment_created',
+    comment: {
+      id: '10002',
+      author: {
+        accountId: 'bot-service-account',
+        displayName: 'Archon Bot',
+      },
+      body: {
+        version: 1,
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: `Here is my response${SELF_TRIGGER_MARKER}` }],
+          },
+        ],
+      },
+      created: '2024-01-01T00:00:00.000+0000',
+      updated: '2024-01-01T00:00:00.000+0000',
+    },
+    issue: {
+      id: '10000',
+      key: 'DF-123',
+      fields: {
+        summary: 'Test Issue Summary',
         description: null,
         status: { name: 'Open' },
         priority: { name: 'Medium' },
@@ -175,18 +231,21 @@ describe('JiraAdapter', () => {
   describe('constructor validation', () => {
     const lockManager = new ConversationLockManager();
 
-    test('throws if botAccountId is empty', () => {
-      expect(
-        () =>
-          new JiraAdapter(
-            TEST_BASE_URL,
-            TEST_EMAIL,
-            TEST_API_TOKEN,
-            TEST_WEBHOOK_SECRET,
-            lockManager as never,
-            ''
-          )
-      ).toThrow('botAccountId');
+    test('defaults botMention to Archon when empty string is passed', async () => {
+      const adapter = new JiraAdapter(
+        TEST_BASE_URL,
+        TEST_EMAIL,
+        TEST_API_TOKEN,
+        TEST_WEBHOOK_SECRET,
+        lockManager as never,
+        ''
+      );
+      // An @Archon ADF mention should be processed with the default name
+      const payload = createCommentPayload({
+        commentBody: adfWithNameMention('Archon', 'hello'),
+      });
+      await adapter.handleWebhook(payload, TEST_WEBHOOK_SECRET);
+      expect(mockHandleMessage).toHaveBeenCalledTimes(1);
     });
 
     test('throws if baseUrl is empty', () => {
@@ -198,7 +257,7 @@ describe('JiraAdapter', () => {
             TEST_API_TOKEN,
             TEST_WEBHOOK_SECRET,
             lockManager as never,
-            TEST_BOT_ACCOUNT_ID
+            TEST_BOT_MENTION
           )
       ).toThrow('baseUrl');
     });
@@ -212,7 +271,7 @@ describe('JiraAdapter', () => {
             TEST_API_TOKEN,
             TEST_WEBHOOK_SECRET,
             lockManager as never,
-            TEST_BOT_ACCOUNT_ID
+            TEST_BOT_MENTION
           )
       ).toThrow('email');
     });
@@ -226,7 +285,7 @@ describe('JiraAdapter', () => {
             '',
             TEST_WEBHOOK_SECRET,
             lockManager as never,
-            TEST_BOT_ACCOUNT_ID
+            TEST_BOT_MENTION
           )
       ).toThrow('apiToken');
     });
@@ -240,7 +299,7 @@ describe('JiraAdapter', () => {
             TEST_API_TOKEN,
             '',
             lockManager as never,
-            TEST_BOT_ACCOUNT_ID
+            TEST_BOT_MENTION
           )
       ).toThrow('webhookSecret');
     });
@@ -285,10 +344,9 @@ describe('JiraAdapter', () => {
   });
 
   describe('self-trigger guard', () => {
-    test('ignores comments authored by botAccountId', async () => {
+    test('ignores comments containing the self-trigger marker', async () => {
       const adapter = createAdapter();
-      const payload = createCommentPayload({ authorAccountId: TEST_BOT_ACCOUNT_ID });
-      await adapter.handleWebhook(payload, TEST_WEBHOOK_SECRET);
+      await adapter.handleWebhook(createMarkedCommentPayload(), TEST_WEBHOOK_SECRET);
       expect(mockHandleMessage).not.toHaveBeenCalled();
     });
   });
@@ -319,25 +377,27 @@ describe('JiraAdapter', () => {
   });
 
   describe('ADF mention detection', () => {
-    test('ignores comment with no mention node', async () => {
+    test('ignores comment with no mention node and no @name text', async () => {
       const adapter = createAdapter();
       const payload = createCommentPayload({ commentBody: adfTextOnly('just text, no mention') });
       await adapter.handleWebhook(payload, TEST_WEBHOOK_SECRET);
       expect(mockHandleMessage).not.toHaveBeenCalled();
     });
 
-    test('ignores comment mentioning a different accountId', async () => {
+    test('ignores comment mentioning a different name', async () => {
       const adapter = createAdapter();
       const payload = createCommentPayload({
-        commentBody: adfWithMention('different-account-id', 'hello'),
+        commentBody: adfWithNameMention('SomeOtherBot', 'hello'),
       });
       await adapter.handleWebhook(payload, TEST_WEBHOOK_SECRET);
       expect(mockHandleMessage).not.toHaveBeenCalled();
     });
 
-    test('processes comment with ADF mention matching botAccountId', async () => {
+    test('processes ADF mention node matching bot name via attrs.text', async () => {
       const adapter = createAdapter();
-      const payload = createCommentPayload();
+      const payload = createCommentPayload({
+        commentBody: adfWithNameMention(TEST_BOT_MENTION, 'hello'),
+      });
       await adapter.handleWebhook(payload, TEST_WEBHOOK_SECRET);
       expect(mockHandleMessage).toHaveBeenCalledTimes(1);
       expect(mockHandleMessage).toHaveBeenCalledWith(
@@ -349,6 +409,33 @@ describe('JiraAdapter', () => {
           isolationHints: { workflowType: 'thread', workflowId: 'DF-123' },
         })
       );
+    });
+
+    test('processes ADF mention node case-insensitively (ARCHON)', async () => {
+      const adapter = createAdapter();
+      const payload = createCommentPayload({
+        commentBody: adfWithNameMention(TEST_BOT_MENTION.toUpperCase(), 'hello'),
+      });
+      await adapter.handleWebhook(payload, TEST_WEBHOOK_SECRET);
+      expect(mockHandleMessage).toHaveBeenCalledTimes(1);
+    });
+
+    test('processes plain text @name mention', async () => {
+      const adapter = createAdapter();
+      const payload = createCommentPayload({
+        commentBody: adfWithTextMention(TEST_BOT_MENTION, 'help me fix this'),
+      });
+      await adapter.handleWebhook(payload, TEST_WEBHOOK_SECRET);
+      expect(mockHandleMessage).toHaveBeenCalledTimes(1);
+    });
+
+    test('processes plain text @name mention case-insensitively (@archon)', async () => {
+      const adapter = createAdapter();
+      const payload = createCommentPayload({
+        commentBody: adfWithTextMention(TEST_BOT_MENTION.toLowerCase(), 'help me fix this'),
+      });
+      await adapter.handleWebhook(payload, TEST_WEBHOOK_SECRET);
+      expect(mockHandleMessage).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/adapters/src/community/task-management/jira/adapter.ts
+++ b/packages/adapters/src/community/task-management/jira/adapter.ts
@@ -25,13 +25,17 @@ function getLog(): ReturnType<typeof createLogger> {
 
 const MAX_COMMENT_LENGTH = 30000;
 
+// Appended to every outgoing comment. Presence in an incoming webhook payload
+// means this adapter authored it — used by the self-trigger guard in handleWebhook.
+const SELF_TRIGGER_MARKER = '​​​';
+
 export class JiraAdapter implements IPlatformAdapter {
   private readonly baseUrl: string;
   private readonly email: string;
   private readonly apiToken: string;
   private readonly webhookSecret: string;
   private readonly lockManager: ConversationLockManager;
-  private readonly botAccountId: string;
+  private readonly botMention: string;
   private readonly allowedAccountIds: string[];
 
   constructor(
@@ -40,11 +44,8 @@ export class JiraAdapter implements IPlatformAdapter {
     apiToken: string,
     webhookSecret: string,
     lockManager: ConversationLockManager,
-    botAccountId: string
+    botMention: string
   ) {
-    if (!botAccountId) {
-      throw new Error('JiraAdapter requires a non-empty botAccountId (JIRA_BOT_MENTION)');
-    }
     if (!baseUrl) throw new Error('JiraAdapter requires a non-empty baseUrl');
     if (!email) throw new Error('JiraAdapter requires a non-empty email');
     if (!apiToken) throw new Error('JiraAdapter requires a non-empty apiToken');
@@ -55,7 +56,7 @@ export class JiraAdapter implements IPlatformAdapter {
     this.apiToken = apiToken;
     this.webhookSecret = webhookSecret;
     this.lockManager = lockManager;
-    this.botAccountId = botAccountId;
+    this.botMention = botMention || 'Archon';
     this.allowedAccountIds = parseAllowedAccountIds(process.env.JIRA_ALLOWED_ACCOUNT_IDS);
 
     if (this.allowedAccountIds.length > 0) {
@@ -64,7 +65,10 @@ export class JiraAdapter implements IPlatformAdapter {
       getLog().info('jira.allowlist_disabled');
     }
 
-    getLog().info({ baseUrl: this.baseUrl }, 'jira.adapter_initialized');
+    getLog().info(
+      { baseUrl: this.baseUrl, botMention: this.botMention },
+      'jira.adapter_initialized'
+    );
   }
 
   // ---------------------------------------------------------------------------
@@ -179,15 +183,29 @@ export class JiraAdapter implements IPlatformAdapter {
   }
 
   private extractTextFromAdf(node: JiraAdfNode): string {
-    if (node.type === 'text') return node.text ?? '';
+    if (node.type === 'text') return (node.text ?? '').replaceAll(SELF_TRIGGER_MARKER, '');
     if (node.type === 'hardBreak') return '\n';
     if (node.type === 'mention') return '';
     return (node.content ?? []).map(child => this.extractTextFromAdf(child)).join('');
   }
 
-  private hasMention(node: JiraAdfNode, accountId: string): boolean {
-    if (node.type === 'mention' && node.attrs?.id === accountId) return true;
-    return (node.content ?? []).some(child => this.hasMention(child, accountId));
+  // Detects whether the bot is mentioned in an ADF node tree by display name (case-insensitive).
+  // Matches real Jira @mention nodes (attrs.text / attrs.displayName) and plain text "@name" patterns.
+  private hasMention(node: JiraAdfNode, botName: string): boolean {
+    const normalized = botName.toLowerCase();
+    if (node.type === 'mention') {
+      const attrText = ((node.attrs?.text as string | undefined) ?? '')
+        .replace(/^@/, '')
+        .toLowerCase();
+      const displayName = ((node.attrs?.displayName as string | undefined) ?? '')
+        .replace(/^@/, '')
+        .toLowerCase();
+      if (attrText === normalized || displayName === normalized) return true;
+    }
+    if (node.type === 'text' && (node.text ?? '').toLowerCase().includes(`@${normalized}`)) {
+      return true;
+    }
+    return (node.content ?? []).some(child => this.hasMention(child, botName));
   }
 
   // ---------------------------------------------------------------------------
@@ -216,7 +234,8 @@ export class JiraAdapter implements IPlatformAdapter {
   // ---------------------------------------------------------------------------
 
   private async postComment(issueKey: string, text: string): Promise<void> {
-    const adfDoc = this.buildAdfDocument(text);
+    // Append the self-trigger marker so handleWebhook can skip echoed webhooks.
+    const adfDoc = this.buildAdfDocument(text + SELF_TRIGGER_MARKER);
     await this.jiraApi('POST', `/issue/${issueKey}/comment`, { body: adfDoc });
     getLog().debug({ issueKey }, 'jira.comment_posted');
   }
@@ -237,7 +256,13 @@ export class JiraAdapter implements IPlatformAdapter {
       return;
     }
 
-    // 2. Parse event
+    // 2. Self-trigger guard — our own comments contain SELF_TRIGGER_MARKER
+    if (payload.includes(SELF_TRIGGER_MARKER)) {
+      log.debug('jira.ignoring_own_comment');
+      return;
+    }
+
+    // 3. Parse event
     let event: JiraWebhookEvent;
     try {
       event = JSON.parse(payload) as JiraWebhookEvent;
@@ -246,16 +271,10 @@ export class JiraAdapter implements IPlatformAdapter {
       return;
     }
 
-    // 3. Filter to comment_created only
+    // 4. Filter to comment_created only
     if (event.webhookEvent !== 'comment_created') return;
 
     const commentEvent = event as JiraCommentCreatedEvent;
-
-    // 4. Self-trigger guard
-    if (commentEvent.comment.author.accountId === this.botAccountId) {
-      log.debug({ authorAccountId: this.botAccountId }, 'jira.ignoring_own_comment');
-      return;
-    }
 
     // 5. Authorization check
     if (!isAccountIdAuthorized(commentEvent.comment.author.accountId, this.allowedAccountIds)) {
@@ -267,7 +286,7 @@ export class JiraAdapter implements IPlatformAdapter {
     }
 
     // 6. Check @mention in ADF
-    if (!this.hasMention(commentEvent.comment.body, this.botAccountId)) return;
+    if (!this.hasMention(commentEvent.comment.body, this.botMention)) return;
 
     if (!commentEvent.issue?.key) {
       log.warn({ webhookEvent: 'comment_created' }, 'jira.webhook_missing_issue_key');

--- a/packages/adapters/src/community/task-management/jira/adapter.ts
+++ b/packages/adapters/src/community/task-management/jira/adapter.ts
@@ -1,0 +1,308 @@
+import type { IPlatformAdapter, MessageMetadata } from '@archon/core';
+import type { IsolationHints } from '@archon/isolation';
+import {
+  handleMessage,
+  classifyAndFormatError,
+  toError,
+  ConversationLockManager,
+} from '@archon/core';
+import { createLogger } from '@archon/paths';
+import { splitIntoParagraphChunks } from '../../../utils/message-splitting';
+import { verifyWebhookSecret, parseAllowedAccountIds, isAccountIdAuthorized } from './auth';
+import type {
+  JiraWebhookEvent,
+  JiraAdfNode,
+  JiraAdfDocument,
+  JiraCommentCreatedEvent,
+  JiraCommentListResponse,
+} from './types';
+
+let cachedLog: ReturnType<typeof createLogger> | undefined;
+function getLog(): ReturnType<typeof createLogger> {
+  if (!cachedLog) cachedLog = createLogger('adapter.jira');
+  return cachedLog;
+}
+
+const MAX_COMMENT_LENGTH = 30000;
+
+export class JiraAdapter implements IPlatformAdapter {
+  private readonly baseUrl: string;
+  private readonly email: string;
+  private readonly apiToken: string;
+  private readonly webhookSecret: string;
+  private readonly lockManager: ConversationLockManager;
+  private readonly botAccountId: string;
+  private readonly allowedAccountIds: string[];
+
+  constructor(
+    baseUrl: string,
+    email: string,
+    apiToken: string,
+    webhookSecret: string,
+    lockManager: ConversationLockManager,
+    botAccountId: string
+  ) {
+    if (!botAccountId) {
+      throw new Error('JiraAdapter requires a non-empty botAccountId (JIRA_BOT_MENTION)');
+    }
+    if (!baseUrl) throw new Error('JiraAdapter requires a non-empty baseUrl');
+    if (!email) throw new Error('JiraAdapter requires a non-empty email');
+    if (!apiToken) throw new Error('JiraAdapter requires a non-empty apiToken');
+    if (!webhookSecret) throw new Error('JiraAdapter requires a non-empty webhookSecret');
+
+    this.baseUrl = baseUrl.replace(/\/+$/, '');
+    this.email = email;
+    this.apiToken = apiToken;
+    this.webhookSecret = webhookSecret;
+    this.lockManager = lockManager;
+    this.botAccountId = botAccountId;
+    this.allowedAccountIds = parseAllowedAccountIds(process.env.JIRA_ALLOWED_ACCOUNT_IDS);
+
+    if (this.allowedAccountIds.length > 0) {
+      getLog().info({ accountCount: this.allowedAccountIds.length }, 'jira.allowlist_enabled');
+    } else {
+      getLog().info('jira.allowlist_disabled');
+    }
+
+    getLog().info({ baseUrl: this.baseUrl }, 'jira.adapter_initialized');
+  }
+
+  // ---------------------------------------------------------------------------
+  // IPlatformAdapter methods
+  // ---------------------------------------------------------------------------
+
+  async sendMessage(
+    conversationId: string,
+    message: string,
+    _metadata?: MessageMetadata
+  ): Promise<void> {
+    getLog().debug({ conversationId, messageLength: message.length }, 'jira.send_message');
+
+    if (message.length <= MAX_COMMENT_LENGTH) {
+      await this.postComment(conversationId, message);
+    } else {
+      getLog().debug({ messageLength: message.length }, 'jira.message_splitting');
+      const chunks = splitIntoParagraphChunks(message, MAX_COMMENT_LENGTH);
+
+      for (let i = 0; i < chunks.length; i++) {
+        try {
+          await this.postComment(conversationId, chunks[i]);
+        } catch (error) {
+          const err = error as Error;
+          getLog().error(
+            { err, chunkIndex: i + 1, totalChunks: chunks.length, conversationId },
+            'jira.chunk_post_failed'
+          );
+          const partialError = new Error(
+            `Failed to post comment chunk ${String(i + 1)}/${String(chunks.length)}. ` +
+              `${String(i)} chunk(s) were posted before failure.`
+          );
+          partialError.cause = error;
+          throw partialError;
+        }
+      }
+    }
+  }
+
+  getStreamingMode(): 'batch' {
+    return 'batch';
+  }
+
+  getPlatformType(): string {
+    return 'jira';
+  }
+
+  async start(): Promise<void> {
+    getLog().info('jira.webhook_adapter_ready');
+  }
+
+  stop(): void {
+    getLog().info('jira.adapter_stopped');
+  }
+
+  async ensureThread(originalConversationId: string): Promise<string> {
+    return originalConversationId;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Jira REST API helper
+  // ---------------------------------------------------------------------------
+
+  private async jiraApi<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const url = `${this.baseUrl}/rest/api/3${path}`;
+    const auth = Buffer.from(`${this.email}:${this.apiToken}`).toString('base64');
+    const response = await fetch(url, {
+      method,
+      headers: {
+        Authorization: `Basic ${auth}`,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `Jira API ${method} ${path}: ${String(response.status)} ${response.statusText} - ${text}`
+      );
+    }
+    return response.json() as Promise<T>;
+  }
+
+  // ---------------------------------------------------------------------------
+  // ADF building and parsing
+  // ---------------------------------------------------------------------------
+
+  private buildAdfDocument(text: string): JiraAdfDocument {
+    if (!text) {
+      return { version: 1, type: 'doc', content: [{ type: 'paragraph', content: [] }] };
+    }
+
+    const paragraphs = text.split(/\n\n+/);
+    const content: JiraAdfNode[] = paragraphs.map(para => {
+      const lines = para.split('\n');
+      const inlineContent: JiraAdfNode[] = [];
+
+      for (let i = 0; i < lines.length; i++) {
+        if (i > 0) {
+          inlineContent.push({ type: 'hardBreak' });
+        }
+        inlineContent.push({ type: 'text', text: lines[i] });
+      }
+
+      return { type: 'paragraph', content: inlineContent };
+    });
+
+    return { version: 1, type: 'doc', content };
+  }
+
+  private extractTextFromAdf(node: JiraAdfNode): string {
+    if (node.type === 'text') return node.text ?? '';
+    if (node.type === 'hardBreak') return '\n';
+    if (node.type === 'mention') return '';
+    return (node.content ?? []).map(child => this.extractTextFromAdf(child)).join('');
+  }
+
+  private hasMention(node: JiraAdfNode, accountId: string): boolean {
+    if (node.type === 'mention' && node.attrs?.id === accountId) return true;
+    return (node.content ?? []).some(child => this.hasMention(child, accountId));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Comment history
+  // ---------------------------------------------------------------------------
+
+  private async fetchCommentHistory(issueKey: string): Promise<string[]> {
+    try {
+      const response = await this.jiraApi<JiraCommentListResponse>(
+        'GET',
+        `/issue/${issueKey}/comment?maxResults=20`
+      );
+      return response.comments.map(c => {
+        const author = c.author.displayName;
+        const body = this.extractTextFromAdf(c.body);
+        return `${author}: ${body}`;
+      });
+    } catch (error) {
+      getLog().error({ err: error, issueKey }, 'jira.comment_history_fetch_failed');
+      return [];
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Comment posting
+  // ---------------------------------------------------------------------------
+
+  private async postComment(issueKey: string, text: string): Promise<void> {
+    const adfDoc = this.buildAdfDocument(text);
+    await this.jiraApi('POST', `/issue/${issueKey}/comment`, { body: adfDoc });
+    getLog().debug({ issueKey }, 'jira.comment_posted');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Webhook handler
+  // ---------------------------------------------------------------------------
+
+  async handleWebhook(payload: string, secret: string): Promise<void> {
+    const log = getLog();
+
+    // 1. Verify secret
+    if (!verifyWebhookSecret(secret, this.webhookSecret)) {
+      log.error(
+        { secretPrefix: secret?.substring(0, 8) + '...', payloadSize: payload.length },
+        'jira.invalid_webhook_secret'
+      );
+      return;
+    }
+
+    // 2. Parse event
+    let event: JiraWebhookEvent;
+    try {
+      event = JSON.parse(payload) as JiraWebhookEvent;
+    } catch (error) {
+      log.error({ err: error, payloadSize: payload.length }, 'jira.webhook_parse_failed');
+      return;
+    }
+
+    // 3. Filter to comment_created only
+    if (event.webhookEvent !== 'comment_created') return;
+
+    const commentEvent = event as JiraCommentCreatedEvent;
+
+    // 4. Self-trigger guard
+    if (commentEvent.comment.author.accountId === this.botAccountId) {
+      log.debug({ authorAccountId: this.botAccountId }, 'jira.ignoring_own_comment');
+      return;
+    }
+
+    // 5. Authorization check
+    if (!isAccountIdAuthorized(commentEvent.comment.author.accountId, this.allowedAccountIds)) {
+      const maskedId = commentEvent.comment.author.accountId
+        ? `${commentEvent.comment.author.accountId.slice(0, 4)}***`
+        : 'unknown';
+      log.info({ maskedAccountId: maskedId }, 'jira.unauthorized_webhook');
+      return;
+    }
+
+    // 6. Check @mention in ADF
+    if (!this.hasMention(commentEvent.comment.body, this.botAccountId)) return;
+
+    const issueKey = commentEvent.issue.key;
+    log.info({ issueKey }, 'jira.webhook_processing');
+
+    // 7. Extract text and build context
+    const rawText = this.extractTextFromAdf(commentEvent.comment.body);
+
+    const issue = commentEvent.issue;
+    const priority = issue.fields.priority?.name ?? 'None';
+    const labels = issue.fields.labels.join(', ') || 'None';
+    const issueContext = `[Jira Issue Context]
+Issue ${issue.key}: "${issue.fields.summary}"
+Status: ${issue.fields.status.name}
+Priority: ${priority}
+Labels: ${labels}`;
+
+    // 8. Thread context
+    const commentHistory = await this.fetchCommentHistory(issueKey);
+    const threadContext = commentHistory.length > 0 ? commentHistory.join('\n') : undefined;
+
+    // 9. Dispatch
+    await this.lockManager.acquireLock(issueKey, async () => {
+      try {
+        await handleMessage(this, issueKey, rawText, {
+          issueContext,
+          threadContext,
+          isolationHints: { workflowType: 'thread', workflowId: issueKey } as IsolationHints,
+        });
+      } catch (error) {
+        const err = toError(error);
+        log.error({ err, issueKey }, 'jira.message_handling_error');
+        try {
+          await this.sendMessage(issueKey, classifyAndFormatError(err));
+        } catch (sendError) {
+          log.error({ err: toError(sendError), issueKey }, 'jira.error_message_send_failed');
+        }
+      }
+    });
+  }
+}

--- a/packages/adapters/src/community/task-management/jira/adapter.ts
+++ b/packages/adapters/src/community/task-management/jira/adapter.ts
@@ -167,7 +167,9 @@ export class JiraAdapter implements IPlatformAdapter {
         if (i > 0) {
           inlineContent.push({ type: 'hardBreak' });
         }
-        inlineContent.push({ type: 'text', text: lines[i] });
+        if (lines[i] !== '') {
+          inlineContent.push({ type: 'text', text: lines[i] });
+        }
       }
 
       return { type: 'paragraph', content: inlineContent };
@@ -229,7 +231,7 @@ export class JiraAdapter implements IPlatformAdapter {
     // 1. Verify secret
     if (!verifyWebhookSecret(secret, this.webhookSecret)) {
       log.error(
-        { secretPrefix: secret?.substring(0, 8) + '...', payloadSize: payload.length },
+        { secretPrefix: secret.substring(0, 8) + '...', payloadSize: payload.length },
         'jira.invalid_webhook_secret'
       );
       return;
@@ -266,6 +268,11 @@ export class JiraAdapter implements IPlatformAdapter {
 
     // 6. Check @mention in ADF
     if (!this.hasMention(commentEvent.comment.body, this.botAccountId)) return;
+
+    if (!commentEvent.issue?.key) {
+      log.warn({ webhookEvent: 'comment_created' }, 'jira.webhook_missing_issue_key');
+      return;
+    }
 
     const issueKey = commentEvent.issue.key;
     log.info({ issueKey }, 'jira.webhook_processing');

--- a/packages/adapters/src/community/task-management/jira/adapter.ts
+++ b/packages/adapters/src/community/task-management/jira/adapter.ts
@@ -51,9 +51,12 @@ export class JiraAdapter implements IPlatformAdapter {
     if (!apiToken) throw new Error('JiraAdapter requires a non-empty apiToken');
     if (!webhookSecret) throw new Error('JiraAdapter requires a non-empty webhookSecret');
 
-    this.baseUrl = baseUrl.replace(/\/+$/, '');
-    this.email = email;
-    this.apiToken = apiToken;
+    this.baseUrl = (baseUrl.startsWith('http') ? baseUrl : `https://${baseUrl}`).replace(
+      /\/+$/,
+      ''
+    );
+    this.email = email.trim();
+    this.apiToken = apiToken.trim();
     this.webhookSecret = webhookSecret;
     this.lockManager = lockManager;
     this.botMention = botMention || 'Archon';
@@ -182,7 +185,8 @@ export class JiraAdapter implements IPlatformAdapter {
     return { version: 1, type: 'doc', content };
   }
 
-  private extractTextFromAdf(node: JiraAdfNode): string {
+  private extractTextFromAdf(node: JiraAdfNode | string): string {
+    if (typeof node === 'string') return node.replaceAll(SELF_TRIGGER_MARKER, '');
     if (node.type === 'text') return (node.text ?? '').replaceAll(SELF_TRIGGER_MARKER, '');
     if (node.type === 'hardBreak') return '\n';
     if (node.type === 'mention') return '';
@@ -191,8 +195,9 @@ export class JiraAdapter implements IPlatformAdapter {
 
   // Detects whether the bot is mentioned in an ADF node tree by display name (case-insensitive).
   // Matches real Jira @mention nodes (attrs.text / attrs.displayName) and plain text "@name" patterns.
-  private hasMention(node: JiraAdfNode, botName: string): boolean {
+  private hasMention(node: JiraAdfNode | string, botName: string): boolean {
     const normalized = botName.toLowerCase();
+    if (typeof node === 'string') return node.toLowerCase().includes(`@${normalized}`);
     if (node.type === 'mention') {
       const attrText = ((node.attrs?.text as string | undefined) ?? '')
         .replace(/^@/, '')
@@ -300,11 +305,13 @@ export class JiraAdapter implements IPlatformAdapter {
     const rawText = this.extractTextFromAdf(commentEvent.comment.body);
 
     const issue = commentEvent.issue;
-    const priority = issue.fields.priority?.name ?? 'None';
-    const labels = issue.fields.labels.join(', ') || 'None';
+    const priority = issue.fields?.priority?.name ?? 'None';
+    const labels = (issue.fields?.labels ?? []).join(', ') || 'None';
+    const summary = issue.fields?.summary ?? '(no summary)';
+    const status = issue.fields?.status?.name ?? 'Unknown';
     const issueContext = `[Jira Issue Context]
-Issue ${issue.key}: "${issue.fields.summary}"
-Status: ${issue.fields.status.name}
+Issue ${issue.key}: "${summary}"
+Status: ${status}
 Priority: ${priority}
 Labels: ${labels}`;
 

--- a/packages/adapters/src/community/task-management/jira/auth.ts
+++ b/packages/adapters/src/community/task-management/jira/auth.ts
@@ -1,0 +1,26 @@
+import { timingSafeEqual } from 'crypto';
+
+export function parseAllowedAccountIds(envValue: string | undefined): string[] {
+  if (!envValue || envValue.trim() === '') return [];
+  return envValue
+    .split(',')
+    .map(id => id.trim())
+    .filter(id => id !== '');
+}
+
+export function isAccountIdAuthorized(
+  accountId: string | undefined,
+  allowedIds: string[]
+): boolean {
+  if (allowedIds.length === 0) return true;
+  if (!accountId || accountId.trim() === '') return false;
+  return allowedIds.includes(accountId);
+}
+
+export function verifyWebhookSecret(received: string, expected: string): boolean {
+  if (!received || !expected) return false;
+  const a = Buffer.from(received);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}

--- a/packages/adapters/src/community/task-management/jira/index.ts
+++ b/packages/adapters/src/community/task-management/jira/index.ts
@@ -1,0 +1,1 @@
+export { JiraAdapter } from './adapter';

--- a/packages/adapters/src/community/task-management/jira/types.ts
+++ b/packages/adapters/src/community/task-management/jira/types.ts
@@ -1,0 +1,73 @@
+// ADF node types
+
+export interface JiraAdfNode {
+  type: string;
+  text?: string;
+  attrs?: Record<string, unknown>;
+  content?: JiraAdfNode[];
+  marks?: { type: string; attrs?: Record<string, unknown> }[];
+}
+
+export interface JiraAdfDocument {
+  version: 1;
+  type: 'doc';
+  content: JiraAdfNode[];
+}
+
+// Author
+
+export interface JiraCommentAuthor {
+  accountId: string;
+  displayName: string;
+}
+
+// Comment (as it appears in webhook payload)
+
+export interface JiraComment {
+  id: string;
+  author: JiraCommentAuthor;
+  body: JiraAdfDocument;
+  created: string;
+  updated: string;
+}
+
+// Issue fields
+
+export interface JiraIssueFields {
+  summary: string;
+  description: JiraAdfDocument | null;
+  status: { name: string };
+  priority: { name: string } | null;
+  labels: string[];
+}
+
+// Issue
+
+export interface JiraIssue {
+  id: string;
+  key: string;
+  fields: JiraIssueFields;
+}
+
+// Webhook event (only comment_created is handled; other types are filtered in handleWebhook)
+
+export interface JiraCommentCreatedEvent {
+  webhookEvent: 'comment_created';
+  comment: JiraComment;
+  issue: JiraIssue;
+}
+
+export interface JiraUnknownEvent {
+  webhookEvent: string;
+}
+
+export type JiraWebhookEvent = JiraCommentCreatedEvent | JiraUnknownEvent;
+
+// API response shape for GET /comment
+
+export interface JiraCommentListResponse {
+  comments: {
+    author: JiraCommentAuthor;
+    body: JiraAdfDocument;
+  }[];
+}

--- a/packages/docs-web/src/content/docs/adapters/community/jira.md
+++ b/packages/docs-web/src/content/docs/adapters/community/jira.md
@@ -1,0 +1,134 @@
+---
+title: Jira
+description: Talk to Archon inside Jira issues — @mention the bot in a comment and it replies on the ticket.
+category: adapters
+area: adapters
+audience: [operator]
+sidebar:
+  order: 8
+---
+
+:::note
+Jira is a **community adapter** in the `task-management` category — contributed and maintained by the community.
+:::
+
+Connect Archon to Jira Cloud so each issue becomes a live conversation: `@mention` the bot in a comment, and Archon runs through the orchestrator and replies back as a comment on the same ticket. Many tickets means many parallel conversations, the same way Slack threads work.
+
+This adapter is a **conversation point, not an end-to-end auto-resolver.** It routes a comment into Archon and posts the reply back. Actually resolving a ticket (explore → implement → open a PR → transition the issue) is a *workflow* concern, not the adapter's job — Jira hosts no code, so the adapter never clones a repo or manages a worktree.
+
+## Prerequisites
+
+- Archon server running (see [Getting Started](/getting-started/overview/))
+- A Jira Cloud site where you can create issues and register a webhook
+- An Atlassian API token (created against the account the bot posts as)
+- A public endpoint for webhooks (see the ngrok step below for local development)
+
+## Step 1: Create an Atlassian API Token
+
+1. Go to **[id.atlassian.com → Security → API tokens](https://id.atlassian.com/manage-profile/security/api-tokens)**
+2. **Create API token**, give it a label (e.g. `archon`), and copy it (starts with `ATAT…`)
+3. Note the **email address** of that Atlassian account — Archon authenticates as `email:api_token` (HTTP Basic auth)
+
+:::caution
+The token must belong to an account that can view and comment on the target project. An invalid email/token returns `401 Unauthorized` (or a `404` on the issue) — see Troubleshooting.
+:::
+
+## Step 2: Generate a Webhook Secret
+
+```bash
+openssl rand -hex 32
+```
+
+Windows (PowerShell):
+
+```powershell
+-join ((1..32) | ForEach-Object { '{0:x2}' -f (Get-Random -Maximum 256) })
+```
+
+Save this — you'll use it in Steps 4 and 5.
+
+## Step 3: Expose Your Local Server (Development Only)
+
+```bash
+ngrok http 3090
+# Copy the HTTPS URL (e.g., https://abc123.ngrok-free.app)
+```
+
+For production, use your deployed server URL directly.
+
+## Step 4: Configure the Jira Webhook
+
+In Jira, go to **Settings → System → WebHooks → Create a WebHook**:
+
+| Field | Value |
+|-------|-------|
+| **URL** | `https://your-domain.com/webhooks/jira?secret=YOUR_SECRET` |
+| **Events** | Enable **Comment → created** |
+
+:::note
+Jira does **not** HMAC-sign webhook bodies the way GitHub does. Authentication is the shared secret passed in the URL as `?secret=…`, which must match `JIRA_WEBHOOK_SECRET` exactly. Make sure the `?secret=` query string survives any URL editing.
+:::
+
+## Step 5: Set Environment Variables
+
+```ini
+JIRA_DOMAIN=yourorg.atlassian.net
+JIRA_EMAIL=you@example.com
+JIRA_API_TOKEN=ATATT-your-token-here
+JIRA_WEBHOOK_SECRET=your-secret-here
+```
+
+Optional:
+
+```ini
+# Display name to match in @mentions; case-insensitive (default: Archon)
+JIRA_BOT_MENTION=Archon
+# Comma-separated Jira accountIds; when set, only these users can trigger the bot
+JIRA_ALLOWED_ACCOUNT_IDS=
+```
+
+`JIRA_DOMAIN` accepts a bare domain (`yourorg.atlassian.net`) or a full URL (`https://yourorg.atlassian.net`). The adapter starts automatically once `JIRA_DOMAIN`, `JIRA_EMAIL`, `JIRA_API_TOKEN`, and `JIRA_WEBHOOK_SECRET` are set.
+
+## Usage
+
+Mention the bot in any issue comment:
+
+```
+@Archon what's the simplest fix for this ticket?
+@Archon /status
+@Archon summarize the discussion so far
+```
+
+The mention is matched by **display name**, case-insensitive (`@Archon`, `@archon`) — there is no bot Atlassian account to set up. Archon replies as a comment on the same issue, using the account from `JIRA_EMAIL`.
+
+## Conversation ID Format
+
+| Type | Format | Example |
+|------|--------|---------|
+| Issue | `ISSUE-KEY` | `DFE-7` |
+
+Each issue key is its own conversation, so replies stay scoped to the ticket and multiple tickets run in parallel.
+
+## Supported Events
+
+| Jira Event | Action |
+|-----------|--------|
+| **Comment created** (with @mention of the bot) | Triggers an Archon conversation |
+| Comment created (no mention) | Ignored |
+| The bot's own comments | Ignored via an invisible self-trigger marker (no loops) |
+
+## Troubleshooting
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| `jira.invalid_webhook_secret` | `?secret=` missing or mismatched | Ensure the webhook URL ends with `?secret=` and the value matches `JIRA_WEBHOOK_SECRET` exactly |
+| `404 Not Found` from ngrok | Wrong path | The route is `/webhooks/jira` (two o's) |
+| `401 Unauthorized` / `404 ... do not have permission` on reply | Bad `JIRA_EMAIL` / `JIRA_API_TOKEN` | Verify the email matches the token's account and the token is current; regenerate if unsure |
+| No reply, webhook returns `200` | Mention not detected | The comment must contain `@<JIRA_BOT_MENTION>` (default `@Archon`), case-insensitive |
+| No webhook delivery | ngrok URL changed | Update the webhook URL after restarting ngrok |
+
+## Notes
+
+- The adapter reads the comment from the webhook payload (Jira delivers the body as text) and posts replies in Atlassian Document Format (ADF) via `POST /rest/api/3/issue/{key}/comment`.
+- Long replies are split into multiple comments.
+- No repository is cloned and no isolation environment is created — this is a conversation adapter, not a forge.

--- a/packages/docs-web/src/content/docs/adapters/index.md
+++ b/packages/docs-web/src/content/docs/adapters/index.md
@@ -30,6 +30,7 @@ Community adapters follow the same `IPlatformAdapter` interface but target platf
 | [**Discord**](/adapters/community/discord/) | WebSocket | Bot token | [Setup guide](/adapters/community/discord/) |
 | [**Gitea**](/adapters/community/gitea/) | Webhooks | Token + webhook secret | [Setup guide](/adapters/community/gitea/) |
 | [**GitLab**](/adapters/community/gitlab/) | Webhooks | Token + webhook secret | [Setup guide](/adapters/community/gitlab/) |
+| [**Jira**](/adapters/community/jira/) | Webhooks | Email + API token + webhook secret | [Setup guide](/adapters/community/jira/) |
 
 ## How Adapters Work
 
@@ -46,5 +47,6 @@ All adapters implement the `IPlatformAdapter` interface. They handle:
 - **Slack** and **Telegram** are ideal for mobile access and team collaboration.
 - **GitHub** integrates directly into your issue and PR workflow.
 - **Discord** works well for community or team servers.
+- **Jira** turns each issue into a conversation — @mention the bot in a comment to work the ticket with Archon.
 
 You can run multiple adapters simultaneously. Any adapter with the required environment variables set will start automatically when you launch the server.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -279,8 +279,7 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
       process.env.JIRA_BASE_URL &&
       process.env.JIRA_EMAIL &&
       process.env.JIRA_API_TOKEN &&
-      process.env.JIRA_WEBHOOK_SECRET &&
-      process.env.JIRA_BOT_MENTION
+      process.env.JIRA_WEBHOOK_SECRET
     );
 
     if (!hasTelegram && !hasDiscord && !hasGitHub && !hasGitea && !hasGitLab && !hasJira) {
@@ -342,16 +341,16 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
       process.env.JIRA_BASE_URL &&
       process.env.JIRA_EMAIL &&
       process.env.JIRA_API_TOKEN &&
-      process.env.JIRA_WEBHOOK_SECRET &&
-      process.env.JIRA_BOT_MENTION
+      process.env.JIRA_WEBHOOK_SECRET
     ) {
+      const jiraBotMention = process.env.JIRA_BOT_MENTION || 'Archon';
       jira = new JiraAdapter(
         process.env.JIRA_BASE_URL,
         process.env.JIRA_EMAIL,
         process.env.JIRA_API_TOKEN,
         process.env.JIRA_WEBHOOK_SECRET,
         lockManager,
-        process.env.JIRA_BOT_MENTION
+        jiraBotMention
       );
       await jira.start();
       activePlatforms.push('Jira');

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -58,6 +58,7 @@ import { validationErrorHook } from './routes/openapi-defaults';
 import { TelegramAdapter, GitHubAdapter, DiscordAdapter, SlackAdapter } from '@archon/adapters';
 import { GiteaAdapter } from '@archon/adapters/community/forge/gitea';
 import { GitLabAdapter } from '@archon/adapters/community/forge/gitlab';
+import { JiraAdapter } from '@archon/adapters/community/task-management/jira';
 import { WebAdapter } from './adapters/web';
 import { MessagePersistence } from './adapters/web/persistence';
 import { SSETransport } from './adapters/web/transport';
@@ -261,6 +262,7 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
   let github: GitHubAdapter | null = null;
   let gitea: GiteaAdapter | null = null;
   let gitlab: GitLabAdapter | null = null;
+  let jira: JiraAdapter | null = null;
   let discord: DiscordAdapter | null = null;
   let slack: SlackAdapter | null = null;
 
@@ -273,8 +275,15 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
       process.env.GITEA_URL && process.env.GITEA_TOKEN && process.env.GITEA_WEBHOOK_SECRET
     );
     const hasGitLab = Boolean(process.env.GITLAB_TOKEN && process.env.GITLAB_WEBHOOK_SECRET);
+    const hasJira = Boolean(
+      process.env.JIRA_BASE_URL &&
+      process.env.JIRA_EMAIL &&
+      process.env.JIRA_API_TOKEN &&
+      process.env.JIRA_WEBHOOK_SECRET &&
+      process.env.JIRA_BOT_MENTION
+    );
 
-    if (!hasTelegram && !hasDiscord && !hasGitHub && !hasGitea && !hasGitLab) {
+    if (!hasTelegram && !hasDiscord && !hasGitHub && !hasGitea && !hasGitLab && !hasJira) {
       getLog().warn('no_platform_adapters_configured');
     }
 
@@ -326,6 +335,28 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
       activePlatforms.push('GitLab');
     } else {
       getLog().info('gitlab_adapter_skipped');
+    }
+
+    // Initialize Jira adapter (conditional)
+    if (
+      process.env.JIRA_BASE_URL &&
+      process.env.JIRA_EMAIL &&
+      process.env.JIRA_API_TOKEN &&
+      process.env.JIRA_WEBHOOK_SECRET &&
+      process.env.JIRA_BOT_MENTION
+    ) {
+      jira = new JiraAdapter(
+        process.env.JIRA_BASE_URL,
+        process.env.JIRA_EMAIL,
+        process.env.JIRA_API_TOKEN,
+        process.env.JIRA_WEBHOOK_SECRET,
+        lockManager,
+        process.env.JIRA_BOT_MENTION
+      );
+      await jira.start();
+      activePlatforms.push('Jira');
+    } else {
+      getLog().info('jira_adapter_skipped');
     }
 
     // Initialize Discord adapter (conditional)
@@ -562,6 +593,24 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
       }
     });
     getLog().info('gitlab_webhook_registered');
+  }
+
+  // Jira webhook endpoint
+  if (jira) {
+    app.post('/webhooks/jira', async c => {
+      try {
+        const secret = c.req.query('secret') ?? '';
+        const payload = await c.req.text();
+        jira.handleWebhook(payload, secret).catch((error: unknown) => {
+          getLog().error({ err: error }, 'jira.webhook_processing_error');
+        });
+        return c.text('OK', 200);
+      } catch (error) {
+        getLog().error({ err: error }, 'jira.webhook_endpoint_error');
+        return c.json({ error: 'Internal server error' }, 500);
+      }
+    });
+    getLog().info('jira_webhook_registered');
   }
 
   // Health check endpoints

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -276,7 +276,7 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
     );
     const hasGitLab = Boolean(process.env.GITLAB_TOKEN && process.env.GITLAB_WEBHOOK_SECRET);
     const hasJira = Boolean(
-      process.env.JIRA_BASE_URL &&
+      process.env.JIRA_DOMAIN &&
       process.env.JIRA_EMAIL &&
       process.env.JIRA_API_TOKEN &&
       process.env.JIRA_WEBHOOK_SECRET
@@ -338,14 +338,14 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
 
     // Initialize Jira adapter (conditional)
     if (
-      process.env.JIRA_BASE_URL &&
+      process.env.JIRA_DOMAIN &&
       process.env.JIRA_EMAIL &&
       process.env.JIRA_API_TOKEN &&
       process.env.JIRA_WEBHOOK_SECRET
     ) {
       const jiraBotMention = process.env.JIRA_BOT_MENTION || 'Archon';
       jira = new JiraAdapter(
-        process.env.JIRA_BASE_URL,
+        process.env.JIRA_DOMAIN,
         process.env.JIRA_EMAIL,
         process.env.JIRA_API_TOKEN,
         process.env.JIRA_WEBHOOK_SECRET,

--- a/packages/web/src/routes/SettingsPage.tsx
+++ b/packages/web/src/routes/SettingsPage.tsx
@@ -620,6 +620,7 @@ function PlatformConnectionsSection({
     { name: 'GitHub', connected: active.has('GitHub') },
     { name: 'Gitea', connected: active.has('Gitea') },
     { name: 'GitLab', connected: active.has('GitLab') },
+    { name: 'Jira', connected: active.has('Jira') },
   ];
 
   return (


### PR DESCRIPTION
## Summary

Adds a **Jira adapter** in a new **`task-management`** adapter category (sibling to `chat/` and `forge/`), so each Jira issue becomes a live Archon conversation: `@mention` the bot in a comment, it runs through the orchestrator and replies back as a comment on the same ticket. Many tickets = many parallel conversations, the same way Slack threads work.

This is a **conversation point, not an end-to-end auto-resolver** — the adapter only routes the conversation (webhook in → `handleMessage` → comment back). Actually resolving a ticket (explore → implement → PR → transition) stays a *workflow* concern, with a future `jira` skill for status transitions.

Closes #1750.

## What it adds

- `packages/adapters/src/community/task-management/jira/` — `adapter.ts` (`JiraAdapter`), `auth.ts`, `types.ts`, `index.ts`, `adapter.test.ts`
- `community/task-management/README.md` — category conventions
- `/webhooks/jira` route + env-gated init in `packages/server/src/index.ts`
- Export from `packages/adapters/src/index.ts`; example env-template entry

## Key design decisions

- **New `task-management` category** — Jira is a work tracker, not a chat platform or a code forge. It borrows chat-style conversation semantics (conversation = issue key; no repo/clone/worktree) and forge-style webhook transport.
- **Bot identity is a display-name string** (`JIRA_BOT_MENTION`, optional, defaults to `Archon`, case-insensitive) — **no Jira accountId required**. Mention detection matches a real ADF mention node *or* plain `@name` text.
- **Self-trigger guard** appends an invisible zero-width marker to the bot's own comments (the bot posts via the same account it reads from, so an author-based guard can't work).
- **Auth:** Basic auth (email + API token); the webhook is verified by a shared secret passed as `?secret=` (Jira doesn't HMAC-sign its webhooks).
- Optional allowlist for which users may trigger the bot.

## Validated live (end-to-end)

Tested against a real Jira site + ticket: an `@Archon` comment → webhook → mention detected → orchestrator reply posted back to the ticket; a follow-up message worked too; no self-trigger loop. The live run surfaced and fixed several real payload-shape issues:

- Site is read from **`JIRA_DOMAIN`** (accepts a bare domain or a full URL).
- Jira's comment webhook delivers the **comment body as a plain string, not ADF** — handled in both `hasMention` and `extractTextFromAdf`.
- The webhook's **`issue.fields` is partial** — issue-context building is now defensive.
- Account email + credential are trimmed to avoid whitespace-related Basic-auth failures.

## Test plan

- [x] `type-check` (all packages), `lint --max-warnings 0`, `format:check` clean
- [x] Adapter unit tests pass
- [x] Manual end-to-end against a live Jira ticket (mention → reply round-trip)
- [ ] Reviewer: confirm the new `task-management` category placement + README
- [ ] Follow-up: companion `jira` workflow skill (status transitions) + docs-web page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
