### PR TITLE
Use final Codex message for structured output

### DIFF
--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -1569,6 +1569,24 @@ describe('CodexProvider', () => {
     });
 
     describe('structured output normalization', () => {
+      const mockAgentMessagePayloads = (...payloads: Record<string, unknown>[]): void => {
+        mockRunStreamed.mockResolvedValueOnce({
+          events: (async function* () {
+            for (const [index, payload] of payloads.entries()) {
+              yield {
+                type: 'item.completed',
+                item: {
+                  type: 'agent_message',
+                  id: `msg-${String(index + 1)}`,
+                  text: JSON.stringify(payload),
+                },
+              };
+            }
+            yield { type: 'turn.completed', usage: defaultUsage };
+          })(),
+        });
+      };
+
       test('populates structuredOutput on result when outputFormat is set and text is valid JSON', async () => {
         const jsonPayload = { status: 'ok', count: 42 };
         mockRunStreamed.mockResolvedValueOnce({
@@ -1598,19 +1616,7 @@ describe('CodexProvider', () => {
       test('uses the latest agent_message for structuredOutput when outputFormat is set', async () => {
         const firstPayload = { status: 'draft', count: 1 };
         const finalPayload = { status: 'ok', count: 42 };
-        mockRunStreamed.mockResolvedValueOnce({
-          events: (async function* () {
-            yield {
-              type: 'item.completed',
-              item: { type: 'agent_message', id: 'msg-1', text: JSON.stringify(firstPayload) },
-            };
-            yield {
-              type: 'item.completed',
-              item: { type: 'agent_message', id: 'msg-2', text: JSON.stringify(finalPayload) },
-            };
-            yield { type: 'turn.completed', usage: defaultUsage };
-          })(),
-        });
+        mockAgentMessagePayloads(firstPayload, finalPayload);
 
         const chunks = [];
         for await (const chunk of client.sendQuery('test', '/tmp', undefined, {
@@ -1708,19 +1714,7 @@ describe('CodexProvider', () => {
       test('uses the latest agent_message for structuredOutput from nodeConfig.output_format', async () => {
         const firstPayload = { key: 'draft' };
         const finalPayload = { key: 'value' };
-        mockRunStreamed.mockResolvedValueOnce({
-          events: (async function* () {
-            yield {
-              type: 'item.completed',
-              item: { type: 'agent_message', id: 'msg-1', text: JSON.stringify(firstPayload) },
-            };
-            yield {
-              type: 'item.completed',
-              item: { type: 'agent_message', id: 'msg-2', text: JSON.stringify(finalPayload) },
-            };
-            yield { type: 'turn.completed', usage: defaultUsage };
-          })(),
-        });
+        mockAgentMessagePayloads(firstPayload, finalPayload);
 
         const chunks = [];
         for await (const chunk of client.sendQuery('test', '/tmp', undefined, {

--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -1595,6 +1595,40 @@ describe('CodexProvider', () => {
         );
       });
 
+      test('uses the latest agent_message for structuredOutput when outputFormat is set', async () => {
+        const firstPayload = { status: 'draft', count: 1 };
+        const finalPayload = { status: 'ok', count: 42 };
+        mockRunStreamed.mockResolvedValueOnce({
+          events: (async function* () {
+            yield {
+              type: 'item.completed',
+              item: { type: 'agent_message', id: 'msg-1', text: JSON.stringify(firstPayload) },
+            };
+            yield {
+              type: 'item.completed',
+              item: { type: 'agent_message', id: 'msg-2', text: JSON.stringify(finalPayload) },
+            };
+            yield { type: 'turn.completed', usage: defaultUsage };
+          })(),
+        });
+
+        const chunks = [];
+        for await (const chunk of client.sendQuery('test', '/tmp', undefined, {
+          outputFormat: { type: 'json_schema', schema: { type: 'object' } },
+        })) {
+          chunks.push(chunk);
+        }
+
+        const assistantChunks = chunks.filter(c => c.type === 'assistant');
+        expect(assistantChunks).toHaveLength(2);
+
+        const resultChunk = chunks.find(c => c.type === 'result');
+        expect(resultChunk).toBeDefined();
+        expect(resultChunk!.type === 'result' && resultChunk!.structuredOutput).toEqual(
+          finalPayload
+        );
+      });
+
       test('yields system warning when outputFormat is set but text is not valid JSON', async () => {
         mockRunStreamed.mockResolvedValueOnce({
           events: (async function* () {
@@ -1668,6 +1702,37 @@ describe('CodexProvider', () => {
         expect(resultChunk).toBeDefined();
         expect(resultChunk!.type === 'result' && resultChunk!.structuredOutput).toEqual(
           jsonPayload
+        );
+      });
+
+      test('uses the latest agent_message for structuredOutput from nodeConfig.output_format', async () => {
+        const firstPayload = { key: 'draft' };
+        const finalPayload = { key: 'value' };
+        mockRunStreamed.mockResolvedValueOnce({
+          events: (async function* () {
+            yield {
+              type: 'item.completed',
+              item: { type: 'agent_message', id: 'msg-1', text: JSON.stringify(firstPayload) },
+            };
+            yield {
+              type: 'item.completed',
+              item: { type: 'agent_message', id: 'msg-2', text: JSON.stringify(finalPayload) },
+            };
+            yield { type: 'turn.completed', usage: defaultUsage };
+          })(),
+        });
+
+        const chunks = [];
+        for await (const chunk of client.sendQuery('test', '/tmp', undefined, {
+          nodeConfig: { output_format: { type: 'object' } },
+        })) {
+          chunks.push(chunk);
+        }
+
+        const resultChunk = chunks.find(c => c.type === 'result');
+        expect(resultChunk).toBeDefined();
+        expect(resultChunk!.type === 'result' && resultChunk!.structuredOutput).toEqual(
+          finalPayload
         );
       });
     });

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -441,7 +441,7 @@ async function* streamCodexEvents(
       switch (itemType) {
         case 'agent_message':
           if (item.text) {
-            if (hasOutputFormat) accumulatedText += item.text as string;
+            if (hasOutputFormat) accumulatedText = item.text as string;
             yield { type: 'assistant', content: item.text as string };
           }
           break;


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: Codex structured-output turns can emit more than one `agent_message`; the provider concatenated all message texts and produced adjacent JSON objects that could not be parsed.
- Why it matters: Workflow nodes using `output_format` silently lost `structuredOutput`, causing downstream `$node.output.field` references and gated `when:` conditions to evaluate against invalid raw text.
- What changed: The Codex provider now keeps the latest structured `agent_message` as the parse target, and regression tests cover both direct `outputFormat` and `nodeConfig.output_format`.
- What did **not** change (scope boundary): Non-structured Codex streaming, assistant chunk emission, workflow executor behavior, and condition evaluation remain unchanged.

## UX Journey

### Before

```text
User/Workflow          Archon Workflow          Codex Provider          Codex
-------------          ---------------          --------------          -----
run output_format ->   starts node       ->      requests turn     ->    emits draft JSON
                       streams chunks    <-      assistant chunk   <-    emits final JSON
                       waits result      <-      parses draft+final
                       warns missing
downstream gate skips because structuredOutput is absent
```

### After

```text
User/Workflow          Archon Workflow          Codex Provider          Codex
-------------          ---------------          --------------          -----
run output_format ->   starts node       ->      requests turn     ->    emits draft JSON
                       streams chunks    <-      assistant chunk   <-    emits final JSON
                       gets result       <-      [parses latest JSON]
downstream gate reads structuredOutput from the final response
```

## Architecture Diagram

### Before

```text
Codex SDK events
  -> packages/providers/src/codex/provider.ts
       accumulates all agent_message text for output_format
       JSON.parse fails on adjacent JSON objects
  -> packages/workflows/src/dag-executor.ts
       receives result without structuredOutput
  -> packages/workflows/src/condition-evaluator.ts
       falls back to parsing invalid raw output
```

### After

```text
Codex SDK events
  -> [~] packages/providers/src/codex/provider.ts
       keeps latest agent_message text for output_format
       JSON.parse succeeds on final JSON object
  -> packages/workflows/src/dag-executor.ts
       receives result with structuredOutput
  -> packages/workflows/src/condition-evaluator.ts
       reads structured field values normally
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| Codex SDK event stream | `packages/providers/src/codex/provider.ts` | **modified** | Provider now treats the latest `agent_message` as the authoritative structured-output parse target. |
| `packages/providers/src/codex/provider.ts` | `packages/workflows/src/dag-executor.ts` | unchanged | Existing `MessageChunk.structuredOutput` contract is preserved. |
| `packages/workflows/src/dag-executor.ts` | `packages/workflows/src/condition-evaluator.ts` | unchanged | Existing downstream structured-output preference remains unchanged. |
| `packages/providers/src/codex/provider.test.ts` | `packages/providers/src/codex/provider.ts` | **modified** | Regression coverage now asserts two-message structured output uses the final JSON object. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `tests`
- Module: `providers:codex`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi`

## Linked Issue

- Fixes #1856
- Related #1854
- Depends on # (if stacked): None
- Supersedes # (if replacing older PR): None

## Validation Evidence (required)

Commands and result summary:

```bash
bun test packages/providers/src/codex/provider.test.ts
bun run format:check
```

- Evidence provided (test/log/trace/screenshot): Targeted Codex provider suite passed with 66 tests, including the new multiple-`agent_message` structured-output cases. Format check reported all matched files use Prettier code style.
- If any command is intentionally skipped, explain why: Full validation was already recorded in the run artifact: `bun run type-check`, `bun run lint`, `bun run format:check`, `bun run test`, and `bun run build` all passed. I reran the targeted provider test and format check after applying the final source changes.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: Not applicable.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Database migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: Not applicable.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Two complete Codex `agent_message` JSON payloads with direct `outputFormat` return `structuredOutput` from the final payload. The same behavior is covered for `nodeConfig.output_format`.
- Edge cases checked: Invalid JSON still yields the existing warning and omits `structuredOutput`; valid single-message JSON still parses; no `outputFormat` still does not populate structured output.
- What was not verified: A live Codex SDK run with multiple real streamed messages was not executed.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Codex provider structured-output normalization and provider tests.
- Potential unintended effects: If Codex ever emits one structured JSON object split across multiple `agent_message` items instead of multiple complete messages, replacing instead of appending would parse only the final fragment.
- Guardrails/monitoring for early detection: Existing non-JSON warning remains in place; regression tests cover direct and node-config structured-output paths.

## Rollback Plan (required)

- Fast rollback command/path: `git revert cee83ff3`
- Feature flags or config toggles (if any): None
- Observable failure symptoms: Codex `output_format` nodes warn that structured output is missing, and downstream gates or `$node.output.field` references do not evaluate as expected.

## Risks and Mitigations

- Risk: Codex could theoretically split one JSON document across multiple `agent_message` events.
  - Mitigation: The issue evidence and Codex turn semantics point to multiple complete messages; tests preserve assistant streaming while ensuring the final structured message is parsed.
