### PR TITLE
Gate stale workflow resumes

### DIFF
--- a/packages/core/src/handlers/command-handler.test.ts
+++ b/packages/core/src/handlers/command-handler.test.ts
@@ -1401,7 +1401,7 @@ describe('CommandHandler', () => {
     });
 
     describe('/workflow resume', () => {
-      test('should indicate failed run is ready to resume', async () => {
+      test('should return workflow dispatch data for failed run resume', async () => {
         const run = {
           id: 'run-123',
           workflow_name: 'implement',
@@ -1417,12 +1417,20 @@ describe('CommandHandler', () => {
           working_path: '/workspace/wt',
         };
         mockGetWorkflowRun.mockResolvedValueOnce(run);
+        spyDiscoverWorkflows.mockResolvedValueOnce({
+          workflows: [
+            makeTestWorkflowWithSource({ name: 'implement', description: 'Implement changes' }),
+          ],
+          errors: [],
+        });
 
         const result = await handleCommand(baseConversation, '/workflow resume run-123');
 
         expect(result.success).toBe(true);
-        expect(result.message).toContain('ready to resume');
-        expect(result.message).toContain('implement');
+        expect(result.message).toContain('Resuming workflow: `implement`');
+        expect(result.workflow?.definition.name).toBe('implement');
+        expect(result.workflow?.args).toBe('test');
+        expect(result.workflow?.resumeRunId).toBe('run-123');
       });
 
       test('should accept already-failed run without status change', async () => {
@@ -1441,12 +1449,44 @@ describe('CommandHandler', () => {
           working_path: null,
         };
         mockGetWorkflowRun.mockResolvedValueOnce(run);
+        spyDiscoverWorkflows.mockResolvedValueOnce({
+          workflows: [makeTestWorkflowWithSource({ name: 'plan', description: 'Plan changes' })],
+          errors: [],
+        });
 
         const result = await handleCommand(baseConversation, '/workflow resume run-456');
 
         expect(result.success).toBe(true);
+        expect(result.workflow?.resumeRunId).toBe('run-456');
         // Already failed — no status change needed
         expect(mockFailWorkflowRun).not.toHaveBeenCalled();
+      });
+
+      test('should return error when workflow definition is unavailable', async () => {
+        mockGetWorkflowRun.mockResolvedValueOnce({
+          id: 'run-missing-workflow',
+          workflow_name: 'missing-workflow',
+          conversation_id: 'conv-1',
+          parent_conversation_id: null,
+          codebase_id: null,
+          status: 'failed' as const,
+          user_message: 'test',
+          metadata: {},
+          started_at: new Date(),
+          completed_at: null,
+          last_activity_at: null,
+          working_path: null,
+        });
+        spyDiscoverWorkflows.mockResolvedValueOnce({ workflows: [], errors: [] });
+
+        const result = await handleCommand(
+          baseConversation,
+          '/workflow resume run-missing-workflow'
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.message).toContain('was not found');
+        expect(result.workflow).toBeUndefined();
       });
 
       test('should reject resume of non-resumable run', async () => {
@@ -1664,6 +1704,60 @@ describe('CommandHandler', () => {
         expect(result.workflow).toBeDefined();
         expect(result.workflow?.definition.name).toBe('fix-issue');
         expect(result.workflow?.args).toBe('#42 add dark mode');
+      });
+
+      test('should parse --force after workflow name and strip it from args', async () => {
+        spyDiscoverWorkflows.mockResolvedValueOnce({
+          workflows: [
+            makeTestWorkflowWithSource({ name: 'test-workflow', description: 'A test workflow' }),
+          ],
+          errors: [],
+        });
+
+        const result = await handleCommand(
+          conversationWithCodebase,
+          '/workflow run test-workflow --force do it'
+        );
+
+        expect(result.success).toBe(true);
+        expect(result.workflow?.force).toBe(true);
+        expect(result.workflow?.args).toBe('do it');
+      });
+
+      test('should parse --force anywhere in workflow args and strip it', async () => {
+        spyDiscoverWorkflows.mockResolvedValueOnce({
+          workflows: [
+            makeTestWorkflowWithSource({ name: 'test-workflow', description: 'A test workflow' }),
+          ],
+          errors: [],
+        });
+
+        const result = await handleCommand(
+          conversationWithCodebase,
+          '/workflow run test-workflow do --force it'
+        );
+
+        expect(result.success).toBe(true);
+        expect(result.workflow?.force).toBe(true);
+        expect(result.workflow?.args).toBe('do it');
+      });
+
+      test('should leave force unset when --force is absent', async () => {
+        spyDiscoverWorkflows.mockResolvedValueOnce({
+          workflows: [
+            makeTestWorkflowWithSource({ name: 'test-workflow', description: 'A test workflow' }),
+          ],
+          errors: [],
+        });
+
+        const result = await handleCommand(
+          conversationWithCodebase,
+          '/workflow run test-workflow do it'
+        );
+
+        expect(result.success).toBe(true);
+        expect(result.workflow?.force).toBeUndefined();
+        expect(result.workflow?.args).toBe('do it');
       });
 
       test('should return not-found when no codebase is configured', async () => {

--- a/packages/core/src/handlers/command-handler.test.ts
+++ b/packages/core/src/handlers/command-handler.test.ts
@@ -474,6 +474,20 @@ describe('CommandHandler', () => {
       expect(result.args).toEqual(['plan', '']);
     });
 
+    test('should unescape quoted workflow suggestions', () => {
+      const result = parseCommand(
+        '/workflow run test --force "fix \\\\ path \\"quoted\\" \\`tick\\`"'
+      );
+      expect(result.command).toBe('workflow');
+      expect(result.args).toEqual(['run', 'test', '--force', 'fix \\ path "quoted" `tick`']);
+    });
+
+    test('should unescape single quoted strings', () => {
+      const result = parseCommand("/command-invoke plan 'it\\'s \\\\ ready'");
+      expect(result.command).toBe('command-invoke');
+      expect(result.args).toEqual(['plan', "it's \\ ready"]);
+    });
+
     test('should return empty command for non-slash-prefixed input (Windows Git Bash path expansion)', () => {
       const result = parseCommand('C:/Program Files/Git/status');
       expect(result.command).toBe('');
@@ -1486,6 +1500,42 @@ describe('CommandHandler', () => {
 
         expect(result.success).toBe(false);
         expect(result.message).toContain('was not found');
+        expect(result.workflow).toBeUndefined();
+      });
+
+      test('should surface workflow load errors before not found during resume', async () => {
+        mockGetWorkflowRun.mockResolvedValueOnce({
+          id: 'run-bad-workflow',
+          workflow_name: 'bad-workflow',
+          conversation_id: 'conv-1',
+          parent_conversation_id: null,
+          codebase_id: null,
+          status: 'failed' as const,
+          user_message: 'test',
+          metadata: {},
+          started_at: new Date(),
+          completed_at: null,
+          last_activity_at: null,
+          working_path: '/workspace/wt',
+        });
+        spyDiscoverWorkflows.mockResolvedValueOnce({
+          workflows: [],
+          errors: [
+            {
+              filename: 'bad-workflow.yaml',
+              error: 'Invalid workflow YAML',
+              errorType: 'parse_error',
+            },
+          ],
+        });
+
+        const result = await handleCommand(baseConversation, '/workflow resume run-bad-workflow');
+
+        expect(result.success).toBe(false);
+        expect(result.message).toContain(
+          'Workflow `bad-workflow` failed to load: Invalid workflow YAML'
+        );
+        expect(result.message).toContain('Fix the YAML file and try again');
         expect(result.workflow).toBeUndefined();
       });
 

--- a/packages/core/src/handlers/command-handler.ts
+++ b/packages/core/src/handlers/command-handler.ts
@@ -695,10 +695,36 @@ async function handleWorkflowCommand(
       }
       try {
         const run = await resumeWorkflow(runId);
-        const pathInfo = run.working_path ? `\nPath: \`${run.working_path}\`` : '';
+        let workflowEntries: readonly WorkflowWithSource[];
+        try {
+          const result = await discoverWorkflowsWithConfig(workflowCwd, loadConfig);
+          workflowEntries = result.workflows;
+        } catch (error) {
+          const err = error as Error;
+          getLog().error({ err, cwd: workflowCwd, runId }, 'cmd.workflow_resume_discovery_failed');
+          return {
+            success: false,
+            message: `Failed to load workflows: ${err.message}\n\nCheck .archon/workflows/ for YAML syntax issues.`,
+          };
+        }
+        const workflows = workflowEntries.map(ws => ws.workflow);
+        const workflow = resolveWorkflowName(run.workflow_name, workflows);
+        if (!workflow) {
+          return {
+            success: false,
+            message:
+              `Workflow \`${run.workflow_name}\` for run ${runId} was not found.\n\n` +
+              'Use /workflow list to check available workflows.',
+          };
+        }
         return {
           success: true,
-          message: `Workflow run \`${run.workflow_name}\` (${runId}) is ready to resume.${pathInfo}\nRun the same workflow again to auto-resume from completed nodes.`,
+          message: `Resuming workflow: \`${workflow.name}\``,
+          workflow: {
+            definition: workflow,
+            args: run.user_message,
+            resumeRunId: run.id,
+          },
         };
       } catch (error) {
         const err = error as Error;
@@ -817,7 +843,9 @@ async function handleWorkflowCommand(
     case 'run': {
       // Directly invoke a workflow by name (bypasses AI router)
       const workflowName = args[1];
-      const workflowArgs = args.slice(2).join(' ');
+      const restArgs = args.slice(2);
+      const force = restArgs.includes('--force');
+      const workflowArgs = restArgs.filter(arg => arg !== '--force').join(' ');
 
       if (!workflowName) {
         return {
@@ -906,6 +934,7 @@ async function handleWorkflowCommand(
         workflow: {
           definition: workflow,
           args: workflowArgs,
+          force: force ? true : undefined,
         },
       };
     }

--- a/packages/core/src/handlers/command-handler.ts
+++ b/packages/core/src/handlers/command-handler.ts
@@ -239,6 +239,18 @@ export function parseCommand(text: string): { command: string; args: string[] } 
   return { command, args };
 }
 
+function findWorkflowLoadError(
+  loadErrors: readonly WorkflowLoadError[],
+  workflowName: string
+): WorkflowLoadError | undefined {
+  return loadErrors.find(
+    error =>
+      error.filename.replace(/\.ya?ml$/, '') === workflowName ||
+      error.filename === `${workflowName}.yaml` ||
+      error.filename === `${workflowName}.yml`
+  );
+}
+
 /**
  * Safely deactivate a session with TOCTOU race handling.
  * Between getActiveSession() and deactivateSession(), another process
@@ -751,12 +763,7 @@ async function handleWorkflowCommand(
         const workflows = workflowEntries.map(ws => ws.workflow);
         const workflow = resolveWorkflowName(run.workflow_name, workflows);
         if (!workflow) {
-          const loadError = loadErrors.find(
-            e =>
-              e.filename.replace(/\.ya?ml$/, '') === run.workflow_name ||
-              e.filename === `${run.workflow_name}.yaml` ||
-              e.filename === `${run.workflow_name}.yml`
-          );
+          const loadError = findWorkflowLoadError(loadErrors, run.workflow_name);
           if (loadError) {
             return {
               success: false,
@@ -957,12 +964,7 @@ async function handleWorkflowCommand(
 
       if (!workflow) {
         // Check if the requested workflow had a load error
-        const loadError = loadErrors.find(
-          e =>
-            e.filename.replace(/\.ya?ml$/, '') === workflowName ||
-            e.filename === `${workflowName}.yaml` ||
-            e.filename === `${workflowName}.yml`
-        );
+        const loadError = findWorkflowLoadError(loadErrors, workflowName);
         if (loadError) {
           return {
             success: false,

--- a/packages/core/src/handlers/command-handler.ts
+++ b/packages/core/src/handlers/command-handler.ts
@@ -177,8 +177,53 @@ async function formatRepoContext(
 }
 
 export function parseCommand(text: string): { command: string; args: string[] } {
-  // Match quoted strings or non-whitespace sequences
-  const matches = text.match(/"[^"]+"|'[^']+'|\S+/g) ?? [];
+  const matches: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+  let escaping = false;
+  let hasToken = false;
+
+  for (const char of text.trim()) {
+    if (quote) {
+      hasToken = true;
+      if (escaping) {
+        current += char;
+        escaping = false;
+      } else if (char === '\\') {
+        escaping = true;
+      } else if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      if (hasToken) {
+        matches.push(current);
+        current = '';
+        hasToken = false;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      hasToken = true;
+      continue;
+    }
+
+    current += char;
+    hasToken = true;
+  }
+
+  if (escaping) {
+    current += '\\';
+  }
+  if (hasToken) {
+    matches.push(current);
+  }
 
   if (matches.length === 0 || !matches[0]) {
     return { command: '', args: [] };
@@ -189,13 +234,7 @@ export function parseCommand(text: string): { command: string; args: string[] } 
   }
 
   const command = matches[0].substring(1); // Remove leading '/'
-  const args = matches.slice(1).map(arg => {
-    // Remove surrounding quotes if present
-    if ((arg.startsWith('"') && arg.endsWith('"')) || (arg.startsWith("'") && arg.endsWith("'"))) {
-      return arg.slice(1, -1);
-    }
-    return arg;
-  });
+  const args = matches.slice(1);
 
   return { command, args };
 }
@@ -696,9 +735,11 @@ async function handleWorkflowCommand(
       try {
         const run = await resumeWorkflow(runId);
         let workflowEntries: readonly WorkflowWithSource[];
+        let loadErrors: readonly WorkflowLoadError[];
         try {
           const result = await discoverWorkflowsWithConfig(workflowCwd, loadConfig);
           workflowEntries = result.workflows;
+          loadErrors = result.errors;
         } catch (error) {
           const err = error as Error;
           getLog().error({ err, cwd: workflowCwd, runId }, 'cmd.workflow_resume_discovery_failed');
@@ -710,6 +751,18 @@ async function handleWorkflowCommand(
         const workflows = workflowEntries.map(ws => ws.workflow);
         const workflow = resolveWorkflowName(run.workflow_name, workflows);
         if (!workflow) {
+          const loadError = loadErrors.find(
+            e =>
+              e.filename.replace(/\.ya?ml$/, '') === run.workflow_name ||
+              e.filename === `${run.workflow_name}.yaml` ||
+              e.filename === `${run.workflow_name}.yml`
+          );
+          if (loadError) {
+            return {
+              success: false,
+              message: `Workflow \`${run.workflow_name}\` failed to load: ${loadError.error}\n\nFix the YAML file and try again.`,
+            };
+          }
           return {
             success: false,
             message:
@@ -724,6 +777,7 @@ async function handleWorkflowCommand(
             definition: workflow,
             args: run.user_message,
             resumeRunId: run.id,
+            resumeRun: run,
           },
         };
       } catch (error) {

--- a/packages/core/src/handlers/command-handler.ts
+++ b/packages/core/src/handlers/command-handler.ts
@@ -243,12 +243,8 @@ function findWorkflowLoadError(
   loadErrors: readonly WorkflowLoadError[],
   workflowName: string
 ): WorkflowLoadError | undefined {
-  return loadErrors.find(
-    error =>
-      error.filename.replace(/\.ya?ml$/, '') === workflowName ||
-      error.filename === `${workflowName}.yaml` ||
-      error.filename === `${workflowName}.yml`
-  );
+  // Stripping the .yaml/.yml extension already covers the exact-filename cases.
+  return loadErrors.find(error => error.filename.replace(/\.ya?ml$/, '') === workflowName);
 }
 
 /**

--- a/packages/core/src/operations/workflow-operations.test.ts
+++ b/packages/core/src/operations/workflow-operations.test.ts
@@ -332,11 +332,27 @@ describe('abandonWorkflow', () => {
     expect(mockCancelWorkflowRun).toHaveBeenCalledWith('run-1');
   });
 
-  test('throws on terminal run', async () => {
+  test('cancels a failed run', async () => {
+    mockGetWorkflowRun.mockResolvedValueOnce(makePausedRun({ status: 'failed' }));
+
+    const run = await abandonWorkflow('run-1');
+    expect(run.id).toBe('run-1');
+    expect(mockCancelWorkflowRun).toHaveBeenCalledWith('run-1');
+  });
+
+  test('throws on completed run', async () => {
     mockGetWorkflowRun.mockResolvedValueOnce(makePausedRun({ status: 'completed' }));
 
     await expect(abandonWorkflow('run-1')).rejects.toThrow(
       "Cannot abandon run with status 'completed'"
+    );
+  });
+
+  test('throws on cancelled run', async () => {
+    mockGetWorkflowRun.mockResolvedValueOnce(makePausedRun({ status: 'cancelled' }));
+
+    await expect(abandonWorkflow('run-1')).rejects.toThrow(
+      "Cannot abandon run with status 'cancelled'"
     );
   });
 });

--- a/packages/core/src/operations/workflow-operations.ts
+++ b/packages/core/src/operations/workflow-operations.ts
@@ -7,7 +7,6 @@
 import { createLogger, captureApprovalResolved } from '@archon/paths';
 import {
   RESUMABLE_WORKFLOW_STATUSES,
-  TERMINAL_WORKFLOW_STATUSES,
   isApprovalContext,
 } from '@archon/workflows/schemas/workflow-run';
 import type { WorkflowRun, ApprovalContext } from '@archon/workflows/schemas/workflow-run';
@@ -106,7 +105,7 @@ export async function resumeWorkflow(runId: string): Promise<WorkflowRun> {
  */
 export async function abandonWorkflow(runId: string): Promise<WorkflowRun> {
   const run = await getRunOrThrow(runId, 'operations.workflow_abandon_lookup_failed');
-  if (TERMINAL_WORKFLOW_STATUSES.includes(run.status)) {
+  if (run.status === 'completed' || run.status === 'cancelled') {
     throw new Error(`Cannot abandon run with status '${run.status}'. Run is already terminal.`);
   }
   try {

--- a/packages/core/src/operations/workflow-operations.ts
+++ b/packages/core/src/operations/workflow-operations.ts
@@ -101,12 +101,19 @@ export async function resumeWorkflow(runId: string): Promise<WorkflowRun> {
 }
 
 /**
- * Abandon a non-terminal workflow run (marks it as cancelled).
+ * Abandon a workflow run (marks it as cancelled).
+ *
+ * Running, paused, AND failed runs can be abandoned. A `failed` run is terminal
+ * per TERMINAL_WORKFLOW_STATUSES but remains resumable, so the user must be able
+ * to discard it — hence the inline check here intentionally diverges from that
+ * constant and blocks only the two non-resumable terminal states.
  */
 export async function abandonWorkflow(runId: string): Promise<WorkflowRun> {
   const run = await getRunOrThrow(runId, 'operations.workflow_abandon_lookup_failed');
   if (run.status === 'completed' || run.status === 'cancelled') {
-    throw new Error(`Cannot abandon run with status '${run.status}'. Run is already terminal.`);
+    throw new Error(
+      `Cannot abandon run with status '${run.status}'. Only running, paused, or failed runs can be abandoned.`
+    );
   }
   try {
     await workflowDb.cancelWorkflowRun(runId);

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1382,6 +1382,25 @@ describe('workflow dispatch routing — interactive flag', () => {
     };
   }
 
+  function makeResumableRun(overrides: Partial<WorkflowRun> = {}): WorkflowRun {
+    return {
+      id: 'resumable-run-1',
+      workflow_name: 'test-workflow',
+      conversation_id: 'conv-1',
+      parent_conversation_id: 'conv-1',
+      codebase_id: 'codebase-1',
+      status: 'failed',
+      user_message: 'old failed prompt',
+      metadata: {},
+      started_at: new Date(),
+      completed_at: null,
+      last_activity_at: null,
+      working_path: '/repos/test-repo/worktrees/feature',
+      user_id: null,
+      ...overrides,
+    };
+  }
+
   beforeEach(() => {
     mockExecuteWorkflow.mockClear();
     mockDispatchBackgroundWorkflow.mockClear();
@@ -1422,14 +1441,7 @@ describe('workflow dispatch routing — interactive flag', () => {
     mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
     mockHandleCommand.mockReturnValueOnce(Promise.resolve(makeWorkflowResult(true)));
     mockFindResumableRunByParentConversation.mockReturnValueOnce(
-      Promise.resolve({
-        id: 'resumable-run-1',
-        workflow_name: 'test-workflow',
-        working_path: '/repos/test-repo/worktrees/feature',
-        parent_conversation_id: 'conv-1',
-        status: 'failed',
-        user_message: 'old failed prompt',
-      })
+      Promise.resolve(makeResumableRun())
     );
 
     const platform = makePlatform(); // getPlatformType returns 'web'
@@ -1462,14 +1474,12 @@ describe('workflow dispatch routing — interactive flag', () => {
     mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
     mockHandleCommand.mockReturnValueOnce(Promise.resolve(makeWorkflowResult(true)));
     mockFindResumableRunByParentConversation.mockReturnValueOnce(
-      Promise.resolve({
-        id: 'resumable-run-preview',
-        workflow_name: 'test-workflow',
-        working_path: '/repos/test-repo/worktrees/feature',
-        parent_conversation_id: 'conv-1',
-        status: 'failed',
-        user_message: priorMessage,
-      })
+      Promise.resolve(
+        makeResumableRun({
+          id: 'resumable-run-preview',
+          user_message: priorMessage,
+        })
+      )
     );
 
     const platform = makePlatform();
@@ -1489,14 +1499,11 @@ describe('workflow dispatch routing — interactive flag', () => {
       Promise.resolve(makeWorkflowResult(true, { args: 'fix \\ path "quoted" `tick`' }))
     );
     mockFindResumableRunByParentConversation.mockReturnValueOnce(
-      Promise.resolve({
-        id: 'resumable-run-escape',
-        workflow_name: 'test-workflow',
-        working_path: '/repos/test-repo/worktrees/feature',
-        parent_conversation_id: 'conv-1',
-        status: 'failed',
-        user_message: 'old failed prompt',
-      })
+      Promise.resolve(
+        makeResumableRun({
+          id: 'resumable-run-escape',
+        })
+      )
     );
 
     const platform = makePlatform();
@@ -1535,14 +1542,7 @@ describe('workflow dispatch routing — interactive flag', () => {
       Promise.resolve(makeWorkflowResult(true, { resumeRunId: 'resumable-run-1' }))
     );
     mockFindResumableRunByParentConversation.mockReturnValueOnce(
-      Promise.resolve({
-        id: 'resumable-run-1',
-        workflow_name: 'test-workflow',
-        working_path: '/repos/test-repo/worktrees/feature',
-        parent_conversation_id: 'conv-1',
-        status: 'failed',
-        user_message: 'old failed prompt',
-      })
+      Promise.resolve(makeResumableRun())
     );
 
     const platform = makePlatform();
@@ -1557,21 +1557,11 @@ describe('workflow dispatch routing — interactive flag', () => {
   });
 
   test('resumeRun option: hydrates the requested run without latest-run lookup', async () => {
-    const requestedRun: WorkflowRun = {
+    const requestedRun = makeResumableRun({
       id: 'old-run',
-      workflow_name: 'test-workflow',
-      conversation_id: 'conv-1',
-      parent_conversation_id: 'conv-1',
-      codebase_id: 'codebase-1',
-      status: 'failed',
       user_message: 'requested prompt',
-      metadata: {},
-      started_at: new Date(),
-      completed_at: null,
-      last_activity_at: null,
       working_path: '/repos/test-repo/worktrees/old',
-      user_id: null,
-    };
+    });
     mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
     mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
     mockHandleCommand.mockReturnValueOnce(
@@ -1598,21 +1588,11 @@ describe('workflow dispatch routing — interactive flag', () => {
   });
 
   test('resumeRun option: reports requested run with missing working path', async () => {
-    const requestedRun: WorkflowRun = {
+    const requestedRun = makeResumableRun({
       id: 'old-run-missing-path',
-      workflow_name: 'test-workflow',
-      conversation_id: 'conv-1',
-      parent_conversation_id: 'conv-1',
-      codebase_id: 'codebase-1',
-      status: 'failed',
       user_message: 'requested prompt',
-      metadata: {},
-      started_at: new Date(),
-      completed_at: null,
-      last_activity_at: null,
       working_path: null,
-      user_id: null,
-    };
+    });
     mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
     mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
     mockHandleCommand.mockReturnValueOnce(
@@ -1644,13 +1624,11 @@ describe('workflow dispatch routing — interactive flag', () => {
     mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
     mockHandleCommand.mockReturnValueOnce(Promise.resolve(makeWorkflowResult(true)));
     mockFindResumableRunByParentConversation.mockReturnValueOnce(
-      Promise.resolve({
-        id: 'resumable-run-1',
-        workflow_name: 'test-workflow',
-        working_path: '/repos/test-repo/worktrees/feature',
-        parent_conversation_id: 'conv-1',
-        status: 'paused',
-      })
+      Promise.resolve(
+        makeResumableRun({
+          status: 'paused',
+        })
+      )
     );
 
     const platform = makePlatform(); // getPlatformType returns 'web'
@@ -1681,13 +1659,12 @@ describe('workflow dispatch routing — interactive flag', () => {
     mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
     mockHandleCommand.mockReturnValueOnce(Promise.resolve(makeWorkflowResult(true)));
     mockFindResumableRunByParentConversation.mockReturnValueOnce(
-      Promise.resolve({
-        id: 'empty-prior-run',
-        workflow_name: 'test-workflow',
-        working_path: '/repos/test-repo/worktrees/feature',
-        parent_conversation_id: 'conv-1',
-        status: 'paused',
-      })
+      Promise.resolve(
+        makeResumableRun({
+          id: 'empty-prior-run',
+          status: 'paused',
+        })
+      )
     );
     mockHydrateResumableRun.mockReturnValueOnce(Promise.resolve(null));
 

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -165,10 +165,11 @@ mock.module('../workflows/store-adapter', () => ({
 
 const mockGetPausedWorkflowRun = mock(() => Promise.resolve(null as unknown));
 const mockFindResumableRunByParentConversation = mock(() => Promise.resolve(null as unknown));
+const mockUpdateWorkflowRun = mock(() => Promise.resolve());
 mock.module('../db/workflows', () => ({
   getPausedWorkflowRun: mockGetPausedWorkflowRun,
   findResumableRunByParentConversation: mockFindResumableRunByParentConversation,
-  updateWorkflowRun: mock(() => Promise.resolve()),
+  updateWorkflowRun: mockUpdateWorkflowRun,
 }));
 
 const mockCreateWorkflowEvent = mock(() => Promise.resolve());
@@ -1363,13 +1364,18 @@ describe('workflow dispatch routing — interactive flag', () => {
     };
   }
 
-  function makeWorkflowResult(interactive?: boolean) {
+  function makeWorkflowResult(
+    interactive?: boolean,
+    options: { force?: boolean; resumeRunId?: string; args?: string } = {}
+  ) {
     return {
       success: true,
       message: 'ok',
       workflow: {
         definition: makeTestWorkflow({ name: 'test-workflow', interactive }),
-        args: 'test message',
+        args: options.args ?? 'test message',
+        force: options.force,
+        resumeRunId: options.resumeRunId,
       },
     };
   }
@@ -1379,6 +1385,8 @@ describe('workflow dispatch routing — interactive flag', () => {
     mockDispatchBackgroundWorkflow.mockClear();
     mockFindResumableRunByParentConversation.mockClear();
     mockHydrateResumableRun.mockClear();
+    mockUpdateWorkflowRun.mockClear();
+    mockUpdateWorkflowRun.mockImplementation(() => Promise.resolve());
     mockHandleCommand.mockReset();
     mockHandleCommand.mockImplementation(() =>
       Promise.resolve({ success: true, message: 'ok', workflow: undefined })
@@ -1407,7 +1415,146 @@ describe('workflow dispatch routing — interactive flag', () => {
     expect(opts.parentConversationId).toBe('conv-1');
   });
 
-  test('foreground_resume_detected: passes parentConversationId to executeWorkflow when a resumable run exists', async () => {
+  test('failed_resume_user_prompted: failed runs are not auto-resumed', async () => {
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(Promise.resolve(makeWorkflowResult(true)));
+    mockFindResumableRunByParentConversation.mockReturnValueOnce(
+      Promise.resolve({
+        id: 'resumable-run-1',
+        workflow_name: 'test-workflow',
+        working_path: '/repos/test-repo/worktrees/feature',
+        parent_conversation_id: 'conv-1',
+        status: 'failed',
+        user_message: 'old failed prompt',
+      })
+    );
+
+    const platform = makePlatform(); // getPlatformType returns 'web'
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow');
+
+    expect(mockHydrateResumableRun).not.toHaveBeenCalled();
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+    expect(mockDispatchBackgroundWorkflow).not.toHaveBeenCalled();
+    expect(platform.sendMessage).toHaveBeenCalledWith(
+      'conv-1',
+      expect.stringContaining('Found a prior failed run of **test-workflow**')
+    );
+    expect(platform.sendMessage).toHaveBeenCalledWith(
+      'conv-1',
+      expect.stringContaining('/workflow resume resumable-run-1')
+    );
+    expect(platform.sendMessage).toHaveBeenCalledWith(
+      'conv-1',
+      expect.stringContaining('/workflow abandon resumable-run-1')
+    );
+    expect(platform.sendMessage).toHaveBeenCalledWith(
+      'conv-1',
+      expect.stringContaining('/workflow run test-workflow --force "test message"')
+    );
+  });
+
+  test('failed_resume_user_prompted: prompt includes normalized truncated prior prompt preview', async () => {
+    const priorMessage = `line one\n${'x'.repeat(220)}`;
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(Promise.resolve(makeWorkflowResult(true)));
+    mockFindResumableRunByParentConversation.mockReturnValueOnce(
+      Promise.resolve({
+        id: 'resumable-run-preview',
+        workflow_name: 'test-workflow',
+        working_path: '/repos/test-repo/worktrees/feature',
+        parent_conversation_id: 'conv-1',
+        status: 'failed',
+        user_message: priorMessage,
+      })
+    );
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow');
+
+    const prompt = (platform.sendMessage as ReturnType<typeof mock>).mock.calls.at(-1)?.[1] as
+      | string
+      | undefined;
+    expect(prompt).toContain(`> line one ${'x'.repeat(151)}…`);
+    expect(prompt).not.toContain('\nline one\n');
+  });
+
+  test('failed_resume_user_prompted: escapes backslash, double quote, and backtick in suggested commands', async () => {
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(
+      Promise.resolve(makeWorkflowResult(true, { args: 'fix \\ path "quoted" `tick`' }))
+    );
+    mockFindResumableRunByParentConversation.mockReturnValueOnce(
+      Promise.resolve({
+        id: 'resumable-run-escape',
+        workflow_name: 'test-workflow',
+        working_path: '/repos/test-repo/worktrees/feature',
+        parent_conversation_id: 'conv-1',
+        status: 'failed',
+        user_message: 'old failed prompt',
+      })
+    );
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow');
+
+    const prompt = (platform.sendMessage as ReturnType<typeof mock>).mock.calls.at(-1)?.[1] as
+      | string
+      | undefined;
+    expect(prompt).toContain('/workflow run test-workflow "fix \\\\ path \\"quoted\\" \\`tick\\`"');
+    expect(prompt).toContain(
+      '/workflow run test-workflow --force "fix \\\\ path \\"quoted\\" \\`tick\\`"'
+    );
+  });
+
+  test('--force flag: skips resume detection and dispatches a fresh run', async () => {
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(
+      Promise.resolve(makeWorkflowResult(true, { force: true }))
+    );
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow --force');
+
+    expect(mockFindResumableRunByParentConversation).not.toHaveBeenCalled();
+    expect(mockHydrateResumableRun).not.toHaveBeenCalled();
+    expect(mockExecuteWorkflow).toHaveBeenCalled();
+    const callArgs = mockExecuteWorkflow.mock.calls[0] as unknown[];
+    expect(callArgs[3]).toBe('/test/cwd');
+  });
+
+  test('resumeRunId option: failed run resumes when resumeRunId matches', async () => {
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(
+      Promise.resolve(makeWorkflowResult(true, { resumeRunId: 'resumable-run-1' }))
+    );
+    mockFindResumableRunByParentConversation.mockReturnValueOnce(
+      Promise.resolve({
+        id: 'resumable-run-1',
+        workflow_name: 'test-workflow',
+        working_path: '/repos/test-repo/worktrees/feature',
+        parent_conversation_id: 'conv-1',
+        status: 'failed',
+        user_message: 'old failed prompt',
+      })
+    );
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/workflow resume resumable-run-1');
+
+    expect(mockHydrateResumableRun).toHaveBeenCalled();
+    expect(mockExecuteWorkflow).toHaveBeenCalled();
+    expect(platform.sendMessage).not.toHaveBeenCalledWith(
+      'conv-1',
+      expect.stringContaining('Found a prior failed run')
+    );
+  });
+
+  test('foreground_resume_detected: passes parentConversationId to executeWorkflow when a paused run exists', async () => {
     // Regression for the foreground-resume branch: when
     // findResumableRunByParentConversation returns a paused run, the
     // orchestrator must hydrate it (single DB roundtrip — no second
@@ -1423,7 +1570,7 @@ describe('workflow dispatch routing — interactive flag', () => {
         workflow_name: 'test-workflow',
         working_path: '/repos/test-repo/worktrees/feature',
         parent_conversation_id: 'conv-1',
-        status: 'failed',
+        status: 'paused',
       })
     );
 
@@ -1460,7 +1607,7 @@ describe('workflow dispatch routing — interactive flag', () => {
         workflow_name: 'test-workflow',
         working_path: '/repos/test-repo/worktrees/feature',
         parent_conversation_id: 'conv-1',
-        status: 'failed',
+        status: 'paused',
       })
     );
     mockHydrateResumableRun.mockReturnValueOnce(Promise.resolve(null));
@@ -1674,6 +1821,11 @@ describe('natural-language approval routing', () => {
     mockGetCodebase.mockReset();
     mockGetCodebase.mockImplementation(() => Promise.resolve(null));
     mockExecuteWorkflow.mockClear();
+    mockFindResumableRunByParentConversation.mockReset();
+    mockFindResumableRunByParentConversation.mockImplementation(() => Promise.resolve(null));
+    mockHydrateResumableRun.mockClear();
+    mockUpdateWorkflowRun.mockClear();
+    mockUpdateWorkflowRun.mockImplementation(() => Promise.resolve());
     mockDiscoverWorkflowsWithConfig.mockReset();
     mockDiscoverWorkflowsWithConfig.mockImplementation(() =>
       Promise.resolve({ workflows: [], errors: [] })
@@ -1690,6 +1842,16 @@ describe('natural-language approval routing', () => {
     mockDiscoverWorkflowsWithConfig.mockImplementation(() =>
       Promise.resolve({ workflows: [{ workflow: approvalWorkflow }], errors: [] })
     );
+    mockFindResumableRunByParentConversation.mockReturnValueOnce(
+      Promise.resolve(
+        makePausedRun({
+          id: 'run-1',
+          status: 'failed',
+          working_path: '/repos/test-repo',
+          parent_conversation_id: 'conv-1',
+        })
+      )
+    );
 
     const platform = makePlatform();
     await handleMessage(platform, 'conv-1', 'looks good, proceed with implementation');
@@ -1702,9 +1864,18 @@ describe('natural-language approval routing', () => {
       expect.stringContaining('Resuming')
     );
     // Workflow should be executed
+    expect(mockUpdateWorkflowRun).toHaveBeenCalledWith('run-1', {
+      status: 'failed',
+      metadata: { approval_response: 'approved', rejection_reason: '', rejection_count: 0 },
+    });
+    expect(mockHydrateResumableRun).toHaveBeenCalled();
     expect(mockExecuteWorkflow).toHaveBeenCalled();
     // NL approval path captures the binary resolution
     expect(mockCaptureApprovalResolved).toHaveBeenCalledWith({ resolution: 'approved' });
+    expect(platform.sendMessage).not.toHaveBeenCalledWith(
+      'conv-1',
+      expect.stringContaining('Found a prior failed run')
+    );
   });
 
   test('slash command bypasses approval interception — getPausedWorkflowRun not called', async () => {

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -17,6 +17,7 @@ import { createMockLogger } from '../test/mocks/logger';
 import { makeTestWorkflow, makeTestWorkflowWithSource } from '@archon/workflows/test-utils';
 import type { Codebase, Conversation, IPlatformAdapter } from '../types';
 import type { WorkflowDefinition } from '@archon/workflows/schemas/workflow';
+import type { WorkflowRun } from '@archon/workflows/schemas/workflow-run';
 
 // ─── Mock setup (ALL mocks must come before the module under test import) ────
 
@@ -1366,7 +1367,7 @@ describe('workflow dispatch routing — interactive flag', () => {
 
   function makeWorkflowResult(
     interactive?: boolean,
-    options: { force?: boolean; resumeRunId?: string; args?: string } = {}
+    options: { force?: boolean; resumeRunId?: string; resumeRun?: WorkflowRun; args?: string } = {}
   ) {
     return {
       success: true,
@@ -1376,6 +1377,7 @@ describe('workflow dispatch routing — interactive flag', () => {
         args: options.args ?? 'test message',
         force: options.force,
         resumeRunId: options.resumeRunId,
+        resumeRun: options.resumeRun,
       },
     };
   }
@@ -1551,6 +1553,83 @@ describe('workflow dispatch routing — interactive flag', () => {
     expect(platform.sendMessage).not.toHaveBeenCalledWith(
       'conv-1',
       expect.stringContaining('Found a prior failed run')
+    );
+  });
+
+  test('resumeRun option: hydrates the requested run without latest-run lookup', async () => {
+    const requestedRun: WorkflowRun = {
+      id: 'old-run',
+      workflow_name: 'test-workflow',
+      conversation_id: 'conv-1',
+      parent_conversation_id: 'conv-1',
+      codebase_id: 'codebase-1',
+      status: 'failed',
+      user_message: 'requested prompt',
+      metadata: {},
+      started_at: new Date(),
+      completed_at: null,
+      last_activity_at: null,
+      working_path: '/repos/test-repo/worktrees/old',
+      user_id: null,
+    };
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(
+      Promise.resolve(
+        makeWorkflowResult(true, { resumeRunId: requestedRun.id, resumeRun: requestedRun })
+      )
+    );
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/workflow resume old-run');
+
+    expect(mockFindResumableRunByParentConversation).not.toHaveBeenCalled();
+    expect(mockHydrateResumableRun).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: 'old-run' })
+    );
+    expect(mockExecuteWorkflow).toHaveBeenCalled();
+    const callArgs = mockExecuteWorkflow.mock.calls[0] as unknown[];
+    expect(callArgs[3]).toBe('/repos/test-repo/worktrees/old');
+    expect(platform.sendMessage).not.toHaveBeenCalledWith(
+      'conv-1',
+      expect.stringContaining('Found a prior failed run')
+    );
+  });
+
+  test('resumeRun option: reports requested run with missing working path', async () => {
+    const requestedRun: WorkflowRun = {
+      id: 'old-run-missing-path',
+      workflow_name: 'test-workflow',
+      conversation_id: 'conv-1',
+      parent_conversation_id: 'conv-1',
+      codebase_id: 'codebase-1',
+      status: 'failed',
+      user_message: 'requested prompt',
+      metadata: {},
+      started_at: new Date(),
+      completed_at: null,
+      last_activity_at: null,
+      working_path: null,
+      user_id: null,
+    };
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(
+      Promise.resolve(
+        makeWorkflowResult(true, { resumeRunId: requestedRun.id, resumeRun: requestedRun })
+      )
+    );
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/workflow resume old-run-missing-path');
+
+    expect(mockFindResumableRunByParentConversation).not.toHaveBeenCalled();
+    expect(mockHydrateResumableRun).not.toHaveBeenCalled();
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+    expect(platform.sendMessage).toHaveBeenCalledWith(
+      'conv-1',
+      'Cannot resume old-run-missing-path: missing working path.'
     );
   });
 

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1468,6 +1468,36 @@ describe('workflow dispatch routing — interactive flag', () => {
     );
   });
 
+  test('failed_resume_user_prompted: stale running orphan gates with status-accurate copy', async () => {
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(Promise.resolve(makeWorkflowResult(true)));
+    // findResumableRunByParentConversation also surfaces stale 'running' orphans,
+    // not just 'failed' runs — the prompt must not mislabel them as "failed".
+    mockFindResumableRunByParentConversation.mockReturnValueOnce(
+      Promise.resolve(makeResumableRun({ status: 'running' }))
+    );
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow');
+
+    // Gate still fires (no silent auto-resume) ...
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+    expect(platform.sendMessage).toHaveBeenCalledWith(
+      'conv-1',
+      expect.stringContaining('/workflow resume resumable-run-1')
+    );
+    // ... but the copy reflects the real status, not "failed".
+    expect(platform.sendMessage).toHaveBeenCalledWith(
+      'conv-1',
+      expect.stringContaining('Found a prior interrupted run of **test-workflow**')
+    );
+    expect(platform.sendMessage).not.toHaveBeenCalledWith(
+      'conv-1',
+      expect.stringContaining('Found a prior failed run')
+    );
+  });
+
   test('failed_resume_user_prompted: prompt includes normalized truncated prior prompt preview', async () => {
     const priorMessage = `line one\n${'x'.repeat(220)}`;
     mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -43,6 +43,7 @@ import type {
   WorkflowLoadError,
   WorkflowSource,
 } from '@archon/workflows/schemas/workflow';
+import type { WorkflowRun } from '@archon/workflows/schemas/workflow-run';
 import { isPerUserGitHubEnabled } from '../github-auth/config';
 import { getDecryptedAccessToken } from '../db/user-github-token-store';
 import { isPerUserProviderKeysEnabled } from '../credentials/config';
@@ -480,6 +481,7 @@ function filterToolIndicators(assistantMessages: string[]): string {
 interface WorkflowDispatchOptions {
   force?: boolean;
   resumeRunId?: string;
+  resumeRun?: WorkflowRun;
 }
 
 /**
@@ -579,11 +581,19 @@ async function dispatchOrchestratorWorkflow(
   // github) resume after approval gates just like web does.
   const resumableRun = options?.force
     ? null
-    : await workflowDb.findResumableRunByParentConversation(
+    : (options?.resumeRun ??
+      (await workflowDb.findResumableRunByParentConversation(
         workflow.name,
         conversation.id,
         codebase.id
-      );
+      )));
+  if (options?.resumeRun && !options.resumeRun.working_path) {
+    await platform.sendMessage(
+      conversationId,
+      `Cannot resume ${options.resumeRun.id}: missing working path.`
+    );
+    return;
+  }
   if (resumableRun?.working_path) {
     if (resumableRun.status !== 'paused' && resumableRun.id !== options?.resumeRunId) {
       const escapedMsg = userMessage.replace(/[\\"`]/g, '\\$&');
@@ -1061,7 +1071,7 @@ export async function handleMessage(
             isolationHints,
             userId,
             workflowSource,
-            { resumeRunId: pausedRun.id }
+            { resumeRunId: pausedRun.id, resumeRun: pausedRun }
           );
           getLog().info(
             { conversationId, workflowRunId: pausedRun.id, workflowName: pausedRun.workflow_name },
@@ -1144,6 +1154,7 @@ export async function handleMessage(
             {
               force: result.workflow.force,
               resumeRunId: result.workflow.resumeRunId,
+              resumeRun: result.workflow.resumeRun,
             }
           );
         }

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -477,6 +477,11 @@ function filterToolIndicators(assistantMessages: string[]): string {
 
 // ─── Workflow Dispatch ──────────────────────────────────────────────────────
 
+interface WorkflowDispatchOptions {
+  force?: boolean;
+  resumeRunId?: string;
+}
+
 /**
  * Dispatch a workflow after the orchestrator resolves a project.
  * Auto-attaches the project to the conversation, resolves isolation, and executes.
@@ -498,7 +503,8 @@ async function dispatchOrchestratorWorkflow(
    * report their real name, custom ones report "custom"). Optional: callers
    * that don't have it readily in scope omit it and the run reports "custom".
    */
-  source?: WorkflowSource
+  source?: WorkflowSource,
+  options?: WorkflowDispatchOptions
 ): Promise<void> {
   // Capability gate: hard-fail before any worktree/clone/AI cost if the
   // workflow declares `requires: [github]` and the originating user hasn't
@@ -571,12 +577,68 @@ async function dispatchOrchestratorWorkflow(
   // is in a resumable state (paused/failed-by-approval) in this conversation+codebase
   // before dispatching fresh. This ensures chat platforms (slack, telegram, discord,
   // github) resume after approval gates just like web does.
-  const resumableRun = await workflowDb.findResumableRunByParentConversation(
-    workflow.name,
-    conversation.id,
-    codebase.id
-  );
+  const resumableRun = options?.force
+    ? null
+    : await workflowDb.findResumableRunByParentConversation(
+        workflow.name,
+        conversation.id,
+        codebase.id
+      );
   if (resumableRun?.working_path) {
+    if (resumableRun.status !== 'paused' && resumableRun.id !== options?.resumeRunId) {
+      const escapedMsg = userMessage.replace(/[\\"`]/g, '\\$&');
+      const baseCmd = `/workflow run ${workflow.name}`;
+      const PREVIEW_MAX = 160;
+      const priorMessage = (resumableRun.user_message ?? '').replace(/\s+/g, ' ').trim();
+      const priorPreview = priorMessage
+        ? priorMessage.length > PREVIEW_MAX
+          ? `${priorMessage.slice(0, PREVIEW_MAX)}…`
+          : priorMessage
+        : '(no message stored)';
+      const promptText = [
+        '---',
+        '',
+        `Found a prior failed run of **${workflow.name}** (run \`${resumableRun.id}\`).`,
+        '',
+        '**Run prompt was:**',
+        '',
+        `> ${priorPreview}`,
+        '',
+        '---',
+        '',
+        '**Choose how to proceed:**',
+        '',
+        '**1. Resume that run** (re-runs the prompt shown above, not your current message):',
+        '```',
+        `/workflow resume ${resumableRun.id}`,
+        '```',
+        '',
+        '**2. Discard the failed run, then start fresh with your current message:**',
+        '```',
+        `/workflow abandon ${resumableRun.id}`,
+        '```',
+        'then re-run your command:',
+        '```',
+        `${baseCmd} "${escapedMsg}"`,
+        '```',
+        '',
+        '**3. Start fresh with your current message, leave the failed run as-is** (skips the resume check):',
+        '```',
+        `${baseCmd} --force "${escapedMsg}"`,
+        '```',
+      ].join('\n');
+      getLog().info(
+        {
+          workflowName: workflow.name,
+          resumableRunId: resumableRun.id,
+          platformType: platform.getPlatformType(),
+        },
+        'orchestrator.failed_resume_user_prompted'
+      );
+      await platform.sendMessage(conversationId, promptText);
+      return;
+    }
+
     getLog().info(
       {
         workflowName: workflow.name,
@@ -998,7 +1060,8 @@ export async function handleMessage(
             pausedRun.user_message,
             isolationHints,
             userId,
-            workflowSource
+            workflowSource,
+            { resumeRunId: pausedRun.id }
           );
           getLog().info(
             { conversationId, workflowRunId: pausedRun.id, workflowName: pausedRun.workflow_name },
@@ -1077,7 +1140,11 @@ export async function handleMessage(
             result.workflow.definition,
             result.workflow.args ?? message,
             isolationHints,
-            userId
+            userId,
+            {
+              force: result.workflow.force,
+              resumeRunId: result.workflow.resumeRunId,
+            }
           );
         }
         return;
@@ -2237,7 +2304,8 @@ async function handleWorkflowRunCommand(
   workflow: WorkflowDefinition,
   userMessage: string,
   isolationHints?: HandleMessageContext['isolationHints'],
-  userId?: string
+  userId?: string,
+  options?: WorkflowDispatchOptions
 ): Promise<void> {
   // Check if conversation has a project
   if (conversation.codebase_id) {
@@ -2258,7 +2326,9 @@ async function handleWorkflowRunCommand(
       workflow,
       userMessage,
       isolationHints,
-      userId
+      userId,
+      undefined,
+      options
     );
     return;
   }
@@ -2337,7 +2407,8 @@ async function handleWorkflowRunCommand(
       userMessage,
       isolationHints,
       userId,
-      resolvedEntry?.source
+      resolvedEntry?.source,
+      options
     );
     return;
   }

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -509,11 +509,15 @@ function buildFailedRunResumePrompt(
   const escapedMessage = escapeWorkflowCommandArg(userMessage);
   const baseCommand = `/workflow run ${workflowName}`;
   const priorPreview = formatPriorRunPromptPreview(resumableRun.user_message);
+  // This prompt fires for any non-paused resumable run — that includes a stale
+  // 'running' orphan (started but never finished), not only 'failed' runs, so
+  // the wording must track the actual status rather than hardcoding "failed".
+  const stateLabel = resumableRun.status === 'running' ? 'interrupted' : resumableRun.status;
 
   return [
     '---',
     '',
-    `Found a prior failed run of **${workflowName}** (run \`${resumableRun.id}\`).`,
+    `Found a prior ${stateLabel} run of **${workflowName}** (run \`${resumableRun.id}\`).`,
     '',
     '**Run prompt was:**',
     '',
@@ -648,6 +652,14 @@ async function dispatchOrchestratorWorkflow(
         codebase.id
       )));
   if (options?.resumeRun && !options.resumeRun.working_path) {
+    getLog().warn(
+      {
+        runId: options.resumeRun.id,
+        workflowName: workflow.name,
+        platformType: platform.getPlatformType(),
+      },
+      'orchestrator.resume_missing_working_path'
+    );
     await platform.sendMessage(
       conversationId,
       `Cannot resume ${options.resumeRun.id}: missing working path.`

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -484,6 +484,66 @@ interface WorkflowDispatchOptions {
   resumeRun?: WorkflowRun;
 }
 
+const FAILED_RUN_PROMPT_PREVIEW_MAX = 160;
+
+function escapeWorkflowCommandArg(value: string): string {
+  return value.replace(/[\\"`]/g, '\\$&');
+}
+
+function formatPriorRunPromptPreview(message: string | null): string {
+  const normalized = (message ?? '').replace(/\s+/g, ' ').trim();
+  if (!normalized) {
+    return '(no message stored)';
+  }
+  if (normalized.length <= FAILED_RUN_PROMPT_PREVIEW_MAX) {
+    return normalized;
+  }
+  return `${normalized.slice(0, FAILED_RUN_PROMPT_PREVIEW_MAX)}…`;
+}
+
+function buildFailedRunResumePrompt(
+  workflowName: string,
+  resumableRun: WorkflowRun,
+  userMessage: string
+): string {
+  const escapedMessage = escapeWorkflowCommandArg(userMessage);
+  const baseCommand = `/workflow run ${workflowName}`;
+  const priorPreview = formatPriorRunPromptPreview(resumableRun.user_message);
+
+  return [
+    '---',
+    '',
+    `Found a prior failed run of **${workflowName}** (run \`${resumableRun.id}\`).`,
+    '',
+    '**Run prompt was:**',
+    '',
+    `> ${priorPreview}`,
+    '',
+    '---',
+    '',
+    '**Choose how to proceed:**',
+    '',
+    '**1. Resume that run** (re-runs the prompt shown above, not your current message):',
+    '```',
+    `/workflow resume ${resumableRun.id}`,
+    '```',
+    '',
+    '**2. Discard the failed run, then start fresh with your current message:**',
+    '```',
+    `/workflow abandon ${resumableRun.id}`,
+    '```',
+    'then re-run your command:',
+    '```',
+    `${baseCommand} "${escapedMessage}"`,
+    '```',
+    '',
+    '**3. Start fresh with your current message, leave the failed run as-is** (skips the resume check):',
+    '```',
+    `${baseCommand} --force "${escapedMessage}"`,
+    '```',
+  ].join('\n');
+}
+
 /**
  * Dispatch a workflow after the orchestrator resolves a project.
  * Auto-attaches the project to the conversation, resolves isolation, and executes.
@@ -596,47 +656,6 @@ async function dispatchOrchestratorWorkflow(
   }
   if (resumableRun?.working_path) {
     if (resumableRun.status !== 'paused' && resumableRun.id !== options?.resumeRunId) {
-      const escapedMsg = userMessage.replace(/[\\"`]/g, '\\$&');
-      const baseCmd = `/workflow run ${workflow.name}`;
-      const PREVIEW_MAX = 160;
-      const priorMessage = (resumableRun.user_message ?? '').replace(/\s+/g, ' ').trim();
-      const priorPreview = priorMessage
-        ? priorMessage.length > PREVIEW_MAX
-          ? `${priorMessage.slice(0, PREVIEW_MAX)}…`
-          : priorMessage
-        : '(no message stored)';
-      const promptText = [
-        '---',
-        '',
-        `Found a prior failed run of **${workflow.name}** (run \`${resumableRun.id}\`).`,
-        '',
-        '**Run prompt was:**',
-        '',
-        `> ${priorPreview}`,
-        '',
-        '---',
-        '',
-        '**Choose how to proceed:**',
-        '',
-        '**1. Resume that run** (re-runs the prompt shown above, not your current message):',
-        '```',
-        `/workflow resume ${resumableRun.id}`,
-        '```',
-        '',
-        '**2. Discard the failed run, then start fresh with your current message:**',
-        '```',
-        `/workflow abandon ${resumableRun.id}`,
-        '```',
-        'then re-run your command:',
-        '```',
-        `${baseCmd} "${escapedMsg}"`,
-        '```',
-        '',
-        '**3. Start fresh with your current message, leave the failed run as-is** (skips the resume check):',
-        '```',
-        `${baseCmd} --force "${escapedMsg}"`,
-        '```',
-      ].join('\n');
       getLog().info(
         {
           workflowName: workflow.name,
@@ -645,7 +664,10 @@ async function dispatchOrchestratorWorkflow(
         },
         'orchestrator.failed_resume_user_prompted'
       );
-      await platform.sendMessage(conversationId, promptText);
+      await platform.sendMessage(
+        conversationId,
+        buildFailedRunResumePrompt(workflow.name, resumableRun, userMessage)
+      );
       return;
     }
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -2,6 +2,7 @@
  * Core type definitions for the Remote Coding Agent platform
  */
 import type { WorkflowDefinition } from '@archon/workflows/schemas/workflow';
+import type { WorkflowRun } from '@archon/workflows/schemas/workflow-run';
 
 // MessageChunk + TokenUsage are used by IPlatformAdapter below.
 import type { MessageChunk, TokenUsage } from '@archon/providers/types';
@@ -65,6 +66,7 @@ export interface CommandResult {
     args: string;
     force?: boolean;
     resumeRunId?: string;
+    resumeRun?: WorkflowRun;
   };
 }
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -63,6 +63,8 @@ export interface CommandResult {
     // If set, orchestrator should execute this workflow
     definition: WorkflowDefinition;
     args: string;
+    force?: boolean;
+    resumeRunId?: string;
   };
 }
 

--- a/packages/docs-web/src/content/docs/book/quick-reference.md
+++ b/packages/docs-web/src/content/docs/book/quick-reference.md
@@ -26,7 +26,7 @@ This chapter collects every CLI command, variable, and YAML option in one place.
 | `archon workflow run <name> --cwd /path "<prompt>"` | Run against a specific directory |
 | `archon workflow status` | Show status of active workflow runs |
 | `archon workflow resume <run-id>` | Resume a failed workflow run |
-| `archon workflow abandon <run-id>` | Abandon a non-terminal workflow run |
+| `archon workflow abandon <run-id>` | Abandon a workflow run (running, paused, or failed) |
 | `archon workflow cleanup [days]` | Delete old workflow run records (default: 7 days) |
 
 ### `archon isolation`

--- a/packages/docs-web/src/content/docs/getting-started/overview.md
+++ b/packages/docs-web/src/content/docs/getting-started/overview.md
@@ -311,7 +311,7 @@ archon workflow run <name> --cwd /path/to/repo "<message>"
 | `archon workflow runs` | List recent runs of every status for this project |
 | `archon workflow get <id>` | Show detail for a single run (any status) |
 | `archon workflow resume <id>` | Resume a failed workflow |
-| `archon workflow abandon <id>` | Abandon a non-terminal run |
+| `archon workflow abandon <id>` | Abandon a run (running, paused, or failed) |
 | `archon workflow approve <id> [comment]` | Approve an interactive loop gate |
 | `archon workflow reject <id> [--reason "..."]` | Reject an approval gate |
 | `archon workflow cleanup [days]` | Delete old run records (default: 7 days) |

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -557,7 +557,7 @@ When a `nodes:` (DAG) workflow fails, the prior run stays in the database as a c
 **How to resume:**
 
 - **CLI**: `archon workflow run <name> --resume` resumes the most recent failed run for `(workflow_name, cwd)`. Or `archon workflow resume <run-id>` to target a specific run.
-- **Chat (web)**: Approving or rejecting a paused workflow auto-resumes from where it left off (the platform already knows the run id).
+- **Chat**: Approving or rejecting a _paused_ workflow auto-resumes from where it left off (the platform already knows the run id). For a prior **failed** (or stale `running`) run, `/workflow run <name>` does **not** silently resume — it shows a prompt offering three choices: resume it, abandon it and run fresh, or start fresh anyway. Pass `--force` to skip the prompt: `/workflow run <name> --force <args>` always starts a fresh run.
 - **Web UI**: Resume button on the workflow card.
 
 **What happens on resume:**

--- a/packages/docs-web/src/content/docs/reference/api.md
+++ b/packages/docs-web/src/content/docs/reference/api.md
@@ -266,7 +266,7 @@ Only user-defined workflows can be deleted. Bundled defaults cannot be removed.
 | GET | `/api/workflows/runs/by-worker/{platformId}` | Look up a run by worker conversation ID |
 | POST | `/api/workflows/runs/{runId}/cancel` | Cancel a running workflow |
 | POST | `/api/workflows/runs/{runId}/resume` | Resume a failed workflow |
-| POST | `/api/workflows/runs/{runId}/abandon` | Abandon a non-terminal run |
+| POST | `/api/workflows/runs/{runId}/abandon` | Abandon a run (running, paused, or failed) |
 | POST | `/api/workflows/runs/{runId}/approve` | Approve a paused workflow |
 | POST | `/api/workflows/runs/{runId}/reject` | Reject a paused workflow |
 | DELETE | `/api/workflows/runs/{runId}` | Delete a terminal run and its events |

--- a/packages/docs-web/src/content/docs/reference/commands.md
+++ b/packages/docs-web/src/content/docs/reference/commands.md
@@ -35,7 +35,7 @@ These commands are handled deterministically by the orchestrator — they always
 | `/workflow status` | Show active workflows |
 | `/workflow cancel` | Cancel running workflow |
 | `/workflow resume <id>` | Resume a failed run (re-runs, skipping completed nodes) |
-| `/workflow abandon <id>` | Discard a non-terminal run |
+| `/workflow abandon <id>` | Discard a run (running, paused, or failed) |
 | `/workflow approve <id> [comment]` | Approve a paused workflow run at an approval gate |
 | `/workflow reject <id> [reason]` | Reject a paused workflow run at an approval gate |
 | `/workflow run <name> [args]` | Run a workflow directly |


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: Fresh `/workflow run <name> ...` commands could silently resume a prior failed run for the same workflow/conversation/codebase and execute the failed run's stale `user_message` instead of the new request.
- Why it matters: This caused silent intent loss in a P1 workflow path, where a user-visible fresh command could dispatch old work with no confirmation and no clean abandon path for failed runs.
- What changed: Added explicit dispatch intent for forced fresh runs and explicit resumes, gated failed resume candidates behind a 3-option prompt before hydration, preserved paused approval auto-resume, parsed `/workflow run --force` anywhere in args, and allowed failed runs to be abandoned to `cancelled`.
- What did **not** change (scope boundary): The existing `findResumableRunByParentConversation` lookup, `hydrateResumableRun` resume model, and `WorkflowNotResumableError` CAS guards remain the owner of the failed/paused -> running transition.

## UX Journey

### Before

```text
User                         Archon                             Workflow engine
----                         ------                             ---------------
/workflow run fix A ----->   creates/dispatches workflow ---->  run fails

/workflow run fix B ----->   finds prior failed run
                             hydrates/resumes old row ------->  executes with old user_message A
User sees fresh command      no prompt shown                    stale intent runs
```

### After

```text
User                         Archon                             Workflow engine
----                         ------                             ---------------
/workflow run fix A ----->   creates/dispatches workflow ---->  run fails

/workflow run fix B ----->   finds prior failed run
                             [shows 3-option prompt]
                             returns without hydrate/execute
User chooses:
  /workflow resume <id> -->  [resumeRunId bypass] ----------->  hydrateResumableRun owns CAS resume
  /workflow abandon <id> ->  failed -> cancelled
  /workflow run fix B --force [skip lookup] ----------------->  starts fresh run with B
```

## Architecture Diagram

### Before

```text
command-handler
  | CommandResult.workflow { definition, args }
  v
orchestrator-agent dispatchOrchestratorWorkflow
  | findResumableRunByParentConversation(failed|paused)
  | hydrateResumableRun(any candidate)
  v
workflows executor / dag executor
  | uses persisted workflowRun.user_message
  v
workflow db

workflow-operations abandonWorkflow
  | rejects all terminal statuses, including failed
  v
workflow db
```

### After

```text
command-handler [~]
  | CommandResult.workflow { definition, args, force, resumeRunId }
  v
orchestrator-agent dispatchOrchestratorWorkflow [~]
  | [force skips lookup]
  | findResumableRunByParentConversation(failed|paused)
  | [failed + no matching resumeRunId -> 3-option prompt, return]
  | hydrateResumableRun(paused or explicit resume)
  v
workflows executor / dag executor
  | unchanged CAS-owned resume and persisted run hydration
  v
workflow db

workflow-operations abandonWorkflow [~]
  | rejects completed/cancelled only; failed -> cancelled
  v
workflow db
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `packages/core/src/handlers/command-handler.ts` | `packages/core/src/types/index.ts` | **modified** | Workflow command payload now carries `force` and `resumeRunId` intent. |
| `packages/core/src/orchestrator/orchestrator-agent.ts` | `packages/core/src/db/workflows.ts` | unchanged | Still uses `findResumableRunByParentConversation`; caller now gates failed rows before hydration. |
| `packages/core/src/orchestrator/orchestrator-agent.ts` | `packages/workflows/src/executor.ts` | **modified** | Dispatch only passes `resumeRunId`-authorized or paused candidates into hydration. |
| `packages/core/src/orchestrator/orchestrator-agent.ts` | platform response sending | **modified** | Fresh run with prior failed run now sends the verbatim 3-option prompt and returns. |
| `packages/core/src/operations/workflow-operations.ts` | workflow DB update path | **modified** | Failed runs can be abandoned/cancelled; completed and cancelled remain rejected. |
| `packages/core/src/**/*.test.ts` | command/orchestrator/operation modules | **modified** | Added regression coverage for all issue acceptance paths. |

## Label Snapshot

- Risk: `risk: medium`
- Size: `size: M`
- Scope: `core|tests`
- Module: `core:orchestrator`, `core:command-handler`, `core:workflow-operations`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #1549
- Related #1551
- Depends on #1830
- Supersedes #1551

## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check
bun run lint
bun run format:check
bun run test
bun run validate
```

- Evidence provided (test/log/trace/screenshot): Run artifact validation reports type-check passed, lint passed with 0 warnings, format check passed, `bun run test` passed with 4834 passed / 0 failed, build passed, and `bun run validate` passed.
- If any command is intentionally skipped, explain why: None skipped. The validation artifact notes root `bun test` was not used as the authoritative command because this repo documents that root `bun test` causes Bun `mock.module()` pollution; `bun run test` is the supported isolated test entrypoint and passed.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- New external network calls? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- File system access scope changed? (`Yes/No`) No
- If any `Yes`, describe risk and mitigation: No security-sensitive behavior changes were introduced.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Database migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: No migration or operator action required.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Fresh `/workflow run` with a prior failed run prompts and does not call `executeWorkflow`; `--force` bypasses the lookup and starts fresh; `/workflow resume <id>` dispatches with `resumeRunId`; natural-language approval resumes without prompting; paused auto-resume remains unchanged; failed abandon transitions to cancelled.
- Edge cases checked: `--force` can appear anywhere after the workflow name and is stripped from workflow args; completed and cancelled runs still cannot be abandoned; the failed-run prompt escapes backslash, double quote, and backtick in the suggested command and truncates the prior user message preview.
- What was not verified: No manual end-to-end UI screenshot was captured; coverage is through focused command/orchestrator/operation regression tests plus full repository validation.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Core workflow command handling, orchestrator workflow dispatch, workflow abandon operation, and related tests.
- Potential unintended effects: Users with a failed run will now see a prompt instead of implicit failed-run resume when issuing a fresh `/workflow run`; automation that depended on implicit failed auto-resume should switch to `/workflow resume <id>`.
- Guardrails/monitoring for early detection: Regression tests assert no `executeWorkflow` call occurs on the prompt path and that explicit resume paths still hydrate through the existing CAS model.

## Rollback Plan (required)

- Fast rollback command/path: Revert commit `cde8b12b96b98b54d3a99de504898a8f801a2e50`.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: `/workflow run` prompts unexpectedly for failed candidates, explicit `/workflow resume <id>` loops back to a prompt, natural-language approval fails to resume, or failed runs cannot be abandoned.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: Explicit resume and paused approval paths could be mistaken for fresh-run intent and prompt-loop.
  - Mitigation: `resumeRunId` bypasses the failed-run prompt, and tests cover `/workflow resume <id>` plus natural-language approval redispatch.
- Risk: The fix could accidentally bypass the existing CAS guard by pre-transitioning runs.
  - Mitigation: No pre-transition is added; hydration remains before execution and owns the CAS transition through the current `WorkflowNotResumableError` path.
- Risk: The new prompt could make stale failed runs harder to clear.
  - Mitigation: `abandonWorkflow` now accepts failed runs and transitions them to `cancelled` so the prompt can be cleared intentionally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `/workflow run` so `--force` is recognized anywhere in the command, controlling whether resume suggestions are considered.
  * `/workflow resume` now provides richer resume details and more precise outcomes.
* **Bug Fixes**
  * Improved handling for failed/stale runs: users are prompted to resume, abandon, or start fresh instead of silently re-running.
  * Clearer errors when a workflow can’t be loaded or found; improved guidance when resuming is impossible due to missing working data.
* **Documentation**
  * Updated CLI and API docs to reflect that `workflow abandon` applies to running, paused, and failed runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->