### PR TITLE
fix(providers): mirror CLAUDE_API_KEY to ANTHROPIC_API_KEY for the Claude subprocess

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,8 @@
 # - Not set: Auto-detect (use tokens if present, otherwise global auth)
 CLAUDE_USE_GLOBAL_AUTH=true
 # CLAUDE_CODE_OAUTH_TOKEN=...
-# CLAUDE_API_KEY=...
+# CLAUDE_API_KEY=...         # Automatically mirrored to ANTHROPIC_API_KEY for the Claude subprocess.
+#                            # CLAUDE_CODE_OAUTH_TOKEN takes precedence when both are set.
 
 # Claude Code executable path (REQUIRED for compiled Archon binaries)
 # Archon does not bundle Claude Code — install it separately and point us at it.

--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,10 @@
 # - Not set: Auto-detect (use tokens if present, otherwise global auth)
 CLAUDE_USE_GLOBAL_AUTH=true
 # CLAUDE_CODE_OAUTH_TOKEN=...
-# CLAUDE_API_KEY=...         # Automatically mirrored to ANTHROPIC_API_KEY for the Claude subprocess.
-#                            # CLAUDE_CODE_OAUTH_TOKEN takes precedence when both are set.
+# CLAUDE_API_KEY is mirrored to ANTHROPIC_API_KEY for the Claude subprocess.
+# Precedence: CLAUDE_CODE_OAUTH_TOKEN > CLAUDE_API_KEY. A set API key is used
+# even with CLAUDE_USE_GLOBAL_AUTH=true (metered API billing, not `claude /login`).
+# CLAUDE_API_KEY=...
 
 # Claude Code executable path (REQUIRED for compiled Archon binaries)
 # Archon does not bundle Claude Code — install it separately and point us at it.

--- a/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
+++ b/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
@@ -96,6 +96,8 @@ Claude Code supports three authentication modes via `CLAUDE_USE_GLOBAL_AUTH`:
 2. **Explicit Tokens** (set to `false`): Uses tokens from env vars below
 3. **Auto-Detect** (not set): Uses tokens if present in env, otherwise global auth
 
