### PR TITLE
fix(providers): record resolved model metadata

### DIFF
--- a/packages/docs-web/src/content/docs/reference/architecture.md
+++ b/packages/docs-web/src/content/docs/reference/architecture.md
@@ -347,7 +347,9 @@ export type MessageChunk =
       cost?: number;
       stopReason?: string;
       numTurns?: number;
-      modelUsage?: Record<string, unknown>;
+      // Concrete provider-reported model. Omitted for providers such as Codex
+      // whose SDK completion events do not expose the resolved model.
+      resolvedModel?: ResolvedModel;
       // Session-resume outcome: true = restored, false = requested but fell back
       // to a fresh session, omitted = no resume requested. Set only when
       // resumeSessionId was passed (stamp it via withResumedOutcome).

--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -246,9 +246,9 @@ describe('ClaudeProvider', () => {
           num_turns: 3,
           modelUsage: {
             'claude-sonnet-4-6': {
-              input_tokens: 100,
-              output_tokens: 50,
-              cache_read_input_tokens: 10,
+              inputTokens: 100,
+              outputTokens: 50,
+              cacheReadInputTokens: 10,
             },
           },
         };
@@ -268,6 +268,60 @@ describe('ClaudeProvider', () => {
         numTurns: 3,
         resolvedModel: { id: 'claude-sonnet-4-6' },
       });
+      // Single-model usage is unambiguous — no ambiguity warning.
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+
+    test('picks the greatest-output-token model and warns when modelUsage has multiple keys', async () => {
+      // A subagent pinned via `agents:` (or a fallbackModel takeover) puts more
+      // than one model in the record, and key order carries no guarantee — the
+      // main model here is deliberately NOT first.
+      mockQuery.mockImplementation(async function* () {
+        yield {
+          type: 'result',
+          session_id: 'sid-multi-model',
+          modelUsage: {
+            'claude-haiku-4-5-20251001': {
+              inputTokens: 400,
+              outputTokens: 20,
+              cacheReadInputTokens: 0,
+            },
+            'claude-sonnet-5': {
+              inputTokens: 120,
+              outputTokens: 900,
+              cacheReadInputTokens: 10,
+            },
+          },
+        };
+      });
+
+      const chunks = [];
+      for await (const chunk of client.sendQuery('test', '/workspace')) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks[0]).toMatchObject({ resolvedModel: { id: 'claude-sonnet-5' } });
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        {
+          models: ['claude-haiku-4-5-20251001', 'claude-sonnet-5'],
+          selected: 'claude-sonnet-5',
+        },
+        'claude.resolved_model_ambiguous'
+      );
+    });
+
+    test('omits resolvedModel when modelUsage is an empty record', async () => {
+      mockQuery.mockImplementation(async function* () {
+        yield { type: 'result', session_id: 'sid-empty-usage', modelUsage: {} };
+      });
+
+      const chunks = [];
+      for await (const chunk of client.sendQuery('test', '/workspace')) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks[0]).not.toHaveProperty('resolvedModel');
+      expect(mockLogger.warn).not.toHaveBeenCalled();
     });
 
     test('omits cost, stopReason, numTurns, and resolvedModel when SDK result has none', async () => {

--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -236,7 +236,7 @@ describe('ClaudeProvider', () => {
       });
     });
 
