### PR TITLE
fix(workflows): allow abandoning failed runs as help text promises

### DIFF
--- a/packages/core/src/handlers/command-handler.test.ts
+++ b/packages/core/src/handlers/command-handler.test.ts
@@ -1523,6 +1523,30 @@ describe('CommandHandler', () => {
         expect(mockCancelWorkflowRun).toHaveBeenCalledWith('run-123');
       });
 
+      test('should abandon a failed run — help text promises abandon discards failed runs', async () => {
+        const run = {
+          id: 'run-456',
+          workflow_name: 'implement',
+          conversation_id: 'conv-1',
+          parent_conversation_id: null,
+          codebase_id: null,
+          status: 'failed' as const,
+          user_message: 'test',
+          metadata: {},
+          started_at: new Date(),
+          completed_at: new Date(),
+          last_activity_at: null,
+          working_path: null,
+        };
+        mockGetWorkflowRun.mockResolvedValueOnce(run);
+
+        const result = await handleCommand(baseConversation, '/workflow abandon run-456');
+
+        expect(result.success).toBe(true);
+        expect(result.message).toContain('Abandoned');
+        expect(mockCancelWorkflowRun).toHaveBeenCalledWith('run-456');
+      });
+
       test('should reject abandon of already-terminal run', async () => {
         mockGetWorkflowRun.mockResolvedValueOnce({
           id: 'run-done',

--- a/packages/core/src/operations/workflow-operations.test.ts
+++ b/packages/core/src/operations/workflow-operations.test.ts
@@ -321,12 +321,30 @@ describe('abandonWorkflow', () => {
     expect(mockCancelWorkflowRun).toHaveBeenCalledWith('run-1');
   });
 
-  test('throws on terminal run', async () => {
+  test('cancels a failed run — failed doubles as a resumable state, not settled', async () => {
+    mockGetWorkflowRun.mockResolvedValueOnce(makePausedRun({ status: 'failed' }));
+
+    const run = await abandonWorkflow('run-1');
+    expect(run.id).toBe('run-1');
+    expect(mockCancelWorkflowRun).toHaveBeenCalledWith('run-1');
+  });
+
+  test('throws on completed run', async () => {
     mockGetWorkflowRun.mockResolvedValueOnce(makePausedRun({ status: 'completed' }));
 
     await expect(abandonWorkflow('run-1')).rejects.toThrow(
       "Cannot abandon run with status 'completed'"
     );
+    expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  test('throws on cancelled run', async () => {
+    mockGetWorkflowRun.mockResolvedValueOnce(makePausedRun({ status: 'cancelled' }));
+
+    await expect(abandonWorkflow('run-1')).rejects.toThrow(
+      "Cannot abandon run with status 'cancelled'"
+    );
+    expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/operations/workflow-operations.ts
+++ b/packages/core/src/operations/workflow-operations.ts
@@ -7,7 +7,7 @@
 import { createLogger } from '@archon/paths';
 import {
   RESUMABLE_WORKFLOW_STATUSES,
-  TERMINAL_WORKFLOW_STATUSES,
+  SETTLED_WORKFLOW_STATUSES,
   isApprovalContext,
 } from '@archon/workflows/schemas/workflow-run';
 import type { WorkflowRun, ApprovalContext } from '@archon/workflows/schemas/workflow-run';
@@ -102,11 +102,15 @@ export async function resumeWorkflow(runId: string): Promise<WorkflowRun> {
 }
 
 /**
- * Abandon a non-terminal workflow run (marks it as cancelled).
+ * Abandon a workflow run (marks it as cancelled).
+ *
+ * Failed runs ARE abandonable: 'failed' doubles as a resumable/approval state,
+ * and every help surface promises abandon discards failed runs. Only
+ * 'completed' and 'cancelled' are refused (see SETTLED_WORKFLOW_STATUSES).
  */
 export async function abandonWorkflow(runId: string): Promise<WorkflowRun> {
   const run = await getRunOrThrow(runId, 'operations.workflow_abandon_lookup_failed');
-  if (TERMINAL_WORKFLOW_STATUSES.includes(run.status)) {
+  if (SETTLED_WORKFLOW_STATUSES.includes(run.status)) {
     throw new Error(`Cannot abandon run with status '${run.status}'. Run is already terminal.`);
   }
   try {

--- a/packages/core/src/orchestrator/manage-run-tool.ts
+++ b/packages/core/src/orchestrator/manage-run-tool.ts
@@ -117,7 +117,7 @@ const HELP_BY_ACTION: Record<Exclude<Action, 'help'>, string> = {
   cancel:
     'cancel — mark a running (non-terminal) run cancelled. Required: runId, confirm=true. Irreversible. A process already executing may finish its current step before it stops.',
   abandon:
-    'abandon — discard a paused/failed (non-terminal) run. Required: runId, confirm=true. Irreversible: the run becomes cancelled.',
+    'abandon — discard a paused/failed run. Required: runId, confirm=true. Irreversible: the run becomes cancelled.',
   approve:
     'approve — approve a paused human gate so the run can continue. Required: runId, confirm=true. Optional: message (comment recorded with the approval). Only paused runs with an approval gate.',
   reject:

--- a/packages/core/src/orchestrator/prompt-builder.ts
+++ b/packages/core/src/orchestrator/prompt-builder.ts
@@ -238,7 +238,7 @@ Run these from within the project's git repo (any subdirectory works — they re
 - \`archon workflow run <workflow> "<message>" --detach\` — start a run in the background (returns immediately)
 - \`archon workflow approve <run-id> [--json]\` / \`archon workflow reject <run-id> [reason] [--json]\` — resolve a paused approval gate
 - \`archon workflow resume <run-id>\` — re-run a failed/paused run, skipping completed nodes (run as a background task; \`--json\` validates only)
-- \`archon workflow abandon <run-id> [--json]\` — cancel a non-terminal run
+- \`archon workflow abandon <run-id> [--json]\` — discard a run that is not yet completed/cancelled (marks it cancelled)
 
 When the user asks what's running, whether a run passed/failed, or to approve / reject / resume / cancel a run, use these commands directly instead of invoking a workflow. The \`manage-run\` skill has the full reference if it is loaded.`;
 }

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -2825,8 +2825,13 @@ export function registerApiRoutes(
       if (SETTLED_WORKFLOW_STATUSES.includes(run.status)) {
         return apiError(c, 400, `Cannot abandon workflow in '${run.status}' status`);
       }
-      await workflowDb.cancelWorkflowRun(runId);
-      return c.json({ success: true, message: `Abandoned workflow: ${run.workflow_name}` });
+      const { cancelled } = await workflowDb.cancelWorkflowRun(runId);
+      return c.json({
+        success: true,
+        message: cancelled
+          ? `Abandoned workflow: ${run.workflow_name}`
+          : `Workflow ${run.workflow_name} already finished — nothing to abandon.`,
+      });
     } catch (error) {
       getLog().error({ err: error, runId }, 'api.workflow_run_abandon_failed');
       return apiError(c, 500, 'Failed to abandon workflow run');

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -72,6 +72,7 @@ import { isValidCommandName } from '@archon/workflows/command-validation';
 import { BUNDLED_WORKFLOWS, BUNDLED_COMMANDS, isBinaryBuild } from '@archon/workflows/defaults';
 import {
   RESUMABLE_WORKFLOW_STATUSES,
+  SETTLED_WORKFLOW_STATUSES,
   TERMINAL_WORKFLOW_STATUSES,
 } from '@archon/workflows/schemas/workflow-run';
 import type { ApprovalContext, WorkflowRun } from '@archon/workflows/schemas/workflow-run';
@@ -736,7 +737,7 @@ const abandonWorkflowRunRoute = createRoute({
   method: 'post',
   path: '/api/workflows/runs/{runId}/abandon',
   tags: ['Workflows'],
-  summary: 'Abandon a workflow run (mark as failed)',
+  summary: 'Abandon a workflow run (mark as cancelled)',
   request: { params: z.object({ runId: z.string() }) },
   responses: {
     200: {
@@ -2819,7 +2820,9 @@ export function registerApiRoutes(
       if (!run) {
         return apiError(c, 404, 'Workflow run not found');
       }
-      if (TERMINAL_WORKFLOW_STATUSES.includes(run.status)) {
+      // Failed runs are abandonable — 'failed' doubles as a resumable/approval
+      // state; only completed/cancelled runs are refused.
+      if (SETTLED_WORKFLOW_STATUSES.includes(run.status)) {
         return apiError(c, 400, `Cannot abandon workflow in '${run.status}' status`);
       }
       await workflowDb.cancelWorkflowRun(runId);

--- a/packages/server/src/routes/api.workflow-runs.test.ts
+++ b/packages/server/src/routes/api.workflow-runs.test.ts
@@ -1223,6 +1223,7 @@ describe('POST /api/workflows/runs/:runId/abandon', () => {
 
   test('returns 200 and calls cancelWorkflowRun for running run', async () => {
     mockGetWorkflowRun.mockResolvedValueOnce(MOCK_RUNNING_RUN);
+    mockCancelWorkflowRun.mockImplementationOnce(async () => ({ cancelled: true }));
     const { app } = makeApp();
     const response = await app.request('/api/workflows/runs/run-uuid-1/abandon', {
       method: 'POST',
@@ -1236,6 +1237,7 @@ describe('POST /api/workflows/runs/:runId/abandon', () => {
 
   test('returns 200 and calls cancelWorkflowRun for failed run', async () => {
     mockGetWorkflowRun.mockResolvedValueOnce(MOCK_FAILED_RUN);
+    mockCancelWorkflowRun.mockImplementationOnce(async () => ({ cancelled: true }));
     const { app } = makeApp();
     const response = await app.request('/api/workflows/runs/run-uuid-4/abandon', {
       method: 'POST',
@@ -1245,6 +1247,23 @@ describe('POST /api/workflows/runs/:runId/abandon', () => {
     expect(body.success).toBe(true);
     expect(body.message).toContain('Abandoned');
     expect(mockCancelWorkflowRun).toHaveBeenCalledWith('run-uuid-4');
+  });
+
+  test('reports "nothing to abandon" when the run settled in the abandon TOCTOU window', async () => {
+    // Run passes the status pre-check (failed), but cancelWorkflowRun no-ops
+    // because the run reached a settled state first — the route must not claim
+    // a false "Abandoned" (same shape as the cancel route, #1830 I1).
+    mockGetWorkflowRun.mockResolvedValueOnce(MOCK_FAILED_RUN);
+    mockCancelWorkflowRun.mockImplementationOnce(async () => ({ cancelled: false }));
+
+    const { app } = makeApp();
+    const response = await app.request('/api/workflows/runs/run-uuid-4/abandon', {
+      method: 'POST',
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { success: boolean; message: string };
+    expect(body.success).toBe(true);
+    expect(body.message).toContain('nothing to abandon');
   });
 });
 

--- a/packages/server/src/routes/api.workflow-runs.test.ts
+++ b/packages/server/src/routes/api.workflow-runs.test.ts
@@ -1233,6 +1233,19 @@ describe('POST /api/workflows/runs/:runId/abandon', () => {
     expect(body.message).toContain('Abandoned');
     expect(mockCancelWorkflowRun).toHaveBeenCalledWith('run-uuid-1');
   });
+
+  test('returns 200 and calls cancelWorkflowRun for failed run', async () => {
+    mockGetWorkflowRun.mockResolvedValueOnce(MOCK_FAILED_RUN);
+    const { app } = makeApp();
+    const response = await app.request('/api/workflows/runs/run-uuid-4/abandon', {
+      method: 'POST',
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { success: boolean; message: string };
+    expect(body.success).toBe(true);
+    expect(body.message).toContain('Abandoned');
+    expect(mockCancelWorkflowRun).toHaveBeenCalledWith('run-uuid-4');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/lib/api.generated.d.ts
+++ b/packages/web/src/lib/api.generated.d.ts
@@ -1212,7 +1212,7 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Abandon a workflow run (mark as failed) */
+    /** Abandon a workflow run (mark as cancelled) */
     post: {
       parameters: {
         query?: never;

--- a/packages/workflows/src/schemas/index.ts
+++ b/packages/workflows/src/schemas/index.ts
@@ -98,6 +98,7 @@ export {
   artifactTypeSchema,
   TERMINAL_WORKFLOW_STATUSES,
   RESUMABLE_WORKFLOW_STATUSES,
+  SETTLED_WORKFLOW_STATUSES,
   isApprovalContext,
 } from './workflow-run';
 export type {

--- a/packages/workflows/src/schemas/workflow-run.ts
+++ b/packages/workflows/src/schemas/workflow-run.ts
@@ -31,6 +31,18 @@ export const RESUMABLE_WORKFLOW_STATUSES: readonly WorkflowRunStatus[] = [
   'paused',
 ] as const;
 
+/**
+ * Terminal statuses that can never be cancelled or abandoned. 'failed' is
+ * deliberately NOT in this set: it is overloaded as a resumable/approval state,
+ * so abandoning a failed run (discarding it as 'cancelled') is a valid
+ * transition. Mirrors the guard inside cancelWorkflowRun, which only refuses
+ * 'completed' and 'cancelled'.
+ */
+export const SETTLED_WORKFLOW_STATUSES: readonly WorkflowRunStatus[] = [
+  'completed',
+  'cancelled',
+] as const;
+
 // ---------------------------------------------------------------------------
 // WorkflowStepStatus
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the contradiction in #1866: every help surface promises `/workflow abandon` discards failed runs, but both abandon gates rejected `'failed'` because they checked `TERMINAL_WORKFLOW_STATUSES`, which includes it. The console's RunActionBar already renders Resume · Abandon for failed runs — the Abandon button just 400s today.

The DB layer already settled the design question: `cancelWorkflowRun` explicitly documents `'failed' is intentionally still cancellable (it is overloaded as a resumable/approval state)` and its WHERE clause only refuses `completed`/`cancelled`. The two upstream gates contradicted the DB layer's own documented intent.

## Changes

- New `SETTLED_WORKFLOW_STATUSES` constant (`completed`, `cancelled`) in `packages/workflows/src/schemas/workflow-run.ts`, mirroring `cancelWorkflowRun`'s guard exactly; re-exported from the schemas index.
- `abandonWorkflow` (operations) and the `POST /api/workflows/runs/{runId}/abandon` route gate now check `SETTLED_WORKFLOW_STATUSES` instead of `TERMINAL_WORKFLOW_STATUSES`. The CLI inherits the fix via operations; the console needs zero frontend changes.
- Corrected the abandon route summary: "mark as failed" → "mark as cancelled" (abandon marks runs cancelled), plus the matching one-line doc comment in `api.generated.d.ts`. I applied that generated-file line by hand because regeneration requires a running server at port 3090; the edit is exactly what `bun generate:types` would emit for the new summary string.
- Dropped the now-wrong "(non-terminal)" qualifier from the `manage_run` help text and the run-management prompt section.
- `TERMINAL_WORKFLOW_STATUSES` is untouched and still correct for its other call sites (delete gate, resume route): failed runs remain terminal for retention/cleanup purposes — they just aren't settled.

## Tests

- `workflow-operations.test.ts`: abandon now has four cases — running succeeds, **failed succeeds** (new), completed throws, cancelled throws (the latter two assert `cancelWorkflowRun` is never called).
- `command-handler.test.ts`: `/workflow abandon` on a failed run succeeds.
- `api.workflow-runs.test.ts`: abandon route returns 200 for a failed run (uses the existing `MOCK_FAILED_RUN` fixture).
- Pre-fix audit: no existing test pinned the failed-rejection — all three "terminal" rejection tests used `completed`.

## Validation

`bun run` type-check (10/10 packages), lint, format:check, check:bundled / check:bundled-skill / check:bundled-schema all pass; touched test lanes run per-package per the mock-isolation rules (21 + 110 + 14 + 24 + 81 pass).

Closes #1866


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Abandon now allows failed runs to be discarded while refusing already completed or cancelled runs; API responses reflect cancelled vs already-finished outcomes.

* **Documentation**
  * Clarified command help, prompts, and API docs to state which run states can be abandoned and that abandonment marks runs cancelled.

* **Tests**
  * Added and expanded unit and route tests to cover abandoning failed, completed, cancelled, and race conditions.

* **New Exports**
  * Introduced a settled-status grouping for run-state checks and re-exported it for shared use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->