### PR TITLE
feat(slack): umbrella Slack UX upgrade — buttons, status, reactions, slash commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ bun test --watch            # Watch mode (single package)
 bun test packages/core/src/handlers/command-handler.test.ts  # Single file
 ```
 
-**Test isolation (mock.module pollution):** Bun's `mock.module()` permanently replaces modules in the process-wide cache — `mock.restore()` does NOT undo it ([oven-sh/bun#7823](https://github.com/oven-sh/bun/issues/7823)). To prevent cross-file pollution, packages that have conflicting `mock.module()` calls split their tests into separate `bun test` invocations: `@archon/core` (7 batches), `@archon/workflows` (5), `@archon/adapters` (3), `@archon/isolation` (3). See each package's `package.json` for the exact splits.
+**Test isolation (mock.module pollution):** Bun's `mock.module()` permanently replaces modules in the process-wide cache — `mock.restore()` does NOT undo it ([oven-sh/bun#7823](https://github.com/oven-sh/bun/issues/7823)). To prevent cross-file pollution, packages that have conflicting `mock.module()` calls split their tests into separate `bun test` invocations: `@archon/core` (7 batches), `@archon/workflows` (5), `@archon/adapters` (6), `@archon/isolation` (3). See each package's `package.json` for the exact splits.
 
 **Do NOT run `bun test` from the repo root** — it discovers all test files across all packages and runs them in one process, causing ~135 mock pollution failures. Always use `bun run test` (which uses `bun --filter '*' test` for per-package isolation).
 

--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
         "@archon/git": "workspace:*",
         "@archon/isolation": "workspace:*",
         "@archon/paths": "workspace:*",
+        "@archon/providers": "workspace:*",
         "@octokit/rest": "^22.0.0",
         "@slack/bolt": "^4.6.0",
         "discord.js": "^14.16.0",

--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
         "@archon/isolation": "workspace:*",
         "@archon/paths": "workspace:*",
         "@archon/providers": "workspace:*",
+        "@archon/workflows": "workspace:*",
         "@octokit/rest": "^22.0.0",
         "@slack/bolt": "^4.6.0",
         "discord.js": "^14.16.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -19,6 +19,7 @@
     "@archon/git": "workspace:*",
     "@archon/isolation": "workspace:*",
     "@archon/paths": "workspace:*",
+    "@archon/providers": "workspace:*",
     "@octokit/rest": "^22.0.0",
     "@slack/bolt": "^4.6.0",
     "discord.js": "^14.16.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -11,7 +11,7 @@
     "./community/forge/gitlab": "./src/community/forge/gitlab/index.ts"
   },
   "scripts": {
-    "test": "bun test src/chat/ src/community/chat/ src/community/forge/gitlab/auth.test.ts src/forge/github/auth.test.ts src/utils/ && bun test src/forge/github/adapter.test.ts && bun test src/forge/github/context.test.ts && bun test src/community/forge/gitea/adapter.test.ts && bun test src/community/forge/gitlab/adapter.test.ts",
+    "test": "bun test src/chat/slack/adapter.test.ts src/chat/slack/auth.test.ts src/chat/slack/blocks.test.ts src/chat/telegram/ src/community/chat/ src/community/forge/gitlab/auth.test.ts src/forge/github/auth.test.ts src/utils/ && bun test src/chat/slack/workflow-bridge.test.ts && bun test src/forge/github/adapter.test.ts && bun test src/forge/github/context.test.ts && bun test src/community/forge/gitea/adapter.test.ts && bun test src/community/forge/gitlab/adapter.test.ts",
     "type-check": "bun x tsc --noEmit"
   },
   "dependencies": {
@@ -20,6 +20,7 @@
     "@archon/isolation": "workspace:*",
     "@archon/paths": "workspace:*",
     "@archon/providers": "workspace:*",
+    "@archon/workflows": "workspace:*",
     "@octokit/rest": "^22.0.0",
     "@slack/bolt": "^4.6.0",
     "discord.js": "^14.16.0",

--- a/packages/adapters/src/chat/slack/adapter.test.ts
+++ b/packages/adapters/src/chat/slack/adapter.test.ts
@@ -29,6 +29,8 @@ const mockReplies = mock(() => Promise.resolve({ messages: [] }));
 const mockEvent = mock(() => {});
 const mockStart = mock(() => Promise.resolve(undefined));
 const mockStop = mock(() => Promise.resolve(undefined));
+const mockCommand = mock(() => {});
+const mockAction = mock(() => {});
 
 const mockApp = {
   client: {
@@ -40,6 +42,8 @@ const mockApp = {
     },
   },
   event: mockEvent,
+  command: mockCommand,
+  action: mockAction,
   start: mockStart,
   stop: mockStop,
 };
@@ -364,6 +368,150 @@ describe('SlackAdapter', () => {
           blocks: [{ type: 'markdown', text: '' }],
         })
       );
+    });
+
+    test('single-chunk message is sent without _part footer', async () => {
+      await adapter.sendMessage('C1:111.0', 'short message');
+      expect(mockPostMessage).toHaveBeenCalledTimes(1);
+      const blocks = (mockPostMessage as Mock<typeof mockPostMessage>).mock.calls[0][0].blocks;
+      expect(blocks[0].text).toBe('short message');
+      expect(blocks[0].text).not.toContain('_part ');
+    });
+
+    test('multi-chunk message annotates each part with _part i/n_', async () => {
+      const paragraph1 = 'a'.repeat(10000);
+      const paragraph2 = 'b'.repeat(10000);
+      await adapter.sendMessage('C1:111.0', `${paragraph1}\n\n${paragraph2}`);
+      expect(mockPostMessage).toHaveBeenCalledTimes(2);
+      const calls = (mockPostMessage as Mock<typeof mockPostMessage>).mock.calls;
+      expect(calls[0][0].blocks[0].text).toContain('_part 1/2_');
+      expect(calls[1][0].blocks[0].text).toContain('_part 2/2_');
+    });
+  });
+
+  describe('triggering message tracking', () => {
+    test('FIFO evicts oldest entry past the cap', async () => {
+      // SlackAdapter caps the in-memory map at 1000 entries. To keep this
+      // test fast we exercise the eviction trigger by pumping app_mention
+      // events through the registered handler.
+      mockEvent.mockClear();
+      const adapter = new SlackAdapter('xoxb-fake', 'xapp-fake');
+      adapter.onMessage(async () => {
+        /* no-op handler; we only care about the trigger map side-effect */
+      });
+      await adapter.start();
+      // Find the app_mention handler we just registered.
+      const calls = (mockEvent as unknown as Mock<(t: string, h: unknown) => void>).mock.calls;
+      const mentionReg = calls.find(c => c[0] === 'app_mention');
+      expect(mentionReg).toBeDefined();
+      const handler = mentionReg![1] as (args: { event: SlackMessageEvent }) => Promise<void>;
+
+      const CAP = 1000;
+      for (let i = 0; i < CAP + 5; i++) {
+        await handler({
+          event: { text: 'hi', user: 'U1', channel: 'C1', ts: `${i}.0` },
+        });
+      }
+
+      // Oldest 5 should be evicted (channel:ts pairs 0.0 .. 4.0)
+      expect(adapter.getTriggeringMessage('C1:0.0')).toBeUndefined();
+      expect(adapter.getTriggeringMessage('C1:4.0')).toBeUndefined();
+      // Boundary: entry 5 is the new oldest and must still be tracked.
+      expect(adapter.getTriggeringMessage('C1:5.0')).toEqual({ channel: 'C1', ts: '5.0' });
+      // Newest entry must be present.
+      expect(adapter.getTriggeringMessage(`C1:${CAP + 4}.0`)).toEqual({
+        channel: 'C1',
+        ts: `${CAP + 4}.0`,
+      });
+    });
+  });
+
+  describe('slash commands', () => {
+    function findCommandHandler(name: string): (args: unknown) => Promise<void> {
+      const calls = (mockCommand as unknown as Mock<(n: string, h: unknown) => void>).mock.calls;
+      const reg = calls.find(c => c[0] === name);
+      if (!reg) throw new Error(`no handler registered for ${name}`);
+      return reg[1] as (args: unknown) => Promise<void>;
+    }
+
+    function makeSlashArgs(overrides: Record<string, unknown> = {}) {
+      const ack = mock(async () => {});
+      const respond = mock(async () => {});
+      const fakeClient = { chat: { postMessage: mockPostMessage } };
+      return {
+        ack,
+        respond,
+        client: fakeClient,
+        command: {
+          user_id: 'U123',
+          text: 'list',
+          channel_id: 'C1',
+          trigger_id: 't1',
+          ...overrides,
+        },
+      };
+    }
+
+    test('unauthorized user is silently rejected — no respond, no seed post', async () => {
+      mockPostMessage.mockClear();
+      mockCommand.mockClear();
+      const original = process.env.SLACK_ALLOWED_USER_IDS;
+      process.env.SLACK_ALLOWED_USER_IDS = 'U1ALICE';
+      try {
+        const adapter = new SlackAdapter('xoxb-fake', 'xapp-fake');
+        adapter.onMessage(async () => {});
+        await adapter.start();
+
+        const handler = findCommandHandler('/archon-workflow');
+        const args = makeSlashArgs({ user_id: 'U2BOB' });
+        await handler(args);
+
+        // ack always fires (Slack 3s deadline).
+        expect((args.ack as Mock<() => Promise<void>>).mock.calls.length).toBe(1);
+        // But the unauthorized branch must NOT speak back to the user
+        // (mirrors the app_mention silent-rejection policy).
+        expect((args.respond as Mock<() => Promise<void>>).mock.calls.length).toBe(0);
+        expect(mockPostMessage).not.toHaveBeenCalled();
+      } finally {
+        if (original === undefined) delete process.env.SLACK_ALLOWED_USER_IDS;
+        else process.env.SLACK_ALLOWED_USER_IDS = original;
+      }
+    });
+
+    test('seed-post failure surfaces ephemeral error and skips message handler', async () => {
+      mockPostMessage.mockClear();
+      mockCommand.mockClear();
+      const adapter = new SlackAdapter('xoxb-fake', 'xapp-fake');
+      const onMessage = mock(async () => {});
+      adapter.onMessage(onMessage);
+      await adapter.start();
+
+      // Reject the seed post — adapter must surface an ephemeral error and
+      // never invoke the message handler with an undefined ts.
+      const seedError = new Error('not_in_channel');
+      const failingPost = mock(async () => Promise.reject(seedError));
+      const fakeClient = { chat: { postMessage: failingPost } };
+      const ack = mock(async () => {});
+      const respond = mock(async () => {});
+
+      const handler = findCommandHandler('/archon');
+      await handler({
+        ack,
+        respond,
+        client: fakeClient,
+        command: {
+          user_id: 'U123',
+          text: 'hello',
+          channel_id: 'C_HIDDEN',
+          trigger_id: 't1',
+        },
+      });
+
+      expect(failingPost).toHaveBeenCalledTimes(1);
+      expect(onMessage).not.toHaveBeenCalled();
+      const respondCalls = (respond as Mock<() => Promise<void>>).mock.calls;
+      expect(respondCalls.length).toBe(1);
+      expect((respondCalls[0]![0] as { response_type: string }).response_type).toBe('ephemeral');
     });
   });
 });

--- a/packages/adapters/src/chat/slack/adapter.ts
+++ b/packages/adapters/src/chat/slack/adapter.ts
@@ -391,7 +391,6 @@ export class SlackAdapter implements IPlatformAdapter {
       }
     });
 
-    // Slash commands: /archon (general) and /archon-workflow (workflow control)
     this.app.command('/archon', async ({ command, ack, respond, client }) => {
       await ack();
       await this.handleSlashCommand(command, respond, client, 'archon');

--- a/packages/adapters/src/chat/slack/adapter.ts
+++ b/packages/adapters/src/chat/slack/adapter.ts
@@ -420,14 +420,13 @@ export class SlackAdapter implements IPlatformAdapter {
   ): Promise<void> {
     const actorId = command.user_id;
     if (!isSlackUserAuthorized(actorId, this.allowedUserIds)) {
+      // Silent rejection with masked logging — matches the inbound event-handler
+      // policy (see app_mention / message.im handlers above). Posting a denial
+      // would tell unauthorized users a bot exists and is listening.
       getLog().info(
         { maskedUserId: `${actorId.slice(0, 4)}***`, kind },
         'slack.slash_unauthorized'
       );
-      await respond({
-        response_type: 'ephemeral',
-        text: 'Sorry — you are not on the allowed user list for this Archon instance.',
-      });
       return;
     }
 

--- a/packages/adapters/src/chat/slack/adapter.ts
+++ b/packages/adapters/src/chat/slack/adapter.ts
@@ -2,12 +2,14 @@
  * Slack platform adapter using @slack/bolt with Socket Mode
  * Handles message sending with markdown block formatting for AI responses
  */
-import { App, LogLevel } from '@slack/bolt';
+import { App, LogLevel, type SlashCommand } from '@slack/bolt';
 import type { IPlatformAdapter, MessageMetadata } from '@archon/core';
+import type { TokenUsage } from '@archon/providers/types';
 import { createLogger } from '@archon/paths';
 import { isSlackUserAuthorized } from './auth';
 import { parseAllowedUserIds } from './auth';
 import { splitIntoParagraphChunks } from '../../utils/message-splitting';
+import { formatCostFooter } from './blocks';
 import type { SlackMessageEvent } from './types';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
@@ -19,11 +21,22 @@ function getLog(): ReturnType<typeof createLogger> {
 
 const MAX_MARKDOWN_BLOCK_LENGTH = 12000; // Slack markdown block limit
 
+/** Slack channel + message ts pair used for reactions and edits. */
+export interface SlackMessageRef {
+  channel: string;
+  ts: string;
+}
+
+/** Cap on the in-memory triggering-message map to prevent unbounded growth. */
+const MAX_TRACKED_TRIGGERS = 1000;
+
 export class SlackAdapter implements IPlatformAdapter {
   private app: App;
   private streamingMode: 'stream' | 'batch';
   private messageHandler: ((event: SlackMessageEvent) => Promise<void>) | null = null;
   private allowedUserIds: string[];
+  /** Maps conversation ID → triggering Slack message so the bridge can react / edit. */
+  private triggeringMessages = new Map<string, SlackMessageRef>();
 
   constructor(botToken: string, appToken: string, mode: 'stream' | 'batch' = 'batch') {
     this.app = new App({
@@ -48,7 +61,8 @@ export class SlackAdapter implements IPlatformAdapter {
   /**
    * Send a message to a Slack channel/thread
    * Uses markdown block for proper formatting of AI responses
-   * Automatically splits messages longer than 12000 characters
+   * Automatically splits messages longer than 12000 characters and footers each
+   * chunk with `_part i/n_` so users know the output was wrapped.
    */
   async sendMessage(
     channelId: string,
@@ -63,16 +77,20 @@ export class SlackAdapter implements IPlatformAdapter {
       : [channelId, undefined];
 
     if (message.length <= MAX_MARKDOWN_BLOCK_LENGTH) {
-      // Use markdown block for proper formatting
       await this.sendWithMarkdownBlock(channel, message, threadTs);
-    } else {
-      // Long message: split by paragraphs
-      getLog().debug({ messageLength: message.length }, 'slack.message_splitting');
-      const chunks = splitIntoParagraphChunks(message, MAX_MARKDOWN_BLOCK_LENGTH - 500);
+      return;
+    }
 
-      for (const chunk of chunks) {
-        await this.sendWithMarkdownBlock(channel, chunk, threadTs);
-      }
+    getLog().debug({ messageLength: message.length }, 'slack.message_splitting');
+    // Reserve headroom for the trailing "_part i/n_" footer. The longest footer
+    // appears on the largest split (e.g. 7 chunks → "_part 7/7_") and is well
+    // under 32 chars, so a 64-char reserve is comfortable.
+    const chunks = splitIntoParagraphChunks(message, MAX_MARKDOWN_BLOCK_LENGTH - 500 - 64);
+    const total = chunks.length;
+    for (let i = 0; i < total; i++) {
+      const body = chunks[i] ?? '';
+      const annotated = total > 1 ? `${body}\n\n_part ${i + 1}/${total}_` : body;
+      await this.sendWithMarkdownBlock(channel, annotated, threadTs);
     }
   }
 
@@ -112,6 +130,40 @@ export class SlackAdapter implements IPlatformAdapter {
   }
 
   /**
+   * Append a small italic cost / token footer after a direct-chat assistant
+   * turn. Posted as a context block so it visually de-emphasises vs the
+   * assistant reply. No-op when there's nothing meaningful to surface.
+   */
+  async sendResultFooter(
+    conversationId: string,
+    info: { cost?: number; tokens?: TokenUsage; stopReason?: string }
+  ): Promise<void> {
+    const text = formatCostFooter(info);
+    if (!text) return;
+
+    const [channel, threadTs] = conversationId.includes(':')
+      ? conversationId.split(':')
+      : [conversationId, undefined];
+
+    try {
+      await this.app.client.chat.postMessage({
+        channel,
+        thread_ts: threadTs,
+        text,
+        blocks: [
+          {
+            type: 'context',
+            elements: [{ type: 'mrkdwn', text }],
+          },
+        ],
+      });
+    } catch (error) {
+      // Cost footer is informational only — never let it fail the conversation.
+      getLog().warn({ err: error as Error, channel }, 'slack.result_footer_failed');
+    }
+  }
+
+  /**
    * Get the Bolt App instance
    */
   getApp(): App {
@@ -130,6 +182,37 @@ export class SlackAdapter implements IPlatformAdapter {
    */
   getPlatformType(): string {
     return 'slack';
+  }
+
+  /**
+   * Returns the channel/ts of the inbound user message that triggered the
+   * given conversation, if we have it. Workflow bridge uses this to add
+   * lifecycle reactions to the user's mention/DM.
+   */
+  getTriggeringMessage(conversationId: string): SlackMessageRef | undefined {
+    return this.triggeringMessages.get(conversationId);
+  }
+
+  /** Drop the cached triggering message for a conversation (e.g. on workflow terminal). */
+  clearTriggeringMessage(conversationId: string): void {
+    this.triggeringMessages.delete(conversationId);
+  }
+
+  /** Test seam: expose the configured whitelist to the workflow bridge. */
+  getAllowedUserIds(): string[] {
+    return this.allowedUserIds;
+  }
+
+  private trackTrigger(conversationId: string, ref: SlackMessageRef): void {
+    // Defensive cap so chat-only conversations that never run a workflow
+    // can't grow the map without bound.
+    if (this.triggeringMessages.size >= MAX_TRACKED_TRIGGERS) {
+      const oldest = this.triggeringMessages.keys().next().value;
+      if (oldest !== undefined) {
+        this.triggeringMessages.delete(oldest);
+      }
+    }
+    this.triggeringMessages.set(conversationId, ref);
   }
 
   /**
@@ -260,6 +343,10 @@ export class SlackAdapter implements IPlatformAdapter {
           ts: event.ts,
           thread_ts: event.thread_ts,
         };
+        this.trackTrigger(this.getConversationId(messageEvent), {
+          channel: event.channel,
+          ts: event.ts,
+        });
         // Fire-and-forget - errors handled by caller
         void this.messageHandler(messageEvent);
       }
@@ -296,12 +383,128 @@ export class SlackAdapter implements IPlatformAdapter {
           ts: event.ts,
           thread_ts: 'thread_ts' in event ? event.thread_ts : undefined,
         };
+        this.trackTrigger(this.getConversationId(messageEvent), {
+          channel: event.channel,
+          ts: event.ts,
+        });
         void this.messageHandler(messageEvent);
       }
     });
 
+    // Slash commands: /archon (general) and /archon-workflow (workflow control)
+    this.app.command('/archon', async ({ command, ack, respond, client }) => {
+      await ack();
+      await this.handleSlashCommand(command, respond, client, 'archon');
+    });
+    this.app.command('/archon-workflow', async ({ command, ack, respond, client }) => {
+      await ack();
+      await this.handleSlashCommand(command, respond, client, 'archon-workflow');
+    });
+
     await this.app.start();
     getLog().info('slack.bot_started');
+  }
+
+  /**
+   * Forward a slash command into the same message-handling flow used by
+   * @mention. Slash commands carry no message ts of their own, so we first
+   * post a visible "seed" message in the channel — its ts becomes the thread
+   * root for everything that follows, giving slash-driven runs the same
+   * threading model as @mention runs.
+   */
+  private async handleSlashCommand(
+    command: SlashCommand,
+    respond: (msg: { response_type: 'ephemeral' | 'in_channel'; text: string }) => Promise<unknown>,
+    client: App['client'],
+    kind: 'archon' | 'archon-workflow'
+  ): Promise<void> {
+    const actorId = command.user_id;
+    if (!isSlackUserAuthorized(actorId, this.allowedUserIds)) {
+      getLog().info(
+        { maskedUserId: `${actorId.slice(0, 4)}***`, kind },
+        'slack.slash_unauthorized'
+      );
+      await respond({
+        response_type: 'ephemeral',
+        text: 'Sorry — you are not on the allowed user list for this Archon instance.',
+      });
+      return;
+    }
+
+    if (!this.messageHandler) {
+      await respond({
+        response_type: 'ephemeral',
+        text: 'Archon is starting up — try again in a moment.',
+      });
+      return;
+    }
+
+    const raw = (command.text ?? '').trim();
+    if (!raw) {
+      const help =
+        kind === 'archon-workflow'
+          ? 'Usage: `/archon-workflow <subcommand>` — e.g. `list`, `status`, `run <name> <args>`, `approve <id>`, `reject <id> <reason>`, `abandon <id>`.'
+          : 'Usage: `/archon <message>` — talk to Archon in this channel.';
+      await respond({ response_type: 'ephemeral', text: help });
+      return;
+    }
+
+    const messageText = kind === 'archon-workflow' ? `/workflow ${raw}` : raw;
+
+    // Post a visible seed message so the bot's responses thread cleanly under
+    // a parent. The seed quotes the invoking user and the command they ran,
+    // mirroring how @mention surfaces the original message in the thread.
+    let seedTs: string | undefined;
+    try {
+      const seedText =
+        kind === 'archon-workflow'
+          ? `<@${actorId}> ran \`/archon-workflow ${raw}\``
+          : `<@${actorId}> via /archon: ${raw}`;
+      const posted = await client.chat.postMessage({
+        channel: command.channel_id,
+        text: seedText,
+      });
+      seedTs = posted.ts ?? undefined;
+    } catch (error) {
+      getLog().warn(
+        { err: error as Error, channel: command.channel_id, kind },
+        'slack.slash_seed_post_failed'
+      );
+      await respond({
+        response_type: 'ephemeral',
+        text: 'Could not post in this channel — is the bot invited here?',
+      });
+      return;
+    }
+
+    if (!seedTs) {
+      await respond({
+        response_type: 'ephemeral',
+        text: 'Could not start the conversation (Slack returned no message id).',
+      });
+      return;
+    }
+
+    const messageEvent: SlackMessageEvent = {
+      text: messageText,
+      user: actorId,
+      channel: command.channel_id,
+      ts: seedTs,
+    };
+    this.trackTrigger(this.getConversationId(messageEvent), {
+      channel: command.channel_id,
+      ts: seedTs,
+    });
+
+    await respond({
+      response_type: 'ephemeral',
+      text:
+        kind === 'archon-workflow'
+          ? `Running \`/workflow ${raw}\` — see thread for output.`
+          : `Running \`${raw}\` — see thread for output.`,
+    });
+
+    void this.messageHandler(messageEvent);
   }
 
   /**

--- a/packages/adapters/src/chat/slack/blocks.test.ts
+++ b/packages/adapters/src/chat/slack/blocks.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Unit tests for Slack Block Kit builders and cost footer formatter.
+ */
+import {
+  buildApprovalBlocks,
+  buildApprovalResolutionBlocks,
+  buildStatusBlocks,
+  formatCostFooter,
+  REACTION_FAILURE,
+  REACTION_RUNNING,
+  REACTION_SUCCESS,
+  type RunSnapshot,
+} from './blocks';
+
+describe('formatCostFooter', () => {
+  test('returns null when neither cost nor tokens are present', () => {
+    expect(formatCostFooter({})).toBeNull();
+  });
+
+  test('returns null when cost is undefined and tokens are zero', () => {
+    expect(formatCostFooter({ tokens: { input: 0, output: 0 } })).toBeNull();
+  });
+
+  test('formats cost only', () => {
+    expect(formatCostFooter({ cost: 0.0234 })).toBe('_cost: $0.0234_');
+  });
+
+  test('formats tokens from input+output sum', () => {
+    expect(formatCostFooter({ tokens: { input: 1500, output: 500 } })).toBe('_2.0k tokens_');
+  });
+
+  test('formats tokens using explicit total when provided', () => {
+    expect(formatCostFooter({ tokens: { input: 0, output: 0, total: 12345 } })).toBe(
+      '_12.3k tokens_'
+    );
+  });
+
+  test('formats millions with M suffix', () => {
+    expect(formatCostFooter({ tokens: { input: 1_200_000, output: 800_000 } })).toBe(
+      '_2.0M tokens_'
+    );
+  });
+
+  test('combines cost, tokens, and stopReason', () => {
+    expect(
+      formatCostFooter({
+        cost: 0.1234,
+        tokens: { input: 5000, output: 7500 },
+        stopReason: 'end_turn',
+      })
+    ).toBe('_cost: $0.1234 · 12.5k tokens · stop: end_turn_');
+  });
+
+  test('drops non-finite cost', () => {
+    expect(formatCostFooter({ cost: Number.NaN })).toBeNull();
+    expect(formatCostFooter({ cost: Number.POSITIVE_INFINITY })).toBeNull();
+  });
+});
+
+describe('buildApprovalBlocks', () => {
+  test('produces section + actions block with both buttons', () => {
+    const { blocks, fallbackText } = buildApprovalBlocks({
+      runId: 'a1b2c3d4-deadbeef',
+      nodeId: 'review-step',
+      message: 'Approve the migration?',
+    });
+
+    expect(fallbackText).toBe('Approval needed for run a1b2c3d4');
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toMatchObject({
+      type: 'section',
+      text: { type: 'mrkdwn' },
+    });
+    const sectionText = (blocks[0] as { text: { text: string } }).text.text;
+    expect(sectionText).toContain('Approval needed');
+    expect(sectionText).toContain('Approve the migration?');
+    expect(sectionText).toContain('a1b2c3d4');
+
+    const actions = blocks[1] as {
+      type: string;
+      block_id?: string;
+      elements: Array<{ type: string; action_id: string; style?: string }>;
+    };
+    expect(actions.type).toBe('actions');
+    expect(actions.block_id).toBe('approval:a1b2c3d4-deadbeef:review-step');
+    expect(actions.elements).toHaveLength(2);
+    expect(actions.elements[0]?.action_id).toBe('approve:a1b2c3d4-deadbeef:review-step');
+    expect(actions.elements[0]?.style).toBe('primary');
+    expect(actions.elements[1]?.action_id).toBe('reject:a1b2c3d4-deadbeef:review-step');
+    expect(actions.elements[1]?.style).toBe('danger');
+  });
+});
+
+describe('buildApprovalResolutionBlocks', () => {
+  test('approved variant includes actor and original message, no buttons', () => {
+    const { blocks } = buildApprovalResolutionBlocks({
+      runId: 'a1b2c3d4-x',
+      nodeId: 'review',
+      decision: 'approved',
+      actorUserId: 'U123ALICE',
+      originalMessage: 'Approve the migration?',
+      comment: 'looks good',
+      outcomeNote: 'workflow resumed',
+    });
+
+    expect(blocks).toHaveLength(1);
+    const text = (blocks[0] as { text: { text: string } }).text.text;
+    expect(text).toContain('Approved');
+    expect(text).toContain('<@U123ALICE>');
+    expect(text).toContain('Approve the migration?');
+    expect(text).toContain('> looks good');
+    expect(text).toContain('workflow resumed');
+  });
+
+  test('rejected variant uses red x and Rejected label', () => {
+    const { blocks } = buildApprovalResolutionBlocks({
+      runId: 'a1b2c3d4-x',
+      nodeId: 'review',
+      decision: 'rejected',
+      actorUserId: 'U123BOB',
+      originalMessage: 'Approve?',
+    });
+    const text = (blocks[0] as { text: { text: string } }).text.text;
+    expect(text).toContain('Rejected');
+    expect(text).toContain(':x:');
+  });
+});
+
+describe('buildStatusBlocks', () => {
+  const startedAt = 1_000_000;
+
+  function snapshot(overrides: Partial<RunSnapshot> = {}): RunSnapshot {
+    return {
+      runId: 'a1b2c3d4-zzzz',
+      workflowName: 'assist',
+      startedAt,
+      nodes: [],
+      ...overrides,
+    };
+  }
+
+  test('running snapshot includes Cancel button and elapsed time', () => {
+    const { blocks } = buildStatusBlocks(snapshot(), startedAt + 12_345);
+    const header = (blocks[0] as { text: { text: string } }).text.text;
+    expect(header).toContain('Workflow running');
+    expect(header).toContain('`assist`');
+    expect(header).toContain('`a1b2c3d4`');
+    expect(header).toContain('12s');
+
+    const last = blocks[blocks.length - 1] as {
+      type: string;
+      block_id?: string;
+      elements?: Array<{ action_id: string }>;
+    };
+    expect(last.type).toBe('actions');
+    expect(last.block_id).toBe('run-controls:a1b2c3d4-zzzz');
+    expect(last.elements?.[0]?.action_id).toBe('cancel:a1b2c3d4-zzzz');
+  });
+
+  test('renders node list with state glyphs', () => {
+    const { blocks } = buildStatusBlocks(
+      snapshot({
+        nodes: [
+          { nodeId: 'a', nodeName: 'plan', state: 'completed', durationMs: 4000 },
+          { nodeId: 'b', nodeName: 'review', state: 'running' },
+          { nodeId: 'c', nodeName: 'apply', state: 'pending' },
+          { nodeId: 'd', nodeName: 'verify', state: 'failed', error: 'boom' },
+          { nodeId: 'e', nodeName: 'cleanup', state: 'skipped' },
+        ],
+      }),
+      startedAt + 5000
+    );
+    const nodeBlock = blocks[1] as { text: { text: string } };
+    const text = nodeBlock.text.text;
+    expect(text).toContain(':white_check_mark: `plan`');
+    expect(text).toContain('4s');
+    expect(text).toContain(':hourglass_flowing_sand: `review`');
+    expect(text).toContain(':white_circle: `apply`');
+    expect(text).toContain(':x: `verify`');
+    expect(text).toContain('boom');
+    expect(text).toContain(':fast_forward: `cleanup`');
+  });
+
+  test('terminal completed snapshot drops Cancel button and shows total cost', () => {
+    const { blocks } = buildStatusBlocks(
+      snapshot({
+        terminal: 'completed',
+        totalCostUsd: 0.123,
+      }),
+      startedAt + 1000
+    );
+    expect(blocks.find(b => (b as { type: string }).type === 'actions')).toBeUndefined();
+    const header = (blocks[0] as { text: { text: string } }).text.text;
+    expect(header).toContain('Workflow completed');
+    const ctx = blocks.find(b => (b as { type: string }).type === 'context') as {
+      elements: Array<{ text: string }>;
+    };
+    expect(ctx.elements[0]?.text).toContain('total cost: $0.1230');
+  });
+
+  test('terminal failed snapshot shows reason', () => {
+    const { blocks } = buildStatusBlocks(
+      snapshot({
+        terminal: 'failed',
+        failureReason: 'Type error in plan node',
+      }),
+      startedAt + 1000
+    );
+    const ctx = blocks.find(b => (b as { type: string }).type === 'context') as {
+      elements: Array<{ text: string }>;
+    };
+    expect(ctx.elements[0]?.text).toContain('reason: Type error in plan node');
+  });
+});
+
+describe('reaction name constants', () => {
+  test('are stable Slack emoji names', () => {
+    expect(REACTION_RUNNING).toBe('arrows_counterclockwise');
+    expect(REACTION_SUCCESS).toBe('white_check_mark');
+    expect(REACTION_FAILURE).toBe('x');
+  });
+});

