### PR TITLE
feat(git): forge detection (github/gitea/gitlab) salvaged from #1104

### DIFF
--- a/packages/git/src/forge.test.ts
+++ b/packages/git/src/forge.test.ts
@@ -1,0 +1,135 @@
+import { describe, test, expect, beforeEach, afterEach, spyOn, type Mock } from 'bun:test';
+import * as repo from './repo';
+import { detectForge } from './forge';
+import { toRepoPath } from './types';
+
+const testRepo = toRepoPath('/tmp/test-repo');
+
+const FORGE_ENV_VARS = ['GITHUB_URL', 'GITEA_URL', 'GITLAB_URL'] as const;
+
+describe('detectForge', () => {
+  let getRemoteUrlSpy: Mock<typeof repo.getRemoteUrl>;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    getRemoteUrlSpy = spyOn(repo, 'getRemoteUrl');
+    // Save + clear the env vars the detector reads so ambient values can't
+    // leak into assertions
+    for (const key of FORGE_ENV_VARS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    getRemoteUrlSpy.mockRestore();
+    for (const [key, val] of Object.entries(savedEnv)) {
+      if (val === undefined) delete process.env[key];
+      else process.env[key] = val;
+    }
+  });
+
+  test('detects GitHub from HTTPS remote', async () => {
+    getRemoteUrlSpy.mockResolvedValue('https://github.com/owner/repo.git');
+    const info = await detectForge(testRepo);
+    expect(info.type).toBe('github');
+    expect(info.apiBase).toBe('https://api.github.com');
+  });
+
+  test('detects GitHub from SSH remote', async () => {
+    getRemoteUrlSpy.mockResolvedValue('git@github.com:owner/repo.git');
+    const info = await detectForge(testRepo);
+    expect(info.type).toBe('github');
+    expect(info.apiBase).toBe('https://api.github.com');
+  });
+
+  test('detects GitHub Enterprise when GITHUB_URL env matches remote hostname', async () => {
+    process.env.GITHUB_URL = 'https://github.corp.com';
+    getRemoteUrlSpy.mockResolvedValue('https://github.corp.com/owner/repo.git');
+    const info = await detectForge(testRepo);
+    expect(info.type).toBe('github');
+    expect(info.apiBase).toBe('https://github.corp.com/api/v3');
+  });
+
+  test('detects Gitea when GITEA_URL env matches remote hostname', async () => {
+    process.env.GITEA_URL = 'https://gitea.example.com';
+    getRemoteUrlSpy.mockResolvedValue('https://gitea.example.com/owner/repo.git');
+    const info = await detectForge(testRepo);
+    expect(info.type).toBe('gitea');
+    expect(info.apiBase).toBe('https://gitea.example.com/api/v1');
+  });
+
+  test('detects Gitea with trailing slash in GITEA_URL', async () => {
+    process.env.GITEA_URL = 'https://gitea.example.com/';
+    getRemoteUrlSpy.mockResolvedValue('https://gitea.example.com/owner/repo.git');
+    const info = await detectForge(testRepo);
+    expect(info.type).toBe('gitea');
+    expect(info.apiBase).toBe('https://gitea.example.com/api/v1');
+  });
+
+  test('detects Gitea from SSH remote', async () => {
+    process.env.GITEA_URL = 'https://gitea.example.com';
+    getRemoteUrlSpy.mockResolvedValue('git@gitea.example.com:owner/repo.git');
+    const info = await detectForge(testRepo);
+    expect(info.type).toBe('gitea');
+    expect(info.apiBase).toBe('https://gitea.example.com/api/v1');
+  });
+
+  test('detects GitLab from gitlab.com remote', async () => {
+    getRemoteUrlSpy.mockResolvedValue('https://gitlab.com/owner/repo.git');
+    const info = await detectForge(testRepo);
+    expect(info.type).toBe('gitlab');
+    expect(info.apiBase).toBe('https://gitlab.com/api/v4');
+  });
+
+  test('detects GitLab from SSH remote', async () => {
+    getRemoteUrlSpy.mockResolvedValue('git@gitlab.com:owner/repo.git');
+    const info = await detectForge(testRepo);
+    expect(info.type).toBe('gitlab');
+    expect(info.apiBase).toBe('https://gitlab.com/api/v4');
+  });
+
+  test('detects self-hosted GitLab when GITLAB_URL env matches', async () => {
+    process.env.GITLAB_URL = 'https://gitlab.corp.com';
+    getRemoteUrlSpy.mockResolvedValue('https://gitlab.corp.com/team/project.git');
+    const info = await detectForge(testRepo);
+    expect(info.type).toBe('gitlab');
+    expect(info.apiBase).toBe('https://gitlab.corp.com/api/v4');
+  });
+
+  test('returns unknown for unrecognized remote', async () => {
+    getRemoteUrlSpy.mockResolvedValue('https://bitbucket.org/owner/repo.git');
+    const info = await detectForge(testRepo);
+    expect(info.type).toBe('unknown');
+    expect(info.apiBase).toBe('');
+  });
+
+  test('returns unknown for a remote with no parseable hostname', async () => {
+    getRemoteUrlSpy.mockResolvedValue('/local/bare/repo.git');
+    const info = await detectForge(testRepo);
+    expect(info.type).toBe('unknown');
+    expect(info.apiBase).toBe('');
+  });
+
+  test('defaults to github when no remote exists', async () => {
+    getRemoteUrlSpy.mockResolvedValue(null);
+    const info = await detectForge(testRepo);
+    expect(info.type).toBe('github');
+    expect(info.apiBase).toBe('https://api.github.com');
+  });
+
+  test('ignores invalid GITEA_URL env value', async () => {
+    process.env.GITEA_URL = 'not-a-url';
+    getRemoteUrlSpy.mockResolvedValue('https://gitea.example.com/owner/repo.git');
+    const info = await detectForge(testRepo);
+    expect(info.type).toBe('unknown');
+    expect(info.apiBase).toBe('');
+  });
+
+  test('Gitea detection is case-insensitive on hostname', async () => {
+    process.env.GITEA_URL = 'https://Gitea.Example.COM';
+    getRemoteUrlSpy.mockResolvedValue('https://gitea.example.com/owner/repo.git');
+    const info = await detectForge(testRepo);
+    expect(info.type).toBe('gitea');
+  });
+});

