### PR TITLE
docs(github-app): document canonical Docker deploy recipe (port→127.0.0.1, Caddy /internal/* drop, opt-out flag)

### DIFF
--- a/packages/docs-web/src/content/docs/adapters/github-app-setup.md
+++ b/packages/docs-web/src/content/docs/adapters/github-app-setup.md
@@ -198,8 +198,12 @@ Without this flag, Archon refuses to start in App mode and exits with `github_ap
 # Apply the override + Caddyfile + env changes, then restart app + caddy.
 docker compose up -d --force-recreate app caddy
 
-# From outside the host — must be 404
-curl -i https://your-archon/internal/git-credential
+# From outside the host — must be 404/403 from the proxy.
+# Use POST (the endpoint's actual method) — a GET probe can false-pass when
+# the proxy 404s unmatched GETs while still forwarding the POST upstream.
+curl -i -X POST https://your-archon/internal/git-credential \
+  -H 'Content-Type: application/json' \
+  -d '{"host":"github.com","path":"any/repo"}'
 
 # On the host — port should bind to loopback only
 ss -tlnp | grep :3000
@@ -210,7 +214,7 @@ docker compose logs app --tail 200 | grep "internal_endpoint_exposed_acknowledge
 # This event confirms the opt-out path was taken (audit trail).
 ```
 
-If `/internal/git-credential` returns anything other than `404` from outside the host, **stop and fix the proxy config** before going live — the endpoint hands out live installation tokens to whoever can reach it.
+If the external POST probe returns anything other than `404` or `403` from the proxy — i.e. anything that suggests the request reached the Archon process — **stop and fix the proxy config** before going live. The endpoint hands out live installation tokens to whoever can reach it.
 
 ## Migration from PAT mode
 

--- a/packages/docs-web/src/content/docs/adapters/github-app-setup.md
+++ b/packages/docs-web/src/content/docs/adapters/github-app-setup.md
@@ -141,10 +141,10 @@ The credential-helper backend is exposed at `POST /internal/git-credential` and 
 
 Archon enforces this at startup: with App mode active and the server bound to a non-loopback interface (e.g. `0.0.0.0`), the process **refuses to start** and exits with `github_app.internal_endpoint_public_bind_rejected`. Two correct configurations:
 
-1. **Recommended — bind Archon to `127.0.0.1`** (`HOST=127.0.0.1`) and put a reverse proxy in front. Configure the proxy to drop `/internal/*` paths. Operators who use systemd / docker for upstream routing also fall into this category.
-2. **Opt-in escape hatch — `ARCHON_ALLOW_INTERNAL_ON_PUBLIC_BIND=1`** combined with `HOST=0.0.0.0` (or unset). Use ONLY when your reverse proxy already drops `/internal/*` AND your deployment topology genuinely requires the upstream to bind non-loopback (e.g. a container network where loopback isn't reachable from the proxy). Startup logs `github_app.internal_endpoint_exposed_acknowledged` so the choice is auditable.
+1. **Recommended (bare-metal / systemd) — bind Archon to `127.0.0.1`** (`HOST=127.0.0.1`) and put a reverse proxy in front. Configure the proxy to drop `/internal/*` paths.
+2. **Opt-in escape hatch — `ARCHON_ALLOW_INTERNAL_ON_PUBLIC_BIND=1`** combined with `HOST=0.0.0.0` (or unset). Use ONLY when your reverse proxy already drops `/internal/*` AND your deployment topology genuinely requires the upstream to bind non-loopback (e.g. a container network where loopback isn't reachable from the proxy). **Docker / docker-compose deployments fall here** — the app container *must* bind `0.0.0.0` inside the container for docker-proxy to forward traffic, so option 1 isn't directly usable. See the [Canonical Docker setup](#canonical-docker-setup) below. Startup logs `github_app.internal_endpoint_exposed_acknowledged` so the choice is auditable.
 
-Example Caddy snippet that drops `/internal/*`:
+Example Caddy snippet that drops `/internal/*` (bare-metal):
 
 ```caddyfile
 example.com {
@@ -153,6 +153,64 @@ example.com {
   reverse_proxy 127.0.0.1:3090
 }
 ```
+
+### Canonical Docker setup
+
+The canonical Archon Docker stack (`docker-compose.yml` + `docker-compose.override.yml` + Caddy) publishes the app container's port `3000` and runs Caddy as a reverse proxy. Because the app container can't bind `127.0.0.1` and still have docker-proxy forward traffic to it, option 1 above isn't directly usable. Take option 2 with three layers of defense:
+
+**1. In `docker-compose.override.yml` — bind the published host port to loopback only.**
+
+```yaml
+services:
+  app:
+    ports: !override
+      - "127.0.0.1:${PORT:-3000}:${PORT:-3000}"
+```
+
+The `!override` tag (compose-spec) replaces the base file's `ports` list instead of merging. After this, port `3000` is reachable only via the Docker network (where Caddy lives) or from the host itself — not from the public internet.
+
+**2. In `Caddyfile` — drop `/internal/*` requests.**
+
+Insert this `handle` block before the fallthrough `handle { }` block:
+
+```caddyfile
+handle /internal/* {
+  respond "Not Found" 404
+}
+```
+
+Caddy evaluates `handle` blocks by path specificity, so `/internal/*` (more specific) wins over the generic fallthrough regardless of order.
+
+**3. In `.env` — opt out of the loopback-bind guard.**
+
+```ini
+# Safe because:
+#  1. docker-compose binds port 3000 to 127.0.0.1 only (override above)
+#  2. Caddy drops /internal/* (handle block above)
+ARCHON_ALLOW_INTERNAL_ON_PUBLIC_BIND=1
+```
+
+Without this flag, Archon refuses to start in App mode and exits with `github_app.internal_endpoint_public_bind_rejected`.
+
+**Apply + verify:**
+
+```sh
+# Apply the override + Caddyfile + env changes, then restart app + caddy.
+docker compose up -d --force-recreate app caddy
+
+# From outside the host — must be 404
+curl -i https://your-archon/internal/git-credential
+
+# On the host — port should bind to loopback only
+ss -tlnp | grep :3000
+# Expected: 127.0.0.1:3000   (NOT 0.0.0.0:3000)
+
+# Startup log should contain:
+docker compose logs app --tail 200 | grep "internal_endpoint_exposed_acknowledged"
+# This event confirms the opt-out path was taken (audit trail).
+```
+
+If `/internal/git-credential` returns anything other than `404` from outside the host, **stop and fix the proxy config** before going live — the endpoint hands out live installation tokens to whoever can reach it.
 
 ## Migration from PAT mode
 
@@ -194,8 +252,8 @@ A webhook-secret mismatch causes `github.signature_mismatch` / `github.signature
 
 ### Server refused to start: `github_app.internal_endpoint_public_bind_rejected`
 
-- App mode is active but the server is bound to a non-loopback interface. This is a fail-fast guard — the `/internal/git-credential` endpoint hands out live installation access tokens and would leak credentials to the network. Either set `HOST=127.0.0.1` (recommended), or, if your reverse proxy already drops `/internal/*` and you genuinely need a non-loopback bind, set `ARCHON_ALLOW_INTERNAL_ON_PUBLIC_BIND=1`.
+- App mode is active but the server is bound to a non-loopback interface. This is a fail-fast guard — the `/internal/git-credential` endpoint hands out live installation access tokens and would leak credentials to the network. Either set `HOST=127.0.0.1` (bare-metal / systemd), or, if you're on Docker, follow the [Canonical Docker setup](#canonical-docker-setup) above (port→127.0.0.1 binding + Caddy `/internal/*` drop + `ARCHON_ALLOW_INTERNAL_ON_PUBLIC_BIND=1`).
 
 ### Server log shows `github_app.internal_endpoint_exposed_acknowledged`
 
-- You set `ARCHON_ALLOW_INTERNAL_ON_PUBLIC_BIND=1`. Double-check that your reverse proxy actually drops `/internal/*` — a `curl https://your-archon/internal/git-credential -d '{"host":"github.com","path":"any/repo"}'` from outside the host must return 404 or 403 from the proxy (NOT a token from Archon).
+- You set `ARCHON_ALLOW_INTERNAL_ON_PUBLIC_BIND=1`. Double-check that your reverse proxy actually drops `/internal/*` — a `curl https://your-archon/internal/git-credential -d '{"host":"github.com","path":"any/repo"}'` from outside the host must return 404 or 403 from the proxy (NOT a token from Archon). On the canonical Docker stack, also confirm `ss -tlnp | grep :3000` shows `127.0.0.1:3000` (not `0.0.0.0:3000`).


### PR DESCRIPTION
## Summary

- **Problem:** Operators following `packages/docs-web/.../adapters/github-app-setup.md` on the canonical Archon Docker stack (`docker-compose.yml` + `docker-compose.override.yml` + Caddy) can't follow the doc's recommended `HOST=127.0.0.1` path — the app container *must* bind `0.0.0.0` inside the container for docker-proxy to forward traffic. They end up needing `ARCHON_ALLOW_INTERNAL_ON_PUBLIC_BIND=1` plus a couple of specific compose/Caddy changes that PR-B never wrote down.
- **Why it matters:** Hit during the `archon.dynamous.ai` dogfood deploy this afternoon — server failed to start with `github_app.internal_endpoint_public_bind_rejected`, recovery required re-reading PR-B's source and reasoning about the docker-compose / Caddy boundary. The three-line fix is mechanical once you know what it is; documenting unblocks the next operator without that read-the-source loop.
- **What changed:** Added a "Canonical Docker setup" subsection inside the existing "Internal endpoint security — REQUIRED" section, plus tightened the two adjacent sentences and added cross-references from the relevant Troubleshooting entries.
- **What did NOT change (scope boundary):** No code, no schema, no behaviour. Pure doc. Existing bare-metal Caddy snippet preserved verbatim. Bare-metal `HOST=127.0.0.1` path stays as the recommended option for that deployment style.

## UX Journey

### Before

```
Operator: registers App, sets env vars, restarts Archon
  → server refuses to start: github_app.internal_endpoint_public_bind_rejected
  → reads doc: "set HOST=127.0.0.1" or "set ARCHON_ALLOW_INTERNAL_ON_PUBLIC_BIND=1"
  → tries HOST=127.0.0.1 → docker port forwarding stops working → 502 via Caddy
  → sets ARCHON_ALLOW_INTERNAL_ON_PUBLIC_BIND=1 alone → /internal/git-credential
    reachable externally → silent token-leak risk → unsafe
  → reads PR-B source to figure out the full picture
  → 30-60 min of yak-shaving
```

### After

```
Operator: registers App, sets env vars, restarts Archon
  → server refuses to start: github_app.internal_endpoint_public_bind_rejected
  → reads doc → finds "Canonical Docker setup" subsection
  → applies the three changes (override port→127.0.0.1, Caddy /internal/* drop,
    .env opt-out flag) following the recipe verbatim
  → docker compose up -d --force-recreate app caddy
  → curl https://your-archon/internal/git-credential → 404
  → ss -tlnp | grep :3000 → 127.0.0.1:3000
  → done. ~3 min.
```

## Architecture Diagram

N/A — doc-only change.

## Connection inventory

| From | To | Status | Notes |
|------|----|--------|-------|
| §"Internal endpoint security" → option 1 | unchanged | **modified** | Clarified that option 1 is the bare-metal / systemd path |
| §"Internal endpoint security" → option 2 | new §"Canonical Docker setup" | **new** | Forward link added to option 2's description; "Docker / docker-compose deployments fall here" call-out |
| Existing bare-metal Caddy snippet | unchanged | **modified** | Labelled "(bare-metal)" so it doesn't get confused with the Docker recipe |
| §"Canonical Docker setup" | three concrete changes (`docker-compose.override.yml`, `Caddyfile`, `.env`) + apply/verify recipe | **new** | The actual content this PR adds |
| Troubleshooting: `…public_bind_rejected` | §"Canonical Docker setup" | **modified** | Cross-reference added; Docker-specific guidance |
| Troubleshooting: `…exposed_acknowledged` | §"Canonical Docker setup" | **modified** | Added `ss -tlnp | grep :3000` verification hint |

## Label Snapshot

- Risk: `risk: low` (docs only; no code paths touched)
- Size: `size: XS` (1 file, +63/-5)
- Scope: `docs`
- Module: `docs:adapters/github-app-setup`

## Change Metadata

- Change type: `docs`
- Primary scope: `docs`

## Linked Issue

- Closes #
- Related #1788 (PR-B introduced the internal endpoint + the public-bind guardrail this PR documents the safe deploy recipe for)
- Depends on # — none
- Supersedes # — none

## Validation Evidence (required)

```bash
bun x prettier --check packages/docs-web/src/content/docs/adapters/github-app-setup.md
# All matched files use Prettier code style!
```

- Evidence provided: prettier passes on the touched file.
- Skipped commands: `bun run validate` (type-check / lint / tests) — doc-only change, no code paths affected. CI will run the full suite anyway.

## Security Impact (required)

- New permissions/capabilities? **No.**
- New external network calls? **No.**
- Secrets/tokens handling changed? **No** in code. The doc *clarifies* the security model for the canonical Docker stack — the recipe documented here is what an operator already has to discover to avoid the token-leak risk PR-B's startup guard protects against. Net effect: safer deployments, not less safe.
- File system access scope changed? **No.**

## Compatibility / Migration

- Backward compatible? **Yes** (doc only). No reader of the previous doc broke.
- Config/env changes? **No new env vars.** `ARCHON_ALLOW_INTERNAL_ON_PUBLIC_BIND` was introduced in #1788; this PR documents the canonical Docker recipe that uses it correctly.
- Database migration needed? **No.**
- If yes, exact upgrade steps: N/A.

## Human Verification (required)

What was personally validated beyond CI:

- **Verified scenarios:**
  - Applied the exact three-step recipe described in the new section on `archon.dynamous.ai` (real production VPS, Hetzner-class box, Caddy + Postgres + Auth-service compose stack). Server started cleanly with `github_app.internal_endpoint_exposed_acknowledged`. `/api/health` returns `200`, `activePlatforms: ["Web", "GitHub (App)"]`. External `curl https://archon.dynamous.ai/internal/git-credential` returns `404`. Host `ss -tlnp` confirms `127.0.0.1:3000` (not `0.0.0.0:3000`).
  - Prettier check passes on the touched file.
- **Edge cases checked:**
  - Cross-references from both Troubleshooting entries land on the new subsection's anchor.
  - The bare-metal `HOST=127.0.0.1` path was not regressed — still labelled "Recommended (bare-metal / systemd)".
- **What was not verified:** The exact `!override` compose-spec tag syntax was confirmed against the override file currently in production. Documented behaviour matches what we observed live. Did not verify it on an older docker-compose version (`!override` was added in compose-spec; pre-spec docker-compose versions might handle this differently — out of scope for v1 docs).

## Side Effects / Blast Radius (required)

- **Affected subsystems/workflows:** none beyond the doc reader.
- **Potential unintended effects:** future operators might assume the Docker recipe is the only valid path. The doc keeps option 1 (`HOST=127.0.0.1`) clearly labelled and recommended for non-Docker deployments to head this off.
- **Guardrails/monitoring for early detection:** N/A — doc change. The `github_app.internal_endpoint_exposed_acknowledged` log event remains the in-product audit trail; the doc now explicitly tells operators to grep for it as part of the verification step.

## Rollback Plan (required)

- **Fast rollback command/path:** `git revert <commit>` — pure doc, instant rollback.
- **Feature flags or config toggles:** N/A.
- **Observable failure symptoms:** N/A (no code change). If the recipe in the doc turns out wrong for an operator, the existing startup guards (`…_public_bind_rejected`) still fail-fast safely — no silent token leak.

## Risks and Mitigations

- **Risk:** The `!override` compose-spec YAML tag may not be supported on very old docker-compose versions.
  - **Mitigation:** Documented behaviour was verified on the production stack; older versions can use the equivalent explicit ports replacement. Will add a compatibility note if anyone reports trouble on an old version.
- **Risk:** Operators may copy the Caddyfile snippet but place it AFTER the fallthrough `handle { }` block, breaking the `/internal/*` match.
  - **Mitigation:** The doc explicitly states *"Insert this `handle` block before the fallthrough `handle { }` block"* and clarifies *"Caddy evaluates `handle` blocks by path specificity, so `/internal/*` (more specific) wins over the generic fallthrough regardless of order"* — so the rule is correct either way, but the doc still gives the order that matches reading flow.
- **Risk:** Operators on non-canonical Caddy/proxy setups (nginx, Traefik) get less direct guidance.
  - **Mitigation:** The principle stated in the doc generalises — drop `/internal/*` at the reverse-proxy layer regardless of which proxy. Specific nginx/Traefik recipes can land as separate follow-up docs if there's demand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified internal endpoint security guidance with two configuration options (recommended loopback + reverse proxy, and opt-in public bind escape hatch)
  * Added a canonical Docker setup walkthrough with compose/proxy/.env layering and verification commands
  * Added explicit warning to stop if internal endpoints are externally reachable
  * Expanded troubleshooting with precise expected proxy responses and Docker validation steps

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1795?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->