### PR TITLE
fix(workflows): interactive-loop completion — signal_completes, finalize-on-bare-approve, honest + agent-steerable gates

### DIFF
--- a/.claude/skills/manage-run/SKILL.md
+++ b/.claude/skills/manage-run/SKILL.md
@@ -44,6 +44,7 @@ workflows, setup, or config, use the broader **`archon`** skill instead.
 | **Active** runs only (running/paused) | `archon workflow status --json` |
 | **Start** a run, non-blocking | `archon workflow run <workflow> "<message>" --detach` |
 | **Approve** a paused gate | `archon workflow approve <run-id> "looks good" --json` |
+| **Accept & complete** a signal-bearing loop gate | `archon workflow approve <run-id> --json` (NO comment) |
 | **Reject** a paused gate | `archon workflow reject <run-id> "fix X first" --json` |
 | **Cancel** a non-terminal run | `archon workflow abandon <run-id> --json` |
 
@@ -88,6 +89,22 @@ If you only need to record the decision (e.g. cancel via reject) and don't need 
 drive the run forward, the `--json` step alone is enough. To approve **and** continue
 in one blocking call, drop `--json`: `archon workflow approve <run-id> "ship it"`
 auto-resumes (run it as a background task).
+
+### Interactive-loop gates: no comment = accept & complete
+
+When a paused **interactive loop** gate detected its completion signal
+(`archon workflow get <run-id> --json` → `.metadata.approval.completionSignaled` is
+`true`), approving with **no comment** accepts the completion — on resume the node
+finalizes from the already-computed output with **no re-run**. Approving **with** a
+comment runs another iteration using it as feedback. Read the gate state first, then
+choose deliberately:
+```bash
+archon workflow get <run-id> --json | jq .metadata.approval.completionSignaled
+archon workflow approve <run-id> --json          # accept & complete (finalize, no re-run)
+archon workflow approve <run-id> "redo X" --json # run another iteration with feedback
+```
+(In project-scoped chat, the `manage_run` tool's approve action mirrors this: no
+`message` — or `accept: true` — finalizes; a `message` iterates.)
 
 ## Reference
 

--- a/.claude/skills/manage-run/references/commands.md
+++ b/.claude/skills/manage-run/references/commands.md
@@ -88,6 +88,13 @@ Approve a paused gate (approval node or interactive loop).
 ```
 Non-`--json`: records the approval **and auto-resumes** (blocking — run as a background task).
 
+**Interactive-loop gates:** the comment decides finalize-vs-iterate. If the gate paused on
+an iteration that emitted the completion signal (`get <run-id> --json` →
+`.metadata.approval.completionSignaled` is `true`), approving with **no comment** accepts
+the completion — the node finalizes from its computed output on resume (no re-run).
+A comment runs another iteration with it as `$LOOP_USER_INPUT`. On a non-signaled gate,
+both forms iterate.
+
 ### `archon workflow reject <run-id> [reason] [--json]`
 Reject a paused gate. `cancelled: false` means an `on_reject` rework pass is queued
 (run is resumable); `cancelled: true` ends the run.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -801,7 +801,7 @@ async function createSession(conversationId: string, codebaseId: string) {
 - `$WORKFLOW_ID` - The workflow run ID
 - `$BASE_BRANCH` - Base branch; auto-detected from git when `worktree.baseBranch` is not set; fails only if referenced in a prompt and auto-detection also fails
 - `$DOCS_DIR` - Documentation directory path; configured via `docs.path` in `.archon/config.yaml`. Defaults to `docs/`. Never throws.
-- `$LOOP_USER_INPUT` - User feedback provided via `/workflow approve <id> <text>` at an interactive loop gate. Only populated on the first iteration of a resumed interactive loop; empty string on all other iterations.
+- `$LOOP_USER_INPUT` - User feedback provided via `/workflow approve <id> <text>` at an interactive loop gate. Only populated on the first iteration of a resumed interactive loop; empty string on all other iterations. Note: on a gate whose iteration emitted the completion signal, approving with NO text finalizes the node from the already-computed output (no new iteration, so `$LOOP_USER_INPUT` is never read) — providing text runs another iteration with it (#2074).
 - `$REJECTION_REASON` - Reviewer feedback provided via `/workflow reject <id> <reason>` at an approval gate. Only populated in `on_reject` prompts; empty string elsewhere.
 - `$LOOP_PREV_OUTPUT` - Cleaned output of the previous loop iteration (loop nodes only). Empty string on the first iteration (no prior output exists). Useful for `fresh_context: true` loops that need to reference what the previous pass produced or why it failed without carrying full session history.
 

--- a/packages/adapters/src/chat/slack/workflow-bridge.ts
+++ b/packages/adapters/src/chat/slack/workflow-bridge.ts
@@ -469,9 +469,13 @@ export class SlackWorkflowBridge {
       try {
         if (decision === 'approved') {
           const result = await workflowOperations.approveWorkflow(runId);
+          // Interactive-loop approves are outcome-ambiguous from here: a gate that
+          // paused on a completion signal finalizes on resume (no re-run, #2074);
+          // otherwise the loop runs another iteration. Hedge like manage_run does —
+          // this bridge approves with no comment, so both outcomes are reachable.
           outcomeNote =
             result.type === 'interactive_loop'
-              ? 'recorded — loop will continue on resume'
+              ? 'recorded — finalizes if the gate paused on a completion signal, otherwise the loop runs another iteration on resume'
               : 'workflow resumed';
         } else {
           const result = await workflowOperations.rejectWorkflow(runId);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -634,9 +634,13 @@ async function main(): Promise<number> {
               console.error('Usage: archon workflow approve <run-id> [comment]');
               return 1;
             }
-            // Accept comment as positional args (everything after run ID) or --comment flag
-            const approveComment =
-              (values.comment as string | undefined) || positionals.slice(3).join(' ') || undefined;
+            // Accept comment as positional args (everything after run ID) or --comment flag.
+            // Explicit empty→undefined conversion (not `|| undefined`): "no comment" must
+            // reach approveWorkflow as undefined so a signal-bearing interactive-loop gate
+            // finalizes instead of re-running (#2074, loop_feedback_given).
+            const rawApproveComment =
+              (values.comment as string | undefined) || positionals.slice(3).join(' ');
+            const approveComment = rawApproveComment.length > 0 ? rawApproveComment : undefined;
             await workflowApproveCommand(approveRunId, approveComment, jsonFlag, effectiveCwd);
             break;
           }
@@ -647,8 +651,9 @@ async function main(): Promise<number> {
               console.error('Usage: archon workflow reject <run-id> [reason]');
               return 1;
             }
-            const rejectReason =
-              (values.reason as string | undefined) || positionals.slice(3).join(' ') || undefined;
+            const rawRejectReason =
+              (values.reason as string | undefined) || positionals.slice(3).join(' ');
+            const rejectReason = rawRejectReason.length > 0 ? rawRejectReason : undefined;
             await workflowRejectCommand(rejectRunId, rejectReason, jsonFlag, effectiveCwd);
             break;
           }

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -2388,6 +2388,64 @@ describe('workflowGetCommand', () => {
     expect(code).toBe(0);
   });
 
+  it('emits the full metadata.approval (incl. completionSignaled) in --json for a paused interactive_loop run (#2074 E)', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'run-gate-json',
+      workflow_name: 'validate',
+      status: 'paused',
+      working_path: '/tmp/wt',
+      started_at: new Date(),
+      metadata: {
+        approval: {
+          type: 'interactive_loop',
+          nodeId: 'refine',
+          message: 'gate',
+          iteration: 2,
+          completionSignaled: true,
+          signaledOutput: 'REPORT',
+        },
+      },
+    });
+
+    const code = await workflowGetCommand('run-gate-json', true);
+
+    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as {
+      metadata: { approval: { completionSignaled: boolean; signaledOutput: string } };
+    };
+    // The agent read surface: the C fields flow through the CLI --json dump unchanged.
+    expect(parsed.metadata.approval.completionSignaled).toBe(true);
+    expect(parsed.metadata.approval.signaledOutput).toBe('REPORT');
+    expect(code).toBe(0);
+  });
+
+  it('prints a Gate line (human) for a paused interactive_loop run (#2074 E)', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'run-gate-human',
+      workflow_name: 'validate',
+      status: 'paused',
+      working_path: '/tmp/wt',
+      started_at: new Date(),
+      metadata: {
+        approval: {
+          type: 'interactive_loop',
+          nodeId: 'refine',
+          message: 'gate',
+          iteration: 2,
+          completionSignaled: true,
+          signaledOutput: 'REPORT',
+        },
+      },
+    });
+
+    await workflowGetCommand('run-gate-human');
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '  Gate:   awaiting approval — signal detected: yes (iteration 2)'
+    );
+  });
+
   it('attaches events in verbose JSON mode', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
     const eventsDb = await import('@archon/core/db/workflow-events');

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -47,7 +47,7 @@ import type {
   WorkflowSource,
   WorkflowWithSource,
 } from '@archon/workflows/schemas/workflow';
-import { workflowRunStatusSchema } from '@archon/workflows/schemas/workflow-run';
+import { workflowRunStatusSchema, isApprovalContext } from '@archon/workflows/schemas/workflow-run';
 import type { WorkflowRun, WorkflowRunStatus } from '@archon/workflows/schemas/workflow-run';
 import {
   approveWorkflow,
@@ -1656,6 +1656,20 @@ export async function workflowGetCommand(
   console.log(`  Path:   ${run.working_path ?? '(none)'}`);
   console.log(`  Status: ${run.status}`);
   console.log(`  Age:    ${formatAge(run.started_at)}`);
+  // Paused interactive-loop gate: one honest line so a human (or an agent parsing
+  // the plain output) sees whether the paused iteration emitted its completion
+  // signal (#2074). --json already carries the full metadata.approval.
+  const gateMeta = run.metadata.approval;
+  if (
+    run.status === 'paused' &&
+    isApprovalContext(gateMeta) &&
+    gateMeta.type === 'interactive_loop'
+  ) {
+    const signal = gateMeta.completionSignaled === true ? 'yes' : 'no';
+    console.log(
+      `  Gate:   awaiting approval — signal detected: ${signal} (iteration ${String(gateMeta.iteration ?? '?')})`
+    );
+  }
   const runError = typeof run.metadata.error === 'string' ? run.metadata.error : undefined;
   if (runError) {
     console.log(`  Error:  ${runError}`);

--- a/packages/core/src/db/workflows.test.ts
+++ b/packages/core/src/db/workflows.test.ts
@@ -281,6 +281,33 @@ describe('workflows database', () => {
       };
       expect(payload.approval.resolved).toBeNull();
       expect(payload.approval.nodeId).toBe('review');
+      // completionSignaled/signaledOutput follow the same explicit-null rule
+      // (#2074): standard approval pauses never set them, so they must be
+      // written as null (never omitted — JSON.stringify drops undefined and
+      // SQLite would keep a stale value from a previous interactive-loop gate).
+      expect(payload.approval.completionSignaled).toBeNull();
+      expect(payload.approval.signaledOutput).toBeNull();
+    });
+
+    test('preserves completionSignaled/signaledOutput when the gate provides them (#2074)', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([], 1));
+
+      await pauseWorkflowRun('workflow-run-123', {
+        nodeId: 'refine',
+        message: 'gate',
+        type: 'interactive_loop',
+        iteration: 1,
+        completionSignaled: true,
+        signaledOutput: 'REPORT',
+      });
+
+      const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+      const payload = JSON.parse(params[1] as string) as {
+        approval: Record<string, unknown>;
+      };
+      expect(payload.approval.completionSignaled).toBe(true);
+      expect(payload.approval.signaledOutput).toBe('REPORT');
+      expect(payload.approval.resolved).toBeNull();
     });
 
     test('throws when the run is not running', async () => {

--- a/packages/core/src/db/workflows.ts
+++ b/packages/core/src/db/workflows.ts
@@ -698,11 +698,13 @@ export async function cancelWorkflowRun(id: string): Promise<{ cancelled: boolea
  * Sets status to 'paused' and stores approval context in metadata.
  * Does NOT set completed_at — the run is not finished.
  *
- * `resolved` is reset to an explicit null on every fresh pause so a prior
- * gate's resolution can never leak into this one: SQLite's json_patch
- * deep-merges the new context into the stored one (an omitted key would keep
- * the old 'approved'), and RFC 7396 null removes the key; Postgres `||`
- * replaces the approval object wholesale. See ApprovalContext.resolved.
+ * `resolved`, `completionSignaled`, and `signaledOutput` are reset to an
+ * explicit null on every fresh pause so a prior gate's resolution or signal
+ * state can never leak into this one: SQLite's json_patch deep-merges the new
+ * context into the stored one (an omitted key would keep the old value —
+ * JSON.stringify drops undefined, so the values are computed explicitly), and
+ * RFC 7396 null removes the key; Postgres `||` replaces the approval object
+ * wholesale. See ApprovalContext.resolved / .completionSignaled.
  */
 export async function pauseWorkflowRun(
   id: string,
@@ -714,7 +716,17 @@ export async function pauseWorkflowRun(
       `UPDATE remote_agent_workflow_runs
        SET status = 'paused', metadata = ${dialect.jsonMerge('metadata', 2)}
        WHERE id = $1 AND status = 'running'`,
-      [id, JSON.stringify({ approval: { ...approvalContext, resolved: null } })]
+      [
+        id,
+        JSON.stringify({
+          approval: {
+            ...approvalContext,
+            resolved: null,
+            completionSignaled: approvalContext.completionSignaled ?? null,
+            signaledOutput: approvalContext.signaledOutput ?? null,
+          },
+        }),
+      ]
     );
     if (result.rowCount === 0) {
       getLog().warn({ workflowRunId: id }, 'db.workflow_run_pause_no_match');

--- a/packages/core/src/handlers/command-handler.test.ts
+++ b/packages/core/src/handlers/command-handler.test.ts
@@ -2177,6 +2177,8 @@ describe('CommandHandler', () => {
               resolved: 'approved',
             },
             loop_user_input: 'Add error handling',
+            // A real comment counts as feedback ⇒ the resumed loop iterates (#2074)
+            loop_feedback_given: true,
           },
         });
       });

--- a/packages/core/src/handlers/command-handler.test.ts
+++ b/packages/core/src/handlers/command-handler.test.ts
@@ -2219,6 +2219,45 @@ describe('CommandHandler', () => {
         );
       });
 
+      test('bare approve (no comment) passes undefined through — finalize-eligible (#2074)', async () => {
+        mockGetWorkflowRun.mockResolvedValueOnce({
+          id: 'run-bare',
+          workflow_name: 'loop-wf',
+          conversation_id: 'conv-approve',
+          parent_conversation_id: null,
+          codebase_id: null,
+          status: 'paused',
+          user_message: 'start',
+          metadata: {
+            approval: {
+              type: 'interactive_loop',
+              nodeId: 'validate',
+              iteration: 1,
+              message: 'gate',
+              completionSignaled: true,
+              signaledOutput: 'REPORT',
+            },
+          },
+          started_at: new Date(),
+          completed_at: null,
+          last_activity_at: new Date(),
+          working_path: null,
+        });
+
+        const result = await handleCommand(baseConversation, '/workflow approve run-bare');
+
+        expect(result.success).toBe(true);
+        // The chat handler must NOT pre-default the comment to 'Approved' —
+        // loop_feedback_given derives from the raw comment, and a masked
+        // no-feedback would make every chat approve iterate instead of finalize.
+        expect(mockUpdateWorkflowRun).toHaveBeenCalledWith('run-bare', {
+          metadata: expect.objectContaining({
+            loop_feedback_given: false,
+            loop_user_input: 'Approved',
+          }),
+        });
+      });
+
       test('returns error when run is not paused', async () => {
         mockGetWorkflowRun.mockResolvedValueOnce({
           id: 'run-789',

--- a/packages/core/src/handlers/command-handler.ts
+++ b/packages/core/src/handlers/command-handler.ts
@@ -853,7 +853,13 @@ async function handleWorkflowCommand(
           message: 'Usage: /workflow approve <id> [comment]\n\nApproves a paused workflow run.',
         };
       }
-      const comment = args.slice(2).join(' ') || 'Approved';
+      // Pass the RAW comment through (undefined when the user typed none) —
+      // approveWorkflow defaults the recorded comment internally, but "no
+      // feedback" must survive so a signal-bearing interactive-loop gate
+      // finalizes instead of re-running (#2074, loop_feedback_given). Mirrors
+      // the HTTP route and CLI.
+      const rawComment = args.slice(2).join(' ');
+      const comment = rawComment.length > 0 ? rawComment : undefined;
       try {
         const result = await approveWorkflow(runId, comment);
         const pathInfo = result.workingPath ? `\nPath: \`${result.workingPath}\`` : '';

