### PR TITLE
fix(web/console): gate /console behind auth + correct run-event normalizer

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -8,7 +8,7 @@
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "type-check": "tsc --noEmit",
-    "test": "bun test src/lib/ && bun test src/stores/ && bun test src/hooks/ && bun test src/components/",
+    "test": "bun test src/lib/ && bun test src/stores/ && bun test src/hooks/ && bun test src/components/ && bun test src/experiments/console/",
     "generate:types": "openapi-typescript http://localhost:3090/api/openapi.json -o src/lib/api.generated.d.ts"
   },
   "dependencies": {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -75,8 +75,9 @@ export function App(): React.ReactElement {
               {/*
                 Console mounts OUTSIDE Layout (so it does not inherit TopNav) but
                 still INSIDE SessionGate — otherwise /console would bypass web auth
-                that every other app route enforces. SessionGate is a passthrough
-                when web auth is disabled (the solo default), so this is a no-op there.
+                that every other app route enforces. When web auth is disabled (the
+                solo default) SessionGate passes children through unchanged after a
+                brief auth-status check (cached for the session) — no login required.
               */}
               <Route
                 path="/console/*"

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -72,8 +72,20 @@ export function App(): React.ReactElement {
             <Routes>
               {/* Login mounts OUTSIDE the SessionGate so it is always reachable. */}
               <Route path="/login" element={<LoginPage />} />
-              {/* Console experiment mounts OUTSIDE Layout so it does not inherit TopNav. */}
-              <Route path="/console/*" element={<ConsoleApp />} />
+              {/*
+                Console mounts OUTSIDE Layout (so it does not inherit TopNav) but
+                still INSIDE SessionGate — otherwise /console would bypass web auth
+                that every other app route enforces. SessionGate is a passthrough
+                when web auth is disabled (the solo default), so this is a no-op there.
+              */}
+              <Route
+                path="/console/*"
+                element={
+                  <SessionGate>
+                    <ConsoleApp />
+                  </SessionGate>
+                }
+              />
               <Route
                 element={
                   <SessionGate>

--- a/packages/web/src/experiments/README.md
+++ b/packages/web/src/experiments/README.md
@@ -4,7 +4,7 @@ Staging area for in-repo spikes and prototypes.
 
 Rules:
 
-- Not part of the shipped product. CI does not guarantee these routes work.
+- Not part of the shipped product. CI does not guarantee these routes work end-to-end, though unit tests for experiment primitives that opt in (e.g. `console/`, wired into the web `test` script) do run in CI.
 - Each experiment lives in its own folder and mounts under a dedicated route so it cannot affect production surfaces.
 - Does not import from `packages/web/src/components/`, `stores/`, `contexts/`, `routes/`, or `hooks/`. Shared types come from `@/lib/api.generated` only. This decoupling is the point — experiments have to prove they can stand on their own before they replace anything.
 - If an experiment becomes the product: extract it into its own workspace package or replace the existing surface. Don't let experiments accrete indefinitely.

--- a/packages/web/src/experiments/console/primitives/event.test.ts
+++ b/packages/web/src/experiments/console/primitives/event.test.ts
@@ -97,6 +97,28 @@ describe('toRunEvent — node transitions', () => {
     expect(e.transition).toBe('skipped');
     expect(e.skipReason).toBe('prior_success');
   });
+
+  test('node_failed maps to a failed transition (guards the map vs the skipped default)', () => {
+    const e = toRunEvent(raw({ event_type: 'node_failed' }));
+    expect(e.kind).toBe('node_transition');
+    if (e.kind !== 'node_transition') throw new Error('unreachable');
+    // Must NOT fall through to the `?? 'skipped'` default.
+    expect(e.transition).toBe('failed');
+    expect(e.skipReason).toBeNull();
+    expect(e.outputPreview).toBeNull();
+  });
+
+  test('nodeName prefers data.name, falling back to step_name', () => {
+    const named = toRunEvent(
+      raw({ event_type: 'node_started', step_name: 'plan', data: { name: 'Plan the work' } })
+    );
+    if (named.kind !== 'node_transition') throw new Error('unreachable');
+    expect(named.nodeName).toBe('Plan the work');
+
+    const unnamed = toRunEvent(raw({ event_type: 'node_started', step_name: 'plan' }));
+    if (unnamed.kind !== 'node_transition') throw new Error('unreachable');
+    expect(unnamed.nodeName).toBe('plan');
+  });
 });
 
 describe('toRunEvent — tool calls (regression guard)', () => {
@@ -155,11 +177,55 @@ describe('toRunEvent — approvals (server writes approval_requested/approval_re
     });
   });
 
+  test('approval_received with a missing/unknown decision stays unresolved (never silently approved)', () => {
+    const missing = toRunEvent(raw({ event_type: 'approval_received', data: {} }));
+    if (missing.kind !== 'approval') throw new Error('unreachable');
+    expect(missing.resolution).toBeNull();
+
+    const garbage = toRunEvent(raw({ event_type: 'approval_received', data: { decision: '???' } }));
+    if (garbage.kind !== 'approval') throw new Error('unreachable');
+    expect(garbage.resolution).toBeNull();
+  });
+
   test('the old (never-written) approval_pending type is NOT treated as an approval', () => {
     // Guards against regressing to the pre-fix keys: approval_pending/approval_resolved
     // are not emitted by the server, so they must fall through, not render as approvals.
     const e = toRunEvent(raw({ event_type: 'approval_pending', data: { message: 'x' } }));
     expect(e.kind).not.toBe('approval');
+  });
+});
+
+describe('toRunEvent — error & workflow lifecycle', () => {
+  test('error prefers the `error` key over `message`', () => {
+    const e = toRunEvent(
+      raw({ event_type: 'error', data: { error: 'boom', message: 'ignored', recoverable: true } })
+    );
+    expect(e.kind).toBe('error');
+    if (e.kind !== 'error') throw new Error('unreachable');
+    expect(e.message).toBe('boom');
+    expect(e.recoverable).toBe(true);
+  });
+
+  test('error falls back to `message` when `error` is absent', () => {
+    const e = toRunEvent(raw({ event_type: 'error', data: { message: 'fallback' } }));
+    if (e.kind !== 'error') throw new Error('unreachable');
+    expect(e.message).toBe('fallback');
+    expect(e.recoverable).toBe(false);
+  });
+
+  test('workflow_completed → a system event with a label', () => {
+    const e = toRunEvent(raw({ event_type: 'workflow_completed', data: { name: 'deploy' } }));
+    expect(e.kind).toBe('system');
+    if (e.kind !== 'system') throw new Error('unreachable');
+    expect(e.label).toBe('Workflow completed');
+    expect(e.detail).toBe('deploy');
+  });
+
+  test('workflow_failed surfaces the error in `detail`', () => {
+    const e = toRunEvent(raw({ event_type: 'workflow_failed', data: { error: 'node X failed' } }));
+    if (e.kind !== 'system') throw new Error('unreachable');
+    expect(e.label).toBe('Workflow failed');
+    expect(e.detail).toBe('node X failed');
   });
 });
 

