### PR TITLE
feat(workflows): per-node settingSources override for Claude nodes

### DIFF
--- a/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
+++ b/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
@@ -144,7 +144,7 @@ assistants:
     # claudeBinaryPath: /absolute/path/to/claude
 ```
 
-The `settingSources` option controls which `CLAUDE.md`, skill, command, and agent files the Claude Code SDK loads. The default is `['project', 'user']`, which loads both the project-level `<cwd>/.claude/` and your personal `~/.claude/`. Set it to `['project']` if you want to scope a workflow to project-only resources.
+The `settingSources` option controls which `CLAUDE.md`, skill, command, and agent files the Claude Code SDK loads. The default is `['project', 'user']`, which loads both the project-level `<cwd>/.claude/` and your personal `~/.claude/`. Set it to `['project']` if you want to scope a workflow to project-only resources. Individual workflow nodes can override this with a per-node `settingSources:` field (e.g. `settingSources: []` for a lean node that loads no setting sources at all) — see [Claude SDK Advanced Options](/guides/authoring-workflows/#claude-sdk-advanced-options).
 
 ### Set as Default (Optional)
 

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -226,10 +226,11 @@ nodes:
 | `fallbackModel` | string | — | Model to use if primary model fails. Claude only. Also settable at workflow level |
 | `betas` | string[] | — | SDK beta feature flags (e.g., `'context-1m-2025-08-07'`). Claude only. Also settable at workflow level |
 | `sandbox` | object | — | OS-level filesystem/network restrictions for the Claude subprocess. Claude only. Also settable at workflow level |
+| `settingSources` | (`'project'`\|`'user'`)[] | inherited | Which filesystem setting sources Claude loads (CLAUDE.md, skills, commands, agents). Overrides the assistant-level default; unset everywhere = `['project', 'user']`. `[]` loads none. Claude only. Per-node only |
 
 ### Claude SDK Advanced Options
 
-These fields map directly to Claude Agent SDK options. `maxBudgetUsd`, `systemPrompt`, `fallbackModel`, `betas`, and `sandbox` are Claude-only — Codex and other providers emit a warning and ignore them. `effort` and `thinking` also apply to Pi and Copilot, which map them to their own reasoning controls (Codex uses `modelReasoningEffort` instead; OpenCode configures reasoning via `opencode.json`). They can be set **per-node** or at the **workflow level** as defaults (per-node takes precedence). `maxBudgetUsd` and `systemPrompt` are per-node only.
+These fields map directly to Claude Agent SDK options. `maxBudgetUsd`, `systemPrompt`, `fallbackModel`, `betas`, `sandbox`, and `settingSources` are Claude-only — Codex and other providers emit a warning and ignore them. `effort` and `thinking` also apply to Pi and Copilot, which map them to their own reasoning controls (Codex uses `modelReasoningEffort` instead; OpenCode configures reasoning via `opencode.json`). They can be set **per-node** or at the **workflow level** as defaults (per-node takes precedence). `maxBudgetUsd`, `systemPrompt`, and `settingSources` are per-node only (`settingSources` also has an assistant-level default in `.archon/config.yaml`).
 
 **effort** — reasoning depth:
 
@@ -294,6 +295,20 @@ These fields map directly to Claude Agent SDK options. `maxBudgetUsd`, `systemPr
     filesystem:
       denyWrite: ['/etc', '/usr']
 ```
+
+**settingSources** — control which filesystem setting sources the Claude SDK loads (project `CLAUDE.md`/`.claude/` skills, commands, agents vs the user-level `~/.claude/`). Loading fewer sources gives a leaner context and a faster node start — a lean reviewer node can skip project context entirely while a writer node in the same workflow keeps it:
+
+```yaml
+- id: lean-review
+  command: review
+  settingSources: []              # load no CLAUDE.md / skills / commands / agents
+
+- id: implement
+  command: implement
+  settingSources: ['project']     # project sources only, skip ~/.claude/
+```
+
+Omitting the field inherits the assistant-level `assistants.claude.settingSources` from `.archon/config.yaml`; if that is also unset, the default is `['project', 'user']`.
 
 **Workflow-level defaults** (inherited by all Claude nodes unless overridden per-node):
 

--- a/packages/docs-web/src/content/docs/reference/provider-capabilities.md
+++ b/packages/docs-web/src/content/docs/reference/provider-capabilities.md
@@ -48,6 +48,7 @@ per-node YAML field for that provider; a ❌ means the field is accepted but ign
 | Thinking control (`thinking`) | ✅ | ❌ | ❌ | ✅ | ✅ |
 | Fallback model (`fallbackModel`) | ✅ | ❌ | ❌ | ❌ | ❌ |
 | Sandbox (`sandbox`) | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Setting sources (`settingSources`) | ✅ | ❌ | ❌ | ❌ | ❌ |
 | In-process native tools | ✅ | ❌ | ❌ | ✅ | ❌ |
 | Container exec (folder-project container backend) | ✅ | ❌ | ❌ | ❌ | ❌ |
 

--- a/packages/providers/src/claude/capabilities.ts
+++ b/packages/providers/src/claude/capabilities.ts
@@ -63,6 +63,7 @@ export const CLAUDE_CAPABILITIES: ProviderCapabilities = {
   thinkingControl: true,
   fallbackModel: true,
   sandbox: true,
+  settingSources: true, // per-node override of the SDK's settingSources option
   nativeTools: true,
   containerExec: true, // spawns the CLI in-container via spawnClaudeCodeProcess
 };

--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -132,6 +132,7 @@ describe('ClaudeProvider', () => {
         thinkingControl: true,
         fallbackModel: true,
         sandbox: true,
+        settingSources: true,
         nativeTools: true,
       });
     });
@@ -1206,6 +1207,41 @@ describe('ClaudeProvider', () => {
       expect(mockQuery).toHaveBeenCalledTimes(1);
       const callArgs = mockQuery.mock.calls[0][0] as { options: Record<string, unknown> };
       expect(callArgs.options.settingSources).toEqual(['project']);
+    });
+
+    test('per-node settingSources override wins over the assistant default', async () => {
+      mockQuery.mockImplementation(async function* () {
+        yield { type: 'result', session_id: 'test-session' };
+      });
+
+      for await (const _ of client.sendQuery('test', '/tmp', undefined, {
+        nodeConfig: { settingSources: ['project'] },
+        assistantConfig: { settingSources: ['project', 'user'] },
+      })) {
+        // consume
+      }
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const callArgs = mockQuery.mock.calls[0][0] as { options: Record<string, unknown> };
+      expect(callArgs.options.settingSources).toEqual(['project']);
+    });
+
+    test('per-node settingSources applies when no assistant default is set', async () => {
+      mockQuery.mockImplementation(async function* () {
+        yield { type: 'result', session_id: 'test-session' };
+      });
+
+      for await (const _ of client.sendQuery('test', '/tmp', undefined, {
+        nodeConfig: { settingSources: [] },
+      })) {
+        // consume
+      }
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const callArgs = mockQuery.mock.calls[0][0] as { options: Record<string, unknown> };
+      // An explicit empty array is a valid opt-out of ALL setting sources —
+      // it must not fall through to the ['project', 'user'] default.
+      expect(callArgs.options.settingSources).toEqual([]);
     });
 
     test('passes env from requestOptions into SDK options', async () => {

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -702,7 +702,10 @@ function buildBaseClaudeOptions(
     permissionMode: 'bypassPermissions',
     allowDangerouslySkipPermissions: true,
     systemPrompt: requestOptions?.systemPrompt ?? { type: 'preset', preset: 'claude_code' },
-    settingSources: assistantDefaults.settingSources ?? ['project', 'user'],
+    // Per-node override wins over the assistant-level default; the final
+    // fallback stays ['project', 'user'] (the SDK-loading default Archon ships).
+    settingSources: requestOptions?.nodeConfig?.settingSources ??
+      assistantDefaults.settingSources ?? ['project', 'user'],
     hooks: buildToolCaptureHooks(toolResultQueue),
     stderr: (data: string): void => {
       const output = data.trim();

--- a/packages/providers/src/codex/capabilities.ts
+++ b/packages/providers/src/codex/capabilities.ts
@@ -14,6 +14,7 @@ export const CODEX_CAPABILITIES: ProviderCapabilities = {
   thinkingControl: false,
   fallbackModel: false,
   sandbox: false,
+  settingSources: false, // Claude Agent SDK-only knob (which setting sources the agent loads)
   nativeTools: false,
   containerExec: false, // no in-container spawn path yet (fail-fast source of truth)
 };

--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -87,6 +87,7 @@ describe('CodexProvider', () => {
         thinkingControl: false,
         fallbackModel: false,
         sandbox: false,
+        settingSources: false,
         nativeTools: false,
         containerExec: false,
       });

--- a/packages/providers/src/community/copilot/capabilities.ts
+++ b/packages/providers/src/community/copilot/capabilities.ts
@@ -25,6 +25,7 @@ export const COPILOT_CAPABILITIES: ProviderCapabilities = {
   thinkingControl: true,
   fallbackModel: false,
   sandbox: false,
+  settingSources: false, // Claude Agent SDK-only knob (which setting sources the agent loads)
   nativeTools: false,
   containerExec: false, // no in-container spawn path yet (fail-fast source of truth)
 };

--- a/packages/providers/src/community/opencode/capabilities.ts
+++ b/packages/providers/src/community/opencode/capabilities.ts
@@ -36,6 +36,7 @@ export const OPENCODE_CAPABILITIES: ProviderCapabilities = {
   thinkingControl: false, // OpenCode handles effort/thinking via opencode.json agent config, not prompt body
   fallbackModel: false,
   sandbox: false,
+  settingSources: false, // Claude Agent SDK-only knob (which setting sources the agent loads)
   nativeTools: false,
   containerExec: false, // no in-container spawn path yet (fail-fast source of truth)
 };

--- a/packages/providers/src/community/pi/capabilities.ts
+++ b/packages/providers/src/community/pi/capabilities.ts
@@ -30,6 +30,7 @@ export const PI_CAPABILITIES: ProviderCapabilities = {
   thinkingControl: true,
   fallbackModel: false,
   sandbox: false,
+  settingSources: false, // Claude Agent SDK-only knob (which setting sources the agent loads)
   nativeTools: true,
   containerExec: false, // no in-container spawn path yet (fail-fast source of truth)
 };

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -511,6 +511,14 @@ export interface NodeConfig {
   maxBudgetUsd?: number;
   systemPrompt?: SystemPromptInput;
   fallbackModel?: string;
+  /**
+   * Per-node override for Claude Code settingSources — which filesystem
+   * setting sources the SDK loads (CLAUDE.md, skills, commands, agents).
+   * Overrides the assistant-level default; falls back to ['project', 'user']
+   * when neither is set. Claude-only; other providers ignore it (the
+   * dag-executor warns via the settingSources capability axis).
+   */
+  settingSources?: ('project' | 'user')[];
   idle_timeout?: number;
   /**
    * Per-node override for Claude's `agentProgressSummaries` flag (Phase 4 of #975).
@@ -590,6 +598,13 @@ export interface ProviderCapabilities {
   thinkingControl: boolean;
   fallbackModel: boolean;
   sandbox: boolean;
+  /**
+   * Whether the provider honors the per-node `settingSources` override (which
+   * filesystem setting sources the agent loads: CLAUDE.md, skills, commands,
+   * agents). `true` for Claude only — the Claude Agent SDK's `settingSources`
+   * option; other providers have no equivalent knob.
+   */
+  settingSources: boolean;
   /** Whether the provider can register in-process `NativeTool`s for a turn. */
   nativeTools: boolean;
   /**

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -163,6 +163,7 @@ const mockClaudeCapabilities = () => ({
   thinkingControl: true,
   fallbackModel: true,
   sandbox: true,
+  settingSources: true,
 });
 /** Limited capabilities for Codex mock */
 const mockCodexCapabilities = () => ({
@@ -179,6 +180,7 @@ const mockCodexCapabilities = () => ({
   thinkingControl: false,
   fallbackModel: false,
   sandbox: false,
+  settingSources: false,
 });
 
 /** Mock AI sendQuery generator */
@@ -1174,6 +1176,81 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
     const nodeConfig = optionsArg?.nodeConfig as Record<string, unknown>;
     expect(nodeConfig?.allowed_tools).toEqual(['Read', 'Grep']);
+  });
+
+  it('passes settingSources to sendQuery nodeConfig for Claude node', async () => {
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-dag',
+      testDir,
+      {
+        name: 'dag-setting-sources',
+        nodes: [{ id: 'lean-review', command: 'my-cmd', settingSources: ['project'] }],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
+    const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
+    const nodeConfig = optionsArg?.nodeConfig as Record<string, unknown>;
+    expect(nodeConfig?.settingSources).toEqual(['project']);
+    // Claude supports settingSources — no ignored-capability warning
+    const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
+    const warnings = sendMessage.mock.calls
+      .map(call => call[1] as string)
+      .filter(msg => typeof msg === 'string' && msg.includes('settingSources'));
+    expect(warnings).toEqual([]);
+  });
+
+  it('warns that settingSources is ignored on a Codex node', async () => {
+    mockGetAgentProviderDag.mockImplementation(() => ({
+      sendQuery: mockSendQueryDag,
+      getType: () => 'codex',
+      getCapabilities: mockCodexCapabilities,
+    }));
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-dag',
+      testDir,
+      {
+        name: 'dag-setting-sources-codex',
+        nodes: [{ id: 'step1', command: 'my-cmd', provider: 'codex', settingSources: ['project'] }],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    // Capability gate: codex declares settingSources: false, so the executor
+    // must surface a visible "will be ignored" warning instead of a silent no-op.
+    const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
+    const warnings = sendMessage.mock.calls
+      .map(call => call[1] as string)
+      .filter(msg => typeof msg === 'string' && msg.includes('settingSources'));
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain("doesn't support");
   });
 
   it('routes Codex tier effort to assistantConfig.modelReasoningEffort', async () => {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -932,6 +932,7 @@ async function resolveNodeProviderAndModel(
       (node.fallbackModel ?? workflowLevelOptions.fallbackModel) !== undefined,
     ],
     ['sandbox', 'sandbox', (node.sandbox ?? workflowLevelOptions.sandbox) !== undefined],
+    ['settingSources', 'settingSources', node.settingSources !== undefined],
     ['env', 'envInjection', (config.envVars && Object.keys(config.envVars).length > 0) === true],
   ];
 
@@ -1012,6 +1013,7 @@ async function resolveNodeProviderAndModel(
     maxBudgetUsd: node.maxBudgetUsd,
     systemPrompt: node.systemPrompt,
     fallbackModel: fb,
+    settingSources: node.settingSources,
   };
 
   // Pass assistantConfig from config — provider parses internally

--- a/packages/workflows/src/schemas.test.ts
+++ b/packages/workflows/src/schemas.test.ts
@@ -403,6 +403,44 @@ describe('dagNodeSchema — new Claude SDK options', () => {
       expect((result.data as PromptNode).fallbackModel).toBe('claude-haiku-4-5-20251001');
   });
 
+  test('parses settingSources array of valid sources', () => {
+    const result = dagNodeSchema.safeParse({
+      id: 'n',
+      prompt: 'do it',
+      settingSources: ['project'],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect((result.data as PromptNode).settingSources).toEqual(['project']);
+  });
+
+  test('rejects settingSources with invalid source value', () => {
+    const result = dagNodeSchema.safeParse({
+      id: 'n',
+      prompt: 'do it',
+      settingSources: ['project', 'global'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects non-array settingSources', () => {
+    const result = dagNodeSchema.safeParse({
+      id: 'n',
+      prompt: 'do it',
+      settingSources: 'project',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('strips settingSources from bash nodes', () => {
+    const result = dagNodeSchema.safeParse({
+      id: 'b',
+      bash: 'echo hi',
+      settingSources: ['project'],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect('settingSources' in result.data).toBe(false);
+  });
+
   test('strips AI-only fields from bash nodes', () => {
     const result = dagNodeSchema.safeParse({
       id: 'b',

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -218,6 +218,12 @@ export const dagNodeBaseSchema = z.object({
   // programmatically by the orchestrator for prompt caching; Zod intentionally stays narrow.
   systemPrompt: z.string().min(1).optional(),
   fallbackModel: z.string().min(1).optional(),
+  // Per-node override for which filesystem setting sources Claude loads
+  // (CLAUDE.md, skills, commands, agents). Omitting it inherits the
+  // assistant-level default (['project', 'user'] when unset). Claude-only;
+  // other providers warn and ignore it. Lets a lean node (e.g. a reviewer)
+  // skip project/user context loading for faster startup.
+  settingSources: z.array(z.enum(['project', 'user'])).optional(),
   betas: betasSchema.optional(),
   sandbox: sandboxSettingsSchema.optional(),
   // Opt out of resume caching: when true, this node re-runs on resume even if a
@@ -493,6 +499,7 @@ export const BASH_NODE_AI_FIELDS: readonly string[] = [
   'maxBudgetUsd',
   'systemPrompt',
   'fallbackModel',
+  'settingSources',
   'betas',
   'sandbox',
   'persist_session',
@@ -794,6 +801,7 @@ export const dagNodeSchema = dagNodeBaseSchema
       ...(data.maxBudgetUsd !== undefined ? { maxBudgetUsd: data.maxBudgetUsd } : {}),
       ...(data.systemPrompt !== undefined ? { systemPrompt: data.systemPrompt } : {}),
       ...(data.fallbackModel !== undefined ? { fallbackModel: data.fallbackModel } : {}),
+      ...(data.settingSources !== undefined ? { settingSources: data.settingSources } : {}),
       ...(data.betas !== undefined ? { betas: data.betas } : {}),
       ...(data.sandbox !== undefined ? { sandbox: data.sandbox } : {}),
       ...(data.persist_session !== undefined ? { persist_session: data.persist_session } : {}),

--- a/scripts/generate-capability-matrix.ts
+++ b/scripts/generate-capability-matrix.ts
@@ -63,6 +63,7 @@ const AXES: readonly { key: keyof ProviderCapabilities; label: string }[] = [
   { key: 'thinkingControl', label: 'Thinking control (`thinking`)' },
   { key: 'fallbackModel', label: 'Fallback model (`fallbackModel`)' },
   { key: 'sandbox', label: 'Sandbox (`sandbox`)' },
+  { key: 'settingSources', label: 'Setting sources (`settingSources`)' },
   { key: 'nativeTools', label: 'In-process native tools' },
   { key: 'containerExec', label: 'Container exec (folder-project container backend)' },
 ];


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: `settingSources` (which CLAUDE.md/skills/commands/agents the Claude SDK loads) is only configurable at the assistant level in `.archon/config.yaml` — every Claude node in a workflow loads the same setting sources, even lean nodes that need none of it.
- Why it matters: loading project + user context on every node costs real time. @avro198 measured 111s → 56s on a lean node with this override (original PR #1386).
- What changed: per-node `settingSources: ('project' | 'user')[]` on Claude workflow nodes. Resolution chain: node override → `assistants.claude.settingSources` → `['project', 'user']`. Gated behind a new `settingSources` capability axis (claude-only) so non-Claude nodes get the loud ignored-capability warning instead of a silent no-op. Docs + generated capability matrix updated.
- What did **not** change (scope boundary): no workflow-level `settingSources` default (per-node only, like `maxBudgetUsd`/`systemPrompt`); assistant-level config behavior and the `['project', 'user']` default are byte-for-byte unchanged for existing workflows; no other provider gains the knob.

## UX Journey

### Before

```
  Author                          Archon                        Claude SDK
  ──────                          ──────                        ──────────
  writes workflow YAML ─────────▶ every Claude node uses
                                  assistants.claude.settingSources
                                  (or ['project','user']) ─────▶ loads CLAUDE.md,
                                                                 skills, commands,
                                                                 agents on EVERY node
  lean reviewer node waits ◀───── ~2x slower node startup
