### PR TITLE
fix(smoke): repoint codex smoke workflows to gpt-5.6-luna

### DIFF
--- a/.archon/workflows/test-workflows/e2e-codex-smoke.yaml
+++ b/.archon/workflows/test-workflows/e2e-codex-smoke.yaml
@@ -3,7 +3,7 @@
 name: e2e-codex-smoke
 description: "E2E smoke test for Codex provider. Runs a simple prompt + structured output node."
 provider: codex
-model: gpt-5.2
+model: gpt-5.6-luna
 
 nodes:
   - id: simple

--- a/.archon/workflows/test-workflows/e2e-mixed-providers.yaml
+++ b/.archon/workflows/test-workflows/e2e-mixed-providers.yaml
@@ -18,7 +18,7 @@ nodes:
   - id: codex-node
     prompt: "Say 'codex-ok' and nothing else."
     provider: codex
-    model: gpt-5.2
+    model: gpt-5.6-luna
     idle_timeout: 30000
 
   # 3. Assert both providers returned output


### PR DESCRIPTION
## Summary

- **Problem:** Two Codex smoke workflows pinned `gpt-5.2`, which ChatGPT-plan accounts now reject with `400 invalid_request_error: "The 'gpt-5.2' model is not supported when using Codex with a ChatGPT account."` — so the smokes can no longer be run on plan auth.
- **Why it matters:** These are the CI-adjacent smoke loops that verify the Codex provider path (provider selection, `sendQuery`, structured output, cross-provider output refs). A stale model pin makes them fail before exercising anything real.
- **What changed:** Repointed both smoke workflows from `gpt-5.2` to `gpt-5.6-luna` — the cheapest/lightest variant of the current GPT-5.6 lineup ($1 input / $6 output per 1M tokens), which is more than enough for the trivial smoke prompts.
- **What did NOT change (scope boundary):** No package/code changes. `.archon/workflows/experimental/archon-fix-github-issue-codex.yaml` was intentionally left alone — its `gpt-5.5` and `gpt-5.4-mini` pins are both still accepted on ChatGPT-plan auth (verified live), so no repoint or comment update was warranted there.

## Model-slug grounding

The slug was not guessed. Evidence gathered before pinning:

- The installed Codex CLI (`codex-cli 0.144.4`) binary embeds the current lineup: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` (plus the older `gpt-5.4`/`gpt-5.5` families). This machine's `~/.codex/config.toml` already defaults to `gpt-5.6-sol` on the live ChatGPT plan.
- Tier semantics (OpenAI GPT-5.6 launch, 2026-07): **Sol** = flagship ($5/$30), **Terra** = 2x cheaper than 5.5 ($2.50/$15), **Luna** = lowest cost ($1/$6). Luna is the right pick for a smoke.
- Direct probe on the live ChatGPT-plan credential:
  - `codex exec -m gpt-5.6-luna "What is 2+2?"` → `4` (accepted)
  - `codex exec -m gpt-5.2 "What is 2+2?"` → `400 ... "The 'gpt-5.2' model is not supported when using Codex with a ChatGPT account."` (reproduces the bug)
  - `codex exec -m gpt-5.5` and `-m gpt-5.4-mini` → both accepted (why the experimental file is left unchanged)

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `workflows`
- Module: `workflows:test-workflows`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes #2137

## Validation Evidence (required)

```bash
bun run validate                              # full suite
bun run cli validate workflows e2e-codex-smoke        # 1 valid, 0 errors
bun run cli validate workflows e2e-mixed-providers    # 1 valid, 0 errors
bun run cli workflow run e2e-codex-smoke --no-worktree      # PASS
bun run cli workflow run e2e-mixed-providers --no-worktree  # PASS
```

- Evidence provided: Both smokes executed live on a real ChatGPT-plan Codex credential.
  - `e2e-codex-smoke`: `PASS: simple='4' structured='{category:math}'` (both nodes resolved to `codex/gpt-5.6-luna`).
  - `e2e-mixed-providers`: `PASS: claude='claude-ok' codex='codex-ok'` (codex-node resolved to `codex/gpt-5.6-luna`, claude-node to `claude/haiku`).
  - `bun run cli validate workflows` reports 0 errors for both files. The one WARNING per file (`"$nodeId.output"` double-quoting in the pre-existing `assert` bash node) is unchanged by this PR and out of scope.
- Skipped: nothing.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios: Ran both smoke workflows end-to-end via the Archon CLI on a live ChatGPT-plan Codex login; both completed successfully with the new pin. Confirmed the old `gpt-5.2` pin is rejected by the same account (bug repro).
- Edge cases checked: Confirmed `gpt-5.5` / `gpt-5.4-mini` (the experimental Codex workflow's pins) are still plan-accepted, so that file is correctly left untouched.
- What was not verified: The API-key (non-plan) Codex path — the reported failure and this fix are specific to ChatGPT-plan auth, and `gpt-5.6-luna` is available across ChatGPT/Codex/API.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Only the two Codex smoke workflows under `.archon/workflows/test-workflows/`. No engine, provider, or package code touched.
- Potential unintended effects: None — these are test-only workflows not shipped in the bundled defaults.
- Guardrails/monitoring for early detection: The smokes themselves are the guardrail; they now run green on plan auth.

## Rollback Plan (required)

- Fast rollback command/path: `git revert` this commit — it only changes two YAML `model:` values.
- Feature flags or config toggles: None.
- Observable failure symptoms: Smoke workflow fails at the Codex node with a `400 invalid_request_error` naming an unsupported model.

## Risks and Mitigations

- Risk: A future GPT lineup rev could deprecate `gpt-5.6-luna` the same way `gpt-5.2` was deprecated.
  - Mitigation: Same one-line repoint; the grounding method (CLI binary slug list + live `codex exec` probe) is documented above for the next bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end smoke tests to use the newer `gpt-5.6-luna` model.
  * Updated mixed-provider workflow coverage while preserving existing execution and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->