### PR TITLE
docs(capabilities): surface per-cell caveats in the generated capability matrix

### DIFF
--- a/packages/docs-web/src/content/docs/reference/provider-capabilities.md
+++ b/packages/docs-web/src/content/docs/reference/provider-capabilities.md
@@ -38,8 +38,8 @@ per-node YAML field for that provider; a ❌ means the field is accepted but ign
 | Session resume | ✅ | ✅ | ✅ | ✅ | ✅ |
 | MCP servers (`mcp:`) | ✅ | ✅ | ✅ | ❌ | ✅ |
 | Hooks (`hooks:`) | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Skills (`skills:`) | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Inline sub-agents (`agents:`) | ✅ | ❌ | ✅ | ❌ | ✅ |
+| Skills (`skills:`) | ✅ | ✅¹ | ✅ | ✅ | ✅ |
+| Inline sub-agents (`agents:`) | ✅ | ❌ | ✅² | ❌ | ✅ |
 | Tool restrictions (`allowed_tools`/`denied_tools`) | ✅ | ❌ | ✅ | ✅ | ✅ |
 | Structured output (`output_format`) | **enforced** | **enforced** | **enforced** | best-effort | best-effort |
 | Env injection (`env:`) | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -51,9 +51,16 @@ per-node YAML field for that provider; a ❌ means the field is accepted but ign
 | In-process native tools | ✅ | ❌ | ❌ | ✅ | ❌ |
 | Container exec (folder-project container backend) | ✅ | ❌ | ❌ | ❌ | ❌ |
 
+## Caveats
+
+- ¹ `codex` — Skills (`skills:`) — Filesystem auto-discovery from `.agents/skills/` — per-node `skills:` lists are informational; use `provider: claude` for node-scoped skills.
+- ² `opencode` — Inline sub-agents (`agents:`) — Config-file-based agent selection (named agents from `opencode.json`) with per-call model/tools overrides — not inline sub-agent definitions.
+
 ## Legend
 
 - **✅ / ❌** — the per-node field is wired for this provider, or accepted-but-ignored.
