### PR TITLE
fix(cli): accept short run-id prefixes in workflow run-addressing commands

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -584,7 +584,8 @@ async function main(): Promise<number> {
             return await workflowGetCommand(
               getRunId,
               jsonFlag,
-              values.verbose as boolean | undefined
+              values.verbose as boolean | undefined,
+              effectiveCwd
             );
           }
 
@@ -613,7 +614,7 @@ async function main(): Promise<number> {
               console.error('Usage: archon workflow resume <run-id>');
               return 1;
             }
-            await workflowResumeCommand(resumeRunId, jsonFlag);
+            await workflowResumeCommand(resumeRunId, jsonFlag, effectiveCwd);
             break;
           }
 
@@ -623,7 +624,7 @@ async function main(): Promise<number> {
               console.error('Usage: archon workflow abandon <run-id>');
               return 1;
             }
-            await workflowAbandonCommand(abandonRunId, jsonFlag);
+            await workflowAbandonCommand(abandonRunId, jsonFlag, effectiveCwd);
             break;
           }
 
@@ -636,7 +637,7 @@ async function main(): Promise<number> {
             // Accept comment as positional args (everything after run ID) or --comment flag
             const approveComment =
               (values.comment as string | undefined) || positionals.slice(3).join(' ') || undefined;
-            await workflowApproveCommand(approveRunId, approveComment, jsonFlag);
+            await workflowApproveCommand(approveRunId, approveComment, jsonFlag, effectiveCwd);
             break;
           }
 
@@ -648,7 +649,7 @@ async function main(): Promise<number> {
             }
             const rejectReason =
               (values.reason as string | undefined) || positionals.slice(3).join(' ') || undefined;
-            await workflowRejectCommand(rejectRunId, rejectReason, jsonFlag);
+            await workflowRejectCommand(rejectRunId, rejectReason, jsonFlag, effectiveCwd);
             break;
           }
 

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -2556,6 +2556,68 @@ describe('run-id prefix resolution (short ids from `workflow runs`)', () => {
     expect(parsed.runId).toBe(FULL_ID);
   });
 
