### PR TITLE
fix(workflows): classify session-limit/quota errors as FATAL (never retried)

### DIFF
--- a/packages/workflows/src/executor-shared.test.ts
+++ b/packages/workflows/src/executor-shared.test.ts
@@ -659,6 +659,46 @@ describe('classifyError', () => {
     expect(classifyError(new Error('unauthorized: exited with code 1'))).toBe('FATAL');
   });
 
+  it('classifies session-limit errors as FATAL (never retried) — #2177', () => {
+    expect(
+      classifyError(
+        new Error(
+          'Claude session limit reached — resets 3:20pm (UTC). Abandon this run and retry after reset.'
+        )
+      )
+    ).toBe('FATAL');
+    expect(
+      classifyError(
+        new Error(
+          'Claude session limit reached — abandon this run and retry when the session resets.'
+        )
+      )
+    ).toBe('FATAL');
+  });
+
+  it('classifies usage-limit and credit-exhaustion errors as FATAL', () => {
+    expect(classifyError(new Error('Claude AI usage limit reached|1751234567'))).toBe('FATAL');
+    expect(classifyError(new Error('Credit exhaustion detected — resume when credits reset'))).toBe(
+      'FATAL'
+    );
+  });
+
+  it('session-limit stays FATAL even when the message also matches a TRANSIENT pattern', () => {
+    expect(classifyError(new Error('rate limit: session limit reached'))).toBe('FATAL');
+  });
+
+  it('every detectCreditExhaustion output string classifies FATAL (drift guard)', () => {
+    const outputs = [
+      detectCreditExhaustion("You've hit your session limit · resets 3am"),
+      detectCreditExhaustion('session limit reached'),
+      detectCreditExhaustion('out of credits'),
+    ];
+    for (const msg of outputs) {
+      expect(msg).not.toBeNull();
+      expect(classifyError(new Error(msg as string))).toBe('FATAL');
+    }
+  });
+
   it('classifies unknown errors as UNKNOWN', () => {
     expect(classifyError(new Error('something completely unexpected happened'))).toBe('UNKNOWN');
   });

--- a/packages/workflows/src/executor-shared.test.ts
+++ b/packages/workflows/src/executor-shared.test.ts
@@ -659,7 +659,8 @@ describe('classifyError', () => {
     expect(classifyError(new Error('unauthorized: exited with code 1'))).toBe('FATAL');
   });
 
