### PR TITLE
feat(providers/workflows): model alias resolver core

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -551,7 +551,8 @@ assistants:
 
 **Model Validation:**
 - Workflows are validated at load time for provider _identity_ only — `provider:` (workflow-level and per-node) must be a registered provider id, otherwise the YAML is rejected with `Unknown provider '<id>'. Registered: claude, codex, pi`.
-- Model strings are NOT validated by Archon. Whatever the user writes in `model:` is forwarded verbatim to the resolved SDK. Vendor SDKs ship new models faster than Archon can update; the SDK and the upstream API are the source of truth for what names exist.
+- Model strings are classified by `resolveModelSpec()` in `packages/workflows/src/model-validation.ts`: tier keywords (`small`/`medium`/`large`) resolve via tier-defaults and fallback chains; `@<name>` refs resolve via the merged alias map from config; anything else is forwarded verbatim to the resolved SDK. **Call-sites are not yet wired** — currently all strings pass through as literals.
+- `aliases:` is now a valid key on `GlobalConfig` and `RepoConfig` (repo overrides global). Reserved names `small`, `medium`, `large` cannot be used as custom alias names. Custom alias keys must start with `@` (e.g. `@fast`).
 - Provider is resolved via an explicit chain: `node.provider ?? workflow.provider ?? config.assistant`. Model never influences provider selection.
 
 ### Running the App in Worktrees

--- a/packages/core/src/config/config-loader.test.ts
+++ b/packages/core/src/config/config-loader.test.ts
@@ -382,6 +382,50 @@ worktree:
       expect(config.baseBranch).toBeUndefined();
     });
 
