### PR TITLE
fix(core): resolve configured default assistant for new conversations

### DIFF
--- a/packages/core/src/db/conversations.test.ts
+++ b/packages/core/src/db/conversations.test.ts
@@ -1,5 +1,9 @@
-import { mock, describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mock, describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { createQueryResult, mockPostgresDialect } from '../test/mocks/database';
+// spyOn (NOT mock.module) for config-loader: this file shares a `bun test`
+// invocation with the real config-loader.test.ts and worktree-sync.test.ts —
+// a mock.module here would poison them (pattern: worktree-sync.test.ts).
+import * as configLoader from '../config/config-loader';
 
 const mockQuery = mock(() => Promise.resolve(createQueryResult([])));
 
@@ -25,21 +29,16 @@ describe('conversations', () => {
   });
 
   describe('getOrCreateConversation', () => {
-    let originalDefaultAiAssistant: string | undefined;
+    const mergedConfig = (assistant: string) =>
+      ({ assistant }) as Awaited<ReturnType<typeof configLoader.loadConfig>>;
+    let loadConfigSpy: ReturnType<typeof spyOn>;
 
     beforeEach(() => {
-      // Save and clear env var to ensure test isolation
-      originalDefaultAiAssistant = process.env.DEFAULT_AI_ASSISTANT;
-      delete process.env.DEFAULT_AI_ASSISTANT;
+      loadConfigSpy = spyOn(configLoader, 'loadConfig').mockResolvedValue(mergedConfig('claude'));
     });
 
     afterEach(() => {
-      // Restore original env var value
-      if (originalDefaultAiAssistant === undefined) {
-        delete process.env.DEFAULT_AI_ASSISTANT;
-      } else {
-        process.env.DEFAULT_AI_ASSISTANT = originalDefaultAiAssistant;
-      }
+      loadConfigSpy.mockRestore();
     });
 
     const existingConversation: Conversation = {
@@ -82,6 +81,7 @@ describe('conversations', () => {
       const result = await getOrCreateConversation('telegram', 'chat-789');
 
       expect(result).toEqual(newConversation);
+      expect(loadConfigSpy).toHaveBeenCalledTimes(1);
       expect(mockQuery).toHaveBeenCalledTimes(2);
       expect(mockQuery).toHaveBeenNthCalledWith(
         2,
@@ -119,11 +119,15 @@ describe('conversations', () => {
         'INSERT INTO remote_agent_conversations (platform_type, platform_conversation_id, ai_assistant_type, codebase_id, cwd, user_id) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *',
         ['telegram', 'chat-789', 'codex', 'codebase-123', null, null]
       );
+      // The codebase-level assistant short-circuits the config chain.
+      expect(loadConfigSpy).not.toHaveBeenCalled();
     });
 
-    test('uses DEFAULT_AI_ASSISTANT env var when set', async () => {
-      // Set env var for this test (afterEach will restore original)
-      process.env.DEFAULT_AI_ASSISTANT = 'codex';
+    // Harvested from PR #1826 (credit: @EugeneChan00) — the configured default
+    // assistant chain (config > DEFAULT_AI_ASSISTANT env > first built-in, all
+    // owned by loadConfig) must reach new conversations without a codebase.
+    test('resolves the configured default assistant when no codebase is scoped', async () => {
+      loadConfigSpy.mockResolvedValueOnce(mergedConfig('codex'));
 
       const newConversation: Conversation = {
         ...existingConversation,
@@ -134,17 +138,39 @@ describe('conversations', () => {
       mockQuery.mockResolvedValueOnce(createQueryResult([]));
       mockQuery.mockResolvedValueOnce(createQueryResult([newConversation]));
 
-      const result = await getOrCreateConversation('telegram', 'chat-789');
+      const result = await getOrCreateConversation('web', 'web-new-chat');
+
+      expect(result).toEqual(newConversation);
+      expect(loadConfigSpy).toHaveBeenCalledTimes(1);
+      expect(mockQuery).toHaveBeenNthCalledWith(
+        2,
+        'INSERT INTO remote_agent_conversations (platform_type, platform_conversation_id, ai_assistant_type, codebase_id, cwd, user_id) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *',
+        ['web', 'web-new-chat', 'codex', null, null, null]
+      );
+    });
+
+    test('falls back to claude when config load fails', async () => {
+      loadConfigSpy.mockRejectedValueOnce(new Error('config unavailable'));
+
+      const newConversation: Conversation = {
+        ...existingConversation,
+        id: 'conv-new',
+      };
+
+      mockQuery.mockResolvedValueOnce(createQueryResult([]));
+      mockQuery.mockResolvedValueOnce(createQueryResult([newConversation]));
+
+      const result = await getOrCreateConversation('web', 'web-new-chat');
 
       expect(result).toEqual(newConversation);
       expect(mockQuery).toHaveBeenNthCalledWith(
         2,
         'INSERT INTO remote_agent_conversations (platform_type, platform_conversation_id, ai_assistant_type, codebase_id, cwd, user_id) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *',
-        ['telegram', 'chat-789', 'codex', null, null, null]
+        ['web', 'web-new-chat', 'claude', null, null, null]
       );
     });
 
-    test('falls back to claude when codebase not found', async () => {
+    test('falls back to configured default when codebase not found', async () => {
       const newConversation: Conversation = {
         ...existingConversation,
         id: 'conv-new',
@@ -160,6 +186,8 @@ describe('conversations', () => {
       const result = await getOrCreateConversation('telegram', 'chat-789', 'non-existent-codebase');
 
       expect(result).toEqual(newConversation);
+      // Missing row → falls through to the config chain.
+      expect(loadConfigSpy).toHaveBeenCalledTimes(1);
       expect(mockQuery).toHaveBeenNthCalledWith(
         3,
         'INSERT INTO remote_agent_conversations (platform_type, platform_conversation_id, ai_assistant_type, codebase_id, cwd, user_id) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *',
@@ -213,6 +241,8 @@ describe('conversations', () => {
         'INSERT INTO remote_agent_conversations (platform_type, platform_conversation_id, ai_assistant_type, codebase_id, cwd, user_id) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *',
         ['discord', 'thread-123', 'codex', 'codebase-123', '/workspace/project', null]
       );
+      // Parent inheritance short-circuits the config chain.
+      expect(loadConfigSpy).not.toHaveBeenCalled();
     });
 
     test('does not inherit when parent has no context', async () => {

--- a/packages/core/src/db/conversations.ts
+++ b/packages/core/src/db/conversations.ts
@@ -5,6 +5,7 @@ import { pool, getDialect } from './connection';
 import type { Conversation } from '../types';
 import { ConversationNotFoundError } from '../types';
 import { createLogger } from '@archon/paths';
+import { loadConfig } from '../config/config-loader';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
@@ -76,7 +77,7 @@ export async function getOrCreateConversation(
   // Check if we should inherit from a parent conversation (e.g., Discord thread inheriting from parent channel)
   let inheritedCodebaseId: string | null = null;
   let inheritedCwd: string | null = null;
-  let assistantType = process.env.DEFAULT_AI_ASSISTANT ?? 'claude';
+  let assistantType: string | undefined;
 
   if (parentConversationId) {
     const parent = await pool.query<Conversation>(
@@ -107,6 +108,30 @@ export async function getOrCreateConversation(
       assistantType = codebase.rows[0].ai_assistant_type;
     }
   }
+
+  // No parent or codebase signal: resolve the configured default assistant
+  // instead of hard-defaulting to Claude (#2241). loadConfig() owns the
+  // fallback chain — explicit config (repo assistant > global defaultAssistant)
+  // > DEFAULT_AI_ASSISTANT env > first registered built-in provider. The
+  // per-user default assistant (#1998) deliberately stays OUT of this row: the
+  // orchestrator applies it per turn (userAiPrefs.defaultProvider ??
+  // conversation.ai_assistant_type), sender-first (#1982), so a personal
+  // preference is never baked into a shared conversation.
+  if (assistantType === undefined) {
+    try {
+      const config = await loadConfig();
+      assistantType = config.assistant;
+    } catch (err) {
+      // Intentional fallback: a broken config (e.g. an unregistered
+      // DEFAULT_AI_ASSISTANT value makes loadConfig throw) must not block
+      // conversation creation — the turn itself surfaces config errors.
+      getLog().warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        'db.conversation_default_assistant_config_load_failed'
+      );
+    }
+  }
+  assistantType ??= 'claude';
 
   const created = await pool.query<Conversation>(
     'INSERT INTO remote_agent_conversations (platform_type, platform_conversation_id, ai_assistant_type, codebase_id, cwd, user_id) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *',

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -3646,6 +3646,45 @@ describe('per-user AI prefs in chat + tier-fallback nudge', () => {
     expect(mockGetUserAiPrefsDb).toHaveBeenCalledWith('creator-1');
   });
 
+  test("per-user default provider wins over the conversation's stored assistant (#2241 chain)", async () => {
+    // Chain order: user pref → conversation row (creation-time default). The
+    // row says claude; the user's personal default assistant must win.
+    mockGetOrCreateConversation.mockReturnValueOnce(
+      Promise.resolve(makeConversation({ user_id: 'user-9' } as Partial<Conversation>))
+    );
+    mockGetUserAiPrefsDb.mockImplementation(async () => ({ defaultProvider: 'codex' }));
+    mockLogger.debug.mockClear();
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', 'Hello');
+
+    const sendingLog = mockLogger.debug.mock.calls.find(c => c[1] === 'sending_to_ai') as
+      | [Record<string, unknown>, string]
+      | undefined;
+    expect(sendingLog).toBeDefined();
+    expect(sendingLog?.[0].assistantType).toBe('claude');
+    expect(sendingLog?.[0].resolvedAssistantType).toBe('codex');
+  });
+
+  test("without an identity the conversation's stored assistant drives the turn (#2241 chain)", async () => {
+    // No sender and no creator: the creation-time default on the conversation
+    // row (resolved from config since #2241) is what executes.
+    mockGetOrCreateConversation.mockReturnValueOnce(
+      Promise.resolve(makeConversation({ ai_assistant_type: 'codex' }))
+    );
+    mockLogger.debug.mockClear();
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', 'Hello');
+
+    expect(mockGetUserAiPrefsDb).not.toHaveBeenCalled();
+    const sendingLog = mockLogger.debug.mock.calls.find(c => c[1] === 'sending_to_ai') as
+      | [Record<string, unknown>, string]
+      | undefined;
+    expect(sendingLog).toBeDefined();
+    expect(sendingLog?.[0].resolvedAssistantType).toBe('codex');
+  });
+
   test('structurally invalid stored prefs degrade to config-only (chat still answers)', async () => {
     mockGetOrCreateConversation.mockReturnValueOnce(
       Promise.resolve(makeConversation({ user_id: 'user-9' } as Partial<Conversation>))


### PR DESCRIPTION
## Summary

- Problem: new conversations created without a codebase or parent (the typical new web chat) stamped `ai_assistant_type` from `DEFAULT_AI_ASSISTANT ?? 'claude'` and never consulted the configured `assistant` from `.archon/config.yaml` — every new unscoped chat hard-landed on Claude.
- Why it matters: the install-wide default assistant setting (Settings UI / `archon ai default`) silently did nothing for new web chats unless the sender had a personal per-user default masking it.
- What changed: the creation-time fallthrough in `getOrCreateConversation` now resolves through `loadConfig()`, which already owns the chain explicit config (repo `assistant:` > global `defaultAssistant`) > `DEFAULT_AI_ASSISTANT` env > first registered built-in. A config load failure warns (`db.conversation_default_assistant_config_load_failed`) and falls back to `claude` instead of blocking conversation creation.
- What did **not** change (scope boundary): the per-user layer (#1998/#1982) is untouched — `userAiPrefs.defaultProvider` still wins per turn, sender-first, above the conversation row (new orchestrator tests witness both directions). Parent-conversation inheritance and the codebase-row assistant keep their precedence.
- Extraction note: harvested from closed PR #1826 (credit @EugeneChan00 — `conversations.ts` hunk + the config-default test). The other half of that hunk (merged project config beating the codebase row) is deliberately NOT taken: `MergedConfig.assistant` is always defined, so it would make the row dead code except on load failure and regress `.codex`/`.claude` folder-detected codebases to the global default. #1826's `mock.module('../config/config-loader')` test approach is replaced with `spyOn` (mock-isolation: same `bun test` batch as the real `config-loader.test.ts`).

## UX Journey

### Before

```
  User (config.yaml: assistant: codex)      Archon
  ────                                      ──────
  opens new web chat ────────────────────▶  getOrCreateConversation
                                            row.ai_assistant_type = env ?? 'claude'   ← config ignored
  sends message ─────────────────────────▶  orchestrator: userPref ?? row → **claude**
  gets Claude despite configured codex ◀──
```

### After

```
  User (config.yaml: assistant: codex)      Archon
  ────                                      ──────
  opens new web chat ────────────────────▶  getOrCreateConversation
                                            row.ai_assistant_type = [loadConfig().assistant → codex]
  sends message ─────────────────────────▶  orchestrator: userPref ?? row → **codex**
  gets the configured assistant ◀────────   (a personal per-user default still wins per turn)
```

## Architecture Diagram

### Before

```
  server/routes/api.ts ──▶ core/db/conversations.ts ──▶ env DEFAULT_AI_ASSISTANT ?? 'claude'
  orchestrator-agent.ts ─▶ core/db/conversations.ts
  orchestrator-agent.ts ─▶ user_ai_prefs.defaultProvider ?? conversation row
```

### After

```
  server/routes/api.ts ──▶ core/db/conversations.ts [~] ═══▶ core/config/config-loader.ts (loadConfig)
  orchestrator-agent.ts ─▶ core/db/conversations.ts [~]
  orchestrator-agent.ts ─▶ user_ai_prefs.defaultProvider ?? conversation row   (unchanged)
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `core/db/conversations.ts` | `core/config/config-loader.ts` | **new** | fallthrough default resolution; no import cycle (config-loader has no db dep) |
| `core/db/conversations.ts` | `process.env.DEFAULT_AI_ASSISTANT` | **removed** | env now participates via loadConfig (explicit config > env, per its documented semantics) |
| `orchestrator-agent.ts` | `core/db/conversations.ts` | unchanged | per-user layer stays above the row |
| `server/routes/api.ts` | `core/db/conversations.ts` | unchanged | web conversation creation |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`
- Module: `core:db`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #2241
- Related #1826 (source of the extracted fix, credit @EugeneChan00), #1998, #1982

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # exit 0 — generated checks, type-check, lint, format, all package tests green
bun test packages/core/src/db/conversations.test.ts          # 17 pass
bun test packages/core/src/orchestrator/orchestrator-agent.test.ts  # 211 pass
```

- Evidence provided (test/log/trace/screenshot): new tests cover config-chain resolution, config-load-failure fallback, codebase-row short-circuit, parent-inheritance short-circuit, per-user-default-wins, and no-identity fallback; the failure test's WARN (`db.conversation_default_assistant_config_load_failed`) is visible in test output.
- If any command is intentionally skipped, explain why: none skipped.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No (loadConfig already reads `~/.archon/config.yaml` throughout the orchestrator)

## Compatibility / Migration

- Backward compatible? Yes — installs with no config keep `claude` (loadConfig's seeded default is the first built-in, i.e. claude). One deliberate precedence alignment: a raw `DEFAULT_AI_ASSISTANT` env value no longer beats an explicitly configured assistant at this seam, matching loadConfig's documented fallback semantics ("an explicit save via the Web UI takes precedence over the env var") and the chain in #2241. An unregistered `DEFAULT_AI_ASSISTANT` now yields a WARN + claude fallback instead of stamping a garbage provider on the row.
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: full test-suite run via `bun run validate` in the worktree; traced the end-to-end resolution (creation seam → orchestrator per-user layer) against current dev before changing anything.
- Edge cases checked: config load failure, missing codebase row, parent inheritance, per-user default override, no-identity fallback.
- What was not verified: live multi-user VPS smoke (no behavior change expected there — per-user layer untouched).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: conversation creation on all platforms (web/Slack/Telegram/Discord/CLI worker conversations). Codebase-scoped and thread-inherited conversations are byte-for-byte unchanged.
- Potential unintended effects: installs that relied on `DEFAULT_AI_ASSISTANT` env overriding an explicitly configured assistant see config win (documented intent).
- Guardrails/monitoring for early detection: `db.conversation_default_assistant_config_load_failed` WARN; `sending_to_ai` debug logs `resolvedAssistantType`.

## Rollback Plan (required)

- Fast rollback command/path: `git revert 8cb7c6c0` — single isolated commit.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: new conversations created with an unexpected provider; conversation-creation errors referencing config-loader.

## Risks and Mitigations

- Risk: a broken/malformed config could change the default for new conversations.
  - Mitigation: loadConfig is defensive (returns defaults on parse errors); a thrown error (e.g. unregistered `DEFAULT_AI_ASSISTANT`) is caught, WARN-logged, and falls back to `claude` — conversation creation never blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversation creation now uses the configured default AI assistant when no specific assistant is selected.
  * Falls back to Claude if configuration loading is unavailable.
  * User-specific AI preferences can override the conversation’s stored assistant selection when applicable.

* **Bug Fixes**
  * Preserved assistant selection for codebase-scoped and parent conversations.
  * Ensured conversations without sender identity use their stored assistant configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->