### PR TITLE
fix(server): resolve small tier for title generation at server entry points

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -79,7 +79,8 @@ export * as isolationOperations from './operations/isolation-operations';
 // =============================================================================
 // Orchestrator
 // =============================================================================
-export { handleMessage } from './orchestrator/orchestrator-agent';
+export { handleMessage, resolveTitleRequest } from './orchestrator/orchestrator-agent';
+export type { TitleRequest } from './orchestrator/orchestrator-agent';
 export {
   buildOrchestratorPrompt,
   buildProjectScopedPrompt,

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -314,6 +314,7 @@ import {
   parseOrchestratorCommands,
   handleMessage,
   resolveChatModelRequest,
+  resolveTitleRequest,
 } from './orchestrator-agent';
 import { buildAiProfile } from '@archon/workflows/model-validation';
 
@@ -4023,5 +4024,94 @@ describe('resolveChatModelRequest', () => {
       { assistants: { claude: {}, codex: {} }, tiers }
     );
     expect(req.model).toBe('sonnet');
+  });
+});
+
+// ─── resolveTitleRequest (#1855): small-tier title generation ────────────────
+
+describe('resolveTitleRequest', () => {
+  beforeEach(() => {
+    mockLoadConfig.mockReset();
+    mockLoadConfig.mockImplementation(() =>
+      Promise.resolve({
+        assistants: { claude: {}, codex: { model: 'gpt-5.3-codex' } },
+        envVars: {},
+      })
+    );
+    mockGetUserAiPrefsDb.mockReset();
+    mockGetUserAiPrefsDb.mockImplementation(async () => ({}));
+  });
+
+  test('resolves the built-in codex small tier instead of the raw config-default model', async () => {
+    const req = await resolveTitleRequest('codex');
+
+    expect(req.provider).toBe('codex');
+    // Built-in codex small tier — NOT the (ChatGPT-plan-unsupported) assistants default.
+    expect(req.options.model).toBe('gpt-5.5');
+    // Preset effort is routed to the Codex reasoning-effort field.
+    expect(req.options.assistantConfig).toEqual({
+      model: 'gpt-5.3-codex',
+      modelReasoningEffort: 'minimal',
+    });
+  });
+
+  test('a configured small tier wins (including a provider switch)', async () => {
+    mockLoadConfig.mockResolvedValueOnce({
+      assistants: { claude: {}, codex: { model: 'gpt-5.3-codex' } },
+      tiers: { small: { provider: 'claude', model: 'haiku' } },
+      envVars: {},
+    });
+
+    const req = await resolveTitleRequest('codex');
+
+    expect(req.provider).toBe('claude');
+    expect(req.options.model).toBe('haiku');
+    expect(req.options.assistantConfig).toEqual({});
+  });
+
+  test('per-user small tier participates when a userId is available', async () => {
+    mockGetUserAiPrefsDb.mockResolvedValueOnce({
+      tiers: { small: { provider: 'codex', model: 'gpt-5.4-mini' } },
+    });
+
+    const req = await resolveTitleRequest('codex', 'user-1');
+
+    expect(mockGetUserAiPrefsDb).toHaveBeenCalledWith('user-1');
+    expect(req.provider).toBe('codex');
+    expect(req.options.model).toBe('gpt-5.4-mini');
+  });
+
+  test('per-user prefs are NOT consulted without a userId', async () => {
+    await resolveTitleRequest('codex');
+    expect(mockGetUserAiPrefsDb).not.toHaveBeenCalled();
+  });
+
+  test('per-user default provider rebases the built-in tier defaults', async () => {
+    mockGetUserAiPrefsDb.mockResolvedValueOnce({ defaultProvider: 'claude' });
+
+    const req = await resolveTitleRequest('codex', 'user-1');
+
+    expect(req.provider).toBe('claude');
+    expect(req.options.model).toBe('haiku');
+  });
+
+  test('structurally invalid stored prefs degrade to config-only resolution', async () => {
+    // Missing '@' prefix makes buildAiProfile throw for the user layer.
+    mockGetUserAiPrefsDb.mockResolvedValueOnce({
+      aliases: { fast: { provider: 'codex', model: 'gpt-5.5' } },
+    });
+
+    const req = await resolveTitleRequest('codex', 'user-1');
+
+    expect(req.provider).toBe('codex');
+    expect(req.options.model).toBe('gpt-5.5');
+  });
+
+  test('NEVER throws — config load failure falls back to the bare legacy request', async () => {
+    mockLoadConfig.mockRejectedValueOnce(new Error('config exploded'));
+
+    const req = await resolveTitleRequest('codex', 'user-1');
+
+    expect(req).toEqual({ provider: 'codex', options: {} });
   });
 });

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -198,6 +198,71 @@ export function resolveChatModelRequest(
   return request;
 }
 
