### PR TITLE
feat(orchestrator): /setproject none detaches a conversation back to neutral

### DIFF
--- a/packages/core/src/handlers/command-handler.ts
+++ b/packages/core/src/handlers/command-handler.ts
@@ -1064,7 +1064,7 @@ Talk naturally — the orchestrator routes your requests to the right workflow a
 - \`/register-project <name> <path>\` — Register a local project
 - \`/update-project <name> <new-path>\` — Update a project's path
 - \`/remove-project <name>\` — Remove a registered project
-- \`/setproject <name>\` — Bind this conversation to a registered project
+- \`/setproject <name>\` — Bind this conversation to a registered project (\`/setproject none\` to detach and go neutral)
 
 **Session**
 - \`/status\` — Show current session and project info

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -3560,6 +3560,170 @@ describe('handleMessage — /setproject dispatch', () => {
     expect(mockUpdateConversation).not.toHaveBeenCalled();
     expect(platform.sendMessage).toHaveBeenCalledWith('conv-1', expect.stringContaining('Usage'));
   });
+
+  // ─── clear-to-neutral (/setproject none) ────────────────────────────────────
+
+  test('/setproject none clears the project scope on the DB conversation id', async () => {
+    // Same regression guard as the rebind path: the write must target
+    // conversation.id, never the platform conversation id (Telegram chat ids and
+    // GitHub owner/repo#n are not the conversations-table primary key).
+    mockGetOrCreateConversation.mockImplementation(() =>
+      Promise.resolve(
+        makeConversation({
+          id: 'db-conv-clear',
+          platform_type: 'telegram',
+          platform_conversation_id: '40865006',
+          codebase_id: 'cb-old',
+          cwd: '/old/worktree',
+        })
+      )
+    );
+    mockParseCommand.mockReturnValue({ command: 'setproject', args: ['none'] });
+
+    const platform = makePlatform();
+    await handleMessage(platform, '40865006', '/setproject none');
+
+    expect(mockUpdateConversation).toHaveBeenCalledWith('db-conv-clear', {
+      codebase_id: null,
+      cwd: null,
+      isolation_env_id: null,
+    });
+    expect(platform.sendMessage).toHaveBeenCalledWith(
+      '40865006',
+      expect.stringContaining('neutral')
+    );
+  });
+
+  test('/setproject none deactivates the active AI session before clearing', async () => {
+    // Without this the stale assistant_session_id survives the detach and is
+    // resumed against the now-neutral cwd — on Claude that throws, and since the
+    // turn throws, tryPersistSessionId never clears it: the conversation wedges.
+    mockGetOrCreateConversation.mockImplementation(() =>
+      Promise.resolve(makeConversation({ id: 'db-conv-clear', codebase_id: 'cb-old' }))
+    );
+    mockGetActiveSession.mockImplementation(() =>
+      Promise.resolve({ id: 'session-123', conversation_id: 'db-conv-clear', active: true })
+    );
+    mockParseCommand.mockReturnValue({ command: 'setproject', args: ['none'] });
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/setproject none');
+
+    expect(mockDeactivateSession).toHaveBeenCalledWith('session-123', 'project-changed');
+    expect(mockUpdateConversation).toHaveBeenCalledWith('db-conv-clear', {
+      codebase_id: null,
+      cwd: null,
+      isolation_env_id: null,
+    });
+  });
+
+  test('/setproject CLEAR clears regardless of case', async () => {
+    mockGetOrCreateConversation.mockImplementation(() =>
+      Promise.resolve(makeConversation({ id: 'db-conv-clear', codebase_id: 'cb-old' }))
+    );
+    mockParseCommand.mockReturnValue({ command: 'setproject', args: ['CLEAR'] });
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/setproject CLEAR');
+
+    expect(mockUpdateConversation).toHaveBeenCalledWith('db-conv-clear', {
+      codebase_id: null,
+      cwd: null,
+      isolation_env_id: null,
+    });
+  });
+
+  test('/setproject - clears (documented alias, otherwise silently regressable)', async () => {
+    mockGetOrCreateConversation.mockImplementation(() =>
+      Promise.resolve(makeConversation({ id: 'db-conv-clear', codebase_id: 'cb-old' }))
+    );
+    mockParseCommand.mockReturnValue({ command: 'setproject', args: ['-'] });
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/setproject -');
+
+    expect(mockUpdateConversation).toHaveBeenCalledWith('db-conv-clear', {
+      codebase_id: null,
+      cwd: null,
+      isolation_env_id: null,
+    });
+  });
+
+  test('clears with zero projects registered (returns before listCodebases)', async () => {
+    // Detaching must not be breakable by an empty or broken project list —
+    // that is exactly when a user most wants out.
+    mockGetOrCreateConversation.mockImplementation(() =>
+      Promise.resolve(makeConversation({ id: 'db-conv-clear', codebase_id: 'cb-old' }))
+    );
+    mockListCodebases.mockImplementation(() => Promise.reject(new Error('db down')));
+    mockParseCommand.mockReturnValue({ command: 'setproject', args: ['none'] });
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/setproject none');
+
+    expect(mockListCodebases).not.toHaveBeenCalled();
+    expect(mockUpdateConversation).toHaveBeenCalledWith('db-conv-clear', {
+      codebase_id: null,
+      cwd: null,
+      isolation_env_id: null,
+    });
+  });
+
+  test('multi-token argument falls through to name resolution, not the clear path', async () => {
+    // The single-token gate is what keeps `/setproject none of your business`
+    // a (failing) project lookup rather than a silent detach.
+    mockListCodebases.mockImplementation(() => Promise.resolve([makeCodebase('project-a')]));
+    mockParseCommand.mockReturnValue({
+      command: 'setproject',
+      args: ['none', 'of', 'your', 'business'],
+    });
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/setproject none of your business');
+
+    expect(mockUpdateConversation).not.toHaveBeenCalled();
+    const msg = (platform.sendMessage as ReturnType<typeof mock>).mock.calls[0]?.[1] as string;
+    expect(msg).toContain('none of your business');
+  });
+
+  test('notes the detached worktree when clearing an isolation-bound conversation', async () => {
+    mockGetOrCreateConversation.mockImplementation(() =>
+      Promise.resolve(
+        makeConversation({
+          id: 'db-conv-clear-wt',
+          codebase_id: 'cb-old',
+          cwd: '/old/worktree',
+          isolation_env_id: 'env-old',
+        })
+      )
+    );
+    mockParseCommand.mockReturnValue({ command: 'setproject', args: ['none'] });
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/setproject none');
+
+    const sent = (platform.sendMessage as ReturnType<typeof mock>).mock.calls
+      .map(c => String(c[1]))
+      .join('\n');
+    expect(sent).toContain('neutral');
+    expect(sent).toContain('previous worktree was detached');
+  });
+
+  test('omits the worktree note when clearing a conversation with no isolation env', async () => {
+    mockGetOrCreateConversation.mockImplementation(() =>
+      Promise.resolve(makeConversation({ id: 'db-conv-clear', codebase_id: 'cb-old' }))
+    );
+    mockParseCommand.mockReturnValue({ command: 'setproject', args: ['none'] });
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/setproject none');
+
+    const sent = (platform.sendMessage as ReturnType<typeof mock>).mock.calls
+      .map(c => String(c[1]))
+      .join('\n');
+    expect(sent).toContain('neutral');
+    expect(sent).not.toContain('previous worktree');
+  });
 });
 
 // ─── handleMessage — /update-project dispatch (issue #2085) ───────────────────

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -2638,7 +2638,16 @@ async function handleRemoveProject(message: string): Promise<string> {
 }
 
 /**
- * Handle /setproject command. Four effects:
+ * Reserved single-token arguments to `/setproject` that detach the conversation
+ * from its project instead of binding it to a named one.
+ */
+const SETPROJECT_CLEAR_KEYWORDS = new Set(['none', 'clear', '-']);
+
+/**
+ * Handle /setproject command. Two modes, both writing by the DB primary key
+ * (conversation.id), never the platform conversation id.
+ *
+ * REBIND — `/setproject <name>`. Four effects:
  * 1. Binds the conversation to the resolved codebase (writes `codebase_id`).
  * 2. Clears `cwd` — the project root remains codebase.default_cwd;
  *    conversation.cwd is only an explicit runtime override.
@@ -2646,13 +2655,66 @@ async function handleRemoveProject(message: string): Promise<string> {
  * 4. Deactivates the active AI session ('project-changed'), so the next
  *    message starts fresh in the new project's context.
  * Uses 4-tier fuzzy name resolution (exact → case-insensitive → prefix →
- * substring) via resolveCodebaseName. Updates by the DB primary key
- * (conversation.id), never the platform conversation id.
+ * substring) via resolveCodebaseName.
+ *
+ * CLEAR — `/setproject none` (also `clear`, `-`). The same three column writes
+ * with `codebase_id: null`, and the same session deactivation. It clears the
+ * project SCOPE; it does not reproduce a brand-new conversation, whose
+ * `ai_assistant_type` is resolved once at creation and which updateConversation
+ * cannot touch.
  */
 async function handleSetProject(message: string, conversation: Conversation): Promise<string> {
   const { args } = commandHandler.parseCommand(message);
   if (args.length < 1) {
-    return 'Usage: /setproject <project-name>';
+    return 'Usage: /setproject <project-name> (or /setproject none to detach)';
+  }
+
+  // Clear-to-neutral. Persistent chats (a Telegram chat_id is one permanent row)
+  // otherwise stay pinned to the first project they ever attached to: nothing
+  // else nulls codebase_id, and /reset preserves it by design. Gated on a single
+  // exact token — a project genuinely named `none` stays reachable through the
+  // prefix/substring tiers, but not by its bare exact name.
+  //
+  // Deliberately returns BEFORE listCodebases(): detaching must work with zero
+  // projects registered, and must not be breakable by a bad project list.
+  if (args.length === 1 && SETPROJECT_CLEAR_KEYWORDS.has(args[0].toLowerCase())) {
+    // Deactivate BEFORE clearing, for the same reason the rebind path below
+    // does. getActiveSession filters on conversation_id + active only, so a
+    // surviving session hands its assistant_session_id to the provider on the
+    // next turn alongside the now-neutral cwd. Claude resumes-or-errors on an
+    // invalid id, and because that turn throws, tryPersistSessionId is never
+    // reached — the stale id stays put and every later turn fails identically.
+    const session = await sessionDb.getActiveSession(conversation.id);
+    if (session) {
+      await safeDeactivateSession(session.id, 'setproject');
+    }
+
+    // Non-destructive, exactly as in the rebind path: the worktree may hold
+    // uncommitted work, so the env row is left for the cleanup tools.
+    const detachedWorktree = conversation.isolation_env_id !== null;
+    await db.updateConversation(conversation.id, {
+      codebase_id: null,
+      cwd: null,
+      isolation_env_id: null,
+    });
+    if (detachedWorktree) {
+      getLog().info(
+        { conversationId: conversation.id, isolationEnvId: conversation.isolation_env_id },
+        'project.clear_worktree_detached'
+      );
+    }
+    getLog().info({ conversationId: conversation.id }, 'project.clear_completed');
+
+    let cleared =
+      'Project scope cleared — this conversation is now neutral. Name a project or run a workflow to attach one.';
+    if (detachedWorktree) {
+      // Same caveat as the rebind path, and worse here: `/worktree remove` reads
+      // isolation_env_id from THIS conversation (just cleared) and is gated
+      // behind a codebase check that a detached conversation also fails.
+      cleared +=
+        '\n\nNote: the previous worktree was detached but left in place — clean it up with `archon isolation cleanup` or from the project’s Environments list in the web UI.';
+    }
+    return cleared;
   }
 
   const projectName = args.join(' ');

--- a/packages/docs-web/src/content/docs/reference/commands.md
+++ b/packages/docs-web/src/content/docs/reference/commands.md
@@ -25,6 +25,7 @@ These commands are handled deterministically by the orchestrator — they always
 | `/update-project <name> <path>` | Update a project's directory path |
 | `/remove-project <name>` | Remove a project registration |
 | `/setproject <name>` | Bind this conversation to a registered project. Clears any working-directory/worktree override and starts a fresh AI session on the next message (chat history stays visible) |
+| `/setproject none` | Detach this conversation from its project, clearing the project scope (also `clear` or `-`). Same three writes as a rebind, with no project bound, plus the same fresh AI session. Useful on persistent chats -- a Telegram chat is one permanent conversation row, so without this it stays pinned to the first project it ever attached to |
 
 ## Workflows
 


### PR DESCRIPTION
## Summary

- Problem: a conversation can be bound to a project but never unbound. `/setproject <name>` only rebinds,
  `/reset` preserves `codebase_id` by design, and the only thing that actually clears the binding is deleting
  the project (the `deleteCodebase` cascade).
- Why it matters: persistent-conversation platforms have one permanent row — Telegram maps a whole chat,
  Discord a whole channel. The row bound today is still bound months later, and being bound is not cosmetic:
  it selects the project-scoped system prompt, injects the `manage_run` tool, resolves `cwd` to that project,
  merges its codebase env vars, and syncs its workspace on every turn.
- What changed: `/setproject none` (also `clear`, `-`, case-insensitive) nulls `codebase_id`, `cwd` and
  `isolation_env_id`, returning the conversation to exactly the state a fresh one starts in. Plus `/help`
  text and the command reference.
- What did **not** change (scope boundary): `/setproject <name>` binding behaviour, `/reset`, the resolution
  tiers, and the DB schema (all three columns are already nullable). No new dependency.

## UX Journey

### Before

```
  User                          Archon
  ────                          ──────
  /setproject archon ─────────▶ conversation bound to "archon"
  ...weeks later...
  "what's the weather" ───────▶ still project-scoped: syncs the workspace,
                                loads archon env vars, biases routing
  /reset ─────────────────────▶ session cleared, binding PRESERVED
  /setproject ??? ────────────▶ no way to say "no project"