--- a/packages/web/src/experiments/console/primitives/event.test.ts
+++ b/packages/web/src/experiments/console/primitives/event.test.ts
@@ -1,0 +1,173 @@
+import { describe, test, expect } from 'bun:test';
+import { toRunEvent } from './event';
+
+type Raw = Parameters<typeof toRunEvent>[0];
+
+function raw(over: Partial<Raw> & { event_type: string }): Raw {
+  return {
+    id: 'e1',
+    workflow_run_id: 'r1',
+    step_index: null,
+    step_name: 'node-a',
+    data: {},
+    created_at: '2026-06-05T10:00:00Z',
+    ...over,
+  };
+}
+
+describe('toRunEvent — base mapping', () => {
+  test('maps id, runId, timestamp, nodeId from the row', () => {
+    const e = toRunEvent(raw({ event_type: 'node_started', step_name: 'plan' }));
+    expect(e.id).toBe('e1');
+    expect(e.runId).toBe('r1');
+    expect(e.timestamp).toBe('2026-06-05T10:00:00Z');
+    expect(e.nodeId).toBe('plan');
+  });
+});
+
+describe('toRunEvent — node transitions', () => {
+  test('node_completed reads duration_ms (regression: server writes duration_ms, not duration)', () => {
+    const e = toRunEvent(
+      raw({
+        event_type: 'node_completed',
+        data: {
+          duration_ms: 11370,
+          node_output: '1717',
+          cost_usd: 0.1399,
+          stop_reason: 'end_turn',
+          num_turns: 1,
+        },
+      })
+    );
+    expect(e.kind).toBe('node_transition');
+    if (e.kind !== 'node_transition') throw new Error('unreachable');
+    expect(e.transition).toBe('completed');
+    expect(e.durationMs).toBe(11370); // was always null when reading `duration`
+    expect(e.outputPreview).toBe('1717');
+    expect(e.costUsd).toBe(0.1399);
+    expect(e.stopReason).toBe('end_turn');
+    expect(e.numTurns).toBe(1);
+  });
+
+  test('node_completed truncates a long output preview to 300 chars', () => {
+    const long = 'x'.repeat(500);
+    const e = toRunEvent(raw({ event_type: 'node_completed', data: { node_output: long } }));
+    if (e.kind !== 'node_transition') throw new Error('unreachable');
+    expect(e.outputPreview).toHaveLength(300);
+  });
+
+  test('node_started has null duration and null enrichment', () => {
+    const e = toRunEvent(raw({ event_type: 'node_started' }));
+    if (e.kind !== 'node_transition') throw new Error('unreachable');
+    expect(e.transition).toBe('started');
+    expect(e.durationMs).toBeNull();
+    expect(e.outputPreview).toBeNull();
+    expect(e.costUsd).toBeNull();
+  });
+
+  test('node_skipped carries when_condition reason + expr', () => {
+    const e = toRunEvent(
+      raw({
+        event_type: 'node_skipped',
+        data: { reason: 'when_condition', expr: "$classify.output.issue_type != 'bug'" },
+      })
+    );
+    if (e.kind !== 'node_transition') throw new Error('unreachable');
+    expect(e.transition).toBe('skipped');
+    expect(e.skipReason).toBe('when_condition');
+    expect(e.skipExpr).toBe("$classify.output.issue_type != 'bug'");
+  });
+
+  test('node_skipped trigger_rule has no expr', () => {
+    const e = toRunEvent(raw({ event_type: 'node_skipped', data: { reason: 'trigger_rule' } }));
+    if (e.kind !== 'node_transition') throw new Error('unreachable');
+    expect(e.skipReason).toBe('trigger_rule');
+    expect(e.skipExpr).toBeNull();
+  });
+
+  test('node_skipped_prior_success maps to a skipped transition (was dropped entirely)', () => {
+    const e = toRunEvent(
+      raw({
+        event_type: 'node_skipped_prior_success',
+        data: { reason: 'prior_success', node_output: '1516' },
+      })
+    );
+    expect(e.kind).toBe('node_transition');
+    if (e.kind !== 'node_transition') throw new Error('unreachable');
+    expect(e.transition).toBe('skipped');
+    expect(e.skipReason).toBe('prior_success');
+  });
+});
+
+describe('toRunEvent — tool calls (regression guard)', () => {
+  test('tool_called carries tool name + input, no result yet', () => {
+    const e = toRunEvent(
+      raw({ event_type: 'tool_called', data: { tool_name: 'Bash', tool_input: { cmd: 'ls' } } })
+    );
+    expect(e.kind).toBe('tool_call');
+    if (e.kind !== 'tool_call') throw new Error('unreachable');
+    expect(e.tool).toBe('Bash');
+    expect(e.args).toEqual({ cmd: 'ls' });
+    expect(e.result).toBeNull();
+  });
+
+  test('tool_completed reads duration_ms into the result', () => {
+    const e = toRunEvent(
+      raw({ event_type: 'tool_completed', data: { tool_name: 'Bash', duration_ms: 667 } })
+    );
+    if (e.kind !== 'tool_call') throw new Error('unreachable');
+    expect(e.result).toEqual({ ok: true, durationMs: 667 });
+  });
+});
+
+describe('toRunEvent — approvals (server writes approval_requested/approval_received)', () => {
+  test('approval_requested → pending approval with the prompt', () => {
+    const e = toRunEvent(
+      raw({ event_type: 'approval_requested', data: { message: 'Review the plan?' } })
+    );
+    expect(e.kind).toBe('approval');
+    if (e.kind !== 'approval') throw new Error('unreachable');
+    expect(e.prompt).toBe('Review the plan?');
+    expect(e.resolution).toBeNull();
+  });
+
+  test('approval_received approved → approved resolution with comment', () => {
+    const e = toRunEvent(
+      raw({ event_type: 'approval_received', data: { decision: 'approved', comment: 'ship it' } })
+    );
+    if (e.kind !== 'approval') throw new Error('unreachable');
+    expect(e.resolution).toEqual({
+      kind: 'approved',
+      at: '2026-06-05T10:00:00Z',
+      comment: 'ship it',
+    });
+  });
+
+  test('approval_received rejected → rejected resolution with reason', () => {
+    const e = toRunEvent(
+      raw({ event_type: 'approval_received', data: { decision: 'rejected', reason: 'fix tests' } })
+    );
+    if (e.kind !== 'approval') throw new Error('unreachable');
+    expect(e.resolution).toEqual({
+      kind: 'rejected',
+      at: '2026-06-05T10:00:00Z',
+      reason: 'fix tests',
+    });
+  });
+
+  test('the old (never-written) approval_pending type is NOT treated as an approval', () => {
+    // Guards against regressing to the pre-fix keys: approval_pending/approval_resolved
+    // are not emitted by the server, so they must fall through, not render as approvals.
+    const e = toRunEvent(raw({ event_type: 'approval_pending', data: { message: 'x' } }));
+    expect(e.kind).not.toBe('approval');
+  });
+});
+
+describe('toRunEvent — fallback', () => {
+  test('unknown event types fall through to a text event with a payload summary', () => {
+    const e = toRunEvent(raw({ event_type: 'mystery_event', data: { foo: 'bar' } }));
+    expect(e.kind).toBe('text');
+    if (e.kind !== 'text') throw new Error('unreachable');
+    expect(e.content).toContain('mystery_event');
+  });
+});

