### PR TITLE
chore: sweep stale GPT model references to the 5.6 lineup

### DIFF
--- a/.claude/skills/archon/references/parameter-matrix.md
+++ b/.claude/skills/archon/references/parameter-matrix.md
@@ -187,7 +187,7 @@ Use this matrix to find the right parameter. Use these references for the full e
 | `skills` (per-node)             | yes           | informational (auto-discovers `.agents/skills/`) | yes                          | yes                  | yes                 |
 | `agents`                        | yes           | no                                      | no                                   | **yes**              | **yes**             |
 | `sandbox` / `maxBudgetUsd` / `fallbackModel` | yes | no                                | no                                   | no                   | no                  |
-| Model naming                    | `haiku`, `sonnet`, `opus`, `opus[1m]`   | Codex model ID (e.g. `gpt-5.3-codex`)   | `<vendor>/<model>` (e.g. `anthropic/claude-opus-4-5`, `openrouter/qwen/qwen3-coder`) | OpenCode catalog ref | Copilot model id |
+| Model naming                    | `haiku`, `sonnet`, `opus`, `opus[1m]`   | Codex model ID (e.g. `gpt-5.6-sol`)   | `<vendor>/<model>` (e.g. `anthropic/claude-opus-4-5`, `openrouter/qwen/qwen3-coder`) | OpenCode catalog ref | Copilot model id |
 | `effort` / `thinking`           | yes           | use `modelReasoningEffort` for reasoning models | via `effort:` (maps to thinking level) | no (opencode.json agent config) | yes (maps like Pi) |
 | Provider session resume (`persist_session`, `context: shared` threading) | yes | yes            | yes                                  | yes                  | yes                 |
 

--- a/.claude/skills/archon/references/repo-init.md
+++ b/.claude/skills/archon/references/repo-init.md
@@ -131,7 +131,7 @@ assistants:
   claude:
     model: sonnet
   codex:
-    model: gpt-5.3-codex
+    model: gpt-5.6-sol
     modelReasoningEffort: medium
 
 concurrency:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -560,7 +560,7 @@ assistants:
       # Required in compiled binaries if
       # CLAUDE_BIN_PATH env var is not set.
   codex:
-    model: gpt-5.3-codex
+    model: gpt-5.6-sol
     modelReasoningEffort: medium # 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
     webSearchMode: live # 'disabled' | 'cached' | 'live'
     additionalDirectories:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -578,7 +578,7 @@ assistants:
                                                 # Required in compiled binaries if
                                                 # CLAUDE_BIN_PATH env var is not set.
   codex:
-    model: gpt-5.3-codex
+    model: gpt-5.6-sol
     modelReasoningEffort: medium  # 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
     webSearchMode: live  # 'disabled' | 'cached' | 'live'
     additionalDirectories:

