### PR TITLE
feat(workflows/condition-evaluator): support shorthand path and unquoted numeric/boolean RHS

### DIFF
--- a/packages/workflows/src/condition-evaluator.test.ts
+++ b/packages/workflows/src/condition-evaluator.test.ts
@@ -512,7 +512,7 @@ describe('evaluateCondition', () => {
     expect(parsed).toBe(false);
   });
 
-  // --- #1763: shorthand path ($nodeId.field) ---
+  // --- shorthand path ($nodeId.field) ---
 
   it('shorthand path: $node.field is equivalent to $node.output.field', () => {
     const outputs = new Map([['classify', makeOutput(JSON.stringify({ type: 'BUG' }))]]);
@@ -545,7 +545,17 @@ describe('evaluateCondition', () => {
     expect(res.parsed).toBe(false);
   });
 
-  // --- #1763: unquoted numeric/boolean RHS ---
+  it('shorthand path: absent field resolves to empty string like the canonical form', () => {
+    // An absent shorthand field is not a parse error — it resolves to '' (parsed: true),
+    // mirroring the `$node.output.field` empty-string semantics.
+    const outputs = new Map([['n', makeOutput(JSON.stringify({ type: 'BUG' }))]]);
+    const res = evaluateCondition("$n.missing == 'x'", outputs);
+    expect(res.result).toBe(false);
+    expect(res.parsed).toBe(true);
+    expect(evaluateCondition("$n.missing == ''", outputs).result).toBe(true);
+  });
+
+  // --- unquoted numeric/boolean RHS ---
 
   it('unquoted RHS: integer comparison with ==', () => {
     const outputs = new Map([['t', makeOutput(JSON.stringify({ exit_code: 0 }))]]);

--- a/packages/workflows/src/condition-evaluator.test.ts
+++ b/packages/workflows/src/condition-evaluator.test.ts
@@ -511,4 +511,106 @@ describe('evaluateCondition', () => {
     expect(result).toBe(false);
     expect(parsed).toBe(false);
   });
+
+  // --- #1763: shorthand path ($nodeId.field) ---
+
+  it('shorthand path: $node.field is equivalent to $node.output.field', () => {
+    const outputs = new Map([['classify', makeOutput(JSON.stringify({ type: 'BUG' }))]]);
+    expect(evaluateCondition("$classify.type == 'BUG'", outputs).result).toBe(true);
+    expect(evaluateCondition("$classify.type == 'FEATURE'", outputs).result).toBe(false);
+  });
+
+  it('shorthand path: matches the canonical .output.field form exactly', () => {
+    const outputs = new Map([['classify', makeOutput(JSON.stringify({ type: 'BUG' }))]]);
+    expect(evaluateCondition("$classify.type == 'BUG'", outputs)).toEqual(
+      evaluateCondition("$classify.output.type == 'BUG'", outputs)
+    );
+  });
+
+  it('shorthand path: resolves structuredOutput like the canonical form', () => {
+    const outputs = new Map([['classify', makeOutput('prose', 'completed', { type: 'BUG' })]]);
+    expect(evaluateCondition("$classify.type == 'BUG'", outputs).result).toBe(true);
+  });
+
+  it('shorthand path: works with numeric operators', () => {
+    const outputs = new Map([['score', makeOutput(JSON.stringify({ confidence: 0.95 }))]]);
+    expect(evaluateCondition("$score.confidence >= '0.9'", outputs).result).toBe(true);
+    expect(evaluateCondition("$score.confidence >= '0.99'", outputs).result).toBe(false);
+  });
+
+  it('shorthand path: rejects a sub-field ($node.field.subfield) fail-closed', () => {
+    const outputs = new Map([['n', makeOutput(JSON.stringify({ a: { b: 'x' } }))]]);
+    const res = evaluateCondition("$n.a.b == 'x'", outputs);
+    expect(res.result).toBe(false);
+    expect(res.parsed).toBe(false);
+  });
+
+  // --- #1763: unquoted numeric/boolean RHS ---
+
+  it('unquoted RHS: integer comparison with ==', () => {
+    const outputs = new Map([['t', makeOutput(JSON.stringify({ exit_code: 0 }))]]);
+    expect(evaluateCondition('$t.exit_code == 0', outputs).result).toBe(true);
+    expect(evaluateCondition('$t.exit_code == 1', outputs).result).toBe(false);
+  });
+
+  it('unquoted RHS: negative integer comparison', () => {
+    const outputs = new Map([['t', makeOutput(JSON.stringify({ delta: -3 }))]]);
+    expect(evaluateCondition('$t.delta == -3', outputs).result).toBe(true);
+  });
+
+  it('unquoted RHS: integer with numeric operators', () => {
+    const outputs = new Map([['t', makeOutput(JSON.stringify({ exit_code: 0 }))]]);
+    expect(evaluateCondition('$t.exit_code > 0', outputs).result).toBe(false);
+    expect(evaluateCondition('$t.exit_code >= 0', outputs).result).toBe(true);
+    expect(evaluateCondition('$t.exit_code < 1', outputs).result).toBe(true);
+  });
+
+  it('unquoted RHS: decimal comparison', () => {
+    const outputs = new Map([['score', makeOutput(JSON.stringify({ confidence: 0.95 }))]]);
+    expect(evaluateCondition('$score.confidence >= 0.9', outputs).result).toBe(true);
+    expect(evaluateCondition('$score.confidence == 0.95', outputs).result).toBe(true);
+  });
+
+  it('unquoted RHS: boolean true/false', () => {
+    const outputs = new Map([['n', makeOutput(JSON.stringify({ passed: true }))]]);
+    expect(evaluateCondition('$n.passed == true', outputs).result).toBe(true);
+    expect(evaluateCondition('$n.passed == false', outputs).result).toBe(false);
+    expect(evaluateCondition('$n.passed != false', outputs).result).toBe(true);
+  });
+
+  it('unquoted RHS: works on the canonical .output.field form too', () => {
+    const outputs = new Map([['t', makeOutput(JSON.stringify({ exit_code: 0 }))]]);
+    expect(evaluateCondition('$t.output.exit_code == 0', outputs).result).toBe(true);
+  });
+
+  it('unquoted RHS: parsed:true for a valid unquoted expression', () => {
+    const outputs = new Map([['t', makeOutput(JSON.stringify({ exit_code: 0 }))]]);
+    expect(evaluateCondition('$t.exit_code == 0', outputs).parsed).toBe(true);
+  });
+
+  it('mixed quoted + unquoted inside an AND compound', () => {
+    const outputs = new Map([
+      ['classify', makeOutput(JSON.stringify({ type: 'BUG' }))],
+      ['test', makeOutput(JSON.stringify({ exit_code: 0 }))],
+    ]);
+    expect(
+      evaluateCondition("$classify.type == 'BUG' && $test.exit_code == 0", outputs).result
+    ).toBe(true);
+    expect(
+      evaluateCondition("$classify.type == 'BUG' && $test.exit_code == 1", outputs).result
+    ).toBe(false);
+  });
+
+  it('mixed quoted + unquoted inside an OR compound', () => {
+    const outputs = new Map([
+      ['classify', makeOutput(JSON.stringify({ type: 'FEATURE' }))],
+      ['test', makeOutput(JSON.stringify({ passed: true }))],
+    ]);
+    expect(
+      evaluateCondition("$classify.type == 'BUG' || $test.passed == true", outputs).result
+    ).toBe(true);
+    expect(
+      evaluateCondition("$classify.type == 'BUG' || $test.passed == false", outputs).result
+    ).toBe(false);
+  });
 });

--- a/packages/workflows/src/condition-evaluator.ts
+++ b/packages/workflows/src/condition-evaluator.ts
@@ -4,8 +4,11 @@
  * Supports:
  *   String equality:  "$nodeId.output == 'VALUE'"  / "$nodeId.output != 'VALUE'"
  *   Dot notation:     "$nodeId.output.field == 'VALUE'"
+ *   Shorthand path:   "$nodeId.field == 'VALUE'"  (equivalent to "$nodeId.output.field")
  *   Numeric ops:      "$nodeId.output > '80'"  / ">=" / "<" / "<="
  *                     (both sides must parse as finite numbers; fail-closed otherwise)
+ *   Unquoted RHS:     "$nodeId.exit_code == 0"  / "$nodeId.passed == true"
+ *                     (numbers and booleans may be written without surrounding quotes)
  *   Compound AND/OR:  "$a.output == 'X' && $b.output != 'Y'"
  *                     "$a.output == 'X' || $b.output == 'Y'"
  *                     AND has higher precedence than OR. No parentheses.
@@ -120,9 +123,23 @@ function splitOutsideQuotes(expr: string, sep: string): string[] {
   return parts;
 }
 
-/** Pattern matching a single condition atom: $nodeId.output[.field] OPERATOR 'value' */
+/**
+ * Pattern matching a single condition atom.
+ *
+ * Capture groups:
+ *   1. nodeId       — `$nodeId`
+ *   2. segment1     — first path segment after the node (`output` for canonical refs, else a
+ *                     shorthand field name)
+ *   3. segment2     — optional second path segment (the field name when segment1 is `output`)
+ *   4. operator     — `== | != | <= | >= | < | >`
+ *   5. quotedValue  — single-quoted RHS literal (may be empty)
+ *   6. unquotedValue — bare numeric or boolean RHS (`-?\d+(.\d+)?` | `true` | `false`)
+ *
+ * Exactly one of groups 5/6 is populated on a successful match. The canonical-vs-shorthand
+ * path resolution and the sub-field rejection happen in evaluateAtom.
+ */
 const atomPattern =
-  /^\$([a-zA-Z_][a-zA-Z0-9_-]*)\.output(?:\.([a-zA-Z_][a-zA-Z0-9_]*))?\s*(==|!=|<=|>=|<|>)\s*'([^']*)'$/;
+  /^\$([a-zA-Z_][a-zA-Z0-9_-]*)\.([a-zA-Z_][a-zA-Z0-9_]*)(?:\.([a-zA-Z_][a-zA-Z0-9_]*))?\s*(==|!=|<=|>=|<|>)\s*(?:'([^']*)'|(-?\d+(?:\.\d+)?|true|false))$/;
 
 /**
  * Evaluate a single atomic condition expression against upstream node outputs.
@@ -139,9 +156,33 @@ function evaluateAtom(
     return { result: false, parsed: false };
   }
 
-  const [, nodeId, field, operator, expected] = match;
+  const [, nodeId, segment1, segment2, operator, quotedValue, unquotedValue] = match;
 
-  if (nodeId === undefined || operator === undefined || expected === undefined) {
+  if (nodeId === undefined || segment1 === undefined || operator === undefined) {
+    getLog().debug({ expr }, 'condition_parse_unexpected_undefined');
+    return { result: false, parsed: false };
+  }
+
+  // Resolve the effective field, preserving the canonical `$node.output[.field]` semantics
+  // while also accepting the `$node.field` shorthand:
+  //   - `$node.output`        → bare output reference (field undefined)
+  //   - `$node.output.field`  → field access on the output
+  //   - `$node.field`         → shorthand, equivalent to `$node.output.field`
+  // The shorthand form cannot carry a sub-field (`$node.field.sub` is rejected fail-closed).
+  let field: string | undefined;
+  if (segment1 === 'output') {
+    field = segment2;
+  } else {
+    if (segment2 !== undefined) {
+      getLog().debug({ expr }, 'condition_parse_failed');
+      return { result: false, parsed: false };
+    }
+    field = segment1;
+  }
+
+  // Quoted RHS takes precedence; the unquoted alternative covers numbers and booleans.
+  const expected = quotedValue !== undefined ? quotedValue : unquotedValue;
+  if (expected === undefined) {
     getLog().debug({ expr }, 'condition_parse_unexpected_undefined');
     return { result: false, parsed: false };
   }


### PR DESCRIPTION
## Summary

- Problem: `when:` clauses force the verbose `$nodeId.output.field` form and only accept single-quoted RHS literals — even for numbers, so `$test.exit_code > '0'` quotes a number as a string.
- Why it matters: reduces friction when authoring conditions; numeric/boolean comparisons read naturally.
- What changed: the atom regex now accepts `$nodeId.field` shorthand (≡ `$nodeId.output.field`) and bare numeric/boolean RHS (`== 0`, `== true`); `evaluateAtom` resolves the canonical-vs-shorthand path and picks quoted-or-unquoted RHS.
- What did **not** change (scope boundary): the AND/OR splitter, `resolveOutputRef`, and the numeric coercion path are untouched. No new operators, parentheses, or function calls. Every currently-valid `when:` clause evaluates identically. Shorthand with a sub-field (`$n.field.sub`) is rejected fail-closed.

## UX Journey

### Before

```
Workflow author                  condition-evaluator
───────────────                  ───────────────────
writes when: clause
  $test.output.exit_code > '0' ─▶ atom regex requires `.output.`
  $test.output.passed == 'true'   and single-quoted RHS only
                                ◀─ numbers must be quoted as strings
```

### After

```
Workflow author                  condition-evaluator
───────────────                  ───────────────────
writes when: clause
  $test.exit_code > 0          ─▶ *shorthand path accepted*
  $test.passed == true            *unquoted numeric/boolean RHS accepted*
  $test.output.exit_code > '0' ─▶ canonical + quoted forms still valid
                                ◀─ identical evaluation result
```

## Architecture Diagram

### Before

```
dag-executor.ts ──▶ evaluateCondition() ──▶ splitOutsideQuotes() ──▶ evaluateAtom()
                                                                        │
                                                                        ▼
                                                                   resolveOutputRef()
```

### After

```
dag-executor.ts ──▶ evaluateCondition() ──▶ splitOutsideQuotes() ──▶ evaluateAtom() [~]
                                                                        │  (regex + path/RHS
                                                                        │   resolution updated)
                                                                        ▼
                                                                   resolveOutputRef()  (unchanged)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| dag-executor | evaluateCondition | unchanged | call site untouched |
| evaluateCondition | evaluateAtom | unchanged | |
| evaluateAtom | resolveOutputRef | unchanged | shorthand resolves to same `field` arg |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `workflows`
- Module: `workflows:condition-evaluator`

## Change Metadata

- Change type: `feature`
- Primary scope: `workflows`

## Linked Issue

- Closes #1763

## Validation Evidence (required)

```bash
bun test packages/workflows/src/condition-evaluator.test.ts   # 69 pass / 0 fail
bun --filter @archon/workflows type-check                      # ok
bun run lint                                                   # ok (--max-warnings 0)
prettier --check (changed files)                               # ok
```

- Evidence provided: 69 unit tests pass (54 existing + 15 new); type-check, lint, prettier all green.
- End-to-end: ran a temporary all-`bash:`-node workflow through the CLI (`workflow run --no-worktree`) exercising the real DAG executor. `condition_evaluated` debug logs confirmed shorthand path resolves to the correct field and unquoted int/bool/decimal RHS evaluated correctly; the `$probe.passed == false` node was correctly skipped. Temp workflow removed afterward.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios: shorthand path (`$n.field`), unquoted integer/decimal/boolean RHS, canonical `.output.` form still valid, mixed quoted+unquoted in AND/OR compounds, both unit-tested and run through the live DAG executor.
- Edge cases checked: sub-field rejection on shorthand (`$n.field.sub` → fail-closed), empty quoted RHS (`== ''`), negative integers, false-case skip.
- What was not verified: AI-backed node types (not relevant — change is purely in the condition string parser).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: only `when:` clause evaluation on DAG nodes.
- Potential unintended effects: a previously-unparseable expression that now parses — mitigated by the regex being a strict superset and full regression coverage.
- Guardrails/monitoring: `condition_parse_failed` / `condition_evaluated` debug logs already in place.

## Rollback Plan (required)

- Fast rollback: revert this commit; the evaluator returns to the prior regex with no data or schema impact.
- Feature flags or config toggles: none.
- Observable failure symptoms: `dag_node_skipped_condition_parse_error` messages on previously-valid clauses (none expected).

## Risks and Mitigations

- Risk: regex change unintentionally alters evaluation of an existing clause.
  - Mitigation: superset grammar + all 54 prior tests pass unchanged + live DAG e2e.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Condition expressions accept a shorthand field reference form and allow unquoted numeric and boolean literals in comparisons.
  * Compound expressions mixing quoted and unquoted values for &&/|| are supported.

* **Bug Fixes / Safety**
  * Deep chained shorthand references are rejected to avoid ambiguous resolution.
  * Missing shorthand fields resolve to an empty value without error.

* **Tests**
  * Expanded coverage for shorthand parsing, unquoted literals, comparisons, and compound expressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->