### PR TITLE
fix(core): /update-project distinguishes row-gone from transient DB errors

### DIFF
--- a/packages/core/src/db/codebases.test.ts
+++ b/packages/core/src/db/codebases.test.ts
@@ -510,27 +510,21 @@ describe('codebases', () => {
     test('throws CodebaseNotFoundError when codebase not found', async () => {
       mockQuery.mockResolvedValueOnce(createQueryResult([], 0));
 
-      const error = await updateCodebase('nonexistent', { default_cwd: '/path' }).then(
-        () => null,
-        (err: unknown) => err
-      );
+      const error = await updateCodebase('nonexistent', { default_cwd: '/path' }).catch(e => e);
 
       expect(error).toBeInstanceOf(CodebaseNotFoundError);
-      expect((error as CodebaseNotFoundError).message).toBe('Codebase nonexistent not found');
-      expect((error as CodebaseNotFoundError).codebaseId).toBe('nonexistent');
+      expect(error.message).toBe('Codebase nonexistent not found');
+      expect(error.codebaseId).toBe('nonexistent');
     });
 
     test('does not wrap operational DB errors in CodebaseNotFoundError', async () => {
       mockQuery.mockRejectedValueOnce(new Error('connection refused'));
 
-      const error = await updateCodebase('codebase-123', { default_cwd: '/path' }).then(
-        () => null,
-        (err: unknown) => err
-      );
+      const error = await updateCodebase('codebase-123', { default_cwd: '/path' }).catch(e => e);
 
       expect(error).toBeInstanceOf(Error);
       expect(error).not.toBeInstanceOf(CodebaseNotFoundError);
-      expect((error as Error).message).toBe('connection refused');
+      expect(error.message).toBe('connection refused');
     });
 
     test('no-ops when no fields provided', async () => {

--- a/packages/core/src/db/codebases.test.ts
+++ b/packages/core/src/db/codebases.test.ts
@@ -25,6 +25,7 @@ import {
   findCodebaseByName,
   updateCodebase,
   deleteCodebase,
+  CodebaseNotFoundError,
 } from './codebases';
 
 describe('codebases', () => {
@@ -506,12 +507,30 @@ describe('codebases', () => {
       );
     });
 
-    test('throws when codebase not found', async () => {
+    test('throws CodebaseNotFoundError when codebase not found', async () => {
       mockQuery.mockResolvedValueOnce(createQueryResult([], 0));
 
-      await expect(updateCodebase('nonexistent', { default_cwd: '/path' })).rejects.toThrow(
-        'Codebase nonexistent not found'
+      const error = await updateCodebase('nonexistent', { default_cwd: '/path' }).then(
+        () => null,
+        (err: unknown) => err
       );
+
+      expect(error).toBeInstanceOf(CodebaseNotFoundError);
+      expect((error as CodebaseNotFoundError).message).toBe('Codebase nonexistent not found');
+      expect((error as CodebaseNotFoundError).codebaseId).toBe('nonexistent');
+    });
+
+    test('does not wrap operational DB errors in CodebaseNotFoundError', async () => {
+      mockQuery.mockRejectedValueOnce(new Error('connection refused'));
+
+      const error = await updateCodebase('codebase-123', { default_cwd: '/path' }).then(
+        () => null,
+        (err: unknown) => err
+      );
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error).not.toBeInstanceOf(CodebaseNotFoundError);
+      expect((error as Error).message).toBe('connection refused');
     });
 
     test('no-ops when no fields provided', async () => {

--- a/packages/core/src/db/codebases.ts
+++ b/packages/core/src/db/codebases.ts
@@ -146,6 +146,18 @@ export async function findCodebaseByName(name: string): Promise<Codebase | null>
   return result.rows[0] || null;
 }
 
+/**
+ * Error thrown when an UPDATE matched no codebase row (row deleted between
+ * fetch and update). Lets callers distinguish "row gone" from operational
+ * DB failures (connection refused, timeout, constraint violation).
+ */
+export class CodebaseNotFoundError extends Error {
+  constructor(public codebaseId: string) {
+    super(`Codebase ${codebaseId} not found`);
+    this.name = 'CodebaseNotFoundError';
+  }
+}
+
 export async function updateCodebase(
   id: string,
   data: { default_cwd?: string; repository_url?: string | null; default_branch?: string | null }
@@ -180,7 +192,7 @@ export async function updateCodebase(
     values
   );
   if ((result.rowCount ?? 0) === 0) {
-    throw new Error(`Codebase ${id} not found`);
+    throw new CodebaseNotFoundError(id);
   }
 }
 

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -78,10 +78,19 @@ mock.module('../db/conversations', () => ({
 
 const mockListCodebases = mock(() => Promise.resolve([] as unknown[]));
 const mockCreateCodebase = mock(() => Promise.resolve({ id: 'new-codebase-id' }));
+const mockUpdateCodebase = mock(() => Promise.resolve());
+class MockCodebaseNotFoundError extends Error {
+  constructor(public codebaseId: string) {
+    super(`Codebase ${codebaseId} not found`);
+    this.name = 'CodebaseNotFoundError';
+  }
+}
 mock.module('../db/codebases', () => ({
   getCodebase: mockGetCodebase,
   listCodebases: mockListCodebases,
   createCodebase: mockCreateCodebase,
+  updateCodebase: mockUpdateCodebase,
+  CodebaseNotFoundError: MockCodebaseNotFoundError,
 }));
 
 const mockGetActiveSession = mock(() => Promise.resolve(null));
@@ -3263,6 +3272,59 @@ describe('handleMessage — /setproject dispatch', () => {
 
     expect(mockUpdateConversation).not.toHaveBeenCalled();
     expect(platform.sendMessage).toHaveBeenCalledWith('conv-1', expect.stringContaining('Usage'));
+  });
+});
+
+// ─── handleMessage — /update-project dispatch (issue #2085) ───────────────────
+
+describe('handleMessage — /update-project dispatch', () => {
+  beforeEach(() => {
+    mockGetOrCreateConversation.mockReset();
+    mockListCodebases.mockReset();
+    mockUpdateCodebase.mockReset();
+    mockParseCommand.mockReset();
+
+    mockGetOrCreateConversation.mockImplementation(() => Promise.resolve(makeConversation()));
+    mockListCodebases.mockImplementation(() => Promise.resolve([makeCodebase('my-app')]));
+    mockUpdateCodebase.mockImplementation(() => Promise.resolve());
+    // '/' always exists — the handler's un-mocked existsSync check passes.
+    mockParseCommand.mockReturnValue({ command: 'update-project', args: ['my-app', '/'] });
+  });
+
+  test('reports success with old and new path', async () => {
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/update-project my-app /');
+
+    expect(mockUpdateCodebase).toHaveBeenCalledWith('id-my-app', { default_cwd: '/' });
+    const msg = (platform.sendMessage as ReturnType<typeof mock>).mock.calls[0]?.[1] as string;
+    expect(msg).toContain('updated');
+    expect(msg).toContain('/repos/my-app');
+  });
+
+  test('row-gone failure (CodebaseNotFoundError) reports removal, not a DB error', async () => {
+    mockUpdateCodebase.mockImplementation(() =>
+      Promise.reject(new MockCodebaseNotFoundError('id-my-app'))
+    );
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/update-project my-app /');
+
+    const msg = (platform.sendMessage as ReturnType<typeof mock>).mock.calls[0]?.[1] as string;
+    expect(msg).toContain('removed');
+    expect(msg).toContain('/register-project');
+    expect(msg).not.toContain('database error');
+  });
+
+  test('transient DB failure reports a database error, not removal', async () => {
+    mockUpdateCodebase.mockImplementation(() => Promise.reject(new Error('connection refused')));
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/update-project my-app /');
+
+    const msg = (platform.sendMessage as ReturnType<typeof mock>).mock.calls[0]?.[1] as string;
+    expect(msg).toContain('database error');
+    expect(msg).toContain('try again');
+    expect(msg).not.toContain('removed');
   });
 });
 

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -2451,7 +2451,13 @@ async function handleUpdateProject(message: string): Promise<string> {
     await codebaseDb.updateCodebase(codebase.id, { default_cwd: newPath });
   } catch (err) {
     getLog().warn({ err: err as Error, codebaseId: codebase.id, newPath }, 'project.update_failed');
-    return `Project "${projectName}" could not be updated — it may have been removed.`;
+    // Row gone (deleted between the fetch above and the UPDATE) is the only
+    // case where "removed" is the honest answer; anything else is an
+    // operational DB failure and should say so instead of blaming data state.
+    if (err instanceof codebaseDb.CodebaseNotFoundError) {
+      return `Project "${projectName}" could not be updated — it appears to have been removed. Use /register-project to re-create it.`;
+    }
+    return `Project "${projectName}" could not be updated — database error. Please try again.`;
   }
   getLog().info(
     { name: projectName, oldPath: codebase.default_cwd, newPath, id: codebase.id },


### PR DESCRIPTION
## Summary

- Problem: `handleUpdateProject` caught every `updateCodebase` failure and replied "it may have been removed" — a transient DB error (connection refused, timeout) was mislabeled as a data-state problem, steering users to `/register-project` instead of a retry.
- Why it matters: the recovery advice is actively wrong for the common failure mode; the row was fetched a few lines above, so "removed" is almost never the real cause. Violates the spirit of Fail Fast + Explicit Errors (error not swallowed, but mislabeled).
- What changed: `updateCodebase` now throws a typed `CodebaseNotFoundError` (mirrors `SessionNotFoundError`) when the UPDATE matches no row; `handleUpdateProject` branches on `instanceof` — row-gone keeps the "removed" reply (now with a `/register-project` hint), everything else gets an honest "database error. Please try again."
- What did **not** change (scope boundary): the `project.update_failed` warn log (kept, both paths), the error message text (`Codebase <id> not found`), other `updateCodebase` callers (clone handler, forge adapters — a narrower error class is strictly more information), `manage-run-tool.ts`, `cli/commands/workflow.ts`, workflows loader/validator (parallel PRs in flight).

## UX Journey

### Before

```
  User                          Archon
  ────                          ──────
  /update-project my-app /p ──▶ finds codebase row
                                UPDATE fails (ANY reason)
  "may have been removed" ◀───  same reply for row-gone AND
                                connection refused/timeout
  re-registers project (wrong recovery for a transient blip)
```

### After

```
  User                          Archon
  ────                          ──────
  /update-project my-app /p ──▶ finds codebase row
                                UPDATE fails
                                [branch on CodebaseNotFoundError]
  row gone:
  "appears to have been removed.
   Use /register-project…" ◀──  honest data-state reply
  transient:
  *"database error.
   Please try again."* ◀──────  honest operational reply
```

## Architecture Diagram

### Before

```
orchestrator-agent.ts                    db/codebases.ts
  handleUpdateProject ──────────────────▶ updateCodebase
    catch (err): one message               rowCount 0 → generic Error
    for every failure                      driver error → propagates
```

### After

```
orchestrator-agent.ts                    db/codebases.ts
  handleUpdateProject ──────────────────▶ updateCodebase
    catch (err):                           rowCount 0 → [+] CodebaseNotFoundError
    [~] instanceof CodebaseNotFoundError   driver error → propagates (unchanged)
        → "removed" reply
        else → "database error" reply
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `core:orchestrator` (`handleUpdateProject`) | `core:db` (`updateCodebase`) | **modified** | now discriminates the typed not-found error |
| `core:handlers` (clone), `adapters:forge/*` | `core:db` (`updateCodebase`) | unchanged | error class narrowed, message text identical |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`
- Module: `core:orchestrator`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #2085

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # all eight checks pass (bundled/skill/schema/pi-vendor-map, type-check, lint, format, tests)
bun test packages/core/src/db/codebases.test.ts               # 39 pass
bun test packages/core/src/orchestrator/orchestrator-agent.test.ts  # 199 pass
```

- Evidence provided (test/log/trace/screenshot): new tests cover the typed not-found throw, non-wrapping of operational errors, and all three `/update-project` replies (success / row-gone / transient)
- If any command is intentionally skipped, explain why: none skipped

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes (error message text unchanged; only the class narrows)
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: unit tests exercise the full `/update-project` dispatch path through `handleMessage` for success, row-gone, and transient-error cases
- Edge cases checked: operational driver errors are not wrapped into `CodebaseNotFoundError`; no caller anywhere matches on the old error message string (grepped)
- What was not verified: live end-to-end run against a real DB outage (behavior is fully covered by the unit tests)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `/update-project` chat command reply text; `updateCodebase` error type
- Potential unintended effects: callers doing `err.message` matching would be unaffected (text identical); `instanceof Error` remains true
- Guardrails/monitoring for early detection: existing `project.update_failed` warn log retained with the raw error

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge-commit>` — single isolated commit, no schema or config changes
- Feature flags or config toggles (if any): none
- Observable failure symptoms: wrong reply text on `/update-project` failure

## Risks and Mitigations

- Risk: a hypothetical caller depending on the not-found error being a plain `Error` subclass check
  - Mitigation: `CodebaseNotFoundError extends Error` with identical message text; all callers grepped — none discriminate today

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `/update-project` error handling when a project/codebase has been removed.
  * Added a more specific user response prompting re-registration for deleted projects.
  * Prevented transient database/update failures from being incorrectly treated as “not found” cases.
  * Improved reliability and correctness when updating a project’s default working directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->