### PR TITLE
fix(core): resolve configured default assistant in createCodebase (fixes #2201)

### DIFF
--- a/packages/core/src/db/codebases.test.ts
+++ b/packages/core/src/db/codebases.test.ts
@@ -53,9 +53,9 @@ describe('codebases', () => {
     // Default spy: loadConfig resolves to 'claude' unless overridden per-test
     let loadConfigSpy: ReturnType<typeof spyOn>;
     beforeEach(() => {
-      loadConfigSpy = spyOn(configLoader, 'loadConfig').mockResolvedValue(
-        { assistant: 'claude' } as Awaited<ReturnType<typeof configLoader.loadConfig>>
-      );
+      loadConfigSpy = spyOn(configLoader, 'loadConfig').mockResolvedValue({
+        assistant: 'claude',
+      } as Awaited<ReturnType<typeof configLoader.loadConfig>>);
     });
     afterEach(() => {
       loadConfigSpy.mockRestore();
@@ -106,9 +106,9 @@ describe('codebases', () => {
     });
 
     test('resolves default assistant from loadConfig when ai_assistant_type omitted', async () => {
-      loadConfigSpy.mockResolvedValue(
-        { assistant: 'codex' } as Awaited<ReturnType<typeof configLoader.loadConfig>>
-      );
+      loadConfigSpy.mockResolvedValue({ assistant: 'codex' } as Awaited<
+        ReturnType<typeof configLoader.loadConfig>
+      >);
       mockQuery.mockResolvedValueOnce(
         createQueryResult([{ ...mockCodebase, ai_assistant_type: 'codex' }])
       );

--- a/packages/core/src/db/codebases.test.ts
+++ b/packages/core/src/db/codebases.test.ts
@@ -1,7 +1,10 @@
-import { mock, describe, test, expect, beforeEach } from 'bun:test';
+import { mock, describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { join } from 'path';
 import { createQueryResult, mockPostgresDialect } from '../test/mocks/database';
 import { Codebase } from '../types';
+// spyOn (NOT mock.module) for config-loader: avoids poisoning config-loader.test.ts
+// in the same bun test invocation (pattern: conversations.test.ts).
+import * as configLoader from '../config/config-loader';
 
 const mockQuery = mock(() => Promise.resolve(createQueryResult([])));
 
@@ -47,6 +50,17 @@ describe('codebases', () => {
   };
 
   describe('createCodebase', () => {
+    // Default spy: loadConfig resolves to 'claude' unless overridden per-test
+    let loadConfigSpy: ReturnType<typeof spyOn>;
+    beforeEach(() => {
+      loadConfigSpy = spyOn(configLoader, 'loadConfig').mockResolvedValue(
+        { assistant: 'claude' } as Awaited<ReturnType<typeof configLoader.loadConfig>>
+      );
+    });
+    afterEach(() => {
+      loadConfigSpy.mockRestore();
+    });
+
     test('creates codebase with all fields', async () => {
       mockQuery.mockResolvedValueOnce(createQueryResult([mockCodebase]));
 
@@ -91,23 +105,10 @@ describe('codebases', () => {
       );
     });
 
-    test('defaults ai_assistant_type to claude when no env var set', async () => {
-      delete process.env.DEFAULT_AI_ASSISTANT;
-      mockQuery.mockResolvedValueOnce(createQueryResult([mockCodebase]));
-
-      await createCodebase({
-        name: 'test-project',
-        default_cwd: '/workspace/test-project',
-      });
-
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.arrayContaining(['claude'])
+    test('resolves default assistant from loadConfig when ai_assistant_type omitted', async () => {
+      loadConfigSpy.mockResolvedValue(
+        { assistant: 'codex' } as Awaited<ReturnType<typeof configLoader.loadConfig>>
       );
-    });
-
-    test('reads DEFAULT_AI_ASSISTANT env var when ai_assistant_type omitted', async () => {
-      process.env.DEFAULT_AI_ASSISTANT = 'codex';
       mockQuery.mockResolvedValueOnce(
         createQueryResult([{ ...mockCodebase, ai_assistant_type: 'codex' }])
       );
@@ -117,12 +118,27 @@ describe('codebases', () => {
         default_cwd: '/workspace/test-project',
       });
 
+      expect(loadConfigSpy).toHaveBeenCalledTimes(1);
       expect(mockQuery).toHaveBeenCalledWith(expect.any(String), expect.arrayContaining(['codex']));
-      delete process.env.DEFAULT_AI_ASSISTANT;
     });
 
-    test('explicit ai_assistant_type takes priority over env var', async () => {
-      process.env.DEFAULT_AI_ASSISTANT = 'codex';
+    test('falls back to claude when loadConfig throws', async () => {
+      loadConfigSpy.mockRejectedValue(new Error('config load failed'));
+      mockQuery.mockResolvedValueOnce(createQueryResult([mockCodebase]));
+
+      await createCodebase({
+        name: 'test-project',
+        default_cwd: '/workspace/test-project',
+      });
+
+      expect(loadConfigSpy).toHaveBeenCalledTimes(1);
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.arrayContaining(['claude'])
+      );
+    });
+
+    test('explicit ai_assistant_type bypasses loadConfig', async () => {
       mockQuery.mockResolvedValueOnce(
         createQueryResult([{ ...mockCodebase, ai_assistant_type: 'pi' }])
       );
@@ -133,8 +149,8 @@ describe('codebases', () => {
         ai_assistant_type: 'pi',
       });
 
+      expect(loadConfigSpy).not.toHaveBeenCalled();
       expect(mockQuery).toHaveBeenCalledWith(expect.any(String), expect.arrayContaining(['pi']));
-      delete process.env.DEFAULT_AI_ASSISTANT;
     });
   });
 

--- a/packages/core/src/db/codebases.test.ts
+++ b/packages/core/src/db/codebases.test.ts
@@ -119,6 +119,26 @@ describe('codebases', () => {
       });
 
       expect(loadConfigSpy).toHaveBeenCalledTimes(1);
+      expect(loadConfigSpy).toHaveBeenCalledWith('/workspace/test-project');
+      expect(mockQuery).toHaveBeenCalledWith(expect.any(String), expect.arrayContaining(['codex']));
+    });
+
+    test('resolves default assistant from loadConfig when ai_assistant_type is null', async () => {
+      loadConfigSpy.mockResolvedValue({ assistant: 'codex' } as Awaited<
+        ReturnType<typeof configLoader.loadConfig>
+      >);
+      mockQuery.mockResolvedValueOnce(
+        createQueryResult([{ ...mockCodebase, ai_assistant_type: 'codex' }])
+      );
+
+      await createCodebase({
+        name: 'test-project',
+        default_cwd: '/workspace/test-project',
+        ai_assistant_type: null as unknown as undefined,
+      });
+
+      expect(loadConfigSpy).toHaveBeenCalledTimes(1);
+      expect(loadConfigSpy).toHaveBeenCalledWith('/workspace/test-project');
       expect(mockQuery).toHaveBeenCalledWith(expect.any(String), expect.arrayContaining(['codex']));
     });
 

--- a/packages/core/src/db/codebases.ts
+++ b/packages/core/src/db/codebases.ts
@@ -23,9 +23,9 @@ export async function createCodebase(data: {
   kind?: 'repo' | 'folder';
 }): Promise<Codebase> {
   let assistantType = data.ai_assistant_type;
-  if (assistantType === undefined) {
+  if (assistantType == null) {
     try {
-      const config = await loadConfig();
+      const config = await loadConfig(data.default_cwd);
       assistantType = config.assistant;
     } catch (err) {
       getLog().warn(

--- a/packages/core/src/db/codebases.ts
+++ b/packages/core/src/db/codebases.ts
@@ -5,6 +5,7 @@ import { sep as pathSep } from 'path';
 import { pool, getDialect } from './connection';
 import type { Codebase } from '../types';
 import { createLogger, captureCodebaseRegistered } from '@archon/paths';
+import { loadConfig } from '../config/config-loader';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
@@ -21,7 +22,19 @@ export async function createCodebase(data: {
   ai_assistant_type?: string;
   kind?: 'repo' | 'folder';
 }): Promise<Codebase> {
-  const assistantType = data.ai_assistant_type ?? process.env.DEFAULT_AI_ASSISTANT ?? 'claude';
+  let assistantType = data.ai_assistant_type;
+  if (assistantType === undefined) {
+    try {
+      const config = await loadConfig();
+      assistantType = config.assistant;
+    } catch (err) {
+      getLog().warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        'db.codebase_default_assistant_config_load_failed'
+      );
+    }
+  }
+  assistantType ??= 'claude';
   const result = await pool.query<Codebase>(
     'INSERT INTO remote_agent_codebases (name, repository_url, default_cwd, default_branch, ai_assistant_type, kind) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *',
     [


### PR DESCRIPTION
## UX Journey

A user sets their default AI assistant via the config system (repo `.archon/config.yaml` or global config), but new codebases still stamp `'claude'` or whatever `DEFAULT_AI_ASSISTANT` env says, ignoring the configured value. After this fix, new codebases respect the full config resolution chain.

## Architecture Diagram

```
createCodebase(data)
  └─ data.ai_assistant_type provided? → use it
  └─ else → loadConfig().assistant
               └─ explicit config (repo > global) > DEFAULT_AI_ASSISTANT env > first builtin
  └─ loadConfig() throws? → warn + fallback 'claude'
```

## Label Snapshot

- `fix`, `area: config`

## Change Metadata

| Metric | Value |
|--------|-------|
| Files changed | 2 |
| Lines added | ~48 |
| Lines removed | ~19 |
| Tests added | 3 (config resolution, error fallback, bypass on explicit) |
| Tests modified | 1 (optional-fields test now works with config spy) |

## Linked Issue

Closes #2201

## Validation Evidence

```
bun test packages/core/src/db/codebases.test.ts
39 pass, 0 fail, 59 expect() calls [549ms]

tsc --noEmit (packages/core) — no errors
```

## Security Impact

None. The change routes through the existing `loadConfig()` path which already validates provider names and throws on unregistered values. Error handling is defensive (warn + fallback).

## Compatibility/Migration

Backward-compatible. `DEFAULT_AI_ASSISTANT` env var still works (loadConfig respects it as fallback). Explicit `ai_assistant_type` on creation still wins.

## Human Verification

- [x] `bun test packages/core/src/db/codebases.test.ts` — 39 pass
- [x] `tsc --noEmit` — clean
- [x] Pattern matches merged #2245 (conversations.ts equivalent)

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| loadConfig() throws in edge cases | try/catch with 'claude' fallback + warning log |
| bun mock.module leak in tests | Uses spyOn pattern (proven in conversations.test.ts) |

## Side Effects/Blast Radius

Only `createCodebase()` is affected. Existing codebases with `ai_assistant_type` already set are unchanged. The per-user default assistant stays above this seam (orchestrator applies it per-turn).

## Rollback Plan

Revert commit; the only behavioral change is which assistant name gets stamped on new codebase rows when no explicit type is provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When creating a codebase without an assistant, the app now retrieves the default assistant from configuration.
* **Bug Fixes**
  * If configuration can’t be loaded, codebases now fall back to Claude.
  * If an assistant is explicitly provided (including null-treated-as-omitted behavior), the stored assistant behavior matches the input and isn’t unintentionally overridden.
* **Tests**
  * Updated coverage to verify configuration-based defaults, explicit assistant precedence, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->