### PR TITLE
chore(deps): standardize on zod v4 across the codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@
 - Schema naming: camelCase, descriptive suffix (e.g., `workflowRunSchema`, `errorSchema`)
 - Type derivation: always use `z.infer<typeof schema>` — never write parallel hand-crafted interfaces
 - Import `z` from `@hono/zod-openapi` (not from `zod` directly)
+- Record schemas: always pass an explicit key type — `z.record(z.string(), valueSchema)` — zod v4 dropped the single-arg `z.record(valueSchema)` form
 - All new/modified API routes must use `registerOpenApiRoute(createRoute({...}), handler)` — the local wrapper handles the TypedResponse bypass. Two narrow exceptions exist: (1) routes that serve raw non-JSON content (e.g. `/api/artifacts/:runId/*` returns `text/markdown`/`text/plain`) AND use wildcard path params that OpenAPI 3.0 can't represent, use `app.get(...)` with an explanatory comment; (2) multipart-or-JSON routes (e.g. `/api/conversations/:id/message`, `/api/workflows/:name/run`) register through `registerOpenApiRoute` but drop `request.body` from the route config so Zod doesn't validate multipart payloads against a JSON schema — the handler parses both content types manually.
 - Core row schemas live in `packages/core/src/schemas/` — one file per data shape (conversation, message, user, codebase, session, workflow-event, env-var, workflow-run); `index.ts` re-exports all
 - Route schemas live in `packages/server/src/routes/schemas/` — one file per domain

--- a/bun.lock
+++ b/bun.lock
@@ -73,11 +73,11 @@
         "@archon/paths": "workspace:*",
         "@archon/providers": "workspace:*",
         "@archon/workflows": "workspace:*",
-        "@hono/zod-openapi": "^0.19.6",
+        "@hono/zod-openapi": "^1.4.0",
         "@octokit/auth-app": "^8.0.0",
         "@octokit/rest": "^22.0.0",
         "pg": "^8.11.0",
-        "zod": "^3",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/pg": "^8.11.0",
@@ -160,10 +160,10 @@
         "@archon/paths": "workspace:*",
         "@archon/providers": "workspace:*",
         "@archon/workflows": "workspace:*",
-        "@hono/zod-openapi": "^0.19.6",
+        "@hono/zod-openapi": "^1.4.0",
         "dotenv": "^17.2.3",
         "hono": "^4.12.16",
-        "zod": "^3.25.28",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -228,8 +228,8 @@
         "@archon/git": "workspace:*",
         "@archon/paths": "workspace:*",
         "@archon/providers": "workspace:*",