--- a/packages/adapters/src/chat/slack/blocks.test.ts
+++ b/packages/adapters/src/chat/slack/blocks.test.ts
@@ -1,6 +1,3 @@
-/**
- * Unit tests for Slack Block Kit builders and cost footer formatter.
- */
 import {
   buildApprovalBlocks,
   buildApprovalResolutionBlocks,
@@ -99,7 +96,6 @@ describe('buildApprovalResolutionBlocks', () => {
       decision: 'approved',
       actorUserId: 'U123ALICE',
       originalMessage: 'Approve the migration?',
-      comment: 'looks good',
       outcomeNote: 'workflow resumed',
     });
 
@@ -108,7 +104,6 @@ describe('buildApprovalResolutionBlocks', () => {
     expect(text).toContain('Approved');
     expect(text).toContain('<@U123ALICE>');
     expect(text).toContain('Approve the migration?');
-    expect(text).toContain('> looks good');
     expect(text).toContain('workflow resumed');
   });
 

--- a/packages/adapters/src/chat/slack/blocks.test.ts
+++ b/packages/adapters/src/chat/slack/blocks.test.ts
@@ -211,6 +211,20 @@ describe('buildStatusBlocks', () => {
     };
     expect(ctx.elements[0]?.text).toContain('reason: Type error in plan node');
   });
