### PR TITLE
feat(cli): extend --detach to workflow approve/reject/resume control verbs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,7 @@ The rules `--help` will not tell you:
 - Isolation is the default for `workflow run` — it creates a worktree unless you pass `--no-worktree` or `--folder`.
 - `--json` is supported on the read/write subcommands (`list`, `status`, `runs`, `get`, `approve`, `reject`, `abandon`, `resume`). On `approve`/`reject`/`resume` it records the decision and returns an ack **without** the inline auto-resume, leaving the run resumable — drive continuation separately.
 - `--detach` works on `approve`/`reject`/`resume` as well as `run`. Adding it INVERTS the `--json` rule above: the parent validates the run read-only and refuses synchronously, then spawns a child without `--json`, so the child takes the inline path and DOES continue the run. The ack carries `continues: true` so an automation knows it no longer owns continuation.
+- When you already hold a run id, recover with `workflow resume <run-id> --detach`, not `workflow run <name> --resume --detach`. The name form selects the newest resumable run of that workflow **in the current checkout**, so it finds nothing from another worktree and expresses less than the id you already have (#2645).
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,7 @@ The rules `--help` will not tell you:
 - Workflow and isolation commands must run inside a git repository; subdirectories resolve to the repo root. `--folder` is the escape hatch for a non-git directory.
 - Isolation is the default for `workflow run` — it creates a worktree unless you pass `--no-worktree` or `--folder`.
 - `--json` is supported on the read/write subcommands (`list`, `status`, `runs`, `get`, `approve`, `reject`, `abandon`, `resume`). On `approve`/`reject`/`resume` it records the decision and returns an ack **without** the inline auto-resume, leaving the run resumable — drive continuation separately.
+- `--detach` works on `approve`/`reject`/`resume` as well as `run`. Adding it INVERTS the `--json` rule above: the parent validates the run read-only and refuses synchronously, then spawns a child without `--json`, so the child takes the inline path and DOES continue the run. The ack carries `continues: true` so an automation knows it no longer owns continuation.
 
 ## Architecture
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -171,7 +171,7 @@ Options:
   --verbose, -v              Show debug-level output
   --json                     Output machine-readable JSON (list/status/get/runs/approve/reject/abandon/resume)
   --events                   For verbose JSON status/get: output raw event rows instead of node summaries
-  --detach                   Run 'workflow run' in a detached background child (returns immediately)
+  --detach                   Run 'workflow run'/'approve'/'reject'/'resume' in a detached background child (returns immediately)
   --all                      For 'workflow runs': list across all projects (ignore cwd scope)
   --status <status>          For 'workflow runs': filter to one status (running, completed, failed, ...)
   --limit <n>                For 'workflow runs': max rows (default 20)
@@ -679,7 +679,7 @@ async function main(): Promise<number> {
               console.error('Usage: archon workflow resume <run-id>');
               return 1;
             }
-            await workflowResumeCommand(resumeRunId, jsonFlag, effectiveCwd);
+            await workflowResumeCommand(resumeRunId, jsonFlag, effectiveCwd, detachFlag);
             break;
           }
 
@@ -706,7 +706,13 @@ async function main(): Promise<number> {
             const rawApproveComment =
               (values.comment as string | undefined) || positionals.slice(3).join(' ');
             const approveComment = rawApproveComment.length > 0 ? rawApproveComment : undefined;
-            await workflowApproveCommand(approveRunId, approveComment, jsonFlag, effectiveCwd);
+            await workflowApproveCommand(
+              approveRunId,
+              approveComment,
+              jsonFlag,
+              effectiveCwd,
+              detachFlag
+            );
             break;
           }
 
@@ -719,7 +725,13 @@ async function main(): Promise<number> {
             const rawRejectReason =
               (values.reason as string | undefined) || positionals.slice(3).join(' ');
             const rejectReason = rawRejectReason.length > 0 ? rawRejectReason : undefined;
-            await workflowRejectCommand(rejectRunId, rejectReason, jsonFlag, effectiveCwd);
+            await workflowRejectCommand(
+              rejectRunId,
+              rejectReason,
+              jsonFlag,
+              effectiveCwd,
+              detachFlag
+            );
             break;
           }
 

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -5049,6 +5049,44 @@ describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand
     expect(parsed).toMatchObject({ ok: true, detached: true, continues: true });
   });
 
+  it('threads a caller-supplied --cwd to the child instead of the parent process.cwd()', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const paths = await import('@archon/paths');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({ ...pausedRun });
+    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
+      throw new Error('no home in test');
+    });
+    const spawnSpy = mockSpawn();
+    const savedArgv = process.argv;
+    process.argv = [
+      'bun',
+      '/abs/cli.ts',
+      'workflow',
+      'approve',
+      'run-123',
+      '--cwd',
+      '/caller/repo',
+      '--detach',
+    ];
+
+    let spawnCmd: string[] = [];
+    let spawnOptions: { cwd: string; cmd: string[] } | undefined;
+    try {
+      await workflowApproveCommand('run-123', undefined, undefined, '/caller/repo', true);
+      spawnOptions = spawnSpy.mock.calls[0]?.[0] as { cwd: string; cmd: string[] } | undefined;
+      spawnCmd = (spawnOptions?.cmd ?? []).slice();
+    } finally {
+      process.argv = savedArgv;
+      spawnSpy.mockRestore();
+    }
+
+    expect(spawnOptions?.cwd).toBe('/caller/repo');
+    // buildDetachedRunCmd appends --cwd LAST (parser is last-wins), so the
+    // appended value is what the child actually resolves.
+    const lastCwdIdx = spawnCmd.lastIndexOf('--cwd');
+    expect(spawnCmd[lastCwdIdx + 1]).toBe('/caller/repo');
+  });
+
   it('approve --detach refuses a non-paused run synchronously and spawns nothing', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
     (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -284,6 +284,51 @@ function firstJsonPayload(spy: ReturnType<typeof spyOn>): string {
   return ((spy.mock.calls[0]?.[0] as string) ?? '').trimEnd();
 }
 
+/**
+ * Stand-in for the child `spawnDetachedWorkflowRun` starts. `node:child_process`'s
+ * spawn routes through `Bun.spawn` under Bun, so spying on `Bun.spawn` intercepts it
+ * and Bun wraps this object into the ChildProcess whose events the startup window
+ * listens on. Shared by both detach suites — `run` and the control verbs.
+ */
+function createDetachedChildFixture(pid: number | null = 12345): {
+  child: ReturnType<typeof Bun.spawn>;
+  unref: ReturnType<typeof mock>;
+} {
+  const unref = mock(() => undefined);
+  const child = {
+    pid: pid ?? undefined,
+    unref,
+  };
+
+  return {
+    child: child as unknown as ReturnType<typeof Bun.spawn>,
+    unref,
+  };
+}
+
+/**
+ * Drive a detach command past `waitForDetachedStartup` (#2279). The command awaits a
+ * 500 ms window in which a dying child would reject, so a test that never advances
+ * the fake timer hangs — and one that never awaits the command silently skips the
+ * window altogether. Both suites go through here so neither can pass by accident.
+ */
+async function finishStartupWindow(
+  commandPromise: Promise<void>,
+  spawnSpy: ReturnType<typeof spyOn>,
+  expectedSpawnCount = 1
+): Promise<void> {
+  for (
+    let attempt = 0;
+    attempt < 20 && spawnSpy.mock.calls.length < expectedSpawnCount;
+    attempt++
+  ) {
+    await Promise.resolve();
+  }
+  expect(spawnSpy).toHaveBeenCalledTimes(expectedSpawnCount);
+  jest.advanceTimersByTime(500);
+  await commandPromise;
+}
+
 describe('workflowListCommand', () => {
   let consoleSpy: ReturnType<typeof spyOn>;
   let stdoutSpy: ReturnType<typeof spyOn>;
@@ -4524,39 +4569,6 @@ describe('workflowRunCommand — detach', () => {
   let consoleSpy: ReturnType<typeof spyOn>;
   let stdoutSpy: ReturnType<typeof spyOn>;
 
-  function createDetachedChildFixture(pid: number | null = 12345): {
-    child: ReturnType<typeof Bun.spawn>;
-    unref: ReturnType<typeof mock>;
-  } {
-    const unref = mock(() => undefined);
-    const child = {
-      pid: pid ?? undefined,
-      unref,
-    };
-
-    return {
-      child: child as unknown as ReturnType<typeof Bun.spawn>,
-      unref,
-    };
-  }
-
-  async function finishStartupWindow(
-    commandPromise: Promise<void>,
-    spawnSpy: ReturnType<typeof spyOn>,
-    expectedSpawnCount = 1
-  ): Promise<void> {
-    for (
-      let attempt = 0;
-      attempt < 20 && spawnSpy.mock.calls.length < expectedSpawnCount;
-      attempt++
-    ) {
-      await Promise.resolve();
-    }
-    expect(spawnSpy).toHaveBeenCalledTimes(expectedSpawnCount);
-    jest.advanceTimersByTime(500);
-    await commandPromise;
-  }
-
   beforeEach(() => {
     jest.useFakeTimers();
     consoleSpy = spyOn(console, 'log').mockImplementation(() => {});
@@ -4908,13 +4920,21 @@ describe('workflowRunCommand — detach', () => {
 
 describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand — detach', () => {
   let consoleSpy: ReturnType<typeof spyOn>;
+  let warnSpy: ReturnType<typeof spyOn>;
+  let stdoutSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
+    jest.useFakeTimers();
     consoleSpy = spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    stdoutSpy = spyOnJsonStdout();
   });
 
   afterEach(() => {
+    jest.useRealTimers();
     consoleSpy.mockRestore();
+    warnSpy.mockRestore();
+    stdoutSpy.mockRestore();
   });
 
   // working_path is deliberately a distro-style path: the child must spawn with
@@ -4930,40 +4950,41 @@ describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand
     metadata: { approval: { nodeId: 'gate', message: 'Approve?' } },
   };
 
-  // Mirrors the run-detach tests: pid is required (spawnDetachedWorkflowRun
-  // throws when child.pid === undefined), and node:child_process.spawn routes
-  // through Bun.spawn so spying on Bun.spawn intercepts it.
-  const mockSpawn = () =>
-    spyOn(Bun, 'spawn').mockReturnValue({
-      pid: 12345,
-      unref: mock(() => undefined),
-    } as unknown as ReturnType<typeof Bun.spawn>);
+  /** Suppress the log file so the test writes nothing to disk (logPath becomes null). */
+  const silenceLogFile = async (): Promise<void> => {
+    const paths = await import('@archon/paths');
+    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
+      throw new Error('no home in test');
+    });
+  };
 
   it('approve --detach spawns a detached child (minus --detach) and performs ZERO writes in the parent', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
     const { executeWorkflow } = await import('@archon/workflows/executor');
-    const paths = await import('@archon/paths');
     (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({ ...pausedRun });
-    // Force the log-file path to fall back to 'ignore' so the test writes no files
-    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
-      throw new Error('no home in test');
-    });
+    await silenceLogFile();
 
     const updateBefore = (workflowDb.updateWorkflowRun as ReturnType<typeof mock>).mock.calls
       .length;
     const execBefore = (executeWorkflow as ReturnType<typeof mock>).mock.calls.length;
-    const spawnSpy = mockSpawn();
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
     const savedArgv = process.argv;
     process.argv = ['bun', '/abs/cli.ts', 'workflow', 'approve', 'run-123', 'ship it', '--detach'];
 
-    let spawnCallCount = 0;
     let spawnCmd: string[] = [];
     let spawnOptions: { cwd: string; cmd: string[]; detached?: boolean } | undefined;
     try {
       // Signature: (runId, comment, json, cwd, detach) — detach is the 5th arg,
-      // layered after upstream's cwd (the orthogonal-collision the plan warns of).
-      await workflowApproveCommand('run-123', 'ship it', undefined, undefined, true);
-      spawnCallCount = spawnSpy.mock.calls.length;
+      // layered after upstream's cwd.
+      const commandPromise = workflowApproveCommand(
+        'run-123',
+        'ship it',
+        undefined,
+        undefined,
+        true
+      );
+      await finishStartupWindow(commandPromise, spawnSpy);
       spawnOptions = spawnSpy.mock.calls[0]?.[0] as
         | { cwd: string; cmd: string[]; detached?: boolean }
         | undefined;
@@ -4973,7 +4994,6 @@ describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand
       spawnSpy.mockRestore();
     }
 
-    expect(spawnCallCount).toBe(1);
     expect(spawnOptions?.detached).toBe(true);
     expect(spawnCmd).not.toContain('--detach');
     expect(spawnCmd).toContain('approve');
@@ -4988,27 +5008,32 @@ describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand
     );
     expect((executeWorkflow as ReturnType<typeof mock>).mock.calls.length).toBe(execBefore);
     expect(consoleSpy).toHaveBeenCalledWith("Started 'approve' for run run-123 in the background.");
+    // No log file could be opened, so the child's output is discarded — say so.
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Warning: could not open a log file — child output will not be captured.'
+    );
   });
 
-  it('approve --detach --json emits a structured ack without approving', async () => {
+  it('approve --detach --json emits a structured ack on stdout without approving', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
-    const paths = await import('@archon/paths');
     (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({ ...pausedRun });
-    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
-      throw new Error('no home in test');
-    });
-    const spawnSpy = mockSpawn();
+    await silenceLogFile();
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
     const savedArgv = process.argv;
     process.argv = ['bun', '/abs/cli.ts', 'workflow', 'approve', 'run-123', '--detach', '--json'];
 
     try {
-      await workflowApproveCommand('run-123', undefined, true, undefined, true);
+      const commandPromise = workflowApproveCommand('run-123', undefined, true, undefined, true);
+      await finishStartupWindow(commandPromise, spawnSpy);
     } finally {
       process.argv = savedArgv;
       spawnSpy.mockRestore();
     }
 
-    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    // The ack goes through writeJsonLine (flushed stdout), not console.log — a
+    // console.log ack can be truncated on a pipe (#2384).
+    const parsed = JSON.parse(firstJsonPayload(stdoutSpy)) as Record<string, unknown>;
     expect(parsed).toMatchObject({
       ok: true,
       runId: 'run-123',
@@ -5016,22 +5041,24 @@ describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand
       detached: true,
       workflowName: 'assist',
     });
+    // logPath is a path or null — never a serialized Promise, which is what an
+    // un-awaited spawnDetachedWorkflowRun produces ({} through JSON.stringify).
+    expect(parsed.logPath).toBeNull();
   });
 
   it('--detach --json spawns a child WITHOUT --json (so it continues) and says so in the ack', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
-    const paths = await import('@archon/paths');
     (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({ ...pausedRun });
-    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
-      throw new Error('no home in test');
-    });
-    const spawnSpy = mockSpawn();
+    await silenceLogFile();
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
     const savedArgv = process.argv;
     process.argv = ['bun', '/abs/cli.ts', 'workflow', 'approve', 'run-123', '--detach', '--json'];
 
     let spawnCmd: string[] = [];
     try {
-      await workflowApproveCommand('run-123', undefined, true, undefined, true);
+      const commandPromise = workflowApproveCommand('run-123', undefined, true, undefined, true);
+      await finishStartupWindow(commandPromise, spawnSpy);
       spawnCmd = (
         (spawnSpy.mock.calls[0]?.[0] as { cmd: string[] } | undefined)?.cmd ?? []
       ).slice();
@@ -5045,18 +5072,16 @@ describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand
     expect(spawnCmd).not.toContain('--detach');
     expect(spawnCmd).not.toContain('--json');
     // ...so the ack must tell the caller it does NOT own continuation.
-    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    const parsed = JSON.parse(firstJsonPayload(stdoutSpy)) as Record<string, unknown>;
     expect(parsed).toMatchObject({ ok: true, detached: true, continues: true });
   });
 
   it('threads a caller-supplied --cwd to the child instead of the parent process.cwd()', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
-    const paths = await import('@archon/paths');
     (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({ ...pausedRun });
-    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
-      throw new Error('no home in test');
-    });
-    const spawnSpy = mockSpawn();
+    await silenceLogFile();
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
     const savedArgv = process.argv;
     process.argv = [
       'bun',
@@ -5072,7 +5097,14 @@ describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand
     let spawnCmd: string[] = [];
     let spawnOptions: { cwd: string; cmd: string[] } | undefined;
     try {
-      await workflowApproveCommand('run-123', undefined, undefined, '/caller/repo', true);
+      const commandPromise = workflowApproveCommand(
+        'run-123',
+        undefined,
+        undefined,
+        '/caller/repo',
+        true
+      );
+      await finishStartupWindow(commandPromise, spawnSpy);
       spawnOptions = spawnSpy.mock.calls[0]?.[0] as { cwd: string; cmd: string[] } | undefined;
       spawnCmd = (spawnOptions?.cmd ?? []).slice();
     } finally {
@@ -5087,13 +5119,61 @@ describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand
     expect(spawnCmd[lastCwdIdx + 1]).toBe('/caller/repo');
   });
 
