### PR TITLE
Fix error for Git repos without remotes

### DIFF
--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -3138,6 +3138,25 @@ describe('WorktreeProvider', () => {
       expect(syncWorkspaceSpy).not.toHaveBeenCalled();
     });
 
+    test('throws actionable error when no remote is configured', async () => {
+      getDefaultRemoteSpy.mockResolvedValue(null);
+      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args.includes('remote') && !args.includes('get-url')) {
+          return { stdout: '', stderr: '' };
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      const localProvider = new WorktreeProvider(async () => ({ baseBranch: 'main' }));
+      const creation = localProvider.create(baseRequest);
+
+      await expect(creation).rejects.toThrow(
+        /no git remote is configured.*git remote add origin URL.*--no-worktree/s
+      );
+      await expect(creation).rejects.not.toThrow(/multiple remotes|worktree\.remote/s);
+      expect(syncWorkspaceSpy).not.toHaveBeenCalled();
+    });
+
     test('uses custom remote for same-repo PR fetch and tracking', async () => {
       const prRequest: PRIsolationRequest = {
         codebaseId: 'cb-123',

--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -3140,12 +3140,6 @@ describe('WorktreeProvider', () => {
 
     test('throws actionable error when no remote is configured', async () => {
       getDefaultRemoteSpy.mockResolvedValue(null);
-      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
-        if (args.includes('remote') && !args.includes('get-url')) {
-          return { stdout: '', stderr: '' };
-        }
-        return { stdout: '', stderr: '' };
-      });
 
       const localProvider = new WorktreeProvider(async () => ({ baseBranch: 'main' }));
       const creation = localProvider.create(baseRequest);

--- a/packages/isolation/src/providers/worktree.ts
+++ b/packages/isolation/src/providers/worktree.ts
@@ -811,15 +811,26 @@ export class WorktreeProvider implements IIsolationProvider {
       return detected;
     }
 
-    // Ambiguous (multiple non-origin remotes) — list them for an actionable error
-    let remoteList = '<unknown>';
+    // Distinguish no remotes from multiple non-origin remotes for an actionable error.
+    let remoteNames: string[] | null = null;
     try {
       const { stdout } = await execFileAsync('git', ['-C', repoPath, 'remote'], { timeout: 10000 });
-      remoteList = stdout.trim().split(/\r?\n/).join(', ');
+      remoteNames = stdout
+        .split(/\r?\n/)
+        .map(remote => remote.trim())
+        .filter(remote => remote.length > 0);
     } catch {
       // Best-effort for error message only
     }
 
+    if (remoteNames?.length === 0) {
+      throw new Error(
+        `Cannot determine git remote for ${repoPath}: no git remote is configured. ` +
+          'Add one with `git remote add origin URL`, or use `--no-worktree` to run in the live checkout.'
+      );
+    }
+
+    const remoteList = remoteNames?.join(', ') ?? '<unknown>';
     throw new Error(
       `Cannot determine git remote for ${repoPath}: no 'origin' remote found and ` +
         `multiple remotes exist (${remoteList}). ` +


### PR DESCRIPTION
## Summary

- Problem: local Git repositories with no remotes were reported as having "multiple remotes," with an empty list and an unusable configuration remedy.
- Why it matters: users now receive an accurate, actionable path to continue isolated work without guessing at an invalid remote name.
- What changed: the worktree provider recognizes a successfully listed empty remote set and recommends adding `origin` or using `--no-worktree`; a regression test covers that path.
- What did **not** change (scope boundary): default remote selection, other `getDefaultRemote()` callers, sync behavior, configuration schemas, and database behavior remain unchanged.

## UX Journey

### Before

```
  User                    Archon                         Git repository
  ────                    ──────                         ──────────────
  starts isolated run ──▶ resolves worktree remote ────▶ lists no remotes
                          reports "multiple remotes ()"
  sees unusable          advises worktree.remote
  remediation ◀────────  (no remote exists to configure)
```

### After

```
  User                    Archon                         Git repository
  ────                    ──────                         ──────────────
  starts isolated run ──▶ resolves worktree remote ────▶ lists no remotes
                          [recognizes zero configured remotes]
  sees actionable         [advises `git remote add origin URL` or
  remediation ◀─────────  `--no-worktree`]
```

## Architecture Diagram

### Before

```
[~] WorktreeProvider.resolveRemote ──▶ getDefaultRemote
             │                              │
             └──── diagnostic `git remote` ◀┘
                     │
                     └──── zero remotes treated as ambiguous error
```

### After

```
[~] WorktreeProvider.resolveRemote ──▶ getDefaultRemote
             │                              │
             └──── diagnostic `git remote` ◀┘
                     │
                     ├── [~] empty names ──▶ zero-remote guidance
                     └── unchanged names ──▶ ambiguous-remote guidance

[~] worktree.test ──▶ verifies both error paths and no workspace sync
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `WorktreeProvider.resolveRemote` | `getDefaultRemote` | unchanged | Shared selector retains its `string \| null` contract. |
| `WorktreeProvider.resolveRemote` | `git remote` diagnostic command | **modified** | Empty output is now recognized as zero configured remotes. |
| `worktree.test` | `WorktreeProvider.create` | **modified** | Adds a zero-remote regression assertion alongside ambiguity coverage. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `isolation`
- Module: `isolation:worktree-provider`

## Change Metadata

- Change type: `bug`
- Primary scope: `isolation`

## Linked Issue

- Closes #2374
- Related # None
- Depends on # None
- Supersedes # None

## Validation Evidence (required)

Commands and result summary:

```bash
bun test packages/isolation/src/providers/worktree.test.ts  # 154 passed
bun run type-check                                           # passed
bun run lint                                                 # passed
bun run format:check                                         # passed
bun run test                                                 # passed
bun run build                                                # passed
bun run validate                                             # passed
```

- Evidence provided (test/log/trace/screenshot): targeted regression suite passed; manual smoke tests verified both zero-remote and multiple-non-`origin` remote messages.
- If any command is intentionally skipped, explain why: none.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation: not applicable.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: not applicable.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: a local repository with no remote reports the add-remote or live-checkout remedies; multiple non-`origin` remotes still list names and recommend `worktree.remote`.
- Edge cases checked: no workspace sync occurs for either remote-resolution failure; empty remote output does not claim multiple remotes.
- What was not verified: no external integrations or database paths changed.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: worktree isolation remote resolution before workspace sync or worktree creation.
- Potential unintended effects: the user-facing error changes only when the diagnostic remote list is successfully empty.
- Guardrails/monitoring for early detection: targeted regression tests preserve both zero-remote and ambiguous-remote behavior and assert no sync side effect.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `faf9ec8e97d27f00d8b1476bdc993a4d2eebd392`.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: zero-remote repositories would again show an empty "multiple remotes" list and recommend `worktree.remote`.

## Risks and Mitigations

- Risk: handling empty output could accidentally alter the ambiguous-remote diagnostic.
  - Mitigation: the existing ambiguous-remotes test remains, and the new test isolates the empty-list path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree setup errors for repositories without a configured remote.
  * Added actionable guidance to configure a remote or disable worktree isolation.
  * Preserved detailed error reporting for repositories with multiple possible remotes.
  * Prevented unnecessary workspace synchronization when setup cannot proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->