### PR TITLE
Clear stale workflow errors on resume

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -2374,6 +2374,22 @@ describe('workflowGetCommand', () => {
     expect(consoleSpy).toHaveBeenCalledWith('  Error:  Step failed: build');
   });
 
+  it('does not print an error for a completed run with cleared error metadata', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'run-completed',
+      workflow_name: 'implement',
+      status: 'completed',
+      working_path: '/tmp/wt',
+      started_at: new Date(),
+      metadata: { error: null },
+    });
+
+    await workflowGetCommand('run-completed');
+
+    expect(consoleSpy.mock.calls.some(([line]) => String(line).startsWith('  Error:'))).toBe(false);
+  });
+
   it('emits the raw run as a single clean JSON object', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
     (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -2374,22 +2374,6 @@ describe('workflowGetCommand', () => {
     expect(consoleSpy).toHaveBeenCalledWith('  Error:  Step failed: build');
   });
 
-  it('does not print an error for a completed run with cleared error metadata', async () => {
-    const workflowDb = await import('@archon/core/db/workflows');
-    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
-      id: 'run-completed',
-      workflow_name: 'implement',
-      status: 'completed',
-      working_path: '/tmp/wt',
-      started_at: new Date(),
-      metadata: { error: null },
-    });
-
-    await workflowGetCommand('run-completed');
-
-    expect(consoleSpy.mock.calls.some(([line]) => String(line).startsWith('  Error:'))).toBe(false);
-  });
-
   it('emits the raw run as a single clean JSON object', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
     (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({

--- a/packages/core/src/db/workflows.resume-cas.integration.test.ts
+++ b/packages/core/src/db/workflows.resume-cas.integration.test.ts
@@ -60,12 +60,17 @@ await db.query(
 );
 
 /** Insert a run with an explicit status and a SQL expression for last_activity_at. */
-async function seed(id: string, status: string, lastActivityExpr: string): Promise<void> {
+async function seed(
+  id: string,
+  status: string,
+  lastActivityExpr: string,
+  metadata: Record<string, unknown> = {}
+): Promise<void> {
   await db.query(
     `INSERT INTO remote_agent_workflow_runs
-       (id, workflow_name, conversation_id, user_message, status, started_at, last_activity_at)
-     VALUES ($1, 'wf', 'conv-1', 'msg', $2, datetime('now'), ${lastActivityExpr})`,
-    [id, status]
+       (id, workflow_name, conversation_id, user_message, status, started_at, last_activity_at, metadata)
+     VALUES ($1, 'wf', 'conv-1', 'msg', $2, datetime('now'), ${lastActivityExpr}, $3)`,
+    [id, status, JSON.stringify(metadata)]
   );
 }
 
@@ -81,6 +86,17 @@ describe('resumeWorkflowRun — real SQLite (CAS + orphan recovery)', () => {
   test('resumes a failed run', async () => {
     await seed('failed', 'failed', "datetime('now')");
     expect((await resumeWorkflowRun('failed')).status).toBe('running');
+  });
+
+  test('clears a failed run error when resuming', async () => {
+    await seed('failed-with-error', 'failed', "datetime('now')", {
+      error: 'Process terminated (SIGTERM)',
+    });
+
+    const resumed = await resumeWorkflowRun('failed-with-error');
+
+    expect(resumed.status).toBe('running');
+    expect((await getWorkflowRun('failed-with-error'))?.metadata.error ?? null).toBeNull();
   });
 
   test('resumes a paused run', async () => {

--- a/packages/core/src/db/workflows.resume-cas.integration.test.ts
+++ b/packages/core/src/db/workflows.resume-cas.integration.test.ts
@@ -88,15 +88,89 @@ describe('resumeWorkflowRun — real SQLite (CAS + orphan recovery)', () => {
     expect((await resumeWorkflowRun('failed')).status).toBe('running');
   });
 
-  test('clears a failed run error when resuming', async () => {
+  test('clears a failed run error when resuming, preserving it as an event', async () => {
+    // #2329: a run that failed, resumed and completed kept rendering its old
+    // error. #2348: for the motivating run the error lived ONLY in metadata —
+    // the CLI's SIGTERM handler calls failWorkflowRun and writes no event — so
+    // clearing it silently destroyed the only record that the run ever failed.
     await seed('failed-with-error', 'failed', "datetime('now')", {
       error: 'Process terminated (SIGTERM)',
+      unrelated: 'keep me',
     });
 
     const resumed = await resumeWorkflowRun('failed-with-error');
 
     expect(resumed.status).toBe('running');
-    expect((await getWorkflowRun('failed-with-error'))?.metadata.error ?? null).toBeNull();
+    const after = await getWorkflowRun('failed-with-error');
+    expect(after?.metadata.error ?? null).toBeNull();
+    // Merge, not replace: unrelated metadata survives the clear.
+    expect(after?.metadata.unrelated).toBe('keep me');
+
+    // ...and the cleared error is now recoverable from the audit trail.
+    const events = await db.query<{ data: string }>(
+      `SELECT data FROM remote_agent_workflow_events
+       WHERE workflow_run_id = $1 AND event_type = 'workflow_resumed'`,
+      ['failed-with-error']
+    );
+    expect(events.rows).toHaveLength(1);
+    expect(JSON.parse(events.rows[0]?.data ?? '{}')).toEqual({
+      error: 'Process terminated (SIGTERM)',
+    });
+  });
+
+  test('writes no event when the resumed run carried no error', async () => {
+    // A paused gate resumes with nothing to preserve — it must not gain a
+    // spurious "this run failed once" record.
+    await seed('paused-clean', 'paused', "datetime('now')");
+
+    expect((await resumeWorkflowRun('paused-clean')).status).toBe('running');
+
+    const events = await db.query<{ cnt: number }>(
+      `SELECT COUNT(*) AS cnt FROM remote_agent_workflow_events
+       WHERE workflow_run_id = $1 AND event_type = 'workflow_resumed'`,
+      ['paused-clean']
+    );
+    expect(Number(events.rows[0]?.cnt ?? -1)).toBe(0);
+  });
+
+  test('two concurrent resumes: exactly one wins and exactly one event lands', async () => {
+    // The loser read the same error but its CAS matched nothing — it must write
+    // nothing, or a lost race still emits an audit event for a clear it never did.
+    await seed('resume-race', 'failed', "datetime('now')", { error: 'boom' });
+
+    const outcomes = await Promise.allSettled([
+      resumeWorkflowRun('resume-race'),
+      resumeWorkflowRun('resume-race'),
+    ]);
+
+    expect(outcomes.filter(o => o.status === 'fulfilled')).toHaveLength(1);
+    const events = await db.query<{ cnt: number }>(
+      `SELECT COUNT(*) AS cnt FROM remote_agent_workflow_events
+       WHERE workflow_run_id = $1 AND event_type = 'workflow_resumed'`,
+      ['resume-race']
+    );
+    expect(Number(events.rows[0]?.cnt ?? -1)).toBe(1);
+  });
+
+  test('rolls back the clear when the audit-event write fails', async () => {
+    // The preservation is only worth anything if it cannot be skipped: a failed
+    // event INSERT must roll the clear back, leaving the run resumable with its
+    // error intact rather than erasing it with no record.
+    await seed('resume-atomic', 'failed', "datetime('now')", { error: 'boom' });
+
+    // Break the event INSERT by removing the table for the duration of the call.
+    await db.query('ALTER TABLE remote_agent_workflow_events RENAME TO events_stash', []);
+    try {
+      await expect(resumeWorkflowRun('resume-atomic')).rejects.toThrow(
+        /Failed to resume workflow run/
+      );
+    } finally {
+      await db.query('ALTER TABLE events_stash RENAME TO remote_agent_workflow_events', []);
+    }
+
+    const after = await getWorkflowRun('resume-atomic');
+    expect(after?.status).toBe('failed');
+    expect(after?.metadata.error).toBe('boom');
   });
 
   test('resumes a paused run', async () => {

--- a/packages/core/src/db/workflows.test.ts
+++ b/packages/core/src/db/workflows.test.ts
@@ -908,9 +908,10 @@ describe('workflows database', () => {
       const [updateQuery, updateParams] = mockQuery.mock.calls[0] as [string, unknown[]];
       expect(updateQuery).toContain("status = 'running'");
       expect(updateQuery).toContain('completed_at = NULL');
+      expect(updateQuery).toContain('metadata = metadata || $3::jsonb');
       // $1 = id, $2 = ORPHAN_RESUME_STALE_DAYS. The day param MUST be bound or the
       // CAS predicate's `< $2 days` references an unbound placeholder (PR #1830 C1).
-      expect(updateParams).toEqual(['workflow-run-123', 1]);
+      expect(updateParams).toEqual(['workflow-run-123', 1, JSON.stringify({ error: null })]);
       // Second call: SELECT
       const [selectQuery, selectParams] = mockQuery.mock.calls[1] as [string, unknown[]];
       expect(selectQuery).toContain('SELECT *');
@@ -949,7 +950,7 @@ describe('workflows database', () => {
       expect(updateQuery).toContain("status = 'running' AND");
       // The stale-orphan arm references $2 — it MUST be bound to the day count.
       expect(updateQuery).toContain('$2');
-      expect(updateParams).toEqual(['workflow-run-123', 1]);
+      expect(updateParams).toEqual(['workflow-run-123', 1, JSON.stringify({ error: null })]);
     });
 
     test('throws when no row matched and the run is gone (not found)', async () => {

--- a/packages/core/src/db/workflows.test.ts
+++ b/packages/core/src/db/workflows.test.ts
@@ -4,11 +4,17 @@ import type { WorkflowRun } from '@archon/workflows/schemas/workflow-run';
 
 const mockQuery = mock(() => Promise.resolve(createQueryResult([])));
 
-// Mock the connection module before importing the module under test
+// Mock the connection module before importing the module under test.
+// `getDatabase().withTransaction` runs its callback against the SAME mockQuery,
+// so a transactional function's statements land in mockQuery.mock.calls in
+// order, exactly like the non-transactional ones.
 mock.module('./connection', () => ({
   pool: {
     query: mockQuery,
   },
+  getDatabase: () => ({
+    withTransaction: <T>(fn: (query: typeof mockQuery) => Promise<T>): Promise<T> => fn(mockQuery),
+  }),
   getDialect: () => mockPostgresDialect,
   getDatabaseType: () => 'postgresql' as const,
 }));
@@ -33,6 +39,7 @@ import {
   listWorkflowRuns,
   deleteOldWorkflowRuns,
   deleteWorkflowRun,
+  WorkflowNotResumableError,
 } from './workflows';
 
 describe('workflows database', () => {
@@ -895,6 +902,8 @@ describe('workflows database', () => {
   describe('resumeWorkflowRun', () => {
     test('updates run to running, clears completed_at, and returns updated row', async () => {
       const updatedRun = { ...mockWorkflowRun, status: 'running' as const, completed_at: null };
+      // Pre-CAS read of the metadata about to be cleared (no prior error here)
+      mockQuery.mockResolvedValueOnce(createQueryResult([{ metadata: {} }]));
       // UPDATE query returns rowCount 1
       mockQuery.mockResolvedValueOnce(createQueryResult([], 1));
       // SELECT query returns the updated row
@@ -904,18 +913,27 @@ describe('workflows database', () => {
 
       expect(result.status).toBe('running');
       expect(result.completed_at).toBeNull();
-      // First call: UPDATE
-      const [updateQuery, updateParams] = mockQuery.mock.calls[0] as [string, unknown[]];
+      // First call: the row-pinning read of the error the CAS is about to clear.
+      const [priorQuery, priorParams] = mockQuery.mock.calls[0] as [string, unknown[]];
+      expect(priorQuery).toContain('SELECT metadata');
+      // Postgres row lock — without it the value read is not guaranteed to be the
+      // value the CAS clears, so the preserved error could be stale (#2348).
+      expect(priorQuery).toContain('FOR UPDATE');
+      expect(priorParams).toEqual(['workflow-run-123']);
+      // Second call: UPDATE
+      const [updateQuery, updateParams] = mockQuery.mock.calls[1] as [string, unknown[]];
       expect(updateQuery).toContain("status = 'running'");
       expect(updateQuery).toContain('completed_at = NULL');
       expect(updateQuery).toContain('metadata = metadata || $3::jsonb');
       // $1 = id, $2 = ORPHAN_RESUME_STALE_DAYS. The day param MUST be bound or the
       // CAS predicate's `< $2 days` references an unbound placeholder (PR #1830 C1).
       expect(updateParams).toEqual(['workflow-run-123', 1, JSON.stringify({ error: null })]);
-      // Second call: SELECT
-      const [selectQuery, selectParams] = mockQuery.mock.calls[1] as [string, unknown[]];
+      // Third call: SELECT
+      const [selectQuery, selectParams] = mockQuery.mock.calls[2] as [string, unknown[]];
       expect(selectQuery).toContain('SELECT *');
       expect(selectParams).toEqual(['workflow-run-123']);
+      // No prior error → no audit event (only three statements ran).
+      expect(mockQuery.mock.calls).toHaveLength(3);
     });
 
     test('refreshes started_at to NOW so resumed row competes fairly in the path-lock tiebreaker', async () => {
@@ -923,6 +941,7 @@ describe('workflows database', () => {
       // hours-old) started_at and sorts ahead of any currently-active holder
       // in the older-wins tiebreaker — slipping past the lock and causing
       // two active workflows on the same working_path.
+      mockQuery.mockResolvedValueOnce(createQueryResult([{ metadata: {} }]));
       mockQuery.mockResolvedValueOnce(createQueryResult([], 1));
       mockQuery.mockResolvedValueOnce(
         createQueryResult([{ ...mockWorkflowRun, status: 'running' as const }])
@@ -930,7 +949,7 @@ describe('workflows database', () => {
 
       await resumeWorkflowRun('workflow-run-123');
 
-      const [updateQuery] = mockQuery.mock.calls[0] as [string, unknown[]];
+      const [updateQuery] = mockQuery.mock.calls[1] as [string, unknown[]];
       expect(updateQuery).toContain('started_at = NOW()');
     });
 
@@ -938,6 +957,7 @@ describe('workflows database', () => {
       // The flip to 'running' must only match a row that is still resumable —
       // failed/paused, or a stale 'running' orphan — so two concurrent resumers
       // can't both win and double-claim the worktree.
+      mockQuery.mockResolvedValueOnce(createQueryResult([{ metadata: {} }]));
       mockQuery.mockResolvedValueOnce(createQueryResult([], 1));
       mockQuery.mockResolvedValueOnce(
         createQueryResult([{ ...mockWorkflowRun, status: 'running' as const }])
@@ -945,7 +965,7 @@ describe('workflows database', () => {
 
       await resumeWorkflowRun('workflow-run-123');
 
-      const [updateQuery, updateParams] = mockQuery.mock.calls[0] as [string, unknown[]];
+      const [updateQuery, updateParams] = mockQuery.mock.calls[1] as [string, unknown[]];
       expect(updateQuery).toContain("status IN ('failed', 'paused')");
       expect(updateQuery).toContain("status = 'running' AND");
       // The stale-orphan arm references $2 — it MUST be bound to the day count.
@@ -953,7 +973,52 @@ describe('workflows database', () => {
       expect(updateParams).toEqual(['workflow-run-123', 1, JSON.stringify({ error: null })]);
     });
 
+    test('preserves the cleared error as a workflow_resumed event (CAS winner only)', async () => {
+      // The resume clears metadata.error, which for a SIGTERM-killed CLI run is
+      // the ONLY record that the run ever failed — no workflow_failed/node_failed
+      // event is written on that path (#2348). The clear must not lose it.
+      mockQuery.mockResolvedValueOnce(
+        createQueryResult([{ metadata: { error: 'Process terminated (SIGTERM)' } }])
+      );
+      mockQuery.mockResolvedValueOnce(createQueryResult([], 1)); // CAS wins
+      mockQuery.mockResolvedValueOnce(createQueryResult([])); // event INSERT
+      mockQuery.mockResolvedValueOnce(
+        createQueryResult([{ ...mockWorkflowRun, status: 'running' as const }])
+      );
+
+      await resumeWorkflowRun('workflow-run-123');
+
+      const [eventQuery, eventParams] = mockQuery.mock.calls[2] as [string, unknown[]];
+      expect(eventQuery).toContain('INSERT INTO remote_agent_workflow_events');
+      // [id, workflow_run_id, event_type, step_index, step_name, data]
+      expect(eventParams[1]).toBe('workflow-run-123');
+      expect(eventParams[2]).toBe('workflow_resumed');
+      expect(eventParams[5]).toBe(JSON.stringify({ error: 'Process terminated (SIGTERM)' }));
+    });
+
+    test('writes no event when the CAS loses, even though an error was read', async () => {
+      // A concurrent resumer already flipped the row: this caller read the error
+      // but its UPDATE matched nothing, so it must write NOTHING at all —
+      // otherwise a lost race still emits an audit event for a clear it never did.
+      mockQuery.mockResolvedValueOnce(
+        createQueryResult([{ metadata: { error: 'Process terminated (SIGTERM)' } }])
+      );
+      mockQuery.mockResolvedValueOnce(createQueryResult([], 0)); // CAS loses
+      mockQuery.mockResolvedValueOnce(createQueryResult([{ status: 'running' }])); // probe
+
+      await expect(resumeWorkflowRun('workflow-run-123')).rejects.toThrow(
+        WorkflowNotResumableError
+      );
+
+      const inserts = mockQuery.mock.calls.filter(([sql]) =>
+        String(sql).includes('INSERT INTO remote_agent_workflow_events')
+      );
+      expect(inserts).toHaveLength(0);
+    });
+
     test('throws when no row matched and the run is gone (not found)', async () => {
+      // Pre-CAS read finds nothing (row already deleted)
+      mockQuery.mockResolvedValueOnce(createQueryResult([]));
       // UPDATE returns rowCount 0
       mockQuery.mockResolvedValueOnce(createQueryResult([], 0));
       // Probe SELECT finds no row → deleted
@@ -965,6 +1030,7 @@ describe('workflows database', () => {
     });
 
     test('throws "not resumable" when the run was concurrently activated (CAS miss)', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([{ metadata: {} }]));
       // UPDATE matches nothing because the row is already 'running'
       mockQuery.mockResolvedValueOnce(createQueryResult([], 0));
       // Probe SELECT reveals the current status
@@ -976,6 +1042,7 @@ describe('workflows database', () => {
     });
 
     test('throws on database error during the disambiguation probe', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([{ metadata: {} }]));
       mockQuery.mockResolvedValueOnce(createQueryResult([], 0)); // UPDATE matched nothing
       mockQuery.mockRejectedValueOnce(new Error('Connection lost')); // probe fails
 
@@ -985,6 +1052,17 @@ describe('workflows database', () => {
     });
 
     test('throws on database error during UPDATE', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([{ metadata: {} }]));
+      mockQuery.mockRejectedValueOnce(new Error('Lock timeout'));
+
+      await expect(resumeWorkflowRun('workflow-run-123')).rejects.toThrow(
+        'Failed to resume workflow run: Lock timeout'
+      );
+    });
+
+    test('throws on database error during the pre-CAS read', async () => {
+      // The read shares the CAS's try/catch — a failure there must surface as the
+      // same resume error, and the transaction rolls back with nothing written.
       mockQuery.mockRejectedValueOnce(new Error('Lock timeout'));
 
       await expect(resumeWorkflowRun('workflow-run-123')).rejects.toThrow(
@@ -993,6 +1071,7 @@ describe('workflows database', () => {
     });
 
     test('throws on database error during SELECT after UPDATE', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([{ metadata: {} }]));
       // UPDATE succeeds
       mockQuery.mockResolvedValueOnce(createQueryResult([], 1));
       // SELECT fails
@@ -1004,6 +1083,7 @@ describe('workflows database', () => {
     });
 
     test('throws when row vanishes between UPDATE and SELECT', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([{ metadata: {} }]));
       // UPDATE succeeds (rowCount 1)
       mockQuery.mockResolvedValueOnce(createQueryResult([], 1));
       // SELECT returns nothing (row deleted between statements)

--- a/packages/core/src/db/workflows.ts
+++ b/packages/core/src/db/workflows.ts
@@ -74,6 +74,41 @@ function resumableStatusClause(dialect: SqlDialect, dayParamIndex: number): stri
 }
 
 /**
+ * `FOR UPDATE` on Postgres, empty on SQLite (which has no such syntax and does
+ * not need it — the adapter serializes transactions on one connection, and a
+ * cross-process writer that commits between our read and our write makes the
+ * deferred BEGIN's read→write upgrade fail with SQLITE_BUSY rather than let a
+ * stale snapshot through). Used by resumeWorkflowRun to pin the row across its
+ * read-then-CAS pair so the value it reads is the value the CAS acts on.
+ * Dialect-branched here rather than in SqlDialect: this is the only caller, and
+ * the branch mirrors unresolvedGateClause's local getDatabaseType() check.
+ */
+function rowLockClause(): string {
+  return getDatabaseType() === 'postgresql' ? ' FOR UPDATE' : '';
+}
+
+/**
+ * Extract a non-empty `metadata.error` string from a raw column value, or null
+ * when there is nothing worth preserving. SQLite stores metadata as JSON TEXT
+ * and Postgres returns a parsed object (same split normalizeWorkflowRun handles),
+ * so both shapes are accepted; absent / null / non-string / empty / unparseable
+ * all collapse to null.
+ */
+function readMetadataError(raw: unknown): string | null {
+  let metadata: unknown = raw;
+  if (typeof metadata === 'string') {
+    try {
+      metadata = JSON.parse(metadata);
+    } catch {
+      return null;
+    }
+  }
+  if (typeof metadata !== 'object' || metadata === null) return null;
+  const error = (metadata as Record<string, unknown>).error;
+  return typeof error === 'string' && error !== '' ? error : null;
+}
+
+/**
  * SQL predicate matching a run whose approval gate is still OPEN: the row is
  * 'paused' AND metadata.approval.resolved is JSON null or absent. Dialect-aware
  * (Postgres `->>`, SQLite `json_extract`) and kept in ONE place so the two forms
@@ -674,7 +709,7 @@ export async function resumeWorkflowRun(id: string): Promise<WorkflowRun> {
   // Split into UPDATE + SELECT to support both PostgreSQL and SQLite
   // (SQLite does not support RETURNING on UPDATE statements)
   // Each phase has its own try/catch to avoid string-sniffing own errors in a shared catch.
-  let updateResult: Awaited<ReturnType<typeof pool.query>>;
+  let updateResult: { rowCount: number };
   try {
     // Refresh started_at to NOW so the resumed row competes fairly with
     // currently-active rows in getActiveWorkflowRunByPath's older-wins
@@ -696,16 +731,49 @@ export async function resumeWorkflowRun(id: string): Promise<WorkflowRun> {
     // Resume + a chat re-dispatch, or the lock-less CLI path) could both flip
     // the same run to 'running' and double-claim the worktree. The day param is
     // bound at $2 (ORPHAN_RESUME_STALE_DAYS), matching findResumableRun's bind.
-    updateResult = await pool.query(
-      `UPDATE remote_agent_workflow_runs
-       SET status = 'running',
-           completed_at = NULL,
-           started_at = ${dialect.now()},
-           last_activity_at = ${dialect.now()},
-           metadata = ${dialect.jsonMerge('metadata', 3)}
-       WHERE id = $1 AND ${resumableStatusClause(dialect, 2)}`,
-      [id, ORPHAN_RESUME_STALE_DAYS, JSON.stringify({ error: null })]
-    );
+    //
+    // The CAS also clears `metadata.error` so a run that fails, is resumed, and
+    // then completes doesn't keep rendering its old failure (#2329). Because
+    // metadata is the ONLY place some failures are recorded — the CLI's SIGTERM
+    // handler calls failWorkflowRun and writes no event (#2348) — the error being
+    // cleared is first preserved as a `workflow_resumed` event, in the SAME
+    // transaction as the clear, so the audit trail can never lose it. The read,
+    // the CAS and the event INSERT are one transaction (mirroring
+    // resolveApprovalGate, #2146): the row is pinned by rowLockClause() so the
+    // value read is the value cleared, and the event is written ONLY by the
+    // caller whose CAS matched — a losing concurrent resumer writes nothing.
+    // Read-then-UPDATE rather than UPDATE…RETURNING because the SQLite adapter
+    // rejects RETURNING on UPDATE and points at exactly this pattern.
+    updateResult = await getDatabase().withTransaction(async query => {
+      const priorRows = await query<{ metadata: unknown }>(
+        `SELECT metadata FROM remote_agent_workflow_runs WHERE id = $1${rowLockClause()}`,
+        [id]
+      );
+      const clearedError = readMetadataError(priorRows.rows[0]?.metadata);
+
+      const result = await query(
+        `UPDATE remote_agent_workflow_runs
+         SET status = 'running',
+             completed_at = NULL,
+             started_at = ${dialect.now()},
+             last_activity_at = ${dialect.now()},
+             metadata = ${dialect.jsonMerge('metadata', 3)}
+         WHERE id = $1 AND ${resumableStatusClause(dialect, 2)}`,
+        [id, ORPHAN_RESUME_STALE_DAYS, JSON.stringify({ error: null })]
+      );
+
+      const rowCount = result.rowCount;
+      if (rowCount > 0 && clearedError !== null) {
+        // Same `{ error }` payload shape workflow_failed uses, so every consumer
+        // that already reads an error off a workflow_* event keeps working.
+        await insertWorkflowEvent(query, {
+          workflow_run_id: id,
+          event_type: 'workflow_resumed',
+          data: { error: clearedError },
+        });
+      }
+      return { rowCount };
+    });
   } catch (error) {
     const err = error as Error;
     getLog().error({ err, workflowRunId: id }, 'db.workflow_run_resume_failed');

--- a/packages/core/src/db/workflows.ts
+++ b/packages/core/src/db/workflows.ts
@@ -701,9 +701,10 @@ export async function resumeWorkflowRun(id: string): Promise<WorkflowRun> {
        SET status = 'running',
            completed_at = NULL,
            started_at = ${dialect.now()},
-           last_activity_at = ${dialect.now()}
+           last_activity_at = ${dialect.now()},
+           metadata = ${dialect.jsonMerge('metadata', 3)}
        WHERE id = $1 AND ${resumableStatusClause(dialect, 2)}`,
-      [id, ORPHAN_RESUME_STALE_DAYS]
+      [id, ORPHAN_RESUME_STALE_DAYS, JSON.stringify({ error: null })]
     );
   } catch (error) {
     const err = error as Error;

--- a/packages/web/src/experiments/console/primitives/event.ts
+++ b/packages/web/src/experiments/console/primitives/event.ts
@@ -262,13 +262,23 @@ export function toRunEvent(raw: RawWorkflowEvent): RunEvent {
     };
   }
 
-  if (et === 'workflow_started' || et === 'workflow_completed' || et === 'workflow_failed') {
+  if (
+    et === 'workflow_started' ||
+    et === 'workflow_completed' ||
+    et === 'workflow_failed' ||
+    et === 'workflow_resumed'
+  ) {
+    // `workflow_resumed` is written only when a resume CLEARED a prior error
+    // (#2348), and carries that error in `data.error` — the same key
+    // `workflow_failed` uses, so the shared `detail` fallback below surfaces it.
     const label =
       et === 'workflow_started'
         ? 'Workflow started'
         : et === 'workflow_completed'
           ? 'Workflow completed'
-          : 'Workflow failed';
+          : et === 'workflow_resumed'
+            ? 'Workflow resumed (prior error cleared)'
+            : 'Workflow failed';
     const detail =
       readString(data, 'name') ||
       readString(data, 'workflow') ||

--- a/packages/workflows/src/store.ts
+++ b/packages/workflows/src/store.ts
@@ -26,6 +26,12 @@ export const WORKFLOW_EVENT_TYPES = [
   'workflow_started',
   'workflow_completed',
   'workflow_failed',
+  // #2348 — written by the resume CAS ONLY when it clears a non-empty
+  // `metadata.error`, carrying that error in `data.error`. It is the audit
+  // record for a failure that resume would otherwise erase (the CLI's SIGTERM
+  // handler records a failure in metadata and nowhere else), NOT a general
+  // "a resume happened" marker: its absence never means the run wasn't resumed.
+  'workflow_resumed',
   'node_started',
   'node_completed',
   'node_failed',


### PR DESCRIPTION
## Summary

- Problem: resumed workflow runs retained the prior attempt's `metadata.error`, so `archon workflow get` could show a SIGTERM error after the run completed successfully.
- Why it matters: the CLI, JSON, and API read surfaces could present an old failure as the run's current state.
- What changed: clear the current error atomically in the resume compare-and-swap transition, with PostgreSQL SQL, real SQLite, and CLI regression coverage.
- What did **not** change (scope boundary): workflow event history, failure persistence for active failed attempts, CLI production rendering, and run-status semantics are unchanged.

## UX Journey

### Before

```
User                    Archon CLI / workflow store
────                    ──────────────────────────
resumes failed run ───▶ transitions run to running
                        retains metadata.error = SIGTERM
run completes ───────▶ marks run completed
gets run details ────▶ displays "Error: SIGTERM" beside completed status
```

### After

```
User                    Archon CLI / workflow store
────                    ──────────────────────────
resumes failed run ───▶ [transitions run to running and clears metadata.error]
run completes ───────▶ marks run completed
gets run details ────▶ [shows completed status without a stale error]
```

## Architecture Diagram

### Before

```
workflow executor ──▶ core workflow store adapter ──▶ core DB resumeWorkflowRun
                                                         │
                                                         └── leaves metadata.error unchanged
CLI workflow get ────────────────────────────────────▶ reads and renders metadata.error
```

### After

```
workflow executor ──▶ core workflow store adapter ──▶ [~ core DB resumeWorkflowRun]
                                                         │
                                                         === clears metadata.error atomically
CLI workflow get ────────────────────────────────────▶ reads metadata; null/absent error is not rendered
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| Workflow executor | Core workflow store adapter | unchanged | Continues to request run resumption. |
| Core workflow store adapter | Core DB `resumeWorkflowRun` | **modified** | Resume persistence now clears the current error marker. |
| Core DB | SQLite/PostgreSQL metadata JSON | **modified** | Uses existing dialect JSON merge behavior to write an error-null patch. |
| CLI `workflow get` | Workflow run metadata | unchanged | Existing string-only rendering naturally suppresses cleared errors. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `core`, `cli`, `tests`
- Module: `core:workflow-persistence`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi`

## Linked Issue

- Closes #2329
- Related # None
- Depends on # None
- Supersedes # None

## Validation Evidence (required)

Commands and result summary:

```bash
bun test packages/core/src/db/workflows.test.ts
bun test packages/core/src/db/workflows.resume-cas.integration.test.ts
bun test packages/cli/src/commands/workflow.test.ts
bun run type-check
bun run lint
bun run format:check
bun run test
bun run build
```

- Evidence provided (test/log/trace/screenshot): focused tests passed (292 tests, 0 failures); type check, lint with zero warnings, format check, package-isolated test suite, and build passed. The SQLite regression seeds `Process terminated (SIGTERM)`, resumes the run, and confirms its error is null or absent; the CLI regression confirms completed output contains no `Error:` line.
- If any command is intentionally skipped, explain why: none. An earlier full validation attempt had a baseline-only bundled-content mismatch caused by pre-existing, unstaged `.archon/` edits in this worktree; the committed fix is independent of those edits and all issue-related checks passed.

## Security Impact (required)

- New permissions/capabilities? (No)
- New external network calls? (No)
- Secrets/tokens handling changed? (No)
- File system access scope changed? (No)
- If any `Yes`, describe risk and mitigation: Not applicable.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Database migration needed? (No)
- If yes, exact upgrade steps: Not applicable.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: a failed run with a persisted SIGTERM error resumes through the real SQLite persistence path and no longer exposes a current error; a completed run with `error: null` does not print an `Error:` line.
- Edge cases checked: the SQL mock locks the PostgreSQL parameter ordering; SQLite's JSON patch may remove the key while PostgreSQL retains JSON null, and both satisfy the read contract; existing failed-run error rendering remains covered.
- What was not verified: a manual end-to-end run against a live provider and PostgreSQL database was not performed.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: resumable workflow-run persistence plus CLI/API/JSON consumers of workflow metadata.
- Potential unintended effects: resumed runs no longer retain the previous attempt's error in their mutable current-state metadata.
- Guardrails/monitoring for early detection: immutable workflow events still retain failed-attempt history; focused mock, SQLite integration, and CLI regression tests protect the lifecycle boundary and display behavior.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `38c60ec9` from this PR.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: a resumed-and-completed workflow may again show the prior attempt's `Error:` value in `archon workflow get`, JSON, and API metadata.

## Risks and Mitigations

- Risk: clearing error metadata could remove useful failure context.
  - Mitigation: only the mutable current-attempt error marker is cleared at resume; immutable workflow events preserve attempt history, and later failures continue to write their new error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Workflow resume operations now clear error metadata and create resumption audit events for improved tracking
* Resumption events record prior error details and are displayed in event history
* Event logs now show workflow resume events alongside other lifecycle events when workflows are retried

<!-- end of auto-generated comment: release notes by coderabbit.ai -->