### PR TITLE
fix(providers/pi): extension-registered models resolve on 2nd+ DAG node in a run

### DIFF
--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -5,6 +5,11 @@ import { tmpdir } from 'node:os';
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { AgentSessionEvent } from '@earendil-works/pi-coding-agent';
 
+// Typed against the real registration shape (config: ProviderConfig) so the
+// mock runtime drifts loudly, not silently, if the SDK/type changes — same
+// precedent as `AgentSessionEvent` above.
+import type { ExtensionProviderRegistration } from './resource-loader';
+
 import { createMockLogger } from '../../test/mocks/logger';
 
 // ─── Mock @archon/paths logger so provider instantiation is quiet ───────
@@ -121,13 +126,9 @@ const mockResourceLoaderReload = mock(async () => undefined);
 // calling pi.registerProvider() during the single cached reload()
 // (issue #2064); the real SDK's bindCore() drains this queue into the FIRST
 // session's registry and reassigns it to [].
-const mockLoaderRuntime: {
-  pendingProviderRegistrations: Array<{
-    name: string;
-    config: Record<string, unknown>;
-    extensionPath: string;
-  }>;
-} = { pendingProviderRegistrations: [] };
+const mockLoaderRuntime: { pendingProviderRegistrations: ExtensionProviderRegistration[] } = {
+  pendingProviderRegistrations: [],
+};
 const mockGetExtensions = mock(() => ({
   extensions: [],
   errors: [],

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -60,7 +60,7 @@ const mockSession = {
   sessionId: 'mock-session-uuid',
 };
 
-const mockCreateAgentSession = mock(async () => ({
+const mockCreateAgentSession = mock(async (_options?: unknown) => ({
   session: mockSession,
   extensionsResult: { extensions: [], errors: [], runtime: {} },
   modelFallbackMessage: undefined,
@@ -115,12 +115,31 @@ const mockSettingsManagerCreate = mock(() => ({
 }));
 const mockSettingsManagerInMemory = mock((_settings?: unknown) => ({}));
 const mockResourceLoaderReload = mock(async () => undefined);
+// Shared extension runtime exposed by the mock loader's getExtensions() —
+// one object shared across sessions, exactly like Pi's real runtime. Tests
+// seed `pendingProviderRegistrations` to simulate an extension factory
+// calling pi.registerProvider() during the single cached reload()
+// (issue #2064); the real SDK's bindCore() drains this queue into the FIRST
+// session's registry and reassigns it to [].
+const mockLoaderRuntime: {
+  pendingProviderRegistrations: Array<{
+    name: string;
+    config: Record<string, unknown>;
+    extensionPath: string;
+  }>;
+} = { pendingProviderRegistrations: [] };
+const mockGetExtensions = mock(() => ({
+  extensions: [],
+  errors: [],
+  runtime: mockLoaderRuntime,
+}));
 // Return-style constructor: bun's mock() wraps the function such that the
 // `this`-binding doesn't reliably propagate to `new` call sites. Returning a
 // plain object from the constructor sidesteps this — ES semantics use the
 // returned object when a constructor explicitly returns one.
 const MockDefaultResourceLoader = mock((_opts: unknown) => ({
   reload: mockResourceLoaderReload,
+  getExtensions: mockGetExtensions,
 }));
 
 // Tool factory mocks — each returns an opaque object tagged with the tool
@@ -211,6 +230,8 @@ describe('PiProvider', () => {
     mockSetModel.mockClear();
     mockSetFlagValue.mockClear();
     mockResourceLoaderReload.mockClear();
+    mockGetExtensions.mockClear();
+    mockLoaderRuntime.pendingProviderRegistrations = [];
     mockCreateAgentSession.mockClear();
     mockAuthCreate.mockClear();
     mockModelRegistryCreate.mockClear();
@@ -2047,6 +2068,162 @@ describe('PiProvider', () => {
       expect(loader).toBeDefined();
       expect(MockDefaultResourceLoader).toHaveBeenCalledTimes(2);
       expect(mockResourceLoaderReload).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ─── extension provider registrations across sessions (issue #2064) ────
+  //
+  // Extension factories (e.g. pi-cursor's) run only during the single cached
+  // reload() and queue their pi.registerProvider() calls on the loader's
+  // shared runtime. The real SDK drains that queue into the FIRST session's
+  // ModelRegistry and clears it — so before the fix, the 2nd+ sendQuery in a
+  // process (DAG node 2) built a fresh registry that never saw extension
+  // models and failed LOOKUP-2 with "Pi model not found".
+  describe('extension provider registrations across sessions (issue #2064)', () => {
+    /** Registration matching what pi-cursor queues at factory/load time. */
+    const cursorRegistration = {
+      name: 'cursor',
+      config: {
+        name: 'Cursor',
+        baseUrl: 'http://localhost:33417/v1',
+        apiKey: 'cursor-proxy',
+        api: 'openai-completions',
+        models: [],
+      },
+      extensionPath: '/mock/ext/pi-cursor',
+    };
+
+    /**
+     * A per-call fake registry that resolves ONLY providers explicitly
+     * registered into it — like the real one, whose static catalog does not
+     * contain extension providers such as 'cursor'.
+     */
+    function fakeExtensionAwareRegistry(): {
+      registered: Map<string, unknown>;
+      find: (
+        provider: string,
+        modelId: string
+      ) => { id: string; provider: string; name: string } | undefined;
+      registerProvider: (name: string, config: unknown) => void;
+    } {
+      const registered = new Map<string, unknown>();
+      return {
+        registered,
+        find: (provider: string, modelId: string) =>
+          registered.has(provider)
+            ? { id: modelId, provider, name: `${provider}/${modelId}` }
+            : undefined,
+        registerProvider: (name: string, config: unknown) => {
+          registered.set(name, config);
+        },
+      };
+    }
+
+    /**
+     * Simulate the real SDK's bindCore() drain for one createAgentSession
+     * call: flush the shared runtime's pending queue into THIS session's
+     * registry, then clear it (the SDK reassigns to []).
+     */
+    function drainQueueOnceIntoSessionRegistry(): void {
+      mockCreateAgentSession.mockImplementationOnce(async (options?: unknown) => {
+        const { modelRegistry } = options as {
+          modelRegistry: { registerProvider: (name: string, config: unknown) => void };
+        };
+        for (const { name, config } of mockLoaderRuntime.pendingProviderRegistrations) {
+          modelRegistry.registerProvider(name, config);
+        }
+        mockLoaderRuntime.pendingProviderRegistrations = [];
+        return {
+          session: mockSession,
+          extensionsResult: { extensions: [], errors: [], runtime: {} },
+          modelFallbackMessage: undefined,
+        };
+      });
+    }
+
+    test('extension-registered model resolves on the 2nd+ sendQuery (the issue #2064 scenario)', async () => {
+      // The extension factory queued its registration during the single reload().
+      mockLoaderRuntime.pendingProviderRegistrations = [cursorRegistration];
+
+      const registries: ReturnType<typeof fakeExtensionAwareRegistry>[] = [];
+      const nextRegistry = (): ReturnType<typeof fakeExtensionAwareRegistry> => {
+        const registry = fakeExtensionAwareRegistry();
+        registries.push(registry);
+        return registry;
+      };
+      mockModelRegistryCreate.mockImplementationOnce(nextRegistry);
+      mockModelRegistryCreate.mockImplementationOnce(nextRegistry);
+      drainQueueOnceIntoSessionRegistry();
+      drainQueueOnceIntoSessionRegistry();
+
+      // Node 1: works with or without the fix (bindCore's drain registers cursor).
+      resetScript(scriptedAgentEnd());
+      const first = await consume(
+        new PiProvider().sendQuery('a', '/tmp', undefined, { model: 'cursor/gpt-5.4-nano' })
+      );
+      expect(first.error).toBeUndefined();
+
+      // Node 2: the queue is drained; only the loader-level snapshot re-apply
+      // can register cursor into this call's fresh registry. Before the fix
+      // this failed with "Pi model not found: provider='cursor'".
+      resetScript(scriptedAgentEnd());
+      const second = await consume(
+        new PiProvider().sendQuery('b', '/tmp', undefined, { model: 'cursor/gpt-5.4-nano' })
+      );
+      expect(second.error).toBeUndefined();
+
+      expect(registries).toHaveLength(2);
+      expect(registries[1]?.registered.has('cursor')).toBe(true);
+      // The extension model was resolved and set on both sessions.
+      expect(mockSetModel).toHaveBeenCalledTimes(2);
+      // Single-reload constraint (issue #1877) intact: no re-reload happened.
+      expect(mockResourceLoaderReload).toHaveBeenCalledTimes(1);
+    });
+
+    test('snapshot is captured before any session drains the shared queue and is served from cache', async () => {
+      mockLoaderRuntime.pendingProviderRegistrations = [cursorRegistration];
+
+      const entry = await getOrCreateReloadedExtensionLoader('/tmp', {});
+      // Simulate the SDK's bindCore() drain (reassigns the runtime array).
+      mockLoaderRuntime.pendingProviderRegistrations = [];
+
+      expect(entry.providerRegistrations).toEqual([
+        expect.objectContaining({ name: 'cursor', extensionPath: '/mock/ext/pi-cursor' }),
+      ]);
+
+      // Later nodes hit the cache and still see the captured registrations.
+      const again = await getOrCreateReloadedExtensionLoader('/tmp', {});
+      expect(again.providerRegistrations).toEqual(entry.providerRegistrations);
+      expect(mockResourceLoaderReload).toHaveBeenCalledTimes(1);
+    });
+
+    test('a failing re-apply warns and does not fail nodes using other providers', async () => {
+      process.env.GEMINI_API_KEY = 'sk-test';
+      mockLoaderRuntime.pendingProviderRegistrations = [
+        { name: 'broken', config: { baseUrl: 'http://x' }, extensionPath: '/mock/ext/broken' },
+      ];
+      // Static-catalog model resolves via the default find(); registerProvider
+      // rejects the broken extension config — mirroring a validation throw.
+      mockModelRegistryCreate.mockImplementationOnce(() => ({
+        find: mockModelRegistryFind,
+        registerProvider: (): void => {
+          throw new Error('Provider broken: "apiKey" or "oauth" is required when defining models.');
+        },
+      }));
+
+      resetScript(scriptedAgentEnd());
+      const { error } = await consume(
+        new PiProvider().sendQuery('hi', '/tmp', undefined, { model: 'google/gemini-2.5-pro' })
+      );
+
+      expect(error).toBeUndefined();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          piExtensionProvider: 'broken',
+          extensionPath: '/mock/ext/broken',
+        }),
+        'pi.extension_provider_reapply_failed'
+      );
     });
   });
 });

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -473,9 +473,42 @@ export class PiProvider implements IAgentProvider {
       ...(systemPrompt !== undefined ? { systemPrompt } : {}),
       ...(skillPaths.length > 0 ? { additionalSkillPaths: skillPaths } : {}),
     };
-    const resourceLoader: DefaultResourceLoader = enableExtensions
-      ? await getOrCreateReloadedExtensionLoader(cwd, loaderOptions)
-      : createNoopResourceLoader(cwd, loaderOptions);
+    let resourceLoader: DefaultResourceLoader;
+    if (enableExtensions) {
+      const { loader, providerRegistrations } = await getOrCreateReloadedExtensionLoader(
+        cwd,
+        loaderOptions
+      );
+      resourceLoader = loader;
+      // Re-apply the load-time extension provider registrations to THIS call's
+      // fresh ModelRegistry (issue #2064). Extension factories run only during
+      // the single cached reload(), and the SDK drains their queued
+      // registerProvider() calls into the FIRST session's registry only — so
+      // without this, the 2nd+ sendQuery in a process (e.g. DAG node 2) never
+      // sees extension models (pi-cursor's `cursor/*`) and LOOKUP-2 fails.
+      // registerProvider() is a documented upsert, so the first call receiving
+      // the same configs again via its own bindCore() flush is harmless.
+      for (const { name, config, extensionPath } of providerRegistrations) {
+        try {
+          modelRegistry.registerProvider(name, config);
+        } catch (err) {
+          // Intentional non-fatal fallback mirroring the SDK's own bindCore()
+          // flush (per-entry try/catch + emitted extension error): one broken
+          // extension config must not fail nodes that use other providers.
+          // If the model this node actually needs is missing, LOOKUP-2 below
+          // still throws the loud, actionable "Pi model not found" error.
+          getLog().warn(
+            { err, piExtensionProvider: name, extensionPath },
+            'pi.extension_provider_reapply_failed'
+          );
+        }
+      }
+      if (providerRegistrations.length > 0) {
+        getLog().debug({ count: providerRegistrations.length }, 'pi.extension_providers_reapplied');
+      }
+    } else {
+      resourceLoader = createNoopResourceLoader(cwd, loaderOptions);
+    }
 
     getLog().info(
       {

--- a/packages/providers/src/community/pi/resource-loader.ts
+++ b/packages/providers/src/community/pi/resource-loader.ts
@@ -1,4 +1,5 @@
 import { DefaultResourceLoader, getAgentDir } from '@earendil-works/pi-coding-agent';
+import type { ProviderConfig } from '@earendil-works/pi-coding-agent';
 
 /**
  * In pi-coding-agent <= 0.67.x, DefaultResourceLoader and PackageManager
@@ -129,7 +130,44 @@ export function createNoopResourceLoader(
  * this cache prevents. Time/idle-based reclamation belongs with isolation
  * cleanup (a future cross-package hook), not a blind cap here.
  */
-const reloadedExtensionLoaderCache = new Map<string, Promise<DefaultResourceLoader>>();
+const reloadedExtensionLoaderCache = new Map<string, Promise<ReloadedExtensionLoader>>();
+
+/**
+ * One extension provider registration captured at load time — the payload an
+ * extension factory passed to `pi.registerProvider()` while `reload()` ran.
+ * Mirrors the SDK's `ExtensionRuntimeState['pendingProviderRegistrations']`
+ * element shape.
+ */
+export interface ExtensionProviderRegistration {
+  name: string;
+  config: ProviderConfig;
+  extensionPath: string;
+}
+
+/**
+ * A cached, already-reloaded extension loader plus the provider registrations
+ * its extensions queued at load time (issue #2064).
+ *
+ * Why the snapshot exists: extension factories run only during the single
+ * cached `reload()` (see the deadlock note above), and a load-time
+ * `pi.registerProvider()` call is QUEUED on the loader's shared extension
+ * runtime (`runtime.pendingProviderRegistrations`), not applied. The first
+ * session built on this loader drains that queue into ITS ModelRegistry via
+ * `bindCore()` and clears it — so the second and later sendQuery calls, which
+ * each build a fresh per-call ModelRegistry, would never see extension models
+ * (e.g. pi-cursor's `cursor/*`) and fail LOOKUP-2 with "Pi model not found".
+ *
+ * The snapshot is taken right after `reload()` completes, BEFORE any session
+ * can drain the queue (`bindCore()` reassigns the array rather than mutating
+ * it, so the copy is stable). The provider re-applies it to every per-call
+ * registry — `ModelRegistry.registerProvider()` is a documented upsert, so
+ * the first session receiving the same configs twice (our re-apply + its own
+ * `bindCore()` flush) is harmless.
+ */
+export interface ReloadedExtensionLoader {
+  loader: DefaultResourceLoader;
+  providerRegistrations: readonly ExtensionProviderRegistration[];
+}
 
 /**
  * Cache key over every input baked into the loader. `systemPrompt` and
@@ -147,19 +185,21 @@ function extensionLoaderCacheKey(
 }
 
 /**
- * Return a process-cached, already-reloaded extension-bearing ResourceLoader,
- * constructing + `reload()`ing it on first use for a given input set. Always
- * loads with `enableExtensions: true` — this is the only path that runs the
- * non-re-entrant `reload()`, so it is the only path that needs the cache.
+ * Return a process-cached, already-reloaded extension-bearing ResourceLoader
+ * plus the load-time provider registrations its extensions queued (see
+ * `ReloadedExtensionLoader`), constructing + `reload()`ing it on first use for
+ * a given input set. Always loads with `enableExtensions: true` — this is the
+ * only path that runs the non-re-entrant `reload()`, so it is the only path
+ * that needs the cache.
  *
- * Concurrency: the cache stores the in-flight Promise (not the resolved loader)
+ * Concurrency: the cache stores the in-flight Promise (not the resolved entry)
  * so concurrent same-layer nodes await a single shared `reload()` instead of
  * racing into two. A failed reload is evicted so the next call retries cleanly.
  */
 export async function getOrCreateReloadedExtensionLoader(
   cwd: string,
   options: Pick<NoopResourceLoaderOptions, 'systemPrompt' | 'additionalSkillPaths'> = {}
-): Promise<DefaultResourceLoader> {
+): Promise<ReloadedExtensionLoader> {
   const key = extensionLoaderCacheKey(
     cwd,
     options.systemPrompt,
@@ -167,7 +207,7 @@ export async function getOrCreateReloadedExtensionLoader(
   );
   let pending = reloadedExtensionLoaderCache.get(key);
   if (!pending) {
-    pending = (async (): Promise<DefaultResourceLoader> => {
+    pending = (async (): Promise<ReloadedExtensionLoader> => {
       const loader = createNoopResourceLoader(cwd, { ...options, enableExtensions: true });
       // reload() loads the extensions into the loader so createAgentSession can
       // build session.extensionRunner. Without it the runner is undefined and the
@@ -175,6 +215,14 @@ export async function getOrCreateReloadedExtensionLoader(
       // would silently never apply.
       try {
         await loader.reload();
+        // Snapshot NOW, before any session's bindCore() drains the queue into
+        // its own ModelRegistry and clears it. Defensive copy: bindCore()
+        // reassigns the array, so the copy stays stable, but a copy also
+        // guards against future in-place mutation upstream.
+        const providerRegistrations: ExtensionProviderRegistration[] = [
+          ...loader.getExtensions().runtime.pendingProviderRegistrations,
+        ];
+        return { loader, providerRegistrations };
       } catch (error) {
         // Extensions execute arbitrary JS from ~/.pi/agent/extensions/ (and the
         // repo's .pi/); a broken one fails here. Rethrow with an actionable
@@ -188,7 +236,6 @@ export async function getOrCreateReloadedExtensionLoader(
           { cause: error }
         );
       }
-      return loader;
     })();
     reloadedExtensionLoaderCache.set(key, pending);
     // Evict on failure so a transient reload error doesn't poison the cache.


### PR DESCRIPTION
## Summary

- Problem: Multi-node Pi workflows using extension-provided models (e.g. `cursor/gpt-5.4-nano` from `@schultzp2020/pi-cursor`) fail deterministically on DAG node 2+ with `Pi model not found`, while node 1 and single-node workflows succeed.
- Why it matters: Any multi-node workflow on a Pi extension backend is unusable (including bundled multi-node workflows); the only workaround is one-node-per-process orchestration.
- What changed: The cached extension loader now captures the load-time `pi.registerProvider()` registrations its extensions queued during the single `reload()`, and the provider re-applies them to every per-call `ModelRegistry` before `createAgentSession()`.
- What did **not** change (scope boundary): No new `reload()` calls and no cache eviction — the single-reload-per-process constraint from I1877 (2nd reload deadlocks) is fully preserved. No changes outside `packages/providers/src/community/pi/`.

## UX Journey

### Before

```
  User                   Archon DAG Executor          Pi Provider
  ────                   ───────────────────          ───────────
  runs workflow ────────▶ node "first"
                          fresh ModelRegistry #1
                          cached loader (reload #1) ─▶ extension queues registerProvider('cursor')
                          session 1 bindCore ────────▶ queue → registry #1, queue cleared
                          LOOKUP-2 finds cursor ✓
                          node "first" completes

                          node "second"
                          fresh ModelRegistry #2
                          cached loader (no reload) ─▶ queue is EMPTY
                          [X] LOOKUP-2 misses
  sees workflow error ◀── "Pi model not found: provider='cursor'"
```

### After

```
  User                   Archon DAG Executor          Pi Provider
  ────                   ───────────────────          ───────────
  runs workflow ────────▶ node "first"
                          cached loader (reload #1) ─▶ *snapshot queued registrations*
                          *re-apply snapshot → registry #1* (idempotent with bindCore flush)
                          node "first" completes

                          node "second"
                          fresh ModelRegistry #2
                          cached loader (no reload)
                          *re-apply snapshot → registry #2*
                          LOOKUP-2 finds cursor ✓
  sees workflow succeed ◀─ both nodes complete
```

## Architecture Diagram

### Before

```
provider.ts sendQuery()
  ├── ModelRegistry.create()  (fresh per call)
  ├── getOrCreateReloadedExtensionLoader() ──▶ resource-loader.ts cache (loader only)
  │        loader.reload() once ──▶ SDK runtime.pendingProviderRegistrations (drained by 1st session)
  └── createAgentSession({ modelRegistry, resourceLoader })
```

### After

```
provider.ts sendQuery()
  ├── ModelRegistry.create()  (fresh per call)
  ├── getOrCreateReloadedExtensionLoader() ──▶ [~] resource-loader.ts cache { loader, [+] providerRegistrations }
  │        loader.reload() once ──▶ [+] snapshot of pendingProviderRegistrations (pre-drain)
  ├── [+] re-apply snapshot ═══▶ modelRegistry.registerProvider(name, config) per entry
  └── createAgentSession({ modelRegistry, resourceLoader })
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `provider.ts` | `resource-loader.ts` (`getOrCreateReloadedExtensionLoader`) | **modified** | Return type is now `{ loader, providerRegistrations }` |
| `resource-loader.ts` | Pi SDK `loader.getExtensions().runtime` | **new** | Read-only snapshot of the pending-registration queue after `reload()` |
| `provider.ts` | Pi SDK `ModelRegistry.registerProvider` | **new** | Re-apply captured registrations per call (documented upsert) |
| `provider.ts` | Pi SDK `createAgentSession` | unchanged | |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `adapters`
- Module: `providers:pi`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi` (providers package only)

## Linked Issue

- Closes #2064
- Related #1877 (single-reload constraint this fix preserves)

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # exit 0 — check:bundled(+skill/schema/pi-vendor-map), type-check, lint, format:check, tests all pass
cd packages/providers && bun test src/community/pi/provider.test.ts   # 82 pass, 0 fail
```

- Evidence provided (test/log/trace/screenshot): New regression suite `extension provider registrations across sessions (issue #2064)` — with the re-apply loop temporarily removed, the node-2 test fails with the exact error from the issue (`Pi model not found: provider='cursor' model='gpt-5.4-nano'`); with the fix it passes. The suite also asserts `reload()` runs exactly once across both calls (I1877 invariant).
- If any command is intentionally skipped, explain why: Empirical repro with a real pi-cursor + Cursor auth is not possible in this environment; the mechanism was verified by reading Pi SDK 0.80.6 dist (`extensions/loader.js` queue, `extensions/runner.js` `bindCore()` flush-and-clear, `agent-session.js` shared-runtime wiring) and pi-cursor 0.5.0 source (factory-time `register()`), and the tests reproduce that exact sequence.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: n/a — extension code already executes under `enableExtensions: true`; this change only replays registration payloads those extensions already produced into per-call registries.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No
- If yes, exact upgrade steps: n/a

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Root cause traced line-by-line through Pi SDK 0.80.6 (`pendingProviderRegistrations` queued pre-bind in `loader.js`; `bindCore()` flush + `= []` clear in `runner.js`; one shared runtime per cached loader in `agent-session.js`) and pi-cursor 0.5.0 (`register()` at factory end; `session_start` handler only logs). Regression test proven red-before/green-after.
- Edge cases checked: double application on node 1 (upsert — harmless); broken registration config (per-entry warn, node using other providers unaffected, LOOKUP-2 still throws when the needed model is absent); failed `reload()` still evicted with the same actionable error; snapshot survives the SDK's queue reassignment.
- What was not verified: Live end-to-end run against a real Cursor account (auth unavailable here); post-bind *dynamic* registrations from a `session_start` handler are out of scope (no known extension registers models that way — pi-cursor registers at load time).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Pi provider only, and only the `enableExtensions` (default-on) path; extensions-off path untouched.
- Potential unintended effects: An extension provider that intentionally overrides static-catalog entries now applies that override on every node, not just node 1 — this is a consistency improvement (node 2 previously silently diverged from node 1).
- Guardrails/monitoring for early detection: `pi.extension_providers_reapplied` (debug) and `pi.extension_provider_reapply_failed` (warn) structured logs; the existing `Pi model not found` error remains loud if resolution still misses.

## Rollback Plan (required)

- Fast rollback command/path: `git revert` the single commit — the change is self-contained in three files under `packages/providers/src/community/pi/`.
- Feature flags or config toggles (if any): `assistants.pi.enableExtensions: false` bypasses the entire code path.
- Observable failure symptoms: node 2+ of multi-node Pi workflows failing with `Pi model not found` for extension models (the pre-fix behavior).

## Risks and Mitigations

- Risk: Registration configs are captured once and replayed; a config whose closure state goes stale (e.g. a proxy port change) could serve outdated endpoints.
  - Mitigation: Configs close over the extension's module state (pi-cursor refreshes via `oauth.modifyModels` → `ensureProxy` at resolution time), matching exactly what the SDK itself replays to the first session; no divergence introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Extension-provided models stay available across subsequent requests and sessions.
  - Improved reliability for extension loading when requests run concurrently.
  - If extension provider re-registration fails, the system now emits warnings (without disrupting other providers).

- **Tests**
  - Added regression coverage for cross-session extension provider registrations, repeated request behavior, caching semantics, and queued re-apply failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->