+
+  test('terminal cancelled snapshot also surfaces reason', () => {
+    const { blocks } = buildStatusBlocks(
+      snapshot({
+        terminal: 'cancelled',
+        failureReason: 'user clicked cancel',
+      }),
+      startedAt + 1000
+    );
+    const ctx = blocks.find(b => (b as { type: string }).type === 'context') as {
+      elements: Array<{ text: string }>;
+    };
+    expect(ctx.elements[0]?.text).toContain('reason: user clicked cancel');
+  });
 });
 
 describe('reaction name constants', () => {

--- a/packages/adapters/src/chat/slack/blocks.ts
+++ b/packages/adapters/src/chat/slack/blocks.ts
@@ -1,9 +1,8 @@
 /**
- * Pure Block Kit builders + cost footer formatter for the Slack adapter.
- *
- * Kept side-effect-free so they can be unit-tested without touching the Bolt
- * client. The Slack adapter and workflow bridge import these and feed the
- * results into `chat.postMessage` / `chat.update`.
+ * Side-effect-free so callers can unit-test these without spinning up a
+ * Bolt client. Consumed by `adapter.ts` (`sendResultFooter`) and the
+ * workflow bridge, both of which feed the output into `chat.postMessage`
+ * / `chat.update`.
  */
 import type { types } from '@slack/bolt';
 import type { TokenUsage } from '@archon/providers/types';
@@ -148,7 +147,6 @@ export function buildApprovalResolutionBlocks(input: {
   decision: 'approved' | 'rejected';
   actorUserId: string;
   originalMessage: string;
-  comment?: string;
   outcomeNote?: string;
 }): { blocks: KnownBlock[]; fallbackText: string } {
   const icon = input.decision === 'approved' ? ':white_check_mark:' : ':x:';
@@ -158,9 +156,6 @@ export function buildApprovalResolutionBlocks(input: {
     '',
     input.originalMessage,
   ];
-  if (input.comment) {
-    lines.push('', `> ${input.comment}`);
-  }
   if (input.outcomeNote) {
     lines.push('', `_${input.outcomeNote}_`);
   }

--- a/packages/adapters/src/chat/slack/blocks.ts
+++ b/packages/adapters/src/chat/slack/blocks.ts
@@ -1,0 +1,264 @@
+/**
+ * Pure Block Kit builders + cost footer formatter for the Slack adapter.
+ *
+ * Kept side-effect-free so they can be unit-tested without touching the Bolt
+ * client. The Slack adapter and workflow bridge import these and feed the
+ * results into `chat.postMessage` / `chat.update`.
+ */
+import type { types } from '@slack/bolt';
+import type { TokenUsage } from '@archon/providers/types';
+
+type KnownBlock = types.KnownBlock;
+
+/** State of a single DAG node as tracked by the workflow bridge. */
+export type NodeState = 'pending' | 'running' | 'completed' | 'failed' | 'skipped';
+
+/** Terminal state for an entire workflow run, used by status block + reactions. */
+export type RunTerminalState = 'completed' | 'failed' | 'cancelled';
+
+export interface NodeSnapshot {
+  nodeId: string;
+  nodeName: string;
+  state: NodeState;
+  durationMs?: number;
+  error?: string;
+}
+
+export interface RunSnapshot {
+  runId: string;
+  workflowName: string;
+  startedAt: number;
+  nodes: NodeSnapshot[];
+  /** Set only after a terminal event arrives. */
+  terminal?: RunTerminalState;
+  /** Final cost in USD; only set once persisted on workflow_runs.metadata.total_cost_usd. */
+  totalCostUsd?: number;
+  /** Optional failure reason for failed/cancelled runs. */
+  failureReason?: string;
+}
+
+const NODE_GLYPH: Record<NodeState, string> = {
+  pending: ':white_circle:',
+  running: ':hourglass_flowing_sand:',
+  completed: ':white_check_mark:',
+  failed: ':x:',
+  skipped: ':fast_forward:',
+};
+
+const TERMINAL_HEADER: Record<RunTerminalState, string> = {
+  completed: ':white_check_mark: Workflow completed',
+  failed: ':x: Workflow failed',
+  cancelled: ':no_entry: Workflow cancelled',
+};
+
+function shortRunId(runId: string): string {
+  return runId.length > 8 ? runId.slice(0, 8) : runId;
+}
+
+function formatElapsed(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const remS = s % 60;
+  return `${m}m ${remS}s`;
+}
+
+/**
+ * Format a small italic cost footer line.
+ * Returns null when there's nothing meaningful to display (no cost AND no tokens).
+ */
+export function formatCostFooter(input: {
+  cost?: number;
+  tokens?: TokenUsage;
+  stopReason?: string;
+}): string | null {
+  const parts: string[] = [];
+  if (typeof input.cost === 'number' && Number.isFinite(input.cost)) {
+    parts.push(`cost: $${input.cost.toFixed(4)}`);
+  }
+  if (input.tokens) {
+    const summed = (input.tokens.input ?? 0) + (input.tokens.output ?? 0);
+    const total = input.tokens.total ?? summed;
+    if (total > 0) {
+      parts.push(`${formatTokenCount(total)} tokens`);
+    }
+  }
+  if (input.stopReason) {
+    parts.push(`stop: ${input.stopReason}`);
+  }
+  if (parts.length === 0) return null;
+  return `_${parts.join(' · ')}_`;
+}
+
+function formatTokenCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+/**
+ * Block Kit message for an approval gate. Includes Approve / Reject buttons
+ * whose action_ids encode the run + node so handlers stay stateless.
+ */
+export function buildApprovalBlocks(input: { runId: string; nodeId: string; message: string }): {
+  blocks: KnownBlock[];
+  fallbackText: string;
+} {
+  const blocks: KnownBlock[] = [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `:pause_button: *Approval needed* — run \`${shortRunId(input.runId)}\`\n\n${input.message}`,
+      },
+    },
+    {
+      type: 'actions',
+      block_id: `approval:${input.runId}:${input.nodeId}`,
+      elements: [
+        {
+          type: 'button',
+          style: 'primary',
+          text: { type: 'plain_text', text: 'Approve', emoji: true },
+          action_id: `approve:${input.runId}:${input.nodeId}`,
+        },
+        {
+          type: 'button',
+          style: 'danger',
+          text: { type: 'plain_text', text: 'Reject', emoji: true },
+          action_id: `reject:${input.runId}:${input.nodeId}`,
+        },
+      ],
+    },
+  ];
+  return {
+    blocks,
+    fallbackText: `Approval needed for run ${shortRunId(input.runId)}`,
+  };
+}
+
+/**
+ * Block Kit message used to show the resolution of an approval after a button
+ * was clicked. Buttons are removed so the message is no longer interactive.
+ */
+export function buildApprovalResolutionBlocks(input: {
+  runId: string;
+  nodeId: string;
+  decision: 'approved' | 'rejected';
+  actorUserId: string;
+  originalMessage: string;
+  comment?: string;
+  outcomeNote?: string;
+}): { blocks: KnownBlock[]; fallbackText: string } {
+  const icon = input.decision === 'approved' ? ':white_check_mark:' : ':x:';
+  const verb = input.decision === 'approved' ? 'Approved' : 'Rejected';
+  const lines: string[] = [
+    `${icon} *${verb}* by <@${input.actorUserId}> — run \`${shortRunId(input.runId)}\``,
+    '',
+    input.originalMessage,
+  ];
+  if (input.comment) {
+    lines.push('', `> ${input.comment}`);
+  }
+  if (input.outcomeNote) {
+    lines.push('', `_${input.outcomeNote}_`);
+  }
+  const blocks: KnownBlock[] = [
+    {
+      type: 'section',
+      text: { type: 'mrkdwn', text: lines.join('\n') },
+    },
+  ];
+  return {
+    blocks,
+    fallbackText: `${verb} run ${shortRunId(input.runId)}`,
+  };
+}
+
+/**
+ * Block Kit status message shown for the duration of a workflow run, edited
+ * in place as nodes start and complete. Includes a Cancel button while the
+ * run is non-terminal; the button is removed on terminal events.
+ */
+export function buildStatusBlocks(
+  snapshot: RunSnapshot,
+  now: number = Date.now()
+): { blocks: KnownBlock[]; fallbackText: string } {
+  const elapsed = formatElapsed(Math.max(0, now - snapshot.startedAt));
+  const header = snapshot.terminal
+    ? TERMINAL_HEADER[snapshot.terminal]
+    : ':arrows_counterclockwise: Workflow running';
+
+  const headerSection: KnownBlock = {
+    type: 'section',
+    text: {
+      type: 'mrkdwn',
+      text: `${header}\n*Workflow:* \`${snapshot.workflowName}\` · *Run:* \`${shortRunId(snapshot.runId)}\` · *Elapsed:* ${elapsed}`,
+    },
+  };
+
+  const blocks: KnownBlock[] = [headerSection];
+
+  if (snapshot.nodes.length > 0) {
+    const lines = snapshot.nodes.map(n => {
+      const glyph = NODE_GLYPH[n.state];
+      const duration =
+        n.state === 'completed' && typeof n.durationMs === 'number'
+          ? ` · ${formatElapsed(n.durationMs)}`
+          : '';
+      const errSuffix = n.state === 'failed' && n.error ? ` — ${truncate(n.error, 120)}` : '';
+      return `${glyph} \`${n.nodeName}\`${duration}${errSuffix}`;
+    });
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: lines.join('\n') },
+    });
+  }
+
+  const footerParts: string[] = [];
+  if (snapshot.terminal && typeof snapshot.totalCostUsd === 'number') {
+    footerParts.push(`total cost: $${snapshot.totalCostUsd.toFixed(4)}`);
+  }
+  if (snapshot.terminal === 'failed' && snapshot.failureReason) {
+    footerParts.push(`reason: ${truncate(snapshot.failureReason, 200)}`);
+  }
+  if (footerParts.length > 0) {
+    blocks.push({
+      type: 'context',
+      elements: [{ type: 'mrkdwn', text: footerParts.map(p => `_${p}_`).join(' · ') }],
+    });
+  }
+
+  if (!snapshot.terminal) {
+    blocks.push({
+      type: 'actions',
+      block_id: `run-controls:${snapshot.runId}`,
+      elements: [
+        {
+          type: 'button',
+          style: 'danger',
+          text: { type: 'plain_text', text: 'Cancel', emoji: true },
+          action_id: `cancel:${snapshot.runId}`,
+        },
+      ],
+    });
+  }
+
+  return {
+    blocks,
+    fallbackText: snapshot.terminal
+      ? `${TERMINAL_HEADER[snapshot.terminal]} (${snapshot.workflowName})`
+      : `Workflow ${snapshot.workflowName} running`,
+  };
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, Math.max(0, max - 1)) + '…';
+}
+
+/** Slack reaction names corresponding to workflow lifecycle states. */
+export const REACTION_RUNNING = 'arrows_counterclockwise';
+export const REACTION_SUCCESS = 'white_check_mark';
+export const REACTION_FAILURE = 'x';

