### PR TITLE
test(cli): build the web-dist tarball fixture in-process instead of spawning tar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ bun test packages/core/src/handlers/command-handler.test.ts  # Single file
 
 **Test isolation (mock.module pollution):** Bun's `mock.module()` permanently replaces modules in the process-wide cache — `mock.restore()` does NOT undo it ([oven-sh/bun#7823](https://github.com/oven-sh/bun/issues/7823)). To prevent cross-file pollution, packages that have conflicting `mock.module()` calls split their tests into separate `bun test` invocations: `@archon/core` (20 batches), `@archon/workflows` (5), `@archon/adapters` (6), `@archon/isolation` (3). See each package's `package.json` for the exact splits.
 
-**Do NOT run `bun test` from the repo root** — it discovers all test files across all packages and runs them in one process, causing ~135 mock pollution failures. Always use `bun run test` (which uses `bun --filter '*' test` for per-package isolation).
+**Do NOT run `bun test` from the repo root** — it discovers all test files across all packages and runs them in one process, causing ~135 mock pollution failures. Always use `bun run test` (which uses `bun --filter '*' --parallel test` for per-package isolation). Note the `--parallel`: all ten package test processes run concurrently, and each one that spawns subprocesses competes for the same cores — which is why subprocess-spawning tests should stay rare and cheap (see #2306).
 
 ### Type Checking & Linting
 

--- a/packages/cli/src/commands/serve.test.ts
+++ b/packages/cli/src/commands/serve.test.ts
@@ -9,7 +9,7 @@ import {
   afterEach,
   spyOn,
 } from 'bun:test';
-import { existsSync, mkdtempSync, rmSync } from 'fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -152,6 +152,16 @@ function concatBytes(blocks: Uint8Array[]): Uint8Array {
   return out;
 }
 
