### PR TITLE
feat(settings): AI Settings UI + config tiers editor + CLI parity (PR 3b)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,6 +293,14 @@ bun run cli ai login <provider>            # connect a SUBSCRIPTION (claude/copi
 bun run cli ai list                        # list connected providers (no secrets)
 bun run cli ai logout <provider>           # disconnect a provider
 
+# Model tiers + default assistant (install-wide config; works on solo installs — these
+# write ~/.archon/config.yaml and need NO TOKEN_ENCRYPTION_KEY). Full parity with the
+# console "AI Settings" → Model Tiers / Defaults sections.
+bun run cli ai tier set <tier> <provider> <model> [--effort <e>]   # set small/medium/large → provider/model
+bun run cli ai tier list [--json]          # show configured tiers vs built-in defaults
+bun run cli ai tier unset <tier>           # reset a tier to its built-in default
+bun run cli ai default <provider>          # set the default assistant
+
 # Inspect or rotate the anonymous telemetry install UUID
 bun run cli telemetry status
 bun run cli telemetry reset
@@ -910,6 +918,11 @@ Pattern: Use `classifyIsolationError()` (from `@archon/isolation`) to map git er
 - `POST /api/auth/providers/:provider/oauth/start` - Begin a subscription (OAuth) login (claude/copilot; **codex gated** — Pi drops the OpenAI `id_token` so the Codex CLI rejects the auth.json, see #1924; codex stays API-key-only); returns `{ sessionId, mode: 'manual'|'device', url?, userCode?, verificationUri?, expiresIn }` (no secret). 400 non-subscription provider, 404 disabled. Held server-side by the `oauth-bridge` (over Pi's `login()`). `SUBSCRIPTION_PROVIDERS` (in `oauth-providers.ts`) is the single source of truth — it excludes providers wired in `ARCHON_TO_PI_OAUTH` but not usable end-to-end.
 - `POST /api/auth/providers/:provider/oauth/poll` - Poll the login session; body `{ sessionId, code? }` (`code` = pasted manual-code); returns `{ status: 'pending'|'connected'|'error', detail? }`. Session bound to the caller's userId.
 - Gated on `isPerUserProviderKeysEnabled()` (`TOKEN_ENCRYPTION_KEY`); credentials (API keys + subscriptions) injected into runs/chat env at execution time. Subscription tokens refresh-on-read and re-save on rotation. Subscriptions are delivered to native Claude/Codex (env / `CODEX_HOME/auth.json`) AND to Pi (per-run `auth.json` via `ARCHON_PI_AUTH_PATH`).
+
+**Config (System; ungated — works on solo installs, NOT `requireWebUser`):**
+- `GET /api/config` - Read-only safe config; returns `{ config, database }`. `config` includes `tiers` (configured small/medium/large presets) and `tierDefaults` (built-in presets for the default provider, computed via `buildAiProfile` — lets the UI show what an unset tier resolves to).
+- `PATCH /api/config/assistants` - Update default assistant + per-provider model defaults.
+- `PATCH /api/config/tiers` - Update model-tier presets; body `{ tiers: { small?, medium?, large? } }` where each tier is `{ provider, model, effort? }` or `null` (unset). Per-key merge; validates each `provider` via `isRegisteredProvider`. Writes `~/.archon/config.yaml`. Drives the console "AI Settings → Model Tiers" panel + `archon ai tier` CLI.
 
 **System:**
 - `GET /api/health` - Health check with adapter/system status

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -72,7 +72,16 @@ import { validateWorkflowsCommand, validateCommandsCommand } from './commands/va
 import { serveCommand } from './commands/serve';
 import { doctorCommand } from './commands/doctor';
 import { authGithubCommand } from './commands/auth';
-import { aiKeySetCommand, aiListCommand, aiLogoutCommand, aiLoginCommand } from './commands/ai';
+import {
+  aiKeySetCommand,
+  aiListCommand,
+  aiLogoutCommand,
+  aiLoginCommand,
+  aiTierSetCommand,
+  aiTierListCommand,
+  aiTierUnsetCommand,
+  aiDefaultCommand,
+} from './commands/ai';
 import { telemetryStatusCommand, telemetryResetCommand } from './commands/telemetry';
 import { closeDatabase } from '@archon/core';
 import {
@@ -124,9 +133,13 @@ Commands:
   doctor                     Verify your Archon setup (Claude binary, gh auth, DB, adapters)
   auth github                Connect your GitHub identity via device flow (multi-user installs)
   ai key set <provider>      Connect an AI provider API key (multi-user installs; key read from prompt/stdin)
-  ai login <provider>        Connect a subscription (claude/codex/copilot) via OAuth
+  ai login <provider>        Connect a subscription (claude/copilot) via OAuth — codex is API-key only
   ai list                    List your connected AI provider keys
   ai logout <provider>       Disconnect an AI provider key
+  ai tier set <t> <p> <m>    Set a model tier (small/medium/large) → provider/model [--effort <e>]
+  ai tier list [--json]      Show configured tiers vs built-in defaults
+  ai tier unset <tier>       Reset a tier to its built-in default
+  ai default <provider>      Set the default assistant
   telemetry status           Show anonymous telemetry state (enabled, reason, ID, host)
   telemetry reset            Rotate the anonymous install UUID
   validate workflows [name]  Validate workflow definitions and their references
@@ -282,6 +295,7 @@ async function main(): Promise<number> {
         all: { type: 'boolean' },
         status: { type: 'string' },
         limit: { type: 'string' },
+        effort: { type: 'string' },
       },
       allowPositionals: true,
       strict: false, // Allow unknown flags to pass through
@@ -806,13 +820,38 @@ async function main(): Promise<number> {
             return await aiLogoutCommand(positionals[2]);
           case 'login':
             return await aiLoginCommand(positionals[2]);
+          case 'tier': {
+            const action = positionals[2];
+            switch (action) {
+              case 'set':
+                return await aiTierSetCommand(
+                  positionals[3],
+                  positionals[4],
+                  positionals[5],
+                  values.effort as string | undefined
+                );
+              case 'list':
+                return await aiTierListCommand(jsonFlag);
+              case 'unset':
+                return await aiTierUnsetCommand(positionals[3]);
+              default:
+                console.error(
+                  'Usage: archon ai tier set <small|medium|large> <provider> <model> [--effort <e>] | tier list [--json] | tier unset <tier>'
+                );
+                return 1;
+            }
+          }
+          case 'default':
+            return await aiDefaultCommand(positionals[2]);
           default:
             if (subcommand === undefined) {
               console.error('Missing ai subcommand');
             } else {
               console.error(`Unknown ai subcommand: ${subcommand}`);
             }
-            console.error('Available: key set <provider>, list, logout <provider>');
+            console.error(
+              'Available: key set <provider>, login <provider>, list, logout <provider>, tier set|list|unset, default <provider>'
+            );
             return 1;
         }
       }

--- a/packages/cli/src/commands/ai.test.ts
+++ b/packages/cli/src/commands/ai.test.ts
@@ -62,6 +62,13 @@ const mockPollOAuth = mock(
     ({ status: 'connected' }) as { status: 'pending' | 'connected' | 'error'; detail?: string }
 );
 
+const mockUpdateGlobalConfig = mock(async (_updates: unknown) => {});
+let loadConfigResult: { assistant: string; tiers?: Record<string, unknown> } = {
+  assistant: 'claude',
+  tiers: {},
+};
+const mockLoadConfig = mock(async () => loadConfigResult);
+
 mock.module('@archon/core', () => ({
   isPerUserProviderKeysEnabled: () => enabled,
   persistProviderApiKey: mockPersist,
@@ -71,6 +78,8 @@ mock.module('@archon/core', () => ({
   SUBSCRIPTION_PROVIDERS: SUBSCRIPTION,
   startOAuth: mockStartOAuth,
   pollOAuth: mockPollOAuth,
+  loadConfig: mockLoadConfig,
+  updateGlobalConfig: mockUpdateGlobalConfig,
 }));
 mock.module('@archon/core/db/users', () => ({
   findOrCreateUserByPlatformIdentity: mock(async () => ({ id: 'u1' })),
@@ -78,7 +87,21 @@ mock.module('@archon/core/db/users', () => ({
 mock.module('./auth', () => ({ resolveCliUserId: () => 'cli-alice' }));
 mock.module('@archon/paths', () => ({ createLogger: noopLogger }));
 
-import { aiKeySetCommand, aiListCommand, aiLogoutCommand, aiLoginCommand } from './ai';
+// @archon/providers is NOT mocked — register builtins so isRegisteredProvider()
+// (used by the tier/default commands) resolves claude/codex/etc.
+import { registerBuiltinProviders } from '@archon/providers';
+registerBuiltinProviders();
+
+import {
+  aiKeySetCommand,
+  aiListCommand,
+  aiLogoutCommand,
+  aiLoginCommand,
+  aiTierSetCommand,
+  aiTierListCommand,
+  aiTierUnsetCommand,
+  aiDefaultCommand,
+} from './ai';
 
 let logSpy: ReturnType<typeof spyOn<Console, 'log'>>;
 let errSpy: ReturnType<typeof spyOn<Console, 'error'>>;
@@ -91,6 +114,9 @@ beforeEach(() => {
   mockPersist.mockClear();
   mockList.mockClear();
   mockDelete.mockClear();
+  mockUpdateGlobalConfig.mockClear();
+  mockLoadConfig.mockClear();
+  loadConfigResult = { assistant: 'claude', tiers: {} };
   logSpy = spyOn(console, 'log').mockImplementation(() => {});
   errSpy = spyOn(console, 'error').mockImplementation(() => {});
 });
@@ -241,5 +267,79 @@ describe('aiLoginCommand', () => {
     mockPollOAuth.mockReturnValueOnce({ status: 'error', detail: 'denied' });
     expect(await aiLoginCommand('copilot')).toBe(1);
     expect(out()).toContain('denied');
+  });
+});
+
+describe('aiTierSetCommand', () => {
+  it('sets a tier → 0 and writes a clean RawAliasEntry', async () => {
+    expect(await aiTierSetCommand('large', 'claude', 'opus', 'high')).toBe(0);
+    expect(mockUpdateGlobalConfig).toHaveBeenCalledTimes(1);
+    const arg = mockUpdateGlobalConfig.mock.calls[0]?.[0] as { tiers: Record<string, unknown> };
+    expect(arg.tiers.large).toEqual({ provider: 'claude', model: 'opus', effort: 'high' });
+  });
+
+  it('invalid tier name → 1, no write', async () => {
+    expect(await aiTierSetCommand('huge', 'claude', 'opus', undefined)).toBe(1);
+    expect(mockUpdateGlobalConfig).not.toHaveBeenCalled();
+  });
+
+  it('unknown provider → 1, no write', async () => {
+    expect(await aiTierSetCommand('large', 'bogus-provider', 'x', undefined)).toBe(1);
+    expect(out()).toContain('Unknown provider');
+    expect(mockUpdateGlobalConfig).not.toHaveBeenCalled();
+  });
+
+  it('missing model → 1', async () => {
+    expect(await aiTierSetCommand('large', 'claude', undefined, undefined)).toBe(1);
+    expect(mockUpdateGlobalConfig).not.toHaveBeenCalled();
+  });
+});
+
+describe('aiTierUnsetCommand', () => {
+  it('unset → 0 and writes null', async () => {
+    expect(await aiTierUnsetCommand('medium')).toBe(0);
+    const arg = mockUpdateGlobalConfig.mock.calls[0]?.[0] as { tiers: Record<string, unknown> };
+    expect(arg.tiers.medium).toBeNull();
+  });
+
+  it('invalid tier → 1, no write', async () => {
+    expect(await aiTierUnsetCommand('xl')).toBe(1);
+    expect(mockUpdateGlobalConfig).not.toHaveBeenCalled();
+  });
+});
+
+describe('aiTierListCommand', () => {
+  it('lists configured tiers + built-in defaults, exits 0', async () => {
+    loadConfigResult = {
+      assistant: 'claude',
+      tiers: { large: { provider: 'codex', model: 'gpt-5.5' } },
+    };
+    expect(await aiTierListCommand(false)).toBe(0);
+    const text = out();
+    expect(text).toContain('codex/gpt-5.5'); // configured large
+    expect(text).toContain('default'); // unset tiers show their default
+  });
+
+  it('--json emits structured output', async () => {
+    loadConfigResult = { assistant: 'claude', tiers: {} };
+    expect(await aiTierListCommand(true)).toBe(0);
+    const parsed = JSON.parse(logSpy.mock.calls[0]?.[0] as string) as {
+      defaultAssistant: string;
+      tiers: unknown[];
+    };
+    expect(parsed.defaultAssistant).toBe('claude');
+    expect(Array.isArray(parsed.tiers)).toBe(true);
+  });
+});
+
+describe('aiDefaultCommand', () => {
+  it('sets the default assistant → 0', async () => {
+    expect(await aiDefaultCommand('codex')).toBe(0);
+    expect(mockUpdateGlobalConfig).toHaveBeenCalledWith({ defaultAssistant: 'codex' });
+  });
+
+  it('unknown provider → 1, no write', async () => {
+    expect(await aiDefaultCommand('nope')).toBe(1);
+    expect(mockUpdateGlobalConfig).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/ai.test.ts
+++ b/packages/cli/src/commands/ai.test.ts
@@ -289,6 +289,12 @@ describe('aiTierSetCommand', () => {
     expect(mockUpdateGlobalConfig).not.toHaveBeenCalled();
   });
 
+  it('invalid effort for the provider → 1, no write', async () => {
+    expect(await aiTierSetCommand('large', 'claude', 'opus', 'ultra')).toBe(1);
+    expect(out()).toContain('Invalid effort');
+    expect(mockUpdateGlobalConfig).not.toHaveBeenCalled();
+  });
+
   it('missing model → 1', async () => {
     expect(await aiTierSetCommand('large', 'claude', undefined, undefined)).toBe(1);
     expect(mockUpdateGlobalConfig).not.toHaveBeenCalled();

--- a/packages/cli/src/commands/ai.ts
+++ b/packages/cli/src/commands/ai.ts
@@ -28,7 +28,13 @@ import {
   SUBSCRIPTION_PROVIDERS,
   startOAuth,
   pollOAuth,
+  loadConfig,
+  updateGlobalConfig,
+  type TiersPatch,
 } from '@archon/core';
+import { isRegisteredProvider, getProviderInfoList } from '@archon/providers';
+import { TIER_NAMES, buildAiProfile } from '@archon/workflows/model-validation';
+import type { TierName, RawAliasEntry } from '@archon/workflows/model-validation';
 import * as userDb from '@archon/core/db/users';
 import { resolveCliUserId } from './auth';
 
@@ -255,4 +261,136 @@ async function pollLoginLoop(
   }
   console.error('\n✗ Subscription login timed out.');
   return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Model tiers + default assistant — install-wide config (writes config.yaml).
+// These are NOT credentials, so there's NO `ensureEnabled`/`resolveUser` gate;
+// they work on every install (solo too), mirroring the ungated config routes.
+// ---------------------------------------------------------------------------
+
+function isTierName(v: string | undefined): v is TierName {
+  return v !== undefined && (TIER_NAMES as readonly string[]).includes(v);
+}
+
+function providerCatalog(): string {
+  return getProviderInfoList()
+    .map(p => p.id)
+    .join(', ');
+}
+
+/** `archon ai tier set <small|medium|large> <provider> <model> [--effort <e>]` */
+export async function aiTierSetCommand(
+  tier: string | undefined,
+  provider: string | undefined,
+  model: string | undefined,
+  effort: string | undefined
+): Promise<number> {
+  if (!isTierName(tier) || !provider || !model) {
+    console.error(
+      'Usage: archon ai tier set <small|medium|large> <provider> <model> [--effort <effort>]'
+    );
+    return 1;
+  }
+  if (!isRegisteredProvider(provider)) {
+    console.error(`Unknown provider '${provider}'. Available: ${providerCatalog()}.`);
+    return 1;
+  }
+  const entry: RawAliasEntry = { provider, model, ...(effort ? { effort } : {}) };
+  const tiers: TiersPatch = {};
+  tiers[tier] = entry;
+  try {
+    await updateGlobalConfig({ tiers });
+    console.log(
+      `✓ Set tier '${tier}' → ${provider}/${model}${effort ? ` (effort: ${effort})` : ''}.`
+    );
+    return 0;
+  } catch (err) {
+    getLog().error({ err: err as Error, tier }, 'cli.ai_tier_set_failed');
+    console.error(`✗ ${(err as Error).message}`);
+    return 1;
+  }
+}
+
+/** `archon ai tier unset <small|medium|large>` — reset a tier to its built-in default. */
+export async function aiTierUnsetCommand(tier: string | undefined): Promise<number> {
+  if (!isTierName(tier)) {
+    console.error('Usage: archon ai tier unset <small|medium|large>');
+    return 1;
+  }
+  const tiers: TiersPatch = {};
+  tiers[tier] = null;
+  try {
+    await updateGlobalConfig({ tiers });
+    console.log(`✓ Unset tier '${tier}' (falls back to the built-in default).`);
+    return 0;
+  } catch (err) {
+    getLog().error({ err: err as Error, tier }, 'cli.ai_tier_unset_failed');
+    console.error(`✗ ${(err as Error).message}`);
+    return 1;
+  }
+}
+
+/** `archon ai tier list [--json]` — show configured tiers vs built-in defaults. */
+export async function aiTierListCommand(json?: boolean): Promise<number> {
+  try {
+    const config = await loadConfig();
+    const configured = config.tiers ?? {};
+    // No options → just the built-in tier-defaults for the default provider.
+    const defaults = buildAiProfile(config.assistant).aliases;
+    const rows = TIER_NAMES.map(tier => {
+      const set = configured[tier];
+      const def = defaults[tier];
+      return {
+        tier,
+        configured: set ? { provider: set.provider, model: set.model, effort: set.effort } : null,
+        default: def ? { provider: def.provider, model: def.model, effort: def.effort } : null,
+      };
+    });
+
+    if (json) {
+      console.log(JSON.stringify({ defaultAssistant: config.assistant, tiers: rows }, null, 2));
+      return 0;
+    }
+
+    console.log(`Model tiers (default assistant: ${config.assistant}):`);
+    for (const r of rows) {
+      const label = r.tier.padEnd(7);
+      if (r.configured) {
+        const eff = r.configured.effort ? ` (effort: ${r.configured.effort})` : '';
+        console.log(`  ${label} ${r.configured.provider}/${r.configured.model}${eff}`);
+      } else if (r.default) {
+        console.log(`  ${label} (default: ${r.default.provider}/${r.default.model})`);
+      } else {
+        console.log(`  ${label} (unset)`);
+      }
+    }
+    return 0;
+  } catch (err) {
+    getLog().error({ err: err as Error }, 'cli.ai_tier_list_failed');
+    console.error(`✗ Failed to list tiers: ${(err as Error).message}`);
+    return 1;
+  }
+}
+
+/** `archon ai default <provider>` — set the default assistant (`defaultAssistant`). */
+export async function aiDefaultCommand(provider: string | undefined): Promise<number> {
+  if (!provider) {
+    console.error('Usage: archon ai default <provider>');
+    console.error(`Providers: ${providerCatalog()}`);
+    return 1;
+  }
+  if (!isRegisteredProvider(provider)) {
+    console.error(`Unknown provider '${provider}'. Available: ${providerCatalog()}.`);
+    return 1;
+  }
+  try {
+    await updateGlobalConfig({ defaultAssistant: provider });
+    console.log(`✓ Default assistant set to '${provider}'.`);
+    return 0;
+  } catch (err) {
+    getLog().error({ err: err as Error, provider }, 'cli.ai_default_failed');
+    console.error(`✗ ${(err as Error).message}`);
+    return 1;
+  }
 }

--- a/packages/cli/src/commands/ai.ts
+++ b/packages/cli/src/commands/ai.ts
@@ -1,13 +1,17 @@
 /**
- * `archon ai` — manage the current CLI user's per-user AI-provider credentials.
+ * `archon ai` — per-user AI-provider credentials AND install-wide model config.
  *
  *   archon ai key set <provider>   Connect an API key (read from masked prompt or piped stdin)
  *   archon ai list                 List connected providers (metadata only, no secrets)
  *   archon ai logout <provider>    Disconnect a provider
- *   archon ai login <provider>     (reserved — OAuth subscription login ships in a later release)
+ *   archon ai login <provider>     Connect a subscription (claude/copilot) via OAuth
+ *   archon ai tier set|list|unset  Edit small/medium/large tier presets (config, not a credential)
+ *   archon ai default <provider>   Set the default assistant (config, not a credential)
  *
- * Gated on TOKEN_ENCRYPTION_KEY (isPerUserProviderKeysEnabled). Solo installs
- * keep reading provider keys from the environment unchanged.
+ * The CREDENTIAL commands (key/list/logout/login) are gated on
+ * TOKEN_ENCRYPTION_KEY (isPerUserProviderKeysEnabled); solo installs keep reading
+ * provider keys from the environment unchanged. The CONFIG commands (tier/default)
+ * write ~/.archon/config.yaml and are ungated — they work on every install.
  *
  * The API key is NEVER taken from argv (it would leak into shell history and the
  * process list). It is read from a masked `@clack/prompts` password input on a
@@ -33,7 +37,12 @@ import {
   type TiersPatch,
 } from '@archon/core';
 import { isRegisteredProvider, getProviderInfoList } from '@archon/providers';
-import { TIER_NAMES, buildAiProfile } from '@archon/workflows/model-validation';
+import {
+  TIER_NAMES,
+  buildAiProfile,
+  isEffortValidForProvider,
+  validEffortsForProvider,
+} from '@archon/workflows/model-validation';
 import type { TierName, RawAliasEntry } from '@archon/workflows/model-validation';
 import * as userDb from '@archon/core/db/users';
 import { resolveCliUserId } from './auth';
@@ -273,7 +282,7 @@ function isTierName(v: string | undefined): v is TierName {
   return v !== undefined && (TIER_NAMES as readonly string[]).includes(v);
 }
 
-function providerCatalog(): string {
+function registeredProvidersList(): string {
   return getProviderInfoList()
     .map(p => p.id)
     .join(', ');
@@ -293,7 +302,14 @@ export async function aiTierSetCommand(
     return 1;
   }
   if (!isRegisteredProvider(provider)) {
-    console.error(`Unknown provider '${provider}'. Available: ${providerCatalog()}.`);
+    console.error(`Unknown provider '${provider}'. Available: ${registeredProvidersList()}.`);
+    return 1;
+  }
+  if (effort !== undefined && !isEffortValidForProvider(provider, effort)) {
+    console.error(
+      `Invalid effort '${effort}' for provider '${provider}'. ` +
+        `Valid: ${validEffortsForProvider(provider)?.join(', ') ?? '(this provider has no effort setting)'}.`
+    );
     return 1;
   }
   const entry: RawAliasEntry = { provider, model, ...(effort ? { effort } : {}) };
@@ -337,7 +353,14 @@ export async function aiTierListCommand(json?: boolean): Promise<number> {
     const config = await loadConfig();
     const configured = config.tiers ?? {};
     // No options → just the built-in tier-defaults for the default provider.
-    const defaults = buildAiProfile(config.assistant).aliases;
+    // Degrade like the route's `tierDefaultsFor` (buildAiProfile ~never throws
+    // with no aliases, but a defaults lookup must not fail the whole listing).
+    let defaults: Record<string, RawAliasEntry> = {};
+    try {
+      defaults = buildAiProfile(config.assistant).aliases;
+    } catch (err) {
+      getLog().warn({ err: err as Error }, 'cli.ai_tier_list_defaults_failed');
+    }
     const rows = TIER_NAMES.map(tier => {
       const set = configured[tier];
       const def = defaults[tier];
@@ -377,11 +400,11 @@ export async function aiTierListCommand(json?: boolean): Promise<number> {
 export async function aiDefaultCommand(provider: string | undefined): Promise<number> {
   if (!provider) {
     console.error('Usage: archon ai default <provider>');
-    console.error(`Providers: ${providerCatalog()}`);
+    console.error(`Providers: ${registeredProvidersList()}`);
     return 1;
   }
   if (!isRegisteredProvider(provider)) {
-    console.error(`Unknown provider '${provider}'. Available: ${providerCatalog()}.`);
+    console.error(`Unknown provider '${provider}'. Available: ${registeredProvidersList()}.`);
     return 1;
   }
   try {

--- a/packages/core/src/config/config-loader.test.ts
+++ b/packages/core/src/config/config-loader.test.ts
@@ -690,6 +690,55 @@ assistants:
         'Permission denied'
       );
     });
+
+    test('sets a model tier', async () => {
+      mockFsReadFile.mockResolvedValue('defaultAssistant: claude\n');
+      await updateGlobalConfig({ tiers: { large: { provider: 'claude', model: 'opus' } } });
+      const written = mockFsWriteFile.mock.calls[0]?.[1] as string;
+      expect(written).toContain('tiers');
+      expect(written).toContain('opus');
+    });
+
+    test('per-tier merge: setting one tier preserves the others', async () => {
+      mockFsReadFile.mockResolvedValue(`
+tiers:
+  small:
+    provider: claude
+    model: haiku
+`);
+      await updateGlobalConfig({ tiers: { large: { provider: 'codex', model: 'gpt-5.5' } } });
+      const written = mockFsWriteFile.mock.calls[0]?.[1] as string;
+      expect(written).toContain('haiku'); // small preserved
+      expect(written).toContain('gpt-5.5'); // large added
+    });
+
+    test('null tier value unsets that tier', async () => {
+      mockFsReadFile.mockResolvedValue(`
+tiers:
+  large:
+    provider: claude
+    model: opus
+`);
+      await updateGlobalConfig({ tiers: { large: null } });
+      const written = mockFsWriteFile.mock.calls[0]?.[1] as string;
+      expect(written).not.toContain('opus');
+    });
+
+    test('existing tiers survive an assistants-only update', async () => {
+      mockFsReadFile.mockResolvedValue(`
+tiers:
+  large:
+    provider: claude
+    model: opus
+assistants:
+  claude:
+    model: sonnet
+`);
+      await updateGlobalConfig({ assistants: { claude: { model: 'haiku' } } });
+      const written = mockFsWriteFile.mock.calls[0]?.[1] as string;
+      expect(written).toContain('opus'); // tiers preserved via the {...current} spread
+      expect(written).toContain('haiku');
+    });
   });
 
   describe('toSafeConfig', () => {
@@ -732,6 +781,23 @@ assistants:
       expect(safe.assistants.claude).toBeDefined();
       expect(safe.assistants.codex).toBeDefined();
       expect(safe.assistants.codex).not.toHaveProperty('additionalDirectories');
+    });
+
+    test('exposes configured tiers and computed tierDefaults', async () => {
+      mockFsReadFile.mockResolvedValue(`
+defaultAssistant: claude
+tiers:
+  large:
+    provider: codex
+    model: gpt-5.5
+`);
+      const config = await loadConfig();
+      const safe = toSafeConfig(config);
+      // Configured tier round-trips.
+      expect(safe.tiers?.large).toEqual({ provider: 'codex', model: 'gpt-5.5' });
+      // tierDefaults = built-in presets for the default provider (claude → opus@large).
+      expect(safe.tierDefaults?.large).toEqual({ provider: 'claude', model: 'opus' });
+      expect(safe.tierDefaults?.small).toEqual({ provider: 'claude', model: 'haiku' });
     });
   });
 });

--- a/packages/core/src/config/config-loader.test.ts
+++ b/packages/core/src/config/config-loader.test.ts
@@ -724,6 +724,21 @@ tiers:
       expect(written).not.toContain('opus');
     });
 
+    test('unsetting every tier collapses `tiers` to undefined (no empty tiers key)', async () => {
+      mockFsReadFile.mockResolvedValue(`
+defaultAssistant: claude
+tiers:
+  large:
+    provider: claude
+    model: opus
+`);
+      await updateGlobalConfig({ tiers: { small: null, medium: null, large: null } });
+      const written = mockFsWriteFile.mock.calls[0]?.[1] as string;
+      expect(written).not.toContain('opus');
+      // Collapsed to `undefined` → no serialized `tiers:` key at all.
+      expect(written).not.toMatch(/^tiers:/m);
+    });
+
     test('existing tiers survive an assistants-only update', async () => {
       mockFsReadFile.mockResolvedValue(`
 tiers:

--- a/packages/core/src/config/config-loader.ts
+++ b/packages/core/src/config/config-loader.ts
@@ -45,6 +45,15 @@ import {
   registerBuiltinProviders,
   registerCommunityProviders,
 } from '@archon/providers';
+import { buildAiProfile, TIER_NAMES } from '@archon/workflows/model-validation';
+import type { RawAliasEntry, TierName } from '@archon/workflows/model-validation';
+
+/**
+ * A per-key patch for the `tiers:` config. Unlike `RawTiersConfig`, a tier value
+ * may be `null` to explicitly UNSET it (RawTiersConfig can't express removal).
+ * Consumed by `updateGlobalConfig({ tiers })`.
+ */
+export type TiersPatch = Partial<Record<TierName, RawAliasEntry | null>>;
 
 /**
  * Pure read of registered provider IDs. Registration is guaranteed by
@@ -569,7 +578,9 @@ export function logConfig(config: MergedConfig): void {
  * Reads current config, deep-merges updates, and writes back to YAML.
  * Invalidates the cached config so next loadConfig() picks up changes.
  */
-export async function updateGlobalConfig(updates: Partial<GlobalConfig>): Promise<void> {
+export async function updateGlobalConfig(
+  updates: Partial<Omit<GlobalConfig, 'tiers'>> & { tiers?: TiersPatch }
+): Promise<void> {
   const configPath = getArchonConfigPath();
 
   try {
@@ -597,6 +608,24 @@ export async function updateGlobalConfig(updates: Partial<GlobalConfig>): Promis
       merged.concurrency = { ...current.concurrency, ...updates.concurrency };
     }
 
+    if (updates.tiers) {
+      // Per-key merge: `null` unsets a tier, a value sets it, and an absent key
+      // (`undefined`) preserves the existing tier — so a single-tier PATCH/CLI
+      // set doesn't wipe the others. Rebuilt fresh (no dynamic delete).
+      const nextTiers: RawTiersConfig = {};
+      for (const tier of TIER_NAMES) {
+        const incoming = updates.tiers[tier];
+        if (incoming === null) continue; // explicit unset → omit
+        if (incoming !== undefined) {
+          nextTiers[tier] = incoming;
+        } else {
+          const existing = current.tiers?.[tier];
+          if (existing) nextTiers[tier] = existing;
+        }
+      }
+      merged.tiers = Object.keys(nextTiers).length > 0 ? nextTiers : undefined;
+    }
+
     // Serialize to YAML and write
     const yaml = Bun.YAML.stringify(merged);
     await mkdir(dirname(configPath), { recursive: true });
@@ -620,6 +649,33 @@ export async function updateGlobalConfig(updates: Partial<GlobalConfig>): Promis
 }
 
 /**
+ * Built-in tier presets (small/medium/large) for a provider, from
+ * tier-defaults.json via buildAiProfile. Lets the settings UI show what an
+ * unset tier resolves to. Never throws — an unknown/odd provider yields {}.
+ */
+function tierDefaultsFor(provider: string): RawTiersConfig | undefined {
+  try {
+    const profile = buildAiProfile(provider);
+    const out: RawTiersConfig = {};
+    for (const tier of TIER_NAMES) {
+      const preset = profile.aliases[tier];
+      if (preset) {
+        out[tier] = {
+          provider: preset.provider,
+          model: preset.model,
+          ...(preset.effort !== undefined ? { effort: preset.effort } : {}),
+          ...(preset.thinking !== undefined ? { thinking: preset.thinking } : {}),
+        };
+      }
+    }
+    return Object.keys(out).length > 0 ? out : undefined;
+  } catch (error) {
+    getLog().warn({ provider, err: error }, 'config.tier_defaults_failed');
+    return undefined;
+  }
+}
+
+/**
  * Project a MergedConfig to a SafeConfig suitable for sending to web clients.
  * Strips filesystem paths and any other server-internal fields.
  */
@@ -639,5 +695,7 @@ export function toSafeConfig(config: MergedConfig): SafeConfig {
       loadDefaultCommands: config.defaults.loadDefaultCommands,
       loadDefaultWorkflows: config.defaults.loadDefaultWorkflows,
     },
+    tiers: config.tiers,
+    tierDefaults: tierDefaultsFor(config.assistant),
   };
 }

--- a/packages/core/src/config/config-loader.ts
+++ b/packages/core/src/config/config-loader.ts
@@ -651,7 +651,8 @@ export async function updateGlobalConfig(
 /**
  * Built-in tier presets (small/medium/large) for a provider, from
  * tier-defaults.json via buildAiProfile. Lets the settings UI show what an
- * unset tier resolves to. Never throws — an unknown/odd provider yields {}.
+ * unset tier resolves to. Never throws — an unknown/odd provider (or a throw)
+ * yields `undefined` (every consumer uses optional chaining).
  */
 function tierDefaultsFor(provider: string): RawTiersConfig | undefined {
   try {

--- a/packages/core/src/config/config-types.ts
+++ b/packages/core/src/config/config-types.ts
@@ -354,4 +354,12 @@ export interface SafeConfig {
     loadDefaultCommands: boolean;
     loadDefaultWorkflows: boolean;
   };
+  /** Configured small/medium/large tier presets (merged repo > global). */
+  tiers?: RawTiersConfig;
+  /**
+   * Built-in tier presets for the current default provider (from
+   * tier-defaults.json via buildAiProfile). Lets the editor show what an
+   * unset tier resolves to without the web bundle importing @archon/workflows.
+   */
+  tierDefaults?: RawTiersConfig;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -111,6 +111,7 @@ export {
   logConfig,
   toSafeConfig,
   updateGlobalConfig,
+  type TiersPatch,
 } from './config/config-loader';
 
 // =============================================================================

--- a/packages/server/src/routes/api.providers.test.ts
+++ b/packages/server/src/routes/api.providers.test.ts
@@ -18,6 +18,7 @@ const mockLoadConfig = mock(async () => ({
   worktree: { baseBranch: 'main' },
 }));
 const mockGetDatabaseType = mock(() => 'sqlite' as const);
+const mockUpdateGlobalConfig = mock(async (_updates: unknown) => {});
 
 mock.module('@archon/core', () => ({
   handleMessage: mock(async () => {}),
@@ -34,7 +35,7 @@ mock.module('@archon/core', () => ({
   getArchonWorkspacesPath: () => '/tmp/.archon/workspaces',
   toSafeConfig: (config: unknown) => config,
   generateAndSetTitle: mock(async () => {}),
-  updateGlobalConfig: mock(async () => {}),
+  updateGlobalConfig: mockUpdateGlobalConfig,
   createLogger: () => ({
     fatal: mock(() => undefined),
     error: mock(() => undefined),
@@ -225,5 +226,62 @@ describe('GET /api/providers', () => {
     expect(typeof caps.hooks).toBe('boolean');
     // structuredOutput is the tiered union, not a boolean.
     expect(['enforced', 'best-effort', false]).toContain(caps.structuredOutput);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: PATCH /api/config/tiers (ungated — solo-OK)
+// ---------------------------------------------------------------------------
+
+describe('PATCH /api/config/tiers', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = makeApp();
+    mockUpdateGlobalConfig.mockClear();
+  });
+
+  function patch(tiers: unknown): Promise<Response> {
+    return app.request('/api/config/tiers', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tiers }),
+    });
+  }
+
+  test('sets a tier → 200 and calls updateGlobalConfig with a clean RawAliasEntry', async () => {
+    const res = await patch({ large: { provider: 'claude', model: 'opus', effort: 'high' } });
+    expect(res.status).toBe(200);
+    expect(mockUpdateGlobalConfig).toHaveBeenCalledTimes(1);
+    const arg = mockUpdateGlobalConfig.mock.calls[0]?.[0] as { tiers: Record<string, unknown> };
+    expect(arg.tiers.large).toEqual({ provider: 'claude', model: 'opus', effort: 'high' });
+  });
+
+  test('unknown provider → 400, no write', async () => {
+    const res = await patch({ large: { provider: 'definitely-not-a-provider', model: 'x' } });
+    expect(res.status).toBe(400);
+    expect(mockUpdateGlobalConfig).not.toHaveBeenCalled();
+  });
+
+  test('null tier value unsets (passes null through)', async () => {
+    const res = await patch({ large: null });
+    expect(res.status).toBe(200);
+    const arg = mockUpdateGlobalConfig.mock.calls[0]?.[0] as { tiers: Record<string, unknown> };
+    expect(arg.tiers.large).toBeNull();
+  });
+
+  test('drops `thinking` from the written entry (no UI surface)', async () => {
+    const res = await patch({
+      small: { provider: 'claude', model: 'haiku', thinking: { level: 'high' } },
+    });
+    expect(res.status).toBe(200);
+    const arg = mockUpdateGlobalConfig.mock.calls[0]?.[0] as { tiers: Record<string, unknown> };
+    expect(arg.tiers.small).toEqual({ provider: 'claude', model: 'haiku' });
+  });
+
+  test('is ungated — succeeds with no auth identity', async () => {
+    // No X-Archon-User header, web auth disabled in the harness → still 200.
+    const res = await patch({ medium: { provider: 'claude', model: 'sonnet' } });
+    expect(res.status).toBe(200);
   });
 });

--- a/packages/server/src/routes/api.providers.test.ts
+++ b/packages/server/src/routes/api.providers.test.ts
@@ -263,6 +263,12 @@ describe('PATCH /api/config/tiers', () => {
     expect(mockUpdateGlobalConfig).not.toHaveBeenCalled();
   });
 
+  test('invalid effort for the provider → 400, no write (not silently dropped)', async () => {
+    const res = await patch({ large: { provider: 'claude', model: 'opus', effort: 'ultra' } });
+    expect(res.status).toBe(400);
+    expect(mockUpdateGlobalConfig).not.toHaveBeenCalled();
+  });
+
   test('null tier value unsets (passes null through)', async () => {
     const res = await patch({ large: null });
     expect(res.status).toBe(200);

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -150,7 +150,11 @@ import {
   updateTiersBodySchema,
   codebaseEnvironmentsResponseSchema,
 } from './schemas/config.schemas';
-import { TIER_NAMES } from '@archon/workflows/model-validation';
+import {
+  TIER_NAMES,
+  isEffortValidForProvider,
+  validEffortsForProvider,
+} from '@archon/workflows/model-validation';
 import { providerListResponseSchema } from './schemas/provider.schemas';
 import {
   authStatusResponseSchema,
@@ -3701,6 +3705,14 @@ export function registerApiRoutes(
             `Unknown provider '${entry.provider}' for tier '${tier}'. Available: ${getProviderInfoList()
               .map(p => p.id)
               .join(', ')}`
+          );
+        }
+        if (entry.effort !== undefined && !isEffortValidForProvider(entry.provider, entry.effort)) {
+          return apiError(
+            c,
+            400,
+            `Invalid effort '${entry.effort}' for provider '${entry.provider}' (tier '${tier}'). ` +
+              `Valid: ${validEffortsForProvider(entry.provider)?.join(', ') ?? '(none)'}`
           );
         }
         // Build a clean RawAliasEntry — drop `thinking` (no UI/CLI surface yet).

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -16,6 +16,7 @@ import type {
   AttachedFile,
   HandleMessageContext,
   GlobalConfig,
+  TiersPatch,
   UserRole,
 } from '@archon/core';
 import {
@@ -146,8 +147,10 @@ import {
   updateAssistantConfigBodySchema,
   updateAssistantConfigResponseSchema,
   configResponseSchema,
+  updateTiersBodySchema,
   codebaseEnvironmentsResponseSchema,
 } from './schemas/config.schemas';
+import { TIER_NAMES } from '@archon/workflows/model-validation';
 import { providerListResponseSchema } from './schemas/provider.schemas';
 import {
   authStatusResponseSchema,
@@ -870,6 +873,30 @@ const patchAssistantConfigRoute = createRoute({
   responses: {
     200: {
       content: { 'application/json': { schema: updateAssistantConfigResponseSchema } },
+      description: 'Updated configuration',
+    },
+    400: jsonError('Invalid request body'),
+    500: jsonError('Server error'),
+  },
+});
+
+const patchTiersConfigRoute = createRoute({
+  method: 'patch',
+  path: '/api/config/tiers',
+  tags: ['System'],
+  summary: 'Update model-tier presets (small/medium/large)',
+  description:
+    'Writes the `tiers:` config to ~/.archon/config.yaml. Ungated (works on solo ' +
+    'installs). Per-tier merge; a `null` tier value unsets it.',
+  request: {
+    body: {
+      content: { 'application/json': { schema: updateTiersBodySchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: configResponseSchema } },
       description: 'Updated configuration',
     },
     400: jsonError('Invalid request body'),
@@ -3650,6 +3677,50 @@ export function registerApiRoutes(
     } catch (error) {
       getLog().error({ err: error }, 'config.assistants_update_failed');
       return apiError(c, 500, 'Failed to update assistant configuration');
+    }
+  });
+
+  // PATCH /api/config/tiers - Update model-tier presets (ungated — solo-OK, like /assistants)
+  registerOpenApiRoute(patchTiersConfigRoute, async c => {
+    try {
+      const body = getValidatedBody(c, updateTiersBodySchema);
+
+      // Validate the provider of each tier we're SETTING (null = unset, skip).
+      const tiers: TiersPatch = {};
+      for (const tier of TIER_NAMES) {
+        const entry = body.tiers[tier];
+        if (entry === undefined) continue;
+        if (entry === null) {
+          tiers[tier] = null;
+          continue;
+        }
+        if (!isRegisteredProvider(entry.provider)) {
+          return apiError(
+            c,
+            400,
+            `Unknown provider '${entry.provider}' for tier '${tier}'. Available: ${getProviderInfoList()
+              .map(p => p.id)
+              .join(', ')}`
+          );
+        }
+        // Build a clean RawAliasEntry — drop `thinking` (no UI/CLI surface yet).
+        tiers[tier] = {
+          provider: entry.provider,
+          model: entry.model,
+          ...(entry.effort !== undefined ? { effort: entry.effort } : {}),
+        };
+      }
+
+      await updateGlobalConfig({ tiers });
+
+      const config = await loadConfig();
+      return c.json({
+        config: toSafeConfig(config),
+        database: getDatabaseType(),
+      });
+    } catch (error) {
+      getLog().error({ err: error }, 'config.tiers_update_failed');
+      return apiError(c, 500, 'Failed to update tier configuration');
     }
   });
 

--- a/packages/server/src/routes/schemas/config.schemas.ts
+++ b/packages/server/src/routes/schemas/config.schemas.ts
@@ -9,7 +9,9 @@ const providerDefaultsSchema = z.record(z.string(), z.unknown()).openapi('Provid
 /**
  * A single model-tier preset — mirrors `RawAliasEntry` in
  * `@archon/workflows/model-validation` ({ provider, model, effort?, thinking? }).
- * `thinking` is structurally allowed (pass-through) but has no UI surface yet.
+ * `thinking` is accepted on READ so it round-trips an existing config.yaml, but
+ * the PATCH /api/config/tiers handler DROPS it on write (no UI/CLI surface yet) —
+ * so saving a tier in the UI/CLI clears any `thinking` previously set in YAML.
  */
 export const tierEntrySchema = z
   .object({

--- a/packages/server/src/routes/schemas/config.schemas.ts
+++ b/packages/server/src/routes/schemas/config.schemas.ts
@@ -6,6 +6,40 @@ import { z } from '@hono/zod-openapi';
 /** Schema for the safe config subset returned to web clients (mirrors SafeConfig in config-types.ts). */
 const providerDefaultsSchema = z.record(z.string(), z.unknown()).openapi('ProviderDefaults');
 
+/**
+ * A single model-tier preset — mirrors `RawAliasEntry` in
+ * `@archon/workflows/model-validation` ({ provider, model, effort?, thinking? }).
+ * `thinking` is structurally allowed (pass-through) but has no UI surface yet.
+ */
+export const tierEntrySchema = z
+  .object({
+    provider: z.string().min(1),
+    model: z.string().min(1),
+    effort: z.string().optional(),
+    thinking: z.unknown().optional(),
+  })
+  .openapi('TierEntry');
+
+/** The three reserved tiers, each optional — mirrors `RawTiersConfig`. */
+export const tiersConfigSchema = z
+  .object({
+    small: tierEntrySchema.optional(),
+    medium: tierEntrySchema.optional(),
+    large: tierEntrySchema.optional(),
+  })
+  .openapi('TiersConfig');
+
+/** PATCH /api/config/tiers body — each tier optional; `null` unsets that tier. */
+export const updateTiersBodySchema = z
+  .object({
+    tiers: z.object({
+      small: tierEntrySchema.nullable().optional(),
+      medium: tierEntrySchema.nullable().optional(),
+      large: tierEntrySchema.nullable().optional(),
+    }),
+  })
+  .openapi('UpdateTiersBody');
+
 export const safeConfigSchema = z
   .object({
     botName: z.string(),
@@ -23,6 +57,10 @@ export const safeConfigSchema = z
       loadDefaultCommands: z.boolean(),
       loadDefaultWorkflows: z.boolean(),
     }),
+    // Configured small/medium/large tiers (merged repo > global). Absent keys
+    // fall back to `tierDefaults` (built-in presets for the default provider).
+    tiers: tiersConfigSchema.optional(),
+    tierDefaults: tiersConfigSchema.optional(),
   })
   .openapi('SafeConfig');
 

--- a/packages/web/src/experiments/console/components/AssistantConfigPanel.tsx
+++ b/packages/web/src/experiments/console/components/AssistantConfigPanel.tsx
@@ -96,14 +96,14 @@ export function AssistantConfigPanel(): ReactElement {
   const loadError = configError ?? providersError;
   if (loadError !== undefined) {
     return (
-      <SettingsSection title="Assistant">
+      <SettingsSection title="Defaults">
         <p className="font-mono text-[11px] text-error">{loadError.message}</p>
       </SettingsSection>
     );
   }
   if (form === null || providers === undefined) {
     return (
-      <SettingsSection title="Assistant">
+      <SettingsSection title="Defaults">
         <p className="font-mono text-[11px] text-text-tertiary">Loading…</p>
       </SettingsSection>
     );
@@ -132,7 +132,7 @@ export function AssistantConfigPanel(): ReactElement {
   };
 
   return (
-    <SettingsSection title="Assistant">
+    <SettingsSection title="Defaults">
       <label className="mb-5 flex items-center gap-[18px]">
         <span className="w-[150px] shrink-0 text-[13.5px] font-semibold text-text-secondary">
           Default assistant

--- a/packages/web/src/experiments/console/components/ModelTiersPanel.tsx
+++ b/packages/web/src/experiments/console/components/ModelTiersPanel.tsx
@@ -85,6 +85,15 @@ export function ModelTiersPanel(): ReactElement {
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
 
+  // Guard async setState after unmount (mirrors ProviderConnectionsPanel).
+  const cancelledRef = useRef(false);
+  useEffect(() => {
+    cancelledRef.current = false;
+    return (): void => {
+      cancelledRef.current = true;
+    };
+  }, []);
+
   const loadError = configError ?? providersError;
   if (loadError !== undefined) {
     return (
@@ -113,11 +122,13 @@ export function ModelTiersPanel(): ReactElement {
     setSaveError(null);
     try {
       await skill.updateTiers(skill.buildTiersUpdate(form));
+      if (cancelledRef.current) return;
       invalidate(K.config); // refetch re-seeds the form and clears `dirty`
     } catch (e: unknown) {
+      if (cancelledRef.current) return;
       setSaveError(e instanceof Error ? e.message : 'Failed to save tiers.');
     } finally {
-      setSaving(false);
+      if (!cancelledRef.current) setSaving(false);
     }
   };
 

--- a/packages/web/src/experiments/console/components/ModelTiersPanel.tsx
+++ b/packages/web/src/experiments/console/components/ModelTiersPanel.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useRef, useState, type ReactElement, type ReactNode } from 'react';
+import * as skill from '../skills';
+import type { ProviderInfo, SafeConfigTiers, TiersForm, TierName, TierRowForm } from '../skills';
+import { TIER_ORDER } from '../skills';
+import { useEntity, invalidate } from '../store/cache';
+import { K } from '../store/keys';
+import { SettingsSection } from './SettingsSection';
+
+// Field styling mirrors AssistantConfigPanel (design v5 .set-input / .set-select):
+// mono fields on the page surface with a magenta focus ring.
+const INPUT_CLASS =
+  'w-full rounded-[9px] border border-border bg-surface px-3.5 py-[11px] font-mono text-[13px] text-text-primary placeholder:text-text-tertiary transition-all focus:border-accent-bright/50 focus:outline-none focus:shadow-[0_0_0_3px_color-mix(in_oklch,var(--brand-magenta),transparent_92%)]';
+const SELECT_CLASS =
+  'w-full cursor-pointer appearance-none rounded-[9px] border border-border bg-surface-elevated py-[11px] pl-3.5 pr-8 font-mono text-[13px] font-semibold text-text-primary transition-all focus:border-accent-bright/50 focus:outline-none focus:shadow-[0_0_0_3px_color-mix(in_oklch,var(--brand-magenta),transparent_92%)]';
+
+/** Relative wrapper that overlays the design chevron on an appearance-none select. */
+function SelectShell({
+  children,
+  className = '',
+}: {
+  children: ReactNode;
+  className?: string;
+}): ReactElement {
+  return (
+    <span className={`relative inline-flex items-center ${className}`}>
+      {children}
+      <span
+        aria-hidden
+        className="pointer-events-none absolute right-[11px] flex text-text-tertiary"
+      >
+        <svg
+          width="13"
+          height="13"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </span>
+    </span>
+  );
+}
+
+/** Seed the editable tier form from the saved config (configured tiers only). */
+function seedTiers(cfg: SafeConfigTiers): TiersForm {
+  const row = (t: TierName): TierRowForm => {
+    const set = cfg.tiers?.[t];
+    return { provider: set?.provider ?? '', model: set?.model ?? '', effort: set?.effort ?? '' };
+  };
+  return { small: row('small'), medium: row('medium'), large: row('large') };
+}
+
+/** "provider/model" hint for an unset tier's built-in default. */
+function defaultHint(cfg: SafeConfigTiers, t: TierName): string {
+  const d = cfg.tierDefaults?.[t];
+  return d ? `${d.provider}/${d.model}` : 'built-in default';
+}
+
+/**
+ * Editor for the install-wide model tiers (small/medium/large → provider/model).
+ * Writes PATCH /api/config/tiers → ~/.archon/config.yaml. Ungated, so it works on
+ * solo installs too (unlike Provider Auth). A row left on "Default" is sent as an
+ * unset and falls back to the built-in preset for the default provider.
+ */
+export function ModelTiersPanel(): ReactElement {
+  const { data: config, error: configError } = useEntity(K.config, skill.getConfig);
+  const { data: providers, error: providersError } = useEntity<ProviderInfo[]>(
+    K.providers,
+    skill.listProviders
+  );
+
+  const [form, setForm] = useState<TiersForm | null>(null);
+  const baselineRef = useRef('');
+  useEffect(() => {
+    if (config === undefined) return;
+    const seeded = seedTiers(config.config as SafeConfigTiers);
+    setForm(seeded);
+    baselineRef.current = JSON.stringify(seeded);
+  }, [config]);
+
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const loadError = configError ?? providersError;
+  if (loadError !== undefined) {
+    return (
+      <SettingsSection title="Model Tiers">
+        <p className="font-mono text-[11px] text-error">{loadError.message}</p>
+      </SettingsSection>
+    );
+  }
+  if (form === null || providers === undefined || config === undefined) {
+    return (
+      <SettingsSection title="Model Tiers">
+        <p className="font-mono text-[11px] text-text-tertiary">Loading…</p>
+      </SettingsSection>
+    );
+  }
+
+  const cfg = config.config as SafeConfigTiers;
+  const dirty = JSON.stringify(form) !== baselineRef.current;
+
+  const setRow = (t: TierName, partial: Partial<TierRowForm>): void => {
+    setForm(f => (f === null ? f : { ...f, [t]: { ...f[t], ...partial } }));
+  };
+
+  const onSave = async (): Promise<void> => {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await skill.updateTiers(skill.buildTiersUpdate(form));
+      invalidate(K.config); // refetch re-seeds the form and clears `dirty`
+    } catch (e: unknown) {
+      setSaveError(e instanceof Error ? e.message : 'Failed to save tiers.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <SettingsSection title="Model Tiers">
+      <p className="mb-4 text-[12.5px] leading-relaxed text-text-tertiary">
+        Bundled workflows resolve <code className="font-mono">small</code> /{' '}
+        <code className="font-mono">medium</code> / <code className="font-mono">large</code> to
+        these models. Leave a row on “Default” to use the built-in preset.
+      </p>
+
+      <div className="flex flex-col gap-[11px]">
+        {TIER_ORDER.map(tier => {
+          const row = form[tier];
+          const unset = row.provider === '';
+          return (
+            <div
+              key={tier}
+              className="flex flex-wrap items-center gap-[14px] rounded-xl border border-border bg-surface-elevated p-4"
+            >
+              <div className="w-[78px] shrink-0 text-[13.5px] font-bold capitalize text-text-primary">
+                {tier}
+              </div>
+              <SelectShell className="w-[160px] shrink-0">
+                <select
+                  value={row.provider}
+                  onChange={e => {
+                    setRow(tier, { provider: e.target.value });
+                  }}
+                  className={SELECT_CLASS}
+                >
+                  <option value="">Default ({defaultHint(cfg, tier)})</option>
+                  {providers.map(p => (
+                    <option key={p.id} value={p.id}>
+                      {p.displayName}
+                    </option>
+                  ))}
+                </select>
+              </SelectShell>
+              <input
+                value={row.model}
+                onChange={e => {
+                  setRow(tier, { model: e.target.value });
+                }}
+                disabled={unset}
+                placeholder={
+                  unset ? `default: ${defaultHint(cfg, tier)}` : 'model (e.g. opus, gpt-5.5)'
+                }
+                className={`${INPUT_CLASS} min-w-[160px] flex-1 ${unset ? 'opacity-50' : ''}`}
+              />
+              <input
+                value={row.effort}
+                onChange={e => {
+                  setRow(tier, { effort: e.target.value });
+                }}
+                disabled={unset}
+                placeholder="effort"
+                className={`${INPUT_CLASS} w-[110px] shrink-0 ${unset ? 'opacity-50' : ''}`}
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mt-[18px] flex items-center justify-end gap-3">
+        {saveError !== null ? (
+          <span className="font-mono text-[11px] text-error">{saveError}</span>
+        ) : null}
+        <button
+          type="button"
+          onClick={() => void onSave()}
+          disabled={!dirty || saving}
+          className="brand-bar rounded-[10px] px-[18px] py-2.5 text-[13px] font-bold text-white shadow-[0_8px_22px_-10px_color-mix(in_oklch,var(--brand-magenta),transparent_20%)] transition-all hover:-translate-y-px hover:brightness-110 disabled:translate-y-0 disabled:opacity-40 disabled:shadow-none"
+        >
+          {saving ? 'Saving…' : 'Save changes'}
+        </button>
+      </div>
+    </SettingsSection>
+  );
+}

--- a/packages/web/src/experiments/console/components/ProviderConnectionsPanel.tsx
+++ b/packages/web/src/experiments/console/components/ProviderConnectionsPanel.tsx
@@ -4,6 +4,7 @@ import { useEntity, invalidate } from '../store/cache';
 import { K } from '../store/keys';
 import { HttpError } from '../lib/http';
 import { SettingsSection } from './SettingsSection';
+import { SubscriptionLoginFlow } from './SubscriptionLoginFlow';
 
 // Mirrors AssistantConfigPanel's INPUT_CLASS so inputs match the console form style.
 const INPUT_CLASS =
@@ -19,8 +20,10 @@ const INPUT_CLASS =
  * `enabled: false` (no TOKEN_ENCRYPTION_KEY). Any OTHER load error still renders
  * a visible error section rather than hiding it.
  *
- * API-key connect only (PR-2). OAuth subscription rows land with the Pi OAuth
- * bridge (PR-3).
+ * Both connect paths: an API key for ANY provider (the non-subscription
+ * providers — openrouter/openai/codex/Pi backends — are API-key only), plus a
+ * subscription "Login" affordance for providers the server advertises in
+ * `subscriptionAvailable` (claude/copilot; codex is gated, #1924).
  */
 export function ProviderConnectionsPanel(): ReactElement | null {
   const { data, error } = useEntity(K.providerConnections, skill.listProviderKeys);
@@ -31,6 +34,7 @@ export function ProviderConnectionsPanel(): ReactElement | null {
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [disconnecting, setDisconnecting] = useState<string | null>(null);
+  const [loginProvider, setLoginProvider] = useState<string | null>(null);
 
   const cancelledRef = useRef(false);
   useEffect(() => {
@@ -51,14 +55,14 @@ export function ProviderConnectionsPanel(): ReactElement | null {
   if (error instanceof HttpError && error.status === 401) return null;
   if (error !== undefined) {
     return (
-      <SettingsSection title="AI Provider Keys">
+      <SettingsSection title="Provider Auth">
         <p className="font-mono text-[11px] text-error">{error.message}</p>
       </SettingsSection>
     );
   }
   if (data === undefined) {
     return (
-      <SettingsSection title="AI Provider Keys">
+      <SettingsSection title="Provider Auth">
         <p className="font-mono text-[11px] text-text-tertiary">Loading…</p>
       </SettingsSection>
     );
@@ -103,7 +107,7 @@ export function ProviderConnectionsPanel(): ReactElement | null {
   };
 
   return (
-    <SettingsSection title="AI Provider Keys">
+    <SettingsSection title="Provider Auth">
       <div className="flex flex-col gap-4 text-[12px]">
         <p className="text-text-secondary">
           Connect your own provider API keys. Runs and chats you start bill to your key instead of
@@ -138,6 +142,53 @@ export function ProviderConnectionsPanel(): ReactElement | null {
         ) : (
           <p className="text-text-tertiary">No provider keys connected yet.</p>
         )}
+
+        {data.subscriptionAvailable.length > 0 ? (
+          <div className="flex flex-col gap-2 border-t border-border pt-3">
+            <p className="text-text-secondary">
+              Or connect a subscription — bills to your plan, no API key needed:
+            </p>
+            {data.subscriptionAvailable.map(p => {
+              const connected = data.connections.some(c => c.provider === p && c.kind === 'oauth');
+              if (loginProvider === p) {
+                return (
+                  <SubscriptionLoginFlow
+                    key={p}
+                    provider={p}
+                    onDone={() => {
+                      setLoginProvider(null);
+                    }}
+                  />
+                );
+              }
+              return (
+                <div
+                  key={p}
+                  className="flex items-center justify-between gap-3 rounded border border-border bg-surface-inset px-3 py-2"
+                >
+                  <span className="text-text-secondary">
+                    <span className="font-medium capitalize text-text-primary">{p}</span>
+                    {connected ? (
+                      <span className="ml-2 text-text-tertiary">· subscription connected</span>
+                    ) : null}
+                  </span>
+                  {!connected ? (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setLoginProvider(p);
+                      }}
+                      disabled={loginProvider !== null}
+                      className="brand-bar shrink-0 rounded px-3 py-0.5 text-[11px] font-medium text-white transition-all hover:brightness-110 disabled:opacity-40"
+                    >
+                      Login
+                    </button>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        ) : null}
 
         <div className="flex flex-col gap-2.5 border-t border-border pt-3">
           <div className="flex gap-2">

--- a/packages/web/src/experiments/console/components/SubscriptionLoginFlow.tsx
+++ b/packages/web/src/experiments/console/components/SubscriptionLoginFlow.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useRef, useState, type ReactElement } from 'react';
+import * as skill from '../skills';
+import type { ProviderOAuthStart } from '../skills';
+import { invalidate } from '../store/cache';
+import { K } from '../store/keys';
+
+type Phase = 'starting' | 'manual' | 'device' | 'error';
+
+/**
+ * Normalize whatever the user pastes from the manual (claude) flow into the
+ * `code#state` form the bridge expects. The browser redirect on a HEADLESS
+ * server lands on the *server's* `localhost:<port>/callback?code=…&state=…`
+ * (unreachable from the user's machine → "site can't be reached"); the user
+ * copies that URL or just the code. Accept a full URL, a bare `code=…&state=…`
+ * query, an explicit `code#state`, or a bare code. (On a LOCAL install the
+ * callback server resolves the login itself and no paste is needed.)
+ */
+function normalizeCode(pasted: string): string {
+  const v = pasted.trim();
+  if (v.includes('code=')) {
+    try {
+      const query = v.includes('?') ? v.slice(v.indexOf('?')) : `?${v}`;
+      const params = new URLSearchParams(query);
+      const code = params.get('code');
+      const state = params.get('state');
+      if (code) return state ? `${code}#${state}` : code;
+    } catch {
+      // fall through — treat as already-normalized
+    }
+  }
+  return v;
+}
+
+/**
+ * Drives one subscription (OAuth) login for `provider` through the held-session
+ * bridge. Mirrors GithubIdentityPanel's poll loop, generalized to both bridge
+ * modes: `device` (copilot — show user-code + URL, poll) and `manual` (claude —
+ * show URL + a paste-code input; the single poll loop submits the pasted code via
+ * `pendingCodeRef`, and also catches the local-callback-server resolution with no
+ * paste). On `connected` it invalidates the connections cache and calls `onDone`.
+ */
+export function SubscriptionLoginFlow({
+  provider,
+  onDone,
+}: {
+  provider: string;
+  onDone: () => void;
+}): ReactElement {
+  const [phase, setPhase] = useState<Phase>('starting');
+  const [start, setStart] = useState<ProviderOAuthStart | null>(null);
+  const [code, setCode] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+
+  const cancelledRef = useRef(false);
+  const pendingCodeRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    let started = false;
+
+    const pollLoop = async (sessionId: string): Promise<void> => {
+      const deadline = Date.now() + 10 * 60 * 1000; // bridge SESSION_TTL_MS
+      for (;;) {
+        if (cancelledRef.current) return;
+        if (Date.now() > deadline) {
+          setPhase('error');
+          setMessage('Login timed out — close and try again.');
+          return;
+        }
+        await new Promise(r => setTimeout(r, 2000));
+        if (cancelledRef.current) return;
+        try {
+          const submit = pendingCodeRef.current;
+          pendingCodeRef.current = undefined;
+          const res = await skill.pollProviderOAuth(provider, sessionId, submit);
+          if (cancelledRef.current) return;
+          if (res.status === 'connected') {
+            invalidate(K.providerConnections);
+            onDone();
+            return;
+          }
+          if (res.status === 'error') {
+            setPhase('error');
+            setMessage(res.detail ?? 'Login failed.');
+            return;
+          }
+          // 'pending' → keep polling
+        } catch (e: unknown) {
+          if (cancelledRef.current) return;
+          setPhase('error');
+          setMessage(e instanceof Error ? e.message : 'Login poll failed.');
+          return;
+        }
+      }
+    };
+
+    void (async (): Promise<void> => {
+      try {
+        const s = await skill.startProviderOAuth(provider);
+        if (cancelledRef.current || started) return;
+        started = true;
+        setStart(s);
+        setPhase(s.mode === 'device' ? 'device' : 'manual');
+        void pollLoop(s.sessionId);
+      } catch (e: unknown) {
+        if (cancelledRef.current) return;
+        setPhase('error');
+        setMessage(e instanceof Error ? e.message : 'Failed to start login.');
+      }
+    })();
+
+    return (): void => {
+      cancelledRef.current = true;
+    };
+  }, [provider, onDone]);
+
+  const submitCode = (): void => {
+    if (code.trim() === '') return;
+    pendingCodeRef.current = normalizeCode(code);
+    setCode('');
+    setMessage('Submitting…');
+  };
+
+  return (
+    <div className="flex flex-col gap-2 rounded border border-border bg-surface-inset p-3 text-[12px] text-text-secondary">
+      <div className="flex items-center justify-between gap-3">
+        <span className="font-medium text-text-primary capitalize">
+          {provider} subscription login
+        </span>
+        <button
+          type="button"
+          onClick={onDone}
+          className="shrink-0 rounded border border-border px-2 py-0.5 text-[11px] text-text-secondary transition-colors hover:border-border-bright hover:text-text-primary"
+        >
+          Cancel
+        </button>
+      </div>
+
+      {phase === 'starting' ? <span className="text-text-tertiary">Starting…</span> : null}
+
+      {phase === 'device' && start?.userCode && start.verificationUri ? (
+        <span>
+          Visit{' '}
+          <a
+            href={start.verificationUri}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-text-primary underline underline-offset-2"
+          >
+            {start.verificationUri}
+          </a>{' '}
+          and enter code:{' '}
+          <span className="font-mono font-semibold tracking-widest text-text-primary">
+            {start.userCode}
+          </span>
+          <span className="ml-2 text-text-tertiary">(polling…)</span>
+        </span>
+      ) : null}
+
+      {phase === 'manual' && start?.url ? (
+        <div className="flex flex-col gap-2">
+          <span>
+            1. Open{' '}
+            <a
+              href={start.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-text-primary underline underline-offset-2"
+            >
+              this authorization link
+            </a>{' '}
+            and approve.
+          </span>
+          <span className="text-text-tertiary">
+            2. If it shows a code (or a failed <code className="font-mono">localhost</code>{' '}
+            redirect), paste the code or the whole redirect URL below. (If you’re on the same
+            machine as the server, it may connect on its own.)
+          </span>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={code}
+              onChange={e => {
+                setCode(e.target.value);
+              }}
+              placeholder="Paste code or localhost callback URL"
+              autoComplete="off"
+              className="w-full rounded-[9px] border border-border bg-surface px-3 py-2 font-mono text-[12px] text-text-primary placeholder:text-text-tertiary focus:border-accent-bright/50 focus:outline-none"
+            />
+            <button
+              type="button"
+              onClick={submitCode}
+              disabled={code.trim() === ''}
+              className="brand-bar shrink-0 rounded px-3 py-1 text-[11px] font-medium text-white transition-all hover:brightness-110 disabled:opacity-40"
+            >
+              Submit
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {message !== null ? (
+        <p
+          className={`font-mono text-[11px] ${phase === 'error' ? 'text-error' : 'text-text-tertiary'}`}
+        >
+          {message}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/web/src/experiments/console/components/SubscriptionLoginFlow.tsx
+++ b/packages/web/src/experiments/console/components/SubscriptionLoginFlow.tsx
@@ -3,33 +3,9 @@ import * as skill from '../skills';
 import type { ProviderOAuthStart } from '../skills';
 import { invalidate } from '../store/cache';
 import { K } from '../store/keys';
+import { normalizeOAuthCode } from '../lib/oauth-code';
 
 type Phase = 'starting' | 'manual' | 'device' | 'error';
-
-/**
- * Normalize whatever the user pastes from the manual (claude) flow into the
- * `code#state` form the bridge expects. The browser redirect on a HEADLESS
- * server lands on the *server's* `localhost:<port>/callback?code=…&state=…`
- * (unreachable from the user's machine → "site can't be reached"); the user
- * copies that URL or just the code. Accept a full URL, a bare `code=…&state=…`
- * query, an explicit `code#state`, or a bare code. (On a LOCAL install the
- * callback server resolves the login itself and no paste is needed.)
- */
-function normalizeCode(pasted: string): string {
-  const v = pasted.trim();
-  if (v.includes('code=')) {
-    try {
-      const query = v.includes('?') ? v.slice(v.indexOf('?')) : `?${v}`;
-      const params = new URLSearchParams(query);
-      const code = params.get('code');
-      const state = params.get('state');
-      if (code) return state ? `${code}#${state}` : code;
-    } catch {
-      // fall through — treat as already-normalized
-    }
-  }
-  return v;
-}
 
 /**
  * Drives one subscription (OAuth) login for `provider` through the held-session
@@ -53,6 +29,12 @@ export function SubscriptionLoginFlow({
 
   const cancelledRef = useRef(false);
   const pendingCodeRef = useRef<string | undefined>(undefined);
+  // Keep `onDone` in a ref so the start/poll effect depends only on `provider`.
+  // Otherwise the parent's inline `onDone={() => …}` is a fresh fn each render,
+  // and a mid-flow parent re-render would tear down the effect and RESTART the
+  // OAuth session (dropping the in-flight login + any pasted code). (#1926 I1)
+  const onDoneRef = useRef(onDone);
+  onDoneRef.current = onDone;
 
   useEffect(() => {
     cancelledRef.current = false;
@@ -76,7 +58,7 @@ export function SubscriptionLoginFlow({
           if (cancelledRef.current) return;
           if (res.status === 'connected') {
             invalidate(K.providerConnections);
-            onDone();
+            onDoneRef.current();
             return;
           }
           if (res.status === 'error') {
@@ -112,11 +94,11 @@ export function SubscriptionLoginFlow({
     return (): void => {
       cancelledRef.current = true;
     };
-  }, [provider, onDone]);
+  }, [provider]);
 
   const submitCode = (): void => {
     if (code.trim() === '') return;
-    pendingCodeRef.current = normalizeCode(code);
+    pendingCodeRef.current = normalizeOAuthCode(code);
     setCode('');
     setMessage('Submitting…');
   };

--- a/packages/web/src/experiments/console/lib/oauth-code.test.ts
+++ b/packages/web/src/experiments/console/lib/oauth-code.test.ts
@@ -1,0 +1,31 @@
+import { describe, test, expect } from 'bun:test';
+import { normalizeOAuthCode } from './oauth-code';
+
+describe('normalizeOAuthCode', () => {
+  test('full localhost callback URL → code#state', () => {
+    expect(normalizeOAuthCode('http://localhost:53692/callback?code=ABC&state=XYZ')).toBe(
+      'ABC#XYZ'
+    );
+  });
+
+  test('bare code=…&state=… query → code#state', () => {
+    expect(normalizeOAuthCode('code=ABC&state=XYZ')).toBe('ABC#XYZ');
+  });
+
+  test('URL with code but no state → bare code', () => {
+    expect(normalizeOAuthCode('http://localhost/cb?code=ABC')).toBe('ABC');
+  });
+
+  test('already code#state → unchanged', () => {
+    expect(normalizeOAuthCode('ABC#XYZ')).toBe('ABC#XYZ');
+  });
+
+  test('bare code (no code= marker) → unchanged', () => {
+    expect(normalizeOAuthCode('ABC')).toBe('ABC');
+  });
+
+  test('trims surrounding whitespace', () => {
+    expect(normalizeOAuthCode('  ABC  ')).toBe('ABC');
+    expect(normalizeOAuthCode('  http://x/cb?code=A&state=B ')).toBe('A#B');
+  });
+});

--- a/packages/web/src/experiments/console/lib/oauth-code.ts
+++ b/packages/web/src/experiments/console/lib/oauth-code.ts
@@ -1,0 +1,27 @@
+/**
+ * Normalize whatever a user pastes from a manual (claude) subscription login
+ * into the `code#state` form the bridge expects.
+ *
+ * The browser redirect on a HEADLESS server lands on the *server's*
+ * `localhost:<port>/callback?code=…&state=…` (unreachable from the user's
+ * machine → "site can't be reached"); the user copies that URL or just the code.
+ * Accepts a full URL, a bare `code=…&state=…` query, an explicit `code#state`,
+ * or a bare code. (On a LOCAL install the callback server resolves the login
+ * itself and no paste is needed.)
+ */
+export function normalizeOAuthCode(pasted: string): string {
+  const v = pasted.trim();
+  if (v.includes('code=')) {
+    try {
+      const query = v.includes('?') ? v.slice(v.indexOf('?')) : `?${v}`;
+      const params = new URLSearchParams(query);
+      const code = params.get('code');
+      const state = params.get('state');
+      if (code) return state ? `${code}#${state}` : code;
+    } catch (err) {
+      // Couldn't parse it as a URL/query — surface (not swallow) and send as-is.
+      console.warn('normalizeOAuthCode: failed to parse pasted value; sending as-is', err);
+    }
+  }
+  return v;
+}

--- a/packages/web/src/experiments/console/routes/SettingsPage.tsx
+++ b/packages/web/src/experiments/console/routes/SettingsPage.tsx
@@ -1,13 +1,16 @@
 import { type ReactElement } from 'react';
-import { AssistantConfigPanel } from '../components/AssistantConfigPanel';
+import { ModelTiersPanel } from '../components/ModelTiersPanel';
 import { ProviderConnectionsPanel } from '../components/ProviderConnectionsPanel';
+import { AssistantConfigPanel } from '../components/AssistantConfigPanel';
 import { SystemPanel } from '../components/SystemPanel';
 import { GithubIdentityPanel } from '../components/GithubIdentityPanel';
 
 /**
- * Global (installation-wide) console settings — assistant config + system health.
- * Mounted at `/console/settings`, not under a project, because the write path
- * (PATCH /api/config/assistants → ~/.archon/config.yaml) is global only.
+ * Global (installation-wide) console "AI Settings" — sectioned: Model Tiers (the
+ * config tiers editor, ungated) → Provider Auth (per-user keys + subscription
+ * login) → Defaults (default assistant + per-provider model) → System → GitHub.
+ * Mounted at `/console/settings`; the config write paths (PATCH /api/config/*
+ * → ~/.archon/config.yaml) are install-wide.
  */
 export function SettingsPage(): ReactElement {
   return (
@@ -17,8 +20,9 @@ export function SettingsPage(): ReactElement {
       </header>
       <div className="flex-1 overflow-y-auto px-10 pb-14 pt-5">
         <div className="mx-auto flex max-w-[680px] flex-col gap-[22px]">
-          <AssistantConfigPanel />
+          <ModelTiersPanel />
           <ProviderConnectionsPanel />
+          <AssistantConfigPanel />
           <SystemPanel />
           <GithubIdentityPanel />
         </div>

--- a/packages/web/src/experiments/console/skills/providerKeys.ts
+++ b/packages/web/src/experiments/console/skills/providerKeys.ts
@@ -27,6 +27,11 @@ export interface ProviderKeyList {
   connections: ProviderKeyConnection[];
   /** Server-owned catalog of connectable provider ids (no client duplication). */
   available: string[];
+  /**
+   * Subset of `available` that supports subscription (OAuth) login. Codex is
+   * intentionally excluded (gated, #1924) so the UI shows it API-key-only.
+   */
+  subscriptionAvailable: string[];
 }
 
 export interface ProviderKeySetResult {
@@ -34,6 +39,53 @@ export interface ProviderKeySetResult {
   provider: string;
   kind: 'api_key';
   label: string | null;
+}
+
+/** POST /api/auth/providers/:provider/oauth/start response. */
+export interface ProviderOAuthStart {
+  sessionId: string;
+  mode: 'manual' | 'device';
+  url?: string;
+  userCode?: string;
+  verificationUri?: string;
+  expiresIn: number;
+}
+
+/** POST /api/auth/providers/:provider/oauth/poll response. */
+export interface ProviderOAuthPoll {
+  status: 'pending' | 'connected' | 'error';
+  mode?: 'manual' | 'device';
+  url?: string;
+  userCode?: string;
+  verificationUri?: string;
+  detail?: string;
+}
+
+/** Begin a subscription (OAuth) login — held server-side by the oauth-bridge. */
+export function startProviderOAuth(provider: string): Promise<ProviderOAuthStart> {
+  return requestJson<ProviderOAuthStart>(
+    `/api/auth/providers/${encodeURIComponent(provider)}/oauth/start`,
+    { method: 'POST' }
+  );
+}
+
+/**
+ * Poll a held login. For `manual` (claude) submit the pasted `code`; for
+ * `device` (copilot) call with no code and poll until `connected`. The `:provider`
+ * segment only keeps the route under the exempt prefix — poll keys off sessionId.
+ */
+export function pollProviderOAuth(
+  provider: string,
+  sessionId: string,
+  code?: string
+): Promise<ProviderOAuthPoll> {
+  return requestJson<ProviderOAuthPoll>(
+    `/api/auth/providers/${encodeURIComponent(provider)}/oauth/poll`,
+    {
+      method: 'POST',
+      body: JSON.stringify(code ? { sessionId, code } : { sessionId }),
+    }
+  );
 }
 
 /** GET /api/auth/providers — 401s when there's no web identity (panel reads as "hide"). */

--- a/packages/web/src/experiments/console/skills/settings.test.ts
+++ b/packages/web/src/experiments/console/skills/settings.test.ts
@@ -1,5 +1,11 @@
 import { describe, test, expect } from 'bun:test';
-import { buildAssistantUpdate, type AssistantConfigForm } from './settings';
+import {
+  buildAssistantUpdate,
+  buildTiersUpdate,
+  type AssistantConfigForm,
+  type TiersForm,
+  type TierRowForm,
+} from './settings';
 
 function form(over: Partial<AssistantConfigForm> = {}): AssistantConfigForm {
   return {
@@ -62,5 +68,54 @@ describe('buildAssistantUpdate', () => {
   test('everything blank → just the assistant, no assistants key', () => {
     const body = buildAssistantUpdate(form({ models: { claude: '', codex: '' } }));
     expect(body).toEqual({ assistant: 'claude' });
+  });
+});
+
+const BLANK: TierRowForm = { provider: '', model: '', effort: '' };
+function tierForm(
+  over: Partial<Record<'small' | 'medium' | 'large', Partial<TierRowForm>>>
+): TiersForm {
+  return {
+    small: { ...BLANK, ...over.small },
+    medium: { ...BLANK, ...over.medium },
+    large: { ...BLANK, ...over.large },
+  };
+}
+
+describe('buildTiersUpdate', () => {
+  test('a fully-set row → entry with provider/model/effort', () => {
+    const body = buildTiersUpdate(
+      tierForm({ large: { provider: 'claude', model: 'opus', effort: 'high' } })
+    );
+    expect(body.tiers.large).toEqual({ provider: 'claude', model: 'opus', effort: 'high' });
+  });
+
+  test('omits effort when blank', () => {
+    const body = buildTiersUpdate(tierForm({ large: { provider: 'claude', model: 'opus' } }));
+    expect(body.tiers.large).toEqual({ provider: 'claude', model: 'opus' });
+  });
+
+  test('blank provider → null (unset)', () => {
+    const body = buildTiersUpdate(tierForm({ large: { provider: '', model: 'opus' } }));
+    expect(body.tiers.large).toBeNull();
+  });
+
+  test('blank model → null (unset) — the OR-blank branch is not inverted', () => {
+    const body = buildTiersUpdate(tierForm({ large: { provider: 'claude', model: '' } }));
+    expect(body.tiers.large).toBeNull();
+  });
+
+  test('always sends all three tiers (set + null)', () => {
+    const body = buildTiersUpdate(tierForm({ small: { provider: 'claude', model: 'haiku' } }));
+    expect(body.tiers.small).toEqual({ provider: 'claude', model: 'haiku' });
+    expect(body.tiers.medium).toBeNull();
+    expect(body.tiers.large).toBeNull();
+  });
+
+  test('trims whitespace on every field', () => {
+    const body = buildTiersUpdate(
+      tierForm({ large: { provider: '  claude ', model: ' opus ', effort: ' high ' } })
+    );
+    expect(body.tiers.large).toEqual({ provider: 'claude', model: 'opus', effort: 'high' });
   });
 });

--- a/packages/web/src/experiments/console/skills/settings.ts
+++ b/packages/web/src/experiments/console/skills/settings.ts
@@ -76,3 +76,71 @@ export function buildAssistantUpdate(form: AssistantConfigForm): UpdateAssistant
   if (Object.keys(assistants).length > 0) body.assistants = assistants;
   return body;
 }
+
+// ---------------------------------------------------------------------------
+// Model tiers (PR-3b). Types inlined (mirroring server/.../config.schemas.ts)
+// until a regen lands TiersConfig / UpdateTiersBody / SafeConfig.tiers in
+// @/lib/api.generated — same convention as skills/github.ts. Migrate to
+// `components['schemas']['TiersConfig']` etc. once the spec is regenerated.
+// ---------------------------------------------------------------------------
+
+export interface TierEntry {
+  provider: string;
+  model: string;
+  effort?: string;
+}
+
+export interface TiersMap {
+  small?: TierEntry;
+  medium?: TierEntry;
+  large?: TierEntry;
+}
+
+/** `SafeConfig` + the tier fields not yet in the generated spec. */
+export type SafeConfigTiers = SafeConfig & { tiers?: TiersMap; tierDefaults?: TiersMap };
+
+export interface UpdateTiersBody {
+  tiers: { small?: TierEntry | null; medium?: TierEntry | null; large?: TierEntry | null };
+}
+
+export function updateTiers(body: UpdateTiersBody): Promise<ConfigResponse> {
+  return requestJson<ConfigResponse>('/api/config/tiers', {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+}
+
+export type TierName = 'small' | 'medium' | 'large';
+export const TIER_ORDER: readonly TierName[] = ['small', 'medium', 'large'];
+
+export interface TierRowForm {
+  provider: string; // '' = unset (falls back to the built-in default)
+  model: string;
+  effort: string;
+}
+
+export type TiersForm = Record<TierName, TierRowForm>;
+
+/**
+ * Pure form → PATCH body. A row whose provider OR model is blank is sent as
+ * `null` (unset → built-in default); a fully-set row carries `effort` when
+ * present. The editor always sends all three tiers, so the per-key-merge route
+ * cleanly applies sets and unsets in one call.
+ */
+export function buildTiersUpdate(form: TiersForm): UpdateTiersBody {
+  const tiers: UpdateTiersBody['tiers'] = {};
+  for (const tier of TIER_ORDER) {
+    const row = form[tier];
+    const provider = row.provider.trim();
+    const model = row.model.trim();
+    if (provider && model) {
+      const entry: TierEntry = { provider, model };
+      const effort = row.effort.trim();
+      if (effort) entry.effort = effort;
+      tiers[tier] = entry;
+    } else {
+      tiers[tier] = null;
+    }
+  }
+  return { tiers };
+}

--- a/packages/web/src/experiments/console/skills/settings.ts
+++ b/packages/web/src/experiments/console/skills/settings.ts
@@ -78,12 +78,18 @@ export function buildAssistantUpdate(form: AssistantConfigForm): UpdateAssistant
 }
 
 // ---------------------------------------------------------------------------
-// Model tiers (PR-3b). Types inlined (mirroring server/.../config.schemas.ts)
-// until a regen lands TiersConfig / UpdateTiersBody / SafeConfig.tiers in
+// Model tiers. Types inlined (mirroring server/.../config.schemas.ts) until a
+// regen lands TiersConfig / UpdateTiersBody / SafeConfig.tiers in
 // @/lib/api.generated — same convention as skills/github.ts. Migrate to
 // `components['schemas']['TiersConfig']` etc. once the spec is regenerated.
 // ---------------------------------------------------------------------------
 
+/**
+ * A tier preset as the UI handles it. `thinking` is intentionally omitted — there
+ * is no UI control for it, and the PATCH /api/config/tiers handler drops it on
+ * write, so saving a tier here clears any `thinking` set in config.yaml. Known
+ * limitation (advanced; rare).
+ */
 export interface TierEntry {
   provider: string;
   model: string;

--- a/packages/workflows/src/model-validation.ts
+++ b/packages/workflows/src/model-validation.ts
@@ -239,3 +239,26 @@ export function routePresetEffort(provider: string, effort: string): EffortRouti
   }
   return null;
 }
+
+/**
+ * The effort vocabulary for a provider, or `null` if the provider has no known
+ * effort concept (Pi/OpenRouter/Copilot/OpenCode — effort doesn't route there).
+ * Lets the tier-config write path (route + CLI) validate `effort` UP FRONT
+ * instead of letting `routePresetEffort` silently drop an unknown value at run
+ * time (so `--effort ultra` errors instead of succeeding with no effect).
+ */
+export function validEffortsForProvider(provider: string): readonly string[] | null {
+  if (provider === 'claude') return [...CLAUDE_EFFORTS];
+  if (provider === 'codex') return [...CODEX_REASONING_EFFORTS];
+  return null;
+}
+
+/**
+ * True if `effort` is acceptable for `provider`. Providers WITHOUT a known
+ * effort vocabulary accept any value (we don't block what we can't validate;
+ * it's a no-op for them, not an error).
+ */
+export function isEffortValidForProvider(provider: string, effort: string): boolean {
+  const valid = validEffortsForProvider(provider);
+  return valid === null || valid.includes(effort);
+}


### PR DESCRIPTION
## Summary

- **Problem:** After PR-3a the credential plumbing works, but there was no surface to drive it — `tiers:` was YAML-hand-edit-only (stripped on read, no write path, no Zod schema), the console had no subscription-login UI, and the CLI had no tier/default config.
- **Why it matters:** Operators (and solo users) can now pick which model each `small/medium/large` tier maps to and connect every provider — by API key or subscription — from one settings page or the CLI, without editing `config.yaml`.
- **What changed:** Config `tiers:` read/write API (ungated → solo-OK), sectioned console **AI Settings** (Model Tiers / Provider Auth / Defaults), Provider Auth unified (API key for *all* providers + subscription login for claude/copilot), and full CLI parity (`ai tier set/list/unset`, `ai default`).
- **What did NOT change (scope):** No per-user tier/alias DB store (Phase 3). No codex subscription (gated, #1924 — codex stays API-key-only). No chat-tier config key. No `@custom` alias editor. No composer model picker.

## UX Journey

### Before
```
Console ▸ Settings (flat stack)
  Assistant (default + per-provider model)
  AI Provider Keys (API key only — no subscription)
  System / GitHub
Tiers: invisible/unwritable.   CLI: no tier/default config.
```

### After
```
Console ▸ Settings → sectioned "AI Settings"
  [+] MODEL TIERS    small/medium/large → {provider ▾, model, effort} → PATCH /api/config/tiers  (solo-OK)
  [~] PROVIDER AUTH  API key for EVERY provider  +  [Login] subscription (claude/copilot)*
                       *manual (paste code/URL) | device (poll)   — codex = API-key only (#1924)
  [~] DEFAULTS       default assistant + per-provider model
  SYSTEM / GITHUB

CLI parity:  archon ai tier set large claude opus  ·  ai tier list  ·  ai default claude
```

## Architecture Diagram

### After (changes marked)
```
console SettingsPage [~]
  ├ ModelTiersPanel [+] ──┐
  ├ ProviderConnectionsPanel [~] ── SubscriptionLoginFlow [+] ─┐
  └ AssistantConfigPanel(Defaults) │                          │
       skills/settings.ts [~] (updateTiers)  skills/providerKeys.ts [~] (oauth verbs)
                 │                                   │
       PATCH /api/config/tiers [+]          /api/auth/providers/:p/oauth/start|poll (PR-3a)
                 │
       core/config-loader.ts [~] (updateGlobalConfig tiers branch; toSafeConfig tiers+tierDefaults)
                 │
       ~/.archon/config.yaml  ◀── archon ai tier|default (cli) [+]
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| ModelTiersPanel | PATCH /api/config/tiers | **new** | tier editor → config.yaml |
| ProviderConnectionsPanel | oauth/start\|poll | **new** | subscription login affordance (PR-3a routes) |
| cli `ai tier`/`ai default` | core updateGlobalConfig | **new** | serverless config write |
| api.ts | core updateGlobalConfig({tiers}) | **modified** | new tiers branch |
| config-loader toSafeConfig | workflows buildAiProfile | **new** | computes tierDefaults |

## Label Snapshot
- Risk: `risk: low`
- Size: `size: L`
- Scope: `config server cli web`
- Module: `core:config`, `server:routes`, `cli:ai`, `web:console`

## Change Metadata
- Change type: `feature`
- Primary scope: `multi`

## Linked Issue
- Related #1891 (Part of — umbrella stays open)
- Related #1924 (codex subscription gating context)

## Validation Evidence (required)
```bash
bun run validate   # exit 0
```
- Evidence: `bun run validate` green (check:bundled* + type-check + lint + format:check + all per-package test batches). New tests: config-loader tier cases (set/merge/null-unset/preserve + toSafeConfig tiers+tierDefaults), tiers route (200/400/unset/thinking-drop/ungated), CLI `ai tier`/`ai default` (set/invalid/unset/list/--json/default).
- Skipped: live OAuth round-trip (human-in-loop) → VPS smoke post-merge, as for PR-3a.

## Security Impact (required)
- New permissions/capabilities? **No**
- New external network calls? **No** (subscription login reuses PR-3a's bridge/routes)
- Secrets/tokens handling changed? **No** (config routes carry no secrets; tier values are model strings)
- File system access scope changed? **No** (`updateGlobalConfig` already wrote `~/.archon/config.yaml`)
- Note: config routes are intentionally **ungated** (no `requireWebUser`) — they write non-secret model config and must work on solo installs, matching the existing `PATCH /api/config/assistants`.

## Compatibility / Migration
- Backward compatible? **Yes** (additive — new route/fields/commands; existing config untouched)
- Config/env changes? **No** new env. Adds optional `tiers:` keys to `config.yaml` (already a supported key; this just makes it editable).
- Database migration needed? **No**

## Human Verification (required)
- Verified scenarios: `bun run validate` green; per-package type-check; the config write semantics (set/merge/unset/preserve) via unit tests; CLI commands via unit tests with real provider registry.
- Edge cases checked: solo install (ungated config); unknown provider → 400/nonzero exit; null-unset; tiers survive an assistants-only PATCH; `thinking` dropped on write; codex absent from `subscriptionAvailable`.
- Not verified (post-merge VPS smoke): live subscription login UI (manual claude paste-code + device copilot) end-to-end; the tier editor against a running server. The manual-flow URL/`code#state` normalization directly encodes the headless behavior proven in the PR-3a smoke.

## Side Effects / Blast Radius (required)
- Affected subsystems: `core/config`, `server/routes`, `cli`, `web/console`.
- Potential unintended effects: `toSafeConfig` now calls `buildAiProfile` (wrapped in try/catch → `{}` on failure, never throws) for `tierDefaults`. `updateGlobalConfig` signature widened to `Partial<Omit<GlobalConfig,'tiers'>> & { tiers?: TiersPatch }` — existing callers unaffected.
- Guardrails: per-key tiers merge is unit-tested to not clobber `assistants`.

## Rollback Plan (required)
- Fast rollback: revert the squash commit on `dev`. Purely additive — no data migration, no flag.
- Observable failure symptoms: `GET /api/config` 500 (tierDefaults), or the console Settings page failing to load the Model Tiers panel.

## Risks and Mitigations
- Risk: manual subscription URL is unreachable on a remote server (callback `localhost`).
  - Mitigation: `SubscriptionLoginFlow` requires a paste-code input and normalizes a pasted URL/`code=…`/`code#state`/bare code; also polls so a local callback server resolves with no paste. (Proven in the PR-3a VPS smoke.)
- Risk: `api.generated.d.ts` not regenerated (tiers/oauth types inlined in the console skills).
  - Mitigation: follows the `skills/github.ts` inline-type convention; CI-safe. Regen is a non-urgent follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: manage model tiers (ai tier set|list|unset) and choose a default assistant (ai default)
  * Settings UI: new Model Tiers panel to view/edit small/medium/large provider+model (with optional effort) and save changes
  * Provider Auth: connect subscription providers via an OAuth login flow in Provider Auth panel

* **Documentation**
  * CLI help updated with tier and default-assistant usage and examples
<!-- end of auto-generated comment: release notes by coderabbit.ai -->