### PR TITLE
fix(web): bound tool_result output size to prevent chat UI crash on large payloads

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "bun --watch src/index.ts",
     "start": "bun src/index.ts",
-    "test": "bun test src/routes/api.workflows.test.ts && bun test src/routes/api.conversations.test.ts && bun test src/routes/api.codebases.test.ts && bun test src/routes/api.messages.test.ts && bun test src/routes/api.health.test.ts && bun test src/routes/api.workflow-runs.test.ts && bun test src/routes/api.providers.test.ts && bun test src/adapters/web/transport.test.ts && bun test src/adapters/web/persistence.test.ts",
+    "test": "bun test src/routes/api.workflows.test.ts && bun test src/routes/api.conversations.test.ts && bun test src/routes/api.codebases.test.ts && bun test src/routes/api.messages.test.ts && bun test src/routes/api.health.test.ts && bun test src/routes/api.workflow-runs.test.ts && bun test src/routes/api.providers.test.ts && bun test src/adapters/web/transport.test.ts && bun test src/adapters/web/persistence.test.ts && bun test src/adapters/web/truncate.test.ts && bun test src/adapters/web.test.ts",
     "type-check": "bun x tsc --noEmit",
     "setup-auth": "bun src/scripts/setup-auth.ts"
   },

--- a/packages/server/src/adapters/web.test.ts
+++ b/packages/server/src/adapters/web.test.ts
@@ -1,0 +1,127 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+// Mock logger before importing any module that transitively imports @archon/paths
+const mockLogger = {
+  fatal: mock(() => undefined),
+  error: mock(() => undefined),
+  warn: mock(() => undefined),
+  info: mock(() => undefined),
+  debug: mock(() => undefined),
+  trace: mock(() => undefined),
+  child: mock(function (this: unknown) {
+    return this;
+  }),
+  bindings: mock(() => ({ module: 'test' })),
+  isLevelEnabled: mock(() => true),
+  level: 'info' as const,
+};
+
+mock.module('@archon/paths', () => ({
+  createLogger: mock(() => mockLogger),
+}));
+
+import { WebAdapter } from './web';
+import { MAX_TOOL_OUTPUT_CHARS } from './web/truncate';
+import type { SSETransport } from './web/transport';
+import type { MessagePersistence } from './web/persistence';
+import type { WorkflowEventBridge } from './web/workflow-bridge';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAdapter(): {
+  adapter: WebAdapter;
+  emitted: string[];
+  appendToolResultCalls: unknown[][];
+} {
+  const emitted: string[] = [];
+  const appendToolResultCalls: unknown[][] = [];
+
+  const mockTransport = {
+    emit: mock(async (_id: string, event: string) => {
+      emitted.push(event);
+    }),
+  } as unknown as SSETransport;
+
+  const mockPersistence = {
+    appendToolResult: mock((_id: string, name: string, output: string, duration: number) => {
+      appendToolResultCalls.push([_id, name, output, duration]);
+    }),
+    appendToolCall: mock(() => {}),
+    appendText: mock(() => {}),
+    flush: mock(async () => {}),
+    finalizeRunningTools: mock(() => {}),
+  } as unknown as MessagePersistence;
+
+  const mockBridge = {
+    emitOutput: mock(() => {}),
+    registerOutputCallback: mock(() => {}),
+    removeOutputCallback: mock(() => {}),
+    setStepTransitionCallback: mock(() => {}),
+    start: mock(() => {}),
+    stop: mock(() => {}),
+    bridgeWorkerEvents: mock(() => () => {}),
+  } as unknown as WorkflowEventBridge;
+
+  const adapter = new WebAdapter(mockTransport, mockPersistence, mockBridge);
+  return { adapter, emitted, appendToolResultCalls };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockLogger.warn.mockClear();
+  mockLogger.error.mockClear();
+});
+
+describe('WebAdapter.sendStructuredEvent — tool_result output bounding', () => {
+  test('truncates SSE event output when toolOutput exceeds the cap', async () => {
+    const { adapter, emitted } = makeAdapter();
+    const largeOutput = 'x'.repeat(MAX_TOOL_OUTPUT_CHARS + 50_000);
+
+    await adapter.sendStructuredEvent('conv-1', {
+      type: 'tool_result',
+      toolName: 'bash',
+      toolOutput: largeOutput,
+    });
+
+    expect(emitted.length).toBe(1);
+    const parsed = JSON.parse(emitted[0]!) as { output: string };
+    expect(parsed.output.length).toBeLessThan(largeOutput.length);
+    expect(parsed.output).toContain('[truncated');
+    expect(parsed.output).toContain('full output preserved in run history');
+  });
+
+  test('passes SSE event output through unchanged when within the cap', async () => {
+    const { adapter, emitted } = makeAdapter();
+    const smallOutput = 'small tool output';
+
+    await adapter.sendStructuredEvent('conv-1', {
+      type: 'tool_result',
+      toolName: 'bash',
+      toolOutput: smallOutput,
+    });
+
+    expect(emitted.length).toBe(1);
+    const parsed = JSON.parse(emitted[0]!) as { output: string };
+    expect(parsed.output).toBe(smallOutput);
+  });
+
+  test('persists full untruncated output to DB regardless of the SSE cap', async () => {
+    const { adapter, appendToolResultCalls } = makeAdapter();
+    const largeOutput = 'z'.repeat(MAX_TOOL_OUTPUT_CHARS + 50_000);
+
+    await adapter.sendStructuredEvent('conv-1', {
+      type: 'tool_result',
+      toolName: 'bash',
+      toolOutput: largeOutput,
+    });
+
+    expect(appendToolResultCalls.length).toBe(1);
+    // Third argument to appendToolResult is the output — must be the full string
+    expect(appendToolResultCalls[0]![2]).toBe(largeOutput);
+  });
+});