+  it('approve --detach rejects an immediate non-zero child exit instead of acking success', async () => {
+    // The parent awaits spawnDetachedWorkflowRun's startup window (#2279). Without
+    // that await the failure arrives as an unhandled rejection AFTER `{ok:true}`
+    // has already been printed — the exact hole --detach exists to close.
+    const workflowDb = await import('@archon/core/db/workflows');
+    const tempHome = mkdtempSync(join(tmpdir(), 'archon-detached-control-failure-'));
+    const logPath = join(tempHome, 'logs', 'detached-run-run-123.log');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({ ...pausedRun });
+    const paths = await import('@archon/paths');
+    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => tempHome);
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
+    const savedArgv = process.argv;
+    process.argv = ['bun', '/abs/cli.ts', 'workflow', 'approve', 'run-123', '--detach', '--json'];
+
+    try {
+      const commandPromise = workflowApproveCommand('run-123', undefined, true, undefined, true);
+      for (let attempt = 0; attempt < 20 && spawnSpy.mock.calls.length === 0; attempt++) {
+        await Promise.resolve();
+      }
+      expect(spawnSpy).toHaveBeenCalledTimes(1);
+      appendFileSync(logPath, 'database unavailable during startup\n');
+      const spawnOptions = spawnSpy.mock.calls[0]?.[0] as
+        | {
+            onExit?: (
+              subprocess: ReturnType<typeof Bun.spawn>,
+              exitCode: number | null,
+              signalCode: number | null,
+              error?: Error
+            ) => void;
+          }
+        | undefined;
+      spawnOptions?.onExit?.(child.child, 1, null);
+      await commandPromise;
+    } finally {
+      process.argv = savedArgv;
+      spawnSpy.mockRestore();
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+
+    // --json turns the throw into the standard { ok: false } line; either way the
+    // caller never sees a success ack for a child that died on startup.
+    const parsed = JSON.parse(firstJsonPayload(stdoutSpy)) as Record<string, unknown>;
+    expect(parsed).toMatchObject({ ok: false, runId: 'run-123', action: 'approve' });
+    expect(String(parsed.error)).toMatch(/exit code 1[\s\S]*database unavailable during startup/);
+  });
+
   it('approve --detach refuses a non-paused run synchronously and spawns nothing', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
     (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
       ...pausedRun,
       status: 'running',
     });
-    const spawnSpy = mockSpawn();
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
 
     let spawnCallCount = -1;
     try {
@@ -5107,6 +5187,29 @@ describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand
     expect(spawnCallCount).toBe(0);
   });
 
+  it('approve --detach --json reports a refusal as { ok: false } and spawns nothing', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      ...pausedRun,
+      status: 'completed',
+    });
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
+
+    let spawnCallCount = -1;
+    try {
+      await workflowApproveCommand('run-123', undefined, true, undefined, true);
+      spawnCallCount = spawnSpy.mock.calls.length;
+    } finally {
+      spawnSpy.mockRestore();
+    }
+
+    expect(spawnCallCount).toBe(0);
+    const parsed = JSON.parse(firstJsonPayload(stdoutSpy)) as Record<string, unknown>;
+    expect(parsed).toMatchObject({ ok: false, runId: 'run-123', action: 'approve' });
+    expect(String(parsed.error)).toContain("Cannot approve run with status 'completed'");
+  });
+
   it('approve --detach refuses a child_workflow-blocked parent and spawns nothing', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
     (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
@@ -5115,7 +5218,8 @@ describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand
         approval: { nodeId: 'sub', message: 'blocked', type: 'child_workflow', childRunId: 'c-9' },
       },
     });
-    const spawnSpy = mockSpawn();
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
     try {
       await expect(
         workflowApproveCommand('run-123', undefined, undefined, undefined, true)
@@ -5132,7 +5236,8 @@ describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand
       ...pausedRun,
       metadata: { approval: { nodeId: 'gate', message: 'Approve?', resolved: 'approved' } },
     });
-    const spawnSpy = mockSpawn();
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
     try {
       await expect(
         workflowApproveCommand('run-123', undefined, undefined, undefined, true)
@@ -5149,7 +5254,8 @@ describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand
       ...pausedRun,
       metadata: {},
     });
-    const spawnSpy = mockSpawn();
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
     try {
       await expect(
         workflowApproveCommand('run-123', undefined, undefined, undefined, true)
@@ -5160,16 +5266,55 @@ describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand
     }
   });
 
