### PR TITLE
fix(workflows): fail loudly on unknown-node $id.output.field refs

### DIFF
--- a/packages/workflows/src/condition-evaluator.test.ts
+++ b/packages/workflows/src/condition-evaluator.test.ts
@@ -117,6 +117,22 @@ describe('evaluateCondition', () => {
     expect(warnCalls[0][0]).toEqual(expect.objectContaining({ nodeId: 'missing' }));
   });
 
+  it('unknown node WITH a field: throws (no-silent-drop, unknown-node)', () => {
+    // Whole-text `$missing.output` stays lenient (test above), but a `.field` ref to
+    // an unknown id is a typo — it must fail the node, matching the strict field
+    // posture and `substituteNodeOutputRefs`. did-you-mean names the near miss.
+    const outputs = new Map([['classify', makeOutput('BUG')]]);
+    let caught: unknown;
+    try {
+      evaluateCondition("$classfy.output.type == 'BUG'", outputs);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(OutputRefError);
+    expect((caught as OutputRefError).reason).toBe('unknown-node');
+    expect((caught as OutputRefError).message).toContain("'classify'");
+  });
+
   it('failed node: output is empty string, conditions evaluate accordingly', () => {
     const outputs = new Map([['classify', makeOutput('', 'failed')]]);
     expect(evaluateCondition("$classify.output == ''", outputs).result).toBe(true);

--- a/packages/workflows/src/condition-evaluator.ts
+++ b/packages/workflows/src/condition-evaluator.ts
@@ -27,7 +27,7 @@
  */
 import type { NodeOutput } from './schemas';
 import { createLogger } from '@archon/paths';
-import { resolveNodeOutputField } from './output-ref';
+import { resolveNodeOutputField, OutputRefError, similarNodeIds } from './output-ref';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
@@ -39,8 +39,10 @@ function getLog(): ReturnType<typeof createLogger> {
 /**
  * Resolve a `$nodeId.output` or `$nodeId.output.field` reference to a string value.
  *
- * Unknown node → '' (warn). Whole-text `$node.output` → output text ('' for failed
- * nodes). For `$node.output.field`, the no-silent-drop contract (`resolveNodeOutputField`)
+ * Unknown node: whole-text `$node.output` → '' (warn); `.field` form → THROWS
+ * `OutputRefError('unknown-node')` (a typo must fail, not silently resolve to '').
+ * Whole-text `$node.output` on a known node → output text ('' for failed nodes).
+ * For `$node.output.field`, the no-silent-drop contract (`resolveNodeOutputField`)
  * applies: a declared-optional-absent field resolves to ''; a field not in the
  * producer's schema, or a schemaless node whose output isn't JSON / lacks the key,
  * THROWS an `OutputRefError` that propagates to fail the consuming node (no silent skip).
@@ -52,6 +54,19 @@ function resolveOutputRef(
 ): string {
   const nodeOutput = nodeOutputs.get(nodeId);
   if (!nodeOutput) {
+    // A `.field` ref that resolves to no output (a typo, or a real node that hasn't
+    // run before this reference) fails the consuming node loudly, matching
+    // `resolveNodeOutputField`'s strict no-silent-drop posture (and
+    // `substituteNodeOutputRefs` in dag-executor). A whole-text `$id.output` stays
+    // lenient ('').
+    if (field) {
+      throw new OutputRefError(
+        nodeId,
+        field,
+        'unknown-node',
+        similarNodeIds(nodeId, nodeOutputs.keys())
+      );
+    }
     getLog().warn({ nodeId }, 'condition_output_ref_unknown_node');
     return '';
   }

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -790,6 +790,31 @@ describe('substituteNodeOutputRefs', () => {
     const outputs = new Map([['a', makeOutput('completed', '{"type":"BUG"}')]]);
     expect(() => substituteNodeOutputRefs('$a.output.missing', outputs)).toThrow(OutputRefError);
   });
+
+  it('unknown node ref WITH a field throws (no-silent-drop, unknown-node)', () => {
+    // The whole-text `$missing.output` form stays lenient ('' — see test above), but a
+    // `.field` ref to an unknown id is a typo the load-time validator can't always see
+    // (bash/script/approval/cancel + command-file refs aren't scanned). It must fail the
+    // consuming node loudly, matching known-producer strict-field posture.
+    const outputs = new Map([['analyze', makeOutput('completed', '{"type":"BUG"}')]]);
+    let caught: unknown;
+    try {
+      substituteNodeOutputRefs('Fix $analze.output.type', outputs);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(OutputRefError);
+    expect((caught as OutputRefError).reason).toBe('unknown-node');
+    // did-you-mean names the near miss.
+    expect((caught as OutputRefError).message).toContain("'analyze'");
+  });
+
+  it('unknown node ref WITH a field throws even in bash-escaped mode', () => {
+    const outputs = new Map<string, NodeOutput>();
+    expect(() => substituteNodeOutputRefs('echo $missing.output.field', outputs, true)).toThrow(
+      OutputRefError
+    );
+  });
 });
 
 describe('substituteNodeOutputRefs -- shell escaping', () => {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -61,7 +61,12 @@ import { createLogger, captureWorkflowCompleted } from '@archon/paths';
 import type { WorkflowErrorClass, WorkflowNodeType } from '@archon/paths';
 import { getWorkflowEventEmitter } from './event-emitter';
 import { evaluateCondition } from './condition-evaluator';
-import { declaredFieldsFromSchema, resolveNodeOutputField } from './output-ref';
+import {
+  declaredFieldsFromSchema,
+  resolveNodeOutputField,
+  OutputRefError,
+  similarNodeIds,
+} from './output-ref';
 import { writeNodeArtifact, readNodeArtifacts } from './artifacts-index';
 import {
   logNodeStart,
@@ -617,6 +622,21 @@ export function substituteNodeOutputRefs(
     (match, nodeId: string, field: string | undefined) => {
       const nodeOutput = nodeOutputs.get(nodeId);
       if (!nodeOutput) {
+        // A `.field` ref that resolves to no output (a typo the load-time validator
+        // can't always see — refs in bash/script/approval/cancel fields and inside
+        // command-file content aren't scanned — or a real node that hasn't run before
+        // this reference) fails the consuming node loudly, matching the strict
+        // no-silent-drop posture for known-producer field access below. The whole-text
+        // `$id.output` form stays lenient ('') as a long-documented surface (changing
+        // it is a bigger compatibility break).
+        if (field) {
+          throw new OutputRefError(
+            nodeId,
+            field,
+            'unknown-node',
+            similarNodeIds(nodeId, nodeOutputs.keys())
+          );
+        }
         getLog().warn({ nodeId, match }, 'dag_node_output_ref_unknown_node');
         return escapedForBash ? "''" : '';
       }
@@ -686,6 +706,13 @@ export function substituteLoopPrevRefs(
         // skipped / hasn't settled last iteration). Resolve to empty rather than
         // throwing — the author opted into a cross-iteration ref, and absence on the
         // first pass (or after a skipped node) is expected.
+        //
+        // NOTE: unlike substituteNodeOutputRefs / resolveOutputRef, this seam does NOT
+        // yet fail loudly on a `.field` ref to a genuinely-unknown body node id (a typo
+        // that matches no body node on ANY iteration). Distinguishing that from the
+        // legitimate iteration-1 absence needs the static body-node-id set threaded in
+        // (complicated by nested loop_groups reusing the outer snapshot), which is out
+        // of scope for #2135's `$node.output.field` fix — tracked as #2142.
         getLog().debug({ nodeId, match }, 'loop_group_prev_ref_no_prior_output');
         return escapedForBash ? "''" : '';
       }

--- a/packages/workflows/src/output-ref.test.ts
+++ b/packages/workflows/src/output-ref.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'bun:test';
 
-import { declaredFieldsFromSchema, OutputRefError, resolveNodeOutputField } from './output-ref';
+import {
+  declaredFieldsFromSchema,
+  OutputRefError,
+  resolveNodeOutputField,
+  similarNodeIds,
+} from './output-ref';
 import type { NodeOutput } from './schemas';
 
 function completed(
@@ -163,5 +168,44 @@ describe('resolveNodeOutputField — schemaless producer (bash/script/prose)', (
 
   it('top-level JSON array → throws unparseable (no named fields)', () => {
     expect(() => resolveNodeOutputField(completed('[1,2,3]'), 'n', 'x')).toThrow(OutputRefError);
+  });
+});
+
+describe('OutputRefError — unknown-node', () => {
+  it('names the unknown id and the whole ref', () => {
+    const e = new OutputRefError('typo', 'field', 'unknown-node');
+    expect(e.reason).toBe('unknown-node');
+    expect(e.message).toContain("'typo'");
+    expect(e.message).toContain('$typo.output.field');
+    // Accurate for both a typo AND a real node that has not run before the ref.
+    expect(e.message).toContain('has not run before this reference');
+  });
+
+  it('appends a did-you-mean hint when candidates are supplied', () => {
+    const e = new OutputRefError('analze', 'type', 'unknown-node', ['analyze', 'classify']);
+    expect(e.message).toContain('Did you mean');
+    expect(e.message).toContain("'analyze'");
+    expect(e.message).toContain("'classify'");
+  });
+
+  it('omits the did-you-mean hint when no candidates are close', () => {
+    const e = new OutputRefError('zzz', 'field', 'unknown-node', []);
+    expect(e.message).not.toContain('Did you mean');
+  });
+});
+
+describe('similarNodeIds', () => {
+  it('ranks the nearest known id first', () => {
+    const result = similarNodeIds('analze', ['analyze', 'build', 'classify']);
+    expect(result[0]).toBe('analyze');
+  });
+
+  it('returns [] when nothing is close', () => {
+    expect(similarNodeIds('xyzzy', ['analyze', 'build'])).toEqual([]);
+  });
+
+  it('accepts a Map keys iterable', () => {
+    const map = new Map<string, NodeOutput>([['analyze', completed('x')]]);
+    expect(similarNodeIds('analze', map.keys())).toContain('analyze');
   });
 });

--- a/packages/workflows/src/output-ref.ts
+++ b/packages/workflows/src/output-ref.ts
@@ -20,8 +20,17 @@
  *
  * The whole-text `$node.output` form (no `.field`) is never routed here — it is
  * unchanged and never throws.
+ *
+ * The UNKNOWN-node case (`$typo.output.field` where nothing in the outputs map
+ * resolves — a typo, or a real node that has not run before the reference) is
+ * handled by the callers, not `resolveNodeOutputField` — they own the outputs map.
+ * A `.field` ref to such an id throws `OutputRefError('unknown-node')` there, so it
+ * fails the consuming node loudly, consistent with the strict field posture above;
+ * a whole-text `$typo.output` to an unresolved id stays lenient ('') as a
+ * long-documented surface. See `similarNodeIds`.
  */
 import type { NodeOutput } from './schemas';
+import { findSimilar } from './utils/fuzzy-match';
 
 /**
  * Thrown when a `$nodeId.output.field` reference cannot be honored under the
@@ -32,19 +41,27 @@ export type OutputRefErrorReason =
   | 'not-in-schema'
   | 'unparseable'
   | 'missing-key'
-  | 'producer-not-run';
+  | 'producer-not-run'
+  | 'unknown-node';
 
 export class OutputRefError extends Error {
   constructor(
     public readonly nodeId: string,
     public readonly field: string,
-    public readonly reason: OutputRefErrorReason
+    public readonly reason: OutputRefErrorReason,
+    /** Nearby known node ids for a did-you-mean hint (only used by 'unknown-node'). */
+    public readonly candidates: readonly string[] = []
   ) {
-    super(OutputRefError.messageFor(nodeId, field, reason));
+    super(OutputRefError.messageFor(nodeId, field, reason, candidates));
     this.name = 'OutputRefError';
   }
 
-  private static messageFor(nodeId: string, field: string, reason: OutputRefErrorReason): string {
+  private static messageFor(
+    nodeId: string,
+    field: string,
+    reason: OutputRefErrorReason,
+    candidates: readonly string[]
+  ): string {
     const ref = `$${nodeId}.output.${field}`;
     switch (reason) {
       case 'not-in-schema':
@@ -55,8 +72,26 @@ export class OutputRefError extends Error {
         return `'${ref}' references field '${field}', but node '${nodeId}'s JSON output has no such key. Emit '${field}' in the output, or fix the reference.`;
       case 'producer-not-run':
         return `'${ref}' references field '${field}', but node '${nodeId}' did not run (skipped or pending), so it has no output to read. Guard this reference with a 'when:' condition, or fix the dependency.`;
+      case 'unknown-node': {
+        const hint =
+          candidates.length > 0
+            ? ` Did you mean: ${candidates.map(c => `'${c}'`).join(', ')}?`
+            : '';
+        return `'${ref}' references node '${nodeId}', but no node with that id has produced output at this point — the id is either unknown (a typo) or belongs to a node that has not run before this reference.${hint} Fix the id, or ensure '${nodeId}' runs first (e.g. add it to depends_on).`;
+      }
     }
   }
+}
+
+/**
+ * Rank known producer ids by proximity to a mistyped node id, for the did-you-mean
+ * hint in an 'unknown-node' `OutputRefError`. Returns up to 3 nearest ids (may be
+ * empty when nothing is close). Owned here so both substitution seams
+ * (`substituteNodeOutputRefs`, condition-evaluator's `resolveOutputRef`) build the
+ * error identically.
+ */
+export function similarNodeIds(nodeId: string, knownIds: Iterable<string>): string[] {
+  return findSimilar(nodeId, Array.from(knownIds));
 }
 
 /**

--- a/packages/workflows/src/utils/fuzzy-match.ts
+++ b/packages/workflows/src/utils/fuzzy-match.ts
@@ -1,0 +1,40 @@
+// =============================================================================
+// Levenshtein distance and fuzzy matching
+// =============================================================================
+//
+// Pure string utilities with zero package deps, so lean modules (output-ref,
+// condition-evaluator) can produce did-you-mean hints without pulling in the
+// heavy transitive deps of validator.ts, which is where these used to live.
+
+/** Classic Levenshtein distance between two strings */
+export function levenshtein(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0) as number[]);
+
+  for (let i = 0; i <= m; i++) dp[i][0] = i;
+  for (let j = 0; j <= n; j++) dp[0][j] = j;
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + cost);
+    }
+  }
+
+  return dp[m][n];
+}
+
+/** Find the closest matches from a list of candidates */
+export function findSimilar(
+  name: string,
+  candidates: readonly string[],
+  maxDistance?: number
+): string[] {
+  const threshold = maxDistance ?? Math.max(2, Math.floor(name.length * 0.3));
+  const scored = candidates
+    .map(c => ({ name: c, distance: levenshtein(name.toLowerCase(), c.toLowerCase()) }))
+    .filter(s => s.distance <= threshold && s.distance > 0)
+    .sort((a, b) => a.distance - b.distance);
+  return scored.slice(0, 3).map(s => s.name);
+}

