### PR TITLE
fix(cli): enforce requires:[github] gate on the CLI run path (#2089)

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -90,6 +90,15 @@ mock.module('@archon/core', () => ({
   createWorkflowStore: mock(() => ({
     createWorkflowEvent: mock(() => Promise.resolve()),
   })),
+  // requires: [github] gate. Default to a solo-install posture (disabled) so the
+  // gate is a no-op for every existing test; the gate-specific tests below flip
+  // isPerUserGitHubEnabled on per-invocation.
+  isPerUserGitHubEnabled: mock(() => false),
+  getDecryptedAccessToken: mock(() => Promise.resolve(null)),
+}));
+
+mock.module('@archon/core/db/users', () => ({
+  findOrCreateUserByPlatformIdentity: mock(() => Promise.resolve({ id: 'user-cli-1' })),
 }));
 
 mock.module('@archon/workflows/workflow-discovery', () => ({
@@ -374,6 +383,114 @@ describe('workflowListCommand', () => {
     await expect(workflowListCommand('/test/path')).rejects.toThrow(
       'Error loading workflows: Permission denied'
     );
+  });
+});
+
+describe('workflowRunCommand — requires: [github] gate', () => {
+  let consoleSpy: ReturnType<typeof spyOn>;
+  let priorArchonUserId: string | undefined;
+
+  beforeEach(async () => {
+    consoleSpy = spyOn(console, 'log').mockImplementation(() => {});
+    // Deterministic CLI identity (resolveCliUserId reads ARCHON_USER_ID).
+    priorArchonUserId = process.env.ARCHON_USER_ID;
+    process.env.ARCHON_USER_ID = 'cli-tester';
+
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    const { isPerUserGitHubEnabled, getDecryptedAccessToken } = await import('@archon/core');
+    const usersDb = await import('@archon/core/db/users');
+    (executeWorkflow as ReturnType<typeof mock>).mockClear();
+    (isPerUserGitHubEnabled as ReturnType<typeof mock>).mockClear();
+    (getDecryptedAccessToken as ReturnType<typeof mock>).mockClear();
+    (usersDb.findOrCreateUserByPlatformIdentity as ReturnType<typeof mock>).mockClear();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    if (priorArchonUserId === undefined) delete process.env.ARCHON_USER_ID;
+    else process.env.ARCHON_USER_ID = priorArchonUserId;
+  });
+
+  it('blocks a requires:[github] workflow before any cost when enabled and not connected', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const { isPerUserGitHubEnabled, getDecryptedAccessToken } = await import('@archon/core');
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'ship', requires: ['github'] }, 'project')],
+      errors: [],
+    });
+    (isPerUserGitHubEnabled as ReturnType<typeof mock>).mockReturnValueOnce(true);
+    (getDecryptedAccessToken as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+
+    await expect(
+      workflowRunCommand('/repo/root', 'ship', 'go', { noWorktree: true })
+    ).rejects.toThrow(/connected github identity/i);
+
+    // Hard-blocked before any worktree/AI cost — executeWorkflow never ran.
+    expect(executeWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('allows the run when the acting CLI user has a connected GitHub identity', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const { isPerUserGitHubEnabled, getDecryptedAccessToken } = await import('@archon/core');
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'ship', requires: ['github'] }, 'project')],
+      errors: [],
+    });
+    (isPerUserGitHubEnabled as ReturnType<typeof mock>).mockReturnValueOnce(true);
+    (getDecryptedAccessToken as ReturnType<typeof mock>).mockResolvedValueOnce('gho_token');
+    (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
+      success: true,
+      workflowRunId: 'run-ok',
+    });
+
+    await workflowRunCommand('/repo/root', 'ship', 'go', { noWorktree: true });
+
+    expect(executeWorkflow).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op on solo installs (per-user GitHub disabled) even when github is required', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const { isPerUserGitHubEnabled, getDecryptedAccessToken } = await import('@archon/core');
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'ship', requires: ['github'] }, 'project')],
+      errors: [],
+    });
+    // Default mock returns false; be explicit for readability.
+    (isPerUserGitHubEnabled as ReturnType<typeof mock>).mockReturnValueOnce(false);
+    (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
+      success: true,
+      workflowRunId: 'run-ok',
+    });
+
+    await workflowRunCommand('/repo/root', 'ship', 'go', { noWorktree: true });
+
+    expect(executeWorkflow).toHaveBeenCalledTimes(1);
+    // Gate short-circuited on the env check — no token lookup happened.
+    expect(getDecryptedAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('does not resolve GitHub connection for a workflow without requires', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const { isPerUserGitHubEnabled, getDecryptedAccessToken } = await import('@archon/core');
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'assist' }, 'project')],
+      errors: [],
+    });
+    // Even with per-user GitHub enabled, a workflow with no `requires` skips the lookup.
+    (isPerUserGitHubEnabled as ReturnType<typeof mock>).mockReturnValueOnce(true);
+    (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
+      success: true,
+      workflowRunId: 'run-ok',
+    });
+
+    await workflowRunCommand('/repo/root', 'assist', 'go', { noWorktree: true });
+
+    expect(executeWorkflow).toHaveBeenCalledTimes(1);
+    expect(getDecryptedAccessToken).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -492,6 +492,59 @@ describe('workflowRunCommand — requires: [github] gate', () => {
     expect(executeWorkflow).toHaveBeenCalledTimes(1);
     expect(getDecryptedAccessToken).not.toHaveBeenCalled();
   });