-        "@hono/zod-openapi": "^0.19.6",
-        "zod": "^3.25.28",
+        "@hono/zod-openapi": "^1.4.0",
+        "zod": "^4.4.3",
       },
       "peerDependencies": {
         "typescript": "^5.0.0",
@@ -290,7 +290,7 @@
 
     "@archon/workflows": ["@archon/workflows@workspace:packages/workflows"],
 
-    "@asteasolutions/zod-to-openapi": ["@asteasolutions/zod-to-openapi@7.3.4", "", { "dependencies": { "openapi3-ts": "^4.1.2" }, "peerDependencies": { "zod": "^3.20.2" } }, "sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA=="],
+    "@asteasolutions/zod-to-openapi": ["@asteasolutions/zod-to-openapi@8.5.0", "", { "dependencies": { "openapi3-ts": "^4.1.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q=="],
 
     "@astrojs/compiler": ["@astrojs/compiler@3.0.1", "", {}, "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA=="],
 
@@ -570,9 +570,9 @@
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
-    "@hono/zod-openapi": ["@hono/zod-openapi@0.19.10", "", { "dependencies": { "@asteasolutions/zod-to-openapi": "^7.3.0", "@hono/zod-validator": "^0.7.1", "openapi3-ts": "^4.5.0" }, "peerDependencies": { "hono": ">=4.3.6", "zod": ">=3.0.0" } }, "sha512-dpoS6DenvoJyvxtQ7Kd633FRZ/Qf74+4+o9s+zZI8pEqnbjdF/DtxIib08WDpCaWabMEJOL5TXpMgNEZvb7hpA=="],
+    "@hono/zod-openapi": ["@hono/zod-openapi@1.4.0", "", { "dependencies": { "@asteasolutions/zod-to-openapi": "^8.5.0", "@hono/zod-validator": "^0.8.0", "openapi3-ts": "^4.5.0" }, "peerDependencies": { "hono": ">=4.10.0", "zod": "^4.0.0" } }, "sha512-AFchqR1N/NxfI4hUOSGI2/g8zLROxA1OE7Oh5JJFlTaGxhrdRyH+93gd0tIBpb0z8s9r8hUoNnaOBfHbdb4NMw=="],
 
-    "@hono/zod-validator": ["@hono/zod-validator@0.7.6", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw=="],
+    "@hono/zod-validator": ["@hono/zod-validator@0.8.0", "", { "peerDependencies": { "hono": ">=4.10.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-5uS4S1/LKtZQYvD4BtpPUFkOv8d1wNxHHrChm26buMiEYc1FrHWvDUaKVBwkiVtvSExHSpLGDvcnpI2Copyj9w=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -2690,7 +2690,7 @@
 
     "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
@@ -2699,8 +2699,6 @@
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@antfu/ni/tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
-
-    "@anthropic-ai/claude-agent-sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@astrojs/markdown-remark/remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
 
@@ -3009,6 +3007,8 @@
     "shadcn/execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
 
     "shadcn/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "sitemap/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,11 +35,11 @@
     "@archon/paths": "workspace:*",
     "@archon/providers": "workspace:*",
     "@archon/workflows": "workspace:*",
-    "@hono/zod-openapi": "^0.19.6",
+    "@hono/zod-openapi": "^1.4.0",
     "@octokit/auth-app": "^8.0.0",
     "@octokit/rest": "^22.0.0",
     "pg": "^8.11.0",
-    "zod": "^3"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/pg": "^8.11.0",

--- a/packages/core/src/schemas/codebase.ts
+++ b/packages/core/src/schemas/codebase.ts
@@ -13,7 +13,7 @@ export const codebaseRowSchema = z.object({
   repository_url: z.string().nullable(),
   default_cwd: z.string(),
   ai_assistant_type: z.string(),
-  commands: z.record(z.object({ path: z.string(), description: z.string() })),
+  commands: z.record(z.string(), z.object({ path: z.string(), description: z.string() })),
   created_at: z.date(),
   updated_at: z.date(),
 });

--- a/packages/core/src/schemas/workflow-event.ts
+++ b/packages/core/src/schemas/workflow-event.ts
@@ -13,7 +13,7 @@ export const workflowEventRowSchema = z.object({
   event_type: z.string(),
   step_index: z.number().nullable(),
   step_name: z.string().nullable(),
-  data: z.record(z.unknown()),
+  data: z.record(z.string(), z.unknown()),
   created_at: z.string(),
 });
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,10 +17,10 @@
     "@archon/paths": "workspace:*",
     "@archon/providers": "workspace:*",
     "@archon/workflows": "workspace:*",
-    "@hono/zod-openapi": "^0.19.6",
+    "@hono/zod-openapi": "^1.4.0",
     "dotenv": "^17.2.3",
     "hono": "^4.12.16",
-    "zod": "^3.25.28"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0"

--- a/packages/server/src/routes/api.health.test.ts
+++ b/packages/server/src/routes/api.health.test.ts
@@ -470,3 +470,31 @@ describe('GET /api/commands', () => {
     expect(Array.isArray(body.commands)).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Tests: GET /api/openapi.json — guards @hono/zod-openapi spec generation
+// (the v0 -> v1 / zod v4 upgrade is a major bump; this confirms every
+// registered route's schema still serializes without throwing).
+// ---------------------------------------------------------------------------
+
+describe('GET /api/openapi.json', () => {
+  test('generates a valid OpenAPI 3 document for all registered routes', async () => {
+    const app = makeApp();
+    const response = await app.request('/api/openapi.json');
+    expect(response.status).toBe(200);
+
+    const doc = (await response.json()) as {
+      openapi: string;
+      info: { title: string; version: string };
+      paths: Record<string, unknown>;
+    };
+    expect(doc.openapi).toMatch(/^3\./);
+    expect(typeof doc.info.title).toBe('string');
+    // A representative sample of registered routes must be present, including
+    // ones whose schemas use the patterns touched by the zod v4 migration
+    // (z.record key types, z.string().datetime(), the node-sessions route).
+    expect(Object.keys(doc.paths).length).toBeGreaterThan(0);
+    expect(doc.paths['/api/health']).toBeDefined();
+    expect(doc.paths['/api/workflows/{name}/node-sessions']).toBeDefined();
+  });
+});

--- a/packages/server/src/routes/api.health.test.ts
+++ b/packages/server/src/routes/api.health.test.ts
@@ -487,6 +487,7 @@ describe('GET /api/openapi.json', () => {
       openapi: string;
       info: { title: string; version: string };
       paths: Record<string, unknown>;
+      components?: { schemas?: Record<string, unknown> };
     };
     expect(doc.openapi).toMatch(/^3\./);
     expect(typeof doc.info.title).toBe('string');
@@ -496,5 +497,17 @@ describe('GET /api/openapi.json', () => {
     expect(Object.keys(doc.paths).length).toBeGreaterThan(0);
     expect(doc.paths['/api/health']).toBeDefined();
     expect(doc.paths['/api/workflows/{name}/node-sessions']).toBeDefined();
+    // The datetime-heavy, highest-traffic routes are the ones the zod-to-openapi
+    // v7 -> v8 serialization change most threatens (z.string().datetime() fields
+    // on conversation/codebase schemas). A route can register in `paths` while
+    // its schema silently fails to serialize, so also assert the component
+    // schemas those routes reference actually made it into the document.
+    expect(doc.paths['/api/conversations']).toBeDefined();
+    expect(doc.paths['/api/codebases']).toBeDefined();
+    const schemas = doc.components?.schemas ?? {};
+    expect(Object.keys(schemas).length).toBeGreaterThan(10);
+    expect(schemas['Conversation']).toBeDefined();
+    expect(schemas['Codebase']).toBeDefined();
+    expect(schemas['WorkflowEvent']).toBeDefined();
   });
 });

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -879,7 +879,7 @@ const getHealthRoute = createRoute({
             .object({
               status: z.string(),
               adapter: z.string(),
-              concurrency: z.record(z.unknown()),
+              concurrency: z.record(z.string(), z.unknown()),
               runningWorkflows: z.number(),
               version: z.string().optional(),
               is_docker: z.boolean(),

--- a/packages/server/src/routes/schemas/workflow.schemas.ts
+++ b/packages/server/src/routes/schemas/workflow.schemas.ts
@@ -54,7 +54,7 @@ export const getWorkflowResponseSchema = z
   .openapi('GetWorkflowResponse');
 
 /** Request body for workflow definition endpoints (PUT and POST /validate). */
-const definitionBodySchema = z.object({ definition: z.record(z.unknown()) });
+const definitionBodySchema = z.object({ definition: z.record(z.string(), z.unknown()) });
 
 /** PUT /api/workflows/:name request body. */
 export const saveWorkflowBodySchema = definitionBodySchema.openapi('SaveWorkflowBody');

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -27,8 +27,8 @@
     "@archon/git": "workspace:*",
     "@archon/paths": "workspace:*",
     "@archon/providers": "workspace:*",
-    "@hono/zod-openapi": "^0.19.6",
-    "zod": "^3.25.28"
+    "@hono/zod-openapi": "^1.4.0",
+    "zod": "^4.4.3"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -1736,7 +1736,9 @@ nodes:
 
       const result = await discoverWorkflows(testDir, { loadDefaults: false });
       expect(result.errors).toHaveLength(1);
-      expect(result.errors[0].error).toMatch(/idle_timeout.*finite.*positive/i);
+      // zod v4's base `z.number()` rejects Infinity before the custom finite/positive
+      // refinement runs, so the message is the base "expected number" form; either is fine.
+      expect(result.errors[0].error).toMatch(/idle_timeout.*(finite.*positive|expected number)/i);
     });
 
     it('should ignore AI-specific fields on bash nodes (parses successfully, fields stripped)', async () => {
@@ -2186,7 +2188,9 @@ nodes:
 
       const result = await discoverWorkflows(testDir, { loadDefaults: false });
       expect(result.errors).toHaveLength(1);
-      expect(result.errors[0].error).toMatch(/max_attempts.*required/i);
+      // zod v4 reports a missing required field as "expected number, received undefined"
+      // (v3 said "Required"); the field path is the stable part.
+      expect(result.errors[0].error).toMatch(/max_attempts.*(required|expected number)/i);
     });
 
     it('should reject retry with max_attempts out of range', async () => {

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -43,12 +43,15 @@ function getLog(): ReturnType<typeof createLogger> {
  * doesn't abort the discovery pass. Mirrors the policy used for `tags` /
  * `interactive`. `extra` merges into the warning payload (e.g. the list of
  * valid enum options).
+ *
+ * The return type is inferred from the schema (`z.output<S>`), so
+ * preprocess-based schemas (e.g. `thinkingConfigSchema`, whose input is
+ * `unknown`) still resolve to their parsed output type rather than their
+ * input type. zod v4 removed `ZodTypeDef` as the middle type parameter, so the
+ * old `z.ZodType<T, z.ZodTypeDef, unknown>` form no longer compiles.
  */
 function parseOptionalField<S extends z.ZodType>(
   raw: unknown,
-  // Inferred from the schema (`z.output<S>`), so preprocess-based schemas
-  // (e.g. `thinkingConfigSchema`, whose input is `unknown`) still resolve to
-  // their parsed output type. zod v4 dropped the 3-arg `ZodType<O, Def, I>`.
   schema: S,
   filename: string,
   event: string,
@@ -540,8 +543,8 @@ export function parseWorkflow(content: string, filename: string): ParseResult {
     // betas: trim, drop empties, then validate the cleaned list through
     // `betasSchema` (non-empty array of non-empty strings). An empty result
     // drops the field entirely — the Claude SDK expects a populated beta header
-    // or none at all. Validating via the schema yields the `[string, ...string[]]`
-    // type without an unchecked cast.
+    // or none at all. The schema's `.nonempty()` enforces non-emptiness at
+    // runtime, so the cleaned list reaches the SDK validated without a cast.
     let betas: string[] | undefined;
     if (raw.betas !== undefined) {
       const cleaned = Array.isArray(raw.betas)

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -44,16 +44,16 @@ function getLog(): ReturnType<typeof createLogger> {
  * `interactive`. `extra` merges into the warning payload (e.g. the list of
  * valid enum options).
  */
-function parseOptionalField<T>(
+function parseOptionalField<S extends z.ZodType>(
   raw: unknown,
-  // Output is `T`; the input param stays `unknown` (decoupled from `T`) so
-  // preprocess-based schemas (e.g. `thinkingConfigSchema`, whose input is
-  // `unknown`) infer `T` from their output rather than their input.
-  schema: z.ZodType<T, z.ZodTypeDef, unknown>,
+  // Inferred from the schema (`z.output<S>`), so preprocess-based schemas
+  // (e.g. `thinkingConfigSchema`, whose input is `unknown`) still resolve to
+  // their parsed output type. zod v4 dropped the 3-arg `ZodType<O, Def, I>`.
+  schema: S,
   filename: string,
   event: string,
   extra?: Record<string, unknown>
-): T | undefined {
+): z.output<S> | undefined {
   const result = schema.safeParse(raw);
   if (result.success) return result.data;
   if (raw !== undefined) {
@@ -542,7 +542,7 @@ export function parseWorkflow(content: string, filename: string): ParseResult {
     // drops the field entirely — the Claude SDK expects a populated beta header
     // or none at all. Validating via the schema yields the `[string, ...string[]]`
     // type without an unchecked cast.
-    let betas: [string, ...string[]] | undefined;
+    let betas: string[] | undefined;
     if (raw.betas !== undefined) {
       const cleaned = Array.isArray(raw.betas)
         ? raw.betas

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -44,8 +44,8 @@ export type EffortLevel = z.infer<typeof effortLevelSchema>;
 /**
  * Claude Agent SDK beta header list. Non-empty array of non-empty strings —
  * the SDK expects either a populated beta header or none at all. `.nonempty()`
- * enforces the min-length-1 rule at runtime (in zod v4 the inferred type is
- * `string[]`, not a `[string, ...string[]]` tuple).
+ * enforces the min-length-1 rule at runtime; it does not narrow the inferred
+ * TypeScript type to a non-empty tuple (the type stays `string[]`).
  */
 export const betasSchema = z.array(z.string().min(1)).nonempty("'betas' must be a non-empty array");
 

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -43,9 +43,9 @@ export type EffortLevel = z.infer<typeof effortLevelSchema>;
 
 /**
  * Claude Agent SDK beta header list. Non-empty array of non-empty strings —
- * the SDK expects either a populated beta header or none at all. The
- * `.nonempty()` constraint makes the inferred type `[string, ...string[]]`,
- * which the loader relies on to validate cleaned input without an unchecked cast.
+ * the SDK expects either a populated beta header or none at all. `.nonempty()`
+ * enforces the min-length-1 rule at runtime (in zod v4 the inferred type is
+ * `string[]`, not a `[string, ...string[]]` tuple).
  */
 export const betasSchema = z.array(z.string().min(1)).nonempty("'betas' must be a non-empty array");
 
@@ -98,7 +98,7 @@ export const sandboxSettingsSchema = z
         denyRead: z.array(z.string()).optional(),
       })
       .optional(),
-    ignoreViolations: z.record(z.array(z.string())).optional(),
+    ignoreViolations: z.record(z.string(), z.array(z.string())).optional(),
     enableWeakerNestedSandbox: z.boolean().optional(),
     enableWeakerNetworkIsolation: z.boolean().optional(),
     excludedCommands: z.array(z.string()).optional(),
@@ -145,7 +145,7 @@ export const dagNodeBaseSchema = z.object({
   model: z.string().optional(),
   provider: z.string().trim().min(1).optional(),
   context: z.enum(['fresh', 'shared']).optional(),
-  output_format: z.record(z.unknown()).optional(),
+  output_format: z.record(z.string(), z.unknown()).optional(),
   allowed_tools: z.array(z.string()).optional(),
   denied_tools: z.array(z.string()).optional(),
   idle_timeout: z.number().optional(),
@@ -157,10 +157,22 @@ export const dagNodeBaseSchema = z.object({
     .nonempty("'skills' must be a non-empty array")
     .optional(),
   agents: z
-    .record(
-      z.string().regex(AGENT_ID_REGEX, 'agent IDs must be kebab-case (a-z, 0-9, hyphen)'),
-      agentDefinitionSchema
-    )
+    .record(z.string(), agentDefinitionSchema)
+    // Validate agent-id keys in a superRefine rather than via a regex on the
+    // record key schema: zod v4 collapses a failing key-schema into a generic
+    // "Invalid key in record" message and drops the custom text, so the
+    // kebab-case guidance is emitted here (with the offending key in the path).
+    .superRefine((map, ctx) => {
+      for (const key of Object.keys(map)) {
+        if (!AGENT_ID_REGEX.test(key)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `agent IDs must be kebab-case (a-z, 0-9, hyphen): '${key}'`,
+            path: [key],
+          });
+        }
+      }
+    })
     .refine(map => Object.keys(map).length > 0, "'agents' must have at least one entry")
     .optional(),
   effort: effortLevelSchema.optional(),

--- a/packages/workflows/src/schemas/hooks.ts
+++ b/packages/workflows/src/schemas/hooks.ts
@@ -44,7 +44,7 @@ export const workflowHookMatcherSchema = z.object({
   /** Regex pattern to match tool names (PreToolUse/PostToolUse) or event subtypes. */
   matcher: z.string().optional(),
   /** The SDK SyncHookJSONOutput to return when this hook fires. */
-  response: z.record(z.unknown()),
+  response: z.record(z.string(), z.unknown()),
   /** Timeout in seconds (default: SDK default of 60). */
   timeout: z.number().positive().optional(),
 });

--- a/packages/workflows/src/schemas/workflow-run.ts
+++ b/packages/workflows/src/schemas/workflow-run.ts
@@ -104,7 +104,7 @@ export const workflowRunSchema = z.object({
   codebase_id: z.string().nullable(),
   status: workflowRunStatusSchema,
   user_message: z.string(),
-  metadata: z.record(z.unknown()),
+  metadata: z.record(z.string(), z.unknown()),
   started_at: z.date(),
   completed_at: z.date().nullable(),
   last_activity_at: z.date().nullable(),


### PR DESCRIPTION
## Summary

- **Problem:** Two zod versions coexisted in the tree — `zod@3` (the project + `@hono/zod-openapi@0.19`) and `zod@4` (pulled by `@earendil-works/pi-coding-agent`). A `ZodError` thrown by code using one copy was **not** `instanceof` the `ZodError` imported from the other, so cross-version `instanceof` checks silently failed.
- **Why it matters:** It broke `core › sessions › updateSessionMetadata › throws ZodError` (the only failing test in `validate`) and risks subtle validation/`instanceof` bugs anywhere two zod copies meet.
- **What changed:** Standardized the project's own packages on **zod v4** — bumped `zod` `^3` → `^4.4.3` and `@hono/zod-openapi` `^0.19.6` → `^1.4.0` (its zod-v4 line) in `@archon/core`, `@archon/workflows`, `@archon/server`, plus the source changes v4 requires.
- **What did NOT change (scope boundary):** No schema/validation *behavior* changed — same fields, same accept/reject decisions (only zod's default error wording differs). Nested `zod@4.3.6`/`zod@3.25.76` copies inside unrelated third-party deps (astro, shadcn, MCP/mistral/copilot SDKs) are left as-is; they don't touch our code's `instanceof`. No runtime feature work.

## UX Journey

### Before

```
Developer runs `bun run validate`
  ├─ type-check ... ✅
  ├─ lint ......... ✅
  └─ test ......... ❌  core › sessions › throws ZodError
       updateSessionMetadata() throws ZodError  (from zod copy A)
       test imports ZodError                    (from zod copy B)
       expect(err).toBeInstanceOf(ZodError) ──▶ FALSE  (cross-realm instanceof)
```

### After

```
Developer runs `bun run validate`
  ├─ type-check ... ✅ (10 packages)
  ├─ lint ......... ✅
  └─ test ......... ✅
       updateSessionMetadata() throws ZodError  (zod@4.4.3) [single copy]
       test imports ZodError                    (zod@4.4.3) [single copy]
       expect(err).toBeInstanceOf(ZodError) ──▶ TRUE
```

## Architecture Diagram

### Before

```
                 zod@3.25.76 ◀── @archon/core / workflows / server  (zod: ^3)
                            ◀── @hono/zod-openapi@0.19  (z re-export)
                 zod@4.3.6  ◀── @earendil-works/pi-coding-agent, astro
   → @archon code touches BOTH realms → ZodError instanceof breaks
```

### After

```
                 zod@4.4.3  ◀── @archon/core / workflows / server  (zod: ^4.4.3)  [~]
                            ◀── @hono/zod-openapi@1.4.0  (z re-export)            [~]
                            ◀── @anthropic-ai/claude-agent-sdk (peer ^4.0.0)
   zod@4.3.6 / zod@3.25.76  ◀── only nested in unrelated 3rd-party deps (isolated)
   → all @archon code resolves ONE zod → instanceof works
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `@archon/{core,workflows,server}` | `zod` | **modified** | `^3` → `^4.4.3` |
| `@archon/{core,workflows,server}` | `@hono/zod-openapi` | **modified** | `^0.19.6` → `^1.4.0` (zod-v4 line) |
| schema files | `z.record(key, value)` | **modified** | v4 requires explicit key type |
| `loader.ts` | `parseOptionalField` generic | **modified** | v4 dropped 3-arg `ZodType<O, Def, I>` |
| `dag-node.ts` | `agents` key validation | **modified** | regex-on-key → `superRefine` (preserves message) |

## Label Snapshot

- Risk: `risk: medium` (major dep bump — zod v3→v4 + @hono/zod-openapi v0→v1; mitigated by full green validate + no behavior change)
- Size: `size: S` (~86/42 LOC across 14 files, mostly mechanical)
- Scope: `dependencies`, `core`, `workflows`, `server`, `tests`
- Module: `core:db`, `workflows:loader`, `workflows:schemas`, `server:routes`

## Change Metadata

- Change type: `chore`
- Primary scope: `multi` (dependencies + core + workflows + server)

## Linked Issue

- Closes #1811
- Related _none_
- Depends on _none_
- Supersedes _none_

## Validation Evidence (required)

```bash
$ bun run validate
# check:bundled            ✅
# check:bundled-skill      ✅
# type-check (10 packages) ✅
# lint --max-warnings 0    ✅
# format:check             ✅
# tests                    ✅ (incl. previously-failing sessions ZodError test)
# exit 0
```

- Evidence provided: `bun run validate` exits 0; `bun why zod` shows all `@archon/*` packages resolve `zod@4.4.3`; new `GET /api/openapi.json` test confirms spec generation under `@hono/zod-openapi` v1.
- Skipped: none.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No**

## Compatibility / Migration

- Backward compatible? **Yes** — validation behavior unchanged (only zod's default error *wording* differs, e.g. "Required" → "Invalid input: expected number, received undefined").
- Config/env changes? **No**
- Database migration needed? **No**
- Upgrade steps: a fresh `bun install` picks up the new lockfile; no manual action.

## Human Verification (required)

- **Verified scenarios:**
  - `bun run validate` green end-to-end.
  - The originally-failing `sessions.test.ts › throws ZodError` now passes.
  - `bun why zod` confirms a single `zod@4.4.3` for all `@archon/*` packages.
  - OpenAPI spec generates (new `/api/openapi.json` test) — the highest-risk part of the `@hono/zod-openapi` v0→v1 bump.
- **Edge cases checked:** `z.record` key validation, `z.string().datetime()` (still works in v4), `.strict()` objects, the `agents` kebab-case key error path.
- **What was NOT verified:** end-to-end runtime against a live LLM/Postgres (CI mocks providers; SQLite locally); the nested third-party zod copies were intentionally left untouched.

## Side Effects / Blast Radius (required)

- **Affected subsystems:** every Zod schema in core/workflows/server (parsed at load/runtime) and OpenAPI spec generation. The change is broad but mechanical.
- **Potential unintended effects:** zod v4 default error-message wording differs from v3 — any code/test asserting exact v3 message text would need updating (the two such tests in this repo are fixed here). User-facing validation messages are now v4's phrasing.
- **Guardrails:** full `validate` green; new OpenAPI generation test; type-check across all 10 packages catches schema-shape regressions.

## Rollback Plan (required)

- **Fast rollback:** revert the merge commit (`git revert <sha>`) — restores `zod@3` + `@hono/zod-openapi@0.19` and the source shims. Then `bun install`.
- **Feature flags / toggles:** none.
- **Observable failure symptoms:** type errors referencing `zod/v4`, `bun run validate` failing on schema parsing, or OpenAPI spec generation throwing.

## Risks and Mitigations

- **Risk:** zod v3→v4 is a major version with semantic changes beyond what type-check catches.
  - **Mitigation:** full test suite green (incl. schema-heavy workflows/core/server tests) + new OpenAPI generation test; no validation behavior changed by design.
- **Risk:** `@hono/zod-openapi` v0→v1 could alter OpenAPI output / `.openapi()` registration.
  - **Mitigation:** added a `/api/openapi.json` regression test asserting a valid 3.x doc across all registered routes (including record/datetime schemas and the node-sessions route).
- **Risk:** v4's less-friendly default error wording reaches users.
  - **Mitigation:** documented as a known cosmetic change; field paths remain in messages. Custom messages preserved where they mattered (e.g. `agents` kebab-case).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenAPI specification validation testing to ensure accurate API documentation.

* **Chores**
  * Upgraded Zod to v4.4.3 and `@hono/zod-openapi` to v1.4.0 across packages.
  * Standardized record/key validation across schemas to enforce string-keyed records and tighter validation.
  * Updated tests to align with Zod v4 error messages.

* **Documentation**
  * Clarified schema conventions documentation to reflect Zod v4 record usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1813?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->