### PR TITLE
telemetry: umbrella trust fixes (CI auto-disable, first-run notice, status/reset CLI)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -262,13 +262,19 @@ MAX_CONCURRENT_CONVERSATIONS=10  # Maximum concurrent AI conversations (default:
 
 # Anonymous Telemetry (optional)
 # Archon sends anonymous workflow-invocation events to PostHog so maintainers
-# can see which workflows get real usage. No PII — workflow name/description +
-# platform + Archon version + a random install UUID. No identities, no prompts,
-# no paths, no code. See README "Telemetry" for the full list.
+# can see which workflows get real usage. No PII — workflow name + platform +
+# Archon version + a random install UUID. No identities, no prompts, no paths,
+# no descriptions, no code, no IP. See README "Telemetry" for the full list.
 #
 # Opt out (any one disables telemetry):
 #   ARCHON_TELEMETRY_DISABLED=1
 #   DO_NOT_TRACK=1                          (de facto standard)
+#   POSTHOG_API_KEY=off                     (off | 0 | false | disabled | "")
+#   CI=true                                 (auto-disabled in CI environments)
+#
+# Inspect or rotate the install UUID:
+#   archon telemetry status
+#   archon telemetry reset
 #
 # Point at a self-hosted PostHog or a different project:
 #   POSTHOG_API_KEY=phc_yourKeyHere

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,6 +260,10 @@ bun run cli skill install /path/to/project
 # Verify your Archon setup (Claude binary, gh auth, DB, adapters)
 bun run cli doctor
 
+# Inspect or rotate the anonymous telemetry install UUID
+bun run cli telemetry status
+bun run cli telemetry reset
+
 # Show version
 bun run cli version
 ```

--- a/README.md
+++ b/README.md
@@ -319,16 +319,21 @@ Full documentation is available at **[archon.diy](https://archon.diy)**.
 
 Archon sends a single anonymous event — `workflow_invoked` — each time a workflow starts, so maintainers can see which workflows get real usage and prioritize accordingly. **No PII, ever.**
 
-**What's collected:** the workflow name, the workflow description (both authored by you in YAML), the platform that triggered it (`cli`, `web`, `slack`, etc.), the Archon version, and a random install UUID stored at `~/.archon/telemetry-id`. Nothing else.
+**What's collected:** the workflow name, the platform that triggered it (`cli`, `web`, `slack`, etc.), the Archon version, and a random install UUID stored at `~/.archon/telemetry-id`. Nothing else.
 
-**What's *not* collected:** your code, prompts, messages, git remotes, file paths, usernames, tokens, AI output, workflow node details — none of it.
+**What's *not* collected:** your code, prompts, messages, workflow descriptions, git remotes, file paths, usernames, tokens, AI output, workflow node details, your IP address — none of it.
 
 **Opt out:** set any of these in your environment:
 
 ```bash
 ARCHON_TELEMETRY_DISABLED=1
 DO_NOT_TRACK=1        # de facto standard honored by Astro, Bun, Prisma, Nuxt, etc.
