### PR TITLE
Fix: warn on the bash node $node.output double-quote footgun + docs (#1884)

### DIFF
--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -378,6 +378,22 @@ Variable substitution order:
 1. Standard variables (`$WORKFLOW_ID`, `$USER_MESSAGE`, `$ARTIFACTS_DIR`, etc.)
 2. Node output references (`$nodeId.output`, `$nodeId.output.field`)
 
+:::caution[Double-quoting `$node.output` in `bash:` nodes is a silent footgun]
+In `bash:` nodes, `$nodeId.output` and `$nodeId.output.field` are injected pre-quoted by Archon. For small outputs, values are **single-quoted inline** — the quoting is already provided by the substitution. For outputs exceeding 32 KB, Archon spills to a temp file and substitutes `$(cat '/tmp/path')` instead. Wrapping in double quotes corrupts both forms: for inline values it embeds the single quotes; for `$(cat ...)` it enables word-splitting on the command output.
+
+```bash
+# WRONG — produces status="'ok'" (single quotes become part of the value)
+status="$emit.output.status"
+[ "$status" = "ok" ]   # → always false
+
+# CORRECT — leave unquoted; bash assigns: status=ok
+status=$emit.output.status
+[ "$status" = "ok" ]   # → true
+```
+
+**Rule:** use `var=$node.output.field`, never `var="$node.output.field"`. This applies whether the output is small (single-quoted inline) or large (`$(cat ...)`). Numeric and boolean fields are injected raw (without quotes), so double-quoting accidentally "works" for them — making the bug intermittent and hard to spot.
+:::
+
 ### `output_format` for Structured JSON
 
 Use `output_format` to enforce JSON output from an AI node. For Claude, the schema is passed via the SDK's `outputFormat` option and `structured_output` is used directly. For Codex (v0.116.0+), the schema is passed via `TurnOptions.outputSchema` and the agent's inline JSON response is used. Both ensure clean JSON for `when:` conditions and `$nodeId.output` substitution:

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -379,7 +379,7 @@ Variable substitution order:
 2. Node output references (`$nodeId.output`, `$nodeId.output.field`)
 
 :::caution[Double-quoting `$node.output` in `bash:` nodes is a silent footgun]
-In `bash:` nodes, `$nodeId.output` and `$nodeId.output.field` are injected pre-quoted by Archon. For small outputs, values are **single-quoted inline** — the quoting is already provided by the substitution. For outputs exceeding 32 KB, Archon spills to a temp file and substitutes `$(cat '/tmp/path')` instead. Wrapping in double quotes corrupts both forms: for inline values it embeds the single quotes; for `$(cat ...)` it enables word-splitting on the command output.
+In `bash:` nodes, `$nodeId.output` and `$nodeId.output.field` are injected pre-quoted by Archon. For small outputs, values are **single-quoted inline** — the quoting is already provided by the substitution. For outputs exceeding 32 KB, Archon spills to a temp file and substitutes `$(cat '/tmp/path')` instead. Wrapping the substitution in double quotes breaks the **small (inline) case**: `var="$n.output"` becomes `var="'value'"`, embedding the literal single-quotes as part of the value. (For the large `$(cat ...)` case, double-quoting is harmless — `var="$(cat ...)"` is correct bash — but you can't know the output's size at author time, so the rule is unconditional: never double-quote.)
 
 ```bash
 # WRONG — produces status="'ok'" (single quotes become part of the value)

--- a/packages/docs-web/src/content/docs/guides/loop-nodes.md
+++ b/packages/docs-web/src/content/docs/guides/loop-nodes.md
@@ -150,7 +150,10 @@ loop:
 This is useful for deterministic completion criteria: test suites, lint checks,
 build success. The bash script supports the same variable substitution as
 `prompt` (`$ARTIFACTS_DIR`, `$nodeId.output`, etc.). Note: `$nodeId.output`
-values are shell-escaped when substituted into `until_bash`.
+values are shell-escaped when substituted into `until_bash`. The same
+double-quoting footgun that applies to `bash:` nodes applies here — see
+[Shell Quoting in `bash:` vs `script:`](/reference/variables#shell-quoting-in-bash-vs-script)
+for the unquoted idiom to use.
 
 ## Patterns
 

--- a/packages/docs-web/src/content/docs/reference/variables.md
+++ b/packages/docs-web/src/content/docs/reference/variables.md
@@ -69,21 +69,20 @@ In DAG workflows, nodes can reference the output of any completed upstream node.
 
 `$nodeId.output` values are **auto shell-quoted** when substituted into `bash:` scripts, so the value is always safe to embed in a shell command. For small outputs, values are single-quoted inline. For outputs exceeding 32 KB, Archon spills to a temp file and substitutes `$(cat '/tmp/path')` instead — the unquoted assignment form is correct in both cases. They are **not** shell-quoted when substituted into `script:` bodies — the raw value is embedded as-is. For script nodes, treat substituted values as untrusted input and parse them with language features (e.g. `JSON.parse`), not by interpolating into shell syntax.
 
-Because `bash:` substitutions arrive pre-quoted, wrapping them in double quotes is a silent footgun — for inline values it embeds the single quotes; for `$(cat ...)` it enables word-splitting:
+Because `bash:` substitutions arrive pre-quoted, wrapping them in double quotes is a silent footgun for small (inline) values:
 
 ```bash
-# WRONG — $node.output.field is already quoted by Archon.
-# For inline values: status="'ok'" (single quotes become part of value).
-# For large outputs: double-quoting a $(cat ...) enables word-splitting.
-status="$emit.output.status"        # ← broken in both cases
-[ "$status" = "ok" ] && echo pass   # → silently fails
+# WRONG — for a small value, $emit.output.status is injected as 'ok' (single-quoted),
+# so status="$emit.output.status" becomes status="'ok'" — the quotes become data.
+status="$emit.output.status"
+[ "$status" = "ok" ] && echo pass   # → silently fails ($status is 'ok', not ok)
 
 # CORRECT — leave the substitution unquoted; Archon's quoting is the quoting.
 status=$emit.output.status          # → status='ok' → bash assigns: ok
 [ "$status" = "ok" ] && echo pass   # → passes
 ```
 
-Numeric and boolean fields are injected raw (no surrounding quotes), so double-quoting accidentally "works" for them — which makes the bug intermittent. The rule is unconditional: in `bash:` nodes, use `var=$node.output.field`, never `var="$node.output.field"`.
+For **large** outputs (>32 KB) the substitution is `$(cat '/path')`, where `var="$(cat ...)"` is correct bash — but you can't know the size at author time, so the rule is unconditional. Numeric and boolean **fields** are injected raw (no quotes), so double-quoting accidentally "works" for them — which makes the bug intermittent. Always use `var=$node.output.field`, never `var="$node.output.field"`.
 
 ### Example
 

--- a/packages/docs-web/src/content/docs/reference/variables.md
+++ b/packages/docs-web/src/content/docs/reference/variables.md
@@ -67,7 +67,23 @@ In DAG workflows, nodes can reference the output of any completed upstream node.
 
 ### Shell Quoting in `bash:` vs `script:`
 
-`$nodeId.output` values are **auto shell-quoted** (single-quoted, with embedded `'` escaped) when substituted into `bash:` scripts, so the value is always safe to embed in a shell command. They are **not** shell-quoted when substituted into `script:` bodies — the raw value is embedded as-is. For script nodes, treat substituted values as untrusted input and parse them with language features (e.g. `JSON.parse`), not by interpolating into shell syntax.
+`$nodeId.output` values are **auto shell-quoted** when substituted into `bash:` scripts, so the value is always safe to embed in a shell command. For small outputs, values are single-quoted inline. For outputs exceeding 32 KB, Archon spills to a temp file and substitutes `$(cat '/tmp/path')` instead — the unquoted assignment form is correct in both cases. They are **not** shell-quoted when substituted into `script:` bodies — the raw value is embedded as-is. For script nodes, treat substituted values as untrusted input and parse them with language features (e.g. `JSON.parse`), not by interpolating into shell syntax.
+
+Because `bash:` substitutions arrive pre-quoted, wrapping them in double quotes is a silent footgun — for inline values it embeds the single quotes; for `$(cat ...)` it enables word-splitting:
+
+```bash
+# WRONG — $node.output.field is already quoted by Archon.
+# For inline values: status="'ok'" (single quotes become part of value).
+# For large outputs: double-quoting a $(cat ...) enables word-splitting.
+status="$emit.output.status"        # ← broken in both cases
+[ "$status" = "ok" ] && echo pass   # → silently fails
+
+# CORRECT — leave the substitution unquoted; Archon's quoting is the quoting.
+status=$emit.output.status          # → status='ok' → bash assigns: ok
+[ "$status" = "ok" ] && echo pass   # → passes
+```
+
+Numeric and boolean fields are injected raw (no surrounding quotes), so double-quoting accidentally "works" for them — which makes the bug intermittent. The rule is unconditional: in `bash:` nodes, use `var=$node.output.field`, never `var="$node.output.field"`.
 
 ### Example
 

--- a/packages/workflows/src/validator.test.ts
+++ b/packages/workflows/src/validator.test.ts
@@ -577,7 +577,7 @@ describe('validateWorkflowResources — bash double-quote lint', () => {
     expect(warnings).toHaveLength(1);
     expect(warnings[0].nodeId).toBe('check');
     expect(warnings[0].message).toContain('double-quoting');
-    expect(warnings[0].hint).toContain('Remove the surrounding double quotes');
+    expect(warnings[0].hint).toContain('var=$node.output.field');
   });
 
   test('warning when $nodeId.output is embedded inside a double-quoted string', async () => {
@@ -615,5 +615,38 @@ describe('validateWorkflowResources — bash double-quote lint', () => {
     const issues = await validateWorkflowResources(workflow, tmpDir);
     const warnings = issues.filter(i => i.level === 'warning' && i.field === 'bash');
     expect(warnings).toHaveLength(0);
+  });
+
+  test('no false positive: a prior double-quoted string before an unquoted ref on the same line', async () => {
+    // The closing `"` of "Build complete." must NOT seed a match that slides across
+    // the `;` to the correctly-unquoted $build.output.score.
+    const workflow = makeWorkflow('test', [
+      {
+        id: 'check',
+        bash: 'echo "Build complete."; result=$build.output.score',
+      } as DagNode,
+    ]);
+    const issues = await validateWorkflowResources(workflow, tmpDir);
+    const warnings = issues.filter(i => i.level === 'warning' && i.field === 'bash');
+    expect(warnings).toHaveLength(0);
+  });
+
+  test('warns on a double-quoted $node.output in a loop until_bash', async () => {
+    // until_bash substitutes with the same escapedForBash=true path as bash nodes,
+    // so the footgun applies there too.
+    const workflow = makeWorkflow('test', [
+      {
+        id: 'gen',
+        prompt: 'produce output',
+        loop: {
+          until: 'DONE',
+          until_bash: 'status="$emit.output.status" && [ "$status" = "done" ]',
+        },
+      } as unknown as DagNode,
+    ]);
+    const issues = await validateWorkflowResources(workflow, tmpDir);
+    const warnings = issues.filter(i => i.level === 'warning' && i.field === 'loop.until_bash');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toContain('double-quoting');
   });
 });

--- a/packages/workflows/src/validator.test.ts
+++ b/packages/workflows/src/validator.test.ts
@@ -547,3 +547,73 @@ describe('validateWorkflowResources — agents capability', () => {
     expect(warning).toBeUndefined();
   });
 });