--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -927,7 +927,13 @@ describe('buildDefaultModelChoices (#1999)', () => {
 
   it('includes the curated codex shortlist', () => {
     const values = buildDefaultModelChoices('codex', undefined).map(c => c.value);
-    expect(values).toEqual(['__keep__', 'gpt-5.3-codex', 'gpt-5.5', 'gpt-5.2', '__custom__']);
+    expect(values).toEqual([
+      '__keep__',
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+      '__custom__',
+    ]);
   });
 
   it('falls back to keep + custom only for providers without a curated list', () => {

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -71,7 +71,7 @@ const PI_BACKENDS = [
     label: 'Anthropic',
     hint: 'claude-haiku-4-5, claude-opus-4-7, etc.',
   },
-  { id: 'openai', envVar: 'OPENAI_API_KEY', label: 'OpenAI', hint: 'gpt-4o, gpt-5.3, etc.' },
+  { id: 'openai', envVar: 'OPENAI_API_KEY', label: 'OpenAI', hint: 'gpt-4o, gpt-5.6-sol, etc.' },
   {
     id: 'google',
     envVar: 'GEMINI_API_KEY',
@@ -132,7 +132,7 @@ const DEFAULT_CHAT_MODEL_OPTIONS: Record<string, { value: string; hint?: string 
     { value: 'opus', hint: 'most capable' },
     { value: 'haiku', hint: 'fastest' },
   ],
-  codex: [{ value: 'gpt-5.3-codex' }, { value: 'gpt-5.5' }, { value: 'gpt-5.2' }],
+  codex: [{ value: 'gpt-5.6-sol' }, { value: 'gpt-5.6-terra' }, { value: 'gpt-5.6-luna' }],
 };
 
 /** Sentinel select values for the default-chat-model prompt. Prefixed with
@@ -632,7 +632,7 @@ async function collectDefaultChatModel(provider: string): Promise<string | undef
   if (choice === CUSTOM_MODEL) {
     const typed = await text({
       message: `Model id for ${provider}:`,
-      placeholder: provider === 'codex' ? 'gpt-5.3-codex' : 'claude-sonnet-4-6',
+      placeholder: provider === 'codex' ? 'gpt-5.6-sol' : 'claude-sonnet-4-6',
     });
     if (isCancel(typed)) {
       cancel('Setup cancelled.');

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -321,7 +321,7 @@ describe('workflowListCommand', () => {
           name: 'plan',
           description: 'Planning workflow',
           provider: 'codex',
-          model: 'gpt-5.3-codex',
+          model: 'gpt-5.6-sol',
           modelReasoningEffort: 'high',
           webSearchMode: 'live',
         }),
@@ -340,7 +340,7 @@ describe('workflowListCommand', () => {
       name: 'plan',
       description: 'Planning workflow',
       provider: 'codex',
-      model: 'gpt-5.3-codex',
+      model: 'gpt-5.6-sol',
       modelReasoningEffort: 'high',
       webSearchMode: 'live',
     });

--- a/packages/core/src/config/config-loader.test.ts
+++ b/packages/core/src/config/config-loader.test.ts
@@ -408,7 +408,7 @@ streaming:
         }
         if (pathMatches(path, '.archon/config.yaml') && !globalConfigRead) {
           globalConfigRead = true;
-          return `assistants:\n  claude:\n    model: sonnet\n  codex:\n    model: gpt-5.2-codex\n    modelReasoningEffort: medium\n`;
+          return `assistants:\n  claude:\n    model: sonnet\n  codex:\n    model: gpt-5.6-sol\n    modelReasoningEffort: medium\n`;
         }
         const error = new Error('ENOENT') as NodeJS.ErrnoException;
         error.code = 'ENOENT';
@@ -417,7 +417,7 @@ streaming:
 
       const config = await loadConfig('/test/repo');
       expect(config.assistants.claude.model).toBe('sonnet');
-      expect(config.assistants.codex.model).toBe('gpt-5.2-codex');
+      expect(config.assistants.codex.model).toBe('gpt-5.6-sol');
       expect(config.assistants.codex.modelReasoningEffort).toBe('medium');
       expect(config.assistants.codex.webSearchMode).toBe('live');
       expect(config.assistants.codex.additionalDirectories).toEqual(['/repo']);
@@ -746,7 +746,7 @@ defaultAssistant: codex
 botName: MyBot
 assistants:
   codex:
-    model: gpt-5.3-codex
+    model: gpt-5.6-sol
     modelReasoningEffort: medium
 `);
 

--- a/packages/core/src/config/config-loader.ts
+++ b/packages/core/src/config/config-loader.ts
@@ -201,7 +201,7 @@ const DEFAULT_CONFIG_CONTENT = `# Archon Global Configuration
 #   claude:
 #     model: sonnet
 #   codex:
-#     model: gpt-5.3-codex
+#     model: gpt-5.6-sol
 #     modelReasoningEffort: medium
 #     webSearchMode: disabled
 #     additionalDirectories:

--- a/packages/core/src/db/user-ai-prefs-store.test.ts
+++ b/packages/core/src/db/user-ai-prefs-store.test.ts
@@ -60,7 +60,7 @@ describe('user-ai-prefs-store', () => {
         createQueryResult([
           prefsRow({
             tiers: JSON.stringify({ large: { provider: 'claude', model: 'opus' } }),
-            aliases: JSON.stringify({ '@fast': { provider: 'codex', model: 'gpt-5.3-codex' } }),
+            aliases: JSON.stringify({ '@fast': { provider: 'codex', model: 'gpt-5.6-sol' } }),
             default_provider: 'codex',
             default_model: 'gpt-5.5',
           }),
@@ -69,7 +69,7 @@ describe('user-ai-prefs-store', () => {
       const result = await getUserAiPrefs(USER);
       expect(result).toEqual({
         tiers: { large: { provider: 'claude', model: 'opus' } },
-        aliases: { '@fast': { provider: 'codex', model: 'gpt-5.3-codex' } },
+        aliases: { '@fast': { provider: 'codex', model: 'gpt-5.6-sol' } },
         defaultProvider: 'codex',
         defaultModel: 'gpt-5.5',
       });
@@ -130,7 +130,7 @@ describe('user-ai-prefs-store', () => {
         createQueryResult([
           prefsRow({
             aliases: JSON.stringify({
-              '@fast': { provider: 'codex', model: 'gpt-5.3-codex' },
+              '@fast': { provider: 'codex', model: 'gpt-5.6-sol' },
               '@deep': { provider: 'claude', model: 'opus' },
             }),
           }),

--- a/packages/core/src/utils/error-formatter.test.ts
+++ b/packages/core/src/utils/error-formatter.test.ts
@@ -185,7 +185,7 @@ describe('classifyAndFormatError', () => {
     });
 
     test('returns message as-is for different model names', () => {
-      const msg = '❌ Model "gpt-5.3-codex" not available for your account';
+      const msg = '❌ Model "gpt-5.6-sol" not available for your account';
       const result = classifyAndFormatError(new Error(msg));
       expect(result).toBe(msg);
     });

--- a/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
+++ b/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
@@ -230,7 +230,7 @@ You can configure Codex's behavior in `.archon/config.yaml`:
 ```yaml
 assistants:
   codex:
-    model: gpt-5.3-codex
+    model: gpt-5.6-sol
     modelReasoningEffort: medium  # 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
     webSearchMode: live           # 'disabled' | 'cached' | 'live'
     additionalDirectories:

--- a/packages/docs-web/src/content/docs/getting-started/configuration.md
+++ b/packages/docs-web/src/content/docs/getting-started/configuration.md
@@ -38,7 +38,7 @@ assistants:
     settingSources:
       - project
   codex:
-    model: gpt-5.3-codex
+    model: gpt-5.6-sol
     modelReasoningEffort: medium
 
 # docs:

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -898,7 +898,7 @@ Archon does not keep an internal allow-list for literal model ids because vendor
 Common shapes you'll see in practice:
 
 - **Claude (Anthropic):** family aliases (`sonnet`, `opus`, `haiku`), full model IDs (`claude-opus-4-7`, `claude-3-5-sonnet-20241022`), context-window suffixed forms (`opus[1m]`, `claude-opus-4-7[1m]`), or `inherit` to reuse the previous session's model.
-- **Codex (OpenAI):** any OpenAI model ID — `gpt-5.3-codex`, `gpt-5.2`, `o5-pro`, etc.
+- **Codex (OpenAI):** any OpenAI model ID — `gpt-5.6-sol`, `gpt-5.6-terra`, `o5-pro`, etc.
 - **Pi (community):** `<backend>/<model-id>` refs — e.g. `google/gemini-2.5-pro`, `openrouter/qwen/qwen3-coder`.
 - **Copilot (community):** GitHub Copilot model names — e.g. `gpt-5`, `gpt-5-mini`, `claude-sonnet-4.5`, or `auto`.
 
@@ -909,7 +909,7 @@ If the SDK rejects a literal string at request time, the node fails loudly with 
 ```yaml
 name: my-workflow
 provider: codex
-model: gpt-5.3-codex
+model: gpt-5.6-sol
 modelReasoningEffort: medium    # 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
 webSearchMode: live             # 'disabled' | 'cached' | 'live'
 ```
@@ -990,7 +990,7 @@ assistants:
   claude:
     model: haiku  # Fast model for most tasks
   codex:
-    model: gpt-5.3-codex
+    model: gpt-5.6-sol
     modelReasoningEffort: low
     webSearchMode: disabled
 ```

--- a/packages/paths/src/telemetry.test.ts
+++ b/packages/paths/src/telemetry.test.ts
@@ -779,7 +779,7 @@ describe('sanitizeModelForTelemetry', () => {
       'sonnet',
       'opus',
       'claude-sonnet-4-6',
-      'gpt-5.3-codex',
+      'gpt-5.6-sol',
       'anthropic/claude-haiku-4-5',
       'openrouter/qwen/qwen3-coder',
     ]) {

--- a/packages/paths/src/telemetry.ts
+++ b/packages/paths/src/telemetry.ts
@@ -180,7 +180,7 @@ export function classifyWorkflowForTelemetry(
  * Model ids are user-supplied (forwarded verbatim from workflow/`config.yaml`
  * YAML), so unlike `provider` they're not structurally categorical. Forward a
  * value only when it looks like a real model ref (alphanumerics plus `/._:-`,
- * bounded length — covers `sonnet`, `gpt-5.3-codex`, `anthropic/claude-haiku-4-5`,
+ * bounded length — covers `sonnet`, `gpt-5.6-sol`, `anthropic/claude-haiku-4-5`,
  * `openrouter/qwen/qwen3-coder`). Anything else is dropped so a stray free-text
  * value can't slip through the "categorical only" telemetry contract.
  *

--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -785,7 +785,7 @@ describe('CodexProvider', () => {
       });
 
       for await (const _ of client.sendQuery('test prompt', '/workspace', undefined, {
-        model: 'gpt-5.2-codex',
+        model: 'gpt-5.6-sol',
         assistantConfig: {
           modelReasoningEffort: 'medium',
           webSearchMode: 'live',
@@ -797,7 +797,7 @@ describe('CodexProvider', () => {
 
       expect(mockStartThread).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'gpt-5.2-codex',
+          model: 'gpt-5.6-sol',
           modelReasoningEffort: 'medium',
           webSearchMode: 'live',
           additionalDirectories: ['/other/repo'],
@@ -1487,7 +1487,7 @@ describe('CodexProvider', () => {
       await expect(consumeGenerator()).rejects.toThrow(
         'Model "gpt-5.3-codex" is not available for your account'
       );
-      await expect(consumeGenerator()).rejects.toThrow('model: gpt-5.2-codex');
+      await expect(consumeGenerator()).rejects.toThrow('model: gpt-5.6-sol');
     });
 
     test('uses generic dashboard guidance when fallback mapping is unknown', async () => {

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -210,8 +210,12 @@ function buildCodexMcpConfigOverrides(
   return { mcp_servers: mcpServers };
 }
 
+// Maps slugs that ChatGPT-plan accounts now reject (previously shipped as Archon
+// suggestions/defaults) to a current, plan-accepted slug to suggest instead.
 const CODEX_MODEL_FALLBACKS: Record<string, string> = {
-  'gpt-5.3-codex': 'gpt-5.2-codex',
+  'gpt-5.3-codex': 'gpt-5.6-sol',
+  'gpt-5.2-codex': 'gpt-5.6-sol',
+  'gpt-5.2': 'gpt-5.6-sol',
 };
 
 function isModelAccessError(errorMessage: string): boolean {

--- a/packages/web/src/experiments/console/components/AssistantConfigPanel.tsx
+++ b/packages/web/src/experiments/console/components/AssistantConfigPanel.tsx
@@ -303,7 +303,7 @@ export function AssistantConfigPanel(): ReactElement {
                   onChange={v => {
                     setModel(p.id, v);
                   }}
-                  placeholder="model (e.g. sonnet, gpt-5.3-codex) — blank = inherit"
+                  placeholder="model (e.g. sonnet, gpt-5.6-sol) — blank = inherit"
                   selectEmptyLabel="inherit"
                   ariaLabel={`${p.displayName} default model`}
                   className="w-full"

--- a/packages/web/src/experiments/console/lib/model-options.ts
+++ b/packages/web/src/experiments/console/lib/model-options.ts
@@ -66,14 +66,14 @@ export const CLAUDE_MODEL_OPTIONS: readonly ModelOption[] = [
 ];
 
 /**
- * Codex model strings used across the repo's config examples
- * (docs/getting-started/ai-assistants.md and CLAUDE.md: `gpt-5.3-codex`,
- * tiers example `gpt-5.5`, docs `gpt-5.2`).
+ * Codex model strings mirroring the current lineup in the repo's config
+ * examples (docs/getting-started/ai-assistants.md and CLAUDE.md): `gpt-5.6-sol`
+ * (flagship), `gpt-5.6-terra` (mid), `gpt-5.6-luna` (light).
  */
 export const CODEX_MODEL_OPTIONS: readonly ModelOption[] = [
-  { value: 'gpt-5.3-codex' },
-  { value: 'gpt-5.5' },
-  { value: 'gpt-5.2' },
+  { value: 'gpt-5.6-sol' },
+  { value: 'gpt-5.6-terra' },
+  { value: 'gpt-5.6-luna' },
 ];
 
 /**

--- a/packages/web/src/experiments/console/skills/settings.test.ts
+++ b/packages/web/src/experiments/console/skills/settings.test.ts
@@ -43,13 +43,13 @@ describe('buildAssistantUpdate', () => {
     const body = buildAssistantUpdate(
       form({
         assistant: 'codex',
-        models: { codex: 'gpt-5.3-codex' },
+        models: { codex: 'gpt-5.6-sol' },
         modelReasoningEffort: 'high',
         webSearchMode: 'live',
       })
     );
     expect(body.assistants).toEqual({
-      codex: { model: 'gpt-5.3-codex', modelReasoningEffort: 'high', webSearchMode: 'live' },
+      codex: { model: 'gpt-5.6-sol', modelReasoningEffort: 'high', webSearchMode: 'live' },
     });
   });
 

--- a/packages/web/src/routes/SettingsPage.tsx
+++ b/packages/web/src/routes/SettingsPage.tsx
@@ -535,7 +535,7 @@ function AssistantConfigSection({ config }: { config: SafeConfigResponse }): Rea
                       onChange={e => {
                         updateProviderSettings('codex', { model: e.target.value });
                       }}
-                      placeholder="gpt-5.3-codex"
+                      placeholder="gpt-5.6-sol"
                     />
 
                     <label htmlFor="reasoning">Reasoning Effort</label>

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -399,7 +399,7 @@ nodes:
       const yaml = `name: codex-options
 description: Codex options are parsed
 provider: codex
-model: gpt-5.2-codex
+model: gpt-5.6-sol
 modelReasoningEffort: medium
 webSearchMode: live
 additionalDirectories:

--- a/packages/workflows/src/model-validation.test.ts
+++ b/packages/workflows/src/model-validation.test.ts
@@ -162,7 +162,7 @@ describe('buildAiProfile — alias layering', () => {
   test('alias entry effort is preserved', () => {
     const profile = buildAiProfile('codex', {
       repoAliases: {
-        '@deep': { provider: 'codex', model: 'gpt-5.3-codex', effort: 'xhigh' },
+        '@deep': { provider: 'codex', model: 'gpt-5.6-sol', effort: 'xhigh' },
       },
     });
     expect(profile.aliases['@deep']?.effort).toBe('xhigh');


### PR DESCRIPTION
## Summary

- **Problem:** The Codex lineup moved to 5.6 (sol/terra/luna) and ChatGPT-plan accounts now reject the older slugs (`gpt-5.2` → 400 `invalid_request_error`; `gpt-5.3-codex` stale). Several setup suggestions, the console model picker, the codex model-access fallback map, and config/docs examples still pointed at the old lineup.
- **Why it matters:** A user who accepts a suggested slug (or follows the fallback hint) lands on a model their account rejects — the fallback map even suggested `gpt-5.2-codex`, which is itself now rejected.
- **What changed:** Swept every model-name literal (and its comment/doc/test) to the current lineup: `gpt-5.6-sol` (flagship), `gpt-5.6-terra` (mid), `gpt-5.6-luna` (light). The codex fallback map keeps keying on the dead slugs but now points them at plan-accepted `gpt-5.6-sol`.
- **What did NOT change (scope boundary):** `tier-defaults.json` and all `gpt-5.5` references are untouched — `gpt-5.5` is verified still plan-accepted, and tier-defaults stays consistent with the `gpt-5.5` tier examples. Only model-name literals were touched; no behavior/logic changes. No dag-executor/isolation, workspace paths, console store cache, or CLI doctor.

## UX Journey

### Before

```
User runs `archon setup`, picks Codex default model
  → shortlist: gpt-5.3-codex / gpt-5.5 / gpt-5.2   ← picks gpt-5.2
  → run fails: "Model gpt-5.2 not available for your account"
  → fallback hint (if on gpt-5.3-codex): "try gpt-5.2-codex"  ← ALSO rejected
```

### After

```
User runs `archon setup`, picks Codex default model
  → shortlist: *gpt-5.6-sol* / *gpt-5.6-terra* / *gpt-5.6-luna*   ← all plan-accepted
  → fallback hint for a dead slug now points at *gpt-5.6-sol* (accepted)
```

## Architecture Diagram

### Before / After

No structural change. Only string literals (model ids) in suggestion lists, one
lookup-table's values, and config/doc examples changed.

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| — | — | unchanged | No module-to-module edges added, removed, or modified |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `cli`, `web`, `providers`, `config`, `docs`, `tests`, `skills`
- Module: `providers:codex`, `cli:setup`, `web:console-model-options`

## Change Metadata

- Change type: `chore`
- Primary scope: `multi`

## Linked Issue

- Closes #2139

## Validation Evidence (required)

```bash
bun run validate
# EXIT_CODE=0 — check:bundled, check:bundled-skill, check:bundled-schema,
# check:pi-vendor-map, type-check, lint (--max-warnings 0), format:check, and the
# full per-package test suite all green (0 fail).
```

- Evidence provided: `bun run validate` green from the worktree root.
- Skipped commands: none.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` (existing configs with any prior slug keep loading; the fallback map now hints at an accepted replacement)
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios: slugs (`gpt-5.6-sol`/`terra`/`luna`) confirmed plan-accepted by the maintainer's earlier live probe on a ChatGPT-plan credential (issue ground truth); `gpt-5.2` confirmed rejected, so it was removed from all suggestions and retargeted in the fallback map.
- Edge cases checked: the codex fallback map deliberately RETAINS the dead-slug keys (`gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.2`) so users still on them get a live suggestion — the two remaining `gpt-5.3` grep hits (provider.ts map key + its test) are intentional, not oversights.
- What was not verified: API-key (non-plan) Codex accounts were not probed live; the sweep preserves the pre-existing plan-oriented posture.

## Side Effects / Blast Radius (required)

- Affected subsystems: `archon setup` suggestion prompt, console model picker, codex model-access error hint, config/doc examples.
- Potential unintended effects: none expected — pickers/suggestions GUIDE, never GATE (free-text escape preserved); no resolution logic changed.
- Guardrails: `bun run validate` covers the updated test assertions; model validation stays permissive at request time.

## Rollback Plan (required)

- Fast rollback: `git revert <merge-commit>` — pure literal/doc changes, trivially reversible.
- Feature flags: none.
- Observable failure symptoms: a suggested/fallback slug being rejected at request time (would surface as a Codex model-access error).

## Risks and Mitigations

- Risk: a chosen 5.6 slug is unavailable on some account types.
  - Mitigation: all suggestion/picker surfaces keep a free-text escape and nothing blocks an unlisted model string; the model is validated at request time by the provider, not by Archon.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Codex model suggestions and default examples to `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.
  * Refreshed setup and settings placeholders to reflect the latest Codex models.
  * Improved unavailable-model guidance to recommend the updated Codex model.

* **Documentation**
  * Updated configuration, workflow, and assistant documentation examples with the new default model.

* **Tests**
  * Updated coverage and expectations for the refreshed Codex model options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->