### PR TITLE
Fix Rosetta architecture detection in macOS installer

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "check:pi-vendor-map": "bun run scripts/generate-pi-vendor-map.ts --check",
     "generate:capability-matrix": "bun run scripts/generate-capability-matrix.ts",
     "check:capability-matrix": "bun run scripts/generate-capability-matrix.ts --check",
+    "test:install": "bash scripts/test-install.sh",
     "test": "bun --filter '*' --parallel test",
     "test:watch": "bun --filter @archon/server test:watch",
     "type-check": "bun --filter '*' type-check && bun x tsc --noEmit -p scripts/tsconfig.json",
@@ -35,7 +36,7 @@
     "build:web": "bun --filter @archon/web build",
     "dev:docs": "bun --filter @archon/docs-web dev",
     "build:docs": "bun --filter @archon/docs-web build",
-    "validate": "bun run check:bundled && bun run check:bundled-skill && bun run check:bundled-schema && bun run check:pi-vendor-map && bun run check:capability-matrix && bun run type-check && bun run lint --max-warnings 0 && bun run format:check && bun run test",
+    "validate": "bun run check:bundled && bun run check:bundled-skill && bun run check:bundled-schema && bun run check:pi-vendor-map && bun run check:capability-matrix && bun run type-check && bun run lint --max-warnings 0 && bun run format:check && bun run test:install && bun run test",
     "prepare": "husky",
     "setup-auth": "bun --filter @archon/server setup-auth"
   },

--- a/packages/docs-web/public/install
+++ b/packages/docs-web/public/install
@@ -64,6 +64,14 @@ detect_platform() {
       ;;
   esac
 
+  # Rosetta reports x86_64 even on Apple Silicon. Ask macOS for the physical
+  # architecture before selecting a release asset.
+  if [ "$os" = "darwin" ] \
+    && { [ "$arch" = "x86_64" ] || [ "$arch" = "amd64" ]; } \
+    && [ "$(sysctl -in sysctl.proc_translated 2>/dev/null || true)" = "1" ]; then
+    arch="arm64"
+  fi
+
   case "$arch" in
     x86_64|amd64)
       arch="x64"