--- a/packages/core/src/operations/workflow-operations.test.ts
+++ b/packages/core/src/operations/workflow-operations.test.ts
@@ -163,8 +163,67 @@ describe('approveWorkflow', () => {
           resolved: 'approved',
         },
         loop_user_input: 'fix the tests',
+        // Real feedback ⇒ the resumed loop iterates (#2074)
+        loop_feedback_given: true,
       },
     });
+  });
+
+  test('interactive_loop bare approve — loop_feedback_given false, loop_user_input defaults (#2074)', async () => {
+    const run = makePausedRun({
+      metadata: {
+        approval: {
+          nodeId: 'iterate',
+          message: 'Provide feedback',
+          type: 'interactive_loop',
+          iteration: 1,
+          completionSignaled: true,
+          signaledOutput: 'REPORT',
+        },
+      },
+    });
+    mockGetWorkflowRun.mockResolvedValueOnce(run);
+
+    await approveWorkflow('run-1');
+
+    expect(mockUpdateWorkflowRun).toHaveBeenCalledWith('run-1', {
+      metadata: {
+        approval: {
+          nodeId: 'iterate',
+          message: 'Provide feedback',
+          type: 'interactive_loop',
+          iteration: 1,
+          completionSignaled: true,
+          signaledOutput: 'REPORT',
+          resolved: 'approved',
+        },
+        // The recorded comment still defaults to 'Approved' (events/$LOOP_USER_INPUT
+        // for non-signaled iterate paths) — only the boolean sees the raw undefined.
+        loop_user_input: 'Approved',
+        loop_feedback_given: false,
+      },
+    });
+  });
+
+  test('interactive_loop whitespace-only comment counts as no feedback (#2074)', async () => {
+    const run = makePausedRun({
+      metadata: {
+        approval: {
+          nodeId: 'iterate',
+          message: 'Provide feedback',
+          type: 'interactive_loop',
+          iteration: 1,
+        },
+      },
+    });
+    mockGetWorkflowRun.mockResolvedValueOnce(run);
+
+    await approveWorkflow('run-1', '   ');
+
+    const updateArg = mockUpdateWorkflowRun.mock.calls[0][1] as {
+      metadata: Record<string, unknown>;
+    };
+    expect(updateArg.metadata.loop_feedback_given).toBe(false);
   });
 
   test('throws on already-resolved gate (double-approve guard)', async () => {

--- a/packages/core/src/operations/workflow-operations.test.ts
+++ b/packages/core/src/operations/workflow-operations.test.ts
@@ -224,6 +224,9 @@ describe('approveWorkflow', () => {
       metadata: Record<string, unknown>;
     };
     expect(updateArg.metadata.loop_feedback_given).toBe(false);
+    // Whitespace-only also gets the documented recorded-comment default —
+    // '   ' must never be stored verbatim as $LOOP_USER_INPUT.
+    expect(updateArg.metadata.loop_user_input).toBe('Approved');
   });
 
   test('throws on already-resolved gate (double-approve guard)', async () => {

--- a/packages/core/src/operations/workflow-operations.ts
+++ b/packages/core/src/operations/workflow-operations.ts
@@ -10,7 +10,11 @@ import {
   isApprovalContext,
   isGateResolved,
 } from '@archon/workflows/schemas/workflow-run';
-import type { WorkflowRun, ApprovalContext } from '@archon/workflows/schemas/workflow-run';
+import type {
+  WorkflowRun,
+  ApprovalContext,
+  LoopGateRunMetadata,
+} from '@archon/workflows/schemas/workflow-run';
 import * as workflowDb from '../db/workflows';
 import * as workflowEventDb from '../db/workflow-events';
 import * as workflowNodeSessionDb from '../db/workflow-node-sessions';
@@ -195,11 +199,16 @@ export async function approveWorkflow(
       // resumed executor can detect the correct startIteration.
       // loop_user_input keeps the 'Approved' default so the iterate path (non-signaled
       // gates) still feeds the AI an approval token via $LOOP_USER_INPUT.
+      // Typed via LoopGateRunMetadata so the key spellings match the executor's
+      // resume-time read sites (a typo here is a compile error).
+      const gateRunMetadata: LoopGateRunMetadata = {
+        loop_user_input: approvalComment,
+        loop_feedback_given: feedbackProvided,
+      };
       await workflowDb.updateWorkflowRun(runId, {
         metadata: {
           approval: { ...approval, resolved: 'approved' },
-          loop_user_input: approvalComment,
-          loop_feedback_given: feedbackProvided,
+          ...gateRunMetadata,
         },
       });
       return {

--- a/packages/core/src/operations/workflow-operations.ts
+++ b/packages/core/src/operations/workflow-operations.ts
@@ -169,9 +169,15 @@ export async function approveWorkflow(
   try {
     // Interactive loop gate — store user input in metadata for the next iteration.
     // Note: node_completed is NOT written here. The executor writes it when the AI
-    // emits the completion signal (meaning the user actually approved). Writing it
-    // here would cause the resume to skip the loop node entirely.
+    // emits the completion signal (meaning the user actually approved) — or, for a
+    // signal-bearing gate approved without feedback, at resume time from the
+    // persisted signaledOutput (#2074). Writing it here would cause the resume to
+    // skip the loop node entirely.
     if (approval.type === 'interactive_loop') {
+      // Finalize-vs-iterate discriminator (#2074): derived from the RAW comment,
+      // not approvalComment (which defaults to 'Approved') — a bare approve on a
+      // signal-bearing gate finalizes at resume; real feedback runs another iteration.
+      const feedbackProvided = comment !== undefined && comment.trim().length > 0;
       await workflowEventDb.createWorkflowEvent({
         workflow_run_id: runId,
         event_type: 'approval_received',
@@ -184,10 +190,13 @@ export async function approveWorkflow(
       // IMPORTANT: metadata is MERGED (not replaced) and the approval context is
       // rewritten whole (spread + resolved) — it must survive intact so the
       // resumed executor can detect the correct startIteration.
+      // loop_user_input keeps the 'Approved' default so the iterate path (non-signaled
+      // gates) still feeds the AI an approval token via $LOOP_USER_INPUT.
       await workflowDb.updateWorkflowRun(runId, {
         metadata: {
           approval: { ...approval, resolved: 'approved' },
           loop_user_input: approvalComment,
+          loop_feedback_given: feedbackProvided,
         },
       });
       return {

--- a/packages/core/src/operations/workflow-operations.ts
+++ b/packages/core/src/operations/workflow-operations.ts
@@ -164,7 +164,10 @@ export async function approveWorkflow(
     );
   }
 
-  const approvalComment = comment ?? 'Approved';
+  // Whitespace-only comments count as absent (mirrors feedbackProvided below):
+  // HTTP/CLI/chat pass the raw comment through since #2074, so '   ' would
+  // otherwise be recorded verbatim where the documented default is 'Approved'.
+  const approvalComment = comment !== undefined && comment.trim().length > 0 ? comment : 'Approved';
 
   try {
     // Interactive loop gate — store user input in metadata for the next iteration.

--- a/packages/core/src/orchestrator/manage-run-tool.test.ts
+++ b/packages/core/src/orchestrator/manage-run-tool.test.ts
@@ -180,6 +180,53 @@ describe('manage_run — reads', () => {
     expect(out).toContain('started: 2026-07-10 18:26:36');
     expect(out).toContain('finished: 2026-07-10 18:30:00');
   });
+
+  test('get surfaces the structured gate state on a paused interactive_loop run (#2074 E)', async () => {
+    mockFindByPrefix.mockResolvedValue([
+      makeRun({
+        status: 'paused',
+        metadata: {
+          approval: {
+            nodeId: 'refine',
+            message: 'gate',
+            type: 'interactive_loop',
+            iteration: 3,
+            completionSignaled: true,
+            signaledOutput: 'validation PASS — all 42 checks green',
+          },
+        },
+      }),
+    ]);
+    const tool = buildManageRunTool({ codebaseId: CODEBASE_ID });
+    const out = await tool.handler({ action: 'get', runId: 'r1abcdef' });
+    expect(out).toContain('gate: awaiting approval (node refine, iteration 3)');
+    expect(out).toContain('completionSignaled: true');
+    // The finalize hint tells an AI approver how to accept without re-running.
+    expect(out).toContain('FINALIZE');
+    expect(out).toContain('output: validation PASS');
+  });
+
+  test('get shows completionSignaled: false with no finalize hint on a non-signaled gate (#2074 E)', async () => {
+    mockFindByPrefix.mockResolvedValue([
+      makeRun({
+        status: 'paused',
+        metadata: {
+          approval: {
+            nodeId: 'refine',
+            message: 'gate',
+            type: 'interactive_loop',
+            iteration: 1,
+            completionSignaled: false,
+            signaledOutput: null,
+          },
+        },
+      }),
+    ]);
+    const tool = buildManageRunTool({ codebaseId: CODEBASE_ID });
+    const out = await tool.handler({ action: 'get', runId: 'r1abcdef' });
+    expect(out).toContain('completionSignaled: false');
+    expect(out).not.toContain('FINALIZE');
+  });
 });
 
 describe('manage_run — start', () => {
@@ -266,13 +313,70 @@ describe('manage_run — destructive confirmation gate', () => {
     expect(mockApprove).toHaveBeenCalledWith('r1abcdef-1234', 'lgtm');
   });
 
-  test('approve with confirm on an interactive loop reports loop input', async () => {
+  test('approve with confirm and no message on an interactive loop reports the finalize semantics (#2074)', async () => {
     mockFindByPrefix.mockResolvedValue([makeRun({ status: 'paused' })]);
     mockApprove.mockResolvedValue({ workflowName: 'wf', type: 'interactive_loop' });
     const tool = buildManageRunTool({ codebaseId: CODEBASE_ID });
     const out = await tool.handler({ action: 'approve', runId: 'r1abcdef', confirm: true });
-    expect(out).toContain('Loop input recorded');
-    expect(out).not.toContain('Approved');
+    expect(mockApprove).toHaveBeenCalledWith('r1abcdef-1234', undefined);
+    expect(out).toContain('no feedback');
+    expect(out).toContain('finalizes');
+  });
+
+  test('approve with accept:true finalizes even when a message is present (#2074 E)', async () => {
+    mockFindByPrefix.mockResolvedValue([makeRun({ status: 'paused' })]);
+    mockApprove.mockResolvedValue({ workflowName: 'wf', type: 'interactive_loop' });
+    const tool = buildManageRunTool({ codebaseId: CODEBASE_ID });
+    const out = await tool.handler({
+      action: 'approve',
+      runId: 'r1abcdef',
+      confirm: true,
+      accept: true,
+      message: 'looks good',
+    });
+    // accept forces the finalize path: no feedback reaches the gate.
+    expect(mockApprove).toHaveBeenCalledWith('r1abcdef-1234', undefined);
+    expect(out).toContain('finalizes');
+  });
+
+  test('approve with a message on an interactive loop records feedback (iterate) (#2074 E)', async () => {
+    mockFindByPrefix.mockResolvedValue([makeRun({ status: 'paused' })]);
+    mockApprove.mockResolvedValue({ workflowName: 'wf', type: 'interactive_loop' });
+    const tool = buildManageRunTool({ codebaseId: CODEBASE_ID });
+    const out = await tool.handler({
+      action: 'approve',
+      runId: 'r1abcdef',
+      confirm: true,
+      message: 'redo the check',
+    });
+    expect(mockApprove).toHaveBeenCalledWith('r1abcdef-1234', 'redo the check');
+    expect(out).toContain('another iteration');
+  });
+
+  test('approve preview on a signal-bearing gate states the finalize/iterate effect (#2074 E)', async () => {
+    mockFindByPrefix.mockResolvedValue([
+      makeRun({
+        status: 'paused',
+        metadata: {
+          approval: {
+            nodeId: 'refine',
+            message: 'gate',
+            type: 'interactive_loop',
+            iteration: 1,
+            completionSignaled: true,
+            signaledOutput: 'REPORT',
+          },
+        },
+      }),
+    ]);
+    const tool = buildManageRunTool({ codebaseId: CODEBASE_ID });
+    // No confirm → preview. Bare args would finalize.
+    const bare = await tool.handler({ action: 'approve', runId: 'r1abcdef' });
+    expect(bare).toContain('FINALIZE');
+    // A message would iterate.
+    const withMsg = await tool.handler({ action: 'approve', runId: 'r1abcdef', message: 'redo' });
+    expect(withMsg).toContain('ANOTHER iteration');
+    expect(mockApprove).not.toHaveBeenCalled();
   });
 
   test('reject with confirm and no on-reject prompt reports cancellation', async () => {

--- a/packages/core/src/orchestrator/manage-run-tool.ts
+++ b/packages/core/src/orchestrator/manage-run-tool.ts
@@ -289,6 +289,8 @@ async function handleWrite(
   const run = await getScopedRun(runId, ctx);
   if (typeof run === 'string') return run; // not found / wrong project
 
+  const message = typeof input.message === 'string' ? input.message.trim() : '';
+
   // Destructive actions need explicit confirmation. Without it, preview only.
   if (DESTRUCTIVE_ACTIONS.has(action) && input.confirm !== true) {
     log.info({ runId: run.id, action }, 'manage_run.confirm_preview');
@@ -306,7 +308,6 @@ async function handleWrite(
       approvalMeta.type === 'interactive_loop' &&
       approvalMeta.completionSignaled === true
     ) {
-      const message = typeof input.message === 'string' ? input.message.trim() : '';
       effect =
         input.accept === true || message === ''
           ? ' This gate has completionSignaled=true and your args would FINALIZE the node from the already-computed output (no re-run).'
@@ -318,7 +319,6 @@ async function handleWrite(
     );
   }
 
-  const message = typeof input.message === 'string' ? input.message.trim() : '';
   log.info({ runId: run.id, action }, 'manage_run.write_requested');
 
   // Use the verified full id from `getScopedRun`, not the (possibly short) input

--- a/packages/core/src/orchestrator/manage-run-tool.ts
+++ b/packages/core/src/orchestrator/manage-run-tool.ts
@@ -1,5 +1,6 @@
 import type { NativeTool } from '@archon/providers/types';
 import { createLogger } from '@archon/paths';
+import { isApprovalContext } from '@archon/workflows/schemas/workflow-run';
 import type { WorkflowRun } from '@archon/workflows/schemas/workflow-run';
 import { listDashboardRuns, findWorkflowRunsByIdPrefix } from '../db/workflows';
 import {
@@ -84,6 +85,11 @@ const INPUT_SCHEMA: Record<string, unknown> = {
       description:
         'Required (true) to actually perform a destructive action (cancel/abandon/approve/reject). Omit first to get a preview.',
     },
+    accept: {
+      type: 'boolean',
+      description:
+        'For action=approve on an interactive-loop gate with completionSignaled=true: accept=true finalizes the node from the already-computed output WITHOUT re-running, regardless of any message. Omit and pass message=<feedback> to run another iteration instead.',
+    },
   },
   required: ['action'],
 };
@@ -100,7 +106,7 @@ const HELP_OVERVIEW = [
   '  resume   — check a failed/paused run can resume from completed nodes. Params: runId.',
   '  cancel   — mark a running run cancelled. Params: runId, confirm=true.',
   '  abandon  — discard a paused/failed run. Params: runId, confirm=true.',
-  '  approve  — approve a paused human gate. Params: runId, message=comment, confirm=true.',
+  '  approve  — approve a paused human gate. Params: runId, confirm=true, optional accept/message.',
   '  reject   — reject a paused human gate. Params: runId, message=reason, confirm=true.',
   '',
   'Destructive actions (cancel/abandon/approve/reject) need confirm=true; call once',
@@ -119,7 +125,7 @@ const HELP_BY_ACTION: Record<Exclude<Action, 'help'>, string> = {
   abandon:
     'abandon — discard a paused/failed (non-terminal) run. Required: runId, confirm=true. Irreversible: the run becomes cancelled.',
   approve:
-    'approve — approve a paused human gate so the run can continue. Required: runId, confirm=true. Optional: message (comment recorded with the approval). Only paused runs with an approval gate.',
+    'approve — approve a paused human gate so the run can continue. Required: runId, confirm=true. Optional: accept, message. On an interactive loop whose gate shows completionSignaled=true: NO message (or accept=true) FINALIZES the node from the already-computed output without re-running; message=<feedback> runs another iteration with it. On other gates, message is just a comment recorded with the approval. Only paused runs with an approval gate.',
   reject:
     'reject — reject a paused human gate. Required: runId, confirm=true. Recommended: message (the reason). If the gate has an on-reject prompt the run reworks; otherwise it is cancelled.',
 };
@@ -234,6 +240,26 @@ function formatRunDetail(run: WorkflowRun): string {
   if (run.completed_at !== null) parts.push(`finished: ${formatTimestamp(run.completed_at)}`);
   const error = run.metadata.error;
   if (typeof error === 'string' && error.length > 0) parts.push(`error: ${error.slice(0, 300)}`);
+  // Paused interactive-loop gate: surface the structured gate state (#2074) so an
+  // AI approver can decide finalize-vs-iterate without parsing prose.
+  const rawApproval = run.metadata.approval;
+  if (
+    run.status === 'paused' &&
+    isApprovalContext(rawApproval) &&
+    rawApproval.type === 'interactive_loop'
+  ) {
+    parts.push(
+      `gate: awaiting approval (node ${rawApproval.nodeId}, iteration ${String(rawApproval.iteration ?? '?')})`
+    );
+    parts.push(`completionSignaled: ${rawApproval.completionSignaled === true ? 'true' : 'false'}`);
+    if (rawApproval.completionSignaled === true) {
+      parts.push(
+        '-> approve with NO message (or accept:true) to FINALIZE without re-running; approve with a message to run another iteration.'
+      );
+    }
+    const excerpt = (rawApproval.signaledOutput ?? '').trim().slice(0, 300);
+    if (excerpt) parts.push(`output: ${excerpt}`);
+  }
   log.info({ runId: run.id, status: run.status }, 'manage_run.get_completed');
   return parts.join('\n');
 }
@@ -269,8 +295,25 @@ async function handleWrite(
     const subject = GATE_ACTIONS.has(action)
       ? `the paused human gate on run ${run.id.slice(0, 8)} (${run.workflow_name})`
       : `run ${run.id.slice(0, 8)} (${run.workflow_name}), currently '${run.status}' — irreversible`;
+    // For approve on a signal-bearing interactive-loop gate, tell the agent which
+    // effect its current args would have (finalize vs iterate) so the confirmed
+    // second call is deliberate (#2074).
+    let effect = '';
+    const approvalMeta = run.metadata.approval;
+    if (
+      action === 'approve' &&
+      isApprovalContext(approvalMeta) &&
+      approvalMeta.type === 'interactive_loop' &&
+      approvalMeta.completionSignaled === true
+    ) {
+      const message = typeof input.message === 'string' ? input.message.trim() : '';
+      effect =
+        input.accept === true || message === ''
+          ? ' This gate has completionSignaled=true and your args would FINALIZE the node from the already-computed output (no re-run).'
+          : ' This gate has completionSignaled=true and your message would run ANOTHER iteration (pass accept:true or drop the message to finalize instead).';
+    }
     return (
-      `⚠️ This will ${action} ${subject}. ` +
+      `⚠️ This will ${action} ${subject}.${effect} ` +
       'Confirm with the user, then call manage_run again with confirm: true to proceed.'
     );
   }
@@ -296,10 +339,16 @@ async function handleWrite(
       return `Cancelled run ${cancelled.id.slice(0, 8)} (${cancelled.workflow_name}).`;
     }
     case 'approve': {
-      const result = await approveWorkflow(id, message.length > 0 ? message : undefined);
-      return result.type === 'interactive_loop'
-        ? `Loop input recorded for ${result.workflowName} (${id.slice(0, 8)}). The run is now set to resume.`
-        : `Approved ${result.workflowName} (${id.slice(0, 8)}). The run is now set to resume.`;
+      // accept=true forces the finalize path (#2074): no feedback reaches the gate,
+      // so a signal-bearing loop completes from its persisted output on resume.
+      const feedback = input.accept === true || message.length === 0 ? undefined : message;
+      const result = await approveWorkflow(id, feedback);
+      if (result.type !== 'interactive_loop') {
+        return `Approved ${result.workflowName} (${id.slice(0, 8)}). The run is now set to resume.`;
+      }
+      return feedback === undefined
+        ? `Approved ${result.workflowName} (${id.slice(0, 8)}) with no feedback. If the gate paused on a completion signal, the node finalizes from its computed output on resume (no re-run); otherwise the loop runs another iteration.`
+        : `Feedback recorded for ${result.workflowName} (${id.slice(0, 8)}); the loop will run another iteration with it on resume.`;
     }
     case 'reject': {
       const result = await rejectWorkflow(id, message.length > 0 ? message : undefined);

--- a/packages/core/src/orchestrator/manage-run-tool.ts
+++ b/packages/core/src/orchestrator/manage-run-tool.ts
@@ -85,10 +85,14 @@ const INPUT_SCHEMA: Record<string, unknown> = {
       description:
         'Required (true) to actually perform a destructive action (cancel/abandon/approve/reject). Omit first to get a preview.',
     },
+    // accept deliberately WINS over a simultaneous message (the message is
+    // discarded, not recorded): an agent that reflexively attaches a comment to
+    // every approve must still be able to force finalize — that footgun is the
+    // reason this arg exists (#2074).
     accept: {
       type: 'boolean',
       description:
-        'For action=approve on an interactive-loop gate with completionSignaled=true: accept=true finalizes the node from the already-computed output WITHOUT re-running, regardless of any message. Omit and pass message=<feedback> to run another iteration instead.',
+        'For action=approve on an interactive-loop gate with completionSignaled=true: accept=true finalizes the node from the already-computed output WITHOUT re-running, regardless of any message (a simultaneous message is discarded, not recorded). Omit and pass message=<feedback> to run another iteration instead.',
     },
   },
   required: ['action'],
@@ -290,6 +294,10 @@ async function handleWrite(
   if (typeof run === 'string') return run; // not found / wrong project
 
   const message = typeof input.message === 'string' ? input.message.trim() : '';
+  // Single finalize-vs-iterate predicate for approve (#2074): accept=true or an
+  // empty message means no feedback reaches the gate — used by both the confirm
+  // preview and the write path so they can never disagree.
+  const willFinalize = input.accept === true || message === '';
 
   // Destructive actions need explicit confirmation. Without it, preview only.
   if (DESTRUCTIVE_ACTIONS.has(action) && input.confirm !== true) {
@@ -308,10 +316,9 @@ async function handleWrite(
       approvalMeta.type === 'interactive_loop' &&
       approvalMeta.completionSignaled === true
     ) {
-      effect =
-        input.accept === true || message === ''
-          ? ' This gate has completionSignaled=true and your args would FINALIZE the node from the already-computed output (no re-run).'
-          : ' This gate has completionSignaled=true and your message would run ANOTHER iteration (pass accept:true or drop the message to finalize instead).';
+      effect = willFinalize
+        ? ' This gate has completionSignaled=true and your args would FINALIZE the node from the already-computed output (no re-run).'
+        : ' This gate has completionSignaled=true and your message would run ANOTHER iteration (pass accept:true or drop the message to finalize instead).';
     }
     return (
       `⚠️ This will ${action} ${subject}.${effect} ` +
@@ -341,7 +348,7 @@ async function handleWrite(
     case 'approve': {
       // accept=true forces the finalize path (#2074): no feedback reaches the gate,
       // so a signal-bearing loop completes from its persisted output on resume.
-      const feedback = input.accept === true || message.length === 0 ? undefined : message;
+      const feedback = willFinalize ? undefined : message;
       const result = await approveWorkflow(id, feedback);
       if (result.type !== 'interactive_loop') {
         return `Approved ${result.workflowName} (${id.slice(0, 8)}). The run is now set to resume.`;

--- a/packages/docs-web/src/content/docs/book/quick-reference.md
+++ b/packages/docs-web/src/content/docs/book/quick-reference.md
@@ -183,6 +183,9 @@ Defined under `loop:` inside a node:
 | `max_iterations` | Yes | number | Maximum iterations before the node fails |
 | `fresh_context` | No | boolean | Start a new session each iteration (default: false) |
 | `until_bash` | No | string | Shell script run after each iteration; exit 0 signals completion |
+| `interactive` | No | boolean | Pause at a human gate after each iteration for input via `/workflow approve` |
+| `gate_message` | No | string | Message shown at the interactive gate (required when `interactive: true`) |
+| `signal_completes` | No | boolean | Interactive loops only: a detected completion signal completes the node immediately (even on iteration 1) instead of gating (default: false) |
 
 **Example:**
 
@@ -208,6 +211,7 @@ per iteration (see [Cross-Node Loops](/guides/loop-nodes/#cross-node-loops-with-
 | `until_bash` | No | string | Shell script run after each iteration; exit 0 signals completion |
 | `interactive` | No | boolean | Pause at a human gate after each non-completing iteration |
 | `gate_message` | No | string | Message shown at the interactive gate |
+| `signal_completes` | No | boolean | Interactive loops only: a detected completion signal completes the group immediately (even on iteration 1) instead of gating (default: false) |
 
 Body nodes can reference the previous iteration via
 `$LOOP_PREV.<nodeId>.output`, and outer-DAG outputs via plain `$nodeId.output`.

--- a/packages/docs-web/src/content/docs/getting-started/overview.md
+++ b/packages/docs-web/src/content/docs/getting-started/overview.md
@@ -312,7 +312,7 @@ archon workflow run <name> --cwd /path/to/repo "<message>"
 | `archon workflow get <id>` | Show detail for a single run (any status) |
 | `archon workflow resume <id>` | Resume a failed workflow |
 | `archon workflow abandon <id>` | Abandon a run (running, paused, or failed) |
-| `archon workflow approve <id> [comment]` | Approve an interactive loop gate |
+| `archon workflow approve <id> [comment]` | Approve an interactive loop gate (no comment on a signal-bearing gate = accept & complete; a comment runs another iteration) |
 | `archon workflow reject <id> [--reason "..."]` | Reject an approval gate |
 | `archon workflow cleanup [days]` | Delete old run records (default: 7 days) |
 | `archon workflow event emit` | Emit a workflow event |

--- a/packages/docs-web/src/content/docs/guides/approval-nodes.md
+++ b/packages/docs-web/src/content/docs/guides/approval-nodes.md
@@ -142,7 +142,9 @@ bun run cli workflow reject <run-id> --reason "Plan needs more test coverage"
 
 Interactive **loop** gates (`loop:`/`loop_group:` with `interactive: true`) share these
 approve surfaces but add one rule: when the gate paused on an iteration that emitted the
-loop's completion signal (the gate message starts with "✅ Completion signal detected"),
+loop's completion signal (the persisted gate message — `metadata.approval.message`, shown
+by `workflow get --json` and `manage_run` — leads with "✅ Completion signal detected";
+in chat the same line follows the `⏸ Input required` prefix),
 approving **without a comment** finalizes the loop node from the already-computed output —
 no extra iteration runs. Approving **with** a comment runs another iteration with your
 comment as `$LOOP_USER_INPUT`. Natural-language approval always counts as a comment

--- a/packages/docs-web/src/content/docs/guides/approval-nodes.md
+++ b/packages/docs-web/src/content/docs/guides/approval-nodes.md
@@ -138,6 +138,18 @@ bun run cli workflow reject <run-id> --reason "Plan needs more test coverage"
 /workflow reject <run-id> needs changes
 ```
 
+### Interactive-loop gates: bare approve finalizes
+
+Interactive **loop** gates (`loop:`/`loop_group:` with `interactive: true`) share these
+approve surfaces but add one rule: when the gate paused on an iteration that emitted the
+loop's completion signal (the gate message starts with "✅ Completion signal detected"),
+approving **without a comment** finalizes the loop node from the already-computed output —
+no extra iteration runs. Approving **with** a comment runs another iteration with your
+comment as `$LOOP_USER_INPUT`. Natural-language approval always counts as a comment
+(iterates); use the slash command, CLI, web button, or `manage_run` to finalize. See
+[Loop Nodes → `interactive` and `gate_message`](/guides/loop-nodes/#interactive-and-gate_message)
+for the full semantics, `signal_completes`, and the AI-approver steering pattern.
+
 ### Web UI
 
 Paused workflows show an amber pulsing badge on the dashboard. Click **Approve**

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -1274,7 +1274,7 @@ Two primitives handle human-in-the-loop iteration. Use the right one for your pa
 | User input variable | `$LOOP_USER_INPUT` | `$REJECTION_REASON` |
 | How it works | Same prompt runs each iteration, user input injected as variable | Specific on_reject prompt runs only on rejection |
 | Best for | **Conversational iteration** — explore, refine, review cycles where the AI and human go back and forth | **Gate-then-fix** — approve to proceed, or reject to trigger a specific corrective action |
-| Approval signal | AI detects user intent in its output (`<promise>DONE</promise>`) | User explicitly approves or rejects via button/command |
+| Approval signal | AI emits the completion signal (`<promise>DONE</promise>`); a gate that paused on a signaled iteration finalizes on a bare approve | User explicitly approves or rejects via button/command |
 | Example | PIV loop: explore → user feedback → explore again | Report generation: generate → user rejects → AI revises specific section |
 
 **Interactive loop** (`loop.interactive: true`):
@@ -1291,7 +1291,20 @@ Two primitives handle human-in-the-loop iteration. Use the right one for your pa
     gate_message: "Review the plan. Provide feedback or say 'approved'."
 ```
 
-The AI runs each iteration, pauses for user input, user's text feeds into the next iteration via `$LOOP_USER_INPUT`. The AI decides when to emit the completion signal based on the user's response.
+The AI runs each iteration, pauses for user input, and the user's text feeds into the next
+iteration via `$LOOP_USER_INPUT`. What an approve does depends on the paused iteration:
+
+- If the iteration **emitted the completion signal** (the gate says "Completion signal
+  detected"), approving with **no feedback** accepts the result — the node finalizes from
+  the already-computed output with no extra iteration. Approving **with** feedback runs
+  another iteration instead.
+- If it did **not** signal, any approve runs another iteration with your feedback.
+
+For a loop that should complete autonomously on the signal (no gate at all on success —
+e.g. a validation that only needs a human on failure), add `signal_completes: true`. See
+[Loop Nodes → `interactive` and `gate_message`](/guides/loop-nodes/#interactive-and-gate_message)
+and [`signal_completes`](/guides/loop-nodes/#signal_completes--autonomous-completion) for
+the full semantics.
 
 **Approval with on_reject** (`approval.on_reject`):
 

--- a/packages/docs-web/src/content/docs/guides/loop-nodes.md
+++ b/packages/docs-web/src/content/docs/guides/loop-nodes.md
@@ -74,6 +74,9 @@ the executor checks for workflow cancellation.
                             # iteration for user input via /workflow approve.
     gate_message: "..."     # Required when interactive: true. Message shown to the
                             # user at each pause with the run ID and approve command.
+    signal_completes: true  # Optional. Default: false. Interactive loops only: a detected
+                            # completion signal completes the node immediately (even on
+                            # iteration 1) instead of gating for confirmation.
 ```
 
 ### `prompt`
@@ -269,13 +272,69 @@ completion when tests still fail.
 ### `interactive` and `gate_message`
 
 Set `interactive: true` to pause the loop between iterations and wait for human input.
-After each non-completing iteration the executor:
+After each iteration the executor:
 
-1. Sends the `gate_message` to the user along with the run ID and a `/workflow approve` command
+1. Sends the gate message to the user along with the run ID and a `/workflow approve` command.
+   The delivered message starts with an engine-generated status line — whether the iteration
+   emitted the completion signal (plus a bounded excerpt of the iteration output) — followed
+   by your `gate_message` text, so the gate always reports the real iteration outcome.
 2. Pauses the workflow run
-3. Waits — the workflow resumes when the user runs `/workflow approve <id> <feedback>`
+3. Waits — the workflow resumes when the user runs `/workflow approve <id> [feedback]`
 
 The user's feedback is injected into the next iteration's prompt via `$LOOP_USER_INPUT`.
+
+**Approve semantics (finalize vs iterate).** What an approve does depends on whether the
+paused iteration emitted the completion signal:
+
+- **Gate paused on a signal-bearing iteration** (the status line says "Completion signal
+  detected"): `/workflow approve <id>` with **no feedback** *accepts the completion* — the
+  node finalizes from the already-computed output and the workflow proceeds, with **no
+  re-run**. Approving **with feedback** discards the signal and runs another iteration with
+  your feedback as `$LOOP_USER_INPUT`.
+- **Gate paused without the signal:** both forms run another iteration (there is nothing
+  to finalize).
+
+The same rule applies on every approve surface: chat `/workflow approve`, the CLI
+(`archon workflow approve <id> [--json]` — omit the comment to finalize), the HTTP
+endpoint (omit `comment`), the web console ("Accept & complete" with an empty comment
+field), and the `manage_run` chat tool (no `message`, or `accept: true`).
+
+> **Known limitation:** approving via a plain natural-language chat message (not the
+> slash command) always counts as feedback and iterates. To finalize, use
+> `/workflow approve <id>` with no comment, the CLI/web/`manage_run` surfaces above,
+> or `signal_completes`.
+
+### `signal_completes` — autonomous completion
+
+By default an interactive loop **always gates first**, even when the very first iteration
+emits the completion signal — the human confirms before the node completes. If you want
+the signal itself to complete the node (no gate, no approve), set `signal_completes: true`:
+
+```yaml
+  - id: validate
+    loop:
+      prompt: |
+        Run the validation suite. On PASS output <promise>VALIDATED</promise>.
+        On failure, describe what failed and wait for instructions.
+      until: VALIDATED
+      max_iterations: 5
+      interactive: true
+      gate_message: Validation did not pass — review the failures above.
+      signal_completes: true   # signal ⇒ node completes immediately, no gate
+```
+
+With `signal_completes: true` the gate only appears on iterations that did **not** signal —
+the pattern for "pass through on success, pause for a human on failure". The flag has no
+effect on non-interactive loops (the signal already completes them); setting it without
+`interactive: true` emits a loader warning.
+
+**AI approvers / relay steering.** An orchestrating agent can steer another run's gate:
+read the structured gate state first (`archon workflow get <id> --json` →
+`.metadata.approval.completionSignaled`, or the `manage_run` `get` action, which prints
+`completionSignaled`, the iteration, and an output excerpt), then finalize with
+`archon workflow approve <id> --json` (no comment) or `manage_run` approve with
+`accept: true` — or iterate by passing feedback. The `--json` approve records the decision
+without resuming; a later `resume` executes the finalize or the next iteration.
 
 > **Note**: Interactive loop nodes require `interactive: true` at the **workflow level** as
 > well. If only the loop node has `interactive: true`, a loader warning is emitted and the

--- a/packages/docs-web/src/content/docs/guides/loop-nodes.md
+++ b/packages/docs-web/src/content/docs/guides/loop-nodes.md
@@ -275,9 +275,13 @@ Set `interactive: true` to pause the loop between iterations and wait for human 
 After each iteration the executor:
 
 1. Sends the gate message to the user along with the run ID and a `/workflow approve` command.
-   The delivered message starts with an engine-generated status line — whether the iteration
-   emitted the completion signal (plus a bounded excerpt of the iteration output) — followed
-   by your `gate_message` text, so the gate always reports the real iteration outcome.
+   The gate text is engine-generated: a status line — whether the iteration emitted the
+   completion signal, plus a bounded excerpt of the iteration output — followed by your
+   `gate_message`, so the gate always reports the real iteration outcome. The status line
+   **leads the persisted gate message** (`metadata.approval.message`, also the
+   `approval_requested` event data — what `workflow get --json` and `manage_run` read);
+   the chat-delivered message wraps the same text in a `⏸ Input required (loop ..., iteration N):`
+   prefix, so in chat the status line appears right after that prefix.
 2. Pauses the workflow run
 3. Waits — the workflow resumes when the user runs `/workflow approve <id> [feedback]`
 

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -298,6 +298,8 @@ archon workflow abandon <run-id> --json
 
 Approve a paused workflow run at an interactive approval gate. Optionally provide a comment that is available to the workflow via `$LOOP_USER_INPUT`.
 
+**Interactive-loop gates — finalize vs iterate:** when the gate paused on an iteration that emitted the loop's completion signal (`workflow get <run-id> --json` → `.metadata.approval.completionSignaled` is `true`), approving with **no comment** accepts the completion — the node finalizes from the already-computed output on resume, with no re-run. Approving **with** a comment runs another iteration using it as `$LOOP_USER_INPUT`. On a non-signaled gate, both forms run another iteration.
+
 ```bash
 archon workflow approve <run-id>
 archon workflow approve <run-id> "Looks good, proceed"

--- a/packages/docs-web/src/content/docs/reference/commands.md
+++ b/packages/docs-web/src/content/docs/reference/commands.md
@@ -36,7 +36,7 @@ These commands are handled deterministically by the orchestrator — they always
 | `/workflow cancel` | Cancel running workflow |
 | `/workflow resume <id>` | Resume a failed run (re-runs, skipping completed nodes) |
 | `/workflow abandon <id>` | Discard a run (running, paused, or failed) |
-| `/workflow approve <id> [comment]` | Approve a paused workflow run at an approval gate |
+| `/workflow approve <id> [comment]` | Approve a paused workflow run at an approval gate (interactive-loop gates: no comment on a signal-bearing gate = accept & complete; a comment runs another iteration) |
 | `/workflow reject <id> [reason]` | Reject a paused workflow run at an approval gate |
 | `/workflow run <name> [args]` | Run a workflow directly |
 | `/workflow cleanup [days]` | CLI only -- delete old run records (default: 7 days) |

--- a/packages/docs-web/src/content/docs/reference/variables.md
+++ b/packages/docs-web/src/content/docs/reference/variables.md
@@ -25,7 +25,7 @@ These variables are substituted by the workflow executor in all node types (`com
 | `$CONTEXT` | GitHub issue or PR context, if available | Populated when the workflow is triggered from a GitHub issue/PR. Replaced with empty string when unavailable |
 | `$EXTERNAL_CONTEXT` | Same as `$CONTEXT` | Alias |
 | `$ISSUE_CONTEXT` | Same as `$CONTEXT` | Alias |
-| `$LOOP_USER_INPUT` | User feedback from an interactive loop approval gate | Only populated on the first iteration of a resumed interactive loop. Empty string on all other iterations |
+| `$LOOP_USER_INPUT` | User feedback from an interactive loop approval gate | Only populated on the first iteration of a resumed interactive loop. Empty string on all other iterations. On a signal-bearing gate, a bare approve (no feedback) finalizes the node without a new iteration, so the variable is never read |
 | `$REJECTION_REASON` | Reviewer feedback from an approval node rejection | Only available in `on_reject` prompts. Empty string elsewhere |
 | `$LOOP_PREV_OUTPUT` | Cleaned output of the previous loop iteration (loop nodes only) | Empty string on the first iteration. Useful for `fresh_context: true` loops that need to reference the prior pass without carrying the full session history |
 | `$LOOP_PREV.<nodeId>.output` | A body node's output from the previous iteration (loop_group body nodes only) | Empty string on iteration 1. `$LOOP_PREV.<nodeId>.output.<field>` accesses structured-output fields with the same strict semantics as `$nodeId.output.field`. See [Cross-Node Loops](/guides/loop-nodes/#cross-node-loops-with-loop_group) |

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -3247,7 +3247,24 @@ export function registerApiRoutes(
           `Workflow run was already ${String(approval.resolved)} — resume in progress`
         );
       }
-      const body = (await c.req.json().catch(() => ({}))) as { comment?: string };
+      // Distinguish "no body sent" (legitimate bare approve) from "body sent but
+      // unparseable" (client bug). Since #2074 a bare approve FINALIZES a
+      // signal-bearing loop gate, so silently coercing a malformed body to {}
+      // would discard intended feedback and finalize undiagnosed — reject it.
+      const rawBody = await c.req.text();
+      let body: { comment?: string } = {};
+      if (rawBody.trim().length > 0) {
+        try {
+          body = JSON.parse(rawBody) as { comment?: string };
+        } catch (parseError) {
+          getLog().warn({ err: parseError, runId }, 'api.approve_body_parse_failed');
+          return apiError(
+            c,
+            400,
+            'Request body is not valid JSON — send {"comment": "..."} or no body'
+          );
+        }
+      }
       // Shared gate logic (events, telemetry, metadata staging) — the run stays
       // 'paused' with metadata.approval.resolved = 'approved' (#2075). The
       // pre-checks above map the common error cases to 400s; approveWorkflow
@@ -3298,7 +3315,22 @@ export function registerApiRoutes(
           `Workflow run was already ${String(approval.resolved)} — resume in progress`
         );
       }
-      const body = (await c.req.json().catch(() => ({}))) as { reason?: string };
+      // Mirror of the approve route's malformed-body guard: a swallowed parse
+      // failure would silently drop the reviewer's reason.
+      const rawBody = await c.req.text();
+      let body: { reason?: string } = {};
+      if (rawBody.trim().length > 0) {
+        try {
+          body = JSON.parse(rawBody) as { reason?: string };
+        } catch (parseError) {
+          getLog().warn({ err: parseError, runId }, 'api.reject_body_parse_failed');
+          return apiError(
+            c,
+            400,
+            'Request body is not valid JSON — send {"reason": "..."} or no body'
+          );
+        }
+      }
       const reason = body.reason ?? 'Rejected';
       // Shared gate logic (events, telemetry, staging/cancel decision). When an
       // on_reject rework is staged the run stays 'paused' with

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -3248,12 +3248,15 @@ export function registerApiRoutes(
         );
       }
       const body = (await c.req.json().catch(() => ({}))) as { comment?: string };
-      const comment = body.comment ?? 'Approved';
       // Shared gate logic (events, telemetry, metadata staging) — the run stays
       // 'paused' with metadata.approval.resolved = 'approved' (#2075). The
       // pre-checks above map the common error cases to 400s; approveWorkflow
       // re-validates and anything it throws past them is a 500.
-      await approveWorkflow(runId, comment);
+      // The raw (possibly undefined) comment is passed through — approveWorkflow
+      // defaults the recorded comment internally, but "no feedback" must survive
+      // so a signal-bearing interactive-loop gate finalizes instead of re-running
+      // (#2074, loop_feedback_given).
+      await approveWorkflow(runId, body.comment);
 
       // Auto-resume: dispatch to the orchestrator so the workflow continues
       // without requiring the user to re-run the workflow command. Mirrors

--- a/packages/server/src/routes/api.workflow-runs.test.ts
+++ b/packages/server/src/routes/api.workflow-runs.test.ts
@@ -1409,6 +1409,69 @@ describe('POST /api/workflows/runs/:runId/approve', () => {
     });
     expect(mockCaptureApprovalResolved).toHaveBeenCalledWith({ resolution: 'approved' });
   });
+
+  test('passes an absent comment through as no-feedback on an interactive_loop gate (#2074)', async () => {
+    // The route must NOT default the comment to 'Approved' — approveWorkflow derives
+    // loop_feedback_given from the RAW comment, and a masked no-feedback would make
+    // every web approve iterate instead of finalize.
+    mockGetWorkflowRun.mockResolvedValue({
+      ...MOCK_PAUSED_RUN,
+      id: 'run-loop-bare',
+      metadata: {
+        approval: {
+          type: 'interactive_loop',
+          nodeId: 'refine',
+          message: 'gate',
+          iteration: 1,
+          completionSignaled: true,
+          signaledOutput: 'REPORT',
+        },
+      },
+    });
+    const { app } = makeApp();
+    const response = await app.request('/api/workflows/runs/run-loop-bare/approve', {
+      method: 'POST',
+      body: JSON.stringify({}),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(response.status).toBe(200);
+    const updateCall = mockUpdateWorkflowRun.mock.calls[0] as unknown[];
+    expect(updateCall[1]).toMatchObject({
+      metadata: {
+        loop_feedback_given: false,
+        loop_user_input: 'Approved',
+      },
+    });
+  });
+
+  test('passes a provided comment through as feedback on an interactive_loop gate (#2074)', async () => {
+    mockGetWorkflowRun.mockResolvedValue({
+      ...MOCK_PAUSED_RUN,
+      id: 'run-loop-feedback',
+      metadata: {
+        approval: {
+          type: 'interactive_loop',
+          nodeId: 'refine',
+          message: 'gate',
+          iteration: 1,
+        },
+      },
+    });
+    const { app } = makeApp();
+    const response = await app.request('/api/workflows/runs/run-loop-feedback/approve', {
+      method: 'POST',
+      body: JSON.stringify({ comment: 'actually re-check X' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(response.status).toBe(200);
+    const updateCall = mockUpdateWorkflowRun.mock.calls[0] as unknown[];
+    expect(updateCall[1]).toMatchObject({
+      metadata: {
+        loop_feedback_given: true,
+        loop_user_input: 'actually re-check X',
+      },
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/routes/api.workflow-runs.test.ts
+++ b/packages/server/src/routes/api.workflow-runs.test.ts
@@ -1444,6 +1444,33 @@ describe('POST /api/workflows/runs/:runId/approve', () => {
     });
   });
 
+  test('returns 400 (not a silent bare approve) when the body is sent but malformed (#2074)', async () => {
+    mockGetWorkflowRun.mockResolvedValue({
+      ...MOCK_PAUSED_RUN,
+      id: 'run-bad-body',
+      metadata: {
+        approval: {
+          type: 'interactive_loop',
+          nodeId: 'refine',
+          message: 'gate',
+          iteration: 1,
+          completionSignaled: true,
+          signaledOutput: 'REPORT',
+        },
+      },
+    });
+    const { app } = makeApp();
+    const response = await app.request('/api/workflows/runs/run-bad-body/approve', {
+      method: 'POST',
+      body: '{"comment": "intended feedback', // truncated JSON — client bug
+      headers: { 'Content-Type': 'application/json' },
+    });
+    // A malformed body must never be coerced into a bare approve — that would
+    // FINALIZE a signal-bearing gate while silently discarding the feedback.
+    expect(response.status).toBe(400);
+    expect(mockUpdateWorkflowRun).not.toHaveBeenCalled();
+  });
+
   test('passes a provided comment through as feedback on an interactive_loop gate (#2074)', async () => {
     mockGetWorkflowRun.mockResolvedValue({
       ...MOCK_PAUSED_RUN,

--- a/packages/web/src/experiments/console/components/ApprovalPanel.tsx
+++ b/packages/web/src/experiments/console/components/ApprovalPanel.tsx
@@ -153,7 +153,11 @@ export function ApprovalPanel({ run }: ApprovalPanelProps): ReactElement {
             onClick={() => void approve()}
             disabled={busy}
             className="flex shrink-0 items-center gap-1 rounded border border-success/40 bg-success/15 px-3 text-[12px] font-medium text-success transition-colors hover:bg-success/25 disabled:opacity-50"
-            title={signalBearing ? 'Accept & complete · Enter' : 'Continue · Enter'}
+            title={
+              signalBearing && comment.trim().length === 0
+                ? 'Accept & complete · Enter'
+                : 'Continue · Enter'
+            }
           >
             {signalBearing && comment.trim().length === 0 ? 'Accept & complete' : 'Continue'}
             <span aria-hidden className="font-mono text-[10px] opacity-70">

--- a/packages/web/src/experiments/console/components/ApprovalPanel.tsx
+++ b/packages/web/src/experiments/console/components/ApprovalPanel.tsx
@@ -38,6 +38,11 @@ export function ApprovalPanel({ run }: ApprovalPanelProps): ReactElement {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const isDemo = run.id.startsWith('demo-');
+  // Signal-bearing interactive-loop gate (#2074): a bare approve finalizes the
+  // node from the already-computed output (no re-run); a comment runs another
+  // iteration with it as feedback. Same approveRun call either way — the
+  // backend derives finalize-vs-iterate from comment presence.
+  const signalBearing = run.approval?.completionSignaled === true;
 
   const stopPropagation = (e: MouseEvent | ReactKeyboardEvent): void => {
     e.stopPropagation();
@@ -133,7 +138,11 @@ export function ApprovalPanel({ run }: ApprovalPanelProps): ReactElement {
               if (error !== null) setError(null);
             }}
             onKeyDown={onApproveKey}
-            placeholder="optional comment to send with approval"
+            placeholder={
+              signalBearing
+                ? 'add feedback to run another iteration instead'
+                : 'optional comment to send with approval'
+            }
             disabled={busy}
             autoFocus
             className="min-w-0 flex-1 rounded border border-border bg-surface-inset px-3 py-1.5 text-[13px] text-text-primary placeholder:text-text-tertiary focus:border-border-bright focus:outline-none disabled:opacity-50"
@@ -144,9 +153,9 @@ export function ApprovalPanel({ run }: ApprovalPanelProps): ReactElement {
             onClick={() => void approve()}
             disabled={busy}
             className="flex shrink-0 items-center gap-1 rounded border border-success/40 bg-success/15 px-3 text-[12px] font-medium text-success transition-colors hover:bg-success/25 disabled:opacity-50"
-            title="Continue · Enter"
+            title={signalBearing ? 'Accept & complete · Enter' : 'Continue · Enter'}
           >
-            Continue
+            {signalBearing && comment.trim().length === 0 ? 'Accept & complete' : 'Continue'}
             <span aria-hidden className="font-mono text-[10px] opacity-70">
               ↵
             </span>

--- a/packages/web/src/experiments/console/primitives/run.test.ts
+++ b/packages/web/src/experiments/console/primitives/run.test.ts
@@ -121,7 +121,27 @@ describe('toRun — approval parsing', () => {
         metadata: { approval: { nodeId: 'gate', message: 'Approve?' } },
       })
     );
-    expect(r.approval).toEqual({ nodeId: 'gate', message: 'Approve?' });
+    expect(r.approval).toEqual({ nodeId: 'gate', message: 'Approve?', completionSignaled: false });
+  });
+
+  test('surfaces completionSignaled on a signal-bearing interactive-loop gate (#2074)', () => {
+    const r = toRun(
+      raw({
+        id: 'r1',
+        workflow_name: 'validate',
+        status: 'paused',
+        metadata: {
+          approval: {
+            nodeId: 'refine',
+            message: 'gate',
+            type: 'interactive_loop',
+            completionSignaled: true,
+            signaledOutput: 'REPORT',
+          },
+        },
+      })
+    );
+    expect(r.approval?.completionSignaled).toBe(true);
   });
 
   test('defaults message to empty string when only nodeId is present', () => {
@@ -133,7 +153,7 @@ describe('toRun — approval parsing', () => {
         metadata: { approval: { nodeId: 'gate' } },
       })
     );
-    expect(r.approval).toEqual({ nodeId: 'gate', message: '' });
+    expect(r.approval).toEqual({ nodeId: 'gate', message: '', completionSignaled: false });
   });
 
   test('approval is null when absent or malformed (no string nodeId)', () => {
@@ -188,7 +208,7 @@ describe('toRun — resolved gate (approved/rejected awaiting resume)', () => {
         metadata: { approval: { nodeId: 'gate', message: 'Approve?', resolved: null } },
       })
     );
-    expect(r.approval).toEqual({ nodeId: 'gate', message: 'Approve?' });
+    expect(r.approval).toEqual({ nodeId: 'gate', message: 'Approve?', completionSignaled: false });
     expect(r.gateResolved).toBeNull();
   });
 
@@ -201,7 +221,7 @@ describe('toRun — resolved gate (approved/rejected awaiting resume)', () => {
         metadata: { approval: { nodeId: 'gate', message: 'Approve?', resolved: 'weird' } },
       })
     );
-    expect(r.approval).toEqual({ nodeId: 'gate', message: 'Approve?' });
+    expect(r.approval).toEqual({ nodeId: 'gate', message: 'Approve?', completionSignaled: false });
     expect(r.gateResolved).toBeNull();
   });
 });

--- a/packages/web/src/experiments/console/primitives/run.ts
+++ b/packages/web/src/experiments/console/primitives/run.ts
@@ -35,7 +35,7 @@ export interface Run {
    * iteration that emitted its completion signal (#2074) — a bare approve
    * finalizes the node (no re-run); a comment runs another iteration.
    */
-  approval?: { nodeId: string; message: string; completionSignaled?: boolean } | null;
+  approval?: { nodeId: string; message: string; completionSignaled: boolean } | null;
   /**
    * Set when a paused run's gate was already approved/rejected and the run is
    * only awaiting auto-resume (server: metadata.approval.resolved). The

--- a/packages/web/src/experiments/console/primitives/run.ts
+++ b/packages/web/src/experiments/console/primitives/run.ts
@@ -29,8 +29,13 @@ export interface Run {
   /** Derived from metadata/events at runtime; initially undefined. */
   currentNode?: string | null;
   lastTool?: string | null;
-  /** Pending human gate. Null once the gate is resolved (see gateResolved). */
-  approval?: { nodeId: string; message: string } | null;
+  /**
+   * Pending human gate. Null once the gate is resolved (see gateResolved).
+   * `completionSignaled` is true when an interactive-loop gate paused on an
+   * iteration that emitted its completion signal (#2074) — a bare approve
+   * finalizes the node (no re-run); a comment runs another iteration.
+   */
+  approval?: { nodeId: string; message: string; completionSignaled?: boolean } | null;
   /**
    * Set when a paused run's gate was already approved/rejected and the run is
    * only awaiting auto-resume (server: metadata.approval.resolved). The
@@ -122,6 +127,8 @@ export function toRun(raw: RawWorkflowRun): Run {
             'message' in approval && typeof (approval as { message: unknown }).message === 'string'
               ? (approval as { message: string }).message
               : '',
+          completionSignaled:
+            (approval as { completionSignaled?: unknown }).completionSignaled === true,
         }
       : null;
 

--- a/packages/web/src/experiments/console/routes/PreviewPage.tsx
+++ b/packages/web/src/experiments/console/routes/PreviewPage.tsx
@@ -45,6 +45,7 @@ const SAMPLE_RUNS: Run[] = [
     approval: {
       nodeId: 'implement/verify',
       message: 'Approve running bun validate?',
+      completionSignaled: false,
     },
   },
   {

--- a/packages/web/src/experiments/console/routes/RunsPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunsPage.tsx
@@ -86,6 +86,7 @@ function buildDemoRuns(scope: Scope, projectName: string | null): Run[] {
         nodeId: 'foundation-gate',
         message:
           'Answer the foundation questions above. Your answers will guide the research phase.',
+        completionSignaled: false,
       },
     },
     {
@@ -100,6 +101,7 @@ function buildDemoRuns(scope: Scope, projectName: string | null): Run[] {
       approval: {
         nodeId: 'review/approve',
         message: 'Approve changes before opening PR?',
+        completionSignaled: false,
       },
     },
     {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -5103,8 +5103,14 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         type: 'interactive_loop',
         nodeId: 'refine',
         iteration: 1,
-        message: 'Review the plan and provide feedback.',
+        // No signal this iteration — the engine-generated status line says so (#2074)
+        // and the author's gate text is preserved at the end.
+        completionSignaled: false,
+        signaledOutput: null,
       });
+      const pausedMessage = (pauseCalls[0][1] as { message: string }).message;
+      expect(pausedMessage).toContain('No completion signal');
+      expect(pausedMessage).toContain('Review the plan and provide feedback.');
     });
 
     it('interactive loop first iteration always gates even if AI emits signal', async () => {
@@ -5163,7 +5169,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         type: 'interactive_loop',
         nodeId: 'refine',
         iteration: 1,
+        // The gate persists the signal state (#2074) so a bare approve can
+        // finalize at resume instead of re-running the iteration.
+        completionSignaled: true,
       });
+      const signaledOutput = (pauseCalls[0][1] as { signaledOutput: string }).signaledOutput;
+      expect(signaledOutput).toContain('Plan approved');
+      const gateMessage = (pauseCalls[0][1] as { message: string }).message;
+      expect(gateMessage).toContain('Completion signal detected');
+      expect(gateMessage).toContain('Review and provide feedback.');
     });
 
     it('interactive loop exits on resume when AI emits completion signal (user approved)', async () => {
@@ -5293,6 +5307,256 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // Should have resumed with stored session ID
       const sessionArg = mockSendQueryDag.mock.calls[0][2] as string | undefined;
       expect(sessionArg).toBe('loop-session-1');
+    });
+
+    it('signal_completes: true completes the loop on a first-iteration signal without gating (#2074 B)', async () => {
+      mockSendQueryDag.mockImplementation(function* () {
+        yield { type: 'assistant', content: 'Validation PASS. <promise>VALIDATED</promise>' };
+        yield { type: 'result', sessionId: 'sc-session-1' };
+      });
+
+      const mockDeps = createMockDeps();
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun('signal-completes-run');
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        {
+          name: 'signal-completes-test',
+          nodes: [
+            {
+              id: 'validate',
+              loop: {
+                prompt: 'Validate. Emit VALIDATED on pass.',
+                until: 'VALIDATED',
+                max_iterations: 10,
+                interactive: true,
+                gate_message: 'Review the validation result.',
+                signal_completes: true,
+              },
+            },
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      // No gate: the node completed autonomously on the signal.
+      const pauseCalls = (mockDeps.store.pauseWorkflowRun as Mock<() => Promise<void>>).mock.calls;
+      expect(pauseCalls.length).toBe(0);
+      const eventCalls = (
+        mockDeps.store.createWorkflowEvent as Mock<
+          (e: {
+            event_type: string;
+            step_name: string;
+            data: Record<string, unknown>;
+          }) => Promise<void>
+        >
+      ).mock.calls;
+      const completed = eventCalls.filter(
+        c => c[0].event_type === 'node_completed' && c[0].step_name === 'validate'
+      );
+      expect(completed.length).toBe(1);
+      expect(String(completed[0][0].data.node_output)).toContain('Validation PASS');
+    });
+
+    it('finalizes at resume from persisted signaledOutput on a bare approve — no re-run (#2074 C)', async () => {
+      mockSendQueryDag.mockImplementation(function* () {
+        yield { type: 'assistant', content: 'should never run' };
+        yield { type: 'result', sessionId: 'never' };
+      });
+
+      const mockDeps = createMockDeps();
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun('finalize-run', {
+        metadata: {
+          approval: {
+            type: 'interactive_loop',
+            nodeId: 'refine',
+            iteration: 1,
+            sessionId: 'sig-session-1',
+            message: 'gate',
+            completionSignaled: true,
+            signaledOutput: 'REPORT',
+          },
+          loop_user_input: 'Approved',
+          loop_feedback_given: false,
+        },
+      });
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        {
+          name: 'finalize-on-approve',
+          nodes: [
+            {
+              id: 'refine',
+              loop: {
+                prompt: 'Refine.',
+                until: 'APPROVED',
+                max_iterations: 10,
+                interactive: true,
+                gate_message: 'Review.',
+              },
+            },
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      // No new iteration ran — the node finalized from the persisted output.
+      expect(mockSendQueryDag.mock.calls.length).toBe(0);
+      const eventCalls = (
+        mockDeps.store.createWorkflowEvent as Mock<
+          (e: {
+            event_type: string;
+            step_name: string;
+            data: Record<string, unknown>;
+          }) => Promise<void>
+        >
+      ).mock.calls;
+      const completed = eventCalls.filter(
+        c => c[0].event_type === 'node_completed' && c[0].step_name === 'refine'
+      );
+      expect(completed.length).toBe(1);
+      expect(completed[0][0].data.node_output).toBe('REPORT');
+    });
+
+    it('iterates at resume when feedback was given, even on a signal-bearing gate (#2074 C)', async () => {
+      mockSendQueryDag.mockImplementation(function* () {
+        yield { type: 'assistant', content: 'Re-checked X. <promise>APPROVED</promise>' };
+        yield { type: 'result', sessionId: 'iter-session-2' };
+      });
+
+      const mockDeps = createMockDeps();
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun('feedback-iterates-run', {
+        metadata: {
+          approval: {
+            type: 'interactive_loop',
+            nodeId: 'refine',
+            iteration: 1,
+            sessionId: 'sig-session-1',
+            message: 'gate',
+            completionSignaled: true,
+            signaledOutput: 'REPORT',
+          },
+          loop_user_input: 'actually re-check X',
+          loop_feedback_given: true,
+        },
+      });
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        {
+          name: 'feedback-iterates',
+          nodes: [
+            {
+              id: 'refine',
+              loop: {
+                prompt: 'User said: $LOOP_USER_INPUT. Refine.',
+                until: 'APPROVED',
+                max_iterations: 10,
+                interactive: true,
+                gate_message: 'Review.',
+              },
+            },
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      // Feedback ⇒ a fresh iteration ran with $LOOP_USER_INPUT substituted.
+      expect(mockSendQueryDag.mock.calls.length).toBe(1);
+      const promptArg = mockSendQueryDag.mock.calls[0][0] as string;
+      expect(promptArg).toContain('actually re-check X');
+    });
+
+    it('iterates at resume on a non-signaled gate even without feedback (#2074 C)', async () => {
+      mockSendQueryDag.mockImplementation(function* () {
+        yield { type: 'assistant', content: 'Another pass. <promise>APPROVED</promise>' };
+        yield { type: 'result', sessionId: 'iter-session-3' };
+      });
+
+      const mockDeps = createMockDeps();
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun('nonsignaled-iterates-run', {
+        metadata: {
+          approval: {
+            type: 'interactive_loop',
+            nodeId: 'refine',
+            iteration: 1,
+            sessionId: 'sig-session-1',
+            message: 'gate',
+            completionSignaled: false,
+            signaledOutput: null,
+          },
+          loop_user_input: 'Approved',
+          loop_feedback_given: false,
+        },
+      });
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        {
+          name: 'nonsignaled-iterates',
+          nodes: [
+            {
+              id: 'refine',
+              loop: {
+                prompt: 'Refine.',
+                until: 'APPROVED',
+                max_iterations: 10,
+                interactive: true,
+                gate_message: 'Review.',
+              },
+            },
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      // Nothing to finalize — a normal resumed iteration ran.
+      expect(mockSendQueryDag.mock.calls.length).toBe(1);
     });
 
     it('loop iteration fails loudly when SDK returns error_during_execution', async () => {
@@ -11121,8 +11385,205 @@ describe('executeDagWorkflow -- loop_group node', () => {
       type: 'interactive_loop',
       nodeId: 'refine',
       iteration: 1,
-      message: 'Review the result.',
+      completionSignaled: false,
+      signaledOutput: null,
     });
+    const pausedGroupMessage = (pauseCalls[0][1] as { message: string }).message;
+    expect(pausedGroupMessage).toContain('No completion signal');
+    expect(pausedGroupMessage).toContain('Review the result.');
+  });
+
+  it('INTERACTIVE: loop_group gate persists signal state when iteration 1 signals (#2074)', async () => {
+    // Signal on iteration 1 of a fresh interactive loop_group (no signal_completes):
+    // still gates, but the pause carries completionSignaled + signaledOutput so a
+    // bare approve can finalize at resume.
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'validation PASS\nAPPROVED' };
+      yield { type: 'result', sessionId: 'lg-sig-sess-1' };
+    });
+
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('lg-signal-gate');
+
+    const nodes: DagNode[] = [
+      {
+        id: 'refine',
+        loop_group: {
+          until: 'APPROVED',
+          max_iterations: 5,
+          fresh_context: false,
+          interactive: true,
+          gate_message: 'Review the result.',
+          nodes: [{ id: 'work', prompt: 'validate', depends_on: [] }],
+        },
+        depends_on: [],
+      },
+    ];
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-lg',
+      testDir,
+      { name: 'lg-signal-gate', nodes },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const pauseCalls = (
+      mockDeps.store.pauseWorkflowRun as Mock<
+        (id: string, ctx: Record<string, unknown>) => Promise<void>
+      >
+    ).mock.calls;
+    expect(pauseCalls.length).toBe(1);
+    expect(pauseCalls[0][1]).toMatchObject({
+      type: 'interactive_loop',
+      nodeId: 'refine',
+      iteration: 1,
+      completionSignaled: true,
+    });
+    expect(String(pauseCalls[0][1].signaledOutput)).toContain('validation PASS');
+    expect(String(pauseCalls[0][1].message)).toContain('Completion signal detected');
+  });
+
+  it('INTERACTIVE: loop_group signal_completes completes on a first-iteration signal without gating (#2074 B)', async () => {
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'validation PASS\nAPPROVED' };
+      yield { type: 'result', sessionId: 'lg-sc-sess-1' };
+    });
+
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('lg-signal-completes');
+
+    const nodes: DagNode[] = [
+      {
+        id: 'refine',
+        loop_group: {
+          until: 'APPROVED',
+          max_iterations: 5,
+          fresh_context: false,
+          interactive: true,
+          gate_message: 'Review the result.',
+          signal_completes: true,
+          nodes: [{ id: 'work', prompt: 'validate', depends_on: [] }],
+        },
+        depends_on: [],
+      },
+    ];
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-lg',
+      testDir,
+      { name: 'lg-signal-completes', nodes },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const pauseCalls = (mockDeps.store.pauseWorkflowRun as Mock<() => Promise<void>>).mock.calls;
+    expect(pauseCalls.length).toBe(0);
+    const eventCalls = (
+      mockDeps.store.createWorkflowEvent as Mock<
+        (e: {
+          event_type: string;
+          step_name: string;
+          data: Record<string, unknown>;
+        }) => Promise<void>
+      >
+    ).mock.calls;
+    const completed = eventCalls.filter(
+      c => c[0].event_type === 'node_completed' && c[0].step_name === 'refine'
+    );
+    expect(completed.length).toBe(1);
+  });
+
+  it('INTERACTIVE: loop_group finalizes at resume from persisted signaledOutput on a bare approve (#2074 C)', async () => {
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'should never run' };
+      yield { type: 'result', sessionId: 'never' };
+    });
+
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('lg-finalize', {
+      metadata: {
+        approval: {
+          type: 'interactive_loop',
+          nodeId: 'refine',
+          iteration: 1,
+          sessionId: 'lg-sig-sess-1',
+          sessionProvider: 'claude',
+          message: 'gate',
+          completionSignaled: true,
+          signaledOutput: 'GROUP REPORT',
+        },
+        loop_user_input: 'Approved',
+        loop_feedback_given: false,
+      },
+    });
+
+    const nodes: DagNode[] = [
+      {
+        id: 'refine',
+        loop_group: {
+          until: 'APPROVED',
+          max_iterations: 5,
+          fresh_context: false,
+          interactive: true,
+          gate_message: 'Review the result.',
+          nodes: [{ id: 'work', prompt: 'validate', depends_on: [] }],
+        },
+        depends_on: [],
+      },
+    ];
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-lg',
+      testDir,
+      { name: 'lg-finalize', nodes },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    // No body iteration ran — the group finalized from the persisted output.
+    expect(mockSendQueryDag.mock.calls.length).toBe(0);
+    const eventCalls = (
+      mockDeps.store.createWorkflowEvent as Mock<
+        (e: {
+          event_type: string;
+          step_name: string;
+          data: Record<string, unknown>;
+        }) => Promise<void>
+      >
+    ).mock.calls;
+    const completed = eventCalls.filter(
+      c => c[0].event_type === 'node_completed' && c[0].step_name === 'refine'
+    );
+    expect(completed.length).toBe(1);
+    expect(completed[0][0].data.node_output).toBe('GROUP REPORT');
   });
 
   it('INTERACTIVE: resumed loop_group continues from the next iteration and completes', async () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -5559,6 +5559,66 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
     });
 
+    it('LEGACY: resume with pre-#2074 approval metadata (no completionSignaled/signaledOutput keys) iterates', async () => {
+      // Rows paused before #2074 have neither key in metadata.approval and no
+      // loop_feedback_given — the finalize path must NOT trigger; the loop runs
+      // a normal resumed iteration exactly as before.
+      mockSendQueryDag.mockImplementation(function* () {
+        yield { type: 'assistant', content: 'Legacy pass. <promise>APPROVED</promise>' };
+        yield { type: 'result', sessionId: 'legacy-session-2' };
+      });
+
+      const mockDeps = createMockDeps();
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun('legacy-resume-run', {
+        metadata: {
+          approval: {
+            type: 'interactive_loop',
+            nodeId: 'refine',
+            iteration: 1,
+            sessionId: 'legacy-session-1',
+            message: 'Review and provide feedback.',
+          },
+          loop_user_input: 'approved',
+        },
+      });
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        {
+          name: 'legacy-loop-resume',
+          nodes: [
+            {
+              id: 'refine',
+              loop: {
+                prompt: 'User said: $LOOP_USER_INPUT. Refine.',
+                until: 'APPROVED',
+                max_iterations: 10,
+                interactive: true,
+                gate_message: 'Review and provide feedback.',
+              },
+            },
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      // A real iteration ran (no zero-duration finalize short-circuit).
+      expect(mockSendQueryDag.mock.calls.length).toBe(1);
+      const promptArg = mockSendQueryDag.mock.calls[0][0] as string;
+      expect(promptArg).toContain('approved');
+    });
+
     it('loop iteration fails loudly when SDK returns error_during_execution', async () => {
       // Regression test for #1208: previously the loop silently broke on isError
       // results and kept iterating with empty output, producing "5-second crashes"

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -2429,6 +2429,35 @@ async function executeScriptNode(
   }
 }
 
+/** Cap for the iteration-output excerpt embedded in gate messages — keeps the
+ *  persisted `metadata.approval.message` and SSE payloads bounded (mirrors the
+ *  tool-input truncation used for progress events). */
+const GATE_EXCERPT_MAX = 500;
+
+/**
+ * Build the honest interactive-gate message (#2074, change D): an engine-generated
+ * status line (was the completion signal detected?) plus a bounded excerpt of the
+ * final iteration output, prepended to the author's static `gate_message`. Shared
+ * by executeLoopNode and executeLoopGroupNode so both gates tell the truth about
+ * the iteration they paused on.
+ */
+function buildHonestGateMessage(
+  completionDetected: boolean,
+  untilSignal: string,
+  lastIterationOutput: string,
+  gateMessage: string
+): string {
+  const trimmed = lastIterationOutput.trim();
+  const excerpt = trimmed.slice(0, GATE_EXCERPT_MAX);
+  const statusLine = completionDetected
+    ? `✅ Completion signal detected (\`${untilSignal}\`).`
+    : `⚠️ No completion signal (\`${untilSignal}\`) in this iteration.`;
+  const excerptBlock = excerpt
+    ? `\n\n> ${excerpt}${trimmed.length > GATE_EXCERPT_MAX ? '…' : ''}`
+    : '';
+  return `${statusLine}${excerptBlock}\n\n${gateMessage}`;
+}
+
 /**
  * Execute a loop-group node — runs a multi-node sub-DAG body repeatedly until a
  * completion condition (`until` signal in the body's terminal-node output, and/or
@@ -2497,6 +2526,41 @@ async function executeLoopGroupNode(
   const loopUserInput = isLoopResume
     ? ((workflowRun.metadata?.loop_user_input as string | undefined) ?? '')
     : '';
+
+  // Finalize-on-approve (#2074): mirrors executeLoopNode — a signal-bearing gate
+  // resumed WITHOUT feedback completes the group from the persisted output instead
+  // of re-running the body.
+  const feedbackGiven = workflowRun.metadata?.loop_feedback_given === true;
+  if (isLoopResume && loopGateMeta?.completionSignaled === true && !feedbackGiven) {
+    const finalizeOutput = loopGateMeta.signaledOutput ?? '';
+    await safeSendMessage(
+      platform,
+      conversationId,
+      `Loop-group node '${node.id}' accepted at the completion signal (no re-run)`,
+      msgContext
+    );
+    await deps.store
+      .createWorkflowEvent({
+        workflow_run_id: workflowRun.id,
+        event_type: 'node_completed',
+        step_name: stepName,
+        data: { duration_ms: 0, node_output: finalizeOutput },
+      })
+      .catch((err: Error) => {
+        getLog().error(
+          { err, workflowRunId: workflowRun.id, eventType: 'node_completed' },
+          'workflow_event_persist_failed'
+        );
+      });
+    getWorkflowEventEmitter().emit({
+      type: 'node_completed',
+      runId: workflowRun.id,
+      nodeId: node.id,
+      nodeName: node.id,
+      duration: 0,
+    });
+    return { state: 'completed', output: finalizeOutput };
+  }
 
   let loopPrevOutputs: Map<string, NodeOutput> | undefined; // undefined on iteration 1
   let lastIterationOutput = '';
@@ -2800,9 +2864,11 @@ async function executeLoopGroupNode(
       });
 
     // Completion: honor the signal only when the AI had input to evaluate (interactive
-    // first run always gates first — mirrors executeLoopNode's interactiveFirstRun).
+    // first run always gates first — mirrors executeLoopNode's interactiveFirstRun),
+    // UNLESS the author opted into autonomous completion via signal_completes (#2074).
     const interactiveFirstRun = group.interactive && !isLoopResume;
-    if (completionDetected && !interactiveFirstRun) {
+    const signalCompletes = group.signal_completes === true;
+    if (completionDetected && (!interactiveFirstRun || signalCompletes)) {
       await safeSendMessage(
         platform,
         conversationId,
@@ -2843,10 +2909,18 @@ async function executeLoopGroupNode(
       };
     }
 
-    // Interactive gate — pause after an iteration that did not complete.
+    // Interactive gate — pause after an iteration that did not complete (or, when
+    // interactiveFirstRun && !signalCompletes, an iteration that DID signal — the honest
+    // status line + persisted signal state (#2074) let a bare approve finalize it).
     if (group.interactive && group.gate_message) {
+      const honestMessage = buildHonestGateMessage(
+        completionDetected,
+        group.until,
+        lastIterationOutput,
+        group.gate_message
+      );
       const gateMsg =
-        `⏸ **Input required** (loop_group \`${node.id}\`, iteration ${String(i)}): ${group.gate_message}\n\n` +
+        `⏸ **Input required** (loop_group \`${node.id}\`, iteration ${String(i)}): ${honestMessage}\n\n` +
         `Run ID: \`${workflowRun.id}\`\n` +
         `Respond: \`/workflow approve ${workflowRun.id} <your feedback>\` | Cancel: \`/workflow reject ${workflowRun.id}\``;
       const gateSent = await safeSendMessage(platform, conversationId, gateMsg, {
@@ -2869,14 +2943,14 @@ async function executeLoopGroupNode(
           workflow_run_id: workflowRun.id,
           event_type: 'approval_requested',
           step_name: stepName,
-          data: { message: group.gate_message, iteration: i },
+          data: { message: honestMessage, iteration: i, completionSignaled: completionDetected },
         })
         .catch((err: Error) => {
           logEventStoreError(err, i);
         });
       await deps.store.pauseWorkflowRun(workflowRun.id, {
         nodeId: node.id,
-        message: group.gate_message,
+        message: honestMessage,
         type: 'interactive_loop',
         iteration: i,
         // Persist the body's session cursor so a resumed fresh_context: false loop
@@ -2888,12 +2962,16 @@ async function executeLoopGroupNode(
         // convention as `resolved`; RFC 7396 null removes the key).
         sessionId: loopLastSequentialSession?.sessionId ?? null,
         sessionProvider: loopLastSequentialSession?.provider ?? null,
+        // Signal state for finalize-on-bare-approve (#2074): written unconditionally
+        // for honesty; pauseWorkflowRun nulls both on every fresh pause.
+        completionSignaled: completionDetected,
+        signaledOutput: completionDetected ? lastIterationOutput : null,
       });
       getWorkflowEventEmitter().emit({
         type: 'approval_pending',
         runId: workflowRun.id,
         nodeId: node.id,
-        message: group.gate_message,
+        message: honestMessage,
       });
       return {
         state: 'completed',
@@ -3062,6 +3140,42 @@ async function executeLoopNode(
   const loopUserInput = isLoopResume
     ? ((workflowRun.metadata?.loop_user_input as string | undefined) ?? '')
     : '';
+
+  // Finalize-on-approve (#2074): a gate that paused on a signal-bearing iteration,
+  // resumed WITHOUT feedback, completes the node from the persisted output instead of
+  // re-running the (expensive) iteration. Feedback (loop_feedback_given) OR a
+  // non-signaled gate falls through to a normal resumed iteration below.
+  const feedbackGiven = workflowRun.metadata?.loop_feedback_given === true;
+  if (isLoopResume && loopGateMeta?.completionSignaled === true && !feedbackGiven) {
+    const finalizeOutput = loopGateMeta.signaledOutput ?? '';
+    await safeSendMessage(
+      platform,
+      conversationId,
+      `Loop node '${node.id}' accepted at the completion signal (no re-run)`,
+      msgContext
+    );
+    await deps.store
+      .createWorkflowEvent({
+        workflow_run_id: workflowRun.id,
+        event_type: 'node_completed',
+        step_name: stepName,
+        data: { duration_ms: 0, node_output: finalizeOutput },
+      })
+      .catch((err: Error) => {
+        getLog().error(
+          { err, workflowRunId: workflowRun.id, eventType: 'node_completed' },
+          'workflow_event_persist_failed'
+        );
+      });
+    getWorkflowEventEmitter().emit({
+      type: 'node_completed',
+      runId: workflowRun.id,
+      nodeId: node.id,
+      nodeName: node.id,
+      duration: 0,
+    });
+    return { state: 'completed', output: finalizeOutput, sessionId: currentSessionId };
+  }
 
   let lastIterationOutput = '';
   let lastIterationStructuredOutput: unknown;
@@ -3532,10 +3646,12 @@ async function executeLoopNode(
     // Completion signal detected — exit the loop.
     // For interactive loops: only honor the signal when the AI had user input to evaluate
     // (i.e., this is a resume iteration with loopUserInput). On the first iteration of a
-    // fresh interactive loop, the user hasn't seen anything yet — always gate first.
+    // fresh interactive loop, the user hasn't seen anything yet — always gate first,
+    // UNLESS the author opted into autonomous completion via signal_completes (#2074).
     // For non-interactive loops: the AI signals task completion at any point.
     const interactiveFirstRun = loop.interactive && !isLoopResume;
-    if (completionDetected && !interactiveFirstRun) {
+    const signalCompletes = loop.signal_completes === true;
+    if (completionDetected && (!interactiveFirstRun || signalCompletes)) {
       await safeSendMessage(
         platform,
         conversationId,
@@ -3589,9 +3705,18 @@ async function executeLoopNode(
     // Interactive loop gate — pause after every iteration where the AI did NOT emit the
     // completion signal. The user reviews the AI's output and provides feedback or approval.
     // On approval, the AI will emit the signal in the next iteration, exiting above.
+    // A signal-bearing iteration reaches this gate ONLY when interactiveFirstRun &&
+    // !signalCompletes — the honest status line + persisted signal state (#2074) let
+    // the approver finalize with a bare approve instead of re-running.
     if (loop.interactive && loop.gate_message) {
+      const honestMessage = buildHonestGateMessage(
+        completionDetected,
+        loop.until,
+        lastIterationOutput,
+        loop.gate_message
+      );
       const gateMsg =
-        `\u23f8 **Input required** (loop \`${node.id}\`, iteration ${String(i)}): ${loop.gate_message}\n\n` +
+        `\u23f8 **Input required** (loop \`${node.id}\`, iteration ${String(i)}): ${honestMessage}\n\n` +
         `Run ID: \`${workflowRun.id}\`\n` +
         `Respond: \`/workflow approve ${workflowRun.id} <your feedback>\` | Cancel: \`/workflow reject ${workflowRun.id}\``;
       const gateSent = await safeSendMessage(platform, conversationId, gateMsg, {
@@ -3616,26 +3741,30 @@ async function executeLoopNode(
           workflow_run_id: workflowRun.id,
           event_type: 'approval_requested',
           step_name: stepName,
-          data: { message: loop.gate_message, iteration: i },
+          data: { message: honestMessage, iteration: i, completionSignaled: completionDetected },
         })
         .catch((err: Error) => {
           logEventStoreError(err, i);
         });
       await deps.store.pauseWorkflowRun(workflowRun.id, {
         nodeId: node.id,
-        message: loop.gate_message,
+        message: honestMessage,
         type: 'interactive_loop',
         iteration: i,
         // Explicit null (never key omission) when there is no session — SQLite's
         // json_patch deep-merge would otherwise let a stale sessionId from a previous
         // pause of this run survive (same convention as `resolved`).
         sessionId: currentSessionId ?? null,
+        // Signal state for finalize-on-bare-approve (#2074): written unconditionally
+        // for honesty; pauseWorkflowRun nulls both on every fresh pause.
+        completionSignaled: completionDetected,
+        signaledOutput: completionDetected ? lastIterationOutput : null,
       });
       getWorkflowEventEmitter().emit({
         type: 'approval_pending',
         runId: workflowRun.id,
         nodeId: node.id,
-        message: loop.gate_message,
+        message: honestMessage,
       });
       // Return completed — the between-layer status check sees 'paused' and halts cleanly.
       // This mirrors the approval-node pattern, preventing false "DAG nodes failed" warnings

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -2459,6 +2459,52 @@ function buildHonestGateMessage(
 }
 
 /**
+ * Finalize-on-approve (#2074), shared by executeLoopNode and executeLoopGroupNode:
+ * a gate that paused on a signal-bearing iteration, resumed WITHOUT feedback,
+ * completes the node from the persisted `signaledOutput` instead of re-running
+ * the (expensive) iteration. Sends the user notice and writes/emits the
+ * node_completed pair; the caller builds its own return value (the single-node
+ * loop also threads the restored sessionId).
+ */
+async function finalizeLoopFromSignal(
+  deps: WorkflowDeps,
+  platform: IWorkflowPlatform,
+  conversationId: string,
+  workflowRun: WorkflowRun,
+  nodeId: string,
+  stepName: string,
+  nodeLabel: string,
+  finalizeOutput: string
+): Promise<void> {
+  await safeSendMessage(
+    platform,
+    conversationId,
+    `${nodeLabel} '${nodeId}' accepted at the completion signal (no re-run)`,
+    { workflowId: workflowRun.id, nodeName: nodeId }
+  );
+  await deps.store
+    .createWorkflowEvent({
+      workflow_run_id: workflowRun.id,
+      event_type: 'node_completed',
+      step_name: stepName,
+      data: { duration_ms: 0, node_output: finalizeOutput },
+    })
+    .catch((err: Error) => {
+      getLog().error(
+        { err, workflowRunId: workflowRun.id, eventType: 'node_completed' },
+        'workflow_event_persist_failed'
+      );
+    });
+  getWorkflowEventEmitter().emit({
+    type: 'node_completed',
+    runId: workflowRun.id,
+    nodeId,
+    nodeName: nodeId,
+    duration: 0,
+  });
+}
+
+/**
  * Execute a loop-group node — runs a multi-node sub-DAG body repeatedly until a
  * completion condition (`until` signal in the body's terminal-node output, and/or
  * `until_bash` exit code) or `max_iterations`.
@@ -2533,32 +2579,16 @@ async function executeLoopGroupNode(
   const feedbackGiven = workflowRun.metadata?.loop_feedback_given === true;
   if (isLoopResume && loopGateMeta?.completionSignaled === true && !feedbackGiven) {
     const finalizeOutput = loopGateMeta.signaledOutput ?? '';
-    await safeSendMessage(
+    await finalizeLoopFromSignal(
+      deps,
       platform,
       conversationId,
-      `Loop-group node '${node.id}' accepted at the completion signal (no re-run)`,
-      msgContext
+      workflowRun,
+      node.id,
+      stepName,
+      'Loop-group node',
+      finalizeOutput
     );
-    await deps.store
-      .createWorkflowEvent({
-        workflow_run_id: workflowRun.id,
-        event_type: 'node_completed',
-        step_name: stepName,
-        data: { duration_ms: 0, node_output: finalizeOutput },
-      })
-      .catch((err: Error) => {
-        getLog().error(
-          { err, workflowRunId: workflowRun.id, eventType: 'node_completed' },
-          'workflow_event_persist_failed'
-        );
-      });
-    getWorkflowEventEmitter().emit({
-      type: 'node_completed',
-      runId: workflowRun.id,
-      nodeId: node.id,
-      nodeName: node.id,
-      duration: 0,
-    });
     return { state: 'completed', output: finalizeOutput };
   }
 
@@ -3148,32 +3178,16 @@ async function executeLoopNode(
   const feedbackGiven = workflowRun.metadata?.loop_feedback_given === true;
   if (isLoopResume && loopGateMeta?.completionSignaled === true && !feedbackGiven) {
     const finalizeOutput = loopGateMeta.signaledOutput ?? '';
-    await safeSendMessage(
+    await finalizeLoopFromSignal(
+      deps,
       platform,
       conversationId,
-      `Loop node '${node.id}' accepted at the completion signal (no re-run)`,
-      msgContext
+      workflowRun,
+      node.id,
+      stepName,
+      'Loop node',
+      finalizeOutput
     );
-    await deps.store
-      .createWorkflowEvent({
-        workflow_run_id: workflowRun.id,
-        event_type: 'node_completed',
-        step_name: stepName,
-        data: { duration_ms: 0, node_output: finalizeOutput },
-      })
-      .catch((err: Error) => {
-        getLog().error(
-          { err, workflowRunId: workflowRun.id, eventType: 'node_completed' },
-          'workflow_event_persist_failed'
-        );
-      });
-    getWorkflowEventEmitter().emit({
-      type: 'node_completed',
-      runId: workflowRun.id,
-      nodeId: node.id,
-      nodeName: node.id,
-      duration: 0,
-    });
     return { state: 'completed', output: finalizeOutput, sessionId: currentSessionId };
   }
 

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -44,6 +44,7 @@ import type {
   ThinkingConfig,
   SandboxSettings,
   WorkflowSource,
+  LoopGateRunMetadata,
 } from './schemas';
 import {
   isBashNode,
@@ -2578,14 +2579,13 @@ async function executeLoopGroupNode(
   const loopGateMeta = isApprovalContext(rawApproval) ? rawApproval : undefined;
   const isLoopResume = loopGateMeta?.type === 'interactive_loop' && loopGateMeta.nodeId === node.id;
   const startIteration = isLoopResume ? (loopGateMeta.iteration ?? 0) + 1 : 1;
-  const loopUserInput = isLoopResume
-    ? ((workflowRun.metadata?.loop_user_input as string | undefined) ?? '')
-    : '';
+  const loopGateRunMeta = (workflowRun.metadata ?? {}) as LoopGateRunMetadata;
+  const loopUserInput = isLoopResume ? (loopGateRunMeta.loop_user_input ?? '') : '';
 
   // Finalize-on-approve (#2074): mirrors executeLoopNode — a signal-bearing gate
   // resumed WITHOUT feedback completes the group from the persisted output instead
   // of re-running the body.
-  const feedbackGiven = workflowRun.metadata?.loop_feedback_given === true;
+  const feedbackGiven = loopGateRunMeta.loop_feedback_given === true;
   if (isLoopResume && loopGateMeta?.completionSignaled === true && !feedbackGiven) {
     const finalizeOutput = loopGateMeta.signaledOutput ?? '';
     await finalizeLoopFromSignal(
@@ -3176,15 +3176,14 @@ async function executeLoopNode(
   let currentSessionId: string | undefined = isLoopResume
     ? (loopGateMeta.sessionId ?? undefined)
     : undefined;
-  const loopUserInput = isLoopResume
-    ? ((workflowRun.metadata?.loop_user_input as string | undefined) ?? '')
-    : '';
+  const loopGateRunMeta = (workflowRun.metadata ?? {}) as LoopGateRunMetadata;
+  const loopUserInput = isLoopResume ? (loopGateRunMeta.loop_user_input ?? '') : '';
 
   // Finalize-on-approve (#2074): a gate that paused on a signal-bearing iteration,
   // resumed WITHOUT feedback, completes the node from the persisted output instead of
   // re-running the (expensive) iteration. Feedback (loop_feedback_given) OR a
   // non-signaled gate falls through to a normal resumed iteration below.
-  const feedbackGiven = workflowRun.metadata?.loop_feedback_given === true;
+  const feedbackGiven = loopGateRunMeta.loop_feedback_given === true;
   if (isLoopResume && loopGateMeta?.completionSignaled === true && !feedbackGiven) {
     const finalizeOutput = loopGateMeta.signaledOutput ?? '';
     await finalizeLoopFromSignal(

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -2476,6 +2476,15 @@ async function finalizeLoopFromSignal(
   nodeLabel: string,
   finalizeOutput: string
 ): Promise<void> {
+  // Impossible by construction today (the gate writes signaledOutput whenever
+  // completionSignaled is true) — this warn guards a future decoupling so a
+  // finalize that silently loses the iteration output is diagnosable.
+  if (finalizeOutput === '') {
+    getLog().warn(
+      { workflowRunId: workflowRun.id, nodeId },
+      'loop_node.finalize_missing_signaled_output'
+    );
+  }
   await safeSendMessage(
     platform,
     conversationId,
@@ -3716,12 +3725,11 @@ async function executeLoopNode(
       };
     }
 
-    // Interactive loop gate — pause after every iteration where the AI did NOT emit the
-    // completion signal. The user reviews the AI's output and provides feedback or approval.
-    // On approval, the AI will emit the signal in the next iteration, exiting above.
-    // A signal-bearing iteration reaches this gate ONLY when interactiveFirstRun &&
-    // !signalCompletes — the honest status line + persisted signal state (#2074) let
-    // the approver finalize with a bare approve instead of re-running.
+    // Interactive loop gate — pause after an iteration that did not complete (or, when
+    // interactiveFirstRun && !signalCompletes, an iteration that DID signal — the honest
+    // status line + persisted signal state (#2074) let a bare approve finalize it).
+    // On a non-signaled gate, the user's feedback feeds the next iteration, which exits
+    // above once the AI emits the signal.
     if (loop.interactive && loop.gate_message) {
       const honestMessage = buildHonestGateMessage(
         completionDetected,

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -2643,6 +2643,62 @@ nodes:
       );
     });
 
+    it('should accept a loop with signal_completes (loads without errors)', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+
+      await writeFile(
+        join(workflowDir, 'signal-completes.yaml'),
+        `
+name: signal-completes
+description: Interactive loop that completes autonomously on the signal
+interactive: true
+nodes:
+  - id: validate
+    loop:
+      prompt: Validate.
+      until: VALIDATED
+      max_iterations: 5
+      interactive: true
+      gate_message: Review.
+      signal_completes: true
+`
+      );
+
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.errors).toHaveLength(0);
+      expect(result.workflows).toHaveLength(1);
+    });
+
+    it('should warn (non-blocking) when signal_completes is set without interactive', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+
+      await writeFile(
+        join(workflowDir, 'sc-no-interactive.yaml'),
+        `
+name: sc-no-interactive
+description: signal_completes without interactive is a no-op
+nodes:
+  - id: validate
+    loop:
+      prompt: Validate.
+      until: VALIDATED
+      max_iterations: 5
+      signal_completes: true
+`
+      );
+
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      // Workflow loads successfully — this is a warning, not an error
+      expect(result.errors).toHaveLength(0);
+      expect(result.workflows).toHaveLength(1);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ filename: expect.stringContaining('sc-no-interactive') }),
+        'signal_completes_without_interactive_ignored'
+      );
+    });
+
     it('should reject loop_group with a cyclic body', async () => {
       const workflowDir = join(testDir, '.archon', 'workflows');
       await mkdir(workflowDir, { recursive: true });

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -470,6 +470,22 @@ export function parseWorkflow(content: string, filename: string): ParseResult {
       }
     }
 
+    // Warn (non-blocking) when signal_completes is set without interactive: the flag
+    // only changes interactive-gate behavior — a non-interactive loop already
+    // completes on the signal, so the author's intent is likely a missing
+    // `interactive: true`. The workflow still loads.
+    const hasSignalCompletesWithoutInteractive = (ns: DagNode[]): boolean =>
+      ns.some(
+        n =>
+          (isLoopNode(n) && n.loop.signal_completes === true && n.loop.interactive !== true) ||
+          (isLoopGroupNode(n) &&
+            ((n.loop_group.signal_completes === true && n.loop_group.interactive !== true) ||
+              hasSignalCompletesWithoutInteractive(n.loop_group.nodes)))
+      );
+    if (hasSignalCompletesWithoutInteractive(dagNodes)) {
+      getLog().warn({ filename }, 'signal_completes_without_interactive_ignored');
+    }
+
     // Parse workflow-level worktree policy. Same warn-and-ignore pattern used
     // for `interactive` / `modelReasoningEffort` — invalid values are dropped
     // rather than rejected, so a typo in one workflow doesn't nuke the whole

--- a/packages/workflows/src/schemas/index.ts
+++ b/packages/workflows/src/schemas/index.ts
@@ -114,6 +114,7 @@ export type {
   WorkflowRun,
   ArtifactType,
   ApprovalContext,
+  LoopGateRunMetadata,
 } from './workflow-run';
 
 // Per-node persisted provider sessions

--- a/packages/workflows/src/schemas/loop.ts
+++ b/packages/workflows/src/schemas/loop.ts
@@ -29,6 +29,12 @@ export const loopControlSchema = z
     interactive: z.boolean().optional(),
     /** Message shown to user when paused (required when interactive is true). */
     gate_message: z.string().optional(),
+    /**
+     * When true, a detected completion signal completes the node immediately —
+     * even on the first iteration of a fresh interactive loop — instead of gating.
+     * No effect on non-interactive loops (the signal already completes them). Default false.
+     */
+    signal_completes: z.boolean().optional(),
   })
   .superRefine((data, ctx) => {
     if (data.interactive === true && !data.gate_message) {

--- a/packages/workflows/src/schemas/workflow-run.ts
+++ b/packages/workflows/src/schemas/workflow-run.ts
@@ -171,6 +171,20 @@ export interface ApprovalContext {
    * loop_user_input (consumed in place; the next pause resets it).
    */
   resolved?: 'approved' | 'rejected' | null;
+  /**
+   * Interactive-loop only. True when the iteration this gate paused on emitted the
+   * completion signal (detectCompletionSignal / until_bash exit 0). Read at resume by
+   * executeLoopNode/executeLoopGroupNode: a signal-bearing gate approved WITHOUT feedback
+   * finalizes the node from `signaledOutput` instead of re-running. Reset to null on every
+   * fresh pause (see pauseWorkflowRun) for the same SQLite json_patch reason as `resolved`.
+   */
+  completionSignaled?: boolean | null;
+  /**
+   * Interactive-loop only. The (stripped) output of the signal-bearing paused iteration,
+   * persisted so the finalize path can write node_completed with the real output for
+   * downstream `$nodeId.output` refs. Only set when completionSignaled is true; null otherwise.
+   */
+  signaledOutput?: string | null;
 }
 
 /**

--- a/packages/workflows/src/schemas/workflow-run.ts
+++ b/packages/workflows/src/schemas/workflow-run.ts
@@ -188,6 +188,23 @@ export interface ApprovalContext {
 }
 
 /**
+ * Top-level (non-`approval`) run-metadata keys of the interactive-loop gate
+ * protocol, written by approveWorkflow and read at resume by
+ * executeLoopNode/executeLoopGroupNode (#2074). Deliberately NOT a Zod schema —
+ * run metadata stays schemaless JSON; this alias exists solely so the write and
+ * read sites share one key spelling (a typo is a compile error), nothing broader.
+ */
+export interface LoopGateRunMetadata {
+  /** $LOOP_USER_INPUT for the resumed iteration (approve comment; defaults to 'Approved'). */
+  loop_user_input?: string;
+  /**
+   * True iff the approve carried real (non-whitespace) feedback. False/absent =
+   * bare approve — finalize-eligible when the gate's completionSignaled is true.
+   */
+  loop_feedback_given?: boolean;
+}
+
+/**
  * True when the run's current approval gate has already been resolved
  * (approved, or rejected with a staged on_reject rework) and the run is
  * paused only while awaiting resume. Guards double-approve/reject and the


### PR DESCRIPTION
## Summary

- Problem: an `interactive: true` loop (`loop:`/`loop_group:`) whose prompt emits its completion signal can never terminate — the executor deliberately ignores the signal on the first iteration, approve always launches a fresh iteration (re-running the whole expensive body), and the static `gate_message` can misreport the actual iteration outcome (#2074, reproduced on a real 24-minute Jetson validation loop).
- Why it matters: pass-through-on-success is inexpressible; a passed validation loops forever, re-doing the work on every approve, behind a gate message that lies.
- What changed: four coupled changes so the engine remembers and respects the completion signal — **(B)** opt-in `signal_completes: true` completes the node on the signal with no gate; **(C)** a signal-bearing gate persists `completionSignaled`/`signaledOutput` in pause metadata, and a **bare approve finalizes at resume** from that output (no re-run) while approve-with-feedback still iterates; **(D)** the gate message gets an engine-generated honest status line (signal yes/no + bounded output excerpt) and structured `completionSignaled` on the `approval_requested` event; **(E)** gates are steerable by an AI approver — `manage_run get` surfaces the structured gate state with a finalize hint, `manage_run approve` gains `accept: true`, CLI `workflow get` prints a Gate line (`--json` already carries the metadata), and the console ApprovalPanel shows "Accept & complete".
- What did **not** change (scope boundary): the pause-input transport (#1991), session-continuity design (#2004/#2046), the `--json` approve records-not-resumes contract, #2112 paused-and-staged semantics, no new approver node type, no console redesign beyond the label/placeholder hint. NL chat approval still always iterates (documented limitation, see below).

### Two user-facing semantics changes (please note)

1. **Bare approve on a signal-bearing gate now finalizes.** Previously `/workflow approve <id>` (no comment) on an interactive-loop gate always ran another iteration. Now, when the paused iteration emitted the completion signal, an approve with **no** comment completes the node from the already-computed output — no re-run. Approve **with** a comment still iterates; non-signaled gates iterate for both forms.
2. **`signal_completes: true` skips the first gate.** Opting in lets a first-iteration signal complete the node with no human confirmation at all (previously "always gate first" was unconditional). Default behavior without the flag is unchanged (gate first).

**Documented limitation:** natural-language approval (typing a plain message in the conversation instead of the slash command) always counts as feedback and therefore always iterates — finalizing requires `/workflow approve <id>` with no comment, the CLI/HTTP/web/`manage_run` surfaces, or `signal_completes`.

## UX Journey

### Before

```
  Author: "on pass -> emit <promise>VALIDATED</promise>, done"
  ──────────────────────────────────────────────────────────
  iteration 1 (24 min) ─► PASS ─► signal emitted
        │  interactiveFirstRun ⇒ signal IGNORED
        ▼
  gate: "…count mismatch (business failure)…"   ◄── static, WRONG
        │  /workflow approve <id> "validation PASS, proceed"
        ▼
  iteration 2 STARTS FRESH (24 min) ─► pauses again … loop never ends.
```

### After

```
  PATH B (signal_completes: true):
  iteration 1 ─► PASS ─► signal ─► [node_completed, run proceeds — NO gate]

  PATH C (default gate):
  iteration 1 ─► PASS ─► signal ─► gate:
      "✅ Completion signal detected (`VALIDATED`).  > <excerpt>…  <author gate_message>"
        │ approve (no comment)                 │ approve "re-check X"
        ▼                                      ▼
  [FINALIZE from persisted output —      iteration 2 runs with
   node_completed, NO re-run]            $LOOP_USER_INPUT="re-check X"
```

## Architecture Diagram

### Before

```
 dag-executor (loop/loop_group gate) ──► pauseWorkflowRun ──► metadata.approval{nodeId,message,type,iteration,sessionId}
 approveWorkflow ──► metadata{approval.resolved, loop_user_input}
 api.ts approve route ──► comment ?? 'Approved' ──► approveWorkflow
 manage_run get ──► id/status/times/error only
```

### After

```
 dag-executor (loop/loop_group gate) [~]
   ├─► buildHonestGateMessage [+] ──► delivered msg + approval_requested{completionSignaled} + pause message
   └─► pauseWorkflowRun [~] ──► metadata.approval{…, completionSignaled [+], signaledOutput [+]} (explicit-null reset)
 dag-executor (loop/loop_group resume) [~] ═══► finalize early-return [+] (signal && !loop_feedback_given ⇒ node_completed from signaledOutput)
 approveWorkflow [~] ──► metadata{…, loop_feedback_given [+] (from RAW comment)}
 api.ts approve route [~] --x-- 'Approved' default ──► passes body.comment through
 manage_run [~] ──► get: gate block [+]; approve: accept arg [+], honest returns/help/preview
 cli workflow get [~] ──► human Gate line [+]
 console run.ts/ApprovalPanel [~] ──► completionSignaled → "Accept & complete"
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| dag-executor gates (loop + loop_group) | store.pauseWorkflowRun | **modified** | adds `completionSignaled`/`signaledOutput`; message = honest message |
| dag-executor resume (loop + loop_group) | metadata.approval | **modified** | new finalize early-return before the iteration loop |
| core pauseWorkflowRun | DB metadata | **modified** | explicit-null reset of the two new keys (SQLite json_patch / Postgres `\|\|`) |
| server approve route | approveWorkflow | **modified** | raw `body.comment` passthrough (no `'Approved'` default) |
| approveWorkflow | DB metadata | **modified** | writes `loop_feedback_given` from the raw comment |
| manage_run | workflow-operations / db | **modified** | gate detail block, `accept` arg, honest returns |
| CLI workflow get | db | **modified** | human printer Gate line; `--json` unchanged |
| console toRun/ApprovalPanel | run metadata | **modified** | surfaces `completionSignaled`, label/placeholder hint |
| chat command-handler | approveWorkflow | **modified** | raw comment passthrough (self-review fix — the handler pre-defaulted `'Approved'`, masking no-feedback on every chat platform) |

## Label Snapshot

- Risk: `risk: medium`
- Size: `size: L`
- Scope: `workflows`
- Module: `workflows:executor`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi`

## Linked Issue

- Closes #2074

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # exit 0: check:bundled, check:bundled-skill, check:bundled-schema,
                   # check:pi-vendor-map, type-check (10 pkgs), lint, format:check, all tests
bun test packages/workflows/src/dag-executor.test.ts   # 351 pass (7 new #2074 tests + parity)
bun test packages/workflows/src/loader.test.ts          # 143 pass (2 new)
bun test packages/core/src/operations/workflow-operations.test.ts  # 25 pass (2 new)
bun test packages/core/src/db/workflows.test.ts         # 75 pass (1 new + extended)
bun test packages/server/src/routes/api.workflow-runs.test.ts      # 83 pass (2 new)
bun test packages/core/src/orchestrator/manage-run-tool.test.ts    # 30 pass (6 new/updated)
bun test packages/cli/src/commands/workflow.test.ts     # 174 pass (2 new)
```

- Evidence provided: unit/integration suites above cover pause persistence, finalize/iterate/non-signaled resume in BOTH executors, route comment passthrough, ops feedback flag, dialect-safe null reset, CLI JSON+human surfaces, manage_run get/approve/preview, console parsing.
- Intentionally skipped: a live end-to-end run of a real interactive loop (needs AI credentials in the implementing environment); recommend a maintainer smoke of paths B + C before release (author a loop emitting `<promise>DONE</promise>` on iteration 1; verify gate message honesty, bare-approve finalize with no second iteration, feedback iterate, and `signal_completes` no-gate completion).

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — with the two intentional semantics changes above. No schema change (run metadata is schemaless JSON; `completionSignaled`/`signaledOutput`/`loop_feedback_given` are new optional keys with explicit-null lifecycle). Old paused runs lacking the new keys behave exactly as before (finalize requires `completionSignaled === true`).
- Config/env changes? No (new optional YAML field `loop.signal_completes` / `loop_group.signal_completes`).
- Database migration needed? No.

## Human Verification (required)

- Verified scenarios: full validate suite; every new/changed behavior pinned by a test (see evidence). Existing interactive-loop, approval-gate, resume-CAS, and #2112 gate-staging tests all still green. Self-review (code-reviewer + code-simplifier agents) caught and fixed a critical gap: the chat `/workflow approve` handler pre-defaulted the comment to `'Approved'`, which would have made finalize unreachable from every chat platform — fixed with a raw-comment passthrough + a bare-approve test.
- Edge cases checked: stale-metadata leak across gates (explicit-null reset, both dialects), non-signaled gate + bare approve (iterates), feedback on signal-bearing gate (iterates), loop vs loop_group parity, whitespace-only comment counts as no feedback, double-approve guard untouched, legacy paused rows without the new keys.
- What was not verified: live multi-process detached-run round trip (approve via relay → resume finalize) — covered logically by the resume-time-read design + unit tests, not by a live smoke.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: workflow engine (both loop executors), core approve path, HTTP approve route, manage_run chat tool, CLI `workflow get` printer, console approval UI, docs + manage-run skill.
- Potential unintended effects: any external consumer that pattern-matched the delivered gate message or `approval_requested.data.message` now sees the status line prepended (author text is preserved verbatim at the end). Approvers who habitually pass a comment will keep iterating (by design; `accept:true`/docs mitigate).
- Guardrails/monitoring: `approval_requested` now carries structured `completionSignaled` for observability; finalize path emits a normal `node_completed` with `duration_ms: 0` (easy to spot in `get --verbose`).

## Rollback Plan (required)

- Fast rollback command/path: revert the two commits (`git revert fbdbd630 8d1bcde5`) — no migration, no config, no generated-file changes.
- Feature flags or config toggles: `signal_completes` is opt-in per loop; the finalize-on-bare-approve behavior has no flag (rollback = revert).
- Observable failure symptoms: a loop node completing with `duration_ms: 0` when it should have iterated; a gate message missing the author's `gate_message` text; approve-with-comment failing to iterate.

## Risks and Mitigations

- Risk: empty `loop_user_input` regressing the classic gate→approve→iterate flow.
  - Mitigation: `loop_user_input` keeps its `'Approved'` default; only the new `loop_feedback_given` boolean reads the raw comment. Pinned by ops + route tests.
- Risk: stale `completionSignaled`/`signaledOutput` leaking across gates on SQLite (json_patch deep-merge).
  - Mitigation: explicit `?? null` reset in `pauseWorkflowRun` mirroring the `resolved: null` convention; asserted in `workflows.test.ts` for both provided and omitted values.
- Risk: loop_group twin drift.
  - Mitigation: every B/C/D edit applied to both executors; parity pinned by dedicated loop_group tests (gate persistence, signal_completes, finalize).
- Risk: web approve masking no-feedback (every web approve looks like feedback).
  - Mitigation: route no longer defaults the comment; route tests assert `loop_feedback_given: false` for an empty body; the console already omits blank comments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive-loop gates can now be **accepted & completed** without rerunning when a completion signal was detected (“Accept & complete”).
  * Added `signal_completes` to allow immediate completion on signal-bearing interactive iterations (with a warning when used without interactive enabled).
  * CLI, API, and console now surface gate state and persist finalize vs feedback metadata (including when feedback was provided).
* **Bug Fixes**
  * Improved handling of malformed approval/rejection JSON requests.
* **Documentation**
  * Updated guides and CLI/API references for “bare approve” vs “approve with comment,” and `$LOOP_USER_INPUT` behavior.
* **Tests**
  * Expanded coverage for finalize/iterate outcomes and persisted gate metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Follow-ups (deferred from review round 1)

Review items classified as documented-convention / follow-up tier — not addressed in this PR:

- `loop_feedback_given` typing: stays an untyped top-level metadata key (matches the existing `loop_user_input` / `approval_response` convention; a typed run-metadata shape is a broader refactor).
- Command-handler arg-parsing idiom: the approve branch mirrors the file's existing `args.slice(2).join(' ')` style; an idiom sweep is out of scope.
- Docs: `authoring-workflows.md` loop section and the docs quick-reference table don't yet mention `signal_completes`/finalize semantics — loop-nodes.md, approval-nodes.md, variables.md, and cli.md are the canonical updated pages; a docs sweep can pick up the secondary mentions.