+
+// =============================================================================
+// validateWorkflowResources — bash double-quote lint
+// =============================================================================
+
+describe('validateWorkflowResources — bash double-quote lint', () => {
+  test('no warning when bash uses correct unquoted idiom', async () => {
+    const workflow = makeWorkflow('test', [
+      {
+        id: 'check',
+        bash: 'status=$node.output.field\n[ "$status" = "ok" ] && echo pass',
+      } as DagNode,
+    ]);
+    const issues = await validateWorkflowResources(workflow, tmpDir);
+    const warnings = issues.filter(i => i.level === 'warning' && i.field === 'bash');
+    expect(warnings).toHaveLength(0);
+  });
+
+  test('warning when bash body has double-quoted $nodeId.output.field', async () => {
+    const workflow = makeWorkflow('test', [
+      {
+        id: 'check',
+        bash: 'status="$emit.output.status"\n[ "$status" = "ok" ] && echo pass',
+      } as DagNode,
+    ]);
+    const issues = await validateWorkflowResources(workflow, tmpDir);
+    const warnings = issues.filter(i => i.level === 'warning' && i.field === 'bash');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].nodeId).toBe('check');
+    expect(warnings[0].message).toContain('double-quoting');
+    expect(warnings[0].hint).toContain('Remove the surrounding double quotes');
+  });
+
+  test('warning when $nodeId.output is embedded inside a double-quoted string', async () => {
+    const workflow = makeWorkflow('test', [
+      {
+        id: 'check',
+        bash: 'echo "result: $emit.output.status"',
+      } as DagNode,
+    ]);
+    const issues = await validateWorkflowResources(workflow, tmpDir);
+    const warnings = issues.filter(i => i.level === 'warning' && i.field === 'bash');
+    expect(warnings).toHaveLength(1);
+  });
+
+  test('script nodes are exempt from the double-quote lint', async () => {
+    const workflow = makeWorkflow('test', [
+      {
+        id: 'check',
+        script: 'const status = "$emit.output.status";\nconsole.log(status);',
+        runtime: 'bun',
+      } as unknown as DagNode,
+    ]);
+    const issues = await validateWorkflowResources(workflow, tmpDir);
+    const warnings = issues.filter(i => i.level === 'warning' && i.field === 'bash');
+    expect(warnings).toHaveLength(0);
+  });
+
+  test('no warning when $nodeId.output is inside single quotes', async () => {
+    const workflow = makeWorkflow('test', [
+      {
+        id: 'check',
+        bash: "status='$emit.output.status'",
+      } as DagNode,
+    ]);
+    const issues = await validateWorkflowResources(workflow, tmpDir);
+    const warnings = issues.filter(i => i.level === 'warning' && i.field === 'bash');
+    expect(warnings).toHaveLength(0);
+  });
+});

