### PR TITLE
feat(workflows): Kimi cross-model harness + eval gate (MiniMax parity)

### DIFF
--- a/.archon/workflows/experimental/agentic-eval-gate.yaml
+++ b/.archon/workflows/experimental/agentic-eval-gate.yaml
@@ -118,12 +118,12 @@ nodes:
         have() { grep -q "\"$1\"" package.json; }
         runner=npm; command -v bun >/dev/null 2>&1 && runner=bun
 
-        if have '"type-check"'; then
+        if have 'type-check'; then
           echo "=== type-check ==="
           if $runner run type-check >/tmp/tc.log 2>&1; then TYPECHECK=pass; else TYPECHECK=fail; fi
           tail -30 /tmp/tc.log
         fi
-        if have '"lint"'; then
+        if have 'lint'; then
           echo "=== lint ==="
           if $runner run lint >/tmp/lint.log 2>&1; then LINT=pass; else LINT=fail; fi
           tail -30 /tmp/lint.log

--- a/.archon/workflows/experimental/agentic-eval-gate.yaml
+++ b/.archon/workflows/experimental/agentic-eval-gate.yaml
@@ -1,0 +1,264 @@
+name: agentic-eval-gate
+description: |
+  EXPERIMENTAL: Verification gate from the "New SDLC with vibe coding" whitepaper
+  (Osmani/Saboo/Kartakis). Embodies its core discipline — "set the bar at the eval,
+  not the demo" — by judging the CURRENT diff two ways the paper distinguishes:
+
+    1. OUTPUT eval     — is the final result correct vs the spec / "done means"?
+    2. TRAJECTORY eval — was the path sound? Were required checks (tests, lint,
+                         type-check, error handling, security) ACTUALLY run, or
+                         skipped while still looking correct?
+
+  Key principle: the gate RUNS the checks itself rather than trusting the
+  implementer's summary. A change can pass the output eval and still FAIL the gate
+  if the trajectory skipped a required verification step.
+
+  Read-only: it never edits files. Run it standalone before merging, or after a build
+  workflow (e.g. opus-plan-kimi-build) so every build has to clear the bar before it
+  ships.
+
+  Usage: pass the task / acceptance criteria as the run message ($ARGUMENTS). With
+  no message it falls back to evaluating the diff against its own apparent intent.
+
+  Model routing (the paper's "routing as a financial lever"): bash nodes use no
+  model; the two evals use the `medium` tier (reasoning); the merge uses `small`.
+
+tags: [eval, verification, gate, agentic-engineering, sdlc]
+provider: claude
+mutates_checkout: false
+# Evaluate the operator's ACTUAL working tree, not an empty isolated worktree.
+worktree:
+  enabled: false
+
+nodes:
+  # ─── 1. DIFF (deterministic, no AI) ───────────────────────────────────
+  # Robust diff that survives Windows worktrees and fresh single-commit checkouts.
+  # (Same hardened logic proven in cross-model-code-review.)
+  - id: get-diff
+    bash: |
+      if [ -f .git ]; then
+        gitdir=$(sed -n 's/^gitdir: //p' .git)
+        if command -v cygpath >/dev/null 2>&1; then
+          export GIT_DIR=$(cygpath -u "$gitdir")
+        else
+          export GIT_DIR=$(echo "$gitdir" | sed 's|^\([A-Za-z]\):|/\L\1|; s|\\|/|g')
+        fi
+      fi
+
+      echo "=== BRANCH ==="
+      git branch --show-current
+
+      # Resolve base in-shell only. We deliberately do NOT use Archon's magic
+      # base-branch variable (its token, even inside a comment, forces eager base
+      # resolution before the node runs and hard-fails on repos with no `origin`,
+      # e.g. a local-only checkout). Optional plain override: EVAL_BASE. Otherwise
+      # origin/HEAD, else main. base-mode is only reached when the tree is clean
+      # anyway, so a missing base never blocks the gate.
+      BASE="${EVAL_BASE:-}"
+      [ -z "$BASE" ] && BASE=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
+      case "$BASE" in ""|HEAD) BASE=main ;; esac
+      echo "=== BASE ==="
+      echo "base = $BASE"
+
+      STATUS_PORC="$(git status --porcelain)"
+      HAS_PARENT="$(git rev-parse --verify --quiet HEAD~1 || true)"
+      EMPTY_TREE="$(git hash-object -t tree /dev/null)"
+      if [ -n "$STATUS_PORC" ]; then
+        MODE=worktree; LABEL="(uncommitted working-tree changes vs HEAD)"
+      elif git rev-parse --verify --quiet "origin/$BASE" >/dev/null && [ -n "$(git log --oneline "origin/$BASE..HEAD" 2>/dev/null)" ]; then
+        MODE=base; LABEL="(this branch vs origin/$BASE)"
+      elif [ -n "$HAS_PARENT" ]; then
+        MODE=last; LABEL="(fallback: last commit)"
+      else
+        MODE=root; LABEL="(root commit: full initial tree vs empty tree)"
+      fi
+
+      run_diff() {
+        case "$MODE" in
+          worktree) git diff "$@" HEAD ;;
+          base)     git diff "$@" "origin/$BASE...HEAD" ;;
+          last)     git diff "$@" HEAD~1..HEAD ;;
+          root)     git diff "$@" "$EMPTY_TREE" HEAD ;;
+        esac
+      }
+
+      echo "=== DIFF ==="
+      echo "$LABEL"
+      DIFF_OUT="$(run_diff)"
+      if [ -n "$DIFF_OUT" ]; then
+        echo "$DIFF_OUT"
+      else
+        echo "NO CHANGES DETECTED - working tree clean and nothing to compare against."
+        echo "Evaluators: state there is nothing to evaluate; do not invent findings."
+      fi
+      echo "=== CHANGED FILES ==="
+      run_diff --name-only
+
+  # ─── 2. RUN CHECKS (deterministic trajectory signal, no AI) ───────────
+  # "Run the eval, don't trust the demo." Executes only FAST, SAFE gates that
+  # actually exist (type-check, lint). Deliberately does NOT run the full test
+  # suite (slow; and on this repo the root `bun test` is forbidden — see
+  # CLAUDE.md) — it REPORTS that gap so the trajectory eval can weigh it.
+  # Always exits 0: it records results for the gate to judge, it is not the gate.
+  - id: run-checks
+    depends_on: [get-diff]
+    bash: |
+      if [ -f .git ]; then
+        gitdir=$(sed -n 's/^gitdir: //p' .git)
+        if command -v cygpath >/dev/null 2>&1; then
+          export GIT_DIR=$(cygpath -u "$gitdir")
+        else
+          export GIT_DIR=$(echo "$gitdir" | sed 's|^\([A-Za-z]\):|/\L\1|; s|\\|/|g')
+        fi
+      fi
+
+      TYPECHECK=skipped; LINT=skipped; TESTS=not-run
+
+      if [ -f package.json ]; then
+        have() { grep -q "\"$1\"" package.json; }
+        runner=npm; command -v bun >/dev/null 2>&1 && runner=bun
+
+        if have '"type-check"'; then
+          echo "=== type-check ==="
+          if $runner run type-check >/tmp/tc.log 2>&1; then TYPECHECK=pass; else TYPECHECK=fail; fi
+          tail -30 /tmp/tc.log
+        fi
+        if have '"lint"'; then
+          echo "=== lint ==="
+          if $runner run lint >/tmp/lint.log 2>&1; then LINT=pass; else LINT=fail; fi
+          tail -30 /tmp/lint.log
+        fi
+        echo "NOTE: full test/validate suite intentionally NOT run by this gate (speed + root-test safety). The trajectory eval must treat test coverage as UNVERIFIED unless the diff itself adds/updates tests."
+      else
+        echo "No package.json — no JS gates to run. Trajectory eval should rely on the diff + spec only."
+      fi
+
+      echo "=== CHECKS SUMMARY ==="
+      echo "{\"type_check\":\"$TYPECHECK\",\"lint\":\"$LINT\",\"tests\":\"$TESTS\"}"
+
+  # ─── 3. OUTPUT EVAL (reasoning) ───────────────────────────────────────
+  # "Is the final result correct?" — vs the spec's acceptance criteria.
+  - id: output-eval
+    depends_on: [get-diff]
+    model: medium
+    context: fresh
+    allowed_tools: [Read, Grep, Glob, Bash]
+    prompt: |
+      You are an OUTPUT evaluator. Decide whether the change below actually
+      satisfies its specification — not whether it looks plausible. Verify against
+      the real code: open changed files, run targeted read-only checks if useful.
+      Do NOT edit anything.
+
+      ## Spec / acceptance criteria (may be terse or empty)
+      $ARGUMENTS
+
+      ## Diff under evaluation
+      $get-diff.output
+
+      ## How to judge
+      - Derive concrete acceptance criteria from the spec. If the spec is empty,
+        infer the change's apparent intent from the diff and judge against that.
+      - For EACH criterion decide met / not-met / partial, and cite file:line
+        evidence you actually verified (not a guess).
+      - If there are no changes to evaluate, return verdict "fail" with a single
+        criterion explaining there was nothing to evaluate.
+    output_format:
+      type: object
+      properties:
+        verdict:
+          type: string
+          enum: [pass, partial, fail]
+        criteria:
+          type: array
+          items:
+            type: object
+            properties:
+              criterion: { type: string }
+              status:
+                type: string
+                enum: [met, partial, not-met]
+              evidence: { type: string }
+            required: [criterion, status]
+        summary: { type: string }
+      required: [verdict, summary]
+
+  # ─── 4. TRAJECTORY EVAL (reasoning) ───────────────────────────────────
+  # "Was the path sound?" — were required checks actually run, or skipped?
+  - id: trajectory-eval
+    depends_on: [get-diff, run-checks]
+    model: medium
+    context: fresh
+    allowed_tools: [Read, Grep, Glob, Bash]
+    prompt: |
+      You are a TRAJECTORY evaluator. A change can be correct-looking yet unsound
+      because required verification was skipped. Judge the PROCESS, not just the
+      output. Do NOT edit anything.
+
+      ## Spec (may be empty)
+      $ARGUMENTS
+
+      ## Diff
+      $get-diff.output
+
+      ## Deterministic gate results (type-check / lint actually executed by the gate)
+      $run-checks.output
+
+      ## What to flag as a skipped/unsound step
+      - New or changed behavior with NO added/updated tests (the gate did not run
+        the suite — so absence of test changes in the diff = UNVERIFIED, flag it).
+      - type-check or lint reported "fail" above.
+      - New error paths swallowed, or new external input unvalidated.
+      - Security-sensitive surface (auth, file paths, secrets, shell, SQL) touched
+        without a corresponding guard.
+      List every skipped/unsound step concretely with file:line where relevant.
+    output_format:
+      type: object
+      properties:
+        soundness:
+          type: string
+          enum: [sound, unsound]
+        skipped_checks:
+          type: array
+          items: { type: string }
+        risks:
+          type: array
+          items: { type: string }
+        summary: { type: string }
+      required: [soundness, summary]
+
+  # ─── 5. VERDICT (cheap synthesis = the gate) ──────────────────────────
+  - id: verdict
+    depends_on: [output-eval, trajectory-eval]
+    model: small
+    context: fresh
+    allowed_tools: []
+    prompt: |
+      You are the gate. Combine the two evaluations into ONE decision.
+
+      Rule: gate = PASS only if BOTH hold:
+        - output eval verdict is "pass"  (NOT partial, NOT fail), AND
+        - trajectory eval soundness is "sound".
+      Otherwise gate = FAIL. List every blocking reason. "set the bar at the
+      eval, not the demo" — when uncertain, FAIL and say what evidence is missing.
+
+      ## Output eval
+      verdict: $output-eval.output.verdict
+      $output-eval.output.summary
+
+      ## Trajectory eval
+      soundness: $trajectory-eval.output.soundness
+      $trajectory-eval.output.summary
+
+      Produce the structured gate decision and a short human-readable rationale.
+    output_format:
+      type: object
+      properties:
+        gate:
+          type: string
+          enum: [PASS, FAIL]
+        blocking:
+          type: array
+          items: { type: string }
+        recommendation: { type: string }
+        summary: { type: string }
+      required: [gate, summary]