+
+  it('fails closed when the acting CLI user identity cannot be resolved', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const { isPerUserGitHubEnabled, getDecryptedAccessToken } = await import('@archon/core');
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'ship', requires: ['github'] }, 'project')],
+      errors: [],
+    });
+    (isPerUserGitHubEnabled as ReturnType<typeof mock>).mockReturnValueOnce(true);
+
+    // No resolvable CLI identity → resolveCliUserId() returns null → treated as
+    // "not connected" (fail closed). Clear every identity source for this test.
+    const savedUser = process.env.USER;
+    const savedUsername = process.env.USERNAME;
+    delete process.env.ARCHON_USER_ID;
+    delete process.env.USER;
+    delete process.env.USERNAME;
+    try {
+      await expect(
+        workflowRunCommand('/repo/root', 'ship', 'go', { noWorktree: true })
+      ).rejects.toThrow(/connected github identity/i);
+    } finally {
+      if (savedUser !== undefined) process.env.USER = savedUser;
+      if (savedUsername !== undefined) process.env.USERNAME = savedUsername;
+    }
+
+    // Never resolved a token, and never reached execution.
+    expect(getDecryptedAccessToken).not.toHaveBeenCalled();
+    expect(executeWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the identity/token lookup throws', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const { isPerUserGitHubEnabled } = await import('@archon/core');
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    const usersDb = await import('@archon/core/db/users');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'ship', requires: ['github'] }, 'project')],
+      errors: [],
+    });
+    (isPerUserGitHubEnabled as ReturnType<typeof mock>).mockReturnValueOnce(true);
+    (usersDb.findOrCreateUserByPlatformIdentity as ReturnType<typeof mock>).mockRejectedValueOnce(
+      new Error('db unavailable')
+    );
+
+    // Lookup failure is swallowed inside the gate and defaults to "not connected".
+    await expect(
+      workflowRunCommand('/repo/root', 'ship', 'go', { noWorktree: true })
+    ).rejects.toThrow(/connected github identity/i);
+
+    expect(executeWorkflow).not.toHaveBeenCalled();
+  });
 });
 
 describe('workflowRunCommand', () => {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -9,6 +9,8 @@ import {
   generateAndSetTitle,
   createWorkflowStore,
   getUserAiPrefs,
+  isPerUserGitHubEnabled,
+  getDecryptedAccessToken,
 } from '@archon/core';
 import { WORKFLOW_EVENT_TYPES, type WorkflowEventType } from '@archon/workflows/store';
 import {
@@ -34,6 +36,7 @@ import { createWorkflowDeps } from '@archon/core/workflows/store-adapter';
 import { discoverWorkflowsWithConfig } from '@archon/workflows/workflow-discovery';
 import { resolveWorkflowName } from '@archon/workflows/router';
 import { executeWorkflow, hydrateResumableRun } from '@archon/workflows/executor';
+import { assertWorkflowRequirementsMet } from '@archon/workflows/utils/workflow-requirements';
 import {
   getWorkflowEventEmitter,
   type WorkflowEmitterEvent,
@@ -350,6 +353,40 @@ function assertWorkflowNotWorktreePinnedForFolder(
   if (isFolderProject && pinnedEnabled === true) {
     throw folderWorktreePolicyError(workflowName);
   }
+}
+
+/**
+ * Capability gate for the CLI run path.
+ *
+ * Mirrors the orchestrator's `requires: [github]` enforcement
+ * (orchestrator-agent.ts `dispatchOrchestratorWorkflow`) so a workflow that
+ * declares `requires: [github]` is hard-blocked BEFORE any worktree/clone/AI
+ * cost — and before the `--detach` fork — when the acting CLI user hasn't
+ * connected their GitHub identity. Throws WorkflowRequirementError, surfaced by
+ * the CLI top-level handler (cli.ts) as a clean, actionable `Error: ...` line.
+ *
+ * No-op on solo PAT installs: `isPerUserGitHubEnabled()` is false unless the
+ * GitHub App + TOKEN_ENCRYPTION_KEY are both configured — identical semantics
+ * to the orchestrator gate.
+ */
+async function assertCliWorkflowRequirementsMet(workflow: WorkflowDefinition): Promise<void> {
+  if (!isPerUserGitHubEnabled() || !workflow.requires?.length) return;
+
+  // Resolve the acting CLI user (ARCHON_USER_ID, else $USER/$USERNAME) → Archon
+  // user id, then check for a stored GitHub connection. An unresolvable user or
+  // a lookup failure means "not connected" — fail closed, never silently allow.
+  const cliId = resolveCliUserId();
+  let githubConnected = false;
+  if (cliId) {
+    try {
+      const cliUser = await userDb.findOrCreateUserByPlatformIdentity('cli', cliId, cliId);
+      githubConnected = Boolean(await getDecryptedAccessToken(cliUser.id));
+    } catch (error) {
+      getLog().warn({ err: error as Error, cliId }, 'cli.requirement_gate_user_resolve_failed');
+    }
+  }
+
+  assertWorkflowRequirementsMet(workflow, { githubConnected });
 }
 
 /**
@@ -737,6 +774,13 @@ export async function workflowRunCommand(
   // codebase lookup below. Fail fast — never silently ignore the flags.
   assertNoWorktreeOptionsForFolder(options.folder === true, options);
   assertWorkflowNotWorktreePinnedForFolder(options.folder === true, pinnedEnabled, workflow.name);
+
+  // Capability gate: hard-fail before the --detach fork and any worktree/clone/
+  // AI cost if the workflow declares `requires: [github]` and the acting CLI
+  // user hasn't connected. No-op on solo PAT installs. Mirrors the orchestrator
+  // gate (dispatchOrchestratorWorkflow) so CLI, REST (via orchestrator), and
+  // chat dispatch enforce `requires: [github]` identically.
+  await assertCliWorkflowRequirementsMet(workflow);
 
   // --detach: hand the whole run to a detached background child and return now.
   // Done AFTER workflow resolution + flag validation above (so unknown-workflow /


### PR DESCRIPTION
## Summary

- **Problem:** Workflow-level `requires: [github]` is meant to hard-block a run before any worktree/clone/AI cost when the acting user hasn't connected GitHub, but the CLI run path bypassed it — the pure gate `assertWorkflowRequirementsMet` had a single caller (the orchestrator's `dispatchOrchestratorWorkflow`), while `workflowRunCommand` creates the worktree and calls `executeWorkflow()` directly.
- **Why it matters:** On a multi-user install (App mode + `TOKEN_ENCRYPTION_KEY`), a user with no connected GitHub identity could start a `requires: [github]`-gated workflow from the CLI and burn worktree + AI cost before failing later — or run under the bot/fallback identity. This is a governance control being silently skipped.
- **What changed:** Added a CLI-side capability gate (`assertCliWorkflowRequirementsMet`) that mirrors the orchestrator gate and runs **before** the `--detach` fork and worktree creation, so it fails fast before any cost. It resolves the acting CLI user (`ARCHON_USER_ID`/`$USER` → Archon user id) and checks for a stored GitHub token, then calls the same pure `assertWorkflowRequirementsMet`.
- **What did NOT change (scope boundary):** The orchestrator gate is untouched. **No REST-route change** — `POST /api/workflows/:name/run` is *already* gated: it dispatches `/workflow run` through the orchestrator (`dispatchToOrchestrator` → `handleMessage` → `handleWorkflowRunCommand` → `dispatchOrchestratorWorkflow` → gate), with the acting `userId` flowing the whole way. The issue listed REST as a second bypass; tracing the current code shows it is covered transitively (see UX Journey). Adding a redundant REST gate was rejected (DRY/KISS/YAGNI). Centralizing the gate inside `executeWorkflow()` was also rejected: `@archon/workflows` must not depend on `@archon/core`, and in the CLI the worktree is created before `executeWorkflow()`, so an executor-level gate would fire *after* the cost it's meant to prevent.

## UX Journey

### Before

```
Multi-user install, user with NO connected GitHub, `requires: [github]` workflow:

  CLI:  archon workflow run gated "x"
          resolves workflow
          creates worktree            ← COST incurred
          executeWorkflow()           ← AI cost, runs under fallback identity
        (gate never consulted)

  REST: POST /api/workflows/gated/run
          -> /workflow run -> orchestrator -> dispatchOrchestratorWorkflow
          -> GATE -> BLOCKED  (already correct)
```

### After

```
Multi-user install, user with NO connected GitHub, `requires: [github]` workflow:

  CLI:  archon workflow run gated "x"
          resolves workflow
          *assertCliWorkflowRequirementsMet(workflow)*  ← NEW, before --detach + worktree
          -> WorkflowRequirementError
          -> cli.ts prints "Error: This workflow requires a connected github identity…"
          -> exit 1, NO worktree, NO AI cost, NO detached child spawned

  REST: (unchanged — still blocked via the orchestrator gate)

Solo PAT install (no GITHUB_APP_ID): gate is a no-op; run proceeds as before.
```

## Architecture Diagram

### Before

```
CLI workflowRunCommand ──▶ worktree ──▶ executeWorkflow      (no gate)

orchestrator dispatchOrchestratorWorkflow ──▶ [gate] ──▶ worktree ──▶ executeWorkflow
REST /workflows/:name/run ──▶ orchestrator (/workflow run) ──▶ [gate]
```

### After

```
CLI workflowRunCommand ──▶ [~gate] ──▶ worktree ──▶ executeWorkflow   [~ new gate call]

orchestrator dispatchOrchestratorWorkflow ──▶ [gate] ──▶ worktree ──▶ executeWorkflow
REST /workflows/:name/run ──▶ orchestrator (/workflow run) ──▶ [gate]   (unchanged)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `cli/commands/workflow.ts` | `@archon/workflows/utils/workflow-requirements` | **new** | CLI now calls the pure gate `assertWorkflowRequirementsMet` |
| `cli/commands/workflow.ts` | `@archon/core` (`isPerUserGitHubEnabled`, `getDecryptedAccessToken`) | **new** | Resolve gate context for the acting CLI user |
| `cli/commands/workflow.ts` | `@archon/core/db/users` | unchanged | Already imported; gate reuses `findOrCreateUserByPlatformIdentity` |
| `server routes/api.ts` | orchestrator | unchanged | REST already dispatches `/workflow run` through the gated orchestrator path |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `cli`
- Module: `cli:workflow`

## Change Metadata

- Change type: `bug`
- Primary scope: `cli`

## Linked Issue

- Closes #2089

## Validation Evidence (required)

```bash
bun run validate   # VALIDATE_EXIT=0 — type-check, lint, format:check, bundled/skill/schema/pi-vendor-map checks, and all package tests pass
bun test packages/cli/src/commands/workflow.test.ts   # 155 pass / 0 fail (4 new gate tests + 151 existing)
```

- Evidence provided: full `bun run validate` exited 0 with no failures; the CLI test suite passes with the 4 new regression tests.
- Regression proof: with the gate call removed, `blocks a requires:[github] workflow before any cost when enabled and not connected` fails (command resolves instead of rejecting) — confirming the test fails without the fix.
- Skipped commands: none.

## Security Impact (required)

- New permissions/capabilities? `No` (tightens an existing capability gate)
- New external network calls? `No`
- Secrets/tokens handling changed? `No` (reads an existing per-user GitHub token via the established `getDecryptedAccessToken`; never logs it)
- File system access scope changed? `No`
- Risk/mitigation: This closes a governance bypass. The gate fails **closed** — an unresolvable CLI user or a token-lookup error is treated as "not connected".

## Compatibility / Migration

- Backward compatible? `Yes` — no-op on solo PAT installs; multi-user installs only see enforcement for `requires: [github]` workflows run by unconnected users (the intended behavior).
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios: full `bun run validate` (exit 0); CLI workflow test suite (155 pass); confirmed the block test fails when the gate is removed and passes when restored.
- Edge cases checked: `--no-worktree` path (gate runs before it); `--detach` (gate runs in the parent before the fork, so no child is spawned on block); solo-install no-op (no token lookup); workflow without `requires` (no token lookup).
- What was not verified: a live end-to-end run against a real GitHub-App multi-user install (covered by unit tests + the mirrored orchestrator behavior).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `archon workflow run` (CLI) only. The gate short-circuits on the cheap `isPerUserGitHubEnabled()` env check for the common case.
- Potential unintended effects: In the gated case, `findOrCreateUserByPlatformIdentity` is called slightly earlier than before (idempotent). No behavior change for solo installs or non-`requires` workflows.
- Guardrails/monitoring: `cli.requirement_gate_user_resolve_failed` warn log on lookup failure; the `WorkflowRequirementError` message is user-facing and actionable.

## Rollback Plan (required)

- Fast rollback: revert this commit — the change is isolated to `packages/cli/src/commands/workflow.ts` (+ tests).
- Feature flags/toggles: none; behavior is already gated behind `isPerUserGitHubEnabled()`.
- Observable failure symptoms: a connected user being wrongly blocked (would indicate a token-resolution regression) — none observed.

## Risks and Mitigations

- Risk: A future refactor makes the REST route call `executeWorkflow()` directly, bypassing the orchestrator gate.
  - Mitigation: Documented the REST→orchestrator enforcement chain here; the orchestrator gate remains the single enforcement point for both chat and REST.
- Risk: CLI identity resolution differs from the orchestrator's.
  - Mitigation: The gate reuses the exact `resolveCliUserId` + `findOrCreateUserByPlatformIdentity('cli', …)` mapping the CLI already uses to attribute runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI-side capability gate for workflows that declare `requires: ['github']`.
  * Workflows now fail fast before forking/execution when no decrypted GitHub token is available.
  * Token lookup/identity resolution uses fail-closed behavior to prevent unintended runs.
  * GitHub requirements are skipped when per-user GitHub is disabled (solo installs) or when the workflow does not declare a GitHub requirement.

* **Tests**
  * Updated and expanded CLI workflow-run tests to make GitHub gating deterministic with stable user/token mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->