--- a/packages/workflows/src/validator.ts
+++ b/packages/workflows/src/validator.ts
@@ -22,6 +22,7 @@ import {
 import { execFileAsync } from '@archon/git';
 import { BUNDLED_COMMANDS, isBinaryBuild } from './defaults/bundled-defaults';
 import { isValidCommandName } from './command-validation';
+import { levenshtein, findSimilar } from './utils/fuzzy-match';
 import { getProviderCapabilities, isRegisteredProvider } from '@archon/providers';
 
 /** Lazy-initialized logger */
@@ -91,42 +92,11 @@ export interface ValidationConfig {
   tiers?: RawTiersConfig;
 }
 
-// =============================================================================
-// Levenshtein distance and fuzzy matching
-// =============================================================================
-
-/** Classic Levenshtein distance between two strings */
-export function levenshtein(a: string, b: string): number {
-  const m = a.length;
-  const n = b.length;
-  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0) as number[]);
-
-  for (let i = 0; i <= m; i++) dp[i][0] = i;
-  for (let j = 0; j <= n; j++) dp[0][j] = j;
-
-  for (let i = 1; i <= m; i++) {
-    for (let j = 1; j <= n; j++) {
-      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
-      dp[i][j] = Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + cost);
-    }
-  }
-
-  return dp[m][n];
-}
-
-/** Find the closest matches from a list of candidates */
-export function findSimilar(
-  name: string,
-  candidates: readonly string[],
-  maxDistance?: number
-): string[] {
-  const threshold = maxDistance ?? Math.max(2, Math.floor(name.length * 0.3));
-  const scored = candidates
-    .map(c => ({ name: c, distance: levenshtein(name.toLowerCase(), c.toLowerCase()) }))
-    .filter(s => s.distance <= threshold && s.distance > 0)
-    .sort((a, b) => a.distance - b.distance);
-  return scored.slice(0, 3).map(s => s.name);
-}
+// Levenshtein distance and fuzzy matching now live in ./utils/fuzzy-match so lean
+// modules can reuse them without validator.ts's heavy deps (imported above for the
+// internal command/tool did-you-mean hints). Re-exported to preserve validator.ts's
+// public surface for existing importers (e.g. validator.test.ts).
+export { levenshtein, findSimilar };
 
 // =============================================================================
 // Command discovery


