### PR TITLE
feat(git): support configurable git remote name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Configurable git remote name** — new optional `worktree.remote` in `.archon/config.yaml` plus `getDefaultRemote()` auto-detection (`origin` if it exists, else the sole remote, actionable error on ambiguity). Worktree creation, workspace sync, PR checkout, forge detection, and cleanup all honor the resolved remote, so repos whose only remote isn't named `origin` work out of the box. Default behavior for `origin`-based repos is unchanged. (#1548)
+
 ## [0.6.0] - 2026-07-20
 
 Folder projects, opt-in Docker container isolation, three new workflow-composition primitives (`include:`, `loop_group`, `loop.command`), the Archon Studio builder preview, and a large security + reliability batch spanning gates, providers, Windows, Docker, and the console.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- **Configurable git remote name** — new optional `worktree.remote` in `.archon/config.yaml` plus `getDefaultRemote()` auto-detection (`origin` if it exists, else the sole remote, actionable error on ambiguity). Worktree creation, workspace sync, PR checkout, forge detection, and cleanup all honor the resolved remote, so repos whose only remote isn't named `origin` work out of the box. Default behavior for `origin`-based repos is unchanged. (#1548)
-
 ## [0.6.0] - 2026-07-20
 
 Folder projects, opt-in Docker container isolation, three new workflow-composition primitives (`include:`, `loop_group`, `loop.command`), the Archon Studio builder preview, and a large security + reliability batch spanning gates, providers, Windows, Docker, and the console.

--- a/packages/core/src/config/config-loader.test.ts
+++ b/packages/core/src/config/config-loader.test.ts
@@ -476,6 +476,59 @@ worktree:
       expect(config.baseBranch).toBeUndefined();
     });
 
