### PR TITLE
docs: Guide GUI callers to the native CLI

### DIFF
--- a/packages/docs-web/src/content/docs/getting-started/installation.md
+++ b/packages/docs-web/src/content/docs/getting-started/installation.md
@@ -33,6 +33,18 @@ brew install coleam00/archon/archon
 docker run --rm -v "$PWD:/workspace" ghcr.io/coleam00/archon:latest workflow list
 ```
 
+## Using Archon from a GUI or service
+
+The quick installer and Homebrew install a native, compiled `archon` executable;
+they do not require Bun at runtime. A GUI app, `launchd` job, or other process
+without your login-shell `PATH` should launch that executable by an absolute path,
+configured by the user (for the quick installer, the default is
+`/usr/local/bin/archon`). Do not invoke the Bun-linked/source CLI from these
+processes.
+
+The source-install and `bun link` workflow below is for terminal development and
+requires Bun to be discoverable on `PATH`.
+
 ## From Source
 
 ```bash

--- a/packages/docs-web/src/content/docs/getting-started/installation.md
+++ b/packages/docs-web/src/content/docs/getting-started/installation.md
@@ -38,9 +38,10 @@ docker run --rm -v "$PWD:/workspace" ghcr.io/coleam00/archon:latest workflow lis
 The quick installer and Homebrew install a native, compiled `archon` executable;
 they do not require Bun at runtime. A GUI app, `launchd` job, or other process
 without your login-shell `PATH` should launch that executable by an absolute path,
-configured by the user (for the quick installer, the default is
-`/usr/local/bin/archon`). Do not invoke the Bun-linked/source CLI from these
-processes.
+configured by the user (the quick-installer defaults are
+`/usr/local/bin/archon` on macOS/Linux and
+`%USERPROFILE%\\.archon\\bin\\archon.exe` on Windows). Do not invoke the
+Bun-linked/source CLI from these processes.
 
 The source-install and `bun link` workflow below is for terminal development and
 requires Bun to be discoverable on `PATH`.

--- a/packages/docs-web/src/content/docs/getting-started/installation.md
+++ b/packages/docs-web/src/content/docs/getting-started/installation.md
@@ -43,8 +43,8 @@ configured by the user (the quick-installer defaults are
 `%USERPROFILE%\\.archon\\bin\\archon.exe` on Windows). Do not invoke the
 Bun-linked/source CLI from these processes.
 
-The source-install and `bun link` workflow below is for terminal development and
-requires Bun to be discoverable on `PATH`.
+The source-install and `bun link` workflow is for terminal development and
+requires Bun on `PATH`.
 
 ## From Source
 

--- a/packages/docs-web/src/content/docs/getting-started/overview.md
+++ b/packages/docs-web/src/content/docs/getting-started/overview.md
@@ -227,15 +227,21 @@ The AI router automatically picks the right workflow based on your message.
 
 ---
 
-### Path B: CLI (No Server)
+### Path B: CLI from source (No Server)
 
-**Step 4: Install the CLI globally**
+**Step 4: Link the source CLI for terminal development**
 
 ```bash
 cd packages/cli && bun link && cd ../..
 ```
 
