### PR TITLE
Feat/slack receipt reactions

### DIFF
--- a/packages/adapters/src/chat/slack/adapter.test.ts
+++ b/packages/adapters/src/chat/slack/adapter.test.ts
@@ -27,6 +27,8 @@ mock.module('@archon/paths', () => ({
 // Create mock functions
 const mockPostMessage = mock(() => Promise.resolve(undefined));
 const mockReplies = mock(() => Promise.resolve({ messages: [] }));
+const mockAddReaction = mock(() => Promise.resolve(undefined));
+const mockRemoveReaction = mock(() => Promise.resolve(undefined));
 const mockUsersInfo = mock(() =>
   Promise.resolve({
     user: {
@@ -52,6 +54,10 @@ const mockApp = {
     },
     users: {
       info: mockUsersInfo,
+    },
+    reactions: {
+      add: mockAddReaction,
+      remove: mockRemoveReaction,
     },
   },
   event: mockEvent,
@@ -615,6 +621,103 @@ describe('SlackAdapter', () => {
       const second = await adapter.fetchDisplayName('U_RETRY');
       expect(second).toBe('Eventually');
       expect(mockUsersInfo).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('lifecycle reactions', () => {
+    beforeEach(() => {
+      mockAddReaction.mockClear();
+      mockRemoveReaction.mockClear();
+    });
+
+    async function fireMention(adapter: SlackAdapter): Promise<void> {
+      await adapter.start();
+      const calls = (mockEvent as unknown as Mock<(t: string, h: unknown) => void>).mock.calls;
+      const reg = calls.find(c => c[0] === 'app_mention');
+      if (!reg) throw new Error('app_mention handler not registered');
+      await (reg[1] as (args: { event: SlackMessageEvent }) => Promise<void>)({
+        event: { text: '<@U0> /status', user: 'U123', channel: 'C456', ts: '111.222' },
+      });
+    }
+
+    test('adds 👀 eyes on app_mention receipt', async () => {
+      const adapter = new SlackAdapter('xoxb-fake', 'xapp-fake');
+      adapter.onMessage(async () => {});
+      await fireMention(adapter);
+
+      expect(mockAddReaction).toHaveBeenCalledTimes(1);
+      const call = (
+        mockAddReaction.mock.calls[0] as unknown as {
+          channel: string;
+          name: string;
+          timestamp: string;
+        }[]
+      )[0];
+      expect(call.channel).toBe('C456');
+      expect(call.timestamp).toBe('111.222');
+      expect(call.name).toBe('eyes');
+    });
+
+    test('removes 👀 and adds ✅ when sendMessage replies', async () => {
+      const adapter = new SlackAdapter('xoxb-fake', 'xapp-fake');
+      adapter.onMessage(async () => {});
+      await fireMention(adapter);
+
+      await adapter.sendMessage('C456:111.222', 'Status: all clear');
+
+      // removeReactionSafe is fire-and-forget so called counts may not
+      // always be stable. We assert addReactionSafe order directly.
+      const calls = mockAddReaction.mock.calls as unknown as {
+        channel: string;
+        name: string;
+        timestamp: string;
+      }[][];
+      // First was eyes on receipt, second is white_check_mark on sendMessage.
+      expect(calls.length).toBeGreaterThanOrEqual(2);
+      expect(calls[0]![0].name).toBe('eyes');
+      expect(calls[calls.length - 1]![0].name).toBe('white_check_mark');
+    });
+
+    test('reaction failures are swallowed (do NOT break message processing)', async () => {
+      mockAddReaction.mockRejectedValueOnce(new Error('already_reacted'));
+      const adapter = new SlackAdapter('xoxb-fake', 'xapp-fake');
+      adapter.onMessage(async () => {});
+      await fireMention(adapter);
+
+      // sendMessage must still succeed even if addReaction fails
+      await adapter.sendMessage('C456:111.222', 'Still works');
+
+      // The second addReaction call (white_check_mark) still happens
+      const checkCalls = mockAddReaction.mock.calls as unknown as {
+        channel: string;
+        name: string;
+      }[][];
+      expect(checkCalls.some(c => c[0].name === 'eyes')).toBe(true);
+      expect(checkCalls.some(c => c[0].name === 'white_check_mark')).toBe(true);
+    });
+
+    test('DM handler also adds eyes reaction', async () => {
+      const adapter = new SlackAdapter('xoxb-fake', 'xapp-fake');
+      adapter.onMessage(async () => {});
+      await adapter.start();
+
+      const calls = (mockEvent as unknown as Mock<(t: string, h: unknown) => void>).mock.calls;
+      const reg = calls.find(c => c[0] === 'message');
+      if (!reg) throw new Error('message handler not registered');
+      await (reg[1] as (args: { event: SlackMessageEvent }) => Promise<void>)({
+        event: { text: 'hello', user: 'U789', channel: 'D123', ts: '333.444' },
+      });
+
+      const call = (
+        mockAddReaction.mock.calls[0] as unknown as {
+          channel: string;
+          name: string;
+          timestamp: string;
+        }[]
+      )[0];
+      expect(call.channel).toBe('D123');
+      expect(call.timestamp).toBe('333.444');
+      expect(call.name).toBe('eyes');
     });
   });
 });

--- a/packages/adapters/src/chat/slack/adapter.test.ts
+++ b/packages/adapters/src/chat/slack/adapter.test.ts
@@ -628,6 +628,7 @@ describe('SlackAdapter', () => {
     beforeEach(() => {
       mockAddReaction.mockClear();
       mockRemoveReaction.mockClear();
+      mockEvent.mockClear();
     });
 
     async function fireMention(adapter: SlackAdapter): Promise<void> {
@@ -705,7 +706,7 @@ describe('SlackAdapter', () => {
       const reg = calls.find(c => c[0] === 'message');
       if (!reg) throw new Error('message handler not registered');
       await (reg[1] as (args: { event: SlackMessageEvent }) => Promise<void>)({
-        event: { text: 'hello', user: 'U789', channel: 'D123', ts: '333.444' },
+        event: { text: 'hello', user: 'U789', channel: 'D123', ts: '333.444', channel_type: 'im' },
       });
 
       const call = (

--- a/packages/adapters/src/chat/slack/adapter.test.ts
+++ b/packages/adapters/src/chat/slack/adapter.test.ts
@@ -666,6 +666,17 @@ describe('SlackAdapter', () => {
 
       await adapter.sendMessage('C456:111.222', 'Status: all clear');
 
+      const removeCalls = mockRemoveReaction.mock.calls as unknown as {
+        channel: string;
+        name: string;
+        timestamp: string;
+      }[][];
+      expect(
+        removeCalls.some(
+          c => c[0].channel === 'C456' && c[0].timestamp === '111.222' && c[0].name === 'eyes'
+        )
+      ).toBe(true);
+
       // removeReactionSafe is fire-and-forget so called counts may not
       // always be stable. We assert addReactionSafe order directly.
       const calls = mockAddReaction.mock.calls as unknown as {
@@ -695,6 +706,25 @@ describe('SlackAdapter', () => {
       }[][];
       expect(checkCalls.some(c => c[0].name === 'eyes')).toBe(true);
       expect(checkCalls.some(c => c[0].name === 'white_check_mark')).toBe(true);
+    });
+
+    test('removeReaction failures are also swallowed (best-effort lifecycle)', async () => {
+      mockRemoveReaction.mockRejectedValueOnce(new Error('no_reaction'));
+      const adapter = new SlackAdapter('xoxb-fake', 'xapp-fake');
+      adapter.onMessage(async () => {});
+      await fireMention(adapter);
+
+      // sendMessage must still succeed even if removeReaction fails
+      await adapter.sendMessage('C456:111.222', 'Still works');
+
+      // Both remove and add still attempted; remove may have failed but the
+      // add reaction for the transition still fires
+      expect(
+        mockAddReaction.mock.calls.some((c: unknown) => {
+          const args = (c as unknown[])[0] as { name: string };
+          return args.name === 'white_check_mark';
+        })
+      ).toBe(true);
     });
 
     test('DM handler also adds eyes reaction', async () => {

--- a/packages/adapters/src/chat/slack/adapter.test.ts
+++ b/packages/adapters/src/chat/slack/adapter.test.ts
@@ -629,6 +629,8 @@ describe('SlackAdapter', () => {
       mockAddReaction.mockClear();
       mockRemoveReaction.mockClear();
       mockEvent.mockClear();
+      mockCommand.mockClear();
+      mockAction.mockClear();
     });
 
     async function fireMention(adapter: SlackAdapter): Promise<void> {
@@ -688,6 +690,48 @@ describe('SlackAdapter', () => {
       expect(calls.length).toBeGreaterThanOrEqual(2);
       expect(calls[0]![0].name).toBe('eyes');
       expect(calls[calls.length - 1]![0].name).toBe('white_check_mark');
+    });
+
+    test('removes 👀 and adds ✅ when sendMessage replies (multi-chunk)', async () => {
+      const adapter = new SlackAdapter('xoxb-fake', 'xapp-fake');
+      adapter.onMessage(async () => {});
+      await fireMention(adapter);
+
+      mockRemoveReaction.mockClear();
+      mockAddReaction.mockClear();
+
+      const paragraph1 = 'a'.repeat(10000);
+      const paragraph2 = 'b'.repeat(10000);
+      await adapter.sendMessage('C456:111.222', `${paragraph1}\n\n${paragraph2}`);
+
+      // Should split into two markdown blocks
+      expect(mockPostMessage).toHaveBeenCalledTimes(2);
+
+      // Reaction transition happens after the last chunk is sent
+      const removeCalls = mockRemoveReaction.mock.calls as unknown as {
+        channel: string;
+        name: string;
+        timestamp: string;
+      }[][];
+      expect(
+        removeCalls.some(
+          c => c[0].channel === 'C456' && c[0].timestamp === '111.222' && c[0].name === 'eyes'
+        )
+      ).toBe(true);
+
+      const addCalls = mockAddReaction.mock.calls as unknown as {
+        channel: string;
+        name: string;
+        timestamp: string;
+      }[][];
+      expect(
+        addCalls.some(
+          c =>
+            c[0].channel === 'C456' &&
+            c[0].timestamp === '111.222' &&
+            c[0].name === 'white_check_mark'
+        )
+      ).toBe(true);
     });
 
     test('reaction failures are swallowed (do NOT break message processing)', async () => {

--- a/packages/adapters/src/chat/slack/adapter.ts
+++ b/packages/adapters/src/chat/slack/adapter.ts
@@ -250,8 +250,9 @@ export class SlackAdapter implements IPlatformAdapter {
   }
 
   /**
-   * Add a reaction to a Slack message. Failures are best-effort —
-   * a missing reaction must never break the message-processing pipeline.
+   * Add a reaction to a Slack message. Failures are caught so that a
+   * missing reaction never breaks the message-processing pipeline, but
+   * they are logged at `warn` so operators notice scope / duplicate issues.
    */
   private async addReactionSafe(ref: SlackMessageRef, emoji: string): Promise<void> {
     try {
@@ -442,7 +443,8 @@ export class SlackAdapter implements IPlatformAdapter {
   }
 
   /**
-   * Start the bot (connects via Socket Mode)
+   * Start the bot. Registers `app_mention`, DM `message`, and slash-command
+   * handlers, then opens the Socket Mode connection.
    */
   async start(): Promise<void> {
     // Register app_mention event handler (when bot is @mentioned)

--- a/packages/adapters/src/chat/slack/adapter.ts
+++ b/packages/adapters/src/chat/slack/adapter.ts
@@ -97,16 +97,17 @@ export class SlackAdapter implements IPlatformAdapter {
       ? channelId.split(':')
       : [channelId, undefined];
 
-    // Transition the lifecycle reaction on the triggering message from 👀 → ✅.
-    // The triggering ref is keyed by conversationId (channel:ts).
+    // Transition the lifecycle reaction on the triggering message from 👀 → ✅,
+    // but only after the reply has been successfully sent. If sending fails,
+    // the 👀 remains as a visual indicator that something is still pending.
     const triggerRef = this.getTriggeringMessage(channelId);
-    if (triggerRef) {
-      void this.removeReactionSafe(triggerRef, 'eyes');
-      void this.addReactionSafe(triggerRef, 'white_check_mark');
-    }
 
     if (message.length <= MAX_MARKDOWN_BLOCK_LENGTH) {
       await this.sendWithMarkdownBlock(channel, message, threadTs);
+      if (triggerRef) {
+        void this.removeReactionSafe(triggerRef, 'eyes');
+        void this.addReactionSafe(triggerRef, 'white_check_mark');
+      }
       return;
     }
 
@@ -120,6 +121,10 @@ export class SlackAdapter implements IPlatformAdapter {
       const body = chunks[i] ?? '';
       const annotated = total > 1 ? `${body}\n\n_part ${i + 1}/${total}_` : body;
       await this.sendWithMarkdownBlock(channel, annotated, threadTs);
+    }
+    if (triggerRef) {
+      void this.removeReactionSafe(triggerRef, 'eyes');
+      void this.addReactionSafe(triggerRef, 'white_check_mark');
     }
   }
 

--- a/packages/adapters/src/chat/slack/adapter.ts
+++ b/packages/adapters/src/chat/slack/adapter.ts
@@ -97,6 +97,14 @@ export class SlackAdapter implements IPlatformAdapter {
       ? channelId.split(':')
       : [channelId, undefined];
 
+    // Transition the lifecycle reaction on the triggering message from 👀 → ✅.
+    // The triggering ref is keyed by conversationId (channel:ts).
+    const triggerRef = this.getTriggeringMessage(channelId);
+    if (triggerRef) {
+      void this.removeReactionSafe(triggerRef, 'eyes');
+      void this.addReactionSafe(triggerRef, 'white_check_mark');
+    }
+
     if (message.length <= MAX_MARKDOWN_BLOCK_LENGTH) {
       await this.sendWithMarkdownBlock(channel, message, threadTs);
       return;
@@ -234,6 +242,50 @@ export class SlackAdapter implements IPlatformAdapter {
       }
     }
     this.triggeringMessages.set(conversationId, ref);
+  }
+
+  /**
+   * Add a reaction to a Slack message. Failures are best-effort —
+   * a missing reaction must never break the message-processing pipeline.
+   */
+  private async addReactionSafe(ref: SlackMessageRef, emoji: string): Promise<void> {
+    try {
+      await this.app.client.reactions.add({
+        channel: ref.channel,
+        name: emoji,
+        timestamp: ref.ts,
+      });
+    } catch (err) {
+      const e = err as Error & { data?: { error?: string } };
+      const code = e.data?.error ?? 'unknown';
+      // Already reacted, or message gone — fine to ignore.
+      getLog().warn(
+        { channel: ref.channel, ts: ref.ts, emoji, error: code },
+        'slack.reaction_failed'
+      );
+    }
+  }
+
+  /**
+   * Remove a reaction from a Slack message. Best-effort: swallows errors so
+   * that reaction cleanup never fails the underlying message pipeline.
+   */
+  private async removeReactionSafe(ref: SlackMessageRef, emoji: string): Promise<void> {
+    try {
+      await this.app.client.reactions.remove({
+        channel: ref.channel,
+        name: emoji,
+        timestamp: ref.ts,
+      });
+    } catch (err) {
+      const e = err as Error & { data?: { error?: string } };
+      const code = e.data?.error ?? 'unknown';
+      // Reaction not present, message gone — fine to ignore.
+      getLog().debug(
+        { channel: ref.channel, ts: ref.ts, emoji, error: code },
+        'slack.reaction_remove_failed'
+      );
+    }
   }
 
   /**
@@ -408,10 +460,14 @@ export class SlackAdapter implements IPlatformAdapter {
           thread_ts: event.thread_ts,
           displayName,
         };
-        this.trackTrigger(this.getConversationId(messageEvent), {
+        const triggerRef: SlackMessageRef = {
           channel: event.channel,
           ts: event.ts,
-        });
+        };
+        this.trackTrigger(this.getConversationId(messageEvent), triggerRef);
+        // Add an 👀 reaction so the user knows the message was received and
+        // is being processed. Removed automatically when the reply arrives.
+        void this.addReactionSafe(triggerRef, 'eyes');
         // Fire-and-forget - errors handled by caller
         void this.messageHandler(messageEvent);
       }
@@ -450,10 +506,12 @@ export class SlackAdapter implements IPlatformAdapter {
           thread_ts: 'thread_ts' in event ? event.thread_ts : undefined,
           displayName,
         };
-        this.trackTrigger(this.getConversationId(messageEvent), {
+        const triggerRef: SlackMessageRef = {
           channel: event.channel,
           ts: event.ts,
-        });
+        };
+        this.trackTrigger(this.getConversationId(messageEvent), triggerRef);
+        void this.addReactionSafe(triggerRef, 'eyes');
         void this.messageHandler(messageEvent);
       }
     });

--- a/packages/docs-web/src/content/docs/adapters/slack.md
+++ b/packages/docs-web/src/content/docs/adapters/slack.md
@@ -184,10 +184,25 @@ You can also DM the bot directly -- no @mention needed:
 /help
 ```
 
+## Message Receipt & Lifecycle Reactions
+
+When the bot receives any message — whether an `@mention` in a channel or a direct message — it immediately adds an 👀 reaction to the triggering message. This gives the user immediate visual confirmation that the message was received and is being processed.
+
+When the reply is sent back to Slack, the 👀 is removed and replaced with a ✅ reaction. Failures in the reaction pipeline (missing scope, already-reacted, later-deleted message) are swallowed silently — a reaction glitch never blocks message processing.
+
+| Event                    | Reaction pattern |
+|--------------------------|------------------|
+| Message received         | 👀 added         |
+| Reply sent               | 👀 removed → ✅ added |
+| Missing `reactions:write` scope | Message still processes; reaction skipped |
+
+**Required OAuth Scope:** `reactions:write` (listed in Step 3 above).
+
 ## In-Thread UX
 
 When a workflow runs in a Slack thread, Archon now:
 
+- Adds an 👀 reaction to any received message (even non-workflow replies) at the moment it is received, swapped for ✅ when the reply is sent back (see "Message Receipt & Lifecycle Reactions" above for details)
 - Adds 🔄 to your triggering message when the run starts, and swaps it for ✅
   on completion or ❌ on failure / cancellation
 - Posts a single status message in the thread that's edited in place as DAG


### PR DESCRIPTION
## Problem Statement

Users sending `@mention` or DM messages to the Archon Slack bot had zero immediate feedback — no way to tell if the message was even received before the (potentially slow) AI reply arrived. This created uncertainty, especially when:

- The bot is warming up
- A workflow is spinning up a worktree
- The network is slow

## Feature

**Receipt & lifecycle reactions on Slack messages**

| Stage | Reaction | Meaning |
|-------|----------|---------|
| Message received | 👀 | "We're on iation |
| Reply sent | ✅ | "Done" — swapped automatically |
| Processing failed | 👀 stays | No silent drop; user knows something is wrong |

- **Applies to:** `@mention` in channsh commands
- **Fail-safe:** `reactions:write` failures (already-reacted, missing scope, deleted message) are
swallowed — reactions never break the

## Result

- Users get **instant confidence** that their message reached the bot
- No ambiguity during slow-start work
- Consistent with modern Slack-bot UX patterns (e.g., GitHub's Slack integration)
- No extra config required — works automatically when `reactions:write` scope is present

## Test Result
```
bun test packages/adapters/src/chat/slack/adapter.test.ts
bun test v1.3.13-canary.1 (443ba817)

packages/adapters/src/chat/slack/adapter.test.ts:
✓ SlackAdapter > streaming mode configuration > should return batch mode when configured [0.71ms]
✓ SlackAdapter > streaming mode configuration > should default to batch mode [0.06ms]
✓ SlackAdapter > streaming mode configuration > should return stream mode when explicitly configured [0.02ms]
✓ SlackAdapter > platform type > should return slack [0.01ms]
✓ SlackAdapter > thread detection > should detect thread when thread_ts differs from ts
✓ SlackAdapter > thread detection > should not detect thread when thread_ts equals ts
✓ SlackAdapter > thread detection > should not detect thread when thread_ts is undefined
✓ SlackAdapter > conversation ID > should return channel:thread_ts for thread messages [0.09ms]
✓ SlackAdapter > conversation ID > should return channel:ts for non-thread messages [0.01ms]
✓ SlackAdapter > stripBotMention > should strip bot mention from start [0.05ms]
✓ SlackAdapter > stripBotMention > should strip multiple mentions [0.03ms]
✓ SlackAdapter > stripBotMention > should return unchanged if no mention [0.02ms]
✓ SlackAdapter > stripBotMention > should normalize Slack URL formatting
✓ SlackAdapter > stripBotMention > should normalize Slack URL with label [0.03ms]
✓ SlackAdapter > stripBotMention > should normalize multiple URLs
✓ SlackAdapter > parent conversation ID > should return parent conversation ID for thread messages [0.02ms]
✓ SlackAdapter > parent conversation ID > should return null for non-thread messages [0.01ms]
✓ SlackAdapter > app instance > should provide access to app instance [0.02ms]
✓ SlackAdapter > thread creation (ensureThread) > should return original ID unchanged (threading via conversation ID pattern) [0.05ms]
✓ SlackAdapter > thread creation (ensureThread) > should work with thread conversation IDs [0.04ms]
✓ SlackAdapter > thread creation (ensureThread) > should work with channel-only IDs [0.02ms]
✓ SlackAdapter > message formatting > should send short messages with markdown block [0.24ms]
✓ SlackAdapter > message formatting > should send messages without thread_ts when not in thread [0.03ms]
✓ SlackAdapter > message formatting > should truncate fallback text for long messages [0.07ms]
✓ SlackAdapter > message formatting > should fallback to plain text when markdown block fails [2.23ms]
✓ SlackAdapter > message formatting > should split long messages into multiple markdown blocks [0.18ms]
✓ SlackAdapter > message formatting > should handle empty message without crashing [0.16ms]
✓ SlackAdapter > message formatting > single-chunk message is sent without _part footer [0.03ms]
✓ SlackAdapter > message formatting > multi-chunk message annotates each part with _part i/n_ [0.05ms]
✓ SlackAdapter > triggering message tracking > FIFO evicts oldest entry past the cap [1.65ms]
✓ SlackAdapter > slash commands > unauthorized user is silently rejected — no respond, no seed post [0.45ms]
✓ SlackAdapter > slash commands > seed-post failure surfaces ephemeral error and skips message handler [0.23ms]
✓ SlackAdapter > fetchDisplayName (users.info enrichment) > returns real_name from users.info on first call and caches result [0.05ms]
✓ SlackAdapter > fetchDisplayName (users.info enrichment) > returns undefined and warn-logs once on missing_scope failure [0.06ms]
✓ SlackAdapter > fetchDisplayName (users.info enrichment) > missing_scope WARN fires only once per adapter even after many sightings [0.07ms]
✓ SlackAdapter > fetchDisplayName (users.info enrichment) > users_info_failed log strips err.data (no PII leak) [0.10ms]
✓ SlackAdapter > fetchDisplayName (users.info enrichment) > returns undefined for empty slackUserId without calling the API [0.04ms]
✓ SlackAdapter > fetchDisplayName (users.info enrichment) > retries on next sighting after failure (negative results not cached)
✓ SlackAdapter > lifecycle reactions > adds 👀 eyes on app_mention receipt [0.11ms]
✓ SlackAdapter > lifecycle reactions > removes 👀 and adds ✅ when sendMessage replies [0.14ms]
✓ SlackAdapter > lifecycle reactions > reaction failures are swallowed (do NOT break message processing) [0.03ms]
✓ SlackAdapter > lifecycle reactions > DM handler also adds eyes reaction [0.20ms]
----------------------------------------------------------------|---------|---------|-------------------
File                                                            | % Funcs | % Lines | Uncovered Line #s
----------------------------------------------------------------|---------|---------|-------------------
All files                                                       |   25.31 |   35.52 |
 packages/adapters/src/chat/slack/adapter.ts                    |   85.37 |   71.65 | 157-190,226,231,307-336,639-699,706-707
 packages/adapters/src/chat/slack/auth.ts                       |  100.00 |   93.75 | 
 packages/adapters/src/chat/slack/blocks.ts                     |    0.00 |   10.81 | 53,57-62,70-89,93-95,103-136,144-170,179-250,254-255
 packages/adapters/src/utils/message-splitting.ts               |  100.00 |   74.36 | 41-49
 packages/core/src/config/config-loader.ts                      |    0.00 |    5.24 | 20,24-28,70,80-84,92-96,100-122,149-166,172-173,180,230-238,246-255,264-284,294-310,318-341,349-388,395-460,467-512,519-581,591-612,619,626-632,641-722,733-750,759-777
 packages/core/src/config/resolve-assistant.ts                  |    0.00 |   10.42 | 6-7,21-61
 packages/core/src/credentials/catalog.ts                       |    0.00 |   11.82 | 42-70,75-78,83-84,139-143,151-170,180-216
 packages/core/src/credentials/config.ts                        |    0.00 |   33.33 | 13,23-25
 packages/core/src/credentials/connect-service.ts               |    0.00 |   18.03 | 21-22,33-34,54-79,97-116
 packages/core/src/credentials/delivery.ts                      |    0.00 |   11.63 | 38,112-123,135-214,237-257
 packages/core/src/credentials/index.ts                         |  100.00 |  100.00 | 
 packages/core/src/credentials/oauth-bridge.ts                  |    0.00 |    9.16 | 67-68,94-95,102-103,116-122,161-162,167-176,181,211-226,237-392,401-432,437-441,445,450-451
 packages/core/src/credentials/oauth-providers.ts               |    0.00 |   91.67 | 
 packages/core/src/credentials/openai-oauth.ts                  |    0.00 |    5.91 | 70,75-91,101-123,127-135,141-144,155-214,224-260,269-284,294-308,323-331
 packages/core/src/db/adapters/postgres.ts                      |    0.00 |    8.17 | 32-33,46-228,238,242,246,250,254
 packages/core/src/db/adapters/sqlite.ts                        |    0.00 |    3.79 | 12-13,22-115,129-144,153-154,164-342,356-585,594,598,602-604,608-610,614
 packages/core/src/db/bundled-schema.generated.ts               |  100.00 |  100.00 | 
 packages/core/src/db/bundled-schema.ts                         |    0.00 |   40.00 | 17-22
 packages/core/src/db/codebases.ts                              |    0.00 |    9.43 | 10-11,15-39,43-46,50-57,61-83,87-93,97-101,105-109,121-128,132-136,140-174,178-181,185-197
 packages/core/src/db/connection.ts                             |    0.00 |   25.00 | 17-18,30-57,64-76,84,89,98-100,107-111,118-119,126
 packages/core/src/db/conversations.ts                          |    0.00 |    7.08 | 11-12,19-23,32-38,46-53,57-115,119-161,169-173,180-186,193-232,239-243,250-257,264-271
 packages/core/src/db/env-vars.ts                               |    0.00 |   19.35 | 9-10,17-21,26-38,43-47
 packages/core/src/db/isolation-environments.ts                 |    0.00 |    8.06 | 15-16,23-27,34-43,50-58,67-107,114-124,131-143,150-162,169-174,181-185,193-214,223-234,241-258,266-285,293-299
 packages/core/src/db/messages.ts                               |    0.00 |    9.68 | 10-11,23-43,53-63,72-93
 packages/core/src/db/sessions.ts                               |    0.00 |    9.15 | 12-13,21-22,27-31,35-57,61-67,71-78,82-90,103-154,162-168,176-186,197-209
 packages/core/src/db/user-ai-prefs-store.ts                    |    0.00 |    9.88 | 25-26,41-47,53-73,78-96,101,106-116,129-131,139-141,146-149,154-155
 packages/core/src/db/user-github-token-store.ts                |    0.00 |    8.39 | 25-26,41-43,47-79,83-91,95-96,104-106,118-122,126-210
 packages/core/src/db/user-provider-key-store.ts                |    0.00 |    7.18 | 35-36,55-82,87-94,102-115,120-124,146-181,193-265,280-307
 packages/core/src/db/users.ts                                  |    0.00 |    6.90 | 19-20,30-37,41-42,46-53,71-138,149-167,172-203,208-212,221-222,233-244,255-285
 packages/core/src/db/workflow-events.ts                        |    0.00 |    5.67 | 17-18,32-34,43-51,59-84,93-106,114-136,156-182,192-220
 packages/core/src/db/workflow-node-sessions.ts                 |    0.00 |    6.38 | 22-23,27-34,38-83,88-119
 packages/core/src/db/workflows.ts                              |    0.00 |    4.75 | 20-25,37-44,50-51,70-71,82-89,94-160,165-175,187-200,205-214,219-231,241-253,277-333,338-351,356-372,377-399,410-433,438-523,531-546,558-608,613-642,646-663,667-694,703-722,737-766,774-776,785-888,896-948,957-967,978-982,992-1010,1019-1053,1062-1085
 packages/core/src/github-auth/auth.ts                          |    0.00 |    4.40 | 42-43,52,56-226
 packages/core/src/github-auth/config.ts                        |    0.00 |   20.00 | 25,34-41,50-52
 packages/core/src/github-auth/connect-service.ts               |    0.00 |   14.55 | 26-27,39-56,69-95
 packages/core/src/github-auth/credential-helper-install.ts     |    0.00 |   15.38 | 24-25,30-32,51-78
 packages/core/src/github-auth/device-flow.ts                   |    0.00 |    0.56 | 15-193
 packages/core/src/github-auth/errors.ts                        |    0.00 |   23.81 | 10-20,26-30
 packages/core/src/github-auth/index.ts                         |  100.00 |  100.00 | 
 packages/core/src/github-auth/private-key.ts                   |    0.00 |    5.26 | 18-48,52-56
 packages/core/src/handlers/clone.ts                            |    0.00 |    5.90 | 24-25,32-35,66-121,135-144,152-268,275-296,305-392,399-466
 packages/core/src/handlers/command-handler.ts                  |    0.00 |    2.02 | 43-44,67-90,98-115,125-136,147-175,179-199,209-220,226-541,546-917,922-1181
 packages/core/src/index.ts                                     |  100.00 |  100.00 | 
 packages/core/src/operations/isolation-operations.ts           |    0.00 |    8.00 | 14-15,46-70,83-99,111-144,152-160,168-172
 packages/core/src/operations/workflow-operations.ts            |    0.00 |    5.31 | 20-21,60-71,82-86,94-100,107-121,132-218,228-300,313-325
 packages/core/src/orchestrator/manage-run-tool.ts              |    0.00 |   37.61 | 147-186,192-197,201-212,216-225,231-238,243-298,312-320
 packages/core/src/orchestrator/orchestrator-agent.ts           |    0.00 |    2.62 | 82-83,93-115,128-140,182-203,215-237,249,254-255,269-287,307-311,320-327,340-369,378-444,455-474,487-687,694-703,711-737,751-813,818-849,862-1475,1487-1687,1697-1928,1938-1948,1958-2018,2025-2057,2067-2106,2110-2119,2128-2159,2167-2184,2194-2225,2233-2349
 packages/core/src/orchestrator/orchestrator.ts                 |    0.00 |    5.85 | 8,11-21,29-30,72-78,82-97,110-233,284-503,514-518
 packages/core/src/orchestrator/prompt-builder.ts               |    0.00 |    6.40 | 12-18,25-36,52-64,71,79-88,142-170,179-211,228,253-263
 packages/core/src/schemas/codebase.ts                          |  100.00 |  100.00 | 
 packages/core/src/schemas/conversation.ts                      |  100.00 |  100.00 | 
 packages/core/src/schemas/env-var.ts                           |  100.00 |  100.00 | 
 packages/core/src/schemas/index.ts                             |  100.00 |  100.00 | 
 packages/core/src/schemas/message.ts                           |  100.00 |  100.00 | 
 packages/core/src/schemas/session.ts                           |  100.00 |  100.00 | 
 packages/core/src/schemas/user-ai-prefs-row.ts                 |  100.00 |  100.00 | 
 packages/core/src/schemas/user-github-token-row.ts             |  100.00 |  100.00 | 
 packages/core/src/schemas/user.ts                              |  100.00 |  100.00 | 
 packages/core/src/schemas/workflow-event.ts                    |  100.00 |  100.00 | 
 packages/core/src/schemas/workflow-run.ts                      |  100.00 |  100.00 | 
 packages/core/src/services/cleanup-service.ts                  |    0.00 |    4.76 | 31-32,40-45,71-133,162-248,258-262,275-287,296-420,427-442,462-517,525-559,572-591,599-664,672-691,698-702
 packages/core/src/services/title-generator.ts                  |    0.00 |    6.59 | 15-16,36-97,106-110,119-131,138-140
 packages/core/src/state/session-transitions.ts                 |    0.00 |   53.57 | 39,46,54-63
 packages/core/src/test/setup.ts                                |  100.00 |  100.00 | 
 packages/core/src/types/index.ts                               |    0.00 |   50.00 | 27-28
 packages/core/src/utils/commands.ts                            |  100.00 |  100.00 | 
 packages/core/src/utils/conversation-lock.ts                   |    0.00 |    6.47 | 14-15,46-108,117-144,152-169,176-194
 packages/core/src/utils/credential-sanitizer.ts                |    0.00 |   13.64 | 8,12-24,28-32
 packages/core/src/utils/error-formatter.ts                     |    0.00 |    0.00 | 14-98
 packages/core/src/utils/error.ts                               |    0.00 |    0.00 | 1-18
 packages/core/src/utils/github-graphql.ts                      |    0.00 |   10.71 | 11-12,24-71
 packages/core/src/utils/path-validation.ts                     |    0.00 |   22.22 | 8,20-23,36-44
 packages/core/src/utils/port-allocation.ts                     |    0.00 |   17.65 | 11-12,23-25,37-59
 packages/core/src/utils/token-crypto.ts                        |    0.00 |   20.51 | 13-15,23-28,36-43,53-66
 packages/core/src/utils/worktree-sync.ts                       |    0.00 |    8.79 | 11-12,17,22-23,28-42,48-54,64-119
 packages/core/src/workflows/store-adapter.ts                   |    0.00 |   14.10 | 37-38,42-78,96,104-197
 packages/git/src/branch.ts                                     |    0.00 |    4.56 | 8-9,24-75,83-106,118-138,148-175,186-218,236-268,281-309,320-348
 packages/git/src/exec.ts                                       |    0.00 |   33.33 | 8-16
 packages/git/src/index.ts                                      |  100.00 |  100.00 | 
 packages/git/src/repo.ts                                       |    0.00 |    3.51 | 16-17,25-43,52-71,97-187,191-204,208-217,222-225,229-238,243-248,252-273,278-298,311-345,362-401,409-416
 packages/git/src/types.ts                                      |    0.00 |   25.00 | 11-12,17-18,23-24
 packages/git/src/worktree.ts                                   |    0.00 |    6.81 | 10-11,54-75,91-102,119,131-156,168-207,220-236,247-260,269-274,282-301,326-377,385-391
 packages/isolation/src/errors.ts                               |    0.00 |   82.65 | 12-14,116-125,136-139
 packages/isolation/src/factory.ts                              |    0.00 |   50.00 | 19-20,28-29
 packages/isolation/src/index.ts                                |  100.00 |  100.00 | 
 packages/isolation/src/pr-state.ts                             |    0.00 |    6.06 | 14-15,30-89
 packages/isolation/src/providers/worktree.ts                   |    0.00 |    1.83 | 46-47,71-111,118-299,307-542,555-570,589-670,674-1235,1244-1245,1252-1256
 packages/isolation/src/resolver.ts                             |    0.00 |    1.78 | 36-37,73-567
 packages/isolation/src/types.ts                                |    0.00 |    0.00 | 
 packages/isolation/src/worktree-copy.ts                        |    0.00 |    6.72 | 14-15,32-38,50-63,78-144,157-177
 packages/paths/src/archon-paths.ts                             |    0.00 |   13.22 | 24-25,32-36,43-46,56-72,79,87-89,98,105,118,128,138,148,156,168,183-194,202,217-221,225,229-247,251-256,261-327,338-342,349,356,364,380-386,394,402,410,418,426,434,442,451-459,467-474,483-520,527-532,540-550,559-569
 packages/paths/src/bundled-build.ts                            |  100.00 |  100.00 | 
 packages/paths/src/env-loader.ts                               |    0.00 |   13.64 | 36-41,46-48,63-91
 packages/paths/src/index.ts                                    |  100.00 |  100.00 | 
 packages/paths/src/logger.ts                                   |   60.00 |   58.14 | 39-41,43-46,76,80-82,84,113-117
 packages/paths/src/telemetry.ts                                |    0.00 |   11.35 | 90-91,105-109,113,136-152,167-175,189-190,231-239,248,257-280,294-311,316-317,327-336,350-355,370-408,419-422,448-459,463-475,480-509,645-653,662-692,701-713,726-739,755-767,779-798,809-820,830-840,851-876,885-894,903-906
 packages/paths/src/update-check.ts                             |    0.00 |   13.00 | 26,30-43,48-53,62-70,78-85,94-134,143-150
 packages/providers/src/claude/binary-resolver.ts               |    0.00 |   15.29 | 27,48-58,70-85,91-92,126-167
 packages/providers/src/claude/capabilities.ts                  |  100.00 |  100.00 | 
 packages/providers/src/claude/config.ts                        |    0.00 |    0.00 | 14-33
 packages/providers/src/claude/native-tools.ts                  |    0.00 |    7.27 | 24-57,61,70-85
 packages/providers/src/claude/provider.ts                      |    0.00 |    5.46 | 48-49,64-77,88-97,116-123,127-132,136-150,160-195,202,233-253,275-440,487-488,496-559,569-623,633-765,775-810,826,829-835,839-987
 packages/providers/src/codex/binary-resolver.ts                |    0.00 |    9.71 | 24,38-39,48-50,60-127,153-171
 packages/providers/src/codex/capabilities.ts                   |  100.00 |  100.00 | 
 packages/providers/src/codex/config.ts                         |    0.00 |    0.00 | 14-44
 packages/providers/src/codex/provider.ts                       |    0.00 |    8.96 | 32-33,50-51,58-71,78-93,97-101,105-107,136-158,162-165,169-184,188-208,216-220,224-236,253-260,264-271,281-315,330-640,649-671,690-716,721-904
 packages/providers/src/community/copilot/binary-resolver.ts    |    0.00 |   12.23 | 37-48,54,67-76,82-83,90-92,102-176,185-203
 packages/providers/src/community/copilot/capabilities.ts       |  100.00 |  100.00 | 
 packages/providers/src/community/copilot/config.ts             |    0.00 |    0.00 | 13-58
 packages/providers/src/community/copilot/event-bridge.ts       |    0.00 |    5.46 | 27-28,55-58,68-99,111-122,159-224,271-431
 packages/providers/src/community/copilot/index.ts              |  100.00 |  100.00 | 
 packages/providers/src/community/copilot/provider.ts           |    0.00 |    3.91 | 61-62,90-93,97-98,102-106,112-114,127-162,168-177,189-198,208-226,235-254,269-304,315-350,357-366,370-376,386-414,430,434-621
 packages/providers/src/community/copilot/registration.ts       |    0.00 |   14.29 | 15-32
 packages/providers/src/community/opencode/agent-config.ts      |    0.00 |   13.08 | 17-18,24-31,35,39,43-54,58-85,89-96,103-104,111-123,127-130,134-147
 packages/providers/src/community/opencode/agent-fs.ts          |    0.00 |    7.14 | 11-12,18-62,66-96
 packages/providers/src/community/opencode/capabilities.ts      |  100.00 |  100.00 | 
 packages/providers/src/community/opencode/config.ts            |    0.00 |    4.00 | 5-12,22-37
 packages/providers/src/community/opencode/errors.ts            |    0.00 |   33.33 | 26,30-35,39-62,66-72
 packages/providers/src/community/opencode/index.ts             |  100.00 |  100.00 | 
 packages/providers/src/community/opencode/introspection.ts     |    0.00 |    8.16 | 25-26,73-115
 packages/providers/src/community/opencode/multi-agent.ts       |    0.00 |    2.00 | 32-33,37,41-59,63-79,83-105,109-111,115-392
 packages/providers/src/community/opencode/provider.ts          |    0.00 |   11.40 | 33-34,38,45-210,214
 packages/providers/src/community/opencode/registration.ts      |    0.00 |   20.00 | 11-22
 packages/providers/src/community/opencode/runtime.ts           |    0.00 |    5.77 | 8,12-18,22-45,80-81,85-90,95-113,118-125,130-131,135-151,156-157,161-231,235-255,264-278
 packages/providers/src/community/opencode/session.ts           |    0.00 |    3.24 | 17-18,22,26-51,55-78,82-91,95-115,119-301,306-337
 packages/providers/src/community/opencode/tokens.ts            |    0.00 |    6.25 | 3,7-20
 packages/providers/src/community/pi/capabilities.ts            |  100.00 |  100.00 | 
 packages/providers/src/community/pi/config.ts                  |    0.00 |    0.00 | 11-61
 packages/providers/src/community/pi/index.ts                   |  100.00 |  100.00 | 
 packages/providers/src/community/pi/model-catalog.ts           |    0.00 |   18.52 | 15-16,41-60
 packages/providers/src/community/pi/model-ref.ts               |    0.00 |    0.00 | 21-30
 packages/providers/src/community/pi/pi-vendor-map.generated.ts |  100.00 |  100.00 | 
 packages/providers/src/community/pi/provider.ts                |    0.00 |    5.11 | 54,58-64,68-73,93-115,139-140,155-633,638
 packages/providers/src/community/pi/registration.ts            |    0.00 |   28.57 | 16-25
 packages/providers/src/errors.ts                               |    0.00 |   28.57 | 7-11
 packages/providers/src/index.ts                                |  100.00 |  100.00 | 
 packages/providers/src/mcp/config.ts                           |    0.00 |    2.27 | 12-14,22-46,50-97,101-120,127-159
 packages/providers/src/oauth.ts                                |  100.00 |  100.00 | 
 packages/providers/src/registry.ts                             |    0.00 |   21.65 | 28-29,39-43,51-56,64-68,76,83,90-95,102,110-154,178-180
 packages/providers/src/shared/skills.ts                        |    0.00 |    7.27 | 28-37,49-89
 packages/providers/src/shared/structured-output.ts             |    0.00 |    6.25 | 35-45,68-119,131-136,147-149,176-178,188-203,217-231,278-296,306-315
 packages/providers/src/types.ts                                |  100.00 |  100.00 | 
 packages/workflows/src/artifacts-index.ts                      |    0.00 |   10.99 | 8-9,21,31-35,52-85,95-122,131-141
 packages/workflows/src/command-validation.ts                   |    0.00 |    0.00 | 5-13
 packages/workflows/src/condition-evaluator.ts                  |    0.00 |    4.67 | 34-35,48-73,81-98,123-193,205-230
 packages/workflows/src/dag-executor.ts                         |    0.00 |    1.10 | 101-107,116-127,137-151,157-158,172-211,222-233,250-264,307,330-345,356,364,372-392,404-443,458-647,652-680,693-731,740-1563,1580-1749,1759-2018,2031-2668,2677-2857,2865-3857
 packages/workflows/src/defaults/bundled-defaults.generated.ts  |  100.00 |  100.00 | 
 packages/workflows/src/defaults/bundled-defaults.ts            |    0.00 |   66.67 | 
 packages/workflows/src/event-emitter.ts                        |    0.00 |   33.33 | 18-19,174-175,182,189,196,203-206,214-225,233-238,249-252
 packages/workflows/src/executor-shared.ts                      |    0.00 |   13.91 | 19-20,64,73-81,89-101,137-180,202-203,219-232,247-383,413-474,493-517,526,544-560,571-580,589,616-667
 packages/workflows/src/executor.ts                             |    0.00 |    2.07 | 38-39,46,54-101,114-120,134-153,165-178,193-218,228-258,331-350,362-996
 packages/workflows/src/loader.ts                               |    0.00 |    1.63 | 34-35,53-64,71,78-79,88-130,139-220,231-608,623-645
 packages/workflows/src/logger.ts                               |    0.00 |   11.81 | 11-12,50,58-83,92-101,108-115,122-131,138-153,160-167,174-176,181-190,195-207,212-221,226-235
 packages/workflows/src/model-validation.ts                     |    0.00 |   18.55 | 74,78-82,86-90,94-99,103-105,109-114,139-177,188-197,207-219,224,252-258,269-271,280-281
 packages/workflows/src/output-ref.ts                           |    0.00 |    8.89 | 38-43,47-56,70-75,84-86,90-97,107-155
 packages/workflows/src/router.ts                               |    0.00 |    3.61 | 9-10,38-64,73-111,153-199,206-209,223-263
 packages/workflows/src/schemas/dag-node.ts                     |    7.69 |   44.52 | 57-62,165-173,437-565,568-644,654,659,664,669,674,679,691-696
 packages/workflows/src/schemas/hooks.ts                        |  100.00 |  100.00 | 
 packages/workflows/src/schemas/index.ts                        |  100.00 |  100.00 | 
 packages/workflows/src/schemas/loop.ts                         |    0.00 |   63.16 | 23-29
 packages/workflows/src/schemas/node-artifact.ts                |  100.00 |  100.00 | 
 packages/workflows/src/schemas/retry.ts                        |  100.00 |  100.00 | 
 packages/workflows/src/schemas/workflow-node-session.ts        |  100.00 |  100.00 | 
 packages/workflows/src/schemas/workflow-run.ts                 |    0.00 |   93.51 | 148-152
 packages/workflows/src/schemas/workflow.ts                     |  100.00 |  100.00 | 
 packages/workflows/src/script-discovery.ts                     |    0.00 |   16.84 | 12,18-19,44,63-120,130-133,149-160
 packages/workflows/src/utils/duration.ts                       |    0.00 |    4.55 | 9-13,30-45
 packages/workflows/src/utils/github-token-policy.ts            |    0.00 |   11.90 | 30-31,47-69,78-89
 packages/workflows/src/utils/idle-timeout.ts                   |    0.00 |    3.03 | 47-110
 packages/workflows/src/utils/tool-formatter.ts                 |    0.00 |    1.56 | 15-26,37-82,92-96
 packages/workflows/src/utils/workflow-requirements.ts          |    0.00 |   18.75 | 31-36,45-51
 packages/workflows/src/workflow-discovery.ts                   |    0.00 |    4.56 | 34-35,49,53-72,96-153,164-183,205-359,374-389
----------------------------------------------------------------|---------|---------|-------------------

 42 pass
 0 fail
 79 expect() calls
Ran 42 tests across 1 file. [794.00ms]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The Slack adapter now displays lifecycle reaction indicators: 👀 when a mention/DM message is received and ✅ after the adapter’s reply is sent.
  * Reaction updates use best-effort behavior, so failures won’t interrupt message handling (including multi-part replies).

* **Documentation**
  * Updated the Slack adapter docs with a new “receipt” lifecycle reactions section and refreshed in-thread UX guidance to place 👀/✅ as the first step.

* **Tests**
  * Expanded Slack adapter unit tests to cover reaction add/remove behavior and best-effort failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->