+POSTHOG_API_KEY=off   # off | 0 | false | disabled | "" all disable
 ```
+
+CI environments (`CI=true`) are auto-disabled — forks running fixtures in GitHub Actions, CircleCI, etc. do not send events.
+
+**Check the current state:** run `archon telemetry status` to see whether telemetry is enabled, why (if not), the install UUID, and the active host. Run `archon telemetry reset` to rotate the install UUID. `archon doctor` also surfaces the current state in its check list.
 
 Self-host PostHog or use a different project by setting `POSTHOG_API_KEY` and `POSTHOG_HOST`.
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "cli": "bun src/cli.ts",
-    "test": "bun test src/commands/version.test.ts src/commands/setup.test.ts src/commands/skill.test.ts src/commands/doctor.test.ts && bun test src/commands/workflow.test.ts && bun test src/commands/isolation.test.ts && bun test src/commands/chat.test.ts && bun test src/commands/serve.test.ts",
+    "test": "bun test src/commands/version.test.ts src/commands/setup.test.ts src/commands/skill.test.ts src/commands/doctor.test.ts src/commands/telemetry.test.ts && bun test src/commands/workflow.test.ts && bun test src/commands/isolation.test.ts && bun test src/commands/chat.test.ts && bun test src/commands/serve.test.ts",
     "type-check": "bun x tsc --noEmit"
   },
   "dependencies": {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -68,6 +68,7 @@ import { skillInstallCommand } from './commands/skill';
 import { validateWorkflowsCommand, validateCommandsCommand } from './commands/validate';
 import { serveCommand } from './commands/serve';
 import { doctorCommand } from './commands/doctor';
+import { telemetryStatusCommand, telemetryResetCommand } from './commands/telemetry';
 import { closeDatabase } from '@archon/core';
 import {
   setLogLevel,
@@ -113,6 +114,8 @@ Commands:
   serve                      Start the web UI server (downloads web UI on first run)
   skill install [path]       Install the bundled Archon skill into .claude/skills/archon
   doctor                     Verify your Archon setup (Claude binary, gh auth, DB, adapters)
+  telemetry status           Show anonymous telemetry state (enabled, reason, ID, host)
+  telemetry reset            Rotate the anonymous install UUID
   validate workflows [name]  Validate workflow definitions and their references
   validate commands [name]   Validate command files
   version, --version, -V     Show version info (also -v when used alone)
@@ -283,6 +286,7 @@ async function main(): Promise<number> {
     'serve',
     'skill',
     'doctor',
+    'telemetry',
   ];
   const requiresGitRepo = !noGitCommands.includes(command ?? '');
 
@@ -644,6 +648,23 @@ async function main(): Promise<number> {
 
       case 'doctor': {
         return await doctorCommand();
+      }
+
+      case 'telemetry': {
+        switch (subcommand) {
+          case 'status':
+            return telemetryStatusCommand();
+          case 'reset':
+            return telemetryResetCommand();
+          default:
+            if (subcommand === undefined) {
+              console.error('Missing telemetry subcommand');
+            } else {
+              console.error(`Unknown telemetry subcommand: ${subcommand}`);
+            }
+            console.error('Available: status, reset');
+            return 1;
+        }
       }
 
       case 'skill': {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -291,8 +291,9 @@ async function main(): Promise<number> {
   const requiresGitRepo = !noGitCommands.includes(command ?? '');
 
   try {
-    // setup/doctor default to warn to avoid Pino info JSON interleaving with ○/✓ output; lazy loggers pick up this level at first creation
-    const isInteractiveCommand = command === 'setup' || command === 'doctor';
+    // setup/doctor/telemetry default to warn to avoid Pino info JSON interleaving with their human-readable output; lazy loggers pick up this level at first creation
+    const isInteractiveCommand =
+      command === 'setup' || command === 'doctor' || command === 'telemetry';
     const suppressByDefault = isInteractiveCommand && !values.verbose && !isVerboseBoot();
     if (values.quiet || suppressByDefault) {
       setLogLevel('warn');

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -21,6 +21,7 @@ import {
   checkBundledDefaults,
   checkSlack,
   checkTelegram,
+  checkTelemetry,
   doctorCommand,
   type DatabaseDeps,
 } from './doctor';
@@ -350,6 +351,62 @@ describe('checkTelegram', () => {
     const result = await checkTelegram({ TELEGRAM_BOT_TOKEN: '123:abc' });
     expect(result.status).toBe('skip');
     expect(result.message).toContain('ETIMEDOUT');
+  });
+});
+
+describe('checkTelemetry', () => {
+  const ENV_VARS = [
+    'ARCHON_TELEMETRY_DISABLED',
+    'DO_NOT_TRACK',
+    'CI',
+    'POSTHOG_API_KEY',
+    'ARCHON_HOME',
+  ] as const;
+  let saved: Record<string, string | undefined>;
+  let tmpHome: string;
+
+  beforeEach(() => {
+    saved = {};
+    for (const k of ENV_VARS) saved[k] = process.env[k];
+    tmpHome = join(tmpdir(), `archon-doctor-tel-${process.pid}-${Date.now()}`);
+    mkdirSync(tmpHome, { recursive: true });
+    process.env.ARCHON_HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    for (const k of ENV_VARS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('returns pass when telemetry is enabled', async () => {
+    delete process.env.ARCHON_TELEMETRY_DISABLED;
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.CI;
+    delete process.env.POSTHOG_API_KEY;
+    const result = await checkTelemetry();
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('embedded');
+  });
+
+  it('returns skip with CI reason when CI=true', async () => {
+    delete process.env.ARCHON_TELEMETRY_DISABLED;
+    delete process.env.DO_NOT_TRACK;
+    process.env.CI = 'true';
+    const result = await checkTelemetry();
+    expect(result.status).toBe('skip');
+    expect(result.message).toContain('CI=true');
+  });
+
+  it('returns skip with DO_NOT_TRACK reason when opted out', async () => {
+    delete process.env.ARCHON_TELEMETRY_DISABLED;
+    delete process.env.CI;
+    process.env.DO_NOT_TRACK = '1';
+    const result = await checkTelemetry();
+    expect(result.status).toBe('skip');
+    expect(result.message).toContain('DO_NOT_TRACK');
   });
 });
 

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -408,6 +408,26 @@ describe('checkTelemetry', () => {
     expect(result.status).toBe('skip');
     expect(result.message).toContain('DO_NOT_TRACK');
   });
+
+  it('returns skip with POSTHOG_API_KEY reason when key set to an off value', async () => {
+    delete process.env.ARCHON_TELEMETRY_DISABLED;
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.CI;
+    process.env.POSTHOG_API_KEY = 'off';
+    const result = await checkTelemetry();
+    expect(result.status).toBe('skip');
+    expect(result.message).toContain('POSTHOG_API_KEY');
+  });
+
+  it('returns skip with ARCHON_TELEMETRY_DISABLED reason when set', async () => {
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.CI;
+    delete process.env.POSTHOG_API_KEY;
+    process.env.ARCHON_TELEMETRY_DISABLED = '1';
+    const result = await checkTelemetry();
+    expect(result.status).toBe('skip');
+    expect(result.message).toContain('ARCHON_TELEMETRY_DISABLED');
+  });
 });
 
 describe('doctorCommand', () => {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -9,7 +9,7 @@ import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { execFileAsync } from '@archon/git';
-import { BUNDLED_IS_BINARY, getArchonHome, createLogger } from '@archon/paths';
+import { BUNDLED_IS_BINARY, getArchonHome, createLogger, getTelemetryStatus } from '@archon/paths';
 
 // Env vars that indicate a Pi backend API key is configured. Keep in sync with
 // `PI_BACKENDS` in setup.ts — these are the auth signals checkPi inspects.
@@ -204,6 +204,28 @@ export async function checkBundledDefaults(): Promise<CheckResult> {
   }
 }
 
+export async function checkTelemetry(): Promise<CheckResult> {
+  const label = 'Telemetry';
+  const status = getTelemetryStatus();
+  if (status.enabled) {
+    return {
+      label,
+      status: 'pass',
+      message: `anonymous, ${status.keySource} key (opt out: DO_NOT_TRACK=1)`,
+    };
+  }
+  const reasonText: Record<NonNullable<typeof status.disabledReason>, string> = {
+    ARCHON_TELEMETRY_DISABLED: 'ARCHON_TELEMETRY_DISABLED=1',
+    DO_NOT_TRACK: 'DO_NOT_TRACK=1',
+    CI: 'CI=true (auto-disabled)',
+    POSTHOG_API_KEY: 'POSTHOG_API_KEY set to off',
+  };
+  // disabledReason is always non-null when enabled is false; the fallback
+  // satisfies the type checker without changing observable behavior.
+  const reason = status.disabledReason ? reasonText[status.disabledReason] : 'disabled';
+  return { label, status: 'skip', message: `disabled (${reason})` };
+}
+
 export async function checkSlack(env: NodeJS.ProcessEnv): Promise<CheckResult> {
   const label = 'Slack';
   const token = env.SLACK_BOT_TOKEN;
@@ -282,6 +304,7 @@ export async function doctorCommand(
         checkDatabase(),
         checkWorkspaceWritable(),
         checkBundledDefaults(),
+        checkTelemetry(),
         checkSlack(env),
         checkTelegram(env),
       ];

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -214,16 +214,15 @@ export async function checkTelemetry(): Promise<CheckResult> {
       message: `anonymous, ${status.keySource} key (opt out: DO_NOT_TRACK=1)`,
     };
   }
-  const reasonText: Record<NonNullable<typeof status.disabledReason>, string> = {
+  // `status` is narrowed to the disabled arm here, so `disabledReason` is
+  // guaranteed non-null — no fallback branch needed.
+  const reasonText: Record<typeof status.disabledReason, string> = {
     ARCHON_TELEMETRY_DISABLED: 'ARCHON_TELEMETRY_DISABLED=1',
     DO_NOT_TRACK: 'DO_NOT_TRACK=1',
     CI: 'CI=true (auto-disabled)',
-    POSTHOG_API_KEY: 'POSTHOG_API_KEY set to off',
+    POSTHOG_API_KEY: 'POSTHOG_API_KEY set to an opt-out value',
   };
-  // disabledReason is always non-null when enabled is false; the fallback
-  // satisfies the type checker without changing observable behavior.
-  const reason = status.disabledReason ? reasonText[status.disabledReason] : 'disabled';
-  return { label, status: 'skip', message: `disabled (${reason})` };
+  return { label, status: 'skip', message: `disabled (${reasonText[status.disabledReason]})` };
 }
 
 export async function checkSlack(env: NodeJS.ProcessEnv): Promise<CheckResult> {

--- a/packages/cli/src/commands/telemetry.test.ts
+++ b/packages/cli/src/commands/telemetry.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { telemetryStatusCommand, telemetryResetCommand } from './telemetry';
+
+const ENV_VARS = [
+  'ARCHON_HOME',
+  'ARCHON_TELEMETRY_DISABLED',
+  'DO_NOT_TRACK',
+  'CI',
+  'POSTHOG_API_KEY',
+  'POSTHOG_HOST',
+] as const;
+
+describe('telemetryStatusCommand', () => {
+  let saved: Record<string, string | undefined>;
+  let tmpHome: string;
+  let logSpy: ReturnType<typeof spyOn<Console, 'log'>>;
+
+  beforeEach(() => {
+    saved = {};
+    for (const k of ENV_VARS) saved[k] = process.env[k];
+    tmpHome = mkdtempSync(join(tmpdir(), 'archon-cli-telemetry-'));
+    process.env.ARCHON_HOME = tmpHome;
+    logSpy = spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    for (const k of ENV_VARS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    logSpy.mockRestore();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  function output(): string {
+    return logSpy.mock.calls.flat().join('\n');
+  }
+
+  it('returns 0 and prints enabled state + opt-out hint when telemetry is on', () => {
+    delete process.env.ARCHON_TELEMETRY_DISABLED;
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.CI;
+    delete process.env.POSTHOG_API_KEY;
+    expect(telemetryStatusCommand()).toBe(0);
+    const out = output();
+    expect(out).toContain('Telemetry:   enabled');
+    expect(out).toContain('DO_NOT_TRACK=1');
+  });
+
+  it('prints the ARCHON_TELEMETRY_DISABLED reason and no opt-out hint when disabled', () => {
+    process.env.ARCHON_TELEMETRY_DISABLED = '1';
+    expect(telemetryStatusCommand()).toBe(0);
+    const out = output();
+    expect(out).toContain('Telemetry:   disabled');
+    expect(out).toContain('ARCHON_TELEMETRY_DISABLED=1 is set');
+    expect(out).not.toContain('Opt out anytime');
+  });
+
+  it('prints the CI reason when CI=true', () => {
+    delete process.env.ARCHON_TELEMETRY_DISABLED;
+    delete process.env.DO_NOT_TRACK;
+    process.env.CI = 'true';
+    telemetryStatusCommand();
+    expect(output()).toContain('CI=true detected');
+  });
+
+  it('prints the POSTHOG_API_KEY reason when set to an off value', () => {
+    delete process.env.ARCHON_TELEMETRY_DISABLED;
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.CI;
+    process.env.POSTHOG_API_KEY = 'off';
+    telemetryStatusCommand();
+    expect(output()).toContain('POSTHOG_API_KEY is set to an opt-out value');
+  });
+});
+
+describe('telemetryResetCommand', () => {
+  let saved: Record<string, string | undefined>;
+  let tmpHome: string;
+
+  beforeEach(() => {
+    saved = {};
+    for (const k of ENV_VARS) saved[k] = process.env[k];
+    tmpHome = mkdtempSync(join(tmpdir(), 'archon-cli-telemetry-reset-'));
+    process.env.ARCHON_HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    for (const k of ENV_VARS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('returns 0 and prints the new UUID on success', () => {
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    expect(telemetryResetCommand()).toBe(0);
+    expect(logSpy.mock.calls.flat().join(' ')).toContain('Rotated install UUID');
+    logSpy.mockRestore();
+  });
+
+  it('returns 1 and prints an error when the id file cannot be written', () => {
+    // Point ARCHON_HOME under a regular file so mkdir/write fails (ENOTDIR).
+    const filePath = join(tmpdir(), `archon-tel-notdir-${process.pid}-${tmpHome.length}`);
+    writeFileSync(filePath, 'x', 'utf8');
+    process.env.ARCHON_HOME = join(filePath, 'nested');
+    const errSpy = spyOn(console, 'error').mockImplementation(() => {});
+    expect(telemetryResetCommand()).toBe(1);
+    expect(errSpy.mock.calls.flat().join(' ')).toContain('failed to rotate telemetry ID');
+    errSpy.mockRestore();
+    rmSync(filePath, { force: true });
+  });
+});

--- a/packages/cli/src/commands/telemetry.ts
+++ b/packages/cli/src/commands/telemetry.ts
@@ -14,12 +14,13 @@ import { getTelemetryStatus, resetTelemetryId, type TelemetryStatus } from '@arc
 function formatStatus(status: TelemetryStatus): string {
   const lines: string[] = [];
   lines.push(`Telemetry:   ${status.enabled ? 'enabled' : 'disabled'}`);
-  if (!status.enabled && status.disabledReason) {
-    const explanation: Record<NonNullable<typeof status.disabledReason>, string> = {
+  if (!status.enabled) {
+    // Narrowed to the disabled arm: `disabledReason` is guaranteed non-null.
+    const explanation: Record<typeof status.disabledReason, string> = {
       ARCHON_TELEMETRY_DISABLED: 'ARCHON_TELEMETRY_DISABLED=1 is set',
       DO_NOT_TRACK: 'DO_NOT_TRACK=1 is set',
       CI: 'CI=true detected (auto-disabled in CI environments)',
-      POSTHOG_API_KEY: 'POSTHOG_API_KEY is set to an "off" value',
+      POSTHOG_API_KEY: 'POSTHOG_API_KEY is set to an opt-out value (off/0/false/disabled/empty)',
     };
     lines.push(`Reason:      ${explanation[status.disabledReason]}`);
   }

--- a/packages/cli/src/commands/telemetry.ts
+++ b/packages/cli/src/commands/telemetry.ts
@@ -1,0 +1,51 @@
+/**
+ * `archon telemetry` subcommands.
+ *
+ * `status` — print the current telemetry state (enabled/disabled, reason,
+ * distinct ID, host, key source). Useful for users who want to verify their
+ * opt-out is wired correctly without grepping env vars.
+ *
+ * `reset` — rotate the persisted install UUID at `${ARCHON_HOME}/telemetry-id`.
+ * The previous ID is overwritten and not recoverable. Useful when a user wants
+ * to "start fresh" for privacy reasons or when copying an install image.
+ */
+import { getTelemetryStatus, resetTelemetryId, type TelemetryStatus } from '@archon/paths';
+
+function formatStatus(status: TelemetryStatus): string {
+  const lines: string[] = [];
+  lines.push(`Telemetry:   ${status.enabled ? 'enabled' : 'disabled'}`);
+  if (!status.enabled && status.disabledReason) {
+    const explanation: Record<NonNullable<typeof status.disabledReason>, string> = {
+      ARCHON_TELEMETRY_DISABLED: 'ARCHON_TELEMETRY_DISABLED=1 is set',
+      DO_NOT_TRACK: 'DO_NOT_TRACK=1 is set',
+      CI: 'CI=true detected (auto-disabled in CI environments)',
+      POSTHOG_API_KEY: 'POSTHOG_API_KEY is set to an "off" value',
+    };
+    lines.push(`Reason:      ${explanation[status.disabledReason]}`);
+  }
+  lines.push(`Distinct ID: ${status.distinctId}`);
+  lines.push(`Host:        ${status.host}`);
+  lines.push(`Key source:  ${status.keySource}`);
+  return lines.join('\n');
+}
+
+export function telemetryStatusCommand(): number {
+  const status = getTelemetryStatus();
+  console.log(formatStatus(status));
+  if (status.enabled) {
+    console.log('\nOpt out anytime: DO_NOT_TRACK=1 or ARCHON_TELEMETRY_DISABLED=1');
+  }
+  return 0;
+}
+
+export function telemetryResetCommand(): number {
+  try {
+    const newId = resetTelemetryId();
+    console.log(`Rotated install UUID. New ID: ${newId}`);
+    return 0;
+  } catch (error) {
+    const err = error as Error;
+    console.error(`Error: failed to rotate telemetry ID: ${err.message}`);
+    return 1;
+  }
+}

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -86,7 +86,7 @@ archon setup --spawn              # open in a new terminal window
 
 ### `doctor`
 
-Verify your Archon setup. Runs a checklist of common failure points: Claude binary spawn, gh CLI auth, Pi auth (when Pi is configured as default), database reachability, workspace writability, bundled defaults, and adapter token pings (Slack/Telegram, best-effort).
+Verify your Archon setup. Runs a checklist of common failure points: Claude binary spawn, gh CLI auth, Pi auth (when Pi is configured as default), database reachability, workspace writability, bundled defaults, telemetry state, and adapter token pings (Slack/Telegram, best-effort).
 
 ```bash
 archon doctor
