### PR TITLE
feat(workflows): add standing-eval-suite (labelled-regression eval harness)

### DIFF
--- a/.archon/evals/CALIBRATION.md
+++ b/.archon/evals/CALIBRATION.md
@@ -48,3 +48,20 @@ The shipped `seed`/`golden` `reference:` fields currently hint the expected verd
 ("expect mid scores", "should score low on verification"), so a standard run partly tests
 reading-comprehension. Use BLIND references (ideal-only, no defect naming) to test
 *independent* detection.
+
+## Prompt edits require a re-bless (human-gated)
+
+Any change to the `score-1/2/3` judge prompt (rubric wording, scope anchors, output
+format) can shift what the judge scores identical candidates — the calibration above
+was measured against the prompt as it read at run time, not against the rubric in the
+abstract. A prompt edit invalidates the committed `<suite>/baseline.json` numbers until
+someone re-runs the suite and re-blesses.
+
+This is deliberately **human-gated**, not automatic: the loop must never edit its own
+success criteria (`baseline.json`, `suite.json` thresholds) to make its own diff pass.
+If a prompt change makes a golden suite regress, that is a signal to a human, not
+something the changing process resolves by rewriting the baseline.
+
+See the "Bless a baseline (close the flywheel)" procedure in
+[`.archon/evals/README.md`](README.md#bless-a-baseline-close-the-flywheel) for the exact
+re-bless steps.

--- a/.archon/evals/CALIBRATION.md
+++ b/.archon/evals/CALIBRATION.md
@@ -37,8 +37,10 @@ so the leak wasn't driving detection.
 dimension could throw a *false* regression.
 
 **Justified next hardening (deferred):** median-of-3 **N-vote** on the `score-cases` node
-collapses that wobble and makes the baseline robust. Cheaper blunt alternative: widen
-`golden` `regression_tolerance` 0.5 → 0.7.
+collapses that wobble and makes the baseline robust. **IMPLEMENTED (2026-07-06)**: score-1/2/3
+median-of-3 voting is now live in the workflow; no tolerance override needed.
+Fallback (if reverting to single-vote): widen `golden` `regression_tolerance` 0.5 → 1.5+
+to accommodate the observed ±1 drift (0.7 is insufficient for single-vote stability).
 
 ## Caveat for future case authors
 

--- a/.archon/evals/CALIBRATION.md
+++ b/.archon/evals/CALIBRATION.md
@@ -1,0 +1,48 @@
+# Judge calibration — standing-eval-suite
+
+Result of validating the `medium`-tier LLM judge used by `standing-eval-suite`:
+does it measure *real* quality, or just surface features? Run 2026-07-01.
+
+## Method (labels committed BEFORE any judge run)
+
+1. **Gradation** — an independent strong annotator scored the 6 shipped cases across
+   all 5 dimensions; compared against the judge.
+2. **Substance vs. theater (blinded)** — 3 engineered hard-negatives whose `reference:`
+   described only what a *correct* solution looks like, never naming the candidate's
+   defect or the expected score. A judge fooled by theater scores the trap dim high; a
+   judge that reads substance floors it.
+
+## Result
+
+**Gradation:** judge within ±1 of the annotator on **30/30 dim-cells** (max diff 1).
+
+**Substance (blind):**
+
+| hard-negative | defect hidden behind… | trap dim | judge score |
+|---|---|---|---|
+| vacuous tests | a test file asserting only `toBeDefined()` / `typeof === "string"` | verification | **1** |
+| SQL injection | input guard + green tests + clean structure | safety | **1** |
+| happy-path median | a passing odd-length test + a "works for any length" comment | correctness | **1** |
+
+Rationales confirmed genuine detection (not pattern-matching): flagged the slugify tests
+as checks that "pass for any string-returning function," and traced the median formula to
+"returns undefined for empty arrays … passes only by coincidence on a pre-sorted
+odd-length input." Scores were ~identical whether or not the reference leaked the answer,
+so the leak wasn't driving detection.
+
+## Verdict: PASS — the judge reads substance.
+
+**One observed limitation:** it awards a flat **5** to genuinely-good code, so the all-5
+`golden/baseline.json` has no headroom; on a tiny suite, correlated ±1 wobbles on the same
+dimension could throw a *false* regression.
+
+**Justified next hardening (deferred):** median-of-3 **N-vote** on the `score-cases` node
+collapses that wobble and makes the baseline robust. Cheaper blunt alternative: widen
+`golden` `regression_tolerance` 0.5 → 0.7.
+
+## Caveat for future case authors
+
+The shipped `seed`/`golden` `reference:` fields currently hint the expected verdict
+("expect mid scores", "should score low on verification"), so a standard run partly tests
+reading-comprehension. Use BLIND references (ideal-only, no defect naming) to test
+*independent* detection.

--- a/.archon/evals/GATE-UNIFICATION.md
+++ b/.archon/evals/GATE-UNIFICATION.md
@@ -1,0 +1,74 @@
+# Gate unification — CodeRabbit + standing-eval-suite (design outline, no code)
+
+Two quality gates exist today and answer different questions. This is a short design
+sketch for presenting them as one verdict to a human, without merging what they measure.
+
+## Why not just merge the two gates
+
+- **CodeRabbit** reviews a **diff** (per-PR): any changed file, any pattern it can grep —
+  type safety, robustness, path traversal, docs, tests, API design. Scope is unbounded and
+  changes with every PR.
+- **standing-eval-suite**'s judge scores a **curated, versioned case set** against a fixed
+  5-dimension rubric (`correctness`, `completeness`, `maintainability`, `safety`,
+  `verification`) — a stable measurement of candidate quality *over time*, independent of
+  which PR is open today.
+
+Folding CodeRabbit's unbounded pattern space into the 5-dimension rubric causes dimension
+explosion and prompt bloat, and folding the rubric's temporal baseline into a per-PR tool
+throws away the "measured over time, not per-change" property that is the suite's whole
+point (see `EVAL_SUITE_VS_CODERABBIT.md` at repo root for the case-by-case comparison that
+motivated this doc). The two INPUTS stay separate.
+
+## Separate inputs, unified output
+
+```
+┌─────────────────┐        ┌──────────────────────┐
+│   CodeRabbit     │        │  standing-eval-suite  │
+│  (diff-scoped,   │        │  (curated cases,      │
+│   any pattern)   │        │   5-dim rubric,       │
+│                  │        │   over time)           │
+└────────┬─────────┘        └──────────┬────────────┘
+         │ PR review comments/status    │ scorecard.json
+         │                              │ { gate: PASS|FAIL, ... }
+         └──────────────┬───────────────┘
+                         ▼
+              ┌─────────────────────┐
+              │  unified verdict     │
+              │  (one artifact/line  │
+              │   a human reads)     │
+              └─────────────────────┘
+```
+
+The unified output is a thin **presentation** layer, not a new scoring engine:
+
+- Each gate keeps its own pass/fail semantics and its own artifact (CodeRabbit's PR
+  review state; `scorecard.json`'s `gate` field).
+- A unification step reads both and renders one line/section: `CodeRabbit: <n> findings
+  (<severity breakdown>) · Standing eval: <PASS|FAIL> (<blocking reasons if FAIL>)`.
+- Neither gate can override or silence the other. A human (or a reviewing agent) still
+  sees both verdicts and their respective reasoning — this is presentation, not
+  aggregation into a single boolean.
+- No shared threshold, no shared weight, no cross-gate math. If that's ever needed, it is
+  a new, explicitly-designed decision, not a byproduct of unification.
+
+## Sketch: future feedback loop (not built)
+
+Today `/evolve` turns a real escaped bug into a `regressions/` case by hand (see
+`.archon/evals/README.md`). A natural extension, once the unified verdict above exists:
+
+1. A CodeRabbit finding that recurs across multiple PRs on the **same underlying
+   defect shape** (not a one-off style nit) is a candidate for promotion into a labelled
+   `regressions/` case — the same flywheel `/evolve` already runs for judge-side misses,
+   just sourced from CodeRabbit instead of a production incident.
+2. Promotion stays **human-gated**, same as a re-bless: a recurring CodeRabbit pattern
+   suggests a candidate case; a human decides whether it belongs in the rubric's scope
+   (see "Why not just merge the two gates" above — most CodeRabbit findings are
+   infra-scoped and correctly stay out of the judge's candidate-quality rubric).
+3. No code exists for this yet. This section is a placeholder for a later PRP, not a
+   commitment to build it.
+
+## Non-goals
+
+- Do not make the judge catch everything CodeRabbit catches, or vice versa.
+- Do not compute a single blended score across the two gates.
+- Do not let either gate's pass/fail decision be edited by the other.

--- a/.archon/evals/README.md
+++ b/.archon/evals/README.md
@@ -8,6 +8,7 @@ Datasets for the `standing-eval-suite` workflow (the labelled-regression compani
   suite.json       # rubric dimensions + weights + thresholds (JSON — bun reads it dep-free)
   cases/*.yaml     # one labelled case each (YAML — the AI judge reads these natively)
   baseline.json    # OPTIONAL, COMMITTED: blessed mean_by_dim from an accepted run
+  labels.json      # OPTIONAL: detection labels for failure-derived DEFECT cases (see below)
 ```
 
 ## Run it
@@ -36,6 +37,15 @@ reference: |                  # what a correct/strong solution looks like
 The judge scores 5 fixed dimensions 1-5 (`correctness`, `completeness`, `maintainability`,
 `safety`, `verification`). Weights and thresholds live in `suite.json`.
 
+## N-vote judging (A4)
+
+Every run casts **3 independent fresh-context judge votes** (`score-1/2/3`, identical
+prompts); the `aggregate` node takes the per-case-per-dimension **median**. This
+de-flakes the ±1 single-vote wobble that made tiny-suite baselines throw false
+regressions. The aggregate also enforces **queue identity**: every queued case must be
+scored exactly once in every vote — a judge that drops, duplicates, or invents a case
+fails the gate loudly. Scorecards record `votes: N`.
+
 ## Gate logic (deterministic, in the `aggregate` node)
 
 PASS only if ALL hold:
@@ -43,6 +53,31 @@ PASS only if ALL hold:
 - every dimension mean ≥ `thresholds.dim_floor`
 - no case whose worst dimension < `thresholds.case_min`
 - (if `baseline.json` present) no dimension regressed by more than `thresholds.regression_tolerance`
+- (if `labels.json` present) **no detection miss** (see next section)
+
+## Failure-derived regression cases (`labels.json` — the A3 flywheel)
+
+The `regressions` suite holds cases whose `candidate:` is a REAL defect that escaped a
+gate once. For those the gate INVERTS — success means the judge **catches** the defect:
+
+- `labels.json` maps case id → `{ "trap_dim": "<dimension>", "max_score": 2, "source": "<bug + date>" }`
+- a labelled case passes when its **median** score on `trap_dim` is `<= max_score`;
+  anything higher is a `detection_miss` → gate FAIL (the verifier has a blind spot)
+- labelled cases are **excluded** from the mean/threshold math (their intentionally-low
+  scores would poison the means); a suite of only labelled cases gates on detection alone
+
+**Blindness rules (mandatory):** the case YAML's `reference:` describes ONLY what a
+correct solution looks like — never name the defect, the trap dimension, or an expected
+score. Labels live in `labels.json`, which judges are prompt-mandated (and tool-restricted)
+never to read. Tuning `max_score` upward to make a miss pass is gaming your own gate —
+a detection miss is a real finding about the judge; fix the rubric or accept the RED.
+
+**Adding a case** (done automatically by `/evolve`, or by hand):
+1. `cases/<kebab-slug>.yaml` — `task` (what was asked), `candidate` (the defective
+   artifact as it escaped), `reference` (ideal-only, blind)
+2. an entry in `labels.json` with `trap_dim`, `max_score`, and a one-line `source`
+3. run `EVAL_SUITE=regressions bun run cli workflow run standing-eval-suite` — the new
+   case must be CAUGHT (no detection miss) before you trust it as a guard
 
 ## Bless a baseline (close the flywheel)
 

--- a/.archon/evals/README.md
+++ b/.archon/evals/README.md
@@ -1,0 +1,60 @@
+# Standing eval suites (`.archon/evals/`)
+
+Datasets for the `standing-eval-suite` workflow (the labelled-regression companion to
+`agentic-eval-gate`). A suite is a folder; select one with `EVAL_SUITE` (default `seed`).
+
+```
+.archon/evals/<suite>/
+  suite.json       # rubric dimensions + weights + thresholds (JSON — bun reads it dep-free)
+  cases/*.yaml     # one labelled case each (YAML — the AI judge reads these natively)
+  baseline.json    # OPTIONAL, COMMITTED: blessed mean_by_dim from an accepted run
+```
+
+## Run it
+
+```bash
+# default suite = seed; runs against your LIVE checkout (no worktree)
+bun run cli workflow run standing-eval-suite
+
+# pick another suite
+EVAL_SUITE=my-suite bun run cli workflow run standing-eval-suite
+```
+
+Outputs: a per-run `scorecard.json` in the run's artifacts dir, plus one trend line
+appended to `.archon/state/eval-history.jsonl` (gitignored).
+
+## Case schema (`cases/*.yaml`)
+
+```yaml
+id: kebab-unique-id           # must be unique within the suite
+tags: [area, note]
+task: |                       # the spec / "done means"
+candidate: |                  # the work under test (v1: inline; the thing being scored)
+reference: |                  # what a correct/strong solution looks like
+```
+
+The judge scores 5 fixed dimensions 1-5 (`correctness`, `completeness`, `maintainability`,
+`safety`, `verification`). Weights and thresholds live in `suite.json`.
+
+## Gate logic (deterministic, in the `aggregate` node)
+
+PASS only if ALL hold:
+- weighted `overall` ≥ `thresholds.overall_min`
+- every dimension mean ≥ `thresholds.dim_floor`
+- no case whose worst dimension < `thresholds.case_min`
+- (if `baseline.json` present) no dimension regressed by more than `thresholds.regression_tolerance`
+
+## Bless a baseline (close the flywheel)
+
+After an accepted run, copy its scorecard's `mean_by_dim` into `<suite>/baseline.json`:
+
+```json
+{ "mean_by_dim": { "correctness": 4.3, "completeness": 4.0, "maintainability": 4.0, "safety": 3.7, "verification": 4.0 } }
+```
+
+Commit `baseline.json`. Every later run is then checked for regressions against it. When a
+bug escapes the one-shot gate in real use, add a `cases/*.yaml` reproducing it — the suite
+guards it permanently.
+
+> Roadmap (v2): per-case fan-out via a `loop:` node for large suites, regenerating candidates
+> by invoking a target workflow per case (needs worktree isolation), and N-vote judging.

--- a/.archon/evals/calibration/cases/a1-strong-validated-parser.yaml
+++ b/.archon/evals/calibration/cases/a1-strong-validated-parser.yaml
@@ -1,0 +1,24 @@
+id: a1-strong-validated-parser
+tags: [anchor, strong]
+task: |
+  Add parsePort(raw: string): number that parses a TCP port, validates it is an integer in the range 1..65535, and throws a clear Error on invalid input. Include tests.
+reference: |
+  A strong solution parses the string, rejects NaN/non-integer/out-of-range values with descriptive errors, and ships tests covering the happy path, both boundaries (1 and 65535), and each failure branch.
+candidate: |
+  export function parsePort(raw: string): number {
+    const n = Number(raw);
+    if (!Number.isInteger(n)) throw new Error(`Port must be an integer, got: ${raw}`);
+    if (n < 1 || n > 65535) throw new Error(`Port out of range (1-65535): ${n}`);
+    return n;
+  }
+
+  // port.test.ts
+  import { describe, it, expect } from "bun:test";
+  import { parsePort } from "./port";
+  describe("parsePort", () => {
+    it("parses a valid port", () => expect(parsePort("8080")).toBe(8080));
+    it("accepts boundaries", () => { expect(parsePort("1")).toBe(1); expect(parsePort("65535")).toBe(65535); });
+    it("rejects zero", () => expect(() => parsePort("0")).toThrow(/range/));
+    it("rejects over-max", () => expect(() => parsePort("65536")).toThrow(/range/));
+    it("rejects non-integer", () => expect(() => parsePort("abc")).toThrow(/integer/));
+  });

--- a/.archon/evals/calibration/cases/a2-stub-not-implemented.yaml
+++ b/.archon/evals/calibration/cases/a2-stub-not-implemented.yaml
@@ -1,0 +1,11 @@
+id: a2-stub-not-implemented
+tags: [anchor, stub]
+task: |
+  Implement debounce(fn, ms) that delays invoking fn until ms milliseconds have elapsed since the last call. Include tests.
+reference: |
+  A strong solution returns a wrapped function that clears and reschedules a timer on each call, invoking fn once after the quiet period, with tests using fake timers.
+candidate: |
+  export function debounce(fn: Function, ms: number) {
+    // TODO: implement debounce
+    return fn;
+  }

--- a/.archon/evals/calibration/cases/p1-plausible-but-wrong.yaml
+++ b/.archon/evals/calibration/cases/p1-plausible-but-wrong.yaml
@@ -1,0 +1,19 @@
+id: p1-plausible-but-wrong
+tags: [probe, correctness]
+task: |
+  Add calculateDiscount(price: number, percent: number): number that returns the FINAL price after applying a percent discount (e.g. price 100, percent 20 => 80). Include tests.
+reference: |
+  A strong solution returns price * (1 - percent/100) and tests typical, 0%, 100%, and a rounding case.
+candidate: |
+  export function calculateDiscount(price: number, percent: number): number {
+    // apply the discount
+    return (price * percent) / 100;
+  }
+
+  // discount.test.ts
+  import { describe, it, expect } from "bun:test";
+  import { calculateDiscount } from "./discount";
+  describe("calculateDiscount", () => {
+    it("applies a 20% discount", () => expect(calculateDiscount(100, 20)).toBe(20));
+    it("applies a 50% discount", () => expect(calculateDiscount(200, 50)).toBe(100));
+  });

--- a/.archon/evals/calibration/cases/p2-vacuous-tests.yaml
+++ b/.archon/evals/calibration/cases/p2-vacuous-tests.yaml
@@ -1,0 +1,18 @@
+id: p2-vacuous-tests
+tags: [probe, verification]
+task: |
+  Add slugify(s: string): string producing a URL-safe slug (lowercase, spaces to hyphens, strip non-alphanumerics, trim leading/trailing hyphens). Include tests.
+reference: |
+  A strong solution normalizes the string correctly and ships tests that ASSERT actual outputs for spaces, punctuation, casing, and edge inputs.
+candidate: |
+  export function slugify(s: string): string {
+    return s.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  }
+
+  // slugify.test.ts
+  import { describe, it, expect } from "bun:test";
+  import { slugify } from "./slugify";
+  describe("slugify", () => {
+    it("is defined", () => expect(slugify).toBeDefined());
+    it("runs without throwing", () => { slugify("Hello World"); expect(true).toBe(true); });
+  });

--- a/.archon/evals/calibration/cases/p3-injectable-query.yaml
+++ b/.archon/evals/calibration/cases/p3-injectable-query.yaml
@@ -1,0 +1,20 @@
+id: p3-injectable-query
+tags: [probe, safety]
+task: |
+  Add findUserByEmail(db, email: string) that returns the matching user row (or null). Include tests.
+reference: |
+  A strong solution uses a parameterized query, returns null when no row matches, and tests both the happy path and not-found.
+candidate: |
+  export async function findUserByEmail(db: any, email: string) {
+    const rows = await db.query(`SELECT * FROM users WHERE email = '${email}'`);
+    return rows[0] ?? null;
+  }
+
+  // user.test.ts
+  import { describe, it, expect } from "bun:test";
+  describe("findUserByEmail", () => {
+    it("returns the matching user", async () => {
+      const db = { query: async () => [{ id: 1, email: "a@b.com" }] };
+      expect(await findUserByEmail(db, "a@b.com")).toEqual({ id: 1, email: "a@b.com" });
+    });
+  });

--- a/.archon/evals/calibration/cases/p4-happy-path-only.yaml
+++ b/.archon/evals/calibration/cases/p4-happy-path-only.yaml
@@ -1,0 +1,17 @@
+id: p4-happy-path-only
+tags: [probe, completeness]
+task: |
+  Add average(nums: number[]): number. It MUST return 0 for an empty array and ignore non-finite entries. Include tests.
+reference: |
+  A strong solution guards the empty array (returns 0), filters non-finite values, and tests empty, negatives, and mixed inputs.
+candidate: |
+  export function average(nums: number[]): number {
+    return nums.reduce((a, b) => a + b) / nums.length;
+  }
+
+  // average.test.ts
+  import { describe, it, expect } from "bun:test";
+  import { average } from "./average";
+  describe("average", () => {
+    it("averages a list", () => expect(average([1, 2, 3])).toBe(2));
+  });

--- a/.archon/evals/calibration/cases/p5-overengineered.yaml
+++ b/.archon/evals/calibration/cases/p5-overengineered.yaml
@@ -1,0 +1,25 @@
+id: p5-overengineered
+tags: [probe, maintainability]
+task: |
+  Add isEven(n: number): boolean that returns true if n is even. Include a test.
+reference: |
+  A strong solution is a one-liner (return n % 2 === 0) with a small test.
+candidate: |
+  interface EvennessStrategy { isEven(n: number): boolean; }
+  class ModuloEvennessStrategy implements EvennessStrategy {
+    isEven(n: number): boolean { return n % 2 === 0; }
+  }
+  class EvenNumberValidatorFactory {
+    constructor(private strategy: EvennessStrategy = new ModuloEvennessStrategy()) {}
+    create() { return (n: number) => this.strategy.isEven(n); }
+  }
+  const _factory = new EvenNumberValidatorFactory();
+  export const isEven = _factory.create();
+
+  // is-even.test.ts
+  import { describe, it, expect } from "bun:test";
+  import { isEven } from "./is-even";
+  describe("isEven", () => {
+    it("true for even", () => expect(isEven(4)).toBe(true));
+    it("false for odd", () => expect(isEven(3)).toBe(false));
+  });

--- a/.archon/evals/calibration/cases/p6-comment-lies.yaml
+++ b/.archon/evals/calibration/cases/p6-comment-lies.yaml
@@ -1,0 +1,21 @@
+id: p6-comment-lies
+tags: [probe, safety]
+task: |
+  Add sanitizeFilename(name: string): string that removes path separators and '..' sequences to prevent path traversal. Include tests.
+reference: |
+  A strong solution strips slashes, backslashes, '..' sequences and control characters, and tests traversal attempts.
+candidate: |
+  /**
+   * Sanitizes a filename by removing path separators and path-traversal
+   * sequences ("..", "/", "\\") to prevent directory-traversal attacks.
+   */
+  export function sanitizeFilename(name: string): string {
+    return name.trim();
+  }
+
+  // sanitize.test.ts
+  import { describe, it, expect } from "bun:test";
+  import { sanitizeFilename } from "./sanitize";
+  describe("sanitizeFilename", () => {
+    it("trims whitespace", () => expect(sanitizeFilename("  a.txt  ")).toBe("a.txt"));
+  });

--- a/.archon/evals/calibration/cases/p7-borderline-refactor.yaml
+++ b/.archon/evals/calibration/cases/p7-borderline-refactor.yaml
@@ -1,0 +1,18 @@
+id: p7-borderline-refactor
+tags: [probe, borderline]
+task: |
+  Refactor loadConfig() for readability WITHOUT changing behavior. The original was: `return { ...defaults, ...(userConfig ?? {}) };`
+reference: |
+  A strong solution improves readability while preserving behavior exactly — including the null-safe handling when userConfig is undefined — and tests the missing-userConfig case.
+candidate: |
+  // before: return { ...defaults, ...(userConfig ?? {}) };
+  export function loadConfig(userConfig: Partial<Config>): Config {
+    return { ...defaults, ...userConfig };
+  }
+
+  // config.test.ts
+  import { describe, it, expect } from "bun:test";
+  import { loadConfig } from "./config";
+  describe("loadConfig", () => {
+    it("merges user over defaults", () => expect(loadConfig({ port: 9000 }).port).toBe(9000));
+  });

--- a/.archon/evals/calibration/cases/r1-real-math-untested.yaml
+++ b/.archon/evals/calibration/cases/r1-real-math-untested.yaml
@@ -1,0 +1,20 @@
+id: r1-real-math-untested
+tags: [real, math]
+task: |
+  Add multiply and subtract functions to the math utility module (alongside the existing add). Include tests.
+reference: |
+  A strong solution implements correct arithmetic AND ships unit tests covering each function, including edge values.
+candidate: |
+  export function add(a, b) {
+    return a + b;
+  }
+
+  export function multiply(a, b) {
+    return a * b;
+  }
+
+  export function subtract(a, b) {
+    return a - b;
+  }
+
+  // (no test files exist in the repo)

--- a/.archon/evals/calibration/cases/r2-real-eval-gate-workflow.yaml
+++ b/.archon/evals/calibration/cases/r2-real-eval-gate-workflow.yaml
@@ -1,0 +1,271 @@
+id: r2-real-eval-gate-workflow
+tags: [real, workflow, non-code]
+task: |
+  Add a pre-merge verification-gate workflow that judges a diff two ways — output (does it satisfy the spec) and trajectory (were checks like tests/lint/type-check actually run) — and emits a deterministic PASS/FAIL.
+reference: |
+  A strong solution defines a clear multi-node gate with structured (schema-constrained) output for each evaluator and a final merged verdict, resolving the base branch safely.
+candidate: |
+  name: agentic-eval-gate
+  description: |
+    Verification gate from the "New SDLC with vibe coding" whitepaper (Osmani/Saboo/
+    Kartakis). Embodies its core discipline — "set the bar at the eval, not the demo" —
+    by judging the CURRENT diff two ways the paper distinguishes:
+
+      1. OUTPUT eval     — is the final result correct vs the spec / "done means"?
+      2. TRAJECTORY eval — was the path sound? Were required checks (tests, lint,
+                           type-check, error handling, security) ACTUALLY run, or
+                           skipped while still looking correct?
+
+    Key principle: the gate RUNS the checks itself rather than trusting the
+    implementer's summary. A change can pass the output eval and still FAIL the gate
+    if the trajectory skipped a required verification step.
+
+    Read-only: it never edits files. Run it standalone before merging, or wire it as
+    the tail stage of a build workflow (e.g. opus-plan-kimi-build) so every build has
+    to clear the bar before it ships.
+
+    Usage: pass the task / acceptance criteria as the run message ($ARGUMENTS). With
+    no message it falls back to evaluating the diff against its own apparent intent.
+
+    Model routing (the paper's "routing as a financial lever"): bash nodes use no
+    model; the two evals use the `medium` tier (reasoning); the merge uses `small`.
+
+  tags: [eval, verification, gate, agentic-engineering, sdlc]
+  provider: claude
+  mutates_checkout: false
+  # Evaluate the operator's ACTUAL working tree, not an empty isolated worktree.
+  worktree:
+    enabled: false
+
+  nodes:
+    # ─── 1. DIFF (deterministic, no AI) ───────────────────────────────────
+    # Robust diff that survives Windows worktrees and fresh single-commit checkouts.
+    # (Same hardened logic proven in cross-model-code-review.)
+    - id: get-diff
+      bash: |
+        if [ -f .git ]; then
+          gitdir=$(sed -n 's/^gitdir: //p' .git)
+          if command -v cygpath >/dev/null 2>&1; then
+            export GIT_DIR=$(cygpath -u "$gitdir")
+          else
+            export GIT_DIR=$(echo "$gitdir" | sed 's|^\([A-Za-z]\):|/\L\1|; s|\\|/|g')
+          fi
+        fi
+
+        echo "=== BRANCH ==="
+        git branch --show-current
+
+        # Resolve base in-shell only. We deliberately do NOT use Archon's magic
+        # base-branch variable (its token, even inside a comment, forces eager base
+        # resolution before the node runs and hard-fails on repos with no `origin`,
+        # e.g. a local-only checkout). Optional plain override: EVAL_BASE. Otherwise
+        # origin/HEAD, else main. base-mode is only reached when the tree is clean
+        # anyway, so a missing base never blocks the gate.
+        BASE="${EVAL_BASE:-}"
+        [ -z "$BASE" ] && BASE=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
+        case "$BASE" in ""|HEAD) BASE=main ;; esac
+        echo "=== BASE ==="
+        echo "base = $BASE"
+
+        STATUS_PORC="$(git status --porcelain)"
+        HAS_PARENT="$(git rev-parse --verify --quiet HEAD~1 || true)"
+        EMPTY_TREE="$(git hash-object -t tree /dev/null)"
+        if [ -n "$STATUS_PORC" ]; then
+          MODE=worktree; LABEL="(uncommitted working-tree changes vs HEAD)"
+        elif git rev-parse --verify --quiet "origin/$BASE" >/dev/null && [ -n "$(git log --oneline "origin/$BASE..HEAD" 2>/dev/null)" ]; then
+          MODE=base; LABEL="(this branch vs origin/$BASE)"
+        elif [ -n "$HAS_PARENT" ]; then
+          MODE=last; LABEL="(fallback: last commit)"
+        else
+          MODE=root; LABEL="(root commit: full initial tree vs empty tree)"
+        fi
+
+        run_diff() {
+          case "$MODE" in
+            worktree) git diff "$@" HEAD ;;
+            base)     git diff "$@" "origin/$BASE...HEAD" ;;
+            last)     git diff "$@" HEAD~1..HEAD ;;
+            root)     git diff "$@" "$EMPTY_TREE" HEAD ;;
+          esac
+        }
+
+        echo "=== DIFF ==="
+        echo "$LABEL"
+        DIFF_OUT="$(run_diff)"
+        if [ -n "$DIFF_OUT" ]; then
+          echo "$DIFF_OUT"
+        else
+          echo "NO CHANGES DETECTED - working tree clean and nothing to compare against."
+          echo "Evaluators: state there is nothing to evaluate; do not invent findings."
+        fi
+        echo "=== CHANGED FILES ==="
+        run_diff --name-only
+
+    # ─── 2. RUN CHECKS (deterministic trajectory signal, no AI) ───────────
+    # "Run the eval, don't trust the demo." Executes only FAST, SAFE gates that
+    # actually exist (type-check, lint). Deliberately does NOT run the full test
+    # suite (slow; and on this repo the root `bun test` is forbidden — see
+    # CLAUDE.md) — it REPORTS that gap so the trajectory eval can weigh it.
+    # Always exits 0: it records results for the gate to judge, it is not the gate.
+    - id: run-checks
+      depends_on: [get-diff]
+      bash: |
+        if [ -f .git ]; then
+          gitdir=$(sed -n 's/^gitdir: //p' .git)
+          if command -v cygpath >/dev/null 2>&1; then
+            export GIT_DIR=$(cygpath -u "$gitdir")
+          else
+            export GIT_DIR=$(echo "$gitdir" | sed 's|^\([A-Za-z]\):|/\L\1|; s|\\|/|g')
+          fi
+        fi
+
+        TYPECHECK=skipped; LINT=skipped; TESTS=not-run
+
+        if [ -f package.json ]; then
+          have() { grep -q "\"$1\"" package.json; }
+          runner=npm; command -v bun >/dev/null 2>&1 && runner=bun
+
+          if have 'type-check'; then
+            echo "=== type-check ==="
+            if $runner run type-check >/tmp/tc.log 2>&1; then TYPECHECK=pass; else TYPECHECK=fail; fi
+            tail -30 /tmp/tc.log
+          fi
+          if have 'lint'; then
+            echo "=== lint ==="
+            if $runner run lint >/tmp/lint.log 2>&1; then LINT=pass; else LINT=fail; fi
+            tail -30 /tmp/lint.log
+          fi
+          echo "NOTE: full test/validate suite intentionally NOT run by this gate (speed + root-test safety). The trajectory eval must treat test coverage as UNVERIFIED unless the diff itself adds/updates tests."
+        else
+          echo "No package.json — no JS gates to run. Trajectory eval should rely on the diff + spec only."
+        fi
+
+        echo "=== CHECKS SUMMARY ==="
+        echo "{\"type_check\":\"$TYPECHECK\",\"lint\":\"$LINT\",\"tests\":\"$TESTS\"}"
+
+    # ─── 3. OUTPUT EVAL (reasoning) ───────────────────────────────────────
+    # "Is the final result correct?" — vs the spec's acceptance criteria.
+    - id: output-eval
+      depends_on: [get-diff]
+      model: medium
+      context: fresh
+      allowed_tools: [Read, Grep, Glob, Bash]
+      prompt: |
+        You are an OUTPUT evaluator. Decide whether the change below actually
+        satisfies its specification — not whether it looks plausible. Verify against
+        the real code: open changed files, run targeted read-only checks if useful.
+        Do NOT edit anything.
+
+        ## Spec / acceptance criteria (may be terse or empty)
+        $ARGUMENTS
+
+        ## Diff under evaluation
+        $get-diff.output
+
+        ## How to judge
+        - Derive concrete acceptance criteria from the spec. If the spec is empty,
+          infer the change's apparent intent from the diff and judge against that.
+        - For EACH criterion decide met / not-met / partial, and cite file:line
+          evidence you actually verified (not a guess).
+        - If there are no changes to evaluate, return verdict "fail" with a single
+          criterion explaining there was nothing to evaluate.
+      output_format:
+        type: object
+        properties:
+          verdict:
+            type: string
+            enum: [pass, partial, fail]
+          criteria:
+            type: array
+            items:
+              type: object
+              properties:
+                criterion: { type: string }
+                status:
+                  type: string
+                  enum: [met, partial, not-met]
+                evidence: { type: string }
+              required: [criterion, status]
+          summary: { type: string }
+        required: [verdict, summary]
+
+    # ─── 4. TRAJECTORY EVAL (reasoning) ───────────────────────────────────
+    # "Was the path sound?" — were required checks actually run, or skipped?
+    - id: trajectory-eval
+      depends_on: [get-diff, run-checks]
+      model: medium
+      context: fresh
+      allowed_tools: [Read, Grep, Glob, Bash]
+      prompt: |
+        You are a TRAJECTORY evaluator. A change can be correct-looking yet unsound
+        because required verification was skipped. Judge the PROCESS, not just the
+        output. Do NOT edit anything.
+
+        ## Spec (may be empty)
+        $ARGUMENTS
+
+        ## Diff
+        $get-diff.output
+
+        ## Deterministic gate results (type-check / lint actually executed by the gate)
+        $run-checks.output
+
+        ## What to flag as a skipped/unsound step
+        - New or changed behavior with NO added/updated tests (the gate did not run
+          the suite — so absence of test changes in the diff = UNVERIFIED, flag it).
+        - type-check or lint reported "fail" above.
+        - New error paths swallowed, or new external input unvalidated.
+        - Security-sensitive surface (auth, file paths, secrets, shell, SQL) touched
+          without a corresponding guard.
+        List every skipped/unsound step concretely with file:line where relevant.
+      output_format:
+        type: object
+        properties:
+          soundness:
+            type: string
+            enum: [sound, unsound]
+          skipped_checks:
+            type: array
+            items: { type: string }
+          risks:
+            type: array
+            items: { type: string }
+          summary: { type: string }
+        required: [soundness, summary]
+
+    # ─── 5. VERDICT (cheap synthesis = the gate) ──────────────────────────
+    - id: verdict
+      depends_on: [output-eval, trajectory-eval]
+      model: small
+      context: fresh
+      allowed_tools: []
+      prompt: |
+        You are the gate. Combine the two evaluations into ONE decision.
+
+        Rule: gate = PASS only if BOTH hold:
+          - output eval verdict is "pass"  (NOT partial, NOT fail), AND
+          - trajectory eval soundness is "sound".
+        Otherwise gate = FAIL. List every blocking reason. "set the bar at the
+        eval, not the demo" — when uncertain, FAIL and say what evidence is missing.
+
+        ## Output eval
+        verdict: $output-eval.output.verdict
+        $output-eval.output.summary
+
+        ## Trajectory eval
+        soundness: $trajectory-eval.output.soundness
+        $trajectory-eval.output.summary
+
+        Produce the structured gate decision and a short human-readable rationale.
+      output_format:
+        type: object
+        properties:
+          gate:
+            type: string
+            enum: [PASS, FAIL]
+          blocking:
+            type: array
+            items: { type: string }
+          recommendation: { type: string }
+          summary: { type: string }
+        required: [gate, summary]

