### PR TITLE
fix(workflows): interactive loop resume uses fresh session on first iteration

### DIFF
--- a/packages/docs-web/src/content/docs/guides/loop-nodes.md
+++ b/packages/docs-web/src/content/docs/guides/loop-nodes.md
@@ -132,7 +132,10 @@ Controls session continuity between iterations:
 | `true` | Each iteration starts a fresh AI session. No memory of prior iterations. | Work state lives on disk (files, git). Prevents context window exhaustion on long loops. |
 | `false` (default) | Sessions thread — each iteration resumes the prior conversation. | Iterative refinement where the agent needs to remember what it tried before. |
 
-The first iteration is always fresh regardless of this setting.
+The first iteration is always fresh regardless of this setting. The first
+iteration executed after resuming from an interactive loop approval gate is
+also always fresh — the stored session id may have expired during the human
+review wait, and user feedback is carried via `$LOOP_USER_INPUT` instead.
 
 ### `until_bash`
 

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -4960,14 +4960,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // gate, the first resumed iteration must use a fresh session (not the
       // potentially stale stored session id), so the SDK never receives an
       // expired session id that would trigger error_during_execution.
-      let callCount = 0;
       mockSendQueryDag.mockImplementation(function* () {
-        callCount++;
         yield {
           type: 'assistant',
           content: 'Updated plan with error handling. <promise>APPROVED</promise>',
         };
-        yield { type: 'result', sessionId: `fresh-session-${String(callCount)}` };
+        yield { type: 'result', sessionId: 'fresh-session-1' };
       });
 
       const store = createMockStore();

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -4947,9 +4947,90 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // Verify the prompt contains the user input
       const promptArg = mockSendQueryDag.mock.calls[0][0] as string;
       expect(promptArg).toContain('Add error handling');
-      // Should have resumed with stored session ID
+      // Should use a fresh session on the first resumed iteration: the stored
+      // gate session may have expired during the human review wait, so we
+      // start fresh (user feedback is carried via $LOOP_USER_INPUT). See
+      // packages/workflows/src/dag-executor.ts needsFreshSession (#1208).
       const sessionArg = mockSendQueryDag.mock.calls[0][2] as string | undefined;