+If both `CLAUDE_CODE_OAUTH_TOKEN` and `CLAUDE_API_KEY` are set, the OAuth token wins and no API key is passed to Claude. A per-user credential connected in Settings → Agents always takes precedence over these install-wide variables for that user's runs.
+
 ### Option 1: Global Auth (Recommended)
 
 ```ini

--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, beforeEach, spyOn } from 'bun:test';
+import { describe, test, expect, mock, beforeEach, afterEach, spyOn } from 'bun:test';
 import { createMockLogger } from '../test/mocks/logger';
 
 const mockLogger = createMockLogger();
@@ -1124,6 +1124,134 @@ describe('ClaudeProvider', () => {
       const callArgs = mockQuery.mock.calls[0][0] as { options: Record<string, unknown> };
       const env = callArgs.options.env as Record<string, string>;
       expect(env.HOME).toBe('/custom/home');
+    });
+
+    describe('CLAUDE_API_KEY -> ANTHROPIC_API_KEY mapping', () => {
+      let originalClaudeApiKey: string | undefined;
+      let originalAnthropicApiKey: string | undefined;
+      let originalOAuthToken: string | undefined;
+
+      beforeEach(() => {
+        originalClaudeApiKey = process.env.CLAUDE_API_KEY;
+        originalAnthropicApiKey = process.env.ANTHROPIC_API_KEY;
+        originalOAuthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+      });
+
+      afterEach(() => {
+        if (originalClaudeApiKey === undefined) {
+          delete process.env.CLAUDE_API_KEY;
+        } else {
+          process.env.CLAUDE_API_KEY = originalClaudeApiKey;
+        }
+        if (originalAnthropicApiKey === undefined) {
+          delete process.env.ANTHROPIC_API_KEY;
+        } else {
+          process.env.ANTHROPIC_API_KEY = originalAnthropicApiKey;
+        }
+        if (originalOAuthToken === undefined) {
+          delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+        } else {
+          process.env.CLAUDE_CODE_OAUTH_TOKEN = originalOAuthToken;
+        }
+      });
+
+      test('maps when only the API key is set', async () => {
+        mockQuery.mockImplementation(async function* () {
+          yield { type: 'result', session_id: 'sid' };
+        });
+
+        delete process.env.ANTHROPIC_API_KEY;
+        delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+        process.env.CLAUDE_API_KEY = 'sk-test';
+
+        for await (const _ of client.sendQuery('test', '/tmp')) {
+          // consume
+        }
+
+        expect(mockQuery).toHaveBeenCalledTimes(1);
+        const callArgs = mockQuery.mock.calls[0][0] as { options: Record<string, unknown> };
+        const env = callArgs.options.env as Record<string, string>;
+        expect(env.CLAUDE_API_KEY).toBe('sk-test');
+        expect(env.ANTHROPIC_API_KEY).toBe('sk-test');
+      });
+
+      test('does not clobber an explicit ANTHROPIC_API_KEY', async () => {
+        mockQuery.mockImplementation(async function* () {
+          yield { type: 'result', session_id: 'sid' };
+        });
+
+        delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+        process.env.CLAUDE_API_KEY = 'sk-a';
+        process.env.ANTHROPIC_API_KEY = 'sk-b';
+
+        for await (const _ of client.sendQuery('test', '/tmp')) {
+          // consume
+        }
+
+        expect(mockQuery).toHaveBeenCalledTimes(1);
+        const callArgs = mockQuery.mock.calls[0][0] as { options: Record<string, unknown> };
+        const env = callArgs.options.env as Record<string, string>;
+        expect(env.ANTHROPIC_API_KEY).toBe('sk-b');
+      });
+
+      test('OAuth token wins — no injection', async () => {
+        mockQuery.mockImplementation(async function* () {
+          yield { type: 'result', session_id: 'sid' };
+        });
+
+        delete process.env.ANTHROPIC_API_KEY;
+        process.env.CLAUDE_API_KEY = 'sk-a';
+        process.env.CLAUDE_CODE_OAUTH_TOKEN = 'sk-ant-oat01-x';
+
+        for await (const _ of client.sendQuery('test', '/tmp')) {
+          // consume
+        }
+
+        expect(mockQuery).toHaveBeenCalledTimes(1);
+        const callArgs = mockQuery.mock.calls[0][0] as { options: Record<string, unknown> };
+        const env = callArgs.options.env as Record<string, string>;
+        expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+      });
+
+      test('no key, no injection', async () => {
+        mockQuery.mockImplementation(async function* () {
+          yield { type: 'result', session_id: 'sid' };
+        });
+
+        delete process.env.CLAUDE_API_KEY;
+        delete process.env.ANTHROPIC_API_KEY;
+        delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+
+        for await (const _ of client.sendQuery('test', '/tmp')) {
+          // consume
+        }
+
+        expect(mockQuery).toHaveBeenCalledTimes(1);
+        const callArgs = mockQuery.mock.calls[0][0] as { options: Record<string, unknown> };
+        const env = callArgs.options.env as Record<string, string>;
+        expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+      });
+
+      test('requestOptions.env still wins over the mapping', async () => {
+        mockQuery.mockImplementation(async function* () {
+          yield { type: 'result', session_id: 'sid' };
+        });
+
+        delete process.env.ANTHROPIC_API_KEY;
+        delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+        process.env.CLAUDE_API_KEY = 'sk-a';
+
+        for await (const _ of client.sendQuery('test', '/tmp', undefined, {
+          env: { ANTHROPIC_API_KEY: 'sk-override' },
+        })) {
+          // consume
+        }
+
+        expect(mockQuery).toHaveBeenCalledTimes(1);
+        const callArgs = mockQuery.mock.calls[0][0] as { options: Record<string, unknown> };
+        const env = callArgs.options.env as Record<string, string>;
+        expect(env.ANTHROPIC_API_KEY).toBe('sk-override');
+      });
     });
 
     test('passes effort to SDK via nodeConfig', async () => {

--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -1127,31 +1127,23 @@ describe('ClaudeProvider', () => {
     });
 
     describe('CLAUDE_API_KEY -> ANTHROPIC_API_KEY mapping', () => {
-      let originalClaudeApiKey: string | undefined;
-      let originalAnthropicApiKey: string | undefined;
-      let originalOAuthToken: string | undefined;
+      const ENV_KEYS_UNDER_TEST = [
+        'CLAUDE_API_KEY',
+        'ANTHROPIC_API_KEY',
+        'CLAUDE_CODE_OAUTH_TOKEN',
+      ] as const;
+      let savedEnv: Partial<Record<(typeof ENV_KEYS_UNDER_TEST)[number], string>>;
 
       beforeEach(() => {
-        originalClaudeApiKey = process.env.CLAUDE_API_KEY;
-        originalAnthropicApiKey = process.env.ANTHROPIC_API_KEY;
-        originalOAuthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+        savedEnv = {};
+        for (const key of ENV_KEYS_UNDER_TEST) savedEnv[key] = process.env[key];
       });
 
       afterEach(() => {
-        if (originalClaudeApiKey === undefined) {
-          delete process.env.CLAUDE_API_KEY;
-        } else {
-          process.env.CLAUDE_API_KEY = originalClaudeApiKey;
-        }
-        if (originalAnthropicApiKey === undefined) {
-          delete process.env.ANTHROPIC_API_KEY;
-        } else {
-          process.env.ANTHROPIC_API_KEY = originalAnthropicApiKey;
-        }
-        if (originalOAuthToken === undefined) {
-          delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
-        } else {
-          process.env.CLAUDE_CODE_OAUTH_TOKEN = originalOAuthToken;
+        for (const key of ENV_KEYS_UNDER_TEST) {
+          const value = savedEnv[key];
+          if (value === undefined) delete process.env[key];
+          else process.env[key] = value;
         }
       });
 
@@ -1173,6 +1165,8 @@ describe('ClaudeProvider', () => {
         const env = callArgs.options.env as Record<string, string>;
         expect(env.CLAUDE_API_KEY).toBe('sk-test');
         expect(env.ANTHROPIC_API_KEY).toBe('sk-test');
+        // Only the subprocess env copy is written — never process.env itself
+        expect(process.env.ANTHROPIC_API_KEY).toBeUndefined();
       });
 
       test('does not clobber an explicit ANTHROPIC_API_KEY', async () => {
@@ -1251,6 +1245,54 @@ describe('ClaudeProvider', () => {
         const callArgs = mockQuery.mock.calls[0][0] as { options: Record<string, unknown> };
         const env = callArgs.options.env as Record<string, string>;
         expect(env.ANTHROPIC_API_KEY).toBe('sk-override');
+      });
+
+      test('per-user subscription via requestOptions.env suppresses the mirror', async () => {
+        mockQuery.mockImplementation(async function* () {
+          yield { type: 'result', session_id: 'sid' };
+        });
+
+        delete process.env.ANTHROPIC_API_KEY;
+        delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+        process.env.CLAUDE_API_KEY = 'sk-install-fallback';
+
+        // Exact shape produced by deliverCredential()'s anthropic oauth branch:
+        // the delivered env carries OAuth tokens only, never ANTHROPIC_API_KEY.
+        // The mirror must not inject the install key alongside the user's
+        // subscription token (the CLI would prefer the API key and rebill).
+        for await (const _ of client.sendQuery('test', '/tmp', undefined, {
+          env: {
+            CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-user',
+            ANTHROPIC_OAUTH_TOKEN: 'sk-ant-oat01-user',
+          },
+        })) {
+          // consume
+        }
+
+        expect(mockQuery).toHaveBeenCalledTimes(1);
+        const callArgs = mockQuery.mock.calls[0][0] as { options: Record<string, unknown> };
+        const env = callArgs.options.env as Record<string, string>;
+        expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+        expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('sk-ant-oat01-user');
+      });
+
+      test('treats an empty-string ANTHROPIC_API_KEY as missing', async () => {
+        mockQuery.mockImplementation(async function* () {
+          yield { type: 'result', session_id: 'sid' };
+        });
+
+        delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+        process.env.CLAUDE_API_KEY = 'sk-test';
+        process.env.ANTHROPIC_API_KEY = '';
+
+        for await (const _ of client.sendQuery('test', '/tmp')) {
+          // consume
+        }
+
+        expect(mockQuery).toHaveBeenCalledTimes(1);
+        const callArgs = mockQuery.mock.calls[0][0] as { options: Record<string, unknown> };
+        const env = callArgs.options.env as Record<string, string>;
+        expect(env.ANTHROPIC_API_KEY).toBe('sk-test');
       });
     });
 

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -102,7 +102,19 @@ function buildSubprocessEnv(): NodeJS.ProcessEnv {
     { authMode },
     authMode === 'global' ? 'using_global_auth' : 'using_explicit_tokens'
   );
-  return { ...process.env };
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  // CLAUDE_API_KEY is Archon's variable name; the Claude Code CLI only reads
+  // ANTHROPIC_API_KEY. Mirror it so solo .env installs work (delivery.ts sets
+  // both for the per-user path). OAuth token takes precedence — do not inject
+  // an API key alongside it, and never clobber an explicit ANTHROPIC_API_KEY.
+  if (
+    process.env.CLAUDE_API_KEY &&
+    !process.env.ANTHROPIC_API_KEY &&
+    !process.env.CLAUDE_CODE_OAUTH_TOKEN
+  ) {
+    env.ANTHROPIC_API_KEY = process.env.CLAUDE_API_KEY;
+  }
+  return env;
 }
 
 /** Max retries for transient subprocess failures */

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -102,19 +102,7 @@ function buildSubprocessEnv(): NodeJS.ProcessEnv {
     { authMode },
     authMode === 'global' ? 'using_global_auth' : 'using_explicit_tokens'
   );
-  const env: NodeJS.ProcessEnv = { ...process.env };
-  // CLAUDE_API_KEY is Archon's variable name; the Claude Code CLI only reads
-  // ANTHROPIC_API_KEY. Mirror it so solo .env installs work (delivery.ts sets
-  // both for the per-user path). OAuth token takes precedence — do not inject
-  // an API key alongside it, and never clobber an explicit ANTHROPIC_API_KEY.
-  if (
-    process.env.CLAUDE_API_KEY &&
-    !process.env.ANTHROPIC_API_KEY &&
-    !process.env.CLAUDE_CODE_OAUTH_TOKEN
-  ) {
-    env.ANTHROPIC_API_KEY = process.env.CLAUDE_API_KEY;
-  }
-  return env;
+  return { ...process.env };
 }
 
 /** Max retries for transient subprocess failures */
@@ -989,6 +977,19 @@ export class ClaudeProvider implements IAgentProvider {
     // Build subprocess env once (avoids re-logging auth mode per retry)
     const subprocessEnv = buildSubprocessEnv();
     const env = requestOptions?.env ? { ...subprocessEnv, ...requestOptions.env } : subprocessEnv;
+    // CLAUDE_API_KEY is Archon's variable name; the Claude Code CLI only reads
+    // ANTHROPIC_API_KEY, so mirror it or solo .env installs never authenticate
+    // (delivery.ts sets both vars on the per-user api_key path). Guarded on the
+    // MERGED env, not process.env: a per-request CLAUDE_CODE_OAUTH_TOKEN (per-user
+    // subscription delivered via requestOptions.env) must stay authoritative —
+    // the CLI prefers ANTHROPIC_API_KEY over the OAuth token, so injecting the
+    // install key alongside it would silently rebill the run. Truthiness is
+    // intentional: empty string = missing credential. Never clobbers an
+    // explicit ANTHROPIC_API_KEY.
+    if (env.CLAUDE_API_KEY && !env.ANTHROPIC_API_KEY && !env.CLAUDE_CODE_OAUTH_TOKEN) {
+      env.ANTHROPIC_API_KEY = env.CLAUDE_API_KEY;
+      getLog().debug('using_mirrored_api_key');
+    }
 
     // Apply nodeConfig translation once (deterministic, not retry-dependent)
     // We need a throwaway Options to extract warnings from applyNodeConfig,


### PR DESCRIPTION
## Summary

- **Problem:** `CLAUDE_API_KEY` set in `.env` (solo path, no per-user credential store) passes Archon's own credential validation but is never translated to `ANTHROPIC_API_KEY` — the only variable the Claude Code CLI / Agent SDK authenticate with. The key never reaches the Claude subprocess.
- **Why it matters:** In Docker (no `claude /login` state in the container) every Claude query fails with a non-retryable `Claude Code auth error`. On hosts where `claude /login` ran, queries silently use subscription auth — the operator thinks they are on metered API billing but consume subscription quota. The Docker deployment doc explicitly offers `CLAUDE_API_KEY` as "Option B", so the documented path is broken.
- **What changed:** `buildSubprocessEnv()` now mirrors `CLAUDE_API_KEY` → `ANTHROPIC_API_KEY` on the returned env copy, but only when `CLAUDE_API_KEY` is set, `ANTHROPIC_API_KEY` is not already set, and no `CLAUDE_CODE_OAUTH_TOKEN` is present. Added 5 unit tests; annotated the `CLAUDE_API_KEY` entry in `.env.example`.
- **What did NOT change (scope boundary):** No change to `delivery.ts` (the per-user path already sets both vars), `process.env` is never mutated (only the returned copy), `hasExplicitTokens` / log semantics are untouched, and the `requestOptions.env` merge order at the call site is unchanged (per-user delivered credentials still override the base env).

## UX Journey

### Before

```
Solo .env with CLAUDE_API_KEY=sk-ant-... (no OAuth token, no claude /login):

  User              Archon                       Claude subprocess
  ────              ──────                       ─────────────────
  sends message ──▶ boot: hasClaudeCredentials=true (OK, no warning)
                    buildSubprocessEnv()
                    env = { ...process.env }      (CLAUDE_API_KEY only,
                                                   no ANTHROPIC_API_KEY)
                    query(options.env) ─────────▶ CLI reads ANTHROPIC_API_KEY
                                                   → not present → AUTH FAIL
                    errorClass 'auth'
                    shouldRetry=false
  ❌ "Claude Code   ◀── fails immediately
     auth error"
