### PR TITLE
feat(web): make /console the default UI, re-root classic UI under /legacy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,7 +389,7 @@ packages/
         ├── experiments/      # Isolated in-repo spikes; lint-guarded against
         │   │                 # importing production web modules. Drop-in or
         │   │                 # delete cleanly. See experiments/README.md.
-        │   └── console/      # Run-centric console UI mounted at /console
+        │   └── console/      # Run-centric console UI — the default at / (classic UI re-rooted under /legacy)
         └── App.tsx           # Router + layout
 ```
 

--- a/packages/docs-web/src/content/docs/adapters/web.md
+++ b/packages/docs-web/src/content/docs/adapters/web.md
@@ -72,7 +72,7 @@ The center of the screen is the chat interface -- this is where you interact wit
 
 ### Command Center (Dashboard)
 
-Accessible via the `/dashboard` route, the Command Center shows all workflow runs across your projects. It includes:
+Accessible via the `/legacy/dashboard` route, the Command Center shows all workflow runs across your projects. It includes:
 
 - **Status summary bar** -- Counts of running, completed, failed, and paused workflows
 - **Workflow run cards** -- Each run shows its status, workflow name, elapsed time, and node progress
@@ -81,7 +81,7 @@ Accessible via the `/dashboard` route, the Command Center shows all workflow run
 
 ### Settings
 
-The `/settings` page lets you configure assistant defaults (model, provider) without editing YAML files. It also includes a **Projects** section for registering and managing codebases.
+The `/legacy/settings` page lets you configure assistant defaults (model, provider) without editing YAML files. It also includes a **Projects** section for registering and managing codebases.
 
 ## Chat Interface
 
@@ -154,7 +154,7 @@ Click the arrow button in the result card header to open the full execution deta
 
 ### Execution Detail Page
 
-Click on a workflow run (from the dashboard or progress card) to open the execution detail page at `/workflows/runs/:runId`. This shows:
+Click on a workflow run (from the dashboard or progress card) to open the execution detail page at `/legacy/workflows/runs/:runId`. This shows:
 
 - The full DAG graph with per-node status
 - Step-by-step logs for each node
@@ -163,7 +163,7 @@ Click on a workflow run (from the dashboard or progress card) to open the execut
 
 ## Workflow Builder
 
-The Workflow Builder at `/workflows/builder` provides a visual editor for creating and modifying workflow YAML files. Features include:
+The Workflow Builder at `/legacy/workflows/builder` provides a visual editor for creating and modifying workflow YAML files. Features include:
 
 - **DAG canvas** -- Drag-and-drop nodes to build your workflow graph visually
 - **Node palette** -- Drag command, prompt, and bash nodes from a sidebar library. Additional node types (`script`, `loop`, `approval`, `cancel`) are editable via the Code / Split view
@@ -175,7 +175,7 @@ The Workflow Builder at `/workflows/builder` provides a visual editor for creati
 - **Delete node** -- Remove a selected node with `Delete` or `Backspace`, the Delete button in the inspector header, or the right-click context menu on any node
 - **Save** -- Saves the workflow YAML to your project's `.archon/workflows/` directory
 
-You can also browse existing workflows on the `/workflows` page and open any of them in the builder to edit.
+You can also browse existing workflows on the `/legacy/workflows` page and open any of them in the builder to edit.
 
 ## SSE Streaming
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -102,7 +102,8 @@ export function App(): React.ReactElement {
                   </SessionGate>
                 }
               >
-                <Route index element={<ChatPage />} />
+                {/* Land on /legacy/chat (not /legacy) so the TopNav Chat tab highlights. */}
+                <Route index element={<Navigate to="chat" replace />} />
                 <Route path="chat" element={<ChatPage />} />
                 <Route path="chat/*" element={<ChatPage />} />
                 <Route path="dashboard" element={<DashboardPage />} />

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -72,6 +72,8 @@ export function App(): React.ReactElement {
             <Routes>
               {/* Login mounts OUTSIDE the SessionGate so it is always reachable. */}
               <Route path="/login" element={<LoginPage />} />
+              {/* The console is now the default UI. */}
+              <Route path="/" element={<Navigate to="/console" replace />} />
               {/*
                 Console mounts OUTSIDE Layout (so it does not inherit TopNav) but
                 still INSIDE SessionGate — otherwise /console would bypass web auth
@@ -87,22 +89,31 @@ export function App(): React.ReactElement {
                   </SessionGate>
                 }
               />
+              {/*
+                Classic UI, re-rooted under /legacy for the deprecation window.
+                The console links here via "Old UI"; /legacy lands on chat. Removed
+                from the codebase once the console has proven itself.
+              */}
               <Route
+                path="/legacy"
                 element={
                   <SessionGate>
                     <Layout />
                   </SessionGate>
                 }
               >
-                <Route path="/" element={<Navigate to="/chat" replace />} />
-                <Route path="/chat" element={<ChatPage />} />
-                <Route path="/chat/*" element={<ChatPage />} />
-                <Route path="/dashboard" element={<DashboardPage />} />
-                <Route path="/workflows" element={<WorkflowsPage />} />
-                <Route path="/workflows/builder" element={<WorkflowBuilderPage />} />
-                <Route path="/workflows/runs/:runId" element={<WorkflowExecutionPage />} />
-                <Route path="/workflows/runs" element={<Navigate to="/workflows" replace />} />
-                <Route path="/settings" element={<SettingsPage />} />
+                <Route index element={<ChatPage />} />
+                <Route path="chat" element={<ChatPage />} />
+                <Route path="chat/*" element={<ChatPage />} />
+                <Route path="dashboard" element={<DashboardPage />} />
+                <Route path="workflows" element={<WorkflowsPage />} />
+                <Route path="workflows/builder" element={<WorkflowBuilderPage />} />
+                <Route path="workflows/runs/:runId" element={<WorkflowExecutionPage />} />
+                <Route
+                  path="workflows/runs"
+                  element={<Navigate to="/legacy/workflows" replace />}
+                />
+                <Route path="settings" element={<SettingsPage />} />
               </Route>
             </Routes>
           </BrowserRouter>

--- a/packages/web/src/components/chat/ChatInterface.tsx
+++ b/packages/web/src/components/chat/ChatInterface.tsx
@@ -628,7 +628,7 @@ export function ChatInterface({ conversationId }: ChatInterfaceProps): React.Rea
           // Cache messages under the new ID so the remounted ChatInterface picks them up
           // (navigate changes the key prop, causing unmount/remount — state is lost otherwise)
           setCachedMessages(newId, [userMsg, thinkingMsg]);
-          navigate(`/chat/${newId}`, { replace: true });
+          navigate(`/legacy/chat/${newId}`, { replace: true });
           // Trigger title + workflow refreshes after AI generates a proper title
           if (!hasTriggeredTitleRefresh.current && !message.startsWith('/')) {
             hasTriggeredTitleRefresh.current = true;

--- a/packages/web/src/components/chat/MessageList.tsx
+++ b/packages/web/src/components/chat/MessageList.tsx
@@ -222,7 +222,7 @@ function WorkflowResultCard({
           )}
           <button
             onClick={(): void => {
-              navigate(`/workflows/runs/${runId}`);
+              navigate(`/legacy/workflows/runs/${runId}`);
             }}
             className="text-[10px] text-primary hover:text-accent-bright transition-colors shrink-0"
           >
@@ -339,7 +339,7 @@ function MessageListRaw({
                 variant="outline"
                 size="sm"
                 onClick={(): void => {
-                  navigate('/workflows');
+                  navigate('/legacy/workflows');
                 }}
                 className="flex items-center gap-1.5"
               >

--- a/packages/web/src/components/chat/WorkflowProgressCard.tsx
+++ b/packages/web/src/components/chat/WorkflowProgressCard.tsx
@@ -103,9 +103,9 @@ export function WorkflowProgressCard({
 
   const handleViewFullScreen = (): void => {
     if (runId) {
-      navigate(`/workflows/runs/${runId}`);
+      navigate(`/legacy/workflows/runs/${runId}`);
     } else {
-      navigate(`/chat/${encodeURIComponent(workerConversationId)}`);
+      navigate(`/legacy/chat/${encodeURIComponent(workerConversationId)}`);
     }
   };
 

--- a/packages/web/src/components/conversations/ConversationItem.tsx
+++ b/packages/web/src/components/conversations/ConversationItem.tsx
@@ -65,7 +65,7 @@ export function ConversationItem({
         setDeleteDialogOpen(false);
         void queryClient.invalidateQueries({ queryKey: ['conversations'] });
         if (params.conversationId === conversation.platform_conversation_id) {
-          void navigate('/');
+          void navigate('/legacy');
         }
       })
       .catch((err: unknown) => {
@@ -109,7 +109,7 @@ export function ConversationItem({
 
   return (
     <NavLink
-      to={`/chat/${encodeURIComponent(conversation.platform_conversation_id)}`}
+      to={`/legacy/chat/${encodeURIComponent(conversation.platform_conversation_id)}`}
       className={({ isActive }): string =>
         cn(
           'group relative flex min-h-[2.75rem] w-full items-start gap-2 rounded-md px-3 py-2 transition-colors duration-150',

--- a/packages/web/src/components/dashboard/WorkflowHistoryTable.tsx
+++ b/packages/web/src/components/dashboard/WorkflowHistoryTable.tsx
@@ -69,7 +69,7 @@ export function WorkflowHistoryTable({
               </td>
               <td className="px-3 py-2">
                 <Link
-                  to={`/workflows/runs/${run.id}`}
+                  to={`/legacy/workflows/runs/${run.id}`}
                   className="text-text-primary hover:text-primary truncate block"
                 >
                   {run.workflow_name}
@@ -96,7 +96,7 @@ export function WorkflowHistoryTable({
               <td className="px-3 py-2">
                 <div className="flex items-center gap-2">
                   <Link
-                    to={`/workflows/runs/${run.id}`}
+                    to={`/legacy/workflows/runs/${run.id}`}
                     className="text-primary hover:text-primary/80 transition-colors"
                   >
                     View Logs

--- a/packages/web/src/components/dashboard/WorkflowRunCard.tsx
+++ b/packages/web/src/components/dashboard/WorkflowRunCard.tsx
@@ -223,7 +223,7 @@ export function WorkflowRunCard({
         {run.parent_platform_id && run.parent_platform_id !== run.worker_platform_id && (
           <button
             onClick={(): void => {
-              navigate(`/chat/${encodeURIComponent(run.parent_platform_id ?? '')}`);
+              navigate(`/legacy/chat/${encodeURIComponent(run.parent_platform_id ?? '')}`);
             }}
             className="flex items-center gap-1 text-primary/80 hover:text-primary transition-colors"
           >
@@ -277,7 +277,7 @@ export function WorkflowRunCard({
       <div className="flex flex-wrap items-center gap-2 pt-1">
         <button
           onClick={(): void => {
-            navigate(`/workflows/runs/${run.id}`);
+            navigate(`/legacy/workflows/runs/${run.id}`);
           }}
           className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-text-secondary hover:bg-surface-elevated hover:text-text-primary transition-colors"
         >
@@ -287,7 +287,7 @@ export function WorkflowRunCard({
         {chatId && (
           <button
             onClick={(): void => {
-              navigate(`/chat/${encodeURIComponent(chatId)}`);
+              navigate(`/legacy/chat/${encodeURIComponent(chatId)}`);
             }}
             className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-text-secondary hover:bg-surface-elevated hover:text-text-primary transition-colors"
           >

--- a/packages/web/src/components/dashboard/WorkflowRunGroup.tsx
+++ b/packages/web/src/components/dashboard/WorkflowRunGroup.tsx
@@ -36,7 +36,7 @@ export function WorkflowRunGroup({
           <div className="h-px flex-1 bg-border" />
           <button
             onClick={(): void => {
-              navigate(`/chat/${encodeURIComponent(parentPlatformId)}`);
+              navigate(`/legacy/chat/${encodeURIComponent(parentPlatformId)}`);
             }}
             className="flex items-center gap-1.5 rounded-full border border-border bg-surface-elevated px-2.5 py-0.5 text-[11px] text-text-secondary hover:border-primary/40 hover:text-primary transition-colors shrink-0"
           >

--- a/packages/web/src/components/layout/Sidebar.tsx
+++ b/packages/web/src/components/layout/Sidebar.tsx
@@ -162,7 +162,7 @@ export function Sidebar(): React.ReactElement {
 
   const handleNewOrchestratorChat = useCallback((): void => {
     setSelectedProjectId(null);
-    navigate('/chat');
+    navigate('/legacy/chat');
   }, [navigate, setSelectedProjectId]);
 
   useKeyboardShortcuts(shortcuts);
@@ -174,7 +174,7 @@ export function Sidebar(): React.ReactElement {
     >
       {/* Logo */}
       <div className="flex flex-col gap-3 p-4">
-        <Link to="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
+        <Link to="/legacy" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
           <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary">
             <span className="text-sm font-semibold text-primary-foreground">A</span>
           </div>

--- a/packages/web/src/components/layout/TopNav.tsx
+++ b/packages/web/src/components/layout/TopNav.tsx
@@ -6,10 +6,10 @@ import { useSession, signOut } from '@/lib/auth-client';
 import { cn } from '@/lib/utils';
 
 const tabs = [
-  { to: '/chat', end: false, icon: MessageSquare, label: 'Chat' },
-  { to: '/dashboard', end: true, icon: LayoutDashboard, label: 'Dashboard' },
-  { to: '/workflows', end: false, icon: Workflow, label: 'Workflows' },
-  { to: '/settings', end: false, icon: Settings, label: 'Settings' },
+  { to: '/legacy/chat', end: false, icon: MessageSquare, label: 'Chat' },
+  { to: '/legacy/dashboard', end: true, icon: LayoutDashboard, label: 'Dashboard' },
+  { to: '/legacy/workflows', end: false, icon: Workflow, label: 'Workflows' },
+  { to: '/legacy/settings', end: false, icon: Settings, label: 'Settings' },
 ] as const;
 
 export function TopNav(): React.ReactElement {
@@ -49,7 +49,10 @@ export function TopNav(): React.ReactElement {
   return (
     <nav className="flex items-center gap-1 border-b border-border bg-surface px-4">
       {/* Brand logo */}
-      <Link to="/chat" className="flex items-center gap-2 mr-4 hover:opacity-80 transition-opacity">
+      <Link
+        to="/legacy/chat"
+        className="flex items-center gap-2 mr-4 hover:opacity-80 transition-opacity"
+      >
         <div className="flex h-7 w-7 items-center justify-center rounded-md bg-primary">
           <span className="text-sm font-semibold text-primary-foreground">A</span>
         </div>
@@ -72,7 +75,7 @@ export function TopNav(): React.ReactElement {
         >
           <Icon className="h-4 w-4" />
           {label}
-          {to === '/dashboard' && runningCount > 0 && (
+          {to === '/legacy/dashboard' && runningCount > 0 && (
             <span
               className="ml-1 inline-flex min-w-[1.25rem] items-center justify-center rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-medium text-primary-foreground"
               aria-label={`${runningCount} workflows running`}

--- a/packages/web/src/components/sidebar/AllConversationsView.tsx
+++ b/packages/web/src/components/sidebar/AllConversationsView.tsx
@@ -52,7 +52,7 @@ export function AllConversationsView({
   }
 
   const handleNewChat = (): void => {
-    navigate('/chat');
+    navigate('/legacy/chat');
   };
 
   const filtered = conversations?.filter(conv => {

--- a/packages/web/src/components/sidebar/ProjectDetail.tsx
+++ b/packages/web/src/components/sidebar/ProjectDetail.tsx
@@ -79,11 +79,11 @@ export function ProjectDetail({
   }, [runs]);
 
   const handleNewChat = (): void => {
-    navigate('/chat');
+    navigate('/legacy/chat');
   };
 
   const handleRunClick = (run: WorkflowRunResponse): void => {
-    navigate(`/workflows/runs/${run.id}`);
+    navigate(`/legacy/workflows/runs/${run.id}`);
   };
 
   // Filter conversations by search

--- a/packages/web/src/components/sidebar/WorkflowInvoker.tsx
+++ b/packages/web/src/components/sidebar/WorkflowInvoker.tsx
@@ -43,7 +43,7 @@ export function WorkflowInvoker({ codebaseId }: WorkflowInvokerProps): React.Rea
       workflowStarted = true;
       setSelectedWorkflow(null);
       setMessage('');
-      navigate(`/chat/${conversationId}`);
+      navigate(`/legacy/chat/${conversationId}`);
     } catch (err) {
       console.error('[WorkflowInvoker] Failed to start workflow', { err });
       setError(err instanceof Error ? err.message : 'Failed to start workflow');

--- a/packages/web/src/components/workflows/BuilderToolbar.tsx
+++ b/packages/web/src/components/workflows/BuilderToolbar.tsx
@@ -97,7 +97,7 @@ export function BuilderToolbar({
             <button
               type="button"
               onClick={(): void => {
-                navigate('/workflows');
+                navigate('/legacy/workflows');
               }}
               className="text-xs text-text-tertiary hover:text-text-secondary shrink-0"
             >

--- a/packages/web/src/components/workflows/WorkflowBuilder.tsx
+++ b/packages/web/src/components/workflows/WorkflowBuilder.tsx
@@ -314,7 +314,7 @@ function WorkflowBuilderInner(): React.ReactElement {
       const result = await createConversation(selectedProjectId ?? undefined);
       const conversationId = result.conversationId;
       await runWorkflow(workflowName.trim(), conversationId, '');
-      navigate(`/chat/${conversationId}`);
+      navigate(`/legacy/chat/${conversationId}`);
     } catch (err) {
       const error = err instanceof Error ? err : new Error('Unknown error');
       console.error('[workflow-builder] workflow.run_failed', { workflowName, error });

--- a/packages/web/src/components/workflows/WorkflowCard.tsx
+++ b/packages/web/src/components/workflows/WorkflowCard.tsx
@@ -180,7 +180,7 @@ export function WorkflowCard({
         </div>
         <div className="flex items-center gap-1">
           <Link
-            to={`/workflows/builder?edit=${encodeURIComponent(workflow.name)}`}
+            to={`/legacy/workflows/builder?edit=${encodeURIComponent(workflow.name)}`}
             onClick={(e): void => {
               e.stopPropagation();
             }}

--- a/packages/web/src/components/workflows/WorkflowExecution.tsx
+++ b/packages/web/src/components/workflows/WorkflowExecution.tsx
@@ -635,7 +635,7 @@ export function WorkflowExecution({ runId }: WorkflowExecutionProps): React.Reac
             if (window.history.length > 1) {
               navigate(-1);
             } else {
-              navigate('/workflows');
+              navigate('/legacy/workflows');
             }
           }}
           className="text-text-secondary hover:text-text-primary transition-colors text-sm"
@@ -652,7 +652,7 @@ export function WorkflowExecution({ runId }: WorkflowExecutionProps): React.Reac
           {workerRunId && (
             <button
               onClick={(): void => {
-                navigate(`/workflows/runs/${workerRunId}`);
+                navigate(`/legacy/workflows/runs/${workerRunId}`);
               }}
               className="flex items-center gap-1 text-xs text-primary hover:text-accent-bright transition-colors"
               title="View workflow run details"

--- a/packages/web/src/components/workflows/WorkflowList.tsx
+++ b/packages/web/src/components/workflows/WorkflowList.tsx
@@ -57,7 +57,7 @@ export function WorkflowList(): React.ReactElement {
       workflowStarted = true;
       setRunMessage('');
       setSelectedWorkflow(null);
-      navigate(`/chat/${conversationId}`);
+      navigate(`/legacy/chat/${conversationId}`);
     } catch (error) {
       console.error('[Workflows] Failed to run workflow', { error });
       setRunError(

--- a/packages/web/src/experiments/console/ConsoleApp.tsx
+++ b/packages/web/src/experiments/console/ConsoleApp.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState, type ReactElement } from 'react';
-import { Routes, Route, Link, useNavigate } from 'react-router';
-import { Settings } from 'lucide-react';
+import { Routes, Route, useNavigate } from 'react-router';
 import { ProjectRail } from './components/ProjectRail';
 import { AddProjectDialog } from './components/AddProjectDialog';
 import { ProjectPalette } from './components/ProjectPalette';
@@ -64,44 +63,6 @@ export function ConsoleApp(): ReactElement {
 
   return (
     <div className="console-root flex h-screen w-screen flex-col bg-surface text-text-primary">
-      <header className="flex h-12 shrink-0 items-center justify-between border-b border-border px-4">
-        <div className="flex items-center gap-2.5">
-          <img
-            src="/favicon.png"
-            alt=""
-            aria-hidden="true"
-            width={22}
-            height={22}
-            className="shrink-0 select-none"
-            draggable={false}
-          />
-          <span className="brand-text text-base font-semibold tracking-tight">Archon</span>
-          <span className="rounded-full border border-border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-text-tertiary">
-            console
-          </span>
-        </div>
-        <div className="flex items-center gap-2">
-          <Link
-            to="/console/settings"
-            title="Settings ( , )"
-            className="flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-[11px] text-text-secondary transition-colors hover:border-border-bright hover:bg-surface-hover hover:text-text-primary"
-          >
-            <Settings aria-hidden className="h-3.5 w-3.5" />
-            Settings
-          </Link>
-          <Link
-            to="/chat"
-            title="Switch back to the classic UI"
-            className="flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-[11px] text-text-secondary transition-colors hover:border-border-bright hover:bg-surface-hover hover:text-text-primary"
-          >
-            <span aria-hidden className="font-mono text-[11px] leading-none">
-              ←
-            </span>
-            Old UI
-          </Link>
-        </div>
-      </header>
-
       <div className="flex min-h-0 flex-1">
         <ProjectRail
           onAddProject={() => {

--- a/packages/web/src/experiments/console/components/ProjectRail.tsx
+++ b/packages/web/src/experiments/console/components/ProjectRail.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useRef, useState, type ReactElement } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router';
-import { Settings, Workflow, ArrowLeft } from 'lucide-react';
+import { Settings, Workflow, ArrowLeft, type LucideIcon } from 'lucide-react';
 import { ProjectRow } from './ProjectRow';
 import { EnvVarsDialog } from './EnvVarsDialog';
 import { useEntity, invalidate } from '../store/cache';
@@ -49,6 +49,29 @@ function writeRailWidth(w: number): void {
   } catch {
     /* ignore */
   }
+}
+
+const RAIL_NAV_LINK_CLASS =
+  'flex w-full items-center gap-2.5 rounded-[10px] px-2.5 py-1.5 text-left text-[13px] font-medium text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary';
+
+/** A row in the rail's bottom nav menu (Settings / Workflows / Old UI). */
+function RailNavLink({
+  to,
+  icon: Icon,
+  label,
+  title,
+}: {
+  to: string;
+  icon: LucideIcon;
+  label: string;
+  title?: string;
+}): ReactElement {
+  return (
+    <Link to={to} title={title} className={RAIL_NAV_LINK_CLASS}>
+      <Icon aria-hidden className="h-3.5 w-3.5 shrink-0" />
+      <span>{label}</span>
+    </Link>
+  );
 }
 
 /**
@@ -274,30 +297,24 @@ export function ProjectRail({ onAddProject }: ProjectRailProps): ReactElement {
       {/* Nav menu — settings + the classic-UI escape hatches, under Add project
           and separated from it by the border-t divider. */}
       <div className="flex flex-col gap-0.5 border-t border-border px-2.5 py-2">
-        <Link
+        <RailNavLink
           to="/console/settings"
+          icon={Settings}
+          label="Settings"
           title="Settings ( , )"
-          className="flex w-full items-center gap-2.5 rounded-[10px] px-2.5 py-1.5 text-left text-[13px] font-medium text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
-        >
-          <Settings aria-hidden className="h-3.5 w-3.5 shrink-0" />
-          <span>Settings</span>
-        </Link>
-        <Link
+        />
+        <RailNavLink
           to="/legacy/workflows"
+          icon={Workflow}
+          label="Workflows"
           title="Workflows (classic UI)"
-          className="flex w-full items-center gap-2.5 rounded-[10px] px-2.5 py-1.5 text-left text-[13px] font-medium text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
-        >
-          <Workflow aria-hidden className="h-3.5 w-3.5 shrink-0" />
-          <span>Workflows</span>
-        </Link>
-        <Link
+        />
+        <RailNavLink
           to="/legacy"
+          icon={ArrowLeft}
+          label="Old UI"
           title="Switch back to the classic UI"
-          className="flex w-full items-center gap-2.5 rounded-[10px] px-2.5 py-1.5 text-left text-[13px] font-medium text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
-        >
-          <ArrowLeft aria-hidden className="h-3.5 w-3.5 shrink-0" />
-          <span>Old UI</span>
-        </Link>
+        />
       </div>
 
       {/* Resize handle */}

--- a/packages/web/src/experiments/console/components/ProjectRail.tsx
+++ b/packages/web/src/experiments/console/components/ProjectRail.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useRef, useState, type ReactElement } from 'react';
-import { useNavigate, useLocation } from 'react-router';
+import { Link, useNavigate, useLocation } from 'react-router';
+import { Settings, Workflow, ArrowLeft } from 'lucide-react';
 import { ProjectRow } from './ProjectRow';
 import { EnvVarsDialog } from './EnvVarsDialog';
 import { useEntity, invalidate } from '../store/cache';
@@ -125,8 +126,23 @@ export function ProjectRail({ onAddProject }: ProjectRailProps): ReactElement {
       style={{ width, flexBasis: width }}
       className="relative flex h-full shrink-0 flex-col border-r border-border bg-surface-inset"
     >
-      {/* Header: label + count + filter */}
+      {/* Header: brand + label + count + filter */}
       <div className="px-3.5 pb-2.5 pt-4">
+        <div className="flex items-center gap-2.5 px-1 pb-4">
+          <img
+            src="/favicon.png"
+            alt=""
+            aria-hidden="true"
+            width={22}
+            height={22}
+            className="shrink-0 select-none"
+            draggable={false}
+          />
+          <span className="brand-text text-base font-semibold tracking-tight">Archon</span>
+          <span className="rounded-full border border-border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-text-tertiary">
+            console
+          </span>
+        </div>
         <div className="flex items-center gap-2 px-1 pb-3">
           <span className="font-mono text-[11px] font-bold uppercase tracking-[0.14em] text-text-tertiary">
             Projects
@@ -253,6 +269,35 @@ export function ProjectRail({ onAddProject }: ProjectRailProps): ReactElement {
           </span>
           <span>Add project</span>
         </button>
+      </div>
+
+      {/* Nav menu — settings + the classic-UI escape hatches, under Add project
+          and separated from it by the border-t divider. */}
+      <div className="flex flex-col gap-0.5 border-t border-border px-2.5 py-2">
+        <Link
+          to="/console/settings"
+          title="Settings ( , )"
+          className="flex w-full items-center gap-2.5 rounded-[10px] px-2.5 py-1.5 text-left text-[13px] font-medium text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
+        >
+          <Settings aria-hidden className="h-3.5 w-3.5 shrink-0" />
+          <span>Settings</span>
+        </Link>
+        <Link
+          to="/legacy/workflows"
+          title="Workflows (classic UI)"
+          className="flex w-full items-center gap-2.5 rounded-[10px] px-2.5 py-1.5 text-left text-[13px] font-medium text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
+        >
+          <Workflow aria-hidden className="h-3.5 w-3.5 shrink-0" />
+          <span>Workflows</span>
+        </Link>
+        <Link
+          to="/legacy"
+          title="Switch back to the classic UI"
+          className="flex w-full items-center gap-2.5 rounded-[10px] px-2.5 py-1.5 text-left text-[13px] font-medium text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
+        >
+          <ArrowLeft aria-hidden className="h-3.5 w-3.5 shrink-0" />
+          <span>Old UI</span>
+        </Link>
       </div>
 
       {/* Resize handle */}

--- a/packages/web/src/routes/ChatPage.tsx
+++ b/packages/web/src/routes/ChatPage.tsx
@@ -136,7 +136,7 @@ export function ChatPage(): React.ReactElement {
   );
 
   const handleNewChat = useCallback((): void => {
-    navigate('/chat');
+    navigate('/legacy/chat');
   }, [navigate]);
 
   const handleAddSubmit = useCallback((): void => {

--- a/packages/web/src/routes/WorkflowsPage.tsx
+++ b/packages/web/src/routes/WorkflowsPage.tsx
@@ -8,7 +8,7 @@ export function WorkflowsPage(): React.ReactElement {
       <div className="flex items-center justify-between px-4 pt-4 pb-2">
         <h1 className="text-lg font-semibold text-text-primary">Workflows</h1>
         <Link
-          to="/workflows/builder"
+          to="/legacy/workflows/builder"
           className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-white hover:bg-primary/90 transition-colors"
         >
           <Plus className="size-4" />


### PR DESCRIPTION
## Summary

- **Problem:** The run-centric console (`/console`) was a peer route behind a top-banner "Old UI" link; the default landing was still `/` → `/chat`. To make the console the primary UI it has to *be* the default, with the classic UI kept reachable during a deprecation window.
- **Why it matters:** First half of the console cutover — flips the default and establishes the legacy escape hatch so the chat + dashboard surfaces can be retired to the console.
- **What changed:** `/` → `/console` default; classic UI re-rooted under `/legacy`; the console's top banner moved into the left sidebar (brand at top, a Settings/Workflows/Old-UI menu under "Add project" with a divider); ~27 absolute old-UI links prefixed with `/legacy`; cross-UI buttons wired both ways.
- **What did *not* change (scope boundary):** No backend/API/schema/DB. The legacy workflow **builder** is kept as-is (console links out to it — not rebuilt). Chat uploads + run-stream polish are a separate decoupled PR (PR-B). `/api/*` and `/console` links untouched. Login still lands on `/` → `/console`.

## UX Journey

### Before
```
visit /                → redirect to /chat (classic UI is the default)
/console               → peer route; top banner has logo + Settings + "← Old UI" (→ /chat)
classic UI nav         → /chat, /dashboard, /workflows, /settings
```

### After
```
visit /                → *redirect to /console* (console is the default)
/console               → *no top banner*; brand heads the sidebar; a menu under
                         "Add project" (divider) → Settings, Workflows (/legacy), *Old UI (/legacy)*
/legacy                → *classic UI, lands on chat*; nav re-prefixed /legacy/*;
                         TopNav "new UI" button → /console (return path)
```

## Architecture Diagram

### After
```
App.tsx <Routes> [~]
  /            → Navigate to /console            [+]
  /console/*   → SessionGate › ConsoleApp        (unchanged mount)
  /legacy      → SessionGate › Layout            [~ was pathless; now /legacy]
     index→Chat, chat, dashboard, workflows[/builder][/runs], settings  [~ relative]
  /login       → LoginPage                       (unchanged)

ConsoleApp.tsx [~]  — top <header> banner DELETED
        │
        ▼
ProjectRail.tsx [~]  — brand row (top) + nav menu (bottom, border-t divider):
        Settings → /console/settings · Workflows → /legacy/workflows · Old UI → /legacy

old-UI components ×19 [~] — every absolute /chat|/dashboard|/workflows|/settings link → /legacy/*
        (TopNav tabs+brand+badge-compare, Sidebar, chat/dashboard/workflows/sidebar/conversations)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `App.tsx /` | `/console` | **new** | default redirect (was → /chat) |
| `App.tsx` Layout group | `/legacy/*` | **modified** | re-rooted (was pathless absolute) |
| `ConsoleApp` | top banner | **removed** | relocated into rail |
| `ProjectRail` | `/console/settings`, `/legacy/workflows`, `/legacy` | **new** | sidebar menu |
| old-UI ×19 | `/legacy/*` | **modified** | ~27 absolute links prefixed |
| `TopNav` | `/console` | unchanged | the "new UI" return CTA |

## Label Snapshot
- Risk: `risk: medium` (routing blast radius; mechanical link-prefixing)
- Size: `size: M`
- Scope: `web`
- Module: `web:routing`, `web:experiments/console`

## Change Metadata
- Change type: `feature`
- Primary scope: `web`

## Linked Issue
- Related: console roadmap cutover. Follow-ups: #1912 (legacy deprecation lifecycle / bookmark redirects). Sibling PR: uploads + polish (PR-B, separate).

## Validation Evidence (required)
```bash
tsc --noEmit -p packages/web/tsconfig.json   # exit 0
eslint --max-warnings 0 (22 changed files)   # clean (lint-staged also ran --fix)
prettier --check                              # clean
```
- **Evidence:** Manual walkthrough on the running app — `/` redirects to `/console` (no top banner; brand atop the rail; Settings/Workflows/Old-UI menu under "Add project"); `/legacy` loads classic chat with every nav link prefixed (`/legacy/chat|dashboard|workflows|settings`); "Old UI" ⇄ "new UI" round-trip works. Verified no `/legacy/legacy` double-prefix, `/console` CTA + `/api/*` untouched, and the `to === '/legacy/dashboard'` badge comparison stays consistent with the prefixed tab.
- **Skipped:** full `bun run validate` (worktree `bun --filter type-check` mis-resolves `bun-types`, an env quirk; direct `tsc -p packages/web` is clean). Web-only change — `check:bundled*` unaffected. CI runs full validate.

## Security Impact (required)
- New permissions/capabilities? **No** · New external network calls? **No** · Secrets/tokens changed? **No** · FS scope changed? **No**

Routing + presentational only. `SessionGate` still wraps `/console` and `/legacy`, so web-auth gating is preserved for both.

## Compatibility / Migration
- Backward compatible? **Mostly** — in-app nav fully preserved; external bookmarks to old top-level paths (`/chat`, `/dashboard`, …) now 404 (only `/`→`/console` and `/legacy/*` resolve). Compat redirects deferred to #1912.
- Config/env changes? **No** · DB migration? **No**

## Human Verification (required)
- **Verified:** default redirect; sidebar brand + menu; legacy classic UI with prefixed nav; both cross-UI buttons; SessionGate intact.
- **Edge cases:** badge-comparison consistency; query-string link (`/legacy/workflows/builder?edit=`) preserved; template-literal navigates (`/legacy/chat/${id}`) prefixed; console's own `/console/p/:id/chat` left alone.
- **Not verified:** every legacy deep-link by hand (mechanical prefix, grep-verified complete); web-auth-enabled mode (gating structurally unchanged).

## Side Effects / Blast Radius (required)
- **Affected:** all routing; the console shell; ~19 old-UI files (link strings only).
- **Potential unintended effects:** a missed absolute link would navigate out of `/legacy` to a dead path — swept with grep (zero remaining unprefixed; zero double-prefix).
- **Guardrails:** tsc + eslint; the `/legacy/legacy` and unprefixed-link greps are re-runnable.

## Rollback Plan (required)
- **Fast rollback:** `git revert <merge-commit>` — pure web routing/presentational revert; no data/config/flag teardown.
- **Feature flags:** none.
- **Symptoms:** `/` lands on classic UI again / console keeps its top banner / legacy nav 404s.

## Risks and Mitigations
- **Risk:** a legacy absolute link missed by the prefix sweep → dead navigation.
  - **Mitigation:** grep verified zero remaining unprefixed `/chat|/dashboard|/workflows|/settings` nav links and zero `/legacy/legacy`; tsc/eslint clean.
- **Risk:** external bookmarks to old paths 404 during the window.
  - **Mitigation:** accepted for the deprecation window; the console "Old UI" button covers the in-app path; compat redirects tracked in #1912.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Console interface is now the default UI at the application root
  * Added quick navigation in console to access Settings, legacy workflows, and switch to classic UI

* **Updates**
  * Classic chat, dashboard, builder and workflow pages re-rooted under a /legacy namespace
  * App-wide navigation and redirects updated so links and actions point to the new routing structure

* **Documentation**
  * Web UI docs updated to reflect new console/default and legacy routes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->