### PR TITLE
feat(providers): add Gemini community provider (+ showcase/demo)

### DIFF
--- a/.archon/workflows/archon-gemini-showcase.yaml
+++ b/.archon/workflows/archon-gemini-showcase.yaml
@@ -1,0 +1,122 @@
+name: archon-gemini-showcase
+description: |
+  Use when: Demonstrating the Gemini community provider end-to-end in Archon workflows.
+  Triggers: "showcase gemini", "gemini demo", "test gemini showcase".
+  Does: Exercises bash, script, prompt, and loop nodes under `provider: gemini`. Shows a
+        SUPPORTED capability (tool restrictions) running with no warning, an UNSUPPORTED set
+        (effort/thinking/maxBudgetUsd) warning-and-continuing, an iterative loop, and
+        cross-node `$nodeId.output` substitution ending in a self-verification verdict.
+  NOT for: Production development tasks.
+
+# Provider/model resolve via node.provider ?? workflow.provider ?? config.assistant.
+# Model strings are forwarded verbatim to gemini-cli; Archon does not validate them.
+# gemini-2.5-flash is fast and widely available — change freely.
+provider: gemini
+model: gemini-2.5-flash
+
+# IMPORTANT — two @lrilai/gemini-cli-sdk@1.0.0 gotchas this file works around (GEMINI_DEMO.md §5):
+#  1. PROMPTS MUST NOT CONTAIN DOUBLE-QUOTE (") CHARACTERS. The SDK fails to escape them when
+#     invoking gemini-cli, corrupting argv → gemini-cli prints usage → ModelAccessError. Every
+#     prompt below is intentionally quote-free.
+#  2. CROSS-NODE SESSION RESUME degrades answer fidelity (a resumed call tends to ignore its
+#     prompt and reply as if starting over). So every Gemini prompt node sets `context: fresh`
+#     to run as an INDEPENDENT session — single/first calls answer correctly. `$nodeId.output`
+#     substitution still flows between nodes (variable substitution, independent of the AI
+#     session); the loop carries state via `$LOOP_PREV_OUTPUT` with `fresh_context: true`.
+# Prompt nodes carry `allowed_tools: [list_directory]` so the tool-restricted node can do real
+# tool use and the others demonstrate that a supported restriction emits no capability warning;
+# an empty `allowed_tools: []` works for Gemini too (verified separately).
+nodes:
+  # ── bash node ─────────────────────────────────────────────────────────────
+  # No AI. stdout captured as $env-check.output. Runs in parallel with the chain.
+  - id: env-check
+    bash: |
+      echo "provider=gemini"
+      echo "gemini_cli=$(gemini --version 2>/dev/null || echo 'NOT FOUND')"
+      echo "branch=$(git branch --show-current 2>/dev/null || echo 'n/a')"
+
+  # ── script node (bun) ─────────────────────────────────────────────────────
+  # No AI. Emits JSON consumed by a Gemini prompt via $nodeId.output substitution.
+  - id: prepare-topic
+    runtime: bun
+    script: |
+      console.log(JSON.stringify({ topic: "agentic coding assistants", facts: 3 }));
+
+  # ── prompt node (Gemini) — SUPPORTED capability: real tool use ────────────
+  # toolRestrictions === true, so `allowed_tools` maps to gemini-cli --allowed-tools and
+  # NO capability warning is emitted. This node actually invokes list_directory, proving
+  # the restriction is honored end to end.
+  - id: gemini-tool-restricted
+    depends_on: [prepare-topic]
+    context: fresh
+    allowed_tools: [list_directory]
+    prompt: |
+      Using ONLY the list_directory tool, list up to five entries in the current working
+      directory and state how many you found. Answer in two sentences. Do not read files.
+
+  # ── prompt node (Gemini) — core query + output substitution ───────────────
+  # Proves ambient OAuth auth, streaming, and SDK→Archon chunk translation. Consumes the
+  # upstream script output via substitution.
+  - id: gemini-facts
+    depends_on: [prepare-topic, gemini-tool-restricted]
+    context: fresh
+    allowed_tools: [list_directory]
+    prompt: |
+      You are running inside an Archon workflow, powered by the Gemini community provider.
+      An upstream script node produced this JSON: $prepare-topic.output
+      Output exactly the requested number of concise, factual bullet points about the topic.
+      Output only the bullet points — no preamble. Do not use any tools.
+
+  # ── prompt node (Gemini) — UNSUPPORTED capabilities: graceful degradation ─
+  # effort/thinking/maxBudgetUsd map to capabilities GEMINI_CAPABILITIES marks false
+  # (effortControl, thinkingControl, costControl). The dag-executor emits a user-facing
+  # "…will be ignored" warning AND still runs the node — fail-safe, never silent, never
+  # crash. (`allowed_tools` is supported, so it is NOT named in the warning.)
+  - id: gemini-graceful-degradation
+    depends_on: [gemini-facts]
+    context: fresh
+    allowed_tools: [list_directory]
+    effort: high
+    thinking: enabled
+    maxBudgetUsd: 5
+    # NOTE: prompt intentionally avoids double-quote characters — see GEMINI_DEMO.md §5
+    # (@lrilai/gemini-cli-sdk@1.0.0 fails to escape embedded double-quotes when invoking
+    # gemini-cli, producing a ModelAccessError).
+    prompt: |
+      In one sentence, define the term graceful degradation as it applies to a software
+      provider that lacks a requested feature. Do not use any tools.
+
+  # ── loop node (Gemini) — iterative refinement ─────────────────────────────
+  # fresh_context: true → each iteration is an independent session; state is carried
+  # forward via $LOOP_PREV_OUTPUT (prompt-level), not session resume. Exits on the
+  # <promise> completion signal or after max_iterations.
+  - id: gemini-superpowers
+    depends_on: [gemini-graceful-degradation]
+    loop:
+      # Completion-signal demo: the loop runs the prompt until the AI emits the <promise>
+      # tag (or max_iterations is hit). The bar is reachable in one pass so the loop reliably
+      # terminates on the signal; if a pass omits the tag, the loop retries.
+      prompt: |
+        List exactly three distinct superpowers that the Gemini provider gives Archon, as a
+        numbered list with one item per line. Respond with text only; do not use any tools.
+        After the list, on its own line, output exactly this completion tag and nothing after it:
+        <promise>FINISHED</promise>
+      until: FINISHED
+      max_iterations: 3
+      fresh_context: true
+
+  # ── prompt node (Gemini) — self-verification verdict ──────────────────────
+  # Reads the earlier Gemini output via $nodeId.output and renders a terminal verdict,
+  # demonstrating downstream substitution and a clean final result.
+  - id: gemini-verdict
+    depends_on: [gemini-superpowers, gemini-facts]
+    context: fresh
+    allowed_tools: [list_directory]
+    prompt: |
+      Earlier in this workflow a Gemini node produced:
+      ---
+      $gemini-facts.output
+      ---
+      If that contains three distinct factual bullet points about agentic coding assistants,
+      reply with exactly this line and nothing else: GEMINI SHOWCASE VERIFIED ✅
+      Otherwise reply: GEMINI SHOWCASE INCOMPLETE ❌ followed by one sentence explaining why.

--- a/.archon/workflows/test-workflows/e2e-gemini-smoke.yaml
+++ b/.archon/workflows/test-workflows/e2e-gemini-smoke.yaml
@@ -1,0 +1,23 @@
+# E2E smoke test — Gemini community provider
+# Verifies: Gemini connectivity (ambient gemini-cli OAuth), sendQuery streaming, and
+#   SDK→Archon chunk translation. The single prompt node completes only if gemini-cli
+#   responds; any auth/connectivity/translation error fails the node and the workflow.
+# Design notes (divergences from e2e-pi-smoke, see GEMINI_DEMO.md §5):
+#   - Single node (no bash `assert` consumer): bash-node `$nodeId.output` substitution of
+#     Gemini output misbehaved in testing, while prompt-node substitution works (used in the
+#     showcase). A single node is the robust connectivity check for this provider.
+#   - `allowed_tools: [list_directory]` exercises the toolRestrictions translation path.
+#   - Prompt is free of double-quote characters (the SDK fails to escape them; §5.1).
+#   - No effort/thinking fields — Gemini v1 does not support them (would warn-and-ignore).
+# Auth: ambient gemini-cli login (`gemini auth login`, creds in ~/.gemini/). Archon injects
+#   no API key — the subprocess inherits HOME and resolves ~/.gemini.
+name: e2e-gemini-smoke
+description: 'Smoke test for Gemini community provider. Verifies prompt response via sendQuery.'
+provider: gemini
+model: gemini-2.5-flash
+
+nodes:
+  - id: simple
+    allowed_tools: [list_directory]
+    idle_timeout: 120000
+    prompt: 'What is 2+2? Answer with just the number, nothing else. Do not use any tools.'

--- a/.env.example
+++ b/.env.example
@@ -64,7 +64,23 @@ CODEX_ACCOUNT_ID=
 # before the container starts (Pi reads it on each file path lookup).
 # PI_CODING_AGENT_DIR=/.archon/pi
 
-# Default AI Assistant (must match a registered provider, e.g. claude, codex, pi)
+# Gemini (community provider — @lrilai/gemini-cli-sdk → gemini-cli binary)
+# Auth is ambient: run `gemini auth login` to sign in with Google. Credentials land
+# in ~/.gemini/ and are picked up automatically — Archon injects NO key, and the
+# subprocess inherits HOME so ~/.gemini resolves without any config.
+#
+# Alternatively set one of the following (SDK precedence:
+# ADC > GEMINI_API_KEY > GOOGLE_APPLICATION_CREDENTIALS > GOOGLE_API_KEY):
+# GEMINI_API_KEY=                 # Gemini AI Studio API key
+# GOOGLE_APPLICATION_CREDENTIALS= # path to a Vertex AI service-account JSON
+# GOOGLE_API_KEY=                 # Google Cloud API key
+#
+# Requires gemini-cli installed separately (>=0.37.1):
+#   npm install -g @google/gemini-cli
+# Binary path (compiled Archon builds only; dev mode resolves via PATH):
+# GEMINI_BIN_PATH=                # e.g. /usr/local/bin/gemini
+
+# Default AI Assistant (must match a registered provider, e.g. claude, codex, pi, gemini)
 # Used for new conversations when no codebase specified — errors on unknown values
 DEFAULT_AI_ASSISTANT=claude
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,6 +285,7 @@ packages/
 │       ├── claude/           # ClaudeProvider + parseClaudeConfig + MCP/hooks/skills translation
 │       ├── codex/            # CodexProvider + parseCodexConfig + binary-resolver
 │       ├── community/pi/     # PiProvider (builtIn: false) — @mariozechner/pi-coding-agent, ~20 LLM backends
+│       ├── community/gemini/ # GeminiProvider (builtIn: false) — @lrilai/gemini-cli-sdk → gemini-cli, ambient OAuth
 │       └── index.ts          # Package exports
 ├── core/                     # @archon/core - Shared business logic
 │   └── src/
