### PR TITLE
chore(deps): bump @anthropic-ai/claude-agent-sdk 0.3.173 → 0.3.193

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "archon",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.173",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.193",
         "@opencode-ai/sdk": "^1.17.3",
       },
       "devDependencies": {
@@ -135,7 +135,7 @@
       "name": "@archon/providers",
       "version": "0.4.1",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.173",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.193",
         "@archon/paths": "workspace:*",
         "@earendil-works/pi-ai": "^0.79.1",
         "@earendil-works/pi-coding-agent": "^0.79.1",
@@ -256,23 +256,23 @@
   "packages": {
     "@antfu/ni": ["@antfu/ni@25.0.0", "", { "dependencies": { "ansis": "^4.0.0", "fzf": "^0.5.2", "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" }, "bin": { "na": "bin/na.mjs", "ni": "bin/ni.mjs", "nr": "bin/nr.mjs", "nci": "bin/nci.mjs", "nlx": "bin/nlx.mjs", "nun": "bin/nun.mjs", "nup": "bin/nup.mjs" } }, "sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA=="],
 
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.173", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.173", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.173", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.173", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.173", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.173", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.173", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.173", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.173" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-BsdL223y7vCUJA9uBW9osSrhufvwIT+J94IBkh83v+wjyjoBIwLXREdacFabair70bGNdtkw6cWCaYNThSQg7A=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.193", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.193", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.193", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.193", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.193", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.193", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.193", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.193", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.193" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-WzL03VJE1sT0Nz3rEpsYMYR+9n6iyQtLVt7ghMWnYC9pvDsiy6kwcMplZniWSjH8Dm6CfkUBN5t6KB4i/JfouA=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.173", "", { "os": "darwin", "cpu": "arm64" }, "sha512-McW1toJ4Qdo/i7bHnsiFMm2AtyCiK/5V90WgL7M9ZO9llrJr3riGRdBlRGHvWnS7rKuv5ttj4/SuBkLoL9o75A=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.193", "", { "os": "darwin", "cpu": "arm64" }, "sha512-1hT7b+KIm/3E1OSJofr7PF21Xq2zT1ccnjzuVcWQ5LYXJ09lgCMvA/ZfcDBKuoyCZ4lSnuicKXZ/h5vRbWfqrA=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.173", "", { "os": "darwin", "cpu": "x64" }, "sha512-m2Oh1pQ69IUg6DSH6n1nAAAtRq+G7J2B/CKTbTfDAEmg5t0lzakZV9l28GZrlP21xl+PIg71dkiJ5u94KYgpRw=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.193", "", { "os": "darwin", "cpu": "x64" }, "sha512-9x5Y/L6iwETwEJFmPaYXfsE8q0cVgx75V7nL60HvSzi8K1XQNcG5u53jOzRvqDNah8mvGYOb+9AWrMCSJvmFyA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.173", "", { "os": "linux", "cpu": "arm64" }, "sha512-Vb64WJOD2D9tKn/i0ErmLbO6I1187xTwL/kxEANjg4L1FGQnvdYBnZ6J6jU6+x8UgcuIi82imHROQp80gbPW2w=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.193", "", { "os": "linux", "cpu": "arm64" }, "sha512-gvfD9pKHXWxCkkIX6bC4/FOALTxqHYjAu83iT1bzn5mCv6QWSZRl6WLRRtvKpWtWuY1jpML1lL3YfKADsAX/rA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.173", "", { "os": "linux", "cpu": "arm64" }, "sha512-uu8MnPwFBc9ayFg5c94aHaqJVLS51oHNVxHwud4nK27GliP5WoME3F7pmm1N/Jyy2ry2E2CLNnsAm5l3zemfYA=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.193", "", { "os": "linux", "cpu": "arm64" }, "sha512-a3qsVTBe4G6ndsVavfIXEVAXLVXM8uvBUNYpm4jKqk2+ovWZQe/96CXOwmerg9U+/bllg4QJ9lSyYCsdtVIr6w=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.173", "", { "os": "linux", "cpu": "x64" }, "sha512-0l9L5O+Uiw8gq9mu2NqGSYcSmX8RJMAh9GkGacTJqJbkfHCiFxqZmWBWODOt6HP7PTFCV+yMzQK/xJQjnag/jw=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.193", "", { "os": "linux", "cpu": "x64" }, "sha512-1sz+7cn0iuh0ThInuAYF1jpFvLyOaZ0PZYQIF7eb9JDZbBohUf6INeTCwjAwUL0ASCq2xS7Odu/qDVuTtLTeDA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.173", "", { "os": "linux", "cpu": "x64" }, "sha512-ofKxyp/N8+LLSrClt+dJo0laCHDzmBgmN8+Q+zabJ54Jqc1KXee68UsziE7kLCqGbOSY7rsIK9d22T1uQyZkUw=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.193", "", { "os": "linux", "cpu": "x64" }, "sha512-DLXlO4tlcWygz0Ft4nu6ai5KssByYt2tOeWdc4dFXKt6uBKXpbZVziUUq3ePO5zuAFyU6w7EjYLv8MMPURbAiQ=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.173", "", { "os": "win32", "cpu": "arm64" }, "sha512-aulIrBYjFDm+S5kl4CxC8A3KUiTDKLHoKV46Mat64E+skGEyBkC7WzZAGbpGKB2y8KZo1WbrwJTGefgyHMpDhw=="],
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.193", "", { "os": "win32", "cpu": "arm64" }, "sha512-36LJKiGuKusgaPTVeh9QanL00UcaE0RcC4pgK800/0SenApbh979ndxI0XKUVfLHzlGkqlhkhT3foMdqS+zx1w=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.173", "", { "os": "win32", "cpu": "x64" }, "sha512-HjGkfDlNLI3Kh9NIUfevJ3SZY8Xv3td4zx5Cz3YE0VPrrjIkRvdEv9K6WTjT94tlS0TUXQS/kFT+NCmoGXuvZQ=="],
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.193", "", { "os": "win32", "cpu": "x64" }, "sha512-VyyKZlWQpbD6nkUTeNvgmLvpqt1QaPQQBOC30tbEYwYsV5MC1I35Li0H7nWwngGqPSTtMvHpjpz6Eb2FSTn7/A=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.93.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA=="],
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@hono/node-server": "^1.19.13"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.173",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.193",
     "@opencode-ai/sdk": "^1.17.3"
   }
 }

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -26,7 +26,7 @@
     "type-check": "bun x tsc --noEmit"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.173",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.193",
     "@archon/paths": "workspace:*",
     "@github/copilot-sdk": "~1.0.1",
     "@earendil-works/pi-ai": "^0.79.1",