-This registers the `archon` command globally so you can run it from any repository.
+This registers the Bun-based source `archon` command globally so you can run it
+from an interactive terminal in any repository. It requires Bun to be on `PATH`;
+the `~/.bun/bin` setup below applies only to shell-launched use.
+
+For a GUI app, service, or other non-shell caller, install the native release
+executable and configure its absolute path instead. See [Using Archon from a GUI
+or service](/getting-started/installation/#using-archon-from-a-gui-or-service).
 
 You'll see output like `Success! Registered "@archon/cli"` followed by a message about `bun link @archon/cli` — **ignore that second part**, it's for adding Archon as a dependency in another project.
 

--- a/packages/docs-web/src/content/docs/getting-started/overview.md
+++ b/packages/docs-web/src/content/docs/getting-started/overview.md
@@ -235,9 +235,9 @@ The AI router automatically picks the right workflow based on your message.
 cd packages/cli && bun link && cd ../..
 ```
 
-This registers the Bun-based source `archon` command globally so you can run it
-from an interactive terminal in any repository. It requires Bun to be on `PATH`;
-the `~/.bun/bin` setup below applies only to shell-launched use.
+This makes the Bun-based source `archon` command available in interactive
+terminals. It requires Bun on `PATH`, and the `~/.bun/bin` setup below applies
+only to shell-launched use.
 
 For a GUI app, service, or other non-shell caller, install the native release
 executable and configure its absolute path instead. See [Using Archon from a GUI


### PR DESCRIPTION
## Summary

- Problem: GUI and service processes with a minimal `PATH` can attempt to launch the Bun-linked source CLI, whose shebang cannot resolve Bun.
- Why it matters: integrations need a supported, reliable way to invoke Archon outside an interactive shell.
- What changed: documented the existing native release executable path for GUI/service callers and clarified that `bun link` is terminal-only source development.
- What did **not** change (scope boundary): no CLI runtime, installer, launcher shim, package-bin mapping, or configuration behavior changed.

## UX Journey

### Before

```
GUI/service caller          Source-linked archon              Bun
───────────────          ────────────────────────          ───────
launches `archon` ─────▶ #!/usr/bin/env bun ─────────────▶ not found on GUI PATH
                                                              │
fails before CLI starts ◀─────────────────────────────────────┘
```

### After

```
GUI/service caller       Documentation                    Native release executable
───────────────       ─────────────────                  ─────────────────────────
configures [absolute path] ◀── explains native path ─── installed binary needs no Bun
launches [native archon] ───────────────────────────────▶ CLI starts successfully
```

## Architecture Diagram

### Before

```
[~] installation.md ── explains quick/source installs incompletely ──▶ GUI/service integrator
[~] overview.md ────── presents `bun link` and shell PATH setup ────▶ source CLI
source CLI ─────────────────────────────────────────────────────────▶ `/usr/bin/env bun`
```

### After

```
[~] installation.md === documents native executable absolute-path use ===▶ GUI/service integrator
[~] overview.md ======= labels `bun link` as terminal-only and links =====▶ installation.md
GUI/service integrator ===================================================▶ native release executable
terminal developer =======================================================▶ source CLI ──▶ `/usr/bin/env bun`
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `installation.md` | GUI/service integrators | **modified** | Adds native executable and absolute-path guidance. |
| `overview.md` | `installation.md` | **new** | Links source CLI readers to GUI/service guidance. |
| `overview.md` | Bun-linked source CLI | **modified** | Clarifies terminal-only, Bun-on-PATH requirement. |
| GUI/service integrator | Native release executable | **modified** | Documents existing supported invocation model. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `docs`
- Module: `docs:getting-started`

## Change Metadata

- Change type: `docs`
- Primary scope: `cli`

## Linked Issue

- Closes #2385
- Related # None
- Depends on # None
- Supersedes # None

## Validation Evidence (required)

Commands and result summary:

```bash
bun run build:docs       # passed
bun run type-check       # passed
bun run lint             # passed with 0 warnings
bun run format:check     # passed
bun run test             # passed: 6,424 tests, 0 failures
bun run build            # passed
```

- Evidence provided (test/log/trace/screenshot): documentation build verified the new heading anchor and overview link; `archon version` verified the Bun-linked source CLI (v0.7.0).
- If any command is intentionally skipped, explain why: native executable smoke testing under a minimal GUI environment was not possible because no quick-install or Homebrew binary is installed on this machine.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`
- If any `Yes`, describe risk and mitigation: Not applicable.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Database migration needed? `No`
- If yes, exact upgrade steps: Not applicable; GUI/service integrators should configure the absolute path of their installed native executable.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: documentation build, generated heading anchor, overview link, and source-linked `archon version`.
- Edge cases checked: guidance names `/usr/local/bin/archon` only as the quick-installer default and does not assume a Homebrew prefix.
- What was not verified: a native quick-install/Homebrew binary was unavailable for a minimal-GUI-environment smoke test.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: getting-started installation and source CLI documentation.
- Potential unintended effects: readers may confuse the quick-installer default with a universal binary location.
- Guardrails/monitoring for early detection: the wording requires user-configured absolute paths and explicitly avoids a fixed Homebrew prefix.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `de37533a`.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: incorrect or unclear installation guidance; documentation can be restored immediately by reverting the two documentation-file changes.

## Risks and Mitigations

- Risk: GUI callers may still attempt to use the Bun-linked source CLI.
  - Mitigation: both entry points now explicitly distinguish source terminal development from native executable use for GUI and service callers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified installation options for terminal, GUI, service, and background-process usage.
  * Added platform-specific guidance for locating the native executable.
  * Documented requirements for using source installations and linked CLI versions, including Bun availability on `PATH`.
  * Clarified when shell-specific binary path configuration applies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->