### PR TITLE
feat(web/console): wire chat file uploads + cap tool-call input height

### DIFF
--- a/packages/web/src/experiments/console/README.md
+++ b/packages/web/src/experiments/console/README.md
@@ -14,6 +14,15 @@ Mounted at `/console/*`. Not part of the shipped product. Validates the mental m
 - `/console/p/:projectId/chat` → Project-scoped agent chat
 - `/console/p/:projectId/r/:runId` → Run detail
 
+## Chat uploads
+
+The composer's 📎 attaches files (≤5, ≤10 MB each, type-guarded client-side; the
+server validates authoritatively) and sends them via the existing multipart
+`sendMessage`. **Limitation:** files can't ride the *first* message of a brand-new
+conversation (`createConversation` is JSON-only) — the UI shows a notice to
+re-attach once the chat exists. Drag-drop / paste / optimistic chips are tracked
+in #1913.
+
 ## Constraints
 
 - **Isolated.** Forbidden imports from `packages/web/src/{components,stores,contexts,routes,hooks}` and `@tanstack/react-query`, `@/lib/api` (function exports). Enforced by ESLint. Type-only imports from `@/lib/api.generated` are allowed.

--- a/packages/web/src/experiments/console/components/ChatComposer.tsx
+++ b/packages/web/src/experiments/console/components/ChatComposer.tsx
@@ -1,24 +1,83 @@
 import { useRef, useState, type KeyboardEvent, type ReactElement } from 'react';
 
 interface ChatComposerProps {
-  onSend: (message: string) => void;
+  onSend: (message: string, files?: File[]) => void;
   disabled: boolean;
   disabledReason?: string;
 }
 
 const MAX_HEIGHT = 200;