--- a/packages/web/src/experiments/console/primitives/event.ts
+++ b/packages/web/src/experiments/console/primitives/event.ts
@@ -50,14 +50,15 @@ export interface NodeTransitionEvent extends RunEventBase {
   nodeName: string;
   transition: 'started' | 'completed' | 'failed' | 'skipped';
   durationMs: number | null;
-  /** Only populated for `skipped` — `when_condition`, `trigger_rule`, or `prior_success`. */
+  /** Only populated for `skipped` — the server's skip reason (e.g. `when_condition`, `trigger_rule`, `prior_success`). */
   skipReason: string | null;
   /** Only populated for `skipped` — the evaluated expression that gated it. */
   skipExpr: string | null;
   /**
    * `node_completed` enrichment, read straight from the persisted event payload.
-   * Not rendered yet — the per-node accordion (follow-up) surfaces these. Null on
-   * non-completion transitions (and when a provider doesn't report them).
+   * Populated only on the `completed` transition; null on every other transition
+   * (and when a provider doesn't report a given field). Not consumed by any current
+   * renderer — carried so the eventual per-node detail view needn't re-touch this.
    */
   outputPreview: string | null;
   costUsd: number | null;
@@ -128,6 +129,20 @@ function readNumberOrNull(obj: Record<string, unknown>, key: string): number | n
 }
 
 /**
+ * DB node-event `event_type` → UI transition. Listed explicitly (rather than
+ * string-slicing `node_<x>`) because `node_skipped_prior_success` — emitted on
+ * resume for already-completed nodes — doesn't fit that shape, and both skip
+ * variants collapse to `skipped`.
+ */
+const NODE_TRANSITION_BY_EVENT: Record<string, NodeTransitionEvent['transition']> = {
+  node_started: 'started',
+  node_completed: 'completed',
+  node_failed: 'failed',
+  node_skipped: 'skipped',
+  node_skipped_prior_success: 'skipped',
+};
+
+/**
  * Best-effort normalizer from a raw workflow_events row to a typed RunEvent.
  * Unknown event types fall through as text events with the raw payload —
  * the spike surfaces them rather than silently dropping.
@@ -149,17 +164,9 @@ export function toRunEvent(raw: RawWorkflowEvent): RunEvent {
     et === 'node_skipped' ||
     et === 'node_skipped_prior_success'
   ) {
-    // `node_skipped_prior_success` (emitted on resume for already-completed nodes)
-    // doesn't fit the `node_<transition>` shape, so map transitions explicitly
-    // rather than string-slicing.
-    const transition: NodeTransitionEvent['transition'] =
-      et === 'node_started'
-        ? 'started'
-        : et === 'node_completed'
-          ? 'completed'
-          : et === 'node_failed'
-            ? 'failed'
-            : 'skipped';
+    // Guard above restricts `et` to the map's keys; `?? 'skipped'` is only a
+    // defensive default if a new node_* type is added to the guard but not the map.
+    const transition = NODE_TRANSITION_BY_EVENT[et] ?? 'skipped';
     const output = readStringOrNull(data, 'node_output');
     return {
       ...base,
@@ -211,11 +218,13 @@ export function toRunEvent(raw: RawWorkflowEvent): RunEvent {
 
   // The server writes two rows around a human gate: `approval_requested` (carries
   // the prompt in `message`) and `approval_received` (carries the outcome in
-  // `decision` + `comment`/`reason`). The prompt does NOT ride the received row —
-  // a renderer pairs the two by nodeId, the way tool_called/tool_completed pair.
-  // (The old code checked `approval_pending`/`approval_resolved` and read a
-  // `resolution` key, none of which the server ever writes, so approvals fell
-  // through to the raw-JSON fallback below.)
+  // `decision` + `comment`/`reason`). The prompt does NOT ride the received row;
+  // these two are emitted as separate events and a future renderer would pair them
+  // by nodeId. (Today nothing renders `approval` events in the run stream — paused
+  // gates are driven from `run.approval` metadata — so this is correctness of
+  // classification, not display.) The old code checked `approval_pending`/
+  // `approval_resolved` and read a `resolution` key, none of which the server ever
+  // writes, so approvals fell through to the raw-JSON fallback below.
   if (et === 'approval_requested') {
     return {
       ...base,
@@ -226,23 +235,21 @@ export function toRunEvent(raw: RawWorkflowEvent): RunEvent {
   }
 
   if (et === 'approval_received') {
-    const decision = readString(data, 'decision'); // 'approved' | 'rejected'
+    const decision = readString(data, 'decision');
+    // Match the decision explicitly. An unknown/missing value must NOT default to
+    // "approved" (that would silently render a rejected gate as approved — the exact
+    // silent-mismatch class this normalizer exists to prevent); leave it unresolved.
+    const resolution: ApprovalEvent['resolution'] =
+      decision === 'approved'
+        ? { kind: 'approved', at: raw.created_at, comment: readStringOrNull(data, 'comment') }
+        : decision === 'rejected'
+          ? { kind: 'rejected', at: raw.created_at, reason: readString(data, 'reason') }
+          : null;
     return {
       ...base,
       kind: 'approval',
       prompt: '',
-      resolution:
-        decision === 'rejected'
-          ? {
-              kind: 'rejected',
-              at: raw.created_at,
-              reason: readString(data, 'reason'),
-            }
-          : {
-              kind: 'approved',
-              at: raw.created_at,
-              comment: readStringOrNull(data, 'comment'),
-            },
+      resolution,
     };
   }
 

--- a/packages/web/src/experiments/console/primitives/event.ts
+++ b/packages/web/src/experiments/console/primitives/event.ts
@@ -50,10 +50,19 @@ export interface NodeTransitionEvent extends RunEventBase {
   nodeName: string;
   transition: 'started' | 'completed' | 'failed' | 'skipped';
   durationMs: number | null;
-  /** Only populated for `skipped` — `when_condition` or `trigger_rule`. */
+  /** Only populated for `skipped` — `when_condition`, `trigger_rule`, or `prior_success`. */
   skipReason: string | null;
   /** Only populated for `skipped` — the evaluated expression that gated it. */
   skipExpr: string | null;
