### PR TITLE
feat(docker): opt-in root fallback (ARCHON_ALLOW_ROOT_FALLBACK) for macOS bind mounts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -300,6 +300,15 @@ GITEA_ALLOWED_USERS=
 # NOT read by Archon source code.
 # ARCHON_USER_HOME=/opt/archon-user-home
 
+# Docker root fallback (opt-in escape hatch for macOS bind mounts).
+# On macOS VirtioFS bind mounts the entrypoint's ownership fix always fails
+# (host UIDs can't be remapped to container UID 1001), so the container exits 1.
+# Set to 1 to continue running as root instead. Side-effect: exports IS_SANDBOX=1,
+# which bypasses the Claude provider's UID-0 safety guard — AI subprocesses run
+# as root inside the container. Never auto-enabled; default (unset) fails loud.
+# On Linux, fix volume ownership instead: sudo chown -R 1001:1001 <path>
+# ARCHON_ALLOW_ROOT_FALLBACK=1
+
 # Logging (optional)
 # Set log level: fatal | error | warn | info | debug | trace
 # Default: info

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,7 +6,10 @@ set -e
 # which causes the Claude subprocess to fail silently when spawned with a missing cwd.
 mkdir -p /.archon/workspaces /.archon/worktrees
 
-# Determine if we need to use gosu for privilege dropping
+# Determine if we need to use gosu for privilege dropping.
+# Default: run commands as-is — already non-root (e.g., --user flag or
+# Kubernetes), or root via the explicit ARCHON_ALLOW_ROOT_FALLBACK opt-in below.
+RUNNER=""
 if [ "$(id -u)" = "0" ]; then
   # A blanket `chown -R` rewrites metadata for every inode (#1970); only files
   # with wrong ownership are touched.
@@ -45,16 +48,11 @@ if [ "$(id -u)" = "0" ]; then
     # bypassPermissions as root. Never auto-enabled — default stays fail-loud.
     echo "WARNING: ARCHON_ALLOW_ROOT_FALLBACK=1 — continuing as root with IS_SANDBOX=1." >&2
     export IS_SANDBOX=1
-    RUNNER=""
   else
-    # Fail loud (default). On macOS VirtioFS this failure is expected — set
-    # ARCHON_ALLOW_ROOT_FALLBACK=1 to opt in to running as root. On Linux,
-    # fix volume ownership instead (see the docker deployment guide).
+    # Fail loud (default) — see the docker deployment guide for the
+    # ARCHON_ALLOW_ROOT_FALLBACK opt-in.
     exit 1
   fi
-else
-  # Already running as non-root (e.g., --user flag or Kubernetes)
-  RUNNER=""
 fi
 
 # Warn if vars known to be ignored inside the container were set via env_file: .env.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,6 +11,14 @@ if [ "$(id -u)" = "0" ]; then
   # A blanket `chown -R` rewrites metadata for every inode (#1970); only files
   # with wrong ownership are touched.
   # find + chown -h leaves symlinks un-dereferenced (no-dereference by design).
+  #
+  # chown can fail when the host controls ownership: on macOS VirtioFS bind
+  # mounts, host UIDs cannot be remapped to appuser (1001) at all. On Linux,
+  # SELinux/AppArmor denials or read-only mounts produce the same failure and
+  # look identical from inside the container, so we cannot auto-distinguish.
+  # Failures are accumulated (not exited inline) so we can branch once below
+  # on the explicit ARCHON_ALLOW_ROOT_FALLBACK opt-in.
+  chown_failed=0
   fix_ownership() {
     local err
     # -o is correct: we want appuser:appuser on both, not "either matches".
@@ -19,7 +27,7 @@ if [ "$(id -u)" = "0" ]; then
         echo "$err" >&2
       fi
       echo "ERROR: Failed to fix ownership of $1 — volume may be read-only or mounted with incompatible options" >&2
-      exit 1
+      chown_failed=1
     fi
   }
   fix_ownership /.archon
