### PR TITLE
fix(docs): improve sidebar contrast for selected item in dark mode

### DIFF
--- a/packages/docs-web/src/styles/custom.css
+++ b/packages/docs-web/src/styles/custom.css
@@ -23,4 +23,5 @@
 [data-theme='dark'] .sidebar-content a[aria-current='page'] {
   background: linear-gradient(135deg, rgba(168, 85, 247, 0.15), rgba(59, 130, 246, 0.15));
   border-left-color: #a855f7;
+  color: var(--sl-color-white);
 }


### PR DESCRIPTION
## Summary
- Add explicit white text color to the selected sidebar item in dark mode to ensure readability against the accent background

## Problem
The selected menu item in the docs sidebar was difficult to read in dark mode due to insufficient contrast between the text and background colors.

## Solution
Added `color: var(--sl-color-white);` to the existing dark mode sidebar selector in `custom.css`.

## Test plan
- [x] Tested locally with `bun run dev:docs`
- [x] Verified selected sidebar item is readable in dark mode
- [x] Confirmed light mode is unaffected

## Validation Evidence (required)

Commands and result summary:

- `bun run dev:docs` - Tested locally, verified dark mode sidebar item is now readable
- Type-check/lint/test: N/A - CSS-only change in docs package, no TypeScript or runtime code affected

Evidence provided: Visual verification in browser (dark mode toggle)

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Human Verification (required)

- Verified scenarios: Dark mode sidebar with selected item - text now white and readable
- Edge cases checked: Light mode unaffected (already had white text)
- What was not verified: Other browsers (tested in Chrome only)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: docs-web package only (Starlight CSS)
- Potential unintended effects: None expected - additive CSS property
- Guardrails/monitoring: Visual inspection on deploy

## Rollback Plan (required)

- Fast rollback: Revert this commit (single line CSS change)
- Feature flags: N/A
- Observable failure symptoms: Sidebar text becomes unreadable in dark mode again


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visibility of the current page indicator in the sidebar when using dark theme.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1781?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->