### PR TITLE
fix(install): repair the curl|bash entry point and sync the PowerShell mirror

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,11 @@
 
 # Force LF line endings for files that run inside Linux containers
 *.sh text eol=lf
+# The published installer mirrors scripts/install.sh byte-for-byte and a `cmp`
+# assertion enforces that. It has no extension, so `*.sh` misses it and it would
+# fall through to `* text=auto` -> CRLF on a Windows-default checkout, failing the
+# parity check on a clean tree.
+packages/docs-web/public/install text eol=lf
 docker-entrypoint.sh text eol=lf
 Caddyfile text eol=lf
 Caddyfile.example text eol=lf

--- a/packages/docs-web/public/install
+++ b/packages/docs-web/public/install
@@ -239,7 +239,18 @@ main() {
 
   success "Installed to $INSTALL_DIR/$BINARY_NAME"
 
-  echo "$version_output"
+  # Re-run the version check against the INSTALLED path. The probe above ran on the
+  # temp download and its output was cached; printing that after `mv` would report
+  # success without ever executing the file the user will actually invoke — which is
+  # exactly the "installed fine but won't run" failure #2295 reported. See #2338.
+  local installed_output
+  if ! installed_output=$("$INSTALL_DIR/$BINARY_NAME" version 2>&1); then
+    error "Installed binary failed its version check at $INSTALL_DIR/$BINARY_NAME:"
+    echo "$installed_output" >&2
+    exit 1
+  fi
+
+  echo "$installed_output"
   success "Installation complete!"
 
   # Check if in PATH
@@ -259,6 +270,10 @@ main() {
   echo ""
 }
 
-if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+# `${BASH_SOURCE[0]:-$0}` — NOT bare `${BASH_SOURCE[0]}`. Under `curl … | bash` the
+# script arrives on stdin, where BASH_SOURCE[0] is unbound; with `set -u` (above)
+# a bare reference aborts before main() ever runs, so the documented install path
+# fails for every user on every platform. See #2338.
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
   main "$@"
 fi

--- a/packages/docs-web/public/install.ps1
+++ b/packages/docs-web/public/install.ps1
@@ -188,7 +188,7 @@ function Confirm-Checksum {
 function Add-ToUserPath {
     param([string]$Dir)
     $currentPath = [Environment]::GetEnvironmentVariable('Path', 'User')
-    $pathParts   = $currentPath -split ';' | Where-Object { $_ -ne '' }
+    $pathParts   = @($currentPath -split ';' | Where-Object { $_ -ne '' })
 
     if ($Dir -notin $pathParts) {
         $pathParts += $Dir

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -239,7 +239,18 @@ main() {
 
   success "Installed to $INSTALL_DIR/$BINARY_NAME"
 
-  echo "$version_output"
+  # Re-run the version check against the INSTALLED path. The probe above ran on the
+  # temp download and its output was cached; printing that after `mv` would report
+  # success without ever executing the file the user will actually invoke — which is
+  # exactly the "installed fine but won't run" failure #2295 reported. See #2338.
+  local installed_output
+  if ! installed_output=$("$INSTALL_DIR/$BINARY_NAME" version 2>&1); then
+    error "Installed binary failed its version check at $INSTALL_DIR/$BINARY_NAME:"
+    echo "$installed_output" >&2
+    exit 1
+  fi
+
+  echo "$installed_output"
   success "Installation complete!"
 
   # Check if in PATH
@@ -259,6 +270,10 @@ main() {
   echo ""
 }
 
-if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+# `${BASH_SOURCE[0]:-$0}` — NOT bare `${BASH_SOURCE[0]}`. Under `curl … | bash` the
+# script arrives on stdin, where BASH_SOURCE[0] is unbound; with `set -u` (above)
+# a bare reference aborts before main() ever runs, so the documented install path
+# fails for every user on every platform. See #2338.
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
   main "$@"
 fi

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -42,6 +42,20 @@ if [ "$translated" = "fail" ]; then
 fi
 echo "$translated"
 EOF
+  # detect_with_mocks SOURCES the installer, so it depends on the source-guard
+  # suppressing main(). If that guard ever regresses, main() runs and reaches the real
+  # release URL over curl -- and sudo mkdir/mv with a non-writable INSTALL_DIR -- during
+  # `bun run validate`. These stubs turn that latent network/privilege side effect into a
+  # deterministic local failure.
+  for forbidden in curl sudo; do
+    cat >"$mock_dir/$forbidden" <<EOF
+#!/usr/bin/env bash
+echo "TEST BUG: sourced installer invoked $forbidden — the source guard is not suppressing main()" >&2
+exit 99
+EOF
+    chmod +x "$mock_dir/$forbidden"
+  done
+
   chmod +x "$mock_dir/uname" "$mock_dir/sysctl"
   echo "$mock_dir"
 }

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -143,8 +143,10 @@ esac
 # sources it, so none of them can catch this.
 #
 # Mocked curl + a scratch INSTALL_DIR keep this off the network and out of the real system.
+piped_status=0
 piped_stderr="$(PATH="$success_mock_dir:$PATH" INSTALL_DIR="$tmp_dir/piped-bin" \
-  SKIP_CHECKSUM=true bash <"$installer" 2>&1 >/dev/null || true)"
+  SKIP_CHECKSUM=true bash <"$installer" 2>&1 >/dev/null)" || piped_status=$?
+assert_equals "0" "$piped_status" "Piped installer exits successfully"
 case "$piped_stderr" in
   *"unbound variable"*)
     fail "installer aborts when piped to bash (BASH_SOURCE unbound under set -u)"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -160,12 +160,15 @@ esac
 piped_status=0
 piped_stderr="$(PATH="$success_mock_dir:$PATH" INSTALL_DIR="$tmp_dir/piped-bin" \
   SKIP_CHECKSUM=true bash <"$installer" 2>&1 >/dev/null)" || piped_status=$?
-assert_equals "0" "$piped_status" "Piped installer exits successfully"
+# Specific diagnosis FIRST, generic assertion second. With the order reversed the
+# assert_equals fired on any regression and this case block was dead code, so the
+# #2338 failure reported only "expected 0, got 1" with no hint at the cause.
 case "$piped_stderr" in
   *"unbound variable"*)
-    fail "installer aborts when piped to bash (BASH_SOURCE unbound under set -u)"
+    fail "installer aborts when piped to bash (BASH_SOURCE unbound under set -u) — see #2338"
     ;;
 esac
+assert_equals "0" "$piped_status" "Piped installer exits successfully"
 assert_equals "archon 1.2.3" "$("$tmp_dir/piped-bin/archon" version)" "Piped installer installs a working binary"
 
 echo "Installer tests passed"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -71,6 +71,12 @@ assert_platform Darwin x86_64 fail darwin-x64 "Native Intel platform without Ros
 cmp -s "$installer" "$repo_root/packages/docs-web/public/install" \
   || fail "public installer mirror differs from scripts/install.sh"
 
+# The PowerShell pair needs the same guard. It had ALREADY drifted: the public copy
+# was missing the @() array wrapper from 53cabd44 (#1000), so `irm … | iex` shipped a
+# PATH-corrupting installer to Windows users while the repo copy was fixed. #2339.
+cmp -s "$repo_root/scripts/install.ps1" "$repo_root/packages/docs-web/public/install.ps1" \
+  || fail "public install.ps1 mirror differs from scripts/install.ps1"
+
 mock_dir="$tmp_dir/install-mocks"
 install_dir="$tmp_dir/install-bin"
 mkdir -p "$mock_dir" "$install_dir"
@@ -129,5 +135,21 @@ case "$install_output" in
   *"archon 1.2.3"*) ;;
   *) fail "Installer prints verified version" ;;
 esac
