### PR TITLE
fix(server): allow abandoning failed runs via HTTP API

### DIFF
--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -767,7 +767,7 @@ const abandonWorkflowRunRoute = createRoute({
   method: 'post',
   path: '/api/workflows/runs/{runId}/abandon',
   tags: ['Workflows'],
-  summary: 'Abandon a workflow run (mark as failed)',
+  summary: 'Abandon a workflow run (mark as cancelled)',
   request: { params: z.object({ runId: z.string() }) },
   responses: {
     200: {
@@ -3211,8 +3211,16 @@ export function registerApiRoutes(
       if (!run) {
         return apiError(c, 404, 'Workflow run not found');
       }
-      if (TERMINAL_WORKFLOW_STATUSES.includes(run.status)) {
-        return apiError(c, 400, `Cannot abandon workflow in '${run.status}' status`);
+      // A `failed` run is terminal per TERMINAL_WORKFLOW_STATUSES but remains
+      // resumable, so the user must be able to discard it — only the two
+      // non-resumable terminal states are blocked. Mirrors abandonWorkflow in
+      // workflow-operations.ts so the HTTP route agrees with CLI/chat (#1887).
+      if (run.status === 'completed' || run.status === 'cancelled') {
+        return apiError(
+          c,
+          400,
+          `Cannot abandon run with status '${run.status}'. Only running, paused, or failed runs can be abandoned.`
+        );
       }
       await workflowDb.cancelWorkflowRun(runId);
       return c.json({ success: true, message: `Abandoned workflow: ${run.workflow_name}` });

--- a/packages/server/src/routes/api.workflow-runs.test.ts
+++ b/packages/server/src/routes/api.workflow-runs.test.ts
@@ -1212,7 +1212,7 @@ describe('POST /api/workflows/runs/:runId/abandon', () => {
     expect(response.status).toBe(404);
   });
 
-  test('returns 400 when run is already terminal', async () => {
+  test('returns 400 when run is completed (non-resumable terminal)', async () => {
     mockGetWorkflowRun.mockResolvedValueOnce(MOCK_COMPLETED_RUN);
     const { app } = makeApp();
     const response = await app.request('/api/workflows/runs/run-uuid-2/abandon', {
@@ -1221,6 +1221,23 @@ describe('POST /api/workflows/runs/:runId/abandon', () => {
     expect(response.status).toBe(400);
     const body = (await response.json()) as { error: string };
     expect(body.error).toContain('Cannot abandon');
+    expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  test('returns 400 when run is cancelled (non-resumable terminal)', async () => {
+    mockGetWorkflowRun.mockResolvedValueOnce({
+      ...MOCK_RUNNING_RUN,
+      status: 'cancelled' as const,
+      completed_at: NOW,
+    });
+    const { app } = makeApp();
+    const response = await app.request('/api/workflows/runs/run-uuid-1/abandon', {
+      method: 'POST',
+    });
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toContain('Cannot abandon');
+    expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
   });
 
   test('returns 200 and calls cancelWorkflowRun for running run', async () => {
@@ -1234,6 +1251,21 @@ describe('POST /api/workflows/runs/:runId/abandon', () => {
     expect(body.success).toBe(true);
     expect(body.message).toContain('Abandoned');
     expect(mockCancelWorkflowRun).toHaveBeenCalledWith('run-uuid-1');
+  });
+
+  // #1887: a failed run is terminal but resumable, so it must remain
+  // abandonable — the HTTP route previously rejected it, contradicting CLI/chat.
+  test('returns 200 and calls cancelWorkflowRun for failed run', async () => {
+    mockGetWorkflowRun.mockResolvedValueOnce(MOCK_FAILED_RUN);
+    const { app } = makeApp();
+    const response = await app.request('/api/workflows/runs/run-uuid-4/abandon', {
+      method: 'POST',
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { success: boolean; message: string };
+    expect(body.success).toBe(true);
+    expect(body.message).toContain('Abandoned');
+    expect(mockCancelWorkflowRun).toHaveBeenCalledWith('run-uuid-4');
   });
 });
 

--- a/packages/web/src/lib/api.generated.d.ts
+++ b/packages/web/src/lib/api.generated.d.ts
@@ -1755,7 +1755,7 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Abandon a workflow run (mark as failed) */
+    /** Abandon a workflow run (mark as cancelled) */
     post: {
       parameters: {
         query?: never;


### PR DESCRIPTION
## Summary

- **Problem:** `POST /api/workflows/runs/:runId/abandon` returned 400 on a `failed` run because it guarded on `TERMINAL_WORKFLOW_STATUSES` (which includes `failed`), contradicting the CLI/chat path and every help string that says abandon discards failed runs.
- **Why it matters:** Web UI users could not clean up failed runs the way the documented command promises; the CLI/chat and HTTP contracts disagreed for the same operation.
- **What changed:** The HTTP route guard now blocks only the two non-resumable terminal states (`completed`, `cancelled`), mirroring `abandonWorkflow` in `workflow-operations.ts`. A `failed` run is terminal but resumable, so it stays abandonable. The route's OpenAPI summary (wrongly "mark as failed") is corrected to "mark as cancelled" and the generated web client doc comment is synced. Added/updated route tests.
- **What did NOT change (scope boundary):** No change to `workflow-operations.ts` (the CLI/chat path already agreed post-#1935), no change to the approve/reject/resume routes, no schema or DB changes. This is the HTTP-route-only remainder the issue was narrowed to on 2026-07-15.

## UX Journey

### Before

```
  User (Web UI)            Archon HTTP API
  ─────────────            ───────────────
  clicks "Abandon"  ─────▶ POST /runs/:id/abandon
  on a FAILED run          guard: status ∈ TERMINAL? (failed ∈ TERMINAL)
  sees 400 error  ◀─────── 400 "Cannot abandon workflow in 'failed' status"
  (run stays; no
   documented cleanup
   path from web)
```

### After

```
  User (Web UI)            Archon HTTP API
  ─────────────            ───────────────
  clicks "Abandon"  ─────▶ POST /runs/:id/abandon
  on a FAILED run          guard: status ∈ {completed, cancelled}?  *No*
                           cancelWorkflowRun(id) → status = cancelled
  sees success  ◀───────── 200 "Abandoned workflow: <name>"
  (matches CLI/chat)
```

## Architecture Diagram

### Before

```
  CLI / chat ──▶ abandonWorkflow()  ── blocks {completed, cancelled}
  Web UI ──────▶ HTTP abandon route ── blocks TERMINAL {completed, cancelled, failed}   <-- disagreement
                       │
                       └──▶ cancelWorkflowRun()
```

### After

```
  CLI / chat ──▶ abandonWorkflow()  ── blocks {completed, cancelled}
  Web UI ──────▶ HTTP abandon route ── blocks {completed, cancelled}   [~ now agrees]
                       │
                       └──▶ cancelWorkflowRun()
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| HTTP abandon route | `cancelWorkflowRun` | unchanged | still the terminal action |
| HTTP abandon route | guard condition | **modified** | `TERMINAL_WORKFLOW_STATUSES` → explicit `completed`/`cancelled` |
| OpenAPI spec | `api.generated.d.ts` | **modified** | summary doc comment synced |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `server`
- Module: `server:routes`

## Change Metadata

- Change type: `bug`
- Primary scope: `server`

## Linked Issue

- Closes #1887
- Related #1866, #1935, #2112

## Validation Evidence (required)

```bash
bun run validate
# EXIT_CODE=0
```

- Evidence provided: `bun run validate` green from the worktree root — `check:bundled`, `check:bundled-skill`, `check:bundled-schema`, `check:pi-vendor-map` OK; type-check across all 10 packages exit 0; eslint (`--max-warnings 0`) clean; prettier `--check` clean; all package test suites pass. The abandon-route test file (`api.workflow-runs.test.ts`) passes 86/86, including the new `failed`→200 and `cancelled`→400 cases.
- Skipped commands: none.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes` (widens accepted states for an existing route; previously-accepted calls behave identically)
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios: unit tests exercise all six run statuses through the route — `failed` and `running` now return 200 and call `cancelWorkflowRun`; `completed` and `cancelled` return 400 with `cancelWorkflowRun` asserted not called; missing run returns 404.
- Edge cases checked: `cancelled` (no fixture existed) added inline; negative cases assert the DB mutation is not invoked.
- What was not verified: no live web-UI click-through (behavior is fully covered by the route-level tests against the real handler).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: only `POST /api/workflows/runs/:runId/abandon`.
- Potential unintended effects: none expected — the guard strictly widens which statuses are accepted (adds `failed`), and `cancelWorkflowRun` is idempotent w.r.t. marking a run cancelled.
- Guardrails/monitoring: `api.workflow_run_abandon_failed` error log remains; tests lock in both the allowed and blocked status sets.

## Rollback Plan (required)

- Fast rollback: revert this commit; the route reverts to the `TERMINAL_WORKFLOW_STATUSES` guard.
- Feature flags: none.
- Observable failure symptoms: abandon on a `failed` run returns 400 again.

## Risks and Mitigations

- Risk: guard drift between the HTTP route and `abandonWorkflow` in future edits.
  - Mitigation: the route now mirrors the operation's exact condition and error text, and a code comment points to `workflow-operations.ts`; route tests assert the full status matrix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed workflow runs can now be abandoned successfully.
  * Completed and cancelled workflow runs remain protected from abandonment.
  * Updated API documentation to accurately describe run cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->