### PR TITLE
feat(cli): cross-provider run management — get/runs/--json/--detach, manage-run skill, orchestrator delivery

### DIFF
--- a/.claude/skills/archon/references/cli-commands.md
+++ b/.claude/skills/archon/references/cli-commands.md
@@ -77,7 +77,7 @@ An unregistered cwd falls back to a global list with a `(not a registered projec
 
 ### `archon workflow get <run-id> [--verbose]`
 
-Show detail for **one run, any status** (status, working path, error). `--verbose` adds a per-node summary from the event log (and, in `--json`, an `events` array). `--json` emits the raw run object; not found → `{ "error": "not_found", "runId": "…" }`.
+Show detail for **one run, any status** (status, working path, error). `--verbose` adds a per-node summary from the event log (and, in `--json`, an `events` array). `--json` emits the raw run object on success; on failure (not found, DB error) it emits one `{ "ok": false, "runId": "…", "error": "…" }` line and never throws (`error` is `"not_found"` for a missing run).
 
 ```bash
 archon workflow get abc123

--- a/.claude/skills/archon/references/cli-commands.md
+++ b/.claude/skills/archon/references/cli-commands.md
@@ -34,7 +34,7 @@ archon workflow run archon-assist "Investigate the flaky test" --detach
 | `--from <name>` / `--from-branch <name>` | Start-point branch for new worktree (default: repo default branch) |
 | `--no-worktree` | Skip isolation — run in the live checkout |
 | `--resume` | Resume the last failed run of this workflow at this cwd (skips completed nodes) |
-| `--detach` | Run in a detached background child and return immediately (find the run via `workflow runs`). Pair with `--json` for a structured ack. Child output goes to `~/.archon/logs/`. |
+| `--detach` | Run in a detached background child and return immediately (find the run via `workflow runs`). Pair with `--json` for a structured ack. Child output goes to `~/.archon/logs/`. In the web console the run appears in the Workflow dock (listed by project) but may not update **live** until a refetch — it runs out-of-process and doesn't stream to the console's live event feed. |
 | `--cwd <path>` | Working directory override |
 
 **Flag conflicts** (errors):

--- a/.claude/skills/archon/references/cli-commands.md
+++ b/.claude/skills/archon/references/cli-commands.md
@@ -25,6 +25,7 @@ archon workflow run archon-fix-github-issue --branch fix/issue-42 "Fix issue #42
 archon workflow run my-workflow --branch feat/dark-mode --from develop "Add dark mode"
 archon workflow run quick-fix --no-worktree "Fix the typo in README"
 archon workflow run archon-fix-github-issue --resume
+archon workflow run archon-assist "Investigate the flaky test" --detach
 ```
 
 | Flag | Description |
@@ -33,6 +34,7 @@ archon workflow run archon-fix-github-issue --resume
 | `--from <name>` / `--from-branch <name>` | Start-point branch for new worktree (default: repo default branch) |
 | `--no-worktree` | Skip isolation — run in the live checkout |
 | `--resume` | Resume the last failed run of this workflow at this cwd (skips completed nodes) |
+| `--detach` | Run in a detached background child and return immediately (find the run via `workflow runs`). Pair with `--json` for a structured ack. Child output goes to `~/.archon/logs/`. |
 | `--cwd <path>` | Working directory override |
 
 **Flag conflicts** (errors):
@@ -46,14 +48,44 @@ archon workflow run archon-fix-github-issue --resume
 
 ### `archon workflow status`
 
-Show the currently running workflow (if any) with its run ID, state, and last activity.
+Show **active** workflow runs (running + paused) with run ID, state, and last activity. Add `--verbose` for a per-node summary.
 
 ```bash
 archon workflow status
 archon workflow status --json       # Machine-readable output
 ```
 
-### `archon workflow approve <run-id> [comment]`
+### `archon workflow runs [--all] [--status <s>] [--limit <n>]`
+
+List **recent** runs of **all** statuses, scoped to the current project (cwd → codebase). Complements `status`, which is active-only — use this to answer "did the review pass?" for a completed/failed run.
+
+```bash
+archon workflow runs                 # recent runs (all statuses) for this project
+archon workflow runs --json          # machine-readable (full dashboard result + counts)
+archon workflow runs --status failed --limit 50
+archon workflow runs --all           # across all projects (ignore cwd scope)
+```
+
+| Flag | Description |
+|------|-------------|
+| `--all` | List across all projects (drop the cwd→codebase scope) |
+| `--status <s>` | Filter to one status: `pending`, `running`, `completed`, `failed`, `cancelled`, `paused` |
+| `--limit <n>` | Max rows (default 20) |
+| `--json` | Emit the full `{ runs, total, counts }` dashboard result |
+
+An unregistered cwd falls back to a global list with a `(not a registered project — showing all runs)` note (never a silent wrong scope).
+
+### `archon workflow get <run-id> [--verbose]`
+
+Show detail for **one run, any status** (status, working path, error). `--verbose` adds a per-node summary from the event log (and, in `--json`, an `events` array). `--json` emits the raw run object; not found → `{ "error": "not_found", "runId": "…" }`.
+
+```bash
+archon workflow get abc123
+archon workflow get abc123 --json
+archon workflow get abc123 --verbose --json
+```
+
+### `archon workflow approve <run-id> [comment] [--json]`
 
 Approve a paused approval-node workflow. Auto-resumes the workflow.
 
@@ -61,13 +93,16 @@ Approve a paused approval-node workflow. Auto-resumes the workflow.
 archon workflow approve abc123
 archon workflow approve abc123 --comment "Plan looks good"
 archon workflow approve abc123 "Plan looks good"   # positional form
+archon workflow approve abc123 "Plan looks good" --json   # records the decision; does NOT auto-resume
 ```
+
+> **`--json` on `approve`/`reject`/`resume` records/validates the decision and returns a clean JSON line WITHOUT the inline auto-resume** (execution streams output that would corrupt the JSON). The run becomes resumable — drive it to completion with a backgrounded `archon workflow resume <id>` (no `--json`), or drop `--json` to approve-and-resume in one blocking call.
 
 For interactive loop nodes, the comment becomes `$LOOP_USER_INPUT` on the next iteration. For approval nodes with `capture_response: true`, the comment becomes `$<gate-id>.output` for downstream nodes.
 
-### `archon workflow reject <run-id> [reason]`
+### `archon workflow reject <run-id> [reason] [--json]`
 
-Reject a paused approval gate. Without `on_reject` on the node, cancels the workflow. With `on_reject`, runs the rework prompt with `$REJECTION_REASON` substituted and re-pauses.
+Reject a paused approval gate. Without `on_reject` on the node, cancels the workflow. With `on_reject`, runs the rework prompt with `$REJECTION_REASON` substituted and re-pauses. (`--json` records the decision without the inline rework — see the note under `approve`.)
 
 ```bash
 archon workflow reject abc123
@@ -75,19 +110,20 @@ archon workflow reject abc123 --reason "Plan misses test coverage"
 archon workflow reject abc123 "Plan misses test coverage"
 ```
 
-### `archon workflow abandon <run-id>`
+### `archon workflow abandon <run-id> [--json]`
 
 Mark a non-terminal workflow run as cancelled. Use when a `running` row is stuck after a server crash or when you want to discard a paused run without rejecting. This does NOT kill an in-flight subprocess — it only transitions the DB row.
 
 ```bash
 archon workflow abandon abc123
+archon workflow abandon abc123 --json   # { "ok": true, "runId": "abc123", "action": "abandon", "status": "cancelled", ... }
 ```
 
 > **There is no `archon workflow cancel` CLI subcommand.** To actively cancel a running workflow (terminate its subprocess), use the chat slash command `/workflow cancel <run-id>` on the platform that started it (Web UI, Slack, Telegram, etc.), or the Cancel button on the Web UI dashboard. The CLI only offers `abandon`, which is the right tool for orphan cleanup but does not interrupt a live subprocess.
 
-### `archon workflow resume <run-id> [message]`
+### `archon workflow resume <run-id> [message] [--json]`
 
-Explicitly re-run a failed run. Most workflows auto-resume without this — use it when you want to force a specific run ID.
+Explicitly re-run a failed run. Most workflows auto-resume without this — use it when you want to force a specific run ID. (`--json` validates that the run is resumable and returns `executed: false` WITHOUT running — see the note under `approve`; to actually execute, use the blocking form as a background task.)
 
 ```bash
 archon workflow resume abc123

--- a/.claude/skills/archon/references/cli-commands.md
+++ b/.claude/skills/archon/references/cli-commands.md
@@ -71,9 +71,9 @@ archon workflow runs --all           # across all projects (ignore cwd scope)
 | `--all` | List across all projects (drop the cwd→codebase scope) |
 | `--status <s>` | Filter to one status: `pending`, `running`, `completed`, `failed`, `cancelled`, `paused` |
 | `--limit <n>` | Max rows (default 20) |
-| `--json` | Emit the full `{ runs, total, counts }` dashboard result |
+| `--json` | Emit the full `{ runs, total, counts, scopeFallback }` dashboard result |
 
-An unregistered cwd falls back to a global list with a `(not a registered project — showing all runs)` note (never a silent wrong scope).
+An unregistered cwd (or a codebase lookup failure) falls back to a global list with a `(not a registered project — showing all runs)` note (never a silent wrong scope). In `--json`, `scopeFallback: true` flags that the result is global rather than the requested project scope.
 
 ### `archon workflow get <run-id> [--verbose]`
 

--- a/.claude/skills/manage-run/SKILL.md
+++ b/.claude/skills/manage-run/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: manage-run
+description: |
+  Use when: User wants to INSPECT, MONITOR, START, APPROVE, or CONTROL Archon
+  workflow RUNS in the current project — driven through the `archon` CLI over bash.
+  Triggers (inspect): "what's running", "list runs", "show recent runs", "run status",
+            "did the review pass", "check run <id>", "show me run <id>", "what happened in that run".
+  Triggers (control): "approve the plan", "approve run <id>", "reject that run", "cancel that run",
+            "abandon run <id>", "resume run <id>", "continue that run".
+  Triggers (start): "start <workflow> in the background", "kick off <workflow> detached".
+  Capability: Drives `archon workflow runs/get/status/run --detach/approve/reject/abandon/resume`
+            with machine-readable `--json` output, scoped to the current project by cwd.
+  NOT for: Authoring workflows/commands, or Archon setup/config — use the broader `archon` skill.
+argument-hint: "[run-id or workflow] [comment]"
+---
+
+# Manage Archon Runs
+
+A focused skill for **managing workflow runs** through the `archon` CLI. It assumes
+Archon is already installed and you are working **inside the project repo** — the
+current directory scopes every command to that project automatically. For authoring
+workflows, setup, or config, use the broader **`archon`** skill instead.
+
+## Recent runs (live)
+
+!`archon workflow runs --limit 10 2>&1 || echo "Archon CLI not installed. (This skill needs the archon CLI on PATH.)"`
+
+## How output works
+
+- Add `--json` to any command for a **single clean JSON object on stdout** (logs are
+  suppressed automatically in `--json` mode). Prefer `--json` when you will parse the result.
+- Without `--json` you get human-readable text. Diagnostics/warnings always go to stderr.
+- The current directory (cwd) determines which project's runs you see. Run from the repo.
+
+## Verbs
+
+| Goal | Command |
+|------|---------|
+| **List recent runs** (all statuses, this project) | `archon workflow runs --json` |
+| List across **all** projects | `archon workflow runs --all --json` |
+| Filter by status / cap rows | `archon workflow runs --status running --limit 50 --json` |
+| **Show one run** (status, error) | `archon workflow get <run-id> --json` |
+| One run **with per-node detail** | `archon workflow get <run-id> --verbose --json` |
+| **Active** runs only (running/paused) | `archon workflow status --json` |
+| **Start** a run, non-blocking | `archon workflow run <workflow> "<message>" --detach` |
+| **Approve** a paused gate | `archon workflow approve <run-id> "looks good" --json` |
+| **Reject** a paused gate | `archon workflow reject <run-id> "fix X first" --json` |
+| **Cancel** a non-terminal run | `archon workflow abandon <run-id> --json` |
+
+> There is no separate `cancel` verb — `abandon` cancels a non-terminal run by id.
+
+## Patterns
+
+### Monitor a run to completion
+```bash
+archon workflow runs --json                 # find the run id
+archon workflow get <run-id> --json         # poll status: running | completed | failed | paused
+```
+A run is finished when `status` is `completed`, `failed`, or `cancelled`.
+
+### Start work without blocking
+```bash
+archon workflow run archon-assist "Investigate the flaky test" --detach
+# returns immediately; the run then appears in `archon workflow runs`
+```
+`--detach` runs the workflow in a background child. The parent can't print the new
+run id (it's created in the child) — find it with `archon workflow runs`. If the run
+never appears, check the child log path printed by the command (or the `logPath`
+field in `--detach --json`).
+
+### Approve or reject a paused run (two steps)
+`--json` approve/reject/resume **record the decision** (the run becomes resumable) but
+do **not** execute the workflow — execution streams output that would corrupt the JSON.
+So:
+```bash
+archon workflow approve <run-id> "ship it" --json   # records the approval (resumable: true)
+archon workflow resume <run-id>                      # execute it — run this as a BACKGROUND task
+archon workflow get <run-id> --json                  # poll until completed/failed
+```
+If you only need to record the decision (e.g. cancel via reject) and don't need to
+drive the run forward, the `--json` step alone is enough. To approve **and** continue
+in one blocking call, drop `--json`: `archon workflow approve <run-id> "ship it"`
+auto-resumes (run it as a background task).
+
+## Reference
+
+For the full flag list and JSON shapes of each verb: read `references/commands.md`.

--- a/.claude/skills/manage-run/SKILL.md
+++ b/.claude/skills/manage-run/SKILL.md
@@ -68,6 +68,13 @@ run id (it's created in the child) — find it with `archon workflow runs`. If t
 never appears, check the child log path printed by the command (or the `logPath`
 field in `--detach --json`).
 
+> **Console UI note:** a detached run *does* appear in the web console's Workflow dock
+> (the dock lists runs by project), but its progress may **not update live** — detached
+> runs execute in a separate process and don't stream to the console's live event feed,
+> so the dock catches up on its next refetch rather than in real time. Tell the user to
+> refresh if they want the latest state. (Re-running progress live for CLI-started runs
+> is a tracked follow-up.)
+
 ### Approve or reject a paused run (two steps)
 `--json` approve/reject/resume **record the decision** (the run becomes resumable) but
 do **not** execute the workflow — execution streams output that would corrupt the JSON.

--- a/.claude/skills/manage-run/references/commands.md
+++ b/.claude/skills/manage-run/references/commands.md
@@ -36,7 +36,7 @@ active-only).
 Detail for **one run, any status**.
 
 - `--verbose` — also derive a per-node summary from the event log (and, in `--json`, attach the raw `events` array).
-- `--json` emits the raw run object; not found → `{ "error": "not_found", "runId": "…" }`.
+- `--json` emits the raw run object on success; on failure (not found, DB error) it emits one `{ "ok": false, "runId": "…", "error": "…" }` line and never throws (`error` is `"not_found"` for a missing run).
 
 ```json
 { "id": "…", "workflow_name": "archon-assist", "status": "failed",

--- a/.claude/skills/manage-run/references/commands.md
+++ b/.claude/skills/manage-run/references/commands.md
@@ -16,7 +16,7 @@ active-only).
 - `--all` — drop the project scope; list runs across every project.
 - `--status <s>` — filter to one status: `pending | running | completed | failed | cancelled | paused`.
 - `--limit <n>` — max rows (default 20).
-- Unregistered cwd: falls back to a global list and prints a `(not a registered project — showing all runs)` note (never a silent wrong scope).
+- Unregistered cwd (or a codebase lookup failure): falls back to a global list and prints a `(not a registered project — showing all runs)` note (never a silent wrong scope). In `--json` this is the `scopeFallback` field — `true` means the result is global, not the project scope you asked for.
 
 `--json` shape — the dashboard result:
 ```json
@@ -28,7 +28,8 @@ active-only).
   ],
   "total": 87,
   "counts": { "all": 87, "running": 1, "completed": 70, "failed": 12,
-              "cancelled": 3, "pending": 0, "paused": 1 }
+              "cancelled": 3, "pending": 0, "paused": 1 },
+  "scopeFallback": false
 }
 ```
 
@@ -37,6 +38,7 @@ Detail for **one run, any status**.
 
 - `--verbose` — also derive a per-node summary from the event log (and, in `--json`, attach the raw `events` array).
 - `--json` emits the raw run object on success; on failure (not found, DB error) it emits one `{ "ok": false, "runId": "…", "error": "…" }` line and never throws (`error` is `"not_found"` for a missing run).