@@ -28,7 +36,22 @@ if [ "$(id -u)" = "0" ]; then
   # and other user-specific state survive rebuilds. On bind mounts, host UIDs
   # don't map to appuser (1001), so fix ownership via fix_ownership as well.
   fix_ownership /home/appuser
-  RUNNER="gosu appuser"
+  if [ "$chown_failed" = "0" ]; then
+    RUNNER="gosu appuser"
+  elif [ "${ARCHON_ALLOW_ROOT_FALLBACK:-0}" = "1" ]; then
+    # Explicit opt-in (macOS VirtioFS escape hatch): continue as root.
+    # IS_SANDBOX=1 satisfies ClaudeProvider's UID-0 guard
+    # (packages/providers/src/claude/provider.ts), which otherwise refuses
+    # bypassPermissions as root. Never auto-enabled — default stays fail-loud.
+    echo "WARNING: ARCHON_ALLOW_ROOT_FALLBACK=1 — continuing as root with IS_SANDBOX=1." >&2
+    export IS_SANDBOX=1
+    RUNNER=""
+  else
+    # Fail loud (default). On macOS VirtioFS this failure is expected — set
+    # ARCHON_ALLOW_ROOT_FALLBACK=1 to opt in to running as root. On Linux,
+    # fix volume ownership instead (see the docker deployment guide).
+    exit 1
+  fi
 else
   # Already running as non-root (e.g., --user flag or Kubernetes)
   RUNNER=""

