### PR TITLE
Fix SQLite/Postgres schema column parity checks

### DIFF
--- a/packages/core/src/db/adapters/sqlite.test.ts
+++ b/packages/core/src/db/adapters/sqlite.test.ts
@@ -374,8 +374,10 @@ describe('SqliteAdapter', () => {
      *
      * Better Auth's remote_agent_auth_* tables are intentionally Postgres-only
      * (web auth never runs on SQLite — see migrateColumns() and CLAUDE.md), so
-     * they are the one allowlisted exception. A genuinely new Postgres-only
-     * table must be added to this allowlist with a justifying comment.
+     * the table-parity check excludes that prefix. The separate, exact
+     * remote_agent_codebases.allow_env_keys column exception is tracked by
+     * #2318; keep it column-specific. A genuinely new Postgres-only table
+     * must be added to the table allowlist with a justifying comment.
      */
     const POSTGRES_ONLY_PREFIX = 'remote_agent_auth_';
     // #2318 owns this known dead Postgres-only residue. Keep the exception
@@ -443,12 +445,11 @@ describe('SqliteAdapter', () => {
       db = createTestDb();
       const postgresColumns = postgresArchonColumns();
       const codebaseColumns = postgresColumns.get('remote_agent_codebases');
-      const userAiPrefColumns = postgresColumns.get('remote_agent_user_ai_prefs');
+      const userColumns = postgresColumns.get('remote_agent_users');
 
-      // Anti-vacuity checks cover both a CREATE declaration and a column also
-      // present in an idempotent ALTER block.
+      // Anti-vacuity checks cover a CREATE declaration and an ALTER-only one.
       expect(codebaseColumns?.has('allow_env_keys')).toBe(true);
-      expect(userAiPrefColumns?.has('default_model')).toBe(true);
+      expect(userColumns?.has('role')).toBe(true);
 
       const missing: string[] = [];
       for (const [table, expectedColumns] of postgresColumns) {

--- a/packages/core/src/db/adapters/sqlite.test.ts
+++ b/packages/core/src/db/adapters/sqlite.test.ts
@@ -378,18 +378,44 @@ describe('SqliteAdapter', () => {
      * table must be added to this allowlist with a justifying comment.
      */
     const POSTGRES_ONLY_PREFIX = 'remote_agent_auth_';
+    // #2318 owns this known dead Postgres-only residue. Keep the exception
+    // column-specific so every other codebases column remains protected.
+    const POSTGRES_ONLY_COLUMNS = new Set(['remote_agent_codebases.allow_env_keys']);
+    const TABLE_CONSTRAINTS = new Set(['check', 'constraint', 'foreign', 'primary', 'unique']);
 
-    /** Extract Archon table names declared in the Postgres migration. */
-    function postgresArchonTables(): string[] {
+    /** Extract Archon table columns declared or added by the Postgres migration. */
+    function postgresArchonColumns(): Map<string, Set<string>> {
       const sql = getSchemaSQL();
-      const re = /CREATE TABLE(?:\s+IF NOT EXISTS)?\s+"?([a-z0-9_]+)"?/gi;
-      // All Archon tables share this prefix (CLAUDE.md); the filter also drops
-      // false positives — e.g. "above" captured from "...CREATE TABLE above)"
-      // inside a SQL comment.
-      const names = [...sql.matchAll(re)]
-        .map(m => m[1].toLowerCase())
-        .filter(name => name.startsWith('remote_agent_'));
-      return [...new Set(names)];
+      const columnsByTable = new Map<string, Set<string>>();
+      const createTableRe =
+        /CREATE TABLE(?:\s+IF NOT EXISTS)?\s+"?([a-z0-9_]+)"?\s*\(([\s\S]*?)\);/gi;
+
+      for (const match of sql.matchAll(createTableRe)) {
+        const table = match[1].toLowerCase();
+        if (!table.startsWith('remote_agent_')) continue;
+
+        const columns = new Set<string>();
+        for (const declaration of match[2].split('\n')) {
+          const identifier = declaration.trim().match(/^(?:"([^"]+)"|([a-z_][a-z0-9_]*))/i);
+          if (!identifier) continue;
+
+          const column = identifier[1] ?? identifier[2].toLowerCase();
+          if (!TABLE_CONSTRAINTS.has(column.toLowerCase())) columns.add(column);
+        }
+        columnsByTable.set(table, columns);
+      }
+
+      const addColumnRe =
+        /ALTER TABLE\s+"?([a-z0-9_]+)"?\s+ADD COLUMN IF NOT EXISTS\s+"?([a-z_][a-z0-9_]*)"?/gi;
+      for (const match of sql.matchAll(addColumnRe)) {
+        const table = match[1].toLowerCase();
+        if (!table.startsWith('remote_agent_')) continue;
+        const columns = columnsByTable.get(table) ?? new Set<string>();
+        columns.add(match[2].toLowerCase());
+        columnsByTable.set(table, columns);
+      }
+
+      return columnsByTable;
     }
 
     test('every non-auth Postgres table is created by the SQLite schema', async () => {
@@ -399,8 +425,9 @@ describe('SqliteAdapter', () => {
       );
       const sqliteTables = new Set(result.rows.map(r => r.name));
 
-      const expected = postgresArchonTables().filter(
-        name => !name.startsWith(POSTGRES_ONLY_PREFIX)
+      const postgresColumns = postgresArchonColumns();
+      const expected = [...postgresColumns.keys()].filter(
+        table => !table.startsWith(POSTGRES_ONLY_PREFIX)
       );
       // Sanity: the parse found the table set, including the exact table whose
       // absence triggered this regression — guards against the regex silently
@@ -412,17 +439,34 @@ describe('SqliteAdapter', () => {
       expect(missing).toEqual([]);
     });
 
-    /**
-     * The generic table-parity test above is table-name only — it gives no
-     * column coverage. `parent_run_id` (#2121 Phase 2) is added to BOTH schema
-     * sources (sqlite.ts createSchema + runtime ALTER, and 000_combined.sql). A
-     * column added to only one dialect is invisible on the default-SQLite path
-     * (VPS runs Postgres), so assert the fresh-schema column + its index exist.
-     */
-    test('parent_run_id column + index present on a fresh SQLite schema', () => {
+    test('every non-auth Postgres column exists in a fresh SQLite schema', () => {
       db = createTestDb();
-      const workflowRunCols = raw_pragma(currentDbPath, 'remote_agent_workflow_runs');
-      expect(workflowRunCols).toContain('parent_run_id');
+      const postgresColumns = postgresArchonColumns();
+      const codebaseColumns = postgresColumns.get('remote_agent_codebases');
+      const userAiPrefColumns = postgresColumns.get('remote_agent_user_ai_prefs');
+
+      // Anti-vacuity checks cover both a CREATE declaration and a column also
+      // present in an idempotent ALTER block.
+      expect(codebaseColumns?.has('allow_env_keys')).toBe(true);
+      expect(userAiPrefColumns?.has('default_model')).toBe(true);
+
+      const missing: string[] = [];
+      for (const [table, expectedColumns] of postgresColumns) {
+        if (table.startsWith(POSTGRES_ONLY_PREFIX)) continue;
+        const sqliteColumns = new Set(raw_pragma(currentDbPath, table));
+        for (const column of expectedColumns) {
+          const qualifiedColumn = `${table}.${column}`;
+          if (!sqliteColumns.has(column) && !POSTGRES_ONLY_COLUMNS.has(qualifiedColumn)) {
+            missing.push(qualifiedColumn);
+          }
+        }
+      }
+
+      expect(missing.sort()).toEqual([]);
+    });
+
+    test('parent_run_id index exists on a fresh SQLite schema', () => {
+      db = createTestDb();
       const indexes = raw_indexes(currentDbPath);
       expect(indexes).toContain('idx_workflow_runs_parent_run');
     });

--- a/packages/core/src/db/adapters/sqlite.test.ts
+++ b/packages/core/src/db/adapters/sqlite.test.ts
@@ -374,30 +374,67 @@ describe('SqliteAdapter', () => {
      *
      * Better Auth's remote_agent_auth_* tables are intentionally Postgres-only
      * (web auth never runs on SQLite — see migrateColumns() and CLAUDE.md), so
-     * the table-parity check excludes that prefix. The separate, exact
+     * the parity checks exclude that prefix. The separate, exact
      * remote_agent_codebases.allow_env_keys column exception is tracked by
      * #2318; keep it column-specific. A genuinely new Postgres-only table
      * must be added to the table allowlist with a justifying comment.
+     *
+     * Table discovery is deliberately independent of column-body parsing: a
+     * table that is present in the migration but missing from sqlite.ts is the
+     * original drift class (PR #2033), and it must stay caught even if its
+     * CREATE body is unparseable for any reason.
      */
     const POSTGRES_ONLY_PREFIX = 'remote_agent_auth_';
     // #2318 owns this known dead Postgres-only residue. Keep the exception
     // column-specific so every other codebases column remains protected.
     const POSTGRES_ONLY_COLUMNS = new Set(['remote_agent_codebases.allow_env_keys']);
+    // Reverse-direction residue: declared in sqlite.ts, never added to the
+    // migration, and read by nothing. Harmless but real — and reverse drift is
+    // the works-locally / breaks-on-the-Postgres-VPS direction, so the check
+    // itself is worth keeping even though today it costs one entry.
+    const SQLITE_ONLY_COLUMNS = new Set(['remote_agent_isolation_environments.updated_at']);
     const TABLE_CONSTRAINTS = new Set(['check', 'constraint', 'foreign', 'primary', 'unique']);
+    /**
+     * Floor for the number of non-auth columns actually compared. A parser bug
+     * that silently drops columns (rather than mismatching them) makes the
+     * comparison pass vacuously, which is exactly how a truncating body regex
+     * shipped: a `);` inside a comment cut a table from 7 columns to 3 and the
+     * suite stayed green. Adjust when the schema legitimately changes size —
+     * the failure names the count, so the intended value is never a guess.
+     */
+    const MIN_NON_AUTH_COLUMNS = 136;
+
+    /**
+     * Archon table names declared by the Postgres migration. Body-independent
+     * on purpose — see the note above about the PR #2033 drift class.
+     */
+    function postgresArchonTables(): string[] {
+      const re = /CREATE TABLE(?:\s+IF NOT EXISTS)?\s+"?([a-z0-9_]+)"?/gi;
+      // All Archon tables share this prefix (CLAUDE.md).
+      const names = [...stripSqlComments(getSchemaSQL()).matchAll(re)]
+        .map(m => m[1].toLowerCase())
+        .filter(name => name.startsWith('remote_agent_'));
+      return [...new Set(names)];
+    }
 
     /** Extract Archon table columns declared or added by the Postgres migration. */
     function postgresArchonColumns(): Map<string, Set<string>> {
-      const sql = getSchemaSQL();
+      // Comments are stripped first: `migrations/000_combined.sql` writes `);`
+      // inside prose comments as a matter of house style, and any paren- or
+      // semicolon-sensitive scan would otherwise end a table body early.
+      const sql = stripSqlComments(getSchemaSQL());
       const columnsByTable = new Map<string, Set<string>>();
-      const createTableRe =
-        /CREATE TABLE(?:\s+IF NOT EXISTS)?\s+"?([a-z0-9_]+)"?\s*\(([\s\S]*?)\);/gi;
+      const createTableRe = /CREATE TABLE(?:\s+IF NOT EXISTS)?\s+"?([a-z0-9_]+)"?\s*\(/gi;
 
       for (const match of sql.matchAll(createTableRe)) {
         const table = match[1].toLowerCase();
         if (!table.startsWith('remote_agent_')) continue;
 
-        const columns = new Set<string>();
-        for (const declaration of match[2].split('\n')) {
+        const columns = columnsByTable.get(table) ?? new Set<string>();
+        // Depth-tracked so nested parens in REFERENCES / CHECK / DEFAULT
+        // clauses cannot terminate the body or split a declaration.
+        const body = readBalancedParens(sql, match.index + match[0].length - 1);
+        for (const declaration of splitTopLevelCommas(body)) {
           const identifier = declaration.trim().match(/^(?:"([^"]+)"|([a-z_][a-z0-9_]*))/i);
           if (!identifier) continue;
 
@@ -420,6 +457,14 @@ describe('SqliteAdapter', () => {
       return columnsByTable;
     }
 
+    /** Table → columns as the fresh SQLite schema (createSchema()) built them. */
+    async function sqliteSchemaColumns(): Promise<Map<string, Set<string>>> {
+      const result = await db.query<{ name: string }>(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+      );
+      return new Map(result.rows.map(r => [r.name, new Set(raw_pragma(currentDbPath, r.name))]));
+    }
+
     test('every non-auth Postgres table is created by the SQLite schema', async () => {
       db = createTestDb();
       const result = await db.query<{ name: string }>(
@@ -427,8 +472,7 @@ describe('SqliteAdapter', () => {
       );
       const sqliteTables = new Set(result.rows.map(r => r.name));
 
-      const postgresColumns = postgresArchonColumns();
-      const expected = [...postgresColumns.keys()].filter(
+      const expected = postgresArchonTables().filter(
         table => !table.startsWith(POSTGRES_ONLY_PREFIX)
       );
       // Sanity: the parse found the table set, including the exact table whose
@@ -441,29 +485,95 @@ describe('SqliteAdapter', () => {
       expect(missing).toEqual([]);
     });
 
-    test('every non-auth Postgres column exists in a fresh SQLite schema', () => {
+    test('every non-auth Postgres column exists in a fresh SQLite schema', async () => {
       db = createTestDb();
       const postgresColumns = postgresArchonColumns();
-      const codebaseColumns = postgresColumns.get('remote_agent_codebases');
-      const userColumns = postgresColumns.get('remote_agent_users');
+      const sqliteColumns = await sqliteSchemaColumns();
 
       // Anti-vacuity checks cover a CREATE declaration and an ALTER-only one.
-      expect(codebaseColumns?.has('allow_env_keys')).toBe(true);
-      expect(userColumns?.has('role')).toBe(true);
+      // Deliberately NOT an allowlisted column: fixing a listed drift should
+      // require editing the allowlist and nothing else.
+      expect(postgresColumns.get('remote_agent_codebases')?.has('default_cwd')).toBe(true);
+      expect(postgresColumns.get('remote_agent_users')?.has('role')).toBe(true);
 
       const missing: string[] = [];
-      for (const [table, expectedColumns] of postgresColumns) {
+      let compared = 0;
+      for (const table of postgresArchonTables()) {
         if (table.startsWith(POSTGRES_ONLY_PREFIX)) continue;
-        const sqliteColumns = new Set(raw_pragma(currentDbPath, table));
+        const expectedColumns = postgresColumns.get(table) ?? new Set<string>();
+        const actualColumns = sqliteColumns.get(table) ?? new Set<string>();
         for (const column of expectedColumns) {
+          compared++;
           const qualifiedColumn = `${table}.${column}`;
-          if (!sqliteColumns.has(column) && !POSTGRES_ONLY_COLUMNS.has(qualifiedColumn)) {
+          if (!actualColumns.has(column) && !POSTGRES_ONLY_COLUMNS.has(qualifiedColumn)) {
             missing.push(qualifiedColumn);
           }
         }
       }
 
+      expect(compared).toBeGreaterThanOrEqual(MIN_NON_AUTH_COLUMNS);
       expect(missing.sort()).toEqual([]);
+    });
+
+    test('every SQLite column exists in the Postgres migration', async () => {
+      db = createTestDb();
+      const postgresColumns = postgresArchonColumns();
+      const sqliteColumns = await sqliteSchemaColumns();
+
+      const extra: string[] = [];
+      for (const [table, actualColumns] of sqliteColumns) {
+        const expectedColumns = postgresColumns.get(table);
+        // No Postgres counterpart at all: a SQLite-only table. Nothing else
+        // checks this direction, so report the whole table rather than 20
+        // individual column lines.
+        if (!expectedColumns) {
+          extra.push(`${table}.*`);
+          continue;
+        }
+        for (const column of actualColumns) {
+          const qualifiedColumn = `${table}.${column}`;
+          if (!expectedColumns.has(column) && !SQLITE_ONLY_COLUMNS.has(qualifiedColumn)) {
+            extra.push(qualifiedColumn);
+          }
+        }
+      }
+
+      expect(extra.sort()).toEqual([]);
+    });
+
+    /**
+     * Self-expiring allowlists: an entry stops being an exception the moment
+     * the drift it names is fixed, so assert each one still describes reality.
+     * Fixing #2318 (dropping allow_env_keys from the migration) fails here
+     * until the allowlist entry is deleted — the exception cannot outlive its
+     * reason and quietly keep a real column unprotected.
+     */
+    test('parity allowlists still describe real drift', async () => {
+      db = createTestDb();
+      const postgresColumns = postgresArchonColumns();
+      const sqliteColumns = await sqliteSchemaColumns();
+
+      const stale: string[] = [];
+      for (const qualifiedColumn of POSTGRES_ONLY_COLUMNS) {
+        const [table, column] = qualifiedColumn.split('.');
+        if (!postgresColumns.get(table)?.has(column)) {
+          stale.push(`${qualifiedColumn} (no longer in the Postgres migration)`);
+        }
+        if (sqliteColumns.get(table)?.has(column)) {
+          stale.push(`${qualifiedColumn} (now exists in SQLite)`);
+        }
+      }
+      for (const qualifiedColumn of SQLITE_ONLY_COLUMNS) {
+        const [table, column] = qualifiedColumn.split('.');
+        if (!sqliteColumns.get(table)?.has(column)) {
+          stale.push(`${qualifiedColumn} (no longer in the SQLite schema)`);
+        }
+        if (postgresColumns.get(table)?.has(column)) {
+          stale.push(`${qualifiedColumn} (now exists in the Postgres migration)`);
+        }
+      }
+
+      expect(stale.sort()).toEqual([]);
     });
 
     test('parent_run_id index exists on a fresh SQLite schema', () => {
@@ -590,6 +700,77 @@ describe('SqliteAdapter', () => {
     });
   });
 });
+
+/**
+ * Advance past a SQL string literal / quoted identifier that opens at `start`,
+ * returning the index of its closing quote. Doubled quotes escape.
+ */
+function skipQuoted(sql: string, start: number): number {
+  const quote = sql[start];
+  for (let i = start + 1; i < sql.length; i++) {
+    if (sql[i] !== quote) continue;
+    // A doubled quote escapes itself — not the end of the literal.
+    if (sql[i + 1] === quote) i++;
+    else return i;
+  }
+  return sql.length;
+}
+
+/** Remove SQL line and block comments, preserving quoted text. */
+function stripSqlComments(sql: string): string {
+  let out = '';
+  let i = 0;
+  while (i < sql.length) {
+    if (sql[i] === "'" || sql[i] === '"') {
+      const end = skipQuoted(sql, i);
+      out += sql.slice(i, end + 1);
+      i = end + 1;
+    } else if (sql[i] === '-' && sql[i + 1] === '-') {
+      while (i < sql.length && sql[i] !== '\n') i++;
+    } else if (sql[i] === '/' && sql[i + 1] === '*') {
+      const end = sql.indexOf('*/', i + 2);
+      i = end === -1 ? sql.length : end + 2;
+    } else {
+      out += sql[i];
+      i++;
+    }
+  }
+  return out;
+}
+
+/**
+ * Return the text between the `(` at `openIndex` and its matching `)`, tracking
+ * nesting depth so `REFERENCES t(id)` / `CHECK (id = 1)` / `DEFAULT NOW()` do
+ * not end the body early. Throws rather than returning a truncated body — a
+ * silently short column list is the failure mode this whole parser guards.
+ */
+function readBalancedParens(sql: string, openIndex: number): string {
+  let depth = 0;
+  for (let i = openIndex; i < sql.length; i++) {
+    if (sql[i] === "'" || sql[i] === '"') i = skipQuoted(sql, i);
+    else if (sql[i] === '(') depth++;
+    else if (sql[i] === ')' && --depth === 0) return sql.slice(openIndex + 1, i);
+  }
+  throw new Error(`Unbalanced parentheses in schema SQL at index ${openIndex}`);
+}
+
+/** Split a CREATE TABLE body on its top-level commas (depth- and quote-aware). */
+function splitTopLevelCommas(body: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < body.length; i++) {
+    if (body[i] === "'" || body[i] === '"') i = skipQuoted(body, i);
+    else if (body[i] === '(') depth++;
+    else if (body[i] === ')') depth--;
+    else if (body[i] === ',' && depth === 0) {
+      parts.push(body.slice(start, i));
+      start = i + 1;
+    }
+  }
+  parts.push(body.slice(start));
+  return parts;
+}
 
 function raw_pragma(dbPath: string, table: string): string[] {
   const raw = new Database(dbPath, { readonly: true });

--- a/packages/core/src/db/adapters/sqlite.test.ts
+++ b/packages/core/src/db/adapters/sqlite.test.ts
@@ -511,8 +511,27 @@ describe('SqliteAdapter', () => {
         }
       }
 
-      expect(compared).toBeGreaterThanOrEqual(MIN_NON_AUTH_COLUMNS);
+      // Drift FIRST. The vacuity floor below is a guard on this test's own
+      // reach, not a drift assertion -- and asserting it first lets it mask the
+      // thing you actually need to see: two legitimate column removals plus one
+      // real drift made the floor fire and the drift list never printed.
       expect(missing.sort()).toEqual([]);
+
+      // Anti-vacuity: if the parser silently loses columns again (it did -- an
+      // in-body `);` once cut workflow_events from 7 columns to 3 with the suite
+      // still green), `missing` stays empty because there is nothing left to
+      // compare. Thrown rather than expect()ed so the message explains itself:
+      // a bare `Expected: >= 136 / Received: 135` under this test's name reads
+      // as drift when it is either a parser regression or a legitimate removal.
+      if (compared < MIN_NON_AUTH_COLUMNS) {
+        throw new Error(
+          `Schema-parity coverage collapsed: compared ${compared} non-auth columns, ` +
+            `expected at least ${MIN_NON_AUTH_COLUMNS}. Either the migration parser has ` +
+            `silently lost columns (check the CREATE TABLE body extraction), or columns ` +
+            `were legitimately removed from migrations/000_combined.sql -- in which case ` +
+            `lower MIN_NON_AUTH_COLUMNS to the new count. No drift was detected either way.`
+        );
+      }
     });
 
     test('every SQLite column exists in the Postgres migration', async () => {


### PR DESCRIPTION
## Summary

- Problem: The SQLite/Postgres parity test checked only table names, allowing missing shared SQLite columns to pass CI.
- Why it matters: SQLite is the default installation path; silent schema drift can cause runtime failures for SQLite users.
- What changed: Extend the SQLite adapter parity suite to parse PostgreSQL `CREATE TABLE` and `ALTER TABLE ... ADD COLUMN` declarations, compare expected column names against fresh SQLite `PRAGMA table_info` results, and retain the workflow-run index assertion.
- What did **not** change (scope boundary): No runtime schema behavior, migrations, type/constraint parity, or SQLite-only extra-column policy changed. The known `remote_agent_codebases.allow_env_keys` PostgreSQL-only residue remains an explicit, narrowly scoped #2318 exception.

## UX Journey

### Before

```
Developer                 CI parity test                 SQLite user
─────────                 ──────────────                 ───────────
adds PG column ─────────▶ checks table names only
                          passes despite missing column ─▶ encounters runtime schema error
```

### After

```
Developer                 CI parity test                 SQLite user
─────────                 ──────────────                 ───────────
adds PG column ─────────▶ [parses expected column names]
                          [compares them with SQLite PRAGMA]
                          fails on unallowlisted drift ──▶ receives schema with CI-protected parity
```

## Architecture Diagram

### Before

```
migrations/000_combined.sql ──▶ bundled-schema.ts ──▶ sqlite.test.ts [table names only]
sqlite.ts fresh schema ─────────────────────────────▶ sqlite.test.ts
```

### After

```
migrations/000_combined.sql ──▶ bundled-schema.ts ──▶ [~ sqlite.test.ts: table + column names]
sqlite.ts fresh schema ─────────────────────────────▶ [~ sqlite.test.ts: PRAGMA column comparison]
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `migrations/000_combined.sql` | `packages/core/src/db/bundled-schema.ts` | unchanged | Provides PostgreSQL schema SQL. |
| `packages/core/src/db/bundled-schema.ts` | `packages/core/src/db/adapters/sqlite.test.ts` | **modified** | Test now derives expected shared column names as well as table names. |
| `packages/core/src/db/adapters/sqlite.ts` | `packages/core/src/db/adapters/sqlite.test.ts` | **modified** | Fresh SQLite schema is now inspected through `PRAGMA table_info` for column parity. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `tests`
- Module: `core:sqlite-adapter`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #2319
- Related #2318
- Depends on # (if stacked): None
- Supersedes # (if replacing older PR): None

## Validation Evidence (required)

Commands and result summary:

```bash
bun test packages/core/src/db/adapters/sqlite.test.ts  # 18 passed
bun run type-check                                    # passed
bun run lint                                          # passed, 0 warnings
bun run format:check                                  # passed
bun run test                                          # passed per validation artifact
bun run build                                         # passed
```

- Evidence provided (test/log/trace/screenshot): The focused test includes parser anti-vacuity checks and a failure-sensitivity experiment that reported a deliberately excluded expected column; the temporary change was reverted.
- If any command is intentionally skipped, explain why: None. An earlier full-validation attempt was affected by pre-existing, unstaged `.archon/` workflow edits; the validation run regenerated their corresponding bundled artifact and subsequently recorded all commands as passing. Those unrelated files are intentionally excluded from this PR.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation: Not applicable.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: Not applicable.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Fresh SQLite schema exposes every expected shared PostgreSQL column; upgrade-only PostgreSQL column declarations are included; the `parent_run_id` index remains covered.
- Edge cases checked: Parser sanity checks cover `remote_agent_user_ai_prefs.default_model`; PostgreSQL auth tables stay excluded; only `remote_agent_codebases.allow_env_keys` is excepted for #2318.
- What was not verified: Cross-dialect types, constraints, and SQLite-only extra columns are deliberately out of scope.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Core SQLite adapter schema-parity test only.
- Potential unintended effects: Future intentional PostgreSQL-only columns will fail CI until explicitly justified and narrowly allowlisted.
- Guardrails/monitoring for early detection: Deterministic per-table missing-column failures and parser anti-vacuity assertions make drift actionable in CI.

## Rollback Plan (required)

- Fast rollback command/path: Revert commit `e929b01a` from this PR branch.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: Schema-parity test fails for a shared PostgreSQL column absent from fresh SQLite.

## Risks and Mitigations

- Risk: SQL parsing could mistake a constraint for a column or miss a declaration form.
  - Mitigation: Filter constraint keywords, parse both creation and upgrade forms, and assert known table/column parser output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved database schema validation to provide more reliable comparisons across supported database systems.
  - Added coverage for complex SQL definitions, including comments, quoted values, nested expressions, and safely separated declarations.
  - Expanded checks to detect missing or extra tables and columns, while ensuring schema comparison coverage and configuration lists remain up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->