### PR DESCRIPTION
## Summary

- **Problem:** `$nodeId.output.field` references enforce a strict no-silent-drop contract (an unresolvable field fails the consuming node), but a reference to an **unknown node id** silently degraded to `''` — the early `!nodeOutput` return fired before the strict field resolver was ever reached. Same author mistake, inconsistent posture: `$existing-node.output.missing-field` throws, `$missing-node.output.field` silently returned `''`.
- **Why it matters:** #2129's automated node-id renaming makes stale/typo'd ids a systematic possibility, and the un-scanned surfaces (refs in `bash`/`script`/`approval`/`cancel` fields and inside command-file content) never get load-time validation — so this was the only backstop, and it failed open. A silent `''` poisons prompts/conditions instead of failing the node.
- **What changed:** An unknown-node `.field` reference now throws `OutputRefError` with a new reason `'unknown-node'` (plus a did-you-mean hint), failing the consuming node loudly — consistent with the existing strict-field cases. Applied at **both** seams that share this contract: `substituteNodeOutputRefs` (dag-executor) and `resolveOutputRef` (condition-evaluator / `when:`). Extracted `levenshtein`/`findSimilar` into a pure `utils/fuzzy-match.ts` so these lean modules can build the hint without pulling in `validator.ts`'s heavy deps.
- **What did NOT change (scope boundary):** Whole-text `$id.output` refs to unknown ids stay lenient (`''` + warn) — a long-documented surface; changing it is a bigger compatibility break. `substituteLoopPrevRefs` (`$LOOP_PREV.<node>.output.<field>`) is left lenient — it needs the static body-node-id set threaded through a recursive helper (nested loop_groups reuse the outer snapshot) to distinguish a typo from legitimate iteration-1 absence, which is beyond this issue's scope. Filed as follow-up **#2142** with a scope-note comment at the seam.

