### PR TITLE
ci: make AI-credentialed e2e smoke tiers opt-in

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -3,6 +3,20 @@ name: E2E Smoke Tests
 on:
   push:
     branches: [main, dev]
+  # The AI-credentialed smoke tiers (e2e-claude / e2e-codex / e2e-mixed) are
+  # OPT-IN. CI has no funded API keys, so they fail on every dev push with
+  # "credit balance too low" (Anthropic) / "quota exceeded" (OpenAI) — a
+  # permanently-red tier trains people to ignore the whole workflow. Those tiers
+  # now run locally on maintainer subscriptions as the pre-release ritual, and
+  # only run in CI when deliberately enabled: dispatch this workflow with
+  # run_ai_tiers=true, or set the repo variable RUN_AI_SMOKE=true (no file edit
+  # needed to re-enable). The deterministic + container tiers stay unconditional.
+  workflow_dispatch:
+    inputs:
+      run_ai_tiers:
+        description: 'Run the AI-credentialed smoke tiers (Claude/Codex/mixed). Requires funded ANTHROPIC_API_KEY / OPENAI_API_KEY secrets.'
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -151,6 +165,12 @@ jobs:
   e2e-claude:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # OPT-IN (see the `on:` block). && binds tighter than ||, and the explicit
+    # parens make it unmistakable: run only when dispatched with run_ai_tiers
+    # OR when RUN_AI_SMOKE=true. On a push, event_name != workflow_dispatch, so
+    # the first clause is false and an unset RUN_AI_SMOKE ('' == 'true') is false
+    # too — the tier is skipped by default.
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run_ai_tiers) || (vars.RUN_AI_SMOKE == 'true') }}
     steps:
       - uses: actions/checkout@v4
 
@@ -181,6 +201,8 @@ jobs:
   e2e-codex:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # OPT-IN — same gate as e2e-claude (see the `on:` block).
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run_ai_tiers) || (vars.RUN_AI_SMOKE == 'true') }}
     steps:
       - uses: actions/checkout@v4
 
@@ -211,6 +233,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [e2e-claude, e2e-codex]
+    # OPT-IN — same gate as e2e-claude (see the `on:` block). Also skipped
+    # transitively when its needs are skipped, but the explicit gate keeps the
+    # RUN_AI_SMOKE escape hatch consistent across all three AI tiers.
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run_ai_tiers) || (vars.RUN_AI_SMOKE == 'true') }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- **Problem:** The AI-credentialed e2e smoke tiers (`e2e-claude`, `e2e-codex`, `e2e-mixed`) run on every push to `dev`/`main`, but CI has no funded API keys — they fail permanently with "credit balance too low" (Anthropic) / "quota exceeded" (OpenAI).
- **Why it matters:** A permanently-red tier is worse than no tier: it trains everyone to ignore the whole E2E Smoke workflow, so real failures in the deterministic/container tiers get missed too.
- **What changed:** Gate the three AI tiers behind an opt-in — a `workflow_dispatch` boolean input `run_ai_tiers` (default `false`) plus a repo-variable escape hatch `RUN_AI_SMOKE`. Those tiers now run locally on maintainer subscriptions as the pre-release ritual.
- **What did NOT change (scope boundary):** `e2e-deterministic` and the `changes`/`e2e-container` path-gated jobs stay exactly as they were (unconditional / path-gated). No job logic, steps, or secrets wiring were touched — only the `on:` trigger and three `if:` gates. YAML-only change.

## UX Journey

### Before

```
push to dev ──▶ E2E Smoke runs ALL tiers
                 ├─ e2e-deterministic  PASS
                 ├─ e2e-container      PASS (path-gated)
                 ├─ e2e-claude         FAIL  credit balance too low
                 ├─ e2e-codex          FAIL  quota exceeded
                 └─ e2e-mixed          FAIL  (needs claude+codex)
                 -> workflow permanently RED, ignored by everyone
```

### After

```
push to dev ──▶ E2E Smoke runs the fundable tiers
                 ├─ e2e-deterministic  PASS
                 └─ e2e-container      PASS (path-gated)
                 [e2e-claude / e2e-codex / e2e-mixed SKIPPED by default]

opt in to the AI tiers, either:
  * Actions > E2E Smoke Tests > Run workflow > run_ai_tiers = true
  * set repo variable *RUN_AI_SMOKE = true* (no file edit needed)
```

