### PR TITLE
fix(workflows): follow-up to #2134 — loop-node background-task audit trail + live mid-stream cancel check (#2083)

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -1,4 +1,14 @@
-import { describe, it, expect, beforeEach, afterEach, mock, spyOn, type Mock } from 'bun:test';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  mock,
+  spyOn,
+  setSystemTime,
+  type Mock,
+} from 'bun:test';
 import { mkdir, writeFile, rm, readFile } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -4254,6 +4264,56 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect(sent.some(m => m.includes('output may be missing'))).toBe(true);
     });
 
+    it('suppresses the incompleteness warning when the node is genuinely cancelled with live tasks', async () => {
+      // The run is cancelled mid-stream (caught by the throttled status check)
+      // while a background task is still live. The stream ends with the task
+      // dangling, but the node already returns 'failed — Cancelled by user',
+      // so the incompleteness warning must be suppressed as noise.
+      // setSystemTime jumps past CANCEL_CHECK_INTERVAL_MS between chunks so the
+      // second status check fires deterministically (no real waiting).
+      let tasksDelivered = false;
+      mockSendQueryDag.mockImplementation(function* () {
+        yield {
+          type: 'background_tasks',
+          tasks: [{ taskId: 't-live', taskType: 'local_agent', description: 'still running' }],
+        };
+        tasksDelivered = true;
+        setSystemTime(new Date(Date.now() + 11_000));
+        yield { type: 'assistant', content: 'partial work' };
+        yield { type: 'assistant', content: 'MUST NOT BE REACHED' };
+      });
+
+      const store = createMockStore();
+      // 'running' until the task set has been delivered, 'cancelled' after —
+      // guarantees the abort happens with the task registered as live.
+      (store.getWorkflowRunStatus as Mock<() => Promise<string | null>>).mockImplementation(() =>
+        Promise.resolve(tasksDelivered ? 'cancelled' : 'running')
+      );
+      const platform = createMockPlatform();
+      try {
+        await runSingleNode(store, platform, 'bg-cancelled-run');
+      } finally {
+        setSystemTime(); // restore the real clock
+      }
+
+      // The node failed as cancelled — it never completed
+      expect(findCompletedEvent(store)).toBeUndefined();
+      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+      const failedEvent = eventCalls.find(
+        (c: unknown[]) =>
+          (c[0] as { event_type: string }).event_type === 'node_failed' &&
+          (c[0] as { step_name: string }).step_name === 'step1'
+      );
+      expect(failedEvent).toBeDefined();
+      expect((failedEvent![0] as { data: { error: string } }).data.error).toBe('Cancelled by user');
+      // Cancellation exemption: no user-facing incompleteness warning
+      const sent = (platform.sendMessage as ReturnType<typeof mock>).mock.calls.map(c =>
+        String(c[1])
+      );
+      expect(sent.some(m => m.includes('output may be missing'))).toBe(false);
+      expect(sent.some(m => m.includes('background agent'))).toBe(false);
+    });
+
     it('breaks at the first result when no background_tasks chunk was seen (unchanged behavior)', async () => {
       mockSendQueryDag.mockImplementation(function* () {
         yield { type: 'assistant', content: 'normal output' };
@@ -4412,6 +4472,222 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect(completedEvent).toBeDefined();
       // 0.3 (last session-cumulative value), NOT 0.4 (0.1 + 0.3 double-count)
       expect((completedEvent![0] as { data: { cost_usd?: number } }).data.cost_usd).toBe(0.3);
+    });
+
+    it('records the cross-iteration union of dangling background tasks on node_completed (#2083)', async () => {
+      // Iterations 1 and 2 each end with a different task still live (subprocess
+      // death analog); iteration 3 finishes cleanly and signals completion. The
+      // node_completed event must carry the UNION of dangling ids — last-iteration
+      // reporting would hide t-a and t-b behind the clean final iteration.
+      let callCount = 0;
+      mockSendQueryDag.mockImplementation(function* () {
+        callCount++;
+        if (callCount === 1) {
+          yield {
+            type: 'background_tasks',
+            tasks: [{ taskId: 't-a', taskType: 'local_agent', description: 'never drains' }],
+          };
+          yield { type: 'assistant', content: 'first pass' };
+          yield { type: 'result', sessionId: 'sid-1' };
+          // Generator ends with t-a live
+        } else if (callCount === 2) {
+          yield {
+            type: 'background_tasks',
+            tasks: [{ taskId: 't-b', taskType: 'local_agent', description: 'never drains' }],
+          };
+          yield { type: 'assistant', content: 'second pass' };
+          yield { type: 'result', sessionId: 'sid-2' };
+          // Generator ends with t-b live
+        } else {
+          yield { type: 'assistant', content: 'All done! <promise>COMPLETE</promise>' };
+          yield { type: 'result', sessionId: 'sid-3' };
+        }
+      });
+
+      const store = createMockStore();
+      const mockDeps = createMockDeps(store);
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun('loop-bg-union-run');
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        {
+          name: 'dag-loop-bg-union',
+          nodes: [
+            {
+              id: 'my-loop',
+              loop: {
+                prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
+                until: 'COMPLETE',
+                max_iterations: 5,
+              },
+            },
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      expect(mockSendQueryDag.mock.calls.length).toBe(3);
+      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+      const completedEvent = eventCalls.find(
+        (c: unknown[]) =>
+          (c[0] as { event_type: string }).event_type === 'node_completed' &&
+          (c[0] as { step_name: string }).step_name === 'my-loop'
+      );
+      expect(completedEvent).toBeDefined();
+      const data = (completedEvent![0] as { data: Record<string, unknown> }).data;
+      expect(data.background_tasks_incomplete).toEqual(['t-a', 't-b']);
+      // Each incomplete iteration also warned the user
+      const sent = (platform.sendMessage as ReturnType<typeof mock>).mock.calls.map(c =>
+        String(c[1])
+      );
+      expect(sent.filter(m => m.includes('output may be missing')).length).toBe(2);
+    });
+
+    it('omits background_tasks_incomplete from node_completed when every iteration drains cleanly', async () => {
+      mockSendQueryDag.mockImplementation(function* () {
+        yield {
+          type: 'background_tasks',
+          tasks: [{ taskId: 't-1', taskType: 'local_agent', description: 'bg work' }],
+        };
+        yield { type: 'assistant', content: 'Done. <promise>COMPLETE</promise>' };
+        yield { type: 'result', sessionId: 'sid-clean' };
+        yield { type: 'background_tasks', tasks: [] };
+        yield { type: 'result', sessionId: 'sid-clean' };
+      });
+
+      const store = createMockStore();
+      const mockDeps = createMockDeps(store);
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun('loop-bg-clean-run');
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        {
+          name: 'dag-loop-bg-clean',
+          nodes: [
+            {
+              id: 'my-loop',
+              loop: {
+                prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
+                until: 'COMPLETE',
+                max_iterations: 5,
+              },
+            },
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+      const completedEvent = eventCalls.find(
+        (c: unknown[]) =>
+          (c[0] as { event_type: string }).event_type === 'node_completed' &&
+          (c[0] as { step_name: string }).step_name === 'my-loop'
+      );
+      expect(completedEvent).toBeDefined();
+      expect(
+        (completedEvent![0] as { data: Record<string, unknown> }).data.background_tasks_incomplete
+      ).toBeUndefined();
+    });
+
+    it('cancellation mid-stream aborts the iteration and suppresses the incompleteness warning', async () => {
+      // Mirrors the AI-node cancellation-exemption test: the run is cancelled
+      // while an iteration is streaming with a live background task. The new
+      // mid-stream status check must abort the iteration (previously the loop
+      // only noticed cancellation BETWEEN iterations), fail the node with the
+      // observed status, and suppress the incompleteness warning.
+      let tasksDelivered = false;
+      mockSendQueryDag.mockImplementation(function* () {
+        yield {
+          type: 'background_tasks',
+          tasks: [{ taskId: 't-loop', taskType: 'local_agent', description: 'still running' }],
+        };
+        tasksDelivered = true;
+        setSystemTime(new Date(Date.now() + 11_000));
+        yield { type: 'assistant', content: 'working' };
+        yield { type: 'assistant', content: 'MUST NOT BE REACHED' };
+      });
+
+      const store = createMockStore();
+      // 'running' for the between-iteration check, 'cancelled' once the task
+      // set has been delivered mid-stream.
+      (store.getWorkflowRunStatus as Mock<() => Promise<string | null>>).mockImplementation(() =>
+        Promise.resolve(tasksDelivered ? 'cancelled' : 'running')
+      );
+      const mockDeps = createMockDeps(store);
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun('loop-bg-cancel-run');
+
+      try {
+        await executeDagWorkflow(
+          mockDeps,
+          platform,
+          'conv-dag',
+          testDir,
+          {
+            name: 'dag-loop-bg-cancel',
+            nodes: [
+              {
+                id: 'my-loop',
+                loop: {
+                  prompt: 'Do tasks.',
+                  until: 'COMPLETE',
+                  max_iterations: 5,
+                },
+              },
+            ],
+          },
+          workflowRun,
+          'claude',
+          undefined,
+          join(testDir, 'artifacts'),
+          join(testDir, 'logs'),
+          'main',
+          'docs/',
+          minimalConfig
+        );
+      } finally {
+        setSystemTime(); // restore the real clock
+      }
+
+      // Aborted during iteration 1 — no second iteration
+      expect(mockSendQueryDag.mock.calls.length).toBe(1);
+      // The loop never completed
+      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+      const completedEvent = eventCalls.find(
+        (c: unknown[]) =>
+          (c[0] as { event_type: string }).event_type === 'node_completed' &&
+          (c[0] as { step_name: string }).step_name === 'my-loop'
+      );
+      expect(completedEvent).toBeUndefined();
+      const sent = (platform.sendMessage as ReturnType<typeof mock>).mock.calls.map(c =>
+        String(c[1])
+      );
+      // The stop is surfaced with the observed status…
+      expect(sent.some(m => m.includes('stopped during iteration 1 (cancelled)'))).toBe(true);
+      // …and the incompleteness warning is suppressed as noise
+      expect(sent.some(m => m.includes('output may be missing'))).toBe(false);
     });
 
     it('completes after multiple iterations', async () => {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3332,6 +3332,15 @@ async function executeLoopNode(
   let loopFinalStopReason: string | undefined;
   let loopTotalNumTurns: number | undefined;
   let loopTotalTokens: TokenUsage | undefined;
+  // Union of task ids still live when ANY iteration's stream ended abnormally
+  // (idle timeout / subprocess death) — #2083. Union rather than last-iteration:
+  // a mid-loop iteration that lost its background tasks may have produced
+  // incomplete artifacts even when a later iteration finishes cleanly and
+  // signals completion — last-iteration-only reporting would hide that.
+  // Recorded on the node_completed event so an incomplete node never
+  // masquerades as a clean success (mirrors the AI-node path in
+  // executeNodeInternal).
+  const loopBackgroundTasksIncomplete = new Set<string>();
   // Helper to log event store errors consistently
   const logEventStoreError = (err: Error, iteration: number): void => {
     getLog().error({ err, nodeId: node.id, iteration }, 'loop_node.iteration_event_failed');
@@ -3389,6 +3398,16 @@ async function executeLoopNode(
     let cleanOutput = ''; // stripped, for platform display
     let iterationIdleTimedOut = false;
     const iterationAbortController = new AbortController();
+    // Mid-stream cancel-check throttle (see the check inside the stream loop).
+    // The between-iteration status check just ran, so start the clock at the
+    // iteration start. A local timestamp rather than the module-level
+    // lastNodeCancelCheck map the AI node uses: the loop owns its whole
+    // lifecycle in this stack frame, so a local needs no per-return-path map
+    // cleanup.
+    let lastStreamStatusCheckAt = iterationStart;
+    // Status observed by the mid-stream check when it aborts (for the failure
+    // message); undefined when the stream ends for any other reason.
+    let streamStopStatus: string | undefined;
 
     // Background-task gate (#2083) — see createBackgroundTaskTracker. When the
     // set is non-empty at result time this iteration keeps consuming, so a
@@ -3462,6 +3481,40 @@ async function executeLoopNode(
         );
         iterationAbortController.abort();
       })) {
+        // Mid-stream cancel/pause check (every CANCEL_CHECK_INTERVAL_MS) —
+        // lifted from the AI-node stream loop in executeNodeInternal. Same
+        // posture: `paused` is tolerated (a sibling approval node may pause
+        // the run while this loop streams); only terminal/unknown states
+        // abort the in-flight iteration. Without this, a cancelled run kept
+        // streaming until the iteration finished on its own — and the
+        // post-stream `cancelled` exemption below was unreachable.
+        const tickNow = Date.now();
+        if (tickNow - lastStreamStatusCheckAt > CANCEL_CHECK_INTERVAL_MS) {
+          lastStreamStatusCheckAt = tickNow;
+          try {
+            const streamStatus = await deps.store.getWorkflowRunStatus(workflowRun.id);
+            if (!shouldContinueStreamingForStatus(streamStatus)) {
+              streamStopStatus = streamStatus ?? 'deleted';
+              getLog().info(
+                {
+                  workflowRunId: workflowRun.id,
+                  nodeId: node.id,
+                  iteration: i,
+                  status: streamStopStatus,
+                },
+                'loop_node.stop_detected_during_streaming'
+              );
+              iterationAbortController.abort();
+              break;
+            }
+          } catch (statusErr) {
+            getLog().warn(
+              { err: statusErr as Error, workflowRunId: workflowRun.id, nodeId: node.id },
+              'loop_node.status_check_failed'
+            );
+          }
+        }
+
         if (msg.type === 'assistant') {
           fullOutput += msg.content;
           const cleaned = stripCompletionTags(msg.content, loop.until);
@@ -3648,16 +3701,21 @@ async function executeLoopNode(
       foldIterationUsage();
 
       // Stream ended with background tasks still live (idle timeout mid-wait or
-      // subprocess death): their artifacts may be missing — warn loudly instead
-      // of silently continuing (#2083). Cancellation is exempt (iteration fails
-      // with its own message).
+      // subprocess death): their artifacts may be missing — record the
+      // incompleteness (surfaced on the node_completed event) and warn loudly
+      // instead of silently continuing (#2083). Cancellation is exempt from the
+      // user-facing warning (the mid-stream check above returns the node as
+      // failed with its own message just below), but still recorded in the
+      // union — the audit trail should not depend on why the stream ended.
       if (!backgroundTasks.shouldBreakOnResult()) {
+        const danglingTaskIds = backgroundTasks.ids();
+        for (const id of danglingTaskIds) loopBackgroundTasksIncomplete.add(id);
         const cancelled = iterationAbortController.signal.aborted && !iterationIdleTimedOut;
         getLog().warn(
           {
             nodeId: node.id,
             iteration: i,
-            taskIds: backgroundTasks.ids(),
+            taskIds: danglingTaskIds,
             idleTimedOut: iterationIdleTimedOut,
             cancelled,
           },
@@ -3667,10 +3725,32 @@ async function executeLoopNode(
           await safeSendMessage(
             platform,
             conversationId,
-            `⚠️ Loop \`${node.id}\` iteration ${String(i)}: the provider stream ended with ${String(backgroundTasks.count())} background agent task(s) still running (${backgroundTasks.ids().join(', ')}). Their output may be missing.`,
+            `⚠️ Loop \`${node.id}\` iteration ${String(i)}: the provider stream ended with ${String(backgroundTasks.count())} background agent task(s) still running (${danglingTaskIds.join(', ')}). Their output may be missing.`,
             msgContext
           );
         }
+      }
+
+      // Cancelled mid-stream (not idle timeout): stop the node before signal
+      // detection / until_bash / the interactive gate run against a truncated
+      // iteration — mirrors both the AI-node 'Cancelled by user' return and
+      // this loop's own between-iteration stop path.
+      if (iterationAbortController.signal.aborted && !iterationIdleTimedOut) {
+        const effectiveStatus = streamStopStatus ?? 'cancelled';
+        await safeSendMessage(
+          platform,
+          conversationId,
+          `Loop node '${node.id}' stopped during iteration ${String(i)} (${effectiveStatus})`,
+          msgContext
+        );
+        return {
+          state: 'failed',
+          output: '',
+          error: `Workflow ${effectiveStatus}`,
+          costUsd: loopTotalCostUsd,
+          ...(loopTotalTokens !== undefined ? { tokens: loopTotalTokens } : {}),
+          loopIterations: i,
+        };
       }
     } catch (error) {
       foldIterationUsage();
@@ -3904,6 +3984,12 @@ async function executeLoopNode(
             ...(loopTotalCostUsd !== undefined ? { cost_usd: loopTotalCostUsd } : {}),
             ...(loopFinalStopReason ? { stop_reason: loopFinalStopReason } : {}),
             ...(loopTotalNumTurns !== undefined ? { num_turns: loopTotalNumTurns } : {}),
+            // Background Agent tasks still live when any iteration's stream
+            // ended (#2083) — this node's artifacts may be incomplete, even
+            // though a later iteration signaled completion.
+            ...(loopBackgroundTasksIncomplete.size > 0
+              ? { background_tasks_incomplete: [...loopBackgroundTasksIncomplete] }
+              : {}),
           },
         })
         .catch((err: Error) => {


### PR DESCRIPTION
## Summary

Follow-up to #2134 (background-task wait gate for #2083), closing the two gaps its post-merge review surfaced (see the [self-review comment on #2134](https://github.com/coleam00/Archon/pull/2134#issuecomment-4989997794), which flagged the loop-node `cancelled` exemption as "defensive rather than reachable" code):

- Problem 1: `executeLoopNode` detected background-task incompleteness per iteration (warn + chat message) but discarded it — the loop's `node_completed` DB event never carried `background_tasks_incomplete`, unlike the AI-node path. A loop whose mid-iterations lost background tasks could complete looking like a clean success.
- Problem 2: the `cancelled = signal.aborted && !idleTimedOut` exemption was untested on the AI node and **dead code** on the loop node — no mid-stream cancel check existed in the loop path (only the idle-timeout callback aborts the iteration controller).
- What changed: (1) a cross-iteration **union** of dangling task ids is accumulated and recorded on the loop's `node_completed` event; (2) the AI node's throttled mid-stream status check is lifted into the loop iteration stream, making the exemption live — a cancelled run now stops the iteration promptly and fails the node instead of streaming to completion; (3) tests for both, including the AI-node cancellation-suppression path.
- What did **not** change (scope boundary): only `dag-executor.ts` + its tests. No provider changes, no schema changes, no `loop_group` changes (its body nodes run through `executeNodeInternal`/`executeLoopNode`, which both now carry the audit field), no emitter-event shape changes (the field is DB-event-only, matching the AI-node path).

### Choices made (as asked by the review)

- **Union, not last-iteration**, for the dangling-task accumulator: a mid-loop iteration that lost its background tasks may have produced incomplete artifacts even when a later iteration finishes cleanly and emits the completion signal — last-iteration-only reporting would hide that. Documented in the code comment; mirrors the AI-node "an incomplete node never masquerades as a clean success" wording.
- **Option (a) — make the dead branch live** rather than documenting it as unreachable. It was a clean lift: the AI node's check (status read via `shouldContinueStreamingForStatus`, `paused` tolerated, throttled to `CANCEL_CHECK_INTERVAL_MS`) drops into the loop's stream loop with one simplification — a local throttle timestamp instead of the module-level `lastNodeCancelCheck` map, so no per-return-path map cleanup is needed (the loop owns its whole lifecycle in one stack frame). This also fixes a real gap: previously a cancelled run's loop iteration kept streaming (and billing) until the iteration finished on its own, and `until_bash`/the interactive gate could still run against a truncated iteration.

## UX Journey

### Before

```
  User                    Archon (loop node)              AI Client
  ────                    ──────────────────              ─────────
  cancels run ──────────▶ (not noticed mid-stream)
                          iteration keeps streaming ◀──── keeps producing
                          iteration ends on its own
                          between-iteration check ─▶ stop
  ...also:
  iteration N loses bg tasks → warn message only
  iteration N+1 signals COMPLETE → node_completed looks CLEAN
```

### After

```
  User                    Archon (loop node)              AI Client
  ────                    ──────────────────              ─────────
  cancels run ──────────▶ [mid-stream check ≤10s later]
                          [aborts iteration] ──────x───── stream torn down
  sees "stopped during
   iteration N" ◀──────── [node fails with observed status]
  ...also:
  iteration N loses bg tasks → warn message
  iteration N+1 signals COMPLETE → node_completed carries
   [background_tasks_incomplete: union of ALL iterations' dangling ids]
```

## Architecture Diagram

### Before

```
 executeNodeInternal ──▶ node_completed { background_tasks_incomplete }   (AI node: OK)
 executeNodeInternal ──▶ mid-stream cancel check (lastNodeCancelCheck map)

 executeLoopNode ──▶ per-iteration warn (discarded)
 executeLoopNode ──▶ node_completed { ...no audit field }
 executeLoopNode ──▶ between-iteration cancel check only (dead `cancelled` branch mid-stream)
```

### After

```
 executeNodeInternal ──▶ node_completed { background_tasks_incomplete }   (unchanged)

 executeLoopNode [~] ═══▶ loopBackgroundTasksIncomplete (union across iterations) [+]
                  [~] ═══▶ node_completed { background_tasks_incomplete } [+]
                  [~] ═══▶ mid-stream cancel check (local throttle) [+] → `cancelled` branch now live
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| executeLoopNode | store.createWorkflowEvent (node_completed) | **modified** | adds `background_tasks_incomplete` union when non-empty |
| executeLoopNode | store.getWorkflowRunStatus | **modified** | now also called mid-stream (throttled, 10s), not only between iterations |
| executeLoopNode | platform.sendMessage | **modified** | new "stopped during iteration N (status)" message on mid-stream stop; incompleteness warning suppressed when cancelled |
| executeNodeInternal | everything | unchanged | test-only coverage added for the existing cancellation exemption |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `workflows`
- Module: `workflows:dag-executor`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Related #2083, #2134 (no `Closes` — #2083 was closed by #2134; this hardens the same gate)

## Validation Evidence (required)

```bash
bun run validate   # exit 0 — all eight checks pass
bun test packages/workflows/src/dag-executor.test.ts   # 361 pass, 0 fail
```

- Evidence provided: 4 new tests — AI-node cancellation suppresses the incompleteness warning and fails with `Cancelled by user`; loop mid-stream cancel aborts iteration 1 (1 sendQuery call, no node_completed, warning suppressed); cross-iteration union `['t-a','t-b']` recorded on node_completed after a clean signaling iteration; clean-drain loop omits the field. The throttled checks are made deterministic with `setSystemTime` (jump past `CANCEL_CHECK_INTERVAL_MS` between chunks — no real waits, restored in `finally`).
- If any command is intentionally skipped, explain why: none skipped.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — `background_tasks_incomplete` on loop `node_completed` events is additive JSON (the same key the AI-node path already writes). The new mid-stream stop only fires for runs whose status is already terminal/deleted.
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: full dag-executor test file (361 tests) including the 4 new ones; `bun run validate` end to end.
- Edge cases checked: `paused` mid-stream is still tolerated (`shouldContinueStreamingForStatus` unchanged); status-check DB errors are logged and streaming continues (same posture as the AI node); idle timeout is still exempt from the cancellation return (`!iterationIdleTimedOut` guard); usage totals fold before the cancellation return so the failed result still reports cost/tokens.
- What was not verified: a live cancelled run against a real provider subprocess (the abort→SIGTERM teardown path is #2134's existing machinery, not re-verified here).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: loop-node execution only (top-level and inside `loop_group` bodies).
- Potential unintended effects: one extra `getWorkflowRunStatus` read per 10s of loop streaming (same cadence the AI node already has); a cancelled run's loop node now fails mid-iteration instead of finishing the iteration first — that is the intended behavior change.
- Guardrails/monitoring for early detection: `loop_node.stop_detected_during_streaming` / `loop_node.status_check_failed` log events; the existing `loop_node.iteration_stream_ended_with_live_background_tasks` WARN now logs `cancelled` truthfully.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge-commit>` — single commit, two files, no schema/config coupling.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: loop nodes failing with `Workflow cancelled` while the run is actually running (would indicate a status-read bug), or missing/duplicate `background_tasks_incomplete` on loop node_completed events.

## Risks and Mitigations

- Risk: the mid-stream abort could race with an iteration that was about to emit its completion signal, failing a node that would have completed.
  - Mitigation: the check only aborts on terminal/unknown run states (the run is already cancelled/failed/deleted — the node's completion would be discarded anyway); `paused` is tolerated exactly as in the AI-node policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow loop handling when background tasks remain incomplete across iterations.
  * Added clearer warnings when background task results may be missing.
  * Improved cancellation behavior for in-progress loop iterations, including accurate stopped-status reporting.
  * Prevented incomplete-task warnings when cancellation intentionally interrupts an iteration or all background tasks finish successfully.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->