### PR TITLE
Retain bash stdout previews for auditability

### DIFF
--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -186,7 +186,7 @@ nodes:
 |-------|------|-------------|
 | `command` | string | Command name to load from `.archon/commands/` |
 | `prompt` | string | Inline prompt string |
-| `bash` | string | Shell script (no AI). Stdout captured as `$nodeId.output`. Optional `timeout` (ms, default 120000) |
+| `bash` | string | Shell script (no AI). Stdout captured as `$nodeId.output`; successful stdout is also stored in `node_completed.data.node_output` as an audit preview capped at 32 KiB (UTF-8 bytes). Optional `timeout` (ms, default 120000) |
 | `script` | string | TypeScript/JavaScript (via `bun`) or Python (via `uv`) — inline code or named reference to `.archon/scripts/`. Stdout captured as `$nodeId.output`. Requires `runtime: bun` or `runtime: uv`. Optional `deps` (uv only) and `timeout` (ms, default 120000). See [Script Nodes](/guides/script-nodes/) |
 | `loop` | object | Iterative AI prompt until completion signal. See [Loop Nodes](/guides/loop-nodes/) |
 | `loop_group` | object | Multi-node sub-DAG body repeated per iteration until a completion signal. See [Cross-Node Loops](/guides/loop-nodes/#cross-node-loops-with-loop_group) |
@@ -798,6 +798,8 @@ When a node sets `output_type`, the executor writes a typed sidecar after the no
 - `$ARTIFACTS_DIR/nodes/<id>.meta.json` — metadata (`outputType`, `runId`, `producedAt`, `size`, and `sessionId` when available)
 
 This works on **every** node type (`bash`/`script` produce typed outputs too, just without a `sessionId`). The write is **best-effort** — if it fails, the node still succeeds and a warning is logged; the typed sidecar may simply be absent. `output_type` is an open set of labels (`plan`, `findings`, `code`, `summary`, …) — pick a convention and keep casing consistent, since lookup is case-sensitive.
+
+Successful bash stdout is retained by default on the completed run as a bounded audit preview in `node_completed.data.node_output`. Output over 32 KiB (32,768 UTF-8 bytes) ends with a truncation marker, and the event also includes `node_output_truncated: true` plus `node_output_original_bytes`. Because stdout is persisted, never print secrets or credentials from bash nodes. This preview is separate from `output_type`: declaring `output_type` opts into a best-effort file sidecar that may contain the full output and is not required for ordinary bash audit retention.
 
 ---
 

--- a/packages/docs-web/src/content/docs/reference/variables.md
+++ b/packages/docs-web/src/content/docs/reference/variables.md
@@ -64,6 +64,8 @@ In DAG workflows, nodes can reference the output of any completed upstream node.
 | `$nodeId.output` | Full output string of the referenced node | The node must be a declared dependency (in `depends_on`) |
 | `$nodeId.output.field` | A specific JSON field from the node's output | Requires the upstream node to use `output_format` for structured JSON |
 
+During the current run, downstream interpolation and `when:` conditions see the full returned node output. Successful bash events retain only a 32 KiB UTF-8 audit preview, so after a process boundary a resumed run rehydrates that persisted preview rather than the full output. If a large gate verdict must survive a restart intact, store it through a deliberately managed artifact contract instead of relying on the event preview.
+
 ### Shell Quoting in `bash:` vs `script:`
 
 `$nodeId.output` values are **auto shell-quoted** when substituted into `bash:` scripts, so the value is always safe to embed in a shell command. For small outputs, values are single-quoted inline. For outputs exceeding 32 KB, Archon spills to a temp file and substitutes `$(cat '/tmp/path')` instead — the unquoted assignment form is correct in both cases. They are **not** shell-quoted when substituted into `script:` bodies — the raw value is embedded as-is. For script nodes, treat substituted values as untrusted input and parse them with language features (e.g. `JSON.parse`), not by interpolating into shell syntax.

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -4862,6 +4862,189 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     );
   });
 
