### PR TITLE
fix(cli): resolve covering codebase on resume instead of re-registering the worktree

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -3466,6 +3466,62 @@ describe('workflowResumeCommand', () => {
     // No codebase → falls back to working_path (preserves existing behavior)
     expect(discoverSpy).toHaveBeenCalledWith('/tmp/old-worktree', expect.any(Function));
   });
+
+  it('resolves the covering codebase by path prefix instead of re-registering the worktree working_path (#2127)', async () => {
+    // Regression for #2127: resuming from a worktree working_path whose run has
+    // no codebase_id must resolve the covering registered codebase via prefix
+    // lookup (like `workflow run` does) — NOT fall through to auto-registration,
+    // which trips the source-symlink guard for an already-covered path.
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    const workflowDiscovery = await import('@archon/workflows/workflow-discovery');
+    const { registerRepository } = await import('@archon/core');
+
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'run-2127',
+      workflow_name: 'implement',
+      status: 'failed',
+      user_message: 'go',
+      working_path: '/registered/root/worktrees/feat',
+      codebase_id: null,
+    });
+
+    (
+      workflowDiscovery.discoverWorkflowsWithConfig as ReturnType<typeof mock>
+    ).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'implement' })],
+      errors: [],
+    });
+
+    // Exact default_cwd match misses (worktree path != registered root); the
+    // path-prefix lookup resolves the covering repo codebase.
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+    (codebaseDb.findCodebaseByPathPrefix as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'cb-registered',
+      name: 'coleam00/Archon',
+      default_cwd: '/registered/root',
+      kind: 'repo',
+    });
+
+    // If resolution regressed to auto-registration, this is what would run — and
+    // fail with the source-symlink-mismatch guard the issue reported. Clear the
+    // module-level mock's history first so the not-called assertion is scoped to
+    // this test (other tests in the file exercise auto-registration).
+    (registerRepository as ReturnType<typeof mock>).mockClear();
+    (registerRepository as ReturnType<typeof mock>).mockRejectedValueOnce(
+      new Error('Source symlink at ~/.archon/workspaces/coleam00/Archon/source already points to')
+    );
+
+    // With the codebase resolved, resume proceeds past the registration step and
+    // fails later on the absent resumable run (default findResumableRun → null).
+    // The point is it does NOT surface the registration-failure error.
+    await expect(workflowResumeCommand('run-2127')).rejects.toThrow('No resumable run found');
+
+    expect(codebaseDb.findCodebaseByPathPrefix).toHaveBeenCalledWith(
+      '/registered/root/worktrees/feat'
+    );
+    expect(registerRepository).not.toHaveBeenCalled();
+  });
 });
 
 describe('workflowApproveCommand', () => {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -878,12 +878,20 @@ export async function workflowRunCommand(
     );
   }
 
-  // Try to find a codebase for this directory
+  // Try to find a codebase for this directory. Mirror the `run` dispatch gate
+  // (cli.ts) and the --detach folder probe above: exact `default_cwd` match
+  // first, then a path-prefix lookup so a subdirectory or worktree UNDER a
+  // registered root resolves to its covering codebase. Without the prefix
+  // fallback, resume/approve re-enter here with cwd = the run's worktree
+  // working_path, miss the exact match, and fall through to auto-registration —
+  // which trips the source-symlink guard for an already-covered path (#2127).
   let codebase = null;
   let codebaseLookupError: Error | null = null;
   let codebaseRegistrationError: Error | null = null;
   try {
-    codebase = await codebaseDb.findCodebaseByDefaultCwd(cwd);
+    codebase =
+      (await codebaseDb.findCodebaseByDefaultCwd(cwd)) ??
+      (await codebaseDb.findCodebaseByPathPrefix(cwd));
   } catch (error) {
     const err = error as Error;
     codebaseLookupError = err;


### PR DESCRIPTION
## Summary

- **Problem:** `archon workflow resume <id>` (and the approve/reject inline auto-resume) re-enters `workflowRunCommand` with `cwd` set to the run's worktree `working_path`. Codebase resolution there did an *exact* `default_cwd` match only; on a worktree path that misses, and when the run has no `codebase_id` it falls through to auto-registration — which trips the source-symlink-mismatch guard for an already-covered path and hard-fails the resume.
- **Why it matters:** A run started (and paused at an approval gate) from a worktree becomes unresumable from *any* cwd — the guard fires on the persisted `working_path` regardless of where resume runs. The only workaround was re-running the whole flow from a standalone clone.
- **What changed:** `workflowRunCommand`'s path-based codebase lookup now mirrors the `run` dispatch gate (`cli.ts`) and the `--detach` folder probe: exact `default_cwd` match first, then a `findCodebaseByPathPrefix` fallback, so a worktree/subdir under a registered root resolves to its covering codebase **before** any registration attempt. Added a regression test.
- **What did NOT change (scope boundary):** No change to the `resumableStatusClause`/hydrate machinery, the symlink guard itself (it is correct — the bug was reaching registration at all), the `options.codebaseId` fallback, approve/reject/abandon operation logic, or the isolation/worktree-reuse path.

## UX Journey

### Before

```
User                         Archon (workflow resume <id>)
────                         ─────────────────────────────
resume <id> ──────────────▶  load run → cwd = run.working_path (a worktree)
                             findCodebaseByDefaultCwd(worktree) → null (exact miss)
                             run.codebase_id is null → codebaseId fallback skipped
                             auto-register worktree → createProjectSourceSymlink
                             ✗ Error: Source symlink already points to <main checkout>
sees hard failure ◀───────   "Cannot resume: repository registration failed"
```

### After

```
User                         Archon (workflow resume <id>)
────                         ─────────────────────────────
resume <id> ──────────────▶  load run → cwd = run.working_path (a worktree)
                             findCodebaseByDefaultCwd(worktree) → null (exact miss)
                        [*]  findCodebaseByPathPrefix(worktree) → covering codebase
                             (registration NEVER attempted)
                             resume proceeds (skips completed nodes)
sees run resume ◀─────────   workflow continues
```

## Architecture Diagram

### Before

```
cli.ts (run dispatch)              workflow.ts :: workflowRunCommand
  findCodebaseByDefaultCwd            findCodebaseByDefaultCwd   (exact only)
    ?? findCodebaseByPathPrefix         └─ miss → options.codebaseId
                                           └─ null → registerRepository  ✗ symlink guard
resume/approve/reject ─────────────▶ workflowRunCommand(working_path, {codebaseId})
```

### After

```
cli.ts (run dispatch)              workflow.ts :: workflowRunCommand
  findCodebaseByDefaultCwd            findCodebaseByDefaultCwd
    ?? findCodebaseByPathPrefix    [~]  ?? findCodebaseByPathPrefix   (now mirrors run)
                                        └─ miss → options.codebaseId
                                           └─ null → registerRepository
resume/approve/reject ─────────────▶ workflowRunCommand(working_path, {codebaseId})
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `workflowRunCommand` | `codebaseDb.findCodebaseByPathPrefix` | **new** | fallback when exact `default_cwd` match misses |
| `workflowRunCommand` | `codebaseDb.findCodebaseByDefaultCwd` | unchanged | still tried first |
| `workflowResumeCommand` / `workflowApproveCommand` / `workflowRejectCommand` | `workflowRunCommand` | unchanged | shared fix benefits all three |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `cli`
- Module: `cli:workflow`

## Change Metadata

- Change type: `bug`
- Primary scope: `cli`

## Linked Issue

- Closes #2127

## Validation Evidence (required)

```bash
bun run validate   # exit 0 — check:bundled, check:bundled-skill, check:bundled-schema,
                   # check:pi-vendor-map, type-check (all 10 packages), lint (0 warnings),
                   # format:check, and full per-package test suite all pass
```

- Evidence provided: `bun run validate` green from the worktree root. New regression test `workflowResumeCommand > resolves the covering codebase by path prefix instead of re-registering the worktree working_path (#2127)`; `packages/cli/src/commands/workflow.test.ts` = 175 pass / 0 fail. Verified the test fails on the pre-fix code (throws the registration-failure error) and passes on the fix.
- Skipped commands: none.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No` — the change *reduces* filesystem writes by resolving an existing codebase instead of attempting a new workspace/symlink registration.

## Compatibility / Migration

- Backward compatible? `Yes` — exact `default_cwd` match still wins; the prefix lookup only runs on an exact miss and only resolves codebases that already cover the path.
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios: resume of a run whose `working_path` is a worktree under a registered root with `codebase_id` null now resolves the covering codebase (prefix lookup) and does **not** call `registerRepository`; run/approve/reject paths unaffected (they share `workflowRunCommand`).
- Edge cases checked: exact-match hit still short-circuits (prefix not called); exact + prefix both miss still falls through to registration for genuinely unregistered repos; `options.codebaseId` remains the authoritative resolver for an Archon-managed worktree (which lives under `~/.archon/workspaces/.../worktrees`, i.e. not under the codebase's `default_cwd`, so prefix does not shadow it).
- What was not verified: a live end-to-end resume against a real paused approval-gate run (covered by the regression test + full validate instead).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: CLI `workflow run` / `resume` / `approve` / `reject` codebase resolution.
- Potential unintended effects: for a fresh `run` from a subdirectory of a registered repo, resolution now returns the covering codebase directly instead of via `registerRepository`'s already-existed path — same end result, one fewer registration round-trip.
- Guardrails/monitoring: `cli.codebase_auto_registered` / `cli.codebase_auto_registration_failed` logs still fire when registration is genuinely reached.

## Rollback Plan (required)

- Fast rollback: revert this commit — the change is a single localized edit to the codebase-lookup expression plus one test.
- Feature flags/config toggles: none.
- Observable failure symptoms: resume/approve of a worktree-backed run fails with "Cannot resume: repository registration failed / Source symlink already points to ...".

## Risks and Mitigations

- Risk: prefix lookup resolves a `working_path` to a *different* registered project than the run's stored `codebase_id` when the path is physically nested under another project's root.
  - Mitigation: not reachable in Archon's layout — a run's `working_path` is always its own `default_cwd` (exact match) or an Archon-managed worktree under `~/.archon/workspaces/.../worktrees` (not under any `default_cwd`, so it falls through to the authoritative `codebaseId`). Prefix returns the most-specific (longest `default_cwd`) match, and only runs on an exact miss.