### PR TITLE
fix(cli): stop workflow approve from marking paused runs failed on process exit

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -162,6 +162,7 @@ mock.module('@archon/core/db/messages', () => ({
 
 mock.module('@archon/core/db/workflows', () => ({
   getActiveWorkflowRun: mock(() => Promise.resolve(null)),
+  getWorkflowRunStatus: mock(() => Promise.resolve(null)),
   failWorkflowRun: mock(() => Promise.resolve()),
   cancelWorkflowRun: mock(() => Promise.resolve({ cancelled: true })),
   findResumableRun: mock(() => Promise.resolve(null)),
@@ -4350,14 +4351,29 @@ describe('workflowRunCommand — progress rendering', () => {
     expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
   });
 
-  it('should not subscribe to emitter when quiet', async () => {
+  it('should subscribe (for run-id tracking) but not render when quiet', async () => {
     setupWorkflowMocks();
+
+    const { executeWorkflow } = require('@archon/workflows/executor');
+    (executeWorkflow as ReturnType<typeof mock>).mockImplementationOnce(async () => {
+      if (capturedSubscribeHandler) {
+        capturedSubscribeHandler({
+          type: 'node_started',
+          runId: 'run-1',
+          nodeId: 'classify',
+          nodeName: 'classify',
+        });
+      }
+      return { success: true, workflowRunId: 'run-1' };
+    });
 
     await workflowRunCommand('/test/path', 'plan', 'hello', { quiet: true });
 
-    // quiet = true skips subscription entirely
-    expect(capturedSubscribeHandler).toBeNull();
-    expect(mockUnsubscribe).not.toHaveBeenCalled();
+    // quiet still subscribes — the handler tracks the owned run id for the
+    // signal cleanup guard (#1123) — but renders no progress output.
+    expect(capturedSubscribeHandler).not.toBeNull();
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(stderrSpy).not.toHaveBeenCalledWith('[classify] Started\n');
   });
 
   it('should call unsubscribe after executeWorkflow completes', async () => {
@@ -4653,6 +4669,194 @@ describe('workflowRunCommand — progress rendering', () => {
     await workflowRunCommand('/test/path', 'plan', 'hello', {});
 
     expect(stderrSpy).toHaveBeenCalledWith('[slow] Completed (1m30s)\n');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Signal cleanup guard (#1123) — SIGTERM/SIGINT handlers must be run-scoped,
+// status-guarded, and removed once executeWorkflow settles.
+// ---------------------------------------------------------------------------
+
+describe('workflowRunCommand — signal cleanup guard (#1123)', () => {
+  let consoleSpy: ReturnType<typeof spyOn>;
+  let stderrSpy: ReturnType<typeof spyOn>;
+  let exitSpy: ReturnType<typeof spyOn>;
+
+  function setupWorkflowMocks(): void {
+    const discoverMock = require('@archon/workflows/workflow-discovery')
+      .discoverWorkflowsWithConfig as ReturnType<typeof mock>;
+    discoverMock.mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'plan', description: 'Plan work' })],
+      errors: [],
+    });
+
+    const conversationDb = require('@archon/core/db/conversations');
+    (conversationDb.getOrCreateConversation as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'conv-1',
+      platform: 'cli',
+      platform_conversation_id: 'cli-123',
+      title: null,
+      is_active: true,
+      codebase_id: null,
+    });
+
+    const codebaseDb = require('@archon/core/db/codebases');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'cb-1',
+      name: 'test-repo',
+      default_cwd: '/test/path',
+    });
+  }
+
+  /** Flush the cleanup handler's fire-and-forget promise chain. */
+  async function settleCleanup(): Promise<void> {
+    for (let i = 0; i < 5; i++) {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    }
+  }
+
+  /** The SIGTERM listeners added since `baseline` (i.e. by the command under test). */
+  function addedSigtermListeners(baseline: readonly unknown[]): Array<() => void> {
+    return process.listeners('SIGTERM').filter(listener => !baseline.includes(listener)) as Array<
+      () => void
+    >;
+  }
+
+  beforeEach(() => {
+    consoleSpy = spyOn(console, 'log').mockImplementation(() => {});
+    stderrSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+    // The cleanup chain ends in process.exit(1) — neuter it so invoking the
+    // handler in-process doesn't kill the test runner.
+    exitSpy = spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+    capturedSubscribeHandler = null;
+    mockUnsubscribe.mockClear();
+
+    const workflowsDb = require('@archon/core/db/workflows');
+    (workflowsDb.failWorkflowRun as ReturnType<typeof mock>).mockClear();
+    (workflowsDb.getActiveWorkflowRun as ReturnType<typeof mock>).mockClear();
+    (workflowsDb.getWorkflowRunStatus as ReturnType<typeof mock>).mockReset();
+    (workflowsDb.getWorkflowRunStatus as ReturnType<typeof mock>).mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('removes SIGTERM/SIGINT handlers once executeWorkflow settles (no leak, no stacking)', async () => {
+    const sigtermBaseline = process.listenerCount('SIGTERM');
+    const sigintBaseline = process.listenerCount('SIGINT');
+
+    let duringRunSigterm = 0;
+    const { executeWorkflow } = require('@archon/workflows/executor');
+    (executeWorkflow as ReturnType<typeof mock>).mockImplementation(async () => {
+      duringRunSigterm = process.listenerCount('SIGTERM');
+      return { success: true, workflowRunId: 'run-1' };
+    });
+
+    setupWorkflowMocks();
+    await workflowRunCommand('/test/path', 'plan', 'hello', {});
+    expect(duringRunSigterm).toBe(sigtermBaseline + 1);
+    expect(process.listenerCount('SIGTERM')).toBe(sigtermBaseline);
+    expect(process.listenerCount('SIGINT')).toBe(sigintBaseline);
+
+    // A second invocation in the same process must not stack handlers either.
+    setupWorkflowMocks();
+    await workflowRunCommand('/test/path', 'plan', 'hello', {});
+    expect(duringRunSigterm).toBe(sigtermBaseline + 1);
+    expect(process.listenerCount('SIGTERM')).toBe(sigtermBaseline);
+    expect(process.listenerCount('SIGINT')).toBe(sigintBaseline);
+
+    (executeWorkflow as ReturnType<typeof mock>).mockImplementation(() =>
+      Promise.resolve({ success: true, workflowRunId: 'test-run-id' })
+    );
+  });
+
+  it('does not fail the run when it is paused at a new gate at signal time', async () => {
+    const workflowsDb = require('@archon/core/db/workflows');
+    // The run this process drives has committed its pause at the next gate.
+    (workflowsDb.getWorkflowRunStatus as ReturnType<typeof mock>).mockResolvedValue('paused');
+
+    const sigtermBefore = process.listeners('SIGTERM');
+    const { executeWorkflow } = require('@archon/workflows/executor');
+    (executeWorkflow as ReturnType<typeof mock>).mockImplementationOnce(async () => {
+      // The executor announced the run this process owns…
+      capturedSubscribeHandler?.({
+        type: 'workflow_started',
+        runId: 'run-1',
+        workflowName: 'plan',
+        conversationId: 'conv-1',
+      });
+      // …then the signal lands while the handler is still registered.
+      const [handler] = addedSigtermListeners(sigtermBefore);
+      expect(handler).toBeDefined();
+      handler();
+      await settleCleanup();
+      return { success: true, workflowRunId: 'run-1', paused: true };
+    });
+
+    setupWorkflowMocks();
+    await workflowRunCommand('/test/path', 'plan', 'hello', {});
+
+    // Paused-at-gate is an external transition the signal handler must respect.
+    expect(workflowsDb.failWorkflowRun).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('still fails the run on a genuine mid-run interrupt (legacy behavior)', async () => {
+    const workflowsDb = require('@archon/core/db/workflows');
+    (workflowsDb.getWorkflowRunStatus as ReturnType<typeof mock>).mockResolvedValue('running');
+
+    const sigtermBefore = process.listeners('SIGTERM');
+    const { executeWorkflow } = require('@archon/workflows/executor');
+    (executeWorkflow as ReturnType<typeof mock>).mockImplementationOnce(async () => {
+      capturedSubscribeHandler?.({
+        type: 'workflow_started',
+        runId: 'run-1',
+        workflowName: 'plan',
+        conversationId: 'conv-1',
+      });
+      const [handler] = addedSigtermListeners(sigtermBefore);
+      expect(handler).toBeDefined();
+      handler();
+      await settleCleanup();
+      return { success: false, workflowRunId: 'run-1', error: 'interrupted' };
+    });
+
+    setupWorkflowMocks();
+    await expect(workflowRunCommand('/test/path', 'plan', 'hello', {})).rejects.toThrow(
+      'Workflow failed'
+    );
+
+    expect(workflowsDb.failWorkflowRun).toHaveBeenCalledWith(
+      'run-1',
+      'Process terminated (SIGTERM)'
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('never touches a run it does not own (no owned run id at signal time)', async () => {
+    const workflowsDb = require('@archon/core/db/workflows');
+
+    const sigtermBefore = process.listeners('SIGTERM');
+    const { executeWorkflow } = require('@archon/workflows/executor');
+    (executeWorkflow as ReturnType<typeof mock>).mockImplementationOnce(async () => {
+      // No workflow_started yet — this process owns no run. Another process's
+      // run on the same conversation must never be failed by this handler.
+      const [handler] = addedSigtermListeners(sigtermBefore);
+      expect(handler).toBeDefined();
+      handler();
+      await settleCleanup();
+      return { success: true, workflowRunId: 'run-1' };
+    });
+
+    setupWorkflowMocks();
+    await workflowRunCommand('/test/path', 'plan', 'hello', {});
+
+    expect(workflowsDb.failWorkflowRun).not.toHaveBeenCalled();
+    expect(workflowsDb.getActiveWorkflowRun).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 });
 

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1465,20 +1465,53 @@ export async function workflowRunCommand(
     }
   })();
 
-  // Register cleanup handlers for graceful termination
+  // Register cleanup handlers for graceful termination.
+  //
+  // Guard rails (#1123): a signal must only ever fail THE run this process is
+  // driving, and only while that run is still 'running'. The run id is learned
+  // from the resumable lookup (resume path) or the workflow_started emitter
+  // event (fresh runs, see the subscription below) — never from a
+  // conversation-wide "active run" query, which can match a run driven by
+  // another process (children share parent_conversation_id). When the run has
+  // already transitioned elsewhere — paused at a gate, completed, cancelled —
+  // the handler leaves it alone; see "No Autonomous Lifecycle Mutation Across
+  // Process Boundaries" in CLAUDE.md. The handlers themselves are removed in
+  // the finally below once executeWorkflow returns, so a late signal can never
+  // touch a settled run (and repeated workflowRunCommand calls in one process
+  // don't stack handlers).
+  let ownedRunId: string | undefined = resumable?.id;
   let terminating = false;
   const cleanup = (signal: string): void => {
     if (terminating) return;
     terminating = true;
     getLog().info({ conversationId: conversation.id, signal }, 'workflow.process_terminating');
-    workflowDb
-      .getActiveWorkflowRun(conversation.id)
-      .then(activeRun => {
-        if (activeRun) {
-          return workflowDb.failWorkflowRun(activeRun.id, `Process terminated (${signal})`);
-        }
-        return undefined;
-      })
+    const interruptedRunId = ownedRunId;
+    (async (): Promise<void> => {
+      if (!interruptedRunId) {
+        // Signal before this process created/resumed a run — nothing it owns.
+        // A pre-created 'pending' row is covered by the stale-pending hygiene.
+        getLog().info(
+          { conversationId: conversation.id, signal },
+          'workflow.termination_no_owned_run'
+        );
+        return;
+      }
+      const status = await workflowDb.getWorkflowRunStatus(interruptedRunId);
+      if (status !== 'running') {
+        // Externally transitioned (paused at a new gate, completed, cancelled,
+        // failed) — not this handler's to mutate.
+        getLog().info(
+          { runId: interruptedRunId, status, signal },
+          'workflow.termination_skip_not_running'
+        );
+        return;
+      }
+      // Genuine interrupt of the run this process is driving. failWorkflowRun's
+      // own status='running' CAS closes the read-then-write window: if the
+      // executor commits a gate pause between the read above and this write,
+      // the CAS misses and throws (caught below) — the run stays paused.
+      await workflowDb.failWorkflowRun(interruptedRunId, `Process terminated (${signal})`);
+    })()
       .catch((err: unknown) => {
         const e = err as Error;
         getLog().error(
@@ -1507,25 +1540,34 @@ export async function workflowRunCommand(
         process.exit(1);
       });
   };
-  process.once('SIGTERM', () => {
+  const sigtermHandler = (): void => {
     cleanup('SIGTERM');
-  });
-  process.once('SIGINT', () => {
+  };
+  const sigintHandler = (): void => {
     cleanup('SIGINT');
-  });
+  };
+  process.once('SIGTERM', sigtermHandler);
+  process.once('SIGINT', sigintHandler);
 
   // One-time-per-version notice when the workflow uses unconfigured tier keywords.
   await maybePrintTierNotice(workflow, workingCwd, cliUserId, options.quiet);
 
-  // Subscribe to workflow events for progress rendering on stderr.
+  // Subscribe to workflow events: always registered (even with --quiet) because
+  // the handler also learns the run id this process owns — the signal cleanup
+  // guard above needs it for fresh runs, where the id only exists once
+  // executeWorkflow creates the run and emits workflow_started. --quiet only
+  // gates the progress rendering.
   // subscribeForConversation is pure in-memory registration — cannot throw in practice.
   // If that changes, this should be moved inside the try block to prevent blocking executeWorkflow.
   const { quiet, verbose } = options;
-  const unsubscribe = quiet
-    ? undefined
-    : getWorkflowEventEmitter().subscribeForConversation(conversationId, event => {
-        renderWorkflowEvent(event, verbose ?? false);
-      });
+  const unsubscribe = getWorkflowEventEmitter().subscribeForConversation(conversationId, event => {
+    if (event.type === 'workflow_started' && ownedRunId === undefined) {
+      ownedRunId = event.runId;
+    }
+    if (!quiet) {
+      renderWorkflowEvent(event, verbose ?? false);
+    }
+  });
 
   // Notify Web UI that a workflow is dispatching.
   // Mirrors the orchestrator dispatch message structure (category/segment/workflowDispatch),
@@ -1621,7 +1663,16 @@ export async function workflowRunCommand(
       opts
     );
   } finally {
-    unsubscribe?.();
+    unsubscribe();
+
+    // Deregister the signal handlers now that the run's lifecycle is settled
+    // (paused / completed / failed, or the throw propagating out of this
+    // finally). A signal from here on gets default handling — the destructive
+    // failWorkflowRun cleanup must never fire against a settled run (#1123),
+    // and removal keeps repeated workflowRunCommand calls in one process from
+    // stacking handlers.
+    process.off('SIGTERM', sigtermHandler);
+    process.off('SIGINT', sigintHandler);
 
     // Container teardown (Phase C) — in `finally` so a throw from executeWorkflow
     // BEFORE its own try/catch (malformed config, env resolvers, unknown provider)

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -15128,3 +15128,191 @@ describe('executeDagWorkflow -- container write-back gate', () => {
     expect(store.completeWorkflowRun).not.toHaveBeenCalled();
   });
 });
+
+describe('executeDagWorkflow -- gate pause vs external transition (#1123)', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = join(
+      tmpdir(),
+      `dag-pause-race-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    await mkdir(join(testDir, '.archon', 'commands'), { recursive: true });
+    mockSendQueryDag.mockClear();
+    mockGetAgentProviderDag.mockClear();
+    mockGetAgentProviderDag.mockImplementation(() => ({
+      sendQuery: mockSendQueryDag,
+      getType: () => 'claude',
+      getCapabilities: mockClaudeCapabilities,
+    }));
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(testDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  /** Store whose pauseWorkflowRun loses the CAS: the run was externally
+   *  transitioned (e.g. a killed CLI's signal cleanup marked it failed) in the
+   *  window between gate raise and pause commit. getWorkflowRunStatus reports
+   *  'running' until the pause attempt, then the external 'failed'. */
+  function createExternallyFailedStore(): IWorkflowStore {
+    const store = createMockStore();
+    let pauseAttempted = false;
+    store.pauseWorkflowRun = mock(() => {
+      pauseAttempted = true;
+      return Promise.reject(
+        new Error('Workflow run not found or not in running state (id: dag-test-run-id)')
+      );
+    });
+    store.getWorkflowRunStatus = mock(() =>
+      Promise.resolve(pauseAttempted ? ('failed' as const) : ('running' as const))
+    );
+    return store;
+  }
+
+  it('approval gate that loses the pause CAS to an external transition halts cleanly', async () => {
+    const store = createExternallyFailedStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    const emitted: string[] = [];
+    const unsubscribe = getWorkflowEventEmitter().subscribe((event: WorkflowEmitterEvent) => {
+      if ('runId' in event && event.runId === workflowRun.id) emitted.push(event.type);
+    });
+
+    try {
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-pause-race',
+        testDir,
+        {
+          name: 'pause-race-approval',
+          nodes: [{ id: 'review', approval: { message: 'Approve this plan?' } }],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+    } finally {
+      unsubscribe();
+    }
+
+    // The gate never actually paused — no approval_pending signal to live UIs.
+    expect(emitted).not.toContain('approval_pending');
+
+    // The lost CAS must NOT cascade into a node failure or any terminal write —
+    // the external transition owns the run's final state.
+    const events = (store.createWorkflowEvent as Mock<() => Promise<void>>).mock.calls.map(
+      (c: unknown[]) => (c[0] as { event_type: string }).event_type
+    );
+    expect(events).not.toContain('node_failed');
+    expect(store.failWorkflowRun).not.toHaveBeenCalled();
+    expect(store.completeWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  it('interactive loop gate that loses the pause CAS halts cleanly', async () => {
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'Here is the plan. Please review.' };
+      yield { type: 'result', sessionId: 'loop-session-race' };
+    });
+
+    const store = createExternallyFailedStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    const emitted: string[] = [];
+    const unsubscribe = getWorkflowEventEmitter().subscribe((event: WorkflowEmitterEvent) => {
+      if ('runId' in event && event.runId === workflowRun.id) emitted.push(event.type);
+    });
+
+    try {
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-pause-race-loop',
+        testDir,
+        {
+          name: 'pause-race-loop',
+          nodes: [
+            {
+              id: 'refine',
+              loop: {
+                prompt: 'User said: $LOOP_USER_INPUT. Refine the plan.',
+                until: 'APPROVED',
+                max_iterations: 10,
+                interactive: true,
+                gate_message: 'Review the plan and provide feedback.',
+              },
+            },
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+    } finally {
+      unsubscribe();
+    }
+
+    expect(emitted).not.toContain('approval_pending');
+    const events = (store.createWorkflowEvent as Mock<() => Promise<void>>).mock.calls.map(
+      (c: unknown[]) => (c[0] as { event_type: string }).event_type
+    );
+    expect(events).not.toContain('node_failed');
+    expect(store.failWorkflowRun).not.toHaveBeenCalled();
+    expect(store.completeWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  it('gate pause failure with the run still running stays a genuine node failure', async () => {
+    const store = createMockStore();
+    // Pause fails but the run is still 'running' (default mock) — a real store
+    // failure, not an external transition. Legacy behavior must hold: the node
+    // fails and the run is marked failed.
+    store.pauseWorkflowRun = mock(() => Promise.reject(new Error('database connection lost')));
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-pause-genuine-failure',
+      testDir,
+      {
+        name: 'pause-genuine-failure',
+        nodes: [{ id: 'review', approval: { message: 'Approve this plan?' } }],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const events = (store.createWorkflowEvent as Mock<() => Promise<void>>).mock.calls.map(
+      (c: unknown[]) => (c[0] as { event_type: string }).event_type
+    );
+    expect(events).toContain('node_failed');
+    expect(store.failWorkflowRun).toHaveBeenCalled();
+  });
+});

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -50,6 +50,7 @@ import type {
   SandboxSettings,
   WorkflowSource,
   LoopGateRunMetadata,
+  ApprovalContext,
 } from './schemas';
 import {
   isBashNode,
@@ -3421,7 +3422,7 @@ async function executeLoopGroupNode(
         .catch((err: Error) => {
           logEventStoreError(err, i);
         });
-      await deps.store.pauseWorkflowRun(workflowRun.id, {
+      const gatePaused = await pauseGateRespectingExternalTransition(deps, workflowRun.id, {
         nodeId: node.id,
         message: honestMessage,
         type: 'interactive_loop',
@@ -3440,12 +3441,14 @@ async function executeLoopGroupNode(
         completionSignaled: completionDetected,
         signaledOutput: completionDetected ? lastIterationOutput : null,
       });
-      getWorkflowEventEmitter().emit({
-        type: 'approval_pending',
-        runId: workflowRun.id,
-        nodeId: node.id,
-        message: honestMessage,
-      });
+      if (gatePaused) {
+        getWorkflowEventEmitter().emit({
+          type: 'approval_pending',
+          runId: workflowRun.id,
+          nodeId: node.id,
+          message: honestMessage,
+        });
+      }
       return {
         state: 'completed',
         output: lastIterationOutput,
@@ -4411,7 +4414,7 @@ async function executeLoopNode(
         .catch((err: Error) => {
           logEventStoreError(err, i);
         });
-      await deps.store.pauseWorkflowRun(workflowRun.id, {
+      const gatePaused = await pauseGateRespectingExternalTransition(deps, workflowRun.id, {
         nodeId: node.id,
         message: honestMessage,
         type: 'interactive_loop',
@@ -4425,12 +4428,14 @@ async function executeLoopNode(
         completionSignaled: completionDetected,
         signaledOutput: completionDetected ? lastIterationOutput : null,
       });
-      getWorkflowEventEmitter().emit({
-        type: 'approval_pending',
-        runId: workflowRun.id,
-        nodeId: node.id,
-        message: honestMessage,
-      });
+      if (gatePaused) {
+        getWorkflowEventEmitter().emit({
+          type: 'approval_pending',
+          runId: workflowRun.id,
+          nodeId: node.id,
+          message: honestMessage,
+        });
+      }
       // Return completed — the between-layer status check sees 'paused' and halts cleanly.
       // This mirrors the approval-node pattern, preventing false "DAG nodes failed" warnings
       // in multi-node workflows. Resume correctness relies on the 'paused' DB status, not
@@ -4460,6 +4465,48 @@ async function executeLoopNode(
     ...(loopTotalTokens !== undefined ? { tokens: loopTotalTokens } : {}),
     loopIterations: loop.max_iterations,
   };
+}
+
+/**
+ * Pause the run for a human gate, tolerating a lost CAS when the run was
+ * externally transitioned while the gate was being raised — e.g. a killed CLI's
+ * signal cleanup marked the run failed mid-pause (#1123), or an operator
+ * cancelled it from another surface. `pauseWorkflowRun`'s UPDATE only matches
+ * status='running'; when it misses, re-read the status: any non-running status
+ * means the pause lost a legitimate external race — log and return false so
+ * the caller skips the approval_pending emit and returns its normal
+ * completed-shaped output, letting the between-layer status check halt the DAG
+ * cleanly (the same path a successful pause takes). A store error while the
+ * run is still 'running' is a genuine pause failure and rethrows.
+ *
+ * Deliberately NOT used by the container write-back gate (raiseWriteBackGate),
+ * which must stay fail-closed: a lost pause there may never fall through
+ * toward the apply/teardown path — throwing is the safe behavior, and the H2
+ * teardown-preserve logic keeps the overlay volume for a retry.
+ */
+async function pauseGateRespectingExternalTransition(
+  deps: WorkflowDeps,
+  runId: string,
+  approvalContext: ApprovalContext
+): Promise<boolean> {
+  try {
+    await deps.store.pauseWorkflowRun(runId, approvalContext);
+    return true;
+  } catch (pauseErr) {
+    let status: string | null;
+    try {
+      status = await deps.store.getWorkflowRunStatus(runId);
+    } catch {
+      // Status unknowable — surface the original pause failure.
+      throw pauseErr;
+    }
+    if (status === 'running') throw pauseErr;
+    getLog().warn(
+      { workflowRunId: runId, status, err: pauseErr as Error },
+      'dag.gate_pause_skipped_external_transition'
+    );
+    return false;
+  }
 }
 
 /**
@@ -4645,7 +4692,7 @@ async function executeApprovalNode(
       );
     });
 
-  await deps.store.pauseWorkflowRun(workflowRun.id, {
+  const gatePaused = await pauseGateRespectingExternalTransition(deps, workflowRun.id, {
     message: renderedMessage,
     nodeId: node.id,
     type: 'approval',
@@ -4654,14 +4701,17 @@ async function executeApprovalNode(
     onRejectMaxAttempts: node.approval.on_reject?.max_attempts,
   });
 
-  getWorkflowEventEmitter().emit({
-    type: 'approval_pending',
-    runId: workflowRun.id,
-    nodeId: node.id,
-    message: renderedMessage,
-  });
+  if (gatePaused) {
+    getWorkflowEventEmitter().emit({
+      type: 'approval_pending',
+      runId: workflowRun.id,
+      nodeId: node.id,
+      message: renderedMessage,
+    });
+  }
 
-  // Return completed — the between-layer status check will see 'paused' and break.
+  // Return completed — the between-layer status check will see 'paused' (or the
+  // external transition that beat the pause) and break.
   // On resume, the approve endpoint writes a real node_completed event with the user's response.
   return { state: 'completed' as const, output: '' };
 }

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3422,7 +3422,7 @@ async function executeLoopGroupNode(
         .catch((err: Error) => {
           logEventStoreError(err, i);
         });
-      const gatePaused = await pauseGateRespectingExternalTransition(deps, workflowRun.id, {
+      await pauseGateRespectingExternalTransition(deps, workflowRun.id, {
         nodeId: node.id,
         message: honestMessage,
         type: 'interactive_loop',
@@ -3441,14 +3441,6 @@ async function executeLoopGroupNode(
         completionSignaled: completionDetected,
         signaledOutput: completionDetected ? lastIterationOutput : null,
       });
-      if (gatePaused) {
-        getWorkflowEventEmitter().emit({
-          type: 'approval_pending',
-          runId: workflowRun.id,
-          nodeId: node.id,
-          message: honestMessage,
-        });
-      }
       return {
         state: 'completed',
         output: lastIterationOutput,
@@ -4414,7 +4406,7 @@ async function executeLoopNode(
         .catch((err: Error) => {
           logEventStoreError(err, i);
         });
-      const gatePaused = await pauseGateRespectingExternalTransition(deps, workflowRun.id, {
+      await pauseGateRespectingExternalTransition(deps, workflowRun.id, {
         nodeId: node.id,
         message: honestMessage,
         type: 'interactive_loop',
@@ -4428,14 +4420,6 @@ async function executeLoopNode(
         completionSignaled: completionDetected,
         signaledOutput: completionDetected ? lastIterationOutput : null,
       });
-      if (gatePaused) {
-        getWorkflowEventEmitter().emit({
-          type: 'approval_pending',
-          runId: workflowRun.id,
-          nodeId: node.id,
-          message: honestMessage,
-        });
-      }
       // Return completed — the between-layer status check sees 'paused' and halts cleanly.
       // This mirrors the approval-node pattern, preventing false "DAG nodes failed" warnings
       // in multi-node workflows. Resume correctness relies on the 'paused' DB status, not
@@ -4473,11 +4457,13 @@ async function executeLoopNode(
  * signal cleanup marked the run failed mid-pause (#1123), or an operator
  * cancelled it from another surface. `pauseWorkflowRun`'s UPDATE only matches
  * status='running'; when it misses, re-read the status: any non-running status
- * means the pause lost a legitimate external race — log and return false so
- * the caller skips the approval_pending emit and returns its normal
- * completed-shaped output, letting the between-layer status check halt the DAG
- * cleanly (the same path a successful pause takes). A store error while the
- * run is still 'running' is a genuine pause failure and rethrows.
+ * means the pause lost a legitimate external race — log, skip the
+ * approval_pending emit, and return so the caller's normal completed-shaped
+ * output lets the between-layer status check halt the DAG cleanly (the same
+ * path a successful pause takes). On a successful pause, the approval_pending
+ * live signal is emitted HERE (from the ApprovalContext's own nodeId/message)
+ * so no call site can accidentally emit it after a lost CAS. A store error
+ * while the run is still 'running' is a genuine pause failure and rethrows.
  *
  * Deliberately NOT used by the container write-back gate (raiseWriteBackGate),
  * which must stay fail-closed: a lost pause there may never fall through
@@ -4488,10 +4474,9 @@ async function pauseGateRespectingExternalTransition(
   deps: WorkflowDeps,
   runId: string,
   approvalContext: ApprovalContext
-): Promise<boolean> {
+): Promise<void> {
   try {
     await deps.store.pauseWorkflowRun(runId, approvalContext);
-    return true;
   } catch (pauseErr) {
     let status: string | null;
     try {
@@ -4505,8 +4490,14 @@ async function pauseGateRespectingExternalTransition(
       { workflowRunId: runId, status, err: pauseErr as Error },
       'dag.gate_pause_skipped_external_transition'
     );
-    return false;
+    return;
   }
+  getWorkflowEventEmitter().emit({
+    type: 'approval_pending',
+    runId,
+    nodeId: approvalContext.nodeId,
+    message: approvalContext.message,
+  });
 }
 
 /**
@@ -4692,7 +4683,7 @@ async function executeApprovalNode(
       );
     });
 
-  const gatePaused = await pauseGateRespectingExternalTransition(deps, workflowRun.id, {
+  await pauseGateRespectingExternalTransition(deps, workflowRun.id, {
     message: renderedMessage,
     nodeId: node.id,
     type: 'approval',
@@ -4700,15 +4691,6 @@ async function executeApprovalNode(
     onRejectPrompt: node.approval.on_reject?.prompt,
     onRejectMaxAttempts: node.approval.on_reject?.max_attempts,
   });
-
-  if (gatePaused) {
-    getWorkflowEventEmitter().emit({
-      type: 'approval_pending',
-      runId: workflowRun.id,
-      nodeId: node.id,
-      message: renderedMessage,
-    });
-  }
 
   // Return completed — the between-layer status check will see 'paused' (or the
   // external transition that beat the pause) and break.


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: `archon workflow approve` (and reject/resume) auto-resumes inline through `workflowRunCommand`, which registers anonymous, unremovable SIGTERM/SIGINT handlers. A signal could destructively `failWorkflowRun` a run that had legitimately transitioned elsewhere — paused at the next gate, completed, or driven by another process (the cleanup targeted a conversation-wide `getActiveWorkflowRun`, which also matches children via `parent_conversation_id`). Handlers also stacked across repeated `workflowRunCommand` calls in one process and hijacked the exit path after a successful pause. (#1123)
- Why it matters: destructive mutation of non-terminal run state owned by an unknowable party violates the "No Autonomous Lifecycle Mutation Across Process Boundaries" principle; multi-gate approve flows ended up `failed` instead of `paused`, wedging subsequent approves.
- What changed: the signal cleanup is now run-scoped and status-guarded — it only ever fails THE run this process started/resumed (id preset from the resumable lookup on resume; learned from the `workflow_started` emitter event for fresh runs), and only while that run is still `running` (with `failWorkflowRun`'s own `status='running'` CAS closing the remaining read-then-write window). Handlers are named and deregistered in the `finally` once `executeWorkflow` settles. In the engine, the three human-gate pause sites (approval / loop / loop_group) tolerate losing the pause CAS to an external transition: log + skip the `approval_pending` emit + let the between-layer status check halt cleanly, instead of cascading into a spurious node failure.
- What did **not** change (scope boundary): the `--json` approve path (documented workaround — records the approval, never auto-resumes) is untouched; the gate-resolution CAS from #2146 and the paused-staging semantics from #2112 are untouched (the pause-success path is byte-identical); the container write-back gate stays deliberately fail-closed (a lost pause there must never fall through toward apply/teardown — H2 teardown-preserve covers retry); genuine mid-run interrupts still mark the run failed.

## UX Journey

### Before

```
  User                        CLI (approve)                      DB
  ────                        ─────────────                      ──
  workflow approve <id> ────▶ records approval
                              auto-resumes inline
                              registers anon SIGTERM/SIGINT
                              executeWorkflow …
                              pauses at NEXT gate ─────────────▶ status: paused
                              (handlers still live)
  [signal / Ctrl-C] ────────▶ cleanup: getActiveWorkflowRun(conv)
                              → can fail ANOTHER process's run ─▶ *status: failed*
                              process.exit(1) even on success
  workflow approve <id> ────▶ "Cannot approve run…" ✗
```

### After

```
  User                        CLI (approve)                      DB
  ────                        ─────────────                      ──
  workflow approve <id> ────▶ records approval
                              auto-resumes inline
                              registers NAMED handlers,
                              tracks [ownedRunId]
                              executeWorkflow …
                              pauses at NEXT gate ─────────────▶ status: paused
                              [finally: process.off both]
  [signal / Ctrl-C] ────────▶ default handling — run untouched ─▶ status: paused ✓
  workflow approve <id> ────▶ next gate approves normally ✓

  (mid-run signal, run still 'running' and owned → still fails it: legacy kept)
```

## Architecture Diagram

### Before

```
workflowApproveCommand ──▶ workflowRunCommand ──▶ executeWorkflow ──▶ executeDagWorkflow
                              │ process.once(anon)                        │ pauseWorkflowRun
                              ▼                                           │  (throws on lost CAS →
                           cleanup ──▶ getActiveWorkflowRun(conv)         ▼   node_failed cascade)
                                   ──▶ failWorkflowRun(any active run)  core db (CAS)
```

### After

```
workflowApproveCommand ──▶ workflowRunCommand ──▶ executeWorkflow ──▶ executeDagWorkflow
                              │ [~] process.once(named)                   │ [~] pauseGateRespecting-
                              │ [~] finally: process.off                  │     ExternalTransition
                              │ === emitter workflow_started              │     (lost CAS → log, skip
                              ▼     tracks ownedRunId                     ▼      emit, clean halt)
                           cleanup ──▶ getWorkflowRunStatus(ownedRunId) core db (CAS, unchanged)
                                   ──▶ failWorkflowRun(ownedRunId) only while 'running'
                                   --x-- getActiveWorkflowRun(conv)  (removed)
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| cli:workflowRunCommand cleanup | core/db/workflows.getActiveWorkflowRun | **removed** | conversation-wide query could hit another process's run |
| cli:workflowRunCommand cleanup | core/db/workflows.getWorkflowRunStatus | **new** | status guard before the destructive write |
| cli:workflowRunCommand cleanup | core/db/workflows.failWorkflowRun | **modified** | now run-scoped (ownedRunId) + status-guarded |
| cli:workflowRunCommand | workflows:event-emitter.subscribeForConversation | **modified** | subscription now unconditional (was skipped with --quiet); tracks ownedRunId, quiet still gates rendering |
| cli:workflowRunCommand | process signal handlers | **modified** | named handlers, `process.off` in finally |
| workflows:dag-executor gates | store.pauseWorkflowRun | **modified** | wrapped by `pauseGateRespectingExternalTransition` (approval/loop/loop_group); write-back gate unchanged |
| workflows:dag-executor gates | store.getWorkflowRunStatus | **new** | only on a lost pause CAS, to classify the failure |

## Label Snapshot

- Risk: `risk: medium`
- Size: `size: M`
- Scope: `cli`, `workflows`
- Module: `cli:workflow`, `workflows:dag-executor`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi`

## Linked Issue

- Closes #1123
- Related #2112, #2146 (gate semantics this change preserves), #1305 (closed batch PR whose approach this adapts to current dev)

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # all nine checks green
```

- Evidence provided (test/log/trace/screenshot): 4 new CLI tests (`workflowRunCommand — signal cleanup guard (#1123)`): handler removal/no stacking across two invocations, paused-at-new-gate at signal time → no `failWorkflowRun`, genuine mid-run interrupt → `failWorkflowRun('run-1', 'Process terminated (SIGTERM)')`, unowned run never touched. 3 new engine tests (`executeDagWorkflow -- gate pause vs external transition (#1123)`): approval + interactive-loop gates losing the pause CAS halt cleanly (no `node_failed`, no `approval_pending`, no terminal write), and a pause failure with the run still `running` remains a genuine node failure. Full suites: 187 pass (cli/workflow.test.ts), 410 pass (workflows/dag-executor.test.ts).
- If any command is intentionally skipped, explain why: none skipped.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation: n/a

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: n/a

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: traced every signal/pause interleaving against the CAS guards in `core/db/workflows.ts` (`getActiveWorkflowRun` filters `status='running'`; `failWorkflowRun`/`pauseWorkflowRun` CAS on `status='running'`), confirming the DB end-state is consistent in all orders and the guard only changes who is allowed to write.
- Edge cases checked: signal before the run exists (no owned id → no mutation; orphaned `pending` rows are covered by the existing stale-pending hygiene); resume path presets the owned id before `executeWorkflow` (a pre-resume signal sees `paused` and skips); `--quiet` still tracks the run id; second `workflowRunCommand` in one process leaves listener counts at baseline.
- What was not verified: a live multi-gate approve flow against a real DB with an OS-delivered signal (the race windows are not deterministically reproducible live — that is what the unit tests simulate).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: CLI `workflow run/approve/reject/resume` signal handling; engine approval/loop/loop_group gate pause path.
- Potential unintended effects: a signal arriving during the post-run container teardown now gets default handling (previously the cleanup handler also ran); containers remain labeled and reclaimable via `isolation cleanup` / `docker ps --filter label=diy.archon.managed=true`. With `--quiet` an emitter subscription now exists where none did (in-memory only).
- Guardrails/monitoring for early detection: new structured logs `workflow.termination_no_owned_run`, `workflow.termination_skip_not_running`, `dag.gate_pause_skipped_external_transition` make every skipped destructive write observable.

## Rollback Plan (required)

- Fast rollback command/path: `git revert 00c495a2` — single commit, no schema or config coupling.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: runs stuck `running` after a CLI kill (guard too conservative), or paused runs flipping to `failed` on exit (guard ineffective); both visible in `workflow runs` and the logs above.

## Risks and Mitigations

- Risk: the run-scoped guard skips failing a genuinely-interrupted run if the signal lands before `workflow_started` reaches the subscription (sub-millisecond window), leaving it `running`.
  - Mitigation: deliberate trade per the no-autonomous-mutation principle — never guess ownership; the run stays visible in `workflow runs` for a one-command `abandon`, and pre-create `pending` rows are already handled by stale-pending hygiene.
- Risk: regressing #2112/#2146 gate semantics.
  - Mitigation: the pause-success path is byte-identical (same call, same ApprovalContext, same emit); the helper only changes the lost-CAS path; full approval/loop/loop_group/persist-session test suites pass unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow interruption handling to prevent unrelated or already-transitioned runs from being changed.
  * Prevented duplicate signal handlers and ensured cleanup after workflow execution.
  * Quiet mode now suppresses progress output while preserving reliable workflow tracking.
  * Improved handling of approval and interactive gates when a workflow changes state during pausing.
  * Prevented misleading pending or failure events during external workflow transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->