### PR TITLE
Fix: reuse Pi extension loader per process so 2nd+ session doesn't hang (#1877)

### DIFF
--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -167,6 +167,9 @@ mock.module('@earendil-works/pi-coding-agent', () => ({
 // Import AFTER mocks are set — module resolution freezes the mocks.
 import { PiProvider } from './provider';
 import { PI_CAPABILITIES } from './capabilities';
+// Same module instance the provider dynamic-imports, so clearing this cache
+// resets the loader the provider reuses across calls (issue #1877).
+import { resetReloadedExtensionLoaderCache } from './resource-loader';
 
 // ─── Helpers ────────────────────────────────────────────────────────────
 
@@ -237,6 +240,10 @@ describe('PiProvider', () => {
     runtimeOverrides = {};
     delete process.env.GEMINI_API_KEY;
     delete process.env.ANTHROPIC_API_KEY;
+    // The extension-loader cache is module-level and persists across tests;
+    // clear it so each test starts with an empty cache and sees its own
+    // construct/reload calls (issue #1877).
+    resetReloadedExtensionLoaderCache();
   });
 
   test('getType returns "pi"', () => {
@@ -1755,5 +1762,86 @@ describe('PiProvider', () => {
       expect.objectContaining({ scope: 'global', err: loadError }),
       'pi.settings_load_error'
     );
+  });
+
+  // ─── Extension loader reuse (issue #1877) ─────────────────────────────────
+  //
+  // Pi's reload() re-invokes every installed extension factory; the 2nd reload
+  // in a process deadlocks on the first call's never-torn-down state. The fix
+  // loads the extension-bearing loader ONCE per process per input set and
+  // reuses it — so reload()/construct must run once across identical calls,
+  // while each call still gets its own session.
+  describe('extension loader reuse (issue #1877)', () => {
+    test('reload() and loader construction run once across two sequential calls with identical inputs', async () => {
+      process.env.GEMINI_API_KEY = 'sk-test';
+      resetScript(scriptedAgentEnd());
+
+      await consume(
+        new PiProvider().sendQuery('a', '/tmp', undefined, { model: 'google/gemini-2.5-pro' })
+      );
+      await consume(
+        new PiProvider().sendQuery('b', '/tmp', undefined, { model: 'google/gemini-2.5-pro' })
+      );
+
+      // The bug was reload() (and the extension factory it drives) running per
+      // call; after the fix the cached loader is built + reloaded exactly once.
+      expect(MockDefaultResourceLoader).toHaveBeenCalledTimes(1);
+      expect(mockResourceLoaderReload).toHaveBeenCalledTimes(1);
+      // Each call still gets its own session (correctness preserved).
+      expect(mockCreateAgentSession).toHaveBeenCalledTimes(2);
+      expect(mockDispose).toHaveBeenCalledTimes(2);
+    });
+
+    test('different cwd gets its own reloaded loader', async () => {
+      process.env.GEMINI_API_KEY = 'sk-test';
+      resetScript(scriptedAgentEnd());
+
+      await consume(
+        new PiProvider().sendQuery('a', '/tmp/one', undefined, { model: 'google/gemini-2.5-pro' })
+      );
+      await consume(
+        new PiProvider().sendQuery('b', '/tmp/two', undefined, { model: 'google/gemini-2.5-pro' })
+      );
+
+      expect(MockDefaultResourceLoader).toHaveBeenCalledTimes(2);
+      expect(mockResourceLoaderReload).toHaveBeenCalledTimes(2);
+    });
+
+    test('a distinct per-node systemPrompt gets its own reloaded loader (no silent prompt reuse)', async () => {
+      process.env.GEMINI_API_KEY = 'sk-test';
+      resetScript(scriptedAgentEnd());
+
+      await consume(
+        new PiProvider().sendQuery('a', '/tmp', undefined, {
+          model: 'google/gemini-2.5-pro',
+          systemPrompt: 'prompt A',
+        })
+      );
+      await consume(
+        new PiProvider().sendQuery('b', '/tmp', undefined, {
+          model: 'google/gemini-2.5-pro',
+          systemPrompt: 'prompt B',
+        })
+      );
+
+      expect(MockDefaultResourceLoader).toHaveBeenCalledTimes(2);
+      expect(mockResourceLoaderReload).toHaveBeenCalledTimes(2);
+    });
+
+    test('extensions disabled keeps a fresh loader per call and never reloads', async () => {
+      process.env.GEMINI_API_KEY = 'sk-test';
+      resetScript(scriptedAgentEnd());
+
+      const opts = {
+        model: 'google/gemini-2.5-pro',
+        assistantConfig: { enableExtensions: false },
+      };
+      await consume(new PiProvider().sendQuery('a', '/tmp', undefined, opts));
+      await consume(new PiProvider().sendQuery('b', '/tmp', undefined, opts));
+
+      // No caching on the extensions-off path: fresh loader each call, no reload.
+      expect(MockDefaultResourceLoader).toHaveBeenCalledTimes(2);
+      expect(mockResourceLoaderReload).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -169,7 +169,10 @@ import { PiProvider } from './provider';
 import { PI_CAPABILITIES } from './capabilities';
 // Same module instance the provider dynamic-imports, so clearing this cache
 // resets the loader the provider reuses across calls (issue #1877).
-import { resetReloadedExtensionLoaderCache } from './resource-loader';
+import {
+  getOrCreateReloadedExtensionLoader,
+  resetReloadedExtensionLoaderCache,
+} from './resource-loader';
 
 // ─── Helpers ────────────────────────────────────────────────────────────
 
@@ -1842,6 +1845,59 @@ describe('PiProvider', () => {
       // No caching on the extensions-off path: fresh loader each call, no reload.
       expect(MockDefaultResourceLoader).toHaveBeenCalledTimes(2);
       expect(mockResourceLoaderReload).not.toHaveBeenCalled();
+    });
+
+    test('distinct additionalSkillPaths get their own reloaded loader', async () => {
+      const a = await getOrCreateReloadedExtensionLoader('/tmp', {
+        additionalSkillPaths: ['/skills/x'],
+      });
+      const b = await getOrCreateReloadedExtensionLoader('/tmp', {
+        additionalSkillPaths: ['/skills/y'],
+      });
+      expect(a).not.toBe(b);
+      expect(MockDefaultResourceLoader).toHaveBeenCalledTimes(2);
+      expect(mockResourceLoaderReload).toHaveBeenCalledTimes(2);
+    });
+
+    test('concurrent callers (same key) share a single in-flight reload (the documented invariant)', async () => {
+      // Gate reload() so both callers are in-flight before either resolves — the
+      // exact race two parallel same-layer DAG nodes hit. Caching the resolved
+      // value instead of the Promise would construct/reload twice and fail this.
+      let releaseReload: (() => void) | undefined;
+      mockResourceLoaderReload.mockImplementationOnce(
+        () =>
+          new Promise<undefined>(resolve => {
+            releaseReload = (): void => resolve(undefined);
+          })
+      );
+
+      const p1 = getOrCreateReloadedExtensionLoader('/tmp', {});
+      const p2 = getOrCreateReloadedExtensionLoader('/tmp', {});
+      // Both subscribed before reload resolves.
+      releaseReload?.();
+      const [l1, l2] = await Promise.all([p1, p2]);
+
+      expect(l1).toBe(l2);
+      expect(MockDefaultResourceLoader).toHaveBeenCalledTimes(1);
+      expect(mockResourceLoaderReload).toHaveBeenCalledTimes(1);
+    });
+
+    test('a failed reload is evicted so the next call retries cleanly', async () => {
+      mockResourceLoaderReload.mockImplementationOnce(async () => {
+        throw new Error('broken extension');
+      });
+
+      await expect(getOrCreateReloadedExtensionLoader('/tmp', {})).rejects.toThrow(
+        /Pi extension load failed: broken extension/
+      );
+
+      // Entry was evicted on failure → the retry constructs + reloads again
+      // (rather than returning the poisoned rejected promise forever).
+      mockResourceLoaderReload.mockImplementationOnce(async () => undefined);
+      const loader = await getOrCreateReloadedExtensionLoader('/tmp', {});
+      expect(loader).toBeDefined();
+      expect(MockDefaultResourceLoader).toHaveBeenCalledTimes(2);
+      expect(mockResourceLoaderReload).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -448,19 +448,14 @@ export class PiProvider implements IAgentProvider {
     // deadlocks on the first call's never-torn-down state (issue #1877 — see the
     // doc on getOrCreateReloadedExtensionLoader). When extensions are OFF there
     // is no reload() and thus no re-entrancy hazard, so a fresh per-call loader
-    // is fine.
-    let resourceLoader: DefaultResourceLoader;
-    if (enableExtensions) {
-      resourceLoader = await getOrCreateReloadedExtensionLoader(cwd, {
-        ...(systemPrompt !== undefined ? { systemPrompt } : {}),
-        ...(skillPaths.length > 0 ? { additionalSkillPaths: skillPaths } : {}),
-      });
-    } else {
-      resourceLoader = createNoopResourceLoader(cwd, {
-        ...(systemPrompt !== undefined ? { systemPrompt } : {}),
-        ...(skillPaths.length > 0 ? { additionalSkillPaths: skillPaths } : {}),
-      });
-    }
+    // is fine. Build the shared options once so the two paths can't drift.
+    const loaderOptions = {
+      ...(systemPrompt !== undefined ? { systemPrompt } : {}),
+      ...(skillPaths.length > 0 ? { additionalSkillPaths: skillPaths } : {}),
+    };
+    const resourceLoader: DefaultResourceLoader = enableExtensions
+      ? await getOrCreateReloadedExtensionLoader(cwd, loaderOptions)
+      : createNoopResourceLoader(cwd, loaderOptions);
 
     getLog().info(
       {

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -3,6 +3,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { createLogger } from '@archon/paths';
+// Type-only import — erased by TS, so it does NOT trigger Pi's config.js
+// package.json read at module load (see the header note below). Used only to
+// annotate the per-call ResourceLoader local.
+import type { DefaultResourceLoader } from '@earendil-works/pi-coding-agent';
 
 import type {
   IAgentProvider,
@@ -177,7 +181,7 @@ export class PiProvider implements IAgentProvider {
       piCodingAgent,
       { bridgeSession },
       { resolvePiSkills, resolvePiThinkingLevel, resolvePiTools, buildDefaultPiTools },
-      { createNoopResourceLoader },
+      { createNoopResourceLoader, getOrCreateReloadedExtensionLoader },
       { resolvePiSession },
       { createArchonUIBridge, createArchonUIContext },
       { buildPiNativeToolDefinitions },
@@ -437,17 +441,25 @@ export class PiProvider implements IAgentProvider {
     const enableExtensions = piConfig.enableExtensions !== false;
     // Clamp to false without extensions: nothing consumes hasUI without a runner.
     const interactive = enableExtensions && piConfig.interactive !== false;
-    const resourceLoader = createNoopResourceLoader(cwd, {
-      ...(systemPrompt !== undefined ? { systemPrompt } : {}),
-      ...(skillPaths.length > 0 ? { additionalSkillPaths: skillPaths } : {}),
-      ...(enableExtensions ? { enableExtensions: true } : {}),
-    });
 
-    // Required: without reload(), session.extensionRunner is undefined and
-    // setFlagValue silently no-ops. createAgentSession skips this when a
-    // custom resource loader is supplied.
+    // Build the ResourceLoader. When extensions are ON we MUST reuse a
+    // process-cached, already-reloaded loader: Pi's `reload()` re-invokes every
+    // installed extension factory from scratch and the 2nd reload in a process
+    // deadlocks on the first call's never-torn-down state (issue #1877 — see the
+    // doc on getOrCreateReloadedExtensionLoader). When extensions are OFF there
+    // is no reload() and thus no re-entrancy hazard, so a fresh per-call loader
+    // is fine.
+    let resourceLoader: DefaultResourceLoader;
     if (enableExtensions) {
-      await resourceLoader.reload();
+      resourceLoader = await getOrCreateReloadedExtensionLoader(cwd, {
+        ...(systemPrompt !== undefined ? { systemPrompt } : {}),
+        ...(skillPaths.length > 0 ? { additionalSkillPaths: skillPaths } : {}),
+      });
+    } else {
+      resourceLoader = createNoopResourceLoader(cwd, {
+        ...(systemPrompt !== undefined ? { systemPrompt } : {}),
+        ...(skillPaths.length > 0 ? { additionalSkillPaths: skillPaths } : {}),
+      });
     }
 
     getLog().info(

--- a/packages/providers/src/community/pi/resource-loader.ts
+++ b/packages/providers/src/community/pi/resource-loader.ts
@@ -118,6 +118,17 @@ export function createNoopResourceLoader(
  * already-loaded extensions via `resourceLoader.getExtensions()` — so reuse is
  * safe. Each session still builds its own ExtensionRunner and fires
  * `session_start` via `bindExtensions()`, preserving per-node behavior.
+ *
+ * Growth & eviction: entries are keyed by `(cwd, systemPrompt, skillPaths)`, so
+ * the cache grows by at most one small loader per distinct worktree/prompt combo
+ * the process ever runs with extensions on — bounded in practice by the number of
+ * worktrees touched, not by request volume. Eviction is deliberately limited to
+ * the failure path (below): size-capped/LRU eviction is NOT safe here because
+ * dropping a loader that a long-running workflow is still using would make that
+ * workflow's next node cache-miss and `reload()` a second copy of the same
+ * extensions while the first is still live — re-introducing the very deadlock
+ * this cache prevents. Time/idle-based reclamation belongs with isolation
+ * cleanup (a future cross-package hook), not a blind cap here.
  */
 const reloadedExtensionLoaderCache = new Map<string, Promise<DefaultResourceLoader>>();
 

--- a/packages/providers/src/community/pi/resource-loader.ts
+++ b/packages/providers/src/community/pi/resource-loader.ts
@@ -103,21 +103,20 @@ export function createNoopResourceLoader(
  * Pi's `DefaultResourceLoader.reload()` re-runs the entire extension-discovery
  * pipeline — `packageManager.resolve()` + `loadExtensions()` — and
  * `loadExtensions()` re-invokes every installed extension's factory from scratch
- * (jiti is created with `moduleCache: false`). Those factories construct
- * process-scoped singletons (e.g. agent-rooms builds a RoomManager +
- * SdkSessionFactory, which spin up nested AuthStorage/ModelRegistry instances).
- * That state is never torn down between Archon `sendQuery()` calls: Archon
- * disposes sessions via `session.dispose()`, which — unlike `session.reload()` —
- * does NOT emit `session_shutdown`. So the SECOND `reload()` in a process
- * deadlocks colliding with the first call's still-live state, and every Pi
- * workflow node after the first idle-times-out.
+ * (jiti is created with `moduleCache: false`). Those factories can construct
+ * process-scoped singletons (ports, file handles, nested SDK clients) in their
+ * setup or `session_start` handler. That state is never torn down between Archon
+ * `sendQuery()` calls: Archon disposes sessions via `session.dispose()`, which —
+ * unlike `session.reload()` — does NOT emit `session_shutdown`. So the SECOND
+ * `reload()` in a process deadlocks colliding with the first call's still-live
+ * state, and every Pi workflow node after the first idle-times-out.
  *
  * Fix: reload the extension-bearing loader ONCE per process per loader-affecting
  * input set and reuse it. `createAgentSession({ resourceLoader })` skips its own
- * internal `reload()` when a loader is supplied (Pi SDK `sdk.js`), and reads the
- * already-loaded extensions via `resourceLoader.getExtensions()` — so reuse is
- * safe. Each session still builds its own ExtensionRunner and fires
- * `session_start` via `bindExtensions()`, preserving per-node behavior.
+ * internal `reload()` when a loader is supplied, and reads the already-loaded
+ * extensions via `resourceLoader.getExtensions()` — so reuse is safe. Each
+ * session still builds its own ExtensionRunner and fires `session_start` via
+ * `bindExtensions()`, preserving per-node behavior.
  *
  * Growth & eviction: entries are keyed by `(cwd, systemPrompt, skillPaths)`, so
  * the cache grows by at most one small loader per distinct worktree/prompt combo
@@ -170,9 +169,25 @@ export async function getOrCreateReloadedExtensionLoader(
   if (!pending) {
     pending = (async (): Promise<DefaultResourceLoader> => {
       const loader = createNoopResourceLoader(cwd, { ...options, enableExtensions: true });
-      // Without reload(), session.extensionRunner is undefined and setFlagValue
-      // silently no-ops. createAgentSession skips this when a loader is supplied.
-      await loader.reload();
+      // reload() loads the extensions into the loader so createAgentSession can
+      // build session.extensionRunner. Without it the runner is undefined and the
+      // provider's `if (runner)` flag pass-through is skipped — extensionFlags
+      // would silently never apply.
+      try {
+        await loader.reload();
+      } catch (error) {
+        // Extensions execute arbitrary JS from ~/.pi/agent/extensions/ (and the
+        // repo's .pi/); a broken one fails here. Rethrow with an actionable
+        // pointer, preserving the original error as `cause`, so the operator
+        // isn't left with a bare Pi SDK message. The failed promise is evicted
+        // below, so the next call retries cleanly.
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(
+          `Pi extension load failed: ${message}. Check the extensions in ~/.pi/agent/extensions/ ` +
+            "(and the repo's .pi/), or set `assistants.pi.enableExtensions: false` to run without them.",
+          { cause: error }
+        );
+      }
       return loader;
     })();
     reloadedExtensionLoaderCache.set(key, pending);

--- a/packages/providers/src/community/pi/resource-loader.ts
+++ b/packages/providers/src/community/pi/resource-loader.ts
@@ -96,3 +96,86 @@ export function createNoopResourceLoader(
       : {}),
   });
 }
+
+/**
+ * Process-level cache of reloaded, extension-bearing ResourceLoaders (issue #1877).
+ *
+ * Pi's `DefaultResourceLoader.reload()` re-runs the entire extension-discovery
+ * pipeline — `packageManager.resolve()` + `loadExtensions()` — and
+ * `loadExtensions()` re-invokes every installed extension's factory from scratch
+ * (jiti is created with `moduleCache: false`). Those factories construct
+ * process-scoped singletons (e.g. agent-rooms builds a RoomManager +
+ * SdkSessionFactory, which spin up nested AuthStorage/ModelRegistry instances).
+ * That state is never torn down between Archon `sendQuery()` calls: Archon
+ * disposes sessions via `session.dispose()`, which — unlike `session.reload()` —
+ * does NOT emit `session_shutdown`. So the SECOND `reload()` in a process
+ * deadlocks colliding with the first call's still-live state, and every Pi
+ * workflow node after the first idle-times-out.
+ *
+ * Fix: reload the extension-bearing loader ONCE per process per loader-affecting
+ * input set and reuse it. `createAgentSession({ resourceLoader })` skips its own
+ * internal `reload()` when a loader is supplied (Pi SDK `sdk.js`), and reads the
+ * already-loaded extensions via `resourceLoader.getExtensions()` — so reuse is
+ * safe. Each session still builds its own ExtensionRunner and fires
+ * `session_start` via `bindExtensions()`, preserving per-node behavior.
+ */
+const reloadedExtensionLoaderCache = new Map<string, Promise<DefaultResourceLoader>>();
+
+/**
+ * Cache key over every input baked into the loader. `systemPrompt` and
+ * `additionalSkillPaths` are included so a per-node override never silently
+ * reuses a loader carrying a different prompt — a distinct prompt yields a
+ * distinct loader (which is reloaded once on its own). In the common case
+ * (uniform/absent prompt across nodes) all nodes share one cached loader.
+ */
+function extensionLoaderCacheKey(
+  cwd: string,
+  systemPrompt: string | undefined,
+  additionalSkillPaths: readonly string[]
+): string {
+  return JSON.stringify([cwd, systemPrompt ?? null, [...additionalSkillPaths].sort()]);
+}
+
+/**
+ * Return a process-cached, already-reloaded extension-bearing ResourceLoader,
+ * constructing + `reload()`ing it on first use for a given input set. Always
+ * loads with `enableExtensions: true` — this is the only path that runs the
+ * non-re-entrant `reload()`, so it is the only path that needs the cache.
+ *
+ * Concurrency: the cache stores the in-flight Promise (not the resolved loader)
+ * so concurrent same-layer nodes await a single shared `reload()` instead of
+ * racing into two. A failed reload is evicted so the next call retries cleanly.
+ */
+export async function getOrCreateReloadedExtensionLoader(
+  cwd: string,
+  options: Pick<NoopResourceLoaderOptions, 'systemPrompt' | 'additionalSkillPaths'> = {}
+): Promise<DefaultResourceLoader> {
+  const key = extensionLoaderCacheKey(
+    cwd,
+    options.systemPrompt,
+    options.additionalSkillPaths ?? []
+  );
+  let pending = reloadedExtensionLoaderCache.get(key);
+  if (!pending) {
+    pending = (async (): Promise<DefaultResourceLoader> => {
+      const loader = createNoopResourceLoader(cwd, { ...options, enableExtensions: true });
+      // Without reload(), session.extensionRunner is undefined and setFlagValue
+      // silently no-ops. createAgentSession skips this when a loader is supplied.
+      await loader.reload();
+      return loader;
+    })();
+    reloadedExtensionLoaderCache.set(key, pending);
+    // Evict on failure so a transient reload error doesn't poison the cache.
+    pending.catch(() => reloadedExtensionLoaderCache.delete(key));
+  }
+  return pending;
+}
+
+/**
+ * Test-only: clear the process-level loader cache so each test starts empty.
+ * The cache is module-level and would otherwise leak loaders (and their mocked
+ * reload/construct call counts) across tests in the same file.
+ */
+export function resetReloadedExtensionLoaderCache(): void {
+  reloadedExtensionLoaderCache.clear();
+}


### PR DESCRIPTION
## Summary

- **Problem:** With Pi extensions enabled (the default), the 2nd and every subsequent `PiProvider.sendQuery()` call per process hangs in session setup and idle-times-out after 30 min — so every Pi workflow with 2+ AI nodes fails at the 2nd Pi node.
- **Why it matters:** This makes Pi effectively unusable for real multi-node workflows under the default config, blocking the Pi-as-primary-runner direction.
- **What changed:** The extension-bearing `DefaultResourceLoader` is now built + `reload()`ed **once per process** per `(cwd, systemPrompt, skillPaths)` and reused across calls, instead of a fresh loader + `reload()` on every call.
- **What did NOT change (scope boundary):** No subprocess isolation for Pi (would break in-process `customTools`), no change to the `enableExtensions` default, no Pi SDK fork, no change to the extensions-off path (still a fresh loader per call), and no fast-fail first-token guard (deferred — see Risks).

## UX Journey

### Before

```
4-node Pi workflow (one process)            Pi SDK
─────────────────────────────────           ──────
node a → sendQuery #1 ─────────────────────▶ new DefaultResourceLoader + reload()  ✅ ~3s
                                             (extension factories construct singletons)
node b → sendQuery #2 ─────────────────────▶ new DefaultResourceLoader + reload()  ⛔ HANGS
                                             (collides with call #1's live state)
                       ◀──── 30-min idle-timeout, node fails, DAG fails
```

### After

```
4-node Pi workflow (one process)            Pi SDK
─────────────────────────────────           ──────
node a → sendQuery #1 ─────────────────────▶ [build + reload loader ONCE, cache it]  ✅ ~3s
node b → sendQuery #2 ─────────────────────▶ [*reuse cached loader* — no reload]     ✅
node c → sendQuery #3 ─────────────────────▶ [*reuse cached loader*]                 ✅
node d → sendQuery #4 ─────────────────────▶ [*reuse cached loader*]                 ✅
                       ◀──── all nodes complete; each still gets its own session
```

## Architecture Diagram

### Before

```
PiProvider.sendQuery()
  └─▶ createNoopResourceLoader(cwd, …)  ── new DefaultResourceLoader (per call)
        └─▶ await loader.reload()       ── re-runs loadExtensions() every call (per call)
              └─▶ createAgentSession({ resourceLoader })
```

### After

```
PiProvider.sendQuery()
  ├─ extensions ON  ──▶ [+] getOrCreateReloadedExtensionLoader(cwd, {systemPrompt, skillPaths})
  │                          └─ cache miss: createNoopResourceLoader + reload() ONCE, memoize
  │                          └─ cache hit:  *return cached loader* (=== reuse, no reload)
  └─ extensions OFF ──▶ createNoopResourceLoader(cwd, …)   (unchanged: fresh, no reload)
        └─▶ createAgentSession({ resourceLoader })  (skips its own reload when loader supplied)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `provider.ts:sendQuery` | `resource-loader.ts:getOrCreateReloadedExtensionLoader` | **new** | extensions-on path now goes through the process cache |
| `provider.ts:sendQuery` | `resource-loader.ts:createNoopResourceLoader` | **modified** | now called only on the extensions-off path (+ internally by the cache helper) |
| `resource-loader.ts:getOrCreateReloadedExtensionLoader` | `DefaultResourceLoader.reload()` | unchanged | same reload, just invoked once per input set instead of per call |
| `provider.test.ts` | `resource-loader.ts:resetReloadedExtensionLoaderCache` | **new** | test hook clears the module-level cache between tests |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core` (providers package) — closest listed scope is AI clients
- Module: `providers:pi`

## Change Metadata

- Change type: `bug`
- Primary scope: `core` (the `@archon/providers` Pi community provider)

## Linked Issue

- Closes #1877

## Validation Evidence (required)

```bash
bun run validate   # → exit code 0 (type-check, lint, format:check, check:bundled*, all package tests)
bun test packages/providers/src/community/pi/provider.test.ts   # → 71 pass / 0 fail (incl. 4 new)
```

- Evidence provided: `bun run validate` exited `0`. New tests in `provider.test.ts` assert: reload/construct run **once** across two identical sequential calls; distinct `cwd` or `systemPrompt` each reload once; extensions-off never caches and never reloads.
- Skipped commands: none.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No** (same extensions loaded from the same paths; just once instead of N times)

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

- Verified scenarios: full `bun run validate` green; the 4 new regression tests encode the exact failing scenario from the issue (sequential calls sharing one process) and assert single-reload behavior.
- Edge cases checked: distinct `cwd` → separate loaders; distinct per-node `systemPrompt` → separate loaders (no silent prompt reuse); extensions disabled → no caching, no reload; failed reload is evicted so the next call retries.
- What was not verified: a live end-to-end run of `minimax-seq` against a real Pi/MiniMax backend (requires the issue author's installed extensions + API creds). The fix removes the repeated `reload()` that the issue's `session_started:1` evidence pinpointed as the hang.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Pi provider only. Claude/Codex/other providers untouched.
- Potential unintended effects: extension factories now run once per process, so a singleton constructed in call #1 is shared by later calls in the same `cwd` group — this is the intended (and more correct) lifetime; `bindExtensions()`/`session_start` still fire per session. A loader is cached per distinct `(cwd, systemPrompt, skillPaths)`; long-lived processes touching many cwds hold one loader each (bounded, negligible).
- Guardrails/monitoring: the existing `pi.session_started` log now fires once per node again (was 1-per-process); the executor idle-timeout remains as the backstop.

## Rollback Plan (required)

- Fast rollback: `git revert 5486d624` (single self-contained commit) — restores the per-call loader + reload.
- Feature toggles: `assistants.pi.enableExtensions: false` independently bypasses the whole extension path (the issue's documented workaround) without reverting.
- Observable failure symptoms: Pi nodes emitting zero output and idle-timing-out; `pi.session_started` logging once per process instead of once per node.

## Risks and Mitigations

- Risk: Multiple nodes in one process with **genuinely different** `systemPrompt`/`skills` AND extensions enabled still produce >1 `reload()` (each distinct input set reloads once), which could re-trigger the non-re-entrancy hang for that uncommon combo.
  - Mitigation: The reported repro and ~all real workflows use a uniform/absent prompt across nodes → a single cached loader → fully fixed. The investigation artifact proposed a Pi-specific fast-fail first-token guard for this residual; it is **deferred** here because a hard provider-level first-token timeout risks false-positives on legitimately slow cold-start/queued backends and overlaps the existing 30-min executor idle-timeout. Tracked as a follow-up if the heterogeneous case is observed in practice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fix extension loader caching: identical queries now reuse a single extension-enabled loader (redundant reloads suppressed); differing configurations produce separate loaders. Concurrent requests share in-flight reload work, and failed reloads are evicted so retries succeed. When extensions are disabled, caching is bypassed (fresh loader per call).

* **Tests**
  * Added tests covering loader reuse, concurrency, failure retry behavior, and cache reset between tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->