### PR TITLE
feat(web/console): settings core — assistant config + system panel

### DIFF
--- a/packages/web/src/experiments/console/ConsoleApp.tsx
+++ b/packages/web/src/experiments/console/ConsoleApp.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, type ReactElement } from 'react';
 import { Routes, Route, Link, useNavigate } from 'react-router';
+import { Settings } from 'lucide-react';
 import { ProjectRail } from './components/ProjectRail';
 import { AddProjectDialog } from './components/AddProjectDialog';
 import { ProjectPalette } from './components/ProjectPalette';
@@ -8,6 +9,7 @@ import { RunsPage } from './routes/RunsPage';
 import { RunDetailPage } from './routes/RunDetailPage';
 import { ChatPage } from './routes/ChatPage';
 import { PreviewPage } from './routes/PreviewPage';
+import { SettingsPage } from './routes/SettingsPage';
 import { invalidate } from './store/cache';
 import { K } from './store/keys';
 import { useKeymap, type Binding } from './lib/keymap';
@@ -45,8 +47,15 @@ export function ConsoleApp(): ReactElement {
           setHelpOpen(v => !v);
         },
       },
+      {
+        keys: [','],
+        label: 'Open settings',
+        run: (): void => {
+          navigate('/console/settings');
+        },
+      },
     ],