+- Exit code is non-zero when the run is not found (so `archon workflow get <id> && …` and CI checks react to a missing run); `0` on success.
 
 ```json
 { "id": "…", "workflow_name": "archon-assist", "status": "failed",

--- a/.claude/skills/manage-run/references/commands.md
+++ b/.claude/skills/manage-run/references/commands.md
@@ -1,0 +1,124 @@
+# Manage-Run Command Reference
+
+Every command runs through the `archon` CLI and is scoped to the current project by
+the working directory. Add `--json` for a single clean JSON object on stdout (logs
+are suppressed in `--json` mode); omit it for human-readable text. Diagnostics go to
+stderr either way.
+
+---
+
+## Read
+
+### `archon workflow runs [--all] [--status <s>] [--limit <n>] [--json]`
+Recent runs of **all statuses** for this project (complements `status`, which is
+active-only).
+
+- `--all` — drop the project scope; list runs across every project.
+- `--status <s>` — filter to one status: `pending | running | completed | failed | cancelled | paused`.
+- `--limit <n>` — max rows (default 20).
+- Unregistered cwd: falls back to a global list and prints a `(not a registered project — showing all runs)` note (never a silent wrong scope).
+
+`--json` shape — the dashboard result:
+```json
+{
+  "runs": [
+    { "id": "…", "workflow_name": "archon-assist", "status": "completed",
+      "current_step_name": "review", "total_steps": 4, "started_at": "…",
+      "codebase_name": "…", "working_path": "…" }
+  ],
+  "total": 87,
+  "counts": { "all": 87, "running": 1, "completed": 70, "failed": 12,
+              "cancelled": 3, "pending": 0, "paused": 1 }
+}
+```
+
+### `archon workflow get <run-id> [--verbose] [--json]`
+Detail for **one run, any status**.
+
+- `--verbose` — also derive a per-node summary from the event log (and, in `--json`, attach the raw `events` array).
+- `--json` emits the raw run object; not found → `{ "error": "not_found", "runId": "…" }`.
+
+```json
+{ "id": "…", "workflow_name": "archon-assist", "status": "failed",
+  "working_path": "…", "started_at": "…", "completed_at": "…",
+  "metadata": { "error": "Step failed: review" } }
+```
+With `--verbose --json`: `{ …run, "events": [ … ] }`.
+
+### `archon workflow status [--verbose] [--json]`
+**Active** runs only (running + paused). `--json` → `{ "runs": [ … ] }`.
+
+---
+
+## Start
+
+### `archon workflow run <workflow> "<message>" --detach [--json]`
+Run a workflow in a **detached background child**; returns immediately.
+
+- The parent pins a generated branch + conversation id on the child so exactly one
+  worktree/conversation is created. It **cannot** report the new run id (created in the
+  child) — find it via `archon workflow runs`.
+- Combine with the normal `run` flags (`--branch`, `--no-worktree`, `--from`, `--resume`).
+- Child stdout/stderr are written to a per-conversation log file under
+  `~/.archon/logs/`; the path is printed (and is the `logPath` field in `--json`).
+
+`--detach --json` shape:
+```json
+{ "ok": true, "action": "run", "detached": true, "workflow": "archon-assist",
+  "branch": "archon-assist-1780000000000", "conversationId": "cli-…",
+  "logPath": "/Users/you/.archon/logs/detached-run-cli-….log" }
+```
+
+---
+
+## Control
+
+These four accept `--json`. **In `--json` mode they record/validate the decision and
+return — they do NOT execute the workflow inline** (execution streams output that would
+corrupt the JSON). The error path always returns `{ "ok": false, "runId": …, "error": … }`
+instead of throwing, so a parser always gets one JSON line.
+
+### `archon workflow approve <run-id> [comment] [--json]`
+Approve a paused gate (approval node or interactive loop).
+```json
+{ "ok": true, "runId": "…", "action": "approve",
+  "type": "approval_gate", "workflowName": "…", "resumable": true }
+```
+Non-`--json`: records the approval **and auto-resumes** (blocking — run as a background task).
+
+### `archon workflow reject <run-id> [reason] [--json]`
+Reject a paused gate. `cancelled: false` means an `on_reject` rework pass is queued
+(run is resumable); `cancelled: true` ends the run.
+```json
+{ "ok": true, "runId": "…", "action": "reject", "cancelled": false,
+  "maxAttemptsReached": false, "workflowName": "…", "resumable": true }
+```
+
+### `archon workflow abandon <run-id> [--json]`
+Cancel a non-terminal run. (There is no separate `cancel` verb.)
+```json
+{ "ok": true, "runId": "…", "action": "abandon", "status": "cancelled", "workflowName": "…" }
+```
+
+### `archon workflow resume <run-id> [--json]`
+Re-run a failed/paused run, skipping completed nodes.
+
+- **Without `--json`**: executes (blocking — run as a background task), then poll with `get`.
+- **With `--json`**: validates the run is resumable and returns `executed: false` **without
+  running** — to actually execute, use the blocking form (background) or `run <name> --resume --detach`.
+```json
+{ "ok": true, "runId": "…", "action": "resume", "executed": false,
+  "status": "failed", "workflowName": "…", "workingPath": "…" }
+```
+
+---
+
+## Continuation model (paused → done)
+
+```bash
+archon workflow approve <run-id> "ship it" --json   # 1. record decision (fast, parseable)
+archon workflow resume  <run-id>                    # 2. execute — run as a BACKGROUND task
+archon workflow get     <run-id> --json             # 3. poll until completed/failed/cancelled
+```
+Or, to approve and continue in one (blocking) call, drop `--json` from step 1 — it
+auto-resumes. A run is finished when `status` is `completed`, `failed`, or `cancelled`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,14 +203,32 @@ bun run cli workflow run implement --branch feature-auth "Add auth"
 # Opt out of isolation (run in live checkout)
 bun run cli workflow run quick-fix --no-worktree "Fix typo"
 
-# Show running workflows
+# Run in a detached background child (returns immediately; find it via `workflow runs`)
+bun run cli workflow run implement "Add auth" --detach
+
+# Show active runs (running + paused)
 bun run cli workflow status
+
+# List recent runs of ALL statuses, scoped to this project's codebase (cwd)
+bun run cli workflow runs
+bun run cli workflow runs --json                 # machine-readable { runs, total, counts }
+bun run cli workflow runs --status failed --limit 50
+bun run cli workflow runs --all                  # across all projects
+
+# Show detail for one run (any status); --verbose adds per-node summary
+bun run cli workflow get <run-id>
+bun run cli workflow get <run-id> --json
 
 # Resume a failed workflow (re-runs, skipping completed nodes)
 bun run cli workflow resume <run-id>
 
 # Discard a non-terminal run
 bun run cli workflow abandon <run-id>
+
+# Most read/write subcommands accept --json for machine-readable output:
+#   list, status, runs, get, approve, reject, abandon, resume.
+# For approve/reject/resume, --json records/validates the decision and returns a
+# clean JSON line WITHOUT the inline auto-resume (drive continuation separately).
 
 # Delete old workflow run records (default: 7 days)
 bun run cli workflow cleanup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -497,7 +497,7 @@ import type { DagNode, WorkflowDefinition } from '@/lib/api';
 - Variable substitution: `$1`, `$2`, `$3`, `$ARGUMENTS`
 - Session management: Create new or resume existing
 - Stream AI responses to platform
-- System prompt includes a "Managing Workflow Runs" section (`buildRunManagementSection` in `prompt-builder.ts`) so the chat agent on **any** provider can drive run management (`archon workflow runs/get/status/run --detach/approve/reject/abandon`) directly via bash. This is the cross-provider delivery of the `manage-run` skill — direct chat doesn't consume the `skills:` option (workflow-node-only), and Codex has no skills capability, so the system prompt is the only channel that reaches all five providers.
+- System prompt gets a "Managing Workflow Runs" section (`buildRunManagementSection` in `prompt-builder.ts`) teaching the chat agent to drive run management (`archon workflow runs/get/status/run --detach/approve/reject/abandon`) directly via bash. It is appended **only for project-scoped chats on providers without the native `manage_run` tool** (Codex/OpenCode/Copilot) — gated in `orchestrator-agent.ts` on `!scopedCaps.nativeTools`. Claude and Pi instead receive the in-process `manage_run` native tool (the prompt section would be redundant for them). This is the CLI-bash delivery path for providers that have neither native tools nor `skills:` (direct chat doesn't consume the `skills:` option — it is workflow-node-only).
 
 **4. AI Agent Providers** (`packages/providers/src/`)
 - Implement `IAgentProvider` interface

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -497,6 +497,7 @@ import type { DagNode, WorkflowDefinition } from '@/lib/api';
 - Variable substitution: `$1`, `$2`, `$3`, `$ARGUMENTS`
 - Session management: Create new or resume existing
 - Stream AI responses to platform
+- System prompt includes a "Managing Workflow Runs" section (`buildRunManagementSection` in `prompt-builder.ts`) so the chat agent on **any** provider can drive run management (`archon workflow runs/get/status/run --detach/approve/reject/abandon`) directly via bash. This is the cross-provider delivery of the `manage-run` skill — direct chat doesn't consume the `skills:` option (workflow-node-only), and Codex has no skills capability, so the system prompt is the only channel that reaches all five providers.
 
 **4. AI Agent Providers** (`packages/providers/src/`)
 - Implement `IAgentProvider` interface

--- a/packages/cli/src/bundled-skill.ts
+++ b/packages/cli/src/bundled-skill.ts
@@ -9,7 +9,7 @@
  */
 
 // =============================================================================
-// Skill Files (21 total)
+// Skill Files (23 total: 21 archon + 2 manage-run)
 // =============================================================================
 
 import skillMd from '../../../.claude/skills/archon/SKILL.md' with { type: 'text' };

--- a/packages/cli/src/bundled-skill.ts
+++ b/packages/cli/src/bundled-skill.ts
@@ -34,6 +34,10 @@ import troubleshooting from '../../../.claude/skills/archon/references/troublesh
 import variables from '../../../.claude/skills/archon/references/variables.md' with { type: 'text' };
 import workflowDag from '../../../.claude/skills/archon/references/workflow-dag.md' with { type: 'text' };
 
+// manage-run skill (focused run-management skill — separate install target)
+import manageRunSkillMd from '../../../.claude/skills/manage-run/SKILL.md' with { type: 'text' };
+import manageRunCommands from '../../../.claude/skills/manage-run/references/commands.md' with { type: 'text' };
+
 // =============================================================================
 // Export
 // =============================================================================
@@ -63,4 +67,14 @@ export const BUNDLED_SKILL_FILES: Record<string, string> = {
   'references/troubleshooting.md': troubleshooting,
   'references/variables.md': variables,
   'references/workflow-dag.md': workflowDag,
+};
+
+/**
+ * Bundled manage-run skill files - relative path within .claude/skills/manage-run/ -> content.
+ * Installed into a separate `.claude/skills/manage-run/` directory (kept distinct from the
+ * broad `archon` skill so the run-management agent's context stays tiny).
+ */
+export const BUNDLED_MANAGE_RUN_SKILL_FILES: Record<string, string> = {
+  'SKILL.md': manageRunSkillMd,
+  'references/commands.md': manageRunCommands,
 };

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -331,11 +331,15 @@ async function main(): Promise<number> {
     const isInteractiveCommand =
       command === 'setup' || command === 'doctor' || command === 'telemetry';
     const suppressByDefault = isInteractiveCommand && !values.verbose && !isVerboseBoot();
-    // --json implies log suppression: Pino's default destination is stdout, so
-    // without this every `--json` command would interleave info logs with the
-    // JSON payload and break JSON.parse for a consuming agent. Keeps stdout to
-    // exactly the machine-readable result.
-    if (values.quiet || suppressByDefault || jsonFlag) {
+    // --json must keep stdout to EXACTLY the machine-readable payload. Pino's
+    // default destination is stdout, so even one warn/error line would precede
+    // the JSON and break JSON.parse for a consuming agent. Silence logs entirely
+    // (not just lower to 'warn' — warnings still print at that level): every
+    // --json command surfaces failures inside its own { ok: false } envelope, so
+    // no diagnostic the caller needs is lost.
+    if (jsonFlag) {
+      setLogLevel('silent');
+    } else if (values.quiet || suppressByDefault) {
       setLogLevel('warn');
     } else if (values.verbose) {
       setLogLevel('debug');
@@ -488,18 +492,33 @@ async function main(): Promise<number> {
               console.error('Usage: archon workflow get <run-id> [--json] [--verbose]');
               return 1;
             }
-            await workflowGetCommand(getRunId, jsonFlag, values.verbose as boolean | undefined);
-            break;
+            // Propagate the command's exit code so `get <id> && ...` and CI
+            // pipelines see a non-zero status when the run is missing.
+            return await workflowGetCommand(
+              getRunId,
+              jsonFlag,
+              values.verbose as boolean | undefined
+            );
           }
 
-          case 'runs':
+          case 'runs': {
+            const rawLimit = values.limit as string | undefined;
+            let limit: number | undefined;
+            if (rawLimit !== undefined) {
+              limit = Number(rawLimit);
+              if (!Number.isInteger(limit) || limit < 1) {
+                console.error(`Error: --limit must be a positive integer, got '${rawLimit}'.`);
+                return 1;
+              }
+            }
             await workflowRunsCommand(effectiveCwd, {
               json: jsonFlag,
               all: values.all as boolean | undefined,
               status: values.status as string | undefined,
-              limit: values.limit ? Number(values.limit) : undefined,
+              limit,
             });
             break;
+          }
 
           case 'resume': {
             const resumeRunId = positionals[2];

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -44,6 +44,8 @@ import {
   workflowListCommand,
   workflowRunCommand,
   workflowStatusCommand,
+  workflowGetCommand,
+  workflowRunsCommand,
   workflowResumeCommand,
   workflowAbandonCommand,
   workflowApproveCommand,
@@ -106,7 +108,9 @@ Commands:
   setup                      Interactive setup wizard for credentials and config
   workflow list              List available workflows in current directory
   workflow run <name> [msg]  Run a workflow with optional message
-  workflow status            Show status of running workflows
+  workflow status            Show status of running/paused workflows
+  workflow runs              List recent runs (all statuses) for this project
+  workflow get <run-id>      Show detail for a single run (any status)
   workflow search [query]    Search the workflow marketplace
   workflow install <slug>    Install a workflow from the marketplace
   isolation list             List all active worktrees/environments
@@ -134,7 +138,11 @@ Options:
   --spawn                    Open setup wizard in a new terminal window (for setup command)
   --quiet, -q                Reduce log verbosity to warnings and errors only
   --verbose, -v              Show debug-level output
-  --json                     Output machine-readable JSON (for workflow list)
+  --json                     Output machine-readable JSON (list/status/get/runs/approve/reject/abandon/resume)
+  --detach                   Run 'workflow run' in a detached background child (returns immediately)
+  --all                      For 'workflow runs': list across all projects (ignore cwd scope)
+  --status <status>          For 'workflow runs': filter to one status (running, completed, failed, ...)
+  --limit <n>                For 'workflow runs': max rows (default 20)
   --workflow <name>          Workflow to run for 'continue' (default: archon-assist)
   --no-context               Skip context injection for 'continue'
   --conversation-id <id>     Reuse a stable conversation scope across runs (enables
@@ -150,6 +158,9 @@ Examples:
   archon workflow run plan --cwd /path/to/repo "Add dark mode"
   archon workflow run implement --branch feature-auth "Implement auth"
   archon workflow run quick-fix --no-worktree "Fix typo"
+  archon workflow run archon-assist --detach "Investigate the flaky test"
+  archon workflow runs --json
+  archon workflow get <run-id> --json
   archon continue fix/issue-42 --workflow archon-smart-pr-review "Review the changes"
   archon skill install
   archon skill install /path/to/project
@@ -262,6 +273,10 @@ async function main(): Promise<number> {
         yes: { type: 'boolean' },
         force: { type: 'boolean' },
         'conversation-id': { type: 'string' },
+        detach: { type: 'boolean' },
+        all: { type: 'boolean' },
+        status: { type: 'string' },
+        limit: { type: 'string' },
       },
       allowPositionals: true,
       strict: false, // Allow unknown flags to pass through
@@ -284,6 +299,7 @@ async function main(): Promise<number> {
   const resumeFlag = values.resume as boolean | undefined;
   const spawnFlag = values.spawn as boolean | undefined;
   const jsonFlag = values.json as boolean | undefined;
+  const detachFlag = values.detach as boolean | undefined;
   // Handle help flag
   if (values.help) {
     printUsage();
@@ -315,7 +331,11 @@ async function main(): Promise<number> {
     const isInteractiveCommand =
       command === 'setup' || command === 'doctor' || command === 'telemetry';
     const suppressByDefault = isInteractiveCommand && !values.verbose && !isVerboseBoot();
-    if (values.quiet || suppressByDefault) {
+    // --json implies log suppression: Pino's default destination is stdout, so
+    // without this every `--json` command would interleave info logs with the
+    // JSON payload and break JSON.parse for a consuming agent. Keeps stdout to
+    // exactly the machine-readable result.
+    if (values.quiet || suppressByDefault || jsonFlag) {
       setLogLevel('warn');
     } else if (values.verbose) {
       setLogLevel('debug');
@@ -451,6 +471,8 @@ async function main(): Promise<number> {
               // resume between runs (they only resume within chat/REST, which reuse a
               // conversation). Pass the same id on each run to opt into cross-run resume.
               conversationId: values['conversation-id'] as string | undefined,
+              detach: detachFlag,
+              json: jsonFlag,
             };
             await workflowRunCommand(effectiveCwd, workflowName, userMessage, options);
             break;
@@ -460,13 +482,32 @@ async function main(): Promise<number> {
             await workflowStatusCommand(jsonFlag, values.verbose as boolean | undefined);
             break;
 
+          case 'get': {
+            const getRunId = positionals[2];
+            if (!getRunId) {
+              console.error('Usage: archon workflow get <run-id> [--json] [--verbose]');
+              return 1;
+            }
+            await workflowGetCommand(getRunId, jsonFlag, values.verbose as boolean | undefined);
+            break;
+          }
+
+          case 'runs':
+            await workflowRunsCommand(effectiveCwd, {
+              json: jsonFlag,
+              all: values.all as boolean | undefined,
+              status: values.status as string | undefined,
+              limit: values.limit ? Number(values.limit) : undefined,
+            });
+            break;
+
           case 'resume': {
             const resumeRunId = positionals[2];
             if (!resumeRunId) {
               console.error('Usage: archon workflow resume <run-id>');
               return 1;
             }
-            await workflowResumeCommand(resumeRunId);
+            await workflowResumeCommand(resumeRunId, jsonFlag);
             break;
           }
 
@@ -476,7 +517,7 @@ async function main(): Promise<number> {
               console.error('Usage: archon workflow abandon <run-id>');
               return 1;
             }
-            await workflowAbandonCommand(abandonRunId);
+            await workflowAbandonCommand(abandonRunId, jsonFlag);
             break;
           }
 
@@ -489,7 +530,7 @@ async function main(): Promise<number> {
             // Accept comment as positional args (everything after run ID) or --comment flag
             const approveComment =
               (values.comment as string | undefined) || positionals.slice(3).join(' ') || undefined;
-            await workflowApproveCommand(approveRunId, approveComment);
+            await workflowApproveCommand(approveRunId, approveComment, jsonFlag);
             break;
           }
 
@@ -501,7 +542,7 @@ async function main(): Promise<number> {
             }
             const rejectReason =
               (values.reason as string | undefined) || positionals.slice(3).join(' ') || undefined;
-            await workflowRejectCommand(rejectRunId, rejectReason);
+            await workflowRejectCommand(rejectRunId, rejectReason, jsonFlag);
             break;
           }
 
@@ -614,7 +655,7 @@ async function main(): Promise<number> {
               console.error(`Unknown workflow subcommand: ${subcommand}`);
             }
             console.error(
-              'Available: list, run, status, resume, abandon, approve, reject, cleanup, event, search, install'
+              'Available: list, run, status, get, runs, resume, abandon, approve, reject, cleanup, event, search, install'
             );
             return 1;
         }

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -1,9 +1,9 @@
 /**
  * Skill command - Install bundled Archon skill files into a project
  *
- * Writes the bundled SKILL.md, guides, references and examples into
- * <targetPath>/.claude/skills/archon/ so Claude Code picks up the skill
- * the next time the project is opened.
+ * Writes the bundled `archon` skill (SKILL.md, guides, references, examples) and
+ * the focused `manage-run` skill into <targetPath>/.claude/skills/<skill>/ so
+ * Claude Code picks them up the next time the project is opened.
  *
  * Always overwrites existing files to ensure the latest skill version
  * shipped with the current Archon binary is installed.
@@ -11,13 +11,27 @@
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { dirname, join, resolve } from 'path';
 
+/** Write a skill's relative-path→content map under <skillRoot>, creating dirs as needed. */
+function writeSkillFiles(skillRoot: string, files: Record<string, string>): void {
+  for (const [relativePath, content] of Object.entries(files)) {
+    const dest = join(skillRoot, relativePath);
+    const destDir = dirname(dest);
+    if (!existsSync(destDir)) {
+      mkdirSync(destDir, { recursive: true });
+    }
+    writeFileSync(dest, content);
+  }
+}
+
 /**
- * Copy the bundled Archon skill files to <targetPath>/.claude/skills/archon/
+ * Copy the bundled Archon skills into <targetPath>/.claude/skills/:
+ *   - `archon`     — the broad authoring/setup/run skill
+ *   - `manage-run` — the focused run-management skill
  *
  * Pure file-system helper used by both the standalone `skill install` CLI
  * command and the interactive setup wizard.
  *
- * The `bundled-skill` module is dynamically imported here so that its 18 top-level
+ * The `bundled-skill` module is dynamically imported here so that its top-level
  * `import … with { type: 'text' }` statements only execute when this function is
  * actually called. Compiled binaries (`bun build --compile`) still statically
  * analyze the literal-string `import()` and embed the chunk; linked-source
@@ -27,16 +41,10 @@ import { dirname, join, resolve } from 'path';
  * the source skill files are missing from disk.
  */
 export async function copyArchonSkill(targetPath: string): Promise<void> {
-  const { BUNDLED_SKILL_FILES } = await import('../bundled-skill');
-  const skillRoot = join(targetPath, '.claude', 'skills', 'archon');
-  for (const [relativePath, content] of Object.entries(BUNDLED_SKILL_FILES)) {
-    const dest = join(skillRoot, relativePath);
-    const destDir = dirname(dest);
-    if (!existsSync(destDir)) {
-      mkdirSync(destDir, { recursive: true });
-    }
-    writeFileSync(dest, content);
-  }
+  const { BUNDLED_SKILL_FILES, BUNDLED_MANAGE_RUN_SKILL_FILES } = await import('../bundled-skill');
+  const skillsRoot = join(targetPath, '.claude', 'skills');
+  writeSkillFiles(join(skillsRoot, 'archon'), BUNDLED_SKILL_FILES);
+  writeSkillFiles(join(skillsRoot, 'manage-run'), BUNDLED_MANAGE_RUN_SKILL_FILES);
 }
 
 /**
@@ -52,14 +60,18 @@ export async function skillInstallCommand(targetPath: string): Promise<number> {
     return 1;
   }
 
-  const skillRoot = join(absoluteTarget, '.claude', 'skills', 'archon');
+  const skillsRoot = join(absoluteTarget, '.claude', 'skills');
   try {
-    const { BUNDLED_SKILL_FILES } = await import('../bundled-skill');
-    const fileCount = Object.keys(BUNDLED_SKILL_FILES).length;
-    console.log(`Installing Archon skill (${fileCount} files) into ${skillRoot}`);
+    const { BUNDLED_SKILL_FILES, BUNDLED_MANAGE_RUN_SKILL_FILES } =
+      await import('../bundled-skill');
+    const fileCount =
+      Object.keys(BUNDLED_SKILL_FILES).length + Object.keys(BUNDLED_MANAGE_RUN_SKILL_FILES).length;
+    console.log(
+      `Installing Archon skills (archon + manage-run, ${fileCount} files) into ${skillsRoot}`
+    );
 
     await copyArchonSkill(absoluteTarget);
-    console.log('Done. Restart Claude Code to load the skill.');
+    console.log('Done. Restart Claude Code to load the skills.');
     return 0;
   } catch (error) {
     const err = error as NodeJS.ErrnoException;

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -8,6 +8,8 @@ import {
   workflowListCommand,
   workflowRunCommand,
   workflowStatusCommand,
+  workflowGetCommand,
+  workflowRunsCommand,
   workflowResumeCommand,
   workflowAbandonCommand,
   workflowApproveCommand,
@@ -30,6 +32,7 @@ const mockLogger = {
 mock.module('@archon/paths', () => ({
   createLogger: mock(() => mockLogger),
   getArchonHome: mock(() => '/home/test/.archon'),
+  BUNDLED_IS_BINARY: false,
 }));
 
 // Mock @archon/isolation (getIsolationProvider moved here from @archon/core)
@@ -136,6 +139,13 @@ mock.module('@archon/core/db/workflows', () => ({
   getWorkflowRun: mock(() => Promise.resolve(null)),
   updateWorkflowRun: mock(() => Promise.resolve()),
   listWorkflowRuns: mock(() => Promise.resolve([])),
+  listDashboardRuns: mock(() =>
+    Promise.resolve({
+      runs: [],
+      total: 0,
+      counts: { all: 0, running: 0, completed: 0, failed: 0, cancelled: 0, pending: 0, paused: 0 },
+    })
+  ),
   deleteOldWorkflowRuns: mock(() => Promise.resolve({ count: 0 })),
 }));
 
@@ -1716,6 +1726,453 @@ describe('workflowStatusCommand', () => {
     const jsonOutput = consoleSpy.mock.calls[0]?.[0] as string;
     const parsed = JSON.parse(jsonOutput) as { runs: Array<{ events: unknown[] }> };
     expect(parsed.runs[0].events).toHaveLength(1);
+  });
+});
+
+const EMPTY_COUNTS = {
+  all: 0,
+  running: 0,
+  completed: 0,
+  failed: 0,
+  cancelled: 0,
+  pending: 0,
+  paused: 0,
+};
+
+describe('workflowGetCommand', () => {
+  let consoleSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('prints not-found (human) for a missing run', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+
+    await workflowGetCommand('nope');
+
+    expect(consoleSpy).toHaveBeenCalledWith('Workflow run not found: nope');
+  });
+
+  it('emits {error:not_found} JSON for a missing run', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+
+    await workflowGetCommand('nope', true);
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toEqual({
+      error: 'not_found',
+      runId: 'nope',
+    });
+  });
+
+  it('prints run detail (human) including the error from metadata', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'run-xyz',
+      workflow_name: 'implement',
+      status: 'failed',
+      working_path: '/tmp/wt',
+      started_at: new Date(),
+      metadata: { error: 'Step failed: build' },
+    });
+
+    await workflowGetCommand('run-xyz');
+
+    expect(consoleSpy).toHaveBeenCalledWith('  ID:     run-xyz');
+    expect(consoleSpy).toHaveBeenCalledWith('  Name:   implement');
+    expect(consoleSpy).toHaveBeenCalledWith('  Status: failed');
+    expect(consoleSpy).toHaveBeenCalledWith('  Error:  Step failed: build');
+  });
+
+  it('emits the raw run as a single clean JSON object', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'run-json',
+      workflow_name: 'implement',
+      status: 'completed',
+      working_path: '/tmp/wt',
+      started_at: new Date(),
+      metadata: {},
+    });
+
+    await workflowGetCommand('run-json', true);
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as {
+      id: string;
+      status: string;
+    };
+    expect(parsed.id).toBe('run-json');
+    expect(parsed.status).toBe('completed');
+  });
+
+  it('attaches events in verbose JSON mode', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const eventsDb = await import('@archon/core/db/workflow-events');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'run-v',
+      workflow_name: 'implement',
+      status: 'running',
+      working_path: '/tmp/wt',
+      started_at: new Date(),
+      metadata: {},
+    });
+    (eventsDb.listWorkflowEvents as ReturnType<typeof mock>).mockResolvedValueOnce([
+      {
+        event_type: 'node_started',
+        step_name: 'plan',
+        created_at: new Date().toISOString(),
+        data: {},
+      },
+    ]);
+
+    await workflowGetCommand('run-v', true, true);
+
+    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as { events: unknown[] };
+    expect(Array.isArray(parsed.events)).toBe(true);
+    expect(parsed.events).toHaveLength(1);
+  });
+});
+
+describe('workflowRunsCommand', () => {
+  let consoleSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('scopes to the cwd-resolved codebase id', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'cb-proj',
+      name: 'owner/repo',
+      default_cwd: '/test/path',
+    });
+    const listSpy = workflowDb.listDashboardRuns as ReturnType<typeof mock>;
+    listSpy.mockClear();
+    listSpy.mockResolvedValueOnce({ runs: [], total: 0, counts: EMPTY_COUNTS });
+
+    await workflowRunsCommand('/test/path', {});
+
+    expect(listSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ codebaseId: 'cb-proj', limit: 20 })
+    );
+  });
+
+  it('prints the unregistered-cwd note and lists globally when no codebase resolves', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+    (workflowDb.listDashboardRuns as ReturnType<typeof mock>).mockResolvedValueOnce({
+      runs: [],
+      total: 0,
+      counts: EMPTY_COUNTS,
+    });
+
+    await workflowRunsCommand('/unregistered', {});
+
+    expect(consoleSpy).toHaveBeenCalledWith('(not a registered project — showing all runs)');
+  });
+
+  it('emits the full dashboard result as JSON', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+    (workflowDb.listDashboardRuns as ReturnType<typeof mock>).mockResolvedValueOnce({
+      runs: [
+        {
+          id: 'r1',
+          workflow_name: 'assist',
+          status: 'completed',
+          current_step_name: null,
+          total_steps: null,
+          started_at: new Date(),
+        },
+      ],
+      total: 1,
+      counts: { ...EMPTY_COUNTS, all: 1, completed: 1 },
+    });
+
+    await workflowRunsCommand('/test/path', { json: true });
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as {
+      runs: unknown[];
+      total: number;
+    };
+    expect(parsed.total).toBe(1);
+    expect(parsed.runs).toHaveLength(1);
+  });
+
+  it('passes --all (no codebase scope) plus --status/--limit through to listDashboardRuns', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    const findSpy = codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>;
+    findSpy.mockClear();
+    const listSpy = workflowDb.listDashboardRuns as ReturnType<typeof mock>;
+    listSpy.mockClear();
+    listSpy.mockResolvedValueOnce({ runs: [], total: 0, counts: EMPTY_COUNTS });
+
+    await workflowRunsCommand('/test/path', { all: true, status: 'running', limit: 5 });
+
+    // --all skips the codebase lookup entirely
+    expect(findSpy).not.toHaveBeenCalled();
+    const arg = listSpy.mock.calls[0][0] as { codebaseId?: string; status?: string; limit: number };
+    expect(arg.codebaseId).toBeUndefined();
+    expect(arg.status).toBe('running');
+    expect(arg.limit).toBe(5);
+  });
+
+  it('throws on an invalid --status', async () => {
+    await expect(workflowRunsCommand('/test/path', { status: 'bogus' })).rejects.toThrow(
+      /Invalid --status 'bogus'/
+    );
+  });
+});
+
+describe('write command --json output', () => {
+  let consoleSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('abandon --json emits a structured cancelled result', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'run-ab',
+      workflow_name: 'implement',
+      status: 'running',
+    });
+    (workflowDb.cancelWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      cancelled: true,
+    });
+
+    await workflowAbandonCommand('run-ab', true);
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toEqual({
+      ok: true,
+      runId: 'run-ab',
+      action: 'abandon',
+      status: 'cancelled',
+      workflowName: 'implement',
+    });
+  });
+
+  it('abandon --json emits {ok:false} on a not-found run (never throws)', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+
+    await workflowAbandonCommand('missing', true);
+
+    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as {
+      ok: boolean;
+      error: string;
+    };
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain('Workflow run not found');
+  });
+
+  it('approve --json records the decision and does NOT auto-resume', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const discovery = await import('@archon/workflows/workflow-discovery');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'run-ap',
+      workflow_name: 'implement',
+      status: 'paused',
+      working_path: '/tmp/wt',
+      codebase_id: 'cb',
+      conversation_id: 'conv',
+      user_message: 'go',
+      metadata: { approval: { nodeId: 'gate', message: 'ok?' } },
+    });
+    const discoverSpy = discovery.discoverWorkflowsWithConfig as ReturnType<typeof mock>;
+    discoverSpy.mockClear();
+
+    await workflowApproveCommand('run-ap', 'lgtm', true);
+
+    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    expect(parsed).toMatchObject({
+      ok: true,
+      runId: 'run-ap',
+      action: 'approve',
+      type: 'approval_gate',
+      resumable: true,
+    });
+    // No inline resume → workflowRunCommand (whose first step is discovery) never ran
+    expect(discoverSpy).not.toHaveBeenCalled();
+  });
+
+  it('reject --json reports cancelled + resumable correctly without auto-resume', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const discovery = await import('@archon/workflows/workflow-discovery');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'run-rj',
+      workflow_name: 'implement',
+      status: 'paused',
+      working_path: '/tmp/wt',
+      codebase_id: 'cb',
+      conversation_id: 'conv',
+      user_message: 'go',
+      metadata: { approval: { nodeId: 'gate', message: 'ok?' } },
+    });
+    (workflowDb.cancelWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      cancelled: true,
+    });
+    const discoverSpy = discovery.discoverWorkflowsWithConfig as ReturnType<typeof mock>;
+    discoverSpy.mockClear();
+
+    await workflowRejectCommand('run-rj', 'nope', true);
+
+    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    // No onRejectPrompt in approval metadata → run is cancelled, not resumable
+    expect(parsed).toMatchObject({
+      ok: true,
+      runId: 'run-rj',
+      action: 'reject',
+      cancelled: true,
+      resumable: false,
+    });
+    expect(discoverSpy).not.toHaveBeenCalled();
+  });
+
+  it('resume --json validates resumability without executing (executed:false)', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const discovery = await import('@archon/workflows/workflow-discovery');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'run-rs',
+      workflow_name: 'implement',
+      status: 'failed',
+      working_path: '/tmp/wt',
+    });
+    const discoverSpy = discovery.discoverWorkflowsWithConfig as ReturnType<typeof mock>;
+    discoverSpy.mockClear();
+
+    await workflowResumeCommand('run-rs', true);
+
+    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    expect(parsed).toMatchObject({
+      ok: true,
+      runId: 'run-rs',
+      action: 'resume',
+      executed: false,
+      status: 'failed',
+    });
+    expect(discoverSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('workflowRunCommand — detach', () => {
+  let consoleSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('spawns a detached child (minus --detach, plus --branch/--conversation-id) and does NOT await executeWorkflow', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    const paths = await import('@archon/paths');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'assist', description: 'Help' })],
+      errors: [],
+    });
+    // Force the log-file path to fall back to 'ignore' so the test writes no files
+    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
+      throw new Error('no home in test');
+    });
+
+    const execBefore = (executeWorkflow as ReturnType<typeof mock>).mock.calls.length;
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue({
+      unref: mock(() => undefined),
+    } as unknown as ReturnType<typeof Bun.spawn>);
+    const savedArgv = process.argv;
+    process.argv = ['bun', '/abs/cli.ts', 'workflow', 'run', 'assist', 'hello', '--detach'];
+
+    // Capture call data BEFORE mockRestore() — restoring a spy clears its recorded calls.
+    let spawnCallCount = 0;
+    let spawnCmd: string[] = [];
+    try {
+      await workflowRunCommand('/test/path', 'assist', 'hello', { detach: true });
+      spawnCallCount = spawnSpy.mock.calls.length;
+      spawnCmd = (
+        (spawnSpy.mock.calls[0]?.[0] as { cmd: string[] } | undefined)?.cmd ?? []
+      ).slice();
+    } finally {
+      process.argv = savedArgv;
+      spawnSpy.mockRestore();
+    }
+
+    expect(spawnCallCount).toBe(1);
+    expect(spawnCmd).not.toContain('--detach');
+    expect(spawnCmd).toContain('--branch');
+    expect(spawnCmd).toContain('--conversation-id');
+    expect(spawnCmd).toContain('--cwd');
+    // Generated branch is `assist-<timestamp>`
+    const branchIdx = spawnCmd.indexOf('--branch');
+    expect(spawnCmd[branchIdx + 1]).toMatch(/^assist-\d+$/);
+    // executeWorkflow must NOT run in the detaching parent
+    const execAfter = (executeWorkflow as ReturnType<typeof mock>).mock.calls.length;
+    expect(execAfter).toBe(execBefore);
+    expect(consoleSpy).toHaveBeenCalledWith("Started 'assist' in the background.");
+  });
+
+  it('--detach --json emits a structured ack', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const paths = await import('@archon/paths');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'assist', description: 'Help' })],
+      errors: [],
+    });
+    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
+      throw new Error('no home in test');
+    });
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue({
+      unref: mock(() => undefined),
+    } as unknown as ReturnType<typeof Bun.spawn>);
+    const savedArgv = process.argv;
+    process.argv = [
+      'bun',
+      '/abs/cli.ts',
+      'workflow',
+      'run',
+      'assist',
+      'hello',
+      '--detach',
+      '--json',
+    ];
+
+    try {
+      await workflowRunCommand('/test/path', 'assist', 'hello', { detach: true, json: true });
+    } finally {
+      process.argv = savedArgv;
+      spawnSpy.mockRestore();
+    }
+
+    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    expect(parsed).toMatchObject({ ok: true, action: 'run', detached: true, workflow: 'assist' });
+    expect(typeof parsed.conversationId).toBe('string');
   });
 });
 

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -1759,7 +1759,7 @@ describe('workflowGetCommand', () => {
     expect(consoleSpy).toHaveBeenCalledWith('Workflow run not found: nope');
   });
 
-  it('emits {error:not_found} JSON for a missing run', async () => {
+  it('emits {ok:false, error:not_found} JSON for a missing run', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
     (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce(null);
 
@@ -1767,9 +1767,28 @@ describe('workflowGetCommand', () => {
 
     expect(consoleSpy).toHaveBeenCalledTimes(1);
     expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toEqual({
-      error: 'not_found',
+      ok: false,
       runId: 'nope',
+      error: 'not_found',
     });
+  });
+
+  it('emits {ok:false} JSON (never throws) when the DB lookup fails', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockRejectedValueOnce(
+      new Error('connection refused')
+    );
+
+    await workflowGetCommand('run-x', true);
+
+    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as {
+      ok: boolean;
+      runId: string;
+      error: string;
+    };
+    expect(parsed.ok).toBe(false);
+    expect(parsed.runId).toBe('run-x');
+    expect(parsed.error).toContain('connection refused');
   });
 
   it('prints run detail (human) including the error from metadata', async () => {
@@ -1939,6 +1958,17 @@ describe('workflowRunsCommand', () => {
     await expect(workflowRunsCommand('/test/path', { status: 'bogus' })).rejects.toThrow(
       /Invalid --status 'bogus'/
     );
+  });
+
+  it('emits {ok:false} JSON (never throws) on an invalid --status in --json mode', async () => {
+    await workflowRunsCommand('/test/path', { status: 'bogus', json: true });
+
+    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as {
+      ok: boolean;
+      error: string;
+    };
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Invalid --status 'bogus'");
   });
 });
 

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -16,6 +16,7 @@ import {
   workflowRejectCommand,
   workflowCleanupCommand,
   workflowResetSessionsCommand,
+  buildDetachedRunCmd,
 } from './workflow';
 
 const mockLogger = {
@@ -1750,20 +1751,22 @@ describe('workflowGetCommand', () => {
     consoleSpy.mockRestore();
   });
 
-  it('prints not-found (human) for a missing run', async () => {
+  it('prints not-found (human) and exits non-zero for a missing run', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
     (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce(null);
 
-    await workflowGetCommand('nope');
+    const code = await workflowGetCommand('nope');
 
     expect(consoleSpy).toHaveBeenCalledWith('Workflow run not found: nope');
+    // Exit 1 so `get <id> && ...` and CI checks react to a missing run.
+    expect(code).toBe(1);
   });
 
-  it('emits {ok:false, error:not_found} JSON for a missing run', async () => {
+  it('emits {ok:false, error:not_found} JSON and exits non-zero for a missing run', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
     (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce(null);
 
-    await workflowGetCommand('nope', true);
+    const code = await workflowGetCommand('nope', true);
 
     expect(consoleSpy).toHaveBeenCalledTimes(1);
     expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toEqual({
@@ -1771,6 +1774,7 @@ describe('workflowGetCommand', () => {
       runId: 'nope',
       error: 'not_found',
     });
+    expect(code).toBe(1);
   });
 
   it('emits {ok:false} JSON (never throws) when the DB lookup fails', async () => {
@@ -1821,7 +1825,7 @@ describe('workflowGetCommand', () => {
       metadata: {},
     });
 
-    await workflowGetCommand('run-json', true);
+    const code = await workflowGetCommand('run-json', true);
 
     expect(consoleSpy).toHaveBeenCalledTimes(1);
     const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as {
@@ -1830,6 +1834,7 @@ describe('workflowGetCommand', () => {
     };
     expect(parsed.id).toBe('run-json');
     expect(parsed.status).toBe('completed');
+    expect(code).toBe(0);
   });
 
   it('attaches events in verbose JSON mode', async () => {
@@ -1930,9 +1935,32 @@ describe('workflowRunsCommand', () => {
     const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as {
       runs: unknown[];
       total: number;
+      scopeFallback: boolean;
     };
     expect(parsed.total).toBe(1);
     expect(parsed.runs).toHaveLength(1);
+    // codebase did not resolve → result is a global fallback, flagged for agents
+    expect(parsed.scopeFallback).toBe(true);
+  });
+
+  it('marks scopeFallback false in --json when the project scope resolves', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'cb-proj',
+      name: 'owner/repo',
+      default_cwd: '/test/path',
+    });
+    (workflowDb.listDashboardRuns as ReturnType<typeof mock>).mockResolvedValueOnce({
+      runs: [],
+      total: 0,
+      counts: EMPTY_COUNTS,
+    });
+
+    await workflowRunsCommand('/test/path', { json: true });
+
+    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as { scopeFallback: boolean };
+    expect(parsed.scopeFallback).toBe(false);
   });
 
   it('passes --all (no codebase scope) plus --status/--limit through to listDashboardRuns', async () => {
@@ -2203,6 +2231,53 @@ describe('workflowRunCommand — detach', () => {
     const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as Record<string, unknown>;
     expect(parsed).toMatchObject({ ok: true, action: 'run', detached: true, workflow: 'assist' });
     expect(typeof parsed.conversationId).toBe('string');
+  });
+});
+
+describe('buildDetachedRunCmd', () => {
+  // BUNDLED_IS_BINARY is a module-level const (mocked false), so the binary
+  // branch is unreachable through spawnDetachedWorkflowRun — exercise both
+  // branches directly via the pure builder.
+
+  it('dev mode: keeps [execPath, entryScript], slices argv(2), drops --detach/--json', () => {
+    const cmd = buildDetachedRunCmd(
+      false,
+      '/path/to/bun',
+      ['/path/to/bun', '/abs/cli.ts', 'workflow', 'run', 'assist', 'hello', '--detach', '--json'],
+      '/abs/cwd',
+      ['--branch', 'assist-123', '--conversation-id', 'cli-1']
+    );
+
+    expect(cmd[0]).toBe('/path/to/bun');
+    expect(cmd[1]).toBe('/abs/cli.ts');
+    expect(cmd).not.toContain('--detach');
+    expect(cmd).not.toContain('--json');
+    expect(cmd).toContain('assist');
+    // --cwd pinned absolute, then extra flags
+    const cwdIdx = cmd.indexOf('--cwd');
+    expect(cmd[cwdIdx + 1]).toBe('/abs/cwd');
+    expect(cmd).toContain('--branch');
+    expect(cmd).toContain('--conversation-id');
+  });
+
+  it('binary mode: uses [execPath] only (no duplicated entry arg), slices argv(1)', () => {
+    const cmd = buildDetachedRunCmd(
+      true,
+      '/usr/local/bin/archon',
+      ['/usr/local/bin/archon', 'workflow', 'run', 'assist', 'hello', '--detach', '--json'],
+      '/abs/cwd',
+      ['--branch', 'assist-123']
+    );
+
+    expect(cmd[0]).toBe('/usr/local/bin/archon');
+    // The binary path must appear exactly once — never duplicated as argv[1].
+    expect(cmd.filter(arg => arg === '/usr/local/bin/archon')).toHaveLength(1);
+    expect(cmd[1]).toBe('workflow');
+    expect(cmd).not.toContain('--detach');
+    expect(cmd).not.toContain('--json');
+    const cwdIdx = cmd.indexOf('--cwd');
+    expect(cmd[cwdIdx + 1]).toBe('/abs/cwd');
+    expect(cmd.slice(cwdIdx + 2)).toEqual(['--branch', 'assist-123']);
   });
 });
 

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -10,8 +10,9 @@ import {
 } from '@archon/core';
 import { WORKFLOW_EVENT_TYPES, type WorkflowEventType } from '@archon/workflows/store';
 import { configureIsolation, getIsolationProvider } from '@archon/isolation';
-import { createLogger, getArchonHome } from '@archon/paths';
+import { createLogger, getArchonHome, BUNDLED_IS_BINARY } from '@archon/paths';
 import { join } from 'node:path';
+import { mkdirSync, openSync } from 'node:fs';
 import { createWorkflowDeps } from '@archon/core/workflows/store-adapter';
 import { discoverWorkflowsWithConfig } from '@archon/workflows/workflow-discovery';
 import { resolveWorkflowName } from '@archon/workflows/router';
@@ -21,7 +22,8 @@ import {
   type WorkflowEmitterEvent,
 } from '@archon/workflows/event-emitter';
 import type { WorkflowDefinition, WorkflowLoadResult } from '@archon/workflows/schemas/workflow';
-import type { WorkflowRun } from '@archon/workflows/schemas/workflow-run';
+import { workflowRunStatusSchema } from '@archon/workflows/schemas/workflow-run';
+import type { WorkflowRun, WorkflowRunStatus } from '@archon/workflows/schemas/workflow-run';
 import {
   approveWorkflow,
   rejectWorkflow,
@@ -74,6 +76,14 @@ export interface WorkflowRunOptions {
   verbose?: boolean;
   /** Platform conversation ID (e.g. `cli-{ts}-{rand}`), NOT a DB UUID. */
   conversationId?: string;
+  /**
+   * Run the workflow in a detached background child and return immediately.
+   * The parent pins a stable branch + conversation id on the child's argv so
+   * exactly one worktree/conversation is created. The child does all the work.
+   */
+  detach?: boolean;
+  /** Emit a machine-readable JSON ack instead of human text (only honored with --detach). */
+  json?: boolean;
 }
 
 /**
@@ -83,6 +93,61 @@ function generateConversationId(): string {
   const timestamp = Date.now();
   const random = Math.random().toString(36).substring(2, 8);
   return `cli-${String(timestamp)}-${random}`;
+}
+
+/**
+ * Re-invoke `archon workflow run` (minus --detach) as a detached background
+ * child so the caller's shell returns immediately. Reconstructs the current
+ * argv, drops `--detach`, pins `--cwd` (absolute) plus any caller-supplied extra
+ * flags (a generated branch / conversation id), then detaches via `unref()`.
+ *
+ * `dispatchBackgroundWorkflow` is deliberately NOT reused here: it is web-
+ * adapter-coupled and its fire-and-forget dies with the CLI process. The
+ * re-invoke is the only mechanism that survives parent exit.
+ *
+ * Child stdout/stderr are redirected to a per-conversation log file under
+ * ARCHON_HOME/logs so a child that fails BEFORE creating a run record (e.g. DB
+ * unreachable, missing worktree) leaves a trail instead of failing silently.
+ * Falls back to discarding output only if the log file cannot be opened.
+ * Returns the log path (or null when discarded) so the caller can surface it.
+ */
+function spawnDetachedWorkflowRun(
+  cwd: string,
+  conversationId: string,
+  extraArgs: string[]
+): string | null {
+  // In a compiled binary, process.execPath IS the archon binary and there is no
+  // entry-script argv[1]; in dev, execPath is bun and argv[1] is the cli entry.
+  const baseCmd = BUNDLED_IS_BINARY ? [process.execPath] : [process.execPath, process.argv[1]];
+  const userArgs = (BUNDLED_IS_BINARY ? process.argv.slice(1) : process.argv.slice(2)).filter(
+    arg => arg !== '--detach'
+  );
+  // --cwd is appended last (parseArgs last-wins) so the child resolves the same
+  // absolute working dir regardless of any relative --cwd the caller passed.
+  const cmd = [...baseCmd, ...userArgs, '--cwd', cwd, ...extraArgs];
+
+  let logPath: string | null = null;
+  let logFd: number | undefined;
+  try {
+    const logDir = join(getArchonHome(), 'logs');
+    mkdirSync(logDir, { recursive: true });
+    logPath = join(logDir, `detached-run-${conversationId}.log`);
+    logFd = openSync(logPath, 'a');
+  } catch (error) {
+    getLog().warn({ err: error as Error }, 'cli.detached_run_log_open_failed');
+    logPath = null;
+    logFd = undefined;
+  }
+
+  const child = Bun.spawn({
+    cmd,
+    cwd,
+    env: process.env,
+    stdio: ['ignore', logFd ?? 'ignore', logFd ?? 'ignore'],
+  });
+  // Detach: let the parent exit without waiting on (or killing) the child.
+  child.unref();
+  return logPath;
 }
 
 /**
@@ -375,6 +440,62 @@ export async function workflowRunCommand(
     }
   }
 
+  // Default to worktree isolation unless --no-worktree or --resume. Workflow YAML
+  // `worktree.enabled` pins the decision — mismatches with CLI flags are rejected
+  // above, so by this point policy (if set) and flags agree. `--resume` reuses an
+  // existing worktree and takes precedence over the pinned policy. Computed here
+  // (not at the worktree block below) because --detach also needs it to decide
+  // whether to pin a generated branch on the child.
+  const flagWantsIsolation = !options.resume && !options.noWorktree;
+  const wantsIsolation =
+    !options.resume && pinnedEnabled !== undefined ? pinnedEnabled : flagWantsIsolation;
+
+  // --detach: hand the whole run to a detached background child and return now.
+  // Done BEFORE any DB/worktree work (the child does all of it) but AFTER workflow
+  // resolution + flag validation above, so unknown-workflow / bad-flag errors are
+  // still surfaced synchronously to the caller rather than lost in the child.
+  if (options.detach) {
+    const childConversationId = options.conversationId ?? generateConversationId();
+    const extraArgs: string[] = [];
+    let pinnedBranch: string | undefined;
+    // Pin a generated branch only when isolating AND the caller didn't pass
+    // --branch (an explicit --branch is already in argv). Without this, the child
+    // would generate its own timestamped branch and fork a second worktree.
+    if (wantsIsolation && options.branchName === undefined) {
+      pinnedBranch = `${workflowName}-${String(Date.now())}`;
+      extraArgs.push('--branch', pinnedBranch);
+    }
+    // Pin the conversation id only when generated (an explicit one is already in argv).
+    if (options.conversationId === undefined) {
+      extraArgs.push('--conversation-id', childConversationId);
+    }
+
+    const logPath = spawnDetachedWorkflowRun(cwd, childConversationId, extraArgs);
+
+    if (options.json) {
+      console.log(
+        JSON.stringify(
+          {
+            ok: true,
+            action: 'run',
+            detached: true,
+            workflow: workflow.name,
+            branch: pinnedBranch ?? options.branchName ?? null,
+            conversationId: childConversationId,
+            logPath,
+          },
+          null,
+          2
+        )
+      );
+    } else {
+      console.log(`Started '${workflow.name}' in the background.`);
+      console.log('Track it with: archon workflow runs');
+      if (logPath) console.log(`Child output: ${logPath}`);
+    }
+    return;
+  }
+
   console.log(`Running workflow: ${workflowName}`);
   console.log(`Working directory: ${cwd}`);
   console.log('');
@@ -522,15 +643,6 @@ export async function workflowRunCommand(
     console.log(`Working path: ${workingCwd}`);
     console.log('');
   }
-
-  // Default to worktree isolation unless --no-worktree or --resume.
-  // Workflow YAML `worktree.enabled` pins the decision — mismatches with CLI
-  // flags are rejected above, so by this point the policy (if set) and flags
-  // agree. `--resume` reuses an existing worktree and takes precedence over
-  // the pinned policy to avoid disturbing a paused run.
-  const flagWantsIsolation = !options.resume && !options.noWorktree;
-  const wantsIsolation =
-    !options.resume && pinnedEnabled !== undefined ? pinnedEnabled : flagWantsIsolation;
 
   if (wantsIsolation && codebase) {
     // Auto-generate branch identifier from workflow name + timestamp when --branch not provided
@@ -935,6 +1047,35 @@ function buildNodeSummaries(events: WorkflowEventRow[]): NodeSummary[] {
 }
 
 /**
+ * Render per-node summaries for a run's events as an indented "Nodes:" block.
+ * Shared by `workflow status --verbose` and `workflow get --verbose`.
+ * Prints nothing when the run has no node events.
+ */
+function printVerboseNodes(events: WorkflowEventRow[]): void {
+  const nodes = buildNodeSummaries(events);
+  if (nodes.length === 0) return;
+  console.log('  Nodes:');
+  for (const node of nodes) {
+    const iconMap: Record<string, string> = {
+      completed: '✓',
+      failed: '✗',
+      skipped: '-',
+      running: '◌',
+    };
+    const icon = iconMap[node.state] ?? '◌';
+    const duration = node.durationMs !== undefined ? ` (${formatDuration(node.durationMs)})` : '';
+    const stateLabel = node.state === 'running' ? ' (running)' : '';
+    console.log(`    ${icon} ${node.nodeId}${duration}${stateLabel}`);
+    if (node.outputPreview !== undefined) {
+      console.log(`        Output: ${node.outputPreview}`);
+    }
+    if (node.error !== undefined) {
+      console.log(`        Error:  ${node.error}`);
+    }
+  }
+}
+
+/**
  * Show status of all running workflow runs.
  */
 export async function workflowStatusCommand(json?: boolean, verbose?: boolean): Promise<void> {
@@ -983,33 +1124,149 @@ export async function workflowStatusCommand(json?: boolean, verbose?: boolean): 
       } catch {
         events = [];
       }
-      const nodes = buildNodeSummaries(events);
-      if (nodes.length > 0) {
-        console.log('  Nodes:');
-        for (const node of nodes) {
-          const iconMap: Record<string, string> = {
-            completed: '✓',
-            failed: '✗',
-            skipped: '-',
-            running: '◌',
-          };
-          const icon = iconMap[node.state] ?? '◌';
-          const duration =
-            node.durationMs !== undefined ? ` (${formatDuration(node.durationMs)})` : '';
-          const stateLabel = node.state === 'running' ? ' (running)' : '';
-          console.log(`    ${icon} ${node.nodeId}${duration}${stateLabel}`);
-          if (node.outputPreview !== undefined) {
-            console.log(`        Output: ${node.outputPreview}`);
-          }
-          if (node.error !== undefined) {
-            console.log(`        Error:  ${node.error}`);
-          }
-        }
-      }
+      printVerboseNodes(events);
     }
 
     console.log('');
   }
+}
+
+/**
+ * Show detail for a single workflow run by ID (any status).
+ *
+ * Unlike `status` (active runs only), this resolves one run regardless of
+ * status — so an agent can answer "did the review pass?" for a completed/failed
+ * run. `--verbose` adds the per-node event summary; `--json` emits the raw run
+ * (plus an `events` array when verbose).
+ */
+export async function workflowGetCommand(
+  runId: string,
+  json?: boolean,
+  verbose?: boolean
+): Promise<void> {
+  let run: WorkflowRun | null;
+  try {
+    run = await workflowDb.getWorkflowRun(runId);
+  } catch (error) {
+    const err = error as Error;
+    getLog().error({ err, runId }, 'cli.workflow_get_failed');
+    throw new Error(`Failed to get workflow run: ${err.message}`);
+  }
+
+  if (!run) {
+    if (json) {
+      console.log(JSON.stringify({ error: 'not_found', runId }, null, 2));
+    } else {
+      console.log(`Workflow run not found: ${runId}`);
+    }
+    return;
+  }
+
+  // getWorkflowRun returns the base WorkflowRun (no current_step_name) — derive
+  // per-node detail from the event log, and only when verbose is requested.
+  let events: WorkflowEventRow[] | undefined;
+  if (verbose) {
+    try {
+      events = await workflowEventsDb.listWorkflowEvents(run.id);
+    } catch {
+      events = [];
+    }
+  }
+
+  if (json) {
+    console.log(JSON.stringify(verbose ? { ...run, events: events ?? [] } : run, null, 2));
+    return;
+  }
+
+  console.log(`  ID:     ${run.id}`);
+  console.log(`  Name:   ${run.workflow_name}`);
+  console.log(`  Path:   ${run.working_path ?? '(none)'}`);
+  console.log(`  Status: ${run.status}`);
+  console.log(`  Age:    ${formatAge(run.started_at)}`);
+  const runError = typeof run.metadata.error === 'string' ? run.metadata.error : undefined;
+  if (runError) {
+    console.log(`  Error:  ${runError}`);
+  }
+  if (events) {
+    printVerboseNodes(events);
+  }
+}
+
+/**
+ * List recent workflow runs for the current project (all statuses, cwd-scoped).
+ *
+ * Complements `status` (active-only): resolves the codebase from `cwd` the same
+ * way `workflow run` does, then lists that project's recent runs of every
+ * status. `--all` drops the project scope (lists across all projects);
+ * `--status` filters to one status; `--limit` caps the count (default 20).
+ */
+export async function workflowRunsCommand(
+  cwd: string,
+  opts: { json?: boolean; all?: boolean; status?: string; limit?: number } = {}
+): Promise<void> {
+  let statusFilter: WorkflowRunStatus | undefined;
+  if (opts.status) {
+    const parsed = workflowRunStatusSchema.safeParse(opts.status);
+    if (!parsed.success) {
+      throw new Error(
+        `Invalid --status '${opts.status}'. Valid: ${workflowRunStatusSchema.options.join(', ')}.`
+      );
+    }
+    statusFilter = parsed.data;
+  }
+
+  // Scope to this project by resolving the codebase from cwd (mirror
+  // workflowRunCommand). --all opts out of scoping. A lookup failure or an
+  // unregistered cwd both fall back to the global list — never a silent
+  // wrong-scope (the human path prints an explicit note below).
+  let codebase = null;
+  if (!opts.all) {
+    try {
+      codebase = await codebaseDb.findCodebaseByDefaultCwd(cwd);
+    } catch (error) {
+      getLog().warn({ err: error as Error, cwd }, 'cli.workflow_runs_codebase_lookup_failed');
+    }
+  }
+  const codebaseId = opts.all ? undefined : (codebase?.id ?? undefined);
+
+  let result;
+  try {
+    result = await workflowDb.listDashboardRuns({
+      ...(codebaseId ? { codebaseId } : {}),
+      ...(statusFilter ? { status: statusFilter } : {}),
+      limit: opts.limit ?? 20,
+    });
+  } catch (error) {
+    const err = error as Error;
+    getLog().error({ err, cwd }, 'cli.workflow_runs_failed');
+    throw new Error(`Failed to list workflow runs: ${err.message}`);
+  }
+
+  if (opts.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (!opts.all && !codebase) {
+    console.log('(not a registered project — showing all runs)');
+  }
+
+  if (result.runs.length === 0) {
+    console.log('No workflow runs found.');
+    return;
+  }
+
+  console.log(`\nRecent runs (${result.runs.length} of ${result.total}):\n`);
+  for (const run of result.runs) {
+    const step =
+      run.current_step_name !== null
+        ? ` · ${run.current_step_name}${run.total_steps !== null ? `/${String(run.total_steps)}` : ''}`
+        : '';
+    console.log(
+      `  ${run.id.slice(0, 8)}  ${run.status.padEnd(9)}  ${run.workflow_name}${step}  (${formatAge(run.started_at)})`
+    );
+  }
+  console.log('');
 }
 
 /**
@@ -1018,7 +1275,42 @@ export async function workflowStatusCommand(json?: boolean, verbose?: boolean): 
  * Re-executes the workflow with --resume semantics — the executor's
  * findResumableRun picks up the prior failed run and skips completed nodes.
  */
-export async function workflowResumeCommand(runId: string): Promise<void> {
+export async function workflowResumeCommand(runId: string, json?: boolean): Promise<void> {
+  // JSON mode is a non-blocking control-plane ack: validate the run is resumable
+  // and report its state, but do NOT re-execute the workflow inline (execution
+  // streams workflow output to stdout, which would corrupt the JSON contract).
+  // To actually execute a resumable run, use the blocking `resume` (no --json,
+  // run as a background task) or `run <name> --resume --detach`.
+  if (json) {
+    try {
+      const run = await resumeWorkflowOp(runId);
+      console.log(
+        JSON.stringify(
+          {
+            ok: true,
+            runId,
+            action: 'resume',
+            executed: false,
+            status: run.status,
+            workflowName: run.workflow_name,
+            workingPath: run.working_path,
+          },
+          null,
+          2
+        )
+      );
+    } catch (error) {
+      console.log(
+        JSON.stringify(
+          { ok: false, runId, action: 'resume', error: (error as Error).message },
+          null,
+          2
+        )
+      );
+    }
+    return;
+  }
+
   const run = await resumeWorkflowOp(runId);
   if (!run.working_path) {
     throw new Error(
@@ -1076,8 +1368,39 @@ export async function workflowResumeCommand(runId: string): Promise<void> {
 
 /**
  * Abandon a workflow run by ID (marks it as cancelled).
+ *
+ * `--json` emits a structured result instead of human text. In JSON mode the
+ * command never throws — lookup/state errors are reported as `{ ok: false }` so
+ * a parsing agent always gets one clean JSON line.
  */
-export async function workflowAbandonCommand(runId: string): Promise<void> {
+export async function workflowAbandonCommand(runId: string, json?: boolean): Promise<void> {
+  if (json) {
+    try {
+      const run = await abandonWorkflow(runId);
+      console.log(
+        JSON.stringify(
+          {
+            ok: true,
+            runId,
+            action: 'abandon',
+            status: 'cancelled',
+            workflowName: run.workflow_name,
+          },
+          null,
+          2
+        )
+      );
+    } catch (error) {
+      console.log(
+        JSON.stringify(
+          { ok: false, runId, action: 'abandon', error: (error as Error).message },
+          null,
+          2
+        )
+      );
+    }
+    return;
+  }
   const run = await abandonWorkflow(runId);
   console.log(`Abandoned workflow run: ${runId}`);
   console.log(`Workflow: ${run.workflow_name}`);
@@ -1087,7 +1410,44 @@ export async function workflowAbandonCommand(runId: string): Promise<void> {
  * Approve a paused workflow run by ID.
  * Writes the approval events and transitions to 'failed' for auto-resume.
  */
-export async function workflowApproveCommand(runId: string, comment?: string): Promise<void> {
+export async function workflowApproveCommand(
+  runId: string,
+  comment?: string,
+  json?: boolean
+): Promise<void> {
+  // JSON mode records the approval and returns a structured ack WITHOUT the
+  // inline auto-resume (resuming executes the workflow and streams output to
+  // stdout, which would corrupt the JSON contract). The run becomes resumable
+  // — drive it to completion with a backgrounded `resume`/`run --resume`.
+  if (json) {
+    try {
+      const result = await approveWorkflow(runId, comment);
+      console.log(
+        JSON.stringify(
+          {
+            ok: true,
+            runId,
+            action: 'approve',
+            type: result.type,
+            workflowName: result.workflowName,
+            resumable: true,
+          },
+          null,
+          2
+        )
+      );
+    } catch (error) {
+      console.log(
+        JSON.stringify(
+          { ok: false, runId, action: 'approve', error: (error as Error).message },
+          null,
+          2
+        )
+      );
+    }
+    return;
+  }
+
   const result = await approveWorkflow(runId, comment);
 
   // CLI auto-resumes after approval (unlike chat, which defers to next user message)
@@ -1171,7 +1531,45 @@ export async function workflowApproveCommand(runId: string, comment?: string): P
  * If the workflow has an on_reject prompt, auto-resumes with the rejection feedback;
  * otherwise marks the run as cancelled.
  */
-export async function workflowRejectCommand(runId: string, reason?: string): Promise<void> {
+export async function workflowRejectCommand(
+  runId: string,
+  reason?: string,
+  json?: boolean
+): Promise<void> {
+  // JSON mode records the rejection and returns a structured ack WITHOUT the
+  // inline auto-resume (an on_reject rework executes the workflow and streams
+  // to stdout, corrupting the JSON contract). When `cancelled` is false the run
+  // is resumable for the rework pass — drive it with a backgrounded `resume`.
+  if (json) {
+    try {
+      const result = await rejectWorkflow(runId, reason);
+      console.log(
+        JSON.stringify(
+          {
+            ok: true,
+            runId,
+            action: 'reject',
+            cancelled: result.cancelled,
+            maxAttemptsReached: result.maxAttemptsReached,
+            workflowName: result.workflowName,
+            resumable: !result.cancelled,
+          },
+          null,
+          2
+        )
+      );
+    } catch (error) {
+      console.log(
+        JSON.stringify(
+          { ok: false, runId, action: 'reject', error: (error as Error).message },
+          null,
+          2
+        )
+      );
+    }
+    return;
+  }
+
   const result = await rejectWorkflow(runId, reason);
 
   if (result.cancelled) {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -12,7 +12,7 @@ import { WORKFLOW_EVENT_TYPES, type WorkflowEventType } from '@archon/workflows/
 import { configureIsolation, getIsolationProvider } from '@archon/isolation';
 import { createLogger, getArchonHome, BUNDLED_IS_BINARY } from '@archon/paths';
 import { join } from 'node:path';
-import { mkdirSync, openSync } from 'node:fs';
+import { mkdirSync, openSync, closeSync } from 'node:fs';
 import { createWorkflowDeps } from '@archon/core/workflows/store-adapter';
 import { discoverWorkflowsWithConfig } from '@archon/workflows/workflow-discovery';
 import { resolveWorkflowName } from '@archon/workflows/router';
@@ -82,7 +82,12 @@ export interface WorkflowRunOptions {
    * exactly one worktree/conversation is created. The child does all the work.
    */
   detach?: boolean;
-  /** Emit a machine-readable JSON ack instead of human text (only honored with --detach). */
+  /**
+   * Emit a machine-readable JSON ack for the spawned child instead of human
+   * text. Only meaningful together with `detach`: without `detach` a foreground
+   * `workflow run` streams human output and has no JSON ack to emit (passing
+   * `--json` alone still suppresses CLI logs but does not change the output).
+   */
   json?: boolean;
 }
 
@@ -96,9 +101,11 @@ function generateConversationId(): string {
 }
 
 /**
- * Re-invoke `archon workflow run` (minus --detach) as a detached background
- * child so the caller's shell returns immediately. Reconstructs the current
- * argv, drops `--detach`, pins `--cwd` (absolute) plus any caller-supplied extra
+ * Re-invoke `archon workflow run` (minus --detach/--json) as a detached
+ * background child so the caller's shell returns immediately. Reconstructs the
+ * current argv, drops `--detach` (the child runs in the foreground) and `--json`
+ * (the parent already emitted the ack; the child should log normally to its log
+ * file, not run silent), pins `--cwd` (absolute) plus any caller-supplied extra
  * flags (a generated branch / conversation id), then detaches via `unref()`.
  *
  * `dispatchBackgroundWorkflow` is deliberately NOT reused here: it is web-
@@ -111,20 +118,43 @@ function generateConversationId(): string {
  * Falls back to discarding output only if the log file cannot be opened.
  * Returns the log path (or null when discarded) so the caller can surface it.
  */
+/**
+ * Build the argv for the detached re-invoke. Pure (no spawn / no process reads)
+ * so both the dev (bun + entry script) and compiled-binary (execPath only)
+ * branches are unit-testable — the binary branch is otherwise unreachable in
+ * tests because `BUNDLED_IS_BINARY` is a module-level const. Drops `--detach`
+ * and `--json` and appends `--cwd <cwd>` (last-wins) plus any extra flags.
+ */
+export function buildDetachedRunCmd(
+  isBinary: boolean,
+  execPath: string,
+  argv: string[],
+  cwd: string,
+  extraArgs: string[]
+): string[] {
+  // In a compiled binary, execPath IS the archon binary and there is no
+  // entry-script argv[1]; in dev, execPath is bun and argv[1] is the cli entry.
+  const baseCmd = isBinary ? [execPath] : [execPath, argv[1]];
+  const userArgs = (isBinary ? argv.slice(1) : argv.slice(2)).filter(
+    arg => arg !== '--detach' && arg !== '--json'
+  );
+  // --cwd is appended last (parseArgs last-wins) so the child resolves the same
+  // absolute working dir regardless of any relative --cwd the caller passed.
+  return [...baseCmd, ...userArgs, '--cwd', cwd, ...extraArgs];
+}
+
 function spawnDetachedWorkflowRun(
   cwd: string,
   conversationId: string,
   extraArgs: string[]
 ): string | null {
-  // In a compiled binary, process.execPath IS the archon binary and there is no
-  // entry-script argv[1]; in dev, execPath is bun and argv[1] is the cli entry.
-  const baseCmd = BUNDLED_IS_BINARY ? [process.execPath] : [process.execPath, process.argv[1]];
-  const userArgs = (BUNDLED_IS_BINARY ? process.argv.slice(1) : process.argv.slice(2)).filter(
-    arg => arg !== '--detach'
+  const cmd = buildDetachedRunCmd(
+    BUNDLED_IS_BINARY,
+    process.execPath,
+    process.argv,
+    cwd,
+    extraArgs
   );
-  // --cwd is appended last (parseArgs last-wins) so the child resolves the same
-  // absolute working dir regardless of any relative --cwd the caller passed.
-  const cmd = [...baseCmd, ...userArgs, '--cwd', cwd, ...extraArgs];
 
   let logPath: string | null = null;
   let logFd: number | undefined;
@@ -139,14 +169,25 @@ function spawnDetachedWorkflowRun(
     logFd = undefined;
   }
 
-  const child = Bun.spawn({
-    cmd,
-    cwd,
-    env: process.env,
-    stdio: ['ignore', logFd ?? 'ignore', logFd ?? 'ignore'],
-  });
-  // Detach: let the parent exit without waiting on (or killing) the child.
-  child.unref();
+  try {
+    const child = Bun.spawn({
+      cmd,
+      cwd,
+      env: process.env,
+      stdio: ['ignore', logFd ?? 'ignore', logFd ?? 'ignore'],
+    });
+    child.unref();
+  } finally {
+    // The child inherits its own dup of the log fd; close the parent's copy so a
+    // synchronous spawn failure (bad execPath, invalid cwd) doesn't leak it.
+    if (logFd !== undefined) {
+      try {
+        closeSync(logFd);
+      } catch {
+        /* fd already closed/invalid — nothing to clean up */
+      }
+    }
+  }
   return logPath;
 }
 
@@ -1047,6 +1088,24 @@ function buildNodeSummaries(events: WorkflowEventRow[]): NodeSummary[] {
 }
 
 /**
+ * Fetch a run's events for `--verbose` rendering. A failed event query must not
+ * abort the command (the run summary itself is still useful), but it must NOT be
+ * indistinguishable from "this run has no events" — so log a warn and flag the
+ * failure to the caller, which prints a visible note. (In `--json` mode logs are
+ * silenced; the empty `events` array is the documented signal there.)
+ */
+async function fetchVerboseEvents(
+  runId: string
+): Promise<{ events: WorkflowEventRow[]; failed: boolean }> {
+  try {
+    return { events: await workflowEventsDb.listWorkflowEvents(runId), failed: false };
+  } catch (error) {
+    getLog().warn({ err: error as Error, runId }, 'cli.workflow_events_fetch_failed');
+    return { events: [], failed: true };
+  }
+}
+
+/**
  * Render per-node summaries for a run's events as an indented "Nodes:" block.
  * Shared by `workflow status --verbose` and `workflow get --verbose`.
  * Prints nothing when the run has no node events.
@@ -1118,11 +1177,9 @@ export async function workflowStatusCommand(json?: boolean, verbose?: boolean): 
     console.log(`  Age:    ${age}`);
 
     if (verbose) {
-      let events: WorkflowEventRow[];
-      try {
-        events = await workflowEventsDb.listWorkflowEvents(run.id);
-      } catch {
-        events = [];
+      const { events, failed } = await fetchVerboseEvents(run.id);
+      if (failed) {
+        console.log('  (node events unavailable — see logs)');
       }
       printVerboseNodes(events);
     }
@@ -1143,7 +1200,7 @@ export async function workflowGetCommand(
   runId: string,
   json?: boolean,
   verbose?: boolean
-): Promise<void> {
+): Promise<number> {
   let run: WorkflowRun | null;
   try {
     run = await workflowDb.getWorkflowRun(runId);
@@ -1154,34 +1211,36 @@ export async function workflowGetCommand(
     // contract as the write commands) so a parsing agent always gets JSON.
     if (json) {
       console.log(JSON.stringify({ ok: false, runId, error: err.message }, null, 2));
-      return;
+      return 1;
     }
     throw new Error(`Failed to get workflow run: ${err.message}`);
   }
 
   if (!run) {
+    // Not-found exits non-zero so `get <id> && ...` and CI checks see the
+    // failure (the JSON envelope already carries ok:false for parsers).
     if (json) {
       console.log(JSON.stringify({ ok: false, runId, error: 'not_found' }, null, 2));
     } else {
       console.log(`Workflow run not found: ${runId}`);
     }
-    return;
+    return 1;
   }
 
   // getWorkflowRun returns the base WorkflowRun (no current_step_name) — derive
   // per-node detail from the event log, and only when verbose is requested.
   let events: WorkflowEventRow[] | undefined;
+  let eventsFailed = false;
   if (verbose) {
-    try {
-      events = await workflowEventsDb.listWorkflowEvents(run.id);
-    } catch {
-      events = [];
-    }
+    const fetched = await fetchVerboseEvents(run.id);
+    events = fetched.events;
+    eventsFailed = fetched.failed;
   }
 
   if (json) {
-    console.log(JSON.stringify(verbose ? { ...run, events: events ?? [] } : run, null, 2));
-    return;
+    const output = verbose ? { ...run, events: events ?? [] } : run;
+    console.log(JSON.stringify(output, null, 2));
+    return 0;
   }
 
   console.log(`  ID:     ${run.id}`);
@@ -1194,8 +1253,12 @@ export async function workflowGetCommand(
     console.log(`  Error:  ${runError}`);
   }
   if (events) {
+    if (eventsFailed) {
+      console.log('  (node events unavailable — see logs)');
+    }
     printVerboseNodes(events);
   }
+  return 0;
 }
 
 /**
@@ -1237,13 +1300,15 @@ export async function workflowRunsCommand(
       getLog().warn({ err: error as Error, cwd }, 'cli.workflow_runs_codebase_lookup_failed');
     }
   }
-  const codebaseId = opts.all ? undefined : (codebase?.id ?? undefined);
+  // listDashboardRuns ignores undefined filters (truthy-guarded WHERE clauses),
+  // so pass codebaseId/status straight through — no conditional spread needed.
+  const codebaseId = opts.all ? undefined : codebase?.id;
 
   let result;
   try {
     result = await workflowDb.listDashboardRuns({
-      ...(codebaseId ? { codebaseId } : {}),
-      ...(statusFilter ? { status: statusFilter } : {}),
+      codebaseId,
+      status: statusFilter,
       limit: opts.limit ?? 20,
     });
   } catch (error) {
@@ -1256,12 +1321,18 @@ export async function workflowRunsCommand(
     throw new Error(`Failed to list workflow runs: ${err.message}`);
   }
 
+  // True when project scoping was requested but fell back to the global list
+  // (unregistered cwd or a lookup failure). The human path prints a note below;
+  // surface the same signal in --json so an agent isn't handed a global result
+  // it silently mistakes for a project-scoped one.
+  const scopeFallback = !opts.all && !codebase;
+
   if (opts.json) {
-    console.log(JSON.stringify(result, null, 2));
+    console.log(JSON.stringify({ ...result, scopeFallback }, null, 2));
     return;
   }
 
-  if (!opts.all && !codebase) {
+  if (scopeFallback) {
     console.log('(not a registered project — showing all runs)');
   }
 
@@ -1284,10 +1355,22 @@ export async function workflowRunsCommand(
 }
 
 /**
+ * Emit the standard `{ ok: false }` error line for a `--json` write command
+ * (approve/reject/abandon/resume). Centralizes the envelope so all four stay in
+ * lockstep; never throws — in --json mode the JSON line IS the error surface.
+ */
+function printJsonWriteError(runId: string, action: string, error: unknown): void {
+  console.log(
+    JSON.stringify({ ok: false, runId, action, error: (error as Error).message }, null, 2)
+  );
+}
+
+/**
  * Resume a failed workflow run by ID.
  *
- * Re-executes the workflow with --resume semantics — the executor's
- * findResumableRun picks up the prior failed run and skips completed nodes.
+ * Re-executes the workflow with --resume semantics: `workflowRunCommand` locates
+ * the prior failed run via findResumableRun and hands it to the executor, which
+ * skips already-completed nodes (the executor no longer auto-detects on its own).
  */
 export async function workflowResumeCommand(runId: string, json?: boolean): Promise<void> {
   // JSON mode is a non-blocking control-plane ack: validate the run is resumable
@@ -1314,13 +1397,7 @@ export async function workflowResumeCommand(runId: string, json?: boolean): Prom
         )
       );
     } catch (error) {
-      console.log(
-        JSON.stringify(
-          { ok: false, runId, action: 'resume', error: (error as Error).message },
-          null,
-          2
-        )
-      );
+      printJsonWriteError(runId, 'resume', error);
     }
     return;
   }
@@ -1361,9 +1438,9 @@ export async function workflowResumeCommand(runId: string, json?: boolean): Prom
   }
   if (discoveryCwd) console.log(`Discovery path: ${discoveryCwd}`);
 
-  // Re-execute via workflowRunCommand with --resume.
-  // The executor's implicit findResumableRun detects the prior failed run
-  // and skips already-completed nodes.
+  // Re-execute via workflowRunCommand with --resume: it locates the prior failed
+  // run via findResumableRun and skips already-completed nodes (the executor
+  // itself no longer auto-detects resumable runs).
   try {
     await workflowRunCommand(run.working_path, run.workflow_name, run.user_message ?? '', {
       resume: true,
@@ -1405,16 +1482,11 @@ export async function workflowAbandonCommand(runId: string, json?: boolean): Pro
         )
       );
     } catch (error) {
-      console.log(
-        JSON.stringify(
-          { ok: false, runId, action: 'abandon', error: (error as Error).message },
-          null,
-          2
-        )
-      );
+      printJsonWriteError(runId, 'abandon', error);
     }
     return;
   }
+
   const run = await abandonWorkflow(runId);
   console.log(`Abandoned workflow run: ${runId}`);
   console.log(`Workflow: ${run.workflow_name}`);
@@ -1422,7 +1494,11 @@ export async function workflowAbandonCommand(runId: string, json?: boolean): Pro
 
 /**
  * Approve a paused workflow run by ID.
- * Writes the approval events and transitions to 'failed' for auto-resume.
+ *
+ * Human mode writes the approval events (transitioning to 'failed') and then
+ * auto-resumes the run inline. `--json` mode records the approval and returns a
+ * structured ack WITHOUT resuming — the run is left resumable for a backgrounded
+ * `resume`/`run --resume` (inline resume would stream output and break the JSON).
  */
 export async function workflowApproveCommand(
   runId: string,
@@ -1451,13 +1527,7 @@ export async function workflowApproveCommand(
         )
       );
     } catch (error) {
-      console.log(
-        JSON.stringify(
-          { ok: false, runId, action: 'approve', error: (error as Error).message },
-          null,
-          2
-        )
-      );
+      printJsonWriteError(runId, 'approve', error);
     }
     return;
   }
@@ -1573,13 +1643,7 @@ export async function workflowRejectCommand(
         )
       );
     } catch (error) {
-      console.log(
-        JSON.stringify(
-          { ok: false, runId, action: 'reject', error: (error as Error).message },
-          null,
-          2
-        )
-      );
+      printJsonWriteError(runId, 'reject', error);
     }
     return;
   }

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1150,12 +1150,18 @@ export async function workflowGetCommand(
   } catch (error) {
     const err = error as Error;
     getLog().error({ err, runId }, 'cli.workflow_get_failed');
+    // In --json mode never throw — emit one parseable {ok:false} line (same
+    // contract as the write commands) so a parsing agent always gets JSON.
+    if (json) {
+      console.log(JSON.stringify({ ok: false, runId, error: err.message }, null, 2));
+      return;
+    }
     throw new Error(`Failed to get workflow run: ${err.message}`);
   }
 
   if (!run) {
     if (json) {
-      console.log(JSON.stringify({ error: 'not_found', runId }, null, 2));
+      console.log(JSON.stringify({ ok: false, runId, error: 'not_found' }, null, 2));
     } else {
       console.log(`Workflow run not found: ${runId}`);
     }
@@ -1208,9 +1214,13 @@ export async function workflowRunsCommand(
   if (opts.status) {
     const parsed = workflowRunStatusSchema.safeParse(opts.status);
     if (!parsed.success) {
-      throw new Error(
-        `Invalid --status '${opts.status}'. Valid: ${workflowRunStatusSchema.options.join(', ')}.`
-      );
+      const msg = `Invalid --status '${opts.status}'. Valid: ${workflowRunStatusSchema.options.join(', ')}.`;
+      // --json never throws — emit one parseable {ok:false} line (write-command contract).
+      if (opts.json) {
+        console.log(JSON.stringify({ ok: false, error: msg }, null, 2));
+        return;
+      }
+      throw new Error(msg);
     }
     statusFilter = parsed.data;
   }
@@ -1239,6 +1249,10 @@ export async function workflowRunsCommand(
   } catch (error) {
     const err = error as Error;
     getLog().error({ err, cwd }, 'cli.workflow_runs_failed');
+    if (opts.json) {
+      console.log(JSON.stringify({ ok: false, error: err.message }, null, 2));
+      return;
+    }
     throw new Error(`Failed to list workflow runs: ${err.message}`);
   }
 

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -175,6 +175,7 @@ mock.module('./prompt-builder', () => ({
   buildOrchestratorPrompt: mock(() => 'orchestrator system prompt'),
   buildProjectScopedPrompt: mock(() => 'project scoped system prompt'),
   buildOrchestratorSystemAppend: mock(() => 'orchestrator system append'),
+  buildRunManagementSection: mock(() => '## Managing Workflow Runs\n(mocked)'),
   formatWorkflowContextSection: mock((results: unknown[]) =>
     results.length > 0 ? '## Recent Workflow Results\n\n...' : ''
   ),

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1140,6 +1140,54 @@ describe('discoverAllWorkflows — remote sync', () => {
     expect(typeof requestOptions.systemPrompt).toBe('string');
     expect(requestOptions.systemPrompt).toBe('orchestrator system append');
   });
+
+  test('appends the run-management section (and no native tool) for a project-scoped non-native-tool provider', async () => {
+    const providers = await import('@archon/providers');
+    const capsMock = providers.getProviderCapabilities as ReturnType<typeof mock>;
+    capsMock.mockReturnValue({ envInjection: true, nativeTools: false });
+    mockGetOrCreateConversation.mockReturnValueOnce(
+      Promise.resolve(makeConversation({ ai_assistant_type: 'codex', codebase_id: 'codebase-1' }))
+    );
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeCodebaseForSync()));
+
+    try {
+      const platform = makePlatform();
+      await handleMessage(platform, 'conv-1', 'Hello');
+
+      const requestOptions = mockSendQuery.mock.calls[0][3] as Record<string, unknown>;
+      // Codex → plain-string prompt that now carries the CLI pointer section.
+      expect(requestOptions.systemPrompt).toContain('## Managing Workflow Runs');
+      // Providers without native tools get NO in-process tool — bash CLI only.
+      expect(requestOptions.nativeTools).toBeUndefined();
+    } finally {
+      capsMock.mockReturnValue({ envInjection: true });
+    }
+  });
+
+  test('omits the run-management section and injects the native tool for a project-scoped native-tool provider', async () => {
+    const providers = await import('@archon/providers');
+    const capsMock = providers.getProviderCapabilities as ReturnType<typeof mock>;
+    capsMock.mockReturnValue({ envInjection: true, nativeTools: true });
+    mockGetOrCreateConversation.mockReturnValueOnce(
+      Promise.resolve(makeConversation({ ai_assistant_type: 'claude', codebase_id: 'codebase-1' }))
+    );
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeCodebaseForSync()));
+
+    try {
+      const platform = makePlatform();
+      await handleMessage(platform, 'conv-1', 'Hello');
+
+      const requestOptions = mockSendQuery.mock.calls[0][3] as Record<string, unknown>;
+      // Claude → preset object; the append must NOT carry the CLI pointer
+      // (it gets the in-process tool instead, so the pointer would be redundant).
+      const sp = requestOptions.systemPrompt as { append?: string };
+      expect(sp.append).not.toContain('## Managing Workflow Runs');
+      // Native-tool provider gets the manage_run tool instead.
+      expect(Array.isArray(requestOptions.nativeTools)).toBe(true);
+    } finally {
+      capsMock.mockReturnValue({ envInjection: true });
+    }
+  });
 });
 
 // ─── Workflow dispatch routing — interactive flag ─────────────────────────────

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -51,7 +51,11 @@ import type { MergedConfig } from '../config/config-types';
 import { generateAndSetTitle } from '../services/title-generator';
 import { validateAndResolveIsolation, dispatchBackgroundWorkflow } from './orchestrator';
 import { IsolationBlockedError } from '@archon/isolation';
-import { buildOrchestratorSystemAppend, formatWorkflowContextSection } from './prompt-builder';
+import {
+  buildOrchestratorSystemAppend,
+  buildRunManagementSection,
+  formatWorkflowContextSection,
+} from './prompt-builder';
 import type { WorkflowResultContext } from './prompt-builder';
 import * as messageDb from '../db/messages';
 import * as workflowDb from '../db/workflows';
@@ -1037,7 +1041,22 @@ export async function handleMessage(
 
     // Claude supports the preset object for prompt caching; other providers
     // need a plain string (Pi coerces non-string to undefined, Codex ignores it).
-    const systemAppend = buildOrchestratorSystemAppend(conversation, codebases, workflows);
+    let systemAppend = buildOrchestratorSystemAppend(conversation, codebases, workflows);
+    // Capabilities are only consulted for project-scoped chats (both the native tool
+    // and the CLI pointer are scoped features), so look them up lazily — this also
+    // avoids a registry lookup (and a throw for an unregistered provider) on the
+    // unscoped path.
+    const scopedCaps =
+      conversation.codebase_id !== null ? getProviderCapabilities(providerKey) : null;
+    // Providers WITHOUT the in-process manage_run tool (Codex/OpenCode/Copilot) get a
+    // system-prompt pointer to the `archon workflow …` CLI so they can still manage this
+    // project's runs over bash. Claude/Pi get the native tool below and are nudged to it
+    // — adding the CLI pointer there would be redundant and steer them onto a bash path
+    // that needs `archon` on PATH. Project-scoped only: the CLI commands require a
+    // git-repo cwd, which unscoped chats (cwd ~/.archon/workspaces) don't have.
+    if (scopedCaps !== null && !scopedCaps.nativeTools) {
+      systemAppend += `\n\n${buildRunManagementSection()}`;
+    }
     const systemPrompt =
       providerKey === 'claude'
         ? { type: 'preset' as const, preset: 'claude_code' as const, append: systemAppend }
@@ -1051,8 +1070,10 @@ export async function handleMessage(
 
     // Project-scoped chats get the `manage_run` tool so the agent can see and
     // launch this project's workflow runs. Only when a codebase is scoped and
-    // the provider supports in-process native tools (Claude, Pi).
-    if (conversation.codebase_id !== null && getProviderCapabilities(providerKey).nativeTools) {
+    // the provider supports in-process native tools (Claude, Pi). The explicit
+    // codebase_id check (redundant with scopedCaps !== null) narrows it to string
+    // for the block below.
+    if (conversation.codebase_id !== null && scopedCaps?.nativeTools) {
       const scopedCodebaseId = conversation.codebase_id;
       requestOptions.nativeTools = [
         buildManageRunTool({

--- a/packages/core/src/orchestrator/prompt-builder.test.ts
+++ b/packages/core/src/orchestrator/prompt-builder.test.ts
@@ -3,6 +3,7 @@ import {
   buildRoutingRulesWithProject,
   formatWorkflowContextSection,
   buildOrchestratorSystemAppend,
+  buildRunManagementSection,
 } from './prompt-builder';
 
 describe('buildRoutingRulesWithProject', () => {
@@ -133,5 +134,38 @@ describe('buildOrchestratorSystemAppend', () => {
       workflows
     );
     expect(result).toContain('## Registered Projects');
+  });
+
+  test('appends the run-management section for a scoped conversation', () => {
+    const result = buildOrchestratorSystemAppend(makeConversation('cb-1'), codebases, workflows);
+    expect(result).toContain('## Managing Workflow Runs');
+    expect(result).toContain('archon workflow runs');
+    expect(result).toContain('--detach');
+  });
+
+  test('appends the run-management section for an unscoped conversation', () => {
+    const result = buildOrchestratorSystemAppend(makeConversation(null), codebases, workflows);
+    expect(result).toContain('## Managing Workflow Runs');
+    expect(result).toContain('archon workflow approve');
+  });
+});
+
+describe('buildRunManagementSection', () => {
+  test('lists the run-management verbs and the --json hint', () => {
+    const section = buildRunManagementSection();
+    expect(section).toContain('## Managing Workflow Runs');
+    for (const verb of [
+      'archon workflow runs',
+      'archon workflow get',
+      'archon workflow status',
+      'archon workflow run',
+      'archon workflow approve',
+      'archon workflow reject',
+      'archon workflow abandon',
+    ]) {
+      expect(section).toContain(verb);
+    }
+    expect(section).toContain('--json');
+    expect(section).toContain('--detach');
   });
 });

--- a/packages/core/src/orchestrator/prompt-builder.test.ts
+++ b/packages/core/src/orchestrator/prompt-builder.test.ts
@@ -161,6 +161,7 @@ describe('buildRunManagementSection', () => {
       'archon workflow run',
       'archon workflow approve',
       'archon workflow reject',
+      'archon workflow resume',
       'archon workflow abandon',
     ]) {
       expect(section).toContain(verb);

--- a/packages/core/src/orchestrator/prompt-builder.test.ts
+++ b/packages/core/src/orchestrator/prompt-builder.test.ts
@@ -136,17 +136,14 @@ describe('buildOrchestratorSystemAppend', () => {
     expect(result).toContain('## Registered Projects');
   });
 
-  test('appends the run-management section for a scoped conversation', () => {
-    const result = buildOrchestratorSystemAppend(makeConversation('cb-1'), codebases, workflows);
-    expect(result).toContain('## Managing Workflow Runs');
-    expect(result).toContain('archon workflow runs');
-    expect(result).toContain('--detach');
-  });
-
-  test('appends the run-management section for an unscoped conversation', () => {
-    const result = buildOrchestratorSystemAppend(makeConversation(null), codebases, workflows);
-    expect(result).toContain('## Managing Workflow Runs');
-    expect(result).toContain('archon workflow approve');
+  test('does NOT include the run-management section (orchestrator gates it per-provider)', () => {
+    // The CLI run-management pointer is appended by orchestrator-agent.ts only for
+    // project-scoped chats on providers WITHOUT the native manage_run tool — never
+    // here, so Claude/Pi (nativeTools) don't get a redundant pointer.
+    const scoped = buildOrchestratorSystemAppend(makeConversation('cb-1'), codebases, workflows);
+    const unscoped = buildOrchestratorSystemAppend(makeConversation(null), codebases, workflows);
+    expect(scoped).not.toContain('## Managing Workflow Runs');
+    expect(unscoped).not.toContain('## Managing Workflow Runs');
   });
 });
 

--- a/packages/core/src/orchestrator/prompt-builder.ts
+++ b/packages/core/src/orchestrator/prompt-builder.ts
@@ -228,14 +228,17 @@ export function buildRunManagementSection(): string {
 
 You can inspect and control this project's workflow runs directly via the \`archon\` CLI (bash) — you do NOT need to invoke a workflow for run management. Add \`--json\` to any command for a single clean, machine-readable line.
 
+Run these from within the project's git repo (any subdirectory works — they resolve to the repo root, which also scopes \`runs\` to this project). They fail with "Not in a git repository" if the working directory is \`~/.archon/workspaces/\` or another non-repo path.
+
 - \`archon workflow runs [--json]\` — recent runs of ALL statuses for this project
 - \`archon workflow get <run-id> [--json]\` — one run's status/error (add \`--verbose\` for per-node detail)
 - \`archon workflow status [--json]\` — active runs only (running/paused)
 - \`archon workflow run <workflow> "<message>" --detach\` — start a run in the background (returns immediately)
 - \`archon workflow approve <run-id> [--json]\` / \`archon workflow reject <run-id> [reason] [--json]\` — resolve a paused approval gate
+- \`archon workflow resume <run-id>\` — re-run a failed/paused run, skipping completed nodes (run as a background task; \`--json\` validates only)
 - \`archon workflow abandon <run-id> [--json]\` — cancel a non-terminal run
 
-When the user asks what's running, whether a run passed/failed, or to approve / reject / cancel a run, use these commands directly instead of invoking a workflow. The \`manage-run\` skill has the full reference if it is loaded.`;
+When the user asks what's running, whether a run passed/failed, or to approve / reject / resume / cancel a run, use these commands directly instead of invoking a workflow. The \`manage-run\` skill has the full reference if it is loaded.`;
 }
 
 /**

--- a/packages/core/src/orchestrator/prompt-builder.ts
+++ b/packages/core/src/orchestrator/prompt-builder.ts
@@ -213,9 +213,36 @@ ${formatProjectSection(scopedCodebase)}
 }
 
 /**
+ * Build the run-management section of the orchestrator prompt.
+ *
+ * Teaches the chat agent (any provider) that it can inspect and control workflow
+ * runs directly via the `archon` CLI over bash — the cross-provider delivery of
+ * the `manage-run` skill. Direct chat is the one path where the `skills:` option
+ * is NOT consumed (it is workflow-node-only), so the system prompt is the only
+ * reliable channel that reaches every provider, including Codex (no skills
+ * capability). Invocation inherits the same `archon`-on-PATH convention the
+ * `archon` skill already assumes.
+ */
+export function buildRunManagementSection(): string {
+  return `## Managing Workflow Runs
+
+You can inspect and control this project's workflow runs directly via the \`archon\` CLI (bash) — you do NOT need to invoke a workflow for run management. Add \`--json\` to any command for a single clean, machine-readable line.
+
+- \`archon workflow runs [--json]\` — recent runs of ALL statuses for this project
+- \`archon workflow get <run-id> [--json]\` — one run's status/error (add \`--verbose\` for per-node detail)
+- \`archon workflow status [--json]\` — active runs only (running/paused)
+- \`archon workflow run <workflow> "<message>" --detach\` — start a run in the background (returns immediately)
+- \`archon workflow approve <run-id> [--json]\` / \`archon workflow reject <run-id> [reason] [--json]\` — resolve a paused approval gate
+- \`archon workflow abandon <run-id> [--json]\` — cancel a non-terminal run
+
+When the user asks what's running, whether a run passed/failed, or to approve / reject / cancel a run, use these commands directly instead of invoking a workflow. The \`manage-run\` skill has the full reference if it is loaded.`;
+}
+
+/**
  * Build the static orchestrator context string for use as a cacheable system prompt append.
  * Returns the same content as buildOrchestratorPrompt/buildProjectScopedPrompt depending
- * on whether the conversation is scoped to a project.
+ * on whether the conversation is scoped to a project, with the run-management section
+ * appended so every provider's direct chat can drive run management via the CLI.
  */
 export function buildOrchestratorSystemAppend(
   conversation: Conversation,
@@ -226,7 +253,9 @@ export function buildOrchestratorSystemAppend(
     ? codebases.find(c => c.id === conversation.codebase_id)
     : undefined;
 
-  return scopedCodebase
+  const base = scopedCodebase
     ? buildProjectScopedPrompt(scopedCodebase, codebases, workflows)
     : buildOrchestratorPrompt(codebases, workflows);
+
+  return `${base}\n\n${buildRunManagementSection()}`;
 }

--- a/packages/core/src/orchestrator/prompt-builder.ts
+++ b/packages/core/src/orchestrator/prompt-builder.ts
@@ -215,13 +215,15 @@ ${formatProjectSection(scopedCodebase)}
 /**
  * Build the run-management section of the orchestrator prompt.
  *
- * Teaches the chat agent (any provider) that it can inspect and control workflow
- * runs directly via the `archon` CLI over bash — the cross-provider delivery of
- * the `manage-run` skill. Direct chat is the one path where the `skills:` option
- * is NOT consumed (it is workflow-node-only), so the system prompt is the only
- * reliable channel that reaches every provider, including Codex (no skills
- * capability). Invocation inherits the same `archon`-on-PATH convention the
- * `archon` skill already assumes.
+ * Teaches the chat agent it can inspect and control workflow runs directly via
+ * the `archon` CLI over bash — the delivery of the `manage-run` skill for
+ * providers WITHOUT the in-process `manage_run` tool. Direct chat is the one path
+ * where the `skills:` option is NOT consumed (it is workflow-node-only), so the
+ * system prompt is the only channel that reaches Codex/OpenCode/Copilot. The
+ * orchestrator (orchestrator-agent.ts) appends this ONLY for project-scoped chats
+ * on non-nativeTools providers — Claude/Pi use the native tool instead, and the
+ * CLI commands require a git-repo cwd that unscoped chats don't have. Invocation
+ * inherits the same `archon`-on-PATH convention the `archon` skill already assumes.
  */
 export function buildRunManagementSection(): string {
   return `## Managing Workflow Runs
@@ -244,8 +246,9 @@ When the user asks what's running, whether a run passed/failed, or to approve / 
 /**
  * Build the static orchestrator context string for use as a cacheable system prompt append.
  * Returns the same content as buildOrchestratorPrompt/buildProjectScopedPrompt depending
- * on whether the conversation is scoped to a project, with the run-management section
- * appended so every provider's direct chat can drive run management via the CLI.
+ * on whether the conversation is scoped to a project. The run-management section is NOT
+ * appended here — the orchestrator adds it conditionally (project-scoped + non-nativeTools
+ * providers) via buildRunManagementSection().
  */
 export function buildOrchestratorSystemAppend(
   conversation: Conversation,
@@ -256,9 +259,7 @@ export function buildOrchestratorSystemAppend(
     ? codebases.find(c => c.id === conversation.codebase_id)
     : undefined;
 
-  const base = scopedCodebase
+  return scopedCodebase
     ? buildProjectScopedPrompt(scopedCodebase, codebases, workflows)
     : buildOrchestratorPrompt(codebases, workflows);
-
-  return `${base}\n\n${buildRunManagementSection()}`;
 }

--- a/packages/docs-web/src/content/docs/contributing/cli-internals.md
+++ b/packages/docs-web/src/content/docs/contributing/cli-internals.md
@@ -18,7 +18,7 @@ packages/cli/
 ├── src/
 │   ├── cli.ts              # Entry point, argument parsing, routing
 │   ├── commands/
-│   │   ├── workflow.ts     # workflow list/run (approve/reject/status/resume/abandon delegate to @archon/core/operations)
+│   │   ├── workflow.ts     # workflow list/run/runs/get (approve/reject/status/resume/abandon delegate to @archon/core/operations)
 │   │   ├── isolation.ts    # isolation list/cleanup (list/merged-cleanup delegate to @archon/core/operations)
 │   │   ├── setup.ts        # setup command implementation
 │   │   ├── chat.ts         # chat command implementation

--- a/packages/docs-web/src/content/docs/getting-started/overview.md
+++ b/packages/docs-web/src/content/docs/getting-started/overview.md
@@ -306,8 +306,10 @@ archon workflow run <name> --cwd /path/to/repo "<message>"
 | `archon setup` | Interactive setup wizard for credentials and config |
 | `archon doctor` | Verify your setup (Claude binary, gh auth, DB, adapters) |
 | `archon workflow list` | List available workflows |
-| `archon workflow run <name> [msg]` | Run a workflow |
-| `archon workflow status` | Show running workflows |
+| `archon workflow run <name> [msg]` | Run a workflow (`--detach` to background it) |
+| `archon workflow status` | Show active runs (running + paused) |
+| `archon workflow runs` | List recent runs of every status for this project |
+| `archon workflow get <id>` | Show detail for a single run (any status) |
 | `archon workflow resume <id>` | Resume a failed workflow |
 | `archon workflow abandon <id>` | Abandon a non-terminal run |
 | `archon workflow approve <id> [comment]` | Approve an interactive loop gate |
@@ -465,13 +467,14 @@ If you want Claude Code to be able to invoke Archon workflows on your behalf, in
 Archon skill into your project. The setup wizard handles this automatically — just run
 `archon setup` and accept the skill installation prompt.
 
-To install manually instead:
+To install manually instead, run `archon skill install /path/to/your/repo` (which writes both the `archon` and `manage-run` skills), or copy them by hand:
 
 ```bash
 cp -r Archon/.claude/skills/archon /path/to/your/repo/.claude/skills/
+cp -r Archon/.claude/skills/manage-run /path/to/your/repo/.claude/skills/
 ```
 
-Then in Claude Code, say things like "use archon to fix issue #42" and it will invoke the appropriate workflow.
+Then in Claude Code, say things like "use archon to fix issue #42" and it will invoke the appropriate workflow. The `manage-run` skill lets it inspect and control runs (`archon workflow runs`/`get`/`approve`...).
 
 ---
 

--- a/packages/docs-web/src/content/docs/guides/skills.md
+++ b/packages/docs-web/src/content/docs/guides/skills.md
@@ -170,6 +170,7 @@ smaller box with a tastefully curated set of tools."
 | Skill | Install | What It Teaches |
 |-------|---------|----------------|
 | `archon` (bundled) | `archon skill install` | Archon workflows, commands, and project conventions |
+| `manage-run` (bundled) | `archon skill install` | Inspect and control workflow runs via the `archon` CLI (focused run-management skill) |
 | `remotion-best-practices` | `npx skills add remotion-dev/skills` | Remotion animation patterns, API usage, gotchas (35 rules) |
 | `skill-creator` | `npx skills add anthropics/skills` | How to create new SKILL.md files |
 | Community skills | Browse [skills.sh](https://skills.sh) | Search 500K+ skills for any domain |

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -175,6 +175,7 @@ Progress events (node start/complete/fail/skip, approval gates) are written to s
 | `--resume` | Resume from last failed run at the working path (skips completed nodes) |
 | `--quiet`, `-q` | Suppress all progress output to stderr |
 | `--verbose`, `-v` | Also show tool-level events (tool name and duration) |
+| `--detach` | Run in a detached background child and return immediately. The child does all the work; find it later with `workflow runs`/`workflow get`. Child stdout/stderr is captured to `~/.archon/logs/detached-run-<id>.log`. Combine with `--json` for a machine-readable ack. |
 
 **Default (no flags):**
 - Creates worktree with auto-generated branch (`archon/task-<workflow>-<timestamp>`)
@@ -205,11 +206,36 @@ Ambiguous workflow 'review'. Did you mean:
 
 ### `workflow status`
 
-Show all running workflow runs across all worktrees.
+Show **active** workflow runs (running and paused) across all worktrees. For full history (all statuses) scoped to the current project, use `workflow runs`.
 
 ```bash
 archon workflow status
 archon workflow status --json
+archon workflow status --verbose   # add a per-node summary for each run
+```
+
+### `workflow runs`
+
+List recent runs of **every** status (completed, failed, cancelled, running, paused) for the current project. The project is resolved from `cwd` the same way `workflow run` does. Complements `workflow status` (which is active-only).
+
+```bash
+archon workflow runs
+archon workflow runs --json
+archon workflow runs --status failed   # filter to one status
+archon workflow runs --limit 50        # cap rows (default 20)
+archon workflow runs --all             # list across all projects (ignore cwd scope)
+```
+
+If `cwd` is not a registered project, the command falls back to a global list and says so — `--json` carries this as a `scopeFallback: true` field so a consuming agent never mistakes a global result for a project-scoped one.
+
+### `workflow get`
+
+Show detail for a single run by ID, regardless of status (unlike `status`, which is active-only). Use it to answer "did that run pass?" for a completed/failed run. Exits non-zero when the run is not found.
+
+```bash
+archon workflow get <run-id>
+archon workflow get <run-id> --json
+archon workflow get <run-id> --verbose   # add the per-node event summary
 ```
 
 ### `workflow resume`
@@ -218,7 +244,10 @@ Resume a failed workflow run. Re-executes the workflow, automatically skipping n
 
 ```bash
 archon workflow resume <run-id>
+archon workflow resume <run-id> --json   # validate + ack only; does NOT re-execute inline
 ```
+
+In `--json` mode the command is a non-blocking control-plane ack: it validates the run is resumable and reports its state but does **not** re-execute inline (execution streams output to stdout, which would corrupt the JSON). To actually drive a resumable run to completion, use the blocking form or `workflow run <name> --resume --detach`.
 
 ### `workflow abandon`
 
@@ -226,6 +255,7 @@ Discard a workflow run (marks it as `cancelled`). Use this to unblock a worktree
 
 ```bash
 archon workflow abandon <run-id>
+archon workflow abandon <run-id> --json
 ```
 
 ### `workflow approve`
@@ -236,7 +266,10 @@ Approve a paused workflow run at an interactive approval gate. Optionally provid
 archon workflow approve <run-id>
 archon workflow approve <run-id> "Looks good, proceed"
 archon workflow approve <run-id> --comment "Looks good, proceed"
+archon workflow approve <run-id> --json   # record approval + ack; does NOT auto-resume inline
 ```
+
+In human mode `approve`/`reject` auto-resume the run inline. In `--json` mode they record the decision and return an ack **without** resuming (the run is left resumable for a backgrounded `resume`/`run --resume`).
 
 ### `workflow reject`
 
@@ -245,6 +278,7 @@ Reject a paused workflow run at an approval gate. Optionally provide a reason th
 ```bash
 archon workflow reject <run-id>
 archon workflow reject <run-id> --reason "Needs more tests"
+archon workflow reject <run-id> --json
 ```
 
 ### `workflow cleanup`
@@ -381,7 +415,7 @@ The cached web UI is stored at `~/.archon/web-dist/<version>/`. Each version is 
 
 ### `skill install [path]`
 
-Install the bundled Archon skill files into a project's `.claude/skills/archon/` directory. Always overwrites existing files to ensure the latest version shipped with the current Archon binary is installed.
+Install the bundled Archon skills into a project's `.claude/skills/` directory. Always overwrites existing files to ensure the latest version shipped with the current Archon binary is installed.
 
 ```bash
 # Install into the current directory
@@ -391,7 +425,7 @@ archon skill install
 archon skill install /path/to/project
 ```
 
-The Archon skill teaches Claude Code how to work with Archon workflows, commands, and project conventions. It is also installed automatically during `archon setup`.
+Two skills are installed: **`archon`** (`.claude/skills/archon/`), which teaches Claude Code how to work with Archon workflows, commands, and project conventions; and **`manage-run`** (`.claude/skills/manage-run/`), a focused skill for inspecting and controlling workflow runs via the `archon` CLI. Both are also installed automatically during `archon setup`.
 
 ### `version`
 
@@ -408,7 +442,7 @@ archon version
 | `--cwd <path>` | Override working directory (default: current directory) |
 | `--quiet`, `-q` | Reduce log verbosity to warnings and errors only |
 | `--verbose`, `-v` | Show debug-level output |
-| `--json` | Output machine-readable JSON (for workflow list, workflow status) |
+| `--json` | Output machine-readable JSON (workflow `list`, `status`, `runs`, `get`, and the write commands `approve`/`reject`/`abandon`/`resume`). Implies log suppression so stdout is exactly the JSON payload. |
 | `--help`, `-h` | Show help message |
 
 ## Working Directory

--- a/packages/paths/src/logger.ts
+++ b/packages/paths/src/logger.ts
@@ -8,12 +8,14 @@
  *   log.error({ err, conversationId }, 'session_failed');
  *
  * Log levels (standard Pino levels):
- *   fatal (60) - Process cannot continue
- *   error (50) - Failures needing immediate attention
- *   warn  (40) - Degraded behavior, fallbacks
- *   info  (30) - Key user-visible events (DEFAULT)
- *   debug (20) - Internal details, tool calls, state transitions
- *   trace (10) - Fine-grained diagnostic output
+ *   fatal  (60) - Process cannot continue
+ *   error  (50) - Failures needing immediate attention
+ *   warn   (40) - Degraded behavior, fallbacks
+ *   info   (30) - Key user-visible events (DEFAULT)
+ *   debug  (20) - Internal details, tool calls, state transitions
+ *   trace  (10) - Fine-grained diagnostic output
+ *   silent      - Disables all logging (used by the CLI in --json mode so no
+ *                 log line can interleave with the machine-readable payload)
  *
  * Configuration:
  *   LOG_LEVEL env var or setLogLevel() at startup
@@ -27,7 +29,9 @@ import pretty from 'pino-pretty';
 
 export type { Logger } from 'pino';
 
-const VALID_LEVELS = new Set(['fatal', 'error', 'warn', 'info', 'debug', 'trace']);
+// 'silent' is Pino's built-in level that disables all output. The CLI uses it
+// in --json mode to keep stdout to exactly the JSON payload.
+const VALID_LEVELS = new Set(['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent']);
 
 function getInitialLevel(): string {
   const envLevel = process.env.LOG_LEVEL?.toLowerCase();

--- a/scripts/check-bundled-skill.ts
+++ b/scripts/check-bundled-skill.ts
@@ -1,17 +1,21 @@
 #!/usr/bin/env bun
 /**
- * Verifies that packages/cli/src/bundled-skill.ts embeds every file from
- * .claude/skills/archon/. The bundled-skill.ts file is hand-maintained
- * (uses Bun's `with { type: 'text' }` import attributes, which the
- * generator approach in scripts/generate-bundled-defaults.ts cannot
- * reproduce for the binary build). This script is the safety net.
+ * Verifies that packages/cli/src/bundled-skill.ts embeds every file of the
+ * Archon-distributed skills (.claude/skills/archon/ and .claude/skills/manage-run/).
+ * bundled-skill.ts is hand-maintained (Bun's `with { type: 'text' }` import
+ * attributes, which the generator approach in scripts/generate-bundled-defaults.ts
+ * cannot reproduce for the binary build). This script is the safety net.
+ *
+ * Only the BUNDLED_SKILLS allowlist is checked — the repo also carries local/dev
+ * skill dirs under .claude/skills/ (playwright-cli, release, triage, …) that are
+ * NOT shipped in the binary and must not be required here.
  *
  * Usage:
  *   bun run scripts/check-bundled-skill.ts          # exit 1 if missing
  *   bun run scripts/check-bundled-skill.ts --check  # exit 2 if missing (CI)
  *
  * Exit codes:
- *   0  bundled-skill.ts covers every file under .claude/skills/archon/
+ *   0  bundled-skill.ts covers every file of the bundled skills
  *   1  missing files (default mode)
  *   2  missing files (--check mode, used by `bun run validate`)
  */
@@ -19,23 +23,31 @@ import { readdirSync, readFileSync, statSync } from 'fs';
 import { join, relative, resolve } from 'path';
 
 const REPO_ROOT = resolve(import.meta.dir, '..');
-const SKILL_ROOT = join(REPO_ROOT, '.claude', 'skills', 'archon');
+const SKILLS_DIR = join(REPO_ROOT, '.claude', 'skills');
+/** Skills bundled into the binary and installed by `archon skill install`. */
+const BUNDLED_SKILLS = ['archon', 'manage-run'];
 const BUNDLED_SKILL_PATH = join(REPO_ROOT, 'packages', 'cli', 'src', 'bundled-skill.ts');
 
 const CHECK_ONLY = process.argv.includes('--check');
 
-function listSkillFiles(dir: string, base: string = dir): string[] {
+function listSkillFiles(dir: string, base: string): string[] {
   return readdirSync(dir).flatMap(entry => {
     const full = join(dir, entry);
     return statSync(full).isDirectory() ? listSkillFiles(full, base) : [relative(base, full)];
   });
 }
 
-// Normalize to forward slashes so the substring check works on Windows
-// (path.relative() uses backslashes on Windows, but bundled-skill.ts uses forward slashes)
-const skillFiles = listSkillFiles(SKILL_ROOT)
+// Paths are relative to .claude/skills/ so they keep the skill dir name
+// (e.g. `archon/SKILL.md`, `manage-run/references/commands.md`). That makes the
+// substring check distinguish the two skills' identically-named files (both have
+// a SKILL.md) and matches the literal import paths in bundled-skill.ts.
+// Normalize to forward slashes so the substring check works on Windows.
+const skillFiles = BUNDLED_SKILLS.flatMap(skill =>
+  listSkillFiles(join(SKILLS_DIR, skill), SKILLS_DIR)
+)
   .map(f => f.replace(/\\/g, '/'))
   .sort();
+
 const bundledSrc = readFileSync(BUNDLED_SKILL_PATH, 'utf-8');
 // NOTE: This is a substring check — a filename that appears in a comment or
 // stale string literal will also pass. It's a safety net against missing imports,
@@ -45,9 +57,11 @@ const missing = skillFiles.filter(f => !bundledSrc.includes(f));
 if (missing.length > 0) {
   console.error(
     `bundled-skill.ts is missing these files:\n${missing.map(f => `  - ${f}`).join('\n')}\n\n` +
-      `Add a corresponding import + BUNDLED_SKILL_FILES entry to\n  ${relative(REPO_ROOT, BUNDLED_SKILL_PATH)}`
+      `Add a corresponding import + bundled map entry to\n  ${relative(REPO_ROOT, BUNDLED_SKILL_PATH)}`
   );
   process.exit(CHECK_ONLY ? 2 : 1);
 }
 
-console.log(`bundled-skill.ts is up to date (${skillFiles.length} files).`);
+console.log(
+  `bundled-skill.ts is up to date (${skillFiles.length} files across ${BUNDLED_SKILLS.length} skills).`
+);


### PR DESCRIPTION
## Summary

- **Problem:** The native `manage_run` tool only works on Claude + Pi; Codex/OpenCode/Copilot have no in-process tool hook. The CLI was the natural cross-provider surface but had four gaps (no single-run detail, active-only `status`, non-universal `--json`, blocking `run`), and nothing told the chat agent it could use the CLI.
- **Why it matters:** Closes run management for **all five providers** via the one surface every bash-capable agent already has — no served MCP, no per-provider in-process tool.
- **What changed:** Added `workflow get` / `workflow runs`; threaded `--json` into `approve`/`reject`/`abandon`/`resume`; added `--detach`; shipped a focused `manage-run` skill (bundled + installed + CI-guarded); and added a "Managing Workflow Runs" section to the orchestrator system prompt so chat on any provider can drive the CLI.
- **What did NOT change (scope boundary):** The native `manage_run` tool stays (complementary). No served MCP. No new core DB queries (reused `getWorkflowRun`/`listDashboardRuns`). No direct-chat `skills:` plumbing (workflow-node-only today). No `archon`-on-PATH detection (inherits the existing `archon` skill convention).

## UX Journey

### Before

```
Agent (Codex/OpenCode/Copilot) in a project, via bash:
  $ archon workflow list          → workflow DEFINITIONS (not runs)
  $ archon workflow status        → only running/paused (no history)
  $ archon workflow <id>          → ✗ no such command
  $ archon workflow approve <id>  → human text only (hard to parse)
  $ archon workflow run X "msg"   → BLOCKS until the workflow finishes
  Chat agent: no idea it can manage runs at all.
```

### After

```
Agent in a project, via bash (cwd → auto-scoped):
  $ archon workflow runs --json          → recent runs (ALL statuses), this project
  $ archon workflow get <id> --json      → one run: status, error, [per-node]
  $ archon workflow approve <id> --json  → { "ok": true, "action": "approve", "resumable": true }
  $ archon workflow run X "msg" --detach → returns immediately; child runs it
  [*] Chat on any provider: system prompt now teaches these verbs directly.
```

## Architecture Diagram

### After

```
  cli.ts ──▶ commands/workflow.ts ──▶ @archon/core (getWorkflowRun, listDashboardRuns)  [reused]
                     │
                     ├─[+] workflowGetCommand / workflowRunsCommand
                     ├─[+] --json on approve/reject/abandon/resume (record/validate, no inline exec)
                     └─[+] --detach → Bun.spawn detached re-invoke (~/.archon/logs/)

  bundled-skill.ts ─[+]─ BUNDLED_MANAGE_RUN_SKILL_FILES ──▶ skill.ts install ──▶ .claude/skills/manage-run/
                                                            scripts/check-bundled-skill.ts (allowlist guard)

  orchestrator-agent.ts ──▶ prompt-builder.ts ─[+]─ buildRunManagementSection()  (all providers, direct chat)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `commands/workflow.ts` | `@archon/core` db queries | unchanged | reused `getWorkflowRun`, `listDashboardRuns` |
| `cli.ts` | `commands/workflow.ts` | **modified** | new subcommands + flags; `--json` implies log suppression |
| `bundled-skill.ts` | `.claude/skills/manage-run/` | **new** | embedded text imports + new map |
| `prompt-builder.ts` | orchestrator system prompt | **modified** | appended run-management section |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `cli`, `core:orchestrator`, `skills`, `docs`, `tests`
- Module: `cli:workflow`, `core:orchestrator`

## Change Metadata

- Change type: `feature`
- Primary scope: `multi` (cli + core)

## Linked Issue

- Closes # — none (PRP-driven; plans archived under `.claude/PRPs/`)

## Validation Evidence (required)

```bash
bun run validate    # → exit 0
```

- `workflow.test.ts`: 120 pass (was 113); `prompt-builder.test.ts`: 15 pass (was 11); full CLI suite + all packages green; full `bun run validate` exit 0 (type-check, lint, format, check:bundled/-skill/-schema, all tests).
- Manual (dev): `get`/`runs`/`--json` produce clean parseable stdout; `skill install` writes both skills (23 files); CI guard fails on an unbundled skill file; `Bun.spawn`+`unref()` child verified to survive parent `process.exit()`.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **Yes (minor)** — `--detach` writes child stdout/stderr to a per-conversation log file under `~/.archon/logs/` (graceful fallback to discard if unopenable). This is *additive* and exists specifically to avoid silently swallowing a detached child's bootstrap errors.

## Compatibility / Migration

- Backward compatible? **Yes** (all additions; existing human output unchanged byte-for-byte)
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

- Verified scenarios: `get`/`runs` human + `--json` round-trip via `JSON.parse`; `--json` now clean on stdout (Pino default destination is stdout → `--json` implies log suppression); `skill install` into a probe dir; CI-guard negative test; detached-child survival.
- Edge cases checked: unregistered cwd → global list + explicit note; invalid `--status` → fail-fast; write-command `--json` error path returns `{ ok: false }` instead of throwing.
- What was not verified: `--detach` in a **compiled binary** build (implemented symmetrically via `BUNDLED_IS_BINARY`, dev path empirically verified; binary path unit-tested for argv only).

## Side Effects / Blast Radius (required)

- Affected subsystems: `@archon/cli` (workflow commands + entry), bundled-skill pipeline, `core/orchestrator` system prompt.
- Potential unintended effects: the orchestrator system prompt gains a section on every chat — additive guidance only; routing rules unchanged.
- Guardrails: full `bun run validate` in CI; `check:bundled-skill` allowlist guard.

## Rollback Plan (required)

- Fast rollback: revert the two commits (`feat(cli): …`, `feat(orchestrator): …`) — self-contained, no migrations, no state.
- Feature flags: none needed.
- Observable failure symptoms: `archon workflow get/runs` erroring; `--json` output non-parseable; chat agent failing to find `archon` (PATH — same convention as the existing `archon` skill).

## Risks and Mitigations

- Risk: `--detach` re-invoke fragile across dev/binary.
  - Mitigation: mode-detected via `BUNDLED_IS_BINARY`; argv unit-tested; dev path + child-survival empirically verified; child output logged (not discarded) so failures aren't silent.
- Risk: CI-guard wrongly requiring local-only skill dirs (repo has 13).
  - Mitigation: explicit `BUNDLED_SKILLS = ['archon','manage-run']` allowlist; negative test confirms it fails only on a missing *bundled* file.
- Risk: orchestrator prompt assumes `archon` on PATH.
  - Mitigation: inherits the existing `archon` skill's convention (no new assumption); section is additive guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Start workflows in the background with --detach (per-run log files) and new workflow get / workflow runs commands; workflow control commands support machine-readable --json acknowledgements that record decisions without inline execution.

* **Documentation**
  * Expanded CLI and docs to cover detach, --json output, runs/get/status semantics, scopeFallback behavior, and install instructions for the bundled manage-run skill.

* **Tests**
  * Added CLI tests for runs listing/status/get, JSON behavior, detached runs, and control commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->