### PR TITLE
fix(core): prefer a paused run over a newer failed one on chat resume

### DIFF
--- a/packages/core/src/db/workflows.test.ts
+++ b/packages/core/src/db/workflows.test.ts
@@ -24,6 +24,7 @@ import {
   failWorkflowRun,
   updateWorkflowActivity,
   findResumableRun,
+  findResumableRunByParentConversation,
   resumeWorkflowRun,
   pauseWorkflowRun,
   cancelWorkflowRun,
@@ -625,6 +626,52 @@ describe('workflows database', () => {
 
       await expect(findResumableRun('test', '/path')).rejects.toThrow(
         'Failed to find resumable run: Connection refused'
+      );
+    });
+  });
+
+  describe('findResumableRunByParentConversation', () => {
+    test('scopes by workflow name, parent conversation and codebase', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([mockWorkflowRun]));
+
+      const result = await findResumableRunByParentConversation('piv', 'conv-1', 'codebase-789');
+
+      expect(result).toEqual(mockWorkflowRun);
+      const [query, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+      expect(query).toContain('workflow_name = $1');
+      expect(query).toContain('parent_conversation_id = $2');
+      expect(query).toContain('codebase_id = $3');
+      expect(params).toEqual(['piv', 'conv-1', 'codebase-789']);
+    });
+
+    test('prefers a paused run over a newer failed one (paused-first ordering)', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([]));
+
+      await findResumableRunByParentConversation('piv', 'conv-1', 'cb');
+
+      const [query] = mockQuery.mock.calls[0] as [string, unknown[]];
+      expect(query).toContain("status IN ('failed', 'paused')");
+      // Status is the primary sort key: an open gate auto-resumes, while a
+      // failed candidate is gated behind an explicit user prompt. Ordering by
+      // started_at alone lets a newer failure shadow an older waiting gate.
+      expect(query).toContain("ORDER BY CASE WHEN status = 'paused' THEN 0 ELSE 1 END");
+      // Recency still breaks ties within a status.
+      expect(query).toContain('started_at DESC');
+    });
+
+    test('returns null when no run matches', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([]));
+
+      const result = await findResumableRunByParentConversation('piv', 'conv-1', 'cb');
+
+      expect(result).toBeNull();
+    });
+
+    test('throws on database error', async () => {
+      mockQuery.mockRejectedValueOnce(new Error('Connection refused'));
+
+      await expect(findResumableRunByParentConversation('piv', 'conv-1', 'cb')).rejects.toThrow(
+        'Failed to find resumable run by parent conversation: Connection refused'
       );
     });
   });

