### PR TITLE
docs: add markdown URL support for AI consumption

### DIFF
--- a/packages/docs-web/astro.config.mjs
+++ b/packages/docs-web/astro.config.mjs
@@ -57,6 +57,9 @@ export default defineConfig({
         },
       ],
       customCss: ['./src/styles/custom.css'],
+      components: {
+        Head: './src/components/Head.astro',
+      },
       plugins: [
         starlightLlmsTxt({
           description:

--- a/packages/docs-web/src/components/Head.astro
+++ b/packages/docs-web/src/components/Head.astro
@@ -1,0 +1,25 @@
+---
+/**
+ * Custom Head component override for Starlight.
+ * Adds:
+ * 1. <link rel="alternate" type="text/markdown"> pointing to .md version of each page
+ *
+ * This improves AI/LLM discoverability by advertising markdown availability.
+ */
+const { starlightRoute } = Astro.locals;
+const { head, entry } = starlightRoute;
+
+// Build the markdown alternate URL
+// HTML pages are at /path/to/page/ -> .md files are at /path/to/page.md
+const pathname = Astro.url.pathname;
+// Remove trailing slash and add .md extension
+const mdPath = pathname.endsWith('/') ? pathname.slice(0, -1) + '.md' : pathname + '.md';
+const siteUrl = Astro.site?.href ?? 'https://archon.diy';
+const mdUrl = new URL(mdPath, siteUrl).href;
+---
+
+{/* Render original Starlight head elements */}
+{head.map(({ tag: Tag, attrs, content }) => <Tag {...attrs} set:html={content} />)}
+
+{/* Add alternate link to markdown version */}
+<link rel="alternate" type="text/markdown" href={mdUrl} title={`${entry.data.title} (Markdown)`} />

--- a/packages/docs-web/src/components/Head.astro
+++ b/packages/docs-web/src/components/Head.astro
@@ -12,8 +12,10 @@ const { head, entry } = starlightRoute;
 // Build the markdown alternate URL
 // HTML pages are at /path/to/page/ -> .md files are at /path/to/page.md
 const pathname = Astro.url.pathname;
-// Remove trailing slash and add .md extension
-const mdPath = pathname.endsWith('/') ? pathname.slice(0, -1) + '.md' : pathname + '.md';
+// Build .md path: root "/" -> "index.md", others strip trailing slash then append .md
+const mdPath = pathname === '/'
+  ? 'index.md'
+  : (pathname.endsWith('/') ? pathname.slice(0, -1) : pathname) + '.md';
 const siteUrl = Astro.site?.href ?? 'https://archon.diy';
 const mdUrl = new URL(mdPath, siteUrl).href;
 ---

--- a/packages/docs-web/src/pages/[...slug].md.ts
+++ b/packages/docs-web/src/pages/[...slug].md.ts
@@ -6,7 +6,7 @@
  * Uses the same markdown generation pipeline as starlight-llms-txt for consistency.
  */
 import type { APIRoute, GetStaticPaths } from 'astro';
-import { getCollection, render } from 'astro:content';
+import { getCollection } from 'astro:content';
 
 export const prerender = true;
 

--- a/packages/docs-web/src/pages/[...slug].md.ts
+++ b/packages/docs-web/src/pages/[...slug].md.ts
@@ -1,0 +1,56 @@
+/**
+ * Dynamic route that generates markdown (.md) files for each documentation page.
+ * This enables AI/LLM tools to fetch raw markdown via URLs like:
+ *   https://archon.diy/getting-started/installation.md
+ *
+ * Uses the same markdown generation pipeline as starlight-llms-txt for consistency.
+ */
+import type { APIRoute, GetStaticPaths } from 'astro';
+import { getCollection, render } from 'astro:content';
+
+export const prerender = true;
+
+/**
+ * Generate static paths for all documentation pages.
+ * Each doc gets a .md endpoint at the same path as its HTML version.
+ */
+export const getStaticPaths: GetStaticPaths = async () => {
+  const docs = await getCollection('docs', (doc) => !doc.data.draft);
+
+  return docs.map((doc) => ({
+    params: { slug: doc.id },
+    props: { entry: doc },
+  }));
+};
+
+/**
+ * Render the documentation entry to markdown.
+ * Returns the raw source markdown with frontmatter stripped.
+ */
+export const GET: APIRoute = async ({ props }) => {
+  const { entry } = props;
+
+  // Build markdown content with title and description as header
+  const segments: string[] = [];
+
+  // Add title as h1
+  segments.push(`# ${entry.data.title}`);
+
+  // Add description as blockquote if present
+  if (entry.data.description) {
+    segments.push(`> ${entry.data.description}`);
+  }
+
+  // Add the raw markdown body (frontmatter already stripped by content collection)
+  if (entry.body) {
+    segments.push(entry.body);
+  }
+
+  const body = segments.join('\n\n');
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+    },
+  });
+};