+  it('approves by short prefix and reports the resolved full id', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(
+      CODEBASE
+    );
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([
+      { id: FULL_ID },
+    ]);
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: FULL_ID,
+      workflow_name: 'implement',
+      status: 'paused',
+      working_path: '/tmp/wt',
+      codebase_id: 'cb',
+      conversation_id: 'conv',
+      user_message: 'go',
+      metadata: { approval: { nodeId: 'gate', message: 'ok?' } },
+    });
+
+    await workflowApproveCommand('0b1ee8da', 'lgtm', true, '/repo');
+
+    expect(workflowDb.getWorkflowRun).toHaveBeenCalledWith(FULL_ID);
+    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    expect(parsed).toMatchObject({ ok: true, runId: FULL_ID, action: 'approve' });
+  });
+
+  it('rejects by short prefix and reports the resolved full id', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(
+      CODEBASE
+    );
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([
+      { id: FULL_ID },
+    ]);
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: FULL_ID,
+      workflow_name: 'implement',
+      status: 'paused',
+      working_path: '/tmp/wt',
+      codebase_id: 'cb',
+      conversation_id: 'conv',
+      user_message: 'go',
+      metadata: { approval: { nodeId: 'gate', message: 'ok?' } },
+    });
+    (workflowDb.cancelWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      cancelled: true,
+    });
+
+    await workflowRejectCommand('0b1ee8da', 'nope', true, '/repo');
+
+    expect(workflowDb.getWorkflowRun).toHaveBeenCalledWith(FULL_ID);
+    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    expect(parsed).toMatchObject({
+      ok: true,
+      runId: FULL_ID,
+      action: 'reject',
+      cancelled: true,
+    });
+  });
+
   it('skips resolution when no cwd is provided (exact lookup only)', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
     const codebaseDb = await import('@archon/core/db/codebases');

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -165,6 +165,7 @@ mock.module('@archon/core/db/workflows', () => ({
   findResumableRun: mock(() => Promise.resolve(null)),
   resumeWorkflowRun: mock(() => Promise.resolve(null)),
   getWorkflowRun: mock(() => Promise.resolve(null)),
+  findWorkflowRunsByIdPrefix: mock(() => Promise.resolve([])),
   updateWorkflowRun: mock(() => Promise.resolve()),
   listWorkflowRuns: mock(() => Promise.resolve([])),
   listDashboardRuns: mock(() =>
@@ -2372,6 +2373,199 @@ describe('workflowGetCommand', () => {
     const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as { events: unknown[] };
     expect(Array.isArray(parsed.events)).toBe(true);
     expect(parsed.events).toHaveLength(1);
+  });
+});
+
+describe('run-id prefix resolution (short ids from `workflow runs`)', () => {
+  const FULL_ID = '0b1ee8da-1111-2222-3333-444455556666';
+  const CODEBASE = { id: 'cb-1', name: 'proj', default_cwd: '/repo' };
+  let consoleSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(async () => {
+    consoleSpy = spyOn(console, 'log').mockImplementation(() => {});
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockClear();
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockClear();
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockClear();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('resolves a unique short prefix to the full run id (get)', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(
+      CODEBASE
+    );
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([
+      { id: FULL_ID },
+    ]);
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: FULL_ID,
+      workflow_name: 'implement',
+      status: 'completed',
+      working_path: '/tmp/wt',
+      started_at: new Date(),
+      metadata: {},
+    });
+
+    const code = await workflowGetCommand('0b1ee8da', true, undefined, '/repo');
+
+    expect(workflowDb.findWorkflowRunsByIdPrefix).toHaveBeenCalledWith('0b1ee8da', 'cb-1');
+    expect(workflowDb.getWorkflowRun).toHaveBeenCalledWith(FULL_ID);
+    expect(code).toBe(0);
+  });
+
+  it('skips codebase and prefix lookups entirely for a full UUID', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: FULL_ID,
+      workflow_name: 'implement',
+      status: 'completed',
+      working_path: '/tmp/wt',
+      started_at: new Date(),
+      metadata: {},
+    });
+
+    const code = await workflowGetCommand(FULL_ID, true, undefined, '/repo');
+
+    expect(codebaseDb.findCodebaseByDefaultCwd).not.toHaveBeenCalled();
+    expect(workflowDb.findWorkflowRunsByIdPrefix).not.toHaveBeenCalled();
+    expect(workflowDb.getWorkflowRun).toHaveBeenCalledWith(FULL_ID);
+    expect(code).toBe(0);
+  });
+
+  it('skips lookups for a 32-char undashed full id (SQLite id shape)', async () => {
+    const undashedId = 'e1f890f05e5bab0d906921593bf500c4';
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: undashedId,
+      workflow_name: 'implement',
+      status: 'completed',
+      working_path: '/tmp/wt',
+      started_at: new Date(),
+      metadata: {},
+    });
+
+    const code = await workflowGetCommand(undashedId, true, undefined, '/repo');
+
+    expect(codebaseDb.findCodebaseByDefaultCwd).not.toHaveBeenCalled();
+    expect(workflowDb.findWorkflowRunsByIdPrefix).not.toHaveBeenCalled();
+    expect(workflowDb.getWorkflowRun).toHaveBeenCalledWith(undashedId);
+    expect(code).toBe(0);
+  });
+
+  it('throws on an ambiguous prefix (human mode)', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(
+      CODEBASE
+    );
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([
+      { id: '0b1ee8da-1111-2222-3333-444455556666' },
+      { id: '0b1ee8da-9999-8888-7777-666655554444' },
+    ]);
+
+    await expect(workflowResumeCommand('0b1ee8da', undefined, '/repo')).rejects.toThrow(
+      'matches more than one run'
+    );
+  });
+
+  it('emits {ok:false} JSON on an ambiguous prefix (never throws in --json)', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(
+      CODEBASE
+    );
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([
+      { id: '0b1ee8da-1111-2222-3333-444455556666' },
+      { id: '0b1ee8da-9999-8888-7777-666655554444' },
+    ]);
+
+    await workflowAbandonCommand('0b1ee8da', true, '/repo');
+
+    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as {
+      ok: boolean;
+      runId: string;
+      action: string;
+      error: string;
+    };
+    expect(parsed.ok).toBe(false);
+    expect(parsed.runId).toBe('0b1ee8da');
+    expect(parsed.action).toBe('abandon');
+    expect(parsed.error).toContain('matches more than one run');
+  });
+
+  it('passes the id through unchanged when cwd is not a registered project', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+
+    const code = await workflowGetCommand('deadbeef', true, undefined, '/somewhere');
+
+    expect(workflowDb.findWorkflowRunsByIdPrefix).not.toHaveBeenCalled();
+    expect(workflowDb.getWorkflowRun).toHaveBeenCalledWith('deadbeef');
+    expect(code).toBe(1);
+  });
+
+  it('passes the id through when the prefix matches nothing in this project', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(
+      CODEBASE
+    );
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([]);
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+
+    const code = await workflowGetCommand('deadbeef', true, undefined, '/repo');
+
+    expect(workflowDb.getWorkflowRun).toHaveBeenCalledWith('deadbeef');
+    expect(code).toBe(1);
+  });
+
+  it('abandons by short prefix and reports the resolved full id', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(
+      CODEBASE
+    );
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([
+      { id: FULL_ID },
+    ]);
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: FULL_ID,
+      workflow_name: 'implement',
+      status: 'running',
+    });
+    (workflowDb.cancelWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce(undefined);
+
+    await workflowAbandonCommand('0b1ee8da', true, '/repo');
+
+    expect(workflowDb.cancelWorkflowRun).toHaveBeenCalledWith(FULL_ID);
+    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as {
+      ok: boolean;
+      runId: string;
+    };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.runId).toBe(FULL_ID);
+  });
+
+  it('skips resolution when no cwd is provided (exact lookup only)', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+
+    const code = await workflowGetCommand('deadbeef', true);
+
+    expect(codebaseDb.findCodebaseByDefaultCwd).not.toHaveBeenCalled();
+    expect(workflowDb.findWorkflowRunsByIdPrefix).not.toHaveBeenCalled();
+    expect(code).toBe(1);
   });
 });
 

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1607,7 +1607,8 @@ export async function workflowGetCommand(
 ): Promise<number> {
   let run: WorkflowRun | null;
   try {
-    run = await workflowDb.getWorkflowRun(await resolveRunIdArg(runId, cwd));
+    const resolvedId = await resolveRunIdArg(runId, cwd);
+    run = await workflowDb.getWorkflowRun(resolvedId);
   } catch (error) {
     const err = error as Error;
     getLog().error({ err, runId }, 'cli.workflow_get_failed');

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1596,15 +1596,18 @@ export async function workflowStatusCommand(json?: boolean, verbose?: boolean): 
  * status — so an agent can answer "did the review pass?" for a completed/failed
  * run. `--verbose` adds the per-node event summary; `--json` emits the raw run
  * (plus an `events` array when verbose).
+ *
+ * `runId` may be the short id printed by `workflow runs` (see resolveRunIdArg).
  */
 export async function workflowGetCommand(
   runId: string,
   json?: boolean,
-  verbose?: boolean
+  verbose?: boolean,
+  cwd?: string
 ): Promise<number> {
   let run: WorkflowRun | null;
   try {
-    run = await workflowDb.getWorkflowRun(runId);
+    run = await workflowDb.getWorkflowRun(await resolveRunIdArg(runId, cwd));
   } catch (error) {
     const err = error as Error;
     getLog().error({ err, runId }, 'cli.workflow_get_failed');
@@ -1766,6 +1769,40 @@ function printJsonWriteError(runId: string, action: string, error: unknown): voi
   );
 }
 
+/**
+ * Matches a full run id: a dashed UUID (Postgres `gen_random_uuid()`) or 32
+ * undashed hex chars (SQLite `hex(randomblob(16))`). Anything shorter is
+ * treated as a prefix.
+ */
+const FULL_RUN_ID_RE =
+  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9a-f]{32})$/i;
+
+/**
+ * Resolve a run-id argument that may be the 8-char short id printed by
+ * `workflow runs` into the full run id. Mirrors the chat `manage_run` tool's
+ * prefix resolution (getScopedRun): the lookup is scoped to the cwd's
+ * codebase, a unique match resolves, and an ambiguous prefix errors.
+ *
+ * Full UUIDs skip resolution entirely — exact lookup is global, so full ids
+ * keep working from any directory. When `cwd` is omitted, the cwd is not a
+ * registered project, or the prefix matches nothing in this project, the
+ * argument passes through unchanged so the downstream exact lookup keeps its
+ * existing error surface (intentional fallback: it preserves behavior for
+ * runs of other projects and non-UUID ids rather than guessing).
+ */
+async function resolveRunIdArg(runId: string, cwd?: string): Promise<string> {
+  if (cwd === undefined || FULL_RUN_ID_RE.test(runId)) return runId;
+  const codebase = await codebaseDb.findCodebaseByDefaultCwd(cwd);
+  if (!codebase) return runId;
+  const matches = await workflowDb.findWorkflowRunsByIdPrefix(runId, codebase.id);
+  if (matches.length > 1) {
+    throw new Error(
+      `Run id '${runId}' matches more than one run in this project — use more characters or the full id (from 'archon workflow runs --json').`
+    );
+  }
+  return matches[0]?.id ?? runId;
+}
+
 async function resolveDiscoveryCwdForCodebase(
   runId: string,
   codebaseId: string,
@@ -1804,8 +1841,14 @@ async function resolveDiscoveryCwdForCodebase(
  * Re-executes the workflow with --resume semantics: `workflowRunCommand` locates
  * the prior failed run via findResumableRun and hands it to the executor, which
  * skips already-completed nodes (the executor no longer auto-detects on its own).
+ *
+ * `runId` may be the short id printed by `workflow runs` (see resolveRunIdArg).
  */
-export async function workflowResumeCommand(runId: string, json?: boolean): Promise<void> {
+export async function workflowResumeCommand(
+  runId: string,
+  json?: boolean,
+  cwd?: string
+): Promise<void> {
   // JSON mode is a non-blocking control-plane ack: validate the run is resumable
   // and report its state, but do NOT re-execute the workflow inline (execution
   // streams workflow output to stdout, which would corrupt the JSON contract).
@@ -1813,12 +1856,13 @@ export async function workflowResumeCommand(runId: string, json?: boolean): Prom
   // run as a background task) or `run <name> --resume --detach`.
   if (json) {
     try {
-      const run = await resumeWorkflowOp(runId);
+      const resolvedId = await resolveRunIdArg(runId, cwd);
+      const run = await resumeWorkflowOp(resolvedId);
       console.log(
         JSON.stringify(
           {
             ok: true,
-            runId,
+            runId: resolvedId,
             action: 'resume',
             executed: false,
             status: run.status,
@@ -1835,10 +1879,11 @@ export async function workflowResumeCommand(runId: string, json?: boolean): Prom
     return;
   }
 
-  const run = await resumeWorkflowOp(runId);
+  const resolvedId = await resolveRunIdArg(runId, cwd);
+  const run = await resumeWorkflowOp(resolvedId);
   if (!run.working_path) {
     throw new Error(
-      `Workflow run '${runId}' has no working path recorded.\n` +
+      `Workflow run '${resolvedId}' has no working path recorded.\n` +
         'Cannot determine where to resume. The run may be too old.'
     );
   }
@@ -1850,7 +1895,7 @@ export async function workflowResumeCommand(runId: string, json?: boolean): Prom
   // found even when working_path is a worktree or workspace clone that does
   // not contain the user's local (often untracked) workflow YAML.
   const discoveryCwd = run.codebase_id
-    ? await resolveDiscoveryCwdForCodebase(runId, run.codebase_id, 'resume')
+    ? await resolveDiscoveryCwdForCodebase(resolvedId, run.codebase_id, 'resume')
     : undefined;
 
   // Re-execute via workflowRunCommand with --resume: it locates the prior failed
@@ -1865,7 +1910,7 @@ export async function workflowResumeCommand(runId: string, json?: boolean): Prom
   } catch (error) {
     const err = error as Error;
     getLog().error(
-      { err, runId, workflowName: run.workflow_name },
+      { err, runId: resolvedId, workflowName: run.workflow_name },
       'cli.workflow_resume_run_failed'
     );
     throw new Error(`Failed to resume workflow '${run.workflow_name}': ${err.message}`);
@@ -1878,16 +1923,23 @@ export async function workflowResumeCommand(runId: string, json?: boolean): Prom
  * `--json` emits a structured result instead of human text. In JSON mode the
  * command never throws — lookup/state errors are reported as `{ ok: false }` so
  * a parsing agent always gets one clean JSON line.
+ *
+ * `runId` may be the short id printed by `workflow runs` (see resolveRunIdArg).
  */
-export async function workflowAbandonCommand(runId: string, json?: boolean): Promise<void> {
+export async function workflowAbandonCommand(
+  runId: string,
+  json?: boolean,
+  cwd?: string
+): Promise<void> {
   if (json) {
     try {
-      const run = await abandonWorkflow(runId);
+      const resolvedId = await resolveRunIdArg(runId, cwd);
+      const run = await abandonWorkflow(resolvedId);
       console.log(
         JSON.stringify(
           {
             ok: true,
-            runId,
+            runId: resolvedId,
             action: 'abandon',
             status: 'cancelled',
             workflowName: run.workflow_name,
@@ -1902,8 +1954,9 @@ export async function workflowAbandonCommand(runId: string, json?: boolean): Pro
     return;
   }
 
-  const run = await abandonWorkflow(runId);
-  console.log(`Abandoned workflow run: ${runId}`);
+  const resolvedId = await resolveRunIdArg(runId, cwd);
+  const run = await abandonWorkflow(resolvedId);
+  console.log(`Abandoned workflow run: ${resolvedId}`);
   console.log(`Workflow: ${run.workflow_name}`);
 }
 
@@ -1914,11 +1967,14 @@ export async function workflowAbandonCommand(runId: string, json?: boolean): Pro
  * auto-resumes the run inline. `--json` mode records the approval and returns a
  * structured ack WITHOUT resuming — the run is left resumable for a backgrounded
  * `resume`/`run --resume` (inline resume would stream output and break the JSON).
+ *
+ * `runId` may be the short id printed by `workflow runs` (see resolveRunIdArg).
  */
 export async function workflowApproveCommand(
   runId: string,
   comment?: string,
-  json?: boolean
+  json?: boolean,
+  cwd?: string
 ): Promise<void> {
   // JSON mode records the approval and returns a structured ack WITHOUT the
   // inline auto-resume (resuming executes the workflow and streams output to
@@ -1926,12 +1982,13 @@ export async function workflowApproveCommand(
   // — drive it to completion with a backgrounded `resume`/`run --resume`.
   if (json) {
     try {
-      const result = await approveWorkflow(runId, comment);
+      const resolvedId = await resolveRunIdArg(runId, cwd);
+      const result = await approveWorkflow(resolvedId, comment);
       console.log(
         JSON.stringify(
           {
             ok: true,
-            runId,
+            runId: resolvedId,
             action: 'approve',
             type: result.type,
             workflowName: result.workflowName,
@@ -1947,12 +2004,13 @@ export async function workflowApproveCommand(
     return;
   }
 
-  const result = await approveWorkflow(runId, comment);
+  const resolvedId = await resolveRunIdArg(runId, cwd);
+  const result = await approveWorkflow(resolvedId, comment);
 
   // CLI auto-resumes after approval (unlike chat, which defers to next user message)
   if (!result.workingPath) {
     throw new Error(
-      `Workflow run '${runId}' has no working path recorded.\n` +
+      `Workflow run '${resolvedId}' has no working path recorded.\n` +
         'Cannot determine where to resume.'
     );
   }
@@ -1968,14 +2026,14 @@ export async function workflowApproveCommand(
     platformConversationId = originalConversation?.platform_conversation_id ?? undefined;
     if (!originalConversation) {
       getLog().info(
-        { runId, conversationId: result.conversationId },
+        { runId: resolvedId, conversationId: result.conversationId },
         'cli.workflow_approve_conversation_not_found'
       );
     }
   } catch (error) {
     const err = error as Error;
     getLog().warn(
-      { err, runId, conversationId: result.conversationId },
+      { err, runId: resolvedId, conversationId: result.conversationId },
       'cli.workflow_approve_conversation_lookup_failed'
     );
   }
@@ -1985,7 +2043,7 @@ export async function workflowApproveCommand(
     // found even when working_path is a worktree or workspace clone that does
     // not contain the user's local (often untracked) workflow YAML.
     const discoveryCwd = result.codebaseId
-      ? await resolveDiscoveryCwdForCodebase(runId, result.codebaseId, 'approve')
+      ? await resolveDiscoveryCwdForCodebase(resolvedId, result.codebaseId, 'approve')
       : undefined;
 
     await workflowRunCommand(result.workingPath, result.workflowName, result.userMessage ?? '', {
@@ -1997,12 +2055,12 @@ export async function workflowApproveCommand(
   } catch (error) {
     const err = error as Error;
     getLog().error(
-      { err, runId, workflowName: result.workflowName },
+      { err, runId: resolvedId, workflowName: result.workflowName },
       'cli.workflow_approve_resume_failed'
     );
     throw new Error(
       `Approved but failed to resume workflow '${result.workflowName}': ${err.message}\n` +
-        `The approval was recorded. Run 'bun run cli workflow resume ${runId}' to retry.`
+        `The approval was recorded. Run 'bun run cli workflow resume ${resolvedId}' to retry.`
     );
   }
 }
@@ -2011,11 +2069,14 @@ export async function workflowApproveCommand(
  * Reject a paused workflow run by ID.
  * If the workflow has an on_reject prompt, auto-resumes with the rejection feedback;
  * otherwise marks the run as cancelled.
+ *
+ * `runId` may be the short id printed by `workflow runs` (see resolveRunIdArg).
  */
 export async function workflowRejectCommand(
   runId: string,
   reason?: string,
-  json?: boolean
+  json?: boolean,
+  cwd?: string
 ): Promise<void> {
   // JSON mode records the rejection and returns a structured ack WITHOUT the
   // inline auto-resume (an on_reject rework executes the workflow and streams
@@ -2023,12 +2084,13 @@ export async function workflowRejectCommand(
   // is resumable for the rework pass — drive it with a backgrounded `resume`.
   if (json) {
     try {
-      const result = await rejectWorkflow(runId, reason);
+      const resolvedId = await resolveRunIdArg(runId, cwd);
+      const result = await rejectWorkflow(resolvedId, reason);
       console.log(
         JSON.stringify(
           {
             ok: true,
-            runId,
+            runId: resolvedId,
             action: 'reject',
             cancelled: result.cancelled,
             maxAttemptsReached: result.maxAttemptsReached,
@@ -2045,7 +2107,8 @@ export async function workflowRejectCommand(
     return;
   }
 
-  const result = await rejectWorkflow(runId, reason);
+  const resolvedId = await resolveRunIdArg(runId, cwd);
+  const result = await rejectWorkflow(resolvedId, reason);
 
   if (result.cancelled) {
     const suffix = result.maxAttemptsReached ? ' (max attempts reached)' : '';
@@ -2056,7 +2119,7 @@ export async function workflowRejectCommand(
   // Not cancelled = has onRejectPrompt, CLI auto-resumes with rejection feedback
   if (!result.workingPath) {
     throw new Error(
-      `Workflow run '${runId}' has no working path recorded.\n` +
+      `Workflow run '${resolvedId}' has no working path recorded.\n` +
         'Cannot determine where to resume.'
     );
   }
@@ -2070,14 +2133,14 @@ export async function workflowRejectCommand(
     platformConversationId = originalConversation?.platform_conversation_id ?? undefined;
     if (!originalConversation) {
       getLog().info(
-        { runId, conversationId: result.conversationId },
+        { runId: resolvedId, conversationId: result.conversationId },
         'cli.workflow_reject_conversation_not_found'
       );
     }
   } catch (error) {
     const err = error as Error;
     getLog().warn(
-      { err, runId, conversationId: result.conversationId },
+      { err, runId: resolvedId, conversationId: result.conversationId },
       'cli.workflow_reject_conversation_lookup_failed'
     );
   }
@@ -2087,7 +2150,7 @@ export async function workflowRejectCommand(
     // found even when working_path is a worktree or workspace clone that does
     // not contain the user's local (often untracked) workflow YAML.
     const discoveryCwd = result.codebaseId
-      ? await resolveDiscoveryCwdForCodebase(runId, result.codebaseId, 'reject')
+      ? await resolveDiscoveryCwdForCodebase(resolvedId, result.codebaseId, 'reject')
       : undefined;
 
     await workflowRunCommand(result.workingPath, result.workflowName, result.userMessage ?? '', {
@@ -2099,12 +2162,12 @@ export async function workflowRejectCommand(
   } catch (error) {
     const err = error as Error;
     getLog().error(
-      { err, runId, workflowName: result.workflowName },
+      { err, runId: resolvedId, workflowName: result.workflowName },
       'cli.workflow_reject_resume_failed'
     );
     throw new Error(
       `Rejected but failed to resume workflow '${result.workflowName}': ${err.message}\n` +
-        `The rejection was recorded. Run 'bun run cli workflow resume ${runId}' to retry.`
+        `The rejection was recorded. Run 'bun run cli workflow resume ${resolvedId}' to retry.`
     );
   }
 }

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -262,6 +262,8 @@ archon workflow runs --all             # list across all projects (ignore cwd sc
 
 If `cwd` is not a registered project, the command falls back to a global list and says so — `--json` carries this as a `scopeFallback: true` field so a consuming agent never mistakes a global result for a project-scoped one.
 
+The listing shows short 8-character run ids. Every `<run-id>` command below (`get`, `resume`, `abandon`, `approve`, `reject`) accepts these short ids when run from the project directory: a unique prefix resolves to the full id, an ambiguous prefix errors, and full ids keep working from any directory. Short ids from `--all` rows belonging to *other* projects can't be resolved — use the full id from `--json` for those.
+
 ### `workflow get`
 
 Show detail for a single run by ID, regardless of status (unlike `status`, which is active-only). Use it to answer "did that run pass?" for a completed/failed run. Exits non-zero when the run is not found.


### PR DESCRIPTION
## Summary

- Problem: `archon workflow runs` prints 8-char run ids (`0b1ee8da`), but `workflow resume <id>` (and `get`/`abandon`/`approve`/`reject`) do exact-match lookups, so the displayed id fails with `Workflow run not found` — users had to fall back to `--json` for the full id.
- Why it matters: the natural copy-paste flow (`runs` → `resume`) is broken, and it's inconsistent with chat, where the `manage_run` tool already accepts short prefixes.
- What changed: the five run-addressing CLI subcommands now resolve unique short-id prefixes via the existing `findWorkflowRunsByIdPrefix` core helper, mirroring `manage_run`'s semantics — scoped to the cwd's codebase, unique match resolves, ambiguous prefix errors, full ids (dashed UUID or 32-char SQLite hex) skip resolution and keep working globally. Plus a docs note in the CLI reference.
- What did **not** change (scope boundary): `findWorkflowRunsByIdPrefix` and `manage-run-tool.ts` are untouched (imported as-is); chat `/workflow resume` prefix acceptance is a possible follow-up; the `runs` listing format keeps short ids.

## UX Journey

### Before

```
  User                          Archon CLI
  ────                          ──────────
  workflow runs ──────────────▶ prints "0b1ee8da  failed  implement"
  copies 0b1ee8da
  workflow resume 0b1ee8da ───▶ exact lookup WHERE id = '0b1ee8da'
  sees error ◀───────────────── "Workflow run not found: 0b1ee8da"
  workflow runs --json ───────▶ digs out the full id manually
  workflow resume <full-id> ──▶ finally resumes
```

### After

```
  User                          Archon CLI
  ────                          ──────────
  workflow runs ──────────────▶ prints "0b1ee8da  failed  implement"
  copies 0b1ee8da
  workflow resume 0b1ee8da ───▶ [resolveRunIdArg: prefix → full id,
                                 scoped to this project's codebase]
  resumes ◀──────────────────── executes with the resolved full id
                                 (*ambiguous prefix → explicit error*)
```

## Architecture Diagram

### Before

```
  cli.ts ──▶ workflow.ts (get/resume/abandon/approve/reject)
                 │ raw runId
                 ▼
             @archon/core ops + db (exact WHERE id = $1)

  chat manage_run ──▶ findWorkflowRunsByIdPrefix (core db)   ← prefix-aware
```

### After

```
  cli.ts ──effectiveCwd══▶ workflow.ts (get/resume/abandon/approve/reject)
                 │ [+] resolveRunIdArg(runId, cwd)
                 ├──═══▶ codebaseDb.findCodebaseByDefaultCwd (existing)
                 ├──═══▶ workflowDb.findWorkflowRunsByIdPrefix (existing, shared with manage_run)
                 ▼ resolved full id
             @archon/core ops + db (unchanged)
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `cli/cli.ts` | `cli/commands/workflow.ts` | **modified** | passes `effectiveCwd` to the five run-id commands |
| `cli/commands/workflow.ts` | `@archon/core/db/workflows.findWorkflowRunsByIdPrefix` | **new** | same helper + semantics as chat `manage_run` |
| `cli/commands/workflow.ts` | `@archon/core/db/codebases.findCodebaseByDefaultCwd` | unchanged | new call site; same scoping `workflow runs` already uses |
| `cli/commands/workflow.ts` | `@archon/core/operations/workflow-operations` | unchanged | now receives the resolved full id |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `cli`
- Module: `cli:workflow`

## Change Metadata

- Change type: `bug`
- Primary scope: `cli`

## Linked Issue

- Closes #2097

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # all eight checks pass (bundled/skill/schema/pi-vendor-map, type-check, lint, format, tests)
bun test packages/cli/src/commands/workflow.test.ts   # 169 pass, 0 fail
```

- Evidence provided (test/log/trace/screenshot): 9 new tests covering unique-prefix resolution, ambiguous-prefix error (human throw + `--json` `{ok:false}`), full-id skip (dashed UUID and 32-char SQLite hex), unregistered-cwd pass-through, no-match pass-through, no-cwd skip. Manual smoke against the local SQLite DB: `workflow get e1f890f0` resolved to `e1f890f05e5bab0d906921593bf500c4` and printed the run.
- If any command is intentionally skipped, explain why: none skipped.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation: n/a. Resolution is scoped to the cwd's codebase (same query `manage_run` uses), so a prefix can never address another project's runs; full ids behave exactly as before.

## Compatibility / Migration

- Backward compatible? (`Yes`) — full ids take the identical code path (regex short-circuit); non-UUID or unresolvable ids pass through to the existing exact lookup and error surface. The `cwd` parameter is optional; omitting it disables resolution.
- Config/env changes? (`No`)
- Database migration needed? (`No`)

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: `workflow runs` → copy short id → `workflow get <short-id>` resolves and prints the run (real SQLite DB); `workflow get <short-id>` from an unregistered directory falls through to the existing not-found error.
- Edge cases checked: ambiguous prefix (unit test), `--json` never-throw contract preserved (unit test), 32-char undashed SQLite id recognized as full (unit test + the real DB uses this shape).
- What was not verified: approve/reject prefix flow against a live paused run (covered by unit tests through the shared resolver; the op layer receives an already-resolved full id).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: CLI `workflow get/resume/abandon/approve/reject` only. Chat, web, and the `manage_run` tool are untouched.
- Potential unintended effects: a short hex-looking argument that a user intended as an exact id now resolves to a different run sharing that prefix in the same project — only possible if the stored id is shorter than a real run id, which does not occur (ids are always full UUIDs/hex-32).
- Guardrails/monitoring for early detection: ambiguous prefixes fail loudly; `--json` consumers get `{ok:false}` with the reason; resolved full ids are echoed in output and logs.

## Rollback Plan (required)

- Fast rollback command/path: revert the single commit; no schema/config coupling.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: run-id commands erroring on ids that previously worked, or resolving to the wrong run.

## Risks and Mitigations

- Risk: prefix resolves against the wrong scope when the user means a run from another project (e.g. copied from `runs --all`).
  - Mitigation: resolution is codebase-scoped, so a foreign prefix simply finds no match and falls through to the unchanged exact lookup/not-found error; docs call this out and point to `--json` for full ids.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow commands now accept the short 8-character run IDs shown by `workflow runs`.
  * When run from the owning project directory, short IDs are resolved to the matching full run ID.
  * Applies to `get`, `resume`, `abandon`, `approve`, and `reject`.

* **Bug Fixes**
  * Improved short-ID resolution for full/invalid IDs and better handling of ambiguous or non-resolvable prefixes.
  * In `--json` mode, ambiguous cases return a non-OK result; human-readable mode errors.

* **Documentation**
  * Updated `workflow runs` reference docs to clarify short vs full run-ID behavior and cross-project limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->