```

### After

```
  User                          Archon
  ────                          ──────
  /setproject archon ─────────▶ conversation bound to "archon"
  /setproject none ───────────▶ [+] codebase_id / cwd / isolation_env_id = NULL
                                [+] "Project cleared — this conversation is now neutral."
  "what's the weather" ───────▶ generic orchestrator prompt, no workspace sync,
                                no project env vars
  /setproject archon ─────────▶ bound again whenever you want
```

## Architecture Diagram

### Before

```
  command dispatch (orchestrator-agent.ts)
        │  command === 'setproject'
        ▼
  handleSetProject(message, conversation)
        │
        ├── args.length < 1 ────────────▶ usage string
        │
        └── resolveCodebaseName(...) ───▶ codebaseDb.listCodebases()
                    │
                    ├── not found ──────▶ "Project X not found"
                    └── found ──────────▶ deactivate session
                                          db.updateConversation(conversation.id, {
                                            codebase_id, cwd: null, isolation_env_id: null })
```

### After

```
  command dispatch (orchestrator-agent.ts)                       (unchanged)
        │  command === 'setproject'
        ▼
  [~] handleSetProject(message, conversation)
        │
        ├── args.length < 1 ────────────▶ usage string (mentions the detach form)
        │
        ├── [+] single reserved token (none|clear|-)
        │        === db.updateConversation(conversation.id, {
        │              codebase_id: null, cwd: null, isolation_env_id: null })
        │        ── returns BEFORE any codebase lookup ──x-- codebaseDb.listCodebases()
        │
        └── resolveCodebaseName(...) ───▶ codebaseDb.listCodebases()   (unchanged)
                    │
                    ├── not found ──────▶ "Project X not found"
                    └── found ──────────▶ deactivate session + rebind
