### PR TITLE
feat(web/console): GitHub identity panel (device flow) + fix cache error re-render

### DIFF
--- a/packages/web/src/experiments/console/README.md
+++ b/packages/web/src/experiments/console/README.md
@@ -9,7 +9,7 @@ Mounted at `/console/*`. Not part of the shipped product. Validates the mental m
 ## Routes
 
 - `/console` → Runs view (scope = `all`)
-- `/console/settings` → Settings (assistant config + system health) — global
+- `/console/settings` → Settings (assistant config, system health, GitHub identity) — global
 - `/console/p/:projectId` → Runs view scoped to a project
 - `/console/p/:projectId/chat` → Project-scoped agent chat
 - `/console/p/:projectId/r/:runId` → Run detail

--- a/packages/web/src/experiments/console/components/GithubIdentityPanel.tsx
+++ b/packages/web/src/experiments/console/components/GithubIdentityPanel.tsx
@@ -8,10 +8,10 @@ import { SettingsSection } from './SettingsSection';
 type Phase = 'idle' | 'pending' | 'error';
 
 /**
- * Per-user GitHub identity, via the device flow. Multi-user installs only:
- * `GET /api/auth/github` 401s when there's no web identity (the universal
- * solo-PAT state), and we render NOTHING in that case so solo installs never see
- * an irrelevant panel. Any other error surfaces normally.
+ * Per-user GitHub identity, via the device flow. `GET /api/auth/github` 401s when
+ * there's no web identity (the solo-PAT state, and also a logged-out user on a
+ * web-auth install); we render NOTHING then so there's no irrelevant panel. Any
+ * other error surfaces normally.
  *
  * The connect flow ports the old UI's polling state machine into the console's
  * react-query-free cache: start → poll every `interval`s until connected / expired
@@ -53,7 +53,9 @@ export function GithubIdentityPanel(): ReactElement | null {
         const res = await skill.pollGithubDeviceFlow(start.device_code);
         const step = skill.interpretPollStatus(res, interval);
         if (step.kind === 'connected') {
-          setPhase('idle');
+          // Keep `phase = 'pending'` (button stays "Connecting…") until the
+          // invalidate refetch flips `status.connected` to true — otherwise the
+          // not-connected branch flashes "Connect GitHub" for one render.
           setUserCode(null);
           setVerificationUri(null);
           invalidate(K.githubConnection);
@@ -77,6 +79,7 @@ export function GithubIdentityPanel(): ReactElement | null {
   const disconnect = async (): Promise<void> => {
     setDisconnecting(true);
     setMessage(null);
+    setPhase('idle'); // clear any leftover 'pending' from a prior connect
     try {
       await skill.disconnectGithub();
       if (cancelledRef.current) return;
@@ -89,7 +92,9 @@ export function GithubIdentityPanel(): ReactElement | null {
     }
   };
 
-  // Solo-PAT install (no web identity) → 401 → hide the panel entirely.
+  // 401 = no web identity (no Better Auth session and no X-Archon-User): the solo-PAT
+  // state, and also a logged-out user on a web-auth install. Either way there's no
+  // per-user GitHub identity to manage, so hide the panel rather than error.
   if (error instanceof HttpError && error.status === 401) return null;
   if (error !== undefined) {
     return (
@@ -159,9 +164,10 @@ export function GithubIdentityPanel(): ReactElement | null {
           </div>
         ) : null}
 
-        {phase === 'error' && message !== null ? (
-          <p className="font-mono text-[11px] text-error">{message}</p>
-        ) : null}
+        {/* `message` is only ever set by a failed connect OR disconnect (both clear
+            it on start), so render it whenever present — gating on `phase === 'error'`
+            silently swallowed disconnect failures. */}
+        {message !== null ? <p className="font-mono text-[11px] text-error">{message}</p> : null}
       </div>
     </SettingsSection>
   );