+    test('global aliases are propagated to merged config', async () => {
+      mockFsReadFile.mockResolvedValue(`
+aliases:
+  '@fast': { provider: claude, model: haiku }
+`);
+
+      const config = await loadConfig();
+      expect(config.aliases).toEqual({
+        '@fast': { provider: 'claude', model: 'haiku' },
+      });
+    });
+
+    test('repo aliases override global aliases with same key', async () => {
+      const pathMatches = (path: string, pattern: string): boolean =>
+        path.replace(/\\/g, '/').includes(pattern);
+
+      let globalRead = false;
+      mockFsReadFile.mockImplementation(async (path: string) => {
+        if (pathMatches(path, '/repo/.archon/config.yaml')) {
+          return `aliases:\n  '@fast': { provider: codex, model: gpt-5-mini }\n`;
+        }
+        if (pathMatches(path, '.archon/config.yaml') && !globalRead) {
+          globalRead = true;
+          return `aliases:\n  '@fast': { provider: claude, model: haiku }\n  '@deep': { provider: claude, model: opus }\n`;
+        }
+        const e = new Error('ENOENT') as NodeJS.ErrnoException;
+        e.code = 'ENOENT';
+        throw e;
+      });
+
+      const config = await loadConfig('/test/repo');
+      expect(config.aliases?.['@fast']).toEqual({ provider: 'codex', model: 'gpt-5-mini' });
+      expect(config.aliases?.['@deep']).toEqual({ provider: 'claude', model: 'opus' });
+    });
+
+    test('config.aliases is undefined when no aliases configured', async () => {
+      const error = new Error('ENOENT') as NodeJS.ErrnoException;
+      error.code = 'ENOENT';
+      mockFsReadFile.mockRejectedValue(error);
+
+      const config = await loadConfig();
+      expect(config.aliases).toBeUndefined();
+    });
+
     test('propagates docsPath from repo docs config', async () => {
       const pathMatches = (path: string, pattern: string): boolean => {
         const normalizedPath = path.replace(/\\/g, '/');

--- a/packages/core/src/config/config-loader.ts
+++ b/packages/core/src/config/config-loader.ts
@@ -35,6 +35,7 @@ import type {
   SafeConfig,
   AssistantDefaults,
   AssistantDefaultsConfig,
+  RawAliasesConfig,
 } from './config-types';
 import { createLogger } from '@archon/paths';
 import {
@@ -52,6 +53,20 @@ import {
  */
 function getRegisteredProviderNames(): string[] {
   return getRegisteredProviders().map(p => p.id);
+}
+
+/**
+ * Shallow-merge alias maps. Last-write-wins per key, intentional — repo wins
+ * over global, global wins over (currently absent) built-in alias defaults.
+ * Reserved-name validation lives in `buildAiProfile()` (model-validation.ts),
+ * not here — config-loader is a data-merge layer, not a resolver.
+ */
+function mergeAliases(
+  base: RawAliasesConfig | undefined,
+  overrides: RawAliasesConfig | undefined
+): RawAliasesConfig | undefined {
+  if (!overrides && !base) return undefined;
+  return { ...(base ?? {}), ...(overrides ?? {}) };
 }
 
 function mergeAssistantDefaults(
@@ -388,6 +403,9 @@ function mergeGlobalConfig(defaults: MergedConfig, global: GlobalConfig): Merged
 
   result.assistants = mergeAssistantDefaults(result.assistants, global.assistants);
 
+  // Merge global aliases on top of (currently empty) base aliases
+  result.aliases = mergeAliases(result.aliases, global.aliases);
+
   // Streaming preferences
   if (global.streaming) {
     if (global.streaming.telegram) result.streaming.telegram = global.streaming.telegram;
@@ -431,6 +449,9 @@ function mergeRepoConfig(merged: MergedConfig, repo: RepoConfig): MergedConfig {
   }
 
   result.assistants = mergeAssistantDefaults(result.assistants, repo.assistants);
+
+  // Repo aliases override global aliases with the same key
+  result.aliases = mergeAliases(result.aliases, repo.aliases);
 
   // Commands config
   if (repo.commands) {

--- a/packages/core/src/config/config-loader.ts
+++ b/packages/core/src/config/config-loader.ts
@@ -65,8 +65,8 @@ function mergeAliases(
   base: RawAliasesConfig | undefined,
   overrides: RawAliasesConfig | undefined
 ): RawAliasesConfig | undefined {
-  if (!overrides && !base) return undefined;
-  return { ...(base ?? {}), ...(overrides ?? {}) };
+  if (!base && !overrides) return undefined;
+  return { ...base, ...overrides };
 }
 
 function mergeAssistantDefaults(

--- a/packages/core/src/config/config-loader.ts
+++ b/packages/core/src/config/config-loader.ts
@@ -403,7 +403,6 @@ function mergeGlobalConfig(defaults: MergedConfig, global: GlobalConfig): Merged
 
   result.assistants = mergeAssistantDefaults(result.assistants, global.assistants);
 
-  // Merge global aliases on top of (currently empty) base aliases
   result.aliases = mergeAliases(result.aliases, global.aliases);
 
   // Streaming preferences
@@ -450,7 +449,6 @@ function mergeRepoConfig(merged: MergedConfig, repo: RepoConfig): MergedConfig {
 
   result.assistants = mergeAssistantDefaults(result.assistants, repo.assistants);
 
-  // Repo aliases override global aliases with the same key
   result.aliases = mergeAliases(result.aliases, repo.aliases);
 
   // Commands config

--- a/packages/core/src/config/config-types.ts
+++ b/packages/core/src/config/config-types.ts
@@ -20,6 +20,7 @@ import type {
   PiProviderDefaults,
   ProviderDefaultsMap,
 } from '@archon/providers/types';
+import type { RawAliasesConfig } from '@archon/workflows/model-validation';
 
 export type {
   ClaudeProviderDefaults,
@@ -28,6 +29,7 @@ export type {
   PiProviderDefaults,
   ProviderDefaultsMap,
 };
+export type { RawAliasesConfig };
 
 /**
  * Intersection type: generic `ProviderDefaultsMap` (any string key) with
@@ -78,6 +80,12 @@ export interface GlobalConfig {
    * Assistant-specific defaults (model, reasoning effort, etc.)
    */
   assistants?: AssistantDefaultsConfig;
+
+  /**
+   * Named model aliases accessible in workflow/node `model:` fields.
+   * Keys: `@<name>` for custom aliases. Reserved names: small, medium, large.
+   */
+  aliases?: RawAliasesConfig;
 
   /**
    * Platform streaming preferences (can be overridden per conversation)
@@ -132,6 +140,9 @@ export interface RepoConfig {
    * Assistant-specific defaults for this repository
    */
   assistants?: AssistantDefaultsConfig;
+
+  /** Repo-level model aliases — override global aliases with same name. */
+  aliases?: RawAliasesConfig;
 
   /**
    * Commands configuration
@@ -257,6 +268,11 @@ export interface MergedConfig {
   botName: string;
   assistant: string;
   assistants: AssistantDefaults;
+  /**
+   * Merged aliases (repo > global). Used by buildAiProfile at execution time.
+   * Undefined when no aliases are configured anywhere.
+   */
+  aliases?: RawAliasesConfig;
   streaming: {
     telegram: 'stream' | 'batch';
     discord: 'stream' | 'batch';

--- a/packages/core/src/config/config-types.ts
+++ b/packages/core/src/config/config-types.ts
@@ -83,7 +83,8 @@ export interface GlobalConfig {
 
   /**
    * Named model aliases accessible in workflow/node `model:` fields.
-   * Keys: `@<name>` for custom aliases. Reserved names: small, medium, large.
+   * Keys must use `@<name>` prefix (e.g. `@cheap`) — bare names are not
+   * reachable as aliases. Reserved names (enforced at runtime): small, medium, large.
    */
   aliases?: RawAliasesConfig;
 

--- a/packages/docs-web/src/content/docs/reference/configuration.md
+++ b/packages/docs-web/src/content/docs/reference/configuration.md
@@ -96,6 +96,11 @@ paths:
 concurrency:
   maxConversations: 10
 
+# Model aliases — optional. Wired into workflow `model:` resolution in a follow-up.
+# aliases:
+#   '@fast': { provider: claude, model: haiku }
+#   '@think': { provider: claude, model: opus, thinking: { type: enabled, budgetTokens: 8000 } }
+
 ```
 
 ## Repository Configuration
@@ -150,6 +155,10 @@ defaults:
 # env:
 #   MY_API_KEY: value
 #   CUSTOM_ENDPOINT: https://...
+
+# Model aliases — override global aliases with the same name (repo > global).
+# aliases:
+#   '@fast': { provider: claude, model: haiku }
 
 ```
 

--- a/packages/workflows/src/defaults/tier-defaults.json
+++ b/packages/workflows/src/defaults/tier-defaults.json
@@ -1,0 +1,27 @@
+{
+  "claude": {
+    "small": { "model": "haiku" },
+    "medium": { "model": "sonnet" },
+    "large": { "model": "opus" }
+  },
+  "codex": {
+    "small": { "model": "gpt-5.3-codex", "effort": "minimal" },
+    "medium": { "model": "gpt-5.3-codex", "effort": "medium" },
+    "large": { "model": "gpt-5.3-codex", "effort": "high" }
+  },
+  "pi": {
+    "small": { "model": "anthropic/claude-haiku-4-5" },
+    "medium": { "model": "anthropic/claude-sonnet-4-6" },
+    "large": { "model": "anthropic/claude-opus-4-7" }
+  },
+  "copilot": {
+    "small": { "model": "gpt-5-mini" },
+    "medium": { "model": "gpt-5" },
+    "large": { "model": "claude-sonnet-4.5" }
+  },
+  "opencode": {
+    "small": { "model": "anthropic/claude-haiku-4-5" },
+    "medium": { "model": "anthropic/claude-sonnet-4-6" },
+    "large": { "model": "anthropic/claude-opus-4-7" }
+  }
+}

--- a/packages/workflows/src/model-validation.test.ts
+++ b/packages/workflows/src/model-validation.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  buildAiProfile,
+  isLiteralSpec,
+  resolveModelSpec,
+  TIER_NAMES,
+  type ModelAliasPreset,
+  type ResolvedAiProfile,
+} from './model-validation';
+
+describe('TIER_NAMES constant', () => {
+  test('contains exactly small, medium, large', () => {
+    expect([...TIER_NAMES]).toEqual(['small', 'medium', 'large']);
+  });
+});
+
+describe('buildAiProfile — tier defaults', () => {
+  test('builds tier aliases for claude default provider', () => {
+    const profile = buildAiProfile('claude');
+    expect(profile.aliases.small).toBeDefined();
+    expect(profile.aliases.medium).toBeDefined();
+    expect(profile.aliases.large).toBeDefined();
+  });
+
+  test('injects provider into each tier entry', () => {
+    const profile = buildAiProfile('claude');
+    expect(profile.aliases.small?.provider).toBe('claude');
+    expect(profile.aliases.medium?.provider).toBe('claude');
+    expect(profile.aliases.large?.provider).toBe('claude');
+  });
+
+  test('preserves effort from tier defaults (codex)', () => {
+    const profile = buildAiProfile('codex');
+    expect(profile.aliases.small?.effort).toBe('minimal');
+    expect(profile.aliases.medium?.effort).toBe('medium');
+    expect(profile.aliases.large?.effort).toBe('high');
+  });
+
+  test('unknown provider yields empty alias map (no tier defaults)', () => {
+    const profile = buildAiProfile('newprovider');
+    expect(profile.defaultProvider).toBe('newprovider');
+    expect(Object.keys(profile.aliases)).toEqual([]);
+  });
+});
+
+describe('buildAiProfile — alias layering', () => {
+  test('repo alias overrides global alias with same name', () => {
+    const profile = buildAiProfile('claude', {
+      globalAliases: {
+        '@cheap': { provider: 'claude', model: 'haiku' },
+      },
+      repoAliases: {
+        '@cheap': { provider: 'codex', model: 'gpt-5-mini' },
+      },
+    });
+    expect(profile.aliases['@cheap']).toEqual({
+      provider: 'codex',
+      model: 'gpt-5-mini',
+    });
+  });
+
+  test('global alias not overridden by repo survives', () => {
+    const profile = buildAiProfile('claude', {
+      globalAliases: {
+        '@reasoning': { provider: 'claude', model: 'opus' },
+      },
+      repoAliases: {
+        '@cheap': { provider: 'claude', model: 'haiku' },
+      },
+    });
+    expect(profile.aliases['@reasoning']).toEqual({
+      provider: 'claude',
+      model: 'opus',
+    });
+    expect(profile.aliases['@cheap']).toEqual({
+      provider: 'claude',
+      model: 'haiku',
+    });
+  });
+
+  test('custom @ prefix aliases are included in the map', () => {
+    const profile = buildAiProfile('claude', {
+      globalAliases: {
+        '@fast': { provider: 'claude', model: 'haiku' },
+      },
+    });
+    expect(profile.aliases['@fast']).toBeDefined();
+  });
+
+  test('alias entry effort is preserved', () => {
+    const profile = buildAiProfile('codex', {
+      repoAliases: {
+        '@deep': { provider: 'codex', model: 'gpt-5.3-codex', effort: 'xhigh' },
+      },
+    });
+    expect(profile.aliases['@deep']?.effort).toBe('xhigh');
+  });
+
+  test('alias entry thinking is preserved', () => {
+    const profile = buildAiProfile('claude', {
+      repoAliases: {
+        '@think': {
+          provider: 'claude',
+          model: 'opus',
+          thinking: { type: 'enabled', budget_tokens: 10000 },
+        },
+      },
+    });
+    expect(profile.aliases['@think']?.thinking).toEqual({
+      type: 'enabled',
+      budget_tokens: 10000,
+    });
+  });
+});
+
+describe('buildAiProfile — reserved name validation', () => {
+  test('rejects reserved "small" in globalAliases', () => {
+    expect(() =>
+      buildAiProfile('claude', {
+        globalAliases: { small: { provider: 'claude', model: 'opus' } },
+      })
+    ).toThrow(/reserved/);
+  });
+
+  test('rejects reserved "medium" in repoAliases', () => {
+    expect(() =>
+      buildAiProfile('claude', {
+        repoAliases: { medium: { provider: 'claude', model: 'opus' } },
+      })
+    ).toThrow(/reserved/);
+  });
+
+  test('rejects reserved "large" in repoAliases', () => {
+    expect(() =>
+      buildAiProfile('claude', {
+        repoAliases: { large: { provider: 'claude', model: 'opus' } },
+      })
+    ).toThrow(/reserved/);
+  });
+
+  test('error message names the offending tier keyword', () => {
+    expect(() =>
+      buildAiProfile('claude', {
+        globalAliases: { small: { provider: 'claude', model: 'opus' } },
+      })
+    ).toThrow(/'small'/);
+  });
+
+  test('rejects alias entry with empty provider', () => {
+    expect(() =>
+      buildAiProfile('claude', {
+        repoAliases: { '@bad': { provider: '', model: 'opus' } },
+      })
+    ).toThrow(/provider/);
+  });
+});
+
+describe('resolveModelSpec — tier classification', () => {
+  test("'large' returns preset for large tier", () => {
+    const profile = buildAiProfile('claude');
+    const spec = resolveModelSpec(profile, 'large');
+    expect(spec).toEqual({ provider: 'claude', model: 'opus' });
+  });
+
+  test("'medium' returns preset for medium tier", () => {
+    const profile = buildAiProfile('claude');
+    const spec = resolveModelSpec(profile, 'medium');
+    expect(spec).toEqual({ provider: 'claude', model: 'sonnet' });
+  });
+
+  test("'small' returns preset for small tier", () => {
+    const profile = buildAiProfile('claude');
+    const spec = resolveModelSpec(profile, 'small');
+    expect(spec).toEqual({ provider: 'claude', model: 'haiku' });
+  });
+
+  test('returned preset has provider and model fields', () => {
+    const profile = buildAiProfile('claude');
+    const spec = resolveModelSpec(profile, 'large') as ModelAliasPreset;
+    expect(typeof spec.provider).toBe('string');
+    expect(typeof spec.model).toBe('string');
+  });
+});
+
+describe('resolveModelSpec — tier fallback chains', () => {
+  function profileWithTiers(
+    tiers: Partial<Record<'small' | 'medium' | 'large', string>>
+  ): ResolvedAiProfile {
+    const aliases: Record<string, ModelAliasPreset> = {};
+    for (const [tier, model] of Object.entries(tiers)) {
+      if (model) aliases[tier] = { provider: 'claude', model };
+    }
+    return { defaultProvider: 'claude', aliases };
+  }
+
+  test('only small configured → large falls back to small', () => {
+    const profile = profileWithTiers({ small: 'haiku' });
+    expect(resolveModelSpec(profile, 'large')).toEqual({
+      provider: 'claude',
+      model: 'haiku',
+    });
+  });
+
+  test('only small configured → medium falls back to small', () => {
+    const profile = profileWithTiers({ small: 'haiku' });
+    expect(resolveModelSpec(profile, 'medium')).toEqual({
+      provider: 'claude',
+      model: 'haiku',
+    });
+  });
+
+  test('small and medium configured → large falls back to medium', () => {
+    const profile = profileWithTiers({ small: 'haiku', medium: 'sonnet' });
+    expect(resolveModelSpec(profile, 'large')).toEqual({
+      provider: 'claude',
+      model: 'sonnet',
+    });
+  });
+
+  test('only large configured → small falls back to large', () => {
+    const profile = profileWithTiers({ large: 'opus' });
+    expect(resolveModelSpec(profile, 'small')).toEqual({
+      provider: 'claude',
+      model: 'opus',
+    });
+  });
+
+  test('only large configured → medium falls back to large', () => {
+    const profile = profileWithTiers({ large: 'opus' });
+    expect(resolveModelSpec(profile, 'medium')).toEqual({
+      provider: 'claude',
+      model: 'opus',
+    });
+  });
+
+  test('no tier aliases in profile → throws with actionable message', () => {
+    const profile: ResolvedAiProfile = {
+      defaultProvider: 'newprovider',
+      aliases: {},
+    };
+    expect(() => resolveModelSpec(profile, 'large')).toThrow(
+      /Tier 'large'.*newprovider.*aliases\.small\/medium\/large/
+    );
+  });
+});
+
+describe('resolveModelSpec — @custom alias', () => {
+  test('known @alias returns preset from profile', () => {
+    const profile = buildAiProfile('claude', {
+      repoAliases: {
+        '@cheap': { provider: 'claude', model: 'haiku' },
+      },
+    });
+    expect(resolveModelSpec(profile, '@cheap')).toEqual({
+      provider: 'claude',
+      model: 'haiku',
+    });
+  });
+
+  test('unknown @alias throws listing defined aliases', () => {
+    const profile = buildAiProfile('claude', {
+      repoAliases: {
+        '@cheap': { provider: 'claude', model: 'haiku' },
+      },
+    });
+    expect(() => resolveModelSpec(profile, '@unknown')).toThrow(/Unknown alias '@unknown'/);
+    expect(() => resolveModelSpec(profile, '@unknown')).toThrow(/@cheap/);
+  });
+
+  test('unknown @alias with empty alias map throws listing "(none)"', () => {
+    const profile: ResolvedAiProfile = {
+      defaultProvider: 'newprovider',
+      aliases: {},
+    };
+    expect(() => resolveModelSpec(profile, '@unknown')).toThrow(/\(none\)/);
+  });
+});
+
+describe('resolveModelSpec — literal pass-through', () => {
+  const emptyProfile: ResolvedAiProfile = {
+    defaultProvider: 'claude',
+    aliases: {},
+  };
+
+  test("'opus' returns { literal: 'opus' }", () => {
+    expect(resolveModelSpec(emptyProfile, 'opus')).toEqual({ literal: 'opus' });
+  });
+
+  test("'claude-opus-4-7' returns { literal: 'claude-opus-4-7' }", () => {
+    expect(resolveModelSpec(emptyProfile, 'claude-opus-4-7')).toEqual({
+      literal: 'claude-opus-4-7',
+    });
+  });
+
+  test("'gpt-5' returns { literal: 'gpt-5' }", () => {
+    expect(resolveModelSpec(emptyProfile, 'gpt-5')).toEqual({ literal: 'gpt-5' });
+  });
+
+  test('literal return does NOT have provider or model fields', () => {
+    const spec = resolveModelSpec(emptyProfile, 'sonnet');
+    expect(spec).not.toHaveProperty('provider');
+    expect(spec).not.toHaveProperty('model');
+  });
+
+  test('literal pass-through ignores configured tier defaults', () => {
+    const profile = buildAiProfile('claude');
+    // bare literal — not a tier keyword, no @ prefix → pass-through verbatim
+    expect(resolveModelSpec(profile, 'sonnet-3.5')).toEqual({ literal: 'sonnet-3.5' });
+  });
+});
+
+describe('isLiteralSpec type guard', () => {
+  test('returns true for { literal: ... }', () => {
+    expect(isLiteralSpec({ literal: 'foo' })).toBe(true);
+  });
+
+  test('returns false for a ModelAliasPreset', () => {
+    expect(isLiteralSpec({ provider: 'claude', model: 'opus' })).toBe(false);
+  });
+});

--- a/packages/workflows/src/model-validation.test.ts
+++ b/packages/workflows/src/model-validation.test.ts
@@ -103,13 +103,13 @@ describe('buildAiProfile — alias layering', () => {
         '@think': {
           provider: 'claude',
           model: 'opus',
-          thinking: { type: 'enabled', budget_tokens: 10000 },
+          thinking: { type: 'enabled', budgetTokens: 10000 },
         },
       },
     });
     expect(profile.aliases['@think']?.thinking).toEqual({
       type: 'enabled',
-      budget_tokens: 10000,
+      budgetTokens: 10000,
     });
   });
 });
@@ -153,6 +153,22 @@ describe('buildAiProfile — reserved name validation', () => {
         repoAliases: { '@bad': { provider: '', model: 'opus' } },
       })
     ).toThrow(/provider/);
+  });
+
+  test('rejects alias entry with empty model', () => {
+    expect(() =>
+      buildAiProfile('claude', {
+        repoAliases: { '@bad': { provider: 'claude', model: '' } },
+      })
+    ).toThrow(/model/);
+  });
+
+  test('rejects alias key without @ prefix', () => {
+    expect(() =>
+      buildAiProfile('claude', {
+        repoAliases: { cheap: { provider: 'claude', model: 'haiku' } },
+      })
+    ).toThrow(/'@cheap'/);
   });
 });
 
@@ -228,6 +244,14 @@ describe('resolveModelSpec — tier fallback chains', () => {
 
   test('only large configured → medium falls back to large', () => {
     const profile = profileWithTiers({ large: 'opus' });
+    expect(resolveModelSpec(profile, 'medium')).toEqual({
+      provider: 'claude',
+      model: 'opus',
+    });
+  });
+
+  test('large and small configured (no medium) → medium prefers large', () => {
+    const profile = profileWithTiers({ small: 'haiku', large: 'opus' });
     expect(resolveModelSpec(profile, 'medium')).toEqual({
       provider: 'claude',
       model: 'opus',

--- a/packages/workflows/src/model-validation.ts
+++ b/packages/workflows/src/model-validation.ts
@@ -127,11 +127,7 @@ export function buildAiProfile(
     }
   }
 
-  const layers: readonly (RawAliasesConfig | undefined)[] = [
-    options.globalAliases,
-    options.repoAliases,
-  ];
-  for (const layer of layers) {
+  for (const layer of [options.globalAliases, options.repoAliases]) {
     if (!layer) continue;
     for (const [name, entry] of Object.entries(layer)) {
       assertNotReserved(name);

--- a/packages/workflows/src/model-validation.ts
+++ b/packages/workflows/src/model-validation.ts
@@ -1,0 +1,170 @@
+/**
+ * Model alias resolver — pure classification + lookup for workflow `model:` refs.
+ *
+ * Classifies a model reference string as one of:
+ *   - tier keyword (`small` / `medium` / `large`) → looked up in profile with fallback chain
+ *   - `@<name>` custom alias → looked up in profile, errors if unknown
+ *   - bare literal (anything else) → returned unchanged for SDK pass-through
+ *
+ * No side effects, no logger, no I/O. The `ResolvedAiProfile` is built once by
+ * `buildAiProfile()` from layered config (tier defaults → global aliases → repo
+ * aliases) and then handed to `resolveModelSpec()` per call.
+ */
+
+import tierDefaults from './defaults/tier-defaults.json';
+
+/** Reserved tier names — cannot be used as custom alias names */
+export const TIER_NAMES = ['small', 'medium', 'large'] as const;
+export type TierName = (typeof TIER_NAMES)[number];
+
+/** A model preset — provider + model string + optional provider-specific options */
+export interface ModelAliasPreset {
+  provider: string;
+  model: string;
+  effort?: string;
+  thinking?: unknown;
+}
+
+/** Raw alias entry as it appears in config YAML (before provider injection) */
+export interface RawAliasEntry {
+  provider: string;
+  model: string;
+  effort?: string;
+  thinking?: unknown;
+}
+
+/** The aliases map from config YAML — keyed by alias name */
+export type RawAliasesConfig = Record<string, RawAliasEntry>;
+
+/** The resolved AI profile — used by resolveModelSpec */
+export interface ResolvedAiProfile {
+  defaultProvider: string;
+  /** Fully resolved alias map: includes tier entries (small/medium/large) + @custom entries */
+  aliases: Record<string, ModelAliasPreset>;
+}
+
+/** What resolveModelSpec returns */
+export type ResolvedModelSpec = ModelAliasPreset | { literal: string };
+
+/**
+ * Per-tier fallback order. When a workflow asks for `large` but the install
+ * has only `small` configured, we walk this chain and pick the first match.
+ * Order rationale: prefer a "near miss" in capability over an unrelated tier,
+ * but never throw when ANY tier alias exists.
+ */
+const TIER_FALLBACK: Record<TierName, readonly TierName[]> = {
+  large: ['large', 'medium', 'small'],
+  medium: ['medium', 'large', 'small'],
+  small: ['small', 'medium', 'large'],
+};
+
+const TIER_DEFAULTS = tierDefaults as Record<
+  string,
+  Record<TierName, { model: string; effort?: string }>
+>;
+
+function isTierName(value: string): value is TierName {
+  return (TIER_NAMES as readonly string[]).includes(value);
+}
+
+function assertNotReserved(name: string): void {
+  if (isTierName(name)) {
+    throw new Error(
+      `Alias name '${name}' is reserved (small/medium/large are tier keywords). Use a different name.`
+    );
+  }
+}
+
+function assertValidEntry(name: string, entry: RawAliasEntry): void {
+  if (typeof entry.provider !== 'string' || entry.provider.length === 0) {
+    throw new Error(`Alias '${name}' has invalid provider — must be a non-empty string.`);
+  }
+  if (typeof entry.model !== 'string' || entry.model.length === 0) {
+    throw new Error(`Alias '${name}' has invalid model — must be a non-empty string.`);
+  }
+}
+
+export interface BuildAiProfileOptions {
+  /** Aliases from ~/.archon/config.yaml */
+  globalAliases?: RawAliasesConfig;
+  /** Aliases from .archon/config.yaml (repo) — override globalAliases on key collision */
+  repoAliases?: RawAliasesConfig;
+}
+
+/**
+ * Build a ResolvedAiProfile by layering tier defaults → global aliases → repo aliases.
+ * Throws if any alias name collides with a reserved tier name.
+ */
+export function buildAiProfile(
+  defaultProvider: string,
+  options: BuildAiProfileOptions = {}
+): ResolvedAiProfile {
+  const aliases: Record<string, ModelAliasPreset> = {};
+
+  const tierEntries = TIER_DEFAULTS[defaultProvider];
+  if (tierEntries) {
+    for (const tier of TIER_NAMES) {
+      const entry = tierEntries[tier];
+      if (entry) {
+        aliases[tier] = {
+          provider: defaultProvider,
+          model: entry.model,
+          ...(entry.effort !== undefined ? { effort: entry.effort } : {}),
+        };
+      }
+    }
+  }
+
+  const layers: readonly (RawAliasesConfig | undefined)[] = [
+    options.globalAliases,
+    options.repoAliases,
+  ];
+  for (const layer of layers) {
+    if (!layer) continue;
+    for (const [name, entry] of Object.entries(layer)) {
+      assertNotReserved(name);
+      assertValidEntry(name, entry);
+      aliases[name] = {
+        provider: entry.provider,
+        model: entry.model,
+        ...(entry.effort !== undefined ? { effort: entry.effort } : {}),
+        ...(entry.thinking !== undefined ? { thinking: entry.thinking } : {}),
+      };
+    }
+  }
+
+  return { defaultProvider, aliases };
+}
+
+/**
+ * Classify a `model:` reference and resolve it against the profile.
+ *   - tier ('small' | 'medium' | 'large') → preset via fallback chain
+ *   - '@<name>' → preset from profile.aliases, or throw if unknown
+ *   - anything else → { literal: ref } pass-through
+ */
+export function resolveModelSpec(profile: ResolvedAiProfile, ref: string): ResolvedModelSpec {
+  if (isTierName(ref)) {
+    for (const tier of TIER_FALLBACK[ref]) {
+      const preset = profile.aliases[tier];
+      if (preset) return preset;
+    }
+    throw new Error(
+      `Tier '${ref}' has no configured alias and no built-in default for provider '${profile.defaultProvider}'. Configure 'aliases.small/medium/large' in .archon/config.yaml.`
+    );
+  }
+
+  if (ref.startsWith('@')) {
+    const preset = profile.aliases[ref];
+    if (preset) return preset;
+    const defined = Object.keys(profile.aliases);
+    const list = defined.length > 0 ? defined.join(', ') : '(none)';
+    throw new Error(`Unknown alias '${ref}'. Defined aliases: ${list}`);
+  }
+
+  return { literal: ref };
+}
+
+/** Type guard — narrows ResolvedModelSpec to its `{ literal }` variant. */
+export function isLiteralSpec(spec: ResolvedModelSpec): spec is { literal: string } {
+  return 'literal' in spec;
+}

--- a/packages/workflows/src/model-validation.ts
+++ b/packages/workflows/src/model-validation.ts
@@ -12,6 +12,7 @@
  */
 
 import tierDefaults from './defaults/tier-defaults.json';
+import type { ThinkingConfig } from './schemas/dag-node';
 
 /** Reserved tier names — cannot be used as custom alias names */
 export const TIER_NAMES = ['small', 'medium', 'large'] as const;
@@ -22,15 +23,17 @@ export interface ModelAliasPreset {
   provider: string;
   model: string;
   effort?: string;
-  thinking?: unknown;
+  thinking?: ThinkingConfig;
 }
 
-/** Raw alias entry as it appears in config YAML (before provider injection) */
+/** Alias entry as written in config YAML — user-defined @custom aliases.
+ * Structurally identical to ModelAliasPreset; kept separate to distinguish
+ * config-layer input from resolved output. */
 export interface RawAliasEntry {
   provider: string;
   model: string;
   effort?: string;
-  thinking?: unknown;
+  thinking?: ThinkingConfig;
 }
 
 /** The aliases map from config YAML — keyed by alias name */
@@ -54,7 +57,7 @@ export type ResolvedModelSpec = ModelAliasPreset | { literal: string };
  */
 const TIER_FALLBACK: Record<TierName, readonly TierName[]> = {
   large: ['large', 'medium', 'small'],
-  medium: ['medium', 'large', 'small'],
+  medium: ['medium', 'large', 'small'], // prefer over-capable (large) when both sides missing
   small: ['small', 'medium', 'large'],
 };
 
@@ -71,6 +74,14 @@ function assertNotReserved(name: string): void {
   if (isTierName(name)) {
     throw new Error(
       `Alias name '${name}' is reserved (small/medium/large are tier keywords). Use a different name.`
+    );
+  }
+}
+
+function assertCustomAliasPrefix(name: string): void {
+  if (!name.startsWith('@')) {
+    throw new Error(
+      `Alias name '${name}' must start with '@' (e.g. '@${name}'). Reserved tier names (small/medium/large) do not need '@'.`
     );
   }
 }
@@ -93,7 +104,8 @@ export interface BuildAiProfileOptions {
 
 /**
  * Build a ResolvedAiProfile by layering tier defaults → global aliases → repo aliases.
- * Throws if any alias name collides with a reserved tier name.
+ * Throws if any alias name collides with a reserved tier name, or if an alias
+ * entry has an empty provider or model string, or if an alias key lacks the `@` prefix.
  */
 export function buildAiProfile(
   defaultProvider: string,
@@ -123,6 +135,7 @@ export function buildAiProfile(
     if (!layer) continue;
     for (const [name, entry] of Object.entries(layer)) {
       assertNotReserved(name);
+      assertCustomAliasPrefix(name);
       assertValidEntry(name, entry);
       aliases[name] = {
         provider: entry.provider,


### PR DESCRIPTION
## Summary

- **Problem:** Workflow `model:` fields are hard-coded concrete strings (`opus`, `gpt-5.3-codex`). Bundled defaults can't adapt to whatever provider/model a user has installed, making workflows non-portable across different AI setups.
- **Why it matters:** Tier abstraction (`small`/`medium`/`large`) and custom aliases (`@reasoning`, `@cheap`) let workflow authors write portable YAML that resolves correctly per-install.
- **What changed:** New pure `resolveModelSpec` resolver in `@archon/workflows`, seeded tier defaults JSON, `aliases:` config key across global/repo/merged config types, and a `mergeAliases` helper in config-loader.
- **What did not change:** The resolver is defined but not yet threaded into `resolveNodeProviderAndModel` in dag-executor — that wiring is the explicit follow-up. No executor, no bundled-workflow retrofitting, no per-user DB aliases, no UI/CLI.

## UX Journey

### Before

```
workflow.yaml         dag-executor          SDK / Provider
┌──────────────┐      ┌──────────────────┐  ┌──────────────────┐
│ model: opus  │ ───▶ │ pass-through      │─▶│ "opus" verbatim  │
└──────────────┘      │ (no resolution)  │  └──────────────────┘
                      └──────────────────┘

Author writes hard-coded model string in YAML.
Bundled defaults use concrete models; non-portable across installs.
```

### After

```
workflow.yaml         resolveModelSpec       ResolvedAiProfile
┌──────────────┐      ┌──────────────────┐   ┌──────────────────┐
│ model: large │ ───▶ │ tier lookup +    │◀──│ aliases map      │
└──────────────┘      │ fallback chain   │   │ (built from cfg) │
                      └────────┬─────────┘   └──────────────────┘
┌──────────────┐               │                      ▲
│ model: @cheap│ ── @alias ──▶ │              ┌───────┴────────┐
└──────────────┘               │              │tier-defaults.  │
                               │              │json + config   │
┌──────────────┐               │              └────────────────┘
│ model: opus  │ ── literal ──▶│ { literal: "opus" } (unchanged)
└──────────────┘               │
                      ┌────────▼─────────┐
                      │ { provider, model,│
                      │   effort?, ...}   │──▶ SDK (follow-up wiring)
                      └──────────────────┘

Author writes `model: large` or `model: "@reasoning"`.
Tier resolves per-install config; literals still pass through verbatim.
```

## Architecture Diagram

### Before

```
@archon/workflows
  └── model-validation.ts  [does not exist]

@archon/core
  └── config/
      ├── config-types.ts   (GlobalConfig, RepoConfig, MergedConfig)
      └── config-loader.ts  (mergeGlobalConfig, mergeRepoConfig)
```

### After

```
@archon/workflows
  ├── defaults/
  │   └── tier-defaults.json        [+] seeded tier→model map per provider
  ├── model-validation.ts           [+] types + buildAiProfile + resolveModelSpec
  └── model-validation.test.ts      [+] 35 tests, 46 assertions

@archon/core
  └── config/
      ├── config-types.ts           [~] aliases?: RawAliasesConfig on GlobalConfig/RepoConfig/MergedConfig
      └── config-loader.ts          [~] mergeAliases helper + threading into mergeGlobalConfig/mergeRepoConfig
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `config-types.ts` | `@archon/workflows/model-validation` | **new** | Re-exports `RawAliasesConfig` type |
| `config-loader.ts` | `config-types.ts` | unchanged | Already imported |
| `dag-executor.ts` | `model-validation.ts` | not yet | Follow-up wiring issue |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `workflows`, `config`
- Module: `workflows:model-validation`, `core:config`

## Change Metadata

- Change type: `feature`
- Primary scope: `multi` (workflows + core/config)

## Linked Issue

- Closes #1862

## Validation Evidence (required)

```bash
bun run validate
```

| Check | Result |
|-------|--------|
| `check:bundled` | ✅ 36 commands, 20 workflows up to date |
| `check:bundled-skill` | ✅ 23 files up to date |
| `check:bundled-schema` | ✅ up to date |
| `type-check` (all 10 packages) | ✅ pass |
| `lint --max-warnings 0` | ✅ 0 errors, 0 warnings |
| `format:check` | ✅ pass |
| `test` (4448 tests) | ✅ 4448 passed, 0 failed |

Targeted counts:
- `model-validation.test.ts` — 35 tests, 46 assertions, 0 failures
- `core/config/` — 46 tests, 75 assertions, 0 failures

- Evidence provided: all commands ran clean, results captured in `validation.md`
- No commands skipped.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — `aliases:` is an optional config key; existing configs with no `aliases:` key behave identically. Literals still pass through verbatim.
- Config/env changes? Yes (additive): users can now add `aliases:` to `.archon/config.yaml`. No required changes.
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: all 9 test groups (tier resolution, fallback chains, @custom aliases, literal pass-through, reserved-name rejection, alias layering with repo > global precedence) run and pass.
- Edge cases checked: single-tier-set fallback both directions (`large` → `small`, `small` → `large`); unknown provider → empty aliases map; `@unknown` with empty alias map → error lists `(none)`; reserved name in both global and repo aliases throws with clear message.
- What was not verified: end-to-end executor wiring (out of scope for this PR — resolver exists but is not yet called from `resolveNodeProviderAndModel`).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `@archon/workflows` (new module), `@archon/core` config types and loader. No executor paths touched.
- Potential unintended effects: None — resolver is pure (no side effects, no I/O, no DB). Config loader change is additive.
- Guardrails/monitoring for early detection: `buildAiProfile` throws on reserved names or malformed alias entries at profile-build time, giving a clear error before any SDK call is made.

## Rollback Plan (required)

- Fast rollback command/path: revert the 5 changed files; config with `aliases:` silently ignored by old config-loader (TypeScript optional fields are `undefined` when absent).
- Feature flags or config toggles: none — the resolver is defined but not wired; it cannot be invoked in production until the follow-up executor wiring lands.
- Observable failure symptoms: none expected; any regression would surface as a type-check or test failure in CI.

## Risks and Mitigations

- Risk: Circular import between `@archon/core` and `@archon/workflows`
  - Mitigation: Import direction is `core → workflows`, which is the established direction (core already depends on workflows). Verified by type-check passing across all 10 packages.
- Risk: `@archon/workflows/model-validation` subpath not resolving
  - Mitigation: The subpath `"./model-validation": "./src/model-validation.ts"` was pre-registered in `packages/workflows/package.json` exports map (noted in the issue). Type-check confirms it resolves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now define custom model aliases in global and repository configurations.
  * Model references can use tier keywords (small, medium, large) to quickly select pre-configured model options across different providers.
  * Custom aliases require an @ prefix to distinguish them from literal model references.

* **Documentation**
  * Added configuration documentation for setting up and using model aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->