--- a/packages/workflows/src/validator.ts
+++ b/packages/workflows/src/validator.ts
@@ -30,7 +30,7 @@ function getLog(): ReturnType<typeof createLogger> {
   if (!cachedLog) cachedLog = createLogger('workflow.validator');
   return cachedLog;
 }
-import { isScriptNode } from './schemas';
+import { isBashNode, isScriptNode } from './schemas';
 import type { WorkflowDefinition, DagNode, WorkflowSource } from './schemas';
 import type { ScriptRuntime } from './script-discovery';
 import { discoverScriptsForCwd } from './script-discovery';
@@ -585,6 +585,28 @@ export async function validateWorkflowResources(
           field: 'deps',
           message: "'deps' is ignored for bun runtime (bun auto-installs packages at runtime)",
           hint: 'Remove deps or switch to runtime: uv if you need explicit dependency management',
+        });
+      }
+    }
+
+    // In bash nodes, substituted values are injected pre-quoted by Archon (single-quoted
+    // inline for small values, or via $(cat ...) for large outputs >32 KB). Wrapping in
+    // double quotes corrupts both forms: for inline values it embeds the single quotes;
+    // for $(cat ...) it enables word-splitting on the command output.
+    //   wrong="$n.output.field" → wrong="'ok'" (inline) or word-splits $(cat ...) output
+    //   right=$n.output.field   → right='ok' → bash assigns: ok
+    if (isBashNode(node)) {
+      // [^"\n]* intentionally excludes newlines — a double-quote spanning lines is pathological
+      // in workflow bash prompts and not worth detecting.
+      const doubleQuotedOutputRef = /"[^"\n]*\$[a-zA-Z_][a-zA-Z0-9_-]*\.output/;
+      if (doubleQuotedOutputRef.test(node.bash)) {
+        issues.push({
+          level: 'warning',
+          nodeId: node.id,
+          field: 'bash',
+          message:
+            '`"$nodeId.output"` — double-quoting a substitution that is already single-quoted by Archon produces the wrong value',
+          hint: 'Remove the surrounding double quotes: use `var=$node.output.field` not `var="$node.output.field"`. The injected single-quotes are the quoting.',
         });
       }
     }