+
+# Regression for #2338: the installer must survive being READ FROM STDIN, which is how
+# `curl -fsSL … | bash` delivers it. There BASH_SOURCE[0] is unbound, and with `set -u` a
+# bare reference aborted the script before main() ran — the documented install path failed
+# for every user on every platform. Every other case here invokes the installer by path or
+# sources it, so none of them can catch this.
+#
+# Mocked curl + a scratch INSTALL_DIR keep this off the network and out of the real system.
+piped_stderr="$(PATH="$success_mock_dir:$PATH" INSTALL_DIR="$tmp_dir/piped-bin" \
+  SKIP_CHECKSUM=true bash <"$installer" 2>&1 >/dev/null || true)"
+case "$piped_stderr" in
+  *"unbound variable"*)
+    fail "installer aborts when piped to bash (BASH_SOURCE unbound under set -u)"
+    ;;
+esac
+assert_equals "archon 1.2.3" "$("$tmp_dir/piped-bin/archon" version)" "Piped installer installs a working binary"
 
 echo "Installer tests passed"


### PR DESCRIPTION
## Summary

- **Problem:** #2330 added `if [[ "${BASH_SOURCE[0]}" == "$0" ]]` so `test-install.sh` could `source` the installer. Under `set -u` with bash reading from **stdin** — exactly what `curl -fsSL … | bash` does — `BASH_SOURCE[0]` is unbound, so the script aborted before `main()` ran.
- **Why it matters:** the documented install path failed for **every user on every platform**, turning #2295 from "installs but won't run on one Mac config" into "installer hard-fails for everyone". Not yet live — `deploy-docs.yml` publishes only from `main` — but it ships the moment `dev` merges, and `packages/docs-web/**` changed so that deploy will fire. **Release blocker.**
- **What changed:** `${BASH_SOURCE[0]:-$0}`; post-install verification now runs against the installed path; the public `install.ps1` mirror is re-synced; two regression tests.
- **What did NOT change (scope boundary):** the Rosetta detection logic from #2330 is untouched and correct. No change to release assets, Homebrew, or the canonical `scripts/install.ps1`.

