### PR TITLE
fix(workflows): re-derive declaredFields on resume for strict $node.output.field access (#2091)

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -3792,6 +3792,121 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
   });
 
+  // #2091: on resume, prior completed nodes are rehydrated from text only, so the
+  // producer's output_format field set must be re-derived from the loaded definition —
+  // otherwise the strict `$node.output.field` contract downgrades to the schemaless
+  // path and a resumed run gets different semantics than a fresh one.
+  it("re-derives declaredFields on resume so a declared-optional-absent field resolves to ''", async () => {
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('resume-declared-optional');
+
+    let capturedPrompt = '';
+    mockSendQueryDag.mockImplementation(function* (prompt: string) {
+      capturedPrompt = prompt;
+      yield { type: 'assistant', content: 'step2 result' };
+      yield { type: 'result', sessionId: 'session-id' };
+    });
+
+    // Prior JSON output omits the declared-optional `note` field.
+    const priorCompletedNodes = new Map([['step1', '{"type":"BUG"}']]);
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-resume',
+      testDir,
+      {
+        name: 'declared-optional',
+        nodes: [
+          {
+            id: 'step1',
+            prompt: 'produce json',
+            output_format: {
+              type: 'object',
+              properties: { type: { type: 'string' }, note: { type: 'string' } },
+              required: ['type'],
+            },
+          },
+          { id: 'step2', prompt: 'note=[$step1.output.note]', depends_on: ['step1'] },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes
+    );
+
+    // The consumer must run (step1 was skipped, so exactly one AI call = step2),
+    // and the declared-but-absent `note` resolves to '' — not a missing-key throw.
+    expect(mockSendQueryDag.mock.calls.length).toBe(1);
+    expect(capturedPrompt).toBe('note=[]');
+  });
+
+  it('re-derives declaredFields on resume so an undeclared key fails the consumer (not-in-schema)', async () => {
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('resume-undeclared-key');
+
+    // Prior JSON output carries an `extra` key that the schema does NOT declare.
+    const priorCompletedNodes = new Map([['step1', '{"type":"BUG","extra":"x"}']]);
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-resume',
+      testDir,
+      {
+        name: 'undeclared-key',
+        nodes: [
+          {
+            id: 'step1',
+            prompt: 'produce json',
+            output_format: {
+              type: 'object',
+              properties: { type: { type: 'string' } },
+              required: ['type'],
+            },
+          },
+          { id: 'step2', prompt: 'extra=[$step1.output.extra]', depends_on: ['step1'] },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes
+    );
+
+    // The undeclared `extra` must fail the consumer before the AI runs (0 calls),
+    // matching fresh-run behavior instead of silently resolving via the schemaless path.
+    expect(mockSendQueryDag.mock.calls.length).toBe(0);
+
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+    const failedEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_failed' &&
+        (call[0] as { step_name: string }).step_name === 'step2'
+    );
+    expect(failedEvent).toBeDefined();
+    expect((failedEvent[0].data as { error: string }).error).toContain('is not declared in node');
+  });
+
   it('stores node_output in node_completed event data for bash nodes', async () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -4638,11 +4638,23 @@ export async function executeDagWorkflow(
   // Nodes flagged `always_run: true` are excluded — they re-execute on resume
   // and downstream consumers must see the fresh output, not the cached one.
   if (priorCompletedNodes && priorCompletedNodes.size > 0) {
+    const nodesById = new Map(workflow.nodes.map(n => [n.id, n]));
     const alwaysRunIds = new Set(workflow.nodes.filter(n => n.always_run).map(n => n.id));
     let prepopulatedCount = 0;
     for (const [nodeId, output] of priorCompletedNodes) {
       if (alwaysRunIds.has(nodeId)) continue;
-      nodeOutputs.set(nodeId, { state: 'completed', output });
+      // Re-derive the producer's declared field set from the loaded definition so the
+      // strict `$node.output.field` contract (output-ref.ts) is invariant across fresh
+      // vs resumed runs. getCompletedDagNodeOutputs rehydrates text only, so without
+      // this a declared-optional-absent field would throw instead of resolving to ''
+      // and an undeclared key would resolve instead of throwing (#2091). Mirrors the
+      // fresh-completion capture above.
+      const declaredFields = declaredFieldsFromSchema(nodesById.get(nodeId)?.output_format);
+      nodeOutputs.set(nodeId, {
+        state: 'completed',
+        output,
+        ...(declaredFields !== undefined ? { declaredFields } : {}),
+      });
       prepopulatedCount++;
     }
     getLog().info(

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -4639,17 +4639,18 @@ export async function executeDagWorkflow(
   // and downstream consumers must see the fresh output, not the cached one.
   if (priorCompletedNodes && priorCompletedNodes.size > 0) {
     const nodesById = new Map(workflow.nodes.map(n => [n.id, n]));
-    const alwaysRunIds = new Set(workflow.nodes.filter(n => n.always_run).map(n => n.id));
     let prepopulatedCount = 0;
     for (const [nodeId, output] of priorCompletedNodes) {
-      if (alwaysRunIds.has(nodeId)) continue;
+      const node = nodesById.get(nodeId);
+      // Nodes flagged always_run re-execute on resume — leave them for fresh output.
+      if (node?.always_run) continue;
       // Re-derive the producer's declared field set from the loaded definition so the
       // strict `$node.output.field` contract (output-ref.ts) is invariant across fresh
       // vs resumed runs. getCompletedDagNodeOutputs rehydrates text only, so without
       // this a declared-optional-absent field would throw instead of resolving to ''
       // and an undeclared key would resolve instead of throwing (#2091). Mirrors the
       // fresh-completion capture above.
-      const declaredFields = declaredFieldsFromSchema(nodesById.get(nodeId)?.output_format);
+      const declaredFields = declaredFieldsFromSchema(node?.output_format);
       nodeOutputs.set(nodeId, {
         state: 'completed',
         output,


### PR DESCRIPTION
## Summary

- **Problem:** On resume, prior completed DAG nodes are rehydrated from `node_completed` events as plain text only, so the producer's `output_format` field set (`declaredFields`) is lost. The strict `$node.output.field` contract then downgrades to the schemaless path, giving the same workflow different semantics on a resumed run vs a fresh one.
- **Why it matters:** A declared-**optional** field absent from the JSON output throws `missing-key` (instead of resolving to `''`), and a key **not** in the schema resolves silently (instead of throwing `not-in-schema`) — a correctness inconsistency that only appears after a resume.
- **What changed:** At resume pre-population, re-derive `declaredFields` from the loaded workflow definition via the existing `declaredFieldsFromSchema(node.output_format)` helper, mirroring the fresh-completion capture. No DB change.
- **What did NOT change (scope boundary):** No changes to `output-ref.ts` contract logic, no persistence of `declaredFields`/`structuredOutput` into event data, no change to loop-group `$LOOP_PREV` rehydration.

## UX Journey

### Before

```
Author writes a workflow with a schema producer + a downstream $prod.output.optField ref.

  Fresh run:                          Resumed run (after a failure downstream):
  ─────────                           ─────────
  producer completes                  producer rehydrated as TEXT ONLY
  declaredFields = [type, optField]   declaredFields = (lost)
  $prod.output.optField (absent)      $prod.output.optField (absent)
    → '' (declared-optional)            → THROWS missing-key  ✗ consumer fails
  $prod.output.typo                   $prod.output.typo
    → THROWS not-in-schema             → resolves silently    ✗ wrong value
```

### After

```
  Fresh run:                          Resumed run:
  ─────────                           ─────────
  producer completes                  producer rehydrated as text
  declaredFields = [type, optField]   *declaredFields RE-DERIVED from definition*
  $prod.output.optField (absent)      $prod.output.optField (absent)
    → '' (declared-optional)            → '' (declared-optional)   ✓ same
  $prod.output.typo                   $prod.output.typo
    → THROWS not-in-schema             → THROWS not-in-schema      ✓ same
```

## Architecture Diagram

### Before

```
executor.ts ──> executeDagWorkflow (dag-executor.ts)
                   │ pre-populate priorCompletedNodes
                   │   nodeOutputs.set(id, { state:'completed', output })   // text only
                   ▼
                 substituteNodeOutputRefs ──> resolveNodeOutputField (output-ref.ts)
                                                 declaredFields === undefined
                                                 └─> schemaless path (case 3)
```

### After

```
executor.ts ──> executeDagWorkflow (dag-executor.ts)  [~]
                   │ pre-populate priorCompletedNodes
                   │   nodesById = Map(workflow.nodes)                       [+]
                   │   declaredFields = declaredFieldsFromSchema(...)        [+]
                   │   nodeOutputs.set(id, { state:'completed', output, declaredFields? })
                   ▼
                 substituteNodeOutputRefs ==> resolveNodeOutputField (output-ref.ts)
                                                 declaredFields present on resume
                                                 └─> declared-schema path (case 1)  ✓
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `dag-executor.ts` (pre-population) | `output-ref.ts` `declaredFieldsFromSchema` | **modified** | Now also called on the resume path (already imported + used at fresh completion) |
| `dag-executor.ts` (pre-population) | `output-ref.ts` `resolveNodeOutputField` | unchanged | Consumer now receives `declaredFields` on resume |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `workflows`
- Module: `workflows:executor`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes #2091

## Validation Evidence (required)

```bash
bun run validate
```

- Evidence provided: `bun run validate` exited `0` — `check:bundled`, `check:bundled-skill`, `check:bundled-schema`, `check:pi-vendor-map`, type-check (all 10 packages), lint (`--max-warnings 0`), format check, and all package tests passed (0 failures). `packages/workflows` `dag-executor.test.ts`: 322 pass / 0 fail.
- Discriminating-test proof: with the fix reverted (`git stash`), both new tests **fail** (test 1 expected 1 AI call, got 0; test 2 expected 0 AI calls, got 1); with the fix, both pass.
- Skipped commands: none.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Database migration needed? `No` — the re-derive approach reads the already-loaded YAML definition; no schema or event-data change.

## Human Verification (required)

- Verified scenarios: Resume path where a schema producer's prior JSON omits a declared-optional field (downstream ref → `''`, consumer runs); resume path where prior JSON carries an undeclared key (downstream ref → `not-in-schema`, consumer fails) — both exercised end-to-end through `executeDagWorkflow` with `priorCompletedNodes`, and confirmed to match fresh-run semantics.
- Edge cases checked: prior node id absent from `workflow.nodes` and nodes without `output_format` both fall back to `declaredFields === undefined` (schemaless, unchanged behavior).
- What was not verified: no live end-to-end run against a real provider (unit-level coverage through the executor is the established pattern for this path).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: DAG resume pre-population only; downstream `$node.output.field` and `when:` field resolution against prior-run producers.
- Potential unintended effects: A resumed workflow that previously "passed" only because an undeclared-key ref silently resolved will now correctly fail that consumer — this is the intended correction and matches fresh-run behavior.
- Guardrails/monitoring: `dag.workflow_resume_prepopulated` log already records pre-population; the `not-in-schema` error message names the node and field.

## Rollback Plan (required)

- Fast rollback: revert commit `bcdb171a` (single, isolated to `dag-executor.ts` + its test).
- Feature flags/toggles: none.
- Observable failure symptoms: a resumed run failing a downstream node with an `OutputRefError` it did not fail before (would indicate the producer's schema legitimately doesn't declare a referenced field — the fix surfacing a real drift, not a regression).

## Risks and Mitigations

- Risk: Behavior change — resumed runs that leaned on the lenient schemaless path for an undeclared key will now fail that consumer.
  - Mitigation: This restores parity with fresh runs (the correct semantics); the error message is actionable (names node + field), and the change is scoped to the resume pre-population block only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow resumption to correctly handle optional output fields that are missing from previously completed nodes.
  * Added validation for undeclared output fields, allowing workflows to fail fast with a clear error instead of making an unnecessary AI call.
  * Ensured resumed workflows apply the same output-field rules as newly executed workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->