### PR TITLE
docs: per-user AI credentials + AI Settings on the docs site (PR-4, #1891)

### DIFF
--- a/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
+++ b/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
@@ -601,6 +601,53 @@ DEFAULT_AI_ASSISTANT=copilot
 - [Adding a Community Provider](../contributing/adding-a-community-provider/) — the contributor-facing guide for extending Archon with your own provider.
 - [`@github/copilot-sdk`](https://www.npmjs.com/package/@github/copilot-sdk) — upstream SDK.
 
+## Per-user credentials and AI Settings
+
+Everything above configures the **install-wide** assistant credentials (env vars, `claude /login`, etc.) — every run uses the same shared keys. On a **shared Archon box** where several people use the same server, each user can instead connect **their own** provider — by API key or subscription — so their runs and chats bill to them, not to the install's shared key.
+
+### When you need this
+
+- You run Archon for a team and want each person to bring their own provider key or Claude Pro/Max / Copilot subscription.
+- You want a personal key isolated from the shared install key.
+
+Solo users don't need any of this — the install-wide setup above is enough.
+
+### Enabling it
+
+Per-user credentials are gated on a single secret. Set `TOKEN_ENCRYPTION_KEY` (a 64-char hex string) so Archon can encrypt stored credentials at rest (AES-256-GCM):
+
+```ini
+# .env — generate with: openssl rand -hex 32
+TOKEN_ENCRYPTION_KEY=<64-char hex>
+```
+
+Without it, the per-user surface is inert (the settings panel hides, the routes report `enabled: false`) and Archon keeps reading provider keys from the environment as above.
+
+### Connecting from the console
+
+The console **AI Settings** page (Settings in the web UI) has three sections:
+
+- **Model Tiers** — map the `small` / `medium` / `large` tiers to a provider + model (and optional effort). This writes the install's `tiers:` config and works on **any** install, even without `TOKEN_ENCRYPTION_KEY` (it's non-secret config).
+- **Provider Auth** — connect a provider for *your* user. Every provider accepts an **API key**; **`claude`** and **`copilot`** additionally offer **subscription login** (an OAuth flow). `codex` is **API-key-only** — its subscription path is gated pending [#1924](https://github.com/coleam00/Archon/issues/1924).
+- **Defaults** — the default assistant and per-provider model defaults.
+
+### Connecting from the CLI
+
+The same actions are available headless via [`archon ai`](/reference/cli/#ai):
+
+```bash
+# Per-user credentials (need TOKEN_ENCRYPTION_KEY)
+echo "$MY_KEY" | archon ai key set openrouter   # API key for any provider
+archon ai login claude                           # subscription (claude or copilot)
+archon ai list                                   # what's connected
+
+# Model tiers + default (ungated config — solo-OK)
+archon ai tier set large claude opus
+archon ai default claude
+```
+
+The model-tier presets are the same ones you can hand-write in `~/.archon/config.yaml`; see [Configuration](/reference/configuration/) for the YAML format.
+
 ## How Assistant Selection Works
 
 - Assistant type is set per codebase via the `assistant` field in `.archon/config.yaml` or the `DEFAULT_AI_ASSISTANT` env var

--- a/packages/docs-web/src/content/docs/reference/api.md
+++ b/packages/docs-web/src/content/docs/reference/api.md
@@ -351,17 +351,103 @@ Query parameters include status filters, date ranges, and pagination. Used by th
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/api/config` | Get read-only configuration (safe subset) |
-| PATCH | `/api/config/assistants` | Update assistant configuration |
+| PATCH | `/api/config/assistants` | Update the default assistant and per-provider model defaults |
+| PATCH | `/api/config/tiers` | Update model-tier presets (`small`/`medium`/`large`) |
+
+`GET /api/config` returns the safe config subset, now including the configured `tiers` and the built-in `tierDefaults` for the current default provider (what an unset tier resolves to).
+
+These config routes are **ungated** -- they write non-secret model config to `~/.archon/config.yaml` and work on solo installs (no `TOKEN_ENCRYPTION_KEY` required). Contrast with the [AI Provider Credentials](#ai-provider-credentials) routes below, which require an identity.
 
 ```bash
-# Read current config
+# Read current config (includes `tiers` + `tierDefaults`)
 curl http://localhost:3090/api/config
 
-# Update assistant defaults
+# Set the default assistant
 curl -X PATCH http://localhost:3090/api/config/assistants \
   -H "Content-Type: application/json" \
-  -d '{"claude": {"model": "opus"}}'
+  -d '{"assistant": "claude"}'
+
+# Or update per-provider model defaults
+curl -X PATCH http://localhost:3090/api/config/assistants \
+  -H "Content-Type: application/json" \
+  -d '{"assistants": {"claude": {"model": "opus"}}}'
+
+# Set a model tier (a `null` tier value unsets it, falling back to the built-in default)
+curl -X PATCH http://localhost:3090/api/config/tiers \
+  -H "Content-Type: application/json" \
+  -d '{"tiers": {"large": {"provider": "claude", "model": "opus"}}}'
 ```
+
+---
+
+## AI Provider Credentials
+
+Per-user provider credentials let each user bill their runs and chats to **their own** API key or subscription instead of the shared install key. Unlike the config routes above, these endpoints are **gated**: they require `TOKEN_ENCRYPTION_KEY` (a 64-char hex secret) to be set *and* a resolved web identity (the `X-Archon-User` header, or a Better Auth session). On a solo install with no `TOKEN_ENCRYPTION_KEY`, `GET /api/auth/providers` returns `enabled: false` and the write routes return `404`.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/auth/providers` | List the current user's connected credentials (metadata only) |
+| PUT | `/api/auth/providers/{provider}` | Connect (upsert) an API key for a provider |
+| DELETE | `/api/auth/providers/{provider}` | Disconnect a provider credential (idempotent) |
+| POST | `/api/auth/providers/{provider}/oauth/start` | Begin a subscription (OAuth) login |
+| POST | `/api/auth/providers/{provider}/oauth/poll` | Poll a subscription login session |
+
+Credentials are encrypted at rest; **no endpoint ever returns a secret value** -- responses carry only `provider`/`kind`/`label` metadata.
+
+### List Connected Providers
+
+```bash
+curl http://localhost:3090/api/auth/providers \
+  -H "X-Archon-User: your-user-id"
+```
+
+Returns `{ enabled, connections: [{ provider, kind, label }], available, subscriptionAvailable }`:
+- `available` -- every provider id you can connect an API key for.
+- `subscriptionAvailable` -- the subset that supports subscription (OAuth) login: **`claude`** and **`copilot`**. (`codex` is API-key-only; its subscription path is gated -- see [#1924](https://github.com/coleam00/Archon/issues/1924).)
+
+### Connect an API Key
+
+```bash
+curl -X PUT http://localhost:3090/api/auth/providers/openrouter \
+  -H "X-Archon-User: your-user-id" \
+  -H "Content-Type: application/json" \
+  -d '{"apiKey": "sk-...", "label": "personal"}'
+```
+
+Returns `{ success, provider, kind: "api_key", label }`. An unknown provider or a blank key returns `400`.
+
+### Disconnect a Provider
+
+```bash
+curl -X DELETE http://localhost:3090/api/auth/providers/openrouter \
+  -H "X-Archon-User: your-user-id"
+```
+
+Idempotent -- disconnecting a provider that was never connected still returns `{ success: true }`.
+
+### Subscription Login (OAuth)
+
+Subscription login is a two-step `start` -> `poll` flow held server-side. `start` returns a `mode`:
+- `manual` (Claude) -- show the returned `url`; the user authorizes in a browser and pastes the resulting code back via `poll`.
+- `device` (Copilot) -- show `userCode` + `verificationUri`; `poll` until connected.
+
+```bash
+# 1. Start a login session
+curl -X POST http://localhost:3090/api/auth/providers/claude/oauth/start \
+  -H "X-Archon-User: your-user-id"
+# {"sessionId":"...","mode":"manual","url":"https://...","expiresIn":600}
+
+# 2. Poll (pass the pasted `code` once, for manual flows)
+curl -X POST http://localhost:3090/api/auth/providers/claude/oauth/poll \
+  -H "X-Archon-User: your-user-id" \
+  -H "Content-Type: application/json" \
+  -d '{"sessionId": "...", "code": "the-pasted-code"}'
+# {"status":"connected"}
+```
+
+`poll` returns `{ status: "pending" | "connected" | "error", detail? }`. A provider that does not support subscription login returns `400` on `start`.
+
+The CLI equivalent of this whole surface is [`archon ai`](/reference/cli/#ai). For the end-to-end setup walkthrough, see [Per-user credentials and AI Settings](/getting-started/ai-assistants/#per-user-credentials-and-ai-settings).
 
 ---
 

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -108,6 +108,30 @@ Only meaningful on **multi-user installs** running GitHub App mode (`GITHUB_APP_
 
 The command prints a `verification_uri` and a one-time `user_code`; visit the URL, enter the code, and authorize. On success the access/refresh tokens are stored encrypted (AES-256-GCM) in Archon's database. Exit code 0 on success; 1 if per-user GitHub is disabled, the identity can't be resolved, the code expires, or authorization is denied.
 
+### `ai`
+
+Manage **per-user AI-provider credentials** (API keys + subscriptions) and **model-tier config**. CLI identity is resolved from `ARCHON_USER_ID` (explicit override) or `$USER` / `$USERNAME`, mapped to a stable Archon user via the `cli` platform identity — the same as [`auth github`](#auth-github).
+
+The credential subcommands (`key set`, `login`, `list`, `logout`) only work on **multi-user installs** with `TOKEN_ENCRYPTION_KEY` set; on a solo install they exit with an explanatory error. The config subcommands (`tier`, `default`) are **ungated** — they write `~/.archon/config.yaml` and work everywhere.
+
+```bash
+# --- Provider credentials (require TOKEN_ENCRYPTION_KEY) ---
+archon ai key set <provider>     # connect an API key (masked prompt or piped stdin — never argv)
+archon ai login <provider>       # connect a subscription via OAuth (claude or copilot)
+archon ai list                   # list connected providers (metadata only, no secrets)
+archon ai logout <provider>      # disconnect a provider
+
+# --- Model tiers + default assistant (ungated config) ---
+archon ai tier set <small|medium|large> <provider> <model> [--effort <effort>]
+archon ai tier list [--json]     # show configured tiers vs built-in defaults
+archon ai tier unset <small|medium|large>   # reset a tier to its built-in default
+archon ai default <provider>     # set the default assistant
+```
+
+`ai login` supports subscription login for **`claude`** and **`copilot`** only — `codex` is API-key-only (use `ai key set codex`); its subscription path is gated pending [#1924](https://github.com/coleam00/Archon/issues/1924). The API key is never read from argv (it would leak into shell history): pipe it (`echo "$KEY" | archon ai key set openrouter`) or type it at the masked prompt.
+
+`ai tier` and `ai default` edit the same `tiers:` / `defaultAssistant` config you can hand-write in `~/.archon/config.yaml` (see [Configuration](/reference/configuration/)) or edit from the console **AI Settings** page. An unknown provider exits non-zero; `tier unset` removes the override so the tier falls back to its built-in preset. The full per-user setup walkthrough is in [Per-user credentials and AI Settings](/getting-started/ai-assistants/#per-user-credentials-and-ai-settings).
+
 ### `telemetry status`
 
 Show the current anonymous telemetry state: whether it is enabled, the opt-out reason if not, the install UUID, the active PostHog host, and the key source.

--- a/packages/docs-web/src/content/docs/reference/configuration.md
+++ b/packages/docs-web/src/content/docs/reference/configuration.md
@@ -109,6 +109,8 @@ aliases:
 
 ```
 
+The `tiers:` block above is no longer hand-edit-only -- you can also set the `small`/`medium`/`large` presets from the console **AI Settings** -> **Model Tiers** panel, or from the CLI with [`archon ai tier set`](/reference/cli/#ai). Connecting your own provider API key or subscription is covered in [Per-user credentials and AI Settings](/getting-started/ai-assistants/#per-user-credentials-and-ai-settings).
+
 ## Repository Configuration
 
 Create `.archon/config.yaml` in any repository for project-specific settings:

--- a/packages/docs-web/src/content/docs/reference/security.md
+++ b/packages/docs-web/src/content/docs/reference/security.md
@@ -132,6 +132,10 @@ The GitHub and Gitea adapters verify webhook signatures to ensure payloads origi
 - Per-codebase env vars configured via `codebase_env_vars` or `.archon/config.yaml` `env:` are merged on top at workflow execution time.
 - `<cwd>/.env` is the **only** untrusted source. It belongs to the target project, not to Archon. Directory ownership (`.archon/`) is the security boundary — not the filename.
 
+**Per-user provider credentials:**
+- When `TOKEN_ENCRYPTION_KEY` (64-char hex) is set, each user can connect their own provider API key or subscription. These are encrypted at rest with **AES-256-GCM**, never logged, and **never returned by any endpoint** — responses carry only `provider`/`kind`/`label` metadata. See [AI Provider Credentials](/reference/api/#ai-provider-credentials).
+- The credential routes (`/api/auth/providers*`) require a resolved identity (the `X-Archon-User` header or a Better Auth session). The model-config routes (`/api/config/*`, including `tiers`) are intentionally **ungated** — they carry no secrets (just model strings) and must work on solo installs.
+
 ### Target repo `.env` isolation
 
 Archon prevents target repo `.env` from leaking into subprocesses through structural protection:


### PR DESCRIPTION
## Summary

- **Problem:** the per-user AI credentials + AI-settings epic (#1891, PR-1…PR-3b) is documented in `CLAUDE.md` but **not on the public docs site** — `reference/api.md` lacks the `/api/auth/providers*` family and `/api/config/tiers` (and has a **broken** `/api/config/assistants` curl), `reference/cli.md` has **no `archon ai` section at all** (none since #1899), and there's no user-facing per-user-credentials guide.
- **Why it matters:** a new operator setting up a shared Archon box can now self-serve the per-user setup (connect a key or subscription, pick model tiers) from the docs site without reading source or `CLAUDE.md`.
- **What changed:** additive doc edits across 5 `packages/docs-web` files, mirroring each file's existing style.
- **What did **not** change (scope boundary):** docs only — no code, no tests. No Phase 3 docs (per-user DB tier overrides). The `tiers:` YAML format isn't re-documented (`configuration.md` already has it) — only cross-linked.

## UX Journey

### Before

```
  Docs site
  ─────────
  reference/api.md      → /api/config (GET) + /api/config/assistants (PATCH, BROKEN curl); no tiers; no /api/auth/providers*
  reference/cli.md      → auth github, telemetry, workflow … ; NO `archon ai`
  ai-assistants.md      → per-provider install/auth only; no per-user/multi-user layer
```

### After

```
  Docs site
  ─────────
  reference/api.md      → [+] PATCH /api/config/tiers + tiers/tierDefaults; [~] fixed /assistants curl;
                          [+] AI Provider Credentials section (GET/PUT/DELETE /api/auth/providers + POST …/oauth/start|poll)
  reference/cli.md      → [+] `### ai` (key set/login/list/logout, tier set|list|unset, default)
  ai-assistants.md      → [+] "Per-user credentials and AI Settings" section (gate, console AI Settings, CLI equivalents)
  configuration.md      → [~] tiers block cross-links the console / `archon ai tier`
  security.md           → [~] per-user credential encryption (AES-256-GCM) + ungated-config note
```

## Architecture Diagram

### Before

```
docs-web/reference/{api,cli,configuration,security}.md   getting-started/ai-assistants.md
   (per-user credentials + tiers editor undocumented on the site)
```

### After

```
docs-web/reference/api.md          [~]  /api/config/tiers + AI Provider Credentials section
docs-web/reference/cli.md          [~]  `archon ai` section  ===▶ links api.md#ai-provider-credentials, ai-assistants
docs-web/getting-started/ai-assistants.md  [~]  Per-user credentials and AI Settings  ===▶ links cli#ai, configuration
docs-web/reference/configuration.md [~]  tiers cross-link  ===▶ cli#ai, ai-assistants
docs-web/reference/security.md      [~]  per-user credential encryption  ===▶ api#ai-provider-credentials
```

**Connection inventory** (cross-links added; verified against built HTML):

| From | To | Status | Notes |
|------|----|--------|-------|
| `cli.md#ai` | `api.md`, `ai-assistants.md`, `configuration.md` | **new** | anchors resolve in dist |
| `ai-assistants.md` (new section) | `cli.md#ai`, `configuration.md` | **new** | |
| `api.md` (credentials section) | `cli.md#ai`, `ai-assistants.md` | **new** | |
| `security.md` | `api.md#ai-provider-credentials` | **new** | |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `docs`
- Module: `docs:reference`, `docs:getting-started`

## Change Metadata

- Change type: `docs`
- Primary scope: `multi` (docs only)

## Linked Issue

- Related #1891 (Part of — Phase 2 PR-4; umbrella stays open through Phase 3)
- Related #1924 (codex subscription gating — referenced in the prose)

## Validation Evidence (required)

```bash
bun --filter @archon/docs-web build   # ✅ exit 0 — 76 pages built, Pagefind index OK
bunx prettier --check <the 5 files>   # ✅ "All matched files use Prettier code style!"
# Cross-link anchors grepped from the built HTML:
#   #ai-provider-credentials, #ai, #auth-github, #per-user-credentials-and-ai-settings  — all resolve ✅
```

- Evidence: docs build green; all four inbound cross-link anchors confirmed present as `id="…"` in the generated HTML.
- Skipped: `bun run type-check` / `lint` / `test` — **docs-only change, no code touched** (the docs build + prettier are the real gate for `docs-web`).

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No** (docs only; example responses contain no real secrets)
- File system access scope changed? **No**

## Compatibility / Migration

- Backward compatible? **Yes** (additive doc edits)
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

- Verified scenarios: `bun --filter @archon/docs-web build` (exit 0, 76 pages); prettier clean on all 5 files; every new cross-link anchor confirmed in the built `dist/**/*.html`.
- Edge cases checked: `configuration.md` has no `### Model tiers` heading (tiers YAML lives in the `## Global Configuration` code block) → cross-linked the page, not a non-existent anchor; used "and" (not `&`) in the ai-assistants heading for a clean slug.
- What was not verified: visual rendering in a browser (build-only); the docs facts themselves are ported verbatim from `CLAUDE.md` (kept current by #1921/#1926).

## Side Effects / Blast Radius (required)

- Affected subsystems: `packages/docs-web` content only — 5 markdown files.
- Potential unintended effects: none beyond rendered docs; no runtime code paths touched.
- Guardrails/monitoring: the docs build (CI) fails on markdown/build errors.

## Rollback Plan (required)

- Fast rollback: revert this PR — docs return to the prior (incomplete) state; no runtime impact.
- Toggles: none.
- Observable failure symptoms: docs build failure, or a broken internal link (none introduced — anchors verified).

## Risks and Mitigations

- Risk: the docs state codex subscription is gated pending #1924 — if #1924 resolves before/after merge, the `ai login` / `subscriptionAvailable` notes need a one-line update.
  - Mitigation: the gating is called out in exactly two spots (api.md + ai-assistants.md), both linking #1924, so the follow-up edit is trivial and discoverable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added per-user credentials and AI Settings configuration guides for the web console and CLI.
  * Documented new API endpoints for managing default assistants and model tier presets.
  * Added CLI command reference for managing AI provider credentials and model tier configuration.
  * Enhanced security documentation explaining credential encryption and access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->