### PR TITLE
feat(isolation): container isolation Phase A — kind-routed backend seam + ExecutionContext threading

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -394,7 +394,7 @@ packages/
 │       ├── types.ts          # Branded types (RepoPath, BranchName, etc.)
 │       ├── worktree.ts       # Worktree operations (create, remove, list)
 │       └── index.ts          # Package exports
-├── isolation/                # @archon/isolation - Worktree isolation (depends on @archon/git + @archon/paths)
+├── isolation/                # @archon/isolation - Worktree isolation (depends on @archon/git + @archon/paths + @archon/providers/types)
 │   └── src/
 │       ├── types.ts          # Isolation types and interfaces
 │       ├── errors.ts         # Error classifiers (classifyIsolationError, IsolationBlockedError)
@@ -504,7 +504,7 @@ import type { DagNode, WorkflowDefinition } from '@/lib/api';
 - **@archon/paths**: Path resolution utilities, Pino logger factory, web dist cache path (`getWebDistDir`), CWD env stripper (`stripCwdEnv`, `strip-cwd-env-boot`) (no @archon/* deps; `pino` and `dotenv` are allowed external deps)
 - **@archon/git**: Git operations - worktrees, branches, repos, exec wrappers (depends only on @archon/paths)
 - **@archon/providers**: AI agent providers (Claude, Codex, Pi community) — owns SDK deps, `IAgentProvider` interface, `sendQuery()` contract, and provider-specific option translation. `@archon/providers/types` is the contract subpath (zero SDK deps, zero runtime side effects) that `@archon/workflows` imports from. Providers receive raw `nodeConfig` + `assistantConfig` and translate to SDK-specific options internally. Core providers live under `claude/` and `codex/`; community providers live under `community/` (currently `community/pi/`, registered with `builtIn: false`). `@archon/providers/oauth` is the SDK-boundary subpath wrapping Pi's `@earendil-works/pi-ai/oauth` (subscription login: Claude Pro/Max, Copilot) — `@archon/core` drives Pi-based subscription OAuth through it so the Pi SDK dep stays in `@archon/providers`. The ChatGPT/Codex subscription login is NOT Pi-driven: it's Archon-owned PKCE in `@archon/core` `credentials/openai-oauth.ts` (Pi drops the `id_token` the Codex CLI requires, #1924).
-- **@archon/isolation**: Worktree isolation types, providers, resolver, error classifiers (depends only on @archon/git + @archon/paths)
+- **@archon/isolation**: Worktree isolation types, providers, resolver, error classifiers, and the folder-project backend seam — `IIsolationBackend`/`resolveFolderBackend` + the `ExecutionContext` it produces (depends only on @archon/git + @archon/paths + @archon/providers/types — the types-only import that carries the shared `ExecutionContext` contract)
 - **@archon/workflows**: Workflow engine - loader, router, executor, DAG, logger, bundled defaults (depends only on @archon/git + @archon/paths + @archon/providers/types + @hono/zod-openapi + zod; DB/AI/config injected via `WorkflowDeps`)
 - **@archon/cli**: Command-line interface for running workflows and starting the web UI server (depends on @archon/server + @archon/adapters for the serve command)
 - **@archon/core**: Business logic, database, orchestration (depends on @archon/providers for AI and @hono/zod-openapi for core Zod schemas; provides `createWorkflowStore()` adapter bridging core DB → `IWorkflowStore`)

--- a/bun.lock
+++ b/bun.lock
@@ -113,6 +113,7 @@
       "dependencies": {
         "@archon/git": "workspace:*",
         "@archon/paths": "workspace:*",
+        "@archon/providers": "workspace:*",
       },
       "peerDependencies": {
         "typescript": "^5.0.0",

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -20,7 +20,8 @@ import {
   type TierName,
   type RawTiersConfig,
 } from '@archon/workflows/model-validation';
-import { configureIsolation, getIsolationProvider } from '@archon/isolation';
+import { configureIsolation, getIsolationProvider, resolveFolderBackend } from '@archon/isolation';
+import type { ExecutionContext } from '@archon/isolation';
 import {
   createLogger,
   getArchonHome,
@@ -967,6 +968,10 @@ export async function workflowRunCommand(
   // Handle isolation (worktree creation)
   let workingCwd = cwd;
   let isolationEnvId: string | undefined;
+  // Execution context for the run. Repo/worktree and folder-in-place both run on
+  // the host; the folder-backend seam sets this and is where Phase B's `--container`
+  // will flip it to a container context.
+  let execContext: ExecutionContext = { kind: 'host' };
 
   // Handle --resume: locate the prior failed run, reuse its worktree, and hand
   // the resumed-run handle to executeWorkflow below via opts. The executor no
@@ -1046,13 +1051,26 @@ export async function workflowRunCommand(
   assertNoWorktreeOptionsForFolder(isFolderCodebase, options);
   assertWorkflowNotWorktreePinnedForFolder(isFolderCodebase, pinnedEnabled, workflow.name);
 
-  if (isFolderCodebase) {
-    // Folder projects run in place at their root — no worktree isolation. The
-    // agent's cwd is the folder root, so it sees every child folder/repo, and
-    // per-service git (branch/commit/PR) is the agent's job via bash/gh. Stated
-    // explicitly at run start (fail-fast-honest, not a silent skip).
+  if (isFolderCodebase && codebase) {
+    // Folder projects run through the folder-backend seam — no worktree isolation.
+    // The in-place backend (Phase A default) keeps the agent's cwd at the folder
+    // root, so it sees every child folder/repo, and per-service git (branch/commit/PR)
+    // is the agent's job via bash/gh. Stated explicitly at run start (fail-fast-honest,
+    // not a silent skip). Phase B adds `--container` here to select the container
+    // backend instead of in-place.
     console.log('Folder project — running in place (no worktree isolation).');
     getLog().info({ cwd: workingCwd }, 'workflow.running_without_isolation');
+    const folderCodebase = {
+      id: codebase.id,
+      defaultCwd: codebase.default_cwd,
+      name: codebase.name,
+      kind: 'folder' as const,
+    };
+    const backend = resolveFolderBackend(folderCodebase, { container: false });
+    const prepared = await backend.prepare({ codebase: folderCodebase });
+    // In-place prepare returns the folder root + host context — workingCwd is
+    // already that path (same-absolute-path invariant), so this is byte-identical.
+    execContext = prepared.execContext;
   } else if (wantsIsolation && codebase) {
     // Auto-generate branch identifier from workflow name + timestamp when --branch not provided
     const branchIdentifier = options.branchName ?? `${workflowName}-${Date.now()}`;
@@ -1344,6 +1362,7 @@ export async function workflowRunCommand(
           source: workflowSource,
           userId: cliUserId,
           baseBranch: codebaseDefaultBranch,
+          execContext,
           ...prepared,
         }
       : {
@@ -1351,6 +1370,7 @@ export async function workflowRunCommand(
           source: workflowSource,
           userId: cliUserId,
           baseBranch: codebaseDefaultBranch,
+          execContext,
         };
     result = await executeWorkflow(
       deps,

--- a/packages/isolation/package.json
+++ b/packages/isolation/package.json
@@ -8,12 +8,13 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "test": "bun test src/resolver.test.ts && bun test src/providers/ && bun test src/errors.test.ts src/factory.test.ts src/worktree-copy.test.ts && bun test src/pr-state.test.ts",
+    "test": "bun test src/resolver.test.ts && bun test src/providers/ && bun test src/errors.test.ts src/factory.test.ts src/worktree-copy.test.ts && bun test src/pr-state.test.ts && bun test src/backend-router.test.ts src/backends/in-place.test.ts",
     "type-check": "bun x tsc --noEmit"
   },
   "dependencies": {
     "@archon/git": "workspace:*",
-    "@archon/paths": "workspace:*"
+    "@archon/paths": "workspace:*",
+    "@archon/providers": "workspace:*"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/packages/isolation/src/backend-router.test.ts
+++ b/packages/isolation/src/backend-router.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from 'bun:test';
+import { resolveFolderBackend } from './backend-router';
+import { InPlaceBackend } from './backends/in-place';
+
+const folderCodebase = {
+  id: 'cb-folder',
+  defaultCwd: '/tmp/platform',
+  name: 'platform',
+  kind: 'folder' as const,
+};
+
+const repoCodebase = {
+  id: 'cb-repo',
+  defaultCwd: '/repos/myrepo',
+  name: 'owner/repo',
+  kind: 'repo' as const,
+};
+
+describe('resolveFolderBackend', () => {
+  test('folder codebase → in-place backend by default', () => {
+    const backend = resolveFolderBackend(folderCodebase);
+    expect(backend).toBeInstanceOf(InPlaceBackend);
+    expect(backend.id).toBe('in-place');
+  });
+
+  test('folder codebase with { container: false } → in-place backend', () => {
+    const backend = resolveFolderBackend(folderCodebase, { container: false });
+    expect(backend.id).toBe('in-place');
+  });
+
+  test('repo codebase → throws (the seam is folder-only)', () => {
+    expect(() => resolveFolderBackend(repoCodebase)).toThrow(/folder-only/);
+  });
+
+  test('container requested → throws (not available until Phase B, no silent downgrade)', () => {
+    expect(() => resolveFolderBackend(folderCodebase, { container: true })).toThrow(
+      /not available/
+    );
+  });
+});

--- a/packages/isolation/src/backend-router.ts
+++ b/packages/isolation/src/backend-router.ts
@@ -1,0 +1,54 @@
+/**
+ * Kind-routed backend selection for FOLDER-kind projects.
+ *
+ * This is the single seam where folder-project isolation is chosen. Repo-kind
+ * projects keep the worktree path and must never reach here — calling this for a
+ * repo codebase is a caller bug and throws. Folder projects select a backend:
+ * `in-place` by default, `container` when opted in (Phase B).
+ *
+ * Consolidating selection here means Phase B's `--container` flag / config only
+ * has to flip the `container` option; every folder call site (CLI, resolver)
+ * routes through this one function.
+ */
+
+import type { BackendPrepareRequest, IIsolationBackend } from './types';
+import { InPlaceBackend } from './backends/in-place';
+
+export interface ResolveFolderBackendOptions {
+  /**
+   * Opt into the container backend. Phase A has no container implementation, so
+   * a truthy value fails fast (explicit error) rather than silently downgrading
+   * to in-place. Phase B replaces that throw with the container backend.
+   */
+  container?: boolean;
+}
+
+/**
+ * Select the isolation backend for a folder-kind codebase.
+ *
+ * @throws if `codebase.kind !== 'folder'` — the seam is folder-only; repo
+ *   projects use worktree isolation and must not be routed here.
+ * @throws if `container` is requested — not implemented until Phase B; failing
+ *   loudly beats a surprising in-place run when the user asked for a container.
+ */
+export function resolveFolderBackend(
+  codebase: BackendPrepareRequest['codebase'],
+  opts: ResolveFolderBackendOptions = {}
+): IIsolationBackend {
+  if (codebase.kind !== 'folder') {
+    throw new Error(
+      `resolveFolderBackend called for non-folder codebase '${codebase.name}' ` +
+        `(kind: ${codebase.kind}). The backend seam is folder-only; repo projects ` +
+        'use worktree isolation.'
+    );
+  }
+
+  if (opts.container) {
+    throw new Error(
+      'The container isolation backend is not available in this build (Phase B). ' +
+        'Run without the container option to use in-place folder execution.'
+    );
+  }
+
+  return new InPlaceBackend();
+}

--- a/packages/isolation/src/backends/in-place.test.ts
+++ b/packages/isolation/src/backends/in-place.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect } from 'bun:test';
+import { InPlaceBackend } from './in-place';
+
+describe('InPlaceBackend', () => {
+  const backend = new InPlaceBackend();
+  const req = {
+    codebase: {
+      id: 'cb-folder',
+      defaultCwd: '/tmp/platform',
+      name: 'platform',
+      kind: 'folder' as const,
+    },
+  };
+
+  test('id is in-place', () => {
+    expect(backend.id).toBe('in-place');
+  });
+
+  test('prepare returns the real folder cwd + host execution context', async () => {
+    const prepared = await backend.prepare(req);
+    // Must be the real folder path (NOT the '/workspace' docker sentinel).
+    expect(prepared.cwd).toBe('/tmp/platform');
+    expect(prepared.execContext).toEqual({ kind: 'host' });
+    // In-place creates no tracked environment row.
+    expect(prepared.envId).toBeUndefined();
+  });
+
+  test('prepare cwd echoes codebase.defaultCwd (byte-identical to the pre-seam early-return)', async () => {
+    const prepared = await backend.prepare(req);
+    expect(prepared.cwd).toBe(req.codebase.defaultCwd);
+  });
+
+  test('destroy is a no-op (nothing tracked to tear down)', async () => {
+    await expect(backend.destroy('unused')).resolves.toBeUndefined();
+  });
+});

