### PR TITLE
fix(paths): route no-remote repos' logs/artifacts under _local/<basename> (#2132)

### DIFF
--- a/packages/cli/src/commands/continue.ts
+++ b/packages/cli/src/commands/continue.ts
@@ -6,7 +6,7 @@ import * as isolationDb from '@archon/core/db/isolation-environments';
 import * as codebaseDb from '@archon/core/db/codebases';
 import * as workflowDb from '@archon/core/db/workflows';
 import { execFileAsync } from '@archon/git';
-import { createLogger, getRunArtifactsPath, parseOwnerRepo } from '@archon/paths';
+import { createLogger, getRunArtifactsPath, resolveRepoProjectIdentity } from '@archon/paths';
 import type { WorkflowRun } from '@archon/workflows/schemas/workflow-run';
 import { readdir, readFile, stat } from 'fs/promises';
 import { join } from 'path';
@@ -210,9 +210,12 @@ async function resolveArtifactsDir(
   try {
     const codebase = await codebaseDb.getCodebase(codebaseId);
     if (codebase) {
-      const parsed = parseOwnerRepo(codebase.name);
-      if (parsed) {
-        const dir = getRunArtifactsPath(parsed.owner, parsed.repo, runId);
+      // Mirror the executor's identity resolution so no-remote local repos
+      // (scoped under _local/<basename>) are found here too, not just repos
+      // with an owner/repo name (#2132).
+      const identity = resolveRepoProjectIdentity(codebase.name, codebase.default_cwd);
+      if (identity) {
+        const dir = getRunArtifactsPath(identity.owner, identity.repo, runId);
         try {
           await stat(dir);
           return dir;

--- a/packages/paths/src/archon-paths.test.ts
+++ b/packages/paths/src/archon-paths.test.ts
@@ -27,6 +27,7 @@ import {
   logArchonPaths,
   validateAppDefaultsPaths,
   parseOwnerRepo,
+  resolveRepoProjectIdentity,
   getProjectRoot,
   getProjectSourcePath,
   getProjectWorktreesPath,
@@ -429,6 +430,47 @@ describe('archon-paths', () => {
     test('rejects names with special characters', () => {
       expect(parseOwnerRepo('acme/repo;rm -rf')).toBeNull();
       expect(parseOwnerRepo('acme/$HOME')).toBeNull();
+    });
+  });
+
+  describe('resolveRepoProjectIdentity', () => {
+    test('returns parsed owner/repo for an owner/repo name', () => {
+      expect(resolveRepoProjectIdentity('acme/widget', '/repos/widget')).toEqual({
+        owner: 'acme',
+        repo: 'widget',
+      });
+    });
+
+    test('scopes a no-remote bare name under _local/<basename(cwd)>', () => {
+      expect(resolveRepoProjectIdentity('workspace', '/home/username/workspace')).toEqual({
+        owner: '_local',
+        repo: 'workspace',
+      });
+    });
+
+    test('derives the repo segment from cwd, not the name', () => {
+      // Name and directory basename can differ; the on-disk tree registration
+      // creates is keyed off the directory basename.
+      expect(resolveRepoProjectIdentity('some-name', '/srv/projects/checkout')).toEqual({
+        owner: '_local',
+        repo: 'checkout',
+      });
+    });
+
+    test('preserves a basename registration would have used verbatim (spaces allowed)', () => {
+      expect(resolveRepoProjectIdentity('my app', '/home/u/my app')).toEqual({
+        owner: '_local',
+        repo: 'my app',
+      });
+    });
+
+    test('returns null for a dotdot basename (no path escape)', () => {
+      expect(resolveRepoProjectIdentity('workspace', '/home/u/..')).toBeNull();
+    });
+
+    test('returns null for a dot or empty basename', () => {
+      expect(resolveRepoProjectIdentity('workspace', '/home/u/.')).toBeNull();
+      expect(resolveRepoProjectIdentity('workspace', '/')).toBeNull();
     });
   });
 

--- a/packages/paths/src/archon-paths.ts
+++ b/packages/paths/src/archon-paths.ts
@@ -393,6 +393,33 @@ export function parseOwnerRepo(name: string): { owner: string; repo: string } | 
 }
 
 /**
+ * Resolve the `{ owner, repo }` storage identity for a registered *repo*-kind
+ * codebase. This is the single source of truth that keeps `registerRepository()`
+ * (which creates the on-disk `owner/repo` tree) and the log/artifact path
+ * resolvers in agreement — a mismatch between the two dropped no-remote repos'
+ * logs/artifacts into `<cwd>/.archon` instead of `ARCHON_HOME` (#2132).
+ *
+ * - A `name` in exact `owner/repo` form (clones, web-registered repos) → that
+ *   owner/repo.
+ * - Otherwise — most commonly a no-remote local repo registered under its bare
+ *   directory basename — the working directory's basename scoped under the
+ *   `_local` pseudo-owner, mirroring what registration writes to disk.
+ *   `basename()` never contains a path separator, so the only traversal risk is
+ *   `..`; that, `.`, and an empty segment return null so the caller can fall
+ *   back to cwd-local storage.
+ */
+export function resolveRepoProjectIdentity(
+  name: string,
+  cwd: string
+): { owner: string; repo: string } | null {
+  const parsed = parseOwnerRepo(name);
+  if (parsed) return parsed;
+  const repo = basename(cwd);
+  if (repo === '' || repo === '.' || repo === '..') return null;
+  return { owner: '_local', repo };
+}
+
+/**
  * Get the project root directory for a given owner/repo.
  * Returns: ~/.archon/workspaces/owner/repo/
  */

--- a/packages/paths/src/index.ts
+++ b/packages/paths/src/index.ts
@@ -22,6 +22,7 @@ export {
   logArchonPaths,
   validateAppDefaultsPaths,
   parseOwnerRepo,
+  resolveRepoProjectIdentity,
   getProjectRoot,
   getProjectSourcePath,
   getProjectWorktreesPath,

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -27,6 +27,7 @@ const mockCaptureWorkflowCompleted = mock(() => {});
 mock.module('@archon/paths', () => ({
   createLogger: mock(() => mockLogger),
   parseOwnerRepo: mock(() => null),
+  resolveRepoProjectIdentity: mock(() => null),
   getRunArtifactsPath: mock(() => '/tmp/artifacts'),
   getProjectLogsPath: mock(() => '/tmp/logs'),
   getProjectArtifactsPath: mock(() => '/tmp/artifacts-root'),
@@ -1576,7 +1577,7 @@ describe('resolveProjectPaths', () => {
 
   it('routes repo projects to owner/repo/ storage (unchanged)', async () => {
     const paths = await import('@archon/paths');
-    (paths.parseOwnerRepo as ReturnType<typeof mock>).mockReturnValueOnce({
+    (paths.resolveRepoProjectIdentity as ReturnType<typeof mock>).mockReturnValueOnce({
       owner: 'acme',
       repo: 'widget',
     });
@@ -1594,6 +1595,39 @@ describe('resolveProjectPaths', () => {
     const result = await resolveProjectPaths(deps, '/repos/widget', RUN_ID, 'cb-repo');
 
     // getRunArtifactsPath/getProjectLogsPath/getProjectArtifactsPath are mocked to constants
+    expect(result.artifactsDir).toBe('/tmp/artifacts');
+    expect(result.logDir).toBe('/tmp/logs');
+    expect(result.artifactsRoot).toBe('/tmp/artifacts-root');
+  });
+
+  it('routes a no-remote local repo to _local/<basename> storage (#2132)', async () => {
+    const paths = await import('@archon/paths');
+    // A bare-basename codebase name resolves to the _local pseudo-owner rather
+    // than falling through to <cwd>/.archon.
+    (paths.resolveRepoProjectIdentity as ReturnType<typeof mock>).mockReturnValueOnce({
+      owner: '_local',
+      repo: 'workspace',
+    });
+    const store = makeStore({
+      getCodebase: mock(async () => ({
+        id: 'cb-local',
+        name: 'workspace',
+        repository_url: null,
+        default_cwd: '/home/username/workspace',
+        kind: 'repo' as const,
+      })),
+    });
+    const deps = makeDeps(store);
+
+    const result = await resolveProjectPaths(deps, '/home/username/workspace', RUN_ID, 'cb-local');
+
+    expect(paths.resolveRepoProjectIdentity).toHaveBeenCalledWith(
+      'workspace',
+      '/home/username/workspace'
+    );
+    expect(paths.getRunArtifactsPath).toHaveBeenCalledWith('_local', 'workspace', RUN_ID);
+    expect(paths.getProjectLogsPath).toHaveBeenCalledWith('_local', 'workspace');
+    // Routed to project storage (mocked constants), NOT the cwd fallback.
     expect(result.artifactsDir).toBe('/tmp/artifacts');
     expect(result.logDir).toBe('/tmp/logs');
     expect(result.artifactsRoot).toBe('/tmp/artifacts-root');

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -255,15 +255,30 @@ export async function resolveProjectPaths(
             artifactsRoot: archonPaths.getFolderProjectArtifactsPath(slug),
           };
         }
-        const parsed = archonPaths.parseOwnerRepo(codebase.name);
-        if (parsed) {
+        // Repo projects: parse `owner/repo`, or scope a no-remote local repo
+        // under `_local/<basename(cwd)>` — the same identity registration wrote
+        // to disk. Without this branch the paths below fall through to the
+        // <cwd>/.archon fallback, dumping logs/artifacts outside ARCHON_HOME
+        // (#2132).
+        const identity = archonPaths.resolveRepoProjectIdentity(
+          codebase.name,
+          codebase.default_cwd
+        );
+        if (identity) {
           return {
-            artifactsDir: archonPaths.getRunArtifactsPath(parsed.owner, parsed.repo, workflowRunId),
-            logDir: archonPaths.getProjectLogsPath(parsed.owner, parsed.repo),
-            artifactsRoot: archonPaths.getProjectArtifactsPath(parsed.owner, parsed.repo),
+            artifactsDir: archonPaths.getRunArtifactsPath(
+              identity.owner,
+              identity.repo,
+              workflowRunId
+            ),
+            logDir: archonPaths.getProjectLogsPath(identity.owner, identity.repo),
+            artifactsRoot: archonPaths.getProjectArtifactsPath(identity.owner, identity.repo),
           };
         }
-        getLog().warn({ codebaseName: codebase.name }, 'codebase_name_not_owner_repo_format');
+        getLog().warn(
+          { codebaseName: codebase.name, cwd: codebase.default_cwd },
+          'codebase_project_identity_unresolved'
+        );
       }
     } catch (error) {
       const fallbackArtifactsDir = join(cwd, '.archon', 'artifacts', 'runs', workflowRunId);


### PR DESCRIPTION
## Summary

- **Problem:** Workflow run logs (`.jsonl`) and artifacts for a registered git repo with **no `origin` remote** were written to `<cwd>/.archon/...` instead of `$ARCHON_HOME/workspaces/_local/<basename>/...`.
- **Why it matters:** Run output landed outside `ARCHON_HOME` and outside per-instance isolation — losable if the working dir is ephemeral (e.g. a cleaned worktree), and invisible to `archon workflow continue`'s artifact lookup.
- **What changed:** Added `resolveRepoProjectIdentity(name, cwd)` in `@archon/paths` — one derivation that keeps registration and the log/artifact resolvers in agreement — and routed `resolveProjectPaths()` (executor) and `resolveArtifactsDir()` (cli `continue`) through it.
- **What did NOT change (scope boundary):** `registerRepository()` is untouched (it already creates the `_local/<basename>/` tree — it's the source of truth the resolvers now mirror); the git worktree resolver (`git:worktree resolveOwnerRepo`, which has its own last-two-segments fallback) is untouched; no DB schema/migration.

## UX Journey

### Before

```
User                          CLI (workflow run)               executor (resolveProjectPaths)
runs in a no-remote git repo ─▶ auto-registers, name="workspace"
                                runs workflow ───────────────▶ parseOwnerRepo("workspace") → null
                                                               [X] cwd fallback
                                logs/artifacts ◀────────────── <cwd>/.archon/logs   (outside ARCHON_HOME)
```

### After

```
User                          CLI (workflow run)               executor (resolveProjectPaths)
runs in a no-remote git repo ─▶ auto-registers, name="workspace"
                                runs workflow ───────────────▶ resolveRepoProjectIdentity("workspace", cwd)
                                                               *→ { _local, workspace }*
                                logs/artifacts ◀────────────── *$ARCHON_HOME/workspaces/_local/workspace/logs*
```

## Architecture Diagram

### After

```
@archon/paths [~]
  parseOwnerRepo
  resolveRepoProjectIdentity [+]  === used by ===>  workflows:executor resolveProjectPaths [~]
                                  === used by ===>  cli:continue resolveArtifactsDir [~]

core:handlers/clone registerRepository  (unchanged; still writes _local/<basename>/ on disk)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `workflows:executor` | `paths:resolveRepoProjectIdentity` | **new** | replaces direct `parseOwnerRepo` call |
| `cli:continue` | `paths:resolveRepoProjectIdentity` | **new** | replaces direct `parseOwnerRepo` call |
| `core:clone` | `paths` | unchanged | registration unchanged; source of truth |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `paths`
- Module: `paths:archon-paths`, `workflows:executor`, `cli:continue`

## Change Metadata

- Change type: `bug`
- Primary scope: `paths`

## Linked Issue

- Closes #2132

## Validation Evidence (required)

```bash
bun run validate
# EXIT_CODE=0 — check:bundled, check:bundled-skill, check:bundled-schema,
# check:pi-vendor-map, type-check, lint (--max-warnings 0), format:check, test
# all green (every package "0 fail").
```

- Evidence provided: full `bun run validate` green. New unit tests: 7 cases for `resolveRepoProjectIdentity` (`packages/paths/src/archon-paths.test.ts`) + executor routing test for `_local/<basename>` (`packages/workflows/src/executor.test.ts`).
- Skipped commands: none.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No — this **narrows** where files are written (back inside `ARCHON_HOME`). `basename()` never contains a path separator, so the only traversal vector is `..`; that, `.`, and an empty segment return null and fall back to the pre-existing cwd behavior (no `_local/..` escape).

## Compatibility / Migration

- Backward compatible? Yes — `owner/repo` clones resolve exactly as before; only the previously-broken bare-name case changes, and it now matches the `_local/<basename>/` tree registration already created. Fixes existing no-remote rows with no data migration.
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: ran the real (non-mocked) `resolveRepoProjectIdentity` + `getProjectLogsPath`/`getRunArtifactsPath` against the issue's exact repro (`name="workspace"`, cwd `/home/username/workspace`) → `logDir = $ARCHON_HOME/workspaces/_local/workspace/logs`, artifacts under `.../_local/workspace/artifacts/runs/<id>` — matches the issue's Expected.
- Edge cases checked: `acme/widget` clone name → unchanged `{acme, widget}`; `..` basename → `null` (no ARCHON_HOME escape).
- What was not verified: a full live `archon workflow run` against a physical no-remote repo (covered by unit + path-composition tests instead).

## Side Effects / Blast Radius (required)

- Affected subsystems: workflow run log/artifact path resolution (executor), `archon workflow continue` artifact lookup (cli).
- Potential unintended effects: none expected — the `owner/repo` path is byte-for-byte unchanged; only the null-parse branch is redirected from cwd to `_local/<basename>`.
- Guardrails: the executor still logs a WARN (`codebase_project_identity_unresolved`) and falls back to cwd for a genuinely degenerate basename.

## Rollback Plan (required)

- Fast rollback: revert this commit — self-contained, no schema/state changes.
- Feature flags: none.
- Observable failure symptoms: run logs/artifacts appearing under `_local/<basename>/` unexpectedly, or `codebase_project_identity_unresolved` WARNs.

## Risks and Mitigations

- Risk: a repo whose stored `name` is a URL-derived owner/repo that `parseOwnerRepo` **rejects** (non-`SAFE_NAME` chars) could still resolve to `_local/<basename>` here while registration created a different owner dir. Extremely rare and pre-existing; out of scope for this fix.
  - Mitigation: the common no-remote (`_local/<basename>`) and clone (`owner/repo`) paths both round-trip correctly; documented in the helper's docstring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved artifact and log directory resolution for local repositories without a configured remote.
  - Ensured the `continue` command locates artifacts consistently with workflow execution.
  - Preserved support for repositories identified by explicit `owner/repo` names.
  - Added safer handling for invalid or unresolved repository identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->