--- a/packages/adapters/src/chat/slack/blocks.ts
+++ b/packages/adapters/src/chat/slack/blocks.ts
@@ -220,7 +220,10 @@ export function buildStatusBlocks(
   if (snapshot.terminal && typeof snapshot.totalCostUsd === 'number') {
     footerParts.push(`total cost: $${snapshot.totalCostUsd.toFixed(4)}`);
   }
-  if (snapshot.terminal === 'failed' && snapshot.failureReason) {
+  if (
+    (snapshot.terminal === 'failed' || snapshot.terminal === 'cancelled') &&
+    snapshot.failureReason
+  ) {
     footerParts.push(`reason: ${truncate(snapshot.failureReason, 200)}`);
   }
   if (footerParts.length > 0) {

--- a/packages/adapters/src/chat/slack/index.ts
+++ b/packages/adapters/src/chat/slack/index.ts
@@ -1,1 +1,2 @@
 export { SlackAdapter } from './adapter';
+export { SlackWorkflowBridge } from './workflow-bridge';

--- a/packages/adapters/src/chat/slack/workflow-bridge.test.ts
+++ b/packages/adapters/src/chat/slack/workflow-bridge.test.ts
@@ -1,0 +1,447 @@
+/**
+ * Unit tests for SlackWorkflowBridge.
+ *
+ * Mocks @archon/workflows/event-emitter and @archon/core so we can drive
+ * synthetic events through the bridge and assert the resulting Slack API
+ * calls (chat.postMessage / chat.update / reactions.add).
+ *
+ * NOTE: this file uses mock.module() which is process-global and irreversible
+ * in Bun. Adapter package.json keeps this test in its own `bun test`
+ * invocation so it doesn't pollute other suites.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { WorkflowEmitterEvent } from '@archon/workflows/event-emitter';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────
+
+const mockGetConversationId = mock<(runId: string) => string | undefined>(() => undefined);
+let capturedListener: ((event: WorkflowEmitterEvent) => void) | undefined;
+const mockSubscribe = mock((listener: (event: WorkflowEmitterEvent) => void) => {
+  capturedListener = listener;
+  return () => {
+    capturedListener = undefined;
+  };
+});
+
+mock.module('@archon/workflows/event-emitter', () => ({
+  getWorkflowEventEmitter: () => ({
+    subscribe: mockSubscribe,
+    getConversationId: mockGetConversationId,
+    registerRun: mock(() => {}),
+    unregisterRun: mock(() => {}),
+    emit: mock(() => {}),
+  }),
+}));
+
+const mockApproveWorkflow = mock<
+  (runId: string, comment?: string) => Promise<{ type: 'approval_gate' | 'interactive_loop' }>
+>(async () => ({ type: 'approval_gate' }));
+const mockRejectWorkflow = mock<
+  (runId: string, reason?: string) => Promise<{ cancelled: boolean; maxAttemptsReached: boolean }>
+>(async () => ({ cancelled: false, maxAttemptsReached: false }));
+const mockAbandonWorkflow = mock<(runId: string) => Promise<unknown>>(async () => ({}));
+const mockGetWorkflowRun = mock<
+  (runId: string) => Promise<{ metadata: Record<string, unknown> } | null>
+>(async () => ({ metadata: { total_cost_usd: 0.0234 } }));
+
+mock.module('@archon/core', () => ({
+  workflowOperations: {
+    approveWorkflow: mockApproveWorkflow,
+    rejectWorkflow: mockRejectWorkflow,
+    abandonWorkflow: mockAbandonWorkflow,
+  },
+  workflowDb: {
+    getWorkflowRun: mockGetWorkflowRun,
+  },
+}));
+
+// Imports must come AFTER mock.module setup.
+const { SlackWorkflowBridge } = await import('./workflow-bridge');
+const { isSlackUserAuthorized } = await import('./auth');
+// reference to silence unused import lint — we exercise the auth path indirectly.
+void isSlackUserAuthorized;
+
+// ─── Test doubles for the SlackAdapter ────────────────────────────────────
+
+interface PostedMessage {
+  channel: string;
+  thread_ts?: string;
+  text?: string;
+  blocks?: unknown[];
+}
+
+interface UpdatedMessage {
+  channel: string;
+  ts: string;
+  text?: string;
+  blocks?: unknown[];
+}
+
+interface ReactionCall {
+  channel: string;
+  timestamp: string;
+  name: string;
+}
+
+function makeFakeAdapter(allowedUserIds: string[] = []) {
+  const posted: PostedMessage[] = [];
+  const updated: UpdatedMessage[] = [];
+  const reactionsAdded: ReactionCall[] = [];
+  const reactionsRemoved: ReactionCall[] = [];
+  let nextTs = 1;
+
+  let registeredActions: Array<{ pattern: RegExp; handler: (args: unknown) => Promise<void> }> = [];
+
+  const triggerMap = new Map<string, { channel: string; ts: string }>();
+
+  const fakeApp = {
+    client: {
+      chat: {
+        postMessage: mock(async (args: PostedMessage) => {
+          posted.push(args);
+          return { ts: `${nextTs++}.000` };
+        }),
+        update: mock(async (args: UpdatedMessage) => {
+          updated.push(args);
+          return { ok: true };
+        }),
+      },
+      reactions: {
+        add: mock(async (args: ReactionCall) => {
+          reactionsAdded.push(args);
+          return { ok: true };
+        }),
+        remove: mock(async (args: ReactionCall) => {
+          reactionsRemoved.push(args);
+          return { ok: true };
+        }),
+      },
+    },
+    action: mock((pattern: RegExp, handler: (args: unknown) => Promise<void>) => {
+      registeredActions.push({ pattern, handler });
+    }),
+  };
+
+  const fakeAdapter = {
+    getApp: () => fakeApp,
+    getTriggeringMessage: (id: string) => triggerMap.get(id),
+    clearTriggeringMessage: (id: string) => {
+      triggerMap.delete(id);
+    },
+    getAllowedUserIds: () => allowedUserIds,
+  };
+
+  return {
+    adapter: fakeAdapter,
+    fakeApp,
+    posted,
+    updated,
+    reactionsAdded,
+    reactionsRemoved,
+    triggerMap,
+    actions: () => registeredActions,
+    dispatchAction: async (actionId: string, body: Record<string, unknown>) => {
+      for (const { pattern, handler } of registeredActions) {
+        if (pattern.test(actionId)) {
+          await handler({
+            ack: async () => undefined,
+            body,
+            action: { action_id: actionId },
+          });
+        }
+      }
+    },
+  };
+}
+
+async function dispatchEvent(event: WorkflowEmitterEvent): Promise<void> {
+  if (!capturedListener) throw new Error('bridge not attached');
+  capturedListener(event);
+  // Let any awaited promises in the handler settle.
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe('SlackWorkflowBridge', () => {
+  beforeEach(() => {
+    mockGetConversationId.mockReset();
+    mockSubscribe.mockClear();
+    mockApproveWorkflow.mockReset();
+    mockApproveWorkflow.mockResolvedValue({ type: 'approval_gate' });
+    mockRejectWorkflow.mockReset();
+    mockRejectWorkflow.mockResolvedValue({ cancelled: false, maxAttemptsReached: false });
+    mockAbandonWorkflow.mockReset();
+    mockAbandonWorkflow.mockResolvedValue({});
+    mockGetWorkflowRun.mockReset();
+    mockGetWorkflowRun.mockResolvedValue({ metadata: { total_cost_usd: 0.0234 } });
+    capturedListener = undefined;
+  });
+
+  afterEach(() => {
+    // No mock.restore() — see file header.
+  });
+
+  test('does nothing when there is no Slack trigger for the conversation', async () => {
+    const { adapter, posted } = makeFakeAdapter();
+    mockGetConversationId.mockReturnValue('C1:111.0');
+
+    // SUT
+    new SlackWorkflowBridge(adapter as never).attach();
+
+    await dispatchEvent({
+      type: 'workflow_started',
+      runId: 'r1',
+      workflowName: 'assist',
+      conversationId: 'conv-db-uuid',
+    });
+
+    expect(posted).toHaveLength(0);
+  });
+
+  test('workflow_started posts a status message and adds running reaction', async () => {
+    const { adapter, posted, reactionsAdded, triggerMap } = makeFakeAdapter();
+    triggerMap.set('C1:111.0', { channel: 'C1', ts: '111.0' });
+    mockGetConversationId.mockReturnValue('C1:111.0');
+
+    new SlackWorkflowBridge(adapter as never).attach();
+
+    await dispatchEvent({
+      type: 'workflow_started',
+      runId: 'r1',
+      workflowName: 'assist',
+      conversationId: 'conv-db-uuid',
+    });
+
+    expect(reactionsAdded).toContainEqual({
+      channel: 'C1',
+      timestamp: '111.0',
+      name: 'arrows_counterclockwise',
+    });
+    expect(posted).toHaveLength(1);
+    expect(posted[0]?.channel).toBe('C1');
+    expect(posted[0]?.thread_ts).toBe('111.0');
+    expect(posted[0]?.text).toContain('running');
+  });
+
+  test('approval_pending posts a Block Kit approve/reject prompt in-thread', async () => {
+    const { adapter, posted, triggerMap } = makeFakeAdapter();
+    triggerMap.set('C1:111.0', { channel: 'C1', ts: '111.0' });
+    mockGetConversationId.mockReturnValue('C1:111.0');
+
+    new SlackWorkflowBridge(adapter as never).attach();
+
+    await dispatchEvent({
+      type: 'workflow_started',
+      runId: 'r1',
+      workflowName: 'assist',
+      conversationId: 'conv-db-uuid',
+    });
+    await dispatchEvent({
+      type: 'approval_pending',
+      runId: 'r1',
+      nodeId: 'review',
+      message: 'Approve the change?',
+    });
+
+    expect(posted.length).toBeGreaterThanOrEqual(2);
+    const approval = posted[posted.length - 1];
+    expect(approval?.thread_ts).toBe('111.0');
+    expect(approval?.text).toContain('Approval needed');
+    const actionsBlock = (approval?.blocks ?? []).find(
+      (b: { type?: string }) => b?.type === 'actions'
+    ) as { elements?: Array<{ action_id?: string }> } | undefined;
+    expect(actionsBlock?.elements?.[0]?.action_id).toBe('approve:r1:review');
+    expect(actionsBlock?.elements?.[1]?.action_id).toBe('reject:r1:review');
+  });
+
+  test('approve button calls approveWorkflow and edits the message', async () => {
+    const { adapter, posted, updated, triggerMap, dispatchAction } = makeFakeAdapter();
+    triggerMap.set('C1:111.0', { channel: 'C1', ts: '111.0' });
+    mockGetConversationId.mockReturnValue('C1:111.0');
+
+    new SlackWorkflowBridge(adapter as never).attach();
+    await dispatchEvent({
+      type: 'workflow_started',
+      runId: 'r1',
+      workflowName: 'assist',
+      conversationId: 'conv-db-uuid',
+    });
+    await dispatchEvent({
+      type: 'approval_pending',
+      runId: 'r1',
+      nodeId: 'review',
+      message: 'Approve the change?',
+    });
+
+    const approvalTs = posted[posted.length - 1]?.thread_ts; // unused but ensure thread_ts captured
+    void approvalTs;
+
+    await dispatchAction('approve:r1:review', {
+      user: { id: 'U123' },
+      channel: { id: 'C1' },
+      message: { ts: '2.000' },
+    });
+
+    expect(mockApproveWorkflow).toHaveBeenCalledTimes(1);
+    expect(mockApproveWorkflow).toHaveBeenCalledWith('r1');
+    expect(updated).toHaveLength(1);
+    expect(updated[0]?.channel).toBe('C1');
+    expect(updated[0]?.ts).toBe('2.000');
+    const headerText = (updated[0]?.blocks?.[0] as { text?: { text?: string } } | undefined)?.text
+      ?.text;
+    expect(headerText).toContain('Approved');
+    expect(headerText).toContain('<@U123>');
+    expect(headerText).toContain('workflow resumed');
+  });
+
+  test('reject button under retry threshold notes workflow will retry', async () => {
+    const { adapter, updated, triggerMap, dispatchAction } = makeFakeAdapter();
+    triggerMap.set('C1:111.0', { channel: 'C1', ts: '111.0' });
+    mockGetConversationId.mockReturnValue('C1:111.0');
+    mockRejectWorkflow.mockResolvedValue({ cancelled: false, maxAttemptsReached: false });
+
+    new SlackWorkflowBridge(adapter as never).attach();
+    await dispatchEvent({
+      type: 'workflow_started',
+      runId: 'r1',
+      workflowName: 'assist',
+      conversationId: 'conv-db-uuid',
+    });
+    await dispatchEvent({
+      type: 'approval_pending',
+      runId: 'r1',
+      nodeId: 'review',
+      message: 'Approve?',
+    });
+
+    await dispatchAction('reject:r1:review', {
+      user: { id: 'U999' },
+      channel: { id: 'C1' },
+      message: { ts: '2.000' },
+    });
+
+    expect(mockRejectWorkflow).toHaveBeenCalledTimes(1);
+    const text = (updated[0]?.blocks?.[0] as { text?: { text?: string } } | undefined)?.text?.text;
+    expect(text).toContain('Rejected');
+    expect(text).toContain('will retry');
+  });
+
+  test('cancel button calls abandonWorkflow', async () => {
+    const { adapter, triggerMap, dispatchAction } = makeFakeAdapter();
+    triggerMap.set('C1:111.0', { channel: 'C1', ts: '111.0' });
+    mockGetConversationId.mockReturnValue('C1:111.0');
+
+    new SlackWorkflowBridge(adapter as never).attach();
+    await dispatchEvent({
+      type: 'workflow_started',
+      runId: 'r1',
+      workflowName: 'assist',
+      conversationId: 'conv-db-uuid',
+    });
+
+    await dispatchAction('cancel:r1', {
+      user: { id: 'U123' },
+      channel: { id: 'C1' },
+      message: { ts: '1.000' },
+    });
+
+    expect(mockAbandonWorkflow).toHaveBeenCalledTimes(1);
+    expect(mockAbandonWorkflow).toHaveBeenCalledWith('r1');
+  });
+
+  test('unauthorized click is silently dropped and no operation runs', async () => {
+    const { adapter, triggerMap, dispatchAction } = makeFakeAdapter(['U_ALLOWED']);
+    triggerMap.set('C1:111.0', { channel: 'C1', ts: '111.0' });
+    mockGetConversationId.mockReturnValue('C1:111.0');
+
+    new SlackWorkflowBridge(adapter as never).attach();
+    await dispatchEvent({
+      type: 'workflow_started',
+      runId: 'r1',
+      workflowName: 'assist',
+      conversationId: 'conv-db-uuid',
+    });
+    await dispatchEvent({
+      type: 'approval_pending',
+      runId: 'r1',
+      nodeId: 'review',
+      message: 'Approve?',
+    });
+
+    await dispatchAction('approve:r1:review', {
+      user: { id: 'U_NOT_ALLOWED' },
+      channel: { id: 'C1' },
+      message: { ts: '2.000' },
+    });
+
+    expect(mockApproveWorkflow).not.toHaveBeenCalled();
+  });
+
+  test('workflow_completed swaps reaction and posts terminal status with cost', async () => {
+    const { adapter, updated, reactionsAdded, reactionsRemoved, triggerMap } = makeFakeAdapter();
+    triggerMap.set('C1:111.0', { channel: 'C1', ts: '111.0' });
+    mockGetConversationId.mockReturnValue('C1:111.0');
+
+    new SlackWorkflowBridge(adapter as never).attach();
+    await dispatchEvent({
+      type: 'workflow_started',
+      runId: 'r1',
+      workflowName: 'assist',
+      conversationId: 'conv-db-uuid',
+    });
+    await dispatchEvent({
+      type: 'workflow_completed',
+      runId: 'r1',
+      workflowName: 'assist',
+      duration: 1234,
+    });
+
+    expect(reactionsRemoved).toContainEqual({
+      channel: 'C1',
+      timestamp: '111.0',
+      name: 'arrows_counterclockwise',
+    });
+    expect(reactionsAdded).toContainEqual({
+      channel: 'C1',
+      timestamp: '111.0',
+      name: 'white_check_mark',
+    });
+    expect(updated.length).toBeGreaterThan(0);
+    const ctx = (updated[updated.length - 1]?.blocks ?? []).find(
+      (b: { type?: string }) => b?.type === 'context'
+    ) as { elements?: Array<{ text?: string }> } | undefined;
+    expect(ctx?.elements?.[0]?.text).toContain('total cost: $0.0234');
+  });
+
+  test('workflow_failed swaps reaction to x and includes failure reason', async () => {
+    const { adapter, updated, reactionsAdded, triggerMap } = makeFakeAdapter();
+    triggerMap.set('C1:111.0', { channel: 'C1', ts: '111.0' });
+    mockGetConversationId.mockReturnValue('C1:111.0');
+    mockGetWorkflowRun.mockResolvedValue({ metadata: {} });
+
+    new SlackWorkflowBridge(adapter as never).attach();
+    await dispatchEvent({
+      type: 'workflow_started',
+      runId: 'r1',
+      workflowName: 'assist',
+      conversationId: 'conv-db-uuid',
+    });
+    await dispatchEvent({
+      type: 'workflow_failed',
+      runId: 'r1',
+      workflowName: 'assist',
+      error: 'plan node crashed',
+    });
+
+    expect(reactionsAdded).toContainEqual({
+      channel: 'C1',
+      timestamp: '111.0',
+      name: 'x',
+    });
+    const ctx = (updated[updated.length - 1]?.blocks ?? []).find(
+      (b: { type?: string }) => b?.type === 'context'
+    ) as { elements?: Array<{ text?: string }> } | undefined;
+    expect(ctx?.elements?.[0]?.text).toContain('plan node crashed');
+  });
+});

--- a/packages/adapters/src/chat/slack/workflow-bridge.test.ts
+++ b/packages/adapters/src/chat/slack/workflow-bridge.test.ts
@@ -327,6 +327,38 @@ describe('SlackWorkflowBridge', () => {
     expect(text).toContain('will retry');
   });
 
+  test('reject button at max attempts notes the run was cancelled', async () => {
+    const { adapter, updated, triggerMap, dispatchAction } = makeFakeAdapter();
+    triggerMap.set('C1:111.0', { channel: 'C1', ts: '111.0' });
+    mockGetConversationId.mockReturnValue('C1:111.0');
+    mockRejectWorkflow.mockResolvedValue({ cancelled: true, maxAttemptsReached: true });
+
+    new SlackWorkflowBridge(adapter as never).attach();
+    await dispatchEvent({
+      type: 'workflow_started',
+      runId: 'r1',
+      workflowName: 'assist',
+      conversationId: 'conv-db-uuid',
+    });
+    await dispatchEvent({
+      type: 'approval_pending',
+      runId: 'r1',
+      nodeId: 'review',
+      message: 'Approve?',
+    });
+
+    await dispatchAction('reject:r1:review', {
+      user: { id: 'U999' },
+      channel: { id: 'C1' },
+      message: { ts: '2.000' },
+    });
+
+    expect(mockRejectWorkflow).toHaveBeenCalledTimes(1);
+    const text = (updated[0]?.blocks?.[0] as { text?: { text?: string } } | undefined)?.text?.text;
+    expect(text).toContain('Rejected');
+    expect(text).toContain('max reject attempts reached');
+  });
+
   test('cancel button calls abandonWorkflow', async () => {
     const { adapter, triggerMap, dispatchAction } = makeFakeAdapter();
     triggerMap.set('C1:111.0', { channel: 'C1', ts: '111.0' });

--- a/packages/adapters/src/chat/slack/workflow-bridge.ts
+++ b/packages/adapters/src/chat/slack/workflow-bridge.ts
@@ -491,20 +491,20 @@ export class SlackWorkflowBridge {
       getLog().info({ runId, actorId: maskUserId(actorId) }, 'slack.bridge_cancel_dispatched');
     } catch (error) {
       const err = error as Error;
+      // Full error stays in logs; the user-facing message is intentionally
+      // generic so internal DB / library errors don't leak into a channel.
       getLog().warn({ err, runId }, 'slack.bridge_cancel_failed');
-      // Best effort: drop a note in-thread so the user knows the click failed.
       const state = this.runs.get(runId);
       if (state) {
-        await this.adapter
-          .getApp()
-          .client.chat.postMessage({
+        try {
+          await this.adapter.getApp().client.chat.postMessage({
             channel: state.channel,
             thread_ts: state.threadTs,
-            text: `:warning: Could not cancel run \`${runId}\`: ${err.message}`,
-          })
-          .catch(() => {
-            /* already logged */
+            text: `:warning: Could not cancel run \`${runId}\`. Check the server logs or try again.`,
           });
+        } catch (notifyError) {
+          getLog().debug({ err: notifyError as Error, runId }, 'slack.bridge_cancel_notify_failed');
+        }
       }
     }
     // The eventual workflow_cancelled event will repaint the status message.