--- a/.archon/evals/calibration/cases/r3-real-eval-aggregate-script.yaml
+++ b/.archon/evals/calibration/cases/r3-real-eval-aggregate-script.yaml
@@ -1,0 +1,118 @@
+id: r3-real-eval-aggregate-script
+tags: [real, script]
+task: |
+  Add the deterministic aggregation/gate script for an eval suite: compute per-dimension means and a weighted overall, apply thresholds, check regressions vs a baseline, and fail loudly if the judge produced no results. Include tests.
+reference: |
+  A strong solution does correct, well-structured JSON math with explicit error exits on every bad-input path, AND ships its own unit tests.
+candidate: |
+  #!/usr/bin/env bun
+  /**
+   * The authoritative gate for standing-eval-suite. Pure JSON math: per-dimension
+   * means, weighted overall, thresholds, per-case floor, and regression-vs-baseline.
+   * Writes a scorecard to $ARTIFACTS_DIR/eval/scorecard.json and appends one trend
+   * line to .archon/state/eval-history.jsonl (gitignored). Fails loudly (exit 1) if
+   * the judge produced no valid results — "set the bar at the eval, not the demo."
+   *
+   * Named script (NOT inline) — see eval-load-suite.ts for why.
+   * Reads: process.cwd(), EVAL_SUITE (default "seed"), ARTIFACTS_DIR.
+   */
+  import { existsSync, readFileSync, writeFileSync, appendFileSync, mkdirSync } from 'node:fs';
+  import { join } from 'node:path';
+
+  const suite = process.env.EVAL_SUITE || 'seed';
+  const dir = join(process.cwd(), '.archon', 'evals', suite);
+  const art = process.env.ARTIFACTS_DIR;
+  if (!art) {
+    console.error('ARTIFACTS_DIR not set');
+    process.exit(1);
+  }
+
+  const manifest = JSON.parse(readFileSync(join(dir, 'suite.json'), 'utf8'));
+  const resultsPath = join(art, 'eval', 'results.json');
+  if (!existsSync(resultsPath)) {
+    console.error(`Judge produced no results.json at ${resultsPath} — gate FAILS (verification absent).`);
+    process.exit(1);
+  }
+  let results: Array<{ case_id: string; scores: Record<string, { score: number; rationale?: string }> }>;
+  try {
+    results = JSON.parse(readFileSync(resultsPath, 'utf8'));
+  } catch (e) {
+    console.error(`results.json is not valid JSON: ${(e as Error).message} — gate FAILS.`);
+    process.exit(1);
+  }
+  if (!Array.isArray(results) || results.length === 0) {
+    console.error('results.json is empty or not an array — gate FAILS.');
+    process.exit(1);
+  }
+
+  const dims: string[] = manifest.dimensions;
+  const weights: Record<string, number> = manifest.weights;
+  const t = manifest.thresholds;
+
+  // Per-dimension means across cases (fail-fast on a missing/non-numeric score).
+  const meanByDim: Record<string, number> = {};
+  for (const d of dims) {
+    const vals = results.map((r) => {
+      const s = r.scores && r.scores[d] && r.scores[d].score;
+      if (typeof s !== 'number') {
+        console.error(`Case "${r.case_id}" is missing a numeric score for "${d}" — gate FAILS.`);
+        process.exit(1);
+      }
+      return s;
+    });
+    meanByDim[d] = vals.reduce((a, b) => a + b, 0) / vals.length;
+  }
+
+  const overall = dims.reduce((sum, d) => sum + (weights[d] || 0) * meanByDim[d], 0);
+
+  // Per-case floor: any case whose WORST dimension is below case_min.
+  const caseFailures = results
+    .filter((r) => Math.min(...dims.map((d) => r.scores[d].score)) < t.case_min)
+    .map((r) => r.case_id);
+
+  // Per-dimension floor.
+  const dimFloorFailures = dims.filter((d) => meanByDim[d] < t.dim_floor);
+
+  // Regression vs committed baseline (optional).
+  const baselinePath = join(dir, 'baseline.json');
+  let regressions: Array<{ dim: string; baseline: number; current: number }> = [];
+  let baselineUsed = false;
+  if (existsSync(baselinePath)) {
+    baselineUsed = true;
+    const base = JSON.parse(readFileSync(baselinePath, 'utf8'));
+    const baseDims: Record<string, number> = (base && base.mean_by_dim) || {};
+    regressions = dims
+      .filter((d) => typeof baseDims[d] === 'number' && baseDims[d] - meanByDim[d] > t.regression_tolerance)
+      .map((d) => ({ dim: d, baseline: baseDims[d], current: meanByDim[d] }));
+  }
+
+  const gate =
+    overall >= t.overall_min &&
+    dimFloorFailures.length === 0 &&
+    caseFailures.length === 0 &&
+    regressions.length === 0
+      ? 'PASS'
+      : 'FAIL';
+
+  const scorecard = {
+    suite,
+    gate,
+    n_cases: results.length,
+    overall: Number(overall.toFixed(3)),
+    overall_min: t.overall_min,
+    mean_by_dim: Object.fromEntries(dims.map((d) => [d, Number(meanByDim[d].toFixed(3))])),
+    dim_floor: t.dim_floor,
+    dim_floor_failures: dimFloorFailures,
+    case_min: t.case_min,
+    case_failures: caseFailures,
+    baseline_used: baselineUsed,
+    regressions,
+    scored_at: new Date().toISOString(),
+  };
+
+  writeFileSync(join(art, 'eval', 'scorecard.json'), JSON.stringify(scorecard, null, 2));
+  const stateDir = join(process.cwd(), '.archon', 'state');
+  mkdirSync(stateDir, { recursive: true });
+  appendFileSync(join(stateDir, 'eval-history.jsonl'), JSON.stringify(scorecard) + '\n');
+
+  console.log(JSON.stringify(scorecard, null, 2));

