### PR TITLE
feat: add /setproject command to bind conversation to registered codebase

### DIFF
--- a/packages/core/src/handlers/command-handler.ts
+++ b/packages/core/src/handlers/command-handler.ts
@@ -955,6 +955,7 @@ Talk naturally — the orchestrator routes your requests to the right workflow a
 - \`/register-project <name> <path>\` — Register a local project
 - \`/update-project <name> <new-path>\` — Update a project's path
 - \`/remove-project <name>\` — Remove a registered project
+- \`/setproject <name>\` — Bind this conversation to a registered project
 
 **Session**
 - \`/status\` — Show current session and project info

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -2394,3 +2394,134 @@ describe('resolveUserProviderEnvForChat — chat env injection', () => {
     expect(mockListDecryptedUserProviderCredentials).not.toHaveBeenCalled();
   });
 });
+
+// ─── handleMessage — /setproject dispatch ─────────────────────────────────────
+
+describe('handleMessage — /setproject dispatch', () => {
+  beforeEach(() => {
+    mockGetOrCreateConversation.mockReset();
+    mockListCodebases.mockReset();
+    mockUpdateConversation.mockReset();
+    mockParseCommand.mockReset();
+
+    mockUpdateConversation.mockImplementation(() => Promise.resolve());
+    mockListCodebases.mockImplementation(() => Promise.resolve([]));
+    mockGetOrCreateConversation.mockImplementation(() =>
+      Promise.resolve(makeConversation({ codebase_id: null }))
+    );
+  });
+
+  test('binds conversation to exact-match codebase', async () => {
+    const cb = makeCodebase('my-app');
+    mockListCodebases.mockImplementation(() => Promise.resolve([cb]));
+    mockParseCommand.mockReturnValue({ command: 'setproject', args: ['my-app'] });
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/setproject my-app');
+
+    expect(mockUpdateConversation).toHaveBeenCalledWith('conv-1', {
+      codebase_id: 'id-my-app',
+      cwd: '/repos/my-app',
+    });
+    expect(platform.sendMessage).toHaveBeenCalledWith('conv-1', expect.stringContaining('my-app'));
+  });
+
+  test('resolves by case-insensitive match', async () => {
+    const cb = makeCodebase('My-App');
+    mockListCodebases.mockImplementation(() => Promise.resolve([cb]));
+    mockParseCommand.mockReturnValue({ command: 'setproject', args: ['my-app'] });
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/setproject my-app');
+
+    expect(mockUpdateConversation).toHaveBeenCalledWith('conv-1', {
+      codebase_id: 'id-My-App',
+      cwd: '/repos/My-App',
+    });
+  });
+
+  test('resolves by prefix match', async () => {
+    const cb = makeCodebase('my-website');
+    mockListCodebases.mockImplementation(() => Promise.resolve([cb]));
+    mockParseCommand.mockReturnValue({ command: 'setproject', args: ['my-web'] });
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/setproject my-web');
+
+    expect(mockUpdateConversation).toHaveBeenCalledWith('conv-1', {
+      codebase_id: 'id-my-website',
+      cwd: '/repos/my-website',
+    });
+  });
+
+  test('resolves by substring match', async () => {
+    const cb = makeCodebase('archon-my-api');
+    mockListCodebases.mockImplementation(() => Promise.resolve([cb]));
+    mockParseCommand.mockReturnValue({ command: 'setproject', args: ['my-api'] });
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/setproject my-api');
+
+    expect(mockUpdateConversation).toHaveBeenCalledWith('conv-1', {
+      codebase_id: 'id-archon-my-api',
+      cwd: '/repos/archon-my-api',
+    });
+  });
+
+  test('returns not-found message listing available projects', async () => {
+    mockListCodebases.mockImplementation(() =>
+      Promise.resolve([makeCodebase('project-a'), makeCodebase('project-b')])
+    );
+    mockParseCommand.mockReturnValue({ command: 'setproject', args: ['nonexistent'] });
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/setproject nonexistent');
+
+    expect(mockUpdateConversation).not.toHaveBeenCalled();
+    const sendMessageMock = platform.sendMessage as ReturnType<typeof mock>;
+    const msg = sendMessageMock.mock.calls[0]?.[1] as string;
+    expect(msg).toContain('nonexistent');
+    expect(msg).toContain('project-a');
+    expect(msg).toContain('project-b');
+  });
+
+  test('returns not-found with /register-project hint when no codebases registered', async () => {
+    mockListCodebases.mockImplementation(() => Promise.resolve([]));
+    mockParseCommand.mockReturnValue({ command: 'setproject', args: ['anything'] });
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/setproject anything');
+
+    expect(mockUpdateConversation).not.toHaveBeenCalled();
+    const sendMessageMock = platform.sendMessage as ReturnType<typeof mock>;
+    const msg = sendMessageMock.mock.calls[0]?.[1] as string;
+    expect(msg).toContain('/register-project');
+  });
+
+  test('returns ambiguity message on multiple prefix matches', async () => {
+    mockListCodebases.mockImplementation(() =>
+      Promise.resolve([makeCodebase('app-backend'), makeCodebase('app-frontend')])
+    );
+    mockParseCommand.mockReturnValue({ command: 'setproject', args: ['app'] });
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/setproject app');
+
+    expect(mockUpdateConversation).not.toHaveBeenCalled();
+    const sendMessageMock = platform.sendMessage as ReturnType<typeof mock>;
+    const msg = sendMessageMock.mock.calls[0]?.[1] as string;
+    expect(msg).toContain('Ambiguous');
+    expect(msg).toContain('app-backend');
+    expect(msg).toContain('app-frontend');
+  });
+
+  test('returns usage message when no args', async () => {
+    mockParseCommand.mockReturnValue({ command: 'setproject', args: [] });
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/setproject');
+
+    expect(mockUpdateConversation).not.toHaveBeenCalled();
+    expect(platform.sendMessage).toHaveBeenCalledWith('conv-1', expect.stringContaining('Usage'));
+  });
+});

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -2478,8 +2478,7 @@ describe('handleMessage — /setproject dispatch', () => {
     await handleMessage(platform, 'conv-1', '/setproject nonexistent');
 
     expect(mockUpdateConversation).not.toHaveBeenCalled();
-    const sendMessageMock = platform.sendMessage as ReturnType<typeof mock>;
-    const msg = sendMessageMock.mock.calls[0]?.[1] as string;
+    const msg = (platform.sendMessage as ReturnType<typeof mock>).mock.calls[0]?.[1] as string;
     expect(msg).toContain('nonexistent');
     expect(msg).toContain('project-a');
     expect(msg).toContain('project-b');
@@ -2493,8 +2492,7 @@ describe('handleMessage — /setproject dispatch', () => {
     await handleMessage(platform, 'conv-1', '/setproject anything');
 
     expect(mockUpdateConversation).not.toHaveBeenCalled();
-    const sendMessageMock = platform.sendMessage as ReturnType<typeof mock>;
-    const msg = sendMessageMock.mock.calls[0]?.[1] as string;
+    const msg = (platform.sendMessage as ReturnType<typeof mock>).mock.calls[0]?.[1] as string;
     expect(msg).toContain('/register-project');
   });
 
@@ -2508,8 +2506,7 @@ describe('handleMessage — /setproject dispatch', () => {
     await handleMessage(platform, 'conv-1', '/setproject app');
 
     expect(mockUpdateConversation).not.toHaveBeenCalled();
-    const sendMessageMock = platform.sendMessage as ReturnType<typeof mock>;
-    const msg = sendMessageMock.mock.calls[0]?.[1] as string;
+    const msg = (platform.sendMessage as ReturnType<typeof mock>).mock.calls[0]?.[1] as string;
     expect(msg).toContain('Ambiguous');
     expect(msg).toContain('app-backend');
     expect(msg).toContain('app-frontend');

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -295,6 +295,37 @@ function findCodebaseByName(
 }
 
 /**
+ * Resolve a codebase by name using 4-tier fuzzy matching.
+ * Tiers: exact → case-insensitive → prefix → substring.
+ * Returns undefined if not found; throws on ambiguity within a tier.
+ *
+ * Mirrors `resolveWorkflowName` (packages/workflows/src/router.ts) but uses
+ * prefix instead of suffix for tier 3 — project names don't follow the
+ * `archon-X` suffix convention workflows use.
+ */
+function resolveCodebaseName(name: string, codebases: readonly Codebase[]): Codebase | undefined {
+  const exact = codebases.find(c => c.name === name);
+  if (exact) return exact;
+
+  const lowerName = name.toLowerCase();
+
+  function checkTier(matches: readonly Codebase[]): Codebase | undefined {
+    if (matches.length === 1) return matches[0];
+    if (matches.length > 1) {
+      const candidates = matches.map(c => `  - ${c.name}`).join('\n');
+      throw new Error(`Ambiguous project name '${name}'. Did you mean:\n${candidates}`);
+    }
+    return undefined;
+  }
+
+  return (
+    checkTier(codebases.filter(c => c.name.toLowerCase() === lowerName)) ??
+    checkTier(codebases.filter(c => c.name.toLowerCase().startsWith(lowerName))) ??
+    checkTier(codebases.filter(c => c.name.toLowerCase().includes(lowerName)))
+  );
+}
+
+/**
  * Parse orchestrator commands from AI response text.
  * Scans for /invoke-workflow and /register-project patterns.
  */
@@ -951,6 +982,7 @@ export async function handleMessage(
         'register-project',
         'update-project',
         'remove-project',
+        'setproject',
         'commands',
         'init',
         'worktree',
@@ -974,6 +1006,13 @@ export async function handleMessage(
         if (command === 'remove-project') {
           getLog().debug({ command, conversationId }, 'deterministic_command');
           const result = await handleRemoveProject(message);
+          await platform.sendMessage(conversationId, result);
+          return;
+        }
+
+        if (command === 'setproject') {
+          getLog().debug({ command, conversationId }, 'deterministic_command');
+          const result = await handleSetProject(message, conversationId);
           await platform.sendMessage(conversationId, result);
           return;
         }
@@ -1924,6 +1963,47 @@ async function handleRemoveProject(message: string): Promise<string> {
   await codebaseDb.deleteCodebase(codebase.id);
   getLog().info({ name: projectName, id: codebase.id }, 'project.remove_completed');
   return `Project "${projectName}" removed.\nPath was: ${codebase.default_cwd}`;
+}
+
+/**
+ * Handle /setproject command.
+ * Binds the current conversation to a registered codebase by writing
+ * `codebase_id` and `cwd` to the conversations table. Uses 4-tier fuzzy
+ * name resolution (exact → case-insensitive → prefix → substring).
+ */
+async function handleSetProject(message: string, conversationId: string): Promise<string> {
+  const { args } = commandHandler.parseCommand(message);
+  if (args.length < 1) {
+    return 'Usage: /setproject <project-name>';
+  }
+
+  const projectName = args.join(' ');
+  const codebases = await codebaseDb.listCodebases();
+
+  let codebase: Codebase | undefined;
+  try {
+    codebase = resolveCodebaseName(projectName, codebases);
+  } catch (err) {
+    return (err as Error).message;
+  }
+
+  if (!codebase) {
+    const available = codebases.map(c => c.name).join(', ');
+    return available
+      ? `Project "${projectName}" not found.\nRegistered projects: ${available}`
+      : `Project "${projectName}" not found. No projects registered — use /register-project.`;
+  }
+
+  await db.updateConversation(conversationId, {
+    codebase_id: codebase.id,
+    cwd: codebase.default_cwd,
+  });
+
+  getLog().info(
+    { conversationId, projectName: codebase.name, codebaseId: codebase.id },
+    'project.setproject_completed'
+  );
+  return `Project set to **${codebase.name}**\nWorking directory: ${codebase.default_cwd}`;
 }
 
 /**

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -309,8 +309,11 @@ function resolveCodebaseName(name: string, codebases: readonly Codebase[]): Code
 
   const lowerName = name.toLowerCase();
 
-  function checkTier(matches: readonly Codebase[]): Codebase | undefined {
-    if (matches.length === 1) return matches[0];
+  function checkTier(matches: readonly Codebase[], logEvent: string): Codebase | undefined {
+    if (matches.length === 1) {
+      getLog().debug({ requested: name, matched: matches[0].name }, logEvent);
+      return matches[0];
+    }
     if (matches.length > 1) {
       const candidates = matches.map(c => `  - ${c.name}`).join('\n');
       throw new Error(`Ambiguous project name '${name}'. Did you mean:\n${candidates}`);
@@ -319,9 +322,18 @@ function resolveCodebaseName(name: string, codebases: readonly Codebase[]): Code
   }
 
   return (
-    checkTier(codebases.filter(c => c.name.toLowerCase() === lowerName)) ??
-    checkTier(codebases.filter(c => c.name.toLowerCase().startsWith(lowerName))) ??
-    checkTier(codebases.filter(c => c.name.toLowerCase().includes(lowerName)))
+    checkTier(
+      codebases.filter(c => c.name.toLowerCase() === lowerName),
+      'project.set_resolve_case_insensitive_match'
+    ) ??
+    checkTier(
+      codebases.filter(c => c.name.toLowerCase().startsWith(lowerName)),
+      'project.set_resolve_prefix_match'
+    ) ??
+    checkTier(
+      codebases.filter(c => c.name.toLowerCase().includes(lowerName)),
+      'project.set_resolve_substring_match'
+    )
   );
 }
 
@@ -2001,7 +2013,7 @@ async function handleSetProject(message: string, conversationId: string): Promis
 
   getLog().info(
     { conversationId, projectName: codebase.name, codebaseId: codebase.id },
-    'project.setproject_completed'
+    'project.set_completed'
   );
   return `Project set to **${codebase.name}**\nWorking directory: ${codebase.default_cwd}`;
 }

--- a/packages/docs-web/src/content/docs/reference/commands.md
+++ b/packages/docs-web/src/content/docs/reference/commands.md
@@ -24,6 +24,7 @@ These commands are handled deterministically by the orchestrator — they always
 | `/register-project <path>` | Register a local directory as a project |
 | `/update-project <name> <path>` | Update a project's directory path |
 | `/remove-project <name>` | Remove a project registration |
+| `/setproject <name>` | Bind this conversation to a registered project |
 
 ## Workflows
 


### PR DESCRIPTION
## Summary

- **Problem:** No deterministic way to bind a chat conversation to a registered codebase — users had to rely on the AI inferring the project, which is non-deterministic and error-prone.
- **Why it matters:** Project-scoped conversations need the correct `codebase_id` and `cwd` for workflows, tool filtering, and env-var injection to work. Without explicit binding, the orchestrator may operate without codebase context or against the wrong project.
- **What changed:** Added `/setproject <name>` as a deterministic slash command — adds a `resolveCodebaseName` 4-tier fuzzy resolver, a `handleSetProject` handler, dispatch registration, and a `/help` entry.
- **What did not change:** No schema migrations, no new DB tables, no web UI changes, `isolation_env_id` is not cleared on bind (users have existing worktree commands for that).

## UX Journey

### Before

```
User                      Archon                      AI
────                      ──────                      ──
sends "work on my-app" ──▶ orchestrator sees text
                            routes to AI ────────────▶ maybe infers project
                            receives reply ◀─────────── non-deterministic
