### PR TITLE
docs(direction): deployment recipes live in docs, not maintained profiles

### DIFF
--- a/.archon/maintainer-standup/direction.md
+++ b/.archon/maintainer-standup/direction.md
@@ -26,6 +26,7 @@ This file is **committed and shared by all maintainers**. Edit deliberately — 
 - **Not a general-purpose chat UI.** Adapters are conversation surfaces for *workflow execution*, not standalone chat experiences.
 - **Not a replacement for the AI coding agent itself.** Archon orchestrates Claude Code / Codex / Pi — it doesn't reimplement them.
 - **Not opinionated about the dev environment.** No mandatory editor integrations, framework lock-in, or Docker requirement beyond what users opt into.
+- **Not a deployment-infrastructure product.** Caddy is the single maintained reference reverse proxy (`--profile cloud`). Alternative proxies and infra recipes (Traefik, Nginx, k8s, ...) live in **docs** as community-maintained examples against the documented proxy contract (exposed port, health endpoint, `/internal/*` never proxied — see #2193), not as compose profiles Archon maintains: each maintained proxy config doubles a security-critical surface. Cite as `direction.md §deployment-recipes`.
 - **Not a programming language.** The workflow YAML coordinates (gates, joins, retries, sessions, artifacts, reusable structure); `bash:`/`script:` nodes compute; prompts judge. PRs that add computation to the YAML surface conflict — see §workflow-language.
 
 ## Community providers


### PR DESCRIPTION
## Summary

Adds a citable direction clause (`direction.md §deployment-recipes`) recording the call forced by #1224: Archon is not a deployment-infrastructure product. Caddy remains the single maintained reference reverse proxy; alternative proxies and infra recipes (Traefik, Nginx, k8s, …) are welcomed as **docs** examples against the documented proxy contract (#2193) rather than as compose profiles Archon maintains — every maintained proxy config doubles a security-critical surface (the proxy is the access boundary and must drop `/internal/*`).

## Changes

- One line added to the "What Archon is NOT" section of `.archon/maintainer-standup/direction.md`

## Testing

- [x] Docs-only change; no code paths affected

## Related

- #1224 (closed citing this clause)
- #2193 (the proxy-contract docs page this clause points at)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that Archon is not a deployment-infrastructure product.
  * Identified Caddy as the maintained reference reverse proxy for cloud deployments.
  * Documented that other proxy and infrastructure recipes are community-maintained examples.
  * Added proxy requirements, including the rule that `internal/*` paths must never be proxied.
  * Added a reference to the deployment guidance in the project direction documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->