--- a/.archon/workflows/experimental/archon-fix-github-issue-kimi.yaml
+++ b/.archon/workflows/experimental/archon-fix-github-issue-kimi.yaml
@@ -1,0 +1,455 @@
+name: archon-fix-github-issue-kimi
+description: |
+  EXPERIMENTAL (Kimi): Kimi (kimi-for-coding via the Pi provider) variant of
+  archon-fix-github-issue-experimental. Identical DAG shape — same nodes, same
+  dependencies, same command files, same skip gates — but runs on the Pi provider
+  with Kimi instead of Claude/Codex.
+
+  Model: kimi-coding/kimi-for-coding for ALL nodes (set at the workflow level). There
+  is a single kimi-for-coding model, so — unlike the Codex variant — there is no
+  lightweight classifier tier; classify/review-classify run on the same model. Pi has
+  no native structured-output mode, so the `output_format` nodes rely on Pi's
+  best-effort prompt-augmentation + JSON extraction (validated against the declared
+  schema, re-asked up to 3x on a miss) — gate evaluation may be flakier than on
+  Claude/Codex.
+
+  Additions (same as the experimental Claude variant):
+    - Two extra classifier fields: `scope` (small/medium/large) and `needs_external_research`.
+    - A new `smoke-validate` node that checks the issue's concrete claims (file paths,
+      line numbers, symbols, repro commands) against the current codebase before any
+      skip gate fires. Every skip gate has a `claims_accurate == 'false'` override so an
+      inaccurate issue cannot cause a skip.
+    - `when:` gates on web-research and 4 reviewers so small, claim-verified issues
+      skip them. For medium/large issues or when the issue claims don't match the code,
+      behavior is identical to the full workflow.
+
+  Skip gates (all overridden when smoke-validate flags the issue as inaccurate):
+    - web-research       → runs when needs_external_research=='true' OR smoke=='false'
+    - error-handling     → runs when review-classify says yes AND (scope!='small' OR smoke=='false')
+    - test-coverage      → same as error-handling
+    - comment-quality    → same as error-handling
+    - docs-impact        → same as error-handling
+
+  Always runs (same as full): classify, smoke-validate, investigate/plan, bridge-artifacts,
+  implement, validate, create-pr, review-scope, review-classify, code-review, synthesize,
+  self-fix, simplify, report.
+
+  Use when: User wants to FIX, RESOLVE, or IMPLEMENT a solution for a GitHub issue with Kimi.
+  Triggers: "fix this issue with kimi", "implement issue #123 with kimi",
+            "fix it with kimi".
+  NOT for: Comprehensive multi-agent reviews (use archon-issue-review-full),
+           questions about issues, CI failures, PR reviews, general exploration.
+
+  DAG workflow that:
+  1. Classifies the issue (bug/feature/enhancement/etc)
+  2. Researches context (web research + codebase exploration via investigate/plan)
+  3. Routes to investigate (bugs) or plan (features) based on classification
+  4. Implements the fix/feature with validation
+  5. Creates a draft PR using the repo's PR template
+  6. Runs smart review (always code review + CLAUDE.md check, conditional additional agents)
+  7. Aggressively self-fixes all findings (tests, docs, error handling)
+  8. Simplifies changed code (implements fixes directly, not just reports)
+  9. Reports results back to the GitHub issue with follow-up suggestions
+
+provider: pi
+model: kimi-coding/kimi-for-coding
+
+nodes:
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 1: FETCH & CLASSIFY
+  # ═══════════════════════════════════════════════════════════════
+
+  - id: extract-issue-number
+    prompt: |
+      Find the GitHub issue number for this request.
+
+      Request: $ARGUMENTS
+
+      Rules:
+      - If the message contains an explicit issue number (e.g., "#709", "issue 709", "709"), extract that number.
+      - If the message is ambiguous (e.g., "fix the SQLite timestamp bug"), use `gh issue list` to search for matching issues and pick the best match.
+
+      CRITICAL: Your final output must be ONLY the bare number with no quotes, no markdown, no explanation. Example correct output: 709
+
+  - id: fetch-issue
+    bash: |
+      # Strip quotes, whitespace, markdown backticks from AI output
+      ISSUE_NUM=$(echo "$extract-issue-number.output" | tr -d "'\"\`\n " | grep -oE '[0-9]+' | head -1)
+      if [ -z "$ISSUE_NUM" ]; then
+        echo "Failed to extract issue number from: $extract-issue-number.output" >&2
+        exit 1
+      fi
+      gh issue view "$ISSUE_NUM" --json title,body,labels,comments,state,url,author
+    depends_on: [extract-issue-number]
+
+  - id: classify
+    prompt: |
+      You are an issue classifier. Analyze the GitHub issue below and determine:
+      (1) its type, (2) its scope, and (3) whether external web research is needed.
+
+      ## Issue Content
+
+      $fetch-issue.output
+
+      ## Type
+
+      | Type | Indicators |
+      |------|------------|
+      | bug | "broken", "error", "crash", "doesn't work", stack traces, regression |
+      | feature | "add", "new", "support", "would be nice", net-new capability |
+      | enhancement | "improve", "better", "update existing", "extend", incremental improvement |
+      | refactor | "clean up", "simplify", "reorganize", "restructure" |
+      | chore | "update deps", "upgrade", "maintenance", "CI/CD" |
+      | documentation | "docs", "readme", "clarify", "examples" |
+
+      ## Scope
+
+      Estimate how much code the fix is likely to touch. The issue body is your best
+      signal — reporter-pointed file paths, length of the reproducer, how specific the
+      request is. When uncertain, round UP (pick the larger scope).
+
+      | Scope | Indicators |
+      |-------|------------|
+      | small | 1-3 files, single subsystem, clear from the body. Typos, one-line bugs, isolated refactors, doc fixes, small enhancements pointing at specific code. |
+      | medium | 3-10 files, one or two subsystems, some investigation needed. Most features, non-trivial bugs, refactors that cross a few files. |
+      | large | 10+ files, cross-subsystem, vague/exploratory, or requires real codebase discovery before a fix direction is clear. |
+
+      ## External Research
+
+      Does this issue need external (web) research to fix correctly? Say "true" only if
+      the fix depends on specifics of an external library, API, protocol, or standard
+      that are NOT already apparent from the codebase. Internal plumbing, refactoring,
+      obvious bug fixes, and issues where the reporter already cited the relevant docs
+      → "false".
+
+      Provide reasoning that covers all three decisions.
+    depends_on: [fetch-issue]
+    output_format:
+      type: object
+      properties:
+        issue_type:
+          type: string
+          enum: ["bug", "feature", "enhancement", "refactor", "chore", "documentation"]
+        title:
+          type: string
+        scope:
+          type: string
+          enum: ["small", "medium", "large"]
+        needs_external_research:
+          type: string
+          enum: ["true", "false"]
+        reasoning:
+          type: string
+      required: [issue_type, title, scope, needs_external_research, reasoning]
+
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 1.5: SMOKE-VALIDATE
+  # Verifies that the issue's concrete claims (file paths, line numbers,
+  # symbols, repro commands) match the current codebase. Its `claims_accurate`
+  # verdict gates every skip decision downstream — if the issue body is
+  # inaccurate, the workflow falls back to the full pipeline.
+  # ═══════════════════════════════════════════════════════════════
+
+  - id: smoke-validate
+    prompt: |
+      You are a smoke validator. Your job: verify that the issue's claims about the
+      code are ACCURATE, so downstream skip decisions rest on a reliable foundation.
+
+      ## Context
+
+      ### Issue content
+      $fetch-issue.output
+
+      ### Classifier verdict
+      $classify.output
+
+      ## Your Task
+
+      Extract the concrete, verifiable claims from the issue body and comments:
+      - File paths mentioned (e.g. "packages/core/src/foo.ts")
+      - Line numbers or specific code snippets quoted
+      - Function, class, type, or symbol names referenced
+      - Reproduction commands (e.g. "run bun test X")
+
+      Then verify each concrete claim against the current codebase — TARGETED checks,
+      no Explore sub-agent:
+      - Use the Read tool on cited file paths. Confirm the file exists.
+      - If a line or region is cited, Read it and check the described code is there.
+      - If a symbol is cited, `grep -rn "<symbol>" packages/` to confirm it exists.
+      - If a repro command is cited, check `package.json` / the referenced file to
+        confirm the command is plausible. Do NOT execute it.
+
+      ## Budget
+
+      Spend at most ~30 seconds on this. Check the 2-3 most concrete claims — the
+      ones the fix most likely hinges on. Don't exhaustively verify every mention.
+      Prefer false-negative safety (flag inaccurate when uncertain) over
+      false-positive (risking a skip on shaky evidence).
+
+      If the issue has NO concrete claims (purely descriptive — "feature X is broken",
+      no file paths, no line numbers, no symbols), default to `claims_accurate: "false"`.
+      Vibes aren't a reliable foundation for skipping work.
+
+      ## Output
+
+      Set `claims_accurate`:
+      - "true": The concrete claims you checked match the current code. The issue body
+        is a reliable spec — downstream gates can trust the classifier's skip verdict.
+      - "false": One or more claims don't match reality — cited file doesn't exist, the
+        line doesn't contain the described code, the symbol was renamed/removed, the
+        repro command doesn't fit the project. The issue body is NOT a reliable
+        foundation for skipping. Downstream gates will fall back to the full pipeline
+        (research + all review agents).
+
+      In `reasoning`, list exactly what you checked and what you found.
+    depends_on: [classify]
+    context: fresh
+    output_format:
+      type: object
+      properties:
+        claims_accurate:
+          type: string
+          enum: ["true", "false"]
+        reasoning:
+          type: string
+      required: [claims_accurate, reasoning]
+
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 2: RESEARCH (parallel with PR template fetch)
+  # ═══════════════════════════════════════════════════════════════
+
+  - id: web-research
+    command: archon-web-research
+    depends_on: [classify, smoke-validate]
+    # Runs when research is flagged OR smoke-validate finds the issue unreliable (fallback)
+    when: "$classify.output.needs_external_research == 'true' || $smoke-validate.output.claims_accurate == 'false'"
+    context: fresh
+
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 3: INVESTIGATE (bugs) / PLAN (features)
+  # ═══════════════════════════════════════════════════════════════
+
+  - id: investigate
+    command: archon-investigate-issue
+    depends_on: [classify, web-research]
+    when: "$classify.output.issue_type == 'bug'"
+    # Allow web-research to be skipped (needs_external_research == 'false') without blocking
+    trigger_rule: none_failed_min_one_success
+    context: fresh
+
+  - id: plan
+    command: archon-create-plan
+    depends_on: [classify, web-research]
+    when: "$classify.output.issue_type != 'bug'"
+    # Allow web-research to be skipped (needs_external_research == 'false') without blocking
+    trigger_rule: none_failed_min_one_success
+    context: fresh
+
+  # Bridge: ensure investigation.md exists for the implement step
+  # archon-fix-issue reads from $ARTIFACTS_DIR/investigation.md
+  # archon-create-plan writes to $ARTIFACTS_DIR/plan.md
+  # This node copies plan.md → investigation.md when the plan path was taken
+  - id: bridge-artifacts
+    bash: |
+      if [ -f "$ARTIFACTS_DIR/plan.md" ] && [ ! -f "$ARTIFACTS_DIR/investigation.md" ]; then
+        cp "$ARTIFACTS_DIR/plan.md" "$ARTIFACTS_DIR/investigation.md"
+        echo "Bridged plan.md to investigation.md for implement step"
+      elif [ -f "$ARTIFACTS_DIR/investigation.md" ]; then
+        echo "investigation.md exists from investigate step"
+      else
+        echo "WARNING: No investigation.md or plan.md found — implement may fail"
+      fi
+    depends_on: [investigate, plan]
+    trigger_rule: one_success
+
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 4: IMPLEMENT
+  # ═══════════════════════════════════════════════════════════════
+
+  - id: implement
+    command: archon-fix-issue
+    depends_on: [bridge-artifacts]
+    context: fresh
+
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 5: VALIDATE
+  # ═══════════════════════════════════════════════════════════════
+
+  - id: validate
+    command: archon-validate
+    depends_on: [implement]
+    context: fresh
+
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 6: CREATE DRAFT PR
+  # ═══════════════════════════════════════════════════════════════
+
+  - id: create-pr
+    prompt: |
+      Create a draft pull request for the current branch.
+
+      ## Context
+
+      - **Issue**: $ARGUMENTS
+      - **Classification**: $classify.output
+      - **Issue title**: $classify.output.title
+
+      ## Instructions
+
+      1. Check git status. If uncommitted changes exist, stage and commit ONLY source files that are part of the fix:
+         - List them by name with `git add <path1> <path2> ...` — never `git add -A`, `git add .`, or `git add -u`
+         - **Never commit** scratch / review / PR-body artifacts, even if they appear in `git status`:
+           - `.pr-body.md`, `pr-body.md`, `*.scratch.md`, `*.tmp.md` at any path
+           - `review/`, `*-report.md` at the repo root
+           - Anything under `$ARTIFACTS_DIR`
+         - Verify with `git status --porcelain` that nothing scratch is staged before committing
+         - If files you don't recognize as part of the fix appear modified or untracked, leave them alone
+      2. Push the branch: `git push -u origin HEAD`
+      3. Read implementation artifacts from `$ARTIFACTS_DIR/` for context:
+         - `$ARTIFACTS_DIR/investigation.md` or `$ARTIFACTS_DIR/plan.md`
+         - `$ARTIFACTS_DIR/implementation.md`
+         - `$ARTIFACTS_DIR/validation.md`
+      4. Check if a PR already exists for this branch: `gh pr list --head $(git branch --show-current)`
+         - If PR exists, skip creation and capture its number
+      5. Look for the project's PR template at `.github/pull_request_template.md`, `.github/PULL_REQUEST_TEMPLATE.md`, or `docs/PULL_REQUEST_TEMPLATE.md`. Read whichever one exists.
+      6. Create a DRAFT PR: `gh pr create --draft --base $BASE_BRANCH`
+         - Title: concise, imperative mood, under 70 chars
+         - Body: if a PR template was found, fill in **every section** with details from the artifacts. Don't skip sections or leave placeholders. If no template, write a body with summary, changes, validation evidence, and `Fixes #...`.
+         - **PR body file location**: if you write the body to a file (e.g. for `--body-file`), the file MUST live at `$ARTIFACTS_DIR/pr-body.md` or under `/tmp/` — NEVER inside the worktree. Files like `.pr-body.md` at the repo root will be picked up by later commits.
+         - Link to issue: include `Fixes #...` or `Closes #...`
+      7. Capture PR identifiers:
+         ```bash
+         PR_NUMBER=$(gh pr view --json number -q '.number')
+         echo "$PR_NUMBER" > "$ARTIFACTS_DIR/.pr-number"
+         PR_URL=$(gh pr view --json url -q '.url')
+         echo "$PR_URL" > "$ARTIFACTS_DIR/.pr-url"
+         ```
+    depends_on: [validate]
+    context: fresh
+
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 7: REVIEW
+  # ═══════════════════════════════════════════════════════════════
+
+  - id: review-scope
+    command: archon-pr-review-scope
+    depends_on: [create-pr]
+    context: fresh
+
+  - id: review-classify
+    prompt: |
+      You are a PR review classifier. Analyze the PR scope and determine
+      which review agents should run.
+
+      ## PR Scope
+
+      $review-scope.output
+
+      ## Rules
+
+      - **Code review**: ALWAYS run. This is mandatory for every PR. It also checks
+        the PR against CLAUDE.md rules and project conventions.
+      - **Error handling**: Run if the diff touches code with try/catch, error handling,
+        async/await, or adds new failure paths.
+      - **Test coverage**: Run if the diff touches source code (not just tests, docs, or config).
+      - **Comment quality**: Run if the diff adds or modifies comments, docstrings, JSDoc,
+        or significant documentation within code files.
+      - **Docs impact**: Run if the diff adds/removes/renames public APIs, commands, CLI flags,
+        environment variables, or user-facing features.
+
+      Provide your reasoning for each decision.
+    depends_on: [review-scope]
+    context: fresh
+    output_format:
+      type: object
+      properties:
+        run_code_review:
+          type: string
+          enum: ["true", "false"]
+        run_error_handling:
+          type: string
+          enum: ["true", "false"]
+        run_test_coverage:
+          type: string
+          enum: ["true", "false"]
+        run_comment_quality:
+          type: string
+          enum: ["true", "false"]
+        run_docs_impact:
+          type: string
+          enum: ["true", "false"]
+        reasoning:
+          type: string
+      required:
+        - run_code_review
+        - run_error_handling
+        - run_test_coverage
+        - run_comment_quality
+        - run_docs_impact
+        - reasoning
+
+  # Code review always runs — mandatory
+  - id: code-review
+    command: archon-code-review-agent
+    depends_on: [review-classify]
+    context: fresh
+
+  # Reviewer gates: run when review-classify flags them AND the scope is non-small,
+  # OR when smoke-validate found the issue claims unreliable (fallback to full review).
+  # Expression form: A && B || A && C  (the condition evaluator has no parens; && binds tighter than ||)
+  - id: error-handling
+    command: archon-error-handling-agent
+    depends_on: [review-classify]
+    when: "$review-classify.output.run_error_handling == 'true' && $classify.output.scope != 'small' || $review-classify.output.run_error_handling == 'true' && $smoke-validate.output.claims_accurate == 'false'"
+    context: fresh
+
+  - id: test-coverage
+    command: archon-test-coverage-agent
+    depends_on: [review-classify]
+    when: "$review-classify.output.run_test_coverage == 'true' && $classify.output.scope != 'small' || $review-classify.output.run_test_coverage == 'true' && $smoke-validate.output.claims_accurate == 'false'"
+    context: fresh
+
+  - id: comment-quality
+    command: archon-comment-quality-agent
+    depends_on: [review-classify]
+    when: "$review-classify.output.run_comment_quality == 'true' && $classify.output.scope != 'small' || $review-classify.output.run_comment_quality == 'true' && $smoke-validate.output.claims_accurate == 'false'"
+    context: fresh
+
+  - id: docs-impact
+    command: archon-docs-impact-agent
+    depends_on: [review-classify]
+    when: "$review-classify.output.run_docs_impact == 'true' && $classify.output.scope != 'small' || $review-classify.output.run_docs_impact == 'true' && $smoke-validate.output.claims_accurate == 'false'"
+    context: fresh
+
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 8: SYNTHESIZE + SELF-FIX
+  # ═══════════════════════════════════════════════════════════════
+
+  - id: synthesize
+    command: archon-synthesize-review
+    depends_on: [code-review, error-handling, test-coverage, comment-quality, docs-impact]
+    trigger_rule: one_success
+    context: fresh
+
+  - id: self-fix
+    command: archon-self-fix-all
+    depends_on: [synthesize]
+    context: fresh
+
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 9: SIMPLIFY
+  # ═══════════════════════════════════════════════════════════════
+
+  - id: simplify
+    command: archon-simplify-changes
+    depends_on: [self-fix]
+    context: fresh
+
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 10: REPORT
+  # ═══════════════════════════════════════════════════════════════
+
+  - id: report
+    command: archon-issue-completion-report
+    depends_on: [simplify]
+    context: fresh