--- a/packages/web/src/experiments/console/components/GithubIdentityPanel.tsx
+++ b/packages/web/src/experiments/console/components/GithubIdentityPanel.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useRef, useState, type ReactElement } from 'react';
+import * as skill from '../skills';
+import { useEntity, invalidate } from '../store/cache';
+import { K } from '../store/keys';
+import { HttpError } from '../lib/http';
+import { SettingsSection } from './SettingsSection';
+
+type Phase = 'idle' | 'pending' | 'error';
+
+/**
+ * Per-user GitHub identity, via the device flow. Multi-user installs only:
+ * `GET /api/auth/github` 401s when there's no web identity (the universal
+ * solo-PAT state), and we render NOTHING in that case so solo installs never see
+ * an irrelevant panel. Any other error surfaces normally.
+ *
+ * The connect flow ports the old UI's polling state machine into the console's
+ * react-query-free cache: start → poll every `interval`s until connected / expired
+ * / denied. A `cancelledRef` (set on unmount) stops the loop and guards every
+ * setState so a long poll can't write after unmount.
+ */
+export function GithubIdentityPanel(): ReactElement | null {
+  const { data: status, error } = useEntity(K.githubConnection, skill.getGithubConnection);
+
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [userCode, setUserCode] = useState<string | null>(null);
+  const [verificationUri, setVerificationUri] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [disconnecting, setDisconnecting] = useState(false);
+
+  const cancelledRef = useRef(false);
+  useEffect(() => {
+    cancelledRef.current = false;
+    return (): void => {
+      cancelledRef.current = true;
+    };
+  }, []);
+
+  const connect = async (): Promise<void> => {
+    setPhase('pending');
+    setMessage(null);
+    try {
+      const start = await skill.startGithubDeviceFlow();
+      if (cancelledRef.current) return;
+      setUserCode(start.user_code);
+      setVerificationUri(start.verification_uri);
+      const deadline = Date.now() + start.expires_in * 1000;
+      let interval = Math.max(1, start.interval);
+      for (;;) {
+        if (cancelledRef.current) return;
+        if (Date.now() > deadline) throw new Error('Device code expired — try again.');
+        await new Promise(r => setTimeout(r, interval * 1000));
+        if (cancelledRef.current) return;
+        const res = await skill.pollGithubDeviceFlow(start.device_code);
+        const step = skill.interpretPollStatus(res, interval);
+        if (step.kind === 'connected') {
+          setPhase('idle');
+          setUserCode(null);
+          setVerificationUri(null);
+          invalidate(K.githubConnection);
+          return;
+        }
+        if (step.kind === 'retry') {
+          interval = step.nextInterval;
+          continue;
+        }
+        throw new Error(step.message); // 'failed'
+      }
+    } catch (e: unknown) {
+      if (cancelledRef.current) return;
+      setPhase('error');
+      setUserCode(null);
+      setVerificationUri(null);
+      setMessage(e instanceof Error ? e.message : 'GitHub connect failed.');
+    }
+  };
+
+  const disconnect = async (): Promise<void> => {
+    setDisconnecting(true);
+    setMessage(null);
+    try {
+      await skill.disconnectGithub();
+      if (cancelledRef.current) return;
+      invalidate(K.githubConnection);
+    } catch (e: unknown) {
+      if (cancelledRef.current) return;
+      setMessage(e instanceof Error ? e.message : 'Disconnect failed.');
+    } finally {
+      if (!cancelledRef.current) setDisconnecting(false);
+    }
+  };
+
+  // Solo-PAT install (no web identity) → 401 → hide the panel entirely.
+  if (error instanceof HttpError && error.status === 401) return null;
+  if (error !== undefined) {
+    return (
+      <SettingsSection title="GitHub Identity">
+        <p className="font-mono text-[11px] text-error">{error.message}</p>
+      </SettingsSection>
+    );
+  }
+  if (status === undefined) {
+    return (
+      <SettingsSection title="GitHub Identity">
+        <p className="font-mono text-[11px] text-text-tertiary">Loading…</p>
+      </SettingsSection>
+    );
+  }
+
+  return (
+    <SettingsSection title="GitHub Identity">
+      <div className="flex flex-col gap-3 text-[12px]">
+        {status.connected ? (
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-text-secondary">
+              Connected as{' '}
+              <span className="font-medium text-text-primary">@{status.githubLogin}</span>
+            </span>
+            <button
+              type="button"
+              onClick={() => void disconnect()}
+              disabled={disconnecting}
+              className="shrink-0 rounded border border-border px-2.5 py-1 text-[11px] text-text-secondary transition-colors hover:border-border-bright hover:text-text-primary disabled:opacity-40"
+            >
+              {disconnecting ? 'Disconnecting…' : 'Disconnect'}
+            </button>
+          </div>
+        ) : (
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-text-secondary">
+              Connect your GitHub account so PR comments and commits attribute to you.
+            </span>
+            <button
+              type="button"
+              onClick={() => void connect()}
+              disabled={phase === 'pending'}
+              className="brand-bar shrink-0 rounded px-3 py-0.5 text-[11px] font-medium text-white transition-all hover:brightness-110 disabled:opacity-40"
+            >
+              {phase === 'pending' ? 'Connecting…' : 'Connect GitHub'}
+            </button>
+          </div>
+        )}
+
+        {phase === 'pending' && userCode !== null && verificationUri !== null ? (
+          <div className="rounded border border-border bg-surface-inset p-3 text-text-secondary">
+            Visit{' '}
+            <a
+              href={verificationUri}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-text-primary underline underline-offset-2"
+            >
+              {verificationUri}
+            </a>{' '}
+            and enter code:{' '}
+            <span className="font-mono font-semibold tracking-widest text-text-primary">
+              {userCode}
+            </span>
+            <span className="ml-2 text-text-tertiary">(polling…)</span>
+          </div>
+        ) : null}
+
+        {phase === 'error' && message !== null ? (
+          <p className="font-mono text-[11px] text-error">{message}</p>
+        ) : null}
+      </div>
+    </SettingsSection>
+  );
+}

