### PR TITLE
fix(server): accept namespaced workflow names on HTTP launch and read routes

### DIFF
--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -79,7 +79,7 @@ import {
 } from '@archon/paths';
 import { discoverWorkflowsWithConfig } from '@archon/workflows/workflow-discovery';
 import { parseWorkflow } from '@archon/workflows/loader';
-import { isValidCommandName } from '@archon/workflows/command-validation';
+import { isValidCommandName, isValidWorkflowName } from '@archon/workflows/command-validation';
 import { BUNDLED_WORKFLOWS, BUNDLED_COMMANDS, isBinaryBuild } from '@archon/workflows/defaults';
 import {
   RESUMABLE_WORKFLOW_STATUSES,
@@ -2970,7 +2970,7 @@ export function registerApiRoutes(
   registerOpenApiRoute(runWorkflowRoute, async c => {
     const workflowName = c.req.param('name') ?? '';
     const userId = await resolveWebUserId(c);
-    if (!isValidCommandName(workflowName)) {
+    if (!isValidWorkflowName(workflowName)) {
       return apiError(c, 400, 'Invalid workflow name');
     }
 
@@ -3574,7 +3574,7 @@ export function registerApiRoutes(
   // GET /api/workflows/:name - Fetch a single workflow definition
   registerOpenApiRoute(getWorkflowRoute, async c => {
     const name = c.req.param('name') ?? '';
-    if (!isValidCommandName(name)) {
+    if (!isValidWorkflowName(name)) {
       return apiError(c, 400, 'Invalid workflow name');
     }
 

--- a/packages/server/src/routes/api.workflow-runs.test.ts
+++ b/packages/server/src/routes/api.workflow-runs.test.ts
@@ -400,6 +400,57 @@ describe('POST /api/workflows/:name/run', () => {
     );
   });
 
+  test('accepts a percent-encoded namespaced name and forwards the decoded name', async () => {
+    // The run route is the launchability path the namespaced-name fix targets,
+    // so exercise it the way the GET route is exercised: a one-subfolder-deep
+    // name (`triage/review`) must pass the real validator and reach the
+    // orchestrator decoded, not as the raw `triage%2Freview`.
+    const { isValidWorkflowName, isValidCommandName } =
+      await import('@archon/workflows/command-validation');
+    const segmentOk = (seg: string) =>
+      !!seg && !seg.startsWith('.') && !seg.includes('\\') && !seg.includes('..');
+    // Real namespaced logic: `triage/review` is valid (one subfolder deep).
+    (isValidWorkflowName as ReturnType<typeof mock>).mockImplementationOnce((name: string) => {
+      if (!name) return false;
+      const segments = name.split('/');
+      if (segments.length > 2) return false;
+      return segments.every(segmentOk);
+    });
+    // Strict command logic that rejects `/`, so this test goes red if the run
+    // route validates with isValidCommandName instead of isValidWorkflowName.
+    (isValidCommandName as ReturnType<typeof mock>).mockImplementationOnce(
+      (name: string) => segmentOk(name) && !name.includes('/')
+    );
+
+    mockFindConversationByPlatformId.mockImplementationOnce(async () => MOCK_CONV);
+    mockAddMessage.mockImplementationOnce(async () => ({
+      id: 'msg-1',
+      conversation_id: MOCK_CONV.id,
+      role: 'user' as const,
+      content: 'Run triage',
+      metadata: '{}',
+      created_at: NOW,
+    }));
+    mockHandleMessage.mockImplementationOnce(async () => {});
+
+    const { app } = makeApp();
+    const response = await app.request('/api/workflows/triage%2Freview/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ conversationId: 'web-test-abc', message: 'Run triage' }),
+    });
+    expect(response.status).toBe(200);
+
+    expect(mockHandleMessage).toHaveBeenCalledWith(
+      expect.anything(),
+      'web-test-abc',
+      '/workflow run triage/review Run triage',
+      expect.objectContaining({
+        isolationHints: { workflowType: 'thread', workflowId: 'web-test-abc' },
+      })
+    );
+  });
+
   test('persists user message to DB when conversation found', async () => {
     mockFindConversationByPlatformId.mockImplementationOnce(async () => MOCK_CONV);
     mockAddMessage.mockImplementationOnce(async () => ({

--- a/packages/server/src/routes/api.workflow-runs.test.ts
+++ b/packages/server/src/routes/api.workflow-runs.test.ts
@@ -494,9 +494,9 @@ describe('POST /api/workflows/:name/run', () => {
     expect([400, 404]).toContain(response.status);
   });
 
-  test('returns 400 when isValidCommandName rejects the name', async () => {
-    const { isValidCommandName } = await import('@archon/workflows/command-validation');
-    (isValidCommandName as ReturnType<typeof mock>).mockReturnValueOnce(false);
+  test('returns 400 when isValidWorkflowName rejects the name', async () => {
+    const { isValidWorkflowName } = await import('@archon/workflows/command-validation');
+    (isValidWorkflowName as ReturnType<typeof mock>).mockReturnValueOnce(false);
 
     const { app } = makeApp();
     const response = await app.request('/api/workflows/.hidden/run', {

--- a/packages/server/src/routes/api.workflow-runs.test.ts
+++ b/packages/server/src/routes/api.workflow-runs.test.ts
@@ -401,10 +401,7 @@ describe('POST /api/workflows/:name/run', () => {
   });
 
   test('accepts a percent-encoded namespaced name and forwards the decoded name', async () => {
-    // The run route is the launchability path the namespaced-name fix targets,
-    // so exercise it the way the GET route is exercised: a one-subfolder-deep
-    // name (`triage/review`) must pass the real validator and reach the
-    // orchestrator decoded, not as the raw `triage%2Freview`.
+    // Regression guard: percent-encoded '/' must be decoded and validate, not raw-route to 400.
     const { isValidWorkflowName, isValidCommandName } =
       await import('@archon/workflows/command-validation');
     const segmentOk = (seg: string) =>

--- a/packages/server/src/routes/api.workflows.test.ts
+++ b/packages/server/src/routes/api.workflows.test.ts
@@ -67,16 +67,23 @@ mock.module('@archon/workflows/workflow-discovery', () => ({
 mock.module('@archon/workflows/loader', () => ({
   parseWorkflow: mockParseWorkflow,
 }));
-mock.module('@archon/workflows/command-validation', () => ({
-  isValidCommandName: mock(
-    (name: string) =>
-      !name.includes('/') &&
-      !name.includes('\\') &&
-      !name.includes('..') &&
-      !!name &&
-      !name.startsWith('.')
-  ),
-}));
+mock.module('@archon/workflows/command-validation', () => {
+  const isValidCommandName = (name: string) =>
+    !name.includes('/') &&
+    !name.includes('\\') &&
+    !name.includes('..') &&
+    !!name &&
+    !name.startsWith('.');
+  return {
+    isValidCommandName: mock(isValidCommandName),
+    isValidWorkflowName: mock((name: string) => {
+      if (!name) return false;
+      const segments = name.split('/');
+      if (segments.length > 2) return false;
+      return segments.every(isValidCommandName);
+    }),
+  };
+});
 mock.module('@archon/workflows/defaults', () => ({
   BUNDLED_WORKFLOWS: {
     'archon-assist': 'name: archon-assist\ndescription: Archon Assist\nnodes: []',
@@ -347,6 +354,35 @@ describe('GET /api/workflows/:name', () => {
       };
       expect(body.source).toBe('project');
       expect(body.filename).toBe('phase-0-spike.yml');
+      expect(body.workflow).toBeDefined();
+    } finally {
+      await rm(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test('returns a namespaced workflow (one subfolder deep) via percent-encoded slash', async () => {
+    const testDir = join(tmpdir(), `wf-get-ns-test-${Date.now()}`);
+    const workflowDir = join(testDir, '.archon', 'workflows', 'triage');
+    await mkdir(workflowDir, { recursive: true });
+    await writeFile(
+      join(workflowDir, 'review.yaml'),
+      'name: review\ndescription: Triage review\nnodes:\n  - id: plan\n    command: plan\n'
+    );
+
+    try {
+      const app = createTestApp();
+      registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+      mockListCodebases.mockImplementationOnce(async () => [{ default_cwd: testDir }]);
+      const response = await app.request(`/api/workflows/triage%2Freview?cwd=${testDir}`);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        source: string;
+        filename: string;
+        workflow: { name: string };
+      };
+      expect(body.source).toBe('project');
+      expect(body.filename).toBe('triage/review.yaml');
       expect(body.workflow).toBeDefined();
     } finally {
       await rm(testDir, { recursive: true, force: true });

--- a/packages/server/src/test/workflow-mock-factories.ts
+++ b/packages/server/src/test/workflow-mock-factories.ts
@@ -43,9 +43,11 @@ export function makeLoaderMock(): {
  */
 export function makeCommandValidationMock(): {
   isValidCommandName: Mock<() => boolean>;
+  isValidWorkflowName: Mock<() => boolean>;
 } {
   return {
     isValidCommandName: mock(() => true),
+    isValidWorkflowName: mock(() => true),
   };
 }
 

--- a/packages/workflows/src/command-validation.test.ts
+++ b/packages/workflows/src/command-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { isValidCommandName } from './command-validation';
+import { isValidCommandName, isValidWorkflowName } from './command-validation';
 
 describe('isValidCommandName', () => {
   // ---------------------------------------------------------------------------
@@ -179,6 +179,93 @@ describe('isValidCommandName', () => {
 
     test('numeric-only name', () => {
       expect(isValidCommandName('123')).toBe(true);
+    });
+  });
+});
+
+describe('isValidWorkflowName', () => {
+  // Workflows may be namespaced one subfolder deep (MAX_DISCOVERY_DEPTH = 1),
+  // so a single '/' is allowed where isValidCommandName forbids it. Every other
+  // path-traversal protection carries over because each segment must itself be a
+  // valid command name.
+
+  describe('valid names', () => {
+    test('non-namespaced name', () => {
+      expect(isValidWorkflowName('build')).toBe(true);
+    });
+
+    test('single-level namespace', () => {
+      expect(isValidWorkflowName('triage/foo')).toBe(true);
+    });
+
+    test('namespace with hyphens in each segment', () => {
+      expect(isValidWorkflowName('code-review/pre-merge')).toBe(true);
+    });
+  });
+
+  describe('depth limit', () => {
+    test('two levels deep is rejected', () => {
+      expect(isValidWorkflowName('a/b/c')).toBe(false);
+    });
+
+    test('three levels deep is rejected', () => {
+      expect(isValidWorkflowName('a/b/c/d')).toBe(false);
+    });
+  });
+
+  describe('empty segments', () => {
+    test('leading slash', () => {
+      expect(isValidWorkflowName('/build')).toBe(false);
+    });
+
+    test('trailing slash', () => {
+      expect(isValidWorkflowName('triage/')).toBe(false);
+    });
+
+    test('double slash', () => {
+      expect(isValidWorkflowName('triage//foo')).toBe(false);
+    });
+
+    test('bare slash', () => {
+      expect(isValidWorkflowName('/')).toBe(false);
+    });
+  });
+
+  describe('path traversal still blocked', () => {
+    test('bare ".."', () => {
+      expect(isValidWorkflowName('..')).toBe(false);
+    });
+
+    test('".." as a segment', () => {
+      expect(isValidWorkflowName('triage/..')).toBe(false);
+    });
+
+    test('"../etc"', () => {
+      expect(isValidWorkflowName('../etc')).toBe(false);
+    });
+
+    test('backslash', () => {
+      expect(isValidWorkflowName('sub\\command')).toBe(false);
+    });
+
+    test('Windows absolute path', () => {
+      expect(isValidWorkflowName('C:\\Windows')).toBe(false);
+    });
+  });
+
+  describe('leading dot', () => {
+    test('hidden top-level name', () => {
+      expect(isValidWorkflowName('.hidden')).toBe(false);
+    });
+
+    test('hidden segment in namespace', () => {
+      expect(isValidWorkflowName('triage/.hidden')).toBe(false);
+    });
+  });
+
+  describe('empty input', () => {
+    test('empty string', () => {
+      expect(isValidWorkflowName('')).toBe(false);
     });
   });
 });

--- a/packages/workflows/src/command-validation.test.ts
+++ b/packages/workflows/src/command-validation.test.ts
@@ -184,10 +184,7 @@ describe('isValidCommandName', () => {
 });
 
 describe('isValidWorkflowName', () => {
-  // Workflows may be namespaced one subfolder deep (MAX_DISCOVERY_DEPTH = 1),
-  // so a single '/' is allowed where isValidCommandName forbids it. Every other
-  // path-traversal protection carries over because each segment must itself be a
-  // valid command name.
+  // Unlike isValidCommandName, allows one '/' (MAX_DISCOVERY_DEPTH = 1 namespacing).
 
   describe('valid names', () => {
     test('non-namespaced name', () => {

--- a/packages/workflows/src/command-validation.ts
+++ b/packages/workflows/src/command-validation.ts
@@ -15,12 +15,25 @@ export function isValidCommandName(name: string): boolean {
 }
 
 /**
+ * The maximum subfolder depth workflow discovery descends to. A value of 1
+ * means a workflow may be namespaced one folder deep (e.g. `triage/review`).
+ *
+ * This is the single source of truth shared with `workflow-discovery.ts` so the
+ * name validator below and the on-disk loader cannot drift: if discovery ever
+ * descends further, the validator stops rejecting names the loader can find. It
+ * lives in this dependency-free leaf module (see the file note above) so that
+ * the loader can import it without re-introducing the cycle this module breaks.
+ */
+export const MAX_DISCOVERY_DEPTH = 1;
+
+/**
  * Validates a workflow name. Unlike a bare command name, a workflow may be
- * namespaced one subfolder deep (e.g. `triage/review`): workflows are discovered
- * at most `MAX_DISCOVERY_DEPTH` (1) folders deep, so a single `/` is the only
- * nesting allowed. Each segment must itself be a valid command name, which keeps
- * the path-traversal protection intact (no `..`, no `\`, no leading dot, no
- * empty segment — so leading, trailing, and double slashes are all rejected).
+ * namespaced up to `MAX_DISCOVERY_DEPTH` subfolders deep (e.g. `triage/review`):
+ * workflows are discovered at most that many folders deep, so the number of
+ * `/`-separated segments is capped at `MAX_DISCOVERY_DEPTH + 1`. Each segment
+ * must itself be a valid command name, which keeps the path-traversal protection
+ * intact (no `..`, no `\`, no leading dot, no empty segment — so leading,
+ * trailing, and double slashes are all rejected).
  *
  * The HTTP launch and read routes resolve workflows by name the same way the CLI
  * does on disk; using this in place of `isValidCommandName` lets namespaced
@@ -31,8 +44,8 @@ export function isValidWorkflowName(name: string): boolean {
     return false;
   }
   const segments = name.split('/');
-  // At most one level of namespacing (matches MAX_DISCOVERY_DEPTH = 1).
-  if (segments.length > 2) {
+  // At most MAX_DISCOVERY_DEPTH levels of namespacing.
+  if (segments.length > MAX_DISCOVERY_DEPTH + 1) {
     return false;
   }
   // Every segment must be a valid, slash-free command name.

--- a/packages/workflows/src/command-validation.ts
+++ b/packages/workflows/src/command-validation.ts
@@ -13,3 +13,28 @@ export function isValidCommandName(name: string): boolean {
   }
   return true;
 }
+
+/**
+ * Validates a workflow name. Unlike a bare command name, a workflow may be
+ * namespaced one subfolder deep (e.g. `triage/review`): workflows are discovered
+ * at most `MAX_DISCOVERY_DEPTH` (1) folders deep, so a single `/` is the only
+ * nesting allowed. Each segment must itself be a valid command name, which keeps
+ * the path-traversal protection intact (no `..`, no `\`, no leading dot, no
+ * empty segment — so leading, trailing, and double slashes are all rejected).
+ *
+ * The HTTP launch and read routes resolve workflows by name the same way the CLI
+ * does on disk; using this in place of `isValidCommandName` lets namespaced
+ * workflows be launched and fetched over the API instead of only via the CLI.
+ */
+export function isValidWorkflowName(name: string): boolean {
+  if (!name) {
+    return false;
+  }
+  const segments = name.split('/');
+  // At most one level of namespacing (matches MAX_DISCOVERY_DEPTH = 1).
+  if (segments.length > 2) {
+    return false;
+  }
+  // Every segment must be a valid, slash-free command name.
+  return segments.every(isValidCommandName);
+}

--- a/packages/workflows/src/command-validation.ts
+++ b/packages/workflows/src/command-validation.ts
@@ -18,11 +18,7 @@ export function isValidCommandName(name: string): boolean {
  * The maximum subfolder depth workflow discovery descends to. A value of 1
  * means a workflow may be namespaced one folder deep (e.g. `triage/review`).
  *
- * This is the single source of truth shared with `workflow-discovery.ts` so the
- * name validator below and the on-disk loader cannot drift: if discovery ever
- * descends further, the validator stops rejecting names the loader can find. It
- * lives in this dependency-free leaf module (see the file note above) so that
- * the loader can import it without re-introducing the cycle this module breaks.
+ * Shared with workflow-discovery.ts so discovery depth and the name validator can't drift.
  */
 export const MAX_DISCOVERY_DEPTH = 1;
 
@@ -34,10 +30,6 @@ export const MAX_DISCOVERY_DEPTH = 1;
  * must itself be a valid command name, which keeps the path-traversal protection
  * intact (no `..`, no `\`, no leading dot, no empty segment — so leading,
  * trailing, and double slashes are all rejected).
- *
- * The HTTP launch and read routes resolve workflows by name the same way the CLI
- * does on disk; using this in place of `isValidCommandName` lets namespaced
- * workflows be launched and fetched over the API instead of only via the CLI.
  */
 export function isValidWorkflowName(name: string): boolean {
   if (!name) {

--- a/packages/workflows/src/workflow-discovery.ts
+++ b/packages/workflows/src/workflow-discovery.ts
@@ -28,7 +28,7 @@ import { isIncludeNode } from './schemas';
 import * as archonPaths from '@archon/paths';
 import { BUNDLED_WORKFLOWS, BUNDLED_COMMANDS, isBinaryBuild } from './defaults/bundled-defaults';
 import { createLogger } from '@archon/paths';
-import { isValidCommandName } from './command-validation';
+import { isValidCommandName, MAX_DISCOVERY_DEPTH } from './command-validation';
 import { parseWorkflow } from './loader';
 import { expandWorkflowIncludes } from './include-expander';
 
@@ -81,15 +81,12 @@ interface DirLoadResult {
   errors: WorkflowLoadError[];
 }
 
-/**
- * Maximum subfolder depth we descend into when discovering workflows/commands/scripts.
- *
- * `1` allows one level of grouping (e.g. `.archon/workflows/defaults/foo.yaml`);
- * `0` would mean only files at the root. We stop at 1 deliberately — deeper
- * nesting has never been part of the documented convention and adds no
- * organizational value, just routing ambiguity.
- */
-const MAX_DISCOVERY_DEPTH = 1;
+// `MAX_DISCOVERY_DEPTH` (= 1: one level of grouping, e.g.
+// `.archon/workflows/defaults/foo.yaml`) is imported from `command-validation`,
+// the dependency-free leaf module, so the loader here and the workflow-name
+// validator there share one source of truth and cannot drift apart. We stop at
+// one level deliberately — deeper nesting has never been part of the documented
+// convention and adds only routing ambiguity.
 
 /**
  * Load workflows from a directory, descending at most `MAX_DISCOVERY_DEPTH`


### PR DESCRIPTION
## Summary

- **Problem:** Workflows can be namespaced one subfolder deep on disk (`triage/foo`), are discovered at `MAX_DISCOVERY_DEPTH = 1`, and the CLI launches them by that name — but the HTTP `POST /api/workflows/{name}/run` and `GET /api/workflows/{name}` routes validate the name with `isValidCommandName`, which rejects any `/`. So namespaced workflows can only be run from the CLI, never over the API (#2007).
- **Why it matters:** The web UI and every forge/chat adapter reach workflows through these HTTP routes. A documented, CLI-supported layout (`~/.archon/workflows/triage/foo.yaml`) is silently unreachable from the API surface, with two failure modes: an unencoded slash 404s (Hono `:name` matches one segment), and a percent-encoded `%2F` decodes and hits the validator, returning `400 Invalid workflow name`.
- **What changed:** Added `isValidWorkflowName` to `@archon/workflows/command-validation`. It allows a single `/` by splitting on it and requiring every segment to itself be a valid command name — so `..`, `\`, leading dots, and empty segments (leading / trailing / double slash) all stay rejected and the path-traversal protection is unchanged. Wired it into the `/run` and `GET` routes.
- **What did NOT change (scope boundary):** `PUT` and `DELETE /api/workflows/{name}` keep `isValidCommandName`. Those write/remove a file, and creating (or cleaning up) a subfolder on save is a separate concern from resolving an existing one. `isValidCommandName` is untouched, so DAG step-command validation is unaffected.

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `server`
- Module: `server:api-workflows`

## Change Metadata

- Change type: `bug`
- Primary scope: `server`

## Linked Issue

- Closes #2007

## Validation Evidence

```
bun run type-check                                               # exit 0
bunx eslint packages/server/src/routes/api.ts \
  packages/workflows/src/command-validation.ts --max-warnings 0  # exit 0
bun run format:check                                             # All matched files use Prettier code style
bun test packages/workflows/src/command-validation.test.ts      # 52 pass / 0 fail
bun test packages/server/src/routes/api.workflows.test.ts       # 39 pass / 0 fail
bun test packages/server/src/routes/api.providers.test.ts \
         packages/server/src/routes/api.health.test.ts          # 33 pass / 0 fail (mock factory updated)
```

Guards proven red, not just green:
- Mutating `isValidWorkflowName` to delegate to `isValidCommandName` (reject all `/`) turns the two namespace-accepting unit tests red.
- Reverting the `GET` route back to `isValidCommandName` turns the new `triage%2Freview` integration test (writes `.archon/workflows/triage/review.yaml`, expects `200 source:project`) red.

## Security Impact

- New permissions/capabilities? No. New network calls? No. Secrets handling changed? No. File system access scope changed? No — `isValidWorkflowName` is strictly narrower than "allow any name": it permits exactly one extra character class (a single interior `/`) and still rejects `..`, `\`, leading dots, and empty segments, so no new path-traversal surface is opened. The resolved paths are the same ones the CLI already reads.

## Compatibility / Migration

- Backward compatible — names that were valid before stay valid (non-namespaced names have one segment). No config / env / DB changes.

## Side Effects / Blast Radius

- Affects the `/run` and `GET` workflow-name routes only. A name that resolves to a namespaced workflow now reaches discovery/`readFile` instead of 400ing; everything else behaves identically.

## Rollback Plan

- Revert this PR's merge commit. The two routes return to `isValidCommandName` and namespaced workflows are CLI-only again. No flags/config.

## Risks and Mitigations

- Risk: a name with a single `/` that does not correspond to an on-disk namespaced workflow.
  - Mitigation: it falls through to the existing 404 path (no file found) exactly like any other unknown name; the `/run` route resolves through `resolveWorkflowName`, which already handles misses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow endpoints now validate the `:name` path as a workflow name (not a command), enforcing the same safety rules consistently.
  * Percent-encoded namespaced workflow paths in URLs (e.g., `triage%2Freview`) are now accepted and correctly decoded/normalized.
  * Invalid workflow names continue to return `400` with “Invalid workflow name” (including empty input, hidden segments, double slashes, and path-traversal-style values).

* **Tests**
  * Expanded coverage for workflow-name validation and percent-encoded, namespaced workflow routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->