### PR TITLE
feat(workflows): cross-invocation artifact scope + cold-resume pointer recovery

### DIFF
--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -686,6 +686,31 @@ If the stored session is gone (Codex thread expired, Pi JSONL missing or moved, 
 
 The node still completes on that fresh session, and its new session id is persisted so the *next* run continues from it. The node is **not** re-run — the fresh session is already a clean start, so re-running would only repeat it. Expect this only for `persist_session` nodes whose prior session became unavailable; warm resumes and first-time runs are unaffected.
 
+#### By-reference recovery via scope artifacts
+
+A lost session doesn't have to mean lost context. Workflows that use `persist_session` also get a **stable cross-invocation artifact scope** at `scopes/<workflow>/<scope>/` (a sibling of the per-run `runs/<id>/` directory, under the same artifacts root; the scope is the conversation UUID — the same key sessions use). Whenever a persistence-participating node also declares an `output_type`, the engine mirrors its typed output sidecar (`nodes/<id>.md` + `nodes/<id>.meta.json`) into that scope directory in addition to the run directory.
+
+On a cold resume, the warning then goes further: if the scope directory holds typed artifacts from an *earlier* invocation, the message lists them **by reference** (file paths — never pasted content), so the recovered context can be read on demand:
+
+> Artifacts from the previous invocation are available for recovery (read on demand):
+> - plan: `~/.archon/workspaces/acme/widget/artifacts/scopes/feature-dev/<conversation>/nodes/planner.md`
+
+To opt in to recovery, give your `persist_session` nodes an `output_type`:
+
+```yaml
+nodes:
+  - id: planner
+    prompt: "Plan the implementation for: $ARGUMENTS"
+    persist_session: true
+    output_type: plan   # mirrored to the durable scope → recoverable after a cold resume
+```
+
+Notes:
+
+- **Opt-in only.** Workflows without `persist_session` get no scope directory, no mirroring, and no pointer — default behavior is unchanged. Persist nodes without `output_type` keep session continuity but leave nothing behind for recovery.
+- **Last writer wins.** Concurrent runs of the same workflow in the same scope write per-node files into the shared scope directory; the most recent run's output for a given node is what a later cold resume sees.
+- **CLI caveat.** Each `archon workflow run` mints a fresh conversation UUID (a fresh scope) unless you pass `--conversation-id <id>` — the same caveat as session persistence itself.
+
 ### Distinct from `AgentRequestOptions.persistSession`
 
 The Claude Agent SDK also has a `persistSession` flag controlling whether the SDK writes its session transcript to disk. That is a *different* concept — local file persistence inside the SDK. This `persist_session:` field is about Archon's database-stored cross-run session ID for workflow nodes. The two operate at different layers and don't conflict.

--- a/packages/paths/src/archon-paths.test.ts
+++ b/packages/paths/src/archon-paths.test.ts
@@ -34,6 +34,8 @@ import {
   getProjectLogsPath,
   getRunArtifactsPath,
   getRunLogPath,
+  sanitizeScopeSegment,
+  getScopeArtifactsPath,
   slugifyFolderName,
   getFolderProjectRoot,
   getFolderProjectArtifactsPath,
@@ -518,6 +520,49 @@ describe('archon-paths', () => {
       delete process.env.ARCHON_DOCKER;
       expect(getRunLogPath('acme', 'widget', 'run-123')).toBe(
         join(homedir(), '.archon', 'workspaces', 'acme', 'widget', 'logs', 'run-123.jsonl')
+      );
+    });
+  });
+
+  describe('sanitizeScopeSegment', () => {
+    test('keeps safe characters unchanged', () => {
+      expect(sanitizeScopeSegment('my-workflow_v2')).toBe('my-workflow_v2');
+      expect(sanitizeScopeSegment('550e8400-e29b-41d4-a716-446655440000')).toBe(
+        '550e8400-e29b-41d4-a716-446655440000'
+      );
+    });
+
+    test('replaces path separators and dots so a segment cannot escape', () => {
+      expect(sanitizeScopeSegment('../../etc')).toBe('______etc');
+      expect(sanitizeScopeSegment('a/b\\c')).toBe('a_b_c');
+      expect(sanitizeScopeSegment('owner/repo#123')).toBe('owner_repo_123');
+    });
+
+    test('falls back to underscore for an empty input', () => {
+      expect(sanitizeScopeSegment('')).toBe('_');
+    });
+  });
+
+  describe('getScopeArtifactsPath', () => {
+    test('returns scopes/<workflow>/<scope>/ under the given artifacts root', () => {
+      expect(getScopeArtifactsPath('/root/artifacts', 'feature-dev', 'conv-uuid-1')).toBe(
+        join('/root/artifacts', 'scopes', 'feature-dev', 'conv-uuid-1')
+      );
+    });
+
+    test('sanitizes workflow name and scope key segments', () => {
+      expect(getScopeArtifactsPath('/root/artifacts', 'wf/../evil', 'a b#c')).toBe(
+        join('/root/artifacts', 'scopes', 'wf____evil', 'a_b_c')
+      );
+    });
+
+    test('composes with run-artifact roots (sibling of runs/)', () => {
+      delete process.env.WORKSPACE_PATH;
+      delete process.env.ARCHON_HOME;
+      delete process.env.ARCHON_DOCKER;
+      const root = getProjectArtifactsPath('acme', 'widget');
+      expect(getScopeArtifactsPath(root, 'wf', 'scope')).toBe(
+        join(homedir(), '.archon', 'workspaces', 'acme', 'widget', 'artifacts', 'scopes', 'wf', 'scope')
       );
     });
   });

--- a/packages/paths/src/archon-paths.test.ts
+++ b/packages/paths/src/archon-paths.test.ts
@@ -562,7 +562,17 @@ describe('archon-paths', () => {
       delete process.env.ARCHON_DOCKER;
       const root = getProjectArtifactsPath('acme', 'widget');
       expect(getScopeArtifactsPath(root, 'wf', 'scope')).toBe(
-        join(homedir(), '.archon', 'workspaces', 'acme', 'widget', 'artifacts', 'scopes', 'wf', 'scope')
+        join(
+          homedir(),
+          '.archon',
+          'workspaces',
+          'acme',
+          'widget',
+          'artifacts',
+          'scopes',
+          'wf',
+          'scope'
+        )
       );
     });
   });

--- a/packages/paths/src/archon-paths.ts
+++ b/packages/paths/src/archon-paths.ts
@@ -448,6 +448,44 @@ export function getRunLogPath(owner: string, repo: string, workflowRunId: string
   return join(getProjectLogsPath(owner, repo), `${workflowRunId}.jsonl`);
 }
 
