### PR TITLE
chore(providers): bump @openai/codex-sdk to 0.144.5 for gpt-5.6 support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -141,7 +141,7 @@
         "@earendil-works/pi-ai": "^0.80.6",
         "@earendil-works/pi-coding-agent": "^0.80.6",
         "@github/copilot-sdk": "~1.0.1",
-        "@openai/codex-sdk": "^0.144.4",
+        "@openai/codex-sdk": "^0.144.5",
         "@opencode-ai/sdk": "^1.17.3",
         "@sinclair/typebox": "^0.34.41",
         "ajv": "^8.20.0",
@@ -759,21 +759,21 @@
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
-    "@openai/codex": ["@openai/codex@0.144.4", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.4-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.4-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.4-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.144.4-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.4-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.144.4-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-DTHzYatlKq9dw55E0/HsbK4tRCEKabuJ10ybbqpsG8gVv/kvwEdg3Z4OI3cvLXKa21xkIa4lkGlZoO/HmqmFFw=="],
+    "@openai/codex": ["@openai/codex@0.144.5", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.5-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.5-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.5-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.144.5-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.5-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.144.5-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-jjB+K+OMv572mKhS+2QuLxWXDJNdpwbPenf+V+8bdq7wg4Scqt3cn6WEekD8wPqDVZqck0HSX17K9rD9kbDJQA=="],
 
-    "@openai/codex-darwin-arm64": ["@openai/codex@0.144.4-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6J3g498cM2oA7vYIJhpuGJlnIi/M5JdYmjB5BZ1Of5HQ0ziIlplFSvH801oVy9J5TQFp642ODzOu/ZEokDUXsg=="],
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.144.5-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zcT6NfBCqLFt+BReNSETTZW6v6PdbH0dzNtm9j7l7mDGqwPbKZDGJdnpkBao2389I0ZacyIKgSZoI0vez1d4Dw=="],
 
-    "@openai/codex-darwin-x64": ["@openai/codex@0.144.4-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-k1HC8gdbAy+VmMbekYkhM+r+QE2Xfgd67n1VSp94tjz7aXVKoalHcDkdKNM/uUQ8o2tvbiwhHSUftJF8Sm9/Lw=="],
+    "@openai/codex-darwin-x64": ["@openai/codex@0.144.5-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-//Mo0m1MwaoT6psu5xsmofXpKx4/0irIkeq10xJvk59+886EG355ibjA+ZmlRcKhE3bLjsKD7p81nTbAdRL/bw=="],
 
-    "@openai/codex-linux-arm64": ["@openai/codex@0.144.4-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-OlKx65579OwIzech9Tt3OUH9+hFZfFrCBP1hL2MudnMIoNr1+cFZjB5YIj5MWMRoBD+K5W3wdBIpQSH855b5Sg=="],
+    "@openai/codex-linux-arm64": ["@openai/codex@0.144.5-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-zAHggxVwR2TBxKmybXY7ZMiB0G8DMonY2YPdwNNjwXcf+LOIqNGgswwNCDMbP/HEe6r8j+R9ZX/yYoo8f+n/RQ=="],
 
-    "@openai/codex-linux-x64": ["@openai/codex@0.144.4-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-2jxrmV6+/7eBNdg5uhhmOEPFu2o28eYY/ClLzWhSBHH8uo3f2KA1z9JQcVtwlbToW03nEPlEzYNYfCF1UBqsVQ=="],
+    "@openai/codex-linux-x64": ["@openai/codex@0.144.5-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-FalLJlBQGFdK8Gc3kj9sa/ekNdgkHhUawLaKkvy5CtB18JaP2YxtTP/Pe1pD2iBiq8mMUliRnafpF6AdBdQMbg=="],
 
-    "@openai/codex-sdk": ["@openai/codex-sdk@0.144.4", "", { "dependencies": { "@openai/codex": "0.144.4" } }, "sha512-JtND4npLaM1jKlTJVGU3XaX7xqnRG62yusz13kPgialnfd0CBrjOgXFGSRojYcvWZSggQoEkZBVAGtoKE0y8sw=="],
+    "@openai/codex-sdk": ["@openai/codex-sdk@0.144.5", "", { "dependencies": { "@openai/codex": "0.144.5" } }, "sha512-90wHPEGyk74On6gwQPNtw+wzuDJ2zYpiVADDxw43S1cWn3QbBh/21zFS2xlAWWCrdY0gE90yXfmmrzwdUDlBGw=="],
 
-    "@openai/codex-win32-arm64": ["@openai/codex@0.144.4-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-CCgfI1smFhHZTIpTuBwDJwBr/AR40RTqaFxbBWVabu0RMeYDteRuPiDfdTlktf3C43Y1q10VZXhVGYtCokDg2w=="],
+    "@openai/codex-win32-arm64": ["@openai/codex@0.144.5-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-0Pj7iqjEOEvPQPO3kFfCy9vGX4BTu76ChFFZHr2eNNIfVc3FOENAv/X98u4L+iIUtDOK9DbqmfUudW3DPapshg=="],
 
-    "@openai/codex-win32-x64": ["@openai/codex@0.144.4-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-iL1ky0ERgdQJOKzom/Ms1fhpwkSmpsA9eVrzAqURFlYGS8z7JqwEgm33+nLGCsY7y25d8Xs/LJ91Oiqz3yXcUg=="],
+    "@openai/codex-win32-x64": ["@openai/codex@0.144.5-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-DnsSTlnnzleTxvLwIGnBitKInscxn2I7qASqosS8Fv+qysBygd+ZiBn/SQsRCgQ28PAlsNzmd3Gf3ZTecolAmg=="],
 
     "@opencode-ai/sdk": ["@opencode-ai/sdk@1.17.3", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-oXrEjOuP3+J9pPNw3cmOnRma/xiVQ4WIIvGd6YkhPQgqqi2PnD/b1qfNY0AMead3QfNhKwKdDM4QFJdN2LpByg=="],
 

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -33,7 +33,7 @@
     "@earendil-works/pi-ai": "^0.80.6",
     "@earendil-works/pi-coding-agent": "^0.80.6",
     "@opencode-ai/sdk": "^1.17.3",
-    "@openai/codex-sdk": "^0.144.4",
+    "@openai/codex-sdk": "^0.144.5",
     "@sinclair/typebox": "^0.34.41",
     "ajv": "^8.20.0",
     "jsonrepair": "^3.14.0",

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -326,7 +326,7 @@ function buildTurnOptions(requestOptions?: SendQueryOptions): {
 /**
  * Fold the request/node-level systemPrompt into the user prompt.
  *
- * The Codex SDK (verified at @openai/codex-sdk 0.144.4) exposes NO
+ * The Codex SDK (verified at @openai/codex-sdk 0.144.5) exposes NO
  * instructions/system-prompt channel on ThreadOptions or TurnOptions, so the
  * only delivery mechanism is prepending to the prompt string, separated by
  * the same `---` delimiter augmentPromptForJsonSchema uses. See issue #1837.


### PR DESCRIPTION
## Summary

- **Problem:** OpenAI now rejects the gpt-5.6 model lineup from Codex clients older than 0.144.5. Our pinned `@openai/codex-sdk@0.144.4` fails at runtime with: `400 invalid_request_error: "The 'gpt-5.6-luna' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again."`
- **Why it matters:** Every Codex-provider run targeting a 5.6 model (workflows, chat) is dead on 0.144.4. This is a hard block on the current Codex model line.
- **What changed:** Bumped `@openai/codex-sdk` `^0.144.4 → ^0.144.5` in `packages/providers/package.json`, refreshed the lockfile (also pulls in the matching `@openai/codex` 0.144.5 binary, which is what satisfies the server-side version check), and updated the verified-version comment in `codex/provider.ts`.
- **What did NOT change (scope boundary):** No provider logic, no API surface usage, no refactors. Dependency bump only.

## UX Journey

### Before

```
  Workflow/chat          Archon                    Codex API
  ─────────────          ──────                    ─────────
  run codex node ──────▶ CodexProvider.sendQuery
                         @openai/codex 0.144.4 ───▶ 400: model requires newer Codex
  run FAILS   ◀───────── error surfaced
```

### After

```
  Workflow/chat          Archon                    Codex API
  ─────────────          ──────                    ─────────
  run codex node ──────▶ CodexProvider.sendQuery
                         *@openai/codex 0.144.5* ─▶ 200: gpt-5.6-luna accepted
  run SUCCEEDS ◀──────── output streamed
```

## Architecture Diagram

### Before / After

No module topology change. Only the pinned dependency version behind `CodexProvider` changes.

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `@archon/providers` codex/provider.ts | `@openai/codex-sdk` | modified | version pin 0.144.4 → 0.144.5 |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `dependencies`
- Module: `providers:codex`

## Change Metadata

- Change type: `chore`
- Primary scope: `providers` (dependency)

## Linked Issue

- Related # (runtime enforcement error, no tracking issue filed)

## Validation Evidence (required)

```bash
bun run validate   # all 8 checks green, exit 0
```

- Evidence provided:
  - `check:bundled` / `check:bundled-skill` / `check:bundled-schema` — up to date
  - `check:pi-vendor-map` — OK
  - `type-check` — clean across all 10 packages
  - `lint` / `format:check` — clean
  - `test` — all packages pass, 0 fail
  - **Live smoke (this machine, ChatGPT-plan credential, gpt-5.6-luna):**
    - `bun run cli workflow run e2e-codex-smoke --no-worktree "smoke"` → `PASS: simple='4' structured='{category:math}'`
    - `bun run cli workflow run e2e-mixed-providers --no-worktree "smoke"` → `PASS: claude='claude-ok' codex='codex-ok'`
- Skipped commands: none

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Database migration needed? `No`
- Note: consumers on a native/user-placed Codex binary (`codexBinaryPath` / `~/.archon/vendor/codex`) must update that binary separately to clear the 5.6 enforcement; this bump only refreshes the npm-resolved binary.

## Human Verification (required)

- Verified scenarios: both live smokes passed against `gpt-5.6-luna` — the exact model that 400s on 0.144.4. Codex threads started cleanly (`codex.thread_started`), no enforcement error.
- Edge cases checked: mixed Claude+Codex workflow with cross-provider `$nodeId.output` refs; structured-output node validated against declared schema.
- Diffed SDK `.d.ts` 0.144.4 → 0.144.5: single additive optional field (`McpToolCallItem.result._meta?: unknown`), unused by provider code.
- What was not verified: Windows/Linux binaries (only darwin-arm64 exercised); native user-placed Codex binary path.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Codex-provider runs only (workflows + chat).
- Potential unintended effects: none expected — patch-level bump, no type/API changes consumed.
- Guardrails/monitoring: existing e2e codex + mixed-provider smoke workflows.

## Rollback Plan (required)

- Fast rollback: revert this commit (restores `^0.144.4` + prior lockfile), `bun install`.
- Feature flags/toggles: none.
- Observable failure symptoms: Codex runs 400 with the gpt-5.6 version-enforcement message.

## Risks and Mitigations

- Risk: patch bump introduces an unexpected binary regression.
  - Mitigation: live-verified both codex-only and mixed-provider smokes on this machine before merge; single additive type change confirmed via `.d.ts` diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Codex integration to the latest SDK patch version.
  * Updated related documentation to reflect the new SDK version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->