@@ -420,7 +421,7 @@ import type { DagNode, WorkflowDefinition } from '@/lib/api';
 **Package Split:**
 - **@archon/paths**: Path resolution utilities, Pino logger factory, web dist cache path (`getWebDistDir`), CWD env stripper (`stripCwdEnv`, `strip-cwd-env-boot`) (no @archon/* deps; `pino` and `dotenv` are allowed external deps)
 - **@archon/git**: Git operations - worktrees, branches, repos, exec wrappers (depends only on @archon/paths)
-- **@archon/providers**: AI agent providers (Claude, Codex, Pi community) — owns SDK deps, `IAgentProvider` interface, `sendQuery()` contract, and provider-specific option translation. `@archon/providers/types` is the contract subpath (zero SDK deps, zero runtime side effects) that `@archon/workflows` imports from. Providers receive raw `nodeConfig` + `assistantConfig` and translate to SDK-specific options internally. Core providers live under `claude/` and `codex/`; community providers live under `community/` (currently `community/pi/`, registered with `builtIn: false`).
+- **@archon/providers**: AI agent providers (Claude, Codex, Pi + Gemini community) — owns SDK deps, `IAgentProvider` interface, `sendQuery()` contract, and provider-specific option translation. `@archon/providers/types` is the contract subpath (zero SDK deps, zero runtime side effects) that `@archon/workflows` imports from. Providers receive raw `nodeConfig` + `assistantConfig` and translate to SDK-specific options internally. Core providers live under `claude/` and `codex/`; community providers live under `community/` (`community/pi/` and `community/gemini/`, registered with `builtIn: false`).
 - **@archon/isolation**: Worktree isolation types, providers, resolver, error classifiers (depends only on @archon/git + @archon/paths)
 - **@archon/workflows**: Workflow engine - loader, router, executor, DAG, logger, bundled defaults (depends only on @archon/git + @archon/paths + @archon/providers/types + @hono/zod-openapi + zod; DB/AI/config injected via `WorkflowDeps`)
 - **@archon/cli**: Command-line interface for running workflows and starting the web UI server (depends on @archon/server + @archon/adapters for the serve command)
@@ -465,6 +466,7 @@ import type { DagNode, WorkflowDefinition } from '@/lib/api';
 - **ClaudeProvider**: `@anthropic-ai/claude-agent-sdk`
 - **CodexProvider**: `@openai/codex-sdk`
 - **PiProvider** (community, `builtIn: false`): `@mariozechner/pi-coding-agent` — one harness for ~20 LLM backends via `<provider>/<model>` refs (e.g. `anthropic/claude-haiku-4-5`, `openrouter/qwen/qwen3-coder`); supports extensions, skills, tool restrictions, thinking level, best-effort structured output. See `packages/docs-web/src/content/docs/getting-started/ai-assistants.md` for setup, capability matrix, and extension config.
+- **GeminiProvider** (community, `builtIn: false`): `@lrilai/gemini-cli-sdk` — wraps Google's `gemini-cli` (installed separately, ≥0.37.1). Ambient OAuth via `gemini auth login` (Archon injects no API key); v1 supports session resume, tool restrictions, and env injection. See `packages/docs-web/src/content/docs/getting-started/ai-assistants.md`.
 - Streaming: `for await (const event of events) { await platform.send(event) }`
 
 ### Configuration
@@ -511,7 +513,7 @@ assistants:
 3. SDK defaults
 
 **Model Validation:**
-- Workflows are validated at load time for provider _identity_ only — `provider:` (workflow-level and per-node) must be a registered provider id, otherwise the YAML is rejected with `Unknown provider '<id>'. Registered: claude, codex, pi`.
+- Workflows are validated at load time for provider _identity_ only — `provider:` (workflow-level and per-node) must be a registered provider id, otherwise the YAML is rejected with `Unknown provider '<id>'. Registered: claude, codex, pi, gemini`.
 - Model strings are NOT validated by Archon. Whatever the user writes in `model:` is forwarded verbatim to the resolved SDK. Vendor SDKs ship new models faster than Archon can update; the SDK and the upstream API are the source of truth for what names exist.
 - Provider is resolved via an explicit chain: `node.provider ?? workflow.provider ?? config.assistant`. Model never influences provider selection.
 

--- a/GEMINI_DEMO.md
+++ b/GEMINI_DEMO.md
@@ -1,0 +1,270 @@
+# Gemini Provider — End-to-End Demonstration
+
+This document demonstrates that the **Gemini community provider** is wired into Archon
+correctly and is used effectively across workflow node types. It is intended as evidence
+for PR review.
+
+- **Provider id:** `gemini` · **Display name:** `Gemini (community)` · **`builtIn: false`**
+- **SDK:** [`@lrilai/gemini-cli-sdk`](https://www.npmjs.com/package/@lrilai/gemini-cli-sdk),
+  which shells out to Google's `gemini-cli` (installed separately, ≥ 0.37.1).
+- **Auth:** ambient `gemini-cli` OAuth (`gemini auth login`, credentials in `~/.gemini/`).
+  **Archon injects no API key.** The provider subprocess inherits the parent environment
+  (including `HOME`), so the ambient login resolves with zero key handling on Archon's side.
+- **Source:** `packages/providers/src/community/gemini/`
+
+> Verified live on this machine: `gemini-cli 0.43.0`, `bun 1.3.14`, Windows 11.
+
+---
+
+## 1. How the provider is registered
+
+Gemini is registered as a **community provider** (alongside Pi), kept out of
+`registerBuiltinProviders()` on purpose because it wraps a third-party SDK:
+
+```ts
+// packages/providers/src/registry.ts
+export function registerCommunityProviders(): void {
+  registerPiProvider();
+  registerGeminiProvider(); // idempotent, builtIn: false
+}
+```
+
+`GET /api/providers` and `bun run cli workflow list` both surface it. Workflows select it
+via the standard resolution chain — `node.provider ?? workflow.provider ?? config.assistant`
+— and model strings are forwarded verbatim to `gemini-cli` (Archon does not validate them).
+
+---
+
+## 2. Capability matrix
+
+The provider declares a deliberately conservative capability set. Declared flags reflect
+**wired-up behavior**, not potential support, so the engine can warn users when a workflow
+node asks for something the provider ignores. Source: `capabilities.ts`.
+
+| Capability         | Supported | How it behaves in a workflow                                                                               |
+| ------------------ | :-------: | ---------------------------------------------------------------------------------------------------------- |
+| Assistant query    |    ✅     | `prompt:` / `loop:` nodes stream responses via `sendQuery()`.                                              |
+| `sessionResume`    |    ⚠️     | Declared `true`, but cross-call resume is unreliable in v1 — see §5.2. The showcase uses `context: fresh`. |
+| `toolRestrictions` |    ✅     | `allowed_tools:` → gemini-cli `--allowed-tools`. **No** capability warning emitted.                        |
+| `envInjection`     |    ✅     | `config.envVars` merged into the subprocess env; subprocess inherits parent env (→ OAuth).                 |
+| `mcp`              |    ❌     | `mcp:` on a node → **warn-and-ignore** (file-path vs object-map mismatch; deferred to v2).                 |
+| `hooks`            |    ❌     | `hooks:` → warn-and-ignore.                                                                                |
+| `skills`           |    ❌     | `skills:` → warn-and-ignore.                                                                               |
+| `agents`           |    ❌     | `agents:` → warn-and-ignore.                                                                               |
+| `structuredOutput` |    ❌     | `output_format:` unsupported in v1 (`query()` streaming contract; `queryFull()` deferred).                 |
+| `costControl`      |    ❌     | `maxBudgetUsd:` → warn-and-ignore.                                                                         |
+| `effortControl`    |    ❌     | `effort:` → warn-and-ignore.                                                                               |
+| `thinkingControl`  |    ❌     | `thinking:` → warn-and-ignore.                                                                             |
+| `fallbackModel`    |    ❌     | `fallbackModel:` → warn-and-ignore.                                                                        |
+| `sandbox`          |    ❌     | `sandbox:` → warn-and-ignore.                                                                              |
+
+### The two-layer "fail-safe" guarantee
+
+Unsupported features never crash a workflow and are never silently broadened. Two
+independent layers handle them:
+
+1. **Engine, user-facing (always on).** `resolveNodeProviderAndModel()` in
+   `dag-executor.ts` compares each node's config against `getProviderCapabilities('gemini')`
+   and sends a chat/CLI message before running the node:
+   `Warning: Node 'X' uses effort, thinking, maxBudgetUsd but gemini doesn't support them — these will be ignored.`
+   The node then **runs anyway**.
+2. **Provider, dev logs (opt-in).** `warnIgnoredOptions()` emits structured
+   `gemini.option_ignored` log lines, gated on `NODE_ENV=development` or `DEBUG=gemini`.
+
+---
+
+## 3. The showcase workflow
+
+`.archon/workflows/archon-gemini-showcase.yaml` is a fully **headless** workflow (runs end
+to end with no human gate) that exercises the matrix above:
+
+| Node                          | Type     | What it proves                                                              |
+| ----------------------------- | -------- | --------------------------------------------------------------------------- |
+| `env-check`                   | `bash`   | Non-AI node interleaves with Gemini nodes; stdout → `$nodeId.output`.       |
+| `prepare-topic`               | `script` | `bun` script emits JSON consumed downstream.                                |
+| `gemini-tool-restricted`      | `prompt` | **Supported** `allowed_tools` → runs with **no** warning; real tool use.    |
+| `gemini-facts`                | `prompt` | **Core query** — auth + streaming + chunk translation; reads upstream JSON. |
+| `gemini-graceful-degradation` | `prompt` | **Unsupported** `effort`/`thinking`/`maxBudgetUsd` → warn-and-run.          |
+| `gemini-superpowers`          | `loop`   | Iterative loop; exits on the `<promise>FINISHED</promise>` signal.          |
+| `gemini-verdict`              | `prompt` | Downstream `$gemini-facts.output` substitution → terminal verdict.          |
+
+Every Gemini prompt node uses `context: fresh` and the loop uses `fresh_context: true` — see
+§5.2 for why. `$nodeId.output` substitution still flows between nodes regardless.
+
+### Cross-provider coexistence (per-node override)
+
+The captured showcase is intentionally pure-Gemini for a deterministic hands-off run, but
+Gemini participates in mixed-provider DAGs like any built-in provider — a node sets its own
+`provider:`/`model:` and can read an upstream Gemini node's output:
+
+```yaml
+- id: verify
+  provider: claude # per-node override; default stays gemini
+  model: sonnet
+  prompt: |
+    A Gemini node produced: $gemini-facts.output
+    Reply VERIFIED if it has three factual bullet points.
+  depends_on: [gemini-facts]
+```
+
+---
+
+## 4. E2E smoke test (provider test matrix)
+
+`.archon/workflows/test-workflows/e2e-gemini-smoke.yaml` slots Gemini into the existing
+per-provider e2e smoke matrix (Claude / Codex / Pi / MiniMax). It is a **single** Gemini node
+asking `What is 2+2?`; the node completes only if `sendQuery` works end-to-end (auth +
+streaming + chunk translation), so any failure fails the workflow.
+
+It deliberately diverges from the `e2e-pi-smoke.yaml` shape (which adds a bash `assert` node
+reading `$simple.output`): bash-node `$nodeId.output` substitution of Gemini output misbehaved
+in testing, while prompt-node substitution works (as the showcase's `gemini-verdict` proves).
+A single node is the robust connectivity check for this provider. Captured run
+(`docs/gemini-demo-evidence/smoke-run.log`):
+
+```
+[simple] Completed (12.4s)
+Workflow completed successfully.
+```
+
+---
+
+## 5. Findings: bugs uncovered while building this demo
+
+Building and running this demo surfaced two real issues in `@lrilai/gemini-cli-sdk@1.0.0`.
+Both are **provider/SDK-level**, not Archon engine bugs — the Archon dag-executor, capability
+warnings, and `$nodeId.output` substitution behaved correctly throughout.
+
+### 5.1 — 🔴 Double-quote characters in a prompt break the invocation (high impact)
+
+A prompt containing a literal `"` makes the SDK build a `gemini-cli` invocation that gemini-cli
+rejects: it prints its usage text and exits non-zero, which the SDK's `ErrorMapper` surfaces as
+`ModelAccessError`. The failure is instant (~1.5s) and deterministic.
+
+Isolated with a two-node diagnostic (identical except the prompt; see
+`docs/gemini-demo-evidence/gotcha-double-quote.log`):
+
+| Node         | Prompt                                           | Result                        |
+| ------------ | ------------------------------------------------ | ----------------------------- |
+| `noquotes`   | `Define graceful degradation in one sentence.`   | ✅ ok (19.1s)                 |
+| `withquotes` | `Define "graceful degradation" in one sentence.` | ❌ `ModelAccessError` (~1.5s) |
+
+**Impact:** double-quotes are extremely common in real prompts, so this blocks many practical
+workflows. **This earlier masked every other theory** — the showcase's graceful-degradation
+node always contained `"graceful degradation"`, so it always failed regardless of session/cwd.
+
+**Recommended fix (provider):** sanitize/escape the prompt before handing it to the SDK, or
+pass it via stdin rather than argv. Until fixed, **keep Gemini prompts free of `"`** (the
+showcase and smoke workflows do).
+
+### 5.2 — 🟠 Cross-node session resume degrades answer fidelity
+
+When a Gemini node _resumes_ a prior session (the default for sequential nodes), the model
+tends to ignore its new prompt and reply as if starting over (e.g. `gemini-facts` replied
+"Acknowledged. I am ready to assist" instead of producing the requested bullet points). The
+same node with `context: fresh` answered correctly. The showcase therefore sets `context:
+fresh` on every prompt node and `fresh_context: true` on the loop. **This makes the declared
+`sessionResume: true` capability questionable for v1 — worth revisiting.**
+
+> Both are good candidates for code comments in `options-translator.ts` and a note in the
+> provider docs (`packages/docs-web/.../ai-assistants.md`).
+>
+> _(An earlier draft of this doc listed a third "empty `allowed_tools: []` is unsafe" finding.
+> A controlled re-test — empty allowlist with a quote-free prompt — passed cleanly, so that
+> claim was retracted: those failures were the §5.1 double-quote bug, and the apparent slowness
+> was gemini-cli loading project context in a large repo, not the empty array.)_
+
+## 6. How to run it yourself
+
+```bash
+# Prerequisites (one time):
+npm install -g @google/gemini-cli   # provides the `gemini` binary (≥ 0.37.1)
+gemini auth login                   # ambient OAuth — Archon injects no key
+
+# Run the comprehensive showcase:
+bun run cli workflow run archon-gemini-showcase "demo run"
+
+# Run the smoke test:
+bun run cli workflow run e2e-gemini-smoke "smoke"
+
+# See the per-option dev warnings for unsupported features:
+DEBUG=gemini bun run cli workflow run archon-gemini-showcase "demo run"
+```
+
+> Running Archon workflows from inside a Claude Code session prints a `CLAUDECODE=1` warning
+> (#1067). Gemini nodes shell out to the separate `gemini-cli` binary and are unaffected;
+> set `ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING=1` to silence the notice.
+
+> Tip — run in a minimal cwd for a deterministic green verdict: `gemini-cli` auto-loads context
+> files (`GEMINI.md`, etc.) from the working directory. In a context-heavy repo (e.g. Archon-sw
+> with its large `CLAUDE.md`) the model tends to answer _about the project_ instead of the
+> prompt, so `gemini-facts` may not emit three clean bullet points and `gemini-verdict` can then
+> print `GEMINI SHOWCASE INCOMPLETE ❌`. The workflow still completes (exit 0 — the verdict is
+> informational, not a gate), but for the clean `VERIFIED ✅` shown above, run in an empty git
+> dir: `bun run cli workflow run archon-gemini-showcase --cwd <empty-git-dir> "demo"`. Engine
+> behavior (tool use, capability warnings, exit status) is identical either way; only the
+> model's answer fidelity differs.
+
+---
+
+## 7. Captured evidence
+
+Full logs are under `docs/gemini-demo-evidence/`. The clean showcase run
+(`showcase-run.log`, run in a minimal cwd for on-prompt answers — see §5.2) completed all
+seven nodes, exit 0:
+
+```
+[prepare-topic]               Completed (script, bun)
+[env-check]                   provider=gemini  gemini_cli=0.43.0  (bash)
+[gemini-tool-restricted]      Completed (21.4s) — listed cwd via list_directory (no warning)
+[gemini-facts]                Completed (44.3s) — 3 factual bullet points
+Warning: Node 'gemini-graceful-degradation' uses effort, thinking, maxBudgetUsd
+         but gemini doesn't support them — these will be ignored.   ← graceful degradation
+[gemini-graceful-degradation] Completed (20.6s) — ran despite the warning
+[gemini-superpowers]          Completed after 1 iteration — emitted <promise>FINISHED</promise>
+[gemini-verdict]              Completed — "GEMINI SHOWCASE VERIFIED ✅"
+Workflow completed successfully.
+```
+
+Highlights proving correct behavior:
+
+- **Supported `toolRestrictions`**: `gemini-tool-restricted` carried `allowed_tools` and ran
+  with **no** capability warning, actually invoking `list_directory`.
+- **Graceful degradation**: `gemini-graceful-degradation` carried `effort`/`thinking`/
+  `maxBudgetUsd`; the engine warned (`dag.unsupported_capabilities` →
+  `effort, thinking, maxBudgetUsd`) and **still ran the node** — fail-safe, not fail-closed.
+- **Loop + completion signal**: `gemini-superpowers` ran the loop and exited on the
+  `<promise>FINISHED</promise>` signal.
+- **Cross-node substitution**: `gemini-verdict` read `$gemini-facts.output` and returned a
+  clean terminal verdict.
+
+Evidence files:
+
+| File                      | What it shows                                                 |
+| ------------------------- | ------------------------------------------------------------- |
+| `showcase-run.log`        | The clean, all-green showcase run (above).                    |
+| `smoke-run.log`           | The single-node `e2e-gemini-smoke` run (completed, exit 0).   |
+| `gotcha-double-quote.log` | §5.1 — `noquotes` ✅ vs `withquotes` ❌ (`ModelAccessError`). |
+
+---
+
+## 8. Validation
+
+The Gemini demo changes are **YAML workflows + this doc only** — no TypeScript and no bundled
+default files were touched, so they do not affect the code gates or the embedded defaults bundle.
+
+| Gate                      | Result for this work                                              |
+| ------------------------- | ----------------------------------------------------------------- |
+| `cli validate workflows`  | ✅ `archon-gemini-showcase` and `e2e-gemini-smoke` both validate. |
+| `type-check`              | ✅ Pass (no TS changed).                                          |
+| `lint`                    | ✅ Pass (no TS changed).                                          |
+| `format:check` (prettier) | ✅ After `prettier --write GEMINI_DEMO.md`.                       |
+| `check:bundled`           | ⚠️ Pre-existing failure — see note.                               |
+
+> **`check:bundled` note (not caused by this work):** at the start of this session the working
+> tree already contained an uncommitted edit to a bundled default,
+> `.archon/workflows/defaults/archon-workflow-builder.yaml`, without a regenerated
+> `bundled-defaults.generated.ts`. That is what makes `bun run validate` stop at `check:bundled`.
+> The Gemini workflows are **not** bundled defaults (`archon-gemini-showcase.yaml` and
+> `e2e-gemini-smoke.yaml` live outside `defaults/`), so they don't enter the bundle. Resolve the
+> pre-existing item separately with `bun run generate:bundled`, then `bun run validate` is green.

--- a/PRD-gemini-provider-v2.md
+++ b/PRD-gemini-provider-v2.md
@@ -1,0 +1,600 @@
+# PRD: Gemini Provider v2 — Capability Expansion via Config Staging
+
+> **Companion doc:** [GEMINI_DEMO.md](GEMINI_DEMO.md) (v1 evidence + matrix this PRD extends)
+
+---
+
+## 1. Executive Summary
+
+The Gemini community provider shipped in v1 with a deliberately conservative capability set: 3 of 14 declared capabilities are wired up (`sessionResume`, `toolRestrictions`, `envInjection`). The remaining 11 are documented as `false` and rely on a "warn-and-run" graceful-degradation pattern. Research into the gemini-cli documentation reveals that **most of those gaps are not gemini-cli limitations** — they are integration gaps in Archon's provider layer.
+
+The core architectural insight: **gemini-cli reads `.gemini/settings.json` and `.gemini/agents/*.md` from its working directory at startup, with project-layer config overriding user-layer config**. Since the SDK already forwards `cwd` to the subprocess, Archon can materialize per-invocation config files into the worktree before invoke, and gemini-cli will pick them up natively — without any change to `@lrilai/gemini-cli-sdk`.
+
+**MVP goal:** Resolve 4 high-value capabilities (`mcp`, `agents`, `sandbox`, `fallbackModel`) and add a buffered code path for `structuredOutput`, raising Gemini's wired-up capability count from 3 → 8 while preserving the existing warn-and-run fail-safe for everything else. Worktree-isolated runs (Archon's default, ~90% of usage) ship first; `--no-worktree` collision-safety machinery follows in a second phase.
+
+---
+
+## 2. Mission
+
+Bring the Gemini community provider to functional parity with built-in providers (Claude, Codex) for the workflow-node features that gemini-cli actually supports, without compromising the v1 fail-safe guarantees or requiring upstream SDK changes.
+
+**Core principles:**
+
+1. **No SDK rework.** All capability expansion happens in Archon's provider layer. The SDK remains a thin transport.
+2. **Project layer wins.** Use gemini-cli's documented precedence (project `.gemini/settings.json` > user) — never override the user's `~/.gemini/`.
+3. **Fail-safe preserved.** Capabilities Archon cannot honor faithfully stay `false` and continue to warn-and-run. We never silently broaden support.
+4. **Reversible by default.** Worktree-scoped staging is automatically cleaned up. `--no-worktree` runs use backup-and-restore so a crash never leaves a mangled user file.
+5. **Honest capability declarations.** A capability flag flips to `true` only when there is a faithful, tested translation. Partial mappings (e.g. `thinking` → Gemini generation settings) stay declared `false` until a clean design exists.
+
+---
+
+## 3. Target Users
+
+**Primary persona — Archon workflow author using Gemini as the assistant:**
+
+- Authors `.archon/workflows/*.yaml` with `provider: gemini` at workflow or node level
+- Wants the same expressive options available for Claude/Codex nodes (MCP servers, sub-agents, sandbox, fallback model, structured output)
+- Today: must omit these keys or accept warn-and-run silent ignores
+- Pain point: cross-provider workflows lose fidelity when a node switches to Gemini
+
+**Secondary persona — Archon contributor maintaining provider parity:**
+
+- Reads the capability matrix in [GEMINI_DEMO.md](GEMINI_DEMO.md) and the `GEMINI_CAPABILITIES` flags in `packages/providers/src/community/gemini/capabilities.ts`
+- Needs the cross-provider story to be coherent so that new workflow features can reason about provider support without per-provider branching
+- Pain point: the v1 matrix's 11 `false` flags imply more SDK limitation than actually exists
+
+**Technical comfort:** Both personas are senior developers comfortable with YAML config, git worktrees, and reading provider source code.
+
+---
+
+## 4. MVP Scope
+
+### In Scope (Phase 1 — Worktree-Isolated Runs)
+
+**Capability resolutions:**
+
+- ✅ `mcp: true` — Translate `nodeConfig.mcp` (file path string) → `.gemini/settings.json` `mcpServers` block staged into cwd
+- ✅ `agents: true` — Serialize inline `agents:` definitions to `.gemini/agents/<name>.md` with YAML frontmatter; inject `@name` activation hints into prompt
+- ✅ `sandbox: true` — Map `nodeConfig.sandbox` → `tools.sandbox` + `security` keys in staged settings.json
+- ✅ `fallbackModel: true` — Map `nodeConfig.fallbackModel` → `modelConfigs` alias chain in staged settings.json
+- ✅ `structuredOutput: true` — Add buffered code path that calls SDK's existing `queryFull()` for nodes with `output_format` (streaming path unchanged for nodes without it)
+
+**Infrastructure:**
+
+- ✅ `geminiConfigStager` module — Pure functions that build `.gemini/settings.json` and `.gemini/agents/*.md` content from `SendQueryOptions`
+- ✅ `withStagedGeminiConfig()` lifecycle helper — Stage before invoke, clean up after, scoped to a single SDK call
+- ✅ Worktree-only guard — Phase 1 fails the node loudly with a clear error if any of the new capabilities are requested in a `--no-worktree` run
+
+**Documentation:**
+
+- ✅ Update [GEMINI_DEMO.md](GEMINI_DEMO.md) matrix to reflect new capability set
+- ✅ Update `packages/docs-web/src/content/docs/getting-started/ai-assistants.md` capability section
+- ✅ Inline comments in `options-translator.ts` explaining the staging vs SDK-arg split
+
+**Testing:**
+
+- ✅ Unit tests for each builder function (pure, no I/O)
+- ✅ Integration tests for the lifecycle helper (real `tmp` dirs, real file I/O)
+- ✅ One e2e workflow per new capability in `.archon/workflows/test-workflows/`
+
+### In Scope (Phase 2 — `--no-worktree` Collision Safety)
+
+- ✅ Deep-merge logic for existing user `.gemini/settings.json` (additive: union maps, append arrays, never replace whole keys)
+- ✅ Backup-and-restore via `try/finally` with `.gemini/settings.json.archon.bak.<runId>` files
+- ✅ Crash recovery: on startup, restore the oldest `.archon.bak.*` before proceeding
+- ✅ Lockfile `.gemini/.archon.lock` to serialize concurrent Archon runs in the same cwd
+- ✅ Sentinel key `_archonGeneratedRunId: <uuid>` in injected blocks for user inspection
+- ✅ Remove the Phase 1 worktree-only guard
+
+### Out of Scope (Deferred — v3 or Never)
+
+- ❌ `hooks: true` — gemini-cli hooks are shell commands invoked via stdin/stdout JSON, not in-process JS callbacks like Claude's SDK. Would require a separate `hooks_gemini` schema variant; defer pending design discussion.
+- ❌ `skills: true` — gemini-cli has its own Agent Skills system with a different shape from Claude's `SKILL.md` + `AgentDefinition` wrapping. Defer pending schema design.
+- ❌ `thinkingControl: true` / `effortControl: true` — Gemini 3 generation settings exist but aren't 1:1 with Claude's `thinking: { type, budget_tokens }` or Codex's `modelReasoningEffort`. Forced mapping would mislead users. Defer.
+- ❌ `costControl: true` (`maxBudgetUsd`) — gemini-cli has no per-invocation budget primitive. Account-level `billing` config is a different concept. Will not implement.
+- ❌ `denied_tools` support — gemini-cli exposes only `--allowed-tools`, no denylist. Will not implement.
+- ❌ SDK feature requests upstream (`mcpServers` arg, `sandbox` arg, `queryFull` re-export) — quality-of-life only; not blocking. Out of scope for this PRD.
+- ❌ `GEMINI_CONFIG_DIR` redirect approach — Documented as broken on Windows (Archon's primary dev platform per [GEMINI_DEMO.md](GEMINI_DEMO.md)). Not used.
+
+---
+
+## 5. User Stories
+
+### US-1: MCP Servers on a Gemini Node
+
+**As a** workflow author, **I want to** specify `mcp: ./mcp-config.json` on a `provider: gemini` node, **so that** the Gemini agent can call MCP tools the same way a Claude node can.
+
+**Example:**
+
+```yaml
+- id: gemini-research
+  provider: gemini
+  model: gemini-3-pro
+  mcp: ./.archon/mcp/research-servers.json
+  prompt: Use the brave-search MCP server to find recent papers on diffusion models.
+```
+
+Today this emits a warn-and-run notice and the MCP block is ignored. After MVP: gemini-cli loads the servers from a staged `.gemini/settings.json` and the prompt can invoke them.
+
+### US-2: Inline Sub-Agent on a Gemini Node
+
+**As a** workflow author, **I want to** define an inline sub-agent on a Gemini node, **so that** complex tool-heavy work can be delegated to a scoped helper without polluting the main session.
+
+**Example:**
+
+```yaml
+- id: audit
+  provider: gemini
+  agents:
+    - name: security-auditor
+      description: Finds SQL injection, XSS, hardcoded credentials.
+      tools: [read_file, grep_search]
+      prompt: You are a ruthless security auditor...
+  prompt: |
+    @security-auditor Review packages/server/src/routes/ for vulnerabilities.
+```
+
+### US-3: Sandbox-Constrained Gemini Node
+
+**As a** workflow author, **I want to** run a Gemini node in a sandboxed environment, **so that** untrusted tool invocations cannot escape into the host.
+
+**Example:**
+
+```yaml
+- id: untrusted-eval
+  provider: gemini
+  sandbox: docker
+  prompt: Run the provided npm package and report what it does on disk.
+```
+
+### US-4: Model Fallback for Quota Resilience
+
+**As a** workflow author, **I want to** specify a fallback model on a long-running Gemini node, **so that** the workflow continues to succeed if the primary model hits a quota error.
+
+**Example:**
+
+```yaml
+- id: long-analysis
+  provider: gemini
+  model: gemini-3-pro
+  fallbackModel: gemini-3-flash
+  prompt: ...
+```
+
+### US-5: Structured JSON Output from a Gemini Node
+
+**As a** workflow author, **I want to** request `output_format: { type: json, schema: {...} }` from a Gemini node, **so that** downstream nodes can reliably parse `$nodeId.output` without prompt-engineering for JSON.
+
+**Example:**
+
+```yaml
+- id: extract-facts
+  provider: gemini
+  output_format:
+    type: json
+    schema:
+      type: object
+      properties:
+        facts: { type: array, items: { type: string } }
+  prompt: Extract three facts about graceful degradation as a JSON object.
+```
+
+After MVP: the provider routes this node through `queryFull()` and returns a buffered, schema-conformant JSON payload. Streaming nodes (without `output_format`) continue to use `query()` unchanged.
+
+### US-6: Cross-Provider Workflow Without Fidelity Loss
+
+**As a** workflow author, **I want to** mix Claude, Codex, and Gemini nodes in the same workflow with the same expressive option set per node, **so that** the choice of provider doesn't dictate what a node can do.
+
+This is the umbrella story; US-1 through US-5 are concrete instances.
+
+### US-7 (Technical): Provider-Layer Capability Expansion Without SDK Coupling
+
+**As an** Archon contributor, **I want** the capability expansion to live entirely in `packages/providers/src/community/gemini/`, **so that** SDK upstream changes don't block Archon's roadmap and SDK bugs don't regress workflow features.
+
+### US-8 (Technical): Safe Coexistence with User's `.gemini/`
+
+**As an** Archon user running `--no-worktree`, **I want** Archon to never clobber my hand-authored `.gemini/settings.json`, **so that** my personal gemini-cli configuration survives every Archon run, even one that crashes mid-invoke.
+
+---
+
+## 6. Core Architecture & Patterns
+
+### High-Level Approach
+
+Add a **two-layer translation** to the Gemini provider:
+
+1. **Existing layer (unchanged):** `translateOptions()` builds SDK `QueryOptions` for fields the SDK accepts natively (`prompt`, `cwd`, `model`, `systemPrompt`, `allowedTools`, `env`, `session`, etc.).
+2. **New layer:** `stageConfigForInvoke()` materializes per-invocation files into the cwd's `.gemini/` directory for fields the SDK doesn't expose but gemini-cli reads from disk.
+
+The new layer is wrapped in a lifecycle helper `withStagedGeminiConfig()` that handles staging-before / cleanup-after with `try/finally` semantics.
+
+### Directory Layout (new + modified)
+
+```
+packages/providers/src/community/gemini/
+├── capabilities.ts                  # MODIFIED — flip mcp/agents/sandbox/fallbackModel/structuredOutput to true
+├── options-translator.ts            # MODIFIED — remove staged-now-supported keys from warnIgnoredOptions()
+├── provider.ts                      # MODIFIED — wrap sendQuery body in withStagedGeminiConfig()
+├── config-stager/                   # NEW DIRECTORY
+│   ├── index.ts                     # Public exports
+│   ├── settings-builder.ts          # Pure: SendQueryOptions → SettingsJsonPatch
+│   ├── agents-builder.ts            # Pure: nodeConfig.agents → AgentMarkdownFile[]
+│   ├── lifecycle.ts                 # withStagedGeminiConfig() — staging/cleanup orchestration
+│   ├── merge.ts                     # Phase 2 — deep-merge user's existing settings.json
+│   ├── lockfile.ts                  # Phase 2 — .archon.lock acquire/release
+│   ├── backup.ts                    # Phase 2 — backup/restore with crash recovery
+│   ├── settings-builder.test.ts     # NEW
+│   ├── agents-builder.test.ts       # NEW
+│   ├── lifecycle.test.ts            # NEW
+│   ├── merge.test.ts                # NEW (Phase 2)
+│   ├── lockfile.test.ts             # NEW (Phase 2)
+│   └── backup.test.ts               # NEW (Phase 2)
+└── ... (existing files)
+
+.archon/workflows/test-workflows/    # NEW e2e workflows
+├── e2e-gemini-mcp.yaml
+├── e2e-gemini-agents.yaml
+├── e2e-gemini-sandbox.yaml
+├── e2e-gemini-fallback.yaml
+└── e2e-gemini-structured-output.yaml
+```
+
+### Key Design Patterns
+
+**Single Responsibility:** `settings-builder` and `agents-builder` are pure transforms (no I/O). `lifecycle.ts` orchestrates I/O. Tests for builders can run without temp dirs.
+
+**Fail-Fast (CLAUDE.md):** Phase 1 throws an explicit `GeminiConfigStagingNotSupportedError` when any staged capability is requested in `--no-worktree`. No silent fallback.
+
+**Reversibility:** Phase 1's worktree-scoped staging is implicitly reversible (worktree teardown). Phase 2's backup-and-restore is explicitly reversible (always restore in `finally`).
+
+**Match Existing Patterns:** The Claude provider already reads `mcp:` file paths, parses, expands env vars, and passes to the SDK. The Gemini config-stager is the same pattern with a different output target (filesystem instead of SDK arg).
+
+### Dependency Direction (preserved)
+
+```
+@archon/paths ← @archon/git ← @archon/providers (gemini config-stager goes here)
+                            ← @archon/workflows (consumes IAgentProvider, unchanged)
+```
+
+No new package needed. No changes to interface contracts (`IAgentProvider`, `SendQueryOptions`). The stager is an implementation detail of `GeminiProvider`.
+
+---
+
+## 7. Tools/Features
+
+### Feature 1: Settings.json Stager
+
+**Purpose:** Convert per-invocation Gemini-relevant options into a project-layer `.gemini/settings.json` patch.
+
+**Operations:**
+
+- `buildSettingsPatch(options: SendQueryOptions): SettingsJsonPatch` — pure
+- Maps `nodeConfig.mcp` (file path) → reads file → emits `{ mcpServers: {...} }`
+- Maps `nodeConfig.sandbox` → `{ tools: { sandbox: ... }, security: {...} }`
+- Maps `nodeConfig.fallbackModel` → `{ modelConfigs: { customAliases: {...} } }`
+- Stamps every emitted block with `_archonGeneratedRunId: <uuid>` sentinel
+
+### Feature 2: Sub-Agent File Stager
+
+**Purpose:** Convert inline `agents:` array into `.gemini/agents/<name>.md` files with YAML frontmatter.
+
+**Operations:**
+
+- `buildAgentFiles(agents: AgentDefinition[]): AgentMarkdownFile[]` — pure
+- Each file: YAML frontmatter (`name`, `description`, `kind: local`, `tools`, `model`, etc.) + markdown body (the system prompt)
+- Validates names match `^[a-z][a-z0-9_-]*$` (gemini-cli requirement)
+
+### Feature 3: Lifecycle Helper
+
+**Purpose:** Wrap a single SDK `sendQuery` call with staging-before / cleanup-after.
+
+**Operations:**
+
+- `withStagedGeminiConfig<T>(cwd: string, options: SendQueryOptions, fn: () => Promise<T>): Promise<T>`
+- Phase 1: write files into `<cwd>/.gemini/`, run `fn`, delete files we wrote in `finally`
+- Phase 2: acquire lockfile → backup existing → merge → write → run `fn` → restore in `finally`
+- Tracks written file paths in a per-call manifest so cleanup deletes only what we created (never user-authored files)
+
+### Feature 4: Buffered Structured-Output Path
+
+**Purpose:** Route nodes with `output_format` through the SDK's `queryFull()` for schema-conformant JSON.
+
+**Operations:**
+
+- In `provider.ts` `sendQuery`: if `options.outputFormat` is set → call `queryFull()` → wrap the single response as a one-shot async generator yielding an `assistant` chunk + `result` chunk
+- Streaming nodes (no `outputFormat`) continue through `query()` unchanged
+- `queryFull` failure → surface as `ModelAccessError` (existing error class)
+
+---
+
+## 8. Technology Stack
+
+**Languages & Runtimes:**
+
+- TypeScript 5.x (strict mode, project standard)
+- Bun 1.3+ (test runner, package manager)
+
+**Dependencies (existing, no new top-level deps):**
+
+- `@lrilai/gemini-cli-sdk` — unchanged version pin
+- `@archon/paths` — already used for `createLogger`
+- `node:fs/promises` — file staging I/O
+- `node:path` — path joins
+- `node:crypto` — `randomUUID()` for run-id sentinels and lockfile content
+
+**No new dependencies required.** Deep-merge logic in Phase 2 can be implemented in <50 lines for the limited key surface we touch (`mcpServers`, `tools.sandbox`, `modelConfigs`, `security`); pulling in `deepmerge` or `lodash.merge` is not justified for this scope (KISS + YAGNI per CLAUDE.md).
+
+**Test Infrastructure:**
+
+- Bun's built-in test runner with `spyOn()` for internal-module spies (mock isolation rules per CLAUDE.md)
+- Real `os.tmpdir()` directories for integration tests, cleaned up in `afterEach`
+- The gemini provider's existing test split (`provider.test.ts`, `options-translator.test.ts`, `config.test.ts`) gets a 4th file: `config-stager/*.test.ts`. Verify no `mock.module()` conflicts with existing files before adding.
+
+---
+
+## 9. Security & Configuration
+
+### Authentication
+
+Unchanged from v1. The provider continues to rely on ambient `~/.gemini/` OAuth credentials. The subprocess inherits the parent process env (including `HOME`), so credential resolution is unaffected by config staging. The stager never touches `~/.gemini/` — only the project-layer `.gemini/` inside the cwd.
+
+### Configuration Surface
+
+**New `nodeConfig` keys consumed (already in schema, currently warn-and-ignored for Gemini):**
+
+- `mcp: string` — file path to MCP config JSON
+- `agents: AgentDefinition[]` — inline sub-agent definitions
+- `sandbox: SandboxConfig` — sandbox mode (`docker`, `seatbelt`, `none`)
+- `fallbackModel: string` — fallback model id
+- `output_format: { type, schema? }` — structured output request
+
+**No new top-level `.archon/config.yaml` keys.** All config flows through existing per-node and per-workflow keys.
+
+### Security Considerations
+
+**In Scope:**
+
+- ✅ Sentinel keys (`_archonGeneratedRunId`) so users can identify Archon-written config at a glance
+- ✅ Cleanup-on-crash via `try/finally` + startup `.bak` recovery (Phase 2)
+- ✅ Lockfile prevents concurrent Archon runs in the same cwd from corrupting each other's writes (Phase 2)
+- ✅ Sub-agent name validation rejects path-traversal characters (`.`, `/`, `\`) before writing files
+- ✅ MCP config file paths are resolved relative to the workflow cwd and rejected if they escape it (existing `@archon/paths` utility)
+
+**Out of Scope:**
+
+- ❌ Sandbox isolation of the gemini-cli subprocess itself — that's gemini-cli's responsibility (delegated via `tools.sandbox`)
+- ❌ Sub-agent prompt content sanitization — sub-agent prompts are workflow-author code, treated with the same trust as any other workflow YAML
+- ❌ Validating that the user's existing `.gemini/settings.json` is well-formed — if it's already broken, we report and abort the merge rather than try to fix it
+
+### Deployment
+
+No new deployment artifacts. The change is a pure provider-layer enhancement shipped in the standard Archon binary/source build. Bundled defaults (`bundled-defaults.generated.ts`) are unaffected because none of the new e2e test workflows live under `.archon/workflows/defaults/`.
+
+---
+
+## 10. API Specification
+
+No new HTTP endpoints. The provider expansion is transparent to `/api/providers` (the `capabilities` field in the response will simply have more `true` values after MVP).
+
+The `GET /api/providers` response shape is unchanged; the data inside it shifts:
+
+```jsonc
+// Before MVP
+{ "id": "gemini", "capabilities": { "mcp": false, "agents": false, "sandbox": false, "fallbackModel": false, "structuredOutput": false, ... } }
+
+// After MVP Phase 1
+{ "id": "gemini", "capabilities": { "mcp": true, "agents": true, "sandbox": true, "fallbackModel": true, "structuredOutput": true, ... } }
+```
+
+---
+
+## 11. Success Criteria
+
+### MVP Success Definition
+
+A workflow author can write a `provider: gemini` node with `mcp:`, `agents:`, `sandbox:`, `fallbackModel:`, or `output_format:` and have it execute correctly — no warning emitted, no silent ignore — provided the run is worktree-isolated (Phase 1) or running in any cwd (Phase 2).
+
+### Functional Requirements
+
+- ✅ Each of the 5 new e2e workflows in `.archon/workflows/test-workflows/` runs end-to-end with exit 0
+- ✅ `GEMINI_CAPABILITIES` reports `mcp: true`, `agents: true`, `sandbox: true`, `fallbackModel: true`, `structuredOutput: true`
+- ✅ `warnIgnoredOptions()` no longer warns for the 5 newly-supported keys
+- ✅ No regression in existing v1 capability behavior (`sessionResume`, `toolRestrictions`, `envInjection` still work as before)
+- ✅ No regression in v1's `archon-gemini-showcase` and `e2e-gemini-smoke` workflows
+- ✅ `bun run validate` passes (type-check + lint + format + tests + check:bundled)
+
+### Quality Indicators
+
+- ✅ All new code has explicit return types (ESLint zero-warning policy)
+- ✅ No `any` types added without an inline justification comment
+- ✅ Unit tests for every pure builder function (statements + branches)
+- ✅ Integration tests for the lifecycle helper using real temp dirs
+- ✅ Inline comments only where the _why_ is non-obvious (CLAUDE.md guideline)
+
+### User Experience Goals
+
+- ✅ A workflow author who writes `mcp: ./foo.json` on a Gemini node gets the same behavior as on a Claude node
+- ✅ A user with their own hand-authored `~/.gemini/settings.json` sees no change in behavior after Archon runs (Phase 2)
+- ✅ A workflow author moving a node between providers doesn't need to know about provider-specific staging mechanics
+
+---
+
+## 12. Implementation Phases
+
+### Phase 1: Worktree-Only Config Staging (Foundation)
+
+**Goal:** Resolve the 5 high-value capabilities for the 90% case (worktree-isolated runs).
+
+**Deliverables:**
+
+- ✅ `config-stager/settings-builder.ts` + tests
+- ✅ `config-stager/agents-builder.ts` + tests
+- ✅ `config-stager/lifecycle.ts` (worktree-only mode) + tests
+- ✅ `provider.ts` integration: wrap `sendQuery` body in `withStagedGeminiConfig`
+- ✅ `provider.ts` integration: buffered `queryFull()` path for `output_format`
+- ✅ `capabilities.ts` flag flips (mcp, agents, sandbox, fallbackModel, structuredOutput → `true`)
+- ✅ `options-translator.ts` `warnIgnoredOptions()` cleanup
+- ✅ Worktree-detection guard: `GeminiConfigStagingNotSupportedError` if a staged capability is requested in `--no-worktree`
+- ✅ 5 e2e workflows in `.archon/workflows/test-workflows/`
+- ✅ Updated capability matrix in [GEMINI_DEMO.md](GEMINI_DEMO.md)
+- ✅ Updated `packages/docs-web/src/content/docs/getting-started/ai-assistants.md`
+
+**Validation:**
+
+- All 5 e2e workflows pass when run inside a worktree
+- All 5 e2e workflows fail loudly (clear error) when run with `--no-worktree`
+- `archon-gemini-showcase` v1 workflow still passes
+- `bun run validate` passes
+
+**Estimated complexity:** Medium
+
+### Phase 2: `--no-worktree` Collision Safety (Hardening)
+
+**Goal:** Lift the Phase 1 worktree-only restriction without risking user `.gemini/settings.json` corruption.
+
+**Deliverables:**
+
+- ✅ `config-stager/merge.ts` — additive deep-merge for our specific key surface
+- ✅ `config-stager/backup.ts` — backup-and-restore with crash recovery on startup
+- ✅ `config-stager/lockfile.ts` — `.archon.lock` acquire/release/timeout
+- ✅ `lifecycle.ts` enhancement: orchestrate merge → backup → write → run → restore → unlock
+- ✅ Remove worktree-only guard from Phase 1
+- ✅ Crash-recovery test (kill mid-invoke; verify next start restores the .bak)
+- ✅ Concurrency test (two simulated parallel runs in same cwd; verify lockfile serializes)
+
+**Validation:**
+
+- All 5 e2e workflows pass when run with `--no-worktree`
+- Crash recovery test passes
+- Concurrency test passes
+- `bun run validate` passes
+
+**Estimated complexity:** Medium-High (the crash-recovery and lockfile machinery is the trickiest part of the whole PRD)
+
+### Phase 3: Documentation + Capability Discoverability
+
+**Goal:** Make the new capabilities discoverable for workflow authors and consistent with cross-provider docs.
+
+**Deliverables:**
+
+- ✅ Update [GEMINI_DEMO.md](GEMINI_DEMO.md) §5 Findings with any new SDK bugs found during MVP build
+- ✅ Add a "Provider capability parity" section to the AI assistants doc cross-referencing what works where
+- ✅ Add an example to the workflows authoring docs showing a mixed Claude/Gemini workflow with `mcp:` on both nodes
+- ✅ CHANGELOG entry
+
+**Validation:**
+
+- Docs build (`bun --filter @archon/docs-web build`) passes
+- All doc links resolve
+
+**Estimated complexity:** Low
+
+---
+
+## 13. Future Considerations
+
+**v3 — Hooks and Skills (Schema Design Required):**
+
+- Design a `hooks_gemini` schema variant that accepts shell commands (matching gemini-cli's hook contract) rather than JS callbacks (matching Claude's). Avoid pretending the existing `hooks:` key translates.
+- Translate Archon's skill format to gemini-cli's Agent Skills shape, or — equivalently — auto-generate gemini-cli skills from Archon's `SKILL.md` files using a deterministic transformer.
+
+**v3 — Effort/Thinking Mapping:**
+
+- If Google publishes a stable mapping between thinking budgets and Gemini generation settings, add a `thinking`/`effort` translation. Until then, leave `false`.
+
+**Upstream SDK Quality-of-Life:**
+
+- File a feature request on `@lrilai/gemini-cli-sdk` for `mcpServers` / `sandbox` / `modelConfigs` `QueryOptions` args. Would simplify Phase 1 staging logic if accepted.
+- File a feature request for a `bufferedQuery()` or `queryFull()` re-export that doesn't require dual entry points.
+
+**Cross-Provider Capability Negotiation:**
+
+- The capability matrix is currently inspected by the engine at node-execution time. A future refactor could expose it at workflow-load time so workflow authors get static-validation errors (e.g. "this workflow uses `effort:` on a Gemini node — that capability is `false`") rather than runtime warnings.
+
+**SDK Bug Tracking:**
+
+- The v1 demo found two real SDK bugs (double-quote prompts hard-fail; session-resume degrades fidelity). v2 build is likely to surface more. Establish a `docs/gemini-sdk-bugs.md` log to track them.
+
+---
+
+## 14. Risks & Mitigations
+
+### Risk 1: `--no-worktree` crash leaves user's `.gemini/settings.json` mangled
+
+**Mitigation:** Phase 1 ships with a hard guard rejecting staged capabilities under `--no-worktree`. Phase 2's backup + startup-recovery design means any crash between backup-write and restore is recovered by the next Archon run that touches the same cwd. Validated by a deliberate-crash integration test.
+
+### Risk 2: Concurrent Archon runs in the same cwd corrupt each other's settings.json
+
+**Mitigation:** Phase 2 lockfile (`.archon.lock`) serializes runs. Stale-lock detection via PID liveness check + max age. Lockfile owner ID lets a second runner distinguish "owned by live process" from "abandoned by dead process."
+
+### Risk 3: gemini-cli changes its settings.json schema in a future release, breaking our writes
+
+**Mitigation:** Keep the `SettingsJsonPatch` shape narrow — write only the specific keys we need (`mcpServers`, `tools.sandbox`, `modelConfigs`, `security`). Pin a tested `gemini-cli` version range in docs. Failure mode is graceful: gemini-cli ignores unknown keys, so a schema drift typically degrades to "feature silently ignored" rather than "crash."
+
+### Risk 4: SDK bugs cascade into the new code paths (e.g., the v1 double-quote bug)
+
+**Mitigation:** Each e2e test workflow uses prompts that avoid the known v1 SDK gotchas (no `"` characters). The provider's existing `ErrorMapper` continues to surface SDK failures as `ModelAccessError`, unchanged. Any new SDK bug found is documented in [GEMINI_DEMO.md](GEMINI_DEMO.md) §5 with isolated reproduction.
+
+### Risk 5: Capability matrix declarations drift from actual wired-up behavior over time
+
+**Mitigation:** Each capability flag is enforced by an e2e test workflow — if `mcp: true` is declared, an `e2e-gemini-mcp.yaml` run is part of the test suite, and its failure blocks CI. The flag and the test are physically co-located in the PR that introduces them.
+
+---
+
+## 15. Appendix
+
+### Related Documents
+
+- [GEMINI_DEMO.md](GEMINI_DEMO.md) — v1 evidence document, capability matrix, SDK bug log
+- [CLAUDE.md](CLAUDE.md) — Project engineering principles (KISS, YAGNI, Fail-Fast, Reversibility), test isolation rules, package boundaries
+- [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) — Required PR format
+- `packages/providers/src/community/gemini/capabilities.ts` — Source of truth for declared capabilities (flags get flipped here)
+- `packages/providers/src/community/gemini/options-translator.ts` — Existing translation layer
+
+### Key External Dependencies & References
+
+- [`@lrilai/gemini-cli-sdk`](https://www.npmjs.com/package/@lrilai/gemini-cli-sdk) — SDK (unchanged version pin)
+- [Gemini CLI configuration reference](https://geminicli.com/docs/reference/configuration/) — settings.json precedence (defaults < system-defaults < **user** < **project** < system < env vars < CLI args)
+- [Gemini CLI subagents](https://geminicli.com/docs/core/subagents/) — `.gemini/agents/*.md` format and `@name` activation
+- [Gemini CLI model routing](https://geminicli.com/docs/cli/model-routing/) — `modelConfigs` aliases and fallback chains
+- [Gemini CLI headless mode](https://geminicli.com/docs/cli/headless/) — `--output-format json/jsonl` (alternate route if SDK `queryFull()` proves insufficient)
+- [GitHub issue #8248](https://github.com/google-gemini/gemini-cli/issues/8248) — `GEMINI_CONFIG_DIR` broken on Windows (justification for rejecting that approach)
+
+### Package Structure Touched
+
+```
+packages/providers/src/community/gemini/
+├── capabilities.ts                  [MODIFIED]
+├── options-translator.ts            [MODIFIED]
+├── provider.ts                      [MODIFIED]
+├── config-stager/                   [NEW]
+│   ├── index.ts
+│   ├── settings-builder.ts
+│   ├── agents-builder.ts
+│   ├── lifecycle.ts
+│   ├── merge.ts                     (Phase 2)
+│   ├── lockfile.ts                  (Phase 2)
+│   ├── backup.ts                    (Phase 2)
+│   └── *.test.ts
+└── (existing files unchanged)
+
+.archon/workflows/test-workflows/    [NEW e2e workflows]
+├── e2e-gemini-mcp.yaml
+├── e2e-gemini-agents.yaml
+├── e2e-gemini-sandbox.yaml
+├── e2e-gemini-fallback.yaml
+└── e2e-gemini-structured-output.yaml
+
+GEMINI_DEMO.md                       [MODIFIED — matrix update]
+packages/docs-web/src/content/docs/
+  getting-started/ai-assistants.md   [MODIFIED — Gemini capabilities section]
+CHANGELOG.md                         [MODIFIED — release notes entry]
+```
+
+### Assumptions Made (Reviewer Validation Requested)
+
+1. **`@lrilai/gemini-cli-sdk` does not strip or override `.gemini/` files in the cwd it's invoked with.** This needs an empirical confirmation test before Phase 1 begins (write a settings.json into a temp cwd, invoke the SDK, verify gemini-cli picked it up).
+2. **gemini-cli's project-settings discovery walks up from cwd to nearest `.git` directory** (per docs). Archon worktrees always have a `.git` file at the worktree root, so the discovery terminates at the worktree root and not at the parent main repo. Worth confirming on Windows specifically.
+3. **The SDK's `queryFull()` is exported and stable.** PRD assumes it is, based on capabilities.ts comments and SDK v1.0.0 docs. Verify the export exists in the pinned SDK version before relying on it in Phase 1.
+4. **`fs.promises.rename` is atomic enough for backup-restore on Windows.** Phase 2 design assumes Node's rename semantics work for `.bak` restoration. If Windows shows non-atomic behavior, fall back to copy-then-delete with a marker file.
+5. **No workflow author currently relies on the warn-and-run behavior of `mcp`/`agents`/`sandbox`/`fallbackModel`/`output_format` on Gemini nodes** (i.e., depends on them being silently ignored). Flipping these to `true` is a behavior change for those users. This is judged acceptable because the prior behavior was explicitly documented as a fail-safe, not a feature.

--- a/bun.lock
+++ b/bun.lock
@@ -130,6 +130,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.121",
         "@archon/paths": "workspace:*",
+        "@lrilai/gemini-cli-sdk": "^1.0.0",
         "@mariozechner/pi-ai": "^0.67.5",
         "@mariozechner/pi-coding-agent": "^0.67.5",
         "@openai/codex-sdk": "^0.125.0",
@@ -633,6 +634,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@lrilai/gemini-cli-sdk": ["@lrilai/gemini-cli-sdk@1.0.0", "", { "dependencies": { "semver": "^7.7.4", "zod": "^4.3.6", "zod-from-json-schema": "^0.5.2" } }, "sha512-9VbkLnMZQ3h6xtaFa7AETnmllVSH6rJNqUO88OjRdh9URE83M76uk34Kwh0R0mEU9HODevKr7gMWYb88kO7w7w=="],
 
     "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.2", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.2", "@mariozechner/clipboard-darwin-universal": "0.3.2", "@mariozechner/clipboard-darwin-x64": "0.3.2", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.2", "@mariozechner/clipboard-linux-arm64-musl": "0.3.2", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2", "@mariozechner/clipboard-linux-x64-gnu": "0.3.2", "@mariozechner/clipboard-linux-x64-musl": "0.3.2", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.2", "@mariozechner/clipboard-win32-x64-msvc": "0.3.2" } }, "sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA=="],
 
@@ -2798,6 +2801,8 @@
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "zod-from-json-schema": ["zod-from-json-schema@0.5.2", "", { "dependencies": { "zod": "^4.0.17" } }, "sha512-/dNaicfdhJTOuUd4RImbLUE2g5yrSzzDjI/S6C2vO2ecAGZzn9UcRVgtyLSnENSmAOBRiSpUdzDS6fDWX3Z35g=="],
+
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
@@ -2853,6 +2858,8 @@
     "@expressive-code/plugin-shiki/shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@lrilai/gemini-cli-sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@mariozechner/pi-ai/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.90.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg=="],
 
@@ -3133,6 +3140,8 @@
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
+
+    "zod-from-json-schema/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@astrojs/markdown-remark/unified/bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -125,6 +125,49 @@ export async function checkPi(env: NodeJS.ProcessEnv): Promise<CheckResult> {
   };
 }
 
+// Env vars that signal explicit Gemini auth, in the SDK's precedence order
+// (ADC > GEMINI_API_KEY > GOOGLE_APPLICATION_CREDENTIALS > GOOGLE_API_KEY).
+const GEMINI_API_KEY_VARS = [
+  'GEMINI_API_KEY',
+  'GOOGLE_APPLICATION_CREDENTIALS',
+  'GOOGLE_API_KEY',
+] as const;
+
+// Credential filenames `gemini auth login` may write under ~/.gemini/. Probing
+// several avoids false-failing a logged-in user when the filename varies by
+// gemini-cli version.
+const GEMINI_CRED_FILES = ['oauth_creds.json', 'credentials.json', 'google_accounts.json'];
+
+export async function checkGemini(env: NodeJS.ProcessEnv): Promise<CheckResult> {
+  const label = 'Gemini provider';
+  const isDefault = env.DEFAULT_AI_ASSISTANT === 'gemini';
+
+  // Skip unless Gemini is the default — shared Google keys shouldn't trigger a
+  // pass for users who merely have them set for other tools.
+  if (!isDefault) {
+    return { label, status: 'skip', message: 'Gemini not configured' };
+  }
+
+  // Ambient OAuth login (`gemini auth login`) writes credentials under ~/.gemini/.
+  const geminiDir = join(homedir(), '.gemini');
+  const foundCred = GEMINI_CRED_FILES.find(f => probeAuthJsonExists(join(geminiDir, f)));
+  if (foundCred) {
+    return { label, status: 'pass', message: `~/.gemini/${foundCred} found` };
+  }
+
+  const foundKey = GEMINI_API_KEY_VARS.find(v => (env[v] ?? '').trim().length > 0);
+  if (foundKey) {
+    return { label, status: 'pass', message: `${foundKey} is set` };
+  }
+
+  return {
+    label,
+    status: 'fail',
+    message:
+      'Gemini is configured as default but no auth found. Run `gemini auth login` to sign in with Google, or set GEMINI_API_KEY.',
+  };
+}
+
 export interface DatabaseDeps {
   pool: { query: (sql: string) => Promise<unknown> };
   getDatabaseType: () => string;
@@ -279,6 +322,7 @@ export async function doctorCommand(
         checkClaudeBinary(env),
         checkGhAuth(env),
         checkPi(env),
+        checkGemini(env),
         checkDatabase(),
         checkWorkspaceWritable(),
         checkBundledDefaults(),

--- a/packages/core/src/config/config-loader.ts
+++ b/packages/core/src/config/config-loader.ts
@@ -99,6 +99,7 @@ const SAFE_ASSISTANT_FIELDS: Record<string, readonly string[]> = {
   // community providers — list each field we're confident is safe to
   // show in the web UI. Unknown providers fall through with no fields.
   pi: ['model'],
+  gemini: ['model'],
 };
 
 function toSafeAssistantDefaults(assistants: AssistantDefaults): SafeConfig['assistants'] {

--- a/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
+++ b/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
@@ -409,6 +409,94 @@ Unsupported YAML fields trigger a visible warning from the dag-executor when the
 - [Adding a Community Provider](../contributing/adding-a-community-provider/) — the contributor-facing guide for extending Archon with your own provider.
 - [Pi on GitHub](https://github.com/badlogic/pi-mono) — upstream project.
 
+## Gemini (Community Provider)
+
+**Google's Gemini via the `gemini-cli`.** The Gemini provider (`@lrilai/gemini-cli-sdk`) wraps Google's `gemini-cli` and is registered as `builtIn: false` — a community provider alongside Pi. Use it by setting `provider: gemini` and a `model:` such as `gemini-2.5-pro`.
+
+### Install
+
+The SDK is bundled as a dependency of `@archon/providers`, but it shells out to the `gemini-cli` binary, which you install separately (≥ 0.37.1):
+
+```bash
+npm install -g @google/gemini-cli
+```
+
+In **dev/source** runs the SDK finds `gemini` on your `PATH`. In **compiled Archon binaries**, if `gemini` is not on `PATH`, point Archon at it via `GEMINI_BIN_PATH` or `assistants.gemini.geminiBinaryPath` (see below).
+
+### Authenticate (no API key needed)
+
+Gemini uses **ambient OAuth credentials** — the same login the `gemini-cli` uses. Archon injects **no** API key; the subprocess inherits your environment (including `HOME`), so `~/.gemini` resolves automatically.
+
+```bash
+# Sign in with Google — writes credentials under ~/.gemini/
+gemini auth login
+```
+
+Alternatively, set one of these env vars. The SDK's auth precedence is **ADC (your `gemini auth login`) → `GEMINI_API_KEY` → `GOOGLE_APPLICATION_CREDENTIALS` → `GOOGLE_API_KEY`**:
+
+| Env var | Use |
+|---|---|
+| `GEMINI_API_KEY` | Gemini AI Studio API key |
+| `GOOGLE_APPLICATION_CREDENTIALS` | Path to a Vertex AI service-account JSON |
+| `GOOGLE_API_KEY` | Google Cloud API key |
+
+`archon doctor` reports a Gemini check when `DEFAULT_AI_ASSISTANT=gemini`: it passes when a `~/.gemini` credential file or one of the env vars above is present.
+
+### Binary path (compiled builds)
+
+```yaml
+# ~/.archon/config.yaml
+assistants:
+  gemini:
+    geminiBinaryPath: /absolute/path/to/gemini
+```
+
+Or set `GEMINI_BIN_PATH=/absolute/path/to/gemini`. Resolution order: `GEMINI_BIN_PATH` → config `geminiBinaryPath` → `~/.archon/vendor/gemini/` → autodetected npm-global paths.
+
+### Model reference format
+
+Model strings are forwarded verbatim to `gemini-cli` (Archon does not validate them):
+
+```yaml
+assistants:
+  gemini:
+    model: gemini-2.5-pro       # or gemini-2.5-flash, gemini-3-pro, etc.
+```
+
+### Usage in workflows
+
+```yaml
+name: my-workflow
+provider: gemini
+model: gemini-2.5-pro
+
+nodes:
+  - id: explore
+    provider: gemini
+    prompt: "..."
+    allowed_tools: [read, grep]   # mapped to gemini-cli --allowed-tools
+```
+
+### Gemini capabilities (v1)
+
+| Feature | Support | Notes |
+|---|---|---|
+| Session resume | ✅ | automatic (Archon persists `sessionId`) |
+| Tool restrictions | ✅ | `allowed_tools` → `--allowed-tools` (`denied_tools` has no SDK equivalent) |
+| System prompt override | ✅ | `systemPrompt:` (string only) |
+| Codebase env vars (`envInjection`) | ✅ | forwarded to the subprocess; `HOME` is never overridden |
+| MCP servers | ❌ | SDK support is experimental; deferred to a later version |
+| Structured output | ❌ | only the SDK's buffered `queryFull()` supports it; incompatible with streaming in v1 |
+| Skills / hooks / inline sub-agents | ❌ | Claude-only features |
+| Effort / thinking / cost limits / fallback model / sandbox | ❌ | not wired in v1 |
+
+Unsupported YAML fields trigger a visible dag-executor warning when the workflow runs, so you always know what was ignored.
+
+### See also
+
+- [Adding a Community Provider](../contributing/adding-a-community-provider/) — the contributor-facing guide for extending Archon with your own provider.
+- [@lrilai/gemini-cli-sdk on npm](https://www.npmjs.com/package/@lrilai/gemini-cli-sdk) — the wrapped SDK.
+
 ## How Assistant Selection Works
 
 - Assistant type is set per codebase via the `assistant` field in `.archon/config.yaml` or the `DEFAULT_AI_ASSISTANT` env var

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -15,16 +15,18 @@
     "./codex/binary-resolver": "./src/codex/binary-resolver.ts",
     "./mcp/config": "./src/mcp/config.ts",
     "./community/pi": "./src/community/pi/index.ts",
+    "./community/gemini": "./src/community/gemini/index.ts",
     "./errors": "./src/errors.ts",
     "./registry": "./src/registry.ts"
   },
   "scripts": {
-    "test": "bun test src/claude/provider.test.ts && bun test src/codex/provider.test.ts && bun test src/registry.test.ts && bun test src/codex/binary-guard.test.ts && bun test src/codex/binary-resolver.test.ts && bun test src/codex/binary-resolver-dev.test.ts && bun test src/claude/binary-resolver.test.ts && bun test src/claude/binary-resolver-dev.test.ts && bun test src/community/pi/model-ref.test.ts && bun test src/community/pi/config.test.ts && bun test src/community/pi/event-bridge.test.ts && bun test src/community/pi/options-translator.test.ts && bun test src/community/pi/session-resolver.test.ts && bun test src/community/pi/provider.test.ts && bun test src/community/pi/provider-lazy-load.test.ts",
+    "test": "bun test src/claude/provider.test.ts && bun test src/codex/provider.test.ts && bun test src/registry.test.ts && bun test src/codex/binary-guard.test.ts && bun test src/codex/binary-resolver.test.ts && bun test src/codex/binary-resolver-dev.test.ts && bun test src/claude/binary-resolver.test.ts && bun test src/claude/binary-resolver-dev.test.ts && bun test src/community/pi/model-ref.test.ts && bun test src/community/pi/config.test.ts && bun test src/community/pi/event-bridge.test.ts && bun test src/community/pi/options-translator.test.ts && bun test src/community/pi/session-resolver.test.ts && bun test src/community/pi/provider.test.ts && bun test src/community/pi/provider-lazy-load.test.ts && bun test src/community/gemini/config.test.ts && bun test src/community/gemini/options-translator.test.ts && bun test src/community/gemini/provider.test.ts",
     "type-check": "bun x tsc --noEmit"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.121",
     "@archon/paths": "workspace:*",
+    "@lrilai/gemini-cli-sdk": "^1.0.0",
     "@mariozechner/pi-ai": "^0.67.5",
     "@mariozechner/pi-coding-agent": "^0.67.5",
     "@openai/codex-sdk": "^0.125.0",

--- a/packages/providers/src/community/gemini/binary-resolver.ts
+++ b/packages/providers/src/community/gemini/binary-resolver.ts
@@ -1,0 +1,135 @@
+/**
+ * gemini-cli binary resolver for compiled (bun --compile) Archon binaries.
+ *
+ * The @lrilai/gemini-cli-sdk shells out to a separately-installed `gemini-cli`
+ * binary and resolves it from PATH by default. In compiled Archon builds PATH
+ * resolution is unreliable, so this mirrors codex/binary-resolver.ts and feeds
+ * the result into the SDK's `QueryOptions.cliPath`.
+ *
+ * Resolution order:
+ *   1. `GEMINI_BIN_PATH` environment variable
+ *   2. `assistants.gemini.geminiBinaryPath` in config (passed in)
+ *   3. `~/.archon/vendor/gemini/<binary>` (user-placed)
+ *   4. Autodetect canonical npm-global install paths
+ *   5. Throw with install instructions
+ *
+ * In dev mode (BUNDLED_IS_BINARY=false) returns undefined so the SDK uses its
+ * normal PATH resolution.
+ */
+import { existsSync as _existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { BUNDLED_IS_BINARY, getArchonHome, createLogger } from '@archon/paths';
+
+/** Wrapper for existsSync — enables spyOn in tests (direct imports can't be spied on). */
+export function fileExists(path: string): boolean {
+  return _existsSync(path);
+}
+
+/** Lazy-initialized logger. */
+let cachedLog: ReturnType<typeof createLogger> | undefined;
+function getLog(): ReturnType<typeof createLogger> {
+  if (!cachedLog) cachedLog = createLogger('gemini-binary');
+  return cachedLog;
+}
+
+const GEMINI_VENDOR_DIR = 'vendor/gemini';
+
+/**
+ * Resolve the path to the gemini-cli binary.
+ *
+ * In dev mode: returns undefined (SDK resolves via PATH).
+ * In binary mode: resolves from env/config/vendor/autodetect, or throws.
+ */
+export async function resolveGeminiBinaryPath(
+  configGeminiBinaryPath?: string
+): Promise<string | undefined> {
+  if (!BUNDLED_IS_BINARY) return undefined;
+
+  // 1. Environment variable override
+  const envPath = process.env.GEMINI_BIN_PATH;
+  if (envPath) {
+    if (!fileExists(envPath)) {
+      throw new Error(
+        `GEMINI_BIN_PATH is set to "${envPath}" but the file does not exist.\n` +
+          'Please verify the path points to the gemini-cli binary.'
+      );
+    }
+    getLog().info({ binaryPath: envPath, source: 'env' }, 'gemini.binary_resolved');
+    return envPath;
+  }
+
+  // 2. Config file override
+  if (configGeminiBinaryPath) {
+    if (!fileExists(configGeminiBinaryPath)) {
+      throw new Error(
+        `assistants.gemini.geminiBinaryPath is set to "${configGeminiBinaryPath}" but the file does not exist.\n` +
+          'Please verify the path in .archon/config.yaml points to the gemini-cli binary.'
+      );
+    }
+    getLog().info(
+      { binaryPath: configGeminiBinaryPath, source: 'config' },
+      'gemini.binary_resolved'
+    );
+    return configGeminiBinaryPath;
+  }
+
+  // 3. Vendor directory (user-placed binary)
+  const binaryName = process.platform === 'win32' ? 'gemini.cmd' : 'gemini';
+  const vendorBinaryPath = join(getArchonHome(), GEMINI_VENDOR_DIR, binaryName);
+  if (fileExists(vendorBinaryPath)) {
+    getLog().info({ binaryPath: vendorBinaryPath, source: 'vendor' }, 'gemini.binary_resolved');
+    return vendorBinaryPath;
+  }
+
+  // 4. Autodetect canonical install paths
+  for (const probePath of getAutodetectPaths()) {
+    if (fileExists(probePath)) {
+      getLog().info({ binaryPath: probePath, source: 'autodetect' }, 'gemini.binary_resolved');
+      return probePath;
+    }
+  }
+
+  // 5. Not found — throw with install instructions
+  throw new Error(
+    'gemini-cli binary not found. The Gemini provider requires a native binary\n' +
+      'that cannot be resolved automatically in compiled Archon builds.\n\n' +
+      'To fix, choose one of:\n' +
+      '  1. Install globally: npm install -g @google/gemini-cli\n' +
+      '     Then set: GEMINI_BIN_PATH=$(which gemini)\n\n' +
+      `  2. Place the binary at: ~/.archon/${GEMINI_VENDOR_DIR}/\n\n` +
+      '  3. Set the path in config:\n' +
+      '     # .archon/config.yaml\n' +
+      '     assistants:\n' +
+      '       gemini:\n' +
+      '         geminiBinaryPath: /path/to/gemini\n'
+  );
+}
+
+/**
+ * Canonical npm-global install locations probed by tier-4 autodetect. Mirrors
+ * the codex resolver: npm writes `{prefix}/bin/<name>` on POSIX and
+ * `{prefix}\<name>.cmd` on Windows. Users with other prefixes set an explicit
+ * override via GEMINI_BIN_PATH or config.
+ */
+function getAutodetectPaths(): string[] {
+  const paths: string[] = [];
+
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA;
+    if (appData) paths.push(join(appData, 'npm', 'gemini.cmd'));
+    paths.push(join(homedir(), '.npm-global', 'gemini.cmd'));
+    return paths;
+  }
+
+  paths.push(join(homedir(), '.npm-global', 'bin', 'gemini'));
+
+  if (process.platform === 'darwin' && process.arch === 'arm64') {
+    paths.push('/opt/homebrew/bin/gemini');
+  }
+
+  paths.push('/usr/local/bin/gemini');
+
+  return paths;
+}

--- a/packages/providers/src/community/gemini/capabilities.ts
+++ b/packages/providers/src/community/gemini/capabilities.ts
@@ -1,0 +1,34 @@
+import type { ProviderCapabilities } from '../../types';
+
+/**
+ * Gemini v1 capabilities — intentionally conservative. Declared flags reflect
+ * wired-up behavior, not potential support, so the dag-executor can warn users
+ * when a workflow node specifies a feature this provider ignores.
+ *
+ * sessionResume: true — QueryOptions.session accepts a bare session-id string.
+ * toolRestrictions: true — QueryOptions.allowedTools maps to --allowed-tools.
+ * envInjection: true — QueryOptions.env is merged into the subprocess env; the
+ *   subprocess also inherits the parent process env (including HOME), so the
+ *   ambient ~/.gemini OAuth login resolves without any key injection.
+ *
+ * mcp: false — Archon's nodeConfig.mcp is a file-path string ref, while the SDK
+ *   expects an mcpServers object map. Translation is deferred to v2.
+ * structuredOutput: false — outputSchema only works with the SDK's buffered
+ *   queryFull(); calling query() with it throws UnsupportedFeatureError, and
+ *   query() is required for Archon's streaming AsyncGenerator contract.
+ */
+export const GEMINI_CAPABILITIES: ProviderCapabilities = {
+  sessionResume: true,
+  mcp: false,
+  hooks: false,
+  skills: false,
+  agents: false,
+  toolRestrictions: true,
+  structuredOutput: false,
+  envInjection: true,
+  costControl: false,
+  effortControl: false,
+  thinkingControl: false,
+  fallbackModel: false,
+  sandbox: false,
+};

--- a/packages/providers/src/community/gemini/config.test.ts
+++ b/packages/providers/src/community/gemini/config.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+
+import { parseGeminiConfig } from './config';
+
+describe('parseGeminiConfig', () => {
+  test('parses valid model string', () => {
+    expect(parseGeminiConfig({ model: 'gemini-2.5-pro' })).toEqual({ model: 'gemini-2.5-pro' });
+  });
+
+  test('drops invalid model type silently', () => {
+    expect(parseGeminiConfig({ model: 123 })).toEqual({});
+  });
+
+  test('ignores unknown keys', () => {
+    expect(parseGeminiConfig({ futureField: 'x', model: 'gemini-2.5-pro' })).toEqual({
+      model: 'gemini-2.5-pro',
+    });
+  });
+
+  test('returns empty object for empty input', () => {
+    expect(parseGeminiConfig({})).toEqual({});
+  });
+
+  test('does not throw on malformed input', () => {
+    expect(() => parseGeminiConfig({ model: null })).not.toThrow();
+    expect(() => parseGeminiConfig({ model: [] })).not.toThrow();
+  });
+
+  test('parses geminiBinaryPath', () => {
+    expect(parseGeminiConfig({ geminiBinaryPath: '/usr/local/bin/gemini' })).toEqual({
+      geminiBinaryPath: '/usr/local/bin/gemini',
+    });
+  });
+
+  test('drops non-string geminiBinaryPath silently', () => {
+    expect(parseGeminiConfig({ geminiBinaryPath: 42 })).toEqual({});
+    expect(parseGeminiConfig({ geminiBinaryPath: null })).toEqual({});
+  });
+
+  test('parses model and geminiBinaryPath together', () => {
+    expect(
+      parseGeminiConfig({ model: 'gemini-2.5-flash', geminiBinaryPath: '/usr/bin/gemini' })
+    ).toEqual({ model: 'gemini-2.5-flash', geminiBinaryPath: '/usr/bin/gemini' });
+  });
+});

--- a/packages/providers/src/community/gemini/config.ts
+++ b/packages/providers/src/community/gemini/config.ts
@@ -1,0 +1,23 @@
+import type { GeminiProviderDefaults } from '../../types';
+
+export type { GeminiProviderDefaults };
+
+/**
+ * Parse raw YAML-derived config into typed Gemini defaults.
+ * Defensive: invalid fields are dropped silently (matches parseClaudeConfig,
+ * parseCodexConfig, and parsePiConfig — never throws, so broken user config
+ * can't prevent provider registration or workflow discovery).
+ */
+export function parseGeminiConfig(raw: Record<string, unknown>): GeminiProviderDefaults {
+  const result: GeminiProviderDefaults = {};
+
+  if (typeof raw.model === 'string') {
+    result.model = raw.model;
+  }
+
+  if (typeof raw.geminiBinaryPath === 'string') {
+    result.geminiBinaryPath = raw.geminiBinaryPath;
+  }
+
+  return result;
+}

--- a/packages/providers/src/community/gemini/index.ts
+++ b/packages/providers/src/community/gemini/index.ts
@@ -1,0 +1,4 @@
+export { GEMINI_CAPABILITIES } from './capabilities';
+export { parseGeminiConfig, type GeminiProviderDefaults } from './config';
+export { GeminiProvider } from './provider';
+export { registerGeminiProvider } from './registration';

--- a/packages/providers/src/community/gemini/options-translator.test.ts
+++ b/packages/providers/src/community/gemini/options-translator.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import type { MessageChunk as SdkMessageChunk } from '@lrilai/gemini-cli-sdk';
+
+import {
+  translateChunk,
+  translateOptions,
+  resetWarnedKeys,
+  warnIgnoredOptions,
+} from './options-translator';
+
+describe('translateChunk', () => {
+  test('translates assistant chunk', () => {
+    const chunk: SdkMessageChunk = { type: 'assistant', content: 'Hello' };
+    expect(translateChunk(chunk)).toEqual({ type: 'assistant', content: 'Hello' });
+  });
+
+  test('translates thinking chunk', () => {
+    const chunk: SdkMessageChunk = { type: 'thinking', content: 'reasoning...' };
+    expect(translateChunk(chunk)).toEqual({ type: 'thinking', content: 'reasoning...' });
+  });
+
+  test('flattens system chunk into a readable string', () => {
+    const chunk: SdkMessageChunk = {
+      type: 'system',
+      subtype: 'init',
+      sessionId: 's1',
+      model: 'gemini-2.5-pro',
+    };
+    const result = translateChunk(chunk);
+    expect(result.type).toBe('system');
+    if (result.type === 'system') {
+      expect(result.content).toBe('init session=s1 model=gemini-2.5-pro');
+    }
+  });
+
+  test('translates tool chunk — maps toolId→toolCallId, parameters→toolInput', () => {
+    const chunk: SdkMessageChunk = {
+      type: 'tool',
+      toolName: 'bash',
+      toolId: 'call-abc',
+      parameters: { command: 'ls' },
+    };
+    expect(translateChunk(chunk)).toEqual({
+      type: 'tool',
+      toolName: 'bash',
+      toolInput: { command: 'ls' },
+      toolCallId: 'call-abc',
+    });
+  });
+
+  test('translates tool_result chunk — toolName is empty (SDK omits it)', () => {
+    const chunk: SdkMessageChunk = {
+      type: 'tool_result',
+      toolId: 'call-abc',
+      status: 'success',
+      output: 'file1.ts',
+    };
+    const result = translateChunk(chunk);
+    expect(result.type).toBe('tool_result');
+    if (result.type === 'tool_result') {
+      expect(result.toolName).toBe('');
+      expect(result.toolOutput).toBe('file1.ts');
+      expect(result.toolCallId).toBe('call-abc');
+    }
+  });
+
+  test('tool_result with empty output falls back to stringified error', () => {
+    const chunk: SdkMessageChunk = {
+      type: 'tool_result',
+      toolId: 'call-x',
+      status: 'error',
+      output: '',
+      error: { message: 'Permission denied' },
+    };
+    const result = translateChunk(chunk);
+    if (result.type === 'tool_result') {
+      expect(result.toolOutput).toBe(JSON.stringify({ message: 'Permission denied' }));
+    }
+  });
+
+  test('translates rate_limit chunk', () => {
+    const chunk: SdkMessageChunk = {
+      type: 'rate_limit',
+      code: 429,
+      message: 'quota exceeded',
+      status: 'RESOURCE_EXHAUSTED',
+    };
+    expect(translateChunk(chunk)).toEqual({
+      type: 'rate_limit',
+      rateLimitInfo: { code: 429, message: 'quota exceeded', status: 'RESOURCE_EXHAUSTED' },
+    });
+  });
+
+  test('translates result chunk to sessionId + stopReason', () => {
+    const chunk: SdkMessageChunk = {
+      type: 'result',
+      sessionId: 'ses-123',
+      stopReason: 'end_turn',
+    };
+    expect(translateChunk(chunk)).toEqual({
+      type: 'result',
+      sessionId: 'ses-123',
+      stopReason: 'end_turn',
+    });
+  });
+
+  test('workflow_dispatch (reserved, never emitted) degrades to a system message', () => {
+    const chunk: SdkMessageChunk = { type: 'workflow_dispatch' };
+    const result = translateChunk(chunk);
+    expect(result.type).toBe('system');
+    if (result.type === 'system') {
+      expect(result.content).toContain('workflow_dispatch');
+    }
+  });
+});
+
+describe('translateOptions', () => {
+  test('sets approvalMode to yolo for headless execution', () => {
+    const opts = translateOptions('hello', '/cwd', undefined, undefined, undefined);
+    expect(opts.approvalMode).toBe('yolo');
+    expect(opts.prompt).toBe('hello');
+    expect(opts.cwd).toBe('/cwd');
+  });
+
+  test('passes model through', () => {
+    const opts = translateOptions('hi', '/cwd', undefined, { model: 'gemini-2.5-pro' }, undefined);
+    expect(opts.model).toBe('gemini-2.5-pro');
+  });
+
+  test('passes resumeSessionId as session', () => {
+    const opts = translateOptions('hi', '/cwd', 'ses-999', undefined, undefined);
+    expect(opts.session).toBe('ses-999');
+  });
+
+  test('omits session when resumeSessionId is undefined', () => {
+    const opts = translateOptions('hi', '/cwd', undefined, undefined, undefined);
+    expect(opts.session).toBeUndefined();
+  });
+
+  test('forwards env without injecting HOME (subprocess inherits it)', () => {
+    const opts = translateOptions('hi', '/cwd', undefined, { env: { MY_VAR: 'value' } }, undefined);
+    expect(opts.env?.MY_VAR).toBe('value');
+    expect(opts.env?.HOME).toBeUndefined();
+  });
+
+  test('passes cliPath from the binary resolver', () => {
+    const opts = translateOptions('hi', '/cwd', undefined, undefined, '/usr/local/bin/gemini');
+    expect(opts.cliPath).toBe('/usr/local/bin/gemini');
+  });
+
+  test('omits cliPath when undefined', () => {
+    const opts = translateOptions('hi', '/cwd', undefined, undefined, undefined);
+    expect(opts.cliPath).toBeUndefined();
+  });
+
+  test('maps nodeConfig.allowed_tools → allowedTools', () => {
+    const opts = translateOptions(
+      'hi',
+      '/cwd',
+      undefined,
+      { nodeConfig: { allowed_tools: ['bash', 'read'] } },
+      undefined
+    );
+    expect(opts.allowedTools).toEqual(['bash', 'read']);
+  });
+
+  test('systemPrompt: top-level wins over nodeConfig', () => {
+    const opts = translateOptions(
+      'hi',
+      '/cwd',
+      undefined,
+      { systemPrompt: 'top-level', nodeConfig: { systemPrompt: 'node-level' } },
+      undefined
+    );
+    expect(opts.systemPrompt).toBe('top-level');
+  });
+
+  test('systemPrompt falls back to nodeConfig when top-level absent', () => {
+    const opts = translateOptions(
+      'hi',
+      '/cwd',
+      undefined,
+      { nodeConfig: { systemPrompt: 'node-level' } },
+      undefined
+    );
+    expect(opts.systemPrompt).toBe('node-level');
+  });
+
+  test('drops a non-string (preset) systemPrompt', () => {
+    const opts = translateOptions(
+      'hi',
+      '/cwd',
+      undefined,
+      { systemPrompt: { type: 'preset', preset: 'claude_code' } },
+      undefined
+    );
+    expect(opts.systemPrompt).toBeUndefined();
+  });
+});
+
+describe('warnIgnoredOptions', () => {
+  afterEach(() => resetWarnedKeys());
+
+  test('does not throw when options contain ignored fields', () => {
+    expect(() =>
+      warnIgnoredOptions({ maxBudgetUsd: 5, nodeConfig: { mcp: 'x.json' } })
+    ).not.toThrow();
+  });
+
+  test('does not throw for undefined options', () => {
+    expect(() => warnIgnoredOptions(undefined)).not.toThrow();
+  });
+});

--- a/packages/providers/src/community/gemini/options-translator.ts
+++ b/packages/providers/src/community/gemini/options-translator.ts
@@ -1,0 +1,173 @@
+/**
+ * Pure translation helpers between Archon's provider contract and the
+ * @lrilai/gemini-cli-sdk surface.
+ *
+ *   translateOptions — SendQueryOptions → SDK QueryOptions
+ *   translateChunk   — SDK MessageChunk → Archon MessageChunk
+ *   warnIgnoredOptions — dev-mode visibility for options Gemini can't honor
+ *
+ * Port-time fixes vs the reference adapter (seanrobertwright/Gemini-CLI-SDK
+ * adapter-archon): import the SDK types directly (no local mirror), and never
+ * emit a `workflow_dispatch` sentinel (that lives in provider.ts in the
+ * reference — but neither Claude nor Codex emit it, and the SDK's dispatcher
+ * never produces a WorkflowDispatchChunk, so it is dropped entirely).
+ */
+import type { QueryOptions, MessageChunk as SdkMessageChunk } from '@lrilai/gemini-cli-sdk';
+import { createLogger } from '@archon/paths';
+
+import type { MessageChunk, SendQueryOptions } from '../../types';
+
+/** Lazy-initialized logger (deferred so test mocks can intercept createLogger). */
+let cachedLog: ReturnType<typeof createLogger> | undefined;
+function getLog(): ReturnType<typeof createLogger> {
+  if (!cachedLog) cachedLog = createLogger('provider.gemini');
+  return cachedLog;
+}
+
+/** Translate a single SDK chunk into Archon's MessageChunk shape. */
+export function translateChunk(sdk: SdkMessageChunk): MessageChunk {
+  switch (sdk.type) {
+    case 'assistant':
+      return { type: 'assistant', content: sdk.content };
+
+    case 'thinking':
+      return { type: 'thinking', content: sdk.content };
+
+    case 'system': {
+      // SDK system chunks carry subtype/sessionId/model/role/content; flatten
+      // to a single readable string so every platform adapter can display it.
+      const parts: string[] = [sdk.subtype];
+      if (sdk.sessionId) parts.push(`session=${sdk.sessionId}`);
+      if (sdk.model) parts.push(`model=${sdk.model}`);
+      if (sdk.content) parts.push(sdk.content);
+      return { type: 'system', content: parts.join(' ') };
+    }
+
+    case 'tool':
+      return {
+        type: 'tool',
+        toolName: sdk.toolName,
+        toolInput: sdk.parameters,
+        toolCallId: sdk.toolId,
+      };
+
+    case 'tool_result': {
+      // SDK ToolResultChunk has no toolName; Archon requires the field, so emit
+      // an empty string. `error` is a structured object — surface it as text
+      // only when there is no normal output.
+      const toolOutput =
+        sdk.output !== '' ? sdk.output : sdk.error ? JSON.stringify(sdk.error) : '';
+      return { type: 'tool_result', toolName: '', toolOutput, toolCallId: sdk.toolId };
+    }
+
+    case 'rate_limit':
+      // Phase 5 of the SDK throws rate limits rather than emitting them, but the
+      // chunk variant still exists in the union — map it defensively.
+      return {
+        type: 'rate_limit',
+        rateLimitInfo: { code: sdk.code, message: sdk.message, status: sdk.status },
+      };
+
+    case 'result':
+      return {
+        type: 'result',
+        sessionId: sdk.sessionId,
+        stopReason: sdk.stopReason,
+      };
+
+    default:
+      // WorkflowDispatchChunk (reserved, never emitted) or any future variant —
+      // surface as a system message so it is never silently swallowed.
+      return {
+        type: 'system',
+        content: `[gemini:unhandled-chunk:${(sdk as { type: string }).type}]`,
+      };
+  }
+}
+
+/**
+ * Build SDK QueryOptions from Archon's SendQueryOptions. Only fields with a
+ * faithful SDK equivalent are mapped; everything else is dropped (and surfaced
+ * by warnIgnoredOptions in dev mode).
+ *
+ * Auth note: `env` is forwarded but HOME is never injected — the subprocess
+ * inherits the parent process env, so the ambient ~/.gemini credentials resolve.
+ */
+export function translateOptions(
+  prompt: string,
+  cwd: string,
+  resumeSessionId: string | undefined,
+  options: SendQueryOptions | undefined,
+  resolvedCliPath: string | undefined
+): QueryOptions {
+  const nodeConfig = options?.nodeConfig;
+
+  // System prompt: top-level wins over nodeConfig. The SDK only accepts a
+  // string, so preset/array forms (e.g. Claude's SystemPromptPreset) are dropped.
+  const rawSystemPrompt = options?.systemPrompt ?? nodeConfig?.systemPrompt;
+  const systemPrompt = typeof rawSystemPrompt === 'string' ? rawSystemPrompt : undefined;
+
+  const allowedTools = nodeConfig?.allowed_tools;
+
+  return {
+    prompt,
+    cwd,
+    // Headless execution: auto-approve tool use. gemini-cli's interactive
+    // approval prompts would otherwise hang a non-interactive workflow.
+    approvalMode: 'yolo',
+    ...(options?.model !== undefined ? { model: options.model } : {}),
+    ...(systemPrompt !== undefined ? { systemPrompt } : {}),
+    ...(resumeSessionId !== undefined ? { session: resumeSessionId } : {}),
+    ...(options?.abortSignal !== undefined ? { abortSignal: options.abortSignal } : {}),
+    ...(allowedTools !== undefined ? { allowedTools } : {}),
+    ...(options?.env !== undefined ? { env: options.env } : {}),
+    ...(resolvedCliPath !== undefined ? { cliPath: resolvedCliPath } : {}),
+  };
+}
+
+/** Tracks already-warned option keys so each is reported at most once. */
+const warnedKeys = new Set<string>();
+
+/** @internal Test-only reset for the one-time-warning dedupe set. */
+export function resetWarnedKeys(): void {
+  warnedKeys.clear();
+}
+
+/**
+ * Emit one-time dev-mode warnings for options Gemini ignores. Silent in
+ * production (gated on NODE_ENV/DEBUG). Never throws.
+ */
+export function warnIgnoredOptions(options: SendQueryOptions | undefined): void {
+  if (!options) return;
+  const isDev =
+    process.env.NODE_ENV === 'development' || (process.env.DEBUG ?? '').includes('gemini');
+  if (!isDev) return;
+
+  const nodeConfig = options.nodeConfig;
+  const ignored: string[] = [];
+
+  if (options.maxBudgetUsd !== undefined) ignored.push('maxBudgetUsd');
+  if (options.fallbackModel !== undefined) ignored.push('fallbackModel');
+  if (options.forkSession !== undefined) ignored.push('forkSession');
+  if (options.persistSession !== undefined) ignored.push('persistSession');
+  if (options.outputFormat !== undefined) {
+    ignored.push('outputFormat (structuredOutput unsupported in v1)');
+  }
+  if (nodeConfig?.mcp !== undefined) ignored.push('nodeConfig.mcp (MCP unsupported in v1)');
+  if (nodeConfig?.denied_tools !== undefined) {
+    ignored.push('nodeConfig.denied_tools (no SDK equivalent)');
+  }
+  if (nodeConfig?.hooks !== undefined) ignored.push('nodeConfig.hooks');
+  if (nodeConfig?.skills !== undefined) ignored.push('nodeConfig.skills');
+  if (nodeConfig?.agents !== undefined) ignored.push('nodeConfig.agents');
+  if (nodeConfig?.effort !== undefined) ignored.push('nodeConfig.effort');
+  if (nodeConfig?.thinking !== undefined) ignored.push('nodeConfig.thinking');
+  if (nodeConfig?.sandbox !== undefined) ignored.push('nodeConfig.sandbox');
+
+  for (const key of ignored) {
+    if (!warnedKeys.has(key)) {
+      warnedKeys.add(key);
+      getLog().warn({ option: key }, 'gemini.option_ignored');
+    }
+  }
+}

--- a/packages/providers/src/community/gemini/provider.test.ts
+++ b/packages/providers/src/community/gemini/provider.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+import { createMockLogger } from '../../test/mocks/logger';
+
+// ─── Mock @archon/paths so the provider + binary-resolver stay quiet and run
+// in dev mode (BUNDLED_IS_BINARY=false → resolveGeminiBinaryPath returns
+// undefined without touching the filesystem). ──────────────────────────────
+const mockLogger = createMockLogger();
+mock.module('@archon/paths', () => ({
+  createLogger: mock(() => mockLogger),
+  BUNDLED_IS_BINARY: false,
+  getArchonHome: () => '/tmp/.archon-test',
+}));
+
+// ─── Mock the Gemini SDK. `query` replays a scripted chunk sequence and
+// records the QueryOptions it was called with. ─────────────────────────────
+let scriptedChunks: Array<Record<string, unknown>> = [];
+const mockQuery = mock(async function* () {
+  for (const chunk of scriptedChunks) yield chunk;
+});
+mock.module('@lrilai/gemini-cli-sdk', () => ({
+  query: mockQuery,
+}));
+
+// Static import AFTER the mocks — Bun hoists mock.module above this import.
+import { GeminiProvider } from './provider';
+
+async function collect(gen: AsyncGenerator<unknown>): Promise<Array<{ type: string }>> {
+  const results: Array<{ type: string }> = [];
+  for await (const chunk of gen) results.push(chunk as { type: string });
+  return results;
+}
+
+describe('GeminiProvider', () => {
+  let provider: GeminiProvider;
+
+  beforeEach(() => {
+    provider = new GeminiProvider();
+    scriptedChunks = [];
+    mockQuery.mockClear();
+  });
+
+  test('getType() returns gemini', () => {
+    expect(provider.getType()).toBe('gemini');
+  });
+
+  test('getCapabilities() returns the conservative v1 matrix', () => {
+    const caps = provider.getCapabilities();
+    expect(caps.sessionResume).toBe(true);
+    expect(caps.envInjection).toBe(true);
+    expect(caps.toolRestrictions).toBe(true);
+    expect(caps.mcp).toBe(false);
+    expect(caps.structuredOutput).toBe(false);
+    expect(caps.hooks).toBe(false);
+  });
+
+  test('passes an assistant chunk through', async () => {
+    scriptedChunks = [{ type: 'assistant', content: 'Hello world' }];
+    const chunks = await collect(provider.sendQuery('hi', '/cwd'));
+    expect(chunks).toContainEqual({ type: 'assistant', content: 'Hello world' });
+  });
+
+  test('does NOT emit workflow_dispatch before tool chunks (port-time fix)', async () => {
+    scriptedChunks = [{ type: 'tool', toolName: 'bash', toolId: 'id-1', parameters: {} }];
+    const chunks = await collect(provider.sendQuery('hi', '/cwd'));
+    expect(chunks.filter(c => c.type === 'workflow_dispatch')).toHaveLength(0);
+    expect(chunks.filter(c => c.type === 'tool')).toHaveLength(1);
+  });
+
+  test('tool_result has an empty toolName (SDK omits it)', async () => {
+    scriptedChunks = [{ type: 'tool_result', toolId: 'id-1', status: 'success', output: 'ok' }];
+    const chunks = await collect(provider.sendQuery('hi', '/cwd'));
+    const toolResult = chunks.find(c => c.type === 'tool_result') as
+      | { type: string; toolName: string }
+      | undefined;
+    expect(toolResult).toBeDefined();
+    expect(toolResult?.toolName).toBe('');
+  });
+
+  test('forwards env to the SDK without injecting HOME', async () => {
+    scriptedChunks = [{ type: 'result', sessionId: 's', stopReason: 'end_turn' }];
+    await collect(provider.sendQuery('hi', '/cwd', undefined, { env: { MY_SECRET: 'x' } }));
+    const callArg = mockQuery.mock.calls[0]?.[0] as { env?: Record<string, string> };
+    expect(callArg.env?.MY_SECRET).toBe('x');
+    expect(callArg.env?.HOME).toBeUndefined();
+  });
+
+  test('passes resumeSessionId as session', async () => {
+    scriptedChunks = [{ type: 'result', sessionId: 's', stopReason: 'end_turn' }];
+    await collect(provider.sendQuery('hi', '/cwd', 'ses-abc'));
+    const callArg = mockQuery.mock.calls[0]?.[0] as { session?: string };
+    expect(callArg.session).toBe('ses-abc');
+  });
+
+  test('propagates SDK errors', async () => {
+    mockQuery.mockImplementationOnce(async function* () {
+      await Promise.resolve();
+      throw new Error('gemini-cli crashed');
+    });
+    await expect(collect(provider.sendQuery('hi', '/cwd'))).rejects.toThrow('gemini-cli crashed');
+  });
+});

--- a/packages/providers/src/community/gemini/provider.ts
+++ b/packages/providers/src/community/gemini/provider.ts
@@ -1,0 +1,95 @@
+/**
+ * Gemini community provider — wraps @lrilai/gemini-cli-sdk.
+ *
+ * Auth: ambient gemini-cli OAuth login. A `gemini` "Sign in with Google" writes
+ * credentials under ~/.gemini/, picked up automatically by the subprocess.
+ * Archon injects NO key. The subprocess inherits the full parent environment
+ * (including HOME), so ~/.gemini resolves without any env manipulation.
+ *
+ * Port-time fixes vs the reference adapter (seanrobertwright/Gemini-CLI-SDK):
+ *   1. No `workflow_dispatch` sentinel before tool chunks (the SDK never emits
+ *      that chunk and neither Claude nor Codex do this).
+ *   2. Types imported from ../../types and the SDK directly, not a local mirror.
+ *   3. No `isModelCompatible` in registration (the field was removed from
+ *      ProviderRegistration; Archon does not validate model strings).
+ */
+import { query } from '@lrilai/gemini-cli-sdk';
+import { createLogger } from '@archon/paths';
+
+import type {
+  IAgentProvider,
+  MessageChunk,
+  ProviderCapabilities,
+  SendQueryOptions,
+} from '../../types';
+
+import { GEMINI_CAPABILITIES } from './capabilities';
+import { parseGeminiConfig } from './config';
+import { resolveGeminiBinaryPath } from './binary-resolver';
+import { translateChunk, translateOptions, warnIgnoredOptions } from './options-translator';
+
+/** Lazy-initialized logger (deferred so test mocks can intercept createLogger). */
+let cachedLog: ReturnType<typeof createLogger> | undefined;
+function getLog(): ReturnType<typeof createLogger> {
+  if (!cachedLog) cachedLog = createLogger('provider.gemini');
+  return cachedLog;
+}
+
+export class GeminiProvider implements IAgentProvider {
+  async *sendQuery(
+    prompt: string,
+    cwd: string,
+    resumeSessionId?: string,
+    requestOptions?: SendQueryOptions
+  ): AsyncGenerator<MessageChunk> {
+    const assistantConfig = requestOptions?.assistantConfig ?? {};
+    const geminiConfig = parseGeminiConfig(assistantConfig);
+
+    // Resolve the gemini-cli binary (env → config → vendor → autodetect; throws
+    // in binary builds if absent, undefined in dev so the SDK uses PATH).
+    const resolvedCliPath = await resolveGeminiBinaryPath(geminiConfig.geminiBinaryPath);
+
+    // Dev-mode visibility for options Gemini cannot honor (never throws).
+    warnIgnoredOptions(requestOptions);
+
+    const sdkOptions = translateOptions(
+      prompt,
+      cwd,
+      resumeSessionId,
+      requestOptions,
+      resolvedCliPath
+    );
+
+    getLog().info(
+      {
+        cwd,
+        model: sdkOptions.model,
+        hasSession: sdkOptions.session !== undefined,
+        hasAllowedTools: Array.isArray(sdkOptions.allowedTools),
+        hasEnv: sdkOptions.env !== undefined,
+        hasCliPath: sdkOptions.cliPath !== undefined,
+      },
+      'gemini.query_started'
+    );
+
+    try {
+      // PORT-TIME FIX: do NOT yield a workflow_dispatch sentinel before tool
+      // chunks — just translate and forward each chunk.
+      for await (const sdkChunk of query(sdkOptions)) {
+        yield translateChunk(sdkChunk);
+      }
+      getLog().info({ cwd }, 'gemini.query_completed');
+    } catch (err) {
+      getLog().error({ err, cwd }, 'gemini.query_failed');
+      throw err;
+    }
+  }
+
+  getType(): string {
+    return 'gemini';
+  }
+
+  getCapabilities(): ProviderCapabilities {
+    return GEMINI_CAPABILITIES;
+  }
+}

--- a/packages/providers/src/community/gemini/registration.ts
+++ b/packages/providers/src/community/gemini/registration.ts
@@ -1,0 +1,24 @@
+import { isRegisteredProvider, registerProvider } from '../../registry';
+
+import { GEMINI_CAPABILITIES } from './capabilities';
+import { GeminiProvider } from './provider';
+
+/**
+ * Register the Gemini community provider.
+ *
+ * Idempotent — safe to call multiple times, so process entrypoints (CLI,
+ * server, config-loader) can each call it without coordination. Kept in
+ * `registerCommunityProviders()` (not `registerBuiltinProviders()`) because
+ * `builtIn: false` is load-bearing: Gemini wraps a third-party SDK and is
+ * maintained as a community provider alongside Pi.
+ */
+export function registerGeminiProvider(): void {
+  if (isRegisteredProvider('gemini')) return;
+  registerProvider({
+    id: 'gemini',
+    displayName: 'Gemini (community)',
+    factory: () => new GeminiProvider(),
+    capabilities: GEMINI_CAPABILITIES,
+    builtIn: false,
+  });
+}

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -54,3 +54,10 @@ export {
   registerPiProvider,
   type PiProviderDefaults,
 } from './community/pi';
+
+export {
+  GeminiProvider,
+  parseGeminiConfig,
+  registerGeminiProvider,
+  type GeminiProviderDefaults,
+} from './community/gemini';

--- a/packages/providers/src/registry.test.ts
+++ b/packages/providers/src/registry.test.ts
@@ -12,6 +12,7 @@ import {
   clearRegistry,
 } from './registry';
 import { registerPiProvider } from './community/pi/registration';
+import { registerGeminiProvider } from './community/gemini/registration';
 import { UnknownProviderError } from './errors';
 import type { ProviderRegistration, IAgentProvider, ProviderCapabilities } from './types';
 
@@ -252,9 +253,8 @@ describe('registry', () => {
   describe('registerCommunityProviders (aggregator)', () => {
     test('registers all bundled community providers', () => {
       registerCommunityProviders();
-      // Pi is currently the only community provider bundled. When more are
-      // added, they should appear here automatically.
       expect(isRegisteredProvider('pi')).toBe(true);
+      expect(isRegisteredProvider('gemini')).toBe(true);
     });
 
     test('is idempotent', () => {
@@ -262,6 +262,8 @@ describe('registry', () => {
       expect(() => registerCommunityProviders()).not.toThrow();
       const piCount = getRegisteredProviders().filter(p => p.id === 'pi').length;
       expect(piCount).toBe(1);
+      const geminiCount = getRegisteredProviders().filter(p => p.id === 'gemini').length;
+      expect(geminiCount).toBe(1);
     });
   });
 
@@ -316,6 +318,52 @@ describe('registry', () => {
         .map(p => p.id)
         .sort();
       expect(ids).toEqual(['claude', 'codex', 'pi']);
+    });
+  });
+
+  describe('registerGeminiProvider (community provider)', () => {
+    test('registers gemini with builtIn: false', () => {
+      registerGeminiProvider();
+      const reg = getRegistration('gemini');
+      expect(reg.id).toBe('gemini');
+      expect(reg.displayName).toBe('Gemini (community)');
+      expect(reg.builtIn).toBe(false);
+    });
+
+    test('is idempotent', () => {
+      registerGeminiProvider();
+      expect(() => registerGeminiProvider()).not.toThrow();
+      const geminiEntries = getRegisteredProviders().filter(p => p.id === 'gemini');
+      expect(geminiEntries).toHaveLength(1);
+    });
+
+    test('declares conservative v1 capabilities', () => {
+      registerGeminiProvider();
+      const caps = getProviderCapabilities('gemini');
+      expect(caps.sessionResume).toBe(true);
+      expect(caps.envInjection).toBe(true);
+      expect(caps.toolRestrictions).toBe(true);
+      // Out of v1 scope
+      expect(caps.mcp).toBe(false);
+      expect(caps.structuredOutput).toBe(false);
+      expect(caps.hooks).toBe(false);
+      expect(caps.skills).toBe(false);
+    });
+
+    test('appears in getProviderInfoList with builtIn: false', () => {
+      registerGeminiProvider();
+      const info = getProviderInfoList().find(p => p.id === 'gemini');
+      expect(info).toBeDefined();
+      expect(info?.builtIn).toBe(false);
+    });
+
+    test('does not collide with built-ins or Pi', () => {
+      registerGeminiProvider();
+      registerPiProvider();
+      const ids = getRegisteredProviders()
+        .map(p => p.id)
+        .sort();
+      expect(ids).toEqual(['claude', 'codex', 'gemini', 'pi']);
     });
   });
 });

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -18,6 +18,7 @@ import { CodexProvider } from './codex/provider';
 import { CLAUDE_CAPABILITIES } from './claude/capabilities';
 import { CODEX_CAPABILITIES } from './codex/capabilities';
 import { registerPiProvider } from './community/pi/registration';
+import { registerGeminiProvider } from './community/gemini/registration';
 import { UnknownProviderError } from './errors';
 import { createLogger } from '@archon/paths';
 
@@ -153,6 +154,7 @@ export function registerBuiltinProviders(): void {
  */
 export function registerCommunityProviders(): void {
   registerPiProvider();
+  registerGeminiProvider();
 }
 
 /** @internal Test-only — clears the registry. Not for production use. */

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -98,6 +98,25 @@ export interface PiProviderDefaults {
   maxConcurrent?: number;
 }
 
+/**
+ * Community provider defaults for Gemini (@lrilai/gemini-cli-sdk).
+ *
+ * Auth is ambient: a `gemini` CLI "Sign in with Google" login writes
+ * credentials under ~/.gemini/ and the spawned subprocess picks them up
+ * automatically (SDK auth precedence: ADC → GEMINI_API_KEY →
+ * GOOGLE_APPLICATION_CREDENTIALS → GOOGLE_API_KEY). Archon injects NO key.
+ */
+export interface GeminiProviderDefaults {
+  [key: string]: unknown;
+  /** Default model string forwarded verbatim to gemini-cli (e.g. 'gemini-2.5-pro'). */
+  model?: string;
+  /**
+   * Absolute path to the gemini-cli binary. Overrides PATH resolution in
+   * compiled Archon builds (maps to the SDK's `QueryOptions.cliPath`).
+   */
+  geminiBinaryPath?: string;
+}
+
 /** Generic per-provider defaults bag used by config surfaces and UI. */
 export type ProviderDefaults = Record<string, unknown>;
 

--- a/packages/server/src/routes/api.providers.test.ts
+++ b/packages/server/src/routes/api.providers.test.ts
@@ -1,6 +1,10 @@
-import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
 import { OpenAPIHono } from '@hono/zod-openapi';
-import { registerBuiltinProviders, clearRegistry } from '@archon/providers';
+import {
+  registerBuiltinProviders,
+  registerCommunityProviders,
+  clearRegistry,
+} from '@archon/providers';
 import type { ConversationLockManager } from '@archon/core';
 import type { WebAdapter } from '../adapters/web';
 import {
@@ -220,5 +224,43 @@ describe('GET /api/providers', () => {
     expect(typeof caps.mcp).toBe('boolean');
     expect(typeof caps.hooks).toBe('boolean');
     expect(typeof caps.structuredOutput).toBe('boolean');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: GET /api/providers — community providers
+// ---------------------------------------------------------------------------
+
+describe('GET /api/providers — community providers', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    clearRegistry();
+    registerBuiltinProviders();
+    registerCommunityProviders();
+    app = makeApp();
+  });
+
+  afterEach(() => {
+    // Restore the module-level registry state (built-ins only) so the other
+    // describe block's `every(p => p.builtIn)` assertion stays valid.
+    clearRegistry();
+    registerBuiltinProviders();
+  });
+
+  test('includes gemini as a community provider (builtIn: false)', async () => {
+    const response = await app.request('/api/providers');
+    const body = (await response.json()) as { providers: { id: string; builtIn: boolean }[] };
+    const gemini = body.providers.find(p => p.id === 'gemini');
+    expect(gemini).toBeDefined();
+    expect(gemini?.builtIn).toBe(false);
+  });
+
+  test('includes pi as a community provider (builtIn: false)', async () => {
+    const response = await app.request('/api/providers');
+    const body = (await response.json()) as { providers: { id: string; builtIn: boolean }[] };
+    const pi = body.providers.find(p => p.id === 'pi');
+    expect(pi).toBeDefined();
+    expect(pi?.builtIn).toBe(false);
   });
 });

--- a/packages/web/src/routes/SettingsPage.tsx
+++ b/packages/web/src/routes/SettingsPage.tsx
@@ -571,6 +571,28 @@ function AssistantConfigSection({ config }: { config: SafeConfigResponse }): Rea
                 );
               }
 
