### PR TITLE
docs: add llms.txt link directive to HTML pages

### DIFF
--- a/packages/docs-web/astro.config.mjs
+++ b/packages/docs-web/astro.config.mjs
@@ -18,6 +18,15 @@ export default defineConfig({
           tag: 'script',
           content: `if(!localStorage.getItem('archon-theme-init')){localStorage.setItem('archon-theme-init','1');localStorage.setItem('starlight-theme','dark');document.documentElement.dataset.theme='dark';}`,
         },
+        {
+          tag: 'link',
+          attrs: {
+            rel: 'llms',
+            type: 'text/plain',
+            href: '/llms.txt',
+            title: 'LLM-optimized documentation index',
+          },
+        },
       ],
       social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/coleam00/Archon' }],
       editLink: {


### PR DESCRIPTION
## Summary

- Add `<link rel="llms" href="/llms.txt">` directive to all documentation pages via Starlight head config

## Motivation

This PR adds HTML-level discovery of the LLM-optimized documentation index, enabling AI agents to find `/llms.txt` without prior knowledge of the AFDocs spec. The directive is injected into every page's `<head>` by Starlight's head configuration.

**Spec reference:** https://agentdocsspec.com/spec/#llms-txt-directive-html

## Changes

**`packages/docs-web/astro.config.mjs`**
- Add link element to Starlight `head` array with `rel="llms"` pointing to `/llms.txt`

## Test plan

- [x] Build succeeds: `bun --filter @archon/docs-web build`
- [x] Verify directive present: `grep -r 'rel="llms"' packages/docs-web/dist/ | head -3`
- [ ] Deploys to archon.diy (CI/CD)
- [ ] AFDocs check passes: llms-txt-directive-html

## Related

Part of the Archon docs AI-readiness initiative (PR series 1-6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new documentation link in the site header to make a plain-text docs index easier to discover for AI-assisted tools and other text-based consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->