### PR TITLE
fix(workflows): don't thread session ids across provider boundaries in DAG runs

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -11183,6 +11183,9 @@ describe('executeDagWorkflow -- loop_group node', () => {
     ).mock.calls;
     expect(pauseCalls1.length).toBe(1);
     expect(pauseCalls1[0]?.[1]?.sessionId).toBe('lg-resume-sess-1');
+    // The pause payload tags the session with its provider (#1992) so the resume
+    // never threads it into a node that resolves to a different provider.
+    expect(pauseCalls1[0]?.[1]?.sessionProvider).toBe('claude');
 
     // ---- Call 2: resume with metadata.approval carrying iter 1 + user input.
     mockSendQueryDag.mockImplementationOnce(function* () {
@@ -11198,6 +11201,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
           nodeId: 'refine',
           iteration: 1,
           sessionId: 'lg-resume-sess-1',
+          sessionProvider: 'claude',
           message: 'Review.',
         },
         loop_user_input: 'looks great',
@@ -12088,5 +12092,367 @@ describe('resolveBashPath -- platform-aware bash binary resolution (#1326)', () 
       expect(msg).toContain('/definitely/does/not/exist/bash');
       expect(msg).toContain('LOCALAPPDATA');
     }
+  });
+});
+
+describe('executeDagWorkflow -- provider-boundary session threading (#1992)', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `dag-provbound-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(join(testDir, '.archon', 'commands'), { recursive: true });
+    mockSendQueryDag.mockClear();
+    mockGetAgentProviderDag.mockClear();
+    mockGetAgentProviderDag.mockImplementation(() => ({
+      sendQuery: mockSendQueryDag,
+      getType: () => 'claude',
+      getCapabilities: mockClaudeCapabilities,
+    }));
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(testDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  async function runTwoNodeWorkflow(secondNode: DagNode): Promise<void> {
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('provider-boundary-run');
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-prov-bound',
+      testDir,
+      {
+        name: 'dag-provider-boundary',
+        nodes: [{ id: 'a', prompt: 'First step' }, secondNode],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+  }
+
+  it('sequential node on a DIFFERENT provider gets a fresh session (no cross-provider resume)', async () => {
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'step done' };
+      yield { type: 'result', sessionId: 'sess-a' };
+    });
+
+    await runTwoNodeWorkflow({
+      id: 'b',
+      prompt: 'Second step',
+      depends_on: ['a'],
+      provider: 'codex',
+    });
+
+    expect(mockSendQueryDag.mock.calls.length).toBe(2);
+    // Node a (claude) ran fresh; node b (codex) must NOT inherit a's claude session id.
+    expect(mockSendQueryDag.mock.calls[0][2]).toBeUndefined();
+    expect(mockSendQueryDag.mock.calls[1][2]).toBeUndefined();
+  });
+
+  it('sequential node on the SAME provider still threads the session', async () => {
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'step done' };
+      yield { type: 'result', sessionId: 'sess-a' };
+    });
+
+    await runTwoNodeWorkflow({ id: 'b', prompt: 'Second step', depends_on: ['a'] });
+
+    expect(mockSendQueryDag.mock.calls.length).toBe(2);
+    expect(mockSendQueryDag.mock.calls[0][2]).toBeUndefined();
+    expect(mockSendQueryDag.mock.calls[1][2]).toBe('sess-a');
+  });
+
+  it('node after a loop node on a DIFFERENT provider gets a fresh session', async () => {
+    mockSendQueryDag.mockImplementation(function* (prompt: string) {
+      if (prompt.includes('Iterate')) {
+        yield { type: 'assistant', content: 'all done <promise>COMPLETE</promise>' };
+        yield { type: 'result', sessionId: 'loop-sess' };
+      } else {
+        yield { type: 'assistant', content: 'downstream done' };
+        yield { type: 'result', sessionId: 'sess-after' };
+      }
+    });
+
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('provider-boundary-loop-run');
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-prov-bound-loop',
+      testDir,
+      {
+        name: 'dag-provider-boundary-loop',
+        nodes: [
+          {
+            id: 'work',
+            loop: { prompt: 'Iterate until done.', until: 'COMPLETE', max_iterations: 3 },
+          },
+          { id: 'after', prompt: 'Summarize', depends_on: ['work'], provider: 'codex' },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    // 1 loop iteration + 1 downstream call.
+    expect(mockSendQueryDag.mock.calls.length).toBe(2);
+    // Downstream codex node must NOT resume the loop's claude session.
+    expect(mockSendQueryDag.mock.calls[1][2]).toBeUndefined();
+  });
+
+  it('node after a loop node on the SAME provider still threads the loop session', async () => {
+    mockSendQueryDag.mockImplementation(function* (prompt: string) {
+      if (prompt.includes('Iterate')) {
+        yield { type: 'assistant', content: 'all done <promise>COMPLETE</promise>' };
+        yield { type: 'result', sessionId: 'loop-sess' };
+      } else {
+        yield { type: 'assistant', content: 'downstream done' };
+        yield { type: 'result', sessionId: 'sess-after' };
+      }
+    });
+
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('same-provider-loop-run');
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-same-prov-loop',
+      testDir,
+      {
+        name: 'dag-same-provider-loop',
+        nodes: [
+          {
+            id: 'work',
+            loop: { prompt: 'Iterate until done.', until: 'COMPLETE', max_iterations: 3 },
+          },
+          { id: 'after', prompt: 'Summarize', depends_on: ['work'] },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    expect(mockSendQueryDag.mock.calls.length).toBe(2);
+    expect(mockSendQueryDag.mock.calls[1][2]).toBe('loop-sess');
+  });
+
+  it('loop_group body: provider boundaries stay fresh within and across iterations', async () => {
+    // Body: x (claude) -> y (codex), fresh_context: false. y emits DONE on iteration 2.
+    // No call may ever receive a resume id: x->y is a provider boundary within the
+    // iteration, and each cross-iteration handoff (y's codex cursor into x, x's claude
+    // cursor into y) is a provider boundary too.
+    let yCalls = 0;
+    mockSendQueryDag.mockImplementation(function* (prompt: string) {
+      if (prompt.includes('analyze')) {
+        yield { type: 'assistant', content: 'analysis output' };
+        yield { type: 'result', sessionId: 'sess-x' };
+      } else {
+        yCalls++;
+        const content = yCalls === 1 ? 'not finished yet' : 'finished\nDONE';
+        yield { type: 'assistant', content };
+        yield { type: 'result', sessionId: `sess-y-${yCalls}` };
+      }
+    });
+
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('lg-provider-boundary');
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-lg-prov',
+      testDir,
+      {
+        name: 'lg-provider-boundary',
+        nodes: [
+          {
+            id: 'fixer',
+            loop_group: {
+              until: 'DONE',
+              max_iterations: 3,
+              fresh_context: false,
+              nodes: [
+                { id: 'x', prompt: 'analyze the failure', depends_on: [] },
+                {
+                  id: 'y',
+                  prompt: 'apply the fix, emit DONE when green',
+                  depends_on: ['x'],
+                  provider: 'codex',
+                },
+              ],
+            },
+            depends_on: [],
+          },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    // 2 iterations x 2 body nodes = 4 calls, every one fresh.
+    expect(mockSendQueryDag.mock.calls.length).toBe(4);
+    for (const call of mockSendQueryDag.mock.calls) {
+      expect(call[2]).toBeUndefined();
+    }
+  });
+
+  it('loop_group body: same-provider chain still threads within and across iterations', async () => {
+    // Body: x -> y, both claude, fresh_context: false. Threading expectations:
+    // iter1: x fresh, y resumes x's session; iter2 seeds y's iter-1 session into x,
+    // then y resumes x's iter-2 session.
+    let yCalls = 0;
+    mockSendQueryDag.mockImplementation(function* (prompt: string) {
+      if (prompt.includes('analyze')) {
+        yield { type: 'assistant', content: 'analysis output' };
+        yield { type: 'result', sessionId: `sess-x-${String(yCalls + 1)}` };
+      } else {
+        yCalls++;
+        const content = yCalls === 1 ? 'not finished yet' : 'finished\nDONE';
+        yield { type: 'assistant', content };
+        yield { type: 'result', sessionId: `sess-y-${yCalls}` };
+      }
+    });
+
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('lg-same-provider');
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-lg-same',
+      testDir,
+      {
+        name: 'lg-same-provider',
+        nodes: [
+          {
+            id: 'fixer',
+            loop_group: {
+              until: 'DONE',
+              max_iterations: 3,
+              fresh_context: false,
+              nodes: [
+                { id: 'x', prompt: 'analyze the failure', depends_on: [] },
+                { id: 'y', prompt: 'apply the fix, emit DONE when green', depends_on: ['x'] },
+              ],
+            },
+            depends_on: [],
+          },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    expect(mockSendQueryDag.mock.calls.length).toBe(4);
+    const resumeIds = mockSendQueryDag.mock.calls.map(call => call[2]);
+    // iter1: x fresh, y resumes x. iter2: x resumes y's iter-1 session, y resumes x's.
+    expect(resumeIds[0]).toBeUndefined();
+    expect(resumeIds[1]).toBe('sess-x-1');
+    expect(resumeIds[2]).toBe('sess-y-1');
+    expect(resumeIds[3]).toBe('sess-x-2');
+  });
+
+  it('interactive loop_group resume without a provider tag (legacy pause) restores fresh', async () => {
+    // A run paused BEFORE the provider tag existed has approval metadata with a bare
+    // sessionId. Restoring it untagged could thread the session into a different
+    // provider, so the resume starts fresh instead (safe degradation).
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'resumed and finished\nDONE' };
+      yield { type: 'result', sessionId: 'legacy-resume-sess' };
+    });
+
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const resumedRun = makeWorkflowRun('lg-legacy-resume', {
+      metadata: {
+        approval: {
+          type: 'interactive_loop',
+          nodeId: 'refine',
+          iteration: 1,
+          sessionId: 'pre-tag-sess-1', // no sessionProvider — legacy pause
+          message: 'Review.',
+        },
+        loop_user_input: 'continue',
+      },
+    });
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-lg-legacy',
+      testDir,
+      {
+        name: 'lg-legacy-resume',
+        nodes: [
+          {
+            id: 'refine',
+            loop_group: {
+              until: 'DONE',
+              max_iterations: 5,
+              fresh_context: false,
+              interactive: true,
+              gate_message: 'Review.',
+              nodes: [{ id: 'work', prompt: 'Refine the draft.', depends_on: [] }],
+            },
+            depends_on: [],
+          },
+        ],
+      },
+      resumedRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    expect(mockSendQueryDag.mock.calls.length).toBe(1);
+    // The untagged pre-pause session is NOT restored.
+    expect(mockSendQueryDag.mock.calls[0][2]).toBeUndefined();
   });
 });

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -12118,20 +12118,19 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
     }
   });
 
-  async function runTwoNodeWorkflow(secondNode: DagNode): Promise<void> {
+  async function runWorkflow(
+    conversationId: string,
+    workflow: { name: string; nodes: DagNode[] },
+    workflowRun: WorkflowRun
+  ): Promise<WorkflowDeps> {
     const mockDeps = createMockDeps();
     const platform = createMockPlatform();
-    const workflowRun = makeWorkflowRun('provider-boundary-run');
-
     await executeDagWorkflow(
       mockDeps,
       platform,
-      'conv-prov-bound',
+      conversationId,
       testDir,
-      {
-        name: 'dag-provider-boundary',
-        nodes: [{ id: 'a', prompt: 'First step' }, secondNode],
-      },
+      workflow,
       workflowRun,
       'claude',
       undefined,
@@ -12140,6 +12139,18 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
       'main',
       'docs/',
       minimalConfig
+    );
+    return mockDeps;
+  }
+
+  async function runTwoNodeWorkflow(secondNode: DagNode): Promise<void> {
+    await runWorkflow(
+      'conv-prov-bound',
+      {
+        name: 'dag-provider-boundary',
+        nodes: [{ id: 'a', prompt: 'First step' }, secondNode],
+      },
+      makeWorkflowRun('provider-boundary-run')
     );
   }
 
@@ -12186,15 +12197,8 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
       }
     });
 
-    const mockDeps = createMockDeps();
-    const platform = createMockPlatform();
-    const workflowRun = makeWorkflowRun('provider-boundary-loop-run');
-
-    await executeDagWorkflow(
-      mockDeps,
-      platform,
+    await runWorkflow(
       'conv-prov-bound-loop',
-      testDir,
       {
         name: 'dag-provider-boundary-loop',
         nodes: [
@@ -12205,14 +12209,7 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
           { id: 'after', prompt: 'Summarize', depends_on: ['work'], provider: 'codex' },
         ],
       },
-      workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
+      makeWorkflowRun('provider-boundary-loop-run')
     );
 
     // 1 loop iteration + 1 downstream call.
@@ -12232,15 +12229,8 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
       }
     });
 
-    const mockDeps = createMockDeps();
-    const platform = createMockPlatform();
-    const workflowRun = makeWorkflowRun('same-provider-loop-run');
-
-    await executeDagWorkflow(
-      mockDeps,
-      platform,
+    await runWorkflow(
       'conv-same-prov-loop',
-      testDir,
       {
         name: 'dag-same-provider-loop',
         nodes: [
@@ -12251,14 +12241,7 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
           { id: 'after', prompt: 'Summarize', depends_on: ['work'] },
         ],
       },
-      workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
+      makeWorkflowRun('same-provider-loop-run')
     );
 
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
@@ -12283,15 +12266,8 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
       }
     });
 
-    const mockDeps = createMockDeps();
-    const platform = createMockPlatform();
-    const workflowRun = makeWorkflowRun('lg-provider-boundary');
-
-    await executeDagWorkflow(
-      mockDeps,
-      platform,
+    await runWorkflow(
       'conv-lg-prov',
-      testDir,
       {
         name: 'lg-provider-boundary',
         nodes: [
@@ -12315,14 +12291,7 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
           },
         ],
       },
-      workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
+      makeWorkflowRun('lg-provider-boundary')
     );
 
     // 2 iterations x 2 body nodes = 4 calls, every one fresh.
@@ -12349,15 +12318,8 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
       }
     });
 
-    const mockDeps = createMockDeps();
-    const platform = createMockPlatform();
-    const workflowRun = makeWorkflowRun('lg-same-provider');
-
-    await executeDagWorkflow(
-      mockDeps,
-      platform,
+    await runWorkflow(
       'conv-lg-same',
-      testDir,
       {
         name: 'lg-same-provider',
         nodes: [
@@ -12376,14 +12338,7 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
           },
         ],
       },
-      workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
+      makeWorkflowRun('lg-same-provider')
     );
 
     expect(mockSendQueryDag.mock.calls.length).toBe(4);
@@ -12404,26 +12359,8 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
       yield { type: 'result', sessionId: 'legacy-resume-sess' };
     });
 
-    const mockDeps = createMockDeps();
-    const platform = createMockPlatform();
-    const resumedRun = makeWorkflowRun('lg-legacy-resume', {
-      metadata: {
-        approval: {
-          type: 'interactive_loop',
-          nodeId: 'refine',
-          iteration: 1,
-          sessionId: 'pre-tag-sess-1', // no sessionProvider — legacy pause
-          message: 'Review.',
-        },
-        loop_user_input: 'continue',
-      },
-    });
-
-    await executeDagWorkflow(
-      mockDeps,
-      platform,
+    await runWorkflow(
       'conv-lg-legacy',
-      testDir,
       {
         name: 'lg-legacy-resume',
         nodes: [
@@ -12441,18 +12378,72 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
           },
         ],
       },
-      resumedRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
+      makeWorkflowRun('lg-legacy-resume', {
+        metadata: {
+          approval: {
+            type: 'interactive_loop',
+            nodeId: 'refine',
+            iteration: 1,
+            sessionId: 'pre-tag-sess-1', // no sessionProvider — legacy pause
+            message: 'Review.',
+          },
+          loop_user_input: 'continue',
+        },
+      })
     );
 
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
     // The untagged pre-pause session is NOT restored.
     expect(mockSendQueryDag.mock.calls[0][2]).toBeUndefined();
+  });
+
+  it('interactive loop_group gate with no live cursor pauses with EXPLICIT null session fields', async () => {
+    // Body tail is a PARALLEL layer (two sibling nodes, nothing downstream), which
+    // resets the sequential cursor before the gate. The pause payload must write
+    // sessionId/sessionProvider as explicit nulls — key omission would let SQLite's
+    // json_patch deep-merge keep a stale pair from a previous pause of this run
+    // (same convention as ApprovalContext.resolved).
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'checked, not done yet' };
+      yield { type: 'result', sessionId: 'parallel-tail-sess' };
+    });
+
+    const mockDeps = await runWorkflow(
+      'conv-lg-nullpause',
+      {
+        name: 'lg-null-pause',
+        nodes: [
+          {
+            id: 'refine',
+            loop_group: {
+              until: 'DONE',
+              max_iterations: 5,
+              fresh_context: false,
+              interactive: true,
+              gate_message: 'Review.',
+              nodes: [
+                { id: 'lint', prompt: 'run lint checks', depends_on: [] },
+                { id: 'test', prompt: 'run test checks', depends_on: [] },
+              ],
+            },
+            depends_on: [],
+          },
+        ],
+      },
+      makeWorkflowRun('lg-null-pause')
+    );
+
+    const pauseCalls = (
+      mockDeps.store.pauseWorkflowRun as Mock<
+        (id: string, ctx: Record<string, unknown>) => Promise<void>
+      >
+    ).mock.calls;
+    expect(pauseCalls.length).toBe(1);
+    const pauseCtx = pauseCalls[0][1];
+    // Keys present with explicit null — NOT omitted, NOT a live session pair.
+    expect('sessionId' in pauseCtx).toBe(true);
+    expect('sessionProvider' in pauseCtx).toBe(true);
+    expect(pauseCtx.sessionId).toBeNull();
+    expect(pauseCtx.sessionProvider).toBeNull();
   });
 });

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -2512,8 +2512,8 @@ async function executeLoopGroupNode(
   // into a different provider on resume, so those legacy pauses restore fresh instead.
   let loopLastSequentialSession: SequentialSessionCursor | undefined =
     isLoopResume &&
-    loopGateMeta.sessionId !== undefined &&
-    loopGateMeta.sessionProvider !== undefined
+    typeof loopGateMeta.sessionId === 'string' &&
+    typeof loopGateMeta.sessionProvider === 'string'
       ? { sessionId: loopGateMeta.sessionId, provider: loopGateMeta.sessionProvider }
       : undefined;
 
@@ -2882,9 +2882,12 @@ async function executeLoopGroupNode(
         // Persist the body's session cursor so a resumed fresh_context: false loop
         // continues the pre-pause conversation (restored into the cursor on resume).
         // The provider tag rides along so the restore never threads the session into
-        // a different provider (#1992).
-        sessionId: loopLastSequentialSession?.sessionId,
-        sessionProvider: loopLastSequentialSession?.provider,
+        // a different provider (#1992). EXPLICIT null (not key omission) when there
+        // is no cursor — SQLite's json_patch deep-merge would otherwise let a stale
+        // sessionId/sessionProvider from a previous pause of this run survive (same
+        // convention as `resolved`; RFC 7396 null removes the key).
+        sessionId: loopLastSequentialSession?.sessionId ?? null,
+        sessionProvider: loopLastSequentialSession?.provider ?? null,
       });
       getWorkflowEventEmitter().emit({
         type: 'approval_pending',
@@ -3053,7 +3056,9 @@ async function executeLoopNode(
   const loopGateMeta = isApprovalContext(rawApproval) ? rawApproval : undefined;
   const isLoopResume = loopGateMeta?.type === 'interactive_loop' && loopGateMeta.nodeId === node.id;
   const startIteration = isLoopResume ? (loopGateMeta.iteration ?? 0) + 1 : 1;
-  let currentSessionId: string | undefined = isLoopResume ? loopGateMeta.sessionId : undefined;
+  let currentSessionId: string | undefined = isLoopResume
+    ? (loopGateMeta.sessionId ?? undefined)
+    : undefined;
   const loopUserInput = isLoopResume
     ? ((workflowRun.metadata?.loop_user_input as string | undefined) ?? '')
     : '';
@@ -3621,7 +3626,10 @@ async function executeLoopNode(
         message: loop.gate_message,
         type: 'interactive_loop',
         iteration: i,
-        sessionId: currentSessionId,
+        // Explicit null (never key omission) when there is no session — SQLite's
+        // json_patch deep-merge would otherwise let a stale sessionId from a previous
+        // pause of this run survive (same convention as `resolved`).
+        sessionId: currentSessionId ?? null,
       });
       getWorkflowEventEmitter().emit({
         type: 'approval_pending',
@@ -4456,11 +4464,13 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
           // (Claude) or silently cold-falling-back (Codex) on a foreign session id.
           const isFreshSequential = isParallelLayer || node.context === 'fresh';
           const cursor = ctx.lastSequentialSession;
-          const sameProviderCursor = cursor?.provider === provider ? cursor : undefined;
-          let resumeSessionId: string | undefined = isFreshSequential
-            ? undefined
-            : sameProviderCursor?.sessionId;
-          if (!isFreshSequential && cursor !== undefined && sameProviderCursor === undefined) {
+          let resumeSessionId: string | undefined;
+          if (isFreshSequential || cursor === undefined) {
+            resumeSessionId = undefined;
+          } else if (cursor.provider === provider) {
+            resumeSessionId = cursor.sessionId;
+          } else {
+            resumeSessionId = undefined;
             getLog().info(
               { nodeId: node.id, provider, cursorProvider: cursor.provider },
               'dag.session_provider_boundary_fresh'

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -293,6 +293,26 @@ type NodeExecutionResult = NodeOutput & {
   loopIterations?: number;
 };
 
+/**
+ * Sequential-session threading cursor. Tagged with the resolved provider that produced
+ * the session so a downstream sequential node on a DIFFERENT provider starts fresh
+ * instead of attempting an impossible cross-provider resume (#1992) — a foreign session
+ * id hard-fails Claude ("No conversation found with session ID") and cold-falls-back
+ * on Codex.
+ */
+interface SequentialSessionCursor {
+  sessionId: string;
+  provider: string;
+}
+
+/** Per-node result surfaced by a runLayers layer closure. `sessionProvider` tags which
+ *  resolved provider created `output.sessionId` (session-producing paths only). */
+interface LayerNodeResult {
+  nodeId: string;
+  output: NodeExecutionResult;
+  sessionProvider?: string;
+}
+
 /** Throttle state for cancel checks (reads — no write contention in WAL mode) */
 const lastNodeCancelCheck = new Map<string, number>();
 const CANCEL_CHECK_INTERVAL_MS = 10_000;
@@ -2487,9 +2507,15 @@ async function executeLoopGroupNode(
   // fresh_context is true or on iteration 1. runLayers mutates this in place each call.
   // On interactive resume, restore the cursor persisted at pause time so
   // fresh_context: false continues the pre-pause conversation (mirrors executeLoopNode).
-  let loopLastSequentialSessionId: string | undefined = isLoopResume
-    ? loopGateMeta.sessionId
-    : undefined;
+  // The provider tag must be restored WITH the session id (#1992) — metadata from a
+  // pre-tag pause lacks it, and restoring an untagged cursor could thread the session
+  // into a different provider on resume, so those legacy pauses restore fresh instead.
+  let loopLastSequentialSession: SequentialSessionCursor | undefined =
+    isLoopResume &&
+    loopGateMeta.sessionId !== undefined &&
+    loopGateMeta.sessionProvider !== undefined
+      ? { sessionId: loopGateMeta.sessionId, provider: loopGateMeta.sessionProvider }
+      : undefined;
 
   const logEventStoreError = (err: Error, iteration: number): void => {
     getLog().error({ err, nodeId: node.id, iteration }, 'loop_group_node.iteration_event_failed');
@@ -2590,8 +2616,7 @@ async function executeLoopGroupNode(
       // session forward so a body AI node resumes the prior iteration's conversation.
       // Gate on the literal i === 1 (not startIteration): on interactive resume the
       // first processed iteration must continue the restored pre-pause session.
-      lastSequentialSessionId:
-        group.fresh_context || i === 1 ? undefined : loopLastSequentialSessionId,
+      lastSequentialSession: group.fresh_context || i === 1 ? undefined : loopLastSequentialSession,
       totalCostUsd: 0,
       totalTokensIn: 0,
       totalTokensOut: 0,
@@ -2651,7 +2676,7 @@ async function executeLoopGroupNode(
 
     // Carry the body's final sequential session into the next iteration (unless
     // fresh_context forces a reset, handled above by seeding undefined).
-    loopLastSequentialSessionId = iterCtx.lastSequentialSessionId;
+    loopLastSequentialSession = iterCtx.lastSequentialSession;
 
     // Carry prior-iteration snapshot forward for $LOOP_PREV.* on the next iteration.
     loopPrevOutputs = new Map(scopedNodeOutputs);
@@ -2856,7 +2881,10 @@ async function executeLoopGroupNode(
         iteration: i,
         // Persist the body's session cursor so a resumed fresh_context: false loop
         // continues the pre-pause conversation (restored into the cursor on resume).
-        sessionId: loopLastSequentialSessionId,
+        // The provider tag rides along so the restore never threads the session into
+        // a different provider (#1992).
+        sessionId: loopLastSequentialSession?.sessionId,
+        sessionProvider: loopLastSequentialSession?.provider,
       });
       getWorkflowEventEmitter().emit({
         type: 'approval_pending',
@@ -3938,8 +3966,9 @@ interface RunLayersContext {
   nodeOutputs: Map<string, NodeOutput>;
   /** Resume cache: node ids that completed in a prior run (top-level only; undefined for body). */
   priorCompletedNodes?: Map<string, string>;
-  /** Sequential-session threading cursor (mutated by runLayers). */
-  lastSequentialSessionId: string | undefined;
+  /** Sequential-session threading cursor (mutated by runLayers). Provider-tagged so the
+   *  session is only threaded into nodes that resolve to the SAME provider (#1992). */
+  lastSequentialSession: SequentialSessionCursor | undefined;
   /** Run-level usage accumulators (mutated by runLayers; caller reads after). */
   totalCostUsd: number;
   totalTokensIn: number;
@@ -3993,19 +4022,22 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
     stepNamePrefix,
     iteration,
   } = ctx;
-  // nodeOutputs + accumulators + lastSequentialSessionId are mutated in place on `ctx`.
+  // nodeOutputs + accumulators + lastSequentialSession are mutated in place on `ctx`.
 
   for (let layerIdx = 0; layerIdx < layers.length; layerIdx++) {
     const layer = layers[layerIdx];
     const isParallelLayer = layer.length > 1;
 
     if (isParallelLayer) {
-      ctx.lastSequentialSessionId = undefined; // reset — parallel nodes can't share sessions
+      ctx.lastSequentialSession = undefined; // reset — parallel nodes can't share sessions
     }
 
-    // Execute all nodes in the layer concurrently
+    // Execute all nodes in the layer concurrently. `sessionProvider` is the resolved
+    // provider that produced `output.sessionId` — set only by the session-producing
+    // dispatch paths (AI command/prompt nodes and loop nodes) so the cursor write
+    // below can tag the session with its owner (#1992).
     const layerResults = await Promise.allSettled(
-      layer.map(async (node): Promise<{ nodeId: string; output: NodeExecutionResult }> => {
+      layer.map(async (node): Promise<LayerNodeResult> => {
         try {
           // 0. Skip if this node completed successfully in a prior run (resume path).
           // `always_run: true` opts the node out of resume caching — re-execute even
@@ -4252,7 +4284,10 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
               issueContext,
               stepNamePrefix
             );
-            return { nodeId: node.id, output };
+            // Loop nodes run every iteration on the same resolved provider, so the
+            // result session (if any) is attributable to loopProvider — tag it so a
+            // downstream sequential node on a different provider starts fresh (#1992).
+            return { nodeId: node.id, output, sessionProvider: loopProvider };
           }
 
           // 3b'. Loop-group node dispatch — manages its own subgraph iteration
@@ -4414,11 +4449,23 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
           // 5. Determine session — parallel or context:fresh → always fresh
           // Parallel layers always get fresh sessions; explicit 'fresh' context also forces it.
           // 'shared' forces continuation. Default: fresh for parallel, inherited for sequential.
-          // isFreshSequential controls in-run threading (lastSequentialSessionId).
+          // isFreshSequential controls in-run threading (lastSequentialSession).
+          // Cross-provider guard (#1992): a session id can only be resumed by the provider
+          // that created it, so the cursor is threaded only into nodes that resolve to the
+          // SAME provider — on a provider change the node starts fresh instead of failing
+          // (Claude) or silently cold-falling-back (Codex) on a foreign session id.
           const isFreshSequential = isParallelLayer || node.context === 'fresh';
+          const cursor = ctx.lastSequentialSession;
+          const sameProviderCursor = cursor?.provider === provider ? cursor : undefined;
           let resumeSessionId: string | undefined = isFreshSequential
             ? undefined
-            : ctx.lastSequentialSessionId;
+            : sameProviderCursor?.sessionId;
+          if (!isFreshSequential && cursor !== undefined && sameProviderCursor === undefined) {
+            getLog().info(
+              { nodeId: node.id, provider, cursorProvider: cursor.provider },
+              'dag.session_provider_boundary_fresh'
+            );
+          }
 
           // Strictly opt-in: on only when the node sets persist_session (or inherits the
           // workflow-level persist_sessions default) and doesn't opt out via context:'fresh'.
@@ -4624,7 +4671,7 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
             }
           }
 
-          return { nodeId: node.id, output };
+          return { nodeId: node.id, output, sessionProvider: provider };
         } catch (error) {
           const err = error as Error;
           getLog().error({ err, nodeId: node.id }, 'dag_node_pre_execution_failed');
@@ -4664,7 +4711,7 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
     let layerHadFailure = false;
     for (const result of layerResults) {
       if (result.status === 'fulfilled') {
-        const { nodeId, output } = result.value;
+        const { nodeId, output, sessionProvider } = result.value;
         // SINGLE aggregation point for run-level usage telemetry. Per-node
         // cost/tokens must be summed here and ONLY here — adding a per-node
         // telemetry capture elsewhere would double-count against the totals
@@ -4723,7 +4770,13 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
           }
         }
         if (output.state === 'completed' && !isParallelLayer && output.sessionId !== undefined) {
-          ctx.lastSequentialSessionId = output.sessionId;
+          // Tag the cursor with the provider that created the session (#1992). A session
+          // id from a path that can't attest its provider is never threaded — fail-safe:
+          // a fresh downstream session beats a guaranteed-broken cross-provider resume.
+          ctx.lastSequentialSession =
+            sessionProvider !== undefined
+              ? { sessionId: output.sessionId, provider: sessionProvider }
+              : undefined;
         }
         if (output.state === 'failed') layerHadFailure = true;
       } else {
@@ -4887,7 +4940,7 @@ export async function executeDagWorkflow(
   const workflowPersistSessions = workflow.persist_sessions === true;
 
   // Run the topological layers. runLayers mutates the context's mutable fields in place
-  // (nodeOutputs, lastSequentialSessionId, usage accumulators); we read them back below
+  // (nodeOutputs, lastSequentialSession, usage accumulators); we read them back below
   // for the terminal tally. stepNamePrefix is '' for the top-level DAG so node event
   // step_names are the raw node ids (identical to pre-refactor behavior).
   const runCtx: RunLayersContext = {
@@ -4917,7 +4970,7 @@ export async function executeDagWorkflow(
     layers,
     nodeOutputs,
     priorCompletedNodes,
-    lastSequentialSessionId: undefined,
+    lastSequentialSession: undefined,
     totalCostUsd: 0,
     totalTokensIn: 0,
     totalTokensOut: 0,

--- a/packages/workflows/src/schemas/workflow-run.ts
+++ b/packages/workflows/src/schemas/workflow-run.ts
@@ -133,16 +133,22 @@ export interface ApprovalContext {
   type?: 'approval' | 'interactive_loop';
   /** Current loop iteration when paused (interactive loops only). */
   iteration?: number;
-  /** Session ID to restore on resume (interactive loops only). */
-  sessionId?: string;
+  /**
+   * Session ID to restore on resume (interactive loops only). Gate pauses write an
+   * EXPLICIT null (never omit the key) when there is no session to restore — same
+   * json_patch rationale as `resolved` below: on SQLite an omitted key would let a
+   * stale session id from a previous pause of the same run survive the deep-merge.
+   */
+  sessionId?: string | null;
   /**
    * Provider that created `sessionId` (#1992). Persisted by loop_group gates and
    * restored together with the session id so a resumed loop never threads the
    * session into a node that resolves to a different provider (cross-provider
-   * resume is impossible). Absent on single-node loop gates — those restore the
-   * session into the same node, so the provider is the same by construction.
+   * resume is impossible). Same explicit-null-on-pause convention as `sessionId`.
+   * Absent on single-node loop gates — those restore the session into the same
+   * node, so the provider is the same by construction.
    */
-  sessionProvider?: string;
+  sessionProvider?: string | null;
   /** When true, the user's approval comment is stored as `$nodeId.output`. */
   captureResponse?: boolean;
   /** The on_reject prompt template (stored at pause time so reject handlers don't need the workflow def). */

--- a/packages/workflows/src/schemas/workflow-run.ts
+++ b/packages/workflows/src/schemas/workflow-run.ts
@@ -135,6 +135,14 @@ export interface ApprovalContext {
   iteration?: number;
   /** Session ID to restore on resume (interactive loops only). */
   sessionId?: string;
+  /**
+   * Provider that created `sessionId` (#1992). Persisted by loop_group gates and
+   * restored together with the session id so a resumed loop never threads the
+   * session into a node that resolves to a different provider (cross-provider
+   * resume is impossible). Absent on single-node loop gates — those restore the
+   * session into the same node, so the provider is the same by construction.
+   */
+  sessionProvider?: string;
   /** When true, the user's approval comment is stored as `$nodeId.output`. */
   captureResponse?: boolean;
   /** The on_reject prompt template (stored at pause time so reject handlers don't need the workflow def). */


### PR DESCRIPTION
## Summary

- Problem: The DAG executor's sequential-session cursor threads a provider session id into the next node with no provider-equality check. A downstream node on a DIFFERENT resolved provider receives a foreign session id — Claude hard-fails ("No conversation found with session ID"), claude-terminal hangs on the resume picker until boot timeout, Codex silently cold-falls-back.
- Why it matters: Any mixed-provider sequential workflow is broken unless every provider-boundary node is manually annotated with `context: fresh`.
- What changed: The cursor is now provider-tagged (`SequentialSessionCursor { sessionId, provider }`) and threaded only into nodes that resolve to the SAME provider; on a provider change the node starts fresh (logged). The `loop_group` iteration cursor gets the same guard, its interactive-gate pause metadata now persists `sessionProvider` alongside `sessionId`, and loop-node results are tagged with the loop's resolved provider.
- What did **not** change (scope boundary): homogeneous-provider threading (byte-identical behavior, covered by regression tests), `persist_session` storage (already keyed by provider), bash/script/approval dispatch (they never produce session ids; a deterministic node between two same-provider AI nodes still preserves threading), and the bash/script execution region (parallel work in flight).

## UX Journey

### Before

```
  Workflow: nodeA (provider: claude) ──▶ nodeB (provider: codex)
  ────────                              ─────
  nodeA runs, session sess-A created
  cursor := sess-A (untagged)
  nodeB starts with resumeSessionId=sess-A   ◀── foreign session id
  codex/claude-terminal cannot resume it
  ▶ node fails ("No conversation found") / TUI boot timeout / silent cold fallback
  ▶ workflow aborts
```

### After

```
  Workflow: nodeA (provider: claude) ──▶ nodeB (provider: codex)
  ────────                              ─────
  nodeA runs, session sess-A created
  cursor := { sess-A, provider: claude }     ◀── [tagged]
  nodeB resolves provider codex ≠ claude
  ▶ nodeB starts FRESH (no resume id), logs dag.session_provider_boundary_fresh
  ▶ workflow proceeds normally
  (nodeB on claude would still resume sess-A — same-provider threading unchanged)
```

## Architecture Diagram

### Before

```
  runLayers (dag-executor.ts)
    ├── AI node ──▶ executeNodeInternal ──▶ output.sessionId ──▶ ctx.lastSequentialSessionId (string)
    ├── loop node ──▶ executeLoopNode ────▶ output.sessionId ──┘         │
    └── next sequential node ◀── resumeSessionId ◀──────────────────────┘ (no provider check)

  executeLoopGroupNode
    └── loopLastSequentialSessionId (string) ──▶ pause metadata { sessionId } ──▶ resume restore
```

### After

```
  runLayers (dag-executor.ts)
    ├── AI node ──▶ executeNodeInternal ──▶ { output, sessionProvider } ═══▶ [~] ctx.lastSequentialSession
    ├── loop node ─▶ executeLoopNode ─────▶ { output, sessionProvider } ═══▶     { sessionId, provider }
    └── next sequential node ◀── resumeSessionId ◀── [~] same-provider guard ◀──┘

  executeLoopGroupNode
    └── [~] loopLastSequentialSession (tagged) ──▶ pause metadata { sessionId, [+] sessionProvider } ──▶ [~] tagged restore (legacy untagged ⇒ fresh)
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `runLayers` layer closure | cursor write site | **modified** | closure result carries `sessionProvider` (AI + loop paths) |
| cursor | next sequential node | **modified** | threaded only on provider equality |
| `executeLoopGroupNode` | `runLayers` (body) | **modified** | tagged cursor seeded/carried per iteration |
| `executeLoopGroupNode` | `pauseWorkflowRun` metadata | **modified** | persists `sessionProvider` next to `sessionId` |
| `ApprovalContext` (`schemas/workflow-run.ts`) | resume restore | **modified** | optional `sessionProvider` field; untagged legacy pause restores fresh |
| `persist_session` table lookup/upsert | node execution | unchanged | already provider-keyed |
| bash/script/approval dispatch | cursor | unchanged | never produce session ids |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `workflows`
- Module: `workflows:executor`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes #1992
- Related #2050 (closed as a duplicate of #1992 — this PR fixes it too)

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # exit 0 — bundled checks, type-check, lint, format:check, all package tests pass
cd packages/workflows && bun test src/dag-executor.test.ts   # 339 pass, 0 fail
```

- Evidence provided (test/log/trace/screenshot): 7 new tests in `dag-executor.test.ts` under `provider-boundary session threading (#1992)`: mixed-provider sequential pair gets NO resume id; same-provider pair still threads; loop-node → different-provider downstream fresh; loop-node → same-provider downstream threads; loop_group mixed body fresh within AND across iterations; loop_group same-provider body threads across iterations; legacy untagged pause metadata restores fresh. Existing interactive-resume test extended to assert the pause payload carries `sessionProvider`.
- If any command is intentionally skipped, explain why: one `@archon/adapters` GitHub test flaked once in a full-suite run (live-API 401, network-dependent, unrelated package); it passes standalone and in the final full `bun run validate` (exit 0).

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No — the provider tag is a provider id string; session ids keep the existing masking policy in logs (the new boundary log carries provider names only, no session id)
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: n/a

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No — `sessionProvider` is an optional key inside the existing `metadata.approval` JSON; old rows validate unchanged
- If yes, exact upgrade steps: n/a. One deliberate edge: a loop_group run paused BEFORE this change and resumed AFTER it restores the first resumed iteration fresh (the persisted session id has no provider tag, and threading it untagged is exactly the bug). Safe degradation, one-time, interactive loops only.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: traced both cursor write sites and the single read site; confirmed the only session-producing dispatch paths (AI command/prompt nodes, loop nodes) are tagged, and that bash/script nodes still leave the cursor untouched so a deterministic node between two same-provider AI nodes preserves threading.
- Edge cases checked: retry loop still receives the (guarded) resume id; cold-resume warning path unchanged; `persist_session` lookup still overrides the cursor after the guard (already provider-keyed); parallel-layer reset unchanged; SQLite json_patch merge — `sessionProvider` is written in the same pause payload object as `sessionId`.
- What was not verified: a live mixed cursor/claude-terminal run as in the original report (those providers aren't in this repo); the mechanism is provider-agnostic and exercised via claude/codex in tests.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: DAG sequential session threading, loop_group iteration threading, interactive loop_group pause/resume.
- Potential unintended effects: a workflow that (incorrectly) relied on cross-provider inheritance now runs those nodes fresh — that inheritance never worked (resume always failed or fell back cold), so behavior can only improve.
- Guardrails/monitoring for early detection: new `dag.session_provider_boundary_fresh` info log at every guarded boundary; existing cold-resume warning (`dag.session_resume_failed`) would surface any regression in same-provider threading.

## Rollback Plan (required)

- Fast rollback command/path: `git revert` of the single commit; no data migration to unwind (`sessionProvider` in old pause metadata is simply ignored by reverted code).
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: sequential nodes unexpectedly starting fresh on same-provider chains (would show as `isResume: false` where threading is expected, plus missing prior context in node output).

## Risks and Mitigations

- Risk: a session-producing dispatch path added later without a `sessionProvider` tag would stop threading for that path.
  - Mitigation: the write site treats an untagged session as "do not thread" (fail-safe, loudly visible in behavior + covered by the same-provider regression tests), never as "thread blindly".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved workflow session continuity by tracking both session ID and its associated provider across consecutive steps, including loop and interactive `loop_group` flows.

* **Bug Fixes**
  * Prevented resuming with mismatched provider context to avoid cross-provider state carryover.
  * Restores session fields safely (including explicit nulls) so stale session/provider data can’t survive pause/resume merges.
  * Legacy pause metadata without provider info now resumes from a fresh session.

* **Tests**
  * Added provider-boundary session threading coverage for sequential flows, post-loop behavior, and interactive `loop_group` pause/resume compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->