### PR TITLE
feat(workflows,cli,paths): surface resolved model/tier in CLI node_started lines + one-time tier notice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -653,6 +653,7 @@ curl http://localhost:3637/api/conversations/<conversationId>/messages
 ├── vendor/codex/                  # Codex native binary (binary builds, user-placed)
 ├── web-dist/<version>/            # Cached web UI dist (archon serve, binary only)
 ├── update-check.json              # Update check cache (binary builds, 24h TTL)
+├── tier-notice.json               # One-time tier-default notice state (CLI, per version)
 ├── archon.db                     # SQLite database (when DATABASE_URL not set)
 └── config.yaml                   # Global configuration (non-secrets)
 ```

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, spyOn, mock } from 'bun:test';
 import type { WorkflowEmitterEvent } from '@archon/workflows/event-emitter';
-import { makeTestWorkflowWithSource } from '@archon/workflows/test-utils';
+import { makeTestWorkflow, makeTestWorkflowWithSource } from '@archon/workflows/test-utils';
 import {
   workflowListCommand,
   workflowRunCommand,
@@ -17,6 +17,7 @@ import {
   workflowCleanupCommand,
   workflowResetSessionsCommand,
   buildDetachedRunCmd,
+  maybePrintTierNotice,
 } from './workflow';
 
 const mockLogger = {
@@ -3785,5 +3786,109 @@ describe('workflowResetSessionsCommand', () => {
     expect(consoleSpy).toHaveBeenCalledWith(
       JSON.stringify({ workflow: 'feature-dev', deleted: 2, scope: 'conv-1', node: null })
     );
+  });
+});
+
+describe('maybePrintTierNotice', () => {
+  const { loadConfig, getUserAiPrefs } = require('@archon/core') as {
+    loadConfig: ReturnType<typeof mock>;
+    getUserAiPrefs: ReturnType<typeof mock>;
+  };
+  const { readTierNoticeState, markTierNoticeShown } = require('@archon/paths') as {
+    readTierNoticeState: ReturnType<typeof mock>;
+    markTierNoticeShown: ReturnType<typeof mock>;
+  };
+
+  let stderrSpy: ReturnType<typeof spyOn>;
+
+  function makeTierWorkflow(nodeModel?: string, workflowModel?: string) {
+    return makeTestWorkflow({
+      name: 'tier-test',
+      ...(workflowModel !== undefined ? { model: workflowModel } : {}),
+      nodes: [
+        { id: 'n1', command: 'test-cmd', ...(nodeModel !== undefined ? { model: nodeModel } : {}) },
+      ],
+    });
+  }
+
+  beforeEach(() => {
+    stderrSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+    (readTierNoticeState as ReturnType<typeof mock>).mockReturnValue(null);
+    (markTierNoticeShown as ReturnType<typeof mock>).mockClear();
+    (loadConfig as ReturnType<typeof mock>).mockResolvedValue({ defaults: {}, tiers: {} });
+    (getUserAiPrefs as ReturnType<typeof mock>).mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+  });
+
+  it('prints nothing and returns when quiet=true', async () => {
+    const workflow = makeTierWorkflow('large');
+    await maybePrintTierNotice(workflow, '/cwd', undefined, true);
+    expect(stderrSpy).not.toHaveBeenCalled();
+    expect(markTierNoticeShown).not.toHaveBeenCalled();
+  });
+
+  it('prints nothing when no nodes use tier keywords', async () => {
+    const workflow = makeTierWorkflow(undefined);
+    await maybePrintTierNotice(workflow, '/cwd', undefined, false);
+    expect(stderrSpy).not.toHaveBeenCalled();
+    expect(markTierNoticeShown).not.toHaveBeenCalled();
+  });
+
+  it('detects workflow-level tier keyword even when no per-node model is set', async () => {
+    const workflow = makeTierWorkflow(undefined, 'large');
+    await maybePrintTierNotice(workflow, '/cwd', undefined, false);
+    expect(stderrSpy).toHaveBeenCalled();
+    expect(markTierNoticeShown).toHaveBeenCalledWith('0.0.0-test');
+  });
+
+  it('prints nothing when the used tier is explicitly configured in install config', async () => {
+    (loadConfig as ReturnType<typeof mock>).mockResolvedValue({
+      defaults: {},
+      tiers: { large: { provider: 'claude', model: 'opus' } },
+    });
+    const workflow = makeTierWorkflow('large');
+    await maybePrintTierNotice(workflow, '/cwd', undefined, false);
+    expect(stderrSpy).not.toHaveBeenCalled();
+    expect(markTierNoticeShown).not.toHaveBeenCalled();
+  });
+
+  it('prints nothing when the notice was already shown for this version', async () => {
+    (readTierNoticeState as ReturnType<typeof mock>).mockReturnValue({
+      shownForVersion: '0.0.0-test',
+    });
+    const workflow = makeTierWorkflow('large');
+    await maybePrintTierNotice(workflow, '/cwd', undefined, false);
+    expect(stderrSpy).not.toHaveBeenCalled();
+    expect(markTierNoticeShown).not.toHaveBeenCalled();
+  });
+
+  it('prints the notice and marks shown when tier is unconfigured and not yet shown', async () => {
+    const workflow = makeTierWorkflow('large');
+    await maybePrintTierNotice(workflow, '/cwd', undefined, false);
+    expect(stderrSpy).toHaveBeenCalled();
+    const written = stderrSpy.mock.calls[0][0] as string;
+    expect(written).toContain('model tiers');
+    expect(markTierNoticeShown).toHaveBeenCalledWith('0.0.0-test');
+  });
+
+  it('returns silently when loadConfig throws', async () => {
+    (loadConfig as ReturnType<typeof mock>).mockRejectedValue(new Error('parse error'));
+    const workflow = makeTierWorkflow('large');
+    await expect(maybePrintTierNotice(workflow, '/cwd', undefined, false)).resolves.toBeUndefined();
+    expect(stderrSpy).not.toHaveBeenCalled();
+    expect(markTierNoticeShown).not.toHaveBeenCalled();
+  });
+
+  it('prints nothing when user prefs already configure the tier', async () => {
+    (getUserAiPrefs as ReturnType<typeof mock>).mockResolvedValue({
+      tiers: { large: { provider: 'claude', model: 'claude-opus-4-8' } },
+    });
+    const workflow = makeTierWorkflow('large');
+    await maybePrintTierNotice(workflow, '/cwd', 'user-1', false);
+    expect(stderrSpy).not.toHaveBeenCalled();
+    expect(markTierNoticeShown).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -35,6 +35,9 @@ mock.module('@archon/paths', () => ({
   createLogger: mock(() => mockLogger),
   getArchonHome: mock(() => '/home/test/.archon'),
   BUNDLED_IS_BINARY: false,
+  BUNDLED_VERSION: '0.0.0-test',
+  readTierNoticeState: mock(() => null),
+  markTierNoticeShown: mock(() => undefined),
 }));
 
 // Mock @archon/isolation (getIsolationProvider moved here from @archon/core)
@@ -71,6 +74,7 @@ mock.module('@archon/core', () => ({
   loadConfig: mock(() => Promise.resolve({ defaults: {} })),
   generateAndSetTitle: mock(() => Promise.resolve()),
   loadRepoConfig: mock(() => Promise.resolve(null)),
+  getUserAiPrefs: mock(() => Promise.resolve({})),
   createWorkflowStore: mock(() => ({
     createWorkflowEvent: mock(() => Promise.resolve()),
   })),
@@ -3412,6 +3416,74 @@ describe('workflowRunCommand — progress rendering', () => {
     await workflowRunCommand('/test/path', 'plan', 'hello', {});
 
     expect(stderrSpy).toHaveBeenCalledWith('[classify] Started\n');
+  });
+
+  it('should write node_started with provider/model/tier suffix for tier-resolved nodes', async () => {
+    setupWorkflowMocks();
+
+    const { executeWorkflow } = require('@archon/workflows/executor');
+    (executeWorkflow as ReturnType<typeof mock>).mockImplementationOnce(async () => {
+      if (capturedSubscribeHandler) {
+        capturedSubscribeHandler({
+          type: 'node_started',
+          runId: 'run-1',
+          nodeId: 'implement',
+          nodeName: 'implement',
+          provider: 'claude',
+          model: 'opus',
+          tier: 'large',
+        });
+      }
+      return { success: true, workflowRunId: 'run-1' };
+    });
+
+    await workflowRunCommand('/test/path', 'plan', 'hello', {});
+
+    expect(stderrSpy).toHaveBeenCalledWith('[implement] Started  (claude/opus ← large)\n');
+  });
+
+  it('should write node_started with provider/model suffix (no tier) for literal-model nodes', async () => {
+    setupWorkflowMocks();
+
+    const { executeWorkflow } = require('@archon/workflows/executor');
+    (executeWorkflow as ReturnType<typeof mock>).mockImplementationOnce(async () => {
+      if (capturedSubscribeHandler) {
+        capturedSubscribeHandler({
+          type: 'node_started',
+          runId: 'run-1',
+          nodeId: 'classify',
+          nodeName: 'classify',
+          provider: 'claude',
+          model: 'claude-haiku-4-5',
+        });
+      }
+      return { success: true, workflowRunId: 'run-1' };
+    });
+
+    await workflowRunCommand('/test/path', 'plan', 'hello', {});
+
+    expect(stderrSpy).toHaveBeenCalledWith('[classify] Started  (claude/claude-haiku-4-5)\n');
+  });
+
+  it('should write a bare node_started line when no provider/model (bash/script node)', async () => {
+    setupWorkflowMocks();
+
+    const { executeWorkflow } = require('@archon/workflows/executor');
+    (executeWorkflow as ReturnType<typeof mock>).mockImplementationOnce(async () => {
+      if (capturedSubscribeHandler) {
+        capturedSubscribeHandler({
+          type: 'node_started',
+          runId: 'run-1',
+          nodeId: 'build',
+          nodeName: 'build',
+        });
+      }
+      return { success: true, workflowRunId: 'run-1' };
+    });
+
+    await workflowRunCommand('/test/path', 'plan', 'hello', {});
+
+    expect(stderrSpy).toHaveBeenCalledWith('[build] Started\n');
   });
 
   it('should write node_completed event with duration to stderr', async () => {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -286,9 +286,10 @@ function resolveTitleAssistantType(
 /**
  * Print a one-time per-version tier notice to stderr when the workflow uses
  * unconfigured tier-keyword nodes (small/medium/large resolving via built-in
- * defaults). Suppressed under --quiet. Mirrors `archon ai tier list` formatting.
+ * defaults). Suppressed under --quiet. Uses the same 7-char tier column as
+ * `archon ai tier list`.
  */
-async function maybePrintTierNotice(
+export async function maybePrintTierNotice(
   workflow: WorkflowDefinition,
   cwd: string,
   cliUserId: string | undefined,
@@ -296,8 +297,13 @@ async function maybePrintTierNotice(
 ): Promise<void> {
   if (quiet) return;
 
-  // Collect tier keywords used by the workflow's nodes.
+  // Collect tier keywords used by the workflow — check the workflow-level default
+  // first (model: large at the top level applies to all nodes without overrides),
+  // then per-node overrides.
   const usedTiers = new Set<TierName>();
+  if (typeof workflow.model === 'string' && isTierName(workflow.model)) {
+    usedTiers.add(workflow.model);
+  }
   for (const node of workflow.nodes) {
     if ('model' in node && typeof node.model === 'string' && isTierName(node.model)) {
       usedTiers.add(node.model);
@@ -309,7 +315,8 @@ async function maybePrintTierNotice(
   let config: Awaited<ReturnType<typeof loadConfig>>;
   try {
     config = await loadConfig(cwd);
-  } catch {
+  } catch (err) {
+    getLog().debug({ err }, 'tier_notice.config_load_failed');
     return;
   }
   const configuredTiers: RawTiersConfig = config.tiers ?? {};
@@ -332,7 +339,7 @@ async function maybePrintTierNotice(
   if (!hasUnconfigured) return;
 
   // One-time per Archon version (a version bump may ship new tier defaults).
-  const version = BUNDLED_VERSION ?? 'dev';
+  const version = BUNDLED_VERSION;
   if (readTierNoticeState()?.shownForVersion === version) return;
 
   // Build the resolved profile for the effective default assistant.

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -350,7 +350,10 @@ export async function maybePrintTierNotice(
       globalTiers: configuredTiers,
       userTiers,
     }).aliases;
-  } catch {
+  } catch (err) {
+    // Non-fatal: a corrupt tier/alias config can make buildAiProfile throw —
+    // skip the notice rather than blocking the run.
+    getLog().debug({ err }, 'tier_notice.build_profile_failed');
     return;
   }
 

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -385,12 +385,11 @@ export async function maybePrintTierNotice(
 function renderWorkflowEvent(event: WorkflowEmitterEvent, verbose: boolean): void {
   switch (event.type) {
     case 'node_started': {
-      const suffix =
-        event.provider !== undefined && event.model !== undefined
-          ? event.tier !== undefined
-            ? `  (${event.provider}/${event.model} ← ${event.tier})`
-            : `  (${event.provider}/${event.model})`
-          : '';
+      let suffix = '';
+      if (event.provider !== undefined && event.model !== undefined) {
+        const tierPart = event.tier !== undefined ? ` ← ${event.tier}` : '';
+        suffix = `  (${event.provider}/${event.model}${tierPart})`;
+      }
       process.stderr.write(`[${event.nodeName}] Started${suffix}\n`);
       break;
     }

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -7,10 +7,25 @@ import {
   loadRepoConfig,
   generateAndSetTitle,
   createWorkflowStore,
+  getUserAiPrefs,
 } from '@archon/core';
 import { WORKFLOW_EVENT_TYPES, type WorkflowEventType } from '@archon/workflows/store';
+import {
+  isTierName,
+  buildAiProfile,
+  TIER_NAMES,
+  type TierName,
+  type RawTiersConfig,
+} from '@archon/workflows/model-validation';
 import { configureIsolation, getIsolationProvider } from '@archon/isolation';
-import { createLogger, getArchonHome, BUNDLED_IS_BINARY } from '@archon/paths';
+import {
+  createLogger,
+  getArchonHome,
+  BUNDLED_IS_BINARY,
+  BUNDLED_VERSION,
+  readTierNoticeState,
+  markTierNoticeShown,
+} from '@archon/paths';
 import { join } from 'node:path';
 import { mkdirSync, openSync, closeSync } from 'node:fs';
 import { createWorkflowDeps } from '@archon/core/workflows/store-adapter';
@@ -268,12 +283,110 @@ function resolveTitleAssistantType(
   return fallbackAssistant;
 }
 
+/**
+ * Print a one-time per-version tier notice to stderr when the workflow uses
+ * unconfigured tier-keyword nodes (small/medium/large resolving via built-in
+ * defaults). Suppressed under --quiet. Mirrors `archon ai tier list` formatting.
+ */
+async function maybePrintTierNotice(
+  workflow: WorkflowDefinition,
+  cwd: string,
+  cliUserId: string | undefined,
+  quiet: boolean | undefined
+): Promise<void> {
+  if (quiet) return;
+
+  // Collect tier keywords used by the workflow's nodes.
+  const usedTiers = new Set<TierName>();
+  for (const node of workflow.nodes) {
+    if ('model' in node && typeof node.model === 'string' && isTierName(node.model)) {
+      usedTiers.add(node.model);
+    }
+  }
+  if (usedTiers.size === 0) return;
+
+  // Load install config to see which tiers are explicitly configured.
+  let config: Awaited<ReturnType<typeof loadConfig>>;
+  try {
+    config = await loadConfig(cwd);
+  } catch {
+    return;
+  }
+  const configuredTiers: RawTiersConfig = config.tiers ?? {};
+
+  // Layer in the CLI user's personal tier prefs (best-effort, non-fatal).
+  let userTiers: RawTiersConfig = {};
+  let userDefaultProvider: string | undefined;
+  if (cliUserId) {
+    try {
+      const prefs = await getUserAiPrefs(cliUserId);
+      userTiers = prefs.tiers ?? {};
+      userDefaultProvider = prefs.defaultProvider;
+    } catch {
+      // Non-fatal — proceed without user tier info.
+    }
+  }
+
+  // Only notify when at least one used tier is unconfigured (built-in default).
+  const hasUnconfigured = [...usedTiers].some(t => !configuredTiers[t] && !userTiers[t]);
+  if (!hasUnconfigured) return;
+
+  // One-time per Archon version (a version bump may ship new tier defaults).
+  const version = BUNDLED_VERSION ?? 'dev';
+  if (readTierNoticeState()?.shownForVersion === version) return;
+
+  // Build the resolved profile for the effective default assistant.
+  const effectiveAssistant = userDefaultProvider ?? config.assistant;
+  let aliases: ReturnType<typeof buildAiProfile>['aliases'];
+  try {
+    aliases = buildAiProfile(effectiveAssistant, {
+      globalTiers: configuredTiers,
+      userTiers,
+    }).aliases;
+  } catch {
+    return;
+  }
+
+  const lines: string[] = [
+    "ℹ️  This workflow uses model tiers (small/medium/large). You haven't configured them —",
+    `   using built-in defaults for '${effectiveAssistant}':`,
+  ];
+  for (const t of TIER_NAMES) {
+    const preset = aliases[t];
+    if (preset) lines.push(`     ${t.padEnd(7)} → ${preset.provider}/${preset.model}`);
+  }
+  // Plan-dependent 1M note for the large→opus row (the CLI can't detect the plan).
+  const largePreset = aliases.large;
+  if (largePreset?.provider === 'claude' && largePreset.model === 'opus') {
+    lines.push(
+      '   (Opus runs a 1M context window on API keys and Max/Team/Enterprise;',
+      "    on Pro it's 200K unless you set the `large` tier to `opus[1m]`.)"
+    );
+  }
+  lines.push(
+    '   Customize: `archon ai tier set <tier> <provider> <model>`',
+    '              or `tiers:` in .archon/config.yaml',
+    '   See anytime: `archon ai tier list`           (shown once per version)',
+    ''
+  );
+  process.stderr.write(lines.join('\n') + '\n');
+
+  markTierNoticeShown(version);
+}
+
 /** Render a workflow event to stderr as a progress line. Called only when --quiet is not set. */
 function renderWorkflowEvent(event: WorkflowEmitterEvent, verbose: boolean): void {
   switch (event.type) {
-    case 'node_started':
-      process.stderr.write(`[${event.nodeName}] Started\n`);
+    case 'node_started': {
+      const suffix =
+        event.provider !== undefined && event.model !== undefined
+          ? event.tier !== undefined
+            ? `  (${event.provider}/${event.model} ← ${event.tier})`
+            : `  (${event.provider}/${event.model})`
+          : '';
+      process.stderr.write(`[${event.nodeName}] Started${suffix}\n`);
       break;
+    }
     case 'node_completed':
       process.stderr.write(`[${event.nodeName}] Completed (${formatDuration(event.duration)})\n`);
       break;
@@ -928,6 +1041,9 @@ export async function workflowRunCommand(
   process.once('SIGINT', () => {
     cleanup('SIGINT');
   });
+
+  // One-time-per-version notice when the workflow uses unconfigured tier keywords.
+  await maybePrintTierNotice(workflow, workingCwd, cliUserId, options.quiet);
 
   // Subscribe to workflow events for progress rendering on stderr.
   // subscribeForConversation is pure in-memory registration — cannot throw in practice.

--- a/packages/docs-web/src/content/docs/reference/archon-directories.md
+++ b/packages/docs-web/src/content/docs/reference/archon-directories.md
@@ -33,6 +33,7 @@ Archon provides a unified directory and configuration system with:
 ├── worktrees/                # Legacy global worktrees (for repos not in workspaces/)
 ├── web-dist/<version>/       # Cached web UI dist (archon serve, binary only)
 ├── update-check.json         # Update check cache (binary builds only, 24h TTL)
+├── tier-notice.json          # One-time tier-default notice state (CLI, per version)
 └── config.yaml               # Global user configuration
 ```
 

