### PR TITLE
Fix Codex Minimal Reasoning Effort Execution

### DIFF
--- a/packages/adapters/src/forge/github/adapter.test.ts
+++ b/packages/adapters/src/forge/github/adapter.test.ts
@@ -1098,6 +1098,8 @@ describe('GitHubAdapter', () => {
   // circuit, refresh-on-401, self-filter against <slug>[bot], clone path.
   // ---------------------------------------------------------------------------
   describe('App mode', () => {
+    let originalAllowedUsers: string | undefined;
+
     /**
      * Build a mock IGitHubAppAuthProvider. Each fake `(owner) → installationId`
      * pair is encoded by hashing owner — tests assert that distinct owners
@@ -1212,6 +1214,8 @@ describe('GitHubAdapter', () => {
     }
 
     beforeEach(() => {
+      originalAllowedUsers = process.env.GITHUB_ALLOWED_USERS;
+      delete process.env.GITHUB_ALLOWED_USERS;
       mockCloneRepository.mockClear();
       mockCloneRepository.mockResolvedValue({ ok: true, value: undefined });
       mockExecFileAsync.mockClear();
@@ -1219,6 +1223,14 @@ describe('GitHubAdapter', () => {
       mockFindCodebaseByRepoUrl.mockClear();
       mockCreateCodebase.mockClear();
       mockFindOrCreateUserByPlatformIdentity.mockClear();
+    });
+
+    afterEach(() => {
+      if (originalAllowedUsers === undefined) {
+        delete process.env.GITHUB_ALLOWED_USERS;
+      } else {
+        process.env.GITHUB_ALLOWED_USERS = originalAllowedUsers;
+      }
     });
 
     test('getInstallationToken called once per (owner, repo) for sendMessage', async () => {

--- a/packages/cli/src/commands/ai.test.ts
+++ b/packages/cli/src/commands/ai.test.ts
@@ -312,6 +312,13 @@ describe('aiTierSetCommand', () => {
     expect(arg.tiers.large).toEqual({ provider: 'claude', model: 'opus', effort: 'high' });
   });
 
+  it('accepts Codex minimal tier effort', async () => {
+    expect(await aiTierSetCommand('small', 'codex', 'gpt-5.5', 'minimal')).toBe(0);
+    expect(mockUpdateGlobalConfig).toHaveBeenCalledTimes(1);
+    const arg = mockUpdateGlobalConfig.mock.calls[0]?.[0] as { tiers: Record<string, unknown> };
+    expect(arg.tiers.small).toEqual({ provider: 'codex', model: 'gpt-5.5', effort: 'minimal' });
+  });
+
   it('invalid tier name → 1, no write', async () => {
     expect(await aiTierSetCommand('huge', 'claude', 'opus', undefined)).toBe(1);
     expect(mockUpdateGlobalConfig).not.toHaveBeenCalled();

--- a/packages/core/src/db/codebases.test.ts
+++ b/packages/core/src/db/codebases.test.ts
@@ -1,4 +1,4 @@
-import { mock, describe, test, expect, beforeEach } from 'bun:test';
+import { mock, describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { createQueryResult, mockPostgresDialect } from '../test/mocks/database';
 import { Codebase } from '../types';
 
@@ -26,8 +26,20 @@ import {
 } from './codebases';
 
 describe('codebases', () => {
+  let originalDefaultAiAssistant: string | undefined;
+
   beforeEach(() => {
+    originalDefaultAiAssistant = process.env.DEFAULT_AI_ASSISTANT;
+    delete process.env.DEFAULT_AI_ASSISTANT;
     mockQuery.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalDefaultAiAssistant === undefined) {
+      delete process.env.DEFAULT_AI_ASSISTANT;
+    } else {
+      process.env.DEFAULT_AI_ASSISTANT = originalDefaultAiAssistant;
+    }
   });
 
   const mockCodebase: Codebase = {

--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -742,7 +742,7 @@ describe('CodexProvider', () => {
       for await (const _ of client.sendQuery('test prompt', '/workspace', undefined, {
         model: 'gpt-5.2-codex',
         assistantConfig: {
-          modelReasoningEffort: 'medium',
+          modelReasoningEffort: 'minimal',
           webSearchMode: 'live',
           additionalDirectories: ['/other/repo'],
         },
@@ -753,7 +753,7 @@ describe('CodexProvider', () => {
       expect(mockStartThread).toHaveBeenCalledWith(
         expect.objectContaining({
           model: 'gpt-5.2-codex',
-          modelReasoningEffort: 'medium',
+          modelReasoningEffort: 'minimal',
           webSearchMode: 'live',
           additionalDirectories: ['/other/repo'],
         })

--- a/packages/server/src/routes/api.providers.test.ts
+++ b/packages/server/src/routes/api.providers.test.ts
@@ -257,6 +257,14 @@ describe('PATCH /api/config/tiers', () => {
     expect(arg.tiers.large).toEqual({ provider: 'claude', model: 'opus', effort: 'high' });
   });
 
+  test('accepts Codex minimal tier effort', async () => {
+    const res = await patch({ small: { provider: 'codex', model: 'gpt-5.5', effort: 'minimal' } });
+    expect(res.status).toBe(200);
+    expect(mockUpdateGlobalConfig).toHaveBeenCalledTimes(1);
+    const arg = mockUpdateGlobalConfig.mock.calls[0]?.[0] as { tiers: Record<string, unknown> };
+    expect(arg.tiers.small).toEqual({ provider: 'codex', model: 'gpt-5.5', effort: 'minimal' });
+  });
+
   test('unknown provider → 400, no write', async () => {
     const res = await patch({ large: { provider: 'definitely-not-a-provider', model: 'x' } });
     expect(res.status).toBe(400);

--- a/packages/server/src/routes/api.user-ai-prefs.test.ts
+++ b/packages/server/src/routes/api.user-ai-prefs.test.ts
@@ -267,6 +267,23 @@ describe('PATCH /api/auth/me/ai-prefs/tiers', () => {
     expect(await res.json()).toEqual({ tiers: { large: { provider: 'claude', model: 'opus' } } });
   });
 
+  test('accepts Codex minimal tier effort', async () => {
+    const res = await makeApp().request('/api/auth/me/ai-prefs/tiers', {
+      method: 'PATCH',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({
+        tiers: { small: { provider: 'codex', model: 'gpt-5.5', effort: 'minimal' } },
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(mockSetTiers).toHaveBeenCalledWith('user-from-alice', {
+      small: { provider: 'codex', model: 'gpt-5.5', effort: 'minimal' },
+    });
+    expect(await res.json()).toEqual({
+      tiers: { small: { provider: 'codex', model: 'gpt-5.5', effort: 'minimal' } },
+    });
+  });
+
   test('null unsets a tier', async () => {
     prefsByUser['user-from-alice'] = {
       tiers: {

--- a/packages/server/src/routes/api.workflows.test.ts
+++ b/packages/server/src/routes/api.workflows.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, spyOn } from 'bun:test';
+import { afterEach, beforeEach, describe, test, expect, mock, spyOn } from 'bun:test';
 import { OpenAPIHono } from '@hono/zod-openapi';
 import type { ConversationLockManager } from '@archon/core';
 import type { WebAdapter } from '../adapters/web';
@@ -12,6 +12,23 @@ import { makeTestWorkflow, makeTestWorkflowWithSource } from '@archon/workflows/
 function createTestApp(): OpenAPIHono {
   return new OpenAPIHono({ defaultHook: validationErrorHook });
 }
+
+const originalArchonHome = process.env.ARCHON_HOME;
+const isolatedArchonHome = join(tmpdir(), 'archon-api-workflows-test-home');
+
+beforeEach(async () => {
+  await rm(isolatedArchonHome, { recursive: true, force: true });
+  process.env.ARCHON_HOME = isolatedArchonHome;
+});
+
+afterEach(async () => {
+  await rm(isolatedArchonHome, { recursive: true, force: true });
+  if (originalArchonHome === undefined) {
+    delete process.env.ARCHON_HOME;
+  } else {
+    process.env.ARCHON_HOME = originalArchonHome;
+  }
+});
 
 const mockDiscoverWorkflows = mock(async (_cwd: string | null) => ({
   workflows: [makeTestWorkflowWithSource({ name: 'deploy', description: 'Deploy app' }, 'bundled')],

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -1170,6 +1170,147 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     expect(nodeConfig.effort).toBeUndefined();
   });
 
+  it('passes workflow-level Codex options to assistantConfig', async () => {
+    mockGetAgentProviderDag.mockImplementation(() => ({
+      sendQuery: mockSendQueryDag,
+      getType: () => 'codex',
+      getCapabilities: mockCodexCapabilities,
+    }));
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-dag',
+      testDir,
+      {
+        name: 'codex-workflow-options-test',
+        modelReasoningEffort: 'minimal',
+        webSearchMode: 'live',
+        additionalDirectories: ['/workspace/shared'],
+        nodes: [{ id: 'step1', command: 'my-cmd' }],
+      },
+      workflowRun,
+      'codex',
+      'gpt-5.5',
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      {
+        ...minimalConfig,
+        assistants: {
+          claude: {},
+          codex: {
+            modelReasoningEffort: 'high',
+            webSearchMode: 'disabled',
+            additionalDirectories: ['/workspace/default'],
+          },
+        },
+      }
+    );
+
+    expect(mockGetAgentProviderDag.mock.calls[0][0]).toBe('codex');
+    const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
+    const assistantConfig = optionsArg.assistantConfig as Record<string, unknown>;
+    expect(assistantConfig.modelReasoningEffort).toBe('minimal');
+    expect(assistantConfig.webSearchMode).toBe('live');
+    expect(assistantConfig.additionalDirectories).toEqual(['/workspace/shared']);
+  });
+
+  it('routes built-in Codex small tier effort to assistantConfig.modelReasoningEffort', async () => {
+    mockGetAgentProviderDag.mockImplementation(() => ({
+      sendQuery: mockSendQueryDag,
+      getType: () => 'codex',
+      getCapabilities: mockCodexCapabilities,
+    }));
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+    const aiProfile = buildAiProfile('codex');
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-dag',
+      testDir,
+      {
+        name: 'codex-small-tier-effort-test',
+        nodes: [{ id: 'step1', command: 'my-cmd', model: 'small' }],
+      },
+      workflowRun,
+      'codex',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      aiProfile
+    );
+
+    expect(mockGetAgentProviderDag.mock.calls[0][0]).toBe('codex');
+    const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
+    expect(optionsArg.model).toBe('gpt-5.5');
+    const assistantConfig = optionsArg.assistantConfig as Record<string, unknown>;
+    const nodeConfig = optionsArg.nodeConfig as Record<string, unknown>;
+    expect(assistantConfig.modelReasoningEffort).toBe('minimal');
+    expect(nodeConfig.effort).toBeUndefined();
+  });
+
+  it('prefers workflow-level Codex reasoning over tier preset effort', async () => {
+    mockGetAgentProviderDag.mockImplementation(() => ({
+      sendQuery: mockSendQueryDag,
+      getType: () => 'codex',
+      getCapabilities: mockCodexCapabilities,
+    }));
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+    const aiProfile = buildAiProfile('codex', {
+      repoTiers: {
+        small: { provider: 'codex', model: 'gpt-5.5', effort: 'minimal' },
+      },
+    });
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-dag',
+      testDir,
+      {
+        name: 'codex-workflow-reasoning-precedence-test',
+        modelReasoningEffort: 'low',
+        nodes: [{ id: 'step1', command: 'my-cmd', model: 'small' }],
+      },
+      workflowRun,
+      'codex',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      aiProfile
+    );
+
+    expect(mockGetAgentProviderDag.mock.calls[0][0]).toBe('codex');
+    const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
+    expect(optionsArg.model).toBe('gpt-5.5');
+    const assistantConfig = optionsArg.assistantConfig as Record<string, unknown>;
+    expect(assistantConfig.modelReasoningEffort).toBe('low');
+  });
+
   it('applies inherited workflow tier effort to nodes without model overrides', async () => {
     mockGetAgentProviderDag.mockImplementation(() => ({
       sendQuery: mockSendQueryDag,
@@ -1562,6 +1703,10 @@ describe('executeDagWorkflow -- bash nodes', () => {
   });
 
   it('bash node stdout is available for downstream $nodeId.output substitution', async () => {
+    const execSpy = spyOn(git, 'execFileAsync').mockResolvedValue({
+      stdout: '42 files\n',
+      stderr: '',
+    });
     const mockDeps = createMockDeps();
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('bash-test-run-id', {
@@ -1580,27 +1725,31 @@ describe('executeDagWorkflow -- bash nodes', () => {
       { id: 'process', command: 'my-cmd', depends_on: ['stats'] },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
-      platform,
-      'conv-bash',
-      testDir,
-      { name: 'bash-subst-test', nodes },
-      workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    try {
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-bash',
+        testDir,
+        { name: 'bash-subst-test', nodes },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
 
-    // AI client should have been called for the downstream node
-    expect(mockSendQueryDag.mock.calls.length).toBe(1);
-    // The prompt should contain the substituted bash output
-    const prompt = mockSendQueryDag.mock.calls[0][0] as string;
-    expect(prompt).toContain('42 files');
+      // AI client should have been called for the downstream node
+      expect(mockSendQueryDag.mock.calls.length).toBe(1);
+      // The prompt should contain the substituted bash output
+      const prompt = mockSendQueryDag.mock.calls[0][0] as string;
+      expect(prompt).toContain('42 files');
+    } finally {
+      execSpy.mockRestore();
+    }
   });
 
   it('non-zero exit code results in failed state', async () => {
@@ -1642,6 +1791,18 @@ describe('executeDagWorkflow -- bash nodes', () => {
   });
 
   it('failure message surfaces stderr and does not leak the "Command failed: bash -c <body>" prefix', async () => {
+    const execSpy = spyOn(git, 'execFileAsync').mockRejectedValue(
+      Object.assign(
+        new Error(
+          'Command failed: bash -c echo UNIQUE_CMDLINE_MARKER_1389; echo "diagnostic from stderr" >&2; exit 1\n' +
+            'diagnostic from stderr'
+        ),
+        {
+          code: 1,
+          stderr: 'diagnostic from stderr\n',
+        }
+      )
+    );
     const mockDeps = createMockDeps();
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('bash-1389-run-id', {
@@ -1658,35 +1819,39 @@ describe('executeDagWorkflow -- bash nodes', () => {
       bash: 'echo UNIQUE_CMDLINE_MARKER_1389; echo "diagnostic from stderr" >&2; exit 1',
     };
 
-    await executeDagWorkflow(
-      mockDeps,
-      platform,
-      'conv-1389b',
-      testDir,
-      { name: 'bash-1389', nodes: [bashNode] },
-      workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    try {
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-1389b',
+        testDir,
+        { name: 'bash-1389', nodes: [bashNode] },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
 
-    const eventCalls = (mockDeps.store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
-    const failedEvent = eventCalls.find(
-      (call: unknown[]) =>
-        (call[0] as { event_type: string }).event_type === 'node_failed' &&
-        (call[0] as { step_name: string }).step_name === 'fail-bash-1389'
-    );
-    expect(failedEvent).toBeDefined();
-    const errorMsg = (failedEvent![0] as { data: { error: string } }).data.error;
-    expect(errorMsg).toContain("Bash node 'fail-bash-1389' failed");
-    expect(errorMsg).toContain('[exit 1]');
-    expect(errorMsg).not.toContain('Command failed:');
-    expect(errorMsg).not.toContain('UNIQUE_CMDLINE_MARKER_1389');
-    expect(errorMsg).toContain('diagnostic from stderr');
+      const eventCalls = (mockDeps.store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+      const failedEvent = eventCalls.find(
+        (call: unknown[]) =>
+          (call[0] as { event_type: string }).event_type === 'node_failed' &&
+          (call[0] as { step_name: string }).step_name === 'fail-bash-1389'
+      );
+      expect(failedEvent).toBeDefined();
+      const errorMsg = (failedEvent![0] as { data: { error: string } }).data.error;
+      expect(errorMsg).toContain("Bash node 'fail-bash-1389' failed");
+      expect(errorMsg).toContain('[exit 1]');
+      expect(errorMsg).not.toContain('Command failed:');
+      expect(errorMsg).not.toContain('UNIQUE_CMDLINE_MARKER_1389');
+      expect(errorMsg).toContain('diagnostic from stderr');
+    } finally {
+      execSpy.mockRestore();
+    }
   });
 
   it('variable substitution works in bash scripts', async () => {
@@ -3740,6 +3905,10 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
   });
 
   it('stores node_output in node_completed event data for bash nodes', async () => {
+    const execSpy = spyOn(git, 'execFileAsync').mockResolvedValue({
+      stdout: 'bash output\n',
+      stderr: '',
+    });
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
     const platform = createMockPlatform();
@@ -3747,32 +3916,36 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
     const bashNode: BashNode = { id: 'stats', bash: 'echo "bash output"' };
 
-    await executeDagWorkflow(
-      mockDeps,
-      platform,
-      'conv-bash-output',
-      testDir,
-      { name: 'bash-output-test', nodes: [bashNode] },
-      workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    try {
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-bash-output',
+        testDir,
+        { name: 'bash-output-test', nodes: [bashNode] },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
 
-    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
-    const completedEvent = eventCalls.find(
-      (call: unknown[]) =>
-        (call[0] as { event_type: string }).event_type === 'node_completed' &&
-        (call[0] as { step_name: string }).step_name === 'stats'
-    );
-    expect(completedEvent).toBeDefined();
-    expect((completedEvent![0] as { data: { node_output: string } }).data.node_output).toContain(
-      'bash output'
-    );
+      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+      const completedEvent = eventCalls.find(
+        (call: unknown[]) =>
+          (call[0] as { event_type: string }).event_type === 'node_completed' &&
+          (call[0] as { step_name: string }).step_name === 'stats'
+      );
+      expect(completedEvent).toBeDefined();
+      expect((completedEvent![0] as { data: { node_output: string } }).data.node_output).toContain(
+        'bash output'
+      );
+    } finally {
+      execSpy.mockRestore();
+    }
   });
 
   it('stores node_output in node_completed event data for AI nodes', async () => {
@@ -6431,6 +6604,10 @@ describe('executeDagWorkflow -- cancel node', () => {
   });
 
   it('cancel node transitions run to cancelled and sends message', async () => {
+    const execSpy = spyOn(git, 'execFileAsync').mockResolvedValue({
+      stdout: 'blocked\n',
+      stderr: '',
+    });
     const store = createMockStore();
     (store.cancelWorkflowRun as Mock<() => Promise<void>>).mockResolvedValue(undefined);
     // Track whether cancelWorkflowRun has been called to simulate status transition
@@ -6445,37 +6622,41 @@ describe('executeDagWorkflow -- cancel node', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
-      platform,
-      'conv-dag',
-      testDir,
-      {
-        name: 'cancel-test',
-        nodes: [
-          { id: 'check', bash: 'echo blocked' },
-          { id: 'stop', depends_on: ['check'], cancel: 'Precondition failed' },
-        ],
-      },
-      workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    try {
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        {
+          name: 'cancel-test',
+          nodes: [
+            { id: 'check', bash: 'echo blocked' },
+            { id: 'stop', depends_on: ['check'], cancel: 'Precondition failed' },
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
 
-    // cancelWorkflowRun should have been called
-    expect((store.cancelWorkflowRun as Mock<() => Promise<void>>).mock.calls.length).toBe(1);
+      // cancelWorkflowRun should have been called
+      expect((store.cancelWorkflowRun as Mock<() => Promise<void>>).mock.calls.length).toBe(1);
 
-    // A message with the cancel reason should have been sent
-    const sendCalls = (platform.sendMessage as Mock<() => Promise<void>>).mock.calls;
-    const cancelMsg = sendCalls.find(
-      (call: unknown[]) => typeof call[1] === 'string' && call[1].includes('Workflow cancelled')
-    );
-    expect(cancelMsg).toBeDefined();
+      // A message with the cancel reason should have been sent
+      const sendCalls = (platform.sendMessage as Mock<() => Promise<void>>).mock.calls;
+      const cancelMsg = sendCalls.find(
+        (call: unknown[]) => typeof call[1] === 'string' && call[1].includes('Workflow cancelled')
+      );
+      expect(cancelMsg).toBeDefined();
+    } finally {
+      execSpy.mockRestore();
+    }
   });
 
   it('cancel node with when: false is skipped', async () => {
@@ -8509,7 +8690,21 @@ describe('executeDagWorkflow -- final status derivation', () => {
     }
   });
 
+  function mockStatusBashExecutions(): { mockRestore: () => void } {
+    return spyOn(git, 'execFileAsync').mockImplementation(async (_cmd: string, args: string[]) => {
+      const script = String(args[1] ?? '');
+      if (script.includes('exit 1')) {
+        throw Object.assign(new Error(`Command failed: bash -c ${script}\nfailure`), {
+          code: 1,
+          stderr: 'failure\n',
+        });
+      }
+      return { stdout: 'ok\n', stderr: '' };
+    });
+  }
+
   it('one success + one independent failure -> failWorkflowRun, not completeWorkflowRun', async () => {
+    const execSpy = mockStatusBashExecutions();
     const mockStore = createMockStore();
     const mockDeps = createMockDeps(mockStore);
     const platform = createMockPlatform();
@@ -8520,37 +8715,42 @@ describe('executeDagWorkflow -- final status derivation', () => {
       { id: 'fail', bash: 'exit 1' } as BashNode,
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
-      platform,
-      'conv-status',
-      testDir,
-      { name: 'status-test', nodes },
-      workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    try {
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-status',
+        testDir,
+        { name: 'status-test', nodes },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
 
-    expect((mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
-    expect((mockStore.completeWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
-    expect(mockStore.failWorkflowRun).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.stringContaining('fail')
-    );
+      expect((mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+      expect((mockStore.completeWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+      expect(mockStore.failWorkflowRun).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('fail')
+      );
 
-    // Confirm the failure message names the failing node
-    const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
-    const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
-    const failMsg = messages.find((m: string) => m.includes('completed with failures'));
-    expect(failMsg).toBeDefined();
+      // Confirm the failure message names the failing node
+      const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
+      const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
+      const failMsg = messages.find((m: string) => m.includes('completed with failures'));
+      expect(failMsg).toBeDefined();
+    } finally {
+      execSpy.mockRestore();
+    }
   });
 
   it('multiple successes + one failure -> failWorkflowRun, not completeWorkflowRun', async () => {
+    const execSpy = mockStatusBashExecutions();
     const mockStore = createMockStore();
     const mockDeps = createMockDeps(mockStore);
     const platform = createMockPlatform();
@@ -8563,33 +8763,37 @@ describe('executeDagWorkflow -- final status derivation', () => {
       { id: 'fail', bash: 'exit 1' } as BashNode,
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
-      platform,
-      'conv-status',
-      testDir,
-      { name: 'status-test-multi', nodes },
-      workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    try {
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-status',
+        testDir,
+        { name: 'status-test-multi', nodes },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
 
-    expect((mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
-    expect((mockStore.completeWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
-    expect(mockStore.failWorkflowRun).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.stringContaining('fail')
-    );
+      expect((mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+      expect((mockStore.completeWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+      expect(mockStore.failWorkflowRun).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('fail')
+      );
 
-    const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
-    const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
-    const failMsg = messages.find((m: string) => m.includes('completed with failures'));
-    expect(failMsg).toBeDefined();
+      const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
+      const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
+      const failMsg = messages.find((m: string) => m.includes('completed with failures'));
+      expect(failMsg).toBeDefined();
+    } finally {
+      execSpy.mockRestore();
+    }
   });
 
   it('trigger_rule: none_failed skips dependent node + anyFailed still marks run failed', async () => {
@@ -8847,35 +9051,44 @@ describe('executeDagWorkflow -- typed artifacts (output_type)', () => {
   });
 
   it('bash node with output_type writes a sidecar with no sessionId', async () => {
-    await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      {
-        name: 'bash-typed',
-        nodes: [{ id: 'metrics', bash: 'echo "result-data"', output_type: 'metrics' }],
-      },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    const execSpy = spyOn(git, 'execFileAsync').mockResolvedValue({
+      stdout: 'result-data\n',
+      stderr: '',
+    });
 
-    const body = await readFile(join(testDir, 'artifacts', 'nodes', 'metrics.md'), 'utf8');
-    expect(body).toContain('result-data');
-    const meta = JSON.parse(
-      await readFile(join(testDir, 'artifacts', 'nodes', 'metrics.meta.json'), 'utf8')
-    ) as Record<string, unknown>;
-    expect(meta).toMatchObject({ nodeId: 'metrics', outputType: 'metrics' });
-    // Bash nodes have no provider session — the field is omitted, not null.
-    expect('sessionId' in meta).toBe(false);
-    // Bash node does not invoke the AI client.
-    expect(mockSendQueryDag.mock.calls.length).toBe(0);
+    try {
+      await executeDagWorkflow(
+        createMockDeps(),
+        createMockPlatform(),
+        'conv-dag',
+        testDir,
+        {
+          name: 'bash-typed',
+          nodes: [{ id: 'metrics', bash: 'echo "result-data"', output_type: 'metrics' }],
+        },
+        makeWorkflowRun(),
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      const body = await readFile(join(testDir, 'artifacts', 'nodes', 'metrics.md'), 'utf8');
+      expect(body).toContain('result-data');
+      const meta = JSON.parse(
+        await readFile(join(testDir, 'artifacts', 'nodes', 'metrics.meta.json'), 'utf8')
+      ) as Record<string, unknown>;
+      expect(meta).toMatchObject({ nodeId: 'metrics', outputType: 'metrics' });
+      // Bash nodes have no provider session — the field is omitted, not null.
+      expect('sessionId' in meta).toBe(false);
+      // Bash node does not invoke the AI client.
+      expect(mockSendQueryDag.mock.calls.length).toBe(0);
+    } finally {
+      execSpy.mockRestore();
+    }
   });
 
   it('artifact write failure is non-fatal — the node still completes', async () => {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -40,6 +40,8 @@ import type {
   TriggerRule,
   WorkflowRun,
   EffortLevel,
+  ModelReasoningEffort,
+  WebSearchMode,
   ThinkingConfig,
   SandboxSettings,
   WorkflowSource,
@@ -190,7 +192,8 @@ function applyPresetOptions(
   if (
     preset.effort === undefined ||
     node.effort !== undefined ||
-    workflowLevelOptions.effort !== undefined
+    workflowLevelOptions.effort !== undefined ||
+    (provider === 'codex' && workflowLevelOptions.modelReasoningEffort !== undefined)
   ) {
     return;
   }
@@ -210,6 +213,24 @@ function applyPresetOptions(
     nodeConfig.effort = routed.value;
   } else {
     assistantConfig.modelReasoningEffort = routed.value;
+  }
+}
+
+function applyCodexWorkflowAssistantOptions(
+  provider: string,
+  workflowLevelOptions: WorkflowLevelOptions,
+  assistantConfig: Record<string, unknown>
+): void {
+  if (provider !== 'codex') return;
+
+  if (workflowLevelOptions.modelReasoningEffort !== undefined) {
+    assistantConfig.modelReasoningEffort = workflowLevelOptions.modelReasoningEffort;
+  }
+  if (workflowLevelOptions.webSearchMode !== undefined) {
+    assistantConfig.webSearchMode = workflowLevelOptions.webSearchMode;
+  }
+  if (workflowLevelOptions.additionalDirectories !== undefined) {
+    assistantConfig.additionalDirectories = workflowLevelOptions.additionalDirectories;
   }
 }
 
@@ -266,9 +287,12 @@ export async function loadConfiguredMcpServerNames(
   }
 }
 
-/** Workflow-level Claude SDK options — per-node overrides take precedence via ?? */
+/** Workflow-level provider options — per-node overrides take precedence via ?? where supported. */
 interface WorkflowLevelOptions {
   effort?: EffortLevel;
+  modelReasoningEffort?: ModelReasoningEffort;
+  webSearchMode?: WebSearchMode;
+  additionalDirectories?: string[];
   thinking?: ThinkingConfig;
   fallbackModel?: string;
   betas?: string[];
@@ -638,6 +662,7 @@ async function resolveNodeProviderAndModel(
     nodeConfig,
     assistantConfig
   );
+  applyCodexWorkflowAssistantOptions(provider, workflowLevelOptions, assistantConfig);
 
   const options: SendQueryOptions = {
     ...baseOptions,
@@ -2892,6 +2917,9 @@ export async function executeDagWorkflow(
   const dagStartTime = Date.now();
   const workflowLevelOptions = {
     effort: workflow.effort,
+    modelReasoningEffort: workflow.modelReasoningEffort,
+    webSearchMode: workflow.webSearchMode,
+    additionalDirectories: workflow.additionalDirectories,
     thinking: workflow.thinking,
     fallbackModel: workflow.fallbackModel,
     betas: workflow.betas,


### PR DESCRIPTION
﻿## Summary

Describe this PR in 2-5 bullets:

- Problem: workflow-level Codex options such as `modelReasoningEffort: minimal` were parsed but not forwarded into DAG node `assistantConfig`.
- Why it matters: users selecting Codex `minimal` reasoning could get a different runtime effort than configured, especially when tier defaults or aliases were involved.
- What changed: DAG execution now applies Codex workflow-level `modelReasoningEffort`, `webSearchMode`, and `additionalDirectories` to `assistantConfig`, with explicit workflow reasoning taking precedence over preset effort.
- What did **not** change (scope boundary): Claude node/workflow `effort`, Copilot/OpenCode behavior, Settings UI semantics, docs, generated API types, and unrelated workflow YAML/defaults drift.

## UX Journey

### Before

```text
User                    Archon workflow engine              Codex provider
----                    ----------------------              --------------
sets minimal effort --> loader accepts workflow field
                        DAG builds node options
                        workflow Codex fields dropped ----> receives no minimal workflow effort
user observes run <---- response streams back                 SDK uses default/tier behavior
```

### After

```text
User                    Archon workflow engine                    Codex provider
----                    ----------------------                    --------------
sets minimal effort --> loader accepts workflow field
                        DAG builds node options
                        [applies Codex workflow assistant config] ==> receives minimal/webSearch/directories
user observes run <---- response streams back                       SDK uses configured workflow effort
```

## Architecture Diagram

### Before

```text
workflow schema -> loader -> dag-executor -> provider registry -> CodexProvider -> Codex SDK
                         \-> preset tier routing -> assistantConfig
```

### After

```text
workflow schema -> loader -> [~] dag-executor ===> assistantConfig ===> CodexProvider -> Codex SDK
                         \-> [~] preset tier routing respects explicit workflow modelReasoningEffort
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `workflowSchema` | `loader` | unchanged | Existing schema already parsed Codex workflow-level options. |
| `loader` | `dag-executor` | unchanged | Workflow object already carried parsed fields. |
| `dag-executor` | `assistantConfig` | **modified** | Codex workflow-level options are now copied into assistant config. |
| `dag-executor` | preset tier routing | **modified** | Explicit workflow `modelReasoningEffort` blocks preset effort overwrite for Codex. |
| `assistantConfig` | `CodexProvider` | unchanged | Provider already forwards assistant config to SDK thread options. |
| route/CLI validation | config writes | **modified** | Tests now lock acceptance of Codex `effort: minimal`. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `workflows|providers|server|cli|adapters|core|tests`
- Module: `workflows:dag-executor`, `providers:codex`, `server:ai-config`, `cli:ai`, `tests:validation`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi`

## Linked Issue

- Closes: None provided by workflow artifacts.
- Related: Workflow `1d7c2db9d26534d28e79af44b0d707a6`
- Depends on: None
- Supersedes: None

## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check
bun run lint --max-warnings 0
bun run format:check
bun run test
bun run build
bun run validate
```

- Evidence provided (test/log/trace/screenshot): validation artifact reports type-check pass, lint pass with 0 warnings, format pass, `bun run test` pass with 5135 passed / 0 failed / 17 skipped, build pass, and aggregate `bun run validate` pass.
- If any command is intentionally skipped, explain why: none skipped in final validation artifact.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: N/A

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Database migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Codex DAG workflow-level `modelReasoningEffort: minimal` reaches `assistantConfig`; `webSearchMode` and `additionalDirectories` are forwarded for Codex; built-in Codex `small` tier still routes minimal effort; explicit workflow reasoning wins over preset effort.
- Edge cases checked: server install-scope tier/alias writes accept Codex `effort: minimal`; per-user tier/alias writes accept Codex `effort: minimal`; CLI `--effort minimal` validation accepts Codex.
- What was not verified: browser UI flow, because no UI behavior changed; generated API and docs were verified as already accurate and left unchanged.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: DAG workflow execution for Codex nodes, Codex provider forwarding tests, AI preference validation tests, CLI AI config tests, deterministic test isolation in affected suites.
- Potential unintended effects: provider option precedence regressions if future providers reuse Codex-specific fields incorrectly.
- Guardrails/monitoring for early detection: focused DAG regression tests, Codex provider thread option tests, server/CLI validation tests, and aggregate validation.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `6853b056`.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: Codex workflows ignore configured reasoning effort again, or tests around Codex `minimal` effort fail.

## Risks and Mitigations

- Risk: Codex preset effort could override an explicit workflow-level reasoning setting.
  - Mitigation: DAG tests cover explicit workflow precedence over tier preset effort.
- Risk: non-Codex providers could accidentally receive Codex-only workflow fields.
  - Mitigation: the new helper applies only when the resolved provider is `codex`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "minimal" effort tier setting for AI model configuration
  * Introduced workflow-level AI options for reasoning effort, web search mode, and additional directories

* **Tests**
  * Enhanced test isolation and environment variable restoration across test suites
  * Expanded test coverage for AI tier settings and workflow execution behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->