### PR TITLE
fix(cli): drop Bun SFE virtual argv[1] from detached re-invoke (#2248)

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -3222,11 +3222,18 @@ describe('buildDetachedRunCmd', () => {
     expect(cmd).toContain('--conversation-id');
   });
 
-  it('binary mode: uses [execPath] only (no duplicated entry arg), slices argv(1)', () => {
+  // A Bun single-file executable's argv is NOT [binary, ...userArgs]. Bun
+  // injects a virtual entry path at argv[1] and reports argv[0] as 'bun':
+  //   ['bun', '/$bunfs/root/archon', 'workflow', 'run', ...]
+  // Verified against a real `bun build --compile` artifact. The previous
+  // fixture modelled a compiled argv with no argv[1] at all, which is why
+  // #2248 (detached child dies with `Unknown command: B:/~BUN/root/...`)
+  // shipped green.
+  it('binary mode: uses [execPath] only (no duplicated entry arg), drops the Bun SFE virtual argv[1]', () => {
     const cmd = buildDetachedRunCmd(
       true,
       '/usr/local/bin/archon',
-      ['/usr/local/bin/archon', 'workflow', 'run', 'assist', 'hello', '--detach', '--json'],
+      ['bun', '/$bunfs/root/archon', 'workflow', 'run', 'assist', 'hello', '--detach', '--json'],
       '/abs/cwd',
       ['--branch', 'assist-123']
     );
@@ -3234,12 +3241,40 @@ describe('buildDetachedRunCmd', () => {
     expect(cmd[0]).toBe('/usr/local/bin/archon');
     // The binary path must appear exactly once — never duplicated as argv[1].
     expect(cmd.filter(arg => arg === '/usr/local/bin/archon')).toHaveLength(1);
+    // The virtual entry path must never reach the child: cli.ts parses
+    // process.argv.slice(2), so a leaked argv[1] becomes the child's command.
+    expect(cmd.some(arg => arg.includes('$bunfs'))).toBe(false);
     expect(cmd[1]).toBe('workflow');
     expect(cmd).not.toContain('--detach');
     expect(cmd).not.toContain('--json');
     const cwdIdx = cmd.indexOf('--cwd');
     expect(cmd[cwdIdx + 1]).toBe('/abs/cwd');
     expect(cmd.slice(cwdIdx + 2)).toEqual(['--branch', 'assist-123']);
+  });
+
+  it('binary mode: drops the Windows Bun SFE virtual argv[1] (#2248 repro)', () => {
+    const cmd = buildDetachedRunCmd(
+      true,
+      'C:\\Users\\dev\\archon.exe',
+      [
+        'bun',
+        'B:/~BUN/root/archon-windows-x64.exe',
+        'workflow',
+        'run',
+        'assist',
+        'hello',
+        '--detach',
+        '--json',
+      ],
+      'C:\\checkout',
+      ['--branch', 'assist-123']
+    );
+
+    expect(cmd[0]).toBe('C:\\Users\\dev\\archon.exe');
+    // The exact token that appeared as `Unknown command: ...` in the report.
+    expect(cmd).not.toContain('B:/~BUN/root/archon-windows-x64.exe');
+    expect(cmd[1]).toBe('workflow');
+    expect(cmd[2]).toBe('run');
   });
 });
 

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -240,12 +240,18 @@ export function buildDetachedRunCmd(
   cwd: string,
   extraArgs: string[]
 ): string[] {
-  // In a compiled binary, execPath IS the archon binary and there is no
-  // entry-script argv[1]; in dev, execPath is bun and argv[1] is the cli entry.
+  // Only the command prefix differs between modes: in a compiled binary
+  // execPath IS the archon binary and re-invoking it needs no entry script; in
+  // dev, execPath is bun and argv[1] is the cli entry that bun must be handed.
   const baseCmd = isBinary ? [execPath] : [execPath, argv[1]];
-  const userArgs = (isBinary ? argv.slice(1) : argv.slice(2)).filter(
-    arg => arg !== '--detach' && arg !== '--json'
-  );
+  // User args always start at argv[2] in BOTH modes. A Bun single-file
+  // executable does have an argv[1] — the virtual entry path
+  // (`/$bunfs/root/<name>`, `B:/~BUN/root/<name>.exe` on Windows) — so slicing
+  // from 1 in binary mode leaked that path in as the child's first token and
+  // the child died with `Unknown command: B:/~BUN/root/archon-...exe` (#2248).
+  // cli.ts's own parser reads `process.argv.slice(2)` unconditionally, which is
+  // the contract this must match.
+  const userArgs = argv.slice(2).filter(arg => arg !== '--detach' && arg !== '--json');
   // --cwd is appended last (parseArgs last-wins) so the child resolves the same
   // absolute working dir regardless of any relative --cwd the caller passed.
   return [...baseCmd, ...userArgs, '--cwd', cwd, ...extraArgs];


### PR DESCRIPTION
## Summary

- **Problem:** `buildDetachedRunCmd` assumed a compiled binary has no entry-script `argv[1]` and sliced user args from `argv[1]` in binary mode. Bun single-file executables **do** have an `argv[1]` — the virtual entry path (`/$bunfs/root/<name>`, or `B:/~BUN/root/<name>.exe` on Windows) — and report `argv[0]` as `bun`, not `execPath`. That virtual path leaked in as the detached child's first token.
- **Why it matters:** `cli.ts` parses `process.argv.slice(2)` unconditionally, so the child read the virtual path as its command and died with `Unknown command: B:/~BUN/root/archon-windows-x64.exe` — no run record, no worktree, no branch — while the parent still exited 0 with `{ ok: true, conversationId, logPath }`. `--detach` is therefore broken on **every compiled binary**, which is the primary distribution channel (brew / curl install). Reported on Windows x64 and independently reproduced on Ubuntu 24.04 x64, so this is not platform-specific.
- **What changed:** user args are sliced from `argv[2]` in **both** modes; only the command prefix still branches on `isBinary`. The stale comment asserting "there is no entry-script argv[1]" is corrected. The existing binary-mode test fixture — which modelled a compiled argv with no `argv[1]` at all, and so certified the broken behaviour — is corrected to the real Bun SFE shape, plus a Windows-shaped regression test.
- **What did *not* change (scope boundary):** `baseCmd` still branches on `isBinary` (correct as-is). No change to spawn options, log-file handling, `--cwd` last-wins appending, or the `--detach`/`--json` filter. #2080 (detached child not surviving launcher teardown) is a distinct Windows failure already addressed in v0.6.0 and is untouched here.

## UX Journey

### Before

```
  User                        archon (parent, compiled)          detached child
  ────                        ─────────────────────────          ──────────────
  archon workflow run X
    --detach --json ────────▶ builds child argv
                              [execPath, "B:/~BUN/root/          spawn ─────────▶ cli.ts: argv.slice(2)
                               archon.exe", "workflow", ...]                      → command = "B:/~BUN/
                                                                                     root/archon.exe"
                              prints {ok:true, ...}                               ✗ Unknown command
  sees success ◀────────────  exit 0                                              ✗ exits immediately

  archon workflow get <id> ─▶ "Workflow run not found"
  ✗ no run, no worktree, no branch — parent reported success
```

### After

```
  User                        archon (parent, compiled)          detached child
  ────                        ─────────────────────────          ──────────────
  archon workflow run X
    --detach --json ────────▶ builds child argv
                              [execPath, *"workflow"*, ...]      spawn ─────────▶ cli.ts: argv.slice(2)
                              *virtual argv[1] dropped*                           → command = *"workflow"*
                              prints {ok:true, ...}                               ✓ run created
  sees success ◀────────────  exit 0                                              ✓ worktree + branch

  archon workflow get <id> ─▶ run record found, status streams
  ✓ parent's success report now matches reality
```

## Architecture Diagram

### Before

```
  packages/cli/src/commands/workflow.ts
  ┌──────────────────────────────────┐
  │ buildDetachedRunCmd()            │  isBinary ? argv.slice(1)   ← WRONG
  │   (pure argv builder)            │            : argv.slice(2)
  └───────────┬──────────────────────┘
              │ cmd[]
  ┌───────────▼──────────────────────┐
  │ spawnDetachedWorkflowRun()       │  spawn(cmd[0], cmd.slice(1), {detached})
  └───────────┬──────────────────────┘
              │ child process
  ┌───────────▼──────────────────────┐
  │ packages/cli/src/cli.ts          │  process.argv.slice(2)  ← contract mismatch
  │   main() arg parser              │  → "Unknown command"
  └──────────────────────────────────┘
```

### After

```
  packages/cli/src/commands/workflow.ts
  ┌──────────────────────────────────┐
  │ [~] buildDetachedRunCmd()        │  argv.slice(2) in BOTH modes
  │     (pure argv builder)          │  baseCmd still branches on isBinary
  └───────────┬══════════════════════┘
              ║ cmd[]  (== corrected edge)
  ┌───────────▼──────────────────────┐
  │ spawnDetachedWorkflowRun()       │  unchanged
  └───────────┬──────────────────────┘
              │ child process
  ┌───────────▼──────────────────────┐
  │ packages/cli/src/cli.ts          │  process.argv.slice(2)
  │   main() arg parser              │  ✓ contract now honoured
  └──────────────────────────────────┘
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `buildDetachedRunCmd` | `spawnDetachedWorkflowRun` | **modified** | Emitted argv no longer carries the Bun SFE virtual entry path |
| `spawnDetachedWorkflowRun` | detached `cli.ts main()` | **modified** | Child's `argv.slice(2)` now yields the real command; previously the virtual path |
| `workflow.test.ts` | `buildDetachedRunCmd` | **modified** | Binary-mode fixture corrected to real SFE argv; Windows regression test added |
| `cli.ts main()` | — | unchanged | Parser untouched; it was already correct |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `cli`
- Module: `cli:workflow`

## Change Metadata

- Change type: `bug`
- Primary scope: `cli`

## Linked Issue

- Closes #2248
- Related #2080 (distinct Windows detach failure — child not surviving launcher teardown; already fixed in v0.6.0, untouched here)

## Validation Evidence (required)

```bash
bun run validate     # → exit 0 (all nine gates: check:bundled, check:bundled-skill,
                     #   check:bundled-schema, check:pi-vendor-map,
                     #   check:capability-matrix, type-check, lint, format:check, test)
```

- **Evidence provided:**

  **1. Empirical confirmation of Bun SFE argv shape.** Built a throwaway artifact with `bun build --compile` (Bun 1.3.13, macOS arm64) and printed its argv:

  ```
  $ ./argvprobe workflow run foo
  { "execPath": "/…/argvprobe",
    "argv": [ "bun", "/$bunfs/root/argvprobe", "workflow", "run", "foo" ] }
  ```

  `argv[0]` is `bun` (not execPath) and `argv[1]` is the virtual entry path — directly contradicting the comment the old code relied on.

  **2. Fix proven against that real argv:**

  ```
  CURRENT (broken): [<archon>, "/$bunfs/root/fixprobe", "workflow", "run", "assist", "hello"]
  FIXED  slice(2) : [<archon>, "workflow", "run", "assist", "hello"]
  ```

  **3. New tests fail against the previous implementation** (reverted the one-line change and re-ran):

  ```
  (fail) binary mode: … drops the Bun SFE virtual argv[1]
         Expected: false  Received: true      ← $bunfs path present in cmd
  (fail) binary mode: drops the Windows Bun SFE virtual argv[1] (#2248 repro)
         Expected to not contain: "B:/~BUN/root/archon-windows-x64.exe"
         Received: [ "C:\\Users\\dev\\archon.exe", "B:/~BUN/root/archon-windows-x64.exe", …
  ```

  The received array reproduces the reported symptom token-for-token. With the fix applied: `3 pass, 0 fail`; full `@archon/cli` suite `0 fail` across all 6 batches.

- **If any command is intentionally skipped:** none skipped.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No**

Net effect is *removing* an unintended token from a spawned child's argv. The child is the same trusted `execPath` the parent is already running.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Database migration needed? **No**

Dev-mode (`bun` + entry script) behaviour is byte-for-byte identical: that branch already sliced from `argv[2]`. Only the compiled-binary branch changes, and only from broken to working.

## Human Verification (required)

- **Verified scenarios:** Bun SFE argv shape confirmed against a real `bun build --compile` artifact rather than assumed from the report; fix output diffed against that same real argv; both new tests confirmed red against the old implementation and green against the new one; full `bun run validate` exit 0.
- **Edge cases checked:** dev-mode path unchanged (test still green with its original fixture); Windows-shaped `B:/~BUN/…` argv covered by a dedicated test; grepped the whole repo for other `process.argv` consumers — the only other one is `cli.ts:239`, which already uses `slice(2)` and is the contract this now matches.
- **What was not verified:** I did not run a released Windows x64 binary end-to-end (no Windows hardware). The Windows case is covered by unit test using the exact argv token from the report, and by the reporter's Linux reproduction of the identical root cause. A maintainer with a Windows box may want to confirm the end-to-end `--detach` run before release.

## Side Effects / Blast Radius (required)

- **Affected subsystems/workflows:** only `archon workflow run --detach` on compiled binaries. Foreground runs never call this builder.
- **Potential unintended effects:** if any caller relied on the leaked virtual path reaching the child, it would break — but nothing can have, since the child rejected it as an unknown command and exited.
- **Guardrails/monitoring for early detection:** the detached child's stdout/stderr already land in `ARCHON_HOME/logs/detached-run-<conversationId>.log`; a regression reappears there immediately as `Unknown command: …`. The two new unit tests fail loudly on any reintroduction.

## Rollback Plan (required)

- **Fast rollback command/path:** `git revert <merge-sha>` — the change is one expression plus tests in a single file pair, no migrations or state.
- **Feature flags or config toggles:** none (not warranted for a one-line argv correction).
- **Observable failure symptoms:** `archon workflow run --detach` returns `{ ok: true }` but `archon workflow get <conversationId>` reports `Workflow run not found`, and the detached log contains `Unknown command: <virtual path>`.

## Risks and Mitigations

- **Risk:** a future Bun release changes SFE argv shape again (e.g. drops the virtual `argv[1]`), making `slice(2)` wrong in the other direction.
  - **Mitigation:** `slice(2)` is now anchored to the same contract `cli.ts:239` uses, so the two move together — a Bun change would break the CLI's own parser first and far more loudly than the detach path. The tests document the observed shape and the Bun version it was verified against.
- **Risk:** Windows end-to-end behaviour unverified on real hardware (see Human Verification).
  - **Mitigation:** root cause is argv construction, which is platform-independent and unit-tested with the exact Windows token from the report; the Linux reproduction confirms the mechanism is not OS-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed detached workflow commands for compiled Bun “single-file executable” mode by correctly stripping the virtual argv entry token before building the child command.
  * Ensured `--detach`/`--json` are consistently omitted, while `--cwd` and any additional flags are preserved.
  * Added a Windows regression coverage to prevent the virtual argv token from leaking into detached workflow arguments.

* **Tests**
  * Updated and extended unit tests for detached workflow argv construction, including the Windows scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->