### PR TITLE
feat(providers): add Kimi K2.5 community provider via OpenRouter

### DIFF
--- a/packages/providers/src/community/kimi/capabilities.ts
+++ b/packages/providers/src/community/kimi/capabilities.ts
@@ -1,0 +1,27 @@
+import type { ProviderCapabilities } from '../../types';
+
+/**
+ * Kimi K2.5 (via OpenRouter) capabilities.
+ *
+ * Kimi is a streaming chat-completion provider — no session resume, no tools,
+ * no MCP. Use it for content generation and synthesis nodes in a DAG where
+ * Claude handles agentic/tool-heavy nodes (per-node model routing pattern).
+ *
+ * structuredOutput is best-effort via prompt augmentation (JSON schema
+ * appended to the user message). Reliable on Kimi K2.5's instruction following.
+ */
+export const KIMI_CAPABILITIES: ProviderCapabilities = {
+  sessionResume: false,
+  mcp: false,
+  hooks: false,
+  skills: false,
+  agents: false,
+  toolRestrictions: false,
+  structuredOutput: true,
+  envInjection: true,
+  costControl: false,
+  effortControl: false,
+  thinkingControl: false,
+  fallbackModel: false,
+  sandbox: false,
+};

--- a/packages/providers/src/community/kimi/index.ts
+++ b/packages/providers/src/community/kimi/index.ts
@@ -1,0 +1,3 @@
+export { KIMI_CAPABILITIES } from './capabilities';
+export { KimiProvider } from './provider';
+export { registerKimiProvider } from './registration';

