### PR TITLE
fix(workflows): emit node_failed when AI prompt substitution fails

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -1601,6 +1601,70 @@ describe('executeDagWorkflow -- tool restrictions', () => {
   });
 });
 
+describe('executeDagWorkflow -- AI node prompt substitution failure', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `dag-subst-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(testDir, { recursive: true });
+    mockSendQueryDag.mockClear();
+    mockGetAgentProviderDag.mockClear();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(testDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it('records a node_failed event when $BASE_BRANCH cannot be resolved (not a silent skip)', async () => {
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('subst-fail-run-id', {
+      workflow_name: 'subst-fail',
+      conversation_id: 'conv-subst',
+      user_message: 'test',
+    });
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-subst',
+      testDir,
+      {
+        name: 'subst-fail',
+        nodes: [{ id: 'needs-base', prompt: 'Diff the branch against $BASE_BRANCH and review.' }],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      '', // base branch unresolved — the prompt references $BASE_BRANCH so substitution throws
+      'docs/',
+      minimalConfig
+    );
+
+    // The substitution throw must surface as a node_failed event. Previously the
+    // catch returned state:'failed' silently — the node emitted node_started and
+    // then vanished with no terminal event, so downstream all_success rules
+    // skipped instead of the run reporting the failure.
+    const eventCalls = (mockDeps.store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+    const failedEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_failed' &&
+        (call[0] as { step_name: string }).step_name === 'needs-base'
+    );
+    expect(failedEvent).toBeDefined();
+    const errorMsg = (failedEvent![0] as { data: { error: string } }).data.error;
+    expect(errorMsg).toContain('No base branch could be resolved');
+    // The provider must never have been reached — the failure precedes the query.
+    expect(mockSendQueryDag.mock.calls.length).toBe(0);
+  });
+});
+
 describe('executeDagWorkflow -- bash nodes', () => {
   let testDir: string;
 

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1254,6 +1254,31 @@ async function executeNodeInternal(
   } catch (error) {
     const err = error as Error;
     getLog().error({ nodeId: node.id, error: err.message }, 'dag.node_prompt_substitution_failed');
+    await logNodeError(logDir, workflowRun.id, node.id, err.message);
+    // Emit the terminal event (mirrors the command-load failure path above).
+    // Without it the node emits node_started and then vanishes with no terminal
+    // event, so downstream all_success rules silently skip instead of the run
+    // surfacing the failure.
+    deps.store
+      .createWorkflowEvent({
+        workflow_run_id: workflowRun.id,
+        event_type: 'node_failed',
+        step_name: stepName,
+        data: { error: err.message },
+      })
+      .catch((persistErr: Error) => {
+        getLog().error(
+          { err: persistErr, workflowRunId: workflowRun.id, eventType: 'node_failed' },
+          'workflow_event_persist_failed'
+        );
+      });
+    emitter.emit({
+      type: 'node_failed',
+      runId: workflowRun.id,
+      nodeId: node.id,
+      nodeName: node.command ?? node.id,
+      error: err.message,
+    });
     await safeSendMessage(
       platform,
       conversationId,


### PR DESCRIPTION
## Summary

- **Problem:** When an AI node's prompt substitution throws — the clearest trigger is a prompt that references `$BASE_BRANCH` while no base branch could be resolved — `executeNodeInternal`'s catch logs the error and returns `{ state: 'failed' }` but records **no terminal event**: no `logNodeError`, no persisted `node_failed` workflow event, no emitter notification. The node emits `node_started` and then **vanishes**. Because no `node_failed` is ever recorded, downstream `all_success` trigger rules **silently skip** rather than the run surfacing the failure — a failed node that looks, to everything downstream, like it was never there.
- **What changed:** The substitution-failure catch now emits the same terminal signal the sibling **command-load** failure path already emits.
- **Why it matters:** A pre-query node failure becomes observable — it's persisted, streamed to the live feed, and downstream gating reacts to it — instead of disappearing into a silent skip.

## The asymmetry this fixes

`executeNodeInternal` has two pre-query failure paths. About 40 lines apart, they behaved differently:

| Failure path | `logNodeError` | persist `node_failed` | `emitter.emit('node_failed')` |
|---|---|---|---|
| **command load** (`loadCommandPrompt` fails) | ✅ | ✅ | ✅ |
| **prompt substitution** (`buildPromptWithContext` throws) | ❌ | ❌ | ❌ (only `safeSendMessage` + `return failed`) |

Both are terminal, pre-query failures of the *same* node; only the second was silent. This PR makes the substitution path mirror the command-load path exactly.

## The fix

In the substitution `catch`, before the existing chat message + `return { state: 'failed' }`:

1. `await logNodeError(logDir, workflowRun.id, node.id, err.message)` — write the node error log.
2. Persist a `node_failed` workflow event (`step_name: stepName`, `data: { error }`), best-effort with a `workflow_event_persist_failed` log on rejection — identical shape to the command-load path.
3. `emitter.emit({ type: 'node_failed', ... })` so live consumers (web/console) see the terminal event.

`nodeName` uses `node.command ?? node.id` (a `PromptNode` has no `command`), matching the `node_started` emit at the top of the node.

## Testing

- `bun run type-check` — green across all 10 packages.
- `packages/workflows` `dag-executor.test.ts` — **419 pass / 0 fail** (one new test).
- **Red/green verified:** the new test **fails** against the current code (no `node_failed` persisted) and **passes** with the fix.

New test: an AI node whose prompt references `$BASE_BRANCH` with an unresolved base records a `node_failed` event for that step, and the provider is never reached (the failure precedes the query).

## Provenance

Originally fixed in our downstream fork (`buun-dev/Archon`), where the silent skip masked a resume regression (a node vanishing under `all_success` gating). Re-derived here against current `upstream/dev` — the gap survived the `dag-executor` rewrite, so the fix is freshly applied to mirror the current command-load path rather than cherry-picked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workflow failures caused by unresolved prompt variables now emit and persist a `node_failed` event.
  - Downstream workflow steps can reliably detect terminal node failures.
  - Prevented unnecessary provider queries when prompt substitution fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->