@@ -95,6 +95,26 @@ archon doctor
 Exit code 0 if all checks pass or are skipped; 1 if any critical check fails. Adapter pings degrade to `skip` on network errors — a flaky connection does not flip the result red.
 
 Also runs automatically at the end of `archon setup` (optional).
+
+### `telemetry status`
+
+Show the current anonymous telemetry state: whether it is enabled, the opt-out reason if not, the install UUID, the active PostHog host, and the key source.
+
+```bash
+archon telemetry status
+```
+
+Useful for verifying that an opt-out env var (`DO_NOT_TRACK=1`, `ARCHON_TELEMETRY_DISABLED=1`, `CI=true`, `POSTHOG_API_KEY=off`) is being picked up. Inspecting status never creates a `telemetry-id` file while opted out.
+
+### `telemetry reset`
+
+Rotate the persisted anonymous install UUID at `~/.archon/telemetry-id`. The previous ID is overwritten and not recoverable.
+
+```bash
+archon telemetry reset
+```
+
+Exit code 0 on success; 1 if the ID file cannot be written.
 
 ### `workflow list`
 

--- a/packages/docs-web/src/content/docs/reference/configuration.md
+++ b/packages/docs-web/src/content/docs/reference/configuration.md
@@ -345,6 +345,18 @@ The Copilot provider also reads `assistants.copilot.{model, modelReasoningEffort
 | `AUTH_SERVICE_PORT` | Port for the auth service container | `9000` |
 | `COOKIE_MAX_AGE` | Auth cookie lifetime in seconds | `86400` |
 
+### Telemetry
+
+Archon sends a single anonymous `workflow_invoked` event per workflow start (workflow name, platform, version, random install UUID). Any one of these disables it. See `archon telemetry status` to inspect the live state.
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `ARCHON_TELEMETRY_DISABLED` | Set to `1` to disable anonymous telemetry | -- |
+| `DO_NOT_TRACK` | Set to `1` to disable telemetry (de facto standard honored by Astro, Bun, Prisma, etc.) | -- |
+| `CI` | When set to `true` (case-insensitive), telemetry is auto-disabled so fork CI runs don't send events | -- |
+| `POSTHOG_API_KEY` | Set to `off` / `0` / `false` / `disabled` / empty to disable; set to a `phc_*` key to use a custom PostHog project | Built-in key |
+| `POSTHOG_HOST` | Custom PostHog instance URL (first failure on a custom host logs at `warn`) | `https://us.i.posthog.com` |
+
 ### `.env` File Locations
 
 Archon keys env loading on **directory ownership, not filename**. `.archon/` (at `~/` or `<cwd>/`) is archon-owned. Anything else is yours.