--- a/packages/docs-web/src/content/docs/deployment/docker.md
+++ b/packages/docs-web/src/content/docs/deployment/docker.md
@@ -759,7 +759,7 @@ The container runs as `appuser` (UID 1001). The entrypoint tries to fix ownershi
 sudo chown -R 1001:1001 /path/to/archon-data
 ```
 
-**On macOS** (Docker Desktop / VirtioFS bind mounts), host `chown` does **not** help — the host refuses to remap ownership to the container's UID 1001 no matter what the files are owned by on the host. The same applies to read-only mounts and SELinux/AppArmor denials on Linux. For the macOS case, opt in to the root fallback instead — see [Root fallback for macOS bind mounts (opt-in)](#root-fallback-for-macos-bind-mounts-opt-in).
+**On macOS** (Docker Desktop / VirtioFS bind mounts), host `chown` does **not** help — the host refuses to remap ownership to the container's UID 1001 no matter what the files are owned by on the host. For that case (and other failures `chown` can't fix, like read-only mounts or SELinux/AppArmor denials), see [Root fallback for macOS bind mounts (opt-in)](#root-fallback-for-macos-bind-mounts-opt-in).
 
 ### Port conflicts
 

--- a/packages/docs-web/src/content/docs/deployment/docker.md
+++ b/packages/docs-web/src/content/docs/deployment/docker.md
@@ -512,6 +512,28 @@ PI_CODING_AGENT_DIR=/.archon/pi
 
 This must be set before the container starts; the Pi SDK reads the variable on each file path lookup.
 
+### Root fallback for macOS bind mounts (opt-in)
+
+On every start the entrypoint fixes ownership of `/.archon` and `/home/appuser` so they are writable by `appuser` (UID 1001), then drops privileges. On **macOS bind mounts (VirtioFS)** this ownership fix always fails — the host controls file ownership and refuses to remap host UIDs to the container's UID 1001 — so the container exits 1 and crash-loops. Read-only mounts and SELinux/AppArmor denials on Linux fail the same way.
+
+`ARCHON_ALLOW_ROOT_FALLBACK` is the explicit escape hatch for this case:
+
+```ini
+# .env — opt in to running as root when the ownership fix fails
+ARCHON_ALLOW_ROOT_FALLBACK=1
+```
+
+| Value | Behavior when the ownership fix fails |
+|-------|----------------------------------------|
+| unset / anything but `1` (default) | Print the underlying `chown` error and exit 1 (fail loud — unchanged) |
+| `1` | Print a warning, `export IS_SANDBOX=1`, and continue running as **root** (privileges are not dropped to `appuser`) |
+
+The variable has **no effect** when the ownership fix succeeds — Linux setups with correct volume ownership are untouched.
+
+:::caution
+This is a deliberate security tradeoff and is **never auto-enabled**. Running as root also sets `IS_SANDBOX=1`, which bypasses the Claude provider's UID-0 safety guard (it otherwise refuses `bypassPermissions` as root) — so AI subprocesses run as root inside the container. That is acceptable on a single-operator macOS dev machine where the bind mount already scopes what the container can touch; it is the wrong fix on Linux, where the failure means the volume ownership is actually broken — run `sudo chown -R 1001:1001 <path>` on the host instead of opting in.
+:::
+
 ### Folder-project container isolation (`--container`) is unavailable in Docker
 
 The folder-project **container backend** (`archon workflow run … --container`) launches a
@@ -729,11 +751,15 @@ When using `--profile with-db`, ensure:
 
 ### Permission errors in `/.archon/`
 
-The container runs as `appuser` (UID 1001). If using bind mounts instead of Docker volumes:
+The container runs as `appuser` (UID 1001). The entrypoint tries to fix ownership of `/.archon` and `/home/appuser` on every start and exits 1 (with the underlying `chown` error) when it can't.
+
+**On Linux** with bind mounts instead of Docker volumes, fix the ownership on the host:
 
 ```bash
 sudo chown -R 1001:1001 /path/to/archon-data
 ```
+
+**On macOS** (Docker Desktop / VirtioFS bind mounts), host `chown` does **not** help — the host refuses to remap ownership to the container's UID 1001 no matter what the files are owned by on the host. The same applies to read-only mounts and SELinux/AppArmor denials on Linux. For the macOS case, opt in to the root fallback instead — see [Root fallback for macOS bind mounts (opt-in)](#root-fallback-for-macos-bind-mounts-opt-in).
 
 ### Port conflicts
 


### PR DESCRIPTION
## Summary

- Problem: on macOS VirtioFS (and SELinux / read-only bind mounts), `fix_ownership()` in `docker-entrypoint.sh` always fails — host UIDs cannot be remapped to container appuser (1001) — so the container exits 1 and crash-loops. Archon is unrunnable on macOS bind mounts without forking the image.
- Why it matters: the post-#1518/#1981 fail-loud posture is correct, but it has no escape hatch for hosts where the failure is expected and permanent.
- What changed: `fix_ownership()` accumulates failures (`chown_failed=1`) instead of exiting inline; after both paths run, one branch decides — default (var unset) keeps the loud `exit 1`, while an explicit `ARCHON_ALLOW_ROOT_FALLBACK=1` prints a warning and continues as root with `export IS_SANDBOX=1` (satisfies the UID-0 guard in `packages/providers/src/claude/provider.ts`). Docs: new opt-in section in the docker deployment guide, corrected "Permission errors" troubleshooting entry, and a `.env.example` entry.
- What did **not** change (scope boundary): the happy path (`chown` succeeds → `gosu appuser`) is untouched; the ClaudeProvider guard, compose files, and the isolation-container runner image are untouched. Default-unset output per failing path is byte-identical (same stderr echo, same ERROR line, same exit 1); the one disclosed difference is the compound-failure case — when `/.archon` fails, `/home/appuser` is now also attempted, emitting one extra diagnostic block before the same exit 1 (inherent to the accumulate design; see Side Effects / Blast Radius).

## UX Journey

### Before

```
macOS user: docker compose up -d
  entrypoint runs as root
  fix_ownership /.archon → find/chown fails (VirtioFS refuses UID remap)
  prints chown stderr + "ERROR: Failed to fix ownership of /.archon ..."
  exit 1
  → container crash-loops; no way to run Archon on macOS bind mounts
```

### After

```
macOS user (var unset — DEFAULT, unchanged):
  fix_ownership /.archon fails → same stderr + same ERROR line
  fix_ownership /home/appuser also runs → its error printed too      [*only diff: both paths reported]
  exit 1

