### PR TITLE
docs: fix PR template path + link agent files to CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@
 
 - `main` is the release branch. Never commit directly to `main`.
 - `dev` is the working branch. All feature work branches off `dev` and merges back into `dev`.
-- All PRs must use the template at `.github/PULL_REQUEST_TEMPLATE.md` — fill in every section. When opening a PR via `gh pr create`, copy the template into the body explicitly; GitHub only auto-applies it through the web UI.
+- All PRs must use the template at `.github/pull_request_template.md` — fill in every section. When opening a PR via `gh pr create`, copy the template into the body explicitly; GitHub only auto-applies it through the web UI.
 - Link the issue with `Closes #<number>` (or `Fixes` / `Resolves`) in the PR description so it auto-closes on merge.
 - To release, use the `/release` skill. It compares `dev` to `main`, generates changelog entries, bumps the version, and creates a PR to merge `dev` into `main`.
 - Releases follow Semantic Versioning: `/release` (patch), `/release minor`, `/release major`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@
 
 **Git Workflow and Releases**
 
+- **Read [`CONTRIBUTING.md`](./CONTRIBUTING.md) before committing or opening a PR.** It is the source of truth for contributor workflow and carries rules that are deliberately NOT duplicated here — notably commit-message conventions (present tense, first line under 72 characters) and the marketplace submission process. The bullets below cover branch/release policy only; they are not the complete contributor checklist.
 - `main` is the release branch. Never commit directly to `main`.
 - `dev` is the working branch. All feature work branches off `dev` and merges back into `dev`.
 - All PRs must use the template at `.github/pull_request_template.md` — fill in every section. When opening a PR via `gh pr create`, copy the template into the body explicitly; GitHub only auto-applies it through the web UI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,6 @@
 
 **Git Workflow and Releases**
 
-- **Read [`CONTRIBUTING.md`](./CONTRIBUTING.md) before committing or opening a PR.** It is the source of truth for contributor workflow and carries rules that are deliberately NOT duplicated here — notably commit-message conventions (present tense, first line under 72 characters) and the marketplace submission process. The bullets below cover branch/release policy only; they are not the complete contributor checklist.
 - `main` is the release branch. Never commit directly to `main`.
 - `dev` is the working branch. All feature work branches off `dev` and merges back into `dev`.
 - All PRs must use the template at `.github/pull_request_template.md` — fill in every section. When opening a PR via `gh pr create`, copy the template into the body explicitly; GitHub only auto-applies it through the web UI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,6 @@ Archon is being positioned as a governed agentic automation engine for business 
 - `loader.ts` uses `dagNodeSchema.safeParse()` for node validation; graph-level checks (cycles, deps, `$nodeId.output` refs) remain as imperative code in `validateDagStructure()`
 
 **Git Workflow and Releases**
-- **Read [`CONTRIBUTING.md`](./CONTRIBUTING.md) before committing or opening a PR.** It is the source of truth for contributor workflow and carries rules that are deliberately NOT duplicated here — notably commit-message conventions (present tense, first line under 72 characters) and the marketplace submission process. The bullets below cover branch/release policy only; they are not the complete contributor checklist.
 - `main` is the release branch. Never commit directly to `main`.
 - `dev` is the working branch. All feature work branches off `dev` and merges back into `dev`.
 - All PRs must use the template at `.github/pull_request_template.md` — fill in every section. When opening a PR via `gh pr create`, copy the template into the body explicitly; GitHub only auto-applies it through the web UI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ Archon is being positioned as a governed agentic automation engine for business 
 - `loader.ts` uses `dagNodeSchema.safeParse()` for node validation; graph-level checks (cycles, deps, `$nodeId.output` refs) remain as imperative code in `validateDagStructure()`
 
 **Git Workflow and Releases**
+- **Read [`CONTRIBUTING.md`](./CONTRIBUTING.md) before committing or opening a PR.** It is the source of truth for contributor workflow and carries rules that are deliberately NOT duplicated here — notably commit-message conventions (present tense, first line under 72 characters) and the marketplace submission process. The bullets below cover branch/release policy only; they are not the complete contributor checklist.
 - `main` is the release branch. Never commit directly to `main`.
 - `dev` is the working branch. All feature work branches off `dev` and merges back into `dev`.
 - All PRs must use the template at `.github/pull_request_template.md` — fill in every section. When opening a PR via `gh pr create`, copy the template into the body explicitly; GitHub only auto-applies it through the web UI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Archon is being positioned as a governed agentic automation engine for business 
 **Git Workflow and Releases**
 - `main` is the release branch. Never commit directly to `main`.
 - `dev` is the working branch. All feature work branches off `dev` and merges back into `dev`.