+/**
+ * The exact bytes the fixture claims to carry. Every test that extracts asserts
+ * the file lands with THIS content, not merely that a file exists — a hand-rolled
+ * binary format that nothing validates is a worse trap than the hang it replaced.
+ * A `size` field short by a few bytes, dropped padding, or a missing terminator
+ * all still produce an `index.html` and a `tar` exit 0; only comparing content
+ * catches them.
+ */
+const FIXTURE_INDEX_HTML = '<html>ok</html>';
+
 /** `web/` + `web/index.html`, tarred and gzipped — the shape `archon serve` downloads. */
 function buildWebTarball(indexHtml: string): Uint8Array {
   const body = new TextEncoder().encode(indexHtml);
@@ -180,7 +190,7 @@ describe('downloadWebDist', () => {
     // (see buildWebTarball) rather than by shelling out to `tar czf -`, so the
     // hook cannot hang on a subprocess (#2306).
     tmpRoot = mkdtempSync(join(tmpdir(), 'serve-webdist-test-'));
-    tarballBytes = buildWebTarball('<html>ok</html>');
+    tarballBytes = buildWebTarball(FIXTURE_INDEX_HTML);
     const hasher = new Bun.CryptoHasher('sha256');
     hasher.update(tarballBytes);
     tarballHash = hasher.digest('hex');
@@ -206,7 +216,9 @@ describe('downloadWebDist', () => {
 
     await downloadWebDist('9.9.9', targetDir, tarballHash);
 
-    expect(existsSync(join(targetDir, 'index.html'))).toBe(true);
+    // Content, not just existence — a truncated or corrupt fixture still yields
+    // an index.html and a `tar` exit 0, so only this assertion catches it.
+    expect(readFileSync(join(targetDir, 'index.html'), 'utf8')).toBe(FIXTURE_INDEX_HTML);
     // Only the tarball is fetched — checksums.txt must NOT be requested.
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(String(fetchSpy.mock.calls[0]?.[0])).toContain('archon-web.tar.gz');
@@ -236,11 +248,34 @@ describe('downloadWebDist', () => {
 
     await downloadWebDist('9.9.9', targetDir, '');
 
-    expect(existsSync(join(targetDir, 'index.html'))).toBe(true);
+    expect(readFileSync(join(targetDir, 'index.html'), 'utf8')).toBe(FIXTURE_INDEX_HTML);
     // Remote path fetches both checksums.txt and the tarball.
     expect(fetchSpy).toHaveBeenCalledTimes(2);
     const urls = fetchSpy.mock.calls.map(call => String(call[0]));
     expect(urls.some(u => u.includes('checksums.txt'))).toBe(true);
+  });
+});
+
+// Structural conformance of the hand-rolled archive, checked against the POSIX
+// ustar spec rather than against the writer itself.
+//
+// The extraction tests above catch a wrong *payload* (a short `size` field
+// truncates the file, which the content assertions see). They do NOT catch a
+// wrong *envelope*: bsdtar happily extracts an archive with no end-of-archive
+// marker and no block padding, so on macOS those corruptions pass silently and
+// would only surface as a platform-specific CI failure — precisely the class of
+// bug this file is being changed to remove. Hence these two.
+describe('buildWebTarball structural conformance', () => {
+  const archive = Bun.gunzipSync(buildWebTarball(FIXTURE_INDEX_HTML));
+
+  it('is a whole number of 512-byte blocks', () => {
+    expect(archive.length % 512).toBe(0);
+  });
+
+  it('ends with the two zero blocks that mark end-of-archive', () => {
+    const terminator = archive.subarray(archive.length - 1024);
+    expect(terminator.length).toBe(1024);
+    expect(terminator.every(byte => byte === 0)).toBe(true);
   });
 });
 

--- a/packages/cli/src/commands/serve.test.ts
+++ b/packages/cli/src/commands/serve.test.ts
@@ -9,7 +9,7 @@ import {
   afterEach,
   spyOn,
 } from 'bun:test';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -98,6 +98,75 @@ describe('parseEmbeddedChecksum', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// In-process tar.gz fixture builder.
+//
+// downloadWebDist shells out to `tar xzf -`, so the fixture it is fed has to be
+// a genuine gzipped tar — but BUILDING that fixture does not need a subprocess.
+// Spawning `tar czf -` here used to make the beforeAll hook the one thing in
+// this file that could hang on a child process, which is exactly how it failed
+// on windows CI (#2306). Emitting the ~1.1 KB ustar archive directly is
+// deterministic, platform-independent, and needs no `tar` on PATH.
+// ---------------------------------------------------------------------------
+
+/** Write ASCII into a fixed-width header field (NUL padding comes from the zeroed buffer). */
+function writeField(header: Uint8Array, offset: number, value: string, width: number): void {
+  header.set(new TextEncoder().encode(value).subarray(0, width), offset);
+}
+
+/** Write a ustar numeric field: zero-padded octal followed by a trailing NUL. */
+function writeOctalField(header: Uint8Array, offset: number, value: number, width: number): void {
+  writeField(header, offset, value.toString(8).padStart(width - 1, '0'), width - 1);
+}
+
+/** One 512-byte ustar header block. `typeflag` is '0' (file) or '5' (directory). */
+function tarHeader(name: string, size: number, typeflag: '0' | '5', mode: number): Uint8Array {
+  const header = new Uint8Array(512);
+  writeField(header, 0, name, 100);
+  writeOctalField(header, 100, mode, 8);
+  writeOctalField(header, 108, 0, 8); // uid
+  writeOctalField(header, 116, 0, 8); // gid
+  writeOctalField(header, 124, size, 12);
+  writeOctalField(header, 136, 0, 12); // mtime — fixed so the fixture is byte-stable
+  header.fill(0x20, 148, 156); // checksum field reads as 8 spaces while summing
+  header[156] = typeflag.charCodeAt(0);
+  writeField(header, 257, 'ustar', 6); // magic (NUL-terminated by the zeroed buffer)
+  writeField(header, 263, '00', 2); // version
+  let checksum = 0;
+  for (const byte of header) checksum += byte;
+  writeField(header, 148, checksum.toString(8).padStart(6, '0'), 6);
+  header[154] = 0x00;
+  header[155] = 0x20;
+  return header;
+}
+
+/** Concatenate blocks into one buffer. */
+function concatBytes(blocks: Uint8Array[]): Uint8Array {
+  const total = blocks.reduce((sum, block) => sum + block.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const block of blocks) {
+    out.set(block, offset);
+    offset += block.length;
+  }
+  return out;
+}
+
+/** `web/` + `web/index.html`, tarred and gzipped — the shape `archon serve` downloads. */
+function buildWebTarball(indexHtml: string): Uint8Array {
+  const body = new TextEncoder().encode(indexHtml);
+  const padding = new Uint8Array((512 - (body.length % 512)) % 512);
+  return Bun.gzipSync(
+    concatBytes([
+      tarHeader('web/', 0, '5', 0o755),
+      tarHeader('web/index.html', body.length, '0', 0o644),
+      body,
+      padding,
+      new Uint8Array(1024), // two zero blocks terminate the archive
+    ])
+  );
+}
+
 describe('downloadWebDist', () => {
   let tmpRoot: string;
   let tarballBytes: Uint8Array;
@@ -105,15 +174,13 @@ describe('downloadWebDist', () => {
   let fetchSpy: ReturnType<typeof spyOn>;
   let consoleLogSpy: ReturnType<typeof spyOn>;
 
-  beforeAll(async () => {
-    // Build a real tarball (one top-level dir with index.html — downloadWebDist
-    // extracts with --strip-components=1) and compute its true SHA-256.
+  beforeAll(() => {
+    // Fixture: a real gzipped tar with one top-level dir holding index.html —
+    // downloadWebDist extracts with --strip-components=1. Built in-process
+    // (see buildWebTarball) rather than by shelling out to `tar czf -`, so the
+    // hook cannot hang on a subprocess (#2306).
     tmpRoot = mkdtempSync(join(tmpdir(), 'serve-webdist-test-'));
-    const srcDir = join(tmpRoot, 'web');
-    mkdirSync(srcDir);
-    writeFileSync(join(srcDir, 'index.html'), '<html>ok</html>');
-    const proc = Bun.spawn(['tar', 'czf', '-', '-C', tmpRoot, 'web'], { stdout: 'pipe' });
-    tarballBytes = new Uint8Array(await new Response(proc.stdout).arrayBuffer());
+    tarballBytes = buildWebTarball('<html>ok</html>');
     const hasher = new Bun.CryptoHasher('sha256');
     hasher.update(tarballBytes);
     tarballHash = hasher.digest('hex');

--- a/packages/isolation/src/container/overlay-scripts.test.ts
+++ b/packages/isolation/src/container/overlay-scripts.test.ts
@@ -11,6 +11,7 @@
  */
 import { describe, test, expect } from 'bun:test';
 import { execFileSync } from 'child_process';
+import { resolveBashPath } from '@archon/git';
 import {
   mkdtempSync,
   mkdirSync,
@@ -43,6 +44,14 @@ const hasMkfifo = (() => {
   }
 })();
 
+// Resolved ONCE, via the same helper every production bash spawn uses. A bare
+// `execFileSync('bash', …)` is the one thing this file must not do on Windows:
+// CreateProcess searches System32 before PATH, so it resolves to the WSL
+// launcher (`C:\Windows\System32\bash.exe`) rather than Git-Bash — the exact
+// trap resolveBashPath() was written for (#1326). Resolving eagerly also keeps
+// the per-test cost to the spawn itself.
+const bashPath = resolveBashPath();
+
 /** Run a walk script under bash; returns NUL-split records + raw stdout/stderr. */
 function runScript(
   script: string,
@@ -54,7 +63,7 @@ function runScript(
   let stderr = '';
   let code = 0;
   try {
-    stdout = execFileSync('bash', ['-c', script, 'archon-overlay', upper, other, ws], {
+    stdout = execFileSync(bashPath, ['-c', script, 'archon-overlay', upper, other, ws], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
     });


### PR DESCRIPTION
## Summary

- **Problem:** `@archon/cli`'s `downloadWebDist` block intermittently fails on windows-latest at exactly ~5000 ms. The reported failure is a hook, not a test body, and it is immediately preceded by `killed 1 dangling process`.
- **Why it matters:** it red-lights CI on PRs that touch nothing near it, and until now nobody knew whether it was a hung child, a Bun stream bug, or plain slowness — which also left open whether the *engine* could hang the same way on Windows during a real workflow run.
- **What changed:** the fixture stops shelling out to `tar czf -` and emits its gzipped ustar archive in-process, so the hook has no child to hang on. Separately, `overlay-scripts.test.ts` now routes its shell through `resolveBashPath()` instead of a bare `execFileSync('bash', …)`.
- **What did *not* change (scope boundary):** no production code. No timeout was raised anywhere — that was explicitly off the table. This removes **one of four** subprocess sites in the windows cluster; the three `downloadWebDist` `it()` bodies still spawn the real `tar xzf -`, the `@archon/isolation` `.wh.` test still spawns a real shell, and the `@archon/workflows` bash-node tests still spawn a real shell, all by design. CI parallelism is untouched.

## The mechanism, and how it was proved

Three independent pieces of evidence, all pointing the same way: **the `tar` child was still running when the 5 s budget expired.**

**1. Reproduced the CI signature locally, digit for digit.** Hanging a `beforeAll` while a spawned child is still alive produces:

```
killed 1 dangling process

d-timeout-with-child.test.ts:
(fail) hook that hangs while a child is alive > (unnamed) [5000.97ms]
  ^ a beforeEach/afterEach hook timed out for this test.
```

which is the CI log line for line. Two things fall out of this:

- Bun **mislabels a `beforeAll` timeout** as "a beforeEach/afterEach hook". The `beforeEach`/`afterEach` in this block are synchronous and cannot time out, so the CI line can only mean `beforeAll`.
- The control case is what makes `dangling process` load-bearing: the *same* hook hung on an unrelated promise, with a child that had already exited, produces the timeout **without** that line. So `killed N dangling process` means "a child was still alive when the budget expired" — it is not routine cleanup noise.

**2. The CI corpus agrees.** A sweep of 599 `test.yml` runs (2026-06-26 → 07-29, 45 job logs) found `killed N dangling process` **0 times in 16 passing job logs**, and on windows timeouts only where a subprocess is spawned — never on one that doesn't spawn:

| package | test | ms | `dangling`? | spawns? |
|---|---|---|---|---|
| `@archon/workflows` | `bash node executes and captures stdout as output` (07-14) | 5109 | **yes** | yes |
| `@archon/workflows` | same (07-29) | 5031 | **yes** | yes |
| `@archon/cli` | `downloadWebDist > (unnamed)` (07-21, run 29801864393) | 5015 | **yes** | yes |
| `@archon/isolation` | `` `.wh.` (empty decoded name) does NOT wipe the parent dir `` (07-29, job 90566157638) | 5015 | **yes** | yes |
| `@archon/cli` | `downloadWebDist > (unnamed)` (07-29, job 90566157638) | 5015 | no | yes |
| `@archon/adapters` | `webhook installation.id primes the lookup cache` (×2) | 5109 / 5312 | no | no |
| `@archon/core` | `should abandon a running run` (×2) | 6734 / 6813 | no | no |

**The marker proves a live child when present; its absence proves nothing.** The last `@archon/cli` row is a subprocess timeout with no marker — so "no marker" is not evidence the child had exited. Only the positive direction is load-bearing, and that is the direction the local repro establishes.

Even so it separates the cluster into two genuinely different causes, which is why #2303's fix for the `@archon/core` rows does not generalize.

**3. Direct corroboration in the failing run itself** (29801864393). `afterAll`'s `rmSync(tmpRoot)` failed with:

```
error: EBUSY: resource busy or locked, rm 'C:\Users\RUNNER~1\AppData\Local\Temp\serve-webdist-test-JPJRnA'
```

the **only EBUSY in the entire 45-log corpus**. The `tar` child still held a handle on the temp dir — alive, not merely unreaped. In the same log the three `downloadWebDist` `it()` bodies appear neither as `(pass)` nor `(fail)` (`15 pass` = 10 checksum + 5 `serveCommand`), which is only consistent with `beforeAll` failing.

It is a hang, not slowness. Durations are bimodal with ~10x margin: `serve.test.ts` runs in **652 ms** on a passing windows job vs **5.37 s** in the failing one.

## What was ruled out

Recorded so nobody redoes it:

- **No production code is in this class.** Swept from the repo root over `Bun.spawn`, `Bun.$`, `child_process` imports, and every `new Response(proc.*)` site. Production spawns go through `execFileAsync` (`@archon/git`, `dag-executor`, `docker-exec`), `spawn` with `stdio: ['ignore', fd, fd]` (`--detach`), or SDK-driven stdio (`container-spawn`). None consume a stream without a settled process. **This is test-only — real workflow runs cannot hang this way.**
- **Bun eagerly drains piped stdio into an internal buffer** — verified with 5 MB of undrained stderr behind `await proc.exited`, no deadlock. So (a) "the stream never EOF'd after the child exited" is not a reachable state, and (b) `downloadWebDist`'s own extraction step, which awaits exit *before* reading a piped stderr, is safe as written. **No production fix was needed and none was made.**
- **`tar` is present and works on the runner.** The `it()` bodies that spawn `tar xzf -` pass on every other windows run; there is not a single `tar:` / `command not found` / `is not recognized` line in the corpus.
- **Exit code 130 carries no signal.** Under `--filter '*' --parallel`, the failing package exits 1, siblings get SIGINT, and the aggregate reports 130 *or* 1 nondeterministically. 130 also appears on plain assertion failures with no timeout anywhere. It is not a property of this failure class.
- **The WSL/`bash.exe` hypothesis is unsupported** — but the isolation test *is* a real cluster site. Zero hits for `wsl`, `/mnt/c/`, `System32\bash`, or `has no installed distributions`, so there is no evidence that bash *resolution* is what hangs. The `resolveBashPath()` change is therefore consistency hardening, **not** a proven flake fix. What it is not is a fix for a non-problem: job 90566157638 contains

  ```
  @archon/isolation:test | killed 1 dangling process
  @archon/isolation:test | ::error title=error: Test "`.wh.` (empty decoded name) does NOT wipe the parent dir" timed out after 5000ms::
  @archon/isolation:test | (fail) apply script — C1 whiteout-name traversal > `.wh.` … [5015.00ms]
  ```

  so #2306's row for it is correctly attributed and the mechanism matches (synchronous `execFileSync` blocks the loop, child still alive at 5s, killed as dangling). **An earlier revision of this PR claimed that test had never timed out. That was wrong** — the sweep that produced the claim missed run 30448971374 — and the claim is retracted here.

## UX Journey

Test-infrastructure only — no user-facing flow changes.

### Before

```
CI (windows-latest)          bun test (@archon/cli)         OS
─────────────────            ──────────────────────         ──
run `bun run test` ────────▶ serve.test.ts loads
                             beforeAll:
                               Bun.spawn(['tar','czf',…]) ─▶ CreateProcess
                               await Response(stdout)        ...child never exits
                             ── 5000 ms budget expires ──
                             killed 1 dangling process   ──▶ SIGKILL child
                             (fail) downloadWebDist > (unnamed)
                             afterAll: rmSync(tmpRoot)   ──▶ EBUSY (child held handle)
red CI  ◀──────────────────  3 it() bodies never ran
```

### After

```
CI (windows-latest)          bun test (@archon/cli)         OS
─────────────────            ──────────────────────         ──
run `bun run test` ────────▶ serve.test.ts loads
                             beforeAll:
                               *buildWebTarball()*           *(no subprocess)*
                               *Bun.gzipSync(ustar bytes)*
                             ── returns synchronously ──
                             it() ×3: downloadWebDist   ───▶ tar xzf -  (unchanged,
                               ▸ real `tar` still validates      awaits proc.exited)
                                 the hand-rolled archive
green CI ◀─────────────────  18 pass
```

## Architecture Diagram

### Before

```
  packages/cli/src/commands/
    serve.test.ts ──spawn──▶ [tar czf -]  (fixture build)
         │
         └──calls──▶ serve.ts::downloadWebDist ──spawn──▶ [tar xzf -]

  packages/isolation/src/container/
    overlay-scripts.test.ts ──spawn──▶ [bash]   (bare name → System32 first on win32)
         │
         └──imports──▶ ./overlay (buildApplyScript / buildSummaryScript)

  packages/git/src/exec.ts::resolveBashPath  ◀──used by── dag-executor only
```

### After

```
  packages/cli/src/commands/
    serve.test.ts [~] ──in-process──▶ (+) buildWebTarball()  ustar + Bun.gzipSync
         │                                  --x-- [tar czf -]   REMOVED
         └──calls──▶ serve.ts::downloadWebDist ──spawn──▶ [tar xzf -]   (unchanged)

  packages/isolation/src/container/
    overlay-scripts.test.ts [~] ══new══▶ @archon/git::resolveBashPath
         │                     ──spawn──▶ [Git-Bash]  (explicit absolute path on win32)
         └──imports──▶ ./overlay (unchanged)

  packages/git/src/exec.ts::resolveBashPath  ◀──used by── dag-executor, overlay-scripts.test [+]
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `cli/serve.test.ts` | `tar` (subprocess) | **removed** | fixture is now built in-process |
| `cli/serve.test.ts` | `buildWebTarball` (local) | **new** | ~50 lines, file-local; ustar + `Bun.gzipSync` |
| `cli/serve.test.ts` | `serve.ts::downloadWebDist` | unchanged | still exercises the real `tar xzf -` |
| `cli/serve.test.ts` | `node:fs` (`mkdirSync`, `writeFileSync`) | **removed** | no fixture files on disk any more |
| `isolation/overlay-scripts.test.ts` | `@archon/git::resolveBashPath` | **new** | `@archon/git` was already a declared dep |
| `isolation/overlay-scripts.test.ts` | `bash` (subprocess) | **modified** | absolute resolved path instead of bare `'bash'` |
| everything else | — | unchanged | no production module touched |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `tests`, `ci`
- Module: `cli:serve`, `isolation:container`

## Change Metadata

- Change type: `bug`
- Primary scope: `cli`

## Linked Issue

- Closes #
- Related #2306, #2240, #2186
- Depends on #
- Supersedes #

Deliberately **not** using `Closes` on any of them. #2306 tracks the whole windows cluster and this removes **one of its four** subprocess sites (`@archon/workflows` bash-node ×2 occurrences, `@archon/isolation` `.wh.`, `@archon/cli` `downloadWebDist`); #2240 and #2186 were already root-caused by #2303. New evidence for all three issues is in the commit message and above — worth pasting into #2306 rather than closing it.

## Validation Evidence (required)

```bash
bun run validate
```

- **Evidence provided:**
  - `check:bundled`, `check:bundled-skill`, `check:bundled-schema`, `check:pi-vendor-map`, `check:capability-matrix` — all OK.
  - `type-check` — every package exits 0 **except `@archon/docs-web`**, see below.
  - `lint --max-warnings 0` — clean.
  - `format:check` — clean.
  - `test` — full suite, **0 failures** across all 10 packages. Targeted: `serve.test.ts` 20 pass, `overlay-scripts.test.ts` 11 pass.
- **CI on the first revision (`ab6c6907`) was fully green**, including `test (windows-latest)` in 6m6s, where the three `downloadWebDist` bodies ran and passed (281 ms / 62 ms) with no dangling marker — in the failing run they were neither pass nor fail.

Repro harness for the mechanism (scratch, not committed) — four probes: drain-only, drain+`exited`, live-child-timeout, exited-child-timeout. Only the live-child one emits `killed 1 dangling process`.

**Mutation-tested the fixture writer** (each corruption applied, suite re-run, then reverted):

| corruption | before this revision | now |
|---|---|---|
| `size` field short by 3 bytes | 18 pass — **silent** | 2 fail (content assertions) |
| header checksum zeroed | — | 2 fail (extraction fails) |
| end-of-archive terminator dropped | 18 pass — **silent** | 1 fail (structural) |
| block padding dropped | 18 pass — **silent** | 1 fail (structural) |

Local `tar` is bsdtar 3.5.3, which tolerates a missing terminator and missing padding — so those two corruptions would have passed on macOS and only surfaced as a platform-specific CI failure, exactly the class of bug this PR removes. The one corruption still not caught is a bad `ustar` magic string, which is benign here: `tar` extracts byte-correct content anyway.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No** — strictly reduced: the fixture no longer writes `web/index.html` to a temp dir, and no longer spawns a process with access to it.

## Compatibility / Migration

- Backward compatible? **Yes** — test-only.
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

- **Verified scenarios:**
  - The hand-rolled ustar archive is genuinely valid: the `downloadWebDist` tests feed it to the real production `tar xzf - --strip-components=1` and assert the extracted file's **content**, and two structural tests check the archive against the POSIX ustar envelope. Verified by mutation, not by assertion — see the table above.
  - Mechanism reproduced and its control case confirmed locally on Bun 1.3.11 (the same version CI runs).
  - Bun's stdio buffering probed to 5 MB to clear the production extraction path.
  - `resolveBashPath()` returns a bare `'bash'` on non-win32, so the isolation change is a literal no-op on Linux/macOS; 11 pass locally.
  - The `.wh.` timeout was re-verified by pulling job 90566157638 from the API directly. Worth noting: `gh run view --job 90566157638 --log` returns the **wrong** logs (a later run's, timestamped after this job completed) — `gh api repos/.../actions/jobs/<id>/logs` is the one that returns the right bytes. The first tool silently produced a clean grep, which is how the retracted claim above got made.
- **Edge cases checked:** empty-file padding in the tar writer uses `(512 - (n % 512)) % 512`, so a 0- or exactly-512-byte body emits no stray padding block.
- **What was not verified:** the `@archon/workflows` and `@archon/isolation` sites are unaffected by this PR and will fire or not on their own. The macOS-only caveat on the `serve.ts` stdio probe stands: Bun's Windows stdio goes through libuv, so that leg is not platform-verified — it clears the *production* path on macOS/Linux only.

## Side Effects / Blast Radius (required)

- **Affected subsystems:** `@archon/cli` tests, `@archon/isolation` tests. No production module.
- **Potential unintended effects:** if the ustar writer were wrong, `downloadWebDist`'s three tests fail loudly on every platform — a wrong fixture cannot pass silently. On Windows, `resolveBashPath()` could select a different `bash.exe` than the bare name did; if a runner has no Git-Bash it returns the canonical default path and the spawn fails with a clear ENOENT naming it, instead of silently running WSL.
- **Guardrails:** the three `downloadWebDist` tests are the guard on the fixture. For the flake itself, `killed N dangling process` is now a known-meaning marker — its absence from future `@archon/cli` logs is the signal.

## Rollback Plan (required)

- Fast rollback: `git revert <sha>` — three files, no dependents.
- Feature flags: none.
- Observable failure symptoms: `serve.test.ts` failing on all platforms (bad fixture), or `overlay-scripts.test.ts` failing with ENOENT naming a bash path (Windows-only, missing Git-Bash).

## Risks and Mitigations

- **Risk:** the hand-rolled ustar writer drifts or is subtly wrong in a way that matters to a future `tar`.
  - **Mitigation:** validated three ways, none of them self-referential — extraction by the real `tar` (payload), content equality against the declared fixture string (truncation), and structural conformance to the POSIX ustar envelope (padding/terminator). Each was mutation-tested. It also stays byte-stable (fixed mtime 0), so the SHA-256 the tests compute is reproducible.
- **Risk:** this reads as "the windows flake is fixed" and #2306 gets closed prematurely.
  - **Mitigation:** stated in the scope boundary, the commit message, and the linked-issue section. This is one of **four** subprocess sites; the most recent occurrence across the others is 2026-07-29. Deliberately no `Closes`.
- **Risk:** the `resolveBashPath()` change looks like it is claiming a fix it cannot support.
  - **Mitigation:** labelled as hardening throughout. The site is a genuine cluster member, but the specific WSL-resolution mechanism is unsupported by the logs, so no causal claim is made for it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated testing guidance to recommend running isolated package tests (and avoid repo-root `bun test`) to prevent widespread mock pollution failures.

- **Tests**
  - Reworked web distribution tarball fixture creation to build a deterministic gzipped ustar archive in-process, removing reliance on external archive utilities.
  - Strengthened checksum-related assertions to verify extracted contents and added tarball structural conformance checks.
  - Improved shell regression tests by resolving and reusing the intended Bash executable path for consistent execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->