### PR TITLE
fix(core): manage_run get crash on SQLite string timestamps

### DIFF
--- a/packages/core/src/orchestrator/manage-run-tool.test.ts
+++ b/packages/core/src/orchestrator/manage-run-tool.test.ts
@@ -162,6 +162,24 @@ describe('manage_run — reads', () => {
     expect(out).toContain('status: completed');
     expect(out).toContain('finished:');
   });
+
+  test('get does not crash on SQLite rows where timestamps are strings (#2078)', async () => {
+    // SQLite hydrates started_at/completed_at as 'YYYY-MM-DD HH:MM:SS' TEXT
+    // even though the schema type says Date. formatRunDetail must not call
+    // Date methods unguarded — this used to throw and fail interactive resume.
+    mockFindByPrefix.mockResolvedValue([
+      makeRun({
+        status: 'completed',
+        started_at: '2026-07-10 18:26:36' as unknown as Date,
+        completed_at: '2026-07-10 18:30:00' as unknown as Date,
+      }),
+    ]);
+    const tool = buildManageRunTool({ codebaseId: CODEBASE_ID });
+    const out = await tool.handler({ action: 'get', runId: 'r1abcdef' });
+    expect(out).not.toContain('manage_run error');
+    expect(out).toContain('started: 2026-07-10 18:26:36');
+    expect(out).toContain('finished: 2026-07-10 18:30:00');
+  });
 });
 
 describe('manage_run — start', () => {

--- a/packages/core/src/orchestrator/manage-run-tool.ts
+++ b/packages/core/src/orchestrator/manage-run-tool.ts
@@ -213,13 +213,25 @@ async function handleList(ctx: ManageRunContext): Promise<string> {
   return `${runs.length.toString()} run(s) (most recent first):\n${lines.join('\n')}`;
 }
 
+/**
+ * Runtime-safe timestamp formatter. The run schema declares these fields as
+ * Date, but rows are cast, never Zod-parsed: Postgres hydrates TIMESTAMPTZ
+ * into Date objects while SQLite returns TEXT ('YYYY-MM-DD HH:MM:SS', UTC)
+ * as-is (#2078). Mirrors the API serializer pattern (routes/api.ts
+ * toISOString): pass strings through verbatim — re-parsing with new Date()
+ * would misread the UTC wall-clock string as local time — and format Dates.
+ */
+function formatTimestamp(val: Date | string): string {
+  return typeof val === 'string' ? val : val.toISOString();
+}
+
 function formatRunDetail(run: WorkflowRun): string {
   const parts = [
     `Run ${run.id.slice(0, 8)} · ${run.workflow_name}`,
     `status: ${run.status}`,
-    `started: ${run.started_at.toISOString()}`,
+    `started: ${formatTimestamp(run.started_at)}`,
   ];
-  if (run.completed_at !== null) parts.push(`finished: ${run.completed_at.toISOString()}`);
+  if (run.completed_at !== null) parts.push(`finished: ${formatTimestamp(run.completed_at)}`);
   const error = run.metadata.error;
   if (typeof error === 'string' && error.length > 0) parts.push(`error: ${error.slice(0, 300)}`);
   log.info({ runId: run.id, status: run.status }, 'manage_run.get_completed');


### PR DESCRIPTION
## Summary

- Problem: `manage_run` `action=get` calls `.toISOString()` on `run.started_at`/`run.completed_at`, but the SQLite adapter hydrates these as `'YYYY-MM-DD HH:MM:SS'` TEXT (Postgres returns `Date`). Every `get` on a SQLite install throws `TypeError: run.started_at.toISOString is not a function`.
- Why it matters: the interactive-resume path invokes `manage_run get` after a user approves a paused gate — the crash marks the run `failed` despite the user's input being persisted. Deterministic on the default (SQLite) backend.
- What changed: added a `formatTimestamp(Date | string)` helper in `formatRunDetail` mirroring the established API serializer pattern (`routes/api.ts` `toISOString`): strings pass through verbatim, `Date`s format to ISO. Both call sites (`started_at`, `completed_at`) now use it. Regression test added with string-typed timestamps.
- What did **not** change (scope boundary): no row-mapping normalization in `normalizeWorkflowRun` (would change the wire format of every runs API endpoint on SQLite and require careful UTC parsing — see fix-layer rationale below), no changes to `cli/commands/workflow.ts`, `command-handler.ts`, or the run schemas. Strings are passed through, not re-parsed: `new Date('2026-07-10 18:26:36')` would misread the UTC wall-clock string as local time.

## UX Journey

### Before

```
  User                      Archon (web)                 manage_run tool
  ────                      ────────────                 ───────────────
  approves paused gate ──▶  resumes interactive run
                            orchestrator inspects run ─▶ action=get
                                                         formatRunDetail
                                                         *TypeError: toISOString*
  sees run FAILED ◀───────  run marked failed
```

### After

```
  User                      Archon (web)                 manage_run tool
  ────                      ────────────                 ───────────────
  approves paused gate ──▶  resumes interactive run
                            orchestrator inspects run ─▶ action=get
                                                         [formatTimestamp coerces
                                                          Date | string safely]
  run continues ◀─────────  detail returned, resume proceeds
```

## Architecture Diagram

### Before

```
db/workflows.ts (findWorkflowRunsByIdPrefix)
      │  rows: Date (Postgres) / TEXT string (SQLite)
      ▼
manage-run-tool.ts formatRunDetail ──▶ run.started_at.toISOString()  ✗ crashes on SQLite
```

### After

```
db/workflows.ts (findWorkflowRunsByIdPrefix)          (unchanged)
      │  rows: Date (Postgres) / TEXT string (SQLite)
      ▼
manage-run-tool.ts formatRunDetail ══▶ [~] formatTimestamp(Date | string)
                                        string → verbatim, Date → ISO
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `manage-run-tool.ts` | `db/workflows.ts` | unchanged | same queries, same row shapes |
| `manage-run-tool.ts formatRunDetail` | `formatTimestamp` (local) | **new** | internal helper, no new module edges |
| `orchestrator-agent.ts` | `manage-run-tool.ts` | unchanged | tool injection untouched |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `core`
- Module: `core:orchestrator`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #2078

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # all green: check:bundled*, check:pi-vendor-map, type-check, lint, format:check, test
bun test packages/core/src/orchestrator/manage-run-tool.test.ts   # 25 pass, 0 fail
```

- Evidence provided (test/log/trace/screenshot): new regression test `get does not crash on SQLite rows where timestamps are strings (#2078)` exercises the exact failing row shape from the issue (`'2026-07-10 18:26:36'`); the pre-existing `Date`-typed test keeps the Postgres path covered.
- If any command is intentionally skipped, explain why: none skipped.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: n/a

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No
- If yes, exact upgrade steps: n/a

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: unit-level reproduction of the exact SQLite row shape from the issue report (string `started_at` + string `completed_at`) — crashes before the fix (`manage_run error: run.started_at.toISOString is not a function` via the tool's catch), renders run detail after.
- Edge cases checked: `completed_at: null` (running run, existing tests), `Date`-typed timestamps (Postgres path, existing test at the `short prefix` case), error text truncation unaffected.
- What was not verified: full end-to-end interactive-workflow resume against a live SQLite install (the failing call path `handler get → formatRunDetail` is fully covered by the unit tests; the resume plumbing itself is untouched).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `manage_run` native tool output only (project-scoped chat on Claude/Pi); nothing else reads `formatRunDetail`.
- Potential unintended effects: SQLite installs now display the raw stored UTC wall-clock string (`2026-07-10 18:26:36`) instead of crashing; Postgres output is byte-identical to before.
- Guardrails/monitoring for early detection: the tool's existing catch-all logs `manage_run.failed` with the error; the new test pins both backends' row shapes.

## Rollback Plan (required)

- Fast rollback command/path: `git revert dea01547` — single isolated commit.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: `manage_run error: ... toISOString is not a function` in chat output and `manage_run.failed` log events on `action=get`.

## Risks and Mitigations

- Risk: displayed timestamp format differs between backends (verbatim UTC string on SQLite vs ISO on Postgres).
  - Mitigation: consistent with the console API serializer (`routes/api.ts toISOString`), which already passes SQLite strings through on the wire; both are unambiguous UTC. Normalizing formats across backends belongs to a row-mapping-seam change with a much wider blast radius, deliberately out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed run details displaying errors when start or completion timestamps are returned as strings.
  * Preserved SQLite timestamp values accurately in formatted run output, including the `started` and `finished` fields.

* **Tests**
  * Added coverage to verify completed runs with string timestamps display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->