### PR TITLE
fix(workflows): fail loudly on unknown-node $LOOP_PREV.<id>.output.field refs

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -11485,11 +11485,13 @@ describe('executeDagWorkflow -- loop_group node', () => {
     expect(substituteLoopPrevRefs('other=[$LOOP_PREV.absent.output.field]', prev)).toBe('other=[]');
   });
 
-  it('EDGE F (#2142): $LOOP_PREV.<typo>.output.<field> throws unknown-node when a body-id set is given', () => {
-    // Iteration-1 posture: no prior outputs yet. With the static body-id set threaded in,
-    // a `.field` ref to an id that matches NO body node is a typo → fail loudly; a `.field`
-    // ref to a KNOWN body id that simply has no prior output yet stays lenient ('').
-    const knownBodyIds = new Set(['grader', 'work']);
+  it('EDGE F (#2142): substituteLoopPrevRefs classifies absent refs by the two body-id sets', () => {
+    // Iteration-1 posture: no prior outputs yet. `knownBodyIds` is the TRANSITIVE set
+    // (this group + nested descendants); `directBodyIds` is only this group's immediate ids.
+    // Group body: { grader, work, refine(nested group) }; refine's inner body: { polish }.
+    const knownBodyIds = new Set(['grader', 'work', 'refine', 'polish']);
+    const directBodyIds = new Set(['grader', 'work', 'refine']);
+
     // Typo: `grrader` matches no body node → OutputRefError('unknown-node') + did-you-mean.
     let caught: unknown;
     try {
@@ -11498,7 +11500,8 @@ describe('executeDagWorkflow -- loop_group node', () => {
         undefined,
         false,
         undefined,
-        knownBodyIds
+        knownBodyIds,
+        directBodyIds
       );
     } catch (e) {
       caught = e;
@@ -11507,16 +11510,41 @@ describe('executeDagWorkflow -- loop_group node', () => {
     expect((caught as OutputRefError).reason).toBe('unknown-node');
     expect((caught as OutputRefError).message).toContain("'grader'"); // did-you-mean names the near miss
 
-    // Known body id with no prior-iteration output (iteration 1) → '' (legitimate absence).
+    // Direct body id with no prior-iteration output (iteration 1) → '' (legitimate absence).
     expect(
       substituteLoopPrevRefs(
         'score=$LOOP_PREV.grader.output.score',
         undefined,
         false,
         undefined,
-        knownBodyIds
+        knownBodyIds,
+        directBodyIds
       )
     ).toBe('score=');
+
+    // Nested-owned id (`polish` ∈ known, ∉ direct): token left INTACT so the inner
+    // loop_group resolves it against its OWN prior-iteration snapshot later. Both the
+    // `.field` and whole-text forms are preserved.
+    expect(
+      substituteLoopPrevRefs(
+        'draft=[$LOOP_PREV.polish.output.draft]',
+        undefined,
+        false,
+        undefined,
+        knownBodyIds,
+        directBodyIds
+      )
+    ).toBe('draft=[$LOOP_PREV.polish.output.draft]');
+    expect(
+      substituteLoopPrevRefs(
+        'whole=[$LOOP_PREV.polish.output]',
+        undefined,
+        false,
+        undefined,
+        knownBodyIds,
+        directBodyIds
+      )
+    ).toBe('whole=[$LOOP_PREV.polish.output]');
 
     // Whole-text `$LOOP_PREV.<id>.output` to an unknown id stays lenient (no throw), even
     // with the set — mirrors substituteNodeOutputRefs' lenient whole-text surface.
@@ -11526,7 +11554,8 @@ describe('executeDagWorkflow -- loop_group node', () => {
         undefined,
         false,
         undefined,
-        knownBodyIds
+        knownBodyIds,
+        directBodyIds
       )
     ).toBe('all=');
 
@@ -11537,16 +11566,21 @@ describe('executeDagWorkflow -- loop_group node', () => {
         undefined,
         true,
         undefined,
-        knownBodyIds
+        knownBodyIds,
+        directBodyIds
       )
     ).toThrow(OutputRefError);
+
+    // Raw caller with NO sets → fully lenient (pre-#2142 behavior): unknown id .field → ''.
+    expect(substituteLoopPrevRefs('x=[$LOOP_PREV.grrader.output.score]', undefined)).toBe('x=[]');
   });
 
-  it('EDGE F (#2142): applyLoopPrevToBodyNode threads the body-id set — typo throws, nested real id stays lenient', () => {
-    // The executor path builds the static body-id set (transitive across nested groups)
-    // and threads it through applyLoopPrevToBodyNode. Simulate iteration 1 (no prior
-    // outputs). Outer body = { review }; nested inner group `refine` has body node `polish`.
+  it('EDGE F (#2142): applyLoopPrevToBodyNode — typo throws, nested-owned token SURVIVES the outer pass', () => {
+    // The executor path threads the transitive `knownBodyIds` and immediate `directBodyIds`.
+    // Simulate the OUTER group's iteration-1 pass (no prior outputs). Outer body =
+    // { review, refine(nested group) }; refine's inner body = { polish }.
     const knownBodyIds = new Set(['review', 'refine', 'polish']);
+    const directBodyIds = new Set(['review', 'refine']);
 
     // A typo in a body prompt fails loudly.
     expect(() =>
@@ -11559,12 +11593,15 @@ describe('executeDagWorkflow -- loop_group node', () => {
         undefined,
         '',
         undefined,
-        knownBodyIds
+        knownBodyIds,
+        directBodyIds
       )
     ).toThrow(OutputRefError);
 
-    // A nested loop_group whose inner body references a REAL inner id (`polish`) resolves to
-    // '' at the outer granularity — no false-positive throw, because `polish` is in the set.
+    // A nested loop_group whose inner body references its OWN sibling id (`polish`, nested-
+    // owned) must have that token LEFT INTACT by the outer pass — otherwise the inner loop
+    // could never resolve its own prior iteration (this is the #2165 fix; before it the
+    // outer pass destroyed the token to '').
     const nestedGroup = applyLoopPrevToBodyNode(
       {
         id: 'refine',
@@ -11580,12 +11617,44 @@ describe('executeDagWorkflow -- loop_group node', () => {
       undefined,
       '',
       undefined,
-      knownBodyIds
+      knownBodyIds,
+      directBodyIds
     );
     if (!('loop_group' in nestedGroup) || nestedGroup.loop_group === undefined)
       throw new Error('expected loop_group node');
     const polishNode = nestedGroup.loop_group.nodes[0];
-    expect('prompt' in polishNode && polishNode.prompt).toBe('refine on ');
+    expect('prompt' in polishNode && polishNode.prompt).toBe(
+      'refine on $LOOP_PREV.polish.output.draft'
+    );
+
+    // A ref to an OUTER-direct id (`review`) inside the nested body IS resolved now, at the
+    // outer granularity — here to '' (iteration 1, no prior output), not preserved.
+    const nestedReadsOuter = applyLoopPrevToBodyNode(
+      {
+        id: 'refine',
+        loop_group: {
+          until: 'DONE',
+          max_iterations: 2,
+          nodes: [
+            {
+              id: 'polish',
+              prompt: 'saw outer [$LOOP_PREV.review.output.verdict]',
+              depends_on: [],
+            },
+          ],
+        },
+        depends_on: [],
+      } as DagNode,
+      undefined,
+      '',
+      undefined,
+      knownBodyIds,
+      directBodyIds
+    );
+    if (!('loop_group' in nestedReadsOuter) || nestedReadsOuter.loop_group === undefined)
+      throw new Error('expected loop_group node');
+    const polishReadsOuter = nestedReadsOuter.loop_group.nodes[0];
+    expect('prompt' in polishReadsOuter && polishReadsOuter.prompt).toBe('saw outer []');
 
     // But a typo INSIDE the nested body (id in no body node) still throws through the recursion.
     expect(() =>
@@ -11604,9 +11673,89 @@ describe('executeDagWorkflow -- loop_group node', () => {
         undefined,
         '',
         undefined,
-        knownBodyIds
+        knownBodyIds,
+        directBodyIds
       )
     ).toThrow(OutputRefError);
+  });
+
+  it('EDGE F (#2165): a nested inner loop_group resolves its OWN prior-iteration $LOOP_PREV end-to-end', async () => {
+    // The semantics the L3417 comment promises: an inner loop_group body node referencing
+    // its own sibling's previous iteration (`$LOOP_PREV.w.output`) must see that output on
+    // the inner group's 2nd+ iteration — even though the inner group is nested inside an
+    // outer loop_group. Before #2165 the outer loop's substitution pass eagerly destroyed
+    // the token to '' before the inner loop ran, so it was empty on EVERY inner iteration.
+    //
+    // Body node `w` emits a distinct marker each call; we capture the prompt it receives.
+    // Inner iteration 1 → no prior output (''); inner iteration 2 → the marker from
+    // iteration 1 (proving the inner loop resolved its own prior iteration).
+    const capturedPrompts: string[] = [];
+    mockSendQueryDag.mockImplementation(function* (prompt: string) {
+      capturedPrompts.push(prompt ?? '');
+      const n = capturedPrompts.length;
+      // Call 1 emits MARK1 (no signal → inner iterates again); call 2 emits the signal.
+      yield { type: 'assistant', content: n === 1 ? 'MARK1' : 'MARK2 INNER_DONE' };
+      yield { type: 'result', sessionId: `s-${n}` };
+    });
+
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('lg-nested-prev');
+
+    const nodes: DagNode[] = [
+      {
+        id: 'outer',
+        loop_group: {
+          until: 'OUTER_DONE',
+          // One outer iteration is enough to run the inner group to its own completion.
+          max_iterations: 1,
+          fresh_context: false,
+          nodes: [
+            {
+              id: 'inner',
+              loop_group: {
+                until: 'INNER_DONE',
+                max_iterations: 3,
+                fresh_context: false,
+                nodes: [
+                  {
+                    id: 'w',
+                    prompt: 'prev=[$LOOP_PREV.w.output] do work',
+                    depends_on: [],
+                  },
+                ],
+              },
+              depends_on: [],
+            },
+          ],
+        },
+        depends_on: [],
+      },
+    ];
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-lg',
+      testDir,
+      { name: 'lg-nested-prev', nodes },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    // Two inner iterations ran within the single outer iteration.
+    expect(capturedPrompts.length).toBe(2);
+    // Inner iteration 1: no prior output → empty.
+    expect(capturedPrompts[0]).toContain('prev=[]');
+    // Inner iteration 2: the inner loop resolved ITS OWN prior-iteration output — the token
+    // survived the outer pass and resolved against the inner snapshot. This is the fix.
+    expect(capturedPrompts[1]).toContain('prev=[MARK1]');
   });
 
   it('EDGE H: applyLoopPrevToBodyNode uses shell escaping only for shell-bound fields (unit)', () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -11479,8 +11479,134 @@ describe('executeDagWorkflow -- loop_group node', () => {
 
   it('EDGE F: $LOOP_PREV.<id>.output.<field> on a missing prior node resolves to empty', () => {
     // The referenced node wasn't in the prior iteration (skipped/absent) → '' not a throw.
+    // Raw call (no knownBodyIds set) stays fully lenient — the typo check only engages when
+    // the static body-id set is threaded in via the executor path.
     const prev = new Map<string, NodeOutput>([['work', makeOutput('completed', 'ran', undefined)]]);
     expect(substituteLoopPrevRefs('other=[$LOOP_PREV.absent.output.field]', prev)).toBe('other=[]');
+  });
+
+  it('EDGE F (#2142): $LOOP_PREV.<typo>.output.<field> throws unknown-node when a body-id set is given', () => {
+    // Iteration-1 posture: no prior outputs yet. With the static body-id set threaded in,
+    // a `.field` ref to an id that matches NO body node is a typo → fail loudly; a `.field`
+    // ref to a KNOWN body id that simply has no prior output yet stays lenient ('').
+    const knownBodyIds = new Set(['grader', 'work']);
+    // Typo: `grrader` matches no body node → OutputRefError('unknown-node') + did-you-mean.
+    let caught: unknown;
+    try {
+      substituteLoopPrevRefs(
+        'score=$LOOP_PREV.grrader.output.score',
+        undefined,
+        false,
+        undefined,
+        knownBodyIds
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(OutputRefError);
+    expect((caught as OutputRefError).reason).toBe('unknown-node');
+    expect((caught as OutputRefError).message).toContain("'grader'"); // did-you-mean names the near miss
+
+    // Known body id with no prior-iteration output (iteration 1) → '' (legitimate absence).
+    expect(
+      substituteLoopPrevRefs(
+        'score=$LOOP_PREV.grader.output.score',
+        undefined,
+        false,
+        undefined,
+        knownBodyIds
+      )
+    ).toBe('score=');
+
+    // Whole-text `$LOOP_PREV.<id>.output` to an unknown id stays lenient (no throw), even
+    // with the set — mirrors substituteNodeOutputRefs' lenient whole-text surface.
+    expect(
+      substituteLoopPrevRefs(
+        'all=$LOOP_PREV.grrader.output',
+        undefined,
+        false,
+        undefined,
+        knownBodyIds
+      )
+    ).toBe('all=');
+
+    // Bash-escaped mode throws too (the typo would otherwise become an empty shell literal).
+    expect(() =>
+      substituteLoopPrevRefs(
+        'echo $LOOP_PREV.grrader.output.score',
+        undefined,
+        true,
+        undefined,
+        knownBodyIds
+      )
+    ).toThrow(OutputRefError);
+  });
+
+  it('EDGE F (#2142): applyLoopPrevToBodyNode threads the body-id set — typo throws, nested real id stays lenient', () => {
+    // The executor path builds the static body-id set (transitive across nested groups)
+    // and threads it through applyLoopPrevToBodyNode. Simulate iteration 1 (no prior
+    // outputs). Outer body = { review }; nested inner group `refine` has body node `polish`.
+    const knownBodyIds = new Set(['review', 'refine', 'polish']);
+
+    // A typo in a body prompt fails loudly.
+    expect(() =>
+      applyLoopPrevToBodyNode(
+        {
+          id: 'review',
+          prompt: 'act on $LOOP_PREV.reviw.output.verdict',
+          depends_on: [],
+        } as DagNode,
+        undefined,
+        '',
+        undefined,
+        knownBodyIds
+      )
+    ).toThrow(OutputRefError);
+
+    // A nested loop_group whose inner body references a REAL inner id (`polish`) resolves to
+    // '' at the outer granularity — no false-positive throw, because `polish` is in the set.
+    const nestedGroup = applyLoopPrevToBodyNode(
+      {
+        id: 'refine',
+        loop_group: {
+          until: 'DONE',
+          max_iterations: 2,
+          nodes: [
+            { id: 'polish', prompt: 'refine on $LOOP_PREV.polish.output.draft', depends_on: [] },
+          ],
+        },
+        depends_on: [],
+      } as DagNode,
+      undefined,
+      '',
+      undefined,
+      knownBodyIds
+    );
+    if (!('loop_group' in nestedGroup) || nestedGroup.loop_group === undefined)
+      throw new Error('expected loop_group node');
+    const polishNode = nestedGroup.loop_group.nodes[0];
+    expect('prompt' in polishNode && polishNode.prompt).toBe('refine on ');
+
+    // But a typo INSIDE the nested body (id in no body node) still throws through the recursion.
+    expect(() =>
+      applyLoopPrevToBodyNode(
+        {
+          id: 'refine',
+          loop_group: {
+            until: 'DONE',
+            max_iterations: 2,
+            nodes: [
+              { id: 'polish', prompt: 'refine on $LOOP_PREV.reviw.output.verdict', depends_on: [] },
+            ],
+          },
+          depends_on: [],
+        } as DagNode,
+        undefined,
+        '',
+        undefined,
+        knownBodyIds
+      )
+    ).toThrow(OutputRefError);
   });
 
   it('EDGE H: applyLoopPrevToBodyNode uses shell escaping only for shell-bound fields (unit)', () => {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -681,6 +681,29 @@ export function substituteNodeOutputRefs(
 }
 
 /**
+ * Collect the static ids of every node in a loop_group body, recursing into nested
+ * loop_group bodies. This is the *typo detector* for `$LOOP_PREV.<id>.output.<field>`
+ * refs: an id that matches no node anywhere in the (possibly nested) body is a genuine
+ * typo, distinct from a real body id that merely has no prior-iteration output yet.
+ *
+ * The transitive set (not just the outer group's direct ids) is deliberate: nested
+ * loop_group bodies reuse the OUTER loop's prior-iteration snapshot, so a ref inside a
+ * nested body may legitimately name an inner-group node id (which resolves to '' at the
+ * outer granularity — see {@link applyLoopPrevToBodyNode}). Including descendants keeps
+ * such real-but-empty refs lenient while still catching ids that exist nowhere.
+ */
+function collectLoopBodyNodeIds(
+  nodes: readonly DagNode[],
+  into: Set<string> = new Set<string>()
+): Set<string> {
+  for (const n of nodes) {
+    into.add(n.id);
+    if (isLoopGroupNode(n)) collectLoopBodyNodeIds(n.loop_group.nodes, into);
+  }
+  return into;
+}
+
+/**
  * Resolve `$LOOP_PREV.<nodeId>.output` and `$LOOP_PREV.<nodeId>.output.<field>` references
  * against a loop_group body's *prior-iteration* node outputs.
  *
@@ -695,12 +718,21 @@ export function substituteNodeOutputRefs(
  * semantics (declared-schema typo / schemaless non-JSON / missing key → throws
  * `OutputRefError`, propagating to the consuming node's failure). The only value that
  * resolves to empty is an author-declared-optional field — or any ref on iteration 1.
+ *
+ * `knownBodyIds` (the static id set of the enclosing loop_group body, via
+ * {@link collectLoopBodyNodeIds}) turns a `.field` ref to a genuinely-unknown id into a
+ * loud `OutputRefError('unknown-node')` instead of a silent '' — the loop_group analog of
+ * the same fix at the `$node.output.field` seam (#2135/#2142). Only `.field`-form refs to
+ * an id absent from this set throw; a KNOWN id with no prior output (iteration 1 / skipped)
+ * and the whole-text `$LOOP_PREV.<id>.output` form both stay lenient (''). When
+ * `knownBodyIds` is undefined (raw callers with no static set) the seam stays fully lenient.
  */
 export function substituteLoopPrevRefs(
   prompt: string,
   loopPrevOutputs: Map<string, NodeOutput> | undefined,
   escapedForBash = false,
-  outputFileDir?: string
+  outputFileDir?: string,
+  knownBodyIds?: ReadonlySet<string>
 ): string {
   // Fast path: no refs to resolve. When refs ARE present but the map is empty/undefined
   // (iteration 1 — no prior iteration), we still run the replace so each ref resolves to
@@ -713,17 +745,26 @@ export function substituteLoopPrevRefs(
     (match, nodeId: string, field: string | undefined) => {
       const nodeOutput = loopPrevOutputs?.get(nodeId);
       if (!nodeOutput || nodeOutput.state === 'skipped' || nodeOutput.state === 'pending') {
-        // No prior-iteration output for this body node (iteration 1, or the node was
+        // A `.field` ref to an id that matches NO body node anywhere in the enclosing
+        // loop_group (a typo the loader can't see — it never scans `$LOOP_PREV.*` refs)
+        // fails the consuming node loudly, mirroring substituteNodeOutputRefs /
+        // resolveOutputRef. The static id set is required to make this call: the runtime
+        // `loopPrevOutputs` map is empty on iteration 1, so it alone cannot tell a typo
+        // from a legitimate first-pass absence.
+        if (field && knownBodyIds && !knownBodyIds.has(nodeId)) {
+          throw new OutputRefError(
+            nodeId,
+            field,
+            'unknown-node',
+            similarNodeIds(nodeId, knownBodyIds)
+          );
+        }
+        // No prior-iteration output for this KNOWN body node (iteration 1, or the node was
         // skipped / hasn't settled last iteration). Resolve to empty rather than
         // throwing — the author opted into a cross-iteration ref, and absence on the
-        // first pass (or after a skipped node) is expected.
-        //
-        // NOTE: unlike substituteNodeOutputRefs / resolveOutputRef, this seam does NOT
-        // yet fail loudly on a `.field` ref to a genuinely-unknown body node id (a typo
-        // that matches no body node on ANY iteration). Distinguishing that from the
-        // legitimate iteration-1 absence needs the static body-node-id set threaded in
-        // (complicated by nested loop_groups reusing the outer snapshot), which is out
-        // of scope for #2135's `$node.output.field` fix — tracked as #2142.
+        // first pass (or after a skipped node) is expected. The whole-text
+        // `$LOOP_PREV.<id>.output` form also stays lenient here, even for an unknown id,
+        // matching the long-documented lenient whole-text surface.
         getLog().debug({ nodeId, match }, 'loop_group_prev_ref_no_prior_output');
         return escapedForBash ? "''" : '';
       }
@@ -2834,6 +2875,13 @@ async function executeLoopGroupNode(
   // prefix composes across nested loop_groups: `<enclosing>.<groupId>.<bodyNodeId>`.
   const bodyStepNamePrefix = `${stepName}.`;
 
+  // Static (iteration-invariant) id set of every node in this group's body, including
+  // nested loop_group descendants — the typo detector for `$LOOP_PREV.<id>.output.<field>`
+  // refs (#2142). A `.field` ref to an id absent from this set fails the consuming node
+  // loudly; a known id with no prior-iteration output stays lenient (''). Computed once
+  // (the body shape is static) and threaded into every applyLoopPrevToBodyNode call.
+  const knownBodyIds = collectLoopBodyNodeIds(group.nodes);
+
   // Detect interactive loop resume (mirrors executeLoopNode).
   const rawApproval = workflowRun.metadata?.approval;
   const loopGateMeta = isApprovalContext(rawApproval) ? rawApproval : undefined;
@@ -2932,7 +2980,7 @@ async function executeLoopGroupNode(
     const prevSnapshot = loopPrevOutputs;
     const userInputForIter = isLoopResume && i === startIteration ? loopUserInput : '';
     const iterBodyNodes = group.nodes.map(n =>
-      applyLoopPrevToBodyNode(n, prevSnapshot, userInputForIter, logDir)
+      applyLoopPrevToBodyNode(n, prevSnapshot, userInputForIter, logDir, knownBodyIds)
     );
     // Re-layer from the (possibly substituted) body nodes — runLayers walks ctx.layers,
     // not ctx.nodes, so the layers must reference the substituted nodes to take effect.
@@ -3316,12 +3364,19 @@ async function executeLoopGroupNode(
  * Only prompt-bearing fields are substituted in v1; `when:` conditions are NOT (they use
  * evaluateCondition, which does not call substituteLoopPrevRefs). Body authors who need
  * cross-iteration gating should branch on prompt content, not `when:`.
+ *
+ * `knownBodyIds` is the enclosing loop_group's static body-id set (via
+ * {@link collectLoopBodyNodeIds}); it is threaded UNCHANGED into every
+ * substituteLoopPrevRefs call and into the nested-loop_group recursion so `$LOOP_PREV.*`
+ * refs are validated against the OUTER loop's body ids (whose snapshot they resolve
+ * against). Omitted by raw callers, which then skip the typo check.
  */
 export function applyLoopPrevToBodyNode(
   node: DagNode,
   loopPrevOutputs: Map<string, NodeOutput> | undefined,
   loopUserInput: string,
-  outputFileDir?: string
+  outputFileDir?: string,
+  knownBodyIds?: ReadonlySet<string>
 ): DagNode {
   // Substitute $LOOP_USER_INPUT (user free-text) and $LOOP_PREV.* refs.
   // Resolve $LOOP_PREV FIRST, then splice $LOOP_USER_INPUT — so user input containing a
@@ -3334,7 +3389,13 @@ export function applyLoopPrevToBodyNode(
   // cancel reasons are display text, mirroring their normal-path substitution) use the
   // raw values.
   const sub = (s: string, escapedForBash = false): string => {
-    const prevResolved = substituteLoopPrevRefs(s, loopPrevOutputs, escapedForBash, outputFileDir);
+    const prevResolved = substituteLoopPrevRefs(
+      s,
+      loopPrevOutputs,
+      escapedForBash,
+      outputFileDir,
+      knownBodyIds
+    );
     const userInputForField = escapedForBash ? shellQuote(loopUserInput) : loopUserInput;
     return prevResolved.replace(/\$LOOP_USER_INPUT/g, userInputForField);
   };
@@ -3356,7 +3417,10 @@ export function applyLoopPrevToBodyNode(
     // Nested loop_group: recurse into the body (each body node gets $LOOP_PREV resolved
     // against the OUTER loop's prior-iteration snapshot; inner-loop refs resolve at the
     // inner loop's own iteration granularity). The inner group's until_bash is likewise
-    // shell-bound and only ever substituted here for OUTER-loop refs.
+    // shell-bound and only ever substituted here for OUTER-loop refs. `knownBodyIds` is
+    // the OUTER group's transitive body-id set (includes this nested group's own ids),
+    // reused as-is so an inner-body ref to a real node stays lenient while a true typo
+    // still throws.
     return {
       ...node,
       loop_group: {
@@ -3365,7 +3429,7 @@ export function applyLoopPrevToBodyNode(
           ? { until_bash: sub(node.loop_group.until_bash, true) }
           : {}),
         nodes: node.loop_group.nodes.map(n =>
-          applyLoopPrevToBodyNode(n, loopPrevOutputs, loopUserInput, outputFileDir)
+          applyLoopPrevToBodyNode(n, loopPrevOutputs, loopUserInput, outputFileDir, knownBodyIds)
         ),
       },
     };

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -719,20 +719,31 @@ function collectLoopBodyNodeIds(
  * `OutputRefError`, propagating to the consuming node's failure). The only value that
  * resolves to empty is an author-declared-optional field — or any ref on iteration 1.
  *
- * `knownBodyIds` (the static id set of the enclosing loop_group body, via
- * {@link collectLoopBodyNodeIds}) turns a `.field` ref to a genuinely-unknown id into a
- * loud `OutputRefError('unknown-node')` instead of a silent '' — the loop_group analog of
- * the same fix at the `$node.output.field` seam (#2135/#2142). Only `.field`-form refs to
- * an id absent from this set throw; a KNOWN id with no prior output (iteration 1 / skipped)
- * and the whole-text `$LOOP_PREV.<id>.output` form both stay lenient (''). When
- * `knownBodyIds` is undefined (raw callers with no static set) the seam stays fully lenient.
+ * Two static id sets from the enclosing loop_group (both via {@link collectLoopBodyNodeIds}
+ * / its immediate-ids counterpart) drive the absent-output branch. `knownBodyIds` is the
+ * TRANSITIVE set (this group's body plus every nested descendant); `directBodyIds` is only
+ * THIS group's immediate body ids. When output is absent, the id is classified:
+ *   - not in `knownBodyIds` → a typo that matches no body node anywhere. A `.field` ref
+ *     throws `OutputRefError('unknown-node')` (loud, with a did-you-mean) — the loop_group
+ *     analog of the same fix at the `$node.output.field` seam (#2135/#2142); a whole-text
+ *     `$LOOP_PREV.<id>.output` ref stays lenient ('').
+ *   - in `knownBodyIds` but not in `directBodyIds` → the id belongs to a NESTED loop_group,
+ *     not this group's own body. The literal token is left INTACT (`return match`) so the
+ *     inner loop_group resolves it against its OWN prior-iteration snapshot when it runs
+ *     (nested body nodes get a second substituteLoopPrevRefs pass — the outer pass must not
+ *     consume their tokens, or the inner loop could never see its own prior iteration).
+ *   - in `directBodyIds` with no prior output → legitimate iteration-1 / skipped absence → ''.
+ *
+ * When `knownBodyIds` is undefined (raw callers with no static set) the seam stays fully
+ * lenient — every absent ref resolves to '', preserving the pre-#2142 behavior.
  */
 export function substituteLoopPrevRefs(
   prompt: string,
   loopPrevOutputs: Map<string, NodeOutput> | undefined,
   escapedForBash = false,
   outputFileDir?: string,
-  knownBodyIds?: ReadonlySet<string>
+  knownBodyIds?: ReadonlySet<string>,
+  directBodyIds?: ReadonlySet<string>
 ): string {
   // Fast path: no refs to resolve. When refs ARE present but the map is empty/undefined
   // (iteration 1 — no prior iteration), we still run the replace so each ref resolves to
@@ -745,26 +756,36 @@ export function substituteLoopPrevRefs(
     (match, nodeId: string, field: string | undefined) => {
       const nodeOutput = loopPrevOutputs?.get(nodeId);
       if (!nodeOutput || nodeOutput.state === 'skipped' || nodeOutput.state === 'pending') {
-        // A `.field` ref to an id that matches NO body node anywhere in the enclosing
-        // loop_group (a typo the loader can't see — it never scans `$LOOP_PREV.*` refs)
-        // fails the consuming node loudly, mirroring substituteNodeOutputRefs /
-        // resolveOutputRef. The static id set is required to make this call: the runtime
-        // `loopPrevOutputs` map is empty on iteration 1, so it alone cannot tell a typo
-        // from a legitimate first-pass absence.
-        if (field && knownBodyIds && !knownBodyIds.has(nodeId)) {
-          throw new OutputRefError(
-            nodeId,
-            field,
-            'unknown-node',
-            similarNodeIds(nodeId, knownBodyIds)
-          );
+        if (knownBodyIds) {
+          if (!knownBodyIds.has(nodeId)) {
+            // Typo: id matches NO body node anywhere in the enclosing loop_group (a typo
+            // the loader can't see — it never scans `$LOOP_PREV.*` refs). A `.field` ref
+            // fails the consuming node loudly, mirroring substituteNodeOutputRefs /
+            // resolveOutputRef; a whole-text ref stays lenient ('' below). The static set
+            // is required: the runtime `loopPrevOutputs` map is empty on iteration 1, so it
+            // alone cannot tell a typo from a legitimate first-pass absence.
+            if (field) {
+              throw new OutputRefError(
+                nodeId,
+                field,
+                'unknown-node',
+                similarNodeIds(nodeId, knownBodyIds)
+              );
+            }
+          } else if (directBodyIds && !directBodyIds.has(nodeId)) {
+            // Known id owned by a NESTED loop_group, not this group's own body. Leave the
+            // literal token intact so the inner loop_group resolves it against its OWN
+            // prior-iteration snapshot when it executes — the outer pass must not consume
+            // it, or the inner loop could never reference its own previous iteration.
+            return match;
+          }
+          // else: known + direct id with no prior output → legitimate iteration-1 / skipped
+          // absence → lenient '' below.
         }
-        // No prior-iteration output for this KNOWN body node (iteration 1, or the node was
+        // No prior-iteration output for this body node (iteration 1, or the node was
         // skipped / hasn't settled last iteration). Resolve to empty rather than
         // throwing — the author opted into a cross-iteration ref, and absence on the
-        // first pass (or after a skipped node) is expected. The whole-text
-        // `$LOOP_PREV.<id>.output` form also stays lenient here, even for an unknown id,
-        // matching the long-documented lenient whole-text surface.
+        // first pass (or after a skipped node) is expected.
         getLog().debug({ nodeId, match }, 'loop_group_prev_ref_no_prior_output');
         return escapedForBash ? "''" : '';
       }
@@ -2875,12 +2896,14 @@ async function executeLoopGroupNode(
   // prefix composes across nested loop_groups: `<enclosing>.<groupId>.<bodyNodeId>`.
   const bodyStepNamePrefix = `${stepName}.`;
 
-  // Static (iteration-invariant) id set of every node in this group's body, including
-  // nested loop_group descendants — the typo detector for `$LOOP_PREV.<id>.output.<field>`
-  // refs (#2142). A `.field` ref to an id absent from this set fails the consuming node
-  // loudly; a known id with no prior-iteration output stays lenient (''). Computed once
-  // (the body shape is static) and threaded into every applyLoopPrevToBodyNode call.
+  // Static (iteration-invariant) id sets for `$LOOP_PREV.<id>.output[.field]` resolution
+  // (#2142). `knownBodyIds` is TRANSITIVE (this group's body + every nested descendant) —
+  // an id absent from it is a typo (`.field` ref → loud failure). `directBodyIds` is only
+  // THIS group's immediate ids — an id in knownBodyIds but not directBodyIds belongs to a
+  // nested group and its token is preserved for that inner group's own pass. Computed once
+  // (body shape is static) and threaded into every applyLoopPrevToBodyNode call.
   const knownBodyIds = collectLoopBodyNodeIds(group.nodes);
+  const directBodyIds = new Set(group.nodes.map(n => n.id));
 
   // Detect interactive loop resume (mirrors executeLoopNode).
   const rawApproval = workflowRun.metadata?.approval;
@@ -2980,7 +3003,14 @@ async function executeLoopGroupNode(
     const prevSnapshot = loopPrevOutputs;
     const userInputForIter = isLoopResume && i === startIteration ? loopUserInput : '';
     const iterBodyNodes = group.nodes.map(n =>
-      applyLoopPrevToBodyNode(n, prevSnapshot, userInputForIter, logDir, knownBodyIds)
+      applyLoopPrevToBodyNode(
+        n,
+        prevSnapshot,
+        userInputForIter,
+        logDir,
+        knownBodyIds,
+        directBodyIds
+      )
     );
     // Re-layer from the (possibly substituted) body nodes — runLayers walks ctx.layers,
     // not ctx.nodes, so the layers must reference the substituted nodes to take effect.
@@ -3365,18 +3395,21 @@ async function executeLoopGroupNode(
  * evaluateCondition, which does not call substituteLoopPrevRefs). Body authors who need
  * cross-iteration gating should branch on prompt content, not `when:`.
  *
- * `knownBodyIds` is the enclosing loop_group's static body-id set (via
- * {@link collectLoopBodyNodeIds}); it is threaded UNCHANGED into every
- * substituteLoopPrevRefs call and into the nested-loop_group recursion so `$LOOP_PREV.*`
- * refs are validated against the OUTER loop's body ids (whose snapshot they resolve
- * against). Omitted by raw callers, which then skip the typo check.
+ * `knownBodyIds` (transitive body-id set) and `directBodyIds` (this group's immediate body
+ * ids) are threaded UNCHANGED into every substituteLoopPrevRefs call AND into the
+ * nested-loop_group recursion — deliberately not recomputed for the inner group. This keeps
+ * `$LOOP_PREV.*` refs validated against the OUTER loop's snapshot (whose body they resolve
+ * against): a ref to an outer-direct id resolves now, a ref owned by a nested group is left
+ * intact for that inner group's own pass, and a ref to nothing is a typo. Both omitted by
+ * raw callers, which then skip the typo/nested classification entirely (fully lenient).
  */
 export function applyLoopPrevToBodyNode(
   node: DagNode,
   loopPrevOutputs: Map<string, NodeOutput> | undefined,
   loopUserInput: string,
   outputFileDir?: string,
-  knownBodyIds?: ReadonlySet<string>
+  knownBodyIds?: ReadonlySet<string>,
+  directBodyIds?: ReadonlySet<string>
 ): DagNode {
   // Substitute $LOOP_USER_INPUT (user free-text) and $LOOP_PREV.* refs.
   // Resolve $LOOP_PREV FIRST, then splice $LOOP_USER_INPUT — so user input containing a
@@ -3394,7 +3427,8 @@ export function applyLoopPrevToBodyNode(
       loopPrevOutputs,
       escapedForBash,
       outputFileDir,
-      knownBodyIds
+      knownBodyIds,
+      directBodyIds
     );
     const userInputForField = escapedForBash ? shellQuote(loopUserInput) : loopUserInput;
     return prevResolved.replace(/\$LOOP_USER_INPUT/g, userInputForField);
@@ -3414,13 +3448,15 @@ export function applyLoopPrevToBodyNode(
     };
   }
   if (isLoopGroupNode(node)) {
-    // Nested loop_group: recurse into the body (each body node gets $LOOP_PREV resolved
-    // against the OUTER loop's prior-iteration snapshot; inner-loop refs resolve at the
-    // inner loop's own iteration granularity). The inner group's until_bash is likewise
-    // shell-bound and only ever substituted here for OUTER-loop refs. `knownBodyIds` is
-    // the OUTER group's transitive body-id set (includes this nested group's own ids),
-    // reused as-is so an inner-body ref to a real node stays lenient while a true typo
-    // still throws.
+    // Nested loop_group: recurse into the body. `knownBodyIds`/`directBodyIds` are the OUTER
+    // group's sets, threaded UNCHANGED — so during this OUTER pass a ref to an inner-owned id
+    // (in knownBodyIds but not directBodyIds) is left intact (return match) for the inner
+    // group's own pass, while a ref to an OUTER-direct id resolves here at the outer
+    // granularity and a true typo still throws. The inner group's own executeLoopGroupNode
+    // computes fresh sets when it runs, so inner-owned refs resolve at the inner iteration
+    // granularity. The inner group's until_bash is shell-bound and only ever substituted
+    // here for OUTER-loop refs (a nested group's own until_bash cannot reference its own body
+    // via $LOOP_PREV — executeLoopGroupNode does not re-run this pass on the group's until_bash).
     return {
       ...node,
       loop_group: {
@@ -3429,7 +3465,14 @@ export function applyLoopPrevToBodyNode(
           ? { until_bash: sub(node.loop_group.until_bash, true) }
           : {}),
         nodes: node.loop_group.nodes.map(n =>
-          applyLoopPrevToBodyNode(n, loopPrevOutputs, loopUserInput, outputFileDir, knownBodyIds)
+          applyLoopPrevToBodyNode(
+            n,
+            loopPrevOutputs,
+            loopUserInput,
+            outputFileDir,
+            knownBodyIds,
+            directBodyIds
+          )
         ),
       },
     };


### PR DESCRIPTION
## Summary

- **Problem:** `$LOOP_PREV.<node>.output.<field>` in a loop_group body resolved a reference to a **non-existent** body-node id to `''` with only a debug log — a typo poisoned the prompt/bash/script silently. This is the loop_group analog of the `$node.output.field` gap closed by #2135 (PR #2143), which explicitly deferred this seam. A follow-up review of the first pass also surfaced a **pre-existing** correctness bug in the same seam (see below).
- **Why it matters:** #2135 made unknown-node `.field` refs throw at the two primary seams (`substituteNodeOutputRefs`, the `when:` condition-evaluator), but `substituteLoopPrevRefs` was left lenient: telling a **typo** (matches no body node → fail loud) from **legitimate iteration-1 absence** (`''`) needs the static body-node-id set, which the runtime prior-iteration map (empty on iteration 1) cannot supply. The loader never scans `$LOOP_PREV.*` refs, so there was no backstop.
- **What changed:** Thread **two** static id sets of the enclosing loop_group into `substituteLoopPrevRefs`: `knownBodyIds` (TRANSITIVE — this group's body plus every nested descendant) and `directBodyIds` (this group's immediate ids only). In the absent-output branch:
  - id ∉ `knownBodyIds` → typo → a `.field` ref throws `OutputRefError('unknown-node')` with a did-you-mean (reusing `output-ref.ts`'s helpers), failing the consuming node; whole-text `$LOOP_PREV.<id>.output` stays lenient (`''`).
  - id ∈ `knownBodyIds` but ∉ `directBodyIds` → owned by a **nested** loop_group → the literal token is left **intact** so the inner loop_group resolves it against its OWN prior-iteration snapshot when it runs.
  - id ∈ `directBodyIds` with no prior output → legitimate iteration-1 / skipped absence → `''`.
- **What did NOT change (scope boundary):** Whole-text `$LOOP_PREV.<id>.output` refs stay lenient (`''`) for unknown ids. Raw callers of `substituteLoopPrevRefs` that pass no id sets stay fully lenient (backward compatible). No loader-level static validation of `$LOOP_PREV.*` refs is added (larger scope — the runtime backstop is the issue's proposal).

## Second-pass fix (CodeRabbit Critical)

The first commit used only the transitive `knownBodyIds`, which correctly caught typos but **locked in a pre-existing bug**: the OUTER loop's substitution pass eagerly resolved a nested-inner-body `$LOOP_PREV` ref to `''` before the inner loop_group ever ran, permanently destroying the token — so an inner loop could never reference its own prior iteration, contradicting the documented intent ("inner-loop refs resolve at the inner loop's own iteration granularity"). The second commit adds `directBodyIds` and the three-way decision table above so nested-owned tokens **survive** the outer pass and resolve at the inner loop's own granularity. An end-to-end test now proves a nested inner loop_group sees its own iteration-1 output on iteration 2.

## UX Journey

### Before

```
Author writes a typo:                        prompt: "act on $LOOP_PREV.grrader.output.score"
  substituteLoopPrevRefs → !nodeOutput  ──▶   substitutes '' (debug log only) → silently wrong

Nested inner loop references its own prior:   inner body prompt: "prev=[$LOOP_PREV.w.output]"
  OUTER pass resolves it (w not in outer map)──▶ '' — token DESTROYED before inner loop runs
  inner iteration 2 prompt                  ──▶ "prev=[]" (own prior iteration never visible)
```

### After

```
Typo (id in no body node):                   *throws OutputRefError('unknown-node')* + did-you-mean
Direct body id, no prior output (iter 1):    '' (legitimate absence, unchanged)
Whole-text $LOOP_PREV.<id>.output:           '' (lenient, unchanged)

Nested inner loop references its own prior:   inner body prompt: "prev=[$LOOP_PREV.w.output]"
  OUTER pass: w ∈ known, ∉ direct         ──▶ *token LEFT INTACT* for the inner loop's own pass
  inner loop runs (fresh sets)            ──▶ iter 1: "prev=[]"   iter 2: "prev=[MARK1]"  ✓
```

## Architecture Diagram

### Before (first commit)

```
executeLoopGroupNode ── knownBodyIds = collectLoopBodyNodeIds(group.nodes)  (transitive)
        │  applyLoopPrevToBodyNode(knownBodyIds)  → threaded unchanged into nested recursion
        ▼
substituteLoopPrevRefs(knownBodyIds)
   id ∉ known → typo → throw (.field) / '' (whole-text)
   id ∈ known, no output → ''       ← nested-owned refs collapse to '' here (bug locked in)
```

### After (this PR)

```
executeLoopGroupNode ── knownBodyIds = collectLoopBodyNodeIds(group.nodes)   (transitive) [+]
                     ── directBodyIds = new Set(group.nodes.map(n => n.id))   (immediate)  [+]
        │  applyLoopPrevToBodyNode(knownBodyIds, directBodyIds) → both threaded unchanged
        ▼                                                          into nested recursion
substituteLoopPrevRefs(knownBodyIds, directBodyIds) [~]
   id ∉ known                    → typo → throw (.field) / '' (whole-text)
   id ∈ known, ∉ direct          → *return match* (nested-owned; inner loop resolves it)
   id ∈ direct, no output        → '' (legitimate iteration-1 / skipped absence)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| executeLoopGroupNode | collectLoopBodyNodeIds | **new** | transitive `knownBodyIds` (once per group) |
| executeLoopGroupNode | `directBodyIds` set | **new** | immediate body ids (once per group) |
| executeLoopGroupNode | applyLoopPrevToBodyNode | **modified** | passes both sets |
| applyLoopPrevToBodyNode | substituteLoopPrevRefs | **modified** | forwards both sets |
| applyLoopPrevToBodyNode | applyLoopPrevToBodyNode (nested loop_group) | **modified** | forwards both sets UNCHANGED |
| substituteLoopPrevRefs | output-ref.ts (`OutputRefError`, `similarNodeIds`) | **new** | throws for unknown-node `.field` refs, with did-you-mean |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `workflows`
- Module: `workflows:executor`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes #2142
- Related #2135 (the sibling `$node.output.field` fix this completes)
- Related #2143 (the PR that deferred this seam with a scope-note)

## Validation Evidence (required)

```bash
bun run validate
```

- Evidence provided: `bun run validate` green from the worktree root (exit 0). All generated-bundle checks pass; type-check clean across all 10 packages; lint (`--max-warnings 0`) clean; format:check clean; all per-package test batches report `0 fail`. Targeted: `dag-executor.test.ts` 398 pass — the `$LOOP_PREV` unit tests plus a new end-to-end nested-loop test.
- Skipped: none.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No**

## Compatibility / Migration

- Backward compatible? **Yes** — a workflow that previously relied on `''` for an unknown-id `.field` ref was already silently broken; this converts hidden wrongness into a visible failure (fail-fast). Nested-loop `$LOOP_PREV` refs that previously collapsed to `''` now resolve correctly at the inner loop's granularity — a bug fix, not a breaking change. Whole-text behavior is unchanged; raw callers without id sets are unaffected.
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

- Verified scenarios (unit tests): `.field` ref to an id in no body node throws `OutputRefError('unknown-node')` with a did-you-mean; a direct body id with no prior output (iteration 1) → `''`; a nested-owned id's token is **preserved** by the outer pass (both `.field` and whole-text forms); a nested body's ref to an outer-direct id resolves at the outer granularity; whole-text unknown id stays `''`; bash-escaped typo throws; raw caller with no sets stays fully lenient.
- Edge cases checked (end-to-end): a nested inner loop_group referencing its OWN sibling's prior iteration (`$LOOP_PREV.w.output`) sees `''` on inner iteration 1 and the iteration-1 marker on inner iteration 2 — proving the token survives the outer pass and resolves at the inner loop's granularity.
- What was not verified: a nested loop_group's **own** `until_bash` referencing its own inner body id via `$LOOP_PREV` — this was unsupported before this PR (it resolved to `''`) and remains unsupported (`executeLoopGroupNode` does not re-run the `$LOOP_PREV` pass on a group's own `until_bash`; use the `LOOP_PREV_OUTPUT` env var there). Noted in a code comment at the nested-recursion seam.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: workflow execution — any `loop_group` body node whose prompt/bash/script/approval/cancel/command text contains a `$LOOP_PREV.<id>.output[.field]` reference.
- Potential unintended effects: a loop_group with a pre-existing unknown-id `.field` ref (previously silently `''`) will now fail the node — the intended fail-fast conversion. Nested-loop refs that previously produced `''` now produce the correct prior-iteration value.
- Guardrails/monitoring: `OutputRefError` propagates through the existing per-node catch → `node_failed` event + user-facing message; unit + e2e tests lock the behavior.

## Rollback Plan (required)

- Fast rollback: revert this PR (isolated to `@archon/workflows` `dag-executor.ts`; no schema/config).
- Feature flags: none.
- Observable failure symptoms: a loop_group body node failing with an `OutputRefError('unknown-node')` where the author expected an empty substitution — indicates a real typo, not a regression.

## Risks and Mitigations

- Risk: a loop_group silently relying on `''` for an unknown-id `.field` ref starts failing.
  - Mitigation: it was already broken; the new error names the id + did-you-mean and is trivially fixable.
- Risk: the two-set classification mis-preserves or mis-resolves a nested ref.
  - Mitigation: `directBodyIds` is threaded unchanged so classification is stable across the recursion; unit tests cover typo / direct-absent / nested-preserve / nested-reads-outer, and an end-to-end test proves the inner loop resolves its own prior iteration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `$LOOP_PREV.<nodeId>.output` and `$LOOP_PREV.<nodeId>.output.<field>` validation in workflow loops, including typo detection.
  * Typo’d node IDs now raise a clearer error (with did-you-mean) instead of silently substituting empty values for field references.
  * Nested loop groups now correctly preserve `$LOOP_PREV` tokens so inner loops can resolve them against their own prior-iteration outputs.
  * Whole-text `$LOOP_PREV.<id>.output` remains lenient when prior outputs are missing; bash-escaped substitution now matches the same validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->