### PR TITLE
fix(workflows): use Git Bash instead of WSL bash for bash nodes on Windows

### DIFF
--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -5,7 +5,7 @@
  * Independent nodes within the same layer run concurrently via Promise.allSettled.
  * Captures all assistant output regardless of streaming mode for $node_id.output substitution.
  */
-import { writeFileSync } from 'fs';
+import { existsSync, writeFileSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { isAbsolute, join as joinPath, resolve as resolvePath } from 'path';
 import { execFileAsync } from '@archon/git';
@@ -1286,6 +1286,32 @@ const NODE_OUTPUT_FILE_THRESHOLD = 32_768;
  * Runs the script via `bash -c`, captures stdout as node output.
  * No AI session is created — bash nodes are free/deterministic.
  */
+/**
+ * Resolve the bash executable for bash/script nodes.
+ *
+ * On Windows a bare `bash` resolves via PATH to `C:\Windows\System32\bash.exe`
+ * (the WSL launcher) when WSL is installed. Passing a complex multi-line script as a
+ * `bash -c` argument through the Node->WSL interop layer mangles quotes/newlines
+ * (producing "syntax error" / "-c requires an argument"), and WSL can't see Windows
+ * tools (bun/tsc/gh). Prefer Git Bash (MINGW), which runs natively. Override with the
+ * ARCHON_BASH_PATH env var.
+ */
+function resolveBashPath(): string {
+  const override = process.env.ARCHON_BASH_PATH;
+  if (override) return override;
+  if (process.platform === 'win32') {
+    const candidates = [
+      'C:\\Program Files\\Git\\bin\\bash.exe',
+      'C:\\Program Files\\Git\\usr\\bin\\bash.exe',
+      'C:\\Program Files (x86)\\Git\\bin\\bash.exe',
+    ];
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  return 'bash';
+}
+
 async function executeBashNode(
   deps: WorkflowDeps,
   platform: IWorkflowPlatform,
@@ -1363,7 +1389,7 @@ async function executeBashNode(
   };
 
   try {
-    const { stdout, stderr } = await execFileAsync('bash', ['-c', finalScript], {
+    const { stdout, stderr } = await execFileAsync(resolveBashPath(), ['-c', finalScript], {
       cwd,
       timeout,
       env: subprocessEnv,
@@ -2186,7 +2212,7 @@ async function executeLoopNode(
           true, // escapedForBash
           logDir
         );
-        await execFileAsync('bash', ['-c', substitutedBash], {
+        await execFileAsync(resolveBashPath(), ['-c', substitutedBash], {
           cwd,
           timeout: SUBPROCESS_DEFAULT_TIMEOUT,
           env: {


### PR DESCRIPTION
## Summary

- **Problem:** On Windows with WSL installed, `execFile('bash', ['-c', script])` resolves `bash` to `C:\Windows\System32\bash.exe` (the WSL launcher). Multi-line bash-node scripts get mangled by the Node→WSL interop (`syntax error` / `-c requires an argument`), and WSL can't see Windows `bun`/`tsc`/`gh`.
- **Why it matters:** Every bash-heavy bundled workflow (refactor-safely, architect, validate-pr, smart-pr-review, plus scan/validate/verify steps) fails on the first bash node and cascade-skips the rest.
- **What changed:** Added `resolveBashPath()` and used it at both `execFileAsync('bash', …)` call sites in `dag-executor.ts`. Resolution order: `ARCHON_BASH_PATH` env override → Git Bash (MINGW) on `win32` → `bash`.
- **What did NOT change (scope boundary):** No change to script content, substitution, env passing, non-Windows behavior (falls through to `bash`), or any other node type. One file touched.

## UX Journey

### Before

```
  User                 Archon (dag-executor)        shell
  ────                 ─────────────────────        ─────
  run workflow ──────▶ executeBashNode
                       execFile('bash',['-c',S]) ─▶ System32\bash.exe (WSL)
                                                     [X] mangles multi-line S
  node failure ◀────── scan-scope FAILED ◀───────── syntax error
```

### After

```
  User                 Archon (dag-executor)        shell
  ────                 ─────────────────────        ─────
  run workflow ──────▶ executeBashNode
                       execFile(*resolveBashPath()*,['-c',S]) ─▶ *Git Bash (MINGW)*
                                                     runs S natively, sees bun/gh
  node output ◀─────── scan-scope OK ◀───────────── stdout
```

## Architecture Diagram

### Before

```
dag-executor.executeBashNode ──▶ @archon/git.execFileAsync('bash', ...) ──▶ PATH 'bash' (WSL on win32)
dag-executor.<script-node bash> ─▶ execFileAsync('bash', ...) ──────────────▶ PATH 'bash' (WSL on win32)
```

### After

```
dag-executor.resolveBashPath() [+]
dag-executor.executeBashNode ──▶ execFileAsync(resolveBashPath(), ...) ==▶ Git Bash on win32 (else 'bash')
dag-executor.<script-node bash> ─▶ execFileAsync(resolveBashPath(), ...) ==▶ Git Bash on win32 (else 'bash')
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `executeBashNode` | `execFileAsync` | **modified** | bin arg `'bash'` → `resolveBashPath()` |
| script-node bash | `execFileAsync` | **modified** | same |
| `resolveBashPath` | `fs.existsSync` | **new** | probes Git Bash locations on win32 |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `workflows`
- Module: `workflows:dag-executor`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes #1808

## Validation Evidence (required)

```bash
bun run type-check   # pass (compiles)
bun run lint         # pass (husky lint-staged: eslint --fix + prettier ran clean on commit)
```

- Evidence provided: Reproduced via Node `execFile`: WSL `bash` **failed** on a representative multi-line script; Git Bash **succeeded**. After the patch, the full `archon-refactor-safely` flow ran end-to-end on Windows (scan-scope→analyze→plan→execute→validate→fix→verify all completed) where it previously failed at `scan-scope`.
- Skipped commands: full `bun run validate`/test suite not run locally for this one-file change; CI covers it.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No` (only `existsSync` probes of fixed Git install paths)
- Notes: prefers a known-native shell; `ARCHON_BASH_PATH` lets users pin an explicit binary.

## Compatibility / Migration

- Backward compatible? `Yes` (non-win32 unchanged; win32 without Git Bash falls back to `bash`)
- Config/env changes? `Yes` (optional new `ARCHON_BASH_PATH` override; no default required)
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios: Windows 11 + WSL2; `archon-refactor-safely` and `archon-architect` previously failed at the first bash node, now run end-to-end.
- Edge cases checked: `ARCHON_BASH_PATH` override path; fallback to `bash` when Git Bash absent.
- What was not verified: macOS/Linux (logic is a no-op there — falls through to `bash`).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: all workflow bash nodes + script nodes on Windows.
- Potential unintended effects: if a user intended WSL bash specifically, they can set `ARCHON_BASH_PATH=/path/to/wsl/bash` (or any bash) to restore it.
- Guardrails: env override; unchanged behavior off-Windows.

## Rollback Plan (required)

- Fast rollback: revert this commit (single file).
- Feature flags/toggles: `ARCHON_BASH_PATH` env var.
- Observable failure symptoms: bash nodes erroring with shell syntax errors / `-c requires an argument`.

## Risks and Mitigations

- Risk: Git Bash path differs from the hardcoded candidates on some installs.
  - Mitigation: `ARCHON_BASH_PATH` override; otherwise falls back to PATH `bash` (current behavior).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved bash executable resolution to support custom paths via environment variables, enhancing system configuration flexibility.
* Enhanced cross-platform compatibility with automatic detection of Git Bash installations on Windows.
* Implemented reliable fallback mechanisms for consistent execution across different operating systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1809?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->