--- a/packages/core/src/db/workflows.ts
+++ b/packages/core/src/db/workflows.ts
@@ -639,6 +639,15 @@ export async function findResumableRun(
  * Used by the orchestrator (all platforms) to detect approved runs that need foreground resume
  * on the prior run's worktree. Codebase scope prevents cross-project resume on persistent
  * chat conversation IDs (Telegram chat_id, Slack thread, etc.).
+ *
+ * Ordering is status-first, then recency WITHIN a status — not bare recency. The two statuses
+ * are not interchangeable candidates for the caller: a `paused` run is an open gate that is
+ * legitimately waiting and gets hydrated and resumed, while a `failed` one is deliberately gated
+ * behind an explicit user prompt first (#1549). Ordering purely by `started_at` therefore lets a
+ * newer failure shadow an older open gate, and approving that gate resumes nothing.
+ *
+ * Contrast with getActiveWorkflowRunByPath below, which sorts the opposite way (older-wins) —
+ * it answers "who took the path lock first", a different question.
  */
 export async function findResumableRunByParentConversation(
   workflowName: string,
@@ -652,7 +661,7 @@ export async function findResumableRunByParentConversation(
          AND parent_conversation_id = $2
          AND codebase_id = $3
          AND status IN ('failed', 'paused')
-       ORDER BY started_at DESC
+       ORDER BY CASE WHEN status = 'paused' THEN 0 ELSE 1 END, started_at DESC
        LIMIT 1`,
       [workflowName, parentConversationId, codebaseId]
     );


### PR DESCRIPTION
## Summary

- Problem: `findResumableRunByParentConversation` ordered resume candidates by `started_at` alone, so a newer
  `failed` run shadowed an older `paused` approval gate in the same conversation + codebase.
- Why it matters: the two statuses are not interchangeable for the single caller — `paused` gets hydrated and
  resumed in the foreground, `failed` is deliberately gated behind an explicit user prompt (#1549). When the
  wrong row wins, approving a gate resumes nothing and the user gets a resume prompt for an unrelated failed
  run instead.
- What changed: the ordering is now status-first, then recency within status
  (`ORDER BY CASE WHEN status = 'paused' THEN 0 ELSE 1 END, started_at DESC`), plus a doc comment stating the
  guarantee, plus the first test coverage this function has had.
- What did **not** change (scope boundary): the `WHERE` clause, the caller, the resume/hydration path, and
  every other query in the file. No schema change, no new dependency.

## UX Journey

### Before

```
  User                        Archon                                  DB
  ────                        ──────                                  ──
  starts W ─────────────────▶ run A pauses at gate (started_at T1)
  starts W again ───────────▶ run B fails          (started_at T2>T1)
  approves gate of A ───────▶ resolveApprovalGate(A)
                              A stays 'paused'  (#2075)
                              findResumableRunByParentConversation
                                ORDER BY started_at DESC ────────────▶ returns B
                              B.status !== 'paused'
                              → buildFailedRunResumePrompt(B)
  sees a prompt about ◀────── run A never resumes
  the WRONG run
```

### After

```
  User                        Archon                                  DB
  ────                        ──────                                  ──
  starts W ─────────────────▶ run A pauses at gate (started_at T1)
  starts W again ───────────▶ run B fails          (started_at T2>T1)
  approves gate of A ───────▶ resolveApprovalGate(A)
                              A stays 'paused'  (#2075)
                              findResumableRunByParentConversation
                                *ORDER BY paused-first, then recency* ─▶ returns A
                              A.status === 'paused'
                              → hydrateResumableRun(A) → executeWorkflow
  sees run A continue ◀────── on its prior worktree, completed nodes kept
```

## Architecture Diagram

### Before

```
  orchestrator-agent.ts
    dispatchOrchestratorWorkflow
        │
        │ (workflowName, conversation.id, codebase.id)
        ▼
  db/workflows.ts
    findResumableRunByParentConversation
        │  status IN ('failed','paused')
        │  ORDER BY started_at DESC          ── recency only
        ▼
    ┌───────────────┴────────────────┐
    │                                │
  status === 'paused'          status === 'failed'
    │                                │
    ▼                                ▼
  hydrateResumableRun          buildFailedRunResumePrompt
  → executeWorkflow            → return (no dispatch)
```

### After

```
  orchestrator-agent.ts
    dispatchOrchestratorWorkflow                     (unchanged)
        │
        ▼
  db/workflows.ts
    [~] findResumableRunByParentConversation
        │  status IN ('failed','paused')
        │  === ORDER BY CASE WHEN status='paused' THEN 0 ELSE 1 END, started_at DESC
        ▼
    ┌───────────────┴────────────────┐
    │                                │
  status === 'paused'          status === 'failed'
    │  (now wins whenever one exists)│  (reached only when no gate is open)
    ▼                                ▼
  hydrateResumableRun          buildFailedRunResumePrompt   (both unchanged)
```

**Connection inventory**

| From | To | Status | Notes |
|------|----|--------|-------|
| `orchestrator-agent.ts` `dispatchOrchestratorWorkflow` | `db/workflows.ts` `findResumableRunByParentConversation` | unchanged | same signature, same call site — only which row comes back changes |
| `findResumableRunByParentConversation` | `remote_agent_workflow_runs` | **modified** | `ORDER BY` clause only; `WHERE` and params untouched |
| `dispatchOrchestratorWorkflow` | `hydrateResumableRun` / `buildFailedRunResumePrompt` | unchanged | branch logic untouched |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `core`
- Module: `core:database`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #2289
- Related #2075 (gates stay `paused` instead of staging a fake `failed` — makes this bug easier to hit)
- Related #1549 (the explicit prompt that gates `failed` candidates, i.e. why the two statuses differ)

## Validation Evidence (required)

```bash
bun run validate
```

Result: exit 0 — `check:bundled`, `check:bundled-skill`, `check:bundled-schema`, `check:pi-vendor-map`,
`check:capability-matrix`, `type-check`, `lint --max-warnings 0`, `format:check`, `test` all pass.

Targeted:

```bash
bun test packages/core/src/db/workflows.test.ts
#  86 pass
#  0 fail
```

- Evidence provided: full `bun run validate` run on this branch (Linux, Bun 1.3.11) plus the targeted file run
  above.
- If any command is intentionally skipped, explain why: none skipped.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Database migration needed? `No` — ordering-only change to an existing `SELECT`; `CASE WHEN` is portable
  across PostgreSQL and SQLite, so no dialect helper is involved.
- If yes, exact upgrade steps: n/a

## Human Verification (required)

- Verified scenarios: paused-and-failed candidate set in one conversation — the paused gate is now selected;
  single-candidate cases (only paused, only failed, neither) behave exactly as before.
- Edge cases checked: no candidates → still `null`; DB error → still wrapped as
  `Failed to find resumable run by parent conversation: …`; ties within a status still resolve by
  `started_at DESC`.
- What was not verified: multi-hour production soak. The change is a single `ORDER BY` clause on a query with
  one caller, and the branch has been running on a self-hosted instance since the change was written.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: chat-initiated workflow dispatch only. `findResumableRunByParentConversation`
  has exactly one production caller (`dispatchOrchestratorWorkflow`); no other module reads this query or
  depends on its ordering.
- Potential unintended effects: a conversation that has both an open gate and a newer failed run will now
  resume the gate where it previously prompted about the failure. That is the intended fix; the failed run
  remains reachable via `/workflow resume <id>` and `/workflow runs`.
- Guardrails/monitoring for early detection: existing `workflow.*` events are unchanged; a mis-selection would
  surface as the same user-visible symptom as before, inverted.

## Rollback Plan (required)

- Fast rollback command/path: revert this commit — the previous `ORDER BY started_at DESC` is restored with no
  state to migrate.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: approving a gate produces a resume prompt for a different run instead of
  continuing the gated one.

## Risks and Mitigations

- Risk: a user who *wants* the newest candidate regardless of status now gets the paused one first.
  - Mitigation: explicit addressing is unaffected — `/workflow resume <id>` short-circuits this lookup
    entirely (the caller passes `resumeRunId`), and `/workflow runs` lists every candidate.
- Risk: the SQL fragment is asserted by string matching in the new test, so a future reformat of the query
  could fail the test spuriously.
  - Mitigation: the assertions match the existing style in this test file (`toContain` on query fragments),
    and are split so a failure points at the specific guarantee that broke.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resumable workflow selection by prioritizing paused runs over failed runs.
  * Ensured the most recently started run is selected when multiple runs share the same status.

* **Tests**
  * Added coverage for workflow, conversation, and codebase filtering.
  * Added tests for empty results and database query errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->