### PR TITLE
Add Archon learning curriculum docs

### DIFF
--- a/packages/docs-web/astro.config.mjs
+++ b/packages/docs-web/astro.config.mjs
@@ -48,6 +48,10 @@ export default defineConfig({
           autogenerate: { directory: 'reference' },
         },
         {
+          label: 'Learning',
+          autogenerate: { directory: 'learning' },
+        },
+        {
           label: 'Contributing',
           autogenerate: { directory: 'contributing' },
         },

--- a/packages/docs-web/src/content.config.ts
+++ b/packages/docs-web/src/content.config.ts
@@ -30,6 +30,7 @@ export const collections = {
          * - adapters: Platform adapter setup (Slack, Telegram, GitHub, Discord, Web)
          * - deployment: Running in production (Docker, cloud, Windows)
          * - reference: Technical reference (architecture, CLI, commands, database, API)
+         * - learning: Tutorial, curriculum, and workshop material
          * - contributing: Developer guides (internals, DX, releasing, testing)
          */
         category: z
@@ -39,6 +40,7 @@ export const collections = {
             'adapters',
             'deployment',
             'reference',
+            'learning',
             'contributing',
             'book',
           ])

--- a/packages/docs-web/src/content/docs/index.mdx
+++ b/packages/docs-web/src/content/docs/index.mdx
@@ -63,4 +63,13 @@ Archon is a **workflow engine for AI coding agents**. Define multi-step developm
   <Card title="Multi-provider" icon="rocket">
     Works with Claude Code SDK and Codex SDK
   </Card>
+  <Card title="Learn Archon" icon="open-book">
+    Follow the practical tutorial and curriculum from first install to supervised PR
+  </Card>
 </CardGrid>
+
+## Learn Archon
+
+- [Curriculum Package Map](/learning/package-map/) -- every learning asset and when to use it.
+- [Quick-Start Paths](/learning/quick-start-paths/) -- short routes for solo learners, facilitators, team leads, operators, maintainers, and blocked learners.
+- [Practical Tutorial](/learning/practical-tutorial/) -- a source-backed path from install to supervised issue-to-PR workflows.

--- a/packages/docs-web/src/content/docs/learning/capstone-assessment.md
+++ b/packages/docs-web/src/content/docs/learning/capstone-assessment.md
@@ -1,0 +1,126 @@
+---
+title: Capstone Assessment
+description: Capstone options, deliverables, scoring rubric, and sign-off questions for Archon learners.
+category: learning
+audience: [user, operator]
+status: current
+sidebar:
+  order: 5
+---
+
+Use a capstone to decide whether a learner is ready to use Archon on a real
+project with supervision. The goal is operating judgment, not memorizing command
+syntax.
+
+Use [Facilitator Evaluation](/learning/facilitator-evaluation/) to record the
+final score, red flags, sign-off boundary, and any remediation assignment.
+After a learner passes, use
+[Graduation Checklist](/learning/graduation-checklist/) and
+[Real Repository Transition](/learning/real-repository-transition/) to define
+the first supervised real-repository run.
+
+## Required Safety Boundary
+
+Every capstone starts with these rules:
+
+- Use a disposable repository or a low-risk training repository.
+- Keep secrets out of chat, shared notes, logs, artifacts, and diffs.
+- Use an isolated branch or worktree for modifying work.
+- Validate custom commands and workflows before running them.
+- Stop before autonomous merge or deployment.
+- Record the evidence used for the final decision.
+
+## Capstone Options
+
+| Option | Best for | Required outcome |
+| --- | --- | --- |
+| Local operator | Learners who will run existing workflows | Run a built-in workflow, inspect logs and artifacts, and write a run report. |
+| Workflow author | Learners who will create automation | Build a supervised Plan-Implement-Validate workflow with at least one approval gate. |
+| Provider router | Learners using multiple assistants | Verify a single-provider baseline, then route one node to another provider with a written reason. |
+| Model-role project operator | Learners using Claude/Codex for planning or testing and Gemini/Qwen/Kimi/Codex/Claude for inner development | Complete a guided project with explicit model roles, artifact handoffs, deterministic validation, and independent review. |
+| GitHub operator | Learners using issues and PRs | Prepare or create a supervised pull request from an issue and stop before merge. |
+| Team remote operator | Teams running Archon through GitHub, chat adapters, Docker, VPS, or a server | Verify runtime boundary, adapter exposure, health checks, logs, artifacts, rollback, and supervised workflow execution. |
+
+## Required Deliverables
+
+Every capstone must produce:
+
+- A run report.
+- The command or workflow definition used, if custom.
+- Relevant artifact paths or summaries.
+- Logs inspected.
+- Validation evidence.
+- A human decision: approve, reject, revise, or defer.
+- One operating-checklist update based on the run.
+
+GitHub capstones also require:
+
+- Issue or request reference.
+- Branch name.
+- PR link or PR-ready branch note.
+- Manual review notes.
+- Explicit statement that no autonomous merge was performed.
+
+Model-role capstones also require:
+
+- Planner provider and model.
+- Inner-development provider and verified model ID.
+- Reviewer or test-strategy provider.
+- Artifact passed across each model boundary.
+- Fallback provider or stop condition if the routed model is unavailable.
+- Explanation of why the chosen implementation model was appropriate.
+
+Team remote capstones also require:
+
+- Runtime location: local server, Docker, VPS, or simulated remote.
+- Enabled interface or adapter.
+- Allowed users or access boundary.
+- Secret-handling note.
+- Health check evidence.
+- Log and artifact locations.
+- Rollback or incident response note.
+
+## Scoring Rubric
+
+Score each category from 1 to 3. A score of 2 in every category is the minimum
+for supervised real-repository work. A score of 3 indicates the learner can help
+others.
+
+| Category | 1 - Needs practice | 2 - Ready with supervision | 3 - Strong operator |
+| --- | --- | --- | --- |
+| Safety boundary | Uses the sandbox inconsistently or exposes risky details. | Uses sandbox, protects secrets, and keeps approval gates. | Adjusts safety boundaries based on repository and task risk. |
+| Workflow execution | Can run a command only by following exact steps. | Runs workflows and finds status, logs, worktrees, and artifacts. | Diagnoses run state and explains evidence to others. |
+| Authoring | Creates unclear commands or workflows that depend on hidden assumptions. | Creates a narrow command and workflow with validation. | Designs clean artifact handoffs and rollback-friendly workflow shapes. |
+| Validation | Relies on model summaries. | Runs deterministic checks and records results. | Chooses validation that matches the risk and knows when evidence is incomplete. |
+| Approval | Approves or rejects without a clear reason. | Reviews plan and output before moving forward. | Gives actionable revision instructions at approval gates. |
+| Model-role routing | Routes by model preference or novelty. | Assigns models by node responsibility and verifies model IDs. | Designs fallback behavior and independent review for routed workflows. |
+| GitHub practice | Pushes or merges too early. | Prepares or creates a supervised PR and stops for review. | Produces a clear PR readiness note with residual risks. |
+| Team/server operation | Cannot explain where Archon runs or who can trigger it. | Defines runtime, adapter exposure, health checks, logs, and rollback. | Operates a supervised remote flow and records incident-ready evidence. |
+
+## Sign-Off Questions
+
+Before graduating a learner, ask:
+
+1. What repository would you use next, and why is it low risk enough?
+2. Which workflow will you run first, and what could it change?
+3. Where will artifacts and logs appear?
+4. What validation must pass before you trust the result?
+5. Where are secrets stored, and what should never be pasted into chat?
+6. What approval gate would make you reject or revise the run?
+7. What is your rollback path if the generated change is wrong?
+
+The learner does not need perfect answers. They need evidence-based answers and
+a willingness to stop when the evidence is weak.
+
+## Pass, Revise, Or Defer
+
+Use these outcomes:
+
+| Outcome | Meaning | Next step |
+| --- | --- | --- |
+| Pass | The learner met every safety and evidence requirement. | Move to supervised real-repository work. |
+| Revise | The workflow or report is close, but one decision or artifact needs correction. | Repeat the narrow failed section. |
+| Defer | Evidence is missing, secrets were mishandled, or the learner cannot explain the risk boundary. | Return to the relevant session and repeat the capstone later. |
+
+Do not graduate a learner by removing safety gates. Graduate them by showing
+they know which gates still matter and why.

--- a/packages/docs-web/src/content/docs/learning/cohort-report.md
+++ b/packages/docs-web/src/content/docs/learning/cohort-report.md
@@ -1,0 +1,113 @@
+---
+title: Cohort Report
+description: Report template for summarizing an Archon learning cohort after completion.
+category: learning
+audience: [operator]
+status: current
+sidebar:
+  order: 31
+---
+
+Use this report after a workshop or hybrid cohort. It records readiness,
+blockers, remediation, and curriculum improvements.
+
+## Cohort Summary
+
+```text
+Cohort name:
+Dates:
+Facilitators:
+Archon version or commit:
+Delivery mode: self-study support / workshop / hybrid
+Learner count:
+Completion count:
+Ready with supervision:
+Peer-ready:
+Remediation needed:
+Deferred:
+```
+
+## Curriculum Coverage
+
+```text
+Orientation completed:
+Setup completed:
+First workflow completed:
+Authoring completed:
+Plan-Implement-Validate completed:
+Provider routing completed:
+GitHub/operations completed:
+Capstone completed:
+```
+
+## Evidence Summary
+
+```text
+Run reports submitted:
+Workflow briefs submitted:
+Approval reviews submitted:
+PR readiness notes submitted:
+Capstone reports submitted:
+Graduation checklists completed:
+```
+
+## Common Blockers
+
+| Blocker | Count | Resolution | Curriculum change |
+| --- | --- | --- | --- |
+| Setup |  |  |  |
+| Provider auth |  |  |  |
+| Wrong repository |  |  |  |
+| Missing artifacts/logs |  |  |  |
+| Validation confusion |  |  |  |
+| GitHub readiness |  |  |  |
+
+## Outcome Review
+
+```text
+Strongest outcome:
+Weakest outcome:
+Most common remediation:
+Most useful exercise:
+Exercise to revise:
+Docs page to improve:
+```
+
+## Safety Review
+
+```text
+Secrets exposed: yes / no
+Unsafe real-repository attempt: yes / no
+Autonomous merge attempted: yes / no
+Approval gate skipped: yes / no
+Provider routing before baseline: yes / no
+Notes:
+```
+
+## Learner Readiness
+
+| Learner | Outcome | First real-repository recommendation | Follow-up |
+| --- | --- | --- | --- |
+|  | ready / peer-ready / remediation / deferred |  |  |
+
+## Facilitator Retrospective
+
+```text
+What worked:
+What confused learners:
+What took too long:
+What should be removed:
+What should be added:
+What source-backed claim needs review:
+What to change before the next cohort:
+```
+
+## Final Recommendation
+
+```text
+Recommended next cohort date:
+Recommended curriculum changes:
+Recommended team adoption step:
+Owner:
+Due date:
+```

--- a/packages/docs-web/src/content/docs/learning/cohort-runbook.md
+++ b/packages/docs-web/src/content/docs/learning/cohort-runbook.md
@@ -1,0 +1,158 @@
+---
+title: Cohort Runbook
+description: Operational runbook for preparing and running an Archon learning cohort.
+category: learning
+audience: [operator]
+status: current
+sidebar:
+  order: 8
+---
+
+Use this runbook when preparing a group training. It keeps operational details
+separate from the curriculum so the class can focus on learning Archon safely.
+
+Pair this runbook with [Workshop Session Plans](/learning/session-plans/),
+[Sandbox Setup Guide](/learning/sandbox-setup/), the
+[Instructor Notes](/learning/instructor-notes/),
+[Sample Artifacts](/learning/sample-artifacts/), the
+[Exercise Bank](/learning/exercise-bank/), and
+[Troubleshooting Labs](/learning/troubleshooting-labs/). Before teaching, run
+the [Publishing Checklist](/learning/publishing-checklist/).
+Use [Printable Checklist Pack](/learning/printable-checklists/) during live
+sessions.
+Use [Office Hours Guide](/learning/office-hours-guide/) for between-session
+support and [Remediation Playbook](/learning/remediation-playbook/) when
+learners miss completion signals.
+After the cohort, complete [Cohort Report](/learning/cohort-report/) and review
+[Curriculum Metrics](/learning/curriculum-metrics/).
+
+## Two Weeks Before
+
+- Choose the delivery track: self-study support, workshop, or hybrid.
+- Pick the installation path learners will use.
+- Choose the first assistant/provider and one fallback.
+- Decide whether GitHub authentication is required during the cohort.
+- Create a resettable sandbox repository.
+- Create a second sandbox repository with one prepared failure.
+- Confirm the Web UI can run on the target machines or provide a CLI-only
+  fallback.
+- Decide where learners will keep notes.
+- Publish the safety contract.
+
+## One Week Before
+
+- Verify the selected Archon version or commit.
+- Run the practical tutorial setup path on a clean machine.
+- Run one known-good workflow in the sandbox.
+- Prepare a sample plan artifact that should be approved.
+- Prepare a sample plan artifact that should be rejected.
+- Prepare a sanitized run log excerpt.
+- Prepare a sanitized PR readiness note.
+- Confirm no training material contains secrets.
+
+## One Day Before
+
+```text
+Archon version or commit:
+Install command or source path:
+Sandbox repository:
+Prepared failure repository:
+Known-good workflow:
+Known-good validation command:
+Web UI URL:
+Provider fallback:
+GitHub fallback:
+Support channel:
+```
+
+Send learners:
+
+- Session schedule.
+- Prerequisites.
+- Safety contract.
+- Prework reading.
+- Setup expectations.
+- What not to share.
+
+## During Each Session
+
+Use this operator loop:
+
+1. State the goal.
+2. Repeat the safety rule.
+3. Demo the happy path once.
+4. Put learners in the driver seat.
+5. Ask for evidence, not impressions.
+6. Record blockers with owners.
+7. Close with the next checklist update.
+
+## Blocker Triage
+
+| Blocker | Keep learner moving with | After-session fix |
+| --- | --- | --- |
+| CLI missing | Pair with another learner for evidence inspection | Fix PATH or install path |
+| Provider auth unavailable | Use read-only docs and workflow authoring exercises | Configure provider privately |
+| Web UI unavailable | Continue with CLI workflow status and logs | Resolve port or browser issue |
+| GitHub unavailable | Prepare PR-ready branch note instead of creating PR | Finish `gh auth` later |
+| Workflow fails | Inspect status, logs, artifacts, and config | Preserve evidence for review |
+
+## Cohort Dashboard
+
+```text
+Learner:
+Setup:
+First workflow:
+Run report:
+Custom command:
+Custom workflow:
+PIV:
+GitHub/PR:
+Capstone:
+Current blocker:
+Next action:
+```
+
+## Evidence Collection Policy
+
+Collect:
+
+- Run reports.
+- Workflow design briefs.
+- PR readiness notes.
+- Final operating checklists.
+- Sanitized screenshots only when they do not show secrets.
+
+Do not collect:
+
+- API keys.
+- OAuth tokens.
+- Provider auth files.
+- Full `.env` contents.
+- Raw logs that have not been inspected for secrets.
+
+## After The Cohort
+
+- Review capstone assessments.
+- Assign remediation where needed.
+- Decide which learners are ready for supervised real-repository work.
+- Archive sanitized examples.
+- Update the sandbox repositories.
+- Record curriculum corrections for the next cohort.
+
+## Retrospective Prompts
+
+Ask facilitators:
+
+1. Which setup step blocked the most learners?
+2. Which safety rule needed the most repetition?
+3. Which workflow produced the clearest learning evidence?
+4. Which exercise was too broad?
+5. Which docs page should be improved before the next cohort?
+6. Which capstone outcomes were deferred, and why?
+
+Ask learners:
+
+1. Where did Archon feel most useful?
+2. Where did you almost trust output without evidence?
+3. Which approval gate helped most?
+4. What do you still need before using Archon on a real repository?

--- a/packages/docs-web/src/content/docs/learning/curriculum-metrics.md
+++ b/packages/docs-web/src/content/docs/learning/curriculum-metrics.md
@@ -1,0 +1,109 @@
+---
+title: Curriculum Metrics
+description: Practical metrics for evaluating Archon curriculum effectiveness without encouraging unsafe behavior.
+category: learning
+audience: [operator]
+status: current
+sidebar:
+  order: 32
+---
+
+Use metrics to improve the curriculum, not to pressure learners into rushing.
+The safest metric is not "how fast did the model produce code." The safest
+metric is "did learners make evidence-backed decisions?"
+
+## Measurement Principles
+
+- Measure evidence quality.
+- Measure safety behavior.
+- Measure remediation needs.
+- Measure repeated blockers.
+- Do not reward skipped approval gates.
+- Do not reward autonomous merge during learning.
+
+## Recommended Metrics
+
+| Metric | Why it matters |
+| --- | --- |
+| Setup completion rate | Shows whether prerequisites and setup docs are clear. |
+| First workflow completion rate | Shows whether learners can run Archon safely. |
+| Run report completion rate | Shows whether learners inspect evidence. |
+| Approval rejection quality | Shows whether learners can stop vague plans. |
+| Validation recording rate | Shows whether deterministic checks are treated seriously. |
+| Capstone pass/revise/defer rate | Shows readiness distribution. |
+| Remediation completion rate | Shows whether support paths work. |
+| Secret-handling incidents | Shows safety risk. |
+| Wrong-repository incidents | Shows context and workflow-starting risk. |
+| PR readiness errors | Shows GitHub readiness gaps. |
+
+## Metrics To Avoid
+
+Avoid using:
+
+- Lines of code generated.
+- Number of workflows run without context.
+- Fastest completion time.
+- Number of PRs created.
+- Number of providers used.
+
+These can reward unsafe behavior if used without evidence quality.
+
+## Cohort Metrics Template
+
+```text
+Cohort:
+Learners:
+Setup completed:
+First workflow completed:
+Run reports completed:
+Custom commands/workflows completed:
+PIV exercises completed:
+Capstones passed:
+Capstones revised:
+Capstones deferred:
+Remediation assigned:
+Remediation completed:
+Secret incidents:
+Wrong-repository incidents:
+PR readiness issues:
+Most common blocker:
+Most useful curriculum page:
+Page needing revision:
+```
+
+## Evidence Quality Score
+
+Use this simple scale:
+
+| Score | Meaning |
+| --- | --- |
+| 1 | Evidence mostly repeats assistant claims. |
+| 2 | Evidence includes status, files, artifacts/logs, and validation. |
+| 3 | Evidence also names uncertainty, risk, decision, and rollback. |
+
+Use the score for coaching, not ranking.
+
+## Safety Signal Review
+
+After each cohort, ask:
+
+```text
+Did anyone expose secrets?
+Did anyone use a real repository too early?
+Did anyone skip isolation for modifying work?
+Did anyone approve a vague plan?
+Did anyone treat PR creation as merge readiness?
+Did anyone route providers before baseline?
+```
+
+Any "yes" should become a curriculum improvement or remediation assignment.
+
+## Improvement Loop
+
+1. Collect cohort report.
+2. Identify repeated blockers.
+3. Update FAQ, troubleshooting labs, or session plans.
+4. Re-run docs build.
+5. Record changes in maintenance notes.
+
+Metrics are useful only when they change the next cohort for the better.

--- a/packages/docs-web/src/content/docs/learning/curriculum.md
+++ b/packages/docs-web/src/content/docs/learning/curriculum.md
@@ -1,0 +1,708 @@
+---
+title: Archon Curriculum Guide
+description: Self-study, workshop, hybrid delivery, assessment, and capstone guidance for learning Archon safely.
+category: learning
+audience: [user, operator]
+status: current
+sidebar:
+  order: 2
+---
+
+This curriculum turns the Archon practical tutorial into a repeatable learning
+program for both self-study and facilitated workshops. The tutorial remains the
+lesson body. This guide tells you how to schedule it, teach it, assess it, and
+adapt it without losing the safety posture.
+
+## Reader And Outcome
+
+This guide is for two readers:
+
+- A self-study learner who wants a paced path from first install to supervised
+  issue-to-PR workflow.
+- A facilitator who wants to run Archon onboarding for a team without inventing
+  a workshop plan from scratch.
+
+After using this guide, you should be able to complete or teach the full Archon
+learning path, verify learner readiness, and decide what each learner should do
+next.
+
+## How To Use This Guide
+
+Choose one track first: self-study, workshop, or hybrid. Then use this guide as
+the schedule and assessment layer while the practical tutorial supplies the
+lesson content.
+
+For teaching-ready material, use the companion pages:
+
+- [Curriculum Package Map](/learning/package-map/) for a full inventory of the
+  learning bundle.
+- [Quick-Start Paths](/learning/quick-start-paths/) for short role-specific
+  routes through the curriculum.
+- [Curriculum Syllabus](/learning/syllabus/) for course-level framing,
+  schedule, assessment, and completion requirements.
+- [Reading Map](/learning/reading-map/) for role-based navigation through the
+  learning materials.
+- [Workshop Session Plans](/learning/session-plans/) for agendas, deliverables,
+  facilitator checks, and recovery patterns.
+- [Sandbox Setup Guide](/learning/sandbox-setup/) for preparing resettable
+  training repositories.
+- [Curriculum Templates](/learning/templates/) for journals, run reports,
+  workflow briefs, approval reviews, PR readiness notes, and preflight records.
+- [Capstone Assessment](/learning/capstone-assessment/) for final exercises,
+  scoring, and sign-off questions.
+- [Learner Workbook](/learning/learner-workbook/) for day-by-day learner notes
+  and evidence prompts.
+- [Facilitator Evaluation](/learning/facilitator-evaluation/) for scoring,
+  red flags, sign-off, and remediation.
+- [Cohort Runbook](/learning/cohort-runbook/) for preparing and operating a
+  group training.
+- [Instructor Notes](/learning/instructor-notes/) for teaching scripts,
+  facilitation patterns, and evidence-first questions.
+- [Sample Artifacts](/learning/sample-artifacts/) for secret-free examples of
+  acceptable learner evidence.
+- [Curriculum Glossary](/learning/glossary/) for shared vocabulary.
+- [Printable Checklist Pack](/learning/printable-checklists/) for compact live
+  session checklists.
+- [Knowledge Checks](/learning/knowledge-checks/) for unit questions and
+  scenario prompts.
+- [Slide Outline](/learning/slide-outline/) for creating workshop decks.
+- [Learner FAQ](/learning/faq/) for common learner questions.
+- [Publishing Checklist](/learning/publishing-checklist/) before running a live
+  cohort.
+- [Office Hours Guide](/learning/office-hours-guide/) for structured learner
+  support.
+- [Remediation Playbook](/learning/remediation-playbook/) for targeted recovery
+  when learners miss completion signals.
+- [Peer Review Practice](/learning/peer-review-practice/) for learner-to-learner
+  evidence review.
+- [Graduation Checklist](/learning/graduation-checklist/) for final readiness.
+- [Real Repository Transition](/learning/real-repository-transition/) for the
+  first supervised real-repository run.
+- [Team Adoption Path](/learning/team-adoption-path/) for rollout after
+  individual readiness.
+- [Learning Outcomes Matrix](/learning/outcomes-matrix/) for mapping skills to
+  evidence and remediation.
+- [Cohort Report](/learning/cohort-report/) and
+  [Curriculum Metrics](/learning/curriculum-metrics/) for post-cohort review.
+- [Exercise Bank](/learning/exercise-bank/) for extra practice and remediation.
+- [Troubleshooting Labs](/learning/troubleshooting-labs/) for prepared failure
+  scenarios.
+- [Provider Routing Lab](/learning/provider-routing-lab/) for multi-provider
+  practice after a single-provider baseline works.
+- [Model Role Recipes](/learning/model-role-recipes/) for practical guided
+  coding projects where Claude or Codex plans and reviews while Gemini, Qwen,
+  Kimi, Codex, or Claude handles inner development.
+
+For self-study, read the day row, complete the matching tutorial parts, run the
+exercise in a sandbox, and write the journal entry before moving on.
+
+For workshops, assign the tutorial parts before each session when possible, then
+use live time for setup, labs, evidence inspection, troubleshooting, and review.
+
+For hybrid delivery, move concepts into prework and keep live sessions focused
+on the places where learners are most likely to get blocked.
+
+## Curriculum Principles
+
+Teach Archon as a harness, not as one large prompt. Every session should connect
+AI work to deterministic process: isolated worktrees, explicit artifacts,
+validation commands, logs, and human approval gates.
+
+Keep learners on disposable repositories until they can explain the safety
+rules. Real project work comes after the capstone habits are visible.
+
+Prefer supported behavior over transcript-inspired experiments. Transcript
+material is useful for imagination, but official documentation and local
+validation decide what belongs in a lesson.
+
+## Learning Tracks
+
+| Track | Best for | Pace | Completion signal |
+| --- | --- | --- | --- |
+| Self-study | Individual users learning Archon locally | Seven focused days or two weekends | Learner completes the supervised GitHub capstone and writes a personal operating checklist. |
+| Workshop | Team onboarding, internal enablement, cohort training | Six sessions plus optional capstone lab | Participants can run, inspect, author, validate, and review supervised workflows in a sandbox. |
+| Hybrid | Teams with mixed schedules | Self-study prep plus live labs | Learners read concepts alone, then practice risky or confusing steps with a facilitator. |
+
+Use the same tutorial parts for all tracks. Change pacing, discussion, and
+assessment, not the underlying safety model.
+
+## Prerequisites
+
+Learners need:
+
+- Basic Git comfort: branches, commits, pull requests, and remotes.
+- A local development environment that can run Archon.
+- A disposable Git repository for all early exercises.
+- Access to the assistants or providers chosen for the class.
+- A place to record run notes, decisions, errors, and fixes.
+
+Facilitators additionally need:
+
+- A preflight checklist for each machine or workshop image.
+- A known-good sandbox repository that can be reset between sessions.
+- A policy for secrets, GitHub tokens, and provider authentication.
+- A fallback plan for learners who cannot use one provider during class.
+
+## Safety Contract
+
+Start every track by agreeing to these rules:
+
+- Do not paste API keys, OAuth tokens, provider auth files, or `.env` contents
+  into chat or shared notes.
+- Use a disposable repository for first runs and capstone rehearsals.
+- Use isolated branches or worktrees for any workflow that may change files.
+- Validate custom commands and workflows before running them.
+- Keep human approval before implementation, PR creation, and any production
+  step while learning.
+- Review generated pull requests manually. Do not teach autonomous merge as a
+  beginner behavior.
+
+If a learner breaks one of these rules, pause the curriculum and recover before
+continuing. The recovery is part of the lesson.
+
+## Self-Study Path
+
+The self-study path is designed as a careful first week. Faster learners can
+combine days, but should not skip the completion signal for each day.
+
+| Day | Tutorial parts | Focus | Completion signal |
+| --- | --- | --- | --- |
+| 1 | 0-1 | Harness model, vocabulary, starting path | Learner can explain why Archon uses workflows, artifacts, and approval gates. |
+| 2 | 2-3 | Install, verify, create sandbox | CLI and Web UI both work against the disposable repository. |
+| 3 | 4-5 | Built-in workflows, worktrees, artifacts, logs | Learner can run a safe workflow and find its run state, worktree, log, and artifact output. |
+| 4 | 6-7 | Custom command and custom YAML workflow | Learner validates one command and one workflow. |
+| 5 | 8 | Plan-Implement-Validate | Learner can explain which steps are AI reasoning, deterministic validation, and human decisions. |
+| 6 | 9-11 | Provider routing and GitHub | Learner can run single-provider workflows first, then prepare or create a supervised PR. |
+| 7 | 12-16 | Operations, troubleshooting, capstones, reference | Learner completes one capstone and writes a personal safe operating checklist. |
+
+### Daily Practice Loop
+
+Use this loop every day:
+
+1. Read the assigned tutorial parts.
+2. Run the smallest matching exercise in the sandbox.
+3. Record what ran, what changed, and what was verified.
+4. Fix one failure mode instead of starting over immediately.
+5. End by updating the learner's operating checklist.
+
+### Self-Study Journal Prompt
+
+After each day, write:
+
+```text
+Today's workflow or command:
+What I expected:
+What actually happened:
+Evidence I inspected:
+Safety rule I practiced:
+Question to revisit:
+```
+
+The journal is not busywork. It creates the habit of treating AI coding output
+as evidence to inspect, not magic to trust.
+
+## Workshop Path
+
+The workshop path assumes sessions of 90 to 120 minutes. For shorter sessions,
+split each lab from its discussion and assign the reading beforehand.
+
+| Session | Tutorial parts | Live goal | Facilitator checkpoint |
+| --- | --- | --- | --- |
+| 1. Orientation and safety | 0-1 | Build the shared mental model and choose the safe starting path. | Every participant can explain the safety contract and identify the sandbox repository. |
+| 2. Local setup lab | 2-3 | Install, verify, and connect CLI/Web UI to the sandbox. | Everyone reaches a working health check or has a documented blocker. |
+| 3. First workflow lab | 4-5 | Run built-in workflows and inspect isolation, logs, and artifacts. | Participants can show evidence from a run without exposing secrets. |
+| 4. Authoring lab | 6-7 | Create and validate one command and one YAML workflow. | Each participant has a valid reusable command or workflow in the sandbox. |
+| 5. Supervised automation lab | 8-10 | Build or run Plan-Implement-Validate with provider routing. | Participants can describe artifact handoffs and approval decisions. |
+| 6. Interfaces and operations | 11-14 | Practice GitHub flow, adapter concepts, deployment boundaries, and troubleshooting. | Participants can distinguish local usage, team usage, and deployment responsibilities. |
+| 7. Capstone lab | 15-16 | Complete a supervised issue-to-PR workflow and final checklist. | The PR is reviewed or prepared, not merged automatically. |
+
+### Facilitator Run Of Show
+
+For each live session:
+
+1. State the goal in one sentence.
+2. Rehearse the relevant safety rule.
+3. Demo the happy path once, using placeholder secrets only.
+4. Give learners time to run the lab.
+5. Ask learners to inspect evidence before sharing conclusions.
+6. Close with one failure mode and how to recover from it.
+
+Keep live demos short. Learners need time with their own terminal, Web UI, logs,
+and workflow artifacts.
+
+### Session Lesson Plans
+
+Use these plans as the default workshop script. Each plan assumes learners have
+the practical tutorial open and are working in a disposable repository.
+
+#### Session 1 - Orientation And Safety
+
+Goal: learners understand Archon as a harness and can name the safety contract.
+
+Prework:
+
+- Read Parts 0 and 1.
+- Bring one real workflow idea, but do not use a real repository yet.
+
+Live agenda:
+
+1. Define harness engineering, workflow, node, provider, artifact, worktree, and
+   approval gate.
+2. Compare chat-only AI coding with repeatable workflow execution.
+3. Walk through the safety contract.
+4. Choose or create the sandbox repository.
+5. Draft each learner's first operating checklist.
+
+Lab deliverable:
+
+- A three-sentence note explaining what Archon will do, what Git will isolate,
+  and what the human will approve.
+
+Facilitator checks:
+
+- The learner does not describe Archon as autonomous merge automation.
+- The learner can explain why the first repository is disposable.
+- The learner can name at least two kinds of evidence they will inspect after a
+  run.
+
+#### Session 2 - Local Setup Lab
+
+Goal: learners install Archon, verify the CLI, and reach the Web UI.
+
+Prework:
+
+- Read Parts 2 and 3.
+- Install the local prerequisites for the chosen operating system.
+
+Live agenda:
+
+1. Verify the shell, Git, Bun, and repository location.
+2. Install or run Archon from the selected path.
+3. Configure the first assistant without sharing secrets.
+4. Start the Web UI.
+5. Register or open the sandbox repository.
+
+Lab deliverable:
+
+- A setup note containing the interface used, the sandbox path, and the
+  verification command output summary.
+
+Facilitator checks:
+
+- The learner never pastes token values into shared chat.
+- The CLI and Web UI point at the intended sandbox.
+- Any blocked setup has a written next action, not a vague "doesn't work."
+
+#### Session 3 - First Workflow Lab
+
+Goal: learners run a safe workflow and inspect the evidence it produced.
+
+Prework:
+
+- Read Parts 4 and 5.
+- Run `archon workflow list` from the sandbox if setup is complete.
+
+Live agenda:
+
+1. Review built-in workflow categories.
+2. Run one read-only or low-risk workflow.
+3. Inspect workflow status.
+4. Inspect worktrees or isolation environments.
+5. Inspect logs and artifacts.
+6. Write a run report.
+
+Lab deliverable:
+
+- A run report with workflow name, command, run status, files changed, evidence
+  inspected, and one safety observation.
+
+Facilitator checks:
+
+- The learner distinguishes "the model said it passed" from actual validation
+  evidence.
+- The learner can find a run again after terminal output scrolls away.
+- The learner can identify whether the workflow changed files.
+
+#### Session 4 - Authoring Lab
+
+Goal: learners create one command and one workflow, then validate both.
+
+Prework:
+
+- Read Parts 6 and 7.
+- Bring one narrow repeated task from the sandbox.
+
+Live agenda:
+
+1. Create a custom command for a read-only or validation-oriented task.
+2. Run the command in the sandbox.
+3. Create a minimal YAML workflow.
+4. Add deterministic validation.
+5. Validate command and workflow definitions.
+6. Record common authoring mistakes.
+
+Lab deliverable:
+
+- One command file, one workflow file, and a short validation note.
+
+Facilitator checks:
+
+- The workflow has a concrete current use case.
+- Validation is deterministic where possible.
+- The learner does not add provider routing before the single-provider version
+  works.
+
+#### Session 5 - Supervised Automation Lab
+
+Goal: learners practice Plan-Implement-Validate with explicit handoffs.
+
+Prework:
+
+- Read Parts 8, 9, and 10.
+- Identify one small change the sandbox can safely accept.
+
+Live agenda:
+
+1. Draw the Plan-Implement-Validate shape.
+2. Decide which node writes the plan artifact.
+3. Decide where human approval belongs.
+4. Run a supervised workflow on the sandbox change.
+5. Review artifacts before implementation and validation output after
+   implementation.
+6. Discuss provider routing only after the baseline run works.
+
+Lab deliverable:
+
+- A workflow trace showing plan artifact, approval decision, implementation
+  result, validation result, and final human decision.
+
+Facilitator checks:
+
+- The learner can say which steps are AI work, deterministic work, and human
+  review.
+- Artifact handoffs are explicit.
+- Provider choices are attached to node responsibility, not model hype.
+
+#### Session 6 - Interfaces And Operations
+
+Goal: learners understand GitHub, adapters, deployment boundaries, and recovery
+without expanding risk too early.
+
+Prework:
+
+- Read Parts 11, 12, and 14.
+- Confirm whether GitHub CLI authentication is available for the lab.
+
+Live agenda:
+
+1. Practice the local issue-to-PR path or prepare the PR steps without pushing.
+2. Review Web UI usage and adapter boundaries.
+3. Compare local, Docker, and VPS operation.
+4. Review secret handling for GitHub, chat adapters, and provider credentials.
+5. Troubleshoot one prepared failure.
+
+Lab deliverable:
+
+- A deployment boundary note: where Archon runs, which interfaces are enabled,
+  where secrets live, and who approves PRs.
+
+Facilitator checks:
+
+- The learner can separate local CLI use from remote adapter exposure.
+- The learner knows which credentials exist and where they must not appear.
+- The learner has a recovery path for failed, paused, or unsafe runs.
+
+#### Session 7 - Capstone Lab
+
+Goal: learners prove they can operate safely from request to reviewed outcome.
+
+Prework:
+
+- Read Parts 15 and 16.
+- Choose a capstone option and prepare the sandbox.
+
+Live agenda:
+
+1. State the capstone objective and risk boundary.
+2. Run or author the required workflow.
+3. Inspect artifacts, logs, and validation output.
+4. Prepare or create the supervised PR if using the GitHub capstone.
+5. Present the evidence and final decision.
+6. Update the personal or team operating checklist.
+
+Lab deliverable:
+
+- Final run report, checklist, and reviewed PR or PR-ready branch.
+
+Facilitator checks:
+
+- The learner stops before unsafe merge or deployment.
+- The learner can justify approval or rejection from evidence.
+- The learner can describe what they would change before using a real
+  repository.
+
+### Group Exercises
+
+Use these exercises when the group needs discussion rather than more commands:
+
+- Approval gate review: show a plan artifact and ask whether it should be
+  approved, rejected, or revised.
+- Artifact handoff review: ask which node should write an artifact and which
+  node should consume it.
+- Provider routing review: assign each node a provider only after the group
+  names the node's job.
+- Model-role project review: decide whether Claude/Codex should plan, review,
+  or test while Gemini/Qwen/Kimi performs inner implementation, then name the
+  artifact handoff between those roles.
+- Troubleshooting review: present a failure without secrets and ask what
+  evidence should be inspected first.
+- PR readiness review: compare "tests ran" with "this PR is ready to merge" and
+  make learners name the missing review steps.
+
+## Learner Artifacts
+
+Ask learners to keep these artifacts in a private notebook or a safe shared
+training space. Do not include secrets, token values, provider auth files, or
+full `.env` contents.
+
+### Run Report Template
+
+```text
+Workflow or command:
+Repository:
+Branch or worktree:
+Request:
+Run status:
+Files changed:
+Artifacts inspected:
+Logs inspected:
+Validation command and result:
+Human decision:
+Follow-up:
+```
+
+### Workflow Design Brief
+
+```text
+Workflow name:
+Repeated task this solves:
+Inputs:
+Nodes:
+Artifact handoffs:
+Deterministic validation:
+Approval gates:
+Provider choice per node:
+Rollback path:
+Known limits:
+```
+
+### PR Readiness Note
+
+```text
+Issue or request:
+Branch:
+Summary of change:
+Validation evidence:
+Artifact evidence:
+Reviewer concerns:
+Secrets checked:
+Merge decision:
+```
+
+These templates are intentionally short. The habit matters more than the format:
+record enough evidence that another person can understand what happened without
+trusting a chat transcript.
+
+## Remediation Paths
+
+Use remediation when a learner gets a completion signal wrong. Do not move to a
+real repository just because the schedule says the class should be there.
+
+| Gap | Symptom | Remediation exercise |
+| --- | --- | --- |
+| Safety | Learner wants to run first changes in a real repository. | Repeat Session 1 with a disposable repository and require a written risk boundary. |
+| Setup | CLI works but Web UI or project registration is unclear. | Repeat Session 2 using only health checks and project registration; skip AI runs. |
+| Evidence inspection | Learner trusts model text without checking files, logs, or artifacts. | Repeat Session 3 and require a run report before discussing conclusions. |
+| Authoring | Workflow has too many speculative nodes or options. | Reduce it to one current use case, one command, and one validation step. |
+| Approval judgment | Learner approves vague plans. | Run approval gate review with a flawed plan artifact and require a rejection reason. |
+| Provider routing | Learner routes by favorite model instead of node responsibility. | Re-run the workflow with one provider, then justify only one provider change. |
+| GitHub readiness | Learner equates PR creation with merge readiness. | Complete the PR readiness note and identify at least one manual review concern. |
+| Troubleshooting | Learner restarts everything without inspecting evidence. | Use the troubleshooting section to inspect status, logs, artifacts, and config in order. |
+
+Remediation is successful when the learner can explain the correction and repeat
+the safer behavior once.
+
+## Hybrid Path
+
+Hybrid delivery works well for teams that cannot spend a full week in live
+training. Assign conceptual reading before each session and reserve live time
+for setup, authoring, troubleshooting, and review.
+
+| Before live session | Live session focus | After live session |
+| --- | --- | --- |
+| Read orientation and safety material. | Discuss the safety contract and choose the sandbox. | Write a one-sentence harness goal. |
+| Read installation and repository setup. | Verify local setup together. | Capture local setup notes and blockers. |
+| Read built-in workflow and isolation sections. | Run and inspect a workflow. | Submit a three-line run report. |
+| Read authoring sections. | Build and validate command/workflow artifacts. | Revise artifacts after facilitator review. |
+| Read PIV, provider, and GitHub sections. | Complete capstone rehearsal. | Finalize operating checklist. |
+
+## Assessment
+
+Assessment should measure operating judgment, not memorization. A learner is
+ready to use Archon on a real project when they can show evidence in these
+areas.
+
+| Area | Ready | Strong |
+| --- | --- | --- |
+| Safety | Uses sandbox work first, protects secrets, and keeps human approval before risky actions. | Can recover from a rejected or unsafe run and explain why the recovery was chosen. |
+| Workflow operation | Runs built-in workflows and inspects status, logs, worktrees, and artifacts. | Diagnoses paused, failed, or abandoned runs without guessing. |
+| Workflow authoring | Creates and validates a command and workflow. | Designs artifact handoffs and approval gates that match the risk of the work. |
+| Provider routing | Starts with one provider and verifies Pi or Gemini routing locally before relying on it. | Assigns providers by node responsibility and avoids hidden chat-memory handoffs. |
+| GitHub practice | Creates or prepares a supervised pull request from an issue. | Reviews the PR, records verification, and refuses autonomous merge while learning. |
+| Communication | Writes a concise run report. | Teaches another learner how to inspect evidence from a run. |
+
+### Scoring Rubric
+
+Use this rubric for capstone sign-off. A score of 2 in every category is the
+minimum for supervised real-repository work. A score of 3 indicates the learner
+can help others.
+
+| Category | 1 - Needs practice | 2 - Ready with supervision | 3 - Strong operator |
+| --- | --- | --- | --- |
+| Safety boundary | Uses the sandbox inconsistently or exposes risky details. | Uses sandbox, protects secrets, and keeps approval gates. | Adjusts safety boundaries based on repository and task risk. |
+| Workflow execution | Can run a command only by following exact steps. | Runs workflows and finds status, logs, worktrees, and artifacts. | Diagnoses run state and explains evidence to others. |
+| Authoring | Creates unclear commands or workflows that depend on hidden assumptions. | Creates a narrow command and workflow with validation. | Designs clean artifact handoffs and rollback-friendly workflow shapes. |
+| Validation | Relies on model summaries. | Runs deterministic checks and records results. | Chooses validation that matches the risk and knows when evidence is incomplete. |
+| Approval | Approves or rejects without a clear reason. | Reviews plan and output before moving forward. | Gives actionable revision instructions at approval gates. |
+| GitHub practice | Pushes or merges too early. | Prepares or creates a supervised PR and stops for review. | Produces a clear PR readiness note with residual risks. |
+
+### Sign-Off Conversation
+
+Before graduating a learner, ask:
+
+1. What repository would you use next, and why is it low risk enough?
+2. Which workflow will you run first, and what could it change?
+3. Where will artifacts and logs appear?
+4. What validation must pass before you trust the result?
+5. Where are secrets stored, and what should never be pasted into chat?
+6. What approval gate would make you reject or revise the run?
+7. What is your rollback path if the generated change is wrong?
+
+The learner does not need perfect answers. They need evidence-based answers and
+a willingness to stop when the evidence is weak.
+
+## Capstone Options
+
+Use the tutorial capstones as the official final exercises. Pick based on the
+learner's target usage:
+
+- Local operator: run a built-in workflow, inspect logs and artifacts, and write
+  a run report.
+- Workflow author: build a supervised Plan-Implement-Validate workflow with at
+  least one approval gate.
+- Provider router: route work across providers only after single-provider runs
+  are verified.
+- Model-role project operator: plan and review with Claude or Codex, implement
+  with a verified Gemini, Qwen, Kimi, Codex, or Claude route, and validate
+  deterministically.
+- GitHub operator: prepare or create a supervised pull request from an issue and
+  stop before merge.
+- Team remote operator: run or simulate a deployed/server workflow with one
+  exposed adapter, health checks, logs, rollback, and no production deployment.
+
+For a workshop, assign one shared capstone and one individual variation. The
+shared capstone keeps discussion focused; the variation proves transfer.
+
+### Capstone Deliverables
+
+Every capstone should produce:
+
+- A run report.
+- The command or workflow definition used, if custom.
+- The relevant artifact paths or summaries.
+- Validation evidence.
+- A human decision: approve, reject, revise, or defer.
+- One checklist update based on what the learner discovered.
+
+For the GitHub capstone, also require:
+
+- Issue or request reference.
+- Branch name.
+- PR link or PR-ready branch note.
+- Manual review notes.
+- Explicit statement that no autonomous merge was performed.
+
+## Facilitator Preflight
+
+Before teaching, verify:
+
+- The installation path used in class works on the target operating systems.
+- The sandbox repository can be recreated quickly.
+- The selected assistant/provider setup is available to all learners or has a
+  fallback.
+- GitHub authentication is optional until the GitHub session.
+- The Web UI is reachable locally.
+- No shared slides, notes, or recordings contain secrets.
+- The curriculum's default branch, workflow names, and provider notes still
+  match the current repository documentation.
+
+### Facilitation Supplies
+
+Prepare these before a cohort starts:
+
+- A resettable sandbox repository with one intentionally small issue.
+- A second sandbox with a deliberately failing test for troubleshooting.
+- A sample plan artifact that should be approved.
+- A sample plan artifact that should be rejected.
+- A sanitized run log excerpt.
+- A sanitized PR readiness note.
+- A shared parking lot for questions that need source verification.
+
+Keep all examples secret-free. Use fake tokens only when showing where a value
+would go.
+
+## Adaptation Guide
+
+For a solo developer, keep the full safety contract and reduce group exercises
+to journal prompts.
+
+For a small team, require each learner to complete the first four sessions, then
+let people specialize in provider routing, GitHub, adapters, or deployment.
+
+For an advanced team, shorten orientation but keep the sandbox, artifact, and
+approval exercises. Experienced developers are still new to this harness.
+
+For a production-facing rollout, add a separate policy session for secrets,
+access control, audit logs, deployment boundaries, and incident recovery before
+any real repository work.
+
+## Completion Checklist
+
+The curriculum is complete when the learner or cohort can:
+
+- Explain Archon as a harness for repeatable AI coding workflows.
+- Install and verify Archon locally.
+- Run a safe workflow in a disposable repository.
+- Inspect run status, worktrees, logs, and artifacts.
+- Create and validate one command and one workflow.
+- Explain a supervised Plan-Implement-Validate flow.
+- Route providers intentionally after verifying each one.
+- Use GitHub to prepare or create a supervised PR.
+- Troubleshoot common failures without exposing secrets.
+- Maintain a personal or team operating checklist.
+
+## Next Steps
+
+After this curriculum, choose one path:
+
+- Personal productivity: turn the safest capstone workflow into a reusable
+  workflow for a real but low-risk repository.
+- Team onboarding: require new users to complete the capstone before they run
+  Archon on shared repositories.
+- Workflow engineering: design a narrow workflow for one repeated team process,
+  validate it, and document its approval gates.
+- Operations: review adapter exposure, deployment boundaries, access control,
+  and incident recovery before remote usage.
+
+Do not graduate by removing safety gates. Graduate by knowing which gates are
+still needed and why.

--- a/packages/docs-web/src/content/docs/learning/exercise-bank.md
+++ b/packages/docs-web/src/content/docs/learning/exercise-bank.md
@@ -1,0 +1,408 @@
+---
+title: Exercise Bank
+description: Reusable Archon curriculum exercises for self-study, workshops, and remediation.
+category: learning
+audience: [user, operator]
+status: current
+sidebar:
+  order: 9
+---
+
+Use this exercise bank when a learner needs more practice than the main tutorial
+provides. Every exercise should run in a disposable repository or a low-risk
+training repository.
+
+Use [Sandbox Setup Guide](/learning/sandbox-setup/) to prepare the default
+repository and the prepared failure repository before assigning these exercises.
+
+## Exercise Format
+
+Each exercise includes:
+
+- Skill practiced.
+- Setup.
+- Task.
+- Evidence to inspect.
+- Completion signal.
+- Common failure.
+
+## 1. Repository Explanation
+
+Skill practiced: safe read-only workflow operation.
+
+Setup:
+
+- Use the sandbox repository from the practical tutorial.
+- Confirm the repository has an initial commit.
+
+Task:
+
+```bash
+archon workflow run archon-assist --no-worktree "Explain this repository structure. Do not edit files."
+```
+
+Evidence to inspect:
+
+- Workflow status.
+- Assistant summary.
+- Git status.
+
+Completion signal:
+
+- `git status` shows no unexpected changes.
+- Learner can name the files Archon inspected.
+
+Common failure:
+
+- Learner runs from the Archon source repo instead of the sandbox.
+
+## 2. Evidence Hunt
+
+Skill practiced: finding run evidence after output scrolls away.
+
+Setup:
+
+- Complete any safe workflow run.
+
+Task:
+
+Find and record:
+
+```text
+Run ID:
+Run status:
+Worktree or branch:
+Artifacts:
+Logs:
+Changed files:
+```
+
+Evidence to inspect:
+
+- CLI status output.
+- Filesystem artifacts.
+- Git branch or worktree state.
+
+Completion signal:
+
+- Another learner can understand what happened without seeing the original chat
+  transcript.
+
+Common failure:
+
+- Learner quotes only the assistant summary and does not inspect files.
+
+## 3. Narrow Custom Command
+
+Skill practiced: command authoring without speculative scope.
+
+Setup:
+
+- Choose one repeated read-only task.
+- Create `.archon/commands/` in the sandbox if needed.
+
+Task:
+
+Write a command that asks the assistant to inspect one module and produce a
+short report. The command should not request edits.
+
+Evidence to inspect:
+
+- Command file.
+- Command validation output.
+- Workflow or command run output.
+- Git status.
+
+Completion signal:
+
+- The command solves one current task and does not contain secrets.
+
+Common failure:
+
+- Command asks for implementation, review, tests, and PR creation all at once.
+
+## 4. Minimal Workflow
+
+Skill practiced: workflow authoring with deterministic validation.
+
+Setup:
+
+- Use the sandbox repository.
+- Start with one agentic node and one validation node.
+
+Task:
+
+Create a workflow that asks for one small implementation and runs a deterministic
+validation command.
+
+Evidence to inspect:
+
+- Workflow YAML.
+- Validation output.
+- Changed files.
+- Run report.
+
+Completion signal:
+
+- The workflow validates successfully before it is used on a real repository.
+
+Common failure:
+
+- Workflow depends on hidden chat memory instead of an explicit artifact.
+
+## 5. Approval Gate Drill
+
+Skill practiced: rejecting vague plans.
+
+Setup:
+
+- Use a plan artifact from a previous run or write a small sample plan.
+
+Task:
+
+Decide whether to approve, reject, revise, or defer.
+
+Evidence to inspect:
+
+```text
+Does the plan name files?
+Does the plan name validation commands?
+Does the plan name risks?
+Does the plan name rollback steps?
+Does the plan fit the request?
+```
+
+Completion signal:
+
+- Learner gives a decision with a concrete reason and next instruction.
+
+Common failure:
+
+- Learner approves because the plan "sounds reasonable."
+
+## 6. PR Readiness Drill
+
+Skill practiced: distinguishing PR creation from merge readiness.
+
+Setup:
+
+- Use a sandbox branch with one small change.
+
+Task:
+
+Write a PR readiness note before creating or reviewing a PR.
+
+Evidence to inspect:
+
+- Diff.
+- Validation output.
+- Artifact summary.
+- Secret check.
+
+Completion signal:
+
+- Learner can say what is ready, what remains uncertain, and why merge should
+  wait for human review.
+
+Common failure:
+
+- Learner treats passing tests as the only merge criterion.
+
+## 7. Remediation Mini-Exercise
+
+Skill practiced: recovering from a failed learning signal.
+
+Setup:
+
+- Pick one failed completion signal from the curriculum.
+
+Task:
+
+Repeat only the smallest exercise that proves the missing skill.
+
+Evidence to inspect:
+
+- The original failed evidence.
+- The corrected evidence.
+- The checklist update.
+
+Completion signal:
+
+- Learner can explain what changed in their operating behavior.
+
+Common failure:
+
+- Learner reruns everything without identifying the specific gap.
+
+## 8. Model Role Routing Project
+
+Skill practiced: assigning models by responsibility in a guided coding project.
+
+Setup:
+
+- Complete the Provider Routing Lab first.
+- Verify one baseline provider works.
+- Verify one inner-development provider privately through Pi, such as Gemini,
+  Qwen, Kimi, or a local/custom model.
+
+Task:
+
+Create a tiny workflow or workflow sketch with these roles:
+
+```text
+Planner: Claude or Codex
+Approval: human
+Inner developer: Gemini, Qwen, Kimi, Codex, or Claude
+Validation: bash or script node
+Reviewer: Claude or Codex
+```
+
+Evidence to inspect:
+
+- Plan artifact or node output.
+- Approval decision.
+- Verified model ID for the inner-development provider.
+- Changed files.
+- Deterministic validation output.
+- Independent review output.
+- Rollback path.
+
+Completion signal:
+
+- The learner can explain why each model was assigned to its role.
+- Implementation does not start before plan approval.
+- Validation result comes from a deterministic command, not an assistant
+  summary.
+
+Common failure:
+
+- Learner routes every node to a different model without a job-specific reason.
+
+## 9. Guided Solo Vibe Coding Project
+
+Skill practiced: completing a personal local project with model roles and
+evidence.
+
+Setup:
+
+- Use the sandbox repository or a low-risk local repository.
+- Choose one small change with a fast validation command.
+
+Task:
+
+Run a supervised project:
+
+```text
+1. Claude or Codex writes the plan.
+2. Human approves or revises the plan.
+3. Gemini, Qwen, Kimi, Codex, or Claude implements the approved scope.
+4. A deterministic command validates the result.
+5. Claude or Codex reviews the diff and validation output.
+6. Human decides keep, revise, or discard.
+```
+
+Evidence to inspect:
+
+- Workflow YAML or command sequence.
+- Model-role decision note.
+- Plan and review artifacts.
+- Git diff.
+- Validation output.
+- Final human decision.
+
+Completion signal:
+
+- Another learner can replay the evidence and understand why the final decision
+  was made.
+
+Common failure:
+
+- Learner treats the implementation model's final message as enough evidence.
+
+## 10. Team GitHub Workflow Rehearsal
+
+Skill practiced: team issue-to-PR operation with explicit model roles.
+
+Setup:
+
+- Use a disposable GitHub repository.
+- Create one issue with the prepared sandbox change request.
+- Confirm `gh auth status` works privately.
+
+Task:
+
+Run or rehearse:
+
+```text
+Issue intake -> plan -> approval -> implementation -> validation -> review -> PR-ready branch or PR
+```
+
+Assign Claude or Codex to planning and review. Assign Gemini, Qwen, Kimi,
+Codex, or Claude to implementation only after its model ID and auth are
+verified.
+
+Evidence to inspect:
+
+- Issue reference.
+- Branch or worktree.
+- Plan approval.
+- Implementation provider and fallback.
+- Validation output.
+- PR readiness note.
+- Explicit no-merge statement.
+
+Completion signal:
+
+- The workflow prepares or creates a PR and stops for human review.
+
+Common failure:
+
+- Learner treats PR creation as the end of review.
+
+## 11. Server Or Deployed Team Operation Rehearsal
+
+Skill practiced: operating Archon from a local server, Docker environment, VPS,
+or simulated remote setup.
+
+Setup:
+
+- Complete local workflow exercises first.
+- Choose one interface: Web UI, GitHub webhook, Slack, Telegram, or Discord.
+- Use a sandbox repository and placeholder secrets in shared notes.
+
+Task:
+
+Write and verify a deployment boundary note:
+
+```text
+Runtime location:
+Database:
+Enabled adapter:
+Allowed users:
+Secrets location:
+Health checks:
+Log location:
+Artifact location:
+Rollback:
+Incident contact:
+```
+
+Then run or simulate one request through the chosen interface.
+
+Evidence to inspect:
+
+- Health endpoint output.
+- Adapter or server log summary.
+- Workflow run status.
+- Artifact location.
+- Validation output.
+- Recovery or rollback note.
+
+Completion signal:
+
+- The learner can explain where Archon runs, who can trigger it, where evidence
+  is stored, and how to stop or recover a risky run.
+
+Common failure:
+
+- Learner exposes an adapter before defining allowed users and secret handling.

--- a/packages/docs-web/src/content/docs/learning/facilitator-evaluation.md
+++ b/packages/docs-web/src/content/docs/learning/facilitator-evaluation.md
@@ -1,0 +1,128 @@
+---
+title: Facilitator Evaluation
+description: Evaluation sheets and review prompts for assessing Archon curriculum learners.
+category: learning
+audience: [operator]
+status: current
+sidebar:
+  order: 7
+---
+
+Use this page to evaluate whether a learner can use Archon safely with
+supervision. Assessment should measure evidence-based operating judgment, not
+memorized commands.
+
+If a learner misses a completion signal, assign a focused path from
+[Remediation Playbook](/learning/remediation-playbook/). For lightweight
+practice before sign-off, use
+[Peer Review Practice](/learning/peer-review-practice/).
+When the learner is ready, complete
+[Graduation Checklist](/learning/graduation-checklist/).
+Use [Learning Outcomes Matrix](/learning/outcomes-matrix/) when you need to map
+weak evidence to targeted remediation.
+
+## Evaluation Summary
+
+```text
+Learner:
+Evaluator:
+Date:
+Archon version or commit:
+Training repository:
+Capstone option:
+Overall result: pass / revise / defer
+Recommended next workflow:
+Recommended supervision level:
+```
+
+## Evidence Checklist
+
+| Evidence | Required | Observed |
+| --- | --- | --- |
+| Disposable or low-risk repository used | yes |  |
+| Secrets kept out of chat, notes, logs, artifacts, and diffs | yes |  |
+| CLI or Web UI setup verified | yes |  |
+| Safe workflow run completed | yes |  |
+| Run status inspected | yes |  |
+| Worktree or branch inspected | yes |  |
+| Logs inspected | yes |  |
+| Artifacts inspected | yes |  |
+| Custom command or workflow validated | yes, for authoring track |  |
+| Approval decision explained | yes |  |
+| Deterministic validation recorded | yes |  |
+| PR stopped before merge | yes, for GitHub track |  |
+
+## Scoring
+
+Score each category from 1 to 3.
+
+| Category | Score | Notes |
+| --- | --- | --- |
+| Safety boundary |  |  |
+| Workflow execution |  |  |
+| Evidence inspection |  |  |
+| Workflow authoring |  |  |
+| Validation judgment |  |  |
+| Approval judgment |  |  |
+| Provider routing judgment |  |  |
+| GitHub readiness |  |  |
+| Communication |  |  |
+
+Suggested interpretation:
+
+- Mostly 1s: repeat the relevant sessions before real project work.
+- All 2s or better: ready for supervised real-repository work.
+- Mostly 3s: ready to help other learners inspect evidence and review runs.
+
+## Review Prompts
+
+Ask the learner:
+
+1. What did Archon do in this run?
+2. What did Git isolate?
+3. What changed on disk?
+4. Which evidence did you inspect?
+5. Which validation result matters most?
+6. Which model or provider claim did you not fully trust?
+7. Why did you approve, reject, revise, or defer?
+8. What would make this unsafe in a real repository?
+9. What is the rollback path?
+10. What checklist item changed because of this run?
+
+## Red Flags
+
+Defer graduation if any of these happen:
+
+- Learner exposes or copies secrets into shared materials.
+- Learner cannot identify the repository or branch used.
+- Learner trusts the assistant summary without inspecting files or validation.
+- Learner approves a vague plan with no files, commands, risks, or rollback.
+- Learner routes providers by model preference before a baseline works.
+- Learner treats PR creation as merge readiness.
+- Learner wants to remove safety gates to move faster.
+
+## Sign-Off Note
+
+```text
+The learner is ready to use Archon on:
+
+Repository type:
+Allowed workflows:
+Required approval gates:
+Required validation:
+Provider limits:
+GitHub limits:
+Supervision required:
+Follow-up date:
+```
+
+## Remediation Assignment
+
+```text
+Gap:
+Session to repeat:
+Exercise:
+Evidence required:
+Due date:
+Reviewer:
+```

--- a/packages/docs-web/src/content/docs/learning/faq.md
+++ b/packages/docs-web/src/content/docs/learning/faq.md
@@ -1,0 +1,87 @@
+---
+title: Learner FAQ
+description: Frequently asked questions for learners and facilitators using the Archon curriculum.
+category: learning
+audience: [user, operator]
+status: current
+sidebar:
+  order: 20
+---
+
+Use this FAQ during self-study or workshops. It gives consistent answers to
+common learner questions.
+
+## Can I Use A Real Repository For The First Exercise?
+
+No. Use a disposable sandbox first. Real repositories come after you can inspect
+run status, worktrees, artifacts, logs, changed files, validation output, and
+approval decisions.
+
+## Why So Much Focus On Evidence?
+
+Because assistant summaries are useful but not enough. Evidence lets you verify
+what actually happened: which repository was used, which files changed, what
+validation ran, and what decision is justified.
+
+## When Can I Use `--no-worktree`?
+
+Use `--no-worktree` for read-only tasks while learning. If a workflow might edit
+files, use an isolated branch or worktree.
+
+## What Counts As A Secret?
+
+API keys, OAuth tokens, GitHub tokens, provider auth files, credentials, and full
+environment file contents. Do not paste them into chat, shared notes, artifacts,
+logs, command files, or workflow files.
+
+## What If Setup Fails?
+
+Do not burn the whole session on setup. Record the blocker, assign a next
+action, and continue with a fallback: workbook prompts, evidence review, sample
+artifacts, command design, or pairing with another learner.
+
+## Why Start With One Provider?
+
+Because provider routing adds complexity. First prove the workflow works with
+one provider. Then route one node only if its responsibility justifies a
+different provider.
+
+## How Do I Know A Plan Is Good Enough To Approve?
+
+A beginner-friendly plan should name:
+
+- Files it will inspect or change.
+- Validation commands.
+- Risks.
+- Rollback path.
+- Expected artifacts or output.
+
+If those are missing, reject or revise the plan.
+
+## Is Passing Validation Enough To Merge?
+
+No. Passing validation is one piece of evidence. Merge readiness also requires
+diff inspection, PR review, secret checks, residual risk assessment, and a human
+merge decision.
+
+## What If The Assistant Says Something That Conflicts With The Docs?
+
+Trust source-backed docs and local validation over assistant claims. Record the
+conflict and inspect the relevant command, workflow, logs, or source file.
+
+## Can I Skip The Capstone?
+
+Not if you want to use Archon on a real project. The capstone proves you can
+operate safely from request to evidence-backed decision.
+
+## What Is The Fastest Safe Path?
+
+Use the syllabus, create the sandbox, run a read-only workflow, inspect evidence,
+author one narrow command or workflow, run Plan-Implement-Validate, and complete
+a small capstone. Fast is fine; skipping evidence is not.
+
+## What Should I Do After Completing The Curriculum?
+
+Pick one low-risk real repository, choose one workflow, define approval gates,
+run deterministic validation, and keep supervision until your team agrees the
+operating checklist is reliable.

--- a/packages/docs-web/src/content/docs/learning/glossary.md
+++ b/packages/docs-web/src/content/docs/learning/glossary.md
@@ -1,0 +1,139 @@
+---
+title: Curriculum Glossary
+description: Plain-language definitions for Archon curriculum terms.
+category: learning
+audience: [user, operator]
+status: current
+sidebar:
+  order: 17
+---
+
+Use this glossary when teaching or reviewing the curriculum. The definitions are
+plain-language teaching definitions, not exhaustive technical reference entries.
+
+## Agentic Workflow
+
+A workflow step or sequence where an AI coding assistant reasons, reads files,
+writes code, reviews output, or summarizes findings.
+
+## Approval Gate
+
+A workflow pause where a human decides whether to approve, reject, revise, or
+defer the next step. Approval should depend on evidence.
+
+## Artifact
+
+A file written by a workflow step so later steps or humans can inspect it. Good
+artifacts reduce dependence on hidden chat memory.
+
+## Assistant
+
+The coding-agent client Archon asks to do work, such as Claude Code, Codex, or
+Pi.
+
+## Baseline
+
+The simplest working version of a workflow. In the curriculum, provider routing
+starts only after a single-provider baseline works.
+
+## Capstone
+
+The final exercise where a learner proves they can operate Archon safely from
+request to evidence-backed decision.
+
+## Command
+
+A Markdown prompt template stored in `.archon/commands/`. Commands are reusable
+building blocks for repeated assistant tasks.
+
+## Deterministic Validation
+
+A check whose result does not depend on the assistant's opinion, such as a test
+command, lint command, type check, or explicit file inspection.
+
+## Evidence
+
+Anything inspected outside the assistant's final summary: Git status, diffs,
+logs, artifacts, validation output, branches, worktrees, or PR content.
+
+## Harness
+
+The process around an assistant: workflow steps, isolation, artifacts,
+validation, logs, and human approval gates.
+
+## Human Decision
+
+The learner's explicit choice after inspecting evidence. Common decisions are
+approve, reject, revise, defer, or stop.
+
+## Isolation
+
+Keeping generated work away from the main checkout, usually with branches or Git
+worktrees.
+
+## Learner Operating Checklist
+
+A personal checklist the learner updates throughout the curriculum. It records
+the habits they will use before running, approving, trusting, or merging work.
+
+## Model
+
+The specific model an assistant uses. Provider routing should be based on node
+responsibility, not model popularity.
+
+## Node
+
+One step in a workflow. A node might ask an assistant to plan, run a script,
+wait for approval, validate output, or summarize evidence.
+
+## Plan-Implement-Validate
+
+A supervised workflow shape: write a plan, inspect and approve it, implement the
+change, run deterministic validation, then make a final human decision.
+
+## Provider
+
+The Archon workflow provider used for a node, such as `claude`, `codex`, or
+`pi`.
+
+## Provider Routing
+
+Assigning different workflow nodes to different providers. In the curriculum,
+learners route providers only after a single-provider baseline works.
+
+## PR Readiness
+
+The state where a branch is ready for human pull-request review. It is not the
+same as being ready to merge.
+
+## Remediation
+
+Focused practice assigned when a learner misses a completion signal. Good
+remediation repeats the smallest exercise that proves the missing skill.
+
+## Run Report
+
+A short evidence record for a workflow or command run: what ran, where it ran,
+what changed, what evidence was inspected, what validation ran, and what human
+decision followed.
+
+## Sandbox
+
+A disposable or low-risk repository used for learning. Early curriculum work
+should happen in a sandbox before real project work.
+
+## Secret
+
+Any API key, OAuth token, provider auth file, GitHub token, credential, or full
+environment file content. Secrets do not belong in chat, shared notes, logs,
+artifacts, or diffs.
+
+## Workflow
+
+A YAML file stored in `.archon/workflows/` that defines a repeatable process
+made of nodes.
+
+## Worktree
+
+A Git working directory separate from the main checkout. Worktrees help isolate
+workflow changes and make rollback easier.

--- a/packages/docs-web/src/content/docs/learning/graduation-checklist.md
+++ b/packages/docs-web/src/content/docs/learning/graduation-checklist.md
@@ -1,0 +1,118 @@
+---
+title: Graduation Checklist
+description: Final readiness checklist for Archon learners before supervised real-repository work.
+category: learning
+audience: [user, operator]
+status: current
+sidebar:
+  order: 27
+---
+
+Use this checklist after the capstone. Graduation means the learner is ready for
+supervised real-repository work. It does not mean approval gates, validation, or
+human review can be removed.
+
+## Learner Readiness
+
+```text
+Learner:
+Reviewer:
+Date:
+Capstone option:
+Training repository:
+Recommended first real repository:
+Recommended supervision level:
+```
+
+## Required Evidence
+
+The learner must show:
+
+```text
+Setup note:
+Safe workflow run report:
+Custom command or workflow:
+Validation evidence:
+Approval decision:
+Capstone report:
+Operating checklist:
+Rollback path:
+```
+
+## Skill Checklist
+
+| Skill | Ready | Evidence |
+| --- | --- | --- |
+| Explains Archon as a workflow harness |  |  |
+| Protects secrets |  |  |
+| Uses sandbox before real work |  |  |
+| Runs a safe workflow |  |  |
+| Inspects status, logs, artifacts, and changed files |  |  |
+| Creates or validates a narrow command/workflow |  |  |
+| Reviews plan artifacts before implementation |  |  |
+| Runs deterministic validation |  |  |
+| Assigns model roles by workflow responsibility |  |  |
+| Verifies Gemini, Qwen, Kimi, or other routed model IDs before use |  |  |
+| Distinguishes PR readiness from merge readiness |  |  |
+| Defines team/server runtime boundaries when remote interfaces are used |  |  |
+| Names rollback path |  |  |
+
+## First Real-Repository Boundary
+
+Before a learner moves to a real repository, define:
+
+```text
+Repository:
+Why this repository is low-risk enough:
+First workflow:
+What the workflow may change:
+Branch or worktree strategy:
+Required approval gate:
+Required validation:
+Provider and model-role rules:
+Reviewer:
+Rollback path:
+Stop conditions:
+```
+
+## Stop Conditions
+
+The learner should stop and ask for review if:
+
+- The workflow touches unexpected files.
+- Validation fails.
+- Artifacts contradict the assistant summary.
+- The plan does not name files, validation, risk, or rollback.
+- A provider fails or uses an unverified model.
+- A routed implementation model has no documented fallback or stop condition.
+- A server adapter is reachable before access control and secrets are reviewed.
+- Secrets appear in output, artifacts, logs, or diffs.
+- The change feels ready to merge but has not been reviewed.
+
+## Graduation Outcomes
+
+| Outcome | Meaning | Next step |
+| --- | --- | --- |
+| Ready with supervision | Learner can run one low-risk workflow with reviewer oversight. | Schedule first real-repository run. |
+| Peer-ready | Learner can also help others inspect evidence. | Pair with a newer learner. |
+| Remediation needed | One or more completion signals are weak. | Assign focused remediation. |
+| Deferred | Evidence is missing or safety behavior is not reliable. | Repeat capstone later. |
+
+## Graduation Note
+
+```text
+Decision:
+Reason:
+Evidence reviewed:
+Allowed workflows:
+Required reviewer:
+Required validation:
+Limits:
+Follow-up date:
+```
+
+## Reminder
+
+The first real-repository workflow should be boring. Choose a small, reversible
+task with clear validation. Confidence should come from evidence, not from the
+assistant sounding confident.

--- a/packages/docs-web/src/content/docs/learning/index.md
+++ b/packages/docs-web/src/content/docs/learning/index.md
@@ -1,0 +1,114 @@
+---
+title: Learning
+description: Tutorial and curriculum material for learning Archon safely.
+category: learning
+audience: [user, operator]
+status: current
+sidebar:
+  order: 0
+---
+
+Use these materials when you want a structured path from first install to safe,
+supervised workflows.
+
+## Start Here
+
+- [Curriculum Package Map](/learning/package-map/) shows every learning asset
+  and when to use it.
+- [Quick-Start Paths](/learning/quick-start-paths/) gives short routes for solo
+  learners, facilitators, team leads, operators, maintainers, and blocked
+  learners.
+- [Curriculum Syllabus](/learning/syllabus/) defines the course promise,
+  audience, prerequisites, schedule, assessment, and completion requirements.
+- [Reading Map](/learning/reading-map/) routes learners, facilitators, team
+  leads, operators, and maintainers to the right pages.
+
+## Core Path
+
+- [Archon Practical Tutorial](/learning/practical-tutorial/) walks through
+  local setup, sandbox workflows, custom commands, Plan-Implement-Validate,
+  provider routing, GitHub, deployment boundaries, troubleshooting, and
+  capstones.
+- [Archon Curriculum Guide](/learning/curriculum/) turns the tutorial into a
+  self-study plan, workshop series, hybrid path, assessment rubric, and
+  facilitator checklist.
+- [Learner Workbook](/learning/learner-workbook/) gives day-by-day prompts for
+  completing the curriculum and recording evidence.
+- [Curriculum Templates](/learning/templates/) collects copy-ready learner,
+  facilitator, run-report, approval, and PR-readiness templates.
+- [Sample Artifacts](/learning/sample-artifacts/) provides secret-free examples
+  of run reports, workflow briefs, approval reviews, and PR readiness notes.
+- [Curriculum Glossary](/learning/glossary/) defines the teaching vocabulary
+  used across the curriculum.
+
+## Teaching And Facilitation
+
+- [Workshop Session Plans](/learning/session-plans/) gives facilitators
+  session-by-session agendas, deliverables, checks, and recovery patterns.
+- [Cohort Runbook](/learning/cohort-runbook/) covers operational preparation,
+  blocker triage, evidence collection, and retrospectives.
+- [Sandbox Setup Guide](/learning/sandbox-setup/) explains how to prepare
+  resettable repositories for exercises and workshops.
+- [Instructor Notes](/learning/instructor-notes/) gives teaching scripts,
+  facilitation moves, timing adjustments, and evidence-first questions.
+- [Slide Outline](/learning/slide-outline/) gives a lightweight deck structure
+  for live workshops and onboarding.
+
+## Practice And Support
+
+- [Exercise Bank](/learning/exercise-bank/) provides reusable practice and
+  remediation exercises.
+- [Troubleshooting Labs](/learning/troubleshooting-labs/) gives prepared
+  failure scenarios for evidence-based debugging.
+- [Provider Routing Lab](/learning/provider-routing-lab/) teaches
+  single-provider baselines before multi-provider workflows.
+- [Model Role Recipes](/learning/model-role-recipes/) gives practical routing
+  patterns for Claude/Codex planning and review with Gemini, Qwen, Kimi, Codex,
+  or Claude inner development.
+- [Office Hours Guide](/learning/office-hours-guide/) explains how to unblock
+  learners without losing evidence habits.
+- [Remediation Playbook](/learning/remediation-playbook/) gives targeted
+  practice paths for missed completion signals.
+- [Peer Review Practice](/learning/peer-review-practice/) structures learner
+  review of run reports, plans, and PR readiness notes.
+- [Learner FAQ](/learning/faq/) answers common curriculum questions.
+
+## Assessment And Graduation
+
+- [Knowledge Checks](/learning/knowledge-checks/) provides quiz questions,
+  scenario prompts, and expected answers for each unit.
+- [Capstone Assessment](/learning/capstone-assessment/) defines capstone
+  options, deliverables, scoring, and sign-off questions.
+- [Facilitator Evaluation](/learning/facilitator-evaluation/) provides scoring,
+  red flags, sign-off notes, and remediation assignments.
+- [Learning Outcomes Matrix](/learning/outcomes-matrix/) maps skills to
+  evidence, exercises, assessment, and remediation.
+- [Graduation Checklist](/learning/graduation-checklist/) defines readiness for
+  supervised real-repository work.
+- [Printable Checklist Pack](/learning/printable-checklists/) provides compact
+  checklists for learners, facilitators, reviewers, and maintainers.
+
+## Rollout And Maintenance
+
+- [Real Repository Transition](/learning/real-repository-transition/) guides the
+  first safe run after sandbox training.
+- [Team Adoption Path](/learning/team-adoption-path/) shows how teams can roll
+  out Archon after learner graduation.
+- [Cohort Report](/learning/cohort-report/) records readiness, blockers,
+  remediation, and curriculum improvements after a cohort.
+- [Curriculum Metrics](/learning/curriculum-metrics/) defines safe metrics for
+  evaluating the training without rewarding risky shortcuts.
+- [Curriculum Maintenance Guide](/learning/maintenance-guide/) explains how to
+  keep source-backed learning material current.
+- [Publishing Checklist](/learning/publishing-checklist/) provides final checks
+  before publishing or teaching.
+- [Version Review](/learning/version-review/) guides updates when Archon
+  workflows, providers, CLI behavior, or docs change.
+- [Archon Tutorial Plan](/learning/tutorial-plan/) records the source inventory,
+  verification decisions, structure, and maintenance notes behind the tutorial.
+
+## Safety Default
+
+Start in a disposable repository, keep secrets out of chat and shared notes, use
+isolated branches or worktrees for modifying workflows, validate custom files
+before running them, and review generated pull requests before merge.

--- a/packages/docs-web/src/content/docs/learning/instructor-notes.md
+++ b/packages/docs-web/src/content/docs/learning/instructor-notes.md
@@ -1,0 +1,190 @@
+---
+title: Instructor Notes
+description: Teaching notes, talk tracks, timing advice, and facilitation patterns for the Archon curriculum.
+category: learning
+audience: [operator]
+status: current
+sidebar:
+  order: 15
+---
+
+Use these notes while teaching the Archon curriculum. They are written for
+facilitators who need crisp explanations, useful prompts, and recovery language
+during live sessions.
+
+Companion teaching assets:
+
+- [Knowledge Checks](/learning/knowledge-checks/) for end-of-unit questions.
+- [Slide Outline](/learning/slide-outline/) for workshop deck structure.
+- [Sample Artifacts](/learning/sample-artifacts/) for evidence examples.
+- [Learner FAQ](/learning/faq/) for consistent answers.
+- [Office Hours Guide](/learning/office-hours-guide/) for between-session
+  support.
+- [Peer Review Practice](/learning/peer-review-practice/) for structured
+  learner-to-learner review.
+
+## Core Teaching Frame
+
+Repeat this frame often:
+
+```text
+Archon does not make AI coding safe by trusting the model more.
+Archon makes AI coding safer by making the process inspectable:
+workflows, worktrees, artifacts, logs, validation, and human approval.
+```
+
+The learner should leave each session with a stronger evidence habit.
+
+## Terms To Reinforce
+
+Harness:
+
+: The process around the assistant: workflow steps, isolation, artifacts,
+  deterministic checks, and approval gates.
+
+Artifact:
+
+: A file produced by one workflow step so another step or human can inspect it.
+  Artifacts are safer than hidden chat memory.
+
+Worktree:
+
+: A separate Git working directory where modifying work can happen without
+  touching the main checkout.
+
+Approval gate:
+
+: A deliberate human decision point. Approval should depend on evidence, not
+  vibes.
+
+Validation:
+
+: A deterministic command or inspection that checks whether the work is
+  acceptable. Validation is not the same as an assistant summary.
+
+## Teaching Moves
+
+Use these moves when learners get stuck.
+
+| Situation | Teaching move |
+| --- | --- |
+| Learner trusts a summary | Ask, "What evidence would convince someone who never saw this chat?" |
+| Learner wants to use a real repo | Ask, "What is the rollback path if the workflow edits the wrong file?" |
+| Learner approves a vague plan | Ask, "Which files, commands, risks, and rollback steps are missing?" |
+| Learner wants multi-provider immediately | Ask, "Which node responsibility changed after the baseline worked?" |
+| Learner wants to merge | Ask, "What review evidence is still missing?" |
+| Learner reruns without inspecting | Ask, "What did the last run prove?" |
+
+## Session Opening Script
+
+```text
+Today we are practicing supervised AI workflow operation.
+The goal is not to make Archon do everything.
+The goal is to make every important step inspectable.
+We will use a sandbox, protect secrets, inspect evidence, and stop before unsafe merge or deployment.
+```
+
+## Session Closing Script
+
+```text
+Before we close, write down:
+what ran,
+what changed,
+what evidence you inspected,
+what decision you made,
+and what checklist item changed.
+```
+
+## Demo Guidance
+
+Keep demos short. A good demo is:
+
+- One narrow request.
+- One visible command.
+- One evidence inspection.
+- One explicit decision.
+
+Avoid:
+
+- Debugging provider setup live for too long.
+- Showing real secrets.
+- Running a complex workflow before learners understand run evidence.
+- Treating the assistant's final message as the whole result.
+
+## Handling Setup Problems
+
+When setup blocks a learner:
+
+1. Record the blocker.
+2. Assign an owner.
+3. Move the learner to a fallback exercise.
+4. Fix setup outside the main teaching flow.
+
+Fallback options:
+
+- Pair with another learner for evidence inspection.
+- Use the docs to design a workflow on paper.
+- Complete workbook prompts.
+- Review sample artifacts.
+- Practice approval decisions.
+
+## Handling Unsafe Suggestions
+
+If a learner suggests unsafe automation, respond calmly and convert it into a
+boundary exercise.
+
+```text
+That might be possible later. For this curriculum, let's name the safety gates
+that would need to exist before it becomes acceptable.
+```
+
+Then ask:
+
+- What could this change?
+- Who approves it?
+- What validation must pass?
+- Where are artifacts and logs?
+- What is the rollback path?
+
+## Evidence-First Questions
+
+Use these questions throughout the course:
+
+1. What repository did this run use?
+2. What branch or worktree did it use?
+3. What files changed?
+4. What artifact was written?
+5. What log did you inspect?
+6. What validation ran?
+7. What did the assistant claim?
+8. Which claim did evidence confirm?
+9. Which claim remains uncertain?
+10. What decision follows from the evidence?
+
+## Common Timing Adjustments
+
+If the group is ahead:
+
+- Add an exercise from the [Exercise Bank](/learning/exercise-bank/).
+- Add one [Troubleshooting Lab](/learning/troubleshooting-labs/).
+- Ask learners to critique a sample artifact.
+
+If the group is behind:
+
+- Skip provider routing.
+- Skip GitHub PR creation and write a PR-ready note instead.
+- Keep deployment conceptual.
+- Finish with the operating checklist instead of a full capstone.
+
+## Instructor Self-Check
+
+After each session, write:
+
+```text
+What learners could do:
+What learners could explain:
+What evidence they inspected:
+Where they got stuck:
+Which safety rule needed repetition:
+What to change next time:
+```

--- a/packages/docs-web/src/content/docs/learning/knowledge-checks.md
+++ b/packages/docs-web/src/content/docs/learning/knowledge-checks.md
@@ -1,0 +1,272 @@
+---
+title: Knowledge Checks
+description: Quiz questions and discussion prompts for assessing Archon curriculum understanding.
+category: learning
+audience: [user, operator]
+status: current
+sidebar:
+  order: 18
+---
+
+Use these checks after each unit or before the capstone. They are designed to
+test operating judgment, not trivia.
+
+## How To Use
+
+For self-study:
+
+- Answer without looking first.
+- Then compare against the expected answer.
+- Repeat the related exercise if the answer is weak.
+
+For workshops:
+
+- Ask one or two questions at the end of each session.
+- Require evidence-based answers.
+- Let learners discuss before revealing the expected answer.
+
+## Unit 1: Orientation And Safety
+
+Question:
+
+```text
+Why is Archon described as a harness instead of a bigger prompt?
+```
+
+Expected answer:
+
+```text
+Because Archon structures the process around the assistant: workflow steps,
+worktrees, artifacts, logs, validation, and approval gates. The assistant still
+does AI work, but the process is repeatable and inspectable.
+```
+
+Question:
+
+```text
+What should a learner avoid during the first week?
+```
+
+Expected answer:
+
+```text
+Production repositories, autonomous merge, production deployment, secrets in
+chat, and broad modifying workflows without an approval gate.
+```
+
+## Unit 2: Setup
+
+Question:
+
+```text
+What evidence proves setup is ready enough for the first workflow?
+```
+
+Expected answer:
+
+```text
+The Archon CLI works, the Web UI or chosen interface is reachable, the intended
+sandbox has an initial commit, the selected provider is configured privately,
+and health checks or equivalent setup checks pass.
+```
+
+Question:
+
+```text
+Where should secrets not appear?
+```
+
+Expected answer:
+
+```text
+Secrets should not appear in chat, shared notes, Git diffs, workflow artifacts,
+logs shared publicly, command files, workflow files, or full environment file
+copies.
+```
+
+## Unit 3: First Workflow
+
+Question:
+
+```text
+The assistant says "tests passed." What should you inspect before trusting that?
+```
+
+Expected answer:
+
+```text
+The actual validation command and output, changed files, workflow status, logs,
+artifacts, and Git status or branch state.
+```
+
+Question:
+
+```text
+When is --no-worktree acceptable while learning?
+```
+
+Expected answer:
+
+```text
+For read-only tasks where the learner does not expect file edits. Modifying work
+should use an isolated branch or worktree.
+```
+
+## Unit 4: Authoring
+
+Question:
+
+```text
+What makes a good first custom workflow?
+```
+
+Expected answer:
+
+```text
+It solves one current sandbox task, has a narrow input, uses explicit artifacts
+for handoffs, includes deterministic validation, and avoids speculative provider
+routing.
+```
+
+Question:
+
+```text
+Why are artifacts safer than hidden chat memory?
+```
+
+Expected answer:
+
+```text
+Artifacts can be inspected by humans and later workflow nodes. Hidden chat
+memory is harder to audit, reproduce, or hand off safely.
+```
+
+## Unit 5: Supervised Automation
+
+Question:
+
+```text
+What should make you reject a plan artifact?
+```
+
+Expected answer:
+
+```text
+Missing files, missing validation commands, vague implementation steps, no risk
+boundary, no rollback path, or a plan that does not match the request.
+```
+
+Question:
+
+```text
+What is the difference between AI work, deterministic validation, and human decision?
+```
+
+Expected answer:
+
+```text
+AI work reasons, writes, reviews, or summarizes. Deterministic validation runs
+checks whose result does not depend on model opinion. Human decision approves,
+rejects, revises, defers, or stops based on evidence.
+```
+
+## Unit 6: GitHub And Operations
+
+Question:
+
+```text
+Why is PR creation not the same as merge readiness?
+```
+
+Expected answer:
+
+```text
+A PR is a review artifact. Merge readiness also requires human review,
+validation evidence, diff inspection, secret checks, and residual risk
+assessment.
+```
+
+Question:
+
+```text
+What should an operator know before enabling remote adapters?
+```
+
+Expected answer:
+
+```text
+Where Archon runs, which interfaces are exposed, where secrets live, who is
+authorized, how logs and artifacts are handled, and who approves risky actions.
+```
+
+## Unit 7: Capstone
+
+Question:
+
+```text
+What evidence should a capstone include?
+```
+
+Expected answer:
+
+```text
+A run report, changed files or PR-ready branch, artifacts, logs, validation
+output, human decision, safety boundary, and operating-checklist update.
+```
+
+Question:
+
+```text
+What is a valid capstone outcome besides "pass"?
+```
+
+Expected answer:
+
+```text
+Revise or defer. If evidence is incomplete or risk is unclear, stopping is the
+correct behavior.
+```
+
+## Scenario Prompts
+
+Use these for group discussion.
+
+```text
+A workflow changed files in the main checkout. What do you inspect first?
+```
+
+```text
+The plan artifact is persuasive but names no validation command. What decision
+do you make?
+```
+
+```text
+A learner wants to route every node to a different provider. What baseline do
+you require first?
+```
+
+```text
+A PR exists and tests passed. What evidence is still needed before merge?
+```
+
+```text
+A provider fails because the model ID is unknown. What should not happen next?
+```
+
+## Passing Standard
+
+A strong answer:
+
+- Names concrete evidence.
+- Distinguishes assistant claims from validation.
+- Protects secrets.
+- Preserves human approval.
+- Names a rollback or stop condition.
+
+A weak answer:
+
+- Trusts the assistant summary alone.
+- Treats speed as the reason to skip gates.
+- Cannot identify repository, branch, or changed files.
+- Guesses provider details.
+- Treats PR creation as completion.

--- a/packages/docs-web/src/content/docs/learning/learner-workbook.md
+++ b/packages/docs-web/src/content/docs/learning/learner-workbook.md
@@ -1,0 +1,269 @@
+---
+title: Learner Workbook
+description: Day-by-day workbook prompts for completing the Archon curriculum safely.
+category: learning
+audience: [user]
+status: current
+sidebar:
+  order: 6
+---
+
+Use this workbook while following the practical tutorial or attending a
+workshop. Keep it in a private notebook or a safe shared training space. Do not
+record secrets, token values, provider auth files, or full `.env` contents.
+
+For extra practice, use the [Exercise Bank](/learning/exercise-bank/). If you
+get blocked, use the [Troubleshooting Labs](/learning/troubleshooting-labs/) to
+practice inspecting evidence before rerunning.
+
+## Before You Start
+
+Write your starting boundary:
+
+```text
+My training repository:
+Why it is safe enough:
+Assistant/provider I will use first:
+Interface I will use first: CLI / Web UI / both
+What I will not automate yet:
+Where I will store notes:
+```
+
+Write your safety promise:
+
+```text
+I will keep secrets out of chat and shared notes.
+I will use a disposable repository until I can inspect evidence from a run.
+I will use isolated branches or worktrees for modifying workflows.
+I will validate custom commands and workflows before running them.
+I will review generated PRs before merge.
+```
+
+## Day 1: Orientation
+
+Read:
+
+- Practical Tutorial Parts 0 and 1.
+
+Practice:
+
+- Explain Archon as a harness, not a bigger prompt.
+- Choose your first safe path.
+
+Workbook:
+
+```text
+My one-sentence harness goal:
+Three terms I can explain:
+The first repository I will use:
+Why I am not using a production repository yet:
+Approval gate I expect to need:
+Question to revisit:
+```
+
+Completion signal:
+
+- You can explain why workflows, artifacts, worktrees, validation, and approval
+  gates make AI coding more repeatable.
+
+## Day 2: Setup
+
+Read:
+
+- Practical Tutorial Parts 2 and 3.
+
+Practice:
+
+- Install or run Archon.
+- Verify CLI and Web UI access.
+- Create or register the sandbox repository.
+
+Workbook:
+
+```text
+Archon version or commit:
+Operating system and shell:
+Sandbox path:
+CLI check result:
+Web UI check result:
+Health check result:
+Provider configured:
+Setup blocker:
+Next action:
+```
+
+Completion signal:
+
+- CLI and Web UI both point at the intended sandbox, or you have a documented
+  blocker with a next action.
+
+## Day 3: First Workflow
+
+Read:
+
+- Practical Tutorial Parts 4 and 5.
+
+Practice:
+
+- Run one safe workflow.
+- Inspect status, worktree or branch, logs, artifacts, and changed files.
+
+Workbook:
+
+```text
+Workflow:
+Command:
+Request:
+Run status:
+Files changed:
+Worktree or branch:
+Artifact evidence:
+Log evidence:
+Validation evidence:
+What I trust:
+What I do not trust yet:
+```
+
+Completion signal:
+
+- You can find evidence after a run without relying only on the assistant's
+  summary.
+
+## Day 4: Authoring
+
+Read:
+
+- Practical Tutorial Parts 6 and 7.
+
+Practice:
+
+- Create one custom command.
+- Create one minimal custom workflow.
+- Validate both.
+
+Workbook:
+
+```text
+Repeated task:
+Command file:
+Workflow file:
+Input:
+Expected artifact:
+Validation command:
+Validation result:
+Authoring mistake I fixed:
+Known limit:
+```
+
+Completion signal:
+
+- You have one narrow command and one narrow workflow that solve a current
+  sandbox problem.
+
+## Day 5: Supervised Automation
+
+Read:
+
+- Practical Tutorial Parts 8, 9, and 10.
+
+Practice:
+
+- Run or build a Plan-Implement-Validate flow.
+- Approve, reject, revise, or defer from evidence.
+- Try provider routing only after a single-provider baseline works.
+
+Workbook:
+
+```text
+Plan artifact:
+Plan quality: approve / reject / revise / defer
+Approval reason:
+Implementation result:
+Validation command:
+Validation result:
+Final decision:
+Provider routing used:
+Provider routing reason:
+```
+
+Completion signal:
+
+- You can explain which steps are AI reasoning, which steps are deterministic
+  validation, and which decisions belong to a human.
+
+## Day 6: GitHub And Operations
+
+Read:
+
+- Practical Tutorial Parts 11, 12, and 14.
+
+Practice:
+
+- Prepare or create a supervised PR from a safe issue.
+- Review adapter and deployment boundaries.
+- Troubleshoot one failure from evidence.
+
+Workbook:
+
+```text
+Issue or request:
+Branch:
+PR link or PR-ready branch:
+Enabled interfaces:
+Where Archon runs:
+Where secrets live:
+Validation evidence:
+Manual review concern:
+No autonomous merge performed: yes / no
+Troubleshooting evidence inspected:
+```
+
+Completion signal:
+
+- You can distinguish PR creation from merge readiness.
+
+## Day 7: Capstone
+
+Read:
+
+- Practical Tutorial Parts 15 and 16.
+- Capstone Assessment.
+
+Practice:
+
+- Complete one capstone option.
+- Present evidence and final decision.
+- Update your operating checklist.
+
+Workbook:
+
+```text
+Capstone option:
+Objective:
+Risk boundary:
+Workflow or command:
+Artifacts inspected:
+Logs inspected:
+Validation:
+Human decision:
+Checklist update:
+What I would change before using a real repository:
+```
+
+Completion signal:
+
+- You can show evidence for a safe final decision and name what you would do
+  differently before using Archon on a real project.
+
+## Final Reflection
+
+```text
+The first real repository I might use:
+Why it is low-risk enough:
+The first workflow I would run:
+What it could change:
+Validation required:
+Approval gate required:
+Rollback path:
+Remaining risks:
+```

--- a/packages/docs-web/src/content/docs/learning/maintenance-guide.md
+++ b/packages/docs-web/src/content/docs/learning/maintenance-guide.md
@@ -1,0 +1,172 @@
+---
+title: Curriculum Maintenance Guide
+description: How to keep the Archon curriculum aligned with current source, docs, workflows, and safety policy.
+category: learning
+audience: [developer, operator]
+status: current
+sidebar:
+  order: 21
+---
+
+Use this guide when updating the curriculum after Archon changes. The goal is to
+keep learning material source-backed, current, and safe.
+
+## Maintenance Principle
+
+Do not update the curriculum from memory. Verify claims against the repository,
+current docs, and local commands. Transcript material can inspire examples, but
+official source and local validation decide what the curriculum teaches.
+
+## When To Review
+
+Review the curriculum when:
+
+- CLI commands change.
+- Workflow names or defaults change.
+- Provider setup changes.
+- Web UI routes or behavior change.
+- Adapter setup changes.
+- Security or secret-handling guidance changes.
+- Release notes mention workflows, providers, isolation, approvals, or GitHub.
+- A cohort reports a repeated blocker.
+
+## Source Inventory
+
+Check these first:
+
+```text
+README.md
+CONTRIBUTING.md
+CHANGELOG.md
+packages/docs-web/src/content/docs/
+packages/cli/src/
+packages/workflows/src/defaults/
+packages/providers/src/
+packages/server/src/routes/
+packages/adapters/src/
+```
+
+For learning-specific structure, also check:
+
+```text
+packages/docs-web/src/content/docs/learning/
+docs/learning/
+TUTORIAL.md
+```
+
+## Review Checklist
+
+```text
+CLI command examples still work:
+Default workflow names still match:
+Provider names and setup still match:
+Model examples are still valid or clearly marked:
+GitHub flow still stops before merge:
+Approval gate behavior still matches docs:
+Worktree/isolation guidance still matches source:
+Artifact/log paths still match source:
+Secret-handling guidance still matches security docs:
+Docs build passes:
+```
+
+## Claims That Need Fresh Verification
+
+Always verify these before publishing:
+
+- Current default branch.
+- Default workflow catalog.
+- Supported CLI subcommands.
+- Provider configuration fields.
+- Binary versus source setup behavior.
+- GitHub adapter requirements.
+- Web UI URLs and health endpoints.
+- Any model identifier.
+- Any statement about unavailable commands.
+
+## Updating Examples
+
+When an example changes:
+
+1. Update the practical tutorial first.
+2. Update the curriculum guide if pacing or assessment changes.
+3. Update exercise pages if the example is used in labs.
+4. Update sample artifacts if expected evidence changes.
+5. Update the reading map if new pages are added.
+6. Run the docs build.
+
+## Handling Uncertainty
+
+If a claim cannot be verified:
+
+- Remove it, or
+- Mark it explicitly as a maintenance note, or
+- Point learners to the live command that discovers the answer.
+
+Prefer:
+
+```text
+Run archon workflow list for the current workflow catalog.
+```
+
+Avoid:
+
+```text
+Archon always ships exactly N workflows.
+```
+
+## Safety Regression Review
+
+Before publishing, inspect whether any new text encourages:
+
+- Real repositories before sandbox practice.
+- Secrets in chat or shared notes.
+- Modifying work without isolation.
+- Provider routing before a baseline.
+- Approval gates removed for convenience.
+- Autonomous merge while learning.
+- Trusting assistant summaries without evidence.
+
+If it does, rewrite the section.
+
+## Cohort Feedback Loop
+
+After each cohort, record:
+
+```text
+Repeated setup blocker:
+Most confusing term:
+Exercise that took too long:
+Exercise that was too easy:
+Safety rule that needed repetition:
+Docs page that learners opened most:
+Docs page that was missing:
+Recommended curriculum update:
+```
+
+Turn repeated blockers into:
+
+- FAQ entries.
+- Troubleshooting labs.
+- Instructor notes.
+- Setup guide changes.
+
+Use [Cohort Report](/learning/cohort-report/) and
+[Curriculum Metrics](/learning/curriculum-metrics/) to decide which updates are
+worth making.
+
+## Build Verification
+
+Run:
+
+```bash
+bun --filter @archon/docs-web build
+```
+
+Expected:
+
+```text
+Build completes and generates the learning routes.
+```
+
+If the build fails, fix schema, frontmatter, route, or Markdown issues before
+publishing.

--- a/packages/docs-web/src/content/docs/learning/model-role-recipes.md
+++ b/packages/docs-web/src/content/docs/learning/model-role-recipes.md
@@ -1,0 +1,286 @@
+---
+title: Model Role Recipes
+description: Practical Archon model-routing recipes for guided vibe coding projects.
+category: learning
+audience: [user, operator]
+status: current
+sidebar:
+  order: 12
+---
+
+Use these recipes after a single-provider workflow works. They turn model
+routing into a practical project pattern instead of a model comparison game.
+
+## Core Rule
+
+Assign models by workflow responsibility:
+
+- Planning and test strategy need careful reasoning.
+- Inner development needs reliable file editing and fast iteration.
+- Validation should be deterministic whenever possible.
+- Review should be independent from implementation when risk is meaningful.
+
+Do not route by hype, novelty, or preference. Route only when the node's job
+justifies a different provider.
+
+## Default Guided Project Shape
+
+Use this shape for personal and team vibe coding projects:
+
+```text
+request
+  -> clarify scope
+  -> plan with Claude or Codex
+  -> approve plan
+  -> implement with Gemini, Qwen, Kimi, Codex, or Claude
+  -> run deterministic validation
+  -> review with Claude or Codex
+  -> approve final result
+  -> prepare PR or stop with run report
+```
+
+Every model boundary should pass through an artifact, not hidden chat memory.
+
+## Recommended Role Split
+
+| Role | Good default | Why |
+| --- | --- | --- |
+| Scope clarification | Codex or Claude | Keeps the request, repository, and risk boundary precise. |
+| Planning | Claude or Codex with stronger reasoning settings | Produces file-aware plans, validation strategy, and rollback notes. |
+| Inner development | Gemini, Qwen, Kimi, Codex, or Claude after local verification | Handles implementation iterations once the plan is explicit. |
+| Deterministic validation | `bash:` or `script:` node | Avoids trusting an assistant summary for pass/fail. |
+| Review and test critique | Claude or Codex, preferably not the implementer | Gives an independent read of the diff, tests, risks, and PR readiness. |
+| PR creation | Existing Archon PR command or GitHub workflow | Keeps repository publication explicit and reviewable. |
+
+## Provider Mapping
+
+Archon provider names are not the same thing as model brands.
+
+| Desired model family | Typical Archon route | Notes |
+| --- | --- | --- |
+| Claude | `provider: claude` or `provider: pi` with an Anthropic model | Use `provider: claude` when you need Claude-specific hooks, MCP, skills, or sub-agents. |
+| Codex | `provider: codex` | Good default for planning, repository exploration, implementation, and review. |
+| Gemini | `provider: pi`, model like `google/<verified-model-id>` | Verify the exact model ID locally; do not invent Gemini model strings. |
+| Qwen | `provider: pi`, often local/custom or OpenRouter | Examples may look like `openrouter/qwen/qwen3-coder` or a local Pi model ID. |
+| Kimi | `provider: pi`, often OpenRouter or custom OpenAI-compatible endpoint | Verify the provider and model ID in Pi before committing workflow YAML. |
+| Local models | `provider: pi` with local/custom provider registration | Register in `~/.pi/agent/models.json` and keep a cloud or Codex fallback. |
+
+## Recipe 1: Personal Local Feature
+
+Use this for a solo developer working locally in a sandbox or low-risk repo.
+
+```text
+Planner:
+Claude or Codex writes `$ARTIFACTS_DIR/plan.md`.
+
+Approval:
+Human approves, revises, or rejects the plan.
+
+Inner developer:
+Gemini, Qwen, Kimi, Codex, or Claude implements only the approved plan.
+
+Validation:
+`bash:` runs the project test command.
+
+Reviewer:
+Claude or Codex reviews the diff and validation output.
+
+Final decision:
+Human decides whether to keep the branch, revise, or discard it.
+```
+
+Completion evidence:
+
+```text
+Plan artifact:
+Approved scope:
+Implementation provider:
+Changed files:
+Validation command:
+Review artifact:
+Final human decision:
+Rollback path:
+```
+
+## Recipe 2: Team GitHub Issue To PR
+
+Use this after the learner has completed the GitHub capstone in a disposable
+repository.
+
+```text
+Issue intake:
+Codex or Claude summarizes the issue and names risk.
+
+Plan:
+Claude or Codex writes a plan with files, tests, rollback, and stop conditions.
+
+Approval:
+Reviewer approves the plan before implementation.
+
+Implementation:
+Gemini, Qwen, Kimi, Codex, or Claude implements in an isolated worktree.
+
+Validation:
+`bash:` or `script:` runs deterministic checks.
+
+Independent review:
+Claude or Codex reviews the diff, tests, artifacts, and PR readiness.
+
+PR:
+Archon prepares or creates a PR, then stops before merge.
+```
+
+Team evidence:
+
+```text
+Issue:
+Branch:
+Reviewer:
+Plan approval:
+Implementation provider and fallback:
+Validation:
+Review decision:
+PR link or PR-ready note:
+No autonomous merge:
+```
+
+## Recipe 3: Frontend Guided Build
+
+Use this when one model is stronger at product planning and another is stronger
+at UI iteration.
+
+```text
+Content and acceptance criteria:
+Claude or Codex names user goal, states, edge cases, and validation.
+
+UI implementation:
+Gemini, Qwen, Kimi, Codex, or Claude builds the interface.
+
+Build validation:
+`bash:` runs lint, type-check, tests, or build.
+
+Visual review:
+Human inspects the Web UI. Use browser testing when the app is local and
+interactive.
+
+Code review:
+Claude or Codex reviews integration, accessibility, and test gaps.
+```
+
+Do not accept a frontend result only because it looks good. The build and
+integration checks still decide whether the implementation is usable.
+
+## Recipe 4: Server Or Deployed Team Operation
+
+Use this after local workflows are reliable.
+
+```text
+Deployment boundary:
+Human defines where Archon runs, which adapters are enabled, where secrets live,
+and who can trigger workflows.
+
+Operator setup:
+Docker or VPS environment starts with health checks.
+
+Remote trigger:
+GitHub webhook or chat adapter receives a sandbox request.
+
+Workflow:
+Plan, approve, implement, validate, review, and prepare PR.
+
+Recovery:
+Operator inspects logs, artifacts, health endpoints, and rollback path.
+```
+
+Required boundary note:
+
+```text
+Runtime location:
+Database:
+Enabled adapters:
+Allowed users:
+Secrets location:
+Health checks:
+Log location:
+Artifact location:
+Rollback:
+Incident contact:
+```
+
+## Minimal YAML Sketch
+
+Use this as a sketch, not a copy-paste promise. Replace provider names and model
+IDs with values verified in your environment.
+
+```yaml
+name: guided-feature-routing
+description: Plan with a reasoning model, implement with a verified inner-dev model, validate deterministically, and review independently.
+interactive: true
+provider: codex
+
+nodes:
+  - id: plan
+    prompt: |
+      Write an implementation plan for: $ARGUMENTS
+      Include files, validation command, risks, and rollback.
+      Save the plan summary in your response.
+
+  - id: approve-plan
+    depends_on: [plan]
+    approval:
+      prompt: Review the plan. Approve only if files, validation, risks, and rollback are clear.
+      capture_response: true
+
+  - id: implement
+    depends_on: [approve-plan]
+    provider: pi
+    model: openrouter/qwen/qwen3-coder
+    prompt: |
+      Implement only the approved plan.
+      Plan:
+      $plan.output
+      Approval note:
+      $approve-plan.output
+
+  - id: validate
+    depends_on: [implement]
+    bash: npm test
+
+  - id: review
+    depends_on: [validate]
+    provider: codex
+    prompt: |
+      Review the implementation and validation result.
+      Identify bugs, missing tests, secret exposure, and PR readiness gaps.
+      Validation:
+      $validate.output
+```
+
+## Fallback Rules
+
+Before a routed workflow reaches a real repository, write:
+
+```text
+Primary inner-development provider:
+Verified model ID:
+Fallback provider:
+What to do if provider auth fails:
+What to do if output quality drops:
+What to do if validation fails:
+```
+
+Fallbacks should be explicit. A provider failure should pause or reroute the
+workflow; it should not silently broaden permissions or skip validation.
+
+## Completion Checklist
+
+You are ready to use role-based routing when:
+
+- The same task works with one provider first.
+- Every extra provider is installed, authenticated, and model IDs are verified.
+- Planning and implementation communicate through artifacts or explicit node
+  outputs.
+- Deterministic validation runs after implementation.
+- Review is independent for team or higher-risk work.
+- The workflow stops before merge or deployment unless a separate team policy
+  explicitly allows it.

--- a/packages/docs-web/src/content/docs/learning/office-hours-guide.md
+++ b/packages/docs-web/src/content/docs/learning/office-hours-guide.md
@@ -1,0 +1,133 @@
+---
+title: Office Hours Guide
+description: How to run Archon curriculum office hours without turning them into unstructured debugging.
+category: learning
+audience: [operator, user]
+status: current
+sidebar:
+  order: 24
+---
+
+Use office hours to unblock learners while preserving the curriculum's evidence
+habits. The goal is not to fix everything live. The goal is to teach learners
+how to inspect, explain, and recover.
+
+## Office Hours Format
+
+Default format:
+
+1. Learner states the goal.
+2. Learner states the safety boundary.
+3. Learner shows sanitized evidence.
+4. Facilitator asks evidence-first questions.
+5. Learner chooses the next action.
+6. Learner records the decision.
+
+Keep each case to 10 to 15 minutes. If the issue needs more time, turn it into
+a blocker note with an owner.
+
+## What Learners Should Bring
+
+Ask learners to bring:
+
+```text
+Repository:
+Branch or worktree:
+Workflow or command:
+Request:
+Run status:
+Artifact inspected:
+Log inspected:
+Validation command:
+Validation result:
+Question:
+```
+
+They should not bring:
+
+- API keys.
+- OAuth tokens.
+- Provider auth files.
+- Full `.env` contents.
+- Raw logs that have not been inspected for secrets.
+
+## Triage Questions
+
+Ask in this order:
+
+1. What were you trying to do?
+2. What repository did Archon use?
+3. What branch or worktree did it use?
+4. What changed on disk?
+5. What artifact did you inspect?
+6. What log did you inspect?
+7. What validation ran?
+8. What did the assistant claim?
+9. What evidence confirms or contradicts that claim?
+10. What decision are you considering?
+
+## Common Office Hours Cases
+
+| Case | Response |
+| --- | --- |
+| Setup blocked | Record exact command and output summary, assign owner, move learner to workbook or evidence review. |
+| Workflow failed | Inspect status, logs, artifacts, and changed files before rerunning. |
+| Plan is vague | Require a revision request that names files, validation, risk, and rollback. |
+| Provider unavailable | Fall back to a single-provider baseline and verify provider setup privately later. |
+| PR feels ready | Require a PR readiness note and human review before merge. |
+| Learner wants real repo | Ask for risk boundary, validation, approval gate, and rollback path first. |
+
+## Decision Outcomes
+
+Every office-hours case should end with one outcome:
+
+| Outcome | Meaning |
+| --- | --- |
+| Continue | Learner has enough evidence and a safe next step. |
+| Revise | Learner needs to change a command, workflow, plan, or request. |
+| Remediate | Learner should repeat a specific exercise. |
+| Defer | Evidence is missing or risk is too high. |
+| Escalate | A maintainer, operator, or provider-specific expert is needed. |
+
+## Office Hours Note
+
+```text
+Learner:
+Date:
+Goal:
+Safety boundary:
+Evidence shown:
+Missing evidence:
+Decision:
+Next action:
+Owner:
+Follow-up needed:
+```
+
+## Facilitator Boundaries
+
+Do:
+
+- Ask for evidence.
+- Keep secrets out of shared spaces.
+- Prefer small next steps.
+- Record blockers.
+- Assign remediation when a skill gap is visible.
+
+Do not:
+
+- Take over the learner's terminal for the whole session.
+- Debug provider credentials in shared view.
+- Approve vague plans to save time.
+- Encourage merge or deployment during beginner support.
+- Let office hours replace the capstone.
+
+## Closing Prompt
+
+End with:
+
+```text
+What will you do next?
+What evidence will prove it worked?
+What will make you stop?
+```

--- a/packages/docs-web/src/content/docs/learning/outcomes-matrix.md
+++ b/packages/docs-web/src/content/docs/learning/outcomes-matrix.md
@@ -1,0 +1,82 @@
+---
+title: Learning Outcomes Matrix
+description: Curriculum outcomes mapped to evidence, exercises, assessment, and remediation.
+category: learning
+audience: [operator, user]
+status: current
+sidebar:
+  order: 30
+---
+
+Use this matrix to connect curriculum goals to observable evidence. It helps
+facilitators avoid vague pass/fail decisions.
+
+## Outcome Levels
+
+| Level | Meaning |
+| --- | --- |
+| Introduced | Learner has seen the concept and can define it with help. |
+| Practiced | Learner has completed a sandbox exercise. |
+| Demonstrated | Learner can show evidence without prompting. |
+| Ready | Learner can apply the skill in supervised real-repository work. |
+
+## Outcomes
+
+| Outcome | Evidence | Practice | Assessment | Remediation |
+| --- | --- | --- | --- | --- |
+| Explain Archon as a harness | Harness goal, glossary use | Orientation workbook | Knowledge check Unit 1 | Re-read glossary and write a one-sentence harness goal |
+| Protect secrets | No secrets in notes, logs, artifacts, or diffs | Setup workbook | Facilitator evidence checklist | Safety gap remediation |
+| Use sandbox first | Training repository and risk boundary | Sandbox setup | Graduation checklist | Sandbox boundary prompt |
+| Run safe workflow | Run report | Repository explanation exercise | Capstone local operator option | Evidence hunt |
+| Inspect evidence | Status, logs, artifacts, changed files | Evidence hunt | Run report review | Evidence inspection remediation |
+| Author narrow command/workflow | Validated command or workflow | Authoring lab | Workflow author capstone | Authoring remediation |
+| Review approval gate | Approval review note | Approval gate drill | Supervised automation lab | Approval judgment remediation |
+| Run deterministic validation | Validation command and result | Minimal workflow exercise | Capstone report | Validation note review |
+| Route providers intentionally | Baseline and routing decision note | Provider routing lab | Provider router capstone | Provider routing remediation |
+| Assign model roles in guided projects | Model-role decision note, verified model IDs, artifact handoffs | Model role routing project | Model-role project operator capstone | Repeat baseline and justify one routed node |
+| Prepare supervised PR | PR readiness note | PR readiness drill | GitHub operator capstone | GitHub readiness remediation |
+| Operate team/server boundary | Runtime boundary note, health checks, logs, artifacts, rollback | Server or deployed team operation rehearsal | Team remote operator capstone | Repeat local flow and document adapter exposure |
+| Transition to real repository | Graduation checklist and reviewer boundary | Capstone | Real repository transition review | Repeat capstone or focused remediation |
+
+## Evidence Quality
+
+Good evidence is:
+
+- Specific.
+- Secret-free.
+- Inspectable by another person.
+- Tied to a human decision.
+- Clear about what it does not prove.
+
+Weak evidence is:
+
+- Only an assistant summary.
+- Missing repository or branch context.
+- Missing validation output.
+- Missing changed files.
+- Missing stop condition or rollback.
+
+## Matrix Review
+
+Before graduating a learner, pick one row where the learner is weakest and ask:
+
+```text
+What evidence proves this skill?
+Who inspected it?
+What would make this evidence insufficient?
+What remediation would prove the skill?
+```
+
+## Team Use
+
+For a cohort, aggregate by outcome:
+
+```text
+Outcome:
+Learners ready:
+Learners needing remediation:
+Common evidence gap:
+Curriculum page to improve:
+```
+
+Use the aggregate to improve the curriculum, not to shame learners.

--- a/packages/docs-web/src/content/docs/learning/package-map.md
+++ b/packages/docs-web/src/content/docs/learning/package-map.md
@@ -1,0 +1,80 @@
+---
+title: Curriculum Package Map
+description: A map of every Archon curriculum asset and when to use it.
+category: learning
+audience: [user, operator, developer]
+status: current
+sidebar:
+  order: 33
+---
+
+Use this map when you need to find the right curriculum asset quickly. The
+practical tutorial is the lesson body. The rest of the package helps you teach,
+practice, assess, support, and maintain it.
+
+## Core Learning Path
+
+| Asset | Use when |
+| --- | --- |
+| [Curriculum Syllabus](/learning/syllabus/) | You need course framing, schedule, requirements, and completion policy. |
+| [Quick-Start Paths](/learning/quick-start-paths/) | You need the shortest next-step path for a specific role or situation. |
+| [Practical Tutorial](/learning/practical-tutorial/) | A learner needs the full step-by-step lesson body. |
+| [Curriculum Guide](/learning/curriculum/) | You need self-study, workshop, hybrid, assessment, and adaptation guidance. |
+| [Learner Workbook](/learning/learner-workbook/) | A learner needs day-by-day prompts and evidence notes. |
+| [Reading Map](/learning/reading-map/) | A role needs a customized path through the material. |
+
+## Teaching And Facilitation
+
+| Asset | Use when |
+| --- | --- |
+| [Workshop Session Plans](/learning/session-plans/) | You are teaching the seven-session workshop. |
+| [Instructor Notes](/learning/instructor-notes/) | You need teaching scripts, prompts, and facilitation moves. |
+| [Slide Outline](/learning/slide-outline/) | You need to create a workshop deck. |
+| [Cohort Runbook](/learning/cohort-runbook/) | You are preparing or operating a cohort. |
+| [Sandbox Setup Guide](/learning/sandbox-setup/) | You need resettable repositories for exercises. |
+
+## Practice And Support
+
+| Asset | Use when |
+| --- | --- |
+| [Exercise Bank](/learning/exercise-bank/) | Learners need extra practice. |
+| [Troubleshooting Labs](/learning/troubleshooting-labs/) | Learners need prepared failure scenarios. |
+| [Provider Routing Lab](/learning/provider-routing-lab/) | Learners are ready to practice multi-provider routing. |
+| [Model Role Recipes](/learning/model-role-recipes/) | Learners need practical model-role patterns for guided coding projects. |
+| [Office Hours Guide](/learning/office-hours-guide/) | Learners need between-session support. |
+| [Peer Review Practice](/learning/peer-review-practice/) | Learners need structured evidence review with each other. |
+| [Learner FAQ](/learning/faq/) | Learners ask common questions. |
+
+## Assessment And Graduation
+
+| Asset | Use when |
+| --- | --- |
+| [Knowledge Checks](/learning/knowledge-checks/) | You need unit questions or discussion prompts. |
+| [Facilitator Evaluation](/learning/facilitator-evaluation/) | You need to score readiness and record sign-off. |
+| [Capstone Assessment](/learning/capstone-assessment/) | Learners are completing final exercises. |
+| [Learning Outcomes Matrix](/learning/outcomes-matrix/) | You need to map skills to evidence and remediation. |
+| [Graduation Checklist](/learning/graduation-checklist/) | A learner may be ready for supervised real-repository work. |
+
+## Rollout And Maintenance
+
+| Asset | Use when |
+| --- | --- |
+| [Real Repository Transition](/learning/real-repository-transition/) | A learner is moving from sandbox to first real run. |
+| [Team Adoption Path](/learning/team-adoption-path/) | A team is rolling Archon out beyond individual learners. |
+| [Cohort Report](/learning/cohort-report/) | A cohort has finished and needs a summary. |
+| [Curriculum Metrics](/learning/curriculum-metrics/) | You need to evaluate training effectiveness safely. |
+| [Curriculum Maintenance Guide](/learning/maintenance-guide/) | You need to keep curriculum claims current. |
+| [Publishing Checklist](/learning/publishing-checklist/) | You are publishing or teaching soon. |
+| [Version Review](/learning/version-review/) | Archon source, release, workflows, or providers changed. |
+| [Tutorial Plan](/learning/tutorial-plan/) | You need source inventory and verification notes. |
+
+## Reference Helpers
+
+| Asset | Use when |
+| --- | --- |
+| [Learning Landing Page](/learning/) | You need the grouped table of contents for the curriculum. |
+| [Curriculum Package Map](/learning/package-map/) | You need this complete asset map. |
+| [Curriculum Templates](/learning/templates/) | You need copy-ready notes and reports. |
+| [Sample Artifacts](/learning/sample-artifacts/) | Learners need examples of acceptable evidence. |
+| [Curriculum Glossary](/learning/glossary/) | Learners need shared vocabulary. |
+| [Printable Checklist Pack](/learning/printable-checklists/) | You need compact checklists for live sessions. |

--- a/packages/docs-web/src/content/docs/learning/peer-review-practice.md
+++ b/packages/docs-web/src/content/docs/learning/peer-review-practice.md
@@ -1,0 +1,149 @@
+---
+title: Peer Review Practice
+description: Structured peer-review exercises for Archon curriculum learners.
+category: learning
+audience: [user, operator]
+status: current
+sidebar:
+  order: 26
+---
+
+Peer review helps learners practice evidence inspection without relying on the
+facilitator for every decision. Use these exercises after learners have
+completed at least one run report.
+
+## Peer Review Rules
+
+- Review evidence, not personality.
+- Ask for missing evidence before giving advice.
+- Do not request secrets.
+- Do not approve merge during beginner practice.
+- Write down the decision.
+
+## Pair Review Format
+
+Learner A presents:
+
+```text
+Workflow or command:
+Repository:
+Branch or worktree:
+Request:
+Changed files:
+Artifacts:
+Logs:
+Validation:
+Human decision:
+Question for reviewer:
+```
+
+Learner B reviews:
+
+```text
+Evidence I could verify:
+Evidence missing:
+Risk I see:
+Suggested decision:
+Checklist update:
+```
+
+Then switch roles.
+
+## Review Exercise 1: Run Report Review
+
+Goal:
+
+- Determine whether a run report is complete enough for another person to
+  understand the run.
+
+Reviewer checks:
+
+- Repository and branch are named.
+- Changed files are named or explicitly "none."
+- Artifacts and logs are mentioned.
+- Validation output is summarized.
+- Human decision is clear.
+
+Decision:
+
+```text
+accept / revise / defer
+```
+
+## Review Exercise 2: Approval Review
+
+Goal:
+
+- Practice approving or rejecting a plan artifact.
+
+Reviewer checks:
+
+- Files are named.
+- Validation is named.
+- Risk is named.
+- Rollback is named.
+- Scope matches the request.
+
+Decision:
+
+```text
+approve / reject / revise / defer
+```
+
+## Review Exercise 3: PR Readiness Review
+
+Goal:
+
+- Decide whether a branch is ready for PR review, not merge.
+
+Reviewer checks:
+
+- Diff summary matches changed files.
+- Validation evidence exists.
+- Artifacts support the summary.
+- Secrets are not present in shared evidence.
+- Manual review concern is named.
+
+Decision:
+
+```text
+ready for PR review / revise branch / defer / stop
+```
+
+## Reviewer Prompts
+
+Use these prompts:
+
+```text
+What evidence did you inspect directly?
+What did the assistant claim?
+Which claim is confirmed?
+Which claim remains uncertain?
+What would make you stop?
+What is the rollback path?
+```
+
+## Peer Review Note
+
+```text
+Presenter:
+Reviewer:
+Artifact reviewed:
+Evidence present:
+Evidence missing:
+Decision:
+Revision request:
+Checklist update:
+```
+
+## Facilitator Use
+
+Use peer review when:
+
+- The group is large.
+- Learners need more evidence practice.
+- Office hours are overloaded.
+- A learner needs remediation but not a full facilitator review.
+
+Do not use peer review as the only capstone assessment. A facilitator or
+designated reviewer should still sign off on real-repository readiness.

--- a/packages/docs-web/src/content/docs/learning/practical-tutorial.md
+++ b/packages/docs-web/src/content/docs/learning/practical-tutorial.md
@@ -1,0 +1,2782 @@
+---
+title: Archon Practical Tutorial
+description: A source-backed learning path from first install to supervised issue-to-PR workflows.
+category: learning
+audience: [user, operator]
+status: current
+sidebar:
+  order: 1
+---
+
+This tutorial teaches Archon as a practical harness for real software projects.
+It is written for a learner on Windows who wants cross-platform commands,
+the CLI and Web UI, Codex plus Gemini through Pi, a disposable sandbox
+repository, personal local usage first, team usage later, and human approval
+gates enabled while learning.
+
+## Setup Profile Used In This Tutorial
+
+- Operating system: Windows-first, with macOS, Linux, and WSL notes.
+- Recommended Windows mode: WSL2 for full workflow compatibility; native
+  PowerShell is fine for basic server, Web UI, and simple workflows.
+- Interfaces: CLI plus Web UI.
+- Assistants: Codex first; Pi for Gemini and other community-provider routing.
+- Repository: disposable sandbox before any real project.
+- Usage goal: personal local usage first, team usage later.
+- Safety posture: human approval gates enabled; no autonomous merge as the
+  learning default.
+
+> Security warning
+>
+> Do not paste API keys, GitHub tokens, OAuth tokens, or `.env` contents into
+> chat. Use placeholders in notes, and enter secrets locally in Archon-owned
+> environment files or setup screens.
+
+## Source And Verification Notes
+
+Official source of truth:
+
+- `README.md`
+- `CONTRIBUTING.md`
+- `.archon/workflows/defaults/`
+- `.archon/commands/defaults/`
+- `.claude/skills/archon/`
+- `packages/docs-web/src/content/docs/`
+- `packages/cli/`
+- `packages/providers/`
+- `packages/server/`
+- `packages/adapters/`
+
+Additional verification:
+
+- The current remote default branch was checked dynamically with
+  `git remote show origin`; it is `dev` at the time this tutorial was written.
+- Context7 resolved Archon docs to `/websites/archon_diy`.
+- The published URLs `https://archon.diy/llms.txt`,
+  `https://archon.diy/llms-small.txt`, and
+  `https://archon.diy/llms-full.txt` returned 404 during this review, so they
+  are not used as evidence here.
+
+Transcript sources in `transcripts/` are used only as case studies. Official
+repo documentation overrides any transcript claim.
+
+## Curriculum Map
+
+Use this map to choose a pace. The full path is designed for a careful first
+week, but each milestone can also stand alone as a workshop session.
+
+| Milestone | Parts | Time | Outcome |
+| --- | --- | --- | --- |
+| Orientation | 0-1 | 45-60 minutes | You can explain Archon's harness model and choose the safe starting path. |
+| Local setup | 2-3 | 60-120 minutes | Archon runs locally against a disposable sandbox repository. |
+| First workflows | 4-5 | 90-150 minutes | You can run built-in workflows and inspect runs, worktrees, logs, and artifacts. |
+| Authoring basics | 6-7 | 2-4 hours | You can create a custom command and a custom YAML workflow. |
+| Supervised automation | 8-10 | 3-6 hours | You can build a Plan-Implement-Validate workflow and route provider work intentionally. |
+| Interfaces and operations | 11-14 | 2-5 hours | You can use GitHub, understand adapters, deploy safely, and troubleshoot common failures. |
+| Capstone | 15-16 | 2-4 hours | You can complete a supervised issue-to-PR workflow and keep a personal operating checklist. |
+
+Suggested modes:
+
+- Self-study: complete one milestone per day and keep a run journal.
+- Workshop: teach one milestone per session, with the capstone as the final lab.
+- Team onboarding: assign Parts 0-8 to everyone, then split provider, GitHub,
+  deployment, and troubleshooting topics by role.
+
+---
+
+# Part 0 - Executive Overview
+
+## Learning Objective
+
+Understand what Archon is, why it exists, and what it should and should not
+automate during your first week.
+
+## Why This Matters
+
+If you treat Archon as "a bigger prompt," you will miss its main value. Archon
+is useful because it makes the process repeatable: the same phases, the same
+handoffs, and the same validation gates every run.
+
+## Prerequisites
+
+None. This part is conceptual.
+
+## What Archon Is
+
+Archon is a workflow engine for AI coding agents. You write your development
+process as YAML workflows, then Archon runs those workflows through coding
+assistants such as Claude, Codex, and Pi.
+
+Instead of asking one chat session to remember the whole process, you encode the
+process:
+
+```text
+investigate -> plan -> approve -> implement -> validate -> review -> approve -> PR
+```
+
+The AI still reasons and writes code, but the structure is deterministic and
+owned by you.
+
+## Prompt Engineering, Context Engineering, And Harness Engineering
+
+Prompt engineering is writing better instructions for one model call.
+
+Context engineering is choosing the right files, docs, examples, rules, and
+prior outputs to give the assistant.
+
+Harness engineering is designing the process around the assistant: separate
+steps, fresh sessions, explicit artifacts, deterministic checks, isolation, and
+human approval gates.
+
+Archon is mainly a harness engineering tool.
+
+## Vocabulary
+
+Assistant: the coding agent client that executes work, such as Claude Code,
+Codex CLI, or Pi.
+
+Model: the specific model used by an assistant, such as a Codex model or a Pi
+model reference.
+
+Provider: the Archon workflow provider name, such as `claude`, `codex`, or
+`pi`.
+
+Command: a Markdown prompt template in `.archon/commands/`.
+
+Workflow: a YAML file in `.archon/workflows/` that connects nodes into a DAG.
+
+Node: one step in a workflow. A node can be an AI command, inline prompt, bash
+script, script node, loop, approval gate, or cancellation.
+
+Artifact: a file written to `$ARTIFACTS_DIR` so another node can read it later.
+
+Worktree: an isolated Git working directory for a workflow run.
+
+Adapter: a user-facing interface such as CLI, Web UI, GitHub, Slack, Telegram,
+or Discord.
+
+Human approval gate: a workflow pause where a human approves or rejects the next
+step.
+
+## First Week Automation Boundary
+
+During week one, Archon should automate:
+
+- Repository explanation and exploration.
+- Planning artifacts.
+- Safe branch/worktree setup.
+- Repetitive implementation on disposable tasks.
+- Deterministic validation commands.
+- Draft pull requests.
+- Review summaries.
+
+During week one, Archon should not automate:
+
+- Merging to protected branches.
+- Rotating or reading secrets unless you explicitly decide it is safe.
+- Production deployment.
+- Large rewrites in an important repo without a plan approval gate.
+- Unreviewed GitHub issue-to-merge loops.
+
+## Mental Model Diagram
+
+```text
+User request
+  -> Archon workflow
+  -> isolated worktree
+  -> planning
+  -> human plan approval
+  -> implementation
+  -> deterministic validation
+  -> review
+  -> human final approval
+  -> pull request
+```
+
+## Verification Checklist
+
+- You can explain why a workflow is more repeatable than one long chat.
+- You can name where commands and workflows live.
+- You understand that artifacts, not hidden conversation memory, are the safe
+  handoff mechanism.
+
+## Expected Result
+
+You should be able to describe Archon as a workflow harness for coding agents,
+not as a replacement for human engineering judgment.
+
+## Common Mistakes
+
+- Treating a workflow as a bigger prompt instead of a process.
+- Relying on one AI conversation to remember everything.
+- Skipping human gates before implementation.
+- Letting transcripts define "official" behavior when repo docs disagree.
+
+## Mini Exercise
+
+Write a one-sentence harness goal for your first sandbox task:
+
+```text
+I want Archon to explore a disposable repo, write a plan, pause for review,
+implement one small change, run tests, and stop before merging.
+```
+
+## Completion Checkpoint
+
+Move on when you can explain the diagram in your own words.
+
+## Source References
+
+- `README.md`
+- `packages/docs-web/src/content/docs/book/what-is-archon.md`
+- `packages/docs-web/src/content/docs/getting-started/concepts.md`
+- `packages/docs-web/src/content/docs/guides/authoring-workflows.md`
+- `packages/docs-web/src/content/docs/guides/authoring-commands.md`
+
+---
+
+# Part 1 - Choose The Correct Starting Path
+
+## Learning Objective
+
+Choose the setup path that gets you to a safe first run quickly.
+
+## Why This Matters
+
+The wrong starting path makes Archon feel more complex than it is. A local
+source setup gives you visibility into workflows and commands while keeping
+deployment concerns out of the first lesson.
+
+## Prerequisites
+
+You should know which operating system and assistant path you intend to use.
+
+## Recommended Path For You
+
+Use this order:
+
+1. Source-based local setup in WSL2.
+2. CLI plus Web UI.
+3. Codex configured as the first assistant.
+4. Pi configured later for Gemini routing.
+5. Disposable Git sandbox.
+6. Human approval gates.
+7. GitHub issue-to-PR only after local workflows are comfortable.
+
+This gives you the most compatibility for worktrees, shell nodes, Web UI, and
+GitHub workflows without starting with VPS complexity.
+
+## Decision Tree
+
+Choose guided full setup if you want Archon to walk you through credentials and
+project setup. Avoid it if you want to understand each file manually.
+
+Choose quick CLI installation if you want the fastest `archon` binary. Avoid it
+if you want to inspect and modify Archon source while learning.
+
+Choose source-based local development if you want the Web UI, repo examples,
+and current workflow files visible. This is the recommended path for this
+tutorial.
+
+Choose Web UI first if visual monitoring and approval buttons matter. Avoid it
+if you want minimal terminal-only operation.
+
+Choose CLI-only if you want repeatable terminal commands. Avoid it if you are
+learning approval gates, because the Web UI makes paused runs easier to see.
+
+## Verification Checklist
+
+- You know which path you are following.
+- You know whether you are in native Windows, WSL2, macOS, or Linux.
+- You have decided not to use a real production repo for the first run.
+
+## Expected Result
+
+You should choose source-based local setup, CLI plus Web UI, Codex first, Pi
+later, and a disposable sandbox repository.
+
+## Common Mistakes
+
+- Running Archon from the Archon repo when the target should be your sandbox
+  repo.
+- Starting with VPS deployment before local validation.
+- Trying mixed-provider workflows before a single-provider workflow works.
+
+## Mini Exercise
+
+Write down your path:
+
+```text
+I will use WSL2/source setup, CLI plus Web UI, Codex first, and a disposable sandbox.
+```
+
+## Completion Checkpoint
+
+Move on when the starting path is settled and you are not planning to use a real
+project for the first workflow.
+
+## Source References
+
+- `README.md`
+- `packages/docs-web/src/content/docs/getting-started/overview.md`
+- `packages/docs-web/src/content/docs/getting-started/installation.md`
+- `packages/docs-web/src/content/docs/deployment/windows.md`
+
+---
+
+# Part 2 - Installation And Safe Verification
+
+## Learning Objective
+
+Install Archon, verify the CLI and Web UI, configure Codex safely, and avoid
+secret leakage.
+
+## Why This Matters
+
+Most early Archon failures come from environment setup: missing binaries,
+wrong PATH, unclear provider authentication, or secrets in the wrong file.
+
+## Prerequisites
+
+Install:
+
+- Git
+- Bun
+- GitHub CLI, `gh`, for GitHub workflows and PR creation
+- Codex CLI
+- Optional but often useful: Claude Code, because many current default
+  workflows and docs are Claude-oriented
+- Pi, when you reach the Gemini module
+
+## Step-By-Step Summary
+
+1. Install system tools.
+2. Clone Archon.
+3. Run `bun install`.
+4. Link the CLI.
+5. Configure Codex.
+6. Start the Web UI.
+7. Run health checks.
+8. Confirm no secrets were placed in the target repo `.env`.
+
+> Current-docs note
+>
+> The installation docs still describe Claude Code as required for the primary
+> path, while the AI Assistants docs say Archon can configure Claude, Codex, and
+> Pi. For a Codex-first learner, configure Codex, then treat Claude-only fields
+> and Claude-declared default workflows carefully.
+
+## Windows Recommended Setup: WSL2
+
+PowerShell:
+
+```powershell
+wsl --install
+```
+
+Restart if prompted. Open Ubuntu from the Start menu.
+
+Inside WSL2:
+
+```bash
+sudo apt update
+sudo apt install -y git curl
+curl -fsSL https://bun.sh/install | bash
+source ~/.bashrc
+```
+
+Install GitHub CLI inside WSL2 using the current GitHub CLI instructions for
+your distribution, then verify:
+
+```bash
+git --version
+bun --version
+gh --version
+```
+
+## Native Windows Basic Setup
+
+PowerShell:
+
+```powershell
+git --version
+irm bun.sh/install.ps1 | iex
+bun --version
+winget install GitHub.cli
+gh --version
+```
+
+Native Windows works for basic server, Web UI, and simple workflows. WSL2 is
+recommended for full worktree and shell compatibility.
+
+## Clone And Install Archon From Source
+
+macOS, Linux, or WSL:
+
+```bash
+git clone https://github.com/coleam00/Archon
+cd Archon
+bun install
+```
+
+Windows PowerShell:
+
+```powershell
+git clone https://github.com/coleam00/Archon
+cd Archon
+bun install
+```
+
+## Link The CLI
+
+From the Archon repo:
+
+```bash
+cd packages/cli
+bun link
+cd ../..
+archon version
+```
+
+If `archon` is not found, make sure Bun's bin directory is on your `PATH`.
+
+## Configure Codex
+
+Install Codex:
+
+```bash
+npm install -g @openai/codex
+codex login
+```
+
+The current docs describe Codex credential environment variables:
+
+```ini
+CODEX_ID_TOKEN=...
+CODEX_ACCESS_TOKEN=...
+CODEX_REFRESH_TOKEN=...
+CODEX_ACCOUNT_ID=...
+```
+
+Do not paste these into chat. Prefer `archon setup`, `~/.archon/.env`, or a
+private local editor.
+
+Create or edit `~/.archon/config.yaml`:
+
+```yaml
+defaultAssistant: codex
+assistants:
+  codex:
+    model: gpt-5.3-codex
+    modelReasoningEffort: medium
+    webSearchMode: disabled
+```
+
+If your installed Codex model names differ, use the model ID that your Codex CLI
+currently supports. Do not guess model strings in workflows that other people
+will run.
+
+## Optional Claude Setup
+
+Install Claude only if you plan to run Claude-backed defaults as written:
+
+macOS, Linux, WSL:
+
+```bash
+curl -fsSL https://claude.ai/install.sh | bash
+claude /login
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://claude.ai/install.ps1 | iex
+claude /login
+```
+
+For compiled Archon binaries, configure `CLAUDE_BIN_PATH` or
+`assistants.claude.claudeBinaryPath`. Source mode usually resolves from the
+development environment.
+
+## Start The Web UI
+
+From the Archon repo:
+
+```bash
+bun run dev
+```
+
+Expected:
+
+```text
+API server: http://localhost:3090
+Web UI:     http://localhost:5173
+```
+
+Verify in a second terminal:
+
+```bash
+curl http://localhost:3090/health
+curl http://localhost:3090/health/db
+```
+
+## Binary Web UI Path
+
+For compiled binary installs, the docs use:
+
+```bash
+archon serve
+archon serve --port 4000
+archon serve --download-only
+```
+
+In source development, use `bun run dev` instead of `archon serve`.
+
+## No `archon doctor` In Current CLI
+
+The requested curriculum mentions `archon doctor`, but the current CLI reference
+and source list no `doctor` command. Use these supported checks instead:
+
+```bash
+archon version
+archon workflow list --cwd /path/to/repo
+archon validate workflows --cwd /path/to/repo
+archon validate commands --cwd /path/to/repo
+curl http://localhost:3090/health
+curl http://localhost:3090/health/db
+```
+
+## What Not To Share
+
+Do not share:
+
+- `~/.archon/.env`
+- `<repo>/.archon/.env`
+- `~/.codex/auth.json`
+- GitHub tokens
+- OAuth tokens
+- API keys
+- full debug logs unless you inspected them for secrets
+- terminal history containing token export commands
+
+## Expected Result
+
+You should have `archon version`, `bun run dev`, the API health endpoint, and
+Codex authentication working locally.
+
+## Common Mistakes
+
+- Running commands as root on a VPS.
+- Putting Archon secrets in the target repo `.env`.
+- Assuming `archon doctor` exists in the current CLI.
+- Installing Codex but not authenticating it.
+- Forgetting that many default workflows are still Claude-oriented unless
+  configured otherwise.
+
+## Mini Exercise
+
+Run the supported setup checks:
+
+```bash
+archon version
+curl http://localhost:3090/health
+curl http://localhost:3090/health/db
+```
+
+## Verification Checklist
+
+- `archon version` prints a version.
+- `bun run dev` starts the local server and Web UI.
+- Health checks return OK.
+- Codex is installed and authenticated.
+- No real secret appears in shell output, chat, or Git diff.
+
+## Completion Checkpoint
+
+You are ready for Part 3 when:
+
+- `archon version` works.
+- `bun run dev` starts the Web UI from source.
+- `curl http://localhost:3090/health` returns OK.
+- Codex is installed and authenticated.
+- You know where Archon-owned env files live.
+
+## Source References
+
+- `packages/docs-web/src/content/docs/getting-started/overview.md`
+- `packages/docs-web/src/content/docs/getting-started/installation.md`
+- `packages/docs-web/src/content/docs/getting-started/ai-assistants.md`
+- `packages/docs-web/src/content/docs/reference/cli.md`
+- `packages/docs-web/src/content/docs/reference/configuration.md`
+- `packages/docs-web/src/content/docs/reference/security.md`
+- `packages/docs-web/src/content/docs/deployment/windows.md`
+- `packages/cli/src/cli.ts`
+
+---
+
+# Part 3 - Your First Target Repository
+
+## Learning Objective
+
+Create a disposable Git repository, run Archon against it, and inspect the
+result without risking important code.
+
+## Why This Matters
+
+The sandbox lets you learn worktrees, artifacts, approvals, and GitHub flows
+without risking a real codebase.
+
+## Prerequisites
+
+- Archon CLI works.
+- Web UI starts.
+- Git can create commits.
+
+## Create A Sandbox Repository
+
+macOS, Linux, WSL:
+
+```bash
+mkdir -p ~/archon-sandbox
+cd ~/archon-sandbox
+git init
+cat > README.md <<'EOF'
+# Archon Sandbox
+
+This repository exists only for learning Archon.
+EOF
+mkdir -p src
+cat > src/math.js <<'EOF'
+export function add(a, b) {
+  return a + b;
+}
+EOF
+cat > package.json <<'EOF'
+{
+  "type": "module"
+}
+EOF
+git add .
+git commit -m "Initial sandbox commit"
+```
+
+Windows PowerShell:
+
+```powershell
+mkdir $HOME\archon-sandbox
+cd $HOME\archon-sandbox
+git init
+"# Archon Sandbox`n`nThis repository exists only for learning Archon." | Set-Content README.md
+mkdir src
+"export function add(a, b) {`n  return a + b;`n}" | Set-Content src\math.js
+'{"type":"module"}' | Set-Content package.json
+git add .
+git commit -m "Initial sandbox commit"
+```
+
+## Run Archon From The Target Repository
+
+The target repository is the repo Archon should inspect or modify. Do not run
+your first sandbox workflow from inside the Archon source repo.
+
+```bash
+cd ~/archon-sandbox
+archon workflow list
+```
+
+Read-only exploration:
+
+```bash
+archon workflow run archon-assist --no-worktree "Explain this repository structure."
+```
+
+If you prefer explicit paths:
+
+```bash
+archon workflow run archon-assist --cwd ~/archon-sandbox --no-worktree "Explain this repository structure."
+```
+
+## Web UI Project Registration
+
+1. Open `http://localhost:5173`.
+2. Add a project from the sidebar or settings.
+3. Enter the local sandbox path.
+4. Start a new conversation.
+5. Ask:
+
+```text
+Explain the structure of this sandbox repository.
+```
+
+## Expected Result
+
+Archon should explain:
+
+- There is a README.
+- There is a small JavaScript source file.
+- The repo is intentionally minimal.
+
+## Verification Checklist
+
+- `archon workflow list` shows workflows.
+- The sandbox has an initial Git commit.
+- The first run did not modify files.
+- The Web UI can register the project.
+
+## Common Mistakes
+
+- Running from the Archon repo instead of the sandbox.
+- Forgetting the initial commit.
+- Hitting a Git identity error on the first commit. If that happens, set a local
+  disposable identity with `git config user.name "Archon Learner"` and
+  `git config user.email "learner@example.com"` in the sandbox repo.
+- Using a real private repo before you understand artifacts and logs.
+
+## Mini Exercise
+
+Ask Archon to describe one file:
+
+```bash
+archon workflow run archon-assist --no-worktree "Explain src/math.js and suggest one tiny improvement without editing files."
+```
+
+## Completion Checkpoint
+
+Move on when both CLI and Web UI can see the sandbox repository.
+
+## Source References
+
+- `README.md`
+- `packages/docs-web/src/content/docs/getting-started/quick-start.md`
+- `packages/docs-web/src/content/docs/reference/cli.md`
+- `packages/docs-web/src/content/docs/adapters/web.md`
+
+---
+
+# Part 4 - Using Built-In Workflows
+
+## Learning Objective
+
+Know which current built-in workflows exist and which ones to learn first.
+
+## Why This Matters
+
+The workflow catalog is powerful but broad. Beginners get better results by
+learning a few workflows deeply before trying specialized automation.
+
+## Prerequisites
+
+- You can run `archon workflow list`.
+- You have a sandbox repository.
+
+## Current Default Workflows
+
+At the time this tutorial was reviewed, `.archon/workflows/defaults/` contains
+these workflow files:
+
+- `archon-adversarial-dev`
+- `archon-architect`
+- `archon-assist`
+- `archon-comprehensive-pr-review`
+- `archon-create-issue`
+- `archon-feature-development`
+- `archon-fix-github-issue`
+- `archon-idea-to-pr`
+- `archon-interactive-prd`
+- `archon-issue-review-full`
+- `archon-piv-loop`
+- `archon-plan-to-pr`
+- `archon-ralph-dag`
+- `archon-refactor-safely`
+- `archon-remotion-generate`
+- `archon-resolve-conflicts`
+- `archon-smart-pr-review`
+- `archon-test-loop-dag`
+- `archon-validate-pr`
+- `archon-workflow-builder`
+
+Always run this for the current catalog:
+
+```bash
+archon workflow list
+```
+
+## Learning Progression
+
+Start with:
+
+1. `archon-assist` for explanation and exploration.
+2. `archon-piv-loop` for guided Plan-Implement-Validate with human review.
+3. `archon-refactor-safely` on a disposable small refactor.
+4. `archon-idea-to-pr` once you understand PR creation.
+5. `archon-fix-github-issue` after GitHub CLI and tokens are set up.
+6. `archon-smart-pr-review` after you have a PR.
+7. `archon-validate-pr` after you understand ports and test setup.
+
+Treat these as advanced or specialized:
+
+- `archon-adversarial-dev`
+- `archon-ralph-dag`
+- `archon-issue-review-full`
+- `archon-comprehensive-pr-review`
+- `archon-remotion-generate`
+- `archon-workflow-builder`
+- `archon-test-loop-dag`
+
+## Beginner Workflow Examples
+
+Explore:
+
+```bash
+archon workflow run archon-assist --no-worktree "What does this repo do?"
+```
+
+Guided development with a human loop:
+
+```bash
+archon workflow run archon-piv-loop --branch piv/add-subtract "Add a subtract function and tests."
+```
+
+Safe refactor:
+
+```bash
+archon workflow run archon-refactor-safely --branch refactor/math-module "Refactor the tiny math module without changing behavior."
+```
+
+GitHub issue fix:
+
+```bash
+archon workflow run archon-fix-github-issue --branch fix/issue-1 "Fix issue #1"
+```
+
+PR review:
+
+```bash
+archon workflow run archon-smart-pr-review "Review PR #1"
+```
+
+## Human Review Placement
+
+For beginners, human review belongs:
+
+- After exploration, before implementation.
+- After plan creation.
+- After deterministic validation.
+- Before PR creation if the workflow supports it.
+- Before merge, always.
+
+## Expected Result
+
+You should know which workflow to reach for when exploring, building, fixing a
+GitHub issue, reviewing a PR, or validating a PR.
+
+## Verification Checklist
+
+- `archon workflow list` runs in the sandbox.
+- You can identify at least three beginner workflows.
+- You know which workflows are advanced or specialized.
+
+## Common Mistakes
+
+- Treating every default workflow as beginner-friendly.
+- Using a PR workflow before GitHub auth works.
+- Running a modifying workflow without a branch.
+
+## Mini Exercise
+
+Pick the best workflow for each prompt:
+
+```text
+"What does this repo do?"
+"Fix issue #1"
+"Review PR #2"
+"Refactor this tiny module safely"
+```
+
+## Completion Checkpoint
+
+You can move on when:
+
+- You can pick a workflow for exploration, feature work, issue fixing, PR review,
+  and validation.
+- You understand that `--branch` is the safe default for modifying work.
+- You know some built-ins may be Claude-oriented unless changed.
+
+## Source References
+
+- `.archon/workflows/defaults/`
+- `README.md`
+- `packages/docs-web/src/content/docs/book/essential-workflows.md`
+- `packages/docs-web/src/content/docs/reference/cli.md`
+
+---
+
+# Part 5 - Worktrees, Isolation, Artifacts, And Logs
+
+## Learning Objective
+
+Understand where Archon runs work and how to inspect what happened.
+
+## Why This Matters
+
+Worktrees protect your main checkout. Artifacts and logs let you audit what the
+AI did after the fact.
+
+## Prerequisites
+
+- A Git repository with an initial commit.
+- At least one completed or running workflow.
+
+## Why Worktrees Matter
+
+When a workflow modifies code, it should not write directly into your main
+checkout. Git worktrees let Archon create a separate working directory and
+branch for a run.
+
+Default workflow runs create isolated worktrees unless you opt out or a workflow
+pins `worktree.enabled: false`.
+
+Use:
+
+```bash
+archon workflow run archon-assist --branch learn/explain "Explain the project and write a short summary."
+```
+
+For read-only questions, `--no-worktree` is acceptable:
+
+```bash
+archon workflow run archon-assist --no-worktree "What files define the CLI?"
+```
+
+Use `--no-worktree` cautiously for anything that might edit files.
+
+## Where Files Live
+
+Typical user-level layout:
+
+```text
+~/.archon/
+  workspaces/<owner>/<repo>/
+    source/
+    worktrees/
+    artifacts/
+    logs/
+  archon.db
+  config.yaml
+```
+
+Artifacts:
+
+```text
+~/.archon/workspaces/<owner>/<repo>/artifacts/runs/<run-id>/
+```
+
+Logs:
+
+```text
+~/.archon/workspaces/<owner>/<repo>/logs/<run-id>.jsonl
+```
+
+## Inspect Active Runs
+
+```bash
+archon workflow status
+archon workflow status --json
+```
+
+## Inspect Worktrees
+
+```bash
+archon isolation list
+```
+
+Cleanup stale environments:
+
+```bash
+archon isolation cleanup
+archon isolation cleanup 14
+archon isolation cleanup --merged
+```
+
+Complete a branch lifecycle after merge:
+
+```bash
+archon complete <branch-name>
+```
+
+## Inspect JSONL Logs
+
+macOS, Linux, WSL:
+
+```bash
+tail -n 50 ~/.archon/workspaces/<owner>/<repo>/logs/<run-id>.jsonl
+jq 'select(.type == "node_error" or .type == "workflow_error")' ~/.archon/workspaces/<owner>/<repo>/logs/<run-id>.jsonl
+```
+
+Windows PowerShell:
+
+```powershell
+Get-Content "$HOME\.archon\workspaces\<owner>\<repo>\logs\<run-id>.jsonl" -Tail 50
+```
+
+## Expected Result
+
+You should be able to find a run ID, locate its log file, locate its artifact
+directory, and identify the worktree branch.
+
+## CLI Versus Server File Visibility
+
+The CLI reads local commands and workflows directly from the working directory.
+It sees uncommitted edits.
+
+The server and adapters read from the workspace clone under `~/.archon/workspaces/`.
+For server-based adapters such as GitHub, Slack, and Telegram, commit and push
+workflow or command changes before expecting the server clone to see them.
+
+## Mini Exercise
+
+Run an isolated workflow:
+
+```bash
+archon workflow run archon-assist --branch learn/artifacts "Explain this repo and mention where artifacts are stored."
+archon workflow status
+archon isolation list
+```
+
+Then locate the run's log and artifact directory.
+
+## Verification Checklist
+
+- `archon workflow status` shows recent run state.
+- `archon isolation list` shows or confirms active worktrees.
+- You can locate the JSONL log file.
+- You can locate the artifact run directory.
+
+## Common Mistakes
+
+- Looking for artifacts inside the Git repo.
+- Cleaning up a worktree before checking whether the PR was merged.
+- Using `--no-worktree` for implementation work.
+
+## Completion Checkpoint
+
+You can move on when:
+
+- You can find active runs.
+- You can find worktrees.
+- You can explain why artifacts are outside Git.
+- You know when not to use `--no-worktree`.
+
+## Source References
+
+- `packages/docs-web/src/content/docs/book/isolation.md`
+- `packages/docs-web/src/content/docs/book/how-it-works.md`
+- `packages/docs-web/src/content/docs/reference/archon-directories.md`
+- `packages/docs-web/src/content/docs/reference/configuration.md`
+- `packages/docs-web/src/content/docs/reference/cli.md`
+- `.claude/skills/archon/references/troubleshooting.md`
+
+---
+
+# Part 6 - Custom Commands
+
+## Learning Objective
+
+Create a reusable Archon command and validate it.
+
+## Why This Matters
+
+Commands make reusable AI instructions. They keep workflow nodes focused and
+make team processes easier to share.
+
+## Prerequisites
+
+- A repository with `.archon/` available or ready to create.
+- `archon validate commands` works.
+
+## Command Location
+
+Repo-specific commands live here:
+
+```text
+.archon/commands/
+```
+
+Global commands can live here:
+
+```text
+~/.archon/commands/
+```
+
+## Create A Verification Command
+
+Create:
+
+```text
+.archon/commands/sandbox-verify.md
+```
+
+Content:
+
+```markdown
+---
+description: Run the sandbox verification routine and write an artifact summary.
+argument-hint: <what changed>
+---
+
+# Sandbox Verify
+
+Input: $ARGUMENTS
+
+## Mission
+
+Verify the sandbox repository after a small change.
+
+## Steps
+
+1. Inspect `git status --short`.
+2. Inspect the changed files.
+3. Run the project's available validation command if one exists.
+4. Create `$ARTIFACTS_DIR/sandbox-verification.md`.
+
+## Artifact Requirements
+
+The artifact must include:
+
+- Change summary
+- Validation command used
+- Validation result
+- Remaining risks
+- Recommended next action
+```
+
+Validate:
+
+```bash
+archon validate commands sandbox-verify
+```
+
+Run through an inline workflow later, or use it as a command node in Part 7.
+
+## Expected Result
+
+The command validates and clearly instructs the AI to write a verification
+artifact.
+
+## Verification Checklist
+
+- The command file has frontmatter.
+- It references `$ARGUMENTS`.
+- It writes to `$ARTIFACTS_DIR`.
+- `archon validate commands sandbox-verify` exits successfully.
+
+## Common Mistakes
+
+- Writing command files that do not tell the AI where to save artifacts.
+- Assuming the next node remembers what this command found.
+- Putting secrets in command files.
+- Forgetting frontmatter is for metadata, not secrets.
+
+## Mini Exercise
+
+Change the command so the artifact also includes "What I did not check." Validate
+the command again.
+
+## Completion Checkpoint
+
+You can move on when `archon validate commands sandbox-verify` succeeds.
+
+## Source References
+
+- `packages/docs-web/src/content/docs/guides/authoring-commands.md`
+- `packages/docs-web/src/content/docs/reference/variables.md`
+- `.archon/commands/defaults/`
+- `.claude/skills/archon/references/authoring-commands.md`
+
+---
+
+# Part 7 - Custom YAML Workflows
+
+## Learning Objective
+
+Build a workflow gradually, using only currently documented fields.
+
+## Why This Matters
+
+Workflow authoring is where Archon becomes your process instead of someone
+else's defaults.
+
+## Prerequisites
+
+- You have created at least one command.
+- You know the difference between an AI node and a deterministic node.
+
+## File Location
+
+Create:
+
+```text
+.archon/workflows/sandbox-piv.yaml
+```
+
+## Module 7.1 - Minimal Plan And Implement
+
+```yaml
+name: sandbox-piv
+description: Plan and implement a tiny sandbox change.
+provider: codex
+model: gpt-5.3-codex
+
+nodes:
+  - id: plan
+    prompt: |
+      Create a concise implementation plan for this request:
+      $USER_MESSAGE
+
+      Write the plan to $ARTIFACTS_DIR/plan.md.
+
+  - id: implement
+    depends_on: [plan]
+    prompt: |
+      Read $ARTIFACTS_DIR/plan.md.
+      Implement the smallest safe change.
+```
+
+Validate:
+
+```bash
+archon validate workflows sandbox-piv
+```
+
+Run:
+
+```bash
+archon workflow run sandbox-piv --branch sandbox/add-subtract "Add a subtract function."
+```
+
+## Expected Result
+
+The workflow validates, creates a plan artifact, implements a tiny change, and
+can be extended without changing its basic shape.
+
+## Module 7.2 - Add Deterministic Validation
+
+Add:
+
+```yaml
+  - id: validate
+    depends_on: [implement]
+    bash: |
+      git status --short
+      bun -e "import('./src/math.js').then(m => { if (m.add(2, 3) !== 5) process.exit(1); })"
+```
+
+`bash` is deterministic. Its stdout becomes `$validate.output`.
+
+## Module 7.3 - Add Artifact Handoffs
+
+Revise `plan`:
+
+```yaml
+  - id: plan
+    prompt: |
+      Create a concise implementation plan for this request:
+      $USER_MESSAGE
+
+      Save it to $ARTIFACTS_DIR/plan.md with:
+      - files to change
+      - exact validation command
+      - risks
+```
+
+Revise `implement`:
+
+```yaml
+  - id: implement
+    depends_on: [plan]
+    context: fresh
+    prompt: |
+      You are in a fresh session.
+      Read $ARTIFACTS_DIR/plan.md.
+      Implement only the approved plan.
+```
+
+## Module 7.4 - Add Fresh Context
+
+Use `context: fresh` on AI `command` or `prompt` nodes when the node should not
+inherit prior conversation state. Do not use `context: fresh` on `loop` nodes;
+loops use `loop.fresh_context`.
+
+## Module 7.5 - Add Conditional Logic
+
+Use `output_format` for structured data and `when:` for routing:
+
+```yaml
+  - id: classify
+    prompt: |
+      Classify this request: $USER_MESSAGE
+    output_format:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [READ_ONLY, MODIFY]
+      required: [type]
+
+  - id: explain-only
+    depends_on: [classify]
+    when: "$classify.output.type == 'READ_ONLY'"
+    prompt: "Answer without editing files."
+
+  - id: plan
+    depends_on: [classify]
+    when: "$classify.output.type == 'MODIFY'"
+    prompt: "Create $ARTIFACTS_DIR/plan.md for the requested change."
+```
+
+## Module 7.6 - Add A Validation Loop
+
+```yaml
+  - id: fix-until-valid
+    depends_on: [implement]
+    loop:
+      prompt: |
+        Run validation. If it fails, fix the smallest issue.
+        When validation passes, output <promise>VALID</promise>.
+      until: VALID
+      max_iterations: 3
+      until_bash: |
+        bun -e "import('./src/math.js').then(m => { if (m.add(2, 3) !== 5) process.exit(1); })"
+      fresh_context: false
+```
+
+Do not put `provider` or `model` on the loop node. Current docs say those fields
+are ignored on loops; use workflow-level provider/model or design separate AI
+nodes.
+
+## Module 7.7 - Add Human Approval
+
+```yaml
+interactive: true
+
+nodes:
+  - id: plan
+    prompt: |
+      Create $ARTIFACTS_DIR/plan.md for: $USER_MESSAGE
+
+  - id: approve-plan
+    depends_on: [plan]
+    approval:
+      message: "Review $ARTIFACTS_DIR/plan.md. Approve to implement."
+      capture_response: true
+      on_reject:
+        prompt: |
+          The plan was rejected: $REJECTION_REASON
+          Revise $ARTIFACTS_DIR/plan.md.
+        max_attempts: 3
+
+  - id: implement
+    depends_on: [approve-plan]
+    context: fresh
+    prompt: |
+      Read $ARTIFACTS_DIR/plan.md.
+      Additional reviewer note: $approve-plan.output
+      Implement the plan.
+```
+
+Workflow-level `interactive: true` is required for Web UI approval gates.
+
+## Module 7.8 - Interactive Loops Versus Approval Nodes
+
+Use `approval:` for one clear checkpoint, such as "approve plan before
+implementation."
+
+Use `loop.interactive: true` when each iteration needs feedback, such as "revise
+this design until I approve it."
+
+## Module 7.9 - DAG And Parallel Nodes
+
+Nodes with no dependency between them can run in parallel:
+
+```yaml
+  - id: review-code
+    depends_on: [validate]
+    prompt: "Review code changes."
+
+  - id: review-tests
+    depends_on: [validate]
+    prompt: "Review test coverage."
+
+  - id: synthesize
+    depends_on: [review-code, review-tests]
+    trigger_rule: none_failed_min_one_success
+    prompt: "Synthesize review findings."
+```
+
+## Completion Checkpoint
+
+You can move on when:
+
+- `archon validate workflows sandbox-piv` succeeds.
+- You can explain each node type used.
+- You can approve and reject a paused workflow.
+- You know which fields are ignored on loops, bash, script, and approval nodes.
+
+## Verification Checklist
+
+- `archon validate workflows sandbox-piv` succeeds.
+- The workflow has a plan node and an implement node.
+- The validation node is deterministic.
+- Approval examples use workflow-level `interactive: true`.
+
+## Common Mistakes
+
+- Setting `provider` or `model` on a loop node and expecting it to work.
+- Reading free-form AI text in `when:` conditions instead of using
+  `output_format`.
+- Forgetting workflow-level `interactive: true`.
+- Creating one huge workflow before the two-node version works.
+
+## Mini Exercise
+
+Add one read-only `review` prompt node after validation and make it use
+`context: fresh`.
+
+## Source References
+
+- `packages/docs-web/src/content/docs/guides/authoring-workflows.md`
+- `packages/docs-web/src/content/docs/guides/loop-nodes.md`
+- `packages/docs-web/src/content/docs/guides/approval-nodes.md`
+- `packages/docs-web/src/content/docs/guides/script-nodes.md`
+- `.claude/skills/archon/references/parameter-matrix.md`
+
+---
+
+# Part 8 - Plan-Implement-Validate As The Core Harness
+
+## Learning Objective
+
+Build a supervised workflow that plans, pauses, implements, validates, reviews,
+pauses again, and then prepares a PR.
+
+## Why This Matters
+
+PIV is the practical default for real work because it keeps the AI productive
+while reserving judgment calls for a human.
+
+## Prerequisites
+
+- Custom workflow validation works.
+- You understand approval nodes.
+- You have a sandbox branch you can safely modify.
+
+## Why This Is A Strong Default
+
+Plan-Implement-Validate works because each step has a clear owner:
+
+- AI investigates and drafts a plan.
+- Human reviews the plan.
+- AI implements from the approved artifact.
+- Bash or scripts validate deterministically.
+- AI reviews the diff.
+- Human approves final state.
+- GitHub PR creation is explicit.
+
+## Supervised Workflow Shape
+
+```text
+explore
+  -> plan artifact
+  -> approval gate
+  -> implementation in fresh context
+  -> deterministic validation
+  -> fix loop if validation fails
+  -> independent review
+  -> final approval gate
+  -> create PR
+```
+
+## Exercise
+
+Run the current built-in guided workflow first:
+
+```bash
+archon workflow run archon-piv-loop --branch piv/sandbox-subtract "Add a subtract function and validate it."
+```
+
+Then compare it to your custom `sandbox-piv.yaml`.
+
+## Expected Result
+
+You should have a supervised workflow run where implementation happens only
+after plan review.
+
+## Verification Checklist
+
+- A plan artifact exists.
+- A human approval gate pauses the workflow.
+- Validation is deterministic.
+- Final review happens in a separate node or phase.
+
+## Common Mistakes
+
+- Letting implementation start before plan approval.
+- Treating AI validation as a substitute for tests.
+- Keeping all phases in one shared context.
+
+## Mini Exercise
+
+Reject the plan once with a concrete reason, then verify the workflow revises
+before asking again.
+
+## Completion Checkpoint
+
+Move on when you can explain which PIV steps are AI reasoning, which are
+deterministic, and which are human decisions.
+
+## Human Role
+
+You stay involved at:
+
+- Scope selection.
+- Plan approval.
+- Validation review.
+- PR review.
+- Merge decision.
+
+## Source References
+
+- `.archon/workflows/defaults/archon-piv-loop.yaml`
+- `packages/docs-web/src/content/docs/guides/approval-nodes.md`
+- `packages/docs-web/src/content/docs/guides/loop-nodes.md`
+- `packages/docs-web/src/content/docs/book/first-workflow.md`
+- Transcript case study: `Pi Coding Agent + Archon Build ANY AI Coding Workflow (No Claude Code Bloat).txt`
+
+---
+
+# Part 9 - AI Assistants, Providers, And Model Routing
+
+## Learning Objective
+
+Use provider and model routing safely, especially with Codex and Pi/Gemini.
+
+## Why This Matters
+
+Provider routing can reduce cost and improve quality, but only if each node has
+an explicit handoff and a verified model string.
+
+## Prerequisites
+
+- Codex works by itself.
+- Pi works by itself before mixed-provider workflows.
+- You can validate workflow YAML.
+
+## Current Provider Model
+
+Archon docs cover:
+
+- `provider: claude`
+- `provider: codex`
+- `provider: pi` as a community provider
+
+Provider and model can be set at workflow level:
+
+```yaml
+name: codex-workflow
+provider: codex
+model: gpt-5.3-codex
+nodes:
+  - id: explain
+    prompt: "Explain this repo."
+```
+
+Or per AI node:
+
+```yaml
+nodes:
+  - id: explore
+    provider: codex
+    model: gpt-5.3-codex
+    prompt: "Map the relevant files."
+
+  - id: plan
+    provider: pi
+    model: google/gemini-2.5-pro
+    depends_on: [explore]
+    prompt: "Create a plan from $explore.output."
+```
+
+## Gemini Through Pi
+
+The docs show Pi model references in this format:
+
+```text
+<pi-provider-id>/<model-id>
+```
+
+Examples in docs include:
+
+```yaml
+model: google/gemini-2.5-pro
+```
+
+For Gemini 3.1 Pro, verify the exact Pi model ID locally before using it in a
+workflow. Do not invent the model string. Check Pi's model picker or your
+`~/.pi/agent/models.json`.
+
+## Routing Heuristic
+
+This is a starting heuristic, not a benchmark result.
+
+| Work type | Suggested route |
+| --- | --- |
+| Fast repo exploration | Codex medium effort |
+| Deep planning | Stronger model through Codex or Pi/Gemini |
+| Implementation | Codex, Claude, or a verified Pi backend such as Gemini, Qwen, Kimi, or a local model you trust for edits |
+| Deterministic validation | `bash` or `script`, no AI |
+| Code review | Separate AI node, fresh context |
+| Frontend design | Model/provider you have benchmarked for UI quality |
+| Low-risk repetitive tasks | Cheaper/faster model |
+
+For practical role assignments, use
+[Model Role Recipes](/learning/model-role-recipes/) after the baseline
+single-provider workflow works.
+
+## Mixed-Provider Rule
+
+When providers change between nodes, do not rely on implicit shared
+conversation. Write artifacts and read artifacts explicitly.
+
+## Expected Result
+
+You should be able to design a workflow where Codex or Claude plans and reviews,
+Gemini, Qwen, Kimi, Codex, or Claude handles inner development, and a
+deterministic node validates, with artifacts between each step.
+
+## Provider-Specific Caveats
+
+- Claude supports Claude-only fields such as hooks, MCP per node, skills per
+  node, and tool restrictions.
+- Codex ignores some Claude-only fields; use Codex CLI config where applicable.
+- Pi is community-maintained and has its own capability boundaries.
+- `output_format` is reliable for Claude/Codex and best-effort for Pi.
+
+## Verification Checklist
+
+- Every provider name is documented.
+- Every model string was verified locally.
+- Cross-provider nodes read artifacts or upstream outputs explicitly.
+- Planning, implementation, validation, and review roles are assigned by node
+  responsibility.
+
+## Common Mistakes
+
+- Guessing a Gemini, Qwen, or Kimi model ID.
+- Assuming providers share one conversation.
+- Applying Claude-only fields to Codex or Pi nodes.
+
+## Mini Exercise
+
+Write a two-node YAML sketch where Codex maps files and Pi/Gemini writes a plan
+from the Codex output. Validate before running.
+
+## Completion Checkpoint
+
+Move on when single-provider Codex and single-provider Pi runs both work.
+
+## Source References
+
+- `packages/docs-web/src/content/docs/getting-started/ai-assistants.md`
+- `packages/docs-web/src/content/docs/guides/authoring-workflows.md`
+- `packages/providers/src/`
+- `.claude/skills/archon/references/parameter-matrix.md`
+- Transcript case study: `Plan with Claude Opus, Build with Kimi K2.6 LIVE Mixed-Provider Benchmark.txt`
+- Transcript case study: `Pushing My AI Dark Factory to Its Limits with Opus + Kimi Combined.txt`
+
+---
+
+# Part 10 - Pi Integration
+
+## Learning Objective
+
+Use Pi as a community provider, including Gemini routing and extension-aware
+workflows, without treating experimental transcript patterns as core guarantees.
+
+## Why This Matters
+
+Pi gives Archon access to many backends, but it is community-maintained and has
+different capabilities from Claude and Codex.
+
+## Prerequisites
+
+- Pi is installed or available through Archon's provider dependency.
+- Pi authentication or local model configuration works.
+- You know the exact model reference you plan to use.
+
+## What Pi Is In Archon
+
+Pi is documented as a community provider integrated under `provider: pi`.
+It can route to many backends, including Google/Gemini, OpenAI, Anthropic, Groq,
+Mistral, OpenRouter, Hugging Face, and local/custom endpoints.
+
+## Authentication
+
+Pi can use:
+
+- OAuth subscriptions configured by running `pi` and `/login`.
+- API keys such as `GEMINI_API_KEY` for Google/Gemini.
+- Local/custom providers registered in `~/.pi/agent/models.json`.
+
+Never paste keys into chat.
+
+## Secure Setup Checklist
+
+- Run Pi login locally.
+- Store API keys only in Archon-owned env files or Pi's expected local files.
+- Keep `~/.pi/agent/auth.json` private.
+- Keep `~/.pi/agent/models.json` free of secrets if possible.
+- Verify third-party extensions before installing.
+- Disable extensions for a workflow if you do not need them:
+
+```yaml
+assistants:
+  pi:
+    enableExtensions: false
+```
+
+## Pi Workflow Example: Read-Only Analysis
+
+```yaml
+name: pi-readonly-analysis
+description: Read-only repository analysis using Pi.
+provider: pi
+model: google/gemini-2.5-pro
+worktree:
+  enabled: false
+
+nodes:
+  - id: analyze
+    prompt: |
+      Analyze the repository structure for $USER_MESSAGE.
+      Do not edit files.
+      Write a summary to $ARTIFACTS_DIR/pi-analysis.md.
+```
+
+Before using Gemini 3.1 Pro, replace the model with the exact Pi model ID shown
+by your local Pi configuration.
+
+Validate:
+
+```bash
+archon validate workflows pi-readonly-analysis
+```
+
+Run:
+
+```bash
+archon workflow run pi-readonly-analysis --no-worktree "Find the main extension points."
+```
+
+## Expected Result
+
+The workflow performs read-only analysis and writes
+`$ARTIFACTS_DIR/pi-analysis.md`.
+
+## Verification Checklist
+
+- `provider: pi` validates.
+- The Pi model reference is real in your environment.
+- No code modification happens in the read-only exercise.
+
+## Experimental Transcript Patterns
+
+The transcripts discuss Pi extensions such as plan review UIs and third-party
+approval tooling. Treat those as inspiration unless the current official docs
+confirm the exact extension and fields you plan to use.
+
+## Common Mistakes
+
+- Installing third-party Pi extensions without review.
+- Assuming a transcript YAML field is officially supported.
+- Using a cloud API key where a local model would be enough for a read-only test.
+
+## Mini Exercise
+
+Run Pi against the sandbox with a read-only prompt, then inspect the artifact
+before attempting any implementation workflow.
+
+## Completion Checkpoint
+
+Move on when you can explain which parts are official Pi support and which parts
+are extension or transcript-inspired.
+
+## Source References
+
+- `packages/docs-web/src/content/docs/getting-started/ai-assistants.md`
+- `packages/providers/src/community/pi/`
+- Transcript case study: `Pi Coding Agent + Archon Build ANY AI Coding Workflow (No Claude Code Bloat).txt`
+- Transcript case study: `Pi is INCREDIBLE - Building a Custom Coding Agent Live.txt`
+
+---
+
+# Part 11 - GitHub, Adapters, And Interfaces
+
+## Learning Objective
+
+Use GitHub safely as both a CLI dependency and a workflow entry point, then
+understand optional chat adapters.
+
+## Why This Matters
+
+GitHub is where Archon becomes useful for real team work: issues become
+workflow inputs, PRs become review targets, and webhook comments can trigger
+automation.
+
+## Prerequisites
+
+- `gh auth status` works.
+- Your sandbox is pushed to GitHub if you want to run issue workflows.
+- You have a private place to store GitHub tokens.
+
+## CLI
+
+Use the CLI for local learning:
+
+```bash
+archon workflow list
+archon workflow run archon-assist --no-worktree "Explain this repo."
+archon workflow status
+archon isolation list
+```
+
+## Web UI
+
+Use the Web UI for:
+
+- registering projects
+- chatting with a selected project
+- running workflows
+- watching progress
+- approving paused runs
+- viewing artifacts
+
+Start from source:
+
+```bash
+bun run dev
+```
+
+## GitHub CLI Setup
+
+Install and authenticate:
+
+```bash
+gh auth login
+gh auth status
+```
+
+For GitHub-backed workflows, make sure the repository has a remote and issues
+or PRs exist.
+
+## GitHub Token Safety
+
+Archon docs use both:
+
+```ini
+GH_TOKEN=YOUR_GITHUB_TOKEN
+GITHUB_TOKEN=YOUR_GITHUB_TOKEN
+```
+
+Use placeholders in documentation. Enter real values only in private local
+configuration.
+
+Prefer:
+
+- `~/.archon/.env` for user-wide Archon secrets.
+- `<repo>/.archon/.env` for repo-specific Archon secrets.
+
+Do not put Archon secrets in `<repo>/.env`; current docs say Archon strips target
+repo `.env` keys at boot to prevent leakage.
+
+## GitHub Issue-To-PR Local Exercise
+
+After creating a GitHub repository for your sandbox:
+
+1. Push the sandbox repo to GitHub.
+2. Create issue `#1`, such as "Add subtract function".
+3. Run:
+
+```bash
+archon workflow run archon-fix-github-issue --branch fix/issue-1 "Fix issue #1"
+```
+
+Expected result:
+
+- issue is investigated
+- code is changed in an isolated branch/worktree
+- validation runs according to the workflow
+- a PR may be created if credentials and repo permissions are correct
+- you review before merge
+
+## Expected Result
+
+You should be able to run a GitHub issue workflow from the CLI, understand the
+branch and PR it creates, and stop before merge for human review.
+
+## Verification Checklist
+
+- The issue exists.
+- The branch/worktree is isolated.
+- The PR is reviewed by a human before merge.
+- No token was printed in chat or committed.
+
+## GitHub Webhook Adapter
+
+Use this after local CLI workflows work.
+
+The GitHub adapter lets you interact with Archon from issue and PR comments by
+mentioning the bot.
+
+Development setup requires a public endpoint such as ngrok or Cloudflare Tunnel:
+
+```bash
+ngrok http 3090
+```
+
+Webhook settings:
+
+```text
+Payload URL: https://your-public-url/webhooks/github
+Content type: application/json
+Secret: same value as WEBHOOK_SECRET
+Events: issues, issue_comment, pull_request
+```
+
+Generate a webhook secret:
+
+macOS, Linux, WSL:
+
+```bash
+openssl rand -hex 32
+```
+
+Windows PowerShell:
+
+```powershell
+-join ((1..32) | ForEach-Object { '{0:x2}' -f (Get-Random -Maximum 256) })
+```
+
+Set:
+
+```ini
+WEBHOOK_SECRET=YOUR_WEBHOOK_SECRET
+GITHUB_ALLOWED_USERS=your-github-username
+```
+
+The whitelist is strongly recommended when exposing any adapter.
+
+## Slack
+
+Slack is an optional adapter. It uses Socket Mode, so it can work without a
+public HTTP endpoint.
+
+Secrets:
+
+```ini
+SLACK_BOT_TOKEN=xoxb-...
+SLACK_APP_TOKEN=xapp-...
+SLACK_ALLOWED_USER_IDS=U01ABC,U02DEF
+```
+
+Use after the Web UI and CLI are comfortable.
+
+## Telegram
+
+Telegram is an optional adapter.
+
+Secrets:
+
+```ini
+TELEGRAM_BOT_TOKEN=...
+TELEGRAM_ALLOWED_USER_IDS=123456789
+```
+
+## Discord
+
+Discord is documented as a community adapter.
+
+Secrets:
+
+```ini
+DISCORD_BOT_TOKEN=...
+DISCORD_ALLOWED_USER_IDS=123456789012345678
+```
+
+## Jira
+
+Jira appears in the transcript set as an experimental case study. Do not present
+Jira as production-ready unless the current official docs add it.
+
+The useful architecture idea is:
+
+```text
+ticket -> persistent conversation or workflow entry point -> plan -> implementation -> PR
+```
+
+## Completion Checkpoint
+
+You can move on when:
+
+- `gh auth status` works.
+- You understand GitHub token placement.
+- You can run a GitHub issue workflow from the CLI.
+- You know GitHub webhooks require a public endpoint and signature secret.
+- You can distinguish core, optional, community, and experimental adapters.
+
+## Common Mistakes
+
+- Forgetting to set both `GH_TOKEN` and `GITHUB_TOKEN` where required.
+- Using a webhook without `WEBHOOK_SECRET`.
+- Leaving adapter access open to all users on a public endpoint.
+- Treating Jira transcript experiments as official adapter docs.
+
+## Mini Exercise
+
+Create a disposable GitHub issue for the sandbox, run the issue workflow, and
+stop at the PR review step without merging.
+
+## Source References
+
+- `packages/docs-web/src/content/docs/adapters/github.md`
+- `packages/docs-web/src/content/docs/adapters/web.md`
+- `packages/docs-web/src/content/docs/adapters/slack.md`
+- `packages/docs-web/src/content/docs/adapters/telegram.md`
+- `packages/docs-web/src/content/docs/adapters/community/discord.md`
+- `packages/docs-web/src/content/docs/reference/security.md`
+- `packages/docs-web/src/content/docs/reference/configuration.md`
+- Transcript case study: `Archon + Jira Drag a Ticket, Get a Pull Request (Live Build).txt`
+
+---
+
+# Part 12 - Local Development, Docker, VPS, And Deployment
+
+## Learning Objective
+
+Know when local usage is enough and when Docker or VPS deployment is appropriate.
+
+## Why This Matters
+
+Deployment adds security and operational responsibilities. Local usage is the
+right default until workflows are proven.
+
+## Prerequisites
+
+- Local CLI and Web UI work.
+- You understand secret placement.
+- You have completed at least one sandbox workflow.
+
+## Local Is Enough When
+
+- You are learning.
+- You are a single user.
+- You do not need 24/7 adapters.
+- You can start `bun run dev` when needed.
+- You use the CLI for local workflows.
+
+## Docker Desktop Local
+
+Use Docker after source mode works:
+
+```bash
+git clone https://github.com/coleam00/Archon.git
+cd Archon
+cp .env.example .env
+docker compose up -d
+```
+
+On Windows, build from WSL rather than PowerShell if Docker Desktop cannot
+follow workspace symlinks.
+
+## VPS Deployment
+
+Delay VPS deployment until after the local capstone.
+
+Core steps:
+
+1. Provision Ubuntu VPS.
+2. Create a non-root deployment user.
+3. Install Docker and Docker Compose.
+4. Clone Archon to `/opt/archon`.
+5. Configure `.env` privately.
+6. Configure DNS.
+7. Open ports 22, 80, and 443.
+8. Start Docker Compose profiles.
+9. Verify health endpoint.
+
+Do not run Archon as root. Current docs explicitly warn against root usage for
+Archon and Claude Code.
+
+## SQLite Versus PostgreSQL
+
+SQLite is the local default and requires no setup.
+
+PostgreSQL is recommended for cloud deployments and team/server use.
+
+## Monitoring And Recovery
+
+Use:
+
+```bash
+docker compose ps
+docker compose logs -f app
+curl http://localhost:3090/health
+curl http://localhost:3090/health/db
+```
+
+## Expected Result
+
+You should know whether local, Docker, or VPS deployment fits your current
+stage.
+
+## Verification Checklist
+
+- Local health checks pass.
+- Docker logs can be inspected.
+- VPS deployments use a non-root user.
+
+## Common Mistakes
+
+- Exposing the Web UI publicly without auth.
+- Running as root.
+- Using SQLite for a serious team deployment without considering PostgreSQL.
+- Starting with cloud deployment before local workflows work.
+
+## Mini Exercise
+
+Write a deployment decision for yourself:
+
+```text
+I will stay local until Capstone 4 passes on a disposable repository.
+```
+
+## Completion Checkpoint
+
+Move on when you can explain why VPS deployment is a later step, not the first
+step.
+
+## Source References
+
+- `packages/docs-web/src/content/docs/deployment/local.md`
+- `packages/docs-web/src/content/docs/deployment/docker.md`
+- `packages/docs-web/src/content/docs/deployment/cloud.md`
+- `packages/docs-web/src/content/docs/deployment/windows.md`
+- `packages/docs-web/src/content/docs/reference/database.md`
+- `packages/docs-web/src/content/docs/reference/configuration.md`
+
+---
+
+# Part 13 - Advanced Inspiration
+
+## Learning Objective
+
+Learn from the transcripts without confusing live experiments with supported
+core features.
+
+## Why This Matters
+
+The transcripts are valuable because they show real workflow thinking, mistakes,
+and experiments. They are risky if treated as current official documentation.
+
+## Prerequisites
+
+- You have read the official docs sections for the feature you want to try.
+- You can label a pattern as official, community, or experimental.
+
+## Case Study A - Mixed-Provider Efficiency
+
+Idea: use a stronger reasoning model for planning and a cheaper or faster model
+for implementation, validation, or glue.
+
+Risk: wrong provider/model strings, unsupported fields, and noisy comparisons.
+
+Safe experiment: run the same small sandbox issue twice with two explicit
+workflow YAML files and compare validation results, time, and review quality.
+
+Transcript sources:
+
+- `Plan with Claude Opus, Build with Kimi K2.6 LIVE Mixed-Provider Benchmark.txt`
+- `Pushing My AI Dark Factory to Its Limits with Opus + Kimi Combined.txt`
+
+## Case Study B - Dark Factory Experimentation
+
+Idea: issue intake, triage, implementation, validation, PR review, and possibly
+deployment loops.
+
+Risk: too much autonomy too early.
+
+Safe version: issue-to-draft-PR with plan approval and final approval. No
+autonomous merge.
+
+Transcript sources:
+
+- `The AI Dark Factory is ALIVE A Codebase That Writes Its Own Code, Live.txt`
+- `Pushing My AI Dark Factory to Its Limits with Opus + Kimi Combined.txt`
+
+## Case Study C - Frontend-Specialized Routing
+
+Idea: one model plans accurate content, another generates UI, another handles
+integration, and a validator checks the result.
+
+Risk: a pretty UI with broken integration.
+
+Safe version: route only the design draft to the UI-specialized model, then run
+deterministic build/test checks and a separate code review.
+
+Transcript source:
+
+- `Claude Plans, Gemini Designs One Workflow for Beautiful Frontends (LIVE).txt`
+
+## Case Study D - Jira-Style Ticket Workflows
+
+Idea: a ticket can become a persistent Archon conversation or workflow entry
+point.
+
+Risk: Jira adapter details may be experimental unless official docs add support.
+
+Safe version: manually copy a ticket summary into a GitHub issue or local plan,
+then run a supervised workflow.
+
+Transcript source:
+
+- `Archon + Jira Drag a Ticket, Get a Pull Request (Live Build).txt`
+
+## Case Study E - Pi Extensions
+
+Idea: Pi extensions can add specialized review gates, UI flows, and custom
+tooling.
+
+Risk: third-party extension trust and unsupported Archon YAML fields.
+
+Safe version: install one extension in a disposable environment, run read-only
+analysis first, and keep human approval gates.
+
+Transcript sources:
+
+- `Pi Coding Agent + Archon Build ANY AI Coding Workflow (No Claude Code Bloat).txt`
+- `Pi is INCREDIBLE - Building a Custom Coding Agent Live.txt`
+
+## Expected Result
+
+You should have a short list of advanced experiments, each with a safe supervised
+version.
+
+## Verification Checklist
+
+- Every experiment has a human gate.
+- No experiment is presented as official unless docs confirm it.
+- GitHub/Dark Factory experiments stop before autonomous merge.
+
+## Common Mistakes
+
+- Copying live-stream commands without checking current docs.
+- Benchmarking providers without controlling the task.
+- Installing extension packages without reviewing them.
+
+## Mini Exercise
+
+Pick one case study and rewrite it as a two-node supervised sandbox workflow.
+
+## Completion Checkpoint
+
+Move on when every transcript-derived idea in your notes has a label:
+official, community, experimental, historical, or illustrative.
+
+## Source References
+
+- `transcripts/The Next Evolution of AI Coding Is Harnesses - Here's How to Build Them.txt`
+- `transcripts/Pi Coding Agent + Archon Build ANY AI Coding Workflow (No Claude Code Bloat).txt`
+- `transcripts/Pi is INCREDIBLE - Building a Custom Coding Agent Live.txt`
+- `transcripts/Plan with Claude Opus, Build with Kimi K2.6 LIVE Mixed-Provider Benchmark.txt`
+- `transcripts/Pushing My AI Dark Factory to Its Limits with Opus + Kimi Combined.txt`
+- `transcripts/The AI Dark Factory is ALIVE A Codebase That Writes Its Own Code, Live.txt`
+- `transcripts/Claude Plans, Gemini Designs One Workflow for Beautiful Frontends (LIVE).txt`
+- `transcripts/Archon + Jira Drag a Ticket, Get a Pull Request (Live Build).txt`
+
+---
+
+# Part 14 - Troubleshooting Guide
+
+## Learning Objective
+
+Diagnose common failures without leaking secrets.
+
+## Why This Matters
+
+Troubleshooting often tempts people to paste logs, env files, or auth files into
+chat. A safe diagnostic routine prevents that.
+
+## Prerequisites
+
+- You know where logs and artifacts live.
+- You know which files may contain secrets.
+
+| Symptom | Likely cause | Diagnostic command | Safe fix |
+| --- | --- | --- | --- |
+| `archon` command not found | Bun link path missing | `archon version` | Add Bun bin directory to PATH; rerun `bun link` |
+| Bun not found | Bun not installed or shell not reloaded | `bun --version` | Install Bun; reload shell |
+| Claude binary not found | Compiled binary needs path | `where claude` or `which claude` | Set `CLAUDE_BIN_PATH` or config path |
+| Codex binary not found | Codex CLI not installed or path missing | `codex --version` | Install Codex; set `CODEX_BIN_PATH` or config path if needed |
+| Authentication failure | Missing or expired provider credentials | provider CLI status command | Re-login locally; do not paste tokens into chat |
+| GitHub clone failure | Missing token or repo permission | `gh auth status` | Fix GitHub auth and token scope |
+| Stale worktrees | Old run left environment | `archon isolation list` | `archon isolation cleanup` or `archon complete <branch>` |
+| Workflow not discovered | Wrong folder or invalid YAML | `archon workflow list --json` | Put YAML in `.archon/workflows/`; validate |
+| Invalid YAML | Syntax error | `archon validate workflows <name>` | Fix indentation and node fields |
+| Unknown provider | Provider not configured | `archon validate workflows <name>` | Use `claude`, `codex`, or `pi` as documented |
+| Invalid model string | Model ID not supported by provider | provider CLI model list | Replace with verified model ID |
+| Missing command file | Workflow references absent command | `archon validate workflows <name>` | Add `.archon/commands/<name>.md` |
+| Missing skill directory | Claude-only skill missing | `archon validate workflows <name>` | Install or remove skill reference |
+| Missing MCP config | Claude-only MCP path invalid | `archon validate workflows <name>` | Fix config path or remove MCP |
+| Approval gate invisible in Web UI | Workflow missing `interactive: true` | inspect YAML | Add workflow-level `interactive: true` |
+| Web UI disconnected | Server stopped or port conflict | `curl http://localhost:3090/health` | Restart server; resolve port conflict |
+| Port already in use | Stale process | `netstat -ano | findstr :3090` | Kill stale `bun` or `node` process by PID |
+| Server not seeing local workflow changes | Server clone has not synced pushed changes | `git status` | Commit and push workflow/command changes |
+| Pi auth problem | Pi login/env/model not configured | run `pi`, check local model config | Re-login or fix env privately |
+| Secret exposed in terminal history | Token pasted into command | inspect history locally | Rotate token; remove history entry |
+
+## Token Rotation Steps
+
+1. Revoke the exposed token at the provider.
+2. Create a new token.
+3. Update only private local env files.
+4. Restart Archon.
+5. Confirm no token is committed:
+
+```bash
+git status --short
+git diff -- . ':!*.lock'
+```
+
+Do not paste the exposed token into an issue, PR, chat, or support request.
+
+## Expected Result
+
+You can diagnose common setup, workflow, provider, GitHub, Web UI, and secret
+incidents using supported commands.
+
+## Verification Checklist
+
+- You can get `archon version`.
+- You can validate a workflow.
+- You can inspect a log tail.
+- You can rotate a token if exposed.
+
+## Common Mistakes
+
+- Sharing `~/.codex/auth.json`.
+- Using screenshots that reveal tokens.
+- Killing active assistant processes when only a stale server process was the
+  problem.
+
+## Mini Exercise
+
+Run:
+
+```bash
+archon workflow status
+archon isolation list
+archon validate workflows
+```
+
+Then write down where you would look first for a failed run.
+
+## Completion Checkpoint
+
+Move on when you can troubleshoot without exposing secrets.
+
+## Source References
+
+- `packages/docs-web/src/content/docs/reference/troubleshooting.md`
+- `packages/docs-web/src/content/docs/reference/security.md`
+- `.claude/skills/archon/references/troubleshooting.md`
+- `packages/docs-web/src/content/docs/deployment/windows.md`
+
+---
+
+# Part 15 - Capstone Projects
+
+## Learning Objective
+
+Apply the tutorial sequence to four progressively harder projects.
+
+## Why This Matters
+
+Capstones turn reference knowledge into repeatable practice.
+
+## Prerequisites
+
+- Local setup works.
+- Sandbox repo exists.
+- GitHub sandbox repo exists for Capstone 4.
+- Human approval gates are enabled where needed.
+
+## Capstone 1 - Beginner
+
+Goal: run a built-in workflow on the sandbox and inspect results.
+
+```bash
+archon workflow run archon-assist --no-worktree "Explain this sandbox repository."
+archon workflow status
+```
+
+Done when you can explain what ran and where logs live.
+
+## Capstone 2 - Intermediate
+
+Goal: create a custom Plan-Implement-Validate workflow with deterministic tests
+and one human approval gate.
+
+Required:
+
+- `.archon/workflows/sandbox-piv.yaml`
+- `interactive: true`
+- `approval:` node after plan
+- `bash:` validation node
+
+Run:
+
+```bash
+archon validate workflows sandbox-piv
+archon workflow run sandbox-piv --branch capstone/piv "Add subtract and validation."
+```
+
+## Capstone 3 - Advanced
+
+Goal: create a mixed-provider workflow with explicit artifacts.
+
+Required:
+
+- Codex exploration node
+- Pi/Gemini planning node with verified model ID
+- deterministic validation node
+- fresh context between provider changes
+- artifact handoff through `$ARTIFACTS_DIR`
+
+Do not proceed until each provider works separately.
+
+## Capstone 4 - Supervised GitHub Issue-To-PR
+
+Goal: use GitHub issue intake with human gates and no autonomous merge.
+
+Required:
+
+- disposable GitHub repo
+- issue intake
+- isolated worktree
+- planning artifact
+- human plan approval
+- implementation
+- deterministic validation
+- independent review
+- final human approval
+- pull request creation
+
+Suggested run:
+
+```bash
+archon workflow run archon-fix-github-issue --branch capstone/issue-1 "Fix issue #1"
+```
+
+Do not enable autonomous merge in the learning version.
+
+## Capstone 5 - Model-Role Guided Project
+
+Goal: complete one guided vibe coding project with explicit model roles.
+
+Required:
+
+- Claude or Codex planning node
+- human plan approval
+- Gemini, Qwen, Kimi, Codex, or Claude implementation node with verified model
+  ID
+- deterministic validation node
+- Claude or Codex review or test-strategy node
+- artifact or explicit node-output handoff across each model boundary
+- fallback provider or stop condition
+
+Example role note:
+
+```text
+Planner: codex, gpt-5.3-codex, medium reasoning
+Inner developer: pi, openrouter/qwen/qwen3-coder
+Reviewer: codex, independent from implementation
+Fallback: use codex implementation if Pi auth fails; do not skip validation
+```
+
+Do not run this capstone in a real repository until the same request works with
+one provider first.
+
+## Capstone 6 - Team Remote Operation
+
+Goal: run or simulate a team/server workflow with one exposed interface and
+clear operating boundaries.
+
+Required:
+
+- local server, Docker, VPS, or simulated remote runtime
+- Web UI, GitHub webhook, Slack, Telegram, or Discord interface selected
+- allowed-user or access boundary documented
+- secret-handling note
+- health endpoint evidence
+- workflow status evidence
+- log and artifact locations
+- rollback or incident response note
+- no production deployment and no autonomous merge
+
+Boundary note:
+
+```text
+Runtime:
+Database:
+Interface:
+Allowed users:
+Secrets:
+Health checks:
+Logs:
+Artifacts:
+Rollback:
+Stop conditions:
+```
+
+This capstone proves operational readiness, not production autonomy.
+
+## Expected Result
+
+After the capstones that match your role, you can safely run a supervised
+workflow on a disposable repository and define the boundary for the first real
+repository or team/server run.
+
+## Verification Checklist
+
+- Capstone 1: you inspected output and logs.
+- Capstone 2: custom PIV validates and pauses.
+- Capstone 3: mixed-provider workflow uses explicit artifacts.
+- Capstone 4: GitHub PR is created or prepared, but not merged automatically.
+- Capstone 5: model roles are explicit and validation is deterministic.
+- Capstone 6: runtime boundary, health checks, logs, artifacts, and rollback
+  are documented.
+
+## Assessment Rubric
+
+Use this rubric for self-checks, workshops, or team onboarding sign-off.
+
+| Area | Pass | Strong |
+| --- | --- | --- |
+| Safety | Uses a sandbox, avoids secrets in chat, and keeps human approval before risky changes. | Can explain why each approval gate exists and how to recover from a rejected run. |
+| Workflow operation | Runs built-in workflows, checks status, and finds logs and artifacts. | Can diagnose a paused, failed, or abandoned run from CLI output and JSONL logs. |
+| Workflow authoring | Creates a valid command and a valid YAML workflow with deterministic validation. | Uses artifacts, fresh context, and conditional or loop nodes only where they reduce real risk. |
+| Provider and model-role routing | Runs Codex first and treats Pi/Gemini/Qwen/Kimi model IDs as locally verified configuration. | Separates planning, implementation, validation, and review responsibilities with artifact handoffs and fallback behavior. |
+| GitHub practice | Creates or prepares a supervised PR from an issue. | Reviews the PR, documents verification, and refuses autonomous merge while learning. |
+| Team/server operation | Can explain where Archon runs, which interface is enabled, and where evidence lives. | Verifies health checks, logs, artifacts, access boundaries, and rollback before broader rollout. |
+
+## Common Mistakes
+
+- Skipping straight to Capstone 4.
+- Running mixed-provider workflows before single-provider workflows work.
+- Treating a generated PR as merge-ready without human review.
+- Exposing a server adapter before access control, secrets, and rollback are
+  documented.
+
+## Mini Exercise
+
+After each capstone, write a three-line run report:
+
+```text
+What ran:
+What changed:
+What I verified:
+```
+
+## Completion Checkpoint
+
+The learning path is complete when the capstone for your target role produces
+secret-free evidence and you can explain every gate in the workflow.
+
+## Source References
+
+- `.archon/workflows/defaults/archon-assist.yaml`
+- `.archon/workflows/defaults/archon-piv-loop.yaml`
+- `.archon/workflows/defaults/archon-fix-github-issue.yaml`
+- `packages/docs-web/src/content/docs/adapters/github.md`
+
+---
+
+# Part 16 - Final Reference Material
+
+## Learning Objective
+
+Keep the operational commands, safety rules, glossary, and source map in one
+place.
+
+## Why This Matters
+
+A good reference lets you operate Archon without rereading the full tutorial.
+
+## Prerequisites
+
+You have completed or at least read Parts 0 through 15.
+
+## One-Page Cheat Sheet
+
+```bash
+archon version
+archon setup
+archon workflow list
+archon workflow run <workflow> --branch <branch> "<message>"
+archon workflow run <workflow> --no-worktree "<read-only message>"
+archon workflow status
+archon workflow approve <run-id> "approved"
+archon workflow reject <run-id> --reason "needs changes"
+archon workflow resume <run-id>
+archon workflow abandon <run-id>
+archon validate workflows <name>
+archon validate commands <name>
+archon isolation list
+archon isolation cleanup
+archon complete <branch>
+bun run dev
+curl http://localhost:3090/health
+curl http://localhost:3090/health/db
+gh auth status
+```
+
+## Safe Operating Checklist
+
+- Use a disposable sandbox first.
+- Use `--branch` for modifying workflows.
+- Use `--no-worktree` only for read-only tasks.
+- Validate workflows before running.
+- Put secrets only in Archon-owned env files or provider auth files.
+- Keep human plan approval enabled.
+- Review PRs before merge.
+- Do not expose Web UI publicly without access control.
+- Use adapter whitelists.
+- Rotate any exposed token immediately.
+
+## Glossary
+
+Artifact: file-based handoff between workflow nodes.
+
+Assistant: coding agent client such as Codex, Claude, or Pi.
+
+Command: Markdown prompt template.
+
+DAG: directed acyclic graph; nodes run according to dependencies.
+
+Provider: Archon execution provider, such as `codex` or `pi`.
+
+Worktree: isolated Git checkout for a branch/run.
+
+Workflow: YAML process definition.
+
+## First Week Practice Plan
+
+Day 1: install, verify, run `archon-assist` on sandbox.
+
+Day 2: inspect worktrees, logs, and artifacts.
+
+Day 3: create one command.
+
+Day 4: create the minimal PIV workflow.
+
+Day 5: add validation and approval.
+
+Day 6: configure GitHub CLI and run a GitHub issue workflow on the sandbox.
+
+Day 7: try a Pi/Gemini read-only analysis workflow.
+
+## What To Learn Next
+
+- Workflow hooks, MCP, and skills if you use Claude nodes.
+- Script nodes for deterministic utilities.
+- GitHub webhooks for team usage.
+- Docker and VPS deployment after local capstones.
+- Provider benchmarking on your own repo.
+
+## Expected Result
+
+You have a compact checklist and command set for your first week with Archon.
+
+## Verification Checklist
+
+- You can find the command cheat sheet.
+- You can find the source appendix.
+- You can explain the safe operating checklist.
+
+## Common Mistakes
+
+- Keeping useful workflows only on one machine and not committing them.
+- Forgetting to update docs when a team workflow changes.
+- Using transcript experiments without labels.
+
+## Mini Exercise
+
+Adapt the safe operating checklist into your team onboarding notes and remove any
+items that do not apply to your environment.
+
+## Completion Checkpoint
+
+The tutorial is complete when you can use the cheat sheet to run, validate,
+inspect, and clean up a supervised workflow.
+
+## Source Appendix
+
+Official files and docs:
+
+- `README.md`
+- `CONTRIBUTING.md`
+- `.archon/workflows/defaults/`
+- `.archon/commands/defaults/`
+- `.claude/skills/archon/`
+- `.claude/skills/archon/references/parameter-matrix.md`
+- `.claude/skills/archon/references/troubleshooting.md`
+- `packages/docs-web/src/content/docs/getting-started/overview.md`
+- `packages/docs-web/src/content/docs/getting-started/installation.md`
+- `packages/docs-web/src/content/docs/getting-started/ai-assistants.md`
+- `packages/docs-web/src/content/docs/guides/authoring-workflows.md`
+- `packages/docs-web/src/content/docs/guides/authoring-commands.md`
+- `packages/docs-web/src/content/docs/guides/approval-nodes.md`
+- `packages/docs-web/src/content/docs/guides/loop-nodes.md`
+- `packages/docs-web/src/content/docs/reference/cli.md`
+- `packages/docs-web/src/content/docs/reference/configuration.md`
+- `packages/docs-web/src/content/docs/reference/security.md`
+- `packages/docs-web/src/content/docs/reference/troubleshooting.md`
+- `packages/docs-web/src/content/docs/adapters/web.md`
+- `packages/docs-web/src/content/docs/adapters/github.md`
+- `packages/docs-web/src/content/docs/adapters/slack.md`
+- `packages/docs-web/src/content/docs/adapters/telegram.md`
+- `packages/docs-web/src/content/docs/adapters/community/discord.md`
+- `packages/docs-web/src/content/docs/deployment/windows.md`
+- `packages/docs-web/src/content/docs/deployment/docker.md`
+- `packages/docs-web/src/content/docs/deployment/cloud.md`
+- `packages/cli/src/cli.ts`
+- `packages/providers/src/`
+- `packages/server/src/`
+- `packages/adapters/src/`
+
+Published docs note:
+
+- `https://archon.diy/llms.txt`, `llms-small.txt`, and `llms-full.txt`
+  returned 404 during this review.
+- Context7 resolved current docs as `/websites/archon_diy`.
+
+Transcript case studies:
+
+- `The Next Evolution of AI Coding Is Harnesses - Here's How to Build Them.txt`
+- `Pi Coding Agent + Archon Build ANY AI Coding Workflow (No Claude Code Bloat).txt`
+- `Pi is INCREDIBLE - Building a Custom Coding Agent Live.txt`
+- `Plan with Claude Opus, Build with Kimi K2.6 LIVE Mixed-Provider Benchmark.txt`
+- `Pushing My AI Dark Factory to Its Limits with Opus + Kimi Combined.txt`
+- `The AI Dark Factory is ALIVE A Codebase That Writes Its Own Code, Live.txt`
+- `Claude Plans, Gemini Designs One Workflow for Beautiful Frontends (LIVE).txt`
+- `Archon + Jira Drag a Ticket, Get a Pull Request (Live Build).txt`
+- `🔴LIVE - My AI Coding Workflow has 10x'd Again with Archon - See it in Action.txt`

--- a/packages/docs-web/src/content/docs/learning/printable-checklists.md
+++ b/packages/docs-web/src/content/docs/learning/printable-checklists.md
@@ -1,0 +1,123 @@
+---
+title: Printable Checklist Pack
+description: Compact Archon curriculum checklists for learners, facilitators, reviewers, and maintainers.
+category: learning
+audience: [user, operator, developer]
+status: current
+sidebar:
+  order: 35
+---
+
+Use these compact checklists during live sessions, office hours, capstones, and
+publishing reviews.
+
+## Learner Run Checklist
+
+```text
+Before running:
+[ ] I am in the intended repository.
+[ ] The repository is disposable or low-risk enough.
+[ ] Secrets are not in chat, notes, commands, or workflow files.
+[ ] Modifying work uses a branch or worktree.
+[ ] I know what validation should run.
+
+After running:
+[ ] I inspected run status.
+[ ] I inspected logs.
+[ ] I inspected artifacts.
+[ ] I inspected changed files.
+[ ] I inspected validation output.
+[ ] I wrote a human decision.
+```
+
+## Approval Gate Checklist
+
+```text
+Before approving:
+[ ] Plan names files.
+[ ] Plan names validation commands.
+[ ] Plan names risks.
+[ ] Plan names rollback.
+[ ] Plan matches the request.
+[ ] Human reviewer understands what may change.
+
+Decision:
+[ ] approve
+[ ] reject
+[ ] revise
+[ ] defer
+```
+
+## Facilitator Session Checklist
+
+```text
+Before session:
+[ ] Goal is clear.
+[ ] Safety rule is selected.
+[ ] Sandbox is ready.
+[ ] Provider fallback is ready.
+[ ] Exercise is selected.
+[ ] No shared material contains secrets.
+
+During session:
+[ ] Demo is short.
+[ ] Learners drive hands-on work.
+[ ] Evidence is inspected.
+[ ] Blockers are recorded.
+[ ] Checklist update is captured.
+```
+
+## Capstone Checklist
+
+```text
+[ ] Objective stated.
+[ ] Risk boundary stated.
+[ ] Workflow or command selected.
+[ ] Branch or worktree identified.
+[ ] Artifacts inspected.
+[ ] Logs inspected.
+[ ] Validation recorded.
+[ ] Human decision recorded.
+[ ] No autonomous merge.
+[ ] Operating checklist updated.
+```
+
+## First Real Repository Checklist
+
+```text
+[ ] Learner passed capstone.
+[ ] Graduation checklist complete.
+[ ] Repository is low-risk enough.
+[ ] Reviewer assigned.
+[ ] Workflow selected.
+[ ] Expected files named.
+[ ] Validation named.
+[ ] Rollback path named.
+[ ] Stop conditions named.
+```
+
+## Publishing Checklist
+
+```text
+[ ] Source-backed claims reviewed.
+[ ] CLI examples verified.
+[ ] Workflow examples verified.
+[ ] Provider examples verified.
+[ ] Safety guidance reviewed.
+[ ] Learning index links major pages.
+[ ] Docs build passes.
+[ ] Known limitations recorded.
+```
+
+## Maintenance Checklist
+
+```text
+[ ] Changelog reviewed.
+[ ] CLI changes reviewed.
+[ ] Workflow catalog reviewed.
+[ ] Provider docs reviewed.
+[ ] GitHub/adapters reviewed.
+[ ] Safety model reviewed.
+[ ] Curriculum updates made.
+[ ] Docs build passes.
+```

--- a/packages/docs-web/src/content/docs/learning/provider-routing-lab.md
+++ b/packages/docs-web/src/content/docs/learning/provider-routing-lab.md
@@ -1,0 +1,175 @@
+---
+title: Provider Routing Lab
+description: A safe lab for teaching single-provider baselines before multi-provider Archon workflows.
+category: learning
+audience: [user, operator]
+status: current
+sidebar:
+  order: 11
+---
+
+Use this lab after learners can run a single-provider workflow and inspect its
+evidence. Do not start provider routing by comparing model hype. Start from node
+responsibility.
+
+After this lab, use [Model Role Recipes](/learning/model-role-recipes/) to turn
+the routing decision into a full guided coding project.
+
+## Learning Goal
+
+Learners should be able to:
+
+- Run a single-provider baseline first.
+- Identify the job of each node.
+- Route a provider only when the node responsibility justifies it.
+- Verify provider setup privately.
+- Record fallback behavior.
+- Explain whether Claude, Codex, Gemini, Qwen, Kimi, or a local model belongs
+  in planning, implementation, validation, or review.
+
+## Safety Rules
+
+- Do not paste provider tokens or auth files into chat or shared notes.
+- Do not guess model IDs.
+- Do not use a multi-provider workflow until the single-provider version works.
+- Do not let provider routing replace explicit artifacts.
+
+## Lab Setup
+
+Use a sandbox task with three responsibilities:
+
+```text
+Plan a tiny change.
+Implement the change.
+Validate the change.
+```
+
+The baseline provider should be whichever assistant is already working for the
+learner.
+
+## Step 1: Run The Baseline
+
+Task:
+
+```text
+Run the workflow with one provider only.
+Record the plan artifact, implementation result, and validation output.
+```
+
+Evidence:
+
+```text
+Provider:
+Workflow:
+Plan artifact:
+Changed files:
+Validation command:
+Validation result:
+Human decision:
+```
+
+Completion signal:
+
+- The workflow works before routing is introduced.
+
+## Step 2: Classify Node Responsibility
+
+For each node, write:
+
+```text
+Node:
+Job:
+Needs broad reasoning: yes / no
+Needs code-editing reliability: yes / no
+Needs deterministic execution: yes / no
+Needs external tool access: yes / no
+Artifact produced:
+Artifact consumed:
+```
+
+Completion signal:
+
+- Provider choice is tied to a node job, not to a favorite model.
+
+## Step 3: Choose One Routing Change
+
+Choose at most one provider change for the first routed run.
+
+Good reasons:
+
+- A planning node needs stronger reasoning.
+- An implementation node works better with a specific coding assistant.
+- A review node should be independent from the implementation provider.
+
+Weak reasons:
+
+- The model is new.
+- The model is popular.
+- The learner wants to try everything at once.
+
+Decision note:
+
+```text
+Node to route:
+Original provider:
+New provider:
+Reason:
+Expected benefit:
+Fallback if unavailable:
+```
+
+## Step 4: Verify Provider Setup
+
+Privately verify:
+
+```text
+Provider installed:
+Provider authenticated:
+Model ID verified:
+No credentials in notes:
+Single-provider fallback available:
+```
+
+Completion signal:
+
+- The learner can prove the provider exists without sharing secrets.
+
+## Step 5: Run The Routed Workflow
+
+Task:
+
+```text
+Run the routed workflow in the sandbox.
+Compare output with the baseline.
+Inspect artifacts and validation.
+```
+
+Evidence:
+
+```text
+Baseline result:
+Routed result:
+Artifact difference:
+Validation difference:
+Provider-specific failure:
+Human decision:
+```
+
+Completion signal:
+
+- The learner can say whether routing improved the workflow, made no difference,
+  or added risk.
+
+## Debrief Questions
+
+1. Which node actually benefited from routing?
+2. Which artifact crossed provider boundaries?
+3. What would have failed if the second provider was unavailable?
+4. Did validation change?
+5. Would you keep this routing in a real workflow?
+
+## Facilitator Notes
+
+If learners want to route every node, return to the baseline. Multi-provider
+workflows are useful when responsibilities differ. They are not a substitute for
+clear artifacts, deterministic checks, and human review.

--- a/packages/docs-web/src/content/docs/learning/publishing-checklist.md
+++ b/packages/docs-web/src/content/docs/learning/publishing-checklist.md
@@ -1,0 +1,129 @@
+---
+title: Publishing Checklist
+description: Final checks before publishing or teaching the Archon curriculum.
+category: learning
+audience: [developer, operator]
+status: current
+sidebar:
+  order: 22
+---
+
+Use this checklist before publishing the curriculum or running a live cohort.
+
+## Source-Backed Content
+
+```text
+Practical tutorial reviewed:
+Curriculum guide reviewed:
+Learning index reviewed:
+Reading map reviewed:
+CLI examples verified:
+Workflow examples verified:
+Provider examples verified:
+GitHub examples verified:
+Deployment boundaries verified:
+```
+
+## Safety Review
+
+```text
+Sandbox-first guidance present:
+Secret-handling warnings present:
+Human approval guidance present:
+No autonomous merge recommendation:
+No production deployment in beginner path:
+Provider routing requires baseline:
+PR creation distinguished from merge readiness:
+Validation distinguished from assistant summary:
+```
+
+## Navigation Review
+
+```text
+Learning section appears in sidebar:
+Learning index links every major curriculum page:
+Package map includes every major curriculum asset:
+Quick-start paths cover common roles:
+Homepage links learning materials:
+Reading map covers learner roles:
+Session plans link workbook and evaluation:
+Cohort runbook links setup and labs:
+Capstone links evaluation:
+```
+
+## Facilitator Readiness
+
+```text
+Syllabus available:
+Session plans available:
+Instructor notes available:
+Slide outline available:
+Sandbox setup guide available:
+Sample artifacts available:
+Knowledge checks available:
+FAQ available:
+Evaluation sheet available:
+Capstone rubric available:
+```
+
+## Sandbox Readiness
+
+```text
+Resettable sandbox repository prepared:
+Prepared failure repository prepared:
+Known-good workflow selected:
+Known-good validation command selected:
+Provider fallback selected:
+GitHub optional path decided:
+No secrets in sandbox:
+Reset path tested:
+```
+
+## Build And Route Check
+
+Run:
+
+```bash
+bun --filter @archon/docs-web build
+```
+
+Confirm the generated routes include:
+
+```text
+/learning/
+/learning/practical-tutorial/
+/learning/curriculum/
+/learning/session-plans/
+/learning/learner-workbook/
+/learning/capstone-assessment/
+/learning/sandbox-setup/
+/learning/knowledge-checks/
+/learning/faq/
+```
+
+## Review Sign-Off
+
+```text
+Reviewer:
+Date:
+Archon version or commit:
+Docs build result:
+Known limitations:
+Approved for publishing: yes / no
+Approved for live cohort: yes / no
+```
+
+## If Publishing Is Blocked
+
+Record:
+
+```text
+Blocking issue:
+Affected page:
+Risk:
+Owner:
+Next action:
+```
+
+Do not publish if the blocker affects safety, secrets, validation, or unsupported
+command behavior.

--- a/packages/docs-web/src/content/docs/learning/quick-start-paths.md
+++ b/packages/docs-web/src/content/docs/learning/quick-start-paths.md
@@ -1,0 +1,86 @@
+---
+title: Quick-Start Paths
+description: Short paths through the Archon curriculum for common learning situations.
+category: learning
+audience: [user, operator]
+status: current
+sidebar:
+  order: 34
+---
+
+Use these paths when you do not need the full curriculum immediately. Each path
+keeps the safety model intact.
+
+## Solo Learner: First Safe Week
+
+1. Read [Curriculum Syllabus](/learning/syllabus/).
+2. Follow [Practical Tutorial](/learning/practical-tutorial/) Parts 0-5.
+3. Fill in [Learner Workbook](/learning/learner-workbook/) Days 1-3.
+4. Complete the Repository Explanation and Evidence Hunt exercises in
+   [Exercise Bank](/learning/exercise-bank/).
+5. Continue through Practical Tutorial Parts 6-10.
+6. Complete one capstone from [Capstone Assessment](/learning/capstone-assessment/).
+7. Use [Graduation Checklist](/learning/graduation-checklist/) before real work.
+
+## Facilitator: Prepare A Workshop
+
+1. Read [Curriculum Guide](/learning/curriculum/).
+2. Read [Cohort Runbook](/learning/cohort-runbook/).
+3. Prepare repositories with [Sandbox Setup Guide](/learning/sandbox-setup/).
+4. Teach from [Workshop Session Plans](/learning/session-plans/).
+5. Use [Instructor Notes](/learning/instructor-notes/) during sessions.
+6. Assign [Learner Workbook](/learning/learner-workbook/) prompts.
+7. Score with [Facilitator Evaluation](/learning/facilitator-evaluation/).
+
+## Team Lead: Decide Readiness
+
+1. Read [Curriculum Syllabus](/learning/syllabus/).
+2. Review [Learning Outcomes Matrix](/learning/outcomes-matrix/).
+3. Use [Capstone Assessment](/learning/capstone-assessment/).
+4. Complete [Graduation Checklist](/learning/graduation-checklist/).
+5. Review [Model Role Recipes](/learning/model-role-recipes/) for approved
+   model responsibilities.
+6. Move to [Real Repository Transition](/learning/real-repository-transition/).
+7. Plan rollout with [Team Adoption Path](/learning/team-adoption-path/).
+
+## Operator: Prepare Safe Environments
+
+1. Read [Sandbox Setup Guide](/learning/sandbox-setup/).
+2. Read Practical Tutorial setup and operations sections.
+3. Review [Cohort Runbook](/learning/cohort-runbook/).
+4. Review [Publishing Checklist](/learning/publishing-checklist/).
+5. Use [Office Hours Guide](/learning/office-hours-guide/) for support.
+6. Record blockers in [Cohort Report](/learning/cohort-report/).
+
+## Maintainer: Keep Curriculum Current
+
+1. Read [Tutorial Plan](/learning/tutorial-plan/).
+2. Run [Version Review](/learning/version-review/) after source changes.
+3. Use [Curriculum Maintenance Guide](/learning/maintenance-guide/).
+4. Run [Publishing Checklist](/learning/publishing-checklist/).
+5. Build docs with `bun --filter @archon/docs-web build`.
+
+## Learner In Trouble
+
+1. Read [Learner FAQ](/learning/faq/).
+2. Use [Troubleshooting Labs](/learning/troubleshooting-labs/).
+3. Bring evidence to [Office Hours Guide](/learning/office-hours-guide/).
+4. Complete targeted practice from
+   [Remediation Playbook](/learning/remediation-playbook/).
+5. Use [Peer Review Practice](/learning/peer-review-practice/) before capstone.
+
+## Fastest Safe Route To Real Work
+
+1. Create sandbox with [Sandbox Setup Guide](/learning/sandbox-setup/).
+2. Run a read-only workflow.
+3. Write a run report.
+4. Create or validate one narrow workflow.
+5. Complete one Plan-Implement-Validate exercise.
+6. Use [Model Role Recipes](/learning/model-role-recipes/) if more than one
+   model will participate.
+7. Complete one capstone.
+8. Complete [Graduation Checklist](/learning/graduation-checklist/).
+9. Run first real task with [Real Repository Transition](/learning/real-repository-transition/).
+
+Fast does not mean skipping evidence. Every path still requires sandbox,
+validation, approval, and review.

--- a/packages/docs-web/src/content/docs/learning/reading-map.md
+++ b/packages/docs-web/src/content/docs/learning/reading-map.md
@@ -1,0 +1,173 @@
+---
+title: Reading Map
+description: A role-based map through the Archon learning curriculum and documentation.
+category: learning
+audience: [user, operator, developer]
+status: current
+sidebar:
+  order: 13
+---
+
+Use this map to decide what to read before, during, and after the curriculum.
+The practical tutorial remains the lesson body; this page points different
+roles to the right supporting material.
+
+If you want a complete inventory first, start with
+[Curriculum Package Map](/learning/package-map/). If you need the shortest route
+for a specific situation, use [Quick-Start Paths](/learning/quick-start-paths/).
+
+## First-Time Learner
+
+Read in order:
+
+1. [Curriculum Syllabus](/learning/syllabus/)
+2. [Practical Tutorial](/learning/practical-tutorial/)
+3. [Learner Workbook](/learning/learner-workbook/)
+4. [Exercise Bank](/learning/exercise-bank/)
+5. [Capstone Assessment](/learning/capstone-assessment/)
+6. [Learner FAQ](/learning/faq/)
+
+Skip until later:
+
+- Cohort operations.
+- Facilitator evaluation.
+- Advanced provider routing.
+- Deployment details beyond your setup path.
+
+## Workshop Facilitator
+
+Read in order:
+
+1. [Curriculum Guide](/learning/curriculum/)
+2. [Cohort Runbook](/learning/cohort-runbook/)
+3. [Workshop Session Plans](/learning/session-plans/)
+4. [Sandbox Setup Guide](/learning/sandbox-setup/)
+5. [Instructor Notes](/learning/instructor-notes/)
+6. [Sample Artifacts](/learning/sample-artifacts/)
+7. [Knowledge Checks](/learning/knowledge-checks/)
+8. [Slide Outline](/learning/slide-outline/)
+9. [Facilitator Evaluation](/learning/facilitator-evaluation/)
+10. [Troubleshooting Labs](/learning/troubleshooting-labs/)
+
+Prepare before live sessions:
+
+- Resettable sandbox repository.
+- Prepared failure repository.
+- Sample plan artifact to approve.
+- Sample plan artifact to reject.
+- Sanitized run log excerpt.
+- Provider fallback.
+
+## Team Lead
+
+Read in order:
+
+1. [Curriculum Syllabus](/learning/syllabus/)
+2. [Curriculum Guide](/learning/curriculum/)
+3. [Capstone Assessment](/learning/capstone-assessment/)
+4. [Facilitator Evaluation](/learning/facilitator-evaluation/)
+5. [Cohort Runbook](/learning/cohort-runbook/)
+
+Focus on:
+
+- Completion requirements.
+- Real-repository readiness.
+- Approval gates.
+- Secret-handling policy.
+- Supervision level after graduation.
+
+## Workflow Author
+
+Read in order:
+
+1. Practical Tutorial Parts 6-8.
+2. [Exercise Bank](/learning/exercise-bank/)
+3. [Provider Routing Lab](/learning/provider-routing-lab/)
+4. [Model Role Recipes](/learning/model-role-recipes/)
+5. [Authoring Workflows](/guides/authoring-workflows/)
+6. [Approval Nodes](/guides/approval-nodes/)
+7. [Script Nodes](/guides/script-nodes/)
+
+Focus on:
+
+- Narrow current use cases.
+- Artifact handoffs.
+- Deterministic validation.
+- Approval gates.
+- Rollback paths.
+
+## Operator
+
+Read in order:
+
+1. Practical Tutorial Parts 11-14.
+2. [Cohort Runbook](/learning/cohort-runbook/)
+3. [Local Deployment](/deployment/local/)
+4. [Docker Deployment](/deployment/docker/)
+5. [Cloud Deployment](/deployment/cloud/)
+6. [Security Reference](/reference/security/)
+7. [Troubleshooting Reference](/reference/troubleshooting/)
+
+Focus on:
+
+- Where Archon runs.
+- Which interfaces are exposed.
+- Where secrets live.
+- How logs and artifacts are handled.
+- Who approves PRs and production steps.
+
+## Developer Or Maintainer
+
+Read in order:
+
+1. [Tutorial Plan](/learning/tutorial-plan/)
+2. [Curriculum Maintenance Guide](/learning/maintenance-guide/)
+3. [Publishing Checklist](/learning/publishing-checklist/)
+4. [Version Review](/learning/version-review/)
+5. [Architecture Reference](/reference/architecture/)
+6. [CLI Reference](/reference/cli/)
+7. [Contributing](/contributing/)
+8. [DX Quirks](/contributing/dx-quirks/)
+
+Focus on:
+
+- Source-backed claims.
+- Current CLI behavior.
+- Test isolation.
+- Documentation maintenance notes.
+- Keeping tutorial examples aligned with source.
+
+## Quick Reference By Need
+
+| Need | Read |
+| --- | --- |
+| Teach a live session | [Workshop Session Plans](/learning/session-plans/) |
+| Prepare a cohort | [Cohort Runbook](/learning/cohort-runbook/) |
+| Explain key terms | [Curriculum Glossary](/learning/glossary/) |
+| Navigate all assets | [Curriculum Package Map](/learning/package-map/) |
+| Pick a short route | [Quick-Start Paths](/learning/quick-start-paths/) |
+| Print compact checklists | [Printable Checklist Pack](/learning/printable-checklists/) |
+| Use teaching scripts | [Instructor Notes](/learning/instructor-notes/) |
+| Show example evidence | [Sample Artifacts](/learning/sample-artifacts/) |
+| Check understanding | [Knowledge Checks](/learning/knowledge-checks/) |
+| Build a workshop deck | [Slide Outline](/learning/slide-outline/) |
+| Answer common questions | [Learner FAQ](/learning/faq/) |
+| Maintain the curriculum | [Curriculum Maintenance Guide](/learning/maintenance-guide/) |
+| Publish or teach soon | [Publishing Checklist](/learning/publishing-checklist/) |
+| Review after releases | [Version Review](/learning/version-review/) |
+| Run support sessions | [Office Hours Guide](/learning/office-hours-guide/) |
+| Assign remediation | [Remediation Playbook](/learning/remediation-playbook/) |
+| Practice peer review | [Peer Review Practice](/learning/peer-review-practice/) |
+| Graduate a learner | [Graduation Checklist](/learning/graduation-checklist/) |
+| Start real repository work | [Real Repository Transition](/learning/real-repository-transition/) |
+| Roll out to a team | [Team Adoption Path](/learning/team-adoption-path/) |
+| Map outcomes to evidence | [Learning Outcomes Matrix](/learning/outcomes-matrix/) |
+| Report cohort results | [Cohort Report](/learning/cohort-report/) |
+| Track training metrics | [Curriculum Metrics](/learning/curriculum-metrics/) |
+| Give learner homework | [Learner Workbook](/learning/learner-workbook/) |
+| Assign extra practice | [Exercise Bank](/learning/exercise-bank/) |
+| Teach debugging | [Troubleshooting Labs](/learning/troubleshooting-labs/) |
+| Teach provider routing | [Provider Routing Lab](/learning/provider-routing-lab/) |
+| Assign model roles in a project | [Model Role Recipes](/learning/model-role-recipes/) |
+| Score readiness | [Facilitator Evaluation](/learning/facilitator-evaluation/) |
+| Run final assessment | [Capstone Assessment](/learning/capstone-assessment/) |

--- a/packages/docs-web/src/content/docs/learning/real-repository-transition.md
+++ b/packages/docs-web/src/content/docs/learning/real-repository-transition.md
@@ -1,0 +1,136 @@
+---
+title: Real Repository Transition
+description: How to move from Archon sandbox training into supervised real-repository work.
+category: learning
+audience: [user, operator]
+status: current
+sidebar:
+  order: 29
+---
+
+Use this guide for the first real-repository run after curriculum graduation.
+The first real run should be small, reversible, and reviewed.
+
+## Entry Criteria
+
+Do not start until the learner has:
+
+- Completed a capstone.
+- Passed or reviewed the graduation checklist.
+- Chosen a low-risk repository.
+- Named a reviewer.
+- Defined validation.
+- Defined rollback.
+
+## Choose The First Repository
+
+Good first repositories:
+
+- Small internal tools.
+- Documentation-heavy repositories.
+- Repositories with fast tests.
+- Repositories with easy rollback.
+- Repositories where a reviewer is available.
+
+Poor first repositories:
+
+- Production-critical services.
+- Repositories with unclear ownership.
+- Repositories with slow or flaky validation.
+- Repositories containing sensitive secrets.
+- Repositories with no clear rollback path.
+
+## Choose The First Task
+
+Good first tasks:
+
+- Documentation cleanup.
+- Small test-backed bug fix.
+- Narrow refactor with no behavior change.
+- Adding a tiny helper with tests.
+- Reviewing a PR without editing files.
+
+Poor first tasks:
+
+- Large rewrites.
+- Authentication changes.
+- Secret rotation.
+- Production deployment.
+- Multi-provider workflow experiments.
+- Autonomous issue-to-merge loops.
+
+## First Run Plan
+
+```text
+Repository:
+Task:
+Workflow:
+Branch:
+Reviewer:
+Expected files:
+Required artifact:
+Required validation:
+Rollback:
+Stop conditions:
+```
+
+## During The Run
+
+The learner should:
+
+1. Confirm the repository and branch.
+2. Run the workflow with isolation.
+3. Inspect the plan artifact.
+4. Get approval before implementation.
+5. Inspect changed files.
+6. Run deterministic validation.
+7. Write a PR readiness note if creating a PR.
+8. Stop for human review.
+
+## After The Run
+
+Record:
+
+```text
+What ran:
+What changed:
+What evidence was inspected:
+What validation passed or failed:
+What reviewer decided:
+What rollback path remains:
+What checklist item changed:
+```
+
+## Reviewer Checklist
+
+```text
+Repository was intended:
+Branch/worktree was intended:
+Files changed were expected:
+Artifacts support the change:
+Validation is appropriate:
+Secrets are not exposed:
+PR summary matches diff:
+Residual risk is named:
+Merge waits for review:
+```
+
+## Expand Carefully
+
+After the first successful real run, expand one dimension at a time:
+
+- Slightly larger task, or
+- Another low-risk repository, or
+- Another trained learner, or
+- Another workflow.
+
+Do not expand all dimensions at once.
+
+## Transition Complete
+
+The transition is complete when:
+
+- The learner completes a real-repository run with supervision.
+- The reviewer accepts the evidence trail.
+- The team checklist is updated.
+- The next allowed workflow is defined.

--- a/packages/docs-web/src/content/docs/learning/remediation-playbook.md
+++ b/packages/docs-web/src/content/docs/learning/remediation-playbook.md
@@ -1,0 +1,204 @@
+---
+title: Remediation Playbook
+description: Targeted remediation paths when Archon curriculum learners miss completion signals.
+category: learning
+audience: [operator, user]
+status: current
+sidebar:
+  order: 25
+---
+
+Use remediation when a learner misses a completion signal. Remediation should be
+small, specific, and evidence-based. Do not repeat the whole course when one
+skill is missing.
+
+## Remediation Rule
+
+Repeat the smallest exercise that proves the missing skill.
+
+Good remediation:
+
+```text
+Repeat the approval gate drill and reject a vague plan with a concrete revision request.
+```
+
+Weak remediation:
+
+```text
+Redo the whole workflow and try harder.
+```
+
+## Remediation Record
+
+```text
+Learner:
+Gap:
+Evidence of gap:
+Assigned exercise:
+Required evidence:
+Reviewer:
+Due date:
+Result: pass / revise / defer
+```
+
+## Safety Gap
+
+Symptoms:
+
+- Learner wants to start in a production repository.
+- Learner shares or nearly shares secrets.
+- Learner removes approval gates for speed.
+
+Remediation:
+
+1. Re-read the safety contract.
+2. Complete the sandbox boundary prompt.
+3. Write a risk boundary for the proposed real repository.
+4. Name approval gates, validation, and rollback.
+
+Required evidence:
+
+```text
+Repository risk boundary:
+Secrets policy:
+Approval gate:
+Validation:
+Rollback path:
+Decision to stay in sandbox or proceed with supervision:
+```
+
+## Evidence Inspection Gap
+
+Symptoms:
+
+- Learner quotes only the assistant summary.
+- Learner cannot find logs or artifacts.
+- Learner cannot say what changed.
+
+Remediation:
+
+1. Complete the Evidence Hunt exercise.
+2. Write a run report.
+3. Have a peer verify the report from the same evidence.
+
+Required evidence:
+
+```text
+Run status:
+Logs inspected:
+Artifacts inspected:
+Changed files:
+Validation output:
+Human decision:
+```
+
+## Authoring Gap
+
+Symptoms:
+
+- Command or workflow is too broad.
+- Workflow lacks deterministic validation.
+- Workflow depends on hidden chat memory.
+
+Remediation:
+
+1. Reduce to one current sandbox task.
+2. Define one input, one artifact, and one validation command.
+3. Validate the command or workflow before running it.
+
+Required evidence:
+
+```text
+Narrow task:
+Command or workflow path:
+Artifact:
+Validation command:
+Validation result:
+Known limit:
+```
+
+## Approval Judgment Gap
+
+Symptoms:
+
+- Learner approves vague plans.
+- Learner cannot explain rejection criteria.
+- Learner treats confidence as evidence.
+
+Remediation:
+
+1. Review one acceptable sample artifact.
+2. Review one flawed plan.
+3. Write an approval review that rejects or revises the flawed plan.
+
+Required evidence:
+
+```text
+Decision:
+Missing files:
+Missing validation:
+Missing risk or rollback:
+Revision request:
+```
+
+## Provider Routing Gap
+
+Symptoms:
+
+- Learner routes by model preference.
+- Learner uses multiple providers before a baseline works.
+- Learner guesses model IDs.
+
+Remediation:
+
+1. Run a single-provider baseline.
+2. Classify each node responsibility.
+3. Route at most one node with a written reason.
+4. Record fallback behavior.
+
+Required evidence:
+
+```text
+Baseline provider:
+Baseline result:
+Node routed:
+Routing reason:
+Provider verified privately:
+Fallback:
+```
+
+## GitHub Readiness Gap
+
+Symptoms:
+
+- Learner equates PR creation with merge readiness.
+- Learner skips diff inspection.
+- Learner wants autonomous merge while learning.
+
+Remediation:
+
+1. Write a PR readiness note.
+2. Inspect the diff.
+3. Inspect validation evidence.
+4. Name one manual review concern.
+5. Stop before merge.
+
+Required evidence:
+
+```text
+Branch:
+Diff summary:
+Validation:
+Artifact evidence:
+Reviewer concern:
+Merge decision:
+```
+
+## Passing Remediation
+
+Remediation passes when the learner:
+
+- Shows the required evidence.
+- Explains what changed in their behavior.
+- Updates their operating checklist.
+- Can repeat the safer action once without prompting.

--- a/packages/docs-web/src/content/docs/learning/sample-artifacts.md
+++ b/packages/docs-web/src/content/docs/learning/sample-artifacts.md
@@ -1,0 +1,273 @@
+---
+title: Sample Artifacts
+description: Secret-free sample run reports, approval reviews, workflow briefs, and PR readiness notes.
+category: learning
+audience: [user, operator]
+status: current
+sidebar:
+  order: 16
+---
+
+Use these samples when learners need to see what "good enough evidence" looks
+like. They are intentionally small and secret-free.
+
+## Sample Run Report
+
+```text
+Workflow or command:
+archon-assist
+
+Repository:
+~/archon-sandbox
+
+Branch or worktree:
+main, read-only run with --no-worktree
+
+Request:
+Explain this repository structure. Do not edit files.
+
+Run status:
+Completed
+
+Files changed:
+None. git status showed a clean working tree.
+
+Artifacts inspected:
+No implementation artifact expected for this read-only run.
+
+Logs inspected:
+Workflow log showed the request stayed read-only.
+
+Validation command and result:
+git status -> clean working tree
+
+Human decision:
+Accept the explanation as a learning result. No code action taken.
+
+Follow-up:
+Run the first modifying workflow on an isolated branch.
+```
+
+## Sample Workflow Design Brief
+
+```text
+Workflow name:
+sandbox-add-subtract
+
+Repeated task this solves:
+Safely add a tiny function to the sandbox and validate it.
+
+Inputs:
+User request describing the function to add.
+
+Nodes:
+1. plan-change: write a plan artifact.
+2. approve-plan: human approval gate.
+3. implement-change: edit src/math.js and src/math.test.js.
+4. validate-change: run npm test.
+5. summarize-result: write a short result summary.
+
+Artifact handoffs:
+plan-change writes plan.md.
+implement-change reads plan.md.
+summarize-result reads validation output.
+
+Deterministic validation:
+npm test
+
+Approval gates:
+Before implementation.
+
+Provider choice per node:
+Use the baseline provider for all nodes until the workflow works.
+
+Rollback path:
+Discard the sandbox branch or worktree.
+
+Known limits:
+Only intended for the tiny JavaScript sandbox.
+```
+
+## Sample Model-Role Decision Note
+
+```text
+Project:
+Add subtract(a, b) to the sandbox math module.
+
+Planner:
+codex, gpt-5.3-codex, medium reasoning.
+
+Inner developer:
+pi, openrouter/qwen/qwen3-coder.
+
+Reviewer:
+codex, fresh context from validation output and git diff.
+
+Why this split:
+Codex is already verified for repository planning and review. Qwen is being
+tested only for the small implementation node after the single-provider
+baseline worked.
+
+Artifact handoff:
+Plan node output is copied into the implementation prompt. Validation output is
+copied into the review prompt.
+
+Fallback:
+If Pi auth or the Qwen model fails, stop the run or rerun implementation with
+Codex. Do not skip validation.
+
+Validation:
+npm test
+```
+
+## Sample Team Runtime Boundary Note
+
+```text
+Runtime:
+Local Docker rehearsal on a team laptop.
+
+Database:
+SQLite for rehearsal only. PostgreSQL required before shared server rollout.
+
+Interface:
+GitHub webhook simulation. No public webhook enabled yet.
+
+Allowed users:
+One reviewer and one learner during rehearsal.
+
+Secrets:
+Stored in Archon-owned env files. No tokens in shared notes.
+
+Health checks:
+/health and /health/db pass locally.
+
+Logs:
+Docker app logs and Archon workflow logs inspected.
+
+Artifacts:
+Workflow artifacts stored under the Archon workspace path.
+
+Rollback:
+Stop services, abandon run, discard sandbox branch or worktree.
+
+Stop conditions:
+Unexpected files changed, failed validation, missing webhook signature, or
+secret exposure.
+```
+
+## Sample Approval Review
+
+```text
+Plan or output reviewed:
+Plan artifact for adding subtract(a, b).
+
+Decision:
+revise
+
+Reason:
+The plan names src/math.js but does not name the test file or validation command.
+
+Evidence used:
+Plan artifact, current repository file list.
+
+Risk accepted:
+None yet. Implementation should not proceed.
+
+Required revision:
+Name src/math.test.js, state that npm test must pass, and include rollback by
+discarding the branch.
+
+Next validation:
+Review revised plan before approving implementation.
+```
+
+## Sample Validation Note
+
+```text
+Validation command:
+npm test
+
+Result:
+Passed
+
+Output summary:
+math tests passed
+
+What this proves:
+The current tiny math test passes.
+
+What this does not prove:
+It does not prove broad application correctness, performance, security, or PR
+readiness.
+
+Next action:
+Inspect the diff and write a PR readiness note.
+```
+
+## Sample PR Readiness Note
+
+```text
+Issue or request:
+Add subtract(a, b) to the sandbox math module.
+
+Branch:
+feature/subtract
+
+PR link or PR-ready branch:
+PR-ready branch only. No merge performed.
+
+Summary of change:
+Added subtract(a, b) to src/math.js and added a test for subtract(5, 2).
+
+Validation evidence:
+npm test passed.
+
+Artifact evidence:
+Plan artifact named files, validation command, risk, and rollback path.
+
+Reviewer concerns:
+Confirm function naming and whether more edge cases are needed.
+
+Secrets checked:
+No secrets in diff, artifacts, notes, or logs.
+
+Residual risk:
+Test coverage is intentionally tiny because this is a sandbox exercise.
+
+Merge decision:
+Stop for human review. Do not merge automatically.
+```
+
+## Sample Remediation Note
+
+```text
+Gap:
+Learner approved a vague plan.
+
+Session to repeat:
+Approval gate drill.
+
+Exercise:
+Review the sample plan and reject it unless it names files, validation, risks,
+and rollback.
+
+Evidence required:
+Written approval review with a concrete rejection reason and revision request.
+
+Due date:
+Before GitHub capstone.
+
+Reviewer:
+Facilitator or peer reviewer.
+```
+
+## What Makes These Samples Acceptable
+
+They are:
+
+- Specific enough for another person to understand the run.
+- Clear about what evidence was inspected.
+- Clear about what evidence does not prove.
+- Explicit about human decisions.
+- Free of secrets.
+- Small enough to write during a workshop.

--- a/packages/docs-web/src/content/docs/learning/sandbox-setup.md
+++ b/packages/docs-web/src/content/docs/learning/sandbox-setup.md
@@ -1,0 +1,181 @@
+---
+title: Sandbox Setup Guide
+description: How to prepare resettable repositories for Archon curriculum exercises and workshops.
+category: learning
+audience: [operator, user]
+status: current
+sidebar:
+  order: 14
+---
+
+Use disposable repositories for early Archon learning. A sandbox lets learners
+practice workflows, worktrees, artifacts, approval gates, and pull-request
+readiness without risking important code.
+
+## Sandbox Requirements
+
+A good sandbox has:
+
+- An initial Git commit.
+- One tiny source file.
+- One tiny test or validation command.
+- One intentionally small change request.
+- No secrets.
+- No production remotes.
+- A reset path.
+
+## Minimal JavaScript Sandbox
+
+Create this sandbox for quick local exercises.
+
+macOS, Linux, or WSL:
+
+```bash
+mkdir -p ~/archon-sandbox/src
+cd ~/archon-sandbox
+git init
+cat > README.md <<'EOF'
+# Archon Sandbox
+
+This repository exists only for learning Archon.
+EOF
+cat > src/math.js <<'EOF'
+export function add(a, b) {
+  return a + b;
+}
+EOF
+cat > src/math.test.js <<'EOF'
+import { add } from './math.js';
+
+if (add(2, 3) !== 5) {
+  throw new Error('add should return the sum');
+}
+
+console.log('math tests passed');
+EOF
+cat > package.json <<'EOF'
+{
+  "type": "module",
+  "scripts": {
+    "test": "node src/math.test.js"
+  }
+}
+EOF
+git add .
+git commit -m "Initial sandbox commit"
+```
+
+Windows PowerShell:
+
+```powershell
+mkdir $HOME\archon-sandbox
+mkdir $HOME\archon-sandbox\src
+cd $HOME\archon-sandbox
+git init
+"# Archon Sandbox`n`nThis repository exists only for learning Archon." | Set-Content README.md
+"export function add(a, b) {`n  return a + b;`n}" | Set-Content src\math.js
+"import { add } from './math.js';`n`nif (add(2, 3) !== 5) {`n  throw new Error('add should return the sum');`n}`n`nconsole.log('math tests passed');" | Set-Content src\math.test.js
+'{"type":"module","scripts":{"test":"node src/math.test.js"}}' | Set-Content package.json
+git add .
+git commit -m "Initial sandbox commit"
+```
+
+Verify:
+
+```bash
+npm test
+git status
+```
+
+Expected:
+
+```text
+math tests passed
+working tree clean
+```
+
+## Prepared Change Request
+
+Use this request for first implementation exercises:
+
+```text
+Add a subtract(a, b) function to src/math.js and update the test file to verify
+subtract(5, 2) returns 3. Keep the module simple.
+```
+
+Expected validation:
+
+```bash
+npm test
+```
+
+## Prepared Failure Sandbox
+
+Create a second repository or branch with a deliberate failing test.
+
+```bash
+cp -R ~/archon-sandbox ~/archon-sandbox-failing
+cd ~/archon-sandbox-failing
+git checkout -b prepared/failing-test
+```
+
+Edit `src/math.test.js` so it expects the wrong value:
+
+```js
+import { add } from './math.js';
+
+if (add(2, 3) !== 6) {
+  throw new Error('prepared failure: add should return 6');
+}
+
+console.log('math tests passed');
+```
+
+Commit it:
+
+```bash
+git add src/math.test.js
+git commit -m "Prepare failing validation exercise"
+```
+
+Use this repository for [Troubleshooting Labs](/learning/troubleshooting-labs/).
+
+## Optional GitHub Sandbox
+
+For GitHub exercises:
+
+1. Create a private or throwaway repository.
+2. Push the sandbox.
+3. Create one issue with the prepared change request.
+4. Authenticate `gh` privately.
+5. Confirm learners stop at PR review, not merge.
+
+Do not use a production repository for the first GitHub capstone.
+
+## Reset Instructions
+
+For local-only sandboxes, reset by deleting and recreating the directory, or by
+returning to the initial branch:
+
+```bash
+git status
+git branch
+git log --oneline -3
+```
+
+If the sandbox has no work you need to preserve, recreate it from the commands
+above. Do not run destructive cleanup commands in a real repository.
+
+## Facilitator Checklist
+
+```text
+Sandbox path:
+Initial commit exists:
+Test command works:
+Prepared change request exists:
+Prepared failure exists:
+GitHub issue exists, if needed:
+No secrets present:
+Reset path tested:
+Provider fallback tested:
+```

--- a/packages/docs-web/src/content/docs/learning/session-plans.md
+++ b/packages/docs-web/src/content/docs/learning/session-plans.md
@@ -1,0 +1,342 @@
+---
+title: Workshop Session Plans
+description: Facilitator-ready lesson plans for teaching Archon in seven sessions.
+category: learning
+audience: [operator, user]
+status: current
+sidebar:
+  order: 3
+---
+
+Use these session plans when teaching Archon to a team or cohort. Each session
+assumes learners have the practical tutorial open, work in a disposable
+repository, and keep secrets out of shared notes.
+
+Companion materials:
+
+- [Learner Workbook](/learning/learner-workbook/) for daily learner prompts.
+- [Facilitator Evaluation](/learning/facilitator-evaluation/) for scoring and
+  sign-off.
+- [Cohort Runbook](/learning/cohort-runbook/) for workshop operations.
+- [Sandbox Setup Guide](/learning/sandbox-setup/) for resettable training
+  repositories.
+- [Instructor Notes](/learning/instructor-notes/) for teaching scripts and
+  facilitation moves.
+- [Sample Artifacts](/learning/sample-artifacts/) for examples learners can
+  critique.
+- [Exercise Bank](/learning/exercise-bank/) and
+  [Troubleshooting Labs](/learning/troubleshooting-labs/) for extra practice.
+
+## Delivery Shape
+
+Default session length: 90 to 120 minutes.
+
+Recommended rhythm:
+
+1. State the session goal.
+2. Rehearse the relevant safety rule.
+3. Demo the happy path once.
+4. Give learners most of the time for hands-on work.
+5. Inspect evidence before discussing conclusions.
+6. Close with one recovery pattern.
+
+## Session 1: Orientation And Safety
+
+Goal: learners understand Archon as a workflow harness and can name the safety
+contract.
+
+Prework:
+
+- Read Practical Tutorial Parts 0 and 1.
+- Bring one real workflow idea, but do not use a real repository yet.
+
+Live agenda:
+
+| Time | Activity |
+| --- | --- |
+| 0-10 min | Define harness, workflow, node, provider, artifact, worktree, adapter, and approval gate. |
+| 10-25 min | Compare chat-only coding with repeatable workflow execution. |
+| 25-40 min | Walk through the safety contract. |
+| 40-65 min | Choose or create each learner's sandbox repository. |
+| 65-85 min | Draft each learner's first operating checklist. |
+| 85-100 min | Share one safe first workflow idea per learner. |
+
+Lab deliverable:
+
+```text
+Archon will:
+Git/worktrees will:
+The human will approve:
+Evidence I will inspect:
+```
+
+Facilitator checks:
+
+- The learner does not describe Archon as autonomous merge automation.
+- The learner can explain why the first repository is disposable.
+- The learner can name at least two kinds of evidence they will inspect after a
+  run.
+
+Recovery pattern:
+
+If a learner wants to start in a real project, pause and have them write the
+risk boundary for that project. Then move the same task into a disposable repo.
+
+## Session 2: Local Setup Lab
+
+Goal: learners install Archon, verify the CLI, and reach the Web UI.
+
+Prework:
+
+- Read Practical Tutorial Parts 2 and 3.
+- Install local prerequisites for the chosen operating system.
+
+Live agenda:
+
+| Time | Activity |
+| --- | --- |
+| 0-10 min | Confirm shell, Git, Bun, and repository location. |
+| 10-30 min | Install or run Archon from the selected path. |
+| 30-50 min | Configure the first assistant without exposing secrets. |
+| 50-70 min | Start the API and Web UI. |
+| 70-90 min | Register or open the sandbox repository. |
+| 90-110 min | Run health checks and record setup notes. |
+
+Lab deliverable:
+
+```text
+Interface used:
+Sandbox path:
+CLI check:
+Web UI check:
+Health check:
+Blocker or next action:
+```
+
+Facilitator checks:
+
+- The learner never pastes token values into shared chat.
+- The CLI and Web UI point at the intended sandbox.
+- Any blocked setup has a written next action.
+
+Recovery pattern:
+
+If the Web UI is blocked, keep the learner in the CLI path for the day and
+record the exact port, process, or authentication issue to fix later.
+
+## Session 3: First Workflow Lab
+
+Goal: learners run a safe workflow and inspect the evidence it produced.
+
+Prework:
+
+- Read Practical Tutorial Parts 4 and 5.
+- Run `archon workflow list` from the sandbox if setup is complete.
+
+Live agenda:
+
+| Time | Activity |
+| --- | --- |
+| 0-10 min | Review the built-in workflow catalog. |
+| 10-25 min | Choose one read-only or low-risk workflow. |
+| 25-45 min | Run the workflow in the sandbox. |
+| 45-65 min | Inspect status, worktree, logs, and artifacts. |
+| 65-85 min | Write a run report. |
+| 85-105 min | Compare model claims with validation evidence. |
+
+Lab deliverable:
+
+```text
+Workflow:
+Command:
+Run status:
+Files changed:
+Worktree or branch:
+Artifacts inspected:
+Logs inspected:
+Safety observation:
+```
+
+Facilitator checks:
+
+- The learner distinguishes "the model said it passed" from actual validation
+  evidence.
+- The learner can find a run again after terminal output scrolls away.
+- The learner can identify whether the workflow changed files.
+
+Recovery pattern:
+
+If a run fails, do not restart immediately. Inspect status, logs, artifacts, and
+configuration in that order.
+
+## Session 4: Authoring Lab
+
+Goal: learners create one command and one workflow, then validate both.
+
+Prework:
+
+- Read Practical Tutorial Parts 6 and 7.
+- Bring one narrow repeated task from the sandbox.
+
+Live agenda:
+
+| Time | Activity |
+| --- | --- |
+| 0-15 min | Pick a narrow, current use case. |
+| 15-35 min | Create a custom command for a read-only or validation task. |
+| 35-50 min | Run the command in the sandbox. |
+| 50-75 min | Create a minimal YAML workflow. |
+| 75-95 min | Add deterministic validation. |
+| 95-115 min | Validate command and workflow definitions. |
+
+Lab deliverable:
+
+```text
+Command file:
+Workflow file:
+Task solved:
+Validation command:
+Validation result:
+Known limit:
+```
+
+Facilitator checks:
+
+- The workflow has a concrete current use case.
+- Validation is deterministic where possible.
+- The learner does not add provider routing before the single-provider version
+  works.
+
+Recovery pattern:
+
+If the workflow grows too broad, reduce it to one input, one agentic step, one
+validation step, and one expected artifact.
+
+## Session 5: Supervised Automation Lab
+
+Goal: learners practice Plan-Implement-Validate with explicit handoffs.
+
+Prework:
+
+- Read Practical Tutorial Parts 8, 9, and 10.
+- Identify one small change the sandbox can safely accept.
+
+Live agenda:
+
+| Time | Activity |
+| --- | --- |
+| 0-15 min | Draw the Plan-Implement-Validate flow. |
+| 15-30 min | Decide which node writes the plan artifact. |
+| 30-45 min | Decide where human approval belongs. |
+| 45-75 min | Run a supervised workflow on the sandbox change. |
+| 75-95 min | Review artifacts before implementation and validation after implementation. |
+| 95-115 min | Discuss provider routing after the baseline run works. |
+
+Lab deliverable:
+
+```text
+Plan artifact:
+Approval decision:
+Implementation result:
+Validation result:
+Final human decision:
+Provider choice reason:
+```
+
+Facilitator checks:
+
+- The learner can say which steps are AI work, deterministic work, and human
+  review.
+- Artifact handoffs are explicit.
+- Provider choices are attached to node responsibility, not model preference.
+
+Recovery pattern:
+
+If a plan is vague, reject it and require concrete files, commands, risks, and
+rollback steps before implementation.
+
+## Session 6: Interfaces And Operations
+
+Goal: learners understand GitHub, adapters, deployment boundaries, and recovery
+without expanding risk too early.
+
+Prework:
+
+- Read Practical Tutorial Parts 11, 12, and 14.
+- Confirm whether GitHub CLI authentication is available for the lab.
+
+Live agenda:
+
+| Time | Activity |
+| --- | --- |
+| 0-20 min | Practice the local issue-to-PR path or prepare PR steps without pushing. |
+| 20-40 min | Review Web UI and adapter boundaries. |
+| 40-60 min | Compare local, Docker, and VPS operation. |
+| 60-80 min | Review secret handling for GitHub, chat adapters, and provider credentials. |
+| 80-105 min | Troubleshoot one prepared failure. |
+
+Lab deliverable:
+
+```text
+Where Archon runs:
+Enabled interfaces:
+Where secrets live:
+Who approves PRs:
+Deployment boundary:
+Recovery path:
+```
+
+Facilitator checks:
+
+- The learner separates local CLI use from remote adapter exposure.
+- The learner knows which credentials exist and where they must not appear.
+- The learner has a recovery path for failed, paused, or unsafe runs.
+
+Recovery pattern:
+
+If learners conflate PR creation with merge readiness, require a PR readiness
+note before discussing merge.
+
+## Session 7: Capstone Lab
+
+Goal: learners prove they can operate safely from request to reviewed outcome.
+
+Prework:
+
+- Read Practical Tutorial Parts 15 and 16.
+- Choose a capstone option and prepare the sandbox.
+
+Live agenda:
+
+| Time | Activity |
+| --- | --- |
+| 0-15 min | State the capstone objective and risk boundary. |
+| 15-55 min | Run or author the required workflow. |
+| 55-80 min | Inspect artifacts, logs, and validation output. |
+| 80-100 min | Prepare or create the supervised PR if using the GitHub capstone. |
+| 100-115 min | Present evidence and final decision. |
+| 115-120 min | Update the operating checklist. |
+
+Lab deliverable:
+
+```text
+Objective:
+Risk boundary:
+Workflow or command:
+Evidence inspected:
+Validation:
+Human decision:
+Checklist update:
+```
+
+Facilitator checks:
+
+- The learner stops before unsafe merge or deployment.
+- The learner can justify approval or rejection from evidence.
+- The learner can describe what they would change before using a real
+  repository.
+
+Recovery pattern:
+
+If evidence is incomplete, the capstone result is "defer" rather than "pass."
+The learner should name the missing evidence and the next validation step.

--- a/packages/docs-web/src/content/docs/learning/slide-outline.md
+++ b/packages/docs-web/src/content/docs/learning/slide-outline.md
@@ -1,0 +1,209 @@
+---
+title: Slide Outline
+description: A presentation outline for teaching the Archon curriculum.
+category: learning
+audience: [operator]
+status: current
+sidebar:
+  order: 19
+---
+
+Use this outline to create slides for a live workshop or onboarding session.
+Keep slides light; learners should spend most of the time in the terminal, Web
+UI, artifacts, logs, and workbook.
+
+## Deck 1: Orientation And Safety
+
+Slide 1: Title
+
+- Archon as a supervised AI coding workflow harness.
+- Goal: repeatable, inspectable AI-assisted development.
+
+Slide 2: The Problem
+
+- One long chat is hard to audit.
+- Hidden context is fragile.
+- Model summaries are not validation.
+
+Slide 3: The Harness Model
+
+- Workflow.
+- Worktree.
+- Artifact.
+- Validation.
+- Approval gate.
+
+Slide 4: First Week Boundary
+
+- Sandbox first.
+- Secrets stay private.
+- Human approval before risky steps.
+- Stop before autonomous merge or deployment.
+
+Slide 5: Evidence Habit
+
+- What ran?
+- Where did it run?
+- What changed?
+- What evidence confirms it?
+
+## Deck 2: Setup And First Run
+
+Slide 1: Setup Goal
+
+- CLI works.
+- Web UI works or CLI fallback is documented.
+- Provider configured privately.
+- Sandbox has an initial commit.
+
+Slide 2: Sandbox Repository
+
+- Tiny source file.
+- Tiny validation command.
+- No secrets.
+- Easy reset.
+
+Slide 3: First Workflow
+
+- Start read-only.
+- Use the intended repository.
+- Record the run.
+
+Slide 4: Inspect Evidence
+
+- Status.
+- Logs.
+- Artifacts.
+- Git status.
+- Changed files.
+
+## Deck 3: Authoring
+
+Slide 1: Commands
+
+- Markdown prompt templates.
+- Reusable narrow tasks.
+- No secrets.
+
+Slide 2: Workflows
+
+- YAML process.
+- Nodes and dependencies.
+- Explicit handoffs.
+
+Slide 3: Good First Workflow
+
+- One current task.
+- One clear input.
+- One artifact.
+- One deterministic validation.
+
+Slide 4: Common Authoring Mistakes
+
+- Too broad.
+- Hidden chat-memory handoffs.
+- No validation.
+- Provider routing too early.
+
+## Deck 4: Plan-Implement-Validate
+
+Slide 1: Flow
+
+- Plan.
+- Approve.
+- Implement.
+- Validate.
+- Decide.
+
+Slide 2: Approval Gate
+
+- Approve from evidence.
+- Reject vague plans.
+- Revise with concrete instructions.
+- Defer when evidence is missing.
+
+Slide 3: Validation
+
+- Tests.
+- Lint.
+- Type checks.
+- File inspection.
+- PR review.
+
+Slide 4: Human Decision
+
+- Approve.
+- Reject.
+- Revise.
+- Defer.
+- Stop.
+
+## Deck 5: Providers And GitHub
+
+Slide 1: Provider Routing Rule
+
+- Baseline first.
+- Route by node responsibility.
+- Verify provider setup privately.
+- Keep artifacts explicit.
+
+Slide 2: GitHub Boundary
+
+- Issue-to-PR is supervised.
+- PR creation is not merge readiness.
+- Review before merge.
+
+Slide 3: Adapter Boundary
+
+- Local CLI and Web UI differ from remote adapters.
+- Exposure changes risk.
+- Authorization and secrets matter.
+
+## Deck 6: Capstone And Graduation
+
+Slide 1: Capstone Goal
+
+- Operate safely from request to evidence-backed decision.
+
+Slide 2: Required Evidence
+
+- Run report.
+- Artifacts.
+- Logs.
+- Validation.
+- Human decision.
+- Checklist update.
+
+Slide 3: Scoring
+
+- Safety boundary.
+- Workflow execution.
+- Evidence inspection.
+- Validation.
+- Approval.
+- GitHub readiness.
+
+Slide 4: Graduation
+
+- Do not graduate by removing safety gates.
+- Graduate by knowing which gates still matter and why.
+
+## Speaker Notes Pattern
+
+For each slide, prepare:
+
+```text
+Point:
+Demo:
+Question:
+Evidence to inspect:
+Safety reminder:
+```
+
+## Slide Design Notes
+
+- Use diagrams for workflow flow, not dense text.
+- Use screenshots only if they contain no secrets.
+- Avoid provider comparison scoreboards.
+- Prefer one concrete example per concept.
+- Keep command blocks short enough to type.

--- a/packages/docs-web/src/content/docs/learning/syllabus.md
+++ b/packages/docs-web/src/content/docs/learning/syllabus.md
@@ -1,0 +1,146 @@
+---
+title: Curriculum Syllabus
+description: A course-style syllabus for teaching Archon from first install to supervised workflow operation.
+category: learning
+audience: [user, operator]
+status: current
+sidebar:
+  order: 12
+---
+
+Use this syllabus when running Archon as a structured course. It defines the
+course promise, audience, prerequisites, schedule, grading model, and completion
+requirements.
+
+## Course Promise
+
+By the end of this course, learners can use Archon as a supervised AI coding
+workflow harness: install it, run safe workflows, inspect evidence, author small
+commands and workflows, route providers intentionally, prepare pull requests,
+and stop before unsafe merge or deployment.
+
+## Audience
+
+This course is for:
+
+- Developers learning Archon for personal workflow automation.
+- Team leads preparing safe onboarding for AI-assisted development.
+- Operators responsible for local, Docker, or remote Archon environments.
+- Facilitators running a cohort or internal enablement workshop.
+
+This course is not for:
+
+- Unsupervised production automation.
+- Autonomous issue-to-merge pipelines.
+- Secret management training beyond Archon-specific safety boundaries.
+- Advanced workflow engineering before learners can inspect basic run evidence.
+
+## Prerequisites
+
+Learners should have:
+
+- Basic Git comfort: commits, branches, remotes, diffs, and pull requests.
+- A local shell that can run the selected Archon setup path.
+- Access to the chosen assistant/provider.
+- A disposable repository for early exercises.
+- A private place to keep run notes.
+
+Facilitators should also have:
+
+- A resettable sandbox repository.
+- A prepared failure repository.
+- A provider fallback.
+- A policy for secrets, GitHub tokens, and shared notes.
+
+## Required Materials
+
+- [Practical Tutorial](/learning/practical-tutorial/)
+- [Curriculum Guide](/learning/curriculum/)
+- [Learner Workbook](/learning/learner-workbook/)
+- [Workshop Session Plans](/learning/session-plans/)
+- [Exercise Bank](/learning/exercise-bank/)
+- [Model Role Recipes](/learning/model-role-recipes/)
+- [Knowledge Checks](/learning/knowledge-checks/)
+- [Capstone Assessment](/learning/capstone-assessment/)
+- [Graduation Checklist](/learning/graduation-checklist/)
+- [Real Repository Transition](/learning/real-repository-transition/)
+
+## Schedule
+
+| Unit | Topic | Tutorial parts | Evidence due |
+| --- | --- | --- | --- |
+| 1 | Orientation and safety | 0-1 | Harness goal and safety boundary |
+| 2 | Local setup | 2-3 | CLI/Web UI setup note |
+| 3 | First workflow | 4-5 | Run report with logs and artifacts |
+| 4 | Authoring basics | 6-7 | One validated command and workflow |
+| 5 | Supervised automation | 8-10 | Plan artifact, approval decision, validation output |
+| 6 | GitHub, model roles, and operations | 11-14 plus Model Role Recipes | PR readiness, model-role decision, or deployment boundary note |
+| 7 | Capstone | 15-16 | Capstone report and operating checklist |
+
+## Attendance And Participation
+
+Learners should attend live labs or complete the equivalent workbook prompts.
+Participation means showing evidence from runs, not merely reporting that a
+command was executed.
+
+Expected participation:
+
+- Keep secrets out of shared spaces.
+- Use the sandbox until completion criteria are met.
+- Share sanitized run reports.
+- Ask for review before risky operations.
+- Update the personal operating checklist after each unit.
+
+## Assessment
+
+Assessment is evidence-based. Learners pass by demonstrating safe operation,
+not by memorizing commands.
+
+Required evidence:
+
+- Setup note.
+- Safe workflow run report.
+- Custom command or workflow validation.
+- Approval gate decision.
+- Deterministic validation result.
+- Model-role decision note when using multiple models.
+- Capstone report.
+- Final operating checklist.
+
+Use [Facilitator Evaluation](/learning/facilitator-evaluation/) and
+[Capstone Assessment](/learning/capstone-assessment/) for scoring.
+
+## Completion Requirements
+
+A learner completes the course when they can:
+
+- Explain Archon as a harness for repeatable AI coding workflows.
+- Install and verify Archon locally.
+- Run a safe workflow in a disposable repository.
+- Inspect status, worktrees, logs, artifacts, and changed files.
+- Create and validate one command and one workflow.
+- Explain a Plan-Implement-Validate flow.
+- Route providers only after a single-provider baseline works.
+- Assign Claude, Codex, Gemini, Qwen, Kimi, or local models by workflow
+  responsibility when using multi-model projects.
+- Prepare or create a supervised PR and stop before merge.
+- Define local, GitHub, Docker, VPS, or server runtime boundaries before team
+  operation.
+- Troubleshoot common failures without exposing secrets.
+- Name a rollback path for generated changes.
+
+## Completion Outcomes
+
+Use these completion levels:
+
+| Outcome | Meaning |
+| --- | --- |
+| Complete with supervision | Learner can use Archon on a low-risk real repository with a reviewer. |
+| Complete and peer-ready | Learner can help others inspect evidence and review runs. |
+| Remediation needed | Learner should repeat one or more units before real-repository work. |
+
+## Course Policy
+
+The course default is supervised operation. Do not graduate learners by removing
+approval gates. Graduate them by proving they know which gates still matter and
+why.

--- a/packages/docs-web/src/content/docs/learning/team-adoption-path.md
+++ b/packages/docs-web/src/content/docs/learning/team-adoption-path.md
@@ -1,0 +1,206 @@
+---
+title: Team Adoption Path
+description: How teams can adopt Archon after completing the curriculum.
+category: learning
+audience: [operator, user]
+status: current
+sidebar:
+  order: 28
+---
+
+Use this path when moving from individual training to team usage. Team adoption
+should be gradual, supervised, and evidence-based.
+
+## Adoption Principles
+
+- Start with low-risk repositories.
+- Use one workflow before many workflows.
+- Keep approval gates visible.
+- Require run reports for early real work.
+- Review generated PRs manually.
+- Treat provider routing as an advanced optimization.
+- Treat remote/server operation as a separate rollout stage, not a side effect
+  of local success.
+- Record operating decisions where the team can find them.
+
+## Phase 1: Individual Readiness
+
+Entry criteria:
+
+- Learner completed the capstone.
+- Learner has a graduation checklist.
+- Learner can inspect evidence without facilitator prompting.
+
+Team action:
+
+```text
+Assign one low-risk repository.
+Assign one reviewer.
+Choose one workflow.
+Define required validation.
+Define stop conditions.
+```
+
+Exit criteria:
+
+- Learner completes one supervised real-repository run.
+- Reviewer confirms evidence and decision quality.
+
+## Phase 2: Shared Workflow Trial
+
+Entry criteria:
+
+- At least two learners are ready with supervision.
+- A repeated team task has been identified.
+
+Team action:
+
+```text
+Choose one repeated task:
+Write or select one workflow:
+Define allowed repositories:
+Define approval gates:
+Define validation:
+Define reviewer rotation:
+```
+
+Exit criteria:
+
+- The workflow produces useful results in at least three supervised runs.
+- The team records known limits and rollback.
+
+## Phase 3: Team Operating Checklist
+
+Create a shared checklist:
+
+```text
+Allowed workflows:
+Allowed repositories:
+Required branches or worktrees:
+Required approval gates:
+Required validation:
+Provider limits:
+Model-role rules:
+GitHub limits:
+Secret-handling policy:
+Incident or rollback path:
+```
+
+Review the checklist after every meaningful workflow change.
+
+## Phase 4: Model-Role Trial
+
+Entry criteria:
+
+- The shared workflow has at least three supervised successful runs.
+- The baseline single-provider version still works.
+- The team has one real reason to route a node to a different provider.
+
+Team action:
+
+```text
+Planner provider:
+Inner-development provider:
+Reviewer provider:
+Verified model IDs:
+Artifact handoffs:
+Fallback provider or stop condition:
+Cost or rate-limit boundary:
+Validation:
+```
+
+Exit criteria:
+
+- The routed workflow improves quality, speed, cost, or reviewer confidence
+  without weakening validation or approval gates.
+- The team records where Claude, Codex, Gemini, Qwen, Kimi, local models, or
+  other Pi routes are allowed.
+
+## Phase 5: Remote Or Server Trial
+
+Entry criteria:
+
+- Local usage is stable.
+- The team has a reason for always-on or remote triggering.
+- A maintainer has reviewed adapter exposure and secrets.
+
+Team action:
+
+```text
+Runtime location:
+Database choice:
+Enabled adapter:
+Allowed users:
+Webhook or chat secret:
+Provider credential location:
+Health checks:
+Log location:
+Artifact location:
+Rollback:
+Incident contact:
+```
+
+Exit criteria:
+
+- Health checks pass.
+- One sandbox request succeeds through the selected interface.
+- Logs and artifacts are inspectable.
+- Access boundaries are documented.
+- Rollback and incident response are understood.
+
+Do not expose more than one new interface during the first remote trial.
+
+## Phase 6: Broader Rollout
+
+Broader rollout is appropriate when:
+
+- Workflows have clear owners.
+- Validation is reliable.
+- Reviewers know what evidence to inspect.
+- Secrets policy is understood.
+- Adapter exposure is reviewed separately.
+- Server health checks, logs, artifacts, and rollback are owned by a named
+  operator when remote usage is enabled.
+- A rollback path exists.
+
+Do not expand because the first runs felt exciting. Expand because the evidence
+is repeatable.
+
+## Team Review Cadence
+
+Suggested cadence:
+
+| Cadence | Review |
+| --- | --- |
+| Weekly during rollout | Runs, failures, approval decisions, checklist updates |
+| Monthly after rollout | Workflow usefulness, safety issues, provider/model changes, adapter exposure |
+| On release | Version review and source-backed curriculum updates |
+
+## Team Retrospective
+
+```text
+Which workflow saved time:
+Which workflow created confusion:
+Which evidence was most useful:
+Which validation was weak:
+Which approval gate prevented risk:
+Which model-role decision helped or hurt:
+Which adapter or server boundary needs tightening:
+Which repository should remain off-limits:
+Which curriculum page should be improved:
+```
+
+## Adoption Anti-Patterns
+
+Avoid:
+
+- Giving everyone broad access before capstones.
+- Running advanced workflows before simple ones are understood.
+- Treating PR creation as done.
+- Adding remote adapters before local usage is stable.
+- Letting model preference drive workflow design.
+- Routing implementation to Gemini, Qwen, or Kimi without a verified model ID
+  and fallback.
+- Removing approval gates to prove adoption is working.
+- Treating a reachable server as a production-ready service before access,
+  logging, recovery, and rollback are tested.

--- a/packages/docs-web/src/content/docs/learning/templates.md
+++ b/packages/docs-web/src/content/docs/learning/templates.md
@@ -1,0 +1,162 @@
+---
+title: Curriculum Templates
+description: Copy-ready learner, facilitator, run-report, workflow-brief, and PR-readiness templates.
+category: learning
+audience: [user, operator]
+status: current
+sidebar:
+  order: 4
+---
+
+Use these templates in a private notebook or a safe shared training space. Do
+not include secrets, token values, provider auth files, or full `.env` contents.
+
+## Learner Daily Journal
+
+```text
+Date:
+Tutorial part or session:
+Workflow or command:
+What I expected:
+What actually happened:
+Evidence I inspected:
+Safety rule I practiced:
+Question to revisit:
+Checklist update:
+```
+
+## Run Report
+
+```text
+Workflow or command:
+Repository:
+Branch or worktree:
+Request:
+Run status:
+Files changed:
+Artifacts inspected:
+Logs inspected:
+Validation command and result:
+Human decision:
+Follow-up:
+```
+
+## Workflow Design Brief
+
+```text
+Workflow name:
+Repeated task this solves:
+Inputs:
+Nodes:
+Artifact handoffs:
+Deterministic validation:
+Approval gates:
+Provider choice per node:
+Rollback path:
+Known limits:
+```
+
+## Approval Gate Review
+
+```text
+Plan or output reviewed:
+Decision: approve / reject / revise / defer
+Reason:
+Evidence used:
+Risk accepted:
+Required revision:
+Next validation:
+```
+
+## PR Readiness Note
+
+```text
+Issue or request:
+Branch:
+PR link or PR-ready branch:
+Summary of change:
+Validation evidence:
+Artifact evidence:
+Reviewer concerns:
+Secrets checked:
+Residual risk:
+Merge decision:
+```
+
+## Personal Operating Checklist
+
+```text
+Before I run Archon:
+- I am in the intended repository.
+- The repository is disposable or low-risk enough for the task.
+- Secrets are stored locally and not pasted into chat.
+- The workflow has the right branch or worktree behavior.
+- Custom commands and workflows are validated.
+
+Before I approve implementation:
+- I inspected the plan artifact.
+- The plan names files, validation commands, risks, and rollback steps.
+- The approval gate is explicit.
+
+Before I trust the result:
+- I inspected changed files.
+- I inspected artifacts and logs.
+- Deterministic validation ran.
+- I recorded remaining uncertainty.
+
+Before I create or review a PR:
+- The branch is the intended branch.
+- The PR summary matches the actual diff.
+- Secrets are not present in the diff, artifacts, or logs.
+- A human review happens before merge.
+```
+
+## Facilitator Preflight
+
+```text
+Workshop date:
+Archon version or commit:
+Operating systems:
+Installation path:
+Sandbox repository path:
+Fallback repository path:
+Assistant/provider used:
+Provider fallback:
+GitHub required: yes / no
+Web UI required: yes / no
+Known-good health check:
+Known-good workflow:
+Prepared failure exercise:
+Secret-handling reminder reviewed:
+```
+
+## Blocker Note
+
+```text
+Learner:
+Machine or environment:
+Command attempted:
+Observed output summary:
+Evidence inspected:
+Likely cause:
+Next action:
+Owner:
+Can continue with fallback: yes / no
+```
+
+## Cohort Completion Record
+
+```text
+Learner:
+Sandbox setup complete:
+Safe workflow run complete:
+Run report complete:
+Custom command complete:
+Custom workflow complete:
+PIV exercise complete:
+Provider routing verified:
+GitHub or PR-ready exercise complete:
+Capstone complete:
+Ready for supervised real repository work: yes / no
+Facilitator notes:
+```

--- a/packages/docs-web/src/content/docs/learning/troubleshooting-labs.md
+++ b/packages/docs-web/src/content/docs/learning/troubleshooting-labs.md
@@ -1,0 +1,206 @@
+---
+title: Troubleshooting Labs
+description: Prepared failure scenarios for teaching evidence-based Archon troubleshooting.
+category: learning
+audience: [user, operator]
+status: current
+sidebar:
+  order: 10
+---
+
+Use these labs to teach learners to inspect evidence before restarting,
+rerunning, or changing configuration. Keep all examples secret-free.
+
+Use [Sandbox Setup Guide](/learning/sandbox-setup/) to create the prepared
+failure sandbox used in these labs.
+
+## Troubleshooting Order
+
+Use this order unless the error clearly points somewhere else:
+
+1. Confirm the intended repository and branch.
+2. Inspect workflow status.
+3. Inspect logs.
+4. Inspect artifacts.
+5. Inspect changed files.
+6. Inspect configuration.
+7. Decide whether to rerun, resume, abandon, revise, or defer.
+
+## Lab 1: Wrong Repository
+
+Scenario:
+
+The learner expected Archon to inspect the sandbox, but output describes the
+Archon source repository.
+
+Prepared cause:
+
+- The command was run from the wrong working directory.
+
+Learner task:
+
+```text
+Identify the repository Archon actually used.
+Find the intended sandbox path.
+Write the corrected command with --cwd or by changing directories.
+```
+
+Evidence to inspect:
+
+- Current shell path.
+- Git remote or repository root.
+- Workflow run request.
+
+Completion signal:
+
+- Learner can explain how to prevent the same mistake next time.
+
+## Lab 2: Missing Initial Commit
+
+Scenario:
+
+A workflow that expects Git isolation fails or behaves oddly in a brand-new
+sandbox.
+
+Prepared cause:
+
+- The sandbox repository was initialized but never committed.
+
+Learner task:
+
+```text
+Check git status.
+Create an initial safe commit.
+Rerun the smallest safe workflow.
+```
+
+Evidence to inspect:
+
+- `git status`
+- `git log --oneline -1`
+- Workflow status after rerun.
+
+Completion signal:
+
+- Learner can explain why worktree workflows need a real Git baseline.
+
+## Lab 3: Vague Plan Rejected
+
+Scenario:
+
+An approval gate pauses on a plan that does not name files, validation commands,
+or rollback steps.
+
+Prepared cause:
+
+- The prompt was too broad or the planning node produced a weak artifact.
+
+Learner task:
+
+```text
+Reject the plan.
+Write revision instructions.
+Require files, validation, risks, and rollback.
+Resume or rerun according to the workflow.
+```
+
+Evidence to inspect:
+
+- Plan artifact.
+- Approval decision.
+- Revised plan artifact.
+
+Completion signal:
+
+- Learner rejects the plan for evidence-based reasons instead of approving it
+  because it sounds plausible.
+
+## Lab 4: Validation Failed
+
+Scenario:
+
+The implementation completed, but deterministic validation failed.
+
+Prepared cause:
+
+- The sandbox contains a deliberately failing test or command.
+
+Learner task:
+
+```text
+Find the validation output.
+Identify whether the failure is from the generated change or the prepared test.
+Decide whether to revise, rerun validation, or defer.
+```
+
+Evidence to inspect:
+
+- Validation command.
+- Validation output.
+- Changed files.
+- Relevant artifact.
+
+Completion signal:
+
+- Learner records the failure without claiming the run passed.
+
+## Lab 5: Provider Not Available
+
+Scenario:
+
+A provider-routed workflow fails before useful work starts.
+
+Prepared cause:
+
+- The provider is not authenticated or the model ID is not verified locally.
+
+Learner task:
+
+```text
+Identify which node requested the provider.
+Verify the provider setup privately.
+Replace the workflow with a single-provider baseline if needed.
+Record the fallback.
+```
+
+Evidence to inspect:
+
+- Workflow YAML.
+- Provider configuration.
+- Logs with secrets removed.
+- Single-provider baseline result.
+
+Completion signal:
+
+- Learner does not guess model IDs or paste credentials into shared notes.
+
+## Lab 6: PR Created Too Early
+
+Scenario:
+
+A branch has a PR-ready change, but the learner wants to merge immediately.
+
+Prepared cause:
+
+- Learner equates PR creation with completion.
+
+Learner task:
+
+```text
+Write a PR readiness note.
+Inspect the diff.
+Inspect validation evidence.
+Name at least one manual review concern.
+Stop before merge.
+```
+
+Evidence to inspect:
+
+- Diff.
+- Validation output.
+- Run report.
+- PR readiness note.
+
+Completion signal:
+
+- Learner can explain why merge waits for human review.

--- a/packages/docs-web/src/content/docs/learning/tutorial-plan.md
+++ b/packages/docs-web/src/content/docs/learning/tutorial-plan.md
@@ -1,0 +1,200 @@
+---
+title: Archon Tutorial Plan
+description: Source inventory, verification decisions, structure, and maintenance notes for the Archon tutorial.
+category: learning
+audience: [developer, operator]
+status: current
+sidebar:
+  order: 3
+---
+
+This planning file records the tutorial structure, source inventory, verification
+decisions, and remaining maintenance notes for the Archon practical tutorial.
+
+## Objective
+
+Create a complete, practical, step-by-step tutorial that teaches a learner to use
+Archon progressively:
+
+1. Install and verify Archon.
+2. Run safe local workflows.
+3. Understand worktrees, artifacts, logs, and approval gates.
+4. Author commands and YAML workflows.
+5. Build supervised Plan-Implement-Validate workflows.
+6. Route work across Codex, Claude, Pi, and verified Gemini/Qwen/Kimi/local
+   model IDs.
+7. Use GitHub issue-to-PR workflows safely.
+8. Understand optional adapters and deployment paths.
+9. Treat transcript material as case studies, not official behavior.
+
+## Reader And Defaults
+
+- Operating system: Windows-first, with cross-platform commands.
+- Recommended Windows mode: WSL2 for full compatibility.
+- Interfaces: CLI plus Web UI.
+- Assistants: Codex first; Pi for Gemini and other community-provider routing.
+- Repository: disposable sandbox before real projects.
+- Usage goal: personal local usage first, team usage later.
+- Safety posture: human approval gates enabled, no autonomous merge.
+- GitHub: included as a first-class path.
+
+## Canonical Tutorial File
+
+- `docs/learning/archon-practical-tutorial.md`
+- `docs/learning/archon-curriculum.md`
+
+The top-level `TUTORIAL.md` is intentionally only a landing page so stale
+commands do not fork away from the source-backed tutorial.
+
+## Official Source Inventory
+
+Primary repository files:
+
+- `README.md`
+- `CONTRIBUTING.md`
+- `.archon/workflows/defaults/`
+- `.archon/commands/defaults/`
+- `.claude/skills/archon/`
+- `packages/docs-web/src/content/docs/`
+- `packages/cli/`
+- `packages/providers/`
+- `packages/server/`
+- `packages/adapters/`
+
+Key documentation pages:
+
+- `packages/docs-web/src/content/docs/getting-started/overview.md`
+- `packages/docs-web/src/content/docs/getting-started/installation.md`
+- `packages/docs-web/src/content/docs/getting-started/ai-assistants.md`
+- `packages/docs-web/src/content/docs/guides/authoring-workflows.md`
+- `packages/docs-web/src/content/docs/guides/authoring-commands.md`
+- `packages/docs-web/src/content/docs/guides/approval-nodes.md`
+- `packages/docs-web/src/content/docs/guides/loop-nodes.md`
+- `packages/docs-web/src/content/docs/reference/cli.md`
+- `packages/docs-web/src/content/docs/reference/configuration.md`
+- `packages/docs-web/src/content/docs/reference/security.md`
+- `packages/docs-web/src/content/docs/reference/troubleshooting.md`
+- `packages/docs-web/src/content/docs/adapters/web.md`
+- `packages/docs-web/src/content/docs/adapters/github.md`
+- `packages/docs-web/src/content/docs/adapters/slack.md`
+- `packages/docs-web/src/content/docs/adapters/telegram.md`
+- `packages/docs-web/src/content/docs/adapters/community/discord.md`
+- `packages/docs-web/src/content/docs/deployment/windows.md`
+- `packages/docs-web/src/content/docs/deployment/docker.md`
+- `packages/docs-web/src/content/docs/deployment/cloud.md`
+
+Agent-focused references:
+
+- `.claude/skills/archon/references/parameter-matrix.md`
+- `.claude/skills/archon/references/troubleshooting.md`
+- `.claude/skills/archon/references/repo-init.md`
+
+## Transcript Case Studies
+
+Use these as illustrative or experimental material only:
+
+- `transcripts/The Next Evolution of AI Coding Is Harnesses - Here's How to Build Them.txt`
+- `transcripts/Pi Coding Agent + Archon Build ANY AI Coding Workflow (No Claude Code Bloat).txt`
+- `transcripts/Pi is INCREDIBLE - Building a Custom Coding Agent Live.txt`
+- `transcripts/Plan with Claude Opus, Build with Kimi K2.6 LIVE Mixed-Provider Benchmark.txt`
+- `transcripts/Pushing My AI Dark Factory to Its Limits with Opus + Kimi Combined.txt`
+- `transcripts/The AI Dark Factory is ALIVE A Codebase That Writes Its Own Code, Live.txt`
+- `transcripts/Claude Plans, Gemini Designs One Workflow for Beautiful Frontends (LIVE).txt`
+- `transcripts/Archon + Jira Drag a Ticket, Get a Pull Request (Live Build).txt`
+- `transcripts/Live - My AI Coding Workflow has 10x'd Again with Archon - See it in Action.txt`
+
+Note: the last filename is normalized here for ASCII readability. The actual
+source file in this workspace includes a leading red-circle symbol.
+
+## Verification Decisions
+
+- The current remote default branch was checked with `git remote show origin`;
+  it is `dev`.
+- Context7 resolved current Archon docs as `/websites/archon_diy`.
+- `https://archon.diy/llms.txt`, `llms-small.txt`, and `llms-full.txt` returned
+  404 during review.
+- Current CLI/source references do not include `archon doctor`; the tutorial
+  explicitly tells learners to use supported checks instead.
+- `.archon/workflows/defaults/` currently contains 20 workflow YAML files, even
+  though some prose still mentions 17 defaults. The tutorial tells learners to
+  run `archon workflow list` as the live source of truth.
+- Pi is treated as a community provider.
+- Gemini, Qwen, Kimi, and local model names must be verified through Pi or the
+  configured provider before use. The tutorial does not invent provider model
+  IDs.
+- GitHub is included in local CLI setup, issue-to-PR exercises, webhook adapter
+  setup, security guidance, and capstones.
+
+## Tutorial Structure
+
+Part 0: executive overview and vocabulary.
+
+Part 1: choose the correct starting path.
+
+Part 2: installation and safe verification.
+
+Part 3: first target repository.
+
+Part 4: built-in workflows.
+
+Part 5: worktrees, isolation, artifacts, and logs.
+
+Part 6: custom commands.
+
+Part 7: custom YAML workflows.
+
+Part 8: Plan-Implement-Validate.
+
+Part 9: assistants, providers, and model routing.
+
+Part 10: Pi integration.
+
+Model Role Recipes: practical guided-project routing patterns.
+
+Part 11: GitHub, adapters, and interfaces.
+
+Part 12: local development, Docker, VPS, and deployment.
+
+Part 13: advanced case studies.
+
+Part 14: troubleshooting.
+
+Part 15: capstone projects.
+
+Part 16: final reference material.
+
+## Quality Gates Applied
+
+- Major parts include learning objective, why it matters, prerequisites,
+  expected result, verification, common mistakes, mini exercise, completion
+  checkpoint, and source references where applicable.
+- The tutorial includes a curriculum map with milestones, estimated time, and
+  learner outcomes.
+- The curriculum guide provides self-study pacing, workshop session plans,
+  hybrid delivery notes, facilitator preflight checks, and assessment criteria.
+- Capstones include an assessment rubric for self-study, workshops, and team
+  onboarding sign-off.
+- Secret-handling warnings are included in setup, GitHub, Pi, troubleshooting,
+  and operating checklist sections.
+- Unsupported or uncertain items are explicitly labeled.
+- GitHub usage stops at supervised PR review and does not recommend autonomous
+  merge.
+- The full tutorial is linked from the top-level `TUTORIAL.md` landing page.
+
+## Maintenance Notes
+
+- Re-run `archon workflow list` before publishing if default workflow count or
+  names matter.
+- Re-check `packages/docs-web/src/content/docs/getting-started/ai-assistants.md`
+  before giving model/provider examples.
+- Re-check GitHub adapter docs before documenting webhook events or secrets.
+- If `archon.diy/llms*.txt` becomes available later, add it to the source
+  appendix after verifying content.
+- If direct Gemini, Qwen, or Kimi providers are added, update Parts 9 and 10 and
+  Model Role Recipes to distinguish them from Pi routing.
+
+For ongoing upkeep, use:
+
+- [Curriculum Maintenance Guide](/learning/maintenance-guide/)
+- [Publishing Checklist](/learning/publishing-checklist/)
+- [Version Review](/learning/version-review/)

--- a/packages/docs-web/src/content/docs/learning/version-review.md
+++ b/packages/docs-web/src/content/docs/learning/version-review.md
@@ -1,0 +1,148 @@
+---
+title: Version Review
+description: How to review the Archon curriculum when versions, workflows, providers, or CLI behavior change.
+category: learning
+audience: [developer, operator]
+status: current
+sidebar:
+  order: 23
+---
+
+Use this page when Archon releases or source changes may affect the curriculum.
+
+## Review Trigger
+
+Start a version review when:
+
+- `package.json` version changes.
+- `CHANGELOG.md` adds workflow, CLI, provider, adapter, or deployment notes.
+- Default workflow files change.
+- CLI command files change.
+- Provider configuration changes.
+- Docs pages under getting started, guides, reference, adapters, or deployment
+  change.
+
+## Version Review Record
+
+```text
+Review date:
+Reviewer:
+Archon version:
+Commit:
+Reason for review:
+Docs build result:
+Curriculum pages changed:
+Follow-up needed:
+```
+
+## Workflow Catalog Review
+
+Check:
+
+```bash
+archon workflow list
+```
+
+Record:
+
+```text
+Workflow count:
+New workflows:
+Removed workflows:
+Renamed workflows:
+Beginner recommendations changed:
+Advanced/specialized list changed:
+Tutorial update needed:
+```
+
+## CLI Review
+
+Check current CLI help and source.
+
+Record:
+
+```text
+Commands added:
+Commands removed:
+Flags added:
+Flags removed:
+Examples affected:
+Unsupported-command notes affected:
+```
+
+Pay special attention to setup, workflow, isolation, serve, validate, and GitHub
+examples.
+
+## Provider Review
+
+Record:
+
+```text
+Provider names changed:
+Config fields changed:
+Model examples changed:
+Binary/source behavior changed:
+Authentication guidance changed:
+Provider fallback changed:
+```
+
+Never preserve a model ID in the curriculum unless it is verified or clearly
+presented as something learners must verify locally.
+
+## Safety Review
+
+Record:
+
+```text
+Approval behavior changed:
+Worktree behavior changed:
+Artifact/log behavior changed:
+Secret-handling guidance changed:
+GitHub merge boundary changed:
+Adapter exposure changed:
+```
+
+If safety behavior changes, update:
+
+- Practical tutorial.
+- Curriculum guide.
+- Capstone assessment.
+- Facilitator evaluation.
+- FAQ.
+
+## Docs Route Review
+
+Run the docs build and confirm Learning routes still render.
+
+```bash
+bun --filter @archon/docs-web build
+```
+
+Record:
+
+```text
+Build passed:
+Generated learning pages:
+Broken links found:
+Schema/frontmatter changes needed:
+```
+
+## Change Classification
+
+Classify the update:
+
+| Type | Meaning | Action |
+| --- | --- | --- |
+| Patch | Wording, small examples, links | Update affected pages and build. |
+| Minor | New workflow, command, provider option, or lab impact | Update tutorial, curriculum, labs, and assessment as needed. |
+| Major | Safety model, setup path, provider model, or GitHub flow changes | Re-review the full curriculum path before teaching. |
+
+## Review Completion
+
+Version review is complete when:
+
+- Source-backed claims are rechecked.
+- Affected examples are updated.
+- Safety guidance remains explicit.
+- Learning routes build.
+- Known limitations are recorded.


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: The docs did not have a complete guided Archon curriculum for personal, team, model-routed, GitHub, and deployed/server usage.
- Why it matters: Learners need practical evidence-based exercises for safe vibe coding projects instead of isolated reference material or transcript-inspired patterns.
- What changed: Added a full Learning docs section, practical tutorial, curriculum support package, model-role recipes, expanded capstones, team adoption guidance, sample artifacts, exercises, and docs navigation/schema support.
- What did **not** change (scope boundary): No runtime Archon behavior, workflow engine code, provider implementation, adapters, database schema, or deployment code changed.

## UX Journey

### Before

```text
Learner              Docs site              Archon practice
  |                     |                         |
  | looks for path ---->| scattered references     |
  |                     | limited curriculum       |
  | tries providers --->| conceptual routing       |
  |                     | few project-shaped labs  |
  | prepares team ----->| limited rollout path     |
```

### After

```text
Learner              Docs site                         Archon practice
  |                     |                                  |
  | opens Learning ---->| [guided curriculum package]      |
  | follows tutorial -->| [sandbox, PIV, GitHub, ops]      |
  | assigns models ---->| [model-role recipes]             |
  | practices team ---->| [server/team rollout capstones]  |
  | graduates --------->| [evidence checklist]             |
```

## Architecture Diagram

### Before

```text
packages/docs-web
  astro.config.mjs
  src/content.config.ts
  src/content/docs/index.mdx
  src/content/docs/{getting-started,guides,reference,deployment,...}
```

### After

```text
packages/docs-web
  [~] astro.config.mjs === [+] learning sidebar section
  [~] src/content.config.ts === [+] learning category
  [~] src/content/docs/index.mdx === [+] Learn Archon entry links
  [+] src/content/docs/learning/*.md === curriculum package
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `astro.config.mjs` | `src/content/docs/learning/` | **new** | Adds generated Learning sidebar section. |
| `src/content.config.ts` | learning frontmatter category | **new** | Allows learning docs in content schema. |
| `src/content/docs/index.mdx` | Learning docs | **new** | Adds homepage links into the curriculum. |
| `src/content/docs/learning/*.md` | Existing docs | **new** | Links to setup, provider, GitHub, deployment, and guide references. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XL`
- Scope: `docs`
- Module: `docs:learning`

## Change Metadata

- Change type: `docs`
- Primary scope: `web`

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Validation Evidence (required)

Commands and result summary:

```bash
bun --filter @archon/docs-web build
```

- Evidence provided (test/log/trace/screenshot): Docs build completed successfully and generated `/learning/model-role-recipes/` plus the rest of the Learning section.
- If any command is intentionally skipped, explain why: Full `bun run validate` was not run because this is a docs-only curriculum addition; docs build validates the touched docs site surface.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation: N/A

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Learning docs route generation, model-role recipe page inclusion, curriculum navigation links, and docs build.
- Edge cases checked: Missing Learning category support and sidebar registration were added so frontmatter validates and pages are reachable.
- What was not verified: Full production deployment of docs site and end-to-end browser navigation were not run.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Documentation site content and sidebar only.
- Potential unintended effects: Larger docs navigation and search index due to new Learning section.
- Guardrails/monitoring for early detection: Docs build and Starlight content sync catch schema/link-generation issues.

## Rollback Plan (required)

- Fast rollback command/path: Revert this PR or remove `src/content/docs/learning/` plus the Learning docs config/sidebar entries.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: Docs build failure, missing Learning sidebar, or broken Learning links.

## Risks and Mitigations

- Risk: Curriculum claims drift from implementation over time.
  - Mitigation: Added maintenance/version-review docs that call out provider, CLI, workflow, and deployment changes.
- Risk: Learners route models by hype rather than responsibility.
  - Mitigation: Added model-role recipes, provider routing lab guidance, explicit capstones, and evidence requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive learning curriculum with guidance for self-study, workshops, and facilitation
  * Introduced multiple learning paths tailored to different user roles (solo learner, team, facilitator, operator, maintainer)
  * Added practical tutorial, exercise bank, templates, and interactive checklists for all learner levels
  * Included assessment guides, glossary, troubleshooting labs, and session plans to support learning outcomes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->