-    []
+    [navigate]
   );
   useKeymap({
     bindings: globalBindings,
@@ -71,16 +80,26 @@ export function ConsoleApp(): ReactElement {
             console
           </span>
         </div>
-        <Link
-          to="/chat"
-          title="Switch back to the classic UI"
-          className="flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-[11px] text-text-secondary transition-colors hover:border-border-bright hover:bg-surface-hover hover:text-text-primary"
-        >
-          <span aria-hidden className="font-mono text-[11px] leading-none">
-            ←
-          </span>
-          Old UI
-        </Link>
+        <div className="flex items-center gap-2">
+          <Link
+            to="/console/settings"
+            title="Settings ( , )"
+            className="flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-[11px] text-text-secondary transition-colors hover:border-border-bright hover:bg-surface-hover hover:text-text-primary"
+          >
+            <Settings aria-hidden className="h-3.5 w-3.5" />
+            Settings
+          </Link>
+          <Link
+            to="/chat"
+            title="Switch back to the classic UI"
+            className="flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-[11px] text-text-secondary transition-colors hover:border-border-bright hover:bg-surface-hover hover:text-text-primary"
+          >
+            <span aria-hidden className="font-mono text-[11px] leading-none">
+              ←
+            </span>
+            Old UI
+          </Link>
+        </div>
       </header>
 
       <div className="flex min-h-0 flex-1">
@@ -92,6 +111,7 @@ export function ConsoleApp(): ReactElement {
         <main className="flex min-w-0 flex-1 flex-col">
           <Routes>
             <Route index element={<RunsPage />} />
+            <Route path="settings" element={<SettingsPage />} />
             <Route path="_preview" element={<PreviewPage />} />
             <Route path="p/:projectId" element={<RunsPage />} />
             <Route path="p/:projectId/chat" element={<ChatPage />} />

--- a/packages/web/src/experiments/console/README.md
+++ b/packages/web/src/experiments/console/README.md
@@ -9,6 +9,7 @@ Mounted at `/console/*`. Not part of the shipped product. Validates the mental m
 ## Routes
 
 - `/console` → Runs view (scope = `all`)
+- `/console/settings` → Settings (assistant config + system health) — global
 - `/console/p/:projectId` → Runs view scoped to a project
 - `/console/p/:projectId/chat` → Project-scoped agent chat
 - `/console/p/:projectId/r/:runId` → Run detail

--- a/packages/web/src/experiments/console/components/AssistantConfigPanel.tsx
+++ b/packages/web/src/experiments/console/components/AssistantConfigPanel.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useRef, useState, type ReactElement } from 'react';
+import * as skill from '../skills';
+import type { SafeConfig, ProviderInfo, AssistantConfigForm } from '../skills';
+import { useEntity, invalidate } from '../store/cache';
+import { K } from '../store/keys';
+
+const REASONING_EFFORTS = ['minimal', 'low', 'medium', 'high', 'xhigh'] as const;
+const WEB_SEARCH_MODES = ['disabled', 'cached', 'live'] as const;
+
+const INPUT_CLASS =
+  'w-full rounded border border-border bg-surface px-2 py-1 font-mono text-[12px] text-text-primary placeholder:text-text-tertiary focus:border-border-bright focus:outline-none';
+
+/** Read a string field off the open `ProviderDefaults` record, '' when absent/non-string. */
+function readStr(rec: SafeConfig['assistants'][string] | undefined, key: string): string {
+  const v = rec?.[key];
+  return typeof v === 'string' ? v : '';
+}
+
+/** Seed editable form state from the saved config + the registered provider list. */
+function seedForm(config: SafeConfig, providers: ProviderInfo[]): AssistantConfigForm {
+  const models: Record<string, string> = {};
+  for (const p of providers) models[p.id] = readStr(config.assistants[p.id], 'model');
+  const codex = config.assistants.codex;
+  return {
+    assistant: config.assistant,
+    models,
+    modelReasoningEffort: readStr(codex, 'modelReasoningEffort'),
+    webSearchMode: readStr(codex, 'webSearchMode'),
+  };
+}
+
+/**
+ * Editor for the global default assistant + per-provider model (and Codex
+ * reasoning/web-search). Model is a FREE-TEXT input for every provider — Archon
+ * does not validate model strings (the SDK is the source of truth and ships
+ * models faster than we can enumerate them). Saves via PATCH /api/config/assistants
+ * → ~/.archon/config.yaml, then invalidates K.config so the form re-seeds from the
+ * persisted values (which also clears the dirty state).
+ */
+export function AssistantConfigPanel(): ReactElement {
+  const { data: config, error: configError } = useEntity(K.config, skill.getConfig);
+  const { data: providers, error: providersError } = useEntity(K.providers, skill.listProviders);
+
+  const [form, setForm] = useState<AssistantConfigForm | null>(null);
+  const baselineRef = useRef('');
+  useEffect(() => {
+    if (config === undefined || providers === undefined) return;
+    const seeded = seedForm(config.config, providers);
+    setForm(seeded);
+    baselineRef.current = JSON.stringify(seeded);
+  }, [config, providers]);
+
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const loadError = configError ?? providersError;
+  if (loadError !== undefined) {
+    return (
+      <Section title="Assistant">
+        <p className="font-mono text-[11px] text-error">{loadError.message}</p>
+      </Section>
+    );
+  }
+  if (form === null || providers === undefined) {
+    return (
+      <Section title="Assistant">
+        <p className="font-mono text-[11px] text-text-tertiary">Loading…</p>
+      </Section>
+    );
+  }
+
+  const dirty = JSON.stringify(form) !== baselineRef.current;
+
+  const setModel = (id: string, value: string): void => {
+    setForm(f => (f === null ? f : { ...f, models: { ...f.models, [id]: value } }));
+  };
+  const patch = (partial: Partial<AssistantConfigForm>): void => {
+    setForm(f => (f === null ? f : { ...f, ...partial }));
+  };
+
+  const onSave = async (): Promise<void> => {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await skill.updateAssistantConfig(skill.buildAssistantUpdate(form));
+      invalidate(K.config); // refetch re-seeds the form and clears `dirty`
+    } catch (e: unknown) {
+      setSaveError(e instanceof Error ? e.message : 'Failed to save settings.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Section title="Assistant">
+      <label className="mb-4 flex items-center gap-3 text-[12px]">
+        <span className="w-32 shrink-0 text-text-secondary">Default assistant</span>
+        <select
+          value={form.assistant}
+          onChange={e => {
+            patch({ assistant: e.target.value });
+          }}
+          className={INPUT_CLASS}
+        >
+          {providers.map(p => (
+            <option key={p.id} value={p.id}>
+              {p.displayName}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <div className="flex flex-col gap-3">
+        {providers.map(p => (
+          <div key={p.id} className="flex flex-col gap-2 rounded border border-border/60 p-3">
+            <div className="flex items-center gap-3 text-[12px]">
+              <span className="w-32 shrink-0 font-medium text-text-primary">{p.displayName}</span>
+              <input
+                value={form.models[p.id] ?? ''}
+                onChange={e => {
+                  setModel(p.id, e.target.value);
+                }}
+                placeholder="model (e.g. sonnet, gpt-5.3-codex) — blank = inherit"
+                className={INPUT_CLASS}
+              />
+            </div>
+            {p.id === 'codex' ? (
+              <div className="flex flex-wrap items-center gap-3 pl-[8.75rem] text-[12px]">
+                <label className="flex items-center gap-2">
+                  <span className="text-text-tertiary">effort</span>
+                  <select
+                    value={form.modelReasoningEffort}
+                    onChange={e => {
+                      patch({ modelReasoningEffort: e.target.value });
+                    }}
+                    className="rounded border border-border bg-surface px-2 py-1 font-mono text-[11px] text-text-primary focus:border-border-bright focus:outline-none"
+                  >
+                    <option value="">inherit</option>
+                    {REASONING_EFFORTS.map(o => (
+                      <option key={o} value={o}>
+                        {o}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="flex items-center gap-2">
+                  <span className="text-text-tertiary">web search</span>
+                  <select
+                    value={form.webSearchMode}
+                    onChange={e => {
+                      patch({ webSearchMode: e.target.value });
+                    }}
+                    className="rounded border border-border bg-surface px-2 py-1 font-mono text-[11px] text-text-primary focus:border-border-bright focus:outline-none"
+                  >
+                    <option value="">inherit</option>
+                    {WEB_SEARCH_MODES.map(o => (
+                      <option key={o} value={o}>
+                        {o}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+            ) : null}
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-4 flex items-center justify-end gap-3">
+        {saveError !== null ? (
+          <span className="font-mono text-[11px] text-error">{saveError}</span>
+        ) : null}
+        <button
+          type="button"
+          onClick={() => void onSave()}
+          disabled={!dirty || saving}
+          className="brand-bar rounded px-3 py-0.5 text-[11px] font-medium text-white transition-all hover:brightness-110 disabled:opacity-40"
+        >
+          {saving ? 'Saving…' : 'Save changes'}
+        </button>
+      </div>
+    </Section>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactElement | ReactElement[];
+}): ReactElement {
+  return (
+    <section className="rounded-md border border-border bg-surface p-4">
+      <h2 className="mb-3 text-sm font-semibold text-text-primary">{title}</h2>
+      {children}
+    </section>
+  );
+}

--- a/packages/web/src/experiments/console/components/AssistantConfigPanel.tsx
+++ b/packages/web/src/experiments/console/components/AssistantConfigPanel.tsx
@@ -3,12 +3,15 @@ import * as skill from '../skills';
 import type { SafeConfig, ProviderInfo, AssistantConfigForm } from '../skills';
 import { useEntity, invalidate } from '../store/cache';
 import { K } from '../store/keys';
+import { SettingsSection } from './SettingsSection';
 
 const REASONING_EFFORTS = ['minimal', 'low', 'medium', 'high', 'xhigh'] as const;
 const WEB_SEARCH_MODES = ['disabled', 'cached', 'live'] as const;
 
 const INPUT_CLASS =
   'w-full rounded border border-border bg-surface px-2 py-1 font-mono text-[12px] text-text-primary placeholder:text-text-tertiary focus:border-border-bright focus:outline-none';
+const SELECT_CLASS =
+  'rounded border border-border bg-surface px-2 py-1 font-mono text-[11px] text-text-primary focus:border-border-bright focus:outline-none';
 
 /** Read a string field off the open `ProviderDefaults` record, '' when absent/non-string. */
 function readStr(rec: SafeConfig['assistants'][string] | undefined, key: string): string {
@@ -56,16 +59,16 @@ export function AssistantConfigPanel(): ReactElement {
   const loadError = configError ?? providersError;
   if (loadError !== undefined) {
     return (
-      <Section title="Assistant">
+      <SettingsSection title="Assistant">
         <p className="font-mono text-[11px] text-error">{loadError.message}</p>
-      </Section>
+      </SettingsSection>
     );
   }
   if (form === null || providers === undefined) {
     return (
-      <Section title="Assistant">
+      <SettingsSection title="Assistant">
         <p className="font-mono text-[11px] text-text-tertiary">Loading…</p>
-      </Section>
+      </SettingsSection>
     );
   }
 
@@ -92,7 +95,7 @@ export function AssistantConfigPanel(): ReactElement {
   };
 
   return (
-    <Section title="Assistant">
+    <SettingsSection title="Assistant">
       <label className="mb-4 flex items-center gap-3 text-[12px]">
         <span className="w-32 shrink-0 text-text-secondary">Default assistant</span>
         <select
@@ -133,7 +136,7 @@ export function AssistantConfigPanel(): ReactElement {
                     onChange={e => {
                       patch({ modelReasoningEffort: e.target.value });
                     }}
-                    className="rounded border border-border bg-surface px-2 py-1 font-mono text-[11px] text-text-primary focus:border-border-bright focus:outline-none"
+                    className={SELECT_CLASS}
                   >
                     <option value="">inherit</option>
                     {REASONING_EFFORTS.map(o => (
@@ -150,7 +153,7 @@ export function AssistantConfigPanel(): ReactElement {
                     onChange={e => {
                       patch({ webSearchMode: e.target.value });
                     }}
-                    className="rounded border border-border bg-surface px-2 py-1 font-mono text-[11px] text-text-primary focus:border-border-bright focus:outline-none"
+                    className={SELECT_CLASS}
                   >
                     <option value="">inherit</option>
                     {WEB_SEARCH_MODES.map(o => (
@@ -179,21 +182,6 @@ export function AssistantConfigPanel(): ReactElement {
           {saving ? 'Saving…' : 'Save changes'}
         </button>
       </div>
-    </Section>
-  );
-}
-
-function Section({
-  title,
-  children,
-}: {
-  title: string;
-  children: ReactElement | ReactElement[];
-}): ReactElement {
-  return (
-    <section className="rounded-md border border-border bg-surface p-4">
-      <h2 className="mb-3 text-sm font-semibold text-text-primary">{title}</h2>
-      {children}
-    </section>
+    </SettingsSection>
   );
 }

--- a/packages/web/src/experiments/console/components/SettingsSection.tsx
+++ b/packages/web/src/experiments/console/components/SettingsSection.tsx
@@ -1,0 +1,17 @@
+import type { ReactElement, ReactNode } from 'react';
+
+/** Shared card shell for the console settings panels (Assistant, System, …). */
+export function SettingsSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}): ReactElement {
+  return (
+    <section className="rounded-md border border-border bg-surface p-4">
+      <h2 className="mb-3 text-sm font-semibold text-text-primary">{title}</h2>
+      {children}
+    </section>
+  );
+}

--- a/packages/web/src/experiments/console/components/SystemPanel.tsx
+++ b/packages/web/src/experiments/console/components/SystemPanel.tsx
@@ -3,6 +3,7 @@ import * as skill from '../skills';
 import { useEntity } from '../store/cache';
 import { K } from '../store/keys';
 import { useHealth } from '../lib/health';
+import { SettingsSection } from './SettingsSection';
 
 /** Coerce a field off the open `concurrency` record to a finite number (0 otherwise). */
 function num(rec: Record<string, unknown>, key: string): number {
@@ -19,66 +20,95 @@ function num(rec: Record<string, unknown>, key: string): number {
 export function SystemPanel(): ReactElement {
   const { data: health, error: healthError } = useHealth();
   const { data: config } = useEntity(K.config, skill.getConfig);
-  const { data: update } = useEntity(K.updateCheck, skill.getUpdateCheck);
+  const { data: update, error: updateError } = useEntity(K.updateCheck, skill.getUpdateCheck);
+
+  if (healthError !== undefined) {
+    return (
+      <SettingsSection title="System">
+        <p className="font-mono text-[11px] text-error">{healthError.message}</p>
+      </SettingsSection>
+    );
+  }
+  if (health === undefined) {
+    return (
+      <SettingsSection title="System">
+        <p className="font-mono text-[11px] text-text-tertiary">Loading…</p>
+      </SettingsSection>
+    );
+  }
+
+  const platforms = health.activePlatforms ?? [];
 
   return (
-    <section className="rounded-md border border-border bg-surface p-4">
-      <h2 className="mb-3 text-sm font-semibold text-text-primary">System</h2>
-      {healthError !== undefined ? (
-        <p className="font-mono text-[11px] text-error">{healthError.message}</p>
-      ) : health === undefined ? (
-        <p className="font-mono text-[11px] text-text-tertiary">Loading…</p>
-      ) : (
-        <div className="flex flex-col gap-2 text-[12px]">
-          <Row label="status" value={health.status} />
-          <Row label="adapter" value={health.adapter} />
-          <Row label="database" value={config?.database ?? '—'} />
-          <Row label="version" value={health.version ?? '—'} />
-          <Row
-            label="concurrency"
-            value={`${num(health.concurrency, 'active')} / ${num(health.concurrency, 'maxConcurrent')} active`}
-          />
-          <Row label="running workflows" value={String(health.runningWorkflows)} />
+    <SettingsSection title="System">
+      <div className="flex flex-col gap-2 text-[12px]">
+        <Row label="status" value={health.status} />
+        <Row label="adapter" value={health.adapter} />
+        <Row label="database" value={config?.database ?? '—'} />
+        <Row label="version" value={health.version ?? '—'} />
+        <Row
+          label="concurrency"
+          value={`${num(health.concurrency, 'active')} / ${num(health.concurrency, 'maxConcurrent')} active`}
+        />
+        <Row label="running workflows" value={String(health.runningWorkflows)} />
 
-          <div className="flex items-baseline gap-3">
-            <span className="w-32 shrink-0 text-text-tertiary">platforms</span>
-            <div className="flex flex-wrap gap-1.5">
-              {(health.activePlatforms ?? []).length === 0 ? (
-                <span className="text-text-tertiary">none</span>
-              ) : (
-                (health.activePlatforms ?? []).map(pl => (
-                  <span
-                    key={pl}
-                    className="rounded border border-border px-1.5 py-0.5 font-mono text-[10px] text-text-secondary"
-                  >
-                    {pl}
-                  </span>
-                ))
-              )}
-            </div>
-          </div>
-
-          <div className="mt-1 flex items-baseline gap-3">
-            <span className="w-32 shrink-0 text-text-tertiary">updates</span>
-            {update === undefined ? (
-              <span className="text-text-tertiary">checking…</span>
-            ) : update.updateAvailable ? (
-              <a
-                href={update.releaseUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="text-text-secondary underline-offset-2 hover:text-text-primary hover:underline"
-              >
-                {update.latestVersion} available →
-              </a>
+        <div className="flex items-baseline gap-3">
+          <span className="w-32 shrink-0 text-text-tertiary">platforms</span>
+          <div className="flex flex-wrap gap-1.5">
+            {platforms.length === 0 ? (
+              <span className="text-text-tertiary">none</span>
             ) : (
-              <span className="text-text-secondary">Up to date ({update.currentVersion})</span>
+              platforms.map(pl => (
+                <span
+                  key={pl}
+                  className="rounded border border-border px-1.5 py-0.5 font-mono text-[10px] text-text-secondary"
+                >
+                  {pl}
+                </span>
+              ))
             )}
           </div>
         </div>
-      )}
-    </section>
+
+        <div className="mt-1 flex items-baseline gap-3">
+          <span className="w-32 shrink-0 text-text-tertiary">updates</span>
+          <UpdateStatus update={update} error={updateError} />
+        </div>
+      </div>
+    </SettingsSection>
   );
+}
+
+/**
+ * Update-check line. Distinguishes failed (don't strand on "checking…" forever — the
+ * silent-failure trap), still-loading, update-available, and up-to-date.
+ */
+function UpdateStatus({
+  update,
+  error,
+}: {
+  update: skill.UpdateCheckResponse | undefined;
+  error: Error | undefined;
+}): ReactElement {
+  if (error !== undefined) {
+    return <span className="text-text-tertiary">update check unavailable</span>;
+  }
+  if (update === undefined) {
+    return <span className="text-text-tertiary">checking…</span>;
+  }
+  if (update.updateAvailable) {
+    return (
+      <a
+        href={update.releaseUrl}
+        target="_blank"
+        rel="noreferrer"
+        className="text-text-secondary underline-offset-2 hover:text-text-primary hover:underline"
+      >
+        {update.latestVersion} available →
+      </a>
+    );
+  }
+  return <span className="text-text-secondary">Up to date ({update.currentVersion})</span>;
 }
 
 function Row({ label, value }: { label: string; value: string }): ReactElement {

--- a/packages/web/src/experiments/console/components/SystemPanel.tsx
+++ b/packages/web/src/experiments/console/components/SystemPanel.tsx
@@ -1,0 +1,91 @@
+import { type ReactElement } from 'react';
+import * as skill from '../skills';
+import { useEntity } from '../store/cache';
+import { K } from '../store/keys';
+import { useHealth } from '../lib/health';
+
+/** Coerce a field off the open `concurrency` record to a finite number (0 otherwise). */
+function num(rec: Record<string, unknown>, key: string): number {
+  const n = Number(rec[key]);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Read-only system status: server/adapter/db/version, concurrency, running
+ * workflows, active platform adapters, and the update-check. `concurrency` is an
+ * open record in the generated type, so each field is coerced defensively rather
+ * than destructured.
+ */
+export function SystemPanel(): ReactElement {
+  const { data: health, error: healthError } = useHealth();
+  const { data: config } = useEntity(K.config, skill.getConfig);
+  const { data: update } = useEntity(K.updateCheck, skill.getUpdateCheck);
+
+  return (
+    <section className="rounded-md border border-border bg-surface p-4">
+      <h2 className="mb-3 text-sm font-semibold text-text-primary">System</h2>
+      {healthError !== undefined ? (
+        <p className="font-mono text-[11px] text-error">{healthError.message}</p>
+      ) : health === undefined ? (
+        <p className="font-mono text-[11px] text-text-tertiary">Loading…</p>
+      ) : (
+        <div className="flex flex-col gap-2 text-[12px]">
+          <Row label="status" value={health.status} />
+          <Row label="adapter" value={health.adapter} />
+          <Row label="database" value={config?.database ?? '—'} />
+          <Row label="version" value={health.version ?? '—'} />
+          <Row
+            label="concurrency"
+            value={`${num(health.concurrency, 'active')} / ${num(health.concurrency, 'maxConcurrent')} active`}
+          />
+          <Row label="running workflows" value={String(health.runningWorkflows)} />
+
+          <div className="flex items-baseline gap-3">
+            <span className="w-32 shrink-0 text-text-tertiary">platforms</span>
+            <div className="flex flex-wrap gap-1.5">
+              {(health.activePlatforms ?? []).length === 0 ? (
+                <span className="text-text-tertiary">none</span>
+              ) : (
+                (health.activePlatforms ?? []).map(pl => (
+                  <span
+                    key={pl}
+                    className="rounded border border-border px-1.5 py-0.5 font-mono text-[10px] text-text-secondary"
+                  >
+                    {pl}
+                  </span>
+                ))
+              )}
+            </div>
+          </div>
+
+          <div className="mt-1 flex items-baseline gap-3">
+            <span className="w-32 shrink-0 text-text-tertiary">updates</span>
+            {update === undefined ? (
+              <span className="text-text-tertiary">checking…</span>
+            ) : update.updateAvailable ? (
+              <a
+                href={update.releaseUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="text-text-secondary underline-offset-2 hover:text-text-primary hover:underline"
+              >
+                {update.latestVersion} available →
+              </a>
+            ) : (
+              <span className="text-text-secondary">Up to date ({update.currentVersion})</span>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }): ReactElement {
+  return (
+    <div className="flex items-baseline gap-3">
+      <span className="w-32 shrink-0 text-text-tertiary">{label}</span>
+      <span className="font-mono text-text-primary">{value}</span>
+    </div>
+  );
+}

--- a/packages/web/src/experiments/console/lib/health.ts
+++ b/packages/web/src/experiments/console/lib/health.ts
@@ -1,24 +1,23 @@
 /**
- * Server-health surface. Currently only used for the Docker check so we
- * know whether to render the `Open in IDE` (vscode://) affordance. The
- * default is `true` (hide the button) until we hear otherwise — matches
- * the old UI's safer default and prevents flashing a broken link on first
- * paint inside Docker.
+ * Server-health surface. Two consumers share the one `K.health` cache entry:
+ * `useIsDocker` (gates the `Open in IDE` vscode:// affordance) and the Settings
+ * SystemPanel (full status grid). The docker default stays `true` (hide the
+ * button) until health resolves — matches the old UI and avoids flashing a broken
+ * link on first paint inside Docker.
  */
 
-import { useEntity } from '../store/cache';
-import { requestJson } from './http';
+import { useEntity, type EntityView } from '../store/cache';
+import { K } from '../store/keys';
+import { getHealth, type HealthResponse } from '../skills/settings';
 
-interface HealthResponse {
-  is_docker?: boolean;
+export type { HealthResponse };
+
+export function useHealth(): EntityView<HealthResponse> {
+  return useEntity<HealthResponse>(K.health, getHealth);
 }
 
-const HEALTH_KEY = 'health';
-
 export function useIsDocker(): boolean {
-  const { data } = useEntity<HealthResponse>(HEALTH_KEY, () =>
-    requestJson<HealthResponse>('/api/health')
-  );
+  const { data } = useHealth();
   return data?.is_docker ?? true;
 }
 

--- a/packages/web/src/experiments/console/lib/shortcuts.ts
+++ b/packages/web/src/experiments/console/lib/shortcuts.ts
@@ -7,6 +7,7 @@ export const SHORTCUTS: readonly KeymapGroup[] = [
     entries: [
       { keys: ['p'], label: 'Pick a project' },
       { keys: ['n'], label: 'Start a new run' },
+      { keys: [','], label: 'Open settings' },
       { keys: ['?'], label: 'Show this help' },
     ],
   },

--- a/packages/web/src/experiments/console/routes/SettingsPage.tsx
+++ b/packages/web/src/experiments/console/routes/SettingsPage.tsx
@@ -1,0 +1,24 @@
+import { type ReactElement } from 'react';
+import { AssistantConfigPanel } from '../components/AssistantConfigPanel';
+import { SystemPanel } from '../components/SystemPanel';
+
+/**
+ * Global (installation-wide) console settings — assistant config + system health.
+ * Mounted at `/console/settings`, not under a project, because the write path
+ * (PATCH /api/config/assistants → ~/.archon/config.yaml) is global only.
+ */
+export function SettingsPage(): ReactElement {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <header className="flex flex-col gap-3 border-b border-border px-6 py-4">
+        <h1 className="truncate text-base font-medium text-text-primary">Settings</h1>
+      </header>
+      <div className="flex-1 overflow-y-auto px-6 py-4">
+        <div className="mx-auto flex max-w-2xl flex-col gap-6">
+          <AssistantConfigPanel />
+          <SystemPanel />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/experiments/console/skills/index.ts
+++ b/packages/web/src/experiments/console/skills/index.ts
@@ -15,5 +15,7 @@ export * from './startRun';
 export * from './messages';
 export * from './conversations';
 export * from './envVars';
+export * from './settings';
+export * from './providers';
 
 export { HttpError } from '../lib/http';

--- a/packages/web/src/experiments/console/skills/providers.ts
+++ b/packages/web/src/experiments/console/skills/providers.ts
@@ -1,0 +1,11 @@
+import { requestJson } from '../lib/http';
+import type { components } from '@/lib/api.generated';
+
+/** Registered AI providers — drives the default-assistant picker + per-provider model rows. */
+export type ProviderInfo = components['schemas']['ProviderInfo'];
+
+export function listProviders(): Promise<ProviderInfo[]> {
+  return requestJson<components['schemas']['ProviderListResponse']>('/api/providers').then(
+    r => r.providers
+  );
+}

--- a/packages/web/src/experiments/console/skills/settings.test.ts
+++ b/packages/web/src/experiments/console/skills/settings.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect } from 'bun:test';
+import { buildAssistantUpdate, type AssistantConfigForm } from './settings';
+
+function form(over: Partial<AssistantConfigForm> = {}): AssistantConfigForm {
+  return {
+    assistant: 'claude',
+    models: {},
+    modelReasoningEffort: '',
+    webSearchMode: '',
+    ...over,
+  };
+}
+
+describe('buildAssistantUpdate', () => {
+  test('passes the default assistant through', () => {
+    expect(buildAssistantUpdate(form({ assistant: 'codex' })).assistant).toBe('codex');
+  });
+
+  test('omits a provider whose model is blank (never writes {model: ""})', () => {
+    const body = buildAssistantUpdate(form({ models: { claude: '', pi: '   ' } }));
+    expect(body.assistants).toBeUndefined();
+  });
+
+  test('trims the model before writing it', () => {
+    const body = buildAssistantUpdate(form({ models: { claude: '  sonnet  ' } }));
+    expect(body.assistants).toEqual({ claude: { model: 'sonnet' } });
+  });
+
+  test('a provider with only a model writes just { model }', () => {
+    const body = buildAssistantUpdate(form({ models: { pi: 'anthropic/claude-haiku-4-5' } }));
+    expect(body.assistants).toEqual({ pi: { model: 'anthropic/claude-haiku-4-5' } });
+  });
+
+  test('codex attaches reasoning effort + web search alongside its model', () => {
+    const body = buildAssistantUpdate(
+      form({
+        assistant: 'codex',
+        models: { codex: 'gpt-5.3-codex' },
+        modelReasoningEffort: 'high',
+        webSearchMode: 'live',
+      })
+    );
+    expect(body.assistants).toEqual({
+      codex: { model: 'gpt-5.3-codex', modelReasoningEffort: 'high', webSearchMode: 'live' },
+    });
+  });
+
+  test('codex enums attach even when its model is blank (effort-only edit)', () => {
+    const body = buildAssistantUpdate(
+      form({ models: { codex: '' }, modelReasoningEffort: 'medium' })
+    );
+    expect(body.assistants).toEqual({ codex: { modelReasoningEffort: 'medium' } });
+  });
+
+  test('reasoning/web-search are NOT attached to non-codex providers', () => {
+    const body = buildAssistantUpdate(
+      form({ models: { claude: 'opus' }, modelReasoningEffort: 'high', webSearchMode: 'live' })
+    );
+    expect(body.assistants).toEqual({ claude: { model: 'opus' } });
+  });
+
+  test('everything blank → just the assistant, no assistants key', () => {
+    const body = buildAssistantUpdate(form({ models: { claude: '', codex: '' } }));
+    expect(body).toEqual({ assistant: 'claude' });
+  });
+});

--- a/packages/web/src/experiments/console/skills/settings.ts
+++ b/packages/web/src/experiments/console/skills/settings.ts
@@ -1,0 +1,74 @@
+import { requestJson } from '../lib/http';
+import type { components } from '@/lib/api.generated';
+
+/**
+ * Installation-wide settings skills: assistant config + system health/version.
+ *
+ * Mirrors the envVars skill (requestJson + method). Types come from the generated
+ * OpenAPI spec (`@/lib/api.generated`) — never `@/lib/api` — so the console stays
+ * inside its isolation boundary. The write path is GLOBAL only: PATCH
+ * /api/config/assistants persists to ~/.archon/config.yaml (no repo overrides).
+ */
+
+export type SafeConfig = components['schemas']['SafeConfig'];
+export type ConfigResponse = components['schemas']['ConfigResponse'];
+export type UpdateAssistantConfigBody = components['schemas']['UpdateAssistantConfigBody'];
+export type HealthResponse = components['schemas']['HealthResponse'];
+export type UpdateCheckResponse = components['schemas']['UpdateCheckResponse'];
+
+export function getConfig(): Promise<ConfigResponse> {
+  return requestJson<ConfigResponse>('/api/config');
+}
+
+export function updateAssistantConfig(body: UpdateAssistantConfigBody): Promise<ConfigResponse> {
+  return requestJson<ConfigResponse>('/api/config/assistants', {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+}
+
+export function getHealth(): Promise<HealthResponse> {
+  return requestJson<HealthResponse>('/api/health');
+}
+
+export function getUpdateCheck(): Promise<UpdateCheckResponse> {
+  return requestJson<UpdateCheckResponse>('/api/update-check');
+}
+
+/**
+ * Editable assistant form state. `models` is providerId → free-text model (model
+ * strings are intentionally unvalidated — the SDK ships models faster than Archon
+ * can enumerate them). The codex-only reasoning/web-search fields are flat here
+ * and only attached to the codex entry by `buildAssistantUpdate`.
+ */
+export interface AssistantConfigForm {
+  assistant: string;
+  models: Record<string, string>;
+  modelReasoningEffort: string;
+  webSearchMode: string;
+}
+
+/**
+ * Pure form → PATCH-body transform. Omits a provider's `model` when blank (so we
+ * never overwrite a saved model with `''`) and drops a provider entirely when it
+ * contributes no fields. Codex additionally carries `modelReasoningEffort` /
+ * `webSearchMode` when set. The server safe-filters per provider, so extra keys on
+ * the wrong provider are harmless, but we keep the body minimal regardless.
+ */
+export function buildAssistantUpdate(form: AssistantConfigForm): UpdateAssistantConfigBody {
+  const assistants: Record<string, Record<string, unknown>> = {};
+  for (const [providerId, rawModel] of Object.entries(form.models)) {
+    const entry: Record<string, unknown> = {};
+    const model = rawModel.trim();
+    if (model !== '') entry.model = model;
+    if (providerId === 'codex') {
+      if (form.modelReasoningEffort !== '') entry.modelReasoningEffort = form.modelReasoningEffort;
+      if (form.webSearchMode !== '') entry.webSearchMode = form.webSearchMode;
+    }
+    if (Object.keys(entry).length > 0) assistants[providerId] = entry;
+  }
+
+  const body: UpdateAssistantConfigBody = { assistant: form.assistant };
+  if (Object.keys(assistants).length > 0) body.assistants = assistants;
+  return body;
+}

--- a/packages/web/src/experiments/console/skills/settings.ts
+++ b/packages/web/src/experiments/console/skills/settings.ts
@@ -52,8 +52,12 @@ export interface AssistantConfigForm {
  * Pure form → PATCH-body transform. Omits a provider's `model` when blank (so we
  * never overwrite a saved model with `''`) and drops a provider entirely when it
  * contributes no fields. Codex additionally carries `modelReasoningEffort` /
- * `webSearchMode` when set. The server safe-filters per provider, so extra keys on
- * the wrong provider are harmless, but we keep the body minimal regardless.
+ * `webSearchMode` when set.
+ *
+ * Safety note: the PATCH route validates only provider *ids* and merges the body
+ * into config.yaml UNFILTERED — per-field safe-filtering runs on the read path, not
+ * the write path. So it matters that this function only ever attaches the codex-only
+ * fields to the `codex` entry (it does); it must not leak them onto other providers.
  */
 export function buildAssistantUpdate(form: AssistantConfigForm): UpdateAssistantConfigBody {
   const assistants: Record<string, Record<string, unknown>> = {};

--- a/packages/web/src/experiments/console/store/keys.ts
+++ b/packages/web/src/experiments/console/store/keys.ts
@@ -22,8 +22,9 @@ export const K = {
   artifacts: (runId: string): string => `artifacts:${runId}`,
   // Installation-wide settings surfaces (static keys — one row each).
   config: 'config' as const,
-  // NOTE: must stay the literal 'health' — lib/health.ts already caches under
-  // this key, so the Settings SystemPanel and the IDE docker-check share one entry.
+  // Health has two consumers — the Settings SystemPanel and the IDE docker-check.
+  // Both must read via lib/health's useHealth() so they share this one cache entry
+  // instead of issuing duplicate /api/health fetches.
   health: 'health' as const,
   providers: 'providers' as const,
   updateCheck: 'update-check' as const,

--- a/packages/web/src/experiments/console/store/keys.ts
+++ b/packages/web/src/experiments/console/store/keys.ts
@@ -20,4 +20,11 @@ export const K = {
   pendingRuns: 'pendingRuns' as const,
   envVars: (projectId: string): string => `envVars:${projectId}`,
   artifacts: (runId: string): string => `artifacts:${runId}`,
+  // Installation-wide settings surfaces (static keys — one row each).
+  config: 'config' as const,
+  // NOTE: must stay the literal 'health' — lib/health.ts already caches under
+  // this key, so the Settings SystemPanel and the IDE docker-check share one entry.
+  health: 'health' as const,
+  providers: 'providers' as const,
+  updateCheck: 'update-check' as const,
 } as const;


### PR DESCRIPTION
## Summary

- **Problem:** The run-centric console (`/console`) has **no settings surface** — to change which assistant/model runs, or to see version/health/platform status, you must leave it for the old UI.
- **Why it matters:** Parity floor before making `/console` the default UI. Theme of the console-replaces-old-UI sequence (PR #4, after #1878/#1881/#1885).
- **What changed:** A global `/console/settings` route with an **AssistantConfigPanel** (default-assistant picker + per-provider free-text model + Codex reasoning/web-search, saving via `PATCH /api/config/assistants`) and a **SystemPanel** (health grid + update-check), backed by a new console `skills/settings.ts` + `skills/providers.ts` layer and a ⚙ header entry + `,` keybinding.
- **What did NOT change (scope boundary):** **No server change** — every API consumed already exists. GitHub device-flow panel split to **PR #5**. Env-var editing stays on the project rail (it's project-scoped). Non-safe-filtered fields (`claudeBinaryPath`, `settingSources`, …) are out of scope (not round-trippable). Web-only, inside the `experiments/console` isolation boundary.

## UX Journey

### Before
```
/console → runs / chat.  To change the model or see health → leave for /settings (old UI).
console header:  [Archon console]                         ← Old UI
```
### After
```
console header:  [Archon console]              ⚙ Settings   ← Old UI
/console/settings (global)
┌── Assistant ───────────────────────────────────────────┐
│ Default assistant [ claude ▾ ]                          │
│ Claude   model [ sonnet          ]                      │
│ Codex    model [ gpt-5.3-codex   ] effort [▾] web [▾]   │
│ OpenCode model [                 ]                       │
│ Pi       model [                 ]                       │
│ Copilot  model [                 ]            [Save]     │
├── System ──────────────────────────────────────────────┤
│ status ok · adapter web · db sqlite · v0.4.1            │
│ concurrency 0/10 active · running 0 · platforms [Web]   │
│ Up to date (0.4.1)                                      │
└─────────────────────────────────────────────────────────┘
```

## Architecture Diagram

### After
```
getConfig / listProviders / getHealth / getUpdateCheck  (skills → requestJson)
  → useEntity(K.config|providers|health|updateCheck)
      → AssistantConfigPanel  → buildAssistantUpdate(form) → updateAssistantConfig
          → PATCH /api/config/assistants → ~/.archon/config.yaml → invalidate(K.config)
      → SystemPanel (read-only)
ConsoleApp [~]  → /console/settings route [+], ⚙ header link [+], ',' keybinding [+]
lib/health.ts [~]  → full HealthResponse + useHealth()  (useIsDocker derives from it)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `skills/settings.ts` | `lib/http` `requestJson` | **new** | config/health/update-check + PATCH |
| `skills/providers.ts` | `/api/providers` | **new** | registered provider list |
| `AssistantConfigPanel` | `updateAssistantConfig` → `invalidate(K.config)` | **new** | save + re-seed |
| `lib/health.ts` | `skills/settings.getHealth` | **modified** | shared `K.health` cache |
| `ConsoleApp` | `routes/SettingsPage` | **new** | global route + nav + keybinding |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `web`
- Module: `web:console`

## Change Metadata

- Change type: `feature`
- Primary scope: `web`

## Linked Issue

- Related #1878, #1881, #1885 (console sequence; this is PR #4)

## Validation Evidence (required)

```bash
bun --filter @archon/web type-check   # exit 0
bun run lint                          # exit 0 (--max-warnings 0)
bun run format:check                  # clean
cd packages/web && bun test src/experiments/console/   # 59 pass / 0 fail (8 new in settings.test.ts)
```

- **Evidence:** static checks green; the pure `buildAssistantUpdate` transform has 8 unit tests (empty-model omitted, trimmed, codex enums attached, effort-only edit, non-codex providers don't get enums, default-assistant passthrough, all-blank). Verified **end-to-end against an isolated server** (`ARCHON_HOME=/tmp`, real `~/.archon` untouched): the 4 read APIs return the shapes the panels consume; **Save round-trips** (`PATCH` → `config.yaml` → `GET` re-reads the new value) with `claudeBinaryPath` preserved by the server's deep-merge; a **browser smoke** of `/console/settings` rendered both panels (5 provider rows, Codex effort/web-search selects, the system grid, Save correctly dirty-gated).
- **Skipped:** full all-packages `bun run validate` — change is isolated to `@archon/web`; ran that package's suite + the isolated end-to-end instead. CI runs the rest.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No** (reuses existing `/api/config`, `/api/providers`, `/api/health`, `/api/update-check`)
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No** (the existing `PATCH /api/config/assistants` writes `~/.archon/config.yaml` as before)

## Compatibility / Migration

- Backward compatible? **Yes** — additive console route + skills; no server/schema change.
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

- **Verified scenarios:** type-check/lint/format/59 tests green; isolated-server end-to-end (read APIs + save round-trip persisting to `config.yaml`); browser render of `/console/settings` (both panels, 5 providers, Codex extras, dirty-gated Save, ⚙ header link + `,` keybinding).
- **Edge cases checked:** provider with no saved model → blank input, and saving omits it (no `{model:''}` written — unit-tested); Codex effort-only edit attaches the enum without a model; non-Codex providers never receive the enums; `health.concurrency` coerced (`Number`, open-record type, no NaN); update-check no-update → "Up to date"; `error !== undefined` (not `null`) used throughout (the #1885 cache gotcha).
- **What was not verified:** a save *through the browser UI* against the real `~/.archon` (verified the same PATCH path via the isolated server instead, to avoid reserializing your real config.yaml). Community providers (opencode/pi/copilot) render free-text model inputs but weren't exercised with real models.

## Side Effects / Blast Radius (required)

- **Affected subsystems:** console settings route + the new skill layer + `lib/health.ts` (web only).
- **Potential unintended effects:** `lib/health.ts` now routes `useIsDocker` through `useHealth()` on the same `K.health` key — behavior preserved (`is_docker ?? true`); the only shared-cache change is that the IDE docker-check and the SystemPanel read one entry.
- **Guardrails:** console tests run in CI; the save path is the same endpoint the old UI uses; `buildAssistantUpdate` is unit-tested.

## Rollback Plan (required)

- **Fast rollback:** `git revert <merge-commit>` — 11 files, web-only, additive.
- **Feature flags/toggles:** none.
- **Observable failure symptoms:** `/console/settings` shows an error panel (a read API failing) or Save fails (surfaced inline); no effect on other console routes.

## Risks and Mitigations

- Risk: saving a model accidentally wipes a provider's non-safe-filtered fields (e.g. `claudeBinaryPath`).
  - Mitigation: the server `updateGlobalConfig` deep-merges per provider (verified: `mergeAssistantDefaults(merge(defaults, current), updates)`); confirmed end-to-end that a model save preserves `claudeBinaryPath`.
- Risk: `health.concurrency` shape assumed → NaN/crash.
  - Mitigation: each field coerced via `Number(...)` defensively (open-record type); confirmed real keys are `active`/`maxConcurrent`.
- Risk: free-text model lets users type an invalid model.
  - Mitigation: intended per repo principle (Archon does not validate model strings; the SDK is the source of truth).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Settings page with assistant configuration: choose default assistant and override per-provider models
  * Settings page shows system health, active platforms, and update status (including link to release when available)
  * Inline save for assistant settings with loading/error states and change-detection so Save enables only when edits exist
  * Global keyboard shortcut (`,`) to open Settings from anywhere in the console
<!-- end of auto-generated comment: release notes by coderabbit.ai -->