### PR TITLE
Fix Codex tool duration reporting

### DIFF
--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -218,8 +218,13 @@ describe('CodexProvider', () => {
       mockRunStreamed.mockResolvedValue({
         events: (async function* () {
           yield {
+            type: 'item.started',
+            item: { id: 'cmd-1', type: 'command_execution', command: 'npm test' },
+          };
+          yield {
             type: 'item.completed',
             item: {
+              id: 'cmd-1',
               type: 'command_execution',
               command: 'npm test',
               aggregated_output: 'tests passed\n',
@@ -235,11 +240,12 @@ describe('CodexProvider', () => {
         chunks.push(chunk);
       }
 
-      expect(chunks[0]).toEqual({ type: 'tool', toolName: 'npm test' });
+      expect(chunks[0]).toEqual({ type: 'tool', toolName: 'npm test', toolCallId: 'cmd-1' });
       expect(chunks[1]).toEqual({
         type: 'tool_result',
         toolName: 'npm test',
         toolOutput: 'tests passed\n',
+        toolCallId: 'cmd-1',
       });
     });
 
@@ -247,8 +253,13 @@ describe('CodexProvider', () => {
       mockRunStreamed.mockResolvedValue({
         events: (async function* () {
           yield {
+            type: 'item.started',
+            item: { id: 'cmd-2', type: 'command_execution', command: 'npm test' },
+          };
+          yield {
             type: 'item.completed',
             item: {
+              id: 'cmd-2',
               type: 'command_execution',
               command: 'npm test',
               aggregated_output: 'failure\n',
@@ -268,6 +279,7 @@ describe('CodexProvider', () => {
         type: 'tool_result',
         toolName: 'npm test',
         toolOutput: 'failure\n\n[exit code: 1]',
+        toolCallId: 'cmd-2',
       });
     });
 
@@ -293,7 +305,14 @@ describe('CodexProvider', () => {
     test('yields tool events from web_search items', async () => {
       mockRunStreamed.mockResolvedValue({
         events: (async function* () {
-          yield { type: 'item.completed', item: { type: 'web_search', query: 'codex sdk' } };
+          yield {
+            type: 'item.started',
+            item: { id: 'search-1', type: 'web_search', query: 'codex sdk' },
+          };
+          yield {
+            type: 'item.completed',
+            item: { id: 'search-1', type: 'web_search', query: 'codex sdk' },
+          };
           yield { type: 'turn.completed', usage: defaultUsage };
         })(),
       });
@@ -303,11 +322,16 @@ describe('CodexProvider', () => {
         chunks.push(chunk);
       }
 
-      expect(chunks[0]).toEqual({ type: 'tool', toolName: '\u{1F50D} Searching: codex sdk' });
+      expect(chunks[0]).toEqual({
+        type: 'tool',
+        toolName: '\u{1F50D} Searching: codex sdk',
+        toolCallId: 'search-1',
+      });
       expect(chunks[1]).toEqual({
         type: 'tool_result',
         toolName: '\u{1F50D} Searching: codex sdk',
         toolOutput: '',
+        toolCallId: 'search-1',
       });
     });
 
@@ -493,12 +517,39 @@ describe('CodexProvider', () => {
       mockRunStreamed.mockResolvedValue({
         events: (async function* () {
           yield {
-            type: 'item.completed',
-            item: { type: 'mcp_tool_call', server: 'fs', tool: 'readFile', status: 'in_progress' },
+            type: 'item.started',
+            item: {
+              id: 'mcp-1',
+              type: 'mcp_tool_call',
+              server: 'fs',
+              tool: 'readFile',
+              status: 'in_progress',
+            },
           };
           yield {
             type: 'item.completed',
             item: {
+              id: 'mcp-1',
+              type: 'mcp_tool_call',
+              server: 'fs',
+              tool: 'readFile',
+              status: 'completed',
+            },
+          };
+          yield {
+            type: 'item.started',
+            item: {
+              id: 'mcp-2',
+              type: 'mcp_tool_call',
+              server: 'fs',
+              tool: 'readFile',
+              status: 'in_progress',
+            },
+          };
+          yield {
+            type: 'item.completed',
+            item: {
+              id: 'mcp-2',
               type: 'mcp_tool_call',
               server: 'fs',
               tool: 'readFile',
@@ -515,19 +566,27 @@ describe('CodexProvider', () => {
         chunks.push(chunk);
       }
 
-      // First mcp call (in_progress on item.completed): start + empty result
-      expect(chunks[0]).toEqual({ type: 'tool', toolName: '\u{1F50C} MCP: fs/readFile' });
+      expect(chunks[0]).toEqual({
+        type: 'tool',
+        toolName: '\u{1F50C} MCP: fs/readFile',
+        toolCallId: 'mcp-1',
+      });
       expect(chunks[1]).toEqual({
         type: 'tool_result',
         toolName: '\u{1F50C} MCP: fs/readFile',
         toolOutput: '',
+        toolCallId: 'mcp-1',
       });
-      // Second mcp call (failed): start + error result so the UI card closes
-      expect(chunks[2]).toEqual({ type: 'tool', toolName: '\u{1F50C} MCP: fs/readFile' });
+      expect(chunks[2]).toEqual({
+        type: 'tool',
+        toolName: '\u{1F50C} MCP: fs/readFile',
+        toolCallId: 'mcp-2',
+      });
       expect(chunks[3]).toEqual({
         type: 'tool_result',
         toolName: '\u{1F50C} MCP: fs/readFile',
         toolOutput: '\u274C Error: Permission denied',
+        toolCallId: 'mcp-2',
       });
       expect(mockLogger.warn).toHaveBeenCalledWith(
         expect.objectContaining({ server: 'fs', tool: 'readFile' }),
@@ -539,16 +598,28 @@ describe('CodexProvider', () => {
       mockRunStreamed.mockResolvedValue({
         events: (async function* () {
           yield {
-            type: 'item.completed',
-            item: { type: 'mcp_tool_call', tool: 'readFile', status: 'in_progress' },
+            type: 'item.started',
+            item: { id: 'mcp-tool', type: 'mcp_tool_call', tool: 'readFile' },
           };
           yield {
             type: 'item.completed',
-            item: { type: 'mcp_tool_call', server: 'fs', status: 'in_progress' },
+            item: { id: 'mcp-tool', type: 'mcp_tool_call', tool: 'readFile', status: 'completed' },
+          };
+          yield {
+            type: 'item.started',
+            item: { id: 'mcp-server', type: 'mcp_tool_call', server: 'fs' },
           };
           yield {
             type: 'item.completed',
-            item: { type: 'mcp_tool_call', status: 'in_progress' },
+            item: { id: 'mcp-server', type: 'mcp_tool_call', server: 'fs', status: 'completed' },
+          };
+          yield {
+            type: 'item.started',
+            item: { id: 'mcp-unknown', type: 'mcp_tool_call' },
+          };
+          yield {
+            type: 'item.completed',
+            item: { id: 'mcp-unknown', type: 'mcp_tool_call', status: 'completed' },
           };
           yield { type: 'turn.completed', usage: defaultUsage };
         })(),
@@ -559,23 +630,38 @@ describe('CodexProvider', () => {
         chunks.push(chunk);
       }
 
-      expect(chunks[0]).toEqual({ type: 'tool', toolName: '\u{1F50C} MCP: readFile' });
+      expect(chunks[0]).toEqual({
+        type: 'tool',
+        toolName: '\u{1F50C} MCP: readFile',
+        toolCallId: 'mcp-tool',
+      });
       expect(chunks[1]).toEqual({
         type: 'tool_result',
         toolName: '\u{1F50C} MCP: readFile',
         toolOutput: '',
+        toolCallId: 'mcp-tool',
       });
-      expect(chunks[2]).toEqual({ type: 'tool', toolName: '\u{1F50C} MCP: fs' });
+      expect(chunks[2]).toEqual({
+        type: 'tool',
+        toolName: '\u{1F50C} MCP: fs',
+        toolCallId: 'mcp-server',
+      });
       expect(chunks[3]).toEqual({
         type: 'tool_result',
         toolName: '\u{1F50C} MCP: fs',
         toolOutput: '',
+        toolCallId: 'mcp-server',
       });
-      expect(chunks[4]).toEqual({ type: 'tool', toolName: '\u{1F50C} MCP: MCP tool' });
+      expect(chunks[4]).toEqual({
+        type: 'tool',
+        toolName: '\u{1F50C} MCP: MCP tool',
+        toolCallId: 'mcp-unknown',
+      });
       expect(chunks[5]).toEqual({
         type: 'tool_result',
         toolName: '\u{1F50C} MCP: MCP tool',
         toolOutput: '',
+        toolCallId: 'mcp-unknown',
       });
     });
 
@@ -583,8 +669,18 @@ describe('CodexProvider', () => {
       mockRunStreamed.mockResolvedValue({
         events: (async function* () {
           yield {
+            type: 'item.started',
+            item: { id: 'mcp-failure', type: 'mcp_tool_call', server: 'db', tool: 'query' },
+          };
+          yield {
             type: 'item.completed',
-            item: { type: 'mcp_tool_call', server: 'db', tool: 'query', status: 'failed' },
+            item: {
+              id: 'mcp-failure',
+              type: 'mcp_tool_call',
+              server: 'db',
+              tool: 'query',
+              status: 'failed',
+            },
           };
           yield { type: 'turn.completed', usage: defaultUsage };
         })(),
@@ -595,11 +691,16 @@ describe('CodexProvider', () => {
         chunks.push(chunk);
       }
 
-      expect(chunks[0]).toEqual({ type: 'tool', toolName: '\u{1F50C} MCP: db/query' });
+      expect(chunks[0]).toEqual({
+        type: 'tool',
+        toolName: '\u{1F50C} MCP: db/query',
+        toolCallId: 'mcp-failure',
+      });
       expect(chunks[1]).toEqual({
         type: 'tool_result',
         toolName: '\u{1F50C} MCP: db/query',
         toolOutput: '\u274C Error: MCP tool failed',
+        toolCallId: 'mcp-failure',
       });
     });
 
@@ -607,8 +708,13 @@ describe('CodexProvider', () => {
       mockRunStreamed.mockResolvedValue({
         events: (async function* () {
           yield {
+            type: 'item.started',
+            item: { id: 'mcp-completed', type: 'mcp_tool_call', server: 'fs', tool: 'readFile' },
+          };
+          yield {
             type: 'item.completed',
             item: {
+              id: 'mcp-completed',
               type: 'mcp_tool_call',
               server: 'fs',
               tool: 'readFile',
@@ -626,11 +732,16 @@ describe('CodexProvider', () => {
       }
 
       expect(chunks).toHaveLength(3);
-      expect(chunks[0]).toEqual({ type: 'tool', toolName: '\u{1F50C} MCP: fs/readFile' });
+      expect(chunks[0]).toEqual({
+        type: 'tool',
+        toolName: '\u{1F50C} MCP: fs/readFile',
+        toolCallId: 'mcp-completed',
+      });
       expect(chunks[1]).toEqual({
         type: 'tool_result',
         toolName: '\u{1F50C} MCP: fs/readFile',
         toolOutput: JSON.stringify([{ type: 'text', text: 'file contents' }]),
+        toolCallId: 'mcp-completed',
       });
       expect(chunks[2]).toEqual({
         type: 'result',
@@ -1209,7 +1320,10 @@ describe('CodexProvider', () => {
     test('logs progress for item.started and item.completed events', async () => {
       mockRunStreamed.mockResolvedValue({
         events: (async function* () {
-          yield { type: 'item.started', item: { id: 'item-1', type: 'command_execution' } };
+          yield {
+            type: 'item.started',
+            item: { id: 'item-1', type: 'command_execution', command: 'npm test' },
+          };
           yield {
             type: 'item.completed',
             item: { id: 'item-1', type: 'command_execution', command: 'npm test' },
@@ -1236,6 +1350,90 @@ describe('CodexProvider', () => {
           command: 'npm test',
         },
         'item_completed'
+      );
+      expect(chunks[0]).toEqual({
+        type: 'tool',
+        toolName: 'npm test',
+        toolCallId: 'item-1',
+      });
+      expect(chunks[1]).toEqual({
+        type: 'tool_result',
+        toolName: 'npm test',
+        toolOutput: '',
+        toolCallId: 'item-1',
+      });
+    });
+
+    test('deduplicates repeated tool lifecycle events by item id', async () => {
+      const started = {
+        type: 'item.started',
+        item: { id: 'cmd-duplicate', type: 'command_execution', command: 'npm test' },
+      };
+      const completed = {
+        type: 'item.completed',
+        item: {
+          id: 'cmd-duplicate',
+          type: 'command_execution',
+          command: 'npm test',
+          aggregated_output: 'done',
+          exit_code: 0,
+        },
+      };
+      mockRunStreamed.mockResolvedValue({
+        events: (async function* () {
+          yield started;
+          yield started;
+          yield completed;
+          yield completed;
+          yield { type: 'turn.completed', usage: defaultUsage };
+        })(),
+      });
+
+      const chunks = [];
+      for await (const chunk of client.sendQuery('test', '/workspace')) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks.filter(chunk => chunk.type === 'tool')).toHaveLength(1);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(1);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        { itemId: 'cmd-duplicate', itemType: 'command_execution' },
+        'tool_item_duplicate_completion'
+      );
+    });
+
+    test('does not recreate a tool start when completion arrives alone', async () => {
+      mockRunStreamed.mockResolvedValue({
+        events: (async function* () {
+          yield {
+            type: 'item.completed',
+            item: {
+              id: 'cmd-completed-only',
+              type: 'command_execution',
+              command: 'npm test',
+              aggregated_output: 'done',
+              exit_code: 0,
+            },
+          };
+          yield { type: 'turn.completed', usage: defaultUsage };
+        })(),
+      });
+
+      const chunks = [];
+      for await (const chunk of client.sendQuery('test', '/workspace')) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks.some(chunk => chunk.type === 'tool')).toBe(false);
+      expect(chunks[0]).toEqual({
+        type: 'tool_result',
+        toolName: 'npm test',
+        toolOutput: 'done',
+        toolCallId: 'cmd-completed-only',
+      });
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        { itemId: 'cmd-completed-only', itemType: 'command_execution' },
+        'tool_item_completed_without_start'
       );
     });
 

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -370,6 +370,15 @@ function buildEffectivePrompt(prompt: string, requestOptions?: SendQueryOptions)
 /** State maintained across Codex event stream normalization. */
 interface CodexStreamState {
   lastTodoListSignature?: string;
+  startedToolItemIds: Set<string>;
+  completedToolItemIds: Set<string>;
+}
+
+function getMcpToolName(item: Record<string, unknown>): string {
+  const server = item.server as string | undefined;
+  const tool = item.tool as string | undefined;
+  const toolInfo = server && tool ? `${server}/${tool}` : (tool ?? server ?? 'MCP tool');
+  return `🔌 MCP: ${toolInfo}`;
 }
 
 /**
@@ -383,7 +392,10 @@ async function* streamCodexEvents(
   abortSignal?: AbortSignal,
   surfaceMcpClientErrors = false
 ): AsyncGenerator<MessageChunk> {
-  const state: CodexStreamState = {};
+  const state: CodexStreamState = {
+    startedToolItemIds: new Set<string>(),
+    completedToolItemIds: new Set<string>(),
+  };
   let accumulatedText = '';
 
   // A new thread's id is assigned during the run via the `thread.started` event
@@ -432,11 +444,33 @@ async function* streamCodexEvents(
     }
 
     if (event.type === 'item.started') {
-      const item = event.item as { type: string; id: string };
-      getLog().debug(
-        { eventType: event.type, itemType: item.type, itemId: item.id },
-        'item_started'
-      );
+      const item = event.item as Record<string, unknown>;
+      const itemType = item.type as string;
+      const itemId = item.id as string;
+      getLog().debug({ eventType: event.type, itemType, itemId }, 'item_started');
+
+      let toolName: string | undefined;
+      if (itemType === 'command_execution') {
+        if (typeof item.command === 'string' && item.command.length > 0) {
+          toolName = item.command;
+        } else {
+          getLog().warn({ itemId }, 'command_execution_missing_command');
+        }
+      } else if (itemType === 'web_search') {
+        if (typeof item.query === 'string' && item.query.length > 0) {
+          toolName = `🔍 Searching: ${item.query}`;
+        } else {
+          getLog().debug({ itemId }, 'web_search_missing_query');
+        }
+      } else if (itemType === 'mcp_tool_call') {
+        toolName = getMcpToolName(item);
+      }
+
+      if (toolName && itemId && !state.startedToolItemIds.has(itemId)) {
+        state.startedToolItemIds.add(itemId);
+        yield { type: 'tool', toolName, toolCallId: itemId };
+      }
+      continue;
     }
 
     if (event.type === 'error') {
@@ -487,6 +521,22 @@ async function* streamCodexEvents(
       }
       getLog().debug(logContext, 'item_completed');
 
+      const itemId = item.id as string;
+      const isToolItem =
+        itemType === 'command_execution' ||
+        itemType === 'web_search' ||
+        itemType === 'mcp_tool_call';
+      if (isToolItem) {
+        if (state.completedToolItemIds.has(itemId)) {
+          getLog().warn({ itemId, itemType }, 'tool_item_duplicate_completion');
+          continue;
+        }
+        state.completedToolItemIds.add(itemId);
+        if (!state.startedToolItemIds.has(itemId)) {
+          getLog().warn({ itemId, itemType }, 'tool_item_completed_without_start');
+        }
+      }
+
       switch (itemType) {
         case 'agent_message':
           if (item.text) {
@@ -500,7 +550,6 @@ async function* streamCodexEvents(
         case 'command_execution':
           if (item.command) {
             const cmd = item.command as string;
-            yield { type: 'tool', toolName: cmd };
             const exitCode = item.exit_code as number | null | undefined;
             const exitSuffix =
               exitCode != null && exitCode !== 0 ? `\n[exit code: ${String(exitCode)}]` : '';
@@ -508,6 +557,7 @@ async function* streamCodexEvents(
               type: 'tool_result',
               toolName: cmd,
               toolOutput: ((item.aggregated_output as string) ?? '') + exitSuffix,
+              toolCallId: itemId,
             };
           } else {
             getLog().warn({ itemId: item.id }, 'command_execution_missing_command');
@@ -523,8 +573,12 @@ async function* streamCodexEvents(
         case 'web_search':
           if (item.query) {
             const searchToolName = `🔍 Searching: ${item.query as string}`;
-            yield { type: 'tool', toolName: searchToolName };
-            yield { type: 'tool_result', toolName: searchToolName, toolOutput: '' };
+            yield {
+              type: 'tool_result',
+              toolName: searchToolName,
+              toolOutput: '',
+              toolCallId: itemId,
+            };
           } else {
             getLog().debug({ itemId: item.id }, 'web_search_missing_query');
           }
@@ -595,10 +649,7 @@ async function* streamCodexEvents(
         case 'mcp_tool_call': {
           const server = item.server as string | undefined;
           const tool = item.tool as string | undefined;
-          const toolInfo = server && tool ? `${server}/${tool}` : (tool ?? server ?? 'MCP tool');
-          const mcpToolName = `🔌 MCP: ${toolInfo}`;
-
-          yield { type: 'tool', toolName: mcpToolName };
+          const mcpToolName = getMcpToolName(item);
 
           if ((item.status as string) === 'failed') {
             getLog().warn(
@@ -609,7 +660,12 @@ async function* streamCodexEvents(
             const errMsg = mcpError?.message
               ? `❌ Error: ${mcpError.message}`
               : '❌ Error: MCP tool failed';
-            yield { type: 'tool_result', toolName: mcpToolName, toolOutput: errMsg };
+            yield {
+              type: 'tool_result',
+              toolName: mcpToolName,
+              toolOutput: errMsg,
+              toolCallId: itemId,
+            };
           } else {
             let toolOutput = '';
             const mcpResult = item.result as { content?: unknown } | undefined;
@@ -628,7 +684,7 @@ async function* streamCodexEvents(
                 );
               }
             }
-            yield { type: 'tool_result', toolName: mcpToolName, toolOutput };
+            yield { type: 'tool_result', toolName: mcpToolName, toolOutput, toolCallId: itemId };
           }
           break;
         }

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -3556,6 +3556,55 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
     });
   });
 
+  it('correlates interleaved DAG tool lifecycles by toolCallId', async () => {
+    const mockStore = createMockStore();
+    const mockDeps = createMockDeps(mockStore);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'tool', toolName: 'read_file', toolCallId: 'id-a' };
+      setSystemTime(new Date('2026-01-01T00:00:00.010Z'));
+      yield { type: 'tool', toolName: 'write_file', toolCallId: 'id-b' };
+      setSystemTime(new Date('2026-01-01T00:00:00.040Z'));
+      yield { type: 'tool_result', toolName: 'read_file', toolCallId: 'id-a' };
+      setSystemTime(new Date('2026-01-01T00:00:00.070Z'));
+      yield { type: 'tool_result', toolName: 'write_file', toolCallId: 'id-b' };
+      yield { type: 'result', sessionId: 'dag-sess-interleaved-tools' };
+    });
+
+    try {
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-dag-interleaved-tools',
+        testDir,
+        { name: 'dag-interleaved-tools', nodes: [node('my-cmd')] },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+    } finally {
+      setSystemTime();
+    }
+
+    const completedEvents = (mockStore.createWorkflowEvent as ReturnType<typeof mock>).mock.calls
+      .filter(([event]: [{ event_type: string }]) => event.event_type === 'tool_completed')
+      .map(([event]: [{ data: Record<string, unknown> }]) => event.data);
+    expect(completedEvents).toEqual(
+      expect.arrayContaining([
+        { tool_name: 'read_file', duration_ms: 40 },
+        { tool_name: 'write_file', duration_ms: 60 },
+      ])
+    );
+  });
+
   it('should not emit tool_completed when no tools were called in DAG node', async () => {
     const mockStore = createMockStore();
     const mockDeps = createMockDeps(mockStore);
@@ -5285,6 +5334,64 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         tool_name: 'read_file',
         duration_ms: 50,
       });
+    });
+
+    it('correlates interleaved loop tool lifecycles by toolCallId', async () => {
+      const store = createMockStore();
+      const mockDeps = createMockDeps(store);
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun('loop-interleaved-tools-run');
+
+      setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+      mockSendQueryDag.mockImplementation(function* () {
+        yield { type: 'tool', toolName: 'read_file', toolCallId: 'id-a' };
+        setSystemTime(new Date('2026-01-01T00:00:00.010Z'));
+        yield { type: 'tool', toolName: 'write_file', toolCallId: 'id-b' };
+        setSystemTime(new Date('2026-01-01T00:00:00.040Z'));
+        yield { type: 'tool_result', toolName: 'read_file', toolCallId: 'id-a' };
+        setSystemTime(new Date('2026-01-01T00:00:00.070Z'));
+        yield { type: 'tool_result', toolName: 'write_file', toolCallId: 'id-b' };
+        yield { type: 'assistant', content: 'Done. <promise>COMPLETE</promise>' };
+        yield { type: 'result', sessionId: 'loop-sess-interleaved-tools' };
+      });
+
+      try {
+        await executeDagWorkflow(
+          mockDeps,
+          platform,
+          'conv-loop-interleaved-tools',
+          testDir,
+          {
+            name: 'loop-interleaved-tools',
+            nodes: [
+              {
+                id: 'my-loop',
+                loop: { prompt: 'Complete the task.', until: 'COMPLETE', max_iterations: 1 },
+              },
+            ],
+          },
+          workflowRun,
+          'claude',
+          undefined,
+          join(testDir, 'artifacts'),
+          join(testDir, 'logs'),
+          'main',
+          'docs/',
+          minimalConfig
+        );
+      } finally {
+        setSystemTime();
+      }
+
+      const completedEvents = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls
+        .filter(([event]: [{ event_type: string }]) => event.event_type === 'tool_completed')
+        .map(([event]: [{ data: Record<string, unknown> }]) => event.data);
+      expect(completedEvents).toEqual(
+        expect.arrayContaining([
+          { tool_name: 'read_file', duration_ms: 40 },
+          { tool_name: 'write_file', duration_ms: 60 },
+        ])
+      );
     });
 
     it('completes on <promise>COMPLETE</promise> signal in first iteration', async () => {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -131,6 +131,26 @@ function dagNodeTelemetryType(node: DagNode): WorkflowNodeType {
   return 'prompt';
 }
 
+interface RunningTool {
+  toolName: string;
+  startedAt: number;
+}
+
+function findRunningTool(
+  runningTools: Map<string, RunningTool>,
+  toolName: string,
+  toolCallId: string | undefined
+): [string, RunningTool] | undefined {
+  if (toolCallId) {
+    const tool = runningTools.get(toolCallId);
+    return tool ? [toolCallId, tool] : undefined;
+  }
+
+  return Array.from(runningTools.entries())
+    .reverse()
+    .find(([, tool]) => tool.toolName === toolName);
+}
+
 /**
  * Usage totals for the terminal telemetry event. Fields are omitted (not sent
  * as zero) when nothing was reported, so absence in PostHog means "providers
@@ -1400,7 +1420,9 @@ async function executeNodeInternal(
   };
   let nodeIdleTimedOut = false;
   const effectiveIdleTimeout = node.idle_timeout ?? STEP_IDLE_TIMEOUT_MS;
-  let lastToolStartedAt: { toolName: string; startedAt: number } | null = null;
+  const runningTools = new Map<string, RunningTool>();
+  let anonymousToolSequence = 0;
+  let lastAnonymousToolCallId: string | undefined;
   // Task ids still live when the stream ended abnormally (idle timeout /
   // subprocess death) — recorded on the node_completed event so an incomplete
   // node never masquerades as a clean success (#2083).
@@ -1510,10 +1532,16 @@ async function executeNodeInternal(
         await logAssistant(logDir, workflowRun.id, msg.content);
       } else if (msg.type === 'tool' && msg.toolName) {
         const now = Date.now();
+        const toolCallId = msg.toolCallId ?? `anonymous-${String(++anonymousToolSequence)}`;
 
-        // Emit tool_completed for the previous tool (fire-and-forget)
-        if (lastToolStartedAt) {
-          const prevTool = lastToolStartedAt;
+        // Providers without stable IDs report sequential tool calls. Preserve their
+        // legacy boundary while allowing identified calls to overlap.
+        const previousTool = lastAnonymousToolCallId
+          ? runningTools.get(lastAnonymousToolCallId)
+          : undefined;
+        if (previousTool && lastAnonymousToolCallId !== undefined) {
+          const previousToolCallId = lastAnonymousToolCallId;
+          const prevTool = previousTool;
           getWorkflowEventEmitter().emit({
             type: 'tool_completed',
             runId: workflowRun.id,
@@ -1537,8 +1565,10 @@ async function executeNodeInternal(
                 'workflow_event_persist_failed'
               );
             });
+          runningTools.delete(previousToolCallId);
         }
-        lastToolStartedAt = { toolName: msg.toolName, startedAt: now };
+        runningTools.set(toolCallId, { toolName: msg.toolName, startedAt: now });
+        if (!msg.toolCallId) lastAnonymousToolCallId = toolCallId;
 
         // Emit tool_started for the current tool (fire-and-forget)
         getWorkflowEventEmitter().emit({
@@ -1580,14 +1610,15 @@ async function executeNodeInternal(
           });
       } else if (msg.type === 'tool_result' && msg.toolName) {
         const now = Date.now();
-        if (lastToolStartedAt) {
-          const completedTool = lastToolStartedAt;
+        const completedTool = findRunningTool(runningTools, msg.toolName, msg.toolCallId);
+        if (completedTool) {
+          const [completedToolCallId, tool] = completedTool;
           getWorkflowEventEmitter().emit({
             type: 'tool_completed',
             runId: workflowRun.id,
-            toolName: completedTool.toolName,
+            toolName: tool.toolName,
             stepName: node.id,
-            durationMs: now - completedTool.startedAt,
+            durationMs: now - tool.startedAt,
           });
           deps.store
             .createWorkflowEvent({
@@ -1595,8 +1626,8 @@ async function executeNodeInternal(
               event_type: 'tool_completed',
               step_name: stepName,
               data: {
-                tool_name: completedTool.toolName,
-                duration_ms: now - completedTool.startedAt,
+                tool_name: tool.toolName,
+                duration_ms: now - tool.startedAt,
               },
             })
             .catch((err: Error) => {
@@ -1605,15 +1636,17 @@ async function executeNodeInternal(
                 'workflow_event_persist_failed'
               );
             });
-          lastToolStartedAt = null;
+          runningTools.delete(completedToolCallId);
+          if (completedToolCallId === lastAnonymousToolCallId) {
+            lastAnonymousToolCallId = undefined;
+          }
         }
         if (streamingMode === 'stream' && platform.sendStructuredEvent) {
           await platform.sendStructuredEvent(conversationId, msg);
         }
       } else if (msg.type === 'result') {
-        // Emit tool_completed for the last tool in the node
-        if (lastToolStartedAt) {
-          const prevTool = lastToolStartedAt;
+        // A terminal result closes every outstanding lifecycle.
+        for (const [toolCallId, prevTool] of runningTools) {
           getWorkflowEventEmitter().emit({
             type: 'tool_completed',
             runId: workflowRun.id,
@@ -1637,7 +1670,7 @@ async function executeNodeInternal(
                 'workflow_event_persist_failed'
               );
             });
-          lastToolStartedAt = null;
+          runningTools.delete(toolCallId);
         }
         if (msg.sessionId) newSessionId = msg.sessionId;
         if (msg.resumed !== undefined) nodeResumed = msg.resumed;
@@ -4202,7 +4235,9 @@ async function executeLoopNode(
       };
 
       const generator = aiClient.sendQuery(finalPrompt, cwd, resumeSessionId, iterationOptions);
-      let lastToolStartedAt: { toolName: string; startedAt: number } | null = null;
+      const runningTools = new Map<string, RunningTool>();
+      let anonymousToolSequence = 0;
+      let lastAnonymousToolCallId: string | undefined;
 
       const effectiveIdleTimeout = node.idle_timeout ?? STEP_IDLE_TIMEOUT_MS;
 
@@ -4257,9 +4292,8 @@ async function executeLoopNode(
           }
           await logAssistant(logDir, workflowRun.id, msg.content);
         } else if (msg.type === 'result') {
-          // Emit tool_completed for the last tool in the iteration
-          if (lastToolStartedAt) {
-            const prevTool = lastToolStartedAt;
+          // A terminal result closes every outstanding lifecycle.
+          for (const [toolCallId, prevTool] of runningTools) {
             getWorkflowEventEmitter().emit({
               type: 'tool_completed',
               runId: workflowRun.id,
@@ -4280,7 +4314,7 @@ async function executeLoopNode(
               .catch((err: Error) => {
                 logEventStoreError(err, i);
               });
-            lastToolStartedAt = null;
+            runningTools.delete(toolCallId);
           }
           if (msg.sessionId) currentSessionId = msg.sessionId;
           // Overwrite, don't accumulate — a later result in the same iteration
@@ -4366,10 +4400,16 @@ async function executeLoopNode(
           backgroundTasks.update(msg.tasks);
         } else if (msg.type === 'tool' && msg.toolName) {
           const now = Date.now();
+          const toolCallId = msg.toolCallId ?? `anonymous-${String(++anonymousToolSequence)}`;
 
-          // Emit tool_completed for the previous tool
-          if (lastToolStartedAt) {
-            const prevTool = lastToolStartedAt;
+          // Providers without stable IDs report sequential tool calls. Preserve their
+          // legacy boundary while allowing identified calls to overlap.
+          const previousTool = lastAnonymousToolCallId
+            ? runningTools.get(lastAnonymousToolCallId)
+            : undefined;
+          if (previousTool && lastAnonymousToolCallId !== undefined) {
+            const previousToolCallId = lastAnonymousToolCallId;
+            const prevTool = previousTool;
             getWorkflowEventEmitter().emit({
               type: 'tool_completed',
               runId: workflowRun.id,
@@ -4387,8 +4427,10 @@ async function executeLoopNode(
               .catch((err: Error) => {
                 logEventStoreError(err, i);
               });
+            runningTools.delete(previousToolCallId);
           }
-          lastToolStartedAt = { toolName: msg.toolName, startedAt: now };
+          runningTools.set(toolCallId, { toolName: msg.toolName, startedAt: now });
+          if (!msg.toolCallId) lastAnonymousToolCallId = toolCallId;
 
           // Emit tool_started for the current tool (fire-and-forget)
           getWorkflowEventEmitter().emit({
@@ -4432,14 +4474,15 @@ async function executeLoopNode(
             });
         } else if (msg.type === 'tool_result' && msg.toolName) {
           const now = Date.now();
-          if (lastToolStartedAt) {
-            const completedTool = lastToolStartedAt;
+          const completedTool = findRunningTool(runningTools, msg.toolName, msg.toolCallId);
+          if (completedTool) {
+            const [completedToolCallId, tool] = completedTool;
             getWorkflowEventEmitter().emit({
               type: 'tool_completed',
               runId: workflowRun.id,
-              toolName: completedTool.toolName,
+              toolName: tool.toolName,
               stepName: node.id,
-              durationMs: now - completedTool.startedAt,
+              durationMs: now - tool.startedAt,
             });
             deps.store
               .createWorkflowEvent({
@@ -4447,14 +4490,17 @@ async function executeLoopNode(
                 event_type: 'tool_completed',
                 step_name: stepName,
                 data: {
-                  tool_name: completedTool.toolName,
-                  duration_ms: now - completedTool.startedAt,
+                  tool_name: tool.toolName,
+                  duration_ms: now - tool.startedAt,
                 },
               })
               .catch((err: Error) => {
                 logEventStoreError(err, i);
               });
-            lastToolStartedAt = null;
+            runningTools.delete(completedToolCallId);
+            if (completedToolCallId === lastAnonymousToolCallId) {
+              lastAnonymousToolCallId = undefined;
+            }
           }
           if (platform.sendStructuredEvent) {
             await platform.sendStructuredEvent(conversationId, msg);

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1540,14 +1540,12 @@ async function executeNodeInternal(
           ? runningTools.get(lastAnonymousToolCallId)
           : undefined;
         if (previousTool && lastAnonymousToolCallId !== undefined) {
-          const previousToolCallId = lastAnonymousToolCallId;
-          const prevTool = previousTool;
           getWorkflowEventEmitter().emit({
             type: 'tool_completed',
             runId: workflowRun.id,
-            toolName: prevTool.toolName,
+            toolName: previousTool.toolName,
             stepName: node.id,
-            durationMs: now - prevTool.startedAt,
+            durationMs: now - previousTool.startedAt,
           });
           deps.store
             .createWorkflowEvent({
@@ -1555,8 +1553,8 @@ async function executeNodeInternal(
               event_type: 'tool_completed',
               step_name: stepName,
               data: {
-                tool_name: prevTool.toolName,
-                duration_ms: now - prevTool.startedAt,
+                tool_name: previousTool.toolName,
+                duration_ms: now - previousTool.startedAt,
               },
             })
             .catch((err: Error) => {
@@ -1565,7 +1563,7 @@ async function executeNodeInternal(
                 'workflow_event_persist_failed'
               );
             });
-          runningTools.delete(previousToolCallId);
+          runningTools.delete(lastAnonymousToolCallId);
         }
         runningTools.set(toolCallId, { toolName: msg.toolName, startedAt: now });
         if (!msg.toolCallId) lastAnonymousToolCallId = toolCallId;
@@ -4408,26 +4406,27 @@ async function executeLoopNode(
             ? runningTools.get(lastAnonymousToolCallId)
             : undefined;
           if (previousTool && lastAnonymousToolCallId !== undefined) {
-            const previousToolCallId = lastAnonymousToolCallId;
-            const prevTool = previousTool;
             getWorkflowEventEmitter().emit({
               type: 'tool_completed',
               runId: workflowRun.id,
-              toolName: prevTool.toolName,
+              toolName: previousTool.toolName,
               stepName: node.id,
-              durationMs: now - prevTool.startedAt,
+              durationMs: now - previousTool.startedAt,
             });
             deps.store
               .createWorkflowEvent({
                 workflow_run_id: workflowRun.id,
                 event_type: 'tool_completed',
                 step_name: stepName,
-                data: { tool_name: prevTool.toolName, duration_ms: now - prevTool.startedAt },
+                data: {
+                  tool_name: previousTool.toolName,
+                  duration_ms: now - previousTool.startedAt,
+                },
               })
               .catch((err: Error) => {
                 logEventStoreError(err, i);
               });
-            runningTools.delete(previousToolCallId);
+            runningTools.delete(lastAnonymousToolCallId);
           }
           runningTools.set(toolCallId, { toolName: msg.toolName, startedAt: now });
           if (!msg.toolCallId) lastAnonymousToolCallId = toolCallId;


### PR DESCRIPTION
## Summary

- Problem: Codex emitted normalized `tool` and `tool_result` chunks together after a tool had completed, causing recorded tool durations to be near zero.
- Why it matters: workflow history and performance data reported a confident but incorrect duration for Codex command, web-search, and MCP tools.
- What changed: forward each supported Codex tool's start event, close it on the matching completion event, and correlate both chunks with the Codex item ID; add regression coverage for lifecycle pairing, duplicate events, and missing starts.
- What did **not** change (scope boundary): the workflow executor, shared message-chunk contract, SDK timing model, UI, configuration, and database schema remain unchanged.

## UX Journey

### Before

```
  User                 Archon workflow              Codex
  ────                 ───────────────              ─────
  runs task ────────▶  starts agent ─────────────▶  runs tool
                                                    completes tool
                       receives completion ◀──────  emits item.completed
                       emits tool + result together
  sees ~0 ms duration ◀ records adjacent chunks
```

### After

```
  User                 Archon workflow              Codex
  ────                 ───────────────              ─────
  runs task ────────▶  starts agent ─────────────▶  starts tool
                       records [tool start] ◀────── emits item.started
                                                    completes tool
                       records [matching result] ◀─ emits item.completed
  sees actual duration ◀ measures start-to-result interval
```

## Architecture Diagram

### Before

```
Codex SDK item.started ──▶ Codex provider (log only)
Codex SDK item.completed ──▶ Codex provider ──▶ tool + tool_result ──▶ DAG executor
```

### After

```
Codex SDK item.started ──▶ [~ Codex provider] ===▶ tool (item ID) ──▶ DAG executor
Codex SDK item.completed ──▶ [~ Codex provider] ===▶ tool_result (same item ID) ──▶ DAG executor
                                                              └──▶ records measured interval
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| Codex SDK `item.started` | Codex provider | **modified** | Provider now normalizes supported tool starts. |
| Codex SDK `item.completed` | Codex provider | **modified** | Provider now emits only the matching terminal result. |
| Codex provider | Workflow DAG executor | **modified** | Lifecycle chunks carry the stable Codex item ID and arrive at distinct boundaries. |
| Workflow DAG executor | Workflow event store | unchanged | Existing result-boundary duration measurement persists the observed interval. |

## Label Snapshot

- Risk: `risk: medium`
- Size: `size: M`
- Scope: `workflows`
- Module: `workflows:codex-provider`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes #2342
- Related #2336
- Depends on # N/A
- Supersedes # N/A

## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check
bun run lint
bun run format:check
bun run test
bun run build
```

- Evidence provided (test/log/trace/screenshot): all commands passed; focused provider tests passed 78 tests and workflow executor tests passed 240 tests. Regression coverage exercises command success/non-zero exit, web search, MCP success/failure, duplicate lifecycle events, and completion without a start.
- If any command is intentionally skipped, explain why: live Codex/MCP verification was not run because it requires configured external Codex and MCP services; deterministic provider and executor tests verify the lifecycle boundary.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: N/A.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No
- If yes, exact upgrade steps: N/A.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: inspected the Codex SDK event declarations and exercised normalized command, web-search, and MCP lifecycle pairs through provider tests.
- Edge cases checked: stable item-ID pairing, duplicate start/completion suppression, non-zero command exit output, failed MCP calls, and completion without a preceding start.
- What was not verified: a live Codex session with external MCP services.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Codex provider streaming and workflow tool-duration event reporting for command execution, web search, and MCP calls.
- Potential unintended effects: consumers now receive `tool` earlier and correlated with `toolCallId`; unmatched completion events remain guarded by the provider behavior.
- Guardrails/monitoring for early detection: focused regression tests assert exact lifecycle ordering and IDs; existing executor tests assert duration closes at `tool_result`.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `47d7764e`.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: missing or duplicated Codex tool cards/results, or tool durations returning to near-zero values.

## Risks and Mitigations

- Risk: Codex may deliver duplicate or incomplete lifecycle events.
  - Mitigation: provider regression tests cover duplicate events and missing starts, and completion remains correlated by the Codex item ID.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tracking of overlapping tool calls so each result is matched to the correct operation.
  - Added support for reliable command, web-search, and MCP tool completion results, including failures and command exit statuses.
  - Prevented duplicate tool events and handled incomplete lifecycle events more safely.
  - Improved workflow event durations and completion reporting for concurrent tools and loop executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->