+  it('approve --detach refuses a run with no recorded working path and spawns nothing', async () => {
+    // The child always auto-resumes after approving, and a resume needs a working
+    // path. Refuse in the parent rather than letting the child throw into its log.
+    const workflowDb = await import('@archon/core/db/workflows');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      ...pausedRun,
+      working_path: null,
+    });
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
+    try {
+      await expect(
+        workflowApproveCommand('run-123', undefined, undefined, undefined, true)
+      ).rejects.toThrow('has no working path recorded');
+      expect(spawnSpy.mock.calls.length).toBe(0);
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
+  it('resume --detach refuses a run with no recorded working path and spawns nothing', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      ...pausedRun,
+      status: 'failed',
+      working_path: null,
+    });
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
+    try {
+      await expect(workflowResumeCommand('run-123', undefined, undefined, true)).rejects.toThrow(
+        'has no working path recorded'
+      );
+      expect(spawnSpy.mock.calls.length).toBe(0);
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
   it('reject --detach refuses a child_workflow-blocked parent but TOLERATES missing context', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
-    const paths = await import('@archon/paths');
     (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
       ...pausedRun,
       metadata: {
         approval: { nodeId: 'sub', message: 'blocked', type: 'child_workflow', childRunId: 'c-9' },
       },
     });
-    let spawnSpy = mockSpawn();
+    const blockedChild = createDetachedChildFixture();
+    let spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(blockedChild.child);
     try {
       await expect(
         workflowRejectCommand('run-123', undefined, undefined, undefined, true)
@@ -5184,15 +5329,20 @@ describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand
       ...pausedRun,
       metadata: {},
     });
-    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
-      throw new Error('no home in test');
-    });
-    spawnSpy = mockSpawn();
+    await silenceLogFile();
+    const child = createDetachedChildFixture();
+    spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
     const savedArgv = process.argv;
     process.argv = ['bun', '/abs/cli.ts', 'workflow', 'reject', 'run-123', '--detach'];
     try {
-      await workflowRejectCommand('run-123', undefined, undefined, undefined, true);
-      expect(spawnSpy.mock.calls.length).toBe(1);
+      const commandPromise = workflowRejectCommand(
+        'run-123',
+        undefined,
+        undefined,
+        undefined,
+        true
+      );
+      await finishStartupWindow(commandPromise, spawnSpy);
     } finally {
       process.argv = savedArgv;
       spawnSpy.mockRestore();
@@ -5202,24 +5352,27 @@ describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand
   it('reject --detach spawns a detached child (minus --detach) and performs ZERO writes in the parent', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
     const { executeWorkflow } = await import('@archon/workflows/executor');
-    const paths = await import('@archon/paths');
     (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({ ...pausedRun });
-    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
-      throw new Error('no home in test');
-    });
+    await silenceLogFile();
 
     const updateBefore = (workflowDb.updateWorkflowRun as ReturnType<typeof mock>).mock.calls
       .length;
     const execBefore = (executeWorkflow as ReturnType<typeof mock>).mock.calls.length;
-    const spawnSpy = mockSpawn();
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
     const savedArgv = process.argv;
     process.argv = ['bun', '/abs/cli.ts', 'workflow', 'reject', 'run-123', 'not good', '--detach'];
 
-    let spawnCallCount = 0;
     let spawnCmd: string[] = [];
     try {
-      await workflowRejectCommand('run-123', 'not good', undefined, undefined, true);
-      spawnCallCount = spawnSpy.mock.calls.length;
+      const commandPromise = workflowRejectCommand(
+        'run-123',
+        'not good',
+        undefined,
+        undefined,
+        true
+      );
+      await finishStartupWindow(commandPromise, spawnSpy);
       spawnCmd = (
         (spawnSpy.mock.calls[0]?.[0] as { cmd: string[] } | undefined)?.cmd ?? []
       ).slice();
@@ -5228,7 +5381,6 @@ describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand
       spawnSpy.mockRestore();
     }
 
-    expect(spawnCallCount).toBe(1);
     expect(spawnCmd).not.toContain('--detach');
     expect(spawnCmd).toContain('reject');
     expect(spawnCmd).toContain('run-123');
@@ -5242,28 +5394,25 @@ describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand
   it('resume --detach spawns a detached child (minus --detach) and does NOT execute in the parent', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
     const { executeWorkflow } = await import('@archon/workflows/executor');
-    const paths = await import('@archon/paths');
     // resume validates read-only via resumeWorkflowOp, which reads getWorkflowRun;
     // a failed run is resumable.
     (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
       ...pausedRun,
       status: 'failed',
     });
-    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
-      throw new Error('no home in test');
-    });
+    await silenceLogFile();
 
     const execBefore = (executeWorkflow as ReturnType<typeof mock>).mock.calls.length;
-    const spawnSpy = mockSpawn();
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
     const savedArgv = process.argv;
     process.argv = ['bun', '/abs/cli.ts', 'workflow', 'resume', 'run-123', '--detach'];
 
-    let spawnCallCount = 0;
     let spawnCmd: string[] = [];
     try {
       // Signature: (runId, json, cwd, detach) — detach is the 4th arg.
-      await workflowResumeCommand('run-123', undefined, undefined, true);
-      spawnCallCount = spawnSpy.mock.calls.length;
+      const commandPromise = workflowResumeCommand('run-123', undefined, undefined, true);
+      await finishStartupWindow(commandPromise, spawnSpy);
       spawnCmd = (
         (spawnSpy.mock.calls[0]?.[0] as { cmd: string[] } | undefined)?.cmd ?? []
       ).slice();
@@ -5272,7 +5421,6 @@ describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand
       spawnSpy.mockRestore();
     }
 
-    expect(spawnCallCount).toBe(1);
     expect(spawnCmd).not.toContain('--detach');
     expect(spawnCmd).toContain('resume');
     expect(spawnCmd).toContain('run-123');

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -5018,6 +5018,37 @@ describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand
     });
   });
 
+  it('--detach --json spawns a child WITHOUT --json (so it continues) and says so in the ack', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const paths = await import('@archon/paths');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({ ...pausedRun });
+    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
+      throw new Error('no home in test');
+    });
+    const spawnSpy = mockSpawn();
+    const savedArgv = process.argv;
+    process.argv = ['bun', '/abs/cli.ts', 'workflow', 'approve', 'run-123', '--detach', '--json'];
+
+    let spawnCmd: string[] = [];
+    try {
+      await workflowApproveCommand('run-123', undefined, true, undefined, true);
+      spawnCmd = (
+        (spawnSpy.mock.calls[0]?.[0] as { cmd: string[] } | undefined)?.cmd ?? []
+      ).slice();
+    } finally {
+      process.argv = savedArgv;
+      spawnSpy.mockRestore();
+    }
+
+    // Both flags are stripped: the child runs the ordinary inline path, which
+    // auto-resumes. That is deliberate — --detach exists to host that execution.
+    expect(spawnCmd).not.toContain('--detach');
+    expect(spawnCmd).not.toContain('--json');
+    // ...so the ack must tell the caller it does NOT own continuation.
+    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    expect(parsed).toMatchObject({ ok: true, detached: true, continues: true });
+  });
+
   it('approve --detach refuses a non-paused run synchronously and spawns nothing', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
     (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -4906,6 +4906,219 @@ describe('workflowRunCommand — detach', () => {
   });
 });
 
+describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand — detach', () => {
+  let consoleSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  // working_path is deliberately a distro-style path: the child must spawn with
+  // the PARENT's cwd (it re-resolves by run-id), because a container run's
+  // working_path is unreachable on the host and would ENOENT the spawn.
+  const pausedRun = {
+    id: 'run-123',
+    status: 'paused',
+    workflow_name: 'assist',
+    working_path: '/distro/only/path',
+    conversation_id: 'conv-123',
+    user_message: 'hello',
+    metadata: {},
+  };
+
+  // Mirrors the run-detach tests: pid is required (spawnDetachedWorkflowRun
+  // throws when child.pid === undefined), and node:child_process.spawn routes
+  // through Bun.spawn so spying on Bun.spawn intercepts it.
+  const mockSpawn = () =>
+    spyOn(Bun, 'spawn').mockReturnValue({
+      pid: 12345,
+      unref: mock(() => undefined),
+    } as unknown as ReturnType<typeof Bun.spawn>);
+
+  it('approve --detach spawns a detached child (minus --detach) and performs ZERO writes in the parent', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    const paths = await import('@archon/paths');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({ ...pausedRun });
+    // Force the log-file path to fall back to 'ignore' so the test writes no files
+    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
+      throw new Error('no home in test');
+    });
+
+    const updateBefore = (workflowDb.updateWorkflowRun as ReturnType<typeof mock>).mock.calls
+      .length;
+    const execBefore = (executeWorkflow as ReturnType<typeof mock>).mock.calls.length;
+    const spawnSpy = mockSpawn();
+    const savedArgv = process.argv;
+    process.argv = ['bun', '/abs/cli.ts', 'workflow', 'approve', 'run-123', 'ship it', '--detach'];
+
+    let spawnCallCount = 0;
+    let spawnCmd: string[] = [];
+    let spawnOptions: { cwd: string; cmd: string[]; detached?: boolean } | undefined;
+    try {
+      // Signature: (runId, comment, json, cwd, detach) — detach is the 5th arg,
+      // layered after upstream's cwd (the orthogonal-collision the plan warns of).
+      await workflowApproveCommand('run-123', 'ship it', undefined, undefined, true);
+      spawnCallCount = spawnSpy.mock.calls.length;
+      spawnOptions = spawnSpy.mock.calls[0]?.[0] as
+        | { cwd: string; cmd: string[]; detached?: boolean }
+        | undefined;
+      spawnCmd = (spawnOptions?.cmd ?? []).slice();
+    } finally {
+      process.argv = savedArgv;
+      spawnSpy.mockRestore();
+    }
+
+    expect(spawnCallCount).toBe(1);
+    expect(spawnOptions?.detached).toBe(true);
+    expect(spawnCmd).not.toContain('--detach');
+    expect(spawnCmd).toContain('approve');
+    expect(spawnCmd).toContain('run-123');
+    // Parent cwd, never the run's working_path (see pausedRun comment above).
+    expect(spawnOptions?.cwd).toBe(process.cwd());
+    expect(spawnCmd).not.toContain('/distro/only/path');
+    // ZERO state mutation in the detaching parent — the child owns the approve
+    // (a parent-side approve would record the decision twice).
+    expect((workflowDb.updateWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(
+      updateBefore
+    );
+    expect((executeWorkflow as ReturnType<typeof mock>).mock.calls.length).toBe(execBefore);
+    expect(consoleSpy).toHaveBeenCalledWith("Started 'approve' for run run-123 in the background.");
+  });
+
+  it('approve --detach --json emits a structured ack without approving', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const paths = await import('@archon/paths');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({ ...pausedRun });
+    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
+      throw new Error('no home in test');
+    });
+    const spawnSpy = mockSpawn();
+    const savedArgv = process.argv;
+    process.argv = ['bun', '/abs/cli.ts', 'workflow', 'approve', 'run-123', '--detach', '--json'];
+
+    try {
+      await workflowApproveCommand('run-123', undefined, true, undefined, true);
+    } finally {
+      process.argv = savedArgv;
+      spawnSpy.mockRestore();
+    }
+
+    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    expect(parsed).toMatchObject({
+      ok: true,
+      runId: 'run-123',
+      action: 'approve',
+      detached: true,
+      workflowName: 'assist',
+    });
+  });
+
+  it('approve --detach refuses a non-paused run synchronously and spawns nothing', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      ...pausedRun,
+      status: 'running',
+    });
+    const spawnSpy = mockSpawn();
+
+    let spawnCallCount = -1;
+    try {
+      await expect(
+        workflowApproveCommand('run-123', undefined, undefined, undefined, true)
+      ).rejects.toThrow("Cannot approve run with status 'running'");
+      spawnCallCount = spawnSpy.mock.calls.length;
+    } finally {
+      spawnSpy.mockRestore();
+    }
+    expect(spawnCallCount).toBe(0);
+  });
+
+  it('reject --detach spawns a detached child (minus --detach) and performs ZERO writes in the parent', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    const paths = await import('@archon/paths');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({ ...pausedRun });
+    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
+      throw new Error('no home in test');
+    });
+
+    const updateBefore = (workflowDb.updateWorkflowRun as ReturnType<typeof mock>).mock.calls
+      .length;
+    const execBefore = (executeWorkflow as ReturnType<typeof mock>).mock.calls.length;
+    const spawnSpy = mockSpawn();
+    const savedArgv = process.argv;
+    process.argv = ['bun', '/abs/cli.ts', 'workflow', 'reject', 'run-123', 'not good', '--detach'];
+
+    let spawnCallCount = 0;
+    let spawnCmd: string[] = [];
+    try {
+      await workflowRejectCommand('run-123', 'not good', undefined, undefined, true);
+      spawnCallCount = spawnSpy.mock.calls.length;
+      spawnCmd = (
+        (spawnSpy.mock.calls[0]?.[0] as { cmd: string[] } | undefined)?.cmd ?? []
+      ).slice();
+    } finally {
+      process.argv = savedArgv;
+      spawnSpy.mockRestore();
+    }
+
+    expect(spawnCallCount).toBe(1);
+    expect(spawnCmd).not.toContain('--detach');
+    expect(spawnCmd).toContain('reject');
+    expect(spawnCmd).toContain('run-123');
+    expect((workflowDb.updateWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(
+      updateBefore
+    );
+    expect((executeWorkflow as ReturnType<typeof mock>).mock.calls.length).toBe(execBefore);
+    expect(consoleSpy).toHaveBeenCalledWith("Started 'reject' for run run-123 in the background.");
+  });
+
+  it('resume --detach spawns a detached child (minus --detach) and does NOT execute in the parent', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    const paths = await import('@archon/paths');
+    // resume validates read-only via resumeWorkflowOp, which reads getWorkflowRun;
+    // a failed run is resumable.
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      ...pausedRun,
+      status: 'failed',
+    });
+    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
+      throw new Error('no home in test');
+    });
+
+    const execBefore = (executeWorkflow as ReturnType<typeof mock>).mock.calls.length;
+    const spawnSpy = mockSpawn();
+    const savedArgv = process.argv;
+    process.argv = ['bun', '/abs/cli.ts', 'workflow', 'resume', 'run-123', '--detach'];
+
+    let spawnCallCount = 0;
+    let spawnCmd: string[] = [];
+    try {
+      // Signature: (runId, json, cwd, detach) — detach is the 4th arg.
+      await workflowResumeCommand('run-123', undefined, undefined, true);
+      spawnCallCount = spawnSpy.mock.calls.length;
+      spawnCmd = (
+        (spawnSpy.mock.calls[0]?.[0] as { cmd: string[] } | undefined)?.cmd ?? []
+      ).slice();
+    } finally {
+      process.argv = savedArgv;
+      spawnSpy.mockRestore();
+    }
+
+    expect(spawnCallCount).toBe(1);
+    expect(spawnCmd).not.toContain('--detach');
+    expect(spawnCmd).toContain('resume');
+    expect(spawnCmd).toContain('run-123');
+    expect((executeWorkflow as ReturnType<typeof mock>).mock.calls.length).toBe(execBefore);
+  });
+});
+
 describe('buildDetachedRunCmd', () => {
   // BUNDLED_IS_BINARY is a module-level const (mocked false), so the binary
   // branch is unreachable through spawnDetachedWorkflowRun — exercise both

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -4927,7 +4927,7 @@ describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand
     working_path: '/distro/only/path',
     conversation_id: 'conv-123',
     user_message: 'hello',
-    metadata: {},
+    metadata: { approval: { nodeId: 'gate', message: 'Approve?' } },
   };
 
   // Mirrors the run-detach tests: pid is required (spawnDetachedWorkflowRun
@@ -5036,6 +5036,98 @@ describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand
       spawnSpy.mockRestore();
     }
     expect(spawnCallCount).toBe(0);
