### PR TITLE
feat(pi): fall back to the operator's Pi default model when none is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,9 @@ Workflow runs now record what they actually resolved to — assistant, model, ef
 - **The PowerShell installer fails when its version check exits non-zero**, instead of reporting a successful install. (#2391)
 - **Incompatible x64 quick installs are rejected** rather than installing a binary that cannot run. (#2379)
 - **`archon doctor` honors the `claudeBinaryPath` config fallback.** (#2275, #2263)
+### Added
+
+- **Pi model-default fallback** — when no model is set on a workflow node or in `.archon/config.yaml`, the Pi provider now falls back to the operator's own Pi default (`defaultProvider`/`defaultModel` in `~/.pi/agent/settings.json`, as written by the `pi` CLI). This keeps Pi workflows model-agnostic — no vendor model hardcoded — so setups whose catalog drifts (e.g. a LiteLLM proxy) work without pinning a specific model, mirroring how the standalone `pi` CLI boots. Falls through to the existing explicit "requires a model" error when no default is configured.
 
 ## [0.7.0] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,9 @@ Run output moves out of the repository for good — see Breaking below before up
 - **Truncation is named correctly in clipped-output errors.** The truncation marker was matched against the exact tail, so a single trailing newline was enough to report the generic "not a JSON object" error instead of naming the truncation. (#2493)
 - **Include-expander warnings are visible to tests again.** The expander cached its logger at module scope behind a comment stating the deferral existed so test mocks could intercept it — the cache defeated exactly that, and three loader tests failed whenever they shared a process with the expander's own tests. CI had been protected only by the accident of running them in different batches. (#2461)
 - **Installer environment-variable documentation corrected**, along with the release tooling's changelog commit boundary. (#2437)
+### Added
+
+- **Pi model-default fallback** — when no model is set on a workflow node or in `.archon/config.yaml`, the Pi provider now falls back to the operator's own Pi default (`defaultProvider`/`defaultModel` in `~/.pi/agent/settings.json`, as written by the `pi` CLI). This keeps Pi workflows model-agnostic — no vendor model hardcoded — so setups whose catalog drifts (e.g. a LiteLLM proxy) work without pinning a specific model, mirroring how the standalone `pi` CLI boots. Falls through to the existing explicit "requires a model" error when no default is configured.
 
 ## [0.7.1] - 2026-08-04
 

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -442,6 +442,42 @@ describe('PiProvider', () => {
     expect(error?.message).toContain('Pi provider requires a model');
   });
 
+  test('falls back to the operator Pi default (settings.json) when no model is configured', async () => {
+    // With no node/config model, Archon composes the operator's Pi default
+    // (defaultProvider/defaultModel) so no vendor model is hardcoded — e.g. a
+    // litellm-only setup boots on its own configured default model.
+    process.env.GEMINI_API_KEY = 'sk-test';
+    mockSettingsManagerGetGlobalSettings.mockImplementation(() => ({
+      defaultProvider: 'google',
+      defaultModel: 'gemini-2.5-pro',
+    }));
+    resetScript(scriptedAgentEnd());
+
+    // No `model` in the request options — must resolve from settings.
+    const { error } = await consume(new PiProvider().sendQuery('hi', '/tmp'));
+
+    expect(error).toBeUndefined();
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { modelRef: 'google/gemini-2.5-pro' },
+      'pi.model_defaulted_from_settings'
+    );
+    expect(mockModelRegistryFind).toHaveBeenCalledWith('google', 'gemini-2.5-pro');
+  });
+
+  test('still throws when no model and settings default is incomplete (provider without model)', async () => {
+    // A partial default (provider set but no model, or vice versa) must NOT
+    // silently resolve — fail fast with the actionable "requires a model" error.
+    mockSettingsManagerGetGlobalSettings.mockImplementation(() => ({
+      defaultProvider: 'google',
+    }));
+    const { error } = await consume(new PiProvider().sendQuery('hi', '/tmp'));
+    expect(error?.message).toContain('Pi provider requires a model');
+    expect(mockLogger.info).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'pi.model_defaulted_from_settings'
+    );
+  });
+
   test('throws when model ref is malformed', async () => {
     const { error } = await consume(
       new PiProvider().sendQuery('hi', '/tmp', undefined, { model: 'sonnet' })

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -478,6 +478,22 @@ describe('PiProvider', () => {
     );
   });
 
+  test('drains and logs settings errors when falling through the missing-model path', async () => {
+    // A malformed/unreadable settings.json is recorded via drainErrors() (not
+    // thrown) and yields empty defaults. The error must be surfaced, not
+    // swallowed behind the "requires a model" throw below.
+    mockSettingsManagerGetGlobalSettings.mockImplementation(() => ({}));
+    mockSettingsManagerDrainErrors.mockImplementation(() => [
+      { scope: 'global', error: new Error('bad settings.json') },
+    ]);
+    const { error } = await consume(new PiProvider().sendQuery('hi', '/tmp'));
+    expect(error?.message).toContain('Pi provider requires a model');
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: 'global' }),
+      'pi.settings_default_model_read_error'
+    );
+  });
+
   test('throws when model ref is malformed', async () => {
     const { error } = await consume(
       new PiProvider().sendQuery('hi', '/tmp', undefined, { model: 'sonnet' })

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -392,6 +392,42 @@ describe('PiProvider', () => {
     expect(error?.message).toContain('Pi provider requires a model');
   });
 
+  test('falls back to the operator Pi default (settings.json) when no model is configured', async () => {
+    // With no node/config model, Archon composes the operator's Pi default
+    // (defaultProvider/defaultModel) so no vendor model is hardcoded — e.g. a
+    // litellm-only setup boots on its own configured default model.
+    process.env.GEMINI_API_KEY = 'sk-test';
+    mockSettingsManagerGetGlobalSettings.mockImplementation(() => ({
+      defaultProvider: 'google',
+      defaultModel: 'gemini-2.5-pro',
+    }));
+    resetScript(scriptedAgentEnd());
+
+    // No `model` in the request options — must resolve from settings.
+    const { error } = await consume(new PiProvider().sendQuery('hi', '/tmp'));
+
+    expect(error).toBeUndefined();
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { modelRef: 'google/gemini-2.5-pro' },
+      'pi.model_defaulted_from_settings'
+    );
+    expect(mockModelRegistryFind).toHaveBeenCalledWith('google', 'gemini-2.5-pro');
+  });
+
+  test('still throws when no model and settings default is incomplete (provider without model)', async () => {
+    // A partial default (provider set but no model, or vice versa) must NOT
+    // silently resolve — fail fast with the actionable "requires a model" error.
+    mockSettingsManagerGetGlobalSettings.mockImplementation(() => ({
+      defaultProvider: 'google',
+    }));
+    const { error } = await consume(new PiProvider().sendQuery('hi', '/tmp'));
+    expect(error?.message).toContain('Pi provider requires a model');
+    expect(mockLogger.info).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'pi.model_defaulted_from_settings'
+    );
+  });
+
   test('throws when model ref is malformed', async () => {
     const { error } = await consume(
       new PiProvider().sendQuery('hi', '/tmp', undefined, { model: 'sonnet' })

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -428,6 +428,22 @@ describe('PiProvider', () => {
     );
   });
 
+  test('drains and logs settings errors when falling through the missing-model path', async () => {
+    // A malformed/unreadable settings.json is recorded via drainErrors() (not
+    // thrown) and yields empty defaults. The error must be surfaced, not
+    // swallowed behind the "requires a model" throw below.
+    mockSettingsManagerGetGlobalSettings.mockImplementation(() => ({}));
+    mockSettingsManagerDrainErrors.mockImplementation(() => [
+      { scope: 'global', error: new Error('bad settings.json') },
+    ]);
+    const { error } = await consume(new PiProvider().sendQuery('hi', '/tmp'));
+    expect(error?.message).toContain('Pi provider requires a model');
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: 'global' }),
+      'pi.settings_default_model_read_error'
+    );
+  });
+
   test('throws when model ref is malformed', async () => {
     const { error } = await consume(
       new PiProvider().sendQuery('hi', '/tmp', undefined, { model: 'sonnet' })

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -370,7 +370,17 @@ export class PiProvider implements IAgentProvider {
     let modelRef = requestOptions?.model ?? piConfig.model;
     if (!modelRef) {
       try {
-        const settings = piCodingAgent.SettingsManager.create(cwd).getGlobalSettings();
+        const settingsManager = piCodingAgent.SettingsManager.create(cwd);
+        const settings = settingsManager.getGlobalSettings();
+        // SettingsManager records malformed/unreadable settings via
+        // drainErrors() rather than throwing, so a broken settings.json yields
+        // default (empty) settings here. Drain + log them so that case is
+        // visible instead of being swallowed behind the "requires a model"
+        // error below (this branch may throw before the main settings load
+        // that would otherwise surface them).
+        for (const { scope, error: settingsErr } of settingsManager.drainErrors()) {
+          getLog().warn({ scope, err: settingsErr }, 'pi.settings_default_model_read_error');
+        }
         const provider = settings.defaultProvider?.trim();
         const modelId = settings.defaultModel?.trim();
         if (provider && modelId) {

--- a/packages/providers/src/community/pi/provider.ts
+++ b/packages/providers/src/community/pi/provider.ts
@@ -360,11 +360,34 @@ export class PiProvider implements IAgentProvider {
       }
     }
 
-    // 1. Resolve model ref: request (workflow node / chat) → config default
-    const modelRef = requestOptions?.model ?? piConfig.model;
+    // 1. Resolve model ref: request (workflow node / chat) → config default →
+    //    the operator's own Pi default (defaultProvider/defaultModel in
+    //    ~/.pi/agent/settings.json, as written by the `pi` CLI when a model is
+    //    selected). The settings fallback keeps Archon model-agnostic for Pi:
+    //    no vendor model is hardcoded anywhere, and litellm-only setups — whose
+    //    catalog drifts over time — work without pinning a specific model.
+    //    Mirrors how the standalone `pi` CLI boots with the user's default.
+    let modelRef = requestOptions?.model ?? piConfig.model;
+    if (!modelRef) {
+      try {
+        const settings = piCodingAgent.SettingsManager.create(cwd).getGlobalSettings();
+        const provider = settings.defaultProvider?.trim();
+        const modelId = settings.defaultModel?.trim();
+        if (provider && modelId) {
+          modelRef = `${provider}/${modelId}`;
+          getLog().info({ modelRef }, 'pi.model_defaulted_from_settings');
+        }
+      } catch (err) {
+        // Non-fatal: settings.json may be absent (user never ran `pi`) or
+        // unreadable. Fall through to the explicit "requires a model" error
+        // below rather than swallowing the missing-model condition.
+        getLog().debug({ err }, 'pi.settings_default_model_read_failed');
+      }
+    }
     if (!modelRef) {
       throw new Error(
-        'Pi provider requires a model. Set `model` on the workflow node or `assistants.pi.model` in .archon/config.yaml. ' +
+        'Pi provider requires a model. Set `model` on the workflow node or `assistants.pi.model` in .archon/config.yaml, ' +
+          'or select a default model in the `pi` CLI (writes defaultProvider/defaultModel to ~/.pi/agent/settings.json). ' +
           "Format: '<pi-provider-id>/<model-id>' (e.g. 'google/gemini-2.5-pro')."
       );
     }


### PR DESCRIPTION
## Summary

- **Problem:** the Pi provider resolves a model from the workflow node → `assistants.pi.model` config, and hard-errors "Pi provider requires a model" when neither is set. A LiteLLM-only setup (whose catalog drifts) had to pin a specific model even though the operator already selected a default in the `pi` CLI.
- **Why it matters:** keeps Archon model-agnostic for Pi — no vendor model hardcoded anywhere — and lets a machine boot on its own configured Pi default, mirroring how the standalone `pi` CLI behaves.
- **What changed:** add one fallback step before the error — read `defaultProvider`/`defaultModel` from the operator's `~/.pi/agent/settings.json` (what the `pi` CLI writes when a model is selected) and use `<provider>/<model>`.
- **What did NOT change (scope boundary):** the existing resolution order (node → config) is unchanged; the fallback only runs when both are absent. A **partial** default (provider without model) still fails fast with the same actionable error. No other provider touched.

## Change Metadata

- Change type: `feature`
- Primary scope: `core` (providers)

## What changed, in detail

`packages/providers/src/community/pi/provider.ts` — model resolution becomes: request (workflow node / chat) → config default → **operator Pi default** (`defaultProvider`/`defaultModel` from `~/.pi/agent/settings.json`). Reading settings is wrapped so an absent/unreadable `settings.json` is non-fatal (falls through to the "requires a model" error rather than swallowing it). The error message now also points users at the `pi` CLI default.

## Linked Issue

- Supersedes staging PR `k4n4lm00n/Archon#5` (our fork's review gate for this change)

## Validation Evidence (required)

```bash
# packages/providers
bun run type-check                                   # exit 0, clean
bun test src/community/pi/provider.test.ts           # 98 pass / 0 fail (235 assertions)
```

Two new unit tests added and passing:
- `falls back to the operator Pi default (settings.json) when no model is configured`
- `still throws when no model and settings default is incomplete (provider without model)`

`eslint --fix` + `prettier --write` ran clean via the lint-staged pre-commit hook. Full `bun run validate` left to CI.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **Reads** `~/.pi/agent/settings.json` (the same Pi settings the provider already operates against) — read-only, no new write scope.

## Compatibility / Migration

- Backward compatible? **Yes** — the fallback only fires when no model is otherwise configured; every existing config resolves exactly as before.
- Config/env changes? **No** (opt-in by virtue of the operator having a `pi` default).
- Database migration needed? **No**

## Human Verification (required)

- Verified scenarios: type-check + full Pi provider suite green, including both new tests.
- Edge cases checked: partial default (provider set, model missing) → fails fast; absent/unreadable `settings.json` → non-fatal, falls through to the explicit error.
- What was not verified: no e2e run (pure unit-level resolution logic with mocked settings).

## Side Effects / Blast Radius (required)

- Affected subsystems: `packages/providers` Pi provider model-resolution only.
- Potential unintended effects: a machine with a `pi` default set could now resolve a model where it previously errored — intended, and only when nothing else is configured.
- Guardrails: unit tests cover both the fallback and the fail-fast partial-default path.

## Rollback Plan (required)

- Fast rollback: revert this single commit; resolution returns to node → config → error.
- Toggles: none.
- Observable failure symptoms: Pi resolving an unexpected default model on a misconfigured host (would surface as a wrong-model run, not a crash).

## Risks and Mitigations

- Risk: resolving a default the operator didn't intend for a given workflow.
  - Mitigation: only triggers when neither node nor config sets a model; requires a complete `pi` CLI default to have been chosen; logged as `pi.model_defaulted_from_settings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pi workflows now use the configured default provider and model from global Pi settings when no model is specified.
  * Missing or unreadable settings are handled gracefully, with clear guidance when a model still cannot be resolved.

* **Documentation**
  * Added an unreleased changelog entry describing Pi model-default fallback behavior.

* **Tests**
  * Added coverage for successful fallback and incomplete or unreadable configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->