### PR TITLE
feat(workflows): add loop.command for loading loop prompts from files (#1759)

### DIFF
--- a/packages/core/src/db/workflows.test.ts
+++ b/packages/core/src/db/workflows.test.ts
@@ -287,6 +287,10 @@ describe('workflows database', () => {
       // SQLite would keep a stale value from a previous interactive-loop gate).
       expect(payload.approval.completionSignaled).toBeNull();
       expect(payload.approval.signaledOutput).toBeNull();
+      // commandSnapshot (command-backed interactive loops) follows the same
+      // rule — a stale snapshot from a prior loop gate must never survive
+      // into an unrelated pause.
+      expect(payload.approval.commandSnapshot).toBeNull();
     });
 
     test('preserves completionSignaled/signaledOutput when the gate provides them (#2074)', async () => {
@@ -299,6 +303,7 @@ describe('workflows database', () => {
         iteration: 1,
         completionSignaled: true,
         signaledOutput: 'REPORT',
+        commandSnapshot: 'Loaded command body',
       });
 
       const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
@@ -307,6 +312,7 @@ describe('workflows database', () => {
       };
       expect(payload.approval.completionSignaled).toBe(true);
       expect(payload.approval.signaledOutput).toBe('REPORT');
+      expect(payload.approval.commandSnapshot).toBe('Loaded command body');
       expect(payload.approval.resolved).toBeNull();
     });
 

--- a/packages/core/src/db/workflows.ts
+++ b/packages/core/src/db/workflows.ts
@@ -894,6 +894,7 @@ export async function pauseWorkflowRun(
             iteration: approvalContext.iteration ?? null,
             sessionId: approvalContext.sessionId ?? null,
             sessionProvider: approvalContext.sessionProvider ?? null,
+            commandSnapshot: approvalContext.commandSnapshot ?? null,
           },
           // Fold caller-supplied run-level metadata (e.g. `pending_writeback`) into the
           // SAME atomic write so there is no window where the run is paused without it (M3).

--- a/packages/docs-web/src/content/docs/book/quick-reference.md
+++ b/packages/docs-web/src/content/docs/book/quick-reference.md
@@ -178,7 +178,8 @@ Defined under `loop:` inside a node:
 
 | Field | Required | Type | Description |
 |-------|----------|------|-------------|
-| `prompt` | Yes | string | AI instructions executed each iteration |
+| `prompt` | One of `prompt`/`command` | string | Inline AI instructions executed each iteration |
+| `command` | One of `prompt`/`command` | string | Command file (under `.archon/commands/`) whose body is the iteration prompt — exactly one of `prompt` or `command` |
 | `until` | Yes | string | Completion signal string — loop ends when AI output contains this |
 | `max_iterations` | Yes | number | Maximum iterations before the node fails |
 | `fresh_context` | No | boolean | Start a new session each iteration (default: false) |

--- a/packages/docs-web/src/content/docs/guides/loop-nodes.md
+++ b/packages/docs-web/src/content/docs/guides/loop-nodes.md
@@ -71,8 +71,9 @@ the executor checks for workflow cancellation.
 - id: my-loop
   loop:
     prompt: "..."           # Inline prompt. Exactly one of `prompt` or `command` is required.
-    command: <name>         # Alternative to `prompt`: command name under .archon/commands/.
-                            # Loaded once at node start; reused for every iteration.
+    # command: <name>       # Alternative to `prompt`: command name under .archon/commands/,
+    #                       # loaded once per run and reused for every iteration.
+    #                       # Never combine with `prompt` — the loader rejects both together.
     until: COMPLETE         # Required. Completion signal string.
     max_iterations: 10      # Required. Hard limit — node fails if exceeded.
     fresh_context: true     # Optional. Default: false.
@@ -125,10 +126,12 @@ are rejected at parse time. Static workflow validation also flags a
 "create `.archon/commands/<name>.md`" guidance), the same way it does for
 `command:` nodes.
 
-The file is **read once when the loop node starts** and the loaded text is
-reused for every iteration. Editing the file mid-run does not affect the
-remaining iterations of that run. A missing, empty, or unreadable target
-fails the node immediately with an actionable error — no iterations execute.
+The file is **read once per run** — loaded when the loop node starts and
+reused for every iteration, including across interactive-gate pauses: the
+loaded text is persisted with the pause, so editing or deleting the file while
+a run sits paused neither changes nor breaks the resumed loop's prompt. A
+missing, empty, or unreadable target fails the node immediately with an
+actionable error — no iterations execute.
 
 Once loaded, the text behaves identically to an inline `prompt`: all the
 variable substitution above applies unchanged (including `$LOOP_PREV_OUTPUT`
@@ -141,7 +144,7 @@ and `$LOOP_USER_INPUT`), as do all the iteration semantics (`until`,
   model: opus
   depends_on: [generate-prd]
   loop:
-    command: archon-ralph-implement   # loads .archon/commands/archon-ralph-implement.md
+    command: archon-ralph-implement   # resolved repo → home → bundled (see precedence above)
     until: COMPLETE
     max_iterations: 15
     fresh_context: true

--- a/packages/docs-web/src/content/docs/guides/loop-nodes.md
+++ b/packages/docs-web/src/content/docs/guides/loop-nodes.md
@@ -17,6 +17,11 @@ Use loop nodes for autonomous multi-step work: implement N stories from a PRD,
 iterate on a design until validation passes, or refine output until quality
 criteria are met.
 
+A loop node's iteration prompt can live **inline** (`loop.prompt`) or in a
+**command file** (`loop.command`, loaded from `.archon/commands/` the same way
+[`command:` nodes](/guides/authoring-commands/) load their text). Provide
+exactly one — both at once, or neither, is rejected at workflow load time.
+
 ## Quick Start
 
 ```yaml
@@ -65,7 +70,9 @@ the executor checks for workflow cancellation.
 ```yaml
 - id: my-loop
   loop:
-    prompt: "..."           # Required. The prompt sent each iteration.
+    prompt: "..."           # Inline prompt. Exactly one of `prompt` or `command` is required.
+    command: <name>         # Alternative to `prompt`: command name under .archon/commands/.
+                            # Loaded once at node start; reused for every iteration.
     until: COMPLETE         # Required. Completion signal string.
     max_iterations: 10      # Required. Hard limit — node fails if exceeded.
     fresh_context: true     # Optional. Default: false.
@@ -100,6 +107,50 @@ the agent has no memory of prior iterations, so the prompt must include all
 context needed to continue the work. `$LOOP_PREV_OUTPUT` complements this by
 exposing the previous iteration's own output without forcing the engine to
 thread the session.
+
+### `command`
+
+Alternative to `prompt` — names a command file (under `.archon/commands/`)
+whose body is loaded as the iteration prompt. **Exactly one of `prompt` or
+`command` is required**; specifying both, or neither, is rejected at workflow
+load time with a clear error.
+
+The named command resolves with the same repo → home → bundled precedence as a
+[`command:` node](/guides/authoring-commands/): `.archon/commands/<name>.md`
+relative to the working directory first, then `~/.archon/commands/<name>.md`,
+then the bundled defaults shipped with Archon. The same command-name safety
+rules apply — no path separators, no `..`, no leading `.` — and unsafe names
+are rejected at parse time. Static workflow validation also flags a
+`loop.command` that points at a missing file (with "did you mean…" /
+"create `.archon/commands/<name>.md`" guidance), the same way it does for
+`command:` nodes.
+
+The file is **read once when the loop node starts** and the loaded text is
+reused for every iteration. Editing the file mid-run does not affect the
+remaining iterations of that run. A missing, empty, or unreadable target
+fails the node immediately with an actionable error — no iterations execute.
+
+Once loaded, the text behaves identically to an inline `prompt`: all the
+variable substitution above applies unchanged (including `$LOOP_PREV_OUTPUT`
+and `$LOOP_USER_INPUT`), as do all the iteration semantics (`until`,
+`until_bash`, `max_iterations`, `fresh_context`, `interactive` /
+`gate_message`).
+
+```yaml
+- id: implement
+  model: opus
+  depends_on: [generate-prd]
+  loop:
+    command: archon-ralph-implement   # loads .archon/commands/archon-ralph-implement.md
+    until: COMPLETE
+    max_iterations: 15
+    fresh_context: true
+```
+
+Use this when the iteration prompt is long enough that keeping it inline
+obscures the shape of the pipeline — Ralph-style implement/build loops and
+iterate-until-valid loops are the typical case. It is the loop-node parallel
+of moving a `prompt:` node to a `command:` node.
 
 ### `until`
 

--- a/packages/web/src/experiments/console/builder/components/BuilderNodeView.tsx
+++ b/packages/web/src/experiments/console/builder/components/BuilderNodeView.tsx
@@ -23,7 +23,8 @@ export function contentPreview(node: BuilderNode): string {
     case 'script':
       return node.data.script.split('\n')[0] ?? '';
     case 'loop':
-      return node.data.prompt.split('\n')[0] ?? '';
+      // Command-backed loops preview the command name (same as command nodes).
+      return node.data.command ?? node.data.prompt?.split('\n')[0] ?? '';
     case 'approval':
       return node.data.message.split('\n')[0] ?? '';
     case 'cancel':

--- a/packages/web/src/experiments/console/builder/components/inspector/LoopFields.tsx
+++ b/packages/web/src/experiments/console/builder/components/inspector/LoopFields.tsx
@@ -1,7 +1,7 @@
 /** Inspector sub-form for loop nodes. */
 import type { ReactElement } from 'react';
 import type { LoopNodeData } from '../../types';
-import { CheckboxField, NumberField, TextAreaField, TextField } from './fields';
+import { CheckboxField, NumberField, SelectField, TextAreaField, TextField } from './fields';
 
 export function LoopFields({
   data,
@@ -10,17 +10,49 @@ export function LoopFields({
   data: LoopNodeData;
   onChange: (next: LoopNodeData) => void;
 }): ReactElement {
+  // Exactly-one prompt source (engine one-of rule): the toggle swaps which
+  // field is present, dropping the other so a stale value can never leak into
+  // the export. `command` keys the mode (matching loopToDag's export branch);
+  // the importer guarantees at most one of the two is present on `data`.
+  const sourceMode: 'prompt' | 'command' = data.command !== undefined ? 'command' : 'prompt';
   return (
     <>
-      <TextAreaField
-        label="Prompt (each iteration)"
-        value={data.prompt}
-        rows={5}
-        placeholder="Keep fixing failing tests…"
-        onChange={(prompt): void => {
-          onChange({ ...data, prompt });
+      <SelectField
+        label="Prompt source"
+        value={sourceMode}
+        options={[
+          { value: 'prompt', label: 'Inline prompt' },
+          { value: 'command', label: 'Command file' },
+        ]}
+        onChange={(next): void => {
+          if (next === sourceMode) return;
+          const rest: LoopNodeData = { ...data };
+          delete rest.prompt;
+          delete rest.command;
+          onChange(next === 'command' ? { ...rest, command: '' } : { ...rest, prompt: '' });
         }}
       />
+      {sourceMode === 'command' ? (
+        <TextField
+          label="Command (each iteration)"
+          value={data.command ?? ''}
+          mono
+          placeholder="my-command"
+          onChange={(command): void => {
+            onChange({ ...data, command });
+          }}
+        />
+      ) : (
+        <TextAreaField
+          label="Prompt (each iteration)"
+          value={data.prompt ?? ''}
+          rows={5}
+          placeholder="Keep fixing failing tests…"
+          onChange={(prompt): void => {
+            onChange({ ...data, prompt });
+          }}
+        />
+      )}
       <TextField
         label="Until (completion signal)"
         value={data.until}

--- a/packages/web/src/experiments/console/builder/fixtures/index.ts
+++ b/packages/web/src/experiments/console/builder/fixtures/index.ts
@@ -3,17 +3,25 @@
  * preview). Each fixture is a wire `WorkflowDefinition` authored already-sparse.
  */
 import type { WireWorkflowDefinition } from '../types';
-import { loopFixture } from './loop.fixture';
+import { loopFixture, loopCommandFixture } from './loop.fixture';
 import { approvalFixture } from './approval.fixture';
 import { cancelFixture } from './cancel.fixture';
 import { scriptFixture } from './script.fixture';
 import { mixedFixture } from './mixed.fixture';
 
-export { loopFixture, approvalFixture, cancelFixture, scriptFixture, mixedFixture };
+export {
+  loopFixture,
+  loopCommandFixture,
+  approvalFixture,
+  cancelFixture,
+  scriptFixture,
+  mixedFixture,
+};
 
 /** All builder fixtures keyed by name, for table-driven tests. */
 export const FIXTURES: Record<string, WireWorkflowDefinition> = {
   loop: loopFixture,
+  loopCommand: loopCommandFixture,
   approval: approvalFixture,
   cancel: cancelFixture,
   script: scriptFixture,

--- a/packages/web/src/experiments/console/builder/fixtures/loop.fixture.ts
+++ b/packages/web/src/experiments/console/builder/fixtures/loop.fixture.ts
@@ -23,3 +23,24 @@ export const loopFixture: WireWorkflowDefinition = {
     },
   ],
 };
+
+/**
+ * Command-backed loop fixture: the per-iteration prompt comes from a command
+ * file (`loop.command`), the exactly-one alternative to `loop.prompt`. No
+ * `prompt` key may appear anywhere in the round-trip of this fixture.
+ */
+export const loopCommandFixture: WireWorkflowDefinition = {
+  name: 'loop-command-fixture',
+  description: 'Iterates a command-file prompt until COMPLETE.',
+  nodes: [
+    {
+      id: 'refine-cmd',
+      loop: {
+        command: 'refine-draft',
+        until: 'COMPLETE',
+        max_iterations: 5,
+        fresh_context: false,
+      },
+    },
+  ],
+};

--- a/packages/web/src/experiments/console/builder/model/from-workflow.ts
+++ b/packages/web/src/experiments/console/builder/model/from-workflow.ts
@@ -45,6 +45,26 @@ function nodeFromDag(node: WireWorkflowDefinition['nodes'][number], issues: Issu
     return { id, variant: 'prompt', base, data: defaultPromptData() };
   }
 
+  if (
+    variant === 'loop' &&
+    typeof variantSpecific.loop?.prompt === 'string' &&
+    typeof variantSpecific.loop.command === 'string'
+  ) {
+    // The engine schema rejects a loop carrying both prompt sources; a wire
+    // node that somehow has both cannot round-trip faithfully. loopFromDag
+    // deterministically keeps `prompt` — surface the dropped `command`.
+    issues.push(
+      makeIssue({
+        rule: 'structural.field.unsupported',
+        severity: 'error',
+        source: 'client-instant',
+        message:
+          "loop node has both 'prompt' and 'command' (engine allows exactly one); editing as an inline-prompt loop — 'command' was dropped",
+        path: { nodeId: id, field: 'loop.command' },
+      })
+    );
+  }
+
   if (variant === 'script' && variantSpecific.runtime === undefined) {
     // The engine requires `runtime` on script nodes. scriptFromDag defaults to
     // 'bun' so the node stays editable, but the gap must not be silent.

--- a/packages/web/src/experiments/console/builder/model/round-trip.test.ts
+++ b/packages/web/src/experiments/console/builder/model/round-trip.test.ts
@@ -25,6 +25,21 @@ describe('round-trip fidelity', () => {
     }
   });
 
+  test('command-backed loop round-trips exactly — command preserved, no prompt key introduced', () => {
+    const { workflow, issues } = fromWorkflowDefinition(FIXTURES.loopCommand);
+    expect(issues).toEqual([]);
+    const node = workflow.nodes[0];
+    expect(node.variant).toBe('loop');
+    if (node.variant === 'loop') {
+      expect(node.data.command).toBe('refine-draft');
+      expect(node.data.prompt).toBeUndefined();
+    }
+    const exported = toWorkflowDefinition(workflow);
+    // Exact equality: `{ command }` must NOT come back as `{ prompt: '' }`.
+    expect(exported).toEqual(FIXTURES.loopCommand);
+    expect('prompt' in (exported.nodes[0].loop ?? {})).toBe(false);
+  });
+
   test('approval on_reject and capture_response survive partitioning', () => {
     const bw = fromWorkflowDefinition(FIXTURES.approval).workflow;
     const node = bw.nodes[0];
@@ -113,6 +128,35 @@ describe('import issues', () => {
     expect(issues[0].path).toEqual({ nodeId: 'p', field: 'timeout' });
     const out = toWorkflowDefinition(workflow);
     expect('timeout' in out.nodes[0]).toBe(false);
+  });
+
+  test('a loop with both prompt and command is flagged with an error and keeps the prompt', () => {
+    // Not engine-producible input (the schema enforces exactly-one) — the
+    // importer must not silently drop either source.
+    const { workflow, issues } = fromWorkflowDefinition(
+      wire([
+        {
+          id: 'both',
+          loop: {
+            prompt: 'inline',
+            command: 'cmd-file',
+            until: 'DONE',
+            max_iterations: 3,
+            fresh_context: false,
+          },
+        },
+      ])
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].rule).toBe('structural.field.unsupported');
+    expect(issues[0].severity).toBe('error');
+    expect(issues[0].path).toEqual({ nodeId: 'both', field: 'loop.command' });
+    const node = workflow.nodes[0];
+    expect(node.variant).toBe('loop');
+    if (node.variant === 'loop') {
+      expect(node.data.prompt).toBe('inline');
+      expect(node.data.command).toBeUndefined();
+    }
   });
 
   test('timeout on bash and script nodes is carried, not flagged', () => {

--- a/packages/web/src/experiments/console/builder/types/variant.ts
+++ b/packages/web/src/experiments/console/builder/types/variant.ts
@@ -68,9 +68,18 @@ export type BaseFields = Pick<WireDagNode, WireBaseKey>;
 // Per-variant data shapes
 // ---------------------------------------------------------------------------
 
-/** Loop config. `fresh_context` is always present (engine default `false`). */
+/**
+ * Loop config. `fresh_context` is always present (engine default `false`).
+ *
+ * Exactly ONE of `prompt` (inline per-iteration prompt) / `command` (named
+ * command file whose body is the per-iteration prompt) is present — mirroring
+ * the engine schema's one-of rule. The inspector's source toggle maintains the
+ * invariant while editing; structural validation reports a violation instead
+ * of letting export guess.
+ */
 export interface LoopNodeData {
-  prompt: string;
+  prompt?: string;
+  command?: string;
   until: string;
   max_iterations: number;
   fresh_context: boolean;

--- a/packages/web/src/experiments/console/builder/validation/content.ts
+++ b/packages/web/src/experiments/console/builder/validation/content.ts
@@ -38,7 +38,9 @@ function textBodies(node: BuilderNode): string[] {
     case 'approval':
       return [node.data.message];
     case 'loop':
-      return [node.data.prompt];
+      // A command-backed loop has no inline text to scan — the command file's
+      // body is loaded at runtime (same posture as the engine loader's ref scan).
+      return node.data.prompt !== undefined ? [node.data.prompt] : [];
     case 'cancel':
       return [];
   }

--- a/packages/web/src/experiments/console/builder/validation/structural.ts
+++ b/packages/web/src/experiments/console/builder/validation/structural.ts
@@ -86,7 +86,15 @@ function checkRequiredFields(node: BuilderNode): Issue[] {
         invalid('runtime', "script requires runtime 'bun' or 'uv'");
       break;
     case 'loop':
-      if (node.data.prompt.trim().length === 0) missing('loop.prompt', 'loop requires a prompt');
+      // One-of rule (mirrors the engine schema): exactly one prompt source,
+      // and whichever is present must be non-empty.
+      if (node.data.prompt !== undefined && node.data.command !== undefined)
+        invalid('loop.command', "loop accepts exactly one of 'prompt' or 'command', not both");
+      else if (node.data.command !== undefined) {
+        if (node.data.command.trim().length === 0)
+          missing('loop.command', 'loop requires a command name');
+      } else if ((node.data.prompt ?? '').trim().length === 0)
+        missing('loop.prompt', 'loop requires a prompt (or a command file)');
       if (node.data.until.trim().length === 0)
         missing('loop.until', "loop requires an 'until' signal");
       if (!Number.isInteger(node.data.max_iterations) || node.data.max_iterations <= 0)

--- a/packages/web/src/experiments/console/builder/variants/loop.ts
+++ b/packages/web/src/experiments/console/builder/variants/loop.ts
@@ -20,7 +20,9 @@ export function loopFromDag(variantSpecific: Partial<WireDagNode>): LoopNodeData
     );
   }
   return {
-    prompt: loop.prompt,
+    // `prompt` is optional on the wire (a loop may use `command` instead); the
+    // builder only models prompt-based loops, so fall back to the empty default.
+    prompt: loop.prompt ?? '',
     until: loop.until,
     max_iterations: loop.max_iterations,
     // Engine default is false but the generated type makes it required, so it is

--- a/packages/web/src/experiments/console/builder/variants/loop.ts
+++ b/packages/web/src/experiments/console/builder/variants/loop.ts
@@ -20,9 +20,16 @@ export function loopFromDag(variantSpecific: Partial<WireDagNode>): LoopNodeData
     );
   }
   return {
-    // `prompt` is optional on the wire (a loop may use `command` instead); the
-    // builder only models prompt-based loops, so fall back to the empty default.
-    prompt: loop.prompt ?? '',
+    // Exactly one prompt source survives the round-trip. A command-backed loop
+    // keeps `command` (never collapsed to an empty prompt); a prompt-backed
+    // loop keeps `prompt`. A wire node carrying BOTH is invalid per the engine
+    // schema — the importer flags it (see nodeFromDag) and `prompt` wins here
+    // so the flagged node stays deterministically editable.
+    ...(typeof loop.prompt === 'string'
+      ? { prompt: loop.prompt }
+      : typeof loop.command === 'string'
+        ? { command: loop.command }
+        : { prompt: '' }),
     until: loop.until,
     max_iterations: loop.max_iterations,
     // Engine default is false but the generated type makes it required, so it is
@@ -38,7 +45,10 @@ export function loopFromDag(variantSpecific: Partial<WireDagNode>): LoopNodeData
 export function loopToDag(data: LoopNodeData): Partial<WireDagNode> {
   return {
     loop: {
-      prompt: data.prompt,
+      // Emit exactly the prompt source the node carries (one-of invariant).
+      // A node with neither (transient editing state) exports `prompt: ''`
+      // so the engine's own "requires prompt or command" validation fires.
+      ...(data.command !== undefined ? { command: data.command } : { prompt: data.prompt ?? '' }),
       until: data.until,
       max_iterations: data.max_iterations,
       fresh_context: data.fresh_context,

--- a/packages/web/src/lib/api.generated.d.ts
+++ b/packages/web/src/lib/api.generated.d.ts
@@ -3344,6 +3344,11 @@ export interface components {
       worktree?: {
         enabled?: boolean;
       };
+      container?: {
+        enabled?: boolean;
+        /** @enum {string} */
+        write_back?: 'approve' | 'auto';
+      };
       mutates_checkout?: boolean;
       persist_sessions?: boolean;
       tags?: string[];
@@ -3535,6 +3540,13 @@ export interface components {
           maxTurns?: number;
         };
       };
+      pi?: {
+        enableExtensions?: boolean;
+        interactive?: boolean;
+        extensionFlags?: {
+          [key: string]: boolean | string;
+        };
+      };
       /** @enum {string} */
       effort?: 'low' | 'medium' | 'high' | 'max';
       thinking?:
@@ -3600,6 +3612,7 @@ export interface components {
         until_bash?: string;
         interactive?: boolean;
         gate_message?: string;
+        signal_completes?: boolean;
         prompt?: string;
         command?: string;
       };
@@ -3611,6 +3624,7 @@ export interface components {
         until_bash?: string;
         interactive?: boolean;
         gate_message?: string;
+        signal_completes?: boolean;
         nodes: components['schemas']['DagNode'][];
       };
       approval?: {
@@ -3622,6 +3636,8 @@ export interface components {
         };
       };
       cancel?: string;
+      include?: string;
+      with?: unknown;
       script?: string;
       /** @enum {string} */
       runtime?: 'bun' | 'uv';

--- a/packages/web/src/lib/api.generated.d.ts
+++ b/packages/web/src/lib/api.generated.d.ts
@@ -3600,7 +3600,8 @@ export interface components {
         until_bash?: string;
         interactive?: boolean;
         gate_message?: string;
-        prompt: string;
+        prompt?: string;
+        command?: string;
       };
       loop_group?: {
         until: string;

--- a/packages/web/src/lib/dag-layout.test.ts
+++ b/packages/web/src/lib/dag-layout.test.ts
@@ -20,6 +20,22 @@ describe('resolveNodeDisplay', () => {
     });
   });
 
+  test('command-backed loop node labels by command name and carries no promptText', () => {
+    const dn: DagNode = {
+      id: 'implement',
+      loop: {
+        command: 'archon-ralph-implement',
+        until: 'COMPLETE',
+        max_iterations: 15,
+        fresh_context: true,
+      },
+    };
+    expect(resolveNodeDisplay(dn)).toEqual({
+      label: 'archon-ralph-implement',
+      nodeType: 'loop',
+    });
+  });
+
   test('approval node returns label Approval and nodeType approval', () => {
     const dn: DagNode = {
       id: 'n2',

--- a/packages/web/src/lib/dag-layout.ts
+++ b/packages/web/src/lib/dag-layout.ts
@@ -62,6 +62,9 @@ export function resolveNodeDisplay(dn: DagNode): {
     return { label: dn.command, nodeType: 'command' };
   }
   if ('loop' in dn && dn.loop) {
+    if (dn.loop.command) {
+      return { label: dn.loop.command, nodeType: 'loop' };
+    }
     return { label: 'Loop', nodeType: 'loop', promptText: dn.loop.prompt };
   }
   if ('approval' in dn && dn.approval) {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -10,6 +10,7 @@ import {
   type Mock,
 } from 'bun:test';
 import { mkdir, writeFile, rm, readFile } from 'fs/promises';
+import { unlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import * as git from '@archon/git';
@@ -6654,6 +6655,327 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         >
       ).mock.calls;
       expect(pauseCalls.length).toBe(0);
+    });
+
+    // ─── loop.command (command-file-backed loop nodes) ──────────────────────
+    //
+    // These cover the runtime contract of the `loop.command` feature
+    // (`specs/loop-command.md`):
+    //   • The command file is loaded **once at node start** and the loaded
+    //     text is reused for every iteration. Spec section 3:
+    //     "editing the file mid-run does not affect the remaining iterations
+    //     of that run". The read-once test proves this by deleting the file
+    //     synchronously between iterations and asserting iteration 2 still
+    //     runs from the in-memory template.
+    //   • A missing / empty / unsafe `loop.command` fails the node *before*
+    //     any iteration runs — no `sendQuery` call, `node_failed` event
+    //     emitted with an actionable error. The schema's superRefine catches
+    //     unsafe names at parse, but a hand-constructed workflow can bypass
+    //     parse; these tests exercise the executor's defense-in-depth branch.
+    //   • Loop variable substitution (`$LOOP_PREV_OUTPUT`, `$LOOP_USER_INPUT`,
+    //     and the standard workflow vars) applies to the loaded command-file
+    //     text identically to inline `loop.prompt` text.
+
+    it('reads loop.command file once at node start, not per iteration', async () => {
+      // Regression guard for the "load once, reuse" invariant. We write a
+      // command file, run iteration 1, delete the file synchronously inside
+      // the mock generator, and confirm iteration 2 still runs successfully.
+      // If the executor re-read the file per iteration, the load would fail
+      // on iteration 2 and surface as `node_failed` / `loop_iteration_failed`.
+      const cmdPath = join(testDir, '.archon', 'commands', 'read-once-loop.md');
+      await writeFile(cmdPath, 'Command-loaded loop body. iter prev=<<$LOOP_PREV_OUTPUT>>');
+
+      let callCount = 0;
+      mockSendQueryDag.mockImplementation(function* () {
+        callCount++;
+        if (callCount === 1) {
+          // Delete the source file *during* iteration 1 so it is gone by the
+          // time iteration 2 begins. Synchronous unlink ensures the file is
+          // removed before the next `for await` yield resumes the loop body.
+          unlinkSync(cmdPath);
+          yield { type: 'assistant', content: 'iter1 work output' };
+          yield { type: 'result', sessionId: 'sid-once-1' };
+        } else {
+          yield { type: 'assistant', content: 'iter2 done. <promise>COMPLETE</promise>' };
+          yield { type: 'result', sessionId: 'sid-once-2' };
+        }
+      });
+
+      const store = createMockStore();
+      const mockDeps = createMockDeps(store);
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun();
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        {
+          name: 'loop-cmd-read-once',
+          nodes: [
+            {
+              id: 'read-once-loop',
+              loop: {
+                command: 'read-once-loop',
+                until: 'COMPLETE',
+                max_iterations: 5,
+                fresh_context: true,
+              },
+            } as unknown as DagNode,
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      // Both iterations ran — the mid-run deletion did not break iteration 2.
+      expect(mockSendQueryDag.mock.calls.length).toBe(2);
+      // No failure events of any kind.
+      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+      const failedEvents = eventCalls.filter((call: unknown[]) => {
+        const evt = (call[0] as Record<string, unknown>).event_type as string;
+        return evt === 'node_failed' || evt === 'loop_iteration_failed';
+      });
+      expect(failedEvents).toHaveLength(0);
+      // Both iterations received the *same* file body as their prompt template
+      // — proving the file contents were loaded once and reused, not re-read.
+      expect(mockSendQueryDag.mock.calls[0][0] as string).toContain('Command-loaded loop body.');
+      expect(mockSendQueryDag.mock.calls[1][0] as string).toContain('Command-loaded loop body.');
+    });
+
+    it('fails fast with node_failed when loop.command names a missing file', async () => {
+      // Schema rejection at parse only fires when the workflow is parsed via
+      // the loader; a hand-constructed workflow bypasses that. The runtime
+      // guard inside `executeLoopNode` must catch the missing command and
+      // fail the node before iteration 1 runs.
+      const store = createMockStore();
+      const mockDeps = createMockDeps(store);
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun();
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        {
+          name: 'loop-cmd-missing',
+          nodes: [
+            {
+              id: 'missing-loop',
+              loop: {
+                command: 'does-not-exist-anywhere',
+                until: 'COMPLETE',
+                max_iterations: 3,
+              },
+            } as unknown as DagNode,
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      // sendQuery must never have been invoked — load failed pre-iteration.
+      expect(mockSendQueryDag.mock.calls.length).toBe(0);
+      // `node_failed` event was emitted with the actionable message.
+      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+      const failed = eventCalls.find(
+        (call: unknown[]) =>
+          (call[0] as Record<string, unknown>).event_type === 'node_failed' &&
+          (call[0] as Record<string, unknown>).step_name === 'missing-loop'
+      );
+      expect(failed).toBeDefined();
+      const data = (failed![0] as Record<string, unknown>).data as Record<string, unknown>;
+      expect(String(data.error)).toContain('not found');
+    });
+
+    it('fails fast with node_failed when loop.command target file is empty', async () => {
+      // An empty command file is a load-time failure in `loadCommandPrompt`
+      // (same as for `command:` nodes). The loop must fail with the empty-file
+      // diagnostic before iteration 1.
+      await writeFile(join(testDir, '.archon', 'commands', 'empty-loop.md'), '');
+
+      const store = createMockStore();
+      const mockDeps = createMockDeps(store);
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun();
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        {
+          name: 'loop-cmd-empty',
+          nodes: [
+            {
+              id: 'empty-loop',
+              loop: {
+                command: 'empty-loop',
+                until: 'COMPLETE',
+                max_iterations: 3,
+              },
+            } as unknown as DagNode,
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      expect(mockSendQueryDag.mock.calls.length).toBe(0);
+      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+      const failed = eventCalls.find(
+        (call: unknown[]) =>
+          (call[0] as Record<string, unknown>).event_type === 'node_failed' &&
+          (call[0] as Record<string, unknown>).step_name === 'empty-loop'
+      );
+      expect(failed).toBeDefined();
+      const data = (failed![0] as Record<string, unknown>).data as Record<string, unknown>;
+      expect(String(data.error)).toContain('empty');
+    });
+
+    it('fails fast with node_failed when loop.command is an unsafe name', async () => {
+      // The loop schema's superRefine rejects `'../escape'` at parse, but a
+      // programmatically-constructed workflow bypasses parse. The executor
+      // branch must still flag this via `isValidCommandName` inside
+      // `loadCommandPrompt` rather than attempting any file resolution.
+      const store = createMockStore();
+      const mockDeps = createMockDeps(store);
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun();
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        {
+          name: 'loop-cmd-unsafe',
+          nodes: [
+            {
+              id: 'unsafe-loop',
+              loop: {
+                command: '../escape',
+                until: 'COMPLETE',
+                max_iterations: 3,
+              },
+            } as unknown as DagNode,
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      expect(mockSendQueryDag.mock.calls.length).toBe(0);
+      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+      const failed = eventCalls.find(
+        (call: unknown[]) =>
+          (call[0] as Record<string, unknown>).event_type === 'node_failed' &&
+          (call[0] as Record<string, unknown>).step_name === 'unsafe-loop'
+      );
+      expect(failed).toBeDefined();
+      const data = (failed![0] as Record<string, unknown>).data as Record<string, unknown>;
+      expect(String(data.error)).toContain('Invalid command name');
+    });
+
+    it('applies $LOOP_PREV_OUTPUT and $LOOP_USER_INPUT substitution to command-loaded text', async () => {
+      // Spec acceptance criterion: "All loop variable substitution applies to
+      // command-loaded prompt text identically to inline prompt text." We
+      // embed both `$LOOP_PREV_OUTPUT` and `$LOOP_USER_INPUT` inside the
+      // command file body and assert the prompt actually sent to the AI on
+      // each iteration substitutes them the same way the inline-prompt tests
+      // already verify for `loop.prompt`. The body itself must appear in the
+      // sent prompt — proof the file contents (not the YAML node body) flow
+      // through `substituteWorkflowVariables`.
+      await writeFile(
+        join(testDir, '.archon', 'commands', 'subst-loop.md'),
+        'Cmd-file body. PREV=<<$LOOP_PREV_OUTPUT>> USER=<<$LOOP_USER_INPUT>>'
+      );
+
+      let callCount = 0;
+      mockSendQueryDag.mockImplementation(function* () {
+        callCount++;
+        if (callCount === 1) {
+          yield { type: 'assistant', content: 'iter1 result text' };
+          yield { type: 'result', sessionId: 'sid-subst-1' };
+        } else {
+          yield { type: 'assistant', content: 'done. <promise>COMPLETE</promise>' };
+          yield { type: 'result', sessionId: 'sid-subst-2' };
+        }
+      });
+
+      const mockDeps = createMockDeps();
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun();
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        {
+          name: 'loop-cmd-subst',
+          nodes: [
+            {
+              id: 'subst-loop',
+              loop: {
+                command: 'subst-loop',
+                until: 'COMPLETE',
+                max_iterations: 5,
+                fresh_context: true,
+              },
+            } as unknown as DagNode,
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      expect(mockSendQueryDag.mock.calls.length).toBe(2);
+      const promptIter1 = mockSendQueryDag.mock.calls[0][0] as string;
+      const promptIter2 = mockSendQueryDag.mock.calls[1][0] as string;
+      // The file body is what reached the AI — not the YAML inline-prompt path.
+      expect(promptIter1).toContain('Cmd-file body.');
+      expect(promptIter2).toContain('Cmd-file body.');
+      // Iteration 1: PREV substitutes to empty (no prior output); USER empty
+      // (non-interactive, no resume metadata).
+      expect(promptIter1).toContain('PREV=<<>>');
+      expect(promptIter1).toContain('USER=<<>>');
+      // Iteration 2: PREV carries iteration 1's cleaned output, USER stays
+      // empty (still non-interactive).
+      expect(promptIter2).toContain('PREV=<<iter1 result text>>');
+      expect(promptIter2).toContain('USER=<<>>');
     });
   });
 });

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -6659,19 +6659,16 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
     // ─── loop.command (command-file-backed loop nodes) ──────────────────────
     //
-    // These cover the runtime contract of the `loop.command` feature
-    // (`specs/loop-command.md`):
-    //   • The command file is loaded **once at node start** and the loaded
-    //     text is reused for every iteration. Spec section 3:
-    //     "editing the file mid-run does not affect the remaining iterations
-    //     of that run". The read-once test proves this by deleting the file
-    //     synchronously between iterations and asserting iteration 2 still
-    //     runs from the in-memory template.
+    // Hidden mechanics these tests pin down:
+    //   • The command file is read ONCE per run/node — loaded at node start,
+    //     reused for every iteration, and persisted across an interactive gate
+    //     pause (`commandSnapshot`) so a file edited or deleted while paused
+    //     cannot change the running loop's prompt.
     //   • A missing / empty / unsafe `loop.command` fails the node *before*
-    //     any iteration runs — no `sendQuery` call, `node_failed` event
-    //     emitted with an actionable error. The schema's superRefine catches
-    //     unsafe names at parse, but a hand-constructed workflow can bypass
-    //     parse; these tests exercise the executor's defense-in-depth branch.
+    //     any iteration runs — no `sendQuery` call, one `node_failed` event
+    //     with an actionable error. The schema's superRefine catches unsafe
+    //     names at parse, but a hand-constructed workflow can bypass parse;
+    //     these tests exercise the executor's defense-in-depth branch.
     //   • Loop variable substitution (`$LOOP_PREV_OUTPUT`, `$LOOP_USER_INPUT`,
     //     and the standard workflow vars) applies to the loaded command-file
     //     text identically to inline `loop.prompt` text.
@@ -6748,6 +6745,16 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // — proving the file contents were loaded once and reused, not re-read.
       expect(mockSendQueryDag.mock.calls[0][0] as string).toContain('Command-loaded loop body.');
       expect(mockSendQueryDag.mock.calls[1][0] as string).toContain('Command-loaded loop body.');
+      // node_started carries the command name so the event stream identifies
+      // command-backed loops without reading the workflow YAML.
+      const started = eventCalls.find(
+        (call: unknown[]) =>
+          (call[0] as Record<string, unknown>).event_type === 'node_started' &&
+          (call[0] as Record<string, unknown>).step_name === 'read-once-loop'
+      );
+      expect(started).toBeDefined();
+      const startedData = (started![0] as Record<string, unknown>).data as Record<string, unknown>;
+      expect(startedData.command).toBe('read-once-loop');
     });
 
     it('fails fast with node_failed when loop.command names a missing file', async () => {
@@ -6990,6 +6997,185 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // empty (still non-interactive).
       expect(promptIter2).toContain('PREV=<<iter1 result text>>');
       expect(promptIter2).toContain('USER=<<>>');
+    });
+
+    it('reuses the pause-time command snapshot on approval resume — file mutated and deleted while paused', async () => {
+      // Two-invocation contract: invocation 1 loads the command file and pauses
+      // at the interactive gate, persisting the loaded body (`commandSnapshot`)
+      // in the pause context. While the run sits paused, the file is rewritten
+      // AND then deleted. Invocation 2 (the approval resume) must run the next
+      // iteration from the SNAPSHOT — never from the mutated file, and without
+      // failing on the missing file.
+      const cmdPath = join(testDir, '.archon', 'commands', 'gated-loop.md');
+      await writeFile(cmdPath, 'ORIGINAL gated body. USER=<<$LOOP_USER_INPUT>>');
+
+      mockSendQueryDag.mockImplementation(function* () {
+        yield { type: 'assistant', content: 'iteration output, no signal yet' };
+        yield { type: 'result', sessionId: 'sid-gated-1' };
+      });
+
+      const mockDeps = createMockDeps();
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun();
+
+      const gatedWorkflow = {
+        name: 'loop-cmd-gated',
+        nodes: [
+          {
+            id: 'gated-loop',
+            loop: {
+              command: 'gated-loop',
+              until: 'COMPLETE',
+              max_iterations: 5,
+              interactive: true,
+              gate_message: 'Review this iteration.',
+            },
+          } as unknown as DagNode,
+        ],
+      };
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        gatedWorkflow,
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      // Invocation 1 paused at the gate and persisted the loaded body.
+      const pauseCalls = (
+        mockDeps.store.pauseWorkflowRun as Mock<
+          (id: string, ctx: Record<string, unknown>) => Promise<void>
+        >
+      ).mock.calls;
+      expect(pauseCalls.length).toBe(1);
+      const pausedContext = pauseCalls[0][1] as Record<string, unknown>;
+      expect(pausedContext.commandSnapshot).toContain('ORIGINAL gated body.');
+      expect(mockSendQueryDag.mock.calls[0][0] as string).toContain('ORIGINAL gated body.');
+
+      // While paused: the file is rewritten, then deleted entirely.
+      await writeFile(cmdPath, 'TAMPERED body that must never run');
+      unlinkSync(cmdPath);
+
+      // Invocation 2: approval resume with feedback (feedback forces a real
+      // resumed iteration rather than a bare-approve finalize).
+      mockSendQueryDag.mockClear();
+      mockSendQueryDag.mockImplementation(function* () {
+        yield { type: 'assistant', content: 'refined. <promise>COMPLETE</promise>' };
+        yield { type: 'result', sessionId: 'sid-gated-2' };
+      });
+      const resumedRun = makeWorkflowRun('gated-resume-run', {
+        metadata: {
+          approval: { ...pausedContext },
+          loop_user_input: 'tighten the summary',
+          loop_feedback_given: true,
+        },
+      });
+      const store2 = createMockStore();
+      const mockDeps2 = createMockDeps(store2);
+
+      await executeDagWorkflow(
+        mockDeps2,
+        platform,
+        'conv-dag',
+        testDir,
+        gatedWorkflow,
+        resumedRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      // The resumed iteration ran from the snapshot: original body, user
+      // feedback substituted, no trace of the tampered content, no failure
+      // from the deleted file.
+      expect(mockSendQueryDag.mock.calls.length).toBe(1);
+      const resumedPrompt = mockSendQueryDag.mock.calls[0][0] as string;
+      expect(resumedPrompt).toContain('ORIGINAL gated body.');
+      expect(resumedPrompt).toContain('USER=<<tighten the summary>>');
+      expect(resumedPrompt).not.toContain('TAMPERED');
+      const failed = (store2.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.filter(
+        (call: unknown[]) => (call[0] as Record<string, unknown>).event_type === 'node_failed'
+      );
+      expect(failed).toHaveLength(0);
+    });
+
+    it('closes the loop lifecycle with exactly one node_failed on max-iterations exhaustion', async () => {
+      // Failure finalizer contract: every failed exit after node_started goes
+      // through one finalizer — exactly one node_failed row per started loop
+      // node, paired with its node_started.
+      await writeFile(
+        join(testDir, '.archon', 'commands', 'exhaust-loop.md'),
+        'Body that never signals completion'
+      );
+
+      mockSendQueryDag.mockImplementation(function* () {
+        yield { type: 'assistant', content: 'still going, no signal' };
+        yield { type: 'result', sessionId: 'sid-exhaust' };
+      });
+
+      const store = createMockStore();
+      const mockDeps = createMockDeps(store);
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun();
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        {
+          name: 'loop-cmd-exhaust',
+          nodes: [
+            {
+              id: 'exhaust-loop',
+              loop: {
+                command: 'exhaust-loop',
+                until: 'COMPLETE',
+                max_iterations: 2,
+                fresh_context: true,
+              },
+            } as unknown as DagNode,
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      expect(mockSendQueryDag.mock.calls.length).toBe(2);
+      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+      const started = eventCalls.filter(
+        (call: unknown[]) =>
+          (call[0] as Record<string, unknown>).event_type === 'node_started' &&
+          (call[0] as Record<string, unknown>).step_name === 'exhaust-loop'
+      );
+      const failed = eventCalls.filter(
+        (call: unknown[]) =>
+          (call[0] as Record<string, unknown>).event_type === 'node_failed' &&
+          (call[0] as Record<string, unknown>).step_name === 'exhaust-loop'
+      );
+      expect(started).toHaveLength(1);
+      expect(failed).toHaveLength(1);
+      const data = (failed[0][0] as Record<string, unknown>).data as Record<string, unknown>;
+      expect(String(data.error)).toContain('exceeded max iterations');
     });
   });
 });
@@ -11760,6 +11946,79 @@ describe('executeDagWorkflow -- loop_group node', () => {
     // Two iterations: iter 1 (no signal) → iter 2 (DONE signal) → complete.
     expect(callCount).toBe(2);
     expect(result).toContain('iteration 2 final result');
+  });
+
+  it('runs a command-backed loop node inside a loop_group body with namespaced lifecycle events', async () => {
+    // A `loop:` body node may use `loop.command` like any top-level loop. The
+    // command body must reach the AI, and the loop's persisted lifecycle events
+    // must carry the `<groupId>.<nodeId>` namespaced step_name (#2090).
+    await writeFile(
+      join(testDir, '.archon', 'commands', 'body-loop-cmd.md'),
+      'Command-file body for the inner loop.'
+    );
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'inner work done. <promise>INNER_DONE</promise>\nDONE' };
+      yield { type: 'result', sessionId: 'lg-cmd-sess' };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('dag-loopgroup-cmd');
+
+    const nodes: DagNode[] = [
+      {
+        id: 'grp',
+        loop_group: {
+          until: 'DONE',
+          max_iterations: 3,
+          fresh_context: false,
+          nodes: [
+            {
+              id: 'inner-loop',
+              loop: {
+                command: 'body-loop-cmd',
+                until: 'INNER_DONE',
+                max_iterations: 2,
+                fresh_context: false,
+              },
+              depends_on: [],
+            } as unknown as DagNode,
+          ],
+        },
+        depends_on: [],
+      },
+    ];
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-lg',
+      testDir,
+      { name: 'dag-loopgroup-cmd', nodes },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    // The command file's body (not a YAML inline prompt) reached the AI.
+    expect(mockSendQueryDag.mock.calls.length).toBe(1);
+    expect(mockSendQueryDag.mock.calls[0][0] as string).toContain(
+      'Command-file body for the inner loop.'
+    );
+    // Inner-loop lifecycle events are namespaced under the group id.
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+    const innerStarted = eventCalls.filter(
+      (call: unknown[]) =>
+        (call[0] as Record<string, unknown>).event_type === 'node_started' &&
+        (call[0] as Record<string, unknown>).step_name === 'grp.inner-loop'
+    );
+    expect(innerStarted.length).toBeGreaterThanOrEqual(1);
   });
 
   it('delivers $LOOP_USER_INPUT to a resumed body script via env, never spliced into source (#2115)', async () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -6925,14 +6925,13 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('applies $LOOP_PREV_OUTPUT and $LOOP_USER_INPUT substitution to command-loaded text', async () => {
-      // Spec acceptance criterion: "All loop variable substitution applies to
-      // command-loaded prompt text identically to inline prompt text." We
-      // embed both `$LOOP_PREV_OUTPUT` and `$LOOP_USER_INPUT` inside the
-      // command file body and assert the prompt actually sent to the AI on
-      // each iteration substitutes them the same way the inline-prompt tests
-      // already verify for `loop.prompt`. The body itself must appear in the
-      // sent prompt — proof the file contents (not the YAML node body) flow
-      // through `substituteWorkflowVariables`.
+      // Loop variable substitution applies to command-loaded prompt text
+      // identically to inline prompt text: both `$LOOP_PREV_OUTPUT` and
+      // `$LOOP_USER_INPUT` are embedded in the command file body, and the
+      // prompt actually sent to the AI must substitute them the same way the
+      // inline-prompt tests verify for `loop.prompt`. The body itself must
+      // appear in the sent prompt — proof the file contents (not the YAML
+      // node body) flow through `substituteWorkflowVariables`.
       await writeFile(
         join(testDir, '.archon', 'commands', 'subst-loop.md'),
         'Cmd-file body. PREV=<<$LOOP_PREV_OUTPUT>> USER=<<$LOOP_USER_INPUT>>'

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -6803,6 +6803,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // The failing command name must travel with the event so consumers of the
       // event stream see the same context as the structured log.
       expect(data.command).toBe('does-not-exist-anywhere');
+
+      // node_started must be paired with node_failed even when the failure is
+      // pre-iteration — same lifecycle contract as bash and script nodes.
+      const started = eventCalls.find(
+        (call: unknown[]) =>
+          (call[0] as Record<string, unknown>).event_type === 'node_started' &&
+          (call[0] as Record<string, unknown>).step_name === 'missing-loop'
+      );
+      expect(started).toBeDefined();
     });
 
     it('fails fast with node_failed when loop.command target file is empty', async () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -6800,6 +6800,9 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect(failed).toBeDefined();
       const data = (failed![0] as Record<string, unknown>).data as Record<string, unknown>;
       expect(String(data.error)).toContain('not found');
+      // The failing command name must travel with the event so consumers of the
+      // event stream see the same context as the structured log.
+      expect(data.command).toBe('does-not-exist-anywhere');
     });
 
     it('fails fast with node_failed when loop.command target file is empty', async () => {
@@ -6851,6 +6854,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect(failed).toBeDefined();
       const data = (failed![0] as Record<string, unknown>).data as Record<string, unknown>;
       expect(String(data.error)).toContain('empty');
+      expect(data.command).toBe('empty-loop');
     });
 
     it('fails fast with node_failed when loop.command is an unsafe name', async () => {
@@ -6901,6 +6905,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect(failed).toBeDefined();
       const data = (failed![0] as Record<string, unknown>).data as Record<string, unknown>;
       expect(String(data.error)).toContain('Invalid command name');
+      expect(data.command).toBe('../escape');
     });
 
     it('applies $LOOP_PREV_OUTPUT and $LOOP_USER_INPUT substitution to command-loaded text', async () => {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3646,7 +3646,9 @@ async function executeLoopNode(
           workflow_run_id: workflowRun.id,
           event_type: 'node_failed',
           step_name: stepName,
-          data: { error: errMsg },
+          // Mirror the structured log context: callers reading the event stream
+          // need the failing command name too, not just the resolution error.
+          data: { error: errMsg, command: loop.command },
         })
         .catch((err: Error) => {
           getLog().error(

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3624,20 +3624,24 @@ async function executeLoopNode(
   // each event's data (`iteration`), so no separate iteration param is threaded here.
   const stepName = stepNamePrefix + node.id;
 
-  // Emit node_started up-front so every loop-node terminal event
-  // (node_failed from a pre-iteration command-load failure, node_failed from
-  // an iteration error, or node_completed at the end) is paired with a
-  // corresponding _started event — same pattern the bash and script node
-  // executors follow. Without this the new loop.command fail-fast path emits
-  // node_failed with no prior node_started.
-  getLog().info({ nodeId: node.id, type: 'loop' }, 'dag_node_started');
+  // Emit node_started up-front so every terminal outcome of this loop node is
+  // paired with a corresponding _started event — same pattern the bash and
+  // script node executors follow. The pairing contract: every `return` of a
+  // failed result below goes through `failLoopNode` (one terminal log line, one
+  // persisted node_failed row, exactly one node_failed emitter event), success
+  // paths write node_completed, and a gate pause intentionally has NO terminal
+  // event (the node is still in flight; the resumed invocation emits its own
+  // node_started and eventually the terminal event). Exits that THROW (e.g.
+  // until_bash system errors) are paired by the dispatcher's catch in
+  // runLayers, which emits its own node_failed.
+  getLog().info({ nodeId: node.id, type: 'loop' }, 'loop_node.started');
   await logNodeStart(logDir, workflowRun.id, node.id, '<loop>');
 
   deps.store
     .createWorkflowEvent({
       workflow_run_id: workflowRun.id,
       event_type: 'node_started',
-      step_name: node.id,
+      step_name: stepName,
       data: { type: 'loop', command: loop.command ?? null },
     })
     .catch((err: Error) => {
@@ -3654,48 +3658,122 @@ async function executeLoopNode(
     nodeName: node.id,
   });
 
+  /**
+   * Single failure finalizer for this loop node (see the pairing contract on
+   * the node_started comment above). Call sites keep their specific diagnostic
+   * logs/events (e.g. loop_iteration_failed with per-iteration data); this
+   * closes the node's lifecycle exactly once.
+   */
+  const failLoopNode = async (
+    error: string,
+    extras: {
+      output?: string;
+      costUsd?: number;
+      tokens?: TokenUsage;
+      loopIterations?: number;
+      /** Extra persisted node_failed payload (e.g. the failing command name). */
+      data?: Record<string, unknown>;
+    } = {}
+  ): Promise<NodeExecutionResult> => {
+    getLog().error({ nodeId: node.id, error, ...(extras.data ?? {}) }, 'loop_node.failed');
+    await logNodeError(logDir, workflowRun.id, node.id, error);
+    deps.store
+      .createWorkflowEvent({
+        workflow_run_id: workflowRun.id,
+        event_type: 'node_failed',
+        step_name: stepName,
+        data: { error, ...(extras.data ?? {}) },
+      })
+      .catch((err: Error) => {
+        getLog().error(
+          { err, workflowRunId: workflowRun.id, eventType: 'node_failed' },
+          'workflow_event_persist_failed'
+        );
+      });
+    getWorkflowEventEmitter().emit({
+      type: 'node_failed',
+      runId: workflowRun.id,
+      nodeId: node.id,
+      nodeName: node.id,
+      error,
+    });
+    return {
+      state: 'failed',
+      output: extras.output ?? '',
+      error,
+      ...(extras.costUsd !== undefined ? { costUsd: extras.costUsd } : {}),
+      ...(extras.tokens !== undefined ? { tokens: extras.tokens } : {}),
+      ...(extras.loopIterations !== undefined ? { loopIterations: extras.loopIterations } : {}),
+    };
+  };
+
+  // Detect interactive loop resume — check if workflowRun.metadata has loop gate state for this node
+  const rawApproval = workflowRun.metadata?.approval;
+  const loopGateMeta = isApprovalContext(rawApproval) ? rawApproval : undefined;
+  const isLoopResume = loopGateMeta?.type === 'interactive_loop' && loopGateMeta.nodeId === node.id;
+  const startIteration = isLoopResume ? (loopGateMeta.iteration ?? 0) + 1 : 1;
+  let currentSessionId: string | undefined = isLoopResume
+    ? (loopGateMeta.sessionId ?? undefined)
+    : undefined;
+  const loopGateRunMeta = (workflowRun.metadata ?? {}) as LoopGateRunMetadata;
+  const loopUserInput = isLoopResume ? (loopGateRunMeta.loop_user_input ?? '') : '';
+
+  // Finalize-on-approve (#2074): a gate that paused on a signal-bearing iteration,
+  // resumed WITHOUT feedback, completes the node from the persisted output instead of
+  // re-running the (expensive) iteration. Feedback (loop_feedback_given) OR a
+  // non-signaled gate falls through to a normal resumed iteration below. Runs
+  // BEFORE prompt-source resolution: a bare approve never needs the prompt, so a
+  // command file deleted while the run sat paused cannot fail the finalize.
+  const feedbackGiven = loopGateRunMeta.loop_feedback_given === true;
+  if (isLoopResume && loopGateMeta?.completionSignaled === true && !feedbackGiven) {
+    const finalizeOutput = loopGateMeta.signaledOutput ?? '';
+    await finalizeLoopFromSignal(
+      deps,
+      platform,
+      conversationId,
+      workflowRun,
+      node.id,
+      stepName,
+      'Loop node',
+      finalizeOutput
+    );
+    return { state: 'completed', output: finalizeOutput, sessionId: currentSessionId };
+  }
+
   // Resolve the iteration prompt source. `loop.prompt` is used directly;
-  // `loop.command` is read once here from a command file and the loaded text
-  // is reused for every iteration — editing the file mid-run cannot change the
-  // remaining iterations of this run. The schema guarantees exactly one of the
-  // two is defined.
+  // `loop.command` is read ONCE per run/node: the first invocation loads the
+  // command file, and the interactive gate persists the loaded text
+  // (`commandSnapshot` in the pause context) so a resumed invocation reuses the
+  // snapshot instead of re-reading — a command file edited or deleted while the
+  // run sat paused at a gate can neither change nor break the running loop's
+  // prompt. The schema guarantees exactly one of prompt/command is defined.
   let loopPromptTemplate: string;
   if (typeof loop.prompt === 'string') {
     loopPromptTemplate = loop.prompt;
   } else if (typeof loop.command === 'string') {
-    const promptResult = await loadCommandPrompt(deps, cwd, loop.command, configuredCommandFolder);
-    if (!promptResult.success) {
-      const errMsg = promptResult.message;
-      getLog().error(
-        { nodeId: node.id, command: loop.command, error: errMsg },
-        'loop_node.command_load_failed'
+    if (isLoopResume && typeof loopGateMeta?.commandSnapshot === 'string') {
+      loopPromptTemplate = loopGateMeta.commandSnapshot;
+    } else {
+      // Fresh execution — or a resume of a run paused under a build that
+      // predates commandSnapshot: fall back to a fresh read (documented,
+      // fail-safe) rather than failing an otherwise-valid resume.
+      const promptResult = await loadCommandPrompt(
+        deps,
+        cwd,
+        loop.command,
+        configuredCommandFolder
       );
-      await logNodeError(logDir, workflowRun.id, node.id, errMsg);
-      deps.store
-        .createWorkflowEvent({
-          workflow_run_id: workflowRun.id,
-          event_type: 'node_failed',
-          step_name: stepName,
-          // Mirror the structured log context: callers reading the event stream
-          // need the failing command name too, not just the resolution error.
-          data: { error: errMsg, command: loop.command },
-        })
-        .catch((err: Error) => {
-          getLog().error(
-            { err, workflowRunId: workflowRun.id, eventType: 'node_failed' },
-            'workflow_event_persist_failed'
-          );
-        });
-      getWorkflowEventEmitter().emit({
-        type: 'node_failed',
-        runId: workflowRun.id,
-        nodeId: node.id,
-        nodeName: node.id,
-        error: errMsg,
-      });
-      return { state: 'failed', output: '', error: errMsg };
+      if (!promptResult.success) {
+        getLog().error(
+          { nodeId: node.id, command: loop.command, error: promptResult.message },
+          'loop_node.command_load_failed'
+        );
+        // The failing command name travels on the node_failed payload so the
+        // event stream carries the same context as the structured log.
+        return failLoopNode(promptResult.message, { data: { command: loop.command } });
+      }
+      loopPromptTemplate = promptResult.content;
     }
-    loopPromptTemplate = promptResult.content;
   } else {
     // Unreachable: superRefine on loopNodeConfigSchema enforces exactly-one.
     throw new Error(
@@ -3714,38 +3792,7 @@ async function executeLoopNode(
       { err, nodeId: node.id, provider: workflowProvider },
       'loop_node.provider_failed'
     );
-    return { state: 'failed', output: '', error: errorMsg };
-  }
-
-  // Detect interactive loop resume — check if workflowRun.metadata has loop gate state for this node
-  const rawApproval = workflowRun.metadata?.approval;
-  const loopGateMeta = isApprovalContext(rawApproval) ? rawApproval : undefined;
-  const isLoopResume = loopGateMeta?.type === 'interactive_loop' && loopGateMeta.nodeId === node.id;
-  const startIteration = isLoopResume ? (loopGateMeta.iteration ?? 0) + 1 : 1;
-  let currentSessionId: string | undefined = isLoopResume
-    ? (loopGateMeta.sessionId ?? undefined)
-    : undefined;
-  const loopGateRunMeta = (workflowRun.metadata ?? {}) as LoopGateRunMetadata;
-  const loopUserInput = isLoopResume ? (loopGateRunMeta.loop_user_input ?? '') : '';
-
-  // Finalize-on-approve (#2074): a gate that paused on a signal-bearing iteration,
-  // resumed WITHOUT feedback, completes the node from the persisted output instead of
-  // re-running the (expensive) iteration. Feedback (loop_feedback_given) OR a
-  // non-signaled gate falls through to a normal resumed iteration below.
-  const feedbackGiven = loopGateRunMeta.loop_feedback_given === true;
-  if (isLoopResume && loopGateMeta?.completionSignaled === true && !feedbackGiven) {
-    const finalizeOutput = loopGateMeta.signaledOutput ?? '';
-    await finalizeLoopFromSignal(
-      deps,
-      platform,
-      conversationId,
-      workflowRun,
-      node.id,
-      stepName,
-      'Loop node',
-      finalizeOutput
-    );
-    return { state: 'completed', output: finalizeOutput, sessionId: currentSessionId };
+    return failLoopNode(errorMsg, { data: { provider: workflowProvider } });
   }
 
   let lastIterationOutput = '';
@@ -3789,7 +3836,12 @@ async function executeLoopNode(
         `Loop node '${node.id}' stopped at iteration ${String(i)} (${effectiveStatus})`,
         msgContext
       );
-      return { state: 'failed', output: '', error: `Workflow ${effectiveStatus}` };
+      return failLoopNode(`Workflow ${effectiveStatus}`, {
+        costUsd: loopTotalCostUsd,
+        ...(loopTotalTokens !== undefined ? { tokens: loopTotalTokens } : {}),
+        loopIterations: i - 1,
+        data: { status: effectiveStatus, iteration: i },
+      });
     }
 
     // Emit iteration started
@@ -4165,14 +4217,12 @@ async function executeLoopNode(
           `Loop node '${node.id}' stopped during iteration ${String(i)} (${effectiveStatus})`,
           msgContext
         );
-        return {
-          state: 'failed',
-          output: '',
-          error: `Workflow ${effectiveStatus}`,
+        return await failLoopNode(`Workflow ${effectiveStatus}`, {
           costUsd: loopTotalCostUsd,
           ...(loopTotalTokens !== undefined ? { tokens: loopTotalTokens } : {}),
           loopIterations: i,
-        };
+          data: { status: effectiveStatus, iteration: i },
+        });
       }
     } catch (error) {
       foldIterationUsage();
@@ -4196,14 +4246,12 @@ async function executeLoopNode(
         .catch((evtErr: Error) => {
           logEventStoreError(evtErr, i);
         });
-      return {
-        state: 'failed',
-        output: '',
-        error: `Loop iteration ${i} failed: ${err.message}`,
+      return failLoopNode(`Loop iteration ${i} failed: ${err.message}`, {
         costUsd: loopTotalCostUsd,
         ...(loopTotalTokens !== undefined ? { tokens: loopTotalTokens } : {}),
         loopIterations: i,
-      };
+        data: { iteration: i },
+      });
     }
 
     // Notify on idle timeout
@@ -4254,14 +4302,12 @@ async function executeLoopNode(
         .catch((evtErr: Error) => {
           logEventStoreError(evtErr, i);
         });
-      return {
-        state: 'failed',
-        output: '',
-        error: `Loop iteration ${i} failed: ${emptyError}`,
+      return failLoopNode(`Loop iteration ${i} failed: ${emptyError}`, {
         costUsd: loopTotalCostUsd,
         ...(loopTotalTokens !== undefined ? { tokens: loopTotalTokens } : {}),
         loopIterations: i,
-      };
+        data: { iteration: i },
+      });
     }
 
     // Batch mode: send accumulated output
@@ -4474,11 +4520,16 @@ async function executeLoopNode(
           { nodeId: node.id, workflowRunId: workflowRun.id, iteration: i },
           'loop_node.gate_message_send_failed'
         );
-        return {
-          state: 'failed',
-          output: lastIterationOutput,
-          error: `Loop gate message failed to deliver for node '${node.id}' — cannot pause safely`,
-        };
+        return failLoopNode(
+          `Loop gate message failed to deliver for node '${node.id}' — cannot pause safely`,
+          {
+            output: lastIterationOutput,
+            costUsd: loopTotalCostUsd,
+            ...(loopTotalTokens !== undefined ? { tokens: loopTotalTokens } : {}),
+            loopIterations: i,
+            data: { iteration: i },
+          }
+        );
       }
       deps.store
         .createWorkflowEvent({
@@ -4503,6 +4554,10 @@ async function executeLoopNode(
         // for honesty; pauseWorkflowRun nulls both on every fresh pause.
         completionSignaled: completionDetected,
         signaledOutput: completionDetected ? lastIterationOutput : null,
+        // Read-once command body for command-backed loops: the resumed invocation
+        // reuses this snapshot instead of re-reading the file (explicit null for
+        // prompt-based loops — same json_patch convention as `sessionId`).
+        commandSnapshot: typeof loop.command === 'string' ? loopPromptTemplate : null,
       });
       // Return completed — the between-layer status check sees 'paused' and halts cleanly.
       // This mirrors the approval-node pattern, preventing false "DAG nodes failed" warnings
@@ -4525,14 +4580,13 @@ async function executeLoopNode(
     'loop_node.max_iterations_reached'
   );
   await safeSendMessage(platform, conversationId, errorMsg, msgContext);
-  return {
-    state: 'failed',
+  return failLoopNode(errorMsg, {
     output: lastIterationOutput,
-    error: errorMsg,
     costUsd: loopTotalCostUsd,
     ...(loopTotalTokens !== undefined ? { tokens: loopTotalTokens } : {}),
     loopIterations: loop.max_iterations,
-  };
+    data: { maxIterations: loop.max_iterations },
+  });
 }
 
 /**

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3530,7 +3530,11 @@ export function applyLoopPrevToBodyNode(
       ...node,
       loop: {
         ...node.loop,
-        prompt: sub(node.loop.prompt),
+        // A command-backed loop has no inline prompt to substitute — its prompt text
+        // is loaded from the command file inside executeLoopNode. Group-level
+        // $LOOP_PREV.<bodyId>.output refs are resolved only in YAML fields (this
+        // pass); they are not scanned inside command-file bodies.
+        ...(node.loop.prompt !== undefined ? { prompt: sub(node.loop.prompt) } : {}),
         ...(node.loop.until_bash !== undefined
           ? { until_bash: sub(node.loop.until_bash, true) }
           : {}),
@@ -3609,6 +3613,7 @@ async function executeLoopNode(
   nodeOutputs: Map<string, NodeOutput>,
   config: WorkflowConfig,
   issueContext?: string,
+  configuredCommandFolder?: string,
   stepNamePrefix = '',
   execContext: ExecutionContext = { kind: 'host' }
 ): Promise<NodeExecutionResult> {
@@ -3618,6 +3623,53 @@ async function executeLoopNode(
   // ('' → node.id at top level, #2090). The loop's own per-iteration number lives in
   // each event's data (`iteration`), so no separate iteration param is threaded here.
   const stepName = stepNamePrefix + node.id;
+
+  // Resolve the iteration prompt source. `loop.prompt` is used directly;
+  // `loop.command` is read once here from a command file and the loaded text
+  // is reused for every iteration — editing the file mid-run cannot change the
+  // remaining iterations of this run. The schema guarantees exactly one of the
+  // two is defined.
+  let loopPromptTemplate: string;
+  if (typeof loop.prompt === 'string') {
+    loopPromptTemplate = loop.prompt;
+  } else if (typeof loop.command === 'string') {
+    const promptResult = await loadCommandPrompt(deps, cwd, loop.command, configuredCommandFolder);
+    if (!promptResult.success) {
+      const errMsg = promptResult.message;
+      getLog().error(
+        { nodeId: node.id, command: loop.command, error: errMsg },
+        'loop_node.command_load_failed'
+      );
+      await logNodeError(logDir, workflowRun.id, node.id, errMsg);
+      deps.store
+        .createWorkflowEvent({
+          workflow_run_id: workflowRun.id,
+          event_type: 'node_failed',
+          step_name: stepName,
+          data: { error: errMsg },
+        })
+        .catch((err: Error) => {
+          getLog().error(
+            { err, workflowRunId: workflowRun.id, eventType: 'node_failed' },
+            'workflow_event_persist_failed'
+          );
+        });
+      getWorkflowEventEmitter().emit({
+        type: 'node_failed',
+        runId: workflowRun.id,
+        nodeId: node.id,
+        nodeName: node.id,
+        error: errMsg,
+      });
+      return { state: 'failed', output: '', error: errMsg };
+    }
+    loopPromptTemplate = promptResult.content;
+  } else {
+    // Unreachable: superRefine on loopNodeConfigSchema enforces exactly-one.
+    throw new Error(
+      `Loop node '${node.id}' has neither 'loop.prompt' nor 'loop.command' — schema invariant violated`
+    );
+  }
 
   // Resolve AI client — fail fast with descriptive error
   let aiClient: ReturnType<typeof deps.getAgentProvider>;
@@ -3788,7 +3840,7 @@ async function executeLoopNode(
       // executor starts a fresh `lastIterationOutput` variable, so the first iteration of
       // the resume also receives an empty $LOOP_PREV_OUTPUT.
       const { prompt: substitutedPrompt } = substituteWorkflowVariables(
-        loop.prompt,
+        loopPromptTemplate,
         workflowRun.id,
         workflowRun.user_message,
         artifactsDir,
@@ -5144,6 +5196,7 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
               ctx.nodeOutputs,
               config,
               issueContext,
+              configuredCommandFolder,
               stepNamePrefix,
               execContext
             );

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3624,6 +3624,36 @@ async function executeLoopNode(
   // each event's data (`iteration`), so no separate iteration param is threaded here.
   const stepName = stepNamePrefix + node.id;
 
+  // Emit node_started up-front so every loop-node terminal event
+  // (node_failed from a pre-iteration command-load failure, node_failed from
+  // an iteration error, or node_completed at the end) is paired with a
+  // corresponding _started event — same pattern the bash and script node
+  // executors follow. Without this the new loop.command fail-fast path emits
+  // node_failed with no prior node_started.
+  getLog().info({ nodeId: node.id, type: 'loop' }, 'dag_node_started');
+  await logNodeStart(logDir, workflowRun.id, node.id, '<loop>');
+
+  deps.store
+    .createWorkflowEvent({
+      workflow_run_id: workflowRun.id,
+      event_type: 'node_started',
+      step_name: node.id,
+      data: { type: 'loop', command: loop.command ?? null },
+    })
+    .catch((err: Error) => {
+      getLog().error(
+        { err, workflowRunId: workflowRun.id, eventType: 'node_started' },
+        'workflow_event_persist_failed'
+      );
+    });
+
+  getWorkflowEventEmitter().emit({
+    type: 'node_started',
+    runId: workflowRun.id,
+    nodeId: node.id,
+    nodeName: node.id,
+  });
+
   // Resolve the iteration prompt source. `loop.prompt` is used directly;
   // `loop.command` is read once here from a command file and the loaded text
   // is reused for every iteration — editing the file mid-run cannot change the

--- a/packages/workflows/src/include-expander.ts
+++ b/packages/workflows/src/include-expander.ts
@@ -147,7 +147,9 @@ function rewriteNodeOutputRefs(node: DagNode, rename: (id: string) => string): v
   if (node.when !== undefined) node.when = whenExpr(node.when);
 
   if (isLoopNode(node)) {
-    node.loop.prompt = prose(node.loop.prompt);
+    // A command-backed loop has no inline prompt; its `command` is a NAME, not a ref
+    // (same rule as `command:` nodes above), so there is nothing to rewrite.
+    if (node.loop.prompt !== undefined) node.loop.prompt = prose(node.loop.prompt);
     if (node.loop.until_bash !== undefined) node.loop.until_bash = code(node.loop.until_bash);
   } else if (isLoopGroupNode(node)) {
     if (node.loop_group.until_bash !== undefined) {

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -2743,6 +2743,152 @@ nodes:
       );
     });
 
+    // -----------------------------------------------------------------------
+    // loop.command — alternative to loop.prompt that loads the iteration
+    // prompt from a command file (parallel to how `command:` nodes work).
+    // The loader only enforces the schema-level "exactly one" rule and the
+    // command-name safety rule; file resolution is validator-level (Level 3)
+    // and is covered separately in validator.test.ts.
+    // -----------------------------------------------------------------------
+
+    it('should parse a loop node with loop.command (no inline prompt)', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+
+      await writeFile(
+        join(workflowDir, 'loop-cmd-only.yaml'),
+        `
+name: loop-cmd-only
+description: Command-backed loop
+nodes:
+  - id: my-loop
+    loop:
+      command: my-loop-cmd
+      until: COMPLETE
+      max_iterations: 5
+`
+      );
+
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.errors).toHaveLength(0);
+      expect(result.workflows).toHaveLength(1);
+
+      const node = result.workflows[0].workflow.nodes[0];
+      expect(isLoopNode(node)).toBe(true);
+      if (isLoopNode(node)) {
+        expect(node.loop.command).toBe('my-loop-cmd');
+        expect(node.loop.prompt).toBeUndefined();
+      }
+    });
+
+    it('should reject a loop node with both loop.prompt and loop.command', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+
+      await writeFile(
+        join(workflowDir, 'loop-both.yaml'),
+        `
+name: loop-both
+description: Both prompt and command on loop
+nodes:
+  - id: my-loop
+    loop:
+      prompt: "Do stuff."
+      command: my-loop-cmd
+      until: DONE
+      max_iterations: 5
+`
+      );
+
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.errors.length).toBeGreaterThan(0);
+      // Error must mention the "exactly one" rule and both candidate fields,
+      // so authors immediately understand the conflict.
+      expect(result.errors[0].error).toContain('exactly one');
+      expect(result.errors[0].error).toContain('loop.prompt');
+      expect(result.errors[0].error).toContain('loop.command');
+    });
+
+    it('should reject a loop node with neither loop.prompt nor loop.command (message mentions both options)', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+
+      await writeFile(
+        join(workflowDir, 'loop-neither.yaml'),
+        `
+name: loop-neither
+description: Loop with no prompt source
+nodes:
+  - id: my-loop
+    loop:
+      until: DONE
+      max_iterations: 5
+`
+      );
+
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.errors.length).toBeGreaterThan(0);
+      // Error must offer both alternatives, not just the legacy 'loop.prompt'
+      // path, so authors discover loop.command exists.
+      expect(result.errors[0].error).toContain('loop.prompt');
+      expect(result.errors[0].error).toContain('loop.command');
+    });
+
+    it("should reject a loop node whose loop.command is an unsafe name ('../escape')", async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+
+      await writeFile(
+        join(workflowDir, 'loop-unsafe-cmd.yaml'),
+        `
+name: loop-unsafe-cmd
+description: Loop with unsafe command name
+nodes:
+  - id: my-loop
+    loop:
+      command: "../escape"
+      until: DONE
+      max_iterations: 5
+`
+      );
+
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0].error).toContain('invalid command name');
+      expect(result.errors[0].error).toContain('../escape');
+    });
+
+    it('should not false-positive the $nodeId.output ref scan on a command-backed loop with a sibling that consumes its output', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+
+      // Regression guard for the loader change that skips the ref scan when
+      // loop.prompt is absent: the scanner must (a) not crash trying to read
+      // the missing inline prompt, and (b) still register the loop's id so a
+      // sibling can reference `$my-loop.output` like any other node output.
+      await writeFile(
+        join(workflowDir, 'loop-cmd-with-sibling.yaml'),
+        `
+name: loop-cmd-with-sibling
+description: Command-backed loop with a downstream consumer
+nodes:
+  - id: my-loop
+    loop:
+      command: my-loop-cmd
+      until: DONE
+      max_iterations: 3
+  - id: consumer
+    depends_on: [my-loop]
+    prompt: "Process the loop output: $my-loop.output"
+`
+      );
+
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.errors).toHaveLength(0);
+      expect(result.workflows).toHaveLength(1);
+      expect(result.workflows[0].workflow.nodes).toHaveLength(2);
+    });
+
     it('should accept a loop with signal_completes (loads without errors)', async () => {
       const workflowDir = join(testDir, '.archon', 'workflows');
       await mkdir(workflowDir, { recursive: true });

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -2893,11 +2893,12 @@ nodes:
       const workflowDir = join(testDir, '.archon', 'workflows');
       await mkdir(workflowDir, { recursive: true });
 
-      // Regression guard: a quoted YAML value like `" my-loop-cmd "` (or one with
-      // a stray trailing newline from awkward block scalars) must not pass parse
-      // with whitespace intact, because downstream `loadCommandPrompt` resolves
-      // the literal filename and would fail at runtime with a confusing
-      // "not found" instead of failing fast at parse with a clearer error.
+      // Parsing NORMALIZES the command name (schema-level trim) rather than
+      // rejecting it: a quoted YAML value like `" my-loop-cmd "` (or one with a
+      // stray trailing newline from awkward block scalars) is stored trimmed,
+      // so downstream `loadCommandPrompt` — which resolves the literal filename
+      // — sees the same name the author meant instead of failing at runtime
+      // with a confusing "not found".
       await writeFile(
         join(workflowDir, 'loop-cmd-whitespace.yaml'),
         `

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -2889,6 +2889,40 @@ nodes:
       expect(result.workflows[0].workflow.nodes).toHaveLength(2);
     });
 
+    it('should trim surrounding whitespace from loop.command so resolution sees the normalized name', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+
+      // Regression guard: a quoted YAML value like `" my-loop-cmd "` (or one with
+      // a stray trailing newline from awkward block scalars) must not pass parse
+      // with whitespace intact, because downstream `loadCommandPrompt` resolves
+      // the literal filename and would fail at runtime with a confusing
+      // "not found" instead of failing fast at parse with a clearer error.
+      await writeFile(
+        join(workflowDir, 'loop-cmd-whitespace.yaml'),
+        `
+name: loop-cmd-whitespace
+description: Command-backed loop with stray whitespace around the name
+nodes:
+  - id: my-loop
+    loop:
+      command: "  my-loop-cmd  "
+      until: DONE
+      max_iterations: 3
+`
+      );
+
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.errors).toHaveLength(0);
+      expect(result.workflows).toHaveLength(1);
+
+      const node = result.workflows[0].workflow.nodes[0];
+      expect(isLoopNode(node)).toBe(true);
+      if (isLoopNode(node)) {
+        expect(node.loop.command).toBe('my-loop-cmd');
+      }
+    });
+
     it('should accept a loop with signal_completes (loads without errors)', async () => {
       const workflowDir = join(testDir, '.archon', 'workflows');
       await mkdir(workflowDir, { recursive: true });

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -245,7 +245,13 @@ export function validateDagStructure(
     if (isCancelNode(node)) sources.push(node.cancel);
     if (isApprovalNode(node)) sources.push(node.approval.message);
     if (isLoopNode(node)) {
-      sources.push(stripMarkdownCode(node.loop.prompt));
+      // Only inline `loop.prompt` is scanned for `$nodeId.output` refs. A
+      // command-backed loop (`loop.command`) loads its prompt text from a file
+      // at runtime; that file's contents are the author's responsibility, the
+      // same way a `command:` node's body is not scanned at parse time.
+      if (typeof node.loop.prompt === 'string') {
+        sources.push(stripMarkdownCode(node.loop.prompt));
+      }
       if (node.loop.until_bash) sources.push(node.loop.until_bash);
     }
     if (isLoopGroupNode(node) && node.loop_group.until_bash) {

--- a/packages/workflows/src/schemas/loop.ts
+++ b/packages/workflows/src/schemas/loop.ts
@@ -9,6 +9,7 @@
  * session reset, interactive gate). Each variant extends it with its body shape.
  */
 import { z } from '@hono/zod-openapi';
+import { isValidCommandName } from '../command-validation';
 
 /**
  * Shared iteration-control fields for `loop:` and `loop_group:`.
@@ -48,10 +49,48 @@ export const loopControlSchema = z
 
 export type LoopControl = z.infer<typeof loopControlSchema>;
 
-/** `loop:` node config — iteration control plus a single inline prompt. */
-export const loopNodeConfigSchema = loopControlSchema.extend({
-  /** Inline prompt text executed each iteration. */
-  prompt: z.string().min(1, "loop node requires 'loop.prompt' (non-empty string)"),
-});
+/**
+ * `loop:` node config — iteration control plus exactly one iteration-prompt source:
+ * an inline `prompt` or a named command file (`command`). `loop_group:` shares only
+ * the control surface, so the one-of refinement lives here, not on `loopControlSchema`.
+ */
+export const loopNodeConfigSchema = loopControlSchema
+  .extend({
+    /** Inline prompt text executed each iteration. Mutually exclusive with `command`. */
+    prompt: z.string().min(1, "'loop.prompt' must be a non-empty string").optional(),
+    /**
+     * Named command file (under `.archon/commands/`) whose body is loaded as the iteration
+     * prompt. Resolved with repo → home → bundled precedence, identical to `command:` nodes.
+     * Mutually exclusive with `prompt`.
+     */
+    command: z.string().min(1, "'loop.command' must be a non-empty string").optional(),
+  })
+  .superRefine((data, ctx) => {
+    const hasPrompt = typeof data.prompt === 'string' && data.prompt.length > 0;
+    const hasCommand = typeof data.command === 'string' && data.command.length > 0;
+
+    if (hasPrompt && hasCommand) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "loop node accepts exactly one of 'loop.prompt' or 'loop.command' (both were provided)",
+        path: ['command'],
+      });
+    } else if (!hasPrompt && !hasCommand) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "loop node requires either 'loop.prompt' (inline) or 'loop.command' (file)",
+        path: ['prompt'],
+      });
+    }
+
+    if (hasCommand && !isValidCommandName((data.command ?? '').trim())) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `invalid command name "${(data.command ?? '').trim()}" — must not contain path separators, '..', or start with '.'`,
+        path: ['command'],
+      });
+    }
+  });
 
 export type LoopNodeConfig = z.infer<typeof loopNodeConfigSchema>;

--- a/packages/workflows/src/schemas/loop.ts
+++ b/packages/workflows/src/schemas/loop.ts
@@ -61,9 +61,11 @@ export const loopNodeConfigSchema = loopControlSchema
     /**
      * Named command file (under `.archon/commands/`) whose body is loaded as the iteration
      * prompt. Resolved with repo → home → bundled precedence, identical to `command:` nodes.
-     * Mutually exclusive with `prompt`.
+     * Mutually exclusive with `prompt`. Surrounding whitespace is trimmed so the stored value
+     * matches what downstream resolution sees — otherwise a value like `" my-cmd "` could pass
+     * parse-time validation and fail at runtime with a confusing "not found" error.
      */
-    command: z.string().min(1, "'loop.command' must be a non-empty string").optional(),
+    command: z.string().trim().min(1, "'loop.command' must be a non-empty string").optional(),
   })
   .superRefine((data, ctx) => {
     const hasPrompt = typeof data.prompt === 'string' && data.prompt.length > 0;
@@ -84,10 +86,10 @@ export const loopNodeConfigSchema = loopControlSchema
       });
     }
 
-    if (hasCommand && !isValidCommandName((data.command ?? '').trim())) {
+    if (hasCommand && !isValidCommandName(data.command ?? '')) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: `invalid command name "${(data.command ?? '').trim()}" — must not contain path separators, '..', or start with '.'`,
+        message: `invalid command name "${data.command ?? ''}" — must not contain path separators, '..', or start with '.'`,
         path: ['command'],
       });
     }

--- a/packages/workflows/src/schemas/workflow-run.ts
+++ b/packages/workflows/src/schemas/workflow-run.ts
@@ -194,6 +194,16 @@ export interface ApprovalContext {
    * downstream `$nodeId.output` refs. Only set when completionSignaled is true; null otherwise.
    */
   signaledOutput?: string | null;
+  /**
+   * Interactive-loop only. Read-once snapshot of a command-backed loop's
+   * (`loop.command`) loaded prompt body, persisted at gate pause so the resumed
+   * invocation reuses the exact text the run started with — a command file
+   * edited or deleted while the run sat paused cannot change or break the
+   * running loop's prompt. Null for prompt-based loops (explicit-null pause
+   * convention, same as `sessionId`). Absent on runs paused by builds that
+   * predate this field — the resume path then falls back to re-reading the file.
+   */
+  commandSnapshot?: string | null;
 }
 
 /**

--- a/packages/workflows/src/validator.test.ts
+++ b/packages/workflows/src/validator.test.ts
@@ -281,6 +281,129 @@ describe('validateWorkflowResources — portable model refs', () => {
 });
 
 // =============================================================================
+// validateWorkflowResources — loop.command (mirrors command-node coverage)
+// =============================================================================
+
+describe('validateWorkflowResources — loop.command', () => {
+  // Helper: build a loop node carrying `loop.command`. We bypass the parser via
+  // `as DagNode` for parity with the command-node tests above, which lets the
+  // validator branch be exercised directly even for inputs the schema would
+  // reject (e.g. an unsafe `loop.command` name).
+  function makeLoopCommandNode(id: string, loopCommand: string): DagNode {
+    return {
+      id,
+      loop: {
+        command: loopCommand,
+        until: 'DONE',
+        max_iterations: 5,
+        fresh_context: false,
+      },
+    } as unknown as DagNode;
+  }
+
+  test('no issues when repo-local command file exists', async () => {
+    // Repo-scope hit: confirms the validator reuses the same repo lookup that
+    // command-nodes use, so a `loop.command` pointing at an existing
+    // `.archon/commands/<name>.md` clears Level 3 silently.
+    await createCommandFile('my-loop-command');
+    const workflow = makeWorkflow('test', [makeLoopCommandNode('step1', 'my-loop-command')]);
+    const issues = await validateWorkflowResources(workflow, tmpDir, {
+      loadDefaultCommands: false,
+    });
+    const errors = issues.filter(i => i.level === 'error');
+    expect(errors).toHaveLength(0);
+  });
+
+  test('error with suggestions when loop.command target is missing', async () => {
+    // Missing target should produce exactly one `field: 'loop.command'` error,
+    // and the suggestions list should populate from `findSimilar` over the
+    // already-discovered command names — the same affordance command-nodes get.
+    await createCommandFile('archon-ralph-implement');
+    const workflow = makeWorkflow('test', [makeLoopCommandNode('step1', 'archon-ralph-implemen')]);
+    const issues = await validateWorkflowResources(workflow, tmpDir, {
+      loadDefaultCommands: false,
+    });
+    const errors = issues.filter(i => i.level === 'error');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].field).toBe('loop.command');
+    expect(errors[0].nodeId).toBe('step1');
+    expect(errors[0].message).toContain("Command 'archon-ralph-implemen' not found");
+    expect(errors[0].suggestions).toContain('archon-ralph-implement');
+  });
+
+  test('error for invalid (unsafe) loop.command name', async () => {
+    // Defense-in-depth: the loop schema's superRefine already rejects unsafe
+    // names at parse time, but a programmatically-constructed workflow can
+    // bypass that path. The validator must still flag it with a clear
+    // `field: 'loop.command'` error rather than treating it as a missing file.
+    const workflow = makeWorkflow('test', [makeLoopCommandNode('step1', '../escape')]);
+    const issues = await validateWorkflowResources(workflow, tmpDir, {
+      loadDefaultCommands: false,
+    });
+    const errors = issues.filter(i => i.level === 'error');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].field).toBe('loop.command');
+    expect(errors[0].message).toContain('Invalid command name');
+  });
+
+  test('no issues when loop.command resolves to a bundled default', async () => {
+    // Bundled-default fallback: a `loop.command` referencing a known bundled
+    // command (e.g. `archon-ralph-generate`) must resolve when defaults are
+    // loaded, even with an empty repo `.archon/commands/`. This is the same
+    // precedence command-nodes already get (repo → home → bundled).
+    const workflow = makeWorkflow('test', [makeLoopCommandNode('step1', 'archon-ralph-generate')]);
+    const issues = await validateWorkflowResources(workflow, tmpDir);
+    const errors = issues.filter(i => i.level === 'error' && i.field === 'loop.command');
+    expect(errors).toHaveLength(0);
+  });
+
+  // --- Home-scoped resolution: mirrors the equivalent command-node test path.
+  // Uses the same ARCHON_HOME swap as the existing home-scope block so the
+  // walks of repo / home / bundled all see the temp dirs.
+  describe('home-scoped loop.command', () => {
+    let homeDir: string;
+    const originalArchonHome = process.env.ARCHON_HOME;
+    const originalArchonDocker = process.env.ARCHON_DOCKER;
+
+    beforeEach(async () => {
+      homeDir = await mkdtemp(join(tmpdir(), 'validator-loop-home-'));
+      process.env.ARCHON_HOME = homeDir;
+      delete process.env.ARCHON_DOCKER;
+    });
+
+    afterEach(async () => {
+      await rm(homeDir, { recursive: true, force: true });
+      if (originalArchonHome === undefined) {
+        delete process.env.ARCHON_HOME;
+      } else {
+        process.env.ARCHON_HOME = originalArchonHome;
+      }
+      if (originalArchonDocker === undefined) {
+        delete process.env.ARCHON_DOCKER;
+      } else {
+        process.env.ARCHON_DOCKER = originalArchonDocker;
+      }
+    });
+
+    async function createHomeCommand(name: string, content = '# Home helper'): Promise<void> {
+      const dir = join(homeDir, 'commands');
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, `${name}.md`), content);
+    }
+
+    test('resolves a loop.command placed under ~/.archon/commands/', async () => {
+      await createHomeCommand('only-in-home-loop');
+      const workflow = makeWorkflow('test', [makeLoopCommandNode('step1', 'only-in-home-loop')]);
+      const issues = await validateWorkflowResources(workflow, tmpDir, {
+        loadDefaultCommands: false,
+      });
+      const errors = issues.filter(i => i.level === 'error');
+      expect(errors).toHaveLength(0);
+    });
+  });
+});
+
+// =============================================================================
 // validateWorkflowResources — MCP validation
 // =============================================================================
 

--- a/packages/workflows/src/validator.ts
+++ b/packages/workflows/src/validator.ts
@@ -406,6 +406,37 @@ export async function validateWorkflowResources(
       }
     }
 
+    // --- Loop nodes with loop.command: check file exists (parallel to command-node check above) ---
+    if (isLoopNode(node) && node.loop.command !== undefined) {
+      const loopCommand = node.loop.command;
+      if (!isValidCommandName(loopCommand)) {
+        issues.push({
+          level: 'error',
+          nodeId: node.id,
+          field: 'loop.command',
+          message: `Invalid command name '${loopCommand}' — must not contain '/', '\\', '..', or start with '.'`,
+          hint: 'Use a simple name like "my-command" (without path separators or the .md extension)',
+        });
+      } else {
+        const resolved = await resolveCommand(loopCommand, cwd, config);
+        if (!resolved) {
+          const similar = findSimilar(loopCommand, availableCommands);
+          const issue: ValidationIssue = {
+            level: 'error',
+            nodeId: node.id,
+            field: 'loop.command',
+            message: `Command '${loopCommand}' not found`,
+            hint: `Create .archon/commands/${loopCommand}.md or use an existing command name`,
+          };
+          if (similar.length > 0) {
+            issue.hint = `Did you mean: ${similar.map(s => `'${s}'`).join(', ')}? Or create .archon/commands/${loopCommand}.md`;
+            issue.suggestions = similar;
+          }
+          issues.push(issue);
+        }
+      }
+    }
+
     // --- MCP nodes: check config file exists and is valid JSON ---
     if ('mcp' in node && typeof node.mcp === 'string') {
       const mcpPath = isAbsolute(node.mcp) ? node.mcp : resolve(cwd, node.mcp);


### PR DESCRIPTION
## Summary

- **Problem:** A workflow loop node could only carry its iteration prompt inline (`loop.prompt`), with no way to externalise it to a command file — even though every non-loop AI prompt has this escape hatch via `command:` nodes (`loadCommandPrompt`).
- **Why it matters:** The longest prompts in workflows (Ralph-style implement/build loops, iterate-until-valid loops) are exactly the ones stuck inline. The bundled `archon-ralph-dag.yaml` inlines ~460 lines in its `implement` loop for this reason.
- **What changed:** Added an optional `loop.command` field that loads the iteration prompt from a command file via the existing `loadCommandPrompt` resolver. Mutually exclusive with `loop.prompt` — exactly one is required. Schema, executor, validator, web types, canvas label, docs, and tests at every layer.
- **What did NOT change (scope boundary):** No bundled workflows refactored. No generic `prompt_file:` for other node types. No visual loop-node editor (none exists today — builder involvement is limited to API types + canvas label). No DB changes, no new external calls.

## UX Journey

### Before
```
Workflow author wants to externalise a long loop prompt:
  author ──▶ loop.prompt: |  (~460 lines inline in YAML)
  author ◀── no alternative; stuck inline
```

### After
```
Workflow author wants to externalise a long loop prompt:
  author ──▶ extract prompt to .archon/commands/my-loop.md
  author ──▶ loop.command: my-loop                                [+]
  engine  ──▶ loadCommandPrompt() (repo → home → bundled)
  engine  ──▶ reuses loaded text every iteration, with variable substitution
```

## Architecture Diagram

### Before
```
loop node    ──▶ loop.prompt (inline string)
              ──▶ substituteWorkflowVariables() ──▶ AI iteration

command node ──▶ loadCommandPrompt() ──▶ command file body ──▶ AI step
                  (repo → home → bundled)
```

### After
```
loop node    ──▶ loop.prompt (inline string) ─────────────────┐
              ──▶ loop.command [+] ──▶ loadCommandPrompt() ───┤
                                       (read once at node start) ──▶ substituteWorkflowVariables()
                                                                      ──▶ AI iteration (reused per iteration)

command node ──▶ loadCommandPrompt() (unchanged)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `executeLoopNode` (`dag-executor.ts`) | `loadCommandPrompt` (`executor-shared.ts`) | **new** | Same resolver `command:` nodes use; read once before iteration loop |
| `loopNodeConfigSchema` (`schemas/loop.ts`) | `isValidCommandName` (`command-validation.ts`) | **new** | Defense-in-depth path-traversal check at parse time |
| `validateWorkflowResources` (`validator.ts`) | `resolveCommand` + `findSimilar` | **new** | Mirrors the command-node check; same hints + "did you mean" |
| `validateDagStructure` (`loader.ts`) | `loop.prompt` only | **modified** | `$nodeId.output` ref scan skips command-loaded text (parse-time can't read it) |
| `resolveNodeDisplay` (`web/dag-layout.ts`) | `dn.loop.command` | **new** | Labels command-backed loops by command name |
| `api.generated.d.ts` | `loop.{prompt?, command?}` | **modified** | Regenerated from the schema; exactly-one enforced server-side |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `workflows|web|docs|tests`
- Module: `workflows:loop`

## Change Metadata

- Change type: `feature`
- Primary scope: `workflows`

## Linked Issue

- Closes #1759

## Validation Evidence (required)

```bash
bun run validate
# All gates green:
# ✅ check:bundled       — 36 commands, 20 workflows up to date
# ✅ check:bundled-skill — 21 files up to date
# ✅ type-check          — all 10 packages clean
# ✅ lint                — 0 errors, 0 warnings (--max-warnings 0)
# ✅ format:check        — all files formatted
# ✅ test                — 0 fail across every package
#                          @archon/workflows: 614 tests
#                          (+5 dag-executor runtime cases, +4 loader cases, +5 validator cases, +1 web canvas case)
```

- Evidence provided: full `bun run validate` exit 0 locally; live end-to-end test documented under Human Verification.
- No commands intentionally skipped.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No** — `loop.command` resolves through the same `loadCommandPrompt` resolver `command:` nodes already use (repo → home → bundled), with the same `isValidCommandName` path-traversal validation. Nothing new is reachable.

## Compatibility / Migration

- Backward compatible? **Yes** — purely additive; every existing `loop.prompt` keeps working unchanged.
- Config/env changes? **No**
- Database migration needed? **No**
- Upgrade steps: none.

## Human Verification (required)

What was personally validated beyond CI:

- **Verified scenarios:** End-to-end live test on a real workflow in a separate repo. The `ralph-wiggum` Archon workflow (an autonomous plan/build loop) has two `loop:` nodes whose inline prompts run ~55 and ~75 lines. I extracted those bodies into `.archon/commands/ralph-plan.md` and `ralph-build.md`, rewired the workflow to use `loop.command: ralph-plan` / `loop.command: ralph-build`, hard-reset a throwaway branch to immediately after the spec commit / before the implementation of a real feature (`semverish-version-validation`), then ran the converted workflow against that state from a local source build of this branch. Both loops loaded their command files, drove real iterations with full variable substitution (`$LOOP_PREV_OUTPUT`, `$LOOP_USER_INPUT`, `$ARGUMENTS`, `$nodeId.output`), and produced the expected per-iteration behaviour. No `loop.command` failures, parse errors, or substitution issues observed.
- **Edge cases checked:** Both-`prompt`-and-`command` and neither-defined reject at parse time with field-targeted errors (loader tests). Unsafe command names (e.g. `../escape`) reject at both parse time and validate time. Missing / empty / unreadable command targets fail the node fast with actionable messages mirroring the command-node failure shape. Read-once invariant proven behaviourally by deleting the source file mid-iteration and confirming subsequent iterations still complete.
- **What was not verified:** A binary-build smoke run — the change is engine-layer; the binary build path was not exercised manually, but `check:bundled` and the embedded-defaults regeneration pipeline are covered by CI.

## Side Effects / Blast Radius (required)

- **Affected subsystems/workflows:** `@archon/workflows` (schema, loader, validator, executor) and `@archon/web` (regenerated API types + canvas label). No backend route, DB, or other-package surface.
- **Potential unintended effects:** None observed. The new path mirrors the existing `command:` node path so closely that any regression would surface in the existing command-node tests too.
- **Guardrails/monitoring:** Schema rejects both/neither at parse time; validator rejects missing-file before a run; executor fails fast with `node_failed` on any runtime resolution failure (same observability shape as a missing `command:` node file).

## Rollback Plan (required)

- **Fast rollback command/path:** Revert this PR (or the merge commit). No DB state, no migrations, no on-disk artefacts.
- **Feature flags or config toggles:** None needed — `loop.command` is opt-in per node. Removing it from a workflow falls back to `loop.prompt` semantics.
- **Observable failure symptoms:** Workflows using `loop.command` would fail at validation time (`'<name>' command not found`) or with a clear `node_failed` event at runtime.

## Risks and Mitigations

- **Risk:** A future refactor of `loadCommandPrompt` could change resolution precedence and inadvertently affect command-backed loops differently from command nodes.
  - **Mitigation:** Both call paths share the same resolver — there's no separate code path to drift. The validator and executor tests for `loop.command` mirror the command-node tests at every layer.
- **Risk:** Workflow authors might miss that a missing command file fails the node rather than warning, in cases where they expected silent fallback.
  - **Mitigation:** Matches existing `command:` node behaviour exactly. Documentation in `loop-nodes.md` calls out the fail-fast semantics. Validator surfaces the missing file with "did you mean…" suggestions before the workflow ever runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Loop nodes can iterate using a command file (`loop.command`) instead of an inline prompt (`loop.prompt`), with consistent loop-variable substitution in both cases.
  * The console loop editor/UI now supports selecting a prompt source (inline vs command), and round-trips command-backed loops correctly.

* **Bug Fixes**
  * Workflows enforce exactly one of `loop.prompt` or `loop.command`, rejecting invalid, missing, empty, unsafe, or both/neither configurations at load time.
  * Command files are loaded once per node run (edits during execution don’t apply).
  * Approval pause metadata now correctly resets `commandSnapshot` each pause.

* **Documentation**
  * Loop Nodes guide and Quick Reference updated to describe `loop.command` precedence, validation rules, and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->