### PR TITLE
refactor(git,paths): unify owner/repo identity resolution on @archon/paths

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -1783,8 +1783,9 @@ describe('workflowRunCommand', () => {
     (conversationDb.getOrCreateConversation as ReturnType<typeof mock>).mockResolvedValueOnce({
       id: 'conv-123',
     });
-    // Single-segment checkout path — resolveOwnerRepo's path heuristic throws
-    // for these, so the stored owner/repo name must reach the provider (#2022).
+    // Single-segment checkout path — the stored owner/repo name must reach the
+    // provider so worktrees use the registered identity instead of the
+    // _local/<basename> path fallback (#2022, #2227).
     (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce({
       id: 'cb-123',
       name: 'owner/repo',

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1349,8 +1349,8 @@ export async function workflowRunCommand(
           : undefined,
         baseBranch: codebaseDefaultBranch ? git.toBranchName(codebaseDefaultBranch) : undefined,
         codebaseId: codebase.id,
-        // owner/repo name lets resolveOwnerRepo skip the path heuristic, which
-        // throws for single-segment checkout paths like /workspace (#2022)
+        // owner/repo name lets resolveOwnerRepo use the registered identity
+        // instead of the _local/<basename> path fallback (#2022, #2227)
         codebaseName: codebase.name,
         canonicalRepoPath: git.toRepoPath(codebase.default_cwd),
         description: `CLI workflow: ${workflowName}`,

--- a/packages/core/src/orchestrator/orchestrator-isolation.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-isolation.test.ts
@@ -22,6 +22,18 @@ mock.module('@archon/paths', () => ({
   getProjectWorktreesPath: mock(
     (owner: string, repo: string) => `/home/test/.archon/workspaces/${owner}/${repo}/worktrees`
   ),
+  // Required by @archon/git worktree.ts (shared identity resolution, #2227).
+  parseOwnerRepo: mock((name: string) => {
+    const parts = name.split('/');
+    if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+    return { owner: parts[0], repo: parts[1] };
+  }),
+  resolveRepoProjectIdentity: mock((name: string, cwd: string) => {
+    const parts = name.split('/');
+    if (parts.length === 2 && parts[0] && parts[1]) return { owner: parts[0], repo: parts[1] };
+    const repo = cwd.split('/').filter(Boolean).pop() ?? '';
+    return repo === '' || repo === '.' || repo === '..' ? null : { owner: '_local', repo };
+  }),
 }));
 
 // DB mocks

--- a/packages/git/src/git.test.ts
+++ b/packages/git/src/git.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach, mock, spyOn, type Mock } from 'bun:test';
 import { writeFile, mkdir as realMkdir, rm } from 'fs/promises';
-import { join } from 'path';
+import { basename, join } from 'path';
 import { tmpdir, homedir } from 'os';
 
 // ---------------------------------------------------------------------------
@@ -47,12 +47,38 @@ function getArchonHome(): string {
   return process.env.ARCHON_HOME ?? join(homedir(), '.archon');
 }
 
+/** Mirror of @archon/paths parseOwnerRepo (must stay aligned with SAFE_NAME). */
+const SAFE_NAME = /^[a-zA-Z0-9._-]+$/;
+function parseOwnerRepo(name: string): { owner: string; repo: string } | null {
+  const parts = name.split('/');
+  if (parts.length !== 2) return null;
+  const [owner, repo] = parts;
+  if (!owner || !repo) return null;
+  if (owner === '.' || owner === '..' || repo === '.' || repo === '..') return null;
+  if (!SAFE_NAME.test(owner) || !SAFE_NAME.test(repo)) return null;
+  return { owner, repo };
+}
+
+/** Mirror of @archon/paths resolveRepoProjectIdentity (_local/<basename> fallback). */
+function resolveRepoProjectIdentity(
+  name: string,
+  cwd: string
+): { owner: string; repo: string } | null {
+  const parsed = parseOwnerRepo(name);
+  if (parsed) return parsed;
+  const repo = basename(cwd);
+  if (repo === '' || repo === '.' || repo === '..') return null;
+  return { owner: '_local', repo };
+}
+
 mock.module('@archon/paths', () => ({
   createLogger: mock(() => mockLogger),
   getArchonWorktreesPath: () => join(getArchonHome(), 'worktrees'),
   getArchonWorkspacesPath: () => join(getArchonHome(), 'workspaces'),
   getProjectWorktreesPath: (owner: string, repo: string) =>
     join(getArchonHome(), 'workspaces', owner, repo, 'worktrees'),
+  parseOwnerRepo,
+  resolveRepoProjectIdentity,
 }));
 
 // ---------------------------------------------------------------------------
@@ -196,15 +222,16 @@ describe('git utilities', () => {
 
     test('returns workspace-scoped base for a local non-workspace repo (via path fallback)', () => {
       // New-model invariant: every repo resolves to workspace-scoped. For a repo
-      // living outside ~/.archon/workspaces/, owner/repo is derived from the last
-      // two path segments (extractOwnerRepo) so the worktree base is still stable.
+      // living outside ~/.archon/workspaces/, the identity is the shared
+      // _local/<basename> fallback (resolveRepoProjectIdentity) — the same
+      // identity registration and log/artifact resolution use (#2227).
       delete process.env.WORKTREE_BASE;
       delete process.env.WORKSPACE_PATH;
       delete process.env.ARCHON_HOME;
       delete process.env.ARCHON_DOCKER;
       const result = git.getWorktreeBase('/workspace/my-repo');
       expect(result).toEqual({
-        base: join(homedir(), '.archon', 'workspaces', 'workspace', 'my-repo', 'worktrees'),
+        base: join(homedir(), '.archon', 'workspaces', '_local', 'my-repo', 'worktrees'),
         layout: 'workspace-scoped',
       });
     });
@@ -216,7 +243,7 @@ describe('git utilities', () => {
       process.env.ARCHON_HOME = '/custom/archon';
       const result = git.getWorktreeBase('/workspace/my-repo');
       expect(result).toEqual({
-        base: join('/custom/archon', 'workspaces', 'workspace', 'my-repo', 'worktrees'),
+        base: join('/custom/archon', 'workspaces', '_local', 'my-repo', 'worktrees'),
         layout: 'workspace-scoped',
       });
     });
@@ -226,7 +253,7 @@ describe('git utilities', () => {
       process.env.ARCHON_DOCKER = 'true';
       const result = git.getWorktreeBase('/workspace/my-repo');
       expect(result).toEqual({
-        base: join('/', '.archon', 'workspaces', 'workspace', 'my-repo', 'worktrees'),
+        base: join('/', '.archon', 'workspaces', '_local', 'my-repo', 'worktrees'),
         layout: 'workspace-scoped',
       });
     });
@@ -281,17 +308,63 @@ describe('git utilities', () => {
       });
     });
 
-    test('ignores invalid codebaseName and falls back to path-derived owner/repo', () => {
+    test('ignores invalid codebaseName and falls back to _local/<basename>', () => {
       // "invalid-no-slash" doesn't parse as owner/repo; the layout still resolves
-      // to workspace-scoped using the last two segments of the repoPath.
+      // to workspace-scoped using the shared _local/<basename> identity.
       delete process.env.WORKSPACE_PATH;
       delete process.env.ARCHON_DOCKER;
       delete process.env.ARCHON_HOME;
       const result = git.getWorktreeBase('/local/repo', 'invalid-no-slash');
       expect(result).toEqual({
-        base: join(homedir(), '.archon', 'workspaces', 'local', 'repo', 'worktrees'),
+        base: join(homedir(), '.archon', 'workspaces', '_local', 'repo', 'worktrees'),
         layout: 'workspace-scoped',
       });
+    });
+
+    test('ignores SSH-URL-shaped codebaseName (contains ":" / "@") and falls back to _local', () => {
+      // Regression guard (PR #1583): a codebase registered with
+      // name = "git@host.example:org/repo" used to be split naively at the last
+      // slash, yielding owner = "git@host.example:org" — that colon broke
+      // docker-compose volume parsing in worktrees (short-form
+      // `HOST:CONTAINER:OPT` mounts inside devcontainers). The strict validator
+      // must reject names containing characters outside `[A-Za-z0-9._-]` and
+      // fall back to the shared _local/<basename> identity.
+      delete process.env.WORKSPACE_PATH;
+      delete process.env.ARCHON_DOCKER;
+      delete process.env.ARCHON_HOME;
+      const result = git.getWorktreeBase(
+        '/srv/projects/widget-app',
+        'git@git.example.net:acme/widget-app'
+      );
+      expect(result).toEqual({
+        base: join(homedir(), '.archon', 'workspaces', '_local', 'widget-app', 'worktrees'),
+        layout: 'workspace-scoped',
+      });
+      // Check only the path below homedir — on Windows the home directory
+      // itself contains ":" in the drive letter (e.g. C:\Users\...).
+      const relativeToHome = result.base.slice(homedir().length);
+      expect(relativeToHome).not.toContain(':');
+      expect(relativeToHome).not.toContain('@');
+    });
+
+    test('resolves single-segment checkout paths via _local fallback (no throw)', () => {
+      // The historical last-two-segments heuristic threw for paths like
+      // /workspace (#2022); the shared fallback handles them.
+      delete process.env.WORKSPACE_PATH;
+      delete process.env.ARCHON_DOCKER;
+      delete process.env.ARCHON_HOME;
+      const result = git.getWorktreeBase('/workspace');
+      expect(result).toEqual({
+        base: join(homedir(), '.archon', 'workspaces', '_local', 'workspace', 'worktrees'),
+        layout: 'workspace-scoped',
+      });
+    });
+
+    test('throws for a degenerate repo path with no usable basename', () => {
+      delete process.env.WORKSPACE_PATH;
+      delete process.env.ARCHON_DOCKER;
+      delete process.env.ARCHON_HOME;
+      expect(() => git.getWorktreeBase('/')).toThrow('Cannot derive a project identity');
     });
 
     test('repoLocal override wins over workspace-scoped default', () => {
@@ -379,37 +452,6 @@ describe('git utilities', () => {
       delete process.env.ARCHON_DOCKER;
       delete process.env.ARCHON_HOME;
       expect(git.isProjectScopedWorktreeBase('/local/repo', 'invalid')).toBe(true);
-    });
-  });
-
-  describe('extractOwnerRepo', () => {
-    test('extracts owner and repo from a multi-segment path', () => {
-      const result = git.extractOwnerRepo(git.toRepoPath('/home/user/owner/repo'));
-      expect(result).toEqual({ owner: 'owner', repo: 'repo' });
-    });
-
-    test('extracts owner and repo from exactly 2-segment path', () => {
-      const result = git.extractOwnerRepo(git.toRepoPath('/owner/repo'));
-      expect(result).toEqual({ owner: 'owner', repo: 'repo' });
-    });
-
-    test('extracts owner and repo from Windows-style path', () => {
-      const result = git.extractOwnerRepo(
-        'C:\\Users\\dev\\owner\\repo' as ReturnType<typeof git.toRepoPath>
-      );
-      expect(result).toEqual({ owner: 'owner', repo: 'repo' });
-    });
-
-    test('throws when repoPath has fewer than 2 segments', () => {
-      expect(() => git.extractOwnerRepo(git.toRepoPath('/repo'))).toThrow(
-        'Cannot extract owner/repo from path "/repo"'
-      );
-    });
-
-    test('throws when repoPath is empty', () => {
-      expect(() => git.extractOwnerRepo('' as ReturnType<typeof git.toRepoPath>)).toThrow(
-        'Cannot extract owner/repo from path ""'
-      );
     });
   });
 

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -17,7 +17,6 @@ export { execFileAsync, mkdirAsync, resolveBashPath } from './exec';
 
 // Worktree operations
 export {
-  extractOwnerRepo,
   getWorktreeBase,
   isProjectScopedWorktreeBase,
   worktreeExists,

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -1,6 +1,12 @@
 import { readFile, access } from 'fs/promises';
 import { join, resolve } from 'path';
-import { createLogger, getArchonWorkspacesPath, getProjectWorktreesPath } from '@archon/paths';
+import {
+  createLogger,
+  getArchonWorkspacesPath,
+  getProjectWorktreesPath,
+  parseOwnerRepo,
+  resolveRepoProjectIdentity,
+} from '@archon/paths';
 import { execFileAsync } from './exec';
 import type { RepoPath, BranchName, WorktreePath, WorktreeInfo } from './types';
 import { toRepoPath, toBranchName, toWorktreePath } from './types';
@@ -43,23 +49,33 @@ export interface WorktreeBaseOverride {
  * Resolve the `{ owner, repo }` identity used to scope archon-managed worktrees.
  *
  * Precedence:
- *   1. Explicit `codebaseName` in `owner/repo` format (from the database / web UI)
+ *   1. Explicit `codebaseName` in strict `owner/repo` format (from the database /
+ *      web UI), validated by the shared `parseOwnerRepo()`
  *   2. Path segments when `repoPath` is already under `~/.archon/workspaces/owner/repo/`
- *   3. Last two path segments of `repoPath` (works for any local checkout)
+ *   3. The shared project-identity fallback: `_local/<basename(repoPath)>`
+ *      (`resolveRepoProjectIdentity()` in `@archon/paths`)
  *
- * The third fallback is what lets non-cloned / locally-registered repos still
- * land in the workspace-scoped layout — every repo gets a stable owner/repo
- * identity derived from its filesystem path.
+ * Identity decisions are delegated to `@archon/paths` so the worktree base
+ * always agrees with the storage identity that registration writes to disk and
+ * that log/artifact path resolution uses (#2227). Historically the fallback
+ * derived owner/repo from the last two path segments, inventing a junk "owner"
+ * from the checkout's parent directory and disagreeing with the `_local/`
+ * storage tree (#2132).
  */
 function resolveOwnerRepo(
   repoPath: RepoPath,
   codebaseName?: string
 ): { owner: string; repo: string } {
   if (codebaseName) {
-    const parts = codebaseName.split('/');
-    if (parts.length === 2 && parts[0] && parts[1]) {
-      return { owner: parts[0], repo: parts[1] };
-    }
+    // Strict validation: owner/repo must match SAFE_NAME (a-zA-Z0-9._-) on both
+    // segments. Names that smuggle `:` or `@` through (e.g. an SSH remote URL
+    // mistakenly stored as the codebase name, "git@host:org/repo") would
+    // otherwise become path segments and break tools that treat `:` as a
+    // separator — most notably docker-compose short-form volume specs
+    // (`HOST:CONTAINER:OPT`). Reject and fall through to the path-derived
+    // identity (#1583).
+    const parsed = parseOwnerRepo(codebaseName);
+    if (parsed) return parsed;
     getLog().warn({ codebaseName }, 'worktree.invalid_codebase_name_format');
   }
   const workspacesPath = getArchonWorkspacesPath();
@@ -70,10 +86,18 @@ function resolveOwnerRepo(
       return { owner: parts[0], repo: parts[1] };
     }
   }
-  // Fallback: derive from path basename/parent-basename — covers local-registered
-  // repos that never lived under workspaces/. Delegates to extractOwnerRepo()
-  // which throws on pathologically short paths.
-  return extractOwnerRepo(repoPath);
+  // Fallback: the shared storage-identity resolver — the same
+  // `_local/<basename>` identity that registration creates on disk and that
+  // the workflow executor uses for logs/artifacts, so all project paths agree.
+  // The name (if any) was already rejected above, so this resolves purely from
+  // the path.
+  const identity = resolveRepoProjectIdentity(codebaseName ?? '', repoPath);
+  if (!identity) {
+    throw new Error(
+      `Cannot derive a project identity from path "${repoPath}": basename is empty or a dot segment`
+    );
+  }
+  return identity;
 }
 
 /**
@@ -376,18 +400,4 @@ export async function verifyWorktreeOwnership(
         'Remove it from that clone or use a different codebase registration.'
     );
   }
-}
-
-/**
- * Extract owner and repo name from the last two segments of a repository path.
- * Throws if the path has fewer than 2 non-empty segments.
- */
-export function extractOwnerRepo(repoPath: RepoPath): { owner: string; repo: string } {
-  const parts = repoPath.split(/[/\\]/).filter(p => p.length > 0);
-  if (parts.length < 2) {
-    throw new Error(
-      `Cannot extract owner/repo from path "${repoPath}": expected at least 2 path segments`
-    );
-  }
-  return { owner: parts[parts.length - 2], repo: parts[parts.length - 1] };
 }

--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach, spyOn, mock, type Mock } from 'bun:test';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 
 // Fixed test home — path assertions use this constant; no duplication of production isDocker() logic.
 const TEST_ARCHON_HOME = '/test/.archon';
@@ -22,6 +22,41 @@ mock.module('@archon/paths', () => ({
   getProjectWorktreesPath: (owner: string, repo: string) =>
     join(TEST_ARCHON_HOME, 'workspaces', owner, repo, 'worktrees'),
   isDocker: () => false,
+  // Mirrors of the real @archon/paths identity helpers (worktree.ts delegates
+  // owner/repo resolution to these — #2227).
+  parseOwnerRepo: (name: string): { owner: string; repo: string } | null => {
+    const parts = name.split('/');
+    if (parts.length !== 2) return null;
+    const [owner, repo] = parts;
+    if (!owner || !repo) return null;
+    if (owner === '.' || owner === '..' || repo === '.' || repo === '..') return null;
+    const SAFE_NAME = /^[a-zA-Z0-9._-]+$/;
+    if (!SAFE_NAME.test(owner) || !SAFE_NAME.test(repo)) return null;
+    return { owner, repo };
+  },
+  resolveRepoProjectIdentity: (
+    name: string,
+    cwd: string
+  ): { owner: string; repo: string } | null => {
+    const parts = name.split('/');
+    if (parts.length === 2 && parts[0] && parts[1]) {
+      const SAFE_NAME = /^[a-zA-Z0-9._-]+$/;
+      const [owner, repo] = parts;
+      if (
+        owner !== '.' &&
+        owner !== '..' &&
+        repo !== '.' &&
+        repo !== '..' &&
+        SAFE_NAME.test(owner) &&
+        SAFE_NAME.test(repo)
+      ) {
+        return { owner, repo };
+      }
+    }
+    const repo = basename(cwd);
+    if (repo === '' || repo === '.' || repo === '..') return null;
+    return { owner: '_local', repo };
+  },
 }));
 
 import * as git from '@archon/git';
@@ -2486,10 +2521,30 @@ describe('WorktreeProvider', () => {
   });
 
   describe('cross-platform path handling', () => {
-    test('getWorktreePath handles Unix-style paths', () => {
+    test('getWorktreePath resolves non-workspace Unix paths via _local fallback', () => {
+      // Path outside the workspaces tree with no codebaseName — resolves to the
+      // shared _local/<basename> storage identity (#2227), not the historical
+      // last-two-segments heuristic.
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/home/dev/.archon/workspaces/owner/repo',
+        canonicalRepoPath: '/home/dev/projects/repo',
+        workflowType: 'issue',
+        identifier: '42',
+      };
+      const branchName = provider.generateBranchName(request);
+      const path = provider.getWorktreePath(request, branchName);
+      expect(path).toBe(
+        join(TEST_ARCHON_HOME, 'workspaces', '_local', 'repo', 'worktrees', branchName)
+      );
+      expect(path).toContain('issue-42');
+    });
+
+    test('getWorktreePath handles Windows-style separators under workspaces/', () => {
+      // The workspaces-prefix branch splits on both / and \ so a Windows-style
+      // repo path under the workspaces tree still yields owner/repo.
+      const request: IsolationRequest = {
+        codebaseId: 'cb-123',
+        canonicalRepoPath: `${join(TEST_ARCHON_HOME, 'workspaces')}\\owner\\repo`,
         workflowType: 'issue',
         identifier: '42',
       };
@@ -2500,10 +2555,10 @@ describe('WorktreeProvider', () => {
       expect(path).toContain('issue-42');
     });
 
-    test('getWorktreePath handles Windows-style paths', () => {
+    test('getWorktreePath handles mixed separator paths under workspaces/', () => {
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: 'C:\\Users\\dev\\.archon\\workspaces\\owner\\repo',
+        canonicalRepoPath: `${join(TEST_ARCHON_HOME, 'workspaces')}/owner\\repo`,
         workflowType: 'issue',
         identifier: '42',
       };
@@ -2514,21 +2569,9 @@ describe('WorktreeProvider', () => {
       expect(path).toContain('issue-42');
     });
 
-    test('getWorktreePath handles mixed separator paths', () => {
-      const request: IsolationRequest = {
-        codebaseId: 'cb-123',
-        canonicalRepoPath: 'C:/Users/dev\\.archon/workspaces\\owner/repo',
-        workflowType: 'issue',
-        identifier: '42',
-      };
-      const branchName = provider.generateBranchName(request);
-      const path = provider.getWorktreePath(request, branchName);
-      expect(path).toContain('owner');
-      expect(path).toContain('repo');
-      expect(path).toContain('issue-42');
-    });
-
-    test('getWorktreePath throws when repoPath has fewer than 2 segments', () => {
+    test('getWorktreePath resolves single-segment repo paths via _local fallback', () => {
+      // The historical last-two-segments heuristic threw for these (#2022);
+      // the shared fallback resolves them like any other checkout.
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
         canonicalRepoPath: '/repo', // only one segment
@@ -2536,8 +2579,21 @@ describe('WorktreeProvider', () => {
         identifier: '42',
       };
       const branchName = provider.generateBranchName(request);
+      expect(provider.getWorktreePath(request, branchName)).toBe(
+        join(TEST_ARCHON_HOME, 'workspaces', '_local', 'repo', 'worktrees', branchName)
+      );
+    });
+
+    test('getWorktreePath throws for a degenerate repo path with no basename', () => {
+      const request: IsolationRequest = {
+        codebaseId: 'cb-123',
+        canonicalRepoPath: '/',
+        workflowType: 'issue',
+        identifier: '42',
+      };
+      const branchName = provider.generateBranchName(request);
       expect(() => provider.getWorktreePath(request, branchName)).toThrow(
-        'Cannot extract owner/repo from path "/repo"'
+        'Cannot derive a project identity'
       );
     });
 

--- a/packages/paths/src/archon-paths.ts
+++ b/packages/paths/src/archon-paths.ts
@@ -395,9 +395,11 @@ export function parseOwnerRepo(name: string): { owner: string; repo: string } | 
 /**
  * Resolve the `{ owner, repo }` storage identity for a registered *repo*-kind
  * codebase. This is the single source of truth that keeps `registerRepository()`
- * (which creates the on-disk `owner/repo` tree) and the log/artifact path
- * resolvers in agreement — a mismatch between the two dropped no-remote repos'
- * logs/artifacts into `<cwd>/.archon` instead of `ARCHON_HOME` (#2132).
+ * (which creates the on-disk `owner/repo` tree), the log/artifact path
+ * resolvers, and the worktree base (`getWorktreeBase()` in `@archon/git`) in
+ * agreement — a mismatch between them dropped no-remote repos' logs/artifacts
+ * into `<cwd>/.archon` instead of `ARCHON_HOME` (#2132), and later split
+ * worktrees and storage across two different workspace trees (#2227).
  *
  * - A `name` in exact `owner/repo` form (clones, web-registered repos) → that
  *   owner/repo.


### PR DESCRIPTION
## Summary

- Problem: Two owner/repo resolvers with divergent fallbacks — `resolveOwnerRepo` (`@archon/git`, worktree base) fell back to the **last two path segments** of the checkout path, while `resolveRepoProjectIdentity` (`@archon/paths`, storage identity for registration/logs/artifacts since #2132) falls back to **`_local/<basename>`**. For repos without a clean `owner/repo` name (no-remote local registrations), one project was split across two workspace trees.
- Why it matters: worktrees landed under an invented "owner" (whatever parent directory the checkout sits in, e.g. `workspaces/projects/myrepo/`) while source symlink, logs, and artifacts lived at `workspaces/_local/myrepo/` — the worktree base and project root disagreed about the project's identity.
- What changed: `resolveOwnerRepo` now delegates both identity decisions to `@archon/paths` — strict `parseOwnerRepo` for the name branch (rejects SSH-URL-shaped names, preserving PR #1583's hardening) and `resolveRepoProjectIdentity` for the path fallback. `extractOwnerRepo` (the last-two-segments heuristic, which also threw on single-segment paths, #2022) is removed.
- What did **not** change (scope boundary): behavior for clean `owner/repo` names and for repos under `~/.archon/workspaces/` is byte-identical; `resolveRepoProjectIdentity` semantics for the executor/`continue` call sites are untouched; no on-disk migration of existing worktrees; folder-project (`_folder/<slug>`) identity untouched.

## UX Journey

### Before

```
User registers a no-remote local repo at /srv/projects/myrepo
  Registration writes:   ~/.archon/workspaces/_local/myrepo/source
  Logs/artifacts go to:  ~/.archon/workspaces/_local/myrepo/{logs,artifacts}   (#2132)
  Worktrees go to:       ~/.archon/workspaces/projects/myrepo/worktrees/       (!! different tree,
                                                                                "owner" = parent dir)
```

### After

```
User registers a no-remote local repo at /srv/projects/myrepo
  Registration writes:   ~/.archon/workspaces/_local/myrepo/source
  Logs/artifacts go to:  ~/.archon/workspaces/_local/myrepo/{logs,artifacts}
  Worktrees go to:       [~/.archon/workspaces/_local/myrepo/worktrees/]        (*same tree*)

Clean owner/repo names (clones, web-registered repos): unchanged in both flows.
```

## Architecture Diagram

### Before

```
@archon/git worktree.ts
  resolveOwnerRepo ── naive split('/') on codebaseName
                   ── workspaces-prefix segments
                   ── extractOwnerRepo (last-two-segments, throws on short paths)

@archon/paths archon-paths.ts
  parseOwnerRepo (strict SAFE_NAME)
  resolveRepoProjectIdentity ── parseOwnerRepo → _local/<basename>
        ▲                ▲
   executor.ts      cli continue.ts        clone.ts (registration, same semantics)
```

### After

```
@archon/paths archon-paths.ts            (single source of truth)
  parseOwnerRepo (strict SAFE_NAME)
  resolveRepoProjectIdentity ── parseOwnerRepo → _local/<basename>
        ▲                ▲            ▲                    ▲
   executor.ts      cli continue.ts   clone.ts    [~] @archon/git resolveOwnerRepo
                                                      (name branch === parseOwnerRepo,
                                                       fallback === resolveRepoProjectIdentity,
                                                       [-] extractOwnerRepo removed)
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `@archon/git` `worktree.ts` | `@archon/paths` `parseOwnerRepo` | **new** | strict name validation (subsumes PR #1583) |
| `@archon/git` `worktree.ts` | `@archon/paths` `resolveRepoProjectIdentity` | **new** | shared `_local/<basename>` fallback |
| `@archon/git` `worktree.ts` | `extractOwnerRepo` | **removed** | heuristic deleted, export dropped (no external callers) |
| `@archon/workflows` `executor.ts` | `resolveRepoProjectIdentity` | unchanged | |
| `@archon/cli` `continue.ts` | `resolveRepoProjectIdentity` | unchanged | |
| `@archon/core` `clone.ts` | `parseOwnerRepo` | unchanged | |
| `@archon/isolation` `providers/worktree.ts` | `getWorktreeBase` | unchanged | only caller of the resolver, create/adopt time only |

## Label Snapshot

- Risk: `risk: medium`
- Size: `size: S`
- Scope: `git`
- Module: `git:worktree`, `paths:archon-paths`

## Change Metadata

- Change type: `refactor`
- Primary scope: `multi`

## Linked Issue

- Closes #2227
- Related #2132, #2022, #1583

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # all nine gates green
```

- Evidence provided: full suite green locally, exit 0 (`check:bundled*`, `check:pi-vendor-map`, `check:capability-matrix`, type-check, lint, format check, all per-package test splits). New/updated tests in `packages/git/src/git.test.ts` and `packages/isolation/src/providers/worktree.test.ts` cover: clean names, invalid single-segment names, SSH-URL-shaped names (rejected, no `:`/`@` below home), single-segment checkout paths (no longer throws), degenerate root path (throws), workspaces-prefix precedence incl. Windows/mixed separators, `repoLocal` override.
- If any command is intentionally skipped, explain why: none skipped.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- The strict name validation *narrows* what can become a path segment (SAFE_NAME only), same posture as PR #1583.

## Compatibility / Migration

- Backward compatible? Yes for clean `owner/repo` names and workspaces-resident repos (byte-identical paths). Behavior change only for repos whose name is not a valid `owner/repo` (no-remote local registrations, SSH-URL-shaped names): **newly created** worktrees land under `workspaces/_local/<basename>/worktrees/` instead of `workspaces/<parent-dir>/<basename>/worktrees/`.
- Config/env changes? No
- Database migration needed? No
- Existing worktrees are not moved and not orphaned: every lifecycle flow (resolver reuse, resume, `archon complete`, `isolation list/cleanup`) reads the absolute `working_path` recorded in `isolation_environments`, and git tracks worktrees by absolute path. Verified at `resolver.ts:184,263,325,369` and `commands/isolation.ts:57,121,124,252`.

## Human Verification (required)

- Verified scenarios: full call-site audit of both resolvers (`getWorktreeBase` → isolation provider only, create/adopt time; `resolveRepoProjectIdentity` → executor + `cli continue` + registration); confirmed registration already writes `_local/<basename>` for no-remote repos, so the worktree side was the lone outlier.
- Edge cases checked: single-segment checkout paths (`/workspace`) now resolve instead of throwing (#2022 comment updated); degenerate root path fails fast; SSH-shaped names produce no `:`/`@` path segments.
- What was not verified: a live end-to-end worktree creation for a no-remote local repo (covered by unit tests + isolation provider suite).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: worktree placement for repos without a clean `owner/repo` name; `@archon/git` public API (drops `extractOwnerRepo`, no external callers).
- Potential unintended effects: a DB-untracked legacy worktree holding branch X + a new request for the same branch will miss adoption (new expected path) — git then fails loudly with "branch already checked out at <old path>", which is actionable and consistent with the trust-git-guardrails principle. Stale empty legacy base dirs may linger until manual cleanup.
- Guardrails/monitoring: `worktree.invalid_codebase_name_format` WARN fires whenever the name branch rejects; fallback identity failure throws with an explicit message.

## Rollback Plan (required)

- Fast rollback command/path: `git revert` of the single commit — no data/schema coupling; newly created `_local/` worktrees remain manageable via their DB-recorded paths after rollback.
- Feature flags or config toggles: none.
- Observable failure symptoms: worktrees appearing under an unexpected `workspaces/` owner, or worktree creation errors mentioning "Cannot derive a project identity".

## Risks and Mitigations

- Risk: interaction with open PR #1583 (adds the same strict `parseOwnerRepo` validation to `resolveOwnerRepo`). This PR subsumes its production change, so the rejection semantics survive either merge order; whichever lands second needs a trivial rebase. #1583's new regression test asserts the rejected SSH-shaped name falls back to the last-two-segments path (`workspaces/projects/widget-app`) — under the converged fallback that expectation becomes `workspaces/_local/widget-app` (its `:`/`@` assertions still hold). An equivalent regression test is included here.
  - Mitigation: interaction called out to the #1583 author path; test expectation delta is a one-line change on rebase.
- Risk: relocated placement for future worktrees of affected repos (see Compatibility).
  - Mitigation: lifecycle flows are DB-path-driven (verified); convergence matches the identity registration already writes to disk.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree identity and path resolution for local, nonstandard, and single-segment repository paths.
  * Prevented invalid repository names or SSH-style inputs from producing incorrect worktree locations.
  * Standardized fallback paths under `_local/<repository>` and improved error handling when identity cannot be determined.
* **Tests**
  * Expanded coverage for cross-platform paths, local repositories, and workspace configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->