### PR TITLE
feat(workflows/pi): portable per-node extension posture in workflow YAML

### DIFF
--- a/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
+++ b/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
@@ -421,7 +421,19 @@ Most extensions need three config surfaces:
 |---|---|
 | `extensionFlags` | Per-extension feature flags (maps 1:1 to Pi's `--flag` CLI switches) |
 | `env` | Env vars the extension reads at runtime (managed via `.archon/config.yaml` or the Web UI codebase env panel) |
-| Workflow-level `interactive: true` | Required for **approval-gate extensions** on the web UI — forces foreground execution so the user can respond |
+| `interactive: true` | Binds a UI context so approval-gate extensions can block for human input; also set the **workflow-level** `interactive: true` on the web UI so the run stays foreground |
+
+#### Scoping extension posture per node
+
+`enableExtensions`, `interactive`, and `extensionFlags` are the three fields that make up a node's **extension posture**. Setting them under `assistants.pi` applies the posture to *every* Pi node in *every* workflow — which is usually wrong. A planning extension like plannotator only belongs on the node that actually plans: if the same `plan: true` flag leaks into a downstream `implement` node, that node starts in planning mode, its code edits get blocked ("edits are limited to markdown files"), and it hangs waiting on a review nobody asked for.
+
+Scope the posture to the node that plays that role. Three layers resolve per node, in ascending precedence:
+
+1. **Assistant-level** (`assistants.pi.*`) — the install-wide default for every Pi node.
+2. **Install-level node map** (`assistants.pi.nodes.<nodeId>`) — overrides the default for a node id on this machine. Handy when you can't edit the workflow, but it's non-portable: the override lives in one machine's `config.yaml` and is keyed by node-id string, so a node rename silently orphans it.
+3. **Portable node `pi:` block** — the per-node posture written directly in the workflow YAML. It travels with the workflow and wins over both layers above. This is the recommended surface.
+
+Each layer's `extensionFlags` shallow-merge over the ones below it (later wins per key), so a node can negate an inherited flag with `plan: false`. The `pi:` block is honored on `prompt`, `command`, and `loop` nodes (a `loop:` node's per-iteration call is exactly where planning mode tends to leak); on a `loop_group` it's ignored with a warning — put it on the body nodes instead.
 
 **Example — [plannotator](https://github.com/dmcglinn/plannotator) (human-in-the-loop plan review):**
 
@@ -430,25 +442,60 @@ Most extensions need three config surfaces:
 pi install npm:@plannotator/pi-extension
 ```
 
+Keep `assistants.pi` free of the planning flag — set only the extension's runtime env there:
+
 ```yaml
 # .archon/config.yaml
 assistants:
   pi:
     model: anthropic/claude-haiku-4-5
-    extensionFlags:
-      plan: true              # enables the plannotator "plan" flag
     env:
       PLANNOTATOR_REMOTE: "1" # exposes the review URL on 127.0.0.1:19432 so you can open it from anywhere
 ```
 
+Then grant the `plan` flag and a UI context to the planner node, and explicitly deny them on the implement loop — right in the workflow, so the posture ships with it:
+
 ```yaml
-# .archon/workflows/my-piv.yaml
-name: my-piv
+# .archon/workflows/plan-then-build.yaml
+name: plan-then-build
 provider: pi
-interactive: true             # plannotator gates the node on human approval — required on web UI
+interactive: true             # workflow-level: keeps the run foreground on the web UI so you can approve
+nodes:
+  - id: plan
+    prompt: "Draft a plan for: $ARGUMENTS"
+    pi:
+      interactive: true        # bind the UI context — plannotator opens its review server
+      extensionFlags:
+        plan: true             # planning mode ON for this node only
+
+  - id: implement
+    depends_on: [plan]
+    loop:
+      prompt: "Implement the approved plan. Print DONE when finished."
+      until: "DONE"
+      max_iterations: 10
+    pi:
+      interactive: false       # no review server on the implement loop
+      extensionFlags:
+        plan: false            # planning mode OFF — code edits are allowed
 ```
 
-When the node runs, plannotator prints a review URL and blocks until you click approve/deny in the browser. Archon's CLI/SSE batch buffer flushes that URL to you immediately so you never get stuck waiting on a node that silently wants input.
+When the `plan` node runs, plannotator prints a review URL and blocks until you click approve/deny in the browser. Archon's CLI/SSE batch buffer flushes that URL to you immediately so you never get stuck waiting on a node that silently wants input. The `implement` loop then runs headless with edits allowed.
+
+If you can't edit the workflow (e.g. a bundled default), the same scoping is available install-side via the node map — same precedence, lower priority than the workflow's own `pi:` block:
+
+```yaml
+# .archon/config.yaml
+assistants:
+  pi:
+    nodes:
+      plan:
+        interactive: true
+        extensionFlags: { plan: true }
+      implement:
+        interactive: false
+        extensionFlags: { plan: false }
+```
 
 ### Model reference format
 
@@ -490,7 +537,7 @@ nodes:
 
 | Feature | Support | YAML field |
 |---|---|---|
-| Extensions (community + local) | ✅ (default on) | `enableExtensions: false` to disable; `interactive: false` to load without UI bridge; `extensionFlags: { <name>: true }` per extension |
+| Extensions (community + local) | ✅ (default on) | `enableExtensions: false` to disable; `interactive: false` to load without UI bridge; `extensionFlags: { <name>: true }` per extension. Scope per node with a `pi:` block (`pi: { interactive, enableExtensions, extensionFlags }`) — see [Scoping extension posture per node](#scoping-extension-posture-per-node) |
 | Session resume | ✅ | automatic (Archon persists `sessionId`) |
 | Tool restrictions | ✅ | `allowed_tools` / `denied_tools` (read, bash, edit, write, grep, find, ls) |
 | Thinking level | ✅ | `effort: low\|medium\|high\|max` (max → xhigh) |

--- a/packages/providers/src/community/pi/config.test.ts
+++ b/packages/providers/src/community/pi/config.test.ts
@@ -345,4 +345,103 @@ describe('resolvePiExtensionSettings', () => {
       extensionFlags: undefined,
     });
   });
+
+  // ─── Node-YAML override layer (portable pi: block, #2133) ───────────────
+
+  test('node-YAML pi wins over the config nodes.<id> map', () => {
+    // config map says implement is UI-on with plan: true; the portable pi:
+    // block (3rd arg) overrides it to headless with plan: false.
+    expect(
+      resolvePiExtensionSettings(
+        {
+          extensionFlags: { plan: true },
+          nodes: { implement: { interactive: true, extensionFlags: { plan: true } } },
+        },
+        'implement',
+        { interactive: false, extensionFlags: { plan: false } }
+      )
+    ).toEqual({
+      enableExtensions: true,
+      interactive: false,
+      extensionFlags: { plan: false },
+    });
+  });
+
+  test('node-YAML pi applies even with no config nodes.<id> entry', () => {
+    expect(
+      resolvePiExtensionSettings({ extensionFlags: { plan: true } }, 'implement', {
+        interactive: false,
+        extensionFlags: { plan: false },
+      })
+    ).toEqual({
+      enableExtensions: true,
+      interactive: false,
+      extensionFlags: { plan: false },
+    });
+  });
+
+  test('extensionFlags shallow-merge across all three layers, node-YAML winning per key', () => {
+    expect(
+      resolvePiExtensionSettings(
+        {
+          extensionFlags: { plan: true, 'plan-file': 'BASE.md', shared: 'base' },
+          nodes: { implement: { extensionFlags: { 'plan-file': 'CFG.md', shared: 'cfg' } } },
+        },
+        'implement',
+        { extensionFlags: { shared: 'yaml' } }
+      ).extensionFlags
+    ).toEqual({ plan: true, 'plan-file': 'CFG.md', shared: 'yaml' });
+  });
+
+  test('node-YAML enableExtensions: false clamps interactive and beats a config nodes re-enable', () => {
+    expect(
+      resolvePiExtensionSettings(
+        {
+          interactive: true,
+          nodes: { implement: { enableExtensions: true, interactive: true } },
+        },
+        'implement',
+        { enableExtensions: false }
+      )
+    ).toEqual({
+      enableExtensions: false,
+      interactive: false,
+      extensionFlags: undefined,
+    });
+  });
+
+  test('a partial node-YAML override falls through to the config map for unset fields', () => {
+    // pi: sets only interactive; enableExtensions/flags still come from the config map + base.
+    expect(
+      resolvePiExtensionSettings(
+        {
+          extensionFlags: { plan: true },
+          nodes: { implement: { extensionFlags: { plan: false } } },
+        },
+        'implement',
+        { interactive: false }
+      )
+    ).toEqual({
+      enableExtensions: true,
+      interactive: false,
+      extensionFlags: { plan: false },
+    });
+  });
+
+  test('direct chat (no nodeId) still ignores overrides even if a node-YAML block is passed', () => {
+    // Defensive: the provider never passes nodeConfig.pi without a nodeId, but the
+    // resolver should stay predictable — no nodeId means assistant-level only for
+    // the config-map layer; the node-YAML layer, when present, still applies.
+    expect(
+      resolvePiExtensionSettings(
+        { interactive: true, extensionFlags: { plan: true }, nodes: { implement: {} } },
+        undefined,
+        undefined
+      )
+    ).toEqual({
+      enableExtensions: true,
+      interactive: true,
+      extensionFlags: { plan: true },
+    });
+  });
 });

--- a/packages/providers/src/community/pi/config.ts
+++ b/packages/providers/src/community/pi/config.ts
@@ -8,19 +8,17 @@ export type { PiProviderDefaults };
  * node that actually plays that role — e.g. only the planner node gets
  * plannotator's `plan` flag and a UI-capable context, while an `implement`
  * node runs headless without the planning-mode edit guard (issue #2073).
+ *
+ * The three fields are exactly the extension-posture subset of
+ * `PiProviderDefaults`, so we derive rather than re-declare them.
+ * `extensionFlags` is shallow-merged over the assistant-level flags (node
+ * wins); set a flag to `false` to negate an inherited `true`. Merge and
+ * precedence semantics live in {@link resolvePiExtensionSettings}.
  */
-export interface PiNodeOverride {
-  /** Override extension discovery for this node. */
-  enableExtensions?: boolean;
-  /** Override the UIContext binding (`ctx.hasUI`) for this node. */
-  interactive?: boolean;
-  /**
-   * Per-node extension flags, shallow-merged over the assistant-level
-   * `extensionFlags` (node wins). Set a flag to `false` to negate a base
-   * `true` (extensions check `getFlag(name) === true`).
-   */
-  extensionFlags?: Record<string, boolean | string>;
-}
+export type PiNodeOverride = Pick<
+  PiProviderDefaults,
+  'enableExtensions' | 'interactive' | 'extensionFlags'
+>;
 
 /** parsePiConfig output: assistant-level defaults plus optional per-node overrides. */
 export interface ParsedPiConfig extends PiProviderDefaults {
@@ -35,23 +33,42 @@ export interface PiExtensionSettings {
 }
 
 /**
- * Resolve the effective extension posture for a node. Node overrides
- * (`assistants.pi.nodes.<nodeId>`) win over assistant-level defaults; calls
- * without a node id (direct chat) always get the assistant-level defaults.
- * Node ids are matched verbatim across all workflows — treat them as role
- * names (`plan`, `implement`) when scoping extension behavior.
+ * Resolve the effective extension posture for a node across three layers, in
+ * ascending precedence:
+ *   1. assistant-level defaults (`assistants.pi.*`)
+ *   2. install-level config override (`assistants.pi.nodes.<nodeId>`, #2124)
+ *   3. portable node-YAML override (the workflow node's `pi:` block, #2133)
+ *
+ * The node-YAML layer wins because it travels with the workflow and is what the
+ * author actually sees; the config map stays as the per-install escape hatch.
+ * Calls without a node id (direct chat) get only the assistant-level defaults
+ * and ignore both override layers — `nodeYaml` is undefined there too.
+ *
+ * Node ids are matched verbatim across all workflows for the config-map layer —
+ * treat them as role names (`plan`, `implement`) when scoping extension behavior.
  */
 export function resolvePiExtensionSettings(
   config: ParsedPiConfig,
-  nodeId: string | undefined
+  nodeId: string | undefined,
+  nodeYaml?: PiNodeOverride
 ): PiExtensionSettings {
-  const override = nodeId !== undefined ? config.nodes?.[nodeId] : undefined;
-  const enableExtensions = override?.enableExtensions ?? config.enableExtensions !== false;
+  const configOverride = nodeId !== undefined ? config.nodes?.[nodeId] : undefined;
+  const enableExtensions =
+    nodeYaml?.enableExtensions ??
+    configOverride?.enableExtensions ??
+    config.enableExtensions !== false;
   // Clamp to false without extensions: nothing consumes hasUI without a runner.
-  const interactive = enableExtensions && (override?.interactive ?? config.interactive !== false);
-  const extensionFlags = override?.extensionFlags
-    ? { ...config.extensionFlags, ...override.extensionFlags }
-    : config.extensionFlags;
+  const interactive =
+    enableExtensions &&
+    (nodeYaml?.interactive ?? configOverride?.interactive ?? config.interactive !== false);
+  // Shallow-merge flags across all three layers, later layers winning per key —
+  // so a node-YAML `plan: false` negates an assistant-level `plan: true`.
+  const merged = {
+    ...config.extensionFlags,
+    ...configOverride?.extensionFlags,
+    ...nodeYaml?.extensionFlags,
+  };
+  const extensionFlags = Object.keys(merged).length > 0 ? merged : undefined;
   return { enableExtensions, interactive, extensionFlags };
 }
 

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -1871,6 +1871,77 @@ describe('PiProvider', () => {
     expect(mockSetFlagValue).not.toHaveBeenCalled();
   });
 
+  // ─── Portable node-YAML posture (nodeConfig.pi, #2133) ─────────────────
+
+  test('node-YAML pi overrides the config nodes.<id> map (drops UI, negates plan)', async () => {
+    process.env.GEMINI_API_KEY = 'sk-test';
+    resetScript(scriptedAgentEnd());
+
+    await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, {
+        model: 'google/gemini-2.5-pro',
+        assistantConfig: {
+          enableExtensions: true,
+          interactive: true,
+          extensionFlags: { plan: true },
+          // config map says implement is UI-on with plan: true …
+          nodes: { implement: { interactive: true, extensionFlags: { plan: true } } },
+        },
+        // … but the portable node-YAML block wins and turns it headless.
+        nodeConfig: {
+          nodeId: 'implement',
+          pi: { interactive: false, extensionFlags: { plan: false } },
+        },
+      })
+    );
+
+    expect(mockBindExtensions).toHaveBeenCalledTimes(1);
+    const [bindings] = mockBindExtensions.mock.calls[0] as [{ uiContext?: unknown }];
+    expect(bindings.uiContext).toBeUndefined();
+    expect(mockSetFlagValue).toHaveBeenCalledTimes(1);
+    expect(mockSetFlagValue).toHaveBeenCalledWith('plan', false);
+  });
+
+  test('node-YAML pi grants posture with no config nodes map present', async () => {
+    process.env.GEMINI_API_KEY = 'sk-test';
+    resetScript(scriptedAgentEnd());
+
+    await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, {
+        model: 'google/gemini-2.5-pro',
+        assistantConfig: { enableExtensions: true, interactive: false },
+        // No nodes map; the node's own pi: block re-enables the UI bridge and grants plan.
+        nodeConfig: { nodeId: 'plan', pi: { interactive: true, extensionFlags: { plan: true } } },
+      })
+    );
+
+    expect(mockBindExtensions).toHaveBeenCalledTimes(1);
+    const [bindings] = mockBindExtensions.mock.calls[0] as [{ uiContext?: unknown }];
+    expect(bindings.uiContext).toBeDefined();
+    expect(mockSetFlagValue).toHaveBeenCalledTimes(1);
+    expect(mockSetFlagValue).toHaveBeenCalledWith('plan', true);
+  });
+
+  test('node-YAML pi enableExtensions: false skips binding even when the config map re-enables', async () => {
+    process.env.GEMINI_API_KEY = 'sk-test';
+    resetScript(scriptedAgentEnd());
+
+    await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, {
+        model: 'google/gemini-2.5-pro',
+        assistantConfig: {
+          enableExtensions: true,
+          interactive: true,
+          nodes: { implement: { enableExtensions: true, interactive: true } },
+        },
+        nodeConfig: { nodeId: 'implement', pi: { enableExtensions: false } },
+      })
+    );
+
+    expect(mockBindExtensions).not.toHaveBeenCalled();
+    expect(mockSetFlagValue).not.toHaveBeenCalled();
+  });
+
   test('assistantConfig.env applies to process.env when not already set', async () => {
     process.env.GEMINI_API_KEY = 'sk-test';
     delete process.env.PI_TEST_ONE;

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -464,9 +464,14 @@ export class PiProvider implements IAgentProvider {
     // e.g. only the planner node gets plannotator's `plan` flag and a
     // UI-capable context (hasUI), while an implement node runs without the
     // planning-mode edit guard. Direct chat (no nodeId) uses the defaults.
+    //
+    // The portable node-YAML `pi:` block (#2133) rides on `nodeConfig.pi` and is
+    // the highest-precedence layer — it travels with the workflow, so a node
+    // rename can't orphan it the way the node-id-keyed config map can.
     const { enableExtensions, interactive, extensionFlags } = resolvePiExtensionSettings(
       piConfig,
-      nodeConfig?.nodeId
+      nodeConfig?.nodeId,
+      nodeConfig?.pi
     );
 
     // Build the ResourceLoader. When extensions are ON we MUST reuse a

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -391,6 +391,18 @@ export interface NodeConfig {
   >;
   allowed_tools?: string[];
   denied_tools?: string[];
+  /**
+   * Portable per-node Pi extension-posture override (issue #2133). Carries the
+   * workflow-YAML `pi:` block — the highest-precedence layer over the
+   * install-level `assistants.pi.nodes.<nodeId>` map (#2124) and assistant-level
+   * defaults. Consumed only by the Pi provider (`resolvePiExtensionSettings`);
+   * other providers ignore it. It is exactly the extension-posture subset of
+   * `PiProviderDefaults`, so we derive it rather than re-declare the fields. The
+   * workflows-side authoring schema (`PiNodeConfig` in @archon/workflows) is a
+   * separate hand-mirror only because that package can't import runtime values
+   * across the @archon/providers/types contract boundary.
+   */
+  pi?: Pick<PiProviderDefaults, 'enableExtensions' | 'interactive' | 'extensionFlags'>;
   effort?: string;
   thinking?: unknown;
   sandbox?: unknown;

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -879,6 +879,9 @@ async function resolveNodeProviderAndModel(
     hooks: node.hooks,
     skills: node.skills,
     agents: node.agents,
+    // Portable per-node Pi extension posture (#2133) — Pi provider reads it as
+    // the highest-precedence override; ignored by other providers.
+    pi: node.pi,
     allowed_tools: node.allowed_tools,
     denied_tools: node.denied_tools,
     effort: node.effort ?? workflowLevelOptions.effort,

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -1877,6 +1877,51 @@ nodes:
       expect(warnedFields).not.toContain('model');
       expect(warnedFields).not.toContain('provider');
     });
+
+    it('should NOT warn about pi: on loop nodes and should preserve it (#2133)', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+
+      // The portable pi: posture is threaded into each loop iteration's sendQuery,
+      // so it must survive the transform AND not be flagged as an ignored AI field.
+      await writeFile(
+        join(workflowDir, 'loop-pi.yaml'),
+        // No workflow-level provider: (unregistered in this unit context) — the
+        // pi: block is plain node data the loader preserves regardless of provider.
+        `
+name: loop-pi
+description: Loop with per-node Pi posture
+nodes:
+  - id: implement
+    loop:
+      prompt: "Do something"
+      until: "COMPLETE"
+      max_iterations: 3
+    pi:
+      interactive: false
+      extensionFlags:
+        plan: false
+`
+      );
+
+      (mockLogger.warn as Mock<() => undefined>).mockClear();
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.errors).toHaveLength(0);
+      expect(result.workflows).toHaveLength(1);
+
+      const node = result.workflows[0].workflow.nodes[0];
+      expect(isLoopNode(node)).toBe(true);
+      expect((node as typeof node & { pi?: unknown }).pi).toEqual({
+        interactive: false,
+        extensionFlags: { plan: false },
+      });
+
+      const warnCalls = (mockLogger.warn as Mock<() => undefined>).mock.calls;
+      const aiFieldWarnings = warnCalls.filter(
+        call => typeof call[1] === 'string' && call[1].includes('ai_fields_ignored')
+      );
+      expect(aiFieldWarnings).toHaveLength(0);
+    });
   });
 
   describe('DAG output ref validation', () => {

--- a/packages/workflows/src/schemas.test.ts
+++ b/packages/workflows/src/schemas.test.ts
@@ -3,6 +3,7 @@ import {
   isBashNode,
   isCancelNode,
   isScriptNode,
+  isLoopNode,
   isLoopGroupNode,
   isTriggerRule,
   TRIGGER_RULES,
@@ -415,6 +416,74 @@ describe('dagNodeSchema — new Claude SDK options', () => {
 });
 
 // ---------------------------------------------------------------------------
+// dagNodeSchema — per-node Pi extension posture (`pi:`, #2133)
+// ---------------------------------------------------------------------------
+
+describe('dagNodeSchema — per-node Pi posture (pi:)', () => {
+  test('accepts and preserves a pi: block on a prompt node', () => {
+    const result = dagNodeSchema.safeParse({
+      id: 'plan',
+      prompt: 'plan it',
+      pi: { interactive: true, extensionFlags: { plan: true, 'plan-file': 'PLAN.md' } },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as PromptNode).pi).toEqual({
+        interactive: true,
+        extensionFlags: { plan: true, 'plan-file': 'PLAN.md' },
+      });
+    }
+  });
+
+  test('preserves a pi: block on a loop node (the plannotator leak seam, #2073)', () => {
+    // Loops drop model/provider in the transform, but pi MUST survive — the loop
+    // is exactly where the implement node needs its posture scoped down.
+    const result = dagNodeSchema.safeParse({
+      id: 'implement',
+      loop: { prompt: 'do work', until: 'DONE', max_iterations: 5 },
+      pi: { interactive: false, extensionFlags: { plan: false } },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(isLoopNode(result.data)).toBe(true);
+      expect((result.data as DagNode & { pi?: unknown }).pi).toEqual({
+        interactive: false,
+        extensionFlags: { plan: false },
+      });
+    }
+  });
+
+  test('drops pi: from a bash node in the transform', () => {
+    const result = dagNodeSchema.safeParse({
+      id: 'sh',
+      bash: 'echo hi',
+      pi: { interactive: false },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect('pi' in result.data).toBe(false);
+    }
+  });
+
+  test('rejects a non-boolean/string extensionFlags value', () => {
+    const result = dagNodeSchema.safeParse({
+      id: 'plan',
+      prompt: 'plan it',
+      pi: { extensionFlags: { plan: 42 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('pi is warned-ignored on non-AI + loop_group nodes but supported on loop', () => {
+    // loop uses its per-iteration sendQuery, so pi must NOT be in its ignore list;
+    // loop_group never sendQuerys (body nodes carry their own pi), so it warns.
+    expect(LOOP_NODE_AI_FIELDS).not.toContain('pi');
+    expect(LOOP_GROUP_NODE_AI_FIELDS).toContain('pi');
+    expect(SCRIPT_NODE_AI_FIELDS).toContain('pi');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // isScriptNode
 // ---------------------------------------------------------------------------
 
@@ -807,9 +876,17 @@ describe('dagNodeSchema — loop_group', () => {
 });
 
 describe('LOOP_GROUP_NODE_AI_FIELDS', () => {
-  test('mirrors LOOP_NODE_AI_FIELDS (model/provider forwarded to body AI nodes)', () => {
+  test('excludes model/provider (forwarded to body AI nodes)', () => {
     expect(LOOP_GROUP_NODE_AI_FIELDS).not.toContain('model');
     expect(LOOP_GROUP_NODE_AI_FIELDS).not.toContain('provider');
-    expect(LOOP_GROUP_NODE_AI_FIELDS).toEqual(LOOP_NODE_AI_FIELDS);
+  });
+
+  test('differs from LOOP_NODE_AI_FIELDS only on pi (#2133)', () => {
+    // A plain loop: node calls sendQuery itself, so pi IS honored there (not warned).
+    // A loop_group node never calls sendQuery — body nodes carry their own pi — so
+    // pi is warned-ignored on the group. That single-key difference is intentional.
+    expect(LOOP_NODE_AI_FIELDS).not.toContain('pi');
+    expect(LOOP_GROUP_NODE_AI_FIELDS).toContain('pi');
+    expect(LOOP_GROUP_NODE_AI_FIELDS.filter(f => f !== 'pi')).toEqual([...LOOP_NODE_AI_FIELDS]);
   });
 });

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -130,6 +130,34 @@ export const agentDefinitionSchema = z.object({
 
 export type AgentDefinition = z.infer<typeof agentDefinitionSchema>;
 
+/**
+ * Per-node Pi extension posture — the PORTABLE authoring surface for issue #2133.
+ * Mirrors the install-level `assistants.pi.nodes.<nodeId>` override map (#2124),
+ * but lives on the node itself so it travels with the workflow instead of a
+ * machine's `config.yaml`. Highest-precedence layer: node YAML `pi:` > config
+ * `nodes.<id>` > assistant-level `assistants.pi.*`. Structurally identical to the
+ * providers-side `PiNodeOverride` (@archon/providers/pi/config) — hand-mirrored
+ * because @archon/workflows cannot import runtime values from @archon/providers
+ * (only the contract subpath @archon/providers/types).
+ *
+ * Pi-only, like Claude's `hooks`/`mcp`/`skills`/`agents`. Other providers ignore
+ * it; non-AI node types warn it's ignored (see BASH_NODE_AI_FIELDS).
+ */
+export const piNodeConfigSchema = z.object({
+  /** Override extension discovery for this node (`assistants.pi.enableExtensions`). */
+  enableExtensions: z.boolean().optional(),
+  /** Override the UIContext binding (`ctx.hasUI`) for this node. */
+  interactive: z.boolean().optional(),
+  /**
+   * Per-node extension flags, shallow-merged over the assistant-level and
+   * config `nodes.<id>` flags (node YAML wins). Set a flag to `false` to negate
+   * an inherited `true` (extensions check `getFlag(name) === true`).
+   */
+  extensionFlags: z.record(z.string(), z.union([z.boolean(), z.string()])).optional(),
+});
+
+export type PiNodeConfig = z.infer<typeof piNodeConfigSchema>;
+
 // Kebab-case: no leading/trailing/double hyphens (e.g. `brief-gen`, not `-brief`, `brief-`, `brief--gen`).
 const AGENT_ID_REGEX = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
@@ -179,6 +207,10 @@ export const dagNodeBaseSchema = z.object({
     })
     .refine(map => Object.keys(map).length > 0, "'agents' must have at least one entry")
     .optional(),
+  // Portable per-node Pi extension posture (#2133). Highest-precedence layer
+  // over the install-level `assistants.pi.nodes.<id>` map. Pi-only; ignored
+  // (with a warning) on other providers and on non-AI node types.
+  pi: piNodeConfigSchema.optional(),
   effort: effortLevelSchema.optional(),
   thinking: thinkingConfigSchema.optional(),
   maxBudgetUsd: z.number().positive().optional(),
@@ -429,6 +461,7 @@ export const BASH_NODE_AI_FIELDS: readonly string[] = [
   'mcp',
   'skills',
   'agents',
+  'pi',
   'effort',
   'thinking',
   'maxBudgetUsd',
@@ -444,19 +477,26 @@ export const SCRIPT_NODE_AI_FIELDS: readonly string[] = BASH_NODE_AI_FIELDS;
 
 /**
  * AI-specific fields that are unsupported on loop nodes.
- * `model` and `provider` are excluded because the DAG executor resolves and
- * forwards them to each iteration's AI call (see dag-executor.ts:2602-2648).
+ * `model` and `provider` are excluded because loop iterations inherit them from
+ * the workflow level. `pi` is excluded because the portable per-node Pi posture
+ * (#2133) IS threaded into each iteration's sendQuery — the loop is the very
+ * node whose extension posture users need to scope (plannotator planning-mode
+ * leak, #2073).
  */
 export const LOOP_NODE_AI_FIELDS: readonly string[] = BASH_NODE_AI_FIELDS.filter(
-  f => f !== 'model' && f !== 'provider'
+  f => f !== 'model' && f !== 'provider' && f !== 'pi'
 );
 
 /**
- * AI-specific fields that are unsupported on loop_group nodes. Same set as
- * `loop:` — `model`/`provider` are forwarded to each body AI node (overridable
- * per-node), so they remain meaningful at the group level.
+ * AI-specific fields that are unsupported on loop_group nodes. `model`/`provider`
+ * are forwarded to each body AI node (overridable per-node), so they remain
+ * meaningful at the group level. `pi` is NOT forwarded — the group never calls
+ * sendQuery, and body nodes carry their own `pi:` block — so it's warned as
+ * ignored here (unlike on a plain `loop:` node, which does sendQuery itself).
  */
-export const LOOP_GROUP_NODE_AI_FIELDS: readonly string[] = LOOP_NODE_AI_FIELDS;
+export const LOOP_GROUP_NODE_AI_FIELDS: readonly string[] = BASH_NODE_AI_FIELDS.filter(
+  f => f !== 'model' && f !== 'provider'
+);
 
 // ---------------------------------------------------------------------------
 // dagNodeSchema — flat validation schema with transform to DagNode
@@ -677,6 +717,7 @@ export const dagNodeSchema = dagNodeBaseSchema
       ...(data.mcp !== undefined ? { mcp: data.mcp.trim() } : {}),
       ...(data.skills !== undefined ? { skills: data.skills.map(s => s.trim()) } : {}),
       ...(data.agents !== undefined ? { agents: data.agents } : {}),
+      ...(data.pi !== undefined ? { pi: data.pi } : {}),
       ...(data.effort !== undefined ? { effort: data.effort } : {}),
       ...(data.thinking !== undefined ? { thinking: data.thinking } : {}),
       ...(data.maxBudgetUsd !== undefined ? { maxBudgetUsd: data.maxBudgetUsd } : {}),
@@ -728,9 +769,18 @@ export const dagNodeSchema = dagNodeBaseSchema
     if (data.loop_group !== undefined) {
       return { ...base, ...aiOnly, loop_group: data.loop_group } as LoopGroupNode;
     }
-    // loop — guaranteed by superRefine to be defined at this point
+    // loop — guaranteed by superRefine to be defined at this point.
+    // Unlike the rest of aiOnly (dropped for loops — model/provider inherit from
+    // the workflow level), `pi` posture IS kept: the loop's per-iteration Pi
+    // sendQuery is exactly where plannotator planning mode leaks (#2073/#2133),
+    // so the portable `pi:` block must reach it. Excluded from LOOP_NODE_AI_FIELDS
+    // so the loader doesn't warn it's ignored.
     if (!data.loop) throw new Error('unreachable: loop must be defined after superRefine');
-    return { ...base, loop: data.loop } as LoopNode;
+    return {
+      ...base,
+      ...(data.pi !== undefined ? { pi: data.pi } : {}),
+      loop: data.loop,
+    } as LoopNode;
   })
   .openapi('DagNode');
 

--- a/packages/workflows/src/schemas/index.ts
+++ b/packages/workflows/src/schemas/index.ts
@@ -57,6 +57,7 @@ export {
   thinkingConfigSchema,
   sandboxSettingsSchema,
   agentDefinitionSchema,
+  piNodeConfigSchema,
 } from './dag-node';
 export type {
   TriggerRule,
@@ -76,6 +77,7 @@ export type {
   ThinkingConfig,
   SandboxSettings,
   AgentDefinition,
+  PiNodeConfig,
 } from './dag-node';
 
 // Workflow definition


### PR DESCRIPTION
## Summary

- **Problem:** PR #2124 fixed the plannotator planning-mode leak (#2073) with an INSTALL-level override map (`assistants.pi.nodes.<nodeId>` in `config.yaml`). That works but the authoring surface is non-portable: the workflow defines the node, yet its extension posture lives in one machine's config, keyed by node-id string — a node rename silently orphans the override, and the posture doesn't travel with the workflow.
- **Why it matters:** the fix for a workflow's own behavior should ship WITH the workflow. Otherwise every operator who runs a plan→implement Pi workflow has to hand-edit their local config, and a shared workflow arrives without its posture.
- **What changed:** added the PORTABLE per-node surface — a `pi:` block on a DAG node (`enableExtensions` / `interactive` / `extensionFlags`), mirroring the established provider-specific per-node fields (Claude's `hooks`/`mcp`/`skills`). Precedence: node YAML `pi:` > config `nodes.<id>` map > assistant-level. `resolvePiExtensionSettings` now resolves all three layers with a per-key `extensionFlags` shallow-merge. The config map from #2124 stays as the install-level override layer. Rewrote the `ai-assistants.md` plannotator example around the node-scoped pattern (the docs follow-up #2124's review deferred) and documented the previously-undocumented `nodes:` config map.
- **What did NOT change (scope boundary):** no behavior change for direct chat or for nodes without a `pi:` block (byte-for-byte). No new `reload()` calls (#1877 single-reload constraint respected — posture resolution stays per-`sendQuery`, the seam #2124 built). The dag-executor touch is a single option pass-through (`pi: node.pi`), no restructuring. No DB/migration/config-file changes required by existing installs.

## UX Journey

### Before

```
  Workflow author            config.yaml (one machine)         Pi provider
  ───────────────            ─────────────────────────         ───────────
  writes plan→implement wf   assistants.pi.nodes.implement:
    (posture NOT in the wf)     interactive: false ───────────▶ per-node posture
                                extensionFlags: {plan: false}     (by node-id string)
  renames `implement` node
    → config key now orphaned ──x── override silently lost ────▶ planning mode leaks back
```

### After

```
  Workflow author                                              Pi provider
  ───────────────                                              ───────────
  writes plan→implement wf WITH posture inline:
    nodes:
      - id: plan                                               [plan node]  plan=true, hasUI=true
        pi: {interactive: true, extensionFlags: {plan: true}} ▶ planning mode ✓
      - id: implement (loop)                                   [impl node]  plan=false, hasUI=false
        pi: {interactive: false, extensionFlags: {plan: false}}▶ edits allowed ✓
  posture travels with the workflow; a node rename moves its own pi: block with it
```

## Architecture Diagram

### Before

```
  dag-executor ──(nodeConfig.nodeId)──▶ PiProvider.sendQuery
                                          │
        resolvePiExtensionSettings(config, nodeId)
          → assistant-level  ⊕  config.nodes[nodeId]   (2 layers)
```

### After

```
  DagNode.pi [+] ──▶ dag-executor: nodeConfig.pi = node.pi [~]──▶ PiProvider.sendQuery
                                                                   │
        [~]resolvePiExtensionSettings(config, nodeId, nodeConfig.pi)
          → assistant-level  ⊕  config.nodes[nodeId]  ⊕  node-YAML pi:   (3 layers, node-YAML wins)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `schemas/dag-node.ts` | (schema) | **new** | `piNodeConfigSchema`/`PiNodeConfig`; `pi` field on `dagNodeBaseSchema`; transform preserves `pi` for prompt/command/loop/loop_group |
| `dag-executor.ts` | `providers/types` `NodeConfig` | **modified** | one-line pass-through `pi: node.pi` in `resolveNodeProviderAndModel` |
| `providers/types.ts` `NodeConfig` | — | **modified** | new `pi?` field (derived `Pick<PiProviderDefaults, …>`) |
| `pi/provider.ts` | `pi/config.ts` | **modified** | `resolvePiExtensionSettings(piConfig, nodeId, nodeConfig?.pi)` |
| `pi/config.ts` | — | **modified** | resolver gains 3rd `nodeYaml` layer + 3-way flag merge; `PiNodeOverride` derived via `Pick` |
| loop-node transform | loop `sendQuery` | **new** | `pi` reaches each iteration via `resolvedOptions.nodeConfig` (loops otherwise drop per-node AI fields) |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `workflows`
- Module: `workflows:schemas`, `providers:pi`

## Change Metadata

- Change type: `feature`
- Primary scope: `workflows`

## Linked Issue

- Closes #2133
- Related #2073 (the leak), #2124 (install-level fix this builds on), #1877 (single-reload constraint — respected)

## Validation Evidence (required)

```bash
bun run validate   # green: check:bundled, check:bundled-skill, check:bundled-schema,
                   # check:pi-vendor-map, type-check, lint, format:check, tests
bun test packages/providers/src/community/pi/config.test.ts \
         packages/providers/src/community/pi/provider.test.ts \
         packages/workflows/src/schemas.test.ts \
         packages/workflows/src/loader.test.ts   # 368 pass, 0 fail
```

- Evidence provided: new config-parse/resolver matrix tests for the 3-layer precedence + per-key flag merge; provider wiring tests that a node-YAML `pi:` block overrides the config `nodes` map and assistant-level (drops UIContext, negates `plan`, or skips binding); dag-node schema tests that `pi:` survives the transform for prompt + loop nodes and is dropped/warned on non-AI nodes; a loader test that `pi:` on a loop node is preserved and does NOT emit an `ai_fields_ignored` warning.
- Skipped commands: none. Not verified: a live end-to-end run with plannotator installed (extension not on this machine) — same limitation #2124 noted; the wiring is covered by mocked-SDK tests asserting `bindExtensions`/`setFlagValue` args per layer.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`
- A node-level `pi: { interactive: true }` can re-enable the UI bridge where base config disabled it — the same capability the base flag already grants, now scopeable more narrowly (and only on a node the author already controls).

## Compatibility / Migration

- Backward compatible? `Yes` — a node with no `pi:` block resolves byte-for-byte as before; direct chat ignores it. The config `nodes:` map from #2124 is unchanged, now simply the lower-priority layer.
- Config/env changes? `Yes` (optional) — new per-node `pi:` block in workflow YAML; nothing required for existing workflows.
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios: traced `node.pi` end-to-end (YAML parse → `resolveNodeProviderAndModel` → `executeLoopNode`'s `iterationOptions` → `PiProvider.sendQuery` → `resolvePiExtensionSettings`) and confirmed no break in the chain for a loop node; confirmed the transform drops `pi` for bash/script/approval/cancel and preserves it for prompt/command/loop/loop_group.
- Edge cases checked: node-YAML wins over config map (UIContext dropped, `plan` negated); node-YAML applies with no config map present; 3-layer per-key `extensionFlags` merge; node-YAML `enableExtensions: false` clamps `interactive` and beats a config-map re-enable; partial node-YAML falls through to config-map/base for unset fields; loop_group `pi:` is warned-ignored (body nodes carry their own); a non-boolean/string `extensionFlags` value is a schema error.
- What was not verified: live plannotator run (extension not installed here).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Pi provider sessions only (workflow nodes + direct chat). Claude/Codex/OpenCode/Copilot untouched — they ignore `nodeConfig.pi`.
- Potential unintended effects: `pi:` on a non-Pi provider node is silently ignored (no warning) — consistent with #2124's Pi-specific `nodes:` config map, which also warns on neither surface. Cross-provider warning is a deliberate follow-up (would mean adding a `pi` `ProviderCapabilities` flag across all providers and warning on both surfaces to stay consistent).
- Guardrails/monitoring: `pi.session_started` already logs `nodeId` + `extensionsEnabled`/`interactive` (added in #2124), so the resolved per-node posture stays auditable per session.

## Rollback Plan (required)

- Fast rollback: revert this PR's single commit. Workflows that adopted a `pi:` block would then have it stripped by the schema (unknown field), falling back to config-map / assistant-level posture — no crash.
- Feature flags/toggles: inert unless a node sets `pi:`.
- Observable failure symptoms: an `implement`-style node still hitting "Plannotator: during planning, edits are limited to markdown files" or hanging on `plannotator_submit_plan` despite a node-scoped `pi:` block.

## Risks and Mitigations

- Risk: `pi:` on a `loop_group` node is a no-op (the group never calls `sendQuery`).
  - Mitigation: the loader emits an `ai_fields_ignored` warning for it (via `LOOP_GROUP_NODE_AI_FIELDS`), and the docs say to put the block on the body nodes.
- Risk: a `pi:` block on a node whose provider is not Pi is silently ignored.
  - Mitigation: documented; matches the existing #2124 config-map behavior. A cross-provider capability warning is a follow-up candidate (deferred to avoid a one-sided inconsistency and a wide `ProviderCapabilities` change in this focused PR).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-node Pi configuration for controlling extension availability, interactive approvals, and extension flags.
  * Node-level settings now override assistant and installation defaults, with predictable merge behavior for extension flags.
  * Workflow loop nodes preserve and apply Pi settings, while unsupported node types continue to ignore them.

* **Documentation**
  * Clarified Pi configuration scope, precedence, approval-gate requirements, and recommended planning/implementation examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->