### PR TITLE
Fix Codex output_format schemas for OpenAI strict-mode (#1843)

### DIFF
--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -381,6 +381,8 @@ Variable substitution order:
 
 Use `output_format` to enforce JSON output from an AI node. For Claude, the schema is passed via the SDK's `outputFormat` option and `structured_output` is used directly. For Codex (v0.116.0+), the schema is passed via `TurnOptions.outputSchema` and the agent's inline JSON response is used. Both ensure clean JSON for `when:` conditions and `$nodeId.output` substitution:
 
+> **Codex strict-mode normalization.** OpenAI's Structured Outputs validator rejects any object schema that doesn't set `additionalProperties: false`. Archon normalizes Codex schemas before sending them, injecting `additionalProperties: false` on every object node automatically — so write portable schemas and you won't notice. One caveat: an open-record `additionalProperties: { type: 'string' }` (or `additionalProperties: true`) is **replaced** with `false`, closing the object. OpenAI would reject the open form regardless, but the rewrite is logged (`codex.output_format_open_record_closed`) so it isn't silent. Open-record maps aren't supported for Codex structured output.
+
 ```yaml
 nodes:
   - id: classify

--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -805,6 +805,50 @@ describe('CodexProvider', () => {
       );
     });
 
+    test('normalizes nodeConfig.output_format schema before sending as outputSchema', async () => {
+      // The DAG executor populates nodeConfig.output_format (not outputFormat),
+      // so this is the actual path from issue #1843. Pin the normalized schema
+      // at the SDK boundary, not just the downstream parse.
+      mockRunStreamed.mockResolvedValue({
+        events: (async function* () {
+          yield { type: 'turn.completed', usage: defaultUsage };
+        })(),
+      });
+
+      const chunks = [];
+      for await (const chunk of client.sendQuery('test prompt', '/workspace', undefined, {
+        nodeConfig: {
+          output_format: {
+            type: 'object',
+            properties: {
+              verdict: { type: 'string' },
+              meta: { type: 'object', properties: { score: { type: 'number' } } },
+            },
+          },
+        },
+      })) {
+        chunks.push(chunk);
+      }
+
+      expect(mockRunStreamed).toHaveBeenCalledWith(
+        'test prompt',
+        expect.objectContaining({
+          outputSchema: {
+            type: 'object',
+            properties: {
+              verdict: { type: 'string' },
+              meta: {
+                type: 'object',
+                properties: { score: { type: 'number' } },
+                additionalProperties: false,
+              },
+            },
+            additionalProperties: false,
+          },
+        })
+      );
+    });
+
     test('passes a per-attempt AbortSignal in TurnOptions when caller provides one', async () => {
       mockRunStreamed.mockResolvedValue({
         events: (async function* () {

--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -759,7 +759,7 @@ describe('CodexProvider', () => {
       );
     });
 
-    test('passes outputFormat schema as outputSchema in TurnOptions', async () => {
+    test('normalizes outputFormat schema (adds additionalProperties:false) before sending as outputSchema', async () => {
       mockRunStreamed.mockResolvedValue({
         events: (async function* () {
           yield { type: 'turn.completed', usage: defaultUsage };
@@ -768,7 +768,10 @@ describe('CodexProvider', () => {
 
       const schema = {
         type: 'object',
-        properties: { summary: { type: 'string' } },
+        properties: {
+          summary: { type: 'string' },
+          meta: { type: 'object', properties: { tag: { type: 'string' } } },
+        },
         required: ['summary'],
       };
 
@@ -779,9 +782,26 @@ describe('CodexProvider', () => {
         chunks.push(chunk);
       }
 
+      // OpenAI strict-mode requires additionalProperties:false on every object,
+      // including the nested `meta` object — verifies recursion through the
+      // real provider path. See issue #1843.
       expect(mockRunStreamed).toHaveBeenCalledWith(
         'test prompt',
-        expect.objectContaining({ outputSchema: schema })
+        expect.objectContaining({
+          outputSchema: {
+            type: 'object',
+            properties: {
+              summary: { type: 'string' },
+              meta: {
+                type: 'object',
+                properties: { tag: { type: 'string' } },
+                additionalProperties: false,
+              },
+            },
+            required: ['summary'],
+            additionalProperties: false,
+          },
+        })
       );
     });
 

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -280,10 +280,16 @@ function buildTurnOptions(requestOptions?: SendQueryOptions): {
   hasOutputFormat: boolean;
 } {
   const turnOptions: TurnOptions = {};
+  // Preserve the original precedence: an explicit `outputFormat` wins over
+  // `nodeConfig.output_format` even when its `.schema` is undefined.
   const rawSchema =
-    requestOptions?.outputFormat?.schema ?? requestOptions?.nodeConfig?.output_format;
-  const hasOutputFormat = !!rawSchema;
-  if (rawSchema) {
+    requestOptions?.outputFormat !== undefined
+      ? requestOptions.outputFormat.schema
+      : requestOptions?.nodeConfig?.output_format;
+  const hasOutputFormat = !!(
+    requestOptions?.outputFormat ?? requestOptions?.nodeConfig?.output_format
+  );
+  if (rawSchema !== undefined) {
     // OpenAI Structured Outputs strict-mode requires additionalProperties:false
     // on every object schema (HTTP 400 invalid_json_schema otherwise). Workflow
     // authors write portable output_format schemas, so normalize here before

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -22,7 +22,10 @@ import { CODEX_CAPABILITIES } from './capabilities';
 import { resolveCodexBinaryPath } from './binary-resolver';
 import { createLogger } from '@archon/paths';
 import { loadMcpConfig } from '../mcp/config';
-import { normalizeJsonSchemaForOpenAiStrict } from '../shared/structured-output';
+import {
+  hasOpenAdditionalProperties,
+  normalizeJsonSchemaForOpenAiStrict,
+} from '../shared/structured-output';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
@@ -281,7 +284,10 @@ function buildTurnOptions(requestOptions?: SendQueryOptions): {
 } {
   const turnOptions: TurnOptions = {};
   // Preserve the original precedence: an explicit `outputFormat` wins over
-  // `nodeConfig.output_format` even when its `.schema` is undefined.
+  // `nodeConfig.output_format` even when its `.schema` is undefined. Note the
+  // resulting asymmetry: if `outputFormat` is set but `.schema` is undefined,
+  // `rawSchema` is undefined (no schema sent) yet `hasOutputFormat` is still
+  // true — the stream accumulator runs and JSON.parses the response text.
   const rawSchema =
     requestOptions?.outputFormat !== undefined
       ? requestOptions.outputFormat.schema
@@ -294,6 +300,13 @@ function buildTurnOptions(requestOptions?: SendQueryOptions): {
     // on every object schema (HTTP 400 invalid_json_schema otherwise). Workflow
     // authors write portable output_format schemas, so normalize here before
     // handing the schema to the Codex SDK. See issue #1843.
+    if (hasOpenAdditionalProperties(rawSchema)) {
+      // The normalizer is about to rewrite an open-record `additionalProperties`
+      // (e.g. `{ type: 'string' }` or `true`) to `false`. OpenAI would 400 the
+      // open form anyway, but the author never declared a closed object — warn
+      // so the silent narrowing is visible rather than a surprise at runtime.
+      getLog().warn({ schema: rawSchema }, 'codex.output_format_open_record_closed');
+    }
     turnOptions.outputSchema = normalizeJsonSchemaForOpenAiStrict(rawSchema);
   }
   // Signal assignment is intentionally per-attempt (in sendQuery's retry

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -22,6 +22,7 @@ import { CODEX_CAPABILITIES } from './capabilities';
 import { resolveCodexBinaryPath } from './binary-resolver';
 import { createLogger } from '@archon/paths';
 import { loadMcpConfig } from '../mcp/config';
+import { normalizeJsonSchemaForOpenAiStrict } from '../shared/structured-output';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
@@ -279,14 +280,15 @@ function buildTurnOptions(requestOptions?: SendQueryOptions): {
   hasOutputFormat: boolean;
 } {
   const turnOptions: TurnOptions = {};
-  const hasOutputFormat = !!(
-    requestOptions?.outputFormat ?? requestOptions?.nodeConfig?.output_format
-  );
-  if (requestOptions?.outputFormat) {
-    turnOptions.outputSchema = requestOptions.outputFormat.schema;
-  }
-  if (requestOptions?.nodeConfig?.output_format && !requestOptions?.outputFormat) {
-    turnOptions.outputSchema = requestOptions.nodeConfig.output_format;
+  const rawSchema =
+    requestOptions?.outputFormat?.schema ?? requestOptions?.nodeConfig?.output_format;
+  const hasOutputFormat = !!rawSchema;
+  if (rawSchema) {
+    // OpenAI Structured Outputs strict-mode requires additionalProperties:false
+    // on every object schema (HTTP 400 invalid_json_schema otherwise). Workflow
+    // authors write portable output_format schemas, so normalize here before
+    // handing the schema to the Codex SDK. See issue #1843.
+    turnOptions.outputSchema = normalizeJsonSchemaForOpenAiStrict(rawSchema);
   }
   // Signal assignment is intentionally per-attempt (in sendQuery's retry
   // loop), not here. Reusing a single AbortSignal across retries can poison

--- a/packages/providers/src/shared/structured-output.test.ts
+++ b/packages/providers/src/shared/structured-output.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import {
   augmentPromptForJsonSchema,
+  hasOpenAdditionalProperties,
   normalizeJsonSchemaForOpenAiStrict,
   tryParseStructuredOutput,
 } from './structured-output';
@@ -168,5 +169,76 @@ describe('normalizeJsonSchemaForOpenAiStrict', () => {
     const input = { type: 'object', properties: { a: { type: 'string' } } };
     normalizeJsonSchemaForOpenAiStrict(input);
     expect('additionalProperties' in input).toBe(false);
+  });
+
+  test('is idempotent — an already-normalized schema is structurally unchanged', () => {
+    const alreadyNormalized = {
+      type: 'object',
+      properties: {
+        a: { type: 'string' },
+        nested: {
+          type: 'object',
+          properties: { b: { type: 'number' } },
+          additionalProperties: false,
+        },
+      },
+      additionalProperties: false,
+    };
+    const out = normalizeJsonSchemaForOpenAiStrict(alreadyNormalized);
+    expect(out).toEqual(alreadyNormalized);
+  });
+});
+
+describe('hasOpenAdditionalProperties', () => {
+  test('true when an object declares an open-record additionalProperties subschema', () => {
+    expect(
+      hasOpenAdditionalProperties({
+        type: 'object',
+        properties: { key: { type: 'string' } },
+        additionalProperties: { type: 'number' },
+      })
+    ).toBe(true);
+  });
+
+  test('true when additionalProperties is the boolean true', () => {
+    expect(hasOpenAdditionalProperties({ type: 'object', additionalProperties: true })).toBe(true);
+  });
+
+  test('detects an open-record subschema nested below a closed parent', () => {
+    expect(
+      hasOpenAdditionalProperties({
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          map: { type: 'object', additionalProperties: { type: 'string' } },
+        },
+      })
+    ).toBe(true);
+  });
+
+  test('false when every object is already closed (additionalProperties:false)', () => {
+    expect(
+      hasOpenAdditionalProperties({
+        type: 'object',
+        properties: { a: { type: 'string' } },
+        additionalProperties: false,
+      })
+    ).toBe(false);
+  });
+
+  test('false when no additionalProperties is declared anywhere', () => {
+    expect(
+      hasOpenAdditionalProperties({
+        type: 'object',
+        properties: { a: { type: 'string' } },
+      })
+    ).toBe(false);
+  });
+
+  test('does not flag a non-object node carrying additionalProperties (normalizer leaves it untouched)', () => {
+    // No `type: object` and no `properties` → not an object node by the
+    // normalizer's rule, so the normalizer would NOT rewrite it. The predicate
+    // must match that and stay silent.
+    expect(hasOpenAdditionalProperties({ additionalProperties: { type: 'string' } })).toBe(false);
   });
 });

--- a/packages/providers/src/shared/structured-output.test.ts
+++ b/packages/providers/src/shared/structured-output.test.ts
@@ -145,6 +145,20 @@ describe('normalizeJsonSchemaForOpenAiStrict', () => {
     expect(out.additionalProperties).toBe(false);
   });
 
+  test('replaces an existing additionalProperties subschema with false (OpenAI strict-mode)', () => {
+    const input = {
+      type: 'object',
+      properties: { key: { type: 'string' } },
+      additionalProperties: { type: 'number' },
+    };
+    const out = normalizeJsonSchemaForOpenAiStrict(input) as Record<string, unknown>;
+    // OpenAI strict-mode forbids open/typed additional properties; false is the
+    // only accepted value, so the subschema is intentionally replaced.
+    expect(out.additionalProperties).toBe(false);
+    // Input is not mutated.
+    expect(input.additionalProperties).toEqual({ type: 'number' });
+  });
+
   test('leaves non-object schemas untouched', () => {
     const out = normalizeJsonSchemaForOpenAiStrict({ type: 'string' }) as Record<string, unknown>;
     expect(out.additionalProperties).toBeUndefined();

--- a/packages/providers/src/shared/structured-output.test.ts
+++ b/packages/providers/src/shared/structured-output.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 
-import { augmentPromptForJsonSchema, tryParseStructuredOutput } from './structured-output';
+import {
+  augmentPromptForJsonSchema,
+  normalizeJsonSchemaForOpenAiStrict,
+  tryParseStructuredOutput,
+} from './structured-output';
 
 describe('augmentPromptForJsonSchema', () => {
   test('appends schema and JSON-only instruction', () => {
@@ -82,5 +86,73 @@ After careful evaluation, here is the JSON:
   test('returns undefined when forward scan finds no parseable JSON', () => {
     // First `{` is at index > 0 but what follows is not valid JSON either.
     expect(tryParseStructuredOutput('prose with stray { brace and no closer')).toBeUndefined();
+  });
+});
+
+describe('normalizeJsonSchemaForOpenAiStrict', () => {
+  test('adds additionalProperties:false to a top-level object schema', () => {
+    const out = normalizeJsonSchemaForOpenAiStrict({
+      type: 'object',
+      properties: { a: { type: 'string' } },
+      required: ['a'],
+    }) as Record<string, unknown>;
+    expect(out.additionalProperties).toBe(false);
+  });
+
+  test('recurses into nested object properties', () => {
+    const out = normalizeJsonSchemaForOpenAiStrict({
+      type: 'object',
+      properties: {
+        nested: { type: 'object', properties: { b: { type: 'number' } } },
+      },
+    }) as { additionalProperties: unknown; properties: { nested: Record<string, unknown> } };
+    expect(out.additionalProperties).toBe(false);
+    expect(out.properties.nested.additionalProperties).toBe(false);
+  });
+
+  test('recurses into array items', () => {
+    const out = normalizeJsonSchemaForOpenAiStrict({
+      type: 'array',
+      items: { type: 'object', properties: { c: { type: 'string' } } },
+    }) as { items: Record<string, unknown> };
+    expect(out.items.additionalProperties).toBe(false);
+  });
+
+  test('recurses into anyOf and $defs composition', () => {
+    const out = normalizeJsonSchemaForOpenAiStrict({
+      $defs: { Foo: { type: 'object', properties: { x: { type: 'string' } } } },
+      anyOf: [{ type: 'object', properties: { y: { type: 'string' } } }],
+    }) as {
+      $defs: { Foo: Record<string, unknown> };
+      anyOf: Record<string, unknown>[];
+    };
+    expect(out.$defs.Foo.additionalProperties).toBe(false);
+    expect(out.anyOf[0].additionalProperties).toBe(false);
+  });
+
+  test('treats a schema with properties but no explicit type as an object', () => {
+    const out = normalizeJsonSchemaForOpenAiStrict({
+      properties: { a: { type: 'string' } },
+    }) as Record<string, unknown>;
+    expect(out.additionalProperties).toBe(false);
+  });
+
+  test('handles a type union that includes object', () => {
+    const out = normalizeJsonSchemaForOpenAiStrict({
+      type: ['object', 'null'],
+      properties: { a: { type: 'string' } },
+    }) as Record<string, unknown>;
+    expect(out.additionalProperties).toBe(false);
+  });
+
+  test('leaves non-object schemas untouched', () => {
+    const out = normalizeJsonSchemaForOpenAiStrict({ type: 'string' }) as Record<string, unknown>;
+    expect(out.additionalProperties).toBeUndefined();
+  });
+
+  test('does not mutate the input object (returns a deep clone)', () => {
+    const input = { type: 'object', properties: { a: { type: 'string' } } };
+    normalizeJsonSchemaForOpenAiStrict(input);
+    expect('additionalProperties' in input).toBe(false);
   });
 });

--- a/packages/providers/src/shared/structured-output.ts
+++ b/packages/providers/src/shared/structured-output.ts
@@ -91,3 +91,45 @@ function tryJsonParseObject(text: string): unknown {
     return undefined;
   }
 }
+
+/**
+ * Recursively inject `additionalProperties: false` on every object schema so a
+ * JSON Schema satisfies OpenAI's Structured Outputs strict-mode validator.
+ *
+ * OpenAI rejects any `object` node that does not declare `additionalProperties:
+ * false` (HTTP 400 invalid_json_schema). Claude and most other providers don't
+ * require this, so workflow authors write portable `output_format` schemas and
+ * the Codex provider adapts them here. Returns a deep clone — the caller's
+ * schema object is never mutated.
+ *
+ * Scope: only `additionalProperties` is injected. The other strict-mode rule
+ * (every key in `properties` must appear in `required`) is intentionally NOT
+ * enforced here — forcing it would silently turn optional fields into required
+ * ones. See issue #1843.
+ */
+export function normalizeJsonSchemaForOpenAiStrict(schema: unknown): unknown {
+  if (Array.isArray(schema)) {
+    return schema.map(item => normalizeJsonSchemaForOpenAiStrict(item));
+  }
+  if (schema === null || typeof schema !== 'object') {
+    return schema;
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(schema as Record<string, unknown>)) {
+    result[key] = normalizeJsonSchemaForOpenAiStrict(value);
+  }
+
+  // Treat as an object schema if it declares type:'object' (or a type union
+  // including 'object') or carries a `properties` map. OpenAI requires every
+  // such object to set additionalProperties:false.
+  const isObjectSchema =
+    result.type === 'object' ||
+    (Array.isArray(result.type) && result.type.includes('object')) ||
+    'properties' in result;
+  if (isObjectSchema) {
+    result.additionalProperties = false;
+  }
+
+  return result;
+}

--- a/packages/providers/src/shared/structured-output.ts
+++ b/packages/providers/src/shared/structured-output.ts
@@ -102,6 +102,12 @@ function tryJsonParseObject(text: string): unknown {
  * the Codex provider adapts them here. Returns a deep clone — the caller's
  * schema object is never mutated.
  *
+ * A pre-existing `additionalProperties` on an object — including a value
+ * subschema like `additionalProperties: { type: 'string' }` (an open record /
+ * map) — is replaced with `false`. OpenAI strict-mode forbids open or typed
+ * additional properties, so `false` is the only value the API accepts; keeping
+ * the subschema would just re-trigger the HTTP 400 this normalizer exists to fix.
+ *
  * Scope: only `additionalProperties` is injected. The other strict-mode rule
  * (every key in `properties` must appear in `required`) is intentionally NOT
  * enforced here — forcing it would silently turn optional fields into required

--- a/packages/providers/src/shared/structured-output.ts
+++ b/packages/providers/src/shared/structured-output.ts
@@ -93,6 +93,18 @@ function tryJsonParseObject(text: string): unknown {
 }
 
 /**
+ * True when `node`'s shape marks it as a JSON-Schema object node: it declares
+ * `type: 'object'` (or a type union including `'object'`) or carries a
+ * `properties` map. OpenAI strict-mode requires `additionalProperties: false`
+ * on exactly these nodes.
+ */
+function isObjectSchemaNode(node: Record<string, unknown>): boolean {
+  const typeIncludesObject =
+    node.type === 'object' || (Array.isArray(node.type) && node.type.includes('object'));
+  return typeIncludesObject || 'properties' in node;
+}
+
+/**
  * Recursively inject `additionalProperties: false` on every object schema so a
  * JSON Schema satisfies OpenAI's Structured Outputs strict-mode validator.
  *
@@ -107,35 +119,69 @@ function tryJsonParseObject(text: string): unknown {
  * map) — is replaced with `false`. OpenAI strict-mode forbids open or typed
  * additional properties, so `false` is the only value the API accepts; keeping
  * the subschema would just re-trigger the HTTP 400 this normalizer exists to fix.
+ * Callers that want to warn the author before silently dropping those semantics
+ * can detect the case up front with {@link hasOpenAdditionalProperties}.
  *
  * Scope: only `additionalProperties` is injected. The other strict-mode rule
  * (every key in `properties` must appear in `required`) is intentionally NOT
  * enforced here — forcing it would silently turn optional fields into required
  * ones. See issue #1843.
  */
-export function normalizeJsonSchemaForOpenAiStrict(schema: unknown): unknown {
-  if (Array.isArray(schema)) {
-    return schema.map(item => normalizeJsonSchemaForOpenAiStrict(item));
+export function normalizeJsonSchemaForOpenAiStrict(
+  schema: Record<string, unknown>
+): Record<string, unknown> {
+  return normalizeNode(schema) as Record<string, unknown>;
+}
+
+/**
+ * Recursive worker for {@link normalizeJsonSchemaForOpenAiStrict}. Walks any
+ * JSON value (object, array, or scalar); only object nodes are closed. Kept
+ * private so the public entry point can express the real `Record → Record`
+ * contract while recursion still descends into arrays and scalars.
+ */
+function normalizeNode(node: unknown): unknown {
+  if (Array.isArray(node)) {
+    return node.map(normalizeNode);
   }
-  if (schema === null || typeof schema !== 'object') {
-    return schema;
+  if (node === null || typeof node !== 'object') {
+    return node;
   }
 
   const result: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(schema as Record<string, unknown>)) {
-    result[key] = normalizeJsonSchemaForOpenAiStrict(value);
+  for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+    result[key] = normalizeNode(value);
   }
-
-  // Treat as an object schema if it declares type:'object' (or a type union
-  // including 'object') or carries a `properties` map. OpenAI requires every
-  // such object to set additionalProperties:false.
-  const isObjectSchema =
-    result.type === 'object' ||
-    (Array.isArray(result.type) && result.type.includes('object')) ||
-    'properties' in result;
-  if (isObjectSchema) {
+  if (isObjectSchemaNode(result)) {
     result.additionalProperties = false;
   }
 
   return result;
+}
+
+/**
+ * True if any object node in `schema` declares `additionalProperties` as
+ * something other than `false` — e.g. `additionalProperties: true` or an
+ * open-record subschema like `additionalProperties: { type: 'string' }`.
+ * {@link normalizeJsonSchemaForOpenAiStrict} silently rewrites these to `false`
+ * for OpenAI strict-mode; the Codex provider uses this to warn the author that
+ * their open-record semantics were dropped. Detection reuses the normalizer's
+ * object-node rule, so it never flags a node the normalizer would leave
+ * untouched. See issue #1843.
+ */
+export function hasOpenAdditionalProperties(schema: unknown): boolean {
+  if (Array.isArray(schema)) {
+    return schema.some(hasOpenAdditionalProperties);
+  }
+  if (schema === null || typeof schema !== 'object') {
+    return false;
+  }
+  const node = schema as Record<string, unknown>;
+  if (
+    isObjectSchemaNode(node) &&
+    'additionalProperties' in node &&
+    node.additionalProperties !== false
+  ) {
+    return true;
+  }
+  return Object.values(node).some(hasOpenAdditionalProperties);
 }


### PR DESCRIPTION
## Summary

- **Problem:** The Codex provider forwarded a workflow node's `output_format` JSON Schema verbatim to the SDK's `TurnOptions.outputSchema`. OpenAI's Structured Outputs **strict-mode** validator rejects any object schema missing `additionalProperties: false` with HTTP 400 `invalid_json_schema`.
- **Why it matters:** Every structured-output node failed on Codex. The whole `archon-fix-github-issue*` family (`classify`, `smoke-validate`, `review-classify`) died at the first structured node and the rest of the DAG was skipped — Codex was effectively unusable for structured workflows. Claude was unaffected (it doesn't apply OpenAI strict-mode).
- **What changed:** Added a pure `normalizeJsonSchemaForOpenAiStrict()` in `shared/structured-output.ts` that recursively injects `additionalProperties: false` on every object schema (returns a deep clone; input never mutated), and applied it in the Codex provider's `buildTurnOptions` before setting `outputSchema`.
- **What did NOT change (scope boundary):** Claude provider, dag-executor, the `dag-node` schema, the structured-output parse/return path, and the Copilot/OpenCode providers are untouched. The other strict-mode rule (every `properties` key must appear in `required`) is intentionally **not** auto-enforced — doing so would silently turn optional fields into required ones. The bundled workflow schemas already satisfy it.

## UX Journey

### Before

```
  User                         Codex workflow (DAG)                 OpenAI API
  ────                         ────────────────────                 ──────────
  /workflow run        ──────▶ extract-issue-number ✅
  archon-fix-github-           fetch-issue (bash)    ✅
  issue-codex "fix #X"         classify (output_format) ──────────▶ strict validator
                                                                    [X] additionalProperties
                                                                        required & false
                               classify ❌ HTTP 400 ◀────────────── invalid_json_schema
                               *** 18 downstream nodes skipped ***
  sees failed run ◀─────────── DAG aborted at first structured node
```

### After

```
  User                         Codex workflow (DAG)                 OpenAI API
  ────                         ────────────────────                 ──────────
  /workflow run        ──────▶ extract-issue-number ✅
  archon-fix-github-           fetch-issue (bash)    ✅
  issue-codex "fix #X"         classify (output_format)
                                 *[normalize schema:* ──────────▶ strict validator
                                 *additionalProperties:false]*       ✅ accepted
                               classify ✅ ◀───────────────────────  structured output
                               smoke-validate ✅ → ... → report ✅
  sees completed run ◀──────── DAG proceeds end-to-end
```

## Architecture Diagram

### Before

```
workflows/dag-executor ──(output_format: raw)──▶ providers/codex/provider.ts
                                                   buildTurnOptions
                                                   outputSchema = raw  ──▶ @openai/codex-sdk ──▶ OpenAI (400)

providers/shared/structured-output.ts  (augmentPrompt, tryParse)   [no schema normalizer]
```

### After

```
workflows/dag-executor ──(output_format: raw)──▶ providers/codex/provider.ts
                                                   buildTurnOptions
                                                   [~] outputSchema =
                                                       normalizeJsonSchemaForOpenAiStrict(raw)
                                                          │
                                                          ▼  === new edge
                                       providers/shared/structured-output.ts
                                       [+] normalizeJsonSchemaForOpenAiStrict()
                                                   │
                                                   ▼ ──▶ @openai/codex-sdk ──▶ OpenAI (✅)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `codex/provider.ts:buildTurnOptions` | `shared/structured-output.ts:normalizeJsonSchemaForOpenAiStrict` | **new** | normalize before setting `outputSchema` |
| `dag-executor` | `codex/provider.ts` | unchanged | still passes raw `output_format` |
| `codex/provider.ts` | `@openai/codex-sdk` | **modified** | now sends a strict-valid schema |
| `claude/provider.ts` | `@anthropic-ai/claude-agent-sdk` | unchanged | Claude path not touched |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `workflows` (impact); code lives in `@archon/providers`
- Module: `providers:codex`, `providers:shared`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows` (fix lives in `@archon/providers`; no single provider-scope label exists)

## Linked Issue

- Closes #1843

## Validation Evidence (required)

```bash
bun test packages/providers/src/shared/structured-output.test.ts \
         packages/providers/src/codex/provider.test.ts   # 84 pass, 0 fail
bun --filter @archon/providers test                       # pass
bun run type-check                                        # all 10 packages exit 0
bun run lint                                              # exit 0
bun run format:check                                      # all files Prettier-clean
```

- Evidence provided: test output above. New normalizer unit tests cover top-level/nested objects, array `items`, `anyOf`/`$defs`, type unions, implicit objects (`properties` w/o `type`), existing-`additionalProperties` replacement, non-objects untouched, and no-mutation. The Codex provider test asserts the normalized schema (incl. a nested object) reaches `runStreamed`.
- Skipped: `bun run validate`'s `check:bundled*` steps were not separately run — this PR touches no bundled defaults, skill files, or DB schema, so those generated artifacts are unaffected.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes` — normalization is idempotent: schemas that already carry `additionalProperties: false` are unchanged; Claude/other providers are untouched.
- Config/env changes? `No`
- Database migration needed? `No`
- Note: a schema that previously relied on an open-record `additionalProperties: <subschema>` will now have it forced to `false` (documented in the normalizer) — but such schemas were already rejected by OpenAI strict-mode, so this only changes a hard-400 into a working closed object.

## Human Verification (required)

- Verified scenarios: reproduced the **pre-fix** failure first-hand — running `archon-fix-github-issue-codex "fix #1843"` died at `classify` with the exact `invalid_json_schema` 400. Post-fix, unit + provider tests assert the schema sent to the SDK now carries `additionalProperties: false` at every object level.
- Edge cases checked: nested objects, array items, `anyOf`/`$defs`, type unions, `properties`-without-`type`, pre-existing `additionalProperties` subschema, input-not-mutated.
- What was not verified: a live end-to-end Codex run *with the fix applied* (would kick off an unrelated issue's fix flow). Covered by the provider test that pins the normalized schema reaching `thread.runStreamed`.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Codex provider only; any workflow with `output_format` running on a Codex assistant.
- Potential unintended effects: minimal — the normalizer is pure and deep-clones, so it cannot mutate caller state; Claude and the parse path are untouched.
- Guardrails/monitoring: existing `codex_turn_failed` / `dag_node_failed` logging surfaces any residual schema rejection.

## Rollback Plan (required)

- Fast rollback: `git revert 460750c1 f3686863` (or revert the PR merge). Two-file logic change, trivially reversible.
- Feature flags/toggles: none.
- Observable failure symptoms: Codex structured-output nodes 400 again with `invalid_json_schema`, or produce malformed `structuredOutput`.

## Risks and Mitigations

- Risk: a JSON-Schema shape not detected as an object (e.g. an `additionalProperties`-only map with no `type`/`properties`) wouldn't receive `additionalProperties: false`.
  - Mitigation: bundled workflow schemas use explicit `type: object` + `properties`; detection also keys off a `properties` map and `object` type unions; scope documented; common shapes covered by tests.

---

_Implemented from the investigation artifact `.claude/PRPs/issues/issue-1843.md` (gitignored; kept local). Self-reviewed; review findings folded into commit `460750c1`._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Structured output schemas are now normalized to meet OpenAI strict Structured Output rules, enforcing closed object schemas recursively.
* **Bug Fixes**
  * Ensures normalized schemas are used consistently before sending structured-output requests.
* **Tests**
  * Added and extended tests validating recursive normalization, detection of open additionalProperties, idempotence, and non-mutation.
* **Documentation**
  * Notes added describing strict-mode schema normalization and related behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->