### PR TITLE
fix(web): browse full model list on combobox focus

### DIFF
--- a/packages/web/src/experiments/console/components/ModelPickerField.tsx
+++ b/packages/web/src/experiments/console/components/ModelPickerField.tsx
@@ -116,9 +116,14 @@ function ModelCombobox({
   piModels,
 }: ModelPickerFieldProps): ReactElement {
   const [open, setOpen] = useState(false);
+  // Filter suggestions by the text typed SINCE focus, not the saved value: a
+  // field holding 'haiku' must open showing the whole list (browse), and only
+  // narrow once the user actually types (search). Reset on every focus.
+  const [edited, setEdited] = useState(false);
   // Pi only: include backends without a usable credential in the suggestions.
   const [showAll, setShowAll] = useState(false);
   const shape = modelPickerShape(agentId);
+  const query = edited ? value : '';
 
   // OpenCode on-demand backend list. Per-field state by design: the endpoint
   // is only hit on this field's explicit "Load backend suggestions" click.
@@ -152,18 +157,18 @@ function ModelCombobox({
     }
   };
 
-  // Suggestions per shape; the field's text doubles as the search query.
+  // Suggestions per shape; text typed since focus is the search query.
   const backends = shape === 'pi' ? usablePiBackends(agents) : null;
   const pi =
-    shape === 'pi' ? piModelOptions(piModels, value, backends, showAll, PI_SUGGESTION_LIMIT) : null;
+    shape === 'pi' ? piModelOptions(piModels, query, backends, showAll, PI_SUGGESTION_LIMIT) : null;
   let options: ModelOption[];
   if (pi !== null) {
     options = pi.options;
   } else if (shape === 'opencode') {
     options =
-      ocPhase === 'loaded' ? filterModelOptions(opencodeBackendOptions(ocProviders), value) : [];
+      ocPhase === 'loaded' ? filterModelOptions(opencodeBackendOptions(ocProviders), query) : [];
   } else {
-    options = filterModelOptions(curatedOptionsForAgent(agentId), value);
+    options = filterModelOptions(curatedOptionsForAgent(agentId), query);
   }
 
   const pick = (o: ModelOption): void => {
@@ -185,9 +190,11 @@ function ModelCombobox({
         value={value}
         onChange={e => {
           onChange(e.target.value);
+          setEdited(true);
           setOpen(true);
         }}
         onFocus={() => {
+          setEdited(false);
           setOpen(true);
         }}
         onBlur={() => {


### PR DESCRIPTION
## Summary

- Problem: the Claude/Codex model combobox in Model Tiers / Aliases filters its suggestion list by the field's **saved value**, so a field holding `haiku` opens showing only `haiku` — the curated list can never be browsed. The same applies to Pi and OpenCode suggestion lists when a value is already saved.
- Why it matters: the picker's whole purpose is discovery ("what can I put here?"); filtering by the saved value defeats it exactly when a value exists, which is the common case.
- What changed: suggestions now filter by the text typed **since focus**. On focus the full list shows (browse); once the user types, it narrows (search). One `edited` flag in `ModelCombobox`, reset on focus, set on input.
- What did **not** change (scope boundary): curated list contents, the free-text contract (pickers guide, never gate), the Copilot select shape, the Pi exact-match cost hint (still keyed off the saved value), and all pure helpers in `model-options.ts`.

## UX Journey

### Before

```
User                                 Combobox
────                                 ────────
focuses field (value: "haiku") ────▶ shows ONLY "haiku" (list filtered by saved value)
wants to see other models    ──────▶ must clear the field first
```

### After

```
User                                 Combobox
────                                 ────────
focuses field (value: "haiku") ────▶ [shows FULL curated list — browse]
types "so"                   ──────▶ [narrows to "sonnet" — search]
picks or free-types anything ──────▶ saves as before (guide, never gate)
```

## Architecture Diagram

### Before

```
ModelPickerField.tsx (ModelCombobox) ──filter(value)──▶ model-options.ts helpers
```

### After

```
ModelPickerField.tsx (ModelCombobox) [~] ──filter(query = edited ? value : '')──▶ model-options.ts helpers (unchanged)
```

**Connection inventory**:

| From | To | Status | Notes |
|------|----|--------|-------|
| ModelPickerField.tsx | model-options.ts | **modified** | same helpers, query argument now typed-since-focus |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `web`
- Module: `web:console-settings`

## Change Metadata

- Change type: `bug`
- Primary scope: `web`

## Linked Issue

- Closes #
- Related #

## Validation Evidence (required)

```bash
bun --filter @archon/web type-check   # pass
bun run lint                          # pass (0 warnings)
bun --filter @archon/web test         # 390 pass / 0 fail
```

- Evidence provided: test run summary above; behaviour verified manually in the console Model Tiers panel (focus with saved value shows full list; typing narrows; free text still saves).
- Skipped: full `bun run validate` — change touches one web component; no generated files, schemas, or server code involved.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No

## Human Verification (required)

- Verified scenarios: saved-value focus shows full curated list (claude, codex); typing filters; picking closes and saves; Escape closes; free-typed unlisted values still save.
- Edge cases checked: OpenCode prefix pick keeps the dropdown open and later typing narrows as before; Pi under-field cost hint still keyed to the saved value, not the query.
- What was not verified: Pi catalog behaviour against a live 900-model catalog (exercised via unit-tested `piModelOptions` only).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: console settings panels using `ModelPickerField` (Model Tiers, Aliases, Defaults).
- Potential unintended effects: none expected — suggestion filtering only; saved values and API calls untouched.
- Guardrails: existing `model-options.test.ts` covers the pure filtering helpers.

## Rollback Plan (required)

- Fast rollback: revert this single commit.
- Feature flags: none.
- Observable failure symptoms: suggestion dropdown showing wrong subset on focus/typing.

## Risks and Mitigations

None beyond a cosmetic suggestion-list regression, mitigated by the revert path above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model selection dropdown behavior when reopening a field.
  * Previously saved values no longer immediately narrow available suggestions when browsing.
  * Suggestions now filter only after you begin typing, while typing continues to reopen the dropdown as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->