### PR TITLE
feat(web/console): fold node lifecycle into one divider + node filter + per-node cost/turns

### DIFF
--- a/packages/web/src/experiments/console/README.md
+++ b/packages/web/src/experiments/console/README.md
@@ -21,6 +21,19 @@ Mounted at `/console/*`. Not part of the shipped product. Validates the mental m
 - **Design tokens reused.** Uses the oklch semantic tokens from `packages/web/src/index.css` (`bg-surface`, `text-text-primary`, `bg-success`, `bg-warning`, `bg-error`, etc.).
 - **Vocabulary.** Only *Project, Run, Workflow, Worktree* appear in user-facing copy. No *Dashboard, Deployment, Infrastructure, Secrets, Activity, Pipeline, Stage*.
 
+## Persisted UI state (localStorage)
+
+Client-only view preferences. All reads are try/catch-guarded and fall back to the default, so a disabled/over-quota store never breaks rendering.
+
+| Key | Default | Set by | Purpose |
+|-----|---------|--------|---------|
+| `archon.console.detailView` | `log` | Run detail | Active tab (`log` / `graph` / `artifacts`) |
+| `archon.console.showToolCalls` | `1` (on) | Run detail | Tool-calls toggle in the stream |
+| `archon.console.showSystem` | `0` (off) | Run detail | System/detail toggle in the stream |
+| `archon.console.runNodeFilter` | `all` | Run detail | Node filter (`all` or a nodeId); auto-resets when the node is absent from the open run |
+| `archon.console.railWidth` | — | Project rail | Persisted sidebar width |
+| `archon.console.lastWorkflow` | — | Chat / dispatch | Last-used workflow |
+
 ## Status
 
 Active experiment under `/console`. The original milestoned plan (`M1`–`M4`)

--- a/packages/web/src/experiments/console/components/NodeDivider.tsx
+++ b/packages/web/src/experiments/console/components/NodeDivider.tsx
@@ -3,45 +3,58 @@ import { formatElapsed, formatRelativeToBaseline, formatClock } from '../lib/for
 import { useStreamContext } from '../lib/stream-context';
 
 interface NodeDividerProps {
+  /** `step_name` — the scroll-anchor target for the graph panel. */
+  nodeId: string;
   nodeName: string;
-  transition: 'started' | 'completed' | 'failed' | 'skipped';
+  /** Folded lifecycle status; `running` = the node is still in-flight. */
+  status: 'running' | 'completed' | 'failed' | 'skipped';
   durationMs: number | null;
   timestamp: string;
+  /** From `node_completed` — surfaced inline so per-node spend is visible. */
+  costUsd?: number | null;
+  numTurns?: number | null;
+  /** From `node_completed` — surfaced under the System detail toggle. */
+  stopReason?: string | null;
   /** Only set for `skipped` — `when_condition` / `trigger_rule`. */
   skipReason?: string | null;
   /** Only set for `skipped` — the evaluated gating expression. */
   skipExpr?: string | null;
-  /** When true, surface skip reason + expression inline. */
+  /** When true, surface skip reason / stop reason inline. */
   showDetail?: boolean;
 }
 
