### PR TITLE
fix(providers): retry Claude 400 tool-use-concurrency errors as rate limits

### DIFF
--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -2194,6 +2194,53 @@ describe('API error surfaced as text (#1797)', () => {
     expect(mockQuery).toHaveBeenCalledTimes(4);
   }, 5_000);
 
+  test('400 tool-use-concurrency error with a catch-all code retries like a rate limit (#1341)', async () => {
+    // The SDK types this transient 400 with a catch-all code ('unknown' here;
+    // 'invalid_request' classifies identically), so code-only classification
+    // would fail fast. The narrow text fallback must reclassify it as
+    // rate_limit and drive the existing backoff.
+    const text = 'API Error: 400 due to tool use concurrency issues.';
+    mockQuery.mockImplementation(async function* () {
+      yield syntheticAssistantMessage('unknown', text);
+      yield { ...apiErrorResult(text), api_error_status: 400 };
+    });
+
+    const { error } = await collect(client.sendQuery('test', '/workspace'));
+    expect(error?.message).toContain('Claude API error (unknown)');
+    expect(error?.message).toContain('tool use concurrency');
+    // MAX_SUBPROCESS_RETRIES = 3 → 4 attempts total
+    expect(mockQuery).toHaveBeenCalledTimes(4);
+  }, 5_000);
+
+  test('other catch-all-coded api errors stay non-retryable', async () => {
+    // Guards the narrowness of the #1341 fallback: a genuine client error that
+    // also lands on a catch-all code must NOT be retried.
+    const text = 'Invalid request: max_tokens exceeds model limit';
+    mockQuery.mockImplementation(async function* () {
+      yield syntheticAssistantMessage('invalid_request', text);
+      yield { ...apiErrorResult(text), api_error_status: 400 };
+    });
+
+    const { error } = await collect(client.sendQuery('test', '/workspace'));
+    expect(error?.message).toContain('Claude API error (invalid_request)');
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  test('thrown subprocess error mentioning tool use concurrency retries as rate_limit (#1341)', async () => {
+    mockQuery.mockImplementation(async function* () {
+      throw new Error('API Error: 400 due to tool use concurrency issues.');
+    });
+
+    const consumeGenerator = async (): Promise<void> => {
+      for await (const _ of client.sendQuery('test', '/workspace')) {
+        // consume
+      }
+    };
+
+    await expect(consumeGenerator()).rejects.toThrow(/Claude Code rate_limit/);
+    expect(mockQuery).toHaveBeenCalledTimes(4);
+  }, 5_000);
+
   test('legitimate output that merely mentions the error phrases is untouched', async () => {
     // A real model turn (real model id, no wrapper error field, clean result)
     // whose TEXT happens to discuss login errors — e.g. a node writing docs

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -155,7 +155,15 @@ export function buildRequestSubprocessEnv(
 const MAX_SUBPROCESS_RETRIES = 3;
 const RETRY_BASE_DELAY_MS = 2000;
 
-const RATE_LIMIT_PATTERNS = ['rate limit', 'too many requests', '429', 'overloaded'];
+const RATE_LIMIT_PATTERNS = [
+  'rate limit',
+  'too many requests',
+  '429',
+  'overloaded',
+  // "API Error: 400 due to tool use concurrency issues" — transient server-side
+  // rejection of concurrent tool calls; retrying after backoff succeeds (#1341).
+  'tool use concurrency',
+];
 const AUTH_PATTERNS = [
   'credit balance',
   'unauthorized',
@@ -1124,7 +1132,16 @@ function classifyAndEnrichError(
   // API failures the SDK surfaced as text (#1797) carry a typed error code —
   // classify by that code, never by matching the (arbitrary) message text.
   if (error instanceof ClaudeApiResultError) {
-    const errorClass = classifySdkErrorCode(error.sdkErrorCode);
+    let errorClass = classifySdkErrorCode(error.sdkErrorCode);
+    // Exception for the SDK's catch-all codes only ('unknown'/'invalid_request'
+    // — a 400 status maps here): they conflate transient server-side rejections
+    // with true client errors, so the code alone carries no retry signal. The
+    // "tool use concurrency" 400 is known-transient — reclassify it as
+    // rate_limit so the existing backoff applies (#1341). Specific typed codes
+    // above remain authoritative and are never overridden by text.
+    if (errorClass === 'unknown' && error.message.toLowerCase().includes('tool use concurrency')) {
+      errorClass = 'rate_limit';
+    }
     return {
       enrichedError: error,
       errorClass,

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -164,6 +164,34 @@ const RATE_LIMIT_PATTERNS = [
   // rejection of concurrent tool calls; retrying after backoff succeeds (#1341).
   'tool use concurrency',
 ];
+
+/**
+ * Message-text fallbacks for Anthropic errors the SDK does not yet type.
+ *
+ * Entries are consulted ONLY when the SDK's typed error code has resolved to
+ * the catch-all 'unknown' class (see the ClaudeApiResultError branch in
+ * classifyAndEnrichError) — they must never override a typed classification.
+ * A matching entry reclassifies the error as rate_limit so the existing
+ * backoff-retry applies.
+ *
+ * Admission contract — each entry must:
+ *   1. Name the upstream error it matches.
+ *   2. Link an upstream issue/reference requesting the error be properly typed.
+ *   3. Be removed once the SDK types it.
+ * Do NOT add entries for errors the SDK already classifies.
+ *
+ * This is deliberately a separate list from RATE_LIMIT_PATTERNS above: that
+ * list matches raw subprocess text (no typed code exists at all), while this
+ * one is a narrow escape hatch inside the typed classification path (#1797).
+ */
+const UNTYPED_TRANSIENT_PATTERNS: readonly string[] = [
+  // Anthropic 400 "due to tool use concurrency issues" — transient server-side
+  // rejection of concurrent tool calls; retrying after backoff succeeds (#1341).
+  // TODO: link the upstream SDK issue requesting a typed code for this error,
+  // and remove this entry once the SDK classifies it.
+  'tool use concurrency',
+];
+
 const AUTH_PATTERNS = [
   'credit balance',
   'unauthorized',
@@ -1135,12 +1163,16 @@ function classifyAndEnrichError(
     let errorClass = classifySdkErrorCode(error.sdkErrorCode);
     // Exception for the SDK's catch-all codes only ('unknown'/'invalid_request'
     // — a 400 status maps here): they conflate transient server-side rejections
-    // with true client errors, so the code alone carries no retry signal. The
-    // "tool use concurrency" 400 is known-transient — reclassify it as
-    // rate_limit so the existing backoff applies (#1341). Specific typed codes
-    // above remain authoritative and are never overridden by text.
-    if (errorClass === 'unknown' && error.message.toLowerCase().includes('tool use concurrency')) {
-      errorClass = 'rate_limit';
+    // with true client errors, so the code alone carries no retry signal. For
+    // those, and ONLY those, fall back to UNTYPED_TRANSIENT_PATTERNS (see its
+    // admission contract) to reclassify known-transient errors as rate_limit
+    // so the existing backoff applies (#1341). Specific typed codes above
+    // remain authoritative and are never overridden by text.
+    if (errorClass === 'unknown') {
+      const message = error.message.toLowerCase();
+      if (UNTYPED_TRANSIENT_PATTERNS.some(p => message.includes(p))) {
+        errorClass = 'rate_limit';
+      }
     }
     return {
       enrichedError: error,


### PR DESCRIPTION
## Summary

- Problem: Anthropic's transient `400 due to tool use concurrency issues` error is classified as non-retryable, so workflow nodes and chat turns fail immediately on an error that a short backoff would survive.
- Why it matters: workflows with concurrent tool calls (parallel DAG layers, multi-tool turns) die mid-run on a server-side hiccup, requiring a manual resume.
- What changed: the error is now classified as `rate_limit` (retryable with the existing exponential backoff) on **both** error paths in the Claude provider — the text-pattern path (`RATE_LIMIT_PATTERNS`) and the structural `ClaudeApiResultError` path added by #1797 after the issue was filed.
- What did **not** change (scope boundary): no new retry machinery — the existing `MAX_SUBPROCESS_RETRIES`/backoff applies. Codex and OpenCode `RATE_LIMIT_PATTERNS` untouched (the error string is Anthropic-specific). Specific typed SDK codes (`rate_limit`, `authentication_failed`, etc.) remain authoritative — the text fallback applies **only** when the typed code resolves to the catch-all `unknown` class.

## UX Journey

### Before

```
User                    Archon (workflow node)        Anthropic API
────                    ──────────────────────        ─────────────
runs workflow ────────▶ node issues concurrent
                        tool calls ─────────────────▶ 400 tool use concurrency
                        classify: 'unknown'
                        shouldRetry: false
sees node FAILED ◀───── error propagates immediately
(manual /workflow resume required)
```

### After

```
User                    Archon (workflow node)        Anthropic API
────                    ──────────────────────        ─────────────
runs workflow ────────▶ node issues concurrent
                        tool calls ─────────────────▶ 400 tool use concurrency
                        [classify: 'rate_limit']*
                        [backoff 2s, retry] ────────▶ succeeds
sees node continue ◀─── normal streaming resumes
```

## Architecture Diagram

### Before

```
sendQuery retry loop
      │ error
      ▼
classifyAndEnrichError
      ├── ClaudeApiResultError ──▶ classifySdkErrorCode ──▶ 'unknown' → no retry
      └── thrown Error ──────────▶ classifySubprocessError ─▶ 'unknown' → no retry
```

### After

```
sendQuery retry loop
      │ error
      ▼
classifyAndEnrichError
      ├── ClaudeApiResultError ──▶ classifySdkErrorCode
      │         └── [~] catch-all 'unknown' + "tool use concurrency" text ══▶ 'rate_limit' → retry
      └── thrown Error ──────────▶ classifySubprocessError
                └── [~] RATE_LIMIT_PATTERNS += 'tool use concurrency' ══▶ 'rate_limit' → retry
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `classifyAndEnrichError` | `classifySdkErrorCode` | **modified** | catch-all result refined by narrow text check before retry decision |
| `classifySubprocessError` | `RATE_LIMIT_PATTERNS` | **modified** | one pattern added |
| `sendQuery` retry loop | `classifyAndEnrichError` | unchanged | same retry policy, backoff, max attempts |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `core`
- Module: `providers:claude`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #1341

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # exit 0 — all nine checks green
cd packages/providers && bun test src/claude/provider.test.ts
# 113 pass, 0 fail (110 existing + 3 new)
```

- Evidence provided (test/log/trace/screenshot): 3 new tests — (1) concurrency 400 under catch-all SDK code retries 4× then throws; (2) a different `invalid_request` error stays non-retryable (guards the narrowness of the fallback); (3) thrown subprocess error carrying the text retries as `rate_limit`.
- If any command is intentionally skipped, explain why: none skipped.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No (retries reuse the existing request; bounded by existing `MAX_SUBPROCESS_RETRIES = 3`)
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: n/a

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No
- If yes, exact upgrade steps: n/a

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: full provider test suite locally on macOS; confirmed via the SDK's `sdk.d.ts` that `invalid_request` and `unknown` both resolve to the catch-all class, so a 400 typed either way is covered.
- Edge cases checked: an `invalid_request` error *without* the concurrency text is not retried (test 2); specific typed codes are never overridden by text (guard is on the resolved catch-all class only).
- What was not verified: the fix was not reproduced against the live Anthropic API (the error is server-side and not deterministically triggerable). Classification is derived from the production log excerpt in #1341.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: every Claude-provider consumer (chat orchestrator, workflow nodes) — but only on the specific error string; all other errors classify exactly as before.
- Potential unintended effects: if Anthropic ever returns "tool use concurrency" for a permanent condition, we'd retry 3 extra times (~12s worst case) before failing with the same error as today.
- Guardrails/monitoring for early detection: existing `claude.result_api_error` / `query_error` structured logs still record every attempt with `errorClass`.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge-commit>` — single self-contained commit, no schema/config coupling.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: nodes failing after 4 identical `claude.result_api_error` log entries instead of 1.

## Risks and Mitigations

- Risk: the structural-path fallback matches on message text, which #1797 deliberately avoided for classification.
  - Mitigation: the fallback fires **only** when the typed code resolves to the catch-all `unknown` class (which carries no retry signal by definition); specific codes are never overridden. If maintainers prefer the text-path-only fix from the issue, the structural fallback is one isolated block that can be dropped — happy to trim scope.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Claude tool-use concurrency errors.
  * These transient errors are now recognized as rate-limit conditions and automatically retried.
  * Preserved existing behavior for unrelated API errors, which remain non-retryable.
* **Tests**
  * Added regression coverage to ensure correct retry classification for tool-use concurrency “catch-all” SDK errors and the related thrown subprocess error case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->