### PR TITLE
fix(web): stop model picker truncating model names in favor of the hint

### DIFF
--- a/packages/web/src/experiments/console/components/ModelPickerField.tsx
+++ b/packages/web/src/experiments/console/components/ModelPickerField.tsx
@@ -25,7 +25,11 @@ const DROPDOWN_CLASS =
   // floating dropdown).
   'absolute left-0 right-0 top-full z-20 mt-1 max-h-60 overflow-y-auto rounded-[9px] border border-border bg-surface-elevated shadow-[0_18px_44px_-18px_rgba(0,0,0,0.85)]';
 const OPTION_CLASS =
-  'flex w-full items-baseline justify-between gap-3 px-3 py-2 text-left font-mono text-[12px] transition-colors hover:bg-surface-hover';
+  // Stacked two-line row (same shape as ArtifactPanel's list rows): the model
+  // name is the primary identifier and keeps the full row width; the
+  // cost/context hint rides a muted second line so it can never crowd the
+  // name out (#2031).
+  'flex w-full flex-col gap-0.5 px-3 py-2 text-left font-mono text-[12px] transition-colors hover:bg-surface-hover';
 const FOOTER_BUTTON_CLASS =
   'w-full border-t border-border px-3 py-2 text-left font-mono text-[11px] text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary';
 
@@ -92,9 +96,9 @@ function OptionRow({
       }}
       className={OPTION_CLASS}
     >
-      <span className="min-w-0 truncate text-text-primary">{option.value}</span>
+      <span className="truncate text-text-primary">{option.value}</span>
       {option.hint !== undefined ? (
-        <span className="shrink-0 text-[10px] text-text-tertiary">{option.hint}</span>
+        <span className="truncate text-[10px] text-text-tertiary">{option.hint}</span>
       ) : null}
     </button>
   );


### PR DESCRIPTION
## Summary

- Problem: In the console AI Settings model pickers (Model Tiers / Aliases / Defaults), suggestion rows truncate the model NAME (down to `a` / `ama…`) while the cost/context hint keeps its full width — similarly-prefixed models (e.g. the `amazon-bedrock/*` group) are indistinguishable.
- Why it matters: The picker exists to disambiguate ~920 Pi catalog models; an unreadable name defeats it. Most visible on Pi's long hints, but the same row layout serves Claude/Codex/OpenCode suggestions too.
- What changed: `OptionRow` in `ModelPickerField.tsx` becomes a stacked two-line row (mirroring `ArtifactPanel`'s list rows): the model name keeps the full row width on its own line; the hint moves to a muted `text-[10px]` second line and truncates as the secondary element. The `shrink-0` that gave the hint layout priority is gone.
- What did **not** change (scope boundary): hint content (`lib/model-options.ts`), the Copilot native `<select>`, dropdown sizing/elevation, and the legacy UI are untouched. Existing design tokens and Tailwind utilities only — no new values.

## UX Journey

### Before

```
  User                          Console (AI Settings → Model Tiers)
  ────                          ───────────────────────────────────
  sets agent to Pi ───────────▶ renders searchable model picker
  focuses model input ────────▶ opens suggestions dropdown
                                row: [a…]        [$0.06/M in · $0.24/M out · 300k ctx]
                                     name shrunk  hint keeps full width (shrink-0)
  can't read names ◀──────────  unreadable suggestions
```

### After

```
  User                          Console (AI Settings → Model Tiers)
  ────                          ───────────────────────────────────
  sets agent to Pi ───────────▶ renders searchable model picker
  focuses model input ────────▶ opens suggestions dropdown
                                row: [amazon-bedrock/us.anthropic.claude-…]   *name gets full row width*
                                     [$0.06/M in · $0.24/M out · 300k ctx]    *hint on muted second line*
  picks the right model ◀─────  legible suggestions
```

## Architecture Diagram

### Before

```
ModelTiersPanel ─┐
ModelAliasesPanel ├──▶ ModelPickerField ──▶ OptionRow (single-line flex, hint shrink-0)
DefaultsPanel ───┘          │
                            └──▶ lib/model-options.ts (hint strings)
```

### After

```
ModelTiersPanel ─┐
ModelAliasesPanel ├──▶ ModelPickerField ──▶ [~] OptionRow (stacked flex-col, name-first)
DefaultsPanel ───┘          │
                            └──▶ lib/model-options.ts (unchanged)
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| ModelTiersPanel / ModelAliasesPanel / DefaultsPanel | ModelPickerField | unchanged | Same props, same behavior |
| ModelPickerField | OptionRow | **modified** | Row layout only (utility classes); markup structure and handlers unchanged |
| ModelPickerField | lib/model-options.ts | unchanged | Hint content untouched |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `web`
- Module: `web:console`

## Change Metadata

- Change type: `bug`
- Primary scope: `web`

## Linked Issue

- Closes #2031

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # check:bundled, check:bundled-skill, check:bundled-schema,
                   # check:pi-vendor-map, check:capability-matrix, type-check,
                   # lint, format:check, test — all green (exit 0)
```

- Evidence provided (test/log/trace/screenshot): full `bun run validate` pass on the branch.
- If any command is intentionally skipped, explain why: no test added on purpose — this is a pure CSS/utility-class change with no logic; the console has no `ModelPickerField` component test today, and asserting a Tailwind class string would be a token test with no behavioral value.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: N/A

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: read the rendered class output against the issue's reproduction (Pi catalog rows with long cost/context hints); confirmed `OPTION_CLASS` has a single call site so no other surface shifts.
- Edge cases checked: hint-less rows (Claude/Codex curated options) render single-line as before via the existing conditional; pathologically long names still truncate gracefully on their own line; two-line rows scroll within the existing `max-h-60` dropdown.
- What was not verified: in-browser screenshot of the running console (layout change is deterministic CSS; reviewer can eyeball via AI Settings → Model Tiers → Pi).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: console model-picker dropdowns only (Tiers / Aliases / Defaults panels; Pi, OpenCode, Claude/Codex suggestion shapes).
- Potential unintended effects: rows are taller, so fewer suggestions are visible per scroll page in the `max-h-60` dropdown — readability over density is the point of the fix.
- Guardrails/monitoring for early detection: visual — any regression is immediately obvious in the settings panels.

## Rollback Plan (required)

- Fast rollback command/path: `git revert 677486d1` (single-file, single-commit change).
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: misaligned or overlapping suggestion rows in the model picker dropdowns.

## Risks and Mitigations

- Risk: taller rows reduce visible suggestion count per viewport.
  - Mitigation: dropdown already scrolls (`max-h-60`); the 30-suggestion cap keeps the list short.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated model picker options to use a clearer two-line layout.
  * Improved text truncation so model names and hints remain readable within limited space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->