### PR TITLE
feat(web/console): chat workflow-completion card + SSE-lock + jump-to-bottom

### DIFF
--- a/packages/web/src/experiments/console/components/ChatStream.tsx
+++ b/packages/web/src/experiments/console/components/ChatStream.tsx
@@ -1,6 +1,7 @@
 import { Fragment, type ReactElement } from 'react';
 import { MessageItem } from './MessageItem';
 import { ToolCallItem } from './ToolCallItem';
+import { ConsoleWorkflowResultCard } from './ConsoleWorkflowResultCard';
 import { isSystemCategory, type Message } from '../primitives/message';
 
 interface ChatStreamProps {
@@ -23,15 +24,30 @@ interface ChatStreamProps {
  * resolve — pass runStartedAt: null for wall-clock display.
  */
 export function ChatStream({ messages, showTools = false }: ChatStreamProps): ReactElement {
+  // `workflow_result` messages are normally swept up by `isSystemCategory` (the
+  // `workflow_` prefix), but they carry the run summary + a completion card — let
+  // them through explicitly. Other `workflow_*` narration stays suppressed.
   const visible = showTools
     ? messages
-    : messages.filter(m => !isSystemCategory(m.category) && m.content.trim().length > 0);
+    : messages.filter(
+        m =>
+          m.category === 'workflow_result' ||
+          (!isSystemCategory(m.category) && m.content.trim().length > 0)
+      );
 
   return (
     <div className="flex flex-col gap-1.5">
       {visible.map(message => (
         <Fragment key={message.id}>
-          <MessageItem message={message} />
+          {message.category === 'workflow_result' && message.workflowResult !== null ? (
+            <ConsoleWorkflowResultCard
+              runId={message.workflowResult.runId}
+              workflowName={message.workflowResult.workflowName}
+              summary={message.content}
+            />
+          ) : (
+            <MessageItem message={message} />
+          )}
           {showTools
             ? message.toolCalls.map((call, i) => (
                 <ToolCallItem

--- a/packages/web/src/experiments/console/components/ConsoleWorkflowResultCard.tsx
+++ b/packages/web/src/experiments/console/components/ConsoleWorkflowResultCard.tsx
@@ -1,0 +1,116 @@
+import type { ReactElement } from 'react';
+import { useNavigate } from 'react-router';
+import { useEntity } from '../store/cache';
+import { K } from '../store/keys';
+import * as skill from '../skills';
+import type { RunEvent } from '../primitives/event';
+import type { RunStatus } from '../lib/run-status';
+import { statusTextClass, statusLabel } from '../lib/run-status';
+import { formatElapsed, elapsedSince, formatCost } from '../lib/format';
+
+interface ConsoleWorkflowResultCardProps {
+  runId: string;
+  workflowName: string;
+  /** The orchestrator's summary prose (the message content). Rendered as the body. */
+  summary: string;
+}
+
+const RESULT_GLYPH: Partial<Record<RunStatus, string>> = {
+  completed: '✓',
+  failed: '✕',
+  cancelled: '◌',
+};
+
+const RESULT_LABEL: Partial<Record<RunStatus, string>> = {
+  completed: 'Workflow complete',
+  failed: 'Workflow failed',
+  cancelled: 'Workflow cancelled',
+};
+
+/** Count terminal node transitions (completed/failed/skipped); `started` is in-flight. */
+function countTerminalNodes(events: RunEvent[]): { completed: number; total: number } {
+  let completed = 0;
+  let total = 0;
+  for (const e of events) {
+    if (e.kind !== 'node_transition' || e.transition === 'started') continue;
+    total += 1;
+    if (e.transition === 'completed') completed += 1;
+  }
+  return { completed, total };
+}
+
+/**
+ * A formatted card for a `workflow_result` chat message: status + node counts +
+ * duration + cost + a link to the run detail, with the summary prose as the body.
+ * Fetches authoritative run state via `skill.getRun` (the same call RunDetailPage
+ * uses). If the run can't be loaded (e.g. deleted) it degrades to the summary alone
+ * rather than rendering a broken card.
+ */
+export function ConsoleWorkflowResultCard({
+  runId,
+  workflowName,
+  summary,
+}: ConsoleWorkflowResultCardProps): ReactElement {
+  const navigate = useNavigate();
+  const { data, error } = useEntity<Awaited<ReturnType<typeof skill.getRun>> | null>(
+    K.run(runId),
+    () => skill.getRun(runId)
+  );
+
+  const run = error !== null ? null : (data?.run ?? null);
+
+  // Loading or unfetchable → summary only (never a broken/empty card).
+  if (run === null) {
+    return (
+      <div className="rounded-md border border-border bg-surface px-3 py-2 text-[13px] whitespace-pre-wrap text-text-secondary">
+        {summary}
+      </div>
+    );
+  }
+
+  const { completed, total } = countTerminalNodes(data?.events ?? []);
+  const glyph = RESULT_GLYPH[run.status] ?? '•';
+  const label = RESULT_LABEL[run.status] ?? `Workflow ${statusLabel[run.status].toLowerCase()}`;
+  const duration = formatElapsed(elapsedSince(run.startedAt, run.finishedAt ?? undefined));
+  const cost = run.costUsd !== null ? formatCost(run.costUsd) : null;
+
+  return (
+    <div className="rounded-md border border-border bg-surface">
+      <div className="flex items-center gap-2 border-b border-border/60 px-3 py-2 text-[12px]">
+        <span aria-hidden className={`shrink-0 ${statusTextClass[run.status]}`}>
+          {glyph}
+        </span>
+        <span className={`min-w-0 flex-1 truncate font-medium ${statusTextClass[run.status]}`}>
+          {label}: <span className="text-text-primary">{workflowName}</span>
+        </span>
+        {total > 0 ? (
+          <span className="shrink-0 font-mono text-[11px] text-text-tertiary">
+            {completed}/{total} nodes
+          </span>
+        ) : null}
+        <span className="shrink-0 font-mono text-[11px] text-text-tertiary">{duration}</span>
+        {cost !== null ? (
+          <span className="shrink-0 rounded-full bg-surface-hover px-2 py-0.5 font-mono text-[10px] text-text-tertiary">
+            {cost}
+          </span>
+        ) : null}
+        {run.projectId !== null ? (
+          <button
+            type="button"
+            onClick={(): void => {
+              void navigate(`/console/p/${run.projectId}/r/${runId}`);
+            }}
+            className="shrink-0 text-[11px] text-text-secondary transition-colors hover:text-text-primary"
+          >
+            Open run →
+          </button>
+        ) : null}
+      </div>
+      {summary.trim().length > 0 ? (
+        <div className="px-3 py-2 text-[13px] whitespace-pre-wrap text-text-secondary">
+          {summary}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/web/src/experiments/console/components/ConsoleWorkflowResultCard.tsx
+++ b/packages/web/src/experiments/console/components/ConsoleWorkflowResultCard.tsx
@@ -1,9 +1,9 @@
-import type { ReactElement } from 'react';
+import { useEffect, type ReactElement } from 'react';
 import { useNavigate } from 'react-router';
 import { useEntity } from '../store/cache';
 import { K } from '../store/keys';
 import * as skill from '../skills';
-import type { RunEvent } from '../primitives/event';
+import { countTerminalNodes } from '../primitives/event';
 import type { RunStatus } from '../lib/run-status';
 import { statusTextClass, statusLabel } from '../lib/run-status';
 import { formatElapsed, elapsedSince, formatCost } from '../lib/format';
@@ -15,6 +15,9 @@ interface ConsoleWorkflowResultCardProps {
   summary: string;
 }
 
+// Only terminal statuses get a dedicated glyph/label — this is a *completion* card.
+// A still-`running`/`paused` run reaches here only in a brief race (the card mounts
+// before getRun reflects completion); those fall back to the generic glyph + label.
 const RESULT_GLYPH: Partial<Record<RunStatus, string>> = {
   completed: '✓',
   failed: '✕',
@@ -27,24 +30,13 @@ const RESULT_LABEL: Partial<Record<RunStatus, string>> = {
   cancelled: 'Workflow cancelled',
 };
 
-/** Count terminal node transitions (completed/failed/skipped); `started` is in-flight. */
-function countTerminalNodes(events: RunEvent[]): { completed: number; total: number } {
-  let completed = 0;
-  let total = 0;
-  for (const e of events) {
-    if (e.kind !== 'node_transition' || e.transition === 'started') continue;
-    total += 1;
-    if (e.transition === 'completed') completed += 1;
-  }
-  return { completed, total };
-}
-
 /**
  * A formatted card for a `workflow_result` chat message: status + node counts +
  * duration + cost + a link to the run detail, with the summary prose as the body.
  * Fetches authoritative run state via `skill.getRun` (the same call RunDetailPage
- * uses). If the run can't be loaded (e.g. deleted) it degrades to the summary alone
- * rather than rendering a broken card.
+ * uses). While the run is still loading, or if it can't be loaded at all (deleted,
+ * or a fetch error), it degrades to the summary prose alone rather than rendering a
+ * broken card.
  */
 export function ConsoleWorkflowResultCard({
   runId,
@@ -52,12 +44,25 @@ export function ConsoleWorkflowResultCard({
   summary,
 }: ConsoleWorkflowResultCardProps): ReactElement {
   const navigate = useNavigate();
-  const { data, error } = useEntity<Awaited<ReturnType<typeof skill.getRun>> | null>(
-    K.run(runId),
-    () => skill.getRun(runId)
+  const { data, error } = useEntity<Awaited<ReturnType<typeof skill.getRun>>>(K.run(runId), () =>
+    skill.getRun(runId)
   );
 
-  const run = error !== null ? null : (data?.run ?? null);
+  // useEntity surfaces a fetch failure as `error` (Error | undefined). Don't let it
+  // vanish silently — the card already falls back to the summary, but a transient
+  // 500 looks identical to a deleted run without this breadcrumb.
+  useEffect(() => {
+    if (error !== undefined) {
+      console.warn('[console] workflow result card: getRun failed, showing summary only', {
+        runId,
+        message: error.message,
+      });
+    }
+  }, [error, runId]);
+
+  // `error` is `Error | undefined` (never null) — compare against undefined, else
+  // the rich card never renders. Loading (data undefined) and error both → summary.
+  const run = error !== undefined ? null : (data?.run ?? null);
 
   // Loading or unfetchable → summary only (never a broken/empty card).
   if (run === null) {

--- a/packages/web/src/experiments/console/primitives/event.test.ts
+++ b/packages/web/src/experiments/console/primitives/event.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { toRunEvent } from './event';
+import { toRunEvent, countTerminalNodes } from './event';
 
 type Raw = Parameters<typeof toRunEvent>[0];
 
@@ -235,5 +235,51 @@ describe('toRunEvent — fallback', () => {
     expect(e.kind).toBe('text');
     if (e.kind !== 'text') throw new Error('unreachable');
     expect(e.content).toContain('mystery_event');
+  });
+});
+
+describe('countTerminalNodes', () => {
+  // Build a normalized node-transition RunEvent for `nodeId` via toRunEvent.
+  const node = (nodeId: string | null, eventType: string) =>
+    toRunEvent(raw({ event_type: eventType, step_name: nodeId }));
+
+  test('empty event list → 0/0', () => {
+    expect(countTerminalNodes([])).toEqual({ completed: 0, total: 0 });
+  });
+
+  test('only started (in-flight) nodes are excluded from the total', () => {
+    expect(countTerminalNodes([node('a', 'node_started'), node('b', 'node_started')])).toEqual({
+      completed: 0,
+      total: 0,
+    });
+  });
+
+  test('completed counts toward completed+total; failed/skipped only toward total', () => {
+    const events = [
+      node('a', 'node_completed'),
+      node('b', 'node_failed'),
+      node('c', 'node_skipped'),
+    ];
+    expect(countTerminalNodes(events)).toEqual({ completed: 1, total: 3 });
+  });
+
+  test('a node seen as completed then resume-skipped counts ONCE, still completed (dedup regression)', () => {
+    // A resumed run reuses one run id: the node has its original node_completed AND a
+    // later node_skipped_prior_success. Raw counting would report 2/2; dedup → 1/1.
+    const events = [node('a', 'node_completed'), node('a', 'node_skipped_prior_success')];
+    expect(countTerminalNodes(events)).toEqual({ completed: 1, total: 1 });
+  });
+
+  test('non-node_transition events are ignored', () => {
+    const events = [
+      node('a', 'node_completed'),
+      toRunEvent(raw({ event_type: 'tool_called', data: { tool_name: 'Bash' } })),
+      toRunEvent(raw({ event_type: 'workflow_completed', data: {} })),
+    ];
+    expect(countTerminalNodes(events)).toEqual({ completed: 1, total: 1 });
+  });
+
+  test('a terminal event with a null nodeId is skipped (can not be deduped)', () => {
+    expect(countTerminalNodes([node(null, 'node_completed')])).toEqual({ completed: 0, total: 0 });
   });
 });

--- a/packages/web/src/experiments/console/primitives/event.ts
+++ b/packages/web/src/experiments/console/primitives/event.ts
@@ -292,3 +292,24 @@ export function toRunEvent(raw: RawWorkflowEvent): RunEvent {
       `${et} — ${JSON.stringify(data).slice(0, 200)}`,
   };
 }
+
+/**
+ * Per-node terminal tally for a run's node-count readout (e.g. `7/8 nodes`).
+ * Deduped by `nodeId`: a resumed run reuses one run id, so a node can appear both
+ * as its original `completed` AND a later `node_skipped_prior_success` (normalized
+ * to a `skipped` transition) — counting raw events would double it. `total` =
+ * distinct nodes that reached any terminal (non-`started`) state; `completed` =
+ * distinct nodes that ever completed (so a completed-then-resume-skipped node
+ * stays counted). Nodes with a null `nodeId` can't be deduped and are skipped.
+ */
+export function countTerminalNodes(events: RunEvent[]): { completed: number; total: number } {
+  const completedByNode = new Map<string, boolean>();
+  for (const e of events) {
+    if (e.kind !== 'node_transition' || e.transition === 'started' || e.nodeId === null) continue;
+    const everCompleted = (completedByNode.get(e.nodeId) ?? false) || e.transition === 'completed';
+    completedByNode.set(e.nodeId, everCompleted);
+  }
+  let completed = 0;
+  for (const done of completedByNode.values()) if (done) completed += 1;
+  return { completed, total: completedByNode.size };
+}

--- a/packages/web/src/experiments/console/primitives/message.test.ts
+++ b/packages/web/src/experiments/console/primitives/message.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect } from 'bun:test';
+import { toMessage, isSystemCategory } from './message';
+
+type Raw = Parameters<typeof toMessage>[0];
+
+function raw(over: Partial<Raw> & { id: string }, metadata: Record<string, unknown> = {}): Raw {
+  return {
+    role: 'assistant',
+    content: 'hello',
+    created_at: '2026-06-05T10:00:00Z',
+    metadata: JSON.stringify(metadata),
+    ...over,
+  };
+}
+
+describe('toMessage — workflowResult', () => {
+  test('parses a workflow_result message into category + workflowResult', () => {
+    const m = toMessage(
+      raw(
+        { id: 'm1', content: 'Done — 7/8 nodes.' },
+        {
+          category: 'workflow_result',
+          workflowResult: { workflowName: 'e2e-deterministic', runId: 'run-123' },
+        }
+      )
+    );
+    expect(m.category).toBe('workflow_result');
+    expect(m.workflowResult).toEqual({ workflowName: 'e2e-deterministic', runId: 'run-123' });
+  });
+
+  test('a malformed workflowResult (missing runId) yields null — never half-renders', () => {
+    const m = toMessage(
+      raw(
+        { id: 'm1' },
+        {
+          category: 'workflow_result',
+          workflowResult: { workflowName: 'e2e-deterministic' },
+        }
+      )
+    );
+    expect(m.category).toBe('workflow_result');
+    expect(m.workflowResult).toBeNull();
+  });
+
+  test('a plain assistant message has null category/dispatch/workflowResult', () => {
+    const m = toMessage(raw({ id: 'm1', content: 'hi there' }));
+    expect(m.category).toBeNull();
+    expect(m.dispatch).toBeNull();
+    expect(m.workflowResult).toBeNull();
+  });
+});
+
+describe('toMessage — dispatch (regression)', () => {
+  test('still parses workflowDispatch into dispatch', () => {
+    const m = toMessage(
+      raw(
+        { id: 'm1' },
+        {
+          category: 'workflow_dispatch_status',
+          workflowDispatch: { workflowName: 'plan', workerConversationId: 'cli-9' },
+        }
+      )
+    );
+    expect(m.dispatch).toEqual({ workflowName: 'plan', workerConversationId: 'cli-9' });
+    expect(m.workflowResult).toBeNull();
+  });
+});
+
+describe('isSystemCategory', () => {
+  test('workflow_result is a system category (so ChatStream must branch BEFORE the filter)', () => {
+    expect(isSystemCategory('workflow_result')).toBe(true);
+    expect(isSystemCategory('workflow_status')).toBe(true);
+    expect(isSystemCategory('system_x')).toBe(true);
+  });
+
+  test('null and non-prefixed categories are not system', () => {
+    expect(isSystemCategory(null)).toBe(false);
+    expect(isSystemCategory('tool_call_formatted')).toBe(false);
+  });
+});

--- a/packages/web/src/experiments/console/primitives/message.test.ts
+++ b/packages/web/src/experiments/console/primitives/message.test.ts
@@ -42,11 +42,44 @@ describe('toMessage — workflowResult', () => {
     expect(m.workflowResult).toBeNull();
   });
 
+  test('an explicit workflowResult: null does not throw — yields null (guard regression)', () => {
+    // Regression: the guard must be `!= null`, not `!== undefined`. An explicit
+    // JSON null slips past `!== undefined` and then `typeof wr.workflowName` throws.
+    const m = toMessage(raw({ id: 'm1' }, { category: 'workflow_result', workflowResult: null }));
+    expect(m.category).toBe('workflow_result');
+    expect(m.workflowResult).toBeNull();
+  });
+
+  test('a non-string workflowName yields null (typeof guard)', () => {
+    const m = toMessage(
+      raw(
+        { id: 'm1' },
+        { category: 'workflow_result', workflowResult: { workflowName: 42, runId: 'run-123' } }
+      )
+    );
+    expect(m.workflowResult).toBeNull();
+  });
+
   test('a plain assistant message has null category/dispatch/workflowResult', () => {
     const m = toMessage(raw({ id: 'm1', content: 'hi there' }));
     expect(m.category).toBeNull();
     expect(m.dispatch).toBeNull();
     expect(m.workflowResult).toBeNull();
+  });
+});
+
+describe('toMessage — malformed metadata', () => {
+  test('corrupt metadata JSON degrades to empty (no throw, null category/result)', () => {
+    const m = toMessage({
+      id: 'm1',
+      role: 'assistant',
+      content: 'hi',
+      metadata: '{ not valid json',
+      created_at: '2026-06-05T10:00:00Z',
+    });
+    expect(m.category).toBeNull();
+    expect(m.workflowResult).toBeNull();
+    expect(m.content).toBe('hi');
   });
 });
 

--- a/packages/web/src/experiments/console/primitives/message.ts
+++ b/packages/web/src/experiments/console/primitives/message.ts
@@ -38,6 +38,12 @@ export interface WorkflowDispatchMeta {
   workerConversationId?: string;
 }
 
+/** Completion metadata on a `workflow_result` message — identifies the finished run. */
+export interface WorkflowResultMeta {
+  workflowName: string;
+  runId: string;
+}
+
 export interface Message {
   id: string;
   role: MessageRole;
@@ -45,10 +51,12 @@ export interface Message {
   timestamp: string;
   toolCalls: InlineToolCall[];
   error: InlineError | null;
-  /** Framework category from metadata (e.g. workflow_dispatch_status). */
+  /** Framework category from metadata (e.g. workflow_dispatch_status, workflow_result). */
   category: string | null;
   /** Parsed workflowDispatch payload, if present on this message. */
   dispatch: WorkflowDispatchMeta | null;
+  /** Parsed workflowResult payload — present on `workflow_result` messages. */
+  workflowResult: WorkflowResultMeta | null;
 }
 
 interface RawMessage {
@@ -71,6 +79,10 @@ interface ParsedMetadata {
   workflowDispatch?: {
     workflowName: string;
     workerConversationId?: string;
+  };
+  workflowResult?: {
+    workflowName: string;
+    runId: string;
   };
 }
 
@@ -110,6 +122,13 @@ export function toMessage(raw: RawMessage): Message {
           workerConversationId: meta.workflowDispatch.workerConversationId,
         }
       : null;
+  // Only a fully-formed payload yields a result (the hard-failure orchestrator path
+  // can omit it) — guard both fields so a partial object never half-renders a card.
+  const wr = meta.workflowResult;
+  const workflowResult: WorkflowResultMeta | null =
+    wr !== undefined && typeof wr.workflowName === 'string' && typeof wr.runId === 'string'
+      ? { workflowName: wr.workflowName, runId: wr.runId }
+      : null;
   return {
     id: raw.id,
     role: toMessageRole(raw.role),
@@ -119,5 +138,6 @@ export function toMessage(raw: RawMessage): Message {
     error,
     category: meta.category ?? null,
     dispatch,
+    workflowResult,
   };
 }

--- a/packages/web/src/experiments/console/primitives/message.ts
+++ b/packages/web/src/experiments/console/primitives/message.ts
@@ -80,6 +80,10 @@ interface ParsedMetadata {
     workflowName: string;
     workerConversationId?: string;
   };
+  // Untrusted/raw shape straight from JSON.parse — stays inline (rather than
+  // reusing WorkflowResultMeta) because toMessage validates it before producing
+  // the domain value. Runtime may hand us null or wrong-typed fields regardless
+  // of this annotation; the guard in toMessage is what enforces the contract.
   workflowResult?: {
     workflowName: string;
     runId: string;
@@ -90,7 +94,14 @@ function parseMetadata(raw: string): ParsedMetadata {
   if (raw.length === 0) return {};
   try {
     return JSON.parse(raw) as ParsedMetadata;
-  } catch {
+  } catch (e) {
+    // Corrupt metadata degrades to "no metadata" (the message still renders as
+    // plain prose) — but never silently: a malformed blob here is the kind of
+    // thing that would otherwise hide a real workflow_result with no trace.
+    console.warn('[console] failed to parse message metadata; treating as empty', {
+      error: e,
+      raw: raw.slice(0, 200),
+    });
     return {};
   }
 }
@@ -124,9 +135,11 @@ export function toMessage(raw: RawMessage): Message {
       : null;
   // Only a fully-formed payload yields a result (the hard-failure orchestrator path
   // can omit it) — guard both fields so a partial object never half-renders a card.
+  // `!= null` (not `!== undefined`) so an explicit JSON `null` doesn't slip past and
+  // make the `typeof wr.workflowName` access throw.
   const wr = meta.workflowResult;
   const workflowResult: WorkflowResultMeta | null =
-    wr !== undefined && typeof wr.workflowName === 'string' && typeof wr.runId === 'string'
+    wr != null && typeof wr.workflowName === 'string' && typeof wr.runId === 'string'
       ? { workflowName: wr.workflowName, runId: wr.runId }
       : null;
   return {

--- a/packages/web/src/experiments/console/routes/ChatPage.tsx
+++ b/packages/web/src/experiments/console/routes/ChatPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 import { useParams } from 'react-router';
 import { ChatStream } from '../components/ChatStream';
 import { ChatComposer } from '../components/ChatComposer';
@@ -70,15 +70,29 @@ export function ChatPage(): ReactElement {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // SSE accelerator: invalidates the message cache on text/tool events for
-  // snappy live updates when connected. Correctness doesn't depend on it.
-  useConversationSSE(activeConvId);
+  // Turn-completion state. The settle timer (below) is the correctness floor — it
+  // works even when SSE is absent. The SSE lock event is a fast-path on top of it.
+  const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const settleSigRef = useRef('');
+
+  // SSE accelerator: invalidates the message cache on text/tool events, and via
+  // onLockChange clears `busy` the instant the server releases the conversation
+  // lock (conversation_lock:false) instead of waiting out SETTLE_MS. Must be
+  // useCallback-stable — the hook's effect depends on it, so an inline lambda
+  // would reconnect the EventSource on every render.
+  const onLockChange = useCallback((locked: boolean): void => {
+    if (locked) return;
+    if (settleTimerRef.current !== null) {
+      clearTimeout(settleTimerRef.current);
+      settleTimerRef.current = null;
+    }
+    setBusy(false);
+  }, []);
+  useConversationSSE(activeConvId, onLockChange);
 
   // Derive turn state from the trailing message: a user message means a reply
   // is pending; once an assistant reply lands and stays stable for SETTLE_MS the
   // turn is done. This also recovers a reload mid-turn (trailing user message).
-  const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const settleSigRef = useRef('');
   useEffect(() => {
     const list = messages ?? [];
     const last = list[list.length - 1];
@@ -169,6 +183,23 @@ export function ChatPage(): ReactElement {
     el.scrollTop = el.scrollHeight;
   }, [messages?.length]);
 
+  // Jump-to-bottom affordance: `atBottom` (state) drives the button's visibility;
+  // `lastBottomRef` (above) drives the auto-scroll stickiness. Keep them in sync.
+  const [atBottom, setAtBottom] = useState(true);
+  const handleScroll = useCallback((): void => {
+    const el = scrollRef.current;
+    if (el === null) return;
+    const near = el.scrollHeight - el.scrollTop - el.clientHeight < 120;
+    lastBottomRef.current = near;
+    setAtBottom(near);
+  }, []);
+  const scrollToBottom = useCallback((): void => {
+    const el = scrollRef.current;
+    if (el === null) return;
+    el.scrollTop = el.scrollHeight;
+    setAtBottom(true);
+  }, []);
+
   if (projectId === undefined) {
     return <EmptyState title="No project selected." />;
   }
@@ -208,26 +239,39 @@ export function ChatPage(): ReactElement {
         <ProjectViewTabs projectId={projectId} active="chat" />
       </header>
 
-      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto px-6 py-4">
-        {messageList.length === 0 && !busy ? (
-          <EmptyState
-            title="No messages yet."
-            hint="Ask the agent about this project, or tell it what to run."
-          />
-        ) : (
-          <StreamContextProvider value={{ runStartedAt: null }}>
-            <ChatStream messages={messageList} showTools={showTools} />
-            {busy ? (
-              <WorkingIndicator
-                activity={currentActivity}
-                expanded={showTools}
-                onToggle={() => {
-                  setShowTools(v => !v);
-                }}
-              />
-            ) : null}
-          </StreamContextProvider>
-        )}
+      <div className="relative min-h-0 flex-1">
+        <div ref={scrollRef} onScroll={handleScroll} className="h-full overflow-y-auto px-6 py-4">
+          {messageList.length === 0 && !busy ? (
+            <EmptyState
+              title="No messages yet."
+              hint="Ask the agent about this project, or tell it what to run."
+            />
+          ) : (
+            <StreamContextProvider value={{ runStartedAt: null }}>
+              <ChatStream messages={messageList} showTools={showTools} />
+              {busy ? (
+                <WorkingIndicator
+                  activity={currentActivity}
+                  expanded={showTools}
+                  onToggle={() => {
+                    setShowTools(v => !v);
+                  }}
+                />
+              ) : null}
+            </StreamContextProvider>
+          )}
+        </div>
+        {!atBottom ? (
+          <button
+            type="button"
+            onClick={scrollToBottom}
+            aria-label="Jump to bottom"
+            className="absolute bottom-3 left-1/2 flex -translate-x-1/2 items-center gap-1 rounded-full border border-border bg-surface-elevated px-3 py-1 text-[11px] text-text-secondary shadow-md transition-colors hover:text-text-primary"
+          >
+            <span aria-hidden>↓</span>
+            Jump to bottom
+          </button>
+        ) : null}
       </div>
 
       <WorkflowDock projectId={projectId} />

--- a/packages/web/src/experiments/console/routes/ChatPage.tsx
+++ b/packages/web/src/experiments/console/routes/ChatPage.tsx
@@ -25,6 +25,9 @@ const SETTLE_MS = 6000;
 // Hard cap so a turn that never produces a reply (server error, etc.) can't
 // disable the composer forever.
 const MAX_WAIT_MS = 300_000;
+// Distance from the bottom (px) within which we treat the scroll as "at bottom"
+// — drives both auto-scroll stickiness and the jump-to-bottom button's visibility.
+const NEAR_BOTTOM_PX = 120;
 
 /**
  * Project-scoped agent chat. A tab peer of the runs view under a project.
@@ -175,7 +178,7 @@ export function ChatPage(): ReactElement {
   useEffect(() => {
     const el = scrollRef.current;
     if (el === null) return;
-    lastBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 120;
+    lastBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < NEAR_BOTTOM_PX;
   });
   useEffect(() => {
     const el = scrollRef.current;
@@ -189,7 +192,7 @@ export function ChatPage(): ReactElement {
   const handleScroll = useCallback((): void => {
     const el = scrollRef.current;
     if (el === null) return;
-    const near = el.scrollHeight - el.scrollTop - el.clientHeight < 120;
+    const near = el.scrollHeight - el.scrollTop - el.clientHeight < NEAR_BOTTOM_PX;
     lastBottomRef.current = near;
     setAtBottom(near);
   }, []);


### PR DESCRIPTION
## Summary

- **Problem:** Three gaps kept the console's project-scoped chat from replacing the old `/chat`: (1) a chat-launched workflow's completion was **invisible** — its `workflow_result` message (summary + `{workflowName, runId}`) was swallowed because `ChatStream` filters the whole `workflow_` category prefix and `toMessage` never parsed `workflowResult`; (2) the composer stayed **disabled ~6s** (`SETTLE_MS`) after each reply because the SSE lock event wasn't wired; (3) no jump-to-bottom.
- **Why it matters:** Console-vs-`/chat` parity — Theme A of the console-replaces-old-UI sequence.
- **What changed:** Parse `workflowResult`; render a new `ConsoleWorkflowResultCard`; wire `onLockChange` → `busy`; add a jump-to-bottom button.
- **What did NOT change (scope boundary):** **No server change** — the `workflow_result` message, its payload, and the lock events all already exist server-side. No un-suppressing the `workflow_` prefix (other `workflow_*` narration stays hidden). No `MessageItem` change. No streaming-cursor.

## UX Journey

### Before
```
chat: launch a workflow → it completes → …nothing renders… (workflow_result swallowed)
composer: disabled ~6s after every reply (SETTLE_MS), even though the server already released the lock
```
### After
```
┌─────────────────────────────────────────────────────────┐
│ ✓ Workflow complete: e2e-deterministic  7/8 nodes  18s  │  ◄── ConsoleWorkflowResultCard
│   summarised result…                          Open run →│
└─────────────────────────────────────────────────────────┘
composer: frees the instant conversation_lock:false arrives (settle timer = fallback)
↓ Jump to bottom — appears when scrolled up
```

## Architecture Diagram

```
orchestrator workflow_result (already emitted+persisted+SSE'd)
  → toMessage() NOW parses workflowResult → Message.workflowResult
      → ChatStream: lets workflow_result through the filter → ConsoleWorkflowResultCard
          → skill.getRun(runId) (same call as RunDetailPage) → status/counts/duration/cost
useConversationSSE(activeConvId, onLockChange)  ← NEW 2nd arg (stable)
  → conversation_lock:false → clear settle timer + setBusy(false)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `toMessage` | `Message.workflowResult` | **new** | parse of an already-persisted field |
| `ChatStream` | `ConsoleWorkflowResultCard` | **new** | branch on `category==='workflow_result'` before the filter |
| `ConsoleWorkflowResultCard` | `skill.getRun` | **new** | console cache (`useEntity(K.run)`), not react-query |
| `ChatPage` | `useConversationSSE` `onLockChange` | **new** | stable callback → busy |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `web`
- Module: `web:console`

## Change Metadata

- Change type: `feature`
- Primary scope: `web`

## Linked Issue

- Related #1878, #1881 (console sequence; this is PR #3)

## Validation Evidence (required)

```bash
bun --filter @archon/web type-check   # exit 0
bun run lint                          # exit 0 (--max-warnings 0)
bun run format:check                  # clean
bun run validate                      # exit 0 — all 7 CI checks incl. full suite
# console tests: 42 pass / 0 fail (6 new in message.test.ts)
```

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No (reuses existing `GET /api/workflows/runs/:id` + the SSE stream)
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified: type-check/lint/format/validate green; 42 console tests pass. The two plan gotchas were handled explicitly — `onLockChange` is `useCallback`-stable (no EventSource reconnect loop; the hook's effect deps on it), and the card degrades to the summary prose on `getRun` loading/error (never a broken card).
- Edge cases covered by code/guards: `workflowResult: null` (hard-failure path) → falls through to `MessageItem`; malformed `workflowResult` → `null` (tested); empty summary → body hidden; SSE-absent → settle timer still frees the composer.
- Not verified: live browser screenshot (presentational; `@archon/web` has no jsdom/testing-library — consistent with #1878/#1881). Manual smoke recommended: launch a workflow from console chat and confirm the card + the instant composer-free.

## Side Effects / Blast Radius (required)

- Affected: console chat rendering + the message primitive + ChatPage turn/scroll state (web only).
- Potential unintended effects: a stray EventSource reconnect if `onLockChange` weren't stable — guarded by `useCallback([])` + a no-reconnect acceptance check. Letting `workflow_result` past the filter is an explicit `=== 'workflow_result'` OR; `isSystemCategory` itself is untouched, so other `workflow_*` stay hidden.
- Guardrails: console tests run in CI.

## Rollback Plan (required)

- Fast rollback: `git revert <merge-commit>` — 5 files, web-only.
- Feature flags/toggles: none.
- Observable symptoms: completion cards stop rendering / composer reverts to the 6s settle delay.

## Risks and Mitigations

- Risk: inline `onLockChange` reconnects SSE each render. Mitigation: `useCallback([])` (refs + stable setter only).
- Risk: `getRun` failure → broken card. Mitigation: loading/error path renders the summary alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat now surfaces workflow run results inline with status, node counts, duration, optional cost, summary, and a link to open the run.
  * “Jump to bottom” button improves navigation when scrolled up.

* **Bug Fixes**
  * Improved conversation lock handling and more accurate busy/turn-complete behavior for real-time chat.

* **Tests**
  * Expanded parsing and event tests for workflow result handling, malformed metadata, and node-counting robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->