### PR TITLE
fix(core): respect worktree.enabled: false in dispatchBackgroundWorkflow

### DIFF
--- a/packages/core/src/orchestrator/orchestrator-isolation.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-isolation.test.ts
@@ -3,6 +3,10 @@ import { createMockLogger } from '../test/mocks/logger';
 import { MockPlatformAdapter } from '../test/mocks/platform';
 import type { Conversation, Codebase } from '../types';
 import type { IsolationEnvironmentRow } from '@archon/isolation';
+// Type-only imports are erased at runtime, so these do not load './orchestrator'
+// (or the workflow engine) before the mock.module() calls below take effect.
+import type { WorkflowRoutingContext } from './orchestrator';
+import type { WorkflowDefinition } from '@archon/workflows/schemas/workflow';
 
 // ─── Mock setup (BEFORE importing module under test) ─────────────────────────
 
@@ -22,15 +26,17 @@ mock.module('@archon/paths', () => ({
 
 // DB mocks
 const mockUpdateConversation = mock(() => Promise.resolve());
+const mockGetOrCreateConversation = mock((): Promise<Conversation | null> => Promise.resolve(null));
 mock.module('../db/conversations', () => ({
-  getOrCreateConversation: mock(() => Promise.resolve(null)),
+  getOrCreateConversation: mockGetOrCreateConversation,
   getConversationByPlatformId: mock(() => Promise.resolve(null)),
   updateConversation: mockUpdateConversation,
   touchConversation: mock(() => Promise.resolve()),
 }));
 
+const mockGetCodebase = mock((): Promise<Codebase | null> => Promise.resolve(null));
 mock.module('../db/codebases', () => ({
-  getCodebase: mock(() => Promise.resolve(null)),
+  getCodebase: mockGetCodebase,
   listCodebases: mock(() => Promise.resolve([])),
   createCodebase: mock(() => Promise.resolve({ id: 'new-codebase-id' })),
 }));
@@ -72,9 +78,10 @@ mock.module('@archon/providers', () => ({
   PI_AMBIENT_VENDORS: ['amazon-bedrock', 'google-vertex'],
 }));
 
+const mockCreateWorkflowRun = mock(() => Promise.resolve({ id: 'run-1' }));
 mock.module('../workflows/store-adapter', () => ({
   createWorkflowDeps: mock(() => ({
-    store: {},
+    store: { createWorkflowRun: mockCreateWorkflowRun },
     getAgentProvider: () => ({}),
     loadConfig: async () => ({}),
   })),
@@ -130,8 +137,11 @@ mock.module('../utils/error-formatter', () => ({
 mock.module('@archon/workflows/workflow-discovery', () => ({
   discoverWorkflowsWithConfig: mock(() => Promise.resolve({ workflows: [], errors: [] })),
 }));
+// Resolves to a paused result so dispatchBackgroundWorkflow's fire-and-forget
+// tail is a no-op (no result card is surfaced to the parent conversation).
+const mockExecuteWorkflow = mock(() => Promise.resolve({ paused: true }));
 mock.module('@archon/workflows/executor', () => ({
-  executeWorkflow: mock(() => Promise.resolve()),
+  executeWorkflow: mockExecuteWorkflow,
 }));
 mock.module('@archon/workflows/router', () => ({
   findWorkflow: mock(() => undefined),
@@ -157,7 +167,7 @@ mock.module('../services/title-generator', () => ({
 
 // ─── Import module under test AFTER all mocks ────────────────────────────────
 
-const { validateAndResolveIsolation } = await import('./orchestrator');
+const { validateAndResolveIsolation, dispatchBackgroundWorkflow } = await import('./orchestrator');
 
 // ─── Test helpers ────────────────────────────────────────────────────────────
 
@@ -292,5 +302,95 @@ describe('validateAndResolveIsolation', () => {
       codebase: { defaultBranch?: string | null };
     };
     expect(request.codebase.defaultBranch).toBeNull();
+  });
+});
+
+describe('dispatchBackgroundWorkflow', () => {
+  let platform: MockPlatformAdapter;
+
+  function makeWorkflow(overrides?: Partial<WorkflowDefinition>): WorkflowDefinition {
+    return {
+      name: 'bg-workflow',
+      description: 'background dispatch test workflow',
+      nodes: [],
+      ...overrides,
+    } as WorkflowDefinition;
+  }
+
+  function makeRoutingCtx(): WorkflowRoutingContext {
+    return {
+      platform,
+      conversationId: 'parent-conv',
+      cwd: '/parent/cwd',
+      originalMessage: 'run it',
+      conversationDbId: 'parent-db-id',
+      codebaseId: 'cb-1',
+      availableWorkflows: [],
+    };
+  }
+
+  /** Let the fire-and-forget execution tail settle before the test ends. */
+  async function flushBackgroundExecution(): Promise<void> {
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
+
+  beforeEach(() => {
+    platform = new MockPlatformAdapter();
+    mockResolve.mockClear();
+    mockUpdateConversation.mockClear();
+    mockCreateWorkflowRun.mockClear();
+    mockLogger.info.mockClear();
+    mockGetOrCreateConversation.mockResolvedValue(
+      makeConversation({ id: 'worker-conv-1', platform_conversation_id: 'web-worker-1' })
+    );
+    mockGetCodebase.mockResolvedValue(makeCodebase());
+  });
+
+  test('worktree.enabled: false skips isolation and runs in the parent cwd', async () => {
+    const workflow = makeWorkflow({ worktree: { enabled: false } });
+
+    await dispatchBackgroundWorkflow(makeRoutingCtx(), workflow);
+
+    // Policy opt-out: no isolation resolution attempted at all.
+    expect(mockResolve).not.toHaveBeenCalled();
+    // The run executes in the parent conversation's cwd (live checkout).
+    expect(mockCreateWorkflowRun).toHaveBeenCalledTimes(1);
+    const runRow = mockCreateWorkflowRun.mock.calls[0]?.[0] as unknown as {
+      working_path: string;
+    };
+    expect(runRow.working_path).toBe('/parent/cwd');
+    // Operators can distinguish live-checkout runs from worktree runs in logs.
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { workflowName: 'bg-workflow', conversationId: 'parent-conv', codebaseId: 'cb-1' },
+      'workflow.worktree_disabled_by_policy'
+    );
+
+    await flushBackgroundExecution();
+  });
+
+  test('default policy still resolves isolation for the worker', async () => {
+    const workflow = makeWorkflow();
+    mockResolve.mockResolvedValueOnce({
+      status: 'resolved',
+      env: makeEnvRow({ working_path: '/worktrees/bg-1', branch_name: 'bg-1' }),
+      cwd: '/worktrees/bg-1',
+      method: { type: 'created' },
+    });
+
+    await dispatchBackgroundWorkflow(makeRoutingCtx(), workflow);
+
+    // Without an explicit opt-out, the worker gets its own isolation environment.
+    expect(mockResolve).toHaveBeenCalledTimes(1);
+    expect(mockCreateWorkflowRun).toHaveBeenCalledTimes(1);
+    const runRow = mockCreateWorkflowRun.mock.calls[0]?.[0] as unknown as {
+      working_path: string;
+    };
+    expect(runRow.working_path).toBe('/worktrees/bg-1');
+    expect(mockLogger.info).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'workflow.worktree_disabled_by_policy'
+    );
+
+    await flushBackgroundExecution();
   });
 });

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -318,8 +318,9 @@ export async function dispatchBackgroundWorkflow(
     hidden: true,
   });
 
-  // 3. Resolve isolation for this worker (each background workflow gets its own worktree).
-  // Isolation failure is fatal — never run a workflow in a shared/parent worktree.
+  // 3. Resolve isolation for this worker. Unless the workflow explicitly opts out of
+  // worktrees, each background workflow gets its own worktree — and isolation failure
+  // is then fatal (never fall back to running in a shared/parent worktree).
   let workerCwd: string;
   let codebaseBaseBranch: string | undefined;
   if (ctx.codebaseId) {
@@ -330,22 +331,35 @@ export async function dispatchBackgroundWorkflow(
       );
     }
     codebaseBaseBranch = codebase.default_branch?.trim() || undefined;
-    const result = await validateAndResolveIsolation(
-      workerConv,
-      codebase,
-      ctx.platform,
-      workerPlatformId,
-      { workflowType: 'thread', workflowId: workerPlatformId },
-      false,
-      ctx.userId
-    );
-    workerCwd = result.cwd;
-    await db.updateConversation(workerConv.id, { cwd: workerCwd }).catch((e: unknown) => {
-      getLog().warn(
-        { err: toError(e), workerPlatformId },
-        'orchestrator.worker_cwd_persist_failed'
+    if (workflow.worktree?.enabled === false) {
+      // Respect an explicit worktree opt-out: skip isolation and run in the parent's cwd.
+      getLog().info(
+        {
+          workflowName: workflow.name,
+          conversationId: ctx.conversationId,
+          codebaseId: ctx.codebaseId,
+        },
+        'workflow.worktree_disabled_by_policy'
       );
-    });
+      workerCwd = ctx.cwd;
+    } else {
+      const result = await validateAndResolveIsolation(
+        workerConv,
+        codebase,
+        ctx.platform,
+        workerPlatformId,
+        { workflowType: 'thread', workflowId: workerPlatformId },
+        false,
+        ctx.userId
+      );
+      workerCwd = result.cwd;
+      await db.updateConversation(workerConv.id, { cwd: workerCwd }).catch((e: unknown) => {
+        getLog().warn(
+          { err: toError(e), workerPlatformId },
+          'orchestrator.worker_cwd_persist_failed'
+        );
+      });
+    }
   } else {
     // No codebase — run in parent's cwd (no isolation needed for non-repo workflows)
     workerCwd = ctx.cwd;


### PR DESCRIPTION
## Summary

- Problem: `dispatchBackgroundWorkflow` (the WebUI background-dispatch path) unconditionally called `validateAndResolveIsolation` whenever the conversation had a codebase, so a workflow declaring `worktree.enabled: false` still tried to create a worktree — and failed outright for local-path-only codebases (#1368).
- Why it matters: any worktree-opt-out workflow triggered from the WebUI failed, while the identical workflow ran fine from the CLI (`--no-worktree` / `pinnedEnabled`) and from the foreground chat path (`orchestrator-agent.ts`), which both already honor the policy.
- What changed: the background-dispatch path now mirrors those guards — on `worktree.enabled: false` it skips isolation entirely, runs the worker in the parent conversation's cwd, and emits the same `workflow.worktree_disabled_by_policy` Pino event the foreground path emits, so operators can distinguish live-checkout runs from worktree runs. The codebase row is still fetched first, so the codebase-not-found error and the `$BASE_BRANCH` fallback (`default_branch`) behave exactly like the foreground/CLI paths.
- What did **not** change (scope boundary): no changes to the CLI or foreground guards, the isolation resolver, the worktree default for workflows without an explicit opt-out, or the no-codebase dispatch branch. This intentionally carries only the orchestrator portion of #1369.

## UX Journey

### Before

```
  User (WebUI)             Archon orchestrator                Isolation
  ────────────             ───────────────────                ─────────
  runs workflow with
  worktree.enabled: false ─▶ dispatchBackgroundWorkflow
                             codebaseId set? yes
                             validateAndResolveIsolation ────▶ tries to create worktree
  sees failure ◀──────────── ENOENT / worktree creation error
```

### After

```
  User (WebUI)             Archon orchestrator                Isolation
  ────────────             ───────────────────                ─────────
  runs workflow with
  worktree.enabled: false ─▶ dispatchBackgroundWorkflow
                             codebaseId set? yes
                             [worktree.enabled === false?]
                               yes ─▶ *skip isolation*
                                      log worktree_disabled_by_policy
                                      workerCwd = parent cwd
  sees run execute ◀───────── workflow runs in live checkout
                               no ──▶ validateAndResolveIsolation (unchanged)
```

## Architecture Diagram

### Before

```
  web adapter ──▶ orchestrator.dispatchBackgroundWorkflow ──▶ validateAndResolveIsolation ──▶ @archon/isolation
                        │                                            (always when codebaseId set)
                        └──▶ @archon/workflows executeWorkflow
```

### After

```
  web adapter ──▶ orchestrator.dispatchBackgroundWorkflow [~] ──▶ validateAndResolveIsolation ──▶ @archon/isolation
                        │        (skipped when workflow.worktree.enabled === false)
                        └──▶ @archon/workflows executeWorkflow
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| orchestrator.dispatchBackgroundWorkflow | validateAndResolveIsolation | **modified** | now conditional on `workflow.worktree?.enabled !== false` |
| orchestrator.dispatchBackgroundWorkflow | db/codebases.getCodebase | unchanged | still fetched (not-found error + `$BASE_BRANCH` fallback) |
| orchestrator.dispatchBackgroundWorkflow | @archon/workflows executeWorkflow | unchanged | receives live-checkout cwd on opt-out |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`
- Module: `core:orchestrator`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #1368
- Supersedes #1369 (orchestrator portion only — that PR bundled six unrelated concerns; the headline fix is carried here, written against current `dev`, with credit to @StuartJAtkinson via a `Co-authored-by` trailer on the commit)

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # exit 0 — bundled/schema/vendor-map/capability-matrix checks, type-check, lint, format, all tests green
bun test packages/core/src/orchestrator/orchestrator-isolation.test.ts   # 6 pass, 0 fail
```

- Evidence provided: new `describe('dispatchBackgroundWorkflow')` regression tests in `orchestrator-isolation.test.ts` (its own `bun test` invocation in the @archon/core batch split — no mock.module conflicts). With the guard reverted, the opt-out case fails at `expect(mockResolve).not.toHaveBeenCalled()` (isolation was resolved anyway) — confirming it locks in the fix; the default-policy case passes before and after, confirming no regression to the worktree default.
- If any command is intentionally skipped, explain why: none skipped.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No — the opt-out runs in the parent conversation's cwd, the same directory the CLI `--no-worktree` and foreground paths already use for this policy.

## Compatibility / Migration

- Backward compatible? Yes — workflows without `worktree.enabled: false` behave exactly as before.
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: ran the target test file in both states — guard present (6 pass) and guard reverted (opt-out case fails, proving the regression test bites); full `bun run validate` green.
- Edge cases checked: default-policy dispatch still resolves isolation and uses the resolved worktree cwd for the run row; opt-out still errors on a missing codebase row; no-codebase dispatch branch untouched.
- What was not verified: a live WebUI end-to-end run on a local-path-only codebase (the exact Windows ENOENT repro from #1368 requires a Windows host).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: WebUI/background workflow dispatch only (`dispatchBackgroundWorkflow`); CLI and foreground chat dispatch untouched.
- Potential unintended effects: workflows that declared `worktree.enabled: false` but were silently getting worktrees from the WebUI now run in the live checkout — that is the declared policy taking effect, and it matches existing CLI/foreground behavior.
- Guardrails/monitoring for early detection: the `workflow.worktree_disabled_by_policy` info event marks every opt-out dispatch in Pino logs.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge-commit>` — single self-contained commit (one guard + tests).
- Feature flags or config toggles (if any): none; removing `worktree.enabled: false` from a workflow YAML restores worktree isolation per workflow.
- Observable failure symptoms: opt-out workflows failing again from the WebUI with worktree-creation errors, or runs unexpectedly executing in the live checkout without the policy log event.

## Risks and Mitigations

- Risk: an opt-out workflow now writes to the live checkout instead of a throwaway worktree when dispatched from the WebUI.
  - Mitigation: this is the documented semantics of `worktree.enabled: false` (identical to CLI `--no-worktree` and the foreground path); the policy log event makes each such run auditable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background workflows can now explicitly disable worktree isolation and run in the parent conversation’s working directory.
  * By default, background workflows continue to receive their own isolated worktree.

* **Bug Fixes**
  * Improved background workflow handling to ensure the correct working directory is used based on worktree settings.
  * Added coverage for isolated and non-isolated workflow execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->