+  });
+
+  it('approve --detach refuses a child_workflow-blocked parent and spawns nothing', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      ...pausedRun,
+      metadata: {
+        approval: { nodeId: 'sub', message: 'blocked', type: 'child_workflow', childRunId: 'c-9' },
+      },
+    });
+    const spawnSpy = mockSpawn();
+    try {
+      await expect(
+        workflowApproveCommand('run-123', undefined, undefined, undefined, true)
+      ).rejects.toThrow('Approve or reject the child run instead: /workflow approve c-9');
+      expect(spawnSpy.mock.calls.length).toBe(0);
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
+  it('approve --detach refuses an already-resolved gate and spawns nothing', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      ...pausedRun,
+      metadata: { approval: { nodeId: 'gate', message: 'Approve?', resolved: 'approved' } },
+    });
+    const spawnSpy = mockSpawn();
+    try {
+      await expect(
+        workflowApproveCommand('run-123', undefined, undefined, undefined, true)
+      ).rejects.toThrow('was already approved and is awaiting resume');
+      expect(spawnSpy.mock.calls.length).toBe(0);
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
+  it('approve --detach refuses a missing approval context and spawns nothing', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      ...pausedRun,
+      metadata: {},
+    });
+    const spawnSpy = mockSpawn();
+    try {
+      await expect(
+        workflowApproveCommand('run-123', undefined, undefined, undefined, true)
+      ).rejects.toThrow('Workflow run is paused but missing approval context.');
+      expect(spawnSpy.mock.calls.length).toBe(0);
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
+  it('reject --detach refuses a child_workflow-blocked parent but TOLERATES missing context', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const paths = await import('@archon/paths');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      ...pausedRun,
+      metadata: {
+        approval: { nodeId: 'sub', message: 'blocked', type: 'child_workflow', childRunId: 'c-9' },
+      },
+    });
+    let spawnSpy = mockSpawn();
+    try {
+      await expect(
+        workflowRejectCommand('run-123', undefined, undefined, undefined, true)
+      ).rejects.toThrow('Reject the child run instead: /workflow reject c-9');
+      expect(spawnSpy.mock.calls.length).toBe(0);
+    } finally {
+      spawnSpy.mockRestore();
+    }
+
+    // reject has no nodeId requirement — a malformed context must still spawn.
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      ...pausedRun,
+      metadata: {},
+    });
+    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
+      throw new Error('no home in test');
+    });
+    spawnSpy = mockSpawn();
+    const savedArgv = process.argv;
+    process.argv = ['bun', '/abs/cli.ts', 'workflow', 'reject', 'run-123', '--detach'];
+    try {
+      await workflowRejectCommand('run-123', undefined, undefined, undefined, true);
+      expect(spawnSpy.mock.calls.length).toBe(1);
+    } finally {
+      process.argv = savedArgv;
+      spawnSpy.mockRestore();
+    }
   });
 
   it('reject --detach spawns a detached child (minus --detach) and performs ZERO writes in the parent', async () => {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -75,6 +75,8 @@ import {
   abandonWorkflow,
   getWorkflowStatus,
   resetWorkflowNodeSessions,
+  assertApprovable,
+  assertRejectable,
 } from '@archon/core/operations/workflow-operations';
 import * as conversationDb from '@archon/core/db/conversations';
 import * as codebaseDb from '@archon/core/db/codebases';
@@ -2924,13 +2926,9 @@ export async function workflowApproveCommand(
       if (!run) {
         throw new Error(`Workflow run not found: ${resolvedId}`);
       }
-      // Mirror approveWorkflow's gate so a wrong-status error surfaces
-      // synchronously instead of dying unseen in the child's log.
-      if (run.status !== 'paused') {
-        throw new Error(
-          `Cannot approve run with status '${run.status}'. Only paused runs can be approved.`
-        );
-      }
+      // The SAME gate approveWorkflow enforces — not a copy of one branch of it.
+      // A partial copy acks { ok: true } and lets the child die unseen.
+      assertApprovable(run);
       return run;
     });
     return;
@@ -3045,11 +3043,9 @@ export async function workflowRejectCommand(
       if (!run) {
         throw new Error(`Workflow run not found: ${resolvedId}`);
       }
-      if (run.status !== 'paused') {
-        throw new Error(
-          `Cannot reject run with status '${run.status}'. Only paused runs can be rejected.`
-        );
-      }
+      // The SAME gate rejectWorkflow enforces — not a copy of one branch of it.
+      // A partial copy acks { ok: true } and lets the child die unseen.
+      assertRejectable(run);
       return run;
     });
     return;

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -2688,7 +2688,10 @@ async function resolveRunIdArg(
  * working_path: the child re-resolves everything by run-id, and a container run's
  * working_path is a distro path the host cannot spawn into (ENOENT → the detach would
  * silently no-op). Reuses upstream's spawnDetachedWorkflowRun, which rebuilds the child
- * command from process.argv.
+ * command from process.argv AND awaits the startup window (#2279) — so a child that
+ * dies immediately throws here rather than being acked as started. That await is load
+ * bearing: dropping it turns every startup failure into an unhandled rejection arriving
+ * after the parent has already printed `{ ok: true }`.
  */
 async function runDetachedControlCommand(
   runId: string,
@@ -2705,38 +2708,43 @@ async function runDetachedControlCommand(
     // repo) after the parent has already acked success. The run's working_path
     // is still never a candidate: a container run's working_path is a distro
     // path the host cannot spawn into, so the child re-resolves by run id.
-    const logPath = spawnDetachedWorkflowRun(cwd ?? process.cwd(), runId, []);
+    const logPath = await spawnDetachedWorkflowRun(cwd ?? process.cwd(), runId, []);
     if (json) {
-      console.log(
-        JSON.stringify(
-          {
-            ok: true,
-            runId,
-            action,
-            detached: true,
-            // The child is spawned WITHOUT --json (buildDetachedRunCmd strips it),
-            // so it takes the inline path and DRIVES THE RUN ONWARD — approve's
-            // auto-resume, reject's on_reject rework, resume's re-run. This is the
-            // opposite of bare `--json`, which withholds continuation on purpose.
-            // Surfaced so an automation knows it does not own continuation here.
-            continues: true,
-            workflowName: run.workflow_name,
-            logPath,
-          },
-          null,
-          2
-        )
-      );
+      // Through writeJsonLine, like every other --json ack: it writes with a
+      // completion callback so a piped consumer can't receive a truncated
+      // document (#2384). console.log does not give that guarantee.
+      await writeJsonLine({
+        ok: true,
+        runId,
+        action,
+        detached: true,
+        // The child is spawned WITHOUT --json (buildDetachedRunCmd strips it),
+        // so it takes the inline path and DRIVES THE RUN ONWARD — approve's
+        // auto-resume, reject's on_reject rework, resume's re-run. This is the
+        // opposite of bare `--json`, which withholds continuation on purpose.
+        // Surfaced so an automation knows it does not own continuation here.
+        continues: true,
+        workflowName: run.workflow_name,
+        // null when the log file could not be opened — the child still runs, but
+        // its output is discarded. Same contract as `run --detach`.
+        logPath,
+      });
       return;
     }
     console.log(`Started '${action}' for run ${runId} in the background.`);
     console.log(`Track it with: archon workflow get ${runId}`);
-    if (logPath) console.log(`Child output: ${logPath}`);
+    if (logPath) {
+      console.log(`Child output: ${logPath}`);
+    } else {
+      // Mirrors `run --detach`: with no log file the child's output is discarded,
+      // so a failure after the startup window leaves no trail to read.
+      console.warn('Warning: could not open a log file — child output will not be captured.');
+    }
   } catch (error) {
     // Precheck failures follow each mode's error contract: --json emits the
     // standard { ok: false } line; human mode throws like the inline path.
     if (json) {
-      printJsonWriteError(runId, action, error);
+      await printJsonWriteError(runId, action, error);
       return;
     }
     throw error;
@@ -2796,9 +2804,19 @@ export async function workflowResumeCommand(
   // Composes with --json (structured ack; nothing executes here).
   if (detach) {
     const resolvedId = await resolveRunIdArg(runId, cwd);
-    await runDetachedControlCommand(resolvedId, 'resume', json, cwd, () =>
-      resumeWorkflowOp(resolvedId)
-    );
+    await runDetachedControlCommand(resolvedId, 'resume', json, cwd, async () => {
+      const run = await resumeWorkflowOp(resolvedId);
+      // The inline path below refuses a run with no recorded working path. Check it
+      // here too, on the run the precheck already holds (message copied verbatim):
+      // otherwise the parent acks success and the child throws where nobody reads it.
+      if (!run.working_path) {
+        throw new Error(
+          `Workflow run '${resolvedId}' has no working path recorded.\n` +
+            'Cannot determine where to resume. The run may be too old.'
+        );
+      }
+      return run;
+    });
     return;
   }
 
@@ -2952,6 +2970,15 @@ export async function workflowApproveCommand(
       // The SAME gate approveWorkflow enforces — not a copy of one branch of it.
       // A partial copy acks { ok: true } and lets the child die unseen.
       assertApprovable(run);
+      // The child always auto-resumes after approving, and the inline path below
+      // refuses a run with no recorded working path. Same check here (message
+      // copied verbatim) so the refusal is synchronous instead of buried in a log.
+      if (!run.working_path) {
+        throw new Error(
+          `Workflow run '${resolvedId}' has no working path recorded.\n` +
+            'Cannot determine where to resume.'
+        );
+      }
       return run;
     });
     return;

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -2684,20 +2684,28 @@ async function resolveRunIdArg(
  * approveWorkflow/rejectWorkflow/resumeWorkflow itself, or the decision would be
  * recorded twice (mirrors workflowRunCommand's detach shape: the parent does nothing).
  *
- * Spawns with the PARENT's cwd, never the run's working_path: the child re-resolves
- * everything by run-id, and a container run's working_path is a distro path the host
- * cannot spawn into (ENOENT → the detach would silently no-op). Reuses upstream's
- * spawnDetachedWorkflowRun, which rebuilds the child command from process.argv.
+ * Spawns with the command's `cwd` (falling back to `process.cwd()`), never the run's
+ * working_path: the child re-resolves everything by run-id, and a container run's
+ * working_path is a distro path the host cannot spawn into (ENOENT → the detach would
+ * silently no-op). Reuses upstream's spawnDetachedWorkflowRun, which rebuilds the child
+ * command from process.argv.
  */
 async function runDetachedControlCommand(
   runId: string,
   action: 'approve' | 'reject' | 'resume',
   json: boolean | undefined,
+  cwd: string | undefined,
   precheck: () => Promise<WorkflowRun>
 ): Promise<void> {
   try {
     const run = await precheck();
-    const logPath = spawnDetachedWorkflowRun(process.cwd(), runId, []);
+    // The caller's --cwd, already resolved by cli.ts — NOT process.cwd(). The
+    // appended --cwd is last-wins on the child's argv, so discarding it here
+    // strands the child in the parent's directory (possibly outside any git
+    // repo) after the parent has already acked success. The run's working_path
+    // is still never a candidate: a container run's working_path is a distro
+    // path the host cannot spawn into, so the child re-resolves by run id.
+    const logPath = spawnDetachedWorkflowRun(cwd ?? process.cwd(), runId, []);
     if (json) {
       console.log(
         JSON.stringify(
@@ -2788,7 +2796,9 @@ export async function workflowResumeCommand(
   // Composes with --json (structured ack; nothing executes here).
   if (detach) {
     const resolvedId = await resolveRunIdArg(runId, cwd);
-    await runDetachedControlCommand(resolvedId, 'resume', json, () => resumeWorkflowOp(resolvedId));
+    await runDetachedControlCommand(resolvedId, 'resume', json, cwd, () =>
+      resumeWorkflowOp(resolvedId)
+    );
     return;
   }
 
@@ -2934,7 +2944,7 @@ export async function workflowApproveCommand(
   // in the child. Composes with --json (structured ack; nothing executes here).
   if (detach) {
     const resolvedId = await resolveRunIdArg(runId, cwd);
-    await runDetachedControlCommand(resolvedId, 'approve', json, async () => {
+    await runDetachedControlCommand(resolvedId, 'approve', json, cwd, async () => {
       const run = await workflowDb.getWorkflowRun(resolvedId);
       if (!run) {
         throw new Error(`Workflow run not found: ${resolvedId}`);
@@ -3051,7 +3061,7 @@ export async function workflowRejectCommand(
   // mid-rework. The parent only validates read-only. Composes with --json.
   if (detach) {
     const resolvedId = await resolveRunIdArg(runId, cwd);
-    await runDetachedControlCommand(resolvedId, 'reject', json, async () => {
+    await runDetachedControlCommand(resolvedId, 'reject', json, cwd, async () => {
       const run = await workflowDb.getWorkflowRun(resolvedId);
       if (!run) {
         throw new Error(`Workflow run not found: ${resolvedId}`);

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -2673,6 +2673,53 @@ async function resolveRunIdArg(
   return matches[0].id;
 }
 
+/**
+ * Shared `--detach` front half for `approve`/`reject`/`resume`. Validates the run
+ * READ-ONLY via `precheck`, then hands the whole command to a detached child that
+ * re-invokes the same argv (minus `--detach`/`--json`) and owns ALL state mutation
+ * in its own process group — so killing the shell that hosted the parent cannot
+ * zombie the run mid-resume. The parent must never call
+ * approveWorkflow/rejectWorkflow/resumeWorkflow itself, or the decision would be
+ * recorded twice (mirrors workflowRunCommand's detach shape: the parent does nothing).
+ *
+ * Spawns with the PARENT's cwd, never the run's working_path: the child re-resolves
+ * everything by run-id, and a container run's working_path is a distro path the host
+ * cannot spawn into (ENOENT → the detach would silently no-op). Reuses upstream's
+ * spawnDetachedWorkflowRun, which rebuilds the child command from process.argv.
+ */
+async function runDetachedControlCommand(
+  runId: string,
+  action: 'approve' | 'reject' | 'resume',
+  json: boolean | undefined,
+  precheck: () => Promise<WorkflowRun>
+): Promise<void> {
+  try {
+    const run = await precheck();
+    const logPath = spawnDetachedWorkflowRun(process.cwd(), runId, []);
+    if (json) {
+      console.log(
+        JSON.stringify(
+          { ok: true, runId, action, detached: true, workflowName: run.workflow_name, logPath },
+          null,
+          2
+        )
+      );
+      return;
+    }
+    console.log(`Started '${action}' for run ${runId} in the background.`);
+    console.log(`Track it with: archon workflow get ${runId}`);
+    if (logPath) console.log(`Child output: ${logPath}`);
+  } catch (error) {
+    // Precheck failures follow each mode's error contract: --json emits the
+    // standard { ok: false } line; human mode throws like the inline path.
+    if (json) {
+      printJsonWriteError(runId, action, error);
+      return;
+    }
+    throw error;
+  }
+}
+
 async function resolveDiscoveryCwdForCodebase(
   runId: string,
   codebaseId: string,
@@ -2717,8 +2764,19 @@ async function resolveDiscoveryCwdForCodebase(
 export async function workflowResumeCommand(
   runId: string,
   json?: boolean,
-  cwd?: string
+  cwd?: string,
+  detach?: boolean
 ): Promise<void> {
+  // --detach: validate read-only (resumeWorkflowOp checks the run is resumable),
+  // then let a detached child re-invoke the blocking resume and own all mutation
+  // + execution, so a reaped launching shell can't wedge the run mid-resume.
+  // Composes with --json (structured ack; nothing executes here).
+  if (detach) {
+    const resolvedId = await resolveRunIdArg(runId, cwd);
+    await runDetachedControlCommand(resolvedId, 'resume', json, () => resumeWorkflowOp(resolvedId));
+    return;
+  }
+
   // JSON mode is a non-blocking control-plane ack: validate the run is resumable
   // and report its state, but do NOT re-execute the workflow inline (execution
   // streams workflow output to stdout, which would corrupt the JSON contract).
@@ -2852,8 +2910,32 @@ export async function workflowApproveCommand(
   runId: string,
   comment?: string,
   json?: boolean,
-  cwd?: string
+  cwd?: string,
+  detach?: boolean
 ): Promise<void> {
+  // --detach: hand the approve AND its inline auto-resume to a detached child
+  // (same argv minus --detach/--json). Handled BEFORE any state change — the
+  // parent only validates read-only, so the approval is recorded exactly once,
+  // in the child. Composes with --json (structured ack; nothing executes here).
+  if (detach) {
+    const resolvedId = await resolveRunIdArg(runId, cwd);
+    await runDetachedControlCommand(resolvedId, 'approve', json, async () => {
+      const run = await workflowDb.getWorkflowRun(resolvedId);
+      if (!run) {
+        throw new Error(`Workflow run not found: ${resolvedId}`);
+      }
+      // Mirror approveWorkflow's gate so a wrong-status error surfaces
+      // synchronously instead of dying unseen in the child's log.
+      if (run.status !== 'paused') {
+        throw new Error(
+          `Cannot approve run with status '${run.status}'. Only paused runs can be approved.`
+        );
+      }
+      return run;
+    });
+    return;
+  }
+
   // JSON mode records the approval and returns a structured ack WITHOUT the
   // inline auto-resume (resuming executes the workflow and streams output to
   // stdout, which would corrupt the JSON contract). The run becomes resumable
@@ -2949,8 +3031,30 @@ export async function workflowRejectCommand(
   runId: string,
   reason?: string,
   json?: boolean,
-  cwd?: string
+  cwd?: string,
+  detach?: boolean
 ): Promise<void> {
+  // --detach: hand the reject AND its inline on_reject rework to a detached child,
+  // exactly as approve does. Without it, reject hosts the executor in the calling
+  // shell — a reaped shell (harness task, closed terminal) leaves the run wedged
+  // mid-rework. The parent only validates read-only. Composes with --json.
+  if (detach) {
+    const resolvedId = await resolveRunIdArg(runId, cwd);
+    await runDetachedControlCommand(resolvedId, 'reject', json, async () => {
+      const run = await workflowDb.getWorkflowRun(resolvedId);
+      if (!run) {
+        throw new Error(`Workflow run not found: ${resolvedId}`);
+      }
+      if (run.status !== 'paused') {
+        throw new Error(
+          `Cannot reject run with status '${run.status}'. Only paused runs can be rejected.`
+        );
+      }
+      return run;
+    });
+    return;
+  }
+
   // JSON mode records the rejection and returns a structured ack WITHOUT the
   // inline auto-resume (an on_reject rework executes the workflow and streams
   // to stdout, corrupting the JSON contract). When `cancelled` is false the run

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -2701,7 +2701,20 @@ async function runDetachedControlCommand(
     if (json) {
       console.log(
         JSON.stringify(
-          { ok: true, runId, action, detached: true, workflowName: run.workflow_name, logPath },
+          {
+            ok: true,
+            runId,
+            action,
+            detached: true,
+            // The child is spawned WITHOUT --json (buildDetachedRunCmd strips it),
+            // so it takes the inline path and DRIVES THE RUN ONWARD — approve's
+            // auto-resume, reject's on_reject rework, resume's re-run. This is the
+            // opposite of bare `--json`, which withholds continuation on purpose.
+            // Surfaced so an automation knows it does not own continuation here.
+            continues: true,
+            workflowName: run.workflow_name,
+            logPath,
+          },
           null,
           2
         )

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -2824,7 +2824,10 @@ export async function workflowResumeCommand(
   // and report its state, but do NOT re-execute the workflow inline (execution
   // streams workflow output to stdout, which would corrupt the JSON contract).
   // To actually execute a resumable run, use the blocking `resume` (no --json,
-  // run as a background task) or `run <name> --resume --detach`.
+  // run as a background task) or `resume <run-id> --detach`. Prefer that exact-id
+  // form over `run <name> --resume --detach`, which selects the newest resumable
+  // run of that workflow in the CURRENT checkout — a different question, and the
+  // wrong one when the caller already holds a run id (#2645).
   if (json) {
     try {
       const resolvedId = await resolveRunIdArg(runId, cwd);

--- a/packages/core/src/operations/workflow-operations.test.ts
+++ b/packages/core/src/operations/workflow-operations.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { WorkflowRun } from '@archon/workflows/schemas/workflow-run';
 
 // ---------------------------------------------------------------------------
 // Mock DB modules before importing the module under test
@@ -67,6 +68,8 @@ const {
   resumeWorkflow,
   abandonWorkflow,
   resetWorkflowNodeSessions,
+  assertApprovable,
+  assertRejectable,
 } = await import('./workflow-operations');
 
 // ---------------------------------------------------------------------------
@@ -652,6 +655,83 @@ describe('rejectWorkflow', () => {
     expect(mockResolveApprovalGate).not.toHaveBeenCalled();
     expect(mockResolveAndCancelApprovalGate).not.toHaveBeenCalled();
     expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
+  });
+});
+
+describe('assertApprovable / assertRejectable — shared precondition gate', () => {
+  const baseRun = {
+    id: 'run-1',
+    status: 'paused',
+    workflow_name: 'assist',
+    working_path: '/tmp/x',
+    conversation_id: 'conv-1',
+    user_message: 'hi',
+    metadata: { approval: { nodeId: 'gate', message: 'Approve?' } },
+  } as unknown as WorkflowRun;
+
+  const withMeta = (metadata: Record<string, unknown>, status = 'paused') =>
+    ({ ...baseRun, status, metadata }) as unknown as WorkflowRun;
+
+  test('assertApprovable returns the approval context on a well-formed paused run', () => {
+    expect(assertApprovable(baseRun).nodeId).toBe('gate');
+  });
+
+  test('assertApprovable rejects a non-paused run', () => {
+    expect(() => assertApprovable(withMeta(baseRun.metadata, 'running'))).toThrow(
+      "Cannot approve run with status 'running'"
+    );
+  });
+
+  test('assertApprovable rejects a missing approval context', () => {
+    expect(() => assertApprovable(withMeta({}))).toThrow(
+      'Workflow run is paused but missing approval context.'
+    );
+  });
+
+  test('assertApprovable redirects a child_workflow-blocked parent to the child run', () => {
+    expect(() =>
+      assertApprovable(
+        withMeta({
+          approval: {
+            nodeId: 'sub',
+            message: 'blocked',
+            type: 'child_workflow',
+            childRunId: 'child-9',
+          },
+        })
+      )
+    ).toThrow('Approve or reject the child run instead: /workflow approve child-9');
+  });
+
+  test('assertApprovable rejects an already-resolved gate', () => {
+    expect(() =>
+      assertApprovable(withMeta({ approval: { nodeId: 'g', message: 'm', resolved: 'approved' } }))
+    ).toThrow('was already approved and is awaiting resume');
+  });
+
+  test('assertRejectable TOLERATES a missing approval context (unlike approve)', () => {
+    expect(assertRejectable(withMeta({}))).toBeUndefined();
+  });
+
+  test('assertRejectable redirects a child_workflow-blocked parent', () => {
+    expect(() =>
+      assertRejectable(
+        withMeta({
+          approval: {
+            nodeId: 'sub',
+            message: 'blocked',
+            type: 'child_workflow',
+            childRunId: 'child-9',
+          },
+        })
+      )
+    ).toThrow('Reject the child run instead: /workflow reject child-9');
+  });
+
+  test('assertRejectable rejects an already-resolved gate', () => {
+    expect(() =>
+      assertRejectable(withMeta({ approval: { nodeId: 'g', message: 'm', resolved: 'rejected' } }))
+    ).toThrow('was already rejected and is awaiting resume');
   });
 });
 

--- a/packages/core/src/operations/workflow-operations.ts
+++ b/packages/core/src/operations/workflow-operations.ts
@@ -167,6 +167,96 @@ async function getRunOrThrow(runId: string, logEvent: string): Promise<WorkflowR
   return run;
 }
 
+/**
+ * The four preconditions `approveWorkflow` enforces, as ONE reusable gate.
+ *
+ * Extracted so the CLI's read-only `--detach` precheck validates exactly what the
+ * child will enforce. A partial copy is worse than none: the parent acks
+ * `{ ok: true }` and the child then dies unseen in its log — precisely the failure
+ * `--detach` exists to prevent, on the surface nobody is watching.
+ *
+ * Pure and synchronous (the caller already holds the run), so both the operation
+ * and the CLI precheck can call it without a second DB round-trip.
+ *
+ * Returns the validated context so callers keep today's narrowing — `nodeId` is a
+ * required field on ApprovalContext, so no intersection type is needed.
+ */
+export function assertApprovable(run: WorkflowRun): ApprovalContext {
+  if (run.status !== 'paused') {
+    throw new Error(
+      `Cannot approve run with status '${run.status}'. Only paused runs can be approved.`
+    );
+  }
+  const rawApproval = run.metadata.approval;
+  const approval: ApprovalContext | undefined = isApprovalContext(rawApproval)
+    ? rawApproval
+    : undefined;
+  if (!approval?.nodeId) {
+    throw new Error('Workflow run is paused but missing approval context.');
+  }
+  if (approval.type === 'child_workflow') {
+    // A parent blocked on a `workflow:` sub-run has no approvable gate of its
+    // own — the pause resolves automatically when the child run completes.
+    // Falling through to the generic branch would stamp a node_completed for the
+    // parent's workflow node with empty output (the child's real output is then
+    // discarded on resume) and orphan the still-paused child. Redirect the
+    // operator to the child run, where the actual gate lives.
+    throw new Error(
+      `Run ${run.id} is paused waiting on sub-run ${approval.childRunId ?? '<unknown>'} ` +
+        `('workflow:' node '${approval.nodeId}'). Approve or reject the child run instead` +
+        (approval.childRunId ? `: /workflow approve ${approval.childRunId}` : '.')
+    );
+  }
+  if (isGateResolved(approval)) {
+    // Fast-path friendly error for the common (sequential) case. The run stays
+    // 'paused' after a resolution, so the status check alone no longer blocks a
+    // second approve. This in-memory read can still race a concurrent approve —
+    // the resolveApprovalGate CAS is the real arbiter; a second approve that
+    // slips past this read loses the atomic UPDATE and throws the same way.
+    throw new Error(
+      `Workflow run ${run.id} was already ${String(approval.resolved)} and is awaiting resume.`
+    );
+  }
+  return approval;
+}
+
+/**
+ * The THREE preconditions `rejectWorkflow` enforces. Deliberately NOT the same
+ * gate as `assertApprovable`: reject has no `nodeId` requirement — it falls back
+ * to `approval?.nodeId ?? 'unknown'` when writing its audit event, so a run whose
+ * approval metadata is malformed is still legitimately rejectable. Merging the two
+ * would either break reject or over-permit approve.
+ */
+export function assertRejectable(run: WorkflowRun): ApprovalContext | undefined {
+  if (run.status !== 'paused') {
+    throw new Error(
+      `Cannot reject run with status '${run.status}'. Only paused runs can be rejected.`
+    );
+  }
+  const rawApproval = run.metadata.approval;
+  const approval: ApprovalContext | undefined = isApprovalContext(rawApproval)
+    ? rawApproval
+    : undefined;
+  if (approval?.type === 'child_workflow') {
+    // Same redirect as assertApprovable: the parent's pause is not a rejectable
+    // gate — cancelling the parent here would silently orphan the still-paused
+    // child run. Reject the child (its own gate) or abandon the parent (which
+    // cascade-cancels the subtree) instead.
+    throw new Error(
+      `Run ${run.id} is paused waiting on sub-run ${approval.childRunId ?? '<unknown>'} ` +
+        `('workflow:' node '${approval.nodeId}'). Reject the child run instead` +
+        (approval.childRunId ? `: /workflow reject ${approval.childRunId}` : '.') +
+        ' To discard the whole tree, abandon this run.'
+    );
+  }
+  if (approval && isGateResolved(approval)) {
+    throw new Error(
+      `Workflow run ${run.id} was already ${String(approval.resolved)} and is awaiting resume.`
+    );
+  }
+  return approval;
+}
+
 // ---------------------------------------------------------------------------
 // Operations
 // ---------------------------------------------------------------------------
@@ -291,41 +381,7 @@ export async function approveWorkflow(
   comment?: string
 ): Promise<ApprovalOperationResult> {
   const run = await getRunOrThrow(runId, 'operations.workflow_approve_lookup_failed');
-  if (run.status !== 'paused') {
-    throw new Error(
-      `Cannot approve run with status '${run.status}'. Only paused runs can be approved.`
-    );
-  }
-  const rawApproval = run.metadata.approval;
-  const approval: ApprovalContext | undefined = isApprovalContext(rawApproval)
-    ? rawApproval
-    : undefined;
-  if (!approval?.nodeId) {
-    throw new Error('Workflow run is paused but missing approval context.');
-  }
-  if (approval.type === 'child_workflow') {
-    // A parent blocked on a `workflow:` sub-run has no approvable gate of its
-    // own — the pause resolves automatically when the child run completes.
-    // Falling through to the generic branch would stamp a node_completed for the
-    // parent's workflow node with empty output (the child's real output is then
-    // discarded on resume) and orphan the still-paused child. Redirect the
-    // operator to the child run, where the actual gate lives.
-    throw new Error(
-      `Run ${runId} is paused waiting on sub-run ${approval.childRunId ?? '<unknown>'} ` +
-        `('workflow:' node '${approval.nodeId}'). Approve or reject the child run instead` +
-        (approval.childRunId ? `: /workflow approve ${approval.childRunId}` : '.')
-    );
-  }
-  if (isGateResolved(approval)) {
-    // Fast-path friendly error for the common (sequential) case. The run stays
-    // 'paused' after a resolution, so the status check alone no longer blocks a
-    // second approve. This in-memory read can still race a concurrent approve —
-    // the resolveApprovalGate CAS below is the real arbiter; a second approve
-    // that slips past this read loses the atomic UPDATE and throws the same way.
-    throw new Error(
-      `Workflow run ${runId} was already ${String(approval.resolved)} and is awaiting resume.`
-    );
-  }
+  const approval = assertApprovable(run);
 
   // Whitespace-only comments count as absent (mirrors feedbackProvided below):
   // HTTP/CLI/chat pass the raw comment through since #2074, so '   ' would
@@ -447,35 +503,7 @@ export async function rejectWorkflow(
   reason?: string
 ): Promise<RejectionOperationResult> {
   const run = await getRunOrThrow(runId, 'operations.workflow_reject_lookup_failed');
-  if (run.status !== 'paused') {
-    throw new Error(
-      `Cannot reject run with status '${run.status}'. Only paused runs can be rejected.`
-    );
-  }
-  const rawApproval = run.metadata.approval;
-  const approval: ApprovalContext | undefined = isApprovalContext(rawApproval)
-    ? rawApproval
-    : undefined;
-  if (approval?.type === 'child_workflow') {
-    // Same redirect as approveWorkflow: the parent's pause is not a rejectable
-    // gate — cancelling the parent here would silently orphan the still-paused
-    // child run. Reject the child (its own gate) or abandon the parent (which
-    // cascade-cancels the subtree) instead.
-    throw new Error(
-      `Run ${runId} is paused waiting on sub-run ${approval.childRunId ?? '<unknown>'} ` +
-        `('workflow:' node '${approval.nodeId}'). Reject the child run instead` +
-        (approval.childRunId ? `: /workflow reject ${approval.childRunId}` : '.') +
-        ' To discard the whole tree, abandon this run.'
-    );
-  }
-  if (approval && isGateResolved(approval)) {
-    // Fast-path friendly error, same as approveWorkflow — the run stays 'paused'
-    // after a resolution, so status alone no longer blocks a second reject. The
-    // CAS below is the real arbiter for the concurrent case.
-    throw new Error(
-      `Workflow run ${runId} was already ${String(approval.resolved)} and is awaiting resume.`
-    );
-  }
+  const approval = assertRejectable(run);
   const isWriteBack = approval?.type === 'writeback';
 
   // Engine-level container write-back gate (Phase C): reject means DISCARD the

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -419,6 +419,8 @@ archon workflow resume <run-id> --json   # validate + ack only; does NOT re-exec
 
 In `--json` mode the command is a non-blocking control-plane ack: it validates the run is resumable and reports its state but does **not** re-execute inline (execution streams output to stdout, which would corrupt the JSON). To actually drive a resumable run to completion, use the blocking form or `workflow run <name> --resume --detach`.
 
+Adding `--detach` **inverts** that: the child is re-invoked without `--json`, so it takes the inline path and does re-execute the run — just outside your shell. The ack carries `continues: true` to say so. See [Detached control verbs](#detached-control-verbs).
+
 ### `workflow abandon`
 
 Discard a workflow run (marks it as `cancelled`). Use this to unblock a worktree when you don't want to resume — the path lock is released immediately so a new workflow can start.

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -452,11 +452,15 @@ In human mode `approve`/`reject` auto-resume the run inline. In `--json` mode th
 #### Detached control verbs
 
 `approve`, `reject`, and `resume` accept `--detach`. The parent validates the run
-**read-only** — the same four/three preconditions the operation itself enforces, so a
-wrong-status, missing-context, `child_workflow`-blocked, or already-resolved run is
-refused synchronously and nothing is spawned — then hands the whole command to a
-detached child that owns all state mutation in its own process group. A shell that
-dies mid-flight can no longer wedge the run.
+**read-only** with the same preconditions the operation itself enforces, so a
+wrong-status, missing-context, `child_workflow`-blocked, already-resolved, or
+no-working-path run is refused synchronously and nothing is spawned. The parent then
+hands the whole command to a detached child that owns all state mutation in its own
+process group. A shell that dies mid-flight can no longer wedge the run.
+
+The parent also waits out the child's startup window before acking, so a child that
+dies immediately surfaces as an error carrying the tail of its log rather than as a
+success you only discover was false minutes later.
 
 ```bash
 archon workflow approve <run-id> --detach
@@ -481,9 +485,10 @@ just outside your shell. The ack carries `continues: true` to say so:
 }
 ```
 
-Read `continues` to decide whether your automation still owns continuation. Precheck
-failures follow each verb's existing error contract: `{ ok: false }` under `--json`,
-a thrown error otherwise.
+Read `continues` to decide whether your automation still owns continuation. `logPath`
+is `null` when the log file could not be opened — the child still runs, but its output
+is discarded, so do not assume a string. Precheck failures follow each verb's existing
+error contract: `{ ok: false }` under `--json`, a thrown error otherwise.
 
 ### `workflow reject`
 

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -417,7 +417,9 @@ archon workflow resume <run-id>
 archon workflow resume <run-id> --json   # validate + ack only; does NOT re-execute inline
 ```
 
-In `--json` mode the command is a non-blocking control-plane ack: it validates the run is resumable and reports its state but does **not** re-execute inline (execution streams output to stdout, which would corrupt the JSON). To actually drive a resumable run to completion, use the blocking form or `workflow run <name> --resume --detach`.
+In `--json` mode the command is a non-blocking control-plane ack: it validates the run is resumable and reports its state but does **not** re-execute inline (execution streams output to stdout, which would corrupt the JSON). To actually drive a resumable run to completion, use the blocking form or `workflow resume <run-id> --detach`.
+
+When you already hold a run id, prefer that exact-id form. `workflow run <name> --resume --detach` selects the newest resumable run of that workflow **in the current checkout**, which is a different question — from another worktree it correctly finds nothing, and in a checkout with several historical runs it expresses less than the id you already have. Keep the name form for the case you actually mean: "the latest failed run of this workflow, here."
 
 Adding `--detach` **inverts** that: the child is re-invoked without `--json`, so it takes the inline path and does re-execute the run — just outside your shell. The ack carries `continues: true` to say so. See [Detached control verbs](#detached-control-verbs).
 

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -223,7 +223,7 @@ Note that a real `run` emits a JSON payload **only** under `--detach`. Without i
 | `--resume` | Resume from last failed run at the working path (skips completed nodes) |
 | `--quiet`, `-q` | Suppress all progress output to stderr |
 | `--verbose`, `-v` | Also show tool-level events (tool name and duration) |
-| `--detach` | Run in a detached background child and return immediately. The child does all the work; find it later with `workflow runs`/`workflow get`. Child stdout/stderr is captured to `~/.archon/logs/detached-run-<id>.log`. Combine with `--json` for a machine-readable ack. |
+| `--detach` | Run in a detached background child and return immediately. The child does all the work; find it later with `workflow runs`/`workflow get`. Child stdout/stderr is captured to `~/.archon/logs/detached-run-<id>.log`. Combine with `--json` for a machine-readable ack. Also available on `approve`/`reject`/`resume` — see [Detached control verbs](#detached-control-verbs). |
 | `--dry-run` | Simulate deterministic DAG control flow in memory. Creates no run, worktree, session, event, artifact, or provider request. |
 | `--stubs <path>` | YAML mapping of node ids to scalar or structured outputs for `--dry-run`. Relative paths resolve from `--cwd`. |
 | `--stubs-init <path>` | Write a complete stub scaffold for the expanded workflow and exit. Refuses to overwrite an existing file. Relative paths resolve from `--cwd`. |
@@ -446,6 +446,42 @@ archon workflow approve <run-id> --json   # record approval + ack; does NOT auto
 ```
 
 In human mode `approve`/`reject` auto-resume the run inline. In `--json` mode they record the decision and return an ack **without** resuming (the run is left resumable for a backgrounded `resume`/`run --resume`).
+
+#### Detached control verbs
+
+`approve`, `reject`, and `resume` accept `--detach`. The parent validates the run
+**read-only** — the same four/three preconditions the operation itself enforces, so a
+wrong-status, missing-context, `child_workflow`-blocked, or already-resolved run is
+refused synchronously and nothing is spawned — then hands the whole command to a
+detached child that owns all state mutation in its own process group. A shell that
+dies mid-flight can no longer wedge the run.
+
+```bash
+archon workflow approve <run-id> --detach
+archon workflow approve <run-id> --detach --json
+```
+
+**`--detach --json` deliberately differs from bare `--json`.** Bare `--json` records the
+decision and withholds the inline auto-resume (you drive continuation separately).
+`--detach --json` spawns a child that takes the ordinary inline path, so the run **is**
+driven onward — approve's auto-resume, reject's `on_reject` rework, resume's re-run —
+just outside your shell. The ack carries `continues: true` to say so:
+
+```json
+{
+  "ok": true,
+  "runId": "…",
+  "action": "approve",
+  "detached": true,
+  "continues": true,
+  "workflowName": "assist",
+  "logPath": "~/.archon/logs/detached-run-<id>.log"
+}
+```
+
+Read `continues` to decide whether your automation still owns continuation. Precheck
+failures follow each verb's existing error contract: `{ ok: false }` under `--json`,
+a thrown error otherwise.
 
 ### `workflow reject`
 


### PR DESCRIPTION
## Summary

- **Problem:** `--detach` existed only on `workflow run`. The control verbs (`approve`, `reject`, `resume`) hosted the executor in the calling shell, so a reaped shell — a harness task, a closed terminal, a dropped SSH session — left the run wedged mid-resume: approval recorded, workflow never continued.
- **Why it matters:** These are exactly the commands automation drives. An approve that records the decision and then dies leaves a run paused forever with no signal that anything went wrong.
- **What changed:** `--detach` now works on all three control verbs. The parent validates the run **read-only** and spawns a detached child that owns every state mutation in its own process group. The precondition gate is extracted into `assertApprovable`/`assertRejectable` in `@archon/core` so the parent's precheck and the operation itself are literally the same code. `--detach --json` gains `continues: true`, and the child is now spawned with the caller's `--cwd`.
- **What did *not* change (scope boundary):** No change to the non-detached paths of any verb. No change to `resumeWorkflow`'s gate (its precheck already called the shared operation). No change to the chat/HTTP/`manage_run` surfaces beyond the behavior-preserving extraction. `workflow run --detach` is untouched.

## UX Journey

### Before

```
  Operator                 archon (your shell)          Workflow run
  ────────                 ───────────────────          ────────────
  approve <id> ─────────▶  records approval ──────────▶ paused → resolved
                           resumes inline
                           runs the executor ─────────▶ running ...........
        shell dies ──────▶ ✗ process killed              ✗ WEDGED
                                                          (approved, never resumed)

  approve <id> --detach    [not supported — flag only existed on `workflow run`]
```

### After

```
  Operator                 archon parent            detached child          Workflow run
  ────────                 ─────────────            ──────────────          ────────────
  approve <id> --detach ▶  [*precheck: READ-ONLY*]
                           4 gates, zero writes
                              │
                              ├─ refused? ──────────────────────────────▶ untouched
                              │  {ok:false} to your face, NOTHING spawned
                              │
                              └─ ok ─▶ spawn ─────▶ records approval ────▶ paused → resolved
                           {ok:true,                resumes inline
                            continues:true}         runs executor ───────▶ running ......
                           exits                       │
        shell dies ──────▶ (already gone)              └─ keeps running ──▶ ✓ completed
```

## Architecture Diagram

### Before

```
  packages/cli/src/commands/workflow.ts
    workflowApproveCommand ──┐
    workflowRejectCommand  ──┼─▶ runDetachedControlCommand
    workflowResumeCommand  ──┘        │
                                      ├─▶ [inline precheck: status ONLY]   ← partial copy
                                      └─▶ spawnDetachedWorkflowRun(process.cwd())
                                                                  ▲
                                                     caller's --cwd discarded here

  packages/core/src/operations/workflow-operations.ts
    approveWorkflow ──▶ [inline gate: status, context, child_workflow, resolved]
    rejectWorkflow  ──▶ [inline gate: status, child_workflow, resolved]

  The two gates are unrelated code. They already drifted 3 checks apart.
```

### After

```
  packages/cli/src/commands/workflow.ts
    workflowApproveCommand ──┐
    workflowRejectCommand  ──┼─▶ runDetachedControlCommand(runId, action, json, [+]cwd, precheck)
    workflowResumeCommand  ──┘        │
                                      ├─▶ precheck ===▶ assertApprovable / assertRejectable
                                      └─▶ spawnDetachedWorkflowRun(cwd ?? process.cwd())  [~]

  packages/core/src/operations/workflow-operations.ts
    [+] assertApprovable(run): ApprovalContext            ◀=== CLI precheck
    [+] assertRejectable(run): ApprovalContext | undefined ◀=== CLI precheck
    approveWorkflow [~] ===▶ assertApprovable
    rejectWorkflow  [~] ===▶ assertRejectable

  ONE gate. The parent cannot validate less than the child enforces.
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `cli/commands/workflow.ts` (approve precheck) | `core/operations/workflow-operations.assertApprovable` | **new** | Replaces an inline status-only copy of one of four gates |
| `cli/commands/workflow.ts` (reject precheck) | `core/operations/workflow-operations.assertRejectable` | **new** | Replaces an inline status-only copy of one of three gates |
| `core.approveWorkflow` | `core.assertApprovable` | **new** | Extraction; error strings copied verbatim |
| `core.rejectWorkflow` | `core.assertRejectable` | **new** | Extraction; error strings copied verbatim |
| `runDetachedControlCommand` | `spawnDetachedWorkflowRun` | **modified** | Now passes the command's `cwd`, not `process.cwd()` |
| `cli/cli.ts` | `workflow{Approve,Reject,Resume}Command` | **modified** | Threads `--detach` (5th arg, after upstream's `cwd`) |
| `cli/commands/workflow.ts` (resume precheck) | `core.resumeWorkflow` | unchanged | Already called the shared operation — its single gate was never duplicated |
| `core.{approve,reject}Workflow` | `db/workflows.resolveApprovalGate` | unchanged | The CAS remains the real arbiter for concurrent resolution |
| chat `manage_run` / HTTP API | `core.{approve,reject}Workflow` | unchanged | Same behavior; they inherit the extraction transparently |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `cli`, `core`, `docs`
- Module: `cli:workflow`, `core:operations`

## Change Metadata

- Change type: `feature` (with an embedded `bug` fix for `cwd`, and a `refactor` for the shared gate)
- Primary scope: `cli`

## Linked Issue

- Closes #2645 — *feat(cli): detach an exact workflow run resume*. The issue was filed on 2026-08-19, after this PR opened, and this PR implements it. Checked against its acceptance list: a known run resumes by full or unambiguous short id without blocking the terminal; the detached exact-id path reuses the recorded worktree and inputs exactly as the foreground path does; the ack identifies the same run rather than selecting a different one by name and current path; and the name-form recovery pointers in `cli.md`, the `--json` code comment and `AGENTS.md` are repointed at the exact-id form, so the two are no longer presented as equivalent.
- Related #2279 — **closed 2026-08-03.** The detach ack used to be gated only on the child having a PID; the startup window added there catches a child that dies in its first 500 ms. This PR's control verbs `await` the spawn and therefore inherit that fix. Worth stating explicitly because an earlier revision of this branch called the spawn synchronously and did reopen the hole on the new surface.
- Related #2080 — on-hardware Windows detach smoketest. Its checklist covers `workflow run --detach` only, while this PR widens the surface to three more verbs, so the checklist arguably wants widening too.
- Depends on # — none. (Rebased onto `dev` at `3f78981f`.)
- Supersedes # — none.

## Validation Evidence (required)

```bash
bun run check:bundled && bun run check:bundled-skill && bun run check:bundled-schema \
  && bun run check:pi-vendor-map && bun run check:capability-matrix     # all OK
bun run type-check                                                      # 10/10 packages clean
bun run lint --max-warnings 0                                           # clean
bun run format:check                                                    # clean
bun test packages/cli/src/commands/workflow.test.ts                     # 199 pass / 0 fail
bun test packages/core/src/operations/workflow-operations.test.ts       #  49 pass / 0 fail
bun test packages/core/src/orchestrator/manage-run-tool.test.ts         #  30 pass / 0 fail (unchanged)
bun run test                                                            # see caveat below
```

- **Evidence provided:**
  - CLI suite `packages/cli/src/commands/workflow.test.ts`: **199 pass / 0 fail** (193 pre-change baseline + 6 new).
  - Core suite `packages/core/src/operations/workflow-operations.test.ts`: **49 pass / 0 fail** (41 baseline + 8 new).
  - The two **pre-existing** `child_workflow` refusal tests pass unchanged. That is the proof the gate extraction is behavior-preserving — the error strings were copied verbatim, so no caller-visible message changed.
  - `manage-run-tool.test.ts` (the only file that `mock.module`s `workflow-operations`) passes unchanged at 30/30. Because `mock.module()` merges rather than replaces, the two new exports keep their real implementations there; `manage-run-tool.ts` calls only the mocked operations, never the validators.
  - Compiled-binary verification: see **Human Verification** below.

- **If any command is intentionally skipped, explain why:**
  - `bun run validate` **cannot complete on a Windows host**: the chain reaches `bun run test:install`, and `scripts/test-install.sh` exits immediately with `Windows is not supported. Please use WSL2`. The eight checks before it all pass; the `&&` chain then short-circuits, so `bun run test` was run separately.
  - `bun run test` (full per-package sweep, all 8 test-bearing packages) produced **exactly one** failure: `@archon/providers` → `pathKind > returns "missing" for a broken symlink without throwing`, failing with `EPERM: operation not permitted, symlink`. That is Windows refusing symlink creation without elevation/Developer Mode — an environment limit in a package this branch does not touch. Every other package passed.

## Security Impact (required)

- New permissions/capabilities? **No.** `--detach` re-invokes the same CLI with the same argv minus `--detach`/`--json`; the child has exactly the parent's authority.
- New external network calls? **No.**
- Secrets/tokens handling changed? **No.** No credential path is read, written, logged, or forwarded differently.
- File system access scope changed? **Yes — narrowed.** `runDetachedControlCommand` previously spawned into `process.cwd()` regardless of the caller's `--cwd`. It now spawns into the `cwd` the caller actually asked for. This *reduces* the set of directories a detached child can land in and removes a case where the child could be started outside any git repo after the parent had already acked success. The run's `working_path` remains a non-candidate by design: a container run's `working_path` is a distro path the host cannot spawn into, so the child re-resolves everything by run id.

## Compatibility / Migration

- Backward compatible? **Yes.** `--detach` is purely additive on all three verbs; without it every verb behaves exactly as before. `continues` is an additive field on an ack that only exists under `--detach --json`, a combination that shipped nowhere before this PR. The extracted validators throw the same error strings the inline checks did.
- Config/env changes? **No.**
- Database migration needed? **No.**
- If yes, exact upgrade steps: n/a.

## Human Verification (required)

Verified against a **compiled Windows binary**, not `bun run cli` — dev mode is precisely where the Bun single-file-executable argv bug never appears, so dev-mode evidence cannot cover it.

> **Stale, read with care.** This section describes a binary built at commit `6af8eb2a`, which the rebase onto current `dev` removed. It exercised the pre-#2390 shape of this branch and does **not** cover the code now shipping — in particular it predates awaiting the spawn and the shared control-verb validator. Those are covered by unit tests, including a child dying inside the startup window. Binary-level Windows evidence for the current head would have to be re-run; that gap is #2080.

Binary: `bun build --compile --minify --target=bun-windows-x64` with `BUNDLED_IS_BINARY = true`; self-reports `Archon CLI v0.6.0 / Platform: win32-x64 / Build: binary / Git commit: 6af8eb2a`. Driven against an isolated `ARCHON_HOME` (throwaway SQLite DB) and a throwaway two-bash-nodes-around-one-approval-gate workflow, so the runs are real and cost no AI tokens.

- **Verified scenarios:**

  1. `approve <id> --detach --json` → ack `{ok:true, detached:true, continues:true}`. Child log contains **no** `Unknown command: /$bunfs/root/…` and **no** `Unknown command: B:/~BUN/root/…`. Child log shows `[after] Completed (118ms)` → `past the gate` → `Workflow completed successfully.`; `workflow get` reports `"status": "completed"`. **The run genuinely advanced — the ack alone would not have proven this, since a pre-fix binary acks success too.**
  2. `reject <id> --detach --json` → ack `continues: true`; no `Unknown command`; child log `Rejected and cancelled: smoke-detach-gate`; `workflow get` reports `"status": "cancelled"`.
  3. `resume <id> --detach --json` → ack `continues: true`; no `Unknown command`; child re-invoked, logged `[before] Skipped (prior_success)` and re-paused at the gate as expected.
  4. **Precheck refusal on a gate this PR newly enforces in the parent** — the important one. Recorded an approval with plain `--json` (run stays paused, gate resolved), then ran `approve <id> --detach --json` again: `{"ok": false, "error": "Workflow run … was already approved and is awaiting resume."}`, and that run's child-log file stayed byte-identical (1965 → 1965), proving **nothing was spawned**. Before this PR the parent acked `{ok:true}` here and the child died unseen.
  5. Precheck refusal on the pre-existing status gate — `approve <completed-run-id> --detach --json` → `{"ok": false, "error": "Cannot approve run with status 'completed'. Only paused runs can be approved."}`; log-file count unchanged (3 → 3) and that run's log byte-identical (1718 → 1718). Nothing spawned.

- **Edge cases checked:** `reject` deliberately tolerates a malformed/absent approval context where `approve` refuses (covered by unit test — it must still spawn); the `child_workflow` redirect is refused synchronously for both verbs (unit tests); `cwd: undefined` still falls back to `process.cwd()` so the pre-existing detach test's `expect(spawnOptions?.cwd).toBe(process.cwd())` assertion passes untouched.

- **What was not verified:** the `child_workflow`-blocked-parent redirect was not reproduced against the compiled binary (it needs a `workflow:` sub-run tree and is covered by unit tests at both layers, including two pre-existing tests that pass unchanged). Linux/macOS binaries were not built — the argv fix being relied on (#2273) is platform-independent, but only `win32-x64` was exercised end-to-end here. `bun run validate` was not run to completion on this host (see Validation Evidence).

## Side Effects / Blast Radius (required)

- **Affected subsystems/workflows:** `assertApprovable`/`assertRejectable` now sit on the `approveWorkflow`/`rejectWorkflow` path used by **every** surface — CLI, chat command handler, HTTP API, and the `manage_run` native tool. That is the honest blast radius. It is mitigated by the extraction being behavior-preserving: error strings are verbatim copies, and the pre-existing `child_workflow` refusal tests for both operations pass unchanged.
- **Potential unintended effects:** the `--detach` precheck is now strictly *stricter* than before. A caller who previously got `{ok:true}` for a run with a missing approval context, a `child_workflow` gate, or an already-resolved gate will now get `{ok:false}` synchronously. That is the intended fix, but it is a visible behavior change for anyone who was (unknowingly) relying on the false success.
- **Guardrails/monitoring for early detection:** every refusal path is unit-tested to assert **zero** spawns, so a regression that starts spawning on a refused precheck fails CI rather than silently leaking children. The `continues` field gives automation a machine-readable signal instead of inferred behavior.

## Rollback Plan (required)

- **Fast rollback command/path:** revert the PR. `--detach` disappears from `approve`/`reject`/`resume`; `workflow run --detach` is untouched; the operations revert to their inline gates with identical messages. No data migration, no config, nothing persisted by this change.
- **Feature flags or config toggles (if any):** none — `--detach` is itself the opt-in. Every verb without the flag behaves exactly as before.
- **Observable failure symptoms:** a control verb acking `{ok:true, detached:true}` while `workflow get` shows the run unchanged minutes later; or a `detached-run-<id>.log` containing `Unknown command:` — both indicate the child failed to re-invoke.

## Risks and Mitigations

- **Risk:** the shared validators are on the hot path of every approve/reject surface, so a mistake in the extraction breaks far more than the CLI.
  - **Mitigation:** error strings copied verbatim; the two pre-existing `child_workflow` refusal tests and the full 49-test core operations suite pass unchanged; eight new unit tests pin each gate's message individually.
- **Risk:** adding exports to `workflow-operations` silently un-mocks them in any test that `mock.module`s that path, because Bun's `mock.module()` merges rather than replaces — the documented cause of #2240.
  - **Mitigation:** audited — exactly one factory exists (`manage-run-tool.test.ts`), it mocks only the four operations, and `manage-run-tool.ts` never calls the validators directly. Suite verified passing at 30/30.
- **Risk:** tightening the precheck turns previously "successful" detach calls into synchronous failures for automation that relied on the false success.
  - **Mitigation:** this is the bug being fixed, and the failure is now loud, immediate, and carries the same message the child would have produced. Documented in the CLI reference under *Detached control verbs*.
- **Risk:** `--detach --json` continues the run while bare `--json` does not — a genuine asymmetry that could surprise a caller.
  - **Mitigation:** kept deliberately (withholding continuation under `--detach` would spawn a child that only records a decision, which is what bare `--json` already does), documented in both the CLI reference and `CLAUDE.md`, and made machine-readable via `continues: true`. A unit test asserts the child argv carries neither `--detach` nor `--json`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--detach` support for workflow `approve`, `reject`, and `resume` commands.
  * Detached commands validate immediately, then continue independently in the background.
  * Added JSON acknowledgements with continuation status, startup failure reporting, and log details.
* **Bug Fixes**
  * Preserved validation errors and prevented parent processes from mutating workflow state during detached execution.
* **Documentation**
  * Updated CLI help and documentation with detached workflow usage, behavior, output, and run-ID guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
