### PR TITLE
feat(cli): default chat model step in archon setup

### DIFF
--- a/packages/cli/src/commands/ai.ts
+++ b/packages/cli/src/commands/ai.ts
@@ -649,15 +649,29 @@ export async function aiAliasListCommand(json?: boolean): Promise<number> {
 }
 
 /**
+ * Install-scope atomic default write (#1998/#2082): `defaultAssistant` and,
+ * when a model is given, `assistants.<provider>.model` land in
+ * ~/.archon/config.yaml together. Shared by `archon ai default --scope
+ * install` and the setup wizard's default-chat-model step (#1999) so the
+ * "provider + model must land together" invariant has exactly one home —
+ * a model pin must never ride a different provider. Omitting the model
+ * leaves `assistants.<provider>.model` untouched (it predates this command
+ * and also drives workflow defaults). Caller validates the provider.
+ */
+export async function setInstallDefault(provider: string, model?: string): Promise<void> {
+  await updateGlobalConfig({
+    defaultAssistant: provider,
+    ...(model ? { assistants: { [provider]: { model } } } : {}),
+  });
+}
+
+/**
  * `archon ai default <provider> [<model>] [--scope user|install]` — set the
  * default assistant, optionally with a default CHAT model (#1998).
  *
  * User scope writes provider + model ATOMICALLY to the per-user prefs row:
  * omitting the model clears any previous pin (a pin is only meaningful for the
- * provider it was set with). Install scope writes `defaultAssistant` and, when
- * a model is given, `assistants.<provider>.model` in ~/.archon/config.yaml;
- * omitting the model leaves `assistants.<provider>.model` untouched (it
- * predates this command and also drives workflow defaults).
+ * provider it was set with). Install scope writes via setInstallDefault above.
  */
 export async function aiDefaultCommand(
   provider: string | undefined,
@@ -688,10 +702,7 @@ export async function aiDefaultCommand(
         );
       }
     } else {
-      await updateGlobalConfig({
-        defaultAssistant: provider,
-        ...(model ? { assistants: { [provider]: { model } } } : {}),
-      });
+      await setInstallDefault(provider, model);
       if (model) {
         console.log(`✓ Default assistant set to '${provider}' with default model '${model}'.`);
       } else {

--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -17,6 +17,8 @@ import {
   serializeEnv,
   resolveScopedEnvPath,
   writeHomePiModelConfig,
+  buildDefaultModelChoices,
+  readInstallDefaultModel,
 } from './setup';
 import * as setupModule from './setup';
 import { copyArchonSkill } from './skill';
@@ -901,5 +903,87 @@ describe('checkPiModule', () => {
     });
     expect(result.ok).toBe(false);
     expect(result.error).toContain('pi-coding-agent');
+  });
+});
+
+describe('buildDefaultModelChoices (#1999)', () => {
+  it('leads with "Keep SDK default" when no current model and ends with the free-text escape', () => {
+    const choices = buildDefaultModelChoices('claude', undefined);
+    expect(choices[0].value).toBe('__keep__');
+    expect(choices[0].label).toBe('Keep SDK default');
+    expect(choices[choices.length - 1].value).toBe('__custom__');
+  });
+
+  it('surfaces the current model in the keep option label on re-run', () => {
+    const choices = buildDefaultModelChoices('claude', 'opus');
+    expect(choices[0].label).toBe('Keep current (opus)');
+  });
+
+  it('includes the curated claude shortlist between keep and custom', () => {
+    const values = buildDefaultModelChoices('claude', undefined).map(c => c.value);
+    expect(values).toEqual(['__keep__', 'sonnet', 'opus', 'haiku', '__custom__']);
+  });
+
+  it('includes the curated codex shortlist', () => {
+    const values = buildDefaultModelChoices('codex', undefined).map(c => c.value);
+    expect(values).toEqual(['__keep__', 'gpt-5.3-codex', 'gpt-5.5', 'gpt-5.2', '__custom__']);
+  });
+
+  it('falls back to keep + custom only for providers without a curated list', () => {
+    const values = buildDefaultModelChoices('some-future-provider', undefined).map(c => c.value);
+    expect(values).toEqual(['__keep__', '__custom__']);
+  });
+});
+
+describe('readInstallDefaultModel (#1999)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'archon-default-model-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const configAt = (content: string): string => {
+    const path = join(tmpDir, 'config.yaml');
+    writeFileSync(path, content);
+    return path;
+  };
+
+  it('returns the configured model from assistants.<provider>.model', () => {
+    const path = configAt(
+      'assistants:\n  claude:\n    model: opus\n  codex:\n    model: gpt-5.5\n'
+    );
+    expect(readInstallDefaultModel('claude', path)).toBe('opus');
+    expect(readInstallDefaultModel('codex', path)).toBe('gpt-5.5');
+  });
+
+  it('returns undefined when the config file does not exist', () => {
+    expect(readInstallDefaultModel('claude', join(tmpDir, 'missing.yaml'))).toBeUndefined();
+  });
+
+  it('returns undefined when the provider has no model entry', () => {
+    const path = configAt('assistants:\n  claude:\n    settingSources:\n      - project\n');
+    expect(readInstallDefaultModel('claude', path)).toBeUndefined();
+    expect(readInstallDefaultModel('codex', path)).toBeUndefined();
+  });
+
+  it('treats inherit / empty / non-string models as unset', () => {
+    expect(
+      readInstallDefaultModel('claude', configAt('assistants:\n  claude:\n    model: inherit\n'))
+    ).toBeUndefined();
+    expect(
+      readInstallDefaultModel('claude', configAt('assistants:\n  claude:\n    model: ""\n'))
+    ).toBeUndefined();
+    expect(
+      readInstallDefaultModel('claude', configAt('assistants:\n  claude:\n    model: 42\n'))
+    ).toBeUndefined();
+  });
+
+  it('returns undefined (not a throw) on malformed YAML', () => {
+    // Best-effort hint read: a hand-edited broken config must not break setup.
+    expect(readInstallDefaultModel('claude', configAt(':: not yaml ::\n\t{ nope'))).toBeUndefined();
   });
 });