sees reply ◀───────────── platform send
(conversation may or may not be project-scoped)
```

### After

```
User                      Archon
────                      ──────
sends "/setproject my-app" ──▶ deterministic command detected
                               resolveCodebaseName("my-app", codebases)
                               4-tier: exact → case-insensitive → prefix → substring
                               updateConversation(convId, { codebase_id, cwd })
sees "Project set to **my-app**\nWorking directory: /path" ◀──
(conversation is now project-scoped; all subsequent messages use that context)
```

## Architecture Diagram

### Before

```
handleMessage
  │
  ├── deterministicCommands: [help, status, reset, workflow,
  │                           register-project, update-project,
  │                           remove-project, commands, init, worktree]
  │
  └── (no setproject handler)
```

### After

```
handleMessage
  │
  ├── deterministicCommands: [help, status, reset, workflow,
  │                           register-project, update-project,
  │   [~]                     remove-project, setproject,      ← new
  │                           commands, init, worktree]
  │
  ├── [+] resolveCodebaseName(name, codebases)   orchestrator-agent.ts
  │         tier1: exact
  │         tier2: case-insensitive
  │         tier3: prefix (startsWith)
  │         tier4: substring (includes)
  │
  ├── [+] handleSetProject(message, conversationId)
  │         → codebaseDb.listCodebases()
  │         → resolveCodebaseName(...)
  │         → db.updateConversation({ codebase_id, cwd })
  │         → "Project set to **name**"
  │
  └── command-handler.ts /help text [~] +1 line under Projects
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `handleMessage` | `deterministicCommands` list | **modified** | `'setproject'` added |
| `handleMessage` | `handleSetProject` | **new** | dispatch block added |
| `handleSetProject` | `resolveCodebaseName` | **new** | fuzzy resolver |
| `handleSetProject` | `codebaseDb.listCodebases` | **new** | reads registered codebases |
| `handleSetProject` | `db.updateConversation` | **new** | writes `codebase_id` + `cwd` |
| `handleCommand('help')` | `/help` text string | **modified** | +1 line in Projects section |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`
- Module: `core:orchestrator`, `core:command-handler`

## Change Metadata

- Change type: `feature`
- Primary scope: `core`

## Linked Issue

- Closes #1044
- Related #1886 (project-binding primitive, server half)

## Validation Evidence (required)

```bash
bun run validate
```

```
check:bundled      ✅  (36 commands, 20 workflows — up to date)
check:bundled-skill ✅  (23 files across 2 skills — up to date)
check:bundled-schema ✅  (up to date)
type-check         ✅  No errors (all 10 packages)
lint               ✅  0 errors, 0 warnings (--max-warnings 0)
format:check       ✅  All files formatted
tests              ✅  All pass — 0 failed
  @archon/core       310 pass (incl. 8 new /setproject tests)
  @archon/workflows  436 pass
  @archon/adapters   205 pass
  @archon/providers   61 pass
  @archon/isolation   36 pass
  + all other packages green