### PR DESCRIPTION
## Summary

- Generate static `.md` files for all 64 documentation pages at build time
- Add `<link rel="alternate" type="text/markdown">` to HTML pages advertising markdown availability
- Enables raw markdown access via URLs like `https://archon.diy/getting-started/installation.md`

## Motivation

Addresses the AFDocs `markdown-url-support` check. Part of the docs AI-readiness series:
- PR #2023: Version disambiguation
- PR #2065: robots.txt AI crawler rules  
- PR #2066: llms.txt HTML directive
- PR #2067: llms.txt coverage improvement
- PR #2068: JSON-LD structured data

Raw markdown URLs allow AI/LLM tools to:
1. Fetch content without parsing HTML
2. Get properly formatted code blocks and tables
3. Use content directly in context windows

## Implementation

**New file:** `packages/docs-web/src/pages/[...slug].md.ts`
- Dynamic Astro route using `getStaticPaths`
- Generates `.md` file for each content collection entry
- Returns raw markdown with title as h1, description as blockquote
- Sets `Content-Type: text/markdown` header

**New file:** `packages/docs-web/src/components/Head.astro`
- Overrides Starlight's Head component
- Adds `<link rel="alternate" type="text/markdown">` to each page

**Config change:** `packages/docs-web/astro.config.mjs`
- Registers the Head component override

## Sample Output

**Markdown URL:** `/getting-started/installation.md`
```markdown
# Installation

> Install Archon on macOS, Linux, or Windows.

## Quick Install

### macOS / Linux

\`\`\`bash
curl -fsSL https://archon.diy/install | bash
\`\`\`
...
```

**HTML alternate link:**
```html
<link rel="alternate" type="text/markdown" 
      href="https://archon.diy/getting-started/installation.md" 
      title="Installation (Markdown)">
```

## Test Plan

- [x] `bun run build` passes in `packages/docs-web`
- [x] 64 `.md` files generated in `dist/`
- [x] 64 HTML pages contain `<link rel="alternate" type="text/markdown">`
- [x] `.md` files contain proper title, description, and content
- [x] Lint-staged passes

## Verification Commands

```bash
# Count .md files
find packages/docs-web/dist -name "*.md" | wc -l  # Should be 64

# View sample .md
cat packages/docs-web/dist/getting-started/installation.md | head -20

# Check alternate link
grep 'rel="alternate".*markdown' packages/docs-web/dist/getting-started/installation/index.html
```

## Note on PR #2068 Overlap

Both this PR and #2068 create `src/components/Head.astro`. If #2068 merges first, this PR will need a rebase to combine both the JSON-LD and alternate link into the same component. The merge is straightforward - just add both features to the same file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documentation pages now include a markdown “alternate” link for quick plain-text access.
  * Added statically prerendered markdown endpoints for all non-draft documentation entries.
  * Improved docs head rendering to support the new alternate markdown format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->