--- a/.archon/workflows/experimental/opus-plan-kimi-build.yaml
+++ b/.archon/workflows/experimental/opus-plan-kimi-build.yaml
@@ -1,0 +1,198 @@
+name: opus-plan-kimi-build
+description: |
+  EXPERIMENTAL (cross-model): Build loop on the PIV pattern (Plan → Implement →
+  Validate). Claude Opus does ALL the reasoning (plan, review, and the fix-plan);
+  Kimi (kimi-for-coding via the Pi provider) does ALL the code-writing. Opus never
+  edits source; Kimi never decides what to change.
+
+  Phases:
+  1. plan      (Opus)  — explore the codebase, write a concrete file-level plan. No edits.
+  2. implement (Kimi)  — apply the plan, make the actual file edits, summarize.
+  3. review    (Opus)  — Validate: read the diff, find issues by severity, AND turn the
+                         blocking ones into a concrete FIX-PLAN (re-Plan). No edits.
+  4. fix       (Kimi)  — apply Opus's fix-plan exactly (no-op if the review said "ship").
+  5. re-review (Opus)  — re-Validate: confirm each fix landed and resolved the finding;
+                         final verdict ship / needs work. No edits.
+
+  Why Opus owns the fix-plan (not Kimi auto-patching): deciding which findings are real
+  and exactly what to change is reasoning work — that's Opus's job; Kimi is the hands.
+  This closes the PIV loop (Validate → re-Plan → Implement). Single pass; if re-review
+  says "needs work", re-run the workflow. Pair with `agentic-eval-gate` as a standalone
+  pre-merge gate.
+
+  Models: the Opus nodes use the `large` tier (→ Claude Opus by default; override via
+  `tiers.large` in config). The Kimi nodes use `pi` + `kimi-coding/kimi-for-coding`.
+  Kimi has no native structured-output mode — these nodes use free-form prompts only.
+
+  Credentials: connect Kimi once with `archon ai key set kimi-coding` (or run `pi` then
+  `/login` → "Kimi For Coding" → paste your sk- key). Do NOT also set KIMI_API_KEY in
+  ~/.archon/.env — Archon force-injects that value over the Pi auth store, so a stale
+  key there yields a 401 "API Key invalid or expired" even when your login is valid.
+  Claude/Opus uses your normal Claude credentials (subscription login or ANTHROPIC_API_KEY).
+
+  Use when: a well-defined build or fix task where you want Opus planning + reviewing
+  and Kimi writing the code.
+  Triggers: "build it with kimi", "opus plan kimi build", "plan and implement with kimi".
+  NOT for: questions/exploration, pure reviews, or tasks with no concrete build target.
+
+tags: [plan, implement, review, fix, cross-model, kimi, opus, piv]
+mutates_checkout: true
+
+nodes:
+  # ─── PLAN (Opus) ──────────────────────────────────────────────────────
+  - id: plan
+    provider: claude
+    model: large
+    context: fresh
+    allowed_tools: [Read, Grep, Glob, Bash]
+    prompt: |
+      You are a senior software engineer acting as a planner. Your sole job in this
+      phase is to produce a concrete, actionable implementation plan. Do NOT edit
+      any files (you may run read-only git/grep to ground the plan).
+
+      ## Task
+
+      $ARGUMENTS
+
+      ## Instructions
+
+      1. Explore the codebase (Read, Grep, Glob, `git` read-only) to understand the
+         relevant code paths, existing patterns, and the files that must change.
+      2. Identify every file that must be created or modified.
+      3. For each change, describe exactly what to add, remove, or modify and why.
+      4. Call out edge cases, failure modes, and invariants to preserve.
+      5. Add a "Done means" section: concrete, checkable success criteria, plus the
+         build/lint/test command(s) to verify (if any exist).
+
+      Output the plan as a structured document with clear sections. Be specific —
+      exact file paths, function names, signatures. The implementer (Kimi) receives
+      ONLY this plan output, not the original task message or your exploration.
+
+  # ─── IMPLEMENT (Kimi) ─────────────────────────────────────────────────
+  - id: implement
+    depends_on: [plan]
+    provider: pi
+    model: kimi-coding/kimi-for-coding
+    context: fresh
+    allowed_tools: [Read, Write, Edit, Bash]
+    prompt: |
+      You are an expert software engineer. Implement the plan below exactly, making
+      the necessary file edits. Follow existing code style and patterns. Do not add
+      unrequested changes or refactors outside the plan's scope.
+
+      ## Implementation Plan
+
+      $plan.output
+
+      ## Instructions
+
+      1. Read any file before editing it.
+      2. Apply each change described in the plan.
+      3. Run any build/lint/test command the plan specifies, and fix what you broke.
+      4. Do NOT commit, push, or open a PR — just leave the working tree changed.
+      5. End with a short summary:
+         - Files created or modified (one per line, one-line description each)
+         - Any deviation from the plan (and why)
+         - Anything the reviewer should know
+
+  # ─── REVIEW = Validate + re-Plan (Opus) ───────────────────────────────
+  - id: review
+    depends_on: [implement]
+    provider: claude
+    model: large
+    context: fresh
+    allowed_tools: [Read, Grep, Glob, Bash]
+    prompt: |
+      You are a senior engineer doing a post-implementation review. Do NOT edit any
+      files. You produce two things: a findings list AND a concrete fix-plan that the
+      implementer (Kimi) will apply verbatim — Kimi does not decide anything, so your
+      fix-plan must be precise and self-contained.
+
+      ## Original Plan
+
+      $plan.output
+
+      ## Implementer's Summary
+
+      $implement.output
+
+      ## Instructions
+
+      1. Run `git diff` and `git status` to see exactly what changed; read the changed
+         files in context (don't trust the summary's file list — verify against git).
+      2. Check each plan item was actually implemented and is correct. Hunt for
+         correctness bugs, off-by-one, missing error handling, security issues, broken
+         invariants, regressions, and unmet "Done means" criteria. Cite file:line.
+      3. Group findings by severity: CRITICAL / HIGH / MEDIUM / LOW.
+
+      ## Output (exactly these sections)
+
+      ### Findings
+      The ranked list with file:line and a one-line description each.
+
+      ### Fix Plan
+      For every CRITICAL and HIGH finding (and any low-risk MEDIUM worth doing now),
+      write a precise, file-level instruction the implementer can apply without
+      judgment: which file, which function/line, the exact change, and why. If there
+      are NO blocking issues, write exactly: `NO FIXES NEEDED`.
+
+      ### Verdict
+      One line: `VERDICT: ship` (no blocking issues) or `VERDICT: needs work`.
+
+  # ─── FIX = re-Implement Opus's fix-plan (Kimi) ────────────────────────
+  - id: fix
+    depends_on: [review]
+    provider: pi
+    model: kimi-coding/kimi-for-coding
+    context: fresh
+    allowed_tools: [Read, Write, Edit, Bash]
+    prompt: |
+      You are the implementer (Kimi) again. Apply the reviewer's FIX PLAN below
+      exactly, with minimal-diff discipline — change ONLY what each item specifies.
+      You do not add scope or re-interpret findings; the reviewer already decided.
+
+      ## Reviewer output (findings + fix plan + verdict)
+
+      $review.output
+
+      ## Instructions
+
+      1. If the Fix Plan section is `NO FIXES NEEDED` (or the verdict is `ship` with no
+         fix items), make NO changes and say so — stop here.
+      2. Otherwise apply each fix-plan item precisely. Read each file before editing.
+      3. Re-run any build/lint/test command and confirm it passes after your edits.
+      4. Do NOT commit, push, or open a PR.
+      5. End with: which fix-plan items you applied, and any you could not (with the
+         exact blocker) — do not silently skip.
+
+  # ─── RE-REVIEW = re-Validate (Opus) ───────────────────────────────────
+  - id: re-review
+    depends_on: [fix]
+    provider: claude
+    model: large
+    context: fresh
+    allowed_tools: [Read, Grep, Glob, Bash]
+    prompt: |
+      You are the reviewer confirming the fixes. Do NOT edit any files.
+
+      ## Your earlier review (findings + fix plan)
+
+      $review.output
+
+      ## What the implementer reported doing
+
+      $fix.output
+
+      ## Instructions
+
+      1. Run `git diff` to see the FULL current state of the change.
+      2. For each item in your Fix Plan, confirm it was applied and actually resolves
+         the finding (not just superficially). Check no new bugs were introduced and
+         the original plan's "Done means" criteria now hold.
+      3. If the Fix Plan was `NO FIXES NEEDED`, just confirm the original change still
+         looks correct.
+
+      ## Output
+      A short per-item status (resolved / not resolved / new issue), then one line:
+      `VERDICT: ship` or `VERDICT: needs work` — if needs work, list exactly what
+      remains so the operator can re-run the workflow.