--- a/packages/isolation/src/backends/in-place.ts
+++ b/packages/isolation/src/backends/in-place.ts
@@ -1,0 +1,31 @@
+/**
+ * In-place isolation backend for folder projects.
+ *
+ * Formalizes the pre-seam behavior: a folder project runs directly at its root
+ * on the host, with no worktree and no tracked environment row. Introduced by
+ * the kind-routed seam (Phase A) as the default folder backend; the container
+ * backend (Phase B) is the opt-in alternative selected by `resolveFolderBackend`.
+ */
+
+import type { BackendPrepareRequest, IIsolationBackend, PreparedEnv } from '../types';
+
+export class InPlaceBackend implements IIsolationBackend {
+  readonly id = 'in-place' as const;
+
+  /**
+   * Run in place at the folder root on the host. Returns the same cwd the
+   * resolver's folder early-return produced before the seam existed, so the
+   * result is byte-identical to today's in-place behavior.
+   */
+  async prepare(req: BackendPrepareRequest): Promise<PreparedEnv> {
+    return { cwd: req.codebase.defaultCwd, execContext: { kind: 'host' } };
+  }
+
+  /**
+   * No-op: in-place runs create no tracked environment (no container, no
+   * volume, no `isolation_environments` row), so there is nothing to tear down.
+   */
+  async destroy(_envId: string): Promise<void> {
+    // Intentionally empty — see method doc.
+  }
+}