--- a/packages/workflows/src/validator.ts
+++ b/packages/workflows/src/validator.ts
@@ -30,7 +30,7 @@ function getLog(): ReturnType<typeof createLogger> {
   if (!cachedLog) cachedLog = createLogger('workflow.validator');
   return cachedLog;
 }
-import { isBashNode, isScriptNode } from './schemas';
+import { isBashNode, isLoopNode, isScriptNode } from './schemas';
 import type { WorkflowDefinition, DagNode, WorkflowSource } from './schemas';
 import type { ScriptRuntime } from './script-discovery';
 import { discoverScriptsForCwd } from './script-discovery';
@@ -589,26 +589,39 @@ export async function validateWorkflowResources(
       }
     }
 
-    // In bash nodes, substituted values are injected pre-quoted by Archon (single-quoted
-    // inline for small values, or via $(cat ...) for large outputs >32 KB). Wrapping in
-    // double quotes corrupts both forms: for inline values it embeds the single quotes;
-    // for $(cat ...) it enables word-splitting on the command output.
-    //   wrong="$n.output.field" → wrong="'ok'" (inline) or word-splits $(cat ...) output
+    // In bash node bodies (and loop `until_bash`, which substitutes the same way),
+    // $node.output values are injected PRE-QUOTED by Archon: small values are
+    // single-quoted inline ('the value'), large outputs (>32 KB) spill to a temp
+    // file as $(cat '/path'). Wrapping the substitution in double quotes breaks the
+    // SMALL case — var="$n.output" becomes var="'value'", embedding the literal
+    // single-quote chars as data. (For the large $(cat ...) case double-quoting is
+    // actually fine, but the author can't predict the size at write time, so the
+    // rule is unconditional: never double-quote.) Numeric/boolean FIELD values are
+    // injected raw, so double-quoting is harmless for those — which is why the bug
+    // is intermittent and easy to miss.
+    //   wrong="$n.output.field" → wrong="'ok'" (single quotes become part of the value)
     //   right=$n.output.field   → right='ok' → bash assigns: ok
