### PR TITLE
fix(web): add IME composition guard to console ChatComposer + approval input

### DIFF
--- a/packages/web/src/experiments/console/components/ApprovalPanel.tsx
+++ b/packages/web/src/experiments/console/components/ApprovalPanel.tsx
@@ -95,6 +95,9 @@ export function ApprovalPanel({ run }: ApprovalPanelProps): ReactElement {
 
   const onApproveKey = (e: ReactKeyboardEvent<HTMLInputElement>): void => {
     stopPropagation(e);
+    // Don't submit while an IME composition is in progress (Japanese,
+    // Chinese, Korean, etc. — the first Enter accepts a candidate).
+    if (e.nativeEvent.isComposing || e.keyCode === 229) return;
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       void approve();

--- a/packages/web/src/experiments/console/components/ChatComposer.tsx
+++ b/packages/web/src/experiments/console/components/ChatComposer.tsx
@@ -102,6 +102,9 @@ export function ChatComposer({
   };
 
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>): void => {
+    // Don't submit while an IME composition is in progress (Japanese,
+    // Chinese, Korean, etc. — the first Enter accepts a candidate).
+    if (e.nativeEvent.isComposing || e.keyCode === 229) return;
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       submit();


### PR DESCRIPTION
## Summary

- Problem: The console ChatComposer (`onKeyDown`) and the ApprovalPanel approve input (`onApproveKey`) send on plain Enter with no IME composition guard, so CJK users pressing Enter to confirm an IME candidate send the message mid-compose.
- Why it matters: The console is the default shipping UI; every Japanese/Chinese/Korean IME user hits this on every composed message and approval comment.
- What changed: Added the guard already established in `DraftRunCard.tsx` — `if (e.nativeEvent.isComposing || e.keyCode === 229) return;` (with the same explanatory comment) — before the `Enter && !shiftKey` branch in both handlers.
- What did **not** change (scope boundary): Only the two console components. No server/API changes, no changes to legacy `components/chat/MessageInput.tsx` (already fixed in #1497, mounted only under `/legacy`), and `onRejectKey` untouched (Cmd/Ctrl+Enter does not conflict with IME confirmation).

## UX Journey

### Before

```
CJK user                       Console composer
────────                       ────────────────
types kana/pinyin ───────────▶ IME composition open
presses Enter (confirm) ─────▶ onKeyDown sees key === 'Enter'
                               submit() fires *mid-compose*
half-composed text sent ◀───── message posted prematurely
```

### After

```
CJK user                       Console composer
────────                       ────────────────
types kana/pinyin ───────────▶ IME composition open
presses Enter (confirm) ─────▶ [isComposing / keyCode 229 → return]
                               candidate accepted, nothing sent
presses Enter again ─────────▶ submit() fires with the full text
composed text sent ◀────────── message posted as intended
```

## Architecture Diagram

### Before

```
ChatComposer.onKeyDown ──▶ onSend (chat message)
ApprovalPanel.onApproveKey ──▶ skill.approveRun
DraftRunCard.onTextareaKey ──[IME guard]──▶ submit (run start)
```

### After

```
ChatComposer.onKeyDown ──[~ IME guard]──▶ onSend (chat message)
ApprovalPanel.onApproveKey ──[~ IME guard]──▶ skill.approveRun
DraftRunCard.onTextareaKey ──[IME guard]──▶ submit (unchanged)
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `ChatComposer.onKeyDown` | `onSend` callback | **modified** | Early-return added before the Enter send branch |
| `ApprovalPanel.onApproveKey` | `approve()` | **modified** | Early-return added after `stopPropagation`, before the Enter branch |
| `DraftRunCard.onTextareaKey` | `submit()` | unchanged | Source pattern being mirrored |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `web`
- Module: `web:console`

## Change Metadata

- Change type: `bug`
- Primary scope: `web`

## Linked Issue

- Closes #2215
- Supersedes #1497 — that PR (diagnosis credit to @anyueruhui, carried as `Co-authored-by` on the commit) fixed only the legacy `MessageInput.tsx`, which is mounted solely under `/legacy` and slated for deletion; this PR brings the fix to the shipping console UI.

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate
```

- Evidence provided (test/log/trace/screenshot): `bun run validate` exits 0 locally — all generated-file checks, type-check, lint (`--max-warnings 0`), format check, and the full per-package test suite pass.
- If any command is intentionally skipped, explain why: No new unit test added — `@archon/web` has no component/DOM test harness (its only console `.test.tsx`, `RunStream.test.tsx`, tests an exported pure function without rendering), and inventing a rendering harness for a 2-line early-return guard is not warranted. The identical guard in `DraftRunCard.tsx` ships untested for the same reason.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: n/a

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No
- If yes, exact upgrade steps: n/a

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Guard mirrors `DraftRunCard.tsx` verbatim (including comment); confirmed `e.keyCode` passes this repo's zero-warning lint there and here (lint-staged eslint ran clean on commit).
- Edge cases checked: `onApproveKey` keeps `stopPropagation(e)` ahead of the guard so global keymaps stay suppressed during composition; Escape during composition early-returns, matching DraftRunCard's accepted behavior (the IME itself handles Escape natively).
- What was not verified: Live keystroke test with a real CJK IME in a browser.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Console chat send and approval-gate approve input only.
- Potential unintended effects: None expected — the guard is a no-op unless a composition is in progress (`isComposing`) or the browser reports the IME-processing keyCode 229.
- Guardrails/monitoring for early detection: Plain-Enter send behavior for non-IME input is untouched; any regression would be immediately visible in the composer.

## Rollback Plan (required)

- Fast rollback command/path: `git revert 920d4222` (single commit, two files, 6 inserted lines).
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: Enter failing to send messages outside IME composition.

## Risks and Mitigations

- Risk: `keyCode` is deprecated and could be dropped by future browsers.
  - Mitigation: `e.nativeEvent.isComposing` is the primary check; `keyCode === 229` only covers legacy Safari/older engines, matching the existing DraftRunCard precedent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text composition support in chat and approval workflows.
  * Pressing Enter during Japanese, Chinese, Korean, and other IME input composition no longer prematurely submits messages or approvals.
  * Enter behaves normally after candidate selection or text composition is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->