--- a/packages/git/src/forge.ts
+++ b/packages/git/src/forge.ts
@@ -1,0 +1,102 @@
+// Forge detection: identify the hosting platform (GitHub, Gitea, GitLab)
+// behind a repository's `origin` remote, plus its REST API base URL.
+
+import { getRemoteUrl } from './repo';
+import type { RepoPath } from './types';
+
+/** Forge platform detected from a repository's remote */
+export type ForgeType = 'github' | 'gitea' | 'gitlab' | 'unknown';
+
+/** Result of forge detection: platform type + REST API base URL */
+export interface ForgeInfo {
+  type: ForgeType;
+  /** REST API base URL for the forge; empty string when the forge is unknown */
+  apiBase: string;
+}
+
+/**
+ * Extract the hostname from a git remote URL.
+ * Handles HTTPS (`https://github.com/owner/repo.git`) and
+ * SSH (`git@github.com:owner/repo.git`) formats.
+ */
+function extractHostname(remoteUrl: string): string | null {
+  try {
+    return new URL(remoteUrl).hostname.toLowerCase();
+  } catch {
+    // Not a standard URL — fall through to SSH scp-like syntax
+  }
+  const sshMatch = /^[^@]+@([^:]+):/.exec(remoteUrl);
+  const host = sshMatch?.[1];
+  return host ? host.toLowerCase() : null;
+}
+
+/**
+ * Match a remote hostname against a self-hosted forge base URL taken from an
+ * env var (e.g. `GITEA_URL`). Returns the base URL with trailing slashes
+ * stripped when the hostnames match; null when the env var is unset, not a
+ * valid URL, or points at a different host. An invalid env value is ignored
+ * rather than misdetecting — the caller falls through to the next rule.
+ */
+function matchSelfHostedForge(envVar: string, hostname: string): string | null {
+  const value = process.env[envVar];
+  if (!value) return null;
+  let envHostname: string;
+  try {
+    envHostname = new URL(value).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+  if (envHostname !== hostname) return null;
+  return value.replace(/\/+$/, '');
+}
+
+/**
+ * Detect the forge platform behind a repository's `origin` remote.
+ *
+ * Detection order:
+ * 1. `github.com` hostname → GitHub (`https://api.github.com`)
+ * 2. `GITHUB_URL` env hostname match → GitHub Enterprise (`<base>/api/v3`)
+ * 3. `GITEA_URL` env hostname match → Gitea (`<base>/api/v1`)
+ * 4. `gitlab.com` hostname → GitLab (`https://gitlab.com/api/v4`)
+ * 5. `GITLAB_URL` env hostname match → self-hosted GitLab (`<base>/api/v4`)
+ * 6. No match → `unknown` (empty apiBase)
+ *
+ * A repository with no `origin` remote defaults to GitHub for backwards
+ * compatibility with existing GitHub-only callers.
+ */
+export async function detectForge(repoPath: RepoPath): Promise<ForgeInfo> {
+  const remoteUrl = await getRemoteUrl(repoPath);
+  if (!remoteUrl) {
+    return { type: 'github', apiBase: 'https://api.github.com' };
+  }
+
+  const hostname = extractHostname(remoteUrl);
+  if (!hostname) {
+    return { type: 'unknown', apiBase: '' };
+  }
+
+  if (hostname === 'github.com') {
+    return { type: 'github', apiBase: 'https://api.github.com' };
+  }
+
+  const githubEnterpriseBase = matchSelfHostedForge('GITHUB_URL', hostname);
+  if (githubEnterpriseBase) {
+    return { type: 'github', apiBase: `${githubEnterpriseBase}/api/v3` };
+  }
+
+  const giteaBase = matchSelfHostedForge('GITEA_URL', hostname);
+  if (giteaBase) {
+    return { type: 'gitea', apiBase: `${giteaBase}/api/v1` };
+  }
+
+  if (hostname === 'gitlab.com') {
+    return { type: 'gitlab', apiBase: 'https://gitlab.com/api/v4' };
+  }
+
+  const gitlabBase = matchSelfHostedForge('GITLAB_URL', hostname);
+  if (gitlabBase) {
+    return { type: 'gitlab', apiBase: `${gitlabBase}/api/v4` };
+  }
+
+  return { type: 'unknown', apiBase: '' };
+}

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -44,6 +44,10 @@ export {
   getLastCommitDate,
 } from './branch';
 
+// Forge detection
+export { detectForge } from './forge';
+export type { ForgeType, ForgeInfo } from './forge';
+
 // Repository operations
 export {
   findRepoRoot,


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: Archon has no way to programmatically identify which forge (GitHub, Gitea, GitLab) a repository's remote points at — a prerequisite for forge-agnostic outbound operations on the community adapters (#1574).
- Why it matters: #1574 (accepted) needs a single, tested detection primitive before any adapter or workflow can branch on forge type instead of assuming GitHub.
- What changed: New leaf module `packages/git/src/forge.ts` — `detectForge(repoPath)` resolves the `origin` remote to a `ForgeInfo { type, apiBase }` (github.com / gitlab.com by hostname; GitHub Enterprise / Gitea / self-hosted GitLab via `GITHUB_URL` / `GITEA_URL` / `GITLAB_URL` env hostname match; HTTPS and SSH remote formats; no-remote defaults to GitHub for backward compatibility). 14 unit tests. Exported from `@archon/git`.
- What did **not** change (scope boundary): No consumers wired up — no adapter, workflow-engine, or bundled-default changes; no env-var injection; nothing else from #1104 (its forge-cli.ts script, executor changes, and bundled-default edits are intentionally left behind). Detection currently has zero callers by design: it lands as the reviewed foundation for #1574's consumer PR.
- Provenance: Salvaged prior art from closed PR #1104 by @truck0321 (credited via `Co-authored-by`), adapted to current `@archon/git` conventions (branded `RepoPath`, typed `Mock<>` spies, shared self-hosted matcher helper, env save/restore in tests extended to `GITHUB_URL`).

## UX Journey

### Before

```
(No user-facing flow — internal library addition. No behavior change for any user.)
```

### After

```
(Unchanged. detectForge() has no callers yet; user-facing forge-agnostic
behavior arrives with #1574's consumer PR.)
```

## Architecture Diagram

### Before

```
@archon/git
  ├── repo.ts (getRemoteUrl, ...)
  ├── branch.ts
  ├── worktree.ts
  ├── exec.ts
  └── types.ts (RepoPath, ...)
```

### After

```
@archon/git
  ├── repo.ts (getRemoteUrl, ...)
  ├── [+] forge.ts (detectForge) ═══▶ repo.ts (getRemoteUrl)
  ├── branch.ts
  ├── worktree.ts
  ├── exec.ts
  └── types.ts (RepoPath, ...)
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `git/forge.ts` | `git/repo.ts` | **new** | `getRemoteUrl(repoPath)` — only dependency |
| `git/forge.ts` | `git/types.ts` | **new** | `RepoPath` branded type |
| `git/index.ts` | `git/forge.ts` | **new** | exports `detectForge`, `ForgeType`, `ForgeInfo` |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `git`
- Module: `git:forge`

## Change Metadata

- Change type: `feature`
- Primary scope: `git`

## Linked Issue

- Related #1574 (groundwork — deliberately NOT `Closes`; the consumer PR closes it)
- Supersedes #1104 (partial salvage: forge-detection module only, with credit to @truck0321)

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # exit 0 — all 9 checks green
cd packages/git && bun test src/   # 177 pass, 0 fail (14 new forge tests)
cd packages/git && bun x tsc --noEmit   # clean
```

- Evidence provided (test/log/trace/screenshot): local `bun run validate` exit 0; `@archon/git` 177 pass / 0 fail across 2 files.
- If any command is intentionally skipped, explain why: none skipped.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No (pure string/URL parsing; the only I/O is the existing `git remote get-url` via `getRemoteUrl`)
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: n/a. Note: `GITHUB_URL`/`GITEA_URL`/`GITLAB_URL` are read for hostname matching only; invalid values are ignored (fall through to `unknown`) rather than misdetecting.

## Compatibility / Migration

- Backward compatible? Yes (additive; no existing code path touched)
- Config/env changes? No (the three env vars are optional inputs with no default behavior change)
- Database migration needed? No
- If yes, exact upgrade steps: n/a

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: HTTPS + SSH remotes for github.com/gitlab.com; self-hosted Gitea/GitLab/GHE via env hostname match incl. trailing-slash and case-insensitivity; no-remote → GitHub default; unrecognized host and unparseable remote → `unknown`.
- Edge cases checked: invalid env URL ignored (no misdetection); env vars saved/cleared/restored around each test so ambient values can't leak.
- What was not verified: live API calls against a real Gitea/GitLab instance (out of scope — this PR only computes the API base URL; consumers in #1574 will exercise it).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: none at runtime — `detectForge` has zero callers; only the `@archon/git` export surface grows.
- Potential unintended effects: none identified; module is a leaf over `getRemoteUrl`.
- Guardrails/monitoring for early detection: unit tests pin the detection order and the backwards-compatible GitHub default.

## Rollback Plan (required)

- Fast rollback command/path: revert the single commit (`git revert 94676499`) — removes `forge.ts`, `forge.test.ts`, and the three index exports; nothing depends on them.
- Feature flags or config toggles (if any): none needed.
- Observable failure symptoms: none expected pre-consumer; any issue would surface as a failing `@archon/git` unit test.

## Risks and Mitigations

- Risk: Detection order (env matches before public-hostname fallbacks for GitLab) could surprise a future consumer if an operator points `GITLAB_URL` at gitlab.com.
  - Mitigation: order is documented in the `detectForge` doc comment and pinned by tests; consumers in #1574 review it before wiring.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of repository hosting platforms, including GitHub, GitHub Enterprise, GitLab, and Gitea.
  * Supports both HTTPS and SSH remote URLs.
  * Recognizes self-hosted instances through configured service URLs.
  * Exposes the detected platform and corresponding API base URL for integrations.

* **Tests**
  * Added coverage for supported platforms, invalid or missing remotes, custom hosts, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->