--- a/packages/providers/src/community/kimi/provider.ts
+++ b/packages/providers/src/community/kimi/provider.ts
@@ -1,0 +1,170 @@
+import type {
+  IAgentProvider,
+  MessageChunk,
+  ProviderCapabilities,
+  SendQueryOptions,
+} from '../../types';
+
+import { KIMI_CAPABILITIES } from './capabilities';
+
+const OPENROUTER_BASE = 'https://openrouter.ai/api/v1';
+const DEFAULT_MODEL = 'moonshotai/kimi-k2';
+const HTTP_REFERER = 'https://github.com/coleam00/archon';
+
+/**
+ * Strip ```json ... ``` fences from a string so JSON.parse works.
+ */
+function stripCodeFences(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith('```')) return trimmed;
+  return trimmed
+    .replace(/^```[a-z]*\n?/, '')
+    .replace(/\n?```$/, '')
+    .trim();
+}
+
+/**
+ * Kimi K2.5 provider via OpenRouter (OpenAI-compatible chat completions API).
+ *
+ * Each sendQuery() call is stateless — no session resume. Designed for
+ * content-generation and synthesis nodes in Archon DAGs where the task is
+ * "prompt in → text out" rather than agentic tool-use.
+ *
+ * Auth: reads OPENROUTER_API_KEY from requestOptions.env or process.env.
+ * Model: defaults to moonshotai/kimi-k2; override with requestOptions.model.
+ */
+export class KimiProvider implements IAgentProvider {
+  async *sendQuery(
+    prompt: string,
+    _cwd: string,
+    _resumeSessionId?: string,
+    requestOptions?: SendQueryOptions
+  ): AsyncGenerator<MessageChunk> {
+    const apiKey = requestOptions?.env?.OPENROUTER_API_KEY ?? process.env.OPENROUTER_API_KEY;
+    if (!apiKey) {
+      throw new Error(
+        'KimiProvider requires OPENROUTER_API_KEY. Set it in the environment or in .archon/config.yaml env: section.'
+      );
+    }
+
+    const model = requestOptions?.model ?? DEFAULT_MODEL;
+
+    // Build message list
+    const messages: { role: string; content: string }[] = [];
+
+    const rawSystemPrompt = requestOptions?.systemPrompt;
+    if (typeof rawSystemPrompt === 'string') {
+      messages.push({ role: 'system', content: rawSystemPrompt });
+    }
+
+    // Structured output: append schema as instruction to user message
+    const outputFormat = requestOptions?.outputFormat;
+    const userContent = outputFormat
+      ? `${prompt}\n\n---\n\nCRITICAL: Respond with ONLY a JSON object matching the schema below. No prose, no markdown fences.\n\nSchema:\n${JSON.stringify(outputFormat.schema, null, 2)}`
+      : prompt;
+
+    messages.push({ role: 'user', content: userContent });
+
+    const body = JSON.stringify({
+      model,
+      messages,
+      stream: true,
+      temperature: 0.3,
+    });
+
+    const response = await fetch(`${OPENROUTER_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+        'HTTP-Referer': HTTP_REFERER,
+        'X-Title': 'Archon',
+      },
+      body,
+    });
+
+    if (!response.ok) {
+      const errText = await response.text().catch(() => '(no body)');
+      throw new Error(`OpenRouter ${response.status}: ${errText.slice(0, 200)}`);
+    }
+
+    if (!response.body) {
+      throw new Error('OpenRouter returned no response body');
+    }
+
+    // Parse SSE stream
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let accumulated = '';
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let buffer = '';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        // Keep the last (possibly incomplete) line in the buffer
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          const data = line.slice(6).trim();
+          if (data === '[DONE]') continue;
+
+          try {
+            const parsed = JSON.parse(data) as {
+              choices?: { delta?: { content?: string } }[];
+              usage?: { prompt_tokens?: number; completion_tokens?: number };
+            };
+            const content = parsed.choices?.[0]?.delta?.content;
+            if (content) {
+              accumulated += content;
+              yield { type: 'assistant', content };
+            }
+            if (parsed.usage) {
+              inputTokens = parsed.usage.prompt_tokens ?? 0;
+              outputTokens = parsed.usage.completion_tokens ?? 0;
+            }
+          } catch {
+            // Ignore malformed SSE lines
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    // Parse structured output from accumulated text
+    let structuredOutput: unknown;
+    if (outputFormat && accumulated) {
+      try {
+        structuredOutput = JSON.parse(stripCodeFences(accumulated));
+      } catch {
+        // Degrade gracefully — dag-executor's structured_output_missing path handles it
+      }
+    }
+
+    yield {
+      type: 'result',
+      sessionId: `kimi-${Date.now()}`,
+      tokens: {
+        input: inputTokens,
+        output: outputTokens,
+        total: inputTokens + outputTokens,
+      },
+      structuredOutput,
+    };
+  }
+
+  getType(): string {
+    return 'kimi';
+  }
+
+  getCapabilities(): ProviderCapabilities {
+    return KIMI_CAPABILITIES;
+  }
+}

--- a/packages/providers/src/community/kimi/registration.ts
+++ b/packages/providers/src/community/kimi/registration.ts
@@ -1,0 +1,22 @@
+import { isRegisteredProvider, registerProvider } from '../../registry';
+
+import { KIMI_CAPABILITIES } from './capabilities';
+import { KimiProvider } from './provider';
+
+/**
+ * Register the Kimi K2.5 community provider.
+ *
+ * Idempotent — safe to call multiple times. Kimi is a simple chat-completion
+ * provider via OpenRouter, suited for content-generation and synthesis DAG nodes
+ * that don't need Claude's agentic tool-use capabilities (per-node model routing).
+ */
+export function registerKimiProvider(): void {
+  if (isRegisteredProvider('kimi')) return;
+  registerProvider({
+    id: 'kimi',
+    displayName: 'Kimi K2.5 (via OpenRouter)',
+    factory: () => new KimiProvider(),
+    capabilities: KIMI_CAPABILITIES,
+    builtIn: false,
+  });
+}

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -54,3 +54,5 @@ export {
   registerPiProvider,
   type PiProviderDefaults,
 } from './community/pi';
+
+export { KimiProvider, registerKimiProvider } from './community/kimi';

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -18,6 +18,7 @@ import { CodexProvider } from './codex/provider';
 import { CLAUDE_CAPABILITIES } from './claude/capabilities';
 import { CODEX_CAPABILITIES } from './codex/capabilities';
 import { registerPiProvider } from './community/pi/registration';
+import { registerKimiProvider } from './community/kimi/registration';
 import { UnknownProviderError } from './errors';
 import { createLogger } from '@archon/paths';
 
@@ -153,6 +154,7 @@ export function registerBuiltinProviders(): void {
  */
 export function registerCommunityProviders(): void {
   registerPiProvider();
+  registerKimiProvider();
 }
 
 /** @internal Test-only — clears the registry. Not for production use. */


### PR DESCRIPTION
## Summary

- Adds `KimiProvider` as a community provider under `packages/providers/src/community/kimi/`
- Routes to `moonshotai/kimi-k2` via OpenRouter's OpenAI-compatible API
- Supports SSE streaming, structured output (via prompt augmentation), and env-injected `OPENROUTER_API_KEY`
- Registered automatically in `registerCommunityProviders()` alongside the existing Pi provider

## Implementation

Follows the established community provider pattern (Pi provider):

| File | Purpose |
|---|---|
| `capabilities.ts` | `structuredOutput: true`, `envInjection: true`, all agentic features false |
| `provider.ts` | `fetch`-based SSE streaming; `stripCodeFences()` helper for JSON parse |
| `registration.ts` | Idempotent `registerKimiProvider()` |
| `index.ts` | Barrel export |

`registry.ts` and `index.ts` updated to wire the provider in.

## Motivation

Enables per-node model routing per Cole's hybrid deterministic-AI workflow pattern — Kimi K2.5 handles content generation and knowledge-synthesis workloads where cost matters, while Claude handles agentic/tool-heavy nodes. `OPENROUTER_API_KEY` is the only new env var required.

## Test plan

- [x] `npx tsc --noEmit` passes with zero errors
- [x] ESLint + Prettier via lint-staged (ran on commit)
- [x] Manual smoke test: `KimiProvider.sendQuery()` returns `OK` response chunk

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kimi (K2.5) provider via OpenRouter for streaming chat completions with structured output support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1773?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->