### PR TITLE
fix(oauth-bridge): release the fixed OAuth callback port when a login is abandoned

### DIFF
--- a/packages/core/src/credentials/index.ts
+++ b/packages/core/src/credentials/index.ts
@@ -42,6 +42,7 @@ export {
   startOAuth,
   pollOAuth,
   cancelOAuth,
+  OAuthCallbackPortBusyError,
   type StartOAuthResult,
   type PollOAuthResult,
 } from './oauth-bridge';

--- a/packages/core/src/credentials/oauth-bridge.test.ts
+++ b/packages/core/src/credentials/oauth-bridge.test.ts
@@ -22,17 +22,19 @@ type Callbacks = {
   signal?: AbortSignal;
 };
 let loginImpl: (cb: Callbacks) => Promise<Record<string, unknown>>;
-function makeProvider(id: string) {
+function makeProvider(id: string, usesCallbackServer?: boolean) {
   return {
     id,
     name: id,
+    ...(usesCallbackServer ? { usesCallbackServer } : {}),
     login: (cb: Callbacks) => loginImpl(cb),
     refreshToken: async (c: Record<string, unknown>) => c,
     getApiKey: () => 'k',
   };
 }
-const anthropic = makeProvider('anthropic');
-const codex = makeProvider('openaiCodex');
+// anthropic/codex bind a local fixed-port callback server in pi (#1963).
+const anthropic = makeProvider('anthropic', true);
+const codex = makeProvider('openaiCodex', true);
 const copilot = makeProvider('github-copilot');
 mock.module('@archon/providers/oauth', () => ({
   getOAuthProvider: (id: string) =>
@@ -43,8 +45,13 @@ mock.module('@archon/providers/oauth', () => ({
   githubCopilotOAuthProvider: copilot,
 }));
 
-const { startOAuth, pollOAuth, cancelOAuth, resetOAuthSessionsForTest } =
-  await import('./oauth-bridge');
+const {
+  startOAuth,
+  pollOAuth,
+  cancelOAuth,
+  resetOAuthSessionsForTest,
+  OAuthCallbackPortBusyError,
+} = await import('./oauth-bridge');
 
 function tick(ms = 15): Promise<void> {
   return new Promise(r => setTimeout(r, ms));
@@ -149,5 +156,117 @@ describe('oauth-bridge', () => {
     const second = await startOAuth('u1', 'claude');
     expect(first.sessionId).not.toBe(second.sessionId);
     expect(pollOAuth(first.sessionId, 'u1').status).toBe('error'); // prior session dropped
+  });
+
+  // ---- #1963: abandoned logins must not wedge the fixed callback port ----
+
+  test('aborting a session rejects the manual-code deferred so a pi-style login releases its callback server (#1963)', async () => {
+    // Mirror pi-ai 0.79.1 loginAnthropic: the callback server only closes in a
+    // `finally` reached after onManualCodeInput() settles — pi ignores the
+    // abort signal, so the deferred rejection is the only path there.
+    let serverClosed = false;
+    loginImpl = async cb => {
+      cb.onAuth({ url: 'https://x' });
+      try {
+        await cb.onManualCodeInput!();
+      } finally {
+        serverClosed = true; // pi's `finally { server.close() }`
+      }
+      return { access: 'a' };
+    };
+    const start = await startOAuth('u1', 'claude');
+    expect(serverClosed).toBe(false);
+    cancelOAuth(start.sessionId, 'u1');
+    await tick();
+    expect(serverClosed).toBe(true);
+  });
+
+  test("a callback-server vendor start supersedes another user's abandoned session (#1963)", async () => {
+    let serversClosed = 0;
+    loginImpl = async cb => {
+      cb.onAuth({ url: 'https://x' });
+      try {
+        await cb.onManualCodeInput!();
+      } finally {
+        serversClosed++;
+      }
+      return { access: 'a' };
+    };
+    // alice starts an anthropic login and abandons it (no poll, no code).
+    const a = await startOAuth('alice', 'claude');
+    // bob's anthropic login must not 500 on the held port: it cancels alice's
+    // flow (releasing the server) and proceeds.
+    const b = await startOAuth('bob', 'claude');
+    expect(serversClosed).toBe(1);
+    expect(pollOAuth(a.sessionId, 'alice').status).toBe('error'); // superseded
+    // bob's flow still completes end-to-end.
+    pollOAuth(b.sessionId, 'bob', 'CODE');
+    await tick();
+    expect(pollOAuth(b.sessionId, 'bob').status).toBe('connected');
+  });
+
+  test('device-flow logins (no callback server) for different users coexist', async () => {
+    let resolveFirst!: () => void;
+    const firstGate = new Promise<void>(r => {
+      resolveFirst = r;
+    });
+    loginImpl = async cb => {
+      cb.onDeviceCode({ userCode: 'AAAA', verificationUri: 'https://dev' });
+      await firstGate;
+      return { access: 'a' };
+    };
+    const a = await startOAuth('alice', 'copilot');
+    loginImpl = async cb => {
+      cb.onDeviceCode({ userCode: 'BBBB', verificationUri: 'https://dev' });
+      return { access: 'b' };
+    };
+    const b = await startOAuth('bob', 'copilot');
+    // alice's pending device login was NOT superseded by bob's.
+    expect(pollOAuth(a.sessionId, 'alice').status).toBe('pending');
+    resolveFirst();
+    await tick();
+    expect(pollOAuth(a.sessionId, 'alice').status).toBe('connected');
+    expect(pollOAuth(b.sessionId, 'bob').status).toBe('connected');
+  });
+
+  test('a login impl that ignores the cancel entirely cannot permanently break later starts (#1963 regression)', async () => {
+    // Worst case: login neither honors the abort signal nor consumes the
+    // manual-code deferred, and never settles. The bridge waits a bounded
+    // settle window, then proceeds with the new login.
+    loginImpl = async cb => {
+      cb.onAuth({ url: 'https://wedged' });
+      await new Promise<never>(() => {}); // never settles
+      return {};
+    };
+    const first = await startOAuth('u1', 'claude');
+    expect(first.url).toBe('https://wedged');
+
+    let received: string | undefined;
+    loginImpl = async cb => {
+      cb.onAuth({ url: 'https://fresh' });
+      received = await cb.onManualCodeInput!();
+      return { access: 'a', refresh: 'r', expires: 1 };
+    };
+    const second = await startOAuth('u2', 'claude');
+    expect(second.url).toBe('https://fresh');
+    pollOAuth(second.sessionId, 'u2', 'CODE');
+    await tick();
+    expect(received).toBe('CODE');
+    expect(pollOAuth(second.sessionId, 'u2').status).toBe('connected');
+  }, 10000);
+
+  test('EADDRINUSE at start surfaces an actionable retryable error, not an opaque failure (#1963)', async () => {
+    loginImpl = async () => {
+      throw new Error('listen EADDRINUSE: address already in use 127.0.0.1:53692');
+    };
+    let thrown: unknown;
+    try {
+      await startOAuth('u1', 'claude');
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(OAuthCallbackPortBusyError);
+    expect((thrown as Error).message).toMatch(/callback port/i);
+    expect((thrown as Error).message).toMatch(/retry/i);
   });
 });

--- a/packages/core/src/credentials/oauth-bridge.test.ts
+++ b/packages/core/src/credentials/oauth-bridge.test.ts
@@ -198,11 +198,53 @@ describe('oauth-bridge', () => {
     // flow (releasing the server) and proceeds.
     const b = await startOAuth('bob', 'claude');
     expect(serversClosed).toBe(1);
-    expect(pollOAuth(a.sessionId, 'alice').status).toBe('error'); // superseded
+    // S2: the superseded user's poll detail is user-visible in the console
+    // retry UX — pin the exact message.
+    const supersededPoll = pollOAuth(a.sessionId, 'alice');
+    expect(supersededPoll.status).toBe('error');
+    expect(supersededPoll.detail).toBe('Login session not found or expired.');
     // bob's flow still completes end-to-end.
     pollOAuth(b.sessionId, 'bob', 'CODE');
     await tick();
     expect(pollOAuth(b.sessionId, 'bob').status).toBe('connected');
+  });
+
+  test('cancel AFTER the code was submitted → the credential persists exactly once (S1)', async () => {
+    // abortSession claims rejecting an already-resolved deferred is a no-op;
+    // pin that a post-submit cancel can neither lose nor double-persist.
+    loginImpl = async cb => {
+      cb.onAuth({ url: 'https://x' });
+      const code = await cb.onManualCodeInput!();
+      return { access: `a-${code}`, refresh: 'r', expires: 1 };
+    };
+    const start = await startOAuth('u1', 'claude');
+    mockQuery.mockClear();
+    pollOAuth(start.sessionId, 'u1', 'CODE'); // resolves the deferred
+    cancelOAuth(start.sessionId, 'u1'); // cancel races the in-flight login
+    await tick();
+    // persistProviderOAuth → saveUserProviderKey → exactly one INSERT.
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const sql = mockQuery.mock.calls[0]?.[0] as string;
+    expect(sql).toContain('INSERT INTO remote_agent_user_provider_keys');
+  });
+
+  test('superseded while start is still awaiting the first signal → start throws, not a url-less 200 (S4)', async () => {
+    // First login never signals onAuth; it unblocks only when the supersede
+    // rejects the manual-code deferred.
+    loginImpl = async cb => {
+      await cb.onManualCodeInput!();
+      return { access: 'a' };
+    };
+    const first = startOAuth('u1', 'claude');
+    await tick(1); // let the first session register
+    loginImpl = async cb => {
+      cb.onAuth({ url: 'https://second' });
+      await cb.onManualCodeInput!();
+      return { access: 'a' };
+    };
+    const second = await startOAuth('u1', 'claude');
+    expect(second.url).toBe('https://second');
+    await expect(first).rejects.toThrow(/superseded/i);
   });
 
   test('device-flow logins (no callback server) for different users coexist', async () => {

--- a/packages/core/src/credentials/oauth-bridge.ts
+++ b/packages/core/src/credentials/oauth-bridge.ts
@@ -18,6 +18,18 @@
  * logged. GOTCHA (verify on a live run): Anthropic/Codex `login()` may also try a
  * localhost callback server (`usesCallbackServer`) — on a headless host the
  * manual-code path (`onManualCodeInput`/`onPrompt`) must be the one taken.
+ *
+ * CANCEL SEMANTICS (#1963): pi-ai 0.79.1 ignores `options.signal` in its
+ * callback-server login flows (verified against `dist/utils/oauth/anthropic.js`
+ * — the provider's `login()` doesn't even forward the signal), so aborting the
+ * AbortController alone leaks the fixed-port (53692) callback server forever
+ * and wedges every later login install-wide. The one cancel handle pi exposes
+ * is the `onManualCodeInput()` promise: when it REJECTS, pi's login calls
+ * `server.cancelWait()`, unblocks `waitForCode()`, rethrows, and runs
+ * `finally { server.close() }` — releasing the port. `abortSession` therefore
+ * rejects the bridge-owned `codeDeferred` in addition to firing the abort
+ * signal, and `startOAuth` waits (bounded) for superseded logins to settle
+ * before binding a new one.
  */
 import { randomUUID } from 'node:crypto';
 import { createLogger } from '@archon/paths';
@@ -40,6 +52,38 @@ function getLog(): ReturnType<typeof createLogger> {
 const SESSION_TTL_MS = 10 * 60 * 1000; // 10 minutes
 /** How long `start` waits for the first onAuth/onDeviceCode callback before returning. */
 const START_FIRST_SIGNAL_MS = 8000;
+/**
+ * How long `start` waits for superseded logins to settle (i.e. pi's
+ * `finally { server.close() }` to run) before binding the new login's callback
+ * server. Real unwinds settle in microtasks; this bound only matters for a
+ * login impl that ignores the cancel entirely — it then costs one wait and the
+ * port-busy classification below turns any residual collision into an
+ * actionable error instead of a permanent wedge.
+ */
+const ABORT_SETTLE_MS = 1500;
+
+/** Matches the failure modes of a leaked fixed-port callback server. */
+const PORT_BUSY_RE = /EADDRINUSE|address already in use|is port .+ in use/i;
+
+/**
+ * A subscription-login start failed because the OAuth callback port is still
+ * held (a previous attempt's callback server has not released it yet). Mapped
+ * to a 503 by the API route — retryable, unlike an opaque 500.
+ */
+export class OAuthCallbackPortBusyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OAuthCallbackPortBusyError';
+  }
+}
+
+/** Internal: injected into an aborted session's manual-code deferred (see header). */
+class OAuthLoginAbortedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OAuthLoginAbortedError';
+  }
+}
 
 type OAuthMode = 'manual' | 'device' | 'pending';
 type OAuthStatus = 'pending' | 'connected' | 'error';
@@ -47,13 +91,16 @@ type OAuthStatus = 'pending' | 'connected' | 'error';
 interface Deferred<T> {
   promise: Promise<T>;
   resolve: (v: T) => void;
+  reject: (err: Error) => void;
 }
 function deferred<T>(): Deferred<T> {
   let resolve!: (v: T) => void;
-  const promise = new Promise<T>(res => {
+  let reject!: (err: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
     resolve = res;
+    reject = rej;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 interface OAuthSession {
@@ -70,18 +117,39 @@ interface OAuthSession {
   firstSignal: Deferred<true>;
   abort: AbortController;
   expiresAt: number;
+  /** Resolves when the held `login()` call has settled (never rejects). */
+  settled: Promise<void>;
+  /** Set when `login()` failed because the callback port was already bound. */
+  portBusy?: boolean;
 }
 
 const sessions = new Map<string, OAuthSession>();
 
-function sweepExpired(): void {
+/**
+ * Hard-cancel a session's in-flight `login()`: fire the abort signal (honored
+ * by well-behaved flows) AND reject the manual-code deferred — the only handle
+ * pi-ai 0.79.1 actually reacts to. The rejection drives pi's callback-server
+ * flows through their error path into `finally { server.close() }`, releasing
+ * the fixed callback port (#1963). Rejecting an already-resolved deferred is a
+ * no-op, so this is safe after a code was submitted.
+ */
+function abortSession(session: OAuthSession, reason: string): void {
+  session.abort.abort();
+  session.codeDeferred.reject(new OAuthLoginAbortedError(reason));
+}
+
+/** Abort + drop expired sessions; returns their settled promises so `start` can wait. */
+function sweepExpired(): Promise<void>[] {
   const now = Date.now();
+  const sweptSettled: Promise<void>[] = [];
   for (const [id, s] of sessions) {
     if (now > s.expiresAt) {
-      s.abort.abort();
+      abortSession(s, 'Login session expired.');
+      sweptSettled.push(s.settled);
       sessions.delete(id);
     }
   }
+  return sweptSettled;
 }
 
 /** Internal `'pending'` never surfaces past the boundary — default it to `'manual'`. */
@@ -114,7 +182,9 @@ export interface PollOAuthResult {
  * user-code (device), or a short timeout elapses.
  */
 export async function startOAuth(userId: string, providerId: string): Promise<StartOAuthResult> {
-  sweepExpired();
+  // Expired sessions may also hold a callback server — include them in the
+  // settle-wait below so the port is free before the new login binds it.
+  const supersededSettled: Promise<void>[] = sweepExpired();
   const provider = normalizeCredentialVendor(providerId);
   // SUBSCRIPTION_PROVIDERS is the single source of truth for "connectable via
   // subscription" — it excludes vendors that are wired in ARCHON_TO_PI_OAUTH
@@ -127,14 +197,27 @@ export async function startOAuth(userId: string, providerId: string): Promise<St
   if (!piProvider) {
     throw new Error(`Provider '${providerId}' does not support subscription login.`);
   }
-  // One in-flight login per user — abort a prior session so its callback server
-  // (claude/codex `usesCallbackServer`) is released; otherwise a fixed-port flow
-  // would EADDRINUSE a retry of the same user.
+  // Hard-cancel prior in-flight logins that would collide with this one:
+  //   - same user (one login per user — the original I3 behavior), and
+  //   - same vendor when the flow binds a local fixed-port callback server
+  //     (anthropic: 53692). Two such logins can't coexist in one process, and
+  //     an abandoned one would otherwise EADDRINUSE every later start for ANY
+  //     user until restart (#1963). The newest interactive request wins; a
+  //     superseded session's user sees "session not found" on their next poll
+  //     and can simply restart — recoverable, so the heuristic is acceptable.
   for (const [id, s] of sessions) {
-    if (s.userId === userId) {
-      s.abort.abort();
+    const callbackPortConflict = piProvider.usesCallbackServer === true && s.provider === provider;
+    if (s.userId === userId || callbackPortConflict) {
+      abortSession(s, 'Login superseded by a newer attempt.');
+      supersededSettled.push(s.settled);
       sessions.delete(id);
     }
+  }
+  // Wait (bounded) for the cancelled logins to settle — settling means pi's
+  // `finally { server.close() }` has run, so the callback port is free before
+  // the new login binds it.
+  if (supersededSettled.length > 0) {
+    await Promise.race([Promise.all(supersededSettled), sleep(ABORT_SETTLE_MS)]);
   }
   const sessionId = randomUUID();
   const session: OAuthSession = {
@@ -147,11 +230,15 @@ export async function startOAuth(userId: string, providerId: string): Promise<St
     firstSignal: deferred<true>(),
     abort: new AbortController(),
     expiresAt: Date.now() + SESSION_TTL_MS,
+    settled: Promise.resolve(), // replaced with the real login chain below
   };
+  // Device flows never consume the manual-code deferred — keep its abort-path
+  // rejection from surfacing as an unhandled rejection.
+  session.codeDeferred.promise.catch(() => undefined);
   sessions.set(sessionId, session);
 
   // Kick off login() WITHOUT awaiting — it blocks on the callbacks below.
-  void piProvider
+  session.settled = piProvider
     .login({
       onAuth: (info: OAuthAuthInfo) => {
         session.url = info.url;
@@ -182,14 +269,24 @@ export async function startOAuth(userId: string, providerId: string): Promise<St
       getLog().info({ userId, provider }, 'oauth_bridge.connected');
     })
     .catch((err: unknown) => {
+      // An intentional cancel (supersede / expiry sweep / cancelOAuth) unwinding
+      // through pi's login is expected — log quietly and don't mark error state.
+      if (err instanceof OAuthLoginAbortedError) {
+        session.firstSignal.resolve(true);
+        getLog().info({ userId, provider }, 'oauth_bridge.login_aborted');
+        return;
+      }
+      const rawMessage = err instanceof Error ? err.message : 'OAuth login failed.';
       if (session.status !== 'connected') {
         session.status = 'error';
+        // A leaked callback server from a previous attempt (EADDRINUSE on the
+        // fixed port) is retryable — classify it so start() can surface an
+        // actionable error instead of an opaque failure (#1963).
+        session.portBusy = PORT_BUSY_RE.test(rawMessage);
         // Genericize/strip secrets before this can reach a client: Pi's OAuth errors
         // embed auth-endpoint URLs / HTTP response bodies (login bypasses the
         // getOAuthApiKey wrapper). Truncate too (I4).
-        session.detail = sanitizeCredentials(
-          err instanceof Error ? err.message : 'OAuth login failed.'
-        ).slice(0, 200);
+        session.detail = sanitizeCredentials(rawMessage).slice(0, 200);
       }
       // Unblock start()'s race on an early failure (rejection before any callback),
       // so it doesn't wait the full timeout then return a bogus url-less result (I1).
@@ -207,6 +304,15 @@ export async function startOAuth(userId: string, providerId: string): Promise<St
   // rather than returning a misleading { mode:'manual', url:undefined } (I1).
   if (session.status === 'error') {
     sessions.delete(sessionId);
+    if (session.portBusy) {
+      // Retryable: the cancel above releases the port as soon as the previous
+      // login unwinds (microtasks for pi flows), so "retry shortly" is honest
+      // advice — and a restart always clears it (#1963).
+      throw new OAuthCallbackPortBusyError(
+        `A previous '${provider}' login attempt is still holding the OAuth callback port. ` +
+          'Wait a few seconds and retry; if it persists, restart the Archon server.'
+      );
+    }
     throw new Error(session.detail ?? 'Subscription login failed to start.');
   }
 
@@ -232,7 +338,7 @@ export function pollOAuth(sessionId: string, userId: string, code?: string): Pol
     return { status: 'error', detail: 'Login session not found or expired.' };
   }
   if (Date.now() > session.expiresAt) {
-    session.abort.abort();
+    abortSession(session, 'Login session expired.');
     sessions.delete(sessionId);
     return { status: 'error', detail: 'Login session expired.' };
   }
@@ -261,7 +367,7 @@ export function pollOAuth(sessionId: string, userId: string, code?: string): Pol
 export function cancelOAuth(sessionId: string, userId: string): void {
   const session = sessions.get(sessionId);
   if (session?.userId === userId) {
-    session.abort.abort();
+    abortSession(session, 'Login cancelled.');
     sessions.delete(sessionId);
   }
 }
@@ -272,6 +378,6 @@ function sleep(ms: number): Promise<void> {
 
 /** Test-only: drop all in-flight sessions. */
 export function resetOAuthSessionsForTest(): void {
-  for (const s of sessions.values()) s.abort.abort();
+  for (const s of sessions.values()) abortSession(s, 'Test reset.');
   sessions.clear();
 }

--- a/packages/core/src/credentials/oauth-bridge.ts
+++ b/packages/core/src/credentials/oauth-bridge.ts
@@ -15,21 +15,30 @@
  *     to resolve.
  *
  * Sessions are bound to `userId`, short-TTL, and abortable; credentials are never
- * logged. GOTCHA (verify on a live run): Anthropic/Codex `login()` may also try a
- * localhost callback server (`usesCallbackServer`) — on a headless host the
- * manual-code path (`onManualCodeInput`/`onPrompt`) must be the one taken.
+ * logged. On a headless host the callback-server flows must complete via the
+ * manual-code path (`onManualCodeInput`/`onPrompt`) — nothing can reach their
+ * localhost callback server (see CANCEL SEMANTICS for the abort side of this).
  *
  * CANCEL SEMANTICS (#1963): pi-ai 0.79.1 ignores `options.signal` in its
- * callback-server login flows (verified against `dist/utils/oauth/anthropic.js`
- * — the provider's `login()` doesn't even forward the signal), so aborting the
- * AbortController alone leaks the fixed-port (53692) callback server forever
- * and wedges every later login install-wide. The one cancel handle pi exposes
- * is the `onManualCodeInput()` promise: when it REJECTS, pi's login calls
- * `server.cancelWait()`, unblocks `waitForCode()`, rethrows, and runs
- * `finally { server.close() }` — releasing the port. `abortSession` therefore
- * rejects the bridge-owned `codeDeferred` in addition to firing the abort
- * signal, and `startOAuth` waits (bounded) for superseded logins to settle
- * before binding a new one.
+ * CALLBACK-SERVER login flows — `loginAnthropic` never reads it (verified
+ * against `dist/utils/oauth/anthropic.js`; the provider's `login()` doesn't
+ * even forward the signal) and `loginOpenAICodex`'s browser flow never closes
+ * its server on abort. (`loginGitHubCopilot`, device-code, DOES honor
+ * `callbacks.signal` — the narrow claim matters if you add a provider.) So
+ * aborting the AbortController alone leaks the fixed-port callback server
+ * forever — each flow binds its own fixed port (anthropic 53692, openai-codex
+ * 1455), which is also why the supersede logic below keys on provider
+ * identity — and wedges every later login for that vendor install-wide. The
+ * one cancel handle pi exposes is the `onManualCodeInput()` promise: when it
+ * REJECTS, pi's login calls `server.cancelWait()`, unblocks `waitForCode()`,
+ * rethrows, and runs `finally { server.close() }` — releasing the port.
+ * `abortSession` therefore rejects the bridge-owned `codeDeferred` in
+ * addition to firing the abort signal, and `startOAuth` waits (bounded) for
+ * superseded logins to settle before binding a new one.
+ *
+ * Upstream fix requested: https://github.com/earendil-works/pi/issues/5649
+ * (honor `options.signal` / bind an ephemeral port). Re-evaluate the
+ * deferred-rejection workaround when that lands.
  */
 import { randomUUID } from 'node:crypto';
 import { createLogger } from '@archon/paths';
@@ -117,7 +126,11 @@ interface OAuthSession {
   firstSignal: Deferred<true>;
   abort: AbortController;
   expiresAt: number;
-  /** Resolves when the held `login()` call has settled (never rejects). */
+  /**
+   * Resolves when the held `login()` call has settled. Never rejects: it is
+   * the full `.then().catch()` chain built in `startOAuth`, whose terminal
+   * `.catch()` swallows every failure into session state.
+   */
   settled: Promise<void>;
   /** Set when `login()` failed because the callback port was already bound. */
   portBusy?: boolean;
@@ -127,11 +140,12 @@ const sessions = new Map<string, OAuthSession>();
 
 /**
  * Hard-cancel a session's in-flight `login()`: fire the abort signal (honored
- * by well-behaved flows) AND reject the manual-code deferred — the only handle
- * pi-ai 0.79.1 actually reacts to. The rejection drives pi's callback-server
- * flows through their error path into `finally { server.close() }`, releasing
- * the fixed callback port (#1963). Rejecting an already-resolved deferred is a
- * no-op, so this is safe after a code was submitted.
+ * by the device-code flow) AND reject the manual-code deferred — the only
+ * handle pi-ai 0.79.1's callback-server flows actually react to. The rejection
+ * drives those flows through their error path into `finally { server.close() }`,
+ * releasing the flow's fixed callback port (anthropic 53692, openai-codex
+ * 1455; #1963). Rejecting an already-resolved deferred is a no-op, so this is
+ * safe after a code was submitted.
  */
 function abortSession(session: OAuthSession, reason: string): void {
   session.abort.abort();
@@ -316,6 +330,14 @@ export async function startOAuth(userId: string, providerId: string): Promise<St
     throw new Error(session.detail ?? 'Subscription login failed to start.');
   }
 
+  // Superseded (or cancelled) while still waiting for the first signal — the
+  // session is already gone from the map, so a 200 here would hand back a
+  // url-less session the first poll immediately reports as "not found".
+  // Throw the honest answer instead (S4).
+  if (!sessions.has(sessionId)) {
+    throw new Error('Login attempt was superseded by a newer one. Retry to start a fresh login.');
+  }
+
   return {
     sessionId,
     mode: externalMode(session),
@@ -332,7 +354,10 @@ export async function startOAuth(userId: string, providerId: string): Promise<St
  * success, `error` on failure/expiry, else `pending`.
  */
 export function pollOAuth(sessionId: string, userId: string, code?: string): PollOAuthResult {
-  sweepExpired(); // I3: don't leave abandoned sessions (and their callback servers) holding on
+  // I3: don't leave abandoned sessions (and their callback servers) holding on.
+  // `void`: poll has no reason to await port release — only `start` (which is
+  // about to bind the port) waits on the swept sessions' settle promises.
+  void sweepExpired();
   const session = sessions.get(sessionId);
   if (session?.userId !== userId) {
     return { status: 'error', detail: 'Login session not found or expired.' };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -215,6 +215,7 @@ export {
   startOAuth,
   pollOAuth,
   cancelOAuth,
+  OAuthCallbackPortBusyError,
   type ResolvedCredential,
   type DeliveryResult,
   type DeliveryOptions,

--- a/packages/server/src/routes/api.provider-keys.test.ts
+++ b/packages/server/src/routes/api.provider-keys.test.ts
@@ -78,6 +78,15 @@ class InvalidProviderKeyError extends Error {
   }
 }
 
+// Mirror core's retryable port-wedge error so the oauth/start route's
+// `instanceof` check (actionable 503 vs opaque 500) is exercised (#1963).
+class OAuthCallbackPortBusyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OAuthCallbackPortBusyError';
+  }
+}
+
 let keysEnabled = true;
 let savedKeys: { userId: string; provider: string; apiKey: string; label: string | null }[] = [];
 
@@ -148,6 +157,7 @@ mock.module('@archon/core', () => ({
   SUBSCRIPTION_PROVIDERS: SUBSCRIPTION,
   startOAuth: mockStartOAuth,
   pollOAuth: mockPollOAuth,
+  OAuthCallbackPortBusyError,
 }));
 
 mock.module('@archon/paths', () => ({
@@ -507,6 +517,23 @@ describe('POST /api/auth/providers/:provider/oauth/start', () => {
     });
     expect(res.status).toBe(500);
     expect(await res.text()).not.toContain('53999');
+  });
+
+  test('held callback port → 503 with the actionable message (#1963)', async () => {
+    mockStartOAuth.mockRejectedValueOnce(
+      new OAuthCallbackPortBusyError(
+        "A previous 'anthropic' login attempt is still holding the OAuth callback port. " +
+          'Wait a few seconds and retry; if it persists, restart the Archon server.'
+      )
+    );
+    const res = await makeApp().request('/api/auth/providers/claude/oauth/start', {
+      method: 'POST',
+      headers: ALICE,
+    });
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('callback port');
+    expect(body.error).toContain('retry');
   });
 
   test('no identity → 401', async () => {

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -50,6 +50,7 @@ import {
   SUBSCRIPTION_PROVIDERS,
   startOAuth,
   pollOAuth,
+  OAuthCallbackPortBusyError,
   getUserAiPrefs,
   setUserTiers,
   setUserAliases,
@@ -1144,6 +1145,7 @@ const providerOAuthStartRoute = createRoute({
     400: jsonError('Provider does not support subscription login'),
     401: jsonError('Web auth required (X-Archon-User header missing)'),
     404: jsonError('Per-user provider keys not enabled on this install'),
+    503: jsonError('OAuth callback port still held by a previous login attempt — retry shortly'),
   },
 });
 
@@ -1687,6 +1689,11 @@ export function registerApiRoutes(
         { err: err as Error, userId: web.userId, provider },
         'auth.provider_oauth_start_failed'
       );
+      // A leaked callback port from a previous attempt is retryable — surface
+      // the actionable message as a 503 instead of an opaque 500 (#1963).
+      if (err instanceof OAuthCallbackPortBusyError) {
+        return apiError(c, 503, err.message);
+      }
       return apiError(c, 500, 'Failed to start subscription login');
     }
   });

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -1685,15 +1685,19 @@ export function registerApiRoutes(
       const start = await startOAuth(web.userId, provider);
       return c.json(start);
     } catch (err) {
+      // A leaked callback port from a previous attempt is an expected,
+      // retryable condition — log it at warn under its own event (an
+      // error-level `…_failed` would pollute error dashboards on multi-user
+      // installs) and surface the actionable message as a 503 instead of an
+      // opaque 500 (#1963).
+      if (err instanceof OAuthCallbackPortBusyError) {
+        getLog().warn({ userId: web.userId, provider }, 'auth.provider_oauth_start_port_busy');
+        return apiError(c, 503, err.message);
+      }
       getLog().error(
         { err: err as Error, userId: web.userId, provider },
         'auth.provider_oauth_start_failed'
       );
-      // A leaked callback port from a previous attempt is retryable — surface
-      // the actionable message as a 503 instead of an opaque 500 (#1963).
-      if (err instanceof OAuthCallbackPortBusyError) {
-        return apiError(c, 503, err.message);
-      }
       return apiError(c, 500, 'Failed to start subscription login');
     }
   });


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: an abandoned anthropic subscription login wedged pi-ai's fixed-port (53692) OAuth callback server install-wide — every later anthropic OAuth start (any user) failed with an opaque `500 Failed to start subscription login` until process restart (#1963).
- Why it matters: on multi-user installs one abandoned login bricks subscription connect for everyone; severity rises now that the console credential cards (#1962) make login discoverable.
- What changed: the bridge now hard-cancels abandoned logins through the one handle pi-ai 0.79.1 actually reacts to — rejecting the bridge-owned `onManualCodeInput()` deferred — which drives pi's login through `finally { server.close() }` and releases the port. Cancellation runs on every abort path (same-user restart, cross-user supersede for callback-server vendors, expiry sweep, explicit cancel). Residual port collisions are classified into a typed `OAuthCallbackPortBusyError` with an actionable message, mapped to 503 by the route.
- What did **not** change (scope boundary): the login UX (start/poll contract), the persisted credential shape, the device-code (Copilot) flow, and pi-ai itself (upstream issue filed: https://github.com/earendil-works/pi/issues/5649). The openai/ChatGPT gate (#1924) is untouched here — lifted in the stacked follow-up PR.

## UX Journey

### Before

```
  User A                  Archon bridge                pi-ai loginAnthropic
  ──────                  ─────────────                ────────────────────
  start login ──────────▶ login() kicked ────────────▶ binds 127.0.0.1:53692
  abandons (closes tab)   abort()/sweep fires          ignores options.signal
                                                       port 53692 stays LISTEN forever
  User B
  start login ──────────▶ login() kicked ────────────▶ EADDRINUSE 53692
  sees opaque 500 ◀────── "Failed to start subscription login"
  (wedged until Archon restarts)
```

### After

```
  User A                  Archon bridge                pi-ai loginAnthropic
  ──────                  ─────────────                ────────────────────
  start login ──────────▶ login() kicked ────────────▶ binds 127.0.0.1:53692
  abandons (closes tab)
  User B
  start login ──────────▶ [abortSession: rejects the
                           manual-code deferred] ────▶ login unwinds →
                          [waits (≤1.5s) for the       finally { server.close() }
                           old login to settle]        port released
                          login() kicked ────────────▶ binds 53692 cleanly
  sees authorize URL ◀─── normal manual flow
  (worst case — a flow that ignores the cancel: B gets an actionable
   *503 "callback port still held … retry shortly"* instead of an opaque 500)
```

## Architecture Diagram

### Before

```
  routes/api.ts ──▶ oauth-bridge.ts ──▶ @archon/providers/oauth ──▶ pi-ai login()
                       │ abort.abort()  (signal dropped by pi)        │
                       └── sweepExpired (same: signal only)           └── fixed-port callback server (leaks)
```

### After

```
  routes/api.ts ──▶ [~] oauth-bridge.ts ──▶ @archon/providers/oauth ──▶ pi-ai login()
    │ [~] maps          │ [~] abortSession = abort.abort()               │
    │  OAuthCallback-   │     + codeDeferred.reject() ═══════════════════╡ rejection unwinds login →
    │  PortBusyError    │ [~] supersede same-vendor callback-server        finally { server.close() }
    │  → 503            │     sessions (any user) + bounded settle-wait
                        │ [~] EADDRINUSE classification → typed error
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `server/routes/api.ts` | `core/credentials/oauth-bridge.ts` | **modified** | catches `OAuthCallbackPortBusyError` → 503 (was always opaque 500) |
| `core/credentials/oauth-bridge.ts` | `@archon/providers/oauth` (pi-ai `login()`) | **modified** | cancel now also rejects the `onManualCodeInput` deferred; tracks login settlement |
| `core/credentials/oauth-bridge.ts` | `core/credentials/connect-service.ts` | unchanged | `persistProviderOAuth` on success |
| `core/index.ts` / `credentials/index.ts` | `oauth-bridge.ts` | **modified** | export `OAuthCallbackPortBusyError` |

## Label Snapshot

- Risk: `risk: medium`
- Size: `size: S`
- Scope: `core|server`
- Module: `core:credentials`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #1963
- Related #1954, #1924, #1958

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # green (check:bundled, check:bundled-skill, check:bundled-schema,
                   #        type-check, lint, format:check, tests — all pass)
```

- Evidence provided (test/log/trace/screenshot): 5 new regression tests in `oauth-bridge.test.ts` (pi-style finally-close release on cancel; cross-user supersede for callback-server vendors; device-flow coexistence; a login impl that ignores the cancel entirely cannot permanently break later starts; EADDRINUSE → typed actionable error) + a 503 route test in `api.provider-keys.test.ts`.
- If any command is intentionally skipped, explain why: live VPS repro of the wedge not re-run in this PR — the cancel semantics are verified against pi-ai 0.79.1 source (`dist/utils/oauth/anthropic.js`); a live smoke is planned with the stacked #1924 PR's post-merge VPS round.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`) — error details still pass through `sanitizeCredentials` before reaching a client; the 503 message is a fixed string with no internal detail.
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation: n/a

## Compatibility / Migration

- Backward compatible? (`Yes`) — start/poll API shapes unchanged; one additive 503 response on `/oauth/start`.
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: n/a

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: read pi-ai 0.79.1 `anthropic.js`/`openai-codex.js` line-by-line to confirm (a) `options.signal` is never honored in the callback-server flows, and (b) rejecting `onManualCodeInput()` deterministically reaches `finally { server.close() }`. Full test suite locally.
- Edge cases checked: abort before pi calls `onManualCodeInput` (pre-rejected deferred still unwinds when pi later subscribes); device-flow sessions are not superseded cross-user (no callback server, no conflict); deferred rejection after a code was submitted is a no-op.
- What was not verified: a live abandoned-login → second-user retry on the VPS (planned post-merge smoke); the close-vs-listen kernel race on an immediate same-port rebind (mitigated by the bounded settle-wait + the retryable 503 fallback).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: subscription login only (web route + `archon ai login`). Credential storage/refresh/delivery untouched.
- Potential unintended effects: a user actively mid-login can be superseded by another user starting a login for the same callback-server vendor — they see "session not found" on the next poll and restart. Deliberate trade-off: the abandoned-login case is far more common than two simultaneous logins, the operation is fully recoverable, and the alternative is a guaranteed failure for the second user.
- Guardrails/monitoring for early detection: new `oauth_bridge.login_aborted` info log; `oauth_bridge.login_failed` warn retains the raw (sanitized) error; port-busy starts log + surface distinctly.

## Rollback Plan (required)

- Fast rollback command/path: `git revert` of this single commit — no schema/config coupling.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: anthropic `/oauth/start` returning 500/503 repeatedly; `oauth_bridge.login_failed` with EADDRINUSE in logs.

## Risks and Mitigations

- Risk: the cancel lever depends on pi's internal manual-input race (rejecting `onManualCodeInput()`), an implementation detail that could change in a pi upgrade.
  - Mitigation: regression test mirrors pi's exact structure and fails if the contract shifts; upstream issue https://github.com/earendil-works/pi/issues/5649 asks for first-class `options.signal` support; worst case degrades to the bounded settle-wait + actionable 503, never a silent wedge.
- Risk: close-vs-listen race when a new login rebinds the port immediately after supersede.
  - Mitigation: bounded settle-wait (`ABORT_SETTLE_MS`) before binding + EADDRINUSE classified as retryable 503 with honest guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a retryable callback-port error that surfaces actionable guidance when the OAuth callback port is busy.

* **Bug Fixes**
  * OAuth cancellation and supersession now reliably release held callback ports to avoid wedging.
  * Server endpoint returns HTTP 503 with a descriptive message for callback-port conflicts instead of a generic failure.

* **Tests**
  * Expanded OAuth tests to cover callback-port, cancellation, supersession, and regression scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->