### PR TITLE
fix(workflows): complete tool timing at result boundary

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -3503,6 +3503,54 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
     expect(typeof completedEvents[0][0].data?.duration_ms).toBe('number');
   });
 
+  it('emits a DAG tool_completed duration at tool_result, excluding later assistant time', async () => {
+    const mockStore = createMockStore();
+    const mockDeps = createMockDeps(mockStore);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'tool', toolName: 'read_file', toolInput: { path: '/a' } };
+      setSystemTime(new Date('2026-01-01T00:00:00.050Z'));
+      yield { type: 'tool_result', toolName: 'read_file', toolOutput: 'contents' };
+      setSystemTime(new Date('2026-01-01T00:01:00.050Z'));
+      yield { type: 'assistant', content: 'post-tool reasoning' };
+      yield { type: 'result', sessionId: 'dag-sess-tool-result' };
+    });
+
+    try {
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag-tool-result',
+        testDir,
+        { name: 'dag-tool-result-test', nodes: [node('my-cmd')] },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+    } finally {
+      setSystemTime();
+    }
+
+    const completedEvents = (
+      mockStore.createWorkflowEvent as ReturnType<typeof mock>
+    ).mock.calls.filter(
+      ([event]: [{ event_type: string }]) => event.event_type === 'tool_completed'
+    );
+    expect(completedEvents).toHaveLength(1);
+    expect(completedEvents[0][0].data).toMatchObject({
+      tool_name: 'read_file',
+      duration_ms: 50,
+    });
+  });
+
   it('should not emit tool_completed when no tools were called in DAG node', async () => {
     const mockStore = createMockStore();
     const mockDeps = createMockDeps(mockStore);
@@ -4902,6 +4950,66 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
   // ─── Loop Node Tests ─────────────────────────────────────────────────────
 
   describe('loop node execution', () => {
+    it('emits a loop tool_completed duration at tool_result, excluding later assistant time', async () => {
+      const store = createMockStore();
+      const mockDeps = createMockDeps(store);
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun('loop-tool-result-run');
+
+      setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+      mockSendQueryDag.mockImplementation(function* () {
+        yield { type: 'tool', toolName: 'read_file', toolInput: { path: '/a' } };
+        setSystemTime(new Date('2026-01-01T00:00:00.050Z'));
+        yield { type: 'tool_result', toolName: 'read_file', toolOutput: 'contents' };
+        setSystemTime(new Date('2026-01-01T00:01:00.050Z'));
+        yield { type: 'assistant', content: 'Done. <promise>COMPLETE</promise>' };
+        yield { type: 'result', sessionId: 'loop-sess-tool-result' };
+      });
+
+      try {
+        await executeDagWorkflow(
+          mockDeps,
+          platform,
+          'conv-dag',
+          testDir,
+          {
+            name: 'dag-loop-tool-result',
+            nodes: [
+              {
+                id: 'my-loop',
+                loop: {
+                  prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
+                  until: 'COMPLETE',
+                  max_iterations: 5,
+                },
+              },
+            ],
+          },
+          workflowRun,
+          'claude',
+          undefined,
+          join(testDir, 'artifacts'),
+          join(testDir, 'logs'),
+          'main',
+          'docs/',
+          minimalConfig
+        );
+      } finally {
+        setSystemTime();
+      }
+
+      const completedEvents = (
+        store.createWorkflowEvent as ReturnType<typeof mock>
+      ).mock.calls.filter(
+        ([event]: [{ event_type: string }]) => event.event_type === 'tool_completed'
+      );
+      expect(completedEvents).toHaveLength(1);
+      expect(completedEvents[0][0].data).toMatchObject({
+        tool_name: 'read_file',
+        duration_ms: 50,
+      });
+    });
+
     it('completes on <promise>COMPLETE</promise> signal in first iteration', async () => {
       mockSendQueryDag.mockImplementation(function* () {
         yield { type: 'assistant', content: 'Did the task. <promise>COMPLETE</promise>' };

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1578,6 +1578,34 @@ async function executeNodeInternal(
             );
           });
       } else if (msg.type === 'tool_result' && msg.toolName) {
+        const now = Date.now();
+        if (lastToolStartedAt) {
+          const completedTool = lastToolStartedAt;
+          getWorkflowEventEmitter().emit({
+            type: 'tool_completed',
+            runId: workflowRun.id,
+            toolName: completedTool.toolName,
+            stepName: node.id,
+            durationMs: now - completedTool.startedAt,
+          });
+          deps.store
+            .createWorkflowEvent({
+              workflow_run_id: workflowRun.id,
+              event_type: 'tool_completed',
+              step_name: stepName,
+              data: {
+                tool_name: completedTool.toolName,
+                duration_ms: now - completedTool.startedAt,
+              },
+            })
+            .catch((err: Error) => {
+              getLog().error(
+                { err, workflowRunId: workflowRun.id, eventType: 'tool_completed' },
+                'workflow_event_persist_failed'
+              );
+            });
+          lastToolStartedAt = null;
+        }
         if (streamingMode === 'stream' && platform.sendStructuredEvent) {
           await platform.sendStructuredEvent(conversationId, msg);
         }
@@ -4279,8 +4307,35 @@ async function executeLoopNode(
             .catch((err: Error) => {
               logEventStoreError(err, i);
             });
-        } else if (msg.type === 'tool_result' && platform.sendStructuredEvent) {
-          await platform.sendStructuredEvent(conversationId, msg);
+        } else if (msg.type === 'tool_result' && msg.toolName) {
+          const now = Date.now();
+          if (lastToolStartedAt) {
+            const completedTool = lastToolStartedAt;
+            getWorkflowEventEmitter().emit({
+              type: 'tool_completed',
+              runId: workflowRun.id,
+              toolName: completedTool.toolName,
+              stepName: node.id,
+              durationMs: now - completedTool.startedAt,
+            });
+            deps.store
+              .createWorkflowEvent({
+                workflow_run_id: workflowRun.id,
+                event_type: 'tool_completed',
+                step_name: stepName,
+                data: {
+                  tool_name: completedTool.toolName,
+                  duration_ms: now - completedTool.startedAt,
+                },
+              })
+              .catch((err: Error) => {
+                logEventStoreError(err, i);
+              });
+            lastToolStartedAt = null;
+          }
+          if (platform.sendStructuredEvent) {
+            await platform.sendStructuredEvent(conversationId, msg);
+          }
         }
         // rate_limit chunks: already log.warn'd in claude.ts; not surfaced to SSE per design
       }


### PR DESCRIPTION
## Summary

- Problem: Workflow `tool_completed.duration_ms` can include later model thinking and streaming after a tool has finished.
- Why it matters: Persisted telemetry, verbose CLI output, and workflow history misreport tool execution time.
- What changed: Finalize normal DAG-node and loop-iteration tool timings on the provider-normalized `tool_result` boundary, with deterministic regressions for delayed post-tool model output.
- What did **not** change (scope boundary): Provider contracts, event schemas, CLI rendering, direct-chat timing, and fallback handling for streams that omit `tool_result`.

## UX Journey

### Before

```
Workflow user             Workflow executor             AI provider
─────────────             ─────────────────             ───────────
runs AI node ───────────▶ starts tool timer
                                                       tool ───────▶
                                                       tool_result ─▶ forwarded only
                                                       assistant ───▶
                                                       result ──────▶ completes timer
sees inflated duration ◀─ persists inflated duration
```

### After

```
Workflow user             Workflow executor             AI provider
─────────────             ─────────────────             ───────────
runs AI node ───────────▶ starts tool timer
                                                       tool ───────▶
                                                       tool_result ─▶ [completes timer]
sees tool-only duration ◀ [persists accurate duration]  assistant ───▶
                                                       result ──────▶
```

## Architecture Diagram

### Before

```
@archon/providers MessageChunk
          │ tool / tool_result
          ▼
@archon/workflows dag-executor ──▶ workflow event store ──▶ @archon/cli verbose output
          │                                                       │
          └───────────────────────────────────────────────────────▶ @archon/web workflow history
tool_result forwards to adapters; timing closes only at later tool/result
```

### After

```
@archon/providers MessageChunk
          │ tool / tool_result
          ▼
@archon/workflows dag-executor [~] ──▶ workflow event store ──▶ @archon/cli verbose output
          │                                                       │
          └───────────────────────────────────────────────────────▶ @archon/web workflow history
[tool_result completes and persists timing; later tool/result remain fallbacks]
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `@archon/providers` MessageChunk | `@archon/workflows` dag-executor | **modified** | Existing `tool_result` now closes pending timing. |
| `@archon/workflows` dag-executor | workflow event store | **modified** | Persists completion at the actual execution boundary. |
| workflow event store | `@archon/cli` verbose output | unchanged | Displays the stored duration. |
| workflow event store | `@archon/web` workflow history | unchanged | Consumes the existing event lifecycle. |

## Label Snapshot

- Risk: risk: low
- Size: size: S
- Scope: workflows
- Module: workflows:dag-executor

## Change Metadata

- Change type: bug
- Primary scope: workflows

## Linked Issue

- Closes #2296
- Related # None
- Depends on # None
- Supersedes # None

## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check
bun run lint
bun run format:check
bun run test
bun run build
```

- Evidence provided (test/log/trace/screenshot): All commands passed; 6,374 tests passed with 0 failures. Deterministic DAG and loop timing regressions cover a 50 ms tool result followed by 60 seconds of model output.
- If any command is intentionally skipped, explain why: None.

## Security Impact (required)

- New permissions/capabilities? (No)
- New external network calls? (No)
- Secrets/tokens handling changed? (No)
- File system access scope changed? (No)
- If any Yes, describe risk and mitigation: Not applicable.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Database migration needed? (No)
- If yes, exact upgrade steps: Not applicable.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Normal DAG AI nodes and loop iterations complete a tool at `tool_result`; persisted duration excludes a deliberately delayed subsequent assistant turn.
- Edge cases checked: Existing next-tool and terminal-result completion behavior remains as a fallback for streams without `tool_result`.
- What was not verified: Live provider runs were not required; provider-normalized event sequences are covered deterministically.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: AI DAG-node and loop-iteration workflow event timing, plus consumers of persisted duration telemetry.
- Potential unintended effects: Providers that omit `tool_result` could otherwise lose completion events.
- Guardrails/monitoring for early detection: Existing fallback completion paths are retained; regression tests assert one completion with the correct timing boundary.

## Rollback Plan (required)

- Fast rollback command/path: Revert the DAG executor timing commit.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: Missing or duplicate `tool_completed` events, or durations again including post-tool model time.

## Risks and Mitigations

- Risk: Provider stream ordering or missing result chunks can vary.
  - Mitigation: Preserve the existing next-tool and terminal-result completion paths as compatibility fallbacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool execution timing so completion durations reflect the moment a tool returns results, excluding subsequent assistant response streaming.
  * Ensured tool completion events are consistently emitted and recorded for iterative workflow executions.
  * Improved forwarding of structured tool events during loop-based workflows.

* **Tests**
  * Added coverage verifying accurate completion timing for standard and iterative workflow paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->