### PR TITLE
marketplace: add image-node-factory (grounded image prompt-pack workflow)

### DIFF
--- a/packages/docs-web/src/data/marketplace.ts
+++ b/packages/docs-web/src/data/marketplace.ts
@@ -167,4 +167,16 @@ export const marketplaceEntries: MarketplaceEntry[] = [
     tags: ['automation', 'development'],
     archonVersionCompat: '>=0.5.0',
   },
+  {
+    slug: 'image-node-factory',
+    name: 'Image Node Factory',
+    author: 'TheSmokeDev',
+    description:
+      'One visual brief in, a grounded image prompt pack out (optional Codex-rendered bitmaps). Template selection cites a pinned, checksum-verified 511-case style corpus; a deterministic validator fails the run on any citation that does not resolve. Renders are opt-in and every concept ships baked and overlay variants.',
+    sourceUrl:
+      'https://github.com/TheSmokeDev/image-node-factory/tree/da7af16e3a3ba6fca7b58dd7a596dad24689a3f6/marketplace/image-node-factory',
+    sha: 'da7af16e3a3ba6fca7b58dd7a596dad24689a3f6',
+    tags: ['automation', 'development'],
+    archonVersionCompat: '>=0.5.0',
+  },
 ];


### PR DESCRIPTION
Adds a marketplace entry for **image-node-factory** — one natural-language visual brief in, a production-ready image prompt pack out, with optional rendering via Codex built-in image generation. Built for marketing assets: posters, product shots, spokesperson heroes, brand boards, infographics.

- **Package:** [`marketplace/image-node-factory/`](https://github.com/TheSmokeDev/image-node-factory/tree/da7af16e3a3ba6fca7b58dd7a596dad24689a3f6/marketplace/image-node-factory) — workflow YAML + 6 command files (`commands/`), 2 deterministic scripts (`scripts/`), and 7 render-discipline cards (`image-nodes/`). Entry pinned to the release SHA; directory format per the contributing guide.
- **The design:** AI decides, script resolves, AI consumes. The `select` node cites case ids from the MIT-licensed `awesome-gpt-image-2` corpus (511 cases, 22 templates), pinned to a commit and sha256-verified on every read by `scripts/style-corpus.py`. A citation either resolves offline or is never stamped — zero matches degrades honestly to `self_authored: true`. A second script node, `validate-pack`, re-checks the finished pack against the physical grounding artifact and fails the run on any hollow citation, provenance mismatch, over-cap concept count, empty prompt variant, or absolute local path in pack text.
- **Brand-agnostic subject slot:** `subject_mode=placeholder` makes the pack emit a literal `[SUBJECT SUPPLIED AT RENDER TIME]` token instead of inventing a subject; the validator enforces the token and the render node blocks rather than drawing it literally.
- **Safety:** default is `render=false` (prompt pack only). Rendering uses Codex built-in image generation exclusively — no API keys, no external services, and it writes a blocked manifest instead of falling back. No node touches the network; corpus provisioning is a one-time out-of-band `prime` into `~/.archon/cache/`, and the corpus never enters the repo.
- I attest the workflow does not exfiltrate data, credentials, or secrets.
- I attest the workflow does not execute destructive operations without user confirmation.
- `archonVersionCompat: >=0.5.0` (script nodes with `runtime: uv`; live-proven on 0.5.0: `dag_workflow_finished anyFailed:false` with the placeholder sentinel present in every prompt variant).

Workflow repo (MIT): https://github.com/TheSmokeDev/image-node-factory

— SmokeDev