### PR TITLE
feat(cli): archon doctor — add Codex binary and OpenCode runtime checks

### DIFF
--- a/.claude/skills/archon/references/cli-commands.md
+++ b/.claude/skills/archon/references/cli-commands.md
@@ -257,10 +257,11 @@ archon version
 
 ### `archon doctor`
 
-Verify the Archon setup: Claude binary resolution, Pi auth, `gh` auth, database connectivity, connected providers, workspace writability, bundled defaults, and adapter configuration (Slack/Telegram). Run this first when workflows fail with environment-shaped errors (binary not found, auth failures). Note: there is no Codex binary check — Codex resolution issues surface at run time.
+Verify the Archon setup: Claude binary resolution, Codex binary resolution (when Codex is configured or an OpenAI credential is connected), Pi auth, `gh` auth, OpenCode runtime SDK presence (with `--full`, or when OpenCode is the configured assistant), database connectivity, connected providers, workspace writability, bundled defaults, and adapter configuration (Slack/Telegram). Run this first when workflows fail with environment-shaped errors (binary not found, auth failures).
 
 ```bash
 archon doctor
+archon doctor --full   # also probe the OpenCode runtime SDK (module presence only — never boots the runtime)
 ```
 
 ### `archon setup [--spawn]`

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -130,7 +130,7 @@ Commands:
   complete <branch> [...]    Complete branch lifecycle (remove worktree + branches)
   serve                      Start the web UI server (downloads web UI on first run)
   skill install [path]       Install the bundled Archon skill into .claude/skills/archon
-  doctor                     Verify your Archon setup (Claude binary, gh auth, DB, adapters)
+  doctor [--full]            Verify your Archon setup (Claude/Codex binaries, gh auth, DB, adapters; --full also probes the OpenCode runtime SDK)
   auth github                Connect your GitHub identity via device flow (multi-user installs)
   ai key set <provider>      Connect an AI provider API key (multi-user installs; key read from prompt/stdin)
   ai login <provider>        Connect a subscription (claude/copilot) via OAuth — codex is API-key only
@@ -302,6 +302,7 @@ async function main(): Promise<number> {
         status: { type: 'string' },
         limit: { type: 'string' },
         effort: { type: 'string' },
+        full: { type: 'boolean' },
       },
       allowPositionals: true,
       strict: false, // Allow unknown flags to pass through