--- a/.archon/workflows/test-workflows/e2e-kimi-smoke.yaml
+++ b/.archon/workflows/test-workflows/e2e-kimi-smoke.yaml
@@ -1,0 +1,131 @@
+# E2E smoke test — Kimi (kimi-for-coding) via the Pi community provider
+# Verifies: Pi can resolve and call Kimi using the user's local credentials
+#   (api_key entry in ~/.pi/agent/auth.json, connected via `pi /login` →
+#   "Kimi For Coding", or `archon ai key set kimi-coding`).
+# Design: mirrors e2e-minimax-smoke.yaml / e2e-pi-smoke.yaml structure. Three nodes
+#   verify (1) the model responds at all, (2) it can self-identify, (3) it can
+#   produce parseable JSON via output_format (best-effort on Pi). The final bash
+#   node fails fast if any signal is missing.
+# Auth: requires a `kimi-coding` entry in ~/.pi/agent/auth.json. No env vars —
+#   do NOT set KIMI_API_KEY in ~/.archon/.env (Archon force-injects it over the
+#   Pi auth store, so a stale value there yields a 401 even when login is valid).
+name: e2e-kimi-smoke
+description: |
+  Use when: Verifying that Kimi (kimi-for-coding) loads via the Pi provider with the
+            user's local Pi auth (api_key in ~/.pi/agent/auth.json).
+  Triggers: "kimi smoke", "test kimi", "verify kimi", "kimi test".
+  Does: Sends three tiny prompts to Kimi (math, self-identification, structured JSON),
+        asserts non-empty output and basic plausibility.
+  NOT for: Production work — connectivity / capability sanity check only.
+
+provider: pi
+model: kimi-coding/kimi-for-coding
+
+worktree:
+  enabled: false # Smoke test — no need to isolate
+
+nodes:
+  # 1. Connectivity — does Pi resolve the model and stream a response?
+  - id: hello
+    prompt: 'What is 2+2? Answer with just the number, nothing else.'
+    allowed_tools: []
+    effort: low
+    idle_timeout: 60000
+
+  # 2. Self-identification — INFORMATIONAL ONLY. Do not assert on the result.
+  #    LLMs are unreliable narrators about their own identity, and Pi's system
+  #    prompt mentions OpenAI-codex defaults, which causes many models to
+  #    pattern-match and claim that identity. The real proof of routing is in
+  #    Pi's session jsonl (provider=kimi-coding, real billing).
+  - id: identify
+    prompt: 'Without using any tools, on a single short line, tell me which model and provider you are.'
+    allowed_tools: []
+    idle_timeout: 60000
+    depends_on: [hello]
+
+  # 3. Structured output — exercises Pi's best-effort output_format path
+  #    (schema appended to prompt + JSON extracted from result text).
+  - id: json
+    prompt: |
+      Return a JSON object with two fields, no fences and no prose:
+        - "name":     your model name (string)
+        - "ok":       always true (boolean)
+    allowed_tools: []
+    idle_timeout: 60000
+    depends_on: [hello]
+    output_format:
+      type: object
+      properties:
+        name:
+          type: string
+        ok:
+          type: boolean
+      required: [name, ok]
+
+  # 4. Assertions — fail loudly if any node returned empty / unparseable.
+  - id: assert
+    depends_on: [hello, identify, json]
+    bash: |
+      math="$hello.output"
+      ident="$identify.output"
+      jname="$json.output.name"
+      jok="$json.output.ok"
+
+      echo "── results ──"
+      echo "math      = $math"
+      echo "identify  = $ident"
+      echo "json.name = $jname"
+      echo "json.ok   = $jok"
+      echo "──────────────"
+
+      if [ -z "$math" ] || [ -z "$ident" ]; then
+        echo "FAIL: empty output from hello or identify node"
+        exit 1
+      fi
+      if [ -z "$jname" ] || [ -z "$jok" ]; then
+        echo "FAIL: structured-output fields missing — Pi best-effort JSON parse failed"
+        exit 1
+      fi
+
+      # Real proof of routing: Pi writes a session jsonl per call. Find ALL
+      # session jsonls modified in the last 10 minutes (generous window —
+      # smoke's three Pi nodes + assert can collectively take several
+      # minutes on a slow network; capped at 10 to avoid matching old runs).
+      # Check each for the kimi routing signal — any one matching is
+      # sufficient evidence. This avoids:
+      #   - brittle path-encoding assumptions about Pi's per-cwd session dir,
+      #   - non-deterministic `head -1` over `find` output (find doesn't
+      #     guarantee any order),
+      #   - JSON field-order brittleness in a single combined regex
+      #     (`provider` may appear before or after `modelId` in the jsonl).
+      # NOTE: if this FAILs while the nodes clearly ran on Kimi, confirm the
+      # exact `provider`/`modelId` strings Pi writes for kimi-coding in a real
+      # session jsonl and adjust the two greps below to match.
+      recent_sessions=$(find "$HOME/.pi/agent/sessions" -name '*.jsonl' -mmin -10 -print 2>/dev/null)
+      if [ -z "$recent_sessions" ]; then
+        echo "FAIL: no Pi session jsonl modified in the last 10 minutes"
+        exit 1
+      fi
+
+      matched=""
+      while IFS= read -r session; do
+        # Two separate greps for order-independence — JSON field ordering
+        # isn't part of Pi's contract, so a single regex with `.*` between
+        # the two fields would silently false-FAIL if Pi ever reorders.
+        if grep -q '"provider":"kimi-coding"' "$session" \
+           && grep -q '"modelId":"kimi-for-coding"' "$session"; then
+          matched="$session"
+          break
+        fi
+      done <<< "$recent_sessions"
+
+      if [ -n "$matched" ]; then
+        echo "PASS: Pi session log confirms provider=kimi-coding, modelId=kimi-for-coding"
+        echo "      session: $matched"
+      else
+        echo "FAIL: no recent Pi session log confirmed kimi routing — possible misroute"
+        echo "      checked sessions:"
+        echo "$recent_sessions" | sed 's/^/        /'
+        exit 1
+      fi
+      echo "PASS: smoke complete"


