### PR TITLE
feat(marketplace): add pocock-skills-workflow-family

### DIFF
--- a/packages/docs-web/src/data/marketplace.ts
+++ b/packages/docs-web/src/data/marketplace.ts
@@ -167,4 +167,16 @@ export const marketplaceEntries: MarketplaceEntry[] = [
     tags: ['review', 'automation'],
     archonVersionCompat: '>=0.3.0',
   },
+  {
+    slug: 'pocock-skills-workflow-family',
+    name: 'Matt Pocock Skills Workflow Family',
+    author: 'seanrobertwright',
+    description:
+      "Matt Pocock's 'Skills for Real Engineers' (v1.1.0) as six workflows that mount the real SKILL.md files into nodes: spec-to-ship (tracer-bullet tickets -> TDD frontier loop -> two-axis Standards|Spec review -> PR), conservative AFK triage, a diagnosing-bugs pipeline that refuses to theorize without a red feedback loop, an AFK wayfinder frontier, architecture health scans, and repo init. Interactive grilling stays human — the spec issue is the handoff artifact into the AFK back half.",
+    sourceUrl:
+      'https://github.com/seanrobertwright/archon-pocock-workflow/tree/629e57716ea72bb8cf2f77fc7728d3845aa2cf92',
+    sha: '629e57716ea72bb8cf2f77fc7728d3845aa2cf92',
+    tags: ['development', 'planning', 'review', 'automation'],
+    archonVersionCompat: '>=0.5.0',
+  },
 ];

--- a/packages/docs-web/src/data/marketplace.ts
+++ b/packages/docs-web/src/data/marketplace.ts
@@ -174,7 +174,7 @@ export const marketplaceEntries: MarketplaceEntry[] = [
     description:
       "Matt Pocock's 'Skills for Real Engineers' (v1.1.0) as six workflows that mount the real SKILL.md files into nodes: spec-to-ship (tracer-bullet tickets -> TDD frontier loop -> two-axis Standards|Spec review -> PR), conservative AFK triage, a diagnosing-bugs pipeline that refuses to theorize without a red feedback loop, an AFK wayfinder frontier, architecture health scans, and repo init. Interactive grilling stays human — the spec issue is the handoff artifact into the AFK back half.",
     sourceUrl:
-      'https://github.com/seanrobertwright/archon-pocock-workflow/tree/629e57716ea72bb8cf2f77fc7728d3845aa2cf92',
+      'https://github.com/seanrobertwright/archon-pocock-workflow/tree/629e57716ea72bb8cf2f77fc7728d3845aa2cf92/.archon',
     sha: '629e57716ea72bb8cf2f77fc7728d3845aa2cf92',
     tags: ['development', 'planning', 'review', 'automation'],
     archonVersionCompat: '>=0.5.0',


### PR DESCRIPTION
## Summary

- Problem: Matt Pocock's widely-used "Skills for Real Engineers" (v1.1.0) define a complete engineering flow (grill → spec → tickets → TDD implement → two-axis review), but there was no Archon workflow family that runs its AFK half.
- Why it matters: gives Archon users a disciplined idea-to-PR pipeline built on a well-known, documented methodology — with the human/AFK boundary placed exactly where the source skills put it.
- What changed: one new entry appended to `packages/docs-web/src/data/marketplace.ts` (`pocock-skills-workflow-family`).
- What did **not** change (scope boundary): no code, no other data entries, nothing outside the marketplace data file.

## About the submitted workflow family

Repo: https://github.com/seanrobertwright/archon-pocock-workflow (pinned `629e577`)

Six workflows / ten command files / the 18 upstream skill dirs (verified byte-identical to `mattpocock/skills` tag `v1.1.0`, MIT with attribution in LICENSE):

- `pocock-init` — non-interactive port of `/setup-matt-pocock-skills` (GitHub preset; defaults recorded for review)
- `pocock-spec-to-ship` — spec issue → tracer-bullet tickets with blocking edges → one-ticket-per-fresh-context TDD frontier loop → validation → parallel Standards|Spec review → findings fixed → PR
- `pocock-triage` — conservative AFK triage (verifies, briefs, asks reporters; **never closes/wontfixes**)
- `pocock-fix-bug` — diagnosing-bugs discipline: no hypotheses without a red-capable feedback loop; regression test before fix; post-mortem can auto-file an architecture-candidate issue
- `pocock-wayfinder-afk` — works only a wayfinder map's AFK frontier (`wayfinder:research` / agent-driveable `wayfinder:task`); grilling/prototype tickets stay human per the skill's own HITL rules
- `pocock-architecture-health` — survey half of `/improve-codebase-architecture`; files deepening candidates as idea issues

All six validate clean with `archon validate workflows` and `archon validate commands` on 0.5.x.

## UX Journey / Architecture Diagram

N/A — data-only addition to the marketplace listing; no user-facing flow or module in Archon changes.

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `docs`
- Module: `docs:marketplace`

## Change Metadata

- Change type: `docs`
- Primary scope: `docs`

## Linked Issue

- Related: none (marketplace submission per CONTRIBUTING "Contributing Workflows to Marketplace")

## Validation Evidence

- `bun -e "import('./packages/docs-web/src/data/marketplace.ts')"` — module parses; 11 entries; new entry has valid tags subset (`development|planning|review|automation`), 40-char SHA, github.com sourceUrl.
- Full `bun run validate` intentionally skipped locally (data-only change, no workspace install on this machine) — CI covers it.

## Security Impact

- New permissions/capabilities? No
- New external network calls? No (listing entry only)
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No

## Human Verification

- Verified scenarios: all six workflows pass `archon validate workflows`; all ten commands pass `archon validate commands`; skill dirs diffed byte-identical against `mattpocock/skills@v1.1.0`.
- What was not verified: a full end-to-end run of every workflow on a large production repo.

## Side Effects / Blast Radius

- Affected subsystems/workflows: marketplace docs page listing only.
- Potential unintended effects: none beyond listing visibility.

## Rollback Plan

- Revert this commit (single-entry addition to one data file).

## Self-attestation

- The workflows do not exfiltrate data; all writes go to the target repo's own GitHub issues/PRs/labels with AI-disclaimer prefixes, as described in each workflow's `description`.
- No destructive operations without consent: triage never closes issues; nothing force-pushes or deletes; feature work runs in Archon worktree isolation.
- I hold distribution rights: my orchestration is MIT; the bundled skills are MIT (Matt Pocock), redistributed with full license attribution.
- The pinned SHA is a reviewed, stable version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VR5nPLao8Ku9VfQoT32wqz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new marketplace listing: “Matt Pocock Skills Workflow Family.”
  * The listing includes author details, description, source link, version pinning, tags, and a compatibility requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->