### PR TITLE
feat(workflows): evidence gate — refuse terminal completed when evidence_policy.required and evidence.json absent

### DIFF
--- a/packages/docs-web/src/content/docs/reference/workflow-language-constitution.md
+++ b/packages/docs-web/src/content/docs/reference/workflow-language-constitution.md
@@ -39,6 +39,7 @@ If a feature computes rather than coordinates, it is rejected — with the point
 | `include:` (load-time inlining, [#2121](https://github.com/coleam00/Archon/issues/2121)) | ✅ admitted | Textual composition, zero new runtime semantics — the engine sees a flat DAG |
 | `first_success` racing join (proposed, [#1764](https://github.com/coleam00/Archon/issues/1764)) | ✅ admissible | A join rule — coordination |
 | Runtime sub-runs (`workflow:`, #2121 Phase 2) | ✅ shipped (slice 1) | A sub-run is a governance object (own run record, own gates, own audit trail). Slice 1: shared checkout, `input:` string, gate-aware pause/resume; fan-out, `worktree` isolation, racing, and `with:` remain deferred |
+| `evidence_policy` terminal-success gate ([#2230](https://github.com/coleam00/Archon/issues/2230)) | ✅ admitted (thin slice) | A run-status transition (sibling of `approval:`) — the engine gates on `evidence.json` PRESENCE only; computing/validating the evidence stays in the workflow's script/bash nodes. The full typed-schema + reality-verification surface of PR #1601 was rejected as computation |
 | Arithmetic / string functions / regex in `when:` | ❌ rejected | Computation. A script node computes the decision; `when:` gates on its output |
 | Parentheses & nested boolean grouping in `when:` | ❌ rejected (see policy below) | The first step of home-growing an expression language |
 | Templating (Jinja-style interpolation, computed node ids) | ❌ rejected | Evaluation inside declaration — the Helm road |

--- a/packages/paths/src/telemetry.ts
+++ b/packages/paths/src/telemetry.ts
@@ -586,7 +586,13 @@ export interface ChatTurnProperties {
 }
 
 /** Categorical terminal exit reason — a fixed enum, never raw error text. */
-export type WorkflowExitReason = 'no_nodes_completed' | 'node_error' | 'unhandled_error';
+export type WorkflowExitReason =
+  | 'no_nodes_completed'
+  | 'node_error'
+  | 'unhandled_error'
+  // Evidence gate (#2230): all nodes succeeded but `evidence_policy.required`
+  // found no `$ARTIFACTS_DIR/evidence.json`, so the run was marked failed.
+  | 'evidence_missing';
 
 /**
  * Categorical failure class derived from the engine's error classifier

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -10691,6 +10691,215 @@ describe('executeDagWorkflow -- final status derivation', () => {
   });
 });
 
+describe('executeDagWorkflow -- evidence gate (#2230)', () => {
+  // Thin terminal-success gate: when the workflow declares
+  // `evidence_policy.required: true`, the executor refuses terminal `completed`
+  // unless `$ARTIFACTS_DIR/evidence.json` exists. Presence check ONLY — the
+  // workflow's own bash/script nodes compute what counts as evidence.
+  let testDir: string;
+  let artifactsDir: string;
+
+  beforeEach(async () => {
+    testDir = join(
+      tmpdir(),
+      `dag-evidence-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    artifactsDir = join(testDir, 'artifacts');
+    await mkdir(testDir, { recursive: true });
+    mockCaptureWorkflowCompleted.mockClear();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(testDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  async function runEvidenceWorkflow(opts: {
+    store: IWorkflowStore;
+    platform: IWorkflowPlatform;
+    evidencePolicy?: { required: boolean };
+    priorCompletedNodes?: Map<string, string>;
+  }): Promise<void> {
+    const mockDeps = createMockDeps(opts.store);
+    const workflowRun = makeWorkflowRun('dag-evidence-run');
+    const nodes: DagNode[] = [{ id: 'work', bash: 'echo done' } as BashNode];
+
+    await executeDagWorkflow(
+      mockDeps,
+      opts.platform,
+      'conv-evidence',
+      testDir,
+      {
+        name: 'evidence-test',
+        nodes,
+        ...(opts.evidencePolicy ? { evidence_policy: opts.evidencePolicy } : {}),
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      artifactsDir,
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      opts.priorCompletedNodes
+    );
+  }
+
+  it('required: true + missing evidence.json -> failWorkflowRun with explicit reason, never completed', async () => {
+    const mockStore = createMockStore();
+    const platform = createMockPlatform();
+
+    await runEvidenceWorkflow({
+      store: mockStore,
+      platform,
+      evidencePolicy: { required: true },
+    });
+
+    expect((mockStore.completeWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+    expect((mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+    const failCall = (mockStore.failWorkflowRun as ReturnType<typeof mock>).mock
+      .calls[0] as unknown[];
+    expect(failCall[1] as string).toContain('evidence_policy.required');
+    expect(failCall[1] as string).toContain(join(artifactsDir, 'evidence.json'));
+
+    // The user-facing message says exactly why
+    const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
+    const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
+    expect(messages.some(m => m.includes('evidence_policy.required'))).toBe(true);
+  });
+
+  it('missing evidence writes a structured metadata.evidence_validation note', async () => {
+    const mockStore = createMockStore();
+    const platform = createMockPlatform();
+
+    await runEvidenceWorkflow({
+      store: mockStore,
+      platform,
+      evidencePolicy: { required: true },
+    });
+
+    const updateCalls = (mockStore.updateWorkflowRun as ReturnType<typeof mock>).mock
+      .calls as unknown[][];
+    const metadataCall = updateCalls.find(call => {
+      const updates = call[1] as { metadata?: Record<string, unknown> };
+      return updates?.metadata?.evidence_validation !== undefined;
+    });
+    expect(metadataCall).toBeDefined();
+    const note = (metadataCall?.[1] as { metadata: Record<string, unknown> }).metadata
+      .evidence_validation as Record<string, unknown>;
+    expect(note.status).toBe('missing');
+    expect(note.policy).toBe('evidence_policy.required');
+    expect(note.expected_path).toBe(join(artifactsDir, 'evidence.json'));
+    expect(typeof note.checked_at).toBe('string');
+  });
+
+  it('missing evidence persists an evidence_validation_failed workflow event and telemetry exit reason', async () => {
+    const mockStore = createMockStore();
+    const platform = createMockPlatform();
+
+    await runEvidenceWorkflow({
+      store: mockStore,
+      platform,
+      evidencePolicy: { required: true },
+    });
+
+    const eventCalls = (mockStore.createWorkflowEvent as ReturnType<typeof mock>).mock
+      .calls as unknown[][];
+    const evidenceEvent = eventCalls.find(
+      call => (call[0] as { event_type: string }).event_type === 'evidence_validation_failed'
+    );
+    expect(evidenceEvent).toBeDefined();
+    const eventData = (evidenceEvent?.[0] as { data: Record<string, unknown> }).data;
+    expect(eventData.expected_path).toBe(join(artifactsDir, 'evidence.json'));
+
+    const telemetryCalls = mockCaptureWorkflowCompleted.mock.calls as unknown[][];
+    const lastTelemetry = telemetryCalls.at(-1)?.[0] as Record<string, unknown>;
+    expect(lastTelemetry.outcome).toBe('failed');
+    expect(lastTelemetry.exitReason).toBe('evidence_missing');
+  });
+
+  it('required: true + evidence.json present -> completeWorkflowRun', async () => {
+    const mockStore = createMockStore();
+    const platform = createMockPlatform();
+    await mkdir(artifactsDir, { recursive: true });
+    await writeFile(join(artifactsDir, 'evidence.json'), '{"proof": "landed"}');
+
+    await runEvidenceWorkflow({
+      store: mockStore,
+      platform,
+      evidencePolicy: { required: true },
+    });
+
+    expect((mockStore.completeWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+    expect((mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  });
+
+  it('no evidence_policy declared -> completes without checking for evidence.json', async () => {
+    const mockStore = createMockStore();
+    const platform = createMockPlatform();
+
+    await runEvidenceWorkflow({ store: mockStore, platform });
+
+    expect((mockStore.completeWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+    expect((mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  });
+
+  it('required: false -> completes without checking for evidence.json', async () => {
+    const mockStore = createMockStore();
+    const platform = createMockPlatform();
+
+    await runEvidenceWorkflow({
+      store: mockStore,
+      platform,
+      evidencePolicy: { required: false },
+    });
+
+    expect((mockStore.completeWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+    expect((mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  });
+
+  it('resumed run (all nodes prior-completed) with evidence.json now present -> completes', async () => {
+    // A run that failed the gate is resumed after evidence.json was produced:
+    // every node is skipped as prior-completed, the executor re-enters the
+    // completion path, and the gate now passes.
+    const mockStore = createMockStore();
+    const platform = createMockPlatform();
+    await mkdir(artifactsDir, { recursive: true });
+    await writeFile(join(artifactsDir, 'evidence.json'), '{"proof": "landed"}');
+
+    await runEvidenceWorkflow({
+      store: mockStore,
+      platform,
+      evidencePolicy: { required: true },
+      priorCompletedNodes: new Map([['work', 'done']]),
+    });
+
+    expect((mockStore.completeWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+    expect((mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  });
+
+  it('resumed run without evidence.json -> fails the gate again', async () => {
+    const mockStore = createMockStore();
+    const platform = createMockPlatform();
+
+    await runEvidenceWorkflow({
+      store: mockStore,
+      platform,
+      evidencePolicy: { required: true },
+      priorCompletedNodes: new Map([['work', 'done']]),
+    });
+
+    expect((mockStore.completeWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+    expect((mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+  });
+});
+
 describe('provider resolution -- regression for #1610', () => {
   let testDir: string;
 

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -5,7 +5,7 @@
  * Independent nodes within the same layer run concurrently via Promise.allSettled.
  * Captures all assistant output regardless of streaming mode for $node_id.output substitution.
  */
-import { writeFileSync } from 'fs';
+import { existsSync, writeFileSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { isAbsolute, join as joinPath, resolve as resolvePath } from 'path';
 import { execFileAsync, resolveBashPath } from '@archon/git';
@@ -52,6 +52,7 @@ import type {
   WorkflowSource,
   LoopGateRunMetadata,
   ApprovalContext,
+  WorkflowEvidencePolicy,
 } from './schemas';
 import {
   isBashNode,
@@ -6651,6 +6652,8 @@ export async function executeDagWorkflow(
     /** Raw workflow-level `model` ref — used only to derive the workflow tier
      *  keyword for node_started attribution (resolution uses `workflowModel`). */
     model?: string;
+    /** Terminal-success evidence gate (#2230) — read at the completion path. */
+    evidence_policy?: WorkflowEvidencePolicy;
   } & WorkflowLevelOptions,
   workflowRun: WorkflowRun,
   workflowProvider: string,
@@ -7043,6 +7046,93 @@ export async function executeDagWorkflow(
 
   // Check if status was changed externally (e.g. cancelled) before marking complete.
   if (await skipIfStatusChanged('dag.skip_complete_status_changed')) return;
+
+  // Evidence gate (#2230): thin terminal-success gate, a sibling of the
+  // approval/write-back gates (run-status transitions are engine governance).
+  // When the workflow declares `evidence_policy.required: true`, refuse to flip
+  // the run to `completed` unless `$ARTIFACTS_DIR/evidence.json` exists — the
+  // workflow's own bash/script nodes compute what counts as evidence; the
+  // engine checks PRESENCE only (no schema validation, no content checks, no
+  // git/gh I/O — constitution: code computes, YAML coordinates). Placed BEFORE
+  // the container write-back gate so a run that cannot complete never pauses
+  // for (or applies) write-back — mirroring how node-failure runs skip that
+  // gate entirely. Resume-safe: the run id (and therefore artifactsDir) is
+  // stable across resume, so a failed run resumed after evidence.json is
+  // produced re-enters here with all nodes prior-completed and completes.
+  if (workflow.evidence_policy?.required === true) {
+    const evidencePath = joinPath(artifactsDir, 'evidence.json');
+    if (!existsSync(evidencePath)) {
+      const failMsg =
+        `DAG workflow '${workflow.name}' failed the evidence gate: ` +
+        `evidence_policy.required is true but no evidence file exists at ${evidencePath}. ` +
+        'All nodes succeeded — produce evidence.json from a bash/script node, ' +
+        'then resume the run once the file exists.';
+      getLog().error({ workflowRunId: workflowRun.id, evidencePath }, 'dag.evidence_gate_failed');
+      // Anonymous telemetry: terminal failure (evidence missing at completion).
+      captureWorkflowCompleted({
+        outcome: 'failed',
+        workflowName: workflow.name,
+        workflowSource: source,
+        provider: workflowProvider,
+        durationMs: Date.now() - dagStartTime,
+        nodesCompleted: nodeCounts.completed,
+        nodesFailed: nodeCounts.failed,
+        nodesSkipped: nodeCounts.skipped,
+        nodesTotal: nodeCounts.total,
+        exitReason: 'evidence_missing',
+        ...runUsageProps,
+      });
+      // Structured, machine-readable note first (metadata merge), then the
+      // failed-status write — so metadata.evidence_validation is already present
+      // the moment the run reads as failed.
+      await deps.store
+        .updateWorkflowRun(workflowRun.id, {
+          metadata: {
+            evidence_validation: {
+              status: 'missing',
+              policy: 'evidence_policy.required',
+              expected_path: evidencePath,
+              checked_at: new Date().toISOString(),
+            },
+          },
+        })
+        .catch((dbErr: Error) => {
+          getLog().error(
+            { err: dbErr, workflowRunId: workflowRun.id },
+            'dag.evidence_metadata_write_failed'
+          );
+        });
+      await deps.store.failWorkflowRun(workflowRun.id, failMsg).catch((dbErr: Error) => {
+        getLog().error({ err: dbErr, workflowRunId: workflowRun.id }, 'dag_db_fail_failed');
+      });
+      // Persist the reason into the workflow-events log (contract: never throws).
+      await deps.store.createWorkflowEvent({
+        workflow_run_id: workflowRun.id,
+        event_type: 'evidence_validation_failed',
+        data: { policy: 'evidence_policy.required', expected_path: evidencePath },
+      });
+      await logWorkflowError(logDir, workflowRun.id, failMsg).catch((logErr: Error) => {
+        getLog().error(
+          { err: logErr, workflowRunId: workflowRun.id },
+          'dag.workflow_error_log_write_failed'
+        );
+      });
+      const emitterForEvidence = getWorkflowEventEmitter();
+      emitterForEvidence.emit({
+        type: 'workflow_failed',
+        runId: workflowRun.id,
+        workflowName: workflow.name,
+        error: failMsg,
+      });
+      emitterForEvidence.unregisterRun(workflowRun.id);
+      await safeSendMessage(platform, conversationId, `❌ ${failMsg}`, {
+        workflowId: workflowRun.id,
+      });
+      // DO NOT throw — outer executor.ts catch would duplicate workflow_failed events
+      return;
+    }
+    getLog().info({ workflowRunId: workflowRun.id, evidencePath }, 'dag.evidence_gate_passed');
+  }
 
   // Container write-back gate (Phase C): all nodes succeeded — before completing,
   // present the overlay diff and (unless auto) pause for approval. This is an

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -154,6 +154,60 @@ describe('Workflow Loader', () => {
       expect(result.workflows[0].workflow.container).toEqual({ enabled: true });
     });
 
+    it('should parse evidence_policy.required: true (#2230)', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+      const yaml = `name: gated\ndescription: evidence gated\nevidence_policy:\n  required: true\nnodes:\n  - id: n\n    prompt: p\n`;
+      await writeFile(join(workflowDir, 'gated.yaml'), yaml);
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.errors).toHaveLength(0);
+      expect(result.workflows[0].workflow.evidence_policy).toEqual({ required: true });
+    });
+
+    it('should parse evidence_policy.required: false', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+      const yaml = `name: ungated\ndescription: opt-out\nevidence_policy:\n  required: false\nnodes:\n  - id: n\n    prompt: p\n`;
+      await writeFile(join(workflowDir, 'ungated.yaml'), yaml);
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.workflows[0].workflow.evidence_policy).toEqual({ required: false });
+    });
+
+    it('should omit evidence_policy when not present', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+      const yaml = `name: no-evidence\ndescription: none\nnodes:\n  - id: n\n    prompt: p\n`;
+      await writeFile(join(workflowDir, 'no-evidence.yaml'), yaml);
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.workflows[0].workflow.evidence_policy).toBeUndefined();
+    });
+
+    it('should REJECT a malformed evidence_policy block (fail-safe, not warn-and-ignore)', async () => {
+      // Silently dropping a declared terminal-success gate would let runs
+      // complete ungated — a malformed block must fail validation loudly.
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+      const yaml = `name: bad-evidence\ndescription: bad\nevidence_policy:\n  required: "yes"\nnodes:\n  - id: n\n    prompt: p\n`;
+      await writeFile(join(workflowDir, 'bad-evidence.yaml'), yaml);
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.workflows).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].errorType).toBe('validation_error');
+      expect(result.errors[0].error).toContain('evidence_policy');
+    });
+
+    it('should REJECT an empty evidence_policy block (required is mandatory)', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+      const yaml = `name: empty-evidence\ndescription: bad\nevidence_policy: {}\nnodes:\n  - id: n\n    prompt: p\n`;
+      await writeFile(join(workflowDir, 'empty-evidence.yaml'), yaml);
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.workflows).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].errorType).toBe('validation_error');
+      expect(result.errors[0].error).toContain('required: boolean');
+    });
+
     it('should omit container block when not present', async () => {
       const workflowDir = join(testDir, '.archon', 'workflows');
       await mkdir(workflowDir, { recursive: true });

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -36,8 +36,9 @@ import {
   modelReasoningEffortSchema,
   webSearchModeSchema,
   workflowRequirementSchema,
+  workflowEvidencePolicySchema,
 } from './schemas/workflow';
-import type { WorkflowRequirement } from './schemas/workflow';
+import type { WorkflowRequirement, WorkflowEvidencePolicy } from './schemas/workflow';
 import { workflowNodeHooksSchema } from './schemas/hooks';
 import { z } from '@hono/zod-openapi';
 
@@ -606,6 +607,28 @@ export function parseWorkflow(content: string, filename: string): ParseResult {
       }
     }
 
+    // Parse workflow-level evidence policy (#2230). Unlike the worktree/container
+    // convenience policies, a malformed block REJECTS the workflow instead of
+    // warn-and-ignore: silently dropping a declared terminal-success gate would
+    // let a run complete ungated — not fail-safe. Same hard-reject posture as
+    // unknown-provider and persist_session capability validation above.
+    let evidencePolicy: WorkflowEvidencePolicy | undefined;
+    if (raw.evidence_policy !== undefined) {
+      const parsedEvidence = workflowEvidencePolicySchema.safeParse(raw.evidence_policy);
+      if (!parsedEvidence.success) {
+        return {
+          workflow: null,
+          error: {
+            filename,
+            error:
+              "Invalid evidence_policy: expected { required: boolean }. When required is true, the run is refused terminal 'completed' unless $ARTIFACTS_DIR/evidence.json exists.",
+            errorType: 'validation_error',
+          },
+        };
+      }
+      evidencePolicy = parsedEvidence.data;
+    }
+
     // Parse mutates_checkout — boolean, omitted means true (run the path-lock guard).
     // Same parse/warn pattern as `interactive` (invalid non-boolean values are dropped).
     // When false, the executor skips the path-lock guard and allows concurrent runs on the same checkout.
@@ -741,6 +764,7 @@ export function parseWorkflow(content: string, filename: string): ParseResult {
         nodes: dagNodes,
         ...(worktreePolicy ? { worktree: worktreePolicy } : {}),
         ...(containerPolicy ? { container: containerPolicy } : {}),
+        ...(evidencePolicy !== undefined ? { evidence_policy: evidencePolicy } : {}),
         ...(tags !== undefined ? { tags } : {}),
         ...(requires !== undefined ? { requires } : {}),
       },

--- a/packages/workflows/src/schemas/index.ts
+++ b/packages/workflows/src/schemas/index.ts
@@ -93,6 +93,7 @@ export {
   modelReasoningEffortSchema,
   webSearchModeSchema,
   workflowRequirementSchema,
+  workflowEvidencePolicySchema,
   workflowBaseSchema,
   workflowDefinitionSchema,
 } from './workflow';
@@ -100,6 +101,7 @@ export type {
   ModelReasoningEffort,
   WebSearchMode,
   WorkflowRequirement,
+  WorkflowEvidencePolicy,
   WorkflowBase,
   WorkflowDefinition,
 } from './workflow';

--- a/packages/workflows/src/schemas/workflow.ts
+++ b/packages/workflows/src/schemas/workflow.ts
@@ -92,6 +92,27 @@ export const workflowContainerPolicySchema = z.object({
 export type WorkflowContainerPolicy = z.infer<typeof workflowContainerPolicySchema>;
 
 // ---------------------------------------------------------------------------
+// Workflow-level evidence policy (#2230)
+// ---------------------------------------------------------------------------
+
+/**
+ * Terminal-success evidence gate. When `required: true`, the DAG executor
+ * refuses to flip the run to `completed` unless `$ARTIFACTS_DIR/evidence.json`
+ * exists — a missing file marks the run `failed` with a structured note at
+ * `metadata.evidence_validation`. The engine gates ONLY on file presence:
+ * producing (and validating the content of) the evidence belongs to the
+ * workflow's own bash/script nodes (constitution: code computes, YAML
+ * coordinates). Deliberately narrow — no schema validation, no content checks,
+ * no configurable path (deferred until the gate sees adoption; see #2230).
+ */
+export const workflowEvidencePolicySchema = z.object({
+  /** Refuse terminal `completed` unless `$ARTIFACTS_DIR/evidence.json` exists. */
+  required: z.boolean(),
+});
+
+export type WorkflowEvidencePolicy = z.infer<typeof workflowEvidencePolicySchema>;
+
+// ---------------------------------------------------------------------------
 // WorkflowBase — common fields shared by all workflow types
 // ---------------------------------------------------------------------------
 
@@ -110,6 +131,7 @@ export const workflowBaseSchema = z.object({
   sandbox: sandboxSettingsSchema.optional(),
   worktree: workflowWorktreePolicySchema.optional(),
   container: workflowContainerPolicySchema.optional(),
+  evidence_policy: workflowEvidencePolicySchema.optional(),
   /**
    * When `false`, the engine skips the path-exclusive lock for this workflow,
    * allowing N concurrent runs on the same live checkout. The author asserts

--- a/packages/workflows/src/store.ts
+++ b/packages/workflows/src/store.ts
@@ -62,6 +62,10 @@ export const WORKFLOW_EVENT_TYPES = [
   'writeback_requested',
   'writeback_applied',
   'writeback_discarded',
+  // Evidence gate (#2230): `evidence_policy.required` was set but
+  // `$ARTIFACTS_DIR/evidence.json` was absent at completion time — the run was
+  // refused terminal `completed` and marked failed. Data carries the expected path.
+  'evidence_validation_failed',
 ] as const;
 
 export type WorkflowEventType = (typeof WORKFLOW_EVENT_TYPES)[number];


### PR DESCRIPTION
## Summary

- Problem: a workflow run can report terminal `completed` even when its real-world outcome never landed (motivating case #1720 — a commit node "succeeds" in <15s with no commit).
- Why it matters: `completed` is the engine's governance signal; workflows that produce verifiable proof need a way to make that proof a hard condition of success.
- What changed: optional workflow-level `evidence_policy: { required: boolean }`. When `required: true`, the DAG executor refuses terminal `completed` unless `$ARTIFACTS_DIR/evidence.json` exists — the run is marked `failed` with a structured note at `metadata.evidence_validation`, an `evidence_validation_failed` workflow event, and an explicit failure message naming the expected path.
- What did **not** change (scope boundary): the engine gates on file PRESENCE only. No typed evidence schemas, no validator layers, no `verify:` modes, no configurable paths, no git/gh I/O in the engine — all explicitly deferred by #2230. What counts as valid evidence is produced by the workflow's own bash/script nodes.
- Provenance: design carved from @shhaider's closed PR #1601 — this is the thin admissible slice per the workflow-language constitution (the reality-verification layer was computation, not coordination). Credited via `Co-authored-by`.

## UX Journey

### Before

```
  Author                 Archon engine
  ──────                 ─────────────
  runs workflow ───────▶ all nodes succeed
                         run flips to `completed`
  sees "completed" ◀───  (even if the commit/PR/deliverable never landed)
```

### After

```
  Author                 Archon engine
  ──────                 ─────────────
  declares
  evidence_policy:
    required: true
  runs workflow ───────▶ all nodes succeed
                         [gate: $ARTIFACTS_DIR/evidence.json exists?]
                         ├─ yes → run flips to `completed` (unchanged)
                         └─ no  → run marked `failed`
                                  * metadata.evidence_validation note
                                  * evidence_validation_failed event
                                  * message names the expected path
  produces evidence,
  resumes the run ─────▶ nodes skip as prior-completed
                         gate re-checks → `completed`
```

## Architecture Diagram

### Before

```
loader.ts ──parses──▶ workflowBaseSchema
dag-executor.ts (completion path):
  !anyCompleted → fail
  anyFailed     → fail
  skipIfStatusChanged
  container write-back gate ──▶ completeWorkflowRun
```

### After

```
loader.ts ──parses──▶ workflowBaseSchema [~ + evidence_policy]
dag-executor.ts (completion path):
  !anyCompleted → fail
  anyFailed     → fail
  skipIfStatusChanged
  [+ evidence gate] ===▶ failWorkflowRun (+ metadata note + event) on missing file
  container write-back gate ──▶ completeWorkflowRun
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| `loader.ts` | `schemas/workflow.ts` | **modified** | parses `evidence_policy` via `workflowEvidencePolicySchema`; malformed block rejects the workflow |
| `dag-executor.ts` | `store.failWorkflowRun` / `updateWorkflowRun` / `createWorkflowEvent` | **modified** | new gate call sites in the completion path (existing interface methods, no store changes) |
| `dag-executor.ts` | `@archon/paths` telemetry | **modified** | new `evidence_missing` exit reason on the existing `captureWorkflowCompleted` edge |
| `dag-executor.ts` | container write-back gate | unchanged | evidence gate placed BEFORE it — a run that cannot complete never pauses for or applies write-back |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `workflows`
- Module: `workflows:executor`

## Change Metadata

- Change type: `feature`
- Primary scope: `workflows`

## Linked Issue

- Closes #2230
- Related #1720 (motivating false-success case), #1601 (donor PR — this is the carved-down admissible slice)

## Validation Evidence (required)

```bash
bun run validate   # green: bundled/skill/schema/pi-vendor-map/capability-matrix checks,
                   # type-check (all 10 packages), lint --max-warnings 0, format:check, tests
```

- Evidence provided: `packages/workflows` — dag-executor.test.ts 428 pass (8 new gate tests), loader.test.ts 174 pass (5 new schema tests); full per-package suite green via `bun run validate`.
- Skipped: none.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No (one `existsSync` on a path inside the run's own artifacts dir)

## Compatibility / Migration

- Backward compatible? Yes — `evidence_policy` is optional; absent = today's behavior byte-for-byte.
- Config/env changes? No
- Database migration needed? No (`evidence_validation_failed` is a new value in the free-form `workflow_events.event_type` TEXT column; `metadata` note rides the existing JSON merge)

## Human Verification (required)

- Verified scenarios: gate declared + file missing → run failed with metadata note, event, and explicit message; file present → completed; policy absent / `required: false` → unchanged completion; resumed run (all nodes prior-completed) with evidence now present → completed; resumed without evidence → fails again; malformed `evidence_policy` YAML → workflow rejected at load with `validation_error`.
- Edge cases checked: gate ordering vs the container write-back gate (evidence check runs first, so a failing run never pauses for or applies write-back — mirrors how node-failure runs skip that gate); telemetry `exitReason: 'evidence_missing'`.
- What was not verified: a live container-backend run through the combined evidence + write-back path (composition verified by placement + existing write-back tests, not an end-to-end container run).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: only workflows that opt in via `evidence_policy`. The completion path for all other runs is untouched (gate is behind `workflow.evidence_policy?.required === true`).
- Potential unintended effects: an opted-in workflow whose nodes forget to write `evidence.json` will now fail at the finish line — that is the feature, and the failure message + `metadata.evidence_validation` say exactly what to do (produce the file, resume).
- Guardrails/monitoring: `dag.evidence_gate_failed`/`dag.evidence_gate_passed` structured logs, `evidence_validation_failed` workflow event, `evidence_missing` telemetry exit reason.

## Rollback Plan (required)

- Fast rollback command/path: `git revert 3418debf` (single commit, additive surface).
- Feature flags or config toggles: the field itself is the toggle — removing `evidence_policy` from a workflow YAML restores prior behavior without a deploy.
- Observable failure symptoms: runs failing with "failed the evidence gate" despite evidence existing (wrong path resolution) would show in the failure message's absolute path.

## Risks and Mitigations

- Risk: loader posture for malformed `evidence_policy` is hard-reject, unlike the warn-and-ignore `worktree`/`container` blocks — existing YAMLs with a (currently silently-stripped) invalid `evidence_policy` key would stop loading.
  - Mitigation: deliberate fail-safe choice — silently dropping a declared success gate would let runs complete ungated; the field never existed before this PR, so no valid existing YAML is affected.

---

Note: the prp-issue investigation artifact (`.claude/PRPs/issues/issue-2230.md`) is gitignored in this repo, so it is not committed — the issue body itself is the spec. The workflow-language constitution got a one-line case-law row (established table pattern).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional workflow evidence policies requiring `evidence.json` before a run can complete successfully.
  * Added validation for evidence policy configuration, including clear errors for invalid settings.
  * Added distinct workflow events and telemetry for missing required evidence.
  * Evidence checks are supported when resuming workflows.

* **Documentation**
  * Documented evidence policies as terminal-success gates and clarified evidence handling responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->