```

### After

```
Same solo .env:

  User              Archon                       Claude subprocess
  ────              ──────                       ─────────────────
  sends message ──▶ buildSubprocessEnv()
                    env = { ...process.env }
                    *if CLAUDE_API_KEY && !ANTHROPIC_API_KEY && !OAUTH:*
                    *  env.ANTHROPIC_API_KEY = CLAUDE_API_KEY*
                    query(options.env) ─────────▶ CLI reads ANTHROPIC_API_KEY
                                                   → present → AUTHENTICATES
  ✅ streams reply  ◀── response
```

OAuth path unchanged: if `CLAUDE_CODE_OAUTH_TOKEN` is set, no API key is injected and the subprocess continues to use subscription auth exactly as before.

## Architecture Diagram

### Before

```
server/index.ts (boot validation: accepts CLAUDE_API_KEY)
        │
        ▼
providers/claude/provider.ts
  buildSubprocessEnv() ── returns { ...process.env } ──▶ SDK query(options.env)
                                                          (no ANTHROPIC_API_KEY)

core/credentials/delivery.ts  (per-user path: sets BOTH vars — not on solo path)
```

### After

```
server/index.ts (boot validation: unchanged)
        │
        ▼
providers/claude/provider.ts
  [~] buildSubprocessEnv() ── mirrors CLAUDE_API_KEY → ANTHROPIC_API_KEY ══▶ SDK query(options.env)
                              (additive, OAuth-guarded; copy only)              (ANTHROPIC_API_KEY present)