## Architecture Diagram

### Before

```
.github/workflows/e2e-smoke.yml
  on: push[main,dev]
  jobs: changes --> e2e-container
        e2e-deterministic
        e2e-claude --+
        e2e-codex  --+--> e2e-mixed
```

### After

```
.github/workflows/e2e-smoke.yml
  on: push[main,dev]  [+workflow_dispatch(run_ai_tiers)]
  jobs: changes --> e2e-container            (unchanged)
        e2e-deterministic                    (unchanged)
        [~]e2e-claude --+   if: opt-in gate
        [~]e2e-codex  --+--> [~]e2e-mixed  if: opt-in gate
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| e2e-claude / e2e-codex | e2e-mixed | unchanged | `needs:` edge preserved; all three now share the opt-in `if:` |
| workflow_dispatch input | e2e-{claude,codex,mixed} `if:` | **new** | `inputs.run_ai_tiers` opt-in |
| repo var `RUN_AI_SMOKE` | e2e-{claude,codex,mixed} `if:` | **new** | edit-free escape hatch |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `ci`
- Module: `ci:e2e-smoke`

## Change Metadata

- Change type: `chore`
- Primary scope: `ci`

## Linked Issue

- Closes # _(none — CI hygiene; rationale captured here)_
- Related #

## Validation Evidence (required)

```bash
bun run validate   # GREEN (exit 0) — generated-file checks, type-check, lint, format, tests all pass
bun x js-yaml .github/workflows/e2e-smoke.yml   # parses; both push + workflow_dispatch triggers, run_ai_tiers boolean default false
```

- Evidence provided: parsed the workflow with two independent parsers and confirmed `e2e-deterministic`/`changes` stay ungated, `e2e-container` keeps its path gate, and the three AI tiers carry the opt-in `if:`.
- Expression semantics: `if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run_ai_tiers) || (vars.RUN_AI_SMOKE == 'true') }}`. `&&` binds tighter than `||`; the parens are explicit anyway. On a `push`, `github.event_name != 'workflow_dispatch'` so the first clause is `false`, and an unset/empty `RUN_AI_SMOKE` makes `'' == 'true'` -> `false`, so the tier is skipped by default. Dispatching with `run_ai_tiers=true`, or setting `RUN_AI_SMOKE=true`, enables it.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No` (same `secrets.ANTHROPIC_API_KEY` / `secrets.OPENAI_API_KEY` wiring, just runs less often)
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes` — optional repo variable `RUN_AI_SMOKE` (only if you want the AI tiers in CI)
- Database migration needed? `No`

## Human Verification (required)

- Verified scenarios: parsed the YAML with two independent parsers; confirmed the `on:` triggers, the boolean input default, and each job's resolved `if:` expression.
- Edge cases checked: unset `RUN_AI_SMOKE` resolves falsy on push; `workflow_dispatch` default (`run_ai_tiers=false`) also skips; `e2e-mixed` stays gated consistently with its `needs:` parents.
- What was not verified: an actual dispatched CI run of the AI tiers (requires funded keys — that is the point of the change; they run locally instead).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: only the E2E Smoke Tests GitHub Actions workflow.
- Potential unintended effects: none — deterministic + container tiers unchanged. AI-tier regressions are now caught locally / on demand rather than on every push.
- Guardrails/monitoring: the AI tiers remain the documented pre-release local ritual; re-enable in CI anytime via the input or `RUN_AI_SMOKE`.

## Rollback Plan (required)

- Fast rollback: revert this commit — the AI tiers return to running on every push.
- Feature flags/toggles: `RUN_AI_SMOKE` repo variable / `run_ai_tiers` dispatch input.
- Observable failure symptoms: AI smoke tiers unexpectedly skipped or running.

## Risks and Mitigations

- Risk: a real AI-tier regression lands on `dev` without CI catching it.
  - Mitigation: the AI tiers are the pre-release local ritual on maintainer subscriptions, and can be dispatched or var-enabled in CI on demand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated smoke-test workflow controls so AI-credentialed test tiers run only when explicitly enabled.
  * Added a manual workflow option for running AI smoke tests.
  * Kept deterministic and container smoke tests running under their existing conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->