### PR TITLE
feat(adapters/zulip): add Zulip community chat adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -205,11 +205,16 @@ TELEGRAM_ALLOWED_USER_IDS=
 
 # Zulip Bot (community adapter)
 # Create a bot in Zulip: Settings > Personal settings > Bots > Add a new bot
-ZULIP_URL=                 # Zulip realm URL, e.g. https://your-org.zulipchat.com
-ZULIP_BOT_EMAIL=           # Bot email, e.g. bot-name@your-org.zulipchat.com
-ZULIP_BOT_API_KEY=         # Bot API key from the bot's settings
-# ZULIP_BOT_FULL_NAME=     # Bot display name; required for stream @mention detection
-# ZULIP_STREAMING_MODE=batch  # batch (default) | stream
+# Zulip realm URL, e.g. https://your-org.zulipchat.com
+ZULIP_URL=
+# Bot email, e.g. bot-name@your-org.zulipchat.com
+ZULIP_BOT_EMAIL=
+# Bot API key from the bot's settings
+ZULIP_BOT_API_KEY=
+# Bot display name; required for stream @mention detection
+# ZULIP_BOT_FULL_NAME=
+# Streaming mode: batch (default) | stream
+# ZULIP_STREAMING_MODE=batch
 
 # Zulip User Whitelist (optional - comma-separated user IDs)
 # When set, only listed Zulip users can interact with the bot

--- a/.env.example
+++ b/.env.example
@@ -203,6 +203,19 @@ DISCORD_ALLOWED_USER_IDS=
 # Get your user ID by messaging @userinfobot on Telegram
 TELEGRAM_ALLOWED_USER_IDS=
 
+# Zulip Bot (community adapter)
+# Create a bot in Zulip: Settings > Personal settings > Bots > Add a new bot
+ZULIP_URL=                 # Zulip realm URL, e.g. https://your-org.zulipchat.com
+ZULIP_BOT_EMAIL=           # Bot email, e.g. bot-name@your-org.zulipchat.com
+ZULIP_BOT_API_KEY=         # Bot API key from the bot's settings
+# ZULIP_BOT_FULL_NAME=     # Bot display name; required for stream @mention detection
+# ZULIP_STREAMING_MODE=batch  # batch (default) | stream
+
+# Zulip User Whitelist (optional - comma-separated user IDs)
+# When set, only listed Zulip users can interact with the bot
+# When empty/unset, bot responds to all users
+# ZULIP_ALLOWED_USER_IDS=
+
 # Platform Streaming Mode (stream | batch)
 TELEGRAM_STREAMING_MODE=stream  # stream (default) | batch
 DISCORD_STREAMING_MODE=batch    # batch (default) | stream

--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
         "discord.js": "^14.16.0",
         "grammy": "^1.36.0",
         "telegramify-markdown": "^1.3.3",
+        "zulip-js": "^1.0.0",
       },
       "peerDependencies": {
         "typescript": "^5.0.0",
@@ -1285,6 +1286,8 @@
 
     "astro-expressive-code": ["astro-expressive-code@0.41.7", "", { "dependencies": { "rehype-expressive-code": "^0.41.7" }, "peerDependencies": { "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta" } }, "sha512-hUpogGc6DdAd+I7pPXsctyYPRBJDK7Q7d06s4cyP0Vz3OcbziP3FNzN0jZci1BpCvLn9675DvS7B9ctKKX64JQ=="],
 
+    "async": ["async@2.6.4", "", { "dependencies": { "lodash": "^4.17.14" } }, "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA=="],
+
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
@@ -1521,6 +1524,8 @@
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
+    "encoding": ["encoding@0.1.13", "", { "dependencies": { "iconv-lite": "^0.6.2" } }, "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A=="],
+
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.20.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ=="],
@@ -1542,6 +1547,8 @@
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "es6-promise": ["es6-promise@3.3.1", "", {}, "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg=="],
 
     "esast-util-from-estree": ["esast-util-from-estree@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "unist-util-position-from-estree": "^2.0.0" } }, "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ=="],
 
@@ -1666,6 +1673,8 @@
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
+
+    "fs-readfile-promise": ["fs-readfile-promise@3.0.1", "", { "dependencies": { "graceful-fs": "^4.1.11" } }, "sha512-LsSxMeaJdYH27XrW7Dmq0Gx63mioULCRel63B5VeELYLavi1wF5s0XfsIdKDFdCL9hsfQ2qBvXJszQtQJ9h17A=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -1813,6 +1822,8 @@
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
@@ -1868,6 +1879,10 @@
     "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "isomorphic-fetch": ["isomorphic-fetch@2.2.1", "", { "dependencies": { "node-fetch": "^1.0.1", "whatwg-fetch": ">=0.10.0" } }, "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA=="],
+
+    "isomorphic-form-data": ["isomorphic-form-data@0.0.1", "", { "dependencies": { "form-data": "^1.0.0-rc3" } }, "sha512-gFB8es9tawtX4XzY8kEZF/umdNSqyKlEIjJm1nZj/+LOtirJMdHdqcrI74C+0erllsEl+7Dkdt6reNn5MNacjg=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
@@ -2713,6 +2728,8 @@
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
+    "whatwg-fetch": ["whatwg-fetch@3.6.20", "", {}, "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="],
+
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -2756,6 +2773,8 @@
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+
+    "zulip-js": ["zulip-js@1.0.12", "", { "dependencies": { "es6-promise": "^3.2.1", "fs-readfile-promise": "^3.0.0", "ini": "^1.3.4", "isomorphic-fetch": "^2.2.1", "isomorphic-form-data": "0.0.1" } }, "sha512-EIs3rRi2wkSadDFSxyzCvrccsGSfuXXbG/WL0K8D2oIOzLRnrX9K85OGSAYNsNQUa44tntyHfQmOBM1WwMhe6w=="],
 
     "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
 
@@ -2955,6 +2974,8 @@
 
     "eciesjs/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
+    "encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
     "eslint/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "eslint/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
@@ -2974,6 +2995,10 @@
     "hast-util-select/unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
 
     "hast-util-to-mdast/unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "isomorphic-fetch/node-fetch": ["node-fetch@1.7.3", "", { "dependencies": { "encoding": "^0.1.11", "is-stream": "^1.0.1" } }, "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ=="],
+
+    "isomorphic-form-data/form-data": ["form-data@1.0.1", "", { "dependencies": { "async": "^2.0.1", "combined-stream": "^1.0.5", "mime-types": "^2.1.11" } }, "sha512-M4Yhq2mLogpCtpUmfopFlTTuIe6mSCTgKvnlMhDj3NcgVhA1uS20jT0n+xunKPzpmL5w2erSVtp+SKiJf1TlWg=="],
 
     "lint-staged/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -3218,6 +3243,10 @@
     "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "isomorphic-fetch/node-fetch/is-stream": ["is-stream@1.1.0", "", {}, "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="],
+
+    "isomorphic-form-data/form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "log-update/slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
@@ -3486,6 +3515,8 @@
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "axios/form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "isomorphic-form-data/form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "log-update/slice-ansi/is-fullwidth-code-point/get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -43,12 +43,21 @@ TELEGRAM_BOT_TOKEN=123456789:ABC...
 # GITHUB_TOKEN=ghp_...
 # WEBHOOK_SECRET=...
 
+# Zulip - Community chat adapter (long-polling, no public webhook URL needed)
+# ZULIP_URL=https://your-org.zulipchat.com
+# ZULIP_BOT_EMAIL=archon-bot@your-org.zulipchat.com
+# ZULIP_BOT_API_KEY=...
+# ZULIP_BOT_FULL_NAME=Archon                       # required for stream @mention detection
+# ZULIP_ALLOWED_USER_IDS=12345,67890               # optional; unset = open access
+# ZULIP_STREAMING_MODE=batch                       # batch (default) | stream
+
 # ============================================
 # Optional
 # ============================================
 PORT=3000  # Docker deployment default (the included compose/Caddy configs target :3000). For local dev (no Docker), omit PORT — server and Vite proxy both default to 3090.
 # TELEGRAM_STREAMING_MODE=stream
 # DISCORD_STREAMING_MODE=batch
+# ZULIP_STREAMING_MODE=batch
 
 # ============================================
 # Basic Auth (optional — recommended for cloud)

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -11,7 +11,7 @@
     "./community/forge/gitlab": "./src/community/forge/gitlab/index.ts"
   },
   "scripts": {
-    "test": "bun test src/chat/slack/adapter.test.ts src/chat/slack/auth.test.ts src/chat/slack/blocks.test.ts src/chat/telegram/ src/community/chat/ src/community/forge/gitlab/auth.test.ts src/forge/github/auth.test.ts src/utils/ && bun test src/chat/slack/workflow-bridge.test.ts && bun test src/forge/github/adapter.test.ts && bun test src/forge/github/context.test.ts && bun test src/community/forge/gitea/adapter.test.ts && bun test src/community/forge/gitlab/adapter.test.ts",
+    "test": "bun test src/chat/slack/adapter.test.ts src/chat/slack/auth.test.ts src/chat/slack/blocks.test.ts src/chat/telegram/ src/community/chat/ src/community/forge/gitlab/auth.test.ts src/forge/github/auth.test.ts src/utils/ && bun test src/chat/slack/workflow-bridge.test.ts && bun test src/forge/github/adapter.test.ts && bun test src/forge/github/context.test.ts && bun test src/community/forge/gitea/adapter.test.ts && bun test src/community/forge/gitlab/adapter.test.ts && bun test src/community/chat/zulip/adapter.test.ts",
     "type-check": "bun x tsc --noEmit"
   },
   "dependencies": {
@@ -25,7 +25,8 @@
     "@slack/bolt": "^4.6.0",
     "discord.js": "^14.16.0",
     "grammy": "^1.36.0",
-    "telegramify-markdown": "^1.3.3"
+    "telegramify-markdown": "^1.3.3",
+    "zulip-js": "^1.0.0"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/packages/adapters/src/community/chat/zulip/adapter.test.ts
+++ b/packages/adapters/src/community/chat/zulip/adapter.test.ts
@@ -339,6 +339,42 @@ describe('ZulipAdapter', () => {
       adapter.stop();
     });
 
+    test('aborts the backfill cycle (does not process any messages) when the unread fetch fails', async () => {
+      // Wirasm review: `fetchUnread` returning [] on failure silently erased missed messages.
+      // After the fix it returns undefined and `backfillUnansweredMessages` bails — messages stay
+      // unread in Zulip for the next restart to retry. This test guards that contract.
+      process.env.ZULIP_BOT_FULL_NAME = 'TestBot';
+      try {
+        const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+        const handled: number[] = [];
+        adapter.onMessage(m => {
+          handled.push(m.id);
+          return Promise.resolve();
+        });
+        mockEventsRetrieve.mockImplementation(() => new Promise(() => {})); // block live loop
+        mockMessagesRetrieve.mockImplementation(() =>
+          Promise.reject(new Error('zulip 503 backfill fail'))
+        );
+
+        await adapter.start();
+        await flush();
+        await flush();
+
+        expect(handled).toEqual([]); // no messages processed
+        const abortedLog = mockLogger.error.mock.calls.find(
+          args => args[args.length - 1] === 'zulip.backfill_aborted'
+        );
+        expect(abortedLog).toBeDefined();
+        const flagsCalls = mockFetch.mock.calls.filter(c =>
+          String(c[0]).endsWith('/api/v1/messages/flags')
+        );
+        expect(flagsCalls.length).toBe(0); // no spurious mark-read on a failed cycle
+        adapter.stop();
+      } finally {
+        delete process.env.ZULIP_BOT_FULL_NAME;
+      }
+    });
+
     test('answers unread mentions and DMs oldest-first; defers mark-read until a reply', async () => {
       process.env.ZULIP_BOT_FULL_NAME = 'TestBot';
       try {

--- a/packages/adapters/src/community/chat/zulip/adapter.test.ts
+++ b/packages/adapters/src/community/chat/zulip/adapter.test.ts
@@ -55,7 +55,7 @@ globalThis.fetch = mockFetch as unknown as typeof fetch;
 /** Flush queued microtasks/timers so background work (backfill, poll) can run in tests. */
 const flush = (): Promise<void> => new Promise(resolve => setTimeout(resolve, 0));
 
-import { ZulipAdapter } from './adapter';
+import { ZulipAdapter, formatUtcTime } from './adapter';
 import type { ZulipMessage, ZulipReplyContext } from './types';
 
 describe('ZulipAdapter', () => {
@@ -816,5 +816,188 @@ describe('ZulipAdapter', () => {
         delete process.env.ZULIP_BOT_FULL_NAME;
       }
     });
+  });
+});
+
+// Coverage for the gaps Wirasm flagged on PR #1760:
+// formatUtcTime isolate, zulipPost error branch, FIFO eviction, debounce guard,
+// plus the backfill "no abort on successful empty fetch" negative assertion.
+
+describe('formatUtcTime', () => {
+  test('returns time in HH:MM:SS format with zero-padded components', () => {
+    expect(formatUtcTime()).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+  });
+
+  test('uses UTC accessors (independent of local timezone)', () => {
+    // Verify the formatted seconds match Date.getUTCSeconds() at call-time, allowing for the
+    // one-second window where the clock could have ticked between samples.
+    const before = new Date().getUTCSeconds();
+    const result = formatUtcTime();
+    const after = new Date().getUTCSeconds();
+    const parsedSec = Number(result.split(':')[2]);
+    expect([before, after, (before + 1) % 60]).toContain(parsedSec);
+  });
+});
+
+describe('zulipPost error branch', () => {
+  test('throws when the HTTP response has a non-2xx status', async () => {
+    const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ result: 'error', msg: 'unauthorized' }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' },
+        })
+      )
+    );
+    await expect(adapter.start()).rejects.toThrow(/Zulip POST \/register failed: HTTP 401/);
+  });
+
+  test('throws when the response is 200 but result is not "success"', async () => {
+    const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ result: 'error', msg: 'bad request' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      )
+    );
+    await expect(adapter.start()).rejects.toThrow(/Zulip POST \/register failed:.*bad request/);
+  });
+});
+
+describe('FIFO eviction', () => {
+  // The constants live in adapter.ts and are not exported (REPLY_CONTEXTS_MAX=1000,
+  // PROCESSED_IDS_MAX=2000). Tests assert the invariant — the cap holds and the oldest
+  // entry is the one dropped — rather than the specific numeric value.
+  test('evicts the oldest replyContexts entry once REPLY_CONTEXTS_MAX is reached', async () => {
+    process.env.ZULIP_BOT_FULL_NAME = 'TestBot';
+    try {
+      const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+      (adapter as unknown as { client: typeof mockZulipClient }).client = mockZulipClient;
+      const ctxs = (adapter as unknown as { replyContexts: Map<string, ZulipReplyContext> })
+        .replyContexts;
+
+      // Saturate the map up to (just under) the eviction threshold by directly populating it —
+      // dispatching that many messages through the public API would be unnecessarily slow.
+      for (let i = 0; i < 1000; i++) {
+        ctxs.set(`stream:${i}:T`, { type: 'stream', stream_id: i, topic: 'T' });
+      }
+      const capacity = ctxs.size;
+      expect(ctxs.has('stream:0:T')).toBe(true);
+
+      // One more inbound message creates a new context, which must evict the oldest.
+      await (
+        adapter as unknown as { handleIncomingMessage: (m: ZulipMessage) => Promise<void> }
+      ).handleIncomingMessage({
+        id: 99999,
+        sender_id: 5,
+        sender_email: 'u@test.com',
+        sender_full_name: 'U',
+        content: '@**TestBot** hi',
+        type: 'stream',
+        stream_id: 9999,
+        subject: 'new',
+        display_recipient: 'general',
+      });
+
+      expect(ctxs.size).toBe(capacity); // capped, not grown
+      expect(ctxs.has('stream:0:T')).toBe(false); // oldest gone
+      expect(ctxs.has('stream:9999:new')).toBe(true); // new added
+    } finally {
+      delete process.env.ZULIP_BOT_FULL_NAME;
+    }
+  });
+
+  test('evicts the oldest processedMessageIds entry once PROCESSED_IDS_MAX is reached', () => {
+    const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+    const processed = (adapter as unknown as { processedMessageIds: Set<number> })
+      .processedMessageIds;
+
+    for (let i = 1; i <= 2000; i++) processed.add(i);
+    const capacity = processed.size;
+    expect(processed.has(1)).toBe(true);
+
+    (adapter as unknown as { rememberProcessed: (n: number) => void }).rememberProcessed(99999);
+
+    expect(processed.size).toBe(capacity); // capped, not grown
+    expect(processed.has(1)).toBe(false); // oldest gone (Set iteration = insertion order)
+    expect(processed.has(99999)).toBe(true);
+  });
+});
+
+describe('status-message debounce guard', () => {
+  test('skips the status-message edit (and logs) when more entries remain and lastEdit is recent', async () => {
+    const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+    (adapter as unknown as { client: typeof mockZulipClient }).client = mockZulipClient;
+    (adapter as unknown as { replyContexts: Map<string, ZulipReplyContext> }).replyContexts.set(
+      'stream:1:T',
+      { type: 'stream', stream_id: 1, topic: 'T' }
+    );
+    // Two queued status entries so the drain leaves the queue non-empty (debounce only fires
+    // while more entries remain — once empty, the final update always goes through).
+    // lastEdit set to "now" means now - lastEdit ~= 0, well under STATUS_MIN_INTERVAL_MS (500ms).
+    (
+      adapter as unknown as {
+        statusMessageQueues: Map<string, Array<{ id: number; text: string }>>;
+      }
+    ).statusMessageQueues.set('stream:1:T', [
+      { id: 100, text: 'Starting thinking...' },
+      { id: 101, text: 'Starting thinking...' },
+    ]);
+    (adapter as unknown as { statusLastEdit: Map<string, number> }).statusLastEdit.set(
+      'stream:1:T',
+      Date.now()
+    );
+
+    mockFetch.mockClear();
+    mockLogger.warn.mockClear();
+
+    await adapter.sendMessage('stream:1:T', 'answer');
+
+    // No PATCH to /api/v1/messages/<id> (the status-edit endpoint) means the edit was skipped.
+    const patchEdits = mockFetch.mock.calls.filter(c => {
+      const url = String(c[0]);
+      const init = c[1] as { method?: string } | undefined;
+      return /\/api\/v1\/messages\/\d+$/.test(url) && init?.method === 'PATCH';
+    });
+    expect(patchEdits.length).toBe(0);
+
+    const skipped = mockLogger.warn.mock.calls.find(
+      args => args[args.length - 1] === 'zulip.status_debounce_skipped'
+    );
+    expect(skipped).toBeDefined();
+  });
+});
+
+// Negative assertion for the backfill_aborted contract (Wirasm 2nd review): confirm the abort
+// path is taken ONLY on actual fetch failures — a successful fetch that returns zero unread
+// messages must NOT log `zulip.backfill_aborted`. Without this companion to the failure test
+// above, we couldn't distinguish "abort because of failure" from "abort regardless".
+describe('startup backfill — empty success does not trip abort', () => {
+  test('a clean fetch that returns no unread messages completes without backfill_aborted', async () => {
+    process.env.ZULIP_BOT_FULL_NAME = 'TestBot';
+    try {
+      const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+      mockEventsRetrieve.mockImplementation(() => new Promise(() => {})); // block live loop
+      mockMessagesRetrieve.mockImplementation(() => Promise.resolve({ messages: [] }));
+
+      await adapter.start();
+      await flush();
+      await flush();
+
+      const aborted = mockLogger.error.mock.calls.find(
+        args => args[args.length - 1] === 'zulip.backfill_aborted'
+      );
+      expect(aborted).toBeUndefined(); // success-but-empty must NOT take the abort path
+      const none = mockLogger.info.mock.calls.find(
+        args => args[args.length - 1] === 'zulip.backfill_none'
+      );
+      expect(none).toBeDefined();
+      adapter.stop();
+    } finally {
+      delete process.env.ZULIP_BOT_FULL_NAME;
+    }
   });
 });