macOS user (.env: ARCHON_ALLOW_ROOT_FALLBACK=1):
  both errors printed as above
  "WARNING: ARCHON_ALLOW_ROOT_FALLBACK=1 — continuing as root with IS_SANDBOX=1."  [+]
  export IS_SANDBOX=1; RUNNER=""                                                    [+]
  → server starts as root; ClaudeProvider's UID-0 guard passes via IS_SANDBOX=1

Linux user with correct volume ownership: no change whatsoever (chown succeeds, branch not taken).
```

## Architecture Diagram

### Before

```
docker-entrypoint.sh
  fix_ownership() ── find + chown fails ──▶ echo stderr + ERROR ──▶ exit 1 (inline)
  fix_ownership /.archon      (exit here means /home/appuser never attempted)
  fix_ownership /home/appuser
  RUNNER="gosu appuser"
```

### After

```
docker-entrypoint.sh
  [~] RUNNER="" hoisted as the single default (non-root branch and opt-in fallback both use it)
  [~] fix_ownership() ── find + chown fails ──▶ echo stderr + ERROR ──▶ chown_failed=1 (accumulate)
  fix_ownership /.archon
  fix_ownership /home/appuser
  [+] if chown_failed=0        ──▶ RUNNER="gosu appuser"          (unchanged happy path)
  [+] elif ARCHON_ALLOW_ROOT_FALLBACK=1 ═══▶ WARNING + export IS_SANDBOX=1 (RUNNER stays "")
  [+] else                     ──▶ exit 1                          (unchanged default)
                                       │
packages/providers/src/claude/provider.ts (unchanged)
  UID-0 guard: getProcessUid()===0 && IS_SANDBOX!=='1' → throw
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `fix_ownership()` failure | inline `exit 1` | **removed** | replaced by `chown_failed=1` accumulator |
| `fix_ownership()` failure | `chown_failed` accumulator | **new** | both paths report before the single branch |
| failure branch | `ARCHON_ALLOW_ROOT_FALLBACK` env var | **new** | explicit opt-in, `:-0` default |
| failure branch (opt-in) | `export IS_SANDBOX=1` (RUNNER keeps hoisted `""` default) | **new** | satisfies ClaudeProvider UID-0 guard |
| failure branch (default) | `exit 1` | **modified** | moved out of the function; same output, same exit code |
| ClaudeProvider UID-0 guard | `IS_SANDBOX` env | unchanged | still required to run as root |
| `docker-compose.yml` `env_file: .env` | entrypoint env | unchanged | how the var reaches the container |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `docs`
- Module: `docker:entrypoint`

## Change Metadata

- Change type: `feature`
- Primary scope: `multi` (docker entrypoint + docs)

## Linked Issue

- Closes #2225
- Supersedes #1573 — carries over the accepted design (capture stderr, accumulate failures, explicit opt-in, `IS_SANDBOX` handshake) rebuilt on the rewritten post-#1970 `fix_ownership()`. Credit: Co-authored-by @ztech-gthb.

## Validation Evidence (required)

Commands and result summary:

```bash
bash -n docker-entrypoint.sh   # syntax OK
bun run validate               # all nine checks green
```

- Evidence provided (test/log/trace/screenshot): `bash -n` clean; full `bun run validate` green (no TypeScript touched). Branch logic exercised in a throwaway local simulation with a stubbed failing chown — four scenarios verified: happy path (`RUNNER="gosu appuser"`, unchanged), one/both paths failing with var unset (byte-identical per-path error lines, exit 1), both failing with `ARCHON_ALLOW_ROOT_FALLBACK=1` (warning printed, `IS_SANDBOX=1` exported, `RUNNER=""`, exit 0 continues).
- If any command is intentionally skipped, explain why: no shell-test harness exists for `docker-entrypoint.sh` in this repo (nothing in tests or CI references it), so per convention verification is manual reasoning + `bash -n`; no new harness invented.

## Security Impact (required)

