### PR TITLE
Fix Bundled Archon Skill Description Length

### DIFF
--- a/.claude/skills/archon/SKILL.md
+++ b/.claude/skills/archon/SKILL.md
@@ -1,21 +1,16 @@
 ---
 name: archon
 description: |
-  Use when: User wants to run Archon workflows, CREATE workflows or commands,
-  set up Archon, or manage Archon configuration.
-  Triggers (run): "use archon to", "run archon", "archon workflow", "use archon for",
-            "have archon", "let archon", "ask archon to".
-  Triggers (create): "create a workflow", "write a workflow", "make a command",
-            "author a workflow", "new workflow", "new command", "archon workflow yaml".
-  Triggers (setup): "set up archon", "install archon", "how to use archon",
-            "configure archon", "archon setup", "get started with archon".
-  Triggers (config): "change my archon config", "modify archon config", "archon config",
-            "change archon settings", "update my config", "help me change my config",
-            "edit archon config", "archon configuration".
-  Triggers (init): "initialize archon", "set up .archon", "archon init", "add archon to repo".
-  Capability: Runs AI workflows in isolated git worktrees for parallel development.
-  Also: Creates and manages workflow YAML files, command files, and configuration.
-  NOT for: Direct Claude Code work - only for delegating to Archon CLI.
+  Use when: User wants to run Archon workflows; create Archon workflow YAML or
+  command files; set up/install Archon; configure or update Archon settings; or
+  initialize `.archon` in a repo.
+  Triggers: "run archon", "archon workflow", "use archon to", "create a workflow",
+  "new workflow", "make a command", "archon workflow yaml", "set up archon",
+  "install archon", "configure archon", "archon config", "update my config",
+  "archon init", "set up .archon".
+  Capability: Delegates to the Archon CLI for workflow execution and authoring in
+  isolated git worktrees.
+  NOT for: Direct coding work unless the user explicitly wants Archon to run it.
 argument-hint: "[workflow] [message or issue number]"
 ---
 