@@ -859,7 +860,7 @@ async function main(): Promise<number> {
       }
 
       case 'doctor': {
-        return await doctorCommand();
+        return await doctorCommand(undefined, Boolean(values.full));
       }
 
       case 'auth': {

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -14,6 +14,8 @@ import { mkdirSync, rmSync } from 'fs';
 import * as git from '@archon/git';
 import {
   checkClaudeBinary,
+  checkCodexBinary,
+  checkOpenCode,
   checkDatabase,
   checkConnectedProviders,
   checkGhAuth,
@@ -25,8 +27,10 @@ import {
   checkTelemetry,
   checkFolderProject,
   doctorCommand,
+  type CodexBinaryDeps,
   type DatabaseDeps,
   type FolderProjectDeps,
+  type OpenCodeDeps,
 } from './doctor';
 import * as doctorModule from './doctor';
 
@@ -69,6 +73,187 @@ describe('checkClaudeBinary', () => {
     expect(result.status).toBe('fail');
     expect(result.message).toContain('did not spawn');
     expect(result.message).toContain('ENOENT');
+  });
+});
+
+describe('checkCodexBinary', () => {
+  let execSpy: ReturnType<typeof spyOn<typeof git, 'execFileAsync'>>;
+
+  const notConfigured: CodexBinaryDeps = {
+    isDefaultAssistant: false,
+    credentialConnected: false,
+  };
+  const loadDeps = (deps: CodexBinaryDeps) => async () => deps;
+  const resolvesTo =
+    (path: string, source: 'env' | 'config' | 'vendor' | 'autodetect') => async () => ({
+      path,
+      source,
+    });
+
+  beforeEach(() => {
+    execSpy = spyOn(git, 'execFileAsync');
+  });
+
+  afterEach(() => {
+    execSpy.mockRestore();
+  });
+
+  it('skips when Codex is not configured and no credential is connected', async () => {
+    const result = await checkCodexBinary({}, loadDeps(notConfigured), async () => undefined);
+    expect(result.status).toBe('skip');
+    expect(result.label).toBe('Codex binary');
+    expect(result.message).toContain('not configured');
+    expect(execSpy).not.toHaveBeenCalled();
+  });
+
+  it('runs (dev-mode skip) when DEFAULT_AI_ASSISTANT=codex even if config load fails', async () => {
+    // loadDeps throwing must not suppress the check — env signal still counts.
+    const result = await checkCodexBinary(
+      { DEFAULT_AI_ASSISTANT: 'codex' },
+      async () => {
+        throw new Error('config blew up');
+      },
+      async () => undefined // resolver returns undefined → dev mode
+    );
+    expect(result.status).toBe('skip');
+    expect(result.message).toContain('dev mode');
+  });
+
+  it('runs when a config codexBinaryPath is set (configured signal)', async () => {
+    const result = await checkCodexBinary(
+      {},
+      loadDeps({ ...notConfigured, configBinaryPath: '/cfg/codex' }),
+      async () => undefined
+    );
+    expect(result.status).toBe('skip');
+    expect(result.message).toContain('dev mode');
+  });
+
+  it('runs when an OpenAI (Codex) credential is connected', async () => {
+    const result = await checkCodexBinary(
+      {},
+      loadDeps({ ...notConfigured, credentialConnected: true }),
+      async () => undefined
+    );
+    expect(result.status).toBe('skip');
+    expect(result.message).toContain('dev mode');
+  });
+
+  it('passes and reports the resolved source when the binary spawns', async () => {
+    execSpy.mockResolvedValue({ stdout: '1.0.0', stderr: '' });
+    const result = await checkCodexBinary(
+      { DEFAULT_AI_ASSISTANT: 'codex' },
+      loadDeps(notConfigured),
+      resolvesTo('/opt/codex', 'autodetect')
+    );
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('/opt/codex');
+    expect(result.message).toContain('via autodetect');
+    expect(execSpy).toHaveBeenCalledWith('/opt/codex', ['--version'], expect.any(Object));
+  });
+
+  it('fails with install instructions when the resolver throws', async () => {
+    const result = await checkCodexBinary(
+      { DEFAULT_AI_ASSISTANT: 'codex' },
+      loadDeps(notConfigured),
+      async () => {
+        throw new Error(
+          'Codex CLI binary not found. Install globally: npm install -g @openai/codex'
+        );
+      }
+    );
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('Codex CLI binary not found');
+    expect(execSpy).not.toHaveBeenCalled();
+  });
+
+  it('fails when the resolved binary does not spawn', async () => {
+    execSpy.mockRejectedValue(new Error('ENOENT'));
+    const result = await checkCodexBinary(
+      { CODEX_BIN_PATH: '/opt/codex' },
+      loadDeps(notConfigured),
+      resolvesTo('/opt/codex', 'env')
+    );
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('did not spawn');
+    expect(result.message).toContain('ENOENT');
+  });
+});
+
+describe('checkOpenCode', () => {
+  const makeDeps = (over: Partial<OpenCodeDeps> = {}): OpenCodeDeps => ({
+    isDefaultAssistant: false,
+    probeRuntimeModule: async () => true,
+    ...over,
+  });
+
+  it('skips when OpenCode is not configured and --full is absent', async () => {
+    const result = await checkOpenCode({}, false, async () => makeDeps());
+    expect(result.status).toBe('skip');
+    expect(result.label).toBe('OpenCode runtime');
+    expect(result.message).toContain('pass --full');
+  });
+
+  it('passes when OpenCode is the configured assistant and the SDK resolves', async () => {
+    const result = await checkOpenCode({}, false, async () =>
+      makeDeps({ isDefaultAssistant: true })
+    );
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('server not started');
+  });
+
+  it('passes under --full even when OpenCode is not configured', async () => {
+    const result = await checkOpenCode({}, true, async () => makeDeps());
+    expect(result.status).toBe('pass');
+  });
+
+  it('runs when DEFAULT_AI_ASSISTANT=opencode', async () => {
+    const result = await checkOpenCode({ DEFAULT_AI_ASSISTANT: 'opencode' }, false, async () =>
+      makeDeps()
+    );
+    expect(result.status).toBe('pass');
+  });
+
+  it('never boots the runtime — only the cheap module probe is called', async () => {
+    let probeCalls = 0;
+    await checkOpenCode({}, true, async () =>
+      makeDeps({
+        probeRuntimeModule: async () => {
+          probeCalls += 1;
+          return true;
+        },
+      })
+    );
+    expect(probeCalls).toBe(1);
+  });
+
+  it('fails when the runtime SDK cannot be resolved', async () => {
+    const result = await checkOpenCode({}, true, async () =>
+      makeDeps({
+        probeRuntimeModule: async () => {
+          throw new Error('Cannot find module @opencode-ai/sdk');
+        },
+      })
+    );
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('not resolvable');
+    expect(result.message).toContain('bun install');
+  });
+
+  it('fails when the SDK resolves but the entrypoint is missing', async () => {
+    const result = await checkOpenCode({}, true, async () =>
+      makeDeps({ probeRuntimeModule: async () => false })
+    );
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('createOpencode');
+  });
+
+  it('skips gracefully when deps load fails and --full is absent', async () => {
+    const result = await checkOpenCode({}, false, async () => {
+      throw new Error('config load failed');
+    });
+    expect(result.status).toBe('skip');
+    expect(result.message).toContain('not configured');
   });
 });
 

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -255,6 +255,25 @@ describe('checkOpenCode', () => {
     expect(result.status).toBe('skip');
     expect(result.message).toContain('not configured');
   });