### PR DESCRIPTION
## Summary

- **Problem:** Kimi (`kimi-for-coding` via the Pi provider) had no first-class workflow coverage in the repo, while MiniMax shipped a full committed variant set. Cross-model Kimi work lived only as volatile, home-scoped personal workflows.
- **Why it matters:** Brings Kimi to parity with the existing MiniMax precedent so the cheapest coding backend is usable from repo workflows (Opus plans/reviews, Kimi writes), plus lands the whitepaper-derived pre-merge eval gate the build harness pairs with.
- **What changed:** Adds four experimental workflow definitions — a PIV build harness, a GitHub-issue-fix variant, an e2e connectivity smoke, and the `agentic-eval-gate` verification gate.
- **What did NOT change (scope boundary):** No code, no bundled defaults, no DB schema. `kimi-coding` is already a registered Pi vendor (`pi-vendor-map.generated.ts`), so this is YAML-only. The pre-existing `"$node.output"` double-quote validator warning on the two Kimi bash nodes is matched to the MiniMax precedent on purpose and left for a separate family-wide cleanup.

## UX Journey

### Before

```
Operator wants Kimi to do a build/fix in a repo workflow
  → no repo workflow exists; only home-scoped personal YAMLs (volatile, per-machine)
  → MiniMax has the full set; Kimi does not  → no parity
  → no committed pre-merge eval gate to pair with a build loop
```