```

**Connection inventory**

| From | To | Status | Notes |
|------|----|--------|-------|
| command dispatch | `handleSetProject` | unchanged | same signature |
| `handleSetProject` | `db.updateConversation` | **modified** | new call path writing three NULLs; the existing bind call is untouched |
| `handleSetProject` | `codebaseDb.listCodebases` | **modified** | now skipped entirely on the clear path (early return) |
| `handleSetProject` | `sessionDb` / `safeDeactivateSession` | unchanged | the clear path does not touch sessions — see "not verified" below |
| `/help` text, `docs/reference/commands.md` | — | **modified** | document the detach form |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`
- Module: `core:orchestrator`

## Change Metadata

- Change type: `feature`
- Primary scope: `core`

## Linked Issue

- Closes #2290
- Related #2274 — that request is about auto-**binding** Slack threads by channel; this is the inverse
  (**unbinding** an existing conversation). Complementary, not overlapping.
- Related #1937 — established that `/setproject` must write by the conversation DB id; the new path follows
  the same rule and the tests assert it.

## Validation Evidence (required)

```bash
bun run validate
```

Result: exit 0 — `check:bundled`, `check:bundled-skill`, `check:bundled-schema`, `check:pi-vendor-map`,
`check:capability-matrix`, `type-check`, `lint --max-warnings 0`, `format:check`, `test` all pass.

