### PR TITLE
fix(docker): eliminate slow recursive chown in image build and container start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Docker image builds and container restarts no longer spend tens of minutes in recursive chown.**
+  Production stage uses `COPY --chown` and runs `bun install` as `appuser`; entrypoint chowns only
+  files with wrong ownership instead of every inode. (#1970)
 - **`bash` nodes and loop `until_bash` now resolve the bash binary correctly on Windows.** A bare `spawn('bash', ...)` resolved to `C:\Windows\System32\bash.exe` (the WSL launcher) via CreateProcess's System32-first lookup, whose bash has broken `${VAR}` expansion in `-c` mode. New `resolveBashPath()` scans the common Git-Bash install locations on Windows (Program Files, Program Files (x86), user-scope `%LOCALAPPDATA%\Programs\Git`, scoop) and supports `ARCHON_BASH_PATH` override for non-standard installs. Loop `until_bash` now throws on bash-binary failures (ENOENT/EACCES/ENOTDIR) instead of silently re-iterating forever. Fixes #1326, #1808.
 
 ## [0.5.0] - 2026-06-26

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,9 +125,7 @@ RUN useradd -m -u 1001 -s /bin/bash appuser \
 RUN mkdir -p /.archon/workspaces /.archon/worktrees \
     && chown -R appuser:appuser /.archon
 
-# App content below is copied/installed directly as appuser (COPY --chown + USER).
-# A trailing `RUN chown -R appuser:appuser /app` would rewrite every inode into a
-# duplicate image layer and took 50+ minutes on slow disks (#1970).
+# A trailing `RUN chown -R /app` would duplicate every inode into a new image layer (#1970).
 USER appuser
 
 # Copy root package files and lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,56 +117,67 @@ ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
 
 # Create non-root user for running Claude Code
 # Claude Code refuses to run with --dangerously-skip-permissions as root for security
+# /app is still empty here (only WORKDIR created it) — non-recursive chown suffices.
 RUN useradd -m -u 1001 -s /bin/bash appuser \
-    && chown -R appuser:appuser /app
+    && chown appuser:appuser /app
 
 # Create Archon directories
 RUN mkdir -p /.archon/workspaces /.archon/worktrees \
     && chown -R appuser:appuser /.archon
 
+# App content below is copied/installed directly as appuser (COPY --chown + USER).
+# A trailing `RUN chown -R appuser:appuser /app` would rewrite every inode into a
+# duplicate image layer and took 50+ minutes on slow disks (#1970).
+USER appuser
+
 # Copy root package files and lockfile
-COPY package.json bun.lock ./
+COPY --chown=appuser:appuser package.json bun.lock ./
 
 # Copy ALL workspace package.json files
-COPY packages/adapters/package.json ./packages/adapters/
-COPY packages/cli/package.json ./packages/cli/
-COPY packages/core/package.json ./packages/core/
+COPY --chown=appuser:appuser packages/adapters/package.json ./packages/adapters/
+COPY --chown=appuser:appuser packages/cli/package.json ./packages/cli/
+COPY --chown=appuser:appuser packages/core/package.json ./packages/core/
 # docs-web source is NOT copied — it's a static site deployed separately
 # (see .github/workflows/deploy-docs.yml). package.json is included only
 # so Bun's workspace lockfile resolves correctly.
-COPY packages/docs-web/package.json ./packages/docs-web/
-COPY packages/git/package.json ./packages/git/
-COPY packages/isolation/package.json ./packages/isolation/
-COPY packages/paths/package.json ./packages/paths/
-COPY packages/providers/package.json ./packages/providers/
-COPY packages/server/package.json ./packages/server/
-COPY packages/web/package.json ./packages/web/
-COPY packages/workflows/package.json ./packages/workflows/
+COPY --chown=appuser:appuser packages/docs-web/package.json ./packages/docs-web/
+COPY --chown=appuser:appuser packages/git/package.json ./packages/git/
+COPY --chown=appuser:appuser packages/isolation/package.json ./packages/isolation/
+COPY --chown=appuser:appuser packages/paths/package.json ./packages/paths/
+COPY --chown=appuser:appuser packages/providers/package.json ./packages/providers/
+COPY --chown=appuser:appuser packages/server/package.json ./packages/server/
+COPY --chown=appuser:appuser packages/web/package.json ./packages/web/
+COPY --chown=appuser:appuser packages/workflows/package.json ./packages/workflows/
 
-# Install production dependencies only (--ignore-scripts skips husky prepare hook)
-RUN bun install --frozen-lockfile --production --ignore-scripts --linker=hoisted
+# Install production dependencies only (--ignore-scripts skips husky prepare hook).
+# Cache goes to /tmp and is removed in the same layer: not baked into the image,
+# not copied into the /home/appuser volume on first run.
+RUN HOME=/home/appuser BUN_INSTALL_CACHE_DIR=/tmp/bun-install-cache \
+      bun install --frozen-lockfile --production --ignore-scripts --linker=hoisted \
+    && rm -rf /tmp/bun-install-cache
 
 # Copy application source (Bun runs TypeScript directly, no compile step needed)
-COPY packages/adapters/ ./packages/adapters/
-COPY packages/cli/ ./packages/cli/
-COPY packages/core/ ./packages/core/
-COPY packages/git/ ./packages/git/
-COPY packages/isolation/ ./packages/isolation/
-COPY packages/paths/ ./packages/paths/
-COPY packages/providers/ ./packages/providers/
-COPY packages/server/ ./packages/server/
-COPY packages/workflows/ ./packages/workflows/
+COPY --chown=appuser:appuser packages/adapters/ ./packages/adapters/
+COPY --chown=appuser:appuser packages/cli/ ./packages/cli/
+COPY --chown=appuser:appuser packages/core/ ./packages/core/
+COPY --chown=appuser:appuser packages/git/ ./packages/git/
+COPY --chown=appuser:appuser packages/isolation/ ./packages/isolation/
+COPY --chown=appuser:appuser packages/paths/ ./packages/paths/
+COPY --chown=appuser:appuser packages/providers/ ./packages/providers/
+COPY --chown=appuser:appuser packages/server/ ./packages/server/
+COPY --chown=appuser:appuser packages/workflows/ ./packages/workflows/
 
 # Copy pre-built web UI from build stage
-COPY --from=web-build /app/packages/web/dist/ ./packages/web/dist/
+COPY --from=web-build --chown=appuser:appuser /app/packages/web/dist/ ./packages/web/dist/
 
 # Copy config, migrations, and bundled defaults
-COPY .archon/ ./.archon/
-COPY migrations/ ./migrations/
-COPY tsconfig*.json ./
+COPY --chown=appuser:appuser .archon/ ./.archon/
+COPY --chown=appuser:appuser migrations/ ./migrations/
+COPY --chown=appuser:appuser tsconfig*.json ./
 
-# Fix permissions for appuser
-RUN chown -R appuser:appuser /app
+# Back to root: the entrypoint must start as root to fix volume ownership,
+# and the gosu git-config setup below requires it.
+USER root
 
 # Create .codex directory for Codex authentication
 RUN mkdir -p /home/appuser/.codex && chown appuser:appuser /home/appuser/.codex

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,19 +8,23 @@ mkdir -p /.archon/workspaces /.archon/worktrees
 
 # Determine if we need to use gosu for privilege dropping
 if [ "$(id -u)" = "0" ]; then
-  # Running as root: fix volume permissions, then drop to appuser
-  if ! chown -Rh appuser:appuser /.archon 2>/dev/null; then
-    echo "ERROR: Failed to fix ownership of /.archon — volume may be read-only or mounted with incompatible options" >&2
-    exit 1
-  fi
+  # Running as root: fix volume permissions, then drop to appuser.
+  # Only files with wrong ownership are touched — a blanket `chown -R` rewrites
+  # metadata for every inode and can take tens of minutes on large volumes (#1970).
+  # find lstats by default and chown -h targets the symlink itself, preserving the
+  # old `chown -Rh` no-dereference semantics.
+  fix_ownership() {
+    if ! find "$1" \( ! -user appuser -o ! -group appuser \) -exec chown -h appuser:appuser {} + 2>/dev/null; then
+      echo "ERROR: Failed to fix ownership of $1 — volume may be read-only or mounted with incompatible options" >&2
+      exit 1
+    fi
+  }
+  fix_ownership /.archon
   # /home/appuser is persisted to a named volume (or bind-mounted via
   # ARCHON_USER_HOME) so Claude/Codex/Pi config, ~/.gitconfig, shell history,
   # and other user-specific state survive rebuilds. On bind mounts, host UIDs
   # don't map to appuser (1001), so fix ownership the same way we do /.archon.
-  if ! chown -Rh appuser:appuser /home/appuser 2>/dev/null; then
-    echo "ERROR: Failed to fix ownership of /home/appuser — volume may be read-only or mounted with incompatible options" >&2
-    exit 1
-  fi
+  fix_ownership /home/appuser
   RUNNER="gosu appuser"
 else
   # Already running as non-root (e.g., --user flag or Kubernetes)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,13 +8,16 @@ mkdir -p /.archon/workspaces /.archon/worktrees
 
 # Determine if we need to use gosu for privilege dropping
 if [ "$(id -u)" = "0" ]; then
-  # Running as root: fix volume permissions, then drop to appuser.
-  # Only files with wrong ownership are touched — a blanket `chown -R` rewrites
-  # metadata for every inode and can take tens of minutes on large volumes (#1970).
-  # find lstats by default and chown -h targets the symlink itself, preserving the
-  # old `chown -Rh` no-dereference semantics.
+  # A blanket `chown -R` rewrites metadata for every inode (#1970); only files
+  # with wrong ownership are touched.
+  # find + chown -h leaves symlinks un-dereferenced (no-dereference by design).
   fix_ownership() {
-    if ! find "$1" \( ! -user appuser -o ! -group appuser \) -exec chown -h appuser:appuser {} + 2>/dev/null; then
+    local err
+    # -o is correct: we want appuser:appuser on both, not "either matches".
+    if ! err=$(find "$1" \( ! -user appuser -o ! -group appuser \) -exec chown -h appuser:appuser {} + 2>&1 >/dev/null); then
+      if [ -n "$err" ]; then
+        echo "$err" >&2
+      fi
       echo "ERROR: Failed to fix ownership of $1 — volume may be read-only or mounted with incompatible options" >&2
       exit 1
     fi
@@ -23,7 +26,7 @@ if [ "$(id -u)" = "0" ]; then
   # /home/appuser is persisted to a named volume (or bind-mounted via
   # ARCHON_USER_HOME) so Claude/Codex/Pi config, ~/.gitconfig, shell history,
   # and other user-specific state survive rebuilds. On bind mounts, host UIDs
-  # don't map to appuser (1001), so fix ownership the same way we do /.archon.
+  # don't map to appuser (1001), so fix ownership via fix_ownership as well.
   fix_ownership /home/appuser
   RUNNER="gosu appuser"
 else

--- a/packages/docs-web/src/content/docs/deployment/docker.md
+++ b/packages/docs-web/src/content/docs/deployment/docker.md
@@ -493,7 +493,7 @@ mkdir -p /opt/archon-user-home
 sudo chown -R 1001:1001 /opt/archon-user-home
 ```
 
-The entrypoint fixes ownership on every container start — touching only files whose owner is wrong, so startup stays fast even on large volumes — and subsequent rebuilds work without re-running `chown`.
+The entrypoint fixes ownership on every container start, touching only files whose owner is wrong, so startup stays fast even on large volumes. Subsequent rebuilds work without re-running `chown`.
 
 :::caution
 Bind-mount paths do **not** inherit the image's baked `~/.gitconfig` (Docker only copies image content into named volumes on first creation, never into bind mounts). The entrypoint still registers git `safe.directory` entries for `/.archon/workspaces` and `/.archon/worktrees` repos at runtime, so functionality is preserved — but a bind-mounted `~/.gitconfig` starts empty and any author identity / signing config you want must be set explicitly with `git config --global` inside the container.

--- a/packages/docs-web/src/content/docs/deployment/docker.md
+++ b/packages/docs-web/src/content/docs/deployment/docker.md
@@ -493,7 +493,7 @@ mkdir -p /opt/archon-user-home
 sudo chown -R 1001:1001 /opt/archon-user-home
 ```
 
-The entrypoint re-applies ownership on every container start, so subsequent rebuilds work without re-running `chown`.
+The entrypoint fixes ownership on every container start — touching only files whose owner is wrong, so startup stays fast even on large volumes — and subsequent rebuilds work without re-running `chown`.
 
 :::caution
 Bind-mount paths do **not** inherit the image's baked `~/.gitconfig` (Docker only copies image content into named volumes on first creation, never into bind mounts). The entrypoint still registers git `safe.directory` entries for `/.archon/workspaces` and `/.archon/worktrees` repos at runtime, so functionality is preserved — but a bind-mounted `~/.gitconfig` starts empty and any author identity / signing config you want must be set explicitly with `git config --global` inside the container.


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: `RUN chown -R appuser:appuser /app` at the end of the Dockerfile production stage rewrites (and duplicates, under overlay2) every file in `/app` including `node_modules`, causing 50+ minute build stalls on slow disks (#1970). Additionally, `docker-entrypoint.sh` blanket-`chown -Rh`s the entire `/.archon` and `/home/appuser` volumes on every container start, which scales with workspace size ("bottleneck for updates").
- Why it matters: Users on HDDs, slow cloud volumes, or large workspaces cannot feasibly rebuild or restart containers.
- What changed: Production stage now copies sources with `COPY --chown=appuser:appuser` and runs `bun install` as `appuser`, eliminating the recursive-chown layer. The entrypoint now uses `find … -exec chown -h …` to touch only files with wrong ownership instead of every inode. The `bun install` cache goes to `/tmp` and is removed in the same layer, keeping it out of both the image and the persisted home volume.
- What did **not** change (scope boundary): End-state ownership — everything in `/app`, `/.archon`, and `/home/appuser` still ends up `appuser:appuser`. Entrypoint error handling (read-only volumes, incompatible mounts) preserves the same `ERROR … exit 1` semantics. Stages 1–2 (deps, web-build) and `docker-compose.yml` are untouched. The gosu git-config setup and safe.directory find loop remain unchanged.

## UX Journey

### Before

```
User                         Docker / Container
────                         ──────────────────
docker compose up ────────▶  build stalls 50+ min at
                             RUN chown -R appuser:appuser /app
                             (duplicates entire /app layer)
                             
container starts ─────────▶  chown -Rh /.archon (every inode)
                             chown -Rh /home/appuser (every inode)
                             → minutes on large volumes
```

### After

```
User                         Docker / Container
────                         ──────────────────
docker compose up ────────▶  COPY --chown on every source file
                             bun install as appuser
                             → NO chown layer in build
                             
container starts ─────────▶  find ... -exec chown -h (wrong-owned only)
                             → fast scan even on large volumes
```

## Architecture Diagram

### Before

```
Dockerfile (prod stage) ──▶ /app (all files root-owned)
     │                            │
     ▼                            ▼
RUN chown -R /app          duplicate layer (50+ min)

docker-entrypoint.sh ─────▶ /.archon volume
     │                            │
     ▼                            ▼
chown -Rh /.archon          rewrite every inode
chown -Rh /home/appuser     rewrite every inode
```

### After

```
Dockerfile (prod stage) ──▶ /app (COPY --chown: files appuser-owned)
     │                            │
     ▼                            ▼
USER appuser                install as appuser
USER root                   (no chown layer needed)

docker-entrypoint.sh ─────▶ /.archon volume
     │                            │
     ▼                            ▼
fix_ownership()             find + chown -h (wrong-owned only)
fix_ownership()             find + chown -h (wrong-owned only)
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| Dockerfile | /app filesystem | **modified** | COPY --chown + USER appuser replaces post-hoc chown -R |
| Dockerfile | bun install | **modified** | Runs as appuser with redirected cache |
| docker-entrypoint.sh | /.archon volume | **modified** | Selective find-based chown replaces blanket chown -Rh |
| docker-entrypoint.sh | /home/appuser volume | **modified** | Selective find-based chown replaces blanket chown -Rh |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `config`
- Module: `config:docker`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi`

## Linked Issue

- Closes #1970

## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check      # Pre-existing Copilot provider type errors (unrelated to this change)
bun run lint            # OOM in dev environment (unrelated to this change)
bun run format:check    # ✅ All matched files use Prettier code style!
bun run test            # ✅ 0 failures across all packages
```

- Evidence provided (test/log/trace/screenshot):
  - `bash -n docker-entrypoint.sh` → exit 0 ✅
  - `grep` confirms no `chown -R appuser:appuser /app` remains in Dockerfile ✅
  - `grep` confirms exactly one `USER appuser` (line 127) and one `USER root` (line 176) in production stage ✅
  - `grep` confirms all COPY lines between USER boundaries carry `--chown=appuser:appuser` ✅
  - Entrypoint `fix_ownership` simulation: root-owned file + dangling symlink → both correctly chowned, symlink not dereferenced ✅
  - Idempotency: second `find` pass finds 0 wrong-owned files ✅
  - Failure path: `find -exec chown` without permission → exit 1 (triggers ERROR + exit 1) ✅
  - `docker version` → not available in dev environment
- If any command is intentionally skipped, explain why:
  - `bun run validate` full pipeline: `check:pi-vendor-map` fails with pre-existing "stale vs installed pi-ai SDK" error (unrelated to Docker/entrypoint/docs files). `check:bundled`, `check:bundled-skill`, and `check:bundled-schema` all pass. Type-check has pre-existing Copilot provider type errors. Lint OOMs in the dev environment. None of these are related to this PR's file changes.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation: N/A

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: N/A — existing volumes need nothing. First start after upgrade does a one-time selective ownership fix; named volumes already owned by appuser are a no-op scan.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
  - Dockerfile static analysis: no trailing `chown -R /app`, correct USER ordering, all COPYs annotated
  - entrypoint.sh syntax (`bash -n`) passes
  - `fix_ownership` logic simulated with root-owned files, symlinks, and idempotent second pass — all correct
  - Failure path (permission denied on chown) correctly triggers non-zero exit
- Edge cases checked:
  - Dangling symlink: `chown -h` targets the symlink itself (no dereference), matching old `-Rh` behavior
  - Already-correctly-owned files: second find pass correctly finds zero items
  - Read-only volume analogue: chown without permission returns non-zero → triggers ERROR + exit 1
- What was not verified:
  - Full `docker build` / `docker compose up` — no Docker runtime available in dev environment. Reporter's repro machine can confirm the 50+ min → fast build transition.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Docker image build, container startup (entrypoint)
- Potential unintended effects: Image size shrinks slightly (no duplicated chown layer inode metadata, no baked bun install cache). Startup of containers with huge volumes drops from full metadata rewrite to read-only scan.
- Guardrails/monitoring for early detection: Permission-denied errors from the app writing under `/app`, `/.archon`, or `/home/appuser` would indicate ownership regression — the entrypoint ERROR message will surface these at container start.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge-commit>` + rebuild
- Feature flags or config toggles (if any): None
- Observable failure symptoms: Permission-denied errors when the app process (running as appuser via gosu) tries to write to files still owned by root under `/app`, `/.archon`, or `/home/appuser`.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: Legacy Docker builders (<17.09 or non-BuildKit) may not support `COPY --chown=<name>`
  - Mitigation: `COPY --chown` has been supported since Docker 17.09 (2017). No BuildKit-only syntax is used. The user `appuser` exists before the first `--chown` use (created at line 117).
- Risk: `BUN_INSTALL_CACHE_DIR=/tmp/bun-install-cache` could cause install failures in edge cases
  - Mitigation: `BUN_INSTALL_CACHE_DIR` is a documented Bun environment variable. The install is `--frozen-lockfile`, so any failure is deterministic (wrong hash), not corruption. If the cache dir is the issue, dropping only the env var (cache then lands in `/home/appuser/.bun`) is a simple fallback.
- Risk: `USER` directive does not reliably export `HOME` in some Docker versions
  - Mitigation: `HOME=/home/appuser` is set explicitly in the `bun install` RUN command.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized Docker image builds with improved file ownership handling, reducing build time overhead.
  * Accelerated container startup performance on large volumes through selective ownership fixes instead of recursive operations.

* **Documentation**
  * Updated Docker deployment documentation to reflect changes in container entrypoint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->