### PR TITLE
test: add ExecuteDropZone drag-card-triggers-execute-agent smoke coverage

### DIFF
--- a/PRPs/features/completed/e2e-drag-smoke-execute-agent.md
+++ b/PRPs/features/completed/e2e-drag-smoke-execute-agent.md
@@ -1,0 +1,276 @@
+# Feature: E2E Drag Smoke — Move Card Triggers Execute Agent
+
+## Feature Description
+
+Add an "Execute" drop zone to the Console experiment's Kanban-style run feed
+so users can drag an existing run card (or a task card) onto it to enqueue a
+new agent work order via the Copilot SDK provider. Accompany the feature with
+a smoke test (`@pytest.mark.unit` / `bun:test`) that verifies the full
+drag-to-work-order path: card dragged into Execute column → `startRun` called
+→ Copilot SDK agent invoked.
+
+The goal is two-fold:
+
+1. **UI behaviour** — expose a drag target in the console feed that accepts
+   run cards and maps the drop to a `startRun` skill call with the
+   `execute`/`implement` workflow, creating a Copilot SDK agent work order.
+2. **Smoke coverage** — a deterministic, fast test that asserts the
+   drag-drop interaction wires correctly to the backend skill, giving CI
+   confidence that the path from UI gesture to agent invocation is intact.
+
+## User Story
+
+As a developer using the Archon console  
+I want to drag a card into the Execute column  
+So that the Copilot SDK agent is immediately queued to act on that task
+without me having to fill in the DraftRunCard form manually
+
+## Problem Statement
+
+The console run feed today is a list; cards can only be started through the
+`DraftRunCard` form. There is no gestural shortcut that maps a specific task
+(e.g. a paused run, a rerun candidate, or a future backlog card) directly to
+the `execute`/`implement` workflow. Additionally there is no smoke-level
+regression test verifying that the drag-to-agent path works end-to-end.
+
+## Solution Statement
+
+1. Add an `ExecuteDropZone` component to the console that accepts
+   `draggable="true"` card elements (identified by a `data-run-id` or
+   `data-task-id` attribute) and fires `startRun` on drop.
+2. Make run cards in the feed draggable by adding `draggable="true"` and the
+   relevant `dragstart` data-transfer payload (`run id`, `projectId`,
+   `workflow`).
+3. Write a `bun:test` smoke test that:
+   - Mocks `skill.startRun` (the single mutation surface)
+   - Constructs a minimal drag-event fixture
+   - Calls the `ExecuteDropZone`'s `onDrop` handler directly (or via
+     `fireEvent.drop` with `@testing-library/dom`)
+   - Asserts `startRun` was called with `workflow: 'implement'` and the
+     correct `projectId`/`message`.
+
+## Relevant Files
+
+### Existing Files
+
+- **`packages/web/src/experiments/console/components/DraftRunCard.tsx`**
+  - Already handles `DragEvent` for file drops (`dragOver` state, `onDrop`
+    handler); the `ExecuteDropZone` follows the same pattern — lines 1-30
+    import section, drag state variables (~line 72-76), `onDrop` handler.
+- **`packages/web/src/experiments/console/components/ActiveRunCard.tsx`**
+  - Card rendered for `running`/`paused` runs; needs `draggable="true"` +
+    `onDragStart` to set `dataTransfer` payload — lines 1-80.
+- **`packages/web/src/experiments/console/components/RecentRunRow.tsx`**
+  - Compact row for completed/failed runs; same draggable treatment needed.
+- **`packages/web/src/experiments/console/skills/startRun.ts`**
+  - `startRun({ projectId, workflow, message })` — the single call the drop
+    handler must invoke (lines 1-60, entire file).
+- **`packages/web/src/experiments/console/routes/RunsPage.tsx`**
+  - Houses `RunsFeed`; the `ExecuteDropZone` sits below or alongside the
+    feed in this page (line ~250 `RunsFeed` render site).
+- **`packages/web/src/experiments/console/primitives/run.ts`**
+  - `Run` type; need `projectId` and `workflow` fields for the drag payload.
+- **`packages/web/src/experiments/console/README.md`**
+  - Vocabulary and constraints; `ExecuteDropZone` must respect the
+    "Project · Run · Workflow · Worktree" vocabulary.
+- **`packages/web/src/experiments/console/theme.css`**
+  - Design token classes; drop zone uses `bg-surface-inset`, `border-border`,
+    `bg-accent/10` (hover) for brand-aligned visual.
+
+### New Files
+
+- **`packages/web/src/experiments/console/components/ExecuteDropZone.tsx`**
+  New component: accepts a dragged run card, calls `startRun` on drop.
+  Exports `ExecuteDropZone` with props `{ projectId: string; projectCwd: string }`.
+
+- **`packages/web/src/experiments/console/components/ExecuteDropZone.test.ts`**
+  Smoke test (unit): mocks `skill.startRun`, dispatches drop event fixture,
+  asserts `startRun` is called with correct arguments.
+
+- **`packages/web/src/experiments/console/lib/drag-payload.ts`**
+  Typed drag-transfer codec: `encodeDragPayload(run: Run): string` /
+  `decodeDragPayload(raw: string): DragPayload | null`. Keeps the
+  data-transfer format as a single source of truth.
+
+- **`packages/web/src/experiments/console/lib/drag-payload.test.ts`**
+  Unit tests for encode/decode round-trip and malformed-input guard.
+
+## Relevant Research Docstring
+
+- [HTML Drag and Drop API — MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API)
+  - `dataTransfer.setData` / `getData` — used to pass run metadata between
+    draggable card and drop zone.
+  - `dragover` + `preventDefault()` required to enable dropping.
+- [React synthetic drag events — React docs](https://react.dev/reference/react-dom/components/common#drag-events)
+  - `onDragStart`, `onDragOver`, `onDrop`, `onDragLeave` prop signatures.
+- [bun:test docs](https://bun.sh/docs/test/writing)
+  - `mock.module()` / `spyOn` patterns already used throughout the codebase.
+
+## Implementation Plan
+
+### Phase 1: Foundation — Drag Payload Codec
+
+Create the typed drag-transfer codec in `lib/drag-payload.ts` and its
+companion test. This decouples card and drop-zone from ad-hoc JSON parsing
+and gives the smoke test a stable contract to assert against.
+
+### Phase 2: Core Implementation — Draggable Cards + ExecuteDropZone
+
+1. Add `draggable` + `onDragStart` to `ActiveRunCard` and `RecentRunRow`.
+2. Implement `ExecuteDropZone` component: highlights on `dragover`, calls
+   `skill.startRun` on `drop`, shows inline error on failure.
+3. Mount `ExecuteDropZone` below `RunsFeed` inside `RunsPage` (scoped-project
+   view only — `draftProject !== null`).
+
+### Phase 3: Integration — Smoke Test
+
+Write `ExecuteDropZone.test.ts` using `bun:test` + `spyOn` that:
+- Imports `ExecuteDropZone`'s drop handler logic (or the codec layer)
+- Asserts the `startRun` call signature matches expected args
+- Covers happy path + malformed payload guard
+
+## Step by Step Tasks
+
+### Step 1 — Create drag payload codec
+
+- Create `packages/web/src/experiments/console/lib/drag-payload.ts`
+  - Export `interface DragPayload { runId: string; projectId: string; workflow: string; message: string; }`
+  - Export `encodeDragPayload(run: Run): string` — `JSON.stringify` the subset
+  - Export `decodeDragPayload(raw: string): DragPayload | null` — `try/catch` JSON.parse + shape guard
+- Create `packages/web/src/experiments/console/lib/drag-payload.test.ts`
+  - `describe('encodeDragPayload')` — encodes expected fields
+  - `describe('decodeDragPayload')` — round-trip, returns null on invalid JSON, returns null on missing fields
+
+### Step 2 — Make cards draggable
+
+- Edit `packages/web/src/experiments/console/components/ActiveRunCard.tsx`
+  - Import `encodeDragPayload` from `../lib/drag-payload`
+  - Add `draggable={canOpen}` to the `<article>` element
+  - Add `onDragStart` handler that calls `e.dataTransfer.setData('application/archon-run', encodeDragPayload(run))`
+- Edit `packages/web/src/experiments/console/components/RecentRunRow.tsx`
+  - Same draggable treatment (guard with `run.projectId !== null`)
+
+### Step 3 — Implement ExecuteDropZone component
+
+- Create `packages/web/src/experiments/console/components/ExecuteDropZone.tsx`
+  - Props: `{ projectId: string; projectCwd: string }`
+  - Local state: `dragActive: boolean`, `error: string | null`, `submitting: boolean`
+  - `onDragOver(e)` — `e.preventDefault(); setDragActive(true)`
+  - `onDragLeave()` — `setDragActive(false)`
+  - `onDrop(e)` — decode payload, call `skill.startRun({ projectId, workflow: 'implement', message })`, invalidate runs cache, handle errors
+  - Visual: dashed border zone, accent highlight on hover, spinner while submitting, inline error text
+  - Accessible: `role="region"` + `aria-label="Execute drop zone"`
+
+### Step 4 — Mount ExecuteDropZone in RunsPage
+
+- Edit `packages/web/src/experiments/console/routes/RunsPage.tsx`
+  - Import `ExecuteDropZone`
+  - Render `<ExecuteDropZone projectId={...} projectCwd={...} />` immediately below `<RunsFeed>` when `draftProject !== null`
+
+### Step 5 — Write smoke test for ExecuteDropZone
+
+- Create `packages/web/src/experiments/console/components/ExecuteDropZone.test.ts`
+  - `import { describe, test, expect, spyOn, mock } from 'bun:test'`
+  - `mock.module('../skills', ...)` to spy on `startRun` — isolate in a separate `bun test` invocation (per `CLAUDE.md` mock isolation rules)
+  - Test: happy path — `decodeDragPayload` + `startRun` called with `workflow: 'implement'`
+  - Test: malformed payload — `startRun` NOT called, no unhandled error
+  - Test: `startRun` rejects — `error` state set
+
+### Step 6 — Update package.json test script
+
+- Edit `packages/web/package.json`
+  - Add `bun test src/experiments/` as a separate `bun test` invocation in the `test` script to maintain mock isolation (follow existing `&&`-chained pattern)
+
+### Step 7 — Validate
+
+- Run linter, type check, full test suite (see Validation Commands below)
+
+## Testing Strategy
+
+See `CLAUDE.md` for complete testing requirements. Every file in `src/` must have a corresponding test file in `tests/`.
+
+### Unit Tests
+
+`@bun:test` unit tests (Bun's built-in test runner — the project standard):
+
+- **`drag-payload.test.ts`** — `describe('encodeDragPayload')`, `describe('decodeDragPayload')`:
+  round-trip encode/decode, malformed JSON returns null, missing field returns null.
+- **`ExecuteDropZone.test.ts`** — drop handler logic:
+  happy path calls `startRun` with expected args; malformed payload skips `startRun`; rejected `startRun` sets error state.
+
+### Integration Tests
+
+Not required for this feature — the smoke test covers the full path
+(card drag data → codec → skill invocation) in isolation from the network.
+Manual curl validation confirms the backend `/api/workflows/implement/run` is
+reachable (see Validation Commands).
+
+### Edge Cases
+
+- Drop payload missing `projectId` — decoded as null, drop is a no-op + user sees error
+- Drop from a demo run (id starts with `demo-`) — guard in `onDrop`, no `startRun` call
+- `startRun` throws `HttpError` — sets inline error string, `submitting` reset to false
+- `dragLeave` fires on child element (pointer moves over inner text) — use `relatedTarget` guard or CSS pointer-events trick to avoid flickering `dragActive`
+- Multiple rapid drops — `submitting` flag prevents double-submit
+
+## Acceptance Criteria
+
+- [ ] Dragging an `ActiveRunCard` or `RecentRunRow` and dropping it on the
+      `ExecuteDropZone` calls `skill.startRun` with `workflow: 'implement'`
+      and the run's `projectId` + original `userMessage` as `message`.
+- [ ] The drop zone visually indicates drag-over state (accent highlight) and
+      resets after drop or drag-leave.
+- [ ] The drop zone renders only when a project is scoped (`draftProject !== null`).
+- [ ] Demo run cards (`id.startsWith('demo-')`) are draggable for visual demo
+      purposes but the drop zone no-ops on them (no `startRun` call).
+- [ ] `drag-payload.test.ts` passes: round-trip, null-on-invalid.
+- [ ] `ExecuteDropZone.test.ts` passes: happy path + malformed + error state.
+- [ ] `bun run validate` exits 0 (lint, type-check, all tests).
+
+## Validation Commands
+
+Execute every command to validate the feature works correctly with zero regressions.
+
+- **Type checking:** `bun run type-check`
+- **Lint:** `bun run lint`
+- **Format:** `bun run format:check`
+- **Unit tests (web package only, fast):**
+  ```
+  bun test packages/web/src/experiments/console/lib/drag-payload.test.ts
+  bun test packages/web/src/experiments/console/components/ExecuteDropZone.test.ts
+  ```
+- **Full test suite:** `bun run test`
+- **Full validation (pre-PR):** `bun run validate`
+- **Manual smoke** (server must be running at port 3090):
+  ```bash
+  # Health check
+  curl -s http://localhost:3090/api/health | jq .status
+
+  # Create a project / conversation, then open /console?demo=1 in the browser,
+  # drag any run card onto the Execute drop zone, and verify a new run appears
+  # in the Active feed.
+  ```
+
+**Required validation commands:**
+
+- `bun run lint` — Lint check must pass
+- `bun run type-check` — Type check must pass
+- `bun run test` — All tests must pass with zero regressions
+- `bun run validate` — Full pre-PR gate must pass
+
+## Notes
+
+- **Mock isolation:** `ExecuteDropZone.test.ts` uses `mock.module('../skills', ...)`.
+  Per `CLAUDE.md` rules, add it as a separate `bun test` invocation in
+  `packages/web/package.json` to avoid polluting other test files that import
+  `skills`.
+- **Vocabulary:** Use "Execute" (capital E) as the drop-zone label — it maps
+  to the `implement` workflow name on the backend. Avoid "Deploy", "Run",
+  "Stage" per the console README vocabulary constraints.
+- **Design tokens:** `bg-surface-inset`, `border-accent-bright/50`,
+  `text-text-tertiary` — all in `packages/web/src/index.css`.
+- **Future extension:** once validated, the drop-zone model generalises to
+  other workflow targets (Plan, Review) — a `workflow` prop on
+  `ExecuteDropZone` would cover it without API changes.
+- **Priority:** medium — this is a console experiment, not a production
+  surface; it is safe to iterate without a feature flag.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -8,7 +8,7 @@
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "type-check": "tsc --noEmit",
-    "test": "bun test src/lib/ && bun test src/stores/ && bun test src/hooks/ && bun test src/components/",
+    "test": "bun test src/lib/ && bun test src/stores/ && bun test src/hooks/ && bun test src/components/ && bun test src/experiments/console/lib/ && bun test src/experiments/console/components/ExecuteDropZone.test.ts",
     "generate:types": "openapi-typescript http://localhost:3090/api/openapi.json -o src/lib/api.generated.d.ts"
   },
   "dependencies": {

--- a/packages/web/src/experiments/console/components/ActiveRunCard.tsx
+++ b/packages/web/src/experiments/console/components/ActiveRunCard.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react';
+import type { DragEvent as ReactDragEvent, ReactElement } from 'react';
 import { useNavigate } from 'react-router';
 import { StatusStrip } from './StatusStrip';
 import { LiveDot } from './LiveDot';
@@ -9,6 +9,7 @@ import type { Run } from '../primitives/run';
 import { shortRunId, formatElapsed, elapsedSince, formatCost } from '../lib/format';
 import { useIsDocker, openInIde } from '../lib/health';
 import { statusTextClass, statusLabel } from '../lib/run-status';
+import { encodeDragPayload, DRAG_MIME } from '../lib/drag-payload';
 
 interface ActiveRunCardProps {
   run: Run;
@@ -46,9 +47,16 @@ export function ActiveRunCard({
     if (canOpen) navigate(`/console/p/${run.projectId}/r/${run.id}`);
   };
 
+  const onDragStart = (e: ReactDragEvent<HTMLElement>): void => {
+    e.dataTransfer.setData(DRAG_MIME, encodeDragPayload(run));
+    e.dataTransfer.effectAllowed = 'copy';
+  };
+
   return (
     <article
       data-run-id={run.id}
+      draggable={canOpen}
+      onDragStart={canOpen ? onDragStart : undefined}
       onClick={onCardClick}
       role={canOpen ? 'button' : undefined}
       tabIndex={canOpen ? 0 : undefined}

--- a/packages/web/src/experiments/console/components/ExecuteDropZone.test.ts
+++ b/packages/web/src/experiments/console/components/ExecuteDropZone.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Smoke test for ExecuteDropZone drop handler logic.
+ *
+ * Uses mock.module to replace the skills barrel before importing the component,
+ * following the mock-isolation pattern required by CLAUDE.md.
+ * This file must be run as a separate `bun test` invocation in package.json to
+ * prevent mock.module pollution from affecting other test files that import
+ * skills.
+ */
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+// mock.module must be called before any import that transitively loads the
+// real skills module.
+const mockStartRun = mock(() => Promise.resolve());
+
+mock.module('../skills', () => ({
+  startRun: mockStartRun,
+}));
+
+// Import after mock registration.
+import { handleExecuteDrop } from './ExecuteDropZone';
+import type { StartRunArgs } from '../skills/startRun';
+
+beforeEach(() => {
+  mockStartRun.mockClear();
+});
+
+describe('handleExecuteDrop — happy path', () => {
+  test('calls startRun with workflow: implement and the run message', async () => {
+    const { encodeDragPayload } = await import('../lib/drag-payload');
+    const raw = encodeDragPayload({
+      id: 'run-001',
+      projectId: 'proj-abc',
+      projectName: 'my-project',
+      costUsd: null,
+      conversationId: null,
+      conversationPlatformId: null,
+      workflow: 'plan',
+      origin: 'web',
+      status: 'completed',
+      startedAt: new Date().toISOString(),
+      finishedAt: null,
+      workingPath: null,
+      userMessage: 'Add dark mode',
+    });
+
+    const captured: StartRunArgs[] = [];
+    const startRunSpy = mock(async (args: StartRunArgs) => {
+      captured.push(args);
+    });
+
+    const dispatched = await handleExecuteDrop(raw, 'proj-abc', startRunSpy);
+
+    expect(dispatched).toBe(true);
+    expect(startRunSpy).toHaveBeenCalledTimes(1);
+    expect(captured[0]).toEqual({
+      projectId: 'proj-abc',
+      workflow: 'implement',
+      message: 'Add dark mode',
+    });
+  });
+});
+
+describe('handleExecuteDrop — malformed payload', () => {
+  test('returns false and does NOT call startRun for invalid JSON', async () => {
+    const startRunSpy = mock(async (_args: StartRunArgs) => {});
+    const dispatched = await handleExecuteDrop('not json', 'proj-abc', startRunSpy);
+    expect(dispatched).toBe(false);
+    expect(startRunSpy).not.toHaveBeenCalled();
+  });
+
+  test('returns false and does NOT call startRun for missing fields', async () => {
+    const raw = JSON.stringify({ runId: 'r', workflow: 'implement' }); // missing projectId + message
+    const startRunSpy = mock(async (_args: StartRunArgs) => {});
+    const dispatched = await handleExecuteDrop(raw, 'proj-abc', startRunSpy);
+    expect(dispatched).toBe(false);
+    expect(startRunSpy).not.toHaveBeenCalled();
+  });
+
+  test('returns false for empty string without throwing', async () => {
+    const startRunSpy = mock(async (_args: StartRunArgs) => {});
+    const dispatched = await handleExecuteDrop('', 'proj-abc', startRunSpy);
+    expect(dispatched).toBe(false);
+    expect(startRunSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleExecuteDrop — demo run guard', () => {
+  test('returns false and does NOT call startRun for demo- run ids', async () => {
+    const { encodeDragPayload } = await import('../lib/drag-payload');
+    const raw = encodeDragPayload({
+      id: 'demo-running-1',
+      projectId: 'proj-abc',
+      projectName: 'demo',
+      costUsd: null,
+      conversationId: null,
+      conversationPlatformId: null,
+      workflow: 'plan',
+      origin: 'web',
+      status: 'running',
+      startedAt: new Date().toISOString(),
+      finishedAt: null,
+      workingPath: null,
+      userMessage: 'demo task',
+    });
+    const startRunSpy = mock(async (_args: StartRunArgs) => {});
+    const dispatched = await handleExecuteDrop(raw, 'proj-abc', startRunSpy);
+    expect(dispatched).toBe(false);
+    expect(startRunSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleExecuteDrop — startRun rejection', () => {
+  test('propagates the error when startRun rejects', async () => {
+    const { encodeDragPayload } = await import('../lib/drag-payload');
+    const raw = encodeDragPayload({
+      id: 'run-002',
+      projectId: 'proj-abc',
+      projectName: 'my-project',
+      costUsd: null,
+      conversationId: null,
+      conversationPlatformId: null,
+      workflow: 'implement',
+      origin: 'web',
+      status: 'failed',
+      startedAt: new Date().toISOString(),
+      finishedAt: null,
+      workingPath: null,
+      userMessage: 'Fix the bug',
+    });
+    const startRunSpy = mock(async (_args: StartRunArgs) => {
+      throw new Error('Network error');
+    });
+    await expect(handleExecuteDrop(raw, 'proj-abc', startRunSpy)).rejects.toThrow('Network error');
+  });
+});

--- a/packages/web/src/experiments/console/components/ExecuteDropZone.tsx
+++ b/packages/web/src/experiments/console/components/ExecuteDropZone.tsx
@@ -1,0 +1,118 @@
+import { useState, type DragEvent as ReactDragEvent, type ReactElement } from 'react';
+import * as skill from '../skills';
+import { invalidate } from '../store/cache';
+import { decodeDragPayload, DRAG_MIME } from '../lib/drag-payload';
+import type { StartRunArgs } from '../skills/startRun';
+
+interface ExecuteDropZoneProps {
+  projectId: string;
+  projectCwd: string;
+}
+
+/**
+ * Pure helper: decode the drag-transfer payload, validate it, and call the
+ * provided `startRun` function. Returns `false` (no-op) when the payload is
+ * invalid or from a demo run; returns `true` when `startRun` was called.
+ *
+ * Exported for unit testing without rendering the component.
+ */
+export async function handleExecuteDrop(
+  rawPayload: string,
+  projectId: string,
+  startRunFn: (args: StartRunArgs) => Promise<void>
+): Promise<boolean> {
+  const payload = decodeDragPayload(rawPayload);
+  if (payload === null) return false;
+  // Demo runs are draggable for visual purposes but must not trigger real work.
+  if (payload.runId.startsWith('demo-')) return false;
+  await startRunFn({ projectId, workflow: 'implement', message: payload.message });
+  return true;
+}
+
+/**
+ * ExecuteDropZone — accepts a dragged run card and enqueues a new `implement`
+ * agent work order via `skill.startRun`.
+ *
+ * Drop target semantics:
+ * - Accepts cards carrying `application/archon-run` data (set by ActiveRunCard
+ *   and RecentRunRow on `dragstart`).
+ * - Always uses `workflow: 'implement'`, regardless of the source run's
+ *   original workflow.
+ * - Demo runs (id starts with `demo-`) are silently ignored.
+ * - While a run is being dispatched (`submitting`), subsequent drops are no-ops.
+ *
+ * Renders only in the scoped-project view (i.e. `draftProject !== null` in
+ * RunsPage). The parent controls visibility.
+ */
+export function ExecuteDropZone({
+  projectId,
+  projectCwd: _projectCwd,
+}: ExecuteDropZoneProps): ReactElement {
+  const [dragActive, setDragActive] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onDragOver = (e: ReactDragEvent<HTMLDivElement>): void => {
+    if (!e.dataTransfer.types.includes(DRAG_MIME)) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+    if (!dragActive) setDragActive(true);
+  };
+
+  const onDragLeave = (e: ReactDragEvent<HTMLDivElement>): void => {
+    // Only un-flag when leaving the bounding rect, not on each child crossover.
+    if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+    setDragActive(false);
+  };
+
+  const onDrop = (e: ReactDragEvent<HTMLDivElement>): void => {
+    e.preventDefault();
+    setDragActive(false);
+    if (submitting) return;
+
+    const raw = e.dataTransfer.getData(DRAG_MIME);
+    if (raw.length === 0) return;
+
+    setError(null);
+    setSubmitting(true);
+
+    void handleExecuteDrop(raw, projectId, skill.startRun)
+      .then(dispatched => {
+        if (dispatched) {
+          invalidate('runs');
+        }
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : 'Failed to start run.');
+      })
+      .finally(() => {
+        setSubmitting(false);
+      });
+  };
+
+  return (
+    <div
+      role="region"
+      aria-label="Execute drop zone"
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+      className={`flex min-h-[56px] items-center justify-center rounded border border-dashed px-4 py-3 transition-colors ${
+        dragActive
+          ? 'border-accent-bright/60 bg-accent/10 text-accent-bright'
+          : 'border-border bg-surface-inset text-text-tertiary'
+      }${submitting ? ' opacity-60' : ''}`}
+    >
+      <span className="select-none font-mono text-[11px]">
+        {submitting
+          ? 'Starting…'
+          : dragActive
+            ? 'Drop to Execute'
+            : 'Drop a run card here to Execute'}
+      </span>
+      {error !== null ? (
+        <span className="ml-3 font-mono text-[11px] text-error">{error}</span>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/web/src/experiments/console/components/RecentRunRow.tsx
+++ b/packages/web/src/experiments/console/components/RecentRunRow.tsx
@@ -1,10 +1,11 @@
-import type { ReactElement } from 'react';
+import type { DragEvent as ReactDragEvent, ReactElement } from 'react';
 import { useNavigate } from 'react-router';
 import { OriginBadge } from './OriginBadge';
 import type { Run } from '../primitives/run';
 import { shortRunId, formatElapsed, elapsedSince, formatCost } from '../lib/format';
 import { useIsDocker, openInIde } from '../lib/health';
 import { statusTextClass } from '../lib/run-status';
+import { encodeDragPayload, DRAG_MIME } from '../lib/drag-payload';
 
 interface RecentRunRowProps {
   run: Run;
@@ -47,6 +48,11 @@ export function RecentRunRow({
     if (canOpen) navigate(`/console/p/${run.projectId}/r/${run.id}`);
   };
 
+  const onDragStart = (e: ReactDragEvent<HTMLDivElement>): void => {
+    e.dataTransfer.setData(DRAG_MIME, encodeDragPayload(run));
+    e.dataTransfer.effectAllowed = 'copy';
+  };
+
   const onRerun = (): void => {
     if (!canRerun || run.projectId === null) return;
     const params = new URLSearchParams({
@@ -60,6 +66,8 @@ export function RecentRunRow({
   return (
     <div
       data-run-id={run.id}
+      draggable={canOpen}
+      onDragStart={canOpen ? onDragStart : undefined}
       onClick={onClick}
       role={canOpen ? 'button' : undefined}
       className={`group flex h-9 items-center gap-3 border-b border-border/40 px-3 font-mono text-[12px] transition-colors hover:bg-surface-hover ${

--- a/packages/web/src/experiments/console/lib/drag-payload.test.ts
+++ b/packages/web/src/experiments/console/lib/drag-payload.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+import { encodeDragPayload, decodeDragPayload, type DragPayload } from './drag-payload';
+import type { Run } from '../primitives/run';
+
+function makeRun(overrides: Partial<Run> = {}): Run {
+  return {
+    id: 'run-abc-123',
+    projectId: 'proj-xyz',
+    projectName: 'my-project',
+    costUsd: null,
+    conversationId: null,
+    conversationPlatformId: null,
+    workflow: 'implement',
+    origin: 'web',
+    status: 'completed',
+    startedAt: new Date().toISOString(),
+    finishedAt: null,
+    workingPath: null,
+    userMessage: 'Add dark mode support',
+    ...overrides,
+  };
+}
+
+describe('encodeDragPayload', () => {
+  test('encodes required fields as JSON', () => {
+    const run = makeRun();
+    const raw = encodeDragPayload(run);
+    const parsed = JSON.parse(raw) as DragPayload;
+    expect(parsed.runId).toBe('run-abc-123');
+    expect(parsed.projectId).toBe('proj-xyz');
+    expect(parsed.workflow).toBe('implement');
+    expect(parsed.message).toBe('Add dark mode support');
+  });
+
+  test('uses userMessage as message', () => {
+    const run = makeRun({ userMessage: 'Fix the bug' });
+    const raw = encodeDragPayload(run);
+    const parsed = JSON.parse(raw) as DragPayload;
+    expect(parsed.message).toBe('Fix the bug');
+  });
+
+  test('null projectId is encoded as-is', () => {
+    const run = makeRun({ projectId: null });
+    const raw = encodeDragPayload(run);
+    const parsed = JSON.parse(raw) as unknown;
+    expect((parsed as Record<string, unknown>).projectId).toBeNull();
+  });
+});
+
+describe('decodeDragPayload', () => {
+  test('round-trips encode → decode', () => {
+    const run = makeRun();
+    const payload = decodeDragPayload(encodeDragPayload(run));
+    expect(payload).not.toBeNull();
+    expect(payload!.runId).toBe(run.id);
+    expect(payload!.projectId).toBe(run.projectId);
+    expect(payload!.workflow).toBe(run.workflow);
+    expect(payload!.message).toBe(run.userMessage);
+  });
+
+  test('returns null for invalid JSON', () => {
+    expect(decodeDragPayload('not json {')).toBeNull();
+  });
+
+  test('returns null for empty string', () => {
+    expect(decodeDragPayload('')).toBeNull();
+  });
+
+  test('returns null when runId is missing', () => {
+    const raw = JSON.stringify({ projectId: 'p', workflow: 'implement', message: 'hi' });
+    expect(decodeDragPayload(raw)).toBeNull();
+  });
+
+  test('returns null when projectId is missing', () => {
+    const raw = JSON.stringify({ runId: 'r', workflow: 'implement', message: 'hi' });
+    expect(decodeDragPayload(raw)).toBeNull();
+  });
+
+  test('returns null when workflow is a number', () => {
+    const raw = JSON.stringify({ runId: 'r', projectId: 'p', workflow: 42, message: 'hi' });
+    expect(decodeDragPayload(raw)).toBeNull();
+  });
+
+  test('returns null for null input', () => {
+    expect(decodeDragPayload('null')).toBeNull();
+  });
+
+  test('returns null for array input', () => {
+    expect(decodeDragPayload('[]')).toBeNull();
+  });
+});

--- a/packages/web/src/experiments/console/lib/drag-payload.ts
+++ b/packages/web/src/experiments/console/lib/drag-payload.ts
@@ -1,0 +1,43 @@
+import type { Run } from '../primitives/run';
+
+/** Typed payload carried by a run-card drag transfer. */
+export interface DragPayload {
+  runId: string;
+  projectId: string;
+  workflow: string;
+  message: string;
+}
+
+/** MIME type key used in dataTransfer; keeps all drag participants in sync. */
+export const DRAG_MIME = 'application/archon-run';
+
+/** Encode the fields needed by the drop zone into a JSON string. */
+export function encodeDragPayload(run: Run): string {
+  return JSON.stringify({
+    runId: run.id,
+    projectId: run.projectId,
+    workflow: run.workflow,
+    message: run.userMessage,
+  });
+}
+
+/** Decode a raw dataTransfer string. Returns null if the JSON is malformed or
+ *  any required field is missing/wrong type — safe to call on untrusted input. */
+export function decodeDragPayload(raw: string): DragPayload | null {
+  try {
+    const obj = JSON.parse(raw) as unknown;
+    if (obj === null || typeof obj !== 'object') return null;
+    const o = obj as Record<string, unknown>;
+    if (
+      typeof o.runId !== 'string' ||
+      typeof o.projectId !== 'string' ||
+      typeof o.workflow !== 'string' ||
+      typeof o.message !== 'string'
+    ) {
+      return null;
+    }
+    return { runId: o.runId, projectId: o.projectId, workflow: o.workflow, message: o.message };
+  } catch {
+    return null;
+  }
+}

--- a/packages/web/src/experiments/console/routes/RunsPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunsPage.tsx
@@ -5,6 +5,7 @@ import { ActiveRunCard } from '../components/ActiveRunCard';
 import { RecentRunRow } from '../components/RecentRunRow';
 import { FilterChips, type Filter } from '../components/FilterChips';
 import { DraftRunCard } from '../components/DraftRunCard';
+import { ExecuteDropZone } from '../components/ExecuteDropZone';
 import { useEntity } from '../store/cache';
 import { K, type Scope } from '../store/keys';
 import { useDashboardSSE } from '../lib/sse';
@@ -481,12 +482,19 @@ export function RunsPage(): ReactElement {
             hint={scope === 'all' ? 'Start one from a project.' : undefined}
           />
         ) : (
-          <RunsFeed
-            runs={runs}
-            showProject={scope === 'all'}
-            draftProject={draftProject}
-            selectedRunId={selectedRunId}
-          />
+          <>
+            <RunsFeed
+              runs={runs}
+              showProject={scope === 'all'}
+              draftProject={draftProject}
+              selectedRunId={selectedRunId}
+            />
+            {draftProject !== null ? (
+              <div className="mt-6">
+                <ExecuteDropZone projectId={draftProject.id} projectCwd={draftProject.path} />
+              </div>
+            ) : null}
+          </>
         )}
       </div>
     </section>


### PR DESCRIPTION
## Summary

- **Problem:** The console run feed lacked a gestural shortcut to queue tasks directly to the execute/implement workflow, and there was no smoke-level test verifying the drag-to-agent path.
- **Why it matters:** Users had to manually fill in DraftRunCard forms; drag-to-execute reduces friction significantly for practitioners doing iterative AI-assisted development.
- **What changed:** Added `ExecuteDropZone` component, a `drag-payload` codec, draggable treatment on `ActiveRunCard`, and a `bun:test` smoke test verifying the full drag→`startRun` path.
- **What did not change:** Existing `DraftRunCard` form flow, non-console web UI, server/core packages (this is a console experiment addition only).

## UX Journey

### Before

```
User                  Console UI
────                  ──────────
wants to execute  ──▶ opens DraftRunCard form
task                  fills in workflow + message
                      clicks Submit
                  ◀── agent queued
```

### After

```
User                  Console UI               Skill
────                  ──────────               ─────
grabs run card ─────▶ dragstart fires
                      encodes drag payload
drops on           ──▶ ExecuteDropZone.onDrop
ExecuteDropZone        decodes payload
                       calls startRun ─────────▶ Copilot SDK
                  ◀─── agent queued
```

## Architecture Diagram

### After

```
packages/web/src/experiments/console/
├── lib/
│   └── drag-payload.ts          [+] encode/decode drag transfer data
├── components/
│   ├── ActiveRunCard.tsx         [~] draggable="true" + dragstart handler
│   ├── ExecuteDropZone.tsx       [+] drop target → startRun
│   └── ExecuteDropZone.test.ts   [+] smoke test
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `ActiveRunCard` | `drag-payload` | **new** | encodes run id + projectId on dragstart |
| `ExecuteDropZone` | `drag-payload` | **new** | decodes payload on drop |
| `ExecuteDropZone` | `startRun` skill | **new** | fires work order with `workflow: 'implement'` |
| `ExecuteDropZone.test` | `ExecuteDropZone` | **new** | smoke coverage |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `web`
- Module: `web:console-experiment`

## Change Metadata

- Change type: `feature`
- Primary scope: `web`

## Linked Issue

See: `PRPs/features/completed/e2e-drag-smoke-execute-agent.md`

## Validation Evidence (required)

```bash
bun run validate
```

- New test files added: `ExecuteDropZone.test.ts`, `drag-payload.test.ts`
- Smoke test asserts `startRun` called with `workflow: 'implement'` on drop

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified drag-drop interaction in console experiment UI
- Verified `startRun` is called with correct payload on drop
- Edge case: drop with no payload is a no-op (graceful degradation)

## Side Effects / Blast Radius (required)

- Affected subsystems: console experiment only (isolated under `experiments/`)
- No production web UI changes
- No server/core/adapters changes

## Rollback Plan (required)

- Fast rollback: revert this PR (no DB migrations, no config changes)
- No feature flags needed (console experiment is already behind the `/console` route)
- Observable failure: smoke test `ExecuteDropZone.test.ts` would fail

## Risks and Mitigations

- Risk: drag-payload codec produces invalid JSON on unexpected run card shapes
  - Mitigation: `decodeDragPayload` returns `null` on parse failure; `ExecuteDropZone.onDrop` is a no-op when payload is null


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drag-and-drop execution: run cards in the console are now draggable to the Execute zone to trigger workflow executions with a single action.
  * Smart validation: automatically blocks demo runs and provides error feedback for failed operations.
  * Visual feedback: state-aware styling displays drag hover states, submission progress, and error conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1772?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->