### PR TITLE
feat(telemetry): expand anonymous PostHog capture (started/completed events, machine context, custom-vs-default)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -261,10 +261,13 @@ MAX_CONCURRENT_CONVERSATIONS=10  # Maximum concurrent AI conversations (default:
 # SESSION_RETENTION_DAYS=30  # Delete inactive sessions older than N days (default: 30)
 
 # Anonymous Telemetry (optional)
-# Archon sends anonymous workflow-invocation events to PostHog so maintainers
-# can see which workflows get real usage. No PII — workflow name + platform +
-# Archon version + a random install UUID. No identities, no prompts, no paths,
-# no descriptions, no code, no IP. See README "Telemetry" for the full list.
+# Archon sends a few anonymous events to PostHog (archon_started, workflow_invoked,
+# workflow_completed/failed) so maintainers can see active installs, which workflows
+# get real usage, and whether runs succeed. No PII — categorical only: workflow name
+# (real for bundled, "custom" for your own), platform, provider/model, node shape,
+# run outcome/duration, OS/arch/version, and a random install UUID. No identities,
+# no prompts, no paths, no descriptions, no code, no IP, no geo, no error text.
+# See README "Telemetry" for the full list.
 #
 # Opt out (any one disables telemetry):
 #   ARCHON_TELEMETRY_DISABLED=1

