### PR TITLE
fix(core): classify Claude usage-limit errors as rate limits

### DIFF
--- a/packages/core/src/utils/error-formatter.test.ts
+++ b/packages/core/src/utils/error-formatter.test.ts
@@ -5,17 +5,66 @@ describe('classifyAndFormatError', () => {
   describe('rate limit errors', () => {
     test('detects lowercase "rate limit"', () => {
       const result = classifyAndFormatError(new Error('rate limit exceeded'));
-      expect(result).toBe('⚠️ AI rate limit reached. Please wait a moment and try again.');
+      expect(result).toBe('⚠️ AI usage limit reached. Please wait and try again.');
     });
 
     test('detects titlecase "Rate limit"', () => {
       const result = classifyAndFormatError(new Error('Rate limit: 429 Too Many Requests'));
-      expect(result).toBe('⚠️ AI rate limit reached. Please wait a moment and try again.');
+      expect(result).toBe('⚠️ AI usage limit reached. Please wait and try again.');
     });
 
     test('matches rate limit anywhere in message', () => {
       const result = classifyAndFormatError(new Error('Request failed: rate limit hit'));
-      expect(result).toBe('⚠️ AI rate limit reached. Please wait a moment and try again.');
+      expect(result).toBe('⚠️ AI usage limit reached. Please wait and try again.');
+    });
+
+    test('detects "hit your limit" (Claude subscription cap)', () => {
+      const result = classifyAndFormatError(
+        new Error("You've hit your limit · resets 4:50pm (UTC)")
+      );
+      expect(result).toBe(
+        '⚠️ AI usage limit reached (resets 4:50pm (UTC)). Please wait and try again.'
+      );
+    });
+
+    test('detects full enriched Claude usage-cap error with reset time', () => {
+      const result = classifyAndFormatError(
+        new Error(
+          "Claude Code unknown: Claude Code returned an error result: You've hit your limit · resets 4:50pm (UTC)"
+        )
+      );
+      expect(result).toBe(
+        '⚠️ AI usage limit reached (resets 4:50pm (UTC)). Please wait and try again.'
+      );
+    });
+
+    test('detects "usage limit" (Claude org-disabled-overage variant)', () => {
+      const result = classifyAndFormatError(new Error('usage limit exceeded'));
+      expect(result).toBe('⚠️ AI usage limit reached. Please wait and try again.');
+    });
+
+    test('omits reset clause when no reset time present in hit-your-limit message', () => {
+      const result = classifyAndFormatError(new Error("You've hit your limit"));
+      expect(result).toBe('⚠️ AI usage limit reached. Please wait and try again.');
+    });
+
+    test('detects title-case "Hit your limit" (case-insensitive)', () => {
+      const result = classifyAndFormatError(new Error('Hit your limit'));
+      expect(result).toBe('⚠️ AI usage limit reached. Please wait and try again.');
+    });
+
+    test('detects title-case "Usage limit" (case-insensitive)', () => {
+      const result = classifyAndFormatError(new Error('Usage limit exceeded'));
+      expect(result).toBe('⚠️ AI usage limit reached. Please wait and try again.');
+    });
+
+    test('handles reset text containing abbreviated periods (e.g. p.m.)', () => {
+      const result = classifyAndFormatError(
+        new Error("You've hit your limit · resets 4:50 p.m. (UTC)")
+      );
+      expect(result).toBe(
+        '⚠️ AI usage limit reached (resets 4:50 p.m. (UTC)). Please wait and try again.'
+      );
     });
   });
 
@@ -315,7 +364,7 @@ describe('classifyAndFormatError', () => {
     test('rate limit takes precedence over short-message fallback', () => {
       // "rate limit" message is also short, but rate-limit branch fires first
       const result = classifyAndFormatError(new Error('rate limit'));
-      expect(result).toBe('⚠️ AI rate limit reached. Please wait a moment and try again.');
+      expect(result).toBe('⚠️ AI usage limit reached. Please wait and try again.');
     });
 
     test('Claude OAuth check takes precedence over general auth check', () => {

--- a/packages/core/src/utils/error-formatter.test.ts
+++ b/packages/core/src/utils/error-formatter.test.ts
@@ -66,6 +66,56 @@ describe('classifyAndFormatError', () => {
         '⚠️ AI usage limit reached (resets 4:50 p.m. (UTC)). Please wait and try again.'
       );
     });
+
+    test('detects "session limit" (Claude subscription 5h window)', () => {
+      const result = classifyAndFormatError(
+        new Error("You've hit your session limit · resets 3am (America/Mexico_City)")
+      );
+      expect(result).toBe(
+        '⚠️ AI usage limit reached (resets 3am (America/Mexico_City)). Please wait and try again.'
+      );
+    });
+
+    test('captures only the first ·-delimited segment when multiple · separators follow', () => {
+      const result = classifyAndFormatError(
+        new Error("You've hit your limit · resets 4:50pm (UTC) · upgrade to increase your limit")
+      );
+      expect(result).toBe(
+        '⚠️ AI usage limit reached (resets 4:50pm (UTC)). Please wait and try again.'
+      );
+    });
+  });
+
+  describe('reset-time fallback without · separator', () => {
+    test('captures a standalone "Resets in ..." clause', () => {
+      const result = classifyAndFormatError(new Error('rate limit exceeded. Resets in 5 minutes'));
+      expect(result).toBe(
+        '⚠️ AI usage limit reached (Resets in 5 minutes). Please wait and try again.'
+      );
+    });
+
+    test('does not capture a clause from "reset" without the plural form', () => {
+      const result = classifyAndFormatError(new Error('usage limit exceeded, reset pending'));
+      expect(result).toBe('⚠️ AI usage limit reached. Please wait and try again.');
+    });
+
+    test('keeps abbreviated periods intact in the fallback capture', () => {
+      const result = classifyAndFormatError(new Error('rate limit hit. Resets 4:50 p.m. (UTC)'));
+      expect(result).toBe(
+        '⚠️ AI usage limit reached (Resets 4:50 p.m. (UTC)). Please wait and try again.'
+      );
+    });
+
+    test('drops the follow-on sentence from the workflow session-limit FATAL shape (#2181)', () => {
+      const result = classifyAndFormatError(
+        new Error(
+          'Claude session limit reached — resets 3:20pm (UTC). Abandon this run and retry after reset.'
+        )
+      );
+      expect(result).toBe(
+        '⚠️ AI usage limit reached (resets 3:20pm (UTC)). Please wait and try again.'
+      );
+    });
   });
 
   describe('Claude OAuth refresh-token errors', () => {

--- a/packages/core/src/utils/error-formatter.ts
+++ b/packages/core/src/utils/error-formatter.ts
@@ -14,17 +14,25 @@
 export function classifyAndFormatError(error: Error): string {
   const message = error.message || '';
 
-  // Handles AI-provider rate-limit and usage-cap errors (both generic and Claude-specific formats).
+  // AI-provider rate-limit / usage-cap classification
+  // Broad substrings are intentional: every call site feeds errors from handling
+  // an AI conversation turn, so a bare "usage limit" needs no provider prefix.
   const lower = message.toLowerCase();
   if (
     lower.includes('rate limit') ||
     lower.includes('hit your limit') ||
-    lower.includes('usage limit')
+    lower.includes('usage limit') ||
+    lower.includes('session limit')
   ) {
     // Anchor on · (Claude format: "... · resets 4:50pm (UTC)"); stop at · or newline so "p.m." isn't truncated.
+    // The no-· fallback also drops any follow-on sentence (period + capital letter), so shapes like
+    // "Claude session limit reached — resets 3:20pm (UTC). Abandon this run…" yield just the reset clause.
     const reset =
       /·\s*(resets[^·\n]*)/i.exec(message)?.[1]?.trim() ??
-      /resets[^·\n]*/i.exec(message)?.[0]?.trim();
+      /resets[^·\n]*/i
+        .exec(message)?.[0]
+        ?.replace(/\.\s+[A-Z][\s\S]*$/, '')
+        .trim();
     return `⚠️ AI usage limit reached${reset ? ` (${reset})` : ''}. Please wait and try again.`;
   }
 

--- a/packages/core/src/utils/error-formatter.ts
+++ b/packages/core/src/utils/error-formatter.ts
@@ -14,9 +14,22 @@
 export function classifyAndFormatError(error: Error): string {
   const message = error.message || '';
 
-  // AI/SDK errors - rate limits
-  if (message.includes('rate limit') || message.includes('Rate limit')) {
-    return '⚠️ AI rate limit reached. Please wait a moment and try again.';
+  // AI/SDK errors - rate limits and usage caps
+  // Matches: "rate limit" (generic), "hit your limit" (Claude subscription cap),
+  // "usage limit" (Claude org-disabled-overage variant; this function only receives
+  // AI-provider errors, so false-positive risk from OS/container messages is negligible)
+  const lower = message.toLowerCase();
+  if (
+    lower.includes('rate limit') ||
+    lower.includes('hit your limit') ||
+    lower.includes('usage limit')
+  ) {
+    // Anchor on · separator when present (Claude format: "... · resets 4:50pm (UTC)");
+    // fall back to stopping at · or newline so abbreviated periods (e.g. "p.m.") don't truncate.
+    const reset =
+      /·\s*(resets[^·\n]*)/i.exec(message)?.[1]?.trim() ??
+      /resets[^·\n]*/i.exec(message)?.[0]?.trim();
+    return `⚠️ AI usage limit reached${reset ? ` (${reset})` : ''}. Please wait and try again.`;
   }
 
   // Claude-specific auth errors — OAuth token refresh failures

--- a/packages/core/src/utils/error-formatter.ts
+++ b/packages/core/src/utils/error-formatter.ts
@@ -14,18 +14,14 @@
 export function classifyAndFormatError(error: Error): string {
   const message = error.message || '';
 
-  // AI/SDK errors - rate limits and usage caps
-  // Matches: "rate limit" (generic), "hit your limit" (Claude subscription cap),
-  // "usage limit" (Claude org-disabled-overage variant; this function only receives
-  // AI-provider errors, so false-positive risk from OS/container messages is negligible)
+  // Handles AI-provider rate-limit and usage-cap errors (both generic and Claude-specific formats).
   const lower = message.toLowerCase();
   if (
     lower.includes('rate limit') ||
     lower.includes('hit your limit') ||
     lower.includes('usage limit')
   ) {
-    // Anchor on · separator when present (Claude format: "... · resets 4:50pm (UTC)");
-    // fall back to stopping at · or newline so abbreviated periods (e.g. "p.m.") don't truncate.
+    // Anchor on · (Claude format: "... · resets 4:50pm (UTC)"); stop at · or newline so "p.m." isn't truncated.
     const reset =
       /·\s*(resets[^·\n]*)/i.exec(message)?.[1]?.trim() ??
       /resets[^·\n]*/i.exec(message)?.[0]?.trim();


### PR DESCRIPTION
## Summary

- **Problem:** Claude's 5-hour usage cap surfaced to users as a generic "⚠️ An unexpected error occurred. Try /reset…".
- **Why it matters:** On chat surfaces the bot's reply *is* the only error signal — an opaque message looks like a crash and invites pointless `/reset` attempts, when the user just needs to wait for the reset.
- **What changed:** `classifyAndFormatError` (core) now recognises Claude usage-cap phrasings and surfaces a clear message with the reset time. Applies to every platform.
- **What did NOT change (scope boundary):** Only `error-formatter.ts` (+ its tests). No provider, adapter, workflow, or schema changes.

## Provenance

Proudly built **with and by [Archon](https://github.com/coleam00/Archon) and Claude Code**, with a pinch of human experience steering the wheel. 🤖🧂

## Why this is needed

Archon speaks to users through chat (Zulip, Slack, Telegram, …) where there are no logs to open — the bot's reply *is* the entire error surface. `classifyAndFormatError` is the single place that turns raw provider/SDK errors into human guidance, and it already does this for several cases: e.g. an **expired Claude auth/OAuth token** becomes *"⚠️ Claude authentication expired. Run `/login` …"* instead of an opaque failure, telling the user exactly how to recover.

The gap this PR closes sits right next to that case. Claude's 5-hour **usage cap** surfaces as `"You've hit your limit · resets <time>"` (and `"usage limit"` when org overage is disabled). None of those phrasings matched the existing rate-limit branch, so they fell through to the catch-all *"⚠️ An unexpected error occurred. Try /reset…"* — which reads like a crash and triggers `/reset` attempts that cannot help. We now match those phrasings (case-insensitively) alongside `"rate limit"` and echo the reset time.

## UX Journey

### Before

```
[on a Claude usage cap, any platform]
send message ───────────▶  AI query rejected (usage cap)
sees "⚠️ An unexpected     ◀── generic fallback (no cause, no reset time)
 error occurred."
```

### After

```
send message ───────────▶  AI query rejected (usage cap)
sees "⚠️ AI usage limit     ◀── classified message w/ reset time
 reached (resets 4:50pm
 (UTC)). Please wait…"
```

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `core`
- Module: `core:error-formatter`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- No linked GitHub issue.

## Validation Evidence (required)

```bash
bun run type-check    # all packages exit 0
bun run lint          # eslint --cache, 0 warnings/errors
bun run format:check  # all files match Prettier
bun test packages/core/src/utils/error-formatter.test.ts  # 57 pass, 0 fail (100% coverage of error-formatter.ts)
```

## Security Impact (required)

- New permissions/capabilities? **No**.
- New external network calls? **No**.
- Secrets/tokens handling changed? **No**.
- File system access scope changed? **No**.

## Compatibility / Migration

- Backward compatible? **Yes** — only improves an error message's wording.
- Config/env changes? **No**.
- Database migration needed? **No**.

## Human Verification (required)

- Verified: fed Claude's real error string through `classifyAndFormatError` → `⚠️ AI usage limit reached (resets 4:50pm (UTC)). Please wait and try again.`; generic/unrelated errors still fall through unchanged.
- What was not verified: a real production cap end-to-end (the classification path is confirmed; awaiting the next actual cap to observe it live).

## Side Effects / Blast Radius (required)

- Affected subsystems: core error formatting — the new message shows on **all** platforms.
- Potential unintended effects: could re-classify any error text containing "hit your limit" / "usage limit"; low risk since only AI-provider errors reach this function.
- Guardrails/monitoring: `error-formatter.ts` at 100% test coverage (57 cases).

## Rollback Plan (required)

- Fast rollback: revert the single commit.
- Observable failure symptoms: usage-cap errors revert to the generic "unexpected error" message.

## Risks and Mitigations

- Risk: false positives on unrelated error text.
  - Mitigation: only provider errors reach the function; behavior locked down by tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of AI rate/usage limit errors: the app now detects more limit message variants (including “hit your limit” and “usage limit”) case-insensitively, ensuring the limit-specific warning takes precedence.
  * Updated the user-facing wording to **“AI usage limit reached.”**
  * When the original error includes reset timing (e.g., “resets …”), the warning now shows **when it will resume**, with correct handling of common abbreviated time formats.
* **Tests**
  * Updated and expanded coverage to validate the revised messaging and reset-time formatting across variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->