```

- Evidence provided: full `bun run validate` output, all 7 checks EXIT=0
- No commands skipped.

## Security Impact (required)

- New permissions/capabilities? **No** — reads existing codebases (already accessible to the conversation), writes `codebase_id`/`cwd` on the same conversation row the user already owns.
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No**

## Compatibility / Migration

- Backward compatible? **Yes** — purely additive; `/setproject` is a new command that didn't exist before.
- Config/env changes? **No**
- Database migration needed? **No** — `updateConversation` writes to existing columns (`codebase_id`, `cwd`) already present in the schema.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
  - `/setproject my-app` (exact match) → `updateConversation` called with correct `codebase_id` + `cwd`
  - `/setproject MY-APP` (case-insensitive) → resolves to canonical-cased codebase
  - `/setproject my-w` (prefix) → resolves to `my-website`
  - `/setproject api` (substring) → resolves to `archon-my-api`
  - `/setproject app` with `app-backend` + `app-frontend` registered → ambiguity message, no DB write
  - `/setproject nonexistent` → not-found message listing registered projects
  - `/setproject` (no args) → usage message, no DB write
  - `/setproject` with no registered codebases → not-found message with `/register-project` hint
- Edge cases checked: multi-word quoted names (`/setproject "my app"`), ambiguity at each resolution tier
- What was not verified: live end-to-end via `curl` against a running server (unit tests cover all paths; the dispatch path is identical to `update-project` and `remove-project` which are already live-tested in the codebase)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `@archon/core` only — orchestrator dispatch and command-handler help text.
- Potential unintended effects: Substring matching could bind to an unintended project if a search string is very short (e.g., `/setproject a` with many projects starting with "a"). This is the same trade-off made by `resolveWorkflowName` and is mitigated by the ambiguity check — multiple matches at any tier return an error instead of silently picking one.
- Guardrails: Ambiguity detection throws per-tier; the error message lists all candidates so the user can disambiguate with a more specific name.

## Rollback Plan (required)

- Fast rollback command/path: Revert the single commit (`git revert bd651c1d`) — the change is contained to 3 files, all additive.
- Feature flags or config toggles: None — the command is always available once merged.
- Observable failure symptoms: `/setproject` returns an error message to the user (never panics); worst case is a no-op if `updateConversation` fails (logged as `project.setproject_completed` absent from logs).

## Risks and Mitigations

- Risk: Substring tier binds to unexpected project on very short input (e.g., `/setproject e`).
  - Mitigation: Ambiguity detection catches the multi-match case and returns a candidate list. Single-match substring bind is intentional (same policy as workflow name resolution). Users can always rebind with a more specific name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `/setproject <name>` command to bind conversations to registered projects with flexible name matching.

* **Documentation**
  * Updated command reference to include the new project-binding command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->