+
+  it('surfaces the load error (not "entrypoint missing") when deps fail under --full', async () => {
+    const result = await checkOpenCode({}, true, async () => {
+      throw new Error('config load failed');
+    });
+    expect(result.status).toBe('fail');
+    // Must report the real load failure, not a fabricated SDK-entrypoint verdict.
+    expect(result.message).toContain('config load failed');
+    expect(result.message).not.toContain('createOpencode');
+  });
+
+  it('surfaces the load error when deps fail and OpenCode is the configured assistant', async () => {
+    const result = await checkOpenCode({ DEFAULT_AI_ASSISTANT: 'opencode' }, false, async () => {
+      throw new Error('module import failed');
+    });
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('module import failed');
+    expect(result.message).not.toContain('createOpencode');
+  });
 });
 
 describe('checkGhAuth', () => {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -210,20 +210,33 @@ export async function checkOpenCode(
 ): Promise<CheckResult> {
   const label = 'OpenCode runtime';
 
-  let deps: OpenCodeDeps;
+  let deps: OpenCodeDeps | undefined;
+  let loadError: Error | undefined;
   try {
     deps = await loadDeps();
   } catch (err) {
+    // Keep the load error — if the check turns out to be in scope we must
+    // report *this* failure, not a fabricated "entrypoint missing" verdict.
+    loadError = err as Error;
     getLog().debug({ err }, 'doctor.opencode_deps_load_failed');
-    deps = { isDefaultAssistant: false, probeRuntimeModule: async (): Promise<boolean> => false };
   }
 
-  const configured = env.DEFAULT_AI_ASSISTANT === 'opencode' || deps.isDefaultAssistant;
+  const configured = env.DEFAULT_AI_ASSISTANT === 'opencode' || (deps?.isDefaultAssistant ?? false);
   if (!configured && !full) {
     return {
       label,
       status: 'skip',
       message: 'OpenCode not configured (pass --full to probe the runtime SDK)',
+    };
+  }
+
+  // In scope (configured or --full) but the probe deps never loaded — surface
+  // the real load failure instead of falsely blaming the SDK entrypoint below.
+  if (!deps) {
+    return {
+      label,
+      status: 'fail',
+      message: `runtime probe unavailable: ${loadError?.message ?? 'unknown error'}. Reinstall dependencies (bun install).`,
     };
   }
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -10,7 +10,16 @@ import { join } from 'path';
 import { homedir } from 'os';
 import { execFileAsync } from '@archon/git';
 import { BUNDLED_IS_BINARY, getArchonHome, createLogger, getTelemetryStatus } from '@archon/paths';
+import {
+  resolveCodexBinaryWithSource,
+  type CodexBinarySource,
+} from '@archon/providers/codex/binary-resolver';
 import type { Codebase } from '@archon/core';
+
+// Vendor-canonical credential id for Codex (since #1955 credentials are keyed
+// by vendor, not agent). A connected `openai` key signals Codex intent even
+// when it isn't the configured default assistant.
+const CODEX_CREDENTIAL_VENDOR = 'openai';
 
 // Env vars that indicate a Pi backend API key is configured. Keep in sync with
 // `PI_BACKENDS` in setup.ts — these are the auth signals checkPi inspects.
@@ -66,6 +75,194 @@ export async function checkClaudeBinary(
       message: `${path} did not spawn: ${(err as Error).message}`,
     };
   }
+}
+
+export interface CodexBinaryDeps {
+  /** `assistants.codex.codexBinaryPath` from the merged config, if configured. */
+  configBinaryPath?: string;
+  /** True when the merged default assistant resolves to codex. */
+  isDefaultAssistant: boolean;
+  /** True when the CLI user has connected an OpenAI (Codex) credential. */
+  credentialConnected: boolean;
+}
+
+/**
+ * Verify the Codex CLI binary resolves and spawns. Mirrors `checkClaudeBinary`,
+ * but uses Codex's richer four-tier resolution (env → config → vendor →
+ * autodetect) and reports which tier resolved it. Skips (never fails) when
+ * Codex isn't the configured assistant anywhere and no OpenAI (Codex)
+ * credential is connected, so Claude-only users aren't nagged about a binary
+ * they will never use.
+ */
+export async function checkCodexBinary(
+  env: NodeJS.ProcessEnv,
+  // Injected so tests can drive every branch without the dynamic @archon/core
+  // import or a real binary on disk.
+  loadDeps: (env: NodeJS.ProcessEnv) => Promise<CodexBinaryDeps> = defaultLoadCodexBinaryDeps,
+  resolve: (
+    configPath?: string
+  ) => Promise<
+    { path: string; source: CodexBinarySource } | undefined
+  > = resolveCodexBinaryWithSource
+): Promise<CheckResult> {
+  const label = 'Codex binary';
+
+  let deps: CodexBinaryDeps;
+  try {
+    deps = await loadDeps(env);
+  } catch (err) {
+    // Config load can throw (e.g. a typo'd DEFAULT_AI_ASSISTANT) — degrade to
+    // env-only signals rather than failing the whole check.
+    getLog().debug({ err }, 'doctor.codex_deps_load_failed');
+    deps = { isDefaultAssistant: false, credentialConnected: false };
+  }
+
+  const configured =
+    env.DEFAULT_AI_ASSISTANT === 'codex' ||
+    Boolean(env.CODEX_BIN_PATH) ||
+    deps.isDefaultAssistant ||
+    Boolean(deps.configBinaryPath) ||
+    deps.credentialConnected;
+
+  if (!configured) {
+    return {
+      label,
+      status: 'skip',
+      message: 'Codex not configured (not the default assistant, no OpenAI credential connected)',
+    };
+  }
+
+  let resolved: { path: string; source: CodexBinarySource } | undefined;
+  try {
+    resolved = await resolve(deps.configBinaryPath);
+  } catch (err) {
+    // Binary mode + unresolved → the resolver throws with install instructions.
+    return { label, status: 'fail', message: (err as Error).message };
+  }
+
+  // Dev mode: the resolver returns undefined and the SDK resolves via node_modules.
+  if (!resolved) {
+    return { label, status: 'skip', message: 'dev mode (SDK resolves via node_modules)' };
+  }
+
+  try {
+    await execFileAsync(resolved.path, ['--version'], { timeout: 5000 });
+    return {
+      label,
+      status: 'pass',
+      message: `${resolved.path} (via ${resolved.source}, spawns OK)`,
+    };
+  } catch (err) {
+    return {
+      label,
+      status: 'fail',
+      message: `${resolved.path} did not spawn: ${(err as Error).message}`,
+    };
+  }
+}
+
+async function defaultLoadCodexBinaryDeps(env: NodeJS.ProcessEnv): Promise<CodexBinaryDeps> {
+  // Lazy imports so doctor doesn't pull the full @archon/core graph for an
+  // unrelated check (matches defaultLoadDatabaseDeps / defaultLoadProviderDeps).
+  const { loadConfig, listUserProviderKeys } = await import('@archon/core');
+  const userDb = await import('@archon/core/db/users');
+  const config = await loadConfig(process.cwd());
+
+  let credentialConnected = false;
+  const cliId = env.ARCHON_USER_ID || env.USER || env.USERNAME;
+  if (cliId) {
+    try {
+      const user = await userDb.findOrCreateUserByPlatformIdentity('cli', cliId, cliId);
+      const rows = await listUserProviderKeys(user.id);
+      credentialConnected = rows.some(r => r.provider === CODEX_CREDENTIAL_VENDOR);
+    } catch (err) {
+      // Credential lookup is best-effort — a DB hiccup shouldn't force the
+      // binary check to run or skip; treat as "no credential connected".
+      getLog().debug({ err }, 'doctor.codex_credential_lookup_failed');
+    }
+  }
+
+  return {
+    configBinaryPath: config.assistants.codex.codexBinaryPath,
+    isDefaultAssistant: config.assistant === 'codex',
+    credentialConnected,
+  };
+}
+
+export interface OpenCodeDeps {
+  /** True when the merged default assistant is opencode. */
+  isDefaultAssistant: boolean;
+  /** Cheap module-presence probe — resolves the SDK WITHOUT booting the server. */
+  probeRuntimeModule: () => Promise<boolean>;
+}
+
+/**
+ * Report whether the embedded OpenCode runtime SDK is present. OpenCode's
+ * runtime is heavyweight to start (spawns a child process and binds a port),
+ * so doctor NEVER boots it — it only probes that the SDK module resolves. Skips
+ * unless OpenCode is the configured assistant or `--full` is passed, matching
+ * the lazy-start posture of `GET /api/providers/opencode/credentials`.
+ */
+export async function checkOpenCode(
+  env: NodeJS.ProcessEnv,
+  full: boolean,
+  loadDeps: () => Promise<OpenCodeDeps> = defaultLoadOpenCodeDeps
+): Promise<CheckResult> {
+  const label = 'OpenCode runtime';
+
+  let deps: OpenCodeDeps;
+  try {
+    deps = await loadDeps();
+  } catch (err) {
+    getLog().debug({ err }, 'doctor.opencode_deps_load_failed');
+    deps = { isDefaultAssistant: false, probeRuntimeModule: async (): Promise<boolean> => false };
+  }
+
+  const configured = env.DEFAULT_AI_ASSISTANT === 'opencode' || deps.isDefaultAssistant;
+  if (!configured && !full) {
+    return {
+      label,
+      status: 'skip',
+      message: 'OpenCode not configured (pass --full to probe the runtime SDK)',
+    };
+  }
+
+  let present: boolean;
+  try {
+    // Cheap probe only — resolves the SDK module without starting the server.
+    present = await deps.probeRuntimeModule();
+  } catch (err) {
+    return {
+      label,
+      status: 'fail',
+      message: `runtime SDK not resolvable: ${(err as Error).message}. Reinstall dependencies (bun install).`,
+    };
+  }
+
+  if (present) {
+    return {
+      label,
+      status: 'pass',
+      message: 'embedded runtime SDK present (module resolves; server not started)',
+    };
+  }
+  return {
+    label,
+    status: 'fail',
+    message:
+      '@opencode-ai/sdk resolved but the createOpencode entrypoint is missing — reinstall dependencies (bun install).',
+  };
+}
+
+async function defaultLoadOpenCodeDeps(): Promise<OpenCodeDeps> {
+  const { loadConfig } = await import('@archon/core');
+  const { probeOpencodeRuntimeModule } =
+    await import('@archon/providers/community/opencode/runtime');
+  const config = await loadConfig(process.cwd());
+  return {
+    isDefaultAssistant: config.assistant === 'opencode',
+    probeRuntimeModule: probeOpencodeRuntimeModule,
+  };
 }
 
 export async function checkGhAuth(env: NodeJS.ProcessEnv): Promise<CheckResult> {
@@ -422,7 +619,10 @@ function renderResult(r: CheckResult): string {
 export async function doctorCommand(
   // Injected so tests can drive the exit-code contract and the
   // Promise.allSettled rejection branch with synthetic checks.
-  checks?: (() => Promise<CheckResult>)[]
+  checks?: (() => Promise<CheckResult>)[],
+  // `--full` opts the OpenCode runtime probe in even when OpenCode isn't the
+  // configured assistant. Does not boot the runtime — only widens the gate.
+  full = false
 ): Promise<number> {
   console.log('archon doctor — verifying your setup\n');
   getLog().info('doctor.run_started');
@@ -432,8 +632,10 @@ export async function doctorCommand(
     ? checks.map(fn => fn())
     : [
         checkClaudeBinary(env),
+        checkCodexBinary(env),
         checkGhAuth(env),
         checkPi(env),
+        checkOpenCode(env, full),
         checkDatabase(),
         checkFolderProject(),
         checkConnectedProviders(env),

--- a/packages/docs-web/src/content/docs/getting-started/overview.md
+++ b/packages/docs-web/src/content/docs/getting-started/overview.md
@@ -304,7 +304,7 @@ archon workflow run <name> --cwd /path/to/repo "<message>"
 |---------|-------------|
 | `archon chat <message>` | Send a message to the orchestrator |
 | `archon setup` | Interactive setup wizard for credentials and config |
-| `archon doctor` | Verify your setup (Claude binary, gh auth, DB, adapters) |
+| `archon doctor` | Verify your setup (Claude/Codex binaries, gh auth, DB, adapters; `--full` also probes the OpenCode runtime) |
 | `archon workflow list` | List available workflows |
 | `archon workflow run <name> [msg]` | Run a workflow (`--detach` to background it) |
 | `archon workflow status` | Show active runs (running + paused) |

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -88,11 +88,14 @@ archon setup --spawn              # open in a new terminal window
 
 ### `doctor`
 
-Verify your Archon setup. Runs a checklist of common failure points: Claude binary spawn, gh CLI auth, Pi auth (when Pi is configured as default), database reachability, workspace writability, bundled defaults, folder-project detection (contained repos, when run from one), telemetry state, AI credentials (connected provider count, best-effort), and adapter token pings (Slack/Telegram, best-effort).
+Verify your Archon setup. Runs a checklist of common failure points: Claude binary spawn, Codex binary resolution (env → config → vendor → autodetect, reporting which source resolved), gh CLI auth, Pi auth (when Pi is configured as default), OpenCode runtime SDK presence, database reachability, workspace writability, bundled defaults, folder-project detection (contained repos, when run from one), telemetry state, AI credentials (connected provider count, best-effort), and adapter token pings (Slack/Telegram, best-effort).
 
 ```bash
 archon doctor
+archon doctor --full   # also probe the OpenCode runtime SDK even when it isn't the configured assistant
 ```
+
+The Codex check skips (never fails) when Codex isn't the configured assistant anywhere and no OpenAI credential is connected, so Claude-only users aren't nagged about a binary they'll never use. The OpenCode check only probes that the embedded runtime SDK module resolves — it never boots the runtime (which spawns a child process and binds a port) — and skips unless OpenCode is the configured assistant or `--full` is passed.
 
 Exit code 0 if all checks pass or are skipped; 1 if any critical check fails. Adapter pings degrade to `skip` on network errors — a flaky connection does not flip the result red.
 

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -18,6 +18,7 @@
     "./community/pi": "./src/community/pi/index.ts",
     "./community/copilot": "./src/community/copilot/index.ts",
     "./community/copilot/binary-resolver": "./src/community/copilot/binary-resolver.ts",
+    "./community/opencode/runtime": "./src/community/opencode/runtime.ts",
     "./errors": "./src/errors.ts",
     "./registry": "./src/registry.ts"
   },

--- a/packages/providers/src/codex/binary-resolver.ts
+++ b/packages/providers/src/codex/binary-resolver.ts
@@ -44,6 +44,9 @@ const CODEX_VENDOR_DIR = 'vendor/codex';
 
 const SUPPORTED_PLATFORMS = ['darwin', 'linux', 'win32'];
 
+/** Which resolution tier produced the Codex binary path. */
+export type CodexBinarySource = 'env' | 'config' | 'vendor' | 'autodetect';
+
 /** Returns the vendor binary filename for the current platform, or undefined if unsupported. */
 function getVendorBinaryName(): string | undefined {
   if (!SUPPORTED_PLATFORMS.includes(process.platform)) return undefined;
@@ -60,6 +63,19 @@ function getVendorBinaryName(): string | undefined {
 export async function resolveCodexBinaryPath(
   configCodexBinaryPath?: string
 ): Promise<string | undefined> {
+  const resolved = await resolveCodexBinaryWithSource(configCodexBinaryPath);
+  return resolved?.path;
+}
+
+/**
+ * Same resolution as {@link resolveCodexBinaryPath}, but also reports which
+ * tier produced the path. Used by `archon doctor` to tell the user how the
+ * binary was found (env / config / vendor / autodetect). Returns undefined in
+ * dev mode; throws with install instructions in binary mode when unresolved.
+ */
+export async function resolveCodexBinaryWithSource(
+  configCodexBinaryPath?: string
+): Promise<{ path: string; source: CodexBinarySource } | undefined> {
   if (!BUNDLED_IS_BINARY) return undefined;
 
   // 1. Environment variable override
@@ -72,7 +88,7 @@ export async function resolveCodexBinaryPath(
       );
     }
     getLog().info({ binaryPath: envPath, source: 'env' }, 'codex.binary_resolved');
-    return envPath;
+    return { path: envPath, source: 'env' };
   }
 
   // 2. Config file override
@@ -84,7 +100,7 @@ export async function resolveCodexBinaryPath(
       );
     }
     getLog().info({ binaryPath: configCodexBinaryPath, source: 'config' }, 'codex.binary_resolved');
-    return configCodexBinaryPath;
+    return { path: configCodexBinaryPath, source: 'config' };
   }
 
   // 3. Check vendor directory (user-placed binary)
@@ -95,7 +111,7 @@ export async function resolveCodexBinaryPath(
 
     if (fileExists(vendorBinaryPath)) {
       getLog().info({ binaryPath: vendorBinaryPath, source: 'vendor' }, 'codex.binary_resolved');
-      return vendorBinaryPath;
+      return { path: vendorBinaryPath, source: 'vendor' };
     }
   }
 
@@ -107,7 +123,7 @@ export async function resolveCodexBinaryPath(
   for (const probePath of autodetectPaths) {
     if (fileExists(probePath)) {
       getLog().info({ binaryPath: probePath, source: 'autodetect' }, 'codex.binary_resolved');
-      return probePath;
+      return { path: probePath, source: 'autodetect' };
     }
   }
 

--- a/packages/providers/src/community/opencode/runtime.ts
+++ b/packages/providers/src/community/opencode/runtime.ts
@@ -280,6 +280,20 @@ export async function disposeInstanceForDirectory(
   }
 }
 
+/**
+ * Cheap availability probe for `archon doctor` — resolves the embedded
+ * OpenCode SDK module WITHOUT starting the server.
+ *
+ * `acquireEmbeddedRuntime` spawns a child process and binds a port, which is
+ * far too heavy for a diagnostic. This only confirms the SDK is installed and
+ * its `createOpencode` entrypoint is present, so doctor can report runtime
+ * readiness without the boot. Throws if the module cannot be resolved.
+ */
+export async function probeOpencodeRuntimeModule(): Promise<boolean> {
+  const mod = await import('@opencode-ai/sdk');
+  return typeof (mod as { createOpencode?: unknown }).createOpencode === 'function';
+}
+
 /** Reset the embedded runtime state. For testing only. */
 export function resetEmbeddedRuntime(): void {
   embeddedRuntimePromise = undefined;

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -56,7 +56,12 @@ export { parseCodexConfig, type CodexProviderDefaults } from './codex/config';
 // Utilities (needed by consumers)
 export { resetCodexSingleton } from './codex/provider';
 export { loadMcpConfig, type LoadedMcpConfig } from './mcp/config';
-export { resolveCodexBinaryPath, fileExists as codexFileExists } from './codex/binary-resolver';
+export {
+  resolveCodexBinaryPath,
+  resolveCodexBinaryWithSource,
+  fileExists as codexFileExists,
+  type CodexBinarySource,
+} from './codex/binary-resolver';
 export { resolveClaudeBinaryPath, fileExists as claudeFileExists } from './claude/binary-resolver';
 
 // Community providers


### PR DESCRIPTION
## Summary

- **Problem:** `archon doctor` verified the Claude binary, gh auth, DB, providers, workspace, defaults, and adapters — but had **no Codex check at all** and nothing for the embedded OpenCode runtime. "Codex CLI binary not found" and a broken OpenCode install only surfaced mid-run.
- **Why it matters:** doctor exists to catch environment-shaped failures *before* a run burns worktree + AI cost. A missing Codex binary is a documented troubleshooting case that doctor silently missed.
- **What changed:** added `checkCodexBinary` (four-tier resolution, reports which source resolved) and `checkOpenCode` (cheap module-presence probe, never boots the runtime), plus a `--full` flag to opt the OpenCode probe in.
- **What did NOT change (scope boundary):** no change to the Codex/OpenCode providers' runtime behavior, resolution order, or the other doctor checks. `resolveCodexBinaryPath`'s public contract is unchanged (it now delegates to a new source-returning variant).

## UX Journey

### Before

```
User                         Archon doctor
────                         ─────────────
archon doctor ─────────────▶ Claude binary ✓
                             gh CLI, Pi, DB, workspace, defaults, adapters …
                             (no Codex check, no OpenCode check)
sees "All checks passed" ◀── exit 0

… later, a codex workflow run ──▶ "Codex CLI binary not found"  (worktree + AI cost already spent)
```

### After

```
User                         Archon doctor
────                         ─────────────
archon doctor ─────────────▶ Claude binary ✓
                             *Codex binary*  ✓ /path (via autodetect, spawns OK)   [or ○ skip if not configured]
                             gh CLI, Pi …
                             *OpenCode runtime* ○ not configured (pass --full to probe)
                             DB, workspace, defaults, adapters …
sees the codex/opencode status BEFORE running anything ◀── exit 0/1

archon doctor --full ──────▶ *OpenCode runtime* ✓ embedded runtime SDK present (module resolves; server not started)
```

## Architecture Diagram

### Before

```
@archon/cli
  commands/doctor.ts ──▶ @archon/git (execFileAsync)
                    └──▶ @archon/paths, @archon/core (lazy), @archon/workflows/defaults
```

### After

```
@archon/cli
  commands/doctor.ts ──▶ @archon/git (execFileAsync)
                    ├──▶ @archon/paths, @archon/core (lazy: loadConfig, listUserProviderKeys, db/users)
                    ├══▶ [+] @archon/providers/codex/binary-resolver (resolveCodexBinaryWithSource)
                    └══▶ [+] @archon/providers/community/opencode/runtime (probeOpencodeRuntimeModule, lazy)

@archon/providers
  codex/binary-resolver.ts [~]  resolveCodexBinaryPath now delegates to resolveCodexBinaryWithSource [+]
  community/opencode/runtime.ts [~]  + probeOpencodeRuntimeModule [+]  (cheap: import only, no server)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| cli/doctor.ts | providers/codex/binary-resolver | **new** | reuse resolver; report resolved source |
| cli/doctor.ts | providers/community/opencode/runtime | **new** | lazy import; module-presence probe only |
| cli/doctor.ts | core (loadConfig / listUserProviderKeys / db/users) | **new** | lazy — configured-assistant + credential gate |
| providers/index.ts | codex/binary-resolver | **modified** | export `resolveCodexBinaryWithSource` + `CodexBinarySource` |
| providers/package.json exports | opencode/runtime | **new** | `./community/opencode/runtime` subpath |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `cli`
- Module: `cli:doctor`

## Change Metadata

- Change type: `feature`
- Primary scope: `cli`

## Linked Issue

- Closes #2117

## Validation Evidence (required)

```bash
bun run validate
# VALIDATE EXIT: 0
```

- Evidence provided: full `bun run validate` green from the worktree root (check:bundled, check:bundled-skill, check:bundled-schema, check:pi-vendor-map, type-check, lint --max-warnings 0, format:check, tests). New `doctor.test.ts` suites: 64 pass / 0 fail. Existing codex `binary-resolver` tests still pass after the additive refactor.
- Manually ran `archon doctor` and `archon doctor --full` in the worktree (source build): Codex check runs when a `codexBinaryPath` is configured (reports "dev mode" in source builds), OpenCode probe skips by default and passes under `--full` ("module resolves; server not started").
- Skipped commands: none.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No** (checks are local: binary spawn, module import, DB read)
- Secrets/tokens handling changed? **No** (credential check reads existing provider-key rows to detect connection; never reads or logs key values)
- File system access scope changed? **No**

## Compatibility / Migration

- Backward compatible? **Yes** (`resolveCodexBinaryPath` contract unchanged; `doctorCommand` gains an optional param defaulting to false)
- Config/env changes? **No** new config; reads existing `assistants.codex.codexBinaryPath` / `DEFAULT_AI_ASSISTANT` / `CODEX_BIN_PATH`
- Database migration needed? **No**

## Human Verification (required)

- Verified scenarios: `archon doctor` and `archon doctor --full` end-to-end in the worktree; confirmed the OpenCode runtime is **not** booted (probe is a bare dynamic import of `@opencode-ai/sdk`, checking `createOpencode` presence).
- Edge cases checked: Codex not configured → skip; config `codexBinaryPath` set → check runs; config-load failure → degrades to env-only signals; resolver-throws → fail with install instructions; binary won't spawn → fail; OpenCode SDK unresolvable → fail; SDK resolves without `createOpencode` → fail.
- What was not verified: behavior inside a compiled `bun --compile` binary (source build only) — the resolver's binary-mode branch is exercised by the existing `binary-resolver.test.ts` mocks.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `archon doctor` (and the optional doctor run at the end of `archon setup`).
- Potential unintended effects: `checkCodexBinary`'s credential gate calls `findOrCreateUserByPlatformIdentity('cli', …)`, which lazily creates the CLI user row — but `checkConnectedProviders` already does this, so no new side effect. `loadConfig` is invoked twice (once per new check); negligible for a diagnostic command.
- Guardrails/monitoring: both checks are wrapped so a dep-load/DB failure degrades to skip/env-only rather than throwing; doctor already isolates each check via `Promise.allSettled`.

## Rollback Plan (required)

- Fast rollback: revert this commit — the change is additive and self-contained (two checks + one additive resolver export + one provider subpath export + docs).
- Feature flags/toggles: none; the OpenCode probe is gated behind `--full` / configured-assistant.
- Observable failure symptoms: a spurious `Codex binary` / `OpenCode runtime` fail line in doctor output.

## Risks and Mitigations

- Risk: doctor exit code flips to 1 for a user who configured Codex/OpenCode but has a genuinely broken binary/SDK.
  - Mitigation: that is the intended, truthful signal — the check skips entirely for users who haven't configured the provider and have no matching credential.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced `archon doctor` to verify Codex binary availability and perform a lightweight OpenCode runtime module probe.
  - Added `archon doctor --full` for deeper runtime probing and improved setup coverage.
  - Improved Codex diagnostics by reporting the resolution source tier for the binary.
- **Tests**
  - Expanded `doctor` command test coverage for Codex and OpenCode checks, including skip/pass/fail scenarios.
- **Documentation**
  - Updated CLI reference docs and examples to reflect the new checks and `--full` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->