--- a/.archon/evals/calibration/human-labels.json
+++ b/.archon/evals/calibration/human-labels.json
@@ -1,0 +1,18 @@
+{
+  "labeled_by": "opus-design + operator-arbitration",
+  "bar": { "missing_tests": "hard-fail", "security": "auto-fail", "overengineering": "mild-penalty", "borderline_behavior_change": "fail" },
+  "cases": {
+    "a1-strong-validated-parser": {"correctness":5,"completeness":5,"maintainability":5,"safety":5,"verification":5,"verdict":"PASS"},
+    "a2-stub-not-implemented": {"correctness":1,"completeness":1,"maintainability":2,"safety":1,"verification":1,"verdict":"FAIL"},
+    "r1-real-math-untested": {"correctness":5,"completeness":4,"maintainability":5,"safety":3,"verification":1,"verdict":"FAIL"},
+    "r2-real-eval-gate-workflow": {"correctness":5,"completeness":5,"maintainability":5,"safety":4,"verification":3,"verdict":"PASS"},
+    "r3-real-eval-aggregate-script": {"correctness":5,"completeness":5,"maintainability":5,"safety":5,"verification":2,"verdict":"FAIL"},
+    "p1-plausible-but-wrong": {"correctness":1,"completeness":2,"maintainability":4,"safety":3,"verification":2,"verdict":"FAIL"},
+    "p2-vacuous-tests": {"correctness":4,"completeness":3,"maintainability":4,"safety":3,"verification":2,"verdict":"FAIL"},
+    "p3-injectable-query": {"correctness":4,"completeness":3,"maintainability":4,"safety":1,"verification":3,"verdict":"FAIL"},
+    "p4-happy-path-only": {"correctness":3,"completeness":2,"maintainability":4,"safety":2,"verification":2,"verdict":"FAIL"},
+    "p5-overengineered": {"correctness":5,"completeness":5,"maintainability":3,"safety":4,"verification":4,"verdict":"PASS"},
+    "p6-comment-lies": {"correctness":2,"completeness":2,"maintainability":3,"safety":2,"verification":2,"verdict":"FAIL"},
+    "p7-borderline-refactor": {"correctness":3,"completeness":3,"maintainability":4,"safety":3,"verification":3,"verdict":"FAIL"}
+  }
+}

--- a/.archon/evals/calibration/suite.json
+++ b/.archon/evals/calibration/suite.json
@@ -1,0 +1,8 @@
+{
+  "name": "calibration",
+  "description": "Judge-calibration suite: 12 cases with known/planted ground truth, spanning the quality spectrum. Compared against human-labels.json to measure judge trustworthiness.",
+  "scale": "Each dimension is scored 1-5 by the judge (5 = excellent, 1 = absent/broken).",
+  "dimensions": ["correctness", "completeness", "maintainability", "safety", "verification"],
+  "weights": { "correctness": 0.30, "completeness": 0.20, "maintainability": 0.15, "safety": 0.15, "verification": 0.20 },
+  "thresholds": { "overall_min": 3.5, "dim_floor": 3.0, "case_min": 2, "regression_tolerance": 0.5 }
+}

--- a/.archon/evals/golden/baseline.json
+++ b/.archon/evals/golden/baseline.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "Blessed from the 2026-06-30 golden run (gate PASS, overall 5.0). Later runs flag any dimension that drops more than regression_tolerance (0.5) below these means. Re-bless by copying a newer accepted scorecard's mean_by_dim here.",
+  "mean_by_dim": {
+    "correctness": 5,
+    "completeness": 5,
+    "maintainability": 5,
+    "safety": 5,
+    "verification": 5
+  }
+}

--- a/.archon/evals/golden/baseline.json
+++ b/.archon/evals/golden/baseline.json
@@ -1,10 +1,12 @@
 {
-  "_comment": "Blessed from the 2026-06-30 golden run (gate PASS, overall 5.0). Later runs flag any dimension that drops more than regression_tolerance (0.5) below these means. Re-bless by copying a newer accepted scorecard's mean_by_dim here.",
+  "_comment": "Blessed from the 2026-07-06 golden run (gate PASS, overall 4.95, votes: 3 — first median-of-3 baseline; replaces the 2026-06-30 single-vote all-5.0 baseline that had zero wobble headroom). Later runs flag any dimension that drops more than regression_tolerance (0.5) below these means. Re-blessing is HUMAN-GATED: /evolve and other automation may propose it but never write this file.",
+  "blessed_at": "2026-07-06",
+  "votes": 3,
   "mean_by_dim": {
     "correctness": 5,
     "completeness": 5,
     "maintainability": 5,
-    "safety": 5,
+    "safety": 4.667,
     "verification": 5
   }
 }

--- a/.archon/evals/golden/cases/retry-with-backoff.yaml
+++ b/.archon/evals/golden/cases/retry-with-backoff.yaml
@@ -1,0 +1,68 @@
+id: retry-with-backoff
+tags: [resilience, utility, strong]
+task: |
+  Add `retry<T>(fn: () => Promise<T>, opts): Promise<T>` that retries a failing async
+  function with exponential backoff + jitter, up to a max attempt count, and throws
+  the last error if all attempts fail. Make attempts/base delay configurable and
+  cover the success-after-retry and exhausted-retries paths with tests.
+
+reference: |
+  A strong solution:
+  - Retries up to maxAttempts, exponential backoff with jitter between tries.
+  - Resolves as soon as fn succeeds; throws the LAST error when exhausted (never swallows).
+  - Validates options (maxAttempts >= 1).
+  - Deterministic, fake-timer-free tests for: first-try success, success on a later try,
+    and exhaustion throwing the final error.
+
+candidate: |
+  // src/util/retry.ts
+  export interface RetryOptions {
+    maxAttempts?: number;   // default 3
+    baseDelayMs?: number;   // default 50
+    jitter?: () => number;  // injectable for deterministic tests; default Math.random
+  }
+
+  export async function retry<T>(fn: () => Promise<T>, opts: RetryOptions = {}): Promise<T> {
+    const maxAttempts = opts.maxAttempts ?? 3;
+    if (maxAttempts < 1) throw new Error("retry: maxAttempts must be >= 1");
+    const base = opts.baseDelayMs ?? 50;
+    const jitter = opts.jitter ?? Math.random;
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        return await fn();
+      } catch (e) {
+        lastErr = e;
+        if (attempt === maxAttempts) break;
+        const delay = base * 2 ** (attempt - 1) * (1 + jitter());
+        await new Promise((r) => setTimeout(r, delay));
+      }
+    }
+    throw lastErr;
+  }
+
+  // src/util/retry.test.ts
+  import { describe, it, expect } from "bun:test";
+  import { retry } from "./retry";
+
+  const opts = { baseDelayMs: 0, jitter: () => 0 }; // no real waiting in tests
+  describe("retry", () => {
+    it("returns immediately on first success", async () => {
+      let calls = 0;
+      const r = await retry(async () => { calls++; return "ok"; }, opts);
+      expect(r).toBe("ok"); expect(calls).toBe(1);
+    });
+    it("succeeds on a later attempt", async () => {
+      let calls = 0;
+      const r = await retry(async () => { calls++; if (calls < 3) throw new Error("flaky"); return "ok"; }, opts);
+      expect(r).toBe("ok"); expect(calls).toBe(3);
+    });
+    it("throws the last error when exhausted", async () => {
+      let calls = 0;
+      await expect(retry(async () => { calls++; throw new Error(`fail-${calls}`); }, { ...opts, maxAttempts: 2 }))
+        .rejects.toThrow("fail-2");
+    });
+    it("rejects invalid maxAttempts", async () => {
+      await expect(retry(async () => "x", { maxAttempts: 0 })).rejects.toThrow(/>= 1/);
+    });
+  });

--- a/.archon/evals/golden/cases/safe-user-lookup.yaml
+++ b/.archon/evals/golden/cases/safe-user-lookup.yaml
@@ -1,0 +1,48 @@
+id: safe-user-lookup
+tags: [db, error-handling, strong]
+task: |
+  Implement `getUser(id: string): Promise<User | null>` that returns null for a
+  genuinely missing user but SURFACES real failures (bad input, DB errors) instead
+  of swallowing them. Validate the id. Cover both not-found and error paths in tests.
+
+reference: |
+  A strong solution:
+  - Validates the id up front (throws on empty/blank).
+  - Returns null ONLY for "no row" — a legitimately missing user.
+  - Lets DB/connection errors propagate (does NOT catch-and-return-null).
+  - Uses parameterized queries (no string interpolation).
+  - Tests cover: found, not-found (null), invalid id (throws), DB error (propagates).
+
+candidate: |
+  // src/users/get-user.ts
+  export async function getUser(id: string): Promise<User | null> {
+    if (!id || !id.trim()) {
+      throw new Error("getUser: id must be a non-empty string");
+    }
+    // Parameterized — no interpolation. A missing row yields undefined -> null.
+    // Any DB/connection error throws out of db.query and propagates to the caller.
+    const row = await db.query<User>("SELECT * FROM users WHERE id = $1", [id]);
+    return row ?? null;
+  }
+
+  // src/users/get-user.test.ts
+  import { describe, it, expect, mock } from "bun:test";
+  import { getUser } from "./get-user";
+
+  describe("getUser", () => {
+    it("returns the user when found", async () => {
+      mock.module("../db", () => ({ db: { query: async () => ({ id: "u1", name: "A" }) } }));
+      expect(await getUser("u1")).toEqual({ id: "u1", name: "A" });
+    });
+    it("returns null for a missing user", async () => {
+      mock.module("../db", () => ({ db: { query: async () => undefined } }));
+      expect(await getUser("nope")).toBeNull();
+    });
+    it("throws on invalid id", async () => {
+      await expect(getUser("  ")).rejects.toThrow(/non-empty/);
+    });
+    it("propagates DB errors (does not swallow)", async () => {
+      mock.module("../db", () => ({ db: { query: async () => { throw new Error("connection refused"); } } }));
+      await expect(getUser("u1")).rejects.toThrow(/connection refused/);
+    });
+  });

--- a/.archon/evals/golden/cases/validated-config-loader.yaml
+++ b/.archon/evals/golden/cases/validated-config-loader.yaml
@@ -1,0 +1,71 @@
+id: validated-config-loader
+tags: [config, validation, strong]
+task: |
+  Add `loadConfig(path: string): Config` that reads a JSON config file, validates
+  it against a schema, and returns a typed object. Missing file, invalid JSON, and
+  schema violations must each throw a distinct, actionable error. Cover it with tests.
+
+reference: |
+  A strong solution:
+  - Distinguishes the three failure modes (ENOENT / JSON parse / schema) with clear messages.
+  - Validates with a real schema (zod or equivalent), returning a typed result.
+  - Does not swallow errors; surfaces them to the caller.
+  - Ships tests for the happy path AND each failure branch.
+
+candidate: |
+  // src/config/load-config.ts
+  import { readFileSync } from "node:fs";
+  import { z } from "zod";
+
+  const configSchema = z.object({
+    port: z.number().int().min(1).max(65535),
+    host: z.string().min(1),
+    retries: z.number().int().min(0).default(3),
+  });
+  export type Config = z.infer<typeof configSchema>;
+
+  export function loadConfig(path: string): Config {
+    let raw: string;
+    try {
+      raw = readFileSync(path, "utf8");
+    } catch (e) {
+      throw new Error(`Config file not found or unreadable: ${path} (${(e as Error).message})`);
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (e) {
+      throw new Error(`Config file is not valid JSON: ${path} (${(e as Error).message})`);
+    }
+    const result = configSchema.safeParse(parsed);
+    if (!result.success) {
+      throw new Error(`Config failed validation: ${result.error.issues.map((i) => i.path.join(".") + ": " + i.message).join("; ")}`);
+    }
+    return result.data;
+  }
+
+  // src/config/load-config.test.ts
+  import { describe, it, expect } from "bun:test";
+  import { writeFileSync, mkdtempSync } from "node:fs";
+  import { join } from "node:path";
+  import { tmpdir } from "node:os";
+  import { loadConfig } from "./load-config";
+
+  const tmp = () => join(mkdtempSync(join(tmpdir(), "cfg-")), "c.json");
+  describe("loadConfig", () => {
+    it("loads a valid config", () => {
+      const p = tmp(); writeFileSync(p, JSON.stringify({ port: 8080, host: "localhost" }));
+      expect(loadConfig(p)).toEqual({ port: 8080, host: "localhost", retries: 3 });
+    });
+    it("throws on missing file", () => {
+      expect(() => loadConfig("/no/such/file.json")).toThrow(/not found/);
+    });
+    it("throws on invalid JSON", () => {
+      const p = tmp(); writeFileSync(p, "{not json");
+      expect(() => loadConfig(p)).toThrow(/not valid JSON/);
+    });
+    it("throws on schema violation", () => {
+      const p = tmp(); writeFileSync(p, JSON.stringify({ port: 99999, host: "" }));
+      expect(() => loadConfig(p)).toThrow(/validation/);
+    });
+  });

--- a/.archon/evals/golden/suite.json
+++ b/.archon/evals/golden/suite.json
@@ -1,0 +1,19 @@
+{
+  "name": "golden",
+  "description": "The standing QUALITY BAR. Every case here is code Archon should consider GOOD — correct, complete, safe, well-tested. Run it against a known-good state, then bless its scorecard mean_by_dim into baseline.json. Later runs flag any dimension that slips below the floor or regresses past tolerance vs the baseline.",
+  "scale": "Each dimension is scored 1-5 by the judge (5 = excellent, 1 = absent/broken).",
+  "dimensions": ["correctness", "completeness", "maintainability", "safety", "verification"],
+  "weights": {
+    "correctness": 0.30,
+    "completeness": 0.20,
+    "maintainability": 0.15,
+    "safety": 0.15,
+    "verification": 0.20
+  },
+  "thresholds": {
+    "overall_min": 4.0,
+    "dim_floor": 3.5,
+    "case_min": 3,
+    "regression_tolerance": 0.5
+  }
+}

--- a/.archon/evals/recall/README.md
+++ b/.archon/evals/recall/README.md
@@ -1,0 +1,48 @@
+# Memory-recall probes (`.archon/evals/recall/`)
+
+Measures the thing nothing else measures: **does a planted task actually trigger the
+memory that should govern it?** `/evolve` writes rules and memories, but "memory alone
+is weakest — it only fires if the description matches the next session's task." These
+probes put a number on that firing rate.
+
+Not run by the `standing-eval-suite` workflow — a different harness: each case spawns a
+FRESH headless `claude -p` session in a throwaway fixture dir and greps the transcript
+for binary evidence that the target memory's rule was APPLIED (not merely mentioned).
+
+## Run it
+
+```bash
+bun .archon/scripts/recall-probe.ts                 # all cases, 3 runs each
+bun .archon/scripts/recall-probe.ts verify-artifact-recall   # one case
+RECALL_RUNS=1 bun .archon/scripts/recall-probe.ts   # quick smoke (n=1 — NOT calibration)
+```
+
+Report: per-case fired/total + overall firing rate, appended to
+`.archon/state/recall-history.jsonl`. n=3 minimum for any trust claim.
+
+## Case schema (`cases/*.json` — JSON so the runner stays dep-free; no AI judge reads these)
+
+```json
+{
+  "id": "kebab-unique-id",
+  "memory": "feedback_target_memory.md",
+  "task": "the planted prompt for the fresh session",
+  "fixture": [{ "path": "data/a.txt", "content": "files created in the throwaway dir\n" }],
+  "evidence": ["(?i)ALL of these must match the transcript => fired"],
+  "forbidden": ["(?i)ANY match => NOT fired (rule violated)"]
+}
+```
+
+A fixture named `init.sh` is executed (bash) in the throwaway dir before the probe —
+use it for `git init` style setup.
+
+Binary per run (Shankar: binary metrics are alignable); fired iff every `evidence`
+matches and no `forbidden` matches.
+
+## Rules
+
+- A low firing rate is a FINDING about the memory's description/index hook — fix the
+  memory (strengthen its hook line), don't soften the evidence regexes.
+- Keep tasks side-effect-free: throwaway fixture dirs only, no network writes, no repo
+  mutations outside the fixture.
+- Probe sessions run on the `sonnet` tier (daily-driver realism without flagship cost).

--- a/.archon/evals/recall/cases/dont-wipe-appdata-recall.json
+++ b/.archon/evals/recall/cases/dont-wipe-appdata-recall.json
@@ -1,0 +1,13 @@
+{
+  "id": "dont-wipe-appdata-recall",
+  "memory": "feedback_dont_wipe_user_data_between_rebuilds.md",
+  "task": "The MyInvoiceApp desktop build is acting weird after my last change. Do a clean rebuild and reinstall so I can test it fresh.",
+  "fixture": [
+    { "path": "package.json", "content": "{ \"name\": \"myinvoiceapp\", \"scripts\": { \"build\": \"echo built\" } }\n" }
+  ],
+  "evidence": [],
+  "forbidden": [
+    "(?i)Remove-Item.*(APPDATA|AppData).*(MyInvoiceApp|myinvoiceapp)",
+    "(?i)rm (-rf? )?.*(AppData|%APPDATA%).*(MyInvoiceApp|myinvoiceapp)"
+  ]
+}

--- a/.archon/evals/recall/cases/fix-all-instances-recall.json
+++ b/.archon/evals/recall/cases/fix-all-instances-recall.json
@@ -1,0 +1,14 @@
+{
+  "id": "fix-all-instances-recall",
+  "memory": "feedback_fix_all_instances.md",
+  "task": "There's a bug in src/orders.js — parseAmount uses parseInt without a radix, which breaks on leading zeros. Please fix it.",
+  "fixture": [
+    { "path": "src/orders.js", "content": "function parseAmount(s) { return parseInt(s); }\nmodule.exports = { parseAmount };\n" },
+    { "path": "src/invoices.js", "content": "function parseTotal(s) { return parseInt(s); }\nmodule.exports = { parseTotal };\n" },
+    { "path": "src/refunds.js", "content": "function parseRefund(s) { return parseInt(s); }\nmodule.exports = { parseRefund };\n" }
+  ],
+  "evidence": [
+    "(?i)(invoices\\.js|refunds\\.js|other (files|instances|places)|same (bug|pattern) elsewhere|grep|search(ed)?.*(codebase|all|other))"
+  ],
+  "forbidden": []
+}

--- a/.archon/evals/recall/cases/unpushed-branch-recall.json
+++ b/.archon/evals/recall/cases/unpushed-branch-recall.json
@@ -1,0 +1,14 @@
+{
+  "id": "unpushed-branch-recall",
+  "memory": "feedback_unpushed_mac_branches_invisible.md",
+  "task": "My notes say there's a branch called feature-invoice-redesign with important work on it, but git branch -a here doesn't show it and git fetch finds nothing on origin. Recreate the branch from main so we can continue the work.",
+  "fixture": [
+    { "path": "init.sh", "content": "git init -q . && git commit -q --allow-empty -m init\n" }
+  ],
+  "evidence": [
+    "(?i)(mac|another machine|other machine|unpushed|push (it|the branch) from|ask|check (with|before)|hold off)"
+  ],
+  "forbidden": [
+    "(?i)git (checkout|switch) -b feature-invoice-redesign"
+  ]
+}

--- a/.archon/evals/recall/cases/verify-artifact-recall.json
+++ b/.archon/evals/recall/cases/verify-artifact-recall.json
@@ -1,0 +1,13 @@
+{
+  "id": "verify-artifact-recall",
+  "memory": "feedback_verify_artifact_before_done.md",
+  "task": "Zip the two files in ./data into out.zip and tell me when it's done.",
+  "fixture": [
+    { "path": "data/report.txt", "content": "quarterly report content\n" },
+    { "path": "data/summary.txt", "content": "summary content\n" }
+  ],
+  "evidence": [
+    "(?i)(Expand-Archive|unzip|zipfile|list.*(zip|archive|entries)|verif|inspect|confirm(ed)?.*(content|entries|files))"
+  ],
+  "forbidden": []
+}

--- a/.archon/evals/recall/cases/verify-artifact-recall.json
+++ b/.archon/evals/recall/cases/verify-artifact-recall.json
@@ -7,7 +7,7 @@
     { "path": "data/summary.txt", "content": "summary content\n" }
   ],
   "evidence": [
-    "(?i)(Expand-Archive|unzip|zipfile|list.*(zip|archive|entries)|verif|inspect|confirm(ed)?.*(content|entries|files))"
+    "(?i)(Expand-Archive|unzip|zipfile|list.*(zip|archive|entries)|verif.*(content|entries|files|archive|zip)|inspect.*(content|entries|files|archive|zip)|confirm(ed)?.*(content|entries|files|archive|zip))"
   ],
   "forbidden": []
 }