-    test('yields result with cost, stopReason, numTurns, modelUsage when SDK provides them', async () => {
+    test('yields result with cost, stopReason, numTurns, and a resolved model when SDK provides them', async () => {
       mockQuery.mockImplementation(async function* () {
         yield {
           type: 'result',
@@ -244,7 +244,7 @@ describe('ClaudeProvider', () => {
           total_cost_usd: 0.0042,
           stop_reason: 'end_turn',
           num_turns: 3,
-          model_usage: {
+          modelUsage: {
             'claude-sonnet-4-6': {
               input_tokens: 100,
               output_tokens: 50,
@@ -266,17 +266,11 @@ describe('ClaudeProvider', () => {
         cost: 0.0042,
         stopReason: 'end_turn',
         numTurns: 3,
-        modelUsage: {
-          'claude-sonnet-4-6': {
-            input_tokens: 100,
-            output_tokens: 50,
-            cache_read_input_tokens: 10,
-          },
-        },
+        resolvedModel: { id: 'claude-sonnet-4-6' },
       });
     });
 
-    test('omits cost, stopReason, numTurns, modelUsage when SDK result has none', async () => {
+    test('omits cost, stopReason, numTurns, and resolvedModel when SDK result has none', async () => {
       mockQuery.mockImplementation(async function* () {
         yield { type: 'result', session_id: 'sid-bare' };
       });
@@ -289,7 +283,7 @@ describe('ClaudeProvider', () => {
       expect(chunks[0]).not.toHaveProperty('cost');
       expect(chunks[0]).not.toHaveProperty('stopReason');
       expect(chunks[0]).not.toHaveProperty('numTurns');
-      expect(chunks[0]).not.toHaveProperty('modelUsage');
+      expect(chunks[0]).not.toHaveProperty('resolvedModel');
     });
 
     test('omits stopReason when stop_reason is null', async () => {

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -35,6 +35,7 @@ import {
   type HookCallbackMatcher,
   type SDKAssistantMessageError,
   type SDKResultMessage,
+  type ModelUsage,
 } from '@anthropic-ai/claude-agent-sdk';
 import type {
   IAgentProvider,
@@ -86,6 +87,44 @@ function normalizeClaudeUsage(usage?: {
     output,
     ...(typeof total === 'number' ? { total } : {}),
   };
+}
+
+/**
+ * Pick the concrete model that did the bulk of a turn's work from the SDK's
+ * per-model usage record.
+ *
+ * More than one entry is reachable for a single turn: a subagent pinned to
+ * another model via `agents:`, or a `fallbackModel` takeover. Key insertion
+ * order happens to put the main model first today, but nothing in the SDK
+ * guarantees it — so select by greatest output-token count (the main model
+ * produces the bulk of the output) and WARN whenever the record is ambiguous,
+ * so a multi-model turn is visible instead of silently collapsed.
+ *
+ * `modelUsage` is non-optional in the SDK types but arrives over an IPC
+ * boundary, so the absent/empty cases stay guarded — absence yields undefined
+ * and the caller omits `resolvedModel` entirely rather than inventing a value.
+ * On a tie (or output counts the SDK didn't send) the first key wins, which is
+ * exactly the pre-#2314 behavior — safe, and the warning still fires.
+ */
+function selectResolvedModelId(
+  modelUsage: Record<string, ModelUsage> | undefined
+): string | undefined {
+  if (!modelUsage) return undefined;
+  const entries = Object.entries(modelUsage);
+  if (entries.length === 0) return undefined;
+  if (entries.length === 1) return entries[0][0];
+
+  const outputTokensOf = (usage: ModelUsage): number =>
+    Number.isFinite(usage.outputTokens) ? usage.outputTokens : 0;
+  let selected = entries[0];
+  for (const entry of entries.slice(1)) {
+    if (outputTokensOf(entry[1]) > outputTokensOf(selected[1])) selected = entry;
+  }
+  getLog().warn(
+    { models: entries.map(([id]) => id), selected: selected[0] },
+    'claude.resolved_model_ambiguous'
+  );
+  return selected[0];
 }
 
 /**
@@ -992,9 +1031,7 @@ async function* streamClaudeMessages(
       yield { type: 'rate_limit', rateLimitInfo: rateLimitMsg.rate_limit_info ?? {} };
     } else if (event.type === 'result') {
       const resultMsg = msg as SDKResultMessage;
-      const resolvedModelId = resultMsg.modelUsage
-        ? Object.keys(resultMsg.modelUsage)[0]
-        : undefined;
+      const resolvedModelId = selectResolvedModelId(resultMsg.modelUsage);
       // The terminal result resolves any recorded synthetic error message.
       const syntheticError = pendingSdkError;
       pendingSdkError = undefined;

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -34,7 +34,7 @@ import {
   type HookCallback,
   type HookCallbackMatcher,
   type SDKAssistantMessageError,
-  type TerminalReason,
+  type SDKResultMessage,
 } from '@anthropic-ai/claude-agent-sdk';
 import type {
   IAgentProvider,
@@ -991,40 +991,21 @@ async function* streamClaudeMessages(
       getLog().warn({ rateLimitInfo: rateLimitMsg.rate_limit_info }, 'claude.rate_limit_event');
       yield { type: 'rate_limit', rateLimitInfo: rateLimitMsg.rate_limit_info ?? {} };
     } else if (event.type === 'result') {
-      const resultMsg = msg as {
-        session_id?: string;
-        is_error?: boolean;
-        subtype?: string;
-        usage?: { input_tokens?: number; output_tokens?: number; total_tokens?: number };
-        structured_output?: unknown;
-        total_cost_usd?: number;
-        stop_reason?: string | null;
-        num_turns?: number;
-        errors?: string[];
-        result?: string;
-        terminal_reason?: TerminalReason;
-        api_error_status?: number | null;
-        model_usage?: Record<
-          string,
-          {
-            input_tokens: number;
-            output_tokens: number;
-            cache_read_input_tokens?: number;
-            cache_creation_input_tokens?: number;
-          }
-        >;
-      };
+      const resultMsg = msg as SDKResultMessage;
+      const resolvedModelId = resultMsg.modelUsage
+        ? Object.keys(resultMsg.modelUsage)[0]
+        : undefined;
       // The terminal result resolves any recorded synthetic error message.
       const syntheticError = pendingSdkError;
       pendingSdkError = undefined;
       const tokens = normalizeClaudeUsage(resultMsg.usage);
-      const sdkErrors = Array.isArray(resultMsg.errors) ? resultMsg.errors : undefined;
+      const sdkErrors = 'errors' in resultMsg ? resultMsg.errors : undefined;
 
       // `is_error: true` + `subtype: 'success'` is ambiguous: it is BOTH the
       // SDK's stop-sequence termination encoding (#1425, a legitimate success)
       // AND its API-failure-as-text encoding (#1797 — auth/billing/rate-limit
       // errors that even set stop_reason: 'stop_sequence').
-      const isSuccessWithErrorFlag = resultMsg.is_error === true && resultMsg.subtype === 'success';
+      const isSuccessWithErrorFlag = resultMsg.is_error && resultMsg.subtype === 'success';
 
       // Disambiguate structurally: a preceding synthetic error message
       // (primary, typed signal), or the typed terminal_reason 'api_error'
@@ -1057,7 +1038,7 @@ async function* streamClaudeMessages(
       // Fail-safe (never observed in practice): a synthetic error message
       // followed by a non-error result. Yield the withheld text late rather
       // than silently swallowing content.
-      if (syntheticError !== undefined && resultMsg.is_error !== true) {
+      if (syntheticError !== undefined && !resultMsg.is_error) {
         getLog().warn(
           { sessionId: resultMsg.session_id, errorCode: syntheticError.code },
           'claude.synthetic_error_not_confirmed'
@@ -1071,7 +1052,7 @@ async function* streamClaudeMessages(
       // subtype: 'success' — its encoding of "non-default termination, not a
       // failure". Treat that pair as a clean success so downstream consumers
       // (which gate failure on isError) don't misclassify it.
-      const isRealError = resultMsg.is_error === true && !isSuccessWithErrorFlag;
+      const isRealError = resultMsg.is_error && !isSuccessWithErrorFlag;
       if (isRealError) {
         getLog().error(
           {
@@ -1095,7 +1076,7 @@ async function* streamClaudeMessages(
         type: 'result',
         sessionId: resultMsg.session_id,
         ...(tokens ? { tokens } : {}),
-        ...(resultMsg.structured_output !== undefined
+        ...('structured_output' in resultMsg && resultMsg.structured_output !== undefined
           ? { structuredOutput: resultMsg.structured_output }
           : {}),
         ...(isRealError ? { isError: true, errorSubtype: resultMsg.subtype } : {}),
@@ -1103,9 +1084,7 @@ async function* streamClaudeMessages(
         ...(resultMsg.total_cost_usd !== undefined ? { cost: resultMsg.total_cost_usd } : {}),
         ...(resultMsg.stop_reason != null ? { stopReason: resultMsg.stop_reason } : {}),
         ...(resultMsg.num_turns !== undefined ? { numTurns: resultMsg.num_turns } : {}),
-        ...(resultMsg.model_usage
-          ? { modelUsage: resultMsg.model_usage as Record<string, unknown> }
-          : {}),
+        ...(resolvedModelId ? { resolvedModel: { id: resolvedModelId } } : {}),
       };
     }
   }

--- a/packages/providers/src/community/opencode/provider.test.ts
+++ b/packages/providers/src/community/opencode/provider.test.ts
@@ -304,12 +304,7 @@ describe('OpencodeProvider', () => {
         tokens: { input: 11, output: 7, total: 21, cost: 0.42 },
         cost: 0.42,
         stopReason: 'stop',
-        modelUsage: {
-          providerID: 'anthropic',
-          modelID: 'claude-sonnet',
-          reasoning: 3,
-          cache: 1,
-        },
+        resolvedModel: { id: 'claude-sonnet' },
       },
     ]);
   });
@@ -427,12 +422,6 @@ describe('OpencodeProvider', () => {
         type: 'result',
         sessionId: 'session-1',
         structuredOutput: { answer: 'ok', confidence: 0.9 },
-        modelUsage: {
-          providerID: undefined,
-          modelID: undefined,
-          reasoning: undefined,
-          cache: undefined,
-        },
       },
     ]);
   });
@@ -476,12 +465,6 @@ describe('OpencodeProvider', () => {
       {
         type: 'result',
         sessionId: 'session-1',
-        modelUsage: {
-          providerID: undefined,
-          modelID: undefined,
-          reasoning: undefined,
-          cache: undefined,
-        },
       },
     ]);
     expect(mockLogger.warn).toHaveBeenCalledTimes(1);

--- a/packages/providers/src/community/opencode/session.ts
+++ b/packages/providers/src/community/opencode/session.ts
@@ -266,19 +266,9 @@ export async function* streamOpencodeSession(
           ...(typeof latestAssistantInfo?.finish === 'string'
             ? { stopReason: latestAssistantInfo.finish }
             : {}),
-          ...(latestAssistantInfo
-            ? {
-                modelUsage: {
-                  providerID: latestAssistantInfo.providerID,
-                  modelID: latestAssistantInfo.modelID,
-                  reasoning: isRecord(latestAssistantInfo.tokens)
-                    ? latestAssistantInfo.tokens.reasoning
-                    : undefined,
-                  cache: isRecord(latestAssistantInfo.tokens)
-                    ? latestAssistantInfo.tokens.cache
-                    : undefined,
-                },
-              }
+          ...(typeof latestAssistantInfo?.modelID === 'string' &&
+          latestAssistantInfo.modelID.length > 0
+            ? { resolvedModel: { id: latestAssistantInfo.modelID } }
             : {}),
         };
         resultYielded = true;

--- a/packages/providers/src/community/pi/event-bridge.test.ts
+++ b/packages/providers/src/community/pi/event-bridge.test.ts
@@ -179,6 +179,27 @@ describe('buildResultChunk', () => {
     }
   });
 
+  test('records responseModel rather than the requested model', () => {
+    const chunk = buildResultChunk([
+      {
+        role: 'assistant',
+        model: 'large',
+        responseModel: 'claude-opus-5',
+        usage,
+        stopReason: 'stop',
+        content: [],
+      },
+    ]);
+    expect(chunk).toMatchObject({ type: 'result', resolvedModel: { id: 'claude-opus-5' } });
+  });
+
+  test('omits resolvedModel when Pi does not report a responseModel', () => {
+    const chunk = buildResultChunk([
+      { role: 'assistant', model: 'large', usage, stopReason: 'stop', content: [] },
+    ]);
+    expect(chunk).not.toHaveProperty('resolvedModel');
+  });
+
   test('flags isError for stopReason=error and surfaces errorMessage', () => {
     const chunk = buildResultChunk([
       { role: 'assistant', usage, stopReason: 'error', errorMessage: 'auth', content: [] },

--- a/packages/providers/src/community/pi/event-bridge.ts
+++ b/packages/providers/src/community/pi/event-bridge.ts
@@ -168,6 +168,9 @@ export function buildResultChunk(messages: readonly unknown[]): MessageChunk {
     tokens,
     ...(tokens.cost !== undefined ? { cost: tokens.cost } : {}),
     ...(last.stopReason ? { stopReason: last.stopReason } : {}),
+    ...(typeof last.responseModel === 'string' && last.responseModel.length > 0
+      ? { resolvedModel: { id: last.responseModel } }
+      : {}),
     ...(isError
       ? {
           isError: true,

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -171,6 +171,11 @@ export interface TokenUsage {
   cost?: number;
 }
 
+/** Concrete model identifier reported by a provider after a request completes. */
+export interface ResolvedModel {
+  id: string;
+}
+
 /**
  * Message chunk from AI assistant.
  * Discriminated union with per-type required fields for type safety.
@@ -199,7 +204,8 @@ export type MessageChunk =
       cost?: number;
       stopReason?: string;
       numTurns?: number;
-      modelUsage?: Record<string, unknown>;
+      /** Concrete model reported by the provider; omitted when its SDK does not expose one. */
+      resolvedModel?: ResolvedModel;
       /**
        * Outcome of a session-resume attempt, so a failed resume is observable
        * instead of silently continuing with a fresh (cold) session:

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -4673,7 +4673,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
     mockSendQueryDag.mockImplementation(function* () {
       yield { type: 'assistant', content: 'the node output text' };
-      yield { type: 'result', sessionId: 'sid' };
+      yield { type: 'result', sessionId: 'sid', resolvedModel: { id: 'claude-opus-5' } };
     });
 
     await executeDagWorkflow(
@@ -4681,7 +4681,10 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       platform,
       'conv-output',
       testDir,
-      { name: 'single-node', nodes: [{ id: 'step1', command: 'step1' }] },
+      {
+        name: 'single-node',
+        nodes: [{ id: 'step1', command: 'step1', model: 'requested-model' }],
+      },
       workflowRun,
       'claude',
       undefined,
@@ -4702,6 +4705,10 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     expect((completedEvent![0] as { data: { node_output: string } }).data.node_output).toBe(
       'the node output text'
     );
+    expect(
+      (completedEvent![0] as { data: { model_usage: { requested: string; resolved: string } } })
+        .data.model_usage
+    ).toEqual({ requested: 'requested-model', resolved: 'claude-opus-5' });
   });
 
   // ─── Background Agent Task Gating (#2083) ───────────────────────────────

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -4961,6 +4961,133 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       });
     });
 
+    it('records requested model/tier on node_started and the resolved model on node_completed (#2314)', async () => {
+      // Loop nodes own their sendQuery loop, so they need their own half of the
+      // #2314 record: the requested alias on node_started, the concrete model
+      // the provider reported on node_completed.
+      mockSendQueryDag.mockImplementation(function* () {
+        yield { type: 'assistant', content: 'Did the task. <promise>COMPLETE</promise>' };
+        yield {
+          type: 'result',
+          sessionId: 'loop-model-sid',
+          resolvedModel: { id: 'claude-opus-5-20260501' },
+        };
+      });
+
+      const store = createMockStore();
+      const mockDeps = createMockDeps(store);
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun('loop-model-run');
+      const aiProfile = buildAiProfile('claude', {
+        repoTiers: { large: { provider: 'claude', model: 'opus' } },
+      });
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        {
+          name: 'dag-loop-model-usage',
+          nodes: [
+            {
+              id: 'my-loop',
+              model: 'large',
+              loop: {
+                prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
+                until: 'COMPLETE',
+                max_iterations: 5,
+              },
+            },
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        aiProfile
+      );
+
+      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
+        [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
+      >;
+      const startedEvent = eventCalls.find(
+        ([arg]) => arg.event_type === 'node_started' && arg.step_name === 'my-loop'
+      );
+      expect(startedEvent).toBeDefined();
+      expect(startedEvent?.[0].data?.provider).toBe('claude');
+      expect(startedEvent?.[0].data?.model).toBe('opus');
+      expect(startedEvent?.[0].data?.tier).toBe('large');
+
+      const completedEvent = eventCalls.find(
+        ([arg]) => arg.event_type === 'node_completed' && arg.step_name === 'my-loop'
+      );
+      expect(completedEvent).toBeDefined();
+      expect(completedEvent?.[0].data?.model_usage).toEqual({
+        requested: 'opus',
+        resolved: 'claude-opus-5-20260501',
+      });
+    });
+
+    it('omits model_usage on node_completed when the provider reports no resolved model (#2314)', async () => {
+      // Codex cannot report a concrete model — absence must stay absent rather
+      // than being back-filled with the requested alias.
+      mockSendQueryDag.mockImplementation(function* () {
+        yield { type: 'assistant', content: 'Did the task. <promise>COMPLETE</promise>' };
+        yield { type: 'result', sessionId: 'loop-no-model-sid' };
+      });
+
+      const store = createMockStore();
+      const mockDeps = createMockDeps(store);
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun('loop-no-model-run');
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        {
+          name: 'dag-loop-no-model-usage',
+          nodes: [
+            {
+              id: 'my-loop',
+              loop: {
+                prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
+                until: 'COMPLETE',
+                max_iterations: 5,
+              },
+            },
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
+        [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
+      >;
+      const completedEvent = eventCalls.find(
+        ([arg]) => arg.event_type === 'node_completed' && arg.step_name === 'my-loop'
+      );
+      expect(completedEvent).toBeDefined();
+      expect(completedEvent?.[0].data).not.toHaveProperty('model_usage');
+    });
+
     it('does not double-count cost when an iteration sees two results (background-task wait, #2083)', async () => {
       mockSendQueryDag.mockImplementation(function* () {
         yield {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -5088,6 +5088,69 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect(completedEvent?.[0].data).not.toHaveProperty('model_usage');
     });
 
+    it('clears a resolved model when a later result omits it, rather than reporting the stale one', async () => {
+      // Pi/Copilot reask loops emit several result chunks and Pi omits resolvedModel
+      // when its later assistant message carries no responseModel. A guarded
+      // assignment would leave the FIRST chunk's model recorded as the node's answer
+      // -- fabricated attribution, which is the defect #2314 exists to prevent.
+      // Two results in ONE iteration, via the background-task wait (same shape as the
+      // #2083 cost test): the first reports a model, the final one does not.
+      mockSendQueryDag.mockImplementation(function* () {
+        yield {
+          type: 'background_tasks',
+          tasks: [{ taskId: 't-1', taskType: 'local_agent', description: 'bg work' }],
+        };
+        yield { type: 'assistant', content: 'Done. <promise>COMPLETE</promise>' };
+        yield { type: 'result', sessionId: 'stale-sid', resolvedModel: { id: 'claude-haiku-4-5' } };
+        yield { type: 'background_tasks', tasks: [] };
+        // Final result reports NO model, so the node must record none -- not
+        // 'claude-haiku-4-5' retained from the earlier chunk.
+        yield { type: 'result', sessionId: 'stale-sid' };
+      });
+
+      const store = createMockStore();
+      const mockDeps = createMockDeps(store);
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun('loop-stale-model-run');
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag',
+        testDir,
+        {
+          name: 'dag-loop-stale-model',
+          nodes: [
+            {
+              id: 'my-loop',
+              loop: {
+                prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
+                until: 'COMPLETE',
+                max_iterations: 5,
+              },
+            },
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
+        [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
+      >;
+      const completedEvent = eventCalls.find(
+        ([arg]) => arg.event_type === 'node_completed' && arg.step_name === 'my-loop'
+      );
+      expect(completedEvent).toBeDefined();
+      expect(completedEvent?.[0].data).not.toHaveProperty('model_usage');
+    });
+
     it('does not double-count cost when an iteration sees two results (background-task wait, #2083)', async () => {
       mockSendQueryDag.mockImplementation(function* () {
         yield {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3730,7 +3730,9 @@ async function executeLoopNode(
   issueContext?: string,
   configuredCommandFolder?: string,
   stepNamePrefix = '',
-  execContext: ExecutionContext = { kind: 'host' }
+  execContext: ExecutionContext = { kind: 'host' },
+  resolvedModel?: string,
+  resolvedTier?: TierName
 ): Promise<NodeExecutionResult> {
   const loop = node.loop;
   const msgContext = { workflowId: workflowRun.id, nodeName: node.id };
@@ -3757,7 +3759,16 @@ async function executeLoopNode(
       workflow_run_id: workflowRun.id,
       event_type: 'node_started',
       step_name: stepName,
-      data: { type: 'loop', command: loop.command ?? null },
+      data: {
+        type: 'loop',
+        command: loop.command ?? null,
+        // Requested-model attribution, same fields the AI-node path records
+        // (#2314) — every iteration runs on this one resolved provider/model,
+        // so it belongs on the node's single _started row.
+        provider: workflowProvider,
+        model: resolvedModel,
+        tier: resolvedTier,
+      },
     })
     .catch((err: Error) => {
       getLog().error(
@@ -3771,6 +3782,9 @@ async function executeLoopNode(
     runId: workflowRun.id,
     nodeId: node.id,
     nodeName: node.id,
+    provider: workflowProvider,
+    model: resolvedModel,
+    tier: resolvedTier,
   });
 
   /**
@@ -3916,6 +3930,10 @@ async function executeLoopNode(
   let loopFinalStopReason: string | undefined;
   let loopTotalNumTurns: number | undefined;
   let loopTotalTokens: TokenUsage | undefined;
+  // Concrete model the provider resolved to (#2314). Last-seen wins, like
+  // loopFinalStopReason: every iteration runs on the same resolved provider and
+  // model, so the final iteration's report is the node's report.
+  let loopResolvedModel: ResolvedModel | undefined;
   // Union of task ids still live when ANY iteration's stream ended abnormally
   // (idle timeout / subprocess death) — #2083. Union rather than last-iteration:
   // a mid-loop iteration that lost its background tasks may have produced
@@ -4160,6 +4178,7 @@ async function executeLoopNode(
           if (msg.numTurns !== undefined) {
             iterationNumTurns = msg.numTurns;
           }
+          if (msg.resolvedModel) loopResolvedModel = msg.resolvedModel;
           if (msg.structuredOutput !== undefined) {
             lastIterationStructuredOutput = msg.structuredOutput;
           }
@@ -4571,6 +4590,12 @@ async function executeLoopNode(
             ...(loopTotalCostUsd !== undefined ? { cost_usd: loopTotalCostUsd } : {}),
             ...(loopFinalStopReason ? { stop_reason: loopFinalStopReason } : {}),
             ...(loopTotalNumTurns !== undefined ? { num_turns: loopTotalNumTurns } : {}),
+            // Requested alias vs the model the provider actually ran (#2314) —
+            // mirrors the AI-node path. Omitted entirely when the provider
+            // reports no resolved model (e.g. Codex), never faked.
+            ...(loopResolvedModel
+              ? { model_usage: { requested: resolvedModel, resolved: loopResolvedModel.id } }
+              : {}),
             // Background Agent tasks still live when any iteration's stream
             // ended (#2083) — this node's artifacts may be incomplete, even
             // though a later iteration signaled completion.
@@ -5626,21 +5651,25 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
 
           // 3b. Loop node dispatch — manages its own AI sessions and iteration
           if (isLoopNode(node)) {
-            const { provider: loopProvider, options: loopOptions } =
-              await resolveNodeProviderAndModel(
-                node,
-                workflowProvider,
-                workflowModel,
-                config,
-                platform,
-                conversationId,
-                workflowRun.id,
-                cwd,
-                workflowLevelOptions,
-                aiProfile,
-                workflowPreset,
-                execContext
-              );
+            const {
+              provider: loopProvider,
+              options: loopOptions,
+              model: resolvedLoopModel,
+              tier: resolvedLoopTier,
+            } = await resolveNodeProviderAndModel(
+              node,
+              workflowProvider,
+              workflowModel,
+              config,
+              platform,
+              conversationId,
+              workflowRun.id,
+              cwd,
+              workflowLevelOptions,
+              aiProfile,
+              workflowPreset,
+              execContext
+            );
 
             const output = await executeLoopNode(
               deps,
@@ -5660,7 +5689,9 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
               issueContext,
               configuredCommandFolder,
               stepNamePrefix,
-              execContext
+              execContext,
+              resolvedLoopModel,
+              resolvedLoopTier
             );
             // Loop nodes run every iteration on the same resolved provider, so the
             // result session (if any) is attributable to loopProvider — tag it so a

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -21,6 +21,7 @@ import type {
   NodeConfig,
   ProviderCapabilities,
   TokenUsage,
+  ResolvedModel,
   ExecutionContext,
   OverlayChangeSummary,
 } from '@archon/providers/types';
@@ -1385,7 +1386,7 @@ async function executeNodeInternal(
   let nodeCostUsd: number | undefined;
   let nodeStopReason: string | undefined;
   let nodeNumTurns: number | undefined;
-  let nodeModelUsage: Record<string, unknown> | undefined;
+  let nodeResolvedModel: ResolvedModel | undefined;
   const batchMessages: string[] = [];
 
   // Create per-node abort controller for idle timeout cleanup
@@ -1616,7 +1617,7 @@ async function executeNodeInternal(
         if (msg.cost !== undefined) nodeCostUsd = msg.cost;
         if (msg.stopReason !== undefined) nodeStopReason = msg.stopReason;
         if (msg.numTurns !== undefined) nodeNumTurns = msg.numTurns;
-        if (msg.modelUsage) nodeModelUsage = msg.modelUsage;
+        if (msg.resolvedModel) nodeResolvedModel = msg.resolvedModel;
         if (msg.structuredOutput !== undefined) structuredOutput = msg.structuredOutput;
         // Fail the node if the SDK reports a cost cap exceeded error
         if (msg.isError && msg.errorSubtype === 'error_max_budget_usd') {
@@ -2219,7 +2220,9 @@ async function executeNodeInternal(
           ...(nodeCostUsd !== undefined ? { cost_usd: nodeCostUsd } : {}),
           ...(nodeStopReason ? { stop_reason: nodeStopReason } : {}),
           ...(nodeNumTurns !== undefined ? { num_turns: nodeNumTurns } : {}),
-          ...(nodeModelUsage ? { model_usage: nodeModelUsage } : {}),
+          ...(nodeResolvedModel
+            ? { model_usage: { requested: resolvedModel, resolved: nodeResolvedModel.id } }
+            : {}),
           // Background Agent tasks still live when the stream ended (#2083) —
           // this node's artifacts may be incomplete.
           ...(backgroundTasksIncomplete.length > 0

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1617,7 +1617,12 @@ async function executeNodeInternal(
         if (msg.cost !== undefined) nodeCostUsd = msg.cost;
         if (msg.stopReason !== undefined) nodeStopReason = msg.stopReason;
         if (msg.numTurns !== undefined) nodeNumTurns = msg.numTurns;
-        if (msg.resolvedModel) nodeResolvedModel = msg.resolvedModel;
+        // Assigned UNCONDITIONALLY. A guarded assignment cannot CLEAR a stale value:
+        // Pi/Copilot reask loops yield several result chunks, and Pi omits resolvedModel
+        // when its later assistant message has no responseModel — so an earlier attempt's
+        // model would be persisted as the final attempt's answer. Fabricated attribution
+        // is the exact defect #2314 exists to prevent; absence must stay absence.
+        nodeResolvedModel = msg.resolvedModel;
         if (msg.structuredOutput !== undefined) structuredOutput = msg.structuredOutput;
         // Fail the node if the SDK reports a cost cap exceeded error
         if (msg.isError && msg.errorSubtype === 'error_max_budget_usd') {
@@ -4178,7 +4183,10 @@ async function executeLoopNode(
           if (msg.numTurns !== undefined) {
             iterationNumTurns = msg.numTurns;
           }
-          if (msg.resolvedModel) loopResolvedModel = msg.resolvedModel;
+          // Unconditional, for the same reason as the AI-node path above: a later
+          // iteration or result chunk that reports no resolved model must clear the
+          // previous one rather than leave it to be recorded as this node's answer.
+          loopResolvedModel = msg.resolvedModel;
           if (msg.structuredOutput !== undefined) {
             lastIterationStructuredOutput = msg.structuredOutput;
           }


### PR DESCRIPTION
## Summary

- Problem: completed provider results did not retain a concrete model identifier, and Claude read the SDK's nonexistent `model_usage` field.
- Why it matters: model aliases can change, so workflow benchmarking could not reliably identify the model that actually ran.
- What changed: providers normalize a reported concrete model to `resolvedModel`; the DAG executor persists it with the requested model; coverage and architecture documentation were updated.
- What did **not** change (scope boundary): Codex does not synthesize a resolved model because its SDK completion event does not expose one.

## UX Journey

### Before

```
Workflow node -> provider result -> node_completed event
requested alias ------------------> no concrete resolved model
```

### After

```
Workflow node -> provider result -> node_completed event
requested alias --> [resolvedModel] -> [requested + resolved]
```

## Architecture Diagram

### Before

```
Claude/Pi/OpenCode -> MessageChunk(modelUsage, provider-specific) -> DAG event
Codex -------------> MessageChunk -----------------------------> DAG event
```

### After

```
Claude/Pi/OpenCode -> [MessageChunk(resolvedModel)] ===> [DAG event { requested, resolved }]
Codex -------------> MessageChunk (no resolved model) -------> DAG event
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| Claude/Pi/OpenCode providers | MessageChunk | **modified** | Normalized `resolvedModel` fact |
| MessageChunk | DAG executor | **modified** | Persists requested and resolved model together |
| DAG executor | workflow event store | **modified** | Existing JSON event persistence seam |

## Label Snapshot

- Risk: `risk: medium`
- Size: `size: M`
- Scope: `workflows`
- Module: `workflows:executor`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi`

## Linked Issue

- Closes #2314
- Related #1433
- Depends on # (if stacked): none
- Supersedes # (if replacing older PR): none

## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check
bun run lint
bun run format:check
bun run test
```

- Evidence provided (test/log/trace/screenshot): focused Claude, Pi, OpenCode, and DAG regression tests plus the complete suite passed.
- If any command is intentionally skipped, explain why: none.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: n/a.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No
- If yes, exact upgrade steps: n/a.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Claude camel-case SDK metadata, Pi `responseModel`, OpenCode `modelID`, and DAG event persistence.
- Edge cases checked: absent provider metadata is omitted; Codex remains absent rather than using the requested model as a fallback.
- What was not verified: live provider SDK calls.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: provider result normalization and workflow completion events.
- Potential unintended effects: consumers previously reading provider-specific `model_usage` objects must use the normalized `{ requested, resolved }` value.
- Guardrails/monitoring for early detection: typed `ResolvedModel` contract and regression tests through persistence.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `aeb7dade`.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: missing or malformed `model_usage` on completed AI-node events.

## Risks and Mitigations

- Risk: a provider may omit a concrete response model.
  - Mitigation: omit the field explicitly; never substitute requested intent for provider fact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `resolvedModel` metadata to streamed `result`/terminal outputs when the provider can determine the concrete model.
  * Workflow node events now persist and emit both the requested model and the provider-resolved model, including loop nodes.
* **Documentation**
  * Updated the architecture reference to reflect the `resolvedModel` contract and provider omissions.
* **Bug Fixes**
  * Improved resolved-model selection and ambiguity handling, ensuring consistent metadata across success/error and structured output scenarios.
* **Tests**
  * Expanded coverage for resolved-model behavior across providers and workflow execution, including clearing stale resolved metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->