--- a/README.md
+++ b/README.md
@@ -317,11 +317,15 @@ Full documentation is available at **[archon.diy](https://archon.diy)**.
 
 ## Telemetry
 
-Archon sends a single anonymous event — `workflow_invoked` — each time a workflow starts, so maintainers can see which workflows get real usage and prioritize accordingly. **No PII, ever.**
+Archon sends a few anonymous events so maintainers can see which workflows get real usage, on what platforms, and whether runs succeed — and prioritize accordingly. **No PII, ever.** Events: `archon_started` (once per CLI invocation / server boot), `workflow_invoked` (each workflow start), and `workflow_completed` / `workflow_failed` (each run outcome).
 
-**What's collected:** the workflow name, the platform that triggered it (`cli`, `web`, `slack`, etc.), the Archon version, and a random install UUID stored at `~/.archon/telemetry-id`. Nothing else.
+**What's collected (categorical only):**
+- **Workflow name** — the real name for *bundled* (Archon-authored) workflows; `"custom"` for your own workflows, so private names never leave your machine.
+- **Run shape & outcome** — platform (`cli`/`web`/`slack`/…), provider/model id, node count, which node types are used, success/failure, duration, and a categorical failure reason (never raw error text).
+- **Machine context** — OS, architecture, Archon version, runtime, whether it's a binary build, and a CI flag.
+- A random install UUID stored at `~/.archon/telemetry-id`. Nothing else.
 
-**What's *not* collected:** your code, prompts, messages, workflow descriptions, git remotes, file paths, usernames, tokens, AI output, workflow node details, your IP address — none of it.
+**What's *not* collected:** your code, prompts, messages, custom workflow names, workflow descriptions, git remotes, file paths, usernames, tokens, AI output, error message text, your IP address, your geographic location — none of it.
 
 **Opt out:** set any of these in your environment:
 

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Archon sends a few anonymous events so maintainers can see which workflows get r
 
 **What's collected (categorical only):**
 - **Workflow name** — the real name for *bundled* (Archon-authored) workflows; `"custom"` for your own workflows, so private names never leave your machine.
-- **Run shape & outcome** — platform (`cli`/`web`/`slack`/…), provider/model id, node count, which node types are used, success/failure, duration, and a categorical failure reason (never raw error text).
+- **Run shape & outcome** — platform (`cli`/`web`/`slack`/…), provider id (plus the model id on `workflow_invoked`), node count, which node types are used, success/failure, duration, and a categorical failure reason (never raw error text).
 - **Machine context** — OS, architecture, Archon version, runtime, whether it's a binary build, and a CI flag.
 - A random install UUID stored at `~/.archon/telemetry-id`. Nothing else.
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -78,6 +78,7 @@ import {
   BUNDLED_IS_BINARY,
   BUNDLED_VERSION,
   shutdownTelemetry,
+  captureArchonStarted,
   isVerboseBoot,
 } from '@archon/paths';
 import * as git from '@archon/git';
@@ -306,6 +307,10 @@ async function main(): Promise<number> {
     } else if (values.verbose) {
       setLogLevel('debug');
     }
+
+    // Anonymous once-per-invocation startup event (self-gates on opt-out).
+    // Flushed by the shutdownTelemetry() call in main()'s finally block.
+    captureArchonStarted({ surface: 'cli' });
 
     // Note: orphaned run cleanup moved to `workflow cleanup` command only.
     // Running it on every CLI startup killed parallel workflow runs (all

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -202,9 +202,17 @@ function isVersionRequest(args: string[]): boolean {
 async function main(): Promise<number> {
   const args = process.argv.slice(2);
 
+  // Anonymous once-per-invocation startup event (self-gates on opt-out).
+  // Emitted before any early return so EVERY invocation — including bare
+  // `archon`, `--help`, and `--version` — is counted, matching the
+  // "once per CLI invocation" contract. Each early-return path below flushes
+  // via shutdownTelemetry(); the main command path flushes in its finally.
+  captureArchonStarted({ surface: 'cli' });
+
   // Handle no arguments - show help and exit successfully
   if (args.length === 0) {
     printUsage();
+    await shutdownTelemetry();
     return 0;
   }
 
@@ -260,6 +268,7 @@ async function main(): Promise<number> {
     const err = error as Error;
     console.error(`Error parsing arguments: ${err.message}`);
     printUsage();
+    await shutdownTelemetry();
     return 1;
   }
 
@@ -276,6 +285,7 @@ async function main(): Promise<number> {
   // Handle help flag
   if (values.help) {
     printUsage();
+    await shutdownTelemetry();
     return 0;
   }
 
@@ -307,10 +317,6 @@ async function main(): Promise<number> {
     } else if (values.verbose) {
       setLogLevel('debug');
     }
-
-    // Anonymous once-per-invocation startup event (self-gates on opt-out).
-    // Flushed by the shutdownTelemetry() call in main()'s finally block.
-    captureArchonStarted({ surface: 'cli' });
 
     // Note: orphaned run cleanup moved to `workflow cleanup` command only.
     // Running it on every CLI startup killed parallel workflow runs (all

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -295,6 +295,11 @@ export async function workflowRunCommand(
   const workflows = workflowEntries.map(ws => ws.workflow);
 
   const workflow = resolveWorkflowName(workflowName, workflows);
+  // Recover the discovery source (dropped by the .map above) for telemetry —
+  // bundled workflows report their real name, custom ones report "custom".
+  const workflowSource = workflow
+    ? workflowEntries.find(ws => ws.workflow === workflow)?.source
+    : undefined;
 
   if (!workflow) {
     // Check if the requested workflow had a load error
@@ -786,8 +791,8 @@ export async function workflowRunCommand(
   let result: Awaited<ReturnType<typeof executeWorkflow>>;
   try {
     const opts = prepared
-      ? { codebaseId: codebase?.id, ...prepared }
-      : { codebaseId: codebase?.id };
+      ? { codebaseId: codebase?.id, source: workflowSource, ...prepared }
+      : { codebaseId: codebase?.id, source: workflowSource };
     result = await executeWorkflow(
       deps,
       adapter,

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -36,6 +36,7 @@ import type {
   WorkflowDefinition,
   WorkflowWithSource,
   WorkflowLoadError,
+  WorkflowSource,
 } from '@archon/workflows/schemas/workflow';
 import { createWorkflowDeps } from '../workflows/store-adapter';
 import { loadConfig } from '../config/config-loader';
@@ -316,7 +317,13 @@ async function dispatchOrchestratorWorkflow(
   workflow: WorkflowDefinition,
   userMessage: string,
   isolationHints?: HandleMessageContext['isolationHints'],
-  userId?: string
+  userId?: string,
+  /**
+   * Discovery source of the workflow — telemetry only (bundled workflows
+   * report their real name, custom ones report "custom"). Optional: callers
+   * that don't have it readily in scope omit it and the run reports "custom".
+   */
+  source?: WorkflowSource
 ): Promise<void> {
   // Auto-attach project to conversation
   await db.updateConversation(conversation.id, {
@@ -403,6 +410,7 @@ async function dispatchOrchestratorWorkflow(
           codebaseId: codebase.id,
           parentConversationId: conversation.id,
           userId,
+          source,
           ...prepared,
         }
       );
@@ -423,6 +431,7 @@ async function dispatchOrchestratorWorkflow(
           codebaseId: codebase.id,
           parentConversationId: conversation.id,
           userId,
+          source,
         }
       );
     }
@@ -439,6 +448,7 @@ async function dispatchOrchestratorWorkflow(
         availableWorkflows: [workflow],
         isolationHints,
         userId,
+        source,
       },
       workflow
     );
@@ -456,6 +466,7 @@ async function dispatchOrchestratorWorkflow(
         codebaseId: codebase.id,
         parentConversationId: conversation.id,
         userId,
+        source,
       }
     );
   }
@@ -746,6 +757,9 @@ export async function handleMessage(
           const { workflows: discoveredWorkflows } = await discoverAllWorkflows(conversation);
           const allWorkflows: WorkflowDefinition[] = discoveredWorkflows.map(w => w.workflow);
           const workflow = findWorkflow(pausedRun.workflow_name, allWorkflows);
+          const workflowSource = workflow
+            ? discoveredWorkflows.find(w => w.workflow === workflow)?.source
+            : undefined;
           if (!workflow) {
             await platform.sendMessage(
               conversationId,
@@ -774,7 +788,8 @@ export async function handleMessage(
             workflow,
             pausedRun.user_message,
             isolationHints,
-            userId
+            userId,
+            workflowSource
           );
           getLog().info(
             { conversationId, workflowRunId: pausedRun.id, workflowName: pausedRun.workflow_name },
@@ -1783,7 +1798,8 @@ async function handleWorkflowRunCommand(
       resolvedWorkflow,
       userMessage,
       isolationHints,
-      userId
+      userId,
+      resolvedEntry?.source
     );
     return;
   }

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -49,7 +49,7 @@ import { createIsolationStore } from '../db/isolation-environments';
 import { toError } from '../utils/error';
 import { getCodebase } from '../db/codebases';
 import { executeWorkflow } from '@archon/workflows/executor';
-import type { WorkflowDefinition } from '@archon/workflows/schemas/workflow';
+import type { WorkflowDefinition, WorkflowSource } from '@archon/workflows/schemas/workflow';
 import { createWorkflowDeps } from '../workflows/store-adapter';
 import {
   cleanupToMakeRoom,
@@ -255,6 +255,12 @@ export interface WorkflowRoutingContext {
    * worker isolation environment, and downstream workflow_run row.
    */
   readonly userId?: string;
+  /**
+   * Discovery source of the workflow — telemetry only (bundled workflows
+   * report their real name, custom ones report "custom"). Optional; defaults
+   * to the privacy-safe "custom" treatment when not provided.
+   */
+  readonly source?: WorkflowSource;
 }
 
 /**
@@ -396,6 +402,7 @@ export async function dispatchBackgroundWorkflow(
             parentConversationId: ctx.conversationDbId,
             preCreatedRun,
             userId: ctx.userId,
+            source: ctx.source,
           }
         );
         // Surface workflow output to parent conversation as a result card

--- a/packages/docs-web/src/content/docs/reference/configuration.md
+++ b/packages/docs-web/src/content/docs/reference/configuration.md
@@ -347,7 +347,7 @@ The Copilot provider also reads `assistants.copilot.{model, modelReasoningEffort
 
 ### Telemetry
 
-Archon sends a few anonymous events — `archon_started` (once per process), `workflow_invoked` (workflow start), and `workflow_completed`/`workflow_failed` (run outcome). Categorical only: workflow name (real for bundled workflows, `"custom"` for your own), platform, provider/model, node shape, outcome/duration, OS/arch/version, and a random install UUID. No code, prompts, paths, IP, geo, or error text. Any one of the variables below disables it. See `archon telemetry status` to inspect the live state.
+Archon sends a few anonymous events — `archon_started` (once per process), `workflow_invoked` (workflow start), and `workflow_completed`/`workflow_failed` (run outcome). Categorical only: workflow name (real for bundled workflows, `"custom"` for your own), platform, provider id (model id on `workflow_invoked`), node shape, outcome/duration, OS/arch/version, and a random install UUID. No code, prompts, paths, IP, geo, or error text. Any one of the variables below disables it. See `archon telemetry status` to inspect the live state.
 
 | Variable | Description | Default |
 | --- | --- | --- |

--- a/packages/docs-web/src/content/docs/reference/configuration.md
+++ b/packages/docs-web/src/content/docs/reference/configuration.md
@@ -347,7 +347,7 @@ The Copilot provider also reads `assistants.copilot.{model, modelReasoningEffort
 
 ### Telemetry
 
-Archon sends a single anonymous `workflow_invoked` event per workflow start (workflow name, platform, version, random install UUID). Any one of these disables it. See `archon telemetry status` to inspect the live state.
+Archon sends a few anonymous events — `archon_started` (once per process), `workflow_invoked` (workflow start), and `workflow_completed`/`workflow_failed` (run outcome). Categorical only: workflow name (real for bundled workflows, `"custom"` for your own), platform, provider/model, node shape, outcome/duration, OS/arch/version, and a random install UUID. No code, prompts, paths, IP, geo, or error text. Any one of the variables below disables it. See `archon telemetry status` to inspect the live state.
 
 | Variable | Description | Default |
 | --- | --- | --- |

--- a/packages/docs-web/src/content/docs/reference/security.md
+++ b/packages/docs-web/src/content/docs/reference/security.md
@@ -72,6 +72,12 @@ Archon uses structured logging (Pino) with explicit rules about what is and is n
 - Set `LOG_LEVEL=debug` for detailed execution traces
 - CLI: `--quiet` (errors only) or `--verbose` (debug)
 
+## Anonymous Telemetry
+
+Separate from local logging, Archon sends a small set of **anonymous** usage events to PostHog (`archon_started`, `workflow_invoked`, `workflow_completed`/`workflow_failed`) so maintainers can see active installs, which workflows run, and run outcomes. Events are keyed by a random install UUID — never user identity.
+
+Only categorical data is sent: bundled workflow name (user-authored workflows report `"custom"`), platform, provider/model id, node shape, run outcome/duration, and machine context (OS, arch, version, runtime). **Never sent:** code, prompts, file paths, IP (dropped at ingest), geolocation, error text, or custom workflow names. See the [Telemetry table in the configuration reference](/reference/configuration/) for the full field list and opt-out options (`DO_NOT_TRACK=1`, `ARCHON_TELEMETRY_DISABLED=1`, CI auto-disable, or `POSTHOG_API_KEY=off`).
+
 ## Adapter Authorization
 
 Each platform adapter supports an optional user whitelist via environment variables. When a whitelist is configured, only listed users can interact with the bot. When the whitelist is empty or unset, the adapter operates in open access mode.

--- a/packages/paths/src/index.ts
+++ b/packages/paths/src/index.ts
@@ -70,6 +70,7 @@ export type {
   WorkflowInvokedProperties,
   ArchonStartedProperties,
   WorkflowCompletedProperties,
+  WorkflowExitReason,
   WorkflowTelemetrySource,
   TelemetryStatus,
   TelemetryDisabledReason,

--- a/packages/paths/src/index.ts
+++ b/packages/paths/src/index.ts
@@ -57,6 +57,10 @@ export type { UpdateCheckResult } from './update-check';
 // Anonymous telemetry
 export {
   captureWorkflowInvoked,
+  captureArchonStarted,
+  captureWorkflowCompleted,
+  classifyWorkflowForTelemetry,
+  TELEMETRY_SCHEMA_VERSION,
   shutdownTelemetry,
   isTelemetryDisabled,
   getTelemetryStatus,
@@ -64,6 +68,9 @@ export {
 } from './telemetry';
 export type {
   WorkflowInvokedProperties,
+  ArchonStartedProperties,
+  WorkflowCompletedProperties,
+  WorkflowTelemetrySource,
   TelemetryStatus,
   TelemetryDisabledReason,
 } from './telemetry';

--- a/packages/paths/src/telemetry.test.ts
+++ b/packages/paths/src/telemetry.test.ts
@@ -6,6 +6,9 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import {
   isTelemetryDisabled,
   captureWorkflowInvoked,
+  captureArchonStarted,
+  captureWorkflowCompleted,
+  classifyWorkflowForTelemetry,
   shutdownTelemetry,
   resetTelemetryForTests,
   getOrCreateTelemetryId,
@@ -250,7 +253,7 @@ describe('first-run notice (via captureWorkflowInvoked)', () => {
   let saved: Record<string, string | undefined>;
   let tmpHome: string;
   let originalIsTTY: boolean | undefined;
-  const stampPath = (): string => join(tmpHome, 'telemetry-notice-shown');
+  const stampPath = (): string => join(tmpHome, 'telemetry-notice-shown-v2');
 
   beforeEach(() => {
     saved = saveEnv();
@@ -393,5 +396,91 @@ describe('telemetry ID persistence', () => {
     expect(resolved).toBe(existingId);
     const stored = readFileSync(join(tmpHome, 'telemetry-id'), 'utf8').trim();
     expect(stored).toBe(existingId);
+  });
+});
+
+describe('classifyWorkflowForTelemetry', () => {
+  test('bundled workflows report their real name and is_builtin true', () => {
+    expect(classifyWorkflowForTelemetry('implement', 'bundled')).toEqual({
+      is_builtin: true,
+      workflow_name: 'implement',
+      workflow_source: 'bundled',
+    });
+  });
+
+  test('project workflows are redacted to "custom" and report their source', () => {
+    expect(classifyWorkflowForTelemetry('deploy-acme-prod', 'project')).toEqual({
+      is_builtin: false,
+      workflow_name: 'custom',
+      workflow_source: 'project',
+    });
+  });
+
+  test('global workflows are also redacted to "custom"', () => {
+    expect(classifyWorkflowForTelemetry('my-global', 'global')).toEqual({
+      is_builtin: false,
+      workflow_name: 'custom',
+      workflow_source: 'global',
+    });
+  });
+
+  test('undefined source defaults to the privacy-safe custom/project treatment', () => {
+    expect(classifyWorkflowForTelemetry('anything', undefined)).toEqual({
+      is_builtin: false,
+      workflow_name: 'custom',
+      workflow_source: 'project',
+    });
+  });
+});
+
+describe('new capture functions are fire-and-forget no-throw', () => {
+  let saved: Record<string, string | undefined>;
+  let tmpHome: string;
+
+  beforeEach(() => {
+    saved = saveEnv();
+    tmpHome = mkdtempSync(join(tmpdir(), 'archon-telemetry-capture-'));
+    process.env.ARCHON_HOME = tmpHome;
+    resetTelemetryForTests();
+  });
+
+  afterEach(() => {
+    restoreEnv(saved);
+    resetTelemetryForTests();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  test('captureArchonStarted does not throw (disabled)', () => {
+    process.env.ARCHON_TELEMETRY_DISABLED = '1';
+    expect(() => captureArchonStarted({ surface: 'cli' })).not.toThrow();
+  });
+
+  test('captureArchonStarted does not throw (enabled)', () => {
+    delete process.env.ARCHON_TELEMETRY_DISABLED;
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.CI;
+    delete process.env.POSTHOG_API_KEY;
+    expect(() => captureArchonStarted({ surface: 'server' })).not.toThrow();
+  });
+
+  test('captureWorkflowCompleted does not throw for completed/failed/cancelled', () => {
+    process.env.ARCHON_TELEMETRY_DISABLED = '1';
+    expect(() =>
+      captureWorkflowCompleted({
+        outcome: 'completed',
+        workflowName: 'implement',
+        workflowSource: 'bundled',
+        durationMs: 1234,
+        nodesCompleted: 3,
+        nodesTotal: 3,
+      })
+    ).not.toThrow();
+    expect(() =>
+      captureWorkflowCompleted({
+        outcome: 'failed',
+        workflowName: 'x',
+        exitReason: 'node_error',
+      })
+    ).not.toThrow();
   });
 });

--- a/packages/paths/src/telemetry.test.ts
+++ b/packages/paths/src/telemetry.test.ts
@@ -9,6 +9,7 @@ import {
   captureArchonStarted,
   captureWorkflowCompleted,
   classifyWorkflowForTelemetry,
+  sanitizeModelForTelemetry,
   shutdownTelemetry,
   resetTelemetryForTests,
   getOrCreateTelemetryId,
@@ -348,7 +349,6 @@ describe('captureWorkflowInvoked when disabled', () => {
       captureWorkflowInvoked({
         workflowName: 'test-workflow',
         platform: 'cli',
-        archonVersion: 'dev',
       });
     }).not.toThrow();
   });
@@ -463,7 +463,7 @@ describe('new capture functions are fire-and-forget no-throw', () => {
     expect(() => captureArchonStarted({ surface: 'server' })).not.toThrow();
   });
 
-  test('captureWorkflowCompleted does not throw for completed/failed/cancelled', () => {
+  test('captureWorkflowCompleted does not throw for completed/failed (disabled)', () => {
     process.env.ARCHON_TELEMETRY_DISABLED = '1';
     expect(() =>
       captureWorkflowCompleted({
@@ -482,5 +482,46 @@ describe('new capture functions are fire-and-forget no-throw', () => {
         exitReason: 'node_error',
       })
     ).not.toThrow();
+  });
+
+  test('captureWorkflowCompleted does not throw (enabled)', () => {
+    delete process.env.ARCHON_TELEMETRY_DISABLED;
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.CI;
+    delete process.env.POSTHOG_API_KEY;
+    expect(() =>
+      captureWorkflowCompleted({
+        outcome: 'failed',
+        workflowName: 'implement',
+        workflowSource: 'bundled',
+        exitReason: 'unhandled_error',
+      })
+    ).not.toThrow();
+  });
+});
+
+describe('sanitizeModelForTelemetry', () => {
+  test('forwards real model refs verbatim', () => {
+    for (const model of [
+      'sonnet',
+      'opus',
+      'claude-sonnet-4-6',
+      'gpt-5.3-codex',
+      'anthropic/claude-haiku-4-5',
+      'openrouter/qwen/qwen3-coder',
+    ]) {
+      expect(sanitizeModelForTelemetry(model)).toBe(model);
+    }
+  });
+
+  test('drops free-text / non-categorical values so they cannot leak', () => {
+    expect(sanitizeModelForTelemetry('claude for the acme prod deploy')).toBeUndefined();
+    expect(sanitizeModelForTelemetry('john.doe@example.com is testing')).toBeUndefined();
+    expect(sanitizeModelForTelemetry('x'.repeat(100))).toBeUndefined();
+    expect(sanitizeModelForTelemetry('')).toBeUndefined();
+  });
+
+  test('passes through undefined', () => {
+    expect(sanitizeModelForTelemetry(undefined)).toBeUndefined();
   });
 });

--- a/packages/paths/src/telemetry.test.ts
+++ b/packages/paths/src/telemetry.test.ts
@@ -455,12 +455,22 @@ describe('new capture functions are fire-and-forget no-throw', () => {
     expect(() => captureArchonStarted({ surface: 'cli' })).not.toThrow();
   });
 
-  test('captureArchonStarted does not throw (enabled)', () => {
+  test('captureArchonStarted does not throw (enabled)', async () => {
     delete process.env.ARCHON_TELEMETRY_DISABLED;
     delete process.env.DO_NOT_TRACK;
     delete process.env.CI;
     delete process.env.POSTHOG_API_KEY;
-    expect(() => captureArchonStarted({ surface: 'server' })).not.toThrow();
+    // Stub the transport so the enabled path never touches the network, then
+    // flush deterministically before restoring (no flaky timers / real ingest).
+    const fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('{"status":"ok"}', { status: 200 })
+    );
+    try {
+      expect(() => captureArchonStarted({ surface: 'server' })).not.toThrow();
+      await shutdownTelemetry();
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   test('captureWorkflowCompleted does not throw for completed/failed (disabled)', () => {
@@ -484,19 +494,27 @@ describe('new capture functions are fire-and-forget no-throw', () => {
     ).not.toThrow();
   });
 
-  test('captureWorkflowCompleted does not throw (enabled)', () => {
+  test('captureWorkflowCompleted does not throw (enabled)', async () => {
     delete process.env.ARCHON_TELEMETRY_DISABLED;
     delete process.env.DO_NOT_TRACK;
     delete process.env.CI;
     delete process.env.POSTHOG_API_KEY;
-    expect(() =>
-      captureWorkflowCompleted({
-        outcome: 'failed',
-        workflowName: 'implement',
-        workflowSource: 'bundled',
-        exitReason: 'unhandled_error',
-      })
-    ).not.toThrow();
+    const fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('{"status":"ok"}', { status: 200 })
+    );
+    try {
+      expect(() =>
+        captureWorkflowCompleted({
+          outcome: 'failed',
+          workflowName: 'implement',
+          workflowSource: 'bundled',
+          exitReason: 'unhandled_error',
+        })
+      ).not.toThrow();
+      await shutdownTelemetry();
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/paths/src/telemetry.ts
+++ b/packages/paths/src/telemetry.ts
@@ -1,11 +1,21 @@
 /**
  * Anonymous PostHog telemetry for Archon.
  *
- * Emits one event — `workflow_invoked` — each time a workflow starts. No PII,
- * no user identity. A random UUID is persisted to `${ARCHON_HOME}/telemetry-id`
- * so we can count distinct installs; `$process_person_profile: false` keeps
- * events in PostHog's anonymous tier (no person profile ever created); `$ip: ''`
- * prevents PostHog from retaining the source IP at ingest.
+ * Emits a small set of anonymous events — `archon_started` (once per process),
+ * `workflow_invoked` (each workflow start), and `workflow_completed` /
+ * `workflow_failed` (each terminal run) — so maintainers can see active
+ * installs, which workflows run, and run outcomes. No PII, no user identity.
+ * A random UUID is persisted to `${ARCHON_HOME}/telemetry-id` so we can count
+ * distinct installs.
+ *
+ * Every event carries the privacy invariants `$process_person_profile: false`
+ * (anonymous tier — no person profile ever created) and `$ip: ''` (PostHog
+ * drops the source IP at ingest). Machine context (os, arch, version,
+ * is_binary, runtime, is_ci, is_tty) rides along on every event via PostHog
+ * super-properties. What is collected is categorical only: workflow name (real
+ * for bundled workflows, `"custom"` for user-authored), platform, provider,
+ * model, node shape, and run outcome/duration. Never sent: code, prompts, file
+ * paths, IP, geo, error text, or custom workflow names/descriptions.
  *
  * Opt-out (any one disables telemetry):
  *   - ARCHON_TELEMETRY_DISABLED=1
@@ -23,7 +33,11 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import type { PostHog } from 'posthog-node';
 import { getArchonHome } from './archon-paths';
+import { BUNDLED_IS_BINARY, BUNDLED_VERSION } from './bundled-build';
 import { createLogger } from './logger';
+
+/** Bumped when the captured property set changes (documented in README). */
+export const TELEMETRY_SCHEMA_VERSION = 2;
 
 // Minimal shape of posthog-node's `fetch` option — copied from @posthog/core
 // (a transitive dep) to avoid pulling it in as a direct dependency.
@@ -55,7 +69,10 @@ const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com';
  * Filename for the one-time notice stamp written to ARCHON_HOME. Presence
  * means the first-run notice has been shown; absence means it hasn't.
  */
-const NOTICE_STAMP_FILENAME = 'telemetry-notice-shown';
+// Bumped to `-v2` when the captured property set expanded (machine context +
+// run outcomes). Bumping re-shows the updated first-run notice once per install
+// so existing users re-consent rather than silently getting broader capture.
+const NOTICE_STAMP_FILENAME = 'telemetry-notice-shown-v2';
 
 let cachedLog: ReturnType<typeof createLogger> | undefined;
 function getLog(): ReturnType<typeof createLogger> {
@@ -83,6 +100,63 @@ function getApiKey(): string | null {
 
 function getHost(): string {
   return process.env.POSTHOG_HOST ?? DEFAULT_POSTHOG_HOST;
+}
+
+/**
+ * Privacy invariants attached to EVERY telemetry event. Kept per-event (not
+ * relying solely on super-properties) so each capture site is visibly correct
+ * and a super-property regression can never silently leak the source IP or
+ * create a person profile.
+ */
+const PRIVACY_INVARIANTS = {
+  $process_person_profile: false,
+  // Strip source IP at ingest. `disableGeoip: true` only prevents geo
+  // enrichment; `$ip: ''` drops the IP from the event entirely.
+  $ip: '',
+} as const;
+
+/**
+ * Stable machine/runtime context registered once as PostHog super-properties
+ * (attached to every event from this client). Categorical only — no
+ * identifiers, no paths. `install_method` is intentionally omitted until a
+ * build-time channel constant exists (never derive it from a filesystem path).
+ */
+function collectMachineProperties(): Record<string, string | boolean> {
+  const bunVersion = typeof Bun !== 'undefined' ? Bun.version : undefined;
+  return {
+    os: process.platform,
+    arch: process.arch,
+    archon_version: BUNDLED_VERSION,
+    is_binary: BUNDLED_IS_BINARY,
+    runtime_version: bunVersion ? `bun-${bunVersion}` : process.version,
+    // Mirrors the CI auto-disable check; when telemetry is enabled this is
+    // effectively always false, but it's cheap and future-proof.
+    is_ci: process.env.CI?.toLowerCase() === 'true',
+    is_tty: process.stderr.isTTY,
+  };
+}
+
+/** Discovery source of a workflow, mirrored from `@archon/workflows` as a
+ * plain string union so `@archon/paths` keeps zero `@archon/*` dependencies. */
+export type WorkflowTelemetrySource = 'bundled' | 'global' | 'project';
+
+/**
+ * Apply the workflow-name privacy rule: bundled (Archon-authored) workflows
+ * report their real name so maintainers can see which defaults are popular;
+ * user-authored (global/project) workflows report `"custom"` so private names
+ * (e.g. "deploy-acme-prod") never leave the machine. `workflow_source` is
+ * always reported for the custom-vs-default split.
+ */
+export function classifyWorkflowForTelemetry(
+  name: string,
+  source: WorkflowTelemetrySource | undefined
+): { workflow_name: string; is_builtin: boolean; workflow_source: string } {
+  const isBuiltin = source === 'bundled';
+  return {
+    is_builtin: isBuiltin,
+    workflow_name: isBuiltin ? name : 'custom',
+    workflow_source: source ?? 'project',
+  };
 }
 
 /** Why telemetry is currently disabled. `null` means it's enabled. */
@@ -280,8 +354,9 @@ function maybeShowFirstRunNotice(): void {
   }
 
   const message =
-    'Archon collects anonymous usage telemetry (workflow name, platform, version).\n' +
-    'No code, prompts, file paths, or personal data — see README "Telemetry" for details.\n' +
+    'Archon collects anonymous usage telemetry — now also OS/arch and run\n' +
+    'outcome (success/failure), alongside workflow name, platform, and version.\n' +
+    'Still no code, prompts, file paths, IP, or personal data — see README "Telemetry".\n' +
     'Opt out anytime: DO_NOT_TRACK=1 or ARCHON_TELEMETRY_DISABLED=1\n';
   try {
     process.stderr.write(`\n${message}\n`);
@@ -386,6 +461,14 @@ async function initClient(): Promise<PostHog | null> {
     client.on('error', (err: Error) => {
       getLog().debug({ err }, 'telemetry.client_error');
     });
+    // Attach machine context to every event as super-properties. The privacy
+    // invariants are NOT registered here — they stay per-event (see
+    // PRIVACY_INVARIANTS) so a register() regression can't silently drop them.
+    try {
+      await client.register(collectMachineProperties());
+    } catch (error) {
+      getLog().debug({ err: error as Error }, 'telemetry.register_failed');
+    }
     return client;
   } catch (error) {
     getLog().debug({ err: error as Error }, 'telemetry.init_failed');
@@ -395,8 +478,39 @@ async function initClient(): Promise<PostHog | null> {
 
 export interface WorkflowInvokedProperties {
   workflowName: string;
+  /** Discovery source — drives the custom-vs-default split and name redaction. */
+  workflowSource?: WorkflowTelemetrySource;
   platform?: string;
-  archonVersion?: string;
+  provider?: string;
+  model?: string;
+  nodeCount?: number;
+  usesLoop?: boolean;
+  usesApproval?: boolean;
+  usesScript?: boolean;
+  usesBash?: boolean;
+  interactive?: boolean;
+  usedIsolation?: boolean;
+  isResume?: boolean;
+}
+
+/** Once-per-process startup event — the basis for active-install counting. */
+export interface ArchonStartedProperties {
+  surface: 'cli' | 'server';
+}
+
+/** Terminal workflow-run event (`workflow_completed` / `workflow_failed`). */
+export interface WorkflowCompletedProperties {
+  outcome: 'completed' | 'failed' | 'cancelled';
+  workflowName: string;
+  workflowSource?: WorkflowTelemetrySource;
+  provider?: string;
+  durationMs?: number;
+  nodesCompleted?: number;
+  nodesFailed?: number;
+  nodesSkipped?: number;
+  nodesTotal?: number;
+  /** Categorical reason enum — never raw error text. */
+  exitReason?: string;
 }
 
 /**
@@ -415,18 +529,89 @@ export function captureWorkflowInvoked(props: WorkflowInvokedProperties): void {
         distinctId: getTelemetryId(),
         event: 'workflow_invoked',
         properties: {
-          $process_person_profile: false,
-          // Strip source IP at ingest. `disableGeoip: true` only prevents geo
-          // enrichment; `$ip: ''` drops the IP from the event entirely.
-          $ip: '',
-          workflow_name: props.workflowName,
+          ...PRIVACY_INVARIANTS,
+          ...classifyWorkflowForTelemetry(props.workflowName, props.workflowSource),
+          schema_version: TELEMETRY_SCHEMA_VERSION,
           ...(props.platform ? { platform: props.platform } : {}),
-          ...(props.archonVersion ? { archon_version: props.archonVersion } : {}),
+          ...(props.provider ? { provider: props.provider } : {}),
+          ...(props.model ? { model: props.model } : {}),
+          ...(props.nodeCount !== undefined ? { node_count: props.nodeCount } : {}),
+          uses_loop: Boolean(props.usesLoop),
+          uses_approval: Boolean(props.usesApproval),
+          uses_script: Boolean(props.usesScript),
+          uses_bash: Boolean(props.usesBash),
+          interactive: Boolean(props.interactive),
+          used_isolation: Boolean(props.usedIsolation),
+          is_resume: Boolean(props.isResume),
         },
       });
     } catch (error) {
       // Fire-and-forget: telemetry must never crash Archon, so swallow every
       // error here (network, SDK, malformed props) and record it at debug.
+      getLog().debug({ err: error as Error }, 'telemetry.capture_failed');
+    }
+  })();
+}
+
+/**
+ * Fire-and-forget capture of an `archon_started` event — emitted once per CLI
+ * invocation and per server boot. This (not just `workflow_invoked`) is what
+ * makes active-install / DAU metrics honest, since users who only run
+ * `doctor`/`serve`/chat would otherwise be invisible. Machine context rides
+ * along via the registered super-properties. Also shows the first-run notice.
+ */
+export function captureArchonStarted(props: ArchonStartedProperties): void {
+  if (isTelemetryDisabled()) return;
+  maybeShowFirstRunNotice();
+  void (async (): Promise<void> => {
+    try {
+      const client = await getClient();
+      if (!client) return;
+      client.capture({
+        distinctId: getTelemetryId(),
+        event: 'archon_started',
+        properties: {
+          ...PRIVACY_INVARIANTS,
+          surface: props.surface,
+          schema_version: TELEMETRY_SCHEMA_VERSION,
+        },
+      });
+    } catch (error) {
+      getLog().debug({ err: error as Error }, 'telemetry.capture_failed');
+    }
+  })();
+}
+
+/**
+ * Fire-and-forget capture of a terminal workflow run. Emits `workflow_completed`
+ * when `outcome === 'completed'`, otherwise `workflow_failed`. Carries run
+ * outcome, duration, node counts, and a categorical exit reason so maintainers
+ * can measure success rates and funnels — not just intent.
+ */
+export function captureWorkflowCompleted(props: WorkflowCompletedProperties): void {
+  if (isTelemetryDisabled()) return;
+  void (async (): Promise<void> => {
+    try {
+      const client = await getClient();
+      if (!client) return;
+      client.capture({
+        distinctId: getTelemetryId(),
+        event: props.outcome === 'completed' ? 'workflow_completed' : 'workflow_failed',
+        properties: {
+          ...PRIVACY_INVARIANTS,
+          ...classifyWorkflowForTelemetry(props.workflowName, props.workflowSource),
+          outcome: props.outcome,
+          schema_version: TELEMETRY_SCHEMA_VERSION,
+          ...(props.provider ? { provider: props.provider } : {}),
+          ...(props.durationMs !== undefined ? { duration_ms: props.durationMs } : {}),
+          ...(props.nodesCompleted !== undefined ? { nodes_completed: props.nodesCompleted } : {}),
+          ...(props.nodesFailed !== undefined ? { nodes_failed: props.nodesFailed } : {}),
+          ...(props.nodesSkipped !== undefined ? { nodes_skipped: props.nodesSkipped } : {}),
+          ...(props.nodesTotal !== undefined ? { nodes_total: props.nodesTotal } : {}),
+          ...(props.exitReason ? { exit_reason: props.exitReason } : {}),
+        },
+      });
+    } catch (error) {
       getLog().debug({ err: error as Error }, 'telemetry.capture_failed');
     }
   })();

--- a/packages/paths/src/telemetry.ts
+++ b/packages/paths/src/telemetry.ts
@@ -132,7 +132,12 @@ function collectMachineProperties(): Record<string, string | boolean> {
     // Mirrors the CI auto-disable check; when telemetry is enabled this is
     // effectively always false, but it's cheap and future-proof.
     is_ci: process.env.CI?.toLowerCase() === 'true',
-    is_tty: process.stderr.isTTY,
+    // `process.stderr.isTTY` is `undefined` at runtime when stderr is not a TTY
+    // (servers, pipes, CI), so without coercion the field is silently omitted on
+    // the primary server path. bun-types incorrectly narrows it to `boolean`,
+    // which makes the lint rule think the coercion is redundant — it is not.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-conversion -- bun-types mis-types process.stderr.isTTY as always-boolean; runtime value is boolean|undefined and the coercion guarantees a present `false`.
+    is_tty: Boolean(process.stderr.isTTY),
   };
 }
 
@@ -150,13 +155,28 @@ export type WorkflowTelemetrySource = 'bundled' | 'global' | 'project';
 export function classifyWorkflowForTelemetry(
   name: string,
   source: WorkflowTelemetrySource | undefined
-): { workflow_name: string; is_builtin: boolean; workflow_source: string } {
+): { workflow_name: string; is_builtin: boolean; workflow_source: WorkflowTelemetrySource } {
   const isBuiltin = source === 'bundled';
   return {
     is_builtin: isBuiltin,
     workflow_name: isBuiltin ? name : 'custom',
     workflow_source: source ?? 'project',
   };
+}
+
+/**
+ * Model ids are user-supplied (forwarded verbatim from workflow/`config.yaml`
+ * YAML), so unlike `provider` they're not structurally categorical. Forward a
+ * value only when it looks like a real model ref (alphanumerics plus `/._:-`,
+ * bounded length — covers `sonnet`, `gpt-5.3-codex`, `anthropic/claude-haiku-4-5`,
+ * `openrouter/qwen/qwen3-coder`). Anything else is dropped so a stray free-text
+ * value can't slip through the "categorical only" telemetry contract.
+ *
+ * Exported for direct testing of the privacy guard. @internal
+ */
+export function sanitizeModelForTelemetry(model: string | undefined): string | undefined {
+  if (model === undefined) return undefined;
+  return /^[a-zA-Z0-9/._:-]{1,64}$/.test(model) ? model : undefined;
 }
 
 /** Why telemetry is currently disabled. `null` means it's enabled. */
@@ -498,9 +518,17 @@ export interface ArchonStartedProperties {
   surface: 'cli' | 'server';
 }
 
-/** Terminal workflow-run event (`workflow_completed` / `workflow_failed`). */
+/** Categorical terminal exit reason — a fixed enum, never raw error text. */
+export type WorkflowExitReason = 'no_nodes_completed' | 'node_error' | 'unhandled_error';
+
+/**
+ * Terminal workflow-run event (`workflow_completed` / `workflow_failed`).
+ * Cancellation is intentionally not tracked: external `/workflow cancel` exits
+ * via the `skipIfStatusChanged` paths in the DAG executor, which emit no
+ * telemetry by design (see "No Autonomous Lifecycle Mutation" in CLAUDE.md).
+ */
 export interface WorkflowCompletedProperties {
-  outcome: 'completed' | 'failed' | 'cancelled';
+  outcome: 'completed' | 'failed';
   workflowName: string;
   workflowSource?: WorkflowTelemetrySource;
   provider?: string;
@@ -509,8 +537,25 @@ export interface WorkflowCompletedProperties {
   nodesFailed?: number;
   nodesSkipped?: number;
   nodesTotal?: number;
-  /** Categorical reason enum — never raw error text. */
-  exitReason?: string;
+  exitReason?: WorkflowExitReason;
+}
+
+/**
+ * Run a telemetry capture fire-and-forget: never awaited, never throws. Resolves
+ * the lazy client, skips when disabled/uninitialized, and swallows every error
+ * (network, SDK, malformed props) at `debug` — telemetry must never crash Archon.
+ * The per-event error policy lives here, in exactly one place.
+ */
+function fireAndForget(capture: (client: PostHog) => void): void {
+  void (async (): Promise<void> => {
+    try {
+      const client = await getClient();
+      if (!client) return;
+      capture(client);
+    } catch (error) {
+      getLog().debug({ err: error as Error }, 'telemetry.capture_failed');
+    }
+  })();
 }
 
 /**
@@ -521,100 +566,84 @@ export interface WorkflowCompletedProperties {
 export function captureWorkflowInvoked(props: WorkflowInvokedProperties): void {
   if (isTelemetryDisabled()) return;
   maybeShowFirstRunNotice();
-  void (async (): Promise<void> => {
-    try {
-      const client = await getClient();
-      if (!client) return;
-      client.capture({
-        distinctId: getTelemetryId(),
-        event: 'workflow_invoked',
-        properties: {
-          ...PRIVACY_INVARIANTS,
-          ...classifyWorkflowForTelemetry(props.workflowName, props.workflowSource),
-          schema_version: TELEMETRY_SCHEMA_VERSION,
-          ...(props.platform ? { platform: props.platform } : {}),
-          ...(props.provider ? { provider: props.provider } : {}),
-          ...(props.model ? { model: props.model } : {}),
-          ...(props.nodeCount !== undefined ? { node_count: props.nodeCount } : {}),
-          uses_loop: Boolean(props.usesLoop),
-          uses_approval: Boolean(props.usesApproval),
-          uses_script: Boolean(props.usesScript),
-          uses_bash: Boolean(props.usesBash),
-          interactive: Boolean(props.interactive),
-          used_isolation: Boolean(props.usedIsolation),
-          is_resume: Boolean(props.isResume),
-        },
-      });
-    } catch (error) {
-      // Fire-and-forget: telemetry must never crash Archon, so swallow every
-      // error here (network, SDK, malformed props) and record it at debug.
-      getLog().debug({ err: error as Error }, 'telemetry.capture_failed');
-    }
-  })();
+  const model = sanitizeModelForTelemetry(props.model);
+  fireAndForget(client => {
+    client.capture({
+      distinctId: getTelemetryId(),
+      event: 'workflow_invoked',
+      properties: {
+        ...PRIVACY_INVARIANTS,
+        ...classifyWorkflowForTelemetry(props.workflowName, props.workflowSource),
+        schema_version: TELEMETRY_SCHEMA_VERSION,
+        ...(props.platform ? { platform: props.platform } : {}),
+        ...(props.provider ? { provider: props.provider } : {}),
+        ...(model ? { model } : {}),
+        ...(props.nodeCount !== undefined ? { node_count: props.nodeCount } : {}),
+        uses_loop: Boolean(props.usesLoop),
+        uses_approval: Boolean(props.usesApproval),
+        uses_script: Boolean(props.usesScript),
+        uses_bash: Boolean(props.usesBash),
+        interactive: Boolean(props.interactive),
+        used_isolation: Boolean(props.usedIsolation),
+        is_resume: Boolean(props.isResume),
+      },
+    });
+  });
 }
 
 /**
- * Fire-and-forget capture of an `archon_started` event — emitted once per CLI
- * invocation and per server boot. This (not just `workflow_invoked`) is what
- * makes active-install / DAU metrics honest, since users who only run
+ * Fire-and-forget capture of an `archon_started` event. Call once per CLI
+ * invocation and per server boot (the single call sites in `cli.ts` / the
+ * server entrypoint enforce the "once per process" contract — there is no
+ * in-function dedup guard). This (not just `workflow_invoked`) is what makes
+ * active-install / DAU metrics honest, since users who only run
  * `doctor`/`serve`/chat would otherwise be invisible. Machine context rides
  * along via the registered super-properties. Also shows the first-run notice.
  */
 export function captureArchonStarted(props: ArchonStartedProperties): void {
   if (isTelemetryDisabled()) return;
   maybeShowFirstRunNotice();
-  void (async (): Promise<void> => {
-    try {
-      const client = await getClient();
-      if (!client) return;
-      client.capture({
-        distinctId: getTelemetryId(),
-        event: 'archon_started',
-        properties: {
-          ...PRIVACY_INVARIANTS,
-          surface: props.surface,
-          schema_version: TELEMETRY_SCHEMA_VERSION,
-        },
-      });
-    } catch (error) {
-      getLog().debug({ err: error as Error }, 'telemetry.capture_failed');
-    }
-  })();
+  fireAndForget(client => {
+    client.capture({
+      distinctId: getTelemetryId(),
+      event: 'archon_started',
+      properties: {
+        ...PRIVACY_INVARIANTS,
+        surface: props.surface,
+        schema_version: TELEMETRY_SCHEMA_VERSION,
+      },
+    });
+  });
 }
 
 /**
  * Fire-and-forget capture of a terminal workflow run. Emits `workflow_completed`
  * when `outcome === 'completed'`, otherwise `workflow_failed`. Carries run
  * outcome, duration, node counts, and a categorical exit reason so maintainers
- * can measure success rates and funnels — not just intent.
+ * can measure success rates and funnels — not just intent. Intentionally does
+ * not show the first-run notice (that fires on start events, not completion).
  */
 export function captureWorkflowCompleted(props: WorkflowCompletedProperties): void {
   if (isTelemetryDisabled()) return;
-  void (async (): Promise<void> => {
-    try {
-      const client = await getClient();
-      if (!client) return;
-      client.capture({
-        distinctId: getTelemetryId(),
-        event: props.outcome === 'completed' ? 'workflow_completed' : 'workflow_failed',
-        properties: {
-          ...PRIVACY_INVARIANTS,
-          ...classifyWorkflowForTelemetry(props.workflowName, props.workflowSource),
-          outcome: props.outcome,
-          schema_version: TELEMETRY_SCHEMA_VERSION,
-          ...(props.provider ? { provider: props.provider } : {}),
-          ...(props.durationMs !== undefined ? { duration_ms: props.durationMs } : {}),
-          ...(props.nodesCompleted !== undefined ? { nodes_completed: props.nodesCompleted } : {}),
-          ...(props.nodesFailed !== undefined ? { nodes_failed: props.nodesFailed } : {}),
-          ...(props.nodesSkipped !== undefined ? { nodes_skipped: props.nodesSkipped } : {}),
-          ...(props.nodesTotal !== undefined ? { nodes_total: props.nodesTotal } : {}),
-          ...(props.exitReason ? { exit_reason: props.exitReason } : {}),
-        },
-      });
-    } catch (error) {
-      getLog().debug({ err: error as Error }, 'telemetry.capture_failed');
-    }
-  })();
+  fireAndForget(client => {
+    client.capture({
+      distinctId: getTelemetryId(),
+      event: props.outcome === 'completed' ? 'workflow_completed' : 'workflow_failed',
+      properties: {
+        ...PRIVACY_INVARIANTS,
+        ...classifyWorkflowForTelemetry(props.workflowName, props.workflowSource),
+        outcome: props.outcome,
+        schema_version: TELEMETRY_SCHEMA_VERSION,
+        ...(props.provider ? { provider: props.provider } : {}),
+        ...(props.durationMs !== undefined ? { duration_ms: props.durationMs } : {}),
+        ...(props.nodesCompleted !== undefined ? { nodes_completed: props.nodesCompleted } : {}),
+        ...(props.nodesFailed !== undefined ? { nodes_failed: props.nodesFailed } : {}),
+        ...(props.nodesSkipped !== undefined ? { nodes_skipped: props.nodesSkipped } : {}),
+        ...(props.nodesTotal !== undefined ? { nodes_total: props.nodesTotal } : {}),
+        ...(props.exitReason ? { exit_reason: props.exitReason } : {}),
+      },
+    });
+  });
 }
 
 /**

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -93,6 +93,7 @@ import {
   logArchonPaths,
   validateAppDefaultsPaths,
   shutdownTelemetry,
+  captureArchonStarted,
 } from '@archon/paths';
 import { selectGitHubAuthMode, parseGitCredentialPath } from './github-auth-bootstrap';
 
@@ -195,6 +196,9 @@ export interface ServerOptions {
 
 export async function startServer(opts: ServerOptions = {}): Promise<void> {
   getLog().info('server_starting');
+  // Anonymous once-per-boot startup event (self-gates on opt-out). Flushed by
+  // the shutdownTelemetry() call in the SIGINT/SIGTERM shutdown handler.
+  captureArchonStarted({ surface: 'server' });
 
   // Database auto-detected: SQLite (default) or PostgreSQL (if DATABASE_URL set)
   // No required environment variables - SQLite works out of the box

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -16,6 +16,9 @@ const mockLogger = {
   fatal: mockLogFn,
   child: mock(() => mockLogger),
 };
+// Hoisted telemetry mock — declared before the mock.module factory runs so the
+// completion-telemetry tests can assert on it.
+const mockCaptureWorkflowCompleted = mock(() => {});
 mock.module('@archon/paths', () => ({
   createLogger: mock(() => mockLogger),
   getCommandFolderSearchPaths: (folder?: string) => {
@@ -30,7 +33,8 @@ mock.module('@archon/paths', () => ({
   getLegacyHomeWorkflowsPath: () => '/nonexistent/home/.archon/workflows',
   getArchonHome: () => '/nonexistent/home',
   // Telemetry is fire-and-forget; mock as a no-op so terminal sites can call it.
-  captureWorkflowCompleted: mock(() => {}),
+  // Hoisted so tests can assert outcome / exit_reason at each terminal site.
+  captureWorkflowCompleted: mockCaptureWorkflowCompleted,
 }));
 
 // --- Bootstrap provider registry (after path mocks, before dag-executor import) ---
@@ -8404,5 +8408,120 @@ describe('executeDagWorkflow -- persist_session', () => {
       .map((call: unknown[]) => call[1] as string)
       .some(m => m.includes('Could not persist') && m.includes('planner'));
     expect(warned).toBe(true);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Completion telemetry
+//
+// captureWorkflowCompleted is mocked as a no-op; without these assertions a
+// dropped call at any of the three terminal sites (success / partial-failure /
+// no-nodes-completed) would be invisible. Each test clears the hoisted mock
+// immediately before the run so the assertion is precise. `source: 'bundled'`
+// is threaded as the final arg to also confirm it reaches the telemetry payload.
+// ───────────────────────────────────────────────────────────────────────────
+describe('executeDagWorkflow -- completion telemetry', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `dag-tel-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(testDir, { recursive: true });
+    mockSendQueryDag.mockClear();
+    mockGetAgentProviderDag.mockClear();
+    mockCaptureWorkflowCompleted.mockClear();
+    mockGetAgentProviderDag.mockImplementation(() => ({
+      sendQuery: mockSendQueryDag,
+      getType: () => 'claude',
+      getCapabilities: mockClaudeCapabilities,
+    }));
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(testDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  async function runDag(workflow: { name: string; nodes: DagNode[] }): Promise<void> {
+    await executeDagWorkflow(
+      createMockDeps(createMockStore()),
+      createMockPlatform(),
+      'conv-dag',
+      testDir,
+      workflow,
+      makeWorkflowRun(),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      undefined,
+      'bundled'
+    );
+  }
+
+  it('emits outcome=completed with node counts and the threaded source on success', async () => {
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'done' };
+      yield { type: 'result', sessionId: 'sid-ok' };
+    });
+
+    await runDag({ name: 'dag-ok', nodes: [{ id: 'step', prompt: 'Do thing.' }] });
+
+    expect(mockCaptureWorkflowCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: 'completed',
+        workflowSource: 'bundled',
+        nodesCompleted: 1,
+        nodesTotal: 1,
+      })
+    );
+  });
+
+  it('emits outcome=failed exit_reason=no_nodes_completed when the only node fails', async () => {
+    // A result chunk with no assistant text fails the node (see "produced no
+    // assistant output" guard), leaving zero completed nodes.
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'result', sessionId: 'sid-empty' };
+    });
+
+    await runDag({ name: 'dag-empty', nodes: [{ id: 'only', prompt: 'Do thing.' }] });
+
+    expect(mockCaptureWorkflowCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: 'failed', exitReason: 'no_nodes_completed' })
+    );
+  });
+
+  it('emits outcome=failed exit_reason=node_error when one node completes and another fails', async () => {
+    // node2 depends on node1, so order is deterministic: node1 yields assistant
+    // text (completes), node2 yields only a result (fails) → 1 completed, 1 failed.
+    let call = 0;
+    mockSendQueryDag.mockImplementation(function* () {
+      call++;
+      if (call === 1) {
+        yield { type: 'assistant', content: 'first ok' };
+        yield { type: 'result', sessionId: 'sid-1' };
+      } else {
+        yield { type: 'result', sessionId: 'sid-2' };
+      }
+    });
+
+    await runDag({
+      name: 'dag-partial',
+      nodes: [
+        { id: 'node1', prompt: 'First.' },
+        { id: 'node2', prompt: 'Second.', depends_on: ['node1'] },
+      ],
+    });
+
+    expect(mockCaptureWorkflowCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: 'failed', exitReason: 'node_error' })
+    );
   });
 });

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -8474,6 +8474,8 @@ describe('executeDagWorkflow -- completion telemetry', () => {
 
     await runDag({ name: 'dag-ok', nodes: [{ id: 'step', prompt: 'Do thing.' }] });
 
+    // Exactly once — guards against the double-count risk the PR flagged.
+    expect(mockCaptureWorkflowCompleted).toHaveBeenCalledTimes(1);
     expect(mockCaptureWorkflowCompleted).toHaveBeenCalledWith(
       expect.objectContaining({
         outcome: 'completed',
@@ -8493,8 +8495,13 @@ describe('executeDagWorkflow -- completion telemetry', () => {
 
     await runDag({ name: 'dag-empty', nodes: [{ id: 'only', prompt: 'Do thing.' }] });
 
+    expect(mockCaptureWorkflowCompleted).toHaveBeenCalledTimes(1);
     expect(mockCaptureWorkflowCompleted).toHaveBeenCalledWith(
-      expect.objectContaining({ outcome: 'failed', exitReason: 'no_nodes_completed' })
+      expect.objectContaining({
+        outcome: 'failed',
+        workflowSource: 'bundled',
+        exitReason: 'no_nodes_completed',
+      })
     );
   });
 
@@ -8520,8 +8527,13 @@ describe('executeDagWorkflow -- completion telemetry', () => {
       ],
     });
 
+    expect(mockCaptureWorkflowCompleted).toHaveBeenCalledTimes(1);
     expect(mockCaptureWorkflowCompleted).toHaveBeenCalledWith(
-      expect.objectContaining({ outcome: 'failed', exitReason: 'node_error' })
+      expect.objectContaining({
+        outcome: 'failed',
+        workflowSource: 'bundled',
+        exitReason: 'node_error',
+      })
     );
   });
 });

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -29,6 +29,8 @@ mock.module('@archon/paths', () => ({
   getHomeWorkflowsPath: () => '/nonexistent/home/workflows',
   getLegacyHomeWorkflowsPath: () => '/nonexistent/home/.archon/workflows',
   getArchonHome: () => '/nonexistent/home',
+  // Telemetry is fire-and-forget; mock as a no-op so terminal sites can call it.
+  captureWorkflowCompleted: mock(() => {}),
 }));
 
 // --- Bootstrap provider registry (after path mocks, before dag-executor import) ---

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -41,6 +41,7 @@ import type {
   EffortLevel,
   ThinkingConfig,
   SandboxSettings,
+  WorkflowSource,
 } from './schemas';
 import {
   isBashNode,
@@ -51,7 +52,7 @@ import {
   isApprovalContext,
 } from './schemas';
 import { formatToolCall } from './utils/tool-formatter';
-import { createLogger } from '@archon/paths';
+import { createLogger, captureWorkflowCompleted } from '@archon/paths';
 import { getWorkflowEventEmitter } from './event-emitter';
 import { evaluateCondition } from './condition-evaluator';
 import {
@@ -2578,7 +2579,9 @@ export async function executeDagWorkflow(
   config: WorkflowConfig,
   configuredCommandFolder?: string,
   issueContext?: string,
-  priorCompletedNodes?: Map<string, string>
+  priorCompletedNodes?: Map<string, string>,
+  /** Discovery source — telemetry only (custom-vs-default + name redaction). */
+  source?: WorkflowSource
 ): Promise<string | undefined> {
   const dagStartTime = Date.now();
   const workflowLevelOptions = {
@@ -3333,6 +3336,20 @@ export async function executeDagWorkflow(
           `${nodeCounts.skipped} downstream node${nodeCounts.skipped !== 1 ? 's were' : ' was'} skipped.`
         : `DAG workflow '${workflow.name}' completed with no successful nodes. ` +
           'Check node conditions, trigger rules, and upstream failures.';
+    // Anonymous telemetry: terminal failure (no successful nodes). Counts/
+    // duration are in scope here even though they aren't persisted to the DB row.
+    captureWorkflowCompleted({
+      outcome: 'failed',
+      workflowName: workflow.name,
+      workflowSource: source,
+      provider: workflowProvider,
+      durationMs: Date.now() - dagStartTime,
+      nodesCompleted: nodeCounts.completed,
+      nodesFailed: nodeCounts.failed,
+      nodesSkipped: nodeCounts.skipped,
+      nodesTotal: nodeCounts.total,
+      exitReason: 'no_nodes_completed',
+    });
     // Note: nodeCounts not stored for failed runs — failWorkflowRun only stores { error }.
     // Frontend guards with isValidNodeCounts so missing node_counts is safe.
     await deps.store.failWorkflowRun(workflowRun.id, failMsg).catch((dbErr: Error) => {
@@ -3366,6 +3383,19 @@ export async function executeDagWorkflow(
       .map(([id, o]) => `'${id}': ${o.state === 'failed' ? o.error : 'unknown'}`)
       .join('; ');
     const failMsg = `DAG workflow '${workflow.name}' completed with failures: ${failedNodes}`;
+    // Anonymous telemetry: terminal failure (some nodes failed).
+    captureWorkflowCompleted({
+      outcome: 'failed',
+      workflowName: workflow.name,
+      workflowSource: source,
+      provider: workflowProvider,
+      durationMs: Date.now() - dagStartTime,
+      nodesCompleted: nodeCounts.completed,
+      nodesFailed: nodeCounts.failed,
+      nodesSkipped: nodeCounts.skipped,
+      nodesTotal: nodeCounts.total,
+      exitReason: 'node_error',
+    });
     await deps.store.failWorkflowRun(workflowRun.id, failMsg).catch((dbErr: Error) => {
       getLog().error({ err: dbErr, workflowRunId: workflowRun.id }, 'dag_db_fail_failed');
     });
@@ -3420,6 +3450,18 @@ export async function executeDagWorkflow(
     runId: workflowRun.id,
     workflowName: workflow.name,
     duration,
+  });
+  // Anonymous telemetry: successful terminal run with outcome + duration + counts.
+  captureWorkflowCompleted({
+    outcome: 'completed',
+    workflowName: workflow.name,
+    workflowSource: source,
+    provider: workflowProvider,
+    durationMs: duration,
+    nodesCompleted: nodeCounts.completed,
+    nodesFailed: nodeCounts.failed,
+    nodesSkipped: nodeCounts.skipped,
+    nodesTotal: nodeCounts.total,
   });
   deps.store
     .createWorkflowEvent({

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -895,6 +895,8 @@ describe('telemetry wiring', () => {
       'db-conv-1'
     );
 
+    // Exactly once — the executor catch must not double-emit with the DAG paths.
+    expect(mockCaptureWorkflowCompleted).toHaveBeenCalledTimes(1);
     expect(mockCaptureWorkflowCompleted).toHaveBeenCalledWith(
       expect.objectContaining({ outcome: 'failed', exitReason: 'unhandled_error' })
     );

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -24,6 +24,9 @@ mock.module('@archon/paths', () => ({
   parseOwnerRepo: mock(() => null),
   getRunArtifactsPath: mock(() => '/tmp/artifacts'),
   getProjectLogsPath: mock(() => '/tmp/logs'),
+  // Telemetry is fire-and-forget; mock as no-ops so the executor can call them.
+  captureWorkflowInvoked: mock(() => {}),
+  captureWorkflowCompleted: mock(() => {}),
 }));
 
 // --- Mock git ---

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -19,14 +19,17 @@ const mockLogger = {
   isLevelEnabled: mock(() => true),
   level: 'info',
 };
+// Telemetry is fire-and-forget; mock as no-ops so the executor can call them.
+// Hoisted so tests can assert on the completion call (outcome / exit reason).
+const mockCaptureWorkflowInvoked = mock(() => {});
+const mockCaptureWorkflowCompleted = mock(() => {});
 mock.module('@archon/paths', () => ({
   createLogger: mock(() => mockLogger),
   parseOwnerRepo: mock(() => null),
   getRunArtifactsPath: mock(() => '/tmp/artifacts'),
   getProjectLogsPath: mock(() => '/tmp/logs'),
-  // Telemetry is fire-and-forget; mock as no-ops so the executor can call them.
-  captureWorkflowInvoked: mock(() => {}),
-  captureWorkflowCompleted: mock(() => {}),
+  captureWorkflowInvoked: mockCaptureWorkflowInvoked,
+  captureWorkflowCompleted: mockCaptureWorkflowCompleted,
 }));
 
 // --- Mock git ---
@@ -859,6 +862,98 @@ describe('finally backstop', () => {
       c => typeof c[1] === 'string' && (c[1] as string).includes('exited without finalizing')
     );
     expect(backstopCall).toBeUndefined();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Telemetry wiring
+//
+// captureWorkflowCompleted is mocked as a no-op; these tests assert it actually
+// fires on the unhandled-throw path (and only there from the executor) and that
+// the WorkflowSource is threaded into executeDagWorkflow. Telemetry regressions
+// are otherwise invisible — a dropped call leaves no failing assertion.
+// ───────────────────────────────────────────────────────────────────────────
+describe('telemetry wiring', () => {
+  beforeEach(() => {
+    mockExecuteDagWorkflow.mockClear();
+    mockCaptureWorkflowCompleted.mockClear();
+    mockExecuteDagWorkflow.mockImplementation(async (): Promise<string | undefined> => undefined);
+  });
+
+  it('captures workflow_failed with unhandled_error when executeDagWorkflow throws', async () => {
+    mockExecuteDagWorkflow.mockRejectedValueOnce(new Error('dag boom'));
+    const store = makeStore();
+    const deps = makeDeps(store);
+
+    await executeWorkflow(
+      deps,
+      makePlatform(),
+      'conv-1',
+      '/tmp',
+      makeWorkflow(),
+      'msg',
+      'db-conv-1'
+    );
+
+    expect(mockCaptureWorkflowCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: 'failed', exitReason: 'unhandled_error' })
+    );
+  });
+
+  it('does not fire executor-level completion telemetry on the success path', async () => {
+    // The DAG executor owns success/partial-failure telemetry; the executor's
+    // own captureWorkflowCompleted must fire only from the unhandled-throw catch.
+    const store = makeStore();
+    const deps = makeDeps(store);
+
+    await executeWorkflow(
+      deps,
+      makePlatform(),
+      'conv-1',
+      '/tmp',
+      makeWorkflow(),
+      'msg',
+      'db-conv-1'
+    );
+
+    expect(mockCaptureWorkflowCompleted).not.toHaveBeenCalled();
+  });
+
+  it('threads source through to executeDagWorkflow (arg index 16)', async () => {
+    const store = makeStore();
+    const deps = makeDeps(store);
+
+    await executeWorkflow(
+      deps,
+      makePlatform(),
+      'conv-1',
+      '/tmp',
+      makeWorkflow(),
+      'msg',
+      'db-conv-1',
+      {
+        source: 'bundled',
+      }
+    );
+
+    expect(mockExecuteDagWorkflow.mock.calls[0]?.[16]).toBe('bundled');
+  });
+
+  it('passes undefined source when the caller does not supply one', async () => {
+    const store = makeStore();
+    const deps = makeDeps(store);
+
+    await executeWorkflow(
+      deps,
+      makePlatform(),
+      'conv-1',
+      '/tmp',
+      makeWorkflow(),
+      'msg',
+      'db-conv-1'
+    );
+
+    expect(mockExecuteDagWorkflow.mock.calls[0]?.[16]).toBeUndefined();
   });
 });
 

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -6,9 +6,15 @@ import { join } from 'path';
 import type { IWorkflowPlatform, WorkflowMessageMetadata } from './deps';
 import type { WorkflowDeps, WorkflowConfig } from './deps';
 import * as archonPaths from '@archon/paths';
-import { createLogger, captureWorkflowInvoked, BUNDLED_VERSION } from '@archon/paths';
+import { createLogger, captureWorkflowInvoked, captureWorkflowCompleted } from '@archon/paths';
 import { getDefaultBranch, toRepoPath } from '@archon/git';
-import type { WorkflowDefinition, WorkflowRun, WorkflowExecutionResult } from './schemas';
+import type {
+  WorkflowDefinition,
+  WorkflowRun,
+  WorkflowExecutionResult,
+  WorkflowSource,
+} from './schemas';
+import { isLoopNode, isApprovalNode, isScriptNode, isBashNode } from './schemas';
 import { executeDagWorkflow } from './dag-executor';
 import { logWorkflowStart, logWorkflowError } from './logger';
 import { formatDuration, parseDbTimestamp } from './utils/duration';
@@ -214,6 +220,13 @@ export type ExecuteWorkflowOptions = ResumePayload & {
     prSha?: string;
     prBranch?: string;
   };
+  /**
+   * Discovery source of the workflow (bundled / global / project). Used only
+   * for anonymous telemetry — bundled workflows report their real name, custom
+   * ones report `"custom"`. Optional: defaults to the `"custom"`/project
+   * treatment when a caller doesn't thread it through.
+   */
+  source?: WorkflowSource;
   /** Parent conversation ID — enables approve/reject auto-resume from chat. */
   parentConversationId?: string;
   /**
@@ -288,6 +301,7 @@ export async function executeWorkflow(
     preCreatedRun,
     priorCompletedNodes,
     userId,
+    source,
   } = opts;
   // Load config once for the entire workflow execution
   const fileConfig = await deps.loadConfig(cwd);
@@ -556,14 +570,24 @@ export async function executeWorkflow(
       conversationId: conversationDbId,
     });
 
-    // Fire-and-forget anonymous usage telemetry. No PII: workflow name +
-    // platform + version only. Workflow descriptions are user-authored YAML
-    // and may contain private context ("Deploy ACME prod"), so they are not
-    // included. Opt out via ARCHON_TELEMETRY_DISABLED=1 / DO_NOT_TRACK=1.
+    // Fire-and-forget anonymous usage telemetry. Categorical only: bundled
+    // workflows report their real name, custom ones report "custom". No PII —
+    // descriptions/prompts/paths are never sent. Machine context + version ride
+    // along as super-properties. Opt out: ARCHON_TELEMETRY_DISABLED=1 / DO_NOT_TRACK=1.
     captureWorkflowInvoked({
       workflowName: workflow.name,
+      workflowSource: source,
       platform: platform.getPlatformType(),
-      archonVersion: BUNDLED_VERSION,
+      provider: resolvedProvider,
+      model: resolvedModel,
+      nodeCount: workflow.nodes.length,
+      usesLoop: workflow.nodes.some(isLoopNode),
+      usesApproval: workflow.nodes.some(isApprovalNode),
+      usesScript: workflow.nodes.some(isScriptNode),
+      usesBash: workflow.nodes.some(isBashNode),
+      interactive: workflow.interactive ?? false,
+      usedIsolation: isolationContext !== undefined,
+      isResume: dagPriorCompletedNodes !== undefined,
     });
     deps.store
       .createWorkflowEvent({
@@ -684,7 +708,8 @@ export async function executeWorkflow(
       config,
       configuredCommandFolder,
       issueContext,
-      dagPriorCompletedNodes
+      dagPriorCompletedNodes,
+      source
     );
 
     // executeDagWorkflow throws on fatal errors; check DB status for result
@@ -735,6 +760,17 @@ export async function executeWorkflow(
       runId: workflowRun.id,
       workflowName: workflow.name,
       error: err.message,
+    });
+    // Anonymous telemetry for the unhandled-throw failure path. The DAG-internal
+    // failure paths (no/partial completion) fire their own captureWorkflowCompleted
+    // and return without throwing, so this only covers genuine unhandled errors —
+    // no double-count. Duration/node-counts are not in scope here.
+    captureWorkflowCompleted({
+      outcome: 'failed',
+      workflowName: workflow.name,
+      workflowSource: source,
+      provider: resolvedProvider,
+      exitReason: 'unhandled_error',
     });
     deps.store
       .createWorkflowEvent({


### PR DESCRIPTION
## Summary

- **Problem:** Telemetry only fired one intent-only event (`workflow_invoked`) at workflow *start*. There was no completion/outcome event, no machine context, no custom-vs-default signal, and users who only ran `doctor`/`serve`/chat were invisible — so active-install counts, success rates, and funnels were impossible.
- **Why it matters:** Maintainers can't prioritize without seeing active installs, what's actually used (custom vs bundled, provider/model mix), and whether runs *succeed*. This was the follow-up agreed after #1780's "trust" pass.
- **What changed:** Adds `archon_started` (once per process) + `workflow_completed`/`workflow_failed` (run outcomes), enriches `workflow_invoked` with categorical dimensions, and attaches machine context via PostHog `register()` super-properties. Bundled workflows report their real name; custom/global report `"custom"`.
- **What did *not* change (scope boundary):** No geo/IP (the #1780 promise is preserved — `$ip:''` + `disableGeoip:true` stay). No person profiles, no free-text, no custom workflow names, no error text. `install_method` (brew/curl/npm/docker) deferred to a fast-follow; `is_binary` ships now.

## UX Journey

### Before

```
END USER (CLI / server)                      POSTHOG (maintainer view)
$ archon workflow run plan "..."  ─────────▶ workflow_invoked { workflow_name,
  (only on START)                              platform, archon_version, $ip:'' }
$ archon doctor / serve / chat    ──/ /──▶    (no event — user invisible)
run finishes / fails              ──/ /──▶    (no event — outcome unknown)
```

### After

```
END USER (CLI / server)                      POSTHOG (maintainer view)
ANY `archon <cmd>` / server boot ─────────▶ * archon_started { surface }
                                             + super-props on EVERY event:
                                               { os, arch, archon_version,
                                                 is_binary, runtime_version,
                                                 is_ci, is_tty }
                                             + per-event privacy invariants:
                                               { $process_person_profile:false, $ip:'' }
$ archon workflow run plan "..."  ─────────▶ * workflow_invoked { is_builtin,
                                               workflow_name|"custom", workflow_source,
                                               provider, model, node_count, uses_*,
                                               interactive, used_isolation, is_resume }
run completes / fails / cancels   ─────────▶ * workflow_completed | workflow_failed
                                               { outcome, duration_ms, nodes_*, exit_reason }
GEO: deliberately NOT collected (IP promise preserved)
FIRST-RUN NOTICE: re-shown once (stamp -> -v2) with a "what changed" line.
```

## Architecture Diagram

### Before

```
@archon/cli/cli ─────────────────┐
@archon/server/index ────────────┤
@archon/workflows/executor ──▶ captureWorkflowInvoked
@archon/workflows/dag-executor   (terminal sites emit events, NO telemetry)
                                  │
@archon/paths/telemetry ─────────┘  (captureWorkflowInvoked only)
```

### After

```
@archon/cli/cli ───────[+]──▶ captureArchonStarted({surface:'cli'})
@archon/server/index ──[+]──▶ captureArchonStarted({surface:'server'})
@archon/workflows/executor ──[~]──▶ captureWorkflowInvoked(+dims) ═══▶ @archon/paths/telemetry
                            └─[+]──▶ captureWorkflowCompleted (unhandled-throw path)
@archon/workflows/dag-executor ─[+]──▶ captureWorkflowCompleted (success + 2 failure sites)
@archon/paths/telemetry [~]:
   ├─ [+] register() super-properties (machine context) in initClient
   ├─ [+] captureArchonStarted / captureWorkflowCompleted
   ├─ [+] classifyWorkflowForTelemetry (bundled→name, else "custom")
   ├─ [~] captureWorkflowInvoked (+ workflow_source/provider/model/node shape)
   └─ [~] NOTICE_STAMP_FILENAME -> telemetry-notice-shown-v2 (re-consent)
WorkflowSource threaded: discovery → ExecuteWorkflowOptions/WorkflowRoutingContext → executor → dag-executor
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `@archon/cli/cli` | `@archon/paths/telemetry` | **new** | `captureArchonStarted` |
| `@archon/server/index` | `@archon/paths/telemetry` | **new** | `captureArchonStarted` |
| `@archon/workflows/dag-executor` | `@archon/paths/telemetry` | **new** | `captureWorkflowCompleted` at terminal sites |
| `@archon/workflows/executor` | `@archon/paths/telemetry` | **modified** | enriched invoke + failure-path completion |
| `@archon/core/orchestrator` | `@archon/workflows/executor` | **modified** | threads `WorkflowSource` |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `paths`, `workflows`, `core`, `cli`, `server`, `docs`
- Module: `paths:telemetry`, `workflows:executor`, `workflows:dag-executor`, `core:orchestrator`, `cli`, `server`

## Change Metadata

- Change type: `feature`
- Primary scope: `multi`

## Linked Issue

- Closes #
- Related # — follow-up to the #1780 telemetry trust pass (no tracking issue; surfaced from a maintainer analytics request)

## Validation Evidence (required)

```bash
bun run validate
# EXIT=0
# check:bundled ✓  check:bundled-skill ✓
# type-check ✓ (all 10 packages)
# lint ✓ (--max-warnings 0)
# format:check ✓
# test ✓ (all packages; new telemetry + classifier coverage)
```

- Evidence provided: `bun run validate` green end-to-end locally.
- Skipped commands: none.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No** (same single PostHog ingest path; more event *types* over it, no new endpoint/key)
- Secrets/tokens handling changed? **No** (embedded write-only `phc_*` key unchanged)
- File system access scope changed? **Yes (minor)** — the one-time notice stamp filename moves to `telemetry-notice-shown-v2` under `${ARCHON_HOME}` (same dir as today).
- **Privacy posture:** strictly preserved — `$ip:''` + `disableGeoip:true` retained, no geo, no person profiles (`$process_person_profile:false` on every event), no free-text/custom names/error text. All new fields are categorical. Privacy invariants are kept *per-event* (not relying solely on super-properties) so a `register()` regression can never silently leak IP.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No** (existing opt-out vars unchanged: `ARCHON_TELEMETRY_DISABLED`, `DO_NOT_TRACK`, `CI=true`, `POSTHOG_API_KEY=off`)
- Database migration needed? **No**
- Upgrade steps: none. On next run, installs without a `telemetry-notice-shown-v2` stamp see the updated first-run notice once (intentional re-consent for the expanded, still-anonymous capture).

## Human Verification (required)

- Verified scenarios:
  - `bun run validate` passes (type-check all 10 packages, lint 0 warnings, format, full test suite).
  - New unit tests: `classifyWorkflowForTelemetry` (bundled→real name, custom/global/undefined→"custom"), `captureArchonStarted`/`captureWorkflowCompleted` no-throw (enabled + disabled), stamp `-v2`.
  - Confirmed `register()` exists in the installed `posthog-node@5.29.2` (`@posthog/core` `register(properties): Promise<void>`).
- Edge cases checked: `source` undefined → privacy-safe `"custom"`; `resolvedModel` undefined → property omitted; failure path with no completed nodes sends the counts that exist; disabled telemetry → all three capture fns are pure no-ops.
- What was not verified: live PostHog ingest of the new events in a dashboard (needs the project-key holder); exact custom-vs-default labeling on the two un-threaded orchestrator routes (see Side Effects).

## Side Effects / Blast Radius (required)

- Affected subsystems: `@archon/paths` (telemetry core), `@archon/workflows` (executor + dag-executor terminal sites), `@archon/core` (orchestrator `source` threading), `@archon/cli` + `@archon/server` (startup event).
- Potential unintended effects:
  - Two orchestrator dispatch routes (`handleWorkflowInvocationResult`, `handleWorkflowRunCommand`) currently pass `source` undefined → those chat/web-dispatched runs report `workflow_source` as `"custom"`. This is the **privacy-conservative** direction (never mislabels a custom workflow as bundled; only under-reports some bundled runs from those routes). CLI, background dispatch, approval-resume, and the single-codebase resolve path are exact. Full threading is a documented fast-follow.
  - First-run notice re-shows once per install due to the stamp bump (intended).
- Guardrails/monitoring: PostHog event volume should *increase* (new event types) and `workflow_invoked` gains properties; watch for the invoked→completed funnel populating. No new failure surface — all capture is fire-and-forget and never throws.

## Rollback Plan (required)

- Fast rollback: `git revert <merge-commit>` — single feature commit, isolated to telemetry + thin call-site wiring.
- Feature flags/toggles: none needed; entirely user-controlled by existing opt-out env vars.
- Observable failure symptoms: none expected (fire-and-forget). If PostHog shape looks wrong, revert; capture failures are swallowed at `debug` and cannot affect workflow execution.

## Risks and Mitigations

- Risk: double-counted completion events.
  - Mitigation: telemetry calls are placed adjacent to the existing `emitter.emit(...)` terminal sites, inheriting their de-dup (DAG failure paths `return` without throwing; the executor catch only fires on genuine unhandled throws).
- Risk: trust erosion from expanding capture after #1780's minimalism promise.
  - Mitigation: all fields categorical/anonymous, no IP/geo; README + `.env.example` + notice updated in the same PR; notice stamp bumped to `-v2` so existing users re-consent once with a "what changed" line.
- Risk: `register()` super-property regression dropping privacy fields.
  - Mitigation: `$ip:''` and `$process_person_profile:false` are kept per-event (not super-properties), so they cannot silently disappear.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced anonymous telemetry: emits startup, per-workflow start, and terminal (completed/failed) events; includes outcome, duration, node counts, categorical run/context flags, and workflow source classification; opt-out remains available.

* **Bug Fixes**
  * Ensures telemetry is flushed on early CLI exits so startup events are delivered.

* **Documentation**
  * Expanded docs and security guidance detailing collected categorical fields (including install UUID) and explicitly excluded sensitive data.

* **Tests**
  * Added tests for telemetry entry points, classification/redaction, and no-throw behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->