### PR TITLE
feat(marketplace): add Harness Score community workflow

### DIFF
--- a/packages/docs-web/src/data/marketplace.ts
+++ b/packages/docs-web/src/data/marketplace.ts
@@ -155,4 +155,16 @@ export const marketplaceEntries: MarketplaceEntry[] = [
     tags: ['development', 'planning', 'review'],
     archonVersionCompat: '>=0.3.0',
   },
+  {
+    slug: 'harness-score',
+    name: 'Harness Score',
+    author: 'seanrobertwright',
+    description:
+      "Audit a repository's readiness for AI-agent-driven development. Runs 10 deterministic checks (agent instructions, README, build/test commands, CI, tests, lint/typecheck, .archon workflows, security scanning, sensitive paths) scored out of 100, then Claude synthesizes a markdown report with a rating and the top 3 fixes ranked by score gain.",
+    sourceUrl:
+      'https://github.com/seanrobertwright/archon-harness-score/blob/main/harness-score.yaml',
+    sha: '0a5b1406d9869e29507aed005df9456a2ea686e6',
+    tags: ['review', 'automation'],
+    archonVersionCompat: '>=0.3.0',
+  },
 ];

--- a/packages/docs-web/src/data/marketplace.ts
+++ b/packages/docs-web/src/data/marketplace.ts
@@ -160,7 +160,7 @@ export const marketplaceEntries: MarketplaceEntry[] = [
     name: 'Harness Score',
     author: 'seanrobertwright',
     description:
-      "Audit a repository's readiness for AI-agent-driven development. Runs 10 deterministic checks (agent instructions, README, build/test commands, CI, tests, lint/typecheck, .archon workflows, security scanning, sensitive paths) scored out of 100, then Claude synthesizes a markdown report with a rating and the top 3 fixes ranked by score gain.",
+      'Audit a repository for AI-agent readiness. A deterministic script runs 10 checks (agent instructions, README, build/test commands, CI, tests, lint/typecheck, .archon workflows, security scanning, sensitive paths) and computes a score out of 100; Claude then narrates the pre-computed results into a markdown report with a rating and the top 3 fixes ranked by score gain.',
     sourceUrl:
       'https://github.com/seanrobertwright/archon-harness-score/blob/main/harness-score.yaml',
     sha: '0a5b1406d9869e29507aed005df9456a2ea686e6',


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: No marketplace workflow exists for auditing whether a repository is ready for AI-agent-driven development.
- Why it matters: Teams adopting Archon (or any agentic tooling) lack a quick, deterministic way to see what harness infrastructure (agent instructions, CI, tests, lint, security scanning) is missing before pointing agents at a repo.
- What changed: Adds one community entry, `harness-score`, to the marketplace registry (`packages/docs-web/src/data/marketplace.ts`). The workflow runs 10 deterministic checks scored out of 100 via a `bun` script node, then a Claude node synthesizes a markdown report with a rating and top 3 fixes. Hosted at [seanrobertwright/archon-harness-score](https://github.com/seanrobertwright/archon-harness-score), pinned to SHA `0a5b1406d9869e29507aed005df9456a2ea686e6`.
- What did **not** change (scope boundary): No engine, server, web, or docs-page code. No bundled defaults. Only the registry data file gains one array entry.

## UX Journey

### Before

```
  User                          archon.diy/workflows
  ────                          ────────────────────
  browses marketplace ────────▶ 9 entries listed
  searches "readiness audit"    nothing relevant found
```

### After

```
  User                          archon.diy/workflows
  ────                          ────────────────────
  browses marketplace ────────▶ 10 entries listed
  finds [Harness Score]* ─────▶ detail page with pinned source
  installs to .archon/workflows
  runs `archon workflow run harness-score`
  gets harness-score.md report (score /100, rating, top 3 fixes)
```

## Architecture Diagram

### Before

```
marketplace.ts ──▶ workflows/index.astro ──▶ workflows/[slug].astro
      │
      └──▶ workflows.json.ts (API feed)
```

### After

```
marketplace.ts [~ +1 entry] ──▶ workflows/index.astro ──▶ workflows/[slug].astro
      │
      └──▶ workflows.json.ts (API feed)
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| marketplace.ts | workflows/index.astro | unchanged | one more entry rendered |
| marketplace.ts | workflows/[slug].astro | unchanged | new static page generated |
| marketplace.ts | workflows.json.ts | unchanged | new entry in JSON feed |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `docs`
- Module: `docs:marketplace`

## Change Metadata

- Change type: `docs`
- Primary scope: `multi` (docs-web data file only)

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Validation Evidence (required)

Commands and result summary:

```bash
bun packages/docs-web/scripts/lint-marketplace.ts
# Marketplace lint PASSED — all 10 entries valid.
# ✓ [harness-score] https://raw.githubusercontent.com/seanrobertwright/archon-harness-score/0a5b1406d9869e29507aed005df9456a2ea686e6/harness-score.yaml

bunx prettier --check packages/docs-web/src/data/marketplace.ts
# All matched files use Prettier code style!
```

- Evidence provided (test/log/trace/screenshot): marketplace lint output above, including the network check verifying the source file exists at the pinned SHA.
- If any command is intentionally skipped, explain why: full `bun run validate` skipped — this PR touches a single data file in docs-web; the marketplace lint CI job (`marketplace-lint.yml`) is the targeted gate for this path and passes locally.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`) — registry data only; the workflow itself runs locally when a user installs it
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation: N/A

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: marketplace lint passes with the new entry; the pinned raw URL resolves; the workflow YAML is the version in active personal use.
- Edge cases checked: slug uniqueness against all 9 existing entries; tags restricted to the valid set (`review`, `automation`); full 40-char SHA.
- What was not verified: rendered docs-site page (no local Astro build run); workflow behavior on non-JS/TS repos beyond the detection script's Python/Go/Rust manifest handling.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: archon.diy `/workflows` listing, `/workflows/harness-score` detail page, `workflows.json` feed.
- Potential unintended effects: none beyond one additional marketplace card.
- Guardrails/monitoring for early detection: `marketplace-lint.yml` CI re-validates every entry (including source existence at pinned SHA) on any future change to the registry.

## Rollback Plan (required)

- Fast rollback command/path: revert this commit (single-entry array addition).
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: marketplace lint failure or broken `/workflows/harness-score` page.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: source repo could change or disappear after merge.
  - Mitigation: entry is pinned to commit SHA `0a5b1406d9869e29507aed005df9456a2ea686e6`; lint verifies existence at that SHA on every registry change.

## Self-Attestation (marketplace submission)

- [x] The workflow does not exfiltrate data, credentials, or secrets
- [x] The workflow does not execute destructive operations without user confirmation
- [x] I have the right to share this workflow publicly
- [x] The pinned SHA points to a reviewed, stable version of the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the "Harness Score" marketplace workflow — provides scoring and report generation with integrated review and automation. Compatible with Archon v0.3.0 and above.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->