-    if (isBashNode(node)) {
-      // [^"\n]* intentionally excludes newlines — a double-quote spanning lines is pathological
-      // in workflow bash prompts and not worth detecting.
-      const doubleQuotedOutputRef = /"[^"\n]*\$[a-zA-Z_][a-zA-Z0-9_-]*\.output/;
-      if (doubleQuotedOutputRef.test(node.bash)) {
+    //
+    // The `(?:^|[=\s])"` prefix requires the opening `"` to be an operand (line
+    // start, after `=`, or after whitespace) so a *closing* quote of an unrelated
+    // earlier string doesn't cause a false positive (e.g. `echo "hi"; x=$a.output`).
+    // `[^"\n]` excludes newlines — a double-quote spanning lines is pathological.
+    const doubleQuotedOutputRef = /(?:^|[=\s])"[^"\n]*\$[a-zA-Z_][a-zA-Z0-9_-]*\.output/m;
+    const warnDoubleQuoted = (body: string, field: string): void => {
+      if (doubleQuotedOutputRef.test(body)) {
         issues.push({
           level: 'warning',
           nodeId: node.id,
-          field: 'bash',
+          field,
           message:
-            '`"$nodeId.output"` — double-quoting a substitution that is already single-quoted by Archon produces the wrong value',
-          hint: 'Remove the surrounding double quotes: use `var=$node.output.field` not `var="$node.output.field"`. The injected single-quotes are the quoting.',
+            '`"$nodeId.output"` — double-quoting a substitution that is already shell-quoted by Archon produces the wrong value',
+          hint: 'Use `var=$node.output.field` (unquoted) — the substitution is injected already quoted. (Numeric/boolean fields are injected raw, so double-quoting is harmless for those, but the rule is uniform.)',
         });
       }
+    };
+    if (isBashNode(node)) warnDoubleQuoted(node.bash, 'bash');
+    if (isLoopNode(node) && node.loop.until_bash) {
+      warnDoubleQuoted(node.loop.until_bash, 'loop.until_bash');
     }
   }
 


### PR DESCRIPTION
## Summary

