### PR TITLE
Fix cumulative tokens for resumed workflow runs

### DIFF
--- a/packages/core/src/db/workflow-events.test.ts
+++ b/packages/core/src/db/workflow-events.test.ts
@@ -35,6 +35,7 @@ import {
 describe('workflow-events', () => {
   beforeEach(() => {
     mockQuery.mockClear();
+    mockLogger.warn.mockClear();
   });
 
   const mockEvent: WorkflowEventRow = {
@@ -353,6 +354,25 @@ describe('workflow-events', () => {
         ])
       );
       expect(result.tokens).toEqual({ input: 10, output: 1 });
+      expect(mockLogger.warn).toHaveBeenCalledTimes(2);
+    });
+
+    test('does not warn when completed events omit optional token usage', async () => {
+      mockQuery.mockResolvedValueOnce(
+        createQueryResult([
+          {
+            step_name: 'node-a',
+            event_type: 'node_completed',
+            data: { node_output: 'output without usage' },
+          },
+        ])
+      );
+
+      const result = await getDagResumeSnapshot('run-without-tokens');
+
+      expect(result.completedNodeOutputs).toEqual(new Map([['node-a', 'output without usage']]));
+      expect(result.tokens).toEqual({ input: 0, output: 0 });
+      expect(mockLogger.warn).not.toHaveBeenCalled();
     });
 
     test('skips corrupt JSON rows without losing other rows', async () => {

--- a/packages/core/src/db/workflow-events.test.ts
+++ b/packages/core/src/db/workflow-events.test.ts
@@ -29,7 +29,7 @@ import {
   createWorkflowEvent,
   listWorkflowEvents,
   listRecentEvents,
-  getCompletedDagNodeOutputs,
+  getDagResumeSnapshot,
 } from './workflow-events';
 
 describe('workflow-events', () => {
@@ -189,20 +189,32 @@ describe('workflow-events', () => {
     });
   });
 
-  describe('getCompletedDagNodeOutputs', () => {
-    test('returns map of nodeId → output from node_completed events', async () => {
+  describe('getDagResumeSnapshot', () => {
+    test('returns outputs and summed tokens from node_completed events', async () => {
       mockQuery.mockResolvedValueOnce(
         createQueryResult([
-          { step_name: 'node-a', data: { node_output: 'output A' } },
-          { step_name: 'node-b', data: { node_output: 'output B' } },
+          {
+            step_name: 'node-a',
+            event_type: 'node_completed',
+            data: { node_output: 'output A', tokens: { input: 40, output: 4 } },
+          },
+          {
+            step_name: 'node-b',
+            event_type: 'node_completed',
+            data: { node_output: 'output B', tokens: { input: 60, output: 6 } },
+          },
         ])
       );
 
-      const result = await getCompletedDagNodeOutputs('run-123');
+      const result = await getDagResumeSnapshot('run-123');
 
-      expect(result.size).toBe(2);
-      expect(result.get('node-a')).toBe('output A');
-      expect(result.get('node-b')).toBe('output B');
+      expect(result.completedNodeOutputs).toEqual(
+        new Map([
+          ['node-a', 'output A'],
+          ['node-b', 'output B'],
+        ])
+      );
+      expect(result.tokens).toEqual({ input: 100, output: 10 });
       expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('node_completed'), [
         'run-123',
       ]);
@@ -211,16 +223,29 @@ describe('workflow-events', () => {
     test('returns outputs from node_skipped_prior_success events (multi-resume)', async () => {
       mockQuery.mockResolvedValueOnce(
         createQueryResult([
-          { step_name: 'node-a', data: { node_output: 'output A' } },
-          { step_name: 'node-b', data: { reason: 'prior_success', node_output: 'output B' } },
+          {
+            step_name: 'node-a',
+            event_type: 'node_completed',
+            data: { node_output: 'output A', tokens: { input: 40, output: 4 } },
+          },
+          {
+            step_name: 'node-b',
+            event_type: 'node_skipped_prior_success',
+            data: {
+              reason: 'prior_success',
+              node_output: 'output B',
+              tokens: { input: 999, output: 999 },
+            },
+          },
         ])
       );
 
-      const result = await getCompletedDagNodeOutputs('run-resume');
+      const result = await getDagResumeSnapshot('run-resume');
 
-      expect(result.size).toBe(2);
-      expect(result.get('node-a')).toBe('output A');
-      expect(result.get('node-b')).toBe('output B');
+      expect(result.completedNodeOutputs.size).toBe(2);
+      expect(result.completedNodeOutputs.get('node-a')).toBe('output A');
+      expect(result.completedNodeOutputs.get('node-b')).toBe('output B');
+      expect(result.tokens).toEqual({ input: 40, output: 4 });
       expect(mockQuery).toHaveBeenCalledWith(
         expect.stringContaining('node_skipped_prior_success'),
         ['run-resume']
@@ -232,92 +257,142 @@ describe('workflow-events', () => {
         createQueryResult([
           {
             step_name: 'node-x',
+            event_type: 'node_skipped_prior_success',
             data: { reason: 'prior_success', node_output: 'skipped output X' },
           },
           {
             step_name: 'node-y',
+            event_type: 'node_skipped_prior_success',
             data: { reason: 'prior_success', node_output: 'skipped output Y' },
           },
         ])
       );
 
-      const result = await getCompletedDagNodeOutputs('run-all-skipped');
+      const result = await getDagResumeSnapshot('run-all-skipped');
 
-      expect(result.size).toBe(2);
-      expect(result.get('node-x')).toBe('skipped output X');
-      expect(result.get('node-y')).toBe('skipped output Y');
+      expect(result.completedNodeOutputs.size).toBe(2);
+      expect(result.completedNodeOutputs.get('node-x')).toBe('skipped output X');
+      expect(result.completedNodeOutputs.get('node-y')).toBe('skipped output Y');
+      expect(result.tokens).toEqual({ input: 0, output: 0 });
     });
 
     test('parses JSON string data (SQLite path)', async () => {
       mockQuery.mockResolvedValueOnce(
         createQueryResult([
-          { step_name: 'node-a', data: JSON.stringify({ node_output: 'parsed output' }) },
+          {
+            step_name: 'node-a',
+            event_type: 'node_completed',
+            data: JSON.stringify({
+              node_output: 'parsed output',
+              tokens: { input: 8, output: 2 },
+            }),
+          },
         ])
       );
 
-      const result = await getCompletedDagNodeOutputs('run-456');
+      const result = await getDagResumeSnapshot('run-456');
 
-      expect(result.size).toBe(1);
-      expect(result.get('node-a')).toBe('parsed output');
+      expect(result.completedNodeOutputs.get('node-a')).toBe('parsed output');
+      expect(result.tokens).toEqual({ input: 8, output: 2 });
     });
 
     test('skips rows with null step_name', async () => {
       mockQuery.mockResolvedValueOnce(
         createQueryResult([
-          { step_name: null, data: { node_output: 'should be skipped' } },
-          { step_name: 'node-a', data: { node_output: 'kept' } },
+          {
+            step_name: null,
+            event_type: 'node_completed',
+            data: { node_output: 'should be skipped', tokens: { input: 99, output: 99 } },
+          },
+          {
+            step_name: 'node-a',
+            event_type: 'node_completed',
+            data: { node_output: 'kept', tokens: { input: 1, output: 2 } },
+          },
         ])
       );
 
-      const result = await getCompletedDagNodeOutputs('run-789');
+      const result = await getDagResumeSnapshot('run-789');
 
-      expect(result.size).toBe(1);
-      expect(result.get('node-a')).toBe('kept');
+      expect(result.completedNodeOutputs).toEqual(new Map([['node-a', 'kept']]));
+      expect(result.tokens).toEqual({ input: 1, output: 2 });
     });
 
-    test('skips rows where node_output is not a string', async () => {
+    test('preserves valid outputs while ignoring malformed and non-finite tokens', async () => {
       mockQuery.mockResolvedValueOnce(
         createQueryResult([
-          { step_name: 'node-a', data: { node_output: 123 } },
-          { step_name: 'node-b', data: { duration_ms: 500 } },
-          { step_name: 'node-c', data: { node_output: 'valid' } },
+          {
+            step_name: 'node-a',
+            event_type: 'node_completed',
+            data: { node_output: 123, tokens: { input: 10, output: 1 } },
+          },
+          {
+            step_name: 'node-b',
+            event_type: 'node_completed',
+            data: { duration_ms: 500, tokens: { input: 'bad', output: 2 } },
+          },
+          {
+            step_name: 'node-c',
+            event_type: 'node_completed',
+            data: { node_output: 'valid', tokens: { input: Number.NaN, output: Infinity } },
+          },
+          {
+            step_name: 'node-d',
+            event_type: 'node_completed',
+            data: { node_output: 'also valid' },
+          },
         ])
       );
 
-      const result = await getCompletedDagNodeOutputs('run-filter');
+      const result = await getDagResumeSnapshot('run-filter');
 
-      expect(result.size).toBe(1);
-      expect(result.get('node-c')).toBe('valid');
+      expect(result.completedNodeOutputs).toEqual(
+        new Map([
+          ['node-c', 'valid'],
+          ['node-d', 'also valid'],
+        ])
+      );
+      expect(result.tokens).toEqual({ input: 10, output: 1 });
     });
 
     test('skips corrupt JSON rows without losing other rows', async () => {
       mockQuery.mockResolvedValueOnce(
         createQueryResult([
-          { step_name: 'node-a', data: { node_output: 'good first' } },
-          { step_name: 'node-b', data: '{bad json' },
-          { step_name: 'node-c', data: { node_output: 'good last' } },
+          {
+            step_name: 'node-a',
+            event_type: 'node_completed',
+            data: { node_output: 'good first', tokens: { input: 3, output: 1 } },
+          },
+          { step_name: 'node-b', event_type: 'node_completed', data: '{bad json' },
+          {
+            step_name: 'node-c',
+            event_type: 'node_completed',
+            data: { node_output: 'good last', tokens: { input: 7, output: 2 } },
+          },
         ])
       );
 
-      const result = await getCompletedDagNodeOutputs('run-corrupt');
+      const result = await getDagResumeSnapshot('run-corrupt');
 
-      expect(result.size).toBe(2);
-      expect(result.get('node-a')).toBe('good first');
-      expect(result.get('node-c')).toBe('good last');
+      expect(result.completedNodeOutputs.size).toBe(2);
+      expect(result.completedNodeOutputs.get('node-a')).toBe('good first');
+      expect(result.completedNodeOutputs.get('node-c')).toBe('good last');
+      expect(result.tokens).toEqual({ input: 10, output: 3 });
     });
 
-    test('returns empty map when no events exist', async () => {
+    test('returns an empty snapshot when no events exist', async () => {
       mockQuery.mockResolvedValueOnce(createQueryResult([]));
 
-      const result = await getCompletedDagNodeOutputs('run-empty');
+      const result = await getDagResumeSnapshot('run-empty');
 
-      expect(result.size).toBe(0);
+      expect(result.completedNodeOutputs.size).toBe(0);
+      expect(result.tokens).toEqual({ input: 0, output: 0 });
     });
 
     test('throws on DB query error', async () => {
       mockQuery.mockRejectedValueOnce(new Error('connection refused'));
 
-      await expect(getCompletedDagNodeOutputs('run-error')).rejects.toThrow('connection refused');
+      await expect(getDagResumeSnapshot('run-error')).rejects.toThrow('connection refused');
     });
   });
 });

--- a/packages/core/src/db/workflow-events.ts
+++ b/packages/core/src/db/workflow-events.ts
@@ -213,23 +213,26 @@ export async function listWorkflowEventsSince(
 }
 
 /**
- * Return a map of nodeId → output for all node_completed events in a workflow run.
- * Used by the DAG executor to restore node outputs when resuming a failed run.
+ * Return completed node outputs and cumulative token usage for a workflow run.
+ * Used by the DAG executor to restore state when resuming a failed run.
  * Throws on DB error — caller owns the degradation policy.
  */
-export async function getCompletedDagNodeOutputs(
-  workflowRunId: string
-): Promise<Map<string, string>> {
+export async function getDagResumeSnapshot(workflowRunId: string): Promise<{
+  completedNodeOutputs: Map<string, string>;
+  tokens: { input: number; output: number };
+}> {
   const result = await pool.query<{
     step_name: string | null;
+    event_type: 'node_completed' | 'node_skipped_prior_success';
     data: string | Record<string, unknown>;
   }>(
-    `SELECT step_name, data FROM remote_agent_workflow_events
+    `SELECT step_name, event_type, data FROM remote_agent_workflow_events
      WHERE workflow_run_id = $1 AND event_type IN ('node_completed', 'node_skipped_prior_success')
      ORDER BY created_at ASC`,
     [workflowRunId]
   );
-  const outputs = new Map<string, string>();
+  const completedNodeOutputs = new Map<string, string>();
+  const tokens = { input: 0, output: 0 };
   for (const row of result.rows) {
     if (!row.step_name) continue;
     let data: Record<string, unknown>;
@@ -243,8 +246,29 @@ export async function getCompletedDagNodeOutputs(
       continue;
     }
     if (typeof data.node_output === 'string') {
-      outputs.set(row.step_name, data.node_output);
+      completedNodeOutputs.set(row.step_name, data.node_output);
+    }
+    if (row.event_type === 'node_completed') {
+      const eventTokens = data.tokens;
+      if (
+        typeof eventTokens === 'object' &&
+        eventTokens !== null &&
+        'input' in eventTokens &&
+        'output' in eventTokens &&
+        typeof eventTokens.input === 'number' &&
+        typeof eventTokens.output === 'number' &&
+        Number.isFinite(eventTokens.input) &&
+        Number.isFinite(eventTokens.output)
+      ) {
+        tokens.input += eventTokens.input;
+        tokens.output += eventTokens.output;
+      } else {
+        getLog().warn(
+          { runId: workflowRunId, stepName: row.step_name, tokens: eventTokens },
+          'db.workflow_dag_node_tokens_invalid_ignored'
+        );
+      }
     }
   }
-  return outputs;
+  return { completedNodeOutputs, tokens };
 }

--- a/packages/core/src/db/workflow-events.ts
+++ b/packages/core/src/db/workflow-events.ts
@@ -248,7 +248,7 @@ export async function getDagResumeSnapshot(workflowRunId: string): Promise<{
     if (typeof data.node_output === 'string') {
       completedNodeOutputs.set(row.step_name, data.node_output);
     }
-    if (row.event_type === 'node_completed') {
+    if (row.event_type === 'node_completed' && data.tokens !== undefined) {
       const eventTokens = data.tokens;
       if (
         typeof eventTokens === 'object' &&

--- a/packages/core/src/workflows/store-adapter.test.ts
+++ b/packages/core/src/workflows/store-adapter.test.ts
@@ -35,10 +35,15 @@ mock.module('../db/workflows', () => ({
 }));
 
 const mockCreateWorkflowEvent = mock(() => Promise.resolve());
-const mockGetCompletedDagNodeOutputs = mock(() => Promise.resolve(new Map<string, string>()));
+const mockGetDagResumeSnapshot = mock(() =>
+  Promise.resolve({
+    completedNodeOutputs: new Map<string, string>(),
+    tokens: { input: 0, output: 0 },
+  })
+);
 mock.module('../db/workflow-events', () => ({
   createWorkflowEvent: mockCreateWorkflowEvent,
-  getCompletedDagNodeOutputs: mockGetCompletedDagNodeOutputs,
+  getDagResumeSnapshot: mockGetDagResumeSnapshot,
 }));
 
 const mockGetCodebase = mock(() => Promise.resolve(null));
@@ -122,7 +127,7 @@ describe('createWorkflowStore', () => {
       'releaseWritebackClaim',
       'cancelWorkflowRun',
       'createWorkflowEvent',
-      'getCompletedDagNodeOutputs',
+      'getDagResumeSnapshot',
       'getCodebase',
       'getCodebaseEnvVars',
     ];
@@ -160,13 +165,16 @@ describe('createWorkflowStore', () => {
     ).resolves.toBeUndefined();
   });
 
-  test('delegates getCompletedDagNodeOutputs to DB', async () => {
-    const expected = new Map([['step1', 'output text']]);
-    mockGetCompletedDagNodeOutputs.mockResolvedValueOnce(expected);
+  test('delegates getDagResumeSnapshot to DB', async () => {
+    const expected = {
+      completedNodeOutputs: new Map([['step1', 'output text']]),
+      tokens: { input: 40, output: 4 },
+    };
+    mockGetDagResumeSnapshot.mockResolvedValueOnce(expected);
     const store = createWorkflowStore();
-    const result = await store.getCompletedDagNodeOutputs('run-123');
+    const result = await store.getDagResumeSnapshot('run-123');
     expect(result).toBe(expected);
-    expect(mockGetCompletedDagNodeOutputs).toHaveBeenCalledWith('run-123');
+    expect(mockGetDagResumeSnapshot).toHaveBeenCalledWith('run-123');
   });
 
   test('delegates cancelWorkflowRun to DB', async () => {

--- a/packages/core/src/workflows/store-adapter.ts
+++ b/packages/core/src/workflows/store-adapter.ts
@@ -74,7 +74,7 @@ export function createWorkflowStore(): IWorkflowStore {
         );
       }
     },
-    getCompletedDagNodeOutputs: workflowEventDb.getCompletedDagNodeOutputs,
+    getDagResumeSnapshot: workflowEventDb.getDagResumeSnapshot,
     getCodebase: codebaseDb.getCodebase,
     getCodebaseEnvVars: envVarDb.getCodebaseEnvVars,
     getWorkflowNodeSession: workflowNodeSessionDb.getWorkflowNodeSession,

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -143,7 +143,12 @@ function createMockStore(): IWorkflowStore {
     releaseWritebackClaim: mock(() => Promise.resolve()),
     cancelWorkflowRun: mock(() => Promise.resolve()),
     createWorkflowEvent: mock(() => Promise.resolve()),
-    getCompletedDagNodeOutputs: mock(() => Promise.resolve(new Map<string, string>())),
+    getDagResumeSnapshot: mock(() =>
+      Promise.resolve({
+        completedNodeOutputs: new Map<string, string>(),
+        tokens: { input: 0, output: 0 },
+      })
+    ),
     getCodebase: mock(() => Promise.resolve(null)),
     getCodebaseEnvVars: mock(() => Promise.resolve({})),
     getWorkflowNodeSession: mock(() => Promise.resolve(null)),
@@ -4560,6 +4565,150 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
     // Both nodes should execute
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
+  });
+
+  it('reconciles total tokens across a failed run and its resume', async () => {
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('resume-token-reconciliation');
+    const workflow = {
+      name: 'resume-token-reconciliation',
+      nodes: [
+        { id: 'step1', command: 'step1' },
+        { id: 'step2', command: 'step2', depends_on: ['step1'] },
+      ],
+    };
+
+    let firstInvocationCall = 0;
+    mockSendQueryDag.mockImplementation(function* () {
+      firstInvocationCall++;
+      if (firstInvocationCall === 1) {
+        yield { type: 'assistant', content: 'first execution output' };
+        yield {
+          type: 'result',
+          sessionId: 'first-execution-session',
+          tokens: { input: 40, output: 4 },
+        };
+        return;
+      }
+      // A result without assistant output fails step2 after step1 has persisted
+      // its node_completed event.
+      yield { type: 'result', sessionId: 'failed-step-session' };
+    });
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-resume-tokens',
+      testDir,
+      workflow,
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    expect(store.failWorkflowRun).toHaveBeenCalled();
+    expect(store.completeWorkflowRun).not.toHaveBeenCalled();
+
+    const firstExecutionEvents = (
+      store.createWorkflowEvent as ReturnType<typeof mock>
+    ).mock.calls.map(
+      (call: unknown[]) =>
+        call[0] as {
+          event_type: string;
+          step_name?: string;
+          data?: Record<string, unknown>;
+        }
+    );
+    const priorCompletedNodes = new Map<string, string>();
+    const priorTokenUsage = { input: 0, output: 0 };
+    for (const event of firstExecutionEvents) {
+      if (event.event_type !== 'node_completed' || !event.step_name) continue;
+      if (typeof event.data?.node_output === 'string') {
+        priorCompletedNodes.set(event.step_name, event.data.node_output);
+      }
+      const eventTokens = event.data?.tokens as { input?: unknown; output?: unknown } | undefined;
+      if (
+        typeof eventTokens?.input === 'number' &&
+        typeof eventTokens.output === 'number' &&
+        Number.isFinite(eventTokens.input) &&
+        Number.isFinite(eventTokens.output)
+      ) {
+        priorTokenUsage.input += eventTokens.input;
+        priorTokenUsage.output += eventTokens.output;
+      }
+    }
+    expect(priorCompletedNodes).toEqual(new Map([['step1', 'first execution output']]));
+    expect(priorTokenUsage).toEqual({ input: 40, output: 4 });
+
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'resumed execution output' };
+      yield {
+        type: 'result',
+        sessionId: 'resumed-execution-session',
+        tokens: { input: 60, output: 6 },
+      };
+    });
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-resume-tokens',
+      testDir,
+      workflow,
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      priorTokenUsage
+    );
+
+    const completionCalls = (store.completeWorkflowRun as ReturnType<typeof mock>).mock.calls;
+    expect(completionCalls).toHaveLength(1);
+    expect(completionCalls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        total_tokens_in: 100,
+        total_tokens_out: 10,
+      })
+    );
+
+    const completedEvents = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls
+      .map(
+        (call: unknown[]) =>
+          call[0] as {
+            event_type: string;
+            data?: { tokens?: { input: number; output: number } };
+          }
+      )
+      .filter(event => event.event_type === 'node_completed' && event.data?.tokens !== undefined);
+    const eventTokenTotal = completedEvents.reduce(
+      (total, event) => ({
+        input: total.input + (event.data?.tokens?.input ?? 0),
+        output: total.output + (event.data?.tokens?.output ?? 0),
+      }),
+      { input: 0, output: 0 }
+    );
+    expect(eventTokenTotal).toEqual({ input: 100, output: 10 });
   });
 
   // #2091: on resume, prior completed nodes are rehydrated from text only, so the
@@ -9468,7 +9617,7 @@ describe('executeDagWorkflow -- approval node', () => {
 
     // The on_reject synthetic node must NOT produce a node_completed event with
     // step_name equal to the approval gate's own ID ('review'). If it did, a
-    // subsequent resume would find the event via getCompletedDagNodeOutputs and
+    // subsequent resume would find the event via the DAG resume snapshot and
     // skip the approval gate entirely, bypassing the human gate.
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const nodeCompletedEvents = eventCalls.filter(

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -7113,6 +7113,77 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect(completed[0][0].data).not.toHaveProperty('tokens');
     });
 
+    it('warns and omits malformed persisted gate token usage on bare approval', async () => {
+      mockSendQueryDag.mockImplementation(function* () {
+        yield { type: 'assistant', content: 'should never run' };
+        yield { type: 'result', sessionId: 'never' };
+      });
+
+      const mockDeps = createMockDeps();
+      const workflowRun = makeWorkflowRun('finalize-invalid-tokens-run', {
+        metadata: {
+          approval: {
+            type: 'interactive_loop',
+            nodeId: 'refine',
+            iteration: 1,
+            sessionId: 'sig-session-1',
+            message: 'gate',
+            completionSignaled: true,
+            signaledOutput: 'REPORT',
+            signaledTokens: { input: Number.NaN, output: 4 },
+          },
+          loop_user_input: 'Approved',
+          loop_feedback_given: false,
+        },
+      });
+
+      await executeDagWorkflow(
+        mockDeps,
+        createMockPlatform(),
+        'conv-dag',
+        testDir,
+        {
+          name: 'finalize-invalid-tokens',
+          nodes: [
+            {
+              id: 'refine',
+              loop: {
+                prompt: 'Refine.',
+                until: 'APPROVED',
+                max_iterations: 10,
+                interactive: true,
+                gate_message: 'Review.',
+              },
+            },
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      const warnCalls = mockLogFn.mock.calls.filter(
+        (call: unknown[]) => call[1] === 'dag_loop.signaled_tokens_invalid_ignored'
+      );
+      expect(warnCalls).toHaveLength(1);
+      expect(warnCalls[0]?.[0]).toEqual(
+        expect.objectContaining({ workflowRunId: workflowRun.id, nodeId: 'refine' })
+      );
+      const completed = (mockDeps.store.createWorkflowEvent as Mock).mock.calls.find(
+        (call: unknown[]) =>
+          (call[0] as { event_type: string }).event_type === 'node_completed' &&
+          (call[0] as { step_name: string }).step_name === 'refine'
+      );
+      expect((completed?.[0] as { data: Record<string, unknown> }).data).not.toHaveProperty(
+        'tokens'
+      );
+    });
+
     it('iterates at resume when feedback was given, even on a signal-bearing gate (#2074 C)', async () => {
       mockSendQueryDag.mockImplementation(function* () {
         yield { type: 'assistant', content: 'Re-checked X. <promise>APPROVED</promise>' };

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3041,21 +3041,19 @@ function readSignaledTokens(
   context: { workflowRunId: string; nodeId: string }
 ): TokenUsage | undefined {
   if (raw === undefined || raw === null) return undefined;
-  if (typeof raw !== 'object') {
-    getLog().warn({ ...context, tokens: raw }, 'dag_loop.signaled_tokens_invalid_ignored');
-    return undefined;
+  if (typeof raw === 'object') {
+    const { input, output } = raw as { input?: unknown; output?: unknown };
+    if (
+      typeof input === 'number' &&
+      typeof output === 'number' &&
+      Number.isFinite(input) &&
+      Number.isFinite(output)
+    ) {
+      return { input, output };
+    }
   }
-  const { input, output } = raw as { input?: unknown; output?: unknown };
-  if (
-    typeof input !== 'number' ||
-    typeof output !== 'number' ||
-    !Number.isFinite(input) ||
-    !Number.isFinite(output)
-  ) {
-    getLog().warn({ ...context, tokens: raw }, 'dag_loop.signaled_tokens_invalid_ignored');
-    return undefined;
-  }
-  return { input, output };
+  getLog().warn({ ...context, tokens: raw }, 'dag_loop.signaled_tokens_invalid_ignored');
+  return undefined;
 }
 
 /**

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3036,11 +3036,25 @@ function buildHonestGateMessage(
  * non-finite value must be dropped rather than persisted onward as a number a
  * consumer would believe.
  */
-function readSignaledTokens(raw: unknown): TokenUsage | undefined {
-  if (typeof raw !== 'object' || raw === null) return undefined;
+function readSignaledTokens(
+  raw: unknown,
+  context: { workflowRunId: string; nodeId: string }
+): TokenUsage | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw !== 'object') {
+    getLog().warn({ ...context, tokens: raw }, 'dag_loop.signaled_tokens_invalid_ignored');
+    return undefined;
+  }
   const { input, output } = raw as { input?: unknown; output?: unknown };
-  if (typeof input !== 'number' || typeof output !== 'number') return undefined;
-  if (!Number.isFinite(input) || !Number.isFinite(output)) return undefined;
+  if (
+    typeof input !== 'number' ||
+    typeof output !== 'number' ||
+    !Number.isFinite(input) ||
+    !Number.isFinite(output)
+  ) {
+    getLog().warn({ ...context, tokens: raw }, 'dag_loop.signaled_tokens_invalid_ignored');
+    return undefined;
+  }
   return { input, output };
 }
 
@@ -3975,7 +3989,10 @@ async function executeLoopNode(
       stepName,
       'Loop node',
       finalizeOutput,
-      readSignaledTokens(loopGateMeta.signaledTokens)
+      readSignaledTokens(loopGateMeta.signaledTokens, {
+        workflowRunId: workflowRun.id,
+        nodeId: node.id,
+      })
     );
     return { state: 'completed', output: finalizeOutput, sessionId: currentSessionId };
   }

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -4718,7 +4718,7 @@ async function executeLoopNode(
         `Loop node '${node.id}' completed after ${String(i)} iteration${i > 1 ? 's' : ''}`,
         msgContext
       );
-      // Write node_completed event so resume logic (getCompletedDagNodeOutputs) knows this
+      // Write node_completed event so resume hydration knows this
       // node is done. Without this, a resumed DAG would re-enter the loop node.
       deps.store
         .createWorkflowEvent({
@@ -5015,7 +5015,7 @@ async function executeApprovalNode(
 
     // Build a synthetic PromptNode to reuse executeNodeInternal.
     // Use a distinct ID so the node_completed event written by executeNodeInternal
-    // does not collide with the approval gate's own ID in getCompletedDagNodeOutputs.
+    // does not collide with the approval gate's own ID in the resume snapshot.
     // If we used node.id here, a resumed run would find the event and treat the
     // approval gate as already completed, bypassing the human gate entirely.
     //
@@ -5201,7 +5201,7 @@ async function executeWorkflowNode(
   // command/prompt/bash/script nodes (which write their own inside their executor)
   // and unlike approval nodes (written by the approve handler), the workflow node
   // writes node_completed HERE — and ONLY on true completion, never on the paused
-  // branch — so getCompletedDagNodeOutputs skips a truly-finished sub-run on resume
+  // branch — so the resume snapshot skips a truly-finished sub-run on resume
   // but re-runs one still blocked on its child.
   const asCompleted = (outcome: ChildWorkflowOutcome): NodeExecutionResult => {
     if (outcome.output === undefined) {
@@ -5265,7 +5265,7 @@ async function executeWorkflowNode(
 
   // Pause the PARENT "blocked on child" — mirrors executeApprovalNode's PAUSE
   // primitives: pause, emit, return {completed, ''} WITHOUT node_completed so the
-  // node re-runs on the parent's resume (getCompletedDagNodeOutputs reads only
+  // node re-runs on the parent's resume (the resume snapshot reads only
   // node_completed). The RESUME side deliberately differs: an approval gate is
   // resolved externally by the approve handler, while this node re-runs and
   // re-inspects its child. Also unlike the approval node, no approval_requested
@@ -6903,7 +6903,9 @@ export async function executeDagWorkflow(
    * Phase 2). executor.ts is the sole caller and passes it; other callers (unit
    * tests) may omit it, in which case a `workflow:` node fails fast.
    */
-  runChildWorkflow?: RunChildWorkflowFn
+  runChildWorkflow?: RunChildWorkflowFn,
+  /** Cumulative usage restored from prior node_completed events on resume. */
+  priorTokenUsage?: { input: number; output: number }
 ): Promise<string | undefined> {
   const dagStartTime = Date.now();
 
@@ -6997,7 +6999,7 @@ export async function executeDagWorkflow(
       if (node?.always_run) continue;
       // Re-derive the producer's declared field set from the loaded definition so the
       // strict `$node.output.field` contract (output-ref.ts) is invariant across fresh
-      // vs resumed runs. getCompletedDagNodeOutputs rehydrates text only, so without
+      // vs resumed runs. The resume snapshot rehydrates text only, so without
       // this a declared-optional-absent field would throw instead of resolving to ''
       // and an undeclared key would resolve instead of throwing (#2091). Mirrors the
       // fresh-completion capture above.
@@ -7073,8 +7075,8 @@ export async function executeDagWorkflow(
     priorCompletedNodes,
     lastSequentialSession: undefined,
     totalCostUsd: 0,
-    totalTokensIn: 0,
-    totalTokensOut: 0,
+    totalTokensIn: priorTokenUsage?.input ?? 0,
+    totalTokensOut: priorTokenUsage?.output ?? 0,
     totalLoopIterations: 0,
     stepNamePrefix: '',
   };

--- a/packages/workflows/src/executor-preamble.test.ts
+++ b/packages/workflows/src/executor-preamble.test.ts
@@ -97,7 +97,10 @@ function makeStore(overrides: Partial<IWorkflowStore> = {}): IWorkflowStore {
     getWorkflowRunStatus: mock(async () => 'completed' as const),
     createWorkflowEvent: mock(async () => {}),
     findResumableRun: mock(async () => null),
-    getCompletedDagNodeOutputs: mock(async () => new Map<string, string>()),
+    getDagResumeSnapshot: mock(async () => ({
+      completedNodeOutputs: new Map<string, string>(),
+      tokens: { input: 0, output: 0 },
+    })),
     resumeWorkflowRun: mock(async () => makeRun()),
     getCodebase: mock(async () => null),
     getCodebaseEnvVars: mock(async () => ({})),

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -112,7 +112,10 @@ function makeStore(overrides: Partial<IWorkflowStore> = {}): IWorkflowStore {
     getWorkflowRunStatus: mock(async () => 'completed' as const),
     createWorkflowEvent: mock(async () => {}),
     findResumableRun: mock(async () => null),
-    getCompletedDagNodeOutputs: mock(async () => new Map()),
+    getDagResumeSnapshot: mock(async () => ({
+      completedNodeOutputs: new Map(),
+      tokens: { input: 0, output: 0 },
+    })),
     resumeWorkflowRun: mock(async () => makeRun()),
     getCodebase: mock(async () => null),
     getCodebaseEnvVars: mock(async () => ({})),
@@ -231,12 +234,14 @@ describe('executeWorkflow', () => {
         {
           preCreatedRun,
           priorCompletedNodes: new Map([['node1', 'out']]),
+          priorTokenUsage: { input: 40, output: 4 },
           execContext: { kind: 'container', containerId: 'cid' },
           container: { envId: 'env-x', writeBack: 'approve', backend },
         }
       );
       // Guard passed → DAG entered (mocked no-op) → run completes.
       expect(mockExecuteDagWorkflow).toHaveBeenCalledTimes(1);
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[23]).toEqual({ input: 40, output: 4 });
       expect(result.success).toBe(true);
     });
   });
@@ -1618,7 +1623,10 @@ describe('hydrateResumableRun', () => {
     const resumed = makeRun({ id: 'prior-failed', status: 'running' });
     const priorNodes = new Map([['n1', 'out1']]);
     const store = makeStore({
-      getCompletedDagNodeOutputs: mock(async () => priorNodes),
+      getDagResumeSnapshot: mock(async () => ({
+        completedNodeOutputs: priorNodes,
+        tokens: { input: 40, output: 4 },
+      })),
       resumeWorkflowRun: mock(async () => resumed),
     });
     const deps = makeDeps(store);
@@ -1626,13 +1634,17 @@ describe('hydrateResumableRun', () => {
     expect(result).not.toBeNull();
     expect(result?.preCreatedRun).toBe(resumed);
     expect(result?.priorCompletedNodes).toBe(priorNodes);
+    expect(result?.priorTokenUsage).toEqual({ input: 40, output: 4 });
     expect(store.resumeWorkflowRun).toHaveBeenCalledWith('prior-failed');
   });
 
   it('returns null when candidate has no completed nodes and no interactive-loop state', async () => {
     const candidate = makeRun({ id: 'empty-prior', status: 'failed' });
     const store = makeStore({
-      getCompletedDagNodeOutputs: mock(async () => new Map()),
+      getDagResumeSnapshot: mock(async () => ({
+        completedNodeOutputs: new Map(),
+        tokens: { input: 0, output: 0 },
+      })),
     });
     const deps = makeDeps(store);
     const result = await hydrateResumableRun(deps, candidate);
@@ -1649,7 +1661,10 @@ describe('hydrateResumableRun', () => {
     });
     const resumed = makeRun({ id: 'paused-loop', status: 'running' });
     const store = makeStore({
-      getCompletedDagNodeOutputs: mock(async () => new Map()),
+      getDagResumeSnapshot: mock(async () => ({
+        completedNodeOutputs: new Map(),
+        tokens: { input: 0, output: 0 },
+      })),
       resumeWorkflowRun: mock(async () => resumed),
     });
     const deps = makeDeps(store);
@@ -1659,10 +1674,10 @@ describe('hydrateResumableRun', () => {
     expect(store.resumeWorkflowRun).toHaveBeenCalledWith('paused-loop');
   });
 
-  it('propagates DB errors from getCompletedDagNodeOutputs (no silent fallback)', async () => {
+  it('propagates DB errors from getDagResumeSnapshot (no silent fallback)', async () => {
     const candidate = makeRun({ id: 'prior-failed', status: 'failed' });
     const store = makeStore({
-      getCompletedDagNodeOutputs: mock(async () => {
+      getDagResumeSnapshot: mock(async () => {
         throw new Error('DB read failed');
       }),
     });
@@ -1673,7 +1688,10 @@ describe('hydrateResumableRun', () => {
   it('propagates DB errors from resumeWorkflowRun (no silent fallback)', async () => {
     const candidate = makeRun({ id: 'prior-failed', status: 'failed' });
     const store = makeStore({
-      getCompletedDagNodeOutputs: mock(async () => new Map([['n1', 'v1']])),
+      getDagResumeSnapshot: mock(async () => ({
+        completedNodeOutputs: new Map([['n1', 'v1']]),
+        tokens: { input: 0, output: 0 },
+      })),
       resumeWorkflowRun: mock(async () => {
         throw new Error('DB write failed');
       }),

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -850,6 +850,38 @@ describe('executeWorkflow', () => {
       // No fresh row created when a preCreatedRun is supplied.
       expect(store.createWorkflowRun).not.toHaveBeenCalled();
     });
+
+    it('forwards a hydrated resume snapshot into resumed DAG execution', async () => {
+      const candidate = makeRun({ id: 'failed-run', status: 'failed' });
+      const resumed = makeRun({ id: 'resumed-run', status: 'running' });
+      const completedNodeOutputs = new Map([['node-a', 'first output']]);
+      const tokens = { input: 40, output: 4 };
+      const store = makeStore({
+        getDagResumeSnapshot: mock(async () => ({ completedNodeOutputs, tokens })),
+        resumeWorkflowRun: mock(async () => resumed),
+      });
+      const deps = makeDeps(store);
+
+      const hydrated = await hydrateResumableRun(deps, candidate);
+      expect(hydrated).not.toBeNull();
+      if (!hydrated) throw new Error('Expected resumable workflow to hydrate');
+
+      await executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-1',
+        '/tmp',
+        makeWorkflow(),
+        'test message',
+        'db-conv-1',
+        hydrated
+      );
+
+      const dagCall = mockExecuteDagWorkflow.mock.calls[0];
+      expect(dagCall?.[15]).toBe(completedNodeOutputs);
+      expect(dagCall?.[23]).toEqual(tokens);
+      expect(store.createWorkflowRun).not.toHaveBeenCalled();
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -355,20 +355,28 @@ export function resolveScopeArtifactsDir(
 }
 
 /**
- * Resume payload. `priorCompletedNodes` may only appear together with
- * `preCreatedRun` — passing completed-node outputs without the resumed row
- * would silently inject node-skip state into a freshly-created run. Lock-token
- * rows (used by `dispatchBackgroundWorkflow`) supply `preCreatedRun` alone.
+ * Resume state may only appear together with `preCreatedRun` — passing prior
+ * outputs or usage without the resumed row would silently inject state into a
+ * freshly-created run. Lock-token rows (used by `dispatchBackgroundWorkflow`)
+ * supply `preCreatedRun` alone.
  */
 type ResumePayload =
-  | { preCreatedRun: WorkflowRun; priorCompletedNodes?: Map<string, string> }
-  | { preCreatedRun?: undefined; priorCompletedNodes?: undefined };
+  | {
+      preCreatedRun: WorkflowRun;
+      priorCompletedNodes?: Map<string, string>;
+      priorTokenUsage?: { input: number; output: number };
+    }
+  | {
+      preCreatedRun?: undefined;
+      priorCompletedNodes?: undefined;
+      priorTokenUsage?: undefined;
+    };
 
 /**
  * Optional parameters for {@link executeWorkflow}. All trailing args live here
  * so call sites stay readable as new options accrue.
  *
- * To resume a prior run, obtain `preCreatedRun` + `priorCompletedNodes` from
+ * To resume a prior run, obtain the run, prior outputs, and prior usage from
  * {@link hydrateResumableRun} (or look up via `findResumableRun` and hydrate)
  * and spread them in. The executor never queries the store for a prior run on
  * its own; that decision belongs at the call site.
@@ -447,8 +455,13 @@ export type ExecuteWorkflowOptions = ResumePayload & {
 export async function hydrateResumableRun(
   deps: WorkflowDeps,
   candidate: WorkflowRun
-): Promise<{ preCreatedRun: WorkflowRun; priorCompletedNodes: Map<string, string> } | null> {
-  const priorCompletedNodes = await deps.store.getCompletedDagNodeOutputs(candidate.id);
+): Promise<{
+  preCreatedRun: WorkflowRun;
+  priorCompletedNodes: Map<string, string>;
+  priorTokenUsage: { input: number; output: number };
+} | null> {
+  const snapshot = await deps.store.getDagResumeSnapshot(candidate.id);
+  const priorCompletedNodes = snapshot.completedNodeOutputs;
   // A gate whose node deliberately writes NO node_completed on pause must still be
   // resumable with zero completed nodes: interactive loops, and a `workflow:` node
   // blocked on a child (#2121 Phase 2) whose child is the very first node.
@@ -470,7 +483,7 @@ export async function hydrateResumableRun(
     { workflowRunId: preCreatedRun.id, priorCompletedCount: priorCompletedNodes.size },
     'workflow.dag_resuming'
   );
-  return { preCreatedRun, priorCompletedNodes };
+  return { preCreatedRun, priorCompletedNodes, priorTokenUsage: snapshot.tokens };
 }
 
 /** Depth cap on the `workflow:` sub-run tree (D9). A node nested deeper fails fast. */
@@ -871,6 +884,7 @@ export async function executeWorkflow(
     parentConversationId,
     preCreatedRun,
     priorCompletedNodes,
+    priorTokenUsage,
     userId,
     source,
     baseBranch: callerBaseBranch,
@@ -1067,6 +1081,7 @@ export async function executeWorkflow(
   // preCreatedRun (from hydrateResumableRun) + priorCompletedNodes via opts.
   // When both are absent the executor creates a fresh row below.
   const dagPriorCompletedNodes = priorCompletedNodes;
+  const dagPriorTokenUsage = priorTokenUsage;
   let workflowRun: WorkflowRun | undefined = preCreatedRun;
 
   if (preCreatedRun && priorCompletedNodes !== undefined) {
@@ -1493,7 +1508,8 @@ export async function executeWorkflow(
       // Sub-run closure (#2121 Phase 2): captures executeWorkflow (this module — no
       // import cycle) so a `workflow:` node can spawn a governed child run in-process.
       (childArgs: RunChildWorkflowArgs): Promise<ChildWorkflowOutcome> =>
-        runChildWorkflow(deps, platform, childArgs)
+        runChildWorkflow(deps, platform, childArgs),
+      dagPriorTokenUsage
     );
 
     // executeDagWorkflow throws on fatal errors; check DB status for result

--- a/packages/workflows/src/script-node-deps.test.ts
+++ b/packages/workflows/src/script-node-deps.test.ts
@@ -98,7 +98,12 @@ function createMockStore(): IWorkflowStore {
     pauseWorkflowRun: mock(() => Promise.resolve()),
     cancelWorkflowRun: mock(() => Promise.resolve()),
     createWorkflowEvent: mock(() => Promise.resolve()),
-    getCompletedDagNodeOutputs: mock(() => Promise.resolve(new Map<string, string>())),
+    getDagResumeSnapshot: mock(() =>
+      Promise.resolve({
+        completedNodeOutputs: new Map<string, string>(),
+        tokens: { input: 0, output: 0 },
+      })
+    ),
     getCodebase: mock(() => Promise.resolve(null)),
     getCodebaseEnvVars: mock(() => Promise.resolve({})),
   };

--- a/packages/workflows/src/store.ts
+++ b/packages/workflows/src/store.ts
@@ -14,6 +14,14 @@ import type {
 
 export type { WorkflowNodeSession } from './schemas';
 
+export interface DagResumeSnapshot {
+  completedNodeOutputs: Map<string, string>;
+  tokens: {
+    input: number;
+    output: number;
+  };
+}
+
 /** Composite primary key identifying a single persisted node session row. */
 export interface WorkflowNodeSessionKey {
   workflow_name: string;
@@ -193,14 +201,13 @@ export interface IWorkflowStore extends IRunTreeStore {
   }): Promise<void>;
 
   /**
-   * Return a map of nodeId → output for all node_completed events
-   * from a prior DAG workflow run. Used for DAG resume: the executor
-   * pre-populates nodeOutputs so completed nodes are skipped on re-run.
+   * Return completed node outputs and cumulative token usage from a prior DAG
+   * workflow run. Used for resume hydration so completed nodes are skipped and
+   * the run-level token tally includes every execution of the run.
    *
-   * Returns an empty map when no completed nodes exist.
    * Throws on DB error — caller (executor.ts) owns the degradation policy.
    */
-  getCompletedDagNodeOutputs(workflowRunId: string): Promise<Map<string, string>>;
+  getDagResumeSnapshot(workflowRunId: string): Promise<DagResumeSnapshot>;
 
   // Per-codebase env vars for workflow node injection
   getCodebaseEnvVars(codebaseId: string): Promise<Record<string, string>>;

--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -61,7 +61,7 @@ import type { WorkflowDefinition } from './schemas/workflow';
 // ---------------------------------------------------------------------------
 // Stateful in-memory store — implements just enough of IWorkflowStore to drive
 // the real run lifecycle (create / pause / resume / complete / fail / cancel),
-// event log (for getCompletedDagNodeOutputs), the run tree (findChildRuns /
+// event log (for DAG resume snapshots), the run tree (findChildRuns /
 // getRunAncestry), and the ancestor-aware path lock.
 // ---------------------------------------------------------------------------
 
@@ -215,18 +215,34 @@ class InMemoryStore implements IWorkflowStore {
     return Promise.resolve();
   };
 
-  getCompletedDagNodeOutputs = (workflowRunId: string): Promise<Map<string, string>> => {
-    const map = new Map<string, string>();
+  getDagResumeSnapshot: IWorkflowStore['getDagResumeSnapshot'] = workflowRunId => {
+    const completedNodeOutputs = new Map<string, string>();
+    const tokens = { input: 0, output: 0 };
     for (const e of this.events) {
       if (
         e.workflow_run_id === workflowRunId &&
         (e.event_type === 'node_completed' || e.event_type === 'node_skipped_prior_success') &&
         typeof e.step_name === 'string'
       ) {
-        map.set(e.step_name, String(e.data?.node_output ?? ''));
+        completedNodeOutputs.set(e.step_name, String(e.data?.node_output ?? ''));
+        const eventTokens = e.data?.tokens;
+        if (
+          e.event_type === 'node_completed' &&
+          typeof eventTokens === 'object' &&
+          eventTokens !== null &&
+          'input' in eventTokens &&
+          'output' in eventTokens &&
+          typeof eventTokens.input === 'number' &&
+          typeof eventTokens.output === 'number' &&
+          Number.isFinite(eventTokens.input) &&
+          Number.isFinite(eventTokens.output)
+        ) {
+          tokens.input += eventTokens.input;
+          tokens.output += eventTokens.output;
+        }
       }
     }
-    return Promise.resolve(map);
+    return Promise.resolve({ completedNodeOutputs, tokens });
   };
 
   getCodebase = (): Promise<null> => Promise.resolve(null);


### PR DESCRIPTION
## Summary

- Problem: resumed DAG workflow runs persisted only tokens consumed after resumption, omitting completed nodes from an earlier failed attempt.
- Why it matters: run metadata and downstream `workflow:` nodes must report total provider usage for the complete workflow-run ID.
- What changed: resume hydration now reconstructs prior node outputs and finite token totals from `node_completed` events, then seeds the existing DAG accumulator before the terminal completion write.
- What did **not** change (scope boundary): workflow lifecycle/CAS behavior, token aggregation for a single invocation, child-run forwarding, and paused/loop-finalization semantics are unchanged.

## UX Journey

### Before

```
  User                   Archon workflow                 Provider
  ----                   ---------------                 --------
  starts run ─────────▶  executes node A ─────────────▶  returns 40/4 tokens
                         persists node_completed
                         node B fails; run is failed
  resumes run ────────▶  restores A output; tokens reset to 0
                         executes B ──────────────────▶  returns 60/6 tokens
                         completes with metadata 60/6
```

### After

```
  User                   Archon workflow                 Provider
  ----                   ---------------                 --------
  starts run ─────────▶  executes node A ─────────────▶  returns 40/4 tokens
                         persists node_completed
                         node B fails; run is failed
  resumes run ────────▶  [restores A output and 40/4 event usage]
                         executes B ──────────────────▶  returns 60/6 tokens
                         completes with metadata [100/10]
```

## Architecture Diagram

### Before

```
workflow-events DB ──▶ core event reader ──▶ store adapter ──▶ executor ──▶ DAG executor ──▶ workflow_runs metadata
                                      outputs only                                  zero token counters
```

### After

```
workflow-events DB ──▶ [~ core event reader] ──▶ [~ store adapter] ──▶ [~ executor] ──▶ [~ DAG executor] ──▶ workflow_runs metadata
                    completed outputs + finite usage snapshot            passes prior usage       seeds accumulator
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| Workflow event rows | Core workflow-event reader | **modified** | Reconstructs outputs and sums finite tokens from `node_completed` rows only. |
| Core event reader | Core workflow-store adapter | **modified** | Exposes the typed resume snapshot through the engine contract. |
| Workflow-store adapter | Workflow executor | **modified** | Resume hydration receives outputs plus prior token usage. |
| Workflow executor | DAG executor | **modified** | Threads prior usage only with the pre-created resumed run. |
| DAG executor | Workflow-run completion metadata | **modified** | Existing final write receives cumulative rather than invocation-local totals. |

## Label Snapshot

- Risk: `risk: medium`
- Size: `size: M`
- Scope: `core, workflows, tests`
- Module: `workflows:resume-accounting`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi`

## Linked Issue

- Closes #2352
- Related #2347
- Depends on # none
- Supersedes # none

## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check
bun run lint
bun run format:check
bun run test
bun run validate
```

- Evidence provided (test/log/trace/screenshot): implementation and validation artifacts report type-check, lint (zero warnings), format check, build, full package-isolated tests (6,417 passed), and `bun run validate` passing after bundled-default regeneration. Focused coverage included DAG executor (441), executor (69), sub-run (12), workflow-event DB (19), and store-adapter (13) tests.
- If any command is intentionally skipped, explain why: none. The implementation record notes an earlier validation attempt stopped on pre-existing local `.archon/` bundled-default drift; the later validation record refreshed the local generated bundle and reports the complete suite passed. Those local workflow-definition/generated-file edits are intentionally not part of this PR.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`; provider-usage accounting only, not credential handling)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation: not applicable.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: not applicable.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: a failed first invocation with persisted node usage followed by a resumed invocation reconciles final metadata to the combined token totals.
- Edge cases checked: malformed, missing, and non-finite event token payloads are ignored; `node_skipped_prior_success` rows do not double-count usage; outputs still restore during resume.
- What was not verified: live provider billing dashboards and paused-run/loop-finalization accounting were not changed or manually exercised.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: workflow event reading, core-to-engine store adapter, resume hydration, DAG completion metadata, and child workflow token propagation.
- Potential unintended effects: incorrectly shaped historical event data could affect reconstructed usage; only finite numeric tokens from authoritative completion events are included.
- Guardrails/monitoring for early detection: focused malformed-event and fail→resume regression tests; existing DAG logging for non-finite provider usage; terminal completion retains its existing single-writer status guard.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `8d3bbfbc87e6456f716ec7cb2b204a42d7521df4` after merge.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: resumed workflow metadata reports unexpected cumulative token values or resume hydration failures; affected runs can be inspected through their persisted `node_completed` events.

## Risks and Mitigations

- Risk: historical event payloads may be malformed or omit usage values.
  - Mitigation: validate both token values as finite numbers and ignore invalid/missing payloads while preserving output hydration.
- Risk: restored nodes could be counted twice during resume.
  - Mitigation: only `node_completed` events contribute usage; `node_skipped_prior_success` events restore outputs without contributing tokens.

Fixes #2352


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow resumes now preserve cumulative input and output token usage from previous runs.
  * Resume state restores both completed node outputs and token totals.

* **Bug Fixes**
  * Invalid or non-finite token data is safely ignored and logged.
  * Corrupt persisted event data no longer prevents workflow resume.

* **Tests**
  * Expanded coverage for token aggregation, resumed runs, skipped nodes, empty results, and database errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->