### PR TITLE
fix(web): resubscribe during an abandoned in-flight console load runs its own loader

### DIFF
--- a/packages/web/src/experiments/console/store/cache.test.ts
+++ b/packages/web/src/experiments/console/store/cache.test.ts
@@ -185,3 +185,73 @@ describe('subscribeKey — per-key Map lifecycle (#1933)', () => {
     expect(versionOf(key)).toBe(0);
   });
 });
+
+describe('subscribeKey — resubscribe during an abandoned in-flight load (#2101)', () => {
+  test('a resubscribe before the old load settles runs its own loader and wins', async () => {
+    const key = 'test:resub-inflight';
+    let resolveA: (v: string) => void = () => {};
+    let bLoads = 0;
+
+    const unsubA = subscribeKey(
+      key,
+      () => {},
+      () =>
+        new Promise<string>(resolve => {
+          resolveA = resolve;
+        })
+    );
+    unsubA(); // last subscriber leaves while loaderA is still pending
+
+    const unsubB = subscribeKey(
+      key,
+      () => {},
+      () => {
+        bLoads += 1;
+        return Promise.resolve('B');
+      }
+    );
+    await flush();
+
+    expect(bLoads).toBe(1); // B's own loader ran (the bug: it was never invoked)
+    expect(get(key)).toBe('B'); // B's result landed
+    expect(versionOf(key)).toBe(1); // one notify, from B's load
+
+    resolveA('A'); // the abandoned load settles late
+    await flush();
+    expect(get(key)).toBe('B'); // A does not clobber B
+    expect(versionOf(key)).toBe(1); // A's stale settle did not notify
+
+    unsubB();
+  });
+
+  test('a rejecting abandoned load does not surface an error to the resubscriber', async () => {
+    const key = 'test:resub-reject';
+    let rejectA: (e: Error) => void = () => {};
+
+    const unsubA = subscribeKey(
+      key,
+      () => {},
+      () =>
+        new Promise<string>((_resolve, reject) => {
+          rejectA = reject;
+        })
+    );
+    unsubA();
+
+    const unsubB = subscribeKey(
+      key,
+      () => {},
+      () => Promise.resolve('B')
+    );
+    await flush();
+    expect(get(key)).toBe('B');
+    expect(versionOf(key)).toBe(1);
+
+    rejectA(new Error('stale boom')); // loaderA rejects after B already resolved
+    await flush();
+    expect(get(key)).toBe('B'); // B's value untouched
+    expect(versionOf(key)).toBe(1); // no extra notify — A's error was not surfaced
+
+    unsubB();
+  });
+});

--- a/packages/web/src/experiments/console/store/cache.ts
+++ b/packages/web/src/experiments/console/store/cache.ts
@@ -12,6 +12,9 @@
  * - After the last unsubscribe, `cache`/`errors` are deliberately retained so
  *   a remount reads warm; only the per-key version counter is released.
  *   `invalidate()` fully releases subscriber-less keys.