--- a/packages/server/src/adapters/web.ts
+++ b/packages/server/src/adapters/web.ts
@@ -8,6 +8,7 @@ import { createLogger } from '@archon/paths';
 import { MessagePersistence } from './web/persistence';
 import { SSETransport, type SSEWriter } from './web/transport';
 import { WorkflowEventBridge } from './web/workflow-bridge';
+import { truncateToolOutput } from './web/truncate';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
@@ -192,7 +193,7 @@ export class WebAdapter implements IWebPlatformAdapter {
         type: 'tool_result',
         toolCallId: matchedToolCallId,
         name: chunk.toolName,
-        output: chunk.toolOutput,
+        output: truncateToolOutput(chunk.toolOutput),
         duration,
         timestamp: now,
       });

--- a/packages/server/src/adapters/web/truncate.test.ts
+++ b/packages/server/src/adapters/web/truncate.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect } from 'bun:test';
+import { truncateToolOutput, MAX_TOOL_OUTPUT_CHARS } from './truncate';
+
+describe('truncateToolOutput', () => {
+  test('returns empty string unchanged', () => {
+    expect(truncateToolOutput('')).toBe('');
+  });
+
+  test('returns output at exactly the cap unchanged', () => {
+    const atCap = 'a'.repeat(MAX_TOOL_OUTPUT_CHARS);
+    expect(truncateToolOutput(atCap)).toBe(atCap);
+  });
+
+  test('truncates output one byte over the cap', () => {
+    const overCap = 'x'.repeat(MAX_TOOL_OUTPUT_CHARS + 1);
+    const result = truncateToolOutput(overCap);
+    expect(result.startsWith('x'.repeat(MAX_TOOL_OUTPUT_CHARS))).toBe(true);
+    expect(result).toContain('[truncated');
+    expect(result).toContain('full output preserved in run history');
+  });
+
+  test('truncates large output and embeds KB sizes in the marker', () => {
+    const large = 'y'.repeat(MAX_TOOL_OUTPUT_CHARS + 200_000);
+    const result = truncateToolOutput(large);
+    expect(result.length).toBeLessThan(large.length);
+    expect(result.startsWith('y'.repeat(MAX_TOOL_OUTPUT_CHARS))).toBe(true);
+    // Marker must contain KB numbers so users know how much was cut
+    expect(result).toMatch(/\d+ KB of \d+ KB total/);
+    expect(result).toContain('full output preserved in run history');
+  });
+
+  test('does not modify output shorter than the cap', () => {
+    const short = 'hello world\nline two';
+    expect(truncateToolOutput(short)).toBe(short);
+  });
+});

--- a/packages/server/src/adapters/web/truncate.ts
+++ b/packages/server/src/adapters/web/truncate.ts
@@ -43,12 +43,16 @@ export function boundMetadataToolOutputs(metaJson: string): string {
   ) {
     return metaJson;
   }