+  it('persists bash output at or below the byte cap unchanged without truncation metadata', async () => {
+    for (const [nodeId, byteCount] of [
+      ['below-cap', 32_767],
+      ['exact-cap', 32_768],
+    ] as const) {
+      const store = createMockStore();
+      const mockDeps = createMockDeps(store);
+      const workflowRun = makeWorkflowRun(`bash-output-${nodeId}`);
+
+      await executeDagWorkflow(
+        mockDeps,
+        createMockPlatform(),
+        `conv-${nodeId}`,
+        testDir,
+        {
+          name: `bash-output-${nodeId}`,
+          nodes: [{ id: nodeId, bash: `printf '%${String(byteCount)}s' '' | tr ' ' x` }],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+      const completedEvent = eventCalls.find(
+        (call: unknown[]) =>
+          (call[0] as { event_type: string }).event_type === 'node_completed' &&
+          (call[0] as { step_name: string }).step_name === nodeId
+      );
+      const data = (
+        completedEvent![0] as {
+          data: Record<string, unknown> & { node_output: string };
+        }
+      ).data;
+      expect(data.node_output).toBe('x'.repeat(byteCount));
+      expect(data.node_output_truncated).toBeUndefined();
+      expect(data.node_output_original_bytes).toBeUndefined();
+    }
+  });
+
+  it('caps over-limit persisted bash output with a marker and byte metadata', async () => {
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const workflowRun = makeWorkflowRun('bash-output-over-cap');
+
+    await executeDagWorkflow(
+      mockDeps,
+      createMockPlatform(),
+      'conv-over-cap',
+      testDir,
+      {
+        name: 'bash-output-over-cap',
+        nodes: [{ id: 'over-cap', bash: "printf '%32769s' '' | tr ' ' x" }],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+    const completedEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_completed' &&
+        (call[0] as { step_name: string }).step_name === 'over-cap'
+    );
+    const data = (
+      completedEvent![0] as {
+        data: {
+          node_output: string;
+          node_output_truncated: boolean;
+          node_output_original_bytes: number;
+        };
+      }
+    ).data;
+    expect(Buffer.byteLength(data.node_output, 'utf8')).toBeLessThanOrEqual(32_768);
+    expect(data.node_output).toEndWith('\n\n… [truncated; original output was 32769 bytes]');
+    expect(data.node_output_truncated).toBe(true);
+    expect(data.node_output_original_bytes).toBe(32_769);
+    // Resume deliberately rehydrates this bounded node_output preview; preserving
+    // complete cross-process output requires a separately managed artifact.
+  });
+
+  it('keeps a persisted UTF-8 preview valid when the byte cap splits a code point', async () => {
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const workflowRun = makeWorkflowRun('bash-output-utf8-cap');
+
+    await executeDagWorkflow(
+      mockDeps,
+      createMockPlatform(),
+      'conv-utf8-cap',
+      testDir,
+      {
+        name: 'bash-output-utf8-cap',
+        nodes: [{ id: 'utf8-cap', bash: `bun -e "process.stdout.write('🙂'.repeat(8193))"` }],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+    const completedEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_completed' &&
+        (call[0] as { step_name: string }).step_name === 'utf8-cap'
+    );
+    const data = (completedEvent![0] as { data: { node_output: string } }).data;
+    expect(Buffer.byteLength(data.node_output, 'utf8')).toBeLessThanOrEqual(32_768);
+    expect(data.node_output).not.toContain('\ufffd');
+    expect(data.node_output).toEndWith('\n\n… [truncated; original output was 32772 bytes]');
+  });
+
+  it('uses full bash output for same-run when and downstream substitution despite persistence cap', async () => {
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const workflowRun = makeWorkflowRun('bash-output-live-full');
+    const paddingBytes = 33_000;
+
+    await executeDagWorkflow(
+      mockDeps,
+      createMockPlatform(),
+      'conv-live-full',
+      testDir,
+      {
+        name: 'bash-output-live-full',
+        nodes: [
+          {
+            id: 'producer',
+            bash: `printf '{"status":"PASS","padding":"'; printf '%${String(paddingBytes)}s' '' | tr ' ' x; printf '"}'`,
+          },
+          {
+            id: 'consumer',
+            bash: 'value=$producer.output; printf %s "${#value}"',
+            depends_on: ['producer'],
+            when: "$producer.output.status == 'PASS'",
+          },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+    const producerEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_completed' &&
+        (call[0] as { step_name: string }).step_name === 'producer'
+    );
+    const consumerEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_completed' &&
+        (call[0] as { step_name: string }).step_name === 'consumer'
+    );
+    expect(
+      (producerEvent![0] as { data: { node_output_truncated: boolean } }).data.node_output_truncated
+    ).toBe(true);
+    expect((consumerEvent![0] as { data: { node_output: string } }).data.node_output).toBe(
+      String(paddingBytes + 30)
+    );
+  });
+
   it('stores node_output in node_completed event data for AI nodes', async () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -2448,6 +2448,42 @@ async function runSubprocess(
  *  instead of inlined as bash -c arguments, to avoid silent data corruption. */
 const NODE_OUTPUT_FILE_THRESHOLD = 32_768;
 
+/** Maximum UTF-8 bytes retained for successful bash stdout in workflow events. */
+const PERSISTED_BASH_OUTPUT_MAX_BYTES = 32 * 1024;
+
+function formatPersistedBashOutput(output: string): {
+  nodeOutput: string;
+  truncated: boolean;
+  originalBytes?: number;
+} {
+  const outputBytes = Buffer.from(output, 'utf8');
+  if (outputBytes.byteLength <= PERSISTED_BASH_OUTPUT_MAX_BYTES) {
+    return { nodeOutput: output, truncated: false };
+  }
+
+  const marker = `\n\n… [truncated; original output was ${String(outputBytes.byteLength)} bytes]`;
+  const markerBytes = Buffer.byteLength(marker, 'utf8');
+  let headEnd = PERSISTED_BASH_OUTPUT_MAX_BYTES - markerBytes;
+
+  // The byte cap can land inside a multi-byte code point. Inspect the final
+  // sequence in the prefix and drop it when it is incomplete before decoding.
+  let sequenceStart = headEnd - 1;
+  while (sequenceStart >= 0 && (outputBytes[sequenceStart] & 0xc0) === 0x80) {
+    sequenceStart--;
+  }
+  if (sequenceStart >= 0) {
+    const leadByte = outputBytes[sequenceStart];
+    const expectedLength = leadByte < 0x80 ? 1 : leadByte < 0xe0 ? 2 : leadByte < 0xf0 ? 3 : 4;
+    if (headEnd - sequenceStart < expectedLength) headEnd = sequenceStart;
+  }
+
+  return {
+    nodeOutput: outputBytes.subarray(0, headEnd).toString('utf8') + marker,
+    truncated: true,
+    originalBytes: outputBytes.byteLength,
+  };
+}
+
 /**
  * Execute a bash (shell script) DAG node.
  * Runs the script via `bash -c`, captures stdout as node output.
@@ -2567,12 +2603,25 @@ async function executeBashNode(
     getLog().info({ nodeId: node.id, durationMs: duration }, 'dag_node_completed');
     await logNodeComplete(logDir, workflowRun.id, node.id, '<bash>', { durationMs: duration });
 
+    const persistedOutput = formatPersistedBashOutput(output);
+
     deps.store
       .createWorkflowEvent({
         workflow_run_id: workflowRun.id,
         event_type: 'node_completed',
         step_name: stepName,
-        data: { duration_ms: duration, type: 'bash', node_output: output, ...iterationData },
+        data: {
+          duration_ms: duration,
+          type: 'bash',
+          node_output: persistedOutput.nodeOutput,
+          ...(persistedOutput.truncated
+            ? {
+                node_output_truncated: true,
+                node_output_original_bytes: persistedOutput.originalBytes,
+              }
+            : {}),
+          ...iterationData,
+        },
       })
       .catch((err: Error) => {
         getLog().error(

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -2451,6 +2451,13 @@ const NODE_OUTPUT_FILE_THRESHOLD = 32_768;
 /** Maximum UTF-8 bytes retained for successful bash stdout in workflow events. */
 const PERSISTED_BASH_OUTPUT_MAX_BYTES = 32 * 1024;
 
+function utf8SequenceLength(leadByte: number): number {
+  if (leadByte < 0x80) return 1;
+  if (leadByte < 0xe0) return 2;
+  if (leadByte < 0xf0) return 3;
+  return 4;
+}
+
 function formatPersistedBashOutput(output: string): {
   nodeOutput: string;
   truncated: boolean;
@@ -2473,7 +2480,7 @@ function formatPersistedBashOutput(output: string): {
   }
   if (sequenceStart >= 0) {
     const leadByte = outputBytes[sequenceStart];
-    const expectedLength = leadByte < 0x80 ? 1 : leadByte < 0xe0 ? 2 : leadByte < 0xf0 ? 3 : 4;
+    const expectedLength = utf8SequenceLength(leadByte);
     if (headEnd - sequenceStart < expectedLength) headEnd = sequenceStart;
   }
 


### PR DESCRIPTION
## Summary

- Problem: successful bash-node stdout was retained in completion events without an explicit, bounded persistence policy.
- Why it matters: reviewers need a durable post-run audit preview without unbounded event storage or altered live DAG behavior.
- What changed: store a UTF-8-safe 32 KiB stdout preview with a truncation marker and metadata; add regressions and document retention/security semantics.
- What did **not** change (scope boundary): active-run `$node.output` remains full, failures and subprocess behavior are unchanged, and no schema, migration, API, or `output_type` artifact changes were added.

## UX Journey

### Before

```
Workflow author          Bash node                 Workflow event store
───────────────          ─────────                 ────────────────────
runs workflow ───────▶  emits stdout ───────────▶  stores full output
reviews completed run ◀──────────────────────────  no explicit size policy
```

### After

```
Workflow author          Bash node                 Workflow event store
───────────────          ─────────                 ────────────────────
runs workflow ───────▶  emits full stdout ───────▶ [stores UTF-8-safe,
                                                        bounded 32 KiB preview]
continues DAG ◀──────── [receives full live output]
reviews completed run ◀──────────────────────────  sees preview plus truncation metadata
```

## Architecture Diagram

### Before

```
Workflow definition --> dag-executor --> node_completed workflow event
                         |
                         +--> downstream $node.output substitution
```

### After

```
Workflow definition --> [~ dag-executor] --> [~ node_completed workflow event]
                         |                         (bounded audit preview)
                         +--> downstream $node.output substitution
                              (unchanged full live stdout)

[~ workflow documentation] describes audit retention and output semantics
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| Workflow definition | `dag-executor` | unchanged | Bash nodes continue to execute normally. |
| `dag-executor` | `node_completed` workflow event | **modified** | Successful stdout is persisted as a bounded UTF-8-safe preview with metadata when truncated. |
| `dag-executor` | downstream `$node.output` substitution | unchanged | The active DAG still receives full stdout. |
| Workflow documentation | workflow authors | **modified** | Documents retention, truncation, and secret-safety guidance. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `workflows`, `docs`, `tests`
- Module: `workflows:executor`

## Change Metadata

- Change type: `feature`
- Primary scope: `workflows`

## Linked Issue

- Closes #2323
- Related # None
- Depends on # None
- Supersedes # None

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate
```

- Evidence provided (test/log/trace/screenshot): `bun run validate` passed all bundled checks, type checks, lint, format checks, installer checks, and isolated package tests. Focused executor tests passed: 446 tests. Full test suite passed: 6,429 tests, 0 failures.
- If any command is intentionally skipped, explain why: no required validation was skipped. A live CLI workflow run was not performed because it requires caller-provided workflow/run context; deterministic executor coverage validates the persistence and downstream behavior.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation: Not applicable. Documentation explicitly warns authors not to emit secrets to bash stdout because successful stdout is retained in run events.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: Not applicable.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: under-limit and exact-limit output are unchanged; over-limit output includes marker, metadata, and respects the byte cap; successful completion events retain the preview.
- Edge cases checked: Unicode/UTF-8 boundaries remain valid; same-run downstream `$node.output` receives full stdout despite capped persistence; failing bash behavior remains unchanged.
- What was not verified: a live CLI workflow run against a caller-supplied workflow/run context.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: successful bash-node completion-event persistence, workflow run auditing, and workflow author documentation.
- Potential unintended effects: post-restart consumers can only rehydrate the bounded preview for oversized output.
- Guardrails/monitoring for early detection: explicit truncation marker and `node_output_truncated`/`node_output_original_bytes` metadata make truncation observable; regression tests cover byte bounds and live behavior.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `c0460331` from the feature branch or release branch.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: completion events show unexpectedly truncated output, invalid Unicode, or downstream nodes no longer see full live output.

## Risks and Mitigations

- Risk: a bounded event preview cannot preserve complete oversized stdout across a process restart.
  - Mitigation: retain the full value for the active DAG, mark persisted truncation explicitly, and document the resume limitation.
- Risk: authors may emit sensitive values to stdout.
  - Mitigation: document that stdout is persisted and must not contain secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bash node completion events now retain a UTF-8-safe audit preview of stdout up to 32 KiB.
  * Larger outputs include truncation details and the original byte count.
  * Full output remains available for downstream substitutions and conditions during the same run.

* **Documentation**
  * Clarified output retention, truncation behavior, resumed-run handling, and guidance for avoiding secrets in stdout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->