## UX Journey

### Before

```
Workflow author writes a typo:   bash: "echo $analze.output.type"   (node is "analyze")
  Engine                          Result
  ──────                          ──────
  substituteNodeOutputRefs        $analze not in outputs map
  → !nodeOutput early return  ──▶  substitutes ''  (debug-level warn only)
  node runs with "echo "     ──▶  silently wrong output; no failure, no signal
```

### After

```
Workflow author writes a typo:   bash: "echo $analze.output.type"   (node is "analyze")
  Engine                          Result
  ──────                          ──────
  substituteNodeOutputRefs        $analze not in outputs map, .field form
  → *throws OutputRefError*   ──▶  "'$analze.output.type' references node 'analze', but no
    ('unknown-node')               node with that id has produced output ... Did you mean:
                                   'analyze'? ..."
  per-node catch             ──▶  node FAILS loudly with the actionable message
```

## Architecture Diagram

### Before

```
validator.ts  (owns levenshtein/findSimilar, heavy deps: @archon/git, @archon/providers)

output-ref.ts ── resolveNodeOutputField (strict field contract; throws for known producers only)
      ▲
      │ (unknown-node handled by callers → silent '')
dag-executor.ts       substituteNodeOutputRefs   ── !nodeOutput → ''  (bug)
condition-evaluator.ts resolveOutputRef          ── !nodeOutput → ''  (bug)
```