-- All PRs must use the template at `.github/PULL_REQUEST_TEMPLATE.md` — fill in every section. When opening a PR via `gh pr create`, copy the template into the body explicitly; GitHub only auto-applies it through the web UI.
+- All PRs must use the template at `.github/pull_request_template.md` — fill in every section. When opening a PR via `gh pr create`, copy the template into the body explicitly; GitHub only auto-applies it through the web UI.
 - Link the issue with `Closes #<number>` (or `Fixes` / `Resolves`) in the PR description so it auto-closes on merge.
 - To release, use the `/release` skill. It compares `dev` to `main`, generates changelog entries, bumps the version, and creates a PR to merge `dev` into `main`.
 - Releases follow Semantic Versioning: `/release` (patch), `/release minor`, `/release major`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ bun run validate
 1. Create a feature branch from `dev`
 2. Make your changes
 3. Ensure all checks pass
-4. Submit a PR using the template at [`.github/PULL_REQUEST_TEMPLATE.md`](./.github/PULL_REQUEST_TEMPLATE.md). GitHub fills it in automatically when you open a PR through the web UI. If you use `gh pr create`, copy the template into the body — leaving it empty or partially filled slows review.
+4. Submit a PR using the template at [`.github/pull_request_template.md`](./.github/pull_request_template.md). GitHub fills it in automatically when you open a PR through the web UI. If you use `gh pr create`, copy the template into the body — leaving it empty or partially filled slows review.
 5. Link the issue your PR addresses with `Closes #<number>` (or `Fixes #<number>` / `Resolves #<number>`) in the description so it auto-closes on merge.
 
 ## Code Style


### PR DESCRIPTION
## Summary

Fixes a 404 in three docs links. `CONTRIBUTING.md`, `CLAUDE.md`, and `AGENTS.md` all point at `.github/PULL_REQUEST_TEMPLATE.md`, but the file is committed lowercase as `.github/pull_request_template.md`. GitHub blob URLs are case-sensitive, so the link 404s; a case-insensitive local filesystem hides it.

Docs follow reality rather than renaming the template: the maintainer triage workflows already `[ -f ]`-probe both casings, so nothing downstream depends on the uppercase spelling, and renaming a file GitHub treats specially has a larger blast radius than fixing three references.

Per maintainer review, the `CONTRIBUTING.md` pointer bullet has been dropped from `CLAUDE.md` and `AGENTS.md` — those files are injected into every agent session, and PR-time process is a point-of-need concern that belongs in `CONTRIBUTING.md`. Only the three link corrections remain.

## Change Metadata

- Change type: `docs`
- Primary scope: `multi` (repo-root contributor/agent docs)
- Risk: `risk: low` · Size: `size: XS`

## Linked Issue

None — drive-by fix noticed while following `CONTRIBUTING.md` for #2248 and #2263. Happy to open a tracking issue if preferred.

## Validation Evidence (required)

```bash
bun run format:check   # → "All matched files use Prettier code style!" (exit 0)
```

The 404 was verified against the live repo, not inferred from the local filesystem:

```
$ gh api repos/coleam00/Archon/contents/.github/PULL_REQUEST_TEMPLATE.md?ref=dev
{"message":"Not Found","status":"404"}

$ gh api repos/coleam00/Archon/contents/.github/pull_request_template.md?ref=dev
pull_request_template.md
```

`git ls-files .github/` (authoritative, case-sensitive) confirms the committed name is lowercase.

`type-check`/`lint`/`test` are skipped as not meaningful for a markdown-only change touching no code paths; `format:check` is the gate covering `.md`.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No**

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Database migration needed? **No**

No file is renamed, so any external link or tooling pointing at the real lowercase path keeps working.

## Human Verification (required)

- **Verified scenarios:** both casings queried against the live GitHub API on `dev` (404 vs. found); committed filename confirmed via `git ls-files`; repo-wide grep for remaining uppercase references in contributor docs comes back empty; `format:check` passes.
- **Edge cases checked:** the remaining uppercase mentions under `.archon/commands/defaults/` and the maintainer triage workflows are both-casing probes against *arbitrary* target repos, not references to this repo's file, so they were deliberately left alone.
- **What was not verified:** rendering in the GitHub web UI post-merge — the link can only be clicked once merged to `dev`. The API check above is the equivalent evidence.

## Side Effects / Blast Radius (required)

- **Affected subsystems/workflows:** documentation only. No code, config, or template content changes.
- **Guardrails/monitoring for early detection:** a regression is visible as a 404 on the template link.

## Rollback Plan (required)

- **Fast rollback command/path:** `git revert <merge-sha>` — three single-line docs edits.
- **Feature flags or config toggles:** none.
- **Observable failure symptoms:** the template link 404s again.

## Risks and Mitigations

- **Risk:** a maintainer may prefer the opposite fix — renaming the file to match the docs.
  - **Mitigation:** happy to switch; both casings are valid to GitHub, so it is genuinely the maintainers' call. Docs-follow-reality was chosen as the smaller, more reversible option.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor instructions with the correct pull request template path.
  * Clarified that contributors using the command-line workflow should copy the template into the pull request body.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->