### PR TITLE
fix(providers/pi): per-node extension posture — plannotator planning mode no longer leaks into non-planner nodes

### DIFF
--- a/packages/providers/src/community/pi/config.test.ts
+++ b/packages/providers/src/community/pi/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { parsePiConfig } from './config';
+import { parsePiConfig, resolvePiExtensionSettings } from './config';
 
 describe('parsePiConfig', () => {
   test('parses valid model string', () => {
@@ -185,6 +185,164 @@ describe('parsePiConfig', () => {
       model: 'google/gemini-2.5-pro',
       maxConcurrent: 4,
       enableExtensions: true,
+    });
+  });
+
+  test('parses nodes with per-node overrides', () => {
+    expect(
+      parsePiConfig({
+        extensionFlags: { plan: true },
+        nodes: {
+          implement: { interactive: false, extensionFlags: { plan: false } },
+          plan: { enableExtensions: true },
+        },
+      })
+    ).toEqual({
+      extensionFlags: { plan: true },
+      nodes: {
+        implement: { interactive: false, extensionFlags: { plan: false } },
+        plan: { enableExtensions: true },
+      },
+    });
+  });
+
+  test('drops invalid fields inside a node override silently', () => {
+    expect(
+      parsePiConfig({
+        nodes: {
+          implement: {
+            interactive: 'no',
+            enableExtensions: 1,
+            extensionFlags: { plan: false, bogus: 42 },
+          },
+        },
+      })
+    ).toEqual({ nodes: { implement: { extensionFlags: { plan: false } } } });
+  });
+
+  test('drops node entries with nothing valid and non-object entries', () => {
+    expect(
+      parsePiConfig({
+        nodes: {
+          empty: {},
+          allInvalid: { interactive: 'yes' },
+          notAnObject: 'implement',
+          arr: [1],
+          nullish: null,
+        },
+      })
+    ).toEqual({});
+  });
+
+  test('drops non-object nodes silently', () => {
+    expect(parsePiConfig({ nodes: 'implement' })).toEqual({});
+    expect(parsePiConfig({ nodes: ['implement'] })).toEqual({});
+    expect(parsePiConfig({ nodes: null })).toEqual({});
+  });
+});
+
+describe('resolvePiExtensionSettings', () => {
+  test('defaults: extensions + interactive on, no flags', () => {
+    expect(resolvePiExtensionSettings({}, undefined)).toEqual({
+      enableExtensions: true,
+      interactive: true,
+      extensionFlags: undefined,
+    });
+  });
+
+  test('no nodeId (direct chat) uses assistant-level settings and ignores nodes', () => {
+    expect(
+      resolvePiExtensionSettings(
+        {
+          interactive: true,
+          extensionFlags: { plan: true },
+          nodes: { implement: { interactive: false, extensionFlags: { plan: false } } },
+        },
+        undefined
+      )
+    ).toEqual({
+      enableExtensions: true,
+      interactive: true,
+      extensionFlags: { plan: true },
+    });
+  });
+
+  test('nodeId without a matching override uses assistant-level settings', () => {
+    expect(
+      resolvePiExtensionSettings(
+        {
+          extensionFlags: { plan: true },
+          nodes: { implement: { interactive: false } },
+        },
+        'review'
+      )
+    ).toEqual({
+      enableExtensions: true,
+      interactive: true,
+      extensionFlags: { plan: true },
+    });
+  });
+
+  test('node override turns interactive off for that node only', () => {
+    const config = {
+      interactive: true,
+      nodes: { implement: { interactive: false } },
+    };
+    expect(resolvePiExtensionSettings(config, 'implement').interactive).toBe(false);
+    expect(resolvePiExtensionSettings(config, 'plan').interactive).toBe(true);
+  });
+
+  test('node extensionFlags shallow-merge over base — plan: false negates base plan: true', () => {
+    expect(
+      resolvePiExtensionSettings(
+        {
+          extensionFlags: { plan: true, 'plan-file': 'PLAN.md' },
+          nodes: { implement: { extensionFlags: { plan: false } } },
+        },
+        'implement'
+      ).extensionFlags
+    ).toEqual({ plan: false, 'plan-file': 'PLAN.md' });
+  });
+
+  test('node extensionFlags can grant a flag only to the planner node', () => {
+    const config = { nodes: { plan: { extensionFlags: { plan: true } } } };
+    expect(resolvePiExtensionSettings(config, 'plan').extensionFlags).toEqual({ plan: true });
+    expect(resolvePiExtensionSettings(config, 'implement').extensionFlags).toBeUndefined();
+  });
+
+  test('node enableExtensions: false clamps interactive even when base interactive is true', () => {
+    expect(
+      resolvePiExtensionSettings(
+        { interactive: true, nodes: { implement: { enableExtensions: false } } },
+        'implement'
+      )
+    ).toEqual({
+      enableExtensions: false,
+      interactive: false,
+      extensionFlags: undefined,
+    });
+  });
+
+  test('node interactive: true re-enables UI when base interactive is false', () => {
+    const config = { interactive: false, nodes: { plan: { interactive: true } } };
+    expect(resolvePiExtensionSettings(config, 'plan').interactive).toBe(true);
+    expect(resolvePiExtensionSettings(config, 'implement').interactive).toBe(false);
+  });
+
+  test('base enableExtensions: false clamps interactive unless the node re-enables extensions', () => {
+    const config = {
+      enableExtensions: false,
+      nodes: { plan: { enableExtensions: true, interactive: true } },
+    };
+    expect(resolvePiExtensionSettings(config, 'implement')).toEqual({
+      enableExtensions: false,
+      interactive: false,
+      extensionFlags: undefined,
+    });
+    expect(resolvePiExtensionSettings(config, 'plan')).toEqual({
+      enableExtensions: true,
+      interactive: true,
+      extensionFlags: undefined,
     });
   });
 });