+- **✅¹ (superscript)** — supported, but with semantics that differ from the headline
+  meaning of the axis — see [Caveats](#caveats).
 - **Structured output** — `enforced` (the SDK/backend grammar-constrains decoding),
   `best-effort` (schema appended to the prompt, then validated + re-asked up to 3×),
   or ❌ (unsupported). See [AI Assistants → Structured output guarantees](/getting-started/ai-assistants/#structured-output-guarantees).

--- a/scripts/generate-capability-matrix.ts
+++ b/scripts/generate-capability-matrix.ts
@@ -74,6 +74,48 @@ const AXES: readonly { key: keyof ProviderCapabilities; label: string }[] = [
  */
 const SKIP_KEYS = new Set<keyof ProviderCapabilities>(['knownToolNames', 'renamedTools']);
 
+/**
+ * Per-cell caveats (#2219): capabilities that ARE wired for a provider but
+ * with semantics that differ from the axis's headline meaning. Each entry
+ * renders as a superscript marker on the cell (e.g. ✅¹) plus a numbered
+ * entry in the "Caveats" section under the table. Tier-valued axes
+ * (structuredOutput) already express their nuance directly in the cell — do
+ * not duplicate them here. `assertCaveatsValid` fails the generator on stale
+ * entries (unknown provider, axis-less key, or a caveat on a ❌ cell).
+ */
+const CAVEATS: readonly { provider: string; key: keyof ProviderCapabilities; note: string }[] = [
+  {
+    provider: 'codex',
+    key: 'skills',
+    note:
+      'Filesystem auto-discovery from `.agents/skills/` — per-node `skills:` lists are ' +
+      'informational; use `provider: claude` for node-scoped skills.',
+  },
+  {
+    provider: 'opencode',
+    key: 'agents',
+    note:
+      'Config-file-based agent selection (named agents from `opencode.json`) with per-call ' +
+      'model/tools overrides — not inline sub-agent definitions.',
+  },
+];
+
+const SUPERSCRIPT_DIGITS = ['⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹'] as const;
+
+/** Render a positive integer as unicode superscript digits (1 → ¹, 12 → ¹²). */
+function superscript(n: number): string {
+  return String(n)
+    .split('')
+    .map(d => SUPERSCRIPT_DIGITS[Number(d)])
+    .join('');
+}
+
+/** 1-based caveat number for a cell, or undefined when the cell has no caveat. */
+function caveatNumber(providerId: string, key: keyof ProviderCapabilities): number | undefined {
+  const idx = CAVEATS.findIndex(c => c.provider === providerId && c.key === key);
+  return idx === -1 ? undefined : idx + 1;
+}
+
 /** Render a single provider's value for an axis. */
 function renderCell(caps: ProviderCapabilities, key: keyof ProviderCapabilities): string {
   if (key === 'structuredOutput') {
@@ -106,6 +148,34 @@ function assertTotalCoverage(providers: ProviderInfo[]): void {
   }
 }
 
+/**
+ * Fail loudly on stale caveats: every caveat must point at a registered
+ * provider, at a capability the matrix renders as an axis, and at a cell that
+ * renders as supported — a caveat on a ❌ cell means the capability was turned
+ * off and the caveat text is stale.
+ */
+function assertCaveatsValid(providers: ProviderInfo[]): void {
+  const axisKeys = new Set<keyof ProviderCapabilities>(AXES.map(a => a.key));
+  for (const caveat of CAVEATS) {
+    const provider = providers.find(p => p.id === caveat.provider);
+    if (!provider) {
+      throw new Error(
+        `Caveat references unknown provider '${caveat.provider}'. Registered: ${providers.map(p => p.id).join(', ')}.`
+      );
+    }
+    if (!axisKeys.has(caveat.key)) {
+      throw new Error(
+        `Caveat for '${caveat.provider}' references capability '${caveat.key}', which has no matrix axis.`
+      );
+    }
+    if (renderCell(provider.capabilities, caveat.key) === '❌') {
+      throw new Error(
+        `Stale caveat: '${caveat.provider}' no longer declares '${caveat.key}' (cell renders ❌). Remove the caveat entry.`
+      );
+    }
+  }
+}
+
 function buildMarkdown(providers: ProviderInfo[]): string {
   const ids = providers.map(p => p.id);
 
@@ -116,8 +186,21 @@ function buildMarkdown(providers: ProviderInfo[]): string {
   const header = `| Capability | ${ids.map(id => `\`${id}\``).join(' | ')} |`;
   const divider = `|${' --- |'.repeat(ids.length + 1)}`;
   const rows = AXES.map(axis => {
-    const cells = providers.map(p => renderCell(p.capabilities, axis.key));
+    const cells = providers.map(p => {
+      const cell = renderCell(p.capabilities, axis.key);
+      const n = caveatNumber(p.id, axis.key);
+      return n === undefined ? cell : `${cell}${superscript(n)}`;
+    });
     return `| ${axis.label} | ${cells.join(' | ')} |`;
+  }).join('\n');
+
+  const caveatList = CAVEATS.map((c, i) => {
+    const axis = AXES.find(a => a.key === c.key);
+    if (!axis) {
+      // Unreachable: assertCaveatsValid runs before buildMarkdown.
+      throw new Error(`Caveat for '${c.provider}' has no axis for '${c.key}'.`);
+    }
+    return `- ${superscript(i + 1)} \`${c.provider}\` — ${axis.label} — ${c.note}`;
   }).join('\n');
 
   return [
@@ -156,9 +239,12 @@ function buildMarkdown(providers: ProviderInfo[]): string {
     divider,
     rows,
     '',
+    ...(CAVEATS.length > 0 ? ['## Caveats', '', caveatList, ''] : []),
     '## Legend',
     '',
     '- **✅ / ❌** — the per-node field is wired for this provider, or accepted-but-ignored.',
+    '- **✅¹ (superscript)** — supported, but with semantics that differ from the headline',
+    '  meaning of the axis — see [Caveats](#caveats).',
     '- **Structured output** — `enforced` (the SDK/backend grammar-constrains decoding),',
     '  `best-effort` (schema appended to the prompt, then validated + re-asked up to 3×),',
     '  or ❌ (unsupported). See [AI Assistants → Structured output guarantees](/getting-started/ai-assistants/#structured-output-guarantees).',
@@ -179,6 +265,7 @@ async function main(): Promise<void> {
     throw new Error('No providers registered — registry bootstrap failed.');
   }
   assertTotalCoverage(providers);
+  assertCaveatsValid(providers);
 
   const contents = buildMarkdown(providers);
 

--- a/scripts/generate-capability-matrix.ts
+++ b/scripts/generate-capability-matrix.ts
@@ -80,7 +80,7 @@ const SKIP_KEYS = new Set<keyof ProviderCapabilities>(['knownToolNames', 'rename
  * renders as a superscript marker on the cell (e.g. ✅¹) plus a numbered
  * entry in the "Caveats" section under the table. Tier-valued axes
  * (structuredOutput) already express their nuance directly in the cell — do
- * not duplicate them here. `assertCaveatsValid` fails the generator on stale
+ * not duplicate them here. `resolveCaveats` fails the generator on stale
  * entries (unknown provider, axis-less key, or a caveat on a ❌ cell).
  */
 const CAVEATS: readonly { provider: string; key: keyof ProviderCapabilities; note: string }[] = [
@@ -110,10 +110,12 @@ function superscript(n: number): string {
     .join('');
 }
 
-/** 1-based caveat number for a cell, or undefined when the cell has no caveat. */
-function caveatNumber(providerId: string, key: keyof ProviderCapabilities): number | undefined {
-  const idx = CAVEATS.findIndex(c => c.provider === providerId && c.key === key);
-  return idx === -1 ? undefined : idx + 1;
+/** A caveat validated against the registry and joined with its axis label. */
+interface ResolvedCaveat {
+  provider: string;
+  key: keyof ProviderCapabilities;
+  axisLabel: string;
+  note: string;
 }
 
 /** Render a single provider's value for an axis. */
@@ -149,21 +151,23 @@ function assertTotalCoverage(providers: ProviderInfo[]): void {
 }
 
 /**
- * Fail loudly on stale caveats: every caveat must point at a registered
+ * Validate the CAVEATS table and resolve each entry to its matrix axis.
+ * Fails loudly on stale caveats: every caveat must point at a registered
  * provider, at a capability the matrix renders as an axis, and at a cell that
  * renders as supported — a caveat on a ❌ cell means the capability was turned
  * off and the caveat text is stale.
  */
-function assertCaveatsValid(providers: ProviderInfo[]): void {
-  const axisKeys = new Set<keyof ProviderCapabilities>(AXES.map(a => a.key));
-  for (const caveat of CAVEATS) {
+function resolveCaveats(providers: ProviderInfo[]): ResolvedCaveat[] {
+  const axisByKey = new Map(AXES.map(a => [a.key, a] as const));
+  return CAVEATS.map(caveat => {
     const provider = providers.find(p => p.id === caveat.provider);
     if (!provider) {
       throw new Error(
         `Caveat references unknown provider '${caveat.provider}'. Registered: ${providers.map(p => p.id).join(', ')}.`
       );
     }
-    if (!axisKeys.has(caveat.key)) {
+    const axis = axisByKey.get(caveat.key);
+    if (!axis) {
       throw new Error(
         `Caveat for '${caveat.provider}' references capability '${caveat.key}', which has no matrix axis.`
       );
@@ -173,10 +177,11 @@ function assertCaveatsValid(providers: ProviderInfo[]): void {
         `Stale caveat: '${caveat.provider}' no longer declares '${caveat.key}' (cell renders ❌). Remove the caveat entry.`
       );
     }
-  }
+    return { provider: caveat.provider, key: caveat.key, axisLabel: axis.label, note: caveat.note };
+  });
 }
 
-function buildMarkdown(providers: ProviderInfo[]): string {
+function buildMarkdown(providers: ProviderInfo[], caveats: ResolvedCaveat[]): string {
   const ids = providers.map(p => p.id);
 
   const providerList = providers
@@ -188,20 +193,15 @@ function buildMarkdown(providers: ProviderInfo[]): string {
   const rows = AXES.map(axis => {
     const cells = providers.map(p => {
       const cell = renderCell(p.capabilities, axis.key);
-      const n = caveatNumber(p.id, axis.key);
-      return n === undefined ? cell : `${cell}${superscript(n)}`;
+      const idx = caveats.findIndex(c => c.provider === p.id && c.key === axis.key);
+      return idx === -1 ? cell : `${cell}${superscript(idx + 1)}`;
     });
     return `| ${axis.label} | ${cells.join(' | ')} |`;
   }).join('\n');
 
-  const caveatList = CAVEATS.map((c, i) => {
-    const axis = AXES.find(a => a.key === c.key);
-    if (!axis) {
-      // Unreachable: assertCaveatsValid runs before buildMarkdown.
-      throw new Error(`Caveat for '${c.provider}' has no axis for '${c.key}'.`);
-    }
-    return `- ${superscript(i + 1)} \`${c.provider}\` — ${axis.label} — ${c.note}`;
-  }).join('\n');
+  const caveatList = caveats
+    .map((c, i) => `- ${superscript(i + 1)} \`${c.provider}\` — ${c.axisLabel} — ${c.note}`)
+    .join('\n');
 
   return [
     '---',
@@ -239,7 +239,7 @@ function buildMarkdown(providers: ProviderInfo[]): string {
     divider,
     rows,
     '',
-    ...(CAVEATS.length > 0 ? ['## Caveats', '', caveatList, ''] : []),
+    ...(caveats.length > 0 ? ['## Caveats', '', caveatList, ''] : []),
     '## Legend',
     '',
     '- **✅ / ❌** — the per-node field is wired for this provider, or accepted-but-ignored.',
@@ -265,9 +265,9 @@ async function main(): Promise<void> {
     throw new Error('No providers registered — registry bootstrap failed.');
   }
   assertTotalCoverage(providers);
-  assertCaveatsValid(providers);
+  const caveats = resolveCaveats(providers);
 
-  const contents = buildMarkdown(providers);
+  const contents = buildMarkdown(providers, caveats);
 
   if (CHECK_ONLY) {
     let existing = '';


### PR DESCRIPTION
## Summary

- Problem: the generated capability matrix (`provider-capabilities.md`) showed Codex Skills as a plain ✅, but the runtime truth (`packages/providers/src/codex/capabilities.ts:7`) is filesystem auto-discovery from `.agents/skills/` only — per-node `skills:` lists are ignored. The skills guide documented the caveat; the matrix had drifted because it had no way to express "supported, with different semantics".
- Why it matters: the matrix is the *canonical*, drift-proof capability surface (`check:capability-matrix` gates CI) — an unqualified ✅ there actively misleads workflow authors into expecting node-scoped skills on Codex.
- What changed: the **generator** (`scripts/generate-capability-matrix.ts`) gained a typed `CAVEATS` table keyed by provider id + capability axis. Caveated cells render a superscript marker (`✅¹`) pointing at a new `## Caveats` section under the table; a fail-fast guard rejects stale entries (unknown provider, axis-less key, or a caveat on a ❌ cell). Applied to `codex` × skills and `opencode` × inline sub-agents (config-file-based agent selection, not inline definitions — per its `capabilities.ts` header). Matrix regenerated.
- What did **not** change (scope boundary): no runtime behavior, no `ProviderCapabilities` type change (doc strings would leak docs concerns into the `/api/providers` contract), no change to `structuredOutput` tier rendering (its nuance is already expressed in-cell), no change to guides/skills.md (already correct). True per-node Codex skill injection remains out of scope — prior art is PR #1534 (@borshyo), which prototyped it before #1868 shipped the filesystem approach and surfaced this drift.

## UX Journey

### Before

```
Workflow author                 archon.diy docs
───────────────                 ───────────────
opens capability matrix ──────▶ Skills (`skills:`) | codex: ✅
adds skills: to a codex node    (no qualifier)
runs workflow ────────────────▶ skills list silently informational
confused: skill not scoped
```

### After

```
Workflow author                 archon.diy docs
───────────────                 ───────────────
opens capability matrix ──────▶ Skills (`skills:`) | codex: [✅¹]
reads Caveats section ────────▶ [¹ filesystem auto-discovery; per-node
                                 lists informational; use provider: claude]
picks provider: claude for node-scoped skills
```

## Architecture Diagram

### Before

```
packages/providers/src/*/capabilities.ts
        │ (static constants, lazy registry)
        ▼
scripts/generate-capability-matrix.ts ──▶ provider-capabilities.md
        ▲                                  (✅/❌/tier cells only)
        └── check:capability-matrix (CI byte-equality gate)
```

### After

```
packages/providers/src/*/capabilities.ts
        │ (unchanged)
        ▼
scripts/generate-capability-matrix.ts [~]
  ├─ [+] CAVEATS table (provider × axis → note)
  ├─ [+] assertCaveatsValid (fail-fast on stale entries)
  └─ [+] superscript markers + "## Caveats" section
        │
        ▼
provider-capabilities.md [~] (✅¹ cells + Caveats section)
        ▲
        └── check:capability-matrix (unchanged gate, still green)
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `scripts/generate-capability-matrix.ts` | `@archon/providers` registry | unchanged | still reads only static capability metadata |
| `scripts/generate-capability-matrix.ts` | `provider-capabilities.md` | **modified** | output now carries caveat markers + section |
| `bun run validate` / CI | `check:capability-matrix` | unchanged | same byte-equality gate |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `docs`
- Module: `docs:capability-matrix`

## Change Metadata

- Change type: `docs`
- Primary scope: `docs`

## Linked Issue

- Closes #2219
- Related #1534 (prior art: per-node Codex skill injection prototype by @borshyo), #1868, #2116

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # all nine steps green (exit 0)
bun run generate:capability-matrix && bun run check:capability-matrix   # OK, byte-identical
```

- Evidence provided (test/log/trace/screenshot): `bun run validate` exit 0 locally (check:bundled, check:bundled-skill, check:bundled-schema, check:pi-vendor-map, check:capability-matrix, type-check, lint, format:check, tests all pass); regenerated file diff shows `✅¹`/`✅²` cells + Caveats section only.
- If any command is intentionally skipped, explain why: none skipped.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: n/a — docs generator only.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No
- If yes, exact upgrade steps: n/a

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: regenerated matrix renders `✅¹` (codex/skills) and `✅²` (opencode/agents) with a matching Caveats section; `check:capability-matrix` byte-equality passes after the lint-staged prettier pass (generator output is prettier-stable).
- Edge cases checked: guard behavior is exercised by construction — a caveat on an unknown provider, an axis-less key, or a ❌ cell throws before any file is written (exit 1, same failure channel as the existing totality guard).
- What was not verified: rendered Starlight page in a browser (plain unicode superscripts + a markdown section — no plugin dependency, so no rendering risk beyond standard markdown).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: docs site reference page + the generator script; nothing at runtime.
- Potential unintended effects: none beyond the docs page; the guard adds a new (intentional) failure mode for future stale caveats.
- Guardrails/monitoring for early detection: `check:capability-matrix` in `bun run validate` and CI.

## Rollback Plan (required)

- Fast rollback command/path: `git revert` the single commit, then `bun run generate:capability-matrix`.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: `check:capability-matrix` failing in CI, or a generator exit 1 naming the stale caveat.

## Risks and Mitigations

- Risk: a caveat silently outliving a capability change (the very drift class this fixes).
  - Mitigation: `assertCaveatsValid` hard-fails the generator (and thus `bun run validate`/CI via `check:capability-matrix`) when a caveat points at an unknown provider or a cell that renders ❌.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified differences in provider capability entries for Codex `skills:` and OpenCode `agents:`, now marked with superscripts.
  - Added a **Caveats** section describing what the superscripts mean, including filesystem auto-discovery and config/named-agent selection behavior.
  - Updated the capability matrix **Legend** to explain and link the superscript notation.
- **Improvements**
  - Enhanced capability matrix generation to validate caveat references and render per-cell annotations consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->