### PR TITLE
Fix Codex multi-message agent_message concatenation with output_format

### DIFF
--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -1710,6 +1710,39 @@ describe('CodexProvider', () => {
         const systemChunk = chunks.find(c => c.type === 'system');
         expect(systemChunk).toBeUndefined();
       });
+
+      test('uses last agent_message when multiple messages are emitted via nodeConfig.output_format', async () => {
+        // Workflow path: dag-executor sets nodeConfig.output_format from YAML
+        // output_format. Locks the same last-wins fix on this entry point.
+        const preamble = { claims_accurate: 'false', reasoning: 'draft' };
+        const finalAnswer = { claims_accurate: 'true', reasoning: 'verified' };
+        mockRunStreamed.mockResolvedValueOnce({
+          events: (async function* () {
+            yield {
+              type: 'item.completed',
+              item: { type: 'agent_message', id: 'msg-1', text: JSON.stringify(preamble) },
+            };
+            yield {
+              type: 'item.completed',
+              item: { type: 'agent_message', id: 'msg-2', text: JSON.stringify(finalAnswer) },
+            };
+            yield { type: 'turn.completed', usage: defaultUsage };
+          })(),
+        });
+
+        const chunks = [];
+        for await (const chunk of client.sendQuery('test', '/tmp', undefined, {
+          nodeConfig: { output_format: { type: 'object' } },
+        })) {
+          chunks.push(chunk);
+        }
+
+        const resultChunk = chunks.find(c => c.type === 'result');
+        expect(resultChunk).toBeDefined();
+        expect(resultChunk!.type === 'result' && resultChunk!.structuredOutput).toEqual(
+          finalAnswer
+        );
+      });
     });
   });
 });

--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -1670,6 +1670,46 @@ describe('CodexProvider', () => {
           jsonPayload
         );
       });
