### PR TITLE
fix(web): supersede abandoned console loads

### DIFF
--- a/packages/web/src/experiments/console/store/cache.test.ts
+++ b/packages/web/src/experiments/console/store/cache.test.ts
@@ -8,7 +8,7 @@ function flush(): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, 0));
 }
 
-describe('subscribeKey — per-key Map lifecycle (#1933)', () => {
+describe('subscribeKey — per-key lifecycle', () => {
   test('last unsubscribe prunes versions; cache is retained for warm remount', async () => {
     const key = 'test:prune-versions';
     let loads = 0;
@@ -126,6 +126,95 @@ describe('subscribeKey — per-key Map lifecycle (#1933)', () => {
     await flush();
     expect(versionOf(key)).toBe(0); // notify skipped — nothing subscribes
     expect(get(key)).toBe('late'); // cache still warms for a future remount
+  });
+
+  test('resubscribing supersedes an abandoned in-flight loader', async () => {
+    const key = 'test:resubscribe-inflight';
+    let resolveA: (v: string) => void = () => {};
+    let resolveB: (v: string) => void = () => {};
+    let loadsA = 0;
+    let loadsB = 0;
+
+    const unsubscribeA = subscribeKey(
+      key,
+      () => {},
+      () => {
+        loadsA += 1;
+        return new Promise<string>(resolve => {
+          resolveA = resolve;
+        });
+      }
+    );
+    expect(loadsA).toBe(1);
+
+    unsubscribeA();
+
+    let notificationsB = 0;
+    const unsubscribeB = subscribeKey(
+      key,
+      () => {
+        notificationsB += 1;
+      },
+      () => {
+        loadsB += 1;
+        return new Promise<string>(resolve => {
+          resolveB = resolve;
+        });
+      }
+    );
+
+    expect(loadsB).toBe(1);
+
+    resolveB('fresh');
+    await flush();
+    expect(get(key)).toBe('fresh');
+    expect(notificationsB).toBe(1);
+
+    resolveA('stale');
+    await flush();
+    expect(get(key)).toBe('fresh');
+    expect(notificationsB).toBe(1);
+
+    unsubscribeB();
+  });
+
+  test('an abandoned revalidation cannot overwrite a warm remount', async () => {
+    const key = 'test:resubscribe-revalidation';
+    set(key, 'warm');
+
+    let resolveA: (v: string) => void = () => {};
+    const unsubscribeA = subscribeKey(
+      key,
+      () => {},
+      () =>
+        new Promise<string>(resolve => {
+          resolveA = resolve;
+        })
+    );
+    invalidate(key); // Starts a revalidation while retaining the warm value.
+    unsubscribeA();
+
+    let loadsB = 0;
+    let notificationsB = 0;
+    const unsubscribeB = subscribeKey(
+      key,
+      () => {
+        notificationsB += 1;
+      },
+      () => {
+        loadsB += 1;
+        return Promise.resolve('fresh');
+      }
+    );
+
+    expect(loadsB).toBe(0); // The retained cache still satisfies a warm remount.
+
+    resolveA('stale');
+    await flush();
+    expect(get(key)).toBe('warm');
+    expect(notificationsB).toBe(0);
+
+    unsubscribeB();
   });
 
   test('a load rejecting after the last unsubscribe does not resurrect the counter', async () => {

--- a/packages/web/src/experiments/console/store/cache.test.ts
+++ b/packages/web/src/experiments/console/store/cache.test.ts
@@ -217,6 +217,73 @@ describe('subscribeKey — per-key lifecycle', () => {
     unsubscribeB();
   });
 
+  test('invalidating an abandoned revalidation cannot resurrect a purged key', async () => {
+    const key = 'test:invalidate-abandoned-revalidation';
+    set(key, 'warm');
+
+    let resolveLoad: (v: string) => void = () => {};
+    const unsubscribe = subscribeKey(
+      key,
+      () => {},
+      () =>
+        new Promise<string>(resolve => {
+          resolveLoad = resolve;
+        })
+    );
+
+    invalidate(key);
+    unsubscribe();
+    invalidate(key);
+    expect(get(key)).toBeUndefined();
+
+    resolveLoad('stale');
+    await flush();
+    expect(get(key)).toBeUndefined();
+  });
+
+  test('manual revalidation supersedes an abandoned load', async () => {
+    const key = 'test:supersede-abandoned-revalidation';
+    set(key, 'warm');
+
+    let resolveA: (v: string) => void = () => {};
+    const unsubscribeA = subscribeKey(
+      key,
+      () => {},
+      () =>
+        new Promise<string>(resolve => {
+          resolveA = resolve;
+        })
+    );
+    invalidate(key);
+    unsubscribeA();
+
+    let loadsB = 0;
+    let resolveB: (v: string) => void = () => {};
+    const unsubscribeB = subscribeKey(
+      key,
+      () => {},
+      () => {
+        loadsB += 1;
+        return new Promise<string>(resolve => {
+          resolveB = resolve;
+        });
+      }
+    );
+
+    invalidate(key);
+    expect(loadsB).toBe(1);
+
+    resolveB('fresh');
+    await flush();
+    expect(get(key)).toBe('fresh');
+
+    resolveA('stale');
+    await flush();
+    expect(get(key)).toBe('fresh');
+
+    unsubscribeB();
+  });
+
   test('a load rejecting after the last unsubscribe does not resurrect the counter', async () => {
     const key = 'test:inflight-reject';
     let rejectLoad: (e: Error) => void = () => {};

--- a/packages/web/src/experiments/console/store/cache.ts
+++ b/packages/web/src/experiments/console/store/cache.ts
@@ -111,12 +111,18 @@ export function patch(key: string, updater: (prev: unknown) => unknown): void {
 function revalidate(key: string): void {
   const loader = loaders.get(key);
   if (loader === undefined) {
+    const activeLoad = inflight.get(key);
+    if (activeLoad !== undefined) {
+      activeLoad.abandoned = true;
+      inflight.delete(key);
+    }
     cache.delete(key);
     errors.delete(key);
     versions.delete(key); // fully release the key — nothing subscribes, so nothing snapshots it
     return;
   }
-  if (inflight.has(key)) return; // a revalidation is already in flight
+  const activeLoad = inflight.get(key);
+  if (activeLoad !== undefined && !activeLoad.abandoned) return;
   const load: InflightLoad = { abandoned: false };
   const promise = loader();
   inflight.set(key, load);

--- a/packages/web/src/experiments/console/store/cache.ts
+++ b/packages/web/src/experiments/console/store/cache.ts
@@ -5,8 +5,10 @@
  * - UI never writes directly — it calls skill verbs; server pushes truth
  *   back via SSE (lib/sse.ts) or refetch on miss.
  * - `useEntity(key, loader)` subscribes to a key. First subscriber triggers
- *   the loader; subsequent subscribers read from cache. After `invalidate()`
- *   or `refetch()`, any key with an active subscriber reloads automatically.
+ *   the loader; subsequent subscribers share that active load. If every
+ *   subscriber leaves before it settles, a later subscriber starts its own
+ *   load and supersedes the abandoned result. After `invalidate()` or
+ *   `refetch()`, any key with an active subscriber reloads automatically.
  * - `patch` and `set` are for the SSE dispatcher and skill-layer optimistic
  *   updates only.
  * - After the last unsubscribe, `cache`/`errors` are deliberately retained so
@@ -23,7 +25,10 @@ type Listener = () => void;
 const cache = new Map<string, unknown>();
 const listeners = new Map<string, Set<Listener>>();
 const errors = new Map<string, Error>();
-const inflight = new Map<string, Promise<unknown>>();
+interface InflightLoad {
+  abandoned: boolean;
+}
+const inflight = new Map<string, InflightLoad>();
 const loaders = new Map<string, () => Promise<unknown>>();
 // Per-key change counter. `useEntity` snapshots THIS (not the cached value), so a
 // subscriber re-renders on every mutation — including the error transition, where
@@ -43,25 +48,38 @@ function notify(key: string): void {
   for (const l of subs) l();
 }
 
+function canCommitLoad(key: string, load: InflightLoad): boolean {
+  if (inflight.get(key) !== load) return false;
+  // An abandoned load may still warm the cache if nobody replaced its
+  // subscriber. Once a new subscriber exists, its current cache/loader owns
+  // the key and the abandoned result must not overwrite either one.
+  return !load.abandoned || !listeners.has(key);
+}
+
 function ensureLoad(key: string): void {
-  if (cache.has(key) || inflight.has(key)) return;
+  const activeLoad = inflight.get(key);
+  if (cache.has(key) || (activeLoad !== undefined && !activeLoad.abandoned)) return;
   const loader = loaders.get(key);
   if (loader === undefined) return;
-  const p = loader()
+  const load: InflightLoad = { abandoned: false };
+  const promise = loader();
+  inflight.set(key, load);
+  void promise
     .then(v => {
+      if (!canCommitLoad(key, load)) return;
       cache.set(key, v);
       errors.delete(key);
       notify(key);
     })
     .catch((e: unknown) => {
+      if (!canCommitLoad(key, load)) return;
       const err = e instanceof Error ? e : new Error(String(e));
       errors.set(key, err);
       notify(key);
     })
     .finally(() => {
-      inflight.delete(key);
+      if (inflight.get(key) === load) inflight.delete(key);
     });
-  inflight.set(key, p);
 }
 
 export function get(key: string): unknown {
@@ -99,21 +117,25 @@ function revalidate(key: string): void {
     return;
   }
   if (inflight.has(key)) return; // a revalidation is already in flight
-  const p = loader()
+  const load: InflightLoad = { abandoned: false };
+  const promise = loader();
+  inflight.set(key, load);
+  void promise
     .then(v => {
+      if (!canCommitLoad(key, load)) return;
       cache.set(key, v);
       errors.delete(key);
       notify(key);
     })
     .catch((e: unknown) => {
+      if (!canCommitLoad(key, load)) return;
       const err = e instanceof Error ? e : new Error(String(e));
       errors.set(key, err);
       notify(key); // surface the error; any stale value stays in cache
     })
     .finally(() => {
-      inflight.delete(key);
+      if (inflight.get(key) === load) inflight.delete(key);
     });
-  inflight.set(key, p);
 }
 
 export function invalidate(keyPrefix: string): void {
@@ -175,6 +197,13 @@ export function subscribeKey(
     if (remainingSubs.size === 0) {
       listeners.delete(key);
       loaders.delete(key);
+      const activeLoad = inflight.get(key);
+      if (activeLoad !== undefined) {
+        // Promises cannot be cancelled, but a future subscriber must not inherit
+        // this loader. Keep it authoritative only while nobody supersedes it so
+        // an otherwise-unused late result can still warm the cache.
+        activeLoad.abandoned = true;
+      }
       // Drop the change counter too — with no subscribers nothing snapshots it,
       // and `useSyncExternalStore` only compares snapshots for change, so a
       // remount starting back at 0 behaves identically. Without this the


### PR DESCRIPTION
## Summary

- Problem: a console-store subscription that mounted while an earlier, now-abandoned load was still pending inherited that load, so its own loader was never invoked.
- Why it matters: navigating away and back during a slow request could leave the remounted view waiting on stale work or allow the old result to overwrite the current view.
- What changed: in-flight loads now carry an identity and an `abandoned` marker; a later subscriber supersedes abandoned work, and only the current load may commit a value or error. Regression tests cover both a cold remount and an abandoned revalidation over a warm cache.
- What did **not** change (scope boundary): no request cancellation was added; cache/error retention, the public store API, and non-console web behavior remain unchanged.

## UX Journey

### Before

```
User                    Console store                 Loader
────                    ─────────────                 ──────
opens view A ─────────▶ starts load A ──────────────▶ pending
leaves view A ────────▶ removes last subscriber
opens view B ─────────▶ sees load A as in-flight
                         skips load B
sees stale/waiting UI ◀─ load A eventually commits ◀─ resolves
```

### After

```
User                    Console store                 Loader
────                    ─────────────                 ──────
opens view A ─────────▶ starts load A ──────────────▶ pending
leaves view A ────────▶ [marks load A abandoned]
opens view B ─────────▶ [starts load B] ────────────▶ resolves fresh
sees current data ◀──── [commits load B]
                         [ignores late load A] ◀────── resolves stale
```

## Architecture Diagram

### Before

```
Console components
       │ subscribe/useEntity
       ▼
store/cache.ts ───────▶ supplied async loader
  ├─ cache/errors
  ├─ listeners/loaders
  ├─ inflight: Map<key, Promise>
  └─ versions ────────▶ subscriber re-render

cache.test.ts ────────▶ public store lifecycle API
```

### After

```
Console components
       │ subscribe/useEntity
       ▼
[~] store/cache.ts ═══▶ supplied async loader
  ├─ cache/errors
  ├─ listeners/loaders
  ├─ [~] inflight: Map<key, { abandoned }>
  ├─ [+] load-identity commit gate
  └─ versions ────────▶ subscriber re-render

[~] cache.test.ts ═══▶ abandoned-load and warm-remount regressions
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| Console components / `useEntity` | `store/cache.ts` subscription API | unchanged | Existing public API and snapshots are unchanged. |
| `store/cache.ts` | Supplied async loader | **modified** | A new subscriber may start a replacement when the prior load is abandoned. |
| Loader promise settlement | Cache, errors, and listeners | **modified** | Load identity gates stale value/error commits and notifications. |
| Last unsubscribe | In-flight load state | **new** | Marks current work abandoned without attempting promise cancellation. |
| SSE / optimistic callers | `set` and `patch` | unchanged | Mutation and notification semantics are unchanged. |
| `cache.test.ts` | Public store lifecycle API | **modified** | Adds deterministic cold- and warm-remount regression coverage. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `web`
- Module: `web:console-store`

## Change Metadata

- Change type: `bug`
- Primary scope: `web`

## Linked Issue

- Closes #2101
- Related #1938
- Depends on: none
- Supersedes: none

## Validation Evidence (required)

Commands and result summary:

```bash
bun test packages/web/src/experiments/console/store/cache.test.ts
# 10 pass, 0 fail, 37 assertions

bun --filter @archon/web test
# 329 pass, 0 fail, 795 assertions

bun --filter @archon/web type-check
# passed

bun x eslint packages/web/src/experiments/console/store/cache.ts packages/web/src/experiments/console/store/cache.test.ts --no-warn-ignored
# passed

bun x prettier --check packages/web/src/experiments/console/store/cache.ts packages/web/src/experiments/console/store/cache.test.ts
# passed

bun run validate
# generated-artifact checks, all workspace type-checks, repository ESLint,
# and repository Prettier passed. The test phase reached one unchanged
# @archon/adapters failure described below.
```

- Evidence provided (test/log/trace/screenshot): the new cold-remount test failed before the implementation because loader B was called 0 times instead of 1. It now passes and also verifies that a late load A cannot overwrite load B. The warm-remount test verifies that an abandoned revalidation cannot overwrite retained cache state.
- If any command is intentionally skipped, explain why: none. `bun run validate` was run; its only failing test is the unchanged `GitHubAdapter > App mode > credential helper install is attempted after successful App-mode clone` test. It also fails when run alone and is outside this PR's two-file web scope: the adapter test mocks `@archon/paths` without `getArchonHome`, while `installCredentialHelper` calls that export before the asserted git-config call. All other workspace packages were also run independently; only that adapter test failed.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation: not applicable.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: none.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: read the repository contribution guidance and console architecture notes; reproduced the missing loader-B call before the fix; reviewed the final diff after rebasing onto current `dev`; confirmed the replacement load commits and notifies exactly once.
- Edge cases checked: the fresh replacement resolves before the abandoned request; an abandoned revalidation resolves after a warm remount; a late load with no replacement still warms the cache as before; rejected abandoned loads do not resurrect subscriber counters.
- What was not verified: no interactive browser session was needed for this deterministic store-lifecycle change. The unrelated adapter test noted above prevents a fully green aggregate `bun run validate` on this checkout.
- AI assistance: OpenAI Codex co-authored the implementation; repository instructions, the diff, and all reported validation output were reviewed before submission.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: experimental console store subscriptions and revalidation only.
- Potential unintended effects: a late result from abandoned work is intentionally discarded once a new subscriber owns the key; an identity-gating error could otherwise suppress a valid result.
- Guardrails/monitoring for early detection: focused tests cover cold and warm remounts, existing lifecycle tests preserve late-cache-warming behavior, and the full web test suite passes.

## Rollback Plan (required)

- Fast rollback command/path: `git revert 10efaf8a3b388089e9d3a07718dc0e9a5790f3f5`
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: remounted console entities fail to load, show stale data, or receive duplicate notifications.

## Risks and Mitigations

- Risk: identity gating could discard a still-useful abandoned result.
  - Mitigation: an abandoned result may still warm the cache when no successor exists; it is discarded only after a current subscriber or replacement load owns the key, with both paths covered by regression tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reactive cache handling when subscriptions are removed and restored while data is loading.
  * Prevented outdated/abandoned async loader and revalidation results from overwriting newer cached values or errors.
  * Avoided unnecessary notifications by ensuring abandoned operations can’t supersede later invalidation or remounts, keeping warm cached data stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->