## UX Journey

### Before

```
$ curl -fsSL https://archon.diy/install | bash
bash: line 262: BASH_SOURCE[0]: unbound variable
$ echo $?
1
# nothing installed, no diagnostic the user can act on
```

### After

```
$ curl -fsSL https://archon.diy/install | bash
[INFO] Detecting platform...
[OK] Platform: darwin-arm64
...
[OK] Installed to /usr/local/bin/archon
archon 1.2.3
[OK] Installation complete!
```

## Architecture Diagram

### Before

```
curl | bash ──▶ set -u ──▶ guard reads BASH_SOURCE[0] ──▶ ✗ abort (main never runs)
bash install.sh ─▶ guard ─▶ main ✓
source install.sh ─▶ guard ─▶ (skipped) ✓

download ─▶ checksum ─▶ probe TEMP binary ─▶ mv ─▶ print CACHED probe output ─▶ "complete!"
                                                    └─ installed file never executed
```

### After

```
curl | bash ──▶ guard reads ${BASH_SOURCE[0]:-$0} ──▶ main ✓
bash install.sh ─▶ main ✓          source install.sh ─▶ (skipped) ✓

download ─▶ checksum ─▶ probe TEMP binary ─▶ mv ─▶ run INSTALLED binary ─▶ "complete!"
                        (guards an existing install)   (guards the actual artifact)
```

**Connection inventory** (module-to-module edges):

