### PR TITLE
feat(web/console): show run provenance — input message + platform icons

### DIFF
--- a/packages/web/src/experiments/console/components/ActiveRunCard.tsx
+++ b/packages/web/src/experiments/console/components/ActiveRunCard.tsx
@@ -10,6 +10,9 @@ import { shortRunId, formatElapsed, elapsedSince, formatCost } from '../lib/form
 import { useIsDocker, openInIde } from '../lib/health';
 import { statusTextClass, statusLabel } from '../lib/run-status';
 
+/** Present + non-empty — narrows `string | null | undefined` to `string`. */
+const hasValue = (v: string | null | undefined): v is string => v != null && v !== '';
+
 interface ActiveRunCardProps {
   run: Run;
   showProject?: boolean;
@@ -49,6 +52,7 @@ export function ActiveRunCard({
   const canOpen = run.projectId !== null && !run.id.startsWith('demo-');
   const canOpenIde =
     !isDocker && run.workingPath !== null && run.workingPath !== '' && !run.id.startsWith('demo-');
+  const showDetailGrid = run.userMessage !== '' || run.status === 'running';
 
   const onCardClick = (): void => {
     if (canOpen) navigate(`/console/p/${run.projectId}/r/${run.id}`);
@@ -127,9 +131,9 @@ export function ActiveRunCard({
           </div>
         </div>
 
-        {/* Provenance + activity detail: the triggering input (always, truncated —
+        {/* Provenance + activity detail: the triggering input (when present, truncated —
             full text on hover), plus live node/tool rows while running. */}
-        {run.userMessage !== '' || run.status === 'running' ? (
+        {showDetailGrid ? (
           <div className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-[12px]">
             {run.userMessage !== '' ? (
               <>
@@ -139,19 +143,13 @@ export function ActiveRunCard({
                 </span>
               </>
             ) : null}
-            {run.status === 'running' &&
-            run.currentNode !== null &&
-            run.currentNode !== undefined &&
-            run.currentNode !== '' ? (
+            {run.status === 'running' && hasValue(run.currentNode) ? (
               <>
                 <span className="font-mono text-text-tertiary">node</span>
                 <span className="font-mono text-text-primary">{run.currentNode}</span>
               </>
             ) : null}
-            {run.status === 'running' &&
-            run.lastTool !== null &&
-            run.lastTool !== undefined &&
-            run.lastTool !== '' ? (
+            {run.status === 'running' && hasValue(run.lastTool) ? (
               <>
                 <span className="font-mono text-text-tertiary">tool</span>
                 <span className="font-mono text-text-primary">

--- a/packages/web/src/experiments/console/components/ActiveRunCard.tsx
+++ b/packages/web/src/experiments/console/components/ActiveRunCard.tsx
@@ -127,16 +127,31 @@ export function ActiveRunCard({
           </div>
         </div>
 
-        {/* Activity detail — running only */}
-        {run.status === 'running' ? (
+        {/* Provenance + activity detail: the triggering input (always, truncated —
+            full text on hover), plus live node/tool rows while running. */}
+        {run.userMessage !== '' || run.status === 'running' ? (
           <div className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-[12px]">
-            {run.currentNode !== null && run.currentNode !== undefined && run.currentNode !== '' ? (
+            {run.userMessage !== '' ? (
+              <>
+                <span className="font-mono text-text-tertiary">input</span>
+                <span className="truncate font-mono text-text-secondary" title={run.userMessage}>
+                  {run.userMessage}
+                </span>
+              </>
+            ) : null}
+            {run.status === 'running' &&
+            run.currentNode !== null &&
+            run.currentNode !== undefined &&
+            run.currentNode !== '' ? (
               <>
                 <span className="font-mono text-text-tertiary">node</span>
                 <span className="font-mono text-text-primary">{run.currentNode}</span>
               </>
             ) : null}
-            {run.lastTool !== null && run.lastTool !== undefined && run.lastTool !== '' ? (
+            {run.status === 'running' &&
+            run.lastTool !== null &&
+            run.lastTool !== undefined &&
+            run.lastTool !== '' ? (
               <>
                 <span className="font-mono text-text-tertiary">tool</span>
                 <span className="font-mono text-text-primary">

--- a/packages/web/src/experiments/console/components/OriginBadge.tsx
+++ b/packages/web/src/experiments/console/components/OriginBadge.tsx
@@ -12,8 +12,10 @@ const ORIGIN_LABEL: Record<RunOrigin, string> = {
   unknown: '—',
 };
 
-// One icon per platform so the source is recognisable at a glance (mirrors the
-// old dashboard's WorkflowRunCard PLATFORM_ICONS). `unknown` has no icon.
+// One icon per platform so the source is recognisable at a glance. Extends the
+// old dashboard's WorkflowRunCard PLATFORM_ICONS (which had 5 entries and fell
+// back to a Globe): this covers all 7 RunOrigin values, adding `discord` and
+// rendering no icon for `unknown` rather than a misleading default.
 const ORIGIN_ICON: Record<RunOrigin, ReactElement | null> = {
   web: <Globe className="h-3 w-3" />,
   cli: <Terminal className="h-3 w-3" />,

--- a/packages/web/src/experiments/console/components/OriginBadge.tsx
+++ b/packages/web/src/experiments/console/components/OriginBadge.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react';
+import { Globe, Terminal, Hash, Send, MessageCircle, GitBranch } from 'lucide-react';
 import type { RunOrigin } from '../primitives/run';
 
 const ORIGIN_LABEL: Record<RunOrigin, string> = {
@@ -11,13 +12,27 @@ const ORIGIN_LABEL: Record<RunOrigin, string> = {
   unknown: '—',
 };
 
+// One icon per platform so the source is recognisable at a glance (mirrors the
+// old dashboard's WorkflowRunCard PLATFORM_ICONS). `unknown` has no icon.
+const ORIGIN_ICON: Record<RunOrigin, ReactElement | null> = {
+  web: <Globe className="h-3 w-3" />,
+  cli: <Terminal className="h-3 w-3" />,
+  slack: <Hash className="h-3 w-3" />,
+  telegram: <Send className="h-3 w-3" />,
+  discord: <MessageCircle className="h-3 w-3" />,
+  github: <GitBranch className="h-3 w-3" />,
+  unknown: null,
+};
+
 /** Compact monochrome pill. Never ALL-CAPS, never suffixed. */
 export function OriginBadge({ origin }: { origin: RunOrigin }): ReactElement {
+  const icon = ORIGIN_ICON[origin];
   return (
     <span
-      className="inline-flex items-center rounded border border-border px-1.5 py-0.5 font-mono text-[10px] text-text-secondary"
+      className="inline-flex items-center gap-1 rounded border border-border px-1.5 py-0.5 font-mono text-[10px] text-text-secondary"
       title={`Origin: ${ORIGIN_LABEL[origin]}`}
     >
+      {icon}
       {ORIGIN_LABEL[origin]}
     </span>
   );

--- a/packages/web/src/experiments/console/components/RecentRunRow.tsx
+++ b/packages/web/src/experiments/console/components/RecentRunRow.tsx
@@ -53,7 +53,7 @@ export function RecentRunRow({
       rerun: '1',
       workflow: run.workflow,
     });
-    if (run.userMessage.length > 0) params.set('message', run.userMessage);
+    if (run.userMessage !== '') params.set('message', run.userMessage);
     navigate(`/console/p/${run.projectId}?${params.toString()}`);
   };
 
@@ -75,7 +75,15 @@ export function RecentRunRow({
         {run.status}
       </span>
       <div className="flex min-w-0 flex-1 items-center gap-2">
-        <span className="max-w-[55%] shrink-0 truncate text-text-primary">{run.workflow}</span>
+        {/* With a message, cap the name at 55% so both share the line; without one,
+            let the name fill the full width (avoids blank space + needless truncation). */}
+        <span
+          className={`truncate text-text-primary ${
+            run.userMessage !== '' ? 'max-w-[55%] shrink-0' : 'min-w-0 flex-1'
+          }`}
+        >
+          {run.workflow}
+        </span>
         {run.userMessage !== '' ? (
           <span className="min-w-0 truncate text-text-tertiary" title={run.userMessage}>
             {run.userMessage}

--- a/packages/web/src/experiments/console/components/RecentRunRow.tsx
+++ b/packages/web/src/experiments/console/components/RecentRunRow.tsx
@@ -74,7 +74,14 @@ export function RecentRunRow({
       >
         {run.status}
       </span>
-      <span className="min-w-0 flex-1 truncate text-text-primary">{run.workflow}</span>
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <span className="max-w-[55%] shrink-0 truncate text-text-primary">{run.workflow}</span>
+        {run.userMessage !== '' ? (
+          <span className="min-w-0 truncate text-text-tertiary" title={run.userMessage}>
+            {run.userMessage}
+          </span>
+        ) : null}
+      </div>
       {showProject && run.projectName !== null ? (
         <span className="hidden w-40 shrink-0 truncate text-text-secondary md:inline">
           {run.projectName}

--- a/packages/web/src/experiments/console/components/RunDetailHeader.tsx
+++ b/packages/web/src/experiments/console/components/RunDetailHeader.tsx
@@ -140,9 +140,9 @@ export function RunDetailHeader({
       </div>
 
       {/* Provenance sub-row: the input that started this run. `w-full` forces its
-          own line in the flex-wrap header. (A link back to the originating
-          conversation is deferred until the console chat route supports
-          deep-linking to a specific conversation.) */}
+          own line in the flex-wrap header.
+          TODO(#1882): add a "from chat →" link back to the originating
+          conversation once the console chat route supports deep-linking. */}
       {run.userMessage !== '' ? (
         <div className="flex w-full min-w-0 items-baseline gap-2 text-[12px]">
           <span className="shrink-0 font-mono text-text-tertiary">input</span>

--- a/packages/web/src/experiments/console/components/RunDetailHeader.tsx
+++ b/packages/web/src/experiments/console/components/RunDetailHeader.tsx
@@ -138,6 +138,19 @@ export function RunDetailHeader({
           </button>
         ) : null}
       </div>
+
+      {/* Provenance sub-row: the input that started this run. `w-full` forces its
+          own line in the flex-wrap header. (A link back to the originating
+          conversation is deferred until the console chat route supports
+          deep-linking to a specific conversation.) */}
+      {run.userMessage !== '' ? (
+        <div className="flex w-full min-w-0 items-baseline gap-2 text-[12px]">
+          <span className="shrink-0 font-mono text-text-tertiary">input</span>
+          <span className="truncate font-mono text-text-secondary" title={run.userMessage}>
+            {run.userMessage}
+          </span>
+        </div>
+      ) : null}
     </header>
   );
 }

--- a/packages/web/src/experiments/console/components/RunLifecycle.tsx
+++ b/packages/web/src/experiments/console/components/RunLifecycle.tsx
@@ -10,14 +10,21 @@ import { formatElapsed, elapsedSince, formatCost, formatClock } from '../lib/for
  */
 export function RunStartedLine({ run }: { run: Run }): ReactElement {
   return (
-    <div className="flex items-center gap-2 py-1 text-[11px]">
-      <span aria-hidden className="text-[color:var(--running)]">
-        ▶
-      </span>
-      <span className="font-medium text-text-secondary">Workflow {run.workflow} started</span>
-      <span className="font-mono text-text-tertiary">{formatClock(run.startedAt)}</span>
-      <div className="h-px flex-1 bg-border/50" aria-hidden />
-    </div>
+    <>
+      <div className="flex items-center gap-2 py-1 text-[11px]">
+        <span aria-hidden className="text-[color:var(--running)]">
+          ▶
+        </span>
+        <span className="font-medium text-text-secondary">Workflow {run.workflow} started</span>
+        <span className="font-mono text-text-tertiary">{formatClock(run.startedAt)}</span>
+        <div className="h-px flex-1 bg-border/50" aria-hidden />
+      </div>
+      {run.userMessage !== '' ? (
+        <div className="ml-[7px] border-l-2 border-border/60 pl-3 text-[11px] text-text-tertiary">
+          {run.userMessage}
+        </div>
+      ) : null}
+    </>
   );
 }
 

--- a/packages/web/src/experiments/console/primitives/run.test.ts
+++ b/packages/web/src/experiments/console/primitives/run.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect } from 'bun:test';
+import { toRun, normalizeOrigin } from './run';
+
+type Raw = Parameters<typeof toRun>[0];
+
+function raw(over: Partial<Raw> & { id: string; workflow_name: string; status: string }): Raw {
+  return {
+    codebase_id: null,
+    started_at: '2026-06-05T10:00:00Z',
+    ...over,
+  };
+}
+
+describe('normalizeOrigin', () => {
+  test('maps each known platform_type to its RunOrigin', () => {
+    expect(normalizeOrigin('web')).toBe('web');
+    expect(normalizeOrigin('cli')).toBe('cli');
+    expect(normalizeOrigin('slack')).toBe('slack');
+    expect(normalizeOrigin('telegram')).toBe('telegram');
+    expect(normalizeOrigin('discord')).toBe('discord');
+    expect(normalizeOrigin('github')).toBe('github');
+  });
+
+  test('is case-insensitive', () => {
+    expect(normalizeOrigin('CLI')).toBe('cli');
+    expect(normalizeOrigin('GitHub')).toBe('github');
+  });
+
+  test('null, undefined, and unknown strings fall back to "unknown"', () => {
+    expect(normalizeOrigin(null)).toBe('unknown');
+    expect(normalizeOrigin(undefined)).toBe('unknown');
+    expect(normalizeOrigin('carrier-pigeon')).toBe('unknown');
+  });
+});
+
+describe('toRun — provenance', () => {
+  test('userMessage defaults to empty string when absent', () => {
+    const r = toRun(raw({ id: 'r1', workflow_name: 'plan', status: 'running' }));
+    expect(r.userMessage).toBe('');
+  });
+
+  test('userMessage passes through when present', () => {
+    const r = toRun(
+      raw({ id: 'r1', workflow_name: 'plan', status: 'running', user_message: 'summarise PRs' })
+    );
+    expect(r.userMessage).toBe('summarise PRs');
+  });
+
+  test('origin is derived from platform_type', () => {
+    const r = toRun(
+      raw({ id: 'r1', workflow_name: 'plan', status: 'running', platform_type: 'web' })
+    );
+    expect(r.origin).toBe('web');
+  });
+
+  test('detail-sourced row still populates conversationPlatformId (unchanged behavior)', () => {
+    const r = toRun(
+      raw({
+        id: 'r1',
+        workflow_name: 'plan',
+        status: 'completed',
+        conversation_platform_id: 'cli-detail-789',
+      })
+    );
+    expect(r.conversationPlatformId).toBe('cli-detail-789');
+  });
+
+  test("normalizes the transient 'pending' status to running", () => {
+    const r = toRun(raw({ id: 'r1', workflow_name: 'plan', status: 'pending' }));
+    expect(r.status).toBe('running');
+  });
+});

--- a/packages/web/src/experiments/console/primitives/run.test.ts
+++ b/packages/web/src/experiments/console/primitives/run.test.ts
@@ -69,4 +69,84 @@ describe('toRun — provenance', () => {
     const r = toRun(raw({ id: 'r1', workflow_name: 'plan', status: 'pending' }));
     expect(r.status).toBe('running');
   });
+
+  test('an unrecognised status falls back to running', () => {
+    const r = toRun(raw({ id: 'r1', workflow_name: 'plan', status: 'banana' }));
+    expect(r.status).toBe('running');
+  });
+});
+
+describe('toRun — cost', () => {
+  test('reads a positive total_cost_usd from metadata', () => {
+    const r = toRun(
+      raw({
+        id: 'r1',
+        workflow_name: 'plan',
+        status: 'completed',
+        metadata: { total_cost_usd: 1.5 },
+      })
+    );
+    expect(r.costUsd).toBe(1.5);
+  });
+
+  test('treats $0.00 (and non-positive) as null — the > 0 guard', () => {
+    const zero = toRun(
+      raw({ id: 'r1', workflow_name: 'plan', status: 'completed', metadata: { total_cost_usd: 0 } })
+    );
+    expect(zero.costUsd).toBeNull();
+  });
+
+  test('cost is null when metadata is absent or non-numeric', () => {
+    expect(toRun(raw({ id: 'r1', workflow_name: 'plan', status: 'completed' })).costUsd).toBeNull();
+    expect(
+      toRun(
+        raw({
+          id: 'r1',
+          workflow_name: 'plan',
+          status: 'completed',
+          metadata: { total_cost_usd: 'free' },
+        })
+      ).costUsd
+    ).toBeNull();
+  });
+});
+
+describe('toRun — approval parsing', () => {
+  test('parses a well-formed approval from metadata', () => {
+    const r = toRun(
+      raw({
+        id: 'r1',
+        workflow_name: 'review',
+        status: 'paused',
+        metadata: { approval: { nodeId: 'gate', message: 'Approve?' } },
+      })
+    );
+    expect(r.approval).toEqual({ nodeId: 'gate', message: 'Approve?' });
+  });
+
+  test('defaults message to empty string when only nodeId is present', () => {
+    const r = toRun(
+      raw({
+        id: 'r1',
+        workflow_name: 'review',
+        status: 'paused',
+        metadata: { approval: { nodeId: 'gate' } },
+      })
+    );
+    expect(r.approval).toEqual({ nodeId: 'gate', message: '' });
+  });
+
+  test('approval is null when absent or malformed (no string nodeId)', () => {
+    expect(toRun(raw({ id: 'r1', workflow_name: 'review', status: 'paused' })).approval).toBeNull();
+    expect(
+      toRun(
+        raw({
+          id: 'r1',
+          workflow_name: 'review',
+          status: 'paused',
+          metadata: { approval: { message: 'no node id' } },
+        })
+      ).approval
+    ).toBeNull();
+  });
 });

--- a/packages/web/src/experiments/console/primitives/run.ts
+++ b/packages/web/src/experiments/console/primitives/run.ts
@@ -69,7 +69,7 @@ function normalizeStatus(s: string): RunStatus {
   return (KNOWN_STATUSES as readonly string[]).includes(s) ? (s as RunStatus) : 'running';
 }
 
-function normalizeOrigin(s: string | null | undefined): RunOrigin {
+export function normalizeOrigin(s: string | null | undefined): RunOrigin {
   if (s === null || s === undefined) return 'unknown';
   const lower = s.toLowerCase();
   switch (lower) {


### PR DESCRIPTION
## Summary

- **Problem:** Console run cards/rows/detail showed status, workflow, cost, elapsed — but never *what input started a run*. The prompt was already parsed into the `Run` primitive (`toRun`) yet rendered nowhere; the origin badge was text-only. Two CLI runs of the same workflow looked identical.
- **Why it matters:** Directly addresses a stated console-vs-old-dashboard parity gap ("what did I enter into the dialog… cli/chat") — part of making `/console` the default UI.
- **What changed:** Render `user_message` on `ActiveRunCard`, `RecentRunRow`, `RunStartedLine`, `RunDetailHeader`; add per-platform Lucide icons to `OriginBadge`; add the first test for the `run.ts` primitive.
- **What did NOT change (scope boundary):** No server/DB/schema/`api.generated.d.ts` change. No new renderers beyond text rows. Old UI untouched. The "from chat →" link is **deferred** (see Deviation).

## UX Journey

### Before
```
RunDetailHeader:  project / a1b2c3d4   ● running   maintainer-standup  [CLI]   $1.07  11m  ⧉
RecentRunRow:     ▸ completed  maintainer-standup  proj  a1b2c3d4  11m  $1.07  [CLI]
(no prompt shown anywhere; origin is text-only)
```

### After
```
RunDetailHeader:  project / a1b2c3d4   ● running   maintainer-standup  [⌨ CLI]  $1.07  11m  ⧉
                  input  summarise this week's merged PRs and open issues          ◄── NEW sub-row
ActiveRunCard:    input  summarise this week's merged PRs…  (full text on hover)    ◄── NEW grid row
RecentRunRow:     ▸ completed  maintainer-standup  ⟨summarise this week's…⟩  …  [⌨ CLI]  (h-9 kept; title tooltip)
RunStartedLine:   ▶ Workflow maintainer-standup started  10:31
                  ▏ summarise this week's merged PRs and open issues                ◄── NEW blockquote
```

## Architecture Diagram

```
toRun() (run.ts) — already parses user_message + origin — now exported normalizeOrigin for tests
  → Run.userMessage / Run.origin
      → OriginBadge        (+ Lucide PLATFORM_ICONS)
      → ActiveRunCard      (+ `input` grid row)
      → RecentRunRow       (+ inline truncated message, h-9 preserved)
      → RunStartedLine     (+ blockquote line)
      → RunDetailHeader    (+ full-width `input` sub-row)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `OriginBadge` | `lucide-react` | **new** | one icon per platform (existing dep) |
| `Run.userMessage` | 4 components | **new** | rendering of an already-populated field |
| `primitives/run.ts` | `run.test.ts` | **new** | first primitive test; `normalizeOrigin` exported |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `web`
- Module: `web:console`

## Change Metadata

- Change type: `feature`
- Primary scope: `web`

## Linked Issue

- Related #1878 (PR #1 of the console-replaces-old-UI sequence; this is PR #2)

## Validation Evidence (required)

```bash
bun --filter @archon/web type-check   # exit 0
bun run lint                          # exit 0 (--max-warnings 0)
bun run format:check                  # clean
bun run validate                      # exit 0 — all 7 CI checks incl. full test suite
# console tests: 29 pass / 0 fail (21 event + 8 new run normalizer)
```

- Evidence: `bun run validate` is green end-to-end. `run.test.ts` covers `normalizeOrigin` (all 6 platforms + case-insensitive + null/undefined/unknown fallback), `userMessage` default/passthrough, origin derivation, `conversationPlatformId` passthrough, and `pending`→`running`.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: type-check/lint/format/validate green; 29 console tests pass. Folded the `input` row into ActiveRunCard's existing activity grid (no double grid); confirmed RecentRunRow stays `h-9` with the message sharing the workflow line + `title` tooltip; RunDetailHeader sub-row uses `w-full` to wrap onto its own line in the flex-wrap header.
- Edge cases: empty `userMessage` → no row/blockquote/tooltip anywhere; origin `unknown` → no icon, label `—`; long message → truncates with full text on hover.
- Not verified: live browser screenshot (presentational; `@archon/web` has no jsdom/testing-library, consistent with #1878's accepted constraint).

## Side Effects / Blast Radius (required)

- Affected subsystems: console run-display components + the run primitive (web only).
- Potential unintended effects: none expected — the only logic change is `toRun` exporting `normalizeOrigin`; everything else is additive rendering of an existing field.
- Guardrails: the console test segment runs in CI (added in #1878); `run.test.ts` now covers the normalizer.

## Rollback Plan (required)

- Fast rollback: `git revert <merge-commit>` — 7 files, web-only.
- Feature flags/toggles: none.
- Observable failure symptoms: none (presentational); worst case an `input` row renders for an empty message (guarded against).

## Risks and Mitigations

- Risk: RecentRunRow message crowds the row on narrow widths.
  - Mitigation: workflow name capped at `max-w-[55%]`, message `min-w-0 truncate`; row height fixed at `h-9`; full text via `title`.

---

### Deviation from the plan (documented)

The plan's "from chat →" link is **deferred, not built.** Investigation found the console has **no conversation-deep-link route** — `ChatPage` mounts at `p/:projectId/chat` and manages its active conversation internally, so the link has no valid destination. Per the plan's explicit "do not invent a route" constraint, the link **and** the `workerPlatformId`/`parentPlatformId` fields that only existed to feed it were dropped (they'd be unread data — the unused-field smell the #1878 review flagged). The link moves to a follow-up once the console chat route supports deep-linking to a specific conversation. This PR ships the unambiguous wins that fully address the stated need.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Origin badges now include icons for quicker identification.
  * Run cards, headers, recent rows, and lifecycle views show user input/provenance with truncation and full-text tooltips.

* **Bug Fixes**
  * Improved row/layout behavior so provenance displays consistently alongside other run details.

* **Tests**
  * Added tests for run origin normalization, provenance parsing, cost parsing, and approval parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->