### PR TITLE
fix(workflows): add idle_timeout to maintainer-review-pr review node

### DIFF
--- a/.archon/workflows/maintainer/maintainer-review-pr.yaml
+++ b/.archon/workflows/maintainer/maintainer-review-pr.yaml
@@ -105,6 +105,7 @@ nodes:
     depends_on: [fetch-pr, fetch-diff]
     allowed_tools: []
     context: fresh
+    idle_timeout: 60000
     output_format:
       type: object
       properties:


### PR DESCRIPTION
## Summary

- Problem: The review node in the maintainer-review-pr workflow can hang indefinitely when the AI provider idles without producing output
- Why it matters: Idle timeouts cause workflows to stall without any feedback, wasting resources and requiring manual intervention
- What changed: Added `idle_timeout: 60000` (60 seconds) to the review node in `.archon/workflows/maintainer/maintainer-review-pr.yaml`
- What did **not** change: No other workflow nodes or logic were modified

## UX Journey

### Before

```
  Workflow Engine              AI Provider
  ──────────────               ───────────
  dispatches review node ────▶ starts processing
  waits indefinitely ◀───────  (may idle forever)
  (no timeout, hangs)
```

### After

```
  Workflow Engine              AI Provider
  ──────────────               ───────────
  dispatches review node ────▶ starts processing
  [waits 60s max] ◀──────────  completes or idles
  [fails with timeout error]   (if idle >60s)
```

## Architecture Diagram

### Before

```
  ├── fetch-pr ──┐
  ├── fetch-diff ─┤
                  │
                  ├── review (depends_on: [fetch-pr, fetch-diff])
                  │         allowed_tools: []
                  │         context: fresh
                  │
                  └── post-summary (depends_on: [review])
```

### After

```
  ├── fetch-pr ──┐
  ├── fetch-diff ─┤
                  │
                  ├── review (depends_on: [fetch-pr, fetch-diff])
                  │         allowed_tools: []
                  │         context: fresh
                  │[+]      idle_timeout: 60000
                  │
                  └── post-summary (depends_on: [review])
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| fetch-pr | review | unchanged | |
| fetch-diff | review | unchanged | |
| review | post-summary | unchanged | |
| **review node config** | **idle_timeout** | **new** | 60000ms (60s) |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `workflows`
- Module: `workflows:maintainer`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Related #1812 (same class of fix: idle-timeout on DAG nodes)

## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check   # All 10 packages pass
bun run lint          # 0 errors, 0 warnings
bun run format:check  # All files formatted
bun run test          # All packages pass, 0 failures
```

- Evidence provided: All validation commands pass
- If any command is intentionally skipped, explain why: None skipped

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`
- If any `Yes`, describe risk and mitigation: N/A

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: YAML syntax is valid, workflow loads without errors
- Edge cases checked: No schema changes needed (idle_timeout is already a supported field in the DAG node schema)
- What was not verified: Live workflow execution (requires production environment)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Only the `maintainer-review-pr` workflow
- Potential unintended effects: None — idle_timeout is an existing, well-tested mechanism (see #1812)
- Guardrails/monitoring for early detection: The workflow will produce a clear error message on timeout

## Rollback Plan (required)

- Fast rollback command/path: Revert the commit or remove the `idle_timeout` line from the YAML
- Feature flags or config toggles (if any): None
- Observable failure symptoms: Review node may fail with timeout if the AI provider takes >60s to produce output (this is the intended behavior — failing fast is better than hanging)

## Risks and Mitigations

- Risk: The 60s timeout may be too short for very large PR reviews
  - Mitigation: The previous behavior (no timeout) caused indefinite hangs; a 60s timeout is a reasonable starting point. If needed, the value can be adjusted upward based on observed review times.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced stability of the PR review workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->