### PR TITLE
fix(workflows): stop silently dropping workflow-level effort/thinking/fallbackModel/betas/sandbox in loader

### DIFF
--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -623,6 +623,8 @@ Model and options are resolved in this order:
 2. **Config defaults** - `assistants.*` in `.archon/config.yaml`
 3. **SDK defaults** - Built-in defaults from Claude/Codex SDKs
 
+For the Claude SDK advanced options (`effort`, `thinking`, `fallbackModel`, `betas`, `sandbox`) a per-node value sits above the workflow level: a node uses its own value if set, otherwise it inherits the workflow-level default. See [Claude SDK Advanced Options](#claude-sdk-advanced-options).
+
 ### Provider and Model
 
 ```yaml

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -418,13 +418,14 @@ nodes:
     });
 
     it('should round-trip workflow-level effort/thinking/fallbackModel/betas/sandbox', async () => {
-      // Regression: these 5 workflow-level fields used to be declared on
+      // Regression: these 5 workflow-level fields are declared on
       // workflowBaseSchema and consumed by the DAG executor's workflowLevelOptions
-      // (dag-executor.ts:2585-2591), but the loader's manual workflow constructor
-      // silently dropped them. YAML → loader → executor would lose the workflow-level
-      // defaults, so per-node options never inherited them. See `dag-executor.test.ts`
-      // "forwards workflow-level effort to node when no per-node override" — that test
-      // passes because it bypasses the loader.
+      // (the object literal at the top of executeDagWorkflow), but the loader's
+      // manual workflow constructor used to silently drop them. YAML → loader →
+      // executor would lose the workflow-level defaults, so a node without its own
+      // value never inherited them. See `dag-executor.test.ts`
+      // "forwards workflow-level effort to node when no per-node override" — that
+      // test passes because it bypasses the loader.
       const workflowDir = join(testDir, '.archon', 'workflows');
       await mkdir(workflowDir, { recursive: true });
       const yaml = `name: defaults
@@ -483,20 +484,70 @@ nodes:
 description: invalid fallback fields are dropped
 provider: claude
 effort: nuclear
+thinking:
+  type: enhanced
 fallbackModel: ''
 betas: []
+sandbox: 'yes'
 nodes:
   - id: only
     prompt: p
 `;
       await writeFile(join(workflowDir, 'bad.yaml'), yaml);
+      mockLogger.warn.mockClear();
       const result = await discoverWorkflows(testDir, { loadDefaults: false });
       expect(result.errors).toEqual([]);
       expect(result.workflows).toHaveLength(1);
       const wf = result.workflows[0].workflow as Record<string, unknown>;
       expect(wf.effort).toBeUndefined();
+      expect(wf.thinking).toBeUndefined();
       expect(wf.fallbackModel).toBeUndefined();
       expect(wf.betas).toBeUndefined();
+      expect(wf.sandbox).toBeUndefined();
+
+      // The structured warn events are the operator-facing surface — assert each fired.
+      const events = mockLogger.warn.mock.calls.map(call => call[1]);
+      expect(events).toContain('invalid_workflow_effort_value_ignored');
+      expect(events).toContain('invalid_workflow_thinking_value_ignored');
+      expect(events).toContain('invalid_workflow_fallback_model_value_ignored');
+      expect(events).toContain('invalid_workflow_betas_value_ignored');
+      expect(events).toContain('invalid_workflow_sandbox_value_ignored');
+    });
+
+    it('should accept the thinking string shorthand at the workflow level', async () => {
+      // thinkingConfigSchema preprocesses 'enabled' → { type: 'enabled' }. The
+      // round-trip test covers the object form; this covers the shorthand path.
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+      const yaml = `name: thinking-shorthand
+description: thinking as a bare string
+thinking: enabled
+nodes:
+  - id: only
+    prompt: p
+`;
+      await writeFile(join(workflowDir, 'ts.yaml'), yaml);
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      const wf = result.workflows[0].workflow as { thinking?: unknown };
+      expect(wf.thinking).toEqual({ type: 'enabled' });
+    });
+
+    it('should trim surrounding whitespace from workflow-level fallbackModel', async () => {
+      // The inline trim (rather than safeParse) exists specifically so a stray
+      // surrounding space is normalised rather than rejected.
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+      const yaml = `name: fm-trim
+description: fallbackModel with whitespace
+fallbackModel: '  claude-haiku-4-5  '
+nodes:
+  - id: only
+    prompt: p
+`;
+      await writeFile(join(workflowDir, 'fm.yaml'), yaml);
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      const wf = result.workflows[0].workflow as { fallbackModel?: unknown };
+      expect(wf.fallbackModel).toBe('claude-haiku-4-5');
     });
 
     it('should trim and filter empty strings out of workflow-level betas', async () => {

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -416,6 +416,107 @@ nodes:
       expect(workflows[0].webSearchMode).toBe('live');
       expect(workflows[0].additionalDirectories).toEqual(['/repo/a']);
     });
+
+    it('should round-trip workflow-level effort/thinking/fallbackModel/betas/sandbox', async () => {
+      // Regression: these 5 workflow-level fields used to be declared on
+      // workflowBaseSchema and consumed by the DAG executor's workflowLevelOptions
+      // (dag-executor.ts:2585-2591), but the loader's manual workflow constructor
+      // silently dropped them. YAML → loader → executor would lose the workflow-level
+      // defaults, so per-node options never inherited them. See `dag-executor.test.ts`
+      // "forwards workflow-level effort to node when no per-node override" — that test
+      // passes because it bypasses the loader.
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+      const yaml = `name: defaults
+description: workflow-level fallback options
+provider: claude
+effort: high
+thinking:
+  type: enabled
+  budgetTokens: 4000
+fallbackModel: claude-haiku-4-5
+betas:
+  - foo
+  - bar
+sandbox:
+  enabled: true
+nodes:
+  - id: only
+    prompt: p
+`;
+      await writeFile(join(workflowDir, 'defaults.yaml'), yaml);
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      const wf = result.workflows[0].workflow as {
+        effort?: unknown;
+        thinking?: unknown;
+        fallbackModel?: unknown;
+        betas?: unknown;
+        sandbox?: unknown;
+      };
+      expect(wf.effort).toBe('high');
+      expect(wf.thinking).toEqual({ type: 'enabled', budgetTokens: 4000 });
+      expect(wf.fallbackModel).toBe('claude-haiku-4-5');
+      expect(wf.betas).toEqual(['foo', 'bar']);
+      expect(wf.sandbox).toEqual({ enabled: true });
+    });
+
+    it('should omit workflow-level fallback fields when not present', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+      const yaml = `name: bare\ndescription: no fallbacks\nnodes:\n  - id: only\n    prompt: p\n`;
+      await writeFile(join(workflowDir, 'bare.yaml'), yaml);
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      const wf = result.workflows[0].workflow as Record<string, unknown>;
+      expect(wf.effort).toBeUndefined();
+      expect(wf.thinking).toBeUndefined();
+      expect(wf.fallbackModel).toBeUndefined();
+      expect(wf.betas).toBeUndefined();
+      expect(wf.sandbox).toBeUndefined();
+    });
+
+    it('should warn-and-drop invalid workflow-level fallback fields without rejecting the workflow', async () => {
+      // Same warn-and-ignore policy as `interactive` / `modelReasoningEffort`:
+      // a typo in one workflow-level field must not nuke the whole discovery pass.
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+      const yaml = `name: bad
+description: invalid fallback fields are dropped
+provider: claude
+effort: nuclear
+fallbackModel: ''
+betas: []
+nodes:
+  - id: only
+    prompt: p
+`;
+      await writeFile(join(workflowDir, 'bad.yaml'), yaml);
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.errors).toEqual([]);
+      expect(result.workflows).toHaveLength(1);
+      const wf = result.workflows[0].workflow as Record<string, unknown>;
+      expect(wf.effort).toBeUndefined();
+      expect(wf.fallbackModel).toBeUndefined();
+      expect(wf.betas).toBeUndefined();
+    });
+
+    it('should trim and filter empty strings out of workflow-level betas', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+      const yaml = `name: beta-trim
+description: betas with whitespace
+betas:
+  - '  alpha  '
+  - ''
+  - 'beta'
+nodes:
+  - id: only
+    prompt: p
+`;
+      await writeFile(join(workflowDir, 't.yaml'), yaml);
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      const wf = result.workflows[0].workflow as { betas?: unknown };
+      expect(wf.betas).toEqual(['alpha', 'beta']);
+    });
   });
 
   describe('discoverWorkflows', () => {

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -10,6 +10,9 @@ import {
   BASH_NODE_AI_FIELDS,
   SCRIPT_NODE_AI_FIELDS,
   LOOP_NODE_AI_FIELDS,
+  effortLevelSchema,
+  thinkingConfigSchema,
+  sandboxSettingsSchema,
 } from './schemas/dag-node';
 import { modelReasoningEffortSchema, webSearchModeSchema } from './schemas/workflow';
 import { workflowNodeHooksSchema } from './schemas/hooks';
@@ -424,6 +427,67 @@ export function parseWorkflow(content: string, filename: string): ParseResult {
       getLog().warn({ filename, value: raw.tags }, 'invalid_tags_block_ignored');
     }
 
+    // Parse workflow-level fallback fields. Same `safeParse` + warn-and-drop
+    // pattern as `modelReasoningEffort` / `webSearchMode` above. These are
+    // declared on `workflowBaseSchema` and consumed by the DAG executor's
+    // `workflowLevelOptions` as defaults that per-node options inherit when
+    // unset (see dag-executor.ts:2585-2591 — `workflow.effort` etc.). Without
+    // this block, a workflow YAML that sets e.g. `effort: high` at the root
+    // would be silently dropped here and the executor would read undefined,
+    // so per-node overrides would not inherit the workflow-level default.
+    const effortResult = effortLevelSchema.safeParse(raw.effort);
+    const effort = effortResult.success ? effortResult.data : undefined;
+    if (raw.effort !== undefined && !effortResult.success) {
+      getLog().warn(
+        { filename, value: raw.effort, valid: effortLevelSchema.options },
+        'invalid_workflow_effort_value_ignored'
+      );
+    }
+
+    const thinkingResult = thinkingConfigSchema.safeParse(raw.thinking);
+    const thinking = thinkingResult.success ? thinkingResult.data : undefined;
+    if (raw.thinking !== undefined && !thinkingResult.success) {
+      getLog().warn({ filename, value: raw.thinking }, 'invalid_workflow_thinking_value_ignored');
+    }
+
+    // fallbackModel: non-empty trimmed string. Inline rather than safeParse so
+    // a stray trailing space is normalised rather than rejected.
+    const fallbackModelTrimmed =
+      typeof raw.fallbackModel === 'string' ? raw.fallbackModel.trim() : '';
+    const fallbackModel = fallbackModelTrimmed.length > 0 ? fallbackModelTrimmed : undefined;
+    if (raw.fallbackModel !== undefined && fallbackModel === undefined) {
+      getLog().warn(
+        { filename, value: raw.fallbackModel },
+        'invalid_workflow_fallback_model_value_ignored'
+      );
+    }
+
+    // betas: non-empty array of non-empty strings. Same trim+filter as `tags`.
+    // Unlike `tags`, an empty result drops the field entirely (the Claude SDK
+    // expects either a populated beta header or no header at all). The schema
+    // types `betas` as `[string, ...string[]]`, so the cast captures the
+    // length>=1 invariant we just verified.
+    let betas: [string, ...string[]] | undefined;
+    if (Array.isArray(raw.betas)) {
+      const filtered = raw.betas
+        .filter((b): b is string => typeof b === 'string')
+        .map(b => b.trim())
+        .filter(b => b.length > 0);
+      if (filtered.length > 0) {
+        betas = filtered as [string, ...string[]];
+      } else {
+        getLog().warn({ filename, value: raw.betas }, 'invalid_workflow_betas_value_ignored');
+      }
+    } else if (raw.betas !== undefined) {
+      getLog().warn({ filename, value: raw.betas }, 'invalid_workflow_betas_value_ignored');
+    }
+
+    const sandboxResult = sandboxSettingsSchema.safeParse(raw.sandbox);
+    const sandbox = sandboxResult.success ? sandboxResult.data : undefined;
+    if (raw.sandbox !== undefined && !sandboxResult.success) {
+      getLog().warn({ filename, value: raw.sandbox }, 'invalid_workflow_sandbox_value_ignored');
+    }
+
     return {
       workflow: {
         name: raw.name,
@@ -435,6 +499,11 @@ export function parseWorkflow(content: string, filename: string): ParseResult {
         additionalDirectories,
         interactive,
         ...(mutatesCheckout !== undefined ? { mutates_checkout: mutatesCheckout } : {}),
+        ...(effort !== undefined ? { effort } : {}),
+        ...(thinking !== undefined ? { thinking } : {}),
+        ...(fallbackModel !== undefined ? { fallbackModel } : {}),
+        ...(betas !== undefined ? { betas } : {}),
+        ...(sandbox !== undefined ? { sandbox } : {}),
         nodes: dagNodes,
         ...(worktreePolicy ? { worktree: worktreePolicy } : {}),
         ...(tags !== undefined ? { tags } : {}),

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -13,6 +13,7 @@ import {
   effortLevelSchema,
   thinkingConfigSchema,
   sandboxSettingsSchema,
+  betasSchema,
 } from './schemas/dag-node';
 import { modelReasoningEffortSchema, webSearchModeSchema } from './schemas/workflow';
 import { workflowNodeHooksSchema } from './schemas/hooks';
@@ -23,6 +24,32 @@ let cachedLog: ReturnType<typeof createLogger> | undefined;
 function getLog(): ReturnType<typeof createLogger> {
   if (!cachedLog) cachedLog = createLogger('workflow.loader');
   return cachedLog;
+}
+
+/**
+ * Parse an optional, schema-validated workflow field with warn-and-drop
+ * semantics: a present-but-invalid value is logged and dropped (returns
+ * undefined) rather than rejecting the whole workflow, so a typo in one field
+ * doesn't abort the discovery pass. Mirrors the policy used for `tags` /
+ * `interactive`. `extra` merges into the warning payload (e.g. the list of
+ * valid enum options).
+ */
+function parseOptionalField<T>(
+  raw: unknown,
+  // Output is `T`; the input param stays `unknown` (decoupled from `T`) so
+  // preprocess-based schemas (e.g. `thinkingConfigSchema`, whose input is
+  // `unknown`) infer `T` from their output rather than their input.
+  schema: z.ZodType<T, z.ZodTypeDef, unknown>,
+  filename: string,
+  event: string,
+  extra?: Record<string, unknown>
+): T | undefined {
+  const result = schema.safeParse(raw);
+  if (result.success) return result.data;
+  if (raw !== undefined) {
+    getLog().warn({ filename, value: raw, ...extra }, event);
+  }
+  return undefined;
 }
 
 /**
@@ -322,29 +349,21 @@ export function parseWorkflow(content: string, filename: string): ParseResult {
       }
     }
 
-    // Validate modelReasoningEffort — warn and ignore invalid values (preserve original behavior)
-    const modelReasoningEffortResult = modelReasoningEffortSchema.safeParse(
-      raw.modelReasoningEffort
+    // Validate modelReasoningEffort / webSearchMode — warn and ignore invalid values.
+    const modelReasoningEffort = parseOptionalField(
+      raw.modelReasoningEffort,
+      modelReasoningEffortSchema,
+      filename,
+      'invalid_model_reasoning_effort',
+      { valid: modelReasoningEffortSchema.options }
     );
-    const modelReasoningEffort = modelReasoningEffortResult.success
-      ? modelReasoningEffortResult.data
-      : undefined;
-    if (raw.modelReasoningEffort !== undefined && !modelReasoningEffortResult.success) {
-      getLog().warn(
-        { filename, value: raw.modelReasoningEffort, valid: modelReasoningEffortSchema.options },
-        'invalid_model_reasoning_effort'
-      );
-    }
-
-    // Validate webSearchMode — warn and ignore invalid values (preserve original behavior)
-    const webSearchModeResult = webSearchModeSchema.safeParse(raw.webSearchMode);
-    const webSearchMode = webSearchModeResult.success ? webSearchModeResult.data : undefined;
-    if (raw.webSearchMode !== undefined && !webSearchModeResult.success) {
-      getLog().warn(
-        { filename, value: raw.webSearchMode, valid: webSearchModeSchema.options },
-        'invalid_web_search_mode'
-      );
-    }
+    const webSearchMode = parseOptionalField(
+      raw.webSearchMode,
+      webSearchModeSchema,
+      filename,
+      'invalid_web_search_mode',
+      { valid: webSearchModeSchema.options }
+    );
 
     // Filter additionalDirectories — warn on non-strings (preserve original behavior)
     const additionalDirectories = Array.isArray(raw.additionalDirectories)
@@ -427,65 +446,66 @@ export function parseWorkflow(content: string, filename: string): ParseResult {
       getLog().warn({ filename, value: raw.tags }, 'invalid_tags_block_ignored');
     }
 
-    // Parse workflow-level fallback fields. Same `safeParse` + warn-and-drop
-    // pattern as `modelReasoningEffort` / `webSearchMode` above. These are
-    // declared on `workflowBaseSchema` and consumed by the DAG executor's
-    // `workflowLevelOptions` as defaults that per-node options inherit when
-    // unset (see dag-executor.ts:2585-2591 — `workflow.effort` etc.). Without
-    // this block, a workflow YAML that sets e.g. `effort: high` at the root
-    // would be silently dropped here and the executor would read undefined,
-    // so per-node overrides would not inherit the workflow-level default.
-    const effortResult = effortLevelSchema.safeParse(raw.effort);
-    const effort = effortResult.success ? effortResult.data : undefined;
-    if (raw.effort !== undefined && !effortResult.success) {
-      getLog().warn(
-        { filename, value: raw.effort, valid: effortLevelSchema.options },
-        'invalid_workflow_effort_value_ignored'
-      );
-    }
+    // Parse workflow-level fallback fields. Same warn-and-drop pattern as
+    // `modelReasoningEffort` / `webSearchMode` above. These are declared on
+    // `workflowBaseSchema` and consumed by the DAG executor's
+    // `workflowLevelOptions` (the object literal at the top of
+    // `executeDagWorkflow`, reading `workflow.effort` etc.) as defaults that
+    // per-node options inherit when unset. Without this block, a workflow YAML
+    // that sets e.g. `effort: high` at the root would be dropped here and the
+    // executor would read undefined, so a node without its own `effort` would
+    // never inherit the workflow-level default.
+    const effort = parseOptionalField(
+      raw.effort,
+      effortLevelSchema,
+      filename,
+      'invalid_workflow_effort_value_ignored',
+      { valid: effortLevelSchema.options }
+    );
+    const thinking = parseOptionalField(
+      raw.thinking,
+      thinkingConfigSchema,
+      filename,
+      'invalid_workflow_thinking_value_ignored'
+    );
+    const sandbox = parseOptionalField(
+      raw.sandbox,
+      sandboxSettingsSchema,
+      filename,
+      'invalid_workflow_sandbox_value_ignored'
+    );
 
-    const thinkingResult = thinkingConfigSchema.safeParse(raw.thinking);
-    const thinking = thinkingResult.success ? thinkingResult.data : undefined;
-    if (raw.thinking !== undefined && !thinkingResult.success) {
-      getLog().warn({ filename, value: raw.thinking }, 'invalid_workflow_thinking_value_ignored');
-    }
-
-    // fallbackModel: non-empty trimmed string. Inline rather than safeParse so
-    // a stray trailing space is normalised rather than rejected.
+    // fallbackModel: non-empty trimmed string. Inline trim rather than
+    // `safeParse` so a stray surrounding space is normalised rather than rejected.
     const fallbackModelTrimmed =
       typeof raw.fallbackModel === 'string' ? raw.fallbackModel.trim() : '';
     const fallbackModel = fallbackModelTrimmed.length > 0 ? fallbackModelTrimmed : undefined;
     if (raw.fallbackModel !== undefined && fallbackModel === undefined) {
       getLog().warn(
-        { filename, value: raw.fallbackModel },
+        { filename, value: raw.fallbackModel, expected: 'non-empty string' },
         'invalid_workflow_fallback_model_value_ignored'
       );
     }
 
-    // betas: non-empty array of non-empty strings. Same trim+filter as `tags`.
-    // Unlike `tags`, an empty result drops the field entirely (the Claude SDK
-    // expects either a populated beta header or no header at all). The schema
-    // types `betas` as `[string, ...string[]]`, so the cast captures the
-    // length>=1 invariant we just verified.
+    // betas: trim, drop empties, then validate the cleaned list through
+    // `betasSchema` (non-empty array of non-empty strings). An empty result
+    // drops the field entirely — the Claude SDK expects a populated beta header
+    // or none at all. Validating via the schema yields the `[string, ...string[]]`
+    // type without an unchecked cast.
     let betas: [string, ...string[]] | undefined;
-    if (Array.isArray(raw.betas)) {
-      const filtered = raw.betas
-        .filter((b): b is string => typeof b === 'string')
-        .map(b => b.trim())
-        .filter(b => b.length > 0);
-      if (filtered.length > 0) {
-        betas = filtered as [string, ...string[]];
+    if (raw.betas !== undefined) {
+      const cleaned = Array.isArray(raw.betas)
+        ? raw.betas
+            .filter((b): b is string => typeof b === 'string')
+            .map(b => b.trim())
+            .filter(b => b.length > 0)
+        : [];
+      const betasResult = betasSchema.safeParse(cleaned);
+      if (betasResult.success) {
+        betas = betasResult.data;
       } else {
         getLog().warn({ filename, value: raw.betas }, 'invalid_workflow_betas_value_ignored');
       }
-    } else if (raw.betas !== undefined) {
-      getLog().warn({ filename, value: raw.betas }, 'invalid_workflow_betas_value_ignored');
-    }
-
-    const sandboxResult = sandboxSettingsSchema.safeParse(raw.sandbox);
-    const sandbox = sandboxResult.success ? sandboxResult.data : undefined;
-    if (raw.sandbox !== undefined && !sandboxResult.success) {
-      getLog().warn({ filename, value: raw.sandbox }, 'invalid_workflow_sandbox_value_ignored');
     }
 
     return {

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -42,6 +42,14 @@ export const effortLevelSchema = z.enum(['low', 'medium', 'high', 'max']);
 export type EffortLevel = z.infer<typeof effortLevelSchema>;
 
 /**
+ * Claude Agent SDK beta header list. Non-empty array of non-empty strings —
+ * the SDK expects either a populated beta header or none at all. The
+ * `.nonempty()` constraint makes the inferred type `[string, ...string[]]`,
+ * which the loader relies on to validate cleaned input without an unchecked cast.
+ */
+export const betasSchema = z.array(z.string().min(1)).nonempty("'betas' must be a non-empty array");
+
+/**
  * Claude Agent SDK ThinkingConfig — string shorthand or full object form.
  * Shorthand: 'adaptive' → { type: 'adaptive' }, 'enabled' → { type: 'enabled' }, 'disabled' → { type: 'disabled' }.
  */
@@ -162,7 +170,7 @@ export const dagNodeBaseSchema = z.object({
   // programmatically by the orchestrator for prompt caching; Zod intentionally stays narrow.
   systemPrompt: z.string().min(1).optional(),
   fallbackModel: z.string().min(1).optional(),
-  betas: z.array(z.string().min(1)).nonempty("'betas' must be a non-empty array").optional(),
+  betas: betasSchema.optional(),
   sandbox: sandboxSettingsSchema.optional(),
   // Opt out of resume caching: when true, this node re-runs on resume even if a
   // prior run completed it successfully. Use for producers whose exit code does

--- a/packages/workflows/src/schemas/workflow.ts
+++ b/packages/workflows/src/schemas/workflow.ts
@@ -8,6 +8,7 @@ import {
   effortLevelSchema,
   thinkingConfigSchema,
   sandboxSettingsSchema,
+  betasSchema,
 } from './dag-node';
 
 // ---------------------------------------------------------------------------
@@ -65,7 +66,7 @@ export const workflowBaseSchema = z.object({
   effort: effortLevelSchema.optional(),
   thinking: thinkingConfigSchema.optional(),
   fallbackModel: z.string().min(1).optional(),
-  betas: z.array(z.string().min(1)).nonempty("'betas' must be a non-empty array").optional(),
+  betas: betasSchema.optional(),
   sandbox: sandboxSettingsSchema.optional(),
   worktree: workflowWorktreePolicySchema.optional(),
   /**


### PR DESCRIPTION
## Summary

- **Problem:** `parseWorkflow` silently drops five workflow-level fallback fields (`effort`, `thinking`, `fallbackModel`, `betas`, `sandbox`). They're declared on `workflowBaseSchema` and the executor reads them out of `workflow.{field}` at `dag-executor.ts:2585-2591`, but the loader builds the returned workflow object manually and never copies these across.
- **Why it matters:** A workflow YAML that sets e.g. `effort: high` at the root reaches the executor as `workflow.effort === undefined`. Per-node options never inherit the workflow-level default — they fall through to SDK defaults with no warning to the author. Latent silent-misbehavior.
- **What changed:** Five `safeParse` + warn-and-drop blocks mirroring the existing `modelReasoningEffort` / `webSearchMode` pattern, plus conditional spreads alongside `mutates_checkout` / `tags` in the constructor.
- **What did NOT change (scope boundary):** No schema or executor changes. The fields were already correctly declared and correctly consumed; only the loader's manual translation was broken.

## UX Journey

### Before

```
.archon/workflows/feature.yaml:
  name: feature
  description: …
  effort: high                 ← author intent
  fallbackModel: claude-haiku-4-5
  nodes:
    - id: implement
      prompt: …                ← expects to inherit effort=high

      ↓ parseWorkflow

  workflow = {
    name: 'feature',
    description: '…',
    provider, model, ...
    (no effort)                ← silently dropped
    (no fallbackModel)         ← silently dropped
    nodes: [...]
  }

      ↓ executeDagWorkflow

  workflowLevelOptions = {
    effort: undefined,         ← BUG
    fallbackModel: undefined,  ← BUG
    ...
  }

  Per-node resolution:
    node.effort ?? workflowLevelOptions.effort
    = undefined ?? undefined
    = undefined → SDK default

  Author sees: nothing. Workflow runs with SDK defaults silently.
```

### After

```
.archon/workflows/feature.yaml:
  name: feature
  effort: high
  fallbackModel: claude-haiku-4-5
  nodes: [...]

      ↓ parseWorkflow              ← *now validates + copies each field*

  workflow = {
    ...,
    effort: 'high',              ← carried through
    fallbackModel: 'claude-haiku-4-5',
    nodes: [...],
  }

      ↓ executeDagWorkflow

  workflowLevelOptions = {
    effort: 'high',              ← reaches executor
    fallbackModel: 'claude-haiku-4-5',
    ...
  }

  Per-node resolution:
    node.effort ?? workflowLevelOptions.effort
    = undefined ?? 'high'
    = 'high' → forwarded to SDK
```

### Interaction Changes

| Location | Before | After | User Impact |
|---|---|---|---|
| Workflow YAML root | `effort:` / `thinking:` / `fallbackModel:` / `betas:` / `sandbox:` silently dropped | Parsed via `safeParse` (or inline trim), spread into the workflow object | Workflow-level defaults actually reach the executor |
| Invalid values (e.g. `effort: nuclear`) | Same silent drop | Logged warning (`invalid_workflow_*_value_ignored`), workflow still loads | Authors see a hint without a discovery-pass abort |

## Architecture Diagram

### Before

```
        ┌───────────────────────┐
        │ workflowBaseSchema    │  declares 17 workflow-level fields
        └───────────┬───────────┘
                    │ z.infer
                    ▼
        ┌───────────────────────┐
        │ WorkflowDefinition    │  TS type carries all 17
        └───────────────────────┘

YAML → parseWorkflow (manual constructor) → workflow { 12 fields }   x─ silently drops 5
                                                  │
                                                  ▼
                                          executeDagWorkflow
                                                  │
                                                  ▼
                                          workflowLevelOptions {
                                            effort: undefined,
                                            thinking: undefined,
                                            fallbackModel: undefined,
                                            betas: undefined,
                                            sandbox: undefined,
                                          }
```

### After

```
        ┌───────────────────────┐
        │ workflowBaseSchema    │  unchanged
        └───────────┬───────────┘
                    │
                    ▼
        ┌───────────────────────┐
        │ WorkflowDefinition    │  unchanged
        └───────────────────────┘

YAML → parseWorkflow (5 new safeParse blocks [+], 5 new spreads [+])
                    │
                    ▼ workflow { 17 fields }                                    *all 17 reach executor*
                                                  │
                                                  ▼
                                          executeDagWorkflow                   unchanged
                                                  │
                                                  ▼
                                          workflowLevelOptions {              same logic, now sees real values
                                            effort: 'high',
                                            thinking: { type: 'enabled', … },
                                            fallbackModel: 'claude-haiku-4-5',
                                            betas: ['alpha', 'beta'],
                                            sandbox: { enabled: true, … },
                                          }
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `loader.ts` parseWorkflow | `effortLevelSchema.safeParse` | **new** | Same pattern as the existing `modelReasoningEffortSchema.safeParse` call above it |
| `loader.ts` parseWorkflow | `thinkingConfigSchema.safeParse` | **new** | Same |
| `loader.ts` parseWorkflow | `sandboxSettingsSchema.safeParse` | **new** | Same |
| `loader.ts` parseWorkflow | inline trim/filter for `fallbackModel`, `betas` | **new** | Matches `tags` pattern; chose inline so trailing whitespace is normalised rather than rejected |
| Returned workflow object | DAG executor `workflow.{effort,thinking,fallbackModel,betas,sandbox}` | **fixed** | The fields are now actually present at runtime; no change on the executor side |
| `dag-executor.test.ts` | Direct executor invocation with workflow object literal | unchanged | The test that bypassed the loader still passes — it was the reason this bug went undetected |

## Label Snapshot

- Risk: `risk: low` (additive: parses fields that already shouldn't be lost; warn-and-drop on invalid)
- Size: `size: S` (~170 LOC across 2 files, all in `loader.ts` and `loader.test.ts`)
- Scope: `workflows`
- Module: `workflows:loader`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes _none_ (latent bug found during PR #1790 review follow-up audit; no tracking issue opened separately)
- Related #1790 (this is the loader audit I flagged as follow-up in that PR's report)
- Depends on _none_
- Supersedes _none_

## Validation Evidence (required)

```bash
$ bun run validate
# check:bundled                 ✅ 36 commands, 20 workflows
# check:bundled-skill           ✅ 21 files
# type-check (10 packages)      ✅ exit 0
# lint --max-warnings 0         ✅ 0 warnings
# format:check                  ✅
# tests                         ✅ all packages green; loader 125/125
# EXIT 0
```

- Evidence provided: 4 new loader tests (positive round-trip, absent → undefined, invalid warn-and-drop, betas trim semantics)
- Skipped: none

## Security Impact (required)

- New permissions/capabilities? **No** — adds field plumbing, no new auth surface
- New external network calls? **No**
- Secrets/tokens handling changed? **No** — `fallbackModel` is a model identifier, `betas` are SDK beta headers, neither is sensitive
- File system access scope changed? **No**

## Compatibility / Migration

- Backward compatible? **Yes** — fixes silent-misbehavior; nothing observable today changes for workflows that don't use these fields. Workflows that DO use them start behaving as their authors intended (and as the schema declares).
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

- **Verified scenarios:**
  - Type-check across all 10 packages
  - Loader test suite: 124 prior + 4 new = 125 passing
  - Full `bun run validate` exit 0
- **Edge cases checked (via tests):**
  - All 5 fields round-trip from YAML to workflow object
  - Workflow without any of the 5 fields leaves them undefined (no field-presence regression)
  - Invalid `effort: nuclear` → warn + drop, workflow still loads
  - Empty `fallbackModel: ''` → warn + drop
  - Empty `betas: []` → warn + drop (Claude SDK expects populated header or none)
  - `betas: ['  alpha  ', '', 'beta']` → normalised to `['alpha', 'beta']`
  - Discriminated-union narrowing for `thinking: { type: 'enabled', budgetTokens: 4000 }`
- **What was NOT verified:**
  - End-to-end run with a real LLM that observes the workflow-level `effort` actually changes SDK behavior (no API keys in CI; verified by reading the executor's lookup at `dag-executor.ts:472, 474, 1751-1755, 2586-2590`)

## Side Effects / Blast Radius (required)

- **Affected subsystems/workflows:**
  - `loader.ts` `parseWorkflow` — adds five parse/validate blocks and five conditional spreads on the constructed object
  - DAG executor — **no code change**, but starts seeing populated `workflowLevelOptions` for any workflow that sets these fields
- **Potential unintended effects:**
  - Existing workflows that incidentally relied on the silent-drop (e.g. set `effort: high` while expecting per-node defaults to win unconditionally) will now inherit the workflow-level default unless they set per-node overrides. Grep against the bundled defaults returned 0 matches, so no Archon-shipped workflow is affected. User workflows that set these fields at the root were already broken in the opposite direction — silently ignored — so this aligns observed behavior with documented intent.
- **Guardrails/monitoring:**
  - Five new structured log events for invalid values (`invalid_workflow_effort_value_ignored`, `…_thinking_…`, `…_fallback_model_…`, `…_betas_…`, `…_sandbox_…`)
  - Warn-and-drop policy means a typo in one workflow doesn't abort the whole discovery pass (consistent with `interactive` / `modelReasoningEffort` / `tags`)

## Rollback Plan (required)

- **Fast rollback:** `git revert <merge-sha>` — the change is isolated to two files in the workflows package
- **Feature flags / config toggles:** none — fix is unconditional
- **Observable failure symptoms:**
  - If a real user workflow was depending on the silent-drop, they'd see different per-node behavior than before (e.g. `effort` now propagating). Surface in: `invalid_workflow_*_value_ignored` logs at debug/warn level
  - If the parse logic itself has a bug, workflows would fail to load (caught by `result.errors` in `discoverWorkflows`)

## Risks and Mitigations

- **Risk:** A user workflow that set `effort: high` at the root and *also* relied on per-node behavior being "always SDK default" will now inherit `high` per-node.
  - **Mitigation:** Aligning observed behavior with `workflowBaseSchema` and the documented intent of workflow-level defaults. Per-node overrides remain authoritative — if a user wants to opt out, they set `effort: <other>` on the node explicitly, same as documented for every other workflow-level field today.

- **Risk:** The `betas` cast `as [string, ...string[]]` is a type assertion after the `length > 0` guard. If the guard is ever removed or weakened, the cast becomes unsound.
  - **Mitigation:** The guard and the cast sit on adjacent lines with an inline comment explaining the invariant; the schema's tuple-with-at-least-one type is what enforces the requirement at the type level, so a future refactor would have to fight TypeScript to drop it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflows now accept new root-level options: effort, thinking, fallbackModel, betas, and sandbox; node-level values override workflow defaults.
* **Tests**
  * Added unit tests covering parsing, normalization, trimming/filtering, and warn-and-drop behavior for these options.
* **Documentation**
  * Updated authoring docs to clarify inheritance and precedence of these model configuration options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1799?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->