### PR TITLE
fix(providers/codex): capture thread id from thread.started so session resume works

### DIFF
--- a/packages/docs-web/src/content/docs/reference/architecture.md
+++ b/packages/docs-web/src/content/docs/reference/architecture.md
@@ -500,7 +500,14 @@ for await (const msg of query({ prompt, options })) {
 **Codex SDK** (`packages/providers/src/codex/provider.ts`):
 
 ```typescript
+// A new thread's id is assigned during the run via the thread.started event,
+// not synchronously on startThread() — capture it for a resumable sessionId.
+let resolvedThreadId = thread.id;
 for await (const event of result.events) {
+  if (event.type === 'thread.started') {
+    resolvedThreadId = event.thread_id; // resumable id; persist_session depends on it
+    continue;
+  }
   if (event.type === 'item.completed') {
     switch (event.item.type) {
       case 'agent_message':
@@ -514,7 +521,7 @@ for await (const event of result.events) {
         break;
     }
   } else if (event.type === 'turn.completed') {
-    yield { type: 'result', sessionId: thread.id };
+    yield { type: 'result', sessionId: resolvedThreadId };
     break; // CRITICAL: Exit loop on turn completion
   }
 }

--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -146,6 +146,71 @@ describe('CodexProvider', () => {
       });
     });
 
+    test('captured thread id flows through the turn.failed result', async () => {
+      mockStartThread.mockReturnValue({ id: null, runStreamed: mockRunStreamed });
+      mockRunStreamed.mockResolvedValue({
+        events: (async function* () {
+          yield { type: 'thread.started', thread_id: 'evt-thread-id' };
+          yield { type: 'turn.failed', error: { message: 'boom' } };
+        })(),
+      });
+
+      const chunks = [];
+      for await (const chunk of client.sendQuery('x', '/workspace')) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks.find(c => c.type === 'result')).toMatchObject({
+        type: 'result',
+        sessionId: 'evt-thread-id',
+        isError: true,
+      });
+    });
+
+    test('captured thread id flows through the stream_incomplete result', async () => {
+      mockStartThread.mockReturnValue({ id: null, runStreamed: mockRunStreamed });
+      mockRunStreamed.mockResolvedValue({
+        // Stream closes without turn.completed/turn.failed → fail-stop result.
+        events: (async function* () {
+          yield { type: 'thread.started', thread_id: 'evt-thread-id' };
+        })(),
+      });
+
+      const chunks = [];
+      for await (const chunk of client.sendQuery('x', '/workspace')) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks.find(c => c.type === 'result')).toMatchObject({
+        type: 'result',
+        sessionId: 'evt-thread-id',
+        isError: true,
+        errorSubtype: 'codex_stream_incomplete',
+      });
+    });
+
+    test('an empty thread.started thread_id keeps the snapshot id (guard)', async () => {
+      // Default startThread snapshot id is 'new-thread-id'; an empty event id
+      // must not overwrite it (and would otherwise warn, not emit sessionId: '').
+      mockRunStreamed.mockResolvedValue({
+        events: (async function* () {
+          yield { type: 'thread.started', thread_id: '' };
+          yield { type: 'item.completed', item: { type: 'agent_message', text: 'ok' } };
+          yield { type: 'turn.completed', usage: defaultUsage };
+        })(),
+      });
+
+      const chunks = [];
+      for await (const chunk of client.sendQuery('x', '/workspace')) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks.find(c => c.type === 'result')).toMatchObject({
+        type: 'result',
+        sessionId: 'new-thread-id',
+      });
+    });
+
     test('yields tool events from command_execution items', async () => {
       mockRunStreamed.mockResolvedValue({
         events: (async function* () {
@@ -600,8 +665,9 @@ describe('CodexProvider', () => {
         })(),
       });
 
-      for await (const _ of client.sendQuery('test prompt', '/workspace', 'existing-thread')) {
-        // consume
+      const chunks = [];
+      for await (const chunk of client.sendQuery('test prompt', '/workspace', 'existing-thread')) {
+        chunks.push(chunk);
       }
 
       expect(mockResumeThread).toHaveBeenCalledWith(
@@ -615,6 +681,10 @@ describe('CodexProvider', () => {
         })
       );
       expect(mockStartThread).not.toHaveBeenCalled();
+      // No thread.started re-fires on resume → the snapshot (resumeThread's id) survives.
+      expect(chunks.find(c => c.type === 'result')).toMatchObject({
+        sessionId: 'resumed-thread-id',
+      });
     });
 
     test('falls back to new thread when resume fails and notifies user', async () => {

--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -117,6 +117,35 @@ describe('CodexProvider', () => {
       });
     });
 
+    test('captures the new-thread id from the thread.started event (resumable sessionId)', async () => {
+      // The real Codex SDK assigns a NEW thread's id during the run, via the
+      // thread.started event — not synchronously on startThread(). Simulate a
+      // thread whose .id is still null and assert the result carries the id from
+      // the event, so persist_session / suspend-resume have a resumable id.
+      mockStartThread.mockReturnValue({ id: null, runStreamed: mockRunStreamed });
+      mockRunStreamed.mockResolvedValue({
+        events: (async function* () {
+          yield { type: 'thread.started', thread_id: 'evt-thread-id' };
+          yield {
+            type: 'item.completed',
+            item: { type: 'agent_message', text: 'stored' },
+          };
+          yield { type: 'turn.completed', usage: defaultUsage };
+        })(),
+      });
+
+      const chunks = [];
+      for await (const chunk of client.sendQuery('remember X', '/workspace')) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks[chunks.length - 1]).toEqual({
+        type: 'result',
+        sessionId: 'evt-thread-id',
+        tokens: { input: 10, output: 5 },
+      });
+    });
+
     test('yields tool events from command_execution items', async () => {
       mockRunStreamed.mockResolvedValue({
         events: (async function* () {

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -315,6 +315,14 @@ async function* streamCodexEvents(
   const state: CodexStreamState = {};
   let accumulatedText = '';
 
+  // For a NEW thread the snapshot `threadId` passed in is null — the Codex SDK
+  // only assigns the thread id during the run, via the `thread.started` event
+  // handled below. Capture it so the terminal result chunk surfaces a resumable
+  // sessionId; persist_session and suspend/resume both depend on it. For a
+  // resumed thread the snapshot is already the id (thread.started may or may not
+  // re-fire), so the captured value stays correct either way.
+  let resolvedThreadId: string | null | undefined = threadId;
+
   if (abortSignal?.aborted) {
     getLog().info('query_aborted_before_stream');
     throw new Error('Query aborted');
@@ -331,6 +339,18 @@ async function* streamCodexEvents(
     if (abortSignal?.aborted) {
       getLog().info('query_aborted_between_events');
       throw new Error('Query aborted');
+    }
+
+    if (event.type === 'thread.started') {
+      // ThreadStartedEvent.thread_id — "can be used to resume the thread later"
+      // (@openai/codex-sdk index.d.ts). This is the only place a new thread's id
+      // surfaces, so capture it for the result chunk's sessionId.
+      const startedThreadId = (event as { thread_id?: string }).thread_id;
+      if (typeof startedThreadId === 'string' && startedThreadId.length > 0) {
+        resolvedThreadId = startedThreadId;
+        getLog().debug({ threadId: startedThreadId }, 'codex.thread_started');
+      }
+      continue;
     }
 
     if (event.type === 'item.started') {
@@ -367,7 +387,7 @@ async function* streamCodexEvents(
       getLog().error({ errorMessage }, 'turn_failed');
       yield {
         type: 'result',
-        sessionId: threadId ?? undefined,
+        sessionId: resolvedThreadId ?? undefined,
         isError: true,
         errorSubtype: 'codex_turn_failed',
         errors: [errorMessage],
@@ -563,7 +583,7 @@ async function* streamCodexEvents(
 
       yield {
         type: 'result',
-        sessionId: threadId ?? undefined,
+        sessionId: resolvedThreadId ?? undefined,
         tokens: usage,
         ...(structuredOutput !== undefined ? { structuredOutput } : {}),
       };
@@ -583,7 +603,7 @@ async function* streamCodexEvents(
   getLog().error({ message }, 'stream_incomplete');
   yield {
     type: 'result',
-    sessionId: threadId ?? undefined,
+    sessionId: resolvedThreadId ?? undefined,
     isError: true,
     errorSubtype: 'codex_stream_incomplete',
     errors: [message],

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -8,6 +8,7 @@ import {
   type ThreadOptions,
   type TurnOptions,
   type TurnCompletedEvent,
+  type ThreadStartedEvent,
 } from '@openai/codex-sdk';
 import type {
   IAgentProvider,
@@ -315,12 +316,11 @@ async function* streamCodexEvents(
   const state: CodexStreamState = {};
   let accumulatedText = '';
 
-  // For a NEW thread the snapshot `threadId` passed in is null — the Codex SDK
-  // only assigns the thread id during the run, via the `thread.started` event
-  // handled below. Capture it so the terminal result chunk surfaces a resumable
-  // sessionId; persist_session and suspend/resume both depend on it. For a
-  // resumed thread the snapshot is already the id (thread.started may or may not
-  // re-fire), so the captured value stays correct either way.
+  // A new thread's id is assigned during the run via the `thread.started` event
+  // (the SDK emits it only for new threads), not synchronously on startThread().
+  // Capture it so the terminal result chunk surfaces a resumable sessionId —
+  // persist_session and suspend/resume depend on it. A resumed thread keeps the
+  // snapshot id (no thread.started fires), so the seeded value stays correct.
   let resolvedThreadId: string | null | undefined = threadId;
 
   if (abortSignal?.aborted) {
@@ -342,13 +342,21 @@ async function* streamCodexEvents(
     }
 
     if (event.type === 'thread.started') {
-      // ThreadStartedEvent.thread_id — "can be used to resume the thread later"
-      // (@openai/codex-sdk index.d.ts). This is the only place a new thread's id
-      // surfaces, so capture it for the result chunk's sessionId.
-      const startedThreadId = (event as { thread_id?: string }).thread_id;
-      if (typeof startedThreadId === 'string' && startedThreadId.length > 0) {
+      // Capture the new thread's id. Its SDK doc comment reads: "The identifier
+      // of the new thread. Can be used to resume the thread later." This is the
+      // only place a new thread's id surfaces. `continue` — the event carries no
+      // user-facing content, only this metadata.
+      const startedThreadId = (event as ThreadStartedEvent).thread_id;
+      if (startedThreadId) {
         resolvedThreadId = startedThreadId;
-        getLog().debug({ threadId: startedThreadId }, 'codex.thread_started');
+        getLog().info({ threadId: startedThreadId }, 'codex.thread_started');
+      } else {
+        // The SDK types thread_id as a non-empty string, so this should never
+        // fire. If it does, a new thread would surface sessionId: undefined and
+        // the dag-executor would treat the run as session-less — silently
+        // dropping any persist_session continuity. Warn rather than degrade
+        // quietly (CLAUDE.md: Fail Fast + Explicit Errors).
+        getLog().warn({ snapshotThreadId: resolvedThreadId }, 'codex.thread_started_missing_id');
       }
       continue;
     }


### PR DESCRIPTION
## Summary

- **Problem:** `CodexProvider` read `thread.id` *before* consuming the SDK event stream and emitted that snapshot as the result chunk's `sessionId`. For a **new** thread the Codex SDK only assigns the id *during* the run — via the `thread.started` event (whose own type comment in `@openai/codex-sdk` reads *"can be used to resume the thread later"*) — so the snapshot was `null` and **Codex returned no `sessionId` at all**.
- **Why it matters:** a missing `sessionId` silently breaks **session resume on Codex** — `persist_session` nodes never get an id to persist, and the planned suspend/resume primitive can't re-thread. It also meant warm-resume "only worked on Claude"; this is what makes it work cross-provider.
- **What changed:** capture `thread_id` from the `thread.started` event inside `streamCodexEvents` and use it for every result emission (`turn.completed`, `turn.failed`, `stream_incomplete`), keeping the snapshot as the fallback for the resume case where the id is already known.
- **What did NOT change (scope boundary):** Codex-provider only. No contract/schema change, no behavior change for resumed threads (snapshot already carries the id), no change to any other provider.

## UX Journey

### Before

```
startThread()  →  thread.id = null   ──snapshot──▶  result.sessionId = undefined
   run streams … thread.started{thread_id} (ignored)        ▼
                                                  persist_session / resume: no id  ✗
```

### After

```
startThread()  →  thread.id = null
   run streams … thread.started{thread_id: "th_…"}  ──captured──▶  result.sessionId = "th_…"  ✓
```

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `providers`, `tests`
- Module: `providers:codex`

## Change Metadata

- Change type: `bug`
- Primary scope: `providers`

## Linked Issue

- Related: cross-provider warm session-resume for the workflow pause/resume effort. No single tracking issue.

## Validation Evidence (required)

```bash
bun --filter @archon/providers type-check          # ✅
bun x eslint packages/providers/src/codex/provider.ts   # ✅ clean
bun test packages/providers/src/codex/provider.test.ts  # ✅ 60 pass (incl. new thread.started test)
```

- **Live-verified** (Codex `gpt-5.5`, ChatGPT-account auth) with an in-process two-turn probe on a fixed cwd: turn 1 plants an unguessable token and now returns a `sessionId` (`019e86d8-…`, was `NONE`); turn 2 resumes that session and recalls `ZEPHYR-QUOKKA-5291` — **context survives**. Same probe confirms Pi (`minimax/MiniMax-M2.7`) and Claude (`sonnet`) already survive, so all three in-process providers warm-resume.

## Security Impact (required)

- New permissions/capabilities? No.
- New external network calls? No.
- Secrets/tokens handling changed? No.
- File system access scope changed? No.

## Compatibility / Migration

- Backward compatible? **Yes** — resumed threads already carried the id (snapshot); this only *adds* the id for new threads that previously returned none.
- Config/env changes? No.
- Database migration needed? No.

## Human Verification (required)

- Verified: new test (null `thread.id` + `thread.started` event → `result.sessionId === 'evt-thread-id'`); live two-turn resume on Codex `gpt-5.5` recalls the planted token; existing 59 Codex tests still green (snapshot path unchanged).
- Edge cases: resumed thread (snapshot already set, no `thread.started` re-fire needed); `turn.failed` and `stream_incomplete` result chunks now also carry the captured id.
- Not verified: OpenCode (separate provider, not in scope here).

## Side Effects / Blast Radius (required)

- Affected: `streamCodexEvents` result emissions in `@archon/providers/codex`. Consumed by the orchestrator and dag-executor as `MessageChunk.result.sessionId` (session persistence / `persist_session`).
- Potential unintended effects: a result that previously had `sessionId: undefined` now has a real id — strictly more information; downstream already treats `sessionId` as optional.
- Guardrails: `codex.thread_started` debug log records the captured id.

## Rollback Plan (required)

- Fast rollback: revert the single commit. No persisted state, no migration.
- Observable failure symptoms: Codex result chunks returning `sessionId: undefined` again (resume regressing).

## Risks and Mitigations

- Risk: a stale snapshot id overriding the event id on resume → Mitigation: the snapshot is only the *initial* value; `thread.started` (when present) overwrites it; for resumed threads where no `thread.started` fires, the snapshot is the correct resume id.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure resumed sessions use the actual runtime thread/session ID emitted by the provider, preventing incorrect IDs from snapshots.

* **Tests**
  * Added regression tests covering resumable-session scenarios, verifying correct session/thread ID resolution for completed, failed, and incomplete streams.

* **Documentation**
  * Updated streaming example to demonstrate capturing and using the resolved thread/session ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->