+
+      test('uses last agent_message when multiple messages are emitted with output_format', async () => {
+        const preamble = { claims_accurate: 'false', reasoning: "I'll verify first" };
+        const finalAnswer = {
+          claims_accurate: 'true',
+          reasoning: 'Checked — claims are correct',
+        };
+        mockRunStreamed.mockResolvedValueOnce({
+          events: (async function* () {
+            yield {
+              type: 'item.completed',
+              item: { type: 'agent_message', id: 'msg-1', text: JSON.stringify(preamble) },
+            };
+            yield {
+              type: 'item.completed',
+              item: { type: 'agent_message', id: 'msg-2', text: JSON.stringify(finalAnswer) },
+            };
+            yield { type: 'turn.completed', usage: defaultUsage };
+          })(),
+        });
+
+        const chunks = [];
+        for await (const chunk of client.sendQuery('test', '/tmp', undefined, {
+          outputFormat: { type: 'json_schema', schema: { type: 'object' } },
+        })) {
+          chunks.push(chunk);
+        }
+
+        const assistantChunks = chunks.filter(c => c.type === 'assistant');
+        expect(assistantChunks).toHaveLength(2);
+
+        const resultChunk = chunks.find(c => c.type === 'result');
+        expect(resultChunk).toBeDefined();
+        expect(resultChunk!.type === 'result' && resultChunk!.structuredOutput).toEqual(
+          finalAnswer
+        );
+
+        const systemChunk = chunks.find(c => c.type === 'system');
+        expect(systemChunk).toBeUndefined();
+      });
     });
   });
 });

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -441,6 +441,8 @@ async function* streamCodexEvents(
       switch (itemType) {
         case 'agent_message':
           if (item.text) {
+            // Multiple agent_message items can arrive in one turn (preamble + answer);
+            // keep only the last — it's the authoritative structured-output candidate.
             if (hasOutputFormat) accumulatedText = item.text as string;
             yield { type: 'assistant', content: item.text as string };
           }

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -441,7 +441,7 @@ async function* streamCodexEvents(
       switch (itemType) {
         case 'agent_message':
           if (item.text) {
-            if (hasOutputFormat) accumulatedText += item.text as string;
+            if (hasOutputFormat) accumulatedText = item.text as string;
             yield { type: 'assistant', content: item.text as string };
           }
           break;


### PR DESCRIPTION
## Summary

- **Problem**: When a Codex node has `output_format:` set and the model emits multiple `agent_message` items in one turn (e.g. a preamble before the real answer), the provider concatenated them with `+=`, producing `{...}{...}` — invalid JSON that `JSON.parse` rejects silently.
- **Why it matters**: `structuredOutput` is left `undefined`; downstream `$nodeId.output.field` references evaluate to `undefined` and `when:` conditions fail-closed, skipping dependent nodes non-deterministically based on model verbosity.
- **What changed**: One character in `packages/providers/src/codex/provider.ts` — `accumulatedText += item.text` → `accumulatedText = item.text` — so only the **last** `agent_message` is used as the structured output candidate. A regression test was added covering the multi-message case.
- **What did not change**: All `agent_message` items continue to be streamed to the user as `assistant` content. Claude, Pi, and all other providers are untouched. `tryParseStructuredOutput` in `shared/structured-output.ts` is untouched.

## UX Journey

### Before

```
User (workflow with output_format)    Codex SDK           Archon provider.ts
─────────────────────────────────     ─────────           ──────────────────
workflow node runs ───────────────▶   streams events
                                      agent_message #1 ──▶ accumulatedText += "{preamble}"
                                      agent_message #2 ──▶ accumulatedText += "{real-answer}"
                                                           accumulatedText = "{preamble}{real-answer}"
                                      turn.completed ────▶ JSON.parse("{preamble}{real-answer}") ← throws
                                                           structuredOutput = undefined (silent)
workflow downstream node sees ◀──────────────────────────  $nodeId.output.field = undefined
when: condition fails-closed ◀───────────────────────────  node skipped unexpectedly
```

### After

```
User (workflow with output_format)    Codex SDK           Archon provider.ts
─────────────────────────────────     ─────────           ──────────────────
workflow node runs ───────────────▶   streams events
                                      agent_message #1 ──▶ accumulatedText = "{preamble}"   [~replaced]
                                      agent_message #2 ──▶ accumulatedText = "{real-answer}" [~replaced]
                                                           accumulatedText = "{real-answer}"
                                      turn.completed ────▶ JSON.parse("{real-answer}") ← succeeds
                                                           structuredOutput = { claims_accurate: "true", ... }
workflow downstream node ◀───────────────────────────────  $nodeId.output.field resolves correctly
when: condition evaluates ◀──────────────────────────────  node runs as expected
```

## Architecture Diagram

### Before

```
dag-executor.ts
  └─▶ CodexProvider.sendQuery()
        └─▶ streamCodexEvents()
              └─▶ case 'agent_message':
                    accumulatedText += item.text   ← BUG: concatenates all messages
              └─▶ case 'turn.completed':
                    JSON.parse(accumulatedText)    ← fails on multi-message
                    structuredOutput = undefined
```

### After

```
dag-executor.ts
  └─▶ CodexProvider.sendQuery()
        └─▶ streamCodexEvents()
              └─▶ case 'agent_message':
                    accumulatedText = item.text    [~] ← replaces; keeps last message
              └─▶ case 'turn.completed':
                    JSON.parse(accumulatedText)    ← succeeds on final JSON message
                    structuredOutput = { ... }
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `dag-executor.ts` | `CodexProvider.sendQuery()` | unchanged | reads `result.structuredOutput` |
| `streamCodexEvents` | `accumulatedText` | **modified** | `+=` → `=` |
| `streamCodexEvents` | `yield { type: 'assistant' }` | unchanged | all messages still streamed |
| `turn.completed` block | `tryParseStructuredOutput` / `JSON.parse` | unchanged | parser untouched |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `providers`
- Module: `providers:codex`

## Change Metadata

- Change type: `bug`
- Primary scope: `providers`

## Linked Issue

- Closes #1856

## Validation Evidence (required)

```bash
bun run validate
```

- `check:bundled` ✅ — 36 commands, 20 workflows, up to date
- `check:bundled-skill` ✅ — 21 files, up to date
- `check:bundled-schema` ✅ — up to date
- `bun run type-check` ✅ — all 10 packages + scripts tsconfig, 0 errors
- `bun run lint` ✅ — 0 errors, 0 warnings
- `bun run format:check` ✅ — all files formatted
- `bun run test` ✅ — 4352 passed, 0 failed (includes new regression test `uses last agent_message when multiple messages are emitted with output_format`)

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — single `agent_message` turns are unchanged (assigning one value is identical to appending it to an empty buffer).
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: Automated regression test covers the exact failure case from the issue (two `agent_message` events with `output_format`, assert `structuredOutput` equals the second object and no `system` warning chunk is emitted).
- Edge cases checked: Single-message case (unaffected), invalid-JSON final message (still falls through to existing `codex.structured_output_not_json` warning — behavior unchanged).
- What was not verified: Live end-to-end run against a real Codex model that emits preamble messages (requires external API access).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Codex provider only — `streamCodexEvents` in `packages/providers/src/codex/provider.ts`.
- Potential unintended effects: If a model intentionally emits multiple disjoint JSON fragments meant to be concatenated (no known Codex behavior), the last-wins approach would discard earlier ones. This is not a documented or observed Codex pattern.
- Guardrails/monitoring for early detection: Existing `codex.structured_output_not_json` warning log is preserved for cases where even the final message isn't valid JSON.

## Rollback Plan (required)

- Fast rollback command/path: `git revert 828148e1` — single-commit revert, no cascading changes.
- Feature flags or config toggles: None.
- Observable failure symptoms: `codex.structured_output_not_json` warnings in logs; downstream `$nodeId.output.field` evaluating to `undefined`; `when:` conditions failing-closed.

## Risks and Mitigations

- Risk: A Codex model version emits the real JSON as an earlier `agent_message` and a non-JSON summary as the final one.
  - Mitigation: This would be a model API contract change not documented by OpenAI. If observed, the fix is to find the last valid JSON message rather than the last message — but this is speculative and out of scope per YAGNI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed structured output normalization to use the last agent message instead of accumulating multiple messages when outputFormat is enabled. This ensures the final structured output correctly reflects the most recent response.

* **Tests**
  * Added regression tests for structured output handling with multiple agent messages in both direct and workflow output format configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->