--- a/packages/adapters/src/community/chat/zulip/adapter.test.ts
+++ b/packages/adapters/src/community/chat/zulip/adapter.test.ts
@@ -251,7 +251,10 @@ describe('ZulipAdapter', () => {
       await adapter.sendMessage('stream:99:Unknown', 'Hello');
 
       expect(mockLogger.error).toHaveBeenCalled();
-      expect(mockMessagesSend).not.toHaveBeenCalled();
+      // sendMessage posts via fetch (zulipPost), not client.messages.send — assert the real
+      // transport made no message POST, so a stray send can't slip past a vacuous assertion.
+      const msgCalls = mockFetch.mock.calls.filter(c => String(c[0]).endsWith('/api/v1/messages'));
+      expect(msgCalls.length).toBe(0);
     });
   });
 
@@ -269,7 +272,10 @@ describe('ZulipAdapter', () => {
       mockEventsRetrieve.mockImplementation(() => new Promise(() => {}));
 
       const result = await Promise.race([
-        adapter.start().then(() => 'started' as const),
+        (async () => {
+          await adapter.start();
+          return 'started' as const;
+        })(),
         new Promise<'timed-out'>(resolve => setTimeout(() => resolve('timed-out'), 500)),
       ]);
 

--- a/packages/adapters/src/community/chat/zulip/adapter.test.ts
+++ b/packages/adapters/src/community/chat/zulip/adapter.test.ts
@@ -1,0 +1,778 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+// Mock logger to suppress noisy output during tests
+const mockLogger = {
+  fatal: mock(() => undefined),
+  error: mock(() => undefined),
+  warn: mock(() => undefined),
+  info: mock(() => undefined),
+  debug: mock(() => undefined),
+  trace: mock(() => undefined),
+  child: mock(function (this: unknown) {
+    return this;
+  }),
+  bindings: mock(() => ({ module: 'test' })),
+  isLevelEnabled: mock(() => true),
+  level: 'info',
+};
+mock.module('@archon/paths', () => ({
+  createLogger: mock(() => mockLogger),
+}));
+
+// Create mock functions before mocking the module
+const mockMessagesSend = mock(() => Promise.resolve());
+const mockQueuesRegister = mock(() =>
+  Promise.resolve({ queue_id: 'test-queue', last_event_id: 0 })
+);
+const mockEventsRetrieve = mock(() => Promise.resolve({ events: [] }));
+const mockMessagesRetrieve = mock(
+  (_params?: unknown): Promise<{ messages: unknown[] }> => Promise.resolve({ messages: [] })
+);
+
+const mockZulipClient = {
+  queues: { register: mockQueuesRegister },
+  events: { retrieve: mockEventsRetrieve },
+  messages: { send: mockMessagesSend, retrieve: mockMessagesRetrieve },
+};
+
+const mockZulip = mock(() => Promise.resolve(mockZulipClient));
+
+// Mock zulip-js — use { default: mockZulip } so the ESM default import resolves to mockZulip
+mock.module('zulip-js', () => ({ default: mockZulip }));
+
+// The adapter POSTs to the Zulip REST API via global fetch (register / send / flags).
+// Stub it to a success response so tests make no network calls; include queue fields for register.
+const mockFetch = mock((_url?: unknown, _init?: unknown) =>
+  Promise.resolve(
+    new Response(JSON.stringify({ result: 'success', queue_id: 'q', last_event_id: 0 }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  )
+);
+globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+/** Flush queued microtasks/timers so background work (backfill, poll) can run in tests. */
+const flush = (): Promise<void> => new Promise(resolve => setTimeout(resolve, 0));
+
+import { ZulipAdapter } from './adapter';
+import type { ZulipMessage, ZulipReplyContext } from './types';
+
+describe('ZulipAdapter', () => {
+  beforeEach(() => {
+    mockMessagesSend.mockClear();
+    mockQueuesRegister.mockClear();
+    mockEventsRetrieve.mockClear();
+    mockMessagesRetrieve.mockClear();
+    mockMessagesRetrieve.mockImplementation(() => Promise.resolve({ messages: [] }));
+    mockFetch.mockClear();
+    mockLogger.error.mockClear();
+    mockLogger.info.mockClear();
+  });
+
+  describe('streaming mode configuration', () => {
+    test('should default to batch mode', () => {
+      const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+      expect(adapter.getStreamingMode()).toBe('batch');
+    });
+
+    test('should accept explicit batch mode', () => {
+      const adapter = new ZulipAdapter(
+        'https://test.zulipchat.com',
+        'bot@test.com',
+        'key',
+        'batch'
+      );
+      expect(adapter.getStreamingMode()).toBe('batch');
+    });
+
+    test('should accept explicit stream mode', () => {
+      const adapter = new ZulipAdapter(
+        'https://test.zulipchat.com',
+        'bot@test.com',
+        'key',
+        'stream'
+      );
+      expect(adapter.getStreamingMode()).toBe('stream');
+    });
+  });
+
+  describe('platform type', () => {
+    test('should return zulip as platform type', () => {
+      const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+      expect(adapter.getPlatformType()).toBe('zulip');
+    });
+  });
+
+  describe('conversation ID extraction', () => {
+    test('should produce stream conversation ID', () => {
+      const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+      const msg = {
+        type: 'stream',
+        stream_id: 99,
+        subject: 'Topic Name',
+        display_recipient: 'general',
+      } as unknown as ZulipMessage;
+
+      expect(adapter.getConversationId(msg)).toBe('stream:99:Topic Name');
+    });
+
+    test('should produce private conversation ID with sorted user IDs', () => {
+      const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+      const msg = {
+        type: 'private',
+        display_recipient: [
+          { id: 22, email: 'b@test.com', full_name: 'B' },
+          { id: 11, email: 'a@test.com', full_name: 'A' },
+        ],
+      } as unknown as ZulipMessage;
+
+      expect(adapter.getConversationId(msg)).toBe('private:11:22');
+    });
+
+    test('should sort private recipient IDs ascending', () => {
+      const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+      const msg = {
+        type: 'private',
+        display_recipient: [
+          { id: 300, email: 'c@test.com', full_name: 'C' },
+          { id: 10, email: 'a@test.com', full_name: 'A' },
+          { id: 50, email: 'b@test.com', full_name: 'B' },
+        ],
+      } as unknown as ZulipMessage;
+
+      expect(adapter.getConversationId(msg)).toBe('private:10:50:300');
+    });
+  });
+
+  describe('stripBotMention', () => {
+    test('should remove @**Bot Name** mention', () => {
+      const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+      // Set botFullName via accessor (simulate after start())
+      (adapter as unknown as { botFullName: string }).botFullName = 'Archon Bot';
+
+      expect(adapter.stripBotMention('@**Archon Bot** help me')).toBe('help me');
+    });
+
+    test('should remove mention with no trailing space', () => {
+      const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+      (adapter as unknown as { botFullName: string }).botFullName = 'Archon Bot';
+
+      expect(adapter.stripBotMention('@**Archon Bot**help me')).toBe('help me');
+    });
+
+    test('should remove multiple mentions', () => {
+      const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+      (adapter as unknown as { botFullName: string }).botFullName = 'Archon Bot';
+
+      expect(adapter.stripBotMention('@**Archon Bot** hello @**Archon Bot** world')).toBe(
+        'hello world'
+      );
+    });
+
+    test('should return content unchanged when botFullName is empty', () => {
+      const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+      // botFullName defaults to ''
+      expect(adapter.stripBotMention('@**Archon Bot** hello')).toBe('@**Archon Bot** hello');
+    });
+  });
+
+  describe('ensureThread', () => {
+    test('should return the same conversation ID (Zulip topics are already threads)', async () => {
+      const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+      const result = await adapter.ensureThread('stream:99:My Topic');
+      expect(result).toBe('stream:99:My Topic');
+    });
+  });
+
+  describe('sendMessage', () => {
+    test('should send a stream message via direct POST', async () => {
+      const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+      (adapter as unknown as { client: typeof mockZulipClient }).client = mockZulipClient;
+
+      // Set up reply context
+      (adapter as unknown as { replyContexts: Map<string, ZulipReplyContext> }).replyContexts.set(
+        'stream:99:Topic',
+        { type: 'stream', stream_id: 99, topic: 'Topic' }
+      );
+
+      await adapter.sendMessage('stream:99:Topic', 'Hello from Archon');
+
+      const call = mockFetch.mock.calls.find(c => String(c[0]).endsWith('/api/v1/messages'));
+      expect(call).toBeDefined();
+      const body = String((call![1] as { body?: unknown }).body);
+      expect(body).toContain('type=stream');
+      expect(body).toContain('to=99');
+      expect(body).toContain('topic=Topic');
+      expect(body).toContain('content=Hello');
+    });
+
+    test('should send a private message via direct POST (to = JSON id list)', async () => {
+      const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+      (adapter as unknown as { client: typeof mockZulipClient }).client = mockZulipClient;
+
+      (adapter as unknown as { replyContexts: Map<string, ZulipReplyContext> }).replyContexts.set(
+        'private:11:22',
+        { type: 'private', user_ids: [11, 22] }
+      );
+
+      await adapter.sendMessage('private:11:22', 'Hello privately');
+
+      const call = mockFetch.mock.calls.find(c => String(c[0]).endsWith('/api/v1/messages'));
+      expect(call).toBeDefined();
+      const body = decodeURIComponent(String((call![1] as { body?: unknown }).body));
+      expect(body).toContain('type=private');
+      expect(body).toContain('to=[11,22]');
+    });
+
+    test('should split messages longer than 9800 chars into multiple POSTs', async () => {
+      const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+      (adapter as unknown as { client: typeof mockZulipClient }).client = mockZulipClient;
+
+      (adapter as unknown as { replyContexts: Map<string, ZulipReplyContext> }).replyContexts.set(
+        'stream:1:T',
+        { type: 'stream', stream_id: 1, topic: 'T' }
+      );
+
+      const para1 = 'a'.repeat(5000);
+      const para2 = 'b'.repeat(5000);
+      const longMessage = `${para1}\n\n${para2}`;
+
+      await adapter.sendMessage('stream:1:T', longMessage);
+
+      const msgCalls = mockFetch.mock.calls.filter(c => String(c[0]).endsWith('/api/v1/messages'));
+      expect(msgCalls.length).toBeGreaterThan(1);
+    });
+
+    test('should log error and return when no reply context is found', async () => {
+      const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+      (adapter as unknown as { client: typeof mockZulipClient }).client = mockZulipClient;
+
+      await adapter.sendMessage('stream:99:Unknown', 'Hello');
+
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockMessagesSend).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('lifecycle', () => {
+    test('should set running to false on stop', () => {
+      const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+      adapter.stop();
+      expect((adapter as unknown as { running: boolean }).running).toBe(false);
+    });
+
+    test('start() returns promptly while poll loop runs in background', async () => {
+      const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+
+      // Block events.retrieve so start() would hang forever if it awaits the poll loop
+      mockEventsRetrieve.mockImplementation(() => new Promise(() => {}));
+
+      const result = await Promise.race([
+        adapter.start().then(() => 'started' as const),
+        new Promise<'timed-out'>(resolve => setTimeout(() => resolve('timed-out'), 500)),
+      ]);
+
+      expect(result).toBe('started');
+      expect((adapter as unknown as { running: boolean }).running).toBe(true);
+
+      adapter.stop();
+      expect((adapter as unknown as { running: boolean }).running).toBe(false);
+    });
+  });
+
+  describe('message handler registration', () => {
+    test('should allow registering a message handler', () => {
+      const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+      const handler = mock(() => Promise.resolve(undefined));
+      adapter.onMessage(handler);
+      expect((adapter as unknown as { messageHandler: unknown }).messageHandler).toBe(handler);
+    });
+  });
+
+  describe('startup backfill (catch up on missed messages)', () => {
+    const dm = (id: number): ZulipMessage => ({
+      id,
+      sender_id: 6,
+      sender_email: 'v@test.com',
+      sender_full_name: 'V',
+      content: 'ping',
+      type: 'private',
+      display_recipient: [{ id: 6, email: 'v@test.com', full_name: 'V' }],
+    });
+    const mention = (id: number): ZulipMessage => ({
+      id,
+      sender_id: 5,
+      sender_email: 'u@test.com',
+      sender_full_name: 'U',
+      content: '@**TestBot** hi',
+      type: 'stream',
+      stream_id: 1,
+      subject: 'topic',
+      display_recipient: 'general',
+    });
+    // narrow-aware retrieve: return mentions for is:mentioned, dms for is:private
+    const retrieveReturning = (mentions: ZulipMessage[], dms: ZulipMessage[]) =>
+      mockMessagesRetrieve.mockImplementation(params => {
+        // mock declares the param as unknown; the adapter always passes a narrow array
+        const narrow = (params as { narrow: { operand: string }[] }).narrow;
+        const isMention = narrow.some(n => n.operand === 'mentioned');
+        return Promise.resolve({ messages: isMention ? mentions : dms });
+      });
+
+    test('registers the queue (direct POST) with apply_markdown=false for raw-markdown mentions', async () => {
+      const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+      mockEventsRetrieve.mockImplementation(() => new Promise(() => {})); // block live loop
+      await adapter.start();
+      const reg = mockFetch.mock.calls.find(c => String(c[0]).endsWith('/api/v1/register'));
+      expect(reg).toBeDefined();
+      const body = String((reg![1] as { body?: unknown }).body);
+      expect(body).toContain('apply_markdown=false');
+      // subscribes to message + update_message (so edit-to-add-mention is delivered)
+      expect(decodeURIComponent(body)).toContain('update_message');
+      adapter.stop();
+    });
+
+    test('answers unread mentions and DMs oldest-first; defers mark-read until a reply', async () => {
+      process.env.ZULIP_BOT_FULL_NAME = 'TestBot';
+      try {
+        const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+        const handled: number[] = [];
+        adapter.onMessage(m => {
+          handled.push(m.id);
+          return Promise.resolve(); // handler does not post a reply
+        });
+        mockEventsRetrieve.mockImplementation(() => new Promise(() => {})); // block live loop
+        retrieveReturning([mention(10)], [dm(7)]);
+
+        await adapter.start();
+        await flush();
+        await flush();
+
+        expect(handled).toEqual([7, 10]); // sorted by id ascending
+        // No reply was posted, so nothing is marked read yet — it stays unread for retry.
+        const flagsCalls = mockFetch.mock.calls.filter(c =>
+          String(c[0]).endsWith('/api/v1/messages/flags')
+        );
+        expect(flagsCalls.length).toBe(0);
+        adapter.stop();
+      } finally {
+        delete process.env.ZULIP_BOT_FULL_NAME;
+      }
+    });
+
+    test('marks an incoming message read only after a reply is posted', async () => {
+      process.env.ZULIP_BOT_FULL_NAME = 'TestBot';
+      try {
+        const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+        (adapter as unknown as { client: typeof mockZulipClient }).client = mockZulipClient;
+        adapter.onMessage(() => Promise.resolve());
+
+        // Incoming stream mention (id 10, stream_id 1, topic 'topic') -> conversationId stream:1:topic
+        await (
+          adapter as unknown as { handleIncomingMessage: (m: ZulipMessage) => Promise<void> }
+        ).handleIncomingMessage(mention(10));
+
+        // Not marked read yet — no reply has been posted.
+        expect(
+          mockFetch.mock.calls.filter(c => String(c[0]).endsWith('/api/v1/messages/flags')).length
+        ).toBe(0);
+
+        // Posting a reply to that conversation marks the queued id read.
+        await adapter.sendMessage('stream:1:topic', 'hi back');
+
+        const flags = mockFetch.mock.calls.filter(c =>
+          String(c[0]).endsWith('/api/v1/messages/flags')
+        );
+        expect(flags.length).toBe(1);
+        expect(decodeURIComponent(String((flags[0]![1] as { body?: unknown }).body))).toContain(
+          'messages=[10]'
+        );
+      } finally {
+        delete process.env.ZULIP_BOT_FULL_NAME;
+      }
+    });
+
+    test('does not answer a message delivered by both backfill and the live queue', async () => {
+      process.env.ZULIP_BOT_FULL_NAME = 'TestBot';
+      try {
+        const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+        const handled: number[] = [];
+        adapter.onMessage(m => {
+          handled.push(m.id);
+          return Promise.resolve();
+        });
+        retrieveReturning([], [dm(42)]);
+        // Live queue delivers the SAME message once, then blocks.
+        let delivered = false;
+        mockEventsRetrieve.mockImplementation(() => {
+          if (delivered) return new Promise(() => {});
+          delivered = true;
+          return Promise.resolve({ events: [{ type: 'message', id: 1, message: dm(42) }] });
+        });
+
+        await adapter.start();
+        await flush();
+        await flush();
+        await flush();
+
+        expect(handled).toEqual([42]); // handled exactly once
+        adapter.stop();
+      } finally {
+        delete process.env.ZULIP_BOT_FULL_NAME;
+      }
+    });
+  });
+
+  describe('edited messages (edit-to-add-mention)', () => {
+    const edited = (id: number, content: string): ZulipMessage => ({
+      id,
+      sender_id: 5,
+      sender_email: 'u@test.com',
+      sender_full_name: 'U',
+      content,
+      type: 'stream',
+      stream_id: 1,
+      subject: 'topic',
+      display_recipient: 'general',
+    });
+    const callEdit = (a: ZulipAdapter, id: number): Promise<void> =>
+      (a as unknown as { handleEditedMessage: (i: number) => Promise<void> }).handleEditedMessage(
+        id
+      );
+
+    test('answers a message edited to add a mention', async () => {
+      process.env.ZULIP_BOT_FULL_NAME = 'TestBot';
+      try {
+        const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+        (adapter as unknown as { client: typeof mockZulipClient }).client = mockZulipClient;
+        const handled: number[] = [];
+        adapter.onMessage(m => {
+          handled.push(m.id);
+          return Promise.resolve();
+        });
+        mockMessagesRetrieve.mockImplementation(() =>
+          Promise.resolve({ messages: [edited(55, '@**TestBot** now mentioned')] })
+        );
+
+        await callEdit(adapter, 55);
+
+        expect(handled).toEqual([55]);
+      } finally {
+        delete process.env.ZULIP_BOT_FULL_NAME;
+      }
+    });
+
+    test('ignores an edit that still has no mention', async () => {
+      process.env.ZULIP_BOT_FULL_NAME = 'TestBot';
+      try {
+        const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+        (adapter as unknown as { client: typeof mockZulipClient }).client = mockZulipClient;
+        const handled: number[] = [];
+        adapter.onMessage(m => {
+          handled.push(m.id);
+          return Promise.resolve();
+        });
+        mockMessagesRetrieve.mockImplementation(() =>
+          Promise.resolve({ messages: [edited(56, 'still no mention')] })
+        );
+
+        await callEdit(adapter, 56);
+
+        expect(handled).toEqual([]);
+      } finally {
+        delete process.env.ZULIP_BOT_FULL_NAME;
+      }
+    });
+
+    test('does not re-fetch/re-handle an edit for an already-answered message', async () => {
+      const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+      (adapter as unknown as { client: typeof mockZulipClient }).client = mockZulipClient;
+      (adapter as unknown as { processedMessageIds: Set<number> }).processedMessageIds.add(77);
+      mockMessagesRetrieve.mockClear();
+
+      await callEdit(adapter, 77);
+
+      expect(mockMessagesRetrieve).not.toHaveBeenCalled(); // dedup short-circuits before fetch
+    });
+  });
+
+  describe('status messages', () => {
+    const streamMention = (): ZulipMessage => ({
+      id: 100,
+      sender_id: 5,
+      sender_email: 'u@test.com',
+      sender_full_name: 'U',
+      content: '@**TestBot** hello',
+      type: 'stream',
+      stream_id: 1,
+      subject: 'topic',
+      display_recipient: 'general',
+    });
+    const dm = (): ZulipMessage => ({
+      id: 101,
+      sender_id: 6,
+      sender_email: 'v@test.com',
+      sender_full_name: 'V',
+      content: 'ping',
+      type: 'private',
+      display_recipient: [{ id: 6, email: 'v@test.com', full_name: 'V' }],
+    });
+
+    const callHandle = (a: ZulipAdapter, msg: ZulipMessage): Promise<void> =>
+      (
+        a as unknown as { handleIncomingMessage: (m: ZulipMessage) => Promise<void> }
+      ).handleIncomingMessage(msg);
+
+    // Reset fetch mock to return a distinct id for status messages
+    const setupFetchWithId = (statusId: number): void => {
+      mockFetch.mockImplementation((_url?: unknown, _init?: unknown) =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ result: 'success', id: statusId, queue_id: 'q', last_event_id: 0 }),
+            { status: 200, headers: { 'content-type': 'application/json' } }
+          )
+        )
+      );
+    };
+
+    test('creates status message on stream mention, captures message_id', async () => {
+      process.env.ZULIP_BOT_FULL_NAME = 'TestBot';
+      try {
+        setupFetchWithId(42);
+        const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+        (adapter as unknown as { client: typeof mockZulipClient }).client = mockZulipClient;
+        adapter.onMessage(() => Promise.resolve());
+
+        await callHandle(adapter, streamMention());
+
+        const queues = (
+          adapter as unknown as {
+            statusMessageQueues: Map<string, Array<{ id: number; text: string }>>;
+          }
+        ).statusMessageQueues;
+        const conv = 'stream:1:topic';
+        expect(queues.has(conv)).toBe(true);
+        expect(queues.get(conv)![0]!.id).toBe(42);
+        expect(queues.get(conv)![0]!.text).toMatch(/Starting thinking\.\.\./);
+      } finally {
+        delete process.env.ZULIP_BOT_FULL_NAME;
+      }
+    });
+
+    test('creates status message on DM', async () => {
+      setupFetchWithId(99);
+      const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+      (adapter as unknown as { client: typeof mockZulipClient }).client = mockZulipClient;
+      adapter.onMessage(() => Promise.resolve());
+
+      await callHandle(adapter, dm());
+
+      const queues = (
+        adapter as unknown as {
+          statusMessageQueues: Map<string, Array<{ id: number; text: string }>>;
+        }
+      ).statusMessageQueues;
+      const conv = 'private:6';
+      expect(queues.has(conv)).toBe(true);
+      expect(queues.get(conv)![0]!.id).toBe(99);
+    });
+
+    test('status message has no header — only timestamped lines', async () => {
+      process.env.ZULIP_BOT_FULL_NAME = 'TestBot';
+      try {
+        setupFetchWithId(55);
+        const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+        (adapter as unknown as { client: typeof mockZulipClient }).client = mockZulipClient;
+        adapter.onMessage(() => Promise.resolve());
+        mockFetch.mockClear();
+
+        await callHandle(adapter, streamMention());
+
+        const statusCall = mockFetch.mock.calls.find(c =>
+          String((c[1] as { body?: unknown }).body).includes('Starting+thinking')
+        );
+        expect(statusCall).toBeDefined();
+        const rawBody = String((statusCall![1] as { body?: unknown }).body);
+        const content = new URLSearchParams(rawBody).get('content') ?? '';
+        // Must NOT contain a title/header before the timestamp line
+        expect(content).not.toMatch(/^#/);
+        expect(content).toMatch(/\d{2}:\d{2}:\d{2} Starting thinking\.\.\./);
+      } finally {
+        delete process.env.ZULIP_BOT_FULL_NAME;
+      }
+    });
+
+    test('on success: status edited with "Done thinking." then answer posted separately', async () => {
+      process.env.ZULIP_BOT_FULL_NAME = 'TestBot';
+      try {
+        const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+        (adapter as unknown as { client: typeof mockZulipClient }).client = mockZulipClient;
+        adapter.onMessage(() => Promise.resolve());
+
+        // Phase 1: handle incoming — status message created with id=77
+        setupFetchWithId(77);
+        await callHandle(adapter, streamMention());
+        mockFetch.mockClear();
+
+        // Phase 2: answer arrives
+        setupFetchWithId(0); // id doesn't matter for the answer POST
+        await adapter.sendMessage('stream:1:topic', 'The answer');
+
+        const calls = mockFetch.mock.calls;
+        // First call should be PATCH to update status (messages/77)
+        const patchCall = calls.find(
+          c =>
+            String(c[0]).includes('/messages/77') &&
+            (c[1] as { method?: string }).method === 'PATCH'
+        );
+        expect(patchCall).toBeDefined();
+        const patchBody =
+          new URLSearchParams(String((patchCall![1] as { body?: unknown }).body)).get('content') ??
+          '';
+        expect(patchBody).toContain('Done thinking.');
+        expect(patchBody).not.toContain('FAILED');
+
+        // Second call should be POST of the actual answer
+        const answerCall = calls.find(
+          c =>
+            String(c[0]).endsWith('/api/v1/messages') &&
+            (c[1] as { method?: string }).method === 'POST' &&
+            String((c[1] as { body?: unknown }).body).includes('The+answer')
+        );
+        expect(answerCall).toBeDefined();
+
+        // Status message queue must be cleared after the answer
+        const queues = (
+          adapter as unknown as {
+            statusMessageQueues: Map<string, Array<{ id: number; text: string }>>;
+          }
+        ).statusMessageQueues;
+        expect(queues.has('stream:1:topic')).toBe(false);
+      } finally {
+        delete process.env.ZULIP_BOT_FULL_NAME;
+      }
+    });
+
+    test('on failure: status edited with "Done thinking (FAILED)." and error posted in place of answer', async () => {
+      process.env.ZULIP_BOT_FULL_NAME = 'TestBot';
+      try {
+        const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+        (adapter as unknown as { client: typeof mockZulipClient }).client = mockZulipClient;
+        adapter.onMessage(() => Promise.resolve());
+
+        setupFetchWithId(88);
+        await callHandle(adapter, streamMention());
+        mockFetch.mockClear();
+        setupFetchWithId(0);
+
+        await adapter.sendMessage('stream:1:topic', 'Something went wrong', { isError: true });
+
+        const calls = mockFetch.mock.calls;
+        const patchCall = calls.find(
+          c =>
+            String(c[0]).includes('/messages/88') &&
+            (c[1] as { method?: string }).method === 'PATCH'
+        );
+        expect(patchCall).toBeDefined();
+        const patchBody =
+          new URLSearchParams(String((patchCall![1] as { body?: unknown }).body)).get('content') ??
+          '';
+        expect(patchBody).toContain('Done thinking (FAILED).');
+
+        const errorCall = calls.find(
+          c =>
+            String(c[0]).endsWith('/api/v1/messages') &&
+            (c[1] as { method?: string }).method === 'POST' &&
+            String((c[1] as { body?: unknown }).body).includes('went+wrong')
+        );
+        expect(errorCall).toBeDefined();
+      } finally {
+        delete process.env.ZULIP_BOT_FULL_NAME;
+      }
+    });
+
+    test('concurrent mentions in different conversations get independent status messages', async () => {
+      process.env.ZULIP_BOT_FULL_NAME = 'TestBot';
+      try {
+        let nextId = 200;
+        mockFetch.mockImplementation(() =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({ result: 'success', id: nextId++, queue_id: 'q', last_event_id: 0 }),
+              { status: 200, headers: { 'content-type': 'application/json' } }
+            )
+          )
+        );
+        const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+        (adapter as unknown as { client: typeof mockZulipClient }).client = mockZulipClient;
+        adapter.onMessage(() => Promise.resolve());
+
+        const msgConv1: ZulipMessage = {
+          ...streamMention(),
+          id: 1,
+          stream_id: 1,
+          subject: 'topic-a',
+        };
+        const msgConv2: ZulipMessage = {
+          ...streamMention(),
+          id: 2,
+          stream_id: 2,
+          subject: 'topic-b',
+        };
+
+        await callHandle(adapter, msgConv1);
+        await callHandle(adapter, msgConv2);
+
+        const queues = (
+          adapter as unknown as {
+            statusMessageQueues: Map<string, Array<{ id: number; text: string }>>;
+          }
+        ).statusMessageQueues;
+        expect(queues.get('stream:1:topic-a')![0]!.id).not.toBe(
+          queues.get('stream:2:topic-b')![0]!.id
+        );
+      } finally {
+        delete process.env.ZULIP_BOT_FULL_NAME;
+      }
+    });
+
+    test('FIFO: two mentions for same conversation get separate status messages in order', async () => {
+      process.env.ZULIP_BOT_FULL_NAME = 'TestBot';
+      try {
+        let nextId = 300;
+        mockFetch.mockImplementation(() =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({ result: 'success', id: nextId++, queue_id: 'q', last_event_id: 0 }),
+              { status: 200, headers: { 'content-type': 'application/json' } }
+            )
+          )
+        );
+        const adapter = new ZulipAdapter('https://test.zulipchat.com', 'bot@test.com', 'key');
+        (adapter as unknown as { client: typeof mockZulipClient }).client = mockZulipClient;
+        adapter.onMessage(() => Promise.resolve());
+
+        const msg1: ZulipMessage = { ...streamMention(), id: 10 };
+        const msg2: ZulipMessage = { ...streamMention(), id: 11 };
+
+        await callHandle(adapter, msg1); // creates status id=300
+        await callHandle(adapter, msg2); // creates status id=301 (but id=10 is already processed)
+
+        const queues = (
+          adapter as unknown as {
+            statusMessageQueues: Map<string, Array<{ id: number; text: string }>>;
+          }
+        ).statusMessageQueues;
+        // msg2 is ignored by processedMessageIds (id=11 not yet processed) but msg1 is deduped
+        // The important thing: at most 1 entry queued per unique message
+        const q = queues.get('stream:1:topic') ?? [];
+        expect(q.length).toBe(2);
+        expect(q[0]!.id).toBe(300);
+        expect(q[1]!.id).toBe(301);
+      } finally {
+        delete process.env.ZULIP_BOT_FULL_NAME;
+      }
+    });
+  });
+});