-const TRANSITION_LABEL: Record<NodeDividerProps['transition'], string> = {
-  started: 'entered',
+const STATUS_LABEL: Record<NodeDividerProps['status'], string> = {
+  running: 'running',
   completed: 'completed',
   failed: 'failed',
   skipped: 'skipped',
 };
 
-const TRANSITION_COLOR: Record<NodeDividerProps['transition'], string> = {
-  started: 'text-text-tertiary',
+const STATUS_COLOR: Record<NodeDividerProps['status'], string> = {
+  running: 'text-text-tertiary',
   completed: 'text-success',
   failed: 'text-error',
   skipped: 'text-text-tertiary',
 };
 
 /**
- * Thin divider marking a DAG node transition.
+ * Thin divider heading one DAG node — exactly one per node, folded from its
+ * transitions (started + terminal, plus any resume-time skip).
  *   left gutter:  relative timestamp (mono)
  *   left label:   node name in mono
- *   right label:  transition + duration (for completed/failed)
+ *   right label:  status + duration (when terminal)
  *
  * The id targets a scrollIntoView from the graph panel.
  */
 export function NodeDivider({
+  nodeId,
   nodeName,
-  transition,
+  status,
   durationMs,
   timestamp,
+  costUsd,
+  numTurns,
+  stopReason,
   skipReason,
   skipExpr,
   showDetail = false,
@@ -53,21 +66,34 @@ export function NodeDivider({
     durationMs !== null && durationMs > 0
       ? ` · ${formatElapsed(Math.floor(durationMs / 1000))}`
       : '';
+  // Per-node spend, surfaced inline next to the status. Sub-cent costs keep
+  // more precision so cheap nodes don't all read "$0.00".
+  const cost =
+    costUsd !== null && costUsd !== undefined && costUsd > 0
+      ? ` · $${costUsd >= 0.01 ? costUsd.toFixed(2) : costUsd.toFixed(4)}`
+      : '';
+  const turns =
+    numTurns !== null && numTurns !== undefined && numTurns > 0 ? ` · ${numTurns}t` : '';
+
+  const hasStopDetail =
+    status !== 'skipped' &&
+    showDetail &&
+    stopReason !== null &&
+    stopReason !== undefined &&
+    stopReason.length > 0;
 
   const hasSkipDetail =
-    transition === 'skipped' &&
+    status === 'skipped' &&
     showDetail &&
     skipReason !== null &&
     skipReason !== undefined &&
     skipReason.length > 0;
 
-  // Only the `started` transition carries the scroll-anchor id so the graph
-  // click jumps to the node's entry point, not its later `completed` /
-  // `failed` markers — and so duplicate ids never appear in the DOM when a
-  // node emits multiple transitions.
+  // One divider per node now, so the scroll-anchor id is always present and
+  // keyed by nodeId (matches the graph panel's getElementById target).
   return (
     <div
-      id={transition === 'started' ? `node-transition-${nodeName}` : undefined}
+      id={`node-transition-${nodeId}`}
       className="flex flex-col gap-1 border-b border-border/60 py-[11px]"
     >
       <div className="flex items-center gap-4">
@@ -88,11 +114,19 @@ export function NodeDivider({
           }}
           aria-hidden
         />
-        <span className={`font-mono text-[11.5px] ${TRANSITION_COLOR[transition]}`}>
-          {TRANSITION_LABEL[transition]}
+        <span className={`font-mono text-[11.5px] ${STATUS_COLOR[status]}`}>
+          {STATUS_LABEL[status]}
           {dur}
+          {cost}
+          {turns}
         </span>
       </div>
+      {hasStopDetail ? (
+        <div className="ml-[68px] flex flex-wrap items-baseline gap-x-2 font-mono text-[10px] text-text-tertiary">
+          <span>stop</span>
+          <span className="text-text-secondary">{stopReason}</span>
+        </div>
+      ) : null}
       {hasSkipDetail ? (
         <div className="ml-[68px] flex flex-wrap items-baseline gap-x-2 font-mono text-[10px] text-text-tertiary">
           <span>reason</span>

--- a/packages/web/src/experiments/console/components/RunStream.test.tsx
+++ b/packages/web/src/experiments/console/components/RunStream.test.tsx
@@ -1,0 +1,74 @@
+import { describe, test, expect } from 'bun:test';
+import { pairToolEvents } from './RunStream';
+import { toRunEvent } from '../primitives/event';
+
+type Raw = Parameters<typeof toRunEvent>[0];
+
+function raw(over: Partial<Raw> & { event_type: string }): Raw {
+  return {
+    id: 'e1',
+    workflow_run_id: 'r1',
+    step_index: null,
+    step_name: 'node-a',
+    data: {},
+    created_at: '2026-06-05T10:00:00Z',
+    ...over,
+  };
+}
+
+describe('pairToolEvents — node identity threading', () => {
+  test('each paired call carries its source event nodeId (step_name) + duration', () => {
+    const events = [
+      toRunEvent(
+        raw({
+          id: 's1',
+          event_type: 'tool_called',
+          step_name: 'plan',
+          data: { tool_name: 'Read', tool_input: { path: 'a' } },
+        })
+      ),
+      toRunEvent(
+        raw({
+          id: 'c1',
+          event_type: 'tool_completed',
+          step_name: 'plan',
+          data: { tool_name: 'Read', duration_ms: 120 },
+        })
+      ),
+      toRunEvent(
+        raw({
+          id: 's2',
+          event_type: 'tool_called',
+          step_name: 'implement',
+          data: { tool_name: 'Bash', tool_input: { cmd: 'ls' } },
+        })
+      ),
+      toRunEvent(
+        raw({
+          id: 'c2',
+          event_type: 'tool_completed',
+          step_name: 'implement',
+          data: { tool_name: 'Bash', duration_ms: 300 },
+        })
+      ),
+    ];
+
+    const paired = pairToolEvents(events);
+    expect(paired).toHaveLength(2);
+    const byId = new Map(paired.map(p => [p.id, p]));
+    expect(byId.get('s1')?.nodeId).toBe('plan');
+    expect(byId.get('s1')?.call.durationMs).toBe(120);
+    expect(byId.get('s2')?.nodeId).toBe('implement');
+    expect(byId.get('s2')?.call.durationMs).toBe(300);
+  });
+
+  test('a tool_called with a null step_name stays unattributed (nodeId null)', () => {
+    const paired = pairToolEvents([
+      toRunEvent(
+        raw({ id: 's1', event_type: 'tool_called', step_name: null, data: { tool_name: 'Read' } })
+      ),
+    ]);
+    expect(paired).toHaveLength(1);
+    expect(paired[0]?.nodeId).toBeNull();
+  });
+});

--- a/packages/web/src/experiments/console/components/RunStream.tsx
+++ b/packages/web/src/experiments/console/components/RunStream.tsx
@@ -138,6 +138,10 @@ export function RunStream({
   showSystem,
   selectedNodeId,
 }: RunStreamProps): ReactElement {
+  // Single source for the folded nodes — consumed by both the timeline (one
+  // divider per node) and the node-filter window so they can't drift.
+  const nodeRuns = useMemo(() => foldNodeRuns(events), [events]);
+
   const timeline = useMemo<TimelineEntry[]>(() => {
     const entries: TimelineEntry[] = [];
     let inlineToolCount = 0;
@@ -227,7 +231,7 @@ export function RunStream({
     // One divider per node: fold each node's 2–3 transitions (started + terminal,
     // plus a resume-time skipped_prior_success) into a single NodeRun, positioned
     // at its first transition so it heads that node's events in the stream.
-    for (const nr of foldNodeRuns(events)) {
+    for (const nr of nodeRuns) {
       entries.push({
         kind: 'node',
         key: `n:${nr.nodeId}`,
@@ -247,30 +251,30 @@ export function RunStream({
     }
     entries.sort((a, b) => a.at - b.at);
     return entries;
-  }, [messages, events, showSystem]);
+  }, [messages, events, nodeRuns, showSystem]);
 
   // The selected node's execution slice `[startedAt, nextNode.startedAt)`. Used as
-  // a positional fallback so node-blind entries (Claude message-inline tools and
-  // prose, which carry no nodeId) still resolve to a node when filtering — without
-  // it, selecting a node on a Claude run would blank the stream.
+  // a positional fallback so node-blind entries (message-inline tools, prose,
+  // artifacts, system rows — anything carrying no nodeId) still resolve to a node
+  // when filtering — without it, selecting a node on a message-inline-tool run
+  // (e.g. Claude) would blank the stream.
   const nodeWindow = useMemo<{ start: number; end: number } | null>(() => {
     if (selectedNodeId === 'all') return null;
-    const runs = foldNodeRuns(events);
-    const idx = runs.findIndex(r => r.nodeId === selectedNodeId);
+    const idx = nodeRuns.findIndex(r => r.nodeId === selectedNodeId);
     if (idx === -1) return null;
-    const start = new Date(runs[idx].startedAt).getTime();
-    const next = runs[idx + 1];
+    const start = new Date(nodeRuns[idx].startedAt).getTime();
+    const next = nodeRuns[idx + 1];
     return { start, end: next !== undefined ? new Date(next.startedAt).getTime() : Infinity };
-  }, [events, selectedNodeId]);
+  }, [nodeRuns, selectedNodeId]);
 
   const visible = timeline.filter(e => {
     if (e.kind === 'tool' && !showToolCalls) return false;
     if (e.kind === 'system' && !showSystem) return false;
     if (e.kind === 'system_row' && !showSystem) return false;
     // Node filter: isolate one node. Node markers and node-attributed (workflow-
-    // event) tools match by identity; everything node-blind (message-inline tools,
-    // prose, system) falls back to the node's time window so a node's whole slice
-    // of the timeline stays visible regardless of provider.
+    // event) tools match by identity; every node-blind entry (message-inline
+    // tools, prose, artifacts, system rows) falls back to the node's time window
+    // so a node's whole slice of the timeline stays visible regardless of provider.
     if (selectedNodeId !== 'all') {
       if (e.kind === 'node') return e.node.nodeId === selectedNodeId;
       if (e.kind === 'tool' && e.nodeId !== null) return e.nodeId === selectedNodeId;

--- a/packages/web/src/experiments/console/components/RunStream.tsx
+++ b/packages/web/src/experiments/console/components/RunStream.tsx
@@ -5,9 +5,10 @@ import { NodeDivider } from './NodeDivider';
 import { ArtifactItem } from './ArtifactItem';
 import type { InlineToolCall, Message } from '../primitives/message';
 import { isSystemCategory } from '../primitives/message';
+import { foldNodeRuns } from '../primitives/event';
 import type {
   RunEvent,
-  NodeTransitionEvent,
+  NodeRun,
   ArtifactEvent,
   ToolCallEvent,
   SystemEvent,
@@ -20,6 +21,8 @@ interface RunStreamProps {
   events: RunEvent[];
   showToolCalls: boolean;
   showSystem: boolean;
+  /** `'all'` shows every node; otherwise restrict the stream to one node's entries. */
+  selectedNodeId: string;
 }
 
 /**
@@ -42,8 +45,17 @@ interface SystemRow {
 
 type TimelineEntry =
   | { kind: 'message'; key: string; at: number; message: Message }
-  | { kind: 'tool'; key: string; at: number; call: InlineToolCall; timestamp: string }
-  | { kind: 'node'; key: string; at: number; event: NodeTransitionEvent; showDetail: boolean }
+  // `nodeId` carries the owning node (workflow-event tools) or null (message-inline
+  // tools are node-blind) — used only by the node filter, not for display.
+  | {
+      kind: 'tool';
+      key: string;
+      at: number;
+      call: InlineToolCall;
+      timestamp: string;
+      nodeId: string | null;
+    }
+  | { kind: 'node'; key: string; at: number; node: NodeRun; showDetail: boolean }
   | { kind: 'artifact'; key: string; at: number; event: ArtifactEvent }
   | { kind: 'system'; key: string; at: number; event: SystemEvent | ErrorEvent }
   | { kind: 'system_row'; key: string; at: number; row: SystemRow };
@@ -62,10 +74,12 @@ type TimelineEntry =
 interface PairedToolCall {
   id: string;
   timestamp: string;
+  /** Owning node (`step_name`) so the call can be filtered by node; null if unattributed. */
+  nodeId: string | null;
   call: InlineToolCall;
 }
 
-function pairToolEvents(events: RunEvent[]): PairedToolCall[] {
+export function pairToolEvents(events: RunEvent[]): PairedToolCall[] {
   const toolEvents = events.filter((e): e is ToolCallEvent => e.kind === 'tool_call');
   // Track unclaimed completed events per step so each call gets exactly one.
   const completedByStep = new Map<string, ToolCallEvent[]>();
@@ -88,6 +102,7 @@ function pairToolEvents(events: RunEvent[]): PairedToolCall[] {
     paired.push({
       id: e.id,
       timestamp: e.timestamp,
+      nodeId: e.nodeId,
       call: {
         name: e.tool || '(unknown)',
         input,
@@ -121,6 +136,7 @@ export function RunStream({
   events,
   showToolCalls,
   showSystem,
+  selectedNodeId,
 }: RunStreamProps): ReactElement {
   const timeline = useMemo<TimelineEntry[]>(() => {
     const entries: TimelineEntry[] = [];
@@ -188,6 +204,8 @@ export function RunStream({
           at: base + idx + 1,
           call,
           timestamp: m.timestamp,
+          // Message-inline tools (Claude) are node-blind — messages carry no step.
+          nodeId: null,
         });
       });
     }
@@ -201,15 +219,27 @@ export function RunStream({
           at: new Date(t.timestamp).getTime(),
           call: t.call,
           timestamp: t.timestamp,
+          nodeId: t.nodeId,
         });
       }
     }
 
+    // One divider per node: fold each node's 2–3 transitions (started + terminal,
+    // plus a resume-time skipped_prior_success) into a single NodeRun, positioned
+    // at its first transition so it heads that node's events in the stream.
+    for (const nr of foldNodeRuns(events)) {
+      entries.push({
+        kind: 'node',
+        key: `n:${nr.nodeId}`,
+        at: new Date(nr.startedAt).getTime(),
+        node: nr,
+        showDetail: showSystem,
+      });
+    }
+
     for (const e of events) {
       const at = new Date(e.timestamp).getTime();
-      if (e.kind === 'node_transition') {
-        entries.push({ kind: 'node', key: `n:${e.id}`, at, event: e, showDetail: showSystem });
-      } else if (e.kind === 'artifact') {
+      if (e.kind === 'artifact') {
         entries.push({ kind: 'artifact', key: `a:${e.id}`, at, event: e });
       } else if (e.kind === 'system' || e.kind === 'error') {
         entries.push({ kind: 'system', key: `s:${e.id}`, at, event: e });
@@ -219,10 +249,33 @@ export function RunStream({
     return entries;
   }, [messages, events, showSystem]);
 
+  // The selected node's execution slice `[startedAt, nextNode.startedAt)`. Used as
+  // a positional fallback so node-blind entries (Claude message-inline tools and
+  // prose, which carry no nodeId) still resolve to a node when filtering — without
+  // it, selecting a node on a Claude run would blank the stream.
+  const nodeWindow = useMemo<{ start: number; end: number } | null>(() => {
+    if (selectedNodeId === 'all') return null;
+    const runs = foldNodeRuns(events);
+    const idx = runs.findIndex(r => r.nodeId === selectedNodeId);
+    if (idx === -1) return null;
+    const start = new Date(runs[idx].startedAt).getTime();
+    const next = runs[idx + 1];
+    return { start, end: next !== undefined ? new Date(next.startedAt).getTime() : Infinity };
+  }, [events, selectedNodeId]);
+
   const visible = timeline.filter(e => {
     if (e.kind === 'tool' && !showToolCalls) return false;
     if (e.kind === 'system' && !showSystem) return false;
     if (e.kind === 'system_row' && !showSystem) return false;
+    // Node filter: isolate one node. Node markers and node-attributed (workflow-
+    // event) tools match by identity; everything node-blind (message-inline tools,
+    // prose, system) falls back to the node's time window so a node's whole slice
+    // of the timeline stays visible regardless of provider.
+    if (selectedNodeId !== 'all') {
+      if (e.kind === 'node') return e.node.nodeId === selectedNodeId;
+      if (e.kind === 'tool' && e.nodeId !== null) return e.nodeId === selectedNodeId;
+      return nodeWindow !== null && e.at >= nodeWindow.start && e.at < nodeWindow.end;
+    }
     return true;
   });
 
@@ -254,12 +307,16 @@ export function RunStream({
           return (
             <NodeDivider
               key={entry.key}
-              nodeName={entry.event.nodeName}
-              transition={entry.event.transition}
-              durationMs={entry.event.durationMs}
-              timestamp={entry.event.timestamp}
-              skipReason={entry.event.skipReason}
-              skipExpr={entry.event.skipExpr}
+              nodeId={entry.node.nodeId}
+              nodeName={entry.node.nodeName}
+              status={entry.node.status}
+              durationMs={entry.node.durationMs}
+              timestamp={entry.node.startedAt}
+              costUsd={entry.node.costUsd}
+              numTurns={entry.node.numTurns}
+              stopReason={entry.node.stopReason}
+              skipReason={entry.node.skipReason}
+              skipExpr={entry.node.skipExpr}
               showDetail={entry.showDetail}
             />
           );

--- a/packages/web/src/experiments/console/components/StreamToolbar.tsx
+++ b/packages/web/src/experiments/console/components/StreamToolbar.tsx
@@ -1,6 +1,11 @@
-import type { ReactElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 export type DetailView = 'log' | 'graph' | 'artifacts';
+
+export interface NodeFilterOption {
+  id: string;
+  name: string;
+}
 
 interface StreamToolbarProps {
   view: DetailView;
@@ -12,6 +17,41 @@ interface StreamToolbarProps {
   toolCallCount: number;
   messageCount: number;
   artifactCount: number | null;
+  /** Distinct nodes in the run; empty hides the node filter. */
+  nodeOptions: NodeFilterOption[];
+  /** `'all'` or a nodeId. */
+  selectedNodeId: string;
+  onSelectNode: (next: string) => void;
+}
+
+// Compact native select styled with brand tokens — mirrors AssistantConfigPanel's
+// SelectShell/SELECT_CLASS, tuned for the toolbar row height.
+const SELECT_CLASS =
+  'max-w-[180px] cursor-pointer appearance-none truncate rounded-[7px] border border-border bg-surface-elevated py-[3px] pl-2.5 pr-7 font-mono text-[11.5px] font-medium text-text-primary transition-all focus:border-accent-bright/50 focus:outline-none focus:shadow-[0_0_0_3px_color-mix(in_oklch,var(--brand-magenta),transparent_92%)]';
+
+function SelectShell({ children }: { children: ReactNode }): ReactElement {
+  return (
+    <span className="relative inline-flex items-center">
+      {children}
+      <span
+        aria-hidden
+        className="pointer-events-none absolute right-[9px] flex text-text-tertiary"
+      >
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </span>
+    </span>
+  );
 }
 
 interface CheckboxProps {
@@ -77,6 +117,9 @@ export function StreamToolbar({
   toolCallCount,
   messageCount,
   artifactCount,
+  nodeOptions,
+  selectedNodeId,
+  onSelectNode,
 }: StreamToolbarProps): ReactElement {
   const isLog = view === 'log';
   return (
@@ -114,6 +157,28 @@ export function StreamToolbar({
 
       {isLog ? (
         <div className="ml-auto flex items-center gap-[18px] font-mono text-[12px]">
+          {nodeOptions.length > 0 ? (
+            <label className="flex items-center gap-1.5 text-text-secondary">
+              <span className="text-text-tertiary">Node</span>
+              <SelectShell>
+                <select
+                  value={selectedNodeId}
+                  onChange={e => {
+                    onSelectNode(e.target.value);
+                  }}
+                  className={SELECT_CLASS}
+                  aria-label="Filter stream by node"
+                >
+                  <option value="all">All nodes</option>
+                  {nodeOptions.map(o => (
+                    <option key={o.id} value={o.id}>
+                      {o.name}
+                    </option>
+                  ))}
+                </select>
+              </SelectShell>
+            </label>
+          ) : null}
           <Checkbox label="Tool calls" checked={showToolCalls} onChange={onToggleToolCalls} />
           <Checkbox label="System" checked={showSystem} onChange={onToggleSystem} />
         </div>

--- a/packages/web/src/experiments/console/primitives/event.test.ts
+++ b/packages/web/src/experiments/console/primitives/event.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { toRunEvent, countTerminalNodes } from './event';
+import { toRunEvent, countTerminalNodes, foldNodeRuns } from './event';
 
 type Raw = Parameters<typeof toRunEvent>[0];
 
@@ -281,5 +281,108 @@ describe('countTerminalNodes', () => {
 
   test('a terminal event with a null nodeId is skipped (can not be deduped)', () => {
     expect(countTerminalNodes([node(null, 'node_completed')])).toEqual({ completed: 0, total: 0 });
+  });
+});
+
+describe('foldNodeRuns', () => {
+  const at = (s: string): string => `2026-06-05T10:0${s}:00Z`;
+  const node = (
+    nodeId: string | null,
+    eventType: string,
+    over: { created_at?: string; data?: Record<string, unknown> } = {}
+  ) => toRunEvent(raw({ event_type: eventType, step_name: nodeId, ...over }));
+
+  test('empty events → no runs', () => {
+    expect(foldNodeRuns([])).toEqual([]);
+  });
+
+  test('a node with only node_started folds to one running run (no duration/end)', () => {
+    const runs = foldNodeRuns([node('plan', 'node_started')]);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({
+      nodeId: 'plan',
+      status: 'running',
+      endedAt: null,
+      durationMs: null,
+    });
+  });
+
+  test('started + completed folds to ONE completed run carrying duration + cost/turns/stop', () => {
+    const runs = foldNodeRuns([
+      node('plan', 'node_started', { created_at: at('0') }),
+      node('plan', 'node_completed', {
+        created_at: at('5'),
+        data: { duration_ms: 11370, cost_usd: 0.1399, num_turns: 3, stop_reason: 'end_turn' },
+      }),
+    ]);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({
+      nodeId: 'plan',
+      status: 'completed',
+      startedAt: at('0'),
+      endedAt: at('5'),
+      durationMs: 11370,
+      costUsd: 0.1399,
+      numTurns: 3,
+      stopReason: 'end_turn',
+    });
+  });
+
+  test('completed then resume node_skipped_prior_success folds to ONE completed run (dedup)', () => {
+    const runs = foldNodeRuns([
+      node('plan', 'node_completed', { created_at: at('1'), data: { duration_ms: 900 } }),
+      node('plan', 'node_skipped_prior_success', {
+        created_at: at('9'),
+        data: { reason: 'prior_success' },
+      }),
+    ]);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.status).toBe('completed');
+    expect(runs[0]?.durationMs).toBe(900);
+  });
+
+  test('a skipped node carries reason + expr and skipped status', () => {
+    const runs = foldNodeRuns([
+      node('web-research', 'node_skipped', {
+        data: { reason: 'when_condition', expr: "$classify.output.type != 'bug'" },
+      }),
+    ]);
+    expect(runs[0]).toMatchObject({
+      nodeId: 'web-research',
+      status: 'skipped',
+      skipReason: 'when_condition',
+      skipExpr: "$classify.output.type != 'bug'",
+    });
+  });
+
+  test('a failed node folds to failed status', () => {
+    const runs = foldNodeRuns([
+      node('build', 'node_started', { created_at: at('0') }),
+      node('build', 'node_failed', { created_at: at('3'), data: { duration_ms: 42 } }),
+    ]);
+    expect(runs[0]?.status).toBe('failed');
+    expect(runs[0]?.durationMs).toBe(42);
+  });
+
+  test('multiple nodes are returned sorted by startedAt', () => {
+    const runs = foldNodeRuns([
+      node('second', 'node_started', { created_at: at('5') }),
+      node('first', 'node_started', { created_at: at('1') }),
+    ]);
+    expect(runs.map(r => r.nodeId)).toEqual(['first', 'second']);
+  });
+
+  test('transitions with a null nodeId are excluded (can not be keyed)', () => {
+    expect(foldNodeRuns([node(null, 'node_completed')])).toEqual([]);
+  });
+
+  test('non-node_transition events are ignored', () => {
+    const runs = foldNodeRuns([
+      node('plan', 'node_completed'),
+      toRunEvent(raw({ event_type: 'tool_called', data: { tool_name: 'Bash' } })),
+      toRunEvent(raw({ event_type: 'workflow_completed', data: {} })),
+    ]);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.nodeId).toBe('plan');
   });
 });

--- a/packages/web/src/experiments/console/primitives/event.test.ts
+++ b/packages/web/src/experiments/console/primitives/event.test.ts
@@ -364,6 +364,36 @@ describe('foldNodeRuns', () => {
     expect(runs[0]?.durationMs).toBe(42);
   });
 
+  test('failed THEN a later completed (retry) folds to completed — duration/cost from the completion', () => {
+    const runs = foldNodeRuns([
+      node('build', 'node_started', { created_at: at('0') }),
+      node('build', 'node_failed', { created_at: at('2'), data: { duration_ms: 42 } }),
+      node('build', 'node_completed', {
+        created_at: at('8'),
+        data: { duration_ms: 900, cost_usd: 0.05, num_turns: 2 },
+      }),
+    ]);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({
+      status: 'completed',
+      durationMs: 900,
+      costUsd: 0.05,
+      numTurns: 2,
+    });
+  });
+
+  test('completed THEN a later failed still folds to completed (ever-completed wins)', () => {
+    const runs = foldNodeRuns([
+      node('build', 'node_completed', {
+        created_at: at('2'),
+        data: { duration_ms: 900, cost_usd: 0.05 },
+      }),
+      node('build', 'node_failed', { created_at: at('8'), data: { duration_ms: 10 } }),
+    ]);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({ status: 'completed', durationMs: 900, costUsd: 0.05 });
+  });
+
   test('multiple nodes are returned sorted by startedAt', () => {
     const runs = foldNodeRuns([
       node('second', 'node_started', { created_at: at('5') }),

--- a/packages/web/src/experiments/console/primitives/event.ts
+++ b/packages/web/src/experiments/console/primitives/event.ts
@@ -294,22 +294,102 @@ export function toRunEvent(raw: RawWorkflowEvent): RunEvent {
 }
 
 /**
+ * One node's whole lifecycle, folded from its 2–3 `node_transition` events into a
+ * single record. A node emits `node_started` + a terminal (`node_completed` /
+ * `node_failed` / `node_skipped`), and a resumed run reuses one run id so the same
+ * node can ALSO carry a later `node_skipped_prior_success`. The run stream renders
+ * one `NodeRun` per node instead of one divider per raw transition.
+ */
+export interface NodeRun {
+  /** `step_name`. Null-id transitions can't be keyed and are excluded from the fold. */
+  nodeId: string;
+  nodeName: string;
+  /** `running` = only a `started` transition seen so far (in-flight). */
+  status: 'running' | 'completed' | 'failed' | 'skipped';
+  /** Earliest transition timestamp — positions the single divider in the stream. */
+  startedAt: string;
+  /** Terminal transition timestamp; null while still running. */
+  endedAt: string | null;
+  durationMs: number | null;
+  /** From the terminal `node_completed` payload; null for non-AI or non-terminal nodes. */
+  costUsd: number | null;
+  numTurns: number | null;
+  stopReason: string | null;
+  skipReason: string | null;
+  skipExpr: string | null;
+}
+
+/**
+ * Folds a run's `node_transition` events into one `NodeRun` per node, keyed by
+ * `nodeId`. Status precedence is `completed > failed > skipped > running` —
+ * "ever completed wins" (a completed-then-resume-skipped node stays `completed`),
+ * matching the dedup `countTerminalNodes` relies on. Null-`nodeId` transitions are
+ * skipped (can't be keyed). Returned sorted by `startedAt`.
+ */
+export function foldNodeRuns(events: RunEvent[]): NodeRun[] {
+  const byNode = new Map<string, NodeTransitionEvent[]>();
+  for (const e of events) {
+    if (e.kind !== 'node_transition' || e.nodeId === null) continue;
+    const list = byNode.get(e.nodeId) ?? [];
+    list.push(e);
+    byNode.set(e.nodeId, list);
+  }
+
+  const runs: NodeRun[] = [];
+  for (const [nodeId, transitions] of byNode) {
+    // Last-of-each-kind wins; precedence is applied below, not by event order.
+    let completed: NodeTransitionEvent | null = null;
+    let failed: NodeTransitionEvent | null = null;
+    let skipped: NodeTransitionEvent | null = null;
+    let nodeName = '';
+    let startedAt = transitions[0]?.timestamp ?? '';
+    for (const t of transitions) {
+      if (new Date(t.timestamp).getTime() < new Date(startedAt).getTime()) startedAt = t.timestamp;
+      if (nodeName === '' && t.nodeName !== '') nodeName = t.nodeName;
+      if (t.transition === 'completed') completed = t;
+      else if (t.transition === 'failed') failed = t;
+      else if (t.transition === 'skipped') skipped = t;
+    }
+    const terminal = completed ?? failed ?? skipped;
+    const status: NodeRun['status'] =
+      completed !== null
+        ? 'completed'
+        : failed !== null
+          ? 'failed'
+          : skipped !== null
+            ? 'skipped'
+            : 'running';
+    runs.push({
+      nodeId,
+      nodeName: nodeName !== '' ? nodeName : nodeId,
+      status,
+      startedAt,
+      endedAt: terminal?.timestamp ?? null,
+      durationMs: terminal?.durationMs ?? null,
+      costUsd: terminal?.costUsd ?? null,
+      numTurns: terminal?.numTurns ?? null,
+      stopReason: terminal?.stopReason ?? null,
+      skipReason: skipped?.skipReason ?? null,
+      skipExpr: skipped?.skipExpr ?? null,
+    });
+  }
+  return runs.sort((a, b) => new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime());
+}
+
+/**
  * Per-node terminal tally for a run's node-count readout (e.g. `7/8 nodes`).
- * Deduped by `nodeId`: a resumed run reuses one run id, so a node can appear both
- * as its original `completed` AND a later `node_skipped_prior_success` (normalized
- * to a `skipped` transition) — counting raw events would double it. `total` =
- * distinct nodes that reached any terminal (non-`started`) state; `completed` =
- * distinct nodes that ever completed (so a completed-then-resume-skipped node
- * stays counted). Nodes with a null `nodeId` can't be deduped and are skipped.
+ * Derived from {@link foldNodeRuns} so the dedup is single-sourced: `total` =
+ * distinct nodes that reached a terminal (non-`running`) state; `completed` =
+ * distinct nodes that ever completed (a completed-then-resume-skipped node stays
+ * counted). Nodes with a null `nodeId` are excluded by the fold.
  */
 export function countTerminalNodes(events: RunEvent[]): { completed: number; total: number } {
-  const completedByNode = new Map<string, boolean>();
-  for (const e of events) {
-    if (e.kind !== 'node_transition' || e.transition === 'started' || e.nodeId === null) continue;
-    const everCompleted = (completedByNode.get(e.nodeId) ?? false) || e.transition === 'completed';
-    completedByNode.set(e.nodeId, everCompleted);
-  }
   let completed = 0;
-  for (const done of completedByNode.values()) if (done) completed += 1;
-  return { completed, total: completedByNode.size };
+  let total = 0;
+  for (const r of foldNodeRuns(events)) {
+    if (r.status === 'running') continue;
+    total += 1;
+    if (r.status === 'completed') completed += 1;
+  }
+  return { completed, total };
 }

--- a/packages/web/src/experiments/console/primitives/event.ts
+++ b/packages/web/src/experiments/console/primitives/event.ts
@@ -311,7 +311,7 @@ export interface NodeRun {
   /** Terminal transition timestamp; null while still running. */
   endedAt: string | null;
   durationMs: number | null;
-  /** From the terminal `node_completed` payload; null for non-AI or non-terminal nodes. */
+  /** Written by the engine only on `node_completed`; null for non-AI nodes and any non-completed terminal. */
   costUsd: number | null;
   numTurns: number | null;
   stopReason: string | null;
@@ -351,24 +351,26 @@ export function foldNodeRuns(events: RunEvent[]): NodeRun[] {
       else if (t.transition === 'skipped') skipped = t;
     }
     const terminal = completed ?? failed ?? skipped;
-    const status: NodeRun['status'] =
-      completed !== null
-        ? 'completed'
-        : failed !== null
-          ? 'failed'
-          : skipped !== null
-            ? 'skipped'
-            : 'running';
+    // Precedence in documented order: ever-completed wins, then failed, then
+    // skipped, else still running.
+    let status: NodeRun['status'];
+    if (completed !== null) status = 'completed';
+    else if (failed !== null) status = 'failed';
+    else if (skipped !== null) status = 'skipped';
+    else status = 'running';
     runs.push({
       nodeId,
       nodeName: nodeName !== '' ? nodeName : nodeId,
       status,
       startedAt,
+      // Position/duration come from whichever terminal transition exists...
       endedAt: terminal?.timestamp ?? null,
       durationMs: terminal?.durationMs ?? null,
-      costUsd: terminal?.costUsd ?? null,
-      numTurns: terminal?.numTurns ?? null,
-      stopReason: terminal?.stopReason ?? null,
+      // ...but cost/turns/stop are only ever written on `node_completed`, so read
+      // them from that transition (a failed/skipped terminal carries none).
+      costUsd: completed?.costUsd ?? null,
+      numTurns: completed?.numTurns ?? null,
+      stopReason: completed?.stopReason ?? null,
       skipReason: skipped?.skipReason ?? null,
       skipExpr: skipped?.skipExpr ?? null,
     });

--- a/packages/web/src/experiments/console/routes/RunDetailPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunDetailPage.tsx
@@ -16,7 +16,7 @@ import { useEntity, invalidate } from '../store/cache';
 import { K } from '../store/keys';
 import * as skill from '../skills';
 import type { Run } from '../primitives/run';
-import type { RunEvent } from '../primitives/event';
+import { foldNodeRuns, type RunEvent } from '../primitives/event';
 import type { Message } from '../primitives/message';
 import type { Project } from '../primitives/project';
 import type { ArtifactFile } from '../skills/runs';
@@ -45,6 +45,7 @@ const TOGGLE_KEYS = {
   toolCalls: 'archon.console.showToolCalls',
   system: 'archon.console.showSystem',
   view: 'archon.console.detailView',
+  node: 'archon.console.runNodeFilter',
 } as const;
 
 function readToggle(key: string, defaultOn: boolean): boolean {
@@ -82,6 +83,22 @@ function writeView(v: DetailView): void {
   }
 }
 
+function readNodeFilter(): string {
+  try {
+    return localStorage.getItem(TOGGLE_KEYS.node) ?? 'all';
+  } catch {
+    return 'all';
+  }
+}
+
+function writeNodeFilter(v: string): void {
+  try {
+    localStorage.setItem(TOGGLE_KEYS.node, v);
+  } catch {
+    /* ignore */
+  }
+}
+
 export function RunDetailPage(): ReactElement {
   const { projectId, runId } = useParams<{ projectId: string; runId: string }>();
   const navigate = useNavigate();
@@ -93,6 +110,7 @@ export function RunDetailPage(): ReactElement {
     readToggle(TOGGLE_KEYS.system, false)
   );
   const [view, setView] = useState<DetailView>(() => readView());
+  const [selectedNodeId, setSelectedNodeId] = useState<string>(() => readNodeFilter());
 
   // Hoisted above any early returns so the hook order stays stable.
   const scrollToNode = useCallback((nodeId: string): void => {
@@ -165,6 +183,23 @@ export function RunDetailPage(): ReactElement {
     () =>
       runId !== undefined ? skill.listRunArtifacts(runId) : Promise.resolve([] as ArtifactFile[])
   );
+
+  // Distinct nodes drive the node-filter dropdown — derived from the same fold
+  // the stream renders, so the options match the dividers exactly.
+  const nodeOptions = useMemo(
+    () => foldNodeRuns(detail?.events ?? []).map(r => ({ id: r.nodeId, name: r.nodeName })),
+    [detail?.events]
+  );
+
+  // Drop a persisted node selection that doesn't apply to this run (e.g. after
+  // navigating to a different workflow). Guarded on the run being loaded so the
+  // empty list during loading can't clobber a still-valid stored selection.
+  useEffect(() => {
+    if (detail === undefined || detail === null) return;
+    if (selectedNodeId !== 'all' && !nodeOptions.some(o => o.id === selectedNodeId)) {
+      setSelectedNodeId('all');
+    }
+  }, [detail, nodeOptions, selectedNodeId]);
 
   // Auto-scroll to bottom on new content IF user is already near the bottom.
   const lastBottomRef = useRef(true);
@@ -318,6 +353,12 @@ export function RunDetailPage(): ReactElement {
       toolCallCount={toolCallCount}
       messageCount={messageList.length}
       artifactCount={artifactFiles?.length ?? null}
+      nodeOptions={nodeOptions}
+      selectedNodeId={selectedNodeId}
+      onSelectNode={next => {
+        setSelectedNodeId(next);
+        writeNodeFilter(next);
+      }}
     />
   );
 
@@ -341,6 +382,7 @@ export function RunDetailPage(): ReactElement {
                       events={events}
                       showToolCalls={showToolCalls}
                       showSystem={showSystem}
+                      selectedNodeId={selectedNodeId}
                     />
                   </div>
 

--- a/packages/web/src/experiments/console/routes/RunDetailPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunDetailPage.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+} from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { useKeymap, type Binding } from '../lib/keymap';
 import { RunDetailHeader } from '../components/RunDetailHeader';
@@ -194,7 +202,10 @@ export function RunDetailPage(): ReactElement {
   // Drop a persisted node selection that doesn't apply to this run (e.g. after
   // navigating to a different workflow). Guarded on the run being loaded so the
   // empty list during loading can't clobber a still-valid stored selection.
-  useEffect(() => {
+  // useLayoutEffect (not useEffect) so the reset lands before paint — navigating
+  // to a cached run whose node set lacks the selection never flashes an empty
+  // "Waiting for first event…" frame.
+  useLayoutEffect(() => {
     if (detail === undefined || detail === null) return;
     if (selectedNodeId !== 'all' && !nodeOptions.some(o => o.id === selectedNodeId)) {
       setSelectedNodeId('all');


### PR DESCRIPTION
## Summary

- **Problem:** The console run-detail stream rendered **one divider per node *transition*** — so every node showed up twice (`started` + `completed`), three times on resumed runs (`+ node_skipped_prior_success`). That's the "duplicate logs". Separately, tool timeline entries silently **dropped the `nodeId`** they carry, there was **no way to focus a single node**, and per-node spend (cost/turns) was persisted but never shown.
- **Why it matters:** This is the view meant to replace the old dashboard. Duplicate dividers make a 20-node run unscannable, and "what did this node do / cost" was invisible.
- **What changed:** (1) `foldNodeRuns()` primitive folds a node's transitions into one `NodeRun` (status + duration + cost + turns + stop); RunStream renders **one divider per node**. (2) `nodeId` threaded through `pairToolEvents` → the tool entry. (3) **Node filter** dropdown in the toolbar isolates a node's slice (hybrid: exact `nodeId` match where present, time-window fallback for node-blind Claude prose/tools); pure client-side, localStorage-persisted. (4) `NodeDivider` surfaces per-node **cost + turns** inline (`$x · Nt`), `stop_reason` under the System toggle; `running` status for in-flight nodes.
- **What did *not* change (scope boundary):** No server/API/schema/DB. No `ToolCallItem`/`MessageItem`/production-web changes. SSE stays an invalidate-only doorbell. Token counts are **not** surfaced — the engine doesn't persist them (only `cost_usd`/`num_turns`); that needs a separate server change. The expandable accordion (output preview) is deferred.

## UX Journey

### Before

```
RunStream (one entry PER node_transition event)
  ▶ extract-issue   entered            ← node_started divider
  · tool: gh issue view ...            ← tool entry (no nodeId)
  ✓ extract-issue   completed · 00:04  ← node_completed divider (SAME NAME → looks duplicate)
  ▶ plan            entered
  ✓ plan            completed · 00:35
  …24 nodes → ~46 dividers; resumed → ~70…
Toolbar:  [Log|Graph|Artifacts]  22 messages · 493 tool calls   [Tool calls ☑] [System ☐]
```

### After

```
RunStream (ONE entry per node; tools carry nodeId)
  ◆ extract-issue   completed · 00:04 · $0.15 · 1t    ← *single folded divider + cost/turns*
  · tool: gh issue view ...                            ← *nodeId = extract-issue*
  ◆ plan            *running…*                         ← *in-flight nodes show 'running'*
Toolbar: [Log|Graph|Artifacts]  …   [Node ▼ All nodes]  [Tool calls ☑] [System ☐]
              │ pick "implement"
              ▼
  ◆ implement       completed · 22:30 · $18.33 · 130t  ← *that node's slice only*
  · …implement's tools / prose…
```

## Architecture Diagram

### After

```
primitives/event.ts [~]
  + foldNodeRuns(events) → NodeRun[]   (status+duration+cost+turns+stop, 1 per nodeId)
  ~ countTerminalNodes  → re-expressed via foldNodeRuns (single-sourced dedup)
        │
        ▼
components/RunStream.tsx [~]
  ~ pairToolEvents → PairedToolCall now carries nodeId
  ~ TimelineEntry: tool +nodeId, node now { node: NodeRun }
  ~ visible: + hybrid node filter (identity ∪ time-window)
        │                         │
        ▼                         ▼
NodeDivider.tsx [~]         StreamToolbar.tsx [~]
  transition→status (+running)   + node <select> (SelectShell)
  + cost·turns inline, stop          │
                                     ▼
                            routes/RunDetailPage.tsx [~]
                              + selectedNodeId state + localStorage + nodeOptions + reset guard
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `RunStream` | `foldNodeRuns` (event.ts) | **new** | one NodeRun per node |
| `countTerminalNodes` | `foldNodeRuns` | **modified** | re-expressed; existing tests guard semantics |
| `pairToolEvents` | `tool` TimelineEntry | **modified** | `nodeId` now threaded through |
| `RunDetailPage` | `StreamToolbar` / `RunStream` | **modified** | passes `nodeOptions` / `selectedNodeId` |
| `NodeDivider` | graph scroll anchor | **modified** | anchored on `nodeId` (was `nodeName`) |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `web`
- Module: `web:experiments/console`

## Change Metadata

- Change type: `feature`
- Primary scope: `web`

## Linked Issue

- Related: follows #1878 (event normalizer carries the cost/turns fields), #1903 (chat restyle)
- Follow-ups: #1908 (per-node tokens, all providers), #1909 (provider-agnostic tool node-attribution)

## Validation Evidence (required)

```bash
tsc --noEmit -p packages/web/tsconfig.json   # exit 0
eslint --max-warnings 0 (changed source)     # exit 0
prettier --check experiments/console/**       # clean
bun test experiments/console/                 # 78 console tests pass (40 new/touched assertions)
```

- **Evidence:** Unit tests for `foldNodeRuns` (fold precedence `completed>failed>skipped>running`, ordering, null-nodeId exclusion, cost/turns carry) and `pairToolEvents` nodeId threading. Manual UI walkthrough on a real 20-node run (`archon-fix-github-issue-experimental`): single dividers, `running`/`completed · 00:04 · $0.15 · 1t`, node dropdown, filter narrows, graph→node scroll.
- **Skipped:** full `bun run validate` not run end-to-end in the worktree (per-package `bun --filter type-check` mis-resolves `bun-types` in this worktree's isolated install — an env quirk, not the code; direct `tsc -p packages/web` is clean). `check:bundled*` unaffected (web-only change). CI runs full validate on a clean checkout.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No**

Pure presentational/derivation change in an experimental React surface. No new deps, fetches, or token plumbing.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Database migration needed? **No**

New localStorage key `archon.console.runNodeFilter` (defaults to `all`). No API/route/schema changes.

## Human Verification (required)

- **Verified scenarios:** single divider per node; running node shows `running`; completed shows `· $x · Nt`; node dropdown lists the run's nodes; selecting one narrows the stream (incl. Claude message-inline tools via time-window); `All nodes` restores; graph-panel node click still scrolls to the (single) divider.
- **Edge cases checked:** resumed run (`completed` + `skipped_prior_success`) folds to one `completed`; bash node (no cost) shows duration only; null `step_name` excluded from fold + options.
- **What was not verified:** Firefox/Safari pixel parity; mobile viewports (console is desktop-first); token counts (not persisted by the engine — out of scope).

## Side Effects / Blast Radius (required)

- **Affected subsystems:** `experiments/console` run-detail stream only (`event.ts`, `RunStream`, `NodeDivider`, `StreamToolbar`, `RunDetailPage`).
- **Potential unintended effects:** `countTerminalNodes` now derives from `foldNodeRuns` — a fold regression would skew the node counter (guarded by its existing tests). Node-divider repositioning (one per node at `startedAt`) changes ordering vs the old start/end bookends.
- **Guardrails:** ESLint console-isolation rules; `bun test experiments/console/` covers the primitives.

## Rollback Plan (required)

- **Fast rollback:** `git revert <merge-commit>` — single web-only revert, no data/config/flag teardown.
- **Feature flags:** none.
- **Observable failure symptoms:** duplicate node dividers return / node dropdown missing / cost-turns absent / `foldNodeRuns` test failures.

## Risks and Mitigations

- **Risk:** Time-window fallback over-includes a concurrent (parallel-layer) node's events when filtering.
  - **Mitigation:** Acceptable for the focus use case; node-attributed entries still match by exact `nodeId`; default is `All nodes`.
- **Risk:** `foldNodeRuns` precedence drifts from `countTerminalNodes`.
  - **Mitigation:** `countTerminalNodes` is re-expressed via `foldNodeRuns`; its existing test suite is the guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added node filtering to the run timeline—users can now view execution for a specific node
  * Enhanced node status display with execution cost and turn count information
  * Node filter selections now persist automatically in the browser

* **Tests**
  * Added test coverage for node run folding and tool event pairing logic

* **Documentation**
  * Updated README documenting persisted UI state preferences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->