core/credentials/delivery.ts  (unchanged — solo path now matches its both-vars behavior)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| providers/claude `buildSubprocessEnv()` | SDK `query()` `options.env` | **modified** | now includes `ANTHROPIC_API_KEY` in the API-key-alone case |
| server/index.ts boot validation | providers/claude | unchanged | |
| core/credentials/delivery.ts | providers/claude | unchanged | per-user path already correct |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `providers` (closest available list value; package is `@archon/providers`)
- Module: `providers:claude`

## Change Metadata

- Change type: `bug`
- Primary scope: `providers` (`packages/providers/src/claude`)

## Linked Issue

- Closes #1940

## Validation Evidence (required)

`bun run validate` (run with `NODE_OPTIONS=--max-old-space-size=8192` — the ESLint full-repo pass OOMs at the default heap on a low-memory container; this is an environment limit, not a code issue):

```
$ bun run check:bundled         → ok
$ bun run check:bundled-skill   → ok
$ bun run check:bundled-schema  → ok
$ bun run type-check            → all 10 packages Exited with code 0
$ bun run lint --max-warnings 0 → ok (0 warnings)
$ bun run format:check          → All matched files use Prettier code style!
$ bun run test                  → all packages 0 fail
```

`@archon/providers` (the touched package) including the 5 new tests:

