### PR TITLE
fix: Persist per-node workflow token usage

### DIFF
--- a/packages/core/src/db/workflows.ts
+++ b/packages/core/src/db/workflows.ts
@@ -965,6 +965,7 @@ export async function pauseWorkflowRun(
             // null as absent (`!= null`).
             completionSignaled: approvalContext.completionSignaled ?? null,
             signaledOutput: approvalContext.signaledOutput ?? null,
+            signaledTokens: approvalContext.signaledTokens ?? null,
             onRejectPrompt: approvalContext.onRejectPrompt ?? null,
             onRejectMaxAttempts: approvalContext.onRejectMaxAttempts ?? null,
             captureResponse: approvalContext.captureResponse ?? null,

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -4802,6 +4802,84 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     expect(completedEvent?.[0].data).not.toHaveProperty('tokens');
   });
 
+  it('persists only {input, output} — provider-defined total/cost are not part of the shape', async () => {
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'out' };
+      // Pi/OpenCode shape: `total` folds in cache/reasoning tokens, so it is NOT
+      // input + output. Persisting it would hand consumers a field they cannot
+      // interpret without knowing the provider; `cost` duplicates cost_usd.
+      yield {
+        type: 'result',
+        sessionId: 'shape-sid',
+        tokens: { input: 100, output: 10, total: 900, cost: 0.5 },
+      };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+
+    await executeDagWorkflow(
+      mockDeps,
+      createMockPlatform(),
+      'conv-shape',
+      testDir,
+      { name: 'token-shape', nodes: [{ id: 'step1', command: 'step1' }] },
+      makeWorkflowRun('token-shape-run'),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
+      [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
+    >;
+    const completedEvent = eventCalls.find(
+      ([event]) => event.event_type === 'node_completed' && event.step_name === 'step1'
+    );
+    expect(completedEvent?.[0].data?.tokens).toEqual({ input: 100, output: 10 });
+  });
+
+  it('drops non-finite provider token counts instead of persisting them', async () => {
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'out' };
+      yield { type: 'result', sessionId: 'nan-sid', tokens: { input: NaN, output: 10 } };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+
+    await executeDagWorkflow(
+      mockDeps,
+      createMockPlatform(),
+      'conv-nan',
+      testDir,
+      { name: 'nan-tokens', nodes: [{ id: 'step1', command: 'step1' }] },
+      makeWorkflowRun('nan-tokens-run'),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
+      [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
+    >;
+    const completedEvent = eventCalls.find(
+      ([event]) => event.event_type === 'node_completed' && event.step_name === 'step1'
+    );
+    expect(completedEvent).toBeDefined();
+    // A NaN would serialize to `{input: null, output: 10}` — a wrong number that
+    // gets believed. Absence is the honest answer.
+    expect(completedEvent?.[0].data).not.toHaveProperty('tokens');
+  });
+
   // ─── Background Agent Task Gating (#2083) ───────────────────────────────
 
   describe('background task completion gating (#2083)', () => {
@@ -6485,7 +6563,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           type: 'assistant',
           content: 'Plan approved. Proceeding. <promise>APPROVED</promise>',
         };
-        yield { type: 'result', sessionId: 'loop-session-2' };
+        yield { type: 'result', sessionId: 'loop-session-2', tokens: { input: 40, output: 4 } };
       });
 
       const mockDeps = createMockDeps();
@@ -6538,6 +6616,9 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         // The gate persists the signal state (#2074) so a bare approve can
         // finalize at resume instead of re-running the iteration.
         completionSignaled: true,
+        // ...and the usage consumed up to the gate (#2333), so the finalize path
+        // does not report a silent zero for iterations that really ran.
+        signaledTokens: { input: 40, output: 4 },
       });
       const signaledOutput = (pauseCalls[0][1] as { signaledOutput: string }).signaledOutput;
       expect(signaledOutput).toContain('Plan approved');
@@ -6753,6 +6834,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             message: 'gate',
             completionSignaled: true,
             signaledOutput: 'REPORT',
+            signaledTokens: { input: 40, output: 4 },
           },
           loop_user_input: 'Approved',
           loop_feedback_given: false,
@@ -6805,6 +6887,81 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       );
       expect(completed.length).toBe(1);
       expect(completed[0][0].data.node_output).toBe('REPORT');