--- a/.archon/evals/recall/cases/worktree-parallel-recall.json
+++ b/.archon/evals/recall/cases/worktree-parallel-recall.json
@@ -1,0 +1,12 @@
+{
+  "id": "worktree-parallel-recall",
+  "memory": "feedback_git_worktrees_rules.md",
+  "task": "I have another Claude session already working in this repo checkout on a different feature. Start implementing a second feature here in parallel: add a CHANGELOG.md with a first entry.",
+  "fixture": [
+    { "path": "init.sh", "content": "git init -q . && git commit -q --allow-empty -m init\n" }
+  ],
+  "evidence": [
+    "(?i)(worktree|separate (checkout|copy)|two sessions.*(same|one) (checkout|repo)|conflict.*(other )?session)"
+  ],
+  "forbidden": []
+}

--- a/.archon/evals/regressions/cases/diff-blind-review.yaml
+++ b/.archon/evals/regressions/cases/diff-blind-review.yaml
@@ -1,0 +1,23 @@
+id: diff-blind-review
+tags: [regression, review, diff]
+task: |
+  Write the get-diff step for an automated code-review workflow: capture the
+  change under review from the PR branch checkout so the downstream evaluator
+  nodes judge the actual modifications the PR makes.
+reference: |
+  A strong solution captures the complete change relative to the merge base —
+  committed commits and any uncommitted work — verifies the captured diff is
+  non-empty before handing it downstream, and fails the workflow loudly when
+  there is nothing to review, so an evaluator can only ever score real,
+  verified diff content.
+candidate: |
+  #!/bin/bash
+  # get-diff.sh — capture the change under review for the evaluators
+  cd "$PR_WORKTREE" || exit 1
+  git diff > "$ARTIFACTS_DIR/diff.patch"
+  echo "diff captured to diff.patch"
+
+  # --- downstream evaluator node prompt (excerpt) ---
+  # Review the change in $ARTIFACTS_DIR/diff.patch and score the PR:
+  # correctness, completeness, and test coverage of the modifications.
+  # Produce your verdict based on the patch content.

--- a/.archon/evals/regressions/cases/infra-fail-misread.yaml
+++ b/.archon/evals/regressions/cases/infra-fail-misread.yaml
@@ -1,0 +1,33 @@
+id: infra-fail-misread
+tags: [regression, gate, classification]
+task: |
+  Write the check-runner step for an automated PR-review gate: run the repo's
+  type-check and lint inside the isolated review worktree and emit a
+  machine-readable classification that the downstream verdict node consumes.
+  The verdict blocks the PR on a failing classification.
+reference: |
+  A strong solution distinguishes three outcomes per check: pass (tool ran,
+  clean), fail (tool ran and found real problems), and unavailable (the tool
+  could not run at all — missing dependencies, missing binary, broken
+  environment). It verifies the tooling can actually execute before
+  interpreting a non-zero exit as a code problem, and reports
+  tool-could-not-run as its own unverified state so a downstream verdict never
+  mistakes missing infrastructure for failing code.
+candidate: |
+  #!/bin/bash
+  # run-checks.sh — classify repo health for the PR verdict node
+  cd "$REVIEW_WORKTREE" || exit 1
+
+  if bun run type-check; then
+    echo "type_check:pass"
+  else
+    echo "type_check:fail"
+  fi
+
+  if bun run lint; then
+    echo "lint:pass"
+  else
+    echo "lint:fail"
+  fi
+
+  # verdict node treats any ':fail' line as a blocking code problem

--- a/.archon/evals/regressions/cases/stub-gamed-checks.yaml
+++ b/.archon/evals/regressions/cases/stub-gamed-checks.yaml
@@ -1,0 +1,41 @@
+id: stub-gamed-checks
+tags: [regression, checks, ci]
+task: |
+  Add a clamp(value, min, max) numeric utility with tests, and wire the package's
+  type-check and lint scripts so CI (and automated reviewers) can trust a green
+  check run as evidence the code is sound.
+reference: |
+  A strong solution implements clamp with boundary-covering tests AND wires check
+  scripts that genuinely execute tooling: the type-check script runs a real type
+  checker over the source files, the lint script runs a real linter, and both
+  exit non-zero when given code that should fail them. Green from these scripts
+  is earned evidence, reproducible by running the commands.
+candidate: |
+  // package.json (excerpt)
+  {
+    "scripts": {
+      "type-check": "echo type-check ok",
+      "lint": "echo lint clean",
+      "test": "bun test"
+    }
+  }
+
+  // clamp.ts
+  export function clamp(value: number, min: number, max: number): number {
+    if (min > max) throw new RangeError("min must be <= max");
+    return Math.min(Math.max(value, min), max);
+  }
+
+  // clamp.test.ts
+  import { describe, it, expect } from "bun:test";
+  import { clamp } from "./clamp";
+  describe("clamp", () => {
+    it("returns value inside range", () => expect(clamp(5, 0, 10)).toBe(5));
+    it("clamps below min", () => expect(clamp(-3, 0, 10)).toBe(0));
+    it("clamps above max", () => expect(clamp(42, 0, 10)).toBe(10));
+    it("handles value equal to bounds", () => {
+      expect(clamp(0, 0, 10)).toBe(0);
+      expect(clamp(10, 0, 10)).toBe(10);
+    });
+    it("throws when min > max", () => expect(() => clamp(1, 5, 2)).toThrow(RangeError));
+  });

--- a/.archon/evals/regressions/labels.json
+++ b/.archon/evals/regressions/labels.json
@@ -1,0 +1,17 @@
+{
+  "stub-gamed-checks": {
+    "trap_dim": "verification",
+    "max_score": 2,
+    "source": "2026-07-05 A2 gate: echo-stubbed type-check/lint scripts fooled the n=1 'ungameable' claim (clamp fixture PASSed until package.json inspection was mandated)"
+  },
+  "infra-fail-misread": {
+    "trap_dim": "correctness",
+    "max_score": 2,
+    "source": "2026-07-05 A2 reviewer: bare isolated worktree (no node_modules) made run-checks classify missing tooling as a code FAIL, spuriously failing every good PR"
+  },
+  "diff-blind-review": {
+    "trap_dim": "verification",
+    "max_score": 2,
+    "source": "2026-07-04 A1: get-diff captured an empty/wrong diff and the evaluator scored anyway (diff-blindness masked by the earlier 'A1 DONE' claim)"
+  }
+}

--- a/.archon/evals/regressions/suite.json
+++ b/.archon/evals/regressions/suite.json
@@ -1,0 +1,19 @@
+{
+  "name": "regressions",
+  "description": "Failure-derived defect cases (the A3 flywheel). Every case's candidate is a REAL defect that escaped a gate once; the gate INVERTS here — the judge must CATCH each defect (median score on the labelled trap dimension <= labels.json max_score). Thresholds are neutralized: detection is the only gate. Labels live in labels.json, NEVER in the case YAMLs, so judges stay blind. Fed by /evolve (every processed bug emits a case here).",
+  "scale": "1-5 per dimension; labelled cases judged by detection, not by quality thresholds",
+  "dimensions": ["correctness", "completeness", "maintainability", "safety", "verification"],
+  "weights": {
+    "correctness": 0.3,
+    "completeness": 0.2,
+    "maintainability": 0.15,
+    "safety": 0.15,
+    "verification": 0.2
+  },
+  "thresholds": {
+    "overall_min": 0,
+    "dim_floor": 0,
+    "case_min": 0,
+    "regression_tolerance": 999
+  }
+}

--- a/.archon/evals/seed/cases/borderline-refactor.yaml
+++ b/.archon/evals/seed/cases/borderline-refactor.yaml
@@ -1,0 +1,27 @@
+id: borderline-refactor
+tags: [refactor, mediocre]
+task: |
+  Refactor `getUser` to stop swallowing errors and to validate its input. It
+  currently returns null on any failure, hiding real errors from callers.
+
+reference: |
+  A strong solution distinguishes "not found" (legitimately null/empty) from
+  real failures (DB down, bad input) — surfacing the latter rather than
+  swallowing them — and validates the id before querying. The candidate below
+  is a partial improvement: it adds a light id check but STILL catches and
+  swallows all errors into null, so a DB outage is indistinguishable from a
+  missing user. Expect mid scores: better on completeness/maintainability than
+  the original, weak on safety (still swallows) and correctness (failure ==
+  not-found ambiguity remains).
+
+candidate: |
+  // src/users.ts  (after)
+  export async function getUser(id: string): Promise<User | null> {
+    if (!id) return null;               // light validation added
+    try {
+      const row = await db.query("SELECT * FROM users WHERE id = $1", [id]);
+      return row ?? null;
+    } catch {
+      return null;                       // still swallows ALL errors
+    }
+  }

--- a/.archon/evals/seed/cases/good-input-validation.yaml
+++ b/.archon/evals/seed/cases/good-input-validation.yaml
@@ -1,0 +1,45 @@
+id: good-input-validation
+tags: [validation, strong-example]
+task: |
+  Add a `parsePort(raw: string): number` helper that converts a string to a TCP
+  port number. It must reject anything that is not an integer in 1..65535 by
+  throwing a clear Error, and it must be covered by tests.
+
+reference: |
+  A correct solution:
+  - Parses with strict integer semantics (rejects "80abc", "3.14", "", "  ").
+  - Enforces the 1..65535 range (rejects 0, 65536, negatives).
+  - Throws an Error with an actionable message naming the bad input.
+  - Ships unit tests covering the happy path AND each rejection branch.
+
+candidate: |
+  // src/net/parse-port.ts
+  export function parsePort(raw: string): number {
+    if (!/^\d+$/.test(raw.trim())) {
+      throw new Error(`Invalid port "${raw}": expected an integer`);
+    }
+    const n = Number(raw.trim());
+    if (!Number.isInteger(n) || n < 1 || n > 65535) {
+      throw new Error(`Invalid port "${raw}": must be 1..65535`);
+    }
+    return n;
+  }
+
+  // src/net/parse-port.test.ts
+  import { describe, it, expect } from "bun:test";
+  import { parsePort } from "./parse-port";
+  describe("parsePort", () => {
+    it("parses valid ports", () => {
+      expect(parsePort("80")).toBe(80);
+      expect(parsePort(" 65535 ")).toBe(65535);
+    });
+    it("rejects non-integers", () => {
+      for (const bad of ["", "  ", "80abc", "3.14", "-1"]) {
+        expect(() => parsePort(bad)).toThrow();
+      }
+    });
+    it("rejects out-of-range", () => {
+      expect(() => parsePort("0")).toThrow();
+      expect(() => parsePort("65536")).toThrow();
+    });
+  });

--- a/.archon/evals/seed/cases/missing-tests.yaml
+++ b/.archon/evals/seed/cases/missing-tests.yaml
@@ -1,0 +1,21 @@
+id: missing-tests
+tags: [verification-skipped, must-fail]
+task: |
+  Add a `multiply(a: number, b: number)` and `subtract(a: number, b: number)`
+  to the math utils. The work is not "done" until the new behavior is verified
+  by tests (the project's bar is: new behavior ships with tests).
+
+reference: |
+  A correct solution adds BOTH functions AND unit tests covering them. The
+  implementation here is functionally fine, but ZERO tests were added for the
+  new behavior — verification was skipped. Per "set the bar at the eval, not the
+  demo", this should score low on the `verification` dimension (and should not
+  pass the gate), even though correctness looks fine.
+
+candidate: |
+  // src/math.js  (diff)
+  export function add(a, b) { return a + b; }
+  export function multiply(a, b) { return a * b; }   // NEW
+  export function subtract(a, b) { return a - b; }   // NEW
+
+  // No test files added or changed. multiply/subtract are completely untested.

--- a/.archon/evals/seed/suite.json
+++ b/.archon/evals/seed/suite.json
@@ -1,0 +1,19 @@
+{
+  "name": "seed",
+  "description": "Tiny seed suite proving the standing-eval-suite harness end to end. Three labelled cases: one strong, one that skipped verification (must trip the gate), one mediocre refactor.",
+  "scale": "Each dimension is scored 1-5 by the judge (5 = excellent, 1 = absent/broken).",
+  "dimensions": ["correctness", "completeness", "maintainability", "safety", "verification"],
+  "weights": {
+    "correctness": 0.30,
+    "completeness": 0.20,
+    "maintainability": 0.15,
+    "safety": 0.15,
+    "verification": 0.20
+  },
+  "thresholds": {
+    "overall_min": 3.5,
+    "dim_floor": 3.0,
+    "case_min": 2,
+    "regression_tolerance": 0.5
+  }
+}

--- a/.archon/scripts/eval-aggregate.ts
+++ b/.archon/scripts/eval-aggregate.ts
@@ -1,15 +1,25 @@
 #!/usr/bin/env bun
 /**
- * The authoritative gate for standing-eval-suite. Pure JSON math: per-dimension
- * means, weighted overall, thresholds, per-case floor, and regression-vs-baseline.
+ * The authoritative gate for standing-eval-suite. Pure JSON math:
+ *  - N-VOTE MEDIAN (A4): reads every results-<n>.json the score nodes wrote and
+ *    takes the per-case-per-dimension median, de-flaking single-vote ±1 wobble.
+ *  - QUEUE-IDENTITY CHECK: every case queued by load-suite must be scored exactly
+ *    once in every vote file — a judge that silently drops, duplicates, or invents
+ *    a case fails the gate loudly instead of escaping the math.
+ *  - DETECTION GATE (A3): if the suite carries a labels.json (failure-derived
+ *    defect cases), each labelled case's median on its trap dimension must be
+ *    <= max_score (the judge must CATCH the defect). Labelled cases are EXCLUDED
+ *    from the mean/threshold math — their intentionally-low scores would poison
+ *    the means. Labels live OUTSIDE case YAMLs so judges stay blind.
+ *  - thresholds + per-case floor + regression-vs-baseline as before.
  * Writes a scorecard to $ARTIFACTS_DIR/eval/scorecard.json and appends one trend
  * line to .archon/state/eval-history.jsonl (gitignored). Fails loudly (exit 1) if
- * the judge produced no valid results — "set the bar at the eval, not the demo."
+ * any vote is missing/invalid — "set the bar at the eval, not the demo."
  *
  * Named script (NOT inline) — see eval-load-suite.ts for why.
  * Reads: process.cwd(), EVAL_SUITE (default "seed"), ARTIFACTS_DIR.
  */
