### PR TITLE
fix(cli): doctor honors claudeBinaryPath config fallback (#2263)

### DIFF
--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -26,6 +26,7 @@ import {
   checkTelegram,
   checkTelemetry,
   checkFolderProject,
+  defaultLoadClaudeBinaryDeps,
   doctorCommand,
   type ClaudeBinaryDeps,
   type CodexBinaryDeps,
@@ -34,6 +35,7 @@ import {
   type OpenCodeDeps,
 } from './doctor';
 import * as doctorModule from './doctor';
+import type { MergedConfig } from '@archon/core';
 
 describe('checkClaudeBinary', () => {
   let execSpy: ReturnType<typeof spyOn<typeof git, 'execFileAsync'>>;
@@ -136,6 +138,44 @@ describe('checkClaudeBinary', () => {
     );
     // A broken config must not fail the binary check outright.
     expect(result.status).toBe('pass');
+  });
+
+  // The tests above inject BOTH seams, so they only prove parameter plumbing
+  // inside checkClaudeBinary. The two below exercise the real
+  // defaultLoadClaudeBinaryDeps, which is where #2263 actually lived: reading
+  // the wrong config key type-checks and would otherwise ship green.
+  // The stub config deliberately carries a DIFFERENT value under
+  // assistants.codex.codexBinaryPath so a key mix-up fails loudly rather than
+  // resolving to the same string by accident.
+  const stubConfig = async (): Promise<Pick<MergedConfig, 'assistants'>> => ({
+    assistants: {
+      claude: { claudeBinaryPath: '/from/claude/config' },
+      codex: { codexBinaryPath: '/from/codex/config' },
+    },
+  });
+
+  it('reads assistants.claude.claudeBinaryPath, not another assistant key (#2263)', async () => {
+    const deps = await defaultLoadClaudeBinaryDeps(stubConfig);
+    expect(deps.configBinaryPath).toBe('/from/claude/config');
+  });
+
+  it('routes the real deps loader through to the resolver (#2263 wiring guard)', async () => {
+    execSpy.mockResolvedValue({ stdout: '1.0.0', stderr: '' });
+    let sawConfigPath: string | undefined;
+
+    const result = await checkClaudeBinary(
+      true,
+      // The real loader, not a fake — this is the link the bug broke.
+      () => defaultLoadClaudeBinaryDeps(stubConfig),
+      async configPath => {
+        sawConfigPath = configPath;
+        return { path: configPath as string, source: 'config' };
+      }
+    );
+
+    expect(sawConfigPath).toBe('/from/claude/config');
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('via config');
   });
 });
 

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -27,6 +27,7 @@ import {
   checkTelemetry,
   checkFolderProject,
   doctorCommand,
+  type ClaudeBinaryDeps,
   type CodexBinaryDeps,
   type DatabaseDeps,
   type FolderProjectDeps,
@@ -45,23 +46,32 @@ describe('checkClaudeBinary', () => {
     execSpy.mockRestore();
   });
 
+  const noDeps = async (): Promise<ClaudeBinaryDeps> => ({});
+
   it('returns skip when not in binary mode', async () => {
-    const result = await checkClaudeBinary({}, false);
+    const result = await checkClaudeBinary(false);
     expect(result.status).toBe('skip');
     expect(result.label).toBe('Claude binary');
     expect(execSpy).not.toHaveBeenCalled();
   });
 
-  it('returns fail in binary mode when CLAUDE_BIN_PATH is unset', async () => {
-    const result = await checkClaudeBinary({}, true);
+  it('returns fail in binary mode when the whole resolution chain is empty', async () => {
+    const result = await checkClaudeBinary(true, noDeps, async () => {
+      throw new Error('Claude Code not found. Archon requires the Claude Code executable');
+    });
     expect(result.status).toBe('fail');
-    expect(result.message).toContain('CLAUDE_BIN_PATH');
+    // The resolver's install instructions are surfaced verbatim — they are the
+    // actionable message, unlike the old "CLAUDE_BIN_PATH is not set".
+    expect(result.message).toContain('Claude Code not found');
     expect(execSpy).not.toHaveBeenCalled();
   });
 
   it('returns pass in binary mode when binary spawns successfully', async () => {
     execSpy.mockResolvedValue({ stdout: '1.0.0', stderr: '' });
-    const result = await checkClaudeBinary({ CLAUDE_BIN_PATH: '/opt/claude' }, true);
+    const result = await checkClaudeBinary(true, noDeps, async () => ({
+      path: '/opt/claude',
+      source: 'env',
+    }));
     expect(result.status).toBe('pass');
     expect(result.message).toContain('/opt/claude');
     expect(execSpy).toHaveBeenCalledWith('/opt/claude', ['--version'], expect.any(Object));
@@ -69,10 +79,63 @@ describe('checkClaudeBinary', () => {
 
   it('returns fail in binary mode when spawn throws', async () => {
     execSpy.mockRejectedValue(new Error('ENOENT'));
-    const result = await checkClaudeBinary({ CLAUDE_BIN_PATH: '/opt/claude' }, true);
+    const result = await checkClaudeBinary(true, noDeps, async () => ({
+      path: '/opt/claude',
+      source: 'env',
+    }));
     expect(result.status).toBe('fail');
     expect(result.message).toContain('did not spawn');
     expect(result.message).toContain('ENOENT');
+  });
+
+  // #2263: doctor previously read only CLAUDE_BIN_PATH and hard-FAILed setups
+  // configured via assistants.claude.claudeBinaryPath — the documented fix for
+  // compiled builds — even though those setups run workflows fine.
+  it('passes when the binary comes from config rather than CLAUDE_BIN_PATH (#2263)', async () => {
+    execSpy.mockResolvedValue({ stdout: '1.0.0', stderr: '' });
+    let sawConfigPath: string | undefined;
+    const result = await checkClaudeBinary(
+      true,
+      async () => ({ configBinaryPath: '/Users/me/bin/claude' }),
+      async configPath => {
+        sawConfigPath = configPath;
+        return { path: configPath as string, source: 'config' };
+      }
+    );
+
+    // The config path must actually reach the resolver, not be ignored.
+    expect(sawConfigPath).toBe('/Users/me/bin/claude');
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('/Users/me/bin/claude');
+    // Which tier resolved it is surfaced so users can see what the runtime does.
+    expect(result.message).toContain('via config');
+    expect(result.message).not.toContain('CLAUDE_BIN_PATH is not set');
+  });
+
+  it('reports the autodetect tier when the native installer path resolves', async () => {
+    execSpy.mockResolvedValue({ stdout: '1.0.0', stderr: '' });
+    const result = await checkClaudeBinary(true, noDeps, async () => ({
+      path: '/home/me/.local/bin/claude',
+      source: 'autodetect',
+    }));
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('via autodetect');
+  });
+
+  it('degrades to env/autodetect when config loading throws', async () => {
+    execSpy.mockResolvedValue({ stdout: '1.0.0', stderr: '' });
+    const result = await checkClaudeBinary(
+      true,
+      async () => {
+        throw new Error('malformed config.yaml');
+      },
+      async configPath => {
+        expect(configPath).toBeUndefined();
+        return { path: '/opt/claude', source: 'env' };
+      }
+    );
+    // A broken config must not fail the binary check outright.
+    expect(result.status).toBe('pass');
   });
 });
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -18,7 +18,7 @@ import {
   resolveClaudeBinaryWithSource,
   type ClaudeBinaryResolution,
 } from '@archon/providers/claude/binary-resolver';
-import type { Codebase, SchemaVersionInfo } from '@archon/core';
+import type { Codebase, MergedConfig, SchemaVersionInfo } from '@archon/core';
 
 // Vendor-canonical credential id for Codex (since #1955 credentials are keyed
 // by vendor, not agent). A connected `openai` key signals Codex intent even
@@ -125,11 +125,19 @@ export async function checkClaudeBinary(
   }
 }
 
-async function defaultLoadClaudeBinaryDeps(): Promise<ClaudeBinaryDeps> {
-  // Lazy import so doctor doesn't pull the full @archon/core graph for an
-  // unrelated check (matches defaultLoadCodexBinaryDeps).
-  const { loadConfig } = await import('@archon/core');
-  const config = await loadConfig(process.cwd());
+export async function defaultLoadClaudeBinaryDeps(
+  // Injected so the config-key mapping — the tier #2263 was actually about —
+  // can be asserted without mock.module(), which is process-global and would
+  // leak into every other test in this file's batch. Defaults to the real
+  // lazy import so the production path is the zero-argument call.
+  loadMergedConfig: (cwd: string) => Promise<Pick<MergedConfig, 'assistants'>> = async cwd => {
+    // Lazy import so doctor doesn't pull the full @archon/core graph for an
+    // unrelated check (matches defaultLoadCodexBinaryDeps).
+    const { loadConfig } = await import('@archon/core');
+    return loadConfig(cwd);
+  }
+): Promise<ClaudeBinaryDeps> {
+  const config = await loadMergedConfig(process.cwd());
   return { configBinaryPath: config.assistants.claude.claudeBinaryPath };
 }
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -16,7 +16,7 @@ import {
 } from '@archon/providers/codex/binary-resolver';
 import {
   resolveClaudeBinaryWithSource,
-  type ClaudeBinarySource,
+  type ClaudeBinaryResolution,
 } from '@archon/providers/claude/binary-resolver';
 import type { Codebase, SchemaVersionInfo } from '@archon/core';
 
@@ -77,9 +77,7 @@ export async function checkClaudeBinary(
   loadDeps: () => Promise<ClaudeBinaryDeps> = defaultLoadClaudeBinaryDeps,
   resolve: (
     configPath?: string
-  ) => Promise<
-    { path: string; source: ClaudeBinarySource } | undefined
-  > = resolveClaudeBinaryWithSource
+  ) => Promise<ClaudeBinaryResolution | undefined> = resolveClaudeBinaryWithSource
 ): Promise<CheckResult> {
   const label = 'Claude binary';
   if (!isBinary) {
@@ -96,7 +94,7 @@ export async function checkClaudeBinary(
     deps = {};
   }
 
-  let resolved: { path: string; source: ClaudeBinarySource } | undefined;
+  let resolved: ClaudeBinaryResolution | undefined;
   try {
     resolved = await resolve(deps.configBinaryPath);
   } catch (err) {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -14,6 +14,10 @@ import {
   resolveCodexBinaryWithSource,
   type CodexBinarySource,
 } from '@archon/providers/codex/binary-resolver';
+import {
+  resolveClaudeBinaryWithSource,
+  type ClaudeBinarySource,
+} from '@archon/providers/claude/binary-resolver';
 import type { Codebase, SchemaVersionInfo } from '@archon/core';
 
 // Vendor-canonical credential id for Codex (since #1955 credentials are keyed
@@ -47,34 +51,88 @@ export interface CheckResult {
   message: string;
 }
 
+export interface ClaudeBinaryDeps {
+  /** `assistants.claude.claudeBinaryPath` from the merged config, if configured. */
+  configBinaryPath?: string;
+}
+
+/**
+ * Verify the Claude Code binary resolves and spawns.
+ *
+ * Delegates to the SAME resolver the runtime uses
+ * (`resolveClaudeBinaryWithSource`) instead of reading `CLAUDE_BIN_PATH`
+ * directly, and reports which tier produced the path (env / config /
+ * autodetect). Reading only the env var made doctor report a hard FAIL on
+ * setups that run fine, because `assistants.claude.claudeBinaryPath` is the
+ * documented way to configure compiled builds — training users to ignore the
+ * one tool meant to catch real environment breakage (#2263).
+ */
 export async function checkClaudeBinary(
-  env: NodeJS.ProcessEnv,
   // Injected so tests can drive the binary-mode branch — `BUNDLED_IS_BINARY`
-  // is a static const re-export and cannot be spied at runtime.
-  isBinary: boolean = BUNDLED_IS_BINARY
+  // is a static const re-export and cannot be spied at runtime. Kept (rather
+  // than inferred from a nullish resolve result like `checkCodexBinary` does)
+  // because Claude's resolver honors CLAUDE_BIN_PATH in dev mode too, so a
+  // truthy result is NOT proof of binary mode.
+  isBinary: boolean = BUNDLED_IS_BINARY,
+  loadDeps: () => Promise<ClaudeBinaryDeps> = defaultLoadClaudeBinaryDeps,
+  resolve: (
+    configPath?: string
+  ) => Promise<
+    { path: string; source: ClaudeBinarySource } | undefined
+  > = resolveClaudeBinaryWithSource
 ): Promise<CheckResult> {
   const label = 'Claude binary';
   if (!isBinary) {
     return { label, status: 'skip', message: 'dev mode (SDK resolves via node_modules)' };
   }
-  const path = env.CLAUDE_BIN_PATH;
-  if (!path) {
+
+  let deps: ClaudeBinaryDeps;
+  try {
+    deps = await loadDeps();
+  } catch (err) {
+    // Config load can throw (e.g. malformed YAML) — degrade to env/autodetect
+    // rather than failing the whole check. Mirrors checkCodexBinary.
+    getLog().debug({ err }, 'doctor.claude_deps_load_failed');
+    deps = {};
+  }
+
+  let resolved: { path: string; source: ClaudeBinarySource } | undefined;
+  try {
+    resolved = await resolve(deps.configBinaryPath);
+  } catch (err) {
+    // Binary mode + whole chain empty → the resolver throws with install
+    // instructions. That message is the actionable one, so surface it verbatim.
+    return { label, status: 'fail', message: (err as Error).message };
+  }
+
+  // Defensive: the resolver only returns undefined outside binary mode, which
+  // the isBinary guard above already handled.
+  if (!resolved) {
+    return { label, status: 'skip', message: 'dev mode (SDK resolves via node_modules)' };
+  }
+
+  try {
+    await execFileAsync(resolved.path, ['--version'], { timeout: 5000 });
     return {
       label,
-      status: 'fail',
-      message: 'CLAUDE_BIN_PATH is not set. Run `archon setup` to configure.',
+      status: 'pass',
+      message: `${resolved.path} (via ${resolved.source}, spawns OK)`,
     };
-  }
-  try {
-    await execFileAsync(path, ['--version'], { timeout: 5000 });
-    return { label, status: 'pass', message: `${path} (spawns OK)` };
   } catch (err) {
     return {
       label,
       status: 'fail',
-      message: `${path} did not spawn: ${(err as Error).message}`,
+      message: `${resolved.path} did not spawn: ${(err as Error).message}`,
     };
   }
+}
+
+async function defaultLoadClaudeBinaryDeps(): Promise<ClaudeBinaryDeps> {
+  // Lazy import so doctor doesn't pull the full @archon/core graph for an
+  // unrelated check (matches defaultLoadCodexBinaryDeps).
+  const { loadConfig } = await import('@archon/core');
+  const config = await loadConfig(process.cwd());
+  return { configBinaryPath: config.assistants.claude.claudeBinaryPath };
 }
 
 export interface CodexBinaryDeps {
@@ -670,7 +728,7 @@ export async function doctorCommand(
   const promises = checks
     ? checks.map(fn => fn())
     : [
-        checkClaudeBinary(env),
+        checkClaudeBinary(),
         checkCodexBinary(env),
         checkGhAuth(env),
         checkPi(env),

--- a/packages/providers/src/claude/binary-resolver.test.ts
+++ b/packages/providers/src/claude/binary-resolver.test.ts
@@ -62,6 +62,12 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
 
     const result = await resolver.resolveClaudeBinaryPath('/custom/claude/cli.js');
     expect(result).toBe('/custom/claude/cli.js');
+    // Mislabeling this tier as 'env' ships green but makes doctor print
+    // "via env" for a config-resolved path — the exact diagnostic #2263 added.
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { binaryPath: '/custom/claude/cli.js', source: 'config' },
+      'claude.binary_resolved'
+    );
   });
 
   test('throws when config claudeBinaryPath file does not exist', async () => {

--- a/packages/providers/src/claude/binary-resolver.ts
+++ b/packages/providers/src/claude/binary-resolver.ts
@@ -112,6 +112,9 @@ const INSTALL_INSTRUCTIONS =
   '        claudeBinaryPath: /absolute/path/to/claude\n\n' +
   'See: https://archon.diy/docs/reference/configuration#claude';
 
+/** Which resolution tier produced the Claude binary path. */
+export type ClaudeBinarySource = 'env' | 'config' | 'autodetect';
+
 /**
  * Resolve the path to the Claude Code executable (native binary in SDK 0.2.x;
  * legacy `cli.js` is still accepted for operators pinned to npm-installed
@@ -126,6 +129,21 @@ const INSTALL_INSTRUCTIONS =
 export async function resolveClaudeBinaryPath(
   configClaudeBinaryPath?: string
 ): Promise<string | undefined> {
+  const resolved = await resolveClaudeBinaryWithSource(configClaudeBinaryPath);
+  return resolved?.path;
+}
+
+/**
+ * Same resolution as {@link resolveClaudeBinaryPath}, but also reports which
+ * tier produced the path. Used by `archon doctor` to tell the user how the
+ * binary was found (env / config / autodetect) instead of asserting that only
+ * `CLAUDE_BIN_PATH` counts (#2263). Returns undefined when the SDK should
+ * resolve the binary itself; throws with install instructions in binary mode
+ * when the whole chain comes up empty.
+ */
+export async function resolveClaudeBinaryWithSource(
+  configClaudeBinaryPath?: string
+): Promise<{ path: string; source: ClaudeBinarySource } | undefined> {
   // 1. Environment variable override — honored in dev mode too, so operators
   // on libc mismatches (e.g. glibc host with the SDK's musl variant first in
   // its resolution order) can pin a known-good binary without a compiled build.
@@ -133,7 +151,7 @@ export async function resolveClaudeBinaryPath(
   if (envPath) {
     const resolvedEnv = validateAndExpand(envPath, 'CLAUDE_BIN_PATH');
     getLog().info({ binaryPath: resolvedEnv, source: 'env' }, 'claude.binary_resolved');
-    return resolvedEnv;
+    return { path: resolvedEnv, source: 'env' };
   }
 
   if (!BUNDLED_IS_BINARY) return undefined;
@@ -145,7 +163,7 @@ export async function resolveClaudeBinaryPath(
       'assistants.claude.claudeBinaryPath'
     );
     getLog().info({ binaryPath: resolvedConfig, source: 'config' }, 'claude.binary_resolved');
-    return resolvedConfig;
+    return { path: resolvedConfig, source: 'config' };
   }
 
   // 3. Autodetect — the Anthropic native installer
@@ -161,7 +179,7 @@ export async function resolveClaudeBinaryPath(
       { binaryPath: nativeInstallerPath, source: 'autodetect' },
       'claude.binary_resolved'
     );
-    return nativeInstallerPath;
+    return { path: nativeInstallerPath, source: 'autodetect' };
   }
 
   // 4. Not found — throw with install instructions

--- a/packages/providers/src/claude/binary-resolver.ts
+++ b/packages/providers/src/claude/binary-resolver.ts
@@ -115,6 +115,12 @@ const INSTALL_INSTRUCTIONS =
 /** Which resolution tier produced the Claude binary path. */
 export type ClaudeBinarySource = 'env' | 'config' | 'autodetect';
 
+/** A resolved Claude binary path plus the tier that produced it. */
+export interface ClaudeBinaryResolution {
+  path: string;
+  source: ClaudeBinarySource;
+}
+
 /**
  * Resolve the path to the Claude Code executable (native binary in SDK 0.2.x;
  * legacy `cli.js` is still accepted for operators pinned to npm-installed
@@ -143,7 +149,7 @@ export async function resolveClaudeBinaryPath(
  */
 export async function resolveClaudeBinaryWithSource(
   configClaudeBinaryPath?: string
-): Promise<{ path: string; source: ClaudeBinarySource } | undefined> {
+): Promise<ClaudeBinaryResolution | undefined> {
   // 1. Environment variable override — honored in dev mode too, so operators
   // on libc mismatches (e.g. glibc host with the SDK's musl variant first in
   // its resolution order) can pin a known-good binary without a compiled build.


### PR DESCRIPTION
## Summary

- **Problem:** `checkClaudeBinary` read only `env.CLAUDE_BIN_PATH` and hard-failed when it was unset. The runtime resolver (`resolveClaudeBinaryPath`) has a documented three-tier chain: `CLAUDE_BIN_PATH` → `assistants.claude.claudeBinaryPath` (binary mode) → native-installer autodetect. Doctor therefore FAILed setups the runtime runs happily.
- **Why it matters:** the config-file path is the documented fix for compiled builds and the README points users to it, so anyone who followed the docs got a permanent false `✗ Claude binary: CLAUDE_BIN_PATH is not set` while workflows dispatched and ran fine. A doctor that fails working setups trains users to ignore its output.
- **What changed:** doctor now calls the same resolver the runtime uses and reports which tier produced the path (`via env` / `via config` / `via autodetect`), failing only when the whole chain comes up empty — and in that case surfaces the resolver's install instructions verbatim instead of a misleading env-var message. `resolveClaudeBinaryWithSource` is added alongside `resolveClaudeBinaryPath` (which now delegates to it), structured exactly like the existing Codex resolver.
- **What did *not* change (scope boundary):** resolution *order* and *semantics* are untouched — all existing Claude resolver tests pass unchanged. Dev-mode skip behavior is unchanged. No other doctor check touched. `checkCodexBinary` untouched (it was already correct, and is the precedent this follows).

## Review Follow-ups

- **Wiring test added** (67b50c1b) — see Validation Evidence below.
- **`ClaudeBinaryResolution` extracted** (08c4d0ab) — the `{ path, source }` shape had been hand-copied into both the resolver's return type and doctor's `resolve` parameter.
- Left to maintainers per review: the `cli.md:91` docs line, `checkClaudeBinary`'s hard-FAIL for Codex-only users, and the dev-mode `CLAUDE_BIN_PATH` blind spot.

## Change Metadata

- Change type: `bug`
- Primary scope: `cli`
- Risk: `risk: low` · Size: `size: S` · Module: `cli:doctor`

## Linked Issue

- Closes #2263

## Validation Evidence (required)

```bash
bun run validate     # → exit 0 (all nine gates), 6373 pass / 0 fail
```

**1. The doctor→config wiring is now guarded, and the guard is proven to bite.** The original tests injected *both* the deps loader and the resolver, so they only exercised parameter plumbing inside `checkClaudeBinary`; `defaultLoadClaudeBinaryDeps` — which reads `assistants.claude.claudeBinaryPath`, the tier #2263 was about — ran in no test.

It now takes the merged-config loader as an injected parameter defaulting to the real lazy import, so the mapping is assertable without `mock.module()` (process-global, and this file avoids it by design). Two tests cover it: one on the deps function directly, one driving `checkClaudeBinary` through the *real* loader to assert the configured path reaches the resolver. The stub config carries a different value under `codexBinaryPath` so a key mix-up cannot pass by coincidence.

Verified by making the exact swap from the review — `config.assistants.codex.codexBinaryPath`:

```
(fail) checkClaudeBinary > reads assistants.claude.claudeBinaryPath, not another assistant key (#2263)
(fail) checkClaudeBinary > routes the real deps loader through to the resolver (#2263 wiring guard)
 69 pass, 2 fail
```

Both new tests fail, nothing else does. Coverage under the doctor suite alone moved from `doctor.ts` `128-132` uncovered (the whole deps-function body) to `133-136` — only the lazy `import('@archon/core')` inside the default argument, which is unreachable without `mock.module()` or a real config read.

`binary-resolver.ts` remains at 0% function coverage *under the doctor suite* — exercising the real resolver there needs a binary on disk. It is covered by its own 18-test suite; the seam this PR was asked to guard is the config→deps→resolver hand-off, which is now asserted.

**2. The config tier's source label is now asserted** (`binary-resolver.test.ts`). It was the one tier whose label nothing checked; mislabeling it ships green while doctor prints "via env" for a config-resolved path.

**3. The config link is real, not assumed.** Wrote an actual `~/.archon/config.yaml` with the snippet from the issue and ran `loadConfig` against it: `claudeBinaryPath = "/Users/me/bin/claude"`.

**4. Refactor is behavior-preserving.** All existing Claude resolver tests pass untouched: `binary-resolver.test.ts` 18 pass / 0 fail, `binary-resolver-dev.test.ts` 8 pass / 0 fail. Doctor suite: 71 pass / 0 fail.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No** — doctor already spawned the resolved binary with `--version`; it now spawns the path the runtime would have used anyway. Config reading is a lazy import of the same `loadConfig` other checks already call.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Database migration needed? **No**

`CLAUDE_BIN_PATH` remains the highest-priority tier, so existing env-var setups behave identically (message gains a `via env` annotation). Setups that were correctly failing still fail, with a more actionable message. `resolveClaudeBinaryPath`'s signature and return type are unchanged, so `claude/provider.ts` is unaffected. `defaultLoadClaudeBinaryDeps` gained an optional parameter; the production call site is still the zero-argument default.

## Human Verification (required)

- **Verified scenarios:** the config-key regression guard proven to fail on the wrong key (executed, output above); `loadConfig` surfacing `claudeBinaryPath` from a real config file (executed, not mocked); resolver refactor proven non-breaking by the pre-existing tests passing unchanged; all four resolution outcomes (env / config / autodetect / empty-chain) covered; config-load failure path exercised.
- **Edge cases checked:** dev mode still skips (the `isBinary` guard is deliberately kept rather than inferring dev mode from a nullish resolve result the way `checkCodexBinary` does — Claude's resolver honors `CLAUDE_BIN_PATH` in dev mode too, so a truthy result is *not* proof of binary mode); malformed config degrades instead of failing; `CLAUDE_BIN_PATH` still wins over config.
- **What was not verified:** I did not run this from an actual compiled binary on the reporter's platform — `BUNDLED_IS_BINARY` is a compile-time const, so the binary branch is only reachable in tests via the injected `isBinary` seam. The reporter is on v0.6.0 macOS arm64 and can confirm against a release build. Autodetect tier was not exercised against a real `~/.local/bin/claude` on disk.

## Side Effects / Blast Radius (required)

- **Affected subsystems/workflows:** `archon doctor` output for the Claude binary check, and `archon setup` (which invokes doctor at the end and discards the result). No runtime/execution path changes — `resolveClaudeBinaryPath` behaves identically for `claude/provider.ts`.
- **Potential unintended effects:** doctor now performs a lazy `@archon/core` import + `loadConfig` for this check. That is already the established pattern for `checkCodexBinary` / `checkDatabase` / `checkConnectedProviders`, and failures are caught and degraded rather than propagated.
- **Guardrails/monitoring for early detection:** a config-load failure logs `doctor.claude_deps_load_failed` at debug. A regression re-surfaces as the literal string `CLAUDE_BIN_PATH is not set`, asserted against by an existing test, or as a wrong config key, now asserted against by the new wiring tests.

## Rollback Plan (required)

- **Fast rollback command/path:** `git revert <merge-sha>`. Two source files plus tests, no migrations, no state, no config format change.
- **Feature flags or config toggles:** none (not warranted for a diagnostic-accuracy fix).
- **Observable failure symptoms:** `archon doctor` reporting `✗ Claude binary` on a machine where `archon workflow run` succeeds — i.e. the original bug.

## Risks and Mitigations

- **Risk:** doctor now depends on `loadConfig` succeeding for this check, adding a failure mode that did not exist before.
  - **Mitigation:** wrapped in try/catch that degrades to `{}` (env + autodetect still resolve), logged at debug, and covered by a dedicated test. Same posture as `checkCodexBinary`.
- **Risk:** `resolveClaudeBinaryPath` is on the hot path for every Claude run, and it was restructured.
  - **Mitigation:** it is now a two-line delegation to a function whose body is the original code verbatim; the pre-existing resolver tests (including the dev-mode suite) pass without modification, and its exported signature and return type are unchanged.
- **Risk:** binary-mode behavior unverified on a real compiled build (see Human Verification).
  - **Mitigation:** the binary branch is driven through the same injected `isBinary` seam the pre-existing tests already used; the resolver itself is shared with the runtime that reporters confirm works.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Claude Code executable detection across environment settings, configuration, and automatic discovery.
  - Diagnostics now identify how the executable was found.
  - Configured executable paths are recognized and validated.

- **Bug Fixes**
  - Claude binary checks now handle configuration-loading failures gracefully.
  - Improved error messages when Claude Code cannot be found or fails to start.
  - Non-binary installations correctly skip executable validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->