```

### After

```
  Author                          Archon                        Claude SDK
  ──────                          ──────                        ──────────
  writes workflow YAML
  [settingSources: [] on          [node override wins over
   the lean node] ──────────────▶  assistant default] ─────────▶ [loads nothing for
                                                                  the lean node;
                                                                  writer node still
                                                                  loads the default]
  lean node starts fast ◀──────── (111s → 56s in #1386's measurement)

  non-Claude node with
  settingSources: ──────────────▶ *loud "will be ignored"*
                                  *capability warning*
```

## Architecture Diagram

### Before

```
  dag-node.ts (schema) ──▶ dag-executor.ts ──▶ NodeConfig ──▶ claude/provider.ts
       │                        │                                   │
       │                   capChecks table                 settingSources from
       │                   (no settingSources axis)        assistantConfig only
       └── BASH_NODE_AI_FIELDS                                      │
                                                       ProviderCapabilities
                                                       (no settingSources field)
```

### After

```
  dag-node.ts (schema) ──▶ dag-executor.ts ──▶ NodeConfig ──▶ claude/provider.ts
       │ [~]                    │ [~]             [~]               │ [~]
       │ +settingSources   capChecks table   +settingSources   node override ??
       │  in base schema,  [+settingSources  field             assistant default ??
       │  aiOnly spread     axis]                              ['project','user']
       └── [~] BASH_NODE_AI_FIELDS
            +settingSources                ProviderCapabilities [~]
                                           +settingSources: boolean
                                           (claude yes; codex/pi/opencode/copilot no)
                                                    │
                                                    ═══▶ [~] generate-capability-matrix.ts
                                                          (+ axis, regenerated docs page)
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `workflows/schemas/dag-node.ts` | `workflows/dag-executor.ts` | **modified** | new optional `settingSources` field on AI node variants |
| `workflows/dag-executor.ts` | `providers/types.ts` (`NodeConfig`) | **modified** | `node.settingSources` copied into `nodeConfig` |
| `workflows/dag-executor.ts` | provider `capabilities.ts` (via registry) | **modified** | new `capChecks` row warns when set on a provider with `settingSources: false` |
| `providers/claude/provider.ts` | Claude Agent SDK | **modified** | `settingSources` resolution now reads the node override first |
| `scripts/generate-capability-matrix.ts` | `docs-web .../provider-capabilities.md` | **modified** | new matrix axis, page regenerated |
| `providers/claude/config.ts` (assistant-level parse) | `providers/claude/provider.ts` | unchanged | assistant default still parsed/validated the same way |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `workflows`
- Module: `workflows:executor`, `providers:claude`

## Change Metadata

- Change type: `feature`
- Primary scope: `multi` (workflows + providers)

## Linked Issue

- Closes # — none; this is a takeover of a stale community PR, no tracking issue exists
- Related # —
- Depends on # —
- Supersedes #1386 (unmergeable against current dev; re-implemented on the current provider-registry/capability architecture with credit to @avro198 via `Co-authored-by`)

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # exit 0 — check:bundled, check:bundled-skill, check:bundled-schema,
                   # check:pi-vendor-map, check:capability-matrix, type-check (all packages),
                   # lint --max-warnings 0, format:check, per-package tests all green
```

- Evidence provided (test/log/trace/screenshot): new tests — provider resolution chain (node override wins / assistant default second / `['project','user']` fallback / explicit `[]` honored), executor propagation into `nodeConfig` + no-warning-on-claude, codex ignored-capability warning, schema accept/reject/strip-on-bash cases. Targeted suites re-run green: `providers/src/claude/provider.test.ts` (115 pass), `workflows/src/schemas.test.ts` (103 pass), `workflows/src/dag-executor.test.ts` (420 pass), `providers/src/codex/provider.test.ts` capability snapshot updated.
- If any command is intentionally skipped, explain why: none skipped.

## Security Impact (required)

- New permissions/capabilities? (`No`) — the field can only *narrow* what the SDK loads; the default (`['project', 'user']`) is unchanged and a node cannot widen beyond it (schema enum only allows `project`/`user`).
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`) — controls which existing setting files the Claude SDK reads, within its current access.
- If any `Yes`, describe risk and mitigation: n/a