-      expect(sessionArg).toBe('loop-session-1');
+      expect(sessionArg).toBeUndefined();
+    });
+
+    it('interactive loop resume does not crash with error_during_execution on iteration 2', async () => {
+      // Regression test for #1208: when resuming a paused interactive loop
+      // gate, the first resumed iteration must use a fresh session (not the
+      // potentially stale stored session id), so the SDK never receives an
+      // expired session id that would trigger error_during_execution.
+      let callCount = 0;
+      mockSendQueryDag.mockImplementation(function* () {
+        callCount++;
+        yield {
+          type: 'assistant',
+          content: 'Updated plan with error handling. <promise>APPROVED</promise>',
+        };
+        yield { type: 'result', sessionId: `fresh-session-${String(callCount)}` };
+      });
+
+      const store = createMockStore();
+      const mockDeps = createMockDeps(store);
+      const platform = createMockPlatform();
+      // Simulate resumed run: metadata has loop gate state from iteration 1
+      // with a stale session id (the SDK would reject this if reused).
+      const workflowRun = makeWorkflowRun('resume-no-crash-id', {
+        metadata: {
+          approval: {
+            type: 'interactive_loop',
+            nodeId: 'refine',
+            iteration: 1,
+            sessionId: 'stale-session-from-hours-ago',
+            message: 'Review the plan.',
+          },
+          loop_user_input: 'Add error handling',
+        },
+      });
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        {
+          name: 'interactive-loop-no-crash',
+          nodes: [
+            {
+              id: 'refine',
+              loop: {
+                prompt: 'User said: $LOOP_USER_INPUT. Refine the plan.',
+                until: 'APPROVED',
+                max_iterations: 10,
+                interactive: true,
+                gate_message: 'Review the plan.',
+              },
+            },
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      // Exactly one iteration runs (it completes via APPROVED signal)
+      expect(mockSendQueryDag.mock.calls.length).toBe(1);
+      // Crucially: sessionArg must be undefined (fresh session), NOT the stale stored id.
+      const sessionArg = mockSendQueryDag.mock.calls[0][2] as string | undefined;
+      expect(sessionArg).toBeUndefined();
+
+      // No failure events were emitted (no loop_iteration_failed, no node_failed).
+      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+      const failedEvents = eventCalls.filter((call: unknown[]) => {
+        const evt = (call[0] as Record<string, unknown>).event_type as string;
+        return evt === 'loop_iteration_failed' || evt === 'node_failed';
+      });
+      expect(failedEvents).toHaveLength(0);
     });
 
     it('loop iteration fails loudly when SDK returns error_during_execution', async () => {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -2051,8 +2051,8 @@ async function executeLoopNode(
 
     // Session threading. Force a fresh session on the first iteration of an
     // interactive loop resume: the stored session id from the gate metadata
-    // may reference a Claude SDK session that expired during the human review
-    // wait, which would cause the SDK to return error_during_execution.
+    // may be stale after a human review wait — passing it to the SDK can
+    // trigger errors (e.g. error_during_execution on Claude SDK).
     // User feedback is carried via $LOOP_USER_INPUT, so session continuity is
     // not required for the first resumed iteration.
     const needsFreshSession =

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -2049,8 +2049,14 @@ async function executeLoopNode(
         logEventStoreError(err, i);
       });
 
-    // Session threading
-    const needsFreshSession = loop.fresh_context || i === 1;
+    // Session threading. Force a fresh session on the first iteration of an
+    // interactive loop resume: the stored session id from the gate metadata
+    // may reference a Claude SDK session that expired during the human review
+    // wait, which would cause the SDK to return error_during_execution.
+    // User feedback is carried via $LOOP_USER_INPUT, so session continuity is
+    // not required for the first resumed iteration.
+    const needsFreshSession =
+      loop.fresh_context || i === 1 || (isLoopResume && i === startIteration);
     const resumeSessionId = needsFreshSession ? undefined : currentSessionId;
 
     // Stream AI response for this iteration


### PR DESCRIPTION
## Summary

- **Problem**: Interactive loop nodes (`interactive: true`) crash with `error_during_execution` on every iteration after the first approval gate. Iteration 1 runs fine; resuming at iteration 2+ always fails.
- **Why it matters**: Blocks all interactive loop workflows (e.g. `archon-piv-loop`) from completing after the first human gate — the only workaround was `fresh_context: true` on every node.
- **What changed**: One-line fix in `dag-executor.ts` — added `(isLoopResume && i === startIteration)` to the `needsFreshSession` condition so the first iteration of every interactive resume starts with a fresh SDK session instead of reusing a potentially stale one. Updated one test expectation and added a regression test.
- **What did NOT change**: `fresh_context: true` loops, non-interactive loops, `persist_session` loops, and PR #1291's fail-loud throw are all untouched.

## UX Journey

### Before

```
User                  Archon (DAG executor)           Claude SDK
────                  ─────────────────────           ──────────
approves gate ──────▶ resume loop, i=2
                      needsFreshSession = false
                      resumeSessionId = 'session-from-hours-ago'
                      sendQuery(..., sessionId) ─────▶ session expired → error_during_execution
                      PR #1291 throw ◀──────────────── isError: true
workflow FAILS ◀────  node_failed event
```

### After

```
User                  Archon (DAG executor)           Claude SDK
────                  ─────────────────────           ──────────
approves gate ──────▶ resume loop, i=2
                      [needsFreshSession = TRUE]      (isLoopResume && i === startIteration)
                      [resumeSessionId = undefined]
                      sendQuery(..., undefined) ──────▶ fresh session started
                      receives result ◀─────────────── sessionId: 'new-session'
                      [currentSessionId = 'new-session']
iteration 3+          i=3, needsFreshSession = false
                      resumeSessionId = 'new-session' (valid, from i=2)
                      ...continues normally
```

## Architecture Diagram

### Before

```
dag-executor.ts (executeLoop)
  └─ isLoopResume=true, startIteration=2
     needsFreshSession = fresh_context || i===1   ← i=2, always false on resume
     resumeSessionId   = currentSessionId          ← stale loopGateMeta.sessionId
     sendQuery(prompt, opts, staleSessionId)        ← crashes
```

### After

```
dag-executor.ts (executeLoop)
  └─ isLoopResume=true, startIteration=2
     [~] needsFreshSession = fresh_context || i===1 || (isLoopResume && i===startIteration)
     resumeSessionId   = needsFreshSession ? undefined : currentSessionId
     sendQuery(prompt, opts, undefined)             ← fresh session, no crash
     currentSessionId ← msg.sessionId              ← updated after i=2 for i=3+
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `dag-executor.ts:executeLoop` | `aiClient.sendQuery` | **modified** | `resumeSessionId` is now `undefined` on first resumed iteration |
| `dag-executor.ts:executeLoop` | `loopGateMeta.sessionId` | unchanged | Still read, but now discarded (not passed as `resumeSessionId`) on first resume |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `workflows`
- Module: `workflows:executor`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Fixes #1208
- Related #1291 (fail-loud on `isError` — what made this crash visible)
- Related #1294 (orchestrator-side equivalent fix)

## Validation Evidence (required)

```bash
bun run validate
```

| Check | Result |
|-------|--------|
| Bundled defaults | ✅ 36 commands, 20 workflows up to date |
| Bundled skill | ✅ 23 files across 2 skills up to date |
| Bundled schema | ✅ Up to date |
| Type check | ✅ No errors across all 10 packages |
| Lint | ✅ 0 errors, 0 warnings |
| Format | ✅ All files formatted |
| Tests | ✅ 4721 passed, 0 failed |

Directly relevant tests:
- `interactive loop resumes from stored iteration with user input` — updated expectation (`undefined` instead of `'loop-session-1'`) ✅
- `interactive loop resume does not crash with error_during_execution on iteration 2` — new regression test ✅
- `loop iteration fails loudly when SDK returns error_during_execution` — unchanged fail-loud path ✅

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — the only observable behavior change is that the first iteration of an interactive loop resume no longer passes a potentially stale session ID to the SDK.
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified via test suite that iteration 2 of a resumed interactive loop receives `resumeSessionId = undefined` (fresh session).
- Verified that subsequent iterations (i > startIteration) continue to use `currentSessionId` from the previous iteration, preserving multi-turn continuity within a resume.
- Verified the fail-loud `isError` path (PR #1291) still triggers correctly for non-stale-session failures.
- Not verified: live end-to-end with real Claude SDK against an actual expired session (would require waiting hours for real session expiry).

## Side Effects / Blast Radius (required)

- **Affected**: Interactive loop resume path only (`isLoopResume && i === startIteration`).
- **Not affected**: `fresh_context: true` loops, non-interactive loops, `persist_session` loops, or any non-loop DAG nodes.
- **Potential unintended effect**: If a session is still valid when the user approves (e.g. immediate approval), we now discard a valid session and start fresh. Trade-off is intentional: the cost is a slightly slower start; the benefit is eliminating the crash. User input is carried via `$LOOP_USER_INPUT` so session continuity is not required for context.
- Guardrails: PR #1291's fail-loud throw remains the backstop for any other failure mode.

## Rollback Plan (required)

- Fast rollback: `git revert c06173bd`
- No feature flags needed (one-line condition change).
- Observable failure symptoms: `error_during_execution` in workflow run events for interactive loop nodes on iteration 2+.

## Risks and Mitigations

- Risk: Fresh session loses conversational context from iteration 1.
  - Mitigation: `$LOOP_USER_INPUT` carries the user's approval comment into the prompt; the previous iteration's output is available via `$LOOP_PREV_OUTPUT` if configured. Session continuity for multi-turn refinement is restored from iteration 2 onward (currentSessionId is updated after the fresh first iteration).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interactive loops now use fresh AI sessions when resuming after user input, preventing errors from stale stored sessions.

* **Documentation**
  * Clarified when loop sessions are always treated as fresh, including after interactive approval resumption.

* **Tests**
  * Added regression test for stale session handling during resumed iterations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->