### PR TITLE
  fix(workflows): restore interactive-loop cross-gate session continuity (reverts #1923)

### DIFF
--- a/packages/docs-web/src/content/docs/guides/loop-nodes.md
+++ b/packages/docs-web/src/content/docs/guides/loop-nodes.md
@@ -132,10 +132,7 @@ Controls session continuity between iterations:
 | `true` | Each iteration starts a fresh AI session. No memory of prior iterations. | Work state lives on disk (files, git). Prevents context window exhaustion on long loops. |
 | `false` (default) | Sessions thread — each iteration resumes the prior conversation. | Iterative refinement where the agent needs to remember what it tried before. |
 
-The first iteration is always fresh regardless of this setting. The first
-iteration executed after resuming from an interactive loop approval gate is
-also always fresh — the stored session id may have expired during the human
-review wait, and user feedback is carried via `$LOOP_USER_INPUT` instead.
+The first iteration is always fresh regardless of this setting.
 
 ### `until_bash`
 

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -4947,88 +4947,9 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // Verify the prompt contains the user input
       const promptArg = mockSendQueryDag.mock.calls[0][0] as string;
       expect(promptArg).toContain('Add error handling');
-      // Should use a fresh session on the first resumed iteration: the stored
-      // gate session may have expired during the human review wait, so we
-      // start fresh (user feedback is carried via $LOOP_USER_INPUT). See
-      // packages/workflows/src/dag-executor.ts needsFreshSession (#1208).
+      // Should have resumed with stored session ID
       const sessionArg = mockSendQueryDag.mock.calls[0][2] as string | undefined;
-      expect(sessionArg).toBeUndefined();
-    });
-
-    it('interactive loop resume does not crash with error_during_execution on iteration 2', async () => {
-      // Regression test for #1208: when resuming a paused interactive loop
-      // gate, the first resumed iteration must use a fresh session (not the
-      // potentially stale stored session id), so the SDK never receives an
-      // expired session id that would trigger error_during_execution.
-      mockSendQueryDag.mockImplementation(function* () {
-        yield {
-          type: 'assistant',
-          content: 'Updated plan with error handling. <promise>APPROVED</promise>',
-        };
-        yield { type: 'result', sessionId: 'fresh-session-1' };
-      });
-
-      const store = createMockStore();
-      const mockDeps = createMockDeps(store);
-      const platform = createMockPlatform();
-      // Simulate resumed run: metadata has loop gate state from iteration 1
-      // with a stale session id (the SDK would reject this if reused).
-      const workflowRun = makeWorkflowRun('resume-no-crash-id', {
-        metadata: {
-          approval: {
-            type: 'interactive_loop',
-            nodeId: 'refine',
-            iteration: 1,
-            sessionId: 'stale-session-from-hours-ago',
-            message: 'Review the plan.',
-          },
-          loop_user_input: 'Add error handling',
-        },
-      });
-
-      await executeDagWorkflow(
-        mockDeps,
-        platform,
-        'conv-dag',
-        testDir,
-        {
-          name: 'interactive-loop-no-crash',
-          nodes: [
-            {
-              id: 'refine',
-              loop: {
-                prompt: 'User said: $LOOP_USER_INPUT. Refine the plan.',
-                until: 'APPROVED',
-                max_iterations: 10,
-                interactive: true,
-                gate_message: 'Review the plan.',
-              },
-            },
-          ],
-        },
-        workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
-
-      // Exactly one iteration runs (it completes via APPROVED signal)
-      expect(mockSendQueryDag.mock.calls.length).toBe(1);
-      // Crucially: sessionArg must be undefined (fresh session), NOT the stale stored id.
-      const sessionArg = mockSendQueryDag.mock.calls[0][2] as string | undefined;
-      expect(sessionArg).toBeUndefined();
-
-      // No failure events were emitted (no loop_iteration_failed, no node_failed).
-      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
-      const failedEvents = eventCalls.filter((call: unknown[]) => {
-        const evt = (call[0] as Record<string, unknown>).event_type as string;
-        return evt === 'loop_iteration_failed' || evt === 'node_failed';
-      });
-      expect(failedEvents).toHaveLength(0);
+      expect(sessionArg).toBe('loop-session-1');
     });
 
     it('loop iteration fails loudly when SDK returns error_during_execution', async () => {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -2126,14 +2126,8 @@ async function executeLoopNode(
         logEventStoreError(err, i);
       });
 
-    // Session threading. Force a fresh session on the first iteration of an
-    // interactive loop resume: the stored session id from the gate metadata
-    // may be stale after a human review wait — passing it to the SDK can
-    // trigger errors (e.g. error_during_execution on Claude SDK).
-    // User feedback is carried via $LOOP_USER_INPUT, so session continuity is
-    // not required for the first resumed iteration.
-    const needsFreshSession =
-      loop.fresh_context || i === 1 || (isLoopResume && i === startIteration);
+    // Session threading
+    const needsFreshSession = loop.fresh_context || i === 1;
     const resumeSessionId = needsFreshSession ? undefined : currentSessionId;
 
     // Stream AI response for this iteration


### PR DESCRIPTION
## Summary

- **Problem:** [#1923](https://github.com/coleam00/Archon/pull/1923) forced a fresh Claude session on the first iteration after **every** interactive-loop approval gate, so the agent lost all memory of its prior turns across the gate (tracked in [#2004](https://github.com/coleam00/Archon/issues/2004)).
- **Why it matters:** It breaks the single most valuable use of interactive loops — a multi-turn conversation / interview / iterative refinement that a human steers across gates. Every post-gate turn started with no memory of the prior turns, seeing only `$LOOP_USER_INPUT`.
- **What changed:** Removed the `(isLoopResume && i === startIteration)` term from `needsFreshSession` in `dag-executor.ts`, restoring `loop.fresh_context || i === 1`; reinstated the resume test assertion (`sessionArg === 'loop-session-1'`); removed #1923's regression test that encoded the fresh-session behavior; reverted the `loop-nodes.md` doc note.
- **What did NOT change (scope boundary):** [#1291](https://github.com/coleam00/Archon/pull/1291)'s fail-loud `isError` handling, `fresh_context: true` loops, non-interactive loops, and `persist_session` loops are all untouched. This PR does **not** attempt to diagnose or fix the original [#1208](https://github.com/coleam00/Archon/issues/1208) crash — that is separate work.

## UX Journey

### Before

```
User                     Archon (interactive loop)          Claude SDK
────                     ─────────────────────────          ──────────
approve gate "feedback" ▶ resume at iteration 2
                          needsFreshSession = TRUE           (isLoopResume && i === startIteration)
                          resumeSessionId = undefined ──────▶ FRESH session — no memory of iter 1
sees context-free reply ◀─ agent only has $LOOP_USER_INPUT
```

### After

```
User                     Archon (interactive loop)          Claude SDK
────                     ─────────────────────────          ──────────
approve gate "feedback" ▶ resume at iteration 2
                          [needsFreshSession = false]        (fresh_context=false, i>1)
                          [resumeSessionId = gate session] ─▶ RESUMES the iteration-1 session
sees context-aware reply◀─ agent retains prior turns + the new $LOOP_USER_INPUT
```

## Architecture Diagram

### Before

```
dag-executor.ts :: executeLoopNode  (isLoopResume=true, startIteration=2)
  needsFreshSession = fresh_context || i===1 || (isLoopResume && i===startIteration)  ← TRUE on resume
  resumeSessionId   = undefined
  aiClient.sendQuery(prompt, cwd, undefined, opts)   ← fresh session, prior context lost
```

### After

```
dag-executor.ts :: executeLoopNode  (isLoopResume=true, startIteration=2)
  [~] needsFreshSession = fresh_context || i===1        ← false on resume
  resumeSessionId       = currentSessionId (gate sessionId)
  aiClient.sendQuery(prompt, cwd, gateSessionId, opts)  ← threads the stored session
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `dag-executor.ts::executeLoopNode` | `aiClient.sendQuery` | **modified** | `resumeSessionId` again threads the stored gate session on the first resumed iteration (was forced to `undefined` by #1923) |
| `dag-executor.ts::executeLoopNode` | `loopGateMeta.sessionId` | **modified** | now passed through as `resumeSessionId` again (was read then discarded) |
| loop iteration result handler | #1291 `isError` fail-loud throw | unchanged | a genuine resume failure still throws loudly with `errors[]` |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `workflows` (+ `docs`, `tests`)
- Module: `workflows:dag-executor` (`executeLoopNode`)

## Change Metadata

- Change type: `bug` (revert of a regression)
- Primary scope: `workflows`

## Linked Issue

- Closes #2004
- Related #1208, #1291
- Supersedes #1923

## Validation Evidence (required)

`bun run validate` was run on this branch. Per-step results:

```bash
bun run check:bundled         # ✅ pass
bun run check:bundled-skill   # ✅ pass
bun run check:bundled-schema  # ✅ pass
bun run check:pi-vendor-map   # ✅ pass (OK)
bun run type-check            # ✅ exit 0 — all 10 packages
bun run lint --max-warnings 0 # ✅ exit 0
bun run format:check          # ✅ changed files clean (see note)
bun run test                  # ✅ 5144 pass / 0 fail — all packages
```

- Every `bun run validate` step passes. The full per-package test suite is **5144 pass / 0 fail**.
- `format:check` note: the tree-wide `prettier --check .` only warns on **untracked local files** that are not part of this PR and don't exist in a clean checkout/CI. The 3 files this PR changes are Prettier-clean (`bun x prettier --check` on them → "All matched files use Prettier code style!"), and the pre-commit hook (lint-staged: prettier + eslint) ran clean on them at commit time.
- The revert diff is the exact inverse of #1923 on `dag-executor.ts` and `loop-nodes.md`, and was verified byte-identical to a true `git revert` of #1923.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No**
- This is a behavior revert in the workflow loop executor; no security surface is touched.

## Compatibility / Migration

- Backward compatible? **Yes** — restores the behavior shipped in the latest tagged release; the reverted behavior was `dev`-only and unreleased.
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

- Verified scenarios: confirmed the change is the exact inverse of #1923 (`needsFreshSession` term removed, test assertion restored to `'loop-session-1'`, #1923 regression test removed, docs note reverted); `type-check`/`lint`/loop-test green; #1291's "fails loudly on `error_during_execution`" test still passes.
- Edge cases checked: `fresh_context: true` and non-interactive loop paths are logically unchanged (their `needsFreshSession` terms are untouched); #1291 fail-loud path unchanged.
- What was **not** verified: a live end-to-end interactive-loop resume against a real provider (no live run was performed). The full `bun run validate` and per-package test suite (5144 pass / 0 fail) were run — see Validation Evidence.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: workflow-engine loop execution only (`executeLoopNode`); any `interactive: true` loop that resumes after a gate.
- Potential unintended effects: environments that genuinely hit the original [#1208](https://github.com/coleam00/Archon/issues/1208) `error_during_execution` will once again attempt a session resume on the first post-gate iteration. With [#1291](https://github.com/coleam00/Archon/pull/1291) in place this now **fails loudly with the real SDK `errors[]`** rather than being masked — which is the intended behavior, and the data needed to actually diagnose #1208.
- Guardrails/monitoring: #1291's `loop_node.iteration_sdk_error` log + `loop_iteration_failed` event surface any genuine resume failure with the SDK error strings.

## Rollback Plan (required)

- Fast rollback: revert this PR's merge commit (3-file change, +5/−93) — re-applies #1923's fresh-on-resume behavior.
- Feature flags / toggles: none (intentionally no new config; an opt-in flag was considered and dropped per YAGNI since the change is unreleased).
- Observable failure symptoms: if restoring continuity surfaced the unconfirmed #1208 crash for some environment, it would appear as a loud `error_during_execution` failure on the first post-gate iteration (with `errors[]` detail), not a silent regression.

## Risks and Mitigations

- Risk: the original, unconfirmed #1208 `error_during_execution` (suspected environmental — Docker/VPS, Slack batch-streaming, `CLAUDE_CODE_OAUTH_TOKEN` refresh, MCP/tool/network) could resurface for affected users once session resume is restored.
  - Mitigation: #1291's fail-loud handling now surfaces the actual SDK error strings so the real cause can be identified; fixing #1208 is tracked separately and intentionally out of scope here. As a stopgap, affected loops can set `fresh_context: true` (every iteration fresh) until #1208 is properly diagnosed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed loop node session management during interactive resume: session IDs are now properly preserved when resuming iterations, unless `fresh_context` is explicitly enabled.

* **Documentation**
  * Updated loop node guide to clarify `fresh_context` behavior during iterations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->