### PR TITLE
fix(cleanup): read worktree.baseBranch config before git default-branch detection

### DIFF
--- a/packages/core/src/services/cleanup-service.test.ts
+++ b/packages/core/src/services/cleanup-service.test.ts
@@ -843,9 +843,11 @@ describe('getWorktreeStatusBreakdown', () => {
     mockGetDefaultBranch.mockClear();
     mockIsBranchMerged.mockClear();
     mockListByCodebaseWithAge.mockClear();
+    mockLoadRepoConfig.mockClear();
     // Reset defaults
     mockGetDefaultBranch.mockResolvedValue('main');
     mockIsBranchMerged.mockResolvedValue(false);
+    mockLoadRepoConfig.mockResolvedValue({});
   });
 
   test('returns correct breakdown with mixed environments', async () => {
@@ -920,7 +922,7 @@ describe('getWorktreeStatusBreakdown', () => {
 
   test('returns empty breakdown for empty codebase', async () => {
     mockListByCodebaseWithAge.mockResolvedValueOnce([]);
-    // getDefaultBranch returns 'main' (default from beforeEach)
+    // resolveBaseBranch returns 'main' (no config → getDefaultBranch fallback, default from beforeEach)
 
     const breakdown = await getWorktreeStatusBreakdown('codebase-1', '/workspace/repo');
 
@@ -944,9 +946,11 @@ describe('cleanupMergedWorktrees', () => {
     mockWorktreeExists.mockClear();
     mockGetCodebase.mockClear();
     mockUpdateStatus.mockClear();
+    mockLoadRepoConfig.mockClear();
     // Reset defaults
     mockGetDefaultBranch.mockResolvedValue('main');
     mockIsBranchMerged.mockResolvedValue(false);
+    mockLoadRepoConfig.mockResolvedValue({});
     mockIsPatchEquivalent.mockReset();
     mockIsPatchEquivalent.mockResolvedValue(false);
     mockGetPrState.mockReset();
@@ -965,7 +969,7 @@ describe('cleanupMergedWorktrees', () => {
       },
     ]);
 
-    // getDefaultBranch returns 'main' (default from beforeEach)
+    // resolveBaseBranch returns 'main' (no config → getDefaultBranch fallback, default from beforeEach)
     // isBranchMerged returns true for this branch
     mockIsBranchMerged.mockResolvedValueOnce(true);
     // hasUncommittedChanges returns false (default from beforeEach)
@@ -1002,7 +1006,7 @@ describe('cleanupMergedWorktrees', () => {
       },
     ]);
 
-    // getDefaultBranch returns 'main' (default from beforeEach)
+    // resolveBaseBranch returns 'main' (no config → getDefaultBranch fallback, default from beforeEach)
     // isBranchMerged returns true
     mockIsBranchMerged.mockResolvedValueOnce(true);
     // Has uncommitted changes
@@ -1027,7 +1031,7 @@ describe('cleanupMergedWorktrees', () => {
       },
     ]);
 
-    // getDefaultBranch returns 'main' (default from beforeEach)
+    // resolveBaseBranch returns 'main' (no config → getDefaultBranch fallback, default from beforeEach)
     // isBranchMerged returns true
     mockIsBranchMerged.mockResolvedValueOnce(true);
     // hasUncommittedChanges returns false (default from beforeEach)

--- a/packages/core/src/services/cleanup-service.test.ts
+++ b/packages/core/src/services/cleanup-service.test.ts
@@ -93,6 +93,14 @@ mock.module('../db/codebases', () => ({
   getCodebase: mockGetCodebase,
 }));
 
+// Mock config-loader (loadRepoConfig) - cleanup-service consults
+// .archon/config.yaml worktree.baseBranch before falling back to git detection.
+type RepoConfigForTest = { worktree?: { baseBranch?: string } };
+const mockLoadRepoConfig = mock(() => Promise.resolve({} as RepoConfigForTest));
+mock.module('../config/config-loader', () => ({
+  loadRepoConfig: mockLoadRepoConfig,
+}));
+
 import {
   runScheduledCleanup,
   startCleanupScheduler,
@@ -118,12 +126,14 @@ describe('cleanup-service', () => {
     mockUpdateStatus.mockClear();
     mockGetById.mockClear();
     mockGetCodebase.mockClear();
+    mockLoadRepoConfig.mockClear();
     // Reset defaults
     mockHasUncommittedChanges.mockResolvedValue(false);
     mockWorktreeExists.mockResolvedValue(false);
     mockGetDefaultBranch.mockResolvedValue('main');
     mockIsBranchMerged.mockResolvedValue(false);
     mockGetLastCommitDate.mockResolvedValue(null);
+    mockLoadRepoConfig.mockResolvedValue({});
   });
 
   describe('removeEnvironment', () => {
@@ -457,12 +467,14 @@ describe('runScheduledCleanup', () => {
     mockGetById.mockClear();
     mockGetCodebase.mockClear();
     mockDeleteOldSessions.mockClear();
+    mockLoadRepoConfig.mockClear();
     // Reset defaults
     mockHasUncommittedChanges.mockResolvedValue(false);
     mockWorktreeExists.mockResolvedValue(false);
     mockGetDefaultBranch.mockResolvedValue('main');
     mockIsBranchMerged.mockResolvedValue(false);
     mockGetLastCommitDate.mockResolvedValue(null);
+    mockLoadRepoConfig.mockResolvedValue({});
   });
 
   test('returns empty report when no environments exist', async () => {
@@ -1187,6 +1199,142 @@ describe('cleanupMergedWorktrees', () => {
         reason: expect.stringContaining('merge check failed'),
       })
     );
+  });
+});
+
+describe('resolveBaseBranch via runScheduledCleanup (issue #1419)', () => {
+  beforeEach(() => {
+    mockListAllActiveWithCodebase.mockClear();
+    mockWorktreeExists.mockClear();
+    mockGetDefaultBranch.mockClear();
+    mockIsBranchMerged.mockClear();
+    mockHasUncommittedChanges.mockClear();
+    mockLoadRepoConfig.mockClear();
+    mockDeleteOldSessions.mockClear();
+    // Defaults
+    mockWorktreeExists.mockResolvedValue(true);
+    mockHasUncommittedChanges.mockResolvedValue(false);
+    mockIsBranchMerged.mockResolvedValue(false);
+    mockLoadRepoConfig.mockResolvedValue({});
+    mockGetDefaultBranch.mockResolvedValue('main');
+  });
+
+  test('uses worktree.baseBranch from config and skips git detection for master-branch repo', async () => {
+    mockListAllActiveWithCodebase.mockResolvedValueOnce([
+      {
+        id: 'env-master',
+        codebase_id: 'codebase-1',
+        status: 'active',
+        branch_name: 'feature/foo',
+        working_path: '/workspace/.archon/worktrees/feature-foo',
+        codebase_default_cwd: '/workspace/myrepo',
+        codebase_repository_url: null,
+        workflow_type: 'workflow',
+        workflow_id: 'wf-1',
+        created_at: new Date(),
+        created_by_platform: null,
+        created_by_user_id: null,
+        metadata: {},
+        provider: 'worktree',
+      },
+    ]);
+    mockLoadRepoConfig.mockResolvedValueOnce({
+      worktree: { baseBranch: 'master' },
+    });
+
+    const report = await runScheduledCleanup();
+
+    // Config took over — getDefaultBranch must NOT have been called for this env.
+    expect(mockGetDefaultBranch).not.toHaveBeenCalled();
+    expect(report.errors).toHaveLength(0);
+    // isBranchMerged called with 'master', not 'main'.
+    expect(mockIsBranchMerged).toHaveBeenCalledWith('/workspace/myrepo', 'feature/foo', 'master');
+  });
+
+  test('trims whitespace and uses the configured base branch', async () => {
+    mockListAllActiveWithCodebase.mockResolvedValueOnce([
+      {
+        id: 'env-trim',
+        codebase_id: 'codebase-1',
+        status: 'active',
+        branch_name: 'feature/baz',
+        working_path: '/workspace/.archon/worktrees/feature-baz',
+        codebase_default_cwd: '/workspace/repo',
+        codebase_repository_url: null,
+        workflow_type: 'workflow',
+        workflow_id: 'wf-3',
+        created_at: new Date(),
+        created_by_platform: null,
+        created_by_user_id: null,
+        metadata: {},
+        provider: 'worktree',
+      },
+    ]);
+    mockLoadRepoConfig.mockResolvedValueOnce({
+      worktree: { baseBranch: '  develop  ' },
+    });
+
+    await runScheduledCleanup();
+
+    expect(mockGetDefaultBranch).not.toHaveBeenCalled();
+    expect(mockIsBranchMerged).toHaveBeenCalledWith('/workspace/repo', 'feature/baz', 'develop');
+  });
+
+  test('falls back to git detection when worktree.baseBranch is not configured', async () => {
+    mockListAllActiveWithCodebase.mockResolvedValueOnce([
+      {
+        id: 'env-main',
+        codebase_id: 'codebase-2',
+        status: 'active',
+        branch_name: 'feature/bar',
+        working_path: '/workspace/.archon/worktrees/feature-bar',
+        codebase_default_cwd: '/workspace/mainrepo',
+        codebase_repository_url: null,
+        workflow_type: 'workflow',
+        workflow_id: 'wf-2',
+        created_at: new Date(),
+        created_by_platform: null,
+        created_by_user_id: null,
+        metadata: {},
+        provider: 'worktree',
+      },
+    ]);
+    mockLoadRepoConfig.mockResolvedValueOnce({}); // no baseBranch configured
+    mockGetDefaultBranch.mockResolvedValueOnce('main');
+
+    await runScheduledCleanup();
+
+    expect(mockGetDefaultBranch).toHaveBeenCalledWith('/workspace/mainrepo');
+    expect(mockIsBranchMerged).toHaveBeenCalledWith('/workspace/mainrepo', 'feature/bar', 'main');
+  });
+
+  test('whitespace-only baseBranch falls back to git detection', async () => {
+    mockListAllActiveWithCodebase.mockResolvedValueOnce([
+      {
+        id: 'env-ws',
+        codebase_id: 'codebase-3',
+        status: 'active',
+        branch_name: 'feature/qux',
+        working_path: '/workspace/.archon/worktrees/feature-qux',
+        codebase_default_cwd: '/workspace/repo3',
+        codebase_repository_url: null,
+        workflow_type: 'workflow',
+        workflow_id: 'wf-4',
+        created_at: new Date(),
+        created_by_platform: null,
+        created_by_user_id: null,
+        metadata: {},
+        provider: 'worktree',
+      },
+    ]);
+    mockLoadRepoConfig.mockResolvedValueOnce({
+      worktree: { baseBranch: '   ' },
+    });
+    mockGetDefaultBranch.mockResolvedValueOnce('main');
+
+    await runScheduledCleanup();
+
+    expect(mockGetDefaultBranch).toHaveBeenCalledWith('/workspace/repo3');
   });
 });
 

--- a/packages/core/src/services/cleanup-service.ts
+++ b/packages/core/src/services/cleanup-service.ts
@@ -34,10 +34,9 @@ function getLog(): ReturnType<typeof createLogger> {
 }
 
 // Resolve the base branch for a repo, preferring worktree.baseBranch from
-// .archon/config.yaml before falling back to runtime git detection. Without
-// this, repos that use 'master' as default branch (and don't set origin/HEAD)
-// hit getDefaultBranch's "set worktree.baseBranch" error — even when the user
-// already did, because the cleanup service never read it. See #1419.
+// .archon/config.yaml before falling back to runtime git detection. Repos
+// that use 'master' as default and don't have origin/HEAD set will fail
+// getDefaultBranch — reading the config first avoids that error.
 async function resolveBaseBranch(repoPath: RepoPath, cwd: string): Promise<BranchName> {
   const repoConfig = await loadRepoConfig(cwd);
   const configured = repoConfig.worktree?.baseBranch?.trim();

--- a/packages/core/src/services/cleanup-service.ts
+++ b/packages/core/src/services/cleanup-service.ts
@@ -24,12 +24,27 @@ import type { RepoPath, BranchName } from '@archon/git';
 import { createLogger } from '@archon/paths';
 import type { IsolationEnvironmentRow } from '@archon/isolation';
 import { ConversationNotFoundError } from '../types';
+import { loadRepoConfig } from '../config/config-loader';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
 function getLog(): ReturnType<typeof createLogger> {
   if (!cachedLog) cachedLog = createLogger('cleanup');
   return cachedLog;
+}
+
+// Resolve the base branch for a repo, preferring worktree.baseBranch from
+// .archon/config.yaml before falling back to runtime git detection. Without
+// this, repos that use 'master' as default branch (and don't set origin/HEAD)
+// hit getDefaultBranch's "set worktree.baseBranch" error — even when the user
+// already did, because the cleanup service never read it. See #1419.
+async function resolveBaseBranch(repoPath: RepoPath, cwd: string): Promise<BranchName> {
+  const repoConfig = await loadRepoConfig(cwd);
+  const configured = repoConfig.worktree?.baseBranch?.trim();
+  if (configured) {
+    return toBranchName(configured);
+  }
+  return getDefaultBranch(repoPath);
 }
 
 // Configuration constants (configurable via env vars)
@@ -308,7 +323,7 @@ export async function runScheduledCleanup(): Promise<CleanupReport> {
 
         // Check if branch is merged
         const mainRepoPath = toRepoPath(env.codebase_default_cwd);
-        const mainBranch = await getDefaultBranch(mainRepoPath);
+        const mainBranch = await resolveBaseBranch(mainRepoPath, env.codebase_default_cwd);
         const merged = await isBranchMerged(
           mainRepoPath,
           toBranchName(env.branch_name),
@@ -462,7 +477,7 @@ export async function getWorktreeStatusBreakdown(
     activeEnvs: [],
   };
 
-  const mainBranch = await getDefaultBranch(repoPath);
+  const mainBranch = await resolveBaseBranch(repoPath, mainRepoPath);
 
   for (const env of environments) {
     // Skip Telegram (never shown as stale)
@@ -590,7 +605,7 @@ export async function cleanupMergedWorktrees(
   const result: CleanupOperationResult = { removed: [], skipped: [] };
   const environments = await isolationEnvDb.listByCodebase(codebaseId);
   const repoPath = toRepoPath(mainRepoPath);
-  const mainBranch = await getDefaultBranch(repoPath);
+  const mainBranch = await resolveBaseBranch(repoPath, mainRepoPath);
   const includeClosed = options.includeClosed ?? false;
   const prStateCache = new Map<string, PrState>();
 


### PR DESCRIPTION
## Summary

- **Problem**: The cleanup service called `getDefaultBranch()` unconditionally at 3 call sites, causing repeated `env_cleanup_error` logs on every startup for repos whose default branch is not `main` and where `origin/HEAD` is not configured. The error message told users to set `worktree.baseBranch` in `.archon/config.yaml`, but that config value was never read by the cleanup service — making the suggestion useless.
- **Why it matters**: Every tracked environment on a `master`-branch repo triggered a logged error per startup with no viable workaround. Prior fix attempts (#1423, #1424) were closed without landing.
- **What changed**: Added a private `resolveBaseBranch` helper in `cleanup-service.ts` that reads `worktree.baseBranch` from `.archon/config.yaml` first, falling back to `getDefaultBranch()` only when nothing is configured. Replaced all 3 `getDefaultBranch` call sites with `resolveBaseBranch`. Added 4 regression tests.
- **What did not change**: `getDefaultBranch` itself is unchanged; `config-loader.ts` is unchanged; no interface or DB schema changes; the `codebase.default_branch` DB-column fallback (mentioned as "and/or" in the issue) was intentionally omitted to keep scope minimal.

## UX Journey

### Before

```
Startup
  ┌─ for each tracked environment
  │    cleanupService.runScheduledCleanup()
  │      getDefaultBranch(mainRepoPath)   ← throws if origin/HEAD unset + no origin/main
  │        ERROR: env_cleanup_error logged  ← repeats every startup, per env
  │        User sees: "Set worktree.baseBranch in .archon/config.yaml"
  │          ↳ User sets config…
  │            ↳ Error still fires (config never read)  ← dead end
  └─ repeat every startup
```

### After

```
Startup
  ┌─ for each tracked environment
  │    cleanupService.runScheduledCleanup()
  │      resolveBaseBranch(mainRepoPath, cwd)
  │        1. loadRepoConfig(cwd)
  │           worktree.baseBranch set?  →  return configured branch  ← no error
  │           not set?
  │        2. getDefaultBranch(mainRepoPath)
  │           origin/HEAD exists?   →  return detected branch
  │           origin/main exists?   →  return 'main'
  │           neither?              →  throw (legitimate detection failure)
  └─ repeat every startup
```

## Architecture Diagram

### Before

```
cleanup-service.ts
  runScheduledCleanup()       ──calls──▶  @archon/git:getDefaultBranch()
  getWorktreeStatusBreakdown() ──calls──▶  @archon/git:getDefaultBranch()
  cleanupMergedWorktrees()    ──calls──▶  @archon/git:getDefaultBranch()

config-loader.ts (loadRepoConfig)  ◀── NOT imported in cleanup-service.ts
```

### After

```
cleanup-service.ts
  resolveBaseBranch()  [+]    ──reads──▶  config-loader.ts:loadRepoConfig()  [+new connection]
                              ──calls──▶  @archon/git:getDefaultBranch()  (fallback only)

  runScheduledCleanup()       ──calls──▶  resolveBaseBranch()  [~ was getDefaultBranch]
  getWorktreeStatusBreakdown() ──calls──▶  resolveBaseBranch()  [~ was getDefaultBranch]
  cleanupMergedWorktrees()    ──calls──▶  resolveBaseBranch()  [~ was getDefaultBranch]
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `cleanup-service.ts` | `@archon/git:getDefaultBranch` | **modified** | Now indirect via `resolveBaseBranch`; not called when config provides branch |
| `cleanup-service.ts` | `config-loader.ts:loadRepoConfig` | **new** | Added to consult `worktree.baseBranch` first |
| `resolveBaseBranch` | `@archon/git:getDefaultBranch` | **new** | Fallback path when no config value set |
| `resolveBaseBranch` | `config-loader.ts:loadRepoConfig` | **new** | Primary resolution path |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`
- Module: `core:cleanup-service`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #1419
- Supersedes #1423, #1424

## Validation Evidence (required)

```bash
bun run validate
```

All checks passed on the first run:

| Check | Result |
|-------|--------|
| Bundled defaults | ✅ 36 commands, 20 workflows — up to date |
| Bundled skill | ✅ 23 files — up to date |
| Bundled schema | ✅ Up to date |
| Type check | ✅ No errors (all 10 packages) |
| Lint | ✅ 0 errors, 0 warnings |
| Format | ✅ All files formatted |
| Tests | ✅ 111 test files, 0 failures (4 new regression tests in cleanup-service.test.ts) |

- Evidence provided: all 7 `bun run validate` checks passed; 4 new regression tests covering: master-branch-via-config, fallback-to-git-detection, whitespace-trimming, whitespace-only-fallback.
- No checks skipped.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No — `loadRepoConfig` reads `.archon/config.yaml` in the repo CWD, which the cleanup service already has access to.

## Compatibility / Migration

- Backward compatible? Yes — when `worktree.baseBranch` is not configured, behavior is identical to before.
- Config/env changes? No new config keys; existing undocumented-but-documented `worktree.baseBranch` now actually works.
- Database migration needed? No.

## Human Verification (required)

- Verified scenarios: type-check, lint, format, full test suite (including new regression tests) all pass via `bun run validate`.
- Edge cases checked: whitespace-only `baseBranch` correctly falls through to git detection; `loadRepoConfig` returning `{}` (file absent) correctly falls through to git detection.
- What was not verified: live end-to-end against a real `master`-branch repo — the regression tests cover this path at the unit level.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: cleanup service only (`runScheduledCleanup`, `getWorktreeStatusBreakdown`, `cleanupMergedWorktrees`).
- Potential unintended effects: `loadRepoConfig` is called once per tracked environment per cleanup cycle — this is a cheap local file read on a scheduled (non-hot) path, so performance impact is negligible.
- Guardrails: existing per-environment `try/catch` in `runScheduledCleanup` continues to catch any `loadRepoConfig` parse errors and log them as `env_cleanup_error` (with a more useful message than before).

## Rollback Plan (required)

- Fast rollback: `git revert 03fdd3e7` — single commit, no migration to undo.
- Feature flags/config toggles: none required; the change activates only when `worktree.baseBranch` is set.
- Observable failure symptoms: `env_cleanup_error` in server logs per tracked environment on startup (same as before the fix).

## Risks and Mitigations

- Risk: `loadRepoConfig` throws on a malformed `.archon/config.yaml` in a tracked repo.
  - Mitigation: The existing `try/catch` in `runScheduledCleanup` at line ~375 already catches per-environment errors and logs them. `getWorktreeStatusBreakdown` and `cleanupMergedWorktrees` propagate the error to their callers, which already handle it. No new unhandled throw paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to specify a base branch for repository cleanup operations. Falls back to git default branch detection if not explicitly configured.

* **Bug Fixes**
  * Enhanced base branch resolution logic for scheduled cleanup tasks (issue `#1419`), including whitespace trimming and improved fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->