### PR TITLE
docs: improve llms.txt coverage to 95%+

### DIFF
--- a/packages/docs-web/astro.config.mjs
+++ b/packages/docs-web/astro.config.mjs
@@ -63,16 +63,10 @@ export default defineConfig({
             'AI workflow engine -- package your coding workflows as YAML, run them anywhere.',
           details: `Archon lets you define multi-step AI coding workflows (code review, bug fixes, features) in YAML and run them from CLI, Web UI, Slack, Telegram, GitHub, or Discord. Each workflow runs in an isolated git worktree.`,
 
-          // Make llms-small.txt actually small - core concepts only
-          exclude: [
-            'adapters/community/**', // Community adapters are reference material
-            'deployment/**', // Deployment is advanced
-            'contributing/**', // Not needed for using Archon
-            'reference/security', // Deep reference
-            'book/**', // Long-form content
-          ],
+          // No exclusions - include all Starlight docs for maximum sitemap coverage
+          exclude: [],
 
-          // Topic-based subsets for selective ingestion
+          // Topic-based subsets for selective ingestion - cover all major doc sections
           customSets: [
             {
               label: 'Quick Start',
@@ -80,20 +74,59 @@ export default defineConfig({
               paths: ['index', 'getting-started/**'],
             },
             {
+              label: 'The Book',
+              description: 'Tutorials and conceptual guides',
+              paths: ['book/**'],
+            },
+            {
+              label: 'Guides',
+              description: 'How-to guides for workflows, commands, and nodes',
+              paths: ['guides/**'],
+            },
+            {
               label: 'Adapters',
               description: 'Platform integrations (GitHub, Slack, Discord, etc.)',
               paths: ['adapters/**'],
+            },
+            {
+              label: 'Deployment',
+              description: 'Deployment guides for Docker, cloud, and local setups',
+              paths: ['deployment/**'],
             },
             {
               label: 'Reference',
               description: 'CLI commands, configuration, and API reference',
               paths: ['reference/**'],
             },
+            {
+              label: 'Contributing',
+              description: 'Contributor guides for developers',
+              paths: ['contributing/**'],
+            },
+          ],
+
+          // Links to non-Starlight pages in the sitemap
+          optionalLinks: [
+            {
+              label: 'Home',
+              url: 'https://archon.diy/',
+              description: 'Archon homepage',
+            },
+            {
+              label: 'Roadmap',
+              url: 'https://archon.diy/roadmap/',
+              description: 'Project roadmap and planned features',
+            },
+            {
+              label: 'Workflow Marketplace',
+              url: 'https://archon.diy/workflows/',
+              description: 'Browse and discover community workflows',
+            },
           ],
 
           // Control ordering - essentials first
-          promote: ['index', 'getting-started/**', 'guides/first-workflow'],
-          demote: ['reference/changelog', 'contributing/**'],
+          promote: ['index', 'getting-started/**', 'guides/authoring-workflows'],
+          demote: ['contributing/**'],
 
           // Aggressive minification for small version
           minify: {


### PR DESCRIPTION
## Summary

- Remove all exclusions from starlight-llms-txt configuration
- Add customSets for all major doc sections (The Book, Guides, Contributing, Deployment)
- Add optionalLinks for non-Starlight pages (/, /roadmap/, /workflows/)

## Context

Part of the AI-readiness improvements for the Archon documentation. This is PR #3 in a series:
- PR #2065: Added robots.txt with AI crawler allowances
- PR #2066: Added llms.txt HTML directive to docs layout

## Problem

AFDocs reports `llms-txt-coverage: llms.txt covers 54/75 sitemap doc pages (72%); 21 missing`

The previous configuration was overly aggressive with exclusions:
- `adapters/community/**` (3 pages)
- `deployment/**` (7 pages)
- `contributing/**` (6 pages)
- `reference/security` (1 page)
- `book/**` (11 pages)

## Solution

1. **Remove all exclusions** - Include all Starlight docs in both llms-full.txt and llms-small.txt
2. **Add comprehensive customSets** - Create topic-based documentation subsets for all major sections
3. **Add optionalLinks** - Reference non-Starlight pages (homepage, roadmap, marketplace) in llms.txt

### Before vs After

| Metric | Before | After |
|--------|--------|-------|
| Excluded pages | 28 | 0 |
| Custom sets | 3 | 7 |
| Optional links | 0 | 3 |
| llms-small.txt size | 5,682 lines | 8,797 lines |

## Test plan

- [x] Verified `bun run build` completes successfully in packages/docs-web
- [x] Verified llms.txt landing page includes all documentation sets
- [x] Verified llms-small.txt includes previously excluded content (book/**, deployment/**, etc.)
- [ ] Deploy to staging and verify AFDocs coverage metric reaches 95%+

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the documentation sitemap/LLMs TXT coverage to include more doc sections and helpful site pages.
  * Added support for surfacing additional content groups, including guides, deployment, contributing, and the book.

* **Refactor**
  * Updated how documentation content is prioritized, with revised ordering rules for promoted and demoted pages.

* **Bug Fixes**
  * Improved which pages are included in documentation discovery by removing the previous hard-coded exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->