### PR TITLE
docs: add robots.txt with explicit AI bot allowlist

### DIFF
--- a/packages/docs-web/public/robots.txt
+++ b/packages/docs-web/public/robots.txt
@@ -1,0 +1,50 @@
+# Archon Documentation - Bot Access Policy
+# https://archon.diy
+
+# AI Assistant Crawlers - Explicitly Allowed
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+# Standard Search Crawlers
+User-agent: Googlebot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: DuckDuckBot
+Allow: /
+
+# Default: Allow all
+User-agent: *
+Allow: /
+
+# Sitemaps
+Sitemap: https://archon.diy/sitemap-index.xml

--- a/packages/docs-web/public/robots.txt
+++ b/packages/docs-web/public/robots.txt
@@ -45,6 +45,3 @@ Allow: /
 # Default: Allow all
 User-agent: *
 Allow: /
-
-# Sitemaps
-Sitemap: https://archon.diy/sitemap-index.xml


### PR DESCRIPTION
## Summary

  - Add `robots.txt` to the docs site with explicit rules allowing AI assistant crawlers
  - Include sitemap reference for efficient crawling

  ## Context

  Currently `https://archon.diy/robots.txt` returns 404. While this implicitly allows all crawlers, an explicit allowlist signals intentional AI-friendliness and follows emerging best practices for AI-ready documentation.

  **Bots explicitly allowed:**
  - GPTBot, ChatGPT-User (OpenAI)
  - ClaudeBot, Claude-Web (Anthropic)
  - PerplexityBot
  - Google-Extended, Applebot-Extended
  - cohere-ai, CCBot

  ## Test Plan

  - [x] File created at `packages/docs-web/public/robots.txt`
  - [ ] After deploy: `curl -s https://archon.diy/robots.txt` returns the file
  - [ ] Sitemap URL in robots.txt resolves correctly

  ## Security Impact

  - New permissions/capabilities? **No**
  - New external network calls? **No**

  ## Compatibility

  - Backward compatible? **Yes** (new file only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `robots.txt` file to define crawler access rules for archon.diy.
  * Explicitly allows crawling for major search engines and several AI assistant crawlers.
  * Ensures a default rule permits crawling for all other user agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->