### PR TITLE
fix(core): harden clone against credential prompts and token leaks

### DIFF
--- a/packages/core/src/handlers/clone.test.ts
+++ b/packages/core/src/handlers/clone.test.ts
@@ -499,15 +499,13 @@ describe('cloneRepository', () => {
 
       await cloneRepository('https://github.com/owner/repo');
 
-      const cloneCall = spyExecFileAsync.mock.calls.find(
-        (args: unknown[]) =>
-          args[0] === 'git' && Array.isArray(args[1]) && (args[1] as string[])[0] === 'clone'
-      );
+      const cloneCall = (
+        spyExecFileAsync.mock.calls as [string, string[], { env?: NodeJS.ProcessEnv }][]
+      ).find(args => args[0] === 'git' && args[1]?.[0] === 'clone');
       expect(cloneCall).toBeDefined();
-      const opts = cloneCall?.[2] as { env?: Record<string, string> } | undefined;
-      expect(opts?.env?.GIT_TERMINAL_PROMPT).toBe('0');
+      expect(cloneCall?.[2]?.env?.GIT_TERMINAL_PROMPT).toBe('0');
       // The rest of the environment must be inherited, not stripped
-      expect(opts?.env?.PATH).toBe(process.env.PATH);
+      expect(cloneCall?.[2]?.env?.PATH).toBe(process.env.PATH);
     });
   });
 

--- a/packages/core/src/handlers/clone.test.ts
+++ b/packages/core/src/handlers/clone.test.ts
@@ -503,9 +503,14 @@ describe('cloneRepository', () => {
         spyExecFileAsync.mock.calls as [string, string[], { env?: NodeJS.ProcessEnv }][]
       ).find(args => args[0] === 'git' && args[1]?.[0] === 'clone');
       expect(cloneCall).toBeDefined();
-      expect(cloneCall?.[2]?.env?.GIT_TERMINAL_PROMPT).toBe('0');
-      // The rest of the environment must be inherited, not stripped
-      expect(cloneCall?.[2]?.env?.PATH).toBe(process.env.PATH);
+      const env = cloneCall?.[2]?.env ?? {};
+      expect(env.GIT_TERMINAL_PROMPT).toBe('0');
+      // The rest of the environment must be inherited, not stripped. On
+      // Windows the key can be 'Path' — spreading process.env keeps the
+      // original casing — so locate the path key case-insensitively.
+      const pathKey = Object.keys(env).find(k => k.toLowerCase() === 'path');
+      expect(pathKey).toBeDefined();
+      expect(env[pathKey!]).toBe(process.env[pathKey!]);
     });
   });
 

--- a/packages/core/src/handlers/clone.test.ts
+++ b/packages/core/src/handlers/clone.test.ts
@@ -492,6 +492,25 @@ describe('cloneRepository', () => {
     });
   });
 