Targeted:

```bash
bun test packages/core/src/orchestrator/orchestrator-agent.test.ts
#  214 pass
#  0 fail
```

- Evidence provided: full `bun run validate` on this branch (Linux, Bun 1.3.11) plus the targeted file run.
- If any command is intentionally skipped, explain why: none skipped.

## Security Impact (required)

- New permissions/capabilities? `No` — it removes scope rather than granting any
- New external network calls? `No`
- Secrets/tokens handling changed? `No` — detaching stops that codebase's env vars from being injected, which
  narrows exposure
- File system access scope changed? `No` — clearing `cwd` returns the conversation to the neutral
  `~/.archon/workspaces/` root that unbound conversations already use

## Compatibility / Migration

- Backward compatible? `Yes` — purely additive; `/setproject <name>` is unchanged
- Config/env changes? `No`
- Database migration needed? `No` — `codebase_id`, `cwd` and `isolation_env_id` are already nullable, and the
  resulting row is the same shape as a brand-new conversation
- If yes, exact upgrade steps: n/a

## Human Verification (required)

- Verified scenarios: bind → `/setproject none` → conversation is neutral (generic prompt, no project env,
  no workspace sync) → rebind works. `clear`, `-` and mixed case behave identically.
- Edge cases checked: a multi-word project name beginning with a reserved token still resolves as a project
  (covered by a test); the clear path never calls `listCodebases`, so it works even with zero projects
  registered; the write targets the conversation DB id, not the platform id.
