### PR TITLE
feat(console): agent-aware model pickers for tiers, aliases, and defaults

### DIFF
--- a/packages/web/src/experiments/console/components/AgentCredentialCard.tsx
+++ b/packages/web/src/experiments/console/components/AgentCredentialCard.tsx
@@ -450,13 +450,6 @@ function BackendPicker({
 type OpencodePhase = 'idle' | 'loading' | 'loaded' | 'error';
 
 /**
- * Booting the embedded OpenCode runtime is the slow path; give it a generous
- * minute before declaring the load hung so the user always gets the Retry
- * escape (I4) instead of a permanent "Loading…".
- */
-const OPENCODE_LOAD_TIMEOUT_MS = 60_000;
-
-/**
  * OpenCode's dynamic backend list. The introspection endpoint is heavyweight
  * (it boots the embedded runtime), so nothing loads until the user explicitly
  * asks; any load failure (503 runtime-unavailable, network error, timeout)
@@ -479,7 +472,7 @@ function OpencodeBackends(): ReactElement {
         new Promise<never>((_, reject) => {
           timer = setTimeout(() => {
             reject(new Error('Timed out waiting for the OpenCode runtime — retry.'));
-          }, OPENCODE_LOAD_TIMEOUT_MS);
+          }, skill.OPENCODE_LOAD_TIMEOUT_MS);
         }),
       ]);
       if (cancelledRef.current) return;

--- a/packages/web/src/experiments/console/components/AgentCredentialCard.tsx
+++ b/packages/web/src/experiments/console/components/AgentCredentialCard.tsx
@@ -17,10 +17,8 @@ import {
 } from '../lib/agent-status';
 import { useCancelledRef } from '../lib/use-cancelled-ref';
 import { SubscriptionLoginFlow } from './SubscriptionLoginFlow';
+import { INPUT_CLASS } from './SettingsFormPrimitives';
 
-// Mirrors AssistantConfigPanel's INPUT_CLASS so inputs match the console form style.
-const INPUT_CLASS =
-  'w-full rounded-[9px] border border-border bg-surface px-3.5 py-[11px] font-mono text-[13px] text-text-primary placeholder:text-text-tertiary transition-all focus:border-accent-bright/50 focus:outline-none focus:shadow-[0_0_0_3px_color-mix(in_oklch,var(--brand-magenta),transparent_92%)]';
 const GHOST_BUTTON =
   'shrink-0 rounded border border-border px-2.5 py-1 text-[11px] text-text-secondary transition-colors hover:border-border-bright hover:text-text-primary disabled:opacity-40';
 const BRAND_BUTTON =

--- a/packages/web/src/experiments/console/components/AliasesPanel.tsx
+++ b/packages/web/src/experiments/console/components/AliasesPanel.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState, type ReactElement, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactElement } from 'react';
 import * as skill from '../skills';
 import type {
   AliasRowForm,
+  PiModelInfo,
   ProviderInfo,
   ProviderKeyList,
   SafeConfigAliases,
@@ -11,47 +12,12 @@ import type {
 import { useEntity, invalidate } from '../store/cache';
 import { K } from '../store/keys';
 import { providerOptionHint } from '../lib/agent-status';
+import { effortOptionsForAgent, normalizeEffortForAgent } from '../lib/model-options';
 import { useCancelledRef } from '../lib/use-cancelled-ref';
 import { SettingsSection } from './SettingsSection';
 import { ScopeToggle } from './ScopeToggle';
-
-// Field styling mirrors ModelTiersPanel (design v5 .set-input / .set-select).
-const INPUT_CLASS =
-  'w-full rounded-[9px] border border-border bg-surface px-3.5 py-[11px] font-mono text-[13px] text-text-primary placeholder:text-text-tertiary transition-all focus:border-accent-bright/50 focus:outline-none focus:shadow-[0_0_0_3px_color-mix(in_oklch,var(--brand-magenta),transparent_92%)]';
-const SELECT_CLASS =
-  'w-full cursor-pointer appearance-none rounded-[9px] border border-border bg-surface-elevated py-[11px] pl-3.5 pr-8 font-mono text-[13px] font-semibold text-text-primary transition-all focus:border-accent-bright/50 focus:outline-none focus:shadow-[0_0_0_3px_color-mix(in_oklch,var(--brand-magenta),transparent_92%)]';
-
-/** Relative wrapper that overlays the design chevron on an appearance-none select. */
-function SelectShell({
-  children,
-  className = '',
-}: {
-  children: ReactNode;
-  className?: string;
-}): ReactElement {
-  return (
-    <span className={`relative inline-flex items-center ${className}`}>
-      {children}
-      <span
-        aria-hidden
-        className="pointer-events-none absolute right-[11px] flex text-text-tertiary"
-      >
-        <svg
-          width="13"
-          height="13"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.8"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="M6 9l6 6 6-6" />
-        </svg>
-      </span>
-    </span>
-  );
-}
+import { INPUT_CLASS, SELECT_CLASS, SelectShell } from './SettingsFormPrimitives';
+import { ModelPickerField } from './ModelPickerField';
 
 /**
  * Editor for `@custom` model aliases in two scopes: "This install" writes
@@ -77,6 +43,9 @@ export function AliasesPanel(): ReactElement {
     K.providerConnections,
     skill.listProviderKeys
   );
+  // Pi catalog for the model picker's suggestions + cost hints. Best-effort:
+  // the server returns [] when the catalog can't load; an error means no hints.
+  const { data: piModels } = useEntity<PiModelInfo[]>(K.piModels, skill.listPiModels);
 
   const userScopeAvailable = userPrefsError === undefined;
   const [scope, setScope] = useState<SettingsScope>('install');
@@ -173,69 +142,94 @@ export function AliasesPanel(): ReactElement {
         </p>
       ) : (
         <div className="flex flex-col gap-[11px]">
-          {rows.map((row, i) => (
-            <div
-              // Index key is intentional: rows are positional edit buffers and
-              // names are editable (a name key would remount mid-keystroke).
-              key={i}
-              className="flex flex-wrap items-center gap-[14px] rounded-xl border border-border bg-surface-elevated p-4"
-            >
-              <input
-                value={row.name}
-                onChange={e => {
-                  setRow(i, { name: e.target.value });
-                }}
-                placeholder="@fast"
-                aria-label="Alias name"
-                className={`${INPUT_CLASS} w-[120px] shrink-0`}
-              />
-              <SelectShell className="w-[150px] shrink-0">
-                <select
-                  value={row.provider}
-                  onChange={e => {
-                    setRow(i, { provider: e.target.value });
-                  }}
-                  aria-label="Provider"
-                  className={SELECT_CLASS}
-                >
-                  {providers.map(p => (
-                    <option key={p.id} value={p.id}>
-                      {p.displayName}
-                      {providerOptionHint(keyData?.agents, p.id)}
-                    </option>
-                  ))}
-                </select>
-              </SelectShell>
-              <input
-                value={row.model}
-                onChange={e => {
-                  setRow(i, { model: e.target.value });
-                }}
-                placeholder="model (e.g. opus, gpt-5.5)"
-                aria-label="Model"
-                className={`${INPUT_CLASS} min-w-[140px] flex-1`}
-              />
-              <input
-                value={row.effort}
-                onChange={e => {
-                  setRow(i, { effort: e.target.value });
-                }}
-                placeholder="effort"
-                aria-label="Effort"
-                className={`${INPUT_CLASS} w-[90px] shrink-0`}
-              />
-              <button
-                type="button"
-                onClick={() => {
-                  removeRow(i);
-                }}
-                aria-label={`Remove alias ${row.name}`}
-                className="shrink-0 rounded border border-border px-2.5 py-1.5 text-[11px] text-text-secondary transition-colors hover:border-border-bright hover:text-text-primary"
+          {rows.map((row, i) => {
+            const effortOptions = effortOptionsForAgent(row.provider);
+            return (
+              <div
+                // Index key is intentional: rows are positional edit buffers and
+                // names are editable (a name key would remount mid-keystroke).
+                key={i}
+                className="flex flex-wrap items-center gap-[14px] rounded-xl border border-border bg-surface-elevated p-4"
               >
-                Remove
-              </button>
-            </div>
-          ))}
+                <input
+                  value={row.name}
+                  onChange={e => {
+                    setRow(i, { name: e.target.value });
+                  }}
+                  placeholder="@fast"
+                  aria-label="Alias name"
+                  className={`${INPUT_CLASS} w-[120px] shrink-0`}
+                />
+                <SelectShell className="w-[150px] shrink-0">
+                  <select
+                    value={row.provider}
+                    onChange={e => {
+                      // Carry effort across the switch only when the new agent's
+                      // vocabulary accepts it (see ModelTiersPanel).
+                      const provider = e.target.value;
+                      setRow(i, {
+                        provider,
+                        effort: normalizeEffortForAgent(provider, row.effort),
+                      });
+                    }}
+                    aria-label="Provider"
+                    className={SELECT_CLASS}
+                  >
+                    {providers.map(p => (
+                      <option key={p.id} value={p.id}>
+                        {p.displayName}
+                        {providerOptionHint(keyData?.agents, p.id)}
+                      </option>
+                    ))}
+                  </select>
+                </SelectShell>
+                <ModelPickerField
+                  // Re-key per agent so picker-internal state never bleeds
+                  // across a provider switch.
+                  key={row.provider}
+                  agentId={row.provider}
+                  value={row.model}
+                  onChange={v => {
+                    setRow(i, { model: v });
+                  }}
+                  placeholder="model (e.g. opus, gpt-5.5)"
+                  ariaLabel="Model"
+                  className="min-w-[140px] flex-1"
+                  agents={keyData?.agents}
+                  piModels={piModels}
+                />
+                {effortOptions !== null ? (
+                  <SelectShell className="w-[110px] shrink-0">
+                    <select
+                      value={row.effort}
+                      onChange={e => {
+                        setRow(i, { effort: e.target.value });
+                      }}
+                      aria-label="Effort"
+                      className={SELECT_CLASS}
+                    >
+                      <option value="">effort</option>
+                      {effortOptions.map(o => (
+                        <option key={o} value={o}>
+                          {o}
+                        </option>
+                      ))}
+                    </select>
+                  </SelectShell>
+                ) : null}
+                <button
+                  type="button"
+                  onClick={() => {
+                    removeRow(i);
+                  }}
+                  aria-label={`Remove alias ${row.name}`}
+                  className="shrink-0 rounded border border-border px-2.5 py-1.5 text-[11px] text-text-secondary transition-colors hover:border-border-bright hover:text-text-primary"
+                >
+                  Remove
+                </button>
+              </div>
+            );
+          })}
         </div>
       )}
 

--- a/packages/web/src/experiments/console/components/AssistantConfigPanel.tsx
+++ b/packages/web/src/experiments/console/components/AssistantConfigPanel.tsx
@@ -1,54 +1,21 @@
-import { useEffect, useRef, useState, type ReactElement, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactElement } from 'react';
 import * as skill from '../skills';
-import type { SafeConfig, ProviderInfo, AssistantConfigForm, UserAiPrefs } from '../skills';
+import type {
+  SafeConfig,
+  PiModelInfo,
+  ProviderInfo,
+  ProviderKeyList,
+  AssistantConfigForm,
+  UserAiPrefs,
+} from '../skills';
 import { useEntity, invalidate } from '../store/cache';
 import { K } from '../store/keys';
 import { SettingsSection } from './SettingsSection';
+import { SELECT_CLASS_COMPACT, SelectShell } from './SettingsFormPrimitives';
+import { ModelPickerField } from './ModelPickerField';
 
 const REASONING_EFFORTS = ['minimal', 'low', 'medium', 'high', 'xhigh'] as const;
 const WEB_SEARCH_MODES = ['disabled', 'cached', 'live'] as const;
-
-// Design v5 (.set-input / .set-select): mono fields on the page surface with
-// a magenta focus ring. Border colors ride inline styles where needed because
-// the console scope's wildcard border-color rule repaints Tailwind utilities.
-const INPUT_CLASS =
-  'w-full rounded-[9px] border border-border bg-surface px-3.5 py-[11px] font-mono text-[13px] text-text-primary placeholder:text-text-tertiary transition-all focus:border-accent-bright/50 focus:outline-none focus:shadow-[0_0_0_3px_color-mix(in_oklch,var(--brand-magenta),transparent_92%)]';
-// appearance-none kills the browser's edge-pinned arrow; SelectShell paints
-// the design's chevron at right:11px instead (.set-select / .set-select-chev).
-const SELECT_CLASS =
-  'w-full cursor-pointer appearance-none rounded-[9px] border border-border bg-surface-elevated py-[7px] pl-3 pr-8 font-mono text-[12.5px] font-semibold text-text-primary transition-all focus:border-accent-bright/50 focus:outline-none focus:shadow-[0_0_0_3px_color-mix(in_oklch,var(--brand-magenta),transparent_92%)]';
-
-/** Relative wrapper that overlays the design chevron on an appearance-none select. */
-function SelectShell({
-  children,
-  className = '',
-}: {
-  children: ReactNode;
-  className?: string;
-}): ReactElement {
-  return (
-    <span className={`relative inline-flex items-center ${className}`}>
-      {children}
-      <span
-        aria-hidden
-        className="pointer-events-none absolute right-[11px] flex text-text-tertiary"
-      >
-        <svg
-          width="13"
-          height="13"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.8"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="M6 9l6 6 6-6" />
-        </svg>
-      </span>
-    </span>
-  );
-}
 
 /** Read a string field off the open `ProviderDefaults` record, '' when absent/non-string. */
 function readStr(rec: SafeConfig['assistants'][string] | undefined, key: string): string {
@@ -71,9 +38,10 @@ function seedForm(config: SafeConfig, providers: ProviderInfo[]): AssistantConfi
 
 /**
  * Editor for the global default assistant + per-provider model (and Codex
- * reasoning/web-search). Model is a FREE-TEXT input for every provider — Archon
- * does not validate model strings (the SDK is the source of truth and ships
- * models faster than we can enumerate them). Saves via PATCH /api/config/assistants
+ * reasoning/web-search). The model field is agent-aware (ModelPickerField,
+ * #1957) but never blocks free text — Archon does not validate model strings
+ * (the SDK is the source of truth and ships models faster than we can
+ * enumerate them). Saves via PATCH /api/config/assistants
  * → ~/.archon/config.yaml, then invalidates K.config so the form re-seeds from the
  * persisted values (which also clears the dirty state).
  */
@@ -87,6 +55,14 @@ export function AssistantConfigPanel(): ReactElement {
     K.userAiPrefs,
     skill.getUserAiPrefs
   );
+  // Agents matrix + Pi catalog for the agent-aware model pickers (#1957).
+  // Both share cache keys with other Settings panels (one fetch per page);
+  // undefined (401/error) just means pickers render without readiness data.
+  const { data: keyData } = useEntity<ProviderKeyList>(
+    K.providerConnections,
+    skill.listProviderKeys
+  );
+  const { data: piModels } = useEntity<PiModelInfo[]>(K.piModels, skill.listPiModels);
   const userScopeAvailable = userPrefsError === undefined;
   const [savingUserDefault, setSavingUserDefault] = useState(false);
   const [userDefaultError, setUserDefaultError] = useState<string | null>(null);
@@ -177,7 +153,7 @@ export function AssistantConfigPanel(): ReactElement {
             onChange={e => {
               patch({ assistant: e.target.value });
             }}
-            className={`${SELECT_CLASS} py-[11px] pl-3.5 text-[13.5px]`}
+            className={`${SELECT_CLASS_COMPACT} py-[11px] pl-3.5 text-[13.5px]`}
           >
             {providers.map(p => (
               <option key={p.id} value={p.id}>
@@ -201,7 +177,7 @@ export function AssistantConfigPanel(): ReactElement {
               value={userPrefs.defaultProvider ?? ''}
               onChange={e => void onUserDefaultChange(e.target.value)}
               disabled={savingUserDefault}
-              className={`${SELECT_CLASS} py-[11px] pl-3.5 text-[13.5px]`}
+              className={`${SELECT_CLASS_COMPACT} py-[11px] pl-3.5 text-[13.5px]`}
             >
               <option value="">Inherit (this install)</option>
               {providers.map(p => (
@@ -251,13 +227,18 @@ export function AssistantConfigPanel(): ReactElement {
                 ) : null}
               </div>
               <div className="min-w-0 flex-1">
-                <input
+                <ModelPickerField
+                  agentId={p.id}
                   value={form.models[p.id] ?? ''}
-                  onChange={e => {
-                    setModel(p.id, e.target.value);
+                  onChange={v => {
+                    setModel(p.id, v);
                   }}
                   placeholder="model (e.g. sonnet, gpt-5.3-codex) — blank = inherit"
-                  className={INPUT_CLASS}
+                  selectEmptyLabel="inherit"
+                  ariaLabel={`${p.displayName} default model`}
+                  className="w-full"
+                  agents={keyData?.agents}
+                  piModels={piModels}
                 />
                 {p.id === 'codex' ? (
                   <div className="mt-[11px] flex flex-wrap items-center justify-end gap-5">
@@ -269,7 +250,7 @@ export function AssistantConfigPanel(): ReactElement {
                           onChange={e => {
                             patch({ modelReasoningEffort: e.target.value });
                           }}
-                          className={SELECT_CLASS}
+                          className={SELECT_CLASS_COMPACT}
                         >
                           <option value="">inherit</option>
                           {REASONING_EFFORTS.map(o => (
@@ -288,7 +269,7 @@ export function AssistantConfigPanel(): ReactElement {
                           onChange={e => {
                             patch({ webSearchMode: e.target.value });
                           }}
-                          className={SELECT_CLASS}
+                          className={SELECT_CLASS_COMPACT}
                         >
                           <option value="">inherit</option>
                           {WEB_SEARCH_MODES.map(o => (

--- a/packages/web/src/experiments/console/components/AssistantConfigPanel.tsx
+++ b/packages/web/src/experiments/console/components/AssistantConfigPanel.tsx
@@ -10,11 +10,12 @@ import type {
 } from '../skills';
 import { useEntity, invalidate } from '../store/cache';
 import { K } from '../store/keys';
+import { CODEX_EFFORT_OPTIONS } from '../lib/model-options';
+import { useCancelledRef } from '../lib/use-cancelled-ref';
 import { SettingsSection } from './SettingsSection';
 import { SELECT_CLASS_COMPACT, SelectShell } from './SettingsFormPrimitives';
 import { ModelPickerField } from './ModelPickerField';
 
-const REASONING_EFFORTS = ['minimal', 'low', 'medium', 'high', 'xhigh'] as const;
 const WEB_SEARCH_MODES = ['disabled', 'cached', 'live'] as const;
 
 /** Read a string field off the open `ProviderDefaults` record, '' when absent/non-string. */
@@ -67,14 +68,8 @@ export function AssistantConfigPanel(): ReactElement {
   const [savingUserDefault, setSavingUserDefault] = useState(false);
   const [userDefaultError, setUserDefaultError] = useState<string | null>(null);
 
-  // Guard async setState after unmount (mirrors ModelTiersPanel/AliasesPanel).
-  const cancelledRef = useRef(false);
-  useEffect(() => {
-    cancelledRef.current = false;
-    return (): void => {
-      cancelledRef.current = true;
-    };
-  }, []);
+  // Guard async setState after unmount (same hook as the sibling panels).
+  const cancelledRef = useCancelledRef();
 
   const onUserDefaultChange = async (value: string): Promise<void> => {
     setSavingUserDefault(true);
@@ -253,7 +248,7 @@ export function AssistantConfigPanel(): ReactElement {
                           className={SELECT_CLASS_COMPACT}
                         >
                           <option value="">inherit</option>
-                          {REASONING_EFFORTS.map(o => (
+                          {CODEX_EFFORT_OPTIONS.map(o => (
                             <option key={o} value={o}>
                               {o}
                             </option>

--- a/packages/web/src/experiments/console/components/ModelPickerField.tsx
+++ b/packages/web/src/experiments/console/components/ModelPickerField.tsx
@@ -20,13 +20,6 @@ import { INPUT_CLASS, SELECT_CLASS, SelectShell } from './SettingsFormPrimitives
 /** Cap on rendered Pi suggestions — the catalog is ~920 models. */
 const PI_SUGGESTION_LIMIT = 30;
 
-/**
- * Mirrors OPENCODE_LOAD_TIMEOUT_MS in AgentCredentialCard: booting the
- * embedded OpenCode runtime is the slow path; always leave the user a Retry
- * escape instead of a permanent "Loading…".
- */
-const OPENCODE_LOAD_TIMEOUT_MS = 60_000;
-
 const DROPDOWN_CLASS =
   // Same elevation recipe as ProjectRow's context menu (the console's other
   // floating dropdown).
@@ -140,7 +133,7 @@ function ModelCombobox({
         new Promise<never>((_, reject) => {
           timer = setTimeout(() => {
             reject(new Error('Timed out waiting for the OpenCode runtime — retry.'));
-          }, OPENCODE_LOAD_TIMEOUT_MS);
+          }, skill.OPENCODE_LOAD_TIMEOUT_MS);
         }),
       ]);
       if (cancelledRef.current) return;
@@ -159,13 +152,15 @@ function ModelCombobox({
   const backends = shape === 'pi' ? usablePiBackends(agents) : null;
   const pi =
     shape === 'pi' ? piModelOptions(piModels, value, backends, showAll, PI_SUGGESTION_LIMIT) : null;
-  const options: ModelOption[] = pi
-    ? pi.options
-    : shape === 'opencode'
-      ? ocPhase === 'loaded'
-        ? filterModelOptions(opencodeBackendOptions(ocProviders), value)
-        : []
-      : filterModelOptions(curatedOptionsForAgent(agentId), value);
+  let options: ModelOption[];
+  if (pi !== null) {
+    options = pi.options;
+  } else if (shape === 'opencode') {
+    options =
+      ocPhase === 'loaded' ? filterModelOptions(opencodeBackendOptions(ocProviders), value) : [];
+  } else {
+    options = filterModelOptions(curatedOptionsForAgent(agentId), value);
+  }
 
   const pick = (o: ModelOption): void => {
     onChange(o.value);
@@ -224,7 +219,15 @@ function ModelCombobox({
                   …{pi.matchTotal - options.length} more — keep typing to narrow.
                 </p>
               ) : null}
-              {pi.matchTotal === 0 && pi.hiddenByFilter === 0 ? (
+              {/* Two distinct empty states: an undefined catalog (still
+                  loading, or the fetch failed — all panels read K.piModels
+                  best-effort and drop the error) is NOT "no match". */}
+              {piModels === undefined ? (
+                <p className="px-3 py-2 font-mono text-[11px] text-text-tertiary">
+                  Catalog unavailable — free text is fine.
+                </p>
+              ) : null}
+              {piModels !== undefined && pi.matchTotal === 0 && pi.hiddenByFilter === 0 ? (
                 <p className="px-3 py-2 font-mono text-[11px] text-text-tertiary">
                   No catalog match — custom models.json refs are fine as free text.
                 </p>

--- a/packages/web/src/experiments/console/components/ModelPickerField.tsx
+++ b/packages/web/src/experiments/console/components/ModelPickerField.tsx
@@ -1,0 +1,404 @@
+import { useState, type ReactElement } from 'react';
+import * as skill from '../skills';
+import type { AgentCredentials, OpencodeCredentialProvider, PiModelInfo } from '../skills';
+import {
+  COPILOT_MODEL_OPTIONS,
+  curatedOptionsForAgent,
+  filterModelOptions,
+  findPiModel,
+  modelPickerShape,
+  opencodeBackendOptions,
+  piDisconnectedBackendHint,
+  piModelHint,
+  piModelOptions,
+  usablePiBackends,
+  type ModelOption,
+} from '../lib/model-options';
+import { useCancelledRef } from '../lib/use-cancelled-ref';
+import { INPUT_CLASS, SELECT_CLASS, SelectShell } from './SettingsFormPrimitives';
+
+/** Cap on rendered Pi suggestions — the catalog is ~920 models. */
+const PI_SUGGESTION_LIMIT = 30;
+
+/**
+ * Mirrors OPENCODE_LOAD_TIMEOUT_MS in AgentCredentialCard: booting the
+ * embedded OpenCode runtime is the slow path; always leave the user a Retry
+ * escape instead of a permanent "Loading…".
+ */
+const OPENCODE_LOAD_TIMEOUT_MS = 60_000;
+
+const DROPDOWN_CLASS =
+  // Same elevation recipe as ProjectRow's context menu (the console's other
+  // floating dropdown).
+  'absolute left-0 right-0 top-full z-20 mt-1 max-h-60 overflow-y-auto rounded-[9px] border border-border bg-surface-elevated shadow-[0_18px_44px_-18px_rgba(0,0,0,0.85)]';
+const OPTION_CLASS =
+  'flex w-full items-baseline justify-between gap-3 px-3 py-2 text-left font-mono text-[12px] transition-colors hover:bg-surface-hover';
+const FOOTER_BUTTON_CLASS =
+  'w-full border-t border-border px-3 py-2 text-left font-mono text-[11px] text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary';
+
+interface ModelPickerFieldProps {
+  /** Agent provider id ('' renders plain free text — e.g. an unset tier row). */
+  agentId: string;
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  ariaLabel?: string;
+  /** Sizing classes for the field wrapper (e.g. 'min-w-[160px] flex-1'). */
+  className?: string;
+  /**
+   * Label for the empty option in select-shaped pickers (Copilot). The free
+   * text `placeholder` is often too long for an option label, so panels pass a
+   * short one ('inherit', 'Select model…').
+   */
+  selectEmptyLabel?: string;
+  /** Agents matrix (K.providerConnections) — undefined means no readiness data (solo/401). */
+  agents?: AgentCredentials[];
+  /** Pi catalog (K.piModels) — best-effort, undefined/[] means no Pi suggestions. */
+  piModels?: PiModelInfo[];
+}
+
+/**
+ * Agent-aware model input (#1957). One component, four shapes:
+ * - Pi: searchable picker over the baked catalog, default-filtered to usable
+ *   backends per the agents matrix, with an explicit "show all backends"
+ *   toggle. Cost/context/reasoning hints ride each suggestion and the exact
+ *   match. Custom models.json providers are free-typed.
+ * - OpenCode: free text with on-demand backend-prefix suggestions. The
+ *   introspection endpoint boots the embedded runtime, so NOTHING loads until
+ *   the user explicitly clicks "Load backend suggestions" inside the open
+ *   dropdown; it lists `backend/` prefixes (model counts, connected state) and
+ *   the model id itself stays free-typed — the endpoint doesn't expose ids.
+ * - Copilot: fixed select over the curated list + a "Custom…" free-text escape.
+ * - Claude/Codex (and unknown agents): free text; Claude/Codex surface their
+ *   curated common options as suggestions.
+ *
+ * Pickers guide, never gate: every shape saves arbitrary strings, and a model
+ * on a disconnected backend only draws a non-blocking inline hint.
+ */
+export function ModelPickerField(props: ModelPickerFieldProps): ReactElement {
+  if (modelPickerShape(props.agentId) === 'select') {
+    return <CopilotModelSelect {...props} />;
+  }
+  return <ModelCombobox {...props} />;
+}
+
+/** Suggestion row; `onMouseDown` is prevented by the list container so the input never blurs. */
+function OptionRow({
+  option,
+  onPick,
+}: {
+  option: ModelOption;
+  onPick: (o: ModelOption) => void;
+}): ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        onPick(option);
+      }}
+      className={OPTION_CLASS}
+    >
+      <span className="min-w-0 truncate text-text-primary">{option.value}</span>
+      {option.hint !== undefined ? (
+        <span className="shrink-0 text-[10px] text-text-tertiary">{option.hint}</span>
+      ) : null}
+    </button>
+  );
+}
+
+function ModelCombobox({
+  agentId,
+  value,
+  onChange,
+  disabled = false,
+  placeholder,
+  ariaLabel,
+  className = '',
+  agents,
+  piModels,
+}: ModelPickerFieldProps): ReactElement {
+  const [open, setOpen] = useState(false);
+  // Pi only: include backends without a usable credential in the suggestions.
+  const [showAll, setShowAll] = useState(false);
+  const shape = modelPickerShape(agentId);
+
+  // OpenCode on-demand backend list. Per-field state by design: the endpoint
+  // is only hit on this field's explicit "Load backend suggestions" click.
+  const [ocPhase, setOcPhase] = useState<'idle' | 'loading' | 'loaded' | 'error'>('idle');
+  const [ocProviders, setOcProviders] = useState<OpencodeCredentialProvider[]>([]);
+  const [ocError, setOcError] = useState<string | null>(null);
+  const cancelledRef = useCancelledRef();
+
+  const loadOpencode = async (): Promise<void> => {
+    setOcPhase('loading');
+    setOcError(null);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const result = await Promise.race([
+        skill.listOpencodeCredentials(),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => {
+            reject(new Error('Timed out waiting for the OpenCode runtime — retry.'));
+          }, OPENCODE_LOAD_TIMEOUT_MS);
+        }),
+      ]);
+      if (cancelledRef.current) return;
+      setOcProviders(result);
+      setOcPhase('loaded');
+    } catch (e: unknown) {
+      if (cancelledRef.current) return;
+      setOcError(e instanceof Error ? e.message : 'Failed to load OpenCode backends.');
+      setOcPhase('error');
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+
+  // Suggestions per shape; the field's text doubles as the search query.
+  const backends = shape === 'pi' ? usablePiBackends(agents) : null;
+  const pi =
+    shape === 'pi' ? piModelOptions(piModels, value, backends, showAll, PI_SUGGESTION_LIMIT) : null;
+  const options: ModelOption[] = pi
+    ? pi.options
+    : shape === 'opencode'
+      ? ocPhase === 'loaded'
+        ? filterModelOptions(opencodeBackendOptions(ocProviders), value)
+        : []
+      : filterModelOptions(curatedOptionsForAgent(agentId), value);
+
+  const pick = (o: ModelOption): void => {
+    onChange(o.value);
+    // Prefix completions keep the dropdown open: the model id is typed next.
+    if (o.prefix !== true) setOpen(false);
+  };
+
+  // Under-field hints (outside the dropdown, so they show while typing too).
+  const exactPi = shape === 'pi' ? findPiModel(piModels, value) : undefined;
+  const disconnectedHint =
+    shape === 'pi' && !disabled ? piDisconnectedBackendHint(value, agents) : null;
+
+  const hasDropdownContent = options.length > 0 || shape === 'pi' || shape === 'opencode';
+
+  return (
+    <span className={`relative inline-flex flex-col gap-1 ${className}`}>
+      <input
+        value={value}
+        onChange={e => {
+          onChange(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => {
+          setOpen(true);
+        }}
+        onBlur={() => {
+          setOpen(false);
+        }}
+        onKeyDown={e => {
+          if (e.key === 'Escape') setOpen(false);
+        }}
+        disabled={disabled}
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        autoComplete="off"
+        className={`${INPUT_CLASS} ${disabled ? 'opacity-50' : ''}`}
+      />
+
+      {open && !disabled && hasDropdownContent ? (
+        // preventDefault keeps focus in the input, so option clicks land
+        // before any blur-close — the standard combobox trick.
+        <div
+          className={DROPDOWN_CLASS}
+          onMouseDown={e => {
+            e.preventDefault();
+          }}
+        >
+          {options.map(o => (
+            <OptionRow key={o.value} option={o} onPick={pick} />
+          ))}
+
+          {pi !== null ? (
+            <>
+              {pi.matchTotal > options.length ? (
+                <p className="px-3 py-1.5 font-mono text-[10.5px] text-text-tertiary">
+                  …{pi.matchTotal - options.length} more — keep typing to narrow.
+                </p>
+              ) : null}
+              {pi.matchTotal === 0 && pi.hiddenByFilter === 0 ? (
+                <p className="px-3 py-2 font-mono text-[11px] text-text-tertiary">
+                  No catalog match — custom models.json refs are fine as free text.
+                </p>
+              ) : null}
+              {backends !== null ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowAll(s => !s);
+                  }}
+                  className={FOOTER_BUTTON_CLASS}
+                >
+                  {showAll
+                    ? 'Show connected backends only'
+                    : `Show all backends${pi.hiddenByFilter > 0 ? ` (${String(pi.hiddenByFilter)} more match)` : ''}`}
+                </button>
+              ) : null}
+            </>
+          ) : null}
+
+          {shape === 'opencode' ? (
+            <OpencodeDropdownFooter
+              phase={ocPhase}
+              error={ocError}
+              optionCount={options.length}
+              onLoad={() => void loadOpencode()}
+            />
+          ) : null}
+        </div>
+      ) : null}
+
+      {exactPi !== undefined ? (
+        <p className="font-mono text-[10.5px] text-text-tertiary">{piModelHint(exactPi)}</p>
+      ) : null}
+      {disconnectedHint !== null ? (
+        <p className="font-mono text-[10.5px] text-warning">{disconnectedHint}</p>
+      ) : null}
+    </span>
+  );
+}
+
+/** OpenCode dropdown footer: explicit load affordance + loading/error states. */
+function OpencodeDropdownFooter({
+  phase,
+  error,
+  optionCount,
+  onLoad,
+}: {
+  phase: 'idle' | 'loading' | 'loaded' | 'error';
+  error: string | null;
+  optionCount: number;
+  onLoad: () => void;
+}): ReactElement {
+  if (phase === 'idle') {
+    return (
+      <div className="flex flex-col gap-1 px-3 py-2">
+        <p className="font-mono text-[10.5px] text-text-tertiary">
+          Format: <span className="text-text-secondary">backend/model-id</span> (free text).
+        </p>
+        <button
+          type="button"
+          onClick={onLoad}
+          className="self-start rounded border border-border px-2.5 py-1 font-mono text-[11px] text-text-secondary transition-colors hover:border-border-bright hover:text-text-primary"
+        >
+          Load backend suggestions
+        </button>
+      </div>
+    );
+  }
+  if (phase === 'loading') {
+    return (
+      <p className="px-3 py-2 font-mono text-[11px] text-text-tertiary">
+        Loading backends… (starting the OpenCode runtime can take a moment)
+      </p>
+    );
+  }
+  if (phase === 'error') {
+    return (
+      <div className="flex flex-wrap items-center gap-2 px-3 py-2">
+        <p className="font-mono text-[11px] text-error">{error}</p>
+        <button
+          type="button"
+          onClick={onLoad}
+          className="rounded border border-border px-2.5 py-1 font-mono text-[11px] text-text-secondary transition-colors hover:border-border-bright hover:text-text-primary"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+  return (
+    <p className="border-t border-border px-3 py-1.5 font-mono text-[10.5px] text-text-tertiary">
+      {optionCount > 0
+        ? 'Pick a backend prefix, then type the model id.'
+        : 'No backend matches the typed prefix — free text is fine.'}
+    </p>
+  );
+}
+
+/** Sentinel select value that switches the Copilot field to free-text mode. */
+const CUSTOM_SENTINEL = '__custom__';
+
+/**
+ * Copilot's fixed select (the curated list is hand-maintained, see
+ * COPILOT_MODEL_OPTIONS provenance) with a "Custom…" free-text escape. A saved
+ * value outside the list renders in custom mode so it's never misdisplayed.
+ */
+function CopilotModelSelect({
+  value,
+  onChange,
+  disabled = false,
+  placeholder,
+  ariaLabel,
+  className = '',
+  selectEmptyLabel,
+}: ModelPickerFieldProps): ReactElement {
+  const inList = value === '' || COPILOT_MODEL_OPTIONS.some(o => o.value === value);
+  const [customMode, setCustomMode] = useState(false);
+  const custom = customMode || !inList;
+
+  if (custom) {
+    return (
+      <span className={`inline-flex items-center gap-2 ${className}`}>
+        <input
+          value={value}
+          onChange={e => {
+            onChange(e.target.value);
+          }}
+          disabled={disabled}
+          placeholder={placeholder ?? 'model id'}
+          aria-label={ariaLabel}
+          autoComplete="off"
+          className={`${INPUT_CLASS} ${disabled ? 'opacity-50' : ''}`}
+        />
+        <button
+          type="button"
+          onClick={() => {
+            setCustomMode(false);
+            // A non-curated value can't render in the select — clear it.
+            if (!inList) onChange('');
+          }}
+          disabled={disabled}
+          className="shrink-0 rounded border border-border px-2.5 py-1.5 font-mono text-[11px] text-text-secondary transition-colors hover:border-border-bright hover:text-text-primary disabled:opacity-40"
+        >
+          List
+        </button>
+      </span>
+    );
+  }
+
+  return (
+    <SelectShell className={className}>
+      <select
+        value={value}
+        onChange={e => {
+          if (e.target.value === CUSTOM_SENTINEL) {
+            setCustomMode(true);
+          } else {
+            onChange(e.target.value);
+          }
+        }}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        className={`${SELECT_CLASS} ${disabled ? 'opacity-50' : ''}`}
+      >
+        <option value="">{selectEmptyLabel ?? 'Select model…'}</option>
+        {COPILOT_MODEL_OPTIONS.map(o => (
+          <option key={o.value} value={o.value}>
+            {o.value}
+            {o.hint !== undefined ? ` — ${o.hint}` : ''}
+          </option>
+        ))}
+        <option value={CUSTOM_SENTINEL}>Custom…</option>
+      </select>
+    </SelectShell>
+  );
+}

--- a/packages/web/src/experiments/console/components/ModelTiersPanel.tsx
+++ b/packages/web/src/experiments/console/components/ModelTiersPanel.tsx
@@ -217,8 +217,13 @@ export function ModelTiersPanel(): ReactElement {
                     onChange={e => {
                       setRow(tier, { effort: e.target.value });
                     }}
+                    // Currently unreachable while disabled (unset rows have no
+                    // effort vocabulary), but every row control rides the
+                    // shared disabled state so a future widening of `unset`
+                    // can't silently skip this one.
+                    disabled={unset}
                     aria-label={`${tier} effort`}
-                    className={SELECT_CLASS}
+                    className={`${SELECT_CLASS} ${unset ? 'opacity-50' : ''}`}
                   >
                     <option value="">effort</option>
                     {effortOptions.map(o => (

--- a/packages/web/src/experiments/console/components/ModelTiersPanel.tsx
+++ b/packages/web/src/experiments/console/components/ModelTiersPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactElement, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactElement } from 'react';
 import * as skill from '../skills';
 import type {
   PiModelInfo,
@@ -15,48 +15,12 @@ import { TIER_ORDER } from '../skills';
 import { useEntity, invalidate } from '../store/cache';
 import { K } from '../store/keys';
 import { providerOptionHint } from '../lib/agent-status';
+import { effortOptionsForAgent, normalizeEffortForAgent } from '../lib/model-options';
 import { useCancelledRef } from '../lib/use-cancelled-ref';
 import { SettingsSection } from './SettingsSection';
 import { ScopeToggle } from './ScopeToggle';
-
-// Field styling mirrors AssistantConfigPanel (design v5 .set-input / .set-select):
-// mono fields on the page surface with a magenta focus ring.
-const INPUT_CLASS =
-  'w-full rounded-[9px] border border-border bg-surface px-3.5 py-[11px] font-mono text-[13px] text-text-primary placeholder:text-text-tertiary transition-all focus:border-accent-bright/50 focus:outline-none focus:shadow-[0_0_0_3px_color-mix(in_oklch,var(--brand-magenta),transparent_92%)]';
-const SELECT_CLASS =
-  'w-full cursor-pointer appearance-none rounded-[9px] border border-border bg-surface-elevated py-[11px] pl-3.5 pr-8 font-mono text-[13px] font-semibold text-text-primary transition-all focus:border-accent-bright/50 focus:outline-none focus:shadow-[0_0_0_3px_color-mix(in_oklch,var(--brand-magenta),transparent_92%)]';
-
-/** Relative wrapper that overlays the design chevron on an appearance-none select. */
-function SelectShell({
-  children,
-  className = '',
-}: {
-  children: ReactNode;
-  className?: string;
-}): ReactElement {
-  return (
-    <span className={`relative inline-flex items-center ${className}`}>
-      {children}
-      <span
-        aria-hidden
-        className="pointer-events-none absolute right-[11px] flex text-text-tertiary"
-      >
-        <svg
-          width="13"
-          height="13"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.8"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="M6 9l6 6 6-6" />
-        </svg>
-      </span>
-    </span>
-  );
-}
+import { SELECT_CLASS, SelectShell } from './SettingsFormPrimitives';
+import { ModelPickerField } from './ModelPickerField';
 
 /** Seed the editable tier form from a tier map (configured tiers only). */
 function seedTiers(tiers: SafeConfigTiers['tiers']): TiersForm {
@@ -100,8 +64,9 @@ export function ModelTiersPanel(): ReactElement {
     K.userAiPrefs,
     skill.getUserAiPrefs
   );
-  // Pi catalog for the cost/reasoning hint. Best-effort: the server returns []
-  // when the catalog can't load, and a fetch error simply means no hint.
+  // Pi catalog for the model picker's suggestions + cost/reasoning hints.
+  // Best-effort: the server returns [] when the catalog can't load, and a
+  // fetch error simply means no suggestions.
   const { data: piModels } = useEntity<PiModelInfo[]>(K.piModels, skill.listPiModels);
   // Agent credential matrix for readiness hints in the provider dropdowns.
   // Shares the AgentsPanel cache key (one fetch); a 401/error means no hints.
@@ -157,15 +122,6 @@ export function ModelTiersPanel(): ReactElement {
     setForm(f => (f === null ? f : { ...f, [t]: { ...f[t], ...partial } }));
   };
 
-  /** Cost/reasoning hint for a Pi tier model, or null when not applicable. */
-  const piHint = (row: TierRowForm): string | null => {
-    if (row.provider !== 'pi' || piModels === undefined) return null;
-    const m = piModels.find(x => x.ref === row.model.trim());
-    if (!m) return null;
-    const ctx = `${String(Math.round(m.contextWindow / 1000))}k ctx`;
-    return `$${String(m.cost.input)}/M in · $${String(m.cost.output)}/M out${m.reasoning ? ' · reasoning' : ''} · ${ctx}`;
-  };
-
   const onSave = async (): Promise<void> => {
     setSaving(true);
     setSaveError(null);
@@ -203,7 +159,7 @@ export function ModelTiersPanel(): ReactElement {
         {TIER_ORDER.map(tier => {
           const row = form[tier];
           const unset = row.provider === '';
-          const hint = piHint(row);
+          const effortOptions = effortOptionsForAgent(row.provider);
           return (
             <div
               key={tier}
@@ -216,7 +172,14 @@ export function ModelTiersPanel(): ReactElement {
                 <select
                   value={row.provider}
                   onChange={e => {
-                    setRow(tier, { provider: e.target.value });
+                    // Carry effort across the switch only when the new agent's
+                    // vocabulary accepts it; clear it otherwise (the field
+                    // hides for agents where tier effort doesn't route).
+                    const provider = e.target.value;
+                    setRow(tier, {
+                      provider,
+                      effort: normalizeEffortForAgent(provider, row.effort),
+                    });
                   }}
                   className={SELECT_CLASS}
                 >
@@ -229,28 +192,42 @@ export function ModelTiersPanel(): ReactElement {
                   ))}
                 </select>
               </SelectShell>
-              <input
+              <ModelPickerField
+                // Re-key per agent so picker-internal state (Pi "show all",
+                // OpenCode loaded backends) never bleeds across a switch.
+                key={row.provider}
+                agentId={row.provider}
                 value={row.model}
-                onChange={e => {
-                  setRow(tier, { model: e.target.value });
+                onChange={v => {
+                  setRow(tier, { model: v });
                 }}
                 disabled={unset}
                 placeholder={
                   unset ? `default: ${defaultHint(cfg, tier, scope)}` : 'model (e.g. opus, gpt-5.5)'
                 }
-                className={`${INPUT_CLASS} min-w-[160px] flex-1 ${unset ? 'opacity-50' : ''}`}
+                ariaLabel={`${tier} model`}
+                className="min-w-[160px] flex-1"
+                agents={keyData?.agents}
+                piModels={piModels}
               />
-              <input
-                value={row.effort}
-                onChange={e => {
-                  setRow(tier, { effort: e.target.value });
-                }}
-                disabled={unset}
-                placeholder="effort"
-                className={`${INPUT_CLASS} w-[110px] shrink-0 ${unset ? 'opacity-50' : ''}`}
-              />
-              {hint !== null ? (
-                <p className="w-full font-mono text-[10.5px] text-text-tertiary">{hint}</p>
+              {effortOptions !== null ? (
+                <SelectShell className="w-[110px] shrink-0">
+                  <select
+                    value={row.effort}
+                    onChange={e => {
+                      setRow(tier, { effort: e.target.value });
+                    }}
+                    aria-label={`${tier} effort`}
+                    className={SELECT_CLASS}
+                  >
+                    <option value="">effort</option>
+                    {effortOptions.map(o => (
+                      <option key={o} value={o}>
+                        {o}
+                      </option>
+                    ))}
+                  </select>
+                </SelectShell>
               ) : null}
             </div>
           );

--- a/packages/web/src/experiments/console/components/SettingsFormPrimitives.tsx
+++ b/packages/web/src/experiments/console/components/SettingsFormPrimitives.tsx
@@ -1,11 +1,8 @@
 import type { ReactElement, ReactNode } from 'react';
 
 /**
- * Shared form primitives for the console settings panels — the S3 extraction
- * deferred from the PR #1962 review into #1957 so the primitives got designed
- * against the model pickers' final shape. Previously `INPUT_CLASS` /
- * `SELECT_CLASS` / `SelectShell` were copied character-for-character across
- * ModelTiersPanel, AliasesPanel, AssistantConfigPanel, and AgentCredentialCard.
+ * Shared form primitives for the console settings panels (ModelTiersPanel,
+ * AliasesPanel, AssistantConfigPanel, AgentCredentialCard, ModelPickerField).
  *
  * Design v5 (.set-input / .set-select): mono fields on the page surface with a
  * magenta focus ring. Tokens only — colors come from the console theme vars.
@@ -19,7 +16,11 @@ export const INPUT_CLASS =
 export const SELECT_CLASS =
   'w-full cursor-pointer appearance-none rounded-[9px] border border-border bg-surface-elevated py-[11px] pl-3.5 pr-8 font-mono text-[13px] font-semibold text-text-primary transition-all focus:border-accent-bright/50 focus:outline-none focus:shadow-[0_0_0_3px_color-mix(in_oklch,var(--brand-magenta),transparent_92%)]';
 
-/** Compact inline select (Defaults panel's codex effort / web-search options). */
+/**
+ * Compact select base — the Defaults panel's codex effort / web-search options
+ * use it as-is; its assistant/provider pickers reuse it with size overrides
+ * (`py-[11px] pl-3.5 text-[13.5px]`) appended.
+ */
 export const SELECT_CLASS_COMPACT =
   'w-full cursor-pointer appearance-none rounded-[9px] border border-border bg-surface-elevated py-[7px] pl-3 pr-8 font-mono text-[12.5px] font-semibold text-text-primary transition-all focus:border-accent-bright/50 focus:outline-none focus:shadow-[0_0_0_3px_color-mix(in_oklch,var(--brand-magenta),transparent_92%)]';
 

--- a/packages/web/src/experiments/console/components/SettingsFormPrimitives.tsx
+++ b/packages/web/src/experiments/console/components/SettingsFormPrimitives.tsx
@@ -1,0 +1,60 @@
+import type { ReactElement, ReactNode } from 'react';
+
+/**
+ * Shared form primitives for the console settings panels — the S3 extraction
+ * deferred from the PR #1962 review into #1957 so the primitives got designed
+ * against the model pickers' final shape. Previously `INPUT_CLASS` /
+ * `SELECT_CLASS` / `SelectShell` were copied character-for-character across
+ * ModelTiersPanel, AliasesPanel, AssistantConfigPanel, and AgentCredentialCard.
+ *
+ * Design v5 (.set-input / .set-select): mono fields on the page surface with a
+ * magenta focus ring. Tokens only — colors come from the console theme vars.
+ */
+
+/** Free-text field (design v5 .set-input). */
+export const INPUT_CLASS =
+  'w-full rounded-[9px] border border-border bg-surface px-3.5 py-[11px] font-mono text-[13px] text-text-primary placeholder:text-text-tertiary transition-all focus:border-accent-bright/50 focus:outline-none focus:shadow-[0_0_0_3px_color-mix(in_oklch,var(--brand-magenta),transparent_92%)]';
+
+/** Row-sized select (tier/alias provider + effort selects). */
+export const SELECT_CLASS =
+  'w-full cursor-pointer appearance-none rounded-[9px] border border-border bg-surface-elevated py-[11px] pl-3.5 pr-8 font-mono text-[13px] font-semibold text-text-primary transition-all focus:border-accent-bright/50 focus:outline-none focus:shadow-[0_0_0_3px_color-mix(in_oklch,var(--brand-magenta),transparent_92%)]';
+
+/** Compact inline select (Defaults panel's codex effort / web-search options). */
+export const SELECT_CLASS_COMPACT =
+  'w-full cursor-pointer appearance-none rounded-[9px] border border-border bg-surface-elevated py-[7px] pl-3 pr-8 font-mono text-[12.5px] font-semibold text-text-primary transition-all focus:border-accent-bright/50 focus:outline-none focus:shadow-[0_0_0_3px_color-mix(in_oklch,var(--brand-magenta),transparent_92%)]';
+
+/**
+ * Relative wrapper that overlays the design chevron on an appearance-none
+ * select (.set-select / .set-select-chev — the browser's edge-pinned arrow is
+ * killed by appearance-none; this paints the design's chevron at right:11px).
+ */
+export function SelectShell({
+  children,
+  className = '',
+}: {
+  children: ReactNode;
+  className?: string;
+}): ReactElement {
+  return (
+    <span className={`relative inline-flex items-center ${className}`}>
+      {children}
+      <span
+        aria-hidden
+        className="pointer-events-none absolute right-[11px] flex text-text-tertiary"
+      >
+        <svg
+          width="13"
+          height="13"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </span>
+    </span>
+  );
+}

--- a/packages/web/src/experiments/console/lib/model-options.test.ts
+++ b/packages/web/src/experiments/console/lib/model-options.test.ts
@@ -1,0 +1,300 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  CLAUDE_MODEL_OPTIONS,
+  CODEX_MODEL_OPTIONS,
+  COPILOT_MODEL_OPTIONS,
+  curatedOptionsForAgent,
+  effortOptionsForAgent,
+  filterModelOptions,
+  findPiModel,
+  modelPickerShape,
+  modelRefBackend,
+  normalizeEffortForAgent,
+  opencodeBackendOptions,
+  piDisconnectedBackendHint,
+  piModelHint,
+  piModelOptions,
+  usablePiBackends,
+} from './model-options';
+import type {
+  AgentCredentialStatus,
+  AgentCredentials,
+  OpencodeCredentialProvider,
+  PiModelInfo,
+} from '../skills';
+
+function cred(over: Partial<AgentCredentialStatus> & { vendor: string }): AgentCredentialStatus {
+  return {
+    displayName: over.vendor,
+    kinds: ['api_key'],
+    connected: null,
+    subscriptionAvailable: false,
+    installEnv: false,
+    ...over,
+  };
+}
+
+function piAgent(credentials: AgentCredentialStatus[]): AgentCredentials {
+  return { id: 'pi', displayName: 'Pi', catalog: 'static', ready: true, credentials };
+}
+
+function model(over: Partial<PiModelInfo> & { ref: string; provider: string }): PiModelInfo {
+  return {
+    id: over.ref.split('/').slice(1).join('/'),
+    name: over.ref,
+    reasoning: false,
+    cost: { input: 1, output: 2 },
+    contextWindow: 200_000,
+    ...over,
+  };
+}
+
+describe('modelPickerShape', () => {
+  test('maps each known agent to its shape', () => {
+    expect(modelPickerShape('pi')).toBe('pi');
+    expect(modelPickerShape('opencode')).toBe('opencode');
+    expect(modelPickerShape('copilot')).toBe('select');
+    expect(modelPickerShape('claude')).toBe('curated');
+    expect(modelPickerShape('codex')).toBe('curated');
+  });
+
+  test('unknown agents (and the unset row sentinel) fall back to free text', () => {
+    expect(modelPickerShape('')).toBe('free');
+    expect(modelPickerShape('some-future-agent')).toBe('free');
+  });
+});
+
+describe('curatedOptionsForAgent', () => {
+  test('claude/codex/copilot get their curated lists; others get none', () => {
+    expect(curatedOptionsForAgent('claude')).toBe(CLAUDE_MODEL_OPTIONS);
+    expect(curatedOptionsForAgent('codex')).toBe(CODEX_MODEL_OPTIONS);
+    expect(curatedOptionsForAgent('copilot')).toBe(COPILOT_MODEL_OPTIONS);
+    expect(curatedOptionsForAgent('pi')).toEqual([]);
+    expect(curatedOptionsForAgent('')).toEqual([]);
+  });
+
+  test("copilot's list includes 'auto' (the SDK default when nothing is configured)", () => {
+    expect(COPILOT_MODEL_OPTIONS.some(o => o.value === 'auto')).toBe(true);
+  });
+});
+
+describe('effortOptionsForAgent', () => {
+  test('claude and codex expose their (distinct) vocabularies', () => {
+    expect(effortOptionsForAgent('claude')).toEqual(['low', 'medium', 'high', 'max']);
+    expect(effortOptionsForAgent('codex')).toEqual(['minimal', 'low', 'medium', 'high', 'xhigh']);
+  });
+
+  test('agents where tier effort does not route get null (field hidden)', () => {
+    expect(effortOptionsForAgent('pi')).toBeNull();
+    expect(effortOptionsForAgent('opencode')).toBeNull();
+    expect(effortOptionsForAgent('copilot')).toBeNull();
+    expect(effortOptionsForAgent('')).toBeNull();
+  });
+});
+
+describe('normalizeEffortForAgent', () => {
+  test('keeps a value the new vocabulary accepts (codex→claude keeps high)', () => {
+    expect(normalizeEffortForAgent('claude', 'high')).toBe('high');
+  });
+
+  test('clears values the new vocabulary rejects (claude max → codex)', () => {
+    expect(normalizeEffortForAgent('codex', 'max')).toBe('');
+    expect(normalizeEffortForAgent('claude', 'minimal')).toBe('');
+  });
+
+  test('clears any value for agents without an effort concept', () => {
+    expect(normalizeEffortForAgent('pi', 'high')).toBe('');
+    expect(normalizeEffortForAgent('', 'high')).toBe('');
+  });
+});
+
+describe('usablePiBackends', () => {
+  test('null when the matrix is unavailable or carries no pi rows', () => {
+    expect(usablePiBackends(undefined)).toBeNull();
+    expect(usablePiBackends([])).toBeNull();
+    expect(usablePiBackends([piAgent([])])).toBeNull();
+  });
+
+  test('collects vendors with a usable credential (connected / env / ambient)', () => {
+    const backends = usablePiBackends([
+      piAgent([
+        cred({ vendor: 'anthropic', connected: 'api_key' }),
+        cred({ vendor: 'openrouter', installEnv: true }),
+        cred({ vendor: 'amazon-bedrock', kinds: ['ambient'], ambientConfigured: true }),
+        cred({ vendor: 'groq' }),
+      ]),
+    ]);
+    expect(backends).not.toBeNull();
+    expect([...(backends ?? [])].sort()).toEqual(['amazon-bedrock', 'anthropic', 'openrouter']);
+  });
+
+  test('pi present but nothing usable → empty set (filter to nothing, not null)', () => {
+    const backends = usablePiBackends([piAgent([cred({ vendor: 'groq' })])]);
+    expect(backends?.size).toBe(0);
+  });
+});
+
+describe('piModelOptions', () => {
+  const catalog = [
+    model({ ref: 'anthropic/claude-haiku-4-5', provider: 'anthropic' }),
+    model({ ref: 'anthropic/claude-opus-4-5', provider: 'anthropic', reasoning: true }),
+    model({ ref: 'groq/llama-4', provider: 'groq' }),
+    model({ ref: 'openrouter/qwen/qwen3-coder', provider: 'openrouter' }),
+  ];
+  const connected = new Set(['anthropic']);
+
+  test('default-filters to usable backends and reports the hidden count', () => {
+    const r = piModelOptions(catalog, '', connected, false, 30);
+    expect(r.options.map(o => o.value)).toEqual([
+      'anthropic/claude-haiku-4-5',
+      'anthropic/claude-opus-4-5',
+    ]);
+    expect(r.matchTotal).toBe(2);
+    expect(r.hiddenByFilter).toBe(2);
+  });
+
+  test('showAll lifts the backend filter', () => {
+    const r = piModelOptions(catalog, '', connected, true, 30);
+    expect(r.options).toHaveLength(4);
+    expect(r.hiddenByFilter).toBe(0);
+  });
+
+  test('null backends (matrix unavailable) means no filtering', () => {
+    const r = piModelOptions(catalog, '', null, false, 30);
+    expect(r.options).toHaveLength(4);
+  });
+
+  test('query matches ref and name case-insensitively', () => {
+    const r = piModelOptions(catalog, 'QWEN', connected, true, 30);
+    expect(r.options.map(o => o.value)).toEqual(['openrouter/qwen/qwen3-coder']);
+  });
+
+  test('caps options at limit but reports the full match total', () => {
+    const r = piModelOptions(catalog, '', connected, true, 2);
+    expect(r.options).toHaveLength(2);
+    expect(r.matchTotal).toBe(4);
+  });
+
+  test('undefined catalog → empty result', () => {
+    const r = piModelOptions(undefined, '', null, false, 30);
+    expect(r.options).toEqual([]);
+    expect(r.matchTotal).toBe(0);
+    expect(r.hiddenByFilter).toBe(0);
+  });
+
+  test('options carry the cost/context hint', () => {
+    const r = piModelOptions(catalog, 'opus', connected, false, 30);
+    expect(r.options[0]?.hint).toBe('$1/M in · $2/M out · reasoning · 200k ctx');
+  });
+});
+
+describe('piModelHint', () => {
+  test('formats cost, reasoning flag, and rounded context window', () => {
+    const m = model({
+      ref: 'x/y',
+      provider: 'x',
+      reasoning: true,
+      cost: { input: 3, output: 15 },
+      contextWindow: 1_048_576,
+    });
+    expect(piModelHint(m)).toBe('$3/M in · $15/M out · reasoning · 1049k ctx');
+    expect(piModelHint(model({ ref: 'x/z', provider: 'x' }))).toBe('$1/M in · $2/M out · 200k ctx');
+  });
+});
+
+describe('findPiModel', () => {
+  const catalog = [model({ ref: 'groq/llama-4', provider: 'groq' })];
+
+  test('exact ref match, input trimmed', () => {
+    expect(findPiModel(catalog, '  groq/llama-4 ')?.ref).toBe('groq/llama-4');
+  });
+
+  test('no match / blank / undefined catalog → undefined', () => {
+    expect(findPiModel(catalog, 'groq/llama')).toBeUndefined();
+    expect(findPiModel(catalog, '')).toBeUndefined();
+    expect(findPiModel(undefined, 'groq/llama-4')).toBeUndefined();
+  });
+});
+
+describe('modelRefBackend', () => {
+  test('extracts the backend prefix of backend/model refs', () => {
+    expect(modelRefBackend('groq/llama-4')).toBe('groq');
+    expect(modelRefBackend('openrouter/qwen/qwen3-coder')).toBe('openrouter');
+  });
+
+  test('no slash, leading slash, or empty → null', () => {
+    expect(modelRefBackend('sonnet')).toBeNull();
+    expect(modelRefBackend('/oops')).toBeNull();
+    expect(modelRefBackend('')).toBeNull();
+  });
+});
+
+describe('piDisconnectedBackendHint', () => {
+  const agents = [
+    piAgent([
+      cred({ vendor: 'anthropic', connected: 'api_key' }),
+      cred({ vendor: 'groq', displayName: 'Groq' }),
+    ]),
+  ];
+
+  test('known backend without usable credential → non-blocking hint', () => {
+    const hint = piDisconnectedBackendHint('groq/llama-4', agents);
+    expect(hint).toContain('Groq');
+    expect(hint).toContain('saves fine');
+  });
+
+  test('usable backend → no hint', () => {
+    expect(piDisconnectedBackendHint('anthropic/claude-opus-4-5', agents)).toBeNull();
+  });
+
+  test('unknown backend (custom models.json provider) → no hint, we cannot know', () => {
+    expect(piDisconnectedBackendHint('my-custom/model', agents)).toBeNull();
+  });
+
+  test('no prefix or no matrix → no hint', () => {
+    expect(piDisconnectedBackendHint('sonnet', agents)).toBeNull();
+    expect(piDisconnectedBackendHint('groq/llama-4', undefined)).toBeNull();
+  });
+});
+
+describe('filterModelOptions', () => {
+  const options = [{ value: 'sonnet' }, { value: 'opus' }, { value: 'haiku' }];
+
+  test('case-insensitive substring over values; blank returns all', () => {
+    expect(filterModelOptions(options, 'OP').map(o => o.value)).toEqual(['opus']);
+    expect(filterModelOptions(options, '  ')).toHaveLength(3);
+    expect(filterModelOptions(options, 'gpt')).toEqual([]);
+  });
+});
+
+describe('opencodeBackendOptions', () => {
+  const provider = (
+    over: Partial<OpencodeCredentialProvider> & { id: string }
+  ): OpencodeCredentialProvider => ({
+    name: over.id,
+    env: [],
+    connected: false,
+    modelCount: 0,
+    authMethods: [],
+    ...over,
+  });
+
+  test('connected backends sort first, then by model count, then id', () => {
+    const opts = opencodeBackendOptions([
+      provider({ id: 'zed', modelCount: 99 }),
+      provider({ id: 'anthropic', connected: true, modelCount: 5 }),
+      provider({ id: 'openai', connected: true, modelCount: 12 }),
+      provider({ id: 'alpha', modelCount: 99 }),
+    ]);
+    expect(opts.map(o => o.value)).toEqual(['openai/', 'anthropic/', 'alpha/', 'zed/']);
+  });
+
+  test('options are prefix completions with model-count + connected hints', () => {
+    const [opt] = opencodeBackendOptions([
+      provider({ id: 'anthropic', name: 'Anthropic', connected: true, modelCount: 1 }),
+    ]);
+    expect(opt?.value).toBe('anthropic/');
+    expect(opt?.prefix).toBe(true);
+    expect(opt?.hint).toBe('Anthropic · 1 model · connected');
+  });
+});

--- a/packages/web/src/experiments/console/lib/model-options.test.ts
+++ b/packages/web/src/experiments/console/lib/model-options.test.ts
@@ -169,10 +169,34 @@ describe('piModelOptions', () => {
     expect(r.options.map(o => o.value)).toEqual(['openrouter/qwen/qwen3-coder']);
   });
 
+  test('matches the display name alone when it differs from the ref', () => {
+    const named = [
+      model({ ref: 'anthropic/claude-haiku-4-5', provider: 'anthropic', name: 'Claude Haiku 4.5' }),
+      model({ ref: 'groq/llama-4', provider: 'groq', name: 'Llama 4' }),
+    ];
+    // '4.5' appears only in the display name — the ref spells it '4-5'.
+    const r = piModelOptions(named, '4.5', null, false, 30);
+    expect(r.options.map(o => o.value)).toEqual(['anthropic/claude-haiku-4-5']);
+  });
+
   test('caps options at limit but reports the full match total', () => {
     const r = piModelOptions(catalog, '', connected, true, 2);
     expect(r.options).toHaveLength(2);
     expect(r.matchTotal).toBe(4);
+  });
+
+  test('backend filter and limit cap combine without double-counting', () => {
+    const wide = [
+      model({ ref: 'anthropic/a', provider: 'anthropic' }),
+      model({ ref: 'anthropic/b', provider: 'anthropic' }),
+      model({ ref: 'anthropic/c', provider: 'anthropic' }),
+      model({ ref: 'groq/d', provider: 'groq' }),
+      model({ ref: 'xai/e', provider: 'xai' }),
+    ];
+    const r = piModelOptions(wide, '', new Set(['anthropic']), false, 2);
+    expect(r.options.map(o => o.value)).toEqual(['anthropic/a', 'anthropic/b']);
+    expect(r.matchTotal).toBe(3); // every filtered match, not just the rendered cap
+    expect(r.hiddenByFilter).toBe(2); // groq + xai, unaffected by the cap
   });
 
   test('undefined catalog → empty result', () => {
@@ -199,6 +223,12 @@ describe('piModelHint', () => {
     });
     expect(piModelHint(m)).toBe('$3/M in · $15/M out · reasoning · 1049k ctx');
     expect(piModelHint(model({ ref: 'x/z', provider: 'x' }))).toBe('$1/M in · $2/M out · 200k ctx');
+  });
+
+  test('zero-cost (free-tier) models render $0 rather than dropping the hint', () => {
+    expect(
+      piModelHint(model({ ref: 'x/free', provider: 'x', cost: { input: 0, output: 0 } }))
+    ).toBe('$0/M in · $0/M out · 200k ctx');
   });
 });
 

--- a/packages/web/src/experiments/console/lib/model-options.ts
+++ b/packages/web/src/experiments/console/lib/model-options.ts
@@ -1,0 +1,273 @@
+/**
+ * Pure helpers for the agent-aware model pickers (#1957) in the Model Tiers /
+ * Aliases / Defaults panels. The valid model space is agent-shaped — Pi has a
+ * baked catalog, OpenCode a runtime-introspected one, Copilot a small fixed
+ * list, Claude/Codex small curated sets that evolve — so each agent gets a
+ * differently sourced suggestion list. Pickers GUIDE, they never GATE: every
+ * shape keeps a free-text path and the server stays permissive.
+ *
+ * All functions are side-effect free so they stay unit-testable without DOM
+ * rendering — the console's testing pattern for panel logic (lib/agent-status.ts).
+ */
+import type { AgentCredentials, OpencodeCredentialProvider, PiModelInfo } from '../skills';
+import { isCredentialUsable } from './agent-status';
+
+/** One suggestion in a model picker dropdown. */
+export interface ModelOption {
+  /** What picking the option writes into the model field. */
+  value: string;
+  /** Muted metadata rendered next to the value (cost/context, model counts, …). */
+  hint?: string;
+  /**
+   * Prefix completion (OpenCode `backend/`): picking it fills the backend
+   * prefix and keeps the input open for the free-typed model id, because the
+   * credentials endpoint exposes per-backend model COUNTS but not model ids.
+   */
+  prefix?: boolean;
+}
+
+/**
+ * How the model field renders for an agent. Unknown agent ids (future
+ * community providers) fall back to plain free text — never an empty picker.
+ */
+export type ModelPickerShape = 'pi' | 'opencode' | 'select' | 'curated' | 'free';
+
+export function modelPickerShape(agentId: string): ModelPickerShape {
+  switch (agentId) {
+    case 'pi':
+      return 'pi';
+    case 'opencode':
+      return 'opencode';
+    case 'copilot':
+      return 'select';
+    case 'claude':
+    case 'codex':
+      return 'curated';
+    default:
+      return 'free';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Curated lists. These are CONVENIENCE suggestions, not authority — the SDKs
+// ship models faster than Archon can enumerate them, so every consumer keeps a
+// free-text escape and nothing client-side blocks an unlisted model string.
+// ---------------------------------------------------------------------------
+
+/**
+ * Claude SDK model keywords, mirroring the `.archon/config.yaml` examples in
+ * CLAUDE.md and docs/getting-started/ai-assistants.md (`model: sonnet # or
+ * 'opus', 'haiku', 'claude-*'`). Full `claude-*` ids are free-typed.
+ */
+export const CLAUDE_MODEL_OPTIONS: readonly ModelOption[] = [
+  { value: 'sonnet' },
+  { value: 'opus' },
+  { value: 'haiku' },
+];
+
+/**
+ * Codex model strings used across the repo's config examples
+ * (docs/getting-started/ai-assistants.md and CLAUDE.md: `gpt-5.3-codex`,
+ * tiers example `gpt-5.5`, docs `gpt-5.2`).
+ */
+export const CODEX_MODEL_OPTIONS: readonly ModelOption[] = [
+  { value: 'gpt-5.3-codex' },
+  { value: 'gpt-5.5' },
+  { value: 'gpt-5.2' },
+];
+
+/**
+ * Copilot model list. PROVENANCE: no Archon API exposes Copilot's model
+ * catalog (the Copilot CLI negotiates it per subscription at runtime), so this
+ * is hand-curated from docs/getting-started/ai-assistants.md ("'gpt-5',
+ * 'gpt-5-mini', 'claude-sonnet-4.5', 'auto', etc."). NOT authoritative — the
+ * select keeps a "Custom…" free-text escape for anything Copilot ships next.
+ */
+export const COPILOT_MODEL_OPTIONS: readonly ModelOption[] = [
+  { value: 'auto', hint: 'Copilot picks' },
+  { value: 'gpt-5' },
+  { value: 'gpt-5-mini' },
+  { value: 'claude-sonnet-4.5' },
+];
+
+/** Curated suggestions for an agent's combobox; empty when none exist. */
+export function curatedOptionsForAgent(agentId: string): readonly ModelOption[] {
+  if (agentId === 'claude') return CLAUDE_MODEL_OPTIONS;
+  if (agentId === 'codex') return CODEX_MODEL_OPTIONS;
+  if (agentId === 'copilot') return COPILOT_MODEL_OPTIONS;
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// Effort. Tier/alias `effort` only ROUTES on Claude (node `effort`) and Codex
+// (`modelReasoningEffort`) — `routePresetEffort` in
+// packages/workflows/src/model-validation.ts returns null for everything else,
+// and the PATCH routes validate via `isEffortValidForProvider`. The web
+// package cannot import @archon/workflows, so the vocabularies are mirrored
+// here (same convention as REASONING_EFFORTS in the Defaults panel).
+// ---------------------------------------------------------------------------
+
+/** Mirrors CLAUDE_EFFORTS in packages/workflows/src/model-validation.ts. */
+export const CLAUDE_EFFORT_OPTIONS: readonly string[] = ['low', 'medium', 'high', 'max'];
+/** Mirrors CODEX_REASONING_EFFORTS in packages/workflows/src/model-validation.ts. */
+export const CODEX_EFFORT_OPTIONS: readonly string[] = [
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+];
+
+/**
+ * The effort vocabulary an agent's tier/alias `effort` accepts, or null when
+ * effort doesn't route there (Pi/OpenCode/Copilot presets drop it) — null
+ * hides the field entirely instead of offering a no-op input.
+ */
+export function effortOptionsForAgent(agentId: string): readonly string[] | null {
+  if (agentId === 'claude') return CLAUDE_EFFORT_OPTIONS;
+  if (agentId === 'codex') return CODEX_EFFORT_OPTIONS;
+  return null;
+}
+
+/**
+ * Carry an effort value across a provider switch: keep it when the new agent's
+ * vocabulary accepts it (e.g. codex→claude keeps 'high'), clear it otherwise
+ * (including agents with no effort concept, where the field is hidden and a
+ * stale value would be invisible state).
+ */
+export function normalizeEffortForAgent(agentId: string, effort: string): string {
+  const valid = effortOptionsForAgent(agentId);
+  return valid?.includes(effort) === true ? effort : '';
+}
+
+// ---------------------------------------------------------------------------
+// Pi: searchable picker over GET /api/providers/pi/models, default-filtered to
+// backends the agents matrix says are usable.
+// ---------------------------------------------------------------------------
+
+/**
+ * The set of Pi backend ids (vendor-canonical, same ids the Pi catalog uses as
+ * `PiModelInfo.provider`) with a usable credential — connected, install env,
+ * or ambient. Returns null when the matrix is unavailable (401/solo install)
+ * or carries no Pi credential rows: null means "can't filter, show everything"
+ * rather than "nothing is connected".
+ */
+export function usablePiBackends(
+  agents: AgentCredentials[] | undefined
+): ReadonlySet<string> | null {
+  const credentials = agents?.find(a => a.id === 'pi')?.credentials;
+  if (credentials === undefined || credentials.length === 0) return null;
+  return new Set(credentials.filter(isCredentialUsable).map(c => c.vendor));
+}
+
+/** Cost/context/reasoning hint for one Pi catalog model. */
+export function piModelHint(m: PiModelInfo): string {
+  const ctx = `${String(Math.round(m.contextWindow / 1000))}k ctx`;
+  return `$${String(m.cost.input)}/M in · $${String(m.cost.output)}/M out${m.reasoning ? ' · reasoning' : ''} · ${ctx}`;
+}
+
+export interface PiPickerResult {
+  options: ModelOption[];
+  /** Total query matches after backend filtering (options are capped at `limit`). */
+  matchTotal: number;
+  /** Query matches hidden by the connected-backends filter (drives the "show all" toggle copy). */
+  hiddenByFilter: number;
+}
+
+/**
+ * Suggestions for the Pi picker. The field's current text doubles as the
+ * search query (matched against ref and display name). With `backends` known
+ * and `showAll` off, only models on usable backends surface; the hidden count
+ * lets the UI offer an explicit "show all backends" toggle. Custom
+ * ~/.pi/agent/models.json providers aren't in the baked catalog at all —
+ * free text is their (documented) path.
+ */
+export function piModelOptions(
+  models: PiModelInfo[] | undefined,
+  query: string,
+  backends: ReadonlySet<string> | null,
+  showAll: boolean,
+  limit: number
+): PiPickerResult {
+  const q = query.trim().toLowerCase();
+  const all = models ?? [];
+  const queryMatches =
+    q === ''
+      ? all
+      : all.filter(m => m.ref.toLowerCase().includes(q) || m.name.toLowerCase().includes(q));
+  const filtered =
+    showAll || backends === null
+      ? queryMatches
+      : queryMatches.filter(m => backends.has(m.provider));
+  return {
+    options: filtered.slice(0, limit).map(m => ({ value: m.ref, hint: piModelHint(m) })),
+    matchTotal: filtered.length,
+    hiddenByFilter: queryMatches.length - filtered.length,
+  };
+}
+
+/** Exact-ref catalog lookup for the under-field cost hint (trims the input). */
+export function findPiModel(
+  models: PiModelInfo[] | undefined,
+  value: string
+): PiModelInfo | undefined {
+  const v = value.trim();
+  if (v === '') return undefined;
+  return models?.find(m => m.ref === v);
+}
+
+/** The `backend` of a `backend/model` ref, or null when there's no prefix. */
+export function modelRefBackend(value: string): string | null {
+  const i = value.indexOf('/');
+  return i > 0 ? value.slice(0, i) : null;
+}
+
+/**
+ * Non-blocking inline hint when a Pi model ref names a backend the credential
+ * matrix knows but nothing usable is connected. Pickers guide, never gate:
+ * the value still saves (credentials may be connected later or exist only as
+ * run-time env). Unknown backends (custom models.json providers) get NO hint —
+ * we can't know their credential state.
+ */
+export function piDisconnectedBackendHint(
+  value: string,
+  agents: AgentCredentials[] | undefined
+): string | null {
+  const backend = modelRefBackend(value.trim());
+  if (backend === null) return null;
+  const pi = agents?.find(a => a.id === 'pi');
+  const cred = pi?.credentials.find(c => c.vendor === backend);
+  if (!cred || isCredentialUsable(cred)) return null;
+  return `No ${cred.displayName} credential connected — saves fine, but runs need one (Settings → Agents).`;
+}
+
+// ---------------------------------------------------------------------------
+// Generic + OpenCode.
+// ---------------------------------------------------------------------------
+
+/** Case-insensitive substring filter over option values (curated/OpenCode lists). */
+export function filterModelOptions(options: readonly ModelOption[], query: string): ModelOption[] {
+  const q = query.trim().toLowerCase();
+  if (q === '') return [...options];
+  return options.filter(o => o.value.toLowerCase().includes(q));
+}
+
+/**
+ * Backend-prefix options for the OpenCode picker, from the on-demand
+ * introspection endpoint: connected backends first, then by model count, then
+ * id. Values are `backend/` prefixes (see `ModelOption.prefix`).
+ */
+export function opencodeBackendOptions(providers: OpencodeCredentialProvider[]): ModelOption[] {
+  return [...providers]
+    .sort(
+      (a, b) =>
+        Number(b.connected) - Number(a.connected) ||
+        b.modelCount - a.modelCount ||
+        a.id.localeCompare(b.id)
+    )
+    .map(p => ({
+      value: `${p.id}/`,
+      prefix: true,
+      hint: `${p.name} · ${String(p.modelCount)} model${p.modelCount === 1 ? '' : 's'}${p.connected ? ' · connected' : ''}`,
+    }));
+}

--- a/packages/web/src/experiments/console/lib/model-options.ts
+++ b/packages/web/src/experiments/console/lib/model-options.ts
@@ -108,22 +108,21 @@ export function curatedOptionsForAgent(agentId: string): readonly ModelOption[] 
 // ---------------------------------------------------------------------------
 
 /** Mirrors CLAUDE_EFFORTS in packages/workflows/src/model-validation.ts. */
-export const CLAUDE_EFFORT_OPTIONS: readonly string[] = ['low', 'medium', 'high', 'max'];
+export const CLAUDE_EFFORT_OPTIONS = ['low', 'medium', 'high', 'max'] as const;
 /** Mirrors CODEX_REASONING_EFFORTS in packages/workflows/src/model-validation.ts. */
-export const CODEX_EFFORT_OPTIONS: readonly string[] = [
-  'minimal',
-  'low',
-  'medium',
-  'high',
-  'xhigh',
-];
+export const CODEX_EFFORT_OPTIONS = ['minimal', 'low', 'medium', 'high', 'xhigh'] as const;
+
+export type ClaudeEffort = (typeof CLAUDE_EFFORT_OPTIONS)[number];
+export type CodexEffort = (typeof CODEX_EFFORT_OPTIONS)[number];
+/** Any effort value an agent's vocabulary can produce. */
+export type EffortOption = ClaudeEffort | CodexEffort;
 
 /**
  * The effort vocabulary an agent's tier/alias `effort` accepts, or null when
  * effort doesn't route there (Pi/OpenCode/Copilot presets drop it) — null
  * hides the field entirely instead of offering a no-op input.
  */
-export function effortOptionsForAgent(agentId: string): readonly string[] | null {
+export function effortOptionsForAgent(agentId: string): readonly EffortOption[] | null {
   if (agentId === 'claude') return CLAUDE_EFFORT_OPTIONS;
   if (agentId === 'codex') return CODEX_EFFORT_OPTIONS;
   return null;
@@ -135,9 +134,9 @@ export function effortOptionsForAgent(agentId: string): readonly string[] | null
  * (including agents with no effort concept, where the field is hidden and a
  * stale value would be invisible state).
  */
-export function normalizeEffortForAgent(agentId: string, effort: string): string {
+export function normalizeEffortForAgent(agentId: string, effort: string): EffortOption | '' {
   const valid = effortOptionsForAgent(agentId);
-  return valid?.includes(effort) === true ? effort : '';
+  return valid?.find(v => v === effort) ?? '';
 }
 
 // ---------------------------------------------------------------------------
@@ -149,8 +148,10 @@ export function normalizeEffortForAgent(agentId: string, effort: string): string
  * The set of Pi backend ids (vendor-canonical, same ids the Pi catalog uses as
  * `PiModelInfo.provider`) with a usable credential — connected, install env,
  * or ambient. Returns null when the matrix is unavailable (401/solo install)
- * or carries no Pi credential rows: null means "can't filter, show everything"
- * rather than "nothing is connected".
+ * or carries no Pi credential rows: null means "can't filter, show everything".
+ * An EMPTY set is different — the matrix is present but nothing is usable, so
+ * the filter is active and the default suggestion list is empty (the "show
+ * all backends" toggle is the way out).
  */
 export function usablePiBackends(
   agents: AgentCredentials[] | undefined
@@ -162,8 +163,7 @@ export function usablePiBackends(
 
 /** Cost/context/reasoning hint for one Pi catalog model. */
 export function piModelHint(m: PiModelInfo): string {
-  const ctx = `${String(Math.round(m.contextWindow / 1000))}k ctx`;
-  return `$${String(m.cost.input)}/M in · $${String(m.cost.output)}/M out${m.reasoning ? ' · reasoning' : ''} · ${ctx}`;
+  return `$${m.cost.input}/M in · $${m.cost.output}/M out${m.reasoning ? ' · reasoning' : ''} · ${Math.round(m.contextWindow / 1000)}k ctx`;
 }
 
 export interface PiPickerResult {
@@ -268,6 +268,6 @@ export function opencodeBackendOptions(providers: OpencodeCredentialProvider[]):
     .map(p => ({
       value: `${p.id}/`,
       prefix: true,
-      hint: `${p.name} · ${String(p.modelCount)} model${p.modelCount === 1 ? '' : 's'}${p.connected ? ' · connected' : ''}`,
+      hint: `${p.name} · ${p.modelCount} model${p.modelCount === 1 ? '' : 's'}${p.connected ? ' · connected' : ''}`,
     }));
 }

--- a/packages/web/src/experiments/console/skills/providers.ts
+++ b/packages/web/src/experiments/console/skills/providers.ts
@@ -59,3 +59,11 @@ export function listOpencodeCredentials(): Promise<OpencodeCredentialProvider[]>
     '/api/providers/opencode/credentials'
   ).then(r => r.providers);
 }
+
+/**
+ * Client-side deadline for `listOpencodeCredentials` callers: booting the
+ * embedded OpenCode runtime is the slow path, so give it a generous minute
+ * before declaring the load hung — the user always gets a Retry escape
+ * instead of a permanent "Loading…".
+ */
+export const OPENCODE_LOAD_TIMEOUT_MS = 60_000;


### PR DESCRIPTION
## Summary

- Problem: The model field in Model Tiers / Aliases / Defaults is uniform free text regardless of agent, but the valid model space is agent-shaped — Pi has a baked catalog (~920 models on 32 backends), OpenCode a runtime-introspected one, Copilot a small fixed list, Claude/Codex small curated sets. The only assist was a best-effort Pi cost hint after typing an exact ref.
- Why it matters: Picking a model today means knowing each agent's ref format and catalog by heart; on shared installs nothing tells you which Pi backends are actually usable.
- What changed: One `ModelPickerField` component renders the model input per agent — Pi searchable picker (default-filtered to connected backends, explicit "show all backends" toggle, cost/context/reasoning hints), OpenCode free text with on-demand `backend/` prefix suggestions, Copilot fixed select + "Custom…" escape, Claude/Codex curated suggestions over free text. Effort in tiers/aliases became a select shown only where preset effort actually routes (Claude/Codex). Also lands the S3 form-primitives extraction promised in the PR #1962 review disposition (`SettingsFormPrimitives.tsx`).
- What did **not** change (scope boundary): All save semantics, the install/user scope toggle, PATCH bodies, and server validation are untouched — this is input UX only. Pickers guide, never gate: every shape keeps free text and nothing client-side blocks a save.

## UX Journey

### Before

```
  User                          Console Settings
  ────                          ────────────────
  picks agent in tier row ────▶ provider select (readiness hint)
  types model string  ────────▶ bare free-text input, no help
                                (Pi: cost hint only AFTER typing an exact ref)
  types effort string ────────▶ bare free-text input on EVERY agent,
                                even where effort never routes
```

### After

```
  User                          Console Settings
  ────                          ────────────────
  picks agent in tier row ────▶ provider select (readiness hint, unchanged)
  focuses model field ────────▶ [agent-shaped picker]
    Pi:       searchable catalog, *connected backends by default*,
              "show all backends (N more match)" toggle,
              cost/ctx/reasoning per suggestion + exact match,
              *non-blocking warning* for disconnected backends
    OpenCode: free text; "Load backend suggestions" (explicit click)
              → backend/ prefixes with model counts; id free-typed
    Copilot:  fixed <select> (auto, gpt-5, …) + Custom… escape
    Claude:   sonnet/opus/haiku suggestions + free text
    Codex:    gpt-5.3-codex/gpt-5.5/gpt-5.2 suggestions + free text
  sets effort ────────────────▶ [select with the agent's vocabulary,
                                shown ONLY for Claude/Codex]
  saves ──────────────────────▶ unchanged PATCH routes, still permissive
```

## Architecture Diagram

### Before

```
ModelTiersPanel ──┐                      ┌── GET /api/config
  local INPUT/SELECT/SelectShell copy    ├── GET /api/providers
AliasesPanel ─────┤                      ├── GET /api/auth/providers (K.providerConnections)
  local copy      ├── skills/* ──────────┤
AssistantConfigPanel                     └── GET /api/providers/pi/models (K.piModels,
  local copy      │                            tiers panel only — exact-ref hint)
AgentCredentialCard
  local INPUT copy
```

### After

```
ModelTiersPanel ───────┐
AliasesPanel ──────────┼── [+] ModelPickerField ── [+] lib/model-options.ts (pure)
AssistantConfigPanel ──┘         │    │                  │ uses lib/agent-status.isCredentialUsable
                                 │    └=== skills.listOpencodeCredentials (ON DEMAND ONLY)
                                 ├─── piModels (K.piModels, shared cache)
                                 └─── agents matrix (K.providerConnections, shared cache)
ModelTiersPanel / AliasesPanel / AssistantConfigPanel / AgentCredentialCard
                                 └=== [+] SettingsFormPrimitives (S3 extraction from #1962 review)
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| ModelTiersPanel / AliasesPanel / AssistantConfigPanel | ModelPickerField | **new** | model input replaced |
| ModelPickerField | lib/model-options.ts | **new** | all picker logic is pure + unit-tested |
| ModelPickerField | skills.listOpencodeCredentials | **new** | only on explicit "Load backend suggestions" click; 60s timeout + retry |
| AssistantConfigPanel | K.piModels / K.providerConnections | **new** | shared cache keys — no extra fetches on the settings page |
| ModelTiersPanel / AliasesPanel / AssistantConfigPanel / AgentCredentialCard | SettingsFormPrimitives | **new** | replaces 4 char-for-char copies |
| AliasesPanel | K.piModels | **new** | Pi picker suggestions (tiers already fetched it) |
| panels | PATCH /api/config/* and /api/auth/me/ai-prefs/* | unchanged | save path untouched |
| lib/model-options | lib/agent-status | **new** | reuses `isCredentialUsable` for backend filtering |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `web`
- Module: `web:console`

## Change Metadata

- Change type: `feature`
- Primary scope: `web`

## Linked Issue

- Closes #1957
- Related #1954 (epic, PR 3 of 3), #1962 (the S3 `SettingsFormPrimitives` extraction was deferred into this PR in the #1962 review disposition — it lands here as promised)
- Depends on #1958 + #1962 (both merged to dev)

## Validation Evidence (required)

```bash
bun run validate   # exit 0 — check:bundled, check:bundled-skill, check:bundled-schema,
                   # type-check, lint (0 warnings), format:check, tests all green
bun test packages/web/src/experiments/console/   # 221 pass / 0 fail (31 new in lib/model-options.test.ts)
```

- Evidence provided: new unit tests cover every pure helper (shape dispatch, curated lists, effort vocab + carry-over, Pi backend filtering / hidden counts / limit, hints, OpenCode prefix options + sorting) at 100% line coverage of `lib/model-options.ts`.
- Nothing skipped.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No (the OpenCode introspection endpoint was already consumed by the Agents card; the picker calls it strictly on explicit user action)
- Secrets/tokens handling changed? No (the agents matrix carries no secret values)
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — saved values render as-is; a non-curated Copilot model renders in custom (free-text) mode rather than being misdisplayed; a stored effort on an agent without an effort vocabulary is preserved on save (only an explicit provider switch normalizes it).
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: full validate suite; console test suite; type-check.
- Edge cases checked (via unit tests): matrix unavailable (401/solo) → Pi picker shows everything (null ≠ "nothing connected"); pi row present but zero usable backends → empty default list with working "show all"; custom models.json backends get no false "disconnected" hint; effort carried codex→claude only when the value is in both vocabularies; unknown future agent ids fall back to plain free text.
- What was not verified: in-browser interaction pass (combobox focus/blur, dropdown layering) — no DOM tests by console convention; flagging for a quick manual smoke on the settings page before merge.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: console Settings page only (Model Tiers, Model Aliases, Defaults, Agents cards' input styling).
- Potential unintended effects: the effort field disappearing for Pi/OpenCode/Copilot rows is deliberate (preset effort never routes there — `routePresetEffort` returns null); stored values remain untouched.
- Guardrails: pickers never block saves; all dropdown content is best-effort and absent rather than wrong when data is unavailable.

## Rollback Plan (required)

- Fast rollback: revert the single commit (`git revert cac8a708`) — no schema, config, or API surface changes.
- Feature flags: none (console is itself the experiment surface).
- Observable failure symptoms: settings model fields misrendering or dropdowns not closing; saves are unaffected by construction.

## Risks and Mitigations

- Risk: Curated Claude/Codex/Copilot lists go stale as SDKs ship models.
  - Mitigation: lists are suggestions only, sourced from the repo's own docs/config examples with provenance comments; free text always wins. The Copilot list in particular is explicitly documented as non-authoritative (no API exposes Copilot's catalog).
- Risk: Pi backend filter hides a model the user expects.
  - Mitigation: explicit "show all backends (N more match)" toggle with a visible hidden count, plus free text; when the matrix is unavailable the filter is off entirely.

---

**Design decisions** (for reviewers):

1. **OpenCode picker UX**: chose *free text + on-demand backend-prefix suggestions* over a fake full picker. `GET /api/providers/opencode/credentials` exposes per-backend model **counts**, not model ids, so a "model picker" would have to invent data. Picking a suggestion inserts `backend/` and keeps the dropdown open for the free-typed id. The endpoint is never called on page load — only an explicit "Load backend suggestions" click (60s timeout + retry, mirroring the Agents card).
2. **Copilot provenance**: `COPILOT_MODEL_OPTIONS` is hand-curated from the docs' Copilot section (`auto`, `gpt-5`, `gpt-5-mini`, `claude-sonnet-4.5`) with a provenance comment stating it is NOT authoritative; the select carries a "Custom…" free-text escape.
3. **Effort capability source**: the honest signal for *tier/alias* effort is `validEffortsForProvider` (Claude/Codex vocabularies; everything else is a silent no-op at run time), not `capabilities.effortControl` (which describes per-node effort and is e.g. *false* for Codex while tier effort *does* route there as `modelReasoningEffort`). The web package can't import `@archon/workflows`, so the two vocabularies are mirrored locally with pointer comments — same precedent as the Defaults panel's `REASONING_EFFORTS`.
4. **S3 from the #1962 review** lands here as promised in that PR's disposition comment ("Deferred → #1957: …so the primitives get designed against their final shape in PR-3").


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intelligent model picker that adapts to different AI providers with contextual suggestions, backend status indicators, and explicit load/retry for dynamic backends.
  * Added provider-specific effort selection where supported.

* **Refactor**
  * Consolidated shared form styling/components across settings panels for consistent UI.
  * Extracted and centralized model-selection logic into reusable helpers.

* **Tests**
  * Added comprehensive tests covering model picker behavior and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->