+  // ── GIT_TERMINAL_PROMPT fail-fast (salvaged from PR #1404, credit @mlnchk) ─
+  describe('fail-fast env', () => {
+    test('passes GIT_TERMINAL_PROMPT=0 to the git clone subprocess', async () => {
+      mockCreateCodebase.mockResolvedValueOnce(makeCodebase() as ReturnType<typeof makeCodebase>);
+
+      await cloneRepository('https://github.com/owner/repo');
+
+      const cloneCall = spyExecFileAsync.mock.calls.find(
+        (args: unknown[]) =>
+          args[0] === 'git' && Array.isArray(args[1]) && (args[1] as string[])[0] === 'clone'
+      );
+      expect(cloneCall).toBeDefined();
+      const opts = cloneCall?.[2] as { env?: Record<string, string> } | undefined;
+      expect(opts?.env?.GIT_TERMINAL_PROMPT).toBe('0');
+      // The rest of the environment must be inherited, not stripped
+      expect(opts?.env?.PATH).toBe(process.env.PATH);
+    });
+  });
+
   // ── resolveForgeAuth unit tests ──────────────────────────────────────────
   describe('resolveForgeAuth', () => {
     const { resolveForgeAuth } = require('./clone');

--- a/packages/core/src/handlers/clone.ts
+++ b/packages/core/src/handlers/clone.ts
@@ -381,7 +381,11 @@ export async function cloneRepository(repoUrl: string): Promise<RegisterResult> 
   }
 
   try {
-    await execFileAsync('git', ['clone', cloneUrl, targetPath]);
+    // GIT_TERMINAL_PROMPT=0 turns any missing-creds scenario into an
+    // immediate, readable error instead of a hung stdin credential prompt.
+    await execFileAsync('git', ['clone', cloneUrl, targetPath], {
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    });
   } catch (error) {
     const safeErr = sanitizeError(error as Error);
     throw new Error(`Failed to clone repository: ${safeErr.message}`);

--- a/packages/core/src/utils/credential-sanitizer.test.ts
+++ b/packages/core/src/utils/credential-sanitizer.test.ts
@@ -30,6 +30,48 @@ describe('credential-sanitizer', () => {
       const input = 'https://unknown_token@github.com/user/repo';
       expect(sanitizeCredentials(input)).toBe('https://[REDACTED]@github.com/user/repo');
     });
+
+    // Salvaged from PR #1404 (credit @mlnchk), adapted to the generalized
+    // userinfo redaction that preserves the host.
+    it('should replace GITLAB_TOKEN value in string', () => {
+      process.env.GITLAB_TOKEN = 'glpat-abc123';
+      const input = 'fatal: auth failed using token glpat-abc123';
+      const result = sanitizeCredentials(input);
+      expect(result).not.toContain('glpat-abc123');
+      expect(result).toContain('[REDACTED]');
+    });
+
+    it('should replace GITEA_TOKEN value in string', () => {
+      process.env.GITEA_TOKEN = 'gitea-secret-456';
+      const input = 'fatal: auth failed using token gitea-secret-456';
+      const result = sanitizeCredentials(input);
+      expect(result).not.toContain('gitea-secret-456');
+      expect(result).toContain('[REDACTED]');
+    });
+
+    it('should sanitize oauth2-style URL credentials on any host', () => {
+      process.env.GITLAB_TOKEN = ''; // Clear env token so only URL regex matches
+      const input =
+        'fatal: clone failed for https://oauth2:glpat-secret@gitlab.example.com/owner/repo.git';
+      const result = sanitizeCredentials(input);
+      expect(result).not.toContain('glpat-secret');
+      expect(result).toContain('https://[REDACTED]@gitlab.example.com/owner/repo.git');
+    });
+
+    it('should sanitize bare-token URL credentials on any host', () => {
+      const input = 'fatal: unable to access https://gitea-token@gitea.example.com/owner/repo.git';
+      const result = sanitizeCredentials(input);
+      expect(result).not.toContain('gitea-token');
+      expect(result).toBe(
+        'fatal: unable to access https://[REDACTED]@gitea.example.com/owner/repo.git'
+      );
+    });
+
+    it('should not alter URLs without embedded credentials', () => {
+      const input =
+        'see https://gitlab.example.com/owner/repo and https://example.com/docs/a@b for details';
+      expect(sanitizeCredentials(input)).toBe(input);
+    });
   });
 
   describe('sanitizeError', () => {

--- a/packages/core/src/utils/credential-sanitizer.ts
+++ b/packages/core/src/utils/credential-sanitizer.ts
@@ -3,7 +3,7 @@
  * Removes sensitive values from strings to prevent credential leaks
  */
 
-const SENSITIVE_ENV_VARS = ['GH_TOKEN', 'GITHUB_TOKEN'];
+const SENSITIVE_ENV_VARS = ['GH_TOKEN', 'GITHUB_TOKEN', 'GITLAB_TOKEN', 'GITEA_TOKEN'];
 
 function escapeRegExp(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -19,8 +19,13 @@ export function sanitizeCredentials(input: string): string {
     }
   }
 
-  // Catch any URL-embedded credentials we might have missed
-  result = result.replace(/https:\/\/[^@\s]+@github\.com/g, 'https://[REDACTED]@github.com');
+  // Catch any URL-embedded credentials we might have missed. Since #1658
+  // clone URLs can embed tokens on ANY host (oauth2:<token>@gitlab.example.com,
+  // <token>@gitea.example.com), so redact the whole userinfo (user[:pass]) of
+  // any scheme://userinfo@host form — the username itself can be the token —
+  // while keeping scheme and host for debugging. `[^@/\s]+` cannot cross a
+  // `/`, so URLs without embedded credentials are left untouched.
+  result = result.replace(/([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^@/\s]+@/g, '$1[REDACTED]@');
 
   return result;
 }

--- a/packages/git/src/git.test.ts
+++ b/packages/git/src/git.test.ts
@@ -1883,8 +1883,22 @@ branch refs/heads/feature/auth
       expect(execSpy).toHaveBeenCalledWith(
         'git',
         ['clone', 'https://github.com/owner/repo.git', '/tmp/target'],
-        { timeout: 120000 }
+        {
+          timeout: 120000,
+          env: expect.objectContaining({ GIT_TERMINAL_PROMPT: '0' }) as NodeJS.ProcessEnv,
+        }
       );
+    });
+
+    test('passes GIT_TERMINAL_PROMPT=0 to the git clone subprocess', async () => {
+      execSpy.mockResolvedValue({ stdout: '', stderr: '' });
+
+      await git.cloneRepository('https://github.com/owner/repo.git', '/tmp/target');
+
+      const opts = execSpy.mock.calls[0]![2];
+      expect(opts?.env?.GIT_TERMINAL_PROMPT).toBe('0');
+      // The rest of the environment must be inherited, not stripped
+      expect(opts?.env?.PATH).toBe(process.env.PATH);
     });
 
     test('constructs authenticated URL with token', async () => {

--- a/packages/git/src/git.test.ts
+++ b/packages/git/src/git.test.ts
@@ -1895,10 +1895,14 @@ branch refs/heads/feature/auth
 
       await git.cloneRepository('https://github.com/owner/repo.git', '/tmp/target');
 
-      const opts = execSpy.mock.calls[0]![2];
-      expect(opts?.env?.GIT_TERMINAL_PROMPT).toBe('0');
-      // The rest of the environment must be inherited, not stripped
-      expect(opts?.env?.PATH).toBe(process.env.PATH);
+      const env = execSpy.mock.calls[0]![2]?.env ?? {};
+      expect(env.GIT_TERMINAL_PROMPT).toBe('0');
+      // The rest of the environment must be inherited, not stripped. On
+      // Windows the key can be 'Path' — spreading process.env keeps the
+      // original casing — so locate the path key case-insensitively.
+      const pathKey = Object.keys(env).find(k => k.toLowerCase() === 'path');
+      expect(pathKey).toBeDefined();
+      expect(env[pathKey!]).toBe(process.env[pathKey!]);
     });
 
     test('constructs authenticated URL with token', async () => {

--- a/packages/git/src/repo.ts
+++ b/packages/git/src/repo.ts
@@ -351,7 +351,12 @@ export async function cloneRepository(
       cloneUrl = parsed.toString();
     }
 
-    await execFileAsync('git', ['clone', cloneUrl, targetPath], { timeout: 120000 });
+    // GIT_TERMINAL_PROMPT=0 turns any missing-creds scenario into an
+    // immediate, readable error instead of a hung stdin credential prompt.
+    await execFileAsync('git', ['clone', cloneUrl, targetPath], {
+      timeout: 120000,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    });
     return { ok: true, value: undefined };
   } catch (error) {
     const err = error as Error;


### PR DESCRIPTION
## Summary

- Problem: `git clone` in the clone handler runs with no env overrides, so a clone with missing/invalid credentials can hang forever on an interactive credential prompt; and the credential sanitizer only knows `GH_TOKEN`/`GITHUB_TOKEN` and `@github.com` URLs, so since #1658 a failed GitLab/Gitea clone error can carry an embedded token (`oauth2:<GITLAB_TOKEN>@host`, `<GITEA_TOKEN>@host`) unredacted.
- Why it matters: a hung clone blocks the handler with no feedback, and a leaked token in an error message surfaces to chat platforms and logs.
- What changed: both clone exec sites — the handler's (`packages/core/src/handlers/clone.ts`) and `@archon/git`'s `cloneRepository` (`packages/git/src/repo.ts`, the project-registration clone path) — now pass `GIT_TERMINAL_PROMPT=0` merged over `process.env` (fail fast, env otherwise intact; the repo.ts site keeps its 120s timeout); `SENSITIVE_ENV_VARS` gains `GITLAB_TOKEN`/`GITEA_TOKEN`; the URL fallback regex is generalized from `@github.com`-only to redacting the userinfo of any `scheme://user[:pass]@host` form while preserving scheme and host.
- Tests: salvaged the two matching test cases from closed PR #1404 (credit @mlnchk, `Co-authored-by` on the commit) — the `GIT_TERMINAL_PROMPT=0` subprocess assertion and the GitLab/oauth2 redaction cases — adapted to the current `resolveForgeAuth` code and host-preserving redaction, plus a Gitea case and an over-redaction guard.
- What did **not** change (scope boundary): the forge-auth injection logic itself (`resolveForgeAuth`), `@archon/git`'s fetch/sync sites (fetch against an already-cloned remote is a different failure mode than first-contact clone), and PR #1404's unrelated hunks (binary resolvers, release skills, `GITLAB_URL` auth — superseded by #2210). Note: `@archon/git`'s `cloneRepository` was initially excluded, but self-review flagged it as the same hang class on the real project-registration clone path — same issue intent, so it's now covered.

## UX Journey

### Before

```
  User                        Archon (clone handler)              git
  ────                        ──────────────────────              ───
  /register-project URL ────▶ builds cloneUrl (may embed token)
                              execFileAsync git clone ──────────▶ creds missing
                                                                  → interactive prompt
                              ⏳ hangs indefinitely ◀───────────── waits on stdin
  (no feedback)

  on failure: error message may contain oauth2:<token>@host  ──▶ leaked to user/logs
```

### After

```
  User                        Archon (clone handler)              git
  ────                        ──────────────────────              ───
  /register-project URL ────▶ builds cloneUrl (may embed token)
                              execFileAsync git clone
                              [env: GIT_TERMINAL_PROMPT=0] ─────▶ creds missing
                              fails fast ◀──────────────────────  *immediate error*
  sees readable error ◀─────  sanitizeError:
                              [scheme://user[:pass]@host →
                               scheme://[REDACTED]@host, any host]
```

## Architecture Diagram

### Before

```
  clone.ts (cloneRepository)
      │ execFileAsync('git', ['clone', ...])          (no env)
      ▼
  @archon/git exec.ts ──▶ child_process.execFile
      │ on error
      ▼
  credential-sanitizer.ts   [GH_TOKEN/GITHUB_TOKEN + @github.com only]
```

### After

```
  clone.ts (cloneRepository)          @archon/git repo.ts (cloneRepository)
      │ execFileAsync('git',              │ execFileAsync('git', ['clone', ...],
      │  ['clone', ...], {env})           │  {timeout, env})
      │ [~] GIT_TERMINAL_PROMPT=0         │ [~] same env, timeout preserved
      ▼                                   ▼
  @archon/git exec.ts ──▶ child_process.execFile      (env option already supported — unchanged)
      │ on error
      ▼
  credential-sanitizer.ts   [~] +GITLAB_TOKEN/+GITEA_TOKEN; generalized userinfo redaction
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `core/handlers/clone.ts` | `@archon/git` `execFileAsync` | **modified** | now passes `env` (already a supported option; no signature change) |
| `git/repo.ts` `cloneRepository` | `git/exec.ts` `execFileAsync` | **modified** | same `env` addition, existing 120s timeout preserved |
| `core/handlers/clone.ts` | `core/utils/credential-sanitizer.ts` | unchanged | same `sanitizeError` call, wider coverage |
| `core/credentials/oauth-bridge.ts` | `core/utils/credential-sanitizer.ts` | unchanged | existing caller benefits from wider redaction |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`
- Module: `core:clone`

## Change Metadata

- Change type: `security`
- Primary scope: `core`

## Linked Issue

- Closes #2211
- Related #1404 (closed PR this salvages tests from), #1658, #2210

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # all nine checks green (generated-file checks, type-check, lint, format, tests)
bun test packages/core/src/handlers/clone.test.ts               # 74 pass
bun test packages/core/src/utils/credential-sanitizer.test.ts   # 9 pass
bun test packages/git/src/git.test.ts                           # 164 pass
```

- Evidence provided (test/log/trace/screenshot): test counts above; new tests assert `GIT_TERMINAL_PROMPT=0` + inherited `PATH` on the clone subprocess, GitLab/Gitea token redaction, host-preserving oauth2-URL redaction, and a no-over-redaction guard.
- If any command is intentionally skipped, explain why: none skipped.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation: change is strictly narrowing — more token values redacted, and URL-embedded credentials are redacted on any host instead of only github.com. The generalized regex redacts only the userinfo portion (`[^@/\s]+` cannot cross `/`), so URLs without embedded credentials are untouched; a guard test covers this.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: n/a

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: ran both touched test files standalone; confirmed sanitizer output preserves host (`https://[REDACTED]@gitlab.example.com/...`) for both `oauth2:token@` and bare-token forms.
- Edge cases checked: `ssh://git@host` userinfo is redacted too (accepted — username-position can carry tokens on GitHub/Gitea); `https://example.com/docs/a@b` (path `@`, no userinfo) is untouched; env spread keeps `PATH` intact.
- What was not verified: a live hanging-clone repro against a real credential-prompting remote (behavior is git's documented `GIT_TERMINAL_PROMPT` contract).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: repository clone/register paths (`/register-project`, `POST /api/codebases` clone flow, and `@archon/git` `cloneRepository` used by project registration); error sanitization also used by `oauth-bridge` error details.
- Potential unintended effects: error messages that legitimately contained `scheme://name@host` userinfo now show `[REDACTED]` in the userinfo position (host still visible).
- Guardrails/monitoring for early detection: `clone_started`/`clone_completed` logs unchanged; failed clones now surface immediately as `Failed to clone repository: ...`.

## Rollback Plan (required)

- Fast rollback command/path: `git revert` of the single commit (isolated, two files + tests).
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: clones failing with auth errors where an interactive prompt was previously (incorrectly) relied upon; over-redacted error text.

## Risks and Mitigations

- Risk: some environment relied on interactive credential prompts during server-side clones.
  - Mitigation: intentional — a headless server should fail fast; tokens are provided via `GH_TOKEN`/`GITLAB_TOKEN`/`GITEA_TOKEN` env (the supported path since #1658/#2210).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Git clone operations now fail promptly with a clear error when credentials are missing, instead of waiting for interactive input.
  - Improved protection for sensitive credentials in error messages and URLs, including GitLab, Gitea, OAuth, and other token formats.
  - Credential-free URLs remain unchanged while embedded secrets are redacted.

- **Tests**
  - Added coverage for non-interactive cloning, environment inheritance, and expanded credential sanitization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->