-  const meta = parsed as { toolCalls: Record<string, unknown>[] };
+  const meta = parsed as { toolCalls: unknown[] } & Record<string, unknown>;
   const bounded = {
     ...meta,
-    toolCalls: meta.toolCalls.map(tc =>
-      typeof tc.output === 'string' ? { ...tc, output: truncateToolOutput(tc.output) } : tc
-    ),
+    toolCalls: meta.toolCalls.map(tc => {
+      if (!tc || typeof tc !== 'object') return tc;
+      const toolCall = tc as Record<string, unknown>;
+      return typeof toolCall.output === 'string'
+        ? { ...toolCall, output: truncateToolOutput(toolCall.output) }
+        : toolCall;
+    }),
   };
   return JSON.stringify(bounded);
 }

--- a/packages/server/src/adapters/web/truncate.ts
+++ b/packages/server/src/adapters/web/truncate.ts
@@ -1,0 +1,54 @@
+/** Maximum characters of tool output sent across the SSE boundary to the browser. */
+export const MAX_TOOL_OUTPUT_CHARS = 100_000;
+
+/**
+ * Bound tool output to MAX_TOOL_OUTPUT_CHARS for browser transport.
+ * Returns the string unchanged if within the cap.
+ * Appends a human-readable marker so users know truncation occurred and that the
+ * full output is still available in run history (i.e. in the database).
+ *
+ * Apply at SSE emit time and at message-history hydration time.
+ * Do NOT apply before writing to the database — the DB is the authoritative record.
+ */
+export function truncateToolOutput(output: string): string {
+  if (output.length <= MAX_TOOL_OUTPUT_CHARS) return output;
+  const totalKB = Math.round(output.length / 1024);
+  const truncatedKB = Math.round((output.length - MAX_TOOL_OUTPUT_CHARS) / 1024);
+  return (
+    output.slice(0, MAX_TOOL_OUTPUT_CHARS) +
+    `\n\n... [truncated ${String(truncatedKB)} KB of ${String(totalKB)} KB total; full output preserved in run history]`
+  );
+}
+
+/**
+ * Parse message metadata JSON, apply truncateToolOutput to every toolCall output,
+ * and return the re-serialized JSON string.
+ *
+ * Safe to call on any metadata string — passes through unchanged when:
+ * - the string is not valid JSON
+ * - the parsed value has no toolCalls array
+ * - all tool outputs are within the cap
+ */
+export function boundMetadataToolOutputs(metaJson: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(metaJson);
+  } catch {
+    return metaJson;
+  }
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    !Array.isArray((parsed as Record<string, unknown>).toolCalls)
+  ) {
+    return metaJson;
+  }
+  const meta = parsed as { toolCalls: Record<string, unknown>[] };
+  const bounded = {
+    ...meta,
+    toolCalls: meta.toolCalls.map(tc =>
+      typeof tc.output === 'string' ? { ...tc, output: truncateToolOutput(tc.output) } : tc
+    ),
+  };
+  return JSON.stringify(bounded);
+}