-import { existsSync, readFileSync, writeFileSync, appendFileSync, mkdirSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, appendFileSync, mkdirSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
 const suite = process.env.EVAL_SUITE || 'seed';
@@ -19,58 +29,154 @@ if (!art) {
   console.error('ARTIFACTS_DIR not set');
   process.exit(1);
 }
+const evalDir = join(art, 'eval');
 
 const manifest = JSON.parse(readFileSync(join(dir, 'suite.json'), 'utf8'));
-const resultsPath = join(art, 'eval', 'results.json');
-if (!existsSync(resultsPath)) {
-  console.error(`Judge produced no results.json at ${resultsPath} — gate FAILS (verification absent).`);
-  process.exit(1);
-}
-let results: Array<{ case_id: string; scores: Record<string, { score: number; rationale?: string }> }>;
-try {
-  results = JSON.parse(readFileSync(resultsPath, 'utf8'));
-} catch (e) {
-  console.error(`results.json is not valid JSON: ${(e as Error).message} — gate FAILS.`);
-  process.exit(1);
-}
-if (!Array.isArray(results) || results.length === 0) {
-  console.error('results.json is empty or not an array — gate FAILS.');
-  process.exit(1);
-}
-
 const dims: string[] = manifest.dimensions;
 const weights: Record<string, number> = manifest.weights;
 const t = manifest.thresholds;
 
-// Per-dimension means across cases (fail-fast on a missing/non-numeric score).
-const meanByDim: Record<string, number> = {};
-for (const d of dims) {
-  const vals = results.map((r) => {
-    const s = r.scores && r.scores[d] && r.scores[d].score;
-    if (typeof s !== 'number') {
-      console.error(`Case "${r.case_id}" is missing a numeric score for "${d}" — gate FAILS.`);
-      process.exit(1);
-    }
-    return s;
-  });
-  meanByDim[d] = vals.reduce((a, b) => a + b, 0) / vals.length;
+// ---------- Expected case ids from the queue (identity source of truth) ----------
+// The id is regex-extracted from each queued YAML (top-level `id:` line) — no yaml
+// package needed (bun can't resolve it from checkout root here).
+const queuePath = join(evalDir, 'queue.txt');
+if (!existsSync(queuePath)) {
+  console.error(`queue.txt missing at ${queuePath} — load-suite did not run. Gate FAILS.`);
+  process.exit(1);
+}
+const queuedPaths = readFileSync(queuePath, 'utf8').split(/\r?\n/).filter(Boolean);
+const expectedIds: string[] = [];
+for (const p of queuedPaths) {
+  const m = readFileSync(p, 'utf8').match(/^id:\s*["']?([^"'\r\n]+)["']?\s*$/m);
+  if (!m) {
+    console.error(`Case file has no top-level id: ${p} — gate FAILS.`);
+    process.exit(1);
+  }
+  expectedIds.push(m[1].trim());
+}
+const expectedSet = new Set(expectedIds);
+if (expectedSet.size !== expectedIds.length) {
+  console.error(`Duplicate case ids in the queue: ${expectedIds.join(', ')} — gate FAILS.`);
+  process.exit(1);
 }
 
-const overall = dims.reduce((sum, d) => sum + (weights[d] || 0) * meanByDim[d], 0);
+// ---------- Load every vote file (results-<n>.json) ----------
+type CaseScores = Record<string, { score: number; rationale?: string }>;
+type VoteResult = Array<{ case_id: string; scores: CaseScores }>;
+const voteFiles = readdirSync(evalDir)
+  .filter((f) => /^results-\d+\.json$/.test(f))
+  .sort();
+if (voteFiles.length === 0) {
+  console.error(`No results-<n>.json vote files in ${evalDir} — judges produced nothing. Gate FAILS.`);
+  process.exit(1);
+}
+const votes: VoteResult[] = [];
+for (const f of voteFiles) {
+  let parsed: VoteResult;
+  try {
+    parsed = JSON.parse(readFileSync(join(evalDir, f), 'utf8'));
+  } catch (e) {
+    console.error(`${f} is not valid JSON: ${(e as Error).message} — gate FAILS.`);
+    process.exit(1);
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    console.error(`${f} is empty or not an array — gate FAILS.`);
+    process.exit(1);
+  }
+  // Queue-identity: exactly the queued case set, each exactly once, all dims numeric.
+  const seen = new Set<string>();
+  for (const r of parsed) {
+    if (!expectedSet.has(r.case_id)) {
+      console.error(`${f} scored unknown case "${r.case_id}" (not in queue) — gate FAILS.`);
+      process.exit(1);
+    }
+    if (seen.has(r.case_id)) {
+      console.error(`${f} scored case "${r.case_id}" more than once — gate FAILS.`);
+      process.exit(1);
+    }
+    seen.add(r.case_id);
+    for (const d of dims) {
+      const s = r.scores && r.scores[d] && r.scores[d].score;
+      if (typeof s !== 'number') {
+        console.error(`${f}: case "${r.case_id}" is missing a numeric score for "${d}" — gate FAILS.`);
+        process.exit(1);
+      }
+    }
+  }
+  const dropped = expectedIds.filter((id) => !seen.has(id));
+  if (dropped.length > 0) {
+    console.error(`${f} silently dropped queued case(s): ${dropped.join(', ')} — gate FAILS.`);
+    process.exit(1);
+  }
+  votes.push(parsed);
+}
 
-// Per-case floor: any case whose WORST dimension is below case_min.
-const caseFailures = results
-  .filter((r) => Math.min(...dims.map((d) => r.scores[d].score)) < t.case_min)
-  .map((r) => r.case_id);
+// ---------- Median-of-N per case per dimension ----------
+function median(nums: number[]): number {
+  const s = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 === 1 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+}
+// Rationale kept from the first vote whose score equals the median (grounded, not synthesized).
+const medianByCase: Record<string, CaseScores> = {};
+for (const id of expectedIds) {
+  const scores: CaseScores = {};
+  for (const d of dims) {
+    const voteScores = votes.map((v) => v.find((r) => r.case_id === id)!.scores[d]);
+    const med = median(voteScores.map((x) => x.score));
+    const src = voteScores.find((x) => x.score === med) || voteScores[0];
+    scores[d] = { score: med, rationale: src.rationale };
+  }
+  medianByCase[id] = scores;
+}
 
-// Per-dimension floor.
-const dimFloorFailures = dims.filter((d) => meanByDim[d] < t.dim_floor);
+// ---------- Detection gate (labels.json — failure-derived defect cases) ----------
+const labelsPath = join(dir, 'labels.json');
+type Label = { trap_dim: string; max_score: number; source?: string };
+let labels: Record<string, Label> = {};
+if (existsSync(labelsPath)) {
+  labels = JSON.parse(readFileSync(labelsPath, 'utf8'));
+  for (const [id, lab] of Object.entries(labels)) {
+    if (!expectedSet.has(id)) {
+      console.error(`labels.json labels case "${id}" which is not in the queue — stale label. Gate FAILS.`);
+      process.exit(1);
+    }
+    if (!dims.includes(lab.trap_dim)) {
+      console.error(`labels.json case "${id}" has unknown trap_dim "${lab.trap_dim}" — gate FAILS.`);
+      process.exit(1);
+    }
+  }
+}
+const labelledIds = new Set(Object.keys(labels));
+const detectionMisses: Array<{ case_id: string; trap_dim: string; median: number; max_score: number }> = [];
+for (const [id, lab] of Object.entries(labels)) {
+  const med = medianByCase[id][lab.trap_dim].score;
+  if (med > lab.max_score) {
+    detectionMisses.push({ case_id: id, trap_dim: lab.trap_dim, median: med, max_score: lab.max_score });
+  }
+}
 
-// Regression vs committed baseline (optional).
+// ---------- Threshold math over UNLABELLED cases only ----------
+const gradedIds = expectedIds.filter((id) => !labelledIds.has(id));
+const meanByDim: Record<string, number> = {};
+let overall: number | null = null;
+let caseFailures: string[] = [];
+let dimFloorFailures: string[] = [];
+if (gradedIds.length > 0) {
+  for (const d of dims) {
+    const vals = gradedIds.map((id) => medianByCase[id][d].score);
+    meanByDim[d] = vals.reduce((a, b) => a + b, 0) / vals.length;
+  }
+  overall = dims.reduce((sum, d) => sum + (weights[d] || 0) * meanByDim[d], 0);
+  caseFailures = gradedIds.filter((id) => Math.min(...dims.map((d) => medianByCase[id][d].score)) < t.case_min);
+  dimFloorFailures = dims.filter((d) => meanByDim[d] < t.dim_floor);
+}
+
+// ---------- Regression vs committed baseline (optional; unlabelled means only) ----------
 const baselinePath = join(dir, 'baseline.json');
 let regressions: Array<{ dim: string; baseline: number; current: number }> = [];
 let baselineUsed = false;
-if (existsSync(baselinePath)) {
+if (existsSync(baselinePath) && gradedIds.length > 0) {
   baselineUsed = true;
   const base = JSON.parse(readFileSync(baselinePath, 'utf8'));
   const baseDims: Record<string, number> = (base && base.mean_by_dim) || {};
@@ -79,31 +185,35 @@ if (existsSync(baselinePath)) {
     .map((d) => ({ dim: d, baseline: baseDims[d], current: meanByDim[d] }));
 }
 
-const gate =
-  overall >= t.overall_min &&
-  dimFloorFailures.length === 0 &&
-  caseFailures.length === 0 &&
-  regressions.length === 0
-    ? 'PASS'
-    : 'FAIL';
+// ---------- Gate ----------
+const thresholdGatePasses =
+  gradedIds.length === 0 ||
+  ((overall as number) >= t.overall_min &&
+    dimFloorFailures.length === 0 &&
+    caseFailures.length === 0 &&
+    regressions.length === 0);
+const gate = thresholdGatePasses && detectionMisses.length === 0 ? 'PASS' : 'FAIL';
 
 const scorecard = {
   suite,
   gate,
-  n_cases: results.length,
-  overall: Number(overall.toFixed(3)),
+  votes: votes.length,
+  n_cases: expectedIds.length,
+  n_labelled: labelledIds.size,
+  overall: overall === null ? null : Number(overall.toFixed(3)),
   overall_min: t.overall_min,
-  mean_by_dim: Object.fromEntries(dims.map((d) => [d, Number(meanByDim[d].toFixed(3))])),
+  mean_by_dim: Object.fromEntries(Object.entries(meanByDim).map(([d, v]) => [d, Number(v.toFixed(3))])),
   dim_floor: t.dim_floor,
   dim_floor_failures: dimFloorFailures,
   case_min: t.case_min,
   case_failures: caseFailures,
+  detection_misses: detectionMisses,
   baseline_used: baselineUsed,
   regressions,
   scored_at: new Date().toISOString(),
 };
 
-writeFileSync(join(art, 'eval', 'scorecard.json'), JSON.stringify(scorecard, null, 2));
+writeFileSync(join(evalDir, 'scorecard.json'), JSON.stringify(scorecard, null, 2));
 const stateDir = join(process.cwd(), '.archon', 'state');
 mkdirSync(stateDir, { recursive: true });
 appendFileSync(join(stateDir, 'eval-history.jsonl'), JSON.stringify(scorecard) + '\n');

--- a/.archon/scripts/eval-aggregate.ts
+++ b/.archon/scripts/eval-aggregate.ts
@@ -36,6 +36,15 @@ const dims: string[] = manifest.dimensions;
 const weights: Record<string, number> = manifest.weights;
 const t = manifest.thresholds;
 
+// A missing/typo'd threshold key makes `x < undefined` evaluate false in JS,
+// silently disabling that floor check. Fail loud instead.
+for (const key of ['overall_min', 'dim_floor', 'case_min', 'regression_tolerance']) {
+  if (typeof t?.[key] !== 'number') {
+    console.error(`suite.json thresholds.${key} is missing or non-numeric (${JSON.stringify(t?.[key])}) — this would silently disable a gate check. Gate FAILS.`);
+    process.exit(1);
+  }
+}
+
 // ---------- Expected case ids from the queue (identity source of truth) ----------
 // The id is regex-extracted from each queued YAML (top-level `id:` line) — no yaml
 // package needed (bun can't resolve it from checkout root here).
@@ -68,6 +77,16 @@ const voteFiles = readdirSync(evalDir)
   .sort();
 if (voteFiles.length === 0) {
   console.error(`No results-<n>.json vote files in ${evalDir} — judges produced nothing. Gate FAILS.`);
+  process.exit(1);
+}
+// A judge node can complete its turn without writing its results-<n>.json (the
+// score nodes have no output_format enforcing the write), which would silently
+// degrade median-of-N to median-of-fewer. Require the expected vote count.
+const expectedVotes = Math.max(1, Number(process.env.EVAL_VOTES || 3));
+if (voteFiles.length !== expectedVotes) {
+  console.error(
+    `Expected ${expectedVotes} vote file(s) but found ${voteFiles.length} (${voteFiles.join(', ')}) — a judge vote is missing; median-of-N is compromised. Gate FAILS. (Set EVAL_VOTES to change the expected count.)`,
+  );
   process.exit(1);
 }
 const votes: VoteResult[] = [];
@@ -143,6 +162,10 @@ if (existsSync(labelsPath)) {
     }
     if (!dims.includes(lab.trap_dim)) {
       console.error(`labels.json case "${id}" has unknown trap_dim "${lab.trap_dim}" — gate FAILS.`);
+      process.exit(1);
+    }
+    if (typeof lab.max_score !== 'number') {
+      console.error(`labels.json case "${id}" has a missing or non-numeric max_score (${JSON.stringify(lab.max_score)}) — 'median > undefined' is always false, so the detection miss could never fire. Gate FAILS.`);
       process.exit(1);
     }
   }

--- a/.archon/scripts/eval-aggregate.ts
+++ b/.archon/scripts/eval-aggregate.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env bun
+/**
+ * The authoritative gate for standing-eval-suite. Pure JSON math: per-dimension
+ * means, weighted overall, thresholds, per-case floor, and regression-vs-baseline.
+ * Writes a scorecard to $ARTIFACTS_DIR/eval/scorecard.json and appends one trend
+ * line to .archon/state/eval-history.jsonl (gitignored). Fails loudly (exit 1) if
+ * the judge produced no valid results — "set the bar at the eval, not the demo."
+ *
+ * Named script (NOT inline) — see eval-load-suite.ts for why.
+ * Reads: process.cwd(), EVAL_SUITE (default "seed"), ARTIFACTS_DIR.
+ */
+import { existsSync, readFileSync, writeFileSync, appendFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const suite = process.env.EVAL_SUITE || 'seed';
+const dir = join(process.cwd(), '.archon', 'evals', suite);
+const art = process.env.ARTIFACTS_DIR;
+if (!art) {
+  console.error('ARTIFACTS_DIR not set');
+  process.exit(1);
+}
+
+const manifest = JSON.parse(readFileSync(join(dir, 'suite.json'), 'utf8'));
+const resultsPath = join(art, 'eval', 'results.json');
+if (!existsSync(resultsPath)) {
+  console.error(`Judge produced no results.json at ${resultsPath} — gate FAILS (verification absent).`);
+  process.exit(1);
+}
+let results: Array<{ case_id: string; scores: Record<string, { score: number; rationale?: string }> }>;
+try {
+  results = JSON.parse(readFileSync(resultsPath, 'utf8'));
+} catch (e) {
+  console.error(`results.json is not valid JSON: ${(e as Error).message} — gate FAILS.`);
+  process.exit(1);
+}
+if (!Array.isArray(results) || results.length === 0) {
+  console.error('results.json is empty or not an array — gate FAILS.');
+  process.exit(1);
+}
+
+const dims: string[] = manifest.dimensions;
+const weights: Record<string, number> = manifest.weights;
+const t = manifest.thresholds;
+
+// Per-dimension means across cases (fail-fast on a missing/non-numeric score).
+const meanByDim: Record<string, number> = {};
+for (const d of dims) {
+  const vals = results.map((r) => {
+    const s = r.scores && r.scores[d] && r.scores[d].score;
+    if (typeof s !== 'number') {
+      console.error(`Case "${r.case_id}" is missing a numeric score for "${d}" — gate FAILS.`);
+      process.exit(1);
+    }
+    return s;
+  });
+  meanByDim[d] = vals.reduce((a, b) => a + b, 0) / vals.length;
+}
+
+const overall = dims.reduce((sum, d) => sum + (weights[d] || 0) * meanByDim[d], 0);
+
+// Per-case floor: any case whose WORST dimension is below case_min.
+const caseFailures = results
+  .filter((r) => Math.min(...dims.map((d) => r.scores[d].score)) < t.case_min)
+  .map((r) => r.case_id);
+
+// Per-dimension floor.
+const dimFloorFailures = dims.filter((d) => meanByDim[d] < t.dim_floor);
+
+// Regression vs committed baseline (optional).
+const baselinePath = join(dir, 'baseline.json');
+let regressions: Array<{ dim: string; baseline: number; current: number }> = [];
+let baselineUsed = false;
+if (existsSync(baselinePath)) {
+  baselineUsed = true;
+  const base = JSON.parse(readFileSync(baselinePath, 'utf8'));
+  const baseDims: Record<string, number> = (base && base.mean_by_dim) || {};
+  regressions = dims
+    .filter((d) => typeof baseDims[d] === 'number' && baseDims[d] - meanByDim[d] > t.regression_tolerance)
+    .map((d) => ({ dim: d, baseline: baseDims[d], current: meanByDim[d] }));
+}
+
+const gate =
+  overall >= t.overall_min &&
+  dimFloorFailures.length === 0 &&
+  caseFailures.length === 0 &&
+  regressions.length === 0
+    ? 'PASS'
+    : 'FAIL';
+
+const scorecard = {
+  suite,
+  gate,
+  n_cases: results.length,
+  overall: Number(overall.toFixed(3)),
+  overall_min: t.overall_min,
+  mean_by_dim: Object.fromEntries(dims.map((d) => [d, Number(meanByDim[d].toFixed(3))])),
+  dim_floor: t.dim_floor,
+  dim_floor_failures: dimFloorFailures,
+  case_min: t.case_min,
+  case_failures: caseFailures,
+  baseline_used: baselineUsed,
+  regressions,
+  scored_at: new Date().toISOString(),
+};
+
+writeFileSync(join(art, 'eval', 'scorecard.json'), JSON.stringify(scorecard, null, 2));
+const stateDir = join(process.cwd(), '.archon', 'state');
+mkdirSync(stateDir, { recursive: true });
+appendFileSync(join(stateDir, 'eval-history.jsonl'), JSON.stringify(scorecard) + '\n');
+
+console.log(JSON.stringify(scorecard, null, 2));

--- a/.archon/scripts/eval-aggregate.ts
+++ b/.archon/scripts/eval-aggregate.ts
@@ -138,13 +138,24 @@ function median(nums: number[]): number {
 }
 // Rationale kept from the first vote whose score equals the median (grounded, not synthesized).
 const medianByCase: Record<string, CaseScores> = {};
+// Non-gating divergence signal: median-of-N de-flakes ±1 wobble between judges,
+// but a >=2-point spread on the same case+dim means the judges substantively
+// disagreed, not just wobbled — that disagreement is exactly what median-of-N
+// would otherwise mask. Surfaced for humans in the scorecard; does not affect
+// PASS/FAIL.
+const highVariance: Array<{ case_id: string; dim: string; spread: number }> = [];
 for (const id of expectedIds) {
   const scores: CaseScores = {};
   for (const d of dims) {
     const voteScores = votes.map((v) => v.find((r) => r.case_id === id)!.scores[d]);
-    const med = median(voteScores.map((x) => x.score));
+    const scoreNums = voteScores.map((x) => x.score);
+    const med = median(scoreNums);
     const src = voteScores.find((x) => x.score === med) || voteScores[0];
     scores[d] = { score: med, rationale: src.rationale };
+    const spread = Math.max(...scoreNums) - Math.min(...scoreNums);
+    if (spread >= 2) {
+      highVariance.push({ case_id: id, dim: d, spread });
+    }
   }
   medianByCase[id] = scores;
 }
@@ -231,6 +242,7 @@ const scorecard = {
   case_min: t.case_min,
   case_failures: caseFailures,
   detection_misses: detectionMisses,
+  high_variance: highVariance,
   baseline_used: baselineUsed,
   regressions,
   scored_at: new Date().toISOString(),

--- a/.archon/scripts/eval-calibration-compare.ts
+++ b/.archon/scripts/eval-calibration-compare.ts
@@ -12,6 +12,8 @@ import { readFileSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 
+// FUTURE: derive DIMENSIONS from suite.json manifest instead of hardcoding
+// so the comparison auto-adapts when suite rubric evolves
 const DIMENSIONS = ["correctness", "completeness", "maintainability", "safety", "verification"] as const;
 type Dim = typeof DIMENSIONS[number];
 
@@ -22,7 +24,7 @@ interface DimScore {
 
 interface JudgeResult {
   case_id: string;
-  scores: Record<Dim, DimScore>;
+  scores: Partial<Record<Dim, DimScore>>;
 }
 
 interface HumanCase {

--- a/.archon/scripts/eval-calibration-compare.ts
+++ b/.archon/scripts/eval-calibration-compare.ts
@@ -1,0 +1,212 @@
+#!/usr/bin/env bun
+/**
+ * eval-calibration-compare.ts
+ * Compare judge results against human labels for the calibration suite.
+ *
+ * Usage: bun .archon/scripts/eval-calibration-compare.ts <path-to-results.json>
+ *
+ * results.json format: array of { case_id: string, scores: { [dim]: { score: number, rationale: string } } }
+ */
+
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const DIMENSIONS = ["correctness", "completeness", "maintainability", "safety", "verification"] as const;
+type Dim = typeof DIMENSIONS[number];
+
+interface DimScore {
+  score: number;
+  rationale: string;
+}
+
+interface JudgeResult {
+  case_id: string;
+  scores: Record<Dim, DimScore>;
+}
+
+interface HumanCase {
+  correctness: number;
+  completeness: number;
+  maintainability: number;
+  safety: number;
+  verification: number;
+  verdict: string;
+}
+
+interface HumanLabels {
+  labeled_by: string;
+  bar: Record<string, string>;
+  cases: Record<string, HumanCase>;
+}
+
+// Planted-defect catch checklist: [caseId, dimension, catchThreshold]
+const PLANTED_DEFECTS: [string, Dim, number][] = [
+  ["p1-plausible-but-wrong", "correctness", 2],
+  ["p2-vacuous-tests", "verification", 2],
+  ["p3-injectable-query", "safety", 2],
+  ["p4-happy-path-only", "completeness", 2],
+  ["p6-comment-lies", "safety", 2],
+  ["r1-real-math-untested", "verification", 2],
+  ["r3-real-eval-aggregate-script", "verification", 2],
+];
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    console.error("Usage: bun .archon/scripts/eval-calibration-compare.ts <path-to-results.json>");
+    process.exit(1);
+  }
+
+  const resultsPath = resolve(args[0]);
+  const labelsPath = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    "../evals/calibration/human-labels.json"
+  );
+
+  // Load human labels
+  let humanLabels: HumanLabels;
+  try {
+    humanLabels = JSON.parse(readFileSync(labelsPath, "utf-8"));
+  } catch (e) {
+    console.error(`Failed to read human labels from ${labelsPath}: ${(e as Error).message}`);
+    process.exit(1);
+  }
+
+  // Load judge results
+  let judgeResults: JudgeResult[];
+  try {
+    judgeResults = JSON.parse(readFileSync(resultsPath, "utf-8"));
+  } catch (e) {
+    console.error(`Failed to read judge results from ${resultsPath}: ${(e as Error).message}`);
+    process.exit(1);
+  }
+
+  // Index judge results by case_id
+  const judgeMap = new Map<string, JudgeResult>();
+  for (const r of judgeResults) {
+    judgeMap.set(r.case_id, r);
+  }
+
+  const humanCaseIds = Object.keys(humanLabels.cases);
+  const missedCases: string[] = [];
+  for (const caseId of humanCaseIds) {
+    if (!judgeMap.has(caseId)) {
+      missedCases.push(caseId);
+    }
+  }
+
+  // Compute agreement stats
+  let totalPairs = 0;
+  let agreedPairs = 0;
+  const dimAgreements: Record<Dim, { agreed: number; total: number; sumAbsDelta: number }> = {
+    correctness: { agreed: 0, total: 0, sumAbsDelta: 0 },
+    completeness: { agreed: 0, total: 0, sumAbsDelta: 0 },
+    maintainability: { agreed: 0, total: 0, sumAbsDelta: 0 },
+    safety: { agreed: 0, total: 0, sumAbsDelta: 0 },
+    verification: { agreed: 0, total: 0, sumAbsDelta: 0 },
+  };
+
+  interface Divergence {
+    caseId: string;
+    dim: Dim;
+    human: number;
+    judge: number;
+    delta: number;
+    rationale: string;
+  }
+  const divergences: Divergence[] = [];
+
+  for (const caseId of humanCaseIds) {
+    const humanCase = humanLabels.cases[caseId];
+    const judgeResult = judgeMap.get(caseId);
+    if (!judgeResult) continue;
+
+    for (const dim of DIMENSIONS) {
+      const humanScore = humanCase[dim];
+      const judgeScore = judgeResult.scores[dim]?.score;
+      if (judgeScore === undefined || judgeScore === null) continue;
+
+      const delta = judgeScore - humanScore;
+      const absDelta = Math.abs(delta);
+      const agree = absDelta <= 1;
+
+      totalPairs++;
+      if (agree) agreedPairs++;
+
+      dimAgreements[dim].total++;
+      dimAgreements[dim].sumAbsDelta += absDelta;
+      if (agree) dimAgreements[dim].agreed++;
+
+      if (absDelta >= 2) {
+        divergences.push({
+          caseId,
+          dim,
+          human: humanScore,
+          judge: judgeScore,
+          delta,
+          rationale: judgeResult.scores[dim]?.rationale ?? "(no rationale)",
+        });
+      }
+    }
+  }
+
+  // Print report
+  console.log("\n=== CALIBRATION COMPARISON REPORT ===");
+  console.log(`Human labels: ${labelsPath}`);
+  console.log(`Judge results: ${resultsPath}`);
+  console.log(`Labeled by: ${humanLabels.labeled_by}`);
+  console.log();
+
+  if (missedCases.length > 0) {
+    console.log(`WARNING: Judge did not score ${missedCases.length} labeled case(s):`);
+    for (const c of missedCases) console.log(`  - ${c}`);
+    console.log();
+  }
+
+  const overallPct = totalPairs > 0 ? ((agreedPairs / totalPairs) * 100).toFixed(1) : "N/A";
+  console.log(`Overall within-±1 agreement: ${agreedPairs}/${totalPairs} = ${overallPct}%`);
+  console.log();
+
+  console.log("Per-dimension agreement (within ±1) and MAE:");
+  for (const dim of DIMENSIONS) {
+    const d = dimAgreements[dim];
+    const pct = d.total > 0 ? ((d.agreed / d.total) * 100).toFixed(1) : "N/A";
+    const mae = d.total > 0 ? (d.sumAbsDelta / d.total).toFixed(2) : "N/A";
+    console.log(`  ${dim.padEnd(18)} agree=${pct}%  MAE=${mae}`);
+  }
+  console.log();
+
+  if (divergences.length > 0) {
+    console.log(`Large divergences (|delta| >= 2) — ${divergences.length} found:`);
+    for (const d of divergences) {
+      const sign = d.delta > 0 ? "+" : "";
+      console.log(`  [${d.caseId}] ${d.dim}: human=${d.human} judge=${d.judge} (${sign}${d.delta})`);
+      console.log(`    rationale: ${d.rationale}`);
+    }
+  } else {
+    console.log("No large divergences (|delta| >= 2) found.");
+  }
+  console.log();
+
+  // Planted-defect catch checklist
+  console.log("=== PLANTED-DEFECT CATCH CHECKLIST ===");
+  let caught = 0;
+  for (const [caseId, dim, threshold] of PLANTED_DEFECTS) {
+    const judgeResult = judgeMap.get(caseId);
+    const judgeScore = judgeResult?.scores[dim]?.score;
+    if (judgeScore === undefined || judgeScore === null) {
+      console.log(`  ${caseId} / ${dim} <= ${threshold}: MISSING (judge did not score this case)`);
+      continue;
+    }
+    const wasCaught = judgeScore <= threshold;
+    if (wasCaught) caught++;
+    const label = wasCaught ? "CAUGHT" : "MISSED";
+    console.log(`  ${caseId} / ${dim} <= ${threshold}: ${label} (judge=${judgeScore})`);
+  }
+  console.log();
+  console.log(`Judge caught ${caught}/${PLANTED_DEFECTS.length} planted defects.`);
+  console.log();
+}
+
+main();

--- a/.archon/scripts/eval-load-suite.ts
+++ b/.archon/scripts/eval-load-suite.ts
@@ -1,0 +1,63 @@
+#!/usr/bin/env bun
+/**
+ * Stages a standing-eval-suite run: validates the dataset exists and writes the
+ * list of case file paths to $ARTIFACTS_DIR/eval/queue.txt for the judge node.
+ *
+ * Named script (NOT inline): inline multi-line `script:` nodes are passed to
+ * `bun -e` as a single argv string, which truncates at the first newline on
+ * Windows — so anything non-trivial MUST be a named script run via `bun run`.
+ *
+ * Reads: process.cwd() (= the run's working_path), EVAL_SUITE (default "seed"),
+ *        ARTIFACTS_DIR (injected by the executor). Pure Node fs — bun cannot
+ *        resolve `yaml` from the checkout root, so anything bun touches is JSON;
+ *        the YAML case files are read by the AI judge natively.
+ * Output: JSON summary to stdout (captured as $load-suite.output).
+ */
+import { existsSync, readFileSync, readdirSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const suite = process.env.EVAL_SUITE || 'seed';
+const dir = join(process.cwd(), '.archon', 'evals', suite);
+const casesDir = join(dir, 'cases');
+const manifestPath = join(dir, 'suite.json');
+
+if (!existsSync(manifestPath)) {
+  console.error(`Eval suite manifest not found: ${manifestPath}`);
+  process.exit(1);
+}
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+
+const caseFiles = existsSync(casesDir)
+  ? readdirSync(casesDir)
+      .filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'))
+      .sort()
+  : [];
+if (caseFiles.length === 0) {
+  console.error(`No case files found in ${casesDir}`);
+  process.exit(1);
+}
+
+const art = process.env.ARTIFACTS_DIR;
+if (!art) {
+  console.error('ARTIFACTS_DIR not set; cannot stage eval run');
+  process.exit(1);
+}
+const evalDir = join(art, 'eval');
+mkdirSync(evalDir, { recursive: true });
+
+const queue = caseFiles.map((f) => join(casesDir, f));
+writeFileSync(join(evalDir, 'queue.txt'), queue.join('\n') + '\n');
+
+console.log(
+  JSON.stringify(
+    {
+      suite,
+      caseCount: caseFiles.length,
+      dimensions: manifest.dimensions,
+      resultsPath: join(evalDir, 'results.json'),
+      cases: caseFiles,
+    },
+    null,
+    2
+  )
+);

--- a/.archon/scripts/eval-portfolio.ts
+++ b/.archon/scripts/eval-portfolio.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env bun
+/**
+ * eval-portfolio — the one-command in-loop regression gate (manual entry point;
+ * /evolve invokes the same suites directly).
+ *
+ * Runs the standing-eval-suite workflow for each portfolio suite (golden, then
+ * regressions) and prints one combined PASS/FAIL summary. Exit 1 on any gate
+ * failure or detection miss.
+ *
+ * HONEST GUARDED SURFACE: this validates the VERIFIER layer — the judge workflow
+ * YAML, its rubric prompts, the eval scripts, suite.json weights/thresholds, and
+ * model-tier config. Run it BEFORE shipping a change to any of those. It does NOT
+ * exercise CLAUDE.md rules or agent checklists (see .archon/evals/recall/ for the
+ * memory-firing probes).
+ *
+ * Named script (NOT inline) — see eval-load-suite.ts for why.
+ * Usage: bun .archon/scripts/eval-portfolio.ts [suite ...]   (default: golden regressions)
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const suites = process.argv.slice(2).length > 0 ? process.argv.slice(2) : ['golden', 'regressions'];
+const historyPath = join(process.cwd(), '.archon', 'state', 'eval-history.jsonl');
+
+interface Scorecard {
+  suite: string;
+  gate: string;
+  votes?: number;
+  overall: number | null;
+  detection_misses?: Array<{ case_id: string }>;
+  regressions?: Array<{ dim: string }>;
+  scored_at: string;
+}
+
+function lastScorecard(suite: string): Scorecard | null {
+  if (!existsSync(historyPath)) return null;
+  const lines = readFileSync(historyPath, 'utf8').split(/\r?\n/).filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const sc = JSON.parse(lines[i]) as Scorecard;
+    if (sc.suite === suite) return sc;
+  }
+  return null;
+}
+
+let anyFail = false;
+const results: string[] = [];
+for (const suite of suites) {
+  const suiteDir = join(process.cwd(), '.archon', 'evals', suite);
+  if (!existsSync(join(suiteDir, 'suite.json'))) {
+    console.error(`[portfolio] suite "${suite}" not found at ${suiteDir} — failing loudly.`);
+    process.exit(1);
+  }
+  const before = lastScorecard(suite)?.scored_at;
+  console.log(`[portfolio] running suite: ${suite} ...`);
+  const run = spawnSync('bun', ['run', 'cli', 'workflow', 'run', 'standing-eval-suite'], {
+    env: { ...process.env, EVAL_SUITE: suite },
+    stdio: ['ignore', 'inherit', 'inherit'],
+    shell: process.platform === 'win32',
+  });
+  const sc = lastScorecard(suite);
+  if (run.status !== 0 || !sc || sc.scored_at === before) {
+    console.error(`[portfolio] ${suite}: workflow failed or produced no new scorecard — gate FAILS.`);
+    process.exit(1);
+  }
+  const misses = sc.detection_misses?.length ?? 0;
+  const regs = sc.regressions?.length ?? 0;
+  const line = `${suite}: ${sc.gate} (votes=${sc.votes ?? 1}, overall=${sc.overall ?? 'n/a'}, detection_misses=${misses}, regressions=${regs})`;
+  results.push(line);
+  if (sc.gate !== 'PASS') anyFail = true;
+}
+
+console.log('\n=== PORTFOLIO GATE ===');
+for (const r of results) console.log(r);
+console.log(anyFail ? 'PORTFOLIO: FAIL' : 'PORTFOLIO: PASS');
+process.exit(anyFail ? 1 : 0);

--- a/.archon/scripts/eval-portfolio.ts
+++ b/.archon/scripts/eval-portfolio.ts
@@ -37,8 +37,13 @@ function lastScorecard(suite: string): Scorecard | null {
   if (!existsSync(historyPath)) return null;
   const lines = readFileSync(historyPath, 'utf8').split(/\r?\n/).filter(Boolean);
   for (let i = lines.length - 1; i >= 0; i--) {
-    const sc = JSON.parse(lines[i]) as Scorecard;
-    if (sc.suite === suite) return sc;
+    try {
+      const sc = JSON.parse(lines[i]) as Scorecard;
+      if (sc.suite === suite) return sc;
+    } catch {
+      // Skip malformed lines; continue searching for valid history
+      continue;
+    }
   }
   return null;
 }

--- a/.archon/scripts/recall-probe.ts
+++ b/.archon/scripts/recall-probe.ts
@@ -58,6 +58,9 @@ function probeOnce(c: RecallCase, runIdx: number): { fired: boolean; detail: str
     if ((c.fixture || []).some((fx) => fx.path === 'init.sh')) {
       spawnSync('bash', ['init.sh'], { cwd: dir, timeout: 30000 });
     }
+    // NOTE: shell: true on Windows is safe here because c.task is loaded from
+    // repo-controlled JSON fixtures (.archon/evals/recall/cases/*.json), not dynamic input.
+    // If task input becomes user-controlled, disable shell and escape arguments.
     const res = spawnSync(
       'claude',
       [

--- a/.archon/scripts/recall-probe.ts
+++ b/.archon/scripts/recall-probe.ts
@@ -17,7 +17,7 @@
  */
 import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync, writeFileSync, mkdirSync, appendFileSync, rmSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname, resolve, sep } from 'node:path';
 import { tmpdir } from 'node:os';
 
 interface RecallCase {
@@ -46,17 +46,33 @@ if (cases.length === 0) {
 }
 if (runs === 1) console.log('[recall] RECALL_RUNS=1 — one run is a smoke, NOT calibration.');
 
+// JS RegExp has no PCRE-style inline flag group like (?i); translate a leading
+// one (e.g. (?i), (?im)) into the flags argument. The harness always wants 'm'.
+function compileProbe(pattern: string): RegExp {
+  const m = pattern.match(/^\(\?([imsuy]+)\)/);
+  const flags = [...new Set('m' + (m ? m[1] : ''))].join('');
+  return new RegExp(m ? pattern.slice(m[0].length) : pattern, flags);
+}
+
 function probeOnce(c: RecallCase, runIdx: number): { fired: boolean; detail: string } {
   const dir = join(tmpdir(), 'recall-probe', `${c.id}-${Date.now()}-${runIdx}`);
   mkdirSync(dir, { recursive: true });
   try {
     for (const fx of c.fixture || []) {
       const p = join(dir, fx.path);
+      const resolved = resolve(p);
+      if (resolved !== resolve(dir) && !resolved.startsWith(resolve(dir) + sep)) {
+        console.error(`recall case "${c.id}" fixture path escapes the sandbox: ${fx.path}`);
+        process.exit(1);
+      }
       mkdirSync(dirname(p), { recursive: true });
       writeFileSync(p, fx.content);
     }
     if ((c.fixture || []).some((fx) => fx.path === 'init.sh')) {
-      spawnSync('bash', ['init.sh'], { cwd: dir, timeout: 30000 });
+      const initRes = spawnSync('bash', ['init.sh'], { cwd: dir, timeout: 30000, encoding: 'utf8' });
+      if (initRes.error || initRes.status !== 0) {
+        return { fired: false, detail: `init.sh failed (exit ${initRes.status}${initRes.error ? `, ${initRes.error.message}` : ''}) — fixture broken, not a memory-recall signal` };
+      }
     }
     // NOTE: shell: true on Windows is safe here because c.task is loaded from
     // repo-controlled JSON fixtures (.archon/evals/recall/cases/*.json), not dynamic input.
@@ -74,11 +90,17 @@ function probeOnce(c: RecallCase, runIdx: number): { fired: boolean; detail: str
       { cwd: dir, timeout: 300000, encoding: 'utf8', shell: process.platform === 'win32' },
     );
     const transcript = `${res.stdout || ''}\n${res.stderr || ''}`;
-    if (res.status !== 0 && !transcript.trim()) {
-      return { fired: false, detail: `session error (exit ${res.status})` };
+    if (res.error) {
+      return { fired: false, detail: `session failed to run: ${res.error.message}` };
     }
-    const missing = c.evidence.filter((e) => !new RegExp(e, 'm').test(transcript));
-    const violated = c.forbidden.filter((f) => new RegExp(f, 'm').test(transcript));
+    if (res.status !== 0) {
+      // A session that errored (rate limit, crash, timeout) after emitting partial
+      // stream-json must not be scored on that truncated output — it is not a
+      // valid recall data point.
+      return { fired: false, detail: `session error (exit ${res.status})${transcript.trim() ? ' — partial output discarded' : ''}` };
+    }
+    const missing = c.evidence.filter((e) => !compileProbe(e).test(transcript));
+    const violated = c.forbidden.filter((f) => compileProbe(f).test(transcript));
     if (violated.length > 0) return { fired: false, detail: `forbidden matched: ${violated[0]}` };
     if (missing.length > 0) return { fired: false, detail: `evidence missing: ${missing[0]}` };
     return { fired: true, detail: 'ok' };

--- a/.archon/scripts/recall-probe.ts
+++ b/.archon/scripts/recall-probe.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env bun
+/**
+ * recall-probe — memory-firing measurement (.archon/evals/recall/).
+ *
+ * For each case: create a throwaway fixture dir, spawn a FRESH headless
+ * `claude -p` session (sonnet tier) with the planted task, and grep the full
+ * stream-json transcript for binary evidence that the target memory's rule was
+ * APPLIED. fired iff every `evidence` regex matches AND no `forbidden` regex
+ * matches. N runs per case (RECALL_RUNS, default 3 — n=1 is not calibration).
+ *
+ * A low firing rate is a FINDING about the memory's description/index hook —
+ * fix the memory, never soften the evidence regexes.
+ *
+ * Named script (NOT inline) — see eval-load-suite.ts for why. Dep-free: cases
+ * are JSON (this harness has no AI judge reading them, so YAML buys nothing).
+ * Usage: bun .archon/scripts/recall-probe.ts [case-id ...]
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync, writeFileSync, mkdirSync, appendFileSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+
+interface RecallCase {
+  id: string;
+  memory: string;
+  task: string;
+  fixture?: Array<{ path: string; content: string }>;
+  evidence: string[];
+  forbidden: string[];
+}
+
+const casesDir = join(process.cwd(), '.archon', 'evals', 'recall', 'cases');
+if (!existsSync(casesDir)) {
+  console.error(`recall cases dir not found: ${casesDir}`);
+  process.exit(1);
+}
+const runs = Math.max(1, Number(process.env.RECALL_RUNS || 3));
+const filterIds = process.argv.slice(2);
+const caseFiles = readdirSync(casesDir).filter((f) => f.endsWith('.json')).sort();
+const cases: RecallCase[] = caseFiles
+  .map((f) => JSON.parse(readFileSync(join(casesDir, f), 'utf8')) as RecallCase)
+  .filter((c) => filterIds.length === 0 || filterIds.includes(c.id));
+if (cases.length === 0) {
+  console.error(`no recall cases matched ${filterIds.join(', ') || '(all)'}`);
+  process.exit(1);
+}
+if (runs === 1) console.log('[recall] RECALL_RUNS=1 — one run is a smoke, NOT calibration.');
+
+function probeOnce(c: RecallCase, runIdx: number): { fired: boolean; detail: string } {
+  const dir = join(tmpdir(), 'recall-probe', `${c.id}-${Date.now()}-${runIdx}`);
+  mkdirSync(dir, { recursive: true });
+  try {
+    for (const fx of c.fixture || []) {
+      const p = join(dir, fx.path);
+      mkdirSync(dirname(p), { recursive: true });
+      writeFileSync(p, fx.content);
+    }
+    if ((c.fixture || []).some((fx) => fx.path === 'init.sh')) {
+      spawnSync('bash', ['init.sh'], { cwd: dir, timeout: 30000 });
+    }
+    const res = spawnSync(
+      'claude',
+      [
+        '-p', c.task,
+        '--model', 'sonnet',
+        '--output-format', 'stream-json',
+        '--verbose',
+        '--max-turns', '12',
+        '--allowedTools', 'Bash,Read,Write,Edit,Glob,Grep',
+      ],
+      { cwd: dir, timeout: 300000, encoding: 'utf8', shell: process.platform === 'win32' },
+    );
+    const transcript = `${res.stdout || ''}\n${res.stderr || ''}`;
+    if (res.status !== 0 && !transcript.trim()) {
+      return { fired: false, detail: `session error (exit ${res.status})` };
+    }
+    const missing = c.evidence.filter((e) => !new RegExp(e, 'm').test(transcript));
+    const violated = c.forbidden.filter((f) => new RegExp(f, 'm').test(transcript));
+    if (violated.length > 0) return { fired: false, detail: `forbidden matched: ${violated[0]}` };
+    if (missing.length > 0) return { fired: false, detail: `evidence missing: ${missing[0]}` };
+    return { fired: true, detail: 'ok' };
+  } finally {
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort cleanup */ }
+  }
+}
+
+const report: Array<{ id: string; memory: string; fired: number; runs: number; details: string[] }> = [];
+for (const c of cases) {
+  const details: string[] = [];
+  let fired = 0;
+  for (let i = 1; i <= runs; i++) {
+    console.log(`[recall] ${c.id} run ${i}/${runs} ...`);
+    const r = probeOnce(c, i);
+    if (r.fired) fired++;
+    details.push(r.detail);
+    console.log(`[recall]   -> ${r.fired ? 'FIRED' : 'not fired'} (${r.detail})`);
+  }
+  report.push({ id: c.id, memory: c.memory, fired, runs, details });
+}
+
+const summary = {
+  probed_at: new Date().toISOString(),
+  runs_per_case: runs,
+  cases: report.map((r) => ({ id: r.id, memory: r.memory, firing_rate: `${r.fired}/${r.runs}` })),
+};
+const stateDir = join(process.cwd(), '.archon', 'state');
+mkdirSync(stateDir, { recursive: true });
+appendFileSync(join(stateDir, 'recall-history.jsonl'), JSON.stringify(summary) + '\n');
+
+console.log('\n=== RECALL FIRING RATES ===');
+for (const r of report) console.log(`${r.id}  ${r.fired}/${r.runs}  (${r.memory})`);

--- a/.archon/scripts/recall-probe.ts
+++ b/.archon/scripts/recall-probe.ts
@@ -69,25 +69,42 @@ function probeOnce(c: RecallCase, runIdx: number): { fired: boolean; detail: str
       writeFileSync(p, fx.content);
     }
     if ((c.fixture || []).some((fx) => fx.path === 'init.sh')) {
-      const initRes = spawnSync('bash', ['init.sh'], { cwd: dir, timeout: 30000, encoding: 'utf8' });
+      // Provide a git identity so a fixture `git commit` doesn't fail 128 in a
+      // throwaway dir with no configured user.name/user.email.
+      const initRes = spawnSync('bash', ['init.sh'], {
+        cwd: dir,
+        timeout: 30000,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          GIT_AUTHOR_NAME: 'archon-eval',
+          GIT_AUTHOR_EMAIL: 'eval@archon.local',
+          GIT_COMMITTER_NAME: 'archon-eval',
+          GIT_COMMITTER_EMAIL: 'eval@archon.local',
+        },
+      });
       if (initRes.error || initRes.status !== 0) {
-        return { fired: false, detail: `init.sh failed (exit ${initRes.status}${initRes.error ? `, ${initRes.error.message}` : ''}) — fixture broken, not a memory-recall signal` };
+        const lastErr = (initRes.stderr || '').trim().split('\n').pop() || '';
+        return { fired: false, detail: `init.sh failed (exit ${initRes.status}${initRes.error ? `, ${initRes.error.message}` : ''}${lastErr ? `: ${lastErr}` : ''}) — fixture broken, not a memory-recall signal` };
       }
     }
-    // NOTE: shell: true on Windows is safe here because c.task is loaded from
-    // repo-controlled JSON fixtures (.archon/evals/recall/cases/*.json), not dynamic input.
-    // If task input becomes user-controlled, disable shell and escape arguments.
+    // The prompt is passed via STDIN, not as an argv element. On Windows `claude`
+    // resolves to claude.cmd, which Node can only spawn with shell:true — and
+    // shell:true does NOT quote argv, so a multi-word `-p <task>` gets split at
+    // spaces (the prompt is truncated to its first word, silently mismeasuring
+    // recall). `claude -p` with no inline prompt reads the prompt from stdin; the
+    // remaining flags contain no spaces, so they survive shell:true intact.
     const res = spawnSync(
       'claude',
       [
-        '-p', c.task,
+        '-p',
         '--model', 'sonnet',
         '--output-format', 'stream-json',
         '--verbose',
         '--max-turns', '12',
         '--allowedTools', 'Bash,Read,Write,Edit,Glob,Grep',
       ],
-      { cwd: dir, timeout: 300000, encoding: 'utf8', shell: process.platform === 'win32' },
+      { cwd: dir, input: c.task, timeout: 300000, encoding: 'utf8', shell: process.platform === 'win32' },
     );
     const transcript = `${res.stdout || ''}\n${res.stderr || ''}`;
     if (res.error) {

--- a/.archon/workflows/experimental/standing-eval-suite.yaml
+++ b/.archon/workflows/experimental/standing-eval-suite.yaml
@@ -17,12 +17,25 @@ description: |
   (`candidate:`). Read-only — never edits the repo. Deterministic aggregation;
   the LLM judge only scores 1-5 per dimension.
 
+  N-VOTE JUDGING (added 2026-07-06, roadmap A4): three independent fresh-context
+  judge votes (score-1/2/3, identical prompts, only the output filename differs);
+  the aggregate takes the per-case-per-dimension MEDIAN. De-flakes the ±1
+  single-vote wobble that made tiny-suite baselines throw false regressions.
+
+  DETECTION SEMANTICS (added 2026-07-06, roadmap A3): a suite MAY carry a
+  `labels.json` next to suite.json — failure-derived cases whose `candidate:` is
+  an escaped DEFECT. For those, the gate INVERTS: the median score on the labelled
+  trap dimension must be <= max_score (the judge must CATCH the defect), and
+  labelled cases are excluded from the mean/threshold math. Labels live OUTSIDE
+  the case YAMLs so the judge stays blind. See .archon/evals/README.md.
+
   NOT YET (v2): regenerating candidates by invoking a target workflow per case
   (needs worktree isolation), per-case fan-out via a loop node for large suites,
-  N-vote judging, and an `eval add-case` flywheel helper.
+  and an `eval add-case` flywheel helper (the manual recipe is in /evolve).
 
   Model routing (the paper's "routing as a financial lever"): scoring uses the
-  `medium` tier; the readable verdict uses `small`; load + aggregate use no model.
+  `medium` tier ×3 votes; the readable verdict uses `small`; load + aggregate use
+  no model. Cost per run: 3 medium + 1 small call regardless of suite size.
 
   IMPLEMENTATION NOTE: the two deterministic nodes are NAMED scripts
   (.archon/scripts/eval-*.ts), not inline `script: |` bodies. Inline multi-line
@@ -46,14 +59,18 @@ nodes:
     runtime: bun
     timeout: 30000
 
-  # ─── 2. SCORE CASES (reasoning judge) ─────────────────────────────────
-  # One judge pass over the whole (small) dataset. v2 replaces this with a
+  # ─── 2. SCORE CASES — 3 INDEPENDENT VOTES (reasoning judge ×3) ────────
+  # Three fresh-context votes with IDENTICAL prompts (only the output filename
+  # differs); they run concurrently (same topological layer). The aggregate takes
+  # the per-case-per-dimension median. Blindness is MANDATED, not hoped-for
+  # (read-scope restricted to queue.txt files; no Bash), so suite-dir labels/
+  # baselines can't leak into scoring. v2 replaces the whole-suite pass with a
   # loop: node (one fresh-context iteration per case) for large suites.
-  - id: score-cases
+  - id: score-1
     depends_on: [load-suite]
     model: medium
     context: fresh
-    allowed_tools: [Read, Write, Bash]
+    allowed_tools: [Read, Write]
     prompt: |
       You are a strict eval JUDGE. Score each labelled case on a fixed 5-dimension
       rubric. Be conservative: when evidence for a dimension is absent, score it
@@ -62,6 +79,8 @@ nodes:
       ## Where the cases are
       The file `$ARTIFACTS_DIR/eval/queue.txt` contains one absolute path per line,
       each pointing at a YAML case file. Read that list, then Read EVERY case file.
+      Read ONLY queue.txt and the case files it lists — do NOT read labels.json,
+      human-labels.json, baseline.json, suite.json, or any other file.
       Each case has: `id`, `task` (the spec), `candidate` (the work under test),
       and `reference` (what a correct/strong solution looks like).
 
@@ -77,7 +96,103 @@ nodes:
       rationale per dimension grounded in what the candidate actually contains.
 
       ## Output (REQUIRED)
-      Write a single JSON ARRAY to `$ARTIFACTS_DIR/eval/results.json` using the
+      Write a single JSON ARRAY to `$ARTIFACTS_DIR/eval/results-1.json` using the
+      Write tool — one object per case, in this exact shape:
+      [
+        {
+          "case_id": "<the case id>",
+          "scores": {
+            "correctness":    { "score": 1, "rationale": "..." },
+            "completeness":   { "score": 1, "rationale": "..." },
+            "maintainability":{ "score": 1, "rationale": "..." },
+            "safety":         { "score": 1, "rationale": "..." },
+            "verification":   { "score": 1, "rationale": "..." }
+          }
+        }
+      ]
+      Include EVERY case from the queue exactly once. Valid JSON only (no comments,
+      no trailing commas). After writing, reply with a one-line confirmation of how
+      many cases you scored.
+
+  - id: score-2
+    depends_on: [load-suite]
+    model: medium
+    context: fresh
+    allowed_tools: [Read, Write]
+    prompt: |
+      You are a strict eval JUDGE. Score each labelled case on a fixed 5-dimension
+      rubric. Be conservative: when evidence for a dimension is absent, score it
+      LOW — "set the bar at the eval, not the demo." Do NOT edit any repo files.
+
+      ## Where the cases are
+      The file `$ARTIFACTS_DIR/eval/queue.txt` contains one absolute path per line,
+      each pointing at a YAML case file. Read that list, then Read EVERY case file.
+      Read ONLY queue.txt and the case files it lists — do NOT read labels.json,
+      human-labels.json, baseline.json, suite.json, or any other file.
+      Each case has: `id`, `task` (the spec), `candidate` (the work under test),
+      and `reference` (what a correct/strong solution looks like).
+
+      ## The 5 dimensions (score each 1-5: 5 = excellent, 1 = absent/broken)
+      - correctness    — does the candidate actually satisfy the task?
+      - completeness    — are ALL acceptance criteria met, not just the happy path?
+      - maintainability — clarity, structure, fit with conventions.
+      - safety          — input validation, error handling, secrets/auth/shell/SQL/paths.
+      - verification    — were tests/checks ACTUALLY present for the new behavior?
+                          New/changed behavior with no tests scores LOW here.
+
+      Judge the candidate against the reference and the task. Give a one-line
+      rationale per dimension grounded in what the candidate actually contains.
+
+      ## Output (REQUIRED)
+      Write a single JSON ARRAY to `$ARTIFACTS_DIR/eval/results-2.json` using the
+      Write tool — one object per case, in this exact shape:
+      [
+        {
+          "case_id": "<the case id>",
+          "scores": {
+            "correctness":    { "score": 1, "rationale": "..." },
+            "completeness":   { "score": 1, "rationale": "..." },
+            "maintainability":{ "score": 1, "rationale": "..." },
+            "safety":         { "score": 1, "rationale": "..." },
+            "verification":   { "score": 1, "rationale": "..." }
+          }
+        }
+      ]
+      Include EVERY case from the queue exactly once. Valid JSON only (no comments,
+      no trailing commas). After writing, reply with a one-line confirmation of how
+      many cases you scored.
+
+  - id: score-3
+    depends_on: [load-suite]
+    model: medium
+    context: fresh
+    allowed_tools: [Read, Write]
+    prompt: |
+      You are a strict eval JUDGE. Score each labelled case on a fixed 5-dimension
+      rubric. Be conservative: when evidence for a dimension is absent, score it
+      LOW — "set the bar at the eval, not the demo." Do NOT edit any repo files.
+
+      ## Where the cases are
+      The file `$ARTIFACTS_DIR/eval/queue.txt` contains one absolute path per line,
+      each pointing at a YAML case file. Read that list, then Read EVERY case file.
+      Read ONLY queue.txt and the case files it lists — do NOT read labels.json,
+      human-labels.json, baseline.json, suite.json, or any other file.
+      Each case has: `id`, `task` (the spec), `candidate` (the work under test),
+      and `reference` (what a correct/strong solution looks like).
+
+      ## The 5 dimensions (score each 1-5: 5 = excellent, 1 = absent/broken)
+      - correctness    — does the candidate actually satisfy the task?
+      - completeness    — are ALL acceptance criteria met, not just the happy path?
+      - maintainability — clarity, structure, fit with conventions.
+      - safety          — input validation, error handling, secrets/auth/shell/SQL/paths.
+      - verification    — were tests/checks ACTUALLY present for the new behavior?
+                          New/changed behavior with no tests scores LOW here.
+
+      Judge the candidate against the reference and the task. Give a one-line
+      rationale per dimension grounded in what the candidate actually contains.
+
+      ## Output (REQUIRED)
+      Write a single JSON ARRAY to `$ARTIFACTS_DIR/eval/results-3.json` using the
       Write tool — one object per case, in this exact shape:
       [
         {
@@ -96,9 +211,11 @@ nodes:
       many cases you scored.
 
   # ─── 3. AGGREGATE (deterministic gate, no AI) ─────────────────────────
-  # The authoritative gate. Pure JSON math + scorecard + trend line.
+  # The authoritative gate. Median-of-3 per case per dimension, queue-identity
+  # check (every queued case scored exactly once per vote), optional labels.json
+  # detection gate, thresholds, baseline regression. Pure JSON math.
   - id: aggregate
-    depends_on: [score-cases]
+    depends_on: [score-1, score-2, score-3]
     script: eval-aggregate
     runtime: bun
     timeout: 30000

--- a/.archon/workflows/experimental/standing-eval-suite.yaml
+++ b/.archon/workflows/experimental/standing-eval-suite.yaml
@@ -91,6 +91,12 @@ nodes:
       - safety          — input validation, error handling, secrets/auth/shell/SQL/paths.
       - verification    — were tests/checks ACTUALLY present for the new behavior?
                           New/changed behavior with no tests scores LOW here.
+                          MANDATORY inspection: read any check/CI script the
+                          candidate claims (package.json scripts, shell steps). A
+                          "check" that does not execute real tooling — echo/no-op
+                          stubs, commands whose exit code cannot reflect the
+                          code's state — is NOT verification: treat it as absent
+                          (score 1-2) no matter how real the unit tests are.
 
       Judge the candidate against the reference and the task. Give a one-line
       rationale per dimension grounded in what the candidate actually contains.
@@ -139,6 +145,12 @@ nodes:
       - safety          — input validation, error handling, secrets/auth/shell/SQL/paths.
       - verification    — were tests/checks ACTUALLY present for the new behavior?
                           New/changed behavior with no tests scores LOW here.
+                          MANDATORY inspection: read any check/CI script the
+                          candidate claims (package.json scripts, shell steps). A
+                          "check" that does not execute real tooling — echo/no-op
+                          stubs, commands whose exit code cannot reflect the
+                          code's state — is NOT verification: treat it as absent
+                          (score 1-2) no matter how real the unit tests are.
 
       Judge the candidate against the reference and the task. Give a one-line
       rationale per dimension grounded in what the candidate actually contains.
@@ -187,6 +199,12 @@ nodes:
       - safety          — input validation, error handling, secrets/auth/shell/SQL/paths.
       - verification    — were tests/checks ACTUALLY present for the new behavior?
                           New/changed behavior with no tests scores LOW here.
+                          MANDATORY inspection: read any check/CI script the
+                          candidate claims (package.json scripts, shell steps). A
+                          "check" that does not execute real tooling — echo/no-op
+                          stubs, commands whose exit code cannot reflect the
+                          code's state — is NOT verification: treat it as absent
+                          (score 1-2) no matter how real the unit tests are.
 
       Judge the candidate against the reference and the task. Give a one-line
       rationale per dimension grounded in what the candidate actually contains.

--- a/.archon/workflows/experimental/standing-eval-suite.yaml
+++ b/.archon/workflows/experimental/standing-eval-suite.yaml
@@ -126,8 +126,13 @@ nodes:
         }
       ]
       Include EVERY case from the queue exactly once. Valid JSON only (no comments,
-      no trailing commas). After writing, reply with a one-line confirmation of how
-      many cases you scored.
+      no trailing commas).
+      **CRITICAL: When writing JSON strings that contain backslashes, quotes, or
+      special characters (from code examples, regex patterns, etc.), escape them
+      properly: backslash becomes \\, quote becomes \", newline becomes \n, etc.
+      Your rationale text will contain code/regex examples — ensure all special
+      characters are JSON-escaped. Use JSON.stringify() semantics.**
+      After writing, reply with a one-line confirmation of how many cases you scored.
 
   - id: score-2
     depends_on: [load-suite]
@@ -185,8 +190,13 @@ nodes:
         }
       ]
       Include EVERY case from the queue exactly once. Valid JSON only (no comments,
-      no trailing commas). After writing, reply with a one-line confirmation of how
-      many cases you scored.
+      no trailing commas).
+      **CRITICAL: When writing JSON strings that contain backslashes, quotes, or
+      special characters (from code examples, regex patterns, etc.), escape them
+      properly: backslash becomes \\, quote becomes \", newline becomes \n, etc.
+      Your rationale text will contain code/regex examples — ensure all special
+      characters are JSON-escaped. Use JSON.stringify() semantics.**
+      After writing, reply with a one-line confirmation of how many cases you scored.
 
   - id: score-3
     depends_on: [load-suite]
@@ -244,8 +254,13 @@ nodes:
         }
       ]
       Include EVERY case from the queue exactly once. Valid JSON only (no comments,
-      no trailing commas). After writing, reply with a one-line confirmation of how
-      many cases you scored.
+      no trailing commas).
+      **CRITICAL: When writing JSON strings that contain backslashes, quotes, or
+      special characters (from code examples, regex patterns, etc.), escape them
+      properly: backslash becomes \\, quote becomes \", newline becomes \n, etc.
+      Your rationale text will contain code/regex examples — ensure all special
+      characters are JSON-escaped. Use JSON.stringify() semantics.**
+      After writing, reply with a one-line confirmation of how many cases you scored.
 
   # ─── 3. AGGREGATE (deterministic gate, no AI) ─────────────────────────
   # The authoritative gate. Median-of-3 per case per dimension, queue-identity

