### PR TITLE
fix(workflows): namespace loop_group body lifecycle events (#2090)

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -56,6 +56,7 @@ import {
   executeDagWorkflow,
 } from './dag-executor';
 import { writeNodeArtifact } from './artifacts-index';
+import { getWorkflowEventEmitter, type WorkflowEmitterEvent } from './event-emitter';
 import { loadMcpConfig } from '@archon/providers/mcp/config';
 import type { DagNode, BashNode, ScriptNode, NodeOutput, WorkflowRun } from './schemas';
 import { discoverWorkflows } from './workflow-discovery';
@@ -11428,5 +11429,326 @@ describe('executeDagWorkflow -- loop_group node', () => {
     const written = await readFile(join(artifactsDir, 'nodes', 'producer.md'), 'utf8');
     expect(written).toContain('final result v2');
     expect(written).not.toContain('draft v1');
+  });
+});
+
+// #2090: loop_group body lifecycle events must carry a namespaced persisted `step_name`
+// (`<groupId>.<nodeId>`, composing across nested groups) plus the current `iteration`, while
+// the in-process emitter payloads stay raw. Top-level DAG events are unchanged (bare id).
+describe('executeDagWorkflow -- loop_group body step_name namespacing (#2090)', () => {
+  let testDir: string;
+
+  /** All persisted createWorkflowEvent payloads for a store mock. */
+  type PersistedEvent = { event_type: string; step_name?: string; data?: Record<string, unknown> };
+  const persistedEvents = (store: IWorkflowStore): PersistedEvent[] =>
+    (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.map(
+      c => c[0] as PersistedEvent
+    );
+  const eventsWith = (
+    store: IWorkflowStore,
+    eventType: string,
+    stepName: string
+  ): PersistedEvent[] =>
+    persistedEvents(store).filter(e => e.event_type === eventType && e.step_name === stepName);
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `dag-lg-ns-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(join(testDir, '.archon', 'commands'), { recursive: true });
+    mockSendQueryDag.mockClear();
+    mockGetAgentProviderDag.mockClear();
+    mockGetAgentProviderDag.mockImplementation(() => ({
+      sendQuery: mockSendQueryDag,
+      getType: () => 'claude',
+      getCapabilities: mockClaudeCapabilities,
+    }));
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(testDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it('namespaces body node lifecycle step_name and tags iteration; top-level node stays bare', async () => {
+    // `work` (AI) does not emit DONE on iteration 1, emits it on iteration 2 → 2 iterations.
+    let calls = 0;
+    mockSendQueryDag.mockImplementation(function* () {
+      calls++;
+      yield {
+        type: 'assistant',
+        content: calls === 1 ? 'still working' : 'finished\nDONE',
+      };
+      yield { type: 'result', sessionId: `s-${calls}` };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('lg-ns-run');
+
+    const nodes: DagNode[] = [
+      // Top-level bash node — its events must NOT be namespaced and must NOT carry iteration.
+      { id: 'setup', bash: 'echo ready', depends_on: [] },
+      {
+        id: 'fixer',
+        loop_group: {
+          until: 'DONE',
+          max_iterations: 5,
+          fresh_context: false,
+          nodes: [{ id: 'work', prompt: 'do work, emit DONE when done', depends_on: [] }],
+        },
+        depends_on: ['setup'],
+      },
+    ];
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-lg',
+      testDir,
+      { name: 'lg-ns', nodes },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    expect(calls).toBe(2);
+
+    // Body node events are namespaced `<groupId>.<nodeId>`.
+    const bodyStarted = eventsWith(store, 'node_started', 'fixer.work');
+    const bodyCompleted = eventsWith(store, 'node_completed', 'fixer.work');
+    expect(bodyStarted.length).toBe(2); // one per iteration
+    expect(bodyCompleted.length).toBe(2);
+    // Each body lifecycle event carries the iteration it ran in.
+    expect(bodyStarted.map(e => e.data?.iteration).sort()).toEqual([1, 2]);
+    expect(bodyCompleted.map(e => e.data?.iteration).sort()).toEqual([1, 2]);
+
+    // The raw (un-namespaced) body id must NEVER appear as a persisted step_name.
+    expect(persistedEvents(store).some(e => e.step_name === 'work')).toBe(false);
+
+    // The group node's OWN events keep the bare group id (they are not body events).
+    expect(eventsWith(store, 'node_completed', 'fixer').length).toBeGreaterThanOrEqual(1);
+    expect(eventsWith(store, 'loop_iteration_started', 'fixer').length).toBe(2);
+
+    // Top-level node keeps its bare id and carries no `iteration` tag.
+    const setupStarted = eventsWith(store, 'node_started', 'setup');
+    expect(setupStarted.length).toBe(1);
+    expect(setupStarted[0].data?.iteration).toBeUndefined();
+    expect(eventsWith(store, 'node_completed', 'setup').length).toBe(1);
+  });
+
+  it('composes the prefix across nested loop_groups (<outer>.<inner>.<leaf>)', async () => {
+    // Inner group completes in 1 iteration (INNER_DONE); outer completes when review emits
+    // OUTER_DONE. Mirrors the EDGE H harness above.
+    let calls = 0;
+    mockSendQueryDag.mockImplementation(function* () {
+      calls++;
+      yield {
+        type: 'assistant',
+        content: calls === 1 ? 'inner work\nINNER_DONE' : 'outer review\nOUTER_DONE',
+      };
+      yield { type: 'result', sessionId: `s-${calls}` };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('lg-nested-ns');
+
+    const nodes: DagNode[] = [
+      {
+        id: 'outer',
+        loop_group: {
+          until: 'OUTER_DONE',
+          max_iterations: 3,
+          fresh_context: false,
+          nodes: [
+            {
+              id: 'inner',
+              loop_group: {
+                until: 'INNER_DONE',
+                max_iterations: 2,
+                fresh_context: false,
+                nodes: [{ id: 'leaf', prompt: 'inner work, emit INNER_DONE', depends_on: [] }],
+              },
+              depends_on: [],
+            },
+            { id: 'review', prompt: 'review, emit OUTER_DONE', depends_on: ['inner'] },
+          ],
+        },
+        depends_on: [],
+      },
+    ];
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-lg',
+      testDir,
+      { name: 'lg-nested-ns', nodes },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    expect(calls).toBe(2);
+
+    // Deepest body node composes both enclosing group ids.
+    expect(eventsWith(store, 'node_completed', 'outer.inner.leaf').length).toBeGreaterThanOrEqual(
+      1
+    );
+    // The inner group's OWN events are namespaced by the outer group only.
+    expect(
+      eventsWith(store, 'loop_iteration_started', 'outer.inner').length
+    ).toBeGreaterThanOrEqual(1);
+    // The outer body's sibling AI node is namespaced by the outer group.
+    expect(eventsWith(store, 'node_completed', 'outer.review').length).toBeGreaterThanOrEqual(1);
+    // No un-namespaced leaf/review rows leak.
+    expect(persistedEvents(store).some(e => e.step_name === 'leaf')).toBe(false);
+    expect(persistedEvents(store).some(e => e.step_name === 'review')).toBe(false);
+  });
+
+  it('keeps the in-process emitter payload raw (unprefixed nodeId) for body events', async () => {
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'done\nDONE' };
+      yield { type: 'result', sessionId: 's-1' };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('lg-emit-raw');
+
+    const captured: WorkflowEmitterEvent[] = [];
+    const unsubscribe = getWorkflowEventEmitter().subscribe(e => {
+      if (e.runId === workflowRun.id) captured.push(e);
+    });
+
+    try {
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-lg',
+        testDir,
+        {
+          name: 'lg-emit-raw',
+          nodes: [
+            {
+              id: 'fixer',
+              loop_group: {
+                until: 'DONE',
+                max_iterations: 3,
+                fresh_context: false,
+                nodes: [{ id: 'work', prompt: 'do work, emit DONE', depends_on: [] }],
+              },
+              depends_on: [],
+            },
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+    } finally {
+      unsubscribe();
+    }
+
+    // The live emitter carries the RAW body node id (consumers key off this) — never `fixer.work`.
+    const bodyCompleted = captured.filter(
+      e => e.type === 'node_completed' && 'nodeId' in e && e.nodeId === 'work'
+    );
+    expect(bodyCompleted.length).toBeGreaterThanOrEqual(1);
+    expect(
+      captured.some(e => 'nodeId' in e && (e as { nodeId?: string }).nodeId === 'fixer.work')
+    ).toBe(false);
+  });
+
+  it('resume: a namespaced body key in priorCompletedNodes cannot skip a top-level node', async () => {
+    // Simulate a resume where a prior run's loop_group completed: the map holds the group id
+    // AND a namespaced body key. The group must be skipped as a unit (body does NOT re-run),
+    // and the un-namespaced body key must NOT be mistaken for the still-pending top-level node.
+    let calls = 0;
+    mockSendQueryDag.mockImplementation(function* () {
+      calls++;
+      yield { type: 'assistant', content: 'finalize output' };
+      yield { type: 'result', sessionId: `s-${calls}` };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('lg-resume');
+
+    const priorCompletedNodes = new Map<string, string>([
+      ['fixer', 'group output from prior run'],
+      ['fixer.work', 'body output from prior run'],
+    ]);
+
+    const nodes: DagNode[] = [
+      {
+        id: 'fixer',
+        loop_group: {
+          until: 'DONE',
+          max_iterations: 5,
+          fresh_context: false,
+          nodes: [{ id: 'work', prompt: 'do work, emit DONE', depends_on: [] }],
+        },
+        depends_on: [],
+      },
+      { id: 'finalize', prompt: 'finalize using $fixer.output', depends_on: ['fixer'] },
+    ];
+
+    let finalizePrompt = '';
+    mockSendQueryDag.mockImplementation(function* (prompt: string) {
+      calls++;
+      finalizePrompt = prompt;
+      yield { type: 'assistant', content: 'finalize output' };
+      yield { type: 'result', sessionId: `s-${calls}` };
+    });
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-lg',
+      testDir,
+      { name: 'lg-resume', nodes },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes
+    );
+
+    // Only `finalize` executes: the loop_group `fixer` was skipped as a unit (body never
+    // re-ran), and the namespaced `fixer.work` key skipped nothing at the top level.
+    expect(calls).toBe(1);
+    // The skipped group's pre-populated output flows into the still-running downstream node.
+    expect(finalizePrompt).toContain('group output from prior run');
+    // The group was skipped via its own id, and finalize genuinely ran.
+    expect(eventsWith(store, 'node_skipped_prior_success', 'fixer').length).toBe(1);
+    expect(eventsWith(store, 'node_completed', 'finalize').length).toBe(1);
   });
 });

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -833,10 +833,19 @@ async function executeNodeInternal(
   configuredCommandFolder?: string,
   issueContext?: string,
   resolvedModel?: string,
-  resolvedTier?: TierName
+  resolvedTier?: TierName,
+  stepNamePrefix = '',
+  iteration?: number
 ): Promise<NodeExecutionResult> {
   const nodeStartTime = Date.now();
   const nodeContext: SendMessageContext = { workflowId: workflowRun.id, nodeName: node.id };
+  // Persisted step_name is namespaced ('<groupId>.' prefix) for loop_group bodies;
+  // '' for the top-level DAG → identical to node.id. The in-process emitter payloads
+  // below stay raw (node.id) — live SSE/CLI consumers key off those. See #2090.
+  const stepName = stepNamePrefix + node.id;
+  // Only present inside a loop_group body — tags lifecycle rows with the iteration so
+  // multi-iteration runs are disaggregatable in the event log.
+  const iterationData = iteration !== undefined ? { iteration } : {};
 
   const configuredMcpNames = await loadConfiguredMcpServerNames(node.mcp, cwd);
 
@@ -847,8 +856,14 @@ async function executeNodeInternal(
     .createWorkflowEvent({
       workflow_run_id: workflowRun.id,
       event_type: 'node_started',
-      step_name: node.id,
-      data: { command: node.command ?? null, provider, model: resolvedModel, tier: resolvedTier },
+      step_name: stepName,
+      data: {
+        command: node.command ?? null,
+        provider,
+        model: resolvedModel,
+        tier: resolvedTier,
+        ...iterationData,
+      },
     })
     .catch((err: Error) => {
       getLog().error(
@@ -880,7 +895,7 @@ async function executeNodeInternal(
         .createWorkflowEvent({
           workflow_run_id: workflowRun.id,
           event_type: 'node_failed',
-          step_name: node.id,
+          step_name: stepName,
           data: { error: errMsg },
         })
         .catch((err: Error) => {
@@ -1076,7 +1091,7 @@ async function executeNodeInternal(
             .createWorkflowEvent({
               workflow_run_id: workflowRun.id,
               event_type: 'tool_completed',
-              step_name: node.id,
+              step_name: stepName,
               data: {
                 tool_name: prevTool.toolName,
                 duration_ms: now - prevTool.startedAt,
@@ -1117,7 +1132,7 @@ async function executeNodeInternal(
           .createWorkflowEvent({
             workflow_run_id: workflowRun.id,
             event_type: 'tool_called',
-            step_name: node.id,
+            step_name: stepName,
             data: {
               tool_name: msg.toolName,
               tool_input: msg.toolInput ?? {},
@@ -1148,7 +1163,7 @@ async function executeNodeInternal(
             .createWorkflowEvent({
               workflow_run_id: workflowRun.id,
               event_type: 'tool_completed',
-              step_name: node.id,
+              step_name: stepName,
               data: {
                 tool_name: prevTool.toolName,
                 duration_ms: Date.now() - prevTool.startedAt,
@@ -1284,7 +1299,7 @@ async function executeNodeInternal(
           .createWorkflowEvent({
             workflow_run_id: workflowRun.id,
             event_type: 'task_activity',
-            step_name: node.id,
+            step_name: stepName,
             data: {
               task_id: msg.taskId,
               activity: 'started',
@@ -1316,7 +1331,7 @@ async function executeNodeInternal(
           .createWorkflowEvent({
             workflow_run_id: workflowRun.id,
             event_type: 'task_activity',
-            step_name: node.id,
+            step_name: stepName,
             data: {
               task_id: msg.taskId,
               activity: 'progress',
@@ -1346,7 +1361,7 @@ async function executeNodeInternal(
           .createWorkflowEvent({
             workflow_run_id: workflowRun.id,
             event_type: 'task_activity',
-            step_name: node.id,
+            step_name: stepName,
             data: {
               task_id: msg.taskId,
               activity: msg.status,
@@ -1374,7 +1389,7 @@ async function executeNodeInternal(
           .createWorkflowEvent({
             workflow_run_id: workflowRun.id,
             event_type: 'hook_activity',
-            step_name: node.id,
+            step_name: stepName,
             data: {
               hook_id: msg.hookId,
               hook_name: msg.hookName,
@@ -1404,7 +1419,7 @@ async function executeNodeInternal(
           .createWorkflowEvent({
             workflow_run_id: workflowRun.id,
             event_type: 'hook_activity',
-            step_name: node.id,
+            step_name: stepName,
             data: {
               hook_id: msg.hookId,
               hook_name: msg.hookName,
@@ -1587,7 +1602,7 @@ async function executeNodeInternal(
         .createWorkflowEvent({
           workflow_run_id: workflowRun.id,
           event_type: 'node_failed',
-          step_name: node.id,
+          step_name: stepName,
           data: { error: 'Cancelled by user', duration_ms: duration },
         })
         .catch((err: Error) => {
@@ -1632,7 +1647,7 @@ async function executeNodeInternal(
         .createWorkflowEvent({
           workflow_run_id: workflowRun.id,
           event_type: 'node_failed',
-          step_name: node.id,
+          step_name: stepName,
           data: { error: creditError },
         })
         .catch((err: Error) => {
@@ -1669,7 +1684,7 @@ async function executeNodeInternal(
         .createWorkflowEvent({
           workflow_run_id: workflowRun.id,
           event_type: 'node_failed',
-          step_name: node.id,
+          step_name: stepName,
           data: { error: emptyError, duration_ms: duration },
         })
         .catch((err: Error) => {
@@ -1704,7 +1719,7 @@ async function executeNodeInternal(
       .createWorkflowEvent({
         workflow_run_id: workflowRun.id,
         event_type: 'node_completed',
-        step_name: node.id,
+        step_name: stepName,
         data: {
           duration_ms: duration,
           node_output: nodeOutputText,
@@ -1712,6 +1727,7 @@ async function executeNodeInternal(
           ...(nodeStopReason ? { stop_reason: nodeStopReason } : {}),
           ...(nodeNumTurns !== undefined ? { num_turns: nodeNumTurns } : {}),
           ...(nodeModelUsage ? { model_usage: nodeModelUsage } : {}),
+          ...iterationData,
         },
       })
       .catch((err: Error) => {
@@ -1777,7 +1793,7 @@ async function executeNodeInternal(
       .createWorkflowEvent({
         workflow_run_id: workflowRun.id,
         event_type: 'node_failed',
-        step_name: node.id,
+        step_name: stepName,
         data: { error: err.message },
       })
       .catch((err: Error) => {
@@ -1830,10 +1846,15 @@ async function executeBashNode(
   docsDir: string,
   nodeOutputs: Map<string, NodeOutput>,
   issueContext?: string,
-  envVars?: Record<string, string>
+  envVars?: Record<string, string>,
+  stepNamePrefix = '',
+  iteration?: number
 ): Promise<NodeOutput> {
   const nodeStartTime = Date.now();
   const nodeContext: SendMessageContext = { workflowId: workflowRun.id, nodeName: node.id };
+  // Namespaced persisted step_name for loop_group bodies ('' → node.id at top level, #2090).
+  const stepName = stepNamePrefix + node.id;
+  const iterationData = iteration !== undefined ? { iteration } : {};
 
   getLog().info({ nodeId: node.id, type: 'bash' }, 'dag_node_started');
   await logNodeStart(logDir, workflowRun.id, node.id, '<bash>');
@@ -1842,8 +1863,8 @@ async function executeBashNode(
     .createWorkflowEvent({
       workflow_run_id: workflowRun.id,
       event_type: 'node_started',
-      step_name: node.id,
-      data: { type: 'bash' },
+      step_name: stepName,
+      data: { type: 'bash', ...iterationData },
     })
     .catch((err: Error) => {
       getLog().error(
@@ -1921,8 +1942,8 @@ async function executeBashNode(
       .createWorkflowEvent({
         workflow_run_id: workflowRun.id,
         event_type: 'node_completed',
-        step_name: node.id,
-        data: { duration_ms: duration, type: 'bash', node_output: output },
+        step_name: stepName,
+        data: { duration_ms: duration, type: 'bash', node_output: output, ...iterationData },
       })
       .catch((err: Error) => {
         getLog().error(
@@ -1969,7 +1990,7 @@ async function executeBashNode(
       .createWorkflowEvent({
         workflow_run_id: workflowRun.id,
         event_type: 'node_failed',
-        step_name: node.id,
+        step_name: stepName,
         data: { error: errorMsg, type: 'bash' },
       })
       .catch((dbErr: Error) => {
@@ -2009,10 +2030,15 @@ async function executeScriptNode(
   docsDir: string,
   nodeOutputs: Map<string, NodeOutput>,
   issueContext?: string,
-  envVars?: Record<string, string>
+  envVars?: Record<string, string>,
+  stepNamePrefix = '',
+  iteration?: number
 ): Promise<NodeOutput> {
   const nodeStartTime = Date.now();
   const nodeContext: SendMessageContext = { workflowId: workflowRun.id, nodeName: node.id };
+  // Namespaced persisted step_name for loop_group bodies ('' → node.id at top level, #2090).
+  const stepName = stepNamePrefix + node.id;
+  const iterationData = iteration !== undefined ? { iteration } : {};
 
   getLog().info({ nodeId: node.id, type: 'script', runtime: node.runtime }, 'dag_node_started');
   await logNodeStart(logDir, workflowRun.id, node.id, '<script>');
@@ -2021,8 +2047,8 @@ async function executeScriptNode(
     .createWorkflowEvent({
       workflow_run_id: workflowRun.id,
       event_type: 'node_started',
-      step_name: node.id,
-      data: { type: 'script', runtime: node.runtime },
+      step_name: stepName,
+      data: { type: 'script', runtime: node.runtime, ...iterationData },
     })
     .catch((err: Error) => {
       getLog().error(
@@ -2108,7 +2134,7 @@ async function executeScriptNode(
           .createWorkflowEvent({
             workflow_run_id: workflowRun.id,
             event_type: 'node_failed',
-            step_name: node.id,
+            step_name: stepName,
             data: { error: errorMsg, type: 'script' },
           })
           .catch((dbErr: Error) => {
@@ -2139,7 +2165,7 @@ async function executeScriptNode(
           .createWorkflowEvent({
             workflow_run_id: workflowRun.id,
             event_type: 'node_failed',
-            step_name: node.id,
+            step_name: stepName,
             data: { error: errorMsg, type: 'script' },
           })
           .catch((dbErr: Error) => {
@@ -2190,8 +2216,8 @@ async function executeScriptNode(
       .createWorkflowEvent({
         workflow_run_id: workflowRun.id,
         event_type: 'node_completed',
-        step_name: node.id,
-        data: { duration_ms: duration, type: 'script', node_output: output },
+        step_name: stepName,
+        data: { duration_ms: duration, type: 'script', node_output: output, ...iterationData },
       })
       .catch((err: Error) => {
         getLog().error(
@@ -2238,7 +2264,7 @@ async function executeScriptNode(
       .createWorkflowEvent({
         workflow_run_id: workflowRun.id,
         event_type: 'node_failed',
-        step_name: node.id,
+        step_name: stepName,
         data: { error: errorMsg, type: 'script' },
       })
       .catch((dbErr: Error) => {
@@ -2267,10 +2293,12 @@ async function executeScriptNode(
  *
  * Mirrors {@link executeLoopNode} at subgraph granularity: each iteration runs the body's
  * topological layers via {@link runLayers} against a fresh scoped `nodeOutputs` map. The
- * body is a sealed sub-DAG. runLayers' own control events (skip/trigger_rule/when) are
- * namespaced `{groupId}.{nodeId}` via `stepNamePrefix`; the body nodes' lifecycle events
- * (node_started/node_completed/node_failed, tool events) still use the raw node id — a
- * known v1 limitation (executeNodeInternal does not take a step-name override yet).
+ * body is a sealed sub-DAG. Every persisted body event — both runLayers' own control
+ * events (skip/trigger_rule/when) AND the node executors' lifecycle events
+ * (node_started/node_completed/node_failed, and tool/task/hook activity) — is namespaced
+ * `{groupId}.{nodeId}` via `stepNamePrefix`, composing across nested groups; body node
+ * lifecycle rows also carry the current `iteration` in their `data` (#2090). The in-process
+ * emitter payloads stay raw (unprefixed nodeId) so live SSE/CLI consumers are unaffected.
  * `$LOOP_PREV.<id>.output` refs in body prompts resolve against a snapshot of the
  * *previous* iteration's body outputs (empty on iteration 1).
  *
@@ -2301,16 +2329,22 @@ async function executeLoopGroupNode(
   docsDir: string,
   outerNodeOutputs: Map<string, NodeOutput>,
   config: WorkflowConfig,
-  issueContext?: string
+  issueContext?: string,
+  stepNamePrefix = ''
 ): Promise<NodeExecutionResult> {
   const group = node.loop_group;
   const msgContext = { workflowId: workflowRun.id, nodeName: node.id };
+  // This group's OWN persisted step_name — namespaced by any enclosing group so nested
+  // loop_groups compose (e.g. `outer.inner`); '' → node.id at the top level (#2090).
+  const stepName = stepNamePrefix + node.id;
 
   // Body layering is recomputed per iteration from the (possibly $LOOP_PREV-substituted)
   // body nodes — runLayers walks ctx.layers, so the layers must reference the substituted
   // nodes for $LOOP_PREV resolution to take effect. depends_on shape is static, so the
   // layering is stable; only the prompt text changes per iteration.
-  const stepNamePrefix = `${node.id}.`;
+  // Body nodes are namespaced under THIS group's (already-namespaced) step name so the
+  // prefix composes across nested loop_groups: `<enclosing>.<groupId>.<bodyNodeId>`.
+  const bodyStepNamePrefix = `${stepName}.`;
 
   // Detect interactive loop resume (mirrors executeLoopNode).
   const rawApproval = workflowRun.metadata?.approval;
@@ -2370,7 +2404,7 @@ async function executeLoopGroupNode(
       .createWorkflowEvent({
         workflow_run_id: workflowRun.id,
         event_type: 'loop_iteration_started',
-        step_name: node.id,
+        step_name: stepName,
         data: { iteration: i, maxIterations: group.max_iterations, nodeId: node.id },
       })
       .catch((err: Error) => {
@@ -2439,7 +2473,8 @@ async function executeLoopGroupNode(
       totalTokensIn: 0,
       totalTokensOut: 0,
       totalLoopIterations: 0,
-      stepNamePrefix,
+      stepNamePrefix: bodyStepNamePrefix,
+      iteration: i,
     };
     await runLayers(iterCtx);
     // A body approval/cancel node may have paused or cancelled the run mid-iteration.
@@ -2594,7 +2629,7 @@ async function executeLoopGroupNode(
       .createWorkflowEvent({
         workflow_run_id: workflowRun.id,
         event_type: 'loop_iteration_completed',
-        step_name: node.id,
+        step_name: stepName,
         data: { iteration: i, duration, completionDetected, nodeId: node.id },
       })
       .catch((err: Error) => {
@@ -2615,7 +2650,7 @@ async function executeLoopGroupNode(
         .createWorkflowEvent({
           workflow_run_id: workflowRun.id,
           event_type: 'node_completed',
-          step_name: node.id,
+          step_name: stepName,
           data: {
             duration_ms: duration,
             node_output: lastIterationOutput,
@@ -2670,7 +2705,7 @@ async function executeLoopGroupNode(
         .createWorkflowEvent({
           workflow_run_id: workflowRun.id,
           event_type: 'approval_requested',
-          step_name: node.id,
+          step_name: stepName,
           data: { message: group.gate_message, iteration: i },
         })
         .catch((err: Error) => {
@@ -2823,10 +2858,15 @@ async function executeLoopNode(
   docsDir: string,
   nodeOutputs: Map<string, NodeOutput>,
   config: WorkflowConfig,
-  issueContext?: string
+  issueContext?: string,
+  stepNamePrefix = ''
 ): Promise<NodeExecutionResult> {
   const loop = node.loop;
   const msgContext = { workflowId: workflowRun.id, nodeName: node.id };
+  // Namespaced persisted step_name when this loop node runs inside a loop_group body
+  // ('' → node.id at top level, #2090). The loop's own per-iteration number lives in
+  // each event's data (`iteration`), so no separate iteration param is threaded here.
+  const stepName = stepNamePrefix + node.id;
 
   // Resolve AI client — fail fast with descriptive error
   let aiClient: ReturnType<typeof deps.getAgentProvider>;
@@ -2899,7 +2939,7 @@ async function executeLoopNode(
       .createWorkflowEvent({
         workflow_run_id: workflowRun.id,
         event_type: 'loop_iteration_started',
-        step_name: node.id,
+        step_name: stepName,
         data: { iteration: i, maxIterations: loop.max_iterations, nodeId: node.id },
       })
       .catch((err: Error) => {
@@ -2979,7 +3019,7 @@ async function executeLoopNode(
               .createWorkflowEvent({
                 workflow_run_id: workflowRun.id,
                 event_type: 'tool_completed',
-                step_name: node.id,
+                step_name: stepName,
                 data: {
                   tool_name: prevTool.toolName,
                   duration_ms: Date.now() - prevTool.startedAt,
@@ -3061,7 +3101,7 @@ async function executeLoopNode(
               .createWorkflowEvent({
                 workflow_run_id: workflowRun.id,
                 event_type: 'tool_completed',
-                step_name: node.id,
+                step_name: stepName,
                 data: { tool_name: prevTool.toolName, duration_ms: now - prevTool.startedAt },
               })
               .catch((err: Error) => {
@@ -3104,7 +3144,7 @@ async function executeLoopNode(
             .createWorkflowEvent({
               workflow_run_id: workflowRun.id,
               event_type: 'tool_called',
-              step_name: node.id,
+              step_name: stepName,
               data: { tool_name: msg.toolName, tool_input: toolInput },
             })
             .catch((err: Error) => {
@@ -3130,7 +3170,7 @@ async function executeLoopNode(
         .createWorkflowEvent({
           workflow_run_id: workflowRun.id,
           event_type: 'loop_iteration_failed',
-          step_name: node.id,
+          step_name: stepName,
           data: { iteration: i, error: err.message, duration, nodeId: node.id },
         })
         .catch((evtErr: Error) => {
@@ -3183,7 +3223,7 @@ async function executeLoopNode(
         .createWorkflowEvent({
           workflow_run_id: workflowRun.id,
           event_type: 'loop_iteration_failed',
-          step_name: node.id,
+          step_name: stepName,
           data: {
             iteration: i,
             error: emptyError,
@@ -3296,7 +3336,7 @@ async function executeLoopNode(
       .createWorkflowEvent({
         workflow_run_id: workflowRun.id,
         event_type: 'loop_iteration_completed',
-        step_name: node.id,
+        step_name: stepName,
         data: { iteration: i, duration, completionDetected, nodeId: node.id },
       })
       .catch((err: Error) => {
@@ -3326,7 +3366,7 @@ async function executeLoopNode(
         .createWorkflowEvent({
           workflow_run_id: workflowRun.id,
           event_type: 'node_completed',
-          step_name: node.id,
+          step_name: stepName,
           data: {
             duration_ms: Date.now() - iterationStart,
             node_output: lastIterationOutput,
@@ -3393,7 +3433,7 @@ async function executeLoopNode(
         .createWorkflowEvent({
           workflow_run_id: workflowRun.id,
           event_type: 'approval_requested',
-          step_name: node.id,
+          step_name: stepName,
           data: { message: loop.gate_message, iteration: i },
         })
         .catch((err: Error) => {
@@ -3467,9 +3507,13 @@ async function executeApprovalNode(
   configuredCommandFolder?: string,
   issueContext?: string,
   aiProfile?: ResolvedAiProfile,
-  workflowPreset?: ModelAliasPreset
+  workflowPreset?: ModelAliasPreset,
+  stepNamePrefix = '',
+  iteration?: number
 ): Promise<NodeOutput> {
   const msgContext = { workflowId: workflowRun.id, nodeName: node.id };
+  // Namespaced persisted step_name for loop_group bodies ('' → node.id at top level, #2090).
+  const stepName = stepNamePrefix + node.id;
 
   // Detect rejection resume — check metadata for rejection_reason set by reject handlers
   const rawApproval = workflowRun.metadata?.approval;
@@ -3495,7 +3539,7 @@ async function executeApprovalNode(
         .createWorkflowEvent({
           workflow_run_id: workflowRun.id,
           event_type: 'workflow_cancelled',
-          step_name: node.id,
+          step_name: stepName,
           data: { reason: `max_attempts (${String(maxAttempts)}) exhausted` },
         })
         .catch((err: Error) => {
@@ -3585,7 +3629,9 @@ async function executeApprovalNode(
       configuredCommandFolder,
       issueContext,
       resolvedNodeModel,
-      resolvedTier
+      resolvedTier,
+      stepNamePrefix,
+      iteration
     );
 
     if (output.state === 'failed') {
@@ -3608,7 +3654,7 @@ async function executeApprovalNode(
     .createWorkflowEvent({
       workflow_run_id: workflowRun.id,
       event_type: 'approval_requested',
-      step_name: node.id,
+      step_name: stepName,
       data: { message: renderedMessage },
     })
     .catch((err: Error) => {
@@ -3695,9 +3741,11 @@ async function buildColdResumeRecoveryPointer(
  * The top-level DAG and each `loop_group` body iteration construct their own context: the
  * top-level call uses `workflow.nodes` / a fresh `nodeOutputs`; a loop-group body uses the
  * group's `nodes` / a per-iteration scoped `nodeOutputs` (reset each iteration) and a
- * `stepNamePrefix` of `'{groupId}.'` that namespaces runLayers' OWN control events
- * (skip/trigger_rule/when). Body lifecycle events emitted inside executeNodeInternal /
- * executeBashNode / executeScriptNode still use the raw node id (known v1 limitation).
+ * `stepNamePrefix` of `'{groupId}.'` that namespaces the persisted `step_name` of EVERY
+ * body event — runLayers' own control events (skip/trigger_rule/when) AND the lifecycle
+ * events emitted inside executeNodeInternal / executeBashNode / executeScriptNode /
+ * executeLoopNode / executeApprovalNode. Body lifecycle rows additionally carry `iteration`
+ * in `data`. The in-process emitter payloads stay raw (unprefixed) — see #2090.
  */
 interface RunLayersContext {
   // --- run-level invariants (shared by top-level DAG and loop_group body) ---
@@ -3748,8 +3796,14 @@ interface RunLayersContext {
   totalTokensIn: number;
   totalTokensOut: number;
   totalLoopIterations: number;
-  /** Prefix prepended to every `step_name` in emitted events ('' for top-level, '{groupId}.' for body). */
+  /** Prefix prepended to every persisted `step_name` ('' for top-level, '{groupId}.' for a loop_group body). */
   stepNamePrefix: string;
+  /**
+   * The enclosing loop_group iteration (1-based) when these layers are a group body,
+   * else undefined for the top-level DAG. Tagged into body node lifecycle event `data`
+   * so multi-iteration runs are disaggregatable in the persisted event log (#2090).
+   */
+  iteration?: number;
 }
 
 /**
@@ -3788,6 +3842,7 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
     layers,
     priorCompletedNodes,
     stepNamePrefix,
+    iteration,
   } = ctx;
   // nodeOutputs + accumulators + lastSequentialSessionId are mutated in place on `ctx`.
 
@@ -3996,7 +4051,9 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
               docsDir,
               ctx.nodeOutputs,
               issueContext,
-              config.envVars
+              config.envVars,
+              stepNamePrefix,
+              iteration
             );
             return { nodeId: node.id, output };
           }
@@ -4033,7 +4090,8 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
               docsDir,
               ctx.nodeOutputs,
               config,
-              issueContext
+              issueContext,
+              stepNamePrefix
             );
             return { nodeId: node.id, output };
           }
@@ -4077,7 +4135,8 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
               docsDir,
               ctx.nodeOutputs,
               config,
-              issueContext
+              issueContext,
+              stepNamePrefix
             );
             return { nodeId: node.id, output };
           }
@@ -4103,7 +4162,9 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
               configuredCommandFolder,
               issueContext,
               aiProfile,
-              workflowPreset
+              workflowPreset,
+              stepNamePrefix,
+              iteration
             );
             return { nodeId: node.id, output };
           }
@@ -4155,7 +4216,9 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
               docsDir,
               ctx.nodeOutputs,
               issueContext,
-              config.envVars
+              config.envVars,
+              stepNamePrefix,
+              iteration
             );
             return { nodeId: node.id, output };
           }
@@ -4293,7 +4356,9 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
               configuredCommandFolder,
               issueContext,
               resolvedNodeModel,
-              resolvedTier
+              resolvedTier,
+              stepNamePrefix,
+              iteration
             );
 
             if (output.state !== 'failed') break;


### PR DESCRIPTION
## Summary

- **Problem:** Inside a `loop_group` iteration body, node lifecycle events (`node_started` / `node_completed` / `node_failed`, plus tool/task/hook activity) were persisted with the **raw** body node id. Only `runLayers`' own control events (skip / trigger_rule / when) were namespaced. Documented in-code as a v1 limitation at `dag-executor.ts:2270-2273`.
- **Why it matters:** Every persisted-event consumer (`archon workflow get --verbose`, the console DB-tail SSE bridge) could not disambiguate iteration 3's `analyze` from iteration 1's, nor a body node from a same-named node elsewhere. Multi-iteration loop_group runs were ambiguous in observability streams.
- **What changed:** Threaded a `stepNamePrefix` (and, for the leaf executors, `iteration`) through the six node executors so every persisted body `step_name` reads `<groupId>.<nodeId>`, composing across nested loop_groups (`outer.inner.leaf`). Body node lifecycle rows also carry the current `iteration` in their `data`.
- **What did NOT change (scope boundary):** No in-process `WorkflowEventEmitter` payload changed — `nodeId` stays raw, exactly as it already does for control events, so the live console SSE bridge and CLI renderer are untouched. Top-level DAG events are byte-for-byte identical (empty prefix, no `iteration` key). Resume semantics, the approve-endpoint's raw-id writes, and per-iteration body resume are all left as-is.

## UX Journey

### Before

```
loop_group `fixer` (body: `work`), 2 iterations
  persisted workflow_events rows:
    step_name = "work"   (iteration 1 node_started/completed)
    step_name = "work"   (iteration 2 node_started/completed)   ← indistinguishable
  `archon workflow get --verbose` → one collapsed "work" row
```

### After

```
loop_group `fixer` (body: `work`), 2 iterations
  persisted workflow_events rows:
    step_name = "[fixer.work]"  data.[iteration=1]   (iteration 1)
    step_name = "[fixer.work]"  data.[iteration=2]   (iteration 2)   ← disambiguated
  live emitter payload: nodeId = "work"  (raw — unchanged)
  `archon workflow get --verbose` → body nodes grouped under `fixer.*`
```

## Architecture Diagram

### Before

```
runLayers (ctx.stepNamePrefix = "fixer.")
  ├─ control events (skip/trigger_rule/when) ── step_name = "fixer.work"   ✔ namespaced
  └─ dispatch ▶ executeNodeInternal/Bash/Script/Loop/Approval
                   └─ lifecycle events ──────── step_name = "work"          ✘ raw
```

### After

```
runLayers (ctx.stepNamePrefix, ctx.iteration)
  ├─ control events ─────────────────────────── step_name = "fixer.work"          (unchanged)
  └─ dispatch ▶ executeNodeInternal/Bash/Script/Loop/Approval  [~ +stepNamePrefix,+iteration]
                   └─ lifecycle events ───────── step_name = "fixer.work" + data.iteration  [~]
  executeLoopGroupNode  [~ +stepNamePrefix]
     bodyStepNamePrefix = `${stepName}.`  ===▶  iterCtx.stepNamePrefix (composes for nested groups)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `runLayers` | `executeNodeInternal` / `executeBashNode` / `executeScriptNode` / `executeLoopNode` / `executeApprovalNode` | **modified** | now passes `stepNamePrefix` (+ `iteration` for leaf/approval) |
| `runLayers` | `executeLoopGroupNode` | **modified** | passes `stepNamePrefix` for nested-group composition |
| `executeLoopGroupNode` | `runLayers` (body iterCtx) | **modified** | sets `stepNamePrefix = <group>.` and `iteration = i` |
| executors | `deps.store.createWorkflowEvent` | **modified** | persisted `step_name` now `stepNamePrefix + node.id` |
| executors | `WorkflowEventEmitter.emit` | unchanged | payloads stay raw |
| DB-tail SSE bridge / CLI `workflow get` | `workflow_events.step_name` | unchanged (behavior) | now reads namespaced body ids (the intended fix) |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `workflows`
- Module: `workflows:dag-executor`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes #2090

## Validation Evidence (required)

```bash
bun run validate    # → exit 0 (check:bundled, check:bundled-skill, check:bundled-schema,
                    #   check:pi-vendor-map, type-check, lint --max-warnings 0, format:check, test)
bun test packages/workflows/src/dag-executor.test.ts   # → 324 pass, 0 fail
```

- Evidence provided: full `bun run validate` passed (exit 0). New regression tests: 4 added to `dag-executor.test.ts`. Verified the two fix-proving tests **fail** on `origin/dev` source (body namespacing + nested composition) and pass with the fix; the emitter-raw and resume-safety tests pass both ways as safety guards.
- Skipped commands: none.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes` — top-level DAG events are unchanged; only loop_group body `step_name`s (a strict subset that previously carried raw ids) change, and consumers already tolerate arbitrary `step_name` values.
- Config/env changes? `No`
- Database migration needed? `No` — same `workflow_events` schema; only the value written to the existing `step_name` column changes for body rows.

## Human Verification (required)

- Verified scenarios: single-node loop_group body (2 iterations) → `node_started`/`node_completed` persisted as `fixer.work` with `data.iteration` 1 and 2; top-level bash node stays bare (`setup`, no `iteration`); nested loop_group composes to `outer.inner.leaf`; live emitter still emits raw `nodeId: 'work'`.
- Edge cases checked: resume with `priorCompletedNodes` containing both `fixer` and the namespaced `fixer.work` → group skipped as a unit, downstream top-level node still runs (namespaced key never mis-matches a top-level id); raw body id never appears as a persisted `step_name`.
- What was not verified: end-to-end console DB-tail rendering of an out-of-process `--detach` loop_group run (covered indirectly by the mapper's pass-through of `step_name`; consumer unit tests unaffected).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: workflow engine loop_group execution + persisted `workflow_events` for loop_group bodies; downstream observability readers of those rows.
- Potential unintended effects: an out-of-process loop_group run now shows `<group>.<node>` node ids in the console DB-tail view (this is the intended disambiguation, and is already how control events behave).
- Guardrails/monitoring: regression tests assert both the namespacing and that emitter payloads stay raw; `bun run validate` gates CI.

## Rollback Plan (required)

- Fast rollback: revert this commit (`git revert 63ebd6f3`); the change is isolated to `dag-executor.ts` + its test.
- Feature flags/toggles: none.
- Observable failure symptoms: body node ids missing their `<group>.` prefix in `workflow get --verbose`, or (regression) a top-level node wrongly skipped on resume — both covered by tests.

## Risks and Mitigations

- Risk: a consumer that pattern-matched the old raw body `step_name` could miss body rows.
  - Mitigation: consumers key off `step_name` generically (pass-through) and already receive namespaced ids for control events; the live emitter path (primary for the console/CLI) is unchanged.
- Risk: nested loop_group prefix composition regressions.
  - Mitigation: dedicated `outer.inner.leaf` composition test.