### After

```
utils/fuzzy-match.ts [+]  (pure: levenshtein/findSimilar, zero deps)
      ▲                                    ▲
      │ (re-export, surface preserved)     │
validator.ts [~] ==========================┤
                                           │
output-ref.ts [~] ── OutputRefError('unknown-node') + similarNodeIds [+]
      ▲
      │ (callers throw for unknown-node .field refs)
dag-executor.ts [~]       substituteNodeOutputRefs   ── !nodeOutput && field → *throw*
condition-evaluator.ts [~] resolveOutputRef          ── !nodeOutput && field → *throw*
dag-executor.ts           substituteLoopPrevRefs     ── unchanged (scope-noted → #2142)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| output-ref.ts | utils/fuzzy-match.ts | **new** | pure did-you-mean helper |
| validator.ts | utils/fuzzy-match.ts | **new** | import + re-export (surface preserved) |
| dag-executor.ts | output-ref.ts | **modified** | now imports `OutputRefError`, `similarNodeIds` |
| condition-evaluator.ts | output-ref.ts | **modified** | now imports `OutputRefError`, `similarNodeIds` |
| validator.ts | (inline levenshtein/findSimilar) | **removed** | moved to fuzzy-match.ts |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `workflows`
- Module: `workflows:executor`, `workflows:condition-evaluator`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes #2135
- Related #2142 (follow-up: same gap in the `$LOOP_PREV.*` seam)
- Related #2129 (the node-id renaming that motivates the backstop)

## Validation Evidence (required)

```bash
bun run validate   # type-check, lint, format:check, bundled/schema/pi-vendor checks, per-package tests
```

- Evidence provided: `bun run validate` green from the worktree root (full log in PR discussion). Type-check clean across all 10 packages; format:check clean; targeted tests: output-ref (36), dag-executor + condition-evaluator regression cases, validator (63, re-export intact).
- Skipped: none.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No**

## Compatibility / Migration

- Backward compatible? **Yes** — any workflow that previously relied on `''` for an unknown-id `.field` ref was already silently broken; this converts hidden wrongness into a visible, actionable failure (fail-fast). Whole-text `$id.output` behavior is unchanged.
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

- Verified scenarios: unknown-node `.field` ref throws with did-you-mean at both the substitution and `when:` seams (unit tests); whole-text `$missing.output` still resolves to `''` + warn; all known/strict cases (declared-schema typo, schemaless missing key, declared-optional-absent) unchanged.
- Edge cases checked: bash-escaped mode also throws; `validator.ts` internal `findSimilar` uses + public re-export preserved (validator.test.ts green); message wording accurate for BOTH a typo and a real-but-not-yet-run node (loader validates `when:`/`prompt:` refs exist but does not require a `depends_on` edge, so an unknown-at-runtime miss there is an ordering issue, not a typo).
- What was not verified: end-to-end live workflow run (change is a pure-function substitution seam covered by unit tests).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: workflow execution — any node whose prompt/bash/script/approval/cancel/command text or `when:` condition contains a `$nodeId.output.field` reference.
- Potential unintended effects: a workflow with a pre-existing unknown-id `.field` ref (previously silently `''`) will now fail the node. This is the intended fail-fast conversion; the error message names the id and suggests nearby candidates.
- Guardrails/monitoring: `OutputRefError` propagates through the existing per-node catch → `node_failed` event + user-facing message; unit tests lock the behavior at both seams.

## Rollback Plan (required)

- Fast rollback: revert this PR (isolated to `@archon/workflows`; no schema/config).
- Feature flags: none.
- Observable failure symptoms: a workflow node failing with an `OutputRefError('unknown-node')` message where the author expected an empty substitution — indicates a real typo/ordering bug in the workflow, not a regression.

## Risks and Mitigations

- Risk: a workflow silently relying on `''` for an unknown-id `.field` ref starts failing.
  - Mitigation: it was already broken (producing wrong output); the new error names the id + did-you-mean and is trivially fixable. Documented as a compatibility note in the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid workflow output-field references now fail clearly instead of silently returning empty values.
  - Error messages identify unknown nodes and may suggest likely intended node names.
  - Whole-output references retain their existing lenient behavior.
  - Validation and command execution now apply consistent handling, including bash-escaped references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->