### PR TITLE
fix(orchestrator): resume interactive workflows on chat platforms

### DIFF
--- a/packages/core/src/db/workflows.ts
+++ b/packages/core/src/db/workflows.ts
@@ -334,30 +334,33 @@ export async function findResumableRun(
 }
 
 /**
- * Find a resumable (failed/paused) run for a workflow by parent conversation ID.
- * Used by the web orchestrator to detect approved runs that need foreground resume
- * (background dispatch would create a new worktree and lose the resumable run).
+ * Find a resumable (failed/paused) run for a workflow scoped to (parent conversation, codebase).
+ * Used by the orchestrator (all platforms) to detect approved runs that need foreground resume
+ * on the prior run's worktree. Codebase scope prevents cross-project resume on persistent
+ * chat conversation IDs (Telegram chat_id, Slack thread, etc.).
  */
 export async function findResumableRunByParentConversation(
   workflowName: string,
-  parentConversationId: string
+  parentConversationId: string,
+  codebaseId: string
 ): Promise<WorkflowRun | null> {
   try {
     const result = await pool.query<WorkflowRun>(
       `SELECT * FROM remote_agent_workflow_runs
        WHERE workflow_name = $1
          AND parent_conversation_id = $2
+         AND codebase_id = $3
          AND status IN ('failed', 'paused')
        ORDER BY started_at DESC
        LIMIT 1`,
-      [workflowName, parentConversationId]
+      [workflowName, parentConversationId, codebaseId]
     );
     const row = result.rows[0];
     return row ? normalizeWorkflowRun(row) : null;
   } catch (error) {
     const err = error as Error;
     getLog().error(
-      { err, workflowName, parentConversationId },
+      { err, workflowName, parentConversationId, codebaseId },
       'db.workflow_run_find_resumable_by_parent_failed'
     );
     throw new Error(`Failed to find resumable run by parent conversation: ${err.message}`);

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1294,6 +1294,36 @@ describe('workflow dispatch routing — interactive flag', () => {
     expect(mockExecuteWorkflow).not.toHaveBeenCalled();
   });
 
+  test('web non-interactive workflow with resumable run resumes foreground (not background)', async () => {
+    // Pins the priority order: resume detection comes before the background-dispatch
+    // gate. If a resumable run exists, web non-interactive workflows must resume
+    // foreground rather than dispatching a fresh background run. A future refactor
+    // that accidentally moves the resume check inside the interactive guard would
+    // lose worktree state for web users with paused non-interactive runs.
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(Promise.resolve(makeWorkflowResult(undefined))); // non-interactive
+    mockFindResumableRunByParentConversation.mockReturnValueOnce(
+      Promise.resolve({
+        id: 'web-noninteractive-resume-1',
+        workflow_name: 'test-workflow',
+        working_path: '/repos/test-repo/worktrees/web-feature',
+        parent_conversation_id: 'conv-1',
+        status: 'paused',
+      })
+    );
+
+    const platform = makePlatform(); // getPlatformType returns 'web'
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow');
+
+    // Must resume foreground even though workflow is non-interactive
+    expect(mockHydrateResumableRun).toHaveBeenCalled();
+    expect(mockExecuteWorkflow).toHaveBeenCalled();
+    expect(mockDispatchBackgroundWorkflow).not.toHaveBeenCalled();
+    const callArgs = mockExecuteWorkflow.mock.calls[0] as unknown[];
+    expect(callArgs[3]).toBe('/repos/test-repo/worktrees/web-feature');
+  });
+
   test('calls executeWorkflow for interactive workflow on non-web platform', async () => {
     mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
     mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1175,6 +1175,8 @@ describe('workflow dispatch routing — interactive flag', () => {
   beforeEach(() => {
     mockExecuteWorkflow.mockClear();
     mockDispatchBackgroundWorkflow.mockClear();
+    mockFindResumableRunByParentConversation.mockClear();
+    mockHydrateResumableRun.mockClear();
     mockHandleCommand.mockReset();
     mockHandleCommand.mockImplementation(() =>
       Promise.resolve({ success: true, message: 'ok', workflow: undefined })
@@ -1305,6 +1307,92 @@ describe('workflow dispatch routing — interactive flag', () => {
 
     expect(mockExecuteWorkflow).toHaveBeenCalled();
     expect(mockDispatchBackgroundWorkflow).not.toHaveBeenCalled();
+  });
+
+  test('chat resume: resumes a paused run on chat platform when one exists', async () => {
+    // Regression for #1741: chat platforms (slack/telegram/discord/github) used
+    // to skip the resume lookup entirely and always start a fresh run, losing
+    // the prior worktree and re-asking approval questions indefinitely. The
+    // resume lookup must now run for ALL platforms; if a prior run is paused
+    // or failed-by-approval, executeWorkflow runs on the prior worktree with
+    // hydrated state.
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(Promise.resolve(makeWorkflowResult(true)));
+    mockFindResumableRunByParentConversation.mockReturnValueOnce(
+      Promise.resolve({
+        id: 'chat-resume-run-1',
+        workflow_name: 'test-workflow',
+        working_path: '/repos/test-repo/worktrees/chat-feature',
+        parent_conversation_id: 'conv-1',
+        status: 'paused',
+      })
+    );
+
+    const platform = {
+      ...makePlatform(),
+      getPlatformType: mock(() => 'telegram' as const),
+    };
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow');
+
+    expect(mockHydrateResumableRun).toHaveBeenCalled();
+    expect(mockExecuteWorkflow).toHaveBeenCalled();
+    const callArgs = mockExecuteWorkflow.mock.calls[0] as unknown[];
+    // cwd (position 3) is the prior run's working_path, not a fresh resolution
+    expect(callArgs[3]).toBe('/repos/test-repo/worktrees/chat-feature');
+    const opts = callArgs[callArgs.length - 1] as {
+      preCreatedRun?: { id: string };
+      priorCompletedNodes?: Map<string, string>;
+    };
+    expect(opts.preCreatedRun?.id).toBe('chat-resume-run-1');
+    expect(opts.priorCompletedNodes?.size).toBeGreaterThan(0);
+  });
+
+  test('scopes resume query to (workflow, conversation, codebase)', async () => {
+    // Persistent chat conversation IDs (Telegram chat_id, Slack thread) can
+    // accumulate runs from multiple projects. The resume lookup must include
+    // codebase_id so a fresh invocation for project A never resumes a stale
+    // run from project B.
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(Promise.resolve(makeWorkflowResult(true)));
+
+    const platform = {
+      ...makePlatform(),
+      getPlatformType: mock(() => 'slack' as const),
+    };
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow');
+
+    expect(mockFindResumableRunByParentConversation).toHaveBeenCalledWith(
+      'test-workflow',
+      'conv-1',
+      'codebase-1'
+    );
+  });
+
+  test('starts fresh run when no resumable run exists on chat platform', async () => {
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(Promise.resolve(makeWorkflowResult(true)));
+    // Default mock returns null — no resumable run
+
+    const platform = {
+      ...makePlatform(),
+      getPlatformType: mock(() => 'discord' as const),
+    };
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow');
+
+    expect(mockHydrateResumableRun).not.toHaveBeenCalled();
+    expect(mockExecuteWorkflow).toHaveBeenCalled();
+    const callArgs = mockExecuteWorkflow.mock.calls[0] as unknown[];
+    // cwd comes from validateAndResolveIsolation (default '/test/cwd'), not a prior worktree
+    expect(callArgs[3]).toBe('/test/cwd');
+    const opts = callArgs[callArgs.length - 1] as {
+      preCreatedRun?: unknown;
+      priorCompletedNodes?: unknown;
+    };
+    expect(opts.preCreatedRun).toBeUndefined();
+    expect(opts.priorCompletedNodes).toBeUndefined();
   });
 });
 

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -361,71 +361,57 @@ async function dispatchOrchestratorWorkflow(
     }
   }
 
-  // Dispatch workflow
-  if (platform.getPlatformType() === 'web') {
-    // Check for a resumable run from a prior dispatch (e.g. approved approval gate).
-    // A new background dispatch would create a new worker conversation and never find
-    // the prior run's worktree. Execute in foreground to reuse the original working path.
-    const resumableRun = await workflowDb.findResumableRunByParentConversation(
-      workflow.name,
-      conversation.id
+  // Dispatch workflow.
+  // Resume detection runs for ALL platforms: check if a prior run for this workflow
+  // is in a resumable state (paused/failed-by-approval) in this conversation+codebase
+  // before dispatching fresh. This ensures chat platforms (slack, telegram, discord,
+  // github) resume after approval gates just like web does.
+  const resumableRun = await workflowDb.findResumableRunByParentConversation(
+    workflow.name,
+    conversation.id,
+    codebase.id
+  );
+  if (resumableRun?.working_path) {
+    getLog().info(
+      {
+        workflowName: workflow.name,
+        resumableRunId: resumableRun.id,
+        workingPath: resumableRun.working_path,
+        platformType: platform.getPlatformType(),
+      },
+      'orchestrator.foreground_resume_detected'
     );
-    if (resumableRun?.working_path) {
-      getLog().info(
-        {
-          workflowName: workflow.name,
-          resumableRunId: resumableRun.id,
-          workingPath: resumableRun.working_path,
-        },
-        'orchestrator.foreground_resume_detected'
-      );
-      // Hydrate the already-found candidate. If hydration returns null the
-      // prior run had nothing worth resuming (zero completed nodes, no loop
-      // gate) — surface that to the user and fall through to a fresh run on
-      // the same worktree rather than silently restarting.
-      const deps = createWorkflowDeps();
-      const prepared = await hydrateResumableRun(deps, resumableRun);
-      if (prepared) {
-        await executeWorkflow(
-          deps,
-          platform,
-          conversationId,
-          resumableRun.working_path,
-          workflow,
-          userMessage,
-          conversation.id,
-          {
-            codebaseId: codebase.id,
-            parentConversationId: conversation.id,
-            ...prepared,
-          }
-        );
-      } else {
-        await platform.sendMessage(
-          conversationId,
-          `⚠️ Prior run for **${workflow.name}** had no completed nodes; starting fresh in the same worktree.`
-        );
-        await executeWorkflow(
-          deps,
-          platform,
-          conversationId,
-          resumableRun.working_path,
-          workflow,
-          userMessage,
-          conversation.id,
-          {
-            codebaseId: codebase.id,
-            parentConversationId: conversation.id,
-          }
-        );
-      }
-    } else if (workflow.interactive) {
-      // Interactive workflows run in foreground so output stays in the user's conversation
+    // Hydrate the already-found candidate. If hydration returns null the
+    // prior run had nothing worth resuming (zero completed nodes, no loop
+    // gate) — surface that to the user and fall through to a fresh run on
+    // the same worktree rather than silently restarting.
+    const deps = createWorkflowDeps();
+    const prepared = await hydrateResumableRun(deps, resumableRun);
+    if (prepared) {
       await executeWorkflow(
-        createWorkflowDeps(),
+        deps,
         platform,
         conversationId,
-        cwd,
+        resumableRun.working_path,
+        workflow,
+        userMessage,
+        conversation.id,
+        {
+          codebaseId: codebase.id,
+          parentConversationId: conversation.id,
+          ...prepared,
+        }
+      );
+    } else {
+      await platform.sendMessage(
+        conversationId,
+        `⚠️ Prior run for **${workflow.name}** had no completed nodes; starting fresh in the same worktree.`
+      );
+      await executeWorkflow(
+        deps,
+        platform,
+        conversationId,
+        resumableRun.working_path,
         workflow,
         userMessage,
         conversation.id,
@@ -434,22 +420,24 @@ async function dispatchOrchestratorWorkflow(
           parentConversationId: conversation.id,
         }
       );
-    } else {
-      await dispatchBackgroundWorkflow(
-        {
-          platform,
-          conversationId,
-          cwd,
-          originalMessage: userMessage,
-          conversationDbId: conversation.id,
-          codebaseId: codebase.id,
-          availableWorkflows: [workflow],
-          isolationHints,
-        },
-        workflow
-      );
     }
+  } else if (platform.getPlatformType() === 'web' && !workflow.interactive) {
+    // Background dispatch: web-only, non-interactive workflows with no resumable run
+    await dispatchBackgroundWorkflow(
+      {
+        platform,
+        conversationId,
+        cwd,
+        originalMessage: userMessage,
+        conversationDbId: conversation.id,
+        codebaseId: codebase.id,
+        availableWorkflows: [workflow],
+        isolationHints,
+      },
+      workflow
+    );
   } else {
+    // Fresh foreground execution: web interactive workflows + all chat platforms
     await executeWorkflow(
       createWorkflowDeps(),
       platform,

--- a/packages/core/src/orchestrator/orchestrator.test.ts
+++ b/packages/core/src/orchestrator/orchestrator.test.ts
@@ -185,6 +185,18 @@ mock.module('../services/title-generator', () => ({
   generateAndSetTitle: mockGenerateAndSetTitle,
 }));
 
+// Workflow DB mock — dispatchOrchestratorWorkflow now consults findResumableRunByParentConversation
+// for all platforms (not just web), so this module must be stubbed even when these tests don't
+// exercise the resume path. The default null return keeps execution on the "fresh run" branch.
+const mockFindResumableRunByParentConversation = mock(() => Promise.resolve(null));
+const mockGetPausedWorkflowRun = mock(() => Promise.resolve(null));
+const mockUpdateWorkflowRun = mock(() => Promise.resolve());
+mock.module('../db/workflows', () => ({
+  findResumableRunByParentConversation: mockFindResumableRunByParentConversation,
+  getPausedWorkflowRun: mockGetPausedWorkflowRun,
+  updateWorkflowRun: mockUpdateWorkflowRun,
+}));
+
 // ─── Import module under test (AFTER all mocks) ─────────────────────────────
 
 import { handleMessage, parseOrchestratorCommands } from './orchestrator-agent';

--- a/packages/core/src/orchestrator/orchestrator.test.ts
+++ b/packages/core/src/orchestrator/orchestrator.test.ts
@@ -189,13 +189,10 @@ mock.module('../services/title-generator', () => ({
 // Workflow DB mock — dispatchOrchestratorWorkflow now consults findResumableRunByParentConversation
 // for all platforms (not just web), so this module must be stubbed even when these tests don't
 // exercise the resume path. The default null return keeps execution on the "fresh run" branch.
-const mockFindResumableRunByParentConversation = mock(() => Promise.resolve(null));
-const mockGetPausedWorkflowRun = mock(() => Promise.resolve(null));
-const mockUpdateWorkflowRun = mock(() => Promise.resolve());
 mock.module('../db/workflows', () => ({
-  findResumableRunByParentConversation: mockFindResumableRunByParentConversation,
-  getPausedWorkflowRun: mockGetPausedWorkflowRun,
-  updateWorkflowRun: mockUpdateWorkflowRun,
+  findResumableRunByParentConversation: mock(() => Promise.resolve(null)),
+  getPausedWorkflowRun: mock(() => Promise.resolve(null)),
+  updateWorkflowRun: mock(() => Promise.resolve()),
 }));
 
 // ─── Import module under test (AFTER all mocks) ─────────────────────────────

--- a/packages/core/src/orchestrator/orchestrator.test.ts
+++ b/packages/core/src/orchestrator/orchestrator.test.ts
@@ -165,6 +165,7 @@ mock.module('@archon/workflows/workflow-discovery', () => ({
 }));
 mock.module('@archon/workflows/executor', () => ({
   executeWorkflow: mockExecuteWorkflow,
+  hydrateResumableRun: mock(() => Promise.resolve(null)),
 }));
 mock.module('@archon/workflows/router', () => ({
   findWorkflow: mockFindWorkflow,


### PR DESCRIPTION
## Summary

- **Problem**: Approval-gate and interactive-loop workflows launched from Slack, Telegram, Discord, or GitHub never resumed after a user response — each reply triggered a brand-new run from node 0 in a fresh worktree, discarding all completed work and re-asking the same questions indefinitely.
- **Why it matters**: Every chat-platform user running any interactive or approval-gate workflow was fully broken; only Web worked correctly.
- **What changed**: Lifted the resume-detection block (`findResumableRunByParentConversation` → `hydrateResumableRun` → resume path) out of the `if (platform === 'web')` gate in `dispatchOrchestratorWorkflow` so it runs for all platforms. Added `codebase_id` scoping to the resume query to prevent cross-project resume on persistent chat conversation IDs.
- **What did not change**: The background-dispatch path (web + non-interactive, no resumable run) is unchanged. `hydrateResumableRun` is unchanged. `getPausedWorkflowRun` (natural-language approval interceptor) is unchanged. Issue C from the reporter (codebase name resolution) is out of scope.

## UX Journey

### Before

```
User (Slack)            Archon                      Workflow Engine
────────────            ──────                      ───────────────
sends message ────────▶ handleMessage
                        detects workflow name
                        calls dispatchOrchestratorWorkflow
                          platform === 'slack'
                          → ELSE branch (no resume check)
                          → executeWorkflow(fresh cwd) ──────────▶ starts NEW run from node 0
                                                                   creates NEW worktree
                                                                   re-asks approval question ──▶ user sees duplicate question
                        (prior paused run abandoned, loop restarts)
```

### After

```
User (Slack)            Archon                      Workflow Engine
────────────            ──────                      ───────────────
sends message ────────▶ handleMessage
                        detects workflow name
                        calls dispatchOrchestratorWorkflow
                          [findResumableRunByParentConversation(name, convId, codebaseId)]
                          → resumable run found (status=paused)
                          → hydrateResumableRun → prepared != null
                          → executeWorkflow(resumableRun.working_path) ──▶ RESUMES from paused node
                                                                           continues in original worktree
                                                                           workflow completes ──────────▶ user sees result
```

## Architecture Diagram

### Before

```
dispatchOrchestratorWorkflow
├── if platform === 'web'
│   ├── findResumableRunByParentConversation(name, convId)  ← resume lookup
│   │   ├── found: hydrateResumableRun → executeWorkflow(working_path)
│   │   └── not found + interactive: executeWorkflow(fresh cwd)
│   └── not found + !interactive: dispatchBackgroundWorkflow
└── else  (slack / telegram / discord / github)
    └── executeWorkflow(fresh cwd)  ← ALWAYS fresh, no resume check
```

### After

```
dispatchOrchestratorWorkflow
├── [~] findResumableRunByParentConversation(name, convId, codebaseId)  ← ALL platforms
│   ├── found: hydrateResumableRun → executeWorkflow(working_path)
│   └── not found:
│       ├── if platform === 'web' && !interactive: dispatchBackgroundWorkflow
│       └── else: executeWorkflow(fresh cwd)
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `orchestrator-agent.ts:dispatchOrchestratorWorkflow` | `workflowDb.findResumableRunByParentConversation` | **modified** | Now called for all platforms; adds `codebaseId` as 3rd arg |
| `workflows.ts:findResumableRunByParentConversation` | PostgreSQL/SQLite | **modified** | SQL gains `AND codebase_id = $3` |
| `orchestrator-agent.ts:dispatchOrchestratorWorkflow` | `executeWorkflow` | unchanged | Resume path: called with `working_path`; fresh path: called with `cwd` |
| `orchestrator-agent.ts:dispatchOrchestratorWorkflow` | `dispatchBackgroundWorkflow` | unchanged | Condition unchanged: web + non-interactive + no resumable run |
| `orchestrator-agent.ts:dispatchOrchestratorWorkflow` | `hydrateResumableRun` | unchanged | Called only when resume candidate found |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`
- Module: `core:orchestrator`, `core:db`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #1741

## Validation Evidence (required)

```bash
bun run validate
```

All six checks passed:

| Check | Result |
|-------|--------|
| `check:bundled` | ✅ Pass — bundled-defaults.generated.ts up to date (36 commands, 20 workflows) |
| `check:bundled-skill` | ✅ Pass — bundled-skill.ts up to date (21 files) |
| `type-check` | ✅ Pass — 0 errors across all 10 packages |
| `lint` | ✅ Pass — 0 errors, 0 warnings (--max-warnings 0) |
| `format:check` | ✅ Pass — all files formatted |
| `test` | ✅ Pass — all packages, 0 failures |

New tests added to `orchestrator-agent.test.ts`:
- `chat resume: resumes a paused run on chat platform when one exists`
- `chat resume: scopes resume query to (workflow, conversation, codebase)`
- `chat resume: starts fresh run when no resumable run exists on chat platform`

- Evidence provided: All automated checks passed as listed above.
- Intentionally skipped: None.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — the resume query gains an additional `codebase_id` filter; all callers already have `codebase.id` available.
- Config/env changes? No
- Database migration needed? No — `codebase_id` is an existing column on `remote_agent_workflow_runs`; no schema changes.

## Human Verification (required)

Automated CI covers the logic paths via the three new unit tests. Manual end-to-end verification requires a live Slack/Telegram bot with an approval-gate workflow, which was not available in the worktree environment.

- Verified scenarios: type-check, lint, format, all unit tests (including new chat-resume tests)
- Edge cases checked (by tests): codebase-scoped query call, fresh-run fallback when no resumable run found, paused-run resume with correct `working_path`
- What was not verified: live Slack/Telegram end-to-end round-trip

## Side Effects / Blast Radius (required)

- Affected subsystems: `dispatchOrchestratorWorkflow` (all dispatch paths now run the resume lookup), `findResumableRunByParentConversation` (new required `codebaseId` parameter)
- Potential unintended effects: A stale `paused` run pointing to a deleted worktree will be picked up and fail with a clear error; user can `bun run cli workflow abandon <id>` to clear it. This was already the behavior on web.
- Guardrails: `hydrateResumableRun` returns `null` if no completed nodes exist, causing a graceful fall-through to a fresh run on the same worktree.

## Rollback Plan (required)

- Fast rollback: `git revert de5808f2` — single commit, no migration to undo.
- Feature flags: None.
- Observable failure symptoms: Approval/loop workflows on chat platforms restart from scratch after user reply (original symptom from #1741).

## Risks and Mitigations

- **Risk**: All existing dispatches now call `findResumableRunByParentConversation`; if the DB query is slow, chat dispatch latency increases slightly.
  - **Mitigation**: The query is indexed on `(workflow_name, parent_conversation_id, codebase_id, status)` via existing indexes; expected sub-millisecond latency. The query was already executed on every web dispatch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved workflow resumption to correctly identify and handle resumable runs across multiple codebases on all platforms.
  * Non-interactive workflows now resume in the foreground when existing work is available, instead of starting new background runs.
  * Enhanced chat platform support for properly resuming paused workflows from previous execution sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1756?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->