### PR TITLE
fix(core): /setproject writes to conversation DB id, not platform id

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -522,7 +522,7 @@ import type { DagNode, WorkflowDefinition } from '@/lib/api';
 
 **2. Command Handler** (`packages/core/src/handlers/`)
 - Process slash commands (deterministic, no AI)
-- The orchestrator treats only these top-level commands as deterministic: `/help`, `/status`, `/reset`, `/workflow`, `/register-project`, `/update-project`, `/remove-project`, `/commands`, `/init`, `/worktree`
+- The orchestrator treats only these top-level commands as deterministic: `/help`, `/status`, `/reset`, `/workflow`, `/register-project`, `/update-project`, `/remove-project`, `/setproject`, `/commands`, `/init`, `/worktree`
 - `/workflow` handles subcommands like `list`, `run`, `status`, `cancel`, `resume`, `abandon`, `approve`, `reject`, `reset-sessions`
 - Update database, perform operations, return responses
 

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -2974,6 +2974,39 @@ describe('handleMessage — /setproject dispatch', () => {
     });
   });
 
+  test('writes to the DB conversation id, not the platform conversation id', async () => {
+    // Regression: on Telegram/GitHub the platform conversation id (chat id,
+    // owner/repo#n) differs from the conversations-table primary key. /setproject
+    // must update by the DB id, otherwise the UPDATE matches 0 rows and throws
+    // "Conversation not found: <platform-id>".
+    const cb = makeCodebase('my-app');
+    mockListCodebases.mockImplementation(() => Promise.resolve([cb]));
+    mockParseCommand.mockReturnValue({ command: 'setproject', args: ['my-app'] });
+    mockGetOrCreateConversation.mockImplementation(() =>
+      Promise.resolve(
+        makeConversation({
+          id: 'db-hex-id',
+          platform_type: 'telegram',
+          platform_conversation_id: '40865006',
+          codebase_id: null,
+        })
+      )
+    );
+
+    const platform = makePlatform();
+    await handleMessage(platform, '40865006', '/setproject my-app');
+
+    expect(mockUpdateConversation).toHaveBeenCalledWith('db-hex-id', {
+      codebase_id: 'id-my-app',
+      cwd: '/repos/my-app',
+    });
+    // The reply still goes to the platform conversation id.
+    expect(platform.sendMessage).toHaveBeenCalledWith(
+      '40865006',
+      expect.stringContaining('my-app')
+    );
+  });
+
   test('returns not-found message listing available projects', async () => {
     mockListCodebases.mockImplementation(() =>
       Promise.resolve([makeCodebase('project-a'), makeCodebase('project-b')])

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -937,7 +937,11 @@ function makePlatform(): IPlatformAdapter {
 
 function makeConversation(overrides: Partial<Conversation> = {}): Conversation {
   return {
-    id: 'conv-1',
+    // DB primary key deliberately differs from platform_conversation_id — the
+    // real schemas always generate `id` independently, and identical defaults
+    // masked the /setproject platform-id bug (id-conflating tests passed
+    // against the broken code).
+    id: 'conv-1-db',
     platform_type: 'web',
     platform_conversation_id: 'conv-1',
     codebase_id: null,
@@ -1464,7 +1468,7 @@ describe('workflow dispatch routing — interactive flag', () => {
     // dispatch resume back through the orchestrator.
     const callArgs = mockExecuteWorkflow.mock.calls[0] as unknown[];
     const opts = callArgs[callArgs.length - 1] as { parentConversationId?: string };
-    expect(opts.parentConversationId).toBe('conv-1');
+    expect(opts.parentConversationId).toBe('conv-1-db');
   });
 
   test('failed_resume_user_prompted: failed runs are not auto-resumed', async () => {
@@ -1706,7 +1710,7 @@ describe('workflow dispatch routing — interactive flag', () => {
       preCreatedRun?: { id: string };
       priorCompletedNodes?: Map<string, string>;
     };
-    expect(opts.parentConversationId).toBe('conv-1');
+    expect(opts.parentConversationId).toBe('conv-1-db');
     expect(opts.preCreatedRun?.id).toBe('resumable-run-1');
     expect(opts.priorCompletedNodes?.size).toBeGreaterThan(0);
   });
@@ -1743,7 +1747,7 @@ describe('workflow dispatch routing — interactive flag', () => {
       preCreatedRun?: unknown;
       priorCompletedNodes?: unknown;
     };
-    expect(opts.parentConversationId).toBe('conv-1');
+    expect(opts.parentConversationId).toBe('conv-1-db');
     expect(opts.preCreatedRun).toBeUndefined();
     expect(opts.priorCompletedNodes).toBeUndefined();
   });
@@ -1861,7 +1865,7 @@ describe('workflow dispatch routing — interactive flag', () => {
 
     expect(mockFindResumableRunByParentConversation).toHaveBeenCalledWith(
       'test-workflow',
-      'conv-1',
+      'conv-1-db',
       'codebase-1'
     );
   });
@@ -2145,7 +2149,7 @@ describe('handleWorkflowRunCommand — E2 single codebase auto-select', () => {
     await handleMessage(platform, 'conv-1', '/workflow run assist test prompt');
 
     // Should auto-select the codebase and update conversation
-    expect(mockUpdateConversation).toHaveBeenCalledWith('conv-1', { codebase_id: codebase.id });
+    expect(mockUpdateConversation).toHaveBeenCalledWith('conv-1-db', { codebase_id: codebase.id });
     expect(mockDispatchBackgroundWorkflow).toHaveBeenCalled();
   });
 
@@ -2174,7 +2178,7 @@ describe('handleWorkflowRunCommand — E2 single codebase auto-select', () => {
     const platform = makePlatform();
     await handleMessage(platform, 'conv-1', '/workflow run Assist test');
 
-    expect(mockUpdateConversation).toHaveBeenCalledWith('conv-1', { codebase_id: codebase.id });
+    expect(mockUpdateConversation).toHaveBeenCalledWith('conv-1-db', { codebase_id: codebase.id });
     expect(mockDispatchBackgroundWorkflow).toHaveBeenCalled();
   });
 
@@ -2305,7 +2309,7 @@ describe('handleMessage — workflow context injection', () => {
     const platform = makePlatform();
     await handleMessage(platform, 'conv-1', 'What happened?');
 
-    expect(mockGetRecentWorkflowResultMessages).toHaveBeenCalledWith('conv-1', 3);
+    expect(mockGetRecentWorkflowResultMessages).toHaveBeenCalledWith('conv-1-db', 3);
   });
 
   test('does not throw when getRecentWorkflowResultMessages returns empty array', async () => {
@@ -2925,7 +2929,7 @@ describe('handleMessage — /setproject dispatch', () => {
     const platform = makePlatform();
     await handleMessage(platform, 'conv-1', '/setproject my-app');
 
-    expect(mockUpdateConversation).toHaveBeenCalledWith('conv-1', {
+    expect(mockUpdateConversation).toHaveBeenCalledWith('conv-1-db', {
       codebase_id: 'id-my-app',
       cwd: '/repos/my-app',
     });
@@ -2940,7 +2944,7 @@ describe('handleMessage — /setproject dispatch', () => {
     const platform = makePlatform();
     await handleMessage(platform, 'conv-1', '/setproject my-app');
 
-    expect(mockUpdateConversation).toHaveBeenCalledWith('conv-1', {
+    expect(mockUpdateConversation).toHaveBeenCalledWith('conv-1-db', {
       codebase_id: 'id-My-App',
       cwd: '/repos/My-App',
     });
@@ -2954,7 +2958,7 @@ describe('handleMessage — /setproject dispatch', () => {
     const platform = makePlatform();
     await handleMessage(platform, 'conv-1', '/setproject my-web');
 
-    expect(mockUpdateConversation).toHaveBeenCalledWith('conv-1', {
+    expect(mockUpdateConversation).toHaveBeenCalledWith('conv-1-db', {
       codebase_id: 'id-my-website',
       cwd: '/repos/my-website',
     });
@@ -2968,7 +2972,7 @@ describe('handleMessage — /setproject dispatch', () => {
     const platform = makePlatform();
     await handleMessage(platform, 'conv-1', '/setproject my-api');
 
-    expect(mockUpdateConversation).toHaveBeenCalledWith('conv-1', {
+    expect(mockUpdateConversation).toHaveBeenCalledWith('conv-1-db', {
       codebase_id: 'id-archon-my-api',
       cwd: '/repos/archon-my-api',
     });
@@ -3131,7 +3135,7 @@ describe('chat turn telemetry', () => {
 
     // Positive control: the routing path actually ran — dispatch auto-attaches
     // the project to the conversation before isolation/execution.
-    expect(mockUpdateConversation).toHaveBeenCalledWith('conv-1', {
+    expect(mockUpdateConversation).toHaveBeenCalledWith('conv-1-db', {
       codebase_id: 'id-my-project',
     });
     // …and the routing turn was NOT counted as a chat turn.

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -1178,7 +1178,9 @@ export async function handleMessage(
 
         if (command === 'setproject') {
           getLog().debug({ command, conversationId }, 'deterministic_command');
-          const result = await handleSetProject(message, conversationId);
+          // Pass the DB primary key (conversation.id), not the platform
+          // conversation id — updateConversation keys on `id`.
+          const result = await handleSetProject(message, conversation.id);
           await platform.sendMessage(conversationId, result);
           return;
         }
@@ -2422,7 +2424,7 @@ async function handleRemoveProject(message: string): Promise<string> {
  * `codebase_id` and `cwd` to the conversations table. Uses 4-tier fuzzy
  * name resolution (exact → case-insensitive → prefix → substring).
  */
-async function handleSetProject(message: string, conversationId: string): Promise<string> {
+async function handleSetProject(message: string, conversationDbId: string): Promise<string> {
   const { args } = commandHandler.parseCommand(message);
   if (args.length < 1) {
     return 'Usage: /setproject <project-name>';
@@ -2445,13 +2447,13 @@ async function handleSetProject(message: string, conversationId: string): Promis
       : `Project "${projectName}" not found. No projects registered — use /register-project.`;
   }
 
-  await db.updateConversation(conversationId, {
+  await db.updateConversation(conversationDbId, {
     codebase_id: codebase.id,
     cwd: codebase.default_cwd,
   });
 
   getLog().info(
-    { conversationId, projectName: codebase.name, codebaseId: codebase.id },
+    { conversationDbId, projectName: codebase.name, codebaseId: codebase.id },
     'project.set_completed'
   );
   return `Project set to **${codebase.name}**\nWorking directory: ${codebase.default_cwd}`;


### PR DESCRIPTION
## Summary

- **Problem:** `/setproject <name>` failed with `Error: Conversation not found: <id>` on every chat platform. `handleSetProject` passed the platform conversation id (Telegram chat id, `owner/repo#n`, Slack `thread_ts`, `web-…` string) to `db.updateConversation()`, which keys on the conversations-table **DB primary key** — a generated UUID/hex that never equals the platform id on any platform.
- **Why it matters:** Binding a conversation to a registered codebase is the entry point for multi-project use from chat platforms; the command was broken everywhere it could be typed. (The web UI never surfaced it only because it scopes conversations via `POST /api/conversations {codebaseId}` at creation time — a different flow that never invokes `/setproject` — not because of any id equality.)
- **What changed:** `handleSetProject` now receives `conversation.id` (the DB primary key, matching every other `updateConversation` call site); parameter renamed to `conversationDbId`. Regression test added where the DB id differs from the platform id. Maintainer follow-up commit: the shared `makeConversation()` test fixture now generates a DB id that differs from `platform_conversation_id` (the identical defaults were masking this whole bug class — every id-flow assertion in the file now proves the right id reaches the right layer), and `/setproject` was added to CLAUDE.md's deterministic-command list (a pre-existing doc gap).
- **What did NOT change (scope boundary):** No change to name resolution, the dispatch surface, the reply path (still addressed to the platform conversation id), session lifecycle (the known stale-session-after-project-switch gap predates this PR and is being addressed separately), or any other command handler (audited: `/setproject` was the sole outlier — all other `updateConversation` call sites already pass `conversation.id`).

## UX Journey

### Before

```
User (Telegram)            Archon
────                       ──────
/setproject brainlist ───▶ resolve codebase  -> ok
                           updateConversation(WHERE id = '<telegram-chat-id>')
                           -> 0 rows matched
sees error  ◀───────────── "Error: Conversation not found: <chat-id>"
```

### After

```
User (Telegram)            Archon
────                       ──────
/setproject brainlist ───▶ resolve codebase  -> ok
                           updateConversation(WHERE id = [conversation.id])  *DB pk*
                           -> 1 row updated
sees success ◀──────────── "Project set to <name> / Working directory: <cwd>"
```

## Architecture Diagram

### Before

```
handleMessage(conversationId=<platform id>, conversation=<row>)
   └─ handleSetProject(message, conversationId)      --x--  [wrong id]
         └─ db.updateConversation(conversationId)  -> WHERE id = <platform id>  (0 rows)
```

### After

```
handleMessage(conversationId=<platform id>, conversation=<row>)
   └─ handleSetProject(message, conversation.id)     ===    [DB pk]
         └─ db.updateConversation(conversationDbId) -> WHERE id = <DB pk>  (1 row)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| handleMessage | handleSetProject | **modified** | now passes `conversation.id` instead of `conversationId` |
| handleSetProject | db.updateConversation | **modified** | keys on DB primary key (matches every other call site) |
| handleSetProject | platform.sendMessage | unchanged | reply still addressed by platform conversation id |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `core`
- Module: `core:orchestrator`

## Change Metadata

- Change type: `bug`
- Primary scope: `core` (`packages/core/src/orchestrator`)

## Linked Issue

- None — bug found during local setup; the fix is self-describing and the regression test pins the behavior.

## Validation Evidence (required)

- `bun run validate` on the branch rebased onto current `dev`: bundled/schema/pi-vendor checks, type-check (all packages), lint (0 warnings), format check, and full per-package test suite all pass.
- `bun test packages/core/src/orchestrator/orchestrator-agent.test.ts` → 179 pass, 0 fail (includes the new regression test and the 12 assertions updated for the hardened fixture).
- Author verified end-to-end against a live Telegram bot: `/setproject` returns `Project set to ...`.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No**

## Compatibility / Migration

- Backward compatible? **Yes** — fixes a command that previously always threw; no behavior change for any working path.
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

- Verified scenarios: author ran `/setproject` end-to-end on a live Telegram bot (broken → fixed). Maintainer traced the id semantics: `updateConversation` keys on `id` (`WHERE id = $N`), `getOrCreateConversation` looks up by `(platform_type, platform_conversation_id)`, and both schemas generate `id` independently on every platform.
- Edge cases checked: reply routing still uses the platform id (asserted in the regression test); not-found/ambiguity/usage paths unchanged (existing tests); error path still surfaces to the chat user via the top-level catch.
- What was not verified live: Slack/Discord/GitHub adapters (same code path as Telegram; covered by the platform-id-divergent test).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: the `/setproject` deterministic command only. Audited every other handler in the dispatch block and every `updateConversation` call site repo-wide — this was a genuine one-off, not a pattern.
- Potential unintended effects: none expected. The hardened test fixture surfaced 12 assertions that had conflated the two ids; all were mechanical updates (production already passed the DB id in those paths).
- Known adjacent gap (pre-existing, deliberately out of scope): `/setproject` does not deactivate the active AI session after changing `cwd`; tracked separately (overlaps in-flight work on session/cwd resolution).

## Rollback Plan (required)

- Fast rollback: revert the two commits (fix + maintainer follow-up); they are self-contained.
- Feature flags or config toggles: none.
- Observable failure symptoms: `/setproject` returning `Conversation not found` again on chat platforms.

## Risks and Mitigations

- Risk: assertions updated for the hardened fixture could mask a path that *should* receive the platform id.
  - Mitigation: only DB-keyed call sites (`updateConversation`, `findResumableRunByParentConversation`, `getRecentWorkflowResultMessages`, `parentConversationId`) were updated to the DB id; all platform-facing assertions (`platform.sendMessage(...)`) still assert the platform id and pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the deterministic `/setproject` command to update conversation records using the database conversation identifier (not the platform identifier), improving correct message routing and related telemetry behavior.

* **Tests**
  * Updated orchestrator tests to consistently use the database conversation identifier for DB writes/queries, while preserving platform identifiers for user-facing replies.
  * Added/expanded a `/setproject` regression test covering cases where the two identifiers differ.

* **Documentation**
  * Updated command-handler documentation to include `/setproject`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->