+    test('propagates remote from repo worktree config', async () => {
+      const pathMatches = (path: string, pattern: string): boolean => {
+        const normalizedPath = path.replace(/\\/g, '/');
+        return normalizedPath.includes(pattern);
+      };
+
+      mockFsReadFile.mockImplementation(async (path: string) => {
+        if (pathMatches(path, '/repo/.archon/config.yaml')) {
+          return `
+worktree:
+  remote: upstream
+`;
+        }
+        const error = new Error('ENOENT') as NodeJS.ErrnoException;
+        error.code = 'ENOENT';
+        throw error;
+      });
+
+      const config = await loadConfig('/test/repo');
+      expect(config.remote).toBe('upstream');
+    });
+
+    test('trims whitespace from remote', async () => {
+      const pathMatches = (path: string, pattern: string): boolean => {
+        const normalizedPath = path.replace(/\\/g, '/');
+        return normalizedPath.includes(pattern);
+      };
+
+      mockFsReadFile.mockImplementation(async (path: string) => {
+        if (pathMatches(path, '/repo/.archon/config.yaml')) {
+          return `
+worktree:
+  remote: "  mar  "
+`;
+        }
+        const error = new Error('ENOENT') as NodeJS.ErrnoException;
+        error.code = 'ENOENT';
+        throw error;
+      });
+
+      const config = await loadConfig('/test/repo');
+      expect(config.remote).toBe('mar');
+    });
+
+    test('remote is undefined when not configured', async () => {
+      const error = new Error('ENOENT') as NodeJS.ErrnoException;
+      error.code = 'ENOENT';
+      mockFsReadFile.mockRejectedValue(error);
+
+      const config = await loadConfig('/test/repo');
+      expect(config.remote).toBeUndefined();
+    });
+
     test('global aliases are propagated to merged config', async () => {
       mockFsReadFile.mockResolvedValue(`
 aliases:

--- a/packages/core/src/config/config-loader.ts
+++ b/packages/core/src/config/config-loader.ts
@@ -569,6 +569,11 @@ function mergeRepoConfig(merged: MergedConfig, repo: RepoConfig): MergedConfig {
     result.baseBranch = repo.worktree.baseBranch.trim();
   }
 
+  // Pass remote to callers for git fetch/push operations
+  if (repo.worktree?.remote?.trim()) {
+    result.remote = repo.worktree.remote.trim();
+  }
+
   // Propagate docs path for $DOCS_DIR substitution in workflow commands
   if (repo.docs?.path !== undefined) {
     const trimmed = repo.docs.path.trim();

--- a/packages/core/src/config/config-types.ts
+++ b/packages/core/src/config/config-types.ts
@@ -270,6 +270,20 @@ export interface RepoConfig {
      * @example '.worktrees'
      */
     path?: string;
+
+    /**
+     * Git remote name for fetch/push operations.
+     *
+     * When set, all git operations (fetch, push, branch tracking) use this
+     * remote instead of 'origin'. Useful for repos with multiple remotes or
+     * non-standard naming conventions.
+     *
+     * When omitted, auto-detected: 'origin' if it exists, otherwise the sole
+     * remote if only one is configured.
+     *
+     * @example 'upstream'
+     */
+    remote?: string;
   };
 
   /**
@@ -381,6 +395,12 @@ export interface MergedConfig {
    * When undefined, workflows referencing $BASE_BRANCH will fail with an error.
    */
   baseBranch?: string;
+  /**
+   * Git remote name from repo config (worktree.remote).
+   * When undefined, callers auto-detect at runtime via getDefaultRemote()
+   * or fall back to 'origin'.
+   */
+  remote?: string;
   /**
    * Docs directory path from repo config (docs.path).
    * Used for $DOCS_DIR substitution in workflow commands.

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -34,6 +34,10 @@ const mockSyncWorkspace = mock(() =>
 );
 // Identity passthrough — strips branded type for test simplicity; empty-string guard not needed here
 const mockToRepoPath = mock((p: string) => p);
+// Remote auto-detection defaults to 'origin' (standard repos)
+const mockGetDefaultRemote = mock(() => Promise.resolve('origin' as string | null));
+// Repo config defaults to empty (no worktree.remote configured)
+const mockLoadRepoConfig = mock(() => Promise.resolve({} as Record<string, unknown>));
 const mockGetOrCreateConversation = mock(() => Promise.resolve(null as unknown));
 const mockGetCodebase = mock(() => Promise.resolve(null as unknown));
 const mockExecuteWorkflow = mock(() => Promise.resolve());
@@ -208,6 +212,7 @@ mock.module('../db/workflow-events', () => ({
 
 mock.module('../config/config-loader', () => ({
   loadConfig: mockLoadConfig,
+  loadRepoConfig: mockLoadRepoConfig,
 }));
 
 const mockGenerateAndSetTitle = mock(() => Promise.resolve());
@@ -255,6 +260,7 @@ mock.module('../utils/worktree-sync', () => ({
 }));
 
 mock.module('@archon/git', () => ({
+  getDefaultRemote: mockGetDefaultRemote,
   syncWorkspace: mockSyncWorkspace,
   toRepoPath: mockToRepoPath,
   toBranchName: mock((b: string) => b),
@@ -1065,6 +1071,10 @@ describe('discoverAllWorkflows — remote sync', () => {
   beforeEach(() => {
     mockSyncWorkspace.mockClear();
     mockToRepoPath.mockClear();
+    mockGetDefaultRemote.mockClear();
+    mockGetDefaultRemote.mockImplementation(() => Promise.resolve('origin'));
+    mockLoadRepoConfig.mockClear();
+    mockLoadRepoConfig.mockImplementation(() => Promise.resolve({}));
     mockGetOrCreateConversation.mockReset();
     mockGetCodebase.mockReset();
     mockListCodebases.mockReset();
@@ -1095,8 +1105,11 @@ describe('discoverAllWorkflows — remote sync', () => {
     const platform = makePlatform();
     await handleMessage(platform, 'conv-1', 'What is the latest commit?');
 
-    // Non-destructive default sync (#1864): 2-arg call, no explicit reset mode.
-    expect(mockSyncWorkspace).toHaveBeenCalledWith('/repos/test-repo', undefined);
+    // Non-destructive default sync (#1864): no explicit reset mode, only the
+    // resolved remote rides in the options.
+    expect(mockSyncWorkspace).toHaveBeenCalledWith('/repos/test-repo', undefined, {
+      remote: 'origin',
+    });
     // cwd resolution behavior — scoped chat runs the provider in the repo's
     // default_cwd (not the workspaces root) and skips ensureArchonWorkspacesPath
     // — is covered by the 'provider cwd resolution' describe block (issue #1179).
@@ -1117,7 +1130,8 @@ describe('discoverAllWorkflows — remote sync', () => {
 
     expect(mockSyncWorkspace).toHaveBeenCalledWith(
       '/home/test/.archon/workspaces/owner/repo/source',
-      undefined
+      undefined,
+      { remote: 'origin' }
     );
   });
 
@@ -1130,7 +1144,47 @@ describe('discoverAllWorkflows — remote sync', () => {
     const platform = makePlatform();
     await handleMessage(platform, 'conv-1', 'What is the latest commit?');
 
-    expect(mockSyncWorkspace).toHaveBeenCalledWith('/repos/test-repo', 'develop');
+    expect(mockSyncWorkspace).toHaveBeenCalledWith('/repos/test-repo', 'develop', {
+      remote: 'origin',
+    });
+  });
+
+  test('passes configured worktree.remote through to syncWorkspace', async () => {
+    const conversation = makeConversation({ codebase_id: 'codebase-1' });
+    const codebase = makeCodebaseForSync();
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+    mockLoadRepoConfig.mockResolvedValueOnce({ worktree: { remote: 'mar' } });
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', 'What is the latest commit?');
+
+    expect(mockSyncWorkspace).toHaveBeenCalledWith(
+      '/repos/test-repo',
+      undefined,
+      expect.objectContaining({ remote: 'mar' })
+    );
+    // Explicit config wins — auto-detection must not run
+    expect(mockGetDefaultRemote).not.toHaveBeenCalled();
+  });
+
+  test('auto-detects the remote when worktree.remote is not configured', async () => {
+    const conversation = makeConversation({ codebase_id: 'codebase-1' });
+    const codebase = makeCodebaseForSync();
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+    mockGetDefaultRemote.mockResolvedValueOnce('upstream');
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', 'What is the latest commit?');
+
+    expect(mockSyncWorkspace).toHaveBeenCalledWith(
+      '/repos/test-repo',
+      undefined,
+      expect.objectContaining({ remote: 'upstream' })
+    );
   });
 
   test('proceeds without throwing when syncWorkspace rejects', async () => {
@@ -1146,7 +1200,9 @@ describe('discoverAllWorkflows — remote sync', () => {
     await expect(
       handleMessage(platform, 'conv-1', 'What is the latest commit?')
     ).resolves.toBeUndefined();
-    expect(mockSyncWorkspace).toHaveBeenCalledWith('/repos/test-repo', undefined);
+    expect(mockSyncWorkspace).toHaveBeenCalledWith('/repos/test-repo', undefined, {
+      remote: 'origin',
+    });
   });
 
   test('does not call syncWorkspace when conversation has no codebase_id', async () => {

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -29,7 +29,14 @@ import { getAgentProvider, getProviderCapabilities } from '@archon/providers';
 import { buildManageRunTool } from './manage-run-tool';
 import { getArchonWorkspacesPath, ensureArchonWorkspacesPath } from '@archon/paths';
 import { syncArchonToWorktree } from '../utils/worktree-sync';
-import { execFileAsync, findRepoRoot, syncWorkspace, toBranchName, toRepoPath } from '@archon/git';
+import {
+  execFileAsync,
+  findRepoRoot,
+  getDefaultRemote,
+  syncWorkspace,
+  toBranchName,
+  toRepoPath,
+} from '@archon/git';
 import type { WorkspaceSyncResult } from '@archon/git';
 import { discoverWorkflowsWithConfig } from '@archon/workflows/workflow-discovery';
 import { findWorkflow, resolveWorkflowName } from '@archon/workflows/router';
@@ -52,7 +59,7 @@ import { deliverCredential } from '../credentials/delivery';
 import { listDecryptedUserProviderCredentials } from '../db/user-provider-key-store';
 import { getUserAiPrefs, type UserAiPrefs } from '../db/user-ai-prefs-store';
 import { createWorkflowDeps } from '../workflows/store-adapter';
-import { loadConfig } from '../config/config-loader';
+import { loadConfig, loadRepoConfig } from '../config/config-loader';
 import type { MergedConfig } from '../config/config-types';
 import { generateAndSetTitle } from '../services/title-generator';
 import { validateAndResolveIsolation, dispatchBackgroundWorkflow } from './orchestrator';
@@ -981,6 +988,8 @@ interface DiscoverResult {
   syncError?: string;
   config?: MergedConfig;
   codebase?: Codebase | null;
+  /** Remote name used for the workspace sync (undefined when no sync ran). */
+  remote?: string;
 }
 
 /** Discover global + repo-specific workflows, merge by name (repo overrides global) */
@@ -991,6 +1000,7 @@ async function discoverAllWorkflows(conversation: Conversation): Promise<Discove
   let syncError: string | undefined;
   let config: MergedConfig | undefined;
   let codebase: Codebase | null | undefined;
+  let remote: string | undefined;
 
   try {
     // Home-scoped workflows at ~/.archon/workflows/ are discovered automatically
@@ -1018,14 +1028,22 @@ async function discoverAllWorkflows(conversation: Conversation): Promise<Discove
           );
         } else {
           try {
+            // Resolve the git remote: explicit repo config wins, otherwise
+            // auto-detect ('origin' if present, else the sole remote).
+            const repoPath = toRepoPath(codebase.default_cwd);
+            const repoConf = await loadRepoConfig(codebase.default_cwd);
+            remote =
+              repoConf.worktree?.remote?.trim() || (await getDefaultRemote(repoPath)) || undefined;
             syncResult = await syncWorkspace(
-              toRepoPath(codebase.default_cwd),
-              codebase.default_branch ? toBranchName(codebase.default_branch) : undefined
+              repoPath,
+              codebase.default_branch ? toBranchName(codebase.default_branch) : undefined,
+              { remote }
             );
             getLog().debug(
               {
                 codebaseId: codebase.id,
                 repoPath: codebase.default_cwd,
+                remote,
                 ...syncResult,
               },
               'workspace.sync_completed'
@@ -1056,7 +1074,7 @@ async function discoverAllWorkflows(conversation: Conversation): Promise<Discove
     }
   }
 
-  return { workflows, errors: allErrors, syncResult, syncError, config, codebase };
+  return { workflows, errors: allErrors, syncResult, syncError, config, codebase, remote };
 }
 
 /** Build the user-facing prompt with message and optional contexts */
@@ -1349,6 +1367,7 @@ export async function handleMessage(
       syncError,
       config: discoveredConfig,
       codebase: discoveredCodebase,
+      remote: syncRemote,
     } = await discoverAllWorkflows(conversation);
     const workflows: readonly WorkflowDefinition[] = workflowsWithSource.map(ws => ws.workflow);
     if (workflowErrors.length > 0) {
@@ -1368,7 +1387,7 @@ export async function handleMessage(
     } else if (syncResult?.state === 'diverged' && platform.sendStructuredEvent) {
       await platform.sendStructuredEvent(conversationId, {
         type: 'system',
-        content: `Local source/ has diverged from origin/${syncResult.branch} \u2014 manual merge or rebase needed`,
+        content: `Local source/ has diverged from ${syncRemote ?? 'origin'}/${syncResult.branch} \u2014 manual merge or rebase needed`,
       });
     } else if (
       syncResult?.state === 'in_sync' &&
@@ -1377,7 +1396,7 @@ export async function handleMessage(
     ) {
       await platform.sendStructuredEvent(conversationId, {
         type: 'system',
-        content: `Fast-forwarded to origin/${syncResult.branch} \u2014 ${syncResult.previousHead} \u2192 ${syncResult.newHead}`,
+        content: `Fast-forwarded to ${syncRemote ?? 'origin'}/${syncResult.branch} \u2014 ${syncResult.previousHead} \u2192 ${syncResult.newHead}`,
       });
     }
 

--- a/packages/core/src/services/cleanup-service.test.ts
+++ b/packages/core/src/services/cleanup-service.test.ts
@@ -357,6 +357,38 @@ describe('cleanup-service', () => {
       expect(mockUpdateStatus).toHaveBeenCalledWith(envId, 'destroyed');
     });
 
+    test('passes configured worktree.remote to provider.destroy for remote branch deletion', async () => {
+      const envId = 'env-remote-custom';
+
+      mockGetById.mockResolvedValueOnce({
+        id: envId,
+        codebase_id: 'codebase-123',
+        workflow_type: 'pr',
+        workflow_id: '99',
+        provider: 'worktree',
+        working_path: '/workspace/worktrees/pr-99',
+        branch_name: 'feature-branch',
+        status: 'active',
+        created_at: new Date(),
+        created_by_platform: 'github',
+        metadata: {},
+      });
+
+      mockGetCodebase.mockResolvedValueOnce({
+        id: 'codebase-123',
+        name: 'test-repo',
+        default_cwd: '/workspace/repo',
+      });
+      mockLoadRepoConfig.mockResolvedValueOnce({ worktree: { remote: 'upstream' } });
+
+      await removeEnvironment(envId, { deleteRemoteBranch: true });
+
+      expect(mockDestroy).toHaveBeenCalledWith(
+        '/workspace/worktrees/pr-99',
+        expect.objectContaining({ deleteRemoteBranch: true, remote: 'upstream' })
+      );
+    });
+
     test('does not pass deleteRemoteBranch when not specified', async () => {
       const envId = 'env-no-remote-delete';
 
@@ -958,6 +990,9 @@ describe('getWorktreeStatusBreakdown', () => {
 
     expect(breakdown.total).toBe(4);
     expect(breakdown.merged).toBe(1);
+    // No worktree.remote configured — default-branch detection gets undefined
+    // (getDefaultBranch falls back to 'origin' internally)
+    expect(mockGetDefaultBranch).toHaveBeenCalledWith('/workspace/repo', undefined);
     expect(breakdown.stale).toBe(1); // env-2 is stale (30 days), env-4 is Telegram so not counted as stale
     expect(breakdown.active).toBe(2); // env-3 active, env-4 Telegram (counted as active, not stale)
   });
@@ -985,7 +1020,7 @@ describe('getWorktreeStatusBreakdown', () => {
 
   test('returns empty breakdown for empty codebase', async () => {
     mockListByCodebaseWithAge.mockResolvedValueOnce([]);
-    // resolveBaseBranch returns 'main' (no config → getDefaultBranch fallback, default from beforeEach)
+    // resolveRepoGitContext returns 'main' (no config → getDefaultBranch fallback, default from beforeEach)
 
     const breakdown = await getWorktreeStatusBreakdown('codebase-1', '/workspace/repo');
 
@@ -993,6 +1028,15 @@ describe('getWorktreeStatusBreakdown', () => {
     expect(breakdown.merged).toBe(0);
     expect(breakdown.stale).toBe(0);
     expect(breakdown.active).toBe(0);
+  });
+
+  test('detects the default branch on the configured worktree.remote', async () => {
+    mockLoadRepoConfig.mockResolvedValue({ worktree: { remote: 'upstream' } });
+    mockListByCodebaseWithAge.mockResolvedValueOnce([]);
+
+    await getWorktreeStatusBreakdown('codebase-1', '/workspace/repo');
+
+    expect(mockGetDefaultBranch).toHaveBeenCalledWith('/workspace/repo', 'upstream');
   });
 });
 
@@ -1056,6 +1100,56 @@ describe('cleanupMergedWorktrees', () => {
     expect(mockDestroy).toHaveBeenCalledWith(
       '/workspace/repo/worktrees/merged-branch',
       expect.objectContaining({ deleteRemoteBranch: true })
+    );
+  });
+
+  test('threads worktree.remote from repo config to getDefaultBranch and getPrState', async () => {
+    mockLoadRepoConfig.mockResolvedValue({ worktree: { remote: 'upstream' } });
+    mockListByCodebase.mockResolvedValueOnce([
+      {
+        id: 'env-remote',
+        branch_name: 'feature-branch',
+        working_path: '/workspace/repo/worktrees/feature-branch',
+        status: 'active',
+      },
+    ]);
+    // Not merged, not patch-equivalent → falls through to the PR-state check
+    mockIsBranchMerged.mockResolvedValueOnce(false);
+    mockIsPatchEquivalent.mockResolvedValueOnce(false);
+    mockGetPrState.mockResolvedValueOnce('NONE');
+
+    await cleanupMergedWorktrees('codebase-1', '/workspace/repo');
+
+    // Default-branch detection uses the configured remote (no baseBranch set)
+    expect(mockGetDefaultBranch).toHaveBeenCalledWith('/workspace/repo', 'upstream');
+    // PR-state lookup receives the configured remote
+    expect(mockGetPrState).toHaveBeenCalledWith(
+      'feature-branch',
+      '/workspace/repo',
+      expect.any(Map),
+      'upstream'
+    );
+  });
+
+  test('logs a warn before skipping an environment when the merge check fails', async () => {
+    mockListByCodebase.mockResolvedValueOnce([
+      {
+        id: 'env-flaky',
+        branch_name: 'flaky-branch',
+        working_path: '/workspace/repo/worktrees/flaky-branch',
+        status: 'active',
+      },
+    ]);
+    mockIsBranchMerged.mockRejectedValueOnce(new Error('network unreachable'));
+
+    const result = await cleanupMergedWorktrees('codebase-1', '/workspace/repo');
+
+    expect(result.skipped).toEqual([
+      { branchName: 'flaky-branch', reason: 'merge check failed: network unreachable' },
+    ]);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ branchName: 'flaky-branch', repoPath: '/workspace/repo' }),
+      'cleanup.merge_check_failed'
     );
   });
 
@@ -1371,7 +1465,7 @@ describe('resolveBaseBranch via runScheduledCleanup (issue #1419)', () => {
 
     await runScheduledCleanup();
 
-    expect(mockGetDefaultBranch).toHaveBeenCalledWith('/workspace/mainrepo');
+    expect(mockGetDefaultBranch).toHaveBeenCalledWith('/workspace/mainrepo', undefined);
     expect(mockIsBranchMerged).toHaveBeenCalledWith('/workspace/mainrepo', 'feature/bar', 'main');
   });
 
@@ -1401,7 +1495,7 @@ describe('resolveBaseBranch via runScheduledCleanup (issue #1419)', () => {
 
     await runScheduledCleanup();
 
-    expect(mockGetDefaultBranch).toHaveBeenCalledWith('/workspace/repo3');
+    expect(mockGetDefaultBranch).toHaveBeenCalledWith('/workspace/repo3', undefined);
   });
 });
 

--- a/packages/core/src/services/cleanup-service.ts
+++ b/packages/core/src/services/cleanup-service.ts
@@ -35,17 +35,27 @@ function getLog(): ReturnType<typeof createLogger> {
   return cachedLog;
 }
 
-// Resolve the base branch for a repo, preferring worktree.baseBranch from
-// .archon/config.yaml before falling back to runtime git detection. Repos
-// that use 'master' as default and don't have origin/HEAD set will fail
-// getDefaultBranch — reading the config first avoids that error.
-async function resolveBaseBranch(repoPath: RepoPath, cwd: string): Promise<BranchName> {
+/** Git context for a repo's cleanup operations, resolved from repo config. */
+interface RepoGitContext {
+  mainBranch: BranchName;
+  /** Configured remote name (worktree.remote); undefined means 'origin' downstream. */
+  remote?: string;
+}
+
+// Resolve the base branch and remote for a repo, preferring worktree.baseBranch /
+// worktree.remote from .archon/config.yaml before falling back to runtime git
+// detection. Repos that use 'master' as default and don't have <remote>/HEAD set
+// will fail getDefaultBranch — reading the config first avoids that error.
+// loadRepoConfig never throws (returns {} on missing/broken config), so a config
+// problem degrades to git detection instead of failing cleanup.
+async function resolveRepoGitContext(repoPath: RepoPath, cwd: string): Promise<RepoGitContext> {
   const repoConfig = await loadRepoConfig(cwd);
+  const remote = repoConfig.worktree?.remote?.trim() || undefined;
   const configured = repoConfig.worktree?.baseBranch?.trim();
   if (configured) {
-    return toBranchName(configured);
+    return { mainBranch: toBranchName(configured), remote };
   }
-  return getDefaultBranch(repoPath);
+  return { mainBranch: await getDefaultBranch(repoPath, remote), remote };
 }
 
 // Configuration constants (configurable via env vars)
@@ -323,9 +333,16 @@ export async function removeEnvironment(
 
   // Get canonical repo path from codebase for branch cleanup
   let canonicalRepoPath: RepoPath | undefined;
+  let configuredRemote: string | undefined;
   if (env.codebase_id) {
     const codebase = await codebaseDb.getCodebase(env.codebase_id);
     canonicalRepoPath = codebase?.default_cwd ? toRepoPath(codebase.default_cwd) : undefined;
+    // Resolve the configured remote only when remote-branch deletion is requested —
+    // that's the one destroy path that pushes to a remote.
+    if (options?.deleteRemoteBranch && codebase?.default_cwd) {
+      const repoConfig = await loadRepoConfig(codebase.default_cwd);
+      configuredRemote = repoConfig.worktree?.remote?.trim() || undefined;
+    }
   }
 
   // Check if directory exists before attempting removal
@@ -350,6 +367,7 @@ export async function removeEnvironment(
       branchName: toBranchName(env.branch_name),
       canonicalRepoPath,
       deleteRemoteBranch: options?.deleteRemoteBranch,
+      remote: configuredRemote,
     });
 
     // Log warnings from partial failures
@@ -463,7 +481,7 @@ export async function runScheduledCleanup(): Promise<CleanupReport> {
 
         // Check if branch is merged
         const mainRepoPath = toRepoPath(env.codebase_default_cwd);
-        const mainBranch = await resolveBaseBranch(mainRepoPath, env.codebase_default_cwd);
+        const { mainBranch } = await resolveRepoGitContext(mainRepoPath, env.codebase_default_cwd);
         const merged = await isBranchMerged(
           mainRepoPath,
           toBranchName(env.branch_name),
@@ -617,7 +635,7 @@ export async function getWorktreeStatusBreakdown(
     activeEnvs: [],
   };
 
-  const mainBranch = await resolveBaseBranch(repoPath, mainRepoPath);
+  const { mainBranch } = await resolveRepoGitContext(repoPath, mainRepoPath);
 
   for (const env of environments) {
     // Skip Telegram (never shown as stale)
@@ -715,7 +733,8 @@ async function isSafeToRemove(
   branchName: BranchName,
   mainBranch: BranchName,
   prStateCache: Map<string, PrState>,
-  includeClosed: boolean
+  includeClosed: boolean,
+  remote?: string
 ): Promise<{ safe: boolean; openPr: boolean }> {
   // (a) Fast path — fast-forward / merge-commit ancestry
   if (await isBranchMerged(repoPath, branchName, mainBranch)) {
@@ -726,7 +745,7 @@ async function isSafeToRemove(
     return { safe: true, openPr: false };
   }
   // (c) GitHub PR state
-  const prState = await getPrState(branchName, repoPath, prStateCache);
+  const prState = await getPrState(branchName, repoPath, prStateCache, remote);
   if (prState === 'MERGED') return { safe: true, openPr: false };
   if (prState === 'CLOSED') return { safe: includeClosed, openPr: false };
   if (prState === 'OPEN') return { safe: false, openPr: true };
@@ -745,7 +764,7 @@ export async function cleanupMergedWorktrees(
   const result: CleanupOperationResult = { removed: [], skipped: [] };
   const environments = await isolationEnvDb.listByCodebase(codebaseId);
   const repoPath = toRepoPath(mainRepoPath);
-  const mainBranch = await resolveBaseBranch(repoPath, mainRepoPath);
+  const { mainBranch, remote } = await resolveRepoGitContext(repoPath, mainRepoPath);
   const includeClosed = options.includeClosed ?? false;
   const prStateCache = new Map<string, PrState>();
 
@@ -760,12 +779,19 @@ export async function cleanupMergedWorktrees(
         branchName,
         mainBranch,
         prStateCache,
-        includeClosed
+        includeClosed,
+        remote
       );
       safe = decision.safe;
       openPr = decision.openPr;
     } catch (error) {
       const err = error as Error;
+      // Log before skipping — silent skips make transient git/network failures
+      // impossible to debug from the cleanup report alone.
+      getLog().warn(
+        { err, branchName: env.branch_name, repoPath: mainRepoPath },
+        'cleanup.merge_check_failed'
+      );
       result.skipped.push({
         branchName: env.branch_name,
         reason: `merge check failed: ${err.message}`,

--- a/packages/docs-web/src/content/docs/reference/configuration.md
+++ b/packages/docs-web/src/content/docs/reference/configuration.md
@@ -148,6 +148,8 @@ worktree:
                         # <repoRoot>/.worktrees/<branch> instead of under
                         # ~/.archon/workspaces/<owner>/<repo>/worktrees/.
                         # Must be relative; no absolute, no `..` segments.
+  remote: origin        # Optional: git remote name for fetch/push. Auto-detected
+                        # when omitted (origin if it exists, sole remote otherwise).
 
 # Documentation directory
 docs:
@@ -237,9 +239,14 @@ worktree:
 
 **Submodule behavior:** When a repo contains `.gitmodules`, submodules are initialized in new worktrees by default (git's `worktree add` does not do this). The check is a cheap filesystem probe — repos without submodules pay zero cost. Submodule init failure throws a classified error (credentials, network, timeout) rather than silently producing a worktree with empty submodule directories. Set `worktree.initSubmodules: false` to opt out.
 
+**Remote behavior:** By default, all git operations (fetch, push, branch tracking) use the `origin` remote. If your repo uses a different remote name, configure `worktree.remote`. Resolution order:
+1. If `worktree.remote` is set: Uses the configured remote name for all operations.
+2. If omitted: Auto-detects — `origin` if it exists, otherwise the sole remote if only one is configured.
+3. If multiple remotes exist and none is named `origin`: Worktree creation **fails with an actionable error** listing the available remotes and suggesting the config fix.
+
 **Base branch behavior:** Before creating a worktree, the canonical workspace is synced to the latest code. Resolution order:
-1. If `worktree.baseBranch` is set: Uses the configured branch. **Fails with an error** if the branch doesn't exist on remote (no silent fallback).
-2. If omitted: Auto-detects the default branch via `git remote show origin`. Works without any config for standard repos.
+1. If `worktree.baseBranch` is set: Uses the configured branch. **Fails with an error** if the branch doesn't exist on the resolved remote (no silent fallback).
+2. If omitted: Auto-detects the default branch via `git symbolic-ref` on the resolved remote. Works without any config for standard repos.
 3. If auto-detection fails and a workflow references `$BASE_BRANCH`: Fails with an error explaining the resolution chain.
 
 **Docs path behavior:** The `docs.path` setting controls where the `$DOCS_DIR` variable points. When not configured, `$DOCS_DIR` defaults to `docs/`. Unlike `$BASE_BRANCH`, this variable always has a safe default and never throws an error. Configure it when your documentation lives outside the standard `docs/` directory (e.g., `packages/docs-web/src/content/docs`).

--- a/packages/git/src/branch.ts
+++ b/packages/git/src/branch.ts
@@ -14,23 +14,26 @@ function getLog(): ReturnType<typeof createLogger> {
  * Get the default branch name for a repository
  * Uses git symbolic-ref to get the remote HEAD reference
  *
- * Fallback chain: symbolic-ref -> origin/main -> throw
- * Note: Throws if neither origin/HEAD nor origin/main can be resolved.
+ * Fallback chain: symbolic-ref -> <remote>/main -> throw
+ * Note: Throws if neither <remote>/HEAD nor <remote>/main can be resolved.
  * Callers can set worktree.baseBranch in .archon/config.yaml as a manual override.
  *
  * Only falls back for expected git errors (ref not found, branch not found).
  * Throws for unexpected errors (permission denied, git corruption, etc.)
+ *
+ * @param repoPath - Path to the git repository
+ * @param remote - Remote name to check (default: 'origin')
  */
-export async function getDefaultBranch(repoPath: RepoPath): Promise<BranchName> {
+export async function getDefaultBranch(repoPath: RepoPath, remote = 'origin'): Promise<BranchName> {
   // Try to get from remote HEAD
   try {
     const { stdout } = await execFileAsync(
       'git',
-      ['-C', repoPath, 'symbolic-ref', 'refs/remotes/origin/HEAD', '--short'],
+      ['-C', repoPath, 'symbolic-ref', `refs/remotes/${remote}/HEAD`, '--short'],
       { timeout: 10000 }
     );
     // stdout is like "origin/main" - extract just the branch name
-    return toBranchName(stdout.trim().replace('origin/', ''));
+    return toBranchName(stdout.trim().replace(`${remote}/`, ''));
   } catch (error) {
     const err = error as Error & { stderr?: string };
     const errorText = `${err.message} ${err.stderr ?? ''}`;
@@ -40,17 +43,20 @@ export async function getDefaultBranch(repoPath: RepoPath): Promise<BranchName> 
       errorText.includes('not a symbolic ref') ||
       errorText.includes('No such file or directory')
     ) {
-      getLog().debug({ repoPath, err }, 'symbolic_ref_fallback');
+      getLog().debug({ repoPath, remote, err }, 'symbolic_ref_fallback');
     } else {
       // Unexpected error (permission denied, git corruption, etc.) - surface it
-      getLog().error({ repoPath, err, stderr: err.stderr }, 'default_branch_symbolic_ref_failed');
+      getLog().error(
+        { repoPath, remote, err, stderr: err.stderr },
+        'default_branch_symbolic_ref_failed'
+      );
       throw new Error(`Failed to get default branch for ${repoPath}: ${err.message}`);
     }
   }
 
-  // Fallback: check if origin/main exists, otherwise throw
+  // Fallback: check if <remote>/main exists, otherwise throw
   try {
-    await execFileAsync('git', ['-C', repoPath, 'rev-parse', '--verify', 'origin/main'], {
+    await execFileAsync('git', ['-C', repoPath, 'rev-parse', '--verify', `${remote}/main`], {
       timeout: 10000,
     });
     return toBranchName('main');
@@ -58,21 +64,21 @@ export async function getDefaultBranch(repoPath: RepoPath): Promise<BranchName> 
     const err = error as Error & { stderr?: string };
     const errorText = `${err.message} ${err.stderr ?? ''}`;
 
-    // Expected: origin/main doesn't exist — no safe default, fail fast
+    // Expected: <remote>/main doesn't exist — no safe default, fail fast
     if (
       errorText.includes('Not a valid object name') ||
       errorText.includes('Needed a single revision') ||
       errorText.includes('unknown revision')
     ) {
-      getLog().warn({ repoPath }, 'default_branch_detection_failed');
+      getLog().warn({ repoPath, remote }, 'default_branch_detection_failed');
       throw new Error(
-        `Cannot detect default branch for ${repoPath}: neither origin/HEAD nor origin/main exist. ` +
+        `Cannot detect default branch for ${repoPath}: neither ${remote}/HEAD nor ${remote}/main exist. ` +
           'Set worktree.baseBranch in .archon/config.yaml to specify the branch explicitly.'
       );
     }
 
     // Unexpected error - surface it
-    getLog().error({ repoPath, err, stderr: err.stderr }, 'verify_origin_main_failed');
+    getLog().error({ repoPath, remote, err, stderr: err.stderr }, 'verify_origin_main_failed');
     throw new Error(`Failed to get default branch for ${repoPath}: ${err.message}`);
   }
 }

--- a/packages/git/src/forge.test.ts
+++ b/packages/git/src/forge.test.ts
@@ -43,6 +43,13 @@ describe('detectForge', () => {
     expect(info.apiBase).toBe('https://api.github.com');
   });
 
+  test('forwards a custom remote name to getRemoteUrl', async () => {
+    getRemoteUrlSpy.mockResolvedValue('https://github.com/owner/repo.git');
+    const info = await detectForge(testRepo, 'upstream');
+    expect(info.type).toBe('github');
+    expect(getRemoteUrlSpy).toHaveBeenCalledWith(testRepo, 'upstream');
+  });
+
   test('detects GitHub Enterprise when GITHUB_URL env matches remote hostname', async () => {
     process.env.GITHUB_URL = 'https://github.corp.com';
     getRemoteUrlSpy.mockResolvedValue('https://github.corp.com/owner/repo.git');

--- a/packages/git/src/forge.ts
+++ b/packages/git/src/forge.ts
@@ -1,5 +1,5 @@
 // Forge detection: identify the hosting platform (GitHub, Gitea, GitLab)
-// behind a repository's `origin` remote, plus its REST API base URL.
+// behind a repository's remote (default `origin`), plus its REST API base URL.
 
 import { getRemoteUrl } from './repo';
 import type { RepoPath } from './types';
@@ -51,7 +51,7 @@ function matchSelfHostedForge(envVar: string, hostname: string): string | null {
 }
 
 /**
- * Detect the forge platform behind a repository's `origin` remote.
+ * Detect the forge platform behind a repository's remote (default: `origin`).
  *
  * Detection order:
  * 1. `github.com` hostname → GitHub (`https://api.github.com`)
@@ -61,11 +61,14 @@ function matchSelfHostedForge(envVar: string, hostname: string): string | null {
  * 5. `GITLAB_URL` env hostname match → self-hosted GitLab (`<base>/api/v4`)
  * 6. No match → `unknown` (empty apiBase)
  *
- * A repository with no `origin` remote defaults to GitHub for backwards
+ * A repository without the requested remote defaults to GitHub for backwards
  * compatibility with existing GitHub-only callers.
+ *
+ * @param repoPath - Path to the git repository
+ * @param remote - Remote name to inspect (default: 'origin')
  */
-export async function detectForge(repoPath: RepoPath): Promise<ForgeInfo> {
-  const remoteUrl = await getRemoteUrl(repoPath);
+export async function detectForge(repoPath: RepoPath, remote = 'origin'): Promise<ForgeInfo> {
+  const remoteUrl = await getRemoteUrl(repoPath, remote);
   if (!remoteUrl) {
     return { type: 'github', apiBase: 'https://api.github.com' };
   }

--- a/packages/git/src/git.test.ts
+++ b/packages/git/src/git.test.ts
@@ -792,6 +792,38 @@ branch refs/heads/feature/auth
       expect(result).toBe('master');
     });
 
+    test('uses custom remote for symbolic-ref lookup and prefix stripping', async () => {
+      execSpy.mockResolvedValue({ stdout: 'upstream/main\n', stderr: '' });
+
+      const result = await git.getDefaultBranch('/workspace/repo', 'upstream');
+
+      expect(result).toBe('main');
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        ['-C', '/workspace/repo', 'symbolic-ref', 'refs/remotes/upstream/HEAD', '--short'],
+        expect.any(Object)
+      );
+    });
+
+    test('falls back to <remote>/main and names the remote in the failure error', async () => {
+      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args.includes('symbolic-ref')) {
+          throw new Error('fatal: ref refs/remotes/mar/HEAD is not a symbolic ref');
+        }
+        throw new Error('fatal: Needed a single revision');
+      });
+
+      await expect(git.getDefaultBranch('/workspace/repo', 'mar')).rejects.toThrow(
+        'neither mar/HEAD nor mar/main exist'
+      );
+      // Verify the fallback probed mar/main, not origin/main
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        ['-C', '/workspace/repo', 'rev-parse', '--verify', 'mar/main'],
+        expect.any(Object)
+      );
+    });
+
     test('returns non-standard branch from symbolic-ref (origin/develop)', async () => {
       execSpy.mockResolvedValue({ stdout: 'origin/develop\n', stderr: '' });
 
@@ -1600,7 +1632,7 @@ branch refs/heads/feature/auth
         newHead: 'abc12345',
         updated: false,
       });