- What was not verified: the clear path intentionally does **not** deactivate the active AI session, on the
  grounds that detaching is not a session reset (`/reset` is). If maintainers would rather have the session
  deactivated too, that is a two-line addition — happy to change it.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `/setproject` handling only. Downstream behaviour of a neutral conversation is
  the pre-existing unbound path — no new branches were added to prompt building, tool injection, cwd
  resolution or workflow discovery.
- Potential unintended effects: a user with a project literally named `none`, `clear` or `-` cannot select it
  by that bare name. Mitigated by requiring the single-argument form and documented inline; any other
  resolution tier (prefix, substring, owner-qualified) still reaches it.
- Guardrails/monitoring for early detection: the clear path logs `project.cleared` with the conversation id,
  so an unexpected detach is traceable.

## Rollback Plan (required)

- Fast rollback command/path: revert this commit. Conversations already detached simply stay detached — that
  is the same state new conversations start in, so nothing needs repair.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: `/setproject none` resolving as a project-name lookup instead of detaching.

## Risks and Mitigations

- Risk: a project named exactly `none` / `clear` / `-` becomes unselectable by that bare name.
  - Mitigation: only the single-argument form is reserved; other tiers still resolve it, and the behaviour is
    documented in `/help` and the command reference.
- Risk: users expect `/setproject none` to also clear the session, and are surprised it does not.
  - Mitigation: the reply states exactly what happened; `/reset` remains the session command. Easy to change
    if maintainers prefer the opposite default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/setproject none` to detach a conversation from its current project and return it to a neutral state.
  * Added `clear` and `-` as alternative commands for detaching a project.
  * Project-clearing commands are case-insensitive.
  * Active sessions are deactivated when a project is detached.

* **Documentation**
  * Updated command help and reference documentation with the new project-detachment options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->