### PR TITLE
fix(web): stop duplicate assistant replies in chat (#1972)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with a clear error: `"Node '<id>' timed out with no output … Consider increasing idle_timeout or
   reducing prompt size."` Nodes that do produce output before the subprocess hangs still complete
   with a warning, unchanged (#1807).
+- **Duplicate assistant replies in the web chat are fixed.** Tool-less replies (e.g. "hi")
+  could render twice: a stale-`messagesRef` race in `onLockChange` triggered a spurious REST
+  refetch whose freshly-persisted DB row coexisted with the SSE-streamed copy (SSE synthetic
+  ids never match DB UUIDs, so id-based dedupe missed it). The recovery refetch is now gated on
+  `isSendInFlight()` so it only fires when streamed text genuinely never arrived, and both
+  history merges drop client-only assistant messages whose content the DB already returned (#1972).
 
 ## [0.4.1] - 2026-05-28
 

--- a/packages/web/src/components/chat/ChatInterface.tsx
+++ b/packages/web/src/components/chat/ChatInterface.tsx
@@ -28,7 +28,11 @@ import type {
   ErrorDisplay,
   WorkflowDispatchEvent,
 } from '@/lib/types';
-import { applyOnText } from '@/lib/chat-message-reducer';
+import {
+  applyOnText,
+  mergeHydratedHistory,
+  mergeRecoveredHistory,
+} from '@/lib/chat-message-reducer';
 import { applySystemStatus } from '@/lib/system-status-reducer';
 import {
   getCachedMessages,
@@ -162,33 +166,7 @@ export function ChatInterface({ conversationId }: ChatInterfaceProps): React.Rea
         // Uses a module-level flag (isSendInFlight) rather than a component ref
         // because navigate() after new-chat creation causes a full remount, and
         // refs don't survive across mount boundaries.
-        setMessages(prev => {
-          if (prev.length === 0) {
-            return hydrated;
-          }
-          const sendActive = isSendInFlight();
-          // Preserve SSE-only messages: streaming text OR messages with tool calls not yet in DB.
-          // Tool-call messages keep isStreaming:true while the stream is active so the
-          // loading indicator persists; the toolCalls clause below ensures they also
-          // survive hydration regardless of isStreaming state.
-          // Note: dedup below relies on SSE messages using 'msg-{timestamp}' IDs that
-          // never match DB-assigned IDs. Keep SSE IDs synthetic to preserve this invariant.
-          const activeSSE = prev.filter(
-            m =>
-              m.role === 'system' ||
-              (m.isStreaming && (m.content || sendActive)) ||
-              (m.toolCalls && m.toolCalls.length > 0)
-          );
-          if (activeSSE.length === 0) return hydrated;
-          // Merge: DB is canonical, append SSE-only messages that aren't yet in DB.
-          // Identify which SSE messages are already covered by hydrated DB data to avoid dupes.
-          const hydratedIds = new Set(hydrated.map(m => m.id));
-          const sseOnly = activeSSE.filter(m => !hydratedIds.has(m.id));
-          if (sseOnly.length === 0) return hydrated;
-          const merged = [...hydrated, ...sseOnly];
-          merged.sort((a, b) => a.timestamp - b.timestamp);
-          return merged;
-        });
+        setMessages(prev => mergeHydratedHistory(prev, hydrated, isSendInFlight()));
         setHasSentMessage(true);
       })
       .catch((e: unknown) => {
@@ -407,6 +385,14 @@ export function ChatInterface({ conversationId }: ChatInterfaceProps): React.Rea
     setQueuePosition(position);
     if (!isLocked) {
       const now = Date.now();
+      // Capture BEFORE clearing: isSendInFlight() is true only when no SSE text
+      // has arrived for the in-flight send (onText clears it synchronously on the
+      // first text event, even before React re-renders). This is what makes the
+      // stuck-placeholder check below immune to the stale-messagesRef race: when
+      // the final text event and conversation_lock:false arrive in the same SSE
+      // burst, messagesRef still shows an empty placeholder, but sendStillInFlight
+      // is already false — so we don't spuriously refetch and duplicate the reply.
+      const sendStillInFlight = isSendInFlight();
       // AI processing is done (lock released) — always clear the sendInFlight guard.
       // This must be unconditional: if it's only cleared inside hasStuckPlaceholder,
       // the flag stays true after workflow dispatches (where the placeholder is replaced
@@ -420,7 +406,8 @@ export function ChatInterface({ conversationId }: ChatInterfaceProps): React.Rea
       // the lock-release event is received. We detect this race and re-fetch via REST.
       // Read current messages from ref (stable closure-safe snapshot) to avoid
       // side effects inside the state updater (which React may call twice in StrictMode).
-      const hasStuckPlaceholder = messagesRef.current.some(m => m.isStreaming && !m.content);
+      const hasStuckPlaceholder =
+        sendStillInFlight && messagesRef.current.some(m => m.isStreaming && !m.content);
       setMessages(prev =>
         prev.map(msg => {
           const needsToolFix = msg.toolCalls?.some(tc => !tc.output && tc.duration === undefined);
@@ -449,32 +436,7 @@ export function ChatInterface({ conversationId }: ChatInterfaceProps): React.Rea
             const hydrated = rows.map(mapMessageRow);
             // Merge hydrated DB messages with client-only state (system, live SSE) to
             // avoid losing messages that exist only on the client.
-            setMessages(prev => {
-              const hydratedIds = new Set(hydrated.map(m => m.id));
-              // Keep only meaningful client-only messages not present in hydrated set.
-              // Exclude optimistic user rows and empty thinking placeholders.
-              const clientOnly = prev.filter(m => {
-                if (hydratedIds.has(m.id)) return false;
-                if (m.role === 'system') return true;
-                if (m.role !== 'assistant') return false;
-                return (
-                  Boolean(m.content) ||
-                  Boolean(m.error) ||
-                  Boolean(m.workflowDispatch) ||
-                  Boolean(m.workflowResult) ||
-                  Boolean(m.toolCalls?.length)
-                );
-              });
-              if (clientOnly.length === 0) return hydrated;
-              // Interleave client-only messages at their original positions by timestamp
-              const merged = [...hydrated];
-              for (const msg of clientOnly) {
-                const insertIdx = merged.findIndex(m => m.timestamp > msg.timestamp);
-                if (insertIdx === -1) merged.push(msg);
-                else merged.splice(insertIdx, 0, msg);
-              }
-              return merged;
-            });
+            setMessages(prev => mergeRecoveredHistory(prev, hydrated));
           })
           .catch((err: unknown) => {
             console.error(

--- a/packages/web/src/lib/chat-message-reducer.test.ts
+++ b/packages/web/src/lib/chat-message-reducer.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { applyOnText } from './chat-message-reducer';
+import { applyOnText, mergeHydratedHistory, mergeRecoveredHistory } from './chat-message-reducer';
 import type { ChatMessage, ToolCallDisplay } from './types';
 
 // Helpers
@@ -190,5 +190,158 @@ describe('applyOnText — workflow-result (Rule 1)', () => {
     // Same runId already in state — no new message added
     expect(result).toHaveLength(1);
     expect(result).toBe(prev); // reference equality: same array returned
+  });
+});
+// ---------------------------------------------------------------------------
+// mergeRecoveredHistory — regression for #1972 (duplicate assistant replies)
+// ---------------------------------------------------------------------------
+
+function makeUser(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: `user-${String(++idCounter)}`,
+    role: 'user',
+    content: 'hi',
+    timestamp: NOW,
+    ...overrides,
+  };
+}
+
+function makeHydrated(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: crypto.randomUUID(),
+    role: 'assistant',
+    content: '',
+    timestamp: NOW,
+    isStreaming: false,
+    toolCalls: [],
+    ...overrides,
+  };
+}
+
+describe('mergeRecoveredHistory', () => {
+  test('drops the persisted streamed copy (#1972 scenario)', () => {
+    const content = "Hi! I'm Archon, your AI assistant.";
+    const prev: ChatMessage[] = [
+      makeUser({ id: 'user-synth', timestamp: 999 }),
+      makeAssistant({ id: 'assistant-synth', content, isStreaming: false, timestamp: 1000 }),
+    ];
+    const hydrated: ChatMessage[] = [
+      makeUser({ id: 'user-db', timestamp: 999 }),
+      makeHydrated({ content, timestamp: 9000 }),
+    ];
+
+    const result = mergeRecoveredHistory(prev, hydrated);
+
+    expect(result).toHaveLength(2);
+    expect(result.filter(m => m.role === 'assistant')).toHaveLength(1);
+    expect(result.find(m => m.role === 'assistant')?.content).toBe(content);
+    expect(result.find(m => m.role === 'assistant')?.id).not.toBe('assistant-synth');
+  });
+
+  test('keeps distinct client-only content interleaved by timestamp', () => {
+    const prev: ChatMessage[] = [
+      makeUser({ id: 'u1', timestamp: 100 }),
+      makeAssistant({ id: 'a-synth', content: 'client-only', isStreaming: false, timestamp: 200 }),
+    ];
+    const hydrated: ChatMessage[] = [
+      makeUser({ id: 'u-db', timestamp: 100 }),
+      makeHydrated({ content: 'db-reply', timestamp: 300 }),
+    ];
+
+    const result = mergeRecoveredHistory(prev, hydrated);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].role).toBe('user');
+    expect(result[1].content).toBe('client-only');
+    expect(result[2].content).toBe('db-reply');
+  });
+
+  test('keeps system messages even when content matches a hydrated row', () => {
+    const content = 'System announcement';
+    const prev: ChatMessage[] = [{ id: 'sys-1', role: 'system', content, timestamp: NOW }];
+    const hydrated: ChatMessage[] = [makeHydrated({ content, timestamp: NOW + 1 })];
+
+    const result = mergeRecoveredHistory(prev, hydrated);
+
+    expect(result).toHaveLength(2);
+    expect(result.some(m => m.role === 'system')).toBe(true);
+  });
+
+  test('keeps error-bearing messages even when content matches a hydrated row', () => {
+    const content = 'Error happened';
+    const prev: ChatMessage[] = [
+      makeAssistant({
+        id: 'a-err',
+        content,
+        isStreaming: false,
+        timestamp: NOW,
+        error: { message: 'Oops', classification: 'transient', suggestedActions: [] },
+      }),
+    ];
+    const hydrated: ChatMessage[] = [makeHydrated({ content, timestamp: NOW + 1 })];
+
+    const result = mergeRecoveredHistory(prev, hydrated);
+
+    expect(result).toHaveLength(2);
+    expect(result.some(m => m.error !== undefined)).toBe(true);
+  });
+});
+
+describe('mergeHydratedHistory', () => {
+  test('returns hydrated when prev is empty', () => {
+    const hydrated: ChatMessage[] = [makeHydrated({ content: 'hello', timestamp: NOW })];
+
+    const result = mergeHydratedHistory([], hydrated, false);
+
+    expect(result).toEqual(hydrated);
+  });
+
+  test('preserves an empty streaming placeholder when sendActive is true', () => {
+    const prev: ChatMessage[] = [
+      makeUser({ id: 'u1', timestamp: 100 }),
+      makeAssistant({ id: 'thinking-1', content: '', timestamp: 200 }),
+    ];
+    const hydrated: ChatMessage[] = [makeUser({ id: 'u-db', timestamp: 100 })];
+
+    const result = mergeHydratedHistory(prev, hydrated, true);
+
+    expect(result).toHaveLength(2);
+    expect(result.some(m => m.id === 'thinking-1')).toBe(true);
+  });
+
+  test('drops a streaming message whose content already matches a hydrated assistant row', () => {
+    const content = 'already flushed';
+    const prev: ChatMessage[] = [
+      makeUser({ id: 'u1', timestamp: 100 }),
+      makeAssistant({ id: 'a-synth', content, isStreaming: true, timestamp: 200 }),
+    ];
+    const hydrated: ChatMessage[] = [
+      makeUser({ id: 'u-db', timestamp: 100 }),
+      makeHydrated({ content, timestamp: 200 }),
+    ];
+
+    const result = mergeHydratedHistory(prev, hydrated, false);
+
+    expect(result).toHaveLength(2);
+    expect(result.filter(m => m.role === 'assistant')).toHaveLength(1);
+    expect(result.find(m => m.role === 'assistant')?.id).not.toBe('a-synth');
+  });
+
+  test('keeps tool-call messages with empty content (not falsely deduped)', () => {
+    const prev: ChatMessage[] = [
+      makeAssistant({
+        id: 'a-tool',
+        content: '',
+        isStreaming: true,
+        timestamp: 200,
+        toolCalls: [makeToolCall()],
+      }),
+    ];
+    const hydrated: ChatMessage[] = [makeHydrated({ content: 'db-reply', timestamp: 100 })];
+
+    const result = mergeHydratedHistory(prev, hydrated, false);
+
+    expect(result).toHaveLength(2);
+    expect(result.some(m => m.id === 'a-tool')).toBe(true);
   });
 });

--- a/packages/web/src/lib/chat-message-reducer.ts
+++ b/packages/web/src/lib/chat-message-reducer.ts
@@ -104,3 +104,95 @@ export function applyOnText(
   // Rule 6: no active streaming assistant message → create a new one.
   return [...prev, makeStreamingMessage(makeId(), content, now, true)];
 }
+/**
+ * Drops client-only assistant messages whose content already exists in the
+ * hydrated DB set. SSE message IDs are synthetic and never match DB UUIDs,
+ * so id-based deduplication alone cannot catch an already-persisted streamed
+ * reply.
+ */
+function dropHydratedContentDuplicates(
+  clientOnly: ChatMessage[],
+  hydrated: ChatMessage[]
+): ChatMessage[] {
+  const hydratedAssistantContents = new Set(
+    hydrated.filter(m => m.role === 'assistant' && m.content).map(m => m.content)
+  );
+  return clientOnly.filter(
+    m =>
+      !(
+        m.role === 'assistant' &&
+        m.content !== '' &&
+        m.error === undefined &&
+        hydratedAssistantContents.has(m.content)
+      )
+  );
+}
+
+/**
+ * Merge REST-hydrated history into the current list on mount.
+ * DB is canonical; keeps client-only messages that are still live
+ * (system, streaming-with-content, tool calls). Drops client copies whose
+ * content the DB already returned (SSE ids never match DB UUIDs, so id-based
+ * dedupe alone cannot catch an already-persisted streamed reply).
+ */
+export function mergeHydratedHistory(
+  prev: ChatMessage[],
+  hydrated: ChatMessage[],
+  sendActive: boolean
+): ChatMessage[] {
+  if (prev.length === 0) {
+    return hydrated;
+  }
+  // Preserve SSE-only messages: streaming text OR messages with tool calls not yet in DB.
+  // Tool-call messages keep isStreaming:true while the stream is active so the
+  // loading indicator persists; the toolCalls clause below ensures they also
+  // survive hydration regardless of isStreaming state.
+  const activeSSE = prev.filter(
+    m =>
+      m.role === 'system' ||
+      (m.isStreaming && (m.content || sendActive)) ||
+      (m.toolCalls && m.toolCalls.length > 0)
+  );
+  if (activeSSE.length === 0) return hydrated;
+  // Merge: DB is canonical, append SSE-only messages that aren't yet in DB.
+  // Identify which SSE messages are already covered by hydrated DB data to avoid dupes.
+  const hydratedIds = new Set(hydrated.map(m => m.id));
+  let sseOnly = activeSSE.filter(m => !hydratedIds.has(m.id));
+  sseOnly = dropHydratedContentDuplicates(sseOnly, hydrated);
+  if (sseOnly.length === 0) return hydrated;
+  const merged = [...hydrated, ...sseOnly];
+  merged.sort((a, b) => a.timestamp - b.timestamp);
+  return merged;
+}
+
+/**
+ * Merge REST-hydrated history after the stuck-placeholder recovery refetch.
+ * Same dedupe rules; preserves the timestamp-interleave insertion order.
+ */
+export function mergeRecoveredHistory(prev: ChatMessage[], hydrated: ChatMessage[]): ChatMessage[] {
+  const hydratedIds = new Set(hydrated.map(m => m.id));
+  // Keep only meaningful client-only messages not present in hydrated set.
+  // Exclude optimistic user rows and empty thinking placeholders.
+  let clientOnly = prev.filter(m => {
+    if (hydratedIds.has(m.id)) return false;
+    if (m.role === 'system') return true;
+    if (m.role !== 'assistant') return false;
+    return (
+      Boolean(m.content) ||
+      Boolean(m.error) ||
+      Boolean(m.workflowDispatch) ||
+      Boolean(m.workflowResult) ||
+      Boolean(m.toolCalls?.length)
+    );
+  });
+  clientOnly = dropHydratedContentDuplicates(clientOnly, hydrated);
+  if (clientOnly.length === 0) return hydrated;
+  // Interleave client-only messages at their original positions by timestamp
+  const merged = [...hydrated];
+  for (const msg of clientOnly) {
+    const insertIdx = merged.findIndex(m => m.timestamp > msg.timestamp);
+    if (insertIdx === -1) merged.push(msg);
+    else merged.splice(insertIdx, 0, msg);
+  }
+  return merged;
+}


### PR DESCRIPTION
## Summary

- **Problem:** Tool-less assistant replies (e.g. "hi") render twice in the web chat.
- **Why it matters:** On a fresh instance every short reply visibly duplicates; reproduction rate is "always" per #1972.
- **What changed:** Gate the stuck-placeholder recovery refetch on `isSendInFlight()`, and add content-level dedupe to both web-client history merges.
- **What did NOT change (scope boundary):** Server and DB are untouched — verified exactly one `text` SSE event and exactly one persisted row per reply. Purely a `@archon/web` client fix.

## UX Journey

### Before

```
User            Archon (web client)                Server (SSE + DB)
────            ───────────────────                ─────────────────
sends "hi" ───▶ optimistic empty placeholder
                                    ◀── text event (synthetic id) ── streamed reply
                                    ◀── conversation_lock:false ──── (DB row already flushed)
                onLockChange reads STALE messagesRef
                → still sees empty placeholder → spurious REST refetch
                → merges DB row (UUID) ALONGSIDE streamed copy (synthetic id)
sees reply TWICE [X]   (ids never match, so id-based dedupe misses it)
```

### After

```
User            Archon (web client)                Server (SSE + DB)
────            ───────────────────                ─────────────────
sends "hi" ───▶ optimistic empty placeholder
                                    ◀── text event ── *onText clears isSendInFlight()*
                                    ◀── conversation_lock:false
                onLockChange: sendStillInFlight == false  →  *NO refetch*
                (defense-in-depth: merges drop content-duplicate client rows)
sees reply ONCE ✓
```

## Architecture Diagram

### Before

```
useSSE ──(onText)──▶ ChatInterface ──▶ applyOnText ──▶ setMessages
       ──(onLockChange)──▶ ChatInterface ──▶ getMessages (REST) ──▶ setMessages (raw merge)
```

### After

```
useSSE ──(onText)──▶ ChatInterface ──▶ applyOnText ──▶ setMessages
       ──(onLockChange)──▶ ChatInterface ──[~ gated on isSendInFlight()]──▶ getMessages
                                          ──▶ [+ mergeRecoveredHistory] ──▶ setMessages
mount ──[~]──▶ [+ mergeHydratedHistory] ──▶ setMessages
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| useSSE | ChatInterface.onText | unchanged | clears `isSendInFlight()` synchronously |
| useSSE | ChatInterface.onLockChange | **modified** | recovery refetch now gated on captured `sendStillInFlight` |
| ChatInterface | chat-message-reducer.mergeHydratedHistory | **new** | mount hydration merge w/ content-dedupe |
| ChatInterface | chat-message-reducer.mergeRecoveredHistory | **new** | recovery refetch merge w/ content-dedupe |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `web`
- Module: `web:chat`

## Change Metadata

- Change type: `bug`
- Primary scope: `web`

## Linked Issue

- Closes #1972

## Validation Evidence (required)

```bash
bun run type-check   # 10/10 packages exit 0
bun x eslint <2 production files> --max-warnings 0   # clean (.test.ts is config-ignored: **/*.test.ts)
bun x prettier --check CHANGELOG.md   # clean
cd packages/web && bun run test   # 271 pass, 0 fail
```

- Evidence provided: type-check 10/10; full `@archon/web` suite **271 pass / 0 fail** (9 new merge tests in the `src/lib/` batch); live SSE capture showed one `text` event (`isComplete:true`) per tool-less reply and exactly 2 assistant + 2 user DB rows after two turns.
- Skipped: browser-rendered bubble-count check — see Human Verification.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios: live server e2e — "hi" and "what is 2+2?" each produced one `text` SSE event and one persisted assistant row (no server/DB duplication; the bug is purely client-side). Unit tests cover both merges including the exact #1972 scenario.
- Edge cases checked: empty tool-call placeholders, error-bearing rows, and system messages are preserved; distinct-content messages interleave by timestamp; empty placeholder kept while a send is in flight.
- What was not verified: browser-rendered bubble count — this arm64 env cannot launch the x86-64 Chromium (rosetta), and `@archon/web` has no jsdom/testing-library to render `onLockChange` directly. Covered instead by the 271 unit tests, live SSE e2e, and a static race trace (`useSSE` `flushText` → `onText` → `setSendInFlight(false)` runs before `onLockChange`).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: web chat message rendering only (`ChatInterface`, `chat-message-reducer`).
- Potential unintended effects: none server-side; the new merge functions are pure and unit-tested.
- Guardrails/monitoring for early detection: 271 web unit tests; recovery refetch still fires when text genuinely never arrived (the real missed-text case is preserved and tested).

## Rollback Plan (required)

- Fast rollback command/path: `git revert c98810f9` — pure client change, no state or migration to unwind.
- Feature flags or config toggles: none.
- Observable failure symptoms: if reverted, short/tool-less replies duplicate again on fresh web conversations.

## Risks and Mitigations

- Risk: suppressing a legitimately-missed-text recovery refetch.
  - Mitigation: `isSendInFlight()` is cleared only by `onText` on an actual text event, so it stays true precisely when text never arrived — recovery is preserved and unit-tested; content-dedupe is scoped to assistant rows with non-empty content and no error, so tool-only and error turns are never collapsed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DAG nodes now display a clear timeout error when operations exceed idle timeout limits without producing output, preventing incorrect completion recording.
  * Resolved duplicate assistant replies in web chat through improved message history merging during recovery operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->