### PR TITLE
feat(isolation/executor/cli): base-branch fallback from the codebase default branch (#2086)

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -1493,6 +1493,145 @@ describe('workflowRunCommand', () => {
     }
   });
 
+  it('uses codebase default_branch for reuse validation instead of git auto-detection', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    const conversationDb = await import('@archon/core/db/conversations');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    const isolationDb = await import('@archon/core/db/isolation-environments');
+    const gitModule = await import('@archon/git');
+
+    const getDefaultBranchCallsBefore = (gitModule.getDefaultBranch as ReturnType<typeof mock>).mock
+      .calls.length;
+
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'assist', description: 'Help' })],
+      errors: [],
+    });
+    (conversationDb.getOrCreateConversation as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'conv-123',
+    });
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'cb-123',
+      default_cwd: '/test/path',
+      default_branch: 'develop',
+    });
+    (isolationDb.findActiveByWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'env-1',
+      working_path: '/worktrees/feat',
+      branch_name: 'feature-old',
+      workflow_type: 'task',
+      workflow_id: 'my-feature',
+    });
+    (gitModule.isAncestorOf as ReturnType<typeof mock>).mockResolvedValueOnce(false);
+    (conversationDb.updateConversation as ReturnType<typeof mock>).mockResolvedValueOnce(undefined);
+    (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
+      success: true,
+      workflowRunId: 'run-123',
+    });
+
+    const consoleWarnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await workflowRunCommand('/test/path', 'assist', 'hello', { branchName: 'my-feature' });
+      // Warning names the codebase default branch, not the auto-detected 'dev'
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("not based on 'develop'")
+      );
+      // The stored default branch short-circuits git auto-detection entirely
+      const getDefaultBranchCallsAfter = (gitModule.getDefaultBranch as ReturnType<typeof mock>)
+        .mock.calls.length;
+      expect(getDefaultBranchCallsAfter).toBe(getDefaultBranchCallsBefore);
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
+  });
+
+  it('threads codebase default_branch into provider.create and executeWorkflow opts', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    const conversationDb = await import('@archon/core/db/conversations');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    const isolation = await import('@archon/isolation');
+
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'assist', description: 'Help' })],
+      errors: [],
+    });
+    (conversationDb.getOrCreateConversation as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'conv-123',
+    });
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'cb-123',
+      default_cwd: '/test/path',
+      default_branch: 'develop',
+    });
+    (conversationDb.updateConversation as ReturnType<typeof mock>).mockResolvedValueOnce(undefined);
+    (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
+      success: true,
+      workflowRunId: 'run-123',
+    });
+
+    // No branchName, no noWorktree — auto-isolates via provider.create
+    await workflowRunCommand('/test/path', 'assist', 'hello', {});
+
+    const getIsolationProviderMock = isolation.getIsolationProvider as ReturnType<typeof mock>;
+    const provider = getIsolationProviderMock.mock.results.at(-1)?.value as
+      | { create: ReturnType<typeof mock> }
+      | undefined;
+    const lastCreateCall = provider?.create.mock.calls.at(-1)?.[0] as {
+      baseBranch?: string;
+    };
+    expect(lastCreateCall.baseBranch).toBe('develop');
+
+    // executeWorkflow opts (trailing arg) carry the same fallback for $BASE_BRANCH
+    const executeSpy = executeWorkflow as ReturnType<typeof mock>;
+    const lastExecuteArgs = executeSpy.mock.calls.at(-1) as unknown[];
+    const opts = lastExecuteArgs[lastExecuteArgs.length - 1] as { baseBranch?: string };
+    expect(opts.baseBranch).toBe('develop');
+  });
+
+  it('omits baseBranch when the codebase has no stored default_branch', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    const conversationDb = await import('@archon/core/db/conversations');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    const isolation = await import('@archon/isolation');
+
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'assist', description: 'Help' })],
+      errors: [],
+    });
+    (conversationDb.getOrCreateConversation as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'conv-123',
+    });
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'cb-123',
+      default_cwd: '/test/path',
+      default_branch: null,
+    });
+    (conversationDb.updateConversation as ReturnType<typeof mock>).mockResolvedValueOnce(undefined);
+    (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
+      success: true,
+      workflowRunId: 'run-123',
+    });
+
+    await workflowRunCommand('/test/path', 'assist', 'hello', {});
+
+    const getIsolationProviderMock = isolation.getIsolationProvider as ReturnType<typeof mock>;
+    const provider = getIsolationProviderMock.mock.results.at(-1)?.value as
+      | { create: ReturnType<typeof mock> }
+      | undefined;
+    const lastCreateCall = provider?.create.mock.calls.at(-1)?.[0] as {
+      baseBranch?: string;
+    };
+    expect(lastCreateCall.baseBranch).toBeUndefined();
+
+    const executeSpy = executeWorkflow as ReturnType<typeof mock>;
+    const lastExecuteArgs = executeSpy.mock.calls.at(-1) as unknown[];
+    const opts = lastExecuteArgs[lastExecuteArgs.length - 1] as { baseBranch?: string };
+    expect(opts.baseBranch).toBeUndefined();
+  });
+
   it('sends dispatch message before executeWorkflow with correct metadata', async () => {
     const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
     const { executeWorkflow } = await import('@archon/workflows/executor');

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1035,10 +1035,12 @@ export async function workflowRunCommand(
       // Validate base branch before reuse (warning-only — non-blocking)
       try {
         const repoConfig = await loadRepoConfig(codebase.default_cwd);
-        const rawBase = repoConfig?.worktree?.baseBranch;
+        const rawBase = repoConfig?.worktree?.baseBranch?.trim();
         const configuredBase = rawBase
           ? git.toBranchName(rawBase)
-          : await git.getDefaultBranch(git.toRepoPath(codebase.default_cwd));
+          : codebase.default_branch?.trim()
+            ? git.toBranchName(codebase.default_branch.trim())
+            : await git.getDefaultBranch(git.toRepoPath(codebase.default_cwd));
         const isValidBase = await git.isAncestorOf(
           git.toWorktreePath(existingEnv.working_path),
           `origin/${configuredBase}`
@@ -1072,6 +1074,9 @@ export async function workflowRunCommand(
         identifier: branchIdentifier,
         fromBranch: options.fromBranch?.trim()
           ? git.toBranchName(options.fromBranch.trim())
+          : undefined,
+        baseBranch: codebase.default_branch?.trim()
+          ? git.toBranchName(codebase.default_branch.trim())
           : undefined,
         codebaseId: codebase.id,
         canonicalRepoPath: git.toRepoPath(codebase.default_cwd),
@@ -1279,9 +1284,16 @@ export async function workflowRunCommand(
   // Execute workflow with workingCwd (may be worktree path)
   let result: Awaited<ReturnType<typeof executeWorkflow>>;
   try {
+    const baseBranch = codebase?.default_branch?.trim() || undefined;
     const opts = prepared
-      ? { codebaseId: codebase?.id, source: workflowSource, userId: cliUserId, ...prepared }
-      : { codebaseId: codebase?.id, source: workflowSource, userId: cliUserId };
+      ? {
+          codebaseId: codebase?.id,
+          source: workflowSource,
+          userId: cliUserId,
+          baseBranch,
+          ...prepared,
+        }
+      : { codebaseId: codebase?.id, source: workflowSource, userId: cliUserId, baseBranch };
     result = await executeWorkflow(
       deps,
       adapter,

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -991,6 +991,11 @@ export async function workflowRunCommand(
 
   const isFolderCodebase = codebase?.kind === 'folder';
 
+  // The codebase's stored default branch, used as the base-branch fallback when
+  // repo config sets no worktree.baseBranch (reuse validation, worktree
+  // creation, and $BASE_BRANCH resolution all derive from this one value).
+  const codebaseDefaultBranch = codebase?.default_branch?.trim() || undefined;
+
   // Authoritative folder guards for an already-registered folder project run
   // WITHOUT the --folder flag (the flag-based guards above only fire when the
   // caller declared intent). Fail fast before any worktree work.
@@ -1036,11 +1041,15 @@ export async function workflowRunCommand(
       try {
         const repoConfig = await loadRepoConfig(codebase.default_cwd);
         const rawBase = repoConfig?.worktree?.baseBranch?.trim();
-        const configuredBase = rawBase
-          ? git.toBranchName(rawBase)
-          : codebase.default_branch?.trim()
-            ? git.toBranchName(codebase.default_branch.trim())
-            : await git.getDefaultBranch(git.toRepoPath(codebase.default_cwd));
+        // Three-level fallback: repo config → codebase default → git auto-detect.
+        let configuredBase: git.BranchName;
+        if (rawBase) {
+          configuredBase = git.toBranchName(rawBase);
+        } else if (codebaseDefaultBranch) {
+          configuredBase = git.toBranchName(codebaseDefaultBranch);
+        } else {
+          configuredBase = await git.getDefaultBranch(git.toRepoPath(codebase.default_cwd));
+        }
         const isValidBase = await git.isAncestorOf(
           git.toWorktreePath(existingEnv.working_path),
           `origin/${configuredBase}`
@@ -1075,9 +1084,7 @@ export async function workflowRunCommand(
         fromBranch: options.fromBranch?.trim()
           ? git.toBranchName(options.fromBranch.trim())
           : undefined,
-        baseBranch: codebase.default_branch?.trim()
-          ? git.toBranchName(codebase.default_branch.trim())
-          : undefined,
+        baseBranch: codebaseDefaultBranch ? git.toBranchName(codebaseDefaultBranch) : undefined,
         codebaseId: codebase.id,
         canonicalRepoPath: git.toRepoPath(codebase.default_cwd),
         description: `CLI workflow: ${workflowName}`,
@@ -1284,16 +1291,20 @@ export async function workflowRunCommand(
   // Execute workflow with workingCwd (may be worktree path)
   let result: Awaited<ReturnType<typeof executeWorkflow>>;
   try {
-    const baseBranch = codebase?.default_branch?.trim() || undefined;
     const opts = prepared
       ? {
           codebaseId: codebase?.id,
           source: workflowSource,
           userId: cliUserId,
-          baseBranch,
+          baseBranch: codebaseDefaultBranch,
           ...prepared,
         }
-      : { codebaseId: codebase?.id, source: workflowSource, userId: cliUserId, baseBranch };
+      : {
+          codebaseId: codebase?.id,
+          source: workflowSource,
+          userId: cliUserId,
+          baseBranch: codebaseDefaultBranch,
+        };
     result = await executeWorkflow(
       deps,
       adapter,

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1402,16 +1402,18 @@ describe('workflow dispatch routing — interactive flag', () => {
     return makeConversation({ codebase_id: 'codebase-1' });
   }
 
-  function makeDispatchCodebase() {
+  function makeDispatchCodebase(overrides: { default_branch?: string | null } = {}) {
     return {
       id: 'codebase-1',
       name: 'test-repo',
       repository_url: null,
       default_cwd: '/repos/test-repo',
+      default_branch: null,
       ai_assistant_type: 'claude' as const,
       commands: {},
       created_at: new Date(),
       updated_at: new Date(),
+      ...overrides,
     };
   }
 
@@ -1470,7 +1472,9 @@ describe('workflow dispatch routing — interactive flag', () => {
 
   test('calls executeWorkflow (not dispatchBackground) for interactive workflow on web', async () => {
     mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
-    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockGetCodebase.mockReturnValueOnce(
+      Promise.resolve(makeDispatchCodebase({ default_branch: 'develop' }))
+    );
     mockHandleCommand.mockReturnValueOnce(Promise.resolve(makeWorkflowResult(true)));
 
     const platform = makePlatform(); // getPlatformType returns 'web'
@@ -1482,8 +1486,13 @@ describe('workflow dispatch routing — interactive flag', () => {
     // as opts.parentConversationId so the approve/reject API handlers can
     // dispatch resume back through the orchestrator.
     const callArgs = mockExecuteWorkflow.mock.calls[0] as unknown[];
-    const opts = callArgs[callArgs.length - 1] as { parentConversationId?: string };
+    const opts = callArgs[callArgs.length - 1] as {
+      parentConversationId?: string;
+      baseBranch?: string;
+    };
     expect(opts.parentConversationId).toBe('conv-1-db');
+    // The codebase's stored default branch rides along as the $BASE_BRANCH fallback.
+    expect(opts.baseBranch).toBe('develop');
   });
 
   test('failed_resume_user_prompted: failed runs are not auto-resumed', async () => {

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1710,7 +1710,9 @@ describe('workflow dispatch routing — interactive flag', () => {
     // executeWorkflow via opts. parentConversationId still flows so the API
     // helpers keep dispatching resume on subsequent approvals.
     mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
-    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockGetCodebase.mockReturnValueOnce(
+      Promise.resolve(makeDispatchCodebase({ default_branch: 'develop' }))
+    );
     mockHandleCommand.mockReturnValueOnce(Promise.resolve(makeWorkflowResult(true)));
     mockFindResumableRunByParentConversation.mockReturnValueOnce(
       Promise.resolve(
@@ -1731,10 +1733,13 @@ describe('workflow dispatch routing — interactive flag', () => {
     // Resume payload lives on the opts bag (the trailing arg).
     const opts = callArgs[callArgs.length - 1] as {
       parentConversationId?: string;
+      baseBranch?: string;
       preCreatedRun?: { id: string };
       priorCompletedNodes?: Map<string, string>;
     };
     expect(opts.parentConversationId).toBe('conv-1-db');
+    // Resume dispatch carries the codebase default as the $BASE_BRANCH fallback too.
+    expect(opts.baseBranch).toBe('develop');
     expect(opts.preCreatedRun?.id).toBe('resumable-run-1');
     expect(opts.priorCompletedNodes?.size).toBeGreaterThan(0);
   });
@@ -1745,7 +1750,9 @@ describe('workflow dispatch routing — interactive flag', () => {
     // no interactive-loop state), the orchestrator must NOT throw — it sends
     // a user-visible notice and starts a fresh run on the same worktree.
     mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
-    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockGetCodebase.mockReturnValueOnce(
+      Promise.resolve(makeDispatchCodebase({ default_branch: 'develop' }))
+    );
     mockHandleCommand.mockReturnValueOnce(Promise.resolve(makeWorkflowResult(true)));
     mockFindResumableRunByParentConversation.mockReturnValueOnce(
       Promise.resolve(
@@ -1768,10 +1775,13 @@ describe('workflow dispatch routing — interactive flag', () => {
     // Opts bag carries no resume payload — fresh run.
     const opts = callArgs[callArgs.length - 1] as {
       parentConversationId?: string;
+      baseBranch?: string;
       preCreatedRun?: unknown;
       priorCompletedNodes?: unknown;
     };
     expect(opts.parentConversationId).toBe('conv-1-db');
+    // The fresh-run-in-same-worktree branch still threads the codebase default.
+    expect(opts.baseBranch).toBe('develop');
     expect(opts.preCreatedRun).toBeUndefined();
     expect(opts.priorCompletedNodes).toBeUndefined();
   });

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -789,6 +789,7 @@ async function dispatchOrchestratorWorkflow(
           parentConversationId: conversation.id,
           userId,
           source,
+          baseBranch: codebase.default_branch?.trim() || undefined,
           ...prepared,
         }
       );
@@ -810,6 +811,7 @@ async function dispatchOrchestratorWorkflow(
           parentConversationId: conversation.id,
           userId,
           source,
+          baseBranch: codebase.default_branch?.trim() || undefined,
         }
       );
     }
@@ -845,6 +847,7 @@ async function dispatchOrchestratorWorkflow(
         parentConversationId: conversation.id,
         userId,
         source,
+        baseBranch: codebase.default_branch?.trim() || undefined,
       }
     );
   }

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -627,6 +627,10 @@ async function dispatchOrchestratorWorkflow(
   source?: WorkflowSource,
   options?: WorkflowDispatchOptions
 ): Promise<void> {
+  // The codebase's stored default branch — the $BASE_BRANCH fallback for every
+  // executeWorkflow dispatch below (repo config worktree.baseBranch still wins).
+  const codebaseBaseBranch = codebase.default_branch?.trim() || undefined;
+
   // Capability gate: hard-fail before any worktree/clone/AI cost if the
   // workflow declares `requires: [github]` and the originating user hasn't
   // connected. No-op when per-user GitHub is disabled (solo PAT installs).
@@ -789,7 +793,7 @@ async function dispatchOrchestratorWorkflow(
           parentConversationId: conversation.id,
           userId,
           source,
-          baseBranch: codebase.default_branch?.trim() || undefined,
+          baseBranch: codebaseBaseBranch,
           ...prepared,
         }
       );
@@ -811,7 +815,7 @@ async function dispatchOrchestratorWorkflow(
           parentConversationId: conversation.id,
           userId,
           source,
-          baseBranch: codebase.default_branch?.trim() || undefined,
+          baseBranch: codebaseBaseBranch,
         }
       );
     }
@@ -847,7 +851,7 @@ async function dispatchOrchestratorWorkflow(
         parentConversationId: conversation.id,
         userId,
         source,
-        baseBranch: codebase.default_branch?.trim() || undefined,
+        baseBranch: codebaseBaseBranch,
       }
     );
   }

--- a/packages/core/src/orchestrator/orchestrator-isolation.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-isolation.test.ts
@@ -14,6 +14,10 @@ mock.module('@archon/paths', () => ({
   ensureArchonWorkspacesPath: mock(() => Promise.resolve('/home/test/.archon/workspaces')),
   getArchonHome: mock(() => '/home/test/.archon'),
   getCredentialKeyPath: mock(() => '/home/test/.archon/credential-key'),
+  // Required by @archon/git (loaded via orchestrator.ts's toBranchName import).
+  getProjectWorktreesPath: mock(
+    (owner: string, repo: string) => `/home/test/.archon/workspaces/${owner}/${repo}/worktrees`
+  ),
 }));
 
 // DB mocks
@@ -250,5 +254,43 @@ describe('validateAndResolveIsolation', () => {
       'Cleaned up 3 merged worktree(s) to make room.'
     );
     expect(result.status).toBe('new');
+  });
+
+  test('passes codebase default_branch to the resolver as defaultBranch', async () => {
+    const conversation = makeConversation();
+    const codebase = makeCodebase({ default_branch: 'develop' });
+
+    mockResolve.mockResolvedValueOnce({
+      status: 'resolved',
+      env: makeEnvRow(),
+      cwd: '/worktrees/issue-42',
+      method: { type: 'created' },
+    });
+
+    await validateAndResolveIsolation(conversation, codebase, platform, 'conv-1');
+
+    const request = mockResolve.mock.calls.at(-1)?.[0] as unknown as {
+      codebase: { defaultBranch?: string | null };
+    };
+    expect(request.codebase.defaultBranch).toBe('develop');
+  });
+
+  test('passes null defaultBranch to the resolver when the codebase has none stored', async () => {
+    const conversation = makeConversation();
+    const codebase = makeCodebase({ default_branch: null });
+
+    mockResolve.mockResolvedValueOnce({
+      status: 'resolved',
+      env: makeEnvRow(),
+      cwd: '/worktrees/issue-42',
+      method: { type: 'created' },
+    });
+
+    await validateAndResolveIsolation(conversation, codebase, platform, 'conv-1');
+
+    const request = mockResolve.mock.calls.at(-1)?.[0] as unknown as {
+      codebase: { defaultBranch?: string | null };
+    };
+    expect(request.codebase.defaultBranch).toBeNull();
   });
 });

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -134,7 +134,9 @@ export async function validateAndResolveIsolation(
           id: codebase.id,
           defaultCwd: codebase.default_cwd,
           name: codebase.name,
-          defaultBranch: codebase.default_branch ? toBranchName(codebase.default_branch) : null,
+          defaultBranch: codebase.default_branch?.trim()
+            ? toBranchName(codebase.default_branch.trim())
+            : null,
           kind: codebase.kind,
         }
       : null,

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -59,6 +59,7 @@ import {
 import { loadRepoConfig } from '../config/config-loader';
 import { isPerUserGitHubEnabled } from '../github-auth/config';
 import { getUserGithubNoreplyEmail } from '../db/user-github-token-store';
+import { toBranchName } from '@archon/git';
 
 type IsolationResolution =
   | { status: 'existing'; cwd: string; env: IsolationEnvironmentRow }
@@ -133,6 +134,7 @@ export async function validateAndResolveIsolation(
           id: codebase.id,
           defaultCwd: codebase.default_cwd,
           name: codebase.name,
+          defaultBranch: codebase.default_branch ? toBranchName(codebase.default_branch) : null,
           kind: codebase.kind,
         }
       : null,
@@ -317,6 +319,7 @@ export async function dispatchBackgroundWorkflow(
   // 3. Resolve isolation for this worker (each background workflow gets its own worktree).
   // Isolation failure is fatal — never run a workflow in a shared/parent worktree.
   let workerCwd: string;
+  let codebaseBaseBranch: string | undefined;
   if (ctx.codebaseId) {
     const codebase = await getCodebase(ctx.codebaseId);
     if (!codebase) {
@@ -324,6 +327,7 @@ export async function dispatchBackgroundWorkflow(
         `Cannot dispatch workflow "${workflow.name}": codebase ${ctx.codebaseId} not found`
       );
     }
+    codebaseBaseBranch = codebase.default_branch?.trim() || undefined;
     const result = await validateAndResolveIsolation(
       workerConv,
       codebase,
@@ -421,6 +425,7 @@ export async function dispatchBackgroundWorkflow(
             preCreatedRun,
             userId: ctx.userId,
             source: ctx.source,
+            baseBranch: codebaseBaseBranch,
           }
         );
         // Surface workflow output to parent conversation as a result card

--- a/packages/docs-web/src/content/docs/reference/variables.md
+++ b/packages/docs-web/src/content/docs/reference/variables.md
@@ -20,7 +20,7 @@ These variables are substituted by the workflow executor in all node types (`com
 | `$USER_MESSAGE` | Same as `$ARGUMENTS` | Alias |
 | `$WORKFLOW_ID` | Unique ID for the current workflow run | Useful for artifact naming and log correlation |
 | `$ARTIFACTS_DIR` | Pre-created external artifacts directory (`~/.archon/workspaces/<owner>/<repo>/artifacts/runs/<id>/`) | Always exists before node execution; stored outside the repo to avoid polluting the working tree |
-| `$BASE_BRANCH` | Base branch for git operations | Auto-detected from the repository's default branch, or set via `worktree.baseBranch` in `.archon/config.yaml`. Throws an error if referenced in a prompt but cannot be resolved |
+| `$BASE_BRANCH` | Base branch for git operations | Resolved in order: `worktree.baseBranch` in `.archon/config.yaml`, then the registered codebase's stored default branch, then git auto-detection. Throws an error if referenced in a prompt but cannot be resolved |
 | `$DOCS_DIR` | Documentation directory path | Configured via `docs.path` in `.archon/config.yaml`. Defaults to `docs/` when not set. Never throws |
 | `$CONTEXT` | GitHub issue or PR context, if available | Populated when the workflow is triggered from a GitHub issue/PR. Replaced with empty string when unavailable |
 | `$EXTERNAL_CONTEXT` | Same as `$CONTEXT` | Alias |
@@ -40,8 +40,9 @@ If issue context is present but no context variable appears in the prompt, the c
 
 Unlike other variables, `$BASE_BRANCH` will cause the workflow to **fail immediately** if:
 - The variable is referenced in a prompt, AND
-- Auto-detection from git fails, AND
-- `worktree.baseBranch` is not set in `.archon/config.yaml`
+- `worktree.baseBranch` is not set in `.archon/config.yaml`, AND
+- The registered codebase has no stored default branch, AND
+- Auto-detection from git fails
 
 If the variable is not referenced, no error occurs even if the base branch cannot be determined.
 

--- a/packages/isolation/src/errors.test.ts
+++ b/packages/isolation/src/errors.test.ts
@@ -64,6 +64,14 @@ describe('classifyIsolationError', () => {
     expect(result).toContain('Submodule initialization failed');
     expect(result).toContain('initSubmodules: false');
   });
+
+  test('matches default branch detection failures with base branch guidance', () => {
+    const result = classifyIsolationError(
+      new Error('Cannot detect default branch for /repo: neither origin/HEAD nor origin/main exist')
+    );
+    expect(result).toContain('No base branch could be detected');
+    expect(result).toContain('worktree.baseBranch');
+  });
 });
 
 describe('isKnownIsolationError', () => {
@@ -98,6 +106,14 @@ describe('isKnownIsolationError', () => {
   test('identifies submodule initialization failure as known', () => {
     expect(
       isKnownIsolationError(new Error('Submodule initialization failed: network unreachable'))
+    ).toBe(true);
+  });
+
+  test('identifies default branch detection failure as known', () => {
+    expect(
+      isKnownIsolationError(
+        new Error('Cannot detect default branch: neither origin/HEAD nor origin/main exist')
+      )
     ).toBe(true);
   });
 

--- a/packages/isolation/src/errors.ts
+++ b/packages/isolation/src/errors.ts
@@ -80,6 +80,13 @@ const ERROR_PATTERNS: { pattern: string; message: string; known: boolean }[] = [
     known: true,
   },
   {
+    pattern: 'cannot detect default branch',
+    message:
+      '**Error:** No base branch could be detected. Set `worktree.baseBranch` in ' +
+      '`.archon/config.yaml` or update the registered codebase default branch.',
+    known: true,
+  },
+  {
     pattern: 'belongs to a different clone',
     message:
       '**Error:** A worktree at the target path was created by a different local clone. ' +

--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -2290,6 +2290,58 @@ describe('WorktreeProvider', () => {
       });
     });
 
+    test('uses request baseBranch when no config baseBranch is set', async () => {
+      worktreeExistsSpy.mockResolvedValue(false);
+      syncWorkspaceSpy.mockResolvedValue({
+        branch: 'develop',
+        synced: true,
+        mode: 'fast-forward',
+        state: 'in_sync',
+        previousHead: '',
+        newHead: '',
+        updated: false,
+      });
+      const configLoader: RepoConfigLoader = async () => ({});
+      provider = new WorktreeProvider(configLoader);
+
+      await provider.create({
+        ...baseRequest,
+        baseBranch: git.toBranchName('develop'),
+      });
+
+      expect(syncWorkspaceSpy).toHaveBeenCalledWith('/workspace/owner/repo', 'develop', {
+        mode: 'fast-forward',
+      });
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        expect.arrayContaining([
+          'worktree',
+          'add',
+          '--no-track',
+          expect.any(String),
+          '-b',
+          'archon/issue-42',
+          'origin/develop',
+        ]),
+        expect.any(Object)
+      );
+    });
+
+    test('uses configured baseBranch over request baseBranch when both are set', async () => {
+      worktreeExistsSpy.mockResolvedValue(false);
+      const configLoader: RepoConfigLoader = async () => ({ baseBranch: 'main' });
+      provider = new WorktreeProvider(configLoader);
+
+      await provider.create({
+        ...baseRequest,
+        baseBranch: git.toBranchName('develop'),
+      });
+
+      expect(syncWorkspaceSpy).toHaveBeenCalledWith('/workspace/owner/repo', 'main', {
+        mode: 'fast-forward',
+      });
+    });
+
     test('uses explicit reset mode for managed clone worktree creation', async () => {
       worktreeExistsSpy.mockResolvedValue(false);
       const configLoader: RepoConfigLoader = async () => ({});

--- a/packages/isolation/src/providers/worktree.ts
+++ b/packages/isolation/src/providers/worktree.ts
@@ -704,9 +704,11 @@ export class WorktreeProvider implements IIsolationProvider {
   ): Promise<{ warnings: string[] }> {
     const repoPath = request.canonicalRepoPath;
 
-    // Sync uses only the configured base branch (or auto-detects via getDefaultBranch).
+    // Sync uses explicit repo config first, then the registered codebase's
+    // default branch (request.baseBranch), then auto-detects via getDefaultBranch.
     // request.fromBranch is the start-point for worktree creation, not a sync target.
-    const baseBranch = await this.syncWorkspaceBeforeCreate(repoPath, worktreeConfig?.baseBranch);
+    const preferredBaseBranch = worktreeConfig?.baseBranch ?? request.baseBranch;
+    const baseBranch = await this.syncWorkspaceBeforeCreate(repoPath, preferredBaseBranch);
 
     const override: WorktreeBaseOverride = {
       repoLocal: resolveRepoLocalOverride(worktreeConfig?.path, repoPath),

--- a/packages/isolation/src/resolver.test.ts
+++ b/packages/isolation/src/resolver.test.ts
@@ -707,6 +707,113 @@ describe('IsolationResolver', () => {
     expect(capturedRequests[0]).toMatchObject({ codebaseName: 'owner/repo' });
   });
 
+  // --- defaultBranch → baseBranch threading tests ---
+
+  test('passes defaultBranch from codebase as baseBranch on the isolation request', async () => {
+    const capturedRequests: unknown[] = [];
+    const resolver = createResolver({
+      provider: {
+        ...makeMockProvider(),
+        create: async (request: unknown) => {
+          capturedRequests.push(request);
+          return {
+            id: '/worktrees/new-branch',
+            provider: 'worktree' as const,
+            workingPath: '/worktrees/new-branch',
+            branchName: 'new-branch',
+            status: 'active' as const,
+            createdAt: new Date(),
+            metadata: { adopted: false },
+          };
+        },
+      },
+    });
+
+    worktreeExistsSpy.mockResolvedValue(false);
+
+    await resolver.resolve({
+      existingEnvId: null,
+      codebase: {
+        id: 'cb-1',
+        name: 'owner/repo',
+        defaultCwd: '/local/repo',
+        defaultBranch: git.toBranchName('develop'),
+      },
+      hints: { workflowType: 'task', workflowId: 'wf-1' },
+      platformType: 'web',
+    });
+
+    expect(capturedRequests).toHaveLength(1);
+    expect(capturedRequests[0]).toMatchObject({ baseBranch: 'develop' });
+  });
+
+  test('omits baseBranch on the isolation request when defaultBranch is null', async () => {
+    const capturedRequests: unknown[] = [];
+    const resolver = createResolver({
+      provider: {
+        ...makeMockProvider(),
+        create: async (request: unknown) => {
+          capturedRequests.push(request);
+          return {
+            id: '/worktrees/new-branch',
+            provider: 'worktree' as const,
+            workingPath: '/worktrees/new-branch',
+            branchName: 'new-branch',
+            status: 'active' as const,
+            createdAt: new Date(),
+            metadata: { adopted: false },
+          };
+        },
+      },
+    });
+
+    worktreeExistsSpy.mockResolvedValue(false);
+
+    await resolver.resolve({
+      existingEnvId: null,
+      codebase: {
+        id: 'cb-1',
+        name: 'owner/repo',
+        defaultCwd: '/local/repo',
+        defaultBranch: null,
+      },
+      hints: { workflowType: 'task', workflowId: 'wf-1' },
+      platformType: 'web',
+    });
+
+    expect(capturedRequests).toHaveLength(1);
+    expect((capturedRequests[0] as { baseBranch?: string }).baseBranch).toBeUndefined();
+  });
+
+  test('folder project with defaultBranch still short-circuits to none (no provider call)', async () => {
+    const capturedRequests: unknown[] = [];
+    const resolver = createResolver({
+      provider: {
+        ...makeMockProvider(),
+        create: async (request: unknown): Promise<IsolatedEnvironment> => {
+          capturedRequests.push(request);
+          throw new Error('provider.create must not be called for folder projects');
+        },
+      },
+    });
+
+    const result = await resolver.resolve({
+      existingEnvId: null,
+      codebase: {
+        id: 'cb-folder',
+        defaultCwd: '/tmp/platform',
+        name: 'platform',
+        defaultBranch: git.toBranchName('develop'),
+        kind: 'folder',
+      },
+      hints: { workflowType: 'task', workflowId: 'wf-1' },
+      platformType: 'web',
+    });
+
+    expect(result.status).toBe('none');
+    expect(capturedRequests).toHaveLength(0);
+  });
+
   // --- Constructor validation tests ---
 
   test('throws on zero staleThresholdDays', () => {

--- a/packages/isolation/src/resolver.ts
+++ b/packages/isolation/src/resolver.ts
@@ -452,6 +452,7 @@ export class IsolationResolver {
       codebaseId: codebase.id,
       codebaseName: codebase.name,
       canonicalRepoPath: canonicalPath,
+      baseBranch: codebase.defaultBranch ?? undefined,
       identifier: workflowId,
       gitIdentity,
     };

--- a/packages/isolation/src/types.ts
+++ b/packages/isolation/src/types.ts
@@ -42,6 +42,16 @@ interface IsolationRequestBase {
    */
   canonicalRepoPath: RepoPath;
 
+  /**
+   * Preferred base branch for new worktrees when repo config does not override
+   * it (`worktree.baseBranch` still wins).
+   *
+   * Populated from the registered codebase's stored `default_branch` so
+   * locally-registered repos with non-main defaults do not depend on
+   * `origin/HEAD` being set for auto-detection.
+   */
+  baseBranch?: BranchName;
+
   description?: string;
 
   /**
@@ -315,6 +325,12 @@ export interface ResolveRequest {
     id: string;
     defaultCwd: string;
     name: string;
+    /**
+     * The codebase's stored default branch (from registration). Threaded into
+     * the provider's `IsolationRequest.baseBranch` as the fallback base for new
+     * worktrees when repo config sets no `worktree.baseBranch`.
+     */
+    defaultBranch?: BranchName | null;
     /**
      * Project kind. `'folder'` projects run in place at `defaultCwd` with no
      * worktree isolation; the resolver short-circuits to `{ status: 'none' }`.

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -44,8 +44,9 @@ mock.module('@archon/paths', () => ({
 }));
 
 // --- Mock git ---
+const mockGetDefaultBranch = mock(async () => 'main');
 mock.module('@archon/git', () => ({
-  getDefaultBranch: mock(async () => 'main'),
+  getDefaultBranch: mockGetDefaultBranch,
   toRepoPath: mock((p: string) => p),
 }));
 
@@ -164,6 +165,8 @@ describe('executeWorkflow', () => {
     mockEmitter.registerRun.mockClear();
     mockEmitter.unregisterRun.mockClear();
     mockEmitter.emit.mockClear();
+    mockGetDefaultBranch.mockClear();
+    mockGetDefaultBranch.mockImplementation(async () => 'main');
     mockExecuteDagWorkflow.mockImplementation(async (): Promise<string | undefined> => undefined);
   });
 
@@ -581,6 +584,77 @@ describe('executeWorkflow', () => {
       expect(mockExecuteDagWorkflow).toHaveBeenCalledTimes(1);
       const docsDir = mockExecuteDagWorkflow.mock.calls[0]?.[11];
       expect(docsDir).toBe('packages/docs-web/src/content/docs');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Base branch resolution ($BASE_BRANCH)
+  // -------------------------------------------------------------------------
+
+  describe('base branch resolution', () => {
+    it('uses caller-provided baseBranch when repo config is unset', async () => {
+      // Auto-detect would throw — the caller fallback must short-circuit before it.
+      mockGetDefaultBranch.mockImplementation(async () => {
+        throw new Error('Cannot detect default branch: neither origin/HEAD nor origin/main exist');
+      });
+      const deps = makeDeps();
+
+      await executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-1',
+        '/tmp/worktree',
+        makeWorkflow(),
+        'test message',
+        'db-conv-1',
+        { baseBranch: 'develop' }
+      );
+
+      expect(mockGetDefaultBranch).not.toHaveBeenCalled();
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[10]).toBe('develop');
+    });
+
+    it('prefers repo config baseBranch over caller-provided baseBranch', async () => {
+      const deps = makeDeps();
+      deps.loadConfig = mock(
+        async (): Promise<WorkflowConfig> => ({
+          assistant: 'claude' as const,
+          assistants: { claude: {}, codex: {} },
+          baseBranch: 'main',
+          commands: { folder: '' },
+        })
+      ) as unknown as WorkflowDeps['loadConfig'];
+
+      await executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-1',
+        '/tmp/worktree',
+        makeWorkflow(),
+        'test message',
+        'db-conv-1',
+        { baseBranch: 'develop' }
+      );
+
+      expect(mockGetDefaultBranch).not.toHaveBeenCalled();
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[10]).toBe('main');
+    });
+
+    it('falls back to git auto-detection when config and caller branch are unset', async () => {
+      const deps = makeDeps();
+
+      await executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-1',
+        '/tmp/worktree',
+        makeWorkflow(),
+        'test message',
+        'db-conv-1'
+      );
+
+      expect(mockGetDefaultBranch).toHaveBeenCalledWith('/tmp/worktree');
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[10]).toBe('main');
     });
   });
 

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -324,6 +324,12 @@ export type ExecuteWorkflowOptions = ResumePayload & {
   /** Codebase ID for env vars + isolation context. */
   codebaseId?: string;
   /**
+   * Caller-provided base branch fallback for `$BASE_BRANCH`, normally the
+   * codebase's stored `default_branch`. Repo config still wins when
+   * `worktree.baseBranch` is set; git auto-detection remains the last resort.
+   */
+  baseBranch?: string;
+  /**
    * GitHub issue/PR context. When provided:
    * - Stored in `WorkflowRun.metadata` as `{ github_context }`
    * - Substituted into `$CONTEXT` / `$EXTERNAL_CONTEXT` / `$ISSUE_CONTEXT` variables
@@ -420,6 +426,7 @@ export async function executeWorkflow(
     priorCompletedNodes,
     userId,
     source,
+    baseBranch: callerBaseBranch,
   } = opts;
   // Load config once for the entire workflow execution
   const fileConfig = await deps.loadConfig(cwd);
@@ -445,11 +452,15 @@ export async function executeWorkflow(
   };
   const configuredCommandFolder = config.commands.folder;
 
-  // Auto-detect base branch when not configured. Config takes priority.
+  // Resolve base branch: config takes priority, then the caller-provided
+  // codebase default, then git auto-detection.
   // If detection fails, leave empty — substituteWorkflowVariables throws only if $BASE_BRANCH is referenced.
+  const fallbackBaseBranch = callerBaseBranch?.trim();
   let baseBranch: string;
   if (config.baseBranch) {
     baseBranch = config.baseBranch;
+  } else if (fallbackBaseBranch) {
+    baseBranch = fallbackBaseBranch;
   } else {
     try {
       baseBranch = await getDefaultBranch(toRepoPath(cwd));


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: `default_branch` is stored correctly at registration but never consulted for base-branch resolution. A locally-registered repo whose default branch is not `main` (e.g. `develop`), with `origin/HEAD` unset and no `origin/main`, throws at worktree creation and resolves `$BASE_BRANCH` to `''` — even though the DB knows the answer.
- Why it matters: any non-main-default local repo (common `develop`/`dev` trunks) can't run isolated workflows without manually setting `worktree.baseBranch` in every repo config.
- What changed: base-branch resolution is now a three-level fallback at every seam — repo config `worktree.baseBranch` → codebase `default_branch` → git auto-detect. Threaded through isolation (`IsolationRequestBase.baseBranch` / `ResolveRequest.codebase.defaultBranch`), the workflow executor (`ExecuteWorkflowOptions.baseBranch`), the CLI (all three sites), and the chat/web orchestrator dispatch paths. Plus a classified "cannot detect default branch" error message and a docs update.
- What did **not** change (scope boundary): a genuinely remote-less local repo still cannot fork a worktree from `origin/<branch>` — documented limitation, same as the original chunk. Folder projects are untouched (they short-circuit before worktree isolation; non-regression test added). No schema or registration changes — `default_branch` was already captured.

Based on groundwork by @anhle128 in #1994's original branch (preserved at 1caf2e08). Reimplemented fresh against current `dev` (folder projects and recent executor/CLI changes had moved the anchors).

## UX Journey

### Before

```
  User (repo with default branch 'develop', no origin/main)
  ────
  archon workflow run implement "Add auth"
        │
        ▼
  Archon: worktree creation → getDefaultBranch()
          origin/HEAD unset, origin/main missing
        ▼
  ❌ "Cannot detect default branch for /repo: neither
     origin/HEAD nor origin/main exist"
  (workaround: hand-edit worktree.baseBranch in every repo)

  $BASE_BRANCH in prompts → '' → node fails if referenced
```

### After

```
  User (repo with default branch 'develop', no origin/main)
  ────
  archon workflow run implement "Add auth"
        │
        ▼
  Archon: worktree creation
          [config worktree.baseBranch? no]
          [codebase default_branch? → 'develop']  *new*
        ▼
  ✅ worktree forked from origin/develop
  $BASE_BRANCH → 'develop' in prompts             *new*

  (If all three levels fail: classified error telling the user
   to set worktree.baseBranch or fix the registered default)   *new*
```

## Architecture Diagram

### Before

```
  CLI workflow.ts ──────────▶ provider.create (no branch info)
  orchestrator.ts ──resolve──▶ IsolationResolver ──▶ WorktreeProvider
                                                      └─ config.baseBranch → getDefaultBranch → throw
  CLI / orchestrator ──opts──▶ executeWorkflow
                                └─ config.baseBranch → getDefaultBranch → ''
  codebases.default_branch  (stored, never read)
```

### After

```
  CLI workflow.ts ══baseBranch══▶ provider.create [~]
  orchestrator.ts ══defaultBranch══▶ IsolationResolver [~] ══baseBranch══▶ WorktreeProvider [~]
                                                      └─ config.baseBranch → request.baseBranch → getDefaultBranch
  CLI / orchestrator ══opts.baseBranch══▶ executeWorkflow [~]
                                └─ config.baseBranch → opts.baseBranch → getDefaultBranch → ''
  codebases.default_branch ═══ read at every seam above [~]
  errors.ts [~] — "cannot detect default branch" classified
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `cli/workflow.ts` | `isolation provider.create` | **modified** | now passes `baseBranch` from `codebase.default_branch` |
| `cli/workflow.ts` | `workflows/executor` | **modified** | opts gain `baseBranch` |
| `cli/workflow.ts` | `@archon/git isAncestorOf` (reuse validation) | **modified** | validates against `default_branch` before auto-detect |
| `core/orchestrator.ts` | `isolation resolver.resolve` | **modified** | `ResolveRequest.codebase.defaultBranch` |
| `core/orchestrator.ts` + `orchestrator-agent.ts` | `workflows/executor` | **modified** | dispatch opts gain `baseBranch` |
| `isolation/resolver.ts` | `isolation provider.create` | **modified** | forwards `defaultBranch` as `IsolationRequest.baseBranch` |
| `isolation/worktree.ts` | `@archon/git syncWorkspace/getDefaultBranch` | **modified** | prefers config, then `request.baseBranch`, then auto-detect |
| `workflows/executor.ts` | `@archon/git getDefaultBranch` | **modified** | only reached when config + caller fallback are unset |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `isolation`
- Module: `isolation:resolver`, `isolation:worktree`, `workflows:executor`, `cli:workflow`, `core:orchestrator`

## Change Metadata

- Change type: `feature`
- Primary scope: `multi`

## Linked Issue

- Closes #2086
- Related #1994 (original branch carried this chunk; dropped in the maintainer take-over, preserved at 1caf2e08)

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate
# check:bundled ✅  check:bundled-skill ✅  check:bundled-schema ✅  check:pi-vendor-map ✅
# type-check ✅ (all 10 packages)  lint --max-warnings 0 ✅  format:check ✅
# test ✅ (per-package isolated batches, exit 0)
```

- Evidence provided (test/log/trace/screenshot): full `bun run validate` exit 0; targeted suites re-run individually (isolation resolver/worktree/errors batches, workflows executor batch, CLI workflow batch, core orchestrator-agent + orchestrator-isolation batches) — all green
- If any command is intentionally skipped, explain why: none skipped

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation: n/a — the change only reads an already-stored DB column and threads it through existing seams

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: n/a. Repos with `worktree.baseBranch` set keep identical behavior (config still wins). Repos with `default_branch = 'main'` or `NULL` behave as before (fallback is a no-op or skipped).

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: fallback ordering at each seam via the new unit tests (config > codebase default > auto-detect); reuse-validation warning names the stored default branch and skips `getDefaultBranch`; folder-kind resolve still short-circuits to `none` with `defaultBranch` present
- Edge cases checked: `default_branch` NULL / empty-string (`.trim() || undefined` → omitted), resume path (`...prepared` spread keeps resume payload precedence), PR-type isolation requests unaffected (they don't hit `createNewBranch`)
- What was not verified: a live end-to-end run against a real remote-less `develop`-default repo (unit coverage only); Slack/Telegram chat surfaces exercised via the shared orchestrator paths, not live adapters

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: worktree creation base selection (all surfaces), `$BASE_BRANCH` substitution, CLI worktree-reuse validation warning
- Potential unintended effects: a codebase row with a *stale* `default_branch` (repo default changed after registration) now wins over git auto-detection; previously auto-detect could silently pick the new default. Mitigation: `/update-project` re-detects, and repo config `worktree.baseBranch` always overrides.
- Guardrails/monitoring for early detection: existing `worktree.reuse_base_branch_mismatch` warning, `workflow.base_branch_auto_detect_failed` WARN log, and the new classified error message

## Rollback Plan (required)

- Fast rollback command/path: `git revert e23f59c4` — single commit, no schema or config changes
- Feature flags or config toggles (if any): none; setting `worktree.baseBranch` in `.archon/config.yaml` restores pre-PR behavior per repo
- Observable failure symptoms: worktrees forking from an unexpected branch; `$BASE_BRANCH` naming a branch that diverges from what auto-detection would return

## Risks and Mitigations

- Risk: stale `default_branch` values steer worktree creation to an outdated base.
  - Mitigation: config override wins at every seam; `/update-project` refreshes the stored value; the reuse-validation warning surfaces mismatches non-blockingly.
- Risk: behavior change on repos where auto-detection and `default_branch` disagree.
  - Mitigation: `default_branch` is captured from the repo's own HEAD at registration — when they disagree, the stored value is at worst as good as `origin/main` guessing; covered by tests asserting the exact precedence.
