### PR TITLE
fix(workflows): close approve/reject double-resolution TOCTOU with a gate CAS (#2113)

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -167,6 +167,10 @@ mock.module('@archon/core/db/workflows', () => ({
   getWorkflowRun: mock(() => Promise.resolve(null)),
   findWorkflowRunsByIdPrefix: mock(() => Promise.resolve([])),
   updateWorkflowRun: mock(() => Promise.resolve()),
+  // CAS gate resolvers (#2113) — approve/reject stamp the resolution here;
+  // resolveAndCancelApprovalGate atomically resolves+cancels terminal rejects.
+  resolveApprovalGate: mock(() => Promise.resolve({ resolved: true })),
+  resolveAndCancelApprovalGate: mock(() => Promise.resolve({ resolved: true })),
   listWorkflowRuns: mock(() => Promise.resolve([])),
   listDashboardRuns: mock(() =>
     Promise.resolve({
@@ -3848,7 +3852,8 @@ describe('workflowRejectCommand', () => {
 
     await workflowRejectCommand('run-plain', 'not good');
 
-    expect(workflowDb.cancelWorkflowRun).toHaveBeenCalledWith('run-plain');
+    // Terminal reject resolves + cancels atomically (#2113)
+    expect(workflowDb.resolveAndCancelApprovalGate).toHaveBeenCalledWith('run-plain');
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Rejected and cancelled'));
   });
 
@@ -3881,20 +3886,19 @@ describe('workflowRejectCommand', () => {
       // downstream workflowRunCommand failure is acceptable in this unit test
     }
 
-    // Stays 'paused' (no status write) — rework staged on the approval context (#2075)
-    expect(workflowDb.updateWorkflowRun).toHaveBeenCalledWith('run-on-reject', {
-      metadata: {
-        approval: {
-          type: 'approval',
-          nodeId: 'gate',
-          message: 'Approve?',
-          onRejectPrompt: 'Fix: $REJECTION_REASON',
-          onRejectMaxAttempts: 3,
-          resolved: 'rejected',
-        },
-        rejection_reason: 'needs work',
-        rejection_count: 1,
+    // Stays 'paused' (no status write) — rework staged atomically via the CAS on
+    // the approval context (#2075/#2113)
+    expect(workflowDb.resolveApprovalGate).toHaveBeenCalledWith('run-on-reject', {
+      approval: {
+        type: 'approval',
+        nodeId: 'gate',
+        message: 'Approve?',
+        onRejectPrompt: 'Fix: $REJECTION_REASON',
+        onRejectMaxAttempts: 3,
+        resolved: 'rejected',
       },
+      rejection_reason: 'needs work',
+      rejection_count: 1,
     });
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Rejected workflow'));
   });
@@ -3982,7 +3986,8 @@ describe('workflowRejectCommand', () => {
 
     await workflowRejectCommand('run-max', 'still bad');
 
-    expect(workflowDb.cancelWorkflowRun).toHaveBeenCalledWith('run-max');
+    // Terminal reject resolves + cancels atomically (#2113)
+    expect(workflowDb.resolveAndCancelApprovalGate).toHaveBeenCalledWith('run-max');
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('max attempts reached'));
   });
 

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -3852,8 +3852,15 @@ describe('workflowRejectCommand', () => {
 
     await workflowRejectCommand('run-plain', 'not good');
 
-    // Terminal reject resolves + cancels atomically (#2113)
-    expect(workflowDb.resolveAndCancelApprovalGate).toHaveBeenCalledWith('run-plain');
+    // Terminal reject resolves + cancels atomically (#2113); the audit event
+    // rides the same transaction (#2146).
+    expect(workflowDb.resolveAndCancelApprovalGate).toHaveBeenCalledWith('run-plain', [
+      {
+        event_type: 'approval_received',
+        step_name: 'gate',
+        data: { decision: 'rejected', reason: 'not good' },
+      },
+    ]);
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Rejected and cancelled'));
   });
 
@@ -3887,19 +3894,30 @@ describe('workflowRejectCommand', () => {
     }
 
     // Stays 'paused' (no status write) — rework staged atomically via the CAS on
-    // the approval context (#2075/#2113)
-    expect(workflowDb.resolveApprovalGate).toHaveBeenCalledWith('run-on-reject', {
-      approval: {
-        type: 'approval',
-        nodeId: 'gate',
-        message: 'Approve?',
-        onRejectPrompt: 'Fix: $REJECTION_REASON',
-        onRejectMaxAttempts: 3,
-        resolved: 'rejected',
+    // the approval context (#2075/#2113), with the audit event in the same
+    // transaction (#2146)
+    expect(workflowDb.resolveApprovalGate).toHaveBeenCalledWith(
+      'run-on-reject',
+      {
+        approval: {
+          type: 'approval',
+          nodeId: 'gate',
+          message: 'Approve?',
+          onRejectPrompt: 'Fix: $REJECTION_REASON',
+          onRejectMaxAttempts: 3,
+          resolved: 'rejected',
+        },
+        rejection_reason: 'needs work',
+        rejection_count: 1,
       },
-      rejection_reason: 'needs work',
-      rejection_count: 1,
-    });
+      [
+        {
+          event_type: 'approval_received',
+          step_name: 'gate',
+          data: { decision: 'rejected', reason: 'needs work' },
+        },
+      ]
+    );
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Rejected workflow'));
   });
 
@@ -3986,8 +4004,15 @@ describe('workflowRejectCommand', () => {
 
     await workflowRejectCommand('run-max', 'still bad');
 
-    // Terminal reject resolves + cancels atomically (#2113)
-    expect(workflowDb.resolveAndCancelApprovalGate).toHaveBeenCalledWith('run-max');
+    // Terminal reject resolves + cancels atomically (#2113); the audit event
+    // rides the same transaction (#2146).
+    expect(workflowDb.resolveAndCancelApprovalGate).toHaveBeenCalledWith('run-max', [
+      {
+        event_type: 'approval_received',
+        step_name: 'gate',
+        data: { decision: 'rejected', reason: 'still bad' },
+      },
+    ]);
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('max attempts reached'));
   });
 

--- a/packages/core/src/db/adapters/sqlite.ts
+++ b/packages/core/src/db/adapters/sqlite.ts
@@ -18,6 +18,15 @@ export class SqliteAdapter implements IDatabase {
   private db: Database;
   readonly dialect = 'sqlite' as const;
   readonly sql: SqlDialect = sqliteDialect;
+  /**
+   * Tail of the transaction queue. bun:sqlite is a single connection, so two
+   * overlapping `withTransaction` blocks would interleave their BEGINs and throw
+   * "cannot start a transaction within a transaction." Chaining each transaction
+   * onto this tail serializes them: the second waits for the first to COMMIT,
+   * then sees its committed state — exactly what the approval-gate CAS needs so a
+   * concurrent second resolver cleanly loses (rowCount 0) instead of erroring.
+   */
+  private txTail: Promise<unknown> = Promise.resolve();
 
   constructor(dbPath: string) {
     // Ensure directory exists
@@ -97,19 +106,29 @@ export class SqliteAdapter implements IDatabase {
   async withTransaction<T>(
     fn: (query: <U>(sql: string, params?: unknown[]) => Promise<QueryResult<U>>) => Promise<T>
   ): Promise<T> {
-    await this.query('BEGIN');
-    try {
-      const result = await fn(this.query.bind(this));
-      await this.query('COMMIT');
-      return result;
-    } catch (e) {
+    const run = async (): Promise<T> => {
+      await this.query('BEGIN');
       try {
-        await this.query('ROLLBACK');
-      } catch (rollbackError) {
-        getLog().error({ err: rollbackError as Error }, 'db.sqlite_transaction_rollback_failed');
+        const result = await fn(this.query.bind(this));
+        await this.query('COMMIT');
+        return result;
+      } catch (e) {
+        try {
+          await this.query('ROLLBACK');
+        } catch (rollbackError) {
+          getLog().error({ err: rollbackError as Error }, 'db.sqlite_transaction_rollback_failed');
+        }
+        throw e;
       }
-      throw e;
-    }
+    };
+    // Serialize against any in-flight transaction (see `txTail`). The stored tail
+    // is made non-rejecting so one transaction's failure never blocks the next.
+    const result = this.txTail.then(run, run);
+    this.txTail = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
   }
 
   async close(): Promise<void> {

--- a/packages/core/src/db/workflow-events.test.ts
+++ b/packages/core/src/db/workflow-events.test.ts
@@ -61,7 +61,7 @@ describe('workflow-events', () => {
 
       expect(mockQuery).toHaveBeenCalledWith(
         `INSERT INTO remote_agent_workflow_events (id, workflow_run_id, event_type, step_index, step_name, data)
-       VALUES ($1, $2, $3, $4, $5, $6)`,
+     VALUES ($1, $2, $3, $4, $5, $6)`,
         [
           expect.any(String), // generated UUID
           'run-456',

--- a/packages/core/src/db/workflow-events.ts
+++ b/packages/core/src/db/workflow-events.ts
@@ -9,6 +9,7 @@
  * Read operations also throw on error — callers own the degradation policy.
  */
 import { pool, getDialect, getDatabaseType } from './connection';
+import type { QueryResult } from './adapters/types';
 import type { WorkflowEventRow } from '../schemas/workflow-event';
 import { createLogger } from '@archon/paths';
 
@@ -53,31 +54,58 @@ function parseEventRow(row: WorkflowEventRow): WorkflowEventRow {
   }
 }
 
-/**
- * Create a workflow event. Fire-and-forget - never throws.
- */
-export async function createWorkflowEvent(data: {
+/** The column payload for a single workflow-event row. */
+export interface WorkflowEventInput {
   workflow_run_id: string;
   event_type: string;
   step_index?: number;
   step_name?: string;
   data?: Record<string, unknown>;
-}): Promise<void> {
+}
+
+/**
+ * A query function scoped to a specific connection — either the module-level
+ * `pool` or a transaction-scoped query from `IDatabase.withTransaction`. The row
+ * type is unused (INSERT returns none), so it is fixed to `unknown` rather than
+ * generic, which lets a generic transaction query be passed directly.
+ */
+type EventInsertQuery = (sql: string, params?: unknown[]) => Promise<QueryResult<unknown>>;
+
+/**
+ * Insert one workflow-event row via `query` and THROW on failure. This is the
+ * single source of truth for the event columns and dialect UUID; the
+ * fire-and-forget createWorkflowEvent wraps it in try/catch, while callers that
+ * need the write to be atomic with another mutation (the approval-gate CAS in
+ * db/workflows.ts, #2146) pass a transaction-scoped query so a failed event
+ * write rolls back the enclosing UPDATE instead of stranding a resolved gate
+ * with no audit trail.
+ */
+export async function insertWorkflowEvent(
+  query: EventInsertQuery,
+  data: WorkflowEventInput
+): Promise<void> {
+  const dialect = getDialect();
+  const id = dialect.generateUuid();
+  await query(
+    `INSERT INTO remote_agent_workflow_events (id, workflow_run_id, event_type, step_index, step_name, data)
+     VALUES ($1, $2, $3, $4, $5, $6)`,
+    [
+      id,
+      data.workflow_run_id,
+      data.event_type,
+      data.step_index ?? null,
+      data.step_name ?? null,
+      JSON.stringify(data.data ?? {}),
+    ]
+  );
+}
+
+/**
+ * Create a workflow event. Fire-and-forget - never throws.
+ */
+export async function createWorkflowEvent(data: WorkflowEventInput): Promise<void> {
   try {
-    const dialect = getDialect();
-    const id = dialect.generateUuid();
-    await pool.query(
-      `INSERT INTO remote_agent_workflow_events (id, workflow_run_id, event_type, step_index, step_name, data)
-       VALUES ($1, $2, $3, $4, $5, $6)`,
-      [
-        id,
-        data.workflow_run_id,
-        data.event_type,
-        data.step_index ?? null,
-        data.step_name ?? null,
-        JSON.stringify(data.data ?? {}),
-      ]
-    );
+    await insertWorkflowEvent((sql, params) => pool.query(sql, params), data);
   } catch (error) {
     getLog().error(
       { err: error as Error, eventType: data.event_type, runId: data.workflow_run_id },

--- a/packages/core/src/db/workflows.resume-cas.integration.test.ts
+++ b/packages/core/src/db/workflows.resume-cas.integration.test.ts
@@ -30,6 +30,10 @@ const db = new SqliteAdapter(':memory:');
 
 mock.module('./connection', () => ({
   pool: db,
+  // The gate CAS functions run their UPDATE + audit-event INSERT inside one
+  // withTransaction (#2146) — hand them the real adapter so the transaction is
+  // exercised end-to-end.
+  getDatabase: () => db,
   getDialect: () => sqliteDialect,
   getDatabaseType: () => 'sqlite',
 }));
@@ -260,6 +264,25 @@ describe('gate reject staging — real SQLite end-to-end (#2075)', () => {
 // row so a concurrent second resolver loses cleanly.
 // ---------------------------------------------------------------------------
 
+/** A minimal audit event for the gate CAS calls (content is not asserted here). */
+function approvalEvent(decision: 'approved' | 'rejected'): {
+  event_type: string;
+  step_name: string;
+  data: Record<string, unknown>;
+} {
+  return { event_type: 'approval_received', step_name: 'review', data: { decision } };
+}
+
+/** Count workflow_events rows of a given type for a run (atomicity assertions). */
+async function countEvents(runId: string, eventType: string): Promise<number> {
+  const result = await db.query<{ cnt: number }>(
+    `SELECT COUNT(*) AS cnt FROM remote_agent_workflow_events
+     WHERE workflow_run_id = $1 AND event_type = $2`,
+    [runId, eventType]
+  );
+  return Number(result.rows[0]?.cnt ?? 0);
+}
+
 describe('resolveApprovalGate — CAS at the DB layer (#2113)', () => {
   test('wins once on an open gate and merges the resolution metadata', async () => {
     await seedPausedRun(
@@ -269,11 +292,15 @@ describe('resolveApprovalGate — CAS at the DB layer (#2113)', () => {
       { rejection_count: 0 }
     );
 
-    const outcome = await resolveApprovalGate('cas-open', {
-      approval: { nodeId: 'review', message: 'Approve?', type: 'approval', resolved: 'approved' },
-      approval_response: 'approved',
-      rejection_reason: '',
-    });
+    const outcome = await resolveApprovalGate(
+      'cas-open',
+      {
+        approval: { nodeId: 'review', message: 'Approve?', type: 'approval', resolved: 'approved' },
+        approval_response: 'approved',
+        rejection_reason: '',
+      },
+      [approvalEvent('approved')]
+    );
     expect(outcome.resolved).toBe(true);
 
     const staged = await getWorkflowRun('cas-open');
@@ -283,19 +310,42 @@ describe('resolveApprovalGate — CAS at the DB layer (#2113)', () => {
     expect(staged?.metadata.approval_response).toBe('approved');
     // Pre-existing top-level key survives the json_patch/`||` merge.
     expect(staged?.metadata.rejection_count).toBe(0);
+    // The winner's audit event committed in the same transaction (#2146).
+    expect(await countEvents('cas-open', 'approval_received')).toBe(1);
   });
 
-  test('a second CAS on the now-resolved gate loses (no double-resolution)', async () => {
-    // 'cas-open' was resolved to 'approved' by the previous test — resolved is no
-    // longer NULL, so the predicate excludes it and the second stamp is a no-op.
-    const outcome = await resolveApprovalGate('cas-open', {
-      approval: { nodeId: 'review', message: 'Approve?', type: 'approval', resolved: 'rejected' },
+  test('a second CAS on an already-resolved gate loses (no double-resolution)', async () => {
+    // Self-contained: seed an open gate, win it once, then assert the second CAS
+    // loses — resolved is no longer NULL, so the predicate excludes it.
+    await seedPausedRun('cas-resolved', 'wf-cas-resolved', {
+      nodeId: 'review',
+      message: 'Approve?',
+      type: 'approval',
+      resolved: null,
     });
+    const first = await resolveApprovalGate(
+      'cas-resolved',
+      {
+        approval: { nodeId: 'review', message: 'Approve?', type: 'approval', resolved: 'approved' },
+      },
+      [approvalEvent('approved')]
+    );
+    expect(first.resolved).toBe(true);
+
+    const outcome = await resolveApprovalGate(
+      'cas-resolved',
+      {
+        approval: { nodeId: 'review', message: 'Approve?', type: 'approval', resolved: 'rejected' },
+      },
+      [approvalEvent('rejected')]
+    );
     expect(outcome.resolved).toBe(false);
 
-    // The losing payload never lands: resolution stays 'approved'.
-    const staged = await getWorkflowRun('cas-open');
+    // The losing payload never lands: resolution stays 'approved' and the loser
+    // wrote no audit event.
+    const staged = await getWorkflowRun('cas-resolved');
     expect((staged?.metadata.approval as Record<string, unknown>).resolved).toBe('approved');
+    expect(await countEvents('cas-resolved', 'approval_received')).toBe(1);
   });
 
   test('two concurrent CAS calls on one open gate: exactly one wins', async () => {
@@ -307,16 +357,36 @@ describe('resolveApprovalGate — CAS at the DB layer (#2113)', () => {
     });
 
     const [a, b] = await Promise.all([
-      resolveApprovalGate('cas-race', {
-        approval: { nodeId: 'review', message: 'Approve?', type: 'approval', resolved: 'approved' },
-      }),
-      resolveApprovalGate('cas-race', {
-        approval: { nodeId: 'review', message: 'Approve?', type: 'approval', resolved: 'rejected' },
-      }),
+      resolveApprovalGate(
+        'cas-race',
+        {
+          approval: {
+            nodeId: 'review',
+            message: 'Approve?',
+            type: 'approval',
+            resolved: 'approved',
+          },
+        },
+        [approvalEvent('approved')]
+      ),
+      resolveApprovalGate(
+        'cas-race',
+        {
+          approval: {
+            nodeId: 'review',
+            message: 'Approve?',
+            type: 'approval',
+            resolved: 'rejected',
+          },
+        },
+        [approvalEvent('rejected')]
+      ),
     ]);
 
     // Exactly one of the two racers wins the atomic UPDATE.
     expect([a.resolved, b.resolved].filter(Boolean)).toHaveLength(1);
+    // ...and exactly one audit event landed — the loser wrote nothing.
+    expect(await countEvents('cas-race', 'approval_received')).toBe(1);
   });
 
   test('misses a non-paused run even when the gate looks unresolved', async () => {
@@ -329,14 +399,72 @@ describe('resolveApprovalGate — CAS at the DB layer (#2113)', () => {
       [JSON.stringify({ approval: { nodeId: 'review', message: 'Approve?', resolved: null } })]
     );
 
-    const outcome = await resolveApprovalGate('cas-running', {
-      approval: { nodeId: 'review', message: 'Approve?', resolved: 'approved' },
-    });
+    const outcome = await resolveApprovalGate(
+      'cas-running',
+      {
+        approval: { nodeId: 'review', message: 'Approve?', resolved: 'approved' },
+      },
+      [approvalEvent('approved')]
+    );
     expect(outcome.resolved).toBe(false);
     // Untouched — still running, gate still open.
     const row = await getWorkflowRun('cas-running');
     expect(row?.status).toBe('running');
     expect((row?.metadata.approval as Record<string, unknown>).resolved ?? null).toBeNull();
+  });
+
+  test('rolls back the resolution when the audit event write fails (atomic, #2146)', async () => {
+    // Seed an open gate, then attempt a CAS whose event INSERT violates the
+    // NOT NULL on event_type — the whole transaction (UPDATE + INSERT) must roll
+    // back, leaving the gate open so a well-formed retry can still win it.
+    await seedPausedRun('cas-atomic', 'wf-cas-atomic', {
+      nodeId: 'review',
+      message: 'Approve?',
+      type: 'approval',
+      resolved: null,
+    });
+
+    const badEvent = {
+      // Simulates an event-write failure inside the transaction.
+      event_type: null as unknown as string,
+      step_name: 'review',
+      data: { decision: 'approved' },
+    };
+    await expect(
+      resolveApprovalGate(
+        'cas-atomic',
+        {
+          approval: {
+            nodeId: 'review',
+            message: 'Approve?',
+            type: 'approval',
+            resolved: 'approved',
+          },
+        },
+        [badEvent]
+      )
+    ).rejects.toThrow(/Failed to resolve approval gate/);
+
+    // The resolution rolled back — gate still open, no partial event written.
+    const afterFailure = await getWorkflowRun('cas-atomic');
+    expect(afterFailure?.status).toBe('paused');
+    expect(
+      (afterFailure?.metadata.approval as Record<string, unknown>).resolved ?? null
+    ).toBeNull();
+    expect(await countEvents('cas-atomic', 'approval_received')).toBe(0);
+
+    // The retry with a well-formed event now wins the still-open gate.
+    const retry = await resolveApprovalGate(
+      'cas-atomic',
+      {
+        approval: { nodeId: 'review', message: 'Approve?', type: 'approval', resolved: 'approved' },
+      },
+      [approvalEvent('approved')]
+    );
+    expect(retry.resolved).toBe(true);
+    const resolvedRow = await getWorkflowRun('cas-atomic');
+    expect((resolvedRow?.metadata.approval as Record<string, unknown>).resolved).toBe('approved');
+    expect(await countEvents('cas-atomic', 'approval_received')).toBe(1);
   });
 });
 
@@ -349,19 +477,35 @@ describe('resolveAndCancelApprovalGate — atomic reject+cancel CAS (#2113)', ()
       resolved: null,
     });
 
-    const outcome = await resolveAndCancelApprovalGate('rc-open');
+    const outcome = await resolveAndCancelApprovalGate('rc-open', [approvalEvent('rejected')]);
     expect(outcome.resolved).toBe(true);
 
-    // Single atomic transition: paused → cancelled with a completion stamp.
+    // Single atomic transition: paused → cancelled with a completion stamp, plus
+    // the audit event committed in the same transaction (#2146).
     const row = await getWorkflowRun('rc-open');
     expect(row?.status).toBe('cancelled');
     expect(row?.completed_at).not.toBeNull();
+    expect(await countEvents('rc-open', 'approval_received')).toBe(1);
   });
 
-  test('a second call on the now-cancelled gate loses (guard excludes non-paused)', async () => {
-    const outcome = await resolveAndCancelApprovalGate('rc-open');
+  test('a second call on an already-cancelled gate loses (guard excludes non-paused)', async () => {
+    // Self-contained: seed an open gate, cancel it once, then assert the second
+    // call loses because the run is no longer paused.
+    await seedPausedRun('rc-cancelled', 'wf-rc-cancelled', {
+      nodeId: 'review',
+      message: 'Approve?',
+      type: 'approval',
+      resolved: null,
+    });
+    expect(
+      (await resolveAndCancelApprovalGate('rc-cancelled', [approvalEvent('rejected')])).resolved
+    ).toBe(true);
+
+    const outcome = await resolveAndCancelApprovalGate('rc-cancelled', [approvalEvent('rejected')]);
     expect(outcome.resolved).toBe(false);
-    expect((await getWorkflowRun('rc-open'))?.status).toBe('cancelled');
+    expect((await getWorkflowRun('rc-cancelled'))?.status).toBe('cancelled');
+    // The loser wrote no second audit event.
+    expect(await countEvents('rc-cancelled', 'approval_received')).toBe(1);
   });
 
   test('an approve CAS loses against a concurrent reject-cancel on the same gate', async () => {
@@ -373,11 +517,17 @@ describe('resolveAndCancelApprovalGate — atomic reject+cancel CAS (#2113)', ()
     });
 
     // reject-cancel wins the open gate first...
-    expect((await resolveAndCancelApprovalGate('rc-vs-approve')).resolved).toBe(true);
+    expect(
+      (await resolveAndCancelApprovalGate('rc-vs-approve', [approvalEvent('rejected')])).resolved
+    ).toBe(true);
     // ...so a racing approve (guarded on status='paused') can no longer resolve it.
-    const approveOutcome = await resolveApprovalGate('rc-vs-approve', {
-      approval: { nodeId: 'review', message: 'Approve?', resolved: 'approved' },
-    });
+    const approveOutcome = await resolveApprovalGate(
+      'rc-vs-approve',
+      {
+        approval: { nodeId: 'review', message: 'Approve?', resolved: 'approved' },
+      },
+      [approvalEvent('approved')]
+    );
     expect(approveOutcome.resolved).toBe(false);
     expect((await getWorkflowRun('rc-vs-approve'))?.status).toBe('cancelled');
   });

--- a/packages/core/src/db/workflows.resume-cas.integration.test.ts
+++ b/packages/core/src/db/workflows.resume-cas.integration.test.ts
@@ -40,6 +40,8 @@ const {
   getWorkflowRun,
   findResumableRun,
   findResumableRunByParentConversation,
+  resolveApprovalGate,
+  resolveAndCancelApprovalGate,
   WorkflowNotResumableError,
 } = await import('./workflows');
 const { approveWorkflow, rejectWorkflow } = await import('../operations/workflow-operations');
@@ -246,5 +248,137 @@ describe('gate reject staging — real SQLite end-to-end (#2075)', () => {
     const result = await rejectWorkflow('gate-cancel', 'no');
     expect(result.cancelled).toBe(true);
     expect((await getWorkflowRun('gate-cancel'))?.status).toBe('cancelled');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveApprovalGate — the compare-and-swap that closes the approve/reject
+// read-then-write TOCTOU window (#2113). Exercises the REAL SQLite JSON
+// predicate (unresolvedGateClause: json_extract(...,'$.approval.resolved') IS
+// NULL) end-to-end: it must match an open gate (resolved: null), merge the
+// resolution atomically, and then MISS for any already-resolved or non-paused
+// row so a concurrent second resolver loses cleanly.
+// ---------------------------------------------------------------------------
+
+describe('resolveApprovalGate — CAS at the DB layer (#2113)', () => {
+  test('wins once on an open gate and merges the resolution metadata', async () => {
+    await seedPausedRun(
+      'cas-open',
+      'wf-cas-open',
+      { nodeId: 'review', message: 'Approve?', type: 'approval', resolved: null },
+      { rejection_count: 0 }
+    );
+
+    const outcome = await resolveApprovalGate('cas-open', {
+      approval: { nodeId: 'review', message: 'Approve?', type: 'approval', resolved: 'approved' },
+      approval_response: 'approved',
+      rejection_reason: '',
+    });
+    expect(outcome.resolved).toBe(true);
+
+    const staged = await getWorkflowRun('cas-open');
+    // Merged, not replaced: the new keys land and the run stays 'paused'.
+    expect(staged?.status).toBe('paused');
+    expect((staged?.metadata.approval as Record<string, unknown>).resolved).toBe('approved');
+    expect(staged?.metadata.approval_response).toBe('approved');
+    // Pre-existing top-level key survives the json_patch/`||` merge.
+    expect(staged?.metadata.rejection_count).toBe(0);
+  });
+
+  test('a second CAS on the now-resolved gate loses (no double-resolution)', async () => {
+    // 'cas-open' was resolved to 'approved' by the previous test — resolved is no
+    // longer NULL, so the predicate excludes it and the second stamp is a no-op.
+    const outcome = await resolveApprovalGate('cas-open', {
+      approval: { nodeId: 'review', message: 'Approve?', type: 'approval', resolved: 'rejected' },
+    });
+    expect(outcome.resolved).toBe(false);
+
+    // The losing payload never lands: resolution stays 'approved'.
+    const staged = await getWorkflowRun('cas-open');
+    expect((staged?.metadata.approval as Record<string, unknown>).resolved).toBe('approved');
+  });
+
+  test('two concurrent CAS calls on one open gate: exactly one wins', async () => {
+    await seedPausedRun('cas-race', 'wf-cas-race', {
+      nodeId: 'review',
+      message: 'Approve?',
+      type: 'approval',
+      resolved: null,
+    });
+
+    const [a, b] = await Promise.all([
+      resolveApprovalGate('cas-race', {
+        approval: { nodeId: 'review', message: 'Approve?', type: 'approval', resolved: 'approved' },
+      }),
+      resolveApprovalGate('cas-race', {
+        approval: { nodeId: 'review', message: 'Approve?', type: 'approval', resolved: 'rejected' },
+      }),
+    ]);
+
+    // Exactly one of the two racers wins the atomic UPDATE.
+    expect([a.resolved, b.resolved].filter(Boolean)).toHaveLength(1);
+  });
+
+  test('misses a non-paused run even when the gate looks unresolved', async () => {
+    // status='running' with resolved:null — the status arm of the clause excludes it.
+    await db.query(
+      `INSERT INTO remote_agent_workflow_runs
+         (id, workflow_name, conversation_id, user_message, status, metadata, started_at, last_activity_at)
+       VALUES ('cas-running', 'wf-cas-running', 'conv-1', 'msg', 'running', $1,
+               datetime('now'), datetime('now'))`,
+      [JSON.stringify({ approval: { nodeId: 'review', message: 'Approve?', resolved: null } })]
+    );
+
+    const outcome = await resolveApprovalGate('cas-running', {
+      approval: { nodeId: 'review', message: 'Approve?', resolved: 'approved' },
+    });
+    expect(outcome.resolved).toBe(false);
+    // Untouched — still running, gate still open.
+    const row = await getWorkflowRun('cas-running');
+    expect(row?.status).toBe('running');
+    expect((row?.metadata.approval as Record<string, unknown>).resolved ?? null).toBeNull();
+  });
+});
+
+describe('resolveAndCancelApprovalGate — atomic reject+cancel CAS (#2113)', () => {
+  test('wins once on an open gate and flips it terminal in one UPDATE', async () => {
+    await seedPausedRun('rc-open', 'wf-rc-open', {
+      nodeId: 'review',
+      message: 'Approve?',
+      type: 'approval',
+      resolved: null,
+    });
+
+    const outcome = await resolveAndCancelApprovalGate('rc-open');
+    expect(outcome.resolved).toBe(true);
+
+    // Single atomic transition: paused → cancelled with a completion stamp.
+    const row = await getWorkflowRun('rc-open');
+    expect(row?.status).toBe('cancelled');
+    expect(row?.completed_at).not.toBeNull();
+  });
+
+  test('a second call on the now-cancelled gate loses (guard excludes non-paused)', async () => {
+    const outcome = await resolveAndCancelApprovalGate('rc-open');
+    expect(outcome.resolved).toBe(false);
+    expect((await getWorkflowRun('rc-open'))?.status).toBe('cancelled');
+  });
+
+  test('an approve CAS loses against a concurrent reject-cancel on the same gate', async () => {
+    await seedPausedRun('rc-vs-approve', 'wf-rc-vs-approve', {
+      nodeId: 'review',
+      message: 'Approve?',
+      type: 'approval',
+      resolved: null,
+    });
+
+    // reject-cancel wins the open gate first...
+    expect((await resolveAndCancelApprovalGate('rc-vs-approve')).resolved).toBe(true);
+    // ...so a racing approve (guarded on status='paused') can no longer resolve it.
+    const approveOutcome = await resolveApprovalGate('rc-vs-approve', {
+      approval: { nodeId: 'review', message: 'Approve?', resolved: 'approved' },
+    });
+    expect(approveOutcome.resolved).toBe(false);
+    expect((await getWorkflowRun('rc-vs-approve'))?.status).toBe('cancelled');
   });
 });

--- a/packages/core/src/db/workflows.ts
+++ b/packages/core/src/db/workflows.ts
@@ -73,6 +73,93 @@ function resumableStatusClause(dialect: SqlDialect, dayParamIndex: number): stri
 }
 
 /**
+ * SQL predicate matching a run whose approval gate is still OPEN: the row is
+ * 'paused' AND metadata.approval.resolved is JSON null or absent. Dialect-aware
+ * (Postgres `->>`, SQLite `json_extract`) and kept in ONE place so the two forms
+ * cannot drift — mirrors resumableStatusClause and the local jsonIntExtract
+ * helper. `->>'resolved'` / `json_extract(...)` both return SQL NULL for a JSON
+ * null AND for an absent key, so `IS NULL` matches exactly "not yet resolved".
+ * This is the compare-and-swap guard resolveApprovalGate uses to serialize
+ * concurrent approve/reject.
+ */
+function unresolvedGateClause(): string {
+  const resolvedExpr =
+    getDatabaseType() === 'postgresql'
+      ? "metadata->'approval'->>'resolved'"
+      : "json_extract(metadata, '$.approval.resolved')";
+  return `status = 'paused' AND ${resolvedExpr} IS NULL`;
+}
+
+/**
+ * Atomically resolve a paused approval gate (compare-and-swap).
+ *
+ * Merges `metadata` (which carries `approval.resolved = 'approved' | 'rejected'`
+ * plus any gate-specific keys) into the row ONLY while the gate is still open
+ * (unresolvedGateClause). Returns `{ resolved }`: `true` = this caller won the
+ * race and MAY write gate events; `false` = a concurrent approve/reject already
+ * resolved the gate, so the caller must NOT write events (they would duplicate).
+ *
+ * This closes the read-then-write TOCTOU window in approveWorkflow /
+ * rejectWorkflow: the atomic conditional UPDATE — not a prior in-memory
+ * isGateResolved read — is the single arbiter of the resolution. The run STAYS
+ * 'paused' (only metadata changes); the resume CAS (resumeWorkflowRun)
+ * independently guards double-resume. Idempotent in content, so a lost race
+ * corrupts nothing — it only prevents the duplicate events/telemetry (#2113).
+ */
+export async function resolveApprovalGate(
+  id: string,
+  metadata: Record<string, unknown>
+): Promise<{ resolved: boolean }> {
+  const dialect = getDialect();
+  try {
+    const result = await pool.query(
+      `UPDATE remote_agent_workflow_runs
+       SET metadata = ${dialect.jsonMerge('metadata', 2)}
+       WHERE id = $1 AND ${unresolvedGateClause()}`,
+      [id, JSON.stringify(metadata)]
+    );
+    return { resolved: (result.rowCount ?? 0) > 0 };
+  } catch (error) {
+    const err = error as Error;
+    getLog().error({ err, workflowRunId: id }, 'db.workflow_run_resolve_gate_failed');
+    throw new Error(`Failed to resolve approval gate: ${err.message}`);
+  }
+}
+
+/**
+ * Atomically cancel a paused approval gate (compare-and-swap).
+ *
+ * The reject sibling of resolveApprovalGate for the outcomes that TERMINATE the
+ * run (no on_reject prompt, or the attempt cap reached): it flips the run
+ * paused→'cancelled' in a SINGLE conditional UPDATE, guarded on the SAME
+ * open-gate predicate. Doing it in one statement (instead of stamp-resolution +
+ * separate cancelWorkflowRun) means there is never an intermediate
+ * resolved-but-not-cancelled state that a failed second write could strand — a
+ * reject retry could not self-heal past the fast-path gate guard. No `resolved`
+ * marker is written: that marker only matters for the stay-paused rework path,
+ * and the rejection reason is preserved in the approval_received event. Returns
+ * `{ resolved }`; `false` means a concurrent resolver already won (the gate is no
+ * longer open), so the caller writes no events.
+ */
+export async function resolveAndCancelApprovalGate(id: string): Promise<{ resolved: boolean }> {
+  const dialect = getDialect();
+  try {
+    const result = await pool.query(
+      `UPDATE remote_agent_workflow_runs
+       SET status = 'cancelled',
+           completed_at = ${dialect.now()}
+       WHERE id = $1 AND ${unresolvedGateClause()}`,
+      [id]
+    );
+    return { resolved: (result.rowCount ?? 0) > 0 };
+  } catch (error) {
+    const err = error as Error;
+    getLog().error({ err, workflowRunId: id }, 'db.workflow_run_resolve_cancel_gate_failed');
+    throw new Error(`Failed to resolve and cancel approval gate: ${err.message}`);
+  }
+}
+
+/**
  * Thrown by resumeWorkflowRun when the target run is no longer in a resumable
  * state (already running/terminal, or concurrently resumed). Callers translate
  * this into a user-facing "already being resumed" message instead of leaking

--- a/packages/core/src/db/workflows.ts
+++ b/packages/core/src/db/workflows.ts
@@ -1,7 +1,8 @@
 /**
  * Database operations for workflow runs
  */
-import { pool, getDialect, getDatabaseType } from './connection';
+import { pool, getDialect, getDatabaseType, getDatabase } from './connection';
+import { insertWorkflowEvent } from './workflow-events';
 import type { IDatabase, SqlDialect } from './adapters/types';
 import type {
   WorkflowRun,
@@ -91,13 +92,28 @@ function unresolvedGateClause(): string {
 }
 
 /**
- * Atomically resolve a paused approval gate (compare-and-swap).
+ * An audit event written atomically with a gate resolution (#2146). The winning
+ * resolver inserts these in the SAME transaction as the resolution UPDATE, so a
+ * failed event write rolls the resolution back — a resolved gate can never be
+ * left with no audit trail, which the fast-path guard would then wrongly block
+ * from retrying. `workflow_run_id` is supplied by the CAS function.
+ */
+export interface GateResolutionEvent {
+  event_type: string;
+  step_name: string;
+  data: Record<string, unknown>;
+}
+
+/**
+ * Atomically resolve a paused approval gate (compare-and-swap) and record its
+ * audit events in one transaction.
  *
  * Merges `metadata` (which carries `approval.resolved = 'approved' | 'rejected'`
  * plus any gate-specific keys) into the row ONLY while the gate is still open
- * (unresolvedGateClause). Returns `{ resolved }`: `true` = this caller won the
- * race and MAY write gate events; `false` = a concurrent approve/reject already
- * resolved the gate, so the caller must NOT write events (they would duplicate).
+ * (unresolvedGateClause). When the CAS matches, the same transaction inserts
+ * `events`; when it loses (rowCount 0) nothing is written. Returns
+ * `{ resolved }`: `true` = this caller won the race and its events are committed;
+ * `false` = a concurrent approve/reject already resolved the gate.
  *
  * This closes the read-then-write TOCTOU window in approveWorkflow /
  * rejectWorkflow: the atomic conditional UPDATE — not a prior in-memory
@@ -105,20 +121,32 @@ function unresolvedGateClause(): string {
  * 'paused' (only metadata changes); the resume CAS (resumeWorkflowRun)
  * independently guards double-resume. Idempotent in content, so a lost race
  * corrupts nothing — it only prevents the duplicate events/telemetry (#2113).
+ * Wrapping the resolution and its audit rows in one transaction closes the
+ * separate gap where a post-commit event-write failure stranded a resolved gate
+ * with no audit event and no way to retry (#2146).
  */
 export async function resolveApprovalGate(
   id: string,
-  metadata: Record<string, unknown>
+  metadata: Record<string, unknown>,
+  events: GateResolutionEvent[]
 ): Promise<{ resolved: boolean }> {
   const dialect = getDialect();
   try {
-    const result = await pool.query(
-      `UPDATE remote_agent_workflow_runs
-       SET metadata = ${dialect.jsonMerge('metadata', 2)}
-       WHERE id = $1 AND ${unresolvedGateClause()}`,
-      [id, JSON.stringify(metadata)]
-    );
-    return { resolved: (result.rowCount ?? 0) > 0 };
+    return await getDatabase().withTransaction(async query => {
+      const result = await query(
+        `UPDATE remote_agent_workflow_runs
+         SET metadata = ${dialect.jsonMerge('metadata', 2)}
+         WHERE id = $1 AND ${unresolvedGateClause()}`,
+        [id, JSON.stringify(metadata)]
+      );
+      const resolved = (result.rowCount ?? 0) > 0;
+      if (resolved) {
+        for (const event of events) {
+          await insertWorkflowEvent(query, { workflow_run_id: id, ...event });
+        }
+      }
+      return { resolved };
+    });
   } catch (error) {
     const err = error as Error;
     getLog().error({ err, workflowRunId: id }, 'db.workflow_run_resolve_gate_failed');
@@ -137,21 +165,34 @@ export async function resolveApprovalGate(
  * resolved-but-not-cancelled state that a failed second write could strand — a
  * reject retry could not self-heal past the fast-path gate guard. No `resolved`
  * marker is written: that marker only matters for the stay-paused rework path,
- * and the rejection reason is preserved in the approval_received event. Returns
- * `{ resolved }`; `false` means a concurrent resolver already won (the gate is no
- * longer open), so the caller writes no events.
+ * and the rejection reason is preserved in the approval_received event. The
+ * status flip and that audit event commit in ONE transaction (#2146), so a
+ * failed event write rolls the cancellation back rather than terminating the run
+ * with no audit trail. Returns `{ resolved }`; `false` means a concurrent
+ * resolver already won (the gate is no longer open), so nothing is written.
  */
-export async function resolveAndCancelApprovalGate(id: string): Promise<{ resolved: boolean }> {
+export async function resolveAndCancelApprovalGate(
+  id: string,
+  events: GateResolutionEvent[]
+): Promise<{ resolved: boolean }> {
   const dialect = getDialect();
   try {
-    const result = await pool.query(
-      `UPDATE remote_agent_workflow_runs
-       SET status = 'cancelled',
-           completed_at = ${dialect.now()}
-       WHERE id = $1 AND ${unresolvedGateClause()}`,
-      [id]
-    );
-    return { resolved: (result.rowCount ?? 0) > 0 };
+    return await getDatabase().withTransaction(async query => {
+      const result = await query(
+        `UPDATE remote_agent_workflow_runs
+         SET status = 'cancelled',
+             completed_at = ${dialect.now()}
+         WHERE id = $1 AND ${unresolvedGateClause()}`,
+        [id]
+      );
+      const resolved = (result.rowCount ?? 0) > 0;
+      if (resolved) {
+        for (const event of events) {
+          await insertWorkflowEvent(query, { workflow_run_id: id, ...event });
+        }
+      }
+      return { resolved };
+    });
   } catch (error) {
     const err = error as Error;
     getLog().error({ err, workflowRunId: id }, 'db.workflow_run_resolve_cancel_gate_failed');

--- a/packages/core/src/handlers/command-handler.test.ts
+++ b/packages/core/src/handlers/command-handler.test.ts
@@ -2176,19 +2176,30 @@ describe('CommandHandler', () => {
         expect(result.message).toContain('loop input received');
         expect(result.message).toContain('my-loop-wf');
         // Stays 'paused' (no status write) — resolution rides the approval context,
-        // stamped atomically via the CAS (#2075/#2113)
-        expect(mockResolveApprovalGate).toHaveBeenCalledWith('run-123', {
-          approval: {
-            type: 'interactive_loop',
-            nodeId: 'refine',
-            iteration: 2,
-            message: 'Review the output',
-            resolved: 'approved',
+        // stamped atomically via the CAS (#2075/#2113), with the audit event in the
+        // same transaction (#2146)
+        expect(mockResolveApprovalGate).toHaveBeenCalledWith(
+          'run-123',
+          {
+            approval: {
+              type: 'interactive_loop',
+              nodeId: 'refine',
+              iteration: 2,
+              message: 'Review the output',
+              resolved: 'approved',
+            },
+            loop_user_input: 'Add error handling',
+            // A real comment counts as feedback ⇒ the resumed loop iterates (#2074)
+            loop_feedback_given: true,
           },
-          loop_user_input: 'Add error handling',
-          // A real comment counts as feedback ⇒ the resumed loop iterates (#2074)
-          loop_feedback_given: true,
-        });
+          [
+            {
+              event_type: 'approval_received',
+              step_name: 'refine',
+              data: { decision: 'approved', comment: 'Add error handling', iteration: 2 },
+            },
+          ]
+        );
       });
 
       test('creates approval_received event (not node_completed) for interactive_loop', async () => {
@@ -2216,13 +2227,16 @@ describe('CommandHandler', () => {
 
         await handleCommand(baseConversation, '/workflow approve run-456 LGTM');
 
-        // node_completed should NOT be written by the approve command — only the executor
-        // writes it when the AI emits the completion signal (actual loop exit).
-        const nodeCompletedCalls = mockCreateWorkflowEvent.mock.calls.filter(
-          (call: unknown[]) => (call[0] as Record<string, unknown>).event_type === 'node_completed'
-        );
-        expect(nodeCompletedCalls.length).toBe(0);
-        expect(mockCreateWorkflowEvent).toHaveBeenCalledWith(
+        // The audit events ride the CAS transaction now (#2146), not a separate
+        // createWorkflowEvent write. node_completed should NOT be written by the
+        // approve command — only the executor writes it when the AI emits the
+        // completion signal (actual loop exit).
+        expect(mockCreateWorkflowEvent).not.toHaveBeenCalled();
+        const casEvents = mockResolveApprovalGate.mock.calls[0][2] as Array<
+          Record<string, unknown>
+        >;
+        expect(casEvents.filter(e => e.event_type === 'node_completed')).toHaveLength(0);
+        expect(casEvents).toContainEqual(
           expect.objectContaining({ event_type: 'approval_received' })
         );
       });
@@ -2263,7 +2277,9 @@ describe('CommandHandler', () => {
           expect.objectContaining({
             loop_feedback_given: false,
             loop_user_input: 'Approved',
-          })
+          }),
+          // Audit events ride the CAS transaction (#2146); metadata is the focus here.
+          expect.any(Array)
         );
       });
 
@@ -2341,10 +2357,12 @@ describe('CommandHandler', () => {
 
         await handleCommand(baseConversation, '/workflow approve run-cap LGTM looks good');
 
-        const nodeCompletedCall = mockCreateWorkflowEvent.mock.calls.find(
-          (c: unknown[]) => (c[0] as Record<string, unknown>).event_type === 'node_completed'
-        );
-        expect(nodeCompletedCall?.[0]).toMatchObject({
+        // node_completed rides the CAS transaction now (#2146), not a direct write.
+        const casEvents = mockResolveApprovalGate.mock.calls[0][2] as Array<
+          Record<string, unknown>
+        >;
+        const nodeCompleted = casEvents.find(e => e.event_type === 'node_completed');
+        expect(nodeCompleted).toMatchObject({
           data: { node_output: 'LGTM looks good', approval_decision: 'approved' },
         });
       });
@@ -2373,10 +2391,12 @@ describe('CommandHandler', () => {
 
         await handleCommand(baseConversation, '/workflow approve run-nocap a comment');
 
-        const nodeCompletedCall = mockCreateWorkflowEvent.mock.calls.find(
-          (c: unknown[]) => (c[0] as Record<string, unknown>).event_type === 'node_completed'
-        );
-        expect(nodeCompletedCall?.[0]).toMatchObject({
+        // node_completed rides the CAS transaction now (#2146), not a direct write.
+        const casEvents = mockResolveApprovalGate.mock.calls[0][2] as Array<
+          Record<string, unknown>
+        >;
+        const nodeCompleted = casEvents.find(e => e.event_type === 'node_completed');
+        expect(nodeCompleted).toMatchObject({
           data: { node_output: '', approval_decision: 'approved' },
         });
       });
@@ -2429,19 +2449,30 @@ describe('CommandHandler', () => {
         expect(result.success).toBe(true);
         expect(result.message).toContain('Reworking');
         // Stays 'paused' (no status write) — rework staged on the approval context,
-        // stamped atomically via the CAS (#2075/#2113)
-        expect(mockResolveApprovalGate).toHaveBeenCalledWith('run-reject-1', {
-          approval: {
-            type: 'approval',
-            nodeId: 'review',
-            message: 'Approve the plan?',
-            onRejectPrompt: 'Fix: $REJECTION_REASON',
-            onRejectMaxAttempts: 3,
-            resolved: 'rejected',
+        // stamped atomically via the CAS (#2075/#2113), with the audit event in the
+        // same transaction (#2146)
+        expect(mockResolveApprovalGate).toHaveBeenCalledWith(
+          'run-reject-1',
+          {
+            approval: {
+              type: 'approval',
+              nodeId: 'review',
+              message: 'Approve the plan?',
+              onRejectPrompt: 'Fix: $REJECTION_REASON',
+              onRejectMaxAttempts: 3,
+              resolved: 'rejected',
+            },
+            rejection_reason: 'needs work',
+            rejection_count: 1,
           },
-          rejection_reason: 'needs work',
-          rejection_count: 1,
-        });
+          [
+            {
+              event_type: 'approval_received',
+              step_name: 'review',
+              data: { decision: 'rejected', reason: 'needs work' },
+            },
+          ]
+        );
       });
 
       test('cancels when max attempts reached', async () => {
@@ -2473,8 +2504,15 @@ describe('CommandHandler', () => {
 
         expect(result.success).toBe(true);
         expect(result.message).toContain('max attempts reached');
-        // Terminal reject resolves + cancels atomically (#2113)
-        expect(mockResolveAndCancelApprovalGate).toHaveBeenCalledWith('run-reject-max');
+        // Terminal reject resolves + cancels atomically (#2113); the audit event
+        // rides the same transaction (#2146).
+        expect(mockResolveAndCancelApprovalGate).toHaveBeenCalledWith('run-reject-max', [
+          {
+            event_type: 'approval_received',
+            step_name: 'review',
+            data: { decision: 'rejected', reason: 'bad' },
+          },
+        ]);
         expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
       });
 
@@ -2506,8 +2544,15 @@ describe('CommandHandler', () => {
         );
 
         expect(result.success).toBe(true);
-        // Terminal reject resolves + cancels atomically (#2113)
-        expect(mockResolveAndCancelApprovalGate).toHaveBeenCalledWith('run-reject-plain');
+        // Terminal reject resolves + cancels atomically (#2113); the audit event
+        // rides the same transaction (#2146).
+        expect(mockResolveAndCancelApprovalGate).toHaveBeenCalledWith('run-reject-plain', [
+          {
+            event_type: 'approval_received',
+            step_name: 'gate',
+            data: { decision: 'rejected', reason: 'reason' },
+          },
+        ]);
         expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
       });
     });

--- a/packages/core/src/handlers/command-handler.test.ts
+++ b/packages/core/src/handlers/command-handler.test.ts
@@ -38,6 +38,11 @@ const mockGetWorkflowRun = mock(() => Promise.resolve(null));
 const mockResumeWorkflowRun = mock(() => Promise.resolve({ id: 'run-id', status: 'running' }));
 const mockFailWorkflowRun = mock(() => Promise.resolve());
 const mockUpdateWorkflowRun = mock(() => Promise.resolve());
+// CAS gate resolvers (#2113) — approve/reject stamp the resolution atomically here
+// instead of via updateWorkflowRun. resolveAndCancelApprovalGate is the atomic
+// resolve+cancel for terminal reject outcomes. Default to "won the race".
+const mockResolveApprovalGate = mock(() => Promise.resolve({ resolved: true }));
+const mockResolveAndCancelApprovalGate = mock(() => Promise.resolve({ resolved: true }));
 
 // Workflow events database mocks
 const mockCreateWorkflowEvent = mock(() => Promise.resolve());
@@ -92,6 +97,8 @@ mock.module('../db/workflows', () => ({
   resumeWorkflowRun: mockResumeWorkflowRun,
   failWorkflowRun: mockFailWorkflowRun,
   updateWorkflowRun: mockUpdateWorkflowRun,
+  resolveApprovalGate: mockResolveApprovalGate,
+  resolveAndCancelApprovalGate: mockResolveAndCancelApprovalGate,
 }));
 
 mock.module('../db/workflow-events', () => ({
@@ -245,6 +252,8 @@ function clearAllMocks(): void {
   mockResumeWorkflowRun.mockClear();
   mockFailWorkflowRun.mockClear();
   mockUpdateWorkflowRun.mockClear();
+  mockResolveApprovalGate.mockClear();
+  mockResolveAndCancelApprovalGate.mockClear();
   mockCreateWorkflowEvent.mockClear();
   mockDeleteWorkflowNodeSessions.mockClear();
   // Isolation mocks
@@ -2166,20 +2175,19 @@ describe('CommandHandler', () => {
         expect(result.success).toBe(true);
         expect(result.message).toContain('loop input received');
         expect(result.message).toContain('my-loop-wf');
-        // Stays 'paused' (no status write) — resolution rides the approval context (#2075)
-        expect(mockUpdateWorkflowRun).toHaveBeenCalledWith('run-123', {
-          metadata: {
-            approval: {
-              type: 'interactive_loop',
-              nodeId: 'refine',
-              iteration: 2,
-              message: 'Review the output',
-              resolved: 'approved',
-            },
-            loop_user_input: 'Add error handling',
-            // A real comment counts as feedback ⇒ the resumed loop iterates (#2074)
-            loop_feedback_given: true,
+        // Stays 'paused' (no status write) — resolution rides the approval context,
+        // stamped atomically via the CAS (#2075/#2113)
+        expect(mockResolveApprovalGate).toHaveBeenCalledWith('run-123', {
+          approval: {
+            type: 'interactive_loop',
+            nodeId: 'refine',
+            iteration: 2,
+            message: 'Review the output',
+            resolved: 'approved',
           },
+          loop_user_input: 'Add error handling',
+          // A real comment counts as feedback ⇒ the resumed loop iterates (#2074)
+          loop_feedback_given: true,
         });
       });
 
@@ -2250,12 +2258,13 @@ describe('CommandHandler', () => {
         // The chat handler must NOT pre-default the comment to 'Approved' —
         // loop_feedback_given derives from the raw comment, and a masked
         // no-feedback would make every chat approve iterate instead of finalize.
-        expect(mockUpdateWorkflowRun).toHaveBeenCalledWith('run-bare', {
-          metadata: expect.objectContaining({
+        expect(mockResolveApprovalGate).toHaveBeenCalledWith(
+          'run-bare',
+          expect.objectContaining({
             loop_feedback_given: false,
             loop_user_input: 'Approved',
-          }),
-        });
+          })
+        );
       });
 
       test('returns error when run is not paused', async () => {
@@ -2419,20 +2428,19 @@ describe('CommandHandler', () => {
 
         expect(result.success).toBe(true);
         expect(result.message).toContain('Reworking');
-        // Stays 'paused' (no status write) — rework staged on the approval context (#2075)
-        expect(mockUpdateWorkflowRun).toHaveBeenCalledWith('run-reject-1', {
-          metadata: {
-            approval: {
-              type: 'approval',
-              nodeId: 'review',
-              message: 'Approve the plan?',
-              onRejectPrompt: 'Fix: $REJECTION_REASON',
-              onRejectMaxAttempts: 3,
-              resolved: 'rejected',
-            },
-            rejection_reason: 'needs work',
-            rejection_count: 1,
+        // Stays 'paused' (no status write) — rework staged on the approval context,
+        // stamped atomically via the CAS (#2075/#2113)
+        expect(mockResolveApprovalGate).toHaveBeenCalledWith('run-reject-1', {
+          approval: {
+            type: 'approval',
+            nodeId: 'review',
+            message: 'Approve the plan?',
+            onRejectPrompt: 'Fix: $REJECTION_REASON',
+            onRejectMaxAttempts: 3,
+            resolved: 'rejected',
           },
+          rejection_reason: 'needs work',
+          rejection_count: 1,
         });
       });
 
@@ -2465,7 +2473,9 @@ describe('CommandHandler', () => {
 
         expect(result.success).toBe(true);
         expect(result.message).toContain('max attempts reached');
-        expect(mockCancelWorkflowRun).toHaveBeenCalledWith('run-reject-max');
+        // Terminal reject resolves + cancels atomically (#2113)
+        expect(mockResolveAndCancelApprovalGate).toHaveBeenCalledWith('run-reject-max');
+        expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
       });
 
       test('cancels immediately without on_reject', async () => {
@@ -2496,7 +2506,9 @@ describe('CommandHandler', () => {
         );
 
         expect(result.success).toBe(true);
-        expect(mockCancelWorkflowRun).toHaveBeenCalledWith('run-reject-plain');
+        // Terminal reject resolves + cancels atomically (#2113)
+        expect(mockResolveAndCancelApprovalGate).toHaveBeenCalledWith('run-reject-plain');
+        expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
       });
     });
   });

--- a/packages/core/src/operations/workflow-operations.test.ts
+++ b/packages/core/src/operations/workflow-operations.test.ts
@@ -110,26 +110,39 @@ describe('approveWorkflow', () => {
     expect(result.workflowName).toBe('test-workflow');
     expect(result.workingPath).toBe('/workspace/worktree');
 
-    // node_completed + approval_received = 2 events
-    expect(mockCreateWorkflowEvent).toHaveBeenCalledTimes(2);
-    const firstCall = mockCreateWorkflowEvent.mock.calls[0][0] as Record<string, unknown>;
-    expect(firstCall.event_type).toBe('node_completed');
-    const secondCall = mockCreateWorkflowEvent.mock.calls[1][0] as Record<string, unknown>;
-    expect(secondCall.event_type).toBe('approval_received');
+    // Operations no longer writes events directly — node_completed + approval_received
+    // ride the CAS transaction as its 3rd argument (#2146).
+    expect(mockCreateWorkflowEvent).not.toHaveBeenCalled();
 
     // Stays 'paused' (no status write) — resolution recorded atomically via the
-    // CAS on the approval context + rejection state cleared (#2075/#2113)
-    expect(mockResolveApprovalGate).toHaveBeenCalledWith('run-1', {
-      approval: {
-        nodeId: 'review',
-        message: 'Please review',
-        type: 'approval',
-        resolved: 'approved',
+    // CAS on the approval context + rejection state cleared (#2075/#2113), with the
+    // audit events written in the same transaction (#2146).
+    expect(mockResolveApprovalGate).toHaveBeenCalledWith(
+      'run-1',
+      {
+        approval: {
+          nodeId: 'review',
+          message: 'Please review',
+          type: 'approval',
+          resolved: 'approved',
+        },
+        approval_response: 'approved',
+        rejection_reason: '',
+        rejection_count: 0,
       },
-      approval_response: 'approved',
-      rejection_reason: '',
-      rejection_count: 0,
-    });
+      [
+        {
+          event_type: 'node_completed',
+          step_name: 'review',
+          data: { node_output: '', approval_decision: 'approved' },
+        },
+        {
+          event_type: 'approval_received',
+          step_name: 'review',
+          data: { decision: 'approved', comment: 'Looks good' },
+        },
+      ]
+    );
 
     // Anonymous telemetry: binary resolution captured exactly once
     expect(mockCaptureApprovalResolved).toHaveBeenCalledTimes(1);
@@ -153,25 +166,38 @@ describe('approveWorkflow', () => {
 
     expect(result.type).toBe('interactive_loop');
 
-    // Only approval_received — NOT node_completed
-    expect(mockCreateWorkflowEvent).toHaveBeenCalledTimes(1);
-    const call = mockCreateWorkflowEvent.mock.calls[0][0] as Record<string, unknown>;
-    expect(call.event_type).toBe('approval_received');
+    // Operations no longer writes events directly.
+    expect(mockCreateWorkflowEvent).not.toHaveBeenCalled();
+    // Only approval_received rides the CAS — NOT node_completed (the executor
+    // writes that on the real completion signal / at resume).
+    const casEvents = mockResolveApprovalGate.mock.calls[0][2] as Array<Record<string, unknown>>;
+    expect(casEvents).toHaveLength(1);
+    expect(casEvents[0].event_type).toBe('approval_received');
 
     // Stays 'paused' (no status write) — stores loop_user_input and marks the
     // approval context resolved, preserving iteration for startIteration detection
-    expect(mockResolveApprovalGate).toHaveBeenCalledWith('run-1', {
-      approval: {
-        nodeId: 'iterate',
-        message: 'Provide feedback',
-        type: 'interactive_loop',
-        iteration: 2,
-        resolved: 'approved',
+    expect(mockResolveApprovalGate).toHaveBeenCalledWith(
+      'run-1',
+      {
+        approval: {
+          nodeId: 'iterate',
+          message: 'Provide feedback',
+          type: 'interactive_loop',
+          iteration: 2,
+          resolved: 'approved',
+        },
+        loop_user_input: 'fix the tests',
+        // Real feedback ⇒ the resumed loop iterates (#2074)
+        loop_feedback_given: true,
       },
-      loop_user_input: 'fix the tests',
-      // Real feedback ⇒ the resumed loop iterates (#2074)
-      loop_feedback_given: true,
-    });
+      [
+        {
+          event_type: 'approval_received',
+          step_name: 'iterate',
+          data: { decision: 'approved', comment: 'fix the tests', iteration: 2 },
+        },
+      ]
+    );
   });
 
   test('interactive_loop bare approve — loop_feedback_given false, loop_user_input defaults (#2074)', async () => {
@@ -191,21 +217,31 @@ describe('approveWorkflow', () => {
 
     await approveWorkflow('run-1');
 
-    expect(mockResolveApprovalGate).toHaveBeenCalledWith('run-1', {
-      approval: {
-        nodeId: 'iterate',
-        message: 'Provide feedback',
-        type: 'interactive_loop',
-        iteration: 1,
-        completionSignaled: true,
-        signaledOutput: 'REPORT',
-        resolved: 'approved',
+    expect(mockResolveApprovalGate).toHaveBeenCalledWith(
+      'run-1',
+      {
+        approval: {
+          nodeId: 'iterate',
+          message: 'Provide feedback',
+          type: 'interactive_loop',
+          iteration: 1,
+          completionSignaled: true,
+          signaledOutput: 'REPORT',
+          resolved: 'approved',
+        },
+        // The recorded comment still defaults to 'Approved' (events/$LOOP_USER_INPUT
+        // for non-signaled iterate paths) — only the boolean sees the raw undefined.
+        loop_user_input: 'Approved',
+        loop_feedback_given: false,
       },
-      // The recorded comment still defaults to 'Approved' (events/$LOOP_USER_INPUT
-      // for non-signaled iterate paths) — only the boolean sees the raw undefined.
-      loop_user_input: 'Approved',
-      loop_feedback_given: false,
-    });
+      [
+        {
+          event_type: 'approval_received',
+          step_name: 'iterate',
+          data: { decision: 'approved', comment: 'Approved', iteration: 1 },
+        },
+      ]
+    );
   });
 
   test('interactive_loop whitespace-only comment counts as no feedback (#2074)', async () => {
@@ -284,8 +320,10 @@ describe('approveWorkflow', () => {
 
     await approveWorkflow('run-1', 'My review notes');
 
-    const nodeCompletedCall = mockCreateWorkflowEvent.mock.calls[0][0] as Record<string, unknown>;
-    expect((nodeCompletedCall.data as Record<string, unknown>).node_output).toBe('My review notes');
+    // The node_output rides the CAS events (#2146), not a separate event write.
+    const casEvents = mockResolveApprovalGate.mock.calls[0][2] as Array<Record<string, unknown>>;
+    const nodeCompleted = casEvents.find(e => e.event_type === 'node_completed');
+    expect((nodeCompleted?.data as Record<string, unknown>).node_output).toBe('My review notes');
   });
 
   test('throws on non-paused run', async () => {
@@ -340,18 +378,29 @@ describe('rejectWorkflow', () => {
     expect(result.workflowName).toBe('test-workflow');
     expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
     // Stays 'paused' (no status write) — rejection staged atomically via the CAS
-    // on the approval context (#2075/#2113)
-    expect(mockResolveApprovalGate).toHaveBeenCalledWith('run-1', {
-      approval: {
-        nodeId: 'review',
-        message: 'Review',
-        onRejectPrompt: 'Fix: $REJECTION_REASON',
-        onRejectMaxAttempts: 3,
-        resolved: 'rejected',
+    // on the approval context (#2075/#2113), with the audit event in the same
+    // transaction (#2146)
+    expect(mockResolveApprovalGate).toHaveBeenCalledWith(
+      'run-1',
+      {
+        approval: {
+          nodeId: 'review',
+          message: 'Review',
+          onRejectPrompt: 'Fix: $REJECTION_REASON',
+          onRejectMaxAttempts: 3,
+          resolved: 'rejected',
+        },
+        rejection_reason: 'needs more tests',
+        rejection_count: 1,
       },
-      rejection_reason: 'needs more tests',
-      rejection_count: 1,
-    });
+      [
+        {
+          event_type: 'approval_received',
+          step_name: 'review',
+          data: { decision: 'rejected', reason: 'needs more tests' },
+        },
+      ]
+    );
 
     expect(mockCaptureApprovalResolved).toHaveBeenCalledTimes(1);
     expect(mockCaptureApprovalResolved).toHaveBeenCalledWith({ resolution: 'rejected' });
@@ -426,8 +475,15 @@ describe('rejectWorkflow', () => {
     expect(result.cancelled).toBe(true);
     expect(result.maxAttemptsReached).toBe(true);
     // Terminal reject resolves + cancels in ONE atomic CAS (#2113) — never a
-    // separate cancelWorkflowRun that could fail and strand the run.
-    expect(mockResolveAndCancelApprovalGate).toHaveBeenCalledWith('run-1');
+    // separate cancelWorkflowRun that could fail and strand the run. The audit
+    // event rides the same transaction (#2146).
+    expect(mockResolveAndCancelApprovalGate).toHaveBeenCalledWith('run-1', [
+      {
+        event_type: 'approval_received',
+        step_name: 'review',
+        data: { decision: 'rejected', reason: 'still broken' },
+      },
+    ]);
     expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
   });
 
@@ -438,7 +494,13 @@ describe('rejectWorkflow', () => {
 
     expect(result.cancelled).toBe(true);
     expect(result.maxAttemptsReached).toBe(false);
-    expect(mockResolveAndCancelApprovalGate).toHaveBeenCalledWith('run-1');
+    expect(mockResolveAndCancelApprovalGate).toHaveBeenCalledWith('run-1', [
+      {
+        event_type: 'approval_received',
+        step_name: 'review',
+        data: { decision: 'rejected', reason: 'no good' },
+      },
+    ]);
     expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/operations/workflow-operations.test.ts
+++ b/packages/core/src/operations/workflow-operations.test.ts
@@ -8,12 +8,20 @@ const mockGetWorkflowRun = mock(() => Promise.resolve(null));
 const mockListWorkflowRuns = mock(() => Promise.resolve([]));
 const mockUpdateWorkflowRun = mock(() => Promise.resolve());
 const mockCancelWorkflowRun = mock(() => Promise.resolve());
+// CAS gate resolvers (#2113): default to "won the race". Tests that simulate a
+// concurrent loser override with mockResolvedValueOnce({ resolved: false }).
+// resolveApprovalGate = stay-paused resolution (approve, reject stage-rework);
+// resolveAndCancelApprovalGate = atomic resolve + cancel (reject terminal paths).
+const mockResolveApprovalGate = mock(() => Promise.resolve({ resolved: true }));
+const mockResolveAndCancelApprovalGate = mock(() => Promise.resolve({ resolved: true }));
 
 mock.module('../db/workflows', () => ({
   getWorkflowRun: mockGetWorkflowRun,
   listWorkflowRuns: mockListWorkflowRuns,
   updateWorkflowRun: mockUpdateWorkflowRun,
   cancelWorkflowRun: mockCancelWorkflowRun,
+  resolveApprovalGate: mockResolveApprovalGate,
+  resolveAndCancelApprovalGate: mockResolveAndCancelApprovalGate,
 }));
 
 const mockCreateWorkflowEvent = mock(() => Promise.resolve());
@@ -90,6 +98,7 @@ describe('approveWorkflow', () => {
     mockGetWorkflowRun.mockClear();
     mockCreateWorkflowEvent.mockClear();
     mockUpdateWorkflowRun.mockClear();
+    mockResolveApprovalGate.mockClear();
   });
 
   test('approves standard approval gate — writes node_completed + approval_received', async () => {
@@ -108,20 +117,18 @@ describe('approveWorkflow', () => {
     const secondCall = mockCreateWorkflowEvent.mock.calls[1][0] as Record<string, unknown>;
     expect(secondCall.event_type).toBe('approval_received');
 
-    // Stays 'paused' (no status write) — resolution recorded on the approval
-    // context + rejection state cleared (#2075)
-    expect(mockUpdateWorkflowRun).toHaveBeenCalledWith('run-1', {
-      metadata: {
-        approval: {
-          nodeId: 'review',
-          message: 'Please review',
-          type: 'approval',
-          resolved: 'approved',
-        },
-        approval_response: 'approved',
-        rejection_reason: '',
-        rejection_count: 0,
+    // Stays 'paused' (no status write) — resolution recorded atomically via the
+    // CAS on the approval context + rejection state cleared (#2075/#2113)
+    expect(mockResolveApprovalGate).toHaveBeenCalledWith('run-1', {
+      approval: {
+        nodeId: 'review',
+        message: 'Please review',
+        type: 'approval',
+        resolved: 'approved',
       },
+      approval_response: 'approved',
+      rejection_reason: '',
+      rejection_count: 0,
     });
 
     // Anonymous telemetry: binary resolution captured exactly once
@@ -153,19 +160,17 @@ describe('approveWorkflow', () => {
 
     // Stays 'paused' (no status write) — stores loop_user_input and marks the
     // approval context resolved, preserving iteration for startIteration detection
-    expect(mockUpdateWorkflowRun).toHaveBeenCalledWith('run-1', {
-      metadata: {
-        approval: {
-          nodeId: 'iterate',
-          message: 'Provide feedback',
-          type: 'interactive_loop',
-          iteration: 2,
-          resolved: 'approved',
-        },
-        loop_user_input: 'fix the tests',
-        // Real feedback ⇒ the resumed loop iterates (#2074)
-        loop_feedback_given: true,
+    expect(mockResolveApprovalGate).toHaveBeenCalledWith('run-1', {
+      approval: {
+        nodeId: 'iterate',
+        message: 'Provide feedback',
+        type: 'interactive_loop',
+        iteration: 2,
+        resolved: 'approved',
       },
+      loop_user_input: 'fix the tests',
+      // Real feedback ⇒ the resumed loop iterates (#2074)
+      loop_feedback_given: true,
     });
   });
 
@@ -186,22 +191,20 @@ describe('approveWorkflow', () => {
 
     await approveWorkflow('run-1');
 
-    expect(mockUpdateWorkflowRun).toHaveBeenCalledWith('run-1', {
-      metadata: {
-        approval: {
-          nodeId: 'iterate',
-          message: 'Provide feedback',
-          type: 'interactive_loop',
-          iteration: 1,
-          completionSignaled: true,
-          signaledOutput: 'REPORT',
-          resolved: 'approved',
-        },
-        // The recorded comment still defaults to 'Approved' (events/$LOOP_USER_INPUT
-        // for non-signaled iterate paths) — only the boolean sees the raw undefined.
-        loop_user_input: 'Approved',
-        loop_feedback_given: false,
+    expect(mockResolveApprovalGate).toHaveBeenCalledWith('run-1', {
+      approval: {
+        nodeId: 'iterate',
+        message: 'Provide feedback',
+        type: 'interactive_loop',
+        iteration: 1,
+        completionSignaled: true,
+        signaledOutput: 'REPORT',
+        resolved: 'approved',
       },
+      // The recorded comment still defaults to 'Approved' (events/$LOOP_USER_INPUT
+      // for non-signaled iterate paths) — only the boolean sees the raw undefined.
+      loop_user_input: 'Approved',
+      loop_feedback_given: false,
     });
   });
 
@@ -220,13 +223,11 @@ describe('approveWorkflow', () => {
 
     await approveWorkflow('run-1', '   ');
 
-    const updateArg = mockUpdateWorkflowRun.mock.calls[0][1] as {
-      metadata: Record<string, unknown>;
-    };
-    expect(updateArg.metadata.loop_feedback_given).toBe(false);
+    const casMetadata = mockResolveApprovalGate.mock.calls[0][1] as Record<string, unknown>;
+    expect(casMetadata.loop_feedback_given).toBe(false);
     // Whitespace-only also gets the documented recorded-comment default —
     // '   ' must never be stored verbatim as $LOOP_USER_INPUT.
-    expect(updateArg.metadata.loop_user_input).toBe('Approved');
+    expect(casMetadata.loop_user_input).toBe('Approved');
   });
 
   test('throws on already-resolved gate (double-approve guard)', async () => {
@@ -245,10 +246,27 @@ describe('approveWorkflow', () => {
     await expect(approveWorkflow('run-1')).rejects.toThrow(
       'already approved and is awaiting resume'
     );
-    // No duplicate events / telemetry / metadata writes
+    // Fast-path: the in-memory read blocks before any CAS / events / telemetry
+    expect(mockResolveApprovalGate).not.toHaveBeenCalled();
     expect(mockCreateWorkflowEvent).not.toHaveBeenCalled();
     expect(mockCaptureApprovalResolved).not.toHaveBeenCalled();
     expect(mockUpdateWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  test('concurrent loser (CAS miss) writes NO events or telemetry (#2113)', async () => {
+    // Both callers read an UNRESOLVED gate (fast-path passes), but only one wins
+    // the atomic CAS. The loser must not duplicate events/telemetry.
+    mockGetWorkflowRun.mockResolvedValueOnce(makePausedRun());
+    mockResolveApprovalGate.mockResolvedValueOnce({ resolved: false });
+
+    await expect(approveWorkflow('run-1', 'ship it')).rejects.toThrow(
+      'already resolved and is awaiting resume'
+    );
+
+    // The CAS was attempted (unlike the fast-path guard) but lost — no side effects.
+    expect(mockResolveApprovalGate).toHaveBeenCalledTimes(1);
+    expect(mockCreateWorkflowEvent).not.toHaveBeenCalled();
+    expect(mockCaptureApprovalResolved).not.toHaveBeenCalled();
   });
 
   test('approves with captureResponse — stores comment as node output', async () => {
@@ -298,6 +316,8 @@ describe('rejectWorkflow', () => {
     mockCreateWorkflowEvent.mockClear();
     mockUpdateWorkflowRun.mockClear();
     mockCancelWorkflowRun.mockClear();
+    mockResolveApprovalGate.mockClear();
+    mockResolveAndCancelApprovalGate.mockClear();
   });
 
   test('rejects with onRejectPrompt under max attempts — stays paused with staged rework', async () => {
@@ -319,19 +339,18 @@ describe('rejectWorkflow', () => {
     expect(result.cancelled).toBe(false);
     expect(result.workflowName).toBe('test-workflow');
     expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
-    // Stays 'paused' (no status write) — rejection staged on the approval context (#2075)
-    expect(mockUpdateWorkflowRun).toHaveBeenCalledWith('run-1', {
-      metadata: {
-        approval: {
-          nodeId: 'review',
-          message: 'Review',
-          onRejectPrompt: 'Fix: $REJECTION_REASON',
-          onRejectMaxAttempts: 3,
-          resolved: 'rejected',
-        },
-        rejection_reason: 'needs more tests',
-        rejection_count: 1,
+    // Stays 'paused' (no status write) — rejection staged atomically via the CAS
+    // on the approval context (#2075/#2113)
+    expect(mockResolveApprovalGate).toHaveBeenCalledWith('run-1', {
+      approval: {
+        nodeId: 'review',
+        message: 'Review',
+        onRejectPrompt: 'Fix: $REJECTION_REASON',
+        onRejectMaxAttempts: 3,
+        resolved: 'rejected',
       },
+      rejection_reason: 'needs more tests',
+      rejection_count: 1,
     });
 
     expect(mockCaptureApprovalResolved).toHaveBeenCalledTimes(1);
@@ -355,9 +374,36 @@ describe('rejectWorkflow', () => {
     await expect(rejectWorkflow('run-1', 'again')).rejects.toThrow(
       'already rejected and is awaiting resume'
     );
+    // Fast-path: the in-memory read blocks before any CAS / events / cancel
+    expect(mockResolveApprovalGate).not.toHaveBeenCalled();
     expect(mockCreateWorkflowEvent).not.toHaveBeenCalled();
     expect(mockCaptureApprovalResolved).not.toHaveBeenCalled();
     expect(mockUpdateWorkflowRun).not.toHaveBeenCalled();
+    expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  test('concurrent loser (CAS miss) writes NO events, telemetry, or cancel (#2113)', async () => {
+    const run = makePausedRun({
+      metadata: {
+        approval: {
+          nodeId: 'review',
+          message: 'Review',
+          onRejectPrompt: 'Fix: $REJECTION_REASON',
+        },
+        rejection_count: 0,
+      },
+    });
+    mockGetWorkflowRun.mockResolvedValueOnce(run);
+    // Fast-path passes (gate reads unresolved) but the atomic CAS is lost.
+    mockResolveApprovalGate.mockResolvedValueOnce({ resolved: false });
+
+    await expect(rejectWorkflow('run-1', 'needs work')).rejects.toThrow(
+      'already resolved and is awaiting resume'
+    );
+
+    expect(mockResolveApprovalGate).toHaveBeenCalledTimes(1);
+    expect(mockCreateWorkflowEvent).not.toHaveBeenCalled();
+    expect(mockCaptureApprovalResolved).not.toHaveBeenCalled();
     expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
   });
 
@@ -378,7 +424,11 @@ describe('rejectWorkflow', () => {
     const result = await rejectWorkflow('run-1', 'still broken');
 
     expect(result.cancelled).toBe(true);
-    expect(mockCancelWorkflowRun).toHaveBeenCalledWith('run-1');
+    expect(result.maxAttemptsReached).toBe(true);
+    // Terminal reject resolves + cancels in ONE atomic CAS (#2113) — never a
+    // separate cancelWorkflowRun that could fail and strand the run.
+    expect(mockResolveAndCancelApprovalGate).toHaveBeenCalledWith('run-1');
+    expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
   });
 
   test('rejects without onRejectPrompt — cancels immediately', async () => {
@@ -387,7 +437,23 @@ describe('rejectWorkflow', () => {
     const result = await rejectWorkflow('run-1', 'no good');
 
     expect(result.cancelled).toBe(true);
-    expect(mockCancelWorkflowRun).toHaveBeenCalledWith('run-1');
+    expect(result.maxAttemptsReached).toBe(false);
+    expect(mockResolveAndCancelApprovalGate).toHaveBeenCalledWith('run-1');
+    expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  test('terminal reject concurrent loser (CAS miss) writes NO event or telemetry (#2113)', async () => {
+    mockGetWorkflowRun.mockResolvedValueOnce(makePausedRun());
+    // No onRejectPrompt ⇒ the atomic resolve-and-cancel CAS is the guard.
+    mockResolveAndCancelApprovalGate.mockResolvedValueOnce({ resolved: false });
+
+    await expect(rejectWorkflow('run-1', 'no good')).rejects.toThrow(
+      'already resolved and is awaiting resume'
+    );
+
+    expect(mockResolveAndCancelApprovalGate).toHaveBeenCalledTimes(1);
+    expect(mockCreateWorkflowEvent).not.toHaveBeenCalled();
+    expect(mockCaptureApprovalResolved).not.toHaveBeenCalled();
   });
 
   test('throws on non-paused run', async () => {

--- a/packages/core/src/operations/workflow-operations.ts
+++ b/packages/core/src/operations/workflow-operations.ts
@@ -16,7 +16,6 @@ import type {
   LoopGateRunMetadata,
 } from '@archon/workflows/schemas/workflow-run';
 import * as workflowDb from '../db/workflows';
-import * as workflowEventDb from '../db/workflow-events';
 import * as workflowNodeSessionDb from '../db/workflow-node-sessions';
 
 // Lazy logger — NEVER at module scope
@@ -176,12 +175,14 @@ export async function approveWorkflow(
   const approvalComment = comment !== undefined && comment.trim().length > 0 ? comment : 'Approved';
   const isInteractiveLoop = approval.type === 'interactive_loop';
 
-  // Build the resolution metadata for this gate type. IMPORTANT: metadata is
-  // MERGED (not replaced) and the approval context is rewritten whole (spread +
-  // resolved) so it survives intact for the resumed executor's startIteration
-  // detection. Computed up front because the CAS below stamps it atomically as
-  // the double-resolution guard.
+  // Build the resolution metadata AND the audit events for this gate type.
+  // IMPORTANT: metadata is MERGED (not replaced) and the approval context is
+  // rewritten whole (spread + resolved) so it survives intact for the resumed
+  // executor's startIteration detection. Both are handed to the CAS below, which
+  // stamps the metadata and writes the events in ONE transaction — the atomic
+  // double-resolution guard (#2113) and the atomic audit trail (#2146).
   let metadataPayload: Record<string, unknown>;
+  let events: workflowDb.GateResolutionEvent[];
   if (isInteractiveLoop) {
     // Finalize-vs-iterate discriminator (#2074): derived from the RAW comment,
     // not approvalComment (which defaults to 'Approved') — a bare approve on a
@@ -196,6 +197,19 @@ export async function approveWorkflow(
       loop_feedback_given: feedbackProvided,
     };
     metadataPayload = { approval: { ...approval, resolved: 'approved' }, ...gateRunMetadata };
+    // Interactive loop gate — user input already stored in metadata for the next
+    // iteration. Note: node_completed is NOT written here. The executor writes it
+    // when the AI emits the completion signal (meaning the user actually approved)
+    // — or, for a signal-bearing gate approved without feedback, at resume time
+    // from the persisted signaledOutput (#2074). Writing it here would cause the
+    // resume to skip the loop node entirely.
+    events = [
+      {
+        event_type: 'approval_received',
+        step_name: approval.nodeId,
+        data: { decision: 'approved', comment: approvalComment, iteration: approval.iteration },
+      },
+    ];
   } else {
     metadataPayload = {
       approval: { ...approval, resolved: 'approved' },
@@ -203,76 +217,44 @@ export async function approveWorkflow(
       rejection_reason: '',
       rejection_count: 0,
     };
+    const nodeOutput = approval.captureResponse === true ? approvalComment : '';
+    events = [
+      {
+        event_type: 'node_completed',
+        step_name: approval.nodeId,
+        data: { node_output: nodeOutput, approval_decision: 'approved' },
+      },
+      {
+        event_type: 'approval_received',
+        step_name: approval.nodeId,
+        data: { decision: 'approved', comment: approvalComment },
+      },
+    ];
   }
 
-  // Compare-and-swap: stamp the resolution ONLY while the gate is still open.
-  // This atomic UPDATE — not the isGateResolved read above — is the real arbiter,
-  // so a concurrent second approve loses here (resolved=false) and throws BEFORE
-  // any events/telemetry are written, eliminating the duplicates (#2113). The run
-  // stays 'paused'; resume is guarded independently by resumeWorkflowRun's CAS.
-  const { resolved: won } = await workflowDb.resolveApprovalGate(runId, metadataPayload);
+  // Compare-and-swap: stamp the resolution AND write the audit events ONLY while
+  // the gate is still open, all in one transaction. This atomic UPDATE — not the
+  // isGateResolved read above — is the real arbiter, so a concurrent second
+  // approve loses here (resolved=false) and throws BEFORE any events/telemetry
+  // land, eliminating the duplicates (#2113); folding the events into the same
+  // transaction means a failed event write rolls the resolution back so a retry
+  // can win the still-open gate (#2146). The run stays 'paused'; resume is
+  // guarded independently by resumeWorkflowRun's CAS.
+  const { resolved: won } = await workflowDb.resolveApprovalGate(runId, metadataPayload, events);
   if (!won) {
     throw new Error(`Workflow run ${runId} was already resolved and is awaiting resume.`);
   }
 
-  // Won the CAS — record the audit events + telemetry (metadata already staged).
-  try {
-    // Interactive loop gate — user input already stored in metadata for the next
-    // iteration. Note: node_completed is NOT written here. The executor writes it
-    // when the AI emits the completion signal (meaning the user actually approved)
-    // — or, for a signal-bearing gate approved without feedback, at resume time
-    // from the persisted signaledOutput (#2074). Writing it here would cause the
-    // resume to skip the loop node entirely.
-    if (isInteractiveLoop) {
-      await workflowEventDb.createWorkflowEvent({
-        workflow_run_id: runId,
-        event_type: 'approval_received',
-        step_name: approval.nodeId,
-        data: { decision: 'approved', comment: approvalComment, iteration: approval.iteration },
-      });
-      // Anonymous telemetry: binary resolution only — no ids/comments/names.
-      captureApprovalResolved({ resolution: 'approved' });
-      return {
-        workflowName: run.workflow_name,
-        workingPath: run.working_path,
-        userMessage: run.user_message,
-        codebaseId: run.codebase_id,
-        conversationId: run.conversation_id,
-        type: 'interactive_loop',
-      };
-    }
-
-    // Standard approval node path
-    const nodeOutput = approval.captureResponse === true ? approvalComment : '';
-    await workflowEventDb.createWorkflowEvent({
-      workflow_run_id: runId,
-      event_type: 'node_completed',
-      step_name: approval.nodeId,
-      data: { node_output: nodeOutput, approval_decision: 'approved' },
-    });
-    await workflowEventDb.createWorkflowEvent({
-      workflow_run_id: runId,
-      event_type: 'approval_received',
-      step_name: approval.nodeId,
-      data: { decision: 'approved', comment: approvalComment },
-    });
-    // Anonymous telemetry: binary resolution only — no ids/comments/names.
-    captureApprovalResolved({ resolution: 'approved' });
-  } catch (error) {
-    const err = error as Error;
-    getLog().error(
-      { err, errorType: err.constructor.name, runId },
-      'operations.workflow_approve_failed'
-    );
-    throw new Error(`Failed to approve workflow run ${runId}: ${err.message}`);
-  }
+  // Won the CAS — resolution + audit events already committed atomically.
+  // Anonymous telemetry: binary resolution only — no ids/comments/names.
+  captureApprovalResolved({ resolution: 'approved' });
   return {
     workflowName: run.workflow_name,
     workingPath: run.working_path,
     userMessage: run.user_message,
     codebaseId: run.codebase_id,
     conversationId: run.conversation_id,
-    type: 'approval_gate',
+    type: isInteractiveLoop ? 'interactive_loop' : 'approval_gate',
   };
 }
 
@@ -315,6 +297,14 @@ export async function rejectWorkflow(
   // set AND we're under the attempt cap; every other case cancels the run.
   const willStageRework = onRejectConfigured && !maxAttemptsReached;
 
+  // The audit event is identical for all three reject outcomes; the CAS writes it
+  // in the SAME transaction as the resolution (#2146).
+  const rejectionEvent: workflowDb.GateResolutionEvent = {
+    event_type: 'approval_received',
+    step_name: approval?.nodeId ?? 'unknown',
+    data: { decision: 'rejected', reason: rejectReason },
+  };
+
   // Compare-and-swap resolution guard — a concurrent second reject loses here
   // (resolved=false) and throws BEFORE any events, so the gate events can't
   // duplicate (#2113). Stage-rework stamps the resolution + rework metadata and
@@ -323,37 +313,27 @@ export async function rejectWorkflow(
   // context exactly as the 'unknown' nodeId fallback below). The terminal outcomes
   // flip paused→'cancelled' in a SINGLE atomic UPDATE, so there is never a
   // resolved-but-not-cancelled state that a failed second write could strand
-  // (which a reject retry could not self-heal past the guard above).
+  // (which a reject retry could not self-heal past the guard above). Either way
+  // the audit event rides the same transaction, so a failed event write rolls the
+  // resolution/cancellation back rather than losing the audit trail (#2146).
   const { resolved: won } = willStageRework
-    ? await workflowDb.resolveApprovalGate(runId, {
-        approval: { ...approval, resolved: 'rejected' },
-        rejection_reason: rejectReason,
-        rejection_count: currentCount + 1,
-      })
-    : await workflowDb.resolveAndCancelApprovalGate(runId);
+    ? await workflowDb.resolveApprovalGate(
+        runId,
+        {
+          approval: { ...approval, resolved: 'rejected' },
+          rejection_reason: rejectReason,
+          rejection_count: currentCount + 1,
+        },
+        [rejectionEvent]
+      )
+    : await workflowDb.resolveAndCancelApprovalGate(runId, [rejectionEvent]);
   if (!won) {
     throw new Error(`Workflow run ${runId} was already resolved and is awaiting resume.`);
   }
 
-  // Won the CAS — record the audit event + telemetry (resolution/status already
-  // committed atomically above, identically for all three outcomes).
-  try {
-    await workflowEventDb.createWorkflowEvent({
-      workflow_run_id: runId,
-      event_type: 'approval_received',
-      step_name: approval?.nodeId ?? 'unknown',
-      data: { decision: 'rejected', reason: rejectReason },
-    });
-    // Anonymous telemetry: binary resolution only — no ids/reasons/names.
-    captureApprovalResolved({ resolution: 'rejected' });
-  } catch (error) {
-    const err = error as Error;
-    getLog().error(
-      { err, errorType: err.constructor.name, runId },
-      'operations.workflow_reject_failed'
-    );
-    throw new Error(`Failed to reject workflow run ${runId}: ${err.message}`);
-  }
+  // Won the CAS — resolution/status + audit event already committed atomically.
+  // Anonymous telemetry: binary resolution only — no ids/reasons/names.
+  captureApprovalResolved({ resolution: 'rejected' });
 
   return {
     workflowName: run.workflow_name,

--- a/packages/core/src/operations/workflow-operations.ts
+++ b/packages/core/src/operations/workflow-operations.ts
@@ -160,9 +160,11 @@ export async function approveWorkflow(
     throw new Error('Workflow run is paused but missing approval context.');
   }
   if (isGateResolved(approval)) {
-    // The run stays 'paused' after a resolution, so the status check alone no
-    // longer blocks a second approve — this guard does (double events, double
-    // telemetry). The resume CAS independently guards double-resume.
+    // Fast-path friendly error for the common (sequential) case. The run stays
+    // 'paused' after a resolution, so the status check alone no longer blocks a
+    // second approve. This in-memory read can still race a concurrent approve —
+    // the resolveApprovalGate CAS below is the real arbiter; a second approve
+    // that slips past this read loses the atomic UPDATE and throws the same way.
     throw new Error(
       `Workflow run ${runId} was already ${String(approval.resolved)} and is awaiting resume.`
     );
@@ -172,19 +174,56 @@ export async function approveWorkflow(
   // HTTP/CLI/chat pass the raw comment through since #2074, so '   ' would
   // otherwise be recorded verbatim where the documented default is 'Approved'.
   const approvalComment = comment !== undefined && comment.trim().length > 0 ? comment : 'Approved';
+  const isInteractiveLoop = approval.type === 'interactive_loop';
 
+  // Build the resolution metadata for this gate type. IMPORTANT: metadata is
+  // MERGED (not replaced) and the approval context is rewritten whole (spread +
+  // resolved) so it survives intact for the resumed executor's startIteration
+  // detection. Computed up front because the CAS below stamps it atomically as
+  // the double-resolution guard.
+  let metadataPayload: Record<string, unknown>;
+  if (isInteractiveLoop) {
+    // Finalize-vs-iterate discriminator (#2074): derived from the RAW comment,
+    // not approvalComment (which defaults to 'Approved') — a bare approve on a
+    // signal-bearing gate finalizes at resume; real feedback runs another iteration.
+    const feedbackProvided = comment !== undefined && comment.trim().length > 0;
+    // loop_user_input keeps the 'Approved' default so the iterate path (non-signaled
+    // gates) still feeds the AI an approval token via $LOOP_USER_INPUT. Typed via
+    // LoopGateRunMetadata so the key spellings match the executor's resume-time
+    // read sites (a typo here is a compile error).
+    const gateRunMetadata: LoopGateRunMetadata = {
+      loop_user_input: approvalComment,
+      loop_feedback_given: feedbackProvided,
+    };
+    metadataPayload = { approval: { ...approval, resolved: 'approved' }, ...gateRunMetadata };
+  } else {
+    metadataPayload = {
+      approval: { ...approval, resolved: 'approved' },
+      approval_response: 'approved',
+      rejection_reason: '',
+      rejection_count: 0,
+    };
+  }
+
+  // Compare-and-swap: stamp the resolution ONLY while the gate is still open.
+  // This atomic UPDATE — not the isGateResolved read above — is the real arbiter,
+  // so a concurrent second approve loses here (resolved=false) and throws BEFORE
+  // any events/telemetry are written, eliminating the duplicates (#2113). The run
+  // stays 'paused'; resume is guarded independently by resumeWorkflowRun's CAS.
+  const { resolved: won } = await workflowDb.resolveApprovalGate(runId, metadataPayload);
+  if (!won) {
+    throw new Error(`Workflow run ${runId} was already resolved and is awaiting resume.`);
+  }
+
+  // Won the CAS — record the audit events + telemetry (metadata already staged).
   try {
-    // Interactive loop gate — store user input in metadata for the next iteration.
-    // Note: node_completed is NOT written here. The executor writes it when the AI
-    // emits the completion signal (meaning the user actually approved) — or, for a
-    // signal-bearing gate approved without feedback, at resume time from the
-    // persisted signaledOutput (#2074). Writing it here would cause the resume to
-    // skip the loop node entirely.
-    if (approval.type === 'interactive_loop') {
-      // Finalize-vs-iterate discriminator (#2074): derived from the RAW comment,
-      // not approvalComment (which defaults to 'Approved') — a bare approve on a
-      // signal-bearing gate finalizes at resume; real feedback runs another iteration.
-      const feedbackProvided = comment !== undefined && comment.trim().length > 0;
+    // Interactive loop gate — user input already stored in metadata for the next
+    // iteration. Note: node_completed is NOT written here. The executor writes it
+    // when the AI emits the completion signal (meaning the user actually approved)
+    // — or, for a signal-bearing gate approved without feedback, at resume time
+    // from the persisted signaledOutput (#2074). Writing it here would cause the
+    // resume to skip the loop node entirely.
+    if (isInteractiveLoop) {
       await workflowEventDb.createWorkflowEvent({
         workflow_run_id: runId,
         event_type: 'approval_received',
@@ -193,24 +232,6 @@ export async function approveWorkflow(
       });
       // Anonymous telemetry: binary resolution only — no ids/comments/names.
       captureApprovalResolved({ resolution: 'approved' });
-      // Record the resolution; status stays 'paused' for an honest state machine.
-      // IMPORTANT: metadata is MERGED (not replaced) and the approval context is
-      // rewritten whole (spread + resolved) — it must survive intact so the
-      // resumed executor can detect the correct startIteration.
-      // loop_user_input keeps the 'Approved' default so the iterate path (non-signaled
-      // gates) still feeds the AI an approval token via $LOOP_USER_INPUT.
-      // Typed via LoopGateRunMetadata so the key spellings match the executor's
-      // resume-time read sites (a typo here is a compile error).
-      const gateRunMetadata: LoopGateRunMetadata = {
-        loop_user_input: approvalComment,
-        loop_feedback_given: feedbackProvided,
-      };
-      await workflowDb.updateWorkflowRun(runId, {
-        metadata: {
-          approval: { ...approval, resolved: 'approved' },
-          ...gateRunMetadata,
-        },
-      });
       return {
         workflowName: run.workflow_name,
         workingPath: run.working_path,
@@ -237,15 +258,6 @@ export async function approveWorkflow(
     });
     // Anonymous telemetry: binary resolution only — no ids/comments/names.
     captureApprovalResolved({ resolution: 'approved' });
-    // Record the resolution; status stays 'paused'. Clear any rejection state.
-    await workflowDb.updateWorkflowRun(runId, {
-      metadata: {
-        approval: { ...approval, resolved: 'approved' },
-        approval_response: 'approved',
-        rejection_reason: '',
-        rejection_count: 0,
-      },
-    });
   } catch (error) {
     const err = error as Error;
     getLog().error(
@@ -287,8 +299,9 @@ export async function rejectWorkflow(
     ? rawApproval
     : undefined;
   if (approval && isGateResolved(approval)) {
-    // Same double-resolution guard as approveWorkflow — the run stays 'paused'
-    // after a resolution, so status alone no longer blocks a second reject.
+    // Fast-path friendly error, same as approveWorkflow — the run stays 'paused'
+    // after a resolution, so status alone no longer blocks a second reject. The
+    // CAS below is the real arbiter for the concurrent case.
     throw new Error(
       `Workflow run ${runId} was already ${String(approval.resolved)} and is awaiting resume.`
     );
@@ -296,7 +309,34 @@ export async function rejectWorkflow(
   const rejectReason = reason ?? 'Rejected';
   const currentCount = (run.metadata.rejection_count as number | undefined) ?? 0;
   const maxAttempts = approval?.onRejectMaxAttempts ?? 3;
+  const onRejectConfigured = approval?.onRejectPrompt !== undefined;
+  const maxAttemptsReached = onRejectConfigured && currentCount + 1 >= maxAttempts;
+  // The on_reject rework is staged (run stays 'paused') only when a prompt is
+  // set AND we're under the attempt cap; every other case cancels the run.
+  const willStageRework = onRejectConfigured && !maxAttemptsReached;
 
+  // Compare-and-swap resolution guard — a concurrent second reject loses here
+  // (resolved=false) and throws BEFORE any events, so the gate events can't
+  // duplicate (#2113). Stage-rework stamps the resolution + rework metadata and
+  // keeps the run 'paused' (the approval context is rewritten whole so the resumed
+  // executor still sees nodeId/onRejectPrompt; `...approval` tolerates a malformed
+  // context exactly as the 'unknown' nodeId fallback below). The terminal outcomes
+  // flip paused→'cancelled' in a SINGLE atomic UPDATE, so there is never a
+  // resolved-but-not-cancelled state that a failed second write could strand
+  // (which a reject retry could not self-heal past the guard above).
+  const { resolved: won } = willStageRework
+    ? await workflowDb.resolveApprovalGate(runId, {
+        approval: { ...approval, resolved: 'rejected' },
+        rejection_reason: rejectReason,
+        rejection_count: currentCount + 1,
+      })
+    : await workflowDb.resolveAndCancelApprovalGate(runId);
+  if (!won) {
+    throw new Error(`Workflow run ${runId} was already resolved and is awaiting resume.`);
+  }
+
+  // Won the CAS — record the audit event + telemetry (resolution/status already
+  // committed atomically above, identically for all three outcomes).
   try {
     await workflowEventDb.createWorkflowEvent({
       workflow_run_id: runId,
@@ -306,42 +346,6 @@ export async function rejectWorkflow(
     });
     // Anonymous telemetry: binary resolution only — no ids/reasons/names.
     captureApprovalResolved({ resolution: 'rejected' });
-
-    if (approval?.onRejectPrompt !== undefined) {
-      if (currentCount + 1 >= maxAttempts) {
-        await workflowDb.cancelWorkflowRun(runId);
-        return {
-          workflowName: run.workflow_name,
-          workingPath: run.working_path,
-          userMessage: run.user_message,
-          codebaseId: run.codebase_id,
-          conversationId: run.conversation_id,
-          cancelled: true,
-          maxAttemptsReached: true,
-        };
-      }
-      // Record the staged rework; status stays 'paused' (#2075). The approval
-      // context is rewritten whole (spread + resolved) so the resumed executor
-      // still sees nodeId/onRejectPrompt for the on_reject cycle.
-      await workflowDb.updateWorkflowRun(runId, {
-        metadata: {
-          approval: { ...approval, resolved: 'rejected' },
-          rejection_reason: rejectReason,
-          rejection_count: currentCount + 1,
-        },
-      });
-      return {
-        workflowName: run.workflow_name,
-        workingPath: run.working_path,
-        userMessage: run.user_message,
-        codebaseId: run.codebase_id,
-        conversationId: run.conversation_id,
-        cancelled: false,
-        maxAttemptsReached: false,
-      };
-    }
-
-    await workflowDb.cancelWorkflowRun(runId);
   } catch (error) {
     const err = error as Error;
     getLog().error(
@@ -350,14 +354,15 @@ export async function rejectWorkflow(
     );
     throw new Error(`Failed to reject workflow run ${runId}: ${err.message}`);
   }
+
   return {
     workflowName: run.workflow_name,
     workingPath: run.working_path,
     userMessage: run.user_message,
     codebaseId: run.codebase_id,
     conversationId: run.conversation_id,
-    cancelled: true,
-    maxAttemptsReached: false,
+    cancelled: !willStageRework,
+    maxAttemptsReached,
   };
 }
 

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -2036,21 +2036,33 @@ describe('natural-language approval routing', () => {
     const platform = makePlatform();
     await handleMessage(platform, 'conv-1', 'looks good, proceed with implementation');
 
-    // Approval events should be written
-    expect(mockCreateWorkflowEvent).toHaveBeenCalledTimes(2);
+    // Approval events ride the CAS transaction now (#2146), not a direct write:
+    // node_completed + approval_received.
+    expect(mockCreateWorkflowEvent).not.toHaveBeenCalled();
+    const casEvents = (mockResolveApprovalGate.mock.calls[0] as unknown[])[2] as Array<
+      Record<string, unknown>
+    >;
+    expect(casEvents).toHaveLength(2);
+    expect(casEvents[0].event_type).toBe('node_completed');
+    expect(casEvents[1].event_type).toBe('approval_received');
     // Resuming message sent
     expect(platform.sendMessage).toHaveBeenCalledWith(
       'conv-1',
       expect.stringContaining('Resuming')
     );
     // Run stays 'paused' — resolution recorded atomically via the CAS on the
-    // approval context (#2075/#2113)
-    expect(mockResolveApprovalGate).toHaveBeenCalledWith('run-1', {
-      approval: { nodeId: 'gate-1', message: 'Please review', resolved: 'approved' },
-      approval_response: 'approved',
-      rejection_reason: '',
-      rejection_count: 0,
-    });
+    // approval context (#2075/#2113), with the audit events in the same
+    // transaction (#2146)
+    expect(mockResolveApprovalGate).toHaveBeenCalledWith(
+      'run-1',
+      {
+        approval: { nodeId: 'gate-1', message: 'Please review', resolved: 'approved' },
+        approval_response: 'approved',
+        rejection_reason: '',
+        rejection_count: 0,
+      },
+      expect.any(Array)
+    );
     expect(mockHydrateResumableRun).toHaveBeenCalled();
     expect(mockExecuteWorkflow).toHaveBeenCalled();
     // NL approval path captures the binary resolution
@@ -2170,8 +2182,9 @@ describe('natural-language approval routing', () => {
     const conversation = makeConversation({ codebase_id: 'codebase-1', cwd: '/repos/test-repo' });
     mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
     mockGetPausedWorkflowRun.mockReturnValueOnce(Promise.resolve(makePausedRun()));
-    // Simulate DB error when writing approval events
-    mockCreateWorkflowEvent.mockRejectedValueOnce(new Error('connection lost'));
+    // Simulate a DB error resolving the gate — the resolution + audit events now
+    // commit atomically inside this CAS (#2146), so a failure here is the write path.
+    mockResolveApprovalGate.mockRejectedValueOnce(new Error('connection lost'));
 
     const platform = makePlatform();
     await handleMessage(platform, 'conv-1', 'go ahead');

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -187,6 +187,9 @@ mock.module('../workflows/store-adapter', () => ({
 const mockGetPausedWorkflowRun = mock(() => Promise.resolve(null as unknown));
 const mockFindResumableRunByParentConversation = mock(() => Promise.resolve(null as unknown));
 const mockUpdateWorkflowRun = mock(() => Promise.resolve());
+// approveWorkflow stamps the resolution atomically via this CAS (#2113), not
+// updateWorkflowRun. Defaults to "won the race".
+const mockResolveApprovalGate = mock(() => Promise.resolve({ resolved: true }));
 // approveWorkflow (operations/workflow-operations, called by the NL approval
 // path) re-reads the run via getWorkflowRun before recording the resolution.
 const mockGetWorkflowRunDb = mock(() => Promise.resolve(null as unknown));
@@ -195,6 +198,7 @@ mock.module('../db/workflows', () => ({
   getWorkflowRun: mockGetWorkflowRunDb,
   findResumableRunByParentConversation: mockFindResumableRunByParentConversation,
   updateWorkflowRun: mockUpdateWorkflowRun,
+  resolveApprovalGate: mockResolveApprovalGate,
 }));
 
 const mockCreateWorkflowEvent = mock(() => Promise.resolve());
@@ -1473,6 +1477,8 @@ describe('workflow dispatch routing — interactive flag', () => {
     mockHydrateResumableRun.mockClear();
     mockUpdateWorkflowRun.mockClear();
     mockUpdateWorkflowRun.mockImplementation(() => Promise.resolve());
+    mockResolveApprovalGate.mockClear();
+    mockResolveApprovalGate.mockImplementation(() => Promise.resolve({ resolved: true }));
     mockHandleCommand.mockReset();
     mockHandleCommand.mockImplementation(() =>
       Promise.resolve({ success: true, message: 'ok', workflow: undefined })
@@ -1998,6 +2004,8 @@ describe('natural-language approval routing', () => {
     mockHydrateResumableRun.mockClear();
     mockUpdateWorkflowRun.mockClear();
     mockUpdateWorkflowRun.mockImplementation(() => Promise.resolve());
+    mockResolveApprovalGate.mockClear();
+    mockResolveApprovalGate.mockImplementation(() => Promise.resolve({ resolved: true }));
     mockDiscoverWorkflowsWithConfig.mockReset();
     mockDiscoverWorkflowsWithConfig.mockImplementation(() =>
       Promise.resolve({ workflows: [], errors: [] })
@@ -2035,14 +2043,13 @@ describe('natural-language approval routing', () => {
       'conv-1',
       expect.stringContaining('Resuming')
     );
-    // Run stays 'paused' — resolution recorded on the approval context (#2075)
-    expect(mockUpdateWorkflowRun).toHaveBeenCalledWith('run-1', {
-      metadata: {
-        approval: { nodeId: 'gate-1', message: 'Please review', resolved: 'approved' },
-        approval_response: 'approved',
-        rejection_reason: '',
-        rejection_count: 0,
-      },
+    // Run stays 'paused' — resolution recorded atomically via the CAS on the
+    // approval context (#2075/#2113)
+    expect(mockResolveApprovalGate).toHaveBeenCalledWith('run-1', {
+      approval: { nodeId: 'gate-1', message: 'Please review', resolved: 'approved' },
+      approval_response: 'approved',
+      rejection_reason: '',
+      rejection_count: 0,
     });
     expect(mockHydrateResumableRun).toHaveBeenCalled();
     expect(mockExecuteWorkflow).toHaveBeenCalled();

--- a/packages/server/src/routes/api.workflow-runs.test.ts
+++ b/packages/server/src/routes/api.workflow-runs.test.ts
@@ -175,6 +175,11 @@ mock.module('@archon/core/db/isolation-environments', () => ({
 
 const mockDeleteWorkflowRun = mock(async (_id: string) => {});
 const mockUpdateWorkflowRun = mock(async (_id: string, _update: unknown) => {});
+// CAS gate resolvers (#2113) — the real approve/reject operations stamp the
+// resolution here. resolveAndCancelApprovalGate is the atomic resolve+cancel for
+// terminal reject outcomes. Default to "won the race".
+const mockResolveApprovalGate = mock(async (_id: string, _md: unknown) => ({ resolved: true }));
+const mockResolveAndCancelApprovalGate = mock(async (_id: string) => ({ resolved: true }));
 
 mock.module('@archon/core/db/workflows', () => ({
   listWorkflowRuns: mockListWorkflowRuns,
@@ -183,6 +188,8 @@ mock.module('@archon/core/db/workflows', () => ({
   cancelWorkflowRun: mockCancelWorkflowRun,
   deleteWorkflowRun: mockDeleteWorkflowRun,
   updateWorkflowRun: mockUpdateWorkflowRun,
+  resolveApprovalGate: mockResolveApprovalGate,
+  resolveAndCancelApprovalGate: mockResolveAndCancelApprovalGate,
   getWorkflowRunByWorkerPlatformId: mockGetWorkflowRunByWorkerPlatformId,
 }));
 
@@ -1312,6 +1319,8 @@ describe('POST /api/workflows/runs/:runId/approve', () => {
   beforeEach(() => {
     mockGetWorkflowRun.mockReset();
     mockUpdateWorkflowRun.mockReset();
+    mockResolveApprovalGate.mockClear();
+    mockResolveAndCancelApprovalGate.mockClear();
     mockCreateWorkflowEvent.mockReset();
   });
 
@@ -1435,12 +1444,10 @@ describe('POST /api/workflows/runs/:runId/approve', () => {
       headers: { 'Content-Type': 'application/json' },
     });
     expect(response.status).toBe(200);
-    const updateCall = mockUpdateWorkflowRun.mock.calls[0] as unknown[];
-    expect(updateCall[1]).toMatchObject({
-      metadata: {
-        loop_feedback_given: false,
-        loop_user_input: 'Approved',
-      },
+    const casCall = mockResolveApprovalGate.mock.calls[0] as unknown[];
+    expect(casCall[1]).toMatchObject({
+      loop_feedback_given: false,
+      loop_user_input: 'Approved',
     });
   });
 
@@ -1468,7 +1475,7 @@ describe('POST /api/workflows/runs/:runId/approve', () => {
     // A malformed body must never be coerced into a bare approve — that would
     // FINALIZE a signal-bearing gate while silently discarding the feedback.
     expect(response.status).toBe(400);
-    expect(mockUpdateWorkflowRun).not.toHaveBeenCalled();
+    expect(mockResolveApprovalGate).not.toHaveBeenCalled();
   });
 
   test('passes a provided comment through as feedback on an interactive_loop gate (#2074)', async () => {
@@ -1491,12 +1498,10 @@ describe('POST /api/workflows/runs/:runId/approve', () => {
       headers: { 'Content-Type': 'application/json' },
     });
     expect(response.status).toBe(200);
-    const updateCall = mockUpdateWorkflowRun.mock.calls[0] as unknown[];
-    expect(updateCall[1]).toMatchObject({
-      metadata: {
-        loop_feedback_given: true,
-        loop_user_input: 'actually re-check X',
-      },
+    const casCall = mockResolveApprovalGate.mock.calls[0] as unknown[];
+    expect(casCall[1]).toMatchObject({
+      loop_feedback_given: true,
+      loop_user_input: 'actually re-check X',
     });
   });
 });
@@ -1509,6 +1514,8 @@ describe('POST /api/workflows/runs/:runId/reject', () => {
   beforeEach(() => {
     mockGetWorkflowRun.mockReset();
     mockUpdateWorkflowRun.mockReset();
+    mockResolveApprovalGate.mockClear();
+    mockResolveAndCancelApprovalGate.mockClear();
     mockCancelWorkflowRun.mockReset();
     mockCreateWorkflowEvent.mockReset();
   });
@@ -1546,7 +1553,9 @@ describe('POST /api/workflows/runs/:runId/reject', () => {
     expect(response.status).toBe(200);
     const body = (await response.json()) as { success: boolean; message: string };
     expect(body.success).toBe(true);
-    expect(mockCancelWorkflowRun).toHaveBeenCalledWith('run-paused-1');
+    // Terminal reject resolves + cancels atomically (#2113)
+    expect(mockResolveAndCancelApprovalGate).toHaveBeenCalledWith('run-paused-1');
+    expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
     expect(mockCaptureApprovalResolved).toHaveBeenCalledWith({ resolution: 'rejected' });
   });
 
@@ -1575,19 +1584,17 @@ describe('POST /api/workflows/runs/:runId/reject', () => {
     const body = (await response.json()) as { success: boolean; message: string };
     expect(body.success).toBe(true);
     expect(body.message).toContain('On-reject prompt');
-    expect(mockUpdateWorkflowRun).toHaveBeenCalledWith('run-on-reject', {
-      metadata: {
-        approval: {
-          type: 'approval',
-          nodeId: 'review-gate',
-          message: 'Approve?',
-          onRejectPrompt: 'Fix: $REJECTION_REASON',
-          onRejectMaxAttempts: 3,
-          resolved: 'rejected',
-        },
-        rejection_reason: 'needs more tests',
-        rejection_count: 1,
+    expect(mockResolveApprovalGate).toHaveBeenCalledWith('run-on-reject', {
+      approval: {
+        type: 'approval',
+        nodeId: 'review-gate',
+        message: 'Approve?',
+        onRejectPrompt: 'Fix: $REJECTION_REASON',
+        onRejectMaxAttempts: 3,
+        resolved: 'rejected',
       },
+      rejection_reason: 'needs more tests',
+      rejection_count: 1,
     });
     expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
   });
@@ -1617,7 +1624,9 @@ describe('POST /api/workflows/runs/:runId/reject', () => {
     const body = (await response.json()) as { success: boolean; message: string };
     expect(body.success).toBe(true);
     expect(body.message).toContain('max attempts reached');
-    expect(mockCancelWorkflowRun).toHaveBeenCalledWith('run-max-attempts');
+    // Terminal reject resolves + cancels atomically (#2113)
+    expect(mockResolveAndCancelApprovalGate).toHaveBeenCalledWith('run-max-attempts');
+    expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
     expect(mockUpdateWorkflowRun).not.toHaveBeenCalled();
   });
 });
@@ -1632,6 +1641,8 @@ describe('approve/reject auto-resume', () => {
   beforeEach(() => {
     mockGetWorkflowRun.mockReset();
     mockUpdateWorkflowRun.mockReset();
+    mockResolveApprovalGate.mockClear();
+    mockResolveAndCancelApprovalGate.mockClear();
     mockCreateWorkflowEvent.mockReset();
     mockGetConversationById.mockReset();
     mockHandleMessage.mockReset();
@@ -1836,7 +1847,8 @@ describe('approve/reject auto-resume', () => {
     expect(response.status).toBe(200);
     // Cancellation path doesn't auto-resume — nothing to resume to.
     expect(mockHandleMessage).not.toHaveBeenCalled();
-    expect(mockCancelWorkflowRun).toHaveBeenCalledWith('run-paused-1');
+    // Terminal reject resolves + cancels atomically (#2113)
+    expect(mockResolveAndCancelApprovalGate).toHaveBeenCalledWith('run-paused-1');
   });
 });
 

--- a/packages/server/src/routes/api.workflow-runs.test.ts
+++ b/packages/server/src/routes/api.workflow-runs.test.ts
@@ -178,8 +178,14 @@ const mockUpdateWorkflowRun = mock(async (_id: string, _update: unknown) => {});
 // CAS gate resolvers (#2113) — the real approve/reject operations stamp the
 // resolution here. resolveAndCancelApprovalGate is the atomic resolve+cancel for
 // terminal reject outcomes. Default to "won the race".
-const mockResolveApprovalGate = mock(async (_id: string, _md: unknown) => ({ resolved: true }));
-const mockResolveAndCancelApprovalGate = mock(async (_id: string) => ({ resolved: true }));
+// The 3rd arg (approve) / 2nd arg (cancel) is the audit-event batch written in the
+// same transaction as the resolution (#2146).
+const mockResolveApprovalGate = mock(async (_id: string, _md: unknown, _events?: unknown) => ({
+  resolved: true,
+}));
+const mockResolveAndCancelApprovalGate = mock(async (_id: string, _events?: unknown) => ({
+  resolved: true,
+}));
 
 mock.module('@archon/core/db/workflows', () => ({
   listWorkflowRuns: mockListWorkflowRuns,
@@ -1393,10 +1399,12 @@ describe('POST /api/workflows/runs/:runId/approve', () => {
       headers: { 'Content-Type': 'application/json' },
     });
     expect(response.status).toBe(200);
-    const nodeCompletedCall = mockCreateWorkflowEvent.mock.calls.find(
-      (c: unknown[]) => (c[0] as Record<string, unknown>).event_type === 'node_completed'
-    );
-    expect(nodeCompletedCall?.[0]).toMatchObject({
+    // Audit events ride the CAS transaction now (#2146), not a separate write.
+    const casEvents = (mockResolveApprovalGate.mock.calls[0] as unknown[])[2] as Array<
+      Record<string, unknown>
+    >;
+    const nodeCompleted = casEvents.find(e => e.event_type === 'node_completed');
+    expect(nodeCompleted).toMatchObject({
       data: { node_output: 'Looks great, proceed', approval_decision: 'approved' },
     });
   });
@@ -1410,10 +1418,12 @@ describe('POST /api/workflows/runs/:runId/approve', () => {
       headers: { 'Content-Type': 'application/json' },
     });
     expect(response.status).toBe(200);
-    const nodeCompletedCall = mockCreateWorkflowEvent.mock.calls.find(
-      (c: unknown[]) => (c[0] as Record<string, unknown>).event_type === 'node_completed'
-    );
-    expect(nodeCompletedCall?.[0]).toMatchObject({
+    // Audit events ride the CAS transaction now (#2146), not a separate write.
+    const casEvents = (mockResolveApprovalGate.mock.calls[0] as unknown[])[2] as Array<
+      Record<string, unknown>
+    >;
+    const nodeCompleted = casEvents.find(e => e.event_type === 'node_completed');
+    expect(nodeCompleted).toMatchObject({
       data: { node_output: '', approval_decision: 'approved' },
     });
     expect(mockCaptureApprovalResolved).toHaveBeenCalledWith({ resolution: 'approved' });
@@ -1553,8 +1563,15 @@ describe('POST /api/workflows/runs/:runId/reject', () => {
     expect(response.status).toBe(200);
     const body = (await response.json()) as { success: boolean; message: string };
     expect(body.success).toBe(true);
-    // Terminal reject resolves + cancels atomically (#2113)
-    expect(mockResolveAndCancelApprovalGate).toHaveBeenCalledWith('run-paused-1');
+    // Terminal reject resolves + cancels atomically (#2113); the audit event rides
+    // the same transaction (#2146).
+    expect(mockResolveAndCancelApprovalGate).toHaveBeenCalledWith('run-paused-1', [
+      {
+        event_type: 'approval_received',
+        step_name: 'review-gate',
+        data: { decision: 'rejected', reason: 'needs work' },
+      },
+    ]);
     expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
     expect(mockCaptureApprovalResolved).toHaveBeenCalledWith({ resolution: 'rejected' });
   });
@@ -1584,18 +1601,28 @@ describe('POST /api/workflows/runs/:runId/reject', () => {
     const body = (await response.json()) as { success: boolean; message: string };
     expect(body.success).toBe(true);
     expect(body.message).toContain('On-reject prompt');
-    expect(mockResolveApprovalGate).toHaveBeenCalledWith('run-on-reject', {
-      approval: {
-        type: 'approval',
-        nodeId: 'review-gate',
-        message: 'Approve?',
-        onRejectPrompt: 'Fix: $REJECTION_REASON',
-        onRejectMaxAttempts: 3,
-        resolved: 'rejected',
+    expect(mockResolveApprovalGate).toHaveBeenCalledWith(
+      'run-on-reject',
+      {
+        approval: {
+          type: 'approval',
+          nodeId: 'review-gate',
+          message: 'Approve?',
+          onRejectPrompt: 'Fix: $REJECTION_REASON',
+          onRejectMaxAttempts: 3,
+          resolved: 'rejected',
+        },
+        rejection_reason: 'needs more tests',
+        rejection_count: 1,
       },
-      rejection_reason: 'needs more tests',
-      rejection_count: 1,
-    });
+      [
+        {
+          event_type: 'approval_received',
+          step_name: 'review-gate',
+          data: { decision: 'rejected', reason: 'needs more tests' },
+        },
+      ]
+    );
     expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
   });
 
@@ -1624,8 +1651,15 @@ describe('POST /api/workflows/runs/:runId/reject', () => {
     const body = (await response.json()) as { success: boolean; message: string };
     expect(body.success).toBe(true);
     expect(body.message).toContain('max attempts reached');
-    // Terminal reject resolves + cancels atomically (#2113)
-    expect(mockResolveAndCancelApprovalGate).toHaveBeenCalledWith('run-max-attempts');
+    // Terminal reject resolves + cancels atomically (#2113); the audit event rides
+    // the same transaction (#2146).
+    expect(mockResolveAndCancelApprovalGate).toHaveBeenCalledWith('run-max-attempts', [
+      {
+        event_type: 'approval_received',
+        step_name: 'review-gate',
+        data: { decision: 'rejected', reason: 'still bad' },
+      },
+    ]);
     expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
     expect(mockUpdateWorkflowRun).not.toHaveBeenCalled();
   });
@@ -1847,8 +1881,15 @@ describe('approve/reject auto-resume', () => {
     expect(response.status).toBe(200);
     // Cancellation path doesn't auto-resume — nothing to resume to.
     expect(mockHandleMessage).not.toHaveBeenCalled();
-    // Terminal reject resolves + cancels atomically (#2113)
-    expect(mockResolveAndCancelApprovalGate).toHaveBeenCalledWith('run-paused-1');
+    // Terminal reject resolves + cancels atomically (#2113); the audit event rides
+    // the same transaction (#2146).
+    expect(mockResolveAndCancelApprovalGate).toHaveBeenCalledWith('run-paused-1', [
+      {
+        event_type: 'approval_received',
+        step_name: 'review-gate',
+        data: { decision: 'rejected', reason: 'no' },
+      },
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

- **Problem:** `approveWorkflow`/`rejectWorkflow` guarded double-resolution with a read-then-write — they read `metadata.approval.resolved` into memory, checked it, then wrote gate events + the resolution in separate statements. Two concurrent approves/rejects of one gate (UI double-click, duplicate webhook delivery, two operators) could both pass the read-check and both run the resolution path.
- **Why it matters:** The loser duplicated `node_completed`/`approval_received` events and fired `captureApprovalResolved` twice — polluting the event log, any consumer that counts approval events, and telemetry. (Low severity: the resume CAS already prevented double-execution, so no state corruption.)
- **What changed:** Made the resolution write itself the guard, mirroring `resumeWorkflowRun`'s compare-and-swap. A conditional `UPDATE` stamps the resolution only while the gate is still open; events + telemetry are written only after winning it, so a concurrent loser throws before writing anything.
- **What did NOT change (scope boundary):** No touch to `dag-executor.ts` / isolation packages (Phase-A refactor's lane), the ABANDON path / its HTTP guard (#1887's lane), or the resume CAS itself. Metadata merge shape, return values, and error messages are otherwise unchanged.

## UX Journey

### Before

```
Two concurrent approves of one paused gate:
  approve A ──▶ read run: resolved=null ─┐
  approve B ──▶ read run: resolved=null ─┤ both pass isGateResolved()
  approve A ──▶ write node_completed + approval_received, captureApprovalResolved  ← events
  approve B ──▶ write node_completed + approval_received, captureApprovalResolved  ← DUPLICATE events + telemetry
```

### After

```
Two concurrent approves of one paused gate:
  approve A ──▶ [CAS] UPDATE ... WHERE paused AND resolved IS NULL  ──▶ rowCount 1 (won)
  approve B ──▶ [CAS] UPDATE ... WHERE paused AND resolved IS NULL  ──▶ rowCount 0 (lost)
  approve A ──▶ write events + telemetry                            ← written ONCE
  approve B ──▶ throws "already resolved and is awaiting resume"    ← *no events, no telemetry*
```

## Architecture Diagram

### Before

```
approveWorkflow / rejectWorkflow (operations/workflow-operations.ts)
   │  getWorkflowRun ──▶ isGateResolved(in-memory)      ← check
   │  createWorkflowEvent × N ; captureApprovalResolved ← write (events first)
   └▶ updateWorkflowRun({ metadata })                   ← write (resolution last)   [gap between check & write]
```

### After

```
approveWorkflow / rejectWorkflow (operations/workflow-operations.ts)
   │  getWorkflowRun ──▶ isGateResolved(in-memory)      ← friendly fast-path only
   │  [~] resolveApprovalGate(id, metadata) ============▶ db/workflows.ts  [+ CAS: stamp iff gate open]
   │       (terminal reject) [~] resolveAndCancelApprovalGate(id) =========▶ db/workflows.ts  [+ atomic paused→cancelled]
   │       └ both share [+] unresolvedGateClause()   (dialect-aware: PG ->>, SQLite json_extract)
   └▶ if won: createWorkflowEvent × N ; captureApprovalResolved   ← write only after winning
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `workflow-operations.ts` approve/reject | `db/workflows.resolveApprovalGate` | **new** | CAS replaces the `updateWorkflowRun` metadata write |
| `workflow-operations.ts` reject (terminal) | `db/workflows.resolveAndCancelApprovalGate` | **new** | atomic resolve+cancel replaces separate `cancelWorkflowRun` |
| `workflow-operations.ts` reject (terminal) | `db/workflows.cancelWorkflowRun` | **removed** | folded into the atomic UPDATE above |
| `db/workflows` `resolveApprovalGate`/`resolveAndCancelApprovalGate` | `unresolvedGateClause()` | **new** | shared dialect-aware open-gate predicate |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `core`
- Module: `core:operations`, `core:db`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #2113

## Validation Evidence (required)

```bash
bun run validate
```

- Evidence provided: `bun run validate` green from the worktree root — all 8 steps pass (check:bundled, check:bundled-skill, check:bundled-schema, check:pi-vendor-map, type-check, lint `--max-warnings 0`, format:check, tests across all 10 packages, 0 failures).
- New/updated tests: real-SQLite integration tests for both CAS functions (`workflows.resume-cas.integration.test.ts`) — win-once, second-call-loses, a concurrent `Promise.all` race that asserts exactly one winner, non-paused miss, and an approve-loses-to-reject-cancel race; concurrent-loser unit tests for approve and reject (`workflow-operations.test.ts`) asserting the loser writes no events/telemetry; the CLI, chat-handler, and HTTP-route tests were updated to the new CAS seam.
- If any command is intentionally skipped: none.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Database migration needed? `No` (no schema change — the CAS uses existing columns and the existing `metadata` JSON)

## Human Verification (required)

- Verified scenarios: approve (standard + interactive-loop, feedback and bare), reject (stage-rework under cap, cancel at max attempts, cancel with no on_reject) all pass end-to-end against real SQLite via the integration suite; concurrent-loser paths write no duplicate events/telemetry.
- Edge cases checked: `resolved` stored as explicit JSON null vs absent key (both match "open" on PG `->>'` and SQLite `json_extract`); reject with a malformed/absent approval context still cancels; the atomic reject-cancel removes the previously-possible resolved-but-not-cancelled stranded state.
- What was not verified: no live PostgreSQL run locally — the PG predicate is exercised by the shared helper + dialect unit tests, and asserted equivalent to the SQLite path (integration tests run against real bun:sqlite).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: workflow gate approve/reject across all call sites (CLI, chat/command-handler, orchestrator NL-approval, Slack bridge, HTTP routes) — all go through the same two operations.
- Potential unintended effects: on a true race, the concurrent loser now receives an error (HTTP 500 for the web loser; the route's own `isGateResolved` pre-check still returns a friendly 400 for the sequential case) instead of a silent duplicate success — intended.
- Guardrails/monitoring: `db.workflow_run_resolve_gate_failed` / `db.workflow_run_resolve_cancel_gate_failed` log events; approval telemetry now fires exactly once per resolution.

## Rollback Plan (required)

- Fast rollback command/path: `git revert 5c2cd0fd` (single self-contained commit) then redeploy.
- Feature flags or config toggles: none.
- Observable failure symptoms: gate approve/reject throwing unexpectedly, or approvals not being recorded — none seen in the full suite.

## Risks and Mitigations

- Risk: dialect JSON-predicate drift between Postgres and SQLite.
  - Mitigation: single `unresolvedGateClause()` helper branches once on dialect (mirrors the existing `jsonIntExtract`/`resumableStatusClause` precedent); both paths covered by real-SQLite integration tests.
- Risk: reordering the metadata write ahead of the event writes means a post-CAS event-write failure leaves the resolution stamped but the audit event missing.
  - Mitigation: accepted per the issue ("reorder so the CAS comes first") — the resolution is the source of truth for resume; the happy path writes both, and a DB failure still surfaces to the user. The terminal reject path is fully atomic (single UPDATE), so it has no such intermediate state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow approval and rejection handling under concurrent actions to prevent duplicate outcomes, events, and telemetry.
  * Terminal rejections now cancel atomically, with consistent completion timestamps.
  * Preserved approval/rejection details (including retry counts and interactive-loop context) and ensured audit events are written exactly once.
* **New Features**
  * Added reliable compare-and-swap approval-gate resolution for safer paused-workflow transitions.
* **Chores**
  * Improved SQLite transaction safety and refined workflow event insertion utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->