### PR TITLE
fix(maintainer): mechanical fixes from 2026-07-16 maintainer-workflows review (B1/B2/B3/B5/R1/R4/R2)

### DIFF
--- a/.archon/commands/maintainer-review-code-review.md
+++ b/.archon/commands/maintainer-review-code-review.md
@@ -5,7 +5,7 @@ argument-hint: (no arguments — reads PR data and writes findings artifact)
 
 # Maintainer Review — Code Review
 
-You are a focused code reviewer for one GitHub PR. **Always run** for every PR that passes the gate. Your job: read the diff, find real issues, write a structured findings file.
+You are a focused code reviewer for one GitHub PR. **Always run** for every PR under review. Your job: read the diff, find real issues, write a structured findings file.
 
 **Workflow ID**: $WORKFLOW_ID
 
@@ -22,14 +22,6 @@ PR_NUMBER=$(cat $ARTIFACTS_DIR/.pr-number)
 ### Read the project's rules
 
 Read the repo's `CLAUDE.md` (project-level). It's the source of truth for engineering principles, type-safety rules, eslint policy, error-handling conventions, and forbidden patterns.
-
-### Read the gate decision
-
-```bash
-cat $ARTIFACTS_DIR/gate-decision.md
-```
-
-The gate already classified direction/scope. Don't re-litigate that here. Focus on **code quality** within the scope the gate accepted.
 
 ### Read the PR diff
 

--- a/.archon/scripts/__tests__/extract-pr-number.test.ts
+++ b/.archon/scripts/__tests__/extract-pr-number.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'bun:test';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+
+const SCRIPT = resolve(import.meta.dir, '../extract-pr-number.ts');
+
+interface RunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+  prNumberFile?: string;
+}
+
+function run(input: string, withArtifacts = false): RunResult {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  delete env['ARGUMENTS'];
+  let artifactsDir: string | undefined;
+  if (withArtifacts) {
+    artifactsDir = mkdtempSync(join(tmpdir(), 'extract-pr-'));
+    env['ARTIFACTS_DIR'] = artifactsDir;
+  } else {
+    delete env['ARTIFACTS_DIR'];
+  }
+  try {
+    const stdout = execFileSync('bun', [SCRIPT, input], {
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).toString();
+    let prNumberFile: string | undefined;
+    if (artifactsDir) {
+      try {
+        prNumberFile = readFileSync(join(artifactsDir, '.pr-number'), 'utf8');
+      } catch {
+        prNumberFile = undefined;
+      }
+    }
+    return { code: 0, stdout, stderr: '', prNumberFile };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: Buffer; stderr?: Buffer };
+    return {
+      code: err.status ?? 1,
+      stdout: (err.stdout ?? Buffer.from('')).toString(),
+      stderr: (err.stderr ?? Buffer.from('')).toString(),
+    };
+  }
+}
+
+describe('extract-pr-number: anchored forms win', () => {
+  it('#1428', () => expect(run('#1428').stdout.trim()).toBe('1428'));
+  it('PR 1428', () => expect(run('review PR 1428 as maintainer').stdout.trim()).toBe('1428'));
+  it('PR#1428', () => expect(run('PR#1428').stdout.trim()).toBe('1428'));
+  it('PR-1428', () => expect(run('PR-1428').stdout.trim()).toBe('1428'));
+  it('pull URL with coleam00 org (naive grep would return 00)', () =>
+    expect(run('https://github.com/coleam00/Archon/pull/1428').stdout.trim()).toBe('1428'));
+  it('issues URL', () =>
+    expect(run('https://github.com/coleam00/Archon/issues/1428').stdout.trim()).toBe('1428'));
+  it('pr2-tool slug does not win over pull/1428 (S3 precedence)', () =>
+    expect(run('https://github.com/pr2-tool/Archon/pull/1428').stdout.trim()).toBe('1428'));
+  it('ignores an unanchored digit token when an anchor is present', () =>
+    expect(run('the 2nd one, pr #1428').stdout.trim()).toBe('1428'));
+});
+
+describe('extract-pr-number: bare number only when whole input', () => {
+  it('accepts a pure number', () => expect(run('1428').stdout.trim()).toBe('1428'));
+});
+
+describe('extract-pr-number: loud errors (no silent wrong number)', () => {
+  it('errors on anchor-less prose with a leading digit token (I1: coleam00 fix 1428)', () => {
+    const r = run('coleam00 fix 1428');
+    expect(r.code).toBe(1);
+    expect(r.stdout.trim()).toBe('');
+    expect(r.stderr).toContain('no PR number found');
+  });
+
+  it('errors on a version string with a trailing number (I1: v1.2.3 changelog for 1428)', () => {
+    const r = run('v1.2.3 changelog for 1428');
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('no PR number found');
+  });
+
+  it('errors on ambiguous multi-number input, listing them (I2)', () => {
+    const r = run('see #1400, should relate to PR 1428');
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('ambiguous');
+    expect(r.stderr).toContain('1400');
+    expect(r.stderr).toContain('1428');
+  });
+
+  it('errors on empty input', () => {
+    const r = run('   ');
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('empty input');
+  });
+});
+
+describe('extract-pr-number: writes .pr-number', () => {
+  it('writes the number to $ARTIFACTS_DIR/.pr-number', () => {
+    const r = run('https://github.com/coleam00/Archon/pull/1428', true);
+    expect(r.code).toBe(0);
+    expect(r.prNumberFile?.trim()).toBe('1428');
+  });
+});