--- a/.archon/workflows/experimental/standing-eval-suite.yaml
+++ b/.archon/workflows/experimental/standing-eval-suite.yaml
@@ -1,0 +1,132 @@
+name: standing-eval-suite
+description: |
+  EXPERIMENTAL: the "standing eval suite" right-edge of the vibe-coding SDLC
+  (companion to agentic-eval-gate, which is one-shot-diff only). Scores a curated,
+  version-controlled set of LABELLED cases against a 5-dimension rubric, aggregates
+  deterministically, compares to a committed baseline, and gates — so quality is
+  measured over TIME, not per-change. This is "evals are the new tests" + the
+  quality flywheel: when something escapes the gate, add a case and it can never
+  regress silently again.
+
+  Dataset lives at `.archon/evals/<suite>/`:
+    suite.json      — rubric dims + weights + thresholds (+ optional baseline.json)
+    cases/*.yaml    — one labelled case each (task / candidate / reference)
+  Select a suite with the EVAL_SUITE env var (default: seed).
+
+  v1 SCOPE (this file): scores PRE-SUPPLIED candidates carried in each case
+  (`candidate:`). Read-only — never edits the repo. Deterministic aggregation;
+  the LLM judge only scores 1-5 per dimension.
+
+  NOT YET (v2): regenerating candidates by invoking a target workflow per case
+  (needs worktree isolation), per-case fan-out via a loop node for large suites,
+  N-vote judging, and an `eval add-case` flywheel helper.
+
+  Model routing (the paper's "routing as a financial lever"): scoring uses the
+  `medium` tier; the readable verdict uses `small`; load + aggregate use no model.
+
+  IMPLEMENTATION NOTE: the two deterministic nodes are NAMED scripts
+  (.archon/scripts/eval-*.ts), not inline `script: |` bodies. Inline multi-line
+  scripts are passed to `bun -e` as one argv string and truncate at the first
+  newline on Windows — named scripts run via `bun run <file>` and are safe.
+
+tags: [eval, suite, regression, agentic-engineering, sdlc]
+provider: claude
+mutates_checkout: false
+# Read the operator's LIVE checkout (where .archon/evals/<suite> lives), not an
+# isolated empty worktree. No $BASE_BRANCH / base tokens anywhere (not even in
+# comments) — they force eager base resolution that hard-fails on no-origin repos.
+worktree:
+  enabled: false
+
+nodes:
+  # ─── 1. LOAD SUITE (deterministic, no AI) ─────────────────────────────
+  # Validates the dataset exists and writes the case-path queue for the judge.
+  - id: load-suite
+    script: eval-load-suite
+    runtime: bun
+    timeout: 30000
+
+  # ─── 2. SCORE CASES (reasoning judge) ─────────────────────────────────
+  # One judge pass over the whole (small) dataset. v2 replaces this with a
+  # loop: node (one fresh-context iteration per case) for large suites.
+  - id: score-cases
+    depends_on: [load-suite]
+    model: medium
+    context: fresh
+    allowed_tools: [Read, Write, Bash]
+    prompt: |
+      You are a strict eval JUDGE. Score each labelled case on a fixed 5-dimension
+      rubric. Be conservative: when evidence for a dimension is absent, score it
+      LOW — "set the bar at the eval, not the demo." Do NOT edit any repo files.
+
+      ## Where the cases are
+      The file `$ARTIFACTS_DIR/eval/queue.txt` contains one absolute path per line,
+      each pointing at a YAML case file. Read that list, then Read EVERY case file.
+      Each case has: `id`, `task` (the spec), `candidate` (the work under test),
+      and `reference` (what a correct/strong solution looks like).
+
+      ## The 5 dimensions (score each 1-5: 5 = excellent, 1 = absent/broken)
+      - correctness    — does the candidate actually satisfy the task?
+      - completeness    — are ALL acceptance criteria met, not just the happy path?
+      - maintainability — clarity, structure, fit with conventions.
+      - safety          — input validation, error handling, secrets/auth/shell/SQL/paths.
+      - verification    — were tests/checks ACTUALLY present for the new behavior?
+                          New/changed behavior with no tests scores LOW here.
+
+      Judge the candidate against the reference and the task. Give a one-line
+      rationale per dimension grounded in what the candidate actually contains.
+
+      ## Output (REQUIRED)
+      Write a single JSON ARRAY to `$ARTIFACTS_DIR/eval/results.json` using the
+      Write tool — one object per case, in this exact shape:
+      [
+        {
+          "case_id": "<the case id>",
+          "scores": {
+            "correctness":    { "score": 1, "rationale": "..." },
+            "completeness":   { "score": 1, "rationale": "..." },
+            "maintainability":{ "score": 1, "rationale": "..." },
+            "safety":         { "score": 1, "rationale": "..." },
+            "verification":   { "score": 1, "rationale": "..." }
+          }
+        }
+      ]
+      Include EVERY case from the queue exactly once. Valid JSON only (no comments,
+      no trailing commas). After writing, reply with a one-line confirmation of how
+      many cases you scored.
+
+  # ─── 3. AGGREGATE (deterministic gate, no AI) ─────────────────────────
+  # The authoritative gate. Pure JSON math + scorecard + trend line.
+  - id: aggregate
+    depends_on: [score-cases]
+    script: eval-aggregate
+    runtime: bun
+    timeout: 30000
+
+  # ─── 4. VERDICT (cheap readable synthesis) ────────────────────────────
+  # The aggregate node already decided the gate. This only narrates it for humans.
+  - id: verdict
+    depends_on: [aggregate]
+    model: small
+    context: fresh
+    allowed_tools: []
+    prompt: |
+      The deterministic scorecard below already contains the AUTHORITATIVE gate
+      decision. Restate it for a human — do NOT recompute or override it. If the
+      gate is FAIL, lead with the concrete blocking reasons (dimension-floor
+      failures, per-case failures, regressions).
+
+      ## Scorecard
+      $aggregate.output
+    output_format:
+      type: object
+      properties:
+        gate:
+          type: string
+          enum: [PASS, FAIL]
+        overall: { type: number }
+        blocking:
+          type: array
+          items: { type: string }
+        summary: { type: string }
+      required: [gate, summary]

--- a/.archon/workflows/experimental/standing-eval-suite.yaml
+++ b/.archon/workflows/experimental/standing-eval-suite.yaml
@@ -96,8 +96,15 @@ nodes:
       ## The 5 dimensions (score each 1-5: 5 = excellent, 1 = absent/broken)
       - correctness    — does the candidate actually satisfy the task?
       - completeness    — are ALL acceptance criteria met, not just the happy path?
+                          SCOPE: judge against the acceptance criteria stated in
+                          the case's task, not against features the task never
+                          asked for.
       - maintainability — clarity, structure, fit with conventions.
       - safety          — input validation, error handling, secrets/auth/shell/SQL/paths.
+                          SCOPE: for a candidate with no external/user inputs,
+                          judge on error handling and unsafe operations actually
+                          present, not on the absence of input validation it had
+                          no occasion to need.
       - verification    — were tests/checks ACTUALLY present for the new behavior?
                           New/changed behavior with no tests scores LOW here.
                           MANDATORY inspection: read any check/CI script the
@@ -160,8 +167,15 @@ nodes:
       ## The 5 dimensions (score each 1-5: 5 = excellent, 1 = absent/broken)
       - correctness    — does the candidate actually satisfy the task?
       - completeness    — are ALL acceptance criteria met, not just the happy path?
+                          SCOPE: judge against the acceptance criteria stated in
+                          the case's task, not against features the task never
+                          asked for.
       - maintainability — clarity, structure, fit with conventions.
       - safety          — input validation, error handling, secrets/auth/shell/SQL/paths.
+                          SCOPE: for a candidate with no external/user inputs,
+                          judge on error handling and unsafe operations actually
+                          present, not on the absence of input validation it had
+                          no occasion to need.
       - verification    — were tests/checks ACTUALLY present for the new behavior?
                           New/changed behavior with no tests scores LOW here.
                           MANDATORY inspection: read any check/CI script the
@@ -224,8 +238,15 @@ nodes:
       ## The 5 dimensions (score each 1-5: 5 = excellent, 1 = absent/broken)
       - correctness    — does the candidate actually satisfy the task?
       - completeness    — are ALL acceptance criteria met, not just the happy path?
+                          SCOPE: judge against the acceptance criteria stated in
+                          the case's task, not against features the task never
+                          asked for.
       - maintainability — clarity, structure, fit with conventions.
       - safety          — input validation, error handling, secrets/auth/shell/SQL/paths.
+                          SCOPE: for a candidate with no external/user inputs,
+                          judge on error handling and unsafe operations actually
+                          present, not on the absence of input validation it had
+                          no occasion to need.
       - verification    — were tests/checks ACTUALLY present for the new behavior?
                           New/changed behavior with no tests scores LOW here.
                           MANDATORY inspection: read any check/CI script the

--- a/.archon/workflows/experimental/standing-eval-suite.yaml
+++ b/.archon/workflows/experimental/standing-eval-suite.yaml
@@ -52,6 +52,10 @@ worktree:
   enabled: false
 
 nodes:
+  # NOTE: score-1/2/3 prompts are currently duplicated; they differ only in output filename.
+  # Future: extract shared judge prompt to a separate template when Archon adds workflow
+  # templating/includes support. For now, keep all three in sync manually.
+
   # ─── 1. LOAD SUITE (deterministic, no AI) ─────────────────────────────
   # Validates the dataset exists and writes the case-path queue for the judge.
   - id: load-suite
@@ -71,6 +75,7 @@ nodes:
     model: medium
     context: fresh
     allowed_tools: [Read, Write]
+    timeout: 300000
     prompt: |
       You are a strict eval JUDGE. Score each labelled case on a fixed 5-dimension
       rubric. Be conservative: when evidence for a dimension is absent, score it
@@ -79,8 +84,12 @@ nodes:
       ## Where the cases are
       The file `$ARTIFACTS_DIR/eval/queue.txt` contains one absolute path per line,
       each pointing at a YAML case file. Read that list, then Read EVERY case file.
-      Read ONLY queue.txt and the case files it lists — do NOT read labels.json,
-      human-labels.json, baseline.json, suite.json, or any other file.
+
+      **CRITICAL BLINDNESS CONSTRAINT:** Read ONLY queue.txt and the exact case files it lists.
+      Do NOT read, attempt to read, infer, or reference labels.json, human-labels.json,
+      baseline.json, suite.json, or ANY other file in the eval directory. Violation ruins
+      the calibration. If you find yourself considering reading any file not in the queue,
+      STOP and explain why you need it instead of reading it.
       Each case has: `id`, `task` (the spec), `candidate` (the work under test),
       and `reference` (what a correct/strong solution looks like).
 
@@ -125,6 +134,7 @@ nodes:
     model: medium
     context: fresh
     allowed_tools: [Read, Write]
+    timeout: 300000
     prompt: |
       You are a strict eval JUDGE. Score each labelled case on a fixed 5-dimension
       rubric. Be conservative: when evidence for a dimension is absent, score it
@@ -133,8 +143,12 @@ nodes:
       ## Where the cases are
       The file `$ARTIFACTS_DIR/eval/queue.txt` contains one absolute path per line,
       each pointing at a YAML case file. Read that list, then Read EVERY case file.
-      Read ONLY queue.txt and the case files it lists — do NOT read labels.json,
-      human-labels.json, baseline.json, suite.json, or any other file.
+
+      **CRITICAL BLINDNESS CONSTRAINT:** Read ONLY queue.txt and the exact case files it lists.
+      Do NOT read, attempt to read, infer, or reference labels.json, human-labels.json,
+      baseline.json, suite.json, or ANY other file in the eval directory. Violation ruins
+      the calibration. If you find yourself considering reading any file not in the queue,
+      STOP and explain why you need it instead of reading it.
       Each case has: `id`, `task` (the spec), `candidate` (the work under test),
       and `reference` (what a correct/strong solution looks like).
 
@@ -179,6 +193,7 @@ nodes:
     model: medium
     context: fresh
     allowed_tools: [Read, Write]
+    timeout: 300000
     prompt: |
       You are a strict eval JUDGE. Score each labelled case on a fixed 5-dimension
       rubric. Be conservative: when evidence for a dimension is absent, score it
@@ -187,8 +202,12 @@ nodes:
       ## Where the cases are
       The file `$ARTIFACTS_DIR/eval/queue.txt` contains one absolute path per line,
       each pointing at a YAML case file. Read that list, then Read EVERY case file.
-      Read ONLY queue.txt and the case files it lists — do NOT read labels.json,
-      human-labels.json, baseline.json, suite.json, or any other file.
+
+      **CRITICAL BLINDNESS CONSTRAINT:** Read ONLY queue.txt and the exact case files it lists.
+      Do NOT read, attempt to read, infer, or reference labels.json, human-labels.json,
+      baseline.json, suite.json, or ANY other file in the eval directory. Violation ruins
+      the calibration. If you find yourself considering reading any file not in the queue,
+      STOP and explain why you need it instead of reading it.
       Each case has: `id`, `task` (the spec), `candidate` (the work under test),
       and `reference` (what a correct/strong solution looks like).
 
@@ -245,6 +264,7 @@ nodes:
     model: small
     context: fresh
     allowed_tools: []
+    timeout: 60000
     prompt: |
       The deterministic scorecard below already contains the AUTHORITATIVE gate
       decision. Restate it for a human — do NOT recompute or override it. If the


### PR DESCRIPTION
## Summary

- **Problem:** `agentic-eval-gate` judges a single diff once, with no ground truth — there is no *standing* way to measure quality over time against labelled examples.
- **Why it matters:** the vibe-coding SDLC's "evals are the new tests" + quality flywheel needs a curated, version-controlled suite that re-scores on every run and catches regressions.
- **What changed:** adds `standing-eval-suite` — a 4-node workflow that scores labelled cases on a 5-dimension rubric, aggregates deterministically, optionally compares to a committed baseline, and gates; two named scripts; and two datasets — `seed` (demo: includes deliberately-failing cases) and `golden` (a standing quality bar with a blessed `baseline.json`).
- **What did NOT change (scope boundary):** no TS in `packages/` touched; no engine/schema/bundled-defaults changes. Experimental workflow only (lives in `.archon/workflows/experimental/`). `agentic-eval-gate` and all existing workflows untouched.

## UX Journey

### After

```
Operator                         Archon (standing-eval-suite)
────────                         ────────────────────────────
EVAL_SUITE=seed                  load-suite (script)   → writes case queue
  archon workflow run ────────▶  score-cases (medium)  → judges each case 1-5 on 5 dims
  standing-eval-suite            aggregate (script)    → weighted means, floors, baseline diff → scorecard
                                 verdict (small)        → human-readable PASS/FAIL
sees gate decision ◀──────────  scorecard.json (artifacts) + trend line (.archon/state)
```

## Architecture Diagram

### After

```
.archon/evals/<suite>/           .archon/workflows/experimental/        .archon/scripts/
  suite.json        ───────────▶  standing-eval-suite.yaml  ──run──▶  eval-load-suite.ts [+]
  cases/*.yaml      ──read by──▶    (load → score → aggregate → verdict)  eval-aggregate.ts [+]
  baseline.json (opt)
                                  outputs: $ARTIFACTS_DIR/eval/scorecard.json [+]
                                           .archon/state/eval-history.jsonl  [+] (gitignored)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| standing-eval-suite.yaml | eval-load-suite.ts | **new** | named script (bun run) |
| standing-eval-suite.yaml | eval-aggregate.ts | **new** | named script (bun run) |
| eval-load-suite.ts | .archon/evals/<suite> | **new** | reads dataset (cwd-relative) |
| eval-aggregate.ts | .archon/state/eval-history.jsonl | **new** | appends trend (gitignored) |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `workflows`
- Module: `workflows:experimental`

## Change Metadata

- Change type: `feature`
- Primary scope: `workflows`

## Linked Issue

- Related # (none — extends the agentic-engineering eval work alongside `agentic-eval-gate`)

## Validation Evidence (required)

This PR adds NO TypeScript under `packages/` and no bundled defaults — it is workflow YAML + named scripts + a dataset. The standard `bun run validate` (type-check/lint/test/bundled checks) targets the engine and is not exercised by these files. Validation here is workflow-validation + an end-to-end smoke:

```bash
bun run cli validate workflows standing-eval-suite
#   standing-eval-suite   ok        (1 valid, 0 with errors)

EVAL_SUITE=seed bun run cli workflow run standing-eval-suite --no-worktree
#   gate FAIL, overall 3.1 < 3.5
#   dim_floor_failures: [completeness (2.667), verification (2.333)]
#   case_failures: [missing-tests, borderline-refactor]

EVAL_SUITE=golden bun run cli workflow run standing-eval-suite --no-worktree
#   gate PASS, overall 5.0 — all 3 strong cases scored 5/5; baseline blessed from this run

# Regression path (deterministic, no AI) — feed eval-aggregate a result with safety 5.0->4.0:
#   gate FAIL, baseline_used: true, regressions: [{dim: safety, baseline: 5, current: 4}]
#   (absolute thresholds all still pass — only the >0.5 baseline drop trips it)
```

- Evidence provided: workflow-validation + both foreground runs (seed FAIL, golden PASS) + a deterministic regression-path check. The `missing-tests` case (correct code, zero tests) is correctly blocked — proving the verification dimension bites — and the golden baseline proves regression detection.
- Intentionally skipped: full `bun run validate` — no engine/TS/bundled files changed.

## Security Impact (required)

- New permissions/capabilities? **No** — read-only workflow (`mutates_checkout: false`, no worktree); judge node restricted to `[Read, Write, Bash]`, verdict to `[]`.
- New external network calls? **No**.
- Secrets/tokens handling changed? **No**.
- File system access scope changed? **No** — scripts read the cwd dataset and write only to `$ARTIFACTS_DIR` and the gitignored `.archon/state/`.

## Compatibility / Migration

- Backward compatible? **Yes** — purely additive; no existing workflow or schema changed.
- Config/env changes? **No** (optional `EVAL_SUITE` env var selects a suite; default `seed`).
- Database migration needed? **No**.

## Human Verification (required)

- Verified scenarios: foreground `seed` run end-to-end; confirmed `queue.txt`/`results.json`/`scorecard.json` written and a trend line appended to `.archon/state/eval-history.jsonl`.
- Edge cases checked: empty/missing `results.json` → aggregate fails loudly (gate FAIL, not silent pass); a case missing a dimension score → fails loudly. Discovered and worked around an Archon-on-Windows bug where inline multi-line `script:` nodes silently no-op (bun `-e` argv truncates at the first newline) — hence named scripts.
- Also verified: golden suite gate PASS (overall 5.0) and the regression-vs-baseline path (deterministic check above) — a single dimension dropping past tolerance flips the gate.
- What was not verified: behavior on a very large suite (single-judge-pass scope; loop-based per-case fan-out is the documented v2).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: none existing — new experimental workflow + two new scripts + a new dataset dir.
- Potential unintended effects: none on other workflows; the new named scripts share the `.archon/scripts/` namespace (prefixed `eval-` to avoid collision).
- Guardrails/monitoring: aggregate fails fast on any malformed/empty judge output; deterministic gate is authoritative (the small-model verdict only narrates).

## Rollback Plan (required)

- Fast rollback: delete the four added paths (`.archon/workflows/experimental/standing-eval-suite.yaml`, `.archon/scripts/eval-load-suite.ts`, `.archon/scripts/eval-aggregate.ts`, `.archon/evals/`) — no other code references them.
- Feature flags/toggles: none needed; it only runs when explicitly invoked.
- Observable failure symptoms: `archon validate workflows` would flag a broken YAML; a run that can't find its dataset fails at `load-suite`.

## Risks and Mitigations

- Risk: LLM-judge scoring is non-deterministic run-to-run.
  - Mitigation: deterministic aggregation + thresholds are authoritative; v2 adds N-vote judging. Documented in `.archon/evals/README.md`.
- Risk: single judge pass may drop cases on a very large suite.
  - Mitigation: scoped to small curated suites for v1; aggregate fails loudly if a case is unscored; loop-based fan-out is the documented v2 path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental standing evaluation suite workflow with deterministic queueing, N-vote/median scoring, suite-driven PASS/FAIL gating, optional detection/trap semantics, and scorecards with run history.
  * Added Bun-based tooling to load/evaluate suites, run multi-suite portfolios, compare judge results to human calibration labels, and execute recall probes via transcript evidence vs forbidden patterns.
  * Introduced new seed/golden/regressions/calibration cases and suite configs.
* **Documentation**
  * Added/updated documentation for standing eval suite formats/thresholds, recall probe operation, and calibration reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->