--- a/packages/paths/src/index.ts
+++ b/packages/paths/src/index.ts
@@ -55,5 +55,15 @@ export {
 export type { UpdateCheckResult } from './update-check';
 
 // Anonymous telemetry
-export { captureWorkflowInvoked, shutdownTelemetry, isTelemetryDisabled } from './telemetry';
-export type { WorkflowInvokedProperties } from './telemetry';
+export {
+  captureWorkflowInvoked,
+  shutdownTelemetry,
+  isTelemetryDisabled,
+  getTelemetryStatus,
+  resetTelemetryId,
+} from './telemetry';
+export type {
+  WorkflowInvokedProperties,
+  TelemetryStatus,
+  TelemetryDisabledReason,
+} from './telemetry';

--- a/packages/paths/src/telemetry.test.ts
+++ b/packages/paths/src/telemetry.test.ts
@@ -9,12 +9,15 @@ import {
   shutdownTelemetry,
   resetTelemetryForTests,
   getOrCreateTelemetryId,
+  getTelemetryStatus,
+  resetTelemetryId,
 } from './telemetry';
 
 const ENV_VARS = [
   'ARCHON_HOME',
   'ARCHON_TELEMETRY_DISABLED',
   'DO_NOT_TRACK',
+  'CI',
   'POSTHOG_API_KEY',
   'POSTHOG_HOST',
 ];
@@ -51,7 +54,24 @@ describe('telemetry opt-out detection', () => {
   test('enabled by default when no opt-out env vars set', () => {
     delete process.env.ARCHON_TELEMETRY_DISABLED;
     delete process.env.DO_NOT_TRACK;
+    delete process.env.CI;
     delete process.env.POSTHOG_API_KEY;
+    expect(isTelemetryDisabled()).toBe(false);
+  });
+
+  test('CI=true disables telemetry', () => {
+    delete process.env.ARCHON_TELEMETRY_DISABLED;
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.POSTHOG_API_KEY;
+    process.env.CI = 'true';
+    expect(isTelemetryDisabled()).toBe(true);
+  });
+
+  test('CI=1 does not disable (only CI=true is honored)', () => {
+    delete process.env.ARCHON_TELEMETRY_DISABLED;
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.POSTHOG_API_KEY;
+    process.env.CI = '1';
     expect(isTelemetryDisabled()).toBe(false);
   });
 
@@ -75,7 +95,128 @@ describe('telemetry opt-out detection', () => {
     process.env.POSTHOG_API_KEY = '';
     delete process.env.ARCHON_TELEMETRY_DISABLED;
     delete process.env.DO_NOT_TRACK;
+    delete process.env.CI;
     expect(isTelemetryDisabled()).toBe(true);
+  });
+
+  test.each(['off', 'OFF', '0', 'false', 'disabled'])(
+    'POSTHOG_API_KEY=%s disables telemetry',
+    value => {
+      process.env.POSTHOG_API_KEY = value;
+      delete process.env.ARCHON_TELEMETRY_DISABLED;
+      delete process.env.DO_NOT_TRACK;
+      delete process.env.CI;
+      expect(isTelemetryDisabled()).toBe(true);
+    }
+  );
+
+  test('POSTHOG_API_KEY=phc_custom is treated as enabled (self-host)', () => {
+    process.env.POSTHOG_API_KEY = 'phc_custom_self_hosted_key';
+    delete process.env.ARCHON_TELEMETRY_DISABLED;
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.CI;
+    expect(isTelemetryDisabled()).toBe(false);
+  });
+});
+
+describe('getTelemetryStatus', () => {
+  let saved: Record<string, string | undefined>;
+  let tmpHome: string;
+
+  beforeEach(() => {
+    saved = saveEnv();
+    tmpHome = mkdtempSync(join(tmpdir(), 'archon-telemetry-status-'));
+    process.env.ARCHON_HOME = tmpHome;
+    resetTelemetryForTests();
+  });
+
+  afterEach(() => {
+    restoreEnv(saved);
+    resetTelemetryForTests();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  test('reports enabled + embedded key source when no env vars set', () => {
+    delete process.env.ARCHON_TELEMETRY_DISABLED;
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.CI;
+    delete process.env.POSTHOG_API_KEY;
+    const status = getTelemetryStatus();
+    expect(status.enabled).toBe(true);
+    expect(status.disabledReason).toBeNull();
+    expect(status.keySource).toBe('embedded');
+    expect(status.distinctId).toMatch(/^[0-9a-f-]+$/);
+    expect(status.host).toContain('posthog');
+  });
+
+  test('reports CI as the disabled reason', () => {
+    delete process.env.ARCHON_TELEMETRY_DISABLED;
+    delete process.env.DO_NOT_TRACK;
+    process.env.CI = 'true';
+    const status = getTelemetryStatus();
+    expect(status.enabled).toBe(false);
+    expect(status.disabledReason).toBe('CI');
+  });
+
+  test('reports POSTHOG_API_KEY when explicit "off" value is set', () => {
+    delete process.env.ARCHON_TELEMETRY_DISABLED;
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.CI;
+    process.env.POSTHOG_API_KEY = 'off';
+    const status = getTelemetryStatus();
+    expect(status.enabled).toBe(false);
+    expect(status.disabledReason).toBe('POSTHOG_API_KEY');
+    expect(status.keySource).toBe('none');
+  });
+
+  test('reports env key source for non-default API key', () => {
+    delete process.env.ARCHON_TELEMETRY_DISABLED;
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.CI;
+    process.env.POSTHOG_API_KEY = 'phc_self_hosted';
+    const status = getTelemetryStatus();
+    expect(status.enabled).toBe(true);
+    expect(status.keySource).toBe('env');
+  });
+
+  test('precedence: ARCHON_TELEMETRY_DISABLED wins over CI', () => {
+    process.env.ARCHON_TELEMETRY_DISABLED = '1';
+    process.env.CI = 'true';
+    expect(getTelemetryStatus().disabledReason).toBe('ARCHON_TELEMETRY_DISABLED');
+  });
+});
+
+describe('resetTelemetryId', () => {
+  let saved: Record<string, string | undefined>;
+  let tmpHome: string;
+
+  beforeEach(() => {
+    saved = saveEnv();
+    tmpHome = mkdtempSync(join(tmpdir(), 'archon-telemetry-reset-'));
+    process.env.ARCHON_HOME = tmpHome;
+    resetTelemetryForTests();
+  });
+
+  afterEach(() => {
+    restoreEnv(saved);
+    resetTelemetryForTests();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  test('writes a new UUID to telemetry-id and returns it', () => {
+    const id1 = getOrCreateTelemetryId();
+    const id2 = resetTelemetryId();
+    expect(id2).not.toBe(id1);
+    expect(id2).toMatch(/^[0-9a-f-]+$/);
+    const onDisk = readFileSync(join(tmpHome, 'telemetry-id'), 'utf8').trim();
+    expect(onDisk).toBe(id2);
+  });
+
+  test('updates the in-process cache so subsequent calls see the new ID', () => {
+    resetTelemetryId();
+    const cached = getOrCreateTelemetryId();
+    const onDisk = readFileSync(join(tmpHome, 'telemetry-id'), 'utf8').trim();
+    expect(cached).toBe(onDisk);
   });
 });
 
@@ -97,7 +238,6 @@ describe('captureWorkflowInvoked when disabled', () => {
     expect(() => {
       captureWorkflowInvoked({
         workflowName: 'test-workflow',
-        workflowDescription: 'A test',
         platform: 'cli',
         archonVersion: 'dev',
       });

--- a/packages/paths/src/telemetry.test.ts
+++ b/packages/paths/src/telemetry.test.ts
@@ -1,7 +1,7 @@
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 
 import {
   isTelemetryDisabled,
@@ -67,13 +67,24 @@ describe('telemetry opt-out detection', () => {
     expect(isTelemetryDisabled()).toBe(true);
   });
 
-  test('CI=1 does not disable (only CI=true is honored)', () => {
+  test('CI=1 does not disable (only "true" is honored, not "1")', () => {
     delete process.env.ARCHON_TELEMETRY_DISABLED;
     delete process.env.DO_NOT_TRACK;
     delete process.env.POSTHOG_API_KEY;
     process.env.CI = '1';
     expect(isTelemetryDisabled()).toBe(false);
   });
+
+  test.each(['true', 'True', 'TRUE'])(
+    'CI=%s disables (case-insensitive, AppVeyor sets True)',
+    value => {
+      delete process.env.ARCHON_TELEMETRY_DISABLED;
+      delete process.env.DO_NOT_TRACK;
+      delete process.env.POSTHOG_API_KEY;
+      process.env.CI = value;
+      expect(isTelemetryDisabled()).toBe(true);
+    }
+  );
 
   test('ARCHON_TELEMETRY_DISABLED=1 disables telemetry', () => {
     process.env.ARCHON_TELEMETRY_DISABLED = '1';
@@ -143,12 +154,25 @@ describe('getTelemetryStatus', () => {
     delete process.env.DO_NOT_TRACK;
     delete process.env.CI;
     delete process.env.POSTHOG_API_KEY;
+    delete process.env.POSTHOG_HOST;
     const status = getTelemetryStatus();
     expect(status.enabled).toBe(true);
     expect(status.disabledReason).toBeNull();
     expect(status.keySource).toBe('embedded');
     expect(status.distinctId).toMatch(/^[0-9a-f-]+$/);
     expect(status.host).toContain('posthog');
+  });
+
+  test('does not create a telemetry-id file when inspected while disabled', () => {
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.CI;
+    delete process.env.POSTHOG_API_KEY;
+    process.env.ARCHON_TELEMETRY_DISABLED = '1';
+    const status = getTelemetryStatus();
+    expect(status.enabled).toBe(false);
+    expect(status.distinctId).toMatch(/^[0-9a-f-]+$/);
+    // Opted-out users inspecting status must not have a UUID materialized for them.
+    expect(existsSync(join(tmpHome, 'telemetry-id'))).toBe(false);
   });
 
   test('reports CI as the disabled reason', () => {
@@ -219,6 +243,86 @@ describe('resetTelemetryId', () => {
     const cached = getOrCreateTelemetryId();
     const onDisk = readFileSync(join(tmpHome, 'telemetry-id'), 'utf8').trim();
     expect(cached).toBe(onDisk);
+  });
+});
+
+describe('first-run notice (via captureWorkflowInvoked)', () => {
+  let saved: Record<string, string | undefined>;
+  let tmpHome: string;
+  let originalIsTTY: boolean | undefined;
+  const stampPath = (): string => join(tmpHome, 'telemetry-notice-shown');
+
+  beforeEach(() => {
+    saved = saveEnv();
+    tmpHome = mkdtempSync(join(tmpdir(), 'archon-telemetry-notice-'));
+    process.env.ARCHON_HOME = tmpHome;
+    // Telemetry must be enabled for the notice path to be reachable.
+    delete process.env.ARCHON_TELEMETRY_DISABLED;
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.CI;
+    delete process.env.POSTHOG_API_KEY;
+    originalIsTTY = process.stderr.isTTY;
+    resetTelemetryForTests();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stderr, 'isTTY', { value: originalIsTTY, configurable: true });
+    restoreEnv(saved);
+    resetTelemetryForTests();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  function setTTY(value: boolean): void {
+    Object.defineProperty(process.stderr, 'isTTY', { value, configurable: true });
+  }
+
+  test('does not write the notice when stderr is not a TTY', () => {
+    setTTY(false);
+    const writeSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+    captureWorkflowInvoked({ workflowName: 'w' });
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(existsSync(stampPath())).toBe(false);
+    writeSpy.mockRestore();
+  });
+
+  test('writes the notice once on first invocation (TTY, no stamp) and stamps it', () => {
+    setTTY(true);
+    const writeSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+    captureWorkflowInvoked({ workflowName: 'w' });
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    expect(String(writeSpy.mock.calls[0]?.[0])).toContain('anonymous usage telemetry');
+    expect(existsSync(stampPath())).toBe(true);
+    writeSpy.mockRestore();
+  });
+
+  test('does not write again in the same process (noticeChecked guard)', () => {
+    setTTY(true);
+    const writeSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+    captureWorkflowInvoked({ workflowName: 'w' });
+    captureWorkflowInvoked({ workflowName: 'w2' });
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    writeSpy.mockRestore();
+  });
+
+  test('skips the notice when the stamp file already exists (cross-run idempotency)', () => {
+    mkdirSync(tmpHome, { recursive: true });
+    writeFileSync(stampPath(), '2026-01-01T00:00:00.000Z', 'utf8');
+    setTTY(true);
+    const writeSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+    captureWorkflowInvoked({ workflowName: 'w' });
+    expect(writeSpy).not.toHaveBeenCalled();
+    writeSpy.mockRestore();
+  });
+
+  test('does not write the notice when telemetry is disabled', () => {
+    setTTY(true);
+    process.env.DO_NOT_TRACK = '1';
+    resetTelemetryForTests();
+    const writeSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+    captureWorkflowInvoked({ workflowName: 'w' });
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(existsSync(stampPath())).toBe(false);
+    writeSpy.mockRestore();
   });
 });
 

--- a/packages/paths/src/telemetry.test.ts
+++ b/packages/paths/src/telemetry.test.ts
@@ -88,6 +88,8 @@ describe('telemetry opt-out detection', () => {
   test('ARCHON_TELEMETRY_DISABLED=0 does not disable (strict "1" match)', () => {
     process.env.ARCHON_TELEMETRY_DISABLED = '0';
     delete process.env.DO_NOT_TRACK;
+    delete process.env.CI;
+    delete process.env.POSTHOG_API_KEY;
     expect(isTelemetryDisabled()).toBe(false);
   });
 

--- a/packages/paths/src/telemetry.ts
+++ b/packages/paths/src/telemetry.ts
@@ -4,15 +4,18 @@
  * Emits one event — `workflow_invoked` — each time a workflow starts. No PII,
  * no user identity. A random UUID is persisted to `${ARCHON_HOME}/telemetry-id`
  * so we can count distinct installs; `$process_person_profile: false` keeps
- * events in PostHog's anonymous tier (no person profile ever created).
+ * events in PostHog's anonymous tier (no person profile ever created); `$ip: ''`
+ * prevents PostHog from retaining the source IP at ingest.
  *
  * Opt-out (any one disables telemetry):
  *   - ARCHON_TELEMETRY_DISABLED=1
- *   - DO_NOT_TRACK=1                   (de facto standard)
- *   - POSTHOG_API_KEY unset *and* no embedded default
+ *   - DO_NOT_TRACK=1                          (de facto standard)
+ *   - CI=true                                 (auto-disabled in CI environments)
+ *   - POSTHOG_API_KEY=off | 0 | false | disabled | ''
  *
- * All functions are fire-and-forget: telemetry errors are logged at debug level
- * and swallowed. Capture must never crash Archon.
+ * All capture functions are fire-and-forget: telemetry errors are swallowed
+ * (logged at `debug`, with the first network failure also logged at `warn`
+ * so self-hosters notice typo'd hosts). Capture must never crash Archon.
  */
 import { randomUUID } from 'crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
@@ -41,13 +44,17 @@ interface PostHogFetchResponse {
 /**
  * Embedded write-only PostHog project key. Safe to ship in source: `phc_*`
  * keys can only write events, never read data. Override with POSTHOG_API_KEY
- * for self-hosted PostHog or a different project.
+ * for self-hosted PostHog or a different project, or set it to `off` / `0` /
+ * `false` / `disabled` / empty string to opt out entirely.
  */
 const EMBEDDED_POSTHOG_API_KEY = 'phc_rR7oacut9mm4upGRbuoMptnyjRium34TTbbqobiQYS7x';
 const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com';
 
-/** Max length of workflow description sent to PostHog. Guards against unusually long YAML descriptions. */
-const DESCRIPTION_MAX_LENGTH = 500;
+/**
+ * Filename for the one-time notice stamp written to ARCHON_HOME. Presence
+ * means the first-run notice has been shown; absence means it hasn't.
+ */
+const NOTICE_STAMP_FILENAME = 'telemetry-notice-shown';
 
 let cachedLog: ReturnType<typeof createLogger> | undefined;
 function getLog(): ReturnType<typeof createLogger> {
@@ -55,23 +62,87 @@ function getLog(): ReturnType<typeof createLogger> {
   return cachedLog;
 }
 
-function getApiKey(): string {
-  return process.env.POSTHOG_API_KEY ?? EMBEDDED_POSTHOG_API_KEY;
+/** Values of POSTHOG_API_KEY that are interpreted as "explicitly disabled". */
+const KEY_OFF_VALUES = new Set(['', 'off', '0', 'false', 'disabled']);
+
+/**
+ * Resolve the effective PostHog API key.
+ *
+ * - Unset env var → embedded default
+ * - Env var set to a recognized "off" sentinel → `null` (caller treats as opt-out)
+ * - Env var set to anything else → that value (self-hosted / alternate project)
+ */
+function getApiKey(): string | null {
+  const env = process.env.POSTHOG_API_KEY;
+  if (env === undefined) return EMBEDDED_POSTHOG_API_KEY;
+  const trimmed = env.trim();
+  if (KEY_OFF_VALUES.has(trimmed.toLowerCase())) return null;
+  return trimmed;
 }
 
 function getHost(): string {
   return process.env.POSTHOG_HOST ?? DEFAULT_POSTHOG_HOST;
 }
 
+/** Why telemetry is currently disabled. `null` means it's enabled. */
+export type TelemetryDisabledReason =
+  | 'ARCHON_TELEMETRY_DISABLED'
+  | 'DO_NOT_TRACK'
+  | 'CI'
+  | 'POSTHOG_API_KEY';
+
+export interface TelemetryStatus {
+  enabled: boolean;
+  /** Populated only when `enabled` is `false`. */
+  disabledReason: TelemetryDisabledReason | null;
+  /** Stable anonymous install UUID (always populated, even when disabled). */
+  distinctId: string;
+  /** PostHog ingest host. */
+  host: string;
+  /** Whether the active API key is the embedded default or a user override. */
+  keySource: 'embedded' | 'env' | 'none';
+}
+
 /**
- * Check whether telemetry is disabled via env vars or missing key.
- * Exported for tests and callers that want to short-circuit early.
+ * Decide whether telemetry is disabled, and if so, why. The order here is
+ * also the precedence order: the first matching reason wins.
+ */
+function resolveDisabledReason(): TelemetryDisabledReason | null {
+  if (process.env.ARCHON_TELEMETRY_DISABLED === '1') return 'ARCHON_TELEMETRY_DISABLED';
+  if (process.env.DO_NOT_TRACK === '1') return 'DO_NOT_TRACK';
+  // Standard CI env var set by GitHub Actions, CircleCI, GitLab CI, Travis,
+  // Buildkite, etc. Forks running fixtures in CI shouldn't pollute telemetry.
+  if (process.env.CI === 'true') return 'CI';
+  if (getApiKey() === null) return 'POSTHOG_API_KEY';
+  return null;
+}
+
+/**
+ * Check whether telemetry is disabled via env vars or missing/disabled key.
+ * Kept for backwards compatibility; new callers should prefer
+ * {@link getTelemetryStatus} for richer information.
  */
 export function isTelemetryDisabled(): boolean {
-  if (process.env.ARCHON_TELEMETRY_DISABLED === '1') return true;
-  if (process.env.DO_NOT_TRACK === '1') return true;
-  if (!getApiKey()) return true;
-  return false;
+  return resolveDisabledReason() !== null;
+}
+
+/**
+ * Return the full current telemetry state — enabled/disabled, reason,
+ * distinct ID, host, and key source. Used by `archon telemetry status` and
+ * `archon doctor` to surface what's happening without duplicating logic.
+ */
+export function getTelemetryStatus(): TelemetryStatus {
+  const reason = resolveDisabledReason();
+  const apiKey = getApiKey();
+  const keySource: 'embedded' | 'env' | 'none' =
+    apiKey === null ? 'none' : process.env.POSTHOG_API_KEY !== undefined ? 'env' : 'embedded';
+  return {
+    enabled: reason === null,
+    disabledReason: reason,
+    distinctId: getTelemetryId(),
+    host: getHost(),
+    keySource,
+  };
 }
 
 /**
@@ -112,6 +183,64 @@ function getTelemetryId(): string {
 }
 
 /**
+ * Force-rotate the persisted install UUID. Returns the new ID. Used by
+ * `archon telemetry reset`. Caller is responsible for any UX around it.
+ */
+export function resetTelemetryId(): string {
+  const idPath = join(getArchonHome(), 'telemetry-id');
+  const newId = randomUUID();
+  mkdirSync(getArchonHome(), { recursive: true });
+  writeFileSync(idPath, newId, 'utf8');
+  telemetryIdCache = newId;
+  return newId;
+}
+
+/**
+ * Show a one-time stderr notice that telemetry is collected, then stamp the
+ * notice file so we don't show it again. Skipped when:
+ *   - telemetry is disabled (no point notifying about a no-op)
+ *   - the stamp file already exists
+ *   - stderr is not a TTY (avoid polluting scripted / piped output)
+ *
+ * Idempotent in-process via `noticeChecked` so the worst case is one stat()
+ * per process, not one per workflow.
+ */
+let noticeChecked = false;
+function maybeShowFirstRunNotice(): void {
+  if (noticeChecked) return;
+  noticeChecked = true;
+
+  if (!process.stderr.isTTY) return;
+
+  const stampPath = join(getArchonHome(), NOTICE_STAMP_FILENAME);
+  try {
+    if (existsSync(stampPath)) return;
+  } catch (error) {
+    getLog().debug({ err: error as Error, stampPath }, 'telemetry.notice_stat_failed');
+    return;
+  }
+
+  const message =
+    'Archon collects anonymous usage telemetry (workflow name, platform, version).\n' +
+    'No code, prompts, file paths, or personal data — see README "Telemetry" for details.\n' +
+    'Opt out anytime: DO_NOT_TRACK=1 or ARCHON_TELEMETRY_DISABLED=1\n';
+  try {
+    process.stderr.write(`\n${message}\n`);
+  } catch (error) {
+    getLog().debug({ err: error as Error }, 'telemetry.notice_write_failed');
+  }
+
+  try {
+    mkdirSync(getArchonHome(), { recursive: true });
+    writeFileSync(stampPath, new Date().toISOString(), 'utf8');
+  } catch (error) {
+    // Failure here means we'll re-show the notice on the next run; annoying
+    // but not broken. Log so repeat failures leave a diagnostic trace.
+    getLog().debug({ err: error as Error, stampPath }, 'telemetry.notice_stamp_failed');
+  }
+}
+
+/**
  * Lazy singleton. `undefined` = not yet initialized; `null` = disabled or
  * init failed; `PostHog` = live client. Init runs once per process.
  */
@@ -131,8 +260,11 @@ async function getClient(): Promise<PostHog | null> {
  * `posthog-core-stateless.mjs` `logFlushError`). For a fire-and-forget
  * telemetry path we want zero user-visible noise when PostHog is unreachable
  * (offline, firewalled, DNS broken, rate-limited), so we intercept failures
- * before the SDK sees them. The original error is still recorded at debug
- * level.
+ * before the SDK sees them.
+ *
+ * Self-hosters using POSTHOG_HOST need *some* feedback when they typo a URL,
+ * so the first failure in a process is logged at `warn` (visible at default
+ * log levels). Subsequent failures drop to `debug` to stay quiet.
  */
 const FAKE_OK_RESPONSE: PostHogFetchResponse = {
   status: 200,
@@ -141,6 +273,19 @@ const FAKE_OK_RESPONSE: PostHogFetchResponse = {
   headers: { get: () => null },
 };
 
+let firstFailureLogged = false;
+function logFetchFailure(ctx: { status?: number; err?: Error }, event: string): void {
+  if (!firstFailureLogged) {
+    firstFailureLogged = true;
+    getLog().warn(
+      { ...ctx, host: getHost() },
+      `${event} (first failure shown; subsequent suppressed to debug)`
+    );
+    return;
+  }
+  getLog().debug(ctx, event);
+}
+
 async function silentFetch(
   url: string,
   options: PostHogFetchOptions
@@ -148,21 +293,23 @@ async function silentFetch(
   try {
     const res = await fetch(url, options as RequestInit);
     if (res.status < 200 || res.status >= 400) {
-      getLog().debug({ status: res.status }, 'telemetry.http_non_2xx_suppressed');
+      logFetchFailure({ status: res.status }, 'telemetry.http_non_2xx_suppressed');
       return FAKE_OK_RESPONSE;
     }
     return res;
   } catch (error) {
-    getLog().debug({ err: error as Error }, 'telemetry.fetch_failed_suppressed');
+    logFetchFailure({ err: error as Error }, 'telemetry.fetch_failed_suppressed');
     return FAKE_OK_RESPONSE;
   }
 }
 
 async function initClient(): Promise<PostHog | null> {
   if (isTelemetryDisabled()) return null;
+  const apiKey = getApiKey();
+  if (apiKey === null) return null;
   try {
     const posthogModule = await import('posthog-node');
-    const client = new posthogModule.PostHog(getApiKey(), {
+    const client = new posthogModule.PostHog(apiKey, {
       host: getHost(),
       flushAt: 20,
       flushInterval: 10000,
@@ -184,29 +331,31 @@ async function initClient(): Promise<PostHog | null> {
 
 export interface WorkflowInvokedProperties {
   workflowName: string;
-  workflowDescription?: string;
   platform?: string;
   archonVersion?: string;
 }
 
 /**
  * Fire-and-forget capture of a `workflow_invoked` event. Never throws, never
- * awaits — safe to call from hot paths.
+ * awaits — safe to call from hot paths. Shows the first-run notice on first
+ * invocation when telemetry is enabled and stderr is interactive.
  */
 export function captureWorkflowInvoked(props: WorkflowInvokedProperties): void {
   if (isTelemetryDisabled()) return;
+  maybeShowFirstRunNotice();
   void (async (): Promise<void> => {
     try {
       const client = await getClient();
       if (!client) return;
-      const description = props.workflowDescription?.slice(0, DESCRIPTION_MAX_LENGTH);
       client.capture({
         distinctId: getTelemetryId(),
         event: 'workflow_invoked',
         properties: {
           $process_person_profile: false,
+          // Strip source IP at ingest. `disableGeoip: true` only prevents geo
+          // enrichment; `$ip: ''` drops the IP from the event entirely.
+          $ip: '',
           workflow_name: props.workflowName,
-          ...(description ? { workflow_description: description } : {}),
           ...(props.platform ? { platform: props.platform } : {}),
           ...(props.archonVersion ? { archon_version: props.archonVersion } : {}),
         },
@@ -243,4 +392,6 @@ export async function shutdownTelemetry(): Promise<void> {
 export function resetTelemetryForTests(): void {
   clientInit = undefined;
   telemetryIdCache = undefined;
+  noticeChecked = false;
+  firstFailureLogged = false;
 }

--- a/packages/paths/src/telemetry.ts
+++ b/packages/paths/src/telemetry.ts
@@ -11,11 +11,12 @@
  *   - ARCHON_TELEMETRY_DISABLED=1
  *   - DO_NOT_TRACK=1                          (de facto standard)
  *   - CI=true                                 (auto-disabled in CI environments)
- *   - POSTHOG_API_KEY=off | 0 | false | disabled | ''
+ *   - POSTHOG_API_KEY=off | 0 | false | disabled | '' (or whitespace-only)
  *
  * All capture functions are fire-and-forget: telemetry errors are swallowed
- * (logged at `debug`, with the first network failure also logged at `warn`
- * so self-hosters notice typo'd hosts). Capture must never crash Archon.
+ * (logged at `debug`, with the first network failure on a custom POSTHOG_HOST
+ * also logged at `warn` so self-hosters notice typo'd hosts). Capture must
+ * never crash Archon.
  */
 import { randomUUID } from 'crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
@@ -91,17 +92,31 @@ export type TelemetryDisabledReason =
   | 'CI'
   | 'POSTHOG_API_KEY';
 
-export interface TelemetryStatus {
-  enabled: boolean;
-  /** Populated only when `enabled` is `false`. */
-  disabledReason: TelemetryDisabledReason | null;
+interface TelemetryStatusBase {
   /** Stable anonymous install UUID (always populated, even when disabled). */
   distinctId: string;
   /** PostHog ingest host. */
   host: string;
-  /** Whether the active API key is the embedded default or a user override. */
-  keySource: 'embedded' | 'env' | 'none';
 }
+
+/**
+ * Full current telemetry state. Discriminated on `enabled` so an enabled status
+ * can never carry a `disabledReason` (and vice versa), and so `keySource: 'none'`
+ * is only representable in the disabled arm.
+ */
+export type TelemetryStatus =
+  | (TelemetryStatusBase & {
+      enabled: true;
+      disabledReason: null;
+      /** Whether the active API key is the embedded default or a user override. */
+      keySource: 'embedded' | 'env';
+    })
+  | (TelemetryStatusBase & {
+      enabled: false;
+      disabledReason: TelemetryDisabledReason;
+      /** `'none'` means POSTHOG_API_KEY was set to an opt-out value. */
+      keySource: 'embedded' | 'env' | 'none';
+    });
 
 /**
  * Decide whether telemetry is disabled, and if so, why. The order here is
@@ -112,7 +127,9 @@ function resolveDisabledReason(): TelemetryDisabledReason | null {
   if (process.env.DO_NOT_TRACK === '1') return 'DO_NOT_TRACK';
   // Standard CI env var set by GitHub Actions, CircleCI, GitLab CI, Travis,
   // Buildkite, etc. Forks running fixtures in CI shouldn't pollute telemetry.
-  if (process.env.CI === 'true') return 'CI';
+  // Matched case-insensitively because AppVeyor sets `CI=True`; `CI=1` is left
+  // alone (rare, and we keep the match narrow to "true").
+  if (process.env.CI?.toLowerCase() === 'true') return 'CI';
   if (getApiKey() === null) return 'POSTHOG_API_KEY';
   return null;
 }
@@ -133,14 +150,27 @@ export function isTelemetryDisabled(): boolean {
  */
 export function getTelemetryStatus(): TelemetryStatus {
   const reason = resolveDisabledReason();
-  const apiKey = getApiKey();
+  const host = getHost();
+  const envKeySet = process.env.POSTHOG_API_KEY !== undefined;
+  if (reason === null) {
+    // Enabled: a usable key exists, so keySource is embedded or env (never none).
+    return {
+      enabled: true,
+      disabledReason: null,
+      distinctId: getTelemetryId(),
+      host,
+      keySource: envKeySet ? 'env' : 'embedded',
+    };
+  }
+  // Disabled: read the install UUID without creating it, so inspecting status
+  // while opted out never materializes a telemetry-id file the user didn't ask for.
   const keySource: 'embedded' | 'env' | 'none' =
-    apiKey === null ? 'none' : process.env.POSTHOG_API_KEY !== undefined ? 'env' : 'embedded';
+    getApiKey() === null ? 'none' : envKeySet ? 'env' : 'embedded';
   return {
-    enabled: reason === null,
+    enabled: false,
     disabledReason: reason,
-    distinctId: getTelemetryId(),
-    host: getHost(),
+    distinctId: peekTelemetryId(),
+    host,
     keySource,
   };
 }
@@ -183,8 +213,33 @@ function getTelemetryId(): string {
 }
 
 /**
+ * Read the persisted install UUID without creating it. Returns a fresh,
+ * unpersisted UUID when none exists yet. Used for status display while
+ * telemetry is disabled, so inspecting state (`telemetry status` / `doctor`)
+ * never writes a `telemetry-id` file for an opted-out user.
+ */
+function peekTelemetryId(): string {
+  const idPath = join(getArchonHome(), 'telemetry-id');
+  try {
+    if (existsSync(idPath)) {
+      const existing = readFileSync(idPath, 'utf8').trim();
+      if (existing) return existing;
+    }
+  } catch (error) {
+    getLog().debug({ err: error as Error, idPath }, 'telemetry.id_read_failed');
+  }
+  return randomUUID();
+}
+
+/**
  * Force-rotate the persisted install UUID. Returns the new ID. Used by
  * `archon telemetry reset`. Caller is responsible for any UX around it.
+ *
+ * Unlike the other functions here, this is NOT fire-and-forget: it is a
+ * deliberate, user-initiated write, so filesystem errors propagate.
+ * @throws {NodeJS.ErrnoException} if ARCHON_HOME can't be created or the id
+ *   file can't be written (e.g. EACCES, ENOSPC). The CLI caller
+ *   (`telemetryResetCommand`) catches this and exits non-zero.
  */
 export function resetTelemetryId(): string {
   const idPath = join(getArchonHome(), 'telemetry-id');
@@ -210,6 +265,10 @@ function maybeShowFirstRunNotice(): void {
   if (noticeChecked) return;
   noticeChecked = true;
 
+  // Self-contained guards so the function is safe for any caller, not just
+  // captureWorkflowInvoked: never notify about telemetry that won't be sent,
+  // and never pollute scripted / piped output.
+  if (isTelemetryDisabled()) return;
   if (!process.stderr.isTTY) return;
 
   const stampPath = join(getArchonHome(), NOTICE_STAMP_FILENAME);
@@ -234,8 +293,9 @@ function maybeShowFirstRunNotice(): void {
     mkdirSync(getArchonHome(), { recursive: true });
     writeFileSync(stampPath, new Date().toISOString(), 'utf8');
   } catch (error) {
-    // Failure here means we'll re-show the notice on the next run; annoying
-    // but not broken. Log so repeat failures leave a diagnostic trace.
+    // Failure here means we'll re-show the notice on the next process run (the
+    // in-process `noticeChecked` guard still prevents a repeat this run);
+    // annoying but not broken. Log so repeat failures leave a diagnostic trace.
     getLog().debug({ err: error as Error, stampPath }, 'telemetry.notice_stamp_failed');
   }
 }
@@ -258,13 +318,14 @@ async function getClient(): Promise<PostHog | null> {
  * internal `logFlushError` writes to stderr via `console.error` on any network
  * or HTTP error, bypassing logger configuration (see `@posthog/core`
  * `posthog-core-stateless.mjs` `logFlushError`). For a fire-and-forget
- * telemetry path we want zero user-visible noise when PostHog is unreachable
- * (offline, firewalled, DNS broken, rate-limited), so we intercept failures
- * before the SDK sees them.
+ * telemetry path we want no user-visible noise on the default host when
+ * PostHog is unreachable (offline, firewalled, DNS broken, rate-limited), so
+ * we intercept failures before the SDK sees them.
  *
- * Self-hosters using POSTHOG_HOST need *some* feedback when they typo a URL,
- * so the first failure in a process is logged at `warn` (visible at default
- * log levels). Subsequent failures drop to `debug` to stay quiet.
+ * Self-hosters who override POSTHOG_HOST need *some* feedback when they typo a
+ * URL, so on a custom host the first failure in a process is logged at `warn`
+ * (visible at default log levels) and subsequent failures drop to `debug`.
+ * On the default host every failure stays at `debug`.
  */
 const FAKE_OK_RESPONSE: PostHogFetchResponse = {
   status: 200,
@@ -275,7 +336,10 @@ const FAKE_OK_RESPONSE: PostHogFetchResponse = {
 
 let firstFailureLogged = false;
 function logFetchFailure(ctx: { status?: number; err?: Error }, event: string): void {
-  if (!firstFailureLogged) {
+  // Only self-hosters (POSTHOG_HOST overridden) get a visible warning about a
+  // typo'd host. Default-host users who are simply offline/firewalled stay at
+  // `debug`, per the "no user-visible noise on the default host" goal above.
+  if (process.env.POSTHOG_HOST !== undefined && !firstFailureLogged) {
     firstFailureLogged = true;
     getLog().warn(
       { ...ctx, host: getHost() },
@@ -361,6 +425,8 @@ export function captureWorkflowInvoked(props: WorkflowInvokedProperties): void {
         },
       });
     } catch (error) {
+      // Fire-and-forget: telemetry must never crash Archon, so swallow every
+      // error here (network, SDK, malformed props) and record it at debug.
       getLog().debug({ err: error as Error }, 'telemetry.capture_failed');
     }
   })();

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -556,12 +556,12 @@ export async function executeWorkflow(
       conversationId: conversationDbId,
     });
 
-    // Fire-and-forget anonymous usage telemetry. No PII: only workflow name +
-    // description (authored by the user in their YAML) + platform + version.
-    // Opt out via ARCHON_TELEMETRY_DISABLED=1 or DO_NOT_TRACK=1.
+    // Fire-and-forget anonymous usage telemetry. No PII: workflow name +
+    // platform + version only. Workflow descriptions are user-authored YAML
+    // and may contain private context ("Deploy ACME prod"), so they are not
+    // included. Opt out via ARCHON_TELEMETRY_DISABLED=1 / DO_NOT_TRACK=1.
     captureWorkflowInvoked({
       workflowName: workflow.name,
-      workflowDescription: workflow.description,
       platform: platform.getPlatformType(),
       archonVersion: BUNDLED_VERSION,
     });


### PR DESCRIPTION
## Summary

- **Problem:** The PostHog telemetry path had several gaps that hurt trust and data quality: forks' CI emitted real events, users had no first-run signal that data was being collected, the `POSTHOG_API_KEY` opt-out branch was effectively dead code, self-hosters got zero feedback for a typo'd host, there was no way to inspect/reset state, the event payload included user-authored workflow descriptions (potentially private), and the source IP was retained at ingest.
- **Why it matters:** Clones and forks send to the same embedded `phc_*` key. Every gap above either inflates the dataset with garbage signal or quietly does something the user didn't expect. Several of these are now expected hygiene for open-source telemetry (Next.js, Astro, Bun, Prisma all do CI auto-disable + first-run notice).
- **What changed:** Seven coordinated fixes in `packages/paths/src/telemetry.ts` plus a new `archon telemetry status|reset` CLI subcommand and a `Telemetry` check in `archon doctor`. Full list in the commit message.
- **What did NOT change (scope boundary):** No new event types, no new payload properties beyond `$ip: ''`, no change to the embedded `phc_*` write-only key, no change to existing opt-out env vars. Adding `workflow_completed` (outcome event) and install metadata (OS/arch/install-method) are intentionally deferred to a follow-up.

## UX Journey

### Before

```
First clone & run                         PostHog
─────────────────                         ───────
$ git clone … && bun run cli              event(workflow_invoked)
    workflow run plan "..."     ──────▶   distinctId: <random>
                                          workflow_description: "Deploy ACME prod"   ← user-authored
                                          $ip: <client IP retained>
(user has no idea data was sent)

$ archon telemetry status         ✗ no such command
$ archon doctor                   ✗ no telemetry row
POSTHOG_API_KEY=off bun run cli   ✗ silently falls through, events still sent
                                  (only POSTHOG_API_KEY="" disables)
POSTHOG_HOST=https://typo.local   ✗ all flushes "succeed", user sees nothing
```

### After

```
First clone & run                         PostHog
─────────────────                         ───────
$ git clone … && bun run cli              [stderr, one time]
    workflow run plan "..."               * Archon collects anonymous usage telemetry…
                                          * Opt out anytime: DO_NOT_TRACK=1 …
                              ──────▶     event(workflow_invoked)
                                          distinctId: <random>
                                          [workflow_description removed]
                                          $ip: ''            ← stripped at ingest

$ CI=true bun run cli …           ✓ auto-disabled, no event
$ POSTHOG_API_KEY=off bun run cli ✓ disabled (also: 0 | false | disabled | "")
$ archon telemetry status         ✓ enabled/disabled, reason, distinct ID, host
$ archon telemetry reset          ✓ rotates install UUID
$ archon doctor                   ✓ adds a Telemetry row to the check list
POSTHOG_HOST=https://typo.local   ✓ first failure logs at WARN, rest at DEBUG
```

## Architecture Diagram

### Before

```
@archon/workflows/executor ──▶ captureWorkflowInvoked
                                       │
@archon/paths/telemetry ───────────────┘
   ├─ EMBEDDED_POSTHOG_API_KEY
   ├─ isTelemetryDisabled()
   ├─ getOrCreateTelemetryId()
   ├─ silentFetch()  (all failures → debug)
   └─ captureWorkflowInvoked(props incl. workflowDescription)
```

### After

```
@archon/workflows/executor ──▶ captureWorkflowInvoked
                                       │
@archon/paths/telemetry ───────────────┘
   ├─ EMBEDDED_POSTHOG_API_KEY
   ├─ [~] isTelemetryDisabled()             ← +CI=true, +POSTHOG_API_KEY=off
   ├─ [+] getTelemetryStatus()              ← richer state for CLI/doctor
   ├─ [+] resetTelemetryId()                ← rotate distinct ID
   ├─ [+] maybeShowFirstRunNotice()         ← one-time stderr, stamped
   ├─ [~] silentFetch()                     ← first failure → WARN
   └─ [~] captureWorkflowInvoked            ← no workflowDescription, +$ip:''

@archon/cli
   ├─ [+] commands/telemetry.ts             ← status / reset subcommands
   ├─ [~] cli.ts                            ← dispatch + usage
   └─ [~] commands/doctor.ts                ← +checkTelemetry()
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `@archon/cli/commands/telemetry` | `@archon/paths/telemetry` | **new** | `getTelemetryStatus`, `resetTelemetryId` |
| `@archon/cli/commands/doctor` | `@archon/paths/telemetry` | **new** | `getTelemetryStatus` |
| `@archon/cli/cli` | `@archon/cli/commands/telemetry` | **new** | dispatch for `telemetry status|reset` |
| `@archon/workflows/executor` | `@archon/paths/telemetry` | **modified** | drops `workflowDescription` from props |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `paths`, `cli`, `workflows`, `docs`
- Module: `paths:telemetry`, `cli:telemetry`, `cli:doctor`, `workflows:executor`

## Change Metadata

- Change type: `feature` (and minor `security` for IP stripping + description drop)
- Primary scope: `multi`

## Linked Issue

- Closes #
- Related # (none — surfaced from a privacy/trust audit of the existing telemetry path)

## Validation Evidence (required)

```bash
bun run validate
# EXIT=0
# check:bundled ✓
# check:bundled-skill ✓
# type-check ✓ (all 10 packages)
# lint ✓ (max-warnings 0)
# format:check ✓
# test ✓ (all packages, includes new telemetry + doctor coverage)
```

Smoke-tested manually:

- `bun run cli telemetry status` → reports enabled, embedded key
- `DO_NOT_TRACK=1 bun run cli telemetry status` → reports disabled, reason `DO_NOT_TRACK=1 is set`
- `bun run cli telemetry reset` → rotates UUID, persists to disk
- `CI=true` test exercises auto-disable path
- `POSTHOG_API_KEY=off|0|false|disabled` all disable (parameterized test)

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No** (same single PostHog ingest call)
- Secrets/tokens handling changed? **No** (embedded `phc_*` write-only key unchanged)
- File system access scope changed? **Yes (minor)** — adds one new file under `${ARCHON_HOME}`: `telemetry-notice-shown` stamp. Same directory we already write `telemetry-id` to.
- **Privacy improvements in this PR:**
  - `workflow_description` removed from event payload (user-authored, could leak business context)
  - `$ip: ''` added so PostHog drops source IP at ingest
  - First-run notice ensures users are informed before any event leaves their machine
  - CI auto-disable prevents accidental fork-CI traffic

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **Yes (additive)** — `CI=true` and `POSTHOG_API_KEY=off|0|false|disabled|""` now disable telemetry. Existing env vars (`ARCHON_TELEMETRY_DISABLED=1`, `DO_NOT_TRACK=1`) unchanged.
- Database migration needed? **No**
- Upgrade steps: none. Existing installs keep their `telemetry-id`. The first-run notice will fire once on next run for installs without a `telemetry-notice-shown` stamp.

## Human Verification (required)

- Verified scenarios:
  - `archon telemetry status` (enabled / DO_NOT_TRACK / CI / POSTHOG_API_KEY=off variants)
  - `archon telemetry reset` rotates UUID and persists
  - `bun run validate` passes end-to-end
  - Type-check passes for all 10 packages
- Edge cases checked:
  - Strict `CI === 'true'` (not `CI=1`) — covered by test
  - Notice does not fire when stderr isn't a TTY (skipped by `process.stderr.isTTY` guard)
  - Notice does not fire when telemetry is disabled
  - In-process cache invalidation on `resetTelemetryId` — covered by test
- What was not verified:
  - Actual PostHog ingest of `$ip: ''` (verified via PostHog docs only — would need a project-key holder to confirm in their dashboard)
  - First-run notice with a real interactive TTY in production (only smoke-tested via direct `bun run cli`)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows:
  - `@archon/paths/telemetry` — core changes
  - `@archon/workflows/executor.ts` — one call site updated
  - `@archon/cli` — new subcommand + doctor check
- Potential unintended effects:
  - Self-hosters who previously relied on `POSTHOG_API_KEY=""` being the only disable form now have more valid disable values. **Strictly additive** — no existing config breaks.
  - The first-run stderr notice prints to TTY users; could be surprising in interactive shells. Mitigated by skipping non-TTY (scripted) callers and by the one-time stamp.
  - First-failure warn could be noisy if the user has a flaky network — but only one warn per process, then drops to debug.
- Guardrails/monitoring for early detection:
  - PostHog dashboard event volume should decrease slightly (CI events stop, workflow_description property disappears).
  - Logs: search for `telemetry.fetch_first_failure` to surface broken self-hosted hosts.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge-commit>` — single commit, single file owner.
- Feature flags or config toggles: none required; the changes are entirely user-controlled by existing/new env vars.
- Observable failure symptoms:
  - Sudden drop in PostHog event volume → check whether CI auto-disable picked up an env var unexpectedly.
  - Users complaining about the first-run notice → can suppress via `ARCHON_TELEMETRY_DISABLED=1` or by manually creating the stamp file.

## Risks and Mitigations

- **Risk:** existing PostHog dashboards that filter on `workflow_description` will go dark.
  - **Mitigation:** call this out in the release notes; the property was rarely useful (user-authored, high cardinality) and `workflow_name` provides the same signal.
- **Risk:** self-hosters who treat `POSTHOG_API_KEY` as "always opaque string" might be surprised that values like `off` are now interpreted.
  - **Mitigation:** real PostHog keys are `phc_*` and won't collide with the sentinels (`off`, `0`, `false`, `disabled`, `""`). Documented in README and `.env.example`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `archon telemetry status` and `archon telemetry reset` CLI commands; `archon doctor` now reports telemetry state.

* **Documentation**
  * Clarified telemetry payload: sends workflow name, platform, Archon version, and an anonymous install UUID; explicitly excludes code, prompts, paths, IPs, tokens, and descriptions.
  * Expanded opt-out guidance (`POSTHOG_API_KEY=off`, `CI=true` auto-disables).

* **Improvements**
  * Removed workflow descriptions from telemetry, reduced network-error noise, and added a one‑time first-run telemetry notice; rotating the install UUID is now possible.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1780?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->