### PR TITLE
fix(providers): throw on Claude API errors surfaced as text instead of completing them

### DIFF
--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -1955,3 +1955,259 @@ describe('sendQuery decomposition behaviors', () => {
     });
   });
 });
+
+// ─── API errors surfaced as text (#1797) ─────────────────────────────────
+// The SDK does not throw on API-level failures (auth, billing, rate limit).
+// It synthesizes an assistant message (model: '<synthetic>', wrapper
+// `error` code) with the error prose, then emits a result with
+// subtype: 'success' AND is_error: true — the same field pair as the
+// legitimate stop-sequence carve-out (#1425). Shapes below are verbatim
+// captures from claude CLI 2.1.210 (isolated config dir).
+
+describe('API error surfaced as text (#1797)', () => {
+  let client: ClaudeProvider;
+
+  beforeEach(() => {
+    client = new ClaudeProvider({ retryBaseDelayMs: 1 });
+    mockQuery.mockClear();
+    mockLogger.info.mockClear();
+    mockLogger.warn.mockClear();
+    mockLogger.error.mockClear();
+    mockLogger.debug.mockClear();
+  });
+
+  interface CollectedStream {
+    chunks: Array<Record<string, unknown>>;
+    error?: Error;
+  }
+
+  async function collect(gen: AsyncIterable<Record<string, unknown>>): Promise<CollectedStream> {
+    const chunks: Array<Record<string, unknown>> = [];
+    try {
+      for await (const chunk of gen) {
+        chunks.push(chunk);
+      }
+    } catch (e) {
+      return { chunks, error: e as Error };
+    }
+    return { chunks };
+  }
+
+  function syntheticAssistantMessage(errorCode: string, text: string): Record<string, unknown> {
+    return {
+      type: 'assistant',
+      message: {
+        model: '<synthetic>',
+        stop_reason: 'stop_sequence',
+        content: [{ type: 'text', text }],
+        usage: { input_tokens: 0, output_tokens: 0 },
+      },
+      error: errorCode,
+      session_id: 'sid-api-err',
+    };
+  }
+
+  function apiErrorResult(text: string): Record<string, unknown> {
+    return {
+      type: 'result',
+      subtype: 'success',
+      is_error: true,
+      api_error_status: null,
+      result: text,
+      stop_reason: 'stop_sequence',
+      terminal_reason: 'api_error',
+      total_cost_usd: 0,
+      session_id: 'sid-api-err',
+    };
+  }
+
+  test('auth error (Not logged in) throws instead of completing with poisoned output', async () => {
+    mockQuery.mockImplementation(async function* () {
+      yield syntheticAssistantMessage('authentication_failed', 'Not logged in · Please run /login');
+      yield apiErrorResult('Not logged in · Please run /login');
+    });
+
+    const { chunks, error } = await collect(client.sendQuery('test', '/workspace'));
+
+    expect(error).toBeDefined();
+    expect(error?.message).toContain('Claude API error (authentication_failed)');
+    expect(error?.message).toContain('Not logged in');
+    // The poison: no assistant chunk carrying the error prose, no result chunk
+    expect(chunks.filter(c => c.type === 'assistant')).toHaveLength(0);
+    expect(chunks.filter(c => c.type === 'result')).toHaveLength(0);
+    // Auth errors are non-retryable — a single attempt only
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ errorCode: 'authentication_failed' }),
+      'claude.result_api_error'
+    );
+  });
+
+  test('invalid API key (401) shape throws a non-retryable auth error', async () => {
+    mockQuery.mockImplementation(async function* () {
+      yield syntheticAssistantMessage(
+        'authentication_failed',
+        'Invalid API key · Fix external API key'
+      );
+      yield {
+        ...apiErrorResult('Invalid API key · Fix external API key'),
+        api_error_status: 401,
+      };
+    });
+
+    const { error } = await collect(client.sendQuery('test', '/workspace'));
+    expect(error?.message).toContain('Claude API error (authentication_failed)');
+    expect(error?.message).toContain('Invalid API key');
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  test('api_error result without a preceding synthetic message still throws (belt-and-suspenders)', async () => {
+    mockQuery.mockImplementation(async function* () {
+      yield apiErrorResult('Something went wrong upstream');
+    });
+
+    const { chunks, error } = await collect(client.sendQuery('test', '/workspace'));
+    expect(error?.message).toContain('Claude API error (unknown)');
+    expect(error?.message).toContain('Something went wrong upstream');
+    expect(chunks.filter(c => c.type === 'result')).toHaveLength(0);
+  });
+
+  test('synthetic rate_limit error retries per existing subprocess policy, then throws', async () => {
+    mockQuery.mockImplementation(async function* () {
+      yield syntheticAssistantMessage('rate_limit', 'Rate limited · Try again later');
+      yield apiErrorResult('Rate limited · Try again later');
+    });
+
+    const { error } = await collect(client.sendQuery('test', '/workspace'));
+    expect(error?.message).toContain('Claude API error (rate_limit)');
+    // MAX_SUBPROCESS_RETRIES = 3 → 4 attempts total
+    expect(mockQuery).toHaveBeenCalledTimes(4);
+  }, 5_000);
+
+  test('legitimate output that merely mentions the error phrases is untouched', async () => {
+    // A real model turn (real model id, no wrapper error field, clean result)
+    // whose TEXT happens to discuss login errors — e.g. a node writing docs
+    // about auth failures. Must flow through as a normal success.
+    mockQuery.mockImplementation(async function* () {
+      yield {
+        type: 'assistant',
+        message: {
+          model: 'claude-sonnet-4-5',
+          content: [
+            {
+              type: 'text',
+              text: 'If auth fails you may see "Not logged in · Please run /login".',
+            },
+          ],
+        },
+        session_id: 'sid-legit',
+      };
+      yield {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        result: 'done',
+        session_id: 'sid-legit',
+      };
+    });
+
+    const { chunks, error } = await collect(client.sendQuery('test', '/workspace'));
+    expect(error).toBeUndefined();
+    expect(
+      chunks.some(c => typeof c.content === 'string' && c.content.includes('Not logged in'))
+    ).toBe(true);
+    const result = chunks.find(c => c.type === 'result');
+    expect(result).toBeDefined();
+    expect(result).not.toHaveProperty('isError');
+  });
+
+  test('#1425 stop-sequence carve-out is preserved (is_error + subtype success without API-error signals)', async () => {
+    mockQuery.mockImplementation(async function* () {
+      yield {
+        type: 'assistant',
+        message: {
+          model: 'claude-sonnet-4-5',
+          content: [{ type: 'text', text: 'Rate limit guidance: back off exponentially.' }],
+        },
+        session_id: 'sid-stop-seq',
+      };
+      yield {
+        type: 'result',
+        subtype: 'success',
+        is_error: true,
+        stop_reason: 'stop_sequence',
+        session_id: 'sid-stop-seq',
+      };
+    });
+
+    const { chunks, error } = await collect(client.sendQuery('test', '/workspace'));
+    expect(error).toBeUndefined();
+    const result = chunks.find(c => c.type === 'result');
+    expect(result).toBeDefined();
+    expect(result).not.toHaveProperty('isError');
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'sid-stop-seq' }),
+      'claude.result_success_validated'
+    );
+  });
+
+  test('real-model message carrying an error code (e.g. max_output_tokens) is not suppressed', async () => {
+    // A REAL (non-synthetic) message can carry a wrapper error code alongside
+    // genuine truncated output. Only '<synthetic>' content is SDK error prose.
+    mockQuery.mockImplementation(async function* () {
+      yield {
+        type: 'assistant',
+        message: {
+          model: 'claude-sonnet-4-5',
+          content: [{ type: 'text', text: 'partial output before truncation' }],
+        },
+        error: 'max_output_tokens',
+        session_id: 'sid-trunc',
+      };
+      yield {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        session_id: 'sid-trunc',
+      };
+    });
+
+    const { chunks, error } = await collect(client.sendQuery('test', '/workspace'));
+    expect(error).toBeUndefined();
+    expect(chunks.some(c => c.content === 'partial output before truncation')).toBe(true);
+  });
+
+  test('fail-safe: synthetic error contradicted by a clean result yields the withheld text late', async () => {
+    mockQuery.mockImplementation(async function* () {
+      yield syntheticAssistantMessage('server_error', 'Upstream hiccup');
+      yield {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        session_id: 'sid-recovered',
+      };
+    });
+
+    const { chunks, error } = await collect(client.sendQuery('test', '/workspace'));
+    expect(error).toBeUndefined();
+    expect(chunks.some(c => c.type === 'assistant' && c.content === 'Upstream hiccup')).toBe(true);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ errorCode: 'server_error' }),
+      'claude.synthetic_error_not_confirmed'
+    );
+  });
+
+  test('stream ending after a synthetic error without a result throws', async () => {
+    mockQuery.mockImplementation(async function* () {
+      yield syntheticAssistantMessage('billing_error', 'Credit balance is too low');
+      // stream ends abnormally — no result event
+    });
+
+    const { chunks, error } = await collect(client.sendQuery('test', '/workspace'));
+    expect(error?.message).toContain('Claude API error (billing_error)');
+    expect(error?.message).toContain('Credit balance is too low');
+    expect(chunks.filter(c => c.type === 'assistant')).toHaveLength(0);
+    // billing_error classifies as auth → non-retryable
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -34,6 +34,7 @@ import {
   type HookCallback,
   type HookCallbackMatcher,
   type SDKAssistantMessageError,
+  type TerminalReason,
 } from '@anthropic-ai/claude-agent-sdk';
 import type {
   IAgentProvider,
@@ -145,10 +146,12 @@ function classifySubprocessError(
  * This error carries the SDK's typed error code so retry classification is
  * structural — never matched against the message text.
  */
-export class ClaudeApiResultError extends Error {
-  readonly sdkErrorCode: SDKAssistantMessageError | 'unknown';
+type SdkErrorCode = SDKAssistantMessageError | 'unknown';
 
-  constructor(sdkErrorCode: SDKAssistantMessageError | 'unknown', resultText: string) {
+export class ClaudeApiResultError extends Error {
+  readonly sdkErrorCode: SdkErrorCode;
+
+  constructor(sdkErrorCode: SdkErrorCode, resultText: string) {
     super(`Claude API error (${sdkErrorCode}): ${resultText}`);
     this.name = 'ClaudeApiResultError';
     this.sdkErrorCode = sdkErrorCode;
@@ -162,9 +165,7 @@ export class ClaudeApiResultError extends Error {
  * rate_limit/crash backoff. Everything else is 'unknown' — fail fast rather
  * than retry blindly.
  */
-function classifySdkErrorCode(
-  code: SDKAssistantMessageError | 'unknown'
-): 'rate_limit' | 'auth' | 'crash' | 'unknown' {
+function classifySdkErrorCode(code: SdkErrorCode): 'rate_limit' | 'auth' | 'crash' | 'unknown' {
   switch (code) {
     case 'authentication_failed':
     case 'oauth_org_not_allowed':
@@ -885,7 +886,7 @@ async function* streamClaudeMessages(
         num_turns?: number;
         errors?: string[];
         result?: string;
-        terminal_reason?: string;
+        terminal_reason?: TerminalReason;
         api_error_status?: number | null;
         model_usage?: Record<
           string,
@@ -906,15 +907,16 @@ async function* streamClaudeMessages(
       // `is_error: true` + `subtype: 'success'` is ambiguous: it is BOTH the
       // SDK's stop-sequence termination encoding (#1425, a legitimate success)
       // AND its API-failure-as-text encoding (#1797 — auth/billing/rate-limit
-      // errors that even set stop_reason: 'stop_sequence'). Disambiguate
-      // structurally: a preceding synthetic error message (primary, typed
-      // signal), or terminal_reason 'api_error' (secondary — observed at
-      // runtime on API failures but not yet in the SDK's TerminalReason d.ts
-      // union), marks a real failure. Throw so callers fail the node/turn
+      // errors that even set stop_reason: 'stop_sequence').
+      const isSuccessWithErrorFlag = resultMsg.is_error === true && resultMsg.subtype === 'success';
+
+      // Disambiguate structurally: a preceding synthetic error message
+      // (primary, typed signal), or the typed terminal_reason 'api_error'
+      // (secondary — catches an error result with no preceding synthetic
+      // message), marks a real failure. Throw so callers fail the node/turn
       // instead of consuming error prose as successful output.
       if (
-        resultMsg.is_error === true &&
-        resultMsg.subtype === 'success' &&
+        isSuccessWithErrorFlag &&
         (syntheticError !== undefined || resultMsg.terminal_reason === 'api_error')
       ) {
         const code = syntheticError?.code ?? 'unknown';
@@ -953,7 +955,7 @@ async function* streamClaudeMessages(
       // subtype: 'success' — its encoding of "non-default termination, not a
       // failure". Treat that pair as a clean success so downstream consumers
       // (which gate failure on isError) don't misclassify it.
-      const isRealError = resultMsg.is_error === true && resultMsg.subtype !== 'success';
+      const isRealError = resultMsg.is_error === true && !isSuccessWithErrorFlag;
       if (isRealError) {
         getLog().error(
           {
@@ -964,7 +966,7 @@ async function* streamClaudeMessages(
           },
           'claude.result_is_error'
         );
-      } else if (resultMsg.is_error === true && resultMsg.subtype === 'success') {
+      } else if (isSuccessWithErrorFlag) {
         getLog().debug(
           {
             sessionId: resultMsg.session_id,

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -33,6 +33,7 @@ import {
   type Options,
   type HookCallback,
   type HookCallbackMatcher,
+  type SDKAssistantMessageError,
 } from '@anthropic-ai/claude-agent-sdk';
 import type {
   IAgentProvider,
@@ -129,6 +130,54 @@ function classifySubprocessError(
   if (AUTH_PATTERNS.some(p => combined.includes(p))) return 'auth';
   if (SUBPROCESS_CRASH_PATTERNS.some(p => combined.includes(p))) return 'crash';
   return 'unknown';
+}
+
+/**
+ * The Claude Code SDK surfaces API-level failures (auth not configured,
+ * invalid key, billing, rate limit, model errors) as TEXT rather than
+ * throwing: it synthesizes an assistant message (`message.model:
+ * '<synthetic>'`, wrapper `error: SDKAssistantMessageError`) whose content is
+ * the error prose, then emits a result with `subtype: 'success'` and
+ * `is_error: true` — the same field pair as the legitimate stop-sequence
+ * termination carve-out (#1425). Without structural detection the error prose
+ * flows downstream as successful node output (#1797).
+ *
+ * This error carries the SDK's typed error code so retry classification is
+ * structural — never matched against the message text.
+ */
+export class ClaudeApiResultError extends Error {
+  readonly sdkErrorCode: SDKAssistantMessageError | 'unknown';
+
+  constructor(sdkErrorCode: SDKAssistantMessageError | 'unknown', resultText: string) {
+    super(`Claude API error (${sdkErrorCode}): ${resultText}`);
+    this.name = 'ClaudeApiResultError';
+    this.sdkErrorCode = sdkErrorCode;
+  }
+}
+
+/**
+ * Map the SDK's typed assistant-message error code onto the existing
+ * subprocess retry classes. Auth-shaped codes are non-retryable (operator
+ * must fix credentials); transient API states reuse the existing
+ * rate_limit/crash backoff. Everything else is 'unknown' — fail fast rather
+ * than retry blindly.
+ */
+function classifySdkErrorCode(
+  code: SDKAssistantMessageError | 'unknown'
+): 'rate_limit' | 'auth' | 'crash' | 'unknown' {
+  switch (code) {
+    case 'authentication_failed':
+    case 'oauth_org_not_allowed':
+    case 'billing_error':
+      return 'auth';
+    case 'rate_limit':
+    case 'overloaded':
+      return 'rate_limit';
+    case 'server_error':
+      return 'crash';
+    default:
+      return 'unknown';
+  }
 }
 
 function getFirstEventTimeoutMs(): number {
@@ -656,6 +705,12 @@ async function* streamClaudeMessages(
   events: AsyncGenerator,
   toolResultQueue: ToolResultEntry[]
 ): AsyncGenerator<MessageChunk> {
+  // Synthetic error message recorded while waiting for the terminal result to
+  // confirm it (#1797). Detection is two-signal: the typed wrapper `error`
+  // field on a '<synthetic>' assistant message, then `is_error: true` on the
+  // result. See ClaudeApiResultError.
+  let pendingSdkError: { code: SDKAssistantMessageError; text: string } | undefined;
+
   for await (const msg of events) {
     // Drain tool results captured by hooks before processing the next event
     while (toolResultQueue.length > 0) {
@@ -673,8 +728,30 @@ async function* streamClaudeMessages(
     const event = msg as { type: string };
 
     if (event.type === 'assistant') {
-      const message = msg as { message: { content: ContentBlock[] } };
+      const message = msg as {
+        message: { content: ContentBlock[]; model?: string };
+        error?: SDKAssistantMessageError;
+      };
       const content = message.message.content;
+
+      // API-level failure surfaced as text (#1797): the SDK writes the error
+      // prose into a synthesized assistant message instead of throwing. Both
+      // signals are required — a REAL model message can carry an error code
+      // too (e.g. 'max_output_tokens' on truncated output) and its content
+      // must flow through untouched; only '<synthetic>' content is
+      // SDK-generated error prose, never model output.
+      if (message.error !== undefined && message.message.model === '<synthetic>') {
+        const text = content
+          .filter(b => b.type === 'text' && b.text)
+          .map(b => b.text)
+          .join('\n');
+        pendingSdkError = { code: message.error, text };
+        getLog().warn({ errorCode: message.error, text }, 'claude.synthetic_error_message');
+        // Withhold the error prose from the output stream — yielding it is
+        // what poisons downstream $node.output. If the terminal result
+        // contradicts (no is_error), the text is yielded late as a fail-safe.
+        continue;
+      }
 
       for (const block of content) {
         if (block.type === 'text' && block.text) {
@@ -807,6 +884,9 @@ async function* streamClaudeMessages(
         stop_reason?: string | null;
         num_turns?: number;
         errors?: string[];
+        result?: string;
+        terminal_reason?: string;
+        api_error_status?: number | null;
         model_usage?: Record<
           string,
           {
@@ -817,8 +897,56 @@ async function* streamClaudeMessages(
           }
         >;
       };
+      // The terminal result resolves any recorded synthetic error message.
+      const syntheticError = pendingSdkError;
+      pendingSdkError = undefined;
       const tokens = normalizeClaudeUsage(resultMsg.usage);
       const sdkErrors = Array.isArray(resultMsg.errors) ? resultMsg.errors : undefined;
+
+      // `is_error: true` + `subtype: 'success'` is ambiguous: it is BOTH the
+      // SDK's stop-sequence termination encoding (#1425, a legitimate success)
+      // AND its API-failure-as-text encoding (#1797 — auth/billing/rate-limit
+      // errors that even set stop_reason: 'stop_sequence'). Disambiguate
+      // structurally: a preceding synthetic error message (primary, typed
+      // signal), or terminal_reason 'api_error' (secondary — observed at
+      // runtime on API failures but not yet in the SDK's TerminalReason d.ts
+      // union), marks a real failure. Throw so callers fail the node/turn
+      // instead of consuming error prose as successful output.
+      if (
+        resultMsg.is_error === true &&
+        resultMsg.subtype === 'success' &&
+        (syntheticError !== undefined || resultMsg.terminal_reason === 'api_error')
+      ) {
+        const code = syntheticError?.code ?? 'unknown';
+        const text =
+          syntheticError?.text ||
+          resultMsg.result ||
+          sdkErrors?.join('; ') ||
+          'API error result with no error text';
+        getLog().error(
+          {
+            sessionId: resultMsg.session_id,
+            errorCode: code,
+            terminalReason: resultMsg.terminal_reason,
+            apiErrorStatus: resultMsg.api_error_status,
+            text,
+          },
+          'claude.result_api_error'
+        );
+        throw new ClaudeApiResultError(code, text);
+      }
+
+      // Fail-safe (never observed in practice): a synthetic error message
+      // followed by a non-error result. Yield the withheld text late rather
+      // than silently swallowing content.
+      if (syntheticError !== undefined && resultMsg.is_error !== true) {
+        getLog().warn(
+          { sessionId: resultMsg.session_id, errorCode: syntheticError.code },
+          'claude.synthetic_error_not_confirmed'
+        );
+        yield { type: 'assistant', content: syntheticError.text };
+      }
+
       // SDKResultSuccess declares `is_error: boolean` (not literal false). When a
       // model terminates via a configured stop sequence (stop_reason ===
       // 'stop_sequence') the SDK can set is_error: true while keeping
@@ -864,6 +992,17 @@ async function* streamClaudeMessages(
     }
   }
 
+  // Stream ended after a synthetic error message with no terminal result to
+  // confirm or contradict it. A dangling synthetic error is a failure — the
+  // SDK ends every turn with a result, so this is an abnormal end (#1797).
+  if (pendingSdkError !== undefined) {
+    getLog().error(
+      { errorCode: pendingSdkError.code, text: pendingSdkError.text },
+      'claude.synthetic_error_stream_ended'
+    );
+    throw new ClaudeApiResultError(pendingSdkError.code, pendingSdkError.text);
+  }
+
   // Drain any remaining tool results after the stream ends
   while (toolResultQueue.length > 0) {
     const tr = toolResultQueue.shift();
@@ -900,6 +1039,17 @@ function classifyAndEnrichError(
       enrichedError: new Error('Query aborted'),
       errorClass: 'aborted',
       shouldRetry: false,
+    };
+  }
+
+  // API failures the SDK surfaced as text (#1797) carry a typed error code —
+  // classify by that code, never by matching the (arbitrary) message text.
+  if (error instanceof ClaudeApiResultError) {
+    const errorClass = classifySdkErrorCode(error.sdkErrorCode);
+    return {
+      enrichedError: error,
+      errorClass,
+      shouldRetry: errorClass === 'rate_limit' || errorClass === 'crash',
     };
   }
 


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: the Claude Code SDK does not throw on API-level failures (auth not configured, invalid key, billing, rate limit) — it synthesizes an assistant message whose content is the error prose ("Not logged in · Please run /login") plus a result with `subtype: 'success'` + `is_error: true`, the exact field pair the #1425 stop-sequence carve-out treats as a clean success (down to `stop_reason: 'stop_sequence'`). The provider yielded the error prose as successful output.
- Why it matters: silent-failure class — the DAG node completes green, error prose poisons downstream `$node.output`, side-effecting nodes can run on it, and the operator debugs the wrong node (#1797's dogfood run failed one node downstream with "Failed to extract issue number from: 'Not logged in · Please run /login'").
- What changed: `streamClaudeMessages` now detects API-failure-as-text **structurally** (zero text matching) and throws a typed `ClaudeApiResultError`; `classifyAndEnrichError` classifies it by the SDK's typed error code (auth codes non-retryable; `rate_limit`/`overloaded`/`server_error` reuse the existing backoff).
- What did **not** change (scope boundary): `packages/providers/src/claude/**` + tests only. No dag-executor/orchestrator changes (their error paths already fail nodes on thrown provider errors). Codex/Pi audit for the same class is a follow-up. No retry-policy changes.

## Detection design

Verbatim wire capture (claude CLI 2.1.210, isolated config dir, no credentials):

```json
{"type":"assistant","message":{"model":"<synthetic>","stop_reason":"stop_sequence",
 "content":[{"type":"text","text":"Not logged in · Please run /login"}],...},
 "error":"authentication_failed"}
{"type":"result","subtype":"success","is_error":true,"api_error_status":null,
 "result":"Not logged in · Please run /login","terminal_reason":"api_error",...}
```

Signals (SDK 0.3.209):

1. **Primary**: the typed wrapper `error: SDKAssistantMessageError` field on an assistant message with `message.model === '<synthetic>'` — SDK-written error prose, never model output. Both conditions required: a REAL model message can carry `error: 'max_output_tokens'` alongside genuine truncated output and must flow through.
2. **Confirmation**: `is_error: true` + `subtype: 'success'` on the terminal result — only then does the provider throw (two-signal agreement).
3. **Belt-and-suspenders**: `terminal_reason: 'api_error'` on the result — a typed member of the SDK's `TerminalReason` union in 0.3.209 — catches an error result with no preceding synthetic message.

False-positive analysis:
- Legitimate output that *mentions* "Not logged in"/"rate limit": no wrapper `error`, real model id, `is_error: false` → untouched (tested).
- #1425 stop-sequence success (`is_error: true` + `subtype: 'success'`): no synthetic message, no `api_error` terminal reason → still a clean success (existing regression test untouched and green, plus a new variant).
- Real truncated message with `error: 'max_output_tokens'`: `'<synthetic>'` guard keeps its content flowing (tested).

Fail-safes (never silently swallow): a synthetic error contradicted by a clean result yields the withheld text late + warn; a stream ending on an unresolved synthetic error throws.

## UX Journey

### Before

```
  Workflow node (claude)        provider.claude               dag-executor
  ─────────────────────         ───────────────               ────────────
  runs prompt ────────────────▶ SDK returns error AS TEXT
                                yields "Not logged in..."
                                yields result (clean) ──────▶ node_completed ✅ (poisoned)
                                                              downstream node reads
                                                              "$node.output" ──▶ FAILS
                                                              (wrong node blamed)
```

### After

```
  Workflow node (claude)        provider.claude               dag-executor
  ─────────────────────         ───────────────               ────────────
  runs prompt ────────────────▶ SDK returns error AS TEXT
                                [detects synthetic error msg]
                                [withholds poisoned text]
                                [throws ClaudeApiResultError] ▶ *node_failed* ❌
                                                              "Claude Code auth error:
                                                               Claude API error
                                                               (authentication_failed):
                                                               Not logged in · Please
                                                               run /login"
                                                              downstream nodes skipped
```

## Architecture Diagram

### Before

```
  @anthropic-ai/claude-agent-sdk ──▶ streamClaudeMessages ──▶ MessageChunks ──▶ dag-executor / orchestrator
                                          │
                                          └── result: isRealError = is_error && subtype !== 'success'
                                              (API-error-as-text slips through as success)
```

### After

```
  @anthropic-ai/claude-agent-sdk ──▶ [~] streamClaudeMessages ──▶ MessageChunks ──▶ dag-executor / orchestrator
                                          │
                                          ├── [+] synthetic-error detection (wrapper error + '<synthetic>' model)
                                          ├── [+] throw ClaudeApiResultError on confirming result ═══▶ sendQuery catch
                                          └── [~] classifyAndEnrichError: [+] typed-code classification branch
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| claude-agent-sdk | streamClaudeMessages | **modified** | reads wrapper `error`, `message.model`, `terminal_reason`, `result`, `api_error_status` |
| streamClaudeMessages | sendQuery catch | **new** | throws `ClaudeApiResultError` (was: yielded success) |
| classifyAndEnrichError | classifySdkErrorCode | **new** | typed-code classification before text matching |
| provider | dag-executor / orchestrator | unchanged | existing thrown-error paths mark node_failed |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`
- Module: `providers:claude`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #1797

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # exit 0 — bundled/skill/schema/pi-vendor checks, type-check, lint, format, all tests pass
bun test packages/providers/src/claude/provider.test.ts   # 106 pass, 0 fail (97 existing + 9 new)
```

- Evidence provided (test/log/trace/screenshot): both failing shapes were captured live from claude CLI 2.1.210 (isolated `CLAUDE_CONFIG_DIR`, no creds / bogus key) and are replayed verbatim in the new tests; full capture in the issue comment on #1797.
- If any command is intentionally skipped, explain why: none skipped.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: n/a

## Compatibility / Migration

- Backward compatible? Yes — behavior change only for streams that were already failures; genuine successes (including #1425 stop-sequence results) are byte-identical
- Config/env changes? No
- Database migration needed? No
- If yes, exact upgrade steps: n/a

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: reproduced the exact "Not logged in" and "Invalid API key" (401) wire shapes against the real CLI; confirmed the SDK 0.3.209 d.ts types (`SDKAssistantMessageError` union, `SDKResultSuccess.api_error_status`, `TerminalReason`) match the captures.
- Edge cases checked: legit output mentioning error phrases; #1425 stop-sequence shape; real-model `max_output_tokens` truncation; synthetic error contradicted by clean result; stream ending without a result; rate-limit retry semantics.
- What was not verified: a live end-to-end workflow run against an unauthenticated instance (the dogfood scenario from the issue); Codex/Pi equivalents (follow-up).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: every Claude-provider surface (workflow nodes, direct chat, routing). Runs that previously "succeeded" with error prose now fail fast with the real cause.
- Potential unintended effects: if the SDK ever emits a synthetic error message for a recoverable state, the turn now fails at the confirming error result — mitigated by two-signal agreement plus the late-yield fail-safe when the result contradicts.
- Guardrails/monitoring for early detection: new structured logs `claude.synthetic_error_message` (warn), `claude.result_api_error` (error), `claude.synthetic_error_not_confirmed` (warn), `claude.synthetic_error_stream_ended` (error).

## Rollback Plan (required)

- Fast rollback command/path: `git revert 611e54dc` — single self-contained commit, two files.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: Claude nodes failing with `Claude API error (...)` on outputs that are genuinely legitimate (would indicate SDK changed its synthetic-message encoding).

## Risks and Mitigations

- Risk: the SDK could change its synthetic-error encoding (`'<synthetic>'` model name, `terminal_reason` values) in a future version.
  - Mitigation: both signals are typed SDK API in the pinned 0.3.209 (`SDKAssistantMessageError`, `TerminalReason`); an encoding change degrades to a false NEGATIVE (back to today's behavior), never to a false positive on legitimate output.
- Risk: chunk duplication on retried transient classes (rate_limit) if text was yielded before the throw.
  - Mitigation: synthetic error text is withheld (never yielded), and pre-existing retry semantics for mid-stream failures are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Claude SDK API failures so error details are surfaced clearly.
  * Prevented synthetic API error text from appearing as normal assistant output.
  * Added retry behavior for rate-limit API errors.
  * Preserved legitimate model responses that mention error-related phrases.
  * Improved handling of incomplete or ambiguous streamed responses, ensuring correct fail-safe behavior.

* **Tests**
  * Added a comprehensive test suite covering streamed API-failure behaviors and retry rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