--- a/packages/adapters/src/forge/github/adapter.test.ts
+++ b/packages/adapters/src/forge/github/adapter.test.ts
@@ -1199,13 +1199,24 @@ describe('GitHubAdapter', () => {
       provider: ReturnType<typeof makeMockProvider>;
     } {
       const provider = makeMockProvider(opts);
-      const adapter = new GitHubAdapter(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock provider isn't structurally identical to the real interface (suffices for these tests)
-        { kind: 'app', provider: provider.provider as any },
-        'fake-webhook-secret',
-        mockLockManager,
-        'archon'
-      );
+      const originalAllowedUsers = process.env.GITHUB_ALLOWED_USERS;
+      delete process.env.GITHUB_ALLOWED_USERS;
+      let adapter: GitHubAdapter;
+      try {
+        adapter = new GitHubAdapter(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock provider isn't structurally identical to the real interface (suffices for these tests)
+          { kind: 'app', provider: provider.provider as any },
+          'fake-webhook-secret',
+          mockLockManager,
+          'archon'
+        );
+      } finally {
+        if (originalAllowedUsers === undefined) {
+          delete process.env.GITHUB_ALLOWED_USERS;
+        } else {
+          process.env.GITHUB_ALLOWED_USERS = originalAllowedUsers;
+        }
+      }
       // @ts-expect-error - mock signature verification
       adapter.verifySignature = mock(() => true);
       return { adapter, provider };

--- a/packages/cli/src/commands/skill.test.ts
+++ b/packages/cli/src/commands/skill.test.ts
@@ -8,6 +8,62 @@ import { join } from 'path';
 import { BUNDLED_MANAGE_RUN_SKILL_FILES, BUNDLED_SKILL_FILES } from '../bundled-skill';
 import { copyArchonSkill, skillInstallCommand } from './skill';
 
+const SKILL_DESCRIPTION_MAX_CHARS = 1024;
+
+function extractFrontmatter(markdown: string): string {
+  const lines = markdown.split(/\r?\n/);
+  if (lines[0] !== '---') {
+    throw new Error('missing frontmatter');
+  }
+
+  const endIndex = lines.findIndex((line, index) => index > 0 && line === '---');
+  if (endIndex === -1) {
+    throw new Error('unterminated frontmatter');
+  }
+
+  return lines.slice(1, endIndex).join('\n');
+}
+
+function trimBlockIndent(lines: string[]): string {
+  const indentedLines = lines.filter(line => line.trim().length > 0);
+  const indent =
+    indentedLines.length === 0
+      ? 0
+      : Math.min(...indentedLines.map(line => /^\s*/.exec(line)?.[0].length ?? 0));
+
+  return lines
+    .map(line => line.slice(Math.min(indent, line.length)))
+    .join('\n')
+    .trimEnd();
+}
+
+function extractSkillDescription(markdown: string): string {
+  const lines = extractFrontmatter(markdown).split('\n');
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const match = /^description:\s*(.*)$/.exec(lines[i]);
+    if (match === null) {
+      continue;
+    }
+
+    const value = match[1].trim();
+    if (value !== '|') {
+      return value;
+    }
+
+    const blockLines: string[] = [];
+    for (let j = i + 1; j < lines.length; j += 1) {
+      if (lines[j].length > 0 && !/^\s/.test(lines[j])) {
+        break;
+      }
+      blockLines.push(lines[j]);
+    }
+    return trimBlockIndent(blockLines);
+  }
+
+  throw new Error('missing description');
+}
+
 describe('copyArchonSkill', () => {
   let tempDir: string;
 
@@ -63,6 +119,22 @@ describe('copyArchonSkill', () => {
 
     await copyArchonSkill(tempDir);
     expect(readFileSync(skillMdPath, 'utf-8')).toBe(BUNDLED_SKILL_FILES['SKILL.md']);
+  });
+});
+
+describe('bundled skill metadata', () => {
+  it('keeps the archon skill description within the Agent Skills limit', () => {
+    const description = extractSkillDescription(BUNDLED_SKILL_FILES['SKILL.md']);
+
+    expect(description.length).toBeGreaterThan(0);
+    expect(description.length).toBeLessThanOrEqual(SKILL_DESCRIPTION_MAX_CHARS);
+  });
+
+  it('keeps the manage-run skill description within the Agent Skills limit', () => {
+    const description = extractSkillDescription(BUNDLED_MANAGE_RUN_SKILL_FILES['SKILL.md']);
+
+    expect(description.length).toBeGreaterThan(0);
+    expect(description.length).toBeLessThanOrEqual(SKILL_DESCRIPTION_MAX_CHARS);
   });
 });
 

--- a/packages/core/src/db/codebases.test.ts
+++ b/packages/core/src/db/codebases.test.ts
@@ -1,4 +1,4 @@
-import { mock, describe, test, expect, beforeEach } from 'bun:test';
+import { mock, describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { createQueryResult, mockPostgresDialect } from '../test/mocks/database';
 import { Codebase } from '../types';
 
@@ -26,8 +26,20 @@ import {
 } from './codebases';
 
 describe('codebases', () => {
+  let originalDefaultAssistant: string | undefined;
+
   beforeEach(() => {
+    originalDefaultAssistant = process.env.DEFAULT_AI_ASSISTANT;
+    delete process.env.DEFAULT_AI_ASSISTANT;
     mockQuery.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalDefaultAssistant === undefined) {
+      delete process.env.DEFAULT_AI_ASSISTANT;
+    } else {
+      process.env.DEFAULT_AI_ASSISTANT = originalDefaultAssistant;
+    }
   });
 
   const mockCodebase: Codebase = {

--- a/packages/git/src/exec.ts
+++ b/packages/git/src/exec.ts
@@ -1,8 +1,21 @@
 import { execFile } from 'child_process';
+import { existsSync } from 'fs';
 import { mkdir as fsMkdir } from 'fs/promises';
 import { promisify } from 'util';
 
 const promisifiedExecFile = promisify(execFile);
+
+function resolveCommand(cmd: string): string {
+  if (cmd !== 'bash' || process.platform !== 'win32') {
+    return cmd;
+  }
+
+  const candidates = [
+    'C:\\Program Files\\Git\\bin\\bash.exe',
+    'C:\\Program Files\\Git\\usr\\bin\\bash.exe',
+  ];
+  return candidates.find(candidate => existsSync(candidate)) ?? cmd;
+}
 
 /** Wrapper around child_process.execFile for test mockability */
 export async function execFileAsync(
@@ -10,7 +23,7 @@ export async function execFileAsync(
   args: string[],
   options?: { timeout?: number; cwd?: string; maxBuffer?: number; env?: NodeJS.ProcessEnv }
 ): Promise<{ stdout: string; stderr: string }> {
-  const result = await promisifiedExecFile(cmd, args, options);
+  const result = await promisifiedExecFile(resolveCommand(cmd), args, options);
   return {
     stdout: (result.stdout ?? '').toString(),
     stderr: (result.stderr ?? '').toString(),

--- a/packages/server/src/routes/api.workflows.test.ts
+++ b/packages/server/src/routes/api.workflows.test.ts
@@ -280,18 +280,35 @@ describe('GET /api/workflows/:name', () => {
   });
 
   test('returns bundled workflow with source:bundled', async () => {
-    const app = createTestApp();
-    registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+    const tmpHome = join(tmpdir(), `wf-bundled-test-${Date.now()}`);
+    const prevArchonHome = process.env.ARCHON_HOME;
+    process.env.ARCHON_HOME = tmpHome;
 
-    // No cwd → no readFile attempt → checks BUNDLED_WORKFLOWS → archon-assist found
-    mockListCodebases.mockImplementationOnce(async () => []);
+    try {
+      const app = createTestApp();
+      registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
 
-    const response = await app.request('/api/workflows/archon-assist');
-    expect(response.status).toBe(200);
-    const body = (await response.json()) as { source: string; filename: string; workflow: unknown };
-    expect(body.source).toBe('bundled');
-    expect(body.filename).toBe('archon-assist.yaml');
-    expect(body.workflow).toBeDefined();
+      // No cwd and no home-scoped copy, so the request falls through to bundled defaults.
+      mockListCodebases.mockImplementationOnce(async () => []);
+
+      const response = await app.request('/api/workflows/archon-assist');
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        source: string;
+        filename: string;
+        workflow: unknown;
+      };
+      expect(body.source).toBe('bundled');
+      expect(body.filename).toBe('archon-assist.yaml');
+      expect(body.workflow).toBeDefined();
+    } finally {
+      if (prevArchonHome === undefined) {
+        delete process.env.ARCHON_HOME;
+      } else {
+        process.env.ARCHON_HOME = prevArchonHome;
+      }
+      await rm(tmpHome, { recursive: true, force: true });
+    }
   });
 
   test('returns project workflow with source:project when file exists on disk', async () => {

--- a/scripts/check-bundled-skill.ts
+++ b/scripts/check-bundled-skill.ts
@@ -27,6 +27,7 @@ const SKILLS_DIR = join(REPO_ROOT, '.claude', 'skills');
 /** Skills bundled into the binary and installed by `archon skill install`. */
 const BUNDLED_SKILLS = ['archon', 'manage-run'];
 const BUNDLED_SKILL_PATH = join(REPO_ROOT, 'packages', 'cli', 'src', 'bundled-skill.ts');
+const SKILL_DESCRIPTION_MAX_CHARS = 1024;
 
 const CHECK_ONLY = process.argv.includes('--check');
 
@@ -35,6 +36,87 @@ function listSkillFiles(dir: string, base: string): string[] {
     const full = join(dir, entry);
     return statSync(full).isDirectory() ? listSkillFiles(full, base) : [relative(base, full)];
   });
+}
+
+function extractFrontmatter(markdown: string): string | null {
+  const lines = markdown.split(/\r?\n/);
+  if (lines[0] !== '---') {
+    return null;
+  }
+
+  const endIndex = lines.findIndex((line, index) => index > 0 && line === '---');
+  return endIndex === -1 ? null : lines.slice(1, endIndex).join('\n');
+}
+
+function trimBlockIndent(lines: string[]): string {
+  const indentedLines = lines.filter(line => line.trim().length > 0);
+  const indent =
+    indentedLines.length === 0
+      ? 0
+      : Math.min(...indentedLines.map(line => /^\s*/.exec(line)?.[0].length ?? 0));
+
+  return lines
+    .map(line => line.slice(Math.min(indent, line.length)))
+    .join('\n')
+    .trimEnd();
+}
+
+function extractSkillDescription(markdown: string): string | null {
+  const frontmatter = extractFrontmatter(markdown);
+  if (frontmatter === null) {
+    return null;
+  }
+
+  const lines = frontmatter.split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    const match = /^description:\s*(.*)$/.exec(lines[i]);
+    if (match === null) {
+      continue;
+    }
+
+    const value = match[1].trim();
+    if (value !== '|') {
+      return value;
+    }
+
+    const blockLines: string[] = [];
+    for (let j = i + 1; j < lines.length; j += 1) {
+      if (lines[j].length > 0 && !/^\s/.test(lines[j])) {
+        break;
+      }
+      blockLines.push(lines[j]);
+    }
+    return trimBlockIndent(blockLines);
+  }
+
+  return null;
+}
+
+function validateSkillDescription(skill: string): string[] {
+  const skillMdPath = join(SKILLS_DIR, skill, 'SKILL.md');
+  const relativePath = relative(REPO_ROOT, skillMdPath);
+  let markdown: string;
+
+  try {
+    markdown = readFileSync(skillMdPath, 'utf-8');
+  } catch {
+    return [`${relativePath}: missing SKILL.md`];
+  }
+
+  const description = extractSkillDescription(markdown);
+  if (description === null) {
+    return [`${relativePath}: missing description in frontmatter`];
+  }
+  if (description.length === 0) {
+    return [`${relativePath}: description must not be empty`];
+  }
+  if (description.length > SKILL_DESCRIPTION_MAX_CHARS) {
+    return [
+      `${relativePath}: description is ${description.length} characters; maximum is ${SKILL_DESCRIPTION_MAX_CHARS}`,
+    ];
+  }
+
+  return [];
 }
 
 // Paths are relative to .claude/skills/ so they keep the skill dir name
@@ -53,15 +135,27 @@ const bundledSrc = readFileSync(BUNDLED_SKILL_PATH, 'utf-8');
 // stale string literal will also pass. It's a safety net against missing imports,
 // not a structural verification of the export map.
 const missing = skillFiles.filter(f => !bundledSrc.includes(f));
+const descriptionErrors = BUNDLED_SKILLS.flatMap(validateSkillDescription);
+const validationErrors: string[] = [];
 
 if (missing.length > 0) {
-  console.error(
+  validationErrors.push(
     `bundled-skill.ts is missing these files:\n${missing.map(f => `  - ${f}`).join('\n')}\n\n` +
       `Add a corresponding import + bundled map entry to\n  ${relative(REPO_ROOT, BUNDLED_SKILL_PATH)}`
   );
+}
+
+if (descriptionErrors.length > 0) {
+  validationErrors.push(
+    `Bundled skill description validation failed:\n${descriptionErrors.map(e => `  - ${e}`).join('\n')}`
+  );
+}
+
+if (validationErrors.length > 0) {
+  console.error(validationErrors.join('\n\n'));
   process.exit(CHECK_ONLY ? 2 : 1);
 }
 
 console.log(
-  `bundled-skill.ts is up to date (${skillFiles.length} files across ${BUNDLED_SKILLS.length} skills).`
+  `bundled-skill.ts is up to date (${skillFiles.length} files across ${BUNDLED_SKILLS.length} skills; descriptions <= ${SKILL_DESCRIPTION_MAX_CHARS} chars).`
 );


### PR DESCRIPTION
﻿## Summary

Describe this PR in 2-5 bullets:

- Problem: The bundled Archon skill frontmatter description exceeded the Agent Skills 1024-character metadata limit, which can make Codex/LMS project update or skill loading fail.
- Why it matters: Archon should ship bundled skills that install cleanly into both `.claude/skills` and `.agents/skills` without runtime truncation or provider-specific rewriting.
- What changed: Shortened the bundled Archon skill description, added bundled description validation, added CLI regression coverage, and hardened environment-sensitive tests found during validation.
- What did **not** change (scope boundary): No `/update-project` behavior changes, no database migration, no provider-specific skill rewriting, and no migration for already-installed user skills. Users can rerun `archon skill install` after upgrading.

## UX Journey

### Before

```text
User                   Archon CLI             Skill files              AI Client
----                   ----------             -----------              ---------
runs skill install --> copies bundled skill -> overlong description -> rejects/loads unreliably
runs update/load ----------------------------------------------------> may fail max length check
```

### After

```text
User                   Archon CLI              Skill files                 AI Client
----                   ----------              -----------                 ---------
runs skill install --> copies bundled skill --> [description <= 1024] ----> loads metadata
CI/checks -----------> [validate bundled skill descriptions] ------------> prevents recurrence
```

## Architecture Diagram

### Before

```text
.claude/skills/archon/SKILL.md
  -> packages/cli/src/bundled-skill.ts
  -> packages/cli/src/commands/skill.ts
  -> installed .claude/skills + .agents/skills

scripts/check-bundled-skill.ts
  -> checked bundled file presence only
```

### After

```text
[~] .claude/skills/archon/SKILL.md
  -> packages/cli/src/bundled-skill.ts
  -> packages/cli/src/commands/skill.ts
  -> installed .claude/skills + .agents/skills

[~] scripts/check-bundled-skill.ts
  === validates bundled SKILL.md descriptions are present, non-empty, and <= 1024 chars

[~] packages/cli/src/commands/skill.test.ts
  === regression coverage for archon and manage-run bundled descriptions

[~] validation tests/env helpers
  === isolate host env settings that made validation nondeterministic
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `.claude/skills/archon/SKILL.md` | `packages/cli/src/bundled-skill.ts` | unchanged | Bundled source text is still embedded from the same source file. |
| `packages/cli/src/bundled-skill.ts` | `packages/cli/src/commands/skill.ts` | unchanged | Installer still mirrors the same files to Claude and Codex skill locations. |
| `scripts/check-bundled-skill.ts` | `.claude/skills/*/SKILL.md` | **modified** | Now validates description existence and length in addition to bundle completeness. |
| `packages/cli/src/commands/skill.test.ts` | bundled skill maps | **modified** | Adds length regression tests for bundled `SKILL.md` descriptions. |
| test suites | host environment variables | **modified** | Tests now isolate relevant env vars for deterministic local/CI behavior. |
| `packages/git/src/exec.ts` | Windows Git Bash | **modified** | Resolves `bash` to standard Git Bash locations on Windows when available. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `cli|tests|skills|git|server|adapters|core`
- Module: `skills:archon`, `cli:skill-install`, `tests:environment-isolation`, `git:exec`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi`

## Linked Issue

- Closes: N/A (no issue provided)
- Related: N/A
- Depends on: N/A
- Supersedes: N/A

## Validation Evidence (required)

Commands and result summary:

```bash
bun run check:bundled-skill --check                    # PASS
bun --filter @archon/cli type-check                    # PASS
bun test packages/cli/src/commands/skill.test.ts       # PASS, 8 passed
bun --filter @archon/cli test                          # PASS, 215 passed
bun run type-check                                     # PASS
bun run lint                                           # PASS, 0 warnings
bun run format:check                                   # PASS
bun run build                                          # PASS
bun --filter @archon/server test                       # PASS after env isolation
bun --filter @archon/adapters test                     # PASS after env isolation
bun test packages/core/src/db/codebases.test.ts        # PASS after env isolation
bun --filter @archon/workflows test                    # BLOCKED by unrelated stale bundled defaults
bun run validate                                       # BLOCKED at check:bundled
```

- Evidence provided (test/log/trace/screenshot): Workflow artifacts `implementation.md` and `validation.md` for workflow `288d9c96bce91f5a312177eb3b9aafdc`.
- If any command is intentionally skipped, explain why: Nothing was skipped. Full validation was run but is blocked by pre-existing `.archon/workflows/**` edits that make `bundled-defaults.generated.ts` stale. Those workflow YAML edits were explicitly out of scope and were not committed.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- New external network calls? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- File system access scope changed? (`Yes/No`) Yes
- If any `Yes`, describe risk and mitigation: `packages/git/src/exec.ts` now performs read-only existence checks for standard Git Bash paths on Windows when `cmd === 'bash'`. This is narrowly scoped and does not broaden command execution beyond the requested `bash` invocation.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Database migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A. Existing users who already installed the bundled skill can rerun `archon skill install` after upgrading to refresh `.claude/skills` and `.agents/skills`.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Bundled Archon and manage-run skill descriptions are non-empty and within the 1024-character Agent Skills limit; `archon skill install` mirror behavior remains covered by existing tests; environment-sensitive tests pass with isolated host env settings.
- Edge cases checked: Missing/empty/overlong bundled descriptions are reported by `scripts/check-bundled-skill.ts`; block scalar and one-line description parsing are supported.
- What was not verified: Full `bun run validate` cannot pass until the unrelated `.archon/workflows/**` edits are reconciled with `packages/workflows/src/defaults/bundled-defaults.generated.ts`.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Bundled Archon skill metadata, CLI bundled skill validation/install tests, selected deterministic test setup, Windows `bash` command resolution in `@archon/git`.
- Potential unintended effects: Windows callers that relied on the WSL Store shim for `bash` may now use Git Bash when installed.
- Guardrails/monitoring for early detection: Existing package tests plus the new bundled skill description checks; any Windows shell behavior regression should surface in workflow bash-node tests.

## Rollback Plan (required)

- Fast rollback command/path: Revert this PR commit to restore previous skill metadata, validation script, tests, and Windows bash resolution behavior.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: Skill loading failures due metadata length would return; validation may stop catching overlong bundled descriptions.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: Full validation remains blocked by stale bundled defaults from unrelated workflow YAML edits.
  - Mitigation: Left those files uncommitted and documented the blocker so the workflow-defaults change can be resolved separately.
- Risk: Git Bash resolution changes Windows `bash` behavior.
  - Mitigation: Resolution only applies on Windows and only for exact `bash` commands, preserving all other command execution paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bash command resolution on Windows systems for better compatibility.

* **Tests**
  * Enhanced test infrastructure with proper environment variable isolation across multiple test suites.
  * Added validation for skill descriptions to ensure quality standards.

* **Chores**
  * Updated bundled skill validation to enforce description requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->