### PR TITLE
fix(providers/pi): default system prompt for Anthropic subscription-OAuth sessions

### DIFF
--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -85,7 +85,9 @@ const mockGetApiKey = mock(async (providerId: string): Promise<string | undefine
   if (runtimeOverrides[providerId]) return runtimeOverrides[providerId];
   const cred = fileCreds[providerId];
   if (cred?.type === 'api_key') return cred.key;
-  if (cred?.type === 'oauth') return 'oauth-access-token-stub';
+  // Real Anthropic subscription OAuth access tokens are `sk-ant-oat…` — keep
+  // the stub shape-accurate so token-shape-based detection is exercised.
+  if (cred?.type === 'oauth') return 'sk-ant-oat01-file-stub';
   return undefined;
 });
 const mockAuthCreate = mock(() => ({
@@ -185,7 +187,7 @@ mock.module('@earendil-works/pi-coding-agent', () => ({
 }));
 
 // Import AFTER mocks are set — module resolution freezes the mocks.
-import { PiProvider } from './provider';
+import { ARCHON_PI_ANTHROPIC_OAUTH_SYSTEM_PROMPT, PiProvider } from './provider';
 import { PI_CAPABILITIES } from './capabilities';
 // Same module instance the provider dynamic-imports, so clearing this cache
 // resets the loader the provider reuses across calls (issue #1877).
@@ -1303,6 +1305,134 @@ describe('PiProvider', () => {
       | Record<string, unknown>
       | undefined;
     expect(loaderArgs?.systemPrompt).toBeUndefined();
+  });
+
+  test('invalid request-level systemPrompt does not mask valid node-level prompt', async () => {
+    // Regression: a non-string request-level prompt (preset object) must NOT win
+    // via `??` and shadow a valid node-level string — each level is validated
+    // independently before precedence applies.
+    process.env.GEMINI_API_KEY = 'sk-test';
+    resetScript(scriptedAgentEnd());
+
+    await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, {
+        model: 'google/gemini-2.5-pro',
+        systemPrompt: {
+          type: 'preset',
+          preset: 'claude_code',
+          append: 'extra',
+        } as unknown as string,
+        nodeConfig: { systemPrompt: 'node-level prompt' },
+      })
+    );
+
+    // The dropped request-level object is reported, tagged with its source.
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ systemPromptType: 'object', systemPromptSource: 'request' }),
+      'pi.system_prompt_dropped_non_string'
+    );
+
+    // The valid node-level string is used.
+    const loaderArgs = MockDefaultResourceLoader.mock.calls[0]?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(loaderArgs?.systemPrompt).toBe('node-level prompt');
+  });
+
+  // ─── Anthropic subscription-OAuth default system prompt (#1831) ───────
+
+  test('Anthropic OAuth session (env token) falls back to the OAuth-safe default prompt', async () => {
+    // A subscription token (sk-ant-oat*) with no explicit systemPrompt must
+    // suppress Pi's built-in prompt — Anthropic's OAuth endpoint 400s it.
+    resetScript(scriptedAgentEnd());
+
+    await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, {
+        model: 'anthropic/claude-haiku-4-5',
+        env: { ANTHROPIC_OAUTH_TOKEN: 'sk-ant-oat01-bearer' },
+      })
+    );
+
+    const loaderArgs = MockDefaultResourceLoader.mock.calls[0]?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(loaderArgs?.systemPrompt).toBe(ARCHON_PI_ANTHROPIC_OAUTH_SYSTEM_PROMPT);
+  });
+
+  test('Anthropic OAuth session (auth.json subscription cred) falls back to the default prompt', async () => {
+    // Same detection via the `pi /login` path: getApiKey resolves the stored
+    // OAuth access token (sk-ant-oat*), no env var involved.
+    fileCreds.anthropic = { type: 'oauth' };
+    resetScript(scriptedAgentEnd());
+
+    await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, {
+        model: 'anthropic/claude-haiku-4-5',
+      })
+    );
+
+    const loaderArgs = MockDefaultResourceLoader.mock.calls[0]?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(loaderArgs?.systemPrompt).toBe(ARCHON_PI_ANTHROPIC_OAUTH_SYSTEM_PROMPT);
+  });
+
+  test('Anthropic API-key session keeps Pi built-in prompt (systemPrompt undefined)', async () => {
+    // Narrowed scope: API-key auth is not affected by the OAuth classifier, so
+    // Pi's built-in prompt (with its dynamic tool list) must stay intact.
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-api03-key';
+    resetScript(scriptedAgentEnd());
+
+    await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, {
+        model: 'anthropic/claude-haiku-4-5',
+      })
+    );
+
+    const loaderArgs = MockDefaultResourceLoader.mock.calls[0]?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(loaderArgs?.systemPrompt).toBeUndefined();
+  });
+
+  test('non-Anthropic backend keeps Pi built-in prompt (systemPrompt undefined)', async () => {
+    process.env.GEMINI_API_KEY = 'sk-test';
+    resetScript(scriptedAgentEnd());
+
+    await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, { model: 'google/gemini-2.5-pro' })
+    );
+
+    const loaderArgs = MockDefaultResourceLoader.mock.calls[0]?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(loaderArgs?.systemPrompt).toBeUndefined();
+  });
+
+  test('explicit systemPrompt wins over the OAuth default on an OAuth session', async () => {
+    resetScript(scriptedAgentEnd());
+
+    await consume(
+      new PiProvider().sendQuery('hi', '/tmp', undefined, {
+        model: 'anthropic/claude-haiku-4-5',
+        env: { ANTHROPIC_OAUTH_TOKEN: 'sk-ant-oat01-bearer' },
+        nodeConfig: { systemPrompt: 'node-level custom prompt' },
+      })
+    );
+
+    const loaderArgs = MockDefaultResourceLoader.mock.calls[0]?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(loaderArgs?.systemPrompt).toBe('node-level custom prompt');
+  });
+
+  test('ARCHON_PI_ANTHROPIC_OAUTH_SYSTEM_PROMPT carries no third-party "pi harness" tell', () => {
+    // Regression guard: the default must never reintroduce the self-referential
+    // vocabulary that trips Anthropic's subscription-OAuth detector.
+    const p = ARCHON_PI_ANTHROPIC_OAUTH_SYSTEM_PROMPT.toLowerCase();
+    expect(p).not.toContain('pi documentation');
+    expect(p).not.toContain('coding agent harness');
+    expect(p).not.toContain('operating inside pi');
   });
 
   test('capabilities reflect v2 wiring', () => {

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -13,6 +13,7 @@ import type {
   MessageChunk,
   ProviderCapabilities,
   SendQueryOptions,
+  SystemPromptInput,
 } from '../../types';
 
 import { PI_CAPABILITIES } from './capabilities';
@@ -228,6 +229,58 @@ import { augmentPromptForJsonSchema } from '../../shared/structured-output';
 export { augmentPromptForJsonSchema };
 
 /**
+ * Anthropic subscription OAuth access tokens are `sk-ant-oat…` (API keys are
+ * `sk-ant-api…`). This is the same content-shape discriminator pi-ai's
+ * createClient uses to pick OAuth vs API-key auth downstream, so Archon's
+ * detection can never disagree with the SDK's.
+ */
+function isAnthropicOAuthToken(token: string | null | undefined): boolean {
+  return typeof token === 'string' && token.startsWith('sk-ant-oat');
+}
+
+/**
+ * Archon's default system prompt for Pi sessions that authenticate to
+ * Anthropic with a SUBSCRIPTION OAuth token (Claude Pro/Max, `sk-ant-oat*`).
+ *
+ * WHY THIS EXISTS (load-bearing — do not drop without re-reading):
+ * Pi's built-in coding-agent system prompt (pi-coding-agent's
+ * `buildSystemPrompt`) embeds a self-referential "Pi documentation" block
+ * ("...read only when the user asks about pi itself, its SDK, extensions,
+ * themes, skills, or TUI...") plus an "operating inside pi, a coding agent
+ * harness" identity line. That block is dense with third-party-coding-tool
+ * vocabulary, and Anthropic's post-2026-04-04 subscription-OAuth enforcement
+ * classifies any request carrying it as a third-party app — returning
+ * `400 invalid_request_error "You're out of extra usage"` for Pro/Max OAuth
+ * tokens, even though the same token works for first-party Claude Code.
+ *
+ * Supplying ANY custom system prompt makes pi-coding-agent take its
+ * `customPrompt` branch, which omits the incriminating block entirely. pi-ai
+ * still prepends the OAuth-required "You are Claude Code, Anthropic's official
+ * CLI for Claude." block as system[0], so subscription tokens are accepted.
+ * Verified at the wire level (PR #1831): [CC, this-prompt] → HTTP 200;
+ * [CC, pi-default-with-docs-block] → HTTP 400.
+ *
+ * Scope is deliberately narrow: the fallback applies ONLY when the session
+ * will use Anthropic subscription-OAuth auth. API-key sessions and
+ * non-Anthropic backends keep Pi's built-in prompt (with its dynamic tool
+ * list) — there is no benefit to replacing it there. Workflow- or
+ * request-level `systemPrompt` still wins (see sendQuery step 4c).
+ */
+export const ARCHON_PI_ANTHROPIC_OAUTH_SYSTEM_PROMPT = `You are an expert coding assistant. You help users by reading files, executing commands, editing code, and writing new files.
+
+Use the available tools to accomplish the task:
+- read: examine file contents instead of cat/sed
+- bash: run shell commands (ls, grep, find, build, test)
+- edit: make precise, minimal text replacements; each match must be unique
+- write: create new files or fully rewrite existing ones
+
+Guidelines:
+- Prefer reading files before editing them.
+- Keep edits small and targeted; do not pad with unchanged context.
+- Be concise in your responses.
+- Show file paths clearly when working with files.`;
+
+/**
  * Pi community provider — wraps `@earendil-works/pi-coding-agent`'s full
  * coding-agent harness. Each `sendQuery()` call creates a fresh session
  * (no reuse) so concurrent calls don't collide.
@@ -389,8 +442,15 @@ export class PiProvider implements IAgentProvider {
     // Auth validation deferred for extension providers — they manage credentials
     // outside Pi's AuthStorage (e.g. kiro uses AWS SSO/OIDC via ~/.aws/sso/cache/).
     // Only validate early for static-catalog models where we can give actionable hints.
+    // The resolved credential is also kept for the Anthropic subscription-OAuth
+    // detection in step 4c; for 'anthropic' we resolve even when the model is
+    // deferred to extensions (AuthStorage reads are cheap and side-effect-free)
+    // so a catalog miss can never skip the OAuth-safe default prompt.
+    let resolvedKey: Awaited<ReturnType<typeof authStorage.getApiKey>> | undefined;
+    if (model || parsed.provider === 'anthropic') {
+      resolvedKey = await authStorage.getApiKey(parsed.provider);
+    }
     if (model) {
-      const resolvedKey = await authStorage.getApiKey(parsed.provider);
       if (!resolvedKey) {
         if (envVarName) {
           // Name the OAuth var first when the backend has one — a subscription
@@ -454,15 +514,39 @@ export class PiProvider implements IAgentProvider {
 
     //    4c. systemPrompt: request-level (AgentRequestOptions) wins over
     //        node-level; either overrides Pi's default.
-    //        Pi only supports string system prompts; ignore structured preset objects.
-    const rawSystemPrompt = requestOptions?.systemPrompt ?? nodeConfig?.systemPrompt;
-    const systemPrompt = typeof rawSystemPrompt === 'string' ? rawSystemPrompt : undefined;
-    if (rawSystemPrompt !== undefined && systemPrompt === undefined) {
+    //        Pi only supports string system prompts; structured preset objects
+    //        and string[] are dropped. Validate each level INDEPENDENTLY before
+    //        applying precedence — a non-string request-level value (e.g. a
+    //        preset object) must not win via `??` and mask a valid node-level
+    //        string.
+    const coerceStringPrompt = (
+      value: SystemPromptInput | undefined,
+      source: 'request' | 'node'
+    ): string | undefined => {
+      if (value === undefined) return undefined;
+      if (typeof value === 'string') return value;
       getLog().warn(
-        { systemPromptType: typeof rawSystemPrompt },
+        { systemPromptType: typeof value, systemPromptSource: source },
         'pi.system_prompt_dropped_non_string'
       );
-    }
+      return undefined;
+    };
+    const explicitSystemPrompt =
+      coerceStringPrompt(requestOptions?.systemPrompt, 'request') ??
+      coerceStringPrompt(nodeConfig?.systemPrompt, 'node');
+
+    //        When no explicit prompt is set AND this session authenticates to
+    //        Anthropic with a subscription OAuth token, fall back to
+    //        ARCHON_PI_ANTHROPIC_OAUTH_SYSTEM_PROMPT — Anthropic's OAuth
+    //        endpoint hard-400s Pi's self-identifying built-in prompt (see the
+    //        constant's doc comment). Every other session (API-key auth,
+    //        non-Anthropic backends) keeps `undefined` so Pi's built-in prompt,
+    //        with its dynamic tool list, stays intact.
+    const usesAnthropicOAuth =
+      parsed.provider === 'anthropic' && isAnthropicOAuthToken(resolvedKey);
+    const systemPrompt =
+      explicitSystemPrompt ??
+      (usesAnthropicOAuth ? ARCHON_PI_ANTHROPIC_OAUTH_SYSTEM_PROMPT : undefined);
 
     //    4d. skills: Archon uses name references (e.g. `skills: [agent-browser]`).
     //        Resolve each name against .agents/skills and .claude/skills (project
@@ -620,7 +704,12 @@ export class PiProvider implements IAgentProvider {
         cwd,
         thinkingLevel,
         toolCount: filteredTools?.length,
-        hasSystemPrompt: systemPrompt !== undefined,
+        systemPromptSource:
+          explicitSystemPrompt !== undefined
+            ? 'explicit'
+            : systemPrompt !== undefined
+              ? 'anthropic-oauth-default'
+              : 'pi-builtin',
         skillCount: skillPaths.length,
         missingSkillCount: missingSkills.length,
         extensionsEnabled: enableExtensions,


### PR DESCRIPTION
## Summary

- **Problem:** `provider: pi` on an Anthropic model with a Claude Pro/Max **subscription OAuth token** (`sk-ant-oat*`) fails with a hard `400 invalid_request_error "You're out of extra usage"`. Pi's built-in system prompt self-identifies as the Pi harness ("Pi documentation … its SDK, extensions, themes, skills, or TUI"), and Anthropic's subscription-OAuth enforcement classifies that text as a third-party app. pi-ai injects the OAuth-required "You are Claude Code" preamble only around a caller-supplied `customPrompt` — and Archon passes `systemPrompt: undefined` when none is set, letting Pi's flagged built-in prompt through.
- **Why it matters:** Subscription OAuth is a primary way users authenticate Pi against Anthropic, and the #1984/#2000 subscription-delivery work (`ANTHROPIC_OAUTH_TOKEN` env bridge + per-run `auth.json`) made this path much more reachable. Every Pi-on-Anthropic node/chat fails for those users today.
- **What changed:** `PiProvider.sendQuery` now detects an Anthropic subscription-OAuth session from the **resolved credential** (the same `sk-ant-oat*` content-shape discriminator pi-ai's `createClient` uses) and, only then, falls back to a clean Claude-Code-shaped default prompt (`ARCHON_PI_ANTHROPIC_OAUTH_SYSTEM_PROMPT`) instead of `undefined`. Also harvested from the original PR: request- and node-level `systemPrompt` are validated independently (a non-string request-level preset object no longer masks a valid node-level string), and the `hasSystemPrompt` log field became `systemPromptSource: 'explicit' | 'anthropic-oauth-default' | 'pi-builtin'`.
- **What did NOT change (scope boundary):** API-key sessions and non-Anthropic backends keep Pi's built-in prompt (with its dynamic tool list) — this is the deliberate narrowing vs #1831, which replaced Pi's prompt universally. Explicit node/workflow/request `systemPrompt` precedence is untouched (explicit always wins). No SDK/transport/auth-path changes, no new deps, no config or env knob (the original PR's `ARCHON_PI_DEFAULT_SYSTEM_PROMPT` was a constant, not an env override; none is added — YAGNI, an explicit `systemPrompt` is the override path).

## UX Journey

### Before

```
 User                     Archon (Pi provider)              Anthropic API
 ────                     ────────────────────              ─────────────
 run pi node (OAuth) ───▶ resolve creds (sk-ant-oat*)
                          systemPrompt unset → undefined
                          Pi emits built-in prompt
                            system[0] = "You are Claude Code…"
                            system[1] = pi harness + "Pi documentation…"
                          request ────────────────────────▶ classifier: THIRD-PARTY
                          400 "out of extra usage" ◀─────── rejected
 node fails ◀───────────  surface SDK error
```

### After

```
 User                     Archon (Pi provider)              Anthropic API
 ────                     ────────────────────              ─────────────
 run pi node (OAuth) ───▶ resolve creds (sk-ant-oat*)
                          [*] OAuth session detected → inject
                              ARCHON_PI_ANTHROPIC_OAUTH_SYSTEM_PROMPT
                            system[0] = "You are Claude Code…" (pi-ai, unchanged)
                            system[1] = clean coding prompt (no pi self-reference)
                          request ────────────────────────▶ classifier: first-party
                          200 + SSE stream ◀─────────────── accepted
 node completes ◀───────

 run pi node (API key / non-Anthropic) ▶ systemPrompt stays undefined
                          Pi built-in prompt + dynamic tool list (unchanged)
```

## Architecture Diagram

### Before

```
PiProvider.sendQuery ──▶ resolve credentials (authStorage.getApiKey, validation only)
                    └──▶ systemPrompt = explicit string | undefined
                              │
                              ▼
                    createNoopResourceLoader / cached extension loader
                              │
                              ▼
        pi-coding-agent buildSystemPrompt() ── default branch ──▶ built-in prompt
                                                                  (+ "Pi documentation" tell → OAuth 400)
```

### After

```
PiProvider.sendQuery ──▶ [~] resolve credentials — resolvedKey now KEPT
                              (and resolved for anthropic even on a catalog miss)
                    └──▶ [~] explicitSystemPrompt = coerce(request) ?? coerce(node)
                         [+] usesAnthropicOAuth = provider==='anthropic' && sk-ant-oat*
                         [~] systemPrompt = explicit ?? (usesAnthropicOAuth ? OAUTH_DEFAULT : undefined)
                              │
                              ▼
                    createNoopResourceLoader / cached extension loader
                    (cache key already includes systemPrompt — no poisoning)
                              │
                              ▼
        pi-coding-agent buildSystemPrompt({ customPrompt }) ── customPrompt branch (OAuth only)
        pi-coding-agent buildSystemPrompt()                 ── default branch (everyone else, unchanged)
```

**Connection inventory**

| From | To | Status | Notes |
|------|----|--------|-------|
| `PiProvider.sendQuery` | `authStorage.getApiKey` | **modified** | resolved key hoisted + reused for OAuth detection; also resolved for `anthropic` when the model defers to extensions |
| `PiProvider.sendQuery` | `ARCHON_PI_ANTHROPIC_OAUTH_SYSTEM_PROMPT` | **new** | fallback only on Anthropic subscription-OAuth sessions |
| `PiProvider.sendQuery` | resource loader (`loaderOptions.systemPrompt`) | unchanged | still conditional-spread; `undefined` still means "Pi built-in" |
| resource loader | pi `buildSystemPrompt` | unchanged | takes `customPrompt` branch only when a prompt is supplied |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`
- Module: `providers:community/pi`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Supersedes #1831 (community PR by @yanlobkarev — taken over with credit; the commit carries `Co-authored-by`). The root-cause analysis and wire-level bisection there are his; this PR rebuilds the fix on current `dev` with the scope narrowed to OAuth sessions only, per maintainer decision: the universal prompt override in #1831 also replaced Pi's built-in prompt (and its dynamic tool list) for API-key auth and non-Anthropic backends, where nothing is broken.
- Related #1984, #2000 (subscription-delivery work that made the failing path more reachable)

## Validation Evidence (required)

```bash
bun run validate   # exit 0 — check:bundled, check:bundled-skill, check:bundled-schema,
                   # check:pi-vendor-map, check:capability-matrix, type-check, lint,
                   # format:check, tests all green
cd packages/providers && bun test src/community/pi/provider.test.ts   # 96 pass, 0 fail
```

- Evidence provided: 6 new tests — OAuth-session-via-env gets the default prompt; OAuth-session-via-auth.json gets the default prompt; API-key Anthropic session keeps `undefined` (Pi built-in); non-Anthropic backend keeps `undefined`; explicit prompt wins over the OAuth default; regression guard that the default prompt carries none of the third-party "pi harness" vocabulary. Plus the harvested precedence test (invalid request-level prompt no longer masks a valid node-level prompt). Wire-level 200/400 bisection evidence is in #1831 (probes 7–12: `[CC, clean-prompt]` → 200, `[CC, pi-default]` → 400).
- Skipped: live end-to-end against a real Pro/Max OAuth token (validated extensively in #1831 for the same prompt text; the detection seam is unit-tested here).

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No — the resolved credential was already read for validation; it is now additionally inspected in-process for its `sk-ant-oat` prefix and never logged.
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes — explicit `systemPrompt` still wins; API-key and non-Anthropic sessions are byte-for-byte unchanged. Only previously-**failing** OAuth sessions change behavior.
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: full provider test suite (96 tests) including the 7 new/adapted ones; confirmed the extension-loader cache key already includes `systemPrompt` so OAuth vs non-OAuth sessions in one process cannot poison each other's cached loader; confirmed credential resolution (step 4) precedes prompt building (step 4c) so the provider knows the resolved auth at prompt-build time.
- Edge cases checked: auth.json OAuth cred with no env var (mock stub made shape-accurate: `sk-ant-oat…`); OAuth var beating API-key var; anthropic model missing from the static catalog (credential still resolved so detection can't be skipped); non-string preset object at request level with a valid node-level string.
- What was not verified: live 400→200 flip against Anthropic (see #1831's wire evidence for the identical prompt text).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `@archon/providers` Pi community client only.
- Potential unintended effects: Anthropic-OAuth Pi sessions lose Pi's built-in prompt wording (they currently lose the whole request to a 400, so strictly an improvement); the `pi.session_started` log field `hasSystemPrompt` is renamed to `systemPromptSource` (no code consumed the old field).
- Guardrails/monitoring for early detection: `systemPromptSource` makes the chosen prompt path observable per session; the regression test pins the prompt text against reintroducing flagged vocabulary.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge-sha>` — single isolated commit, 2 files.
- Feature flags or config toggles (if any): none needed; setting any explicit `systemPrompt` bypasses the default on demand.
- Observable failure symptoms: Pi-on-Anthropic OAuth sessions returning `400 "out of extra usage"` again.

## Risks and Mitigations

- Risk: Anthropic changes its classifier and a clean custom prompt stops sufficing.
  - Mitigation: self-contained change; `systemPromptSource` breadcrumb + regression test localize future debugging.
- Risk: a Pi-on-Anthropic-OAuth user genuinely wants Pi's built-in prompt.
  - Mitigation: that combination is exactly the one Anthropic rejects — there is no working configuration to preserve; explicit `systemPrompt` remains available for custom wording.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid system prompts, preserving valid configured prompts when request-level values are unsupported.
  * Added appropriate default prompting for Anthropic subscription OAuth sessions.
  * Explicit system prompts now correctly override OAuth-specific defaults.
  * Preserved Pi’s built-in prompting behavior for API-key sessions and non-Anthropic models.
  * Improved support for Anthropic OAuth sessions when model details are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->