## Compatibility / Migration

- Backward compatible? (`Yes`) — omitting the field keeps today's behavior exactly (assistant default, then `['project', 'user']`).
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: n/a

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: full `bun run validate` locally (exit 0); capability-matrix regeneration produces the new `settingSources` row (claude supported, codex/pi/opencode/copilot not); the generator's totality guard was exercised (it fails on the new `ProviderCapabilities` field until the axis is classified — then passes).
- Edge cases checked: explicit `settingSources: []` is honored as "load nothing" (does not fall through to the default); `settingSources` on a `bash:` node is stripped by the schema transform like its AI-only siblings; a codex node with the field produces exactly one visible warning.
- What was not verified: a live wall-clock benchmark reproducing the 111s→56s measurement (figure comes from #1386's author); loop nodes intentionally reject the field via `LOOP_NODE_AI_FIELDS` (inherited from the bash-field list, same as `fallbackModel`).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: workflow schema (new optional field), dag-executor nodeConfig assembly + capability warnings, Claude provider SDK-options build, provider capability matrix docs.
- Potential unintended effects: a node author setting `settingSources: []` also skips project CLAUDE.md conventions for that node — that's the feature, but worth knowing when a "lean" node produces off-convention output.
- Guardrails/monitoring for early detection: schema rejects unknown source values at load time; non-Claude usage emits the standard `dag.unsupported_capabilities` warning (log + chat message); provider tests lock the resolution chain including the "never silently widen to/from the default" contract.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge-commit>` — single commit, additive-only; workflows using the field then fail schema validation loudly (strict enum) rather than silently changing behavior.
- Feature flags or config toggles (if any): none — omit the field to get pre-PR behavior.
- Observable failure symptoms: a Claude node unexpectedly missing project skills/commands (override set too aggressively), or capability warnings on non-Claude nodes.

## Risks and Mitigations

- Risk: regressing the `['project', 'user']` default (the original PR predates that default change — the known trap).
  - Mitigation: the final `?? ['project', 'user']` fallback is unchanged and locked by three pre-existing tests plus the new chain tests; the node override only takes effect when explicitly authored.
- Risk: silent no-op on providers without the knob.
  - Mitigation: new `settingSources` capability axis + `capChecks` row — non-Claude nodes warn loudly (test-covered), and the generated capability matrix documents support per provider.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-node `settingSources` configuration for Claude workflows.
  * Choose project-only, user-only, or no setting sources for individual nodes.
  * Claude supports this option; other providers display a warning and ignore it.
* **Documentation**
  * Updated workflow, AI assistant, and provider capability documentation with configuration details and examples.
* **Bug Fixes**
  * Node-level settings now correctly override assistant-level defaults, including explicit opt-out with `[]`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->