### PR TITLE
fix(core): persist non-web platform messages to remote_agent_messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -459,7 +459,7 @@ import type { DagNode, WorkflowDefinition } from '@/lib/api';
 4. **`isolation_environments`** - Git worktree isolation tracking; nullable `created_by_user_id` preserves first creator
 5. **`workflow_runs`** - Workflow execution tracking and state; nullable `user_id` for per-run attribution
 6. **`workflow_events`** - Step-level workflow event log (step transitions, artifacts, errors)
-7. **`messages`** - Conversation message history with tool call metadata (JSONB); nullable `user_id` (NULL for assistant rows)
+7. **`messages`** - Conversation message history with tool call metadata (JSONB); nullable `user_id` (NULL for assistant rows). Split write-path: the **web** adapter persists its own turns via `MessagePersistence`; the **orchestrator** persists non-web turns (Slack/Telegram/GitHub/Discord/CLI) fire-and-forget, guarded by `isWebAdapter` to avoid double-writing web turns — only AI-bound turns get a user row (deterministic-command and approval-only turns return earlier), so a `user` row always pairs with an `assistant` row
 8. **`codebase_env_vars`** - Per-project env vars injected into project-scoped execution surfaces (Claude, Codex, bash/script nodes, and direct chat when codebase-scoped), managed via Web UI or `env:` in config
 9. **`users`** - Archon-internal identity (one row per human/bot); created lazily on first sight by any adapter; `role` (`'admin'`(default)`/'member'`) is the identity seam for future per-resource scoping (visibility stays open today)
 10. **`user_identities`** - Per-platform mapping (Slack U-id, Telegram chat id, Discord snowflake, GitHub login, Better Auth web user id) → `users.id`; `UNIQUE(platform, platform_user_id)`

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -201,9 +201,10 @@ mock.module('./prompt-builder', () => ({
   ),
 }));
 
+const mockAddMessage = mock(() => Promise.resolve());
 const mockGetRecentWorkflowResultMessages = mock(() => Promise.resolve([]));
 mock.module('../db/messages', () => ({
-  addMessage: mock(() => Promise.resolve()),
+  addMessage: mockAddMessage,
   listMessages: mock(() => Promise.resolve([])),
   getRecentWorkflowResultMessages: mockGetRecentWorkflowResultMessages,
 }));