--- a/packages/providers/src/community/pi/config.ts
+++ b/packages/providers/src/community/pi/config.ts
@@ -55,14 +55,18 @@ export function resolvePiExtensionSettings(
   return { enableExtensions, interactive, extensionFlags };
 }
 
-/** Parse one `nodes.<id>` entry; returns undefined when nothing valid is set. */
-function parsePiNodeOverride(raw: Record<string, unknown>): PiNodeOverride | undefined {
-  const override: PiNodeOverride = {};
+/**
+ * Parse the extension-posture fields shared by assistant-level config and
+ * per-node overrides (`PiNodeOverride` deliberately mirrors these three
+ * `PiProviderDefaults` fields — one validation rule, two config levels).
+ */
+function parseExtensionPostureFields(raw: Record<string, unknown>): PiNodeOverride {
+  const parsed: PiNodeOverride = {};
   if (typeof raw.enableExtensions === 'boolean') {
-    override.enableExtensions = raw.enableExtensions;
+    parsed.enableExtensions = raw.enableExtensions;
   }
   if (typeof raw.interactive === 'boolean') {
-    override.interactive = raw.interactive;
+    parsed.interactive = raw.interactive;
   }
   if (
     raw.extensionFlags &&
@@ -76,9 +80,15 @@ function parsePiNodeOverride(raw: Record<string, unknown>): PiNodeOverride | und
       }
     }
     if (Object.keys(flags).length > 0) {
-      override.extensionFlags = flags;
+      parsed.extensionFlags = flags;
     }
   }
+  return parsed;
+}
+
+/** Parse one `nodes.<id>` entry; returns undefined when nothing valid is set. */
+function parsePiNodeOverride(raw: Record<string, unknown>): PiNodeOverride | undefined {
+  const override = parseExtensionPostureFields(raw);
   return Object.keys(override).length > 0 ? override : undefined;
 }
 
@@ -95,29 +105,7 @@ export function parsePiConfig(raw: Record<string, unknown>): ParsedPiConfig {
     result.model = raw.model;
   }
 
