### PR TITLE
fix(core): /setproject updates by DB id, not platform conversation id

### DIFF
--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -2630,4 +2630,32 @@ describe('handleMessage — /setproject dispatch', () => {
     expect(mockUpdateConversation).not.toHaveBeenCalled();
     expect(platform.sendMessage).toHaveBeenCalledWith('conv-1', expect.stringContaining('Usage'));
   });
+
+  // Regression: handleSetProject previously passed the platform conversation id
+  // (e.g. a Discord channel snowflake) to db.updateConversation, which queries
+  // by the DB primary-key id. The two diverge on Discord and the UPDATE matched
+  // zero rows, surfacing as "Conversation not found". Fix passes conversation.id.
+  test('updates by DB id, not platform conversation id', async () => {
+    const cb = makeCodebase('signals');
+    mockListCodebases.mockImplementation(() => Promise.resolve([cb]));
+    mockGetOrCreateConversation.mockImplementation(() =>
+      Promise.resolve(
+        makeConversation({
+          id: 'db-uuid-abc',
+          platform_conversation_id: '1513767625493184556',
+          platform_type: 'discord',
+          codebase_id: null,
+        })
+      )
+    );
+    mockParseCommand.mockReturnValue({ command: 'setproject', args: ['signals'] });
+
+    const platform = makePlatform();
+    await handleMessage(platform, '1513767625493184556', '/setproject signals');
+
+    expect(mockUpdateConversation).toHaveBeenCalledWith('db-uuid-abc', {
+      codebase_id: 'id-signals',
+      cwd: '/repos/signals',
+    });
+  });
 });

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -1020,7 +1020,7 @@ export async function handleMessage(
 
         if (command === 'setproject') {
           getLog().debug({ command, conversationId }, 'deterministic_command');
-          const result = await handleSetProject(message, conversationId);
+          const result = await handleSetProject(message, conversation);
           await platform.sendMessage(conversationId, result);
           return;
         }
@@ -2018,8 +2018,14 @@ async function handleRemoveProject(message: string): Promise<string> {
  * Binds the current conversation to a registered codebase by writing
  * `codebase_id` and `cwd` to the conversations table. Uses 4-tier fuzzy
  * name resolution (exact → case-insensitive → prefix → substring).
+ *
+ * Takes the loaded `conversation` so the UPDATE targets the DB primary key
+ * (`conversation.id`) rather than the platform conversation id — the two
+ * diverge on platforms like Discord where the platform id is a channel/thread
+ * snowflake and the DB row id is an internal UUID. Passing the platform id
+ * here made the UPDATE match zero rows and surface as `Conversation not found`.
  */
-async function handleSetProject(message: string, conversationId: string): Promise<string> {
+async function handleSetProject(message: string, conversation: Conversation): Promise<string> {
   const { args } = commandHandler.parseCommand(message);
   if (args.length < 1) {
     return 'Usage: /setproject <project-name>';
@@ -2042,13 +2048,13 @@ async function handleSetProject(message: string, conversationId: string): Promis
       : `Project "${projectName}" not found. No projects registered — use /register-project.`;
   }
 
-  await db.updateConversation(conversationId, {
+  await db.updateConversation(conversation.id, {
     codebase_id: codebase.id,
     cwd: codebase.default_cwd,
   });
 
   getLog().info(
-    { conversationId, projectName: codebase.name, codebaseId: codebase.id },
+    { conversationId: conversation.id, projectName: codebase.name, codebaseId: codebase.id },
     'project.set_completed'
   );
   return `Project set to **${codebase.name}**\nWorking directory: ${codebase.default_cwd}`;


### PR DESCRIPTION
## Summary

- **Problem**: `/setproject` errors with `Conversation not found: <platform-id>` on Discord (and any platform where the platform conversation id differs from the DB primary-key id).
- **Why it matters**: The command is unusable on Discord — channel/thread snowflakes never equal the conversation row's UUID, so the UPDATE matches zero rows and `db.updateConversation` throws.
- **What changed**: `handleSetProject` now takes the loaded `Conversation` and writes by `conversation.id`. Dispatch site updated to pass the conversation it already has in scope.
- **What did NOT change**: Command shape, fuzzy resolution, output messages, every other deterministic handler.

## UX Journey

### Before

```
Discord user  ──▶  /setproject foo  ──▶  handleSetProject(msg, platformId)
                                          updateConversation(platformId)  ──▶  WHERE id = '1513767625493184556'
                                                                                 0 rows → ConversationNotFoundError
                  ◀── "Conversation not found: 1513767625493184556. Try /reset"
```

### After

```
Discord user  ──▶  /setproject foo  ──▶  handleSetProject(msg, conversation)
                                          updateConversation(conversation.id)  ──▶  WHERE id = '<uuid>'  → 1 row
                  ◀── "Project set to **foo**"
```

## Architecture Diagram

### Before / After

Single-file change in `packages/core/src/orchestrator/orchestrator-agent.ts`. No new modules or edges.

**Connection inventory**

| From | To | Status | Notes |
|------|----|--------|-------|
| orchestrator-agent → db.updateConversation | conversations table | **modified** | now keyed by DB id instead of platform id |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `core`
- Module: `core:orchestrator`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Related #1917 (the PR that introduced `/setproject`)

## Validation Evidence (required)

```bash
bun run type-check      # all 10 packages PASS
bun run lint            # PASS (zero warnings)
bun run format:check    # PASS
bun test packages/core/src/orchestrator/orchestrator-agent.test.ts
# 143 pass / 0 fail (includes new regression test)
bun run check:bundled / check:bundled-skill / check:bundled-schema  # all up-to-date
```

- Evidence provided: regression test `updates by DB id, not platform conversation id` constructs a conversation where `id !== platform_conversation_id`, invokes `handleMessage` with the platform id, asserts `updateConversation` was called with the DB id.
- Skipped: full `bun run test` (per-package suite) — orchestrator is the only file touched and its package suite passed.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: orchestrator unit suite (143 tests pass), regression test exercises the divergent Discord case explicitly.
- Edge cases checked: existing 7 setproject tests still pass (default `makeConversation` has `id === platform_conversation_id`, so the old assertions remain valid).
- What was not verified: live Discord round-trip (no Discord test fixture in repo).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `/setproject` slash command only.
- Potential unintended effects: None — `handleSetProject` is the only call site; signature is internal.
- Guardrails/monitoring for early detection: existing `project.set_completed` log line now carries the canonical DB id.

## Rollback Plan (required)

- Fast rollback: `git revert <this commit>` — single-file change, no migration.
- Feature flags: None.
- Observable failure symptoms: `/setproject` returning `Conversation not found: <snowflake>` again.

## Risks and Mitigations

- Risk: A future caller passes the platform id to `handleSetProject` again.
  - Mitigation: Signature now takes `Conversation`, not a string id — type system prevents the regression. Test covers the divergent case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `/setproject` command to correctly identify and update conversation records in the database, ensuring proper functionality across different messaging platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->