-      expect(getDefaultBranchSpy).toHaveBeenCalledWith('/workspace/repo');
+      expect(getDefaultBranchSpy).toHaveBeenCalledWith('/workspace/repo', 'origin');
     });
 
     test('throws actionable error when configured branch not found on remote', async () => {
@@ -1861,6 +1893,139 @@ branch refs/heads/feature/auth
         'workspace.merge_base_check_failed'
       );
     });
+
+    test('fetches and resets from custom remote when provided in options', async () => {
+      execSpy.mockResolvedValue({ stdout: '', stderr: '' });
+
+      await git.syncWorkspace('/workspace/repo', 'main', { mode: 'reset', remote: 'mar' });
+
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        ['-C', '/workspace/repo', 'fetch', 'mar', 'main'],
+        expect.any(Object)
+      );
+
+      const resetCalls = execSpy.mock.calls.filter((call: unknown[]) => {
+        const args = call[1] as string[];
+        return args.includes('reset');
+      });
+      expect(resetCalls).toHaveLength(1);
+      expect(resetCalls[0][1]).toEqual(['-C', '/workspace/repo', 'reset', '--hard', 'mar/main']);
+    });
+
+    test('classifies state against the custom remote ref in fast-forward mode', async () => {
+      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args.includes('status')) return { stdout: '', stderr: '' };
+        if (args.includes('rev-parse') && args.includes('--short=8')) {
+          return { stdout: 'abc12345\n', stderr: '' };
+        }
+        if (args.includes('rev-parse') && args.includes('HEAD')) {
+          return { stdout: 'abc12345abcdef\n', stderr: '' };
+        }
+        if (args.includes('rev-parse') && args.includes('upstream/main')) {
+          return { stdout: 'abc12345abcdef\n', stderr: '' };
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      const result = await git.syncWorkspace('/workspace/repo', 'main', { remote: 'upstream' });
+
+      expect(result.state).toBe('in_sync');
+      // The state classification must rev-parse upstream/main, not origin/main
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        ['-C', '/workspace/repo', 'rev-parse', 'upstream/main'],
+        expect.any(Object)
+      );
+    });
+
+    test('passes custom remote to getDefaultBranch when baseBranch not provided', async () => {
+      execSpy.mockResolvedValue({ stdout: '', stderr: '' });
+      getDefaultBranchSpy.mockResolvedValue('develop');
+
+      await git.syncWorkspace('/workspace/repo', undefined, { remote: 'upstream' });
+
+      expect(getDefaultBranchSpy).toHaveBeenCalledWith('/workspace/repo', 'upstream');
+    });
+
+    test('includes custom remote name in fetch error message', async () => {
+      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args.includes('fetch')) {
+          throw new Error("fatal: 'mar' does not appear to be a git repository");
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      await expect(git.syncWorkspace('/workspace/repo', 'main', { remote: 'mar' })).rejects.toThrow(
+        'Sync fetch from mar/main failed'
+      );
+    });
+
+    test('names the custom remote in the configured-branch-missing error', async () => {
+      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args.includes('fetch')) {
+          throw new Error("fatal: couldn't find remote ref does-not-exist");
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      await expect(
+        git.syncWorkspace('/workspace/repo', 'does-not-exist', { remote: 'mar' })
+      ).rejects.toThrow("Configured base branch 'does-not-exist' not found on remote 'mar'");
+    });
+  });
+
+  describe('getDefaultRemote', () => {
+    let execSpy: Mock<typeof git.execFileAsync>;
+
+    beforeEach(() => {
+      execSpy = spyOn(git, 'execFileAsync');
+    });
+
+    afterEach(() => {
+      execSpy.mockRestore();
+    });
+
+    test('returns origin when it exists among multiple remotes', async () => {
+      execSpy.mockResolvedValue({ stdout: 'upstream\norigin\n', stderr: '' });
+
+      const result = await git.getDefaultRemote('/workspace/repo');
+      expect(result).toBe('origin');
+    });
+
+    test('returns sole remote when only one is configured', async () => {
+      execSpy.mockResolvedValue({ stdout: 'mar\n', stderr: '' });
+
+      const result = await git.getDefaultRemote('/workspace/repo');
+      expect(result).toBe('mar');
+    });
+
+    test('returns null when multiple non-origin remotes exist', async () => {
+      execSpy.mockResolvedValue({ stdout: 'jan\nfeb\nmar\n', stderr: '' });
+
+      const result = await git.getDefaultRemote('/workspace/repo');
+      expect(result).toBeNull();
+    });
+
+    test('returns null when no remotes are configured', async () => {
+      execSpy.mockResolvedValue({ stdout: '', stderr: '' });
+
+      const result = await git.getDefaultRemote('/workspace/repo');
+      expect(result).toBeNull();
+    });
+
+    test('propagates git errors instead of swallowing them', async () => {
+      execSpy.mockRejectedValue(new Error('not a git repository'));
+
+      await expect(git.getDefaultRemote('/workspace/repo')).rejects.toThrow('not a git repository');
+    });
+
+    test('handles CRLF line endings from git output', async () => {
+      execSpy.mockResolvedValue({ stdout: 'origin\r\nupstream\r\n', stderr: '' });
+
+      const result = await git.getDefaultRemote('/workspace/repo');
+      expect(result).toBe('origin');
+    });
   });
 
   describe('cloneRepository', () => {
@@ -1974,6 +2139,22 @@ branch refs/heads/feature/auth
         timeout: 60000,
       });
       expect(execSpy).toHaveBeenCalledWith('git', ['reset', '--hard', 'origin/main'], {
+        cwd: '/workspace/repo',
+        timeout: 30000,
+      });
+    });
+
+    test('fetches and resets using a custom remote', async () => {
+      execSpy.mockResolvedValue({ stdout: '', stderr: '' });
+
+      const result = await git.syncRepository('/workspace/repo', 'main', 'upstream');
+
+      expect(result).toEqual({ ok: true, value: undefined });
+      expect(execSpy).toHaveBeenCalledWith('git', ['fetch', 'upstream'], {
+        cwd: '/workspace/repo',
+        timeout: 60000,
+      });
+      expect(execSpy).toHaveBeenCalledWith('git', ['reset', '--hard', 'upstream/main'], {
         cwd: '/workspace/repo',
         timeout: 30000,
       });
@@ -2208,6 +2389,21 @@ branch refs/heads/feature/auth
 
       const result = await git.getRemoteUrl('/workspace/repo');
       expect(result).toBe('https://github.com/owner/repo.git');
+    });
+
+    test('queries a custom remote when provided', async () => {
+      execSpy.mockResolvedValue({
+        stdout: 'https://github.com/owner/repo.git\n',
+        stderr: '',
+      });
+
+      await git.getRemoteUrl('/workspace/repo', 'upstream');
+
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        ['-C', '/workspace/repo', 'remote', 'get-url', 'upstream'],
+        expect.any(Object)
+      );
     });
 
     test('returns null when no remote configured', async () => {

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -51,6 +51,7 @@ export type { ForgeType, ForgeInfo } from './forge';
 // Repository operations
 export {
   findRepoRoot,
+  getDefaultRemote,
   getRemoteUrl,
   listChildRepos,
   syncWorkspace,

--- a/packages/git/src/repo.ts
+++ b/packages/git/src/repo.ts
@@ -75,12 +75,37 @@ export async function listChildRepos(rootPath: string): Promise<string[]> {
 }
 
 /**
- * Get the remote URL for origin (if it exists)
- * Returns null if no remote is configured
+ * Detect the default remote name for a repository.
+ *
+ * Resolution order:
+ *   1. 'origin' — if it exists (standard Git convention)
+ *   2. The sole remote — if only one is configured
+ *   3. null — ambiguous (multiple non-origin remotes) or no remotes at all
+ *
+ * Callers can override via `worktree.remote` in `.archon/config.yaml`.
+ * Git errors (not a repo, permission denied) propagate — a null return
+ * always means "no unambiguous remote", never a swallowed failure.
  */
-export async function getRemoteUrl(repoPath: RepoPath): Promise<string | null> {
+export async function getDefaultRemote(repoPath: RepoPath): Promise<string | null> {
+  const { stdout } = await execFileAsync('git', ['-C', repoPath, 'remote'], { timeout: 10000 });
+  // Split on LF or CRLF (Windows git) and trim each entry defensively
+  const remotes = stdout
+    .split(/\r?\n/)
+    .map(r => r.trim())
+    .filter(r => r.length > 0);
+  if (remotes.length === 0) return null;
+  if (remotes.includes('origin')) return 'origin';
+  if (remotes.length === 1) return remotes[0];
+  return null;
+}
+
+/**
+ * Get the URL configured for a git remote (default: 'origin').
+ * Returns null if the remote does not exist.
+ */
+export async function getRemoteUrl(repoPath: RepoPath, remote = 'origin'): Promise<string | null> {
   try {
-    const { stdout } = await execFileAsync('git', ['-C', repoPath, 'remote', 'get-url', 'origin'], {
+    const { stdout } = await execFileAsync('git', ['-C', repoPath, 'remote', 'get-url', remote], {
       timeout: 10000,
     });
     return stdout.trim() || null;
@@ -88,7 +113,7 @@ export async function getRemoteUrl(repoPath: RepoPath): Promise<string | null> {
     const err = error as Error & { stderr?: string };
     const errorText = `${err.message} ${err.stderr ?? ''}`;
 
-    // Expected: no remote named origin
+    // Expected: no remote with that name
     if (
       errorText.includes('No such remote') ||
       errorText.includes('does not have a url configured')
@@ -97,19 +122,19 @@ export async function getRemoteUrl(repoPath: RepoPath): Promise<string | null> {
     }
 
     // Unexpected error - surface it
-    getLog().error({ repoPath, err, stderr: err.stderr }, 'get_remote_url_failed');
-    throw new Error(`Failed to get remote URL for ${repoPath}: ${err.message}`);
+    getLog().error({ repoPath, remote, err, stderr: err.stderr }, 'get_remote_url_failed');
+    throw new Error(`Failed to get remote URL for ${repoPath} (remote: ${remote}): ${err.message}`);
   }
 }
 
 /**
- * Sync workspace with remote origin.
- * Fetches the base branch from origin, then updates local state according to mode.
+ * Sync workspace with its remote.
+ * Fetches the base branch from the remote, then updates local state according to mode.
  *
  * Modes:
  * - fast-forward (default): fetch, classify state, and fast-forward only when safe.
  * - fetch-only: fetch and classify without touching the working tree.
- * - reset: fetch and hard-reset to origin/<branch>. This is destructive and must be
+ * - reset: fetch and hard-reset to <remote>/<branch>. This is destructive and must be
  *   requested explicitly by callers that own the checkout.
  *
  * Branch resolution:
@@ -119,21 +144,24 @@ export async function getRemoteUrl(repoPath: RepoPath): Promise<string | null> {
  *
  * @param workspacePath - Path to the workspace (canonical repo, not worktree)
  * @param baseBranch - Optional base branch name (e.g., 'main', 'develop'). If omitted, auto-detects default branch
- * @param options - Optional sync mode. Defaults to non-destructive fast-forward.
+ * @param options - Optional settings:
+ *   - `mode`: sync mode. Defaults to non-destructive fast-forward.
+ *   - `remote` (default 'origin'): git remote name to fetch from.
  * @returns Branch used plus whether sync was performed
  * @throws Error with actionable message if configured branch doesn't exist
  */
 export async function syncWorkspace(
   workspacePath: RepoPath,
   baseBranch?: BranchName,
-  options?: { mode?: WorkspaceSyncMode }
+  options?: { mode?: WorkspaceSyncMode; remote?: string }
 ): Promise<WorkspaceSyncResult> {
   const mode = options?.mode ?? 'fast-forward';
-  const branchToSync = baseBranch ?? (await getDefaultBranch(workspacePath));
+  const remote = options?.remote ?? 'origin';
+  const branchToSync = baseBranch ?? (await getDefaultBranch(workspacePath, remote));
 
-  // Fetch from origin to ensure origin/<branchToSync> is up-to-date
+  // Fetch from the remote to ensure <remote>/<branchToSync> is up-to-date
   try {
-    await execFileAsync('git', ['-C', workspacePath, 'fetch', 'origin', branchToSync], {
+    await execFileAsync('git', ['-C', workspacePath, 'fetch', remote, branchToSync], {
       timeout: 60000,
     });
   } catch (error) {
@@ -146,18 +174,18 @@ export async function syncWorkspace(
       (errorMessage.includes("couldn't find remote ref") || errorMessage.includes('not found'))
     ) {
       throw new Error(
-        `Configured base branch '${baseBranch}' not found on remote. ` +
+        `Configured base branch '${baseBranch}' not found on remote '${remote}'. ` +
           'Either create the branch, update worktree.baseBranch in .archon/config.yaml, ' +
           'or remove the setting to use the auto-detected default branch.'
       );
     }
-    throw new Error(`Sync fetch from origin/${branchToSync} failed: ${err.message}`);
+    throw new Error(`Sync fetch from ${remote}/${branchToSync} failed: ${err.message}`);
   }
 
   const previousHead = await readShortSha(workspacePath, 'HEAD');
 
   if (mode !== 'reset') {
-    const state = await classifyWorkspaceState(workspacePath, branchToSync);
+    const state = await classifyWorkspaceState(workspacePath, branchToSync, remote);
 
     if (mode === 'fetch-only' || state !== 'behind') {
       return unchangedSyncResult(branchToSync, mode, state, previousHead);
@@ -171,14 +199,14 @@ export async function syncWorkspace(
     try {
       await execFileAsync(
         'git',
-        ['-C', workspacePath, 'merge', '--ff-only', `origin/${branchToSync}`],
+        ['-C', workspacePath, 'merge', '--ff-only', `${remote}/${branchToSync}`],
         {
           timeout: 30000,
         }
       );
     } catch (error) {
       const err = error as Error;
-      throw new Error(`Fast-forward to origin/${branchToSync} failed: ${err.message}`);
+      throw new Error(`Fast-forward to ${remote}/${branchToSync} failed: ${err.message}`);
     }
 
     const newHead = await readShortSha(workspacePath, 'HEAD');
@@ -193,15 +221,19 @@ export async function syncWorkspace(
     };
   }
 
-  // Hard-reset local working tree to match origin — only safe for Archon-managed
+  // Hard-reset local working tree to match the remote — only safe for Archon-managed
   // clones, never for a user's local working directory.
   try {
-    await execFileAsync('git', ['-C', workspacePath, 'reset', '--hard', `origin/${branchToSync}`], {
-      timeout: 30000,
-    });
+    await execFileAsync(
+      'git',
+      ['-C', workspacePath, 'reset', '--hard', `${remote}/${branchToSync}`],
+      {
+        timeout: 30000,
+      }
+    );
   } catch (error) {
     const err = error as Error;
-    throw new Error(`Reset to origin/${branchToSync} failed: ${err.message}`);
+    throw new Error(`Reset to ${remote}/${branchToSync} failed: ${err.message}`);
   }
 
   const newHead = await readShortSha(workspacePath, 'HEAD');
@@ -306,14 +338,15 @@ async function isAncestor(
 
 async function classifyWorkspaceState(
   workspacePath: RepoPath,
-  branchToSync: BranchName
+  branchToSync: BranchName,
+  remote = 'origin'
 ): Promise<WorkspaceSyncState> {
   if (await hasTrackedModifications(workspacePath)) {
     return 'dirty';
   }
 
   const localSha = await readSha(workspacePath, 'HEAD');
-  const remoteRef = `origin/${branchToSync}`;
+  const remoteRef = `${remote}/${branchToSync}`;
   const remoteSha = await readSha(workspacePath, remoteRef);
 
   if (localSha === remoteSha) {
@@ -386,18 +419,20 @@ export async function cloneRepository(
  *
  * @param repoPath - Path to the local repository
  * @param branch - Branch to sync to (e.g., 'main')
+ * @param remote - Remote name to fetch from (default: 'origin')
  * @returns GitResult<void>
  */
 export async function syncRepository(
   repoPath: RepoPath,
-  branch: BranchName
+  branch: BranchName,
+  remote = 'origin'
 ): Promise<GitResult<void>> {
   try {
-    await execFileAsync('git', ['fetch', 'origin'], { cwd: repoPath, timeout: 60000 });
+    await execFileAsync('git', ['fetch', remote], { cwd: repoPath, timeout: 60000 });
   } catch (error) {
     const err = error as Error & { stderr?: string };
     const errorText = `${err.message} ${err.stderr ?? ''}`.toLowerCase();
-    getLog().error({ err, repoPath, branch }, 'sync_repository_fetch_failed');
+    getLog().error({ err, repoPath, branch, remote }, 'sync_repository_fetch_failed');
 
     if (errorText.includes('not a git repository')) {
       return { ok: false, error: { code: 'not_a_repo', path: repoPath } };
@@ -412,7 +447,7 @@ export async function syncRepository(
   }
 
   try {
-    await execFileAsync('git', ['reset', '--hard', `origin/${branch}`], {
+    await execFileAsync('git', ['reset', '--hard', `${remote}/${branch}`], {
       cwd: repoPath,
       timeout: 30000,
     });
@@ -424,7 +459,7 @@ export async function syncRepository(
       return { ok: false, error: { code: 'branch_not_found', branch } };
     }
 
-    getLog().error({ err, repoPath, branch }, 'sync_repository_reset_failed');
+    getLog().error({ err, repoPath, branch, remote }, 'sync_repository_reset_failed');
     return { ok: false, error: { code: 'unknown', message: `Reset failed: ${err.message}` } };
   }
 

--- a/packages/isolation/src/pr-state.test.ts
+++ b/packages/isolation/src/pr-state.test.ts
@@ -83,6 +83,19 @@ describe('getPrState', () => {
     expect(result).toBe('NONE');
   });
 
+  test('queries the custom remote when provided', async () => {
+    setupGhResponse('https://github.com/owner/repo.git', '[{"state":"MERGED"}]');
+
+    const result = await getPrState(BRANCH, REPO, undefined, 'upstream');
+
+    expect(result).toBe('MERGED');
+    expect(mockExecFileAsync).toHaveBeenCalledWith(
+      'git',
+      ['-C', REPO, 'remote', 'get-url', 'upstream'],
+      expect.any(Object)
+    );
+  });
+
   test('uses cache on subsequent lookups for same branch', async () => {
     setupGhResponse('https://github.com/owner/repo.git', '[{"state":"MERGED"}]');
     const cache = new Map<string, PrState>();

--- a/packages/isolation/src/pr-state.ts
+++ b/packages/isolation/src/pr-state.ts
@@ -26,11 +26,13 @@ export type PrState = 'MERGED' | 'CLOSED' | 'OPEN' | 'NONE';
  *   - 'NONE' if no PR exists, gh is unavailable, or the remote is not GitHub
  *
  * The optional `cache` map dedupes lookups within a single cleanup invocation.
+ * The optional `remote` selects which git remote to inspect (default: 'origin').
  */
 export async function getPrState(
   branch: BranchName,
   repoPath: RepoPath,
-  cache?: Map<string, PrState>
+  cache?: Map<string, PrState>,
+  remote = 'origin'
 ): Promise<PrState> {
   const cached = cache?.get(branch);
   if (cached !== undefined) {
@@ -40,7 +42,7 @@ export async function getPrState(
   // Check whether the remote is on GitHub. Non-GitHub remotes are out of scope.
   let remoteUrl = '';
   try {
-    const { stdout } = await execFileAsync('git', ['-C', repoPath, 'remote', 'get-url', 'origin'], {
+    const { stdout } = await execFileAsync('git', ['-C', repoPath, 'remote', 'get-url', remote], {
       timeout: 10000,
     });
     remoteUrl = stdout.trim();

--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -30,6 +30,7 @@ import type { IsolationRequest, PRIsolationRequest, RepoConfigLoader } from '../
 
 // Track sync function calls for testing
 let getDefaultBranchSpy: Mock<typeof git.getDefaultBranch>;
+let getDefaultRemoteSpy: Mock<typeof git.getDefaultRemote>;
 let syncWorkspaceSpy: Mock<typeof git.syncWorkspace>;
 
 // Mock fs.promises.access for destroy() existence check
@@ -64,6 +65,7 @@ describe('WorktreeProvider', () => {
     findWorktreeByBranchSpy = spyOn(git, 'findWorktreeByBranch');
     getCanonicalRepoPathSpy = spyOn(git, 'getCanonicalRepoPath');
     getDefaultBranchSpy = spyOn(git, 'getDefaultBranch');
+    getDefaultRemoteSpy = spyOn(git, 'getDefaultRemote');
     syncWorkspaceSpy = spyOn(git, 'syncWorkspace');
 
     // Default mocks
@@ -89,6 +91,7 @@ describe('WorktreeProvider', () => {
 
     // Default mocks for workspace sync
     getDefaultBranchSpy.mockResolvedValue('main');
+    getDefaultRemoteSpy.mockResolvedValue('origin');
     syncWorkspaceSpy.mockResolvedValue({
       branch: 'main',
       synced: true,
@@ -108,6 +111,7 @@ describe('WorktreeProvider', () => {
     findWorktreeByBranchSpy.mockRestore();
     getCanonicalRepoPathSpy.mockRestore();
     getDefaultBranchSpy.mockRestore();
+    getDefaultRemoteSpy.mockRestore();
     syncWorkspaceSpy.mockRestore();
     mockAccess.mockClear();
     mockReadFile.mockClear();
@@ -2287,6 +2291,7 @@ describe('WorktreeProvider', () => {
       // syncWorkspace called with undefined → triggers auto-detect via getDefaultBranch
       expect(syncWorkspaceSpy).toHaveBeenCalledWith('/workspace/owner/repo', undefined, {
         mode: 'fast-forward',
+        remote: 'origin',
       });
     });
 
@@ -2311,6 +2316,7 @@ describe('WorktreeProvider', () => {
 
       expect(syncWorkspaceSpy).toHaveBeenCalledWith('/workspace/owner/repo', 'develop', {
         mode: 'fast-forward',
+        remote: 'origin',
       });
       expect(execSpy).toHaveBeenCalledWith(
         'git',
@@ -2339,6 +2345,7 @@ describe('WorktreeProvider', () => {
 
       expect(syncWorkspaceSpy).toHaveBeenCalledWith('/workspace/owner/repo', 'main', {
         mode: 'fast-forward',
+        remote: 'origin',
       });
     });
 
@@ -2355,7 +2362,7 @@ describe('WorktreeProvider', () => {
       expect(syncWorkspaceSpy).toHaveBeenCalledWith(
         '/test/.archon/workspaces/owner/repo/source',
         undefined,
-        { mode: 'reset' }
+        { mode: 'reset', remote: 'origin' }
       );
     });
 
@@ -2376,6 +2383,7 @@ describe('WorktreeProvider', () => {
       // fromBranch is the start-point for the branch, not for sync — sync auto-detects
       expect(syncWorkspaceSpy).toHaveBeenCalledWith('/workspace/owner/repo', undefined, {
         mode: 'fast-forward',
+        remote: 'origin',
       });
     });
 
@@ -2395,6 +2403,7 @@ describe('WorktreeProvider', () => {
 
       expect(syncWorkspaceSpy).toHaveBeenCalledWith('/workspace/owner/repo', 'main', {
         mode: 'fast-forward',
+        remote: 'origin',
       });
     });
 
@@ -2414,6 +2423,7 @@ describe('WorktreeProvider', () => {
       // fromBranch is ignored for non-task types, so syncWorkspace gets undefined → auto-detect
       expect(syncWorkspaceSpy).toHaveBeenCalledWith('/workspace/owner/repo', undefined, {
         mode: 'fast-forward',
+        remote: 'origin',
       });
     });
 
@@ -2428,6 +2438,7 @@ describe('WorktreeProvider', () => {
 
       expect(syncWorkspaceSpy).toHaveBeenCalledWith('/workspace/owner/repo', 'develop', {
         mode: 'fast-forward',
+        remote: 'origin',
       });
       expect(getDefaultBranchSpy).not.toHaveBeenCalled();
     });
@@ -2437,7 +2448,7 @@ describe('WorktreeProvider', () => {
       worktreeExistsSpy.mockResolvedValue(false);
 
       await expect(provider.create(baseRequest)).rejects.toThrow(
-        'Failed to fetch base branch from origin'
+        "Failed to fetch base branch from 'origin'"
       );
     });
 
@@ -2480,7 +2491,7 @@ describe('WorktreeProvider', () => {
       syncWorkspaceSpy.mockRejectedValue(new Error('Network timeout'));
 
       await expect(provider.create(baseRequest)).rejects.toThrow(
-        'Failed to fetch base branch from origin'
+        "Failed to fetch base branch from 'origin'"
       );
     });
   });
@@ -2976,6 +2987,194 @@ describe('WorktreeProvider', () => {
 
       // healthCheck wraps the path in toWorktreePath before calling worktreeExists
       expect(worktreeExistsSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('custom remote support', () => {
+    const baseRequest: IsolationRequest = {
+      codebaseId: 'cb-123',
+      canonicalRepoPath: '/workspace/repo',
+      workflowType: 'issue',
+      identifier: '42',
+    };
+
+    beforeEach(() => {
+      worktreeExistsSpy.mockResolvedValue(false);
+    });
+
+    test('uses configured remote from worktree config', async () => {
+      const customProvider = new WorktreeProvider(async () => ({
+        baseBranch: 'main',
+        remote: 'mar',
+      }));
+
+      await customProvider.create(baseRequest);
+
+      // syncWorkspace receives the configured remote
+      expect(syncWorkspaceSpy).toHaveBeenCalledWith(
+        '/workspace/repo',
+        'main',
+        expect.objectContaining({ remote: 'mar' })
+      );
+      // Explicit config wins — no auto-detection call
+      expect(getDefaultRemoteSpy).not.toHaveBeenCalled();
+
+      // worktree add uses mar/main as the start-point
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        expect.arrayContaining(['worktree', 'add', '-b', 'archon/issue-42', 'mar/main']),
+        expect.any(Object)
+      );
+    });
+
+    test('auto-detects remote when not configured', async () => {
+      getDefaultRemoteSpy.mockResolvedValue('upstream');
+      const autoProvider = new WorktreeProvider(async () => ({ baseBranch: 'main' }));
+
+      await autoProvider.create(baseRequest);
+
+      expect(syncWorkspaceSpy).toHaveBeenCalledWith(
+        '/workspace/repo',
+        'main',
+        expect.objectContaining({ remote: 'upstream' })
+      );
+    });
+
+    test('fromBranch start-point is not remote-prefixed (task workflow)', async () => {
+      const taskRequest: IsolationRequest = {
+        ...baseRequest,
+        workflowType: 'task',
+        identifier: 'my-feature',
+        fromBranch: 'develop',
+      };
+
+      const customProvider = new WorktreeProvider(async () => ({
+        baseBranch: 'main',
+        remote: 'upstream',
+      }));
+
+      await customProvider.create(taskRequest);
+
+      // fromBranch overrides <remote>/<baseBranch> as the start-point
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        expect.arrayContaining(['worktree', 'add', '-b', 'archon/task-my-feature', 'develop']),
+        expect.any(Object)
+      );
+    });
+
+    test('throws actionable error when remote is ambiguous', async () => {
+      getDefaultRemoteSpy.mockResolvedValue(null);
+      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
+        // `git remote` listing for the error message
+        if (args.includes('remote') && !args.includes('get-url')) {
+          return { stdout: 'jan\nfeb\nmar\n', stderr: '' };
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      const ambiguousProvider = new WorktreeProvider(async () => ({ baseBranch: 'main' }));
+
+      await expect(ambiguousProvider.create(baseRequest)).rejects.toThrow(
+        /Cannot determine git remote.*jan, feb, mar.*Set worktree\.remote/s
+      );
+      // No sync attempted from an unknown remote
+      expect(syncWorkspaceSpy).not.toHaveBeenCalled();
+    });
+
+    test('uses custom remote for same-repo PR fetch and tracking', async () => {
+      const prRequest: PRIsolationRequest = {
+        codebaseId: 'cb-123',
+        canonicalRepoPath: '/workspace/repo',
+        workflowType: 'pr',
+        identifier: '42',
+        prBranch: 'feature/auth',
+        isForkPR: false,
+      };
+
+      const customProvider = new WorktreeProvider(async () => ({
+        baseBranch: 'main',
+        remote: 'upstream',
+      }));
+
+      await customProvider.create(prRequest);
+
+      // Fetch uses the custom remote
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        expect.arrayContaining(['-C', '/workspace/repo', 'fetch', 'upstream', 'feature/auth']),
+        expect.any(Object)
+      );
+
+      // Branch tracking uses the custom remote
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        expect.arrayContaining(['branch', '--set-upstream-to', 'upstream/feature/auth']),
+        expect.any(Object)
+      );
+    });
+
+    test('uses custom remote for fork PR fetch', async () => {
+      const forkPrRequest: PRIsolationRequest = {
+        codebaseId: 'cb-123',
+        canonicalRepoPath: '/workspace/repo',
+        workflowType: 'pr',
+        identifier: '42',
+        prBranch: 'feature/auth',
+        isForkPR: true,
+      };
+
+      const customProvider = new WorktreeProvider(async () => ({
+        baseBranch: 'main',
+        remote: 'upstream',
+      }));
+
+      await customProvider.create(forkPrRequest);
+
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        expect.arrayContaining([
+          '-C',
+          '/workspace/repo',
+          'fetch',
+          'upstream',
+          'pull/42/head:pr-42-review',
+        ]),
+        expect.any(Object)
+      );
+    });
+
+    test('uses custom remote for remote branch deletion', async () => {
+      mockAccess.mockResolvedValue(undefined);
+
+      await provider.destroy('worktree-path', {
+        branchName: git.toBranchName('archon/issue-42'),
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
+        deleteRemoteBranch: true,
+        remote: 'upstream',
+      });
+
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        ['-C', '/workspace/repo', 'push', 'upstream', '--delete', 'archon/issue-42'],
+        expect.any(Object)
+      );
+    });
+
+    test('defaults remote branch deletion to origin when no remote passed', async () => {
+      mockAccess.mockResolvedValue(undefined);
+
+      await provider.destroy('worktree-path', {
+        branchName: git.toBranchName('archon/issue-42'),
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
+        deleteRemoteBranch: true,
+      });
+
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        ['-C', '/workspace/repo', 'push', 'origin', '--delete', 'archon/issue-42'],
+        expect.any(Object)
+      );
     });
   });
 });

--- a/packages/isolation/src/providers/worktree.ts
+++ b/packages/isolation/src/providers/worktree.ts
@@ -13,6 +13,7 @@ import {
   execFileAsync,
   findWorktreeByBranch,
   getCanonicalRepoPath,
+  getDefaultRemote,
   getWorktreeBase,
   listWorktrees,
   mkdirAsync,
@@ -292,7 +293,8 @@ export class WorktreeProvider implements IIsolationProvider {
         result.remoteBranchDeleted = await this.deleteRemoteBranchTracked(
           repoPath,
           options.branchName,
-          result
+          result,
+          options.remote
         );
       }
     }
@@ -381,10 +383,11 @@ export class WorktreeProvider implements IIsolationProvider {
   private async deleteRemoteBranchTracked(
     repoPath: string,
     branchName: string,
-    result: DestroyResult
+    result: DestroyResult,
+    remote = 'origin'
   ): Promise<boolean> {
     try {
-      await execFileAsync('git', ['-C', repoPath, 'push', 'origin', '--delete', branchName], {
+      await execFileAsync('git', ['-C', repoPath, 'push', remote, '--delete', branchName], {
         timeout: GIT_OPERATION_TIMEOUT_MS,
       });
       getLog().debug({ repoPath, branchName }, 'remote_branch_deleted');
@@ -704,11 +707,14 @@ export class WorktreeProvider implements IIsolationProvider {
   ): Promise<{ warnings: string[] }> {
     const repoPath = request.canonicalRepoPath;
 
+    // Resolve git remote name: explicit config > auto-detect > actionable error
+    const remote = await this.resolveRemote(repoPath, worktreeConfig?.remote);
+
     // Sync uses explicit repo config first, then the registered codebase's
     // default branch (request.baseBranch), then auto-detects via getDefaultBranch.
     // request.fromBranch is the start-point for worktree creation, not a sync target.
     const preferredBaseBranch = worktreeConfig?.baseBranch ?? request.baseBranch;
-    const baseBranch = await this.syncWorkspaceBeforeCreate(repoPath, preferredBaseBranch);
+    const baseBranch = await this.syncWorkspaceBeforeCreate(repoPath, preferredBaseBranch, remote);
 
     const override: WorktreeBaseOverride = {
       repoLocal: resolveRepoLocalOverride(worktreeConfig?.path, repoPath),
@@ -720,10 +726,10 @@ export class WorktreeProvider implements IIsolationProvider {
 
     if (isPRIsolationRequest(request)) {
       // For PRs: fetch and checkout the PR branch (actual or synthetic)
-      await this.createFromPR(request, worktreePath);
+      await this.createFromPR(request, worktreePath, remote);
     } else {
       // For issues, tasks, threads: create new branch
-      await this.createNewBranch(request, repoPath, worktreePath, branchName, baseBranch);
+      await this.createNewBranch(request, repoPath, worktreePath, branchName, baseBranch, remote);
     }
 
     // Stamp the originating user's git identity on this worktree so workflow
@@ -783,6 +789,45 @@ export class WorktreeProvider implements IIsolationProvider {
   }
 
   /**
+   * Resolve the git remote name to use for all fetch/push operations.
+   *
+   * Resolution order: explicit config (worktree.remote) > auto-detect via
+   * getDefaultRemote() > actionable error when ambiguous.
+   */
+  private async resolveRemote(repoPath: RepoPath, configuredRemote?: string): Promise<string> {
+    const configured = configuredRemote?.trim();
+    if (configured) {
+      getLog().debug({ repoPath, remote: configured }, 'worktree.remote_from_config');
+      return configured;
+    }
+
+    const detected = await getDefaultRemote(repoPath);
+    if (detected) {
+      if (detected !== 'origin') {
+        // Non-standard remote picked up automatically — log at info so the
+        // choice is visible when debugging fetch/push behavior.
+        getLog().info({ repoPath, remote: detected }, 'worktree.remote_auto_detected');
+      }
+      return detected;
+    }
+
+    // Ambiguous (multiple non-origin remotes) — list them for an actionable error
+    let remoteList = '<unknown>';
+    try {
+      const { stdout } = await execFileAsync('git', ['-C', repoPath, 'remote'], { timeout: 10000 });
+      remoteList = stdout.trim().split(/\r?\n/).join(', ');
+    } catch {
+      // Best-effort for error message only
+    }
+
+    throw new Error(
+      `Cannot determine git remote for ${repoPath}: no 'origin' remote found and ` +
+        `multiple remotes exist (${remoteList}). ` +
+        'Set worktree.remote in .archon/config.yaml to specify which remote to use.'
+    );
+  }
+
+  /**
    * Sync workspace with remote before creating a new worktree
    * Ensures new work starts from the latest code on the base branch.
    *
@@ -802,11 +847,12 @@ export class WorktreeProvider implements IIsolationProvider {
    */
   private async syncWorkspaceBeforeCreate(
     repoPath: RepoPath,
-    configuredBaseBranch?: string
+    configuredBaseBranch?: string,
+    remote = 'origin'
   ): Promise<string> {
     try {
       getLog().debug(
-        { repoPath, branch: configuredBaseBranch ?? 'auto-detect' },
+        { repoPath, branch: configuredBaseBranch ?? 'auto-detect', remote },
         'workspace_sync_starting'
       );
       // Only hard-reset for Archon-managed clones when creating isolated worktrees.
@@ -817,9 +863,9 @@ export class WorktreeProvider implements IIsolationProvider {
       const { branch } = await syncWorkspace(
         repoPath,
         configuredBaseBranch ? toBranchName(configuredBaseBranch) : undefined,
-        { mode: isManagedClone ? 'reset' : 'fast-forward' }
+        { mode: isManagedClone ? 'reset' : 'fast-forward', remote }
       );
-      getLog().debug({ repoPath, branch }, 'workspace_synced');
+      getLog().debug({ repoPath, branch, remote }, 'workspace_synced');
       return branch;
     } catch (error) {
       const err = error as Error & { code?: string };
@@ -842,8 +888,8 @@ export class WorktreeProvider implements IIsolationProvider {
       } else {
         // Network errors, timeouts — cannot guarantee correct start-point
         throw new Error(
-          `Failed to fetch base branch from origin: ${err.message}. ` +
-            'Check your network connection and try again.'
+          `Failed to fetch base branch from '${remote}': ${err.message}. ` +
+            'Check your network connection and remote configuration.'
         );
       }
     }
@@ -924,7 +970,11 @@ export class WorktreeProvider implements IIsolationProvider {
    * When prSha is provided, the worktree is initially created at the specific
    * commit (detached HEAD), then a local tracking branch is created.
    */
-  private async createFromPR(request: PRIsolationRequest, worktreePath: string): Promise<void> {
+  private async createFromPR(
+    request: PRIsolationRequest,
+    worktreePath: string,
+    remote = 'origin'
+  ): Promise<void> {
     // Clean up any orphan directory before creating worktree
     await this.cleanOrphanDirectoryIfExists(worktreePath);
 
@@ -934,10 +984,10 @@ export class WorktreeProvider implements IIsolationProvider {
     try {
       if (!request.isForkPR) {
         // Same-repo PR: Use the actual branch so changes push directly to PR
-        await this.createFromSameRepoPR(repoPath, worktreePath, request.prBranch);
+        await this.createFromSameRepoPR(repoPath, worktreePath, request.prBranch, remote);
       } else {
         // Fork PR: Use synthetic review branch
-        await this.createFromForkPR(repoPath, worktreePath, prNumber, request.prSha);
+        await this.createFromForkPR(repoPath, worktreePath, prNumber, remote, request.prSha);
       }
     } catch (error) {
       // Clean up orphaned git-registered worktree from partial failure
@@ -954,10 +1004,11 @@ export class WorktreeProvider implements IIsolationProvider {
   private async createFromSameRepoPR(
     repoPath: string,
     worktreePath: string,
-    prBranch: string
+    prBranch: string,
+    remote = 'origin'
   ): Promise<void> {
     // Fetch the PR's actual branch
-    await execFileAsync('git', ['-C', repoPath, 'fetch', 'origin', prBranch], {
+    await execFileAsync('git', ['-C', repoPath, 'fetch', remote, prBranch], {
       timeout: GIT_OPERATION_TIMEOUT_MS,
     });
 
@@ -966,7 +1017,7 @@ export class WorktreeProvider implements IIsolationProvider {
       // If branch doesn't exist locally, create it tracking remote
       await execFileAsync(
         'git',
-        ['-C', repoPath, 'worktree', 'add', worktreePath, '-b', prBranch, `origin/${prBranch}`],
+        ['-C', repoPath, 'worktree', 'add', worktreePath, '-b', prBranch, `${remote}/${prBranch}`],
         { timeout: GIT_OPERATION_TIMEOUT_MS }
       );
     } catch (error) {
@@ -985,7 +1036,7 @@ export class WorktreeProvider implements IIsolationProvider {
     try {
       await execFileAsync(
         'git',
-        ['-C', worktreePath, 'branch', '--set-upstream-to', `origin/${prBranch}`],
+        ['-C', worktreePath, 'branch', '--set-upstream-to', `${remote}/${prBranch}`],
         { timeout: GIT_OPERATION_TIMEOUT_MS }
       );
     } catch (trackingError) {
@@ -1004,13 +1055,14 @@ export class WorktreeProvider implements IIsolationProvider {
     repoPath: string,
     worktreePath: string,
     prNumber: string,
+    remote = 'origin',
     prSha?: string
   ): Promise<void> {
     const reviewBranch = `pr-${prNumber}-review`;
 
     if (prSha) {
       // SHA provided: create at specific commit for reproducible reviews
-      await execFileAsync('git', ['-C', repoPath, 'fetch', 'origin', `pull/${prNumber}/head`], {
+      await execFileAsync('git', ['-C', repoPath, 'fetch', remote, `pull/${prNumber}/head`], {
         timeout: GIT_OPERATION_TIMEOUT_MS,
       });
 
@@ -1034,7 +1086,7 @@ export class WorktreeProvider implements IIsolationProvider {
         () =>
           execFileAsync(
             'git',
-            ['-C', repoPath, 'fetch', 'origin', `pull/${prNumber}/head:${reviewBranch}`],
+            ['-C', repoPath, 'fetch', remote, `pull/${prNumber}/head:${reviewBranch}`],
             { timeout: GIT_OPERATION_TIMEOUT_MS }
           ),
         reviewBranch
@@ -1079,7 +1131,8 @@ export class WorktreeProvider implements IIsolationProvider {
     repoPath: string,
     worktreePath: string,
     branchName: string,
-    baseBranch: string
+    baseBranch: string,
+    remote = 'origin'
   ): Promise<void> {
     // Clean up any orphan directory before creating worktree
     await this.cleanOrphanDirectoryIfExists(worktreePath);
@@ -1088,7 +1141,7 @@ export class WorktreeProvider implements IIsolationProvider {
     const startPoint =
       request.workflowType === 'task' && request.fromBranch
         ? request.fromBranch
-        : `origin/${baseBranch}`;
+        : `${remote}/${baseBranch}`;
 
     try {
       // `--no-track` keeps `branch.<name>.merge` unset; otherwise `gh pr view`

--- a/packages/isolation/src/types.ts
+++ b/packages/isolation/src/types.ts
@@ -166,6 +166,8 @@ export interface WorktreeDestroyOptions extends DestroyOptions {
   canonicalRepoPath?: RepoPath;
   /** Delete the remote branch (best-effort, e.g., after PR merge) */
   deleteRemoteBranch?: boolean;
+  /** Git remote name for remote branch deletion (default: 'origin') */
+  remote?: string;
 }
 
 /**
@@ -293,6 +295,23 @@ export interface WorktreeCreateConfig {
    * @example '.worktrees'
    */
   path?: string;
+  /**
+   * Git remote name to use for fetch/push operations.
+   *
+   * When set, all git operations (fetch, push, branch tracking) use this
+   * remote instead of 'origin'. Useful for repos with multiple remotes or
+   * non-standard naming conventions.
+   *
+   * When omitted, auto-detected via `getDefaultRemote()`:
+   *   1. 'origin' if it exists
+   *   2. The sole remote if only one is configured
+   *   3. null when ambiguous — worktree creation then fails with an
+   *      actionable error listing the available remotes
+   *
+   * Sourced from `.archon/config.yaml > worktree.remote` in the repo.
+   * @example 'upstream'
+   */
+  remote?: string;
 }
 
 export type RepoConfigLoader = (repoPath: string) => Promise<WorktreeCreateConfig | null>;


### PR DESCRIPTION
## Summary

- **Problem:** Archon hardcodes `'origin'` in every git fetch/reset/branch-detection call, so a registered repo whose sole remote isn't named `origin` fails outright at worktree creation, workspace sync, PR-state lookup, and cleanup.
- **Why it matters:** Repos cloned with a custom remote name (e.g. `upstream`-only forks, org naming conventions) cannot use Archon's isolation or sync at all.
- **What changed:** New optional `worktree.remote` in `.archon/config.yaml` + `getDefaultRemote()` auto-detection (`origin` if present → sole remote → actionable error on ambiguity), threaded through `@archon/git`, the worktree provider, orchestrator sync, PR-state lookup, forge detection, and the cleanup service.
- **What did not change (scope boundary):** No workflow-engine, adapter, or web UI changes. Every new parameter defaults to `'origin'` — zero behavior change for existing installs.
- **Provenance:** Clean rebuild of #1548 (deepakrawat-dce) on current `dev` with the maintainer's outstanding review fixes applied; co-author credit preserved on the commit.

## UX Journey

### Before

```
User                     Archon CLI                Git
────                     ──────────                ───
registers repo whose
sole remote is 'mar'
runs workflow ─────────▶ creates worktree
                         fetch origin <branch> ───▶ ERROR: 'origin' does not exist
sees error ◀──────────── "Check network connection"
```

### After

```
User                     Archon CLI                     Git
────                     ──────────                     ───
runs workflow ─────────▶ [resolveRemote()]
                         config worktree.remote? ──no─▶ git remote
                         ◀────────────────────────────── 'mar' (sole remote)
                         fetch mar <branch> ───────────▶ SUCCESS
                         worktree from mar/<base>
sees worktree ◀───────── isolation ready
(ambiguous multi-remote repos get an actionable error naming the
 remotes and pointing at worktree.remote)
```

## Architecture Diagram

### Before

```
┌──────────────┐     ┌────────────────┐     ┌──────────────┐
│ core         │────▶│ @archon/iso    │────▶│ @archon/git  │
│ orchestrator │     │ worktree.ts    │     │ repo.ts      │
│ cleanup-svc  │     │ pr-state.ts    │     │ branch.ts    │
└──────────────┘     └────────────────┘     │ forge.ts     │
                                            └──────────────┘
All git calls hardcode 'origin'
```

### After

```
┌──────────────────┐     ┌────────────────────┐     ┌──────────────────┐
│ core             │────▶│ @archon/iso        │────▶│ @archon/git      │
│ [~] orchestrator │     │ [~] worktree.ts    │     │ [~] repo.ts      │
│ [~] cleanup-svc  │     │     resolveRemote()│     │ [+] getDefault-  │
│ [~] config-loader│     │ [~] pr-state.ts    │     │     Remote()     │
└──────────────────┘     │ [~] types.ts       │     │ [~] branch.ts    │
        │                └────────────────────┘     │ [~] forge.ts     │
 ┌──────┴─────────┐                                 └──────────────────┘
 │ [~] RepoConfig │
 │  +worktree.    │   All git calls use the resolved remote
 │    remote      │   (config > auto-detect > 'origin' default)
 └────────────────┘
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| WorktreeProvider.createWorktree | resolveRemote (new private) | **new** | config > `getDefaultRemote()` > actionable error |
| WorktreeProvider | syncWorkspace | **modified** | passes `remote` in options |
| WorktreeProvider (PR/branch/destroy paths) | execFileAsync | **modified** | `${remote}/` instead of `origin/` |
| orchestrator-agent.discoverAllWorkflows | syncWorkspace | **modified** | resolves remote via `loadRepoConfig` + `getDefaultRemote`; sync notifications name the real remote |
| cleanup-service.resolveRepoGitContext | loadRepoConfig / getDefaultBranch | **modified** | extends the existing `resolveBaseBranch` seam to also resolve `worktree.remote` — all cleanup callers (CLI, chat, API, scheduler) get it for free |
| cleanup-service.isSafeToRemove | getPrState | **modified** | passes configured remote |
| cleanup-service.removeEnvironment | provider.destroy | **modified** | passes remote for remote-branch deletion |
| detectForge | getRemoteUrl | **modified** | optional `remote` param (forge.ts landed in #2210, after the original branch) |
| config-loader.mergeRepoConfig | MergedConfig | **modified** | propagates trimmed `worktree.remote` |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `git`, `isolation`, `core`, `config`, `docs`
- Module: `git:repo`, `isolation:worktree`, `core:cleanup-service`, `core:orchestrator`, `core:config`

## Change Metadata

- Change type: `feature`
- Primary scope: `multi` (git + isolation + core)

## Linked Issue

- Closes: N/A (no tracking issue)
- Supersedes #1548 — clean rebuild on current `dev`; the original branch conflicted with heavily-churned files (`cleanup-service.ts` and `orchestrator-agent.ts` were reworked on dev since May). Original design and tests by @deepakrawat-dce, credited via `Co-authored-by` on the commit.

## Validation Evidence (required)

```bash
bun run validate
# check:bundled OK, check:bundled-skill OK, check:bundled-schema OK,
# check:pi-vendor-map OK, check:capability-matrix OK
# type-check: all 10 packages clean
# eslint --max-warnings 0: clean
# prettier --check: clean
# tests: all packages green, 0 fail (incl. new suites below)
```

- Evidence provided: full `bun run validate` green locally. New/updated tests: `getDefaultRemote` (6 cases incl. CRLF + error propagation), `syncWorkspace` custom-remote (fetch/reset/state-classification/`getDefaultBranch` passthrough/error messages), `getDefaultBranch` custom-remote, `syncRepository` custom-remote, `getRemoteUrl` custom-remote, `detectForge` remote forwarding, `getPrState` custom-remote, worktree provider `custom remote support` block (8 cases incl. ambiguity error and fork-PR fetch), cleanup-service remote threading + warn-on-skip, orchestrator remote passthrough + auto-detect, config-loader `worktree.remote` propagation/trim/undefined.
- If any command is intentionally skipped: none skipped.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No` (same git fetch/push, configurable remote name only)
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes` — every new parameter defaults to `'origin'`; repos without `worktree.remote` behave identically (auto-detection also returns `origin` whenever it exists).
- Config/env changes? `Yes` — new optional `worktree.remote` field in `.archon/config.yaml` (documented in the configuration reference).
- Database migration needed? `No`
- Upgrade steps: none. Existing configs are untouched.

## Human Verification (required)

- Verified scenarios: read all three maintainer review rounds on #1548 and applied the outstanding asks — warn-log before skipping an env on merge-check failure, config-load resilience in scheduled cleanup (`loadRepoConfig` on current dev is fail-safe by design: returns `{}` and logs), `loadRepoConfig` mocks + remote-passthrough assertions in cleanup-service and orchestrator tests, and the safety-invariant WHY-comments in `syncWorkspaceBeforeCreate`/`createFromPR`/`createFromForkPR` are intact (this rebuild never deleted them). Verified the auto-detect, explicit-config, and ambiguous-remote paths end to end via the new tests.
- Edge cases checked: CRLF git output (Windows), multiple ambiguous remotes (actionable error listing them, sync never attempted), git failures propagating from `getDefaultRemote` (no null-on-error masking), whitespace-only config values trimmed to undefined, task `fromBranch` start-points staying un-prefixed.
- What was not verified: a live end-to-end run against a physical repo with a non-origin sole remote (unit/integration mocks only), Windows host.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: worktree creation, workspace sync (orchestrator + provider), PR worktree checkout, remote branch deletion, merged-worktree cleanup (on-demand + scheduled), PR-state lookup, forge detection.
- Potential unintended effects: none expected — all parameters are additive with `'origin'` defaults. The one observable delta for origin-based repos: cleanup now emits a `cleanup.merge_check_failed` warn log where it previously skipped silently (a requested review fix, not a regression).
- Guardrails/monitoring: `worktree.remote_auto_detected` info log whenever a non-origin remote is picked automatically; error messages now name the remote (`Sync fetch from <remote>/<branch> failed`, `Failed to fetch base branch from '<remote>'`) for fast diagnosis.

## Rollback Plan (required)

- Fast rollback command/path: revert the single squash commit — all changes are additive parameters with defaults, so revert cleanly restores prior behavior.
- Feature flags or config toggles: `worktree.remote` itself is the toggle; removing it falls back to auto-detection, which resolves to `origin` on standard repos.
- Observable failure symptoms: `Failed to fetch base branch from '<remote>'` during worktree creation, or `Cannot determine git remote for <path>` on ambiguous multi-remote repos.

## Risks and Mitigations

- Risk: `getDefaultRemote()` propagates git errors instead of returning null, which could surface new errors in callers.
  - Mitigation: intentional fail-fast (a swallowed error would masquerade as "no remote"). Both call sites sit inside existing try/catch boundaries: the provider's `create()` error classification and the orchestrator's non-fatal sync guard.
- Risk: divergence from #1548's threading approach in `@archon/core` (options plumbing through command-handler/isolation-operations).
  - Mitigation: current dev already grew an internal config seam in cleanup-service (`resolveBaseBranch`, #1419); this PR extends that seam (`resolveRepoGitContext`) instead of re-adding caller plumbing — same coverage (all cleanup entry points remote-aware, including `cleanupToMakeRoom` and the scheduler, which the original reviews flagged as gaps) with a smaller surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Git remote support for worktrees, synchronization, pull requests, branch tracking, and remote branch deletion.
  * Automatically detects the appropriate remote when none is configured, with actionable errors when selection is ambiguous.
  * Sync and status messages now reference the selected remote instead of always using `origin`.

* **Documentation**
  * Documented remote selection, auto-detection, and related base-branch behavior in the configuration reference.

* **Bug Fixes**
  * Cleanup and merge checks now consistently honor configured remotes and report failed merge checks clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->