### PR TITLE
fix(core): fail fast when a scoped chat's working directory is gone

### DIFF
--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -260,8 +260,12 @@ mock.module('@archon/git', () => ({
   hasUncommittedChanges: mock(() => Promise.resolve(false)),
 }));
 
+// Default: every path exists. Hoisted to a named mock so the missing-cwd guard
+// (#1170) can be exercised by overriding it per-test — restore `() => true` after.
+const mockExistsSync = mock((_path: string) => true);
+
 mock.module('fs', () => ({
-  existsSync: mock(() => true),
+  existsSync: mockExistsSync,
   // token-crypto.ts imports these from node:fs for the auto-provisioned credential
   // key. readFileSync returns a valid 64-hex key so getEncryptionKey() resolves
   // without any real disk write when the per-user credential path is exercised.
@@ -1401,6 +1405,83 @@ describe('provider cwd resolution', () => {
       expect.objectContaining({ codebaseId: 'deleted-id' }),
       'orchestrator.scoped_codebase_not_found'
     );
+  });
+
+  // ─── missing cwd guard (issue #1170) ────────────────────────────────────────
+
+  describe('missing cwd guard (#1170)', () => {
+    test('sends an actionable error and never reaches the provider when default_cwd is gone', async () => {
+      const codebase = makeCodebaseForSync();
+      const conversation = makeConversation({ codebase_id: 'codebase-1' });
+      mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+      mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+      mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+      // Simulate the registered repo dir being removed after registration.
+      mockExistsSync.mockImplementation((p: string) => p !== '/repos/test-repo');
+
+      try {
+        const platform = makePlatform();
+        await handleMessage(platform, 'conv-1', 'hello');
+
+        // The provider must never be handed a nonexistent cwd — that is the
+        // whole point of the guard (Codex would die with "os error 2").
+        expect(mockSendQuery).not.toHaveBeenCalled();
+        expect(platform.sendMessage).toHaveBeenCalledWith(
+          'conv-1',
+          expect.stringContaining('Working directory no longer exists: /repos/test-repo')
+        );
+        expect(mockLogger.error).toHaveBeenCalledWith(
+          expect.objectContaining({ codebaseId: 'codebase-1', cwd: '/repos/test-repo' }),
+          'orchestrator.cwd_missing'
+        );
+      } finally {
+        mockExistsSync.mockImplementation(() => true);
+      }
+    });
+
+    test('guards conversation.cwd (worktree override), not just default_cwd', async () => {
+      const codebase = makeCodebaseForSync();
+      const conversation = makeConversation({
+        codebase_id: 'codebase-1',
+        cwd: '/worktrees/cleaned-up',
+      });
+      mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+      mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+      mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+      // The worktree is gone even though the codebase's own dir still exists.
+      mockExistsSync.mockImplementation((p: string) => p !== '/worktrees/cleaned-up');
+
+      try {
+        const platform = makePlatform();
+        await handleMessage(platform, 'conv-1', 'hello');
+
+        expect(mockSendQuery).not.toHaveBeenCalled();
+        expect(platform.sendMessage).toHaveBeenCalledWith(
+          'conv-1',
+          expect.stringContaining('Working directory no longer exists: /worktrees/cleaned-up')
+        );
+      } finally {
+        mockExistsSync.mockImplementation(() => true);
+      }
+    });
+
+    test('does not guard the unscoped path (workspaces root is created on demand)', async () => {
+      const conversation = makeConversation({ codebase_id: null });
+      mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+      mockListCodebases.mockReturnValueOnce(Promise.resolve([]));
+      // Even with nothing on disk, ensureArchonWorkspacesPath() mkdir -p's it,
+      // so the unscoped branch must stay reachable.
+      mockExistsSync.mockImplementation(() => false);
+
+      try {
+        const platform = makePlatform();
+        await handleMessage(platform, 'conv-1', 'hello');
+
+        expect(getSendQueryCwd()).toBe('/home/test/.archon/workspaces');
+      } finally {
+        mockExistsSync.mockImplementation(() => true);
+      }
+    });
   });
 });
 

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -1383,6 +1383,24 @@ export async function handleMessage(
     let cwd: string;
     if (scopedCodebase !== undefined) {
       cwd = conversation.cwd ?? scopedCodebase.default_cwd;
+      // Fail fast when the resolved directory has been removed out from under a
+      // long-lived conversation (cleaned-up worktree, deleted repo dir, reset
+      // volume). Providers pass cwd straight through — Codex hands it to the
+      // native binary as `--cd`, which dies with an opaque
+      // "No such file or directory (os error 2)" (#1170). Mirrors the existsSync
+      // guard /register-project and /update-project already apply.
+      if (!existsSync(cwd)) {
+        getLog().error(
+          { conversationId, codebaseId: scopedCodebase.id, cwd },
+          'orchestrator.cwd_missing'
+        );
+        throw new Error(
+          `Working directory no longer exists: ${cwd}\n\n` +
+            'The project folder or worktree may have been deleted or cleaned up ' +
+            '(e.g. `archon isolation cleanup`, `archon complete`, or a manual removal). ' +
+            'Re-register the project (`/register-project`) or select a different one (`/setproject`).'
+        );
+      }
     } else {
       if (conversation.codebase_id !== null) {
         getLog().warn(

--- a/packages/core/src/utils/error-formatter.test.ts
+++ b/packages/core/src/utils/error-formatter.test.ts
@@ -177,6 +177,57 @@ describe('classifyAndFormatError', () => {
     });
   });
 
+  describe('missing working directory errors (#1170)', () => {
+    test('passes the message through with its recovery guidance intact', () => {
+      const result = classifyAndFormatError(
+        new Error(
+          'Working directory no longer exists: /.archon/workspaces/owner/repo/source\n\n' +
+            'The project folder or worktree may have been deleted or cleaned up ' +
+            '(e.g. `archon isolation cleanup`, `archon complete`, or a manual removal). ' +
+            'Re-register the project (`/register-project`) or select a different one (`/setproject`).'
+        )
+      );
+      expect(result).toContain('Working directory no longer exists');
+      expect(result).toContain('/.archon/workspaces/owner/repo/source');
+      expect(result).toContain('/register-project');
+      expect(result).toContain('/setproject');
+    });
+
+    test('survives the >100-char generic fallback that would otherwise hide the guidance', () => {
+      // The real thrown message is well over 100 chars, so without a dedicated
+      // branch it would degrade to "An unexpected error occurred".
+      const long = `Working directory no longer exists: /${'d'.repeat(150)}`;
+      expect(long.length).toBeGreaterThan(100);
+      const result = classifyAndFormatError(new Error(long));
+      expect(result).not.toContain('An unexpected error occurred');
+      expect(result).toContain('Working directory no longer exists');
+    });
+
+    test('takes precedence over the session branch when the path contains "session"', () => {
+      // Regression guard for branch ordering: a path segment must not divert
+      // this to the unrelated session classifier.
+      const result = classifyAndFormatError(
+        new Error('Working directory no longer exists: /repos/session-manager')
+      );
+      expect(result).toContain('Working directory no longer exists');
+      expect(result).not.toContain('Session error');
+    });
+
+    test('takes precedence over the security filter when the path contains "token"', () => {
+      const result = classifyAndFormatError(
+        new Error('Working directory no longer exists: /repos/token-service')
+      );
+      expect(result).toContain('Working directory no longer exists');
+      expect(result).not.toContain('An unexpected error occurred');
+    });
+
+    test('does not match when the prefix is wrong', () => {
+      const msg = 'Some working directory no longer exists: /repos/app';
+      const result = classifyAndFormatError(new Error(msg));
+      expect(result).toBe(`⚠️ Error: ${msg}. Try /reset if issue persists.`);
+    });
+  });
+
   describe('model not available errors', () => {
     test('returns message as-is when it matches the model unavailable pattern', () => {
       const msg = '❌ Model "claude-opus-4" not available for your account';

--- a/packages/core/src/utils/error-formatter.ts
+++ b/packages/core/src/utils/error-formatter.ts
@@ -14,6 +14,16 @@
 export function classifyAndFormatError(error: Error): string {
   const message = error.message || '';
 
+  // Missing working directory (#1170) — an Archon-generated message that already
+  // carries its own recovery steps, so pass it through verbatim. Checked first:
+  // it embeds an arbitrary filesystem path, and a path segment like "session" or
+  // "token" would otherwise divert it to an unrelated branch or the sensitive-data
+  // fallback, hiding the actionable guidance (the message also exceeds the
+  // generic fallback's 100-char limit).
+  if (message.startsWith('Working directory no longer exists:')) {
+    return `⚠️ ${message}`;
+  }
+
   // AI/SDK errors - rate limits
   if (message.includes('rate limit') || message.includes('Rate limit')) {
     return '⚠️ AI rate limit reached. Please wait a moment and try again.';


### PR DESCRIPTION
## Summary

- Problem: Codex-backed chats in a project-scoped conversation crashed with the opaque `Codex Exec exited with code 1: Error: No such file or directory (os error 2)` whenever the resolved working directory (`conversation.cwd` or `scopedCodebase.default_cwd`) no longer existed on disk — e.g. a cleaned-up worktree, a deleted repo directory, or a reset volume in a fresh Docker deployment.
- Why it matters: The failure surfaced as a raw, unactionable Rust-level OS error deep inside the Codex binary instead of a clear Archon-level message, leaving users unable to tell what actually went wrong or how to fix it.
- What changed: The scoped-codebase branch in `handleMessage` now guards the resolved `cwd` with `existsSync` and throws an actionable error before ever reaching the provider; the error is classified first in `classifyAndFormatError` so it can't be misrouted by unrelated substring matches (e.g. "session", "token") or dropped by the sensitive-data length fallback.
- What did **not** change (scope boundary): No Dockerfile changes. The issue's proposed root cause (Dockerfile purging node/npm, breaking Codex's npm wrapper) was investigated and ruled out — `@openai/codex-sdk` spawns the native binary directly and never executes the JS shim, so a missing node would surface as a differently-formatted Node ENOENT, not this Rust-formatted error. `packages/workflows/src/executor.ts` has a similar theoretical gap but was deferred (narrower race window, tracked as a follow-up).

## UX Journey

### Before

```
  User                        Archon                              Codex (native binary)
  ────                        ──────                              ─────────────────────
  sends message ───────────▶  resolves scoped cwd (no check)
                               streams to provider ─────────────▶  spawned with --cd <stale path>
                                                                    fails: "No such file or
                                                                    directory (os error 2)"
  sees opaque crash ◀────────  raw SDK error passed through
```

### After

```
  User                        Archon                              Codex (native binary)
  ────                        ──────                              ─────────────────────
  sends message ───────────▶  resolves scoped cwd
                               [existsSync check] ── missing ──▶  never invoked
                               throws actionable error
                               classifyAndFormatError picks
                               the new branch FIRST
  sees clear guidance ◀──────  formatted, actionable message
```

## Architecture Diagram

### Before

```
handleMessage (orchestrator-agent.ts)
  ├─ scoped-codebase branch: cwd = conversation.cwd ?? scopedCodebase.default_cwd  (unchecked)
  │    └─▶ provider.sendQuery(cwd) ──▶ Codex native binary --cd <cwd>
  └─ unscoped branch: ensureArchonWorkspacesPath() (mkdir -p, already safe)

classifyAndFormatError (error-formatter.ts)
  ├─ session-related branch
  ├─ sensitive-data / generic fallback branch
  └─ ... (no branch for missing scoped cwd)
```

### After

```
handleMessage (orchestrator-agent.ts)
  ├─ scoped-codebase branch: cwd = conversation.cwd ?? scopedCodebase.default_cwd
  │    ├─ [~] existsSync(cwd) guard ── missing ──▶ throw actionable Error
  │    └─▶ provider.sendQuery(cwd)  (only when cwd exists)
  └─ unscoped branch: unchanged (ensureArchonWorkspacesPath())

classifyAndFormatError (error-formatter.ts)
  ├─ [+] missing-scoped-cwd branch (FIRST check — must win over session/sensitive-data branches)
  ├─ session-related branch
  └─ sensitive-data / generic fallback branch
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `orchestrator-agent.ts` (scoped branch) | `fs.existsSync` | **new** | Guard added before provider dispatch |
| `orchestrator-agent.ts` (catch-all) | `error-formatter.ts` | unchanged | Existing catch-all already formats and sends fatal errors |
| `error-formatter.ts` (`classifyAndFormatError`) | new missing-cwd branch | **new** | Inserted as the first check to avoid misclassification |
| `orchestrator-agent.ts` (scoped branch) | Codex/Claude provider `sendQuery` | **modified** | Now unreachable when cwd is missing |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`
- Module: `core:orchestrator`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #1170
- Related #1260 (prior fix for the unscoped docker-entrypoint.sh mkdir gap)
- Depends on #
- Supersedes #

## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check   # all 8 packages exit 0
bun run lint         # 0 errors, 0 warnings (--max-warnings 0)
bun run format:check # all files match Prettier
bun run test         # @archon/core full suite green; 2 pre-existing
                      # Windows-sandbox-only symlink EPERM failures in
                      # unrelated files (binary-resolver.test.ts,
                      # load-command-prompt.test.ts) - CI runs on
                      # Linux/macOS where these are expected to pass
bun run build         # all packages incl. docs-web build cleanly
```

- Evidence provided (test/log/trace/screenshot): Full command output captured during implementation; see `validation.md` in the run artifacts. Mutation-tested the guard by temporarily disabling it (`if (false && !existsSync(cwd))`) — the two new guard tests correctly flipped from pass to fail, confirming they detect the bug.
- If any command is intentionally skipped, explain why: Manual end-to-end reproduction (deleting a registered project directory against a live Docker install with a Codex credential) was not performed — outside the scope of this worktree. The automated tests simulate the exact failure condition (`existsSync` false for the resolved cwd) and assert the provider is never invoked.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No — this narrows access (fails fast instead of attempting to pass a stale path to a subprocess)
- If any Yes, describe risk and mitigation: N/A

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Automated tests cover (1) missing `scopedCodebase.default_cwd`, (2) missing `conversation.cwd` (worktree override case), and (3) a regression guard confirming the unscoped branch remains unguarded (still calls `ensureArchonWorkspacesPath()` to mkdir -p) when `existsSync` is forced false.
- Edge cases checked: Error-formatter branch ordering — verified the new branch is checked before the "session"-substring branch and the sensitive-data/generic fallback branch, since a filesystem path can accidentally contain those substrings (e.g. a path containing "session" or "token") and misroute the message.
- What was not verified: End-to-end Docker/Codex reproduction of the original crash (requires a live Docker build with Codex credentials, outside this worktree).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `packages/core/src/orchestrator/orchestrator-agent.ts` (scoped-codebase chat dispatch path) and `packages/core/src/utils/error-formatter.ts` (error classification). No changes outside `@archon/core`.
- Potential unintended effects: None expected — the guard only adds a fail-fast check on a path that previously always failed downstream anyway (just with a worse error message).
- Guardrails/monitoring for early detection: Existing structured logging in `handleMessage`'s catch-all already logs and surfaces fatal errors to the user; no new monitoring needed.

## Rollback Plan (required)

- Fast rollback command/path: `git revert 980b763f` (single self-contained commit touching 4 files)
- Feature flags or config toggles (if any): None
- Observable failure symptoms: If reverted, scoped chats against a missing cwd would again surface the opaque Codex OS-level error instead of the actionable Archon message.

## Risks and Mitigations

- Risk: The new error-formatter branch could shadow future legitimate messages if it becomes too broad.
  - Mitigation: The branch uses a `startsWith` check against a specific, Archon-generated message prefix rather than a loose substring match, so it can't collide with unrelated error text.
