### PR TITLE
fix(server): exempt /api/auth/providers from the Better Auth catch-all

### DIFF
--- a/packages/server/src/auth/config.test.ts
+++ b/packages/server/src/auth/config.test.ts
@@ -6,6 +6,7 @@ import {
   isEmailAllowed,
   getSignupMode,
   isApiGateEnabled,
+  isArchonOwnedAuthPath,
 } from './config';
 
 const VALID_SECRET = 'a'.repeat(32);
@@ -116,6 +117,36 @@ describe('auth/config', () => {
           ARCHON_WEB_AUTH_REQUIRED: 'false',
         })
       ).toBe(false);
+    });
+  });
+
+  describe('isArchonOwnedAuthPath', () => {
+    test('exempts Archon-owned /api/auth/* paths (fall through, not Better Auth)', () => {
+      for (const p of [
+        '/api/auth/status',
+        '/api/auth/github',
+        '/api/auth/github/device/start',
+        '/api/auth/github/device/poll',
+        '/api/auth/providers',
+        '/api/auth/providers/openrouter',
+        '/api/auth/providers/claude/oauth/start', // reserved for PR-3
+      ]) {
+        expect(isArchonOwnedAuthPath(p)).toBe(true);
+      }
+    });
+
+    test('does NOT exempt Better Auth-owned paths (those it must handle)', () => {
+      for (const p of [
+        '/api/auth/sign-in',
+        '/api/auth/sign-up',
+        '/api/auth/sign-out',
+        '/api/auth/get-session',
+        '/api/auth/providersX', // prefix guard: must be exact or under '/'
+        '/api/auth/githubbed',
+        '/api/auth',
+      ]) {
+        expect(isArchonOwnedAuthPath(p)).toBe(false);
+      }
     });
   });
 });

--- a/packages/server/src/auth/config.ts
+++ b/packages/server/src/auth/config.ts
@@ -94,3 +94,29 @@ export function getSignupMode(
 export function isApiGateEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   return isWebAuthEnabled(env) && env.ARCHON_WEB_AUTH_REQUIRED !== 'false';
 }
+
+/**
+ * Paths under `/api/auth/*` that Archon owns and the Better Auth catch-all must
+ * NOT handle. Better Auth's `basePath` is `/api/auth`, so when web auth is on its
+ * handler claims every path under that prefix and 404s any it doesn't recognize.
+ * The mount falls through (`next()`) for these so Archon's own route handlers
+ * (registered later in `registerApiRoutes`) run instead.
+ *
+ * Keep this in lockstep with the Archon-owned `/api/auth/*` routes:
+ *   - `/api/auth/status`            (web-auth status)
+ *   - `/api/auth/github` + sub      (per-user GitHub device flow)
+ *   - `/api/auth/providers` + sub   (per-user AI-provider keys; sub = PR-3 OAuth)
+ *
+ * NOTE: only GET/POST go through the catch-all, so PUT/DELETE on these paths are
+ * never intercepted regardless — but listing them here keeps the allow-list the
+ * single source of truth for "this prefix is Archon's, not Better Auth's".
+ */
+export function isArchonOwnedAuthPath(path: string): boolean {
+  return (
+    path === '/api/auth/status' ||
+    path === '/api/auth/github' ||
+    path.startsWith('/api/auth/github/') ||
+    path === '/api/auth/providers' ||
+    path.startsWith('/api/auth/providers/')
+  );
+}

--- a/packages/server/src/auth/index.ts
+++ b/packages/server/src/auth/index.ts
@@ -11,6 +11,7 @@ export {
   isEmailAllowed,
   getSignupMode,
   isApiGateEnabled,
+  isArchonOwnedAuthPath,
   MIN_BETTER_AUTH_SECRET_LENGTH,
 } from './config';
 export { getAuth, closeAuth, resetAuthForTest, type AuthInstance } from './instance';

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -103,7 +103,14 @@ import {
   captureArchonStarted,
 } from '@archon/paths';
 import { selectGitHubAuthMode, parseGitCredentialPath } from './github-auth-bootstrap';
