### PR TITLE
fix(providers): coalesce Pi text_delta chunks to stop fragmented streaming output

### DIFF
--- a/packages/providers/src/community/pi/event-bridge.test.ts
+++ b/packages/providers/src/community/pi/event-bridge.test.ts
@@ -820,3 +820,158 @@ describe('streaming tail completion', () => {
     expect((resultChunk as Record<string, unknown>)?.structuredOutput).toEqual({ partial: true });
   });
 });
+
+// ─── assistant-chunk coalescing (#1814) ──────────────────────────────────────
+
+describe('assistant chunk coalescing', () => {
+  const usage = { input: 1, output: 1, totalTokens: 2, cost: { total: 0 } };
+
+  function textDelta(delta: string): AgentSessionEvent {
+    return {
+      type: 'message_update',
+      message: { role: 'assistant' },
+      assistantMessageEvent: { type: 'text_delta', contentIndex: 0, delta, partial: {} },
+    } as unknown as AgentSessionEvent;
+  }
+
+  function textEnd(content: string): AgentSessionEvent {
+    return {
+      type: 'message_update',
+      message: { role: 'assistant' },
+      assistantMessageEvent: { type: 'text_end', contentIndex: 0, content, partial: {} },
+    } as unknown as AgentSessionEvent;
+  }
+
+  function toolStart(toolCallId: string, toolName: string): AgentSessionEvent {
+    return { type: 'tool_execution_start', toolCallId, toolName, args: {} } as AgentSessionEvent;
+  }
+
+  function toolEnd(toolCallId: string, toolName: string): AgentSessionEvent {
+    return {
+      type: 'tool_execution_end',
+      toolCallId,
+      toolName,
+      result: 'ok',
+      isError: false,
+    } as AgentSessionEvent;
+  }
+
+  function agentEnd(fullText: string): AgentSessionEvent {
+    return {
+      type: 'agent_end',
+      messages: [
+        {
+          role: 'assistant',
+          usage,
+          stopReason: 'stop',
+          content: [{ type: 'text', text: fullText }],
+        },
+      ],
+    } as unknown as AgentSessionEvent;
+  }
+
+  /** Mock session that replays `events` on prompt(), then resolves — unless
+   *  `rejectWith` is set, in which case prompt() throws after replaying. */
+  function makeSession(events: AgentSessionEvent[], rejectWith?: Error): AgentSession {
+    let listener: ((event: AgentSessionEvent) => void) | undefined;
+    return {
+      sessionId: 'session-coalesce',
+      subscribe: (fn: (event: AgentSessionEvent) => void) => {
+        listener = fn;
+        return () => {};
+      },
+      prompt: async () => {
+        for (const event of events) listener?.(event);
+        if (rejectWith) throw rejectWith;
+      },
+      abort: async () => {},
+      dispose: () => {},
+    } as unknown as AgentSession;
+  }
+
+  async function collect(session: AgentSession): Promise<MessageChunk[]> {
+    const chunks: MessageChunk[] = [];
+    for await (const chunk of bridgeSession(session, 'prompt')) chunks.push(chunk);
+    return chunks;
+  }
+
+  test('coalesces char-level deltas into a single assistant chunk', async () => {
+    // Regression for #1814: Pi streams token/char deltas. Before the fix each
+    // became its own chunk and the DAG executor joined them with "\n\n",
+    // yielding "Се\n\nгод\n\nня …". They must arrive as one block-level chunk.
+    const deltas = ['Се', 'год', 'ня ', '**пят', 'ница**'];
+    const full = deltas.join('');
+    const chunks = await collect(
+      makeSession([
+        { type: 'turn_start' } as AgentSessionEvent,
+        ...deltas.map(textDelta),
+        agentEnd(full),
+      ])
+    );
+
+    const assistantChunks = chunks.filter(c => c.type === 'assistant');
+    expect(assistantChunks).toHaveLength(1);
+    expect(assistantChunks[0].content).toBe(full);
+    expect(chunks[chunks.length - 1].type).toBe('result');
+  });
+
+  test('flushes buffered text before a tool call, preserving order', async () => {
+    const full = 'Let me read the file.Done.';
+    const chunks = await collect(
+      makeSession([
+        { type: 'turn_start' } as AgentSessionEvent,
+        textDelta('Let me '),
+        textDelta('read the file.'),
+        toolStart('call-1', 'read'),
+        toolEnd('call-1', 'read'),
+        textDelta('Done.'),
+        agentEnd(full),
+      ])
+    );
+
+    const types = chunks.map(c => c.type);
+    expect(types).toEqual(['assistant', 'tool', 'tool_result', 'assistant', 'result']);
+    const assistantChunks = chunks.filter(c => c.type === 'assistant');
+    expect(assistantChunks[0].content).toBe('Let me read the file.');
+    expect(assistantChunks[1].content).toBe('Done.');
+  });
+
+  test('flushes each completed text block at text_end', async () => {
+    const full = 'block one block two';
+    const chunks = await collect(
+      makeSession([
+        { type: 'turn_start' } as AgentSessionEvent,
+        textDelta('block '),
+        textDelta('one '),
+        textEnd('block one '),
+        textDelta('block two'),
+        agentEnd(full),
+      ])
+    );
+
+    const assistantChunks = chunks.filter(c => c.type === 'assistant');
+    expect(assistantChunks).toHaveLength(2);
+    expect(assistantChunks[0].content).toBe('block one ');
+    expect(assistantChunks[1].content).toBe('block two');
+  });
+
+  test('preserves partial buffered output when the stream errors', async () => {
+    const session = makeSession(
+      [{ type: 'turn_start' } as AgentSessionEvent, textDelta('partial answer before crash')],
+      new Error('stream exploded')
+    );
+
+    const chunks: MessageChunk[] = [];
+    let thrown: Error | undefined;
+    try {
+      for await (const chunk of bridgeSession(session, 'prompt')) chunks.push(chunk);
+    } catch (err) {
+      thrown = err as Error;
+    }
+
+    expect(thrown?.message).toBe('stream exploded');
+    const assistantChunks = chunks.filter(c => c.type === 'assistant');
+    expect(assistantChunks).toHaveLength(1);
+    expect(assistantChunks[0].content).toBe('partial answer before crash');
+  });
+});

