### PR TITLE
fix(workflows): fail dag node on idle-timeout with zero output

### DIFF
--- a/.archon/workflows/maintainer/maintainer-review-pr.yaml
+++ b/.archon/workflows/maintainer/maintainer-review-pr.yaml
@@ -105,7 +105,6 @@ nodes:
     depends_on: [fetch-pr, fetch-diff]
     allowed_tools: []
     context: fresh
-    idle_timeout: 60000
     output_format:
       type: object
       properties:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **DAG nodes no longer silently complete when `idle_timeout` fires before any output is produced.**
+  Previously, an idle timeout with zero output was incorrectly recorded as `completed`. Now it fails
+  with a clear error: `"Node '<id>' timed out with no output … Consider increasing idle_timeout or
+  reducing prompt size."` Nodes that do produce output before the subprocess hangs still complete
+  with a warning, unchanged (#1807).
+
 ## [0.4.1] - 2026-05-28
 
 Hotfix for the v0.4.0 upgrade path.

--- a/packages/docs-web/src/content/docs/book/quick-reference.md
+++ b/packages/docs-web/src/content/docs/book/quick-reference.md
@@ -295,7 +295,7 @@ defaults:
 | `Not a git repository` | Running outside a repo | `cd` into a git repo first — workflow and isolation commands require one |
 | `Unknown provider 'X'. Registered: claude, codex, pi` | Typo in `provider:` (workflow root or node-level) | Set `provider:` to one of the registered ids. Model strings themselves are not validated at load time — the SDK rejects unknown models at request time. |
 | `$BASE_BRANCH referenced but could not be detected` | No base branch set and auto-detection failed | Set `worktree.baseBranch` in `.archon/config.yaml` or ensure `main`/`master` exists |
-| Workflow hangs with no output | Node idle timeout hit | Increase `idle_timeout` on the node (milliseconds) |
+| Node fails with "timed out with no output" | `idle_timeout` fired before the provider emitted anything (time-to-first-token exceeded the window) | Increase `idle_timeout` on the node or reduce prompt size |
 
 ### Debug Techniques
 

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -408,6 +408,26 @@ describe('checkTriggerRule', () => {
   });
 });
 
+describe('checkTriggerRule -- classify-gated pipeline behavior on failure', () => {
+  it('all_success aspect skips when classify failed', () => {
+    const aspect = node('code-review', ['review-classify']);
+    const outputs = new Map([['review-classify', makeOutput('failed', '')]]);
+    expect(checkTriggerRule(aspect, outputs)).toBe('skip');
+  });
+
+  it('one_success synthesize skips when all aspects skipped (classify failed)', () => {
+    const synth = node('synthesize-review', ['code-review', 'error-handling', 'test-coverage'], {
+      trigger_rule: 'one_success',
+    });
+    const outputs = new Map([
+      ['code-review', makeOutput('skipped')],
+      ['error-handling', makeOutput('skipped')],
+      ['test-coverage', makeOutput('skipped')],
+    ]);
+    expect(checkTriggerRule(synth, outputs)).toBe('skip');
+  });
+});
+
 describe('DAG Loader -- cycle detection', () => {
   let testDir: string;
 

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -5350,6 +5350,133 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     expect(nodeCompletedEvents.length).toBeGreaterThan(0);
   });
 