### After

```
Operator                Archon                       Provider
────────                ──────                       ────────
run opus-plan-kimi-build ─▶ plan        (Opus/large) ─▶ writes file-level plan (no edits)
                           implement   (Pi/Kimi)     ─▶ *applies the edits*
                           review      (Opus/large)  ─▶ findings + fix-plan (no edits)
                           fix         (Pi/Kimi)     ─▶ applies fix-plan exactly
                           re-review   (Opus/large)  ─▶ ship / needs-work verdict

run agentic-eval-gate   ─▶ get-diff/run-checks (bash) ─▶ output-eval + trajectory-eval
                           ─▶ verdict: PASS only if output=pass AND trajectory=sound
run e2e-kimi-smoke      ─▶ hello/identify/json (Kimi) ─▶ assert routing via Pi session jsonl
run archon-fix-github-issue-kimi ─▶ classify→smoke-validate→…→PR→review→self-fix (all Kimi)
```

## Architecture Diagram

### Before

```
.archon/workflows/
├── maintainer/        repo-triage-minimax, maintainer-standup-minimax
├── experimental/      archon-fix-github-issue-minimax
└── test-workflows/    e2e-minimax-smoke, minimax-{isolate,seq,smoke}
                       (no Kimi equivalents; no committed eval gate)
```