- New permissions/capabilities? (`Yes`) — but **only behind an explicit opt-in that is never auto-enabled**. With `ARCHON_ALLOW_ROOT_FALLBACK=1` set AND the ownership fix failing, the container keeps running as root and exports `IS_SANDBOX=1`, which bypasses ClaudeProvider's UID-0 refusal — AI subprocesses then run as root inside the container.
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`) — same chown targets; only the failure handling differs.
- If any `Yes`, describe risk and mitigation: risk is confined to operators who deliberately set the var (documented in three places with the side-effect spelled out). The default path is unchanged fail-loud `exit 1` — a typo'd var name falls through to it (safe failure mode). Net effect vs today is strictly opt-in; there is no code path that broadens privileges without the operator's explicit action. Docs steer Linux operators to fix volume ownership instead of opting in, so real misconfigurations aren't masked.

## Compatibility / Migration

- Backward compatible? (`Yes`) — default-unset behavior is unchanged (same error output per failing path, same exit 1); happy-path installs see zero difference.
- Config/env changes? (`Yes`) — one new opt-in env var, `ARCHON_ALLOW_ROOT_FALLBACK` (documented in `.env.example` and the docker deployment guide). No action needed unless opting in.
- Database migration needed? (`No`)
- If yes, exact upgrade steps: macOS bind-mount users add `ARCHON_ALLOW_ROOT_FALLBACK=1` to `.env` (reaches the container via `env_file: .env`).

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: `bash -n` syntax check; local simulation of the extracted branch logic under `set -e` with a stubbed failing chown covering all four combinations of {0,1,2 failing paths} × {var unset, `=0`, `=1`} — output bytes and exit codes match the spec in #2225.
- Edge cases checked: `set -e` does not abort on the captured failure (it occurs inside the `if !` guard, same shape as current code); `${ARCHON_ALLOW_ROOT_FALLBACK:-0}` is set-u-safe; values other than exactly `1` fall through to `exit 1`; `local err` scoping preserved.
- What was not verified: a real macOS VirtioFS end-to-end container start (no macOS Docker Desktop bind-mount reproduction in this environment) and a real SELinux denial. The failure path shape is identical to the simulated one; the `IS_SANDBOX=1` handshake matches the guard at `packages/providers/src/claude/provider.ts` exactly.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `docker-entrypoint.sh` only (compose stack startup); docs. No TypeScript, schema, or build changes.
- Potential unintended effects: with var unset and `/.archon` failing, `/home/appuser` is now also attempted before exit — one additional diagnostic error block on stderr (inherent to the accumulate design; strictly more informative, same exit 1). CI/monitoring that detects misconfigured volumes via the crash-loop still sees exit 1.
- Guardrails/monitoring for early detection: the WARNING line names the var and the `IS_SANDBOX=1` side-effect on every fallback boot, so a root-running container is always loud in `docker compose logs`.

## Rollback Plan (required)

- Fast rollback command/path: revert the commit — behavior returns to current dev (fail-loud unconditionally). No data migration.
- Feature flags or config toggles (if any): the env var itself is the toggle; unsetting it restores fail-loud behavior without a code change.
- Observable failure symptoms: if the fallback misbehaves, the container either crash-loops with the printed chown errors (default path) or runs as root announcing the WARNING line — both visible in container logs.

## Risks and Mitigations

- Risk: a Linux operator masks a genuine volume misconfiguration by setting the var instead of fixing ownership.
  - Mitigation: docs (deployment guide caution + troubleshooting entry + `.env.example`) explicitly say the var is the wrong fix on Linux and give the `chown -R 1001:1001` command; the default remains fail-loud.
- Risk: future entrypoint additions bypass the accumulator with a new inline `exit 1`.
  - Mitigation: the comment block above `fix_ownership()` documents the accumulate-then-branch pattern and why it exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in root fallback for macOS bind-mount setups when ownership fixes fail via `ARCHON_ALLOW_ROOT_FALLBACK=1`.
  * When enabled, the container continues in a safer sandbox mode (`IS_SANDBOX=1`) instead of stopping immediately.

* **Documentation**
  * Updated the Docker deployment guide with macOS-specific troubleshooting and OS-aware permission guidance for `/.archon/`.
  * Expanded security cautions and recommended alternatives (such as fixing volume ownership on Linux).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->