+/**
+ * Restrict a workflow name or scope key to a single filesystem-safe path
+ * segment. Any character outside `[a-zA-Z0-9_-]` becomes `_`, so a stray
+ * separator or `..` can never escape the scopes directory. Distinct inputs can
+ * collide (e.g. `a.b` and `a_b`) — scope dirs hold per-node files keyed by node
+ * id, so a collision co-mingles two scopes' artifacts rather than corrupting
+ * either. Falls back to `'_'` for an empty input.
+ */
+export function sanitizeScopeSegment(value: string): string {
+  const safe = value.replace(/[^a-zA-Z0-9_-]/g, '_');
+  return safe.length > 0 ? safe : '_';
+}
+
+/**
+ * Get the stable cross-invocation artifact scope directory for a workflow +
+ * scope key (the conversation UUID — the same key `persist_session` uses).
+ * Lives alongside the per-run `runs/` layout under the same artifacts root, so
+ * it works for repo projects, folder projects, and unregistered-cwd fallbacks:
+ *
+ *   <artifactsRoot>/scopes/<workflow>/<scope>/
+ *
+ * Unlike `runs/<id>/`, this path is identical across invocations of the same
+ * workflow in the same scope — it is the durable location a later invocation
+ * (e.g. a cold session resume) can read prior typed artifacts from.
+ */
+export function getScopeArtifactsPath(
+  artifactsRoot: string,
+  workflowName: string,
+  scopeKey: string
+): string {
+  return join(
+    artifactsRoot,
+    'scopes',
+    sanitizeScopeSegment(workflowName),
+    sanitizeScopeSegment(scopeKey)
+  );
+}
+
 // =============================================================================
 // Folder-project ("_folder") path functions
 // =============================================================================