--- a/packages/server/src/routes/api.messages.test.ts
+++ b/packages/server/src/routes/api.messages.test.ts
@@ -439,6 +439,111 @@ describe('GET /api/conversations/:id/messages', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tests: GET /api/conversations/:id/messages — tool output bounding
+// ---------------------------------------------------------------------------
+
+const MAX_TOOL_OUTPUT_CHARS = 100_000;
+
+describe('GET /api/conversations/:id/messages — tool output bounding', () => {
+  beforeEach(() => {
+    mockFindConversationByPlatformId.mockReset();
+    mockListMessages.mockReset();
+  });
+
+  test('truncates large tool output in hydration metadata without touching the DB value', async () => {
+    const largeOutput = 'y'.repeat(MAX_TOOL_OUTPUT_CHARS + 10_000);
+    const storedMetadata = JSON.stringify({
+      toolCalls: [
+        {
+          name: 'bash',
+          input: { command: 'cat file.txt' },
+          output: largeOutput,
+          duration: 500,
+        },
+      ],
+    });
+
+    mockFindConversationByPlatformId.mockImplementationOnce(async () => MOCK_CONV);
+    mockListMessages.mockImplementationOnce(async () => [
+      {
+        id: 'msg-tool',
+        conversation_id: MOCK_CONV.id,
+        role: 'assistant' as const,
+        content: '',
+        metadata: storedMetadata,
+        created_at: new Date().toISOString(),
+      },
+    ]);
+
+    const { app } = makeApp();
+    const response = await app.request('/api/conversations/web-test-abc/messages');
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as Array<{ metadata: string }>;
+    const returnedMeta = JSON.parse(body[0]!.metadata) as {
+      toolCalls: Array<{ output: string }>;
+    };
+
+    // Returned tool output must be bounded
+    expect(returnedMeta.toolCalls[0]!.output.length).toBeLessThan(largeOutput.length);
+    expect(returnedMeta.toolCalls[0]!.output).toContain('[truncated');
+    expect(returnedMeta.toolCalls[0]!.output).toContain('full output preserved in run history');
+
+    // listMessages was called once (verifies the DB mock, not this endpoint, holds the full value)
+    expect(mockListMessages).toHaveBeenCalledTimes(1);
+  });
+
+  test('preserves tool output within the cap in hydration', async () => {
+    const smallOutput = 'short output from tool';
+    const metadata = JSON.stringify({
+      toolCalls: [{ name: 'bash', input: {}, output: smallOutput, duration: 10 }],
+    });
+
+    mockFindConversationByPlatformId.mockImplementationOnce(async () => MOCK_CONV);
+    mockListMessages.mockImplementationOnce(async () => [
+      {
+        id: 'msg-small',
+        conversation_id: MOCK_CONV.id,
+        role: 'assistant' as const,
+        content: '',
+        metadata,
+        created_at: new Date().toISOString(),
+      },
+    ]);
+
+    const { app } = makeApp();
+    const response = await app.request('/api/conversations/web-test-abc/messages');
+    const body = (await response.json()) as Array<{ metadata: string }>;
+    const returnedMeta = JSON.parse(body[0]!.metadata) as {
+      toolCalls: Array<{ output: string }>;
+    };
+
+    expect(returnedMeta.toolCalls[0]!.output).toBe(smallOutput);
+  });
+
+  test('returns messages without toolCalls unchanged', async () => {
+    const metadata = JSON.stringify({ workflowResult: { runId: 'abc' } });
+
+    mockFindConversationByPlatformId.mockImplementationOnce(async () => MOCK_CONV);
+    mockListMessages.mockImplementationOnce(async () => [
+      {
+        id: 'msg-no-tools',
+        conversation_id: MOCK_CONV.id,
+        role: 'assistant' as const,
+        content: 'Done.',
+        metadata,
+        created_at: new Date().toISOString(),
+      },
+    ]);
+
+    const { app } = makeApp();
+    const response = await app.request('/api/conversations/web-test-abc/messages');
+    const body = (await response.json()) as Array<{ metadata: string }>;
+    expect(body[0]!.metadata).toBe(metadata);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tests: PATCH /api/conversations/:id
 // ---------------------------------------------------------------------------
 

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -123,6 +123,7 @@ import {
 } from './schemas/config.schemas';
 import { providerListResponseSchema } from './schemas/provider.schemas';
 import { getProviderInfoList, isRegisteredProvider } from '@archon/providers';
+import { boundMetadataToolOutputs } from '../adapters/web/truncate';
 
 // Read app version: use build-time constant in binary, package.json in dev
 let appVersion = 'unknown';
@@ -1278,11 +1279,12 @@ export function registerApiRoutes(
       const messages = await messageDb.listMessages(conv.id, limit);
       // Normalize metadata: PostgreSQL JSONB auto-deserializes to object,
       // but frontend expects JSON string. SQLite returns string already.
+      // Also bound any tool output in metadata so large payloads don't crash the browser tab.
       return c.json(
-        messages.map(m => ({
-          ...m,
-          metadata: typeof m.metadata === 'string' ? m.metadata : JSON.stringify(m.metadata),
-        }))
+        messages.map(m => {
+          const metaStr = typeof m.metadata === 'string' ? m.metadata : JSON.stringify(m.metadata);
+          return { ...m, metadata: boundMetadataToolOutputs(metaStr) };
+        })
       );
     } catch (error) {
       getLog().error({ err: error }, 'list_messages_failed');

--- a/packages/web/src/components/chat/ToolCallCard.tsx
+++ b/packages/web/src/components/chat/ToolCallCard.tsx
@@ -30,10 +30,19 @@ export function ToolCallCard({ tool }: ToolCallCardProps): React.ReactElement {
   const summaryText =
     typeof summary === 'string' ? summary.slice(0, 60) + (summary.length > 60 ? '...' : '') : '';
 
-  // Limit output display
-  const outputLines = tool.output?.split('\n') ?? [];
+  // Limit output display — apply a hard char cap before splitting so a single-line
+  // multi-MB blob doesn't bypass the 20-line limit and crash the browser tab.
+  // The server already truncates at 100 KB; this is defense-in-depth.
+  const MAX_DISPLAY_CHARS = 50_000;
+  const rawOutput = tool.output ?? '';
+  const cappedOutput =
+    rawOutput.length > MAX_DISPLAY_CHARS
+      ? rawOutput.slice(0, MAX_DISPLAY_CHARS) +
+        '\n... [display capped — open run history for full output]'
+      : rawOutput;
+  const outputLines = cappedOutput.split('\n');
   const isLongOutput = outputLines.length > 20;
-  const displayOutput = showAllOutput ? tool.output : outputLines.slice(0, 20).join('\n');
+  const displayOutput = showAllOutput ? cappedOutput : outputLines.slice(0, 20).join('\n');
 
   return (
     <div


### PR DESCRIPTION
## Summary

- **Symptom**: Chat tab spins then crashes when an agent or workflow step emits a large tool result (megabyte-scale: full file dump, large diff, minified bundle). The browser's layout engine OOMs rendering a multi-MB string in a single `<pre>`.
- **Root cause**: `chunk.toolOutput` in `packages/server/src/adapters/web.ts` (`sendStructuredEvent`, `tool_result` branch, ~line 191) was JSON-stringified into the SSE event at full size. That same string flowed unbounded into the SSE wire event, the `eventBuffer` in `transport.ts`, the React store, and `ToolCallCard.tsx`'s `<pre>`. Tool output was the one cross-boundary value left unbounded — the codebase bounds uploads (10 MB), titles (255 chars), etc., but never tool output.
- **Second path**: The page-reload / SSE-recovery hydration path (`GET /api/conversations/:id/messages` in `packages/server/src/routes/api.ts`, ~line 1282) serialized the full stored metadata (including full tool output) back to the browser, so the crash reappeared on reload even if the live SSE path were fixed.

## Fix

Follows the **preserve-don't-drop** pattern established in [#1718](https://github.com/coleam00/Archon/pull/1718) (large bash node output offloaded rather than corrupted). Full output is kept in the database; truncation is a read/transport-time concern applied at boundaries only.

1. **`packages/server/src/adapters/web/truncate.ts`** (new): shared `truncateToolOutput(output)` helper with `MAX_TOOL_OUTPUT_CHARS = 100_000` cap, plus `boundMetadataToolOutputs(metaJson)` for the hydration path. Truncated strings include a human-readable marker: `... [truncated N KB of M KB total; full output preserved in run history]`.

2. **`packages/server/src/adapters/web.ts`** (SSE emit path): applies `truncateToolOutput()` to `output` in the `tool_result` SSE event. The `persistence.appendToolResult()` call immediately above is **not** touched — DB gets the full value.

3. **`packages/server/src/routes/api.ts`** (hydration path): applies `boundMetadataToolOutputs()` when serializing message metadata for `GET /api/conversations/:id/messages`. Critical — without this the bug reappears on page reload.

4. **`packages/web/src/components/chat/ToolCallCard.tsx`** (defense-in-depth): adds a 50 KB hard char cap before the `split('\n')` call. The existing 20-line limit doesn't protect against single-line multi-MB blobs (a `cat` of a minified JS file). This cap is independent of the server fix so a future unbounded path can't crash the tab.

## Tests

New test files added to `packages/server`:

- **`src/adapters/web/truncate.test.ts`**: unit tests for `truncateToolOutput` (empty, at-cap, 1-byte-over, large, short-pass-through).
- **`src/adapters/web.test.ts`**: integration tests for `WebAdapter.sendStructuredEvent` verifying (a) SSE output is bounded on over-cap input, (b) under-cap output passes through unchanged, (c) full output is persisted to DB regardless.
- **`src/routes/api.messages.test.ts`**: two new hydration tests verifying (a) large tool output in stored metadata is bounded in the HTTP response, (b) small output passes through unchanged.

All new tests were written before the implementation (TDD: confirmed RED before GREEN). Full suite passes:

```
bun run validate  # check:bundled, check:bundled-skill, type-check, lint, format:check, test — all pass
```

## Test plan

- [ ] Run `bun run validate` — all six checks pass
- [ ] Reproduce with a workflow that dumps a large file via a tool: confirm chat tab no longer crashes, truncation marker appears in the tool card
- [ ] Reload the page after a large-output run: confirm it loads without crashing (hydration path fix)
- [ ] Confirm the DB still holds the full tool output (e.g. via `sqlite3 ~/.archon/archon.db "select metadata from remote_agent_messages order by created_at desc limit 1"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool outputs are now capped before being sent to the browser: displayed output is truncated with a clear marker while the full output remains preserved in run history and persistence.

* **Behavior**
  * Browser-streamed events and API message responses now return capped/marked tool output to prevent oversized payloads.

* **Tests**
  * Added end-to-end tests covering truncation behavior for streaming, API responses, metadata hydration, and UI display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1755?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->