### After

```
.archon/workflows/
├── experimental/   [+] opus-plan-kimi-build.yaml         (PIV build harness)
│                   [+] archon-fix-github-issue-kimi.yaml (issue-fix variant)
│                   [+] agentic-eval-gate.yaml            (whitepaper pre-merge gate)
└── test-workflows/ [+] e2e-kimi-smoke.yaml               (connectivity smoke)
                        === routes to Pi provider → kimi-coding/kimi-for-coding
                        === eval gate routes to claude (large/medium/small tiers)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| Kimi workflows | Pi provider (`kimi-coding`) | **new** | vendor already registered; no code wiring |
| opus-plan-kimi-build (plan/review) | `large` tier → Claude Opus | **new** | reasoning nodes |
| opus-plan-kimi-build (implement/fix) | Pi `kimi-coding/kimi-for-coding` | **new** | code-writing nodes |
| agentic-eval-gate | Claude (medium/small tiers) | **new** | read-only judge; cheap-model routing |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `workflows`
- Module: `workflows:definitions`

## Change Metadata

- Change type: `feature`
- Primary scope: `workflows`

## Linked Issue

- Closes #
- Related # (MiniMax parity precedent)

## Validation Evidence (required)

```bash
bun run cli validate workflows opus-plan-kimi-build --json
# → valid:true, errors:0, warnings:0
bun run cli validate workflows archon-fix-github-issue-kimi --json
# → valid:true, errors:0, warnings:1  (matches MiniMax precedent)
bun run cli validate workflows e2e-kimi-smoke --json
# → valid:true, errors:0, warnings:1  (matches MiniMax precedent)
bun run cli validate workflows agentic-eval-gate --json
# → valid:true, errors:0, warnings:0
```

- Evidence provided: workflow validation output above (all four valid, 0 errors). The single
  warning on the two Kimi bash nodes (`"$node.output"` double-quoting) is **identical to the
  committed MiniMax counterparts** (`archon-fix-github-issue-minimax`, `e2e-minimax-smoke`) —
  kept for faithful parity.
- If any command is intentionally skipped: full `bun run validate` (type-check/lint/test/
  check:bundled) skipped — this PR adds only **repo** `.archon/workflows/` YAML, touches no
  TypeScript, no bundled defaults, and no DB schema, so those gates are unaffected.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No` (uses the already-registered Pi `kimi-coding` vendor and the operator's existing local Pi/Claude credentials)
- Secrets/tokens handling changed? `No` (workflows document the existing `archon ai key set kimi-coding` flow; no new secret paths)
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes` (purely additive — four new workflow files)
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios: all four workflows pass `archon validate workflows` (0 errors). DAG
  shapes, `depends_on` edges, `when:` gates, and provider/model routing reviewed against the
  MiniMax precedent file-by-file.
- Edge cases checked: confirmed `kimi-coding` is a registered Pi vendor in
  `pi-vendor-map.generated.ts`; confirmed the validator warnings match the MiniMax variants;
  confirmed the eval gate avoids the `$BASE_BRANCH` eager-resolution trap (resolves base in-shell).
- What was not verified: live end-to-end runs against a real Kimi credential (requires the
  operator's `kimi-coding` Pi auth; the smoke workflow exists precisely to do this on demand).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: workflow discovery only (four new entries in `/workflow list`).
- Potential unintended effects: none for existing workflows (additive, distinct names).
- Guardrails/monitoring: `archon validate workflows` in CI; `e2e-kimi-smoke` for runtime routing proof.

## Rollback Plan (required)

- Fast rollback: `git revert e479b57b`, or delete the four YAML files — no state, no migration.
- Feature flags/toggles: none needed (workflows are opt-in by invocation).
- Observable failure symptoms: a Kimi workflow 401s → stale `KIMI_API_KEY` in `~/.archon/.env` overriding Pi auth (documented in each file's header).

## Risks and Mitigations

- Risk: Pi has no native structured-output mode → `output_format` nodes rely on best-effort JSON extraction, which can be flakier than Claude/Codex.
  - Mitigation: documented in the workflow headers; schema is still validated with up-to-3 re-asks; smoke test exercises the JSON path explicitly.
- Risk: pre-existing `"$node.output"` double-quote warning carried over from the MiniMax precedent.
  - Mitigation: intentionally matched for parity; flagged here for a separate family-wide cleanup so MiniMax and Kimi are fixed together.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added several new experimental workflows for agentic change verification, issue-fixing, and build planning/review.
  * Introduced safer validation steps that check changes against specs, claims, and available local checks before approving results.

* **Tests**
  * Added an end-to-end smoke test for the Kimi provider, including connectivity, structured output, and session verification checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->