@@ -3074,5 +3075,101 @@ describe('per-user AI prefs in chat + tier-fallback nudge', () => {
       string,
     ][];
     expect(sendCalls.some(c => c[1].includes("isn't configured"))).toBe(false);
+  });
+});
+
+// ─── Message persistence for non-web platforms (regression for #1182) ────────
+
+describe('message persistence for non-web platforms', () => {
+  beforeEach(() => {
+    mockAddMessage.mockClear();
+    mockGetOrCreateConversation.mockReset();
+    mockGetCodebase.mockReset();
+    mockGetCodebaseEnvVars.mockReset();
+    mockLoadConfig.mockReset();
+    mockSendQuery.mockClear();
+
+    mockGetOrCreateConversation.mockImplementation(() =>
+      Promise.resolve(makeConversation({ id: 'conv-db-id', platform_conversation_id: 'conv-1' }))
+    );
+    mockGetCodebase.mockImplementation(() => Promise.resolve(null));
+    mockGetCodebaseEnvVars.mockImplementation(() => Promise.resolve({}));
+    mockLoadConfig.mockImplementation(() =>
+      Promise.resolve({ assistants: { claude: {}, codex: {} }, envVars: {} })
+    );
+    mockSendQuery.mockImplementation(async function* () {
+      yield { type: 'assistant', content: 'hello back' };
+      yield { type: 'result', sessionId: 'sess-1' };
+    });
+  });
+
+  test('persists user + assistant messages for non-web platform (batch mode)', async () => {
+    const platform: IPlatformAdapter = {
+      ...makePlatform(),
+      getPlatformType: mock(() => 'github'),
+      getStreamingMode: mock(() => 'batch' as const),
+    };
+
+    await handleMessage(platform, 'conv-1', 'what is this repo?');
+
+    // Inbound user message must land in the DB so the Web UI history is non-empty.
+    expect(mockAddMessage).toHaveBeenCalledWith(
+      'conv-db-id',
+      'user',
+      'what is this repo?',
+      undefined,
+      undefined
+    );
+    // Outbound assistant reply must also be persisted (matches what was sent).
+    expect(mockAddMessage).toHaveBeenCalledWith(
+      'conv-db-id',
+      'assistant',
+      expect.stringContaining('hello back')
+    );
+    expect(mockAddMessage).toHaveBeenCalledTimes(2);
+  });
+
+  test('persists user + assistant messages for non-web platform (stream mode)', async () => {
+    const platform: IPlatformAdapter = {
+      ...makePlatform(),
+      getPlatformType: mock(() => 'telegram'),
+      getStreamingMode: mock(() => 'stream' as const),
+    };
+
+    await handleMessage(platform, 'conv-1', 'what is this repo?');
+
+    expect(mockAddMessage).toHaveBeenCalledWith(
+      'conv-db-id',
+      'user',
+      'what is this repo?',
+      undefined,
+      undefined
+    );
+    expect(mockAddMessage).toHaveBeenCalledWith(
+      'conv-db-id',
+      'assistant',
+      expect.stringContaining('hello back')
+    );
+    expect(mockAddMessage).toHaveBeenCalledTimes(2);
+  });
+
+  test('does NOT call addMessage for web platform (web adapter owns persistence)', async () => {
+    const platform = makePlatform(); // makePlatform defaults getPlatformType to 'web'
+
+    await handleMessage(platform, 'conv-1', 'what is this repo?');
+
+    expect(mockAddMessage).not.toHaveBeenCalled();
+  });
+
+  test('platform delivery is not blocked when persistence rejects', async () => {
+    const platform: IPlatformAdapter = {
+      ...makePlatform(),
+      getPlatformType: mock(() => 'github'),
+      getStreamingMode: mock(() => 'batch' as const),
+    };
+    mockAddMessage.mockImplementation(() => Promise.reject(new Error('db down')));
+
+    await expect(handleMessage(platform, 'conv-1', 'what is this repo?')).resolves.toBeUndefined();
+    expect(platform.sendMessage).toHaveBeenCalled();
   });
 });

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -3183,6 +3183,9 @@ describe('message persistence for non-web platforms', () => {
     mockAddMessage.mockImplementation(() => Promise.reject(new Error('db down')));
 
     await expect(handleMessage(platform, 'conv-1', 'what is this repo?')).resolves.toBeUndefined();
+    // Stream mode delivers chunks during the sendQuery loop — a DB failure must
+    // not stop delivery, so the reply must still have reached the platform.
+    expect(platform.sendMessage).toHaveBeenCalled();
   });
 
   test('passes userId to addMessage when context provides it', async () => {
@@ -3201,5 +3204,30 @@ describe('message persistence for non-web platforms', () => {
       undefined,
       'user-abc'
     );
+    // The assistant row is NULL-attributed by design — it must NOT carry userId.
+    expect(mockAddMessage).toHaveBeenCalledWith(
+      'conv-db-id',
+      'assistant',
+      expect.stringContaining('hello back')
+    );
+    expect(mockAddMessage).toHaveBeenCalledTimes(2);
+  });
+
+  test('does NOT persist a user row for a deterministic slash command (no orphan)', async () => {
+    const platform: IPlatformAdapter = {
+      ...makePlatform(),
+      getPlatformType: mock(() => 'github'),
+      getStreamingMode: mock(() => 'batch' as const),
+    };
+    mockParseCommand.mockReturnValueOnce({ command: 'status', args: [] });
+    mockHandleCommand.mockReturnValueOnce(
+      Promise.resolve({ success: true, message: 'status ok', workflow: undefined })
+    );
+
+    await handleMessage(platform, 'conv-1', '/status');
+
+    // Deterministic slash commands return before the AI dispatch, so persisting a
+    // user row here would orphan it (no paired assistant row in the Web UI history).
+    expect(mockAddMessage).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -3082,7 +3082,8 @@ describe('per-user AI prefs in chat + tier-fallback nudge', () => {
 
 describe('message persistence for non-web platforms', () => {
   beforeEach(() => {
-    mockAddMessage.mockClear();
+    mockAddMessage.mockReset();
+    mockAddMessage.mockImplementation(() => Promise.resolve());
     mockGetOrCreateConversation.mockReset();
     mockGetCodebase.mockReset();
     mockGetCodebaseEnvVars.mockReset();
@@ -3171,5 +3172,34 @@ describe('message persistence for non-web platforms', () => {
 
     await expect(handleMessage(platform, 'conv-1', 'what is this repo?')).resolves.toBeUndefined();
     expect(platform.sendMessage).toHaveBeenCalled();
+  });
+
+  test('platform delivery is not blocked when persistence rejects (stream mode)', async () => {
+    const platform: IPlatformAdapter = {
+      ...makePlatform(),
+      getPlatformType: mock(() => 'telegram'),
+      getStreamingMode: mock(() => 'stream' as const),
+    };
+    mockAddMessage.mockImplementation(() => Promise.reject(new Error('db down')));
+
+    await expect(handleMessage(platform, 'conv-1', 'what is this repo?')).resolves.toBeUndefined();
+  });
+
+  test('passes userId to addMessage when context provides it', async () => {
+    const platform: IPlatformAdapter = {
+      ...makePlatform(),
+      getPlatformType: mock(() => 'github'),
+      getStreamingMode: mock(() => 'batch' as const),
+    };
+
+    await handleMessage(platform, 'conv-1', 'what is this repo?', { userId: 'user-abc' });
+
+    expect(mockAddMessage).toHaveBeenCalledWith(
+      'conv-db-id',
+      'user',
+      'what is this repo?',
+      undefined,
+      'user-abc'
+    );
   });
 });

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -896,15 +896,16 @@ export async function handleMessage(
       conversationId
     );
 
-    // Persist inbound message for non-web platforms — the web adapter's API
-    // route saves the user row before invoking the orchestrator, so we only
-    // cover GitHub/Telegram/Discord/Slack/CLI here. Fire-and-forget: a DB
+    // Persist inbound message for non-web platforms — the web adapter's route
+    // already persists the user message, so we only cover
+    // GitHub/Telegram/Discord/Slack/CLI here. Fire-and-forget: a DB
     // failure must not break platform delivery (#1182).
     if (!isWebAdapter(platform)) {
-      const dbId = conversation.id;
-      messageDb.addMessage(dbId, 'user', message, undefined, userId).catch((e: unknown) => {
-        getLog().warn({ err: e, conversationId }, 'orchestrator.user_message_persist_failed');
-      });
+      messageDb
+        .addMessage(conversation.id, 'user', message, undefined, userId)
+        .catch((e: unknown) => {
+          getLog().warn({ err: e, conversationId }, 'orchestrator.user_message_persist_failed');
+        });
     }
 
     // Natural-language approval routing — if a workflow is paused in this

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -16,7 +16,7 @@ import type {
   AttachedFile,
 } from '../types';
 import type { SendQueryOptions, TokenUsage } from '@archon/providers/types';
-import { ConversationNotFoundError } from '../types';
+import { ConversationNotFoundError, isWebAdapter } from '../types';
 import * as db from '../db/conversations';
 import * as codebaseDb from '../db/codebases';
 import * as sessionDb from '../db/sessions';
@@ -896,6 +896,17 @@ export async function handleMessage(
       conversationId
     );
 
+    // Persist inbound message for non-web platforms — the web adapter's API
+    // route saves the user row before invoking the orchestrator, so we only
+    // cover GitHub/Telegram/Discord/Slack/CLI here. Fire-and-forget: a DB
+    // failure must not break platform delivery (#1182).
+    if (!isWebAdapter(platform)) {
+      const dbId = conversation.id;
+      messageDb.addMessage(dbId, 'user', message, undefined, userId).catch((e: unknown) => {
+        getLog().warn({ err: e, conversationId }, 'orchestrator.user_message_persist_failed');
+      });
+    }
+
     // Natural-language approval routing — if a workflow is paused in this
     // conversation, treat any non-slash message as the approval response.
     if (!message.startsWith('/')) {
@@ -1668,7 +1679,15 @@ async function handleStreamMode(
     return;
   }
 
-  // Text was already streamed — nothing more to send
+  // Text was already streamed — nothing more to send.
+  // Persist the assistant reply for non-web platforms so it appears in the
+  // Web UI conversation history. The web adapter persists through its
+  // MessagePersistence buffer; skip it here to avoid double-write (#1182).
+  if (!isWebAdapter(platform) && fullResponse) {
+    messageDb.addMessage(conversation.id, 'assistant', fullResponse).catch((e: unknown) => {
+      getLog().warn({ err: e, conversationId }, 'orchestrator.assistant_message_persist_failed');
+    });
+  }
   await maybeSendResultFooter(platform, conversationId, lastResult);
   // Anonymous telemetry: one completed direct-chat turn. The workflow-invocation
   // and project-registration paths return above without reaching this — those
@@ -1912,6 +1931,14 @@ async function handleBatchMode(
   // No orchestrator commands — send the clean response
   getLog().debug({ messageLength: finalMessage.length }, 'sending_final_message');
   await platform.sendMessage(conversationId, finalMessage);
+  // Persist the assistant reply for non-web platforms so it appears in the
+  // Web UI conversation history. The web adapter persists through its
+  // MessagePersistence buffer; skip it here to avoid double-write (#1182).
+  if (!isWebAdapter(platform) && finalMessage) {
+    messageDb.addMessage(conversation.id, 'assistant', finalMessage).catch((e: unknown) => {
+      getLog().warn({ err: e, conversationId }, 'orchestrator.assistant_message_persist_failed');
+    });
+  }
   await maybeSendResultFooter(platform, conversationId, lastResult);
   // Anonymous telemetry: one completed direct-chat turn (same exclusion
   // rationale as the stream-mode capture in handleStreamMode above).

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -896,18 +896,6 @@ export async function handleMessage(
       conversationId
     );
 
-    // Persist inbound message for non-web platforms — the web adapter's route
-    // already persists the user message, so we only cover
-    // GitHub/Telegram/Discord/Slack/CLI here. Fire-and-forget: a DB
-    // failure must not break platform delivery (#1182).
-    if (!isWebAdapter(platform)) {
-      messageDb
-        .addMessage(conversation.id, 'user', message, undefined, userId)
-        .catch((e: unknown) => {
-          getLog().warn({ err: e, conversationId }, 'orchestrator.user_message_persist_failed');
-        });
-    }
-
     // Natural-language approval routing — if a workflow is paused in this
     // conversation, treat any non-slash message as the approval response.
     if (!message.startsWith('/')) {
@@ -1094,6 +1082,25 @@ export async function handleMessage(
         }
         return;
       }
+    }
+
+    // Persist the inbound user message for non-web platforms (Slack/Telegram/
+    // GitHub/Discord/CLI) — the web adapter's route persists web turns itself.
+    // Placed AFTER the deterministic-command and approval early-returns so only
+    // AI-bound turns get a user row (no orphaned user message without an
+    // assistant reply), and BEFORE the AI call so the user row's timestamp
+    // precedes the assistant row's. Fire-and-forget: a DB failure must not break
+    // platform delivery (#1182).
+    if (!isWebAdapter(platform)) {
+      messageDb
+        .addMessage(conversation.id, 'user', message, undefined, userId)
+        .catch((e: unknown) => {
+          const err = e instanceof Error ? e : new Error(String(e));
+          getLog().warn(
+            { err, errorType: err.constructor.name, conversationId },
+            'orchestrator.user_message_persist_failed'
+          );
+        });
     }
 
     // 3. Load codebases, discover workflows, build prompt
@@ -1686,7 +1693,11 @@ async function handleStreamMode(
   // MessagePersistence buffer; skip it here to avoid double-write (#1182).
   if (!isWebAdapter(platform) && fullResponse) {
     messageDb.addMessage(conversation.id, 'assistant', fullResponse).catch((e: unknown) => {
-      getLog().warn({ err: e, conversationId }, 'orchestrator.assistant_message_persist_failed');
+      const err = e instanceof Error ? e : new Error(String(e));
+      getLog().warn(
+        { err, errorType: err.constructor.name, conversationId },
+        'orchestrator.assistant_message_persist_failed'
+      );
     });
   }
   await maybeSendResultFooter(platform, conversationId, lastResult);
@@ -1937,7 +1948,11 @@ async function handleBatchMode(
   // MessagePersistence buffer; skip it here to avoid double-write (#1182).
   if (!isWebAdapter(platform) && finalMessage) {
     messageDb.addMessage(conversation.id, 'assistant', finalMessage).catch((e: unknown) => {
-      getLog().warn({ err: e, conversationId }, 'orchestrator.assistant_message_persist_failed');
+      const err = e instanceof Error ? e : new Error(String(e));
+      getLog().warn(
+        { err, errorType: err.constructor.name, conversationId },
+        'orchestrator.assistant_message_persist_failed'
+      );
     });
   }
   await maybeSendResultFooter(platform, conversationId, lastResult);


### PR DESCRIPTION
## Summary

- **Problem**: Non-web platform conversations (GitHub, Telegram, Discord, Slack) reply successfully on their native platforms but never persist messages to `remote_agent_messages` — every such conversation appears empty in the Web UI.
- **Why it matters**: Any multi-platform deployment where GitHub issues, Telegram chats, or Discord messages are handled by Archon produces conversations that are invisible in the Web UI (both the legacy chat view and the default console). History is permanently lost from the UI's perspective.
- **What changed**: Three targeted insertions in `orchestrator-agent.ts` — persist the inbound user message once (early, after conversation row is guaranteed) and the outbound assistant reply in both stream and batch modes — guarded by `!isWebAdapter(platform)` so the web adapter's existing dual-path persistence is unaffected.
- **What did NOT change**: Adapter implementations are untouched. Tool-call metadata persistence, workflow event/artifact persistence, and slash-command reply persistence are all out of scope. No schema changes.

## UX Journey

### Before

```
User (GitHub/Telegram)    Archon                        Web UI
──────────────────────    ──────                        ──────
sends message ──────────▶ handleMessage()
                          getOrCreateConversation()
                          inheritThreadContext()
                          routes to AI / workflow
                          streams/batches to AI
                          platform.sendMessage() ──────▶ GitHub/Telegram
                                                         (reply visible on platform)
                                                         [NO DB write]

opens Web UI ───────────────────────────────────────▶  listMessages() → 0 rows
                                                         conversation appears EMPTY ❌
```

### After

```
User (GitHub/Telegram)    Archon                        Web UI
──────────────────────    ──────                        ──────
sends message ──────────▶ handleMessage()
                          getOrCreateConversation()
                          inheritThreadContext()
                          [messageDb.addMessage('user')] ← NEW
                          routes to AI / workflow
                          streams/batches to AI
                          platform.sendMessage() ──────▶ GitHub/Telegram
                          [messageDb.addMessage('assistant')] ← NEW

opens Web UI ───────────────────────────────────────▶  listMessages() → 2 rows
                                                         user + assistant messages shown ✅
```

## Architecture Diagram

### Before

```
handleMessage()
  └─▶ inheritThreadContext()
  └─▶ [command routing / AI invocation]
  └─▶ platform.sendMessage()          ← only writes to platform, never to DB for non-web
        └─▶ GitHub API / Telegram API / Discord API

WebAdapter.sendMessage()
  └─▶ persistence.appendText()        ← only web adapter writes to DB
        └─▶ messageDb.addMessage()
```

### After

```
handleMessage()
  └─▶ inheritThreadContext()
  └─▶ [if !isWebAdapter] messageDb.addMessage('user')   [+] NEW
  └─▶ [command routing / AI invocation]
  └─▶ platform.sendMessage()
        └─▶ GitHub API / Telegram API / Discord API
  └─▶ [if !isWebAdapter] messageDb.addMessage('assistant')  [+] NEW

WebAdapter.sendMessage()
  └─▶ persistence.appendText()        ← unchanged
        └─▶ messageDb.addMessage()
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `orchestrator-agent.ts` `handleMessage()` | `messageDb.addMessage()` | **new** | Inbound user message for non-web platforms |
| `orchestrator-agent.ts` `handleStreamMode()` | `messageDb.addMessage()` | **new** | Assistant reply (stream path) for non-web platforms |
| `orchestrator-agent.ts` `handleBatchMode()` | `messageDb.addMessage()` | **new** | Assistant reply (batch path) for non-web platforms |
| `WebAdapter` | `persistence.appendText()` → `messageDb.addMessage()` | unchanged | Web-only path, unaffected |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `core`
- Module: `core:orchestrator`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #1182
- Supersedes #1375 (closed for drifted diff — reimplemented fresh against current dev)

## Validation Evidence (required)

```bash
bun run validate
```

All seven checks pass:

| Check | Result |
|-------|--------|
| check:bundled | ✅ 36 commands, 20 workflows up to date |
| check:bundled-skill | ✅ 23 files across 2 skills up to date |
| check:bundled-schema | ✅ up to date |
| type-check | ✅ all 10 packages clean |
| lint | ✅ 0 errors, 0 warnings |
| format:check | ✅ |
| tests | ✅ all packages, 0 failures |

New regression tests (`orchestrator-agent.test.ts`, 133 total, 4 new):
- `persists user message and assistant reply for non-web platform (batch mode)`
- `persists user message and assistant reply for non-web platform (stream mode)`
- `does NOT call addMessage for web platform (web adapter owns persistence)`
- `platform delivery is not blocked when persistence rejects`

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — existing web conversations are unchanged; non-web conversations will now populate `remote_agent_messages` going forward (no backfill of historical data)
- Config/env changes? No
- Database migration needed? No — `remote_agent_messages` table already exists; we're just writing to it for new non-web messages

## Human Verification (required)

- Verified scenarios: All four regression tests pass covering batch mode (GitHub), stream mode (Telegram), web non-double-persist, and persistence-failure fire-and-forget.
- Edge cases checked: Empty AI response (early-return guards prevent a persist), `userId` as `undefined` (valid per `addMessage` signature), `isWebAdapter` guard prevents double-persist on web.
- What was not verified: Live end-to-end with a real GitHub webhook or Telegram bot (no live adapter credentials in the test environment).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `@archon/core` orchestrator only; no adapter, server, web, or workflow engine changes.
- Potential unintended effects: None — the three new `messageDb.addMessage()` calls are fire-and-forget; a DB failure logs a WARN and does not block platform delivery.
- Guardrails/monitoring for early detection: `orchestrator.user_message_persist_failed` and `orchestrator.assistant_message_persist_failed` WARN log events are emitted on persistence failure.

## Rollback Plan (required)

- Fast rollback command/path: Revert commit `01868e8d` — three small hunks in `orchestrator-agent.ts`.
- Feature flags or config toggles: None — the change is always-on for non-web platforms.
- Observable failure symptoms: WARN logs matching `orchestrator.*_message_persist_failed`; Web UI conversations for non-web platforms revert to empty.

## Risks and Mitigations

- Risk: Persistence failure blocks non-web platform delivery
  - Mitigation: All three writes are fire-and-forget (`.catch()` logs WARN, never throws); platform delivery is independent of DB write.
- Risk: Double-persist on web platform
  - Mitigation: All three insertions are gated on `!isWebAdapter(platform)`; regression test `does NOT call addMessage for web platform` locks this in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation history persistence for non-web chat platforms by saving both inbound user messages and outbound assistant replies.
  * Ensured chat responses are still delivered even if history saving fails.
  * Avoided duplicate history writes for web-based chat flows.
  * Preserved the user identifier on saved user messages when available, while keeping assistant entries unlinked as intended.
* **Documentation**
  * Updated database schema notes to clarify the web vs non-web message persistence behavior and related write-path rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->