--- a/packages/isolation/src/index.ts
+++ b/packages/isolation/src/index.ts
@@ -28,9 +28,18 @@ export type {
   ResolveRequest,
   ResolutionMethod,
   IsolationResolution,
+  ExecutionContext,
+  BackendPrepareRequest,
+  PreparedEnv,
+  IIsolationBackend,
 } from './types';
 
 export { isPRIsolationRequest } from './types';
+
+// --- Backend seam (folder projects) ---
+export { resolveFolderBackend } from './backend-router';
+export type { ResolveFolderBackendOptions } from './backend-router';
+export { InPlaceBackend } from './backends/in-place';
 
 // --- Store ---
 export type { IIsolationStore } from './store';

--- a/packages/isolation/src/resolver.test.ts
+++ b/packages/isolation/src/resolver.test.ts
@@ -204,6 +204,27 @@ describe('IsolationResolver', () => {
     }
   });
 
+  test('folder project routes through the in-place backend — result byte-identical to the pre-seam early-return', async () => {
+    const resolver = createResolver();
+
+    const result = await resolver.resolve({
+      existingEnvId: null,
+      codebase: {
+        id: 'cb-folder',
+        defaultCwd: '/srv/ops-client',
+        name: 'ops-client',
+        kind: 'folder',
+      },
+      platformType: 'web',
+    });
+
+    // The seam (resolveFolderBackend → InPlaceBackend.prepare) must reproduce
+    // EXACTLY the { status: 'none', cwd: <folder root> } shape the resolver
+    // returned before the backend seam existed. Full-object equality guards the
+    // zero-behavior-change contract against future drift.
+    expect(result).toEqual({ status: 'none', cwd: '/srv/ops-client' });
+  });
+
   test('repo kind (explicit) — proceeds to normal worktree resolution', async () => {
     const env = makeEnvRow();
     const resolver = createResolver({

--- a/packages/isolation/src/resolver.ts
+++ b/packages/isolation/src/resolver.ts
@@ -107,6 +107,15 @@ export class IsolationResolver {
     // the '/workspace' docker sentinel), so chat/workflows land in the actual
     // project directory — byte-identical to the pre-seam early-return. Container
     // selection is a Phase B config concern; the chat path stays in-place for now.
+    //
+    // NOTE (Phase A): only `prepared.cwd` is propagated. `prepared.execContext`
+    // is intentionally DROPPED here because the `IsolationResolution` 'none'
+    // variant carries no execution-context field, so chat/orchestrator callers
+    // (which consume this result) have no channel for it — they run host-only in
+    // Phase A. Phase B, when it wires containerized CHAT, must extend the 'none'
+    // variant with an `execContext` and thread it through the orchestrator; until
+    // then only the CLI workflow path carries execContext (from the backend it
+    // resolves directly).
     if (request.codebase.kind === 'folder') {
       const folderCodebase = {
         id: request.codebase.id,

--- a/packages/isolation/src/resolver.ts
+++ b/packages/isolation/src/resolver.ts
@@ -30,6 +30,7 @@ import type {
 } from './types';
 import type { IIsolationStore } from './store';
 import { classifyIsolationError, isKnownIsolationError } from './errors';
+import { resolveFolderBackend } from './backend-router';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
@@ -101,11 +102,21 @@ export class IsolationResolver {
       return { status: 'none', cwd: '/workspace' };
     }
 
-    // 2b. Folder projects run in place — no worktree. Return the REAL folder
-    // path (not the '/workspace' docker sentinel) so chat/workflows land in the
-    // actual project directory.
+    // 2b. Folder projects run through the folder-backend seam — no worktree.
+    // The in-place backend (Phase A default) returns the REAL folder path (not
+    // the '/workspace' docker sentinel), so chat/workflows land in the actual
+    // project directory — byte-identical to the pre-seam early-return. Container
+    // selection is a Phase B config concern; the chat path stays in-place for now.
     if (request.codebase.kind === 'folder') {
-      return { status: 'none', cwd: request.codebase.defaultCwd };
+      const folderCodebase = {
+        id: request.codebase.id,
+        defaultCwd: request.codebase.defaultCwd,
+        name: request.codebase.name,
+        kind: 'folder' as const,
+      };
+      const backend = resolveFolderBackend(folderCodebase, { container: false });
+      const prepared = await backend.prepare({ codebase: folderCodebase });
+      return { status: 'none', cwd: prepared.cwd };
     }
 
     const codebase = request.codebase;

--- a/packages/isolation/src/types.ts
+++ b/packages/isolation/src/types.ts
@@ -7,6 +7,12 @@
  */
 
 import type { RepoPath, BranchName } from '@archon/git';
+import type { ExecutionContext } from '@archon/providers/types';
+
+// Re-exported so isolation consumers can source the execution-context contract
+// from `@archon/isolation` alongside the backend types that produce it, without
+// reaching into `@archon/providers/types` directly.
+export type { ExecutionContext };
 
 // --- Provider Types ---
 
@@ -368,3 +374,53 @@ export type IsolationResolution =
   | { status: 'stale_cleaned'; previousEnvId: string }
   | { status: 'none'; cwd: string }
   | { status: 'blocked'; reason: IsolationBlockReason; userMessage: string };
+
+// --- Isolation Backend Seam (folder projects only) ---
+//
+// Repo-kind projects keep the worktree path (IIsolationProvider above) untouched.
+// Folder-kind projects route through a pluggable backend selected by
+// `resolveFolderBackend()`. v1 backends: `in-place` (default, today's behavior)
+// and `container` (Phase B). Worktrees are deliberately NOT a backend — the two
+// lifecycles don't share an interface (user decision 2026-07-13).
+
+/**
+ * Minimal identity of a codebase a backend needs to prepare an environment.
+ * Container-specific inputs (image, network, run id) are added by Phase B — kept
+ * out of the Phase A contract to avoid speculative surface (YAGNI).
+ */
+export interface BackendPrepareRequest {
+  codebase: {
+    id: string;
+    /** Absolute path to the folder-project root. */
+    defaultCwd: string;
+    name: string;
+    kind: 'repo' | 'folder';
+  };
+}
+
+/**
+ * Result of a backend `prepare()`: the working directory the run should use and
+ * the execution context (host vs container) threaded through the engine to every
+ * provider turn and deterministic subprocess. `envId` references the tracked
+ * `isolation_environments` row when the backend created one (container backend,
+ * Phase B); in-place runs create no row and leave it undefined.
+ */
+export interface PreparedEnv {
+  cwd: string;
+  execContext: ExecutionContext;
+  envId?: string;
+}
+
+/**
+ * Isolation backend for FOLDER-kind projects. Phase A ships only the required
+ * lifecycle (`prepare`/`destroy`) implemented by the in-place backend; the
+ * container backend (Phase B) extends this interface with the pause/resume and
+ * write-back methods it alone needs. Adding those later is backward-compatible —
+ * they are intentionally absent here rather than declared unimplemented.
+ */
+export interface IIsolationBackend {
+  readonly id: 'in-place' | 'container';
+  prepare(req: BackendPrepareRequest): Promise<PreparedEnv>;
+  /** Tear down a prepared environment. No-op for in-place (nothing was created). */
+  destroy(envId: string): Promise<void>;
+}

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -442,11 +442,12 @@ export interface SendQueryOptions extends AgentRequestOptions {
   assistantConfig?: Record<string, unknown>;
   /**
    * Execution target for this turn. Absent / `{ kind: 'host' }` runs the provider
-   * on the Archon host (default). `{ kind: 'container', … }` (Phase B) tells a
-   * capable provider (Claude v1) to spawn its CLI inside the prepared container.
-   * The engine only ever populates this for the container backend and fails fast
-   * before dispatch for providers lacking the capability, so a provider that
-   * doesn't understand it can safely ignore it.
+   * on the Archon host — the only value the engine produces today, so this field
+   * is currently inert plumbing that every provider can safely ignore.
+   * `{ kind: 'container', … }` will (Phase B) tell a capable provider (Claude
+   * first) to spawn its CLI inside the prepared container. Phase B will also add
+   * a provider capability flag plus a pre-dispatch fail-fast so a `container`
+   * value can never reach a provider that cannot honor it.
    */
   execContext?: ExecutionContext;
 }

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -309,6 +309,26 @@ export interface SystemPromptPreset {
 export type SystemPromptInput = string | string[] | SystemPromptPreset;
 
 /**
+ * Where a provider turn (or a deterministic bash/script subprocess) runs.
+ *  - `host`      — directly on the Archon host process, inheriting its environment.
+ *    This is today's behavior and the default everywhere.
+ *  - `container` — inside a prepared isolation container (the folder-project
+ *    container backend). The provider spawns its CLI via `docker exec` and
+ *    receives only the Archon-managed env bag; `containerId` identifies the
+ *    running container and `execUser` optionally pins the in-container uid/user.
+ *
+ * Plain data with zero SDK / `@archon/*` dependencies, so this contract layer
+ * (which forbids cross-package imports) can own it while `@archon/isolation`
+ * (which produces it) and `@archon/workflows` (which threads it) both import it.
+ * Consumed by providers only after the engine's per-node capability fail-fast
+ * (Phase B) — a `container` value reaching a provider that can't honor it is a
+ * bug the executor prevents, not something the provider silently downgrades.
+ */
+export type ExecutionContext =
+  | { kind: 'host' }
+  | { kind: 'container'; containerId: string; execUser?: string };
+
+/**
  * Universal request options accepted by all providers.
  * Provider-specific fields go through `nodeConfig` and `assistantConfig` in SendQueryOptions.
  */
@@ -420,6 +440,15 @@ export interface SendQueryOptions extends AgentRequestOptions {
   nodeConfig?: NodeConfig;
   /** Per-provider defaults from .archon/config.yaml assistants section. */
   assistantConfig?: Record<string, unknown>;
+  /**
+   * Execution target for this turn. Absent / `{ kind: 'host' }` runs the provider
+   * on the Archon host (default). `{ kind: 'container', … }` (Phase B) tells a
+   * capable provider (Claude v1) to spawn its CLI inside the prepared container.
+   * The engine only ever populates this for the container backend and fails fast
+   * before dispatch for providers lacking the capability, so a provider that
+   * doesn't understand it can safely ignore it.
+   */
+  execContext?: ExecutionContext;
 }
 
 /**

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -21,6 +21,7 @@ import type {
   NodeConfig,
   ProviderCapabilities,
   TokenUsage,
+  ExecutionContext,
 } from '@archon/providers/types';
 import {
   getProviderCapabilities,
@@ -728,7 +729,8 @@ async function resolveNodeProviderAndModel(
   _cwd: string,
   workflowLevelOptions: WorkflowLevelOptions,
   aiProfile?: ResolvedAiProfile,
-  workflowPreset?: ModelAliasPreset
+  workflowPreset?: ModelAliasPreset,
+  execContext: ExecutionContext = { kind: 'host' }
 ): Promise<{
   provider: string;
   model: string | undefined;
@@ -861,6 +863,12 @@ async function resolveNodeProviderAndModel(
   // Build universal base options
   const baseOptions: SendQueryOptions = {};
   if (model) baseOptions.model = model;
+  // Only annotate options with the execution context when running in a container
+  // (Phase B). Host is the default/absent case, so host runs produce byte-identical
+  // options — the provider infers host behavior from the missing field.
+  if (execContext.kind === 'container') {
+    baseOptions.execContext = execContext;
+  }
   if (config.envVars && Object.keys(config.envVars).length > 0) {
     baseOptions.env = config.envVars;
   }
@@ -2091,6 +2099,28 @@ async function executeNodeInternal(
 /** Default timeout for subprocess nodes (bash, script): 2 minutes */
 const SUBPROCESS_DEFAULT_TIMEOUT = 120_000;
 
+/**
+ * Run a deterministic subprocess (bash/script node body, loop `until_bash`) under
+ * the given execution context. This is the seam the container backend (Phase B)
+ * fills in: a `host` context delegates verbatim to `execFileAsync`, so the host
+ * path is byte-identical to a direct call; a `container` context will route the
+ * command through `docker exec` so isolation has no host-escape hole. Until that
+ * lands, a container context fails fast rather than silently running on the host.
+ */
+async function runSubprocess(
+  execContext: ExecutionContext,
+  cmd: string,
+  args: string[],
+  options: { cwd: string; timeout: number; env: NodeJS.ProcessEnv }
+): Promise<{ stdout: string; stderr: string }> {
+  if (execContext.kind === 'container') {
+    throw new Error(
+      'Container subprocess execution is not yet implemented (container isolation Phase B).'
+    );
+  }
+  return execFileAsync(cmd, args, options);
+}
+
 /** Threshold (bytes) above which $nodeId.output values are written to a temp file
  *  instead of inlined as bash -c arguments, to avoid silent data corruption. */
 const NODE_OUTPUT_FILE_THRESHOLD = 32_768;
@@ -2115,7 +2145,8 @@ async function executeBashNode(
   issueContext?: string,
   envVars?: Record<string, string>,
   stepNamePrefix = '',
-  iteration?: number
+  iteration?: number,
+  execContext: ExecutionContext = { kind: 'host' }
 ): Promise<NodeOutput> {
   const nodeStartTime = Date.now();
   const nodeContext: SendMessageContext = { workflowId: workflowRun.id, nodeName: node.id };
@@ -2183,7 +2214,7 @@ async function executeBashNode(
 
   const bashPath = resolveBashPath();
   try {
-    const { stdout, stderr } = await execFileAsync(bashPath, ['-c', finalScript], {
+    const { stdout, stderr } = await runSubprocess(execContext, bashPath, ['-c', finalScript], {
       cwd,
       timeout,
       env: subprocessEnv,
@@ -2303,7 +2334,8 @@ async function executeScriptNode(
   issueContext?: string,
   envVars?: Record<string, string>,
   stepNamePrefix = '',
-  iteration?: number
+  iteration?: number,
+  execContext: ExecutionContext = { kind: 'host' }
 ): Promise<NodeOutput> {
   const nodeStartTime = Date.now();
   const nodeContext: SendMessageContext = { workflowId: workflowRun.id, nodeName: node.id };
@@ -2460,7 +2492,7 @@ async function executeScriptNode(
       }
     }
 
-    const { stdout, stderr } = await execFileAsync(cmd, args, {
+    const { stdout, stderr } = await runSubprocess(execContext, cmd, args, {
       cwd,
       timeout,
       env: subprocessEnv,
@@ -2685,7 +2717,8 @@ async function executeLoopGroupNode(
   outerNodeOutputs: Map<string, NodeOutput>,
   config: WorkflowConfig,
   issueContext?: string,
-  stepNamePrefix = ''
+  stepNamePrefix = '',
+  execContext: ExecutionContext = { kind: 'host' }
 ): Promise<NodeExecutionResult> {
   const group = node.loop_group;
   const msgContext = { workflowId: workflowRun.id, nodeName: node.id };
@@ -2831,6 +2864,10 @@ async function executeLoopGroupNode(
       docsDir,
       configuredCommandFolder: undefined,
       issueContext,
+      // Body nodes inherit the group's execution context so bash/script/AI inside
+      // a loop_group body exec in the same place (host, or the container in Phase B)
+      // — without this a loop_group body would be a host-escape hole.
+      execContext,
       // persist_session across iterations is out of v1 scope (body sessions reset per
       // iteration, governed by fresh_context). Pass undefined/false so body nodes don't
       // participate in cross-run session persistence inside the loop — and therefore
@@ -2959,7 +2996,7 @@ async function executeLoopGroupNode(
           true, // escapedForBash
           logDir
         );
-        await execFileAsync(groupBashPath, ['-c', substitutedBash], {
+        await runSubprocess(execContext, groupBashPath, ['-c', substitutedBash], {
           cwd,
           timeout: SUBPROCESS_DEFAULT_TIMEOUT,
           env: {
@@ -3272,7 +3309,8 @@ async function executeLoopNode(
   nodeOutputs: Map<string, NodeOutput>,
   config: WorkflowConfig,
   issueContext?: string,
-  stepNamePrefix = ''
+  stepNamePrefix = '',
+  execContext: ExecutionContext = { kind: 'host' }
 ): Promise<NodeExecutionResult> {
   const loop = node.loop;
   const msgContext = { workflowId: workflowRun.id, nodeName: node.id };
@@ -3881,7 +3919,7 @@ async function executeLoopNode(
           true, // escapedForBash
           logDir
         );
-        await execFileAsync(loopBashPath, ['-c', substitutedBash], {
+        await runSubprocess(execContext, loopBashPath, ['-c', substitutedBash], {
           cwd,
           timeout: SUBPROCESS_DEFAULT_TIMEOUT,
           env: {
@@ -4385,6 +4423,9 @@ interface RunLayersContext {
   platform: IWorkflowPlatform;
   conversationId: string;
   cwd: string;
+  /** Where nodes in these layers execute (host, or the container in Phase B). Threaded
+   *  into every AI turn's SendQueryOptions and every deterministic subprocess. */
+  execContext: ExecutionContext;
   workflowRun: WorkflowRun;
   /** Workflow name — used for persist_session keying + telemetry. */
   workflowName: string;
@@ -4455,6 +4496,7 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
     platform,
     conversationId,
     cwd,
+    execContext,
     workflowRun,
     workflowName,
     config,
@@ -4698,7 +4740,8 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
                   issueContext,
                   config.envVars,
                   stepNamePrefix,
-                  iteration
+                  iteration,
+                  execContext
                 )
             );
             return { nodeId: node.id, output };
@@ -4718,7 +4761,8 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
                 cwd,
                 workflowLevelOptions,
                 aiProfile,
-                workflowPreset
+                workflowPreset,
+                execContext
               );
 
             const output = await executeLoopNode(
@@ -4737,7 +4781,8 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
               ctx.nodeOutputs,
               config,
               issueContext,
-              stepNamePrefix
+              stepNamePrefix,
+              execContext
             );
             // Loop nodes run every iteration on the same resolved provider, so the
             // result session (if any) is attributable to loopProvider — tag it so a
@@ -4763,7 +4808,8 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
               cwd,
               workflowLevelOptions,
               aiProfile,
-              workflowPreset
+              workflowPreset,
+              execContext
             );
 
             const output = await executeLoopGroupNode(
@@ -4785,7 +4831,8 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
               ctx.nodeOutputs,
               config,
               issueContext,
-              stepNamePrefix
+              stepNamePrefix,
+              execContext
             );
             return { nodeId: node.id, output };
           }
@@ -4875,7 +4922,8 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
                   issueContext,
                   config.envVars,
                   stepNamePrefix,
-                  iteration
+                  iteration,
+                  execContext
                 )
             );
             return { nodeId: node.id, output };
@@ -4898,7 +4946,8 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
             cwd,
             workflowLevelOptions,
             aiProfile,
-            workflowPreset
+            workflowPreset,
+            execContext
           );
 
           // 5. Determine session — parallel or context:fresh → always fresh
@@ -5327,7 +5376,13 @@ export async function executeDagWorkflow(
    * resolved by executor.ts when the workflow uses session persistence (#1846).
    * Undefined otherwise — no mirroring, no cold-resume pointer.
    */
-  scopeArtifactsDir?: string
+  scopeArtifactsDir?: string,
+  /**
+   * Execution context for this run (host by default; the container backend
+   * threads a container context in Phase B). Threaded onto every node's
+   * `RunLayersContext` so provider turns and subprocesses exec in the right place.
+   */
+  execContext: ExecutionContext = { kind: 'host' }
 ): Promise<string | undefined> {
   const dagStartTime = Date.now();
   const workflowTier = workflow.model && isTierName(workflow.model) ? workflow.model : undefined;
@@ -5405,6 +5460,7 @@ export async function executeDagWorkflow(
     platform,
     conversationId,
     cwd,
+    execContext,
     workflowRun,
     workflowName: workflow.name,
     config,

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -4179,7 +4179,8 @@ async function executeApprovalNode(
   aiProfile?: ResolvedAiProfile,
   workflowPreset?: ModelAliasPreset,
   stepNamePrefix = '',
-  iteration?: number
+  iteration?: number,
+  execContext: ExecutionContext = { kind: 'host' }
 ): Promise<NodeOutput> {
   const msgContext = { workflowId: workflowRun.id, nodeName: node.id };
   // Namespaced persisted step_name for loop_group bodies ('' → node.id at top level, #2090).
@@ -4278,7 +4279,8 @@ async function executeApprovalNode(
       cwd,
       workflowLevelOptions,
       aiProfile,
-      workflowPreset
+      workflowPreset,
+      execContext
     );
 
     const output = await executeNodeInternal(
@@ -4860,7 +4862,8 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
               aiProfile,
               workflowPreset,
               stepNamePrefix,
-              iteration
+              iteration,
+              execContext
             );
             return { nodeId: node.id, output };
           }

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -22,6 +22,7 @@ import { formatDuration, parseDbTimestamp } from './utils/duration';
 import { keepAwake } from './utils/keep-awake';
 import { getWorkflowEventEmitter } from './event-emitter';
 import { isRegisteredProvider, getRegisteredProviders } from '@archon/providers';
+import type { ExecutionContext } from '@archon/providers/types';
 import {
   classifyError,
   toTelemetryErrorClass,
@@ -361,6 +362,14 @@ export type ExecuteWorkflowOptions = ResumePayload & {
    * is preserved on resume.
    */
   userId?: string;
+  /**
+   * Execution context resolved by the isolation seam: `{ kind: 'host' }` (default)
+   * runs on the Archon host; `{ kind: 'container', … }` (folder-project container
+   * backend, Phase B) runs provider turns and subprocesses inside the prepared
+   * container. Threaded verbatim into `executeDagWorkflow`. Defaults to host when
+   * absent, so every existing caller is unchanged.
+   */
+  execContext?: ExecutionContext;
 };
 
 /**
@@ -427,6 +436,7 @@ export async function executeWorkflow(
     userId,
     source,
     baseBranch: callerBaseBranch,
+    execContext = { kind: 'host' },
   } = opts;
   // Load config once for the entire workflow execution
   const fileConfig = await deps.loadConfig(cwd);
@@ -961,7 +971,8 @@ export async function executeWorkflow(
       source,
       aiProfile,
       workflowPreset,
-      scopeArtifactsDir
+      scopeArtifactsDir,
+      execContext
     );
 
     // executeDagWorkflow throws on fatal errors; check DB status for result


### PR DESCRIPTION
## Summary

Phase A of the container-isolation-backend plan: the kind-routed isolation seam and `ExecutionContext` threading. Zero-behavior-change, host-only refactor — the foundation the Docker backend (Phase B) plugs into.

- **Problem:** Folder projects run in place with the folder decision duplicated across the CLI and the resolver, and the executor has no notion of *where* a node runs — `bash:`/`script:` nodes exec directly on the host, so there is no seam a container backend could hook into.
- **Why it matters:** Container isolation for folder projects (governed write-back over a read-only mount) needs (a) one place to select the folder backend and (b) an execution context threaded to every provider turn and subprocess. Building that seam first, with no behavior change, de-risks the Docker work.
- **What changed:** Introduced `IIsolationBackend` (folder-only, routed by codebase `kind`), the `in-place` backend (today's behavior), `resolveFolderBackend()`, and an `ExecutionContext` (`{ kind: 'host' } | { kind: 'container', … }`). On the **CLI workflow path** it is threaded end-to-end: the CLI resolves the backend → `executeWorkflow` → `RunLayersContext` → every provider turn and deterministic subprocess (via a new `runSubprocess` wrapper). The **chat/orchestrator path** routes folders through the same backend but consumes only `cwd` (the resolver drops `execContext` — see scope boundary); wiring execContext through chat is Phase B.
- **What did NOT change (scope boundary):** The repo-kind worktree path is byte-identical (worktrees are deliberately **not** a backend). No Docker backend, no `--container` flag, no Dockerfile, no pause/resume or write-back gate — those are Phase B/C. `ExecutionContext` is always `{ kind: 'host' }` in this PR; options carry it only in the (unreachable-here) container case and `runSubprocess` delegates verbatim to `execFileAsync` on the host path.

## UX Journey

### Before

```
$ archon workflow run assist --folder "list the repos"
Folder project — running in place (no worktree isolation).
  agent cwd = folder root (host); bash/script exec directly on host
```

### After

```
$ archon workflow run assist --folder "list the repos"
Folder project — running in place (no worktree isolation).   <- identical output
  [resolveFolderBackend(folder) -> InPlaceBackend.prepare()]  <- NEW seam (returns host ctx, same cwd)
  agent cwd = folder root (host); bash/script exec via runSubprocess(host) === execFileAsync
```

No user-visible change. The seam is internal plumbing for Phase B.

## Architecture Diagram

### Before

```
cli/workflow.ts ──folder? inline──▶ executeWorkflow ──▶ dag-executor ──execFileAsync──▶ host bash/script
isolation/resolver.ts ──folder? inline early-return──▶ {status:'none', cwd}
```

### After

Only the **CLI workflow path** carries `execContext` end-to-end in this PR. The resolver (chat/orchestrator path) routes folders through the same backend but propagates **only `prepared.cwd`** — it drops `prepared.execContext` because `IsolationResolution`'s `'none'` variant has no field for it. Wiring `execContext` through the chat/orchestrator path (extending that variant) is **Phase B**, not this PR.

```
CLI path (carries execContext):
cli/workflow.ts ──[~]──▶ resolveFolderBackend ──[+]──▶ InPlaceBackend.prepare() ──▶ {cwd, execContext:host}
                                                                                          │ execContext
                                                                                          ▼
executeWorkflow(opts.execContext) ──▶ executeDagWorkflow ──▶ RunLayersContext.execContext
     ├─ resolveNodeProviderAndModel ──(container only)──▶ SendQueryOptions.execContext ──▶ provider
     └─ runSubprocess(execContext) ──host──▶ execFileAsync (bash/script nodes + loop/loop_group until_bash)

Chat/orchestrator path (cwd only; execContext dropped until Phase B):
isolation/resolver.ts ──[~]──▶ resolveFolderBackend ──▶ InPlaceBackend.prepare() ──▶ {cwd, execContext} ──▶ returns {status:'none', cwd}   [execContext discarded]
```

`[+]` new · `[~]` modified.

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `@archon/isolation` | `@archon/providers/types` | **new** | types-only workspace dep for the shared `ExecutionContext` (mirrors `@archon/workflows`) |
| `isolation/resolver` | `isolation/backend-router` | **new** | folder early-return routes through `resolveFolderBackend` for the **cwd only**; `execContext` intentionally dropped (`'none'` variant has no field) — chat wiring is Phase B |
| `cli/workflow` | `isolation/backend-router` | **new** | folder run resolves the backend and threads `execContext` into `executeWorkflow` (the only execContext-carrying path in this PR) |
| `workflows/executor` | `workflows/dag-executor` | **modified** | passes `execContext` (default host) |
| `workflows/dag-executor` | `@archon/git execFileAsync` | **modified** | via new `runSubprocess` seam (host path verbatim) |
| repo-kind worktree path | — | unchanged | byte-identical |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `isolation` `workflows` `cli` `providers`
- Module: `isolation:backend-router`, `workflows:dag-executor`

## Change Metadata

- Change type: `refactor`
- Primary scope: `multi` (isolation + workflows + cli + providers)

## Linked Issue

- Related: container-isolation-backend plan, Phase A (Tasks 1–5). Supersedes the folder-projects plan's original Phase 3.
- No standalone GitHub issue — plan-tracked.

## Validation Evidence (required)

```bash
bun run validate   # exit 0 — all 8 checks
```

- Evidence: `bun run validate` exits 0 (check:bundled, check:bundled-skill, check:bundled-schema, check:pi-vendor-map, type-check across all 10 packages, lint `--max-warnings 0`, format:check, full per-package test matrix). New tests: `isolation/src/backend-router.test.ts`, `isolation/src/backends/in-place.test.ts`, plus a full-object-equality regression in `resolver.test.ts` asserting the folder path is byte-identical through the seam. Existing workflows/providers/cli/core tests pass unmodified.
- Skipped: none.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No` (host exec is unchanged; `runSubprocess` on the host path is a verbatim `execFileAsync` call)

## Compatibility / Migration

- Backward compatible? `Yes` (host-only, byte-identical; all new params default to `{ kind: 'host' }`)
- Config/env changes? `No`
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios: `bun run validate` green; isolation resolver + new backend tests pass; workflows/providers/cli/core suites pass unmodified; diff confirms all four deterministic exec sites route through `runSubprocess` and options carry `execContext` only in the container branch.
- Edge cases checked: `resolveFolderBackend` throws for repo-kind and for `{ container: true }` (no silent downgrade); folder resolver result asserted byte-identical via full-object equality; `codebase` narrowed to non-null inside the CLI folder branch.
- What was not verified: no container runtime exercised (Phase B); no live end-to-end CLI run (covered by unit/integration tests + validate).

## Side Effects / Blast Radius (required)

- Affected subsystems: `@archon/isolation` (new seam + resolver folder branch), `@archon/workflows` executor/dag-executor (execContext threading + `runSubprocess`), `@archon/cli` folder run, `@archon/providers` contract type.
- Potential unintended effects: the `runSubprocess` indirection and the always-present `execContext` param on several dag-executor functions — mitigated by conditional options-set (host produces byte-identical options) and full test-suite parity.
- Guardrails: full-object-equality resolver regression test; per-package test matrix in CI.

## Rollback Plan (required)

- Fast rollback: revert this single commit — self-contained, no migration, no config.
- Feature flags: none (behavior is inert until Phase B populates a container context).
- Observable failure symptoms: any change to folder-project run output or worktree runs (none expected).

## Risks and Mitigations

- Risk: `bash`/`script` routing through `runSubprocess` subtly changes host behavior.
  - Mitigation: host branch delegates verbatim to `execFileAsync`; existing bash/script/loop tests pass unmodified.
- Risk: adding `execContext` to `SendQueryOptions` on every AI turn.
  - Mitigation: set **only** when `kind === 'container'`, so host options are byte-identical and no test needed changing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Folder-based workflows now run directly from the project directory using an explicit host execution context.
  * Workflow execution (including provider turns and deterministic script/loop steps) now consistently propagates the execution environment choice.
  * Added folder backend routing with explicit handling when container execution isn’t available.
* **Bug Fixes**
  * Folder resolution preserves the expected working directory and result shape.
* **Tests**
  * Expanded coverage for backend selection/routing, in-place execution, folder resolution, and execution-context propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->