### PR TITLE
marketplace: add token-max-site-factory (programmatic SEO/GEO page factory)

### DIFF
--- a/packages/docs-web/src/data/marketplace.ts
+++ b/packages/docs-web/src/data/marketplace.ts
@@ -155,4 +155,15 @@ export const marketplaceEntries: MarketplaceEntry[] = [
     tags: ['development', 'planning', 'review'],
     archonVersionCompat: '>=0.3.0',
   },
+  {
+    slug: 'token-max-site-factory',
+    name: 'Token-Max Site Factory',
+    author: 'TheSmokeDev',
+    description:
+      'Point-and-shoot programmatic SEO/GEO page factory. Scan any website, then expand it into hundreds of validated 2,800+ word answer-first pages with hard uniqueness gates and packet-only facts. Never deploys - generation ends at a validation report.',
+    sourceUrl: 'https://github.com/TheSmokeDev/token-max-site-factory/tree/main/marketplace/token-max-site-factory',
+    sha: 'd01735a1e731ff00400621d0110d112488eaa68d',
+    tags: ['automation', 'development'],
+    archonVersionCompat: '>=0.5.0',
+  },
 ];

--- a/packages/docs-web/src/data/marketplace.ts
+++ b/packages/docs-web/src/data/marketplace.ts
@@ -161,7 +161,8 @@ export const marketplaceEntries: MarketplaceEntry[] = [
     author: 'TheSmokeDev',
     description:
       'Point-and-shoot programmatic SEO/GEO page factory. Scan any website, then expand it into hundreds of validated 2,800+ word answer-first pages with hard uniqueness gates and packet-only facts. Never deploys - generation ends at a validation report.',
-    sourceUrl: 'https://github.com/TheSmokeDev/token-max-site-factory/tree/main/marketplace/token-max-site-factory',
+    sourceUrl:
+      'https://github.com/TheSmokeDev/token-max-site-factory/tree/d01735a1e731ff00400621d0110d112488eaa68d/marketplace/token-max-site-factory',
     sha: 'd01735a1e731ff00400621d0110d112488eaa68d',
     tags: ['automation', 'development'],
     archonVersionCompat: '>=0.5.0',


### PR DESCRIPTION
Adds a marketplace entry for **token-max-site-factory** — a point-and-shoot programmatic SEO/GEO page factory. Scan any website, then expand it into hundreds of validated pages (2,800-3,400 words, shingle/Jaccard overlap <= 0.10, answer-first structure, packet-only facts). Extracted from a production insurance lane and generalized; the per-site workflow runs a fresh-context generate loop with a validate/regenerate gate.

- **Package:** [`marketplace/token-max-site-factory/`](https://github.com/TheSmokeDev/token-max-site-factory/tree/d01735a1e731ff00400621d0110d112488eaa68d/marketplace/token-max-site-factory) — a bootstrap workflow (prereq check → clone engine → print onboarding); generation itself runs via the per-site workflow the engine installs (`install --site <id>` renders the full DAG into the target repo). Entry pinned to the release SHA, matching the third-party sourceUrl convention.
- **Safety:** the engine never deploys — no DNS, Search Console, sitemap, or indexing operations; a preflight node greps the engine for live-mutation command patterns on every run and refuses to proceed. The bootstrap workflow's only write is a `git clone` into the home directory.
- I attest the workflow does not exfiltrate data, credentials, or secrets.
- I attest the workflow does not execute destructive operations without user confirmation.
- `archonVersionCompat: >=0.5.0` (node scripts are dollar-free; runs use `--no-worktree` from the target repo).

Engine repo (MIT): https://github.com/TheSmokeDev/token-max-site-factory
Companion operating-manual skill ships in the geo-skills pack: https://github.com/TheSmokeDev/geo-skills