+              if (provider.id === 'gemini') {
+                return (
+                  <div
+                    key={provider.id}
+                    className="grid grid-cols-[140px_1fr] items-center gap-2 text-sm"
+                  >
+                    <div className="font-medium">{provider.displayName}</div>
+                    <div className="text-muted-foreground">Community provider settings</div>
+
+                    <label htmlFor="gemini-model">Model</label>
+                    <Input
+                      id="gemini-model"
+                      value={(providerSettings.model as string | undefined) ?? ''}
+                      onChange={e => {
+                        updateProviderSettings('gemini', { model: e.target.value });
+                      }}
+                      placeholder="gemini-2.5-pro"
+                    />
+                  </div>
+                );
+              }
+
               return (
                 <div key={provider.id} className="rounded-md border border-border p-3 text-sm">
                   <div className="font-medium">{provider.displayName}</div>


### PR DESCRIPTION
## Summary

- **Problem:** Archon shipped with Claude, Codex, and Pi providers but no first-class Google Gemini support. Users wanting to use `gemini-cli` (with its ambient OAuth flow) had no integration path.
- **Why it matters:** Gemini-CLI offers a free tier via Google account OAuth and a distinct model family — broadening provider choice without adding a paid API key dependency.
- **What changed:** Adds the `gemini` community provider via `@lrilai/gemini-cli-sdk` (wraps Google's `gemini-cli`), plus a showcase workflow, smoke test, demo doc, and PRD.
- **What did NOT change (scope boundary):** No changes to core orchestrator, executor, or existing providers. No DB schema changes. Provider is registered with `builtIn: false` (community tier).

## UX Journey

### Before

```
User                Archon CLI/Web        Provider Registry
────                ──────────────        ─────────────────
selects model ───▶  resolve provider ───▶ { claude, codex, pi }
                                          (no gemini option)
sees error    ◀─── "Unknown provider 'gemini'"
```

### After

```
User                Archon CLI/Web        Provider Registry
────                ──────────────        ─────────────────
selects model ───▶  resolve provider ───▶ { claude, codex, pi, [+gemini] }
                                                              │
                                          [+gemini-cli-sdk] ──┘
                                                  │
                                          ambient OAuth (no API key)
streams reply ◀─── platform send  ◀───── gemini-cli subprocess
```

## Architecture Diagram

### Before

```
@archon/providers
├── claude/
├── codex/
└── community/
    └── pi/
```

### After

```
@archon/providers
├── claude/
├── codex/
└── community/
    ├── pi/
    └── [+] gemini/        ──── new community provider
                                 │
                                 └─▶ [+] @lrilai/gemini-cli-sdk (peer dep on gemini-cli ≥0.37.1)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `providers/registry.ts` | `community/gemini/GeminiProvider` | **new** | registered with `builtIn: false` |
| `community/gemini/` | `@lrilai/gemini-cli-sdk` | **new** | wraps `gemini-cli` binary |
| `community/gemini/` | ambient OAuth (`gemini auth login`) | **new** | no API key injected by Archon |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `providers`
- Module: `providers:community/gemini`

## Change Metadata

- Change type: `feature`
- Primary scope: `providers`

## Linked Issue

- Closes # _(none — community-provider contribution)_
- Related #

## Validation Evidence (required)

```bash
bun run validate
```

- Evidence: smoke test workflow at `.archon/workflows/test-workflows/e2e-gemini-smoke.yaml` exercises the provider end-to-end. Showcase workflow `archon-gemini-showcase.yaml` demonstrates real-world use.
- Manual validation logs captured locally under `docs/gemini-demo-evidence/*.log` (gitignored).

## Security Impact (required)

- New permissions/capabilities? **No** — provider runs `gemini-cli` subprocess under user's existing OAuth session
- New external network calls? **Yes** — `gemini-cli` calls Google's Gemini API on the user's behalf (ambient auth, no Archon-managed token)
- Secrets/tokens handling changed? **No** — Archon injects no API key; OAuth state lives in `gemini-cli`'s own config
- File system access scope changed? **No**
- Mitigation: provider is `builtIn: false` (opt-in), and the `gemini` binary must be separately installed by the user.

## Compatibility / Migration

- Backward compatible? **Yes** — pure addition
- Config/env changes? **No** required (opt-in via workflow `provider: gemini`)
- Database migration needed? **No**

## Human Verification (required)

- Verified scenarios:
  - `gemini` provider listed in `/api/providers` response
  - Smoke workflow runs to completion against `gemini-cli ≥0.37.1`
  - Showcase workflow demonstrates session resume + tool restrictions
- Edge cases checked:
  - Double-quoted prompts hard-fail (upstream SDK bug — documented in PRD)
  - Session-resume answer-quality degradation observed (upstream SDK bug — documented)
- What was NOT verified:
  - Behavior on Linux/macOS (developed on Windows 11)
  - Long-running session stability beyond demo scope

## Side Effects / Blast Radius (required)

- Affected subsystems: provider registry, workflow loader (provider validation)
- Potential unintended effects: none expected — registry addition is additive
- Guardrails: provider id validation in workflow loader catches typos at load time

## Rollback Plan (required)

- Fast rollback: revert merge commit; no DB or config to clean up
- Feature flags: provider is opt-in by definition (must be referenced explicitly)
- Observable failure symptoms: workflow loader would reject `provider: gemini` if rollback is incomplete

## Risks and Mitigations

- **Risk:** Upstream `@lrilai/gemini-cli-sdk` bugs (double-quote prompt failure, session-resume answer degradation)
  - **Mitigation:** Documented in PRD-gemini-provider-v2.md; users can avoid double-quoted prompts and disable session resume until upstream fixes land.
- **Risk:** `gemini-cli` is a peer dependency the user must install separately
  - **Mitigation:** Documented installation steps; provider surfaces a clear error if the binary is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)