### PR TITLE
Fix workflow run Open in IDE path

### DIFF
--- a/packages/web/src/components/chat/ChatInterface.tsx
+++ b/packages/web/src/components/chat/ChatInterface.tsx
@@ -38,6 +38,7 @@ import {
 } from '@/lib/message-cache';
 import { useProject } from '@/contexts/ProjectContext';
 import { ensureUtc } from '@/lib/format';
+import { resolveChatHeaderPath } from '@/lib/chat-header';
 
 function mapMessageRow(row: MessageResponse): ChatMessage {
   let meta: {
@@ -99,9 +100,13 @@ function mapMessageRow(row: MessageResponse): ChatMessage {
 
 interface ChatInterfaceProps {
   conversationId: string;
+  cwdOverride?: string | null;
 }
 
-export function ChatInterface({ conversationId }: ChatInterfaceProps): React.ReactElement {
+export function ChatInterface({
+  conversationId,
+  cwdOverride,
+}: ChatInterfaceProps): React.ReactElement {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { selectedProjectId } = useProject();
@@ -278,7 +283,7 @@ export function ChatInterface({ conversationId }: ChatInterfaceProps): React.Rea
       ? codebases?.find(cb => cb.id === selectedProjectId)
       : undefined;
   const headerTitle = currentConv?.title ?? 'Chat';
-  const headerSubtitle = currentConv?.cwd ?? undefined;
+  const headerSubtitle = resolveChatHeaderPath(currentConv?.cwd, cwdOverride);
 
   const nextId = (): string => {
     messageIdCounter.current += 1;

--- a/packages/web/src/components/workflows/WorkflowExecution.tsx
+++ b/packages/web/src/components/workflows/WorkflowExecution.tsx
@@ -48,6 +48,7 @@ interface WorkflowRunQueryData {
   workerPlatformId: string | null;
   parentPlatformId: string | null;
   conversationPlatformId: string | null;
+  workingPath: string | null;
   codebaseId: string | null;
   events: WorkflowEventResponse[];
 }
@@ -199,6 +200,7 @@ export function WorkflowExecution({ runId }: WorkflowExecutionProps): React.Reac
         workerPlatformId: data.run.worker_platform_id ?? null,
         parentPlatformId: data.run.parent_platform_id ?? null,
         conversationPlatformId: data.run.conversation_platform_id ?? null,
+        workingPath: data.run.working_path ?? null,
         codebaseId: data.run.codebase_id ?? null,
         events: data.events,
       };
@@ -215,6 +217,7 @@ export function WorkflowExecution({ runId }: WorkflowExecutionProps): React.Reac
   const workerPlatformId = queryData?.workerPlatformId ?? null;
   const parentPlatformId = queryData?.parentPlatformId ?? null;
   const conversationPlatformId = queryData?.conversationPlatformId ?? null;
+  const workingPath = queryData?.workingPath ?? null;
   const error = queryError
     ? queryError instanceof Error
       ? queryError.message
@@ -607,7 +610,7 @@ export function WorkflowExecution({ runId }: WorkflowExecutionProps): React.Reac
     if (isDag && activeView === 'chat' && parentPlatformId) {
       return (
         <div className="flex flex-col flex-1 overflow-hidden min-h-0">
-          <ChatInterface conversationId={parentPlatformId} />
+          <ChatInterface conversationId={parentPlatformId} cwdOverride={workingPath} />
         </div>
       );
     }

--- a/packages/web/src/lib/chat-header.test.ts
+++ b/packages/web/src/lib/chat-header.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveChatHeaderPath } from './chat-header';
+
+describe('resolveChatHeaderPath', () => {
+  test('prefers the workflow run cwd override over the conversation cwd', () => {
+    expect(resolveChatHeaderPath('/worktrees/parent', '/worktrees/worker')).toBe(
+      '/worktrees/worker'
+    );
+  });
+
+  test('falls back to the conversation cwd when no override is available', () => {
+    expect(resolveChatHeaderPath('/worktrees/parent', null)).toBe('/worktrees/parent');
+    expect(resolveChatHeaderPath('/worktrees/parent', undefined)).toBe('/worktrees/parent');
+  });
+
+  test('returns undefined when neither path is available', () => {
+    expect(resolveChatHeaderPath(null, undefined)).toBeUndefined();
+  });
+});

--- a/packages/web/src/lib/chat-header.ts
+++ b/packages/web/src/lib/chat-header.ts
@@ -1,0 +1,10 @@
+export function resolveChatHeaderPath(
+  conversationCwd: string | null | undefined,
+  cwdOverride: string | null | undefined
+): string | undefined {
+  const override = cwdOverride?.trim();
+  if (override) return override;
+
+  const cwd = conversationCwd?.trim();
+  return cwd || undefined;
+}


### PR DESCRIPTION
## Summary

- Problem: The legacy workflow run Chat tab opened the parent conversation worktree from `Open in IDE` instead of the workflow run worktree.
- Why it matters: Users reviewing a run could land in the wrong checkout and edit or inspect the wrong branch/thread.
- What changed: The workflow execution page now passes `run.working_path` into `ChatInterface`, and the chat header prefers that explicit path when building the IDE-open target.
- What did **not** change (scope boundary): No server API, workflow execution, database, or IDE-opening behavior outside the existing header path source changed.

## UX Journey

### Before

```text
User                         WorkflowExecution             ChatInterface/Header
────                         ─────────────────             ────────────────────
opens run Chat tab ───────▶  renders parentPlatformId ───▶ loads parent conversation cwd
clicks Open in IDE ◀───────  header subtitle = parent cwd  opens parent worktree
```

### After

```text
User                         WorkflowExecution                 ChatInterface/Header
────                         ─────────────────                 ────────────────────
opens run Chat tab ───────▶  reads run.working_path ────────▶ [passes cwdOverride]
clicks Open in IDE ◀───────  header subtitle = run cwd        opens workflow run worktree
```

## Architecture Diagram

### Before

```text
/api/workflows/runs/:id
  └─ returns run.working_path, parent_platform_id
       └─ WorkflowExecution
            └─ ChatInterface(parentPlatformId)
                 └─ Header uses parent conversation cwd
```

### After

```text
/api/workflows/runs/:id
  └─ returns run.working_path, parent_platform_id
       └─ [~] WorkflowExecution
            === passes workingPath as cwdOverride
                 └─ [~] ChatInterface
                      └─ [+] chat-header resolver prefers override cwd
                           └─ Header uses workflow run cwd
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `WorkflowExecution` | workflow run API response | unchanged | Existing `working_path` field is reused. |
| `WorkflowExecution` | `ChatInterface` | **modified** | Passes `cwdOverride={workingPath}` for DAG Chat tab. |
| `ChatInterface` | `chat-header` | **new** | Resolves override-vs-conversation header path. |
| `ChatInterface` | `Header` | unchanged | Still passes title/subtitle into existing header component. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `web`
- Module: `web:workflow-execution`

## Change Metadata

- Change type: `bug`
- Primary scope: `web`

## Linked Issue

- Closes #2001
- Related #
- Depends on #
- Supersedes #

## Validation Evidence (required)

Commands and result summary:

```bash
bun test packages/web/src/lib/chat-header.test.ts
bun --filter @archon/web type-check
bun x prettier --check packages/web/src/components/chat/ChatInterface.tsx packages/web/src/components/workflows/WorkflowExecution.tsx packages/web/src/lib/chat-header.ts packages/web/src/lib/chat-header.test.ts
bun x eslint packages/web/src/components/chat/ChatInterface.tsx packages/web/src/components/workflows/WorkflowExecution.tsx packages/web/src/lib/chat-header.ts --max-warnings 0
bun run validate
```

- Evidence provided (test/log/trace/screenshot): All commands completed successfully locally. `bun run validate` passed in a clean worktree based on `upstream/dev`.
- If any command is intentionally skipped, explain why: Browser/IDE click was not performed because clicking `Open in IDE` launches an external application; behavior is covered by the header path resolver unit test and the existing run API field path.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation: N/A

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Unit test confirms workflow run cwd override wins over parent conversation cwd; live local API for the reported run returned the expected `working_path` value.
- Edge cases checked: Missing/empty override falls back to conversation cwd; missing paths return no subtitle.
- What was not verified: I did not click `Open in IDE` because that would launch an external IDE on the local machine.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Legacy web workflow run Chat tab header path.
- Potential unintended effects: A wrong or missing `working_path` would fall back to the parent conversation cwd, preserving prior behavior.
- Guardrails/monitoring for early detection: Unit test covers the path precedence rule; existing workflow run API contract remains unchanged.

## Rollback Plan (required)

- Fast rollback command/path: Revert commit `d3901cbe`.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: Chat tab header/path would again show the parent conversation worktree for workflow runs.

## Risks and Mitigations

- Risk: `working_path` may be unavailable on older or unusual run records.
  - Mitigation: Resolver falls back to the existing conversation cwd behavior when no override is present.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat interface now respects workflow execution context for improved path display accuracy.

* **Tests**
  * Added test coverage for path resolution functionality to ensure correct behavior across different context scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->