### PR TITLE
fix(web/console): release per-key version counter on last unsubscribe (#1933)

### DIFF
--- a/packages/web/src/experiments/console/store/cache.test.ts
+++ b/packages/web/src/experiments/console/store/cache.test.ts
@@ -95,15 +95,79 @@ describe('subscribeKey — per-key Map lifecycle (#1933)', () => {
     await flush();
     unsubscribe();
 
-    // An SSE push for an unsubscribed key re-creates cache + versions entries.
+    // An SSE push for an unsubscribed key updates the still-warm cache; the
+    // version counter stays released because notify skips subscriber-less keys.
     set(key, 'pushed');
     expect(get(key)).toBe('pushed');
-    expect(versionOf(key)).toBe(1);
+    expect(versionOf(key)).toBe(0);
 
-    // With no loader registered, revalidate's prune branch drops everything.
+    // With no loader registered, revalidate's prune branch drops the cache too.
     invalidate(key);
     expect(get(key)).toBeUndefined();
     expect(versionOf(key)).toBe(0);
+  });
+
+  test('a load resolving after the last unsubscribe does not resurrect the counter', async () => {
+    const key = 'test:inflight-resolve';
+    let resolveLoad: (v: string) => void = () => {};
+    const unsubscribe = subscribeKey(
+      key,
+      () => {},
+      () =>
+        new Promise<string>(resolve => {
+          resolveLoad = resolve;
+        })
+    );
+
+    unsubscribe(); // last subscriber leaves while the load is still in flight
+    expect(versionOf(key)).toBe(0);
+
+    resolveLoad('late');
+    await flush();
+    expect(versionOf(key)).toBe(0); // notify skipped — nothing subscribes
+    expect(get(key)).toBe('late'); // cache still warms for a future remount
+  });
+
+  test('a load rejecting after the last unsubscribe does not resurrect the counter', async () => {
+    const key = 'test:inflight-reject';
+    let rejectLoad: (e: Error) => void = () => {};
+    const unsubscribe = subscribeKey(
+      key,
+      () => {},
+      () =>
+        new Promise<string>((_resolve, reject) => {
+          rejectLoad = reject;
+        })
+    );
+
+    unsubscribe();
+    expect(versionOf(key)).toBe(0);
+
+    rejectLoad(new Error('late boom'));
+    await flush();
+    expect(versionOf(key)).toBe(0);
+  });
+
+  test('invalidate by prefix releases every matching subscriber-less key', async () => {
+    const unsubA = subscribeKey(
+      'test-prefix:a',
+      () => {},
+      () => Promise.resolve('a')
+    );
+    const unsubB = subscribeKey(
+      'test-prefix:b',
+      () => {},
+      () => Promise.resolve('b')
+    );
+    await flush();
+    unsubA();
+    unsubB();
+
+    invalidate('test-prefix');
+    expect(get('test-prefix:a')).toBeUndefined();
+    expect(get('test-prefix:b')).toBeUndefined();
+    expect(versionOf('test-prefix:a')).toBe(0);
+    expect(versionOf('test-prefix:b')).toBe(0);
   });
 
   test('errored key still releases its counter on last unsubscribe', async () => {

--- a/packages/web/src/experiments/console/store/cache.test.ts
+++ b/packages/web/src/experiments/console/store/cache.test.ts
@@ -1,0 +1,123 @@
+import { describe, test, expect } from 'bun:test';
+import { subscribeKey, versionOf, get, set, invalidate } from './cache';
+
+// The store's Maps are module-level, so every test uses its own unique key —
+// no cross-test state to reset.
+
+function flush(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+describe('subscribeKey — per-key Map lifecycle (#1933)', () => {
+  test('last unsubscribe prunes versions; cache is retained for warm remount', async () => {
+    const key = 'test:prune-versions';
+    let loads = 0;
+    const unsubscribe = subscribeKey(
+      key,
+      () => {},
+      () => {
+        loads += 1;
+        return Promise.resolve('v1');
+      }
+    );
+    await flush();
+
+    expect(get(key)).toBe('v1');
+    expect(versionOf(key)).toBe(1); // notify bumped on load resolve
+    expect(loads).toBe(1);
+
+    unsubscribe();
+    expect(versionOf(key)).toBe(0); // counter released
+    expect(get(key)).toBe('v1'); // cached value deliberately retained
+
+    // Remount reads warm: ensureLoad short-circuits on the cached value.
+    const unsubscribe2 = subscribeKey(
+      key,
+      () => {},
+      () => {
+        loads += 1;
+        return Promise.resolve('v2');
+      }
+    );
+    await flush();
+    expect(get(key)).toBe('v1');
+    expect(loads).toBe(1); // loader not re-invoked
+    unsubscribe2();
+  });
+
+  test('unsubscribing a non-last subscriber keeps the counter', async () => {
+    const key = 'test:non-last';
+    const unsubA = subscribeKey(
+      key,
+      () => {},
+      () => Promise.resolve('a')
+    );
+    const unsubB = subscribeKey(
+      key,
+      () => {},
+      () => Promise.resolve('a')
+    );
+    await flush();
+    expect(versionOf(key)).toBe(1);
+
+    unsubA();
+    expect(versionOf(key)).toBe(1); // B still subscribed
+
+    unsubB();
+    expect(versionOf(key)).toBe(0);
+  });
+
+  test('unsubscribe stops change notifications', async () => {
+    const key = 'test:notify-stops';
+    let renders = 0;
+    const unsubscribe = subscribeKey(
+      key,
+      () => {
+        renders += 1;
+      },
+      () => Promise.resolve('a')
+    );
+    await flush();
+    expect(renders).toBe(1);
+
+    unsubscribe();
+    set(key, 'b');
+    expect(renders).toBe(1); // no further signal after cleanup
+  });
+
+  test('invalidate fully releases a subscriber-less key (cache + versions)', async () => {
+    const key = 'test:invalidate-prune';
+    const unsubscribe = subscribeKey(
+      key,
+      () => {},
+      () => Promise.resolve('a')
+    );
+    await flush();
+    unsubscribe();
+
+    // An SSE push for an unsubscribed key re-creates cache + versions entries.
+    set(key, 'pushed');
+    expect(get(key)).toBe('pushed');
+    expect(versionOf(key)).toBe(1);
+
+    // With no loader registered, revalidate's prune branch drops everything.
+    invalidate(key);
+    expect(get(key)).toBeUndefined();
+    expect(versionOf(key)).toBe(0);
+  });
+
+  test('errored key still releases its counter on last unsubscribe', async () => {
+    const key = 'test:error-prune';
+    const unsubscribe = subscribeKey(
+      key,
+      () => {},
+      () => Promise.reject(new Error('boom'))
+    );
+    await flush();
+    expect(get(key)).toBeUndefined();
+    expect(versionOf(key)).toBe(1); // error transition notified
+
+    unsubscribe();
+    expect(versionOf(key)).toBe(0);
+  });
+});

--- a/packages/web/src/experiments/console/store/cache.ts
+++ b/packages/web/src/experiments/console/store/cache.ts
@@ -9,6 +9,9 @@
  *   or `refetch()`, any key with an active subscriber reloads automatically.
  * - `patch` and `set` are for the SSE dispatcher and skill-layer optimistic
  *   updates only.
+ * - After the last unsubscribe, `cache`/`errors` are deliberately retained so
+ *   a remount reads warm; only the per-key version counter is released.
+ *   `invalidate()` fully releases subscriber-less keys.
  *
  * Deliberately minimal. No React Query, no Zustand.
  */
@@ -29,9 +32,14 @@ const loaders = new Map<string, () => Promise<unknown>>();
 const versions = new Map<string, number>();
 
 function notify(key: string): void {
-  versions.set(key, (versions.get(key) ?? 0) + 1);
+  // No subscribers ⇒ nothing snapshots the counter, so don't bump it — a late
+  // write (an in-flight load settling after the last unsubscribe, or an SSE
+  // push for an unwatched key) would otherwise resurrect the `versions` entry
+  // that unsubscribe just released (#1933). Cache/error writes still happen at
+  // the call sites so a future remount reads warm.
   const subs = listeners.get(key);
   if (subs === undefined) return;
+  versions.set(key, versionOf(key) + 1);
   for (const l of subs) l();
 }
 
@@ -141,6 +149,9 @@ export function keysStartingWith(prefix: string): string[] {
  * Module-level subscription primitive backing `useEntity`. A plain function
  * (not a hook) so the subscribe/unsubscribe lifecycle is unit-testable — the
  * same extraction shape as `handleBuilderKeydown` in `useBuilderKeyboard`.
+ *
+ * Exported for tests; production code subscribes via `useEntity`, whose
+ * `useSyncExternalStore` wiring guarantees the returned cleanup runs.
  */
 export function subscribeKey(
   key: string,
@@ -158,19 +169,21 @@ export function subscribeKey(
   ensureLoad(key);
 
   return (): void => {
-    const s = listeners.get(key);
-    if (s === undefined) return;
-    s.delete(onStoreChange);
-    if (s.size === 0) {
+    const remainingSubs = listeners.get(key);
+    if (remainingSubs === undefined) return;
+    remainingSubs.delete(onStoreChange);
+    if (remainingSubs.size === 0) {
       listeners.delete(key);
       loaders.delete(key);
       // Drop the change counter too — with no subscribers nothing snapshots it,
       // and `useSyncExternalStore` only compares snapshots for change, so a
       // remount starting back at 0 behaves identically. Without this the
       // `versions` Map grows unbounded across every key a session ever touches
-      // (#1933). `cache` and `errors` are deliberately retained so a remount
-      // reads warm (see the module contract above); `invalidate()` releases
-      // them for subscriber-less keys via `revalidate`'s no-loader branch.
+      // (#1933); `notify` refuses to bump subscriber-less keys, so a load still
+      // in flight here cannot resurrect the entry. `cache` and `errors` are
+      // deliberately retained so a remount reads warm (see the module contract
+      // above); `invalidate()` releases them for subscriber-less keys via
+      // `revalidate`'s no-loader branch.
       versions.delete(key);
     }
   };

--- a/packages/web/src/experiments/console/store/cache.ts
+++ b/packages/web/src/experiments/console/store/cache.ts
@@ -87,6 +87,7 @@ function revalidate(key: string): void {
   if (loader === undefined) {
     cache.delete(key);
     errors.delete(key);
+    versions.delete(key); // fully release the key — nothing subscribes, so nothing snapshots it
     return;
   }
   if (inflight.has(key)) return; // a revalidation is already in flight
@@ -136,6 +137,50 @@ export function keysStartingWith(prefix: string): string[] {
   return out;
 }
 
+/**
+ * Module-level subscription primitive backing `useEntity`. A plain function
+ * (not a hook) so the subscribe/unsubscribe lifecycle is unit-testable — the
+ * same extraction shape as `handleBuilderKeydown` in `useBuilderKeyboard`.
+ */
+export function subscribeKey(
+  key: string,
+  onStoreChange: Listener,
+  loader: () => Promise<unknown>
+): () => void {
+  let subs = listeners.get(key);
+  if (subs === undefined) {
+    subs = new Set();
+    listeners.set(key, subs);
+  }
+  subs.add(onStoreChange);
+
+  loaders.set(key, loader);
+  ensureLoad(key);
+
+  return (): void => {
+    const s = listeners.get(key);
+    if (s === undefined) return;
+    s.delete(onStoreChange);
+    if (s.size === 0) {
+      listeners.delete(key);
+      loaders.delete(key);
+      // Drop the change counter too — with no subscribers nothing snapshots it,
+      // and `useSyncExternalStore` only compares snapshots for change, so a
+      // remount starting back at 0 behaves identically. Without this the
+      // `versions` Map grows unbounded across every key a session ever touches
+      // (#1933). `cache` and `errors` are deliberately retained so a remount
+      // reads warm (see the module contract above); `invalidate()` releases
+      // them for subscriber-less keys via `revalidate`'s no-loader branch.
+      versions.delete(key);
+    }
+  };
+}
+
+/** Snapshot of the per-key change counter — `useEntity`'s store snapshot. */
+export function versionOf(key: string): number {
+  return versions.get(key) ?? 0;
+}
+
 export interface EntityView<T> {
   data: T | undefined;
   error: Error | undefined;
@@ -159,27 +204,8 @@ export function useEntity<T>(key: string, loader: () => Promise<T>): EntityView<
   loaderRef.current = loader;
 
   const subscribe = useCallback(
-    (onStoreChange: () => void): (() => void) => {
-      let subs = listeners.get(key);
-      if (subs === undefined) {
-        subs = new Set();
-        listeners.set(key, subs);
-      }
-      subs.add(onStoreChange);
-
-      loaders.set(key, () => loaderRef.current());
-      ensureLoad(key);
-
-      return (): void => {
-        const s = listeners.get(key);
-        if (s === undefined) return;
-        s.delete(onStoreChange);
-        if (s.size === 0) {
-          listeners.delete(key);
-          loaders.delete(key);
-        }
-      };
-    },
+    (onStoreChange: () => void): (() => void) =>
+      subscribeKey(key, onStoreChange, () => loaderRef.current()),
     [key]
   );
 
@@ -193,8 +219,8 @@ export function useEntity<T>(key: string, loader: () => Promise<T>): EntityView<
   // `loading`, as the panels do.
   useSyncExternalStore(
     subscribe,
-    () => versions.get(key) ?? 0,
-    () => versions.get(key) ?? 0
+    () => versionOf(key),
+    () => versionOf(key)
   );
 
   return {


### PR DESCRIPTION
## Summary

- Problem: the console store's `versions` Map grows unbounded — `notify()` creates an entry for every key a session ever touches and nothing ever deletes it, so long-lived console sessions leak one counter per run/message/entity key forever (#1933).
- Why it matters: the console is designed to stay open for hours with SSE pushing new keys continuously; an append-only Map is a slow memory leak in the default UI.
- What changed: `versions.delete(key)` at the two points a key's lifecycle ends — the last-subscriber unsubscribe, and `revalidate`'s no-loader branch (the `invalidate()` prune path for subscriber-less keys). The subscribe logic is extracted into an exported `subscribeKey()` plain function so the lifecycle is unit-testable, with `useEntity` rewired on top. New `cache.test.ts` pins the behavior.
- What did **not** change (scope boundary): `cache` and `errors` retention after last unsubscribe is untouched — the module contract promises warm remounts (`ensureLoad` short-circuits on a cached value), and the issue itself flags the `versions` leak as the unambiguous part while leaving cache/errors policy open. A test pins the warm-remount retention so a future eviction policy is an explicit decision, not a drift.

## UX Journey

### Before

```
User                          Console store
────                          ─────────────
opens console        ──────▶  useEntity subscribes; versions[key] created
navigates runs/chats ──────▶  more keys: versions grows
panel unmounts       ──────▶  listeners/loaders pruned; versions entry LEAKS
hours of SSE traffic ──────▶  versions grows unbounded, one entry per key ever seen
```

### After

```
User                          Console store
────                          ─────────────
opens console        ──────▶  useEntity subscribes; versions[key] created
navigates runs/chats ──────▶  more keys: versions grows
panel unmounts       ──────▶  listeners/loaders pruned; [versions entry deleted]*
invalidate(prefix)   ──────▶  subscriber-less keys: cache+errors+[versions]* all released
hours of SSE traffic ──────▶  versions bounded by currently-subscribed keys
```

## Architecture Diagram

### Before

```
useEntity (hook)
  └── inline subscribe closure ──▶ listeners / loaders / cache / errors / versions (module Maps)
        unsubscribe: prunes listeners + loaders only
revalidate (no-loader branch): prunes cache + errors only
```

### After

```
useEntity (hook)
  └── subscribeKey() [+exported]  ===▶ listeners / loaders / cache / errors / versions
        unsubscribe: prunes listeners + loaders [~ + versions]
revalidate (no-loader branch): prunes cache + errors [~ + versions]
versionOf() [+exported] ──▶ versions (snapshot read, backs useSyncExternalStore)
cache.test.ts [+] ──▶ subscribeKey / versionOf / get / set / invalidate
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| useEntity | subscribeKey | **new** | extracted from inline closure; behavior identical |
| useEntity | versionOf | **new** | snapshot reads via named export instead of inline lambda body |
| subscribeKey unsubscribe | versions | **new** | `versions.delete(key)` when last subscriber leaves |
| revalidate (no-loader) | versions | **new** | `versions.delete(key)` alongside existing cache/errors prune |
| cache.test.ts | store/cache | **new** | test file |
| useEntity | cache/errors/inflight | unchanged | data/error/loading reads as before |
| SSE dispatcher / skills | set/patch/invalidate | unchanged | public API surface identical |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `web`
- Module: `web:console-store`

## Change Metadata

- Change type: `bug`
- Primary scope: `web`

## Linked Issue

- Part of #1933 — resolves the `versions` leak; the `cache`/`errors` retention is a deliberate scope boundary (see Summary), left open so merging this doesn't auto-close that part.

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # check:bundled, check:bundled-skill, check:bundled-schema,
                   # type-check, lint, format:check all pass
cd packages/web && bun run test   # all five serial suites pass, 0 fail
                                  # (src/experiments/console/: 102 pass incl. 5 new)
```

- Evidence provided: new `cache.test.ts` — 5 tests covering last-unsubscribe prune, non-last-unsubscribe retention, notification stop after cleanup, full release of a subscriber-less key via `invalidate` (including the SSE-push-recreates-entries case), and the errored-key path. Plus a warm-remount assertion proving the loader is NOT re-invoked after unsubscribe/resubscribe (pins the deliberate cache retention).
- If any command is intentionally skipped, explain why: `bun run validate`'s parallel test fan-out crashed in my container (pid-limit SIGTRAP, all packages at once); reran the web package's serial test script directly — exit 0. No other package is touched.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: n/a

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No
- If yes, exact upgrade steps: n/a

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: traced every `versions` reader — only `versionOf` (the `useSyncExternalStore` snapshot) and `notify` (read-increment-write). With zero subscribers nothing snapshots the key, and `useSyncExternalStore` only compares snapshots for change, so a remount restarting the counter at 0 is observationally identical.
- Edge cases checked: (1) two subscribers on one key — counter survives the first unsubscribe; (2) error-state key (lives only in `errors`, not `cache`) — counter still released; (3) SSE `set()` on an unsubscribed key recreates cache+versions entries — `invalidate()`'s no-loader branch now releases all three Maps; (4) in-flight load resolving after unmount — `ensureLoad`'s `.then` repopulates cache+versions for a dead key; bounded by the key set and reclaimed by the same `invalidate` path, noted in the code comment.
- What was not verified: long-session heap profiling in a real browser; the fix is asserted at the Map-lifecycle level.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: console experiment UI only (`packages/web/src/experiments/console/store/cache.ts`); production web UI and server untouched.
- Potential unintended effects: a remounted key's version counter restarts at 0 instead of continuing — safe per the reader trace above (snapshots are compared for inequality, never persisted across subscriptions).
- Guardrails/monitoring for early detection: the 5 new tests pin the lifecycle; any future change that reintroduces the leak or breaks warm remount fails the suite.

## Rollback Plan (required)

- Fast rollback command/path: `git revert` of this single commit; no migrations, no config.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: console panels failing to re-render on data updates after a remount (would indicate the counter-reset reasoning was wrong; tests cover it).

## Risks and Mitigations

- Risk: extraction of `subscribeKey` could subtly change `useEntity` subscription semantics.
  - Mitigation: the function body is a verbatim move of the previous inline closure plus the one-line prune; `useEntity` passes the same `loaderRef`-wrapped loader; the full console suite (102 tests) passes unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for cache subscription lifecycle behaviors, including version resets on unsubscribe, cache retention for remounts, handling of multiple subscribers, cache invalidation, and error scenarios.

* **Refactor**
  * Improved internal cache version management to ensure proper lifecycle handling as subscribers are added and removed, resulting in more reliable and consistent state synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
