### PR TITLE
fix(core): /reset clears the execution binding and abandons resumable runs

### DIFF
--- a/packages/core/src/db/workflows.test.ts
+++ b/packages/core/src/db/workflows.test.ts
@@ -31,6 +31,7 @@ import {
   updateWorkflowActivity,
   findResumableRun,
   findResumableRunByParentConversation,
+  findResumableRunIdsForConversation,
   resumeWorkflowRun,
   pauseWorkflowRun,
   cancelWorkflowRun,
@@ -723,6 +724,50 @@ describe('workflows database', () => {
 
       await expect(findResumableRunByParentConversation('piv', 'conv-1', 'cb')).rejects.toThrow(
         'Failed to find resumable run by parent conversation: Connection refused'
+      );
+    });
+  });
+
+  describe('findResumableRunIdsForConversation', () => {
+    test('matches the conversation and its worker conversations', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([{ id: 'run-1' }, { id: 'run-2' }]));
+
+      const result = await findResumableRunIdsForConversation('conv-1');
+
+      expect(result).toEqual(['run-1', 'run-2']);
+      const [query, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+      expect(query).toContain('conversation_id = $1');
+      expect(query).toContain('parent_conversation_id = $2');
+      expect(query).toContain('ORDER BY started_at DESC');
+      expect(query).not.toMatch(/--.*\$\d/); // #999 guard: $N in SQL comments breaks convertPlaceholders
+      expect(params).toEqual(['conv-1', 'conv-1']);
+    });
+
+    test('never matches live pending or running work', async () => {
+      // The load-bearing assertion. `pending`/`running` may belong to another
+      // process entirely (a CLI run, a webhook dispatch); neither resume lookup
+      // can return them, so cancelling them buys nothing and destroys live work.
+      mockQuery.mockResolvedValueOnce(createQueryResult([]));
+
+      await findResumableRunIdsForConversation('conv-1');
+
+      const [query] = mockQuery.mock.calls[0] as [string, unknown[]];
+      expect(query).toContain("status IN ('paused', 'failed')");
+      expect(query).not.toContain("'running'");
+      expect(query).not.toContain("'pending'");
+    });
+
+    test('returns an empty array when nothing is resumable', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([]));
+
+      expect(await findResumableRunIdsForConversation('conv-1')).toEqual([]);
+    });
+
+    test('throws on database error', async () => {
+      mockQuery.mockRejectedValueOnce(new Error('Connection refused'));
+
+      await expect(findResumableRunIdsForConversation('conv-1')).rejects.toThrow(
+        'Failed to find resumable runs for conversation: Connection refused'
       );
     });
   });

