### PR TITLE
fix(workflows): restore interactive-loop cross-gate session continuity (reverts #1923)

### DIFF
--- a/packages/docs-web/src/content/docs/guides/loop-nodes.md
+++ b/packages/docs-web/src/content/docs/guides/loop-nodes.md
@@ -132,10 +132,7 @@ Controls session continuity between iterations:
 | `true` | Each iteration starts a fresh AI session. No memory of prior iterations. | Work state lives on disk (files, git). Prevents context window exhaustion on long loops. |
 | `false` (default) | Sessions thread — each iteration resumes the prior conversation. | Iterative refinement where the agent needs to remember what it tried before. |
 
-The first iteration is always fresh regardless of this setting. The first
-iteration executed after resuming from an interactive loop approval gate is
-also always fresh — the stored session id may have expired during the human
-review wait, and user feedback is carried via `$LOOP_USER_INPUT` instead.
+The first iteration is always fresh regardless of this setting.
 
 ### `until_bash`
 

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -4997,88 +4997,9 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // Verify the prompt contains the user input
       const promptArg = mockSendQueryDag.mock.calls[0][0] as string;
       expect(promptArg).toContain('Add error handling');
-      // Should use a fresh session on the first resumed iteration: the stored
-      // gate session may have expired during the human review wait, so we
-      // start fresh (user feedback is carried via $LOOP_USER_INPUT). See
-      // packages/workflows/src/dag-executor.ts needsFreshSession (#1208).
+      // Should have resumed with stored session ID
       const sessionArg = mockSendQueryDag.mock.calls[0][2] as string | undefined;
-      expect(sessionArg).toBeUndefined();
-    });
-
-    it('interactive loop resume does not crash with error_during_execution on iteration 2', async () => {
-      // Regression test for #1208: when resuming a paused interactive loop
-      // gate, the first resumed iteration must use a fresh session (not the
-      // potentially stale stored session id), so the SDK never receives an
-      // expired session id that would trigger error_during_execution.
-      mockSendQueryDag.mockImplementation(function* () {
-        yield {
-          type: 'assistant',
-          content: 'Updated plan with error handling. <promise>APPROVED</promise>',
-        };
-        yield { type: 'result', sessionId: 'fresh-session-1' };
-      });
-
-      const store = createMockStore();
-      const mockDeps = createMockDeps(store);
-      const platform = createMockPlatform();
-      // Simulate resumed run: metadata has loop gate state from iteration 1
-      // with a stale session id (the SDK would reject this if reused).
-      const workflowRun = makeWorkflowRun('resume-no-crash-id', {
-        metadata: {
-          approval: {
-            type: 'interactive_loop',
-            nodeId: 'refine',
-            iteration: 1,
-            sessionId: 'stale-session-from-hours-ago',
-            message: 'Review the plan.',
-          },
-          loop_user_input: 'Add error handling',
-        },
-      });
-
-      await executeDagWorkflow(
-        mockDeps,
-        platform,
-        'conv-dag',
-        testDir,
-        {
-          name: 'interactive-loop-no-crash',
-          nodes: [
-            {
-              id: 'refine',
-              loop: {
-                prompt: 'User said: $LOOP_USER_INPUT. Refine the plan.',
-                until: 'APPROVED',
-                max_iterations: 10,
-                interactive: true,
-                gate_message: 'Review the plan.',
-              },
-            },
-          ],
-        },
-        workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
-
-      // Exactly one iteration runs (it completes via APPROVED signal)
-      expect(mockSendQueryDag.mock.calls.length).toBe(1);
-      // Crucially: sessionArg must be undefined (fresh session), NOT the stale stored id.
-      const sessionArg = mockSendQueryDag.mock.calls[0][2] as string | undefined;
-      expect(sessionArg).toBeUndefined();
-
-      // No failure events were emitted (no loop_iteration_failed, no node_failed).
-      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
-      const failedEvents = eventCalls.filter((call: unknown[]) => {
-        const evt = (call[0] as Record<string, unknown>).event_type as string;
-        return evt === 'loop_iteration_failed' || evt === 'node_failed';
-      });
-      expect(failedEvents).toHaveLength(0);
+      expect(sessionArg).toBe('loop-session-1');
     });
 
     it('loop iteration fails loudly when SDK returns error_during_execution', async () => {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -2305,14 +2305,8 @@ async function executeLoopNode(
         logEventStoreError(err, i);
       });
 
-    // Session threading. Force a fresh session on the first iteration of an
-    // interactive loop resume: the stored session id from the gate metadata
-    // may be stale after a human review wait — passing it to the SDK can
-    // trigger errors (e.g. error_during_execution on Claude SDK).
-    // User feedback is carried via $LOOP_USER_INPUT, so session continuity is
-    // not required for the first resumed iteration.
-    const needsFreshSession =
-      loop.fresh_context || i === 1 || (isLoopResume && i === startIteration);
+    // Session threading
+    const needsFreshSession = loop.fresh_context || i === 1;
     const resumeSessionId = needsFreshSession ? undefined : currentSessionId;
 
     // Stream AI response for this iteration


### PR DESCRIPTION
## Summary

- **Problem:** #1923 forced a fresh Claude session on the first iteration after **every** interactive-loop approval gate, so the agent lost all memory of its prior turns across the gate (#2004). It broke the core use of interactive loops — a multi-turn conversation/interview/iterative-refinement steered by a human across gates.
- **What changed:** Reverts #1923 — removes the `(isLoopResume && i === startIteration)` term from `needsFreshSession` in `dag-executor.ts`, restoring `loop.fresh_context || i === 1`, so a resumed iteration re-threads the stored gate session id instead of forcing `undefined`. Restores the resume test assertion (`sessionArg === 'loop-session-1'`), drops #1923's regression test, and reverts the `loop-nodes.md` note.
- **Scope boundary:** #1291's fail-loud `isError` handling, `fresh_context: true` loops, non-interactive loops, and `persist_session` loops are untouched. Does **not** attempt to fix the original #1208 crash (separate work).

## Provenance

Takeover of #2005 by @ianstantiate (commit authorship preserved), rebased onto current `dev` and re-validated. Supersedes #2005. Thanks @ianstantiate.

## Validation Evidence

Rebased onto current `dev` (`dag-executor.ts` has changed since the original PR — verified the revert target `needsFreshSession` is intact and the change still correct):

```
bun --filter @archon/workflows type-check   # ✅ exit 0
bun test packages/workflows/src/dag-executor.test.ts   # ✅ 286 pass / 0 fail
```

The reverted `dag-executor.test.ts` passes alongside the resume/`resumed` tests added by #1842 (no interaction). Net diff: +5/−93 across 3 files.

## Security Impact

- New permissions/capabilities? No. New network calls? No. Secrets handling changed? No. FS scope changed? No.
- Behavior revert in the workflow loop executor; no security surface touched.

## Compatibility / Migration

- Backward compatible — restores behavior shipped in the latest tagged release; #1923's behavior was `dev`-only/unreleased. No config/env/DB changes.

## Side Effects / Blast Radius

- Affects `executeLoopNode` only — any `interactive: true` loop that resumes after a gate. Environments that genuinely hit the unconfirmed #1208 `error_during_execution` will again attempt a resume on the first post-gate iteration; with #1291 in place this now **fails loudly** with the real SDK `errors[]` rather than masking it.

## Rollback Plan

- Revert this PR's merge commit (+5/−93) to re-apply #1923's fresh-on-resume behavior. No flags/config. Stopgap for any affected loop: set `fresh_context: true`.

## Linked Issues

Closes #2004
Supersedes #2005
Related #1208, #1291, #1923


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resumed interactive loops now continue with the previous session on the first resumed iteration, instead of always starting a fresh one.
  * This helps preserve context across approvals and reduces unexpected resets during loop execution.

* **Documentation**
  * Simplified the loop guide to reflect the updated behavior for fresh context on the first iteration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->