+ * - A resubscribe that arrives while a previous, abandoned load for the key is
+ *   still in flight starts its OWN loader; the orphaned load can no longer
+ *   clobber the fresh result (per-key `loadSeq` guard, #2101).
  *
  * Deliberately minimal. No React Query, no Zustand.
  */
@@ -30,6 +33,15 @@ const loaders = new Map<string, () => Promise<unknown>>();
 // the value stays `undefined` and a value-identity snapshot would bail out and
 // never surface `error` (e.g. a 401 panel would hang on "Loading…").
 const versions = new Map<string, number>();
+// Per-key load sequence, bumped each time a load is initiated (via `ensureLoad`
+// or `revalidate`). A load captures the value at start and commits its result
+// only while the sequence still matches. This neutralizes a load orphaned by
+// the last unsubscribe — its promise keeps running (promises aren't
+// cancellable) — so it can't overwrite a value produced by a NEWER load that a
+// resubscriber started for the same key (#2101). Retained across unsubscribe
+// like `cache`/`errors` (so a load that settles with no resubscriber still
+// warms the cache) and released together with them by `invalidate()`.
+const loadSeq = new Map<string, number>();
 
 function notify(key: string): void {
   // No subscribers ⇒ nothing snapshots the counter, so don't bump it — a late
@@ -43,25 +55,42 @@ function notify(key: string): void {
   for (const l of subs) l();
 }
 
-function ensureLoad(key: string): void {
-  if (cache.has(key) || inflight.has(key)) return;
-  const loader = loaders.get(key);
-  if (loader === undefined) return;
+/**
+ * Shared load runner for both load-initiation paths (`ensureLoad` on first
+ * subscribe and `revalidate` on refetch/invalidate). Captures a per-key
+ * sequence number so a stale settle — from a load whose key was torn down and
+ * re-subscribed with a different loader — no-ops instead of clobbering the
+ * current load's result (#2101).
+ */
+function runLoad(key: string, loader: () => Promise<unknown>): void {
+  const seq = (loadSeq.get(key) ?? 0) + 1;
+  loadSeq.set(key, seq);
   const p = loader()
     .then(v => {
+      if ((loadSeq.get(key) ?? 0) !== seq) return; // superseded by a newer load for this key
       cache.set(key, v);
       errors.delete(key);
       notify(key);
     })
     .catch((e: unknown) => {
+      if ((loadSeq.get(key) ?? 0) !== seq) return; // superseded — don't surface a stale error
       const err = e instanceof Error ? e : new Error(String(e));
       errors.set(key, err);
-      notify(key);
+      notify(key); // surface the error; any stale value stays in cache
     })
     .finally(() => {
-      inflight.delete(key);
+      // Only clear the entry if it's still THIS load's promise — a newer load
+      // for the key may already own `inflight[key]`.
+      if (inflight.get(key) === p) inflight.delete(key);
     });
   inflight.set(key, p);
+}
+
+function ensureLoad(key: string): void {
+  if (cache.has(key) || inflight.has(key)) return;
+  const loader = loaders.get(key);
+  if (loader === undefined) return;
+  runLoad(key, loader);
 }
 
 export function get(key: string): unknown {
@@ -96,24 +125,11 @@ function revalidate(key: string): void {
     cache.delete(key);
     errors.delete(key);
     versions.delete(key); // fully release the key — nothing subscribes, so nothing snapshots it
+    loadSeq.delete(key); // release the sequence alongside cache/errors (they move together)
     return;
   }
   if (inflight.has(key)) return; // a revalidation is already in flight
-  const p = loader()
-    .then(v => {
-      cache.set(key, v);
-      errors.delete(key);
-      notify(key);
-    })
-    .catch((e: unknown) => {
-      const err = e instanceof Error ? e : new Error(String(e));
-      errors.set(key, err);
-      notify(key); // surface the error; any stale value stays in cache
-    })
-    .finally(() => {
-      inflight.delete(key);
-    });
-  inflight.set(key, p);
+  runLoad(key, loader);
 }
 
 export function invalidate(keyPrefix: string): void {
@@ -185,6 +201,12 @@ export function subscribeKey(
       // above); `invalidate()` releases them for subscriber-less keys via
       // `revalidate`'s no-loader branch.
       versions.delete(key);
+      // Detach any in-flight load. Promises aren't cancellable, so it keeps
+      // running and may still warm the cache for a future remount (guarded by
+      // its `loadSeq`), but dropping it from `inflight` here means a resubscribe
+      // arriving before it settles runs its OWN loader via `ensureLoad` instead
+      // of inheriting this abandoned request's eventual result (#2101).
+      inflight.delete(key);
     }
   };
 }


### PR DESCRIPTION
## Summary

- Problem: In the console store (`packages/web/src/experiments/console/store/cache.ts`), a component that subscribed to a key while a *previous, abandoned* load for that key was still in flight never got its own loader invoked. `ensureLoad`'s dedup guard (`cache.has(key) || inflight.has(key)`) short-circuited on the stale `inflight` entry, so the new subscriber silently inherited whatever the old request eventually returned.
- Why it matters: The resubscriber could render a foreign/stale result — or, if the abandoned load rejected, surface an error produced by a loader it never registered. Impact is small in practice (loaders for a key are usually equivalent closures, since the key encodes the query), but the #1938 warm-remount fix makes fast unmount/remount lean on this dedup path more often, so it is worth fixing deliberately.
- What changed: Added a per-key **load sequence**. Every load (via `ensureLoad` or `revalidate`) captures the sequence at start and commits its result only while it still matches; the last unsubscribe now detaches the orphaned load from `inflight` so a resubscriber starts fresh. Extracted the shared load runner (`runLoad`) so both load-initiation paths get the guard.
- What did **not** change (scope boundary): The public API (`useEntity`, `subscribeKey`, `get`/`set`/`patch`, `invalidate`, `refetch`) is untouched. The deliberate #1933 behaviors are preserved: `versions` is still pruned on last-unsubscribe, `notify` still refuses to bump subscriber-less keys, and `cache`/`errors` are still retained for warm remount. Only the console-store internals changed; no component, SSE, or skill code touched.

## UX Journey

### Before

```
User                        Console store
────                        ─────────────
opens run detail   ───────▶ subscribeKey(key, loaderA); fetch A in flight
navigates away     ───────▶ last unsubscribe: listeners/loaders/versions pruned
                            (inflight[key] still pending)
navigates back fast ──────▶ subscribeKey(key, loaderB)
                            [X] ensureLoad sees inflight.has(key) → loaderB never called
fetch A settles    ───────▶ B renders A's (possibly stale/foreign) result
```

### After

```
User                        Console store
────                        ─────────────
opens run detail   ───────▶ subscribeKey(key, loaderA); load A (seq 1) in flight
navigates away     ───────▶ last unsubscribe: listeners/loaders/versions pruned
                            *inflight[key] detached* (promise runs on, harmless)
navigates back fast ──────▶ subscribeKey(key, loaderB)
                            *ensureLoad no longer deduped → loaderB runs (seq 2)*
fetch A settles    ───────▶ *seq 1 ≠ current seq 2 → A's result discarded*
fetch B settles    ───────▶ B renders B's own result

(no resubscriber case unchanged: A settles at seq 1 == current → still warms cache)
```

## Architecture Diagram

### Before

```
subscribeKey ─▶ ensureLoad ─▶ loader().then/catch/finally ─▶ inflight/cache/errors/notify
refetch/invalidate ─▶ revalidate ─▶ loader().then/catch/finally  (duplicated body)
unsubscribe(last) ─▶ prune listeners/loaders/versions   (inflight left to settle)
```

### After

```
subscribeKey ─▶ ensureLoad ──┐
                             ├═▶ [~]runLoad(key, loader)  [+ per-key loadSeq guard]
refetch/invalidate ─▶ revalidate ─┘
unsubscribe(last) ─▶ prune listeners/loaders/versions [+ detach inflight]
invalidate no-loader branch ─▶ [+ loadSeq.delete alongside cache/errors/versions]
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `ensureLoad` | `runLoad` | **new** | now delegates the load body |
| `revalidate` | `runLoad` | **new** | now delegates the load body (was duplicated inline) |
| `runLoad` | `loadSeq` | **new** | captures/compares per-key sequence on settle |
| `subscribeKey` (last unsub) | `inflight` | **modified** | now `inflight.delete(key)` to detach orphaned load |
| `revalidate` (no-loader) | `loadSeq` | **new** | `loadSeq.delete(key)` releases alongside cache/errors |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `web`
- Module: `web:console-store`

## Change Metadata

- Change type: `bug`
- Primary scope: `web`

## Linked Issue

- Closes #2101
- Related #1933 (Map-leak fix, PR #1938) — see Side Effects below

## Validation Evidence (required)

```bash
bun run validate   # exit 0
```

- Evidence provided: Full `bun run validate` green from the worktree root (check:bundled, check:bundled-skill, check:bundled-schema, check:pi-vendor-map, type-check, lint --max-warnings 0, format:check, and per-package tests). The console-store batch: `cache.test.ts` 10 pass / 0 fail (8 existing #1933 tests + 2 new #2101 tests); `@archon/web` overall 0 fail across all batches.
- Negative control: with the `inflight.delete` fix removed, both new #2101 tests fail (`loaderB` never invoked, cache stays `undefined`) while the 8 #1933 tests still pass — confirming the new tests pin #2101 specifically.
- Skipped commands: none.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: resubscribe-before-old-load-settles runs the new loader and its result wins; a late-rejecting abandoned load neither surfaces an error nor bumps the version for the resubscriber; the no-resubscriber warm-cache path (#1933) still warms on late resolve.
- Edge cases checked: orphaned promise's `.finally` no longer clears a newer load's `inflight` entry (identity guard); `loadSeq` released by `invalidate()` so it does not grow unbounded (mirrors `cache`/`errors` lifecycle).
- What was not verified: no live browser click-through (store-level unit coverage + full validate deemed sufficient for an internal store fix).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: console experiment UI panels that use `useEntity` under fast unmount/remount.
- Potential unintended effects: minimal — the load body is now shared between `ensureLoad` and `revalidate`; both behave identically to before except for the sequence guard.
- **Interaction with #1933**: not worsened. #1933 was the `versions` Map leak; that fix (pruning `versions` on last-unsubscribe + the `notify` subscriber-less guard) is untouched. The new `loadSeq` Map is retained across unsubscribe on purpose — exactly like the deliberately-retained `cache`/`errors` — and is released together with them in `revalidate`'s no-loader (invalidate) branch, so its growth profile matches `cache`/`errors` and does not reintroduce an unbounded leak. #1933 stays fixed; this change is orthogonal and consistent with its design.
- Guardrails/monitoring: covered by unit tests in `cache.test.ts`.

## Rollback Plan (required)

- Fast rollback: revert this commit (single file + its test); no data or config to unwind.
- Feature flags/config toggles: none.
- Observable failure symptoms: console panels showing stale data after fast navigate-away-and-back, or a "Loading…"/error panel not recovering until the next SSE/invalidate.

## Risks and Mitigations

- Risk: `runLoad` extraction subtly changes the `revalidate` load body.
  - Mitigation: the extracted body is byte-for-byte equivalent to the previous inline versions plus the sequence guard; all existing store tests (including invalidate/refetch paths) pass unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated background loads from overwriting newer cached results after a subscription is removed and restored.
  * Ensured abandoned load failures no longer surface errors or trigger unnecessary notifications.
  * Improved cache consistency when subscribers resubscribe while a previous load is still completing.

* **Tests**
  * Added regression coverage for resubscription behavior, stale results, suppressed errors, and notification handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->