### PR TITLE
fix(console): show chat-dispatched run messages on the run detail page

### DIFF
--- a/packages/web/src/experiments/console/primitives/run.test.ts
+++ b/packages/web/src/experiments/console/primitives/run.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { toRun, normalizeOrigin } from './run';
+import { toRun, normalizeOrigin, runMessageConversationId } from './run';
 
 type Raw = Parameters<typeof toRun>[0];
 
@@ -65,6 +65,22 @@ describe('toRun — provenance', () => {
     expect(r.conversationPlatformId).toBe('cli-detail-789');
   });
 
+  test('worker_platform_id maps through for chat-dispatched runs; absent → null', () => {
+    const web = toRun(
+      raw({
+        id: 'r1',
+        workflow_name: 'plan',
+        status: 'completed',
+        worker_platform_id: 'web-worker-123-abc',
+      })
+    );
+    expect(web.workerPlatformId).toBe('web-worker-123-abc');
+    expect(web.conversationPlatformId).toBeNull();
+
+    const bare = toRun(raw({ id: 'r2', workflow_name: 'plan', status: 'completed' }));
+    expect(bare.workerPlatformId).toBeNull();
+  });
+
   test("normalizes the transient 'pending' status to running", () => {
     const r = toRun(raw({ id: 'r1', workflow_name: 'plan', status: 'pending' }));
     expect(r.status).toBe('running');
@@ -73,6 +89,51 @@ describe('toRun — provenance', () => {
   test('an unrecognised status falls back to running', () => {
     const r = toRun(raw({ id: 'r1', workflow_name: 'plan', status: 'banana' }));
     expect(r.status).toBe('running');
+  });
+});
+
+describe('runMessageConversationId', () => {
+  test('CLI run: uses conversationPlatformId (unchanged behavior)', () => {
+    const r = toRun(
+      raw({
+        id: 'r1',
+        workflow_name: 'plan',
+        status: 'completed',
+        conversation_platform_id: 'cli-1776237248436-q61o4h',
+      })
+    );
+    expect(runMessageConversationId(r)).toBe('cli-1776237248436-q61o4h');
+  });
+
+  test('chat-dispatched run: falls back to the worker conversation (#2048)', () => {
+    const r = toRun(
+      raw({
+        id: 'r1',
+        workflow_name: 'plan',
+        status: 'completed',
+        conversation_platform_id: null,
+        worker_platform_id: 'web-worker-1784559376043-8p44vw',
+      })
+    );
+    expect(runMessageConversationId(r)).toBe('web-worker-1784559376043-8p44vw');
+  });
+
+  test('prefers conversationPlatformId when both are present', () => {
+    const r = toRun(
+      raw({
+        id: 'r1',
+        workflow_name: 'plan',
+        status: 'completed',
+        conversation_platform_id: 'cli-abc',
+        worker_platform_id: 'web-worker-xyz',
+      })
+    );
+    expect(runMessageConversationId(r)).toBe('cli-abc');
+  });
+
+  test('list-sourced row (neither field) → null, message fetching stays off', () => {
+    const r = toRun(raw({ id: 'r1', workflow_name: 'plan', status: 'running' }));
+    expect(runMessageConversationId(r)).toBeNull();
   });
 });
 

--- a/packages/web/src/experiments/console/primitives/run.test.ts
+++ b/packages/web/src/experiments/console/primitives/run.test.ts
@@ -135,6 +135,10 @@ describe('runMessageConversationId', () => {
     const r = toRun(raw({ id: 'r1', workflow_name: 'plan', status: 'running' }));
     expect(runMessageConversationId(r)).toBeNull();
   });
+
+  test('not-yet-loaded run (undefined) → null', () => {
+    expect(runMessageConversationId(undefined)).toBeNull();
+  });
 });
 
 describe('toRun — cost', () => {

--- a/packages/web/src/experiments/console/primitives/run.ts
+++ b/packages/web/src/experiments/console/primitives/run.ts
@@ -19,12 +19,9 @@ export interface Run {
    */
   conversationPlatformId: string | null;
   /**
-   * Platform id of the WORKER conversation for chat-dispatched runs. The
-   * getRun route deliberately splits the pointer: CLI runs get
-   * `conversation_platform_id`, web/chat-dispatched runs (parent conversation
-   * set) get `worker_platform_id` instead — and the worker conversation is
-   * where the run's messages live. Use runMessageConversationId() to pick
-   * the message source (#2048).
+   * Platform id of the WORKER conversation for chat-dispatched (web) runs —
+   * where a chat-dispatched run's messages actually live. See
+   * runMessageConversationId() for how CLI vs. web runs are picked (#2048).
    */
   workerPlatformId: string | null;
   workflow: string;
@@ -120,10 +117,11 @@ function readCost(meta: Record<string, unknown> | undefined): number | null {
  * `/api/conversations/:id/messages` route accepts. CLI runs expose it as
  * `conversationPlatformId`; chat-dispatched (web) runs only expose the worker
  * conversation as `workerPlatformId`, which is where their agent output is
- * persisted (#2048). Null for list-sourced rows (neither field is present),
- * so message fetching stays off there.
+ * persisted (#2048). Null for list-sourced rows (neither field is present)
+ * and for a run that hasn't loaded yet, so message fetching stays off there.
  */
-export function runMessageConversationId(run: Run): string | null {
+export function runMessageConversationId(run: Run | undefined): string | null {
+  if (run === undefined) return null;
   return run.conversationPlatformId ?? run.workerPlatformId;
 }
 

--- a/packages/web/src/experiments/console/primitives/run.ts
+++ b/packages/web/src/experiments/console/primitives/run.ts
@@ -18,6 +18,15 @@ export interface Run {
    * that endpoint. Use this when fetching the run's messages.
    */
   conversationPlatformId: string | null;
+  /**
+   * Platform id of the WORKER conversation for chat-dispatched runs. The
+   * getRun route deliberately splits the pointer: CLI runs get
+   * `conversation_platform_id`, web/chat-dispatched runs (parent conversation
+   * set) get `worker_platform_id` instead — and the worker conversation is
+   * where the run's messages live. Use runMessageConversationId() to pick
+   * the message source (#2048).
+   */
+  workerPlatformId: string | null;
   workflow: string;
   origin: RunOrigin;
   status: RunStatus;
@@ -56,6 +65,8 @@ interface RawWorkflowRun {
   conversation_id?: string | null;
   /** Platform-level conversation id — exposed on the getRun response only. */
   conversation_platform_id?: string | null;
+  /** Worker conversation platform id — getRun response only, web runs only. */
+  worker_platform_id?: string | null;
   status: string;
   started_at: string;
   completed_at?: string | null;
@@ -104,6 +115,18 @@ function readCost(meta: Record<string, unknown> | undefined): number | null {
   return typeof raw === 'number' && Number.isFinite(raw) && raw > 0 ? raw : null;
 }
 
+/**
+ * The platform conversation id that holds this run's messages — the id the
+ * `/api/conversations/:id/messages` route accepts. CLI runs expose it as
+ * `conversationPlatformId`; chat-dispatched (web) runs only expose the worker
+ * conversation as `workerPlatformId`, which is where their agent output is
+ * persisted (#2048). Null for list-sourced rows (neither field is present),
+ * so message fetching stays off there.
+ */
+export function runMessageConversationId(run: Run): string | null {
+  return run.conversationPlatformId ?? run.workerPlatformId;
+}
+
 export function toRun(raw: RawWorkflowRun): Run {
   const approval = raw.metadata?.approval;
   const isApprovalShape =
@@ -139,6 +162,7 @@ export function toRun(raw: RawWorkflowRun): Run {
     costUsd: readCost(raw.metadata),
     conversationId: raw.conversation_id ?? null,
     conversationPlatformId: raw.conversation_platform_id ?? null,
+    workerPlatformId: raw.worker_platform_id ?? null,
     workflow: raw.workflow_name,
     origin: normalizeOrigin(raw.platform_type),
     status: normalizeStatus(raw.status),

--- a/packages/web/src/experiments/console/routes/PreviewPage.tsx
+++ b/packages/web/src/experiments/console/routes/PreviewPage.tsx
@@ -19,6 +19,7 @@ const baseRun: Omit<Run, 'id' | 'workflow' | 'status'> = {
   costUsd: null,
   conversationId: null,
   conversationPlatformId: null,
+  workerPlatformId: null,
   origin: 'cli',
   startedAt: new Date(Date.now() - 4 * 60 * 1000 - 12 * 1000).toISOString(),
   finishedAt: null,

--- a/packages/web/src/experiments/console/routes/RunDetailPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunDetailPage.tsx
@@ -147,8 +147,7 @@ export function RunDetailPage(): ReactElement {
   // conversationPlatformId; chat-dispatched runs only expose the worker
   // conversation (workerPlatformId), which holds their messages (#2048). The
   // helper picks whichever is present.
-  const conversationPlatformId =
-    detail?.run !== undefined ? runMessageConversationId(detail.run) : null;
+  const conversationPlatformId = runMessageConversationId(detail?.run);
 
   const { data: messages } = useEntity<Message[]>(
     conversationPlatformId !== null

--- a/packages/web/src/experiments/console/routes/RunDetailPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunDetailPage.tsx
@@ -23,7 +23,7 @@ import { useRunStreamSSE } from '../lib/sse';
 import { useEntity, invalidate } from '../store/cache';
 import { K } from '../store/keys';
 import * as skill from '../skills';
-import type { Run } from '../primitives/run';
+import { runMessageConversationId, type Run } from '../primitives/run';
 import { foldNodeRuns, type RunEvent } from '../primitives/event';
 import type { Message } from '../primitives/message';
 import type { Project } from '../primitives/project';
@@ -143,9 +143,12 @@ export function RunDetailPage(): ReactElement {
   );
 
   // Messages are tied to the run's conversation — and the /messages endpoint
-  // takes the *platform* conversation id, not the DB id. getRun exposes both;
-  // we consume the platform id here.
-  const conversationPlatformId = detail?.run.conversationPlatformId ?? null;
+  // takes the *platform* conversation id, not the DB id. CLI runs expose it as
+  // conversationPlatformId; chat-dispatched runs only expose the worker
+  // conversation (workerPlatformId), which holds their messages (#2048). The
+  // helper picks whichever is present.
+  const conversationPlatformId =
+    detail?.run !== undefined ? runMessageConversationId(detail.run) : null;
 
   const { data: messages } = useEntity<Message[]>(
     conversationPlatformId !== null

--- a/packages/web/src/experiments/console/routes/RunsPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunsPage.tsx
@@ -48,6 +48,7 @@ function buildDemoRuns(scope: Scope, projectName: string | null): Run[] {
     costUsd: null as number | null,
     conversationId: null as string | null,
     conversationPlatformId: null as string | null,
+    workerPlatformId: null as string | null,
     workingPath: null,
     userMessage: '',
     finishedAt: null as string | null,


### PR DESCRIPTION
## Summary

- Problem: The console run detail page shows "0 messages · N tool calls" and never renders the agent's final answer for chat-dispatched (web) runs. CLI-started runs render fine, and console chat itself renders fine.
- Why it matters: The console is the default UI — for any run kicked off from chat, the primary output of the run is invisible.
- What changed: The console run primitive now maps `worker_platform_id` from the getRun response, and a new `runMessageConversationId()` helper picks the message-source conversation — `conversation_platform_id` (CLI) with a fallback to the worker conversation (web), which is where chat-dispatched runs persist their messages. `RunDetailPage` fetches messages, subscribes to SSE, and runs its safety-net invalidation off that helper.
- What did **not** change (scope boundary): No server or OpenAPI change — the getRun route's deliberate `conversation_platform_id` / `worker_platform_id` split is untouched (`worker_platform_id` was already in the response schema), so the legacy UI and other consumers are unaffected. The reporter's secondary "View full logs" crash is a separate legacy-only bug (`WorkflowExecution.tsx` refetch on undefined) that dies with `/legacy` — intentionally not fixed here.

## UX Journey

### Before

```
  User                        Console RunDetailPage              Server
  ────                        ─────────────────────              ──────
  runs workflow from chat
  opens run detail ─────────▶ getRun(id) ───────────────────────▶ returns worker_platform_id,
                                                                  conversation_platform_id: null
                              conversationPlatformId = null
                              messages query never fires
  sees "0 messages",
  no agent answer ◀────────── renders events only
```

### After

```
  User                        Console RunDetailPage              Server
  ────                        ─────────────────────              ──────
  runs workflow from chat
  opens run detail ─────────▶ getRun(id) ───────────────────────▶ returns worker_platform_id
                              [runMessageConversationId():
                               conversationPlatformId ?? workerPlatformId]
                              *listMessages(worker conv)* ──────▶ /api/conversations/<worker>/messages
  sees messages and the
  agent's final answer ◀───── renders merged timeline + SSE live updates
```

## Architecture Diagram

### Before

```
  server: GET /api/workflows/runs/:runId
      │  (worker_platform_id | conversation_platform_id — deliberate split)
      ▼
  console skills/runs.ts (getRun) ──▶ primitives/run.ts (toRun)
                                          │  maps conversation_platform_id ONLY
                                          ▼
                                     RunDetailPage ──▶ listMessages / SSE
                                          (null for web runs → no fetch)
```

### After

```
  server: GET /api/workflows/runs/:runId            (unchanged)
      │
      ▼
  console skills/runs.ts (getRun) ──▶ [~] primitives/run.ts (toRun)
                                          │  maps conversation_platform_id
                                          │  [+] maps worker_platform_id
                                          │  [+] runMessageConversationId()
                                          ▼
                                     [~] RunDetailPage ═══▶ listMessages / SSE
                                          (worker conv fallback for web runs)
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| console `skills/runs.ts` getRun | `primitives/run.ts` toRun | unchanged | raw payload already carried `worker_platform_id` |
| `primitives/run.ts` toRun | `Run` shape | **modified** | new `workerPlatformId` field + `runMessageConversationId()` helper |
| `RunDetailPage` | `/api/conversations/:id/messages` | **modified** | id now resolved via helper (CLI id, else worker id) |
| `RunDetailPage` | conversation SSE stream (`lib/sse.ts`) | **modified** | subscribes with the same resolved id (was: never, for web runs) |
| `RunsPage` / `PreviewPage` demo fixtures | `Run` shape | **modified** | gained the new required field (`null`) |
| server getRun route | console | unchanged | no schema/API change |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `web`
- Module: `web:console`

## Change Metadata

- Change type: `bug`
- Primary scope: `web`

## Linked Issue

- Closes #2048

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # check:bundled, check:bundled-skill, check:bundled-schema,
                   # check:pi-vendor-map, check:capability-matrix, type-check,
                   # lint (--max-warnings 0), format:check, test — all green
```

- Evidence provided (test/log/trace/screenshot): `run.test.ts` grew from 21 to 25 cases (all pass): `worker_platform_id` mapping (present/absent) and `runMessageConversationId` for all four shapes — CLI id only, worker id only, both (CLI wins), neither (null → fetch stays off). Root cause verified live on dev before the fix: for an affected run, `GET /api/workflows/runs/:id` returned `conversation_platform_id: null` + `worker_platform_id` set, and `GET /api/conversations/<worker_platform_id>/messages` returned the missing assistant messages.
- If any command is intentionally skipped, explain why: none skipped.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: n/a

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No
- If yes, exact upgrade steps: n/a

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: live repro on dev confirmed the exact failure (web run detail: 0 messages, `conversation_platform_id: null`) and the fix path (worker conversation's `/messages` returns the agent output for the same run).
- Edge cases checked: CLI runs keep their existing id (helper prefers `conversationPlatformId`); list-sourced dashboard rows carry neither id, so message fetching stays off there exactly as before; demo/preview fixtures updated for the new required field.
- What was not verified: an end-to-end browser click-through of the patched build (the live verification was against the API layer the page consumes).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: console run detail page only (`experiments/console`). For web runs it now also opens the conversation SSE stream and the 30s safety-net message invalidation, both keyed on the worker conversation — previously dead paths for those runs.
- Potential unintended effects: none expected — the worker conversation is run-scoped, so its messages belong to exactly this run.
- Guardrails/monitoring for early detection: primitive-level unit tests pin the id-selection rules; any regression shows up as the original "0 messages" symptom.

## Rollback Plan (required)

- Fast rollback command/path: `git revert 8ce3c4fa` (single self-contained commit).
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: run detail page for chat-dispatched runs shows "0 messages" and no agent answer again.

## Risks and Mitigations

- Risk: a future consumer treats `workerPlatformId` as a general "the run's conversation" and navigates the user into the worker conversation.
  - Mitigation: doc comments on both fields and the helper spell out the CLI/web split and that the helper is specifically the message-source seam.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved conversation identification for chat-dispatched and CLI runs.
  * Run details now load message history and live updates from the correct conversation.

* **Bug Fixes**
  * Fixed message fetching when the primary conversation identifier is unavailable by falling back to the worker conversation identifier.

* **Tests**
  * Added coverage for conversation selection and worker identifier mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->