+  it('idle-timeout with zero output produces node_failed, not node_completed', async () => {
+    // Regression test for #1807: idle-timeout before first token must fail, not silently complete.
+    // The generator yields nothing; idle_timeout fires before any output is produced.
+    mockSendQueryDag.mockImplementation(async function* (
+      _prompt: string,
+      _cwd: string,
+      _resumeSessionId?: string,
+      options?: { abortSignal?: AbortSignal }
+    ) {
+      // Wait for abort (idle timeout fires abort). Use AbortSignal so no dangling timers remain.
+      await new Promise<void>(resolve => {
+        const onAbort = (): void => resolve();
+        if (options?.abortSignal?.aborted) {
+          resolve();
+        } else {
+          options?.abortSignal?.addEventListener('abort', onAbort, { once: true });
+        }
+      });
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-dag',
+      testDir,
+      {
+        name: 'idle-timeout-no-output',
+        nodes: [
+          {
+            id: 'classify',
+            command: 'my-cmd',
+            idle_timeout: 50,
+            // Disable retries so the test doesn't wait for retry delays (the
+            // "timed out" message matches TRANSIENT patterns, which would trigger
+            // the default 2-retry / 3s-delay policy otherwise).
+            retry: { max_attempts: 0 },
+          },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+    const nodeFailedEvents = eventCalls.filter(
+      (call: unknown[]) => (call[0] as Record<string, unknown>).event_type === 'node_failed'
+    );
+    expect(nodeFailedEvents.length).toBeGreaterThan(0);
+    const failedData = (nodeFailedEvents[0][0] as Record<string, unknown>).data as Record<
+      string,
+      unknown
+    >;
+    expect(failedData.error).toContain('timed out with no output');
+    const nodeCompletedEvents = eventCalls.filter(
+      (call: unknown[]) => (call[0] as Record<string, unknown>).event_type === 'node_completed'
+    );
+    expect(nodeCompletedEvents.length).toBe(0);
+    expect(store.failWorkflowRun).toHaveBeenCalled();
+  });
+
+  it('idle-timeout WITH output produces node_completed and sends warning, not node_failed', async () => {
+    // The "subprocess hung after AI finished" path must still complete the node, not fail it.
+    // Note: no `result` event — the generator yields content then hangs, so idle timeout fires
+    // before the generator exits. This is the "subprocess hung without sending result" case.
+    mockSendQueryDag.mockImplementation(async function* (
+      _prompt: string,
+      _cwd: string,
+      _resumeSessionId?: string,
+      options?: { abortSignal?: AbortSignal }
+    ) {
+      yield { type: 'assistant', content: 'Here is the analysis result.' };
+      // Hang until abort signal fires (idle timeout aborts the controller)
+      await new Promise<void>(resolve => {
+        options?.abortSignal?.addEventListener('abort', () => resolve());
+      });
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-dag',
+      testDir,
+      {
+        name: 'idle-timeout-with-output',
+        nodes: [{ id: 'step1', command: 'my-cmd', idle_timeout: 50, retry: { max_attempts: 0 } }],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+    const nodeFailedEvents = eventCalls.filter(
+      (call: unknown[]) => (call[0] as Record<string, unknown>).event_type === 'node_failed'
+    );
+    expect(nodeFailedEvents.length).toBe(0);
+    const nodeCompletedEvents = eventCalls.filter(
+      (call: unknown[]) => (call[0] as Record<string, unknown>).event_type === 'node_completed'
+    );
+    expect(nodeCompletedEvents.length).toBeGreaterThan(0);
+    const sentMessages = (platform.sendMessage as ReturnType<typeof mock>).mock.calls.map(
+      (c: unknown[]) => c[1] as string
+    );
+    expect(sentMessages.some(m => m.includes('completed via idle timeout'))).toBe(true);
+  });
+
   it('fails the run when a node specifies an unknown provider (defense-in-depth at execution time)', async () => {
     // Loader-time validation also catches this (loader.ts iterates dagNodes
     // after parsing), but the dag-executor's resolveNodeProviderAndModel

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -5359,13 +5359,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
       _resumeSessionId?: string,
       options?: { abortSignal?: AbortSignal }
     ) {
-      // Wait for abort (idle timeout fires abort). Use AbortSignal so no dangling timers remain.
+      // Wait for abort (idle timeout fires abort).
       await new Promise<void>(resolve => {
-        const onAbort = (): void => resolve();
         if (options?.abortSignal?.aborted) {
           resolve();
         } else {
-          options?.abortSignal?.addEventListener('abort', onAbort, { once: true });
+          options?.abortSignal?.addEventListener('abort', () => resolve(), { once: true });
         }
       });
     });

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1039,22 +1039,18 @@ async function executeNodeInternal(
       }
     }
 
-    // Only post "completed via idle timeout" when the node produced output — zero-output timeout falls through to the empty-output guard below.
-    if (nodeIdleTimedOut) {
-      // Invariant: providers only set structuredOutput when the AI produced parseable content.
-      const hasAnyOutput = nodeOutputText.trim() !== '' || structuredOutput !== undefined;
-      if (hasAnyOutput) {
-        getLog().warn(
-          { nodeId: node.id, timeoutMs: effectiveIdleTimeout },
-          'dag_node_completed_via_idle_timeout'
-        );
-        await safeSendMessage(
-          platform,
-          conversationId,
-          `⚠️ Node \`${node.id}\` completed via idle timeout (no output for ${String(effectiveIdleTimeout / 60000)} min). The AI likely finished but the subprocess didn't exit cleanly.`,
-          nodeContext
-        );
-      }
+    // Only post "completed via idle timeout" when output exists — zero-output timeout falls through to the empty-output guard below.
+    if (nodeIdleTimedOut && (nodeOutputText.trim() !== '' || structuredOutput !== undefined)) {
+      getLog().warn(
+        { nodeId: node.id, timeoutMs: effectiveIdleTimeout },
+        'dag_node_completed_via_idle_timeout'
+      );
+      await safeSendMessage(
+        platform,
+        conversationId,
+        `⚠️ Node \`${node.id}\` completed via idle timeout (no output for ${String(effectiveIdleTimeout / 60000)} min). The AI likely finished but the subprocess didn't exit cleanly.`,
+        nodeContext
+      );
     }
 
     // If cancelled during streaming (not idle timeout), return as failed with cancel reason

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1039,10 +1039,9 @@ async function executeNodeInternal(
       }
     }
 
-    // Idle timeout with some output captured = subprocess hung after finishing. Surface as
-    // a completion warning. Idle timeout with no output is handled by the empty-output guard
-    // below so we don't post a contradictory "completed" message.
+    // Only post "completed via idle timeout" when the node produced output — zero-output timeout falls through to the empty-output guard below.
     if (nodeIdleTimedOut) {
+      // Invariant: providers only set structuredOutput when the AI produced parseable content.
       const hasAnyOutput = nodeOutputText.trim() !== '' || structuredOutput !== undefined;
       if (hasAnyOutput) {
         getLog().warn(
@@ -1139,18 +1138,11 @@ async function executeNodeInternal(
       return { state: 'failed', output: nodeOutputText, error: creditError };
     }
 
-    // Fail when the node produced no output at all (no text, no structured output).
-    // Covers two cases:
-    //  1. Non-timeout: provider stream closed silently (rejection, interruption).
-    //  2. Idle-timeout with zero output: the AI never emitted anything before the
-    //     watchdog fired (e.g. time-to-first-token exceeded the idle window on a
-    //     large prompt). This is NOT the "subprocess hung after completion" case —
-    //     that requires some output to have been captured first, which is handled
-    //     by the conditional "completed via idle timeout" message above.
+    // Fail for zero output: covers both silent non-timeout exits AND idle-timeout before first token (time-to-first-token exceeded the window).
     if (nodeOutputText.trim() === '' && structuredOutput === undefined) {
       const duration = Date.now() - nodeStartTime;
       const emptyError = nodeIdleTimedOut
-        ? `Node '${node.id}' timed out with no output (idle for ${String(effectiveIdleTimeout / 1000)}s). The provider did not emit any content before the watchdog fired — likely time-to-first-token exceeded the timeout. Consider increasing idle_timeout or reducing prompt size.`
+        ? `Node '${node.id}' timed out with no output (idle for ${String(effectiveIdleTimeout / 60000)} min). The provider did not emit any content before the watchdog fired — likely time-to-first-token exceeded the timeout. Consider increasing idle_timeout or reducing prompt size.`
         : `Node '${node.id}' produced no assistant output. The provider stream closed without yielding content — likely a silent provider rejection or stream interruption.`;
       getLog().error({ nodeId: node.id, durationMs: duration }, 'dag.node_empty_output');
       await logNodeError(logDir, workflowRun.id, node.id, emptyError);

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1039,18 +1039,23 @@ async function executeNodeInternal(
       }
     }
 
-    // If the node completed via idle timeout, log it
+    // Idle timeout with some output captured = subprocess hung after finishing. Surface as
+    // a completion warning. Idle timeout with no output is handled by the empty-output guard
+    // below so we don't post a contradictory "completed" message.
     if (nodeIdleTimedOut) {
-      getLog().warn(
-        { nodeId: node.id, timeoutMs: effectiveIdleTimeout },
-        'dag_node_completed_via_idle_timeout'
-      );
-      await safeSendMessage(
-        platform,
-        conversationId,
-        `⚠️ Node \`${node.id}\` completed via idle timeout (no output for ${String(effectiveIdleTimeout / 60000)} min). The AI likely finished but the subprocess didn't exit cleanly.`,
-        nodeContext
-      );
+      const hasAnyOutput = nodeOutputText.trim() !== '' || structuredOutput !== undefined;
+      if (hasAnyOutput) {
+        getLog().warn(
+          { nodeId: node.id, timeoutMs: effectiveIdleTimeout },
+          'dag_node_completed_via_idle_timeout'
+        );
+        await safeSendMessage(
+          platform,
+          conversationId,
+          `⚠️ Node \`${node.id}\` completed via idle timeout (no output for ${String(effectiveIdleTimeout / 60000)} min). The AI likely finished but the subprocess didn't exit cleanly.`,
+          nodeContext
+        );
+      }
     }
 
     // If cancelled during streaming (not idle timeout), return as failed with cancel reason
@@ -1134,18 +1139,19 @@ async function executeNodeInternal(
       return { state: 'failed', output: nodeOutputText, error: creditError };
     }
 
-    // Empty assistant output is a failure for AI nodes — a provider stream
-    // that closed cleanly with zero content typically means a silent
-    // rejection or interruption that didn't produce a result.isError chunk.
-    // Bash/script/approval nodes don't reach this path; they have their
-    // own dispatch and never stream through this loop.
-    //
-    // Idle-timeout exits are exempt: the timeout warning at line 1017 has
-    // already told the user the node "completed via idle timeout"; flipping
-    // that to a failure here would directly contradict the on-screen message.
-    if (nodeOutputText.trim() === '' && structuredOutput === undefined && !nodeIdleTimedOut) {
+    // Fail when the node produced no output at all (no text, no structured output).
+    // Covers two cases:
+    //  1. Non-timeout: provider stream closed silently (rejection, interruption).
+    //  2. Idle-timeout with zero output: the AI never emitted anything before the
+    //     watchdog fired (e.g. time-to-first-token exceeded the idle window on a
+    //     large prompt). This is NOT the "subprocess hung after completion" case —
+    //     that requires some output to have been captured first, which is handled
+    //     by the conditional "completed via idle timeout" message above.
+    if (nodeOutputText.trim() === '' && structuredOutput === undefined) {
       const duration = Date.now() - nodeStartTime;
-      const emptyError = `Node '${node.id}' produced no assistant output. The provider stream closed without yielding content — likely a silent provider rejection or stream interruption.`;
+      const emptyError = nodeIdleTimedOut
+        ? `Node '${node.id}' timed out with no output (idle for ${String(effectiveIdleTimeout / 1000)}s). The provider did not emit any content before the watchdog fired — likely time-to-first-token exceeded the timeout. Consider increasing idle_timeout or reducing prompt size.`
+        : `Node '${node.id}' produced no assistant output. The provider stream closed without yielding content — likely a silent provider rejection or stream interruption.`;
       getLog().error({ nodeId: node.id, durationMs: duration }, 'dag.node_empty_output');
       await logNodeError(logDir, workflowRun.id, node.id, emptyError);
 


### PR DESCRIPTION
## Summary

- **Problem:** When `review-classify` idle-times-out before emitting any tokens, the dag-executor incorrectly marks the node `completed` (not `failed`). All downstream aspect gates evaluate `$review-classify.output.*` conditions against empty string → every aspect is skipped → `synthesize-review` skips (no upstream completed) → workflow reports success having reviewed nothing.
- **Why it matters:** A maintainer cannot trust a "completed" status from `maintainer-review-pr`; bad PRs pass unreviewed with no visible signal. Any classify-gated workflow with `output_format` is vulnerable to the same silent success if the classifier times out.
- **What changed:** (1) Engine: narrow the idle-timeout exemption so it only applies when the AI actually produced output; add a distinct, actionable error for idle-timeout-with-zero-output. (2) YAML: remove the `idle_timeout: 60000` copy-paste artefact from `review-classify` (it was the tightest timeout on the largest prompt). (3) Tests: document the classify-failure → aspect-skip → synthesize-skip cascade.
- **What did not change:** Diff-size cap in `fetch-diff`, `trigger_rule` values in the workflow, `archon-smart-pr-review.yaml` / `archon-fix-github-issue.yaml` YAML (they have no `idle_timeout` on classifiers; they benefit from the engine hardening automatically), loop-node idle-timeout path (separate, already has its own empty-output handling).

## UX Journey

### Before

```
User                        dag-executor               Platform
────                        ────────────               ────────
runs maintainer-review-pr
                            review-classify starts
                            (large prompt ~45 KB)
                            60 s idle-timeout fires
                              → nodeIdleTimedOut=true
                              → empty-output guard
                                 skipped (!nodeIdleTimedOut)
                              → node marked: completed
                            aspect gates check
                              $review-classify.output.*
                              → '' === 'true' → false
                            all aspects: skipped
                            synthesize-review: skipped
                              (one_success, all-skipped)
                            workflow: completed ✓
sees "Workflow completed"  ◀──────────────────────────
(PR was never reviewed)
```

### After

```
User                        dag-executor               Platform
────                        ────────────               ────────
runs maintainer-review-pr
                            review-classify starts
                            (large prompt, 30-min default)
                                                         ← timeout removed; node
                                                           gets standard 30-min window
                            [if still times out with 0 output]
                              → empty-output guard fires
                              → node marked: [FAILED]
                              → error: "timed out with no
                                 output; consider increasing
                                 idle_timeout or reducing
                                 prompt size"
                            all aspects: skipped
                              (all_success, upstream failed)
                            synthesize-review: skipped
                            workflow: [FAILED] ✗
sees "Workflow failed:     ◀──────────────────────────
 review-classify timed out
 with no output"
```

## Architecture Diagram

### Before

```
dag-executor.ts (runDagNode)
  │
  ├─ idle_timeout fires → nodeIdleTimedOut = true
  │
  ├─ [~1042] "completed via idle timeout" message  ← always sent
  │
  └─ [~1146] empty-output guard:
       if (text=='' && structured==undefined && !nodeIdleTimedOut)
                                                   ↑ exempts ALL timeouts
         → fail
       else → CONTINUE to completion path
         → node state: completed   ← BUG: fires even with zero output
```

### After

```
dag-executor.ts (runDagNode)
  │
  ├─ idle_timeout fires → nodeIdleTimedOut = true
  │
  ├─ [~1042] "completed via idle timeout" message
  │    └─ gated: only if hasAnyOutput (text or structured)
  │
  └─ [~1146] empty-output guard:
       if (text=='' && structured==undefined)       ← exemption removed
         → nodeIdleTimedOut?
             yes → "timed out with no output" error
             no  → "provider stream closed silently" error
         → node state: failed   ← CORRECT
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `runDagNode` | completion path | **modified** | Zero-output + idle-timeout now routes to `failed`, not `completed` |
| `runDagNode` | "completed via idle timeout" message | **modified** | Gated behind `hasAnyOutput` check |
| `dag-executor.ts` | `checkTriggerRule` | unchanged | Already handles `failed` upstream correctly via `all_success` → skip |
| `condition-evaluator.ts` | `$nodeId.output` resolution | unchanged | Already returns `''` for empty output |
| `maintainer-review-pr.yaml` | `review-classify` node | **modified** | `idle_timeout: 60000` removed; inherits 30-min default |
| `dag-executor.test.ts` | `checkTriggerRule` tests | **new** | Classify-failure cascade documented |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `workflows`
- Module: `workflows:executor`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes #1807

## Validation Evidence (required)

```bash
bun run validate
```

All six checks passed:

| Check | Result |
|-------|--------|
| `check:bundled` | ✅ 36 commands, 20 workflows up to date |
| `check:bundled-skill` | ✅ 21 files up to date |
| `bun run type-check` | ✅ all 10 packages |
| `bun run lint` | ✅ 0 errors, 0 warnings |
| `bun run format:check` | ✅ all files conform |
| `bun run test` | ✅ 257 pass in `dag-executor.test.ts`; 0 failures across all packages |

- Evidence provided: full `bun run validate` suite exit 0, detailed per-package test results in validation artifact.
- No commands skipped.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — the change is engine behavior only; existing workflows that do NOT have `idle_timeout` set (or whose timeout fires after some output was produced) are unaffected.
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: All automated checks passed (type-check, lint, format, full test suite including new `checkTriggerRule` tests for classify-failure cascade). `bun run cli validate workflows maintainer-review-pr` confirmed the YAML is valid after removing `idle_timeout`.
- Edge cases checked: Pi/Minimax partial-output + idle-timeout case (hasAnyOutput=true → original "completed" path unaffected); non-timeout zero-output case (provider stream closed silently → still hits the same failure branch with its original message).
- What was not verified: Live end-to-end run of `maintainer-review-pr` against a real PR; the timeout removal cannot be force-triggered in CI. The logic is covered by the unit tests and the evidence chain in the RCA.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `maintainer-review-pr` (direct fix); `archon-smart-pr-review` and `archon-fix-github-issue` (engine hardening — they had no `idle_timeout` on classifier nodes, so the only visible change is that a zero-output idle-timeout on their classifier would now correctly fail rather than silently succeed).
- Potential unintended effects: Any workflow node with `output_format` that previously relied on idle-timeout-with-zero-output being treated as success (spurious behavior) will now fail explicitly. This is the correct outcome.
- Guardrails/monitoring for early detection: Node failure is logged at `error` level with `dag_node.run_failed` event; the error message is actionable ("consider increasing idle_timeout or reducing prompt size").

## Rollback Plan (required)

- Fast rollback command/path: `git revert a813ca36` — single commit, no migration.
- Feature flags or config toggles: None.
- Observable failure symptoms: `review-classify` nodes that previously timed out silently would revert to spurious `completed` state; identifiable by `dag_node_completed_via_idle_timeout` warn log with zero output in the JSONL log.

## Risks and Mitigations

- Risk: A workflow has an `idle_timeout` node with `output_format` that intentionally tolerated zero-output timeouts as success.
  - Mitigation: Audit of all bundled workflows shows no such pattern exists. The only node with both `idle_timeout` and `output_format` was `review-classify`, and its `idle_timeout: 60000` was an unintentional copy-paste artefact now removed. User-defined workflows with this pattern would need to either increase their timeout or remove it — the new error message tells them exactly that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Nodes now fail with a descriptive "timed out with no output" error when idle timeout occurs before any output is produced, rather than marking the run as completed.
  * Nodes that generate output before hanging continue to complete with a warning.

* **Documentation**
  * Updated troubleshooting guide with clearer idle timeout error descriptions and an additional solution option (reduce prompt size).

* **Tests**
  * Added regression test coverage for idle-timeout scenarios with and without output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1812?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->