+const MAX_FILES = 5;
+const MAX_FILE_BYTES = 10 * 1024 * 1024; // 10 MB
+
+// Picker hint + a light client-side type guard. The server does the
+// authoritative validation; this is UX only. Mirrors the old MessageInput's
+// accepted set (copied, not imported — the console may not import @/components).
+const ACCEPTED_EXTENSIONS_LIST = [
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.pdf',
+  '.md',
+  '.txt',
+  '.csv',
+  '.json',
+  '.yaml',
+  '.yml',
+  '.toml',
+  '.log',
+  '.html',
+  '.css',
+  '.js',
+  '.jsx',
+  '.ts',
+  '.tsx',
+  '.py',
+  '.rb',
+  '.go',
+  '.rs',
+  '.java',
+  '.c',
+  '.cpp',
+  '.h',
+  '.sh',
+  '.sql',
+];
+const ACCEPTED_EXTENSIONS = ACCEPTED_EXTENSIONS_LIST.join(',');
+const ACCEPTED_SET = new Set(ACCEPTED_EXTENSIONS_LIST);
+
+function isAcceptedFileType(file: File): boolean {
+  if (file.type.startsWith('text/') || file.type.startsWith('image/')) return true;
+  if (file.type === 'application/pdf' || file.type === 'application/json') return true;
+  // Many code/config files report an empty MIME type — fall back to the extension.
+  const dot = file.name.lastIndexOf('.');
+  return dot !== -1 && ACCEPTED_SET.has(file.name.slice(dot).toLowerCase());
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${String(bytes)} B`;
+  if (bytes < 1024 * 1024) return `${String(Math.round(bytes / 1024))} KB`;
+  return `${String(Math.round(bytes / (1024 * 1024)))} MB`;
+}
+
+interface PickedFile {
+  file: File;
+  id: string;
+}
 
 /**
  * Console-native chat composer. Auto-growing textarea, Enter sends,
- * Shift+Enter newline, Escape blurs. Text-only for the MVP — file attachment
- * (sendMessage already supports `files`) is a deferred enhancement.
+ * Shift+Enter newline, Escape blurs. Click-to-attach files via 📎 (the send
+ * skill builds the multipart upload).
  *
  * Reimplemented (not imported) from the old chat's MessageInput because the
  * console may not import production `@/components/**` (ESLint isolation rule).
  *
  * Direction-B `cbox` shell: rounded card with `:focus-within` magenta ring,
- * decorative 📎 + `/` lead buttons (inert in MVP), gradient `.brand-bar`
- * Send button + glow, kbd-hint row beneath.
+ * 📎 attach + decorative `/` lead buttons, gradient `.brand-bar` Send button +
+ * glow, kbd-hint row beneath. Attached files render as removable chips above.
  */
 export function ChatComposer({
   onSend,
@@ -26,7 +85,11 @@ export function ChatComposer({
   disabledReason,
 }: ChatComposerProps): ReactElement {
   const [value, setValue] = useState('');
+  const [files, setFiles] = useState<PickedFile[]>([]);
+  const [fileError, setFileError] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const idRef = useRef(0);
 
   const grow = (el: HTMLTextAreaElement): void => {
     el.style.height = 'auto';
@@ -35,11 +98,41 @@ export function ChatComposer({
     el.style.overflowY = next >= MAX_HEIGHT ? 'auto' : 'hidden';
   };
 
+  const addFiles = (incoming: File[]): void => {
+    let err: string | null = null;
+    const next = [...files];
+    for (const file of incoming) {
+      if (next.length >= MAX_FILES) {
+        err = `Up to ${String(MAX_FILES)} files.`;
+        break;
+      }
+      if (file.size > MAX_FILE_BYTES) {
+        err = `${file.name} is larger than ${String(MAX_FILE_BYTES / (1024 * 1024))} MB.`;
+        continue;
+      }
+      if (!isAcceptedFileType(file)) {
+        err = `${file.name} is not a supported file type.`;
+        continue;
+      }
+      next.push({ file, id: String(idRef.current++) });
+    }
+    setFiles(next);
+    setFileError(err);
+  };
+
+  const removeFile = (id: string): void => {
+    setFiles(prev => prev.filter(f => f.id !== id));
+    setFileError(null);
+  };
+
   const submit = (): void => {
     const trimmed = value.trim();
     if (trimmed.length === 0 || disabled) return;
-    onSend(trimmed);
+    onSend(trimmed, files.length > 0 ? files.map(f => f.file) : undefined);
     setValue('');
+    setFiles([]);
+    setFileError(null);
+    if (fileInputRef.current !== null) fileInputRef.current.value = '';
     if (textareaRef.current !== null) {
       textareaRef.current.style.height = 'auto';
       textareaRef.current.focus();
@@ -63,6 +156,37 @@ export function ChatComposer({
       title={disabledReason}
     >
       <div className="mx-auto max-w-[940px]">
+        {files.length > 0 ? (
+          <div className="mb-[10px] flex flex-wrap gap-[6px]">
+            {files.map(f => (
+              <span
+                key={f.id}
+                className="flex items-center gap-[6px] rounded-[8px] border bg-[color:var(--surface-elevated)] py-[4px] pl-[9px] pr-[5px] text-[11.5px]"
+                style={{ borderColor: 'var(--border-bright)' }}
+              >
+                <span className="max-w-[180px] truncate text-text-primary">{f.file.name}</span>
+                <span className="font-mono text-[10px] text-text-tertiary">
+                  {formatBytes(f.file.size)}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => {
+                    removeFile(f.id);
+                  }}
+                  aria-label={`Remove ${f.file.name}`}
+                  className="rounded p-[1px] text-text-tertiary transition-colors hover:bg-[color:var(--surface-hover)] hover:text-text-primary"
+                >
+                  <span aria-hidden className="text-[11px] leading-none">
+                    ✕
+                  </span>
+                </button>
+              </span>
+            ))}
+          </div>
+        ) : null}
+        {fileError !== null ? (
+          <div className="mb-[8px] font-mono text-[11px] text-error">{fileError}</div>
+        ) : null}
         <div
           className="flex items-end gap-[10px] rounded-[14px] border bg-[color:var(--surface-elevated)] py-[8px] pl-[14px] pr-[8px] transition-[border-color,box-shadow] focus-within:border-[color:color-mix(in_oklch,var(--brand-magenta),transparent_40%)] focus-within:shadow-[0_0_0_4px_color-mix(in_oklch,var(--brand-magenta),transparent_92%)]"
           style={{ borderColor: 'var(--border-bright)' }}
@@ -70,14 +194,26 @@ export function ChatComposer({
           <div className="flex shrink-0 items-end gap-[6px] pb-[7px] text-text-tertiary">
             <button
               type="button"
-              tabIndex={-1}
+              onClick={() => {
+                fileInputRef.current?.click();
+              }}
               aria-label="Attach files"
-              disabled
-              title="Attach (coming soon)"
+              disabled={disabled || files.length >= MAX_FILES}
+              title="Attach files"
               className="rounded-md p-[3px] transition-colors hover:bg-[color:var(--surface-hover)] hover:text-text-primary disabled:cursor-default disabled:opacity-50"
             >
               📎
             </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              accept={ACCEPTED_EXTENSIONS}
+              className="hidden"
+              onChange={e => {
+                if (e.target.files !== null) addFiles(Array.from(e.target.files));
+              }}
+            />
             <button
               type="button"
               tabIndex={-1}

--- a/packages/web/src/experiments/console/components/ChatComposer.tsx
+++ b/packages/web/src/experiments/console/components/ChatComposer.tsx
@@ -1,4 +1,12 @@
 import { useRef, useState, type KeyboardEvent, type ReactElement } from 'react';
+import {
+  ACCEPTED_EXTENSIONS,
+  MAX_FILES,
+  MAX_FILE_BYTES,
+  MAX_FILE_MB,
+  formatBytes,
+  isAcceptedFileType,
+} from '../primitives/file';
 
 interface ChatComposerProps {
   onSend: (message: string, files?: File[]) => void;
@@ -7,60 +15,6 @@ interface ChatComposerProps {
 }
 
 const MAX_HEIGHT = 200;
-const MAX_FILES = 5;
-const MAX_FILE_BYTES = 10 * 1024 * 1024; // 10 MB
-
-// Picker hint + a light client-side type guard. The server does the
-// authoritative validation; this is UX only. Mirrors the old MessageInput's
-// accepted set (copied, not imported — the console may not import @/components).
-const ACCEPTED_EXTENSIONS_LIST = [
-  '.png',
-  '.jpg',
-  '.jpeg',
-  '.gif',
-  '.webp',
-  '.pdf',
-  '.md',
-  '.txt',
-  '.csv',
-  '.json',
-  '.yaml',
-  '.yml',
-  '.toml',
-  '.log',
-  '.html',
-  '.css',
-  '.js',
-  '.jsx',
-  '.ts',
-  '.tsx',
-  '.py',
-  '.rb',
-  '.go',
-  '.rs',
-  '.java',
-  '.c',
-  '.cpp',
-  '.h',
-  '.sh',
-  '.sql',
-];
-const ACCEPTED_EXTENSIONS = ACCEPTED_EXTENSIONS_LIST.join(',');
-const ACCEPTED_SET = new Set(ACCEPTED_EXTENSIONS_LIST);
-
-function isAcceptedFileType(file: File): boolean {
-  if (file.type.startsWith('text/') || file.type.startsWith('image/')) return true;
-  if (file.type === 'application/pdf' || file.type === 'application/json') return true;
-  // Many code/config files report an empty MIME type — fall back to the extension.
-  const dot = file.name.lastIndexOf('.');
-  return dot !== -1 && ACCEPTED_SET.has(file.name.slice(dot).toLowerCase());
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${String(bytes)} B`;
-  if (bytes < 1024 * 1024) return `${String(Math.round(bytes / 1024))} KB`;
-  return `${String(Math.round(bytes / (1024 * 1024)))} MB`;
-}
 
 interface PickedFile {
   file: File;
@@ -99,25 +53,31 @@ export function ChatComposer({
   };
 
   const addFiles = (incoming: File[]): void => {
-    let err: string | null = null;
     const next = [...files];
+    // Accumulate every rejection reason (not just the last) so a mixed pick
+    // surfaces all of them.
+    const skipped: string[] = [];
     for (const file of incoming) {
       if (next.length >= MAX_FILES) {
-        err = `Up to ${String(MAX_FILES)} files.`;
-        break;
+        skipped.push(`${file.name}: over the ${String(MAX_FILES)}-file limit`);
+        continue;
       }
       if (file.size > MAX_FILE_BYTES) {
-        err = `${file.name} is larger than ${String(MAX_FILE_BYTES / (1024 * 1024))} MB.`;
+        skipped.push(`${file.name}: larger than ${String(MAX_FILE_MB)} MB`);
         continue;
       }
       if (!isAcceptedFileType(file)) {
-        err = `${file.name} is not a supported file type.`;
+        skipped.push(`${file.name}: unsupported type`);
         continue;
       }
       next.push({ file, id: String(idRef.current++) });
     }
     setFiles(next);
-    setFileError(err);
+    setFileError(
+      skipped.length > 0
+        ? `Skipped ${String(skipped.length)} file(s) — ${skipped.join('; ')}`
+        : null
+    );
   };
 
   const removeFile = (id: string): void => {

--- a/packages/web/src/experiments/console/components/ToolCallItem.tsx
+++ b/packages/web/src/experiments/console/components/ToolCallItem.tsx
@@ -98,7 +98,7 @@ export function ToolCallItem({ call, timestamp }: ToolCallItemProps): ReactEleme
       {expanded && hasDetails ? (
         <div className="ml-[72px] mt-2 space-y-1.5">
           {Object.keys(call.input).length > 0 ? (
-            <pre className="overflow-x-auto rounded border border-border bg-surface-inset p-2 font-mono text-[11px] leading-relaxed text-text-secondary">
+            <pre className="max-h-[320px] overflow-auto rounded border border-border bg-surface-inset p-2 font-mono text-[11px] leading-relaxed text-text-secondary">
               {JSON.stringify(call.input, null, 2)}
             </pre>
           ) : null}

--- a/packages/web/src/experiments/console/console-open-questions.md
+++ b/packages/web/src/experiments/console/console-open-questions.md
@@ -113,8 +113,10 @@ flaky) deserves hardening.
 
 ## 8. Smaller gaps worth tracking
 
-- **File attachments** in the composer (backend supports multipart; composer is
-  text-only).
+- ~~**File attachments** in the composer~~ — shipped (click-to-attach 📎 →
+  multipart send). Remaining: drag-drop / paste-image / optimistic chips on the
+  sent bubble (#1913), and first-message uploads (createConversation is
+  JSON-only — surfaced as a notice, not supported).
 - **Provider/model per conversation** — not selectable in chat.
 - **Keyboard shortcuts** for chat (new chat, focus composer, approve) — the rest
   of the console is keyboard-driven; chat isn't.

--- a/packages/web/src/experiments/console/primitives/file.test.ts
+++ b/packages/web/src/experiments/console/primitives/file.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from 'bun:test';
+import { isAcceptedFileType, formatBytes } from './file';
+
+const file = (name: string, type = ''): File => new File(['x'], name, { type });
+
+describe('isAcceptedFileType', () => {
+  test('accepts by MIME — text/*, image/*, pdf, json', () => {
+    expect(isAcceptedFileType(file('a', 'text/plain'))).toBe(true);
+    expect(isAcceptedFileType(file('a', 'image/png'))).toBe(true);
+    expect(isAcceptedFileType(file('a', 'application/pdf'))).toBe(true);
+    expect(isAcceptedFileType(file('a', 'application/json'))).toBe(true);
+  });
+
+  test('accepts by extension when the MIME type is empty (code/config files)', () => {
+    expect(isAcceptedFileType(file('main.py'))).toBe(true);
+    expect(isAcceptedFileType(file('schema.sql'))).toBe(true);
+    expect(isAcceptedFileType(file('Config.YAML'))).toBe(true); // case-insensitive
+  });
+
+  test('rejects an unknown extension with an empty MIME', () => {
+    expect(isAcceptedFileType(file('archive.zip'))).toBe(false);
+    expect(isAcceptedFileType(file('binary.exe'))).toBe(false);
+  });
+
+  test('rejects no-extension files and dotfiles', () => {
+    expect(isAcceptedFileType(file('Makefile'))).toBe(false);
+    expect(isAcceptedFileType(file('.gitignore'))).toBe(false);
+  });
+});
+
+describe('formatBytes', () => {
+  test('formats B / KB / MB', () => {
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(2048)).toBe('2 KB');
+    expect(formatBytes(5 * 1024 * 1024)).toBe('5 MB');
+  });
+});

--- a/packages/web/src/experiments/console/primitives/file.ts
+++ b/packages/web/src/experiments/console/primitives/file.ts
@@ -1,0 +1,72 @@
+/**
+ * Chat file-attachment limits + client-side validation.
+ *
+ * These are UX hints only — the server is the authoritative validator of
+ * uploads. The accepted-extension list is an *approximate subset* of the old
+ * production MessageInput's set (copied, not imported — the console may not
+ * import `@/components/**`), so it can drift; a file the picker hides may still
+ * be accepted by the server. Kept conservative on purpose.
+ */
+
+export const MAX_FILES = 5;
+export const MAX_FILE_MB = 10;
+export const MAX_FILE_BYTES = MAX_FILE_MB * 1024 * 1024;
+
+const ACCEPTED_EXTENSIONS_LIST = [
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.pdf',
+  '.md',
+  '.txt',
+  '.csv',
+  '.json',
+  '.yaml',
+  '.yml',
+  '.toml',
+  '.log',
+  '.html',
+  '.css',
+  '.js',
+  '.jsx',
+  '.ts',
+  '.tsx',
+  '.py',
+  '.rb',
+  '.go',
+  '.rs',
+  '.java',
+  '.c',
+  '.cpp',
+  '.h',
+  '.sh',
+  '.sql',
+];
+
+/** Comma-separated string for the file input's `accept` attribute. */
+export const ACCEPTED_EXTENSIONS = ACCEPTED_EXTENSIONS_LIST.join(',');
+
+const ACCEPTED_SET = new Set(ACCEPTED_EXTENSIONS_LIST);
+
+/**
+ * True if the file looks acceptable. Prefers the reported MIME type; falls back
+ * to the extension because many code/config files report an empty MIME type. A
+ * file with no extension and a non-text/non-image MIME is rejected.
+ */
+export function isAcceptedFileType(file: File): boolean {
+  // Strip any `;charset=…` parameter — some sources (and Bun's File) append one.
+  const mime = (file.type.split(';')[0] ?? '').trim();
+  if (mime.startsWith('text/') || mime.startsWith('image/')) return true;
+  if (mime === 'application/pdf' || mime === 'application/json') return true;
+  const dot = file.name.lastIndexOf('.');
+  if (dot <= 0) return false; // no extension, or a dotfile like `.gitignore` (no real ext)
+  return ACCEPTED_SET.has(file.name.slice(dot).toLowerCase());
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${String(bytes)} B`;
+  if (bytes < 1024 * 1024) return `${String(Math.round(bytes / 1024))} KB`;
+  return `${String(Math.round(bytes / (1024 * 1024)))} MB`;
+}

--- a/packages/web/src/experiments/console/routes/ChatPage.tsx
+++ b/packages/web/src/experiments/console/routes/ChatPage.tsx
@@ -72,6 +72,9 @@ export function ChatPage(): ReactElement {
   // connects (which it can, cross-origin in dev). SSE is a pure accelerator.
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Non-error advisory (distinct channel from `error` so it doesn't read as a
+  // send failure) — e.g. files dropped from a first message.
+  const [notice, setNotice] = useState<string | null>(null);
 
   // Turn-completion state. The settle timer (below) is the correctness floor — it
   // works even when SSE is absent. The SSE lock event is a fast-path on top of it.
@@ -151,6 +154,7 @@ export function ChatPage(): ReactElement {
   const onSend = (text: string, files?: File[]): void => {
     if (projectId === undefined) return;
     setError(null);
+    setNotice(null);
     setBusy(true); // optimistic: disable the composer immediately
     void (async (): Promise<void> => {
       try {
@@ -160,11 +164,12 @@ export function ChatPage(): ReactElement {
           invalidate(K.conversations(projectId));
           invalidate(K.messages(conv.conversationId));
           // createConversation is JSON-only — files can't ride the first message.
-          // Surface it (not silently dropped) so the user can re-attach now that
-          // the conversation exists.
+          // Surface it as a non-error notice (not silently dropped); phrased so
+          // it's actionable once the agent replies (the composer is locked while
+          // `busy`), not "now".
           if (files !== undefined && files.length > 0) {
-            setError(
-              'Files are not attached to the first message — re-attach them now that the chat has started.'
+            setNotice(
+              "Files aren't attached to the first message of a new chat — re-attach and send them once the chat has started."
             );
           }
         } else {
@@ -293,6 +298,12 @@ export function ChatPage(): ReactElement {
       </div>
 
       <WorkflowDock projectId={projectId} />
+
+      {notice !== null ? (
+        <div className="shrink-0 border-t border-warning/30 bg-warning/[0.06] px-6 py-2 font-mono text-[11px] text-warning">
+          {notice}
+        </div>
+      ) : null}
 
       {error !== null || loadError !== undefined ? (
         <div className="shrink-0 border-t border-error/30 bg-error/[0.06] px-6 py-2 font-mono text-[11px] text-error">

--- a/packages/web/src/experiments/console/routes/ChatPage.tsx
+++ b/packages/web/src/experiments/console/routes/ChatPage.tsx
@@ -148,7 +148,7 @@ export function ChatPage(): ReactElement {
   // Reveal the raw tool trace inline (toggled from the working indicator).
   const [showTools, setShowTools] = useState(false);
 
-  const onSend = (text: string): void => {
+  const onSend = (text: string, files?: File[]): void => {
     if (projectId === undefined) return;
     setError(null);
     setBusy(true); // optimistic: disable the composer immediately
@@ -159,8 +159,16 @@ export function ChatPage(): ReactElement {
           setActiveConvId(conv.conversationId);
           invalidate(K.conversations(projectId));
           invalidate(K.messages(conv.conversationId));
+          // createConversation is JSON-only — files can't ride the first message.
+          // Surface it (not silently dropped) so the user can re-attach now that
+          // the conversation exists.
+          if (files !== undefined && files.length > 0) {
+            setError(
+              'Files are not attached to the first message — re-attach them now that the chat has started.'
+            );
+          }
         } else {
-          await skill.sendMessage(activeConvId, text);
+          await skill.sendMessage(activeConvId, text, files);
           invalidate(K.messages(activeConvId));
         }
       } catch (e: unknown) {


### PR DESCRIPTION
## Summary

- **Problem:** The console chat composer's 📎 was a decorative, disabled no-op (text-only MVP), and the run-stream's expanded tool-call input dumped unbounded JSON — a wall of text on busy nodes (e.g. a 130-tool `TodoWrite`).
- **Why it matters:** Second half of the console cutover (polish). Uploads are table-stakes for a default chat UI; the tool-input cap makes a real multi-node run scannable.
- **What changed:** Wired the 📎 to a file picker with removable chips + client-side size/count/type guards, threaded through the existing multipart send skill; capped the expanded tool-input `<pre>` to a scrollable height.
- **What did *not* change (scope boundary):** No backend/API/skill change — `skill.sendMessage` already built the multipart upload. Independent of PR-A (the structural cutover) — different files, no routing dependency. Drag-drop/paste, optimistic file chips on the sent bubble, and first-message uploads are out of scope (tracked: #1913).

## UX Journey

### Before
```
composer:  [📎 disabled "coming soon"] [/ disabled]  textarea  [Send]
tool call (expanded):  input <pre> → full JSON.stringify, no height cap → wall of text
```

### After
```
composer:  *[📎 opens file picker]* [/ inert]  textarea  [Send]
           *attached → chips above: name · size · ✕   (≤5 files, ≤10 MB, type-guarded)*
           send → text + files → skill.sendMessage (multipart, pre-existing)
tool call (expanded):  input <pre> *max-h-[320px] overflow-auto* → scannable, scrollable
```

## Architecture Diagram

### After
```
ChatComposer.tsx [~]
  📎 → fileInputRef.click() → <input type=file multiple accept=…> (hidden)
  addFiles() → size/count/type guard → chips (name·size·✕)
  submit(text, files?) ─────────────┐
                                     ▼
ChatPage.tsx [~] onSend(text, files?)
  activeConvId → skill.sendMessage(id, text, files)   (multipart — UNCHANGED skill)
  no conv yet  → createConversation(text); files notice (JSON-only first message)

ToolCallItem.tsx [~]  input <pre> → + max-h-[320px] overflow-auto   (presentational)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `ChatComposer` 📎 | hidden file input | **new** | click-to-attach |
| `ChatComposer.submit` | `onSend(text, files?)` | **modified** | prop widened |
| `ChatPage.onSend` | `skill.sendMessage(id, text, files)` | **modified** | forwards files |
| `skill.sendMessage` | `/api/conversations/:id/message` (multipart) | unchanged | already supported |
| `ToolCallItem` input `<pre>` | — | **modified** | height cap only |

## Label Snapshot
- Risk: `risk: low`
- Size: `size: S`
- Scope: `web`
- Module: `web:experiments/console`

## Change Metadata
- Change type: `feature`
- Primary scope: `web`

## Linked Issue
- Related: console cutover (PR-A: #1915). Follow-ups: #1913 (drag-drop / paste / optimistic chips), #1914 (run-detail polish).

## Validation Evidence (required)
```bash
tsc --noEmit -p packages/web/tsconfig.json   # exit 0
eslint --max-warnings 0 (3 changed files)    # clean
prettier --check                              # clean
bun test src/experiments/console/             # 80 pass, 0 fail
```
- **Evidence:** Live walkthrough — the 📎 opens the picker; selecting a file renders a chip (`name · 26 B · ✕`); the chip's remove button works; the `/` commands button stays inert. tsc/eslint/prettier clean; console suite green.
- **Skipped:** end-to-end send (would invoke the AI) — the multipart send path is pre-existing/unchanged. Full `bun run validate` (worktree `bun --filter type-check` `bun-types` env quirk; direct `tsc -p packages/web` clean). CI runs full validate.

## Security Impact (required)
- New permissions/capabilities? **No** · New external network calls? **No** (same `/api/conversations/:id/message`) · Secrets/tokens changed? **No** · FS scope changed? **No**

Client-side size/count/type guards are UX only; the **server remains the authoritative validator** of uploaded files.

## Compatibility / Migration
- Backward compatible? **Yes** · Config/env changes? **No** · DB migration? **No**

Composer prop `onSend` widened to `(message, files?)` — additive (`files` optional).

## Human Verification (required)
- **Verified:** 📎 enabled + opens picker; chip renders (name/size/remove); type/size/count guards; tool-input `<pre>` height-capped + scrollable.
- **Edge cases:** first-message upload → JSON-only `createConversation`, surfaced as a notice (not silently dropped); same file re-selectable after send (input value reset); empty/over-limit handled.
- **Not verified:** real multipart round-trip to the AI (pre-existing path); drag-drop/paste (out of scope, #1913).

## Side Effects / Blast Radius (required)
- **Affected:** console chat composer + send wiring; one className on the run-stream tool item.
- **Potential unintended effects:** none cross-surface — `ToolCallItem` change is purely visual; the send skill is untouched.
- **Guardrails:** console test suite; isolation ESLint (no `@/components` import — accepted set copied).

## Rollback Plan (required)
- **Fast rollback:** `git revert <merge-commit>` — self-contained web revert; no data/config/flag teardown.
- **Feature flags:** none.
- **Symptoms:** 📎 inert again / no file chips / tool input renders unbounded.

## Risks and Mitigations
- **Risk:** client accepted-type set drifts from the server's.
  - **Mitigation:** the set is a UX hint only; the server validates authoritatively and its error surfaces in the existing catch. Drift = a file the picker hides but the server would accept (conservative).
- **Risk:** first-message uploads confuse users.
  - **Mitigation:** explicit notice (not a silent drop); full support tracked in #1913.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attach multiple files to chat messages with client-side validation (count/size/type) and removable attachment chips; first-message uploads are noted and must be re-attached after conversation creation.

* **UI/Style**
  * Expanded tool-call details now scroll vertically within a constrained height.

* **Documentation**
  * Console README and open-questions doc updated to describe uploads, limits, and known gaps.

* **Tests**
  * Added unit tests for file validation and size formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->