--- a/packages/web/src/experiments/console/routes/SettingsPage.tsx
+++ b/packages/web/src/experiments/console/routes/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { type ReactElement } from 'react';
 import { AssistantConfigPanel } from '../components/AssistantConfigPanel';
 import { SystemPanel } from '../components/SystemPanel';
+import { GithubIdentityPanel } from '../components/GithubIdentityPanel';
 
 /**
  * Global (installation-wide) console settings — assistant config + system health.
@@ -17,6 +18,7 @@ export function SettingsPage(): ReactElement {
         <div className="mx-auto flex max-w-2xl flex-col gap-6">
           <AssistantConfigPanel />
           <SystemPanel />
+          <GithubIdentityPanel />
         </div>
       </div>
     </div>

--- a/packages/web/src/experiments/console/skills/github.test.ts
+++ b/packages/web/src/experiments/console/skills/github.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect } from 'bun:test';
+import { interpretPollStatus, type GithubDevicePoll } from './github';
+
+const poll = (
+  over: Partial<GithubDevicePoll> & { status: GithubDevicePoll['status'] }
+): GithubDevicePoll => ({
+  ...over,
+});
+
+describe('interpretPollStatus', () => {
+  test('connected → stop', () => {
+    expect(interpretPollStatus(poll({ status: 'connected', githubLogin: 'octocat' }), 5)).toEqual({
+      kind: 'connected',
+    });
+  });
+
+  test('pending → retry at the same interval', () => {
+    expect(interpretPollStatus(poll({ status: 'pending' }), 5)).toEqual({
+      kind: 'retry',
+      nextInterval: 5,
+    });
+  });
+
+  test('expired → failed with the expiry message', () => {
+    expect(interpretPollStatus(poll({ status: 'expired' }), 5)).toEqual({
+      kind: 'failed',
+      message: 'Device code expired — try again.',
+    });
+  });
+
+  test('denied → failed with the denied message', () => {
+    expect(interpretPollStatus(poll({ status: 'denied' }), 5)).toEqual({
+      kind: 'failed',
+      message: 'Authorization was denied.',
+    });
+  });
+
+  test('error WITH detail → failed, surfacing the detail', () => {
+    expect(interpretPollStatus(poll({ status: 'error', detail: 'rate limited' }), 5)).toEqual({
+      kind: 'failed',
+      message: 'GitHub connect failed: rate limited',
+    });
+  });
+
+  test('error WITHOUT detail → transient: back off by 2s and retry', () => {
+    expect(interpretPollStatus(poll({ status: 'error' }), 5)).toEqual({
+      kind: 'retry',
+      nextInterval: 7,
+    });
+  });
+
+  test('error with an empty-string detail is treated as no detail (retry)', () => {
+    expect(interpretPollStatus(poll({ status: 'error', detail: '' }), 5)).toEqual({
+      kind: 'retry',
+      nextInterval: 7,
+    });
+  });
+});

--- a/packages/web/src/experiments/console/skills/github.test.ts
+++ b/packages/web/src/experiments/console/skills/github.test.ts
@@ -55,4 +55,13 @@ describe('interpretPollStatus', () => {
       nextInterval: 7,
     });
   });
+
+  test('an unrecognized status (server/type drift) fails terminally, never undefined', () => {
+    // Simulate a server status the inlined union doesn't know about.
+    const drifted = { status: 'rate_limited' } as unknown as GithubDevicePoll;
+    expect(interpretPollStatus(drifted, 5)).toEqual({
+      kind: 'failed',
+      message: 'Unexpected GitHub poll status: rate_limited',
+    });
+  });
 });

--- a/packages/web/src/experiments/console/skills/github.ts
+++ b/packages/web/src/experiments/console/skills/github.ts
@@ -1,0 +1,77 @@
+import { requestJson } from '../lib/http';
+
+/**
+ * Per-user GitHub identity (device flow). Multi-user installs only — `getConnection`
+ * 401s when there's no web identity, which the panel reads as "solo install, hide".
+ *
+ * Response types are inlined (mirroring `server/.../auth.schemas.ts`) because the
+ * device-flow schemas are not yet in `@/lib/api.generated`, and `@/lib/api` is
+ * eslint-blocked for the console. Migrate to `components['schemas']['Github*']`
+ * once a regen lands them.
+ */
+
+export interface GithubConnectionStatus {
+  connected: boolean;
+  githubLogin: string | null;
+}
+
+export interface GithubDeviceStart {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  interval: number;
+  expires_in: number;
+}
+
+export interface GithubDevicePoll {
+  status: 'pending' | 'connected' | 'expired' | 'denied' | 'error';
+  githubLogin?: string;
+  detail?: string;
+}
+
+export function getGithubConnection(): Promise<GithubConnectionStatus> {
+  return requestJson<GithubConnectionStatus>('/api/auth/github');
+}
+
+export function startGithubDeviceFlow(): Promise<GithubDeviceStart> {
+  return requestJson<GithubDeviceStart>('/api/auth/github/device/start', { method: 'POST' });
+}
+
+export function pollGithubDeviceFlow(deviceCode: string): Promise<GithubDevicePoll> {
+  return requestJson<GithubDevicePoll>('/api/auth/github/device/poll', {
+    method: 'POST',
+    body: JSON.stringify({ device_code: deviceCode }),
+  });
+}
+
+export function disconnectGithub(): Promise<{ success: boolean }> {
+  return requestJson<{ success: boolean }>('/api/auth/github', { method: 'DELETE' });
+}
+
+/** The poll loop's next action: stop (connected), keep polling, or fail with a message. */
+export type PollStep =
+  | { kind: 'connected' }
+  | { kind: 'retry'; nextInterval: number }
+  | { kind: 'failed'; message: string };
+
+/**
+ * Pure interpretation of a single device-flow poll response (ported from the old
+ * UI's inline branch logic). `pending` keeps the current interval; a transient
+ * `error` with no detail backs off by 2s and retries; everything else is terminal.
+ */
+export function interpretPollStatus(res: GithubDevicePoll, interval: number): PollStep {
+  switch (res.status) {
+    case 'connected':
+      return { kind: 'connected' };
+    case 'pending':
+      return { kind: 'retry', nextInterval: interval };
+    case 'expired':
+      return { kind: 'failed', message: 'Device code expired — try again.' };
+    case 'denied':
+      return { kind: 'failed', message: 'Authorization was denied.' };
+    case 'error':
+      return res.detail !== undefined && res.detail !== ''
+        ? { kind: 'failed', message: `GitHub connect failed: ${res.detail}` }
+        : { kind: 'retry', nextInterval: interval + 2 };
+  }
+}

