### PR TITLE
feat(isolation): pluggable worktree engine - support worktrunk (wt)

### DIFF
--- a/.claude/docs/isolation-and-worktree-guide.md
+++ b/.claude/docs/isolation-and-worktree-guide.md
@@ -83,9 +83,9 @@ Compares `store.countActiveByCodebase()` against `maxWorktrees` (default 25). If
 - Auto-detects default branch: `symbolic-ref` → `origin/main` → `master`
 
 **3. Create worktree**
-- For PRs (same-repo): `git fetch origin prBranch` → `git worktree add path -b prBranch origin/prBranch`
-- For PRs (fork): fetch `refs/pull/{N}/head` → create at SHA → checkout branch
-- For all others: `git worktree add path -b branchName origin/{baseBranch}`
+- For PRs (same-repo): `git fetch origin prBranch` → engine `add()` (`git worktree add`/`wt switch --create`, tracking `origin/prBranch`)
+- For PRs (fork): fetch `refs/pull/{N}/head` → create at SHA → checkout branch — **always raw git**, regardless of the configured engine (no worktrunk equivalent for synthetic review branches)
+- For all others: engine `add()` with start-point `origin/{baseBranch}`
 - Before creation: `cleanOrphanDirectoryIfExists()` removes stale non-worktree directories
 
 **4. Copy configured files**
@@ -93,6 +93,21 @@ Compares `store.countActiveByCodebase()` against `maxWorktrees` (default 25). If
 - User config: additional paths from `.archon/config.yaml` `worktree.copyFiles`
 - Supports `"source -> destination"` arrow syntax
 - Path traversal blocked (security check via `isPathWithinRoot()`)
+
+---
+
+## Worktree Engine (`packages/isolation/src/engine/`, #2260)
+
+The low-level add/remove/list/prune plumbing behind `WorktreeProvider` is pluggable via `worktree.engine` in `.archon/config.yaml` (`'git'` default, `'worktrunk'` opt-in). `WorktreeProvider` resolves the engine once per `create()`/`destroy()`/`list()` call (`resolveWorktreeEngine()` in `resolve.ts`) and never bypasses it for the paths engines cover — all provider-level logic (branch naming, adoption, copyFiles, submodules, branch cleanup) stays engine-independent.
+
+| File | Purpose |
+|------|---------|
+| `engine/types.ts` | `WorktreeEngine` interface: `add`/`remove`/`list`/`prune` |
+| `engine/git-engine.ts` | `GitWorktreeEngine` — the historical raw `git worktree` commands, moved behind the interface verbatim |
+| `engine/worktrunk-engine.ts` | `WorktrunkEngine` — shells out to `wt`; pins the worktree destination via `--config-set worktree-path="<literal>"` so Archon's path layout is unaffected; preflights the binary (`wt --version`) and fails fast (cached only on success) if missing or below `MIN_WORKTRUNK_VERSION` |
+| `engine/resolve.ts` | `resolveWorktreeEngine(engine?: string)` — maps the config string to a singleton engine instance; throws on an unrecognized value (no silent git fallback) |
+
+Fork-PR checkout (`refs/pull/N/head`) always uses raw `git worktree add` directly — never routed through the configured engine (issue #2260 non-goal). Best-effort orphan cleanup after a partial PR-creation failure (`cleanOrphanWorktreeIfExists`) also stays on raw git deliberately: it's cleaning up an ordinary git worktree regardless of which engine created it, so `git worktree remove` works either way, and skipping worktrunk's remove hooks in this rare error-recovery path is an acceptable simplification.
 
 ---
 
@@ -225,6 +240,7 @@ If merged cleanup frees space → proceed with creation. If not → block with f
 | Factory / singleton | `packages/isolation/src/factory.ts` |
 | 7-step resolver | `packages/isolation/src/resolver.ts` |
 | `WorktreeProvider` | `packages/isolation/src/providers/worktree.ts` |
+| `WorktreeEngine` interface + git/worktrunk impls | `packages/isolation/src/engine/` |
 | File copy utilities | `packages/isolation/src/worktree-copy.ts` |
 | Error classification | `packages/isolation/src/errors.ts` |
 | Cleanup service | `packages/core/src/services/cleanup-service.ts` |

--- a/packages/core/src/config/config-loader.test.ts
+++ b/packages/core/src/config/config-loader.test.ts
@@ -262,6 +262,28 @@ recommendedWorkflows: "archon-plan"
 
       expect(config.recommendedWorkflows).toBeUndefined();
     });