--- a/packages/providers/src/community/pi/event-bridge.ts
+++ b/packages/providers/src/community/pi/event-bridge.ts
@@ -299,7 +299,31 @@ export async function* bridgeSession(
   uiBridge?: BridgeNotifier
 ): AsyncGenerator<MessageChunk> {
   const queue = new AsyncQueue<BridgeQueueItem>();
+
+  // ── Assistant-chunk coalescing (#1814) ─────────────────────────────────
+  // Pi streams assistant text as many tiny `text_delta` events (often a few
+  // characters each). Downstream, the DAG executor treats every `assistant`
+  // chunk as a discrete message block — batch mode joins them with "\n\n",
+  // stream mode sends each one separately. That is correct for Claude/Codex,
+  // which each yield one chunk per *complete* text block, but it shatters Pi's
+  // char-level deltas into fragmented "С\n\nег\n\nод\n\nня" output. We coalesce
+  // consecutive deltas into one block-level chunk and flush it only at natural
+  // boundaries (turn start, text-block end, before any non-assistant chunk, and
+  // at end-of-stream/error), so Pi matches the one-chunk-per-block contract the
+  // executor already expects. `currentTurnText`/`assistantBuffer` still
+  // accumulate every delta, so streaming-tail detection and structured-output
+  // buffering are unaffected.
+  let pendingAssistant = '';
+  const flushPendingAssistant = (): void => {
+    if (pendingAssistant.length === 0) return;
+    queue.push({ kind: 'chunk', chunk: { type: 'assistant', content: pendingAssistant } });
+    pendingAssistant = '';
+  };
+
   uiBridge?.setEmitter(chunk => {
+    // A notify() chunk (flush:true) must surface immediately and in order, so
+    // drain any buffered assistant text ahead of it.
+    flushPendingAssistant();
     queue.push({ kind: 'chunk', chunk });
   });
   // Best-effort structured-output buffer. Only accumulates when the caller
@@ -320,6 +344,8 @@ export async function* bridgeSession(
   const unsubscribe = session.subscribe((event: AgentSessionEvent) => {
     try {
       if (event.type === 'turn_start') {
+        // A new turn begins: the previous turn's text block is complete.
+        flushPendingAssistant();
         currentTurnText = '';
       }
       if (event.type === 'agent_end') {
@@ -327,12 +353,23 @@ export async function* bridgeSession(
       }
       for (const chunk of mapPiEvent(event)) {
         if (chunk.type === 'assistant') {
+          // Coalesce char-level deltas; hold them until a boundary flush so the
+          // executor receives one block-level chunk instead of dozens of tiny
+          // ones. The accumulators below still observe every delta.
           currentTurnText += chunk.content;
+          if (wantsStructured) assistantBuffer += chunk.content;
+          pendingAssistant += chunk.content;
+        } else {
+          // Any non-assistant chunk (tool, tool_result, system, result) is a
+          // boundary: drain buffered text first so ordering is preserved.
+          flushPendingAssistant();
+          queue.push({ kind: 'chunk', chunk });
         }
-        if (wantsStructured && chunk.type === 'assistant') {
-          assistantBuffer += chunk.content;
-        }
-        queue.push({ kind: 'chunk', chunk });
+      }
+      // A completed text block flushes promptly so stream-mode consumers see
+      // each block as it finishes rather than waiting for the terminal result.
+      if (event.type === 'message_update' && event.assistantMessageEvent.type === 'text_end') {
+        flushPendingAssistant();
       }
     } catch (err) {
       queue.push({ kind: 'error', error: err as Error });
@@ -366,8 +403,25 @@ export async function* bridgeSession(
 
   try {
     for await (const item of queue) {
-      if (item.kind === 'done') return;
-      if (item.kind === 'error') throw item.error;
+      if (item.kind === 'done') {
+        // Defensive: agent_end normally flushes buffered text via its result
+        // chunk before `done` arrives, but surface any stranded text rather
+        // than dropping it.
+        if (pendingAssistant.length > 0) {
+          yield { type: 'assistant', content: pendingAssistant };
+          pendingAssistant = '';
+        }
+        return;
+      }
+      if (item.kind === 'error') {
+        // Preserve partial output: emit whatever text was buffered before the
+        // failure so it still reaches the user instead of being discarded.
+        if (pendingAssistant.length > 0) {
+          yield { type: 'assistant', content: pendingAssistant };
+          pendingAssistant = '';
+        }
+        throw item.error;
+      }
       // Annotate the terminal result chunk with Pi's session UUID so Archon's
       // orchestrator can pass it back as `resumeSessionId` on the next call.
       // Pi's session.sessionId is always a UUID (even for in-memory); we emit

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -715,7 +715,7 @@ describe('PiProvider', () => {
     expect(mockSetRuntimeApiKey).toHaveBeenCalledWith('anthropic', 'sk-ant-oat01-proc');
   });
 
-  test('yields assistant chunks from text_delta events', async () => {
+  test('coalesces text_delta events into a single assistant chunk (#1814)', async () => {
     process.env.GEMINI_API_KEY = 'sk-test';
     resetScript([
       {
@@ -759,9 +759,11 @@ describe('PiProvider', () => {
       })
     );
     expect(error).toBeUndefined();
+    // Consecutive text_delta events are coalesced into one block-level chunk
+    // (flushed before the terminal result) so downstream consumers don't see
+    // fragmented "Hello\n\n world" output — see #1814.
     expect(chunks).toEqual([
-      { type: 'assistant', content: 'Hello' },
-      { type: 'assistant', content: ' world' },
+      { type: 'assistant', content: 'Hello world' },
       expect.objectContaining({ type: 'result', stopReason: 'stop' }),
     ]);
   });


### PR DESCRIPTION
## Summary

- **Problem**: Workflows run with the Pi community provider produced fragmented assistant text — single characters/tokens separated by extra newlines (`Се\n\nгод\n\nня` instead of `Сегодня`). The fragments were stored that way in the DB and rendered verbatim.
- **Why it matters**: Pi is a first-class community provider (soon the main runner). Fragmented output makes any Pi workflow unreadable in the CLI, DB, and every downstream consumer — a 100%-reproduction, no-workaround bug.
- **What changed**: The Pi event-bridge (`bridgeSession`) now **coalesces** consecutive `text_delta` chunks into one block-level `assistant` chunk, flushed only at natural boundaries (turn start, text-block end, before any non-assistant chunk, end-of-stream, and on error). This makes Pi honor the same one-chunk-per-block contract Claude and Codex already satisfy.
- **What did NOT change (scope boundary)**: `mapPiEvent` stays a pure per-event mapper; the DAG executor is untouched (no shared-executor blast radius); `currentTurnText`/`assistantBuffer` still observe every delta, so streaming-tail detection and structured-output buffering are unaffected; Claude/Codex behavior is byte-for-byte identical.

## Root Cause

Pi streams assistant text as many tiny `text_delta` events (often a few characters). `mapPiEvent` mapped each to its own `{ type: 'assistant', content: delta }` chunk. The DAG executor treats every `assistant` chunk as a discrete message block — in **batch mode** (CLI) it joins them with `"\n\n"` (`batchMessages.join('\n\n')`), in **stream mode** it sends each separately. That is correct for Claude (yields one chunk per *complete* text block, `provider.ts:818-820`) and Codex (one chunk per `agent_message` item), but it shatters Pi's char-level deltas.

Fixing at the executor (per PR #1817) would (a) touch the shared path for all providers, and (b) only *mitigate* — a threshold buffer still emits multiple `batchMessages` entries per logical block, so `"\n\n"` still lands mid-block at the flush boundary. Coalescing to one chunk **per block** at the Pi source is the only place that fully eliminates intra-block `"\n\n"`, and it also fixes direct chat (same bridge funnel), not just workflows.

## UX Journey

### Before

```
  User            Archon (CLI / batch)          Pi SDK
  ────            ────────────────────          ──────
  runs workflow -> starts session
                   assistant chunk  <----------- text_delta "Се"
                   assistant chunk  <----------- text_delta "год"
                   assistant chunk  <----------- text_delta "ня"
                   batchMessages.join("\n\n")
  sees broken   <- "Се\n\nгод\n\nня"
```

### After

```
  User            Archon (CLI / batch)          Pi SDK
  ────            ────────────────────          ──────
  runs workflow -> starts session
                   [bridge coalesces deltas]  <- text_delta "Се","год","ня"
                   [flush at block/turn/result boundary]
                   one assistant chunk "Сегодня"
                   batchMessages = ["Сегодня"]  *no spurious \n\n*
  sees clean    <- "Сегодня"
```

## Architecture Diagram

### After

```
Pi SDK events -> mapPiEvent (unchanged, per-event) -> [~] bridgeSession
                                                        |  coalesce text_delta
                                                        |  flush on: turn_start,
                                                        |  text_end, non-assistant
                                                        |  chunk, done, error
                                                        v
                                              block-level assistant chunks
                                                        v
                              dag-executor / orchestrator (UNCHANGED)
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `mapPiEvent` | `bridgeSession` | unchanged | still emits per-delta assistant chunks |
| `bridgeSession` | consumer (executor/orchestrator) | **modified** | now emits coalesced, block-level assistant chunks |
| `dag-executor` | * | unchanged | no executor changes |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `providers` (`tests`)
- Module: `providers:community:pi:event-bridge`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi` (the `@archon/providers` package)

## Linked Issue

- Closes #1814
- Supersedes #1817 (held PR that buffered in the DAG executor; see Root Cause for why the provider-level fix is preferred)

## Validation Evidence (required)

```bash
bun run validate
# check:bundled / check:bundled-skill / check:bundled-schema / check:pi-vendor-map OK
# type-check: all 10 packages exit 0
# eslint --max-warnings 0: clean
# prettier --check: clean
# tests: all package suites pass
```

- Evidence provided: full `bun run validate` green from the worktree root; event-bridge suite 55 pass / 0 fail (4 new coalescing tests); Pi provider suite 89 pass / 0 fail (1 existing per-delta assertion updated to expect the coalesced chunk).
- Live smoke: see "Human Verification".

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — only changes the granularity of Pi's `assistant` chunk stream; content is identical, just coalesced.
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: `bun run validate` green; 4 new regression tests (multi-delta coalescing, flush-before-tool ordering, text_end block boundary, error-path partial flush); updated the one provider test that encoded the old per-delta behavior.
- Edge cases checked: partial output preserved on error/`done`; `flush:true` notify chunks stay ordered ahead of buffered text; streaming-tail completion + structured-output buffering unaffected (accumulators still see every delta); multi-turn text stays split per turn.
- Live Pi run: **attempted, blocked on credentials — not faked.** `archon workflow run e2e-pi-smoke` dispatched correctly (Pi harness loaded, node started as `pi/anthropic/claude-haiku-4-5`) but failed at Pi auth: Archon's per-user credential vault (`remote_agent_user_provider_keys`) is empty on this machine, and the workflow-run auth path builds its own `auth.json` from that vault rather than the operator's global `~/.pi/agent/auth.json`. The failure is upstream of the streaming path this PR changes, so it neither validates nor invalidates the fix. Coverage is instead provided by the unit tests, which replay the exact Pi `text_delta`/`text_end`/tool/`agent_end` event sequences.

## Side Effects / Blast Radius (required)

- Affected subsystems: only the Pi provider's chunk stream (workflows + direct chat that use Pi). Claude/Codex/OpenCode/Copilot untouched.
- Potential unintended effects: Pi stream-mode consumers now see one chunk per completed text block instead of per token — i.e. block-level streaming, matching Claude. Slightly less "live" typing feel, but the previous per-token stream was unreadable anyway.
- Guardrails: flush at every semantic boundary (turn/block/tool/result/error) guarantees no buffered text is stranded.

## Rollback Plan (required)

- Fast rollback: `git revert <merge-commit>` — single-file source change in `event-bridge.ts`.
- Feature flags: none.
- Observable failure symptoms: if a boundary flush were missed, the last text block would fail to appear; covered by the end-of-stream and result-boundary flushes plus tests.

## Risks and Mitigations

- Risk: A Pi text block that only ends via an infrastructure error (no `text_end`/result) could strand buffered text.
  - Mitigation: the consumer flushes `pendingAssistant` on both the `error` and `done` queue items before returning/throwing (regression-tested).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streamed assistant text is now combined into coherent chunks instead of being split across individual text updates.
  * Assistant text is flushed in the correct order before tool calls and results.
  * Completed text blocks remain properly separated.
  * Partial assistant text is preserved when a stream ends or encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->