### PR TITLE
docs: reframe Archon identity from single-developer coding tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,16 @@
 ## Project Overview
 
-**Remote Agentic Coding Platform**: Control AI coding assistants (Claude Code SDK, Codex SDK) remotely from Slack, Telegram, and GitHub. Built with **Bun + TypeScript + SQLite/PostgreSQL**, single-developer tool for AI-assisted development practitioners. Architecture prioritizes simplicity, flexibility, and user control.
+**Archon — a self-hostable, governed agentic automation engine.** Archon runs multi-step workflows that mix deterministic steps (bash/scripts) with AI agents (Claude Code SDK, Codex SDK, and others), with human approval gates and full audit trails — driven remotely from Slack, Telegram, GitHub, Discord, the web UI, or the CLI. Its most mature surface today is agentic **coding** (controlling Claude Code / Codex against repos); the same engine is being extended to drive general **business-operations** automation. Built with **Bun + TypeScript + SQLite/PostgreSQL** and deployed as a single-tenant install (one isolated instance per operator or client — see *Single-Tenant per Install*). Architecture prioritizes simplicity, flexibility, governance, and user control.
+
+## Product Direction
+
+Archon is being positioned as a governed agentic automation engine for business operations, not only coding.
 
 ## Core Principles
 
-**Single-Developer Tool**
-- No multi-tenant complexity
+**Single-Tenant per Install**
+- One isolated instance per operator or client — the deployment model is one install (e.g. one VPS) per client, **not** one install serving many tenants. Keep the data model and runtime single-tenant: no per-tenant isolation, row-scoping, or tenant multiplexing. Client isolation is achieved at the **deployment** layer, not in code — a deliberate simplification, not a limitation.
+- Multi-**user** within one install (several humans sharing an instance, each with their own identity and credentials) **is** supported, and is distinct from multi-**tenant**. Don't conflate them.
 
 **Platform Agnostic**
 - Unified conversation interface across Slack/Telegram/GitHub/cli/web


### PR DESCRIPTION
## Summary

- Problem: `CLAUDE.md` framed Archon as a *"Remote Agentic Coding Platform... single-developer tool for AI-assisted development practitioners."* That identity is now too narrow and actively misleading about direction.
- Why it matters: `CLAUDE.md` is the canonical instructions file every agent (and contributor) reads. The "single-developer coding tool" framing steers new work toward coding-only, single-dev assumptions.
- What changed: reframed the Project Overview to a *governed agentic automation engine*; renamed the `Single-Developer Tool` principle to `Single-Tenant per Install`; added a one-line Product Direction note.
- What did **not** change (scope boundary): documentation only. No code, schemas, behavior, APIs, config, or tests. The other ~960 lines of `CLAUDE.md` (technical docs) are untouched.

## UX Journey

### Before

```
N/A — documentation-only change. No user-facing flow is affected.
```

### After

```
N/A — no runtime behavior changes.
```

## Architecture Diagram

### Before

```
N/A — no modules touched. Only CLAUDE.md (project instructions) changed.
```

### After

```
N/A
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| — | — | unchanged | No module edges touched (docs only) |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `docs`
- Module: `docs:claude-md`

## Change Metadata

- Change type: `docs`
- Primary scope: `docs`

## Linked Issue

- Closes: None
- Related: None
- Depends on: None
- Supersedes: None

## Validation Evidence (required)

```bash
# Documentation-only change (single Markdown file). The lint-staged pre-commit
# hook ran Prettier on CLAUDE.md at commit time (formatted clean).
```

- Evidence provided (test/log/trace/screenshot): Prettier (via lint-staged) ran on commit and reformatted clean; the rendered diff was reviewed.
- If any command is intentionally skipped, explain why: `type-check`, `lint`, and `test` are not applicable — no TypeScript, code, or tests are touched. Full `bun run validate` is disproportionate for a one-file Markdown reframe.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`
- If any `Yes`, describe risk and mitigation: N/A

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Database migration needed? `No`
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: reviewed the committed diff and the rendered top of `CLAUDE.md`; the three intended edits are present and accurate.
- Edge cases checked: confirmed only `CLAUDE.md` is in the commit (unrelated working-tree WIP left untouched); confirmed the framing describes coding as the *current* surface and business-ops as *direction*, so the doc does not claim unshipped capabilities.
- What was not verified: nothing further — there is no runtime behavior to verify.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: none at runtime. Affects how contributors/agents interpret the project's identity and the single-tenant principle.
- Potential unintended effects: an agent could over-read the "business-operations" direction as shipped capability.
- Guardrails/monitoring for early detection: the text explicitly marks coding as "most mature today" and business-ops as "being extended," plus a Product Direction note labeling it as positioning.

## Rollback Plan (required)

- Fast rollback command/path: `git revert 13868a18` (or revert the merge commit).
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: None — documentation only.

## Risks and Mitigations

- Risk: the reframe references a business-operations direction that is not yet implemented (no scheduler, packs, or per-client provisioning shipped).
  - Mitigation: wording frames coding as the current primary surface and business-ops as direction; the Product Direction note is explicitly positioning, not a capability claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the top-level project description to reflect Archon as a self-hostable, governed agentic automation engine.
  * Clarified deployment guidance to emphasize single-tenant installs, while noting that multiple users can share one installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->