### PR TITLE
fix(web/console): apply BASE_URL prefix to API and favicon paths

### DIFF
--- a/packages/web/src/experiments/console/ConsoleApp.tsx
+++ b/packages/web/src/experiments/console/ConsoleApp.tsx
@@ -57,7 +57,7 @@ export function ConsoleApp(): ReactElement {
       <header className="flex h-12 shrink-0 items-center justify-between border-b border-border px-4">
         <div className="flex items-center gap-2.5">
           <img
-            src="/favicon.png"
+            src={`${(import.meta.env.BASE_URL ?? '/').replace(/\/$/, '')}/favicon.png`}
             alt=""
             aria-hidden="true"
             width={22}

--- a/packages/web/src/experiments/console/lib/http.ts
+++ b/packages/web/src/experiments/console/lib/http.ts
@@ -14,6 +14,17 @@ export const SSE_BASE_URL = import.meta.env.DEV
   ? `http://${window.location.hostname}:${API_PORT}`
   : '';
 
+/**
+ * API path prefix for subpath deployments (e.g. /agent-chat).
+ * In dev, Vite proxy handles /api → backend, so no prefix needed.
+ * In production behind a reverse proxy, requests must include the base path
+ * so the auth-gateway can route /agent-chat/api/* → backend /api/*.
+ * Mirrors API_PREFIX in packages/web/src/lib/api.ts.
+ */
+export const API_PREFIX = import.meta.env.DEV
+  ? ''
+  : (import.meta.env.BASE_URL ?? '/').replace(/\/$/, '');
+
 export class HttpError extends Error {
   readonly status: number;
   readonly path: string;
@@ -51,7 +62,7 @@ export async function requestJson<T>(url: string, options?: RequestInit): Promis
     needsJson ? { 'Content-Type': 'application/json' } : {},
     options?.headers
   );
-  const res = await fetch(url, {
+  const res = await fetch(`${API_PREFIX}${url}`, {
     credentials: 'same-origin',
     ...options,
     headers,

--- a/packages/web/src/experiments/console/skills/runs.ts
+++ b/packages/web/src/experiments/console/skills/runs.ts
@@ -1,4 +1,4 @@
-import { requestJson } from '../lib/http';
+import { API_PREFIX, requestJson } from '../lib/http';
 import { toRun, type Run } from '../primitives/run';
 import { toRunEvent, type RunEvent } from '../primitives/event';
 import type { RunStatus } from '../lib/run-status';
@@ -126,7 +126,9 @@ export async function listRunArtifacts(runId: string): Promise<ArtifactFile[]> {
 /** Fetch a single artifact file as text (markdown or plain). */
 export async function fetchArtifact(runId: string, path: string): Promise<string> {
   const encodedPath = path.split('/').map(encodeURIComponent).join('/');
-  const res = await fetch(`/api/artifacts/${encodeURIComponent(runId)}/${encodedPath}`);
+  const res = await fetch(
+    `${API_PREFIX}/api/artifacts/${encodeURIComponent(runId)}/${encodedPath}`
+  );
   if (!res.ok) {
     const body = (await res.json().catch(() => ({}))) as { error?: string };
     throw new Error(body.error ?? `Failed to fetch artifact: ${res.status.toString()}`);


### PR DESCRIPTION
## Summary

The `experiments/console/` spike was copied from `packages/web/src/lib/api.ts` but omitted the `API_PREFIX` logic. When deployed behind a reverse-proxy under a subpath (e.g. `/agent-chat`), every `/api/*` request fell through to the host root, hit the wrong upstream, and returned the SPA fallback HTML.

User-visible symptom in a `/agent-chat`-based deployment:

```
API error 404 (/api/codebases): <!DOCTYPE html>...
```

Plus a missing logo in the top-left header (the hand-coded `<img src="/favicon.png">` in `ConsoleApp.tsx` had the same root cause — the HTML `<link rel="icon">` works because Vite injects the base at build time, but the React img tag bypasses that).

The Old UI was unaffected because `packages/web/src/lib/api.ts` already handles this correctly via `API_PREFIX` (lines 22-30). This PR mirrors that prefix into the console spike.

## Changes

- `packages/web/src/experiments/console/lib/http.ts` — export `API_PREFIX`, prepend it in `requestJson`
- `packages/web/src/experiments/console/skills/runs.ts` — prepend `API_PREFIX` to `fetchArtifact` URL
- `packages/web/src/experiments/console/ConsoleApp.tsx` — build favicon `src` from `import.meta.env.BASE_URL`

## Compatibility

No effect on root-path deployments — `BASE_URL='/'` strips to `''` so the resulting URLs are identical to before.

## Test plan

- [x] Typecheck clean (`bunx tsc --noEmit -p packages/web`)
- [x] Verified locally on a `/agent-chat`-based deployment: console loads, `/api/codebases` returns JSON, logo renders
- [ ] Reviewer to confirm dev (`BASE_URL='/'`) build still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed console application to work correctly when deployed under a non-root base URL, ensuring proper routing of assets and API requests in reverse proxy setups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coleam00/Archon/pull/1824?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->