--- a/packages/paths/src/index.ts
+++ b/packages/paths/src/index.ts
@@ -29,6 +29,8 @@ export {
   getProjectLogsPath,
   getRunArtifactsPath,
   getRunLogPath,
+  sanitizeScopeSegment,
+  getScopeArtifactsPath,
   slugifyFolderName,
   getFolderProjectRoot,
   getFolderProjectArtifactsPath,

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -55,6 +55,7 @@ import {
   applyLoopPrevToBodyNode,
   executeDagWorkflow,
 } from './dag-executor';
+import { writeNodeArtifact } from './artifacts-index';
 import { loadMcpConfig } from '@archon/providers/mcp/config';
 import type { DagNode, BashNode, ScriptNode, NodeOutput, WorkflowRun } from './schemas';
 import { discoverWorkflows } from './workflow-discovery';
@@ -9092,6 +9093,293 @@ describe('executeDagWorkflow -- persist_session', () => {
       typeof store.upsertWorkflowNodeSession
     >;
     expect(upsertMock.mock.calls[0][0]).toMatchObject({ provider_session_id: 'cold-id' });
+  });
+
+  // --- #1846: cross-invocation artifact scope + cold-resume pointer recovery ---
+
+  /** Arm the mocks for a cold resume: a persisted prior session that the provider
+   *  reports back as not resumed (fresh fallback). */
+  function armColdResume(store: ReturnType<typeof createMockStore>): void {
+    (store.getWorkflowNodeSession as Mock<typeof store.getWorkflowNodeSession>).mockResolvedValue({
+      workflow_name: 'persist-test',
+      node_id: 'planner',
+      scope_key: 'conv-dag',
+      provider: 'claude',
+      provider_session_id: 'prior-session-id',
+      last_run_id: 'prior-run',
+      created_at: '2026-05-01T00:00:00Z',
+      updated_at: '2026-05-01T00:00:00Z',
+    });
+    mockSendQueryDag.mockClear();
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'cold run' };
+      yield { type: 'result', sessionId: 'cold-id', resumed: false };
+    });
+  }
+
+  it('cold resume with prior scope artifacts → warning carries a by-reference pointer', async () => {
+    const scopeDir = join(testDir, 'scope-artifacts');
+    // A PRIOR invocation left a typed artifact in the stable scope dir.
+    await writeNodeArtifact(
+      scopeDir,
+      {
+        nodeId: 'planner',
+        outputType: 'plan',
+        runId: 'prior-run',
+        producedAt: '2026-05-01T00:00:00Z',
+      },
+      'the prior plan'
+    );
+    const store = createMockStore();
+    armColdResume(store);
+    const platform = createMockPlatform();
+
+    await executeDagWorkflow(
+      createMockDeps(store),
+      platform,
+      'conv-dag',
+      testDir,
+      {
+        name: 'persist-test',
+        nodes: [{ id: 'planner', command: 'my-cmd', persist_session: true }],
+      },
+      makeWorkflowRun(),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      scopeDir
+    );
+
+    const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
+    const messages = sendMessage.mock.calls.map(c => String(c[1]));
+    const coldMessage = messages.find(m => m.includes('could not resume the prior session'));
+    expect(coldMessage).toBeDefined();
+    // By reference: the message names the artifact file's path — never its content.
+    expect(coldMessage).toContain('available for recovery');
+    expect(coldMessage).toContain(join(scopeDir, 'nodes', 'planner.md'));
+    expect(coldMessage).not.toContain('the prior plan');
+    // The #1842 invariant holds: the cold run is kept, never replayed.
+    expect(mockSendQueryDag.mock.calls.length).toBe(1);
+  });
+
+  it('cold resume with scope artifacts only from the CURRENT run → plain warning, no pointer', async () => {
+    const scopeDir = join(testDir, 'scope-artifacts');
+    // Only this run's own mirror exists — it recovers nothing.
+    await writeNodeArtifact(
+      scopeDir,
+      {
+        nodeId: 'planner',
+        outputType: 'plan',
+        runId: 'dag-test-run-id',
+        producedAt: '2026-05-01T00:00:00Z',
+      },
+      'this run output'
+    );
+    const store = createMockStore();
+    armColdResume(store);
+    const platform = createMockPlatform();
+
+    await executeDagWorkflow(
+      createMockDeps(store),
+      platform,
+      'conv-dag',
+      testDir,
+      {
+        name: 'persist-test',
+        nodes: [{ id: 'planner', command: 'my-cmd', persist_session: true }],
+      },
+      makeWorkflowRun(),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      scopeDir
+    );
+
+    const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
+    const messages = sendMessage.mock.calls.map(c => String(c[1]));
+    expect(messages.some(m => m.includes('could not resume the prior session'))).toBe(true);
+    expect(messages.some(m => m.includes('available for recovery'))).toBe(false);
+  });
+
+  it('cold resume with an empty/absent scope dir → plain warning, no pointer', async () => {
+    const store = createMockStore();
+    armColdResume(store);
+    const platform = createMockPlatform();
+
+    await executeDagWorkflow(
+      createMockDeps(store),
+      platform,
+      'conv-dag',
+      testDir,
+      {
+        name: 'persist-test',
+        nodes: [{ id: 'planner', command: 'my-cmd', persist_session: true }],
+      },
+      makeWorkflowRun(),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      join(testDir, 'scope-artifacts-never-created')
+    );
+
+    const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
+    const messages = sendMessage.mock.calls.map(c => String(c[1]));
+    expect(messages.some(m => m.includes('could not resume the prior session'))).toBe(true);
+    expect(messages.some(m => m.includes('available for recovery'))).toBe(false);
+  });
+
+  it('persist node with output_type mirrors its typed sidecar into the scope dir', async () => {
+    const scopeDir = join(testDir, 'scope-artifacts');
+
+    await executeDagWorkflow(
+      createMockDeps(),
+      createMockPlatform(),
+      'conv-dag',
+      testDir,
+      {
+        name: 'persist-test',
+        nodes: [{ id: 'planner', command: 'my-cmd', persist_session: true, output_type: 'plan' }],
+      },
+      makeWorkflowRun(),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      scopeDir
+    );
+
+    // Written to BOTH the per-run dir and the durable scope dir.
+    const runCopy = await readFile(join(testDir, 'artifacts', 'nodes', 'planner.md'), 'utf8');
+    const scopeCopy = await readFile(join(scopeDir, 'nodes', 'planner.md'), 'utf8');
+    expect(runCopy).toBe('AI response');
+    expect(scopeCopy).toBe('AI response');
+    const scopeMeta = JSON.parse(
+      await readFile(join(scopeDir, 'nodes', 'planner.meta.json'), 'utf8')
+    ) as Record<string, unknown>;
+    expect(scopeMeta).toMatchObject({
+      nodeId: 'planner',
+      outputType: 'plan',
+      runId: 'dag-test-run-id',
+    });
+  });
+
+  it('non-persist node with output_type does NOT mirror into the scope dir', async () => {
+    const scopeDir = join(testDir, 'scope-artifacts');
+
+    await executeDagWorkflow(
+      createMockDeps(),
+      createMockPlatform(),
+      'conv-dag',
+      testDir,
+      {
+        name: 'persist-test',
+        // scope dir present (another node opted in), but THIS node doesn't persist.
+        nodes: [{ id: 'planner', command: 'my-cmd', output_type: 'plan' }],
+      },
+      makeWorkflowRun(),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      scopeDir
+    );
+
+    // Run-dir sidecar exists; the scope dir stays untouched.
+    const runCopy = await readFile(join(testDir, 'artifacts', 'nodes', 'planner.md'), 'utf8');
+    expect(runCopy).toBe('AI response');
+    let scopeWrote = true;
+    try {
+      await readFile(join(scopeDir, 'nodes', 'planner.md'), 'utf8');
+    } catch {
+      scopeWrote = false;
+    }
+    expect(scopeWrote).toBe(false);
+  });
+
+  it('scope mirror write failure is non-fatal — node completes, run-dir sidecar intact', async () => {
+    const scopeDir = join(testDir, 'scope-artifacts');
+    // Force the scope write to fail: a FILE where the nodes/ dir must go.
+    await mkdir(scopeDir, { recursive: true });
+    await writeFile(join(scopeDir, 'nodes'), 'not a directory', 'utf8');
+
+    await executeDagWorkflow(
+      createMockDeps(),
+      createMockPlatform(),
+      'conv-dag',
+      testDir,
+      {
+        name: 'persist-test',
+        nodes: [{ id: 'planner', command: 'my-cmd', persist_session: true, output_type: 'plan' }],
+      },
+      makeWorkflowRun(),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      scopeDir
+    );
+
+    // Node ran and the run-dir sidecar was still written (mirror is best-effort).
+    expect(mockSendQueryDag.mock.calls.length).toBe(1);
+    const runCopy = await readFile(join(testDir, 'artifacts', 'nodes', 'planner.md'), 'utf8');
+    expect(runCopy).toBe('AI response');
   });
 
   it('persist_session: true but provider returns no sessionId → delete stale row', async () => {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3643,9 +3643,8 @@ async function executeApprovalNode(
  * True when a node participates in cross-run session persistence: a command/prompt
  * node (see {@link isPersistableNode}) that hasn't opted out via `context: 'fresh'`,
  * with `persist_session: true` set directly or inherited from the workflow-level
- * `persist_sessions` default. Mirrors the executor's `effectivePersist` +
- * `bypassesPersistence` gates so the scope-artifact mirror targets exactly the
- * nodes whose sessions are persisted.
+ * `persist_sessions` default. Single source of truth for both the session
+ * lookup/persist gates and the #1846 scope-artifact mirror.
  */
 function nodeUsesPersistedScope(node: DagNode, workflowPersistSessions: boolean): boolean {
   if (!isPersistableNode(node)) return false;
@@ -3671,7 +3670,7 @@ async function buildColdResumeRecoveryPointer(
   try {
     const priorArtifacts = (await readNodeArtifacts(scopeArtifactsDir))
       .filter(entry => entry.runId !== currentRunId)
-      .sort((a, b) => (a.producedAt < b.producedAt ? 1 : -1));
+      .sort((a, b) => b.producedAt.localeCompare(a.producedAt));
     if (priorArtifacts.length === 0) return '';
     const lines = priorArtifacts.map(
       entry =>
@@ -4185,20 +4184,18 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
           // Parallel layers always get fresh sessions; explicit 'fresh' context also forces it.
           // 'shared' forces continuation. Default: fresh for parallel, inherited for sequential.
           // isFreshSequential controls in-run threading (lastSequentialSessionId).
-          // bypassesPersistence (context:'fresh' only) also disables cross-run persist_session;
-          // a parallel-layer node CAN still use persist_session — it just doesn't share with siblings.
           const isFreshSequential = isParallelLayer || node.context === 'fresh';
-          const bypassesPersistence = node.context === 'fresh';
           let resumeSessionId: string | undefined = isFreshSequential
             ? undefined
             : ctx.lastSequentialSessionId;
 
-          const nodePersistFlag = 'persist_session' in node ? node.persist_session : undefined;
-          // Strictly opt-in: off unless the node sets persist_session, or the workflow
-          // sets persist_sessions and the node doesn't override it to false.
-          const effectivePersist: boolean = nodePersistFlag ?? workflowPersistSessions;
+          // Strictly opt-in: on only when the node sets persist_session (or inherits the
+          // workflow-level persist_sessions default) and doesn't opt out via context:'fresh'.
+          // A parallel-layer node CAN still use persist_session — it just doesn't share
+          // with siblings. Same predicate gates the scope-artifact mirror below.
+          const usesPersistedScope = nodeUsesPersistedScope(node, workflowPersistSessions);
 
-          if (effectivePersist && !bypassesPersistence) {
+          if (usesPersistedScope) {
             // Runtime capability guard via the resolved provider instance (catches the
             // case where provider was resolved from .archon/config.yaml defaults).
             // Uses the instance's getCapabilities() rather than the static registry so
@@ -4382,12 +4379,7 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
 
           // Persist (or drop) the node's provider session ID for the next run in this scope.
           // context:'fresh' nodes are excluded (the author opted out of any cross-run memory).
-          if (
-            effectivePersist &&
-            !bypassesPersistence &&
-            persistScopeKey &&
-            output.state === 'completed'
-          ) {
+          if (usesPersistedScope && persistScopeKey && output.state === 'completed') {
             try {
               if (output.sessionId !== undefined) {
                 await deps.store.upsertWorkflowNodeSession({

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3640,19 +3640,6 @@ async function executeApprovalNode(
 }
 
 /**
- * Shared context for {@link runLayers}. Bundles the run-level invariants (deps, platform,
- * run record, resolved provider/model/options, paths, config) together with the per-subgraph
- * mutable state (the node set + its pre-computed topological layers, the shared output map,
- * session threading, usage accumulators, and resume cache).
- *
- * The top-level DAG and each `loop_group` body iteration construct their own context: the
- * top-level call uses `workflow.nodes` / a fresh `nodeOutputs`; a loop-group body uses the
- * group's `nodes` / a per-iteration scoped `nodeOutputs` (reset each iteration) and a
- * `stepNamePrefix` of `'{groupId}.'` that namespaces runLayers' OWN control events
- * (skip/trigger_rule/when). Body lifecycle events emitted inside executeNodeInternal /
- * executeBashNode / executeScriptNode still use the raw node id (known v1 limitation).
- */
-/**
  * True when a node participates in cross-run session persistence: a command/prompt
  * node (see {@link isPersistableNode}) that hasn't opted out via `context: 'fresh'`,
  * with `persist_session: true` set directly or inherited from the workflow-level
@@ -3700,6 +3687,19 @@ async function buildColdResumeRecoveryPointer(
   }
 }
 
+/**
+ * Shared context for {@link runLayers}. Bundles the run-level invariants (deps, platform,
+ * run record, resolved provider/model/options, paths, config) together with the per-subgraph
+ * mutable state (the node set + its pre-computed topological layers, the shared output map,
+ * session threading, usage accumulators, and resume cache).
+ *
+ * The top-level DAG and each `loop_group` body iteration construct their own context: the
+ * top-level call uses `workflow.nodes` / a fresh `nodeOutputs`; a loop-group body uses the
+ * group's `nodes` / a per-iteration scoped `nodeOutputs` (reset each iteration) and a
+ * `stepNamePrefix` of `'{groupId}.'` that namespaces runLayers' OWN control events
+ * (skip/trigger_rule/when). Body lifecycle events emitted inside executeNodeInternal /
+ * executeBashNode / executeScriptNode still use the raw node id (known v1 limitation).
+ */
 interface RunLayersContext {
   // --- run-level invariants (shared by top-level DAG and loop_group body) ---
   deps: WorkflowDeps;

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -52,6 +52,7 @@ import {
   isApprovalNode,
   isCancelNode,
   isScriptNode,
+  isPersistableNode,
   isApprovalContext,
 } from './schemas';
 import { formatToolCall } from './utils/tool-formatter';
@@ -60,7 +61,7 @@ import type { WorkflowErrorClass, WorkflowNodeType } from '@archon/paths';
 import { getWorkflowEventEmitter } from './event-emitter';
 import { evaluateCondition } from './condition-evaluator';
 import { declaredFieldsFromSchema, resolveNodeOutputField } from './output-ref';
-import { writeNodeArtifact } from './artifacts-index';
+import { writeNodeArtifact, readNodeArtifacts } from './artifacts-index';
 import {
   logNodeStart,
   logNodeComplete,
@@ -2419,9 +2420,11 @@ async function executeLoopGroupNode(
       issueContext,
       // persist_session across iterations is out of v1 scope (body sessions reset per
       // iteration, governed by fresh_context). Pass undefined/false so body nodes don't
-      // participate in cross-run session persistence inside the loop.
+      // participate in cross-run session persistence inside the loop — and therefore
+      // no scope-artifact mirroring either.
       persistScopeKey: undefined,
       workflowPersistSessions: false,
+      scopeArtifactsDir: undefined,
       layers: iterBodyLayers,
       nodeOutputs: scopedNodeOutputs,
       priorCompletedNodes: undefined, // body re-runs in full each iteration (v1)
@@ -3649,6 +3652,54 @@ async function executeApprovalNode(
  * (skip/trigger_rule/when). Body lifecycle events emitted inside executeNodeInternal /
  * executeBashNode / executeScriptNode still use the raw node id (known v1 limitation).
  */
+/**
+ * True when a node participates in cross-run session persistence: a command/prompt
+ * node (see {@link isPersistableNode}) that hasn't opted out via `context: 'fresh'`,
+ * with `persist_session: true` set directly or inherited from the workflow-level
+ * `persist_sessions` default. Mirrors the executor's `effectivePersist` +
+ * `bypassesPersistence` gates so the scope-artifact mirror targets exactly the
+ * nodes whose sessions are persisted.
+ */
+function nodeUsesPersistedScope(node: DagNode, workflowPersistSessions: boolean): boolean {
+  if (!isPersistableNode(node)) return false;
+  if (node.context === 'fresh') return false;
+  const nodePersist = 'persist_session' in node ? node.persist_session : undefined;
+  return nodePersist ?? workflowPersistSessions;
+}
+
+/**
+ * Build the by-reference recovery suffix for a cold-resume warning (#1846): list
+ * the typed artifacts that PRIOR invocations of this workflow+scope left in the
+ * stable scope dir, as absolute file paths — never pasted content. Entries
+ * produced by the current run are excluded (they can't recover anything the
+ * fresh session doesn't already have). Returns `''` when there is nothing to
+ * point at, or when the scope dir can't be read — recovery is best-effort and
+ * must never turn a successful (if cold) node into a failure.
+ */
+async function buildColdResumeRecoveryPointer(
+  scopeArtifactsDir: string,
+  currentRunId: string,
+  nodeId: string
+): Promise<string> {
+  try {
+    const priorArtifacts = (await readNodeArtifacts(scopeArtifactsDir))
+      .filter(entry => entry.runId !== currentRunId)
+      .sort((a, b) => (a.producedAt < b.producedAt ? 1 : -1));
+    if (priorArtifacts.length === 0) return '';
+    const lines = priorArtifacts.map(
+      entry =>
+        `- ${entry.outputType} (\`${entry.nodeId}\`): ${joinPath(scopeArtifactsDir, entry.path)}`
+    );
+    return `\nArtifacts from the previous invocation are available for recovery (read on demand):\n${lines.join('\n')}`;
+  } catch (err) {
+    getLog().warn(
+      { err: err as Error, scopeArtifactsDir, nodeId },
+      'dag.cold_resume_artifacts_read_failed'
+    );
+    return '';
+  }
+}
+
 interface RunLayersContext {
   // --- run-level invariants (shared by top-level DAG and loop_group body) ---
   deps: WorkflowDeps;
@@ -3674,6 +3725,15 @@ interface RunLayersContext {
   persistScopeKey: string | undefined;
   /** Workflow-level default for per-node `persist_session` (opt-in). */
   workflowPersistSessions: boolean;
+  /**
+   * Stable cross-invocation artifact scope dir (`scopes/<workflow>/<scope>/`), or
+   * undefined when the workflow doesn't use session persistence. When set,
+   * persistence-participating nodes with `output_type` mirror their typed sidecars
+   * here, and a cold session resume points the user at the prior invocation's
+   * artifacts by reference (#1846). Always undefined for loop_group bodies
+   * (which also run with `persistScopeKey: undefined`).
+   */
+  scopeArtifactsDir: string | undefined;
 
   // --- per-subgraph mutable state (varies between top-level DAG and loop_group body) ---
   /** Pre-computed topological layers (caller builds once — body shape is static). runLayers walks ONLY these; there is deliberately no flat node list here. */
@@ -3725,6 +3785,7 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
     issueContext,
     persistScopeKey,
     workflowPersistSessions,
+    scopeArtifactsDir,
     layers,
     priorCompletedNodes,
     stepNamePrefix,
@@ -4289,6 +4350,16 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
             output.state === 'completed' &&
             output.resumed === false
           ) {
+            // By-reference recovery (#1846): the prior session is gone, but prior
+            // invocations of this workflow+scope may have left typed artifacts in
+            // the stable scope dir. Point at them (paths only — never pasted
+            // content) so the lost context is recoverable on demand. Entries from
+            // THIS run are excluded — they were produced by the current (fresh)
+            // invocation and recover nothing. Best-effort: a scope-dir read
+            // failure degrades to the plain warning, never fails the node.
+            const recoveryPointer = scopeArtifactsDir
+              ? await buildColdResumeRecoveryPointer(scopeArtifactsDir, workflowRun.id, node.id)
+              : '';
             // Mask the session id: it's a resumable artifact, so log only an
             // 8-char preview (same policy as the node_session_resumed event above).
             getLog().warn(
@@ -4297,13 +4368,14 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
                 provider,
                 workflowRunId: workflowRun.id,
                 resumeSessionId: `${resumeSessionId.slice(0, 8)}…`,
+                priorArtifactsFound: recoveryPointer !== '',
               },
               'dag.session_resume_failed'
             );
             await safeSendMessage(
               platform,
               conversationId,
-              `⚠️ Node \`${node.id}\`: could not resume the prior session — continued with a fresh session, so the earlier context was not restored.`,
+              `⚠️ Node \`${node.id}\`: could not resume the prior session — continued with a fresh session, so the earlier context was not restored.${recoveryPointer}`,
               { workflowId: workflowRun.id, nodeName: node.id }
             );
           }
@@ -4426,25 +4498,37 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
         // never fail an otherwise-successful node.
         const completedNode = nodeById.get(nodeId);
         if (output.state === 'completed' && completedNode?.output_type) {
+          const meta = {
+            nodeId,
+            outputType: completedNode.output_type,
+            runId: workflowRun.id,
+            producedAt: new Date().toISOString(),
+            // `sessionId` may be undefined (e.g. bash/script nodes have no
+            // session); writeNodeArtifact omits it from the metadata when so.
+            sessionId: output.sessionId,
+          };
           try {
-            await writeNodeArtifact(
-              artifactsDir,
-              {
-                nodeId,
-                outputType: completedNode.output_type,
-                runId: workflowRun.id,
-                producedAt: new Date().toISOString(),
-                // `sessionId` may be undefined (e.g. bash/script nodes have no
-                // session); writeNodeArtifact omits it from the metadata when so.
-                sessionId: output.sessionId,
-              },
-              output.output
-            );
+            await writeNodeArtifact(artifactsDir, meta, output.output);
           } catch (err) {
             getLog().warn(
               { err: err as Error, nodeId, workflowRunId: workflowRun.id },
               'artifacts.write_failed'
             );
+          }
+          // Scope mirror (#1846): persistence-participating nodes also write their
+          // typed sidecar into the stable `scopes/<workflow>/<scope>/` dir, so the
+          // NEXT invocation can recover this output by reference if its persisted
+          // session comes back cold. Per-node files; concurrent same-scope runs are
+          // last-writer-wins for a given node. Best-effort, like the run-dir write.
+          if (scopeArtifactsDir && nodeUsesPersistedScope(completedNode, workflowPersistSessions)) {
+            try {
+              await writeNodeArtifact(scopeArtifactsDir, meta, output.output);
+            } catch (err) {
+              getLog().warn(
+                { err: err as Error, nodeId, workflowRunId: workflowRun.id, scopeArtifactsDir },
+                'artifacts.scope_write_failed'
+              );
+            }
           }
         }
         if (output.state === 'completed' && !isParallelLayer && output.sessionId !== undefined) {
@@ -4536,7 +4620,13 @@ export async function executeDagWorkflow(
   /** Discovery source — telemetry only (custom-vs-default + name redaction). */
   source?: WorkflowSource,
   aiProfile?: ResolvedAiProfile,
-  workflowPreset?: ModelAliasPreset
+  workflowPreset?: ModelAliasPreset,
+  /**
+   * Stable cross-invocation artifact scope dir (`scopes/<workflow>/<scope>/`),
+   * resolved by executor.ts when the workflow uses session persistence (#1846).
+   * Undefined otherwise — no mirroring, no cold-resume pointer.
+   */
+  scopeArtifactsDir?: string
 ): Promise<string | undefined> {
   const dagStartTime = Date.now();
   const workflowTier = workflow.model && isTierName(workflow.model) ? workflow.model : undefined;
@@ -4617,6 +4707,9 @@ export async function executeDagWorkflow(
     issueContext,
     persistScopeKey,
     workflowPersistSessions,
+    // Scope-keyed persistence surface: without a scope key there is no durable
+    // scope to mirror into or recover from, so the dir is dropped alongside it.
+    scopeArtifactsDir: persistScopeKey !== undefined ? scopeArtifactsDir : undefined,
     layers,
     nodeOutputs,
     priorCompletedNodes,

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -686,6 +686,48 @@ describe('executeWorkflow', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Scope artifacts dir threading (#1846)
+  // -------------------------------------------------------------------------
+
+  describe('scope artifacts dir threading', () => {
+    it('threads scopeArtifactsDir into executeDagWorkflow for persist_session workflows', async () => {
+      const store = makeStore();
+      const deps = makeDeps(store);
+      await executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-1',
+        '/tmp',
+        makeWorkflow({ nodes: [{ id: 'node1', prompt: 'Do something', persist_session: true }] }),
+        'test message',
+        'db-conv-1'
+      );
+      // Positional arg 19 = scopeArtifactsDir (after workflowPreset). Root is the
+      // cwd fallback (.archon/artifacts); scope = workflow name + conversation UUID
+      // ('conv-1' from the createWorkflowRun mock; getScopeArtifactsPath is mocked
+      // to `${root}/scopes/${wf}/${scope}`).
+      const scopeArg = mockExecuteDagWorkflow.mock.calls[0]?.[19] as string | undefined;
+      expect(scopeArg).toBe(`${join('/tmp', '.archon', 'artifacts')}/scopes/test-workflow/conv-1`);
+    });
+
+    it('passes undefined scopeArtifactsDir when the workflow uses no session persistence', async () => {
+      const store = makeStore();
+      const deps = makeDeps(store);
+      await executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-1',
+        '/tmp',
+        makeWorkflow(),
+        'test message',
+        'db-conv-1'
+      );
+      const scopeArg = mockExecuteDagWorkflow.mock.calls[0]?.[19] as string | undefined;
+      expect(scopeArg).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Pre-created run (uses existing row but still runs guards)
   // -------------------------------------------------------------------------
 

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -29,11 +29,16 @@ mock.module('@archon/paths', () => ({
   parseOwnerRepo: mock(() => null),
   getRunArtifactsPath: mock(() => '/tmp/artifacts'),
   getProjectLogsPath: mock(() => '/tmp/logs'),
+  getProjectArtifactsPath: mock(() => '/tmp/artifacts-root'),
   slugifyFolderName: mock((name: string) => name),
   getFolderRunArtifactsPath: mock(
     (slug: string, runId: string) => `/tmp/_folder/${slug}/artifacts/runs/${runId}`
   ),
   getFolderProjectLogsPath: mock((slug: string) => `/tmp/_folder/${slug}/logs`),
+  getFolderProjectArtifactsPath: mock((slug: string) => `/tmp/_folder/${slug}/artifacts`),
+  getScopeArtifactsPath: mock(
+    (root: string, wf: string, scope: string) => `${root}/scopes/${wf}/${scope}`
+  ),
   captureWorkflowInvoked: mockCaptureWorkflowInvoked,
   captureWorkflowCompleted: mockCaptureWorkflowCompleted,
 }));
@@ -72,7 +77,12 @@ clearRegistry();
 registerBuiltinProviders();
 
 // --- Import after mocks ---
-import { executeWorkflow, hydrateResumableRun, resolveProjectPaths } from './executor';
+import {
+  executeWorkflow,
+  hydrateResumableRun,
+  resolveProjectPaths,
+  resolveScopeArtifactsDir,
+} from './executor';
 import { keepAwake } from './utils/keep-awake';
 import type { WorkflowDeps, IWorkflowPlatform, WorkflowConfig } from './deps';
 import type { IWorkflowStore } from './store';
@@ -1445,6 +1455,7 @@ describe('resolveProjectPaths', () => {
     // slugifyFolderName is mocked to identity, so slug === name here
     expect(paths.artifactsDir).toBe('/tmp/_folder/My Platform/artifacts/runs/run-xyz');
     expect(paths.logDir).toBe('/tmp/_folder/My Platform/logs');
+    expect(paths.artifactsRoot).toBe('/tmp/_folder/My Platform/artifacts');
   });
 
   it('routes repo projects to owner/repo/ storage (unchanged)', async () => {
@@ -1466,9 +1477,10 @@ describe('resolveProjectPaths', () => {
 
     const result = await resolveProjectPaths(deps, '/repos/widget', RUN_ID, 'cb-repo');
 
-    // getRunArtifactsPath/getProjectLogsPath are mocked to constants
+    // getRunArtifactsPath/getProjectLogsPath/getProjectArtifactsPath are mocked to constants
     expect(result.artifactsDir).toBe('/tmp/artifacts');
     expect(result.logDir).toBe('/tmp/logs');
+    expect(result.artifactsRoot).toBe('/tmp/artifacts-root');
   });
 
   it('falls back to cwd-based paths when no codebase is registered', async () => {
@@ -1490,5 +1502,51 @@ describe('resolveProjectPaths', () => {
 
     expect(result.artifactsDir).toBe(join('/some/cwd', '.archon', 'artifacts', 'runs', RUN_ID));
     expect(result.logDir).toBe(join('/some/cwd', '.archon', 'logs'));
+    expect(result.artifactsRoot).toBe(join('/some/cwd', '.archon', 'artifacts'));
+  });
+});
+
+describe('resolveScopeArtifactsDir', () => {
+  const ROOT = '/tmp/artifacts-root';
+
+  it('returns the scope dir for a workflow with a persist_session node', () => {
+    const workflow = {
+      name: 'feature-dev',
+      nodes: [
+        { id: 'planner', prompt: 'plan', persist_session: true },
+      ] as WorkflowDefinition['nodes'],
+    };
+    expect(resolveScopeArtifactsDir(workflow, 'conv-1', ROOT)).toBe(
+      `${ROOT}/scopes/feature-dev/conv-1`
+    );
+  });
+
+  it('returns the scope dir for workflow-level persist_sessions', () => {
+    const workflow = {
+      name: 'feature-dev',
+      persist_sessions: true,
+      nodes: [{ id: 'planner', prompt: 'plan' }] as WorkflowDefinition['nodes'],
+    };
+    expect(resolveScopeArtifactsDir(workflow, 'conv-1', ROOT)).toBe(
+      `${ROOT}/scopes/feature-dev/conv-1`
+    );
+  });
+
+  it('returns undefined when the workflow uses no session persistence (opt-in)', () => {
+    const workflow = {
+      name: 'plain',
+      nodes: [{ id: 'a', prompt: 'x' }] as WorkflowDefinition['nodes'],
+    };
+    expect(resolveScopeArtifactsDir(workflow, 'conv-1', ROOT)).toBeUndefined();
+  });
+
+  it('returns undefined without a conversation scope (same guard as persistScopeKey)', () => {
+    const workflow = {
+      name: 'feature-dev',
+      persist_sessions: true,
+      nodes: [] as WorkflowDefinition['nodes'],
+    };
+    expect(resolveScopeArtifactsDir(workflow, null, ROOT)).toBeUndefined();
+    expect(resolveScopeArtifactsDir(workflow, undefined, ROOT)).toBeUndefined();
   });
 });

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -9,6 +9,7 @@ import * as archonPaths from '@archon/paths';
 import { createLogger, captureWorkflowInvoked, captureWorkflowCompleted } from '@archon/paths';
 import { getDefaultBranch, toRepoPath } from '@archon/git';
 import type {
+  DagNode,
   WorkflowDefinition,
   WorkflowRun,
   WorkflowExecutionResult,
@@ -227,6 +228,10 @@ async function resolveUserProviderEnvForWorkflow(
  * Folder projects route to `_folder/<slug>/` storage; falls back to cwd-based
  * paths for unregistered repos.
  *
+ * `artifactsRoot` is the parent of the `runs/` layout (`.../artifacts`) — the base
+ * that run-scoped (`runs/<id>/`) and scope-scoped (`scopes/<workflow>/<scope>/`,
+ * #1846) storage both hang off, whichever branch resolved it.
+ *
  * Exported for unit testing of the kind-based branch selection.
  */
 export async function resolveProjectPaths(
@@ -234,7 +239,7 @@ export async function resolveProjectPaths(
   cwd: string,
   workflowRunId: string,
   codebaseId?: string
-): Promise<{ artifactsDir: string; logDir: string }> {
+): Promise<{ artifactsDir: string; logDir: string; artifactsRoot: string }> {
   if (codebaseId) {
     try {
       const codebase = await deps.store.getCodebase(codebaseId);
@@ -246,6 +251,7 @@ export async function resolveProjectPaths(
           return {
             artifactsDir: archonPaths.getFolderRunArtifactsPath(slug, workflowRunId),
             logDir: archonPaths.getFolderProjectLogsPath(slug),
+            artifactsRoot: archonPaths.getFolderProjectArtifactsPath(slug),
           };
         }
         const parsed = archonPaths.parseOwnerRepo(codebase.name);
@@ -253,6 +259,7 @@ export async function resolveProjectPaths(
           return {
             artifactsDir: archonPaths.getRunArtifactsPath(parsed.owner, parsed.repo, workflowRunId),
             logDir: archonPaths.getProjectLogsPath(parsed.owner, parsed.repo),
+            artifactsRoot: archonPaths.getProjectArtifactsPath(parsed.owner, parsed.repo),
           };
         }
         getLog().warn({ codebaseName: codebase.name }, 'codebase_name_not_owner_repo_format');
@@ -269,7 +276,29 @@ export async function resolveProjectPaths(
   return {
     artifactsDir: join(cwd, '.archon', 'artifacts', 'runs', workflowRunId),
     logDir: join(cwd, '.archon', 'logs'),
+    artifactsRoot: join(cwd, '.archon', 'artifacts'),
   };
+}
+
+/**
+ * Resolve the stable cross-invocation artifact scope dir for a run (#1846), or
+ * undefined when the feature doesn't apply. Applies only when the workflow uses
+ * cross-run session persistence (workflow-level `persist_sessions` or any node
+ * `persist_session: true`) AND the run has a conversation scope — the same
+ * opt-in + scope key the session store uses. No persistence → no new dirs,
+ * default behavior unchanged.
+ */
+export function resolveScopeArtifactsDir(
+  workflow: { name: string; nodes: readonly DagNode[]; persist_sessions?: boolean },
+  conversationId: string | null | undefined,
+  artifactsRoot: string
+): string | undefined {
+  if (!conversationId) return undefined;
+  const usesPersistence =
+    workflow.persist_sessions === true ||
+    workflow.nodes.some(n => 'persist_session' in n && n.persist_session === true);
+  if (!usesPersistence) return undefined;
+  return archonPaths.getScopeArtifactsPath(artifactsRoot, workflow.name, conversationId);
 }
 
 /**
@@ -683,11 +712,27 @@ export async function executeWorkflow(
   }
 
   // Resolve external artifact and log directories
-  const { artifactsDir, logDir } = await resolveProjectPaths(deps, cwd, workflowRun.id, codebaseId);
+  const { artifactsDir, logDir, artifactsRoot } = await resolveProjectPaths(
+    deps,
+    cwd,
+    workflowRun.id,
+    codebaseId
+  );
+
+  // Stable cross-invocation artifact scope (#1846): only for persist_session
+  // workflows with a conversation scope. Undefined otherwise — zero new dirs.
+  const scopeArtifactsDir = resolveScopeArtifactsDir(
+    workflow,
+    workflowRun.conversation_id,
+    artifactsRoot
+  );
 
   // Pre-create the artifacts directory so commands can write to it immediately
+  // (and the durable scope dir, when the workflow opted into one — same disk,
+  // same failure mode, same fatal treatment).
   try {
     await mkdir(artifactsDir, { recursive: true });
+    if (scopeArtifactsDir) await mkdir(scopeArtifactsDir, { recursive: true });
   } catch (error) {
     const err = error as NodeJS.ErrnoException;
     getLog().error(
@@ -904,7 +949,8 @@ export async function executeWorkflow(
       dagPriorCompletedNodes,
       source,
       aiProfile,
-      workflowPreset
+      workflowPreset,
+      scopeArtifactsDir
     );
 
     // executeDagWorkflow throws on fatal errors; check DB status for result


### PR DESCRIPTION
## Summary

- Problem: when a `persist_session` node's provider session can't be restored (Codex thread expired, Pi JSONL gone), the node runs cold with zero prior context. PR #1842 made the loss visible (warn) but not recoverable — the prior invocation's artifacts sit unreachable in run-isolated `runs/<oldId>/` dirs.
- Why it matters: cross-run workflows (plan → implement → review with memory) degrade silently-blind on cold resume; the context needed for recovery is usually already on disk.
- What changed: a stable cross-invocation artifact scope `scopes/<workflow>/<scope>/` (sibling of `runs/<id>/`, same artifacts root); persistence-participating nodes with `output_type` mirror their typed sidecars there; the cold-resume branch (`resumed === false`) now appends a **by-reference** pointer (file paths, never content) to the prior invocation's typed artifacts.
- What did **not** change (scope boundary): no suspend/checkpoint primitive, no `pauseWorkflowRun` type changes (that surface belongs to the container-isolation plan's shared `type:` discriminator design); no DB table (explicitly rejected in the issue); no `$SCOPE_ARTIFACTS_DIR` prompt variable; no summarization (#1848); warm resume / first run / non-persist workflows byte-identical.

## UX Journey

### Before

```
run N:   planner (persist_session, output_type: plan) writes runs/<N>/nodes/plan …
         session 'sess-123' persisted (id only)
run N+1: planner resumes 'sess-123' ──▶ session GONE ──▶ fresh session
         ⚠️ "could not resume the prior session — … context was not restored."
         [!] runs/<N+1>/ is EMPTY; runs/<N>/ artifacts exist but are unreferenced
```

### After

```
run N:   planner (persist_session, output_type: plan)
         └─ sidecar written to runs/<N>/nodes/ AND *scopes/<wf>/<conv>/nodes/*  [+]
run N+1: planner resumes ──▶ session GONE ──▶ resumed=false
         ⚠️ "could not resume the prior session — … context was not restored.
          *Artifacts from the previous invocation are available for recovery
           (read on demand):
           - plan (`planner`): …/artifacts/scopes/feature-dev/<conv>/nodes/planner.md*"  [+]
         └─ by reference — the model/operator Reads it on demand; nothing pasted
```

## Architecture Diagram

### Before

```
executor.ts ── resolveProjectPaths ──▶ { artifactsDir, logDir }
     │
     └─▶ executeDagWorkflow(…, artifactsDir) ─▶ runLayers(ctx)
              ├─ persist lookup (workflow_node_sessions, scope = conversation UUID)
              ├─ cold-resume branch: warn only
              └─ output_type ─▶ writeNodeArtifact(artifactsDir)   [runs/<id>/ only]
```

### After

```
@archon/paths [~]: getScopeArtifactsPath(artifactsRoot, wf, scope) [+], sanitizeScopeSegment [+]
     ▲
executor.ts [~] ── resolveProjectPaths ──▶ { artifactsDir, logDir, artifactsRoot [+] }
     ├─ resolveScopeArtifactsDir [+]  (opt-in: persist_session ∧ conversation scope)
     └─▶ executeDagWorkflow(…, scopeArtifactsDir [+]) ─▶ runLayers(ctx.scopeArtifactsDir [+])
              ├─ persist lookup (unchanged)
              ├─ cold-resume branch [~]: warn + buildColdResumeRecoveryPointer [+]
              │       └=== readNodeArtifacts(scopeArtifactsDir)  (first production reader)
              └─ output_type ─▶ writeNodeArtifact(artifactsDir)
                      └=== ALSO writeNodeArtifact(scopeArtifactsDir) for persist nodes [+]
loop_group iterCtx: scopeArtifactsDir = undefined (bodies never persist — unchanged)
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `executor.resolveProjectPaths` | `@archon/paths` artifact roots | **modified** | also returns `artifactsRoot` (all 3 branches: repo / folder / cwd fallback) |
| `executor.executeWorkflow` | `executor.resolveScopeArtifactsDir` | **new** | opt-in gate; mkdir in the same fatal block as artifactsDir |
| `executor.executeWorkflow` | `dag-executor.executeDagWorkflow` | **modified** | new trailing optional `scopeArtifactsDir` |
| `dag-executor.runLayers` | `artifacts-index.writeNodeArtifact` | **modified** | scope mirror for persist+`output_type` nodes (best-effort, `artifacts.scope_write_failed`) |
| `dag-executor.runLayers` (cold branch) | `artifacts-index.readNodeArtifacts` | **new** | pointer built from prior-run entries only (`runId` filter) |
| `executeLoopGroupNode` iterCtx | `runLayers` | unchanged | `scopeArtifactsDir: undefined`, matching `persistScopeKey: undefined` |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `workflows`
- Module: `workflows:executor`, `workflows:dag-executor`, `paths:archon-paths`

## Change Metadata

- Change type: `feature`
- Primary scope: `workflows`

## Linked Issue

- Closes #1846
- Related #1847 (typed-artifact sidecars this builds on), #1842 (`resumed` outcome + cold-resume branch), #2032 (`runLayers` refactor this is rebased onto)

## Validation Evidence (required)

```bash
bun run validate   # exit 0 — check:bundled, check:bundled-skill, check:bundled-schema,
                   # check:pi-vendor-map, type-check, lint, format:check, tests all green
bun test packages/workflows/src/dag-executor.test.ts   # 320 pass / 0 fail
bun test packages/workflows/src/executor.test.ts       # 63 pass / 0 fail
bun test packages/paths/src/archon-paths.test.ts       # 103 pass / 0 fail
```

- Evidence provided: 6 new dag-executor tests (pointer present / current-run-filtered / empty-scope / both-dir mirror / non-persist exclusion / non-fatal mirror failure), 4 new resolveScopeArtifactsDir tests, artifactsRoot assertions on all resolveProjectPaths branches, 6 new paths tests.
- Skipped: none.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No` — the scope dir lives under the same per-project artifacts root that `runs/<id>/` already uses; `sanitizeScopeSegment` confines workflow name + scope key to single path segments (no traversal).
- If any `Yes`, describe risk and mitigation: n/a

## Compatibility / Migration

- Backward compatible? `Yes` — strictly opt-in: no `persist_session` → no scope dir, no mirror, no pointer. Warm resumes and first runs are untouched (the pointer lives only inside the pre-existing `resumed === false` branch).
- Config/env changes? `No`
- Database migration needed? `No`
- If yes, exact upgrade steps: n/a

## Human Verification (required)

- Verified scenarios: full workflows test suite (5 isolated batches) incl. the #1842 cold-resume invariants (no replay, fresh id persisted) and the #1851 typed-artifact tests; new round-trip test seeds a prior invocation's scope artifact and asserts the cold-resume message carries its path but not its content.
- Edge cases checked: current-run artifacts filtered out of the pointer; absent/empty scope dir → plain warning; scope mirror write failure non-fatal (run-dir sidecar intact, node completes); no conversation scope (CLI default) → feature fully off; loop_group bodies excluded.
- What was not verified: a live provider cold resume end-to-end (requires expiring a real Codex/Pi session); the unit tests simulate the provider `resumed: false` contract exactly as #1842's tests do.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: workflow engine only; behavior changes exclusively for `persist_session` workflows (new dir + mirrored sidecars) and their cold resumes (extended warning).
- Potential unintended effects: scope dirs accumulate per (workflow, conversation) — one small `.md` + `.meta.json` per typed node, overwritten per invocation (bounded growth); concurrent same-scope runs are last-writer-wins per node (documented).
- Guardrails/monitoring: `artifacts.scope_write_failed`, `dag.cold_resume_artifacts_read_failed` warn logs; `dag.session_resume_failed` now records `priorArtifactsFound`.

## Rollback Plan (required)

- Fast rollback command/path: revert the 3 commits (paths / engine / docs) — additive, no migration, no config.
- Feature flags or config toggles: none needed; absence of `persist_session` is the off state.
- Observable failure symptoms: unexpected `scopes/` dirs, scope-write warn logs, malformed cold-resume messages.

## Risks and Mitigations

- Risk: sanitized workflow/scope segments could collide (e.g. `a.b` vs `a_b`), co-mingling two scopes' artifacts.
  - Mitigation: same accepted policy as artifacts-index `safeSegment` and `slugifyFolderName`; per-node files mean a collision co-mingles listings rather than corrupting outputs; documented in the helper's JSDoc.
- Risk: a stale prior artifact could mislead a cold-resumed session.
  - Mitigation: pointer is by-reference and clearly labeled as from the previous invocation; the model reads on demand instead of having stale text injected (the #1392 footgun this design explicitly avoids).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added by-reference cold-resume recovery for persisted sessions: when a fresh-session fallback occurs, the warning can include a pointer to prior typed artifacts stored for that workflow/scope.
  - Introduced stable, cross-invocation scope artifact mirroring for eligible persisted nodes (best-effort) when typed `output_type` is available; cold-resume surfaces earlier artifacts as file-path references.
- **Documentation**
  - Documented the opt-in conditions, scope artifact locations, “last writer wins” behavior, and conversation ID influence.
- **Bug Fixes**
  - If scope mirroring fails, current-run artifacts remain intact.
- **Tests**
  - Expanded coverage for scope path sanitization, scope mirroring, and cold-resume warning/pointer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->