+  /**
+   * `node_completed` enrichment, read straight from the persisted event payload.
+   * Not rendered yet — the per-node accordion (follow-up) surfaces these. Null on
+   * non-completion transitions (and when a provider doesn't report them).
+   */
+  outputPreview: string | null;
+  costUsd: number | null;
+  stopReason: string | null;
+  numTurns: number | null;
 }
 
 export interface ApprovalEvent extends RunEventBase {
@@ -137,17 +146,35 @@ export function toRunEvent(raw: RawWorkflowEvent): RunEvent {
     et === 'node_started' ||
     et === 'node_completed' ||
     et === 'node_failed' ||
-    et === 'node_skipped'
+    et === 'node_skipped' ||
+    et === 'node_skipped_prior_success'
   ) {
-    const transition = et.replace('node_', '') as 'started' | 'completed' | 'failed' | 'skipped';
+    // `node_skipped_prior_success` (emitted on resume for already-completed nodes)
+    // doesn't fit the `node_<transition>` shape, so map transitions explicitly
+    // rather than string-slicing.
+    const transition: NodeTransitionEvent['transition'] =
+      et === 'node_started'
+        ? 'started'
+        : et === 'node_completed'
+          ? 'completed'
+          : et === 'node_failed'
+            ? 'failed'
+            : 'skipped';
+    const output = readStringOrNull(data, 'node_output');
     return {
       ...base,
       kind: 'node_transition',
       nodeName: readString(data, 'name') || (raw.step_name ?? ''),
       transition,
-      durationMs: readNumberOrNull(data, 'duration'),
+      // Server persists `duration_ms` (NOT `duration`); reading the wrong key here
+      // left every node duration null in the UI.
+      durationMs: readNumberOrNull(data, 'duration_ms'),
       skipReason: transition === 'skipped' ? readStringOrNull(data, 'reason') : null,
       skipExpr: transition === 'skipped' ? readStringOrNull(data, 'expr') : null,
+      outputPreview: output === null ? null : output.slice(0, 300),
+      costUsd: readNumberOrNull(data, 'cost_usd'),
+      stopReason: readStringOrNull(data, 'stop_reason'),
+      numTurns: readNumberOrNull(data, 'num_turns'),
     };
   }
 
@@ -182,15 +209,30 @@ export function toRunEvent(raw: RawWorkflowEvent): RunEvent {
     };
   }
 