--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -19,6 +19,7 @@ import {
   writeHomePiModelConfig,
   buildDefaultModelChoices,
   readInstallDefaultModel,
+  writeInstallDefaults,
 } from './setup';
 import * as setupModule from './setup';
 import { copyArchonSkill } from './skill';
@@ -932,6 +933,63 @@ describe('buildDefaultModelChoices (#1999)', () => {
   it('falls back to keep + custom only for providers without a curated list', () => {
     const values = buildDefaultModelChoices('some-future-provider', undefined).map(c => c.value);
     expect(values).toEqual(['__keep__', '__custom__']);
+  });
+});
+
+describe('writeInstallDefaults (#1999)', () => {
+  const baseAi = {
+    claude: true,
+    codex: false,
+    pi: false,
+    defaultAssistant: 'claude',
+  };
+
+  it('writes provider + model together when a chat model was chosen', async () => {
+    const calls: [string, string | undefined][] = [];
+    const written = await writeInstallDefaults(
+      { ...baseAi, defaultAssistantSelected: true, defaultModel: 'opus' },
+      async (provider, model) => {
+        calls.push([provider, model]);
+      }
+    );
+    expect(written).toBe(true);
+    expect(calls).toEqual([['claude', 'opus']]);
+  });
+
+  it('writes defaultAssistant alone when the model was skipped (stale-config guard)', async () => {
+    // The .env DEFAULT_AI_ASSISTANT is fallback-only, so skipping the model
+    // must still record the wizard's fresh selection in config.yaml.
+    const calls: [string, string | undefined][] = [];
+    const written = await writeInstallDefaults(
+      { ...baseAi, defaultAssistantSelected: true },
+      async (provider, model) => {
+        calls.push([provider, model]);
+      }
+    );
+    expect(written).toBe(true);
+    expect(calls).toEqual([['claude', undefined]]);
+  });
+
+  it('does not write when the default was a registry fallback, not a selection', async () => {
+    // 'add' mode and the no-assistant early return leave
+    // defaultAssistantSelected unset — the fallback value must never clobber
+    // an existing config.yaml defaultAssistant.
+    const calls: unknown[] = [];
+    const written = await writeInstallDefaults({ ...baseAi }, async (...args) => {
+      calls.push(args);
+    });
+    expect(written).toBe(false);
+    expect(calls).toEqual([]);
+  });
+
+  it('is non-fatal when the write fails (env write already succeeded)', async () => {
+    const written = await writeInstallDefaults(
+      { ...baseAi, defaultAssistantSelected: true, defaultModel: 'opus' },
+      async () => {
+        throw Object.assign(new Error('read-only fs'), { code: 'EROFS' });
+      }
+    );
+    expect(written).toBe(false);
   });
 });
 

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -38,6 +38,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync, chmod
 import { parse as parseDotenv } from 'dotenv';
 import { join, dirname } from 'path';
 import { copyArchonSkill } from './skill';
