### PR TITLE
fix(workflows): skip base-branch auto-detection on folder projects (#2159)

### DIFF
--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -718,6 +718,67 @@ describe('executeWorkflow', () => {
       expect(mockGetDefaultBranch).toHaveBeenCalledWith('/tmp/worktree');
       expect(mockExecuteDagWorkflow.mock.calls[0]?.[10]).toBe('main');
     });
+
+    it('skips git auto-detection for a folder-kind codebase, no ERROR/WARN spam (#2159)', async () => {
+      const store = makeStore({
+        getCodebase: mock(async () => ({
+          id: 'cb-folder',
+          name: 'Ops Root',
+          repository_url: null,
+          default_cwd: '/tmp/ops',
+          kind: 'folder' as const,
+        })),
+      });
+      const deps = makeDeps(store);
+
+      await executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-1',
+        '/tmp/ops',
+        makeWorkflow(),
+        'test message',
+        'db-conv-1',
+        { codebaseId: 'cb-folder' }
+      );
+
+      // Non-git root: detection is never attempted (no git shell-out), so the
+      // benign auto-detect WARN is never emitted and $BASE_BRANCH resolves to
+      // empty (unresolved-but-not-referenced).
+      expect(mockGetDefaultBranch).not.toHaveBeenCalled();
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[10]).toBe('');
+      const warnedAutoDetect = (mockLogFn.mock.calls as unknown[][]).some(
+        args => args[1] === 'workflow.base_branch_auto_detect_failed'
+      );
+      expect(warnedAutoDetect).toBe(false);
+    });
+
+    it('still auto-detects for a repo-kind codebase (folder skip does not over-trigger)', async () => {
+      const store = makeStore({
+        getCodebase: mock(async () => ({
+          id: 'cb-repo',
+          name: 'acme/widget',
+          repository_url: 'https://github.com/acme/widget',
+          default_cwd: '/repos/widget',
+          kind: 'repo' as const,
+        })),
+      });
+      const deps = makeDeps(store);
+
+      await executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-1',
+        '/tmp/worktree',
+        makeWorkflow(),
+        'test message',
+        'db-conv-1',
+        { codebaseId: 'cb-repo' }
+      );
+
+      expect(mockGetDefaultBranch).toHaveBeenCalledWith('/tmp/worktree');
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[10]).toBe('main');
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -226,6 +226,30 @@ async function resolveUserProviderEnvForWorkflow(
 }
 
 /**
+ * Whether the run's codebase is a folder project (non-git). Folder projects run
+ * in place on a non-git root, so git base-branch auto-detection can only fail
+ * (`fatal: not a git repository`) — skip it to avoid the ERROR/WARN log-spam
+ * pair on every folder run (#2159). `$BASE_BRANCH` keeps its
+ * referenced-but-unresolvable failure semantics (empty string when skipped).
+ *
+ * Contract: NEVER THROWS. A lookup failure returns `false` so the normal
+ * auto-detection path still runs, preserving prior behavior on any DB hiccup.
+ */
+async function isFolderCodebase(
+  deps: WorkflowDeps,
+  codebaseId: string | undefined
+): Promise<boolean> {
+  if (!codebaseId) return false;
+  try {
+    const codebase = await deps.store.getCodebase(codebaseId);
+    return codebase?.kind === 'folder';
+  } catch (err) {
+    getLog().warn({ err: err as Error, codebaseId }, 'workflow.folder_kind_resolve_failed');
+    return false;
+  }
+}
+
+/**
  * Resolve the artifacts and log directories for a workflow run.
  * Looks up the codebase by ID once, parses owner/repo, and returns project-scoped paths.
  * Folder projects route to `_folder/<slug>/` storage; falls back to cwd-based
@@ -520,6 +544,11 @@ export async function executeWorkflow(
     baseBranch = config.baseBranch;
   } else if (fallbackBaseBranch) {
     baseBranch = fallbackBaseBranch;
+  } else if (await isFolderCodebase(deps, codebaseId)) {
+    // Folder projects run on a non-git root — auto-detection can only fail and
+    // emit ERROR/WARN noise on every run (#2159). Leave empty; $BASE_BRANCH
+    // stays unresolved and throws only if a prompt actually references it.
+    baseBranch = '';
   } else {
     try {
       baseBranch = await getDefaultBranch(toRepoPath(cwd));


### PR DESCRIPTION
## Summary

- **Problem:** Every folder-project workflow run logged a benign ERROR/WARN pair at startup (`git.default_branch_symbolic_ref_failed` + `workflow.base_branch_auto_detect_failed`) because `executeWorkflow` ran git base-branch auto-detection unconditionally against a non-git root.
- **Why it matters:** Folder projects are non-git by definition, so the detection can only ever fail. The noise fired on every run and misleads anyone reading logs into thinking something broke.
- **What changed:** Gate the auto-detection on a guarded folder-kind check — when the resolved codebase is `kind: 'folder'`, skip the git shell-out and leave `baseBranch` empty.
- **What did NOT change (scope boundary):** Repo-kind and unregistered runs auto-detect exactly as before. `$BASE_BRANCH` keeps its referenced-but-unresolvable failure semantics (empty string; throws only if a prompt actually references it). No change to isolation, dag-executor, or docs.

## UX Journey

### Before

```
folder-project run ──▶ executeWorkflow
                         resolve base branch:
                           config? no · caller? no
                           getDefaultBranch(cwd) ──▶ git symbolic-ref
                                                     fatal: not a git repository
                         [ERROR git.default_branch_symbolic_ref_failed]
                         [WARN  workflow.base_branch_auto_detect_failed]
                         baseBranch = ''  · run continues
```

### After

```
folder-project run ──▶ executeWorkflow
                         resolve base branch:
                           config? no · caller? no
                           *isFolderCodebase(codebaseId)? YES* ──▶ skip git
                         baseBranch = ''  · run continues  [no log noise]
```

## Architecture Diagram

### Before

```
executeWorkflow ──(unconditional)──▶ @archon/git getDefaultBranch ──▶ git symbolic-ref
```

### After

```
executeWorkflow ──▶ [+] isFolderCodebase(deps.store.getCodebase) ──(kind==='folder')──x-- skip
                 └──(repo / unregistered)──▶ @archon/git getDefaultBranch ──▶ git symbolic-ref
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| executeWorkflow | isFolderCodebase | **new** | guarded kind lookup before auto-detect |
| isFolderCodebase | store.getCodebase | **new** | existing dep, reused for `kind` |
| executeWorkflow | git.getDefaultBranch | modified | now skipped for folder-kind |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `workflows`
- Module: `workflows:executor`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes #2159

## Validation Evidence (required)

```bash
bun run validate   # exit 0 — check:bundled + skill + schema + pi-vendor-map, type-check, lint, format:check, tests all green
bun test packages/workflows/src/executor.test.ts   # 69 pass / 0 fail (2 new base-branch tests)
```

- Evidence provided: `bun run validate` exited 0 with no failing tests; the executor suite passes 69/69 including the two added cases (folder-kind skip asserts `getDefaultBranch` not called + no auto-detect WARN emitted; repo-kind still auto-detects).
- Skipped commands: none.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No (removes an unnecessary git shell-out on folder roots)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: folder-kind codebase skips auto-detection with no WARN and empty `$BASE_BRANCH`; repo-kind codebase and no-codebaseId runs still auto-detect (`getDefaultBranch` called).
- Edge cases checked: `getCodebase` throwing is caught and falls through to the normal auto-detection path (never blocks a run); no `codebaseId` short-circuits before any DB call.
- What was not verified: live containerized folder run against a real DB (covered by unit tests + the #2157 e2e that surfaced the noise).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `$BASE_BRANCH` resolution in `executeWorkflow` only.
- Potential unintended effects: a folder project whose root happens to be a git repo no longer auto-detects a base branch — intentional, since folder-kind is a non-git contract; set `worktree.baseBranch` in config if such a workflow references `$BASE_BRANCH`.
- Guardrails: guarded lookup degrades to prior behavior (with noise) on any DB failure; existing `$BASE_BRANCH`-referenced hard-fail is unchanged.

## Rollback Plan (required)

- Fast rollback: revert this commit (single-file logic change + tests).
- Feature flags: none.
- Observable failure symptoms: folder runs referencing `$BASE_BRANCH` in a prompt would fail (unchanged from before for non-git roots); repo runs missing a detected base branch.

## Risks and Mitigations

- Risk: an extra `getCodebase` round-trip at workflow start.
  - Mitigation: only runs when both config and caller base branch are unset; a single cheap lookup, fully guarded, negligible vs. the git shell-out it replaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow execution for folder-based codebases by skipping unnecessary Git default-branch detection.
  * Reduced misleading warnings and repeated detection errors for projects that are not Git repositories.
  * Preserved automatic default-branch detection for repository-based codebases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->