### PR TITLE
fix(providers/codex): deliver systemPrompt by prepending to the prompt

### DIFF
--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -1542,6 +1542,138 @@ describe('CodexProvider', () => {
       });
     });
 
+    describe('systemPrompt delivery (issue #1837)', () => {
+      // The Codex SDK has no instructions/system-prompt channel, so the
+      // provider must fold systemPrompt into the prompt string it hands to
+      // thread.runStreamed. These tests assert on that SDK boundary.
+      const seedRun = (): void => {
+        mockRunStreamed.mockResolvedValue({
+          events: (async function* () {
+            yield { type: 'turn.completed', usage: defaultUsage };
+          })(),
+        });
+      };
+
+      const drain = async (gen: AsyncGenerator<unknown>): Promise<void> => {
+        for await (const _ of gen) {
+          // consume
+        }
+      };
+
+      test('prepends a string systemPrompt to the prompt with a --- delimiter', async () => {
+        seedRun();
+
+        await drain(
+          client.sendQuery('test prompt', '/workspace', undefined, {
+            systemPrompt: 'AAA routing rules',
+          })
+        );
+
+        expect(mockRunStreamed).toHaveBeenCalledWith(
+          'AAA routing rules\n\n---\n\ntest prompt',
+          expect.anything()
+        );
+      });
+
+      test('joins a string[] systemPrompt with blank lines before prepending', async () => {
+        seedRun();
+
+        await drain(
+          client.sendQuery('test prompt', '/workspace', undefined, {
+            systemPrompt: ['part one', 'part two'],
+          })
+        );
+
+        expect(mockRunStreamed).toHaveBeenCalledWith(
+          'part one\n\npart two\n\n---\n\ntest prompt',
+          expect.anything()
+        );
+      });
+
+      test('drops a Claude-specific preset object with a WARN and keeps the prompt unchanged', async () => {
+        seedRun();
+
+        await drain(
+          client.sendQuery('test prompt', '/workspace', undefined, {
+            systemPrompt: { type: 'preset', preset: 'claude_code', append: 'extra' },
+          })
+        );
+
+        expect(mockRunStreamed).toHaveBeenCalledWith('test prompt', expect.anything());
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          expect.objectContaining({ systemPromptType: 'object' }),
+          'codex.system_prompt_dropped_preset'
+        );
+      });
+
+      test('passes the prompt unchanged when no systemPrompt is set', async () => {
+        seedRun();
+
+        await drain(client.sendQuery('test prompt', '/workspace'));
+
+        expect(mockRunStreamed).toHaveBeenCalledWith('test prompt', expect.anything());
+      });
+
+      test('passes the prompt unchanged when systemPrompt is whitespace-only', async () => {
+        seedRun();
+
+        await drain(
+          client.sendQuery('test prompt', '/workspace', undefined, {
+            systemPrompt: '   ',
+          })
+        );
+
+        expect(mockRunStreamed).toHaveBeenCalledWith('test prompt', expect.anything());
+      });
+
+      test('honors node-level nodeConfig.systemPrompt (workflow path)', async () => {
+        seedRun();
+
+        await drain(
+          client.sendQuery('test prompt', '/workspace', undefined, {
+            nodeConfig: { systemPrompt: 'node-level instructions' },
+          })
+        );
+
+        expect(mockRunStreamed).toHaveBeenCalledWith(
+          'node-level instructions\n\n---\n\ntest prompt',
+          expect.anything()
+        );
+      });
+
+      test('request-level systemPrompt wins over nodeConfig.systemPrompt', async () => {
+        seedRun();
+
+        await drain(
+          client.sendQuery('test prompt', '/workspace', undefined, {
+            systemPrompt: 'request-level',
+            nodeConfig: { systemPrompt: 'node-level' },
+          })
+        );
+
+        expect(mockRunStreamed).toHaveBeenCalledWith(
+          'request-level\n\n---\n\ntest prompt',
+          expect.anything()
+        );
+      });
+
+      test('prepends on resumed threads too (every turn, not first turn only)', async () => {
+        seedRun();
+
+        await drain(
+          client.sendQuery('follow-up prompt', '/workspace', 'existing-session-id', {
+            systemPrompt: 'AAA routing rules',
+          })
+        );
+
+        expect(mockResumeThread).toHaveBeenCalledWith('existing-session-id', expect.anything());
+        expect(mockRunStreamed).toHaveBeenCalledWith(
+          'AAA routing rules\n\n---\n\nfollow-up prompt',
+          expect.anything()
+        );
+      });
+    });
+
     describe('retry behavior', () => {
       test('classifies exit code errors as crash and retries up to 3 times', async () => {
         mockRunStreamed.mockRejectedValue(

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -317,6 +317,46 @@ function buildTurnOptions(requestOptions?: SendQueryOptions): {
   return { turnOptions, hasOutputFormat };
 }
 
+// ─── Effective Prompt Builder ────────────────────────────────────────────
+
+/**
+ * Fold the request/node-level systemPrompt into the user prompt.
+ *
+ * The Codex SDK (verified at @openai/codex-sdk 0.144.4) exposes NO
+ * instructions/system-prompt channel on ThreadOptions or TurnOptions, so the
+ * only delivery mechanism is prepending to the prompt string, separated by
+ * the same `---` delimiter augmentPromptForJsonSchema uses. See issue #1837.
+ *
+ * Precedence mirrors the Pi provider: request-level systemPrompt wins over
+ * node-level. Only string / string[] are supported; SystemPromptPreset
+ * objects are Claude-specific and dropped with a WARN (the orchestrator
+ * already sends non-Claude providers a plain string).
+ *
+ * The prepend intentionally repeats on EVERY turn, including resumed
+ * threads: the provider cannot know whether a resumed session's earlier
+ * turns carried the instructions (the session may predate this fix), and
+ * both the resume-failure fallback and cold retry attempts start fresh
+ * threads where first-turn-only logic would drop the instructions exactly
+ * when they are most needed. This matches Claude, which receives the
+ * systemPrompt on every query.
+ */
+function buildEffectivePrompt(prompt: string, requestOptions?: SendQueryOptions): string {
+  const raw = requestOptions?.systemPrompt ?? requestOptions?.nodeConfig?.systemPrompt;
+  if (raw === undefined) {
+    return prompt;
+  }
+  const systemText =
+    typeof raw === 'string' ? raw : Array.isArray(raw) ? raw.join('\n\n') : undefined;
+  if (systemText === undefined) {
+    getLog().warn({ systemPromptType: typeof raw }, 'codex.system_prompt_dropped_preset');
+    return prompt;
+  }
+  if (systemText.trim() === '') {
+    return prompt;
+  }
+  return `${systemText}\n\n---\n\n${prompt}`;
+}
+
 // ─── Stream Normalizer ───────────────────────────────────────────────────
 
 /** State maintained across Codex event stream normalization. */
@@ -682,6 +722,7 @@ function classifyAndEnrichCodexError(
  * sendQuery orchestrates the following internal helpers:
  * - buildThreadOptions: SDK thread configuration
  * - buildTurnOptions: per-turn configuration (output schema, abort signal)
+ * - buildEffectivePrompt: systemPrompt delivery via prompt prepend (no SDK channel)
  * - streamCodexEvents: raw SDK event normalization into MessageChunks
  * - classifyAndEnrichCodexError: error classification for retry decisions
  */
@@ -809,8 +850,11 @@ export class CodexProvider implements IAgentProvider {
       };
     }
 
-    // 3. Build turn options
+    // 3. Build turn options and the effective prompt (systemPrompt prepend).
+    // Computed once before the retry loop so cold retry attempts, which start
+    // fresh threads, also carry the system instructions.
     const { turnOptions, hasOutputFormat } = buildTurnOptions(requestOptions);
+    const effectivePrompt = buildEffectivePrompt(prompt, requestOptions);
     let lastError: Error | undefined;
 
     for (let attempt = 0; attempt <= MAX_SUBPROCESS_RETRIES; attempt++) {
@@ -853,7 +897,7 @@ export class CodexProvider implements IAgentProvider {
 
         try {
           // 4. Run streamed turn
-          const result = await thread.runStreamed(prompt, turnOptions);
+          const result = await thread.runStreamed(effectivePrompt, turnOptions);
 
           // 5. Stream normalized events (fresh state per attempt to avoid dedup leaks)
           yield* withResumedOutcome(

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -345,8 +345,12 @@ function buildEffectivePrompt(prompt: string, requestOptions?: SendQueryOptions)
   if (raw === undefined) {
     return prompt;
   }
-  const systemText =
-    typeof raw === 'string' ? raw : Array.isArray(raw) ? raw.join('\n\n') : undefined;
+  let systemText: string | undefined;
+  if (typeof raw === 'string') {
+    systemText = raw;
+  } else if (Array.isArray(raw)) {
+    systemText = raw.join('\n\n');
+  }
   if (systemText === undefined) {
     getLog().warn({ systemPromptType: typeof raw }, 'codex.system_prompt_dropped_preset');
     return prompt;


### PR DESCRIPTION
## Summary

- Problem: `CodexProvider.sendQuery` never read `requestOptions.systemPrompt`, so the orchestrator's workflow list + Routing Rules and the run-management CLI section (`buildRunManagementSection`) never reached Codex-backed chats on web, Slack, Telegram, Discord, or CLI — chat-driven workflow routing was silently disabled — and workflow nodes with a node-level `systemPrompt` silently lost it.
- Why it matters: silent degradation of a core feature for every `ai_assistant_type=codex` conversation; the only workaround was the explicit `/workflow run` slash form.
- What changed: new `buildEffectivePrompt()` in the Codex provider folds `requestOptions.systemPrompt ?? nodeConfig.systemPrompt` into the prompt string handed to `thread.runStreamed`, prepended with the `\n\n---\n\n` delimiter already used by `augmentPromptForJsonSchema`. String used as-is, `string[]` joined with blank lines, Claude-specific `SystemPromptPreset` objects dropped with a WARN (Pi precedent). Computed once before the retry loop so cold retry attempts keep the instructions.
- What did **not** change (scope boundary): the SDK call surface (still `startThread`/`resumeThread`/`runStreamed` — verified against the installed `@openai/codex-sdk@0.144.4` that `ThreadOptions`/`TurnOptions` still expose **no** instructions/system-prompt channel, so prompt-prepend is the only delivery mechanism); orchestrator code (`orchestrator-agent.ts` comment cleanup deferred — see below); Pi/Claude/Copilot/OpenCode providers.

## UX Journey

### Before

```
  User (codex chat)      Archon orchestrator                CodexProvider
  ─────────────────      ───────────────────                ─────────────
  "fix github     ────▶  builds systemPrompt string
   issue ..."            (workflow list + Routing Rules
                          + run-management section)
                         sendQuery({ systemPrompt }) ─────▶ [X] systemPrompt never read
                                                            model sees only the raw
                                                            user message
                                                            → answers directly
  gets a direct   ◀───   no /invoke-workflow detected
  answer, no run         no workflow_runs row
```

### After

```
  User (codex chat)      Archon orchestrator                CodexProvider
  ─────────────────      ───────────────────                ─────────────
  "fix github     ────▶  builds systemPrompt string
   issue ..."            sendQuery({ systemPrompt }) ─────▶ *buildEffectivePrompt():
                                                             systemPrompt + "---" +
                                                             user message*
                                                            model sees workflow list
                                                            → emits /invoke-workflow ...
  workflow runs   ◀───   /invoke-workflow detected,
                         workflow dispatched
```

## Architecture Diagram

### Before

```
orchestrator-agent ──systemPrompt──▶ ClaudeProvider ──▶ Claude SDK (system channel)
orchestrator-agent ──systemPrompt──▶ PiProvider     ──▶ Pi SDK (systemPrompt option)
orchestrator-agent ──systemPrompt──▶ CodexProvider --x-- (dropped)
workflow executor ──nodeConfig.systemPrompt──▶ CodexProvider --x-- (dropped)
CodexProvider ──prompt──▶ thread.runStreamed
```

### After

```
orchestrator-agent ──systemPrompt──▶ CodexProvider [~]
workflow executor ──nodeConfig.systemPrompt──▶ CodexProvider [~]
CodexProvider [+ buildEffectivePrompt] ══effectivePrompt══▶ thread.runStreamed
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| core:orchestrator | providers:codex (`sendQuery.requestOptions.systemPrompt`) | **modified** | previously dropped; now folded into the prompt |
| workflows:executor | providers:codex (`nodeConfig.systemPrompt`) | **modified** | node-level systemPrompt now honored (request-level wins) |
| providers:codex | @openai/codex-sdk (`thread.runStreamed`) | **modified** | receives `effectivePrompt` instead of raw `prompt` |
| providers:codex | @openai/codex-sdk (`startThread`/`resumeThread`) | unchanged | thread options untouched |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`
- Module: `providers:codex`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #1837

## Validation Evidence (required)

```bash
bun run validate   # exit 0 — check:bundled, check:bundled-skill, check:bundled-schema,
                   # check:pi-vendor-map, type-check (10 pkgs), lint --max-warnings 0,
                   # format:check, per-package tests all green
bun test packages/providers/src/codex/provider.test.ts   # 76 pass / 0 fail (8 new tests)
```

- Evidence provided: 8 new unit tests in `provider.test.ts` under `describe('systemPrompt delivery (issue #1837)')` asserting on the exact prompt string handed to `thread.runStreamed` — string prepend with delimiter, `string[]` join, preset WARN-drop, unchanged prompt with no/empty systemPrompt, `nodeConfig` path, request-over-node precedence, and resume-turn prepend.
- Intentionally skipped: the issue's cross-package integration test (workflow_runs row on a codex chat) and the stale comment in `orchestrator-agent.ts:1038` ("Codex ignores it") — both outside this PR's surface (`packages/providers/src/codex/**` + tests); the comment cleanup is a trivial follow-up.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — callers that never set a systemPrompt get a byte-identical prompt (regression-guarded by test)
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: SDK-boundary assertions for chat turns (request-level systemPrompt), workflow nodes (node-level), and resumed threads; verified against the installed `@openai/codex-sdk@0.144.4` typings that no first-class instructions option exists (grep over `dist/index.d.ts` for `instruction|systemPrompt|developer` — zero hits) so the prepend remains the correct mechanism after the 0.139 → 0.144.4 bump.
- Edge cases checked: empty/whitespace-only systemPrompt (no stray delimiter), `SystemPromptPreset` object (WARN + passthrough, never throws), retry attempts reuse the effective prompt (computed before the loop).
- What was not verified: live end-to-end smoke with real Codex auth (web/Slack chat emitting `/invoke-workflow` and writing a `workflow_runs` row) — needs an install with Codex credentials.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: every Codex-backed chat turn and every Codex workflow node that carries a systemPrompt now sends it (that is the fix). Prompt grows by the system append (~few KB) per turn.
- Potential unintended effects: on resumed threads the instruction block repeats in history each turn — intentional (see design note below); Codex may occasionally ignore embedded instructions, matching the tradeoff accepted in the issue.
- Guardrails/monitoring for early detection: `codex.system_prompt_dropped_preset` WARN if a Claude preset object ever reaches Codex; existing routing fallback (`archon-assist`) still catches non-routing responses.

## Rollback Plan (required)

- Fast rollback command/path: `git revert` of this single commit — the change is two files, one seam.
- Feature flags or config toggles: none.
- Observable failure symptoms: Codex chats stop emitting `/invoke-workflow` again (routing regression), or malformed prompts visible in Codex turn logs.

## Risks and Mitigations

- Risk: repeating the prepend on every turn of a resumed thread adds tokens and duplicate instruction blocks in history.
  - Mitigation: intentional design — the provider cannot know whether a resumed session's earlier turns carried the instructions (sessions predating this fix), and both the resume-failure fallback and cold retry attempts start fresh threads where first-turn-only logic would drop the instructions exactly when needed. Matches Claude, which receives the systemPrompt on every query. Documented in the `buildEffectivePrompt` doc comment.
- Risk: the SDK later adds a first-class instructions option, making the prepend redundant.
  - Mitigation: `buildEffectivePrompt` is the single seam to swap; its comment records the verified-absent SDK version (0.144.4).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - System instructions are now consistently folded into the prompt sent to Codex.
  - Supports system instructions provided as a single text string or multiple text entries.
  - Request-level instructions take precedence over workflow-level settings.
  - Instructions are preserved across cold retries and resumed sessions.
  - Empty instructions are ignored; unsupported preset formats are skipped with a warning.
- **Tests**
  - Added coverage for system-instruction prompt formatting across new, node-level, request-level, and resumed turns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->