-  if (typeof raw.enableExtensions === 'boolean') {
-    result.enableExtensions = raw.enableExtensions;
-  }
-
-  if (typeof raw.interactive === 'boolean') {
-    result.interactive = raw.interactive;
-  }
-
-  if (
-    raw.extensionFlags &&
-    typeof raw.extensionFlags === 'object' &&
-    !Array.isArray(raw.extensionFlags)
-  ) {
-    const flags: Record<string, boolean | string> = {};
-    for (const [key, value] of Object.entries(raw.extensionFlags as Record<string, unknown>)) {
-      if (typeof value === 'boolean' || typeof value === 'string') {
-        flags[key] = value;
-      }
-    }
-    if (Object.keys(flags).length > 0) {
-      result.extensionFlags = flags;
-    }
-  }
+  Object.assign(result, parseExtensionPostureFields(raw));
 
   if (raw.env && typeof raw.env === 'object' && !Array.isArray(raw.env)) {
     const env: Record<string, string> = {};

--- a/packages/providers/src/community/pi/config.ts
+++ b/packages/providers/src/community/pi/config.ts
@@ -3,13 +3,93 @@ import type { PiProviderDefaults } from '../../types';
 export type { PiProviderDefaults };
 
 /**
+ * Per-node override of Pi extension posture, keyed by workflow node id
+ * (`nodeConfig.nodeId`). Lets install-wide extension settings be scoped to the
+ * node that actually plays that role — e.g. only the planner node gets
+ * plannotator's `plan` flag and a UI-capable context, while an `implement`
+ * node runs headless without the planning-mode edit guard (issue #2073).
+ */
+export interface PiNodeOverride {
+  /** Override extension discovery for this node. */
+  enableExtensions?: boolean;
+  /** Override the UIContext binding (`ctx.hasUI`) for this node. */
+  interactive?: boolean;
+  /**
+   * Per-node extension flags, shallow-merged over the assistant-level
+   * `extensionFlags` (node wins). Set a flag to `false` to negate a base
+   * `true` (extensions check `getFlag(name) === true`).
+   */
+  extensionFlags?: Record<string, boolean | string>;
+}
+
+/** parsePiConfig output: assistant-level defaults plus optional per-node overrides. */
+export interface ParsedPiConfig extends PiProviderDefaults {
+  nodes?: Record<string, PiNodeOverride>;
+}
+
+/** Effective extension posture for one sendQuery call. */
+export interface PiExtensionSettings {
+  enableExtensions: boolean;
+  interactive: boolean;
+  extensionFlags: Record<string, boolean | string> | undefined;
+}
+
+/**
+ * Resolve the effective extension posture for a node. Node overrides
+ * (`assistants.pi.nodes.<nodeId>`) win over assistant-level defaults; calls
+ * without a node id (direct chat) always get the assistant-level defaults.
+ * Node ids are matched verbatim across all workflows — treat them as role
+ * names (`plan`, `implement`) when scoping extension behavior.
+ */
+export function resolvePiExtensionSettings(
+  config: ParsedPiConfig,
+  nodeId: string | undefined
+): PiExtensionSettings {
+  const override = nodeId !== undefined ? config.nodes?.[nodeId] : undefined;
+  const enableExtensions = override?.enableExtensions ?? config.enableExtensions !== false;
+  // Clamp to false without extensions: nothing consumes hasUI without a runner.
+  const interactive = enableExtensions && (override?.interactive ?? config.interactive !== false);
+  const extensionFlags = override?.extensionFlags
+    ? { ...config.extensionFlags, ...override.extensionFlags }
+    : config.extensionFlags;
+  return { enableExtensions, interactive, extensionFlags };
+}
+
+/** Parse one `nodes.<id>` entry; returns undefined when nothing valid is set. */
+function parsePiNodeOverride(raw: Record<string, unknown>): PiNodeOverride | undefined {
+  const override: PiNodeOverride = {};
+  if (typeof raw.enableExtensions === 'boolean') {
+    override.enableExtensions = raw.enableExtensions;
+  }
+  if (typeof raw.interactive === 'boolean') {
+    override.interactive = raw.interactive;
+  }
+  if (
+    raw.extensionFlags &&
+    typeof raw.extensionFlags === 'object' &&
+    !Array.isArray(raw.extensionFlags)
+  ) {
+    const flags: Record<string, boolean | string> = {};
+    for (const [key, value] of Object.entries(raw.extensionFlags as Record<string, unknown>)) {
+      if (typeof value === 'boolean' || typeof value === 'string') {
+        flags[key] = value;
+      }
+    }
+    if (Object.keys(flags).length > 0) {
+      override.extensionFlags = flags;
+    }
+  }
+  return Object.keys(override).length > 0 ? override : undefined;
+}
+
+/**
  * Parse raw YAML-derived config into typed Pi defaults.
  * Defensive: invalid fields are dropped silently (matches parseClaudeConfig
  * and parseCodexConfig — never throws, so broken user config can't prevent
  * provider registration or workflow discovery).
  */
-export function parsePiConfig(raw: Record<string, unknown>): PiProviderDefaults {
-  const result: PiProviderDefaults = {};
+export function parsePiConfig(raw: Record<string, unknown>): ParsedPiConfig {
+  const result: ParsedPiConfig = {};
 
   if (typeof raw.model === 'string') {
     result.model = raw.model;
@@ -57,6 +137,20 @@ export function parsePiConfig(raw: Record<string, unknown>): PiProviderDefaults 
     raw.maxConcurrent > 0
   ) {
     result.maxConcurrent = raw.maxConcurrent;
+  }
+
+  if (raw.nodes && typeof raw.nodes === 'object' && !Array.isArray(raw.nodes)) {
+    const nodes: Record<string, PiNodeOverride> = {};
+    for (const [nodeId, value] of Object.entries(raw.nodes as Record<string, unknown>)) {
+      if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+      const override = parsePiNodeOverride(value as Record<string, unknown>);
+      if (override) {
+        nodes[nodeId] = override;
+      }
+    }
+    if (Object.keys(nodes).length > 0) {
+      result.nodes = nodes;
+    }
   }
 
   return result;

--- a/packages/providers/src/community/pi/index.ts
+++ b/packages/providers/src/community/pi/index.ts
@@ -1,5 +1,12 @@
 export { PI_CAPABILITIES } from './capabilities';
-export { parsePiConfig, type PiProviderDefaults } from './config';
+export {
+  parsePiConfig,
+  resolvePiExtensionSettings,
+  type PiProviderDefaults,
+  type ParsedPiConfig,
+  type PiNodeOverride,
+  type PiExtensionSettings,
+} from './config';
 export { PiProvider } from './provider';
 export { registerPiProvider } from './registration';
 export { listPiModels, type PiModelInfo } from './model-catalog';

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -1778,6 +1778,99 @@ describe('PiProvider', () => {
     expect(mockBindExtensions).not.toHaveBeenCalled();
   });
 
+  // ─── Per-node extension posture (assistants.pi.nodes.<nodeId>, #2073) ──
+
+  test('node override drops UIContext and negates the plan flag for that node', async () => {
+    process.env.GEMINI_API_KEY = 'sk-test';
+    resetScript(scriptedAgentEnd());
+
+    await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, {
+        model: 'google/gemini-2.5-pro',
+        assistantConfig: {
+          enableExtensions: true,
+          interactive: true,
+          extensionFlags: { plan: true },
+          nodes: { implement: { interactive: false, extensionFlags: { plan: false } } },
+        },
+        nodeConfig: { nodeId: 'implement' },
+      })
+    );
+
+    // Extensions still load (session_start must fire) but with no UIContext —
+    // hasUI stays false so plannotator won't open its blocking review server.
+    expect(mockBindExtensions).toHaveBeenCalledTimes(1);
+    const [bindings] = mockBindExtensions.mock.calls[0] as [{ uiContext?: unknown }];
+    expect(bindings.uiContext).toBeUndefined();
+    // Merged flags: node-level plan: false wins over assistant-level plan: true.
+    expect(mockSetFlagValue).toHaveBeenCalledTimes(1);
+    expect(mockSetFlagValue).toHaveBeenCalledWith('plan', false);
+  });
+
+  test('node without an override keeps assistant-level UIContext and flags', async () => {
+    process.env.GEMINI_API_KEY = 'sk-test';
+    resetScript(scriptedAgentEnd());
+
+    await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, {
+        model: 'google/gemini-2.5-pro',
+        assistantConfig: {
+          enableExtensions: true,
+          interactive: true,
+          extensionFlags: { plan: true },
+          nodes: { implement: { interactive: false, extensionFlags: { plan: false } } },
+        },
+        nodeConfig: { nodeId: 'plan' },
+      })
+    );
+
+    expect(mockBindExtensions).toHaveBeenCalledTimes(1);
+    const [bindings] = mockBindExtensions.mock.calls[0] as [{ uiContext?: unknown }];
+    expect(bindings.uiContext).toBeDefined();
+    expect(mockSetFlagValue).toHaveBeenCalledTimes(1);
+    expect(mockSetFlagValue).toHaveBeenCalledWith('plan', true);
+  });
+
+  test('direct chat (no nodeConfig) ignores nodes overrides', async () => {
+    process.env.GEMINI_API_KEY = 'sk-test';
+    resetScript(scriptedAgentEnd());
+
+    await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, {
+        model: 'google/gemini-2.5-pro',
+        assistantConfig: {
+          interactive: true,
+          nodes: { implement: { interactive: false } },
+        },
+      })
+    );
+
+    expect(mockBindExtensions).toHaveBeenCalledTimes(1);
+    const [bindings] = mockBindExtensions.mock.calls[0] as [{ uiContext?: unknown }];
+    expect(bindings.uiContext).toBeDefined();
+  });
+
+  test('node enableExtensions: false skips binding entirely for that node', async () => {
+    process.env.GEMINI_API_KEY = 'sk-test';
+    resetScript(scriptedAgentEnd());
+
+    await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, {
+        model: 'google/gemini-2.5-pro',
+        assistantConfig: {
+          enableExtensions: true,
+          interactive: true,
+          extensionFlags: { plan: true },
+          nodes: { implement: { enableExtensions: false } },
+        },
+        nodeConfig: { nodeId: 'implement' },
+      })
+    );
+
+    expect(mockBindExtensions).not.toHaveBeenCalled();
+    expect(mockSetFlagValue).not.toHaveBeenCalled();
+  });
+
   test('assistantConfig.env applies to process.env when not already set', async () => {
     process.env.GEMINI_API_KEY = 'sk-test';
     delete process.env.PI_TEST_ONE;

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -16,7 +16,7 @@ import type {
 } from '../../types';
 
 import { PI_CAPABILITIES } from './capabilities';
-import { parsePiConfig } from './config';
+import { parsePiConfig, resolvePiExtensionSettings } from './config';
 import { parsePiModelRef } from './model-ref';
 import { withResumedOutcome, resumedOutcome } from '../../shared/resumed';
 
@@ -458,9 +458,16 @@ export class PiProvider implements IAgentProvider {
     // `assistants.pi.enableExtensions: false` (or `interactive: false`) in
     // `.archon/config.yaml`. Previously default-off, which silently broke
     // users who installed or built an extension and expected it to fire.
-    const enableExtensions = piConfig.enableExtensions !== false;
-    // Clamp to false without extensions: nothing consumes hasUI without a runner.
-    const interactive = enableExtensions && piConfig.interactive !== false;
+    //
+    // Extension posture is resolved PER NODE (issue #2073): assistant-level
+    // defaults can be overridden via `assistants.pi.nodes.<nodeId>` so that
+    // e.g. only the planner node gets plannotator's `plan` flag and a
+    // UI-capable context (hasUI), while an implement node runs without the
+    // planning-mode edit guard. Direct chat (no nodeId) uses the defaults.
+    const { enableExtensions, interactive, extensionFlags } = resolvePiExtensionSettings(
+      piConfig,
+      nodeConfig?.nodeId
+    );
 
     // Build the ResourceLoader. When extensions are ON we MUST reuse a
     // process-cached, already-reloaded loader: Pi's `reload()` re-invokes every
@@ -522,6 +529,7 @@ export class PiProvider implements IAgentProvider {
         missingSkillCount: missingSkills.length,
         extensionsEnabled: enableExtensions,
         interactive,
+        nodeId: nodeConfig?.nodeId,
         resumed: resumeSessionId !== undefined && !resumeFailed,
       },
       'pi.session_started'
@@ -576,10 +584,12 @@ export class PiProvider implements IAgentProvider {
 
     // 4e. Extension flag pass-through. Must happen before bindExtensions
     //     below — extensions read flags inside their session_start handler.
-    if (enableExtensions && piConfig.extensionFlags) {
+    //     `extensionFlags` is the per-node resolved map (assistant-level flags
+    //     shallow-merged with `nodes.<nodeId>.extensionFlags`, node wins).
+    if (enableExtensions && extensionFlags) {
       const runner = session.extensionRunner;
       if (runner) {
-        for (const [name, value] of Object.entries(piConfig.extensionFlags)) {
+        for (const [name, value] of Object.entries(extensionFlags)) {
           runner.setFlagValue(name, value);
         }
       }


### PR DESCRIPTION
## Summary

- Problem: Pi extension posture (`interactive`/hasUI, `extensionFlags` like plannotator's `plan`, `enableExtensions`) is derived exclusively from install-wide `assistants.pi` config, so EVERY Pi workflow node inherits it — a non-planner `implement` loop node starts in plannotator planning mode, gets its code edits blocked ("edits are limited to markdown files"), and hangs forever when the confused model calls `plannotator_submit_plan` (hasUI=true opens a blocking browser review server).
- Why it matters: any install following Archon's own documented plannotator setup (`extensionFlags: { plan: true }` install-wide) cannot run a plan→implement workflow — the implement phase deadlocks; the only workaround is manually POSTing approve to the spurious review server.
- What changed: extension posture is now resolved **per node**. New `assistants.pi.nodes.<nodeId>` config overrides `enableExtensions`, `interactive`, and `extensionFlags` (shallow-merged, node wins — `plan: false` negates a base `plan: true`). The provider resolves effective settings per `sendQuery` from `nodeConfig.nodeId` (already delivered by the DAG executor).
- What did **not** change (scope boundary): only `packages/providers/src/community/pi/**` + tests. No dag-executor, workflow-schema, or Claude-provider changes (owned by parallel work streams). No behavior change for direct chat or for nodes without an override (byte-for-byte). No new `reload()` calls (#1877 single-reload constraint respected); #2111 registration re-apply untouched.

## UX Journey

### Before

```
  User                          Archon (Pi provider)              plannotator ext
  ────                          ────────────────────              ───────────────
  runs plan→implement workflow
    plan node ────────────────▶ flags: plan=true, hasUI=true ───▶ planning mode ✓ (intended)
    implement node ───────────▶ flags: plan=true, hasUI=true ───▶ planning mode ✗ (leaked!)
                                edit app/src/main.py ◀────────── BLOCKED (.md only)
                                plannotator_submit_plan ◀─────── opens review server
  run hangs forever ◀────────── (nobody will ever approve)
```

### After

```
  User                          Archon (Pi provider)              plannotator ext
  ────                          ────────────────────              ───────────────
  config: nodes.implement:
    interactive: false
    extensionFlags: {plan: false}
  runs plan→implement workflow
    plan node ────────────────▶ flags: plan=true, hasUI=true ───▶ planning mode ✓
    implement node ───────────▶ [flags: plan=false, hasUI=false]▶ [idle phase]
                                edit app/src/main.py ◀────────── [allowed ✓]
  implement completes ◀──────── code edits + commit proceed
```

## Architecture Diagram

### Before

```
  dag-executor ──(assistantConfig = assistants.pi, identical per node)──▶ PiProvider.sendQuery
                                                                             │
                                              parsePiConfig ─▶ install-wide enableExtensions/
                                                               interactive/extensionFlags
                                                                             │
                                                     bindExtensions({uiContext}) + setFlagValue
```

### After

```
  dag-executor ──(assistantConfig incl. [+]nodes map; nodeConfig.nodeId)──▶ PiProvider.sendQuery
                                                                              │
                       [~]parsePiConfig (parses nodes:) ─▶ [+]resolvePiExtensionSettings(config, nodeId)
                                                                              │
                                                  per-node enableExtensions/interactive/extensionFlags
                                                                              │
                                                      bindExtensions({uiContext?}) + setFlagValue
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `pi/provider.ts` | `pi/config.ts` | **modified** | now also imports `resolvePiExtensionSettings`; posture resolved per `nodeConfig.nodeId` |
| `dag-executor` | `pi/provider.ts` | unchanged | `nodes:` rides the existing `assistantConfig` spread; `nodeId` already flowed |
| `pi/provider.ts` | Pi SDK `bindExtensions`/`setFlagValue` | **modified** | driven by resolved per-node settings instead of install-wide config |
| `pi/index.ts` | `pi/config.ts` | **modified** | exports new resolver + types |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`
- Module: `providers:pi`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #2073
- Related #1299 (introduced the assistant-level `interactive` UIContext binding), #1877 (single-reload constraint — respected), #2111 (registration re-apply — untouched)

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # all green: check:bundled, check:bundled-skill, check:bundled-schema,
                   # check:pi-vendor-map, type-check, lint, format:check, tests
bun test packages/providers/src/community/pi/config.test.ts \
         packages/providers/src/community/pi/provider.test.ts   # 125 pass, 0 fail
```

- Evidence provided (test/log/trace/screenshot): new config parse/resolution matrix tests + provider wiring tests (UIContext dropped and `plan` flag negated for overridden node; unchanged for other nodes and direct chat; `enableExtensions: false` per node skips binding).
- If any command is intentionally skipped, explain why: n/a.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation: n/a. Per-node `interactive: true` can re-enable the UI bridge where base config disabled it — same capability the base flag already grants, now scopeable more narrowly.

## Compatibility / Migration

- Backward compatible? (`Yes`) — configs without `nodes:` behave byte-for-byte identically; unknown/invalid `nodes:` entries are dropped silently per parsePiConfig's documented never-throw convention.
- Config/env changes? (`Yes`) — new optional `assistants.pi.nodes.<nodeId>` key; no changes required for existing installs.
- Database migration needed? (`No`)
- If yes, exact upgrade steps: to fix the reported scenario, add to `.archon/config.yaml`:

```yaml
assistants:
  pi:
    extensionFlags:
      plan: true
    nodes:
      implement:
        interactive: false
        extensionFlags:
          plan: false
```

(or grant `plan`/`interactive` only under `nodes.plan` and drop the install-wide flag entirely.)

## Human Verification (required)

- Verified scenarios: root cause verified against `@plannotator/pi-extension` 0.23.1 source — planning phase is gated on `pi.getFlag("plan")` in `session_start`, the write gate fires purely on `phase === "planning"`, and the review server opens only when `ctx.hasUI` is true. Resolver semantics covered by unit-test matrix; provider wiring covered by mocked-SDK tests asserting `bindExtensions`/`setFlagValue` args per node.
- Edge cases checked: direct chat (no nodeId) ignores `nodes:`; unknown nodeId falls back to base; `enableExtensions: false` override clamps `interactive` and skips binding; flag negation (`plan: false`) merges over base `plan: true`; malformed `nodes:` config dropped without throwing.
- What was not verified: live end-to-end run with plannotator installed (extension is not on this machine); node ids are matched verbatim across all workflows — two workflows sharing an id share the override (documented in the resolver's JSDoc).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Pi provider sessions only (workflow nodes + direct chat). Claude/Codex/OpenCode/Copilot untouched.
- Potential unintended effects: a `nodes.<id>` override applies to every workflow with a node of that id — intentional (ids act as role names), documented.
- Guardrails/monitoring for early detection: `pi.session_started` log now includes `nodeId` alongside `extensionsEnabled`/`interactive`, so per-node posture is auditable per session.

## Rollback Plan (required)

- Fast rollback command/path: revert the single PR commit; the `nodes:` config key becomes an ignored unknown field (parsePiConfig drops it silently), so rollback cannot break configs that adopted it.
- Feature flags or config toggles (if any): the feature is inert unless `assistants.pi.nodes` is set.
- Observable failure symptoms: implement-style nodes still hitting "Plannotator: during planning, edits are limited to markdown files" or hanging on `plannotator_submit_plan`.

## Risks and Mitigations

- Risk: docs (`ai-assistants.md` plannotator example) still recommend install-wide `extensionFlags: { plan: true }`, which reproduces the bug for plan→implement workflows.
  - Mitigation: out of surface for this PR (providers/pi only); follow-up docs change should scope the example via `nodes:`.
- Risk: node-id-keyed overrides are global across workflows.
  - Mitigation: documented in `PiNodeOverride`/resolver JSDoc; a first-class engine-level `planning:` node flag remains an open future seam (noted in the issue).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-node configuration for Pi extensions, including effective resolution of enablement, interactivity, and extension flags.
  * Node-specific settings override assistant defaults; direct chats (no node) continue using assistant-level defaults.
  * Extension flags now follow the selected node’s effective configuration.
* **Bug Fixes**
  * Nodes with extensions disabled no longer bind extensions or receive extension flags.
  * Invalid or empty node configuration entries are ignored.
* **Tests**
  * Added coverage for per-node override semantics and flag merging/precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->