--- a/packages/core/src/db/workflows.ts
+++ b/packages/core/src/db/workflows.ts
@@ -449,6 +449,45 @@ export async function getPausedWorkflowRun(conversationId: string): Promise<Work
 }
 
 /**
+ * Ids of every RESUMABLE run belonging to a conversation, newest first.
+ *
+ * Used by `/reset` to give the user a real escape hatch: after these are
+ * abandoned, the resume lookups find nothing, so the next dispatch starts fresh
+ * instead of continuing a stale run.
+ *
+ * The status set is exactly what the two resume lookups can return —
+ * findResumableRunByParentConversation ('failed'/'paused') and
+ * getPausedWorkflowRun ('paused'). `pending` and `running` are deliberately NOT
+ * matched: neither lookup can ever return them, so leaving them alone cannot
+ * cause the stale continuation this exists to prevent, while cancelling them
+ * would stop live work that may belong to another process entirely (a CLI run,
+ * a webhook-triggered run, a scheduled dispatch).
+ *
+ * `workflow:` sub-runs inherit the parent's `conversation_id` AND
+ * `parent_conversation_id` unchanged at every nesting level
+ * (packages/workflows/src/executor.ts, child run creation), so this predicate
+ * already covers the whole sub-run tree without a `parent_run_id` walk.
+ */
+export async function findResumableRunIdsForConversation(
+  conversationId: string
+): Promise<string[]> {
+  try {
+    const result = await pool.query<{ id: string }>(
+      `SELECT id FROM remote_agent_workflow_runs
+       WHERE (conversation_id = $1 OR parent_conversation_id = $2)
+         AND status IN ('paused', 'failed')
+       ORDER BY started_at DESC`,
+      [conversationId, conversationId]
+    );
+    return result.rows.map(r => r.id);
+  } catch (error) {
+    const err = error as Error;
+    getLog().error({ err, conversationId }, 'db.workflow_run_find_resumable_for_conv_failed');
+    throw new Error(`Failed to find resumable runs for conversation: ${err.message}`);
+  }
+}
+
+/**
  * Find the workflow run currently holding the lock on `workingPath`.
  *
  * The lock is held by any row in `(running, paused)` or `pending` younger

--- a/packages/core/src/handlers/command-handler.test.ts
+++ b/packages/core/src/handlers/command-handler.test.ts
@@ -45,6 +45,9 @@ const mockUpdateWorkflowRun = mock(() => Promise.resolve());
 // findChildRuns → pool.query → created and schema-initialised a real SQLite
 // database on disk, in a test that reads as fully mocked (#2240).
 const mockFindChildRuns = mock(() => Promise.resolve([]));
+const mockFindResumableRunIdsForConversation = mock(
+  (): Promise<string[]> => Promise.resolve([] as string[])
+);
 // CAS gate resolvers (#2113) — approve/reject stamp the resolution atomically here
 // instead of via updateWorkflowRun. resolveAndCancelApprovalGate is the atomic
 // resolve+cancel for terminal reject outcomes. Default to "won the race".
@@ -102,6 +105,7 @@ mock.module('../db/workflows', () => ({
   listWorkflowRuns: mockListWorkflowRuns,
   getWorkflowRun: mockGetWorkflowRun,
   findChildRuns: mockFindChildRuns,
+  findResumableRunIdsForConversation: mockFindResumableRunIdsForConversation,
   resumeWorkflowRun: mockResumeWorkflowRun,
   failWorkflowRun: mockFailWorkflowRun,
   updateWorkflowRun: mockUpdateWorkflowRun,
@@ -741,6 +745,72 @@ describe('CommandHandler', () => {
     });
 
     describe('/reset', () => {
+      beforeEach(() => {
+        mockFindResumableRunIdsForConversation.mockClear();
+        mockFindResumableRunIdsForConversation.mockImplementation(() => Promise.resolve([]));
+        mockUpdateConversation.mockClear();
+        mockUpdateConversation.mockImplementation(() => Promise.resolve());
+        mockGetWorkflowRun.mockClear();
+        mockCancelWorkflowRun.mockClear();
+        mockCancelWorkflowRun.mockImplementation(() => Promise.resolve({ cancelled: true }));
+      });
+
+      test('clears the execution binding but preserves the project attachment', async () => {
+        mockGetActiveSession.mockResolvedValue(null);
+
+        const result = await handleCommand(baseConversation, '/reset');
+
+        expect(result.success).toBe(true);
+        // cwd + isolation env go; codebase_id is deliberately absent from the
+        // payload — detaching the project is /setproject none's job.
+        expect(mockUpdateConversation).toHaveBeenCalledWith(baseConversation.id, {
+          cwd: null,
+          isolation_env_id: null,
+        });
+        const [, payload] = mockUpdateConversation.mock.calls[0] as [string, object];
+        expect(payload).not.toHaveProperty('codebase_id');
+        expect(result.message).toContain('Project attachment preserved');
+      });
+
+      test('abandons resumable runs and names the count', async () => {
+        mockGetActiveSession.mockResolvedValue(null);
+        mockFindResumableRunIdsForConversation.mockImplementation(() =>
+          Promise.resolve(['run-a', 'run-b'])
+        );
+        mockGetWorkflowRun.mockImplementation((id: unknown) =>
+          Promise.resolve({ id, status: 'paused', metadata: {} })
+        );
+
+        const result = await handleCommand(baseConversation, '/reset');
+
+        expect(mockFindResumableRunIdsForConversation).toHaveBeenCalledWith(baseConversation.id);
+        expect(mockCancelWorkflowRun.mock.calls.map(c => c[0])).toEqual(['run-a', 'run-b']);
+        // "resumable", not "pending": pending is itself a status name and reads
+        // as "waiting" to a user.
+        expect(result.message).toContain('Abandoned 2 resumable run(s).');
+      });
+
+      test('still reports the abandoned count when clearing the binding fails', async () => {
+        // The two effects live in separate try blocks precisely so a failure in
+        // the second cannot swallow what the first already did.
+        mockGetActiveSession.mockResolvedValue(null);
+        mockFindResumableRunIdsForConversation.mockImplementation(() => Promise.resolve(['run-a']));
+        mockGetWorkflowRun.mockImplementation((id: unknown) =>
+          Promise.resolve({ id, status: 'paused', metadata: {} })
+        );
+        mockUpdateConversation.mockImplementation(() =>
+          Promise.reject(new Error('Conversation not found: conv-123'))
+        );
+
+        const result = await handleCommand(baseConversation, '/reset');
+
+        expect(result.success).toBe(false);
+        expect(result.message).toContain('Abandoned 1 resumable run(s).');
+        expect(result.message).toContain('Could not clear the workspace binding');
+        // And it must NOT claim the binding was cleared.
+        expect(result.message).not.toContain('Cleared workspace binding');
+      });
+
       test('should deactivate active session', async () => {
         mockGetActiveSession.mockResolvedValue({
           id: 'session-123',

--- a/packages/core/src/handlers/command-handler.ts
+++ b/packages/core/src/handlers/command-handler.ts
@@ -32,6 +32,7 @@ import {
   getWorkflowStatus,
   resumeWorkflow,
   abandonWorkflow,
+  abandonResumableRunsForConversation,
   resetWorkflowNodeSessions,
 } from '../operations/workflow-operations';
 import { safeDeactivateSession } from '../state/session-transitions';
@@ -1198,18 +1199,69 @@ Talk naturally — the orchestrator routes your requests to the right workflow a
     }
 
     case 'reset': {
+      // /reset is an explicit "start fresh" intent, and deactivating the AI
+      // session alone does not deliver it: the execution binding (cwd +
+      // isolation env) survives, and so does every resumable run, so the next
+      // message can continue an old run on an old worktree instead of starting
+      // over. This clears all three.
+      //
+      // `codebase_id` is deliberately PRESERVED. The resulting row —
+      // {codebase_id: <kept>, cwd: null, isolation_env_id: null} — is byte-for-
+      // byte what /setproject already writes, so this is a well-trodden state,
+      // not a novel one. Detaching the project is /setproject none's job.
       const session = await sessionDb.getActiveSession(conversation.id);
       if (session) {
         await safeDeactivateSession(session.id, 'reset');
-        return {
-          success: true,
-          message:
-            'Session cleared. Starting fresh on next message.\n\nCodebase configuration preserved.',
-        };
       }
+
+      // Two independent effects, two independent try blocks. Sharing one would
+      // mean that a binding-clear failure AFTER a successful abandon swallows
+      // the count and reports only the failure — precisely the case where the
+      // user most needs to know that N runs were already cancelled.
+      let abandoned = 0;
+      let abandonFailures = 0;
+      let abandonError: string | null = null;
+      try {
+        ({ abandoned, failures: abandonFailures } = await abandonResumableRunsForConversation(
+          conversation.id
+        ));
+      } catch (error) {
+        const err = error as Error;
+        getLog().error({ err, conversationId: conversation.id }, 'cmd.reset_abandon_failed');
+        abandonError = err.message;
+      }
+
+      let bindingCleared = true;
+      let bindingError: string | null = null;
+      try {
+        await db.updateConversation(conversation.id, { cwd: null, isolation_env_id: null });
+      } catch (error) {
+        const err = error as Error;
+        getLog().error({ err, conversationId: conversation.id }, 'cmd.reset_clear_binding_failed');
+        bindingCleared = false;
+        bindingError = err.message;
+      }
+
+      const parts = [session ? 'Session cleared.' : 'No active session.'];
+      parts.push(
+        bindingCleared
+          ? 'Cleared workspace binding (worktree + isolation env).'
+          : `Could not clear the workspace binding: ${bindingError ?? 'unknown error'}`
+      );
+      if (abandoned > 0) parts.push(`Abandoned ${String(abandoned)} resumable run(s).`);
+      if (abandonFailures > 0) {
+        parts.push(
+          `⚠️ ${String(abandonFailures)} run(s) could not be abandoned — check /workflow status.`
+        );
+      }
+      if (abandonError !== null) {
+        parts.push(`⚠️ Could not look up resumable runs: ${abandonError}`);
+      }
+      parts.push('Project attachment preserved — next message starts fresh.');
+
       return {
-        success: true,
-        message: 'No active session to reset.',
+        success: bindingCleared && abandonError === null,
+        message: parts.join(' '),
       };
     }
 

--- a/packages/core/src/operations/workflow-operations.test.ts
+++ b/packages/core/src/operations/workflow-operations.test.ts
@@ -9,6 +9,9 @@ const mockListWorkflowRuns = mock(() => Promise.resolve([]));
 const mockUpdateWorkflowRun = mock(() => Promise.resolve());
 const mockCancelWorkflowRun = mock(() => Promise.resolve({ cancelled: true }));
 const mockFindChildRuns = mock((): Promise<unknown[]> => Promise.resolve([]));
+const mockFindResumableRunIdsForConversation = mock(
+  (): Promise<string[]> => Promise.resolve([] as string[])
+);
 // CAS gate resolvers (#2113): default to "won the race". Tests that simulate a
 // concurrent loser override with mockResolvedValueOnce({ resolved: false }).
 // resolveApprovalGate = stay-paused resolution (approve, reject stage-rework);
@@ -22,6 +25,7 @@ mock.module('../db/workflows', () => ({
   updateWorkflowRun: mockUpdateWorkflowRun,
   cancelWorkflowRun: mockCancelWorkflowRun,
   findChildRuns: mockFindChildRuns,
+  findResumableRunIdsForConversation: mockFindResumableRunIdsForConversation,
   resolveApprovalGate: mockResolveApprovalGate,
   resolveAndCancelApprovalGate: mockResolveAndCancelApprovalGate,
 }));
@@ -66,6 +70,7 @@ const {
   getWorkflowStatus,
   resumeWorkflow,
   abandonWorkflow,
+  abandonResumableRunsForConversation,
   resetWorkflowNodeSessions,
 } = await import('./workflow-operations');
 
@@ -918,6 +923,73 @@ describe('abandonWorkflow', () => {
 
     await expect(abandonWorkflow('run-1')).rejects.toThrow(
       "Cannot abandon run with status 'cancelled'"
+    );
+  });
+});
+
+describe('abandonResumableRunsForConversation', () => {
+  beforeEach(() => {
+    mockFindResumableRunIdsForConversation.mockClear();
+    mockFindResumableRunIdsForConversation.mockImplementation(() => Promise.resolve([]));
+    mockGetWorkflowRun.mockClear();
+    mockGetWorkflowRun.mockImplementation(() => Promise.resolve(makePausedRun()));
+    mockCancelWorkflowRun.mockClear();
+    mockCancelWorkflowRun.mockImplementation(() => Promise.resolve({ cancelled: true }));
+    mockFindChildRuns.mockClear();
+    mockFindChildRuns.mockImplementation(() => Promise.resolve([]));
+  });
+
+  test('reports zero when the conversation has nothing resumable', async () => {
+    const result = await abandonResumableRunsForConversation('conv-1');
+
+    expect(result).toEqual({ abandoned: 0, failures: 0 });
+    expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  test('routes every resumable run through the shared abandon op', async () => {
+    // Going through abandonWorkflow (rather than a bulk UPDATE) is what buys the
+    // CAS guard, the sub-run cascade and the container/volume reclaim.
+    mockFindResumableRunIdsForConversation.mockImplementation(() =>
+      Promise.resolve(['run-a', 'run-b'])
+    );
+    mockGetWorkflowRun.mockImplementation((id: unknown) =>
+      Promise.resolve(makePausedRun({ id: id as string }))
+    );
+
+    const result = await abandonResumableRunsForConversation('conv-1');
+
+    expect(result).toEqual({ abandoned: 2, failures: 0 });
+    expect(mockFindResumableRunIdsForConversation).toHaveBeenCalledWith('conv-1');
+    expect(mockCancelWorkflowRun.mock.calls.map(c => c[0])).toEqual(['run-a', 'run-b']);
+  });
+
+  test('counts a run that went terminal mid-loop and keeps going', async () => {
+    // A row can go terminal between the SELECT and the abandon, which makes
+    // abandonWorkflow throw. One racing run must not abort the whole reset.
+    mockFindResumableRunIdsForConversation.mockImplementation(() =>
+      Promise.resolve(['run-gone', 'run-ok'])
+    );
+    mockGetWorkflowRun.mockImplementation((id: unknown) =>
+      Promise.resolve(
+        id === 'run-gone'
+          ? makePausedRun({ id: 'run-gone', status: 'completed' })
+          : makePausedRun({ id: id as string })
+      )
+    );
+
+    const result = await abandonResumableRunsForConversation('conv-1');
+
+    expect(result).toEqual({ abandoned: 1, failures: 1 });
+    expect(mockCancelWorkflowRun.mock.calls.map(c => c[0])).toEqual(['run-ok']);
+  });
+
+  test('propagates a lookup failure rather than reporting a false all-clear', async () => {
+    mockFindResumableRunIdsForConversation.mockImplementation(() =>
+      Promise.reject(new Error('Connection refused'))
+    );
+
+    await expect(abandonResumableRunsForConversation('conv-1')).rejects.toThrow(
+      'Connection refused'
     );
   });
 });

--- a/packages/core/src/operations/workflow-operations.ts
+++ b/packages/core/src/operations/workflow-operations.ts
@@ -277,6 +277,63 @@ export async function abandonWorkflow(runId: string): Promise<AbandonWorkflowRes
   return { run, cascadeFailures, blockedParentRunId };
 }
 
+export interface AbandonConversationRunsResult {
+  /** Runs this call actually took to 'cancelled'. */
+  abandoned: number;
+  /**
+   * Runs that could not be abandoned (already terminal by the time we got to
+   * them, or a DB failure). Non-zero means part of the set may still be alive.
+   */
+  failures: number;
+}
+
+/**
+ * Abandon every RESUMABLE run belonging to a conversation.
+ *
+ * Backs `/reset`: with these gone, the resume lookups find nothing, so the next
+ * message starts fresh instead of continuing a stale run.
+ *
+ * Routes through `abandonWorkflow` per run rather than issuing one bulk UPDATE.
+ * That op is where abandon semantics live for EVERY surface (CLI, web API, chat,
+ * manage_run, Slack-cancel) — the CAS guard, the sub-run cascade, and the
+ * immediate container + upper-volume reclaim. A bulk UPDATE here would be a
+ * sixth abandon surface that silently skips all three.
+ *
+ * Only 'paused'/'failed' rows are selected (see
+ * findResumableRunIdsForConversation): live `pending`/`running` work is never
+ * touched, since it may belong to a different process altogether.
+ *
+ * Best-effort per run: a row can go terminal between the SELECT and the abandon,
+ * which makes `abandonWorkflow` throw. That is counted, not propagated — one
+ * racing run must not abort the whole reset.
+ */
+export async function abandonResumableRunsForConversation(
+  conversationId: string
+): Promise<AbandonConversationRunsResult> {
+  const runIds = await workflowDb.findResumableRunIdsForConversation(conversationId);
+  let abandoned = 0;
+  let failures = 0;
+  for (const runId of runIds) {
+    try {
+      await abandonWorkflow(runId);
+      abandoned++;
+    } catch (err) {
+      getLog().warn(
+        { err, runId, conversationId },
+        'operations.workflow_abandon_for_conversation_failed'
+      );
+      failures++;
+    }
+  }
+  if (abandoned > 0 || failures > 0) {
+    getLog().info(
+      { conversationId, abandoned, failures },
+      'operations.workflow_abandon_for_conversation_completed'
+    );
+  }
+  return { abandoned, failures };
+}
+
 /**
  * Approve a paused workflow run.
  *

--- a/packages/docs-web/src/content/docs/reference/commands.md
+++ b/packages/docs-web/src/content/docs/reference/commands.md
@@ -48,7 +48,7 @@ These commands are handled deterministically by the orchestrator — they always
 | Command | Description |
 |---------|-------------|
 | `/status` | Show conversation state |
-| `/reset` | Clear session completely |
+| `/reset` | Start fresh: clears the AI session, releases the execution binding (working-directory override + isolation env), and abandons this conversation's **resumable** runs (`paused`/`failed`) so the next message does not continue one. Runs that are actively executing (`pending`/`running`) are never touched -- they may belong to another process entirely. The project attachment (`codebase_id`) is preserved; use `/setproject none` to drop that too |
 | `/help` | Show all commands |
 
 ---
@@ -111,9 +111,9 @@ Bot: Platform: telegram
 ```
 You: /reset
 
-Bot: Session cleared. Starting fresh on next message.
-
-     Codebase configuration preserved.
+Bot: Session cleared. Cleared workspace binding (worktree + isolation env).
+     Abandoned 1 resumable run(s). Project attachment preserved — next message
+     starts fresh.
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Problem: `/reset` replies "Starting fresh on next message" but only deactivates the AI session. The
  conversation keeps `cwd` + `isolation_env_id`, and every resumable run stays resumable.
- Why it matters: the orchestrator prefers `conversation.cwd` over `codebase.default_cwd`, so the "fresh" turn
  still executes inside the previous worktree; and because `findResumableRunByParentConversation` matches
  `status IN ('failed','paused')` (and `getPausedWorkflowRun` matches `paused`), the next dispatch can
  silently continue a stale run — old arguments, old completed nodes — instead of starting a new one. `/reset`
  is the natural escape hatch for exactly that situation and currently isn't one.
- What changed: `/reset` now also clears `cwd`/`isolation_env_id` and abandons the conversation's resumable
  runs, then reports what it did (including the number of runs abandoned). Adds
  `abandonResumableRunsForConversation` to the workflow-run DB module.
- What did **not** change (scope boundary): `codebase_id` is still preserved — resetting a conversation is not
  the same as leaving the project. Session deactivation is unchanged. No schema change, no new dependency, no
  other command touched.

## UX Journey

### Before

```
  User                        Archon                              DB
  ────                        ──────                              ──
  runs workflow ────────────▶ run pauses at a gate
                              conversation.cwd = <worktree>
                              conversation.isolation_env_id = <env>
  /reset ───────────────────▶ deactivate session
                              [X] cwd / isolation_env_id untouched
                              [X] paused run still resumable
  "start fresh" ────────────▶ resume lookup finds the stale run
                              executes in the OLD worktree  [X]
  sees the old run ◀────────  continue, not a fresh start
```

### After

```
  User                        Archon                              DB
  ────                        ──────                              ──
  runs workflow ────────────▶ run pauses at a gate
  /reset ───────────────────▶ deactivate session
                              *abandonResumableRunsForConversation*
                              *updateConversation(cwd: null,
                                 isolation_env_id: null)*
                              codebase_id preserved
  ◀──────────────────────────  "Session cleared. Cleared workspace binding
                                (worktree + isolation env). Abandoned 1 pending
                                run(s). Project attachment preserved — next
                                message starts fresh."
  "start fresh" ────────────▶ resume lookup finds nothing
                              new run, cwd = codebase.default_cwd,
                              fresh isolation env  [+]
```

## Architecture Diagram

### Before

```
  command-handler.ts
    case 'reset'
        │
        ├── sessionDb.getActiveSession
        └── safeDeactivateSession ─────────▶ sessions
             (nothing else)

  next dispatch
    orchestrator-agent.ts ────────────────▶ db/workflows.ts
                                              findResumableRunByParentConversation
                                              (stale run still matches)
```

### After

```
  command-handler.ts
    [~] case 'reset'
        │
        ├── sessionDb.getActiveSession
        ├── safeDeactivateSession ─────────▶ sessions            (unchanged)
        ├── === workflowDb.abandonResumableRunsForConversation ─▶ [+] workflow_runs
        └── === db.updateConversation(cwd: null,
                 isolation_env_id: null) ──▶ conversations

  next dispatch
    orchestrator-agent.ts ────────────────▶ db/workflows.ts      (unchanged code,
                                              findResumableRun…    now finds nothing)
```

**Connection inventory**

| From | To | Status | Notes |
|------|----|--------|-------|
| `command-handler.ts` `case 'reset'` | `sessionDb` / `safeDeactivateSession` | unchanged | same call, same transition reason |
| `command-handler.ts` `case 'reset'` | `db/workflows.ts` `abandonResumableRunsForConversation` | **new** | new function in an existing module |
| `command-handler.ts` `case 'reset'` | `db/conversations.ts` `updateConversation` | **new** | clears `cwd` + `isolation_env_id` only |
| `abandonResumableRunsForConversation` | `remote_agent_workflow_runs` | **new** | conditional UPDATE, no schema change |
| `orchestrator-agent.ts` | `findResumableRunByParentConversation` | unchanged | untouched; it simply has no stale candidate after a reset |

## Label Snapshot

- Risk: `risk: medium`
- Size: `size: S`
- Scope: `core`
- Module: `core:orchestrator`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #2291
- Related #1549 — the same class of problem from the CLI side (auto-resume of a failed run hijacking a fresh
  request); this gives chat users the escape hatch.

## Validation Evidence (required)

```bash
bun run validate
```

Result: exit 0 — `check:bundled`, `check:bundled-skill`, `check:bundled-schema`, `check:pi-vendor-map`,
`check:capability-matrix`, `type-check`, `lint --max-warnings 0`, `format:check`, `test` all pass.

Targeted:

```bash
bun test packages/core/src/db/workflows.test.ts        #  85 pass, 0 fail
bun test packages/core/src/handlers/command-handler.test.ts   # 123 pass, 0 fail
```

- Evidence provided: full `bun run validate` on this branch (Linux, Bun 1.3.11) plus both targeted file runs.
- If any command is intentionally skipped, explain why: none skipped.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No` — clearing `cwd`/`isolation_env_id` returns the conversation to the
  project root it was already entitled to; the worktree itself is left on disk untouched

## Compatibility / Migration

- Backward compatible? `Yes` for data and API shape. The **behaviour** of `/reset` changes deliberately — see
  Blast Radius.
- Config/env changes? `No`
- Database migration needed? `No` — a new conditional UPDATE against an existing table
- If yes, exact upgrade steps: n/a

## Human Verification (required)

- Verified scenarios: run parked at an approval gate → `/reset` → reply names the abandoned count → the next
  message starts a brand-new run in `codebase.default_cwd` with a fresh isolation env rather than resuming.
  Reset with no session and no runs still clears the binding and says so.
- Edge cases checked: nothing to abandon → count sentence omitted; no active session → "No active session."
  and the binding is still cleared; conversation row vanished mid-reset → `ConversationNotFoundError` is
  absorbed (a reset cannot meaningfully fail on a conversation that no longer exists) while any other DB error
  propagates.
- What was not verified: behaviour under a concurrent dispatch racing the reset. The abandon is a single
  conditional UPDATE, so a run that starts after it simply survives — which is the intuitive outcome — but I
  have not built a harness for that race.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `/reset` on every platform (the command handler is shared), plus any
  subsequent dispatch in that conversation.
- Potential unintended effects — **the one to weigh**: `/reset` becomes destructive toward in-flight runs. A
  user who types `/reset` while a run is legitimately paused at an approval gate loses that run (it becomes
  `cancelled`). That is the intended meaning of "start fresh", but it is a real behaviour change from today's
  no-op. Mitigations: the reply always names the number of runs abandoned, so it is never silent, and the
  command reference now states it explicitly and points at `/workflow approve` / `/workflow resume <id>` as
  the way to keep a run. If maintainers would rather not couple the two, the run-abandoning half can move
  behind an explicit variant (e.g. `/reset --hard`) and the binding-clearing half still stands on its own —
  happy to split it that way.
- Guardrails/monitoring for early detection: abandoned runs land in `cancelled` with `completed_at` set, so
  they remain visible in `/workflow runs` and the console rather than disappearing.

## Rollback Plan (required)

- Fast rollback command/path: revert this commit. Runs already cancelled by a reset stay cancelled — they are
  terminal and visible, and can be inspected via `/workflow get <id>`; no data is deleted.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: `/reset` reporting abandoned runs that the user wanted to keep, or a post-reset
  message still landing in the old worktree.

## Risks and Mitigations

- Risk: a user loses a paused run they wanted to keep.
  - Mitigation: the reply states the count; the docs say what `/reset` discards and how to keep a run; the
    cancelled run remains inspectable. Willing to gate this half behind an explicit flag if preferred.
- Risk: the abandon query misses runs recorded only under a hidden worker conversation.
  - Mitigation: it matches `conversation_id OR parent_conversation_id`, and the test asserts both columns are
    covered along with all four non-terminal statuses.
- Risk: absorbing `ConversationNotFoundError` hides a real failure.
  - Mitigation: only that one error type is absorbed; everything else rethrows. Note this diverges from the
    two other call sites in the file, which return `{ success: false }` instead — converting to that style is
    a one-line change if reviewers prefer consistency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `/reset` to clear the active session and execution binding while preserving the project attachment.
  * Paused and failed resumable workflow runs are now abandoned during reset; active pending or running runs remain untouched.
  * Reset results report abandoned runs and workspace cleanup, including partial outcomes when an operation fails.

* **Documentation**
  * Updated `/reset` guidance and examples to reflect session and workspace clearing, run abandonment, and preserved project attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->