### PR TITLE
fix(pi): resolve API key for custom models.json providers (fixes 401 on self-hosted gateways)

### DIFF
--- a/packages/providers/src/community/pi/custom-provider-key.test.ts
+++ b/packages/providers/src/community/pi/custom-provider-key.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { customProviderApiKeyEnvVar } from './custom-provider-key';
+
+const created: string[] = [];
+
+function modelsDir(contents: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), 'pi-models-'));
+  writeFileSync(join(dir, 'models.json'), JSON.stringify(contents));
+  created.push(dir);
+  return dir;
+}
+
+describe('customProviderApiKeyEnvVar', () => {
+  afterEach(() => {
+    for (const dir of created.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('resolves a "$ENV" apiKey reference to the bare env-var name', () => {
+    const dir = modelsDir({
+      providers: { tiepoint: { apiKey: '$TIEPOINT_AI_GATEWAY_KEY' } },
+    });
+    expect(customProviderApiKeyEnvVar('tiepoint', dir)).toBe('TIEPOINT_AI_GATEWAY_KEY');
+  });
+
+  test('returns undefined for a literal (non-"$") apiKey', () => {
+    const dir = modelsDir({ providers: { foo: { apiKey: 'sk-literal-value' } } });
+    expect(customProviderApiKeyEnvVar('foo', dir)).toBeUndefined();
+  });
+
+  test('returns undefined when the provider is not present', () => {
+    const dir = modelsDir({ providers: {} });
+    expect(customProviderApiKeyEnvVar('missing', dir)).toBeUndefined();
+  });
+
+  test('returns undefined when models.json does not exist', () => {
+    expect(
+      customProviderApiKeyEnvVar('x', join(tmpdir(), 'pi-nonexistent-dir-xyz'))
+    ).toBeUndefined();
+  });
+
+  test('returns undefined on malformed models.json', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pi-bad-'));
+    writeFileSync(join(dir, 'models.json'), '{ not valid json');
+    created.push(dir);
+    expect(customProviderApiKeyEnvVar('x', dir)).toBeUndefined();
+  });
+
+  test('returns undefined for a bare "$" with no name', () => {
+    const dir = modelsDir({ providers: { foo: { apiKey: '$' } } });
+    expect(customProviderApiKeyEnvVar('foo', dir)).toBeUndefined();
+  });
+});

--- a/packages/providers/src/community/pi/custom-provider-key.ts
+++ b/packages/providers/src/community/pi/custom-provider-key.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Resolve the API-key environment-variable name for a *custom* Pi provider —
+ * one the user defined in pi's `models.json` (e.g. a self-hosted, OpenAI-
+ * compatible gateway) that is not one of pi-ai's built-in backends listed in
+ * `PI_PROVIDER_ENV_VARS` (`pi-vendor-map.generated.ts`).
+ *
+ * Pi's `models.json` provider entries declare their key as a `"$ENV_VAR"`
+ * reference, for example:
+ *
+ * ```json
+ * {
+ *   "providers": {
+ *     "myorg": {
+ *       "baseUrl": "https://gateway.example/v1",
+ *       "api": "openai-completions",
+ *       "apiKey": "$MYORG_API_KEY"
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * Returning `"MYORG_API_KEY"` lets the Pi provider inject that key via
+ * `authStorage.setRuntimeApiKey`, so any custom OpenAI-compatible provider
+ * authenticates without a per-provider code change. Previously only built-in
+ * SDK backends (those in the generated vendor map) had their keys forwarded,
+ * so requests to user-defined gateways failed upstream with `401`.
+ *
+ * Reads `$PI_CODING_AGENT_DIR/models.json`, falling back to
+ * `~/.pi/agent/models.json` — the same file pi's own CLI reads. Best-effort:
+ * returns `undefined` on any missing/unreadable/malformed file, or when the
+ * provider's `apiKey` is absent or not a `"$VAR"` reference, so callers fall
+ * through to the existing no-credentials path.
+ */
+export function customProviderApiKeyEnvVar(
+  provider: string,
+  configDir: string = process.env.PI_CODING_AGENT_DIR?.trim() ||
+    join(homedir(), '.pi', 'agent')
+): string | undefined {
+  try {
+    const raw = readFileSync(join(configDir, 'models.json'), 'utf-8');
+    const parsed = JSON.parse(raw) as {
+      providers?: Record<string, { apiKey?: unknown }>;
+    };
+    const apiKey = parsed.providers?.[provider]?.apiKey;
+    if (typeof apiKey === 'string' && apiKey.startsWith('$') && apiKey.length > 1) {
+      return apiKey.slice(1);
+    }
+  } catch {
+    // No models.json, unreadable, or malformed JSON — treat as "no custom var".
+  }
+  return undefined;
+}

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -18,6 +18,7 @@ import type {
 import { PI_CAPABILITIES } from './capabilities';
 import { parsePiConfig } from './config';
 import { parsePiModelRef } from './model-ref';
+import { customProviderApiKeyEnvVar } from './custom-provider-key';
 
 // IMPORTANT: Do NOT add static `import { ... } from '@earendil-works/*'` here,
 // and do NOT statically import sibling modules that themselves import runtime
@@ -266,7 +267,8 @@ export class PiProvider implements IAgentProvider {
 
     // 4. Resolve credentials. Per-request env vars override auth.json entries via
     //    setRuntimeApiKey — codebase-scoped env vars win over the user's global Pi login.
-    const envVarName = PI_PROVIDER_ENV_VARS[parsed.provider];
+    const envVarName =
+      PI_PROVIDER_ENV_VARS[parsed.provider] ?? customProviderApiKeyEnvVar(parsed.provider);
     const envOverride = envVarName
       ? (requestOptions?.env?.[envVarName] ?? process.env[envVarName])
       : undefined;


### PR DESCRIPTION
## Problem

The Pi provider only injects an API key when the provider id is present in the
generated `PI_PROVIDER_ENV_VARS` map (`pi-vendor-map.generated.ts`, derived from
pi-ai's built-in SDK backends). For a **custom provider** the user defines in
pi's `models.json` — e.g. a self-hosted, OpenAI-compatible gateway —

```jsonc
// ~/.pi/agent/models.json
{ "providers": { "mygw": {
    "baseUrl": "https://gateway.example/v1",
    "api": "openai-completions",
    "apiKey": "$MYGW_API_KEY"
} } }
```

`PI_PROVIDER_ENV_VARS["mygw"]` is `undefined`, so `setRuntimeApiKey` is never
called. Execution then takes the "unmapped provider" branch, logs `auth_missing`,
and continues **without credentials** — the upstream request goes out with no
key and the gateway returns **401**. The model resolves fine (it's in
`models.json`), so the failure is purely auth and is confusing to debug.

Using such a provider works with pi's own CLI (which reads the `apiKey: "$ENV"`
reference from `models.json`), but not through Archon.

## Fix

Add a small, pure helper `customProviderApiKeyEnvVar(provider, configDir?)` that,
for a provider **not** in the generated map, reads
`$PI_CODING_AGENT_DIR/models.json` (falling back to `~/.pi/agent/models.json` —
the same file pi's CLI reads) and returns the bare env-var name from that
provider's `apiKey: "$ENV_VAR"` reference. The Pi provider uses it as a fallback:

```ts
const envVarName =
  PI_PROVIDER_ENV_VARS[parsed.provider] ?? customProviderApiKeyEnvVar(parsed.provider);
```

so any custom OpenAI-compatible provider authenticates with no per-provider code
change. The lookup is best-effort: missing/unreadable/malformed `models.json`,
an absent provider, or a non-`$` `apiKey` all return `undefined`, falling through
to the existing no-credentials path. Built-in SDK backends are unchanged.

## Testing

- New `custom-provider-key.test.ts` (6 cases: `$ENV` reference, literal key,
  missing provider, missing file, malformed JSON, bare `$`) — all pass via
  `bun test` (100% coverage of the new module).
- Change is additive; existing mapped-provider behavior is untouched.

## Notes

- Does not modify `pi-vendor-map.generated.ts` or the `check:pi-vendor-map`
  drift guard — this is a runtime fallback only.
- Verified end-to-end against a self-hosted OpenAI-compatible gateway: the Pi
  assistant now authenticates (was 401) and routes correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving API keys from provider configuration files, enabling environment variable references for custom Pi providers beyond the default set.

* **Tests**
  * Added comprehensive test suite covering API key environment variable resolution, including validation of configuration formats and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->