### PR TITLE
fix(core): scoped direct chat runs in repo cwd, not workspaces root

### DIFF
--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -982,6 +982,7 @@ describe('discoverAllWorkflows — remote sync', () => {
     mockToRepoPath.mockClear();
     mockGetOrCreateConversation.mockReset();
     mockGetCodebase.mockReset();
+    mockListCodebases.mockReset();
     mockSendQuery.mockClear();
     mockGetCodebaseEnvVars.mockReset();
     mockLoadConfig.mockReset();
@@ -989,6 +990,7 @@ describe('discoverAllWorkflows — remote sync', () => {
     // Reset mocks between tests in this suite and restore safe defaults
     mockGetOrCreateConversation.mockImplementation(() => Promise.resolve(null));
     mockGetCodebase.mockImplementation(() => Promise.resolve(null));
+    mockListCodebases.mockImplementation(() => Promise.resolve([]));
     mockGetCodebaseEnvVars.mockImplementation(() => Promise.resolve({}));
     mockLoadConfig.mockImplementation(() =>
       Promise.resolve({
@@ -1023,6 +1025,7 @@ describe('discoverAllWorkflows — remote sync', () => {
     };
     mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
     mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
 
     const platform = makePlatform();
     await handleMessage(platform, 'conv-1', 'What is the latest commit?');
@@ -1050,6 +1053,7 @@ describe('discoverAllWorkflows — remote sync', () => {
     const codebase = makeCodebaseForSync();
     mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
     mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
     mockSyncWorkspace.mockRejectedValueOnce(new Error('Network timeout'));
 
     const platform = makePlatform();
@@ -1075,6 +1079,7 @@ describe('discoverAllWorkflows — remote sync', () => {
     const codebase = makeCodebaseForSync();
     mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
     mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
     mockSyncWorkspace.mockRejectedValueOnce(new Error('Network timeout'));
 
     const platform = makePlatform();
@@ -1091,6 +1096,7 @@ describe('discoverAllWorkflows — remote sync', () => {
     const codebase = makeCodebaseForSync();
     mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
     mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
     mockGetCodebaseEnvVars.mockResolvedValueOnce({ DB_SECRET: 'db-value' });
     mockLoadConfig.mockResolvedValueOnce({
       assistants: { claude: {}, codex: {} },
@@ -1122,6 +1128,7 @@ describe('discoverAllWorkflows — remote sync', () => {
     const codebase = makeCodebaseForSync();
     mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
     mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
     mockGetCodebaseEnvVars.mockRejectedValueOnce(new Error('db unavailable'));
     mockLoadConfig.mockResolvedValueOnce({
       assistants: { claude: {}, codex: {} },
@@ -1175,10 +1182,12 @@ describe('discoverAllWorkflows — remote sync', () => {
     const providers = await import('@archon/providers');
     const capsMock = providers.getProviderCapabilities as ReturnType<typeof mock>;
     capsMock.mockReturnValue({ envInjection: true, nativeTools: false });
+    const codebase = makeCodebaseForSync();
     mockGetOrCreateConversation.mockReturnValueOnce(
       Promise.resolve(makeConversation({ ai_assistant_type: 'codex', codebase_id: 'codebase-1' }))
     );
-    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeCodebaseForSync()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
 
     try {
       const platform = makePlatform();
@@ -1198,10 +1207,12 @@ describe('discoverAllWorkflows — remote sync', () => {
     const providers = await import('@archon/providers');
     const capsMock = providers.getProviderCapabilities as ReturnType<typeof mock>;
     capsMock.mockReturnValue({ envInjection: true, nativeTools: true });
+    const codebase = makeCodebaseForSync();
     mockGetOrCreateConversation.mockReturnValueOnce(
       Promise.resolve(makeConversation({ ai_assistant_type: 'claude', codebase_id: 'codebase-1' }))
     );
-    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeCodebaseForSync()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
 
     try {
       const platform = makePlatform();
@@ -1290,7 +1301,6 @@ describe('provider cwd resolution', () => {
   test('scoped chat falls back to workspaces root and warns when codebase not found (deleted)', async () => {
     const conversation = makeConversation({ codebase_id: 'deleted-id' });
     mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
-    mockGetCodebase.mockReturnValueOnce(Promise.resolve(null));
     mockListCodebases.mockReturnValueOnce(Promise.resolve([]));
 
     const platform = makePlatform();

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1003,14 +1003,16 @@ describe('discoverAllWorkflows — remote sync', () => {
     const codebase = makeCodebaseForSync();
     mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
     mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
 
     const platform = makePlatform();
     await handleMessage(platform, 'conv-1', 'What is the latest commit?');
 
+    // Non-destructive default sync (#1864): 2-arg call, no explicit reset mode.
     expect(mockSyncWorkspace).toHaveBeenCalledWith('/repos/test-repo', undefined);
-    // Regression guard: orchestrator must resolve cwd through the ensure variant
-    // so the workspaces dir is created before the AI provider spawn (issue #1528).
-    expect(mockEnsureArchonWorkspacesPath).toHaveBeenCalled();
+    // cwd resolution behavior — scoped chat runs the provider in the repo's
+    // default_cwd (not the workspaces root) and skips ensureArchonWorkspacesPath
+    // — is covered by the 'provider cwd resolution' describe block (issue #1179).
   });
 
   test('does not pass reset mode for managed clones during chat sync', async () => {
@@ -1215,6 +1217,91 @@ describe('discoverAllWorkflows — remote sync', () => {
     } finally {
       capsMock.mockReturnValue({ envInjection: true });
     }
+  });
+});
+
+// ─── provider cwd resolution (issue #1179) ──────────────────────────────────
+
+describe('provider cwd resolution', () => {
+  function getSendQueryCwd(): string {
+    expect(mockSendQuery).toHaveBeenCalled();
+    return mockSendQuery.mock.calls[0][1] as string;
+  }
+
+  beforeEach(() => {
+    mockGetOrCreateConversation.mockReset();
+    mockGetCodebase.mockReset();
+    mockListCodebases.mockReset();
+    mockSendQuery.mockClear();
+    mockEnsureArchonWorkspacesPath.mockClear();
+    mockLogger.warn.mockClear();
+    mockGetOrCreateConversation.mockImplementation(() => Promise.resolve(null));
+    mockGetCodebase.mockImplementation(() => Promise.resolve(null));
+    mockListCodebases.mockImplementation(() => Promise.resolve([]));
+    mockLoadConfig.mockImplementation(() =>
+      Promise.resolve({ assistants: { claude: {}, codex: {} }, envVars: {} })
+    );
+    mockGetCodebaseEnvVars.mockImplementation(() => Promise.resolve({}));
+  });
+
+  test('scoped chat uses codebase.default_cwd as provider cwd', async () => {
+    const codebase = makeCodebaseForSync();
+    const conversation = makeConversation({ codebase_id: 'codebase-1' });
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', 'hello');
+
+    expect(getSendQueryCwd()).toBe('/repos/test-repo');
+    expect(mockEnsureArchonWorkspacesPath).not.toHaveBeenCalled();
+  });
+
+  test('scoped chat uses conversation.cwd when set (active worktree path)', async () => {
+    const codebase = makeCodebaseForSync();
+    const conversation = makeConversation({
+      codebase_id: 'codebase-1',
+      cwd: '/worktrees/feature-branch',
+    });
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', 'hello');
+
+    expect(getSendQueryCwd()).toBe('/worktrees/feature-branch');
+    expect(mockEnsureArchonWorkspacesPath).not.toHaveBeenCalled();
+  });
+
+  test('unscoped chat uses ensureArchonWorkspacesPath result', async () => {
+    const conversation = makeConversation({ codebase_id: null });
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([]));
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', 'hello');
+
+    expect(getSendQueryCwd()).toBe('/home/test/.archon/workspaces');
+    expect(mockEnsureArchonWorkspacesPath).toHaveBeenCalled();
+  });
+
+  test('scoped chat falls back to workspaces root and warns when codebase not found (deleted)', async () => {
+    const conversation = makeConversation({ codebase_id: 'deleted-id' });
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(null));
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([]));
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', 'hello');
+
+    expect(getSendQueryCwd()).toBe('/home/test/.archon/workspaces');
+    expect(mockEnsureArchonWorkspacesPath).toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ codebaseId: 'deleted-id' }),
+      'orchestrator.scoped_codebase_not_found'
+    );
   });
 });
 

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -1078,19 +1078,20 @@ export async function handleMessage(
       attachedFiles,
       workflowContext
     );
+    const scopedCodebase =
+      conversation.codebase_id !== null
+        ? codebases.find(c => c.id === conversation.codebase_id)
+        : undefined;
     let cwd: string;
-    if (conversation.codebase_id !== null) {
-      const scopedCodebase = codebases.find(c => c.id === conversation.codebase_id);
-      if (scopedCodebase !== undefined) {
-        cwd = conversation.cwd ?? scopedCodebase.default_cwd;
-      } else {
+    if (scopedCodebase !== undefined) {
+      cwd = conversation.cwd ?? scopedCodebase.default_cwd;
+    } else {
+      if (conversation.codebase_id !== null) {
         getLog().warn(
           { codebaseId: conversation.codebase_id },
           'orchestrator.scoped_codebase_not_found'
         );
-        cwd = await ensureArchonWorkspacesPath();
       }
-    } else {
       cwd = await ensureArchonWorkspacesPath();
     }
 

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -1078,7 +1078,21 @@ export async function handleMessage(
       attachedFiles,
       workflowContext
     );
-    const cwd = await ensureArchonWorkspacesPath();
+    let cwd: string;
+    if (conversation.codebase_id !== null) {
+      const scopedCodebase = codebases.find(c => c.id === conversation.codebase_id);
+      if (scopedCodebase !== undefined) {
+        cwd = conversation.cwd ?? scopedCodebase.default_cwd;
+      } else {
+        getLog().warn(
+          { codebaseId: conversation.codebase_id },
+          'orchestrator.scoped_codebase_not_found'
+        );
+        cwd = await ensureArchonWorkspacesPath();
+      }
+    } else {
+      cwd = await ensureArchonWorkspacesPath();
+    }
 
     // 4. Update activity and get/create session
     await db.touchConversation(conversation.id);


### PR DESCRIPTION
## Summary

- **Problem**: Direct chat sessions scoped to a codebase executed the AI provider with `~/.archon/workspaces` as the working directory instead of the project repo path, causing file lookups, relative paths, and `git` commands to resolve against the wrong location.
- **Why it matters**: Tool invocations inside a scoped chat (file reads, `ls`, `git log`, etc.) returned results from the workspaces root rather than from the registered project repo — making codebase-scoped chat effectively broken for any tool use.
- **What changed**: Replaced the unconditional `const cwd = await ensureArchonWorkspacesPath()` line in the direct-chat path (`orchestrator-agent.ts:1076`) with codebase-aware resolution (`conversation.cwd ?? codebase.default_cwd`), mirroring the logic already present in the workflow path at line 721. Added four regression tests.
- **What did not change**: Workflow execution cwd (already correct), env injection, per-chat worktree creation, or any other subsystem.

## UX Journey

### Before

```
User (scoped chat)         Archon                          AI Client (e.g. Claude)
──────────────────         ──────                          ───────────────────────
"what files are here?" ──▶ resolves codebase context
                           loads prompts, env vars
                           cwd = ~/.archon/workspaces  ──▶ runs with wrong cwd
                           streams to AI
  sees workspaces root ◀─  receives response (wrong!)
```

### After

```
User (scoped chat)         Archon                          AI Client (e.g. Claude)
──────────────────         ──────                          ───────────────────────
"what files are here?" ──▶ resolves codebase context
                           loads prompts, env vars
                    [~]    cwd = codebase.default_cwd  ──▶ runs with correct cwd
                           streams to AI
  sees project files ◀──   receives response (correct!)
```

## Architecture Diagram

### Before

```
orchestrator-agent.ts (direct-chat path)
  ├── loads codebases (listCodebases)
  ├── loads conversation
  ├── ...
  └── cwd = ensureArchonWorkspacesPath()  ← always workspaces root
        └── sendQuery(prompt, cwd)
```

### After

```
orchestrator-agent.ts (direct-chat path)
  ├── loads codebases (listCodebases)
  ├── loads conversation
  ├── ...
  └── [~] cwd = conversation.cwd ?? codebase.default_cwd  ← project repo path
           (falls back to ensureArchonWorkspacesPath() for unscoped or missing codebase)
        └── sendQuery(prompt, cwd)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `orchestrator-agent.ts` | `codebaseDb.listCodebases()` | unchanged | Already loaded 75 lines above the fix site |
| `orchestrator-agent.ts` | `ensureArchonWorkspacesPath()` | **modified** | Now only called for unscoped chats or missing codebase (fallback) |
| `orchestrator-agent.ts` | `sendQuery()` | **modified** | `cwd` argument now reflects actual project path for scoped chats |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `core`
- Module: `core:orchestrator`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #1179
- Supersedes #1233

## Validation Evidence (required)

```bash
bun run type-check   # ✅ No errors (all 10 packages)
bun run lint         # ✅ 0 errors, 0 warnings (--max-warnings 0)
bun run format:check # ✅ All files formatted
bun run test         # ✅ 4724 passed, 0 failed
bun run validate     # ✅ All 7 checks pass (bundled, skill, schema, type-check, lint, format, tests)
```

- Evidence provided: Full `bun run validate` run: 4724 tests passed. New test suite adds 4 regression cases (133 total in the orchestrator-agent test file, up from 129).
- No commands skipped.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? Yes — the AI provider's working directory is now the registered project repo path instead of `~/.archon/workspaces`. This is the intended and correct scope; scoped chat is expected to run inside the project.

## Compatibility / Migration

- Backward compatible? Yes — unscoped chats are unchanged; scoped chats now correctly use the project path.
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: Type-check, lint, format, full test suite run via `bun run validate`.
- Edge cases checked: Missing codebase row (fallback to workspaces root + warn), `conversation.cwd` override (active worktree path takes precedence over `default_cwd`), unscoped chat (unchanged behavior).
- What was not verified: Live end-to-end browser test with a real registered repo (no running server in the worktree environment).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Direct chat path in `orchestrator-agent.ts` only. Workflow execution, CLI, adapters, and server are untouched.
- Potential unintended effects: A scoped chat conversation whose `codebase.default_cwd` points to a path that no longer exists on disk will surface errors from the AI provider when it tries to list files there — this was already the case in workflow nodes and is the correct behavior (fail fast, surface the problem).
- Guardrails/monitoring: `orchestrator.scoped_codebase_not_found` warn log emitted when the codebase row can't be found; graceful fallback to workspaces root in that case.

## Rollback Plan (required)

- Fast rollback command/path: Revert commit `704be5ba` (`git revert 704be5ba`).
- Feature flags or config toggles: None.
- Observable failure symptoms: Scoped chats listing files from `~/.archon/workspaces` instead of the project repo; provider errors referencing unexpected paths.

## Risks and Mitigations

- Risk: A `conversation.cwd` that points to a deleted worktree path causes provider errors.
  - Mitigation: This is the same risk that exists today in workflow nodes (shared design decision); the path is set intentionally by worktree lifecycle code and cleaned up when the environment is destroyed. Not a new risk introduced by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed working directory resolution for scoped conversations. The system now correctly uses conversation-configured or codebase-specific working directories when available, with improved fallback handling when codebases are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->