### PR TITLE
chore(cli): drop stale CLAUDECODE=1 nested-session warning

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -20,9 +20,6 @@ import { parseArgs } from 'util';
 import { resolve } from 'path';
 import { existsSync } from 'fs';
 
-// CLAUDECODE=1 warning is emitted inside stripCwdEnv() (boot import above)
-// BEFORE the marker is deleted from process.env. No duplicate warning here.
-
 // Smart defaults for Claude auth
 // If no explicit tokens, default to global auth from `claude /login`
 if (!process.env.CLAUDE_API_KEY && !process.env.CLAUDE_CODE_OAUTH_TOKEN) {

--- a/packages/docs-web/src/content/docs/reference/configuration.md
+++ b/packages/docs-web/src/content/docs/reference/configuration.md
@@ -284,7 +284,6 @@ Environment variables override all other configuration. They are organized by ca
 | `DEFAULT_AI_ASSISTANT` | Fallback AI assistant when no config file sets the assistant. Overridden by `defaultAssistant` in global config or `assistant` in repo config. Must match a registered provider id — currently `claude`, `codex`, `pi`, or `copilot`. | `claude` |
 | `MAX_CONCURRENT_CONVERSATIONS` | Maximum concurrent AI conversations | `10` |
 | `SESSION_RETENTION_DAYS` | Delete inactive sessions older than N days | `30` |
-| `ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING` | When set to `1`, suppresses the stderr warning emitted when `archon` is run inside a Claude Code session | -- |
 | `ARCHON_VERBOSE_BOOT` | When set to `1`, prints `[archon] loaded N keys from …` lines to stderr at boot. Also enabled by `LOG_LEVEL=debug` or `LOG_LEVEL=trace`. Silent by default to avoid interleaving with interactive command output. | -- |
 
 ### AI Providers -- Claude

--- a/packages/docs-web/src/content/docs/reference/troubleshooting.md
+++ b/packages/docs-web/src/content/docs/reference/troubleshooting.md
@@ -315,25 +315,19 @@ assistants:
 
 See the [AI Assistants → Binary path configuration](/getting-started/ai-assistants/#binary-path-configuration-compiled-binaries-only) guide for the full install matrix.
 
-## Workflows Hang Silently When Run Inside Claude Code
+## Workflows Time Out Waiting for the First Event
 
-**Symptom:** Workflows started from within a Claude Code session (e.g., via the Terminal tool) produce no output, or the CLI emits a warning about `CLAUDECODE=1` before the workflow hangs.
+**Symptom:** A workflow node produces no output and eventually fails on a first-event timeout.
 
-**Cause:** Nested Claude Code sessions can deadlock — the outer session waits for tool results that the inner session never delivers.
+**Cause:** A slow environment (cold model, constrained machine) can exceed the default 60-second wait for the AI provider's first event.
 
-**Fix:** Run `archon serve` from a regular shell outside Claude Code and use the Web UI or HTTP API instead.
-
-**Suppress the warning:** If you have a non-deadlocking setup and want to silence the warning:
-
-```bash
-ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING=1 archon workflow run ...
-```
-
-**Adjust the timeout:** If your environment is slow and hitting the 60-second first-event timeout:
+**Fix:** Raise the timeout:
 
 ```bash
 ARCHON_CLAUDE_FIRST_EVENT_TIMEOUT_MS=120000 archon workflow run ...
 ```
+
+> Running `archon` from inside a Claude Code session (or another coding agent) is a supported, normal way to drive Archon — it no longer emits a warning.
 
 ## Worktree Belongs to a Different Clone
 

--- a/packages/paths/src/strip-cwd-env.ts
+++ b/packages/paths/src/strip-cwd-env.ts
@@ -84,16 +84,6 @@ export function stripCwdEnv(cwd: string = process.cwd()): void {
   // --- Pass 2: Nested Claude Code session markers ---
   // Pattern-matched (not hardcoded) so new CLAUDE_CODE_* markers added by
   // future Claude Code versions are automatically handled.
-  // Emit warning BEFORE deleting — downstream code won't see CLAUDECODE=1.
-  if (process.env.CLAUDECODE === '1' && !process.env.ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING) {
-    process.stderr.write(
-      '\u26a0  Detected CLAUDECODE=1 \u2014 running inside a Claude Code session.\n' +
-        '   If workflows hang silently, this is a known class of issue.\n' +
-        '   Workaround: run `archon serve` from a regular shell.\n' +
-        '   Suppress: set ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING=1\n' +
-        '   Details: https://github.com/coleam00/Archon/issues/1067\n'
-    );
-  }
   if (process.env.CLAUDECODE) {
     Reflect.deleteProperty(process.env, 'CLAUDECODE');
   }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -41,9 +41,6 @@ if (envPath) {
 import { loadArchonEnv } from '@archon/paths/env-loader';
 loadArchonEnv(process.cwd());
 
-// CLAUDECODE=1 warning is emitted inside stripCwdEnv() (boot import above)
-// BEFORE the marker is deleted from process.env. No duplicate warning here.
-
 // Smart default: fall back to Claude Code's built-in OAuth (`claude /login`)
 // ONLY for solo installs with no explicit credentials. Per-user installs
 // (TOKEN_ENCRYPTION_KEY) deliver Claude auth per-request, so the global-auth


### PR DESCRIPTION
## Summary

- **Problem:** `archon` printed a `CLAUDECODE=1` "running inside a Claude Code session… workflows may hang" warning on every nested run.
- **Why it matters:** running the Archon CLI inside Claude Code (or another coding agent) is now a normal, supported way to drive Archon — the silent-hang risk (#1067) is no longer live, so the warning is pure per-run noise.
- **What changed:** removed the warning emission and its docs/escape-hatch; kept the actual `CLAUDECODE`/`CLAUDE_CODE_*` env strip untouched.
- **What did NOT change (scope boundary):** the env-stripping behavior in `stripCwdEnv()` is unchanged; the genuine `FirstEventTimeoutError` in the Claude provider (which also links #1067 for its diagnostic dump) is left as-is.

## UX Journey

### Before

```
$ archon workflow run <wf> "..."
⚠  Detected CLAUDECODE=1 — running inside a Claude Code session.
   If workflows hang silently, this is a known class of issue.
   Workaround: run `archon serve` from a regular shell.
   Suppress: set ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING=1
   Details: https://github.com/coleam00/Archon/issues/1067
[... workflow runs normally ...]
```

### After

```
$ archon workflow run <wf> "..."
[... workflow runs normally — no nested-session warning ...]
[*] CLAUDECODE / CLAUDE_CODE_* env markers are still stripped from the subprocess env (unchanged).
```

## Architecture Diagram

### Before

```
boot → stripCwdEnv()  ──emits──▶ stderr "CLAUDECODE=1 warning" (gated by ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING)
                      ──strips──▶ CLAUDECODE + CLAUDE_CODE_* from process.env
```

### After

```
boot → stripCwdEnv()  [- warning emission removed]
                      ──strips──▶ CLAUDECODE + CLAUDE_CODE_* from process.env   [~ unchanged]
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `stripCwdEnv()` | stderr (nested-session warning) | **removed** | warning block deleted |
| `stripCwdEnv()` | `process.env` (CLAUDECODE/CLAUDE_CODE_* strip) | unchanged | load-bearing behavior kept |
| docs (configuration/troubleshooting) | `ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING` | **removed** | env var no longer exists |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `cli`, `paths`, `docs`
- Module: `paths:strip-cwd-env`

## Change Metadata

- Change type: `chore`
- Primary scope: `multi` (paths + cli + server + docs)

## Linked Issue

- Closes # — none (addresses the stale warning tracked informally under #1067; not auto-closing #1067 since the genuine first-event-timeout error still references it)
- Related # — #1067

## Validation Evidence (required)

```bash
bun run validate
```

- Evidence provided: `bun run validate` passes — all package type-checks exit 0, lint/format clean, generated-bundle checks pass, test suites `0 fail`. No test asserted the warning fired (only `CLAUDECODE`-strip tests, which remain green).
- Skipped commands: none.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No — the env strip that keeps target-repo/agent env out of Archon subprocesses is unchanged.
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes — `ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING` is removed. It only ever silenced the now-deleted warning, so it is a no-op to drop; any value set for it is simply ignored. Nothing to migrate.
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: `bun run validate` green; warning block removed while the `CLAUDECODE`/`CLAUDE_CODE_*` strip remains (confirmed by reading the surrounding code and the still-passing strip tests).
- Edge cases checked: diff limited to the 5 warning-related files; no behavior change beyond stopping the stderr emission.
- What was not verified: n/a (no behavioral path changed).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: CLI/server boot output only — the nested-session warning no longer prints.
- Potential unintended effects: none expected; the env-stripping safety behavior is untouched.
- Guardrails/monitoring for early detection: CI `validate`; the strip unit tests continue to assert `CLAUDECODE` is removed from `process.env`.

## Rollback Plan (required)

- Fast rollback command/path: revert this commit.
- Feature flags or config toggles: none.
- Observable failure symptoms: n/a (removal of a log line).

## Risks and Mitigations

- Risk: a user/script depended on the warning text or on `ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING`.
  - Mitigation: the var only suppressed a warning that no longer exists; setting it is harmlessly ignored. Single-commit revert if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the warning that appeared when running Archon inside a Claude Code session.
  * Improved handling of startup environment cleanup without affecting other behavior.

* **Documentation**
  * Updated troubleshooting guidance for slow environments and first-event timeouts.
  * Removed outdated references to the nested Claude Code warning from the configuration docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->