--- a/packages/paths/src/index.ts
+++ b/packages/paths/src/index.ts
@@ -54,6 +54,10 @@ export {
 } from './update-check';
 export type { UpdateCheckResult } from './update-check';
 
+// Tier notice (one-time CLI notice for unconfigured tier-keyword workflows)
+export { readTierNoticeState, markTierNoticeShown } from './tier-notice';
+export type { TierNoticeState } from './tier-notice';
+
 // Anonymous telemetry
 export {
   captureWorkflowInvoked,

--- a/packages/paths/src/tier-notice.test.ts
+++ b/packages/paths/src/tier-notice.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { join } from 'path';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { readTierNoticeState, markTierNoticeShown } from './tier-notice';
+
+// Drive the real `getArchonHome()` via ARCHON_HOME (same approach as
+// update-check.test.ts) — no mock.module, so no cross-file pollution.
+describe('tier-notice state cache', () => {
+  const testDir = join(tmpdir(), `archon-tier-notice-test-${Date.now()}`);
+  let originalArchonHome: string | undefined;
+
+  beforeEach(() => {
+    originalArchonHome = process.env.ARCHON_HOME;
+    process.env.ARCHON_HOME = testDir;
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (originalArchonHome !== undefined) {
+      process.env.ARCHON_HOME = originalArchonHome;
+    } else {
+      delete process.env.ARCHON_HOME;
+    }
+    try {
+      rmSync(testDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  test('returns null when no state file exists', () => {
+    expect(readTierNoticeState()).toBeNull();
+  });
+
+  test('persists and reads back the shown version', () => {
+    markTierNoticeShown('1.2.3');
+    expect(readTierNoticeState()?.shownForVersion).toBe('1.2.3');
+  });
+
+  test('re-records when the version changes', () => {
+    markTierNoticeShown('1.2.3');
+    expect(readTierNoticeState()?.shownForVersion).toBe('1.2.3');
+    markTierNoticeShown('1.2.4');
+    expect(readTierNoticeState()?.shownForVersion).toBe('1.2.4');
+  });
+
+  test('returns null for a corrupt state file (missing shownForVersion)', () => {
+    writeFileSync(join(testDir, 'tier-notice.json'), JSON.stringify({ foo: 'bar' }), 'utf-8');
+    expect(readTierNoticeState()).toBeNull();
+  });
+
+  test('returns null for non-JSON content', () => {
+    writeFileSync(join(testDir, 'tier-notice.json'), 'not json at all', 'utf-8');
+    expect(readTierNoticeState()).toBeNull();
+  });
+});

--- a/packages/paths/src/tier-notice.ts
+++ b/packages/paths/src/tier-notice.ts
@@ -25,14 +25,15 @@ function getStatePath(): string {
   return join(getArchonHome(), STATE_FILE);
 }
 
-/** Read the persisted notice state. Returns null when absent or unreadable. */
+/** Read the persisted notice state. Returns null when absent or unreadable (errors silently discarded). */
 export function readTierNoticeState(): TierNoticeState | null {
   try {
     const raw = readFileSync(getStatePath(), 'utf-8');
     const data = JSON.parse(raw) as TierNoticeState;
     if (typeof data.shownForVersion !== 'string') return null;
     return data;
-  } catch {
+  } catch (err) {
+    log.debug({ err }, 'tier_notice.read_failed');
     return null;
   }
 }

--- a/packages/paths/src/tier-notice.ts
+++ b/packages/paths/src/tier-notice.ts
@@ -1,0 +1,48 @@
+/**
+ * One-time CLI tier-notice state cache.
+ *
+ * Mirrors the structure of `update-check.ts`, but with NO time-based staleness:
+ * the notice re-shows only when the Archon `version` changes (a future version
+ * may ship different `tier-defaults.json` values, so a version bump re-alerts).
+ *
+ * No side effects beyond a single JSON file under `~/.archon`. Read/write errors
+ * are swallowed — a missing or corrupt state file simply means "show the notice".
+ */
+import { join } from 'path';
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { getArchonHome } from './archon-paths';
+import { createLogger } from './logger';
+
+const log = createLogger('tier-notice');
+
+export interface TierNoticeState {
+  shownForVersion: string;
+}
+
+const STATE_FILE = 'tier-notice.json';
+
+function getStatePath(): string {
+  return join(getArchonHome(), STATE_FILE);
+}
+
+/** Read the persisted notice state. Returns null when absent or unreadable. */
+export function readTierNoticeState(): TierNoticeState | null {
+  try {
+    const raw = readFileSync(getStatePath(), 'utf-8');
+    const data = JSON.parse(raw) as TierNoticeState;
+    if (typeof data.shownForVersion !== 'string') return null;
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+/** Record that the tier notice has been shown for `version`. Errors are logged at debug. */
+export function markTierNoticeShown(version: string): void {
+  try {
+    mkdirSync(getArchonHome(), { recursive: true });
+    writeFileSync(getStatePath(), JSON.stringify({ shownForVersion: version }), 'utf-8');
+  } catch (err) {
+    log.debug({ err }, 'tier_notice.write_failed');
+  }
+}

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -1258,6 +1258,14 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     expect(optionsArg.model).toBe('opus');
     const nodeConfig = optionsArg.nodeConfig as Record<string, unknown>;
     expect(nodeConfig.effort).toBe('max');
+
+    // Verify that the node_started event carries the resolved tier and model.
+    const createEventCalls = (mockDeps.store.createWorkflowEvent as ReturnType<typeof mock>).mock
+      .calls as Array<[{ event_type: string; data?: Record<string, unknown> }]>;
+    const nodeStartedCall = createEventCalls.find(([arg]) => arg.event_type === 'node_started');
+    expect(nodeStartedCall).toBeDefined();
+    expect(nodeStartedCall?.[0].data?.tier).toBe('large');
+    expect(nodeStartedCall?.[0].data?.model).toBe('opus');
   });
 
   it('passes literal node model through unchanged', async () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -1268,6 +1268,48 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     expect(nodeStartedCall?.[0].data?.model).toBe('opus');
   });
 
+  it('surfaces the workflow-level tier on nodes that inherit the workflow model', async () => {
+    // Regression guard for #2036: the bundled default workflows set the tier at
+    // the WORKFLOW level (e.g. `model: medium`), and their nodes have no own
+    // `model`. The node_started event must still carry the inherited tier.
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+    const aiProfile = buildAiProfile('claude');
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-dag',
+      testDir,
+      {
+        name: 'workflow-level-tier-test',
+        model: 'medium',
+        nodes: [{ id: 'step1', command: 'my-cmd' }],
+      },
+      workflowRun,
+      'claude',
+      'sonnet', // executor resolves the workflow-level `medium` -> `sonnet`
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      aiProfile
+    );
+
+    const createEventCalls = (mockDeps.store.createWorkflowEvent as ReturnType<typeof mock>).mock
+      .calls as Array<[{ event_type: string; data?: Record<string, unknown> }]>;
+    const nodeStartedCall = createEventCalls.find(([arg]) => arg.event_type === 'node_started');
+    expect(nodeStartedCall).toBeDefined();
+    expect(nodeStartedCall?.[0].data?.tier).toBe('medium');
+    expect(nodeStartedCall?.[0].data?.model).toBe('sonnet');
+  });
+
   it('passes literal node model through unchanged', async () => {
     const mockDeps = createMockDeps();
     const platform = createMockPlatform();

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -91,6 +91,7 @@ import {
   routePresetEffort,
   type ModelAliasPreset,
   type ResolvedAiProfile,
+  type TierName,
 } from './model-validation';
 
 /**
@@ -472,7 +473,7 @@ async function resolveNodeProviderAndModel(
   provider: string;
   model: string | undefined;
   options: SendQueryOptions | undefined;
-  tier?: 'small' | 'medium' | 'large';
+  tier?: TierName;
 }> {
   const configuredProvider: string = node.provider ?? workflowProvider;
   let provider: string = configuredProvider;
@@ -762,7 +763,7 @@ async function executeNodeInternal(
   configuredCommandFolder?: string,
   issueContext?: string,
   resolvedModel?: string,
-  resolvedTier?: 'small' | 'medium' | 'large'
+  resolvedTier?: TierName
 ): Promise<NodeExecutionResult> {
   const nodeStartTime = Date.now();
   const nodeContext: SendMessageContext = { workflowId: workflowRun.id, nodeName: node.id };

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -275,6 +275,9 @@ interface WorkflowLevelOptions {
   fallbackModel?: string;
   betas?: string[];
   sandbox?: SandboxSettings;
+  /** Workflow-level tier keyword (when `workflow.model` is small/medium/large), so
+   *  nodes that inherit the workflow model can still surface the `← tier` annotation. */
+  workflowTier?: 'small' | 'medium' | 'large';
 }
 
 /** Internal node execution result — extends NodeOutput with cost data for aggregation. */
@@ -649,9 +652,15 @@ async function resolveNodeProviderAndModel(
   };
 
   // `node.model` is the original ref (e.g. "large"); `model` is the resolved
-  // string (e.g. "opus"). Only surface `tier` when the ref was a tier keyword.
+  // string (e.g. "opus"). Surface `tier` when the ref was a tier keyword — from
+  // the node's own `model`, or (when the node inherits the workflow-level model)
+  // from the workflow tier, mirroring the effectivePreset inheritance condition.
   const tier: 'small' | 'medium' | 'large' | undefined =
-    node.model && isTierName(node.model) ? node.model : undefined;
+    node.model && isTierName(node.model)
+      ? node.model
+      : !node.model && provider === workflowProvider
+        ? workflowLevelOptions.workflowTier
+        : undefined;
 
   return { provider, model, options, tier };
 }
@@ -3049,6 +3058,9 @@ export async function executeDagWorkflow(
     nodes: readonly DagNode[];
     /** Workflow-level default for per-node `persist_session` (read directly here). */
     persist_sessions?: boolean;
+    /** Raw workflow-level `model` ref — used only to derive the workflow tier
+     *  keyword for node_started attribution (resolution uses `workflowModel`). */
+    model?: string;
   } & WorkflowLevelOptions,
   workflowRun: WorkflowRun,
   workflowProvider: string,
@@ -3067,12 +3079,14 @@ export async function executeDagWorkflow(
   workflowPreset?: ModelAliasPreset
 ): Promise<string | undefined> {
   const dagStartTime = Date.now();
+  const workflowTier = workflow.model && isTierName(workflow.model) ? workflow.model : undefined;
   const workflowLevelOptions = {
     effort: workflow.effort,
     thinking: workflow.thinking,
     fallbackModel: workflow.fallbackModel,
     betas: workflow.betas,
     sandbox: workflow.sandbox,
+    workflowTier,
   };
   const layers = buildTopologicalLayers(workflow.nodes);
   const nodeOutputs = new Map<string, NodeOutput>();

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -86,6 +86,7 @@ import {
 } from './executor-shared';
 import {
   isLiteralSpec,
+  isTierName,
   resolveModelSpec,
   routePresetEffort,
   type ModelAliasPreset,
@@ -471,6 +472,7 @@ async function resolveNodeProviderAndModel(
   provider: string;
   model: string | undefined;
   options: SendQueryOptions | undefined;
+  tier?: 'small' | 'medium' | 'large';
 }> {
   const configuredProvider: string = node.provider ?? workflowProvider;
   let provider: string = configuredProvider;
@@ -645,7 +647,12 @@ async function resolveNodeProviderAndModel(
     assistantConfig,
   };
 
-  return { provider, model, options };
+  // `node.model` is the original ref (e.g. "large"); `model` is the resolved
+  // string (e.g. "opus"). Only surface `tier` when the ref was a tier keyword.
+  const tier: 'small' | 'medium' | 'large' | undefined =
+    node.model && isTierName(node.model) ? node.model : undefined;
+
+  return { provider, model, options, tier };
 }
 
 /** Evaluate trigger rule for a node given its upstream states */
@@ -753,7 +760,9 @@ async function executeNodeInternal(
   nodeOutputs: Map<string, NodeOutput>,
   resumeSessionId: string | undefined,
   configuredCommandFolder?: string,
-  issueContext?: string
+  issueContext?: string,
+  resolvedModel?: string,
+  resolvedTier?: 'small' | 'medium' | 'large'
 ): Promise<NodeExecutionResult> {
   const nodeStartTime = Date.now();
   const nodeContext: SendMessageContext = { workflowId: workflowRun.id, nodeName: node.id };
@@ -768,7 +777,7 @@ async function executeNodeInternal(
       workflow_run_id: workflowRun.id,
       event_type: 'node_started',
       step_name: node.id,
-      data: { command: node.command ?? null, provider },
+      data: { command: node.command ?? null, provider, model: resolvedModel, tier: resolvedTier },
     })
     .catch((err: Error) => {
       getLog().error(
@@ -783,6 +792,9 @@ async function executeNodeInternal(
     runId: workflowRun.id,
     nodeId: node.id,
     nodeName: node.command ?? node.id,
+    provider,
+    model: resolvedModel,
+    tier: resolvedTier,
   });
 
   // Load prompt
@@ -2931,7 +2943,12 @@ async function executeApprovalNode(
       ...(node.idle_timeout ? { idle_timeout: node.idle_timeout } : {}),
     };
 
-    const { provider, options: nodeOptions } = await resolveNodeProviderAndModel(
+    const {
+      provider,
+      model: resolvedNodeModel,
+      options: nodeOptions,
+      tier: resolvedTier,
+    } = await resolveNodeProviderAndModel(
       syntheticNode,
       workflowProvider,
       workflowModel,
@@ -2961,7 +2978,9 @@ async function executeApprovalNode(
       nodeOutputs,
       undefined, // fresh session
       configuredCommandFolder,
-      issueContext
+      issueContext,
+      resolvedNodeModel,
+      resolvedTier
     );
 
     if (output.state === 'failed') {
@@ -3435,7 +3454,12 @@ export async function executeDagWorkflow(
           }
 
           // 4. Resolve per-node provider/model/options
-          const { provider, options: nodeOptions } = await resolveNodeProviderAndModel(
+          const {
+            provider,
+            model: resolvedNodeModel,
+            options: nodeOptions,
+            tier: resolvedTier,
+          } = await resolveNodeProviderAndModel(
             node,
             workflowProvider,
             workflowModel,
@@ -3562,7 +3586,9 @@ export async function executeDagWorkflow(
               // ensures the source is never mutated, so retries can safely resume from it.
               resumeSessionId,
               configuredCommandFolder,
-              issueContext
+              issueContext,
+              resolvedNodeModel,
+              resolvedTier
             );
 
             if (output.state !== 'failed') break;

--- a/packages/workflows/src/event-emitter.test.ts
+++ b/packages/workflows/src/event-emitter.test.ts
@@ -659,4 +659,65 @@ describe('WorkflowEventEmitter', () => {
       expect(targetEvents[0]).toMatchObject({ runId: 'run-target' });
     });
   });
+
+  // -------------------------------------------------------------------------
+  // NodeStartedEvent optional model fields (provider/model/tier)
+  // -------------------------------------------------------------------------
+
+  describe('NodeStartedEvent — optional model fields', () => {
+    it('passes through an event with no provider/model/tier (bash/script-like)', () => {
+      const emitter = getWorkflowEventEmitter();
+      const received: WorkflowEmitterEvent[] = [];
+      emitter.subscribe(e => received.push(e));
+
+      emitter.emit({ type: 'node_started', runId: 'run-1', nodeId: 'build', nodeName: 'build' });
+
+      const evt = received[0] as Extract<WorkflowEmitterEvent, { type: 'node_started' }>;
+      expect(evt).toMatchObject({ type: 'node_started', nodeId: 'build' });
+      expect(evt.provider).toBeUndefined();
+      expect(evt.model).toBeUndefined();
+      expect(evt.tier).toBeUndefined();
+    });
+
+    it('passes through provider/model/tier for tier-resolved AI nodes', () => {
+      const emitter = getWorkflowEventEmitter();
+      const received: WorkflowEmitterEvent[] = [];
+      emitter.subscribe(e => received.push(e));
+
+      emitter.emit({
+        type: 'node_started',
+        runId: 'run-2',
+        nodeId: 'implement',
+        nodeName: 'implement',
+        provider: 'claude',
+        model: 'opus',
+        tier: 'large',
+      });
+
+      const evt = received[0] as Extract<WorkflowEmitterEvent, { type: 'node_started' }>;
+      expect(evt.provider).toBe('claude');
+      expect(evt.model).toBe('opus');
+      expect(evt.tier).toBe('large');
+    });
+
+    it('passes through provider/model without tier for literal-model AI nodes', () => {
+      const emitter = getWorkflowEventEmitter();
+      const received: WorkflowEmitterEvent[] = [];
+      emitter.subscribe(e => received.push(e));
+
+      emitter.emit({
+        type: 'node_started',
+        runId: 'run-3',
+        nodeId: 'classify',
+        nodeName: 'classify',
+        provider: 'claude',
+        model: 'claude-haiku-4-5',
+      });
+
+      const evt = received[0] as Extract<WorkflowEmitterEvent, { type: 'node_started' }>;
+      expect(evt.provider).toBe('claude');
+      expect(evt.model).toBe('claude-haiku-4-5');
+      expect(evt.tier).toBeUndefined();
+    });
+  });
 });

--- a/packages/workflows/src/event-emitter.ts
+++ b/packages/workflows/src/event-emitter.ts
@@ -84,6 +84,9 @@ interface NodeStartedEvent {
   runId: string;
   nodeId: string;
   nodeName: string; // command name or node.id for inline prompts
+  provider?: string; // resolved AI provider (absent for bash/script nodes)
+  model?: string; // resolved model string (absent for bash/script nodes)
+  tier?: 'small' | 'medium' | 'large'; // only set when node.model was a tier keyword
 }
 
 interface NodeCompletedEvent {


### PR DESCRIPTION
## Summary

- **Problem**: After the tier-keyword rewrite, bundled workflows use `small`/`medium`/`large` instead of literal model strings, but the CLI's `node_started` progress line only showed `[implement] Started` — no signal about which model actually runs. Unconfigured users got zero hint that tiers exist or how to customize them.
- **Why it matters**: CLI users are silently running workflows on models they didn't choose and can't see, which is especially confusing after the opus[1m] removal from defaults.
- **What changed**: (A) `NodeStartedEvent` now carries `provider`/`model`/`tier`, threaded from `resolveNodeProviderAndModel` through `executeNodeInternal` to the emitter + persisted event data. The CLI renders `[implement] Started  (claude/opus ← large)`. (B) A one-time-per-version tier notice prints to stderr on the first CLI run that hits unconfigured tier-keyword nodes, explaining defaults and how to configure them.
- **What did NOT change**: Model resolution is untouched — this is observability only. Web console UI wiring, loop-node model surfacing, and the `opus[1m]` default decision are out of scope.

## UX Journey

### Before

```
  $ archon workflow run archon-fix-github-issue "fix #123"
  [extract-issue-number] Started
  [classify] Started
  [implement] Started          ← YAML says "large". No signal what model runs.
  [implement] Completed (4m2s)
```

### After

```
  $ archon workflow run archon-fix-github-issue "fix #123"

  ℹ️  This workflow uses model tiers (small/medium/large). You haven't configured them —
     using built-in defaults for 'claude':
       small   → claude/haiku
       medium  → claude/sonnet
       large   → claude/opus
     (Opus runs a 1M context window on API keys and Max/Team/Enterprise;
      on Pro it's 200K unless you set the `large` tier to `opus[1m]`.)
     Customize: `archon ai tier set <tier> <provider> <model>`
                or `tiers:` in .archon/config.yaml
     See anytime: `archon ai tier list`           (shown once per version)

  [extract-issue-number] Started  (claude/haiku ← small)
  [classify] Started  (claude/sonnet ← medium)
  [implement] Started  (claude/opus ← large)
  [implement] Completed (4m2s)
```

## Architecture Diagram

### Before

```
  dag-executor.ts
    resolveNodeProviderAndModel() → { provider, model, options }
    executeNodeInternal()
      emitter.emit({ type: 'node_started', runId, nodeId, nodeName })

  CLI workflow.ts
    renderWorkflowEvent()
      node_started → "[nodeName] Started\n"
```

### After

```
  dag-executor.ts
    resolveNodeProviderAndModel() → { provider, model, options, tier }  [~]
    executeNodeInternal(... resolvedModel?, resolvedTier?)              [~]
      emitter.emit({ ..., provider, model: resolvedModel, tier })       [~]

  event-emitter.ts
    NodeStartedEvent + provider?, model?, tier?                         [~]

  paths/tier-notice.ts (new)                                            [+]
    readTierNoticeState() / markTierNoticeShown()

  paths/index.ts → exports tier-notice helpers                          [~]

  CLI workflow.ts
    renderWorkflowEvent() → "[nodeName] Started  (claude/opus ← large)" [~]
    maybePrintTierNotice() — one-time stderr notice                     [+]
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `dag-executor` | `event-emitter` | **modified** | NodeStartedEvent now carries provider/model/tier |
| `dag-executor` | `model-validation` | unchanged | isTierName already imported |
| `cli/workflow` | `@archon/paths` | **modified** | imports readTierNoticeState, markTierNoticeShown |
| `cli/workflow` | `@archon/workflows/model-validation` | **new** | isTierName, buildAiProfile, TIER_NAMES |
| `paths/tier-notice` | `paths/archon-paths` | **new** | getArchonHome |
| `paths/tier-notice` | `paths/logger` | **new** | createLogger |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `workflows`, `cli`, `paths`
- Module: `workflows:event-emitter`, `workflows:dag-executor`, `cli:workflow`, `paths:tier-notice`

## Change Metadata

- Change type: `feature`
- Primary scope: `multi`

## Linked Issue

- Closes #2036

## Validation Evidence (required)

```bash
bun run validate
```

All eight checks passed:
- `check:bundled` / `check:bundled-skill` / `check:bundled-schema` / `check:pi-vendor-map` ✅
- `bun run type-check` — 0 errors across all 10 packages ✅
- `bun run lint` — 0 errors, 0 warnings ✅
- `bun run format:check` — all files formatted ✅
- `bun run test` — 0 failures ✅

Targeted test runs:
- `event-emitter.test.ts` — 35 pass (incl. 3 new field-passthrough tests)
- `tier-notice.test.ts` — 5 pass (new file)
- `workflow.test.ts` (CLI) — 137 pass (incl. 3 new render-suffix tests)
- `dag-executor.test.ts` — 286 pass

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No — `tier-notice.json` written to `~/.archon/` which is already Archon's home directory

## Compatibility / Migration

- Backward compatible? Yes — all new `NodeStartedEvent` fields are optional; existing consumers that don't read them are unaffected
- Config/env changes? No
- Database migration needed? No — the persisted `workflow_events.data` JSON now optionally carries `model`/`tier` fields; this is additive and existing rows are unaffected

## Human Verification (required)

- Verified scenarios: type-check, lint, format, full test suite all pass via `bun run validate`
- Edge cases checked: bash/script nodes emit no suffix (no provider/model set); `--quiet` suppresses both the per-node suffix and the tier notice; notice only shows once per version (state written to `~/.archon/tier-notice.json`)
- What was not verified: live CLI run against a real workflow (observability-only change; functional behavior is unchanged)

## Side Effects / Blast Radius (required)

- Affected subsystems: CLI progress output (additive suffix), SSE event feed (web console now receives provider/model/tier on `node_started` for free — no UI wiring yet)
- Potential unintended effects: None — model resolution is untouched; the tier notice is stderr-only and suppressed under `--quiet`
- Guardrails: `bun run validate` is the gate; no runtime behavior is changed

## Rollback Plan (required)

- Fast rollback: revert the commit (`git revert ac67733d`)
- Feature flags: none needed — the notice is a one-time stderr print; removing it is the rollback
- Observable failure symptoms: type errors on `NodeStartedEvent.provider/model/tier` if a consumer breaks

## Risks and Mitigations

- Risk: `loadConfig` is called twice per `workflow run` (once in title generation, once in `maybePrintTierNotice`)
  - Mitigation: `loadConfig` is a lightweight config-file parse (no network), so the overhead is negligible
- Risk: Loop-node `node_started` events don't carry model info (separate emit path)
  - Mitigation: Out of scope for this PR as documented; follow-up issue to be filed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a one-time notice for workflows that use tier-based model names, helping users see when defaults may need attention.
  * Workflow progress output now shows more detail, including provider/model information and tier when available.

* **Bug Fixes**
  * Workflow event reporting now preserves model and tier information more consistently across runs.

* **Documentation**
  * Updated CLI and directory documentation to include the new saved notice state used by the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->