### PR TITLE
fix(workflows): wait for live background Agent tasks before completing a node

### DIFF
--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -611,6 +611,87 @@ describe('ClaudeProvider', () => {
       expect(chunks[0]).toMatchObject({ type: 'task_notification', status: 'failed' });
     });
 
+    // --- #2083 — background-task liveness (SDK 0.3.209 background_tasks_changed) ---
+
+    test('yields background_tasks chunk from SDK background_tasks_changed', async () => {
+      mockQuery.mockImplementation(async function* () {
+        yield {
+          type: 'system',
+          subtype: 'background_tasks_changed',
+          tasks: [
+            { task_id: 't-1', task_type: 'local_agent', description: 'Research problem A' },
+            { task_id: 't-2', task_type: 'local_agent', description: 'Research problem B' },
+          ],
+        };
+      });
+
+      const chunks = [];
+      for await (const chunk of client.sendQuery('test', '/workspace')) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks).toEqual([
+        {
+          type: 'background_tasks',
+          tasks: [
+            { taskId: 't-1', taskType: 'local_agent', description: 'Research problem A' },
+            { taskId: 't-2', taskType: 'local_agent', description: 'Research problem B' },
+          ],
+        },
+      ]);
+    });
+
+    test('forwards an EMPTY background_tasks_changed set (drain signal)', async () => {
+      mockQuery.mockImplementation(async function* () {
+        yield { type: 'system', subtype: 'background_tasks_changed', tasks: [] };
+      });
+
+      const chunks = [];
+      for await (const chunk of client.sendQuery('test', '/workspace')) {
+        chunks.push(chunk);
+      }
+
+      // An empty set means "all background work drained" — it must be forwarded,
+      // not dropped, or the executor's wait gate would never release.
+      expect(chunks).toEqual([{ type: 'background_tasks', tasks: [] }]);
+    });
+
+    test('keeps forwarding chunks that arrive AFTER the result (background-task wait window)', async () => {
+      // Single-turn queries keep streaming after the turn-level result while
+      // background tasks drain; streamClaudeMessages must not stop at result.
+      mockQuery.mockImplementation(async function* () {
+        yield {
+          type: 'system',
+          subtype: 'background_tasks_changed',
+          tasks: [{ task_id: 't-1', task_type: 'local_agent', description: 'bg work' }],
+        };
+        yield { type: 'result', subtype: 'success', session_id: 's-1', is_error: false };
+        yield {
+          type: 'system',
+          subtype: 'task_notification',
+          task_id: 't-1',
+          status: 'completed',
+          output_file: '/tmp/t-1.md',
+          summary: 'done',
+        };
+        yield { type: 'system', subtype: 'background_tasks_changed', tasks: [] };
+        yield { type: 'result', subtype: 'success', session_id: 's-1', is_error: false };
+      });
+
+      const types = [];
+      for await (const chunk of client.sendQuery('test', '/workspace')) {
+        types.push(chunk.type);
+      }
+
+      expect(types).toEqual([
+        'background_tasks',
+        'result',
+        'task_notification',
+        'background_tasks',
+        'result',
+      ]);
+    });
+
     test('yields hook_started chunk from SDK system message', async () => {
       mockQuery.mockImplementation(async function* () {
         yield {

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -782,6 +782,8 @@ async function* streamClaudeMessages(
         status?: string;
         output_file?: string;
         skip_transcript?: boolean;
+        // Background-task set (Claude SDK v0.3.209+ `background_tasks_changed`)
+        tasks?: { task_id: string; task_type: string; description: string }[];
         // Hook lifecycle (Claude SDK v0.2.89+)
         hook_id?: string;
         hook_name?: string;
@@ -846,6 +848,20 @@ async function* streamClaudeMessages(
           outputFile: sysMsg.output_file ?? '',
           ...(sysMsg.usage !== undefined ? { usage: sysMsg.usage } : {}),
           ...(sysMsg.tool_use_id !== undefined ? { toolUseId: sysMsg.tool_use_id } : {}),
+        };
+      } else if (subtype === 'background_tasks_changed') {
+        // Level signal: the FULL set of live background tasks after a membership
+        // change (REPLACE semantics — see the MessageChunk variant docs). An
+        // empty `tasks` array is meaningful ("all drained") and MUST be
+        // forwarded, so no `&& sysMsg.tasks` guard here.
+        const tasks = Array.isArray(sysMsg.tasks) ? sysMsg.tasks : [];
+        yield {
+          type: 'background_tasks',
+          tasks: tasks.map(t => ({
+            taskId: t.task_id,
+            taskType: t.task_type,
+            description: t.description,
+          })),
         };
       } else if (subtype === 'hook_started' && sysMsg.hook_id) {
         yield {

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -262,6 +262,17 @@ export type MessageChunk =
       usage?: { total_tokens: number; tool_uses: number; duration_ms: number };
       toolUseId?: string;
     }
+  // Forwarded from SDKBackgroundTasksChangedMessage (`background_tasks_changed`,
+  // Claude SDK v0.3.209+): the FULL set of live background tasks, emitted
+  // whenever membership changes. Level signal with REPLACE semantics — consumers
+  // swap their set for each payload (an empty array means no background work is
+  // running). The dag-executor gates node completion on this: a `result` chunk
+  // that arrives while the set is non-empty must not tear down the stream, or
+  // the SDK subprocess (and the tasks' pending artifacts) get killed (#2083).
+  | {
+      type: 'background_tasks';
+      tasks: { taskId: string; taskType: string; description: string }[];
+    }
   // ─── Hook Lifecycle (Claude SDK `system` subtypes) ─────────────────────
   // Forwarded by the Claude provider from SDKHookStartedMessage /
   // SDKHookResponseMessage. Same aggregation path as task_* above; the bridge

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -4157,6 +4157,151 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     );
   });
 
+  // ─── Background Agent Task Gating (#2083) ───────────────────────────────
+
+  describe('background task completion gating (#2083)', () => {
+    const runSingleNode = async (
+      store: ReturnType<typeof createMockStore>,
+      platform: IWorkflowPlatform,
+      runId: string
+    ): Promise<void> => {
+      const mockDeps = createMockDeps(store);
+      const workflowRun = makeWorkflowRun(runId);
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-bg-tasks',
+        testDir,
+        { name: 'bg-task-test', nodes: [{ id: 'step1', command: 'step1' }] },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+    };
+
+    const findCompletedEvent = (
+      store: ReturnType<typeof createMockStore>
+    ): { data: Record<string, unknown> } | undefined => {
+      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+      const call = eventCalls.find(
+        (c: unknown[]) =>
+          (c[0] as { event_type: string }).event_type === 'node_completed' &&
+          (c[0] as { step_name: string }).step_name === 'step1'
+      );
+      return call?.[0] as { data: Record<string, unknown> } | undefined;
+    };
+
+    it('waits past a result with live background tasks and captures the follow-up output', async () => {
+      mockSendQueryDag.mockImplementation(function* () {
+        yield {
+          type: 'background_tasks',
+          tasks: [{ taskId: 't-1', taskType: 'local_agent', description: 'bg research' }],
+        };
+        yield { type: 'assistant', content: 'spawned agents' };
+        // Turn-level result while t-1 is still live — must NOT complete the node
+        yield { type: 'result', sessionId: 'sid', cost: 0.1 };
+        // Post-result: task drains, follow-up turn integrates its output
+        yield { type: 'assistant', content: ' + integrated task output' };
+        yield { type: 'background_tasks', tasks: [] };
+        yield { type: 'result', sessionId: 'sid', cost: 0.3 };
+      });
+
+      const store = createMockStore();
+      const platform = createMockPlatform();
+      await runSingleNode(store, platform, 'bg-wait-run');
+
+      const completed = findCompletedEvent(store);
+      expect(completed).toBeDefined();
+      // Output includes the post-result follow-up turn (the wait actually happened)
+      expect(completed!.data.node_output).toBe('spawned agents + integrated task output');
+      // Cost is the LAST result's session-cumulative value, not a sum
+      expect(completed!.data.cost_usd).toBe(0.3);
+      // Clean drain → no incompleteness recorded
+      expect(completed!.data.background_tasks_incomplete).toBeUndefined();
+      // The wait was announced to the user once
+      const sent = (platform.sendMessage as ReturnType<typeof mock>).mock.calls.map(c =>
+        String(c[1])
+      );
+      expect(sent.some(m => m.includes('background agent task(s) still running'))).toBe(true);
+    });
+
+    it('records background_tasks_incomplete and warns when the stream ends with live tasks', async () => {
+      mockSendQueryDag.mockImplementation(function* () {
+        yield {
+          type: 'background_tasks',
+          tasks: [{ taskId: 't-orphan', taskType: 'local_agent', description: 'never drains' }],
+        };
+        yield { type: 'assistant', content: 'partial work' };
+        yield { type: 'result', sessionId: 'sid' };
+        // Generator ends without the set draining (subprocess death analog)
+      });
+
+      const store = createMockStore();
+      const platform = createMockPlatform();
+      await runSingleNode(store, platform, 'bg-incomplete-run');
+
+      const completed = findCompletedEvent(store);
+      expect(completed).toBeDefined();
+      expect(completed!.data.background_tasks_incomplete).toEqual(['t-orphan']);
+      const sent = (platform.sendMessage as ReturnType<typeof mock>).mock.calls.map(c =>
+        String(c[1])
+      );
+      expect(sent.some(m => m.includes('output may be missing'))).toBe(true);
+    });
+
+    it('breaks at the first result when no background_tasks chunk was seen (unchanged behavior)', async () => {
+      mockSendQueryDag.mockImplementation(function* () {
+        yield { type: 'assistant', content: 'normal output' };
+        yield { type: 'result', sessionId: 'sid' };
+        // Anything after the result must NOT be consumed
+        yield { type: 'assistant', content: ' MUST NOT APPEAR' };
+      });
+
+      const store = createMockStore();
+      const platform = createMockPlatform();
+      await runSingleNode(store, platform, 'bg-none-run');
+
+      const completed = findCompletedEvent(store);
+      expect(completed).toBeDefined();
+      expect(completed!.data.node_output).toBe('normal output');
+      expect(completed!.data.background_tasks_incomplete).toBeUndefined();
+    });
+
+    it('persists output_file on task_notification task_activity events', async () => {
+      mockSendQueryDag.mockImplementation(function* () {
+        yield { type: 'assistant', content: 'delegating' };
+        yield {
+          type: 'task_notification',
+          taskId: 't-9',
+          status: 'completed',
+          summary: 'wrote the report',
+          outputFile: '/tmp/task-9-output.md',
+        };
+        yield { type: 'result', sessionId: 'sid' };
+      });
+
+      const store = createMockStore();
+      const platform = createMockPlatform();
+      await runSingleNode(store, platform, 'bg-output-file-run');
+
+      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+      const taskEvent = eventCalls.find(
+        (c: unknown[]) =>
+          (c[0] as { event_type: string }).event_type === 'task_activity' &&
+          (c[0] as { data: { task_id?: string } }).data.task_id === 't-9'
+      );
+      expect(taskEvent).toBeDefined();
+      expect((taskEvent![0] as { data: { output_file?: string } }).data.output_file).toBe(
+        '/tmp/task-9-output.md'
+      );
+    });
+  });
+
   // ─── Loop Node Tests ─────────────────────────────────────────────────────
 
   describe('loop node execution', () => {
@@ -4210,6 +4355,63 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect(completeCalls[0][1]).toEqual({
         node_counts: { completed: 1, failed: 0, skipped: 0, total: 1 },
       });
+    });
+
+    it('does not double-count cost when an iteration sees two results (background-task wait, #2083)', async () => {
+      mockSendQueryDag.mockImplementation(function* () {
+        yield {
+          type: 'background_tasks',
+          tasks: [{ taskId: 't-1', taskType: 'local_agent', description: 'bg work' }],
+        };
+        yield { type: 'assistant', content: 'Done. <promise>COMPLETE</promise>' };
+        // Session-cumulative cost: 0.1 at the first result, 0.3 at the final one
+        yield { type: 'result', sessionId: 'loop-sid', cost: 0.1 };
+        yield { type: 'background_tasks', tasks: [] };
+        yield { type: 'result', sessionId: 'loop-sid', cost: 0.3 };
+      });
+
+      const store = createMockStore();
+      const mockDeps = createMockDeps(store);
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun('loop-bg-cost-run');
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        {
+          name: 'dag-loop-bg-cost',
+          nodes: [
+            {
+              id: 'my-loop',
+              loop: {
+                prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
+                until: 'COMPLETE',
+                max_iterations: 5,
+              },
+            },
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+      const completedEvent = eventCalls.find(
+        (c: unknown[]) =>
+          (c[0] as { event_type: string }).event_type === 'node_completed' &&
+          (c[0] as { step_name: string }).step_name === 'my-loop'
+      );
+      expect(completedEvent).toBeDefined();
+      // 0.3 (last session-cumulative value), NOT 0.4 (0.1 + 0.3 double-count)
+      expect((completedEvent![0] as { data: { cost_usd?: number } }).data.cost_usd).toBe(0.3);
     });
 
     it('completes after multiple iterations', async () => {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -355,6 +355,62 @@ const DEFAULT_NODE_RETRY_DELAY_MS = 3000;
 const STRUCTURED_OUTPUT_MAX_REASKS = 3;
 
 /**
+ * Tracks live background Agent tasks within one provider stream pass (#2083).
+ *
+ * Since Claude SDK 0.3.193 the model can delegate work to asynchronous
+ * background agents, so a `result` chunk only means "top-level turn done" —
+ * NOT "all work done". Breaking out of the stream loop at a result while
+ * background tasks are live calls `.return()` on the generator chain, which
+ * tears down the SDK subprocess (SIGTERM) and kills the tasks — the artifacts
+ * they were producing silently never appear.
+ *
+ * Fed by the provider's `background_tasks` chunk (SDK `background_tasks_changed`,
+ * v0.3.209+): a level signal carrying the FULL live set, REPLACE semantics.
+ * Both dag-executor stream loops (AI node + loop iteration) instantiate one
+ * tracker per stream pass and gate their break-on-result on it: when the set
+ * is non-empty, keep consuming — the SDK keeps the subprocess alive until the
+ * tasks drain, gives the agent a follow-up turn to integrate their output, and
+ * emits a final `result` (verified empirically against SDK 0.3.209). The wait
+ * is bounded by the existing idle-timeout machinery: `task_progress` chunks
+ * (~30s cadence while subagents run) reset the idle timer, and a genuinely
+ * hung task hits the normal idle-timeout path.
+ *
+ * Providers that never emit the chunk (Codex/Pi/OpenCode/Copilot, older Claude
+ * CLIs) leave the set empty → break-on-first-result behavior is unchanged.
+ */
+function createBackgroundTaskTracker(): {
+  update(tasks: { taskId: string; description: string }[]): void;
+  shouldBreakOnResult(): boolean;
+  count(): number;
+  ids(): string[];
+  /** True exactly once — lets the caller announce the wait a single time per pass. */
+  shouldAnnounceWait(): boolean;
+} {
+  const live = new Map<string, string>(); // taskId → description
+  let announced = false;
+  return {
+    update(tasks): void {
+      live.clear();
+      for (const t of tasks) live.set(t.taskId, t.description);
+    },
+    shouldBreakOnResult(): boolean {
+      return live.size === 0;
+    },
+    count(): number {
+      return live.size;
+    },
+    ids(): string[] {
+      return [...live.keys()];
+    },
+    shouldAnnounceWait(): boolean {
+      if (announced) return false;
+      announced = true;
+      return true;
+    },
+  };
+}
+
+/**
  * Get effective retry config for a DAG node.
  */
 function getEffectiveNodeRetryConfig(node: DagNode): {
@@ -1113,6 +1169,10 @@ async function executeNodeInternal(
   let nodeIdleTimedOut = false;
   const effectiveIdleTimeout = node.idle_timeout ?? STEP_IDLE_TIMEOUT_MS;
   let lastToolStartedAt: { toolName: string; startedAt: number } | null = null;
+  // Task ids still live when the stream ended abnormally (idle timeout /
+  // subprocess death) — recorded on the node_completed event so an incomplete
+  // node never masquerades as a clean success (#2083).
+  let backgroundTasksIncomplete: string[] = [];
 
   // Best-effort providers (Pi/Copilot) get a bounded validate-and-reask loop: on a
   // structured-output validation miss, re-run the stream with the schema errors
@@ -1138,6 +1198,8 @@ async function executeNodeInternal(
     batchMessages.length = 0; // else a failed attempt's prose flushes during reask
     nodeCostUsd = undefined;
     nodeIdleTimedOut = false;
+    backgroundTasksIncomplete = [];
+    const backgroundTasks = createBackgroundTaskTracker();
     for await (const msg of withIdleTimeout(
       aiClient.sendQuery(attemptPrompt, cwd, attemptResumeId, nodeOptionsWithAbort),
       effectiveIdleTimeout,
@@ -1360,7 +1422,36 @@ async function executeNodeInternal(
           );
           throw new Error(`Node '${node.id}' failed: SDK returned ${subtype}${errorsDetail}`);
         }
-        break; // Result is the "I'm done" signal — don't wait for subprocess to exit
+        if (backgroundTasks.shouldBreakOnResult()) {
+          break; // Result is the "I'm done" signal — don't wait for subprocess to exit
+        }
+        // Result arrived with background Agent tasks still live (#2083).
+        // Breaking here would .return() the generator chain → SDK cleanup →
+        // SIGTERM the CLI → kill the tasks and lose their pending artifacts.
+        // Keep consuming: the SDK holds the subprocess open until the tasks
+        // drain, runs a follow-up turn to integrate their output, and emits a
+        // final result (whose fields overwrite the captures above — correct,
+        // since SDK cost/usage are session-cumulative). Bounded by the
+        // existing idle timeout; task_progress chunks reset it.
+        getLog().warn(
+          {
+            nodeId: node.id,
+            taskCount: backgroundTasks.count(),
+            taskIds: backgroundTasks.ids(),
+          },
+          'dag.node_result_with_live_background_tasks'
+        );
+        if (backgroundTasks.shouldAnnounceWait()) {
+          await safeSendMessage(
+            platform,
+            conversationId,
+            `⏳ Node \`${node.id}\`: turn ended with ${String(backgroundTasks.count())} background agent task(s) still running — waiting for them to finish before completing the node.`,
+            nodeContext
+          );
+        }
+      } else if (msg.type === 'background_tasks') {
+        // Level signal (REPLACE semantics): swap the live set for the payload.
+        backgroundTasks.update(msg.tasks);
       } else if (msg.type === 'system' && msg.content) {
         // Providers yield system chunks for user-actionable issues (missing env
         // vars, Haiku+MCP, structured output failures, etc.). MCP-failure
@@ -1496,6 +1587,7 @@ async function executeNodeInternal(
           activity: msg.status,
           ...(msg.summary !== undefined ? { summary: msg.summary } : {}),
           ...(msg.usage !== undefined ? { usage: msg.usage } : {}),
+          ...(msg.outputFile ? { outputFile: msg.outputFile } : {}),
         });
         deps.store
           .createWorkflowEvent({
@@ -1507,6 +1599,9 @@ async function executeNodeInternal(
               activity: msg.status,
               ...(msg.summary !== undefined ? { summary: msg.summary } : {}),
               ...(msg.usage !== undefined ? { usage: msg.usage } : {}),
+              // Where the settled task wrote its output — the artifact trail
+              // for delegated work (#2083).
+              ...(msg.outputFile ? { output_file: msg.outputFile } : {}),
             },
           })
           .catch((err: Error) => {
@@ -1577,6 +1672,33 @@ async function executeNodeInternal(
           });
       }
       // rate_limit chunks: already log.warn'd in claude.ts; not surfaced to SSE per design
+    }
+
+    // Stream ended with background tasks still live: the SDK subprocess died or
+    // the idle timeout fired mid-wait. The tasks' artifacts may be missing —
+    // record the incompleteness (surfaced on the node_completed event) and warn
+    // loudly instead of silently completing (#2083). Cancellation is exempt:
+    // the node returns 'failed — Cancelled by user' and the warning would be noise.
+    if (!backgroundTasks.shouldBreakOnResult()) {
+      backgroundTasksIncomplete = backgroundTasks.ids();
+      const cancelled = nodeAbortController.signal.aborted && !nodeIdleTimedOut;
+      getLog().warn(
+        {
+          nodeId: node.id,
+          taskIds: backgroundTasksIncomplete,
+          idleTimedOut: nodeIdleTimedOut,
+          cancelled,
+        },
+        'dag.node_stream_ended_with_live_background_tasks'
+      );
+      if (!cancelled) {
+        await safeSendMessage(
+          platform,
+          conversationId,
+          `⚠️ Node \`${node.id}\`: the provider stream ended with ${String(backgroundTasksIncomplete.length)} background agent task(s) still running (${backgroundTasksIncomplete.join(', ')}). Their output may be missing — treat this node's artifacts as potentially incomplete.`,
+          nodeContext
+        );
+      }
     }
   };
 
@@ -1867,6 +1989,11 @@ async function executeNodeInternal(
           ...(nodeStopReason ? { stop_reason: nodeStopReason } : {}),
           ...(nodeNumTurns !== undefined ? { num_turns: nodeNumTurns } : {}),
           ...(nodeModelUsage ? { model_usage: nodeModelUsage } : {}),
+          // Background Agent tasks still live when the stream ended (#2083) —
+          // this node's artifacts may be incomplete.
+          ...(backgroundTasksIncomplete.length > 0
+            ? { background_tasks_incomplete: backgroundTasksIncomplete }
+            : {}),
           ...iterationData,
         },
       })
@@ -3263,6 +3390,38 @@ async function executeLoopNode(
     let iterationIdleTimedOut = false;
     const iterationAbortController = new AbortController();
 
+    // Background-task gate (#2083) — see createBackgroundTaskTracker. When the
+    // set is non-empty at result time this iteration keeps consuming, so a
+    // single iteration can now observe MULTIPLE result chunks. SDK cost/usage
+    // are session-cumulative, so the per-result `+=` accumulation used before
+    // would double-count: capture last-seen values (overwrite semantics) and
+    // fold them into the loop totals once, after the stream ends.
+    const backgroundTasks = createBackgroundTaskTracker();
+    let iterationCost: number | undefined;
+    let iterationTokens: TokenUsage | undefined;
+    let iterationNumTurns: number | undefined;
+    // Fold the last-seen per-iteration values into the loop totals exactly
+    // once — called on both the normal exit and the catch path (an SDK-error
+    // result still carries the iteration's cost, which the totals reported
+    // on the failure return must include, matching the old += behavior).
+    let iterationUsageFolded = false;
+    const foldIterationUsage = (): void => {
+      if (iterationUsageFolded) return;
+      iterationUsageFolded = true;
+      if (iterationCost !== undefined) {
+        loopTotalCostUsd = (loopTotalCostUsd ?? 0) + iterationCost;
+      }
+      if (iterationTokens !== undefined) {
+        loopTotalTokens = {
+          input: (loopTotalTokens?.input ?? 0) + iterationTokens.input,
+          output: (loopTotalTokens?.output ?? 0) + iterationTokens.output,
+        };
+      }
+      if (iterationNumTurns !== undefined) {
+        loopTotalNumTurns = (loopTotalNumTurns ?? 0) + iterationNumTurns;
+      }
+    };
+
     try {
       // Build prompt — substituteWorkflowVariables throws if $BASE_BRANCH referenced but empty
       // Pass loopUserInput on the first resumed iteration; '' on all others (non-interactive
@@ -3338,17 +3497,16 @@ async function executeLoopNode(
             lastToolStartedAt = null;
           }
           if (msg.sessionId) currentSessionId = msg.sessionId;
+          // Overwrite, don't accumulate — a later result in the same iteration
+          // (background-task wait, #2083) carries session-cumulative values.
           if (msg.cost !== undefined) {
-            loopTotalCostUsd = (loopTotalCostUsd ?? 0) + msg.cost;
+            iterationCost = msg.cost;
           }
           if (msg.tokens !== undefined) {
             // Provider-supplied numbers — see the NaN guard rationale at the
             // DAG-level accumulator.
             if (Number.isFinite(msg.tokens.input) && Number.isFinite(msg.tokens.output)) {
-              loopTotalTokens = {
-                input: (loopTotalTokens?.input ?? 0) + msg.tokens.input,
-                output: (loopTotalTokens?.output ?? 0) + msg.tokens.output,
-              };
+              iterationTokens = { input: msg.tokens.input, output: msg.tokens.output };
             } else {
               getLog().warn(
                 { nodeId: node.id, tokens: msg.tokens },
@@ -3358,7 +3516,7 @@ async function executeLoopNode(
           }
           if (msg.stopReason !== undefined) loopFinalStopReason = msg.stopReason;
           if (msg.numTurns !== undefined) {
-            loopTotalNumTurns = (loopTotalNumTurns ?? 0) + msg.numTurns;
+            iterationNumTurns = msg.numTurns;
           }
           if (msg.structuredOutput !== undefined) {
             lastIterationStructuredOutput = msg.structuredOutput;
@@ -3390,7 +3548,32 @@ async function executeLoopNode(
               `Loop '${node.id}' iteration ${String(i)} failed: SDK returned ${subtype}${errorsDetail}`
             );
           }
-          break; // Result is the "I'm done" signal — don't wait for subprocess to exit
+          if (backgroundTasks.shouldBreakOnResult()) {
+            break; // Result is the "I'm done" signal — don't wait for subprocess to exit
+          }
+          // Result with live background Agent tasks (#2083): breaking would
+          // SIGTERM the SDK subprocess and kill them. Keep consuming until the
+          // final result — see the AI-node stream loop for the full rationale.
+          getLog().warn(
+            {
+              nodeId: node.id,
+              iteration: i,
+              taskCount: backgroundTasks.count(),
+              taskIds: backgroundTasks.ids(),
+            },
+            'loop_node.iteration_result_with_live_background_tasks'
+          );
+          if (backgroundTasks.shouldAnnounceWait()) {
+            await safeSendMessage(
+              platform,
+              conversationId,
+              `⏳ Loop \`${node.id}\` iteration ${String(i)}: turn ended with ${String(backgroundTasks.count())} background agent task(s) still running — waiting for them to finish.`,
+              msgContext
+            );
+          }
+        } else if (msg.type === 'background_tasks') {
+          // Level signal (REPLACE semantics): swap the live set for the payload.
+          backgroundTasks.update(msg.tasks);
         } else if (msg.type === 'tool' && msg.toolName) {
           const now = Date.now();
 
@@ -3462,7 +3645,35 @@ async function executeLoopNode(
         }
         // rate_limit chunks: already log.warn'd in claude.ts; not surfaced to SSE per design
       }
+      foldIterationUsage();
+
+      // Stream ended with background tasks still live (idle timeout mid-wait or
+      // subprocess death): their artifacts may be missing — warn loudly instead
+      // of silently continuing (#2083). Cancellation is exempt (iteration fails
+      // with its own message).
+      if (!backgroundTasks.shouldBreakOnResult()) {
+        const cancelled = iterationAbortController.signal.aborted && !iterationIdleTimedOut;
+        getLog().warn(
+          {
+            nodeId: node.id,
+            iteration: i,
+            taskIds: backgroundTasks.ids(),
+            idleTimedOut: iterationIdleTimedOut,
+            cancelled,
+          },
+          'loop_node.iteration_stream_ended_with_live_background_tasks'
+        );
+        if (!cancelled) {
+          await safeSendMessage(
+            platform,
+            conversationId,
+            `⚠️ Loop \`${node.id}\` iteration ${String(i)}: the provider stream ended with ${String(backgroundTasks.count())} background agent task(s) still running (${backgroundTasks.ids().join(', ')}). Their output may be missing.`,
+            msgContext
+          );
+        }
+      }
     } catch (error) {
+      foldIterationUsage();
       const err = error as Error;
       const duration = Date.now() - iterationStart;
       getLog().error({ err, nodeId: node.id, iteration: i }, 'loop_node.iteration_failed');

--- a/packages/workflows/src/event-emitter.ts
+++ b/packages/workflows/src/event-emitter.ts
@@ -161,6 +161,9 @@ interface TaskActivityEvent {
   usage?: { total_tokens: number; tool_uses: number; duration_ms: number };
   lastToolName?: string;
   taskType?: string;
+  /** Transcript/output file the settled task points at (task_notification only)
+   *  — the artifact trail for delegated work (#2083). */
+  outputFile?: string;
   /** True when SDK signaled skip_transcript (housekeeping) — propagated so the
    *  UI / persistence layer can decide whether to surface. The provider
    *  filters these out today, but the field is here for forward-compat. */


### PR DESCRIPTION
## Summary

- Problem: since claude-agent-sdk 0.3.193 the `Task` tool became an async `Agent`/background-task system, so a `result` message only means "turn done" — not "all work done". dag-executor broke out of its stream loop at the first result, which cascades `.return()` down the generator chain → SDK `Query.cleanup()` → `transport.close()` → SIGTERM to the CLI subprocess ~2s later, killing live background tasks. The artifacts they were producing silently never appear (#2083, observed on two runs).
- Why it matters: silent data loss in any workflow node whose prompt triggers sub-agent delegation — the model does this spontaneously for "research N things in parallel" prompts; downstream nodes consume missing artifacts without error.
- What changed: the Claude provider now forwards the SDK's `background_tasks_changed` level signal (v0.3.209, previously dropped as an unhandled system subtype) as a new `background_tasks` MessageChunk; both dag-executor stream loops gate their break-on-result on the live-task set being empty and otherwise keep consuming until the tasks drain and the final result arrives (announced once with ⏳). Abnormal stream end with live tasks warns loudly and records `background_tasks_incomplete` in `node_completed` event data. `task_notification` events now persist `output_file` (the artifact pointer for delegated work).
- What did **not** change (scope boundary): non-Claude providers and pre-0.3.209 CLIs never emit the signal → byte-for-byte existing behavior. Direct chat (orchestrator) needs no change — it never breaks on result, its loop consumes the provider generator to natural exhaustion, which is exactly why task completions already arrive in chat today. #2125's synthetic-error logic and #2126's gate/loop-finalize regions are untouched.

## UX Journey

### Before

```
  User                        Archon (dag-executor)          Claude CLI
  ────                        ─────────────────────          ──────────
  runs workflow ────────────▶ node streams
                              model spawns 5 bg agents ────▶ agents start
                              result chunk arrives
                              *break* → node_completed       agents SIGTERMed
  sees "node succeeded" ◀───  (48s)                          artifacts NEVER written
  downstream node reads missing file → silent garbage
```

### After

```
  User                        Archon (dag-executor)          Claude CLI
  ────                        ─────────────────────          ──────────
  runs workflow ────────────▶ node streams
                              model spawns 5 bg agents ────▶ agents start
                              [background_tasks {5 live}]
                              result chunk arrives
                              [set non-empty → KEEP READING]
  sees "⏳ waiting for 5      task_progress resets idle      agents finish,
   background task(s)" ◀────  timer (existing backstop)      write artifacts
                              [background_tasks {empty}]     follow-up turn integrates output
                              final result → node_completed
  sees "node succeeded" ◀───  artifacts present ✔
  (abnormal end: "⚠️ output may be missing" + background_tasks_incomplete on the event)
```

## Architecture Diagram

### Before

```
Claude SDK ──messages──▶ claude/provider.ts ──MessageChunks──▶ dag-executor
  background_tasks_changed ──x── (dropped: system_message_unhandled)
  result ────────────────────────────────────▶ break (unconditional)
```

### After

```
Claude SDK ──messages──▶ claude/provider.ts ──MessageChunks──▶ dag-executor
  background_tasks_changed ===▶ [+] background_tasks chunk ===▶ [+] createBackgroundTaskTracker
  result ────────────────────────────────────▶ [~] break gated on tracker.shouldBreakOnResult()
  task_notification.output_file ==============▶ [~] persisted on task_activity events
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| claude/provider.ts | providers/types.ts (MessageChunk) | **modified** | new `background_tasks` variant emitted |
| dag-executor (AI-node loop) | provider stream | **modified** | conditional break; waits while tasks live |
| dag-executor (loop-node loop) | provider stream | **modified** | same gate; per-iteration usage folded once (no double-count with 2 results) |
| dag-executor | event-emitter / IWorkflowStore | **modified** | `outputFile` on task_activity; `background_tasks_incomplete` on node_completed data |
| orchestrator / adapters / web bridge | MessageChunk | unchanged | if/else chains ignore the new variant (verified; no exhaustive switches on chunk.type) |

## Label Snapshot

- Risk: `risk: medium`
- Size: `size: M`
- Scope: `workflows`
- Module: `workflows:executor`, `providers:claude`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes #2083

## Validation Evidence (required)

```bash
bun run validate   # exit 0 — check:bundled, check:bundled-skill, check:bundled-schema,
                   # check:pi-vendor-map, type-check, lint, format:check, tests all pass
```

- Evidence provided: empirical probe against the real SDK 0.3.209 + installed Claude CLI — with a prompt spawning one background agent (sleep 20s then write done.txt), the stream shows `background_tasks_changed [1 task]` BEFORE the result; continuing to consume past the result keeps the subprocess alive, `background_tasks_changed []` arrives at +35s, a final result at +38.9s, and `done.txt` exists on disk. Breaking at the first result (today's behavior) kills the tasks and the file is never written. New unit tests pin: wait-then-drain output capture, abnormal-end incompleteness recording, unchanged break-at-result without the signal, loop-node cost no-double-count, provider translation incl. empty-set forwarding and post-result passthrough.
- Skipped: none.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — providers/CLIs that never emit `background_tasks_changed` keep the exact previous break-on-first-result behavior; `background_tasks_incomplete` is an additive optional field in free-form event data.
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: SDK message-stream lifecycle probed live against SDK 0.3.209 (see Validation Evidence); full test suites for @archon/workflows and @archon/providers.
- Edge cases checked: empty-set drain signal forwarded (not dropped); cancellation mid-wait suppresses the warning (node fails with its own message); idle timeout mid-wait lands on the WARN+record path; per-iteration cost folding on both normal and error exits of the loop-node stream.
- What was not verified: a full end-to-end Archon workflow run with real delegating prompts (probe covered the SDK layer directly); Slack/Telegram rendering of the new ⏳/⚠️ messages (plain `sendMessage` strings, same path as existing warnings).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: workflow AI nodes and loop iterations on the Claude provider with CLI ≥0.3.209; nodes that delegate to background agents now run longer (they wait for the delegated work — that time was previously spent producing silently-lost artifacts) and include the follow-up turn's cost (billing now reflects work actually done).
- Potential unintended effects: a node with a genuinely wedged background task now waits until the idle timeout instead of completing incomplete — that is the intended fail-loud trade-off; the wait is announced in-stream and bounded by the existing `idle_timeout` (task_progress chunks reset it, ~30s cadence).
- Guardrails/monitoring: `dag.node_result_with_live_background_tasks` / `dag.node_stream_ended_with_live_background_tasks` (and loop_node equivalents) log events; `background_tasks_incomplete` on node_completed event data; ⏳/⚠️ user-facing messages.

## Rollback Plan (required)

- Fast rollback command/path: revert the single commit (`git revert 05e7ecc0`) — no schema/config coupling.
- Feature flags or config toggles: none; per-node `idle_timeout` bounds the wait.
- Observable failure symptoms: nodes hanging in "waiting for background tasks" until idle timeout (would indicate the SDK stopped emitting the drain signal); unexpected `background_tasks_incomplete` on clean runs.

## Risks and Mitigations

- Risk: the SDK changes `background_tasks_changed` semantics (e.g. stops emitting the empty-set drain signal), turning the wait into an idle-timeout stall.
  - Mitigation: the wait never hangs — generator exhaustion or idle timeout always ends it, and both land on the loud-warn + incompleteness-record path; the tracker is per stream pass so state cannot leak across retries.
- Risk: cost accounting drift in loop nodes now that one iteration can see two results.
  - Mitigation: last-seen fold (session-cumulative semantics) with a dedicated regression test asserting 0.3, not 0.4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow execution now waits for active background tasks to finish before completing a step or loop iteration.
  * Live background-task updates are reflected during streaming, including task status and completion.
  * Task activity records now include associated output file information.

* **Bug Fixes**
  * Prevented workflows from stopping prematurely when background tasks continue after an initial result.
  * Improved handling of incomplete tasks with user warnings and persisted task details.
  * Corrected usage accounting to avoid duplicate cost reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->