### PR TITLE
ci: free runner disk space before the docker build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The image build needs ~14GB more scratch space than a stock runner has
+      # free once the provider SDKs' multi-platform vendor binaries are in
+      # node_modules. Cached-layer builds squeak by; any PR that invalidates an
+      # early Dockerfile layer (apt block, base image) rebuilds everything and
+      # hits "no space left on device". Reclaim the big unused toolchains first.
+      - name: Free runner disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          df -h /
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
## Summary

- **Problem:** `docker-build` fails with `no space left on device` (reproduced 2× on #2119) whenever a PR invalidates an early Dockerfile layer: the full rebuild — inflated since the provider-SDK bumps (#2105) by multi-platform vendor binaries in `node_modules` — no longer fits in a stock runner's free disk. Cached-layer builds (e.g. #1779, #2118 today) still pass, which masked it.
- **Fix:** reclaim ~25GB of unused preinstalled toolchains (dotnet, Android, GHC, CodeQL) + prune docker images before the build, with a `df -h` line for future debugging.
- **Why this shape:** plain `rm -rf` of the documented big directories — no third-party action dependency, runs in ~30s.

## Testing

- CI on this PR exercises the changed workflow itself; the `df -h` output shows the reclaimed headroom.

## Side effects

- None on the image contents — this only touches the runner's own disk before the build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build reliability by freeing runner disk space before Docker builds.
  * Reduced the likelihood of Docker builds failing due to insufficient storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->