### PR TITLE
test(container): bundled e2e container smoke workflow + CI job

### DIFF
--- a/.archon/workflows/test-workflows/e2e-container-smoke.yaml
+++ b/.archon/workflows/test-workflows/e2e-container-smoke.yaml
@@ -1,0 +1,60 @@
+# E2E smoke test — container isolation for folder projects (Phase B, #2153)
+# Bash-node-only, NO AI credential. Runs against a folder project with --container:
+#   bun run cli workflow run e2e-container-smoke --folder --container --cwd <dir> "smoke"
+# Proves the deterministic nodes exec INSIDE the managed runner container over an
+# overlay of the folder root, and that an overlay write is visible in the merged
+# view across separate exec calls within the run.
+#
+# The HOST-folder-unchanged and clean-teardown assertions live in the CI job
+# (.github/workflows/e2e-smoke.yml): they can only be observed from the host after
+# the container is gone, because Phase B discards the overlay on teardown.
+name: e2e-container-smoke
+description: "Container-isolation smoke. Asserts bash nodes run in-container (hostname == container id, overlay mounts present) and an overlay write is visible in the merged view. Host-unchanged + teardown are asserted by the CI job."
+
+nodes:
+  # Prove the deterministic node executed INSIDE the runner container, not on the host.
+  - id: assert-in-container
+    bash: |
+      # Docker sets an unset --hostname to the 12-char short container id and writes
+      # it to /etc/hostname (the `hostname` binary is absent from the slim base).
+      # On the host (CI runner / dev machine) the hostname never matches this shape,
+      # so a 12-hex value is positive proof the node exec'd inside the container.
+      hn="$(cat /etc/hostname 2>/dev/null || hostname)"
+      echo "hostname=$hn"
+      if ! printf '%s' "$hn" | grep -Eq '^[0-9a-f]{12}$'; then
+        echo "FAIL: hostname '$hn' is not a container short-id — node did not run in the container"
+        exit 1
+      fi
+      # The overlay mount points only exist inside the archon-runner container.
+      if [ ! -d /mnt/lower ] || [ ! -d /mnt/upper ]; then
+        echo "FAIL: overlay mount points /mnt/lower + /mnt/upper missing — not the overlay container"
+        exit 1
+      fi
+      echo "PASS: bash node ran inside the managed container (hostname == container id)"
+
+  # Write a file into the workspace (folder root == overlay merged mount).
+  - id: overlay-write
+    bash: |
+      marker="container-smoke-overlay-marker.txt"
+      printf 'archon-overlay-smoke\n' > "$marker"
+      echo "wrote $(pwd)/$marker"
+    depends_on: [assert-in-container]
+    trigger_rule: all_success
+
+  # A SEPARATE docker exec must see the write through the same overlay (merged view).
+  - id: overlay-read
+    bash: |
+      marker="container-smoke-overlay-marker.txt"
+      if [ ! -f "$marker" ]; then
+        echo "FAIL: $marker not visible in merged overlay view from a later node"
+        exit 1
+      fi
+      content="$(cat "$marker")"
+      echo "merged-view content: $content"
+      if [ "$content" != "archon-overlay-smoke" ]; then
+        echo "FAIL: unexpected marker content '$content'"
+        exit 1
+      fi
+      echo "PASS: overlay write visible in merged view across exec calls"
+    depends_on: [overlay-write]
+    trigger_rule: all_success

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -19,6 +19,8 @@ jobs:
       container: ${{ steps.filter.outputs.container }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -26,8 +28,15 @@ jobs:
             container:
               - 'packages/isolation/**'
               - 'scripts/build-runner-image.sh'
+              # The smoke exercises the CLI --container/--folder dispatch + teardown
+              # and the Claude container-exec spawn, so changes there must trigger it.
+              - 'packages/cli/src/commands/workflow.ts'
+              - 'packages/providers/src/claude/container-*'
               - '.github/workflows/e2e-smoke.yml'
               - '.archon/workflows/test-workflows/e2e-container-smoke.yaml'
+              # Deliberately NOT packages/workflows/src/dag-executor.ts: it also
+              # runs container exec, but it churns on unrelated work and would make
+              # this gate near-unconditional. Accept the small coverage gap.
 
   # ─── Tier 1: Deterministic (no API keys needed) ────────────────────────
   e2e-deterministic:
@@ -61,6 +70,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -9,6 +9,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ─── Path gate: only run the container tier when container code changes ──
+  # Building the runner image adds minutes, so the container smoke is gated on
+  # the paths that can affect it. Every other job below runs unconditionally.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      container: ${{ steps.filter.outputs.container }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            container:
+              - 'packages/isolation/**'
+              - 'scripts/build-runner-image.sh'
+              - '.github/workflows/e2e-smoke.yml'
+              - '.archon/workflows/test-workflows/e2e-container-smoke.yaml'
+
   # ─── Tier 1: Deterministic (no API keys needed) ────────────────────────
   e2e-deterministic:
     runs-on: ubuntu-latest
@@ -29,6 +49,92 @@ jobs:
 
       - name: Run deterministic workflow
         run: bun run cli workflow run e2e-deterministic --no-worktree "smoke test"
+
+  # ─── Tier 1b: Container isolation (Docker, no API keys needed) ──────────
+  # Deterministic slice of the container-isolation e2e (folder project +
+  # --container). Bash-node-only, so no AI credential is required. Gated on
+  # container-related paths via the `changes` job above.
+  e2e-container:
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.container == 'true' }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # Cheap fail-fast (no image/daemon needed): --container against the repo
+      # checkout (a git repo, not a folder project) must hard-error with the
+      # folder-only message before any container work.
+      - name: Negative — --container rejected on a repo project
+        run: |
+          set -uo pipefail
+          set +e
+          out="$(bun run cli workflow run e2e-container-smoke --container 'should be rejected' 2>&1)"
+          code=$?
+          set -e
+          echo "$out"
+          if [ "$code" -eq 0 ]; then
+            echo "FAIL: --container on a repo project exited 0 (expected non-zero)"; exit 1
+          fi
+          if ! printf '%s' "$out" | grep -q 'Container isolation is folder-project-only for now'; then
+            echo "FAIL: expected the folder-only error, got exit $code with different output"; exit 1
+          fi
+          echo "PASS: --container on a repo project rejected with the folder-only error (exit $code)"
+
+      - name: Build runner image
+        run: bun run build:runner-image
+
+      - name: Container smoke + teardown/host assertions
+        run: |
+          set -euo pipefail
+          # Force-remove any managed containers + archon-* volumes on exit so a
+          # failed run never leaks resources into later jobs on this runner.
+          # (Volumes are unlabeled, so they are matched by the `archon-` name
+          # prefix; only containers carry diy.archon.managed=true.)
+          cleanup() {
+            docker ps -aq --filter label=diy.archon.managed=true | xargs -r docker rm -f >/dev/null 2>&1 || true
+            docker volume ls --format '{{.Name}}' | grep '^archon-' | xargs -r docker volume rm -f >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          SCRATCH="$(mktemp -d)"
+          mkdir -p "$SCRATCH/.archon/workflows"
+          cp .archon/workflows/test-workflows/e2e-container-smoke.yaml "$SCRATCH/.archon/workflows/"
+          echo "scratch folder project: $SCRATCH"
+
+          # Register the scratch folder project on first use + run in a container.
+          # A non-zero exit here means an in-container assertion failed OR the
+          # container teardown failed — either way the run did not cleanly finish.
+          bun run cli workflow run e2e-container-smoke --folder --container --cwd "$SCRATCH" "container smoke"
+
+          # Host untouched: Phase B discards the overlay, so the marker the run
+          # wrote into the workspace must NOT exist on the host folder.
+          if [ -f "$SCRATCH/container-smoke-overlay-marker.txt" ]; then
+            echo "FAIL: overlay write leaked to the host folder (Phase B must discard the overlay)"; exit 1
+          fi
+          echo "PASS: host folder unchanged after the container run"
+
+          # No managed containers left (teardown removed them).
+          leaked_c="$(docker ps -a --filter label=diy.archon.managed=true --format '{{.Names}}')"
+          if [ -n "$leaked_c" ]; then
+            echo "FAIL: managed containers leaked:"; echo "$leaked_c"; exit 1
+          fi
+          echo "PASS: no managed containers left"
+
+          # No archon-* volumes left (match by name prefix — volumes are unlabeled).
+          leaked_v="$(docker volume ls --format '{{.Name}}' | grep '^archon-' || true)"
+          if [ -n "$leaked_v" ]; then
+            echo "FAIL: archon volumes leaked:"; echo "$leaked_v"; exit 1
+          fi
+          echo "PASS: no archon-* volumes left"
 
   # ─── Tier 2a: Claude provider ──────────────────────────────────────────
   e2e-claude:


### PR DESCRIPTION
## Summary

- **Problem:** The deterministic slice of the container-isolation e2e (Phase B, #2153) was only ever exercised by hand during live acceptance runs, so a regression in the container backend, overlay teardown, or the folder-only guard would not surface until someone ran it manually.
- **Why it matters:** Container isolation hands a workflow a privileged (CAP_SYS_ADMIN in native mode) container and a per-run volume. A silent regression that leaks containers/volumes or writes through to the live host is exactly the kind of thing CI should catch before merge.
- **What changed:** A bundled bash-node-only smoke workflow plus a gated CI job that builds the runner image, runs the smoke against a scratch folder project under `--container`, and asserts clean teardown + host-untouched, with a negative check that `--container` on a repo project hard-errors.
- **What did NOT change (scope boundary):** No product code. Nothing under `packages/**`, `dag-executor`, the isolation backend, or the CLI teardown path was touched — this PR is test infrastructure only (`.archon/workflows/test-workflows/` + `.github/workflows/e2e-smoke.yml`).

## UX Journey

### Before

```
Maintainer                       CI
──────────                       ──
edits isolation code ─────────▶  (no container coverage)
runs e2e by hand on a Mac ────▶  pass/fail known only locally
```

### After

```
Maintainer                       CI (e2e-smoke.yml)
──────────                       ──────────────────
edits packages/isolation/** ──▶  [changes] path-filter → container=true
                                 [e2e-container]
                                   negative: --container on repo → non-zero + folder-only error
                                   build runner image
                                   run smoke (folder project + --container)
                                     ↳ in-container: hostname == container id, overlay mounts present
                                     ↳ overlay write visible in merged view across exec calls
                                   assert: host folder unchanged
                                   assert: no diy.archon.managed containers, no archon-* volumes
                                   trap on exit: force-clean any leak
edits unrelated code ─────────▶  [changes] container=false → e2e-container skipped
```

## Architecture Diagram

### Before

```
.github/workflows/e2e-smoke.yml
  ├── e2e-deterministic (bash/script engine)
  ├── e2e-claude
  ├── e2e-codex
  └── e2e-mixed
```

### After

```
.github/workflows/e2e-smoke.yml
  ├── changes [+]                    (dorny/paths-filter path gate)
  ├── e2e-deterministic
  ├── e2e-container [+] === changes  (folder project + --container smoke)
  ├── e2e-claude
  ├── e2e-codex
  └── e2e-mixed

.archon/workflows/test-workflows/e2e-container-smoke.yaml [+]
  (bash-only: assert-in-container → overlay-write → overlay-read)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `e2e-container` job | `changes` job | **new** | `needs: [changes]` + `if: container == 'true'` gate |
| `e2e-container` job | `scripts/build-runner-image.sh` | **new** | `bun run build:runner-image` |
| `e2e-container` job | `e2e-container-smoke.yaml` | **new** | copied into a scratch folder project, run via CLI |
| existing tiers | anything | unchanged | deterministic/claude/codex/mixed jobs untouched |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `tests` (also `ci`)
- Module: `tests:container-isolation`

## Change Metadata

- Change type: `chore` (tests/CI)
- Primary scope: `isolation` (test coverage for the container backend)

## Linked Issue

- Closes #2157
- Related #2153 (Phase B container backend), #2156 (metadata normalization + dockerized-deploy caveats)

## Validation Evidence (required)

`bun run validate` from the worktree root — **green (exit 0)**: check:bundled, check:bundled-skill, check:bundled-schema, check:pi-vendor-map, type-check (all 10 packages), lint (`--max-warnings 0`), format:check, and the full test suite all pass.

`bun run cli validate workflows e2e-container-smoke` → `1 valid, 0 with errors`.

End-to-end run locally on Docker 28.3.2 (Docker Desktop macOS), verbatim:

```
# positive (folder project + --container)
assert-in-container: hostname=6046db1690ea
                     PASS: bash node ran inside the managed container (hostname == container id)
overlay-write:       wrote /private/tmp/archon-container-smoke.zQrpKe/container-smoke-overlay-marker.txt
overlay-read:        merged-view content: archon-overlay-smoke
                     PASS: overlay write visible in merged view across exec calls
Container and overlay volume removed. (Phase B: overlay changes were NOT applied to the live root ...)
Workflow completed successfully.  (exit 0)
# hostname 6046db1690ea == the 12-char prefix of container id 6046db1690ea0df2...

# post-run assertions
PASS: host folder unchanged (overlay marker absent — Phase B discarded the overlay)
PASS: no managed containers left
PASS: no archon-* volumes left

# negative (--container on the repo checkout, no --folder)
Error: Container isolation is folder-project-only for now. Run --container against a
registered folder project (or add --folder to register this directory as one). ...
exit code: 1
PASS: non-zero exit (1) + folder-only error present
```

- Evidence provided: local run logs (above) + green `bun run validate`.
- Intentionally skipped: the Claude-in-container leg stays out of CI v1 (needs a real credential; plan-auth probing does not belong in CI), matching the issue.

## Security Impact (required)

- New permissions/capabilities? **No** (test code only; the container backend already existed and is unchanged).
- New external network calls? **No new app calls.** The CI job's runner-image build fetches version-pinned bun/uv/claude installers over TLS at build time — same as the existing `e2e-claude` job — not a new pattern.
- Secrets/tokens handling changed? **No** (the smoke needs no credential). Both new checkout steps (`changes` + `e2e-container`) set `persist-credentials: false` so the `GITHUB_TOKEN` is not left in `.git/config` while repo-controlled build/CLI steps run. The pre-existing tiers' checkouts don't set this and are out of scope for this PR — a possible follow-up to harden them consistently.
- File system access scope changed? **No.**

## Compatibility / Migration

- Backward compatible? **Yes.**
- Config/env changes? **No.**
- Database migration needed? **No.**

## Human Verification (required)

- Verified scenarios: positive folder-project `--container` smoke (in-container exec proof, overlay merged view, clean teardown, host untouched) and the negative repo-project rejection, both run locally on Docker Desktop macOS. `bun run validate` green.
- Edge cases checked: overlay marker is written into the workspace and confirmed absent on the host after teardown (Phase B discards the overlay); container/volume leak checks against the `diy.archon.managed=true` label and the `archon-` volume-name prefix (volumes are unlabeled, so name-prefix matching is required); negative path returns non-zero even when repo auto-registration succeeds or fails.
- What was not verified: the exact overlay mount mode on GitHub-hosted ubuntu runners (locally it falls back fuse→native as documented). See Risks.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: CI only (a new gated job) plus one new test workflow file. No runtime/product behavior changes.
- Potential unintended effects: the runner-image build adds minutes to CI — bounded by the path-filter gate so it only runs on container-related changes.
- Guardrails/monitoring: `trap cleanup EXIT` in the smoke job force-removes any managed containers and `archon-*` volumes so a failed run cannot leak resources into later jobs.

## Rollback Plan (required)

- Fast rollback: revert this commit — it only adds a CI job + a test workflow file, no product code.
- Feature flags/config toggles: none needed.
- Observable failure symptoms: `e2e-container` job red on `main`/`dev`.

## Risks and Mitigations

- Risk: native overlay-in-container mount may behave differently on GitHub-hosted ubuntu runners than on Docker Desktop's Linux VM.
  - Mitigation: lowerdir is a host bind and upperdir/workdir live on a VM-local named volume (neither is overlayfs), and native mode runs with `--cap-add SYS_ADMIN --security-opt apparmor=unconfined`, so the mount should succeed as it does locally. If it does not, the failure is in the isolation backend (out of this PR's scope) and would be reported separately.
- Risk: `dorny/paths-filter@v3` is a new third-party action for this repo.
  - Mitigation: pinned to a major tag consistent with the repo's other actions; only the small `changes` gate job depends on it, and it fails open (runs the job) when the push base is ambiguous.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added automated smoke tests for container-isolated folder project execution.
  - Verified workspace changes persist across separate execution steps.
  - Added checks confirming container isolation, overlay storage behavior, and host filesystem protection.
  - Added validation for unsupported container usage with repository-based projects.
  - Added cleanup checks to detect and remove leftover containers or volumes after testing.
  - Tests now run conditionally when relevant container functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->