### PR TITLE
docs(manage-run): correct stale 'no live updates' note for detached runs

### DIFF
--- a/.claude/skills/manage-run/SKILL.md
+++ b/.claude/skills/manage-run/SKILL.md
@@ -68,12 +68,12 @@ run id (it's created in the child) — find it with `archon workflow runs`. If t
 never appears, check the child log path printed by the command (or the `logPath`
 field in `--detach --json`).
 
-> **Console UI note:** a detached run *does* appear in the web console's Workflow dock
-> (the dock lists runs by project), but its progress may **not update live** — detached
-> runs execute in a separate process and don't stream to the console's live event feed,
-> so the dock catches up on its next refetch rather than in real time. Tell the user to
-> refresh if they want the latest state. (Re-running progress live for CLI-started runs
-> is a tracked follow-up.)
+> **Console UI note:** a detached run appears in the web console's Workflow dock
+> (the dock lists runs by project) **and updates live** — even though it executes in a
+> separate process. A server-side poller tails the workflow-event table and replays new
+> rows to the console's live feed (on PostgreSQL a `NOTIFY` trigger pushes them within
+> the same second; on SQLite the poller picks them up on its short interval). No refresh
+> is needed.
 
 ### Approve or reject a paused run (two steps)
 `--json` approve/reject/resume **record the decision** (the run becomes resumable) but


### PR DESCRIPTION
## Summary

- **Problem:** The bundled `manage-run` skill told users a detached/CLI run "may **not** update live" in the web console and to "refresh if they want the latest state."
- **Why it matters:** That behavior was fixed in PR #1861 (DB-tail dashboard poller + PostgreSQL `NOTIFY` trigger). The skill — which both the chat agent and humans read — now ships advice that contradicts shipped behavior.
- **What changed:** Rewrote the "Console UI note" in `.claude/skills/manage-run/SKILL.md` to describe the live-update behavior. The skill is embedded into `packages/cli/src/bundled-skill.ts` via a `with { type: 'text' }` import, so the corrected content flows into the bundle automatically.
- **What did NOT change (scope boundary):** No code, no CLI behavior, no other skill/doc. Single Markdown content edit.

## UX Journey

### Before

```
Agent/human reads manage-run skill
  → "detached runs may NOT update live in the console; tell the user to refresh"
  → user is told to refresh a dock that already updates itself  ✗ wrong since #1861
```

### After

```
Agent/human reads manage-run skill
  → "detached runs DO update live (poller + Postgres NOTIFY); no refresh needed"  ✓ matches reality
```

## Architecture Diagram

### Before / After

```
No module graph change. Documentation-only.
.claude/skills/manage-run/SKILL.md  ──text-import──▶  packages/cli/src/bundled-skill.ts
(content corrected; the import edge is unchanged)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `.claude/skills/manage-run/SKILL.md` | `packages/cli/src/bundled-skill.ts` | unchanged | text-import edge unchanged; only the file's content changed |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `docs`, `skills`
- Module: `skills:manage-run`

## Change Metadata

- Change type: `docs`
- Primary scope: `cli` (bundled skill)

## Linked Issue

- Related #1861 (the PR whose behavior this documents)

## Validation Evidence (required)

```bash
bun run check:bundled-skill   # bundled-skill.ts is up to date (23 files across 2 skills)
bun run format:check          # All matched files use Prettier code style!
```

- Evidence provided: both commands pass (output above). `check:bundled-skill` is the relevant gate (verifies the skill file is still referenced by the bundle); content is embedded at build time via the text import.
- Skipped: full `bun run test` / `type-check` / `lint` — no code paths touched (Markdown content only). CI runs them anyway.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: Manually ran a detached workflow (`archon workflow run … --detach`) against a live console on **both** SQLite (poll @1.5s) and PostgreSQL (NOTIFY + 10s backstop). The Workflow dock updated live with no page reload (Running 0→1→0); on Postgres the run surfaced ~2-3s after start, faster than the 10s backstop, confirming the `NOTIFY` path. This is what makes the old note wrong and the new note correct.
- Edge cases checked: confirmed the skill file is still referenced by `bundled-skill.ts` (`check:bundled-skill` green) and prettier-clean.
- What was not verified: nothing further needed — docs-only.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: the bundled `manage-run` skill text only (read by the chat agent and humans).
- Potential unintended effects: none — no executable code changed.
- Guardrails/monitoring: CI `check:bundled-skill` ensures the bundle still covers the file.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge-commit>` — single Markdown file.
- Feature flags or config toggles: none.
- Observable failure symptoms: none (documentation text).

## Risks and Mitigations

- None (documentation-only correction).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated console UI documentation to clarify that detached workflow runs appear in the web console's Workflow dock and update live with real-time status changes. Previous documentation suggested live updates might not occur and recommended manual refresh for the latest state. Enhanced documentation with technical details explaining the live update mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->