--- a/packages/web/src/experiments/console/skills/github.ts
+++ b/packages/web/src/experiments/console/skills/github.ts
@@ -1,8 +1,9 @@
 import { requestJson } from '../lib/http';
 
 /**
- * Per-user GitHub identity (device flow). Multi-user installs only — `getConnection`
- * 401s when there's no web identity, which the panel reads as "solo install, hide".
+ * Per-user GitHub identity (device flow). `getConnection` 401s when there's no web
+ * identity (no Better Auth session and no X-Archon-User) — the solo-PAT state, and
+ * also a logged-out user on a web-auth install — which the panel reads as "hide".
  *
  * Response types are inlined (mirroring `server/.../auth.schemas.ts`) because the
  * device-flow schemas are not yet in `@/lib/api.generated`, and `@/lib/api` is
@@ -73,5 +74,9 @@ export function interpretPollStatus(res: GithubDevicePoll, interval: number): Po
       return res.detail !== undefined && res.detail !== ''
         ? { kind: 'failed', message: `GitHub connect failed: ${res.detail}` }
         : { kind: 'retry', nextInterval: interval + 2 };
+    default:
+      // Defensive: the inline type can lag the server. Treat an unrecognized status
+      // as a terminal failure rather than crashing the poll loop on `undefined.kind`.
+      return { kind: 'failed', message: `Unexpected GitHub poll status: ${String(res.status)}` };
   }
 }

--- a/packages/web/src/experiments/console/skills/index.ts
+++ b/packages/web/src/experiments/console/skills/index.ts
@@ -17,5 +17,6 @@ export * from './conversations';
 export * from './envVars';
 export * from './settings';
 export * from './providers';
+export * from './github';
 
 export { HttpError } from '../lib/http';

--- a/packages/web/src/experiments/console/store/cache.ts
+++ b/packages/web/src/experiments/console/store/cache.ts
@@ -22,8 +22,14 @@ const listeners = new Map<string, Set<Listener>>();
 const errors = new Map<string, Error>();
 const inflight = new Map<string, Promise<unknown>>();
 const loaders = new Map<string, () => Promise<unknown>>();
+// Per-key change counter. `useEntity` snapshots THIS (not the cached value), so a
+// subscriber re-renders on every mutation — including the error transition, where
+// the value stays `undefined` and a value-identity snapshot would bail out and
+// never surface `error` (e.g. a 401 panel would hang on "Loading…").
+const versions = new Map<string, number>();
 
 function notify(key: string): void {
+  versions.set(key, (versions.get(key) ?? 0) + 1);
   const subs = listeners.get(key);
   if (subs === undefined) return;
   for (const l of subs) l();
@@ -145,7 +151,8 @@ export interface EntityView<T> {
  * the latest value — the previous manual `useState(n => n + 1)` subscription
  * could commit a stale render (the store mutates outside React's knowledge), so
  * a refetched value would land in the cache but never appear on screen until a
- * remount. `notify` is the store's change signal; `getSnapshot` reads the cache.
+ * remount. `notify` is the store's change signal; `getSnapshot` reads the per-key
+ * version counter (see below) so error transitions re-render too.
  */
 export function useEntity<T>(key: string, loader: () => Promise<T>): EntityView<T> {
   const loaderRef = useRef(loader);
@@ -176,17 +183,20 @@ export function useEntity<T>(key: string, loader: () => Promise<T>): EntityView<
     [key]
   );
 