+
+    test('parses worktree.engine as worktrunk', async () => {
+      mockFsReadFile.mockResolvedValue(`
+worktree:
+  engine: worktrunk
+`);
+
+      const config = await loadRepoConfig('/test/repo');
+
+      expect(config.worktree?.engine).toBe('worktrunk');
+    });
+
+    test('worktree.engine is undefined when not configured (git engine applies by default)', async () => {
+      mockFsReadFile.mockResolvedValue(`
+worktree:
+  baseBranch: main
+`);
+
+      const config = await loadRepoConfig('/test/repo');
+
+      expect(config.worktree?.engine).toBeUndefined();
+    });
   });
 
   describe('loadConfig', () => {

--- a/packages/core/src/config/config-types.ts
+++ b/packages/core/src/config/config-types.ts
@@ -284,6 +284,28 @@ export interface RepoConfig {
      * @example 'upstream'
      */
     remote?: string;
+
+    /**
+     * Low-level worktree engine for this repo.
+     *
+     * - `'git'` (default) — raw `git worktree` commands, the historical behavior
+     * - `'worktrunk'` — shells out to the `wt` CLI (https://worktrunk.dev) so
+     *   per-repo worktrunk hooks (env setup, dependency install, cleanup) run
+     *   when Archon creates or removes worktrees, and Archon-managed worktrees
+     *   show up in `wt list`
+     *
+     * Worktree destination paths stay under Archon's control in both engines
+     * (pinned per invocation), so `worktree.path` and the environment registry
+     * behave identically. Fork-PR checkouts always use raw git.
+     *
+     * Fail Fast: with `'worktrunk'` set but no usable `wt` binary on PATH
+     * (missing, or older than the minimum supported version), worktree
+     * operations fail with an actionable error — no silent fallback to git.
+     * Unrecognized values also fail loudly.
+     *
+     * @default 'git'
+     */
+    engine?: 'git' | 'worktrunk';
   };
 
   /**

--- a/packages/docs-web/src/content/docs/reference/configuration.md
+++ b/packages/docs-web/src/content/docs/reference/configuration.md
@@ -150,6 +150,8 @@ worktree:
                         # Must be relative; no absolute, no `..` segments.
   remote: origin        # Optional: git remote name for fetch/push. Auto-detected
                         # when omitted (origin if it exists, sole remote otherwise).
+  engine: git           # Optional: 'git' (default) or 'worktrunk'. See "Worktree engine
+                        # (worktree.engine)" below.
 
 # Documentation directory
 docs:
@@ -250,6 +252,24 @@ worktree:
 3. If auto-detection fails and a workflow references `$BASE_BRANCH`: Fails with an error explaining the resolution chain.
 
 **Docs path behavior:** The `docs.path` setting controls where the `$DOCS_DIR` variable points. When not configured, `$DOCS_DIR` defaults to `docs/`. Unlike `$BASE_BRANCH`, this variable always has a safe default and never throws an error. Configure it when your documentation lives outside the standard `docs/` directory (e.g., `packages/docs-web/src/content/docs`).
+
+### Worktree engine (`worktree.engine`)
+
+The low-level tool Archon uses to create and remove worktrees is pluggable:
+
+```yaml
+worktree:
+  engine: worktrunk  # Optional: 'git' (default) or 'worktrunk'
+```
+
+- **`git`** (default) — raw `git worktree` commands. Zero behavior change from earlier Archon versions.
+- **`worktrunk`** — shells out to [`wt`](https://worktrunk.dev), a git worktree manager built for parallel AI agent workflows. When Archon creates or removes a worktree, your worktrunk hooks (env setup, dependency install, cleanup, etc.) run exactly as they would for a worktree you created by hand, and the worktree shows up in `wt list` alongside everything else.
+
+Archon still owns the worktree's filesystem location in both engines — worktrunk's own path template is overridden per invocation, so `worktree.path`, the default `~/.archon/workspaces/<owner>/<repo>/worktrees/` layout, and the environment registry all behave identically regardless of engine.
+
+**Requirements for `worktrunk`:** the `wt` binary must be on `PATH` and at least the minimum version Archon has verified against. If it's missing or too old, worktree creation **fails with an actionable error naming `wt`** — there is no silent fallback to the git engine. An unrecognized `engine` value fails the same way.
+
+**Not affected by `worktree.engine`:** fork-PR review checkouts (`refs/pull/N/head`) always use raw git — there is no worktrunk equivalent for synthetic review branches. Branch creation/deletion semantics, adoption, `copyFiles`, and submodule init are identical regardless of engine; only the underlying add/remove/list plumbing changes.
 
 ### Recommended workflows (`recommendedWorkflows`)
 

--- a/packages/isolation/package.json
+++ b/packages/isolation/package.json
@@ -8,7 +8,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "test": "bun test src/resolver.test.ts && bun test src/providers/ && bun test src/errors.test.ts src/factory.test.ts src/worktree-copy.test.ts && bun test src/pr-state.test.ts && bun test src/backend-router.test.ts src/backends/in-place.test.ts src/backends/container.test.ts src/container/docker-exec.test.ts src/container/overlay.test.ts src/container/overlay-scripts.test.ts",
+    "test": "bun test src/resolver.test.ts && bun test src/providers/ && bun test src/errors.test.ts src/factory.test.ts src/worktree-copy.test.ts && bun test src/pr-state.test.ts && bun test src/backend-router.test.ts src/backends/in-place.test.ts src/backends/container.test.ts src/container/docker-exec.test.ts src/container/overlay.test.ts src/container/overlay-scripts.test.ts && bun test src/engine/",
     "type-check": "bun x tsc --noEmit"
   },
   "dependencies": {

--- a/packages/isolation/src/engine/git-engine.test.ts
+++ b/packages/isolation/src/engine/git-engine.test.ts
@@ -1,0 +1,174 @@
+import { describe, test, expect, beforeEach, afterEach, spyOn, mock, type Mock } from 'bun:test';
+
+// Mock @archon/paths so nothing in this file touches the real filesystem/home dir.
+mock.module('@archon/paths', () => ({
+  createLogger: () => ({
+    fatal: () => undefined,
+    error: () => undefined,
+    warn: () => undefined,
+    info: () => undefined,
+    debug: () => undefined,
+    trace: () => undefined,
+    child: () => undefined,
+  }),
+}));
+
+import * as git from '@archon/git';
+import { toRepoPath, toBranchName, toWorktreePath } from '@archon/git';
+import { GitWorktreeEngine } from './git-engine';
+
+describe('GitWorktreeEngine', () => {
+  let engine: GitWorktreeEngine;
+  let execSpy: Mock<typeof git.execFileAsync>;
+  let listWorktreesSpy: Mock<typeof git.listWorktrees>;
+
+  beforeEach(() => {
+    engine = new GitWorktreeEngine();
+    execSpy = spyOn(git, 'execFileAsync');
+    listWorktreesSpy = spyOn(git, 'listWorktrees');
+    execSpy.mockResolvedValue({ stdout: '', stderr: '' });
+    listWorktreesSpy.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    execSpy.mockRestore();
+    listWorktreesSpy.mockRestore();
+  });
+
+  test('id is git', () => {
+    expect(engine.id).toBe('git');
+  });
+
+  describe('add', () => {
+    test('new branch without tracking issues --no-track add -b', async () => {
+      await engine.add({
+        repoPath: toRepoPath('/repo'),
+        worktreePath: toWorktreePath('/repo/wt'),
+        branch: toBranchName('archon/task-x'),
+        startPoint: 'origin/main',
+      });
+
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        [
+          '-C',
+          '/repo',
+          'worktree',
+          'add',
+          '--no-track',
+          '/repo/wt',
+          '-b',
+          'archon/task-x',
+          'origin/main',
+        ],
+        expect.objectContaining({ timeout: expect.any(Number) })
+      );
+    });
+
+    test('new branch with tracking (same-repo PR) issues add -b without --no-track', async () => {
+      await engine.add({
+        repoPath: toRepoPath('/repo'),
+        worktreePath: toWorktreePath('/repo/wt'),
+        branch: toBranchName('feature/pr-branch'),
+        startPoint: 'origin/feature/pr-branch',
+        track: true,
+      });
+
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        [
+          '-C',
+          '/repo',
+          'worktree',
+          'add',
+          '/repo/wt',
+          '-b',
+          'feature/pr-branch',
+          'origin/feature/pr-branch',
+        ],
+        expect.objectContaining({ timeout: expect.any(Number) })
+      );
+    });
+
+    test('no start point checks out an existing local branch', async () => {
+      await engine.add({
+        repoPath: toRepoPath('/repo'),
+        worktreePath: toWorktreePath('/repo/wt'),
+        branch: toBranchName('existing-branch'),
+      });
+
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        ['-C', '/repo', 'worktree', 'add', '/repo/wt', 'existing-branch'],
+        expect.objectContaining({ timeout: expect.any(Number) })
+      );
+    });
+
+    test('propagates subprocess errors unchanged', async () => {
+      const err = Object.assign(new Error('already exists'), { stderr: 'fatal: already exists' });
+      execSpy.mockRejectedValueOnce(err);
+
+      await expect(
+        engine.add({
+          repoPath: toRepoPath('/repo'),
+          worktreePath: toWorktreePath('/repo/wt'),
+          branch: toBranchName('archon/task-x'),
+          startPoint: 'origin/main',
+        })
+      ).rejects.toBe(err);
+    });
+  });
+
+  describe('remove', () => {
+    test('issues worktree remove without --force by default', async () => {
+      await engine.remove({
+        repoPath: toRepoPath('/repo'),
+        worktreePath: toWorktreePath('/repo/wt'),
+      });
+
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        ['-C', '/repo', 'worktree', 'remove', '/repo/wt'],
+        expect.objectContaining({ timeout: expect.any(Number) })
+      );
+    });
+
+    test('force: true adds --force', async () => {
+      await engine.remove({
+        repoPath: toRepoPath('/repo'),
+        worktreePath: toWorktreePath('/repo/wt'),
+        force: true,
+      });
+
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        ['-C', '/repo', 'worktree', 'remove', '--force', '/repo/wt'],
+        expect.objectContaining({ timeout: expect.any(Number) })
+      );
+    });
+  });
+
+  describe('list', () => {
+    test('delegates to the shared listWorktrees helper', async () => {
+      const expected = [{ path: toWorktreePath('/repo/wt'), branch: toBranchName('main') }];
+      listWorktreesSpy.mockResolvedValueOnce(expected);
+
+      const result = await engine.list(toRepoPath('/repo'));
+
+      expect(listWorktreesSpy).toHaveBeenCalledWith('/repo');
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe('prune', () => {
+    test('issues git worktree prune', async () => {
+      await engine.prune(toRepoPath('/repo'));
+
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        ['-C', '/repo', 'worktree', 'prune'],
+        expect.objectContaining({ timeout: expect.any(Number) })
+      );
+    });
+  });
+});

--- a/packages/isolation/src/engine/git-engine.ts
+++ b/packages/isolation/src/engine/git-engine.ts
@@ -1,0 +1,72 @@
+/**
+ * Git Worktree Engine (default)
+ *
+ * The historical raw-`git worktree` plumbing moved behind the `WorktreeEngine`
+ * interface. Zero behavior change: every method issues exactly the argv the
+ * pre-engine `WorktreeProvider` issued inline, through the same `@archon/git`
+ * bindings (`execFileAsync`, `listWorktrees`) the provider tests spy on.
+ */
+
+import { execFileAsync, listWorktrees } from '@archon/git';
+import type { RepoPath, WorktreeInfo } from '@archon/git';
+import type { AddWorktreeOptions, RemoveWorktreeOptions, WorktreeEngine } from './types';
+
+/**
+ * Ceiling for a single git subprocess in worktree operations. Generous enough
+ * for repos with heavy post-checkout hooks while still catching genuine hangs
+ * (e.g. credential prompts in non-TTY, stalled network fetches). See #1119, #1029.
+ */
+const GIT_OPERATION_TIMEOUT_MS = 5 * 60 * 1000;
+
+const PRUNE_TIMEOUT_MS = 15000;
+
+export class GitWorktreeEngine implements WorktreeEngine {
+  readonly id = 'git' as const;
+
+  async add(options: AddWorktreeOptions): Promise<void> {
+    const { repoPath, worktreePath, branch, startPoint, track } = options;
+    let args: string[];
+    if (startPoint === undefined) {
+      // Check out an already-existing local branch.
+      args = ['-C', repoPath, 'worktree', 'add', worktreePath, branch];
+    } else if (track) {
+      // New branch tracking its start point (same-repo PR checkout).
+      args = ['-C', repoPath, 'worktree', 'add', worktreePath, '-b', branch, startPoint];
+    } else {
+      // `--no-track` keeps `branch.<name>.merge` unset; otherwise `gh pr view`
+      // (no PR number) resolves to the base branch's PR via upstream config.
+      args = [
+        '-C',
+        repoPath,
+        'worktree',
+        'add',
+        '--no-track',
+        worktreePath,
+        '-b',
+        branch,
+        startPoint,
+      ];
+    }
+    await execFileAsync('git', args, { timeout: GIT_OPERATION_TIMEOUT_MS });
+  }
+
+  async remove(options: RemoveWorktreeOptions): Promise<void> {
+    const { repoPath, worktreePath, force } = options;
+    const args = ['-C', repoPath, 'worktree', 'remove'];
+    if (force) {
+      args.push('--force');
+    }
+    args.push(worktreePath);
+    await execFileAsync('git', args, { timeout: GIT_OPERATION_TIMEOUT_MS });
+  }
+
+  async list(repoPath: RepoPath): Promise<WorktreeInfo[]> {
+    return listWorktrees(repoPath);
+  }
+
+  async prune(repoPath: RepoPath): Promise<void> {
+    await execFileAsync('git', ['-C', repoPath, 'worktree', 'prune'], {
+      timeout: PRUNE_TIMEOUT_MS,
+    });
+  }
+}

--- a/packages/isolation/src/engine/resolve.test.ts
+++ b/packages/isolation/src/engine/resolve.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from 'bun:test';
+import { resolveWorktreeEngine } from './resolve';
+import { GitWorktreeEngine } from './git-engine';
+import { WorktrunkEngine } from './worktrunk-engine';
+
+describe('resolveWorktreeEngine', () => {
+  test('undefined resolves to the default git engine', () => {
+    expect(resolveWorktreeEngine(undefined)).toBeInstanceOf(GitWorktreeEngine);
+  });
+
+  test('empty string resolves to the default git engine', () => {
+    expect(resolveWorktreeEngine('')).toBeInstanceOf(GitWorktreeEngine);
+  });
+
+  test('whitespace-only resolves to the default git engine', () => {
+    expect(resolveWorktreeEngine('   ')).toBeInstanceOf(GitWorktreeEngine);
+  });
+
+  test("'git' resolves to GitWorktreeEngine", () => {
+    expect(resolveWorktreeEngine('git')).toBeInstanceOf(GitWorktreeEngine);
+  });
+
+  test("'worktrunk' resolves to WorktrunkEngine", () => {
+    expect(resolveWorktreeEngine('worktrunk')).toBeInstanceOf(WorktrunkEngine);
+  });
+
+  test('trims surrounding whitespace before matching', () => {
+    expect(resolveWorktreeEngine('  worktrunk  ')).toBeInstanceOf(WorktrunkEngine);
+  });
+
+  test('unrecognized value throws rather than silently falling back to git', () => {
+    expect(() => resolveWorktreeEngine('docker')).toThrow(/worktree\.engine must be one of/);
+  });
+
+  test('returns the same singleton instance across repeated calls (stateless engines)', () => {
+    const first = resolveWorktreeEngine('worktrunk');
+    const second = resolveWorktreeEngine('worktrunk');
+    expect(first).toBe(second);
+  });
+});

--- a/packages/isolation/src/engine/resolve.ts
+++ b/packages/isolation/src/engine/resolve.ts
@@ -1,0 +1,40 @@
+/**
+ * Worktree engine selection.
+ *
+ * Maps `.archon/config.yaml > worktree.engine` to a `WorktreeEngine` instance.
+ * Engines are stateless (the worktrunk preflight cache is the one exception,
+ * and sharing it is desirable), so one singleton per engine id suffices.
+ */
+
+import { WORKTREE_ENGINE_IDS, type WorktreeEngine, type WorktreeEngineId } from './types';
+import { GitWorktreeEngine } from './git-engine';
+import { WorktrunkEngine } from './worktrunk-engine';
+
+const engines: Record<WorktreeEngineId, WorktreeEngine> = {
+  git: new GitWorktreeEngine(),
+  worktrunk: new WorktrunkEngine(),
+};
+
+function isWorktreeEngineId(value: string): value is WorktreeEngineId {
+  return (WORKTREE_ENGINE_IDS as readonly string[]).includes(value);
+}
+
+/**
+ * Resolve the configured engine id to an engine instance.
+ *
+ * `undefined` / empty-after-trim → the default git engine (zero behavior
+ * change for existing users). Any other unrecognized value throws — a typo'd
+ * engine must not silently fall back to git (Fail Fast).
+ */
+export function resolveWorktreeEngine(engine: string | undefined): WorktreeEngine {
+  const trimmed = engine?.trim();
+  if (!trimmed) {
+    return engines.git;
+  }
+  if (!isWorktreeEngineId(trimmed)) {
+    throw new Error(
+      `.archon/config.yaml worktree.engine must be one of ${WORKTREE_ENGINE_IDS.map(id => `'${id}'`).join(', ')} (got: '${trimmed}').`
+    );
+  }
+  return engines[trimmed];
+}

--- a/packages/isolation/src/engine/types.ts
+++ b/packages/isolation/src/engine/types.ts
@@ -1,0 +1,87 @@
+/**
+ * Worktree Engine Abstraction
+ *
+ * Narrow seam over the raw worktree plumbing used by `WorktreeProvider`, so the
+ * low-level tool that creates/removes worktrees is pluggable (#2260):
+ *
+ * - `git` (default)  — raw `git worktree` commands, exactly the historical behavior
+ * - `worktrunk`      — shells out to the `wt` CLI (https://worktrunk.dev), so
+ *   worktrees Archon creates participate in the user's worktrunk setup (per-repo
+ *   hooks, `wt list`, consistent tooling)
+ *
+ * This is deliberately NOT a new `IIsolationProvider`: all Archon-specific logic
+ * (branch naming, fork-PR fetching, adoption, DB registry, copyFiles, submodules)
+ * stays in `WorktreeProvider` and behaves identically regardless of engine. Only
+ * the four operations below vary.
+ *
+ * Deliberately NOT part of the engine surface:
+ * - `exists` — a worktree created by either engine is an ordinary git worktree
+ *   (directory + `.git` pointer file), so the shared fs-based `worktreeExists()`
+ *   helper is engine-independent.
+ * - Fork-PR checkout (`refs/pull/N/head`) — stays on raw git unconditionally;
+ *   there is no worktrunk contract for synthetic review branches (#2260 non-goal).
+ */
+
+import type { RepoPath, BranchName, WorktreePath, WorktreeInfo } from '@archon/git';
+
+/** Valid `worktree.engine` values in `.archon/config.yaml`. */
+export const WORKTREE_ENGINE_IDS = ['git', 'worktrunk'] as const;
+
+export type WorktreeEngineId = (typeof WORKTREE_ENGINE_IDS)[number];
+
+export interface AddWorktreeOptions {
+  /** Canonical main-checkout path — worktree commands run `-C` here. */
+  repoPath: RepoPath;
+  /** Absolute destination path for the new worktree. */
+  worktreePath: WorktreePath;
+  /** Branch to create (when `startPoint` is set) or check out (when omitted). */
+  branch: BranchName;
+  /**
+   * Start point for a NEW branch (e.g. `origin/main`, an existing local branch,
+   * or a commit-ish). Omit to check out an already-existing local branch instead
+   * of creating one.
+   */
+  startPoint?: string;
+  /**
+   * Set upstream tracking for the new branch (git: omit `--no-track`).
+   * Default false — Archon-generated branches keep `branch.<name>.merge` unset
+   * so `gh pr view` doesn't resolve to the base branch's PR. Same-repo PR
+   * checkouts pass true (start point is the remote-tracking ref).
+   * Only meaningful together with `startPoint`.
+   */
+  track?: boolean;
+}
+
+export interface RemoveWorktreeOptions {
+  /** Canonical main-checkout path — worktree commands run `-C` here. */
+  repoPath: RepoPath;
+  /** Absolute path of the worktree to remove. */
+  worktreePath: WorktreePath;
+  /** Remove even with uncommitted changes (git/wt `--force`). */
+  force?: boolean;
+}
+
+/**
+ * Pluggable low-level worktree plumbing.
+ *
+ * Error contract: all methods throw the raw subprocess error (message + `stderr`
+ * attached by `execFileAsync`) so `WorktreeProvider`'s existing error
+ * classification (`already exists` retry, `isWorktreeMissingError`,
+ * `classifyIsolationError`) keeps working unchanged. Engines never delete
+ * branches — branch lifecycle stays with the provider.
+ */
+export interface WorktreeEngine {
+  readonly id: WorktreeEngineId;
+
+  /** Create a worktree (and optionally a new branch at `startPoint`). */
+  add(options: AddWorktreeOptions): Promise<void>;
+
+  /** Remove a worktree. Never deletes the branch. */
+  remove(options: RemoveWorktreeOptions): Promise<void>;
+
+  /** List worktrees as `{ path, branch }` (branchless/detached entries omitted). */
+  list(repoPath: RepoPath): Promise<WorktreeInfo[]>;
+
+  /** Prune stale worktree bookkeeping (`git worktree prune` on both engines). */
+  prune(repoPath: RepoPath): Promise<void>;
+}

--- a/packages/isolation/src/engine/worktrunk-engine.integration.test.ts
+++ b/packages/isolation/src/engine/worktrunk-engine.integration.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Integration test for `WorktrunkEngine` against the real `wt` binary and a real
+ * git repository. Skipped (not failed) when `wt` isn't on PATH — the unit tests
+ * in `worktrunk-engine.test.ts` cover the same logic against a mocked
+ * subprocess and always run.
+ */
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { toRepoPath, toBranchName, toWorktreePath } from '@archon/git';
+import { WorktrunkEngine } from './worktrunk-engine';
+
+const hasWt = (() => {
+  try {
+    execFileSync('wt', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+describe.skipIf(!hasWt)('WorktrunkEngine (integration, real wt + git)', () => {
+  let tmpRoot: string;
+  let repoPath: string;
+  let worktreeDest: string;
+  let originalWorktrunkConfigPath: string | undefined;
+
+  beforeAll(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'archon-wt-engine-'));
+    repoPath = join(tmpRoot, 'repo');
+    worktreeDest = join(tmpRoot, 'dest');
+    execFileSync('git', ['init', '-q', '-b', 'main', repoPath]);
+    execFileSync('git', ['-C', repoPath, 'commit', '-q', '--allow-empty', '-m', 'init']);
+
+    // Point at an empty user config so this test is hermetic: it must not
+    // depend on (or be broken by) whatever hooks the machine running it has
+    // configured globally for worktrunk (e.g. a pre-start hook that creates
+    // untracked files, which would make a later --no-delete-branch removal
+    // fail on "uncommitted changes").
+    const emptyConfigPath = join(tmpRoot, 'empty-wt-config.toml');
+    writeFileSync(emptyConfigPath, '');
+    originalWorktrunkConfigPath = process.env.WORKTRUNK_CONFIG_PATH;
+    process.env.WORKTRUNK_CONFIG_PATH = emptyConfigPath;
+  });
+
+  afterAll(() => {
+    if (originalWorktrunkConfigPath === undefined) {
+      delete process.env.WORKTRUNK_CONFIG_PATH;
+    } else {
+      process.env.WORKTRUNK_CONFIG_PATH = originalWorktrunkConfigPath;
+    }
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  test('add() creates a real worktree at the pinned destination', async () => {
+    const engine = new WorktrunkEngine();
+    const worktreePath = join(worktreeDest, 'feature-x');
+
+    await engine.add({
+      repoPath: toRepoPath(repoPath),
+      worktreePath: toWorktreePath(worktreePath),
+      branch: toBranchName('feature-x'),
+      startPoint: 'main',
+    });
+
+    const gitFile = execFileSync('cat', [join(worktreePath, '.git')]).toString();
+    expect(gitFile).toContain('gitdir:');
+  });
+
+  test('list() reports the created worktree', async () => {
+    const engine = new WorktrunkEngine();
+
+    const worktrees = await engine.list(toRepoPath(repoPath));
+
+    const branchNames = worktrees.map(w => w.branch);
+    expect(branchNames).toContain('feature-x');
+  });
+
+  test('remove() removes the worktree and leaves the branch (--no-delete-branch)', async () => {
+    const engine = new WorktrunkEngine();
+    const worktreePath = join(worktreeDest, 'feature-x');
+
+    await engine.remove({
+      repoPath: toRepoPath(repoPath),
+      worktreePath: toWorktreePath(worktreePath),
+    });
+
+    const worktrees = await engine.list(toRepoPath(repoPath));
+    expect(worktrees.map(w => w.branch)).not.toContain('feature-x');
+
+    const branches = execFileSync('git', ['-C', repoPath, 'branch', '--list', 'feature-x'])
+      .toString()
+      .trim();
+    expect(branches).toContain('feature-x');
+  });
+
+  test('prune() runs cleanly against the real repo', async () => {
+    const engine = new WorktrunkEngine();
+    await expect(engine.prune(toRepoPath(repoPath))).resolves.toBeUndefined();
+  });
+});

--- a/packages/isolation/src/engine/worktrunk-engine.test.ts
+++ b/packages/isolation/src/engine/worktrunk-engine.test.ts
@@ -1,0 +1,291 @@
+import { describe, test, expect, beforeEach, afterEach, spyOn, mock, type Mock } from 'bun:test';
+
+// Mock @archon/paths so nothing in this file touches the real filesystem/home dir.
+mock.module('@archon/paths', () => ({
+  createLogger: () => ({
+    fatal: () => undefined,
+    error: () => undefined,
+    warn: () => undefined,
+    info: () => undefined,
+    debug: () => undefined,
+    trace: () => undefined,
+    child: () => undefined,
+  }),
+}));
+
+import * as git from '@archon/git';
+import { toRepoPath, toBranchName, toWorktreePath } from '@archon/git';
+import { WorktrunkEngine, MIN_WORKTRUNK_VERSION } from './worktrunk-engine';
+
+describe('WorktrunkEngine', () => {
+  let engine: WorktrunkEngine;
+  let execSpy: Mock<typeof git.execFileAsync>;
+
+  /** Route `wt --version` to a fixed success response; other calls fall through to whatever's queued. */
+  function mockVersion(version = MIN_WORKTRUNK_VERSION): void {
+    execSpy.mockImplementation(async (cmd: string, args: string[]) => {
+      if (cmd === 'wt' && args[0] === '--version') {
+        return { stdout: `wt ${version}\n`, stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
+  }
+
+  beforeEach(() => {
+    engine = new WorktrunkEngine();
+    execSpy = spyOn(git, 'execFileAsync');
+    mockVersion();
+  });
+
+  afterEach(() => {
+    execSpy.mockRestore();
+  });
+
+  test('id is worktrunk', () => {
+    expect(engine.id).toBe('worktrunk');
+  });
+
+  describe('binary preflight', () => {
+    test('missing binary fails with an actionable error naming wt', async () => {
+      execSpy.mockImplementation(async (cmd: string) => {
+        if (cmd === 'wt') {
+          const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+          throw err;
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      await expect(engine.list(toRepoPath('/repo'))).rejects.toThrow(
+        /'wt' binary was not found on PATH/
+      );
+    });
+
+    test('too-old version fails with an actionable error naming the minimum version', async () => {
+      mockVersion('0.10.0');
+
+      await expect(engine.list(toRepoPath('/repo'))).rejects.toThrow(
+        new RegExp(
+          `older than the minimum supported ${MIN_WORKTRUNK_VERSION.replace(/\./g, '\\.')}`
+        )
+      );
+    });
+
+    test('unparsable version output fails loudly', async () => {
+      execSpy.mockImplementation(async (cmd: string, args: string[]) => {
+        if (cmd === 'wt' && args[0] === '--version') {
+          return { stdout: 'garbage output\n', stderr: '' };
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      await expect(engine.list(toRepoPath('/repo'))).rejects.toThrow(/older than the minimum/);
+    });
+
+    test('a successful probe is cached across calls (only one --version invocation)', async () => {
+      execSpy.mockImplementation(async (cmd: string, args: string[]) => {
+        if (cmd === 'wt' && args[0] === '--version') {
+          return { stdout: `wt ${MIN_WORKTRUNK_VERSION}\n`, stderr: '' };
+        }
+        return { stdout: '[]', stderr: '' };
+      });
+
+      await engine.list(toRepoPath('/repo'));
+      await engine.list(toRepoPath('/repo'));
+
+      const versionCalls = execSpy.mock.calls.filter(
+        call => call[0] === 'wt' && (call[1] as string[])[0] === '--version'
+      );
+      expect(versionCalls.length).toBe(1);
+    });
+
+    test('a failed probe is not cached, so a later retry re-probes', async () => {
+      let calls = 0;
+      execSpy.mockImplementation(async (cmd: string, args: string[]) => {
+        if (cmd === 'wt' && args[0] === '--version') {
+          calls++;
+          if (calls === 1) {
+            const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+            throw err;
+          }
+          return { stdout: `wt ${MIN_WORKTRUNK_VERSION}\n`, stderr: '' };
+        }
+        return { stdout: '[]', stderr: '' };
+      });
+
+      await expect(engine.list(toRepoPath('/repo'))).rejects.toThrow();
+      await expect(engine.list(toRepoPath('/repo'))).resolves.toEqual([]);
+      expect(calls).toBe(2);
+    });
+  });
+
+  describe('add', () => {
+    test('new branch: wt switch --create <branch> --base <startPoint>, pinned path', async () => {
+      await engine.add({
+        repoPath: toRepoPath('/repo'),
+        worktreePath: toWorktreePath('/repo/wt/archon-task-x'),
+        branch: toBranchName('archon/task-x'),
+        startPoint: 'origin/main',
+      });
+
+      const addCall = execSpy.mock.calls.find(
+        call => call[0] === 'wt' && (call[1] as string[])[0] === 'switch'
+      );
+      expect(addCall).toBeDefined();
+      const args = addCall![1] as string[];
+      expect(args).toEqual(
+        expect.arrayContaining([
+          'switch',
+          '--create',
+          'archon/task-x',
+          '--base',
+          'origin/main',
+          '--no-cd',
+          '--yes',
+          '-C',
+          '/repo',
+        ])
+      );
+      const configSetIndex = args.indexOf('--config-set');
+      expect(configSetIndex).toBeGreaterThan(-1);
+      expect(args[configSetIndex + 1]).toBe(
+        `worktree-path=${JSON.stringify('/repo/wt/archon-task-x')}`
+      );
+    });
+
+    test('no start point: wt switch <branch> (existing local branch)', async () => {
+      await engine.add({
+        repoPath: toRepoPath('/repo'),
+        worktreePath: toWorktreePath('/repo/wt/existing'),
+        branch: toBranchName('existing-branch'),
+      });
+
+      const addCall = execSpy.mock.calls.find(
+        call => call[0] === 'wt' && (call[1] as string[])[0] === 'switch'
+      );
+      const args = addCall![1] as string[];
+      expect(args).toEqual(
+        expect.arrayContaining(['switch', 'existing-branch', '--no-cd', '--yes', '-C', '/repo'])
+      );
+      expect(args).not.toContain('--create');
+    });
+
+    test('propagates subprocess errors unchanged', async () => {
+      execSpy.mockImplementation(async (cmd: string, args: string[]) => {
+        if (cmd === 'wt' && args[0] === '--version') {
+          return { stdout: `wt ${MIN_WORKTRUNK_VERSION}\n`, stderr: '' };
+        }
+        throw Object.assign(new Error('Branch already exists'), {
+          stderr: '✗ Branch already exists',
+        });
+      });
+
+      await expect(
+        engine.add({
+          repoPath: toRepoPath('/repo'),
+          worktreePath: toWorktreePath('/repo/wt'),
+          branch: toBranchName('archon/task-x'),
+          startPoint: 'origin/main',
+        })
+      ).rejects.toThrow('Branch already exists');
+    });
+  });
+
+  describe('remove', () => {
+    test('always passes --no-delete-branch and --foreground (branch lifecycle stays with the provider)', async () => {
+      await engine.remove({
+        repoPath: toRepoPath('/repo'),
+        worktreePath: toWorktreePath('/repo/wt'),
+      });
+
+      const removeCall = execSpy.mock.calls.find(
+        call => call[0] === 'wt' && (call[1] as string[])[0] === 'remove'
+      );
+      const args = removeCall![1] as string[];
+      expect(args).toEqual(
+        expect.arrayContaining([
+          'remove',
+          '/repo/wt',
+          '--foreground',
+          '--no-delete-branch',
+          '--yes',
+          '-C',
+          '/repo',
+        ])
+      );
+      expect(args).not.toContain('--force');
+    });
+
+    test('force: true adds --force', async () => {
+      await engine.remove({
+        repoPath: toRepoPath('/repo'),
+        worktreePath: toWorktreePath('/repo/wt'),
+        force: true,
+      });
+
+      const removeCall = execSpy.mock.calls.find(
+        call => call[0] === 'wt' && (call[1] as string[])[0] === 'remove'
+      );
+      expect(removeCall![1] as string[]).toContain('--force');
+    });
+  });
+
+  describe('list', () => {
+    test('parses wt list --format json, keeping only worktree rows with a branch', async () => {
+      execSpy.mockImplementation(async (cmd: string, args: string[]) => {
+        if (cmd === 'wt' && args[0] === '--version') {
+          return { stdout: `wt ${MIN_WORKTRUNK_VERSION}\n`, stderr: '' };
+        }
+        return {
+          stdout: JSON.stringify([
+            { branch: 'main', path: '/repo', kind: 'worktree' },
+            { branch: 'feature-x', path: '/repo/wt/feature-x', kind: 'worktree' },
+            { branch: 'branch-only-no-worktree', path: null, kind: 'branch' },
+          ]),
+          stderr: '',
+        };
+      });
+
+      const result = await engine.list(toRepoPath('/repo'));
+      expect(result).toEqual([
+        { path: '/repo', branch: 'main' },
+        { path: '/repo/wt/feature-x', branch: 'feature-x' },
+      ]);
+    });
+
+    test('throws on malformed JSON', async () => {
+      execSpy.mockImplementation(async (cmd: string, args: string[]) => {
+        if (cmd === 'wt' && args[0] === '--version') {
+          return { stdout: `wt ${MIN_WORKTRUNK_VERSION}\n`, stderr: '' };
+        }
+        return { stdout: 'not json', stderr: '' };
+      });
+
+      await expect(engine.list(toRepoPath('/repo'))).rejects.toThrow(/Failed to parse/);
+    });
+
+    test('throws when the top-level value is not an array', async () => {
+      execSpy.mockImplementation(async (cmd: string, args: string[]) => {
+        if (cmd === 'wt' && args[0] === '--version') {
+          return { stdout: `wt ${MIN_WORKTRUNK_VERSION}\n`, stderr: '' };
+        }
+        return { stdout: JSON.stringify({ not: 'an array' }), stderr: '' };
+      });
+
+      await expect(engine.list(toRepoPath('/repo'))).rejects.toThrow(/expected an array/);
+    });
+  });
+
+  describe('prune', () => {
+    test('uses raw git worktree prune, not a wt command', async () => {
+      await engine.prune(toRepoPath('/repo'));
+
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        ['-C', '/repo', 'worktree', 'prune'],
+        expect.objectContaining({ timeout: expect.any(Number) })
+      );
+      const wtCalls = execSpy.mock.calls.filter(call => call[0] === 'wt');
+      expect(wtCalls.length).toBe(0);
+    });
+  });
+});

--- a/packages/isolation/src/engine/worktrunk-engine.ts
+++ b/packages/isolation/src/engine/worktrunk-engine.ts
@@ -1,0 +1,220 @@
+/**
+ * Worktrunk Engine
+ *
+ * Routes worktree add/remove/list through the `wt` CLI
+ * (https://worktrunk.dev) so worktrees Archon creates participate in the
+ * user's worktrunk setup: per-repo hooks (env setup, dependency install) run
+ * on creation and removal, and Archon-managed worktrees show up in `wt list`
+ * alongside manually-created ones.
+ *
+ * Path pinning: worktrunk normally derives the worktree destination from its
+ * own `worktree-path` template. Archon owns path layout (the environment
+ * registry and log/artifact resolution depend on it), so every invocation pins
+ * the destination to the exact path via `--config-set worktree-path="<literal>"`
+ * — an inline TOML override with higher priority than the user's config files
+ * and `WORKTRUNK_*` env vars. Branch names may contain `/`, so the literal
+ * resolved path is pinned rather than a `{{ branch }}` template.
+ *
+ * Branch lifecycle stays with the provider: `remove` always passes
+ * `--no-delete-branch` (the provider deletes branches itself, exactly as with
+ * the git engine), and `wt switch --create` sets no upstream tracking —
+ * matching the git engine's `--no-track` behavior.
+ *
+ * Failure mode: if the `wt` binary is missing or older than
+ * `MIN_WORKTRUNK_VERSION`, every operation fails fast with an actionable error
+ * naming the binary — no silent fallback to the git engine.
+ */
+
+import { execFileAsync } from '@archon/git';
+import { toBranchName, toWorktreePath } from '@archon/git';
+import type { RepoPath, WorktreeInfo } from '@archon/git';
+import { createLogger } from '@archon/paths';
+import type { AddWorktreeOptions, RemoveWorktreeOptions, WorktreeEngine } from './types';
+
+/** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
+let cachedLog: ReturnType<typeof createLogger> | undefined;
+function getLog(): ReturnType<typeof createLogger> {
+  if (!cachedLog) cachedLog = createLogger('isolation.worktrunk');
+  return cachedLog;
+}
+
+/**
+ * Oldest worktrunk release this engine is validated against. Needs
+ * `--config-set`, `--no-cd`, `--foreground`, `--no-delete-branch`, and
+ * `wt list --format json` — all verified on 0.61.0.
+ */
+export const MIN_WORKTRUNK_VERSION = '0.61.0';
+
+/**
+ * Ceiling for a single `wt` subprocess in add/remove operations. Matches the
+ * git engine's ceiling: user-configured worktrunk hooks (dependency install,
+ * env setup) play the same role as heavy post-checkout hooks.
+ */
+const WT_OPERATION_TIMEOUT_MS = 5 * 60 * 1000;
+
+const WT_LIST_TIMEOUT_MS = 30000;
+const WT_VERSION_TIMEOUT_MS = 10000;
+const PRUNE_TIMEOUT_MS = 15000;
+
+/** Shape of one `wt list --format json` entry (subset Archon reads). */
+interface WtListEntry {
+  branch?: string | null;
+  path?: string | null;
+  kind?: string;
+}
+
+/**
+ * Serialize a path as a TOML basic string for `--config-set`. JSON string
+ * escaping is a valid TOML basic-string encoding for the characters that can
+ * appear in filesystem paths (quotes, backslashes, control chars).
+ */
+function toTomlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function parseWtVersion(stdout: string): string | null {
+  const match = /(\d+)\.(\d+)\.(\d+)/.exec(stdout);
+  return match ? match[0] : null;
+}
+
+function isVersionAtLeast(version: string, minimum: string): boolean {
+  const parse = (v: string): number[] => v.split('.').map(part => Number.parseInt(part, 10));
+  const [maj, min, pat] = parse(version);
+  const [minMaj, minMin, minPat] = parse(minimum);
+  if (maj !== minMaj) return maj > minMaj;
+  if (min !== minMin) return min > minMin;
+  return pat >= minPat;
+}
+
+export class WorktrunkEngine implements WorktreeEngine {
+  readonly id = 'worktrunk' as const;
+
+  /** Cached successful preflight — one `wt --version` probe per process. */
+  private available: Promise<void> | null = null;
+
+  /**
+   * Fail fast when `wt` is missing or too old. Only a successful probe is
+   * cached, so a user can install/upgrade `wt` and retry without restarting.
+   */
+  private ensureAvailable(): Promise<void> {
+    if (!this.available) {
+      const probe = this.probeBinary();
+      this.available = probe;
+      probe.catch(() => {
+        this.available = null;
+      });
+    }
+    return this.available;
+  }
+
+  private async probeBinary(): Promise<void> {
+    let stdout: string;
+    try {
+      ({ stdout } = await execFileAsync('wt', ['--version'], { timeout: WT_VERSION_TIMEOUT_MS }));
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      getLog().error({ err, code: err.code }, 'worktrunk.binary_probe_failed');
+      throw new Error(
+        "worktree.engine is 'worktrunk' but the 'wt' binary was not found on PATH " +
+          `(${err.code ?? err.message}). Install worktrunk (https://worktrunk.dev) ` +
+          "or remove 'worktree.engine' from .archon/config.yaml to use the default git engine."
+      );
+    }
+
+    const version = parseWtVersion(stdout);
+    if (!version || !isVersionAtLeast(version, MIN_WORKTRUNK_VERSION)) {
+      throw new Error(
+        `worktree.engine is 'worktrunk' but 'wt' reported version '${version ?? stdout.trim()}', ` +
+          `older than the minimum supported ${MIN_WORKTRUNK_VERSION}. Upgrade worktrunk ` +
+          "(https://worktrunk.dev) or remove 'worktree.engine' from .archon/config.yaml."
+      );
+    }
+  }
+
+  /**
+   * `wt switch --create <branch> --base <startPoint>` for a new branch;
+   * `wt switch <branch>` for an existing one. `--no-cd` skips the directory
+   * change (hooks still run), `--yes` skips interactive approval prompts.
+   * `track` is not forwarded: `wt switch --create` never sets upstream
+   * tracking (matching git `--no-track`), and callers that need tracking set
+   * it explicitly afterwards (same as with the git engine).
+   */
+  async add(options: AddWorktreeOptions): Promise<void> {
+    await this.ensureAvailable();
+    const { repoPath, worktreePath, branch, startPoint } = options;
+    const args = ['switch'];
+    if (startPoint !== undefined) {
+      args.push('--create', branch, '--base', startPoint);
+    } else {
+      args.push(branch);
+    }
+    args.push('--no-cd', '--yes', '-C', repoPath, ...pinnedPathArgs(worktreePath));
+    await execFileAsync('wt', args, { timeout: WT_OPERATION_TIMEOUT_MS });
+  }
+
+  async remove(options: RemoveWorktreeOptions): Promise<void> {
+    await this.ensureAvailable();
+    const { repoPath, worktreePath, force } = options;
+    // `--foreground` blocks until removal completes (wt removes in the
+    // background by default); `--no-delete-branch` because branch deletion is
+    // the provider's job — identical to the git engine's contract.
+    const args = ['remove', worktreePath, '--foreground', '--no-delete-branch'];
+    if (force) {
+      args.push('--force');
+    }
+    args.push('--yes', '-C', repoPath);
+    await execFileAsync('wt', args, { timeout: WT_OPERATION_TIMEOUT_MS });
+  }
+
+  async list(repoPath: RepoPath): Promise<WorktreeInfo[]> {
+    await this.ensureAvailable();
+    const { stdout } = await execFileAsync('wt', ['list', '--format', 'json', '-C', repoPath], {
+      timeout: WT_LIST_TIMEOUT_MS,
+    });
+
+    let entries: unknown;
+    try {
+      entries = JSON.parse(stdout);
+    } catch (error) {
+      const err = error as Error;
+      getLog().error({ err, repoPath }, 'worktrunk.list_parse_failed');
+      throw new Error(`Failed to parse 'wt list --format json' output: ${err.message}`);
+    }
+    if (!Array.isArray(entries)) {
+      throw new Error(
+        `Unexpected 'wt list --format json' output: expected an array, got ${typeof entries}`
+      );
+    }
+
+    const worktrees: WorktreeInfo[] = [];
+    for (const entry of entries as WtListEntry[]) {
+      // Parity with the git engine's porcelain parse: only real worktrees with
+      // a branch (skips branch-only rows from config overrides and detached
+      // HEADs, which the git engine also omits).
+      if (entry.kind === 'worktree' && entry.branch && entry.path) {
+        worktrees.push({
+          path: toWorktreePath(entry.path),
+          branch: toBranchName(entry.branch),
+        });
+      }
+    }
+    return worktrees;
+  }
+
+  /**
+   * Worktrunk has no prune command — stale-bookkeeping cleanup is a git-gc
+   * concern, and worktrunk-created worktrees are ordinary git worktrees, so
+   * `git worktree prune` is the correct operation for both engines. This is an
+   * intentional, documented use of git (not a fallback from a missing binary).
+   */
+  async prune(repoPath: RepoPath): Promise<void> {
+    await execFileAsync('git', ['-C', repoPath, 'worktree', 'prune'], {
+      timeout: PRUNE_TIMEOUT_MS,
+    });
+  }
+}
+
+/** Inline TOML override pinning the worktree destination to a literal path. */
+function pinnedPathArgs(worktreePath: string): string[] {
+  return ['--config-set', `worktree-path=${toTomlString(worktreePath)}`];
+}

--- a/packages/isolation/src/index.ts
+++ b/packages/isolation/src/index.ts
@@ -66,6 +66,18 @@ export type { IsolationResolverDeps } from './resolver';
 // --- Provider ---
 export { WorktreeProvider } from './providers/worktree';
 
+// --- Worktree engine (pluggable low-level plumbing: git | worktrunk) ---
+export { WORKTREE_ENGINE_IDS } from './engine/types';
+export type {
+  WorktreeEngine,
+  WorktreeEngineId,
+  AddWorktreeOptions,
+  RemoveWorktreeOptions,
+} from './engine/types';
+export { GitWorktreeEngine } from './engine/git-engine';
+export { WorktrunkEngine, MIN_WORKTRUNK_VERSION } from './engine/worktrunk-engine';
+export { resolveWorktreeEngine } from './engine/resolve';
+
 // --- PR state lookup ---
 export { getPrState } from './pr-state';
 export type { PrState } from './pr-state';

--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -3233,4 +3233,133 @@ describe('WorktreeProvider', () => {
       );
     });
   });
+
+  describe('worktree engine selection (#2260)', () => {
+    const baseRequest: IsolationRequest = {
+      codebaseId: 'cb-123',
+      canonicalRepoPath: '/workspace/repo',
+      workflowType: 'issue',
+      identifier: '42',
+    };
+
+    /** Route `wt --version` to a fixed success response; other `wt` calls resolve empty by default. */
+    function mockWtAvailable(): void {
+      execSpy.mockImplementation(async (cmd: string, args: string[]) => {
+        if (cmd === 'wt' && args[0] === '--version') {
+          return { stdout: 'wt 0.61.0\n', stderr: '' };
+        }
+        return { stdout: '', stderr: '' };
+      });
+    }
+
+    test('create() routes through wt switch --create when worktree.engine is worktrunk', async () => {
+      mockWtAvailable();
+      const worktrunkLoader: RepoConfigLoader = async () => ({
+        baseBranch: 'main',
+        engine: 'worktrunk',
+      });
+      const worktrunkProvider = new WorktreeProvider(worktrunkLoader);
+
+      const env = await worktrunkProvider.create(baseRequest);
+
+      expect(env.branchName).toBe('archon/issue-42');
+      expect(execSpy).toHaveBeenCalledWith(
+        'wt',
+        expect.arrayContaining([
+          'switch',
+          '--create',
+          'archon/issue-42',
+          '--base',
+          'origin/main',
+          '--no-cd',
+          '--yes',
+          '-C',
+          '/workspace/repo',
+        ]),
+        expect.any(Object)
+      );
+      // The raw git worktree add path must not have run.
+      const gitAddCalls = execSpy.mock.calls.filter(
+        call => call[0] === 'git' && (call[1] as string[]).includes('add')
+      );
+      expect(gitAddCalls).toHaveLength(0);
+    });
+
+    test('destroy() routes through wt remove --foreground --no-delete-branch when configured', async () => {
+      mockWtAvailable();
+      mockAccess.mockResolvedValue(undefined);
+      const worktrunkLoader: RepoConfigLoader = async () => ({ engine: 'worktrunk' });
+      const worktrunkProvider = new WorktreeProvider(worktrunkLoader);
+
+      await worktrunkProvider.destroy('/workspace/repo/worktrees/issue-42', {
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
+      });
+
+      expect(execSpy).toHaveBeenCalledWith(
+        'wt',
+        expect.arrayContaining([
+          'remove',
+          '/workspace/repo/worktrees/issue-42',
+          '--foreground',
+          '--no-delete-branch',
+          '--yes',
+          '-C',
+          '/workspace/repo',
+        ]),
+        expect.any(Object)
+      );
+    });
+
+    test('list() routes through wt list --format json when configured', async () => {
+      execSpy.mockImplementation(async (cmd: string, args: string[]) => {
+        if (cmd === 'wt' && args[0] === '--version') {
+          return { stdout: 'wt 0.61.0\n', stderr: '' };
+        }
+        if (cmd === 'wt' && args[0] === 'list') {
+          return {
+            stdout: JSON.stringify([
+              { branch: 'main', path: '/workspace/repo', kind: 'worktree' },
+              {
+                branch: 'issue-42',
+                path: '/workspace/repo/worktrees/issue-42',
+                kind: 'worktree',
+              },
+            ]),
+            stderr: '',
+          };
+        }
+        return { stdout: '', stderr: '' };
+      });
+      const worktrunkLoader: RepoConfigLoader = async () => ({ engine: 'worktrunk' });
+      const worktrunkProvider = new WorktreeProvider(worktrunkLoader);
+
+      const result = await worktrunkProvider.list('/workspace/repo');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].branchName).toBe('issue-42');
+    });
+
+    test('an unrecognized worktree.engine value fails loudly with no silent fallback to git', async () => {
+      const badLoader: RepoConfigLoader = async () => ({ engine: 'docker' });
+      const badProvider = new WorktreeProvider(badLoader);
+
+      await expect(badProvider.create(baseRequest)).rejects.toThrow(
+        /worktree\.engine must be one of/
+      );
+
+      // No git worktree add should have run either — the failure happens before any git op.
+      const gitAddCalls = execSpy.mock.calls.filter(
+        call => call[0] === 'git' && (call[1] as string[]).includes('add')
+      );
+      expect(gitAddCalls).toHaveLength(0);
+    });
+
+    test('an unset engine still uses the git engine (zero behavior change)', async () => {
+      const env = await provider.create(baseRequest);
+
+      expect(env.branchName).toBe('archon/issue-42');
+      const wtCalls = execSpy.mock.calls.filter(call => call[0] === 'wt');
+      expect(wtCalls).toHaveLength(0);
+    });
+  });
 });

--- a/packages/isolation/src/providers/worktree.ts
+++ b/packages/isolation/src/providers/worktree.ts
@@ -2,6 +2,12 @@
  * Worktree Provider - Git worktree-based isolation
  *
  * Default isolation provider using git worktrees.
+ *
+ * The low-level worktree plumbing (add/remove/list/prune) is pluggable via
+ * `worktree.engine` in `.archon/config.yaml` — see `../engine/types.ts`. All
+ * provider logic (branch naming, adoption, fork-PR fetching, copyFiles,
+ * submodules, branch cleanup) is engine-independent and behaves identically
+ * for both engines.
  */
 
 import { createHash } from 'crypto';
@@ -29,6 +35,8 @@ import type { WorktreeBaseOverride } from '@archon/git';
 import { getArchonWorkspacesPath } from '@archon/paths';
 import type { RepoPath, WorktreeInfo } from '@archon/git';
 import { copyWorktreeFiles } from '../worktree-copy';
+import { resolveWorktreeEngine } from '../engine/resolve';
+import type { WorktreeEngine } from '../engine/types';
 import type {
   DestroyResult,
   IIsolationProvider,
@@ -224,16 +232,20 @@ export class WorktreeProvider implements IIsolationProvider {
       return result;
     }
 
+    // Engine selection mirrors create(): per-repo config, loud failure. A
+    // worktrunk-managed worktree removed via raw git would silently skip the
+    // user's pre-remove hooks, so a broken config blocks removal rather than
+    // guessing.
+    const engine = await this.resolveEngineFor(repoPath);
+
     // Only attempt worktree removal if path exists
     if (pathExists) {
-      const gitArgs = ['-C', repoPath, 'worktree', 'remove'];
-      if (options?.force) {
-        gitArgs.push('--force');
-      }
-      gitArgs.push(worktreePath);
-
       try {
-        await execFileAsync('git', gitArgs, { timeout: GIT_OPERATION_TIMEOUT_MS });
+        await engine.remove({
+          repoPath: toRepoPath(repoPath),
+          worktreePath: toWorktreePath(worktreePath),
+          force: options?.force ?? false,
+        });
         result.worktreeRemoved = true;
       } catch (error) {
         if (!this.isWorktreeMissingError(error)) {
@@ -267,7 +279,7 @@ export class WorktreeProvider implements IIsolationProvider {
     // Prune stale worktree references — runs even when path is already gone,
     // because git may still have a stale ref for a manually-deleted worktree
     try {
-      await execFileAsync('git', ['-C', repoPath, 'worktree', 'prune'], { timeout: 15000 });
+      await engine.prune(toRepoPath(repoPath));
     } catch (_error) {
       // Best-effort — pruning failure is not critical
       getLog().debug({ repoPath }, 'worktree_prune_failed');
@@ -303,8 +315,30 @@ export class WorktreeProvider implements IIsolationProvider {
   }
 
   /**
+   * Resolve the worktree engine for a repo from its `.archon/config.yaml`.
+   *
+   * Config load failure is fatal (mirrors `create()`): silently defaulting to
+   * the git engine would strip a worktrunk-managed repo of its hooks. An
+   * invalid `worktree.engine` value throws its own actionable error from
+   * `resolveWorktreeEngine()`.
+   */
+  private async resolveEngineFor(repoPath: string): Promise<WorktreeEngine> {
+    let repoConfig: WorktreeCreateConfig | null;
+    try {
+      repoConfig = await this.loadConfig(repoPath);
+    } catch (error) {
+      const err = error as Error;
+      getLog().error({ err, repoPath }, 'repo_config_load_failed');
+      throw new Error(`Failed to load config: ${err.message}`);
+    }
+    return resolveWorktreeEngine(repoConfig?.engine);
+  }
+
+  /**
    * Check if an error indicates the worktree path is missing.
    * Checks both message and stderr for robustness across git versions/locales.
+   * 'No branch named' is worktrunk's phrasing when the argument matches
+   * neither a branch nor a registered worktree path.
    */
   private isWorktreeMissingError(error: unknown): boolean {
     const err = error as Error & { stderr?: string };
@@ -312,7 +346,8 @@ export class WorktreeProvider implements IIsolationProvider {
     return (
       errorText.includes('No such file or directory') ||
       errorText.includes('does not exist') ||
-      errorText.includes('is not a working tree')
+      errorText.includes('is not a working tree') ||
+      errorText.includes('No branch named')
     );
   }
 
@@ -464,7 +499,8 @@ export class WorktreeProvider implements IIsolationProvider {
   async list(codebaseId: string): Promise<IsolatedEnvironment[]> {
     // codebaseId is the canonical repo path for worktrees
     const repoPath = toRepoPath(codebaseId);
-    const worktrees = await listWorktrees(repoPath);
+    const engine = await this.resolveEngineFor(repoPath);
+    const worktrees = await engine.list(repoPath);
 
     // Filter out main repo (first worktree is typically the main checkout)
     return worktrees
@@ -707,6 +743,11 @@ export class WorktreeProvider implements IIsolationProvider {
   ): Promise<{ warnings: string[] }> {
     const repoPath = request.canonicalRepoPath;
 
+    // Engine selection is per-repo config (worktree.engine). An invalid value
+    // fails loudly here — before any sync/fetch work — rather than silently
+    // falling back to the git engine.
+    const engine = resolveWorktreeEngine(worktreeConfig?.engine);
+
     // Resolve git remote name: explicit config > auto-detect > actionable error
     const remote = await this.resolveRemote(repoPath, worktreeConfig?.remote);
 
@@ -726,10 +767,18 @@ export class WorktreeProvider implements IIsolationProvider {
 
     if (isPRIsolationRequest(request)) {
       // For PRs: fetch and checkout the PR branch (actual or synthetic)
-      await this.createFromPR(request, worktreePath, remote);
+      await this.createFromPR(request, worktreePath, engine, remote);
     } else {
       // For issues, tasks, threads: create new branch
-      await this.createNewBranch(request, repoPath, worktreePath, branchName, baseBranch, remote);
+      await this.createNewBranch(
+        request,
+        repoPath,
+        worktreePath,
+        branchName,
+        baseBranch,
+        engine,
+        remote
+      );
     }
 
     // Stamp the originating user's git identity on this worktree so workflow
@@ -973,6 +1022,7 @@ export class WorktreeProvider implements IIsolationProvider {
   private async createFromPR(
     request: PRIsolationRequest,
     worktreePath: string,
+    engine: WorktreeEngine,
     remote = 'origin'
   ): Promise<void> {
     // Clean up any orphan directory before creating worktree
@@ -984,9 +1034,11 @@ export class WorktreeProvider implements IIsolationProvider {
     try {
       if (!request.isForkPR) {
         // Same-repo PR: Use the actual branch so changes push directly to PR
-        await this.createFromSameRepoPR(repoPath, worktreePath, request.prBranch, remote);
+        await this.createFromSameRepoPR(repoPath, worktreePath, request.prBranch, engine, remote);
       } else {
-        // Fork PR: Use synthetic review branch
+        // Fork PR: Use synthetic review branch. Always raw git regardless of
+        // the configured engine — `refs/pull/N/head` fetching and synthetic
+        // review branches have no worktrunk equivalent (#2260 non-goal).
         await this.createFromForkPR(repoPath, worktreePath, prNumber, remote, request.prSha);
       }
     } catch (error) {
@@ -1005,6 +1057,7 @@ export class WorktreeProvider implements IIsolationProvider {
     repoPath: string,
     worktreePath: string,
     prBranch: string,
+    engine: WorktreeEngine,
     remote = 'origin'
   ): Promise<void> {
     // Fetch the PR's actual branch
@@ -1015,17 +1068,21 @@ export class WorktreeProvider implements IIsolationProvider {
     // Try to create worktree with the branch
     try {
       // If branch doesn't exist locally, create it tracking remote
-      await execFileAsync(
-        'git',
-        ['-C', repoPath, 'worktree', 'add', worktreePath, '-b', prBranch, `${remote}/${prBranch}`],
-        { timeout: GIT_OPERATION_TIMEOUT_MS }
-      );
+      await engine.add({
+        repoPath: toRepoPath(repoPath),
+        worktreePath: toWorktreePath(worktreePath),
+        branch: toBranchName(prBranch),
+        startPoint: `${remote}/${prBranch}`,
+        track: true,
+      });
     } catch (error) {
       const err = error as Error & { stderr?: string };
       // Branch already exists locally - use it directly
       if (err.stderr?.includes('already exists')) {
-        await execFileAsync('git', ['-C', repoPath, 'worktree', 'add', worktreePath, prBranch], {
-          timeout: GIT_OPERATION_TIMEOUT_MS,
+        await engine.add({
+          repoPath: toRepoPath(repoPath),
+          worktreePath: toWorktreePath(worktreePath),
+          branch: toBranchName(prBranch),
         });
       } else {
         throw error;
@@ -1132,6 +1189,7 @@ export class WorktreeProvider implements IIsolationProvider {
     worktreePath: string,
     branchName: string,
     baseBranch: string,
+    engine: WorktreeEngine,
     remote = 'origin'
   ): Promise<void> {
     // Clean up any orphan directory before creating worktree
@@ -1144,25 +1202,15 @@ export class WorktreeProvider implements IIsolationProvider {
         : `${remote}/${baseBranch}`;
 
     try {
-      // `--no-track` keeps `branch.<name>.merge` unset; otherwise `gh pr view`
-      // (no PR number) resolves to the base branch's PR via upstream config.
-      await execFileAsync(
-        'git',
-        [
-          '-C',
-          repoPath,
-          'worktree',
-          'add',
-          '--no-track',
-          worktreePath,
-          '-b',
-          branchName,
-          startPoint,
-        ],
-        {
-          timeout: GIT_OPERATION_TIMEOUT_MS,
-        }
-      );
+      // No tracking (git: `--no-track`) keeps `branch.<name>.merge` unset;
+      // otherwise `gh pr view` (no PR number) resolves to the base branch's PR
+      // via upstream config.
+      await engine.add({
+        repoPath: toRepoPath(repoPath),
+        worktreePath: toWorktreePath(worktreePath),
+        branch: toBranchName(branchName),
+        startPoint,
+      });
     } catch (error) {
       const err = error as Error & { stderr?: string };
       // Branch already exists - reset to intended start-point and use it
@@ -1187,8 +1235,10 @@ export class WorktreeProvider implements IIsolationProvider {
         await execFileAsync('git', ['-C', repoPath, 'branch', '-f', branchName, startPoint], {
           timeout: 10000,
         });
-        await execFileAsync('git', ['-C', repoPath, 'worktree', 'add', worktreePath, branchName], {
-          timeout: GIT_OPERATION_TIMEOUT_MS,
+        await engine.add({
+          repoPath: toRepoPath(repoPath),
+          worktreePath: toWorktreePath(worktreePath),
+          branch: toBranchName(branchName),
         });
       } else {
         throw error;
@@ -1286,6 +1336,11 @@ export class WorktreeProvider implements IIsolationProvider {
   /**
    * Clean up a git-registered worktree that was left by a partial failure.
    * Best-effort: logs errors but doesn't throw (the original error is more important).
+   *
+   * Intentionally raw git (not the configured engine): a worktrunk-created
+   * worktree is an ordinary git worktree, so `git worktree remove` cleans it up
+   * correctly here too — this rare error-recovery path just skips worktrunk's
+   * remove hooks, which is acceptable for a best-effort partial-failure cleanup.
    */
   private async cleanOrphanWorktreeIfExists(repoPath: string, worktreePath: string): Promise<void> {
     try {

--- a/packages/isolation/src/types.ts
+++ b/packages/isolation/src/types.ts
@@ -277,6 +277,22 @@ export interface WorktreeCreateConfig {
   baseBranch?: string;
   copyFiles?: string[];
   /**
+   * Low-level worktree engine: `'git'` (default) uses raw `git worktree`
+   * commands; `'worktrunk'` shells out to the `wt` CLI
+   * (https://worktrunk.dev) so per-repo worktrunk hooks run and Archon-managed
+   * worktrees appear in `wt list`. With `'worktrunk'` set but no usable `wt`
+   * binary on PATH (missing or older than the minimum supported version),
+   * worktree operations fail fast with an actionable error — no silent
+   * fallback to git. Unrecognized values also fail fast.
+   *
+   * Typed as `string` (not the engine-id union) because this shape mirrors the
+   * raw YAML — validation happens in `resolveWorktreeEngine()`.
+   *
+   * Sourced from `.archon/config.yaml > worktree.engine` in the repo.
+   * @example 'worktrunk'
+   */
+  engine?: string;
+  /**
    * Initialize git submodules in the worktree. Defaults to enabled — a worktree
    * with uninitialized submodules is a silent broken state for monorepos.
    * Set to `false` to opt out. No-op when `.gitmodules` is absent.


### PR DESCRIPTION
## Summary

- Problem: Archon's worktree creation/removal is hardcoded to raw `git worktree` commands, so users who manage their worktrees with [worktrunk](https://worktrunk.dev) get a divergent, invisible-to-`wt-list` set of worktrees whenever Archon creates one.
- Why it matters: Users with a worktrunk-centric setup lose their per-repo hooks (env setup, dependency install, cleanup) and a consistent `wt list`/`wt merge` view whenever Archon (not the user) creates the worktree.
- What changed: Extracted the low-level worktree plumbing (`add`/`remove`/`list`/`prune`) behind a small `WorktreeEngine` interface with two implementations — `GitWorktreeEngine` (default, the historical behavior moved verbatim) and `WorktrunkEngine` (shells out to `wt`). Selected per repo via `.archon/config.yaml > worktree.engine` (default `'git'`).
- What did **not** change (scope boundary): `IIsolationProvider`, branch naming, the resolver, adoption logic, the DB schema, and fork-PR checkout (`refs/pull/N/head` always uses raw git — no worktrunk equivalent for synthetic review branches). No new worktrunk-specific UI surface; hooks just run as the user configured them.

## UX Journey

### Before

```
  User                         Archon                        git
  ────                         ──────                        ───
  runs workflow ─────────────▶ WorktreeProvider.create()
                                resolves branch/path
                                calls `git worktree add` ───▶ creates worktree
                                (worktrunk hooks never run,
                                 worktree invisible to `wt list`)
```

### After

```
  User                         Archon                        engine                git / wt
  ────                         ──────                        ──────                ────────
  runs workflow ─────────────▶ WorktreeProvider.create()
                                loads worktree.engine from
                                .archon/config.yaml
                                resolveWorktreeEngine() ────▶ [GitWorktreeEngine]  ──▶ `git worktree add`
                                                          or▶ [WorktrunkEngine]    ──▶ `wt switch --create`
                                                               (pinned dest path,       (user's pre-start/
                                                                preflighted `wt`          post-start hooks
                                                                binary + version)         run; shows in
                                                                                           `wt list`)
```

## Architecture Diagram

### Before

```
WorktreeProvider (packages/isolation/src/providers/worktree.ts)
  │
  ├──▶ execFileAsync('git', ['worktree','add', ...])   (inline)
  ├──▶ execFileAsync('git', ['worktree','remove', ...]) (inline)
  ├──▶ listWorktrees() (@archon/git)                    (inline)
  └──▶ execFileAsync('git', ['worktree','prune'])       (inline)
```

### After

```
WorktreeProvider (packages/isolation/src/providers/worktree.ts)
  │
  ├──▶ resolveWorktreeEngine(config.worktree.engine)  [+] packages/isolation/src/engine/resolve.ts
  │        │
  │        ├──▶ GitWorktreeEngine       [+] packages/isolation/src/engine/git-engine.ts
  │        │        └──▶ execFileAsync('git', ...) / listWorktrees()   (unchanged @archon/git calls)
  │        │
  │        └──▶ WorktrunkEngine         [+] packages/isolation/src/engine/worktrunk-engine.ts
  │                 └──▶ execFileAsync('wt', ...)   ===  (wt CLI, https://worktrunk.dev)
  │
  └──▶ (fork-PR checkout unchanged: always raw git, bypasses engine)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `WorktreeProvider` | `@archon/git` `execFileAsync`/`listWorktrees` (raw) | modified | Same-repo/issue/task/thread worktree add-remove-list-prune now route through the resolved `WorktreeEngine` instead of calling `@archon/git` inline |
| `WorktreeProvider` | `packages/isolation/src/engine/resolve.ts` | **new** | Resolves `worktree.engine` config string to an engine instance once per create/destroy/list call |
| `engine/resolve.ts` | `GitWorktreeEngine` | **new** | Default engine; wraps the same `@archon/git` calls the provider used to make directly |
| `engine/resolve.ts` | `WorktrunkEngine` | **new** | Opt-in engine; shells out to the `wt` binary |
| `WorktrunkEngine` | `wt` CLI (external process) | **new** | New external dependency, opt-in only (default engine is still `git`) |
| `WorktreeProvider` (fork-PR path) | `@archon/git` `execFileAsync` (raw) | unchanged | Always raw git; never routed through the engine |
| `.archon/config.yaml` `worktree.*` | `WorktreeCreateConfig` | modified | Added `engine?: string` field, passed through unchanged from the existing repo-config loader |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: L`
- Scope: `isolation`
- Module: `isolation:worktree-engine`

## Change Metadata

- Change type: `feature`
- Primary scope: `isolation`

## Linked Issue

- Closes #2260

## Validation Evidence (required)

```bash
bun run validate
# check:bundled, check:bundled-skill, check:bundled-schema, check:pi-vendor-map,
# check:capability-matrix, type-check, lint --max-warnings 0, format:check, test
# → all passed, exit code 0
```

Package-level test results:
- `packages/isolation` (`bun run test`): all batches green, including the new `src/engine/` batch — 36 tests (unit tests for both engines with mocked subprocess + a `wt`-gated integration test against a real repo) and the existing provider suite now at 158 tests (153 original, unmodified, + 5 new engine-selection tests)
- `packages/git` (`bun run test`): 192 pass, 0 fail (unchanged)
- `packages/core` `config-loader.test.ts`: 62 pass, 0 fail (includes 2 new tests for `worktree.engine` parsing)

- Evidence provided (test/log/trace/screenshot): full `bun run validate` output; per-package `bun run test` output (see PR description context)
- If any command is intentionally skipped, explain why: none skipped

## Security Impact (required)

- New permissions/capabilities? No — `WorktrunkEngine` shells out to `wt` the same way the codebase already shells out to `git`, via the same `execFileAsync` wrapper (no shell interpolation, argv-based).
- New external network calls? No.
- Secrets/tokens handling changed? No.
- File system access scope changed? No — the worktree destination path is still fully controlled by Archon (pinned via `--config-set worktree-path=<literal>` on every `wt` invocation), so the environment registry and path resolution are unaffected regardless of engine.
- If any `Yes`, describe risk and mitigation: N/A

## Compatibility / Migration

- Backward compatible? Yes — default `worktree.engine` is `'git'`, which is the exact pre-existing behavior (existing tests for `WorktreeProvider` pass unmodified).
- Config/env changes? Yes, additive only: new optional `worktree.engine: 'git' | 'worktrunk'` key in `.archon/config.yaml`. Omitting it is a no-op.
- Database migration needed? No.
- If yes, exact upgrade steps: N/A (no migration required; users opt in per repo)

## Human Verification (required)

- Verified scenarios:
  - `GitWorktreeEngine` issues byte-identical argv to the pre-refactor inline code for: new-branch creation (`--no-track`), same-repo PR tracking checkout, existing-branch checkout, remove (with/without `--force`), list, prune.
  - `WorktrunkEngine` verified against the real `wt` binary (v0.61.0, installed locally) in an integration test: `add()` creates a real worktree at the pinned destination, `list()` reports it, `remove()` removes it while leaving the branch (`--no-delete-branch`), `prune()` runs cleanly.
  - Binary preflight: missing `wt` and too-old `wt` versions both fail with an actionable error naming `wt` and the minimum version; a successful preflight is cached (one `--version` call across repeated operations), a failed one is not (so installing `wt` after a failure doesn't require a process restart).
  - Provider-level engine selection verified end-to-end: `create()`/`destroy()`/`list()` all route through the configured engine; an unrecognized `worktree.engine` value fails loudly before any git/wt operation runs (no silent fallback).
- Edge cases checked: fork-PR checkout still uses raw git unconditionally under both engine settings; branch lifecycle (delete) stays with the provider in both engines (`wt remove` always passes `--no-delete-branch`).
- What was not verified: worktrunk-specific hook behavior (pre-start/post-start user hooks) beyond confirming the mechanism invokes `wt switch`/`wt remove` correctly — hook execution itself is worktrunk's own tested responsibility, out of scope here. Windows behavior for the `wt` binary path was not manually verified (same caveat as the existing git-based worktree code, which also assumes POSIX-friendly tooling in places).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `packages/isolation` (worktree creation/removal/listing for issue, task, thread, review, and same-repo-PR workflows); `packages/core` config loader (new passthrough field only, no behavior change to existing fields).
- Potential unintended effects: none expected for existing users (default engine unchanged). Users who opt into `worktree.engine: worktrunk` take on a new dependency on the `wt` binary being installed and current.
- Guardrails/monitoring for early detection: fail-fast error messages naming the missing/outdated binary at the first worktree operation, before any partial state is created; existing structured logging (`isolation.worktree`/`isolation.worktrunk` loggers) unchanged in shape.

## Rollback Plan (required)

- Fast rollback command/path: revert the PR, or (without reverting) unset/remove `worktree.engine` from `.archon/config.yaml` — the default `'git'` engine is byte-identical to pre-PR behavior.
- Feature flags or config toggles (if any): `worktree.engine` is itself the toggle; default `'git'` is the safe/previous behavior.
- Observable failure symptoms: a misconfigured `worktree.engine` value or missing/outdated `wt` binary surfaces as an immediate, actionable error at worktree creation/removal time (never a silent fallback or partial worktree).

## Risks and Mitigations

- Risk: A worktrunk pre-start hook could fail or hang, blocking worktree creation for users who opt in.
  - Mitigation: This is the same class of risk the existing "heavy post-checkout hooks" comment already documents for git-based worktree creation (5-minute subprocess timeout applies identically to both engines); users control their own worktrunk hooks and can disable/fix them independently of Archon.
- Risk: `wt`'s CLI surface could change in a future release, breaking argv assumptions (e.g. `--config-set`, `--no-delete-branch`, `--format json`).
  - Mitigation: `WorktrunkEngine` preflights the installed version against `MIN_WORKTRUNK_VERSION` and fails loudly on anything older; a future breaking release would need a corresponding version bump here, not a silent behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable worktree engines, with Git as the default and optional Worktrunk support.
  * Worktree operations can now use the Worktrunk CLI, including creation, removal, and listing.
  * Invalid engine settings and unavailable or unsupported Worktrunk installations now fail clearly.

* **Documentation**
  * Added configuration guidance and usage details for selecting a worktree engine.

* **Tests**
  * Added coverage for engine selection, Git operations, Worktrunk integration, validation, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->