@@ -202,6 +210,16 @@ main() {
   # Make executable
   chmod +x "$binary_path"
 
+  # Confirm the release can execute before replacing an existing installation.
+  info "Verifying downloaded binary..."
+  local version_output
+  if ! version_output=$("$binary_path" version 2>&1); then
+    error "Downloaded binary failed its version check:"
+    echo "$version_output" >&2
+    error "Existing installation was left unchanged."
+    exit 1
+  fi
+
   # Install
   info "Installing to $INSTALL_DIR/$BINARY_NAME..."
 
@@ -221,18 +239,8 @@ main() {
 
   success "Installed to $INSTALL_DIR/$BINARY_NAME"
 
-  # Verify installation
-  echo ""
-  info "Verifying installation..."
-  local version_output
-  if version_output=$("$INSTALL_DIR/$BINARY_NAME" version 2>&1); then
-    echo "$version_output"
-    success "Installation complete!"
-  else
-    warn "Binary installed but version check failed:"
-    echo "$version_output"
-    warn "The binary may not work correctly. Please verify manually with: $INSTALL_DIR/$BINARY_NAME version"
-  fi
+  echo "$version_output"
+  success "Installation complete!"
 
   # Check if in PATH
   if ! command -v "$BINARY_NAME" >/dev/null 2>&1; then
@@ -251,4 +259,6 @@ main() {
   echo ""
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -64,6 +64,14 @@ detect_platform() {
       ;;
   esac
 
+  # Rosetta reports x86_64 even on Apple Silicon. Ask macOS for the physical
+  # architecture before selecting a release asset.
+  if [ "$os" = "darwin" ] \
+    && { [ "$arch" = "x86_64" ] || [ "$arch" = "amd64" ]; } \
+    && [ "$(sysctl -in sysctl.proc_translated 2>/dev/null || true)" = "1" ]; then
+    arch="arm64"
+  fi
+
   case "$arch" in
     x86_64|amd64)
       arch="x64"
@@ -202,6 +210,16 @@ main() {
   # Make executable
   chmod +x "$binary_path"
 
+  # Confirm the release can execute before replacing an existing installation.
+  info "Verifying downloaded binary..."
+  local version_output
+  if ! version_output=$("$binary_path" version 2>&1); then
+    error "Downloaded binary failed its version check:"
+    echo "$version_output" >&2
+    error "Existing installation was left unchanged."
+    exit 1
+  fi
+
   # Install
   info "Installing to $INSTALL_DIR/$BINARY_NAME..."
 
@@ -221,18 +239,8 @@ main() {
 
   success "Installed to $INSTALL_DIR/$BINARY_NAME"
 
-  # Verify installation
-  echo ""
-  info "Verifying installation..."
-  local version_output
-  if version_output=$("$INSTALL_DIR/$BINARY_NAME" version 2>&1); then
-    echo "$version_output"
-    success "Installation complete!"
-  else
-    warn "Binary installed but version check failed:"
-    echo "$version_output"
-    warn "The binary may not work correctly. Please verify manually with: $INSTALL_DIR/$BINARY_NAME version"
-  fi
+  echo "$version_output"
+  success "Installation complete!"
 
   # Check if in PATH
   if ! command -v "$BINARY_NAME" >/dev/null 2>&1; then
@@ -251,4 +259,6 @@ main() {
   echo ""
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -21,21 +21,25 @@ assert_equals() {
 }
 
 make_platform_mocks() {
-  local arch="$1"
-  local translated="$2"
-  local mock_dir="$tmp_dir/mocks-$arch-$translated"
+  local os="$1"
+  local arch="$2"
+  local translated="$3"
+  local mock_dir="$tmp_dir/mocks-$os-$arch-$translated"
   mkdir -p "$mock_dir"
 
   cat >"$mock_dir/uname" <<EOF
 #!/usr/bin/env bash
 if [ "\$1" = "-s" ]; then
-  echo Darwin
+  echo "$os"
 else
   echo "$arch"
 fi
 EOF
   cat >"$mock_dir/sysctl" <<EOF
 #!/usr/bin/env bash
+if [ "$translated" = "fail" ]; then
+  exit 1
+fi
 echo "$translated"
 EOF
   chmod +x "$mock_dir/uname" "$mock_dir/sysctl"
@@ -47,14 +51,20 @@ detect_with_mocks() {
   PATH="$mock_dir:$PATH" bash -c 'source "$1"; detect_platform' _ "$installer"
 }
 
-rosetta_mocks="$(make_platform_mocks x86_64 1)"
+rosetta_mocks="$(make_platform_mocks Darwin x86_64 1)"
 assert_equals "darwin-arm64" "$(detect_with_mocks "$rosetta_mocks")" "Rosetta platform"
 
-intel_mocks="$(make_platform_mocks x86_64 0)"
+intel_mocks="$(make_platform_mocks Darwin x86_64 0)"
 assert_equals "darwin-x64" "$(detect_with_mocks "$intel_mocks")" "Native Intel platform"
 
-arm_mocks="$(make_platform_mocks arm64 1)"
+arm_mocks="$(make_platform_mocks Darwin arm64 1)"
 assert_equals "darwin-arm64" "$(detect_with_mocks "$arm_mocks")" "Native ARM platform"
+
+linux_mocks="$(make_platform_mocks Linux x86_64 1)"
+assert_equals "linux-x64" "$(detect_with_mocks "$linux_mocks")" "Linux x64 platform"
+
+missing_marker_mocks="$(make_platform_mocks Darwin x86_64 fail)"
+assert_equals "darwin-x64" "$(detect_with_mocks "$missing_marker_mocks")" "Native Intel platform without Rosetta marker"
 
 cmp -s "$installer" "$repo_root/packages/docs-web/public/install" \
   || fail "public installer mirror differs from scripts/install.sh"
@@ -86,5 +96,36 @@ if PATH="$mock_dir:$PATH" INSTALL_DIR="$install_dir" SKIP_CHECKSUM=true bash "$i
   fail "installer succeeded when downloaded binary failed its version check"
 fi
 assert_equals "working installation" "$(cat "$install_dir/archon")" "Existing installation after failed probe"
+
+success_mock_dir="$tmp_dir/success-install-mocks"
+success_install_dir="$tmp_dir/success-install-bin"
+mkdir -p "$success_mock_dir" "$success_install_dir"
+printf '%s\n' 'old installation' >"$success_install_dir/archon"
+cat >"$success_mock_dir/curl" <<'EOF'
+#!/usr/bin/env bash
+output=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    output="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+cat >"$output" <<'BINARY'
+#!/usr/bin/env bash
+if [ "$1" = "version" ]; then
+  echo "archon 1.2.3"
+fi
+BINARY
+EOF
+chmod +x "$success_mock_dir/curl"
+
+install_output=$(PATH="$success_mock_dir:$PATH" INSTALL_DIR="$success_install_dir" SKIP_CHECKSUM=true bash "$installer")
+assert_equals "archon 1.2.3" "$("$success_install_dir/archon" version)" "Successful probe replaces installation"
+case "$install_output" in
+  *"archon 1.2.3"*) ;;
+  *) fail "Installer prints verified version" ;;
+esac
 
 echo "Installer tests passed"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -51,20 +51,22 @@ detect_with_mocks() {
   PATH="$mock_dir:$PATH" bash -c 'source "$1"; detect_platform' _ "$installer"
 }
 
-rosetta_mocks="$(make_platform_mocks Darwin x86_64 1)"
-assert_equals "darwin-arm64" "$(detect_with_mocks "$rosetta_mocks")" "Rosetta platform"
+assert_platform() {
+  local os="$1"
+  local arch="$2"
+  local translated="$3"
+  local expected="$4"
+  local description="$5"
+  local mocks
+  mocks="$(make_platform_mocks "$os" "$arch" "$translated")"
+  assert_equals "$expected" "$(detect_with_mocks "$mocks")" "$description"
+}
 
-intel_mocks="$(make_platform_mocks Darwin x86_64 0)"
-assert_equals "darwin-x64" "$(detect_with_mocks "$intel_mocks")" "Native Intel platform"
-
-arm_mocks="$(make_platform_mocks Darwin arm64 1)"
-assert_equals "darwin-arm64" "$(detect_with_mocks "$arm_mocks")" "Native ARM platform"
-
-linux_mocks="$(make_platform_mocks Linux x86_64 1)"
-assert_equals "linux-x64" "$(detect_with_mocks "$linux_mocks")" "Linux x64 platform"
-
-missing_marker_mocks="$(make_platform_mocks Darwin x86_64 fail)"
-assert_equals "darwin-x64" "$(detect_with_mocks "$missing_marker_mocks")" "Native Intel platform without Rosetta marker"
+assert_platform Darwin x86_64 1 darwin-arm64 "Rosetta platform"
+assert_platform Darwin x86_64 0 darwin-x64 "Native Intel platform"
+assert_platform Darwin arm64 1 darwin-arm64 "Native ARM platform"
+assert_platform Linux x86_64 1 linux-x64 "Linux x64 platform"
+assert_platform Darwin x86_64 fail darwin-x64 "Native Intel platform without Rosetta marker"
 
 cmp -s "$installer" "$repo_root/packages/docs-web/public/install" \
   || fail "public installer mirror differs from scripts/install.sh"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+installer="$repo_root/scripts/install.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local description="$3"
+
+  [ "$expected" = "$actual" ] || fail "$description: expected $expected, got $actual"
+}
+
+make_platform_mocks() {
+  local arch="$1"
+  local translated="$2"
+  local mock_dir="$tmp_dir/mocks-$arch-$translated"
+  mkdir -p "$mock_dir"
+
+  cat >"$mock_dir/uname" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "-s" ]; then
+  echo Darwin
+else
+  echo "$arch"
+fi
+EOF
+  cat >"$mock_dir/sysctl" <<EOF
+#!/usr/bin/env bash
+echo "$translated"
+EOF
+  chmod +x "$mock_dir/uname" "$mock_dir/sysctl"
+  echo "$mock_dir"
+}
+
+detect_with_mocks() {
+  local mock_dir="$1"
+  PATH="$mock_dir:$PATH" bash -c 'source "$1"; detect_platform' _ "$installer"
+}
+
+rosetta_mocks="$(make_platform_mocks x86_64 1)"
+assert_equals "darwin-arm64" "$(detect_with_mocks "$rosetta_mocks")" "Rosetta platform"
+
+intel_mocks="$(make_platform_mocks x86_64 0)"
+assert_equals "darwin-x64" "$(detect_with_mocks "$intel_mocks")" "Native Intel platform"
+
+arm_mocks="$(make_platform_mocks arm64 1)"
+assert_equals "darwin-arm64" "$(detect_with_mocks "$arm_mocks")" "Native ARM platform"
+
+cmp -s "$installer" "$repo_root/packages/docs-web/public/install" \
+  || fail "public installer mirror differs from scripts/install.sh"
+
+mock_dir="$tmp_dir/install-mocks"
+install_dir="$tmp_dir/install-bin"
+mkdir -p "$mock_dir" "$install_dir"
+printf '%s\n' 'working installation' >"$install_dir/archon"
+cat >"$mock_dir/curl" <<'EOF'
+#!/usr/bin/env bash
+output=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    output="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+cat >"$output" <<'BINARY'
+#!/usr/bin/env bash
+echo "illegal hardware instruction" >&2
+exit 1
+BINARY
+EOF
+chmod +x "$mock_dir/curl"
+
+if PATH="$mock_dir:$PATH" INSTALL_DIR="$install_dir" SKIP_CHECKSUM=true bash "$installer" >/dev/null 2>&1; then
+  fail "installer succeeded when downloaded binary failed its version check"
+fi
+assert_equals "working installation" "$(cat "$install_dir/archon")" "Existing installation after failed probe"
+
+echo "Installer tests passed"


### PR DESCRIPTION
## Summary

- Problem: the quick installer selected `darwin-x64` when invoked from a Rosetta-translated shell on Apple Silicon.
- Why it matters: the downloaded binary passed checksum verification but could not run, leaving users with an unusable CLI.
- What changed: the installer detects Rosetta, selects ARM64, verifies a downloaded binary before replacement, and adds deterministic shell coverage.
- What did **not** change (scope boundary): release targets and Homebrew remain unchanged; the release pipeline already publishes both Darwin assets.

## UX Journey

### Before

```
Apple-Silicon user in Rosetta shell    Installer                 Release assets
──────────────────────────────────    ─────────                 ──────────────
curl .../install | bash ───────────▶  uname -m => x86_64
                                      selects darwin-x64 ─────▶ downloads x64 binary
                                      checksum passes
                                      replaces existing CLI
                                      version probe fails ────▶ unusable install
```

### After

```
Apple-Silicon user in Rosetta shell    Installer                         Release assets
──────────────────────────────────    ─────────                         ──────────────
curl .../install | bash ───────────▶  uname -m => x86_64
                                      [sysctl.proc_translated => 1]
                                      [selects darwin-arm64] ─────────▶ downloads ARM64 binary
                                      [probes downloaded binary first]
                                      replaces existing CLI only on success
```

## Architecture Diagram

### Before

```
scripts/install.sh ───────────────▶ release asset URL
        │
        └─────────────────────────▶ packages/docs-web/public/install (mirrored static installer)
package.json ─────────────────────▶ validation commands
```

### After

```
[~] scripts/install.sh ───────────▶ release asset URL
        │ Rosetta-aware platform resolver
        ├─────────────────────────▶ [~] packages/docs-web/public/install
        └=========================> [+] scripts/test-install.sh
[~] package.json =================▶ [+] installer regression validation
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `scripts/install.sh` | GitHub release assets | **modified** | Selects ARM64 for translated Darwin x64 processes. |
| `scripts/install.sh` | `packages/docs-web/public/install` | **modified** | Public installer remains byte-identical to the canonical script. |
| `scripts/test-install.sh` | installer copies | **new** | Tests platform resolution, mirror equality, and failed-probe preservation. |
| `package.json` | `scripts/test-install.sh` | **new** | Runs installer regression coverage through `validate`. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `cli`, `docs`, `tests`
- Module: `cli:installer`

## Change Metadata

- Change type: `bug`
- Primary scope: `cli`

## Linked Issue

- Closes #2295
- Related # None
- Depends on # None
- Supersedes # None

## Validation Evidence (required)

Commands and result summary:

```bash
bash scripts/test-install.sh
bash -n scripts/install.sh
cmp -s scripts/install.sh packages/docs-web/public/install
bun run validate
```

- Evidence provided (test/log/trace/screenshot): installer tests pass locally; syntax and byte-for-byte mirror checks pass. The implementation validation recorded `bun run type-check`, `bun run lint`, `bun run format:check`, `bun run test` (6,375 passed), and `bun run build` as passing.
- If any command is intentionally skipped, explain why: full validation was not rerun during PR creation because the unchanged committed implementation was already fully validated; the focused installer checks above were rerun after applying it.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`
- If any `Yes`, describe risk and mitigation: Not applicable.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Database migration needed? `No`
- If yes, exact upgrade steps: Not applicable. Users with an already-installed incorrect binary should rerun the installer after release from their preferred shell.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: mocked Rosetta x86_64 selects `darwin-arm64`; native Intel selects `darwin-x64`; native ARM selects `darwin-arm64`.
- Edge cases checked: unavailable/false Rosetta marker does not override x64; a failed downloaded-binary probe leaves an existing installation unchanged; public installer mirror is identical.
- What was not verified: execution on physical Apple-Silicon/Rosetta hardware and an actual release download.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Unix quick installer, docs-hosted installer artifact, root validation command.
- Potential unintended effects: a malformed `sysctl` result could affect Darwin asset choice.
- Guardrails/monitoring for early detection: override occurs only for exact `sysctl.proc_translated=1`; deterministic tests cover Rosetta, native Intel, native ARM, mirror synchronization, and probe failure.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `03a01cfe` from this PR branch.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: installer logs an unexpected platform or fails the downloaded-binary version probe before installation.

## Risks and Mitigations

- Risk: native Intel systems could be misidentified as ARM64.
  - Mitigation: only override `x86_64`/`amd64` when macOS explicitly reports `sysctl.proc_translated=1`; native Intel remains x64.
- Risk: the deployed installer could drift from the source copy.
  - Mitigation: regression test enforces byte-for-byte equality.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved installation support for Apple Silicon Macs running under Rosetta.
  * Installers now verify downloaded binaries before replacing an existing installation.
  * Successful installations display the verified application version and completion message.

* **Bug Fixes**
  * Failed or incompatible downloads no longer overwrite existing installations.
  * Installer scripts can now be safely sourced without running automatically.

* **Tests**
  * Added automated coverage for platform detection, installation validation, failure handling, and installer consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->