+import { setInstallDefault } from './ai';
 import { homedir } from 'os';
 import { randomBytes } from 'crypto';
 import { spawn, execSync, spawnSync, type ChildProcess } from 'child_process';
@@ -158,6 +159,12 @@ interface SetupConfig {
     /** Canonical env var name for the chosen Pi backend, e.g. 'ANTHROPIC_API_KEY' */
     piApiKeyEnvVar?: string;
     defaultAssistant: string;
+    /** True when defaultAssistant came from an actual user selection — gates
+     *  the config.yaml write in writeInstallDefaults. Left unset on the
+     *  no-assistant early return and in 'add' mode, where defaultAssistant is
+     *  a registry fallback that must never clobber an existing config.yaml
+     *  defaultAssistant. */
+    defaultAssistantSelected?: boolean;
     /** Default CHAT model for the default assistant — written to
      *  ~/.archon/config.yaml as `assistants.<defaultAssistant>.model` (#1999).
      *  Unset when the user keeps the SDK default (or the default is Pi, whose
@@ -631,12 +638,52 @@ async function collectDefaultChatModel(provider: string): Promise<string | undef
       cancel('Setup cancelled.');
       process.exit(0);
     }
-    const trimmed = typed.trim();
-    // Empty input = same as keeping the default (guide, never gate).
+    // clack's text() is typed as string but resolves undefined on an empty
+    // submit — guard like the docs-path prompt does. Empty input = same as
+    // keeping the default (guide, never gate).
+    const trimmed = typeof typed === 'string' ? typed.trim() : '';
     return trimmed.length > 0 ? trimmed : undefined;
   }
 
   return choice;
+}
+
+/**
+ * Write the wizard's default assistant (+ optional chat model) to
+ * ~/.archon/config.yaml via the SAME install-scope path as
+ * `archon ai default <provider> [<model>]` — setInstallDefault writes
+ * `defaultAssistant` unconditionally and `assistants.<p>.model` only when a
+ * model was chosen, so the pair stays atomic (#1998/#1999). Writing the
+ * assistant even when the model is skipped matters: the .env
+ * DEFAULT_AI_ASSISTANT is fallback-only (applyEnvOverrides in @archon/core),
+ * so a stale config.yaml defaultAssistant from an earlier `archon ai default`
+ * would otherwise silently override the wizard's fresh selection.
+ *
+ * Gated on `defaultAssistantSelected`: the 'add'-mode / no-assistant registry
+ * fallback must never clobber an existing config.yaml value. Non-fatal on
+ * failure — the env write has already succeeded, so warn + log instead of
+ * aborting setup. Returns true when the config was written.
+ *
+ * The `write` parameter is injected in tests (same convention as
+ * checkPiModule's loader) so this path is testable without `mock.module()`.
+ */
+export async function writeInstallDefaults(
+  ai: SetupConfig['ai'],
+  write: (provider: string, model?: string) => Promise<void> = setInstallDefault
+): Promise<boolean> {
+  if (!ai.defaultAssistantSelected) return false;
+  try {
+    await write(ai.defaultAssistant, ai.defaultModel);
+    return true;
+  } catch (err) {
+    // Non-fatal: the user can run `archon ai default <provider> [<model>]`
+    // later. Surface, don't swallow.
+    const e = err as NodeJS.ErrnoException;
+    const code = e.code ? ` (${e.code})` : '';
+    log.warning(`Could not write default assistant config: ${e.message}${code}`);
+    getLog().warn({ err: e }, 'setup.default_assistant_config_write_failed');
+    return false;
+  }
 }
 
 /**
@@ -1175,6 +1222,7 @@ After upgrading, run 'archon setup' again.`,
     piApiKey,
     piApiKeyEnvVar,
     defaultAssistant,
+    ...(selectedProviders.length > 0 ? { defaultAssistantSelected: true } : {}),
     ...(defaultModel !== undefined ? { defaultModel } : {}),
   };
 }
@@ -2197,30 +2245,13 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
     }
   }
 
-  // Default chat model → ~/.archon/config.yaml through the SAME install-scope
-  // write path as `archon ai default <provider> <model>` (#1998/#1999):
-  // defaultAssistant + assistants.<p>.model are written together so the pair
-  // stays atomic — the .env DEFAULT_AI_ASSISTANT is fallback-only
-  // (applyEnvOverrides in @archon/core), and a stale config.yaml
-  // defaultAssistant from an earlier `archon ai default` must never leave the
-  // model pin riding a different provider. Lazy import keeps @archon/core out
-  // of setup's module graph (same pattern as the doctor import below).
-  if (config.ai.defaultModel) {
-    try {
-      const { updateGlobalConfig } = await import('@archon/core');
-      await updateGlobalConfig({
-        defaultAssistant: config.ai.defaultAssistant,
-        assistants: { [config.ai.defaultAssistant]: { model: config.ai.defaultModel } },
-      });
-    } catch (err) {
-      // Non-fatal: the env write already succeeded, so the user can run
-      // `archon ai default <provider> <model>` later. Surface, don't swallow.
-      const e = err as NodeJS.ErrnoException;
-      const code = e.code ? ` (${e.code})` : '';
-      log.warning(`Could not write default chat model: ${e.message}${code}`);
-      getLog().warn({ err: e }, 'setup.default_model_config_write_failed');
-    }
-  }
+  // Default assistant (+ optional chat model) → ~/.archon/config.yaml through
+  // the SAME install-scope write path as `archon ai default <provider>
+  // [<model>]` (#1998/#1999). Must run AFTER the Pi block above:
+  // writeHomePiModelConfig refuses to append once an `assistants:` block
+  // exists, and updateGlobalConfig can materialize one — the merge-write here
+  // preserves whatever the Pi writer produced.
+  await writeInstallDefaults(config.ai);
 
   // Tell the operator exactly what happened — especially that <repo>/.env was
   // NOT touched, because prior versions wrote there and this is the biggest

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -117,6 +117,28 @@ const PI_DEFAULT_MODELS: Record<string, string> = {
   huggingface: 'huggingface/Qwen/Qwen2.5-72B-Instruct',
 };
 
+/**
+ * Curated default-chat-model suggestions for the built-in SDK providers
+ * (#1999). CONVENIENCE only, not authority — mirrors CLAUDE_MODEL_OPTIONS /
+ * CODEX_MODEL_OPTIONS in packages/web/src/experiments/console/lib/
+ * model-options.ts (the web package can't be imported from the CLI, same
+ * mirroring convention as that file's effort vocabularies). The prompt always
+ * keeps a free-text escape; nothing blocks an unlisted model string.
+ */
+const DEFAULT_CHAT_MODEL_OPTIONS: Record<string, { value: string; hint?: string }[]> = {
+  claude: [
+    { value: 'sonnet', hint: 'balanced (SDK default)' },
+    { value: 'opus', hint: 'most capable' },
+    { value: 'haiku', hint: 'fastest' },
+  ],
+  codex: [{ value: 'gpt-5.3-codex' }, { value: 'gpt-5.5' }, { value: 'gpt-5.2' }],
+};
+
+/** Sentinel select values for the default-chat-model prompt. Prefixed with
+ *  `__` so they can never collide with a real model id. */
+const KEEP_MODEL = '__keep__';
+const CUSTOM_MODEL = '__custom__';
+
 interface SetupConfig {
   ai: {
     claude: boolean;
@@ -136,6 +158,11 @@ interface SetupConfig {
     /** Canonical env var name for the chosen Pi backend, e.g. 'ANTHROPIC_API_KEY' */
     piApiKeyEnvVar?: string;
     defaultAssistant: string;
+    /** Default CHAT model for the default assistant — written to
+     *  ~/.archon/config.yaml as `assistants.<defaultAssistant>.model` (#1999).
+     *  Unset when the user keeps the SDK default (or the default is Pi, whose
+     *  model is collected in collectPiConfig). */
+    defaultModel?: string;
   };
   platforms: {
     github: boolean;
@@ -520,6 +547,96 @@ async function collectPiConfig(): Promise<{
     model,
     ...(key.length > 0 ? { apiKey: key, apiKeyEnvVar: backend.envVar } : {}),
   };
+}
+
+/**
+ * Best-effort read of the install-scope default chat model
+ * (`assistants.<provider>.model` in ~/.archon/config.yaml) so a setup re-run
+ * surfaces the current value (#1999). Hint-only: any read/parse failure
+ * returns undefined rather than blocking the wizard — the authoritative parse
+ * happens in @archon/core's config loader at runtime.
+ */
+export function readInstallDefaultModel(
+  provider: string,
+  configPath: string = join(pathsGetArchonHome(), 'config.yaml')
+): string | undefined {
+  try {
+    if (!existsSync(configPath)) return undefined;
+    const parsed: unknown = Bun.YAML.parse(readFileSync(configPath, 'utf-8'));
+    if (typeof parsed !== 'object' || parsed === null) return undefined;
+    const assistants = (parsed as Record<string, unknown>).assistants;
+    if (typeof assistants !== 'object' || assistants === null) return undefined;
+    const entry = (assistants as Record<string, unknown>)[provider];
+    if (typeof entry !== 'object' || entry === null) return undefined;
+    const model = (entry as Record<string, unknown>).model;
+    if (typeof model !== 'string') return undefined;
+    const trimmed = model.trim();
+    // 'inherit' means "no explicit model" in assistant config — treat as unset.
+    return trimmed.length > 0 && trimmed !== 'inherit' ? trimmed : undefined;
+  } catch {
+    // Intentional best-effort fallback: an unreadable/malformed config.yaml
+    // must not break setup; the prompt just won't show a current value.
+    return undefined;
+  }
+}
+
+/**
+ * Build the select options for the default-chat-model step: keep-current/skip
+ * first (so plain Enter is the happy path), curated suggestions next, and a
+ * free-text escape last.
+ */
+export function buildDefaultModelChoices(
+  provider: string,
+  currentModel: string | undefined
+): { value: string; label: string; hint?: string }[] {
+  const curated = DEFAULT_CHAT_MODEL_OPTIONS[provider] ?? [];
+  return [
+    {
+      value: KEEP_MODEL,
+      label: currentModel ? `Keep current (${currentModel})` : 'Keep SDK default',
+      ...(currentModel ? {} : { hint: 'set one later with `archon ai default`' }),
+    },
+    ...curated.map(o => ({ value: o.value, label: o.value, ...(o.hint ? { hint: o.hint } : {}) })),
+    { value: CUSTOM_MODEL, label: 'Other…', hint: 'type a model id' },
+  ];
+}
+
+/**
+ * Optional, skippable default-chat-model prompt for the chosen default
+ * assistant (#1999). Returns the chosen model string, or undefined when the
+ * user keeps the current/SDK default. Free-text escape for anything the
+ * curated shortlist misses.
+ */
+async function collectDefaultChatModel(provider: string): Promise<string | undefined> {
+  const currentModel = readInstallDefaultModel(provider);
+
+  const choice = await select({
+    message: `Default chat model for ${provider}? (Enter to keep ${currentModel ?? 'the SDK default'})`,
+    options: buildDefaultModelChoices(provider, currentModel),
+  });
+
+  if (isCancel(choice)) {
+    cancel('Setup cancelled.');
+    process.exit(0);
+  }
+
+  if (choice === KEEP_MODEL) return undefined;
+
+  if (choice === CUSTOM_MODEL) {
+    const typed = await text({
+      message: `Model id for ${provider}:`,
+      placeholder: provider === 'codex' ? 'gpt-5.3-codex' : 'claude-sonnet-4-6',
+    });
+    if (isCancel(typed)) {
+      cancel('Setup cancelled.');
+      process.exit(0);
+    }
+    const trimmed = typed.trim();
+    // Empty input = same as keeping the default (guide, never gate).
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  return choice;
 }
 
 /**
@@ -1037,6 +1154,14 @@ After upgrading, run 'archon setup' again.`,
     defaultAssistant = selectedProviders[0];
   }
 
+  // Optional, skippable default-chat-model step for the default assistant
+  // (#1999). Pi is excluded: its model was already chosen in collectPiConfig
+  // and is written by writeHomePiModelConfig.
+  let defaultModel: string | undefined;
+  if (selectedProviders.length > 0 && defaultAssistant !== 'pi') {
+    defaultModel = await collectDefaultChatModel(defaultAssistant);
+  }
+
   return {
     claude: hasClaude,
     claudeAuthType,
@@ -1050,6 +1175,7 @@ After upgrading, run 'archon setup' again.`,
     piApiKey,
     piApiKeyEnvVar,
     defaultAssistant,
+    ...(defaultModel !== undefined ? { defaultModel } : {}),
   };
 }
 
@@ -2071,6 +2197,31 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
     }
   }
 
+  // Default chat model → ~/.archon/config.yaml through the SAME install-scope
+  // write path as `archon ai default <provider> <model>` (#1998/#1999):
+  // defaultAssistant + assistants.<p>.model are written together so the pair
+  // stays atomic — the .env DEFAULT_AI_ASSISTANT is fallback-only
+  // (applyEnvOverrides in @archon/core), and a stale config.yaml
+  // defaultAssistant from an earlier `archon ai default` must never leave the
+  // model pin riding a different provider. Lazy import keeps @archon/core out
+  // of setup's module graph (same pattern as the doctor import below).
+  if (config.ai.defaultModel) {
+    try {
+      const { updateGlobalConfig } = await import('@archon/core');
+      await updateGlobalConfig({
+        defaultAssistant: config.ai.defaultAssistant,
+        assistants: { [config.ai.defaultAssistant]: { model: config.ai.defaultModel } },
+      });
+    } catch (err) {
+      // Non-fatal: the env write already succeeded, so the user can run
+      // `archon ai default <provider> <model>` later. Surface, don't swallow.
+      const e = err as NodeJS.ErrnoException;
+      const code = e.code ? ` (${e.code})` : '';
+      log.warning(`Could not write default chat model: ${e.message}${code}`);
+      getLog().warn({ err: e }, 'setup.default_model_config_write_failed');
+    }
+  }
+
   // Tell the operator exactly what happened — especially that <repo>/.env was
   // NOT touched, because prior versions wrote there and this is the biggest
   // behavior change for returning users.
@@ -2192,7 +2343,7 @@ export async function setupCommand(options: SetupOptions): Promise<void> {
 
   const summaryLines = [
     `AI: ${aiConfigured.length > 0 ? aiConfigured.join(', ') : 'None configured'}`,
-    `Default: ${config.ai.defaultAssistant}`,
+    `Default: ${config.ai.defaultAssistant}${config.ai.defaultModel ? ` (chat model: ${config.ai.defaultModel})` : ''}`,
     `Platforms: ${configuredPlatforms.length > 0 ? configuredPlatforms.join(', ') : 'None (CLI + skill only)'}`,
     '',
     `File written (${scope} scope):`,

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -84,6 +84,8 @@ archon setup --spawn              # open in a new terminal window
 
 **Write safety**: `archon setup` never writes to `<cwd>/.env` — that file belongs to you. The wizard always targets one archon-owned file chosen by `--scope`, merges into existing content (so user-added keys survive), and writes a timestamped backup before every rewrite (e.g. `~/.archon/.env.archon-backup-2026-04-20T09-28-11-000Z`).
 
+**Default chat model**: after you pick the default assistant, the wizard offers an optional default chat model for it — a short curated list (e.g. `sonnet`/`opus`/`haiku` for Claude) plus an "Other…" free-text entry. Press Enter to keep the SDK default. A chosen model is written to `~/.archon/config.yaml` as `defaultAssistant` + `assistants.<provider>.model` — the same write as [`archon ai default <provider> <model>`](#ai) — and re-running setup shows the current value. Pi skips this step because its backend/model pair is chosen earlier in the wizard.
+
 ### `doctor`
 
 Verify your Archon setup. Runs a checklist of common failure points: Claude binary spawn, gh CLI auth, Pi auth (when Pi is configured as default), database reachability, workspace writability, bundled defaults, folder-project detection (contained repos, when run from one), telemetry state, AI credentials (connected provider count, best-effort), and adapter token pings (Slack/Telegram, best-effort).

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -84,7 +84,7 @@ archon setup --spawn              # open in a new terminal window
 
 **Write safety**: `archon setup` never writes to `<cwd>/.env` — that file belongs to you. The wizard always targets one archon-owned file chosen by `--scope`, merges into existing content (so user-added keys survive), and writes a timestamped backup before every rewrite (e.g. `~/.archon/.env.archon-backup-2026-04-20T09-28-11-000Z`).
 
-**Default chat model**: after you pick the default assistant, the wizard offers an optional default chat model for it — a short curated list (e.g. `sonnet`/`opus`/`haiku` for Claude) plus an "Other…" free-text entry. Press Enter to keep the SDK default. A chosen model is written to `~/.archon/config.yaml` as `defaultAssistant` + `assistants.<provider>.model` — the same write as [`archon ai default <provider> <model>`](#ai) — and re-running setup shows the current value. Pi skips this step because its backend/model pair is chosen earlier in the wizard.
+**Default assistant + chat model**: after you pick the default assistant, the wizard offers an optional default chat model for it — a short curated list (e.g. `sonnet`/`opus`/`haiku` for Claude) plus an "Other…" free-text entry. Press Enter to keep the SDK default. Your selection is recorded in `~/.archon/config.yaml` as `defaultAssistant` (plus `assistants.<provider>.model` when you chose a model) — the same write as [`archon ai default <provider> [<model>]`](#ai) — and re-running setup shows the current model. Pi skips the model prompt because its backend/model pair is chosen earlier in the wizard.
 
 ### `doctor`
 


### PR DESCRIPTION
## Summary

- Problem: `archon setup` picks the default assistant but never its chat model — only Pi got a model step (#1999). A fresh Claude/Codex user finishes setup with the model silently left at the SDK default.
- Why it matters: it's the first impression for every new install; the write machinery (`archon ai default <provider> [<model>]`, PR #2082) exists but nothing guides new users to it.
- What changed: after the default-assistant step, the wizard offers an optional, skippable default-chat-model prompt for the chosen provider — curated shortlist (claude: `sonnet`/`opus`/`haiku`; codex: `gpt-5.3-codex`/`gpt-5.5`/`gpt-5.2`, mirrored from the console picker) + an "Other…" free-text escape. The wizard's default-assistant selection (plus the model, when chosen) is written to `~/.archon/config.yaml` through the SAME install-scope path as `archon ai default <p> [<m>]` — the shared `setInstallDefault` helper extracted from `aiDefaultCommand` in self-review. Re-runs surface the current value (`Keep current (opus)`).
- What did **not** change (scope boundary): Pi's flow (its backend/model pair is already collected in `collectPiConfig`; no redundant second prompt), `writeHomePiModelConfig` (deferred cleanup), 'add' mode (doesn't re-ask assistants, so no model prompt), per-user `--scope user` writes (setup is install-level per the issue), `generateEnvContent`/.env shape, and `packages/workflows`/`packages/isolation`/orchestrator (untouched).

## UX Journey

### Before

```
archon setup
  → pick assistants (claude/codex/pi)
  → auth per assistant
  → [Pi only] pick backend + model
  → pick default assistant
  → done                              [!] claude/codex model = silent SDK default
```

### After

```
archon setup
  → ... (as today) ...
  → pick default assistant
  → [+] "Default chat model for claude? (Enter to keep the SDK default)"
        ▸ Keep SDK default            ← Enter = skip, happy path unchanged
        ▸ sonnet / opus / haiku       ← curated shortlist
        ▸ Other…                      ← free-text model id
  → done — summary shows "Default: claude (chat model: opus)"
        [+] writes defaultAssistant (always, on real selection) + assistants.claude.model (when chosen)
            to ~/.archon/config.yaml
```

## Architecture Diagram

### Before

```
setup.ts collectAIConfig ──▶ defaultAssistant ──▶ generateEnvContent ──▶ .env (DEFAULT_AI_ASSISTANT, fallback-only)
setup.ts collectPiConfig ──▶ piModel ──▶ writeHomePiModelConfig ──▶ config.yaml (string append)
cli ai.ts aiDefaultCommand ──▶ updateGlobalConfig (@archon/core) ──▶ config.yaml
```

### After

```
setup.ts collectAIConfig ──▶ defaultAssistant ──▶ generateEnvContent ──▶ .env (unchanged)
                        └─▶ [+] collectDefaultChatModel (skippable; Pi excluded)
                              ├─ [+] readInstallDefaultModel (best-effort config.yaml read, re-run hint)
                              └─ [+] buildDefaultModelChoices (curated + free-text)
setupCommand ═▶ [+] lazy import('@archon/core').updateGlobalConfig
                    { defaultAssistant, assistants.<p>.model }   ← same shape as ai default install scope
cli ai.ts aiDefaultCommand ──▶ updateGlobalConfig ──▶ config.yaml (unchanged)
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `setup.ts collectAIConfig` | `collectDefaultChatModel` | **new** | after default-assistant resolution; skipped for Pi / no assistants |
| `setup.ts setupCommand` | `@archon/core updateGlobalConfig` | **new** | lazy dynamic import; only when a model was chosen; non-fatal on failure |
| `readInstallDefaultModel` | `~/.archon/config.yaml` | **new** | read-only, best-effort (documented fallback) |
| `setup.ts` | `writeHomePiModelConfig` | unchanged | Pi persistence path untouched |
| `ai.ts aiDefaultCommand` | `updateGlobalConfig` | unchanged | setup now writes the identical install-scope shape |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `cli`, `docs`
- Module: `cli:setup`

## Change Metadata

- Change type: `feature`
- Primary scope: `cli`

## Linked Issue

- Closes #1999
- Related #1998, #2082 (the write machinery this builds on), #1494 (wizard lineage)

## Validation Evidence (required)

```bash
bun run validate   # check:bundled*, check:pi-vendor-map, type-check, lint, format:check, tests — exit 0
```

- Evidence provided: full `bun run validate` green; `bun test src/commands/setup.test.ts` 62 pass / 0 fail (10 new tests for `buildDefaultModelChoices` + `readInstallDefaultModel`). Round-trip smoke against a scratch `ARCHON_HOME`: the Step-4 write shape produced `defaultAssistant: claude` + `assistants.claude.model: opus`, `readInstallDefaultModel` surfaced it, and a second write with a sibling key present preserved `claudeBinaryPath` while updating the model.
- Intentionally skipped: none.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No` — model names aren't secrets; they go to config.yaml, not .env
- File system access scope changed? `No` — same `~/.archon/config.yaml` the wizard (Pi) and `archon ai default` already write
- Risk/mitigation: n/a

## Compatibility / Migration

- Backward compatible? `Yes` — existing configs are merge-preserved. Deliberate change (self-review fix): whenever the default assistant came from a real wizard selection, `defaultAssistant` is recorded in config.yaml even when the model is skipped — otherwise a stale config.yaml `defaultAssistant` from an earlier `archon ai default` silently overrides the wizard's fresh pick (`.env DEFAULT_AI_ASSISTANT` is fallback-only). The 'add'-mode / no-assistant registry fallback never writes (gated on `defaultAssistantSelected`).
- Config/env changes? `No` new keys (`assistants.<p>.model` + `defaultAssistant` already exist).
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios: choice-list ordering (keep first / custom last), curated lists per provider, unknown-provider fallback (keep+custom only), current-value surfacing on re-run, `inherit`/empty/non-string treated as unset, malformed YAML returns undefined instead of throwing, write→read round-trip in a scratch `ARCHON_HOME`, sibling assistant keys preserved by the merge write.
- Edge cases checked: Pi as default assistant (no second prompt), no assistants selected (no prompt), empty custom input = skip, 'add' mode (collectAIConfig not called → unaffected).
- What was not verified: full interactive wizard run end-to-end in a real TTY (clack prompts aren't scriptable; the interactive layer is thin wiring over the tested helpers, matching the file's established test approach).

## Side Effects / Blast Radius (required)

- Affected subsystems: `archon setup` wizard only (+ one docs page).
- Potential unintended effects: choosing a model now also pins `defaultAssistant` in config.yaml (see Compatibility — intentional and documented in code).
- Guardrails: write failure is non-fatal (clack warning + `setup.default_model_config_write_failed` structured log) — mirrors the Pi model write; the env write has already succeeded at that point.

## Rollback Plan (required)

- Fast rollback: revert the single commit. Any written config.yaml keys are standard settings users could have set by hand — safe to leave.
- Feature flags: none — inert unless the user picks a model.
- Observable failure symptoms: setup crash at the model step, or `setup.default_model_config_write_failed` warnings.

## Risks and Mitigations

- Risk: curated shortlists go stale as SDKs ship new models.
  - Mitigation: they're convenience-only with a free-text escape (same posture as the console picker they mirror, provenance comment included); nothing blocks unlisted model strings.
- Risk: hand-edited config.yaml breaks the current-value read.
  - Mitigation: `readInstallDefaultModel` is documented best-effort — any parse failure just hides the hint; the authoritative parse stays in @archon/core.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a default chat model selection step to the `archon setup` wizard.
  * Provides curated model suggestions by assistant, with options to keep the SDK default or enter a custom model.
  * Preserves existing model selections when rerunning setup.
  * Displays the selected assistant and model in the setup completion summary.

* **Documentation**
  * Updated CLI reference documentation with default model setup behavior and persistence details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