- **Problem:** In `bash:` nodes, `$nodeId.output[.field]` is injected **pre-quoted** by Archon (single-quoted inline for small values; `$(cat ...)` for outputs >32 KB). Wrapping it in double quotes — `var="$n.output.field"` — bakes the literal single quotes into the value (`'value'`), so downstream comparisons silently fail. Numeric/boolean fields are injected raw, so it "works" for them, making the bug intermittent and hard to spot (#1884).
- **Why it matters:** Surfaced while writing structured-output e2e smokes — the first smoke "failed" purely from this quoting, not the feature under test. It's a real authoring footgun.
- **What changed:** A workflow-validator **warning** when a `bash:` body contains a double-quoted `$nodeId.output` substitution, plus a docs caution callout (authoring-workflows.md), a shell-quoting footgun section (variables.md), and a cross-reference from loop-nodes.md.
- **What did NOT change (scope boundary):** No behavior change to substitution itself (single-quoting is correct for safety); the warning is advisory (`level: 'warning'`), never an error.

## Provenance / why a fresh PR

This is the genuine #1884 fix **extracted** from the autonomous run on #1888, which had bundled three unrelated things into one "bash footgun" PR:

| #1888 contained | Kept here? |
|---|---|
| Validator double-quote warning + docs | ✅ yes (this PR) |
| **Model tier → concrete reverts** (`small`→`haiku`, `medium`→`sonnet`, `large`→`opus[1m]`) across all 14 bundled workflows + regenerated bundle | ❌ dropped — would **undo #1873's** model-alias adoption (it's already on `dev`) and hardcode Claude models into the provider-agnostic defaults |
| `validateModelRef` placement refactor + `title-generator`/`orchestrator-agent` spread→if refactors | ❌ dropped — off-scope |

So #1888 is being closed in favor of this scoped change.

## Architecture Diagram

### After
```
validateWorkflowResources (packages/workflows/src/validator.ts)
  for each node:
    …existing checks…
    [+] if isBashNode(node) && /"[^"\n]*\$\w[\w-]*\.output/.test(node.bash):
          push { level: 'warning', field: 'bash', message: '"$nodeId.output" double-quoting …', hint }
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `validator.ts` | `isBashNode` (`./schemas`) | **new** | added to the existing import |
| `validateWorkflowResources` | bash-double-quote regex check | **new** | advisory warning only |

## Label Snapshot
- Risk: `risk: low` (advisory warning; no runtime behavior change)
- Size: `size: S`
- Scope: `workflows` + `docs`
- Module: `workflows:validator`

## Change Metadata
- Change type: `bug` (DX footgun)
- Primary scope: `workflows`

## Linked Issue
- Closes #1884
- Supersedes #1888 (which is being closed — it tangled this fix with model-alias reverts)

## Validation Evidence (required)
```bash
bun run validate   # → exit 0 (type-check, lint, format, check:bundled*, all tests)
bun test packages/workflows/src/validator.test.ts   # → 53 pass / 0 fail
```
- New validator tests: warns on `var="$emit.output.status"`; warns on `echo "result: $emit.output.status"`; no warning on the unquoted idiom `var=$node.output.field`; no warning on single-quoted; `script:` nodes exempt.

## Security Impact (required)
- New permissions/capabilities? **No** · New external network calls? **No** · Secrets handling changed? **No** · FS scope changed? **No**

## Compatibility / Migration
- Backward compatible? **Yes** — advisory warning only; no config/env/DB changes. Existing bundled defaults that use the pattern will now emit this warning (informational); fixing their quoting is a separate follow-up.

## Human Verification (required)
- **Verified:** `bun run validate` green; the 5 new validator tests cover the warn/no-warn/script-exempt cases; confirmed no test or CI check asserts zero validation **warnings** on bundled defaults (so the new advisory warning doesn't break anything).
- **Not verified:** I did not also rewrite the double-quoting inside the bundled default workflows — they'll surface this warning, but fixing each (distinguishing real footguns from intentional interpolation) is out of scope here.

## Side Effects / Blast Radius (required)
- Affected: `bun run cli validate workflows` now emits a warning for bash nodes with double-quoted output refs. No execution path changes.
- Monitoring: the warning text + hint point authors at the unquoted idiom.

## Rollback Plan (required)
- `git revert <merge>` — single self-contained commit; removes the validator warning + docs.
- No flags/migrations.

## Risks and Mitigations
- **Risk:** the regex `"[^"\n]*\$\w[\w-]*\.output` could flag a legitimately-double-quoted interpolation.
  - **Mitigation:** in `bash:` nodes pre-quoting makes double-quoting wrong in both the assignment and the `echo "...$x.output..."` cases (you'd see the literal `'value'`), so flagging both is correct; it's a warning, not an error; `script:` nodes (raw, unquoted substitution) are exempt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a validation warning that detects and warns when outputs injected into bash contexts are double-quoted (applies to bash nodes and loop until-conditions).

* **Documentation**
  * Added a caution note and expanded guidance on shell quoting, showing correct vs incorrect usage and clarifying behavior for small vs large outputs.

* **Tests**
  * Added/extended tests covering the new double-quote lint across bash and loop scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->