- `scripts/install.sh` ↔ `packages/docs-web/public/install` — byte-identical mirrors (**both changed, parity asserted**)
- `scripts/install.ps1` ↔ `packages/docs-web/public/install.ps1` — byte-identical mirrors (**public copy re-synced, parity now asserted**)
- `scripts/test-install.sh` → both installers (**changed**: two new assertions)
- `bun run validate` → `test:install` (unchanged edge)
- `deploy-docs.yml` → `packages/docs-web/public/*` (unchanged; the publish path for the fixed mirrors)

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `ci`
- Module: `infra:installer`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi`

## Linked Issue

- Closes #2338
- Closes #2339
- Related #2295, #2330, #2332, #2335, #1000

## Validation Evidence (required)

```bash
bash scripts/test-install.sh     # → Installer tests passed
bun run check:bundled            # → up to date (36 commands, 21 workflows)
bun run format:check             # → All matched files use Prettier code style!
```

- **Evidence provided:** the new piped test was verified to **fail** against the broken installer, not merely to pass against the fixed one. With `scripts/install.sh` **and** the public mirror both reverted to `08723171` — so the parity assertion does not mask it — the suite reports:
  `FAIL: installer aborts when piped to bash (BASH_SOURCE unbound under set -u)`
  Restoring the fix returns `Installer tests passed`.
- The guard was independently checked in all three invocation modes (piped → reaches `main`; by path → reaches `main`; sourced → correctly skipped), on macOS system bash **3.2.57**.
- **Intentionally skipped:** full `bun run type-check` / `lint` / `test`. This PR touches only shell scripts and one PowerShell file — no TypeScript. CI runs the full chain.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No** — the new test uses the existing mocked `curl` and a scratch `INSTALL_DIR`; it makes no real request.
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No** — post-install verification executes a path the installer already wrote.
- Risk note: the fix deliberately **keeps** the source-guard rather than deleting it. Removing it would re-arm `detect_with_mocks`, which sources the installer and would then perform a real GitHub download and prompt for **sudo** — and #2335 is about to run this suite in CI.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

- **Verified scenarios:** `… | bash` (the reported failure) fails before and succeeds after; `bash install.sh`; `source install.sh`; installer with a failing binary leaves an existing installation intact; installer with a working binary replaces it and prints the version.
- **Edge cases checked:** bash 3.2.57 (macOS system bash) as well as modern bash; the sourced path still suppresses `main`; `install.ps1` line 191 confirmed to be the **only** divergence before re-syncing, so the mirror update changed exactly one line.
- **What was not verified:** the PowerShell fix was not executed — no Windows host available. It is a byte-for-byte adoption of the canonical copy that has been on `dev` since `53cabd44`, not new code. The published `archon.diy/install` endpoint was confirmed to still serve the pre-#2330 script, so no live user is currently affected.

## Side Effects / Blast Radius (required)

- **Affected subsystems:** shell + PowerShell installers, their published mirrors, `test:install` (which runs inside `bun run validate`).
- **Potential unintended effects:** post-install verification adds one execution of the installed binary. If a platform installs a working file that cannot run in place (e.g. quarantine/SIP), the installer now fails loudly where it previously reported success — intended, and the point of the change.
- **Guardrails:** `cmp` parity on both mirror pairs fails locally and (via #2335) in CI. **Correction:** as originally written this claim was only true for LF checkouts — the extensionless mirror fell through `* text=auto` to CRLF on `core.autocrlf=true` (Windows default), so the assertion failed spuriously on a clean tree there. Fixed in `84ae8c26` by pinning it in `.gitattributes`. The piped test covers the invocation mode the suite previously could not reach, and `make_platform_mocks` now stubs `curl`/`sudo` so a future guard regression fails locally instead of reaching the real release URL during `bun run validate`.

## Rollback Plan (required)

- Fast rollback: `git revert 10fdc201`. Self-contained across four files, no schema or config coupling.
- Caveat: reverting restores the broken `curl | bash` path, so prefer a forward fix.

## Sequencing note for reviewers

**#2335 should not merge before this.** It adds `test:install` to CI; landing it first green-lights a suite that passes while the installer is broken — converting an absent check into a false assurance. After this merges, #2335's CI wiring becomes genuinely protective (it also needs `if: runner.os != 'Windows'` on that step — the installer refuses MINGW, so the Windows job goes red without it).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer reliability for piped execution (`curl … | bash`), including safer entrypoint handling when sourced via stdin.
  * Added a post-install validation step that runs `version` from the installed binary path and fails if it can’t execute.
  * Ensured clear failure when the installed binary probe doesn’t succeed.
  * Added checks to confirm the published Windows PowerShell installer matches the repository copy.

* **Tests**
  * Strengthened piped-installer regression coverage with exit-code and stderr assertions.
  * Improved mock behavior to prevent unintended network/privilege actions.
  * Verified the installed binary after piped installs.

* **Chores**
  * Standardized published installer line endings for accurate byte-for-byte comparison.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->