### PR DESCRIPTION
## Summary

- **Problem:** `@anthropic-ai/claude-agent-sdk` was pinned at `^0.3.173`; latest is `0.3.193` (~20 Claude Code parity releases behind).
- **Why it matters:** keeps the bundled Claude Code binary current (model-alias resolution, `opus`→`claude-opus-4-8` with native 1M context) and pulls fixes relevant to our binary builds and rate-limit handling.
- **What changed:** bumped the dep `^0.3.173` → `^0.3.193` in the root `package.json` and `packages/providers/package.json`; refreshed `bun.lock`.
- **What did NOT change (scope boundary):** no source changes, no API/behavior changes, no config or schema changes. Dependency bump only.

## UX Journey

### Before

```
No user-facing change. Workflow runs and chat drive the Claude Agent SDK 0.3.173 binary.
```

### After

```
Identical user-facing flow; the SDK/binary is now 0.3.193.
[~] Bundled Claude Code binary advanced ~20 parity releases (libc spawn diagnostics,
    rate-limit detection fields, fast-mode regression fix).
```

## Architecture Diagram

### Before

```
@archon/providers ──uses──▶ @anthropic-ai/claude-agent-sdk@0.3.173
(root package.json declares the same dep for the workspace)
```

### After

```
@archon/providers ──uses──▶ @anthropic-ai/claude-agent-sdk@0.3.193  [~ version only]
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `@archon/providers` | `@anthropic-ai/claude-agent-sdk` | **modified** | version `^0.3.173` → `^0.3.193` |
| root workspace | `@anthropic-ai/claude-agent-sdk` | **modified** | version `^0.3.173` → `^0.3.193` |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `dependencies`
- Module: `providers:claude-sdk`

## Change Metadata

- Change type: `chore`
- Primary scope: `multi` (root + providers manifests)

## Linked Issue

- Closes # — none
- Related # — release-readiness review (dev→main)

## Validation Evidence (required)

```bash
bun run validate
```

- Evidence provided: `bun run validate` passes locally — all 10 package type-checks exit 0; lint and format:check clean; the four generated-bundle checks (`check:bundled`, `check:bundled-skill`, `check:bundled-schema`, `check:pi-vendor-map`) pass; per-package test suites report `0 fail`.
- Skipped commands: none.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: `bun run validate` green on the bump; resolved version confirmed as exactly `0.3.193` in `node_modules`.
- Edge cases checked: diff limited to the two manifests + lockfile; no source files touched.
- What was not verified: a live workflow run that spawns **background agents** — see the blast-radius note below (`0.3.186` changes background-agent permission handling). Recommend one manual smoke before relying on it in anger.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: anything driving the Claude provider (chat + workflow nodes) via the bundled Claude Code binary.
- Potential unintended effects: **`0.3.186`** changes background agents to forward permission prompts to `canUseTool` instead of auto-denying. Other notable deltas: `0.3.178` libc (musl/glibc) spawn diagnostics, `0.3.181` rate-limit detection fields, `0.3.191` fast-mode regression fix.
- Guardrails/monitoring for early detection: CI `validate`; watch for provider spawn/permission errors after merge.

## Rollback Plan (required)

- Fast rollback command/path: revert this commit (restores `^0.3.173` in both manifests + lockfile), `bun install`.
- Feature flags or config toggles: none.
- Observable failure symptoms: Claude provider subprocess spawn failures, unexpected permission denials in background-agent workflows, or type/runtime errors against the SDK surface.

## Risks and Mitigations

- Risk: `0.3.186` background-agent permission behavior change (auto-deny → `canUseTool`).
  - Mitigation: smoke-test a workflow that spawns background agents before merging anything that depends on it; rollback is a single-commit revert.
- Risk: minor SDK/runtime drift across ~20 releases.
  - Mitigation: `bun run validate` (type-check + tests) passes; changes are dependency-only and fully reversible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Anthropic Claude agent SDK to a newer version across the app.
  * This keeps the project aligned with the latest compatible release and may include reliability and compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->