### PR TITLE
fix: reject incompatible x64 quick installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,11 @@ Already have Claude Code set up? Install the standalone CLI binary and skip the 
 curl -fsSL https://archon.diy/install | bash
 ```
 
+> **x64 compatibility:** The macOS/Linux quick install requires AVX2 on x64
+> CPUs. Older Intel/AMD hardware and virtual machines that mask AVX2 should use
+> the [source installation guide](https://archon.diy/getting-started/installation/#from-source).
+> ARM64 quick installs are unaffected.
+
 **Windows (PowerShell)**
 ```powershell
 irm https://archon.diy/install.ps1 | iex

--- a/packages/docs-web/public/install
+++ b/packages/docs-web/public/install
@@ -217,10 +217,23 @@ main() {
     error "Install Archon from source instead: https://archon.diy/getting-started/installation/#from-source"
     exit 1
   elif [ "$cpu_compatibility_status" -ne 0 ]; then
-    error "Could not determine whether this x64 CPU supports AVX2."
-    error "No binary was downloaded, installed, or replaced."
-    error "Install Archon from source instead: https://archon.diy/getting-started/installation/#from-source"
-    exit 1
+    # Indeterminate is NOT the same as unsupported: the CPU may well have AVX2,
+    # we just could not read its feature flags (restricted /proc, missing sysctl —
+    # e.g. gVisor, hardened container runtimes). Refusing is still the right
+    # default, but this case gets an override because the user may know something
+    # the installer cannot see. The definitely-absent branch above deliberately
+    # has NO override — forcing a binary that cannot execute is the original bug.
+    if [ "${ARCHON_SKIP_CPU_CHECK:-}" = "1" ]; then
+      warn "Could not determine whether this x64 CPU supports AVX2."
+      warn "Continuing because ARCHON_SKIP_CPU_CHECK=1 is set."
+      warn "If the CPU lacks AVX2, the installed binary will fail with 'Illegal instruction'."
+    else
+      error "Could not determine whether this x64 CPU supports AVX2."
+      error "No binary was downloaded, installed, or replaced."
+      error "If you know it does, re-run with ARCHON_SKIP_CPU_CHECK=1."
+      error "Otherwise install Archon from source: https://archon.diy/getting-started/installation/#from-source"
+      exit 1
+    fi
   fi
 
   # Get download URL

--- a/packages/docs-web/public/install
+++ b/packages/docs-web/public/install
@@ -88,6 +88,34 @@ detect_platform() {
   echo "${os}-${arch}"
 }
 
+# Verify that the host can run the compiled x64 release. Return 1 when AVX2 is
+# definitely absent and 2 when CPU features cannot be determined.
+check_cpu_compatibility() {
+  local platform="$1"
+  local cpu_features
+
+  case "$platform" in
+    linux-x64)
+      local cpuinfo_path="${ARCHON_CPUINFO_PATH:-/proc/cpuinfo}"
+      if [ ! -r "$cpuinfo_path" ]; then
+        return 2
+      fi
+      cpu_features=$(<"$cpuinfo_path") || return 2
+      ;;
+    darwin-x64)
+      cpu_features=$(sysctl -n machdep.cpu.leaf7_features 2>/dev/null) || return 2
+      if [ -z "$cpu_features" ]; then
+        return 2
+      fi
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+
+  printf '%s\n' "$cpu_features" | grep -Eiq '(^|[[:space:]])avx2([[:space:]]|$)'
+}
+
 # Get download URL for the binary
 get_download_url() {
   local platform="$1"
@@ -180,6 +208,20 @@ main() {
   local platform
   platform=$(detect_platform)
   success "Platform: $platform"
+
+  local cpu_compatibility_status=0
+  check_cpu_compatibility "$platform" || cpu_compatibility_status=$?
+  if [ "$cpu_compatibility_status" -eq 1 ]; then
+    error "The compiled Archon x64 binary requires a CPU with AVX2 support."
+    error "No binary was downloaded, installed, or replaced."
+    error "Install Archon from source instead: https://archon.diy/getting-started/installation/#from-source"
+    exit 1
+  elif [ "$cpu_compatibility_status" -ne 0 ]; then
+    error "Could not determine whether this x64 CPU supports AVX2."
+    error "No binary was downloaded, installed, or replaced."
+    error "Install Archon from source instead: https://archon.diy/getting-started/installation/#from-source"
+    exit 1
+  fi
 
   # Get download URL
   local download_url checksums_url

--- a/packages/docs-web/public/install
+++ b/packages/docs-web/public/install
@@ -100,7 +100,7 @@ check_cpu_compatibility() {
       if [ ! -r "$cpuinfo_path" ]; then
         return 2
       fi
-      cpu_features=$(<"$cpuinfo_path") || return 2
+      cpu_features=$(grep -Ei '^[[:space:]]*(flags|features)[[:space:]]*:' "$cpuinfo_path") || return 2
       ;;
     darwin-x64)
       cpu_features=$(sysctl -n machdep.cpu.leaf7_features 2>/dev/null) || return 2

--- a/packages/docs-web/src/content/docs/docs.mdx
+++ b/packages/docs-web/src/content/docs/docs.mdx
@@ -33,11 +33,6 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 curl -fsSL https://archon.diy/install | bash
 ```
 
-> **x64 compatibility:** The macOS/Linux quick install requires AVX2 on x64
-> CPUs. Older Intel/AMD hardware and virtual machines that mask AVX2 should use
-> [From Source](/getting-started/installation/#from-source). ARM64 quick installs
-> are unaffected.
-
 ```powershell [Windows]
 irm https://archon.diy/install.ps1 | iex
 ```
@@ -51,6 +46,11 @@ docker run --rm -v "$PWD:/workspace" ghcr.io/coleam00/archon:latest workflow lis
 ```
 
 :::
+
+> **x64 compatibility:** The macOS/Linux quick install requires AVX2 on x64
+> CPUs. Older Intel/AMD hardware and virtual machines that mask AVX2 should use
+> [From Source](/getting-started/installation/#from-source). ARM64 quick installs
+> are unaffected.
 
 ## What is Archon?
 

--- a/packages/docs-web/src/content/docs/docs.mdx
+++ b/packages/docs-web/src/content/docs/docs.mdx
@@ -33,6 +33,11 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 curl -fsSL https://archon.diy/install | bash
 ```
 
+> **x64 compatibility:** The macOS/Linux quick install requires AVX2 on x64
+> CPUs. Older Intel/AMD hardware and virtual machines that mask AVX2 should use
+> [From Source](/getting-started/installation/#from-source). ARM64 quick installs
+> are unaffected.
+
 ```powershell [Windows]
 irm https://archon.diy/install.ps1 | iex
 ```

--- a/packages/docs-web/src/content/docs/getting-started/installation.md
+++ b/packages/docs-web/src/content/docs/getting-started/installation.md
@@ -15,6 +15,10 @@ sidebar:
 curl -fsSL https://archon.diy/install | bash
 ```
 
+> **x64 compatibility:** Compiled x64 binaries require AVX2. Older Intel/AMD
+> hardware and virtual machines that mask AVX2 cannot use the x64 quick install;
+> use [From Source](#from-source) instead. ARM64 quick installs are unaffected.
+
 ### Windows (PowerShell)
 
 ```powershell

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -217,10 +217,23 @@ main() {
     error "Install Archon from source instead: https://archon.diy/getting-started/installation/#from-source"
     exit 1
   elif [ "$cpu_compatibility_status" -ne 0 ]; then
-    error "Could not determine whether this x64 CPU supports AVX2."
-    error "No binary was downloaded, installed, or replaced."
-    error "Install Archon from source instead: https://archon.diy/getting-started/installation/#from-source"
-    exit 1
+    # Indeterminate is NOT the same as unsupported: the CPU may well have AVX2,
+    # we just could not read its feature flags (restricted /proc, missing sysctl —
+    # e.g. gVisor, hardened container runtimes). Refusing is still the right
+    # default, but this case gets an override because the user may know something
+    # the installer cannot see. The definitely-absent branch above deliberately
+    # has NO override — forcing a binary that cannot execute is the original bug.
+    if [ "${ARCHON_SKIP_CPU_CHECK:-}" = "1" ]; then
+      warn "Could not determine whether this x64 CPU supports AVX2."
+      warn "Continuing because ARCHON_SKIP_CPU_CHECK=1 is set."
+      warn "If the CPU lacks AVX2, the installed binary will fail with 'Illegal instruction'."
+    else
+      error "Could not determine whether this x64 CPU supports AVX2."
+      error "No binary was downloaded, installed, or replaced."
+      error "If you know it does, re-run with ARCHON_SKIP_CPU_CHECK=1."
+      error "Otherwise install Archon from source: https://archon.diy/getting-started/installation/#from-source"
+      exit 1
+    fi
   fi
 
   # Get download URL

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -88,6 +88,34 @@ detect_platform() {
   echo "${os}-${arch}"
 }
 
+# Verify that the host can run the compiled x64 release. Return 1 when AVX2 is
+# definitely absent and 2 when CPU features cannot be determined.
+check_cpu_compatibility() {
+  local platform="$1"
+  local cpu_features
+
+  case "$platform" in
+    linux-x64)
+      local cpuinfo_path="${ARCHON_CPUINFO_PATH:-/proc/cpuinfo}"
+      if [ ! -r "$cpuinfo_path" ]; then
+        return 2
+      fi
+      cpu_features=$(<"$cpuinfo_path") || return 2
+      ;;
+    darwin-x64)
+      cpu_features=$(sysctl -n machdep.cpu.leaf7_features 2>/dev/null) || return 2
+      if [ -z "$cpu_features" ]; then
+        return 2
+      fi
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+
+  printf '%s\n' "$cpu_features" | grep -Eiq '(^|[[:space:]])avx2([[:space:]]|$)'
+}
+
 # Get download URL for the binary
 get_download_url() {
   local platform="$1"
@@ -180,6 +208,20 @@ main() {
   local platform
   platform=$(detect_platform)
   success "Platform: $platform"
+
+  local cpu_compatibility_status=0
+  check_cpu_compatibility "$platform" || cpu_compatibility_status=$?
+  if [ "$cpu_compatibility_status" -eq 1 ]; then
+    error "The compiled Archon x64 binary requires a CPU with AVX2 support."
+    error "No binary was downloaded, installed, or replaced."
+    error "Install Archon from source instead: https://archon.diy/getting-started/installation/#from-source"
+    exit 1
+  elif [ "$cpu_compatibility_status" -ne 0 ]; then
+    error "Could not determine whether this x64 CPU supports AVX2."
+    error "No binary was downloaded, installed, or replaced."
+    error "Install Archon from source instead: https://archon.diy/getting-started/installation/#from-source"
+    exit 1
+  fi
 
   # Get download URL
   local download_url checksums_url

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -100,7 +100,7 @@ check_cpu_compatibility() {
       if [ ! -r "$cpuinfo_path" ]; then
         return 2
       fi
-      cpu_features=$(<"$cpuinfo_path") || return 2
+      cpu_features=$(grep -Ei '^[[:space:]]*(flags|features)[[:space:]]*:' "$cpuinfo_path") || return 2
       ;;
     darwin-x64)
       cpu_features=$(sysctl -n machdep.cpu.leaf7_features 2>/dev/null) || return 2

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -113,6 +113,22 @@ assert_equals "0" "$(check_cpu_with_mocks darwin-x64 AVX2)" "macOS x64 with AVX2
 assert_equals "1" "$(check_cpu_with_mocks darwin-x64 SSE4.2)" "macOS x64 without AVX2"
 assert_equals "0" "$(check_cpu_with_mocks linux-arm64 none)" "Linux ARM64 skips AVX2 check"
 
+missing_cpuinfo="$tmp_dir/missing-cpuinfo"
+missing_cpuinfo_status=0
+ARCHON_CPUINFO_PATH="$missing_cpuinfo" \
+  bash -c 'source "$1"; check_cpu_compatibility linux-x64' _ "$installer" \
+  || missing_cpuinfo_status=$?
+assert_equals "2" "$missing_cpuinfo_status" "Linux x64 with unavailable CPU features"
+
+no_features_cpuinfo="$tmp_dir/cpuinfo-no-features"
+printf '%s\n' 'processor : 0' >"$no_features_cpuinfo"
+no_features_status=0
+ARCHON_CPUINFO_PATH="$no_features_cpuinfo" \
+  bash -c 'source "$1"; check_cpu_compatibility linux-x64' _ "$installer" \
+  || no_features_status=$?
+assert_equals "2" "$no_features_status" "Linux x64 without a feature declaration"
+assert_equals "2" "$(check_cpu_with_mocks darwin-x64 fail)" "macOS x64 with unavailable CPU features"
+
 cmp -s "$installer" "$repo_root/packages/docs-web/public/install" \
   || fail "public installer mirror differs from scripts/install.sh"
 
@@ -187,6 +203,41 @@ esac
 [ ! -e "$curl_marker" ] || fail "installer downloaded a binary before rejecting a non-AVX2 CPU"
 assert_equals "working installation" "$(cat "$no_avx2_install_dir/archon")" \
   "Existing installation after non-AVX2 preflight"
+
+unknown_cpu_mock_dir="$tmp_dir/unknown-cpu-install-mocks"
+unknown_cpu_install_dir="$tmp_dir/unknown-cpu-install-bin"
+unknown_cpu_curl_marker="$tmp_dir/unknown-cpu-curl-called"
+unknown_cpuinfo="$tmp_dir/cpuinfo-unknown"
+mkdir -p "$unknown_cpu_mock_dir" "$unknown_cpu_install_dir"
+printf '%s\n' 'processor : 0' >"$unknown_cpuinfo"
+printf '%s\n' 'working installation' >"$unknown_cpu_install_dir/archon"
+cat >"$unknown_cpu_mock_dir/uname" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "-s" ]; then
+  echo Linux
+else
+  echo x86_64
+fi
+EOF
+cat >"$unknown_cpu_mock_dir/curl" <<EOF
+#!/usr/bin/env bash
+touch "$unknown_cpu_curl_marker"
+exit 99
+EOF
+chmod +x "$unknown_cpu_mock_dir/uname" "$unknown_cpu_mock_dir/curl"
+
+unknown_cpu_status=0
+unknown_cpu_output=$(PATH="$unknown_cpu_mock_dir:$PATH" ARCHON_CPUINFO_PATH="$unknown_cpuinfo" \
+  INSTALL_DIR="$unknown_cpu_install_dir" SKIP_CHECKSUM=true bash "$installer" 2>&1) \
+  || unknown_cpu_status=$?
+[ "$unknown_cpu_status" -ne 0 ] || fail "installer succeeded with undetectable Linux CPU features"
+case "$unknown_cpu_output" in
+  *"Could not determine whether this x64 CPU supports AVX2."*"#from-source"*) ;;
+  *) fail "unknown CPU-feature failure does not explain source installation" ;;
+esac
+[ ! -e "$unknown_cpu_curl_marker" ] || fail "installer downloaded a binary before rejecting unknown CPU features"
+assert_equals "working installation" "$(cat "$unknown_cpu_install_dir/archon")" \
+  "Existing installation after unknown CPU-feature preflight"
 
 success_mock_dir="$tmp_dir/success-install-mocks"
 success_install_dir="$tmp_dir/success-install-bin"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -24,6 +24,7 @@ make_platform_mocks() {
   local os="$1"
   local arch="$2"
   local translated="$3"
+  local cpu_features="${4:-AVX2}"
   local mock_dir="$tmp_dir/mocks-$os-$arch-$translated"
   mkdir -p "$mock_dir"
 
@@ -37,10 +38,19 @@ fi
 EOF
   cat >"$mock_dir/sysctl" <<EOF
 #!/usr/bin/env bash
-if [ "$translated" = "fail" ]; then
+if [ "\$1" = "-in" ] && [ "\$2" = "sysctl.proc_translated" ]; then
+  if [ "$translated" = "fail" ]; then
+    exit 1
+  fi
+  echo "$translated"
+elif [ "\$1" = "-n" ] && [ "\$2" = "machdep.cpu.leaf7_features" ]; then
+  if [ "$cpu_features" = "fail" ]; then
+    exit 1
+  fi
+  echo "$cpu_features"
+else
   exit 1
 fi
-echo "$translated"
 EOF
   # detect_with_mocks SOURCES the installer, so it depends on the source-guard
   # suppressing main(). If that guard ever regresses, main() runs and reaches the real
@@ -82,6 +92,27 @@ assert_platform Darwin arm64 1 darwin-arm64 "Native ARM platform"
 assert_platform Linux x86_64 1 linux-x64 "Linux x64 platform"
 assert_platform Darwin x86_64 fail darwin-x64 "Native Intel platform without Rosetta marker"
 
+check_cpu_with_mocks() {
+  local platform="$1"
+  local cpu_features="$2"
+  local mocks
+  local cpuinfo="$tmp_dir/cpuinfo-${platform}-${cpu_features// /-}"
+  local status=0
+
+  printf 'flags : fpu sse %s\n' "$cpu_features" >"$cpuinfo"
+  mocks="$(make_platform_mocks Darwin x86_64 0 "$cpu_features")"
+  PATH="$mocks:$PATH" ARCHON_CPUINFO_PATH="$cpuinfo" \
+    bash -c 'source "$1"; check_cpu_compatibility "$2"' _ "$installer" "$platform" \
+    || status=$?
+  echo "$status"
+}
+
+assert_equals "0" "$(check_cpu_with_mocks linux-x64 avx2)" "Linux x64 with AVX2"
+assert_equals "1" "$(check_cpu_with_mocks linux-x64 sse4_2)" "Linux x64 without AVX2"
+assert_equals "0" "$(check_cpu_with_mocks darwin-x64 AVX2)" "macOS x64 with AVX2"
+assert_equals "1" "$(check_cpu_with_mocks darwin-x64 SSE4.2)" "macOS x64 without AVX2"
+assert_equals "0" "$(check_cpu_with_mocks linux-arm64 none)" "Linux ARM64 skips AVX2 check"
+
 cmp -s "$installer" "$repo_root/packages/docs-web/public/install" \
   || fail "public installer mirror differs from scripts/install.sh"
 
@@ -94,6 +125,8 @@ cmp -s "$repo_root/scripts/install.ps1" "$repo_root/packages/docs-web/public/ins
 mock_dir="$tmp_dir/install-mocks"
 install_dir="$tmp_dir/install-bin"
 mkdir -p "$mock_dir" "$install_dir"
+avx2_cpuinfo="$tmp_dir/cpuinfo-avx2"
+printf '%s\n' 'flags : fpu sse avx2' >"$avx2_cpuinfo"
 printf '%s\n' 'working installation' >"$install_dir/archon"
 cat >"$mock_dir/curl" <<'EOF'
 #!/usr/bin/env bash
@@ -114,10 +147,46 @@ BINARY
 EOF
 chmod +x "$mock_dir/curl"
 
-if PATH="$mock_dir:$PATH" INSTALL_DIR="$install_dir" SKIP_CHECKSUM=true bash "$installer" >/dev/null 2>&1; then
+if PATH="$mock_dir:$PATH" ARCHON_CPUINFO_PATH="$avx2_cpuinfo" INSTALL_DIR="$install_dir" \
+  SKIP_CHECKSUM=true bash "$installer" >/dev/null 2>&1; then
   fail "installer succeeded when downloaded binary failed its version check"
 fi
 assert_equals "working installation" "$(cat "$install_dir/archon")" "Existing installation after failed probe"
+
+no_avx2_mock_dir="$tmp_dir/no-avx2-install-mocks"
+no_avx2_install_dir="$tmp_dir/no-avx2-install-bin"
+no_avx2_cpuinfo="$tmp_dir/cpuinfo-no-avx2"
+curl_marker="$tmp_dir/no-avx2-curl-called"
+mkdir -p "$no_avx2_mock_dir" "$no_avx2_install_dir"
+printf '%s\n' 'flags : fpu sse4_2' >"$no_avx2_cpuinfo"
+printf '%s\n' 'working installation' >"$no_avx2_install_dir/archon"
+cat >"$no_avx2_mock_dir/uname" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "-s" ]; then
+  echo Linux
+else
+  echo x86_64
+fi
+EOF
+cat >"$no_avx2_mock_dir/curl" <<EOF
+#!/usr/bin/env bash
+touch "$curl_marker"
+exit 99
+EOF
+chmod +x "$no_avx2_mock_dir/uname" "$no_avx2_mock_dir/curl"
+
+no_avx2_status=0
+no_avx2_output=$(PATH="$no_avx2_mock_dir:$PATH" ARCHON_CPUINFO_PATH="$no_avx2_cpuinfo" \
+  INSTALL_DIR="$no_avx2_install_dir" SKIP_CHECKSUM=true bash "$installer" 2>&1) \
+  || no_avx2_status=$?
+[ "$no_avx2_status" -ne 0 ] || fail "installer succeeded on Linux x64 without AVX2"
+case "$no_avx2_output" in
+  *"requires a CPU with AVX2 support"*"#from-source"*) ;;
+  *) fail "non-AVX2 failure does not explain AVX2 requirement and source installation" ;;
+esac
+[ ! -e "$curl_marker" ] || fail "installer downloaded a binary before rejecting a non-AVX2 CPU"
+assert_equals "working installation" "$(cat "$no_avx2_install_dir/archon")" \
+  "Existing installation after non-AVX2 preflight"
 
 success_mock_dir="$tmp_dir/success-install-mocks"
 success_install_dir="$tmp_dir/success-install-bin"
@@ -143,7 +212,8 @@ BINARY
 EOF
 chmod +x "$success_mock_dir/curl"
 
-install_output=$(PATH="$success_mock_dir:$PATH" INSTALL_DIR="$success_install_dir" SKIP_CHECKSUM=true bash "$installer")
+install_output=$(PATH="$success_mock_dir:$PATH" ARCHON_CPUINFO_PATH="$avx2_cpuinfo" \
+  INSTALL_DIR="$success_install_dir" SKIP_CHECKSUM=true bash "$installer")
 assert_equals "archon 1.2.3" "$("$success_install_dir/archon" version)" "Successful probe replaces installation"
 case "$install_output" in
   *"archon 1.2.3"*) ;;
@@ -158,7 +228,8 @@ esac
 #
 # Mocked curl + a scratch INSTALL_DIR keep this off the network and out of the real system.
 piped_status=0
-piped_stderr="$(PATH="$success_mock_dir:$PATH" INSTALL_DIR="$tmp_dir/piped-bin" \
+piped_stderr="$(PATH="$success_mock_dir:$PATH" ARCHON_CPUINFO_PATH="$avx2_cpuinfo" \
+  INSTALL_DIR="$tmp_dir/piped-bin" \
   SKIP_CHECKSUM=true bash <"$installer" 2>&1 >/dev/null)" || piped_status=$?
 # Specific diagnosis FIRST, generic assertion second. With the order reversed the
 # assert_equals fired on any regression and this case block was dead code, so the


### PR DESCRIPTION
## Summary

- Problem: The macOS/Linux quick installer selected Bun-compiled x64 binaries solely by architecture, even on CPUs without AVX2, causing a SIGILL after download.
- Why it matters: Affected users received a non-runnable binary and no targeted explanation or safe, actionable fallback.
- What changed: Add an AVX2 preflight before download, publish the identical installer payload, add deterministic regressions, and document the requirement and source-install fallback.
- What did **not** change (scope boundary): No alternate binary variant, Homebrew behavior, runtime requirements, or automatic source-install workflow was added.

## UX Journey

### Before

```
User on non-AVX2 x64 CPU        Quick installer             Compiled binary
─────────────────────────       ──────────────              ───────────────
runs curl | bash ───────────▶  detects x64
                                downloads asset ──────────▶ starts and SIGILLs
                                reports generic failure ◀──
```

### After

```
User on non-AVX2 x64 CPU        Quick installer
─────────────────────────       ──────────────
runs curl | bash ───────────▶  detects x64
                                [checks AVX2 before download]
sees source-install guidance ◀ [exits non-zero; leaves install unchanged]
```

## Architecture Diagram

### Before

```
scripts/install.sh ─────▶ release binary asset
packages/docs-web/public/install (published installer mirror)
scripts/test-install.sh ─────▶ scripts/install.sh
installation.md ─────▶ quick-install instructions
```

### After

```
scripts/install.sh [~AVX2 preflight] ===▶ release binary asset
        │
        ===▶ source-install guidance on incompatible x64 CPUs
packages/docs-web/public/install [~byte-identical published mirror]
scripts/test-install.sh [~mocked AVX2 and non-destructive regressions] ─────▶ scripts/install.sh
installation.md [~AVX2 compatibility note] ─────▶ source-install instructions
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `scripts/install.sh` | compiled release asset | **modified** | AVX2 is checked before the asset is downloaded. |
| `scripts/install.sh` | source-install documentation | **new** | Incompatible CPUs receive the documented fallback. |
| `packages/docs-web/public/install` | `scripts/install.sh` | **modified** | Published mirror is synchronized byte-for-byte. |
| `scripts/test-install.sh` | `scripts/install.sh` | **modified** | Mocked CPU probes cover pass/fail behavior and ordering. |
| installation guide | source-install instructions | **modified** | Quick-install users can discover the fallback before installation. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `cli`, `docs`, `tests`
- Module: `cli:installer`

## Change Metadata

- Change type: `bug`
- Primary scope: `cli`

## Linked Issue

- Fixes #2277
- Related #
- Depends on # (if stacked): None
- Supersedes # (if replacing older PR): None

## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check
bun run lint
bun run format:check
bun run test
# Or all at once:
bun run validate
```

- Evidence provided (test/log/trace/screenshot): `bun run validate` passed; validation recorded 6,424 tests passed, zero failed. `bun run test:install` also passed, including AVX2-present/absent Linux and macOS checks, ARM64 bypass, no-download failure ordering, preservation of an existing installation, and installer-mirror equality.
- If any command is intentionally skipped, explain why: None.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: Not applicable.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No
- If yes, exact upgrade steps: Not applicable. Non-AVX2 x64 quick installs now fail early with guidance to use the existing source-install path.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Deterministic mocked installer tests for Linux/macOS AVX2 presence and absence, ARM64 behavior, safe failure before `curl`, generic failed binary probe, successful installation, and piped installer execution.
- Edge cases checked: Existing binary remains unchanged after an incompatible CPU is detected; the served public installer remains byte-identical to the source script.
- What was not verified: A physical non-AVX2 CPU was not required because the test harness controls CPU-feature probes deterministically.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: POSIX quick install, published `archon.diy/install` payload, installer regression suite, and installation documentation.
- Potential unintended effects: Feature detection may be unavailable on an unusual x64 host, which now prevents quick installation rather than risking an unusable binary.
- Guardrails/monitoring for early detection: Tests explicitly cover unavailable/incompatible feature paths, assert no download occurs, and enforce byte equality for the published installer mirror.

## Rollback Plan (required)

- Fast rollback command/path: Revert commit `3a763cf7c79fc79e72fd043a08af1a458238e56f` from `dev`.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: Supported x64 quick installs fail at AVX2 detection; installer regression tests identify the platform-specific probe path.

## Risks and Mitigations

- Risk: CPU feature detection differs across Linux and macOS environments.
  - Mitigation: Use native platform probes, fail closed with actionable source-install guidance, and cover both platform paths through controlled mocks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CPU compatibility checks for x64 macOS and Linux installations.
  * Installers now verify AVX2 support before downloading binaries.
  * Unsupported or undetectable systems receive guidance to install from source.
  * ARM64 and other unaffected platforms continue to install normally.

* **Documentation**
  * Updated installation instructions with AVX2 requirements and source-install guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->