### PR TITLE
fix(console): surface late-arriving OAuth signals in the subscription login panel

### DIFF
--- a/packages/web/src/experiments/console/components/SubscriptionLoginFlow.tsx
+++ b/packages/web/src/experiments/console/components/SubscriptionLoginFlow.tsx
@@ -4,6 +4,7 @@ import type { ProviderOAuthStart } from '../skills';
 import { invalidate } from '../store/cache';
 import { K } from '../store/keys';
 import { normalizeOAuthCode } from '../lib/oauth-code';
+import { mergeOAuthSignals } from '../lib/oauth-flow';
 import { useCancelledRef } from '../lib/use-cancelled-ref';
 
 type Phase = 'starting' | 'manual' | 'device' | 'error';
@@ -66,6 +67,14 @@ export function SubscriptionLoginFlow({
           pendingCodeRef.current = undefined;
           const res = await skill.pollProviderOAuth(provider, sessionId, submit);
           if (stale()) return;
+          // The authorize URL / device code can arrive via POLL rather than
+          // start (supersede latency) — merge late signals or the manual
+          // panel stays linkless forever while polling "pending".
+          setStart(prev => (prev ? mergeOAuthSignals(prev, res) : prev));
+          const polledMode = res.mode;
+          if (polledMode) {
+            setPhase(p => (p === 'error' ? p : polledMode));
+          }
           if (res.status === 'connected') {
             invalidate(K.providerConnections);
             onDoneRef.current();
@@ -146,6 +155,13 @@ export function SubscriptionLoginFlow({
             {start.userCode}
           </span>
           <span className="ml-2 text-text-tertiary">(polling…)</span>
+        </span>
+      ) : null}
+
+      {phase === 'manual' && !start?.url ? (
+        <span className="text-text-tertiary">
+          Waiting for the authorization link… (the provider flow is starting; this can take a few
+          seconds when a previous attempt was just cancelled)
         </span>
       ) : null}
 

--- a/packages/web/src/experiments/console/lib/oauth-flow.test.ts
+++ b/packages/web/src/experiments/console/lib/oauth-flow.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+import { mergeOAuthSignals } from './oauth-flow';
+import type { ProviderOAuthPoll, ProviderOAuthStart } from '../skills';
+
+function start(overrides: Partial<ProviderOAuthStart> = {}): ProviderOAuthStart {
+  return { sessionId: 's1', mode: 'manual', expiresIn: 600, ...overrides };
+}
+
+describe('mergeOAuthSignals', () => {
+  test('adopts a late-arriving manual URL from the poll response', () => {
+    // The VPS bug: start raced past pi's onAuth (supersede latency), so the
+    // URL only ever appeared in poll responses — and was dropped.
+    const merged = mergeOAuthSignals(start(), {
+      status: 'pending',
+      mode: 'manual',
+      url: 'https://claude.ai/oauth/authorize?x=1',
+    });
+    expect(merged.url).toBe('https://claude.ai/oauth/authorize?x=1');
+    expect(merged.mode).toBe('manual');
+  });
+
+  test('adopts late device-flow signals (userCode + verificationUri + mode flip)', () => {
+    const merged = mergeOAuthSignals(start({ mode: 'manual' }), {
+      status: 'pending',
+      mode: 'device',
+      userCode: 'WXYZ-1234',
+      verificationUri: 'https://github.com/login/device',
+    });
+    expect(merged.mode).toBe('device');
+    expect(merged.userCode).toBe('WXYZ-1234');
+    expect(merged.verificationUri).toBe('https://github.com/login/device');
+  });
+
+  test('start-provided signals win over poll values (no flapping)', () => {
+    const s = start({ url: 'https://claude.ai/oauth/authorize?orig=1' });
+    const merged = mergeOAuthSignals(s, {
+      status: 'pending',
+      url: 'https://claude.ai/oauth/authorize?other=2',
+    });
+    expect(merged.url).toBe('https://claude.ai/oauth/authorize?orig=1');
+  });
+
+  test('returns the SAME reference when the poll adds nothing (render stability)', () => {
+    const s = start({ url: 'https://claude.ai/oauth/authorize?x=1' });
+    const noNews: ProviderOAuthPoll = { status: 'pending' };
+    expect(mergeOAuthSignals(s, noNews)).toBe(s);
+    // status-only churn never produces a new object
+    expect(mergeOAuthSignals(s, { status: 'pending', mode: 'manual' })).toBe(s);
+  });
+});

--- a/packages/web/src/experiments/console/lib/oauth-flow.ts
+++ b/packages/web/src/experiments/console/lib/oauth-flow.ts
@@ -1,0 +1,33 @@
+import type { ProviderOAuthPoll, ProviderOAuthStart } from '../skills';
+
+/**
+ * Merge late-arriving OAuth signals from a poll response into the start
+ * state. The bridge returns `url`/`userCode` from START only when the
+ * provider's first callback fires within start's bounded wait; when a start
+ * supersedes a prior session (extra settle latency) the signals arrive via
+ * POLL instead — the poll response carries optional `mode`/`url`/`userCode`/
+ * `verificationUri` for exactly this case. Ignoring them leaves the manual
+ * panel rendered with no authorization link forever (the bug behind the
+ * "endless polling, no link" report on the VPS).
+ *
+ * Returns the same reference when the poll adds nothing new, so callers can
+ * use it directly in a state setter without redundant re-renders.
+ */
+export function mergeOAuthSignals(
+  start: ProviderOAuthStart,
+  poll: ProviderOAuthPoll
+): ProviderOAuthStart {
+  const url = start.url ?? poll.url;
+  const mode = poll.mode ?? start.mode;
+  const userCode = start.userCode ?? poll.userCode;
+  const verificationUri = start.verificationUri ?? poll.verificationUri;
+  if (
+    url === start.url &&
+    mode === start.mode &&
+    userCode === start.userCode &&
+    verificationUri === start.verificationUri
+  ) {
+    return start;
+  }
+  return { ...start, url, mode, userCode, verificationUri };
+}


### PR DESCRIPTION
## Summary

- Problem: clicking Login on a credential row often shows a panel with **no authorization link, forever**, while the poll counter climbs every 2s. Reported live on the VPS for both the anthropic and openai rows during the #1954 final verification.
- Why it matters: the subscription login flow is the epic's flagship UX; in the common repeated-click / just-cancelled case it dead-ends with zero feedback.
- What changed: `SubscriptionLoginFlow.pollLoop` now merges the poll response's late-arriving `mode`/`url`/`userCode`/`verificationUri` into state (pure `mergeOAuthSignals` helper, same-reference stable), and the manual phase renders an explicit "Waiting for the authorization link…" state instead of a silent blank.
- What did **not** change (scope boundary): no server changes — the bridge already returned the signals via poll by design (verified healthy live: fresh start returns the URL instantly; the supersede path defers it to poll). No change to cancel semantics (unmount already stops the loop within one 2s tick; the live "cancel doesn't stop it" observation was a second flow instance open on another card).

## Root cause

The bridge's start waits a bounded interval for the provider's first callback; a start that supersedes a prior session (settle wait + provider spin-up) regularly misses that window, so `start.url` is undefined and the URL ships in subsequent poll responses — which the component discarded, reading only `res.status`. The component docstring even claimed it handled this case; now it does.

## UX Journey

### Before

```
User                       Console                          Bridge
────                       ───────                          ──────
clicks Login ────────────▶ start → {sessionId, mode, url: undefined (superseded start)}
                           renders heading + Cancel, NO link
                           poll every 2s ──────────────────▶ {pending, url: <ready!>}
                           ignores res.url — blank forever  ⟲
gives up / clicks again ─▶ supersedes again → same dead end
```

### After

```
clicks Login ────────────▶ start → url undefined
                           renders ["Waiting for the authorization link…"]
                           poll ───────────────────────────▶ {pending, url: claude.ai/…}
                           [merges signals → link renders]
opens link, authorizes, pastes code ─▶ connected ✓
```

## Validation Evidence

```bash
bun run validate   # exit 0
bun test src/experiments/console/lib/oauth-flow.test.ts  # 4 pass
```

## Linked Issue

- Related #1954, #1962 (introduced the reworked panel), #1973 (openai flow it also affects)

## Security Impact

- No. UI-only; renders data the API already returned to the same caller.

## Compatibility / Migration

- Backward compatible: Yes. No API/config/DB changes.

## Human Verification

- Verified the exact failure live on the VPS first (server healthy: fresh `oauth/start` returns the URL; poll carries `url` — component dropped it).
- Not verified: completed end-to-end subscription login (bot-wall gated — pending Rasmus's manual authorize; this fix is the blocker he hit).

## Side Effects / Blast Radius

- Affected: console subscription login panel only.
- Guardrail: merge helper returns the same reference when polls add nothing → no re-render churn from status-only polls.

## Rollback Plan

- Revert the single commit; behavior returns to start-response-only rendering.

## Risks and Mitigations

- Risk: a poll-delivered mode flip fighting the start mode. Mitigation: poll `mode` only overwrites non-error phases; start-provided values win over poll values for url/codes (tested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved OAuth authorization flow to handle authorization URLs and device codes that arrive via polling rather than the initial response.
  * Added wait state in manual authorization mode.

* **Tests**
  * Added comprehensive test coverage for OAuth signal merging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->