+/** A resolved title-generation request: which provider to call, with fully resolved options. */
+export interface TitleRequest {
+  provider: string;
+  options: SendQueryOptions;
+}
+
+/**
+ * Resolve provider + request options for conversation-title generation (#1855).
+ *
+ * Server entry points that fire title generation outside a full chat turn
+ * (create-with-message, web workflow run) resolve the `small` tier here —
+ * config tiers plus per-user prefs when a userId is available — instead of
+ * letting the provider fall through to its raw config-default model, which
+ * the active account may not support (e.g. `gpt-5.3-codex` on ChatGPT-plan
+ * Codex accounts). Mirrors the chat path's title resolution in
+ * `handleMessage` (#1873), which keeps its own inline resolution to reuse
+ * the already-loaded config and profile.
+ *
+ * NEVER THROWS — degrades to `{ provider: fallbackProvider, options: {} }`
+ * (the legacy behavior) so fire-and-forget callers stay safe.
+ */
+export async function resolveTitleRequest(
+  fallbackProvider: string,
+  userId?: string
+): Promise<TitleRequest> {
+  try {
+    const config = await loadConfig();
+    const userAiPrefs = userId ? await resolveUserAiPrefsForChat(userId) : {};
+    let configuredProviderKey = userAiPrefs.defaultProvider ?? fallbackProvider;
+    let aiProfile: ReturnType<typeof buildAiProfile>;
+    try {
+      aiProfile = buildAiProfile(configuredProviderKey, {
+        repoTiers: config.tiers,
+        repoAliases: config.aliases,
+        userTiers: userAiPrefs.tiers,
+        userAliases: userAiPrefs.aliases,
+      });
+    } catch (profileErr) {
+      // Structurally invalid STORED prefs must not break title generation —
+      // degrade to config-only (mirrors the chat path in handleMessage).
+      getLog().warn({ err: profileErr as Error, userId }, 'orchestrator.title_prefs_invalid');
+      configuredProviderKey = fallbackProvider;
+      aiProfile = buildAiProfile(configuredProviderKey, {
+        repoTiers: config.tiers,
+        repoAliases: config.aliases,
+      });
+    }
+    const titleRequest = resolveModelRequest(aiProfile, 'small', configuredProviderKey);
+    const options: SendQueryOptions = {
+      model: titleRequest.model,
+      assistantConfig: { ...(config.assistants[titleRequest.provider] ?? {}) },
+    };
+    if (titleRequest.preset) {
+      applyPresetToRequestOptions(titleRequest.provider, titleRequest.preset, options);
+    }
+    return { provider: titleRequest.provider, options };
+  } catch (err) {
+    getLog().warn(
+      { err: err as Error, fallbackProvider },
+      'orchestrator.title_request_resolve_failed'
+    );
+    return { provider: fallbackProvider, options: {} };
+  }
+}
+
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export interface WorkflowInvocation {

--- a/packages/server/src/routes/api.auth.test.ts
+++ b/packages/server/src/routes/api.auth.test.ts
@@ -74,6 +74,7 @@ mock.module('@archon/core', () => ({
   registerRepository: mock(async () => ({ codebaseId: 'x', alreadyExisted: false })),
   ConversationNotFoundError: class ConversationNotFoundError extends Error {},
   generateAndSetTitle: mock(async () => {}),
+  resolveTitleRequest: mock(async () => ({ provider: 'claude', options: {} })),
   isPerUserGitHubEnabled: () => false,
   getArchonWorkspacesPath: () => '/tmp/.archon/workspaces',
   createLogger: noopLogger,

--- a/packages/server/src/routes/api.codebases.test.ts
+++ b/packages/server/src/routes/api.codebases.test.ts
@@ -58,6 +58,7 @@ mock.module('@archon/core', () => ({
   },
   getArchonWorkspacesPath: () => '/tmp/.archon/workspaces',
   generateAndSetTitle: mock(async () => {}),
+  resolveTitleRequest: mock(async () => ({ provider: 'claude', options: {} })),
   createLogger: () => ({
     fatal: mock(() => undefined),
     error: mock(() => undefined),

--- a/packages/server/src/routes/api.conversations.test.ts
+++ b/packages/server/src/routes/api.conversations.test.ts
@@ -21,7 +21,11 @@ const mockFindConversationByPlatformId = mock(
 const mockSoftDeleteConversation = mock(async (_id: string) => {});
 const mockUpdateConversationTitle = mock(async (_id: string, _title: string) => {});
 
-const mockGenerateAndSetTitle = mock(async () => {});
+const mockGenerateAndSetTitle = mock(async (..._args: unknown[]) => {});
+const mockResolveTitleRequest = mock(async () => ({
+  provider: 'claude',
+  options: {} as Record<string, unknown>,
+}));
 mock.module('@archon/core', () => ({
   handleMessage: mock(async () => {}),
   getDatabaseType: () => 'sqlite',
@@ -40,6 +44,7 @@ mock.module('@archon/core', () => ({
     }
   },
   generateAndSetTitle: mockGenerateAndSetTitle,
+  resolveTitleRequest: mockResolveTitleRequest,
   getArchonWorkspacesPath: () => '/tmp/.archon/workspaces',
   createLogger: () => ({
     fatal: mock(() => undefined),
@@ -389,7 +394,32 @@ describe('POST /api/conversations with message (atomic create+send)', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ message: 'help me debug this function' }),
     });
+    // Title generation is chained behind resolveTitleRequest — flush microtasks.
+    await new Promise(resolve => setTimeout(resolve, 0));
     expect(mockGenerateAndSetTitle.mock.calls.length).toBeGreaterThan(callsBefore);
+  });
+
+  test('forwards the resolved small-tier provider and options to title generation (#1855)', async () => {
+    const titleOptions = {
+      model: 'gpt-5.5',
+      assistantConfig: { modelReasoningEffort: 'minimal' },
+    };
+    mockResolveTitleRequest.mockResolvedValueOnce({ provider: 'codex', options: titleOptions });
+
+    const app = new OpenAPIHono({ defaultHook: validationErrorHook });
+    registerApiRoutes(app, mockWebAdapter, mockLockManager);
+
+    await app.request('/api/conversations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: 'summarize this repo' }),
+    });
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const lastCall = mockGenerateAndSetTitle.mock.calls.at(-1);
+    expect(lastCall?.[2]).toBe('codex'); // resolved provider, not the raw assistant type
+    expect(lastCall?.[5]).toEqual(titleOptions.assistantConfig);
+    expect(lastCall?.[6]).toEqual(titleOptions);
   });
 
   test('skips title generation for slash commands', async () => {

--- a/packages/server/src/routes/api.health.test.ts
+++ b/packages/server/src/routes/api.health.test.ts
@@ -41,6 +41,7 @@ mock.module('@archon/core', () => ({
   getArchonWorkspacesPath: () => '/tmp/.archon/workspaces',
   toSafeConfig: (config: unknown) => config,
   generateAndSetTitle: mock(async () => {}),
+  resolveTitleRequest: mock(async () => ({ provider: 'claude', options: {} })),
   createLogger: () => ({
     fatal: mock(() => undefined),
     error: mock(() => undefined),

--- a/packages/server/src/routes/api.messages.test.ts
+++ b/packages/server/src/routes/api.messages.test.ts
@@ -51,6 +51,7 @@ mock.module('@archon/core', () => ({
   },
   getArchonWorkspacesPath: () => '/tmp/.archon/workspaces',
   generateAndSetTitle: mock(async () => {}),
+  resolveTitleRequest: mock(async () => ({ provider: 'claude', options: {} })),
   createLogger: () => ({
     fatal: mock(() => undefined),
     error: mock(() => undefined),

--- a/packages/server/src/routes/api.provider-keys.test.ts
+++ b/packages/server/src/routes/api.provider-keys.test.ts
@@ -134,6 +134,7 @@ mock.module('@archon/core', () => ({
   registerRepository: mock(async () => ({ codebaseId: 'x', alreadyExisted: false })),
   ConversationNotFoundError: class ConversationNotFoundError extends Error {},
   generateAndSetTitle: mock(async () => {}),
+  resolveTitleRequest: mock(async () => ({ provider: 'claude', options: {} })),
   isPerUserGitHubEnabled: () => false,
   getArchonWorkspacesPath: () => '/tmp/.archon/workspaces',
   createLogger: noopLogger,

--- a/packages/server/src/routes/api.providers.test.ts
+++ b/packages/server/src/routes/api.providers.test.ts
@@ -35,6 +35,7 @@ mock.module('@archon/core', () => ({
   getArchonWorkspacesPath: () => '/tmp/.archon/workspaces',
   toSafeConfig: (config: unknown) => config,
   generateAndSetTitle: mock(async () => {}),
+  resolveTitleRequest: mock(async () => ({ provider: 'claude', options: {} })),
   updateGlobalConfig: mockUpdateGlobalConfig,
   createLogger: () => ({
     fatal: mock(() => undefined),

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -31,6 +31,7 @@ import {
   registerFolder,
   ConversationNotFoundError,
   generateAndSetTitle,
+  resolveTitleRequest,
   isPerUserGitHubEnabled,
   loadDeviceFlowConfig,
   startDeviceFlow,
@@ -2378,13 +2379,21 @@ export function registerApiRoutes(
         const placeholderTitle = message.length > 60 ? message.slice(0, 60) + '...' : message;
         await conversationDb.updateConversationTitle(conversation.id, placeholderTitle);
 
-        // Generate proper AI title for non-command messages (fire-and-forget, overwrites placeholder)
+        // Generate proper AI title for non-command messages (fire-and-forget, overwrites placeholder).
+        // Resolve the `small` tier (config tiers + per-user prefs) instead of the raw
+        // assistant default — the config-default Codex model may not be usable on the
+        // active account (e.g. ChatGPT-plan accounts, #1855). Both calls never throw.
         if (!message.startsWith('/')) {
-          void generateAndSetTitle(
-            conversation.id,
-            message,
-            conversation.ai_assistant_type,
-            getArchonWorkspacesPath()
+          void resolveTitleRequest(conversation.ai_assistant_type, userId).then(titleRequest =>
+            generateAndSetTitle(
+              conversation.id,
+              message,
+              titleRequest.provider,
+              getArchonWorkspacesPath(),
+              undefined,
+              titleRequest.options.assistantConfig,
+              titleRequest.options
+            )
           );
         }
 
@@ -3057,12 +3066,18 @@ export function registerApiRoutes(
         }
         webAdapter.setConversationDbId(conversationId, conv.id);
         if (!conv.title) {
-          void generateAndSetTitle(
-            conv.id,
-            message,
-            conv.ai_assistant_type,
-            getArchonWorkspacesPath(),
-            workflowName
+          // Resolve the `small` tier (config tiers + per-user prefs) instead of the raw
+          // assistant default (#1855). Both calls never throw.
+          void resolveTitleRequest(conv.ai_assistant_type, userId).then(titleRequest =>
+            generateAndSetTitle(
+              conv.id,
+              message,
+              titleRequest.provider,
+              getArchonWorkspacesPath(),
+              workflowName,
+              titleRequest.options.assistantConfig,
+              titleRequest.options
+            )
           );
         }
       }

--- a/packages/server/src/routes/api.user-ai-prefs.test.ts
+++ b/packages/server/src/routes/api.user-ai-prefs.test.ts
@@ -106,6 +106,7 @@ mock.module('@archon/core', () => ({
   registerRepository: mock(async () => ({ codebaseId: 'x', alreadyExisted: false })),
   ConversationNotFoundError: class ConversationNotFoundError extends Error {},
   generateAndSetTitle: mock(async () => {}),
+  resolveTitleRequest: mock(async () => ({ provider: 'claude', options: {} })),
   isPerUserGitHubEnabled: () => false,
   getArchonWorkspacesPath: () => '/tmp/.archon/workspaces',
   createLogger: noopLogger,

--- a/packages/server/src/routes/api.workflow-runs.test.ts
+++ b/packages/server/src/routes/api.workflow-runs.test.ts
@@ -49,6 +49,10 @@ const mockAddMessage = mock(async () => ({
   created_at: new Date().toISOString(),
 }));
 const mockGenerateAndSetTitle = mock(async () => {});
+const mockResolveTitleRequest = mock(async () => ({
+  provider: 'claude',
+  options: {} as Record<string, unknown>,
+}));
 
 // Type aliases for clarity in tests
 type MockWorkflowRun = {
@@ -90,6 +94,7 @@ mock.module('@archon/core', () => ({
   },
   getArchonWorkspacesPath: () => '/tmp/.archon/workspaces',
   generateAndSetTitle: mockGenerateAndSetTitle,
+  resolveTitleRequest: mockResolveTitleRequest,
   createLogger: () => ({
     fatal: mock(() => undefined),
     error: mock(() => undefined),


### PR DESCRIPTION
## Summary

- Problem: on ChatGPT-plan Codex accounts, every conversation title generated from the two server entry points (`POST /api/conversations` create-with-message and web `workflow run`) 400s — the calls pass no model, so the Codex provider falls through to the config-default `gpt-5.3-codex`, which those accounts cannot use.
- Why it matters: titles permanently degrade to truncated message text and an alarming provider-level 400 is logged on every conversation/workflow start.
- What changed: new `resolveTitleRequest(fallbackProvider, userId?)` in the orchestrator resolves the `small` tier (config tiers + per-user prefs when a userId is available, same seam as the #1873 chat-path fix) into provider + fully resolved `SendQueryOptions`; both api.ts call sites now route through it. The helper never throws — on any failure it degrades to the legacy bare request.
- What did **not** change (scope boundary): the orchestrator chat path keeps its inline resolution (reuses already-loaded config/profile); `TITLE_GENERATION_MODEL` remains an operator override inside `generateAndSetTitle`; the CLI title call site (resolves its own assistant type) and the per-user credential env bag for these fire-and-forget sites (#1984 family) are untouched.

## UX Journey

### Before

```
  User                     Archon server                       Codex (ChatGPT plan)
  ────                     ─────────────                       ────────────────────
  new conversation ──────▶ POST /api/conversations
                           generateAndSetTitle(no model)
                           provider falls back to
                           assistants.codex.model ───────────▶ gpt-5.3-codex → 400
                           title.generate_empty / turn_failed
  sees truncated text ◀─── fallback: truncateMessage(msg)
```

### After

```
  User                     Archon server                       Codex (ChatGPT plan)
  ────                     ─────────────                       ────────────────────
  new conversation ──────▶ POST /api/conversations
                           [resolveTitleRequest: small tier
                            = config tiers + user prefs
                            → e.g. gpt-5.5 / effort minimal]
                           generateAndSetTitle(resolved) ────▶ *supported model → 200*
  sees AI title ◀───────── clean 3-6 word title saved
```

## Architecture Diagram

### Before

```
server/routes/api.ts ──(bare call: provider only)──▶ core/services/title-generator
core/orchestrator/orchestrator-agent ──(resolved small tier)──▶ core/services/title-generator
core/orchestrator/orchestrator-agent ──▶ workflows/model-validation (buildAiProfile/tiers)
```

### After

```
server/routes/api.ts ===(resolveTitleRequest)===▶ core/orchestrator/orchestrator-agent [~]
server/routes/api.ts ──(resolved provider+options)──▶ core/services/title-generator
core/orchestrator/orchestrator-agent ──(resolved small tier)──▶ core/services/title-generator (unchanged)
core/orchestrator/orchestrator-agent ──▶ workflows/model-validation (unchanged)
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `server/routes/api.ts` | `core/orchestrator/orchestrator-agent` (`resolveTitleRequest`) | **new** | via `@archon/core` index export |
| `server/routes/api.ts` | `core/services/title-generator` | **modified** | now passes resolved provider + options |
| `core/orchestrator/orchestrator-agent` | `workflows/model-validation` | unchanged | reuses existing `resolveModelRequest` / preset helpers |
| `core/orchestrator/orchestrator-agent` | `core/db/user-ai-prefs-store` | unchanged | reuses `resolveUserAiPrefsForChat` (never throws) |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `server`
- Module: `core:orchestrator`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi`

## Linked Issue

- Closes #1855
- Related #1873, #1984, #1998

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # exit 0 — bundled/skill/schema/pi-vendor-map/capability-matrix checks,
                   # type-check, lint, format:check, and all package tests green
bun test src/orchestrator/orchestrator-agent.test.ts          # 207 pass (7 new resolveTitleRequest tests)
bun test src/routes/api.conversations.test.ts                 # 23 pass (1 new forwarding test)
bun test src/routes/api.workflow-runs.test.ts                 # 86 pass
```

- Evidence provided (test/log/trace/screenshot): unit tests above; new tests cover built-in codex small tier (gpt-5.5 + `modelReasoningEffort: minimal`), configured-tier override with provider switch, per-user tier/default-provider participation, prefs skipped without userId, invalid stored prefs degrading to config-only, and the never-throws fallback.
- If any command is intentionally skipped, explain why: no live ChatGPT-plan Codex account available in this environment — the 400-repro itself is validated by the issue evidence; resolution logic is covered by tests.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: n/a

## Compatibility / Migration

- Backward compatible? Yes — with no tiers/prefs configured, the resolved request equals the built-in small-tier default; `TITLE_GENERATION_MODEL` still overrides; any resolution failure reproduces the previous bare-call behavior exactly.
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: traced both entry points (create-with-message sets a placeholder title, and web workflow run dispatches a `/workflow`-prefixed message — so the orchestrator's already-fixed title path never fires for either; these two sites are the only remaining bare callers on the server).
- Edge cases checked: mocked-out `loadConfig` returning `{}` in server tests (outer catch → legacy fallback); `mockReset` interplay in `api.workflow-runs.test.ts` (default `resolveTitleRequest` mock impl is never reset).
- What was not verified: a live title generation against a real ChatGPT-plan Codex account.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: web conversation creation and web workflow-run title generation only; chat-path and CLI title generation untouched.
- Potential unintended effects: installs that configured `assistants.codex.model` expecting titles to use it will now get the small tier instead (that is the intent — matches the chat path since #1873); the title call now runs `loadConfig()` + a prefs lookup per generation (fire-and-forget, negligible).
- Guardrails/monitoring for early detection: `orchestrator.title_request_resolve_failed` / `orchestrator.title_prefs_invalid` warns; existing `title.generate_*` logs.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge-commit>` — single self-contained commit.
- Feature flags or config toggles (if any): `TITLE_GENERATION_MODEL` env var still force-overrides the model; configuring `tiers.small` steers resolution without code changes.
- Observable failure symptoms: recurring provider 400s on conversation start, titles falling back to truncated message text (`title.generate_empty`).

## Risks and Mitigations

- Risk: a user's configured `small` tier points at a model their account cannot run — the 400 noise would persist for them.
  - Mitigation: tier is user-controllable (`archon ai tier set small …`), and the residual provider-level `turn_failed` log for genuinely failing title turns is deferred (scoping provider log levels to the title path would require widening the provider contract — noted in #1855 as the option-3 remainder).