### PR TITLE
[codex] Resolve Codex binary from PATH

### DIFF
--- a/packages/providers/src/codex/binary-resolver.test.ts
+++ b/packages/providers/src/codex/binary-resolver.test.ts
@@ -22,10 +22,12 @@ import * as resolver from './binary-resolver';
 
 describe('resolveCodexBinaryPath (binary mode)', () => {
   const originalEnv = process.env.CODEX_BIN_PATH;
+  const originalPath = process.env.PATH;
   let fileExistsSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     delete process.env.CODEX_BIN_PATH;
+    process.env.PATH = originalPath;
     fileExistsSpy?.mockRestore();
     mockLogger.info.mockClear();
   });
@@ -35,6 +37,11 @@ describe('resolveCodexBinaryPath (binary mode)', () => {
       process.env.CODEX_BIN_PATH = originalEnv;
     } else {
       delete process.env.CODEX_BIN_PATH;
+    }
+    if (originalPath !== undefined) {
+      process.env.PATH = originalPath;
+    } else {
+      delete process.env.PATH;
     }
     fileExistsSpy?.mockRestore();
   });
@@ -100,6 +107,21 @@ describe('resolveCodexBinaryPath (binary mode)', () => {
     expect(result).toBe(expected);
     expect(mockLogger.info).toHaveBeenCalledWith(
       { binaryPath: expected, source: 'autodetect' },
+      'codex.binary_resolved'
+    );
+  });
+
+  test('autodetects codex on PATH before canonical install paths', async () => {
+    if (process.platform === 'win32') return; // POSIX-only path shape
+    process.env.PATH = '/usr/bin:/custom/bin';
+    fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation(
+      (path: string) => path === '/usr/bin/codex'
+    );
+
+    const result = await resolver.resolveCodexBinaryPath();
+    expect(result).toBe('/usr/bin/codex');
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { binaryPath: '/usr/bin/codex', source: 'autodetect' },
       'codex.binary_resolved'
     );
   });

--- a/packages/providers/src/codex/binary-resolver.ts
+++ b/packages/providers/src/codex/binary-resolver.ts
@@ -9,7 +9,7 @@
  * 1. `CODEX_BIN_PATH` environment variable
  * 2. `assistants.codex.codexBinaryPath` in config
  * 3. `~/.archon/vendor/codex/<platform-binary>` (user-placed)
- * 4. Autodetect canonical install paths (npm prefix defaults per platform)
+ * 4. Autodetect PATH and canonical install paths (npm prefix defaults per platform)
  * 5. Throw with install instructions
  *
  * In dev mode (BUNDLED_IS_BINARY=false), returns undefined so the SDK
@@ -17,7 +17,7 @@
  */
 import { existsSync as _existsSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
 import { BUNDLED_IS_BINARY, getArchonHome, createLogger } from '@archon/paths';
 
 /** Wrapper for existsSync — enables spyOn in tests (direct imports can't be spied on). */
@@ -99,10 +99,10 @@ export async function resolveCodexBinaryPath(
     }
   }
 
-  // 4. Autodetect — probe the handful of paths Codex typically lands at
-  // when installed via the documented package managers. Users who install
-  // somewhere else (custom npm prefix, etc.) still set one of the higher-
-  // priority sources above. Order: most specific → least specific.
+  // 4. Autodetect — first honor PATH, then probe the handful of paths Codex
+  // typically lands at when installed via the documented package managers.
+  // Users who install somewhere else can still set one of the higher-priority
+  // sources above. Order: most specific → least specific.
   const autodetectPaths = getAutodetectPaths();
   for (const probePath of autodetectPaths) {
     if (fileExists(probePath)) {
@@ -144,14 +144,14 @@ export async function resolveCodexBinaryPath(
  *  - `%AppData%\npm\codex.cmd` — Windows npm global default
  *
  * Not covered (explicit override required via CODEX_BIN_PATH or config):
- *   - users with other custom npm prefixes — `npm root -g` would spawn
- *     a subprocess per resolve, too heavy for a probe helper
+ *   - users with custom npm prefixes that are not on PATH — `npm root -g`
+ *     would spawn a subprocess per resolve, too heavy for a probe helper
  *   - Homebrew cask install (`brew install --cask codex`) — cask layout
  *     isn't a PATH binary; users should symlink or set the path
  *   - manual GitHub Releases extract — placement is user-determined
  */
 function getAutodetectPaths(): string[] {
-  const paths: string[] = [];
+  const paths: string[] = getPathCandidates();
 
   if (process.platform === 'win32') {
     const appData = process.env.APPDATA;
@@ -170,4 +170,20 @@ function getAutodetectPaths(): string[] {
   paths.push('/usr/local/bin/codex');
 
   return paths;
+}
+
+function getPathCandidates(): string[] {
+  const pathEnv = process.env.PATH;
+  if (!pathEnv) return [];
+
+  const names = process.platform === 'win32' ? ['codex.cmd', 'codex.exe', 'codex.bat'] : ['codex'];
+
+  const candidates: string[] = [];
+  for (const dir of pathEnv.split(delimiter)) {
+    if (!dir) continue;
+    for (const name of names) {
+      candidates.push(join(dir, name));
+    }
+  }
+  return candidates;
 }


### PR DESCRIPTION
## Summary
- probe PATH for the Codex executable before fixed fallback locations in compiled builds
- keep existing env/config/vendor precedence intact
- add binary resolver coverage for PATH-based installs such as /usr/bin/codex

## Root cause
The compiled Codex resolver only checked vendor and a few canonical npm/Homebrew locations. On this host Codex is installed at /usr/bin/codex, so the resolver missed it unless CODEX_BIN_PATH or config was set.

## Validation
- bun test packages/providers/src/codex/binary-resolver.test.ts
- bun --filter @archon/providers type-check