--- a/.archon/scripts/__tests__/extract-pr-number.test.ts
+++ b/.archon/scripts/__tests__/extract-pr-number.test.ts
@@ -56,7 +56,7 @@ describe('extract-pr-number: anchored forms win', () => {
     expect(run('https://github.com/coleam00/Archon/pull/1428').stdout.trim()).toBe('1428'));
   it('issues URL', () =>
     expect(run('https://github.com/coleam00/Archon/issues/1428').stdout.trim()).toBe('1428'));
-  it('pr2-tool slug does not win over pull/1428 (S3 precedence)', () =>
+  it('pr2-tool slug does not win over pull/1428 (anchor precedence)', () =>
     expect(run('https://github.com/pr2-tool/Archon/pull/1428').stdout.trim()).toBe('1428'));
   it('ignores an unanchored digit token when an anchor is present', () =>
     expect(run('the 2nd one, pr #1428').stdout.trim()).toBe('1428'));
@@ -67,20 +67,20 @@ describe('extract-pr-number: bare number only when whole input', () => {
 });
 
 describe('extract-pr-number: loud errors (no silent wrong number)', () => {
-  it('errors on anchor-less prose with a leading digit token (I1: coleam00 fix 1428)', () => {
+  it('errors on anchor-less prose with a leading digit token (coleam00 fix 1428)', () => {
     const r = run('coleam00 fix 1428');
     expect(r.code).toBe(1);
     expect(r.stdout.trim()).toBe('');
     expect(r.stderr).toContain('no PR number found');
   });
 
-  it('errors on a version string with a trailing number (I1: v1.2.3 changelog for 1428)', () => {
+  it('errors on a version string with a trailing number (v1.2.3 changelog for 1428)', () => {
     const r = run('v1.2.3 changelog for 1428');
     expect(r.code).toBe(1);
     expect(r.stderr).toContain('no PR number found');
   });
 
-  it('errors on ambiguous multi-number input, listing them (I2)', () => {
+  it('errors on ambiguous multi-number input, listing them', () => {
     const r = run('see #1400, should relate to PR 1428');
     expect(r.code).toBe(1);
     expect(r.stderr).toContain('ambiguous');

--- a/.archon/scripts/__tests__/marketplace-decide.test.ts
+++ b/.archon/scripts/__tests__/marketplace-decide.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'bun:test';
+import { decideMarketplace, type DecideInput } from '../marketplace-decide.ts';
+
+// A clean baseline: in-scope, not draft, no scan findings, one valid workflow,
+// AI recommends auto_merge. Individual tests override one axis at a time.
+function base(overrides: Partial<DecideInput> = {}): DecideInput {
+  return {
+    scopeOk: true,
+    isDraft: false,
+    scan: { severity: 'none', findings: [] },
+    schema: { valid: true, files: [{ valid: true }] },
+    ai: { recommendation: 'auto_merge', reasoning: 'looks good' },
+    ...overrides,
+  };
+}
+
+describe('decideMarketplace: reject branches + close policy', () => {
+  it('scope violation -> reject, close TRUE (deterministic)', () => {
+    const r = decideMarketplace(base({ scopeOk: false }));
+    expect(r.decision).toBe('reject');
+    expect(r.close).toBe(true);
+    expect(r.reason).toContain('marketplace.ts');
+  });
+
+  it('critical scan -> reject, close TRUE (deterministic)', () => {
+    const r = decideMarketplace(base({ scan: { severity: 'critical', findings: [{ category: 'rce', context: 'x.ts' }] } }));
+    expect(r.decision).toBe('reject');
+    expect(r.close).toBe(true);
+    expect(r.reason).toContain('rce in x.ts');
+  });
+
+  it('high scan -> reject, close TRUE (deterministic)', () => {
+    const r = decideMarketplace(base({ scan: { severity: 'high', findings: [] } }));
+    expect(r.decision).toBe('reject');
+    expect(r.close).toBe(true);
+  });
+
+  it('AI-only reject (clean scan/scope) -> reject, close FALSE (stays open)', () => {
+    const r = decideMarketplace(base({ ai: { recommendation: 'reject', reasoning: 'subtle concern' } }));
+    expect(r.decision).toBe('reject');
+    expect(r.close).toBe(false);
+    expect(r.reason).toBe('subtle concern');
+  });
+
+  it('high scan wins over an AI auto_merge and closes', () => {
+    const r = decideMarketplace(base({ scan: { severity: 'high', findings: [] }, ai: { recommendation: 'auto_merge' } }));
+    expect(r.decision).toBe('reject');
+    expect(r.close).toBe(true);
+  });
+});
+
+describe('decideMarketplace: request_changes branches (never close)', () => {
+  it('draft -> request_changes', () => {
+    const r = decideMarketplace(base({ isDraft: true }));
+    expect(r.decision).toBe('request_changes');
+    expect(r.close).toBe(false);
+  });
+
+  it('empty workflow files -> request_changes (fail-open guard)', () => {
+    const r = decideMarketplace(base({ schema: { valid: true, files: [] } }));
+    expect(r.decision).toBe('request_changes');
+    expect(r.close).toBe(false);
+    expect(r.reason).toContain('no workflow YAML');
+  });
+
+  it('undefined files list -> request_changes (treated as empty)', () => {
+    const r = decideMarketplace(base({ schema: { valid: true } }));
+    expect(r.decision).toBe('request_changes');
+  });
+
+  it('schema invalid with non-empty files -> request_changes', () => {
+    const r = decideMarketplace(base({ schema: { valid: false, files: [{ valid: false }] } }));
+    expect(r.decision).toBe('request_changes');
+    expect(r.reason).toContain('schema validation');
+  });
+
+  it('medium scan -> request_changes', () => {
+    const r = decideMarketplace(base({ scan: { severity: 'medium', findings: [] } }));
+    expect(r.decision).toBe('request_changes');
+  });
+
+  it('AI request_changes -> request_changes', () => {
+    const r = decideMarketplace(base({ ai: { recommendation: 'request_changes', reasoning: 'fix it' } }));
+    expect(r.decision).toBe('request_changes');
+    expect(r.reason).toBe('fix it');
+  });
+});
+
+describe('decideMarketplace: merge/approve branches', () => {
+  it('clean + AI auto_merge -> auto_merge', () => {
+    expect(decideMarketplace(base()).decision).toBe('auto_merge');
+  });
+
+  it('clean + AI auto_approve (scan none) -> auto_merge (per existing rule)', () => {
+    const r = decideMarketplace(base({ ai: { recommendation: 'auto_approve', reasoning: 'ok' } }));
+    expect(r.decision).toBe('auto_merge');
+  });
+
+  it('low scan + AI auto_merge -> auto_approve (else branch)', () => {
+    const r = decideMarketplace(base({ scan: { severity: 'low', findings: [] }, ai: { recommendation: 'auto_merge' } }));
+    expect(r.decision).toBe('auto_approve');
+    expect(r.close).toBe(false);
+  });
+});
+
+describe('decideMarketplace: reason never undefined (avoids "null" in PR comments)', () => {
+  it('falls back to a placeholder when AI omits reasoning', () => {
+    const r = decideMarketplace(base({ ai: { recommendation: 'auto_merge' } }));
+    expect(typeof r.reason).toBe('string');
+    expect(r.reason.length).toBeGreaterThan(0);
+  });
+});

--- a/.archon/scripts/__tests__/marketplace-validate-schema.test.ts
+++ b/.archon/scripts/__tests__/marketplace-validate-schema.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { resolve, join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+
+const VALIDATOR = resolve(import.meta.dir, '../marketplace-validate-schema.ts');
+
+interface FileResult {
+  name: string;
+  valid: boolean;
+  errors: string[];
+}
+
+interface ValidateOutput {
+  valid: boolean;
+  files: FileResult[];
+  note?: string;
+}
+
+/**
+ * Run the real marketplace-validate-schema.ts against a temp ARTIFACTS_DIR.
+ * Pass `null` to omit the source/ directory entirely; otherwise pass a map of
+ * relative path -> file content to populate source/.
+ */
+function runValidator(sourceFiles: Record<string, string> | null): ValidateOutput {
+  const artifactsDir = mkdtempSync(join(tmpdir(), 'validate-schema-'));
+  if (sourceFiles) {
+    const sourceDir = join(artifactsDir, 'source');
+    mkdirSync(sourceDir, { recursive: true });
+    for (const [rel, content] of Object.entries(sourceFiles)) {
+      const full = join(sourceDir, rel);
+      mkdirSync(dirname(full), { recursive: true });
+      writeFileSync(full, content);
+    }
+  }
+  const output = execFileSync('bun', [VALIDATOR], {
+    env: { ...process.env, ARTIFACTS_DIR: artifactsDir },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).toString();
+  return JSON.parse(output) as ValidateOutput;
+}
+
+const VALID_WORKFLOW = `name: test-workflow
+description: A minimal valid workflow for the empty-submission contract test.
+nodes:
+  - id: hello
+    bash: echo hi
+`;
+
+// The empty-list contract these tests pin: `files: []` means "no workflow YAML
+// found at the pinned SHA". validate-schema emits valid:true for it (nothing
+// FAILED validation), but the decide node in marketplace-pr-review-and-merge
+// must treat an empty list as request_changes, never as a merge signal (B3).
+describe('marketplace-validate-schema: empty-submission contract', () => {
+  it('returns files:[] when there is no source directory', () => {
+    const result = runValidator(null);
+    expect(result.files).toHaveLength(0);
+    expect(result.valid).toBe(true);
+  });
+
+  it('returns files:[] when source has no YAML at all', () => {
+    const result = runValidator({ 'README.md': '# just docs\n' });
+    expect(result.files).toHaveLength(0);
+    expect(result.valid).toBe(true);
+  });
+
+  it('returns files:[] when YAML exists but none is workflow-shaped (no top-level nodes:)', () => {
+    const result = runValidator({ 'brand.yaml': 'name: brand\ncolor: blue\n' });
+    expect(result.files).toHaveLength(0);
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('marketplace-validate-schema: non-empty contrast', () => {
+  it('returns a non-empty files list for a real workflow', () => {
+    const result = runValidator({ 'workflow.yaml': VALID_WORKFLOW });
+    expect(result.files.length).toBeGreaterThan(0);
+    expect(result.files.every((f) => f.valid)).toBe(true);
+    expect(result.valid).toBe(true);
+  });
+
+  it('flags a workflow-shaped YAML that fails schema (files non-empty, valid:false)', () => {
+    const result = runValidator({
+      'bad.yaml': 'name: bad\nnodes:\n  - id: broken\n    provider: nonexistent-provider\n    prompt: hi\n',
+    });
+    expect(result.files.length).toBeGreaterThan(0);
+    expect(result.valid).toBe(false);
+  });
+});

--- a/.archon/scripts/__tests__/marketplace-validate-schema.test.ts
+++ b/.archon/scripts/__tests__/marketplace-validate-schema.test.ts
@@ -51,7 +51,7 @@ nodes:
 // The empty-list contract these tests pin: `files: []` means "no workflow YAML
 // found at the pinned SHA". validate-schema emits valid:true for it (nothing
 // FAILED validation), but the decide node in marketplace-pr-review-and-merge
-// must treat an empty list as request_changes, never as a merge signal (B3).
+// must treat an empty list as request_changes, never as a merge signal.
 describe('marketplace-validate-schema: empty-submission contract', () => {
   it('returns files:[] when there is no source directory', () => {
     const result = runValidator(null);

--- a/.archon/scripts/extract-pr-number.ts
+++ b/.archon/scripts/extract-pr-number.ts
@@ -1,0 +1,91 @@
+#!/usr/bin/env bun
+/**
+ * Extract a single GitHub PR number from a free-form trigger string.
+ *
+ * Input: process.argv[2] (falls back to $ARGUMENTS env var). The workflow bash
+ * node passes "$ARGUMENTS" as a single argv element — it arrives as a subprocess
+ * env var, never textually interpolated, so this is injection-safe.
+ *
+ * Output: the bare number on stdout; also written to $ARTIFACTS_DIR/.pr-number
+ * (checked) when ARTIFACTS_DIR is set. Non-zero exit + stderr message on any
+ * failure (no number, ambiguous input, or write failure) so the node fails loud.
+ *
+ * Rules (deterministic — replaces an AI node that did digit-picking):
+ *  - ANCHORED forms win: `#N`, `PR N` / `PR#N` / `PR-N` (a separator is REQUIRED
+ *    so a URL/repo slug like `pr2-tool` is NOT read as PR #2), and the URL path
+ *    segments `pull/N` / `issues/N`.
+ *  - MULTIPLE DISTINCT anchored numbers => loud error listing them (the old AI
+ *    node errored on ambiguity; a silent first-match would review the wrong PR).
+ *  - Bare-number fallback ONLY when the whole trimmed input is a pure number.
+ *    Anchor-less input with an incidental digit token (e.g. "coleam00 fix 1428",
+ *    "v1.2.3 changelog for 1428") is an ERROR, not a guess.
+ */
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+function collectAnchoredNumbers(input: string): string[] {
+  const found = new Set<string>();
+  // GitHub URL path segments: .../pull/1428, .../issues/1428
+  for (const m of input.matchAll(/\b(?:pull|issues)\/(\d+)/gi)) found.add(m[1]);
+  // Hash form: #1428 (digit must immediately follow '#')
+  for (const m of input.matchAll(/#(\d+)/g)) found.add(m[1]);
+  // "PR" keyword — a separator between "pr" and the digits is REQUIRED, so a
+  // word like "pr2-tool" (digit glued to "pr") does not match as PR #2.
+  for (const m of input.matchAll(/\bpr[\s#:_-]+(\d+)/gi)) found.add(m[1]);
+  return [...found];
+}
+
+function extractPrNumber(rawInput: string): string {
+  const input = rawInput.trim();
+  if (!input) {
+    throw new Error('empty input — provide a PR number (#N, PR N, a pull-request URL, or a bare number)');
+  }
+
+  const anchored = collectAnchoredNumbers(input);
+  if (anchored.length === 1) {
+    return anchored[0];
+  }
+  if (anchored.length > 1) {
+    throw new Error(
+      `ambiguous input — multiple distinct PR numbers found (${anchored.join(', ')}). ` +
+        `Specify exactly one (e.g. "#${anchored[0]}").`,
+    );
+  }
+
+  // No anchored form. Only accept a bare number when that is the WHOLE input —
+  // never pluck a digit token out of prose.
+  if (/^\d+$/.test(input)) {
+    return input;
+  }
+
+  throw new Error(
+    `no PR number found in: ${JSON.stringify(input)}. ` +
+      `Use "#N", "PR N", a pull-request URL, or pass just the number.`,
+  );
+}
+
+function main(): void {
+  const rawInput = process.argv[2] ?? process.env['ARGUMENTS'] ?? '';
+
+  let prNumber: string;
+  try {
+    prNumber = extractPrNumber(rawInput);
+  } catch (err) {
+    process.stderr.write(`ERROR: ${(err as Error).message}\n`);
+    process.exit(1);
+  }
+
+  const artifactsDir = process.env['ARTIFACTS_DIR'];
+  if (artifactsDir) {
+    try {
+      writeFileSync(resolve(artifactsDir, '.pr-number'), prNumber + '\n');
+    } catch (err) {
+      process.stderr.write(`ERROR: failed to write .pr-number: ${(err as Error).message}\n`);
+      process.exit(1);
+    }
+  }
+
+  process.stdout.write(prNumber + '\n');
+}
+
+main();

--- a/.archon/scripts/marketplace-decide.ts
+++ b/.archon/scripts/marketplace-decide.ts
@@ -1,0 +1,117 @@
+/**
+ * Deterministic decision truth table for the marketplace auto-review workflow.
+ *
+ * This gates an irreversible action (auto-merge, and auto-close of a
+ * contributor's PR), so the mapping is a pure, unit-tested function rather than
+ * an inline block. The `decide` node reads the scan/schema/AI/scope/draft inputs
+ * and calls this; the `act` node consumes { decision, reason, close }.
+ *
+ * `close` policy: a reject only auto-closes the PR when a DETERMINISTIC signal
+ * justified it — a scope violation or a critical/high security-scan severity.
+ * An AI-only reject (the model recommended reject while the deterministic checks
+ * are clean) still posts the request-changes review but leaves `close` false, so
+ * the PR stays open and is flagged for a maintainer instead of being closed on a
+ * single model opinion. Setting `close` at each branch keeps one source of truth.
+ */
+
+export interface ScanResult {
+  severity: string;
+  findings?: Array<{ category: string; context: string }>;
+}
+
+export interface SchemaResult {
+  valid: boolean;
+  files?: Array<{ valid: boolean }>;
+}
+
+export interface AiReview {
+  recommendation?: string;
+  reasoning?: string;
+}
+
+export type Decision = 'auto_merge' | 'auto_approve' | 'request_changes' | 'reject';
+
+export interface DecideInput {
+  scopeOk: boolean;
+  isDraft: boolean;
+  scan: ScanResult;
+  schema: SchemaResult;
+  ai: AiReview;
+}
+
+export interface DecideResult {
+  decision: Decision;
+  reason: string;
+  close: boolean;
+}
+
+export function decideMarketplace(input: DecideInput): DecideResult {
+  const { scopeOk, isDraft, scan, schema, ai } = input;
+  const scanHigh = scan.severity === 'critical' || scan.severity === 'high';
+  const noWorkflowFiles = !schema.files || schema.files.length === 0;
+  const aiReason = ai.reasoning ?? '(no reasoning was provided by the AI reviewer)';
+
+  if (!scopeOk) {
+    return {
+      decision: 'reject',
+      reason:
+        'PR modifies files outside packages/docs-web/src/data/marketplace.ts. Only marketplace.ts additions are accepted.',
+      close: true,
+    };
+  }
+
+  if (isDraft) {
+    return {
+      decision: 'request_changes',
+      reason: 'PR is in draft state. Mark as ready for review when complete.',
+      close: false,
+    };
+  }
+
+  if (scanHigh) {
+    const findings = (scan.findings ?? []).map((f) => `${f.category} in ${f.context}`).join('; ');
+    return {
+      decision: 'reject',
+      reason: `Security scan found ${String(scan.severity)} severity issues: ${findings}`,
+      close: true,
+    };
+  }
+
+  if (noWorkflowFiles) {
+    // A marketplace entry must contain at least one workflow. validate-schema
+    // emits { valid: true, files: [] } when the pinned SHA yields no source dir
+    // / no YAML / no workflow-shaped YAML (top-level `nodes:`). Guard it here or
+    // an empty submission scans clean and reaches auto-merge — a fail-open.
+    return {
+      decision: 'request_changes',
+      reason:
+        'Submission contains no workflow YAML at the pinned SHA. A marketplace entry must include at least one workflow definition (a YAML file with a top-level `nodes:` block).',
+      close: false,
+    };
+  }
+
+  if (ai.recommendation === 'reject') {
+    // AI-only reject: deterministic checks are clean, so post the review but
+    // leave the PR open (close:false) and flag it for a maintainer.
+    return { decision: 'reject', reason: aiReason, close: false };
+  }
+
+  if (!schema.valid) {
+    // Reached only when files is non-empty (the empty case is handled above).
+    return {
+      decision: 'request_changes',
+      reason: 'Workflow YAML failed schema validation. Fix structural errors before merging.',
+      close: false,
+    };
+  }
+
+  if (scan.severity === 'medium' || ai.recommendation === 'request_changes') {
+    return { decision: 'request_changes', reason: aiReason, close: false };
+  }
+
+  if (scan.severity === 'none' && (ai.recommendation === 'auto_merge' || ai.recommendation === 'auto_approve')) {
+    return { decision: 'auto_merge', reason: aiReason, close: false };
+  }
+
+  return { decision: 'auto_approve', reason: aiReason, close: false };
+}

--- a/.archon/scripts/marketplace-validate-schema.ts
+++ b/.archon/scripts/marketplace-validate-schema.ts
@@ -57,9 +57,7 @@ if (!artifactsDir) {
 }
 
 const sourceDir = resolve(artifactsDir, 'source');
-if (!existsSync(sourceDir)) {
-  // Empty files list => no workflow found; decide treats this as request_changes.
-  console.log(JSON.stringify({ valid: true, files: [], note: 'no source directory' }));
+if (!existsSync(sourceDir)) {  console.log(JSON.stringify({ valid: true, files: [], note: 'no source directory' }));
   process.exit(0);
 }
 
@@ -78,9 +76,7 @@ function findYamlFiles(dir: string): string[] {
 
 const yamlFiles = findYamlFiles(sourceDir);
 
-if (yamlFiles.length === 0) {
-  // Empty files list => no workflow found; decide treats this as request_changes.
-  console.log(JSON.stringify({ valid: true, files: [], note: 'no yaml files found' }));
+if (yamlFiles.length === 0) {  console.log(JSON.stringify({ valid: true, files: [], note: 'no yaml files found' }));
   process.exit(0);
 }
 
@@ -90,9 +86,7 @@ if (yamlFiles.length === 0) {
 // produces false-positive errors and tanks legitimate submissions.
 const workflowFiles = yamlFiles.filter((p) => looksLikeWorkflow(readFileSync(p, 'utf8')));
 
-if (workflowFiles.length === 0) {
-  // Empty files list => no workflow found; decide treats this as request_changes.
-  console.log(JSON.stringify({ valid: true, files: [], note: 'no workflow yaml files (no top-level nodes:)' }));
+if (workflowFiles.length === 0) {  console.log(JSON.stringify({ valid: true, files: [], note: 'no workflow yaml files (no top-level nodes:)' }));
   process.exit(0);
 }
 

--- a/.archon/scripts/marketplace-validate-schema.ts
+++ b/.archon/scripts/marketplace-validate-schema.ts
@@ -2,6 +2,14 @@
 /**
  * Validates all .yaml files in $ARTIFACTS_DIR/source/ against the Archon workflow schema.
  * Output: JSON to stdout: { valid: boolean, files: FileResult[] }
+ *
+ * Empty-list contract: `files: []` (emitted with `valid: true`) means NO workflow
+ * YAML was found at the pinned SHA — no source dir, no YAML, or no workflow-shaped
+ * YAML (top-level `nodes:`). `valid: true` here reflects only "nothing failed
+ * schema validation", NOT "this is a mergeable submission". The decide node in
+ * marketplace-pr-review-and-merge.yaml treats an empty `files` list as
+ * request_changes (a marketplace entry must contain >=1 workflow), so an empty
+ * list must never be read as a merge signal.
  */
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { resolve, relative } from 'node:path';
@@ -50,6 +58,7 @@ if (!artifactsDir) {
 
 const sourceDir = resolve(artifactsDir, 'source');
 if (!existsSync(sourceDir)) {
+  // Empty files list => no workflow found; decide treats this as request_changes.
   console.log(JSON.stringify({ valid: true, files: [], note: 'no source directory' }));
   process.exit(0);
 }
@@ -70,6 +79,7 @@ function findYamlFiles(dir: string): string[] {
 const yamlFiles = findYamlFiles(sourceDir);
 
 if (yamlFiles.length === 0) {
+  // Empty files list => no workflow found; decide treats this as request_changes.
   console.log(JSON.stringify({ valid: true, files: [], note: 'no yaml files found' }));
   process.exit(0);
 }
@@ -81,6 +91,7 @@ if (yamlFiles.length === 0) {
 const workflowFiles = yamlFiles.filter((p) => looksLikeWorkflow(readFileSync(p, 'utf8')));
 
 if (workflowFiles.length === 0) {
+  // Empty files list => no workflow found; decide treats this as request_changes.
   console.log(JSON.stringify({ valid: true, files: [], note: 'no workflow yaml files (no top-level nodes:)' }));
   process.exit(0);
 }

--- a/.archon/workflows/maintainer/maintainer-review-pr.yaml
+++ b/.archon/workflows/maintainer/maintainer-review-pr.yaml
@@ -212,7 +212,7 @@ nodes:
     timeout: 10000
     depends_on: [post-review]
     script: |
-      import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+      import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
       import { resolve } from 'node:path';
 
       const baseDir = resolve(process.cwd(), '.archon/maintainer-standup');
@@ -237,7 +237,16 @@ nodes:
         run_id: '$WORKFLOW_ID',
       };
 
-      writeFileSync(reviewedPath, JSON.stringify(reviewed, null, 2) + '\n');
+      // Atomic write. This workflow sets mutates_checkout: false, so two
+      // reviews can run concurrently and both read-modify-write this shared
+      // file. Write a temp file in the same directory, then rename over the
+      // target — rename is atomic on POSIX, so a concurrent reader never sees a
+      // half-written file. Last writer wins: an interleaved pair may still drop
+      // one record, which is acceptable here (the standup only needs a
+      // recent-enough "reviewed" marker, and the next review re-adds it).
+      const tmpPath = resolve(baseDir, `.reviewed-prs.${process.pid}.tmp`);
+      writeFileSync(tmpPath, JSON.stringify(reviewed, null, 2) + '\n');
+      renameSync(tmpPath, reviewedPath);
       console.log(`Recorded review of PR #${prNumber}`);
 
   # ═══════════════════════════════════════════════════════════════

--- a/.archon/workflows/maintainer/maintainer-review-pr.yaml
+++ b/.archon/workflows/maintainer/maintainer-review-pr.yaml
@@ -31,26 +31,17 @@ nodes:
 
   - id: extract-pr-number
     bash: |
-      # Bash-first PR-number extraction — digit-picking needs no AI. $ARGUMENTS
-      # arrives as a subprocess env var (never textually interpolated), so
-      # quoting it is safe against shell injection.
+      # PR-number parsing lives in a tested script so its edge cases are pinned
+      # (.archon/scripts/extract-pr-number.ts): anchored forms (#N, PR N,
+      # pull/N, issues/N) win, a bare number is accepted only when it is the
+      # WHOLE input, multiple distinct anchored numbers error loudly, and a URL
+      # org/repo slug (e.g. coleam00, pr2-tool) never leaks a stray digit. The
+      # script writes $ARTIFACTS_DIR/.pr-number (checked) and prints the number.
       #
-      # Anchor on a keyword/URL segment BEFORE grabbing digits: a bare
-      # `grep -oE '[0-9]+' | head -1` picks the first number anywhere in the
-      # string, which is wrong for a PR URL whose org/repo slug contains digits
-      # (github.com/coleam00/Archon/pull/1428 would yield "00"). Prefer the
-      # number following `pull/`, `issues/`, `#`, or `PR`; fall back to a bare
-      # number scan only when no anchored form is present.
-      PR_NUM=$(echo "$ARGUMENTS" | grep -oiE '(pull/|issues/|#|pr[[:space:]#]*)[0-9]+' | grep -oE '[0-9]+' | head -1)
-      if [ -z "$PR_NUM" ]; then
-        PR_NUM=$(echo "$ARGUMENTS" | tr -d "'\"\`\n " | grep -oE '[0-9]+' | head -1)
-      fi
-      if [ -z "$PR_NUM" ]; then
-        echo "ERROR: Could not extract a PR number from arguments: $ARGUMENTS" >&2
-        exit 1
-      fi
-      echo "$PR_NUM" > "$ARTIFACTS_DIR/.pr-number"
-      echo "$PR_NUM"
+      # $ARGUMENTS arrives as a subprocess env var (never textually
+      # interpolated) and is passed as a single argv element, so this is
+      # injection-safe. A non-zero exit (no number / ambiguous) fails the node.
+      bun --no-env-file run .archon/scripts/extract-pr-number.ts "$ARGUMENTS"
     timeout: 10000
 
   # ═══════════════════════════════════════════════════════════════

--- a/.archon/workflows/maintainer/maintainer-review-pr.yaml
+++ b/.archon/workflows/maintainer/maintainer-review-pr.yaml
@@ -30,20 +30,28 @@ nodes:
   # ═══════════════════════════════════════════════════════════════
 
   - id: extract-pr-number
-    prompt: |
-      Find the GitHub PR number for this request.
-
-      Request: $ARGUMENTS
-
-      Rules:
-      - If the message contains an explicit PR number (e.g., "#1428", "PR 1428", "1428"), extract that number.
-      - If the message contains a PR URL (https://github.com/.../pull/N), extract N.
-      - If you cannot determine a single PR number, output ERROR.
-
-      CRITICAL: Output ONLY the bare number with no quotes, markdown, or explanation.
-      Example correct output: 1428
-    allowed_tools: []
-    idle_timeout: 30000
+    bash: |
+      # Bash-first PR-number extraction — digit-picking needs no AI. $ARGUMENTS
+      # arrives as a subprocess env var (never textually interpolated), so
+      # quoting it is safe against shell injection.
+      #
+      # Anchor on a keyword/URL segment BEFORE grabbing digits: a bare
+      # `grep -oE '[0-9]+' | head -1` picks the first number anywhere in the
+      # string, which is wrong for a PR URL whose org/repo slug contains digits
+      # (github.com/coleam00/Archon/pull/1428 would yield "00"). Prefer the
+      # number following `pull/`, `issues/`, `#`, or `PR`; fall back to a bare
+      # number scan only when no anchored form is present.
+      PR_NUM=$(echo "$ARGUMENTS" | grep -oiE '(pull/|issues/|#|pr[[:space:]#]*)[0-9]+' | grep -oE '[0-9]+' | head -1)
+      if [ -z "$PR_NUM" ]; then
+        PR_NUM=$(echo "$ARGUMENTS" | tr -d "'\"\`\n " | grep -oE '[0-9]+' | head -1)
+      fi
+      if [ -z "$PR_NUM" ]; then
+        echo "ERROR: Could not extract a PR number from arguments: $ARGUMENTS" >&2
+        exit 1
+      fi
+      echo "$PR_NUM" > "$ARTIFACTS_DIR/.pr-number"
+      echo "$PR_NUM"
+    timeout: 10000
 
   # ═══════════════════════════════════════════════════════════════
   # PHASE 2: GATHER PR DATA (parallel)
@@ -51,12 +59,8 @@ nodes:
 
   - id: fetch-pr
     bash: |
-      PR_NUM=$(echo "$extract-pr-number.output" | tr -d "'\"\`\n " | grep -oE '[0-9]+' | head -1)
-      if [ -z "$PR_NUM" ]; then
-        echo "Failed to extract PR number from: $extract-pr-number.output" >&2
-        exit 1
-      fi
-      echo "$PR_NUM" > "$ARTIFACTS_DIR/.pr-number"
+      # extract-pr-number already validated + wrote the number to .pr-number.
+      PR_NUM=$(cat "$ARTIFACTS_DIR/.pr-number")
       gh pr view "$PR_NUM" --json number,title,body,labels,comments,reviews,state,mergeable,mergeStateStatus,additions,deletions,changedFiles,files,author,createdAt,updatedAt,baseRefName,headRefName,reviewDecision,reviewRequests,isDraft
     depends_on: [extract-pr-number]
     timeout: 30000

--- a/.archon/workflows/maintainer/maintainer-review-pr.yaml
+++ b/.archon/workflows/maintainer/maintainer-review-pr.yaml
@@ -217,7 +217,14 @@ nodes:
       if (existsSync(reviewedPath)) {
         try {
           reviewed = JSON.parse(readFileSync(reviewedPath, 'utf8'));
-        } catch {
+        } catch (err) {
+          // Corrupt state is not silently reset: log before falling back so the
+          // wiped history leaves a diagnostic trace (unlike a bare catch, which
+          // would erase every recorded review with no signal).
+          console.error(
+            `record-review: reviewed-prs.json is corrupt (${(err as Error).message}); ` +
+              `starting from empty. Prior review markers are lost — restore from git if they mattered.`,
+          );
           reviewed = {};
         }
       }

--- a/.archon/workflows/maintainer/marketplace-pr-review-and-merge.yaml
+++ b/.archon/workflows/maintainer/marketplace-pr-review-and-merge.yaml
@@ -373,7 +373,19 @@ nodes:
         reason = aiReview.reasoning;
       }
 
-      const output = { decision, reason, author, slug };
+      // R2 governance gate: only auto-close a contributor's PR when a
+      // DETERMINISTIC signal justified the reject — a critical/high security
+      // scan or a scope violation. An AI-ONLY reject (Haiku recommended reject
+      // but the deterministic checks are clean) still posts the request-changes
+      // review, but does NOT auto-close: it's flagged for a maintainer to make
+      // the final call. Only `reject` decisions are ever eligible to close.
+      const deterministicReject =
+        scopeResult !== 'SCOPE_OK' ||
+        scanResult.severity === 'critical' ||
+        scanResult.severity === 'high';
+      const close = decision === 'reject' && deterministicReject;
+
+      const output = { decision, reason, author, slug, close };
       writeFileSync(resolve(artifactsDir, 'decision.json'), JSON.stringify(output, null, 2));
       console.log(JSON.stringify(output));
 
@@ -387,6 +399,7 @@ nodes:
       DECISION=$(cat "$ARTIFACTS_DIR/decision.json" | jq -r '.decision')
       REASON=$(cat "$ARTIFACTS_DIR/decision.json" | jq -r '.reason')
       SLUG=$(cat "$ARTIFACTS_DIR/decision.json" | jq -r '.slug // empty')
+      CLOSE=$(cat "$ARTIFACTS_DIR/decision.json" | jq -r '.close // false')
       IS_FORK=$(jq -r '.isCrossRepository // false' "$ARTIFACTS_DIR/pr-meta.json")
 
       # Auth preflight. The earlier read-only nodes (gh pr view/diff) succeed
@@ -459,13 +472,24 @@ nodes:
       *Reviewed by Archon marketplace-pr-review-and-merge workflow.*"
           ;;
         reject)
-          echo "Decision: REJECT — closing PR #$PR_NUM as out of scope or unsafe"
+          if [ "$CLOSE" = "true" ]; then
+            echo "Decision: REJECT — requesting changes and closing PR #$PR_NUM (deterministic scan/scope concurred)"
+          else
+            echo "Decision: REJECT — requesting changes on PR #$PR_NUM (AI-only; flagged for maintainer close, not auto-closed)"
+          fi
           retry gh pr review "$PR_NUM" --request-changes --body "**Marketplace Auto-Review: Rejected**
 
       $REASON
 
       *Reviewed by Archon marketplace-pr-review-and-merge workflow.*"
-          gh pr close "$PR_NUM" --comment "Closing this PR per the automated review above." 2>/dev/null || true
+          # R2: only auto-close when a deterministic signal (critical/high scan or
+          # scope violation) justified the reject. An AI-only reject leaves the PR
+          # open and flags it for a maintainer rather than closing a human's work.
+          if [ "$CLOSE" = "true" ]; then
+            gh pr close "$PR_NUM" --comment "Closing this PR per the automated review above." 2>/dev/null || true
+          else
+            retry gh pr comment "$PR_NUM" --body "**Flagged for maintainer close.** The automated review recommended rejecting this submission, but the deterministic security scan did not independently flag it as critical/high — so it has not been auto-closed. A maintainer should make the final call."
+          fi
           ;;
         *)
           echo "ERROR: Unexpected decision value: $DECISION" >&2

--- a/.archon/workflows/maintainer/marketplace-pr-review-and-merge.yaml
+++ b/.archon/workflows/maintainer/marketplace-pr-review-and-merge.yaml
@@ -35,10 +35,17 @@ nodes:
       # whether the head branch lives on a contributor fork — the base-repo
       # GITHUB_TOKEN cannot delete a fork's branch, so --delete-branch must be
       # skipped for those to avoid a spurious merge-step failure.
-      gh pr view "$PR_NUM" \
-        --json number,title,body,author,state,isDraft,additions,deletions,changedFiles,files,baseRefName,headRefName,isCrossRepository \
-        > "$ARTIFACTS_DIR/pr-meta.json"
-
+      #
+      # Capture-then-check (mirrors fetch-diff): a bare `gh ... > file` masks a
+      # gh failure (auth, network, deleted PR) as an empty file plus exit 0,
+      # which would let verify-scope read zero changed files and mint a false
+      # SCOPE_OK. Let the failure fail this node instead.
+      if ! pr_meta=$(gh pr view "$PR_NUM" \
+        --json number,title,body,author,state,isDraft,additions,deletions,changedFiles,files,baseRefName,headRefName,isCrossRepository); then
+        echo "ERROR: gh pr view failed for PR #$PR_NUM (auth, network, or the PR does not exist)." >&2
+        exit 1
+      fi
+      printf '%s\n' "$pr_meta" > "$ARTIFACTS_DIR/pr-meta.json"
       cat "$ARTIFACTS_DIR/pr-meta.json"
     timeout: 30000
 
@@ -355,8 +362,11 @@ nodes:
   - id: act
     bash: |
       PR_NUM=$(cat "$ARTIFACTS_DIR/.pr-number")
-      DECISION=$(cat "$ARTIFACTS_DIR/decision.json" | jq -r '.decision')
-      REASON=$(cat "$ARTIFACTS_DIR/decision.json" | jq -r '.reason')
+      # `// empty` on every read: a missing field yields "" (handled by the case
+      # default / empty body) rather than the literal string "null" leaking into
+      # a posted PR comment.
+      DECISION=$(cat "$ARTIFACTS_DIR/decision.json" | jq -r '.decision // empty')
+      REASON=$(cat "$ARTIFACTS_DIR/decision.json" | jq -r '.reason // empty')
       SLUG=$(cat "$ARTIFACTS_DIR/decision.json" | jq -r '.slug // empty')
       CLOSE=$(cat "$ARTIFACTS_DIR/decision.json" | jq -r '.close // false')
       IS_FORK=$(jq -r '.isCrossRepository // false' "$ARTIFACTS_DIR/pr-meta.json")
@@ -431,22 +441,27 @@ nodes:
       *Reviewed by Archon marketplace-pr-review-and-merge workflow.*"
           ;;
         reject)
-          if [ "$CLOSE" = "true" ]; then
-            echo "Decision: REJECT — requesting changes and closing PR #$PR_NUM (deterministic scan/scope concurred)"
-          else
-            echo "Decision: REJECT — requesting changes on PR #$PR_NUM (AI-only; flagged for maintainer close, not auto-closed)"
-          fi
           retry gh pr review "$PR_NUM" --request-changes --body "**Marketplace Auto-Review: Rejected**
 
       $REASON
 
       *Reviewed by Archon marketplace-pr-review-and-merge workflow.*"
-          # R2: only auto-close when a deterministic signal (critical/high scan or
-          # scope violation) justified the reject. An AI-only reject leaves the PR
-          # open and flags it for a maintainer rather than closing a human's work.
+          # A reject only auto-closes the PR when a deterministic signal
+          # (critical/high security scan or a scope violation) justified it; an
+          # AI-only reject stays open and is flagged for a maintainer rather than
+          # closing a contributor's work on a single model opinion. Closing is a
+          # governance action, so it runs through `retry` and its failure is
+          # surfaced loudly — never swallowed with `2>/dev/null || true` — and the
+          # "closed" confirmation is printed only when the close actually succeeds.
           if [ "$CLOSE" = "true" ]; then
-            gh pr close "$PR_NUM" --comment "Closing this PR per the automated review above." 2>/dev/null || true
+            echo "Decision: REJECT — deterministic scan/scope concurred; closing PR #$PR_NUM"
+            if retry gh pr close "$PR_NUM" --comment "Closing this PR per the automated review above."; then
+              echo "Closed PR #$PR_NUM."
+            else
+              echo "WARNING: failed to close PR #$PR_NUM after retries — it remains OPEN and needs a manual close." >&2
+            fi
           else
+            echo "Decision: REJECT — deterministic checks clean; PR #$PR_NUM stays open, flagged for maintainer close"
             retry gh pr comment "$PR_NUM" --body "**Flagged for maintainer close.** The automated review recommended rejecting this submission, but the deterministic security scan did not independently flag it as critical/high — so it has not been auto-closed. A maintainer should make the final call."
           fi
           ;;

--- a/.archon/workflows/maintainer/marketplace-pr-review-and-merge.yaml
+++ b/.archon/workflows/maintainer/marketplace-pr-review-and-merge.yaml
@@ -295,6 +295,11 @@ nodes:
     script: |
       import { readFileSync, writeFileSync } from 'node:fs';
       import { resolve } from 'node:path';
+      // The decision truth table (and the auto-close policy) lives in a tested
+      // script — it gates an irreversible auto-merge/close, so the mapping is
+      // unit-tested rather than trusted inline. Relative import resolves from the
+      // workflow cwd (repo root), same as the named `script:` nodes.
+      import { decideMarketplace } from './.archon/scripts/marketplace-decide.ts';
 
       const artifactsDir = process.env['ARTIFACTS_DIR'] ?? '';
       const prMeta = JSON.parse(readFileSync(resolve(artifactsDir, 'pr-meta.json'), 'utf8')) as {
@@ -324,9 +329,6 @@ nodes:
         process.exit(1);
       }
 
-      const author = prMeta.author.login;
-      const isDraft = prMeta.isDraft;
-
       // Read slug from entry.json for merge commit subject
       let slug = '';
       try {
@@ -334,58 +336,15 @@ nodes:
         slug = entry.slug ?? '';
       } catch {}
 
-      let decision: 'auto_merge' | 'auto_approve' | 'request_changes' | 'reject';
-      let reason: string;
+      const { decision, reason, close } = decideMarketplace({
+        scopeOk: scopeResult === 'SCOPE_OK',
+        isDraft: prMeta.isDraft,
+        scan: scanResult,
+        schema: schemaResult,
+        ai: aiReview,
+      });
 
-      if (scopeResult !== 'SCOPE_OK') {
-        decision = 'reject';
-        reason = 'PR modifies files outside packages/docs-web/src/data/marketplace.ts. Only marketplace.ts additions are accepted.';
-      } else if (isDraft) {
-        decision = 'request_changes';
-        reason = 'PR is in draft state. Mark as ready for review when complete.';
-      } else if (scanResult.severity === 'critical' || scanResult.severity === 'high') {
-        decision = 'reject';
-        reason = `Security scan found ${String(scanResult.severity)} severity issues: ${scanResult.findings.map((f: { category: string; context: string }) => `${f.category} in ${f.context}`).join('; ')}`;
-      } else if (!schemaResult.files || (schemaResult.files as Array<{ valid: boolean }>).length === 0) {
-        // A marketplace entry must contain at least one workflow. validate-schema
-        // emits { valid: true, files: [] } when the pinned SHA yields no source
-        // dir / no YAML / no workflow-shaped YAML (top-level `nodes:`). Without
-        // this branch such a submission passes the schema guard below (which only
-        // fires on valid:false with a NON-empty file list), scans clean (nothing
-        // to scan), and reaches auto-merge — a fail-open. Reject deterministically.
-        decision = 'request_changes';
-        reason =
-          'Submission contains no workflow YAML at the pinned SHA. A marketplace entry must include at least one workflow definition (a YAML file with a top-level `nodes:` block).';
-      } else if (aiReview.recommendation === 'reject') {
-        decision = 'reject';
-        reason = aiReview.reasoning;
-      } else if (!schemaResult.valid && schemaResult.files && (schemaResult.files as Array<{valid: boolean}>).length > 0) {
-        decision = 'request_changes';
-        reason = 'Workflow YAML failed schema validation. Fix structural errors before merging.';
-      } else if (scanResult.severity === 'medium' || aiReview.recommendation === 'request_changes') {
-        decision = 'request_changes';
-        reason = aiReview.reasoning;
-      } else if (scanResult.severity === 'none' && (aiReview.recommendation === 'auto_merge' || aiReview.recommendation === 'auto_approve')) {
-        decision = 'auto_merge';
-        reason = aiReview.reasoning;
-      } else {
-        decision = 'auto_approve';
-        reason = aiReview.reasoning;
-      }
-
-      // R2 governance gate: only auto-close a contributor's PR when a
-      // DETERMINISTIC signal justified the reject — a critical/high security
-      // scan or a scope violation. An AI-ONLY reject (Haiku recommended reject
-      // but the deterministic checks are clean) still posts the request-changes
-      // review, but does NOT auto-close: it's flagged for a maintainer to make
-      // the final call. Only `reject` decisions are ever eligible to close.
-      const deterministicReject =
-        scopeResult !== 'SCOPE_OK' ||
-        scanResult.severity === 'critical' ||
-        scanResult.severity === 'high';
-      const close = decision === 'reject' && deterministicReject;
-
-      const output = { decision, reason, author, slug, close };
+      const output = { decision, reason, author: prMeta.author.login, slug, close };
       writeFileSync(resolve(artifactsDir, 'decision.json'), JSON.stringify(output, null, 2));
       console.log(JSON.stringify(output));
 

--- a/.archon/workflows/maintainer/marketplace-pr-review-and-merge.yaml
+++ b/.archon/workflows/maintainer/marketplace-pr-review-and-merge.yaml
@@ -346,6 +346,16 @@ nodes:
       } else if (scanResult.severity === 'critical' || scanResult.severity === 'high') {
         decision = 'reject';
         reason = `Security scan found ${String(scanResult.severity)} severity issues: ${scanResult.findings.map((f: { category: string; context: string }) => `${f.category} in ${f.context}`).join('; ')}`;
+      } else if (!schemaResult.files || (schemaResult.files as Array<{ valid: boolean }>).length === 0) {
+        // A marketplace entry must contain at least one workflow. validate-schema
+        // emits { valid: true, files: [] } when the pinned SHA yields no source
+        // dir / no YAML / no workflow-shaped YAML (top-level `nodes:`). Without
+        // this branch such a submission passes the schema guard below (which only
+        // fires on valid:false with a NON-empty file list), scans clean (nothing
+        // to scan), and reaches auto-merge — a fail-open. Reject deterministically.
+        decision = 'request_changes';
+        reason =
+          'Submission contains no workflow YAML at the pinned SHA. A marketplace entry must include at least one workflow definition (a YAML file with a top-level `nodes:` block).';
       } else if (aiReview.recommendation === 'reject') {
         decision = 'reject';
         reason = aiReview.reasoning;

--- a/.archon/workflows/maintainer/marketplace-pr-review-and-merge.yaml
+++ b/.archon/workflows/maintainer/marketplace-pr-review-and-merge.yaml
@@ -5,6 +5,9 @@ description: |
   runs a deterministic security scan, runs a Haiku AI review, then decides:
   auto-merge / auto-approve / request-changes / reject.
   Clean submissions (scan severity none, AI approval) are auto-merged.
+  Rejects auto-close the PR only when a deterministic signal concurred (a
+  scope violation or a critical/high security scan); an AI-only reject posts a
+  request-changes review and stays open, flagged for a maintainer to close.
   Triggers: "marketplace review", "review marketplace PR <n>",
             "marketplace-pr-review-and-merge <n>".
   Arguments: PR number (integer).

--- a/.archon/workflows/maintainer/repo-triage-minimax.yaml
+++ b/.archon/workflows/maintainer/repo-triage-minimax.yaml
@@ -50,7 +50,7 @@ nodes:
         5. Persist state so future runs remember what's already been processed
 
       Labelling is NOT performed by this Pi/Minimax variant — it requires
-      Claude's Task tool to invoke the on-disk `triage-agent` sub-agent.
+      Claude's Agent tool to invoke the on-disk `triage-agent` sub-agent.
       Run `repo-triage.yaml` (the Claude variant) when label-coverage matters.
 
       # State file
@@ -124,7 +124,7 @@ nodes:
       in a single pass.
 
       For each issue that needs a brief, build this object IN-LINE
-      (no Task calls, no sub-agent — Pi handles everything in one turn):
+      (no Agent calls, no sub-agent — Pi handles everything in one turn):
 
           {
             "number": <N>,
@@ -371,7 +371,7 @@ nodes:
 
       You already have the closed-issue list (with title + body) in
       `$ARTIFACTS_DIR/closed-issues.json`. Read it once and process every
-      entry needing a brief in a single pass — no Task fan-out, no
+      entry needing a brief in a single pass — no Agent fan-out, no
       sub-agent. For each closed issue, build this object inline:
 
           {
@@ -576,7 +576,7 @@ nodes:
       You already have the open and closed PR lists (with title + body)
       in `$ARTIFACTS_DIR/open-prs.json` and `closed-prs.json`. Read them
       once and process every PR needing a brief in a single pass — no
-      Task fan-out, no sub-agent.
+      Agent fan-out, no sub-agent.
 
       For each PR needing a brief, fetch the diff (no `gh pr view` is
       needed because title + body are already in the JSON dump):
@@ -718,7 +718,7 @@ nodes:
       Your job on every (non-dry, non-skipped) run:
         1. For every open PR not yet fully processed, identify related
            open issues by reading the PR title/body/diff and comparing
-           against the open-issue list (inline — no Task fan-out).
+           against the open-issue list (inline — no Agent fan-out).
         2. Add a `Closes #X` SUGGESTION comment on the PR only when the
            PR fully addresses the issue, after re-reading the issue + PR diff.
         3. Otherwise post a conservative "related to #X" cross-reference
@@ -1025,7 +1025,7 @@ nodes:
     allowed_tools: [Bash, Read, Write]
     prompt: |
       You post gentle reminders on GitHub issues and PRs that have gone
-      quiet. No auto-close. No Task fan-out needed — this is direct work.
+      quiet. No auto-close. No Agent fan-out needed — this is direct work.
 
       # Mode check — READ FIRST
 
@@ -1150,7 +1150,7 @@ nodes:
   # Digest — runs LAST, after every other node. Reads each prior node's
   # final assistant output via $<nodeId>.output and synthesises one
   # maintainer-facing report to $ARTIFACTS_DIR/digest.md. Pure synthesis —
-  # no gh calls, no mutations, no Task fan-out.
+  # no gh calls, no mutations, no Agent fan-out.
   # ---------------------------------------------------------------------------
   - id: digest
     depends_on:

--- a/.archon/workflows/maintainer/repo-triage.yaml
+++ b/.archon/workflows/maintainer/repo-triage.yaml
@@ -20,7 +20,7 @@ nodes:
   # ---------------------------------------------------------------------------
   - id: triage-issues
     model: sonnet
-    allowed_tools: [Bash, Read, Write, Task]
+    allowed_tools: [Bash, Read, Write, Agent]
     agents:
       brief-gen:
         description: >-
@@ -86,8 +86,8 @@ nodes:
           full body you would have posted.
         - Do NOT run `gh issue (comment|close|edit)`. Do NOT use the Write
           tool on `.archon/state/*.json`.
-        - When delegating via Task to triage-agent/brief-gen, PREPEND this
-          exact sentence to every Task prompt:
+        - When delegating via Agent to triage-agent/brief-gen, PREPEND this
+          exact sentence to every Agent prompt:
               "DRY_RUN=1 is active. Do NOT apply labels or mutate the
                issue in any way. Instead print `[DRY] would ...` lines
                describing what you would have done."
@@ -170,18 +170,18 @@ nodes:
       ## 4. LABEL PASS — parallel fan-out to triage-agent
 
       PREFLIGHT: verify the on-disk sub-agent definition exists before
-      attempting any Task call:
+      attempting any Agent call:
 
           test -f .claude/agents/triage-agent.md
 
-      If missing, SKIP the whole label pass (do not attempt Task calls
+      If missing, SKIP the whole label pass (do not attempt Agent calls
       that would fail obscurely at runtime). Log:
           "[triage-issues] label pass skipped: .claude/agents/triage-agent.md
            missing — install the skill-adjacent agent file to enable labeling."
       Continue to the brief pass — labeling is a nice-to-have, not a blocker.
 
       Spawn the existing on-disk `triage-agent` sub-agent in PARALLEL (a
-      single assistant turn with multiple Task tool calls — this matters
+      single assistant turn with multiple Agent tool calls — this matters
       for speed). Per-task prompt:
 
           "Triage open issue #<N> in this repository. Fetch it via
@@ -193,7 +193,7 @@ nodes:
 
       ## 5. BRIEF PASS — parallel fan-out to brief-gen
       For every issue that needs a brief, spawn the inline `brief-gen`
-      sub-agent in PARALLEL (single turn, multiple Task calls).
+      sub-agent in PARALLEL (single turn, multiple Agent calls).
 
       Per-task prompt template:
           "Brief issue #<N>.
@@ -249,7 +249,7 @@ nodes:
                 postedAt: "<now-iso>"
               }
 
-      Post sequentially (not via Task) so you can reliably capture each
+      Post sequentially (not via Agent) so you can reliably capture each
       comment ID.
 
       ## 8. RECONCILE PASS — 3-day auto-close
@@ -309,8 +309,8 @@ nodes:
       - State writes are ATOMIC per run — only write the final merged
         state once at step 9. If a pass fails midway, the previous state
         remains.
-      - Parallel Task fan-out is strict: ONE assistant turn with MANY
-        Task tool calls, not sequential Task calls.
+      - Parallel Agent fan-out is strict: ONE assistant turn with MANY
+        Agent tool calls, not sequential Agent calls.
 
   # ---------------------------------------------------------------------------
   # Closed-dedup check — follow-up to triage-issues. Checks whether any
@@ -322,7 +322,7 @@ nodes:
   - id: closed-dedup-check
     depends_on: [triage-issues]
     model: sonnet
-    allowed_tools: [Bash, Read, Write, Task]
+    allowed_tools: [Bash, Read, Write, Agent]
     agents:
       closed-brief-gen:
         description: >-
@@ -372,14 +372,14 @@ nodes:
 
       If SKIP_CLOSED_DEDUP=1 — print
           "Skipping closed-dedup-check per SKIP_CLOSED_DEDUP=1"
-      and exit immediately. No gh calls, no state read, no Task fan-out.
+      and exit immediately. No gh calls, no state read, no Agent fan-out.
 
       If DRY_RUN=1 — READ-ONLY:
         - Do read-only work (gh list/view, state reads, clustering).
         - For every mutation (comment, close, state write), print `[DRY] would ...`.
         - Do NOT run gh issue comment/close.
         - Do NOT use Write on `.archon/state/*.json`.
-        - When spawning closed-brief-gen via Task, prepend to its prompt:
+        - When spawning closed-brief-gen via Agent, prepend to its prompt:
               "DRY_RUN=1 is active. Run only read-only gh commands."
         - End with a summary prefixed `## (DRY RUN) Closed-dedup check — <now>`.
 
@@ -461,9 +461,9 @@ nodes:
         - If `state.closedBriefs[N]` exists AND sha matches → reuse.
         - Else → needs BRIEF.
 
-      ## 4. BRIEF PASS — parallel Task fan-out to closed-brief-gen
+      ## 4. BRIEF PASS — parallel Agent fan-out to closed-brief-gen
       Spawn `closed-brief-gen` in PARALLEL (single assistant turn, multiple
-      Task calls) for every closed issue needing a brief. Per-task prompt:
+      Agent calls) for every closed issue needing a brief. Per-task prompt:
 
           "Brief closed issue #<N>."
 
@@ -509,7 +509,7 @@ nodes:
                 postedAt: "<now-iso>"
               }
 
-      Post sequentially (not via Task) so you can capture comment IDs.
+      Post sequentially (not via Agent) so you can capture comment IDs.
 
       ## 7. RECONCILE PASS — 3-day auto-close
       Cache bot login once at top-of-run: `gh api user --jq .login`.
@@ -556,7 +556,7 @@ nodes:
         erodes trust. When in doubt, skip.
       - If `gh` errors (auth, rate limit), abort cleanly and summarise.
       - State writes are ATOMIC — one Write at step 8.
-      - Parallel Task fan-out required for step 4 only. Step 6 is sequential
+      - Parallel Agent fan-out required for step 4 only. Step 6 is sequential
         to capture comment IDs reliably.
 
   # ---------------------------------------------------------------------------
@@ -568,7 +568,7 @@ nodes:
   # ---------------------------------------------------------------------------
   - id: closed-pr-dedup-check
     model: sonnet
-    allowed_tools: [Bash, Read, Write, Task]
+    allowed_tools: [Bash, Read, Write, Agent]
     agents:
       pr-brief-gen:
         description: >-
@@ -628,7 +628,7 @@ nodes:
         - All read-only gh calls OK.
         - Do NOT run `gh pr comment`. Do NOT use Write on state files.
         - Print `[DRY] would ...` for every mutation.
-        - When spawning pr-brief-gen via Task, prepend:
+        - When spawning pr-brief-gen via Agent, prepend:
               "DRY_RUN=1 is active. Run only read-only gh commands."
         - End with a summary prefixed `## (DRY RUN) Closed-PR dedup — <now>`.
 
@@ -686,7 +686,7 @@ nodes:
           and the sha matches → reuse the cached brief.
         - Else → needs BRIEF.
 
-      ## 4. BRIEF PASS — parallel Task fan-out to pr-brief-gen
+      ## 4. BRIEF PASS — parallel Agent fan-out to pr-brief-gen
       Spawn `pr-brief-gen` in PARALLEL for every PR needing a brief
       (open AND closed, all in a single assistant turn if possible — the
       sub-agent handles both via the `state` hint).
@@ -745,7 +745,7 @@ nodes:
                 postedAt: "<now-iso>"
               }
 
-      Post sequentially (not via Task) for reliable comment-ID capture.
+      Post sequentially (not via Agent) for reliable comment-ID capture.
 
       NO auto-close. PRs are author work product; closing them without
       consent discards effort. A reminder comment is the right ceiling.
@@ -770,7 +770,7 @@ nodes:
       - Idempotent comments — always check existing PR comments before
         posting to avoid noise.
       - State writes are ATOMIC — one Write at step 7.
-      - Parallel Task fan-out for step 4 only. Step 6 sequential.
+      - Parallel Agent fan-out for step 4 only. Step 6 sequential.
       - Strict matching — false positives on PR dedup are a maintainer
         trust hit. When ambiguous, skip.
 
@@ -779,7 +779,7 @@ nodes:
   # ---------------------------------------------------------------------------
   - id: link-prs
     model: sonnet
-    allowed_tools: [Bash, Read, Write, Task]
+    allowed_tools: [Bash, Read, Write, Agent]
     agents:
       pr-issue-matcher:
         description: >-
@@ -862,7 +862,7 @@ nodes:
           "Skipping link-prs per SKIP_PR_LINK=1 — no state read, no gh
            calls, no comments."
       and exit immediately. Do not read state, do not call gh, do not
-      use Task. This is the "staged rollout" escape hatch for the first
+      use Agent. This is the "staged rollout" escape hatch for the first
       live run of the full workflow.
 
       If DRY_RUN=1 — READ-ONLY mode:
@@ -872,8 +872,8 @@ nodes:
           body you would have posted on which target.
         - Do NOT run `gh issue comment` or `gh pr comment`. Do NOT use
           the Write tool on `.archon/state/*.json`.
-        - When delegating via Task to pr-issue-matcher, PREPEND this exact
-          sentence to every Task prompt:
+        - When delegating via Agent to pr-issue-matcher, PREPEND this exact
+          sentence to every Agent prompt:
               "DRY_RUN=1 is active. Run only read-only gh commands."
           (pr-issue-matcher is already read-only, so this is belt-and-braces.)
         - End with the standard summary table, but prefix the title
@@ -960,9 +960,9 @@ nodes:
         - If `state.linkedPrs[N]` exists AND its sha matches → SKIP.
         - Else → needs MATCHING.
 
-      ## 4. MATCH PASS — parallel Task fan-out to pr-issue-matcher
+      ## 4. MATCH PASS — parallel Agent fan-out to pr-issue-matcher
       Spawn `pr-issue-matcher` in PARALLEL for every PR needing matching
-      (single turn, multiple Task calls).
+      (single turn, multiple Agent calls).
 
       Per-task prompt template:
           "Match PR #<N> against the open issues below.
@@ -1034,7 +1034,7 @@ nodes:
       On idempotent SKIP (existing comment found), do NOT attempt to
       extract an ID — leave the slot absent.
 
-      Post sequentially — don't Task-fan-out this step.
+      Post sequentially — don't Agent-fan-out this step.
 
       ## 6b. TEMPLATE NUDGE PASS — auto-comment on low-quality PR fills
 
@@ -1141,7 +1141,7 @@ nodes:
         evidence is overwhelming.
       - If `gh` errors out (auth, rate limit), abort cleanly and summarise.
       - State writes are ATOMIC per run — a single Write at step 7.
-      - Parallel Task fan-out is required for the match pass only. Act
+      - Parallel Agent fan-out is required for the match pass only. Act
         pass is sequential for idempotent comment-ID capture.
       - Template nudge comments happen AT MOST ONCE per PR (tracked via
         `templateNudgedAt`). Never re-nudge — contributors will ignore us.
@@ -1157,7 +1157,7 @@ nodes:
     allowed_tools: [Bash, Read, Write]
     prompt: |
       You post gentle reminders on GitHub issues and PRs that have gone
-      quiet. No auto-close. No Task fan-out needed — this is direct work.
+      quiet. No auto-close. No Agent fan-out needed — this is direct work.
 
       # Mode check — READ FIRST
 
@@ -1282,7 +1282,7 @@ nodes:
   # Digest — runs LAST, after every other node. Reads each prior node's
   # final assistant output via $<nodeId>.output and synthesises one
   # maintainer-facing report to $ARTIFACTS_DIR/digest.md. Pure synthesis —
-  # no gh calls, no mutations, no Task fan-out.
+  # no gh calls, no mutations, no Agent fan-out.
   # ---------------------------------------------------------------------------
   - id: digest
     depends_on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Run tests
         run: bun run test
 
+      # .archon/scripts/ tests aren't discovered by the workspace-filtered
+      # `bun run test`, so run them explicitly here (and chained into
+      # `bun run validate` locally) or their coverage silently bit-rots.
+      - name: Run .archon/scripts tests
+        run: bun run test:archon-scripts
+
   docker-build:
     runs-on: ubuntu-latest
     permissions:

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "generate:capability-matrix": "bun run scripts/generate-capability-matrix.ts",
     "check:capability-matrix": "bun run scripts/generate-capability-matrix.ts --check",
     "test": "bun --filter '*' --parallel test",
+    "test:archon-scripts": "bun test ./.archon/scripts/",
     "test:watch": "bun --filter @archon/server test:watch",
     "type-check": "bun --filter '*' type-check && bun x tsc --noEmit -p scripts/tsconfig.json",
     "lint": "bun x eslint . --cache",
@@ -35,7 +36,7 @@
     "build:web": "bun --filter @archon/web build",
     "dev:docs": "bun --filter @archon/docs-web dev",
     "build:docs": "bun --filter @archon/docs-web build",
-    "validate": "bun run check:bundled && bun run check:bundled-skill && bun run check:bundled-schema && bun run check:pi-vendor-map && bun run check:capability-matrix && bun run type-check && bun run lint --max-warnings 0 && bun run format:check && bun run test",
+    "validate": "bun run check:bundled && bun run check:bundled-skill && bun run check:bundled-schema && bun run check:pi-vendor-map && bun run check:capability-matrix && bun run type-check && bun run lint --max-warnings 0 && bun run format:check && bun run test && bun run test:archon-scripts",
     "prepare": "husky",
     "setup-auth": "bun --filter @archon/server setup-auth"
   },


### PR DESCRIPTION
## Summary

Mechanical fixes from the 2026-07-16 maintainer-workflows review (`.claude/archon/reviews/2026-07-16-maintainer-workflows-review.md`). One commit per finding: **B1, B2, B5, R4, R1, B3, R2**.

- **Problem:** several maintainer workflows had silent failure modes — a renamed SDK tool that killed sub-agent fan-out (B1), a stale artifact reference (B2), a marketplace auto-merge fail-open on empty submissions (B3), a validator-flagged quoting bug (B5), a race on shared state (R1), an AI call for digit-picking (R4), and an AI-only path that auto-closed human PRs (R2).
- **Why it matters:** these degrade triage quality invisibly, waste tokens, or take governance-weight actions (auto-merge, auto-close) with weaker justification than intended.
- **What changed:** targeted fixes to 4 maintainer workflows + 1 command + 1 script, plus a new test for the marketplace schema-validator's empty-submission contract.
- **What did NOT change (scope boundary):** no bundled defaults touched (nothing under `.archon/workflows/defaults` or `commands/defaults`), no engine/package source touched, no DB schema. B4/R3 (the repo-triage fork consolidation) are explicitly **out of scope** here.

> **⚠️ R2 is a governance behavior change and needs maintainer (Rasmus) sign-off — see the flagged section below.**

### Findings addressed

| ID | Commit | Disposition |
|----|--------|-------------|
| B1 | `rename Task tool to Agent` | Fixed — **4** nodes in repo-triage.yaml (review said 2; see discrepancy note) |
| B2 | `drop removed gate-decision references` | Fixed |
| B5 | folded into R4 | Resolved by R4 (offending reference deleted) |
| R4 | `bash-first PR-number extraction` | Fixed — with a URL-robustness correction (see note) |
| R1 | `atomic write of reviewed-prs.json` | Fixed |
| B3 | `reject submissions with no workflow YAML` | Fixed + test |
| R2 | `don't auto-close AI-only marketplace rejects` | **Behavior change — needs sign-off** |

### Verification-time discrepancies vs. the review/instructions (flagged for the record)

1. **B1 undercounted.** The review named `triage-issues` + `closed-dedup-check` (2 nodes × 2 files = "4 sites"). The validator actually flags **four** nodes in `repo-triage.yaml` (`triage-issues`, `closed-dedup-check`, `closed-pr-dedup-check`, `link-prs`) — all four whitelist `Task` and orchestrate `agents:` fan-out through it. Since the acceptance criterion is "the warning disappears," all four are fixed.
2. **The minimax twin has no B1 bug.** `repo-triage-minimax.yaml` is a Pi/Minimax fork with `allowed_tools: [Bash, Read, Write]` (no `Task`) that does all briefing inline and never uses the tool — it validates clean. There were no `allowed_tools` sites to change there; its prose references to the tool were renamed to `Agent` for consistency only.
3. **R4 URL-robustness.** The instruction's "the grep already covers URLs" does **not** hold for this repo: a naive `grep -oE '[0-9]+' | head -1` on `github.com/coleam00/Archon/pull/1428` returns **`00`** (the org slug `coleam00` contains digits). The new extractor anchors on `pull/`, `issues/`, `#`, or `PR` before grabbing digits, so bare numbers, `#N`, `PR N`, and full URLs all resolve to `1428`.
4. **B2 residual.** Besides the "Read the gate decision" section, the command header still said "for every PR that passes the gate" — the same removed-gate reference. Reworded to "for every PR under review."

## UX Journey

These are maintainer-facing automation workflows (no end-user UI). The relevant operator-facing flows:

### Before

```
maintainer-review-pr:
  trigger -> [AI node: extract PR number] -> fetch-pr (re-greps AI output) -> review...
             (LLM call to pick a digit; double-quoted "$node.output" -> validator warn)

marketplace reject (any reason):
  decide=reject -> post request-changes review -> gh pr close  (ALWAYS closes, incl. AI-only)
```

### After

```
maintainer-review-pr:
  trigger -> [*bash node*: extract PR number from $ARGUMENTS, URL-anchored] -> fetch-pr (reads .pr-number) -> review...
             (no LLM; writes .pr-number; fails loudly if none)

marketplace reject:
  decide=reject + [close = deterministic scan/scope concurred?]
     close=true  -> review + gh pr close          (scope violation / critical|high scan - unchanged)
     close=false -> review + "flagged for maintainer close" comment, *PR stays open*  [CHANGED]
```

## Architecture Diagram

### Before

```
repo-triage.yaml --(allowed_tools: Task)--x  Claude SDK  (Task ignored -> agents: fan-out DEAD)
maintainer-review-pr.yaml: extract-pr-number(AI) -> fetch-pr -> .pr-number
marketplace: validate-schema(files:[]) -> decide(guard requires files.length>0) -> act(auto-merge/close)
```

### After

```
repo-triage.yaml --(allowed_tools: [~]Agent)==>  Claude SDK  (agents: fan-out RESTORED)
maintainer-review-pr.yaml: [~]extract-pr-number(bash) ==> .pr-number -> fetch-pr
marketplace: validate-schema(files:[]) ==> [~]decide(empty-files => request_changes; [+]close flag) ==> [~]act(gated close)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| repo-triage nodes | Claude SDK Agent tool | **modified** | `Task` -> `Agent` in 4 nodes; fan-out reachable again |
| extract-pr-number | fetch-pr | **modified** | AI node -> bash node; fetch-pr reads `.pr-number` |
| validate-schema | decide | **modified** | empty `files` now routes to `request_changes` |
| decide | act | **modified** | new `close` field gates `gh pr close` |
| record-review | reviewed-prs.json | **modified** | non-atomic write -> temp+rename |

## Label Snapshot

- Risk: `risk: low` (R2 alone is `risk: medium` — governance behavior)
- Size: `size: M`
- Scope: `workflows`
- Module: `workflows:maintainer-workflows`

## Change Metadata

- Change type: `bug` (R4 is `refactor`, R2 is behavior/`security`-adjacent governance)
- Primary scope: `workflows`

## Linked Issue

- Closes # (none — internal review doc, not a GitHub issue)
- Related # (review: `.claude/archon/reviews/2026-07-16-maintainer-workflows-review.md`, findings B1/B2/B3/B5/R1/R4/R2)

## Validation Evidence (required)

```bash
bun run validate      # -> VALIDATE_PASSED (exit 0; all package test batches: 0 fail)
bun run cli validate workflows repo-triage             # ok (was: 4 Task warnings)
bun run cli validate workflows repo-triage-minimax     # ok
bun run cli validate workflows maintainer-review-pr    # ok (was: 1 double-quote warning)
bun run cli validate workflows marketplace-pr-review-and-merge  # ok
bun test ./.archon/scripts/__tests__/marketplace-validate-schema.test.ts  # 5 pass / 0 fail
```

- Evidence provided: full `bun run validate` exits 0; every `validate workflows` warning that motivated B1/B5 is gone; new empty-submission-contract test passes.
- Intentionally skipped: none. Note: `.archon/scripts/__tests__/` tests are **not** part of `bun run validate` (which is package-scoped) or CI — they run manually. The `decide` node is inline-YAML with no unit harness (stated per instructions); the `validate-schema` script contract it depends on is now test-pinned.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No** (R1 writes a temp file in the same dir it already wrote to)
- Net effect: R2 **reduces** the automation's blast radius (fewer auto-closes of human PRs); B3 **closes** a fail-open (empty submissions can no longer reach auto-merge).

## Compatibility / Migration

- Backward compatible? **Yes** — `record-review` still writes the same `reviewed-prs.json` shape (incl. the `gate_verdict: 'review'` back-compat literal); `.pr-number` artifact contract unchanged; `decision.json` only gains an additive `close` field.
- Config/env changes? **No**
- Database migration needed? **No**
- Upgrade steps: none — these are repo-level maintainer workflow files, picked up on next run.

## Human Verification (required)

- Verified scenarios: ran the PR-number extraction pipeline against `1428`, `#1428`, `PR 1428`, `the 2nd one, pr #1428`, and `github.com/coleam00/Archon/pull/1428` — all resolve to `1428` (the naive grep returns `00` on the URL). Confirmed all four workflows validate clean. Ran the new schema-validator test (5 pass).
- Edge cases checked: empty source dir / no-YAML / non-workflow-YAML all yield `files: []`; a valid workflow yields a non-empty list; an unknown-provider workflow yields `valid: false` with a non-empty list.
- What was not verified: no live end-to-end run against real GitHub PRs (the workflows drive `gh` write actions). The `gh pr close` gating (R2) and marketplace auto-merge path were verified by reading, not by executing against a live PR.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `repo-triage`, `repo-triage-minimax`, `maintainer-review-pr`, `marketplace-pr-review-and-merge`, `maintainer-review-code-review` command, `marketplace-validate-schema` script.
- Potential unintended effects: R2 changes when contributor PRs auto-close — see the flagged section. B1's restored fan-out means repo-triage now actually spawns Haiku sub-agents (intended, but real token cost that was previously silently skipped).
- Guardrails/monitoring: workflow validator is clean; the marketplace `decide` remains deterministic; auto-close now emits an explicit echo line naming whether it closed or flagged-for-maintainer.

## Rollback Plan (required)

- Fast rollback: revert the branch, or cherry-revert individual commits (each finding is one atomic commit). R2 is isolated in its own commit (`afa19014`) and can be reverted alone without affecting the other fixes.
- Feature flags/toggles: none.
- Observable failure symptoms: marketplace PRs not closing when they should (R2), or empty submissions still reaching auto-merge (B3 regression), or `validate workflows` warnings reappearing (B1/B5 regression).

## Risks and Mitigations

- **Risk (R2, needs sign-off):** AI-only rejects (Haiku says reject, deterministic scope + security scan both clean) no longer auto-close — they post the request-changes review and a "flagged for maintainer close" comment, leaving the PR open. Scope-violation and critical/high-scan rejects still auto-close exactly as before. This is the one deliberate governance change; the sharpest auto-action in the set (closing a human's PR on a single Haiku opinion) is downgraded to a maintainer decision.
  - Mitigation: isolated in its own commit; the truth table is documented inline in `decide`; revert-in-place if you'd rather keep AI-only auto-close.
- **Risk:** R4's URL-anchored extraction could, in principle, miss an exotic argument shape the old AI node handled.
  - Mitigation: bare-number fallback covers the plain-integer case; verified against the common shapes above; fails loudly (non-zero exit) when no number is found rather than proceeding on a wrong value.
- **Risk:** B1 restoring fan-out increases per-run token cost (previously the sub-agents were silently skipped).
  - Mitigation: intended behavior; the sub-agents are Haiku (cheap) and gated by preflight checks in the prompts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PR number extraction and artifact-based PR metadata fetching for more reliable review processing.
  - Hardened marketplace schema/decision handling to correctly treat empty/invalid submissions and prevent incorrect fail-open behavior.
  - Reduced risk of lost/overwritten maintainer review records via safer atomic updates.
  - Clarified auto-close behavior: PRs are auto-closed only when the decision explicitly allows it.

- **Tests**
  - Added Bun test suites for PR number extraction, marketplace schema validation, and marketplace decision outcomes.
  - Ensured these tests run in CI.

- **Workflow Improvements**
  - Updated maintainer code-review guidance to run for every PR under review.
  - Standardized parallel operations to use Agent messaging consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->