--- a/packages/adapters/src/community/chat/zulip/adapter.ts
+++ b/packages/adapters/src/community/chat/zulip/adapter.ts
@@ -35,8 +35,8 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-/** Returns current UTC time formatted as HH:MM:SS. */
-function formatUtcTime(): string {
+/** Returns current UTC time formatted as HH:MM:SS. Exported for isolated unit testing. */
+export function formatUtcTime(): string {
   const now = new Date();
   const h = String(now.getUTCHours()).padStart(2, '0');
   const m = String(now.getUTCMinutes()).padStart(2, '0');
@@ -75,8 +75,12 @@ export class ZulipAdapter implements IPlatformAdapter {
     this.botEmail = botEmail;
     this.apiKey = apiKey;
     this.streamingMode = mode;
+    // TODO: `mode === 'stream'` is accepted but currently has no runtime effect — every reply
+    // path uses the batch-style "Starting thinking…" / "Done thinking." status edits.
+    // True progressive token streaming would require splitting `sendMessage` and editing the
+    // answer message in place; until then, callers picking `stream` get the same UX as `batch`.
     this.allowedUserIds = parseAllowedUserIds(process.env.ZULIP_ALLOWED_USER_IDS);
-    // zulip-js@1 has no /users/me endpoint — bot full name must be supplied via env
+    // bot full name (required for @mention detection — must be set via env)
     this.botFullName = process.env.ZULIP_BOT_FULL_NAME ?? '';
 
     if (this.allowedUserIds.length > 0) {
@@ -149,7 +153,15 @@ export class ZulipAdapter implements IPlatformAdapter {
       const statusEntry = statusQueue.shift();
       // `length > 0` above guarantees a value, but the codebase forbids `!` non-null assertions
       // (eslint `no-non-null-assertion`), so we keep this defensive narrowing for the type-checker.
-      if (statusEntry === undefined) return;
+      // If we ever hit this branch in practice, the per-conversation queue invariant has been
+      // violated — log loudly so it's not silently swallowed.
+      if (statusEntry === undefined) {
+        getLog().error(
+          { conversationId, queueLength: statusQueue.length },
+          'zulip.status_queue_inconsistency'
+        );
+        return;
+      }
       const queueNowEmpty = statusQueue.length === 0;
       if (queueNowEmpty) {
         this.statusMessageQueues.delete(conversationId);
@@ -467,7 +479,7 @@ export class ZulipAdapter implements IPlatformAdapter {
         for (const event of eventsResult.events) {
           lastEventId = event.id;
           if (event.type === 'message' && event.message) {
-            // zulip-js ships no types; message shape matches ZulipMessage per Zulip API docs
+            // zulip-js ships no types; casting from their untyped event shape to ZulipMessage.
             await this.handleIncomingMessage(event.message as ZulipMessage);
           } else if (event.type === 'update_message' && typeof event.message_id === 'number') {
             // A message edited to ADD an @mention arrives only as update_message — re-evaluate it.
@@ -552,7 +564,10 @@ export class ZulipAdapter implements IPlatformAdapter {
       const oldestKey = this.replyContexts.keys().next().value;
       if (oldestKey !== undefined) this.replyContexts.delete(oldestKey);
     }
-    if (msg.type === 'stream' && msg.stream_id !== undefined && msg.subject !== undefined) {
+    // Use `typeof === 'number'` (not `!== undefined`) for the numeric check so the intent is
+    // explicit; both forms accept any valid Zulip stream ID (which start at 1, but `0` would
+    // also pass — we don't gate on truthiness).
+    if (msg.type === 'stream' && typeof msg.stream_id === 'number' && msg.subject !== undefined) {
       this.replyContexts.set(conversationId, {
         type: 'stream',
         stream_id: msg.stream_id,
@@ -573,7 +588,6 @@ export class ZulipAdapter implements IPlatformAdapter {
     // (during backfill) short-circuits at the dedup check above.
     this.rememberProcessed(msg.id);
 
-    // Post "Starting thinking..." immediately after reply target is known.
     await this.createStatusMessage(conversationId);
 
     // Defer mark-read until the reply is actually posted (sendMessage). The handler is

--- a/packages/adapters/src/community/chat/zulip/adapter.ts
+++ b/packages/adapters/src/community/chat/zulip/adapter.ts
@@ -175,11 +175,7 @@ export class ZulipAdapter implements IPlatformAdapter {
       // Post the error as a new message in place of the normal answer.
       await this.postChunk(ctx, text);
 
-      const pending = this.pendingReadIds.get(conversationId);
-      if (pending && pending.length > 0) {
-        this.pendingReadIds.delete(conversationId);
-        for (const id of pending) await this.markRead(id);
-      }
+      await this.markOldestPendingRead(conversationId);
       return;
     }
 
@@ -189,11 +185,22 @@ export class ZulipAdapter implements IPlatformAdapter {
       await this.postChunk(ctx, chunk);
     }
 
+    await this.markOldestPendingRead(conversationId);
+  }
+
+  /**
+   * Mark exactly one pending inbound message (the oldest, FIFO) read for this conversation —
+   * the message this reply answers. Each inbound message produces one terminal `sendMessage`
+   * (answer or error) and pushes one id via `handleIncomingMessage`, mirroring the status-message
+   * FIFO. Draining the whole list per reply would ack still-unanswered messages: with two queued,
+   * the first reply would mark both read, and a crash before the second reply posts would lose it.
+   */
+  private async markOldestPendingRead(conversationId: string): Promise<void> {
     const pending = this.pendingReadIds.get(conversationId);
-    if (pending && pending.length > 0) {
-      this.pendingReadIds.delete(conversationId);
-      for (const id of pending) await this.markRead(id);
-    }
+    if (!pending || pending.length === 0) return;
+    const id = pending.shift();
+    if (pending.length === 0) this.pendingReadIds.delete(conversationId);
+    if (id !== undefined) await this.markRead(id);
   }
 
   /** Post a single chunk to the correct Zulip conversation (stream or DM). */
@@ -448,8 +455,11 @@ export class ZulipAdapter implements IPlatformAdapter {
         // which would silently re-register a default queue (all event types, apply_markdown=true
         // → rendered HTML), and @**mention** detection would then never match again.
         try {
+          // Re-register with the SAME event types as start() (QUEUE_EVENT_TYPES). Dropping
+          // `update_message` here would silently lose edited-message @mention detection after
+          // any queue error — diverging from startup behavior and the adapter's contract.
           const queueResult = await this.zulipPost('register', {
-            event_types: JSON.stringify(['message']),
+            event_types: QUEUE_EVENT_TYPES,
             apply_markdown: 'false',
           });
           queueId = String(queueResult.queue_id);

--- a/packages/adapters/src/community/chat/zulip/adapter.ts
+++ b/packages/adapters/src/community/chat/zulip/adapter.ts
@@ -1,0 +1,557 @@
+import type { IPlatformAdapter, MessageMetadata } from '@archon/core';
+import { createLogger } from '@archon/paths';
+import zulip from 'zulip-js';
+import type { ZulipMessage, ZulipReplyContext } from './types';
+import { parseAllowedUserIds, isZulipUserAuthorized } from './auth';
+import { splitIntoParagraphChunks } from '../../../utils/message-splitting';
+
+/** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
+let cachedLog: ReturnType<typeof createLogger> | undefined;
+function getLog(): ReturnType<typeof createLogger> {
+  if (!cachedLog) cachedLog = createLogger('adapter.zulip');
+  return cachedLog;
+}
+
+const MAX_LENGTH = 9800;
+const REPLY_CONTEXTS_MAX = 1000;
+/** Max missed messages handled per boot, so a long outage can't trigger a flood of replies. */
+const BACKFILL_MAX = 50;
+/** Cap on the in-memory set of recently handled message ids (dedupes backfill vs live queue). */
+const PROCESSED_IDS_MAX = 2000;
+/** Minimum milliseconds between consecutive status-message edits (debounce guard). */
+const STATUS_MIN_INTERVAL_MS = 500;
+/**
+ * Event types the bot's queue subscribes to. `update_message` is required so that a message
+ * edited to ADD an @mention (the user forgot it the first time) is picked up — edits do not
+ * arrive as `message` events.
+ */
+const QUEUE_EVENT_TYPES = JSON.stringify(['message', 'update_message']);
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/** Returns current UTC time formatted as HH:MM:SS. */
+function formatUtcTime(): string {
+  const now = new Date();
+  const h = String(now.getUTCHours()).padStart(2, '0');
+  const m = String(now.getUTCMinutes()).padStart(2, '0');
+  const s = String(now.getUTCSeconds()).padStart(2, '0');
+  return `${h}:${m}:${s}`;
+}
+
+export class ZulipAdapter implements IPlatformAdapter {
+  private readonly serverUrl: string;
+  private readonly botEmail: string;
+  private readonly apiKey: string;
+  private streamingMode: 'stream' | 'batch';
+  private allowedUserIds: number[];
+  private replyContexts = new Map<string, ZulipReplyContext>();
+  private processedMessageIds = new Set<number>();
+  // conversationId -> incoming message ids awaiting a reply; marked read only once a reply
+  // is actually posted, so a failed send leaves the message unread for the next boot to retry.
+  private pendingReadIds = new Map<string, number[]>();
+  // conversationId -> FIFO queue of status messages awaiting their answer or error.
+  // Each entry holds the Zulip message_id and accumulated text (full replacement on edit).
+  private statusMessageQueues = new Map<string, { id: number; text: string }[]>();
+  // Last timestamp (Date.now()) a status message was edited, keyed by conversationId.
+  private statusLastEdit = new Map<string, number>();
+  private client: Awaited<ReturnType<typeof zulip>> | null = null;
+  private messageHandler: ((msg: ZulipMessage) => Promise<void>) | null = null;
+  private running = false;
+  private botFullName = '';
+
+  constructor(
+    serverUrl: string,
+    botEmail: string,
+    apiKey: string,
+    mode: 'stream' | 'batch' = 'batch'
+  ) {
+    this.serverUrl = serverUrl;
+    this.botEmail = botEmail;
+    this.apiKey = apiKey;
+    this.streamingMode = mode;
+    this.allowedUserIds = parseAllowedUserIds(process.env.ZULIP_ALLOWED_USER_IDS);
+    // zulip-js@1 has no /users/me endpoint — bot full name must be supplied via env
+    this.botFullName = process.env.ZULIP_BOT_FULL_NAME ?? '';
+
+    if (this.allowedUserIds.length > 0) {
+      getLog().info({ userCount: this.allowedUserIds.length }, 'zulip.whitelist_enabled');
+    } else {
+      getLog().info('zulip.whitelist_disabled');
+    }
+    if (!this.botFullName) {
+      getLog().warn(
+        'zulip.bot_full_name_not_set — set ZULIP_BOT_FULL_NAME; stream @mention detection disabled'
+      );
+    }
+    getLog().info({ mode }, 'zulip.adapter_initialized');
+  }
+
+  getStreamingMode(): 'stream' | 'batch' {
+    return this.streamingMode;
+  }
+
+  getPlatformType(): string {
+    return 'zulip';
+  }
+
+  getConversationId(msg: ZulipMessage): string {
+    if (msg.type === 'stream') {
+      return `stream:${msg.stream_id}:${msg.subject ?? ''}`;
+    }
+    const recipients = msg.display_recipient as { id: number }[];
+    const ids = recipients
+      .map(r => r.id)
+      .sort((a, b) => a - b)
+      .join(':');
+    return `private:${ids}`;
+  }
+
+  stripBotMention(content: string): string {
+    if (!this.botFullName) return content;
+    const pattern = new RegExp(`@\\*\\*${escapeRegex(this.botFullName)}\\*\\*\\s*`, 'g');
+    return content.replace(pattern, '').trim();
+  }
+
+  /** Zulip topics serve as threads — no additional threading needed. */
+  async ensureThread(originalConversationId: string, _messageContext?: unknown): Promise<string> {
+    return originalConversationId;
+  }
+
+  onMessage(handler: (msg: ZulipMessage) => Promise<void>): void {
+    this.messageHandler = handler;
+  }
+
+  async sendMessage(
+    conversationId: string,
+    text: string,
+    metadata?: MessageMetadata
+  ): Promise<void> {
+    if (!this.client) {
+      getLog().error({ conversationId }, 'zulip.send_before_start');
+      return;
+    }
+    const ctx = this.replyContexts.get(conversationId);
+    if (!ctx) {
+      getLog().error({ conversationId }, 'zulip.no_reply_context');
+      return;
+    }
+
+    const isError = metadata?.isError === true;
+
+    // Edit and dequeue the oldest status message for this conversation (FIFO).
+    const statusQueue = this.statusMessageQueues.get(conversationId);
+    if (statusQueue && statusQueue.length > 0) {
+      const statusEntry = statusQueue.shift();
+      if (!statusEntry) return; // unreachable: length > 0 guarantees shift() succeeds
+      const queueNowEmpty = statusQueue.length === 0;
+      if (queueNowEmpty) {
+        this.statusMessageQueues.delete(conversationId);
+        this.statusLastEdit.delete(conversationId);
+      }
+
+      const doneLabel = isError ? 'Done thinking (FAILED).' : 'Done thinking.';
+      const newText = `${statusEntry.text}\n${formatUtcTime()} ${doneLabel}`;
+
+      const now = Date.now();
+      const lastEdit = this.statusLastEdit.get(conversationId) ?? 0;
+      if (now - lastEdit >= STATUS_MIN_INTERVAL_MS) {
+        if (!queueNowEmpty) this.statusLastEdit.set(conversationId, now);
+        await this.updateMessage(statusEntry.id, newText);
+      } else {
+        getLog().warn(
+          { conversationId, messageId: statusEntry.id },
+          'zulip.status_debounce_skipped'
+        );
+      }
+    }
+
+    if (isError) {
+      // Post the error as a new message in place of the normal answer.
+      await this.postChunk(ctx, text);
+
+      const pending = this.pendingReadIds.get(conversationId);
+      if (pending && pending.length > 0) {
+        this.pendingReadIds.delete(conversationId);
+        for (const id of pending) await this.markRead(id);
+      }
+      return;
+    }
+
+    // Normal path: post the answer (potentially split into chunks).
+    const chunks = text.length > MAX_LENGTH ? splitIntoParagraphChunks(text, MAX_LENGTH) : [text];
+    for (const chunk of chunks) {
+      await this.postChunk(ctx, chunk);
+    }
+
+    const pending = this.pendingReadIds.get(conversationId);
+    if (pending && pending.length > 0) {
+      this.pendingReadIds.delete(conversationId);
+      for (const id of pending) await this.markRead(id);
+    }
+  }
+
+  /** Post a single chunk to the correct Zulip conversation (stream or DM). */
+  private async postChunk(ctx: ZulipReplyContext, content: string): Promise<void> {
+    if (ctx.type === 'stream') {
+      await this.zulipPost('messages', {
+        type: 'stream',
+        to: String(ctx.stream_id),
+        topic: ctx.topic,
+        content,
+      });
+    } else {
+      await this.zulipPost('messages', {
+        type: 'private',
+        to: JSON.stringify(ctx.user_ids),
+        content,
+      });
+    }
+  }
+
+  async start(): Promise<void> {
+    this.client = await zulip({
+      realm: this.serverUrl,
+      username: this.botEmail,
+      apiKey: this.apiKey,
+    });
+
+    // Register the message event queue. apply_markdown:false delivers raw markdown so
+    // `@**FullName**` mentions match (the default is rendered HTML, in which the mention
+    // text never appears literally). Registered via a direct POST (zulipPost) rather than
+    // client.queues.register: zulip-js@1's POST path does not serialize the body under Bun,
+    // so event_types/apply_markdown would be dropped (see zulipPost).
+    const firstQueue = await this.zulipPost('register', {
+      event_types: QUEUE_EVENT_TYPES,
+      apply_markdown: 'false',
+    });
+    const queueId = String(firstQueue.queue_id);
+    const lastEventId = Number(firstQueue.last_event_id ?? -1);
+    this.running = true;
+    getLog().info({ botFullName: this.botFullName }, 'zulip.bot_started');
+
+    // Catch up on messages that arrived while the bot was offline (e.g. a maintenance
+    // window) before/alongside the live loop. Both run in the background — start() must
+    // return promptly (same pattern as TelegramAdapter). The dedup set + mark-read keep
+    // backfill and the live queue from answering the same message twice.
+    void this.backfillUnansweredMessages().catch(err => {
+      getLog().error({ err }, 'zulip.backfill_fatal_error');
+    });
+    void this.pollEventsFrom(queueId, lastEventId).catch(err => {
+      getLog().error({ err }, 'zulip.poll_fatal_error');
+    });
+  }
+
+  /**
+   * Answer messages that arrived while the bot was offline. The event queue is forward-only,
+   * so without this any message sent during downtime would be silently dropped. Zulip's
+   * "unread" state is the source of truth for "unanswered": fetch unread @mentions + unread
+   * DMs, process them oldest-first through the normal path, and mark each read (in
+   * handleIncomingMessage) so the next restart won't re-answer it.
+   */
+  private async backfillUnansweredMessages(): Promise<void> {
+    const client = this.client;
+    if (!client) return;
+
+    const fetchUnread = async (kind: 'mentioned' | 'private'): Promise<ZulipMessage[]> => {
+      try {
+        const res = await client.messages.retrieve({
+          anchor: 'newest',
+          num_before: BACKFILL_MAX,
+          num_after: 0,
+          narrow: [
+            { operator: 'is', operand: 'unread' },
+            { operator: 'is', operand: kind },
+          ],
+          apply_markdown: false,
+        });
+        return (res.messages as ZulipMessage[]) ?? [];
+      } catch (error) {
+        getLog().error({ err: error, kind }, 'zulip.backfill_fetch_failed');
+        return [];
+      }
+    };
+
+    const [mentions, dms] = await Promise.all([fetchUnread('mentioned'), fetchUnread('private')]);
+
+    // De-duplicate (a DM can also be a mention) and process oldest-first, capped.
+    const byId = new Map<number, ZulipMessage>();
+    for (const m of [...mentions, ...dms]) byId.set(m.id, m);
+    const missed = [...byId.values()].sort((a, b) => a.id - b.id).slice(-BACKFILL_MAX);
+
+    if (missed.length === 0) {
+      getLog().info('zulip.backfill_none');
+      return;
+    }
+    getLog().info({ count: missed.length }, 'zulip.backfill_started');
+    for (const msg of missed) {
+      try {
+        await this.handleIncomingMessage(msg);
+      } catch (error) {
+        getLog().error({ err: error, messageId: msg.id }, 'zulip.backfill_message_failed');
+      }
+    }
+    getLog().info({ count: missed.length }, 'zulip.backfill_completed');
+  }
+
+  /**
+   * POST (or PATCH) to the Zulip REST API directly, form-encoded. We bypass zulip-js's POST
+   * helper (isomorphic-fetch + isomorphic-form-data): under Bun its multipart body is not
+   * serialized, so the server receives no params ("Missing 'content' argument") and zulip-js
+   * returns the error object instead of throwing — making every send/register fail silently.
+   * Throws on any non-success response so callers can surface the failure. (zulip-js GETs are
+   * fine: they serialize params into the query string.)
+   */
+  private async zulipPost(
+    endpoint: string,
+    params: Record<string, string>,
+    method: 'POST' | 'PATCH' = 'POST'
+  ): Promise<Record<string, unknown>> {
+    const res = await fetch(`${this.serverUrl.replace(/\/+$/, '')}/api/v1/${endpoint}`, {
+      method,
+      headers: {
+        Authorization: `Basic ${Buffer.from(`${this.botEmail}:${this.apiKey}`).toString('base64')}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams(params),
+    });
+    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    if (!res.ok || body.result !== 'success') {
+      const detail = typeof body.msg === 'string' ? body.msg : '';
+      throw new Error(`Zulip ${method} /${endpoint} failed: HTTP ${res.status} ${detail}`.trim());
+    }
+    return body;
+  }
+
+  /**
+   * Mark a message read so it is not re-answered after a restart. Failures are logged, not
+   * thrown — at worst a missed mark-read causes one duplicate answer on the next boot.
+   */
+  private async markRead(messageId: number): Promise<void> {
+    try {
+      await this.zulipPost('messages/flags', {
+        messages: JSON.stringify([messageId]),
+        op: 'add',
+        flag: 'read',
+      });
+    } catch (error) {
+      getLog().warn({ err: error, messageId }, 'zulip.mark_read_failed');
+    }
+  }
+
+  /**
+   * Edit an existing Zulip message (replaces full content). Used to append status lines.
+   * Failures are logged and swallowed — status edits are best-effort.
+   */
+  private async updateMessage(messageId: number, content: string): Promise<void> {
+    try {
+      await this.zulipPost(`messages/${messageId}`, { content }, 'PATCH');
+    } catch (error) {
+      getLog().warn({ err: error, messageId }, 'zulip.status_message_update_failed');
+    }
+  }
+
+  /**
+   * Post the initial "Starting thinking..." status message for a conversation.
+   * Captures the returned message_id and pushes it onto the per-conversation FIFO queue.
+   * Best-effort: failures are logged and do not block normal message processing.
+   */
+  private async createStatusMessage(conversationId: string): Promise<void> {
+    const ctx = this.replyContexts.get(conversationId);
+    if (!ctx) return;
+
+    const initialText = `${formatUtcTime()} Starting thinking...`;
+    let response: Record<string, unknown>;
+    try {
+      if (ctx.type === 'stream') {
+        response = await this.zulipPost('messages', {
+          type: 'stream',
+          to: String(ctx.stream_id),
+          topic: ctx.topic,
+          content: initialText,
+        });
+      } else {
+        response = await this.zulipPost('messages', {
+          type: 'private',
+          to: JSON.stringify(ctx.user_ids),
+          content: initialText,
+        });
+      }
+    } catch (error) {
+      getLog().warn({ err: error, conversationId }, 'zulip.status_message_create_failed');
+      return;
+    }
+
+    const messageId = typeof response.id === 'number' ? response.id : undefined;
+    if (messageId === undefined) {
+      getLog().warn({ conversationId, response }, 'zulip.status_message_no_id');
+      return;
+    }
+
+    const queue = this.statusMessageQueues.get(conversationId) ?? [];
+    queue.push({ id: messageId, text: initialText });
+    this.statusMessageQueues.set(conversationId, queue);
+    getLog().debug({ conversationId, messageId }, 'zulip.status_message_created');
+  }
+
+  /** Record a handled message id, evicting the oldest (FIFO) past the cap. */
+  private rememberProcessed(id: number): void {
+    if (this.processedMessageIds.size >= PROCESSED_IDS_MAX) {
+      const oldest = this.processedMessageIds.values().next().value;
+      if (oldest !== undefined) this.processedMessageIds.delete(oldest);
+    }
+    this.processedMessageIds.add(id);
+  }
+
+  stop(): void {
+    this.running = false;
+    getLog().info('zulip.bot_stopped');
+  }
+
+  private async pollEventsFrom(initialQueueId: string, initialLastEventId: number): Promise<void> {
+    // client is guaranteed non-null here — called only from start()
+    const client = this.client;
+    if (!client) return;
+
+    let queueId = initialQueueId;
+    let lastEventId = initialLastEventId;
+
+    while (this.running) {
+      try {
+        const eventsResult = await client.events.retrieve({
+          queue_id: queueId,
+          last_event_id: lastEventId,
+          dont_block: false,
+        });
+
+        for (const event of eventsResult.events) {
+          lastEventId = event.id;
+          if (event.type === 'message' && event.message) {
+            // zulip-js ships no types; message shape matches ZulipMessage per Zulip API docs
+            await this.handleIncomingMessage(event.message as ZulipMessage);
+          } else if (event.type === 'update_message' && typeof event.message_id === 'number') {
+            // A message edited to ADD an @mention arrives only as update_message — re-evaluate it.
+            await this.handleEditedMessage(event.message_id);
+          }
+        }
+      } catch (error) {
+        if (!this.running) break;
+        const err = error as Error;
+        getLog().error({ err }, 'zulip.poll_error');
+        // Re-register queue on error (e.g., queue expired after inactivity). Use the same
+        // direct POST as start() — client.queues.register (zulip-js) drops its body under Bun,
+        // which would silently re-register a default queue (all event types, apply_markdown=true
+        // → rendered HTML), and @**mention** detection would then never match again.
+        try {
+          const queueResult = await this.zulipPost('register', {
+            event_types: JSON.stringify(['message']),
+            apply_markdown: 'false',
+          });
+          queueId = String(queueResult.queue_id);
+          lastEventId = Number(queueResult.last_event_id ?? -1);
+        } catch (reregisterError) {
+          getLog().error({ err: reregisterError }, 'zulip.reregister_error');
+          await sleep(1000);
+        }
+      }
+    }
+  }
+
+  /**
+   * Handle a message edit (update_message event). The case we care about: a user forgot to
+   * @mention the bot and edited the message to add it — which never arrives as a `message`
+   * event. Fetch the current (edited) message and run it through the normal path; the
+   * mention/auth/self/dedup checks there decide whether to answer. Already-handled ids skip.
+   */
+  private async handleEditedMessage(messageId: number): Promise<void> {
+    if (this.processedMessageIds.has(messageId)) return;
+    const client = this.client;
+    if (!client) return;
+    let edited: ZulipMessage | undefined;
+    try {
+      const res = await client.messages.retrieve({
+        anchor: messageId,
+        num_before: 0,
+        num_after: 0,
+        narrow: [],
+        apply_markdown: false,
+      });
+      edited = (res.messages as ZulipMessage[])[0];
+    } catch (error) {
+      getLog().error({ err: error, messageId }, 'zulip.fetch_edited_failed');
+      return;
+    }
+    if (edited?.id === messageId) await this.handleIncomingMessage(edited);
+  }
+
+  private async handleIncomingMessage(msg: ZulipMessage): Promise<void> {
+    // Skip anything already handled this run (dedupes backfill vs the live queue).
+    if (this.processedMessageIds.has(msg.id)) return;
+
+    // Ignore bot's own messages
+    if (msg.sender_email === this.botEmail) return;
+
+    // Authorization check
+    if (!isZulipUserAuthorized(msg.sender_id, this.allowedUserIds)) {
+      const maskedId = `${String(msg.sender_id).slice(0, 4)}***`;
+      getLog().info({ maskedUserId: maskedId }, 'zulip.unauthorized_message');
+      return;
+    }
+
+    // Stream messages require @mention; private messages always respond
+    if (msg.type === 'stream') {
+      const mention = `@**${this.botFullName}**`;
+      if (!msg.content.includes(mention)) return;
+    }
+
+    const conversationId = this.getConversationId(msg);
+
+    // Store reply context so sendMessage can route responses correctly.
+    // FIFO eviction at REPLY_CONTEXTS_MAX entries prevents unbounded growth in
+    // deployments with many topics (Map iteration order is insertion order).
+    if (this.replyContexts.size >= REPLY_CONTEXTS_MAX) {
+      const oldestKey = this.replyContexts.keys().next().value;
+      if (oldestKey !== undefined) this.replyContexts.delete(oldestKey);
+    }
+    if (msg.type === 'stream' && msg.stream_id !== undefined && msg.subject !== undefined) {
+      this.replyContexts.set(conversationId, {
+        type: 'stream',
+        stream_id: msg.stream_id,
+        topic: msg.subject,
+      });
+    } else if (msg.type === 'private') {
+      const recipients = msg.display_recipient as { id: number }[];
+      this.replyContexts.set(conversationId, {
+        type: 'private',
+        user_ids: recipients.map(r => r.id),
+      });
+    } else {
+      getLog().warn({ conversationId }, 'zulip.incomplete_stream_message');
+      return;
+    }
+
+    // Mark processed BEFORE any await so a concurrent live delivery of the same id
+    // (during backfill) short-circuits at the dedup check above.
+    this.rememberProcessed(msg.id);
+
+    // Post "Starting thinking..." immediately after reply target is known.
+    await this.createStatusMessage(conversationId);
+
+    // Defer mark-read until the reply is actually posted (sendMessage). The handler is
+    // fire-and-forget — it returns before the AI response is sent — so marking read here
+    // would mark a message answered before (or even if) the reply ever goes out. Queue the
+    // id against this conversation; sendMessage marks it read once a reply succeeds.
+    const pending = this.pendingReadIds.get(conversationId) ?? [];
+    pending.push(msg.id);
+    this.pendingReadIds.set(conversationId, pending);
+
+    if (this.messageHandler) {
+      await this.messageHandler(msg);
+    }
+  }
+}

--- a/packages/adapters/src/community/chat/zulip/adapter.ts
+++ b/packages/adapters/src/community/chat/zulip/adapter.ts
@@ -144,11 +144,12 @@ export class ZulipAdapter implements IPlatformAdapter {
 
     const isError = metadata?.isError === true;
 
-    // Edit and dequeue the oldest status message for this conversation (FIFO).
     const statusQueue = this.statusMessageQueues.get(conversationId);
     if (statusQueue && statusQueue.length > 0) {
       const statusEntry = statusQueue.shift();
-      if (!statusEntry) return; // unreachable: length > 0 guarantees shift() succeeds
+      // `length > 0` above guarantees a value, but the codebase forbids `!` non-null assertions
+      // (eslint `no-non-null-assertion`), so we keep this defensive narrowing for the type-checker.
+      if (statusEntry === undefined) return;
       const queueNowEmpty = statusQueue.length === 0;
       if (queueNowEmpty) {
         this.statusMessageQueues.delete(conversationId);
@@ -172,14 +173,15 @@ export class ZulipAdapter implements IPlatformAdapter {
     }
 
     if (isError) {
-      // Post the error as a new message in place of the normal answer.
       await this.postChunk(ctx, text);
-
       await this.markOldestPendingRead(conversationId);
       return;
     }
 
-    // Normal path: post the answer (potentially split into chunks).
+    // Partial-delivery contract: Zulip has no atomic multi-post API and we don't retract earlier
+    // chunks if a later one fails. A throw mid-loop therefore leaves the user with a truncated
+    // answer in the topic — the throw bubbles up to the caller's logging, and the inbound message
+    // is intentionally NOT marked read (see markOldestPendingRead) so the next boot can retry.
     const chunks = text.length > MAX_LENGTH ? splitIntoParagraphChunks(text, MAX_LENGTH) : [text];
     for (const chunk of chunks) {
       await this.postChunk(ctx, chunk);
@@ -221,6 +223,18 @@ export class ZulipAdapter implements IPlatformAdapter {
     }
   }
 
+  /**
+   * Start the Zulip bot: connect, register the event queue, run backfill + poll in background.
+   *
+   * Queue registration uses `apply_markdown:false` so we receive RAW markdown — mentions arrive
+   * as `@**FullName**` literals (the default `apply_markdown:true` returns rendered HTML, in
+   * which the mention text never appears literally and so cannot be matched).
+   *
+   * The queue is registered via a direct POST (see `zulipPost`) rather than
+   * `client.queues.register`: under Bun, zulip-js@1's POST path does not serialize the body,
+   * which would silently drop `event_types`/`apply_markdown` (the server would then default to
+   * all event types + rendered HTML, breaking mention detection).
+   */
   async start(): Promise<void> {
     this.client = await zulip({
       realm: this.serverUrl,
@@ -228,11 +242,6 @@ export class ZulipAdapter implements IPlatformAdapter {
       apiKey: this.apiKey,
     });
 
-    // Register the message event queue. apply_markdown:false delivers raw markdown so
-    // `@**FullName**` mentions match (the default is rendered HTML, in which the mention
-    // text never appears literally). Registered via a direct POST (zulipPost) rather than
-    // client.queues.register: zulip-js@1's POST path does not serialize the body under Bun,
-    // so event_types/apply_markdown would be dropped (see zulipPost).
     const firstQueue = await this.zulipPost('register', {
       event_types: QUEUE_EVENT_TYPES,
       apply_markdown: 'false',
@@ -265,7 +274,11 @@ export class ZulipAdapter implements IPlatformAdapter {
     const client = this.client;
     if (!client) return;
 
-    const fetchUnread = async (kind: 'mentioned' | 'private'): Promise<ZulipMessage[]> => {
+    // Returns `undefined` on failure (vs `[]` = "fetched OK, none unread") so the caller can't
+    // mistake a downgraded API for a clean backfill cycle and silently swallow missed messages.
+    const fetchUnread = async (
+      kind: 'mentioned' | 'private'
+    ): Promise<ZulipMessage[] | undefined> => {
       try {
         const res = await client.messages.retrieve({
           anchor: 'newest',
@@ -280,11 +293,17 @@ export class ZulipAdapter implements IPlatformAdapter {
         return (res.messages as ZulipMessage[]) ?? [];
       } catch (error) {
         getLog().error({ err: error, kind }, 'zulip.backfill_fetch_failed');
-        return [];
+        return undefined;
       }
     };
 
     const [mentions, dms] = await Promise.all([fetchUnread('mentioned'), fetchUnread('private')]);
+    if (mentions === undefined || dms === undefined) {
+      // At least one fetch failed — bail on this cycle. The messages stay `unread` in Zulip, so
+      // the next restart's backfill (or the live event queue, once recovered) will retry them.
+      getLog().error('zulip.backfill_aborted');
+      return;
+    }
 
     // De-duplicate (a DM can also be a mention) and process oldest-first, capped.
     const byId = new Map<number, ZulipMessage>();
@@ -420,6 +439,15 @@ export class ZulipAdapter implements IPlatformAdapter {
     getLog().info('zulip.bot_stopped');
   }
 
+  /**
+   * Drive the Zulip event queue: pull events, dispatch messages, and re-register on errors.
+   *
+   * Re-registration on a queue error uses the same direct POST (`zulipPost`) + `QUEUE_EVENT_TYPES`
+   * as `start()` — `client.queues.register` (zulip-js) drops its body under Bun, which would
+   * silently re-register a default queue (all event types, `apply_markdown:true` → rendered HTML)
+   * and lose `@**mention**` detection. Keeping `update_message` in the event-types list is what
+   * preserves edited-message @mention pickup after a recovery.
+   */
   private async pollEventsFrom(initialQueueId: string, initialLastEventId: number): Promise<void> {
     // client is guaranteed non-null here — called only from start()
     const client = this.client;
@@ -450,14 +478,10 @@ export class ZulipAdapter implements IPlatformAdapter {
         if (!this.running) break;
         const err = error as Error;
         getLog().error({ err }, 'zulip.poll_error');
-        // Re-register queue on error (e.g., queue expired after inactivity). Use the same
-        // direct POST as start() — client.queues.register (zulip-js) drops its body under Bun,
-        // which would silently re-register a default queue (all event types, apply_markdown=true
-        // → rendered HTML), and @**mention** detection would then never match again.
+        // Re-register the queue (e.g. expired after inactivity). See the method docstring for
+        // why we go through `zulipPost` and reuse `QUEUE_EVENT_TYPES` instead of the zulip-js
+        // helper — both points are load-bearing for @mention and edited-message handling.
         try {
-          // Re-register with the SAME event types as start() (QUEUE_EVENT_TYPES). Dropping
-          // `update_message` here would silently lose edited-message @mention detection after
-          // any queue error — diverging from startup behavior and the adapter's contract.
           const queueResult = await this.zulipPost('register', {
             event_types: QUEUE_EVENT_TYPES,
             apply_markdown: 'false',

--- a/packages/adapters/src/community/chat/zulip/auth.test.ts
+++ b/packages/adapters/src/community/chat/zulip/auth.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for Zulip authorization utilities
+ */
+import { describe, test, expect } from 'bun:test';
+import { parseAllowedUserIds, isZulipUserAuthorized } from './auth';
+
+describe('zulip-auth', () => {
+  describe('parseAllowedUserIds', () => {
+    test('should return empty array for undefined (open access)', () => {
+      expect(parseAllowedUserIds(undefined)).toEqual([]);
+    });
+
+    test('should return empty array for empty string (open access)', () => {
+      expect(parseAllowedUserIds('')).toEqual([]);
+    });
+
+    test('should return empty array for whitespace-only string (open access)', () => {
+      expect(parseAllowedUserIds('   ')).toEqual([]);
+    });
+
+    test('should parse a single numeric user ID', () => {
+      expect(parseAllowedUserIds('123456789')).toEqual([123456789]);
+    });
+
+    test('should parse multiple numeric user IDs', () => {
+      expect(parseAllowedUserIds('111,222,333')).toEqual([111, 222, 333]);
+    });
+
+    test('should trim whitespace around IDs', () => {
+      expect(parseAllowedUserIds(' 111 , 222 , 333 ')).toEqual([111, 222, 333]);
+    });
+
+    test('should ignore empty segments between valid IDs', () => {
+      expect(parseAllowedUserIds('111,,222')).toEqual([111, 222]);
+    });
+
+    // Fail-CLOSED: a set-but-malformed allowlist must not collapse to open access.
+    test('should throw when a token is non-numeric', () => {
+      expect(() => parseAllowedUserIds('111,abc,222')).toThrow(/ZULIP_ALLOWED_USER_IDS/);
+    });
+
+    test('should throw when set but no valid IDs are present', () => {
+      expect(() => parseAllowedUserIds('abc')).toThrow(/ZULIP_ALLOWED_USER_IDS/);
+    });
+
+    test('should throw when set to only separators', () => {
+      expect(() => parseAllowedUserIds(',,,')).toThrow(/no valid user IDs/);
+    });
+  });
+
+  describe('isZulipUserAuthorized', () => {
+    describe('open access mode (empty allowedIds)', () => {
+      test('should allow any user when no whitelist', () => {
+        expect(isZulipUserAuthorized(123456, [])).toBe(true);
+      });
+    });
+
+    describe('whitelist mode', () => {
+      const allowedIds = [111, 222, 333];
+
+      test('should allow an authorized user', () => {
+        expect(isZulipUserAuthorized(222, allowedIds)).toBe(true);
+      });
+
+      test('should reject an unauthorized user', () => {
+        expect(isZulipUserAuthorized(999, allowedIds)).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/adapters/src/community/chat/zulip/auth.ts
+++ b/packages/adapters/src/community/chat/zulip/auth.ts
@@ -1,0 +1,15 @@
+/** Parse comma-separated numeric Zulip user IDs from env var. Returns [] for open access. */
+export function parseAllowedUserIds(envValue: string | undefined): number[] {
+  if (!envValue?.trim()) return [];
+  return envValue
+    .split(',')
+    .map(s => s.trim())
+    .filter(s => /^\d+$/.test(s))
+    .map(Number);
+}
+
+/** Returns true if allowedIds is empty (open access) or userId is in the list. */
+export function isZulipUserAuthorized(userId: number, allowedIds: number[]): boolean {
+  if (allowedIds.length === 0) return true;
+  return allowedIds.includes(userId);
+}

--- a/packages/adapters/src/community/chat/zulip/auth.ts
+++ b/packages/adapters/src/community/chat/zulip/auth.ts
@@ -1,11 +1,37 @@
-/** Parse comma-separated numeric Zulip user IDs from env var. Returns [] for open access. */
+/**
+ * Parse comma-separated numeric Zulip user IDs from an env var.
+ *
+ * - undefined / empty / whitespace -> `[]` (open access; the allowlist is intentionally disabled)
+ * - one or more valid numeric IDs   -> the parsed list (allowlist enforced)
+ * - set but containing any non-numeric token, or no IDs at all -> throws
+ *
+ * The throw is deliberate: silently dropping malformed tokens previously let a misconfigured
+ * allowlist (e.g. a typo'd ID, or all-invalid entries) collapse to `[]`, which
+ * `isZulipUserAuthorized` treats as open access — turning a misconfiguration into fail-OPEN.
+ * Failing loudly at startup keeps the allowlist fail-CLOSED.
+ */
 export function parseAllowedUserIds(envValue: string | undefined): number[] {
   if (!envValue?.trim()) return [];
-  return envValue
+  const ids = envValue
     .split(',')
     .map(s => s.trim())
-    .filter(s => /^\d+$/.test(s))
-    .map(Number);
+    .filter(s => s.length > 0)
+    .map(s => {
+      if (!/^\d+$/.test(s)) {
+        throw new Error(
+          `Invalid ZULIP_ALLOWED_USER_IDS: "${s}" is not a numeric user ID. ` +
+            'Provide a comma-separated list of numeric IDs, or unset it for open access.'
+        );
+      }
+      return Number(s);
+    });
+  if (ids.length === 0) {
+    throw new Error(
+      'ZULIP_ALLOWED_USER_IDS is set but contains no valid user IDs. ' +
+        'Provide a comma-separated list of numeric IDs, or unset it for open access.'
+    );
+  }
+  return ids;
 }
 
 /** Returns true if allowedIds is empty (open access) or userId is in the list. */

--- a/packages/adapters/src/community/chat/zulip/index.ts
+++ b/packages/adapters/src/community/chat/zulip/index.ts
@@ -1,0 +1,1 @@
+export { ZulipAdapter } from './adapter';

--- a/packages/adapters/src/community/chat/zulip/types.ts
+++ b/packages/adapters/src/community/chat/zulip/types.ts
@@ -1,0 +1,21 @@
+export interface ZulipMessage {
+  id: number;
+  sender_id: number;
+  sender_email: string;
+  sender_full_name: string;
+  content: string;
+  type: 'stream' | 'private';
+  stream_id?: number;
+  subject?: string;
+  display_recipient: string | { id: number; email: string; full_name: string }[];
+}
+
+export interface ZulipEvent {
+  type: string;
+  id: number;
+  message?: ZulipMessage;
+}
+
+export type ZulipReplyContext =
+  | { type: 'stream'; stream_id: number; topic: string }
+  | { type: 'private'; user_ids: number[] };

--- a/packages/adapters/src/community/chat/zulip/types.ts
+++ b/packages/adapters/src/community/chat/zulip/types.ts
@@ -10,12 +10,6 @@ export interface ZulipMessage {
   display_recipient: string | { id: number; email: string; full_name: string }[];
 }
 
-export interface ZulipEvent {
-  type: string;
-  id: number;
-  message?: ZulipMessage;
-}
-
 export type ZulipReplyContext =
   | { type: 'stream'; stream_id: number; topic: string }
   | { type: 'private'; user_ids: number[] };

--- a/packages/adapters/src/community/chat/zulip/zulip-js.d.ts
+++ b/packages/adapters/src/community/chat/zulip/zulip-js.d.ts
@@ -24,7 +24,11 @@ declare module 'zulip-js' {
 
   interface ZulipPrivateMessageParams {
     type: 'private';
-    to: number[];
+    // JSON-encoded array of user IDs (e.g. `JSON.stringify([1, 2, 3])`). The Zulip REST API
+    // wants a string here, NOT a literal array — on the wire this is `to: "[1,2,3]"`.
+    // (The adapter currently bypasses `client.messages.send` for POSTs via `zulipPost`, but
+    // this type guides any direct caller of `ZulipClient.messages.send`.)
+    to: string;
     content: string;
   }
 

--- a/packages/adapters/src/community/chat/zulip/zulip-js.d.ts
+++ b/packages/adapters/src/community/chat/zulip/zulip-js.d.ts
@@ -1,0 +1,64 @@
+/** Minimal type declarations for zulip-js (no official @types package available). */
+declare module 'zulip-js' {
+  interface ZulipClientConfig {
+    realm: string;
+    username: string;
+    apiKey: string;
+  }
+
+  interface ZulipQueueResult {
+    queue_id: string;
+    last_event_id: number;
+  }
+
+  interface ZulipEventResult {
+    events: { type: string; id: number; message?: unknown; message_id?: number }[];
+  }
+
+  interface ZulipStreamMessageParams {
+    type: 'stream';
+    to: number;
+    topic: string;
+    content: string;
+  }
+
+  interface ZulipPrivateMessageParams {
+    type: 'private';
+    to: number[];
+    content: string;
+  }
+
+  interface ZulipClient {
+    users: {
+      me: {
+        getProfile: () => Promise<{ full_name: string }>;
+      };
+    };
+    queues: {
+      register: (opts: {
+        event_types: string[];
+        apply_markdown?: boolean;
+      }) => Promise<ZulipQueueResult>;
+    };
+    events: {
+      retrieve: (opts: {
+        queue_id: string;
+        last_event_id: number;
+        dont_block?: boolean;
+      }) => Promise<ZulipEventResult>;
+    };
+    messages: {
+      send: (params: ZulipStreamMessageParams | ZulipPrivateMessageParams) => Promise<void>;
+      retrieve: (params: {
+        anchor: string | number;
+        num_before: number;
+        num_after: number;
+        narrow: { operator: string; operand: string }[];
+        apply_markdown?: boolean;
+      }) => Promise<{ messages: unknown[] }>;
+    };
+  }
+
+  function zulip(config: ZulipClientConfig): Promise<ZulipClient>;
+  export = zulip;
+}

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -7,3 +7,4 @@ export { GitHubAdapter } from './forge/github';
 
 // Community adapters
 export { DiscordAdapter } from './community/chat/discord';
+export { ZulipAdapter } from './community/chat/zulip';

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -117,6 +117,8 @@ export interface MessageMetadata {
   segment?: 'new' | 'auto';
   workflowDispatch?: { workerConversationId: string; workflowName: string };
   workflowResult?: { workflowName: string; runId: string };
+  /** True when sendMessage is carrying an error report instead of a normal answer. */
+  isError?: boolean;
 }
 
 export interface IPlatformAdapter {

--- a/packages/docs-web/src/content/docs/adapters/community/zulip.md
+++ b/packages/docs-web/src/content/docs/adapters/community/zulip.md
@@ -52,7 +52,7 @@ All six `ZULIP_*` variables are documented in `.env.example`. Three are **requir
 | `ZULIP_BOT_API_KEY` | **Yes** | The bot's API key (`key` in `zuliprc`). |
 | `ZULIP_BOT_FULL_NAME` | No (but **recommended**) | The bot's display name — required for `@**Bot Name**` mention detection in streams. Without it, the bot still replies to direct messages but cannot detect @mentions. |
 | `ZULIP_ALLOWED_USER_IDS` | No | Comma-separated numeric Zulip user IDs allowed to interact with the bot. **Unset (or empty) → open access**; set → only listed users are answered. A set-but-malformed value (e.g. non-numeric or all-invalid tokens) is a misconfiguration and the bot will **fail to start** — fail-closed, not fail-open. |
-| `ZULIP_STREAMING_MODE` | No | `batch` (default) — the bot edits a "thinking…" status message and posts the full answer once ready. `stream` — the bot streams tokens by editing its own message progressively. See [Configuration → Streaming Modes](/getting-started/configuration/) for the trade-offs. |
+| `ZULIP_STREAMING_MODE` | No | `batch` (default) — the bot edits a "thinking…" status message and posts the full answer once ready. `stream` is accepted but currently has **no runtime effect** in the Zulip adapter (it behaves like `batch`); progressive token streaming is a future addition. See [Configuration → Streaming Modes](/getting-started/configuration/) for the cross-platform overview. |
 
 Example:
 

--- a/packages/docs-web/src/content/docs/adapters/community/zulip.md
+++ b/packages/docs-web/src/content/docs/adapters/community/zulip.md
@@ -1,0 +1,88 @@
+---
+title: Zulip
+description: Connect Archon to Zulip for AI coding assistance in streams and direct messages.
+category: adapters
+area: adapters
+audience: [user, operator]
+status: current
+sidebar:
+  order: 6
+---
+
+:::note
+Zulip is a **community adapter** — contributed and maintained by the community.
+:::
+
+Connect Archon to Zulip so you can interact with your AI coding assistant from any Zulip stream or direct message. The adapter polls the Zulip event queue (long-polling), so no public webhook URL is required.
+
+## Prerequisites
+
+- Archon server running (see [Getting Started](/getting-started/overview/))
+- A Zulip account with admin access (to create a bot)
+- A Zulip server (self-hosted or Zulip Cloud at `zulipchat.com`)
+
+## Create a Zulip Bot
+
+1. Go to **Settings** → **Personal settings** → **Bots**
+2. Click **Add a new bot**
+3. Set **Bot type** to "Generic bot"
+4. Fill in **Full name** (e.g. `Archon`) and **Username** (e.g. `archon-bot`)
+5. Click **Create bot**
+
+## Get Bot Credentials
+
+After creating the bot:
+
+1. Find your bot in the **Active bots** list
+2. Click the download icon (⬇) to download `zuliprc`
+3. Note the values for `email`, `key`, and `site` — these map to the env vars below
+
+## Subscribe Bot to Streams
+
+For the bot to receive messages in a stream, add it as a subscriber to that stream (stream settings → **Add subscribers** → the bot's email address). The bot will also receive direct messages without further setup.
+
+## Environment Variables
+
+All six `ZULIP_*` variables are documented in `.env.example`. Three are **required**, three are **optional**:
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `ZULIP_URL` | **Yes** | Your Zulip realm URL (e.g. `https://your-org.zulipchat.com`). Same as the `site` field in `zuliprc`. |
+| `ZULIP_BOT_EMAIL` | **Yes** | The bot's email (e.g. `archon-bot@your-org.zulipchat.com`). Same as `email` in `zuliprc`. |
+| `ZULIP_BOT_API_KEY` | **Yes** | The bot's API key (`key` in `zuliprc`). |
+| `ZULIP_BOT_FULL_NAME` | No (but **recommended**) | The bot's display name — required for `@**Bot Name**` mention detection in streams. Without it, the bot still replies to direct messages but cannot detect @mentions. |
+| `ZULIP_ALLOWED_USER_IDS` | No | Comma-separated numeric Zulip user IDs allowed to interact with the bot. **Unset (or empty) → open access**; set → only listed users are answered. A set-but-malformed value (e.g. non-numeric or all-invalid tokens) is a misconfiguration and the bot will **fail to start** — fail-closed, not fail-open. |
+| `ZULIP_STREAMING_MODE` | No | `batch` (default) — the bot edits a "thinking…" status message and posts the full answer once ready. `stream` — the bot streams tokens by editing its own message progressively. See [Configuration → Streaming Modes](/getting-started/configuration/) for the trade-offs. |
+
+Example:
+
+```ini
+ZULIP_URL=https://your-org.zulipchat.com
+ZULIP_BOT_EMAIL=archon-bot@your-org.zulipchat.com
+ZULIP_BOT_API_KEY=your_api_key_here
+ZULIP_BOT_FULL_NAME=Archon
+# ZULIP_ALLOWED_USER_IDS=12345,67890
+# ZULIP_STREAMING_MODE=batch
+```
+
+## Usage
+
+The bot responds to:
+
+- **Stream messages** when @mentioned: `@**Archon** help me with this code`. The reply lands in the same stream + topic.
+- **Direct messages** sent to the bot — replies go back as DMs.
+
+A stream + topic pair (or the set of DM recipients) is treated as one conversation. While the bot is "thinking", it edits a `Starting thinking…` status message so you get immediate visual feedback; it switches to `Done thinking.` (or `Done thinking (FAILED).`) when the reply lands.
+
+If you edit your message to *add* the @mention (you forgot it first time), the bot picks that up via Zulip's `update_message` event and replies as if the mention had been there originally.
+
+## Reliability Notes
+
+- **Backfill on restart:** when the server restarts (e.g. crash, deploy), the adapter fetches unread @mentions + unread DMs through the Zulip API and answers them oldest-first. If that fetch fails, the cycle is aborted (logged as `zulip.backfill_aborted`) and the messages stay `unread` so the next restart retries — they are never silently lost.
+- **Reply correspondence:** each inbound message is marked read only **once its own reply has posted**. If the server crashes between two queued replies, the unanswered one stays unread for the next boot to retry.
+- **Queue recovery:** if the long-poll queue expires (e.g. extended inactivity), the adapter re-registers with the same event types as startup so edited-message mention pickup survives the recovery.
+
+## Further Reading
+
+- [Configuration → Streaming Modes](/getting-started/configuration/)
+- [Archon Adapters Overview](/adapters/)

--- a/packages/docs-web/src/content/docs/adapters/index.md
+++ b/packages/docs-web/src/content/docs/adapters/index.md
@@ -30,6 +30,7 @@ Community adapters follow the same `IPlatformAdapter` interface but target platf
 | [**Discord**](/adapters/community/discord/) | WebSocket | Bot token | [Setup guide](/adapters/community/discord/) |
 | [**Gitea**](/adapters/community/gitea/) | Webhooks | Token + webhook secret | [Setup guide](/adapters/community/gitea/) |
 | [**GitLab**](/adapters/community/gitlab/) | Webhooks | Token + webhook secret | [Setup guide](/adapters/community/gitlab/) |
+| [**Zulip**](/adapters/community/zulip/) | Long-polling | Bot email + API key | [Setup guide](/adapters/community/zulip/) |
 
 ## How Adapters Work
 

--- a/packages/docs-web/src/content/docs/getting-started/configuration.md
+++ b/packages/docs-web/src/content/docs/getting-started/configuration.md
@@ -28,6 +28,26 @@ Set these in your shell or `.env` file:
 | `PORT` | No | Server port (default: 3090, Docker: 3000) |
 | `WSL_DISTRO_NAME` | No (WSL sets it automatically) | WSL distro name; Archon reads it to emit Windows-host-friendly `vscode://vscode-remote/wsl+<distro>/...` "Open in IDE" links. Override only to force a specific distro name into the URI. |
 
+## Streaming Modes
+
+Chat adapters support two response-delivery modes, configured per-platform via the `*_STREAMING_MODE` environment variables:
+
+| Mode | Behavior | When to use |
+|------|----------|-------------|
+| `stream` | AI tokens are sent progressively — the bot edits its own message live as text is generated. | When the platform supports real-time message editing (Telegram, Zulip) and you want an interactive feel. |
+| `batch` | The AI completes the full response before sending; a `Starting thinking…` status message gives immediate feedback while the AI works. | More reliable across platforms; recommended as the default. |
+
+**Default modes by platform:**
+
+| Platform | Default |
+|----------|---------|
+| Telegram | `stream` |
+| Discord | `batch` |
+| Slack | `batch` |
+| Zulip | `batch` |
+
+Override per platform via the matching env var (e.g. `ZULIP_STREAMING_MODE=stream`, `TELEGRAM_STREAMING_MODE=batch`).
+
 ## Project Configuration
 
 Create `.archon/config.yaml` in your repository:

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -710,7 +710,7 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
       await zulip.start();
       activePlatforms.push('Zulip');
     } else {
-      getLog().info('zulip_adapter_skipped');
+      getLog().info('zulip.adapter_skipped');
     }
   } else {
     getLog().info('platform_adapters_skipped');

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -68,6 +68,7 @@ import {
   DiscordAdapter,
   SlackAdapter,
   SlackWorkflowBridge,
+  ZulipAdapter,
 } from '@archon/adapters';
 import { GiteaAdapter } from '@archon/adapters/community/forge/gitea';
 import { GitLabAdapter } from '@archon/adapters/community/forge/gitlab';
@@ -187,7 +188,7 @@ function createMessageErrorHandler(
     getLog().error({ err: error, platform, conversationId }, 'message_processing_failed');
     try {
       const userMessage = classifyAndFormatError(error as Error);
-      await adapter.sendMessage(conversationId, userMessage);
+      await adapter.sendMessage(conversationId, userMessage, { isError: true });
     } catch (sendError) {
       getLog().error({ err: sendError, platform, conversationId }, 'error_message_send_failed');
     }
@@ -401,6 +402,7 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
   let discord: DiscordAdapter | null = null;
   let slack: SlackAdapter | null = null;
   let slackBridge: SlackWorkflowBridge | null = null;
+  let zulip: ZulipAdapter | null = null;
 
   if (!opts.skipPlatformAdapters) {
     // Check that at least one platform is configured
@@ -419,8 +421,11 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
       process.env.GITEA_URL && process.env.GITEA_TOKEN && process.env.GITEA_WEBHOOK_SECRET
     );
     const hasGitLab = Boolean(process.env.GITLAB_TOKEN && process.env.GITLAB_WEBHOOK_SECRET);
+    const hasZulip = Boolean(
+      process.env.ZULIP_URL && process.env.ZULIP_BOT_EMAIL && process.env.ZULIP_BOT_API_KEY
+    );
 
-    if (!hasTelegram && !hasDiscord && !hasGitHub && !hasGitea && !hasGitLab) {
+    if (!hasTelegram && !hasDiscord && !hasGitHub && !hasGitea && !hasGitLab && !hasZulip) {
       getLog().warn('no_platform_adapters_configured');
     }
 
@@ -673,6 +678,39 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
       activePlatforms.push('Slack');
     } else {
       getLog().info('slack_adapter_skipped');
+    }
+
+    // Initialize Zulip adapter (conditional)
+    if (process.env.ZULIP_URL && process.env.ZULIP_BOT_EMAIL && process.env.ZULIP_BOT_API_KEY) {
+      const zulipStreamingMode = (process.env.ZULIP_STREAMING_MODE ?? 'batch') as
+        | 'stream'
+        | 'batch';
+      zulip = new ZulipAdapter(
+        process.env.ZULIP_URL,
+        process.env.ZULIP_BOT_EMAIL,
+        process.env.ZULIP_BOT_API_KEY,
+        zulipStreamingMode
+      );
+      const zulipAdapter = zulip;
+
+      zulipAdapter.onMessage(async msg => {
+        const conversationId = zulipAdapter.getConversationId(msg);
+        const content = zulipAdapter.stripBotMention(msg.content);
+        if (!content) return;
+
+        lockManager
+          .acquireLock(conversationId, async () => {
+            await handleMessage(zulipAdapter, conversationId, content, {
+              isolationHints: { workflowType: 'thread', workflowId: conversationId },
+            });
+          })
+          .catch(createMessageErrorHandler('Zulip', zulipAdapter, conversationId));
+      });
+
+      await zulip.start();
+      activePlatforms.push('Zulip');
+    } else {
+      getLog().info('zulip_adapter_skipped');
     }
   } else {
     getLog().info('platform_adapters_skipped');
@@ -1024,6 +1062,7 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
           // pending debounced chat.update can't fire against a closed socket.
           slackBridge?.detach();
           slack?.stop();
+          zulip?.stop();
           gitea?.stop();
           gitlab?.stop();
           pgNotifyListener?.stop();


### PR DESCRIPTION
## Summary

- **Problem:** Archon could not be driven from Zulip (a common self-hosted team chat).
- **Why it matters:** Teams on Zulip want the bot where they already work, alongside the existing Slack / Telegram / Discord / GitHub / GitLab surfaces.
- **What changed:** A new **Zulip community chat adapter** — mention/DM driven, with a live status message and downtime backfill.
- **What did NOT change (scope boundary):** No changes to other adapters, AI providers, the workflow engine, isolation, core error handling, or the database schema. The adapter is opt-in and only starts when its env vars are set.

## Provenance

Proudly built end-to-end **with and by [Archon](https://github.com/coleam00/Archon) and Claude Code** — researched, implemented, reviewed, and shipped through Archon's own remote-agent workflows (Archon building Archon), finished with a generous pinch of human experience and judgement steering the wheel. 🤖🧂

## UX Journey

### Before

```
Zulip user                 Archon
──────────                 ──────
@mention bot ───────────▶  (no Zulip adapter — message ignored)
```

### After

```
Zulip user                 Archon (*new Zulip adapter*)        AI client
──────────                 ────────────────────────────        ─────────
@mention / DM ──────────▶  *posts "HH:MM:SS Starting thinking…"*
                           resolves session, loads context
                           streams to AI ────────────────────▶ processes
                           *edits status → "…Done thinking."*  ◀── result
sees reply ◀────────────   posts answer; marks source read
```

## Architecture Diagram

### Before

```
server/index.ts ── starts ──▶ [Slack | Telegram | Discord | GitHub | GitLab] adapters
        each adapter ── onMessage ──▶ core: handleMessage ──▶ provider (Claude/Codex)
```

### After

```
server/index.ts ── starts ──▶ [Slack | Telegram | Discord | GitHub | GitLab | [+]Zulip]
        [+]ZulipAdapter ══ onMessage ══▶ core: handleMessage ──▶ provider (Claude/Codex)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `server/index.ts` | `ZulipAdapter` | **new** | conditional start behind `ZULIP_URL`+`ZULIP_BOT_EMAIL`+`ZULIP_BOT_API_KEY` |
| `ZulipAdapter` | `core: handleMessage` | **new** (existing pattern) | same `onMessage`→`handleMessage` contract as other chat adapters |
| `ZulipAdapter` | Zulip REST API | **new** | event-queue poll (GET via zulip-js) + direct form-encoded fetch for POSTs |

## Label Snapshot

- Risk: `risk: medium`
- Size: `size: L`
- Scope: `adapters`
- Module: `adapters:zulip`

## Change Metadata

- Change type: `feature`
- Primary scope: `adapters`

## Linked Issue

- No linked GitHub issue — new community chat adapter.

## Validation Evidence (required)

```bash
bun run type-check    # all packages exit 0
bun run lint          # eslint --cache, 0 warnings/errors
bun run format:check  # all files match Prettier
bun test packages/adapters/src/community/chat/zulip/adapter.test.ts  # 33 pass, 0 fail
```

- Evidence provided: command output summarized above.
- Intentionally skipped: full cross-package `bun run test` and `check:bundled*` were not re-run on this branch; the affected adapter test was run directly.

## Security Impact (required)

- New permissions/capabilities? **Yes** — a new outbound chat integration.
- New external network calls? **Yes** — Zulip REST API (event queue + message send).
- Secrets/tokens handling changed? **Yes** — reads `ZULIP_BOT_API_KEY` from env; never logged.
- File system access scope changed? **No**.
- Risk/mitigation: starts only when all three `ZULIP_*` vars are present; supports a `ZULIP_ALLOWED_USER_IDS` allowlist with silent rejection of unauthorized users; the API key is read from env and is not logged or echoed.

## Compatibility / Migration

- Backward compatible? **Yes** — adapter is opt-in.
- Config/env changes? **Yes** — new optional `ZULIP_URL`, `ZULIP_BOT_EMAIL`, `ZULIP_BOT_API_KEY`, `ZULIP_BOT_FULL_NAME`, `ZULIP_ALLOWED_USER_IDS`, `ZULIP_STREAMING_MODE` (documented in `.env.example`).
- Database migration needed? **No**.

## Human Verification (required)

- Verified scenarios: bot answers `@**mention**` in a stream and DMs on a live self-hosted Zulip; the live status message posts then edits to "Done thinking."
- Edge cases checked: messages sent during downtime are backfilled on boot and answered oldest-first; a message edited to add the mention is picked up via `update_message`; POSTs work under Bun (the direct-fetch bypass).
- What was not verified: nothing material outstanding for the adapter path.

## Side Effects / Blast Radius (required)

- Affected subsystems: server startup (one new conditional adapter).
- Potential unintended effects: none expected while `ZULIP_*` is unset (adapter never starts).
- Guardrails/monitoring: adapter gated by env vars; `zulip.*` structured logs for boot/poll/send.

## Rollback Plan (required)

- Fast rollback: revert the commit, or unset the `ZULIP_*` env vars to disable the adapter.
- Feature flags/toggles: the adapter is effectively flagged by the presence of its env vars.
- Observable failure symptoms: `zulip.*` error logs at boot/poll, or the bot not responding to mentions/DMs.

## Risks and Mitigations

- Risk: zulip-js@1 multipart POST bodies are not serialized under Bun (silently drops sends/registers/flags).
  - Mitigation: all POSTs bypass zulip-js with a direct form-encoded `fetch`; GETs still use zulip-js.
- Risk: the Zulip event queue is forward-only, so messages sent while the bot is down would be missed.
  - Mitigation: startup backfill of unread @mentions and DMs; read-marking deferred until a reply is posted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zulip chat integration with configurable env vars (URL, bot email/API key, optional full name, mode, allowlist); thread-aware conversation IDs and per-conversation status messages.

* **Behavior**
  * Long replies split into chunks; messages marked read only after successful replies; allowlist-based authorization; backfill, edit handling, and deduplication to avoid duplicate processing.

* **Tests**
  * Extensive Zulip adapter and authorization test coverage.

* **Documentation**
  * Zulip setup guide, adapters index entry, streaming-modes docs, and example env entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->