-  if (et === 'approval_pending' || et === 'approval_resolved') {
-    const resolution = et === 'approval_resolved';
-    const resolvedAs = readString(data, 'resolution'); // 'approved' | 'rejected'
+  // The server writes two rows around a human gate: `approval_requested` (carries
+  // the prompt in `message`) and `approval_received` (carries the outcome in
+  // `decision` + `comment`/`reason`). The prompt does NOT ride the received row —
+  // a renderer pairs the two by nodeId, the way tool_called/tool_completed pair.
+  // (The old code checked `approval_pending`/`approval_resolved` and read a
+  // `resolution` key, none of which the server ever writes, so approvals fell
+  // through to the raw-JSON fallback below.)
+  if (et === 'approval_requested') {
     return {
       ...base,
       kind: 'approval',
       prompt: readString(data, 'message'),
-      resolution: resolution
-        ? resolvedAs === 'rejected'
+      resolution: null,
+    };
+  }
+
+  if (et === 'approval_received') {
+    const decision = readString(data, 'decision'); // 'approved' | 'rejected'
+    return {
+      ...base,
+      kind: 'approval',
+      prompt: '',
+      resolution:
+        decision === 'rejected'
           ? {
               kind: 'rejected',
               at: raw.created_at,
@@ -200,8 +242,7 @@ export function toRunEvent(raw: RawWorkflowEvent): RunEvent {
               kind: 'approved',
               at: raw.created_at,
               comment: readStringOrNull(data, 'comment'),
-            }
-        : null,
+            },
     };
   }
 


### PR DESCRIPTION
## Summary

- **Problem:** Two issues that block making `/console` the default UI (replacing old `/chat` + dashboard): (1) `/console/*` was reachable **without login** when web auth is enabled, and (2) the run-event normalizer read keys the server never writes, so node durations were always null, approvals never rendered, and resume-skipped nodes vanished.
- **Why it matters:** You can't retire the old UI while the replacement bypasses auth or silently mis-renders run events.
- **What changed:** Wrapped `/console/*` in `SessionGate`; fixed the `event.ts` normalizer (`duration`→`duration_ms`, `approval_requested`/`approval_received` with `decision`/`comment`/`reason`, added `node_skipped_prior_success`, carry node-completion enrichment); added the first console test + wired `src/experiments/console/` into the web test script.
- **What did NOT change (scope boundary):** No new renderers (the per-node accordion and in-stream approval rendering are a follow-up PR); tool-event normalization untouched (already correct); old UI untouched.

## UX Journey

### Before
```
web auth ON:  user → /console  → console loads (NO login required)   ✗ auth bypass
run detail:   node_completed → duration shows "—" (always null)      ✗
              resume → already-done nodes simply missing             ✗
              approval gate → raw "approval_received — {…}" fallback  ✗
```

### After
```
web auth ON:  user → /console  → SessionGate → /login if no session  ✓
web auth OFF: user → /console  → passthrough (unchanged)             ✓
run detail:   node_completed → real duration (read from duration_ms) ✓
              resume → skipped-prior-success nodes render as skipped ✓
              approvals classified correctly (requested/received)    ✓
```

## Architecture Diagram

### Before / After
```
App.tsx Routes
  /console/* ──▶ ConsoleApp                 (before: ungated)
  /console/* ──▶ [~SessionGate] ──▶ ConsoleApp   (after: gated, still no Layout/TopNav)

experiments/console/primitives/event.ts  (toRunEvent normalizer)
  reads workflow_events.data ── corrected keys ──▶ RunEvent ──▶ RunStream/NodeDivider
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `App.tsx` `/console/*` | `SessionGate` | **new** | console now inside the auth gate |
| `SessionGate` | `ConsoleApp` | **new** | passthrough when web auth disabled |
| `event.ts` `toRunEvent` | `workflow_events.data` | **modified** | reads the keys the server actually writes |
| `web/package.json` `test` | `src/experiments/console/` | **new** | CI now runs console tests |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `web`
- Module: `web:console`

## Change Metadata

- Change type: `bug` (security + correctness)
- Primary scope: `web`

## Linked Issue

- Related #1819 (console promotion)

## Validation Evidence (required)

```bash
bun --filter @archon/web type-check   # exit 0
bun run lint                          # exit 0 (--max-warnings 0)
bun run format:check                  # all files clean
bun --filter @archon/web test         # 180 pass / 0 fail (incl. 14 new console normalizer tests)
bun run check:bundled{,-skill,-schema} # all OK (unaffected)
```

- Evidence: commands above all pass. The new `event.test.ts` (14 cases) asserts each corrected mapping against payload shapes taken from **real `workflow_events` rows** in a live DB (`duration_ms`, `node_output`/`cost_usd`/`stop_reason`/`num_turns`, `approval_received` `decision`/`comment`/`reason`, `node_skipped_prior_success` `reason:'prior_success'`).
- Skipped: full all-packages `bun run test` — change is isolated to `@archon/web`; ran that package's full suite instead. CI runs the rest.

## Security Impact (required)

- New permissions/capabilities? **No** — this *removes* an unintended capability (unauthenticated console access).
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- Risk/mitigation: closes an auth-bypass. `SessionGate` is the same component already gating every other route; it no-ops when web auth is disabled, so solo/default installs are unaffected.

## Compatibility / Migration

- Backward compatible? **Yes** — no-op when web auth is disabled (the default).
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: ran the 14-case normalizer test green; payload shapes cross-checked against real `workflow_events` rows (node_completed, node_skipped, node_skipped_prior_success, tool_called/completed) and against the emit sites for approval rows (`dag-executor.ts`, `workflow-operations.ts`). Confirmed `RunStream`/`NodeDivider` already consume `durationMs`/`skipReason`, so the duration + skip fixes are immediately visible.
- Edge cases checked: long node output truncates to 300 chars; `node_started` has null duration/enrichment; the never-written `approval_pending` type correctly does NOT render as an approval (regression guard).
- Not verified: in-stream rendering of approval events — `RunStream` doesn't yet render `kind:'approval'` entries (the normalizer now classifies them correctly; the renderer is a follow-up).

## Side Effects / Blast Radius (required)

- Affected subsystems: console route gating; console run-event normalization; web test script.
- Potential unintended effects: none expected — `SessionGate` passthrough preserves current behavior when auth is off; normalizer changes only correct mismatched keys (the only `NodeTransitionEvent` constructor is the normalizer itself).
- Guardrails: the new console test segment now runs in CI.

## Rollback Plan (required)

- Fast rollback: `git revert <merge-commit>` — 4 files, web-only.
- Feature flags/toggles: none.
- Observable failure symptoms: console redirects to `/login` unexpectedly (would indicate an auth-status misconfig, not this change) or node durations regress to null.

## Risks and Mitigations

- Risk: a consumer somewhere constructs `NodeTransitionEvent` literals and breaks on the new required fields.
  - Mitigation: verified the normalizer is the sole constructor; `RunStream` only reads the type. Type-check passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event details now include enhanced metadata: output previews, cost, stop reasons, and turn counts.

* **Bug Fixes**
  * Console route now enforces authentication consistently.
  * Approval event handling revised for more accurate request/response mapping.

* **Tests**
  * Expanded test coverage for console event transformation and enrichment logic.

* **Documentation**
  * Clarified experiments docs about route status and CI test scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->