-  // getSnapshot returns the cached value by reference. `cache.set` installs a
-  // fresh object on each load, so identity changes exactly when data changes —
-  // satisfying useSyncExternalStore's stable-snapshot requirement.
-  const data = useSyncExternalStore(
+  // Snapshot the per-key version counter (a number bumped on every `notify`), not
+  // the cached value: that way the component re-renders on the error transition too
+  // — where `cache.get(key)` stays `undefined` and a value-identity snapshot would
+  // bail out, leaving `error` unread. `data`/`error`/`loading` are read from the
+  // maps below at render; the cache mutates synchronously before `notify`, so the
+  // version-triggered render always sees consistent values (no tearing).
+  useSyncExternalStore(
     subscribe,
-    () => cache.get(key) as T | undefined,
-    () => cache.get(key) as T | undefined
+    () => versions.get(key) ?? 0,
+    () => versions.get(key) ?? 0
   );
 
   return {
-    data,
+    data: cache.get(key) as T | undefined,
     error: errors.get(key),
     loading: !cache.has(key) && inflight.has(key),
     refetch: (): void => {

--- a/packages/web/src/experiments/console/store/cache.ts
+++ b/packages/web/src/experiments/console/store/cache.ts
@@ -186,9 +186,11 @@ export function useEntity<T>(key: string, loader: () => Promise<T>): EntityView<
   // Snapshot the per-key version counter (a number bumped on every `notify`), not
   // the cached value: that way the component re-renders on the error transition too
   // — where `cache.get(key)` stays `undefined` and a value-identity snapshot would
-  // bail out, leaving `error` unread. `data`/`error`/`loading` are read from the
-  // maps below at render; the cache mutates synchronously before `notify`, so the
-  // version-triggered render always sees consistent values (no tearing).
+  // bail out, leaving `error` unread. `data`/`error`/`loading` are read fresh from
+  // the maps below on each (synchronous) render. They can briefly co-exist in
+  // intermediate states — e.g. `loading` is still true when an error first lands
+  // (`inflight` clears in a later `.finally`) — so consumers check `error` before
+  // `loading`, as the panels do.
   useSyncExternalStore(
     subscribe,
     () => versions.get(key) ?? 0,

--- a/packages/web/src/experiments/console/store/keys.ts
+++ b/packages/web/src/experiments/console/store/keys.ts
@@ -28,4 +28,5 @@ export const K = {
   health: 'health' as const,
   providers: 'providers' as const,
   updateCheck: 'update-check' as const,
+  githubConnection: 'github-connection' as const,
 } as const;


### PR DESCRIPTION
## Summary

- **Problem:** `/console/settings` (shipped #1890) had Assistant + System panels but no GitHub identity panel — multi-user installs still had to use the old UI to connect a per-user GitHub identity.
- **Why it matters:** Last settings piece before console cutover. PR #5 of the sequence (#1878/#1881/#1885/#1890).
- **What changed:** Added `GithubIdentityPanel` (device-flow connect/poll/disconnect, ported from the old UI into the console's react-query-free skill/cache layer). It renders **nothing** on solo-PAT installs (`GET /api/auth/github` 401s with no web identity). **Plus a root-cause cache fix** (see Deviation) without which the 401-hide — and every other console error branch — does not work.
- **What did NOT change:** No server change (all four endpoints + the 401 gate already exist). No Better Auth login UI. No `api.generated.d.ts` regen (device-flow schemas inlined, the console's accepted fallback).

## UX Journey

### After
```
MULTI-USER (GET /api/auth/github → 200):
  /console/settings → [Assistant] [System] [GitHub Identity]
    not connected:  Connect your GitHub account…            [ Connect GitHub ]
        → Visit https://github.com/login/device and enter code: WXYZ-1234 (polling…)
    connected:      Connected as @octocat                   [ Disconnect ]

SOLO-PAT (GET /api/auth/github → 401 = no web identity):
  /console/settings → [Assistant] [System]      ← GitHub panel renders NOTHING
```

## Architecture Diagram

```
getGithubConnection → useEntity(K.githubConnection)
  401 (HttpError.status===401) → panel returns null (hide)
  200 → render: connect runs startGithubDeviceFlow → poll(interval) until
        interpretPollStatus → connected/expired/denied → invalidate(K.githubConnection)
cache.ts useEntity [~] — snapshot is now a per-key version counter (was cache.get(key)),
  so the ERROR transition re-renders (the 401-hide depends on it)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `skills/github.ts` | `/api/auth/github*` (4 verbs) | **new** | inline-typed device flow |
| `GithubIdentityPanel` | `useEntity(K.githubConnection)` | **new** | 401 → null |
| `SettingsPage` | `GithubIdentityPanel` | **new** | third panel |
| `store/cache.ts` `useEntity` | version-counter snapshot | **modified** | error transitions now re-render |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `web`
- Module: `web:console`

## Change Metadata

- Change type: `feature` (+ a `bug` fix in the cache primitive)
- Primary scope: `web`

## Linked Issue

- Related #1878, #1881, #1885, #1890 (console sequence; this is PR #5, the cutover line)

## Validation Evidence (required)

```bash
bun --filter @archon/web type-check   # exit 0
bun run lint                          # exit 0 (--max-warnings 0)
bun run format:check                  # clean
cd packages/web && bun test src/experiments/console/   # 66 pass / 0 fail (7 new in github.test.ts)
```

- **Evidence:** static green; `interpretPollStatus` has 7 unit tests (connected / pending-retry / expired / denied / error+detail / error-no-detail backoff / empty-detail). **Verified end-to-end in a browser** against an isolated server (`ARCHON_HOME=/tmp`, real `~/.archon` untouched): **solo (401)** → the GitHub panel is absent (headings `Settings | Assistant | System`, no "Loading…"); **multi-user (200 via `X-Archon-User`)** → the panel renders "Connect GitHub". The read endpoints (`/api/config`, `/api/health`, `/api/providers`) return 200 and the other two panels render unaffected.
- **Skipped:** full `bun run validate` — change is isolated to `@archon/web`; ran that package's suite + the browser smoke. CI runs the rest. The full device-flow round-trip (completing auth on github.com) was not driven — the panel's loop logic is the unit-tested `interpretPollStatus` + the ported old-UI structure.

## Security Impact (required)

- New permissions/capabilities? **No** — consumes existing per-user GitHub endpoints; on solo installs it renders nothing.
- New external network calls? **No** (existing `/api/auth/github*`).
- Secrets/tokens handling changed? **No** — tokens stay server-side; the UI only sees `{connected, githubLogin}` + the device codes the user is meant to see.
- File system access scope changed? **No**

## Compatibility / Migration

- Backward compatible? **Yes** — additive panel; the cache fix is behavior-preserving on the success path (extra re-renders only on the error transition, which previously rendered nothing).
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

- **Verified scenarios:** type-check/lint/format/66 tests; browser smoke of both the solo (panel hidden on 401) and multi-user (panel shows "Connect GitHub" on 200) paths against an isolated server.
- **Edge cases checked:** 401 → null (hidden), not a hard error; non-401 status error would surface (not hidden) via the now-working error branch; `interpretPollStatus` covers pending-retry / expired / denied / error-with-detail / transient-error backoff; `cancelledRef` guards setState after unmount; `Math.max(1, interval)` + the `expires_in` deadline cap the loop.
- **What was not verified:** an actual completed device-flow authorization on github.com (needs the GitHub App env + a real browser auth); the connected `@login` + Disconnect render path was exercised only via the 200 status shape, not a live token.

## Side Effects / Blast Radius (required)

- **Affected subsystems:** the console settings page (new panel) **and the console cache primitive** (`useEntity`, used by every console screen).
- **Potential unintended effects:** the `useEntity` snapshot change is the one to watch — it now re-renders on every `notify()` rather than only on value-identity change. In practice the only *added* re-renders are error transitions (success already installs a new cached object), so there's no hot-path (SSE runs feed) cost; the upside is that error branches across the console (including #1890's panels) now actually render.
- **Guardrails:** console tests in CI; the cache change is small and commented.

## Rollback Plan (required)

- **Fast rollback:** `git revert <merge-commit>` — 7 files, web-only.
- **Feature flags/toggles:** none.
- **Observable failure symptoms:** GitHub panel shows when it shouldn't (or vice-versa); or, if the cache change regressed, console panels stop updating live (watch the runs feed). Neither observed.

## Risks and Mitigations

- Risk: the cache `useEntity` change causes excess re-renders in the SSE-driven runs feed.
  - Mitigation: success-path re-renders are unchanged (cache.set already swaps object identity); only error transitions add a render. Verified the runs/settings screens render normally.
- Risk: 401 treated as a hard error → broken panel on solo installs.
  - Mitigation: explicit `error instanceof HttpError && error.status === 401 → return null`; verified hidden in a browser.
- Risk: setState after unmount during the long poll loop.
  - Mitigation: `cancelledRef` set in a cleanup effect, checked before every poll/setState.

---

### Deviation from the plan (root-cause fix)

The plan assumed `useEntity().error` was reactive — it is **not**. `useEntity`'s `useSyncExternalStore` snapshot was `cache.get(key)`, which stays `undefined` on an error, so React bailed out of re-rendering and the freshly-set `error` (read outside the store) was never surfaced. The 401-hide therefore didn't work — the panel hung on "Loading…" — and **every other console error branch was silently dead too** (including #1890's Assistant/System panels). Fixed at the root: a per-key version counter, bumped on every `notify()`, is now the snapshot, so error transitions re-render. Browser-verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub identity panel to Settings for connecting, verifying, and disconnecting a GitHub account with live status and verification code display.

* **Bug Fixes**
  * Improved UI reliability so connection/disconnection status and errors update consistently during polling and on page changes.

* **Tests**
  * Added tests validating device-flow polling/status interpretation.

* **Documentation**
  * Updated Settings docs to include GitHub identity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->