--- a/packages/adapters/src/chat/slack/workflow-bridge.ts
+++ b/packages/adapters/src/chat/slack/workflow-bridge.ts
@@ -10,6 +10,7 @@
  * SlackAdapter.start() so app.action handlers register before app.start()
  * fires the Socket Mode connection. Call detach() on shutdown.
  */
+import type { BlockButtonAction, ButtonAction } from '@slack/bolt';
 import { createLogger } from '@archon/paths';
 import {
   getWorkflowEventEmitter,
@@ -57,12 +58,20 @@ interface RunState {
   nodes: Map<string, NodeSnapshot>;
   /** Insertion order — preserved so the status message renders nodes in arrival order. */
   nodeOrder: string[];
-  /** Trailing-edge debounce timer for chat.update. */
+  /** Leading-edge debounce timer for chat.update: the first event in a burst
+   *  arms the timer; subsequent events arriving before it fires are coalesced
+   *  because the timer reads the current run state at fire time. */
   pendingEdit?: ReturnType<typeof setTimeout>;
   /** Active approval block in this run, keyed by nodeId. */
   approvals: Map<string, ApprovalMessage>;
 }
 
+/**
+ * Coalesce window for chat.update on the run status message. Slack's
+ * chat.update rate limit is roughly one call per channel per second, so
+ * 500ms keeps the worst-case rate under that while still feeling live for
+ * DAGs where node transitions span seconds.
+ */
 const STATUS_UPDATE_DEBOUNCE_MS = 500;
 
 export class SlackWorkflowBridge {
@@ -153,7 +162,9 @@ export class SlackWorkflowBridge {
         case 'workflow_cancelled':
           await this.onTerminal(event.runId, 'cancelled', conversationId, event.reason);
           break;
-        // Loop / tool / artifact events are surface-noisy — skipped for v1.
+        // Loop / tool / artifact events would surface as noise in-thread and
+        // aren't tied to a button or actionable state; the status message
+        // already conveys whether the run is healthy via the DAG node states.
         case 'loop_iteration_started':
         case 'loop_iteration_completed':
         case 'loop_iteration_failed':
@@ -332,7 +343,9 @@ export class SlackWorkflowBridge {
   private scheduleStatusUpdate(runId: string): void {
     const state = this.runs.get(runId);
     if (!state) return;
-    if (state.pendingEdit) return; // trailing edge — first event sets the timer
+    // Leading-edge: the first event in a burst arms the timer; later events
+    // are dropped because the timer reads current state when it fires.
+    if (state.pendingEdit) return;
     state.pendingEdit = setTimeout(() => {
       state.pendingEdit = undefined;
       void this.updateStatusMessage(state);
@@ -392,6 +405,8 @@ export class SlackWorkflowBridge {
 
   private async removeReactionSafe(ref: SlackMessageRef, name: string): Promise<void> {
     try {
+      // `no_reaction` (already removed by a teammate / manual click) and rate
+      // limits are non-fatal — the terminal-state add below still fires.
       await this.adapter.getApp().client.reactions.remove({
         channel: ref.channel,
         timestamp: ref.ts,
@@ -413,25 +428,28 @@ export class SlackWorkflowBridge {
     if (this.actionHandlersRegistered) return;
     const app = this.adapter.getApp();
 
-    app.action(/^approve:/, async ({ ack, body, action }) => {
+    // Bolt's action() callback for a regex matches only block button clicks
+    // in our case, so the body/action narrow to BlockButtonAction/ButtonAction.
+    // Telling Bolt the generic shape gets us SDK-typed body.user.id etc.
+    app.action<BlockButtonAction>(/^approve:/, async ({ ack, body, action }) => {
       await ack();
-      await this.handleApprovalDecision(body as ActionBody, action as ActionElement, 'approved');
+      await this.handleApprovalDecision(body, action, 'approved');
     });
-    app.action(/^reject:/, async ({ ack, body, action }) => {
+    app.action<BlockButtonAction>(/^reject:/, async ({ ack, body, action }) => {
       await ack();
-      await this.handleApprovalDecision(body as ActionBody, action as ActionElement, 'rejected');
+      await this.handleApprovalDecision(body, action, 'rejected');
     });
-    app.action(/^cancel:/, async ({ ack, body, action }) => {
+    app.action<BlockButtonAction>(/^cancel:/, async ({ ack, body, action }) => {
       await ack();
-      await this.handleCancelClick(body as ActionBody, action as ActionElement);
+      await this.handleCancelClick(body, action);
     });
 
     this.actionHandlersRegistered = true;
   }
 
   private async handleApprovalDecision(
-    body: ActionBody,
-    action: ActionElement,
+    body: BlockButtonAction,
+    action: ButtonAction,
     decision: 'approved' | 'rejected'
   ): Promise<void> {
     const actorId = body.user?.id;
@@ -441,42 +459,51 @@ export class SlackWorkflowBridge {
     if (!parsed) return;
     const { runId, nodeId } = parsed;
 
+    // Top-level try/catch: applyResolutionEdit must also be guarded because the
+    // block builder or chat.update can throw. Bolt has no app.error registered,
+    // so an unhandled rejection here means the user sees nothing.
     let outcomeNote: string | undefined;
-    let comment: string | undefined;
     try {
-      if (decision === 'approved') {
-        const result = await workflowOperations.approveWorkflow(runId);
-        outcomeNote =
-          result.type === 'interactive_loop'
-            ? 'recorded — loop will continue on resume'
-            : 'workflow resumed';
-      } else {
-        const result = await workflowOperations.rejectWorkflow(runId);
-        outcomeNote = result.cancelled
-          ? result.maxAttemptsReached
-            ? 'cancelled — max reject attempts reached'
-            : 'cancelled'
-          : 'recorded — workflow will retry with feedback';
+      try {
+        if (decision === 'approved') {
+          const result = await workflowOperations.approveWorkflow(runId);
+          outcomeNote =
+            result.type === 'interactive_loop'
+              ? 'recorded — loop will continue on resume'
+              : 'workflow resumed';
+        } else {
+          const result = await workflowOperations.rejectWorkflow(runId);
+          outcomeNote = result.cancelled
+            ? result.maxAttemptsReached
+              ? 'cancelled — max reject attempts reached'
+              : 'cancelled'
+            : 'recorded — workflow will retry with feedback';
+        }
+      } catch (error) {
+        const err = error as Error;
+        getLog().error({ err, runId, nodeId, decision }, 'slack.bridge_approval_action_failed');
+        // Keep the user-facing note generic — full error stays in logs.
+        outcomeNote = 'error: see server logs';
       }
-    } catch (error) {
-      const err = error as Error;
-      getLog().error({ err, runId, nodeId, decision }, 'slack.bridge_approval_action_failed');
-      outcomeNote = `error: ${err.message}`;
-    }
 
-    await this.applyResolutionEdit({
-      runId,
-      nodeId,
-      decision,
-      actorId: actorId ?? 'unknown',
-      messageTs: body.message?.ts,
-      channel: body.channel?.id,
-      comment,
-      outcomeNote,
-    });
+      await this.applyResolutionEdit({
+        runId,
+        nodeId,
+        decision,
+        actorId: actorId ?? 'unknown',
+        messageTs: body.message?.ts,
+        channel: body.channel?.id,
+        outcomeNote,
+      });
+    } catch (error) {
+      getLog().error(
+        { err: error as Error, runId, nodeId, decision },
+        'slack.bridge_approval_handler_failed'
+      );
+    }
   }
 
-  private async handleCancelClick(body: ActionBody, action: ActionElement): Promise<void> {
+  private async handleCancelClick(body: BlockButtonAction, action: ButtonAction): Promise<void> {
     const actorId = body.user?.id;
     if (!this.assertAuthorized(actorId, 'cancel')) return;
 
@@ -487,27 +514,49 @@ export class SlackWorkflowBridge {
     if (!runId) return;
 
     try {
-      await workflowOperations.abandonWorkflow(runId);
-      getLog().info({ runId, actorId: maskUserId(actorId) }, 'slack.bridge_cancel_dispatched');
-    } catch (error) {
-      const err = error as Error;
-      // Full error stays in logs; the user-facing message is intentionally
-      // generic so internal DB / library errors don't leak into a channel.
-      getLog().warn({ err, runId }, 'slack.bridge_cancel_failed');
-      const state = this.runs.get(runId);
-      if (state) {
+      try {
+        await workflowOperations.abandonWorkflow(runId);
+        getLog().info({ runId, actorId: maskUserId(actorId) }, 'slack.bridge_cancel_dispatched');
+        // The eventual workflow_cancelled event will repaint the status message.
+        return;
+      } catch (error) {
+        const err = error as Error;
+        // Full error stays in logs; the user-facing message is intentionally
+        // generic so internal DB / library errors don't leak into a channel.
+        getLog().warn({ err, runId }, 'slack.bridge_cancel_failed');
+
+        // Tell the user something. If we still have run state, drop a note in
+        // the thread. Otherwise (run already terminated) try to acknowledge in
+        // the channel/thread of the message the button was attached to.
+        const state = this.runs.get(runId);
+        const fallbackChannel = body.channel?.id;
+        const fallbackThreadTs = body.message?.ts;
+        const target = state
+          ? { channel: state.channel, thread_ts: state.threadTs }
+          : fallbackChannel
+            ? { channel: fallbackChannel, thread_ts: fallbackThreadTs }
+            : undefined;
+
+        if (!target) {
+          getLog().info({ runId }, 'slack.bridge_cancel_no_target');
+          return;
+        }
+
         try {
           await this.adapter.getApp().client.chat.postMessage({
-            channel: state.channel,
-            thread_ts: state.threadTs,
-            text: `:warning: Could not cancel run \`${runId}\`. Check the server logs or try again.`,
+            channel: target.channel,
+            thread_ts: target.thread_ts,
+            text: state
+              ? `:warning: Could not cancel run \`${runId}\`. Check the server logs or try again.`
+              : `:information_source: Run \`${runId}\` already finished — nothing to cancel.`,
           });
         } catch (notifyError) {
           getLog().debug({ err: notifyError as Error, runId }, 'slack.bridge_cancel_notify_failed');
         }
       }
+    } catch (error) {
+      getLog().error({ err: error as Error, runId }, 'slack.bridge_cancel_handler_failed');
     }
-    // The eventual workflow_cancelled event will repaint the status message.
   }
 
   private async applyResolutionEdit(args: {
@@ -517,7 +566,6 @@ export class SlackWorkflowBridge {
     actorId: string;
     messageTs?: string;
     channel?: string;
-    comment?: string;
     outcomeNote?: string;
   }): Promise<void> {
     if (!args.messageTs || !args.channel) return;
@@ -533,7 +581,6 @@ export class SlackWorkflowBridge {
       decision: args.decision,
       actorUserId: args.actorId,
       originalMessage,
-      comment: args.comment,
       outcomeNote: args.outcomeNote,
     });
     try {
@@ -591,26 +638,4 @@ function maskUserId(userId: string | undefined): string {
 
 function isDefined<T>(v: T | undefined): v is T {
   return v !== undefined;
-}
-
-// ───────────────────────────────────────────────────────────────────────────
-// Narrow type aliases for Bolt action payloads.
-// We intentionally avoid the full BlockButtonAction generic gymnastics here
-// since we only consume a tiny subset.
-// ───────────────────────────────────────────────────────────────────────────
-
-/**
- * Loose subset of @slack/bolt's `SlackAction` shape covering the fields we
- * consume. Bolt's union type forces narrow checks per action variant which
- * adds noise without giving us extra safety; this alias keeps the bridge
- * focused on the values it actually uses.
- */
-export interface ActionBody {
-  user?: { id?: string };
-  channel?: { id?: string };
-  message?: { ts?: string };
-}
-
-export interface ActionElement {
-  action_id?: string;
 }

--- a/packages/adapters/src/chat/slack/workflow-bridge.ts
+++ b/packages/adapters/src/chat/slack/workflow-bridge.ts
@@ -1,0 +1,616 @@
+/**
+ * Slack workflow bridge: translates WorkflowEventEmitter events into Slack
+ * side-effects (reactions on the triggering message, in-thread status
+ * messages with DAG progress, interactive approval/reject/cancel buttons).
+ *
+ * Modelled on packages/server/src/adapters/web/workflow-bridge.ts but emits
+ * Slack chat.postMessage / chat.update / reactions.add calls instead of SSE.
+ *
+ * Lifecycle: instantiate after the SlackAdapter, call attach() BEFORE
+ * SlackAdapter.start() so app.action handlers register before app.start()
+ * fires the Socket Mode connection. Call detach() on shutdown.
+ */
+import { createLogger } from '@archon/paths';
+import {
+  getWorkflowEventEmitter,
+  type WorkflowEmitterEvent,
+} from '@archon/workflows/event-emitter';
+import { workflowOperations, workflowDb } from '@archon/core';
+import {
+  REACTION_FAILURE,
+  REACTION_RUNNING,
+  REACTION_SUCCESS,
+  buildApprovalBlocks,
+  buildApprovalResolutionBlocks,
+  buildStatusBlocks,
+  type NodeSnapshot,
+  type NodeState,
+  type RunSnapshot,
+  type RunTerminalState,
+} from './blocks';
+import { isSlackUserAuthorized } from './auth';
+import type { SlackAdapter, SlackMessageRef } from './adapter';
+
+let cachedLog: ReturnType<typeof createLogger> | undefined;
+function getLog(): ReturnType<typeof createLogger> {
+  if (!cachedLog) cachedLog = createLogger('adapter.slack.bridge');
+  return cachedLog;
+}
+
+interface ApprovalMessage {
+  channel: string;
+  ts: string;
+  /** Original message text we showed alongside the buttons; reused in the resolution edit. */
+  message: string;
+  nodeId: string;
+}
+
+interface RunState {
+  runId: string;
+  workflowName: string;
+  conversationId: string;
+  channel: string;
+  threadTs: string;
+  /** ts of the bot's status message in the thread; used by chat.update. */
+  statusMessageTs?: string;
+  startedAt: number;
+  nodes: Map<string, NodeSnapshot>;
+  /** Insertion order — preserved so the status message renders nodes in arrival order. */
+  nodeOrder: string[];
+  /** Trailing-edge debounce timer for chat.update. */
+  pendingEdit?: ReturnType<typeof setTimeout>;
+  /** Active approval block in this run, keyed by nodeId. */
+  approvals: Map<string, ApprovalMessage>;
+}
+
+const STATUS_UPDATE_DEBOUNCE_MS = 500;
+
+export class SlackWorkflowBridge {
+  private adapter: SlackAdapter;
+  private runs = new Map<string, RunState>();
+  private unsubscribeEvents: (() => void) | null = null;
+  private actionHandlersRegistered = false;
+
+  constructor(adapter: SlackAdapter) {
+    this.adapter = adapter;
+  }
+
+  /**
+   * Register app.action handlers on the Bolt app and start listening for
+   * workflow events. Must be called before SlackAdapter.start().
+   */
+  attach(): void {
+    this.registerActionHandlers();
+    const emitter = getWorkflowEventEmitter();
+    this.unsubscribeEvents = emitter.subscribe(event => {
+      void this.handleEvent(event);
+    });
+    getLog().info('slack.bridge_attached');
+  }
+
+  /** Detach event subscription. Slack app handlers cannot be deregistered. */
+  detach(): void {
+    if (this.unsubscribeEvents) {
+      this.unsubscribeEvents();
+      this.unsubscribeEvents = null;
+    }
+    for (const state of this.runs.values()) {
+      if (state.pendingEdit) clearTimeout(state.pendingEdit);
+    }
+    this.runs.clear();
+    getLog().info('slack.bridge_detached');
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Event handling
+  // ─────────────────────────────────────────────────────────────────────────
+
+  private async handleEvent(event: WorkflowEmitterEvent): Promise<void> {
+    const emitter = getWorkflowEventEmitter();
+    const conversationId = emitter.getConversationId(event.runId);
+    if (!conversationId) return;
+
+    // Skip if this conversation isn't one we have a Slack trigger for. This is
+    // how we filter Slack conversations from web/Telegram/etc. — the adapter
+    // populates `triggeringMessages` on inbound mention/DM/slash.
+    const trigger = this.adapter.getTriggeringMessage(conversationId);
+    if (!trigger) return;
+
+    try {
+      switch (event.type) {
+        case 'workflow_started':
+          await this.onWorkflowStarted(event, conversationId, trigger);
+          break;
+        case 'node_started':
+          this.upsertNode(event.runId, event.nodeId, event.nodeName, 'running');
+          this.scheduleStatusUpdate(event.runId);
+          break;
+        case 'node_completed':
+          this.upsertNode(event.runId, event.nodeId, event.nodeName, 'completed', {
+            durationMs: event.duration,
+          });
+          this.scheduleStatusUpdate(event.runId);
+          break;
+        case 'node_failed':
+          this.upsertNode(event.runId, event.nodeId, event.nodeName, 'failed', {
+            error: event.error,
+          });
+          this.scheduleStatusUpdate(event.runId);
+          break;
+        case 'node_skipped':
+          this.upsertNode(event.runId, event.nodeId, event.nodeName, 'skipped');
+          this.scheduleStatusUpdate(event.runId);
+          break;
+        case 'approval_pending':
+          await this.onApprovalPending(event);
+          break;
+        case 'workflow_completed':
+          await this.onTerminal(event.runId, 'completed', conversationId);
+          break;
+        case 'workflow_failed':
+          await this.onTerminal(event.runId, 'failed', conversationId, event.error);
+          break;
+        case 'workflow_cancelled':
+          await this.onTerminal(event.runId, 'cancelled', conversationId, event.reason);
+          break;
+        // Loop / tool / artifact events are surface-noisy — skipped for v1.
+        case 'loop_iteration_started':
+        case 'loop_iteration_completed':
+        case 'loop_iteration_failed':
+        case 'tool_started':
+        case 'tool_completed':
+        case 'workflow_artifact':
+          break;
+        default: {
+          const exhaustive: never = event;
+          getLog().warn(
+            { type: (exhaustive as { type: string }).type },
+            'slack.bridge_unhandled_event'
+          );
+        }
+      }
+    } catch (error) {
+      getLog().error(
+        { err: error as Error, eventType: event.type, runId: event.runId },
+        'slack.bridge_event_handler_failed'
+      );
+    }
+  }
+
+  private async onWorkflowStarted(
+    event: WorkflowEmitterEvent & { type: 'workflow_started' },
+    conversationId: string,
+    trigger: SlackMessageRef
+  ): Promise<void> {
+    const [channel, threadTs] = splitConversationId(conversationId);
+    if (!threadTs) {
+      getLog().warn({ conversationId }, 'slack.bridge_no_thread_ts');
+      return;
+    }
+    const state: RunState = {
+      runId: event.runId,
+      workflowName: event.workflowName,
+      conversationId,
+      channel,
+      threadTs,
+      startedAt: Date.now(),
+      nodes: new Map(),
+      nodeOrder: [],
+      approvals: new Map(),
+    };
+    this.runs.set(event.runId, state);
+
+    await this.addReactionSafe(trigger, REACTION_RUNNING);
+
+    const { blocks, fallbackText } = buildStatusBlocks(this.snapshot(state));
+    try {
+      const result = await this.adapter.getApp().client.chat.postMessage({
+        channel,
+        thread_ts: threadTs,
+        text: fallbackText,
+        blocks,
+      });
+      state.statusMessageTs = result.ts ?? undefined;
+    } catch (error) {
+      getLog().warn(
+        { err: error as Error, runId: event.runId, channel },
+        'slack.bridge_status_post_failed'
+      );
+    }
+  }
+
+  private async onApprovalPending(
+    event: WorkflowEmitterEvent & { type: 'approval_pending' }
+  ): Promise<void> {
+    const state = this.runs.get(event.runId);
+    if (!state) {
+      getLog().warn({ runId: event.runId }, 'slack.bridge_approval_no_run');
+      return;
+    }
+    const { blocks, fallbackText } = buildApprovalBlocks({
+      runId: event.runId,
+      nodeId: event.nodeId,
+      message: event.message,
+    });
+    try {
+      const result = await this.adapter.getApp().client.chat.postMessage({
+        channel: state.channel,
+        thread_ts: state.threadTs,
+        text: fallbackText,
+        blocks,
+      });
+      if (result.ts) {
+        state.approvals.set(event.nodeId, {
+          channel: state.channel,
+          ts: result.ts,
+          message: event.message,
+          nodeId: event.nodeId,
+        });
+      }
+    } catch (error) {
+      getLog().warn(
+        { err: error as Error, runId: event.runId, nodeId: event.nodeId },
+        'slack.bridge_approval_post_failed'
+      );
+    }
+  }
+
+  private async onTerminal(
+    runId: string,
+    terminal: RunTerminalState,
+    conversationId: string,
+    reason?: string
+  ): Promise<void> {
+    const state = this.runs.get(runId);
+    const trigger = this.adapter.getTriggeringMessage(conversationId);
+
+    // Replace running reaction with the terminal one.
+    if (trigger) {
+      await this.removeReactionSafe(trigger, REACTION_RUNNING);
+      await this.addReactionSafe(
+        trigger,
+        terminal === 'completed' ? REACTION_SUCCESS : REACTION_FAILURE
+      );
+    }
+
+    if (state) {
+      // Cancel any pending debounce.
+      if (state.pendingEdit) {
+        clearTimeout(state.pendingEdit);
+        state.pendingEdit = undefined;
+      }
+
+      // Pull final cost from the workflow run record (best-effort).
+      let totalCostUsd: number | undefined;
+      try {
+        const run = await workflowDb.getWorkflowRun(runId);
+        const raw = run?.metadata?.total_cost_usd;
+        if (typeof raw === 'number' && Number.isFinite(raw)) totalCostUsd = raw;
+      } catch (error) {
+        getLog().debug({ err: error as Error, runId }, 'slack.bridge_cost_lookup_failed');
+      }
+
+      await this.updateStatusMessage(state, {
+        terminal,
+        totalCostUsd,
+        failureReason: terminal === 'completed' ? undefined : reason,
+      });
+
+      this.runs.delete(runId);
+    }
+
+    // Triggering message is no longer needed for this conversation once the
+    // run has terminated. (Reactions stay — we only clear the map entry.)
+    this.adapter.clearTriggeringMessage(conversationId);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Status-message update plumbing
+  // ─────────────────────────────────────────────────────────────────────────
+
+  private upsertNode(
+    runId: string,
+    nodeId: string,
+    nodeName: string,
+    state: NodeState,
+    extra: { durationMs?: number; error?: string } = {}
+  ): void {
+    const run = this.runs.get(runId);
+    if (!run) return;
+    if (!run.nodes.has(nodeId)) {
+      run.nodeOrder.push(nodeId);
+    }
+    run.nodes.set(nodeId, {
+      nodeId,
+      nodeName,
+      state,
+      durationMs: extra.durationMs,
+      error: extra.error,
+    });
+  }
+
+  private scheduleStatusUpdate(runId: string): void {
+    const state = this.runs.get(runId);
+    if (!state) return;
+    if (state.pendingEdit) return; // trailing edge — first event sets the timer
+    state.pendingEdit = setTimeout(() => {
+      state.pendingEdit = undefined;
+      void this.updateStatusMessage(state);
+    }, STATUS_UPDATE_DEBOUNCE_MS);
+  }
+
+  private async updateStatusMessage(
+    state: RunState,
+    overlay: Partial<Pick<RunSnapshot, 'terminal' | 'totalCostUsd' | 'failureReason'>> = {}
+  ): Promise<void> {
+    if (!state.statusMessageTs) return;
+    const snapshot: RunSnapshot = { ...this.snapshot(state), ...overlay };
+    const { blocks, fallbackText } = buildStatusBlocks(snapshot);
+    try {
+      await this.adapter.getApp().client.chat.update({
+        channel: state.channel,
+        ts: state.statusMessageTs,
+        text: fallbackText,
+        blocks,
+      });
+    } catch (error) {
+      getLog().warn(
+        { err: error as Error, runId: state.runId, ts: state.statusMessageTs },
+        'slack.bridge_status_update_failed'
+      );
+    }
+  }
+
+  private snapshot(state: RunState): RunSnapshot {
+    return {
+      runId: state.runId,
+      workflowName: state.workflowName,
+      startedAt: state.startedAt,
+      nodes: state.nodeOrder.map(id => state.nodes.get(id)).filter(isDefined),
+    };
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Reactions
+  // ─────────────────────────────────────────────────────────────────────────
+
+  private async addReactionSafe(ref: SlackMessageRef, name: string): Promise<void> {
+    try {
+      await this.adapter.getApp().client.reactions.add({
+        channel: ref.channel,
+        timestamp: ref.ts,
+        name,
+      });
+    } catch (error) {
+      // `already_reacted` and rate limits are non-fatal — just log.
+      getLog().debug(
+        { err: error as Error, channel: ref.channel, name },
+        'slack.bridge_reaction_add_failed'
+      );
+    }
+  }
+
+  private async removeReactionSafe(ref: SlackMessageRef, name: string): Promise<void> {
+    try {
+      await this.adapter.getApp().client.reactions.remove({
+        channel: ref.channel,
+        timestamp: ref.ts,
+        name,
+      });
+    } catch (error) {
+      getLog().debug(
+        { err: error as Error, channel: ref.channel, name },
+        'slack.bridge_reaction_remove_failed'
+      );
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Block Kit action handlers
+  // ─────────────────────────────────────────────────────────────────────────
+
+  private registerActionHandlers(): void {
+    if (this.actionHandlersRegistered) return;
+    const app = this.adapter.getApp();
+
+    app.action(/^approve:/, async ({ ack, body, action }) => {
+      await ack();
+      await this.handleApprovalDecision(body as ActionBody, action as ActionElement, 'approved');
+    });
+    app.action(/^reject:/, async ({ ack, body, action }) => {
+      await ack();
+      await this.handleApprovalDecision(body as ActionBody, action as ActionElement, 'rejected');
+    });
+    app.action(/^cancel:/, async ({ ack, body, action }) => {
+      await ack();
+      await this.handleCancelClick(body as ActionBody, action as ActionElement);
+    });
+
+    this.actionHandlersRegistered = true;
+  }
+
+  private async handleApprovalDecision(
+    body: ActionBody,
+    action: ActionElement,
+    decision: 'approved' | 'rejected'
+  ): Promise<void> {
+    const actorId = body.user?.id;
+    if (!this.assertAuthorized(actorId, decision)) return;
+
+    const parsed = parseActionId(action.action_id ?? '', decision);
+    if (!parsed) return;
+    const { runId, nodeId } = parsed;
+
+    let outcomeNote: string | undefined;
+    let comment: string | undefined;
+    try {
+      if (decision === 'approved') {
+        const result = await workflowOperations.approveWorkflow(runId);
+        outcomeNote =
+          result.type === 'interactive_loop'
+            ? 'recorded — loop will continue on resume'
+            : 'workflow resumed';
+      } else {
+        const result = await workflowOperations.rejectWorkflow(runId);
+        outcomeNote = result.cancelled
+          ? result.maxAttemptsReached
+            ? 'cancelled — max reject attempts reached'
+            : 'cancelled'
+          : 'recorded — workflow will retry with feedback';
+      }
+    } catch (error) {
+      const err = error as Error;
+      getLog().error({ err, runId, nodeId, decision }, 'slack.bridge_approval_action_failed');
+      outcomeNote = `error: ${err.message}`;
+    }
+
+    await this.applyResolutionEdit({
+      runId,
+      nodeId,
+      decision,
+      actorId: actorId ?? 'unknown',
+      messageTs: body.message?.ts,
+      channel: body.channel?.id,
+      comment,
+      outcomeNote,
+    });
+  }
+
+  private async handleCancelClick(body: ActionBody, action: ActionElement): Promise<void> {
+    const actorId = body.user?.id;
+    if (!this.assertAuthorized(actorId, 'cancel')) return;
+
+    const actionId = action.action_id ?? '';
+    const match = /^cancel:(.+)$/.exec(actionId);
+    if (!match) return;
+    const runId = match[1] ?? '';
+    if (!runId) return;
+
+    try {
+      await workflowOperations.abandonWorkflow(runId);
+      getLog().info({ runId, actorId: maskUserId(actorId) }, 'slack.bridge_cancel_dispatched');
+    } catch (error) {
+      const err = error as Error;
+      getLog().warn({ err, runId }, 'slack.bridge_cancel_failed');
+      // Best effort: drop a note in-thread so the user knows the click failed.
+      const state = this.runs.get(runId);
+      if (state) {
+        await this.adapter
+          .getApp()
+          .client.chat.postMessage({
+            channel: state.channel,
+            thread_ts: state.threadTs,
+            text: `:warning: Could not cancel run \`${runId}\`: ${err.message}`,
+          })
+          .catch(() => {
+            /* already logged */
+          });
+      }
+    }
+    // The eventual workflow_cancelled event will repaint the status message.
+  }
+
+  private async applyResolutionEdit(args: {
+    runId: string;
+    nodeId: string;
+    decision: 'approved' | 'rejected';
+    actorId: string;
+    messageTs?: string;
+    channel?: string;
+    comment?: string;
+    outcomeNote?: string;
+  }): Promise<void> {
+    if (!args.messageTs || !args.channel) return;
+    const state = this.runs.get(args.runId);
+    const approval = state?.approvals.get(args.nodeId);
+    const originalMessage = approval?.message ?? '(approval gate)';
+    if (state) {
+      state.approvals.delete(args.nodeId);
+    }
+    const { blocks, fallbackText } = buildApprovalResolutionBlocks({
+      runId: args.runId,
+      nodeId: args.nodeId,
+      decision: args.decision,
+      actorUserId: args.actorId,
+      originalMessage,
+      comment: args.comment,
+      outcomeNote: args.outcomeNote,
+    });
+    try {
+      await this.adapter.getApp().client.chat.update({
+        channel: args.channel,
+        ts: args.messageTs,
+        text: fallbackText,
+        blocks,
+      });
+    } catch (error) {
+      getLog().warn(
+        { err: error as Error, runId: args.runId, decision: args.decision },
+        'slack.bridge_resolution_update_failed'
+      );
+    }
+  }
+
+  private assertAuthorized(
+    userId: string | undefined,
+    surface: 'approved' | 'rejected' | 'cancel'
+  ): boolean {
+    if (isSlackUserAuthorized(userId, this.adapter.getAllowedUserIds())) return true;
+    getLog().info({ maskedUserId: maskUserId(userId), surface }, 'slack.bridge_unauthorized_click');
+    return false;
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Helpers
+// ───────────────────────────────────────────────────────────────────────────
+
+function splitConversationId(conversationId: string): [string, string | undefined] {
+  if (!conversationId.includes(':')) return [conversationId, undefined];
+  const idx = conversationId.indexOf(':');
+  return [conversationId.slice(0, idx), conversationId.slice(idx + 1)];
+}
+
+function parseActionId(
+  actionId: string,
+  prefix: 'approved' | 'rejected'
+): { runId: string; nodeId: string } | null {
+  const expected = prefix === 'approved' ? 'approve' : 'reject';
+  const match = new RegExp(`^${expected}:([^:]+):(.+)$`).exec(actionId);
+  if (!match) return null;
+  const runId = match[1] ?? '';
+  const nodeId = match[2] ?? '';
+  if (!runId || !nodeId) return null;
+  return { runId, nodeId };
+}
+
+function maskUserId(userId: string | undefined): string {
+  if (!userId) return 'unknown';
+  return `${userId.slice(0, 4)}***`;
+}
+
+function isDefined<T>(v: T | undefined): v is T {
+  return v !== undefined;
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Narrow type aliases for Bolt action payloads.
+// We intentionally avoid the full BlockButtonAction generic gymnastics here
+// since we only consume a tiny subset.
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Loose subset of @slack/bolt's `SlackAction` shape covering the fields we
+ * consume. Bolt's union type forces narrow checks per action variant which
+ * adds noise without giving us extra safety; this alias keeps the bridge
+ * focused on the values it actually uses.
+ */
+export interface ActionBody {
+  user?: { id?: string };
+  channel?: { id?: string };
+  message?: { ts?: string };
+}
+
+export interface ActionElement {
+  action_id?: string;
+}

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -1,6 +1,6 @@
 // Chat adapters
 export { TelegramAdapter } from './chat/telegram';
-export { SlackAdapter } from './chat/slack';
+export { SlackAdapter, SlackWorkflowBridge } from './chat/slack';
 
 // Forge adapters
 export { GitHubAdapter } from './forge/github';

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -15,7 +15,7 @@ import type {
   Codebase,
   AttachedFile,
 } from '../types';
-import type { SendQueryOptions } from '@archon/providers/types';
+import type { SendQueryOptions, TokenUsage } from '@archon/providers/types';
 import { ConversationNotFoundError } from '../types';
 import * as db from '../db/conversations';
 import * as codebaseDb from '../db/codebases';
@@ -1052,6 +1052,7 @@ async function handleStreamMode(
   let newSessionId: string | undefined;
   let commandDetected = false;
   let commandFullyParsed = false;
+  let lastResult: { cost?: number; tokens?: TokenUsage; stopReason?: string } | undefined;
 
   for await (const msg of aiClient.sendQuery(
     fullPrompt,
@@ -1151,6 +1152,11 @@ async function handleStreamMode(
       if (!commandDetected && platform.sendStructuredEvent) {
         await platform.sendStructuredEvent(conversationId, msg);
       }
+      lastResult = {
+        cost: msg.cost,
+        tokens: msg.tokens,
+        stopReason: msg.stopReason,
+      };
     }
   }
 
@@ -1199,6 +1205,7 @@ async function handleStreamMode(
   }
 
   // Text was already streamed — nothing more to send
+  await maybeSendResultFooter(platform, conversationId, lastResult);
 }
 
 // ─── Batch Mode ─────────────────────────────────────────────────────────────
@@ -1229,6 +1236,7 @@ async function handleBatchMode(
   let newSessionId: string | undefined;
   let commandDetected = false;
   let commandFullyParsed = false;
+  let lastResult: { cost?: number; tokens?: TokenUsage; stopReason?: string } | undefined;
 
   for await (const msg of aiClient.sendQuery(
     fullPrompt,
@@ -1326,6 +1334,11 @@ async function handleBatchMode(
         }
         return;
       }
+      lastResult = {
+        cost: msg.cost,
+        tokens: msg.tokens,
+        stopReason: msg.stopReason,
+      };
     }
 
     // Always enforce the total-chunk cap regardless of commandDetected — allChunks grows
@@ -1406,6 +1419,28 @@ async function handleBatchMode(
   // No orchestrator commands — send the clean response
   getLog().debug({ messageLength: finalMessage.length }, 'sending_final_message');
   await platform.sendMessage(conversationId, finalMessage);
+  await maybeSendResultFooter(platform, conversationId, lastResult);
+}
+
+/**
+ * Call the adapter's optional `sendResultFooter` hook with the final result
+ * metadata from a direct-chat turn. Skips when the adapter doesn't implement
+ * it, when there's no metadata to surface, or when the call itself fails —
+ * cost footers are informational and must not block the conversation.
+ */
+async function maybeSendResultFooter(
+  platform: IPlatformAdapter,
+  conversationId: string,
+  info: { cost?: number; tokens?: TokenUsage; stopReason?: string } | undefined
+): Promise<void> {
+  if (!info) return;
+  if (info.cost === undefined && info.tokens === undefined) return;
+  if (!platform.sendResultFooter) return;
+  try {
+    await platform.sendResultFooter(conversationId, info);
+  } catch (error) {
+    getLog().warn({ err: toError(error), conversationId }, 'orchestrator.result_footer_failed');
+  }
 }
 
 // ─── Orchestrator Command Handlers ──────────────────────────────────────────

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -160,6 +160,22 @@ export interface IPlatformAdapter {
 
   /** Retract previously streamed text (used when workflow routing intercepts) */
   emitRetract?(conversationId: string): Promise<void>;
+
+  /**
+   * Optional: Append a small footer summarising cost / token usage / stop reason
+   * after a direct-chat assistant turn. Implemented by adapters that surface
+   * usage info in-band (e.g. Slack posts an italic context line). No-op for
+   * adapters that don't care; orchestrator skips the call when both `cost`
+   * and `tokens` are absent.
+   */
+  sendResultFooter?(
+    conversationId: string,
+    info: {
+      cost?: number;
+      tokens?: { input: number; output: number; total?: number; cost?: number };
+      stopReason?: string;
+    }
+  ): Promise<void>;
 }
 
 /**

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -5,8 +5,8 @@ import type { TransitionTrigger } from '../state/session-transitions';
 import type { WorkflowDefinition } from '@archon/workflows/schemas/workflow';
 import { z } from 'zod';
 
-// MessageChunk imported for use in IPlatformAdapter/IWebPlatformAdapter below
-import type { MessageChunk } from '@archon/providers/types';
+// MessageChunk + TokenUsage are used by IPlatformAdapter below.
+import type { MessageChunk, TokenUsage } from '@archon/providers/types';
 
 /**
  * Custom error for when a conversation is not found during update operations
@@ -170,11 +170,7 @@ export interface IPlatformAdapter {
    */
   sendResultFooter?(
     conversationId: string,
-    info: {
-      cost?: number;
-      tokens?: { input: number; output: number; total?: number; cost?: number };
-      stopReason?: string;
-    }
+    info: { cost?: number; tokens?: TokenUsage; stopReason?: string }
   ): Promise<void>;
 }
 

--- a/packages/docs-web/src/content/docs/adapters/slack.md
+++ b/packages/docs-web/src/content/docs/adapters/slack.md
@@ -54,7 +54,7 @@ Archon uses **Socket Mode** for Slack integration, which means:
 2. Scroll down to **Scopes** > **Bot Token Scopes**
 3. Add these scopes to bot token scopes:
    - `app_mentions:read` -- Receive @mention events
-   - `chat:write` -- Send messages
+   - `chat:write` -- Send and edit messages (covers `chat.update` on the bot's own messages)
    - `channels:history` -- Read messages in public channels (for thread context)
    - `channels:join` -- Allow bot to join public channels
    - `groups:history` -- Read messages in private channels (optional)
@@ -63,6 +63,8 @@ Archon uses **Socket Mode** for Slack integration, which means:
    - `im:read` -- Read DM history (for DM support)
    - `mpim:history` -- Read group DM history (optional)
    - `mpim:write` -- Send group DMs
+   - `reactions:write` -- Add lifecycle reactions (🔄 / ✅ / ❌) to the triggering message
+   - `commands` -- Required for the `/archon` and `/archon-workflow` slash commands
 
 ## Step 4: Subscribe to Events
 
@@ -74,6 +76,39 @@ Archon uses **Socket Mode** for Slack integration, which means:
    - `message.channels` -- Messages in public channels (optional, for broader context)
    - `message.groups` -- Messages in private channels (optional)
 4. Click **Save Changes**
+
+## Step 4b: Enable Interactivity
+
+Interactive buttons (Approve / Reject / Cancel on workflow runs) ride the same
+Socket Mode connection -- no public URL needed.
+
+1. In the left sidebar, click **Interactivity & Shortcuts**
+2. Toggle **Interactivity** to ON
+3. Leave the **Request URL** field blank -- Socket Mode handles routing
+4. Click **Save Changes**
+
+## Step 4c: Register Slash Commands
+
+Two slash commands give the team an alternative to @mention:
+
+| Command | What it does |
+| --- | --- |
+| `/archon <message>` | Talks to Archon in the current channel. Equivalent to `@archon <message>`. |
+| `/archon-workflow <subcommand>` | Direct workflow control. Supports `list`, `status`, `run <name> <args>`, `approve <id> [comment]`, `reject <id> [reason]`, `abandon <id>`, `resume <id>`. |
+
+For each command:
+
+1. In the left sidebar, click **Slash Commands**
+2. Click **Create New Command**
+3. Fill in:
+   - **Command**: `/archon` (or `/archon-workflow`)
+   - **Request URL**: leave blank -- Socket Mode handles routing
+   - **Short Description**: e.g. "Talk to Archon" or "Archon workflow control"
+   - **Usage Hint**: e.g. `<message>` or `<subcommand>`
+4. Save
+
+Reinstall the app (Step 5) after adding scopes or commands so Slack issues a
+fresh token with the new permissions.
 
 ## Step 5: Install to Workspace
 
@@ -147,6 +182,29 @@ You can also DM the bot directly -- no @mention needed:
 ```
 /help
 ```
+
+## In-Thread UX
+
+When a workflow runs in a Slack thread, Archon now:
+
+- Adds 🔄 to your triggering message when the run starts, and swaps it for ✅
+  on completion or ❌ on failure / cancellation
+- Posts a single status message in the thread that's edited in place as DAG
+  nodes start, complete, fail, or get skipped
+- Renders approval gates as interactive **Approve** / **Reject** buttons
+  in-thread -- no need to leave Slack to resume a paused run
+- Adds a **Cancel** button on the status message while the run is
+  non-terminal, so anyone on the allowed user list can abandon a runaway run
+  with a click
+- Appends a small italic cost / token footer after direct-chat replies
+  (e.g. `_cost: $0.0234 · 12.4k tokens · stop: end_turn_`) and on the
+  final status message when a workflow completes
+- Annotates long responses split across multiple Slack messages with
+  `_part i/n_` footers so it's clear they belong together
+
+All clicks on Approve / Reject / Cancel run through the same
+`SLACK_ALLOWED_USER_IDS` whitelist as inbound messages -- unauthorized
+clicks are silently dropped and logged.
 
 ## Troubleshooting
 

--- a/packages/docs-web/src/content/docs/guides/approval-nodes.md
+++ b/packages/docs-web/src/content/docs/guides/approval-nodes.md
@@ -55,9 +55,10 @@ to the user on whatever platform they're using (CLI, Slack, GitHub, etc.). On th
    block the worktree path guard (no other workflow can start on the same path).
 4. **Approve**: The user approves, which writes a `node_completed` event for
    the approval node and transitions the run to resumable. Natural-language
-   messages, the CLI, and the Web UI approve button all auto-resume the
-   workflow from the paused gate. (The explicit `/workflow approve <run-id>`
-   slash command also auto-resumes when issued in the originating conversation.)
+   messages, the CLI, the Web UI approve button, and the in-thread **Approve**
+   button posted by the Slack adapter all auto-resume the workflow from the
+   paused gate. (The explicit `/workflow approve <run-id>` slash command also
+   auto-resumes when issued in the originating conversation.)
 5. **Reject**: The user rejects.
    - **Without `on_reject`**: The workflow is cancelled immediately.
    - **With `on_reject`**: The executor runs the `on_reject.prompt` via AI (with

--- a/packages/docs-web/src/content/docs/reference/architecture.md
+++ b/packages/docs-web/src/content/docs/reference/architecture.md
@@ -104,6 +104,9 @@ export interface IPlatformAdapter {
 
   // Optional: Retract previously streamed text (workflow routing intercept)
   emitRetract?(conversationId: string): Promise<void>;
+
+  // Optional: Append a cost / token footer after a direct-chat reply
+  sendResultFooter?(conversationId: string, info: { cost?: number; tokens?: TokenUsage; stopReason?: string }): Promise<void>;
 }
 ```
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -55,7 +55,13 @@ registerCommunityProviders();
 
 import { OpenAPIHono } from '@hono/zod-openapi';
 import { validationErrorHook } from './routes/openapi-defaults';
-import { TelegramAdapter, GitHubAdapter, DiscordAdapter, SlackAdapter } from '@archon/adapters';
+import {
+  TelegramAdapter,
+  GitHubAdapter,
+  DiscordAdapter,
+  SlackAdapter,
+  SlackWorkflowBridge,
+} from '@archon/adapters';
 import { GiteaAdapter } from '@archon/adapters/community/forge/gitea';
 import { GitLabAdapter } from '@archon/adapters/community/forge/gitlab';
 import { WebAdapter } from './adapters/web';
@@ -456,6 +462,12 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
           })
           .catch(createMessageErrorHandler('Slack', slackAdapter, conversationId));
       });
+
+      // Attach the workflow bridge BEFORE app.start(): Bolt's Socket Mode
+      // refuses new event-handler registrations once the connection is open,
+      // so `app.action(...)` calls inside the bridge must run first.
+      const slackBridge = new SlackWorkflowBridge(slack);
+      slackBridge.attach();
 
       await slack.start();
       activePlatforms.push('Slack');

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -269,6 +269,7 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
   let gitlab: GitLabAdapter | null = null;
   let discord: DiscordAdapter | null = null;
   let slack: SlackAdapter | null = null;
+  let slackBridge: SlackWorkflowBridge | null = null;
 
   if (!opts.skipPlatformAdapters) {
     // Check that at least one platform is configured
@@ -466,7 +467,7 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
       // Attach the workflow bridge BEFORE app.start(): Bolt's Socket Mode
       // refuses new event-handler registrations once the connection is open,
       // so `app.action(...)` calls inside the bridge must run first.
-      const slackBridge = new SlackWorkflowBridge(slack);
+      slackBridge = new SlackWorkflowBridge(slack);
       slackBridge.attach();
 
       await slack.start();
@@ -672,6 +673,9 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
         try {
           telegram?.stop();
           discord?.stop();
+          // Detach Slack workflow bridge BEFORE stopping the adapter so a
+          // pending debounced chat.update can't fire against a closed socket.
+          slackBridge?.detach();
           slack?.stop();
           gitea?.stop();
           gitlab?.stop();


### PR DESCRIPTION
## Summary

- **Problem**: Slack adapter feels frozen during long workflows, has no in-thread interactivity, and surfaces no cost data. Approval gates force users to leave Slack for the web UI.
- **Why it matters**: First step toward a shared team Slack instance — these are the cheapest, highest-impact UX gaps without touching the schema or breaking the single-user model.
- **What changed**: Block Kit Approve/Reject/Cancel buttons, lifecycle reactions (🔄/✅/❌) on the triggering message, an in-thread status message edited in place as DAG nodes progress, `/archon` + `/archon-workflow` slash commands over Socket Mode, `_part i/n_` annotations on split messages, and an italic cost/token footer after assistant replies.
- **What did *not* change (scope boundary)**: No `user_id` plumbing (deferred — needs schema migration), no other adapters (Telegram/Discord/GitHub untouched), no workflow engine / event emitter changes, no DB schema changes.

## UX Journey

### Before

```
User mentions @archon in #channel
    │
    ▼
Bot creates thread, posts replies
    │
    ▼
Workflow runs silently — thread appears frozen
    │
    ▼
Approval gate hits  ──▶  user opens Web UI to click Approve
    │
    ▼
Workflow ends, final reply posted (no cost info, no status indicator)
```

### After

```
User mentions @archon in #channel
    │
    ▼
[🔄] reaction added to user's message
    │
    ▼
Bot posts [status message] in thread:
   :arrows_counterclockwise: Workflow running
   Workflow: assist · Run: a1b2c3d4 · Elapsed: 12s
   :hourglass_flowing_sand: `plan`
   :white_circle: `apply`
   [Cancel button]
    │  (chat.update as nodes start/complete, debounced 500ms)
    ▼
Approval gate?  ──▶  [Block Kit message with Approve / Reject buttons in-thread]
                     click → operation runs → message edits to "Approved by @alice — workflow resumed"
    │
    ▼
Workflow ends:
  [🔄] removed → [✅] (or [❌])
  Status message → "Workflow completed · total cost: $0.0234"
  Direct-chat replies get appended: `_cost: $0.0234 · 12.4k tokens · stop: end_turn_`

Plus: `/archon-workflow list` / `status` / `approve <id>` etc. work natively from any channel
```

## Architecture Diagram

### Before

```
                 ┌──────────────────────┐
                 │ WorkflowEventEmitter │
                 └──────────┬───────────┘
                            │
              ┌─────────────┴───────────┐
              │                         │
              ▼                         ▼
   ┌────────────────────┐    (no other subscribers)
   │ WebEventBridge     │
   │ (SSE → web UI)     │
   └────────────────────┘

   Slack flow:
   SlackAdapter ──▶ messageHandler ──▶ Orchestrator ──▶ Provider
        ▲                                                  │
        └────────────── sendMessage ◀──────────────────────┘
```

### After

```
                 ┌──────────────────────┐
                 │ WorkflowEventEmitter │
                 └──────────┬───────────┘
                            │
              ┌─────────────┴───────────┐
              │                         │
              ▼                         ▼
   ┌────────────────────┐    ┌─────────────────────────┐
   │ WebEventBridge     │    │ SlackWorkflowBridge [+] │
   │ (SSE → web UI)     │    │ (reactions / status /   │
   └────────────────────┘    │  buttons via Bolt app)  │
                             └────────────┬────────────┘
                                          │ getApp().client.*
                                          ▼
   Slack flow (modified):     ┌────────────────────┐
   SlackAdapter [~] ─────────▶│ SlackAdapter app   │
     │   ↑                    │ - chat.postMessage │
     │   │                    │ - chat.update [+]  │
     │   │ sendResultFooter[+]│ - reactions.add[+] │
     │   │                    │ - app.action(...)[+]
     │   │                    │ - app.command(...)[+]
     │   │                    └────────────────────┘
     ▼   │
   messageHandler ──▶ Orchestrator [~] ──▶ Provider
                       (captures `result`
                        chunk, calls
                        sendResultFooter)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `WorkflowEventEmitter` | `SlackWorkflowBridge` | **new** | Bridge subscribes globally, filters Slack convs via `adapter.getTriggeringMessage` |
| `SlackWorkflowBridge` | `SlackAdapter.getApp().client.chat.*` | **new** | postMessage, update for status + approval blocks |
| `SlackWorkflowBridge` | `SlackAdapter.getApp().client.reactions.*` | **new** | reactions.add/remove on triggering message |
| `SlackWorkflowBridge` | `workflowOperations.{approveWorkflow,rejectWorkflow,abandonWorkflow}` | **new** | Button handlers call existing operations |
| `SlackWorkflowBridge` | `workflowDb.getWorkflowRun` | **new** | Reads `metadata.total_cost_usd` on terminal events |
| `SlackAdapter.start()` | `app.command('/archon'\|'/archon-workflow')` | **new** | Slash command handlers |
| `Orchestrator` | `IPlatformAdapter.sendResultFooter` | **new** (optional) | Called at end of direct-chat turns; Slack implements, others no-op |
| `server/index.ts` | `SlackWorkflowBridge` | **new** | Attaches bridge before `slack.start()` |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: L`
- Scope: `adapters`
- Module: `adapters:slack`

## Change Metadata

- Change type: `feature`
- Primary scope: `adapters`

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked) — none
- Supersedes # (if replacing older PR) — none

## Validation Evidence (required)

```bash
bun run validate
# All 6 checks pass:
#   check:bundled            ✓ (36 commands, 20 workflows)
#   check:bundled-skill      ✓ (21 files)
#   type-check               ✓ all 10 packages
#   lint --max-warnings 0    ✓
#   format:check             ✓
#   test                     ✓ all packages
#
# Two new test files added (25 tests total, all passing):
#   packages/adapters/src/chat/slack/blocks.test.ts          (16 tests)
#   packages/adapters/src/chat/slack/workflow-bridge.test.ts (9 tests)
```

- Evidence provided: full `bun run validate` exit-code 0 on the branch tip.
- Intentionally skipped: end-to-end Slack workspace verification — requires the new scopes (`commands`, `reactions:write`) installed on a real Slack app. Listed under Human Verification.

## Security Impact (required)

- New permissions/capabilities? **Yes** — two new Slack bot scopes: `commands` (slash commands) and `reactions:write` (lifecycle emoji). Documented in `slack.md`.
- New external network calls? **No** — same Bolt Socket Mode connection; new API verbs only (chat.update, reactions.add, reactions.remove).
- Secrets/tokens handling changed? **No** — same `SLACK_BOT_TOKEN` / `SLACK_APP_TOKEN`.
- File system access scope changed? **No**.
- **Risk/mitigation**: Block Kit button clicks are gated by the existing `SLACK_ALLOWED_USER_IDS` whitelist inside every action handler. Unauthorized clicks are silently dropped and logged with masked user IDs. Verified by `unauthorized click is silently dropped` test in `workflow-bridge.test.ts`.

## Compatibility / Migration

- Backward compatible? **Yes** — `sendResultFooter` is an optional method on `IPlatformAdapter`; only Slack implements it. Telegram/Discord/GitHub/Web flow unchanged.
- Config/env changes? **No new env vars**. Operators must add `commands` + `reactions:write` scopes and register the two slash commands in the Slack app config and reinstall to workspace (one-time manual step, documented).
- Database migration needed? **No**.
- **Upgrade steps**:
  1. Pull `dev`, deploy
  2. In Slack app settings: add `commands` and `reactions:write` to Bot Token Scopes
  3. Toggle on Interactivity & Shortcuts (leave Request URL blank — Socket Mode handles it)
  4. Register `/archon` and `/archon-workflow` slash commands (blank Request URL)
  5. Reinstall app to workspace to issue a new token with the scopes

## Human Verification (required)

- **Verified scenarios**: Full `bun run validate` (10 packages, all tests pass). The two new unit test files cover: cost footer formatting (cost-only, tokens-only, combined, NaN/Infinity edge cases), approval/resolution/status block builders, reaction name constants, workflow_started → status post + reaction add, approval_pending → buttons in-thread, approve button → `approveWorkflow` called + message edited, reject under retry threshold → "will retry" note, cancel → `abandonWorkflow`, unauthorized click silently dropped, workflow_completed → reaction swap + cost in context block, workflow_failed → x reaction + reason.
- **Edge cases checked**: long messages now correctly footer'd with `_part i/n_`; bridge gracefully drops events for non-Slack conversations (verified by `does nothing when there is no Slack trigger` test); reactions API failures are swallowed-and-logged (won't fail the workflow); `chat.update` on a missing approval message is non-fatal (logged at warn).
- **What was *not* verified**: Live Slack workspace round-trip. Needs the new scopes installed on a real app, which has to happen after this lands. Failure modes I expect to see in real-world testing: rate-limit pushback on `chat.update` if a DAG has very fast nodes (debounced 500ms but theoretical) and `not_in_channel` errors if the bot was added to a channel without `channels:join` already there.

## Side Effects / Blast Radius (required)

- **Affected subsystems/workflows**: Slack adapter only. Other platform adapters unaffected. Orchestrator's direct-chat code paths emit an extra `sendResultFooter` call on adapters that implement it (no-op for Telegram/Discord/GitHub/Web).
- **Potential unintended effects**:
  - `chat.update` requires the bot to own the message — guaranteed since the bridge tracks `result.ts` from its own `chat.postMessage`. If the message is deleted manually, edits fail silently (logged).
  - `triggeringMessages` map is bounded at 1000 entries with FIFO eviction; chat-only conversations that never run a workflow won't grow it.
  - Stream-mode adapters now receive a `sendResultFooter` call after the final assistant chunk — currently only Slack implements it, but any adapter that adopts it should be prepared for it to run before the orchestrator decides to dispatch a workflow (current code skips it correctly on dispatch via early-return).
- **Guardrails / monitoring**: All Slack-side failures (reactions, edits, postMessage) go through `getLog().warn` / `.debug` with named events (`slack.bridge_reaction_add_failed`, `slack.bridge_status_update_failed`, etc.) — easy to grep in production logs.

## Rollback Plan (required)

- **Fast rollback**: `git revert <merge-commit>` on `dev`. The PR is self-contained — no schema changes, no migrations, no other-adapter touch points. Reverting restores the pre-PR Slack adapter behavior exactly.
- **Feature flags / toggles**: None. The bridge is unconditional once the Slack adapter is enabled. To temporarily disable: set `SLACK_BOT_TOKEN` empty (skips the whole Slack adapter init).
- **Observable failure symptoms**:
  - Slack action handlers failing → logs like `slack.bridge_approval_action_failed` with the run/node ID
  - Bolt `app.start()` failing post-attach → `slack.bot_started` log never fires; existing `slack_adapter_skipped` path triggers on missing tokens
  - Cost footer disappearing → check `orchestrator.result_footer_failed` warn logs

## Risks and Mitigations

- **Risk**: A user with `SLACK_ALLOWED_USER_IDS` access could click Cancel on another teammate's workflow.
  - **Mitigation**: Acceptable for v1 — same trust model as the existing thread-shared-state assumption. Per-user attribution is the documented follow-up (deferred from this PR's scope).
- **Risk**: Slack `chat.update` rate limit hit on DAGs with rapid node transitions.
  - **Mitigation**: 500ms trailing-edge debounce in the bridge; failures are warn-logged not thrown.
- **Risk**: Block Kit action handler must `ack()` within 3 seconds, and `approveWorkflow` / `rejectWorkflow` make DB writes.
  - **Mitigation**: All action handlers call `await ack()` *before* invoking operations. Operations are pure DB writes (no AI calls, no network) — fast in practice.
- **Risk**: Slash command flow posts a "seed" message (e.g. `<@U123> ran /archon-workflow list`) to create a thread root, which is more visible than a pure ephemeral response.
  - **Mitigation**: Documented in `slack.md`; chosen deliberately so the conversation has a real `ts` to thread under. An ephemeral acknowledgement is also sent to the invoker so they see "see thread for output."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slash commands (/archon, /archon-workflow) to start workflows and seed threads.
  * In-thread interactive controls: Approve / Reject / Cancel with in-place resolution edits.
  * Workflow status messages with realtime node progress, reaction lifecycle, and tracked thread roots for later edits/reactions.
  * Long-message handling now appends per-chunk “_part i/n_” labels and reserves space for them.
  * Automatic posting of an italic cost/token footer (when available), best-effort and non-blocking.

* **Documentation**
  * Updated Slack setup, scopes, and In-Thread UX.

* **Tests**
  * Added unit tests for Block Kit builders, adapter behaviors, and workflow-to-Slack interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1757?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->