-import { getAuth, closeAuth, isWebAuthEnabled, assertWebAuthAtBoot, getSignupMode } from './auth';
+import {
+  getAuth,
+  closeAuth,
+  isWebAuthEnabled,
+  assertWebAuthAtBoot,
+  getSignupMode,
+  isArchonOwnedAuthPath,
+} from './auth';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
@@ -654,10 +661,10 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
   // an external handler serving its own non-OpenAPI surface, like the webhooks.)
   const webAuth = getAuth();
   if (webAuth) {
-    const isArchonOwnedAuthPath = (path: string): boolean =>
-      path === '/api/auth/status' ||
-      path === '/api/auth/github' ||
-      path.startsWith('/api/auth/github/');
+    // isArchonOwnedAuthPath (in ./auth/config) is the single source of truth for
+    // which /api/auth/* paths fall through to Archon's own handlers vs. Better
+    // Auth. A guard test asserts every Archon-registered /api/auth/* route is in
+    // it, so adding a route without exempting it fails CI rather than 404ing live.
     app.on(['POST', 'GET'], '/api/auth/*', (c, next) => {
       if (isArchonOwnedAuthPath(c.req.path)) return next();
       return webAuth.handler(c.req.raw);

--- a/packages/server/src/routes/api.provider-keys.test.ts
+++ b/packages/server/src/routes/api.provider-keys.test.ts
@@ -185,6 +185,8 @@ mock.module('@archon/core/utils/commands', () => ({
 }));
 
 import { registerApiRoutes } from './api';
+// Import the REAL exemption check (../auth barrel is mocked above; ../auth/config is not).
+import { isArchonOwnedAuthPath } from '../auth/config';
 
 function makeApp(): OpenAPIHono {
   const app = new OpenAPIHono({ defaultHook: validationErrorHook });
@@ -383,5 +385,23 @@ describe('DELETE /api/auth/providers/:provider', () => {
   test('no identity → 401', async () => {
     const res = await makeApp().request('/api/auth/providers/openrouter', { method: 'DELETE' });
     expect(res.status).toBe(401);
+  });
+});
+
+// Airtight guard for the Better Auth catch-all shadowing bug: when web auth is
+// on, Better Auth claims all of /api/auth/* and 404s anything it doesn't own.
+// EVERY Archon-registered /api/auth/* route must be in isArchonOwnedAuthPath or it
+// 404s live (this is exactly what bit GET /api/auth/providers). registerApiRoutes
+// registers only Archon routes (Better Auth mounts separately in index.ts), so
+// all /api/auth/* paths here are Archon's and must be exempted.
+describe('Better Auth catch-all exemption is exhaustive', () => {
+  test('every Archon-registered /api/auth/* route is exempted by isArchonOwnedAuthPath', () => {
+    const app = makeApp();
+    const authPaths = [
+      ...new Set(app.routes.map(r => r.path).filter(p => p.startsWith('/api/auth/'))),
+    ];
+    expect(authPaths.length).toBeGreaterThan(0); // sanity: we actually found auth routes
+    const notExempted = authPaths.filter(p => !isArchonOwnedAuthPath(p));
+    expect(notExempted).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- **Problem:** `GET /api/auth/providers` returns **404 whenever web auth is enabled** (reproduced live on archon.dynamous.ai) — so the new console **AI Provider Keys** panel can't load.
- **Root cause:** Better Auth's `basePath` is `/api/auth`, so its catch-all (`app.on(['GET','POST'], '/api/auth/*')`) claims the whole prefix and 404s any path it doesn't own. The provider-key routes from #1911 were never added to the `isArchonOwnedAuthPath` fall-through allow-list. (PUT/DELETE worked because the catch-all only intercepts GET/POST — only the list `GET` broke.)
- **Why CI was green:** the route unit tests exercise `registerApiRoutes` directly and never go through the `index.ts` Better Auth mount, so the shadowing was invisible to them.
- **What changed:** extracted the inline exemption into a tested pure helper and added `/api/auth/providers`; plus an *airtight guard test*.
- **What did NOT change:** the route paths, the handlers, the gate, the `/api/auth/github*` behavior.

## Fix

- `auth/config.ts`: `isArchonOwnedAuthPath` is now a pure exported helper (was an untested inline literal in `index.ts`), covering `status` + `github*` + **`providers*`** (the `/providers/` prefix also pre-exempts PR-3's OAuth subroutes).
- `index.ts`: imports the helper; the inline literal is gone.
- Tests:
  - unit test of the helper (exempts status/github*/providers*; does **not** exempt Better Auth's own `sign-in`/`get-session`/etc., with prefix-boundary cases like `providersX`).
  - **guard test**: enumerates every Archon-registered `/api/auth/*` route from `registerApiRoutes` and asserts each is exempted — so a future forgotten route fails CI instead of 404ing in prod.

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `server`, `tests`
- Module: `server:auth`

## Change Metadata

- Change type: `bug`
- Primary scope: `server`

## Linked Issue

- Follow-up to #1911 (PR 2/4 of #1891)

## Validation Evidence

```bash
bun --filter @archon/server type-check   # ✅
bun test packages/server/src/auth/config.test.ts            # ✅ 21 (incl. exemption cases)
bun test packages/server/src/routes/api.provider-keys.test.ts  # ✅ 14 (incl. guard)
bun run lint && bun run format:check     # ✅
```

- Reproduced the 404 live (web auth on); will redeploy this fix to the VPS and confirm the panel loads.

## Security Impact

- New permissions/capabilities? **No** — narrows nothing; only routes `GET /api/auth/providers` to Archon's existing (already-gated, `requireWebUser`) handler instead of Better Auth's 404.
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No**

## Compatibility / Migration

- Backward compatible? **Yes** (web-auth-off installs were never affected; this only changes behavior when Better Auth is mounted).
- Config/env changes? **No** · Database migration? **No**

## Human Verification

- Verified: unit + guard tests green; reproduced the live 404.
- Not verified yet: post-deploy panel load (will confirm on the VPS after merge).

## Side Effects / Blast Radius

- Only `/api/auth/providers` GET routing when web auth is on. The guard test prevents regressions for any future `/api/auth/*` route.

## Rollback Plan

- Revert this PR — the feature returns to "panel 404s under web auth" (no other surface affected).

## Risks and Mitigations

- Risk: another `/api/auth/*` route added later without exemption.
  - Mitigation: the guard test fails CI if any Archon-registered `/api/auth/*` route isn't in `isArchonOwnedAuthPath`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for authentication route handling to ensure proper exemption logic is maintained.

* **Chores**
  * Enhanced authentication routing infrastructure with improved helper utilities and expanded documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->