```
$ cd packages/providers && bun test src/claude/provider.test.ts
 80 pass
 0 fail
 159 expect() calls
```

- Evidence provided: full `bun run validate` output (commands above), targeted provider test run.
- Skipped commands: none. (Lint required a raised Node heap locally; CI memory is unaffected.)

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **Yes** — the change copies an already-present secret (`CLAUDE_API_KEY`) to a second key (`ANTHROPIC_API_KEY`) inside the **subprocess env copy only**. `process.env` is not mutated. No secret is logged, transmitted, or persisted; the value already lived in the same process env. The copy is gated so it only occurs when the operator supplied an API key and no OAuth token, i.e. exactly the case where they intend API-key auth.
- File system access scope changed? **No**

## Compatibility / Migration

- Backward compatible? **Yes** — strictly additive and OAuth-guarded. The only configuration whose behavior changes is API-key-alone (currently broken). Deployments with `CLAUDE_CODE_OAUTH_TOKEN`, with an explicit `ANTHROPIC_API_KEY`, or with global auth are byte-for-byte unchanged.
- Config/env changes? **No** (only a clarifying comment added to `.env.example`).
- Database migration needed? **No**

## Human Verification (required)

- Verified scenarios: traced all five env permutations through `sendQuery` → SDK `options.env` (the 5 new tests). Confirmed precedence explicit `ANTHROPIC_API_KEY` > `CLAUDE_CODE_OAUTH_TOKEN` > `CLAUDE_API_KEY`. Verified the per-user delivery path (`requestOptions.env`) still overrides the base env.
- Edge cases checked: API key alone (maps); explicit `ANTHROPIC_API_KEY` present (not clobbered); OAuth token present (no injection); nothing set (no injection); `requestOptions.env` override (wins).
- What was not verified: live end-to-end against a real Anthropic API key / real Docker container (no credentials available in this environment). The behavior is exercised at the exact integration point (`options.env` handed to `query()`).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: only the Claude provider subprocess env (`packages/providers/src/claude/provider.ts`). Every Claude-backed workflow/conversation benefits in the API-key-alone case; all other auth modes unaffected.
- Potential unintended effects: none expected — the OAuth guard prevents silently flipping subscription deployments to API-key billing; the `!ANTHROPIC_API_KEY` guard prevents overriding an explicitly chosen key.
- Guardrails/monitoring for early detection: existing `using_global_auth` / `using_explicit_tokens` boot log; auth failures still surface as `Claude Code auth error`.

## Rollback Plan (required)

- Fast rollback command/path: single-commit revert — `git revert <commit>` (the change is one isolated commit touching `provider.ts`, `provider.test.ts`, `.env.example`).
- Feature flags or config toggles: none. To opt out of the mapping, set an explicit `ANTHROPIC_API_KEY` or use `CLAUDE_CODE_OAUTH_TOKEN`.
- Observable failure symptoms: Claude queries returning `Claude Code auth error` despite a valid `CLAUDE_API_KEY` would indicate regression.

## Risks and Mitigations

- Risk: an operator running both `CLAUDE_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` expecting API-key billing.
  - Mitigation: OAuth token intentionally takes precedence (matches pre-existing CLI behavior, which sees only the OAuth token); documented in `.env.example`. Changing this would silently alter billing for existing deployments, so it is deliberately out of scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Claude authentication now automatically maps `CLAUDE_API_KEY` for the Claude subprocess when appropriate.
  - OAuth tokens and per-user credentials take precedence over install-wide API keys.
  - Existing explicit Anthropic API keys and environment overrides are preserved.

- **Documentation**
  - Clarified Claude authentication precedence and environment-variable behavior in setup documentation.
  - Added guidance to the example environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->