-  it('classifies session-limit errors as FATAL (never retried) — #2177', () => {
+  it('classifies session-limit and usage-limit errors as FATAL (never retried) — #2177', () => {
+    // Verbatim node_failed payload from the issue report — regression pin.
     expect(
       classifyError(
         new Error(
@@ -667,20 +668,9 @@ describe('classifyError', () => {
         )
       )
     ).toBe('FATAL');
-    expect(
-      classifyError(
-        new Error(
-          'Claude session limit reached — abandon this run and retry when the session resets.'
-        )
-      )
-    ).toBe('FATAL');
-  });
-
-  it('classifies usage-limit and credit-exhaustion errors as FATAL', () => {
+    // CLI-only quota string: not producible by detectCreditExhaustion, so the
+    // drift guard below cannot cover it.
     expect(classifyError(new Error('Claude AI usage limit reached|1751234567'))).toBe('FATAL');
-    expect(classifyError(new Error('Credit exhaustion detected — resume when credits reset'))).toBe(
-      'FATAL'
-    );
   });
 
   it('session-limit stays FATAL even when the message also matches a TRANSIENT pattern', () => {

--- a/packages/workflows/src/executor-shared.ts
+++ b/packages/workflows/src/executor-shared.ts
@@ -26,7 +26,11 @@ function getLog(): ReturnType<typeof createLogger> {
 /** Result of error classification */
 export type ErrorType = 'TRANSIENT' | 'FATAL' | 'UNKNOWN';
 
-/** Fatal error patterns - authentication/authorization issues that won't resolve with retry */
+/**
+ * Fatal error patterns - errors that won't resolve with retry: authentication/
+ * authorization failures and provider quota/limit-window exhaustion (a retry
+ * inside the same limit window is guaranteed to fail — see #2177).
+ */
 export const FATAL_PATTERNS = [
   'unauthorized',
   'forbidden',
@@ -37,6 +41,9 @@ export const FATAL_PATTERNS = [
   '403',
   'credit balance',
   'auth error',
+  'session limit', // Claude subscription 5h window — covers every detectCreditExhaustion session variant
+  'usage limit reached', // Claude CLI quota string, e.g. "Claude AI usage limit reached|<ts>"
+  'credit exhaustion', // synthesized "Credit exhaustion detected — resume when credits reset"
 ];
 
 /** Transient error patterns - temporary issues that may resolve with retry */


### PR DESCRIPTION
## Summary

- Problem: `Claude session limit reached` node failures classify as UNKNOWN in `classifyError`, so the DAG retry loop's never-retry FATAL guard doesn't apply — `retry:` blocks burn attempts back-to-back inside the same five-hour limit window where every attempt is doomed (`on_error: all` directly; `on_error: transient` via the `exited with code` manifestation of the same limit). Reported: 45 doomed attempts across 9 runs.
- Why it matters: retries against a limit window can never succeed; they delay the run's death by minutes, waste the node's retry budget on a wall instead of real transients, and mislabel telemetry (`unknown` instead of `fatal`).
- What changed: added `'session limit'`, `'usage limit reached'`, and `'credit exhaustion'` to `FATAL_PATTERNS` in `packages/workflows/src/executor-shared.ts`. FATAL already takes precedence over TRANSIENT, and the existing `!isFatal` guard in the retry loop now fails these nodes on first occurrence under every `on_error` mode. Also closes the same gap for the synthesized `Credit exhaustion detected — resume when credits reset` message (the `credit balance` FATAL pattern doesn't match it).
- What did **not** change (scope boundary): `packages/providers/src/claude/provider.ts` (owned by open #2175; its internal 3× SDK `rate_limit` retry subtlety is noted below, not touched), `detectCreditExhaustion` wording/behavior (#1844), retry schema/semantics, and provider-level `rate_limit_event` `overageStatus: rejected` detection (possible follow-up).

## UX Journey

### Before

```
  User                          Archon (DAG executor)                    Claude
  ────                          ─────────────────────                    ──────
  runs workflow ──────────────▶ node executes ─────────────────────────▶ "You've hit your session limit…"
                                detectCreditExhaustion → node fails
                                classifyError → UNKNOWN (not FATAL)
                                retry wrapper re-attempts (backoff) ───▶ same limit, doomed
                                … repeats until attempts exhausted …
  sees failure minutes later ◀─ run fails, retry budget burned
```

### After

```
  User                          Archon (DAG executor)                    Claude
  ────                          ─────────────────────                    ──────
  runs workflow ──────────────▶ node executes ─────────────────────────▶ "You've hit your session limit…"
                                detectCreditExhaustion → node fails
                                *classifyError → FATAL*
                                *!isFatal guard → NO retry, any on_error mode*
  sees failure immediately ◀──  run fails fast; error text carries
                                "resets <time>" so the operator knows
                                when re-dispatch becomes viable
```

## Architecture Diagram

### Before

```
dag-executor.ts ──(node output text)──▶ detectCreditExhaustion (executor-shared.ts)
      │                                        │
      │◀──(synthesized error string)───────────┘
      ├──▶ classifyError (executor-shared.ts) → UNKNOWN → retry loop may re-attempt
      └──▶ toTelemetryErrorClass → 'unknown'
```

### After

```
dag-executor.ts ──(node output text)──▶ detectCreditExhaustion (executor-shared.ts)
      │                                        │
      │◀──(synthesized error string)───────────┘
      ├──▶ [~] classifyError → FATAL (new limit-window patterns) → retry loop breaks immediately
      └──▶ toTelemetryErrorClass → 'fatal'
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `dag-executor.ts` retry loop | `executor-shared.ts` `classifyError` | **modified** (data only) | Same call, new FATAL result for limit-window strings; `!isFatal` guard now fires |
| `dag-executor.ts` / `executor.ts` telemetry | `executor-shared.ts` `toTelemetryErrorClass` | **modified** (data only) | errorClass `unknown` → `fatal` for these errors |
| `executor-shared.ts` `safeSendMessage` / `executor.ts` `sendCriticalMessage` | `classifyError` | unchanged | Classify platform send errors; those never contain the new phrases |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `workflows`
- Module: `workflows:executor`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes #2177
- Related #1844 (made session-limit fail loudly; this PR is its declared follow-on), #2175 (orthogonal provider-level classification, files deliberately untouched)

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # exit 0 — check:bundled, check:bundled-skill, check:bundled-schema,
                   # check:pi-vendor-map, check:capability-matrix, type-check,
                   # lint --max-warnings 0, format:check, per-package tests all green
bun test packages/workflows/src/executor-shared.test.ts   # 89 pass / 0 fail (5 new tests)
```

- Evidence provided (test/log/trace/screenshot): new tests cover both synthesized session-limit strings, the usage-limit and credit-exhaustion strings, FATAL-over-TRANSIENT precedence (`'rate limit: session limit reached'` → FATAL), and a drift guard asserting every `detectCreditExhaustion` output string classifies FATAL — rewording the synthesized messages later fails CI instead of silently regressing to UNKNOWN. Pre-fix classification was verified empirically: all three synthesized strings returned UNKNOWN.
- If any command is intentionally skipped, explain why: none skipped.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: n/a

## Compatibility / Migration

- Backward compatible? Yes — pure classification-data change; no schema, config, or API surface touched
- Config/env changes? No
- Database migration needed? No
- If yes, exact upgrade steps: n/a

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: reproduced the misclassification with `bun -e` against the real `classifyError` (all three synthesized limit strings → UNKNOWN before, FATAL after); traced the retry decision (`dag-executor.ts:3611-3622`) to confirm FATAL breaks the loop for both `on_error: transient` and `on_error: all`; confirmed the patterns are unchanged since v0.5.0 (`git show v0.5.0:…`) so the reporter's version matches this analysis.
- Edge cases checked: FATAL-over-TRANSIENT precedence when a message contains both "session limit" and "rate limit"; `safeSendMessage`/`sendCriticalMessage` classify *platform* send errors — Slack/Telegram/web error strings do not contain the new phrases, so no behavior change there; the issue's "resets <time>" nicety is already satisfied (the synthesized error carries it into `node_failed` and the failure summary).
- What was not verified: a live session-limit reproduction against a real exhausted Claude subscription (deterministic unit coverage substitutes); the pre-existing ClaudeProvider-internal 3× retry of SDK `rate_limit` errors still happens before the workflow layer sees anything — if a session limit ever surfaces as an SDK `rate_limit` error those internal retries remain (provider-level follow-up, #2175 territory).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: any workflow node whose failure text matches the new patterns — it now fails immediately instead of possibly retrying, and reports telemetry errorClass `fatal`.
- Potential unintended effects: a genuinely transient error whose text coincidentally contains "session limit" / "usage limit reached" / "credit exhaustion" would be blocked from retry. These phrases are provider-quota-specific; same substring-matching risk profile as the existing `credit balance` pattern.
- Guardrails/monitoring for early detection: `dag_node_transient_retry` warn logs disappear for these errors; `node_failed` events carry the full error text; telemetry errorClass shift `unknown` → `fatal` is observable.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge-commit>` — single self-contained commit, two files.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: nodes failing immediately on errors that should have been retried, with FATAL classification in logs.

## Risks and Mitigations

- Risk: over-broad substring match blocks retry of an unrelated error mentioning "session limit".
  - Mitigation: phrases chosen to mirror provider quota wording exactly; drift-guard test pins the synthesized strings; classification is centralized in one array, trivially adjustable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of session-limit, usage-limit, and credit-exhaustion errors.
  * These are now consistently classified as fatal, avoiding inappropriate retries.
  * Added support for common variations in wording (including reset-time phrasing).
* **Tests**
  * Expanded regression coverage to ensure these messages remain fatal across multiple inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->