+      // The finalize row reports the usage the pausing invocation consumed (#2333).
+      // Without this it persists duration_ms: 0 and no tokens for iterations that
+      // really ran — a silent zero, not an absence.
+      expect(completed[0][0].data.tokens).toEqual({ input: 40, output: 4 });
+    });
+
+    it('finalize omits tokens when the gate persisted none (legacy pause / no usage) (#2333)', async () => {
+      mockSendQueryDag.mockImplementation(function* () {
+        yield { type: 'assistant', content: 'should never run' };
+        yield { type: 'result', sessionId: 'never' };
+      });
+
+      const mockDeps = createMockDeps();
+      const workflowRun = makeWorkflowRun('finalize-no-tokens-run', {
+        metadata: {
+          approval: {
+            type: 'interactive_loop',
+            nodeId: 'refine',
+            iteration: 1,
+            sessionId: 'sig-session-1',
+            message: 'gate',
+            completionSignaled: true,
+            signaledOutput: 'REPORT',
+            // No signaledTokens key at all — a run paused by a build predating #2333.
+          },
+          loop_user_input: 'Approved',
+          loop_feedback_given: false,
+        },
+      });
+
+      await executeDagWorkflow(
+        mockDeps,
+        createMockPlatform(),
+        'conv-dag',
+        testDir,
+        {
+          name: 'finalize-on-approve',
+          nodes: [
+            {
+              id: 'refine',
+              loop: {
+                prompt: 'Refine.',
+                until: 'APPROVED',
+                max_iterations: 10,
+                interactive: true,
+                gate_message: 'Review.',
+              },
+            },
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      expect(mockSendQueryDag.mock.calls.length).toBe(0);
+      const eventCalls = (
+        mockDeps.store.createWorkflowEvent as Mock<
+          (e: {
+            event_type: string;
+            step_name: string;
+            data: Record<string, unknown>;
+          }) => Promise<void>
+        >
+      ).mock.calls;
+      const completed = eventCalls.filter(
+        c => c[0].event_type === 'node_completed' && c[0].step_name === 'refine'
+      );
+      expect(completed.length).toBe(1);
+      expect(completed[0][0].data).not.toHaveProperty('tokens');
     });
 
     it('iterates at resume when feedback was given, even on a signal-bearing gate (#2074 C)', async () => {
@@ -14519,14 +14676,37 @@ describe('executeDagWorkflow -- loop_group node', () => {
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
       [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
     >;
-    const completedEvent = eventCalls.find(
+    // The BODY node's per-iteration rows are the authoritative per-node usage.
+    const bodyEvents = eventCalls.filter(
+      ([arg]) => arg.event_type === 'node_completed' && arg.step_name === 'paid.work'
+    );
+    expect(bodyEvents.map(([arg]) => arg.data?.tokens)).toEqual([
+      { input: 100, output: 10 },
+      { input: 200, output: 20 },
+    ]);
+    // The GROUP row must NOT repeat the same total under the same field name: body
+    // rows and the aggregate live in one event stream, so a consumer summing
+    // `data.tokens` would otherwise count this group twice (600/60 for 300/30).
+    const groupEvent = eventCalls.find(
       ([arg]) => arg.event_type === 'node_completed' && arg.step_name === 'paid'
     );
-    expect(completedEvent).toBeDefined();
-    expect(completedEvent?.[0].data?.tokens).toEqual({ input: 300, output: 30 });
+    expect(groupEvent).toBeDefined();
+    expect(groupEvent?.[0].data).not.toHaveProperty('tokens');
+    // The property the persisted stream must hold: a naive consumer summing every
+    // node_completed row's tokens gets the run's real usage, with no discriminator.
+    const naiveSum = eventCalls
+      .filter(([arg]) => arg.event_type === 'node_completed')
+      .reduce(
+        (acc, [arg]) => {
+          const t = arg.data?.tokens as { input: number; output: number } | undefined;
+          return t ? { input: acc.input + t.input, output: acc.output + t.output } : acc;
+        },
+        { input: 0, output: 0 }
+      );
+    expect(naiveSum).toEqual({ input: 300, output: 30 });
   });
 
-  it('omits tokens from a loop_group node_completed event when providers report no usage', async () => {
+  it('omits tokens from loop_group body node_completed events when providers report no usage', async () => {
     mockSendQueryDag.mockImplementation(function* () {
       yield { type: 'assistant', content: 'done\nDONE' };
       yield { type: 'result', sessionId: 'lg-no-usage-sid' };
@@ -14566,11 +14746,17 @@ describe('executeDagWorkflow -- loop_group node', () => {
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
       [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
     >;
-    const completedEvent = eventCalls.find(
+    const bodyEvent = eventCalls.find(
+      ([event]) =>
+        event.event_type === 'node_completed' && event.step_name === 'no-usage-group.work'
+    );
+    expect(bodyEvent).toBeDefined();
+    expect(bodyEvent?.[0].data).not.toHaveProperty('tokens');
+    const groupEvent = eventCalls.find(
       ([event]) => event.event_type === 'node_completed' && event.step_name === 'no-usage-group'
     );
-    expect(completedEvent).toBeDefined();
-    expect(completedEvent?.[0].data).not.toHaveProperty('tokens');
+    expect(groupEvent).toBeDefined();
+    expect(groupEvent?.[0].data).not.toHaveProperty('tokens');
   });
 
   it('SESSION: fresh_context=false threads the body session between iterations', async () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -4767,6 +4767,41 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     ).toEqual({ input: 100, output: 10 });
   });
 
+  it('omits tokens from a direct AI node_completed event when the provider reports no usage', async () => {
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'the node output text' };
+      yield { type: 'result', sessionId: 'no-usage-sid' };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+
+    await executeDagWorkflow(
+      mockDeps,
+      createMockPlatform(),
+      'conv-no-usage',
+      testDir,
+      { name: 'no-usage', nodes: [{ id: 'step1', command: 'step1' }] },
+      makeWorkflowRun('no-usage-run'),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
+      [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
+    >;
+    const completedEvent = eventCalls.find(
+      ([event]) => event.event_type === 'node_completed' && event.step_name === 'step1'
+    );
+    expect(completedEvent).toBeDefined();
+    expect(completedEvent?.[0].data).not.toHaveProperty('tokens');
+  });
+
   // ─── Background Agent Task Gating (#2083) ───────────────────────────────
 
   describe('background task completion gating (#2083)', () => {
@@ -5204,6 +5239,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       );
       expect(completedEvent).toBeDefined();
       expect(completedEvent?.[0].data).not.toHaveProperty('model_usage');
+      expect(completedEvent?.[0].data).not.toHaveProperty('tokens');
     });
 
     it('clears a resolved model when a later result omits it, rather than reporting the stale one', async () => {
@@ -14488,6 +14524,53 @@ describe('executeDagWorkflow -- loop_group node', () => {
     );
     expect(completedEvent).toBeDefined();
     expect(completedEvent?.[0].data?.tokens).toEqual({ input: 300, output: 30 });
+  });
+
+  it('omits tokens from a loop_group node_completed event when providers report no usage', async () => {
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'done\nDONE' };
+      yield { type: 'result', sessionId: 'lg-no-usage-sid' };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const nodes: DagNode[] = [
+      {
+        id: 'no-usage-group',
+        loop_group: {
+          until: 'DONE',
+          max_iterations: 3,
+          fresh_context: false,
+          nodes: [{ id: 'work', prompt: 'do work', depends_on: [] }],
+        },
+        depends_on: [],
+      },
+    ];
+
+    await executeDagWorkflow(
+      mockDeps,
+      createMockPlatform(),
+      'conv-lg-no-usage',
+      testDir,
+      { name: 'lg-no-usage', nodes },
+      makeWorkflowRun('lg-no-usage-run'),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
+      [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
+    >;
+    const completedEvent = eventCalls.find(
+      ([event]) => event.event_type === 'node_completed' && event.step_name === 'no-usage-group'
+    );
+    expect(completedEvent).toBeDefined();
+    expect(completedEvent?.[0].data).not.toHaveProperty('tokens');
   });
 
   it('SESSION: fresh_context=false threads the body session between iterations', async () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -4721,7 +4721,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
     mockSendQueryDag.mockImplementation(function* () {
       yield { type: 'assistant', content: 'the node output text' };
-      yield { type: 'result', sessionId: 'sid', resolvedModel: { id: 'claude-opus-5' } };
+      yield {
+        type: 'result',
+        sessionId: 'sid',
+        resolvedModel: { id: 'claude-opus-5' },
+        tokens: { input: 100, output: 10 },
+      };
     });
 
     await executeDagWorkflow(
@@ -4757,6 +4762,9 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       (completedEvent![0] as { data: { model_usage: { requested: string; resolved: string } } })
         .data.model_usage
     ).toEqual({ requested: 'requested-model', resolved: 'claude-opus-5' });
+    expect(
+      (completedEvent![0] as { data: { tokens: { input: number; output: number } } }).data.tokens
+    ).toEqual({ input: 100, output: 10 });
   });
 
   // ─── Background Agent Task Gating (#2083) ───────────────────────────────
@@ -5079,6 +5087,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           type: 'result',
           sessionId: 'loop-model-sid',
           resolvedModel: { id: 'claude-opus-5-20260501' },
+          tokens: { input: 100, output: 10 },
         };
       });
 
@@ -5143,6 +5152,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         requested: 'opus',
         resolved: 'claude-opus-5-20260501',
       });
+      expect(completedEvent?.[0].data?.tokens).toEqual({ input: 100, output: 10 });
     });
 
     it('omits model_usage on node_completed when the provider reports no resolved model (#2314)', async () => {
@@ -14430,7 +14440,8 @@ describe('executeDagWorkflow -- loop_group node', () => {
       };
     });
 
-    const mockDeps = createMockDeps();
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('lg-tokens');
 
@@ -14469,6 +14480,14 @@ describe('executeDagWorkflow -- loop_group node', () => {
     expect(mockCaptureWorkflowCompleted).toHaveBeenCalledWith(
       expect.objectContaining({ outcome: 'completed', tokensIn: 300, tokensOut: 30 })
     );
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
+      [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
+    >;
+    const completedEvent = eventCalls.find(
+      ([arg]) => arg.event_type === 'node_completed' && arg.step_name === 'paid'
+    );
+    expect(completedEvent).toBeDefined();
+    expect(completedEvent?.[0].data?.tokens).toEqual({ input: 300, output: 30 });
   });
 
   it('SESSION: fresh_context=false threads the body session between iterations', async () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -14213,6 +14213,10 @@ describe('executeDagWorkflow -- loop_group node', () => {
     });
     expect(String(pauseCalls[0][1].signaledOutput)).toContain('validation PASS');
     expect(String(pauseCalls[0][1].message)).toContain('Completion signal detected');
+    // No `signaledTokens` (unlike the plain-loop gate): the group's finalize path has
+    // no consumer for it, because the body's own rows already persisted this
+    // iteration's usage before the pause (#2333).
+    expect(pauseCalls[0][1]).not.toHaveProperty('signaledTokens');
   });
 
   it('INTERACTIVE: loop_group signal_completes completes on a first-iteration signal without gating (#2074 B)', async () => {
@@ -14704,6 +14708,111 @@ describe('executeDagWorkflow -- loop_group node', () => {
         { input: 0, output: 0 }
       );
     expect(naiveSum).toEqual({ input: 300, output: 30 });
+  });
+
+  it('COST: a loop_group gate → bare approve → finalize does not double-count body tokens (#2333)', async () => {
+    // Both phases write to ONE event store, the way a real database behaves. Per-test
+    // isolation would hide the defect entirely: the body's per-iteration rows are
+    // persisted BEFORE the pause and survive it, so a finalize row carrying the same
+    // usage doubles it in the single stream a consumer actually reads.
+    const store = createMockStore();
+    const nodes: DagNode[] = [
+      {
+        id: 'refine',
+        loop_group: {
+          until: 'APPROVED',
+          max_iterations: 5,
+          fresh_context: false,
+          interactive: true,
+          gate_message: 'Review the result.',
+          nodes: [{ id: 'work', prompt: 'validate', depends_on: [] }],
+        },
+        depends_on: [],
+      },
+    ];
+    const workflow = { name: 'lg-finalize-tokens', nodes };
+
+    // Phase 1 — iteration 1 signals but still gates (fresh interactive, no
+    // signal_completes). Its body row persists 100/10, the run's ONLY real usage.
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'validation PASS\nAPPROVED' };
+      yield { type: 'result', sessionId: 'lg-dbl-sess-1', tokens: { input: 100, output: 10 } };
+    });
+
+    await executeDagWorkflow(
+      createMockDeps(store),
+      createMockPlatform(),
+      'conv-lg',
+      testDir,
+      workflow,
+      makeWorkflowRun('lg-finalize-tokens-run'),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const pauseCalls = (
+      store.pauseWorkflowRun as Mock<(id: string, ctx: Record<string, unknown>) => Promise<void>>
+    ).mock.calls;
+    expect(pauseCalls.length).toBe(1);
+
+    // Phase 2 — bare approve. The resumed run carries EXACTLY the context the gate
+    // persisted, so what the pause writes is what the finalize reads.
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'should never run' };
+      yield { type: 'result', sessionId: 'never', tokens: { input: 999, output: 99 } };
+    });
+    const aiCallsBeforeResume = mockSendQueryDag.mock.calls.length;
+
+    await executeDagWorkflow(
+      createMockDeps(store),
+      createMockPlatform(),
+      'conv-lg',
+      testDir,
+      workflow,
+      makeWorkflowRun('lg-finalize-tokens-run', {
+        metadata: {
+          approval: pauseCalls[0][1],
+          loop_user_input: '',
+          loop_feedback_given: false,
+        },
+      }),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    // Finalized from the persisted output — no body iteration re-ran.
+    expect(mockSendQueryDag.mock.calls.length).toBe(aiCallsBeforeResume);
+
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
+      [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
+    >;
+    const completedRows = eventCalls.filter(([arg]) => arg.event_type === 'node_completed');
+    expect(completedRows.map(([arg]) => arg.step_name)).toEqual(['refine.work', 'refine']);
+    // The pre-pause body row is authoritative and still present after the resume.
+    expect(completedRows[0][0].data?.tokens).toEqual({ input: 100, output: 10 });
+    // The finalize row is an aggregate over body rows that already carry the usage —
+    // same reason the natural-completion group row omits `tokens`.
+    expect(completedRows[1][0].data).not.toHaveProperty('tokens');
+    // The property the persisted stream must hold across a gate: a naive consumer
+    // summing every node_completed row's tokens gets the run's real usage.
+    const naiveSum = completedRows.reduce(
+      (acc, [arg]) => {
+        const t = arg.data?.tokens as { input: number; output: number } | undefined;
+        return t ? { input: acc.input + t.input, output: acc.output + t.output } : acc;
+      },
+      { input: 0, output: 0 }
+    );
+    expect(naiveSum).toEqual({ input: 100, output: 10 });
   });
 
   it('omits tokens from loop_group body node_completed events when providers report no usage', async () => {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -2250,6 +2250,7 @@ async function executeNodeInternal(
         data: {
           duration_ms: duration,
           node_output: nodeOutputText,
+          ...(nodeTokens !== undefined ? { tokens: nodeTokens } : {}),
           ...(nodeCostUsd !== undefined ? { cost_usd: nodeCostUsd } : {}),
           ...(nodeStopReason ? { stop_reason: nodeStopReason } : {}),
           ...(nodeNumTurns !== undefined ? { num_turns: nodeNumTurns } : {}),
@@ -3505,6 +3506,7 @@ async function executeLoopGroupNode(
           data: {
             duration_ms: duration,
             node_output: lastIterationOutput,
+            ...(loopTotalTokens !== undefined ? { tokens: loopTotalTokens } : {}),
             ...(loopTotalCostUsd !== undefined ? { cost_usd: loopTotalCostUsd } : {}),
           },
         })
@@ -4650,6 +4652,7 @@ async function executeLoopNode(
           data: {
             duration_ms: Date.now() - iterationStart,
             node_output: lastIterationOutput,
+            ...(loopTotalTokens !== undefined ? { tokens: loopTotalTokens } : {}),
             ...(loopTotalCostUsd !== undefined ? { cost_usd: loopTotalCostUsd } : {}),
             ...(loopFinalStopReason ? { stop_reason: loopFinalStopReason } : {}),
             ...(loopTotalNumTurns !== undefined ? { num_turns: loopTotalNumTurns } : {}),

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3054,9 +3054,13 @@ function readSignaledTokens(raw: unknown): TokenUsage | undefined {
  *
  * `finalizeTokens` is the usage the pausing invocation actually consumed, carried
  * across the gate in the approval context (#2333) — without it this path persists a
- * node_completed reporting no usage for iterations that really ran. `cost_usd` and
- * the resolved model are lost across the same gate for the same reason; both are
- * part of the single "preserve terminal provider stats across a gate" fix in #2345.
+ * node_completed reporting no usage for iterations that really ran. Passed by the
+ * single-node loop ONLY: its per-iteration rows carry no tokens, so this row is the
+ * only record. A loop_group omits it — its body nodes persisted their own namespaced
+ * rows (with tokens) before the pause, and those rows survive it, so repeating the
+ * total here would double-count in the one event stream. `cost_usd` and the resolved
+ * model are lost across the same gate; both are part of the single "preserve terminal
+ * provider stats across a gate" fix in #2345.
  */
 async function finalizeLoopFromSignal(
   deps: WorkflowDeps,
@@ -3203,8 +3207,15 @@ async function executeLoopGroupNode(
       node.id,
       stepName,
       'Loop-group node',
-      finalizeOutput,
-      readSignaledTokens(loopGateMeta.signaledTokens)
+      finalizeOutput
+      // NO finalizeTokens, deliberately — same double-count reasoning as the
+      // natural-completion group row below. A loop_group's body nodes wrote their own
+      // `<groupId>.<nodeId>` node_completed rows (with tokens) BEFORE the gate paused,
+      // and those rows survive the pause: they are already in the event stream this
+      // finalize row is appended to. Reporting the group total here would make a
+      // consumer summing `data.tokens` count the pausing iteration twice. The plain
+      // `loop` DOES pass it — its per-iteration rows carry no tokens, so its finalize
+      // row is the only record of the usage.
     );
     return { state: 'completed', output: finalizeOutput };
   }
@@ -3650,9 +3661,10 @@ async function executeLoopGroupNode(
         // for honesty; pauseWorkflowRun nulls both on every fresh pause.
         completionSignaled: completionDetected,
         signaledOutput: completionDetected ? lastIterationOutput : null,
-        // Usage consumed up to this gate, so a bare approve (finalize, no re-run)
-        // can persist it on node_completed instead of reporting nothing (#2333).
-        signaledTokens: completionDetected ? (loopTotalTokens ?? null) : null,
+        // NO `signaledTokens` — a loop_group gate has no consumer for it. The body's
+        // own `<groupId>.<nodeId>` rows already persisted this iteration's usage before
+        // the pause, so the finalize path deliberately writes no `tokens` (see the
+        // finalizeLoopFromSignal call above). Only the plain `loop` gate carries it.
       });
       return {
         state: 'completed',

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1641,7 +1641,24 @@ async function executeNodeInternal(
         }
         if (msg.sessionId) newSessionId = msg.sessionId;
         if (msg.resumed !== undefined) nodeResumed = msg.resumed;
-        if (msg.tokens) nodeTokens = msg.tokens;
+        if (msg.tokens !== undefined) {
+          // Normalized to `{input, output}` — the ONLY two fields every provider
+          // reports the same way, and therefore the only shape a consumer can read
+          // without knowing which provider produced the row. `total` is
+          // provider-defined and is NOT input + output (Pi folds cacheRead/cacheWrite
+          // into it, OpenCode sums its own per-agent totals); `cost` duplicates the
+          // separately-persisted `cost_usd`. Same NaN guard rationale as the
+          // DAG-level accumulator: a non-finite value must be dropped loudly, not
+          // persisted as a wrong number that gets believed.
+          if (Number.isFinite(msg.tokens.input) && Number.isFinite(msg.tokens.output)) {
+            nodeTokens = { input: msg.tokens.input, output: msg.tokens.output };
+          } else {
+            getLog().warn(
+              { nodeId: node.id, tokens: msg.tokens },
+              'dag_node.usage_tokens_non_finite_ignored'
+            );
+          }
+        }
         if (msg.cost !== undefined) nodeCostUsd = msg.cost;
         if (msg.stopReason !== undefined) nodeStopReason = msg.stopReason;
         if (msg.numTurns !== undefined) nodeNumTurns = msg.numTurns;
@@ -3011,12 +3028,35 @@ function buildHonestGateMessage(
 }
 
 /**
+ * Narrow the token usage a loop gate persisted in its approval context (#2333).
+ *
+ * `metadata.approval` is free-form JSON read back from the DB and `isApprovalContext`
+ * only vouches for nodeId/message, so the declared type carries no runtime authority
+ * here: a run paused by a build that predates the field has none, and a malformed or
+ * non-finite value must be dropped rather than persisted onward as a number a
+ * consumer would believe.
+ */
+function readSignaledTokens(raw: unknown): TokenUsage | undefined {
+  if (typeof raw !== 'object' || raw === null) return undefined;
+  const { input, output } = raw as { input?: unknown; output?: unknown };
+  if (typeof input !== 'number' || typeof output !== 'number') return undefined;
+  if (!Number.isFinite(input) || !Number.isFinite(output)) return undefined;
+  return { input, output };
+}
+
+/**
  * Finalize-on-approve (#2074), shared by executeLoopNode and executeLoopGroupNode:
  * a gate that paused on a signal-bearing iteration, resumed WITHOUT feedback,
  * completes the node from the persisted `signaledOutput` instead of re-running
  * the (expensive) iteration. Sends the user notice and writes/emits the
  * node_completed pair; the caller builds its own return value (the single-node
  * loop also threads the restored sessionId).
+ *
+ * `finalizeTokens` is the usage the pausing invocation actually consumed, carried
+ * across the gate in the approval context (#2333) — without it this path persists a
+ * node_completed reporting no usage for iterations that really ran. `cost_usd` and
+ * the resolved model are lost across the same gate for the same reason; both are
+ * part of the single "preserve terminal provider stats across a gate" fix in #2345.
  */
 async function finalizeLoopFromSignal(
   deps: WorkflowDeps,
@@ -3026,7 +3066,8 @@ async function finalizeLoopFromSignal(
   nodeId: string,
   stepName: string,
   nodeLabel: string,
-  finalizeOutput: string
+  finalizeOutput: string,
+  finalizeTokens?: TokenUsage
 ): Promise<void> {
   // Impossible by construction today (the gate writes signaledOutput whenever
   // completionSignaled is true) — this warn guards a future decoupling so a
@@ -3048,7 +3089,11 @@ async function finalizeLoopFromSignal(
       workflow_run_id: workflowRun.id,
       event_type: 'node_completed',
       step_name: stepName,
-      data: { duration_ms: 0, node_output: finalizeOutput },
+      data: {
+        duration_ms: 0,
+        node_output: finalizeOutput,
+        ...(finalizeTokens !== undefined ? { tokens: finalizeTokens } : {}),
+      },
     })
     .catch((err: Error) => {
       getLog().error(
@@ -3158,7 +3203,8 @@ async function executeLoopGroupNode(
       node.id,
       stepName,
       'Loop-group node',
-      finalizeOutput
+      finalizeOutput,
+      readSignaledTokens(loopGateMeta.signaledTokens)
     );
     return { state: 'completed', output: finalizeOutput };
   }
@@ -3506,7 +3552,21 @@ async function executeLoopGroupNode(
           data: {
             duration_ms: duration,
             node_output: lastIterationOutput,
-            ...(loopTotalTokens !== undefined ? { tokens: loopTotalTokens } : {}),
+            // NO `tokens` here, deliberately. Unlike every other node type, a
+            // loop_group's body nodes write their OWN node_completed rows (namespaced
+            // `<groupId>.<nodeId>`, one per iteration) and those already carry the
+            // tokens. Persisting the group total under the SAME field name would make
+            // a consumer summing `data.tokens` across node_completed rows count this
+            // group's usage twice with nothing in the row to mark it as an aggregate.
+            // The leaves are authoritative: they are per-provider (a body node may
+            // override `provider:`, so the group total can mix providers and is
+            // useless for the cross-provider comparison #2333 exists to enable), and
+            // the group total is recoverable by summing the `<groupId>.` prefix.
+            // The RETURN value below still carries `tokens` — that is the run-level
+            // roll-up path, which counts each group exactly once (body results land in
+            // the scoped iteration ctx, never the run ctx).
+            // NOTE: `cost_usd` has this same double-count shape and predates #2333;
+            // it is left as-is rather than silently changed under a token fix.
             ...(loopTotalCostUsd !== undefined ? { cost_usd: loopTotalCostUsd } : {}),
           },
         })
@@ -3590,6 +3650,9 @@ async function executeLoopGroupNode(
         // for honesty; pauseWorkflowRun nulls both on every fresh pause.
         completionSignaled: completionDetected,
         signaledOutput: completionDetected ? lastIterationOutput : null,
+        // Usage consumed up to this gate, so a bare approve (finalize, no re-run)
+        // can persist it on node_completed instead of reporting nothing (#2333).
+        signaledTokens: completionDetected ? (loopTotalTokens ?? null) : null,
       });
       return {
         state: 'completed',
@@ -3899,7 +3962,8 @@ async function executeLoopNode(
       node.id,
       stepName,
       'Loop node',
-      finalizeOutput
+      finalizeOutput,
+      readSignaledTokens(loopGateMeta.signaledTokens)
     );
     return { state: 'completed', output: finalizeOutput, sessionId: currentSessionId };
   }
@@ -4760,6 +4824,9 @@ async function executeLoopNode(
         // for honesty; pauseWorkflowRun nulls both on every fresh pause.
         completionSignaled: completionDetected,
         signaledOutput: completionDetected ? lastIterationOutput : null,
+        // Usage consumed up to this gate, so a bare approve (finalize, no re-run)
+        // can persist it on node_completed instead of reporting nothing (#2333).
+        signaledTokens: completionDetected ? (loopTotalTokens ?? null) : null,
         // Read-once command body for command-backed loops: the resumed invocation
         // reuses this snapshot instead of re-reading the file (explicit null for
         // prompt-based loops — same json_patch convention as `sessionId`).
@@ -5151,6 +5218,12 @@ async function executeWorkflowNode(
           type: 'workflow',
           child_run_id: outcome.childRunId,
           ...(outcome.costUsd !== undefined ? { cost_usd: outcome.costUsd } : {}),
+          // Rolled up from the child run's persisted totals, exactly like cost_usd —
+          // tokens are the axis every provider reports (Codex reports no cost at all),
+          // so dropping them here while keeping cost would hide the one comparable
+          // number. Does not double count WITHIN this run: the child's own per-node
+          // rows are filed under `child_run_id`, a different workflow_run_id.
+          ...(outcome.tokens !== undefined ? { tokens: outcome.tokens } : {}),
         },
       })
       .catch((err: Error) => {

--- a/packages/workflows/src/schemas/workflow-run.ts
+++ b/packages/workflows/src/schemas/workflow-run.ts
@@ -216,6 +216,20 @@ export interface ApprovalContext {
    */
   signaledOutput?: string | null;
   /**
+   * Interactive-loop only. Token usage accumulated by the invocation that produced the
+   * signal-bearing paused iteration, persisted so the finalize-on-approve path can write
+   * a node_completed carrying the usage it really consumed instead of a silent zero
+   * (#2333). Only set when completionSignaled is true; null otherwise.
+   *
+   * Scope note: this is the PAUSING invocation's total, matching what the normal
+   * (re-run) completion path reports — a loop that gated more than once attributes each
+   * invocation's usage to that invocation, and earlier ones are only visible in the
+   * run-level totals. The gate loses `cost_usd` and the resolved model the same way;
+   * those belong to the single "preserve terminal provider stats across a gate" fix
+   * tracked by #2345.
+   */
+  signaledTokens?: { input: number; output: number } | null;
+  /**
    * Interactive-loop only. Read-once snapshot of a command-backed loop's
    * (`loop.command`) loaded prompt body, persisted at gate pause so the resumed
    * invocation reuses the exact text the run started with — a command file

--- a/packages/workflows/src/schemas/workflow-run.ts
+++ b/packages/workflows/src/schemas/workflow-run.ts
@@ -216,17 +216,24 @@ export interface ApprovalContext {
    */
   signaledOutput?: string | null;
   /**
-   * Interactive-loop only. Token usage accumulated by the invocation that produced the
-   * signal-bearing paused iteration, persisted so the finalize-on-approve path can write
-   * a node_completed carrying the usage it really consumed instead of a silent zero
-   * (#2333). Only set when completionSignaled is true; null otherwise.
+   * Interactive-loop only, and written by the single-node `loop` gate ONLY. Token usage
+   * accumulated by the invocation that produced the signal-bearing paused iteration,
+   * persisted so the finalize-on-approve path can write a node_completed carrying the
+   * usage it really consumed instead of a silent zero (#2333). Only set when
+   * completionSignaled is true; null otherwise. A `loop_group` gate deliberately does
+   * NOT write this: its body nodes persist their own `<groupId>.<nodeId>` rows (with
+   * tokens) before the pause, so a finalize row repeating the total would double-count.
    *
    * Scope note: this is the PAUSING invocation's total, matching what the normal
-   * (re-run) completion path reports — a loop that gated more than once attributes each
-   * invocation's usage to that invocation, and earlier ones are only visible in the
-   * run-level totals. The gate loses `cost_usd` and the resolved model the same way;
-   * those belong to the single "preserve terminal provider stats across a gate" fix
-   * tracked by #2345.
+   * (re-run) completion path reports — a loop that gates more than once attributes each
+   * invocation's usage to that invocation, and EARLIER invocations' usage is reported
+   * nowhere: a pausing invocation never reaches completeWorkflowRun (the status is
+   * `paused`, so the pre-complete status check bails), and `total_tokens_*` are written
+   * only there. So on a twice-gated loop the surviving node row and the run row both
+   * report only the final invocation. That under-report predates this field (before
+   * #2333 nothing was persisted at all) and belongs to the "preserve terminal provider
+   * stats across a gate" fix tracked by #2345, which also covers the `cost_usd` and
+   * resolved-model loss at the same gate.
    */
   signaledTokens?: { input: number; output: number } | null;
   /**

--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -276,7 +276,7 @@ function makeProvider() {
     }),
     sendQuery: mock(function* () {
       yield { type: 'assistant', content: 'ai-output' };
-      yield { type: 'result', sessionId: 'sess', cost: 0.01 };
+      yield { type: 'result', sessionId: 'sess', cost: 0.01, tokens: { input: 7, output: 3 } };
     }),
   };
 }
@@ -333,7 +333,7 @@ describe('workflow: sub-run e2e (#2121 Phase 2)', () => {
     else process.env.ARCHON_HOME = originalArchonHome;
   });
 
-  it('runs a gateless child synchronously, threads output + cost, links parent_run_id', async () => {
+  it('runs a gateless child synchronously, threads output + cost + tokens, links parent_run_id', async () => {
     await writeWorkflow(
       'child-plain',
       `
@@ -408,11 +408,19 @@ nodes:
     // Child persisted its terminal summary + cost for the parent to read back.
     expect((child?.metadata as Record<string, unknown>).summary).toBe('ai-output');
     expect((child?.metadata as Record<string, unknown>).total_cost_usd).toBeCloseTo(0.01, 5);
+    expect((child?.metadata as Record<string, unknown>).total_tokens_in).toBe(7);
+    expect((child?.metadata as Record<string, unknown>).total_tokens_out).toBe(3);
     // The sub node wrote node_completed with the child's output (threaded to $sub.output).
     const subCompleted = store.events.find(
       e => e.event_type === 'node_completed' && e.step_name === 'sub'
     );
     expect(subCompleted?.data?.node_output).toBe('ai-output');
+    // ...and with the child's rolled-up usage. Tokens must ride along with cost:
+    // they are the only usage axis every provider reports (#2333), and the child's
+    // own per-node rows are filed under a different workflow_run_id, so this cannot
+    // double count within the parent's stream.
+    expect(subCompleted?.data?.cost_usd).toBeCloseTo(0.01, 5);
+    expect(subCompleted?.data?.tokens).toEqual({ input: 7, output: 3 });
     // Child conversation is shared with the parent.
     expect(child?.conversation_id).toBe('conv-db');
   });


### PR DESCRIPTION
## Summary

- Problem: successful workflow node completion events omitted token usage even though providers supplied it and the executor already collected it.
- Why it matters: API, CLI, and remote-console consumers could not inspect per-node usage without reading local JSONL logs.
- What changed: direct AI, loop, and loop-group completion events now persist their existing token values; regression tests cover all three paths.
- What did **not** change (scope boundary): provider contracts, run-level aggregation, event schema/storage, APIs, and database migrations are unchanged.

## UX Journey

### Before

```
Workflow operator          Provider              Workflow executor       Event consumers
───────────────          ────────              ─────────────────       ───────────────
runs workflow ─────────▶ returns result
                           + token usage ────▶ captures tokens
                                                  writes completion
                                                  event (without tokens) ──▶ cannot view node usage
```

### After

```
Workflow operator          Provider              Workflow executor       Event consumers
───────────────          ────────              ─────────────────       ───────────────
runs workflow ─────────▶ returns result
                           + token usage ────▶ captures tokens
                                                  writes completion
                                                  event [with tokens] ─────▶ [views node usage]
```

## Architecture Diagram

### Before

```
Provider result tokens ──▶ DAG executor ──▶ JSONL logger
                                 │
                                 └───────▶ workflow_events (node_completed; tokens omitted) ──▶ API / CLI / console
```

### After

```
Provider result tokens ──▶ [~ DAG executor] ──▶ JSONL logger
                                 │
                                 └════════▶ workflow_events (node_completed; [tokens persisted]) ──▶ API / CLI / console
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| Provider result chunks | DAG executor | unchanged | Providers already normalize optional token usage. |
| DAG executor | JSONL logger | unchanged | Direct-node logging already includes tokens. |
| DAG executor | workflow event store | **modified** | Successful direct, loop, and loop-group completion payloads now include available tokens. |
| Workflow event store | API / CLI / console consumers | unchanged | Existing generic event data is returned without schema or storage changes. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `workflows`
- Module: `workflows:executor`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes #2333
- Related #None
- Depends on #None
- Supersedes #None

## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check
bun run lint
bun run format:check
bun run test
bun run validate
```

- Evidence provided (test/log/trace/screenshot): focused DAG executor tests passed (434 passed, 0 failed); full validation in a clean temporary snapshot containing only the two issue files passed. Recorded validation also reports type check, lint, format check, build, and 6,401 tests passing.
- If any command is intentionally skipped, explain why: none. The live worktree validation was blocked only by unrelated pre-existing `.archon/` edits that make bundled defaults stale; the same full gate passed in the clean snapshot with this fix applied.

## Security Impact (required)

- New permissions/capabilities? (No)
- New external network calls? (No)
- Secrets/tokens handling changed? (No; this persists existing aggregate usage counts, not credentials or model prompts.)
- File system access scope changed? (No)
- If any `Yes`, describe risk and mitigation: Not applicable.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Database migration needed? (No)
- If yes, exact upgrade steps: Not applicable.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: direct AI node, loop wrapper, and loop-group completion events retain their reported or aggregated token objects.
- Edge cases checked: absent token usage remains absent rather than being converted to a synthetic zero or `undefined` event field.
- What was not verified: live remote-console rendering was not manually exercised; it reads the unchanged event-data contract.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: workflow DAG execution and consumers of persisted `node_completed` event data.
- Potential unintended effects: event records carrying reported usage gain a small optional JSON object.
- Guardrails/monitoring for early detection: targeted regression tests assert exact direct and aggregate token payloads; optional spreading preserves no-usage behavior.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `aa11bf1a` from `dev` if event payload expansion causes an integration issue.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: consumers reject an added optional `tokens` property or display unexpected node usage values.

## Risks and Mitigations

- Risk: a provider reports no usage or an incomplete usage object.
  - Mitigation: persist only non-undefined values and preserve the provider-normalized object without recalculation.
