### PR TITLE
Fix detached workflow startup acknowledgement

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -1,7 +1,10 @@
 /**
  * Tests for workflow commands
  */
-import { describe, it, expect, beforeEach, afterEach, spyOn, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, spyOn, mock, jest } from 'bun:test';
+import { appendFileSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { WorkflowEmitterEvent } from '@archon/workflows/event-emitter';
 import { makeTestWorkflow, makeTestWorkflowWithSource } from '@archon/workflows/test-utils';
 import {
@@ -3015,11 +3018,46 @@ describe('write command --json output', () => {
 describe('workflowRunCommand — detach', () => {
   let consoleSpy: ReturnType<typeof spyOn>;
 
+  function createDetachedChildFixture(pid: number | null = 12345): {
+    child: ReturnType<typeof Bun.spawn>;
+    unref: ReturnType<typeof mock>;
+  } {
+    const unref = mock(() => undefined);
+    const child = {
+      pid: pid ?? undefined,
+      unref,
+    };
+
+    return {
+      child: child as unknown as ReturnType<typeof Bun.spawn>,
+      unref,
+    };
+  }
+
+  async function finishStartupWindow(
+    commandPromise: Promise<void>,
+    spawnSpy: ReturnType<typeof spyOn>,
+    expectedSpawnCount = 1
+  ): Promise<void> {
+    for (
+      let attempt = 0;
+      attempt < 20 && spawnSpy.mock.calls.length < expectedSpawnCount;
+      attempt++
+    ) {
+      await Promise.resolve();
+    }
+    expect(spawnSpy).toHaveBeenCalledTimes(expectedSpawnCount);
+    jest.advanceTimersByTime(500);
+    await commandPromise;
+  }
+
   beforeEach(() => {
+    jest.useFakeTimers();
     consoleSpy = spyOn(console, 'log').mockImplementation(() => {});
   });
 
   afterEach(() => {
+    jest.useRealTimers();
     consoleSpy.mockRestore();
   });
 
@@ -3037,10 +3075,8 @@ describe('workflowRunCommand — detach', () => {
     });
 
     const execBefore = (executeWorkflow as ReturnType<typeof mock>).mock.calls.length;
-    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue({
-      pid: 12345,
-      unref: mock(() => undefined),
-    } as unknown as ReturnType<typeof Bun.spawn>);
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
     const savedArgv = process.argv;
     process.argv = ['bun', '/abs/cli.ts', 'workflow', 'run', 'assist', 'hello', '--detach'];
 
@@ -3051,7 +3087,8 @@ describe('workflowRunCommand — detach', () => {
       | { cwd: string; cmd: string[]; detached?: boolean; windowsHide?: boolean }
       | undefined;
     try {
-      await workflowRunCommand('/test/path', 'assist', 'hello', { detach: true });
+      const commandPromise = workflowRunCommand('/test/path', 'assist', 'hello', { detach: true });
+      await finishStartupWindow(commandPromise, spawnSpy);
       spawnCallCount = spawnSpy.mock.calls.length;
       spawnOptions = spawnSpy.mock.calls[0]?.[0] as
         | { cwd: string; cmd: string[]; detached?: boolean; windowsHide?: boolean }
@@ -3080,6 +3117,7 @@ describe('workflowRunCommand — detach', () => {
     // executeWorkflow must NOT run in the detaching parent
     const execAfter = (executeWorkflow as ReturnType<typeof mock>).mock.calls.length;
     expect(execAfter).toBe(execBefore);
+    expect(child.unref).toHaveBeenCalledTimes(1);
     expect(consoleSpy).toHaveBeenCalledWith("Started 'assist' in the background.");
   });
 
@@ -3103,15 +3141,14 @@ describe('workflowRunCommand — detach', () => {
       kind: 'folder',
     });
 
-    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue({
-      pid: 12345,
-      unref: mock(() => undefined),
-    } as unknown as ReturnType<typeof Bun.spawn>);
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
     const savedArgv = process.argv;
     process.argv = ['bun', '/abs/cli.ts', 'workflow', 'run', 'assist', 'hello', '--detach'];
     let spawnCmd: string[] = [];
     try {
-      await workflowRunCommand('/test/path', 'assist', 'hello', { detach: true });
+      const commandPromise = workflowRunCommand('/test/path', 'assist', 'hello', { detach: true });
+      await finishStartupWindow(commandPromise, spawnSpy);
       spawnCmd = (
         (spawnSpy.mock.calls[0]?.[0] as { cmd: string[] } | undefined)?.cmd ?? []
       ).slice();
@@ -3135,10 +3172,8 @@ describe('workflowRunCommand — detach', () => {
     (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
       throw new Error('no home in test');
     });
-    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue({
-      pid: 12345,
-      unref: mock(() => undefined),
-    } as unknown as ReturnType<typeof Bun.spawn>);
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
     const savedArgv = process.argv;
     process.argv = [
       'bun',
@@ -3152,7 +3187,11 @@ describe('workflowRunCommand — detach', () => {
     ];
 
     try {
-      await workflowRunCommand('/test/path', 'assist', 'hello', { detach: true, json: true });
+      const commandPromise = workflowRunCommand('/test/path', 'assist', 'hello', {
+        detach: true,
+        json: true,
+      });
+      await finishStartupWindow(commandPromise, spawnSpy);
     } finally {
       process.argv = savedArgv;
       spawnSpy.mockRestore();
@@ -3161,6 +3200,110 @@ describe('workflowRunCommand — detach', () => {
     const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as Record<string, unknown>;
     expect(parsed).toMatchObject({ ok: true, action: 'run', detached: true, workflow: 'assist' });
     expect(typeof parsed.conversationId).toBe('string');
+  });
+
+  it('rejects an immediate non-zero child exit with the log tail and no success ack', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const paths = await import('@archon/paths');
+    const tempHome = mkdtempSync(join(tmpdir(), 'archon-detached-failure-'));
+    const conversationId = 'cli-detached-failure';
+    const logPath = join(tempHome, 'logs', `detached-run-${conversationId}.log`);
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'assist', description: 'Help' })],
+      errors: [],
+    });
+    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => tempHome);
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
+    const savedArgv = process.argv;
+    process.argv = ['bun', '/abs/cli.ts', 'workflow', 'run', 'assist', 'hello', '--detach'];
+
+    try {
+      const commandPromise = workflowRunCommand('/test/path', 'assist', 'hello', {
+        detach: true,
+        json: true,
+        conversationId,
+      });
+      for (let attempt = 0; attempt < 20 && spawnSpy.mock.calls.length === 0; attempt++) {
+        await Promise.resolve();
+      }
+      expect(spawnSpy).toHaveBeenCalledTimes(1);
+      appendFileSync(logPath, 'database unavailable during startup\n');
+      const spawnOptions = spawnSpy.mock.calls[0]?.[0] as
+        | {
+            onExit?: (
+              subprocess: ReturnType<typeof Bun.spawn>,
+              exitCode: number | null,
+              signalCode: number | null,
+              error?: Error
+            ) => void;
+          }
+        | undefined;
+      spawnOptions?.onExit?.(child.child, 1, null);
+
+      await expect(commandPromise).rejects.toThrow(
+        /exit code 1[\s\S]*database unavailable during startup/
+      );
+    } finally {
+      process.argv = savedArgv;
+      spawnSpy.mockRestore();
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+
+    expect(child.unref).not.toHaveBeenCalled();
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it('writes a delimiter for every invocation sharing a conversation id', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const paths = await import('@archon/paths');
+    const tempHome = mkdtempSync(join(tmpdir(), 'archon-detached-delimiters-'));
+    const conversationId = 'cli-shared-conversation';
+    const firstChild = createDetachedChildFixture();
+    const secondChild = createDetachedChildFixture();
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>)
+      .mockResolvedValueOnce({
+        workflows: [makeTestWorkflowWithSource({ name: 'assist', description: 'Help' })],
+        errors: [],
+      })
+      .mockResolvedValueOnce({
+        workflows: [makeTestWorkflowWithSource({ name: 'assist', description: 'Help' })],
+        errors: [],
+      });
+    (paths.getArchonHome as ReturnType<typeof mock>)
+      .mockImplementationOnce(() => tempHome)
+      .mockImplementationOnce(() => tempHome);
+    const spawnSpy = spyOn(Bun, 'spawn')
+      .mockReturnValueOnce(firstChild.child)
+      .mockReturnValueOnce(secondChild.child);
+    const savedArgv = process.argv;
+    process.argv = ['bun', '/abs/cli.ts', 'workflow', 'run', 'assist', 'hello', '--detach'];
+
+    try {
+      const firstRun = workflowRunCommand('/test/path', 'assist', 'hello', {
+        detach: true,
+        conversationId,
+      });
+      await finishStartupWindow(firstRun, spawnSpy);
+      const secondRun = workflowRunCommand('/test/path', 'assist', 'hello', {
+        detach: true,
+        conversationId,
+      });
+      await finishStartupWindow(secondRun, spawnSpy, 2);
+
+      const log = readFileSync(
+        join(tempHome, 'logs', `detached-run-${conversationId}.log`),
+        'utf8'
+      );
+      const delimiters = log
+        .split('\n')
+        .filter(line => line.startsWith(`--- detached workflow invocation: ${conversationId} at `));
+      expect(delimiters).toHaveLength(2);
+    } finally {
+      process.argv = savedArgv;
+      spawnSpy.mockRestore();
+      rmSync(tempHome, { recursive: true, force: true });
+    }
   });
 
   it('throws (no false success ack) when the detached child fails to spawn', async () => {
@@ -3175,10 +3318,8 @@ describe('workflowRunCommand — detach', () => {
     });
     // Node's spawn does not throw synchronously on a bad executable — the only
     // synchronous failure signal is an undefined pid.
-    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue({
-      pid: undefined,
-      unref: mock(() => undefined),
-    } as unknown as ReturnType<typeof Bun.spawn>);
+    const child = createDetachedChildFixture(null);
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
     const savedArgv = process.argv;
     process.argv = ['bun', '/abs/cli.ts', 'workflow', 'run', 'assist', 'hello', '--detach'];
 

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -274,24 +274,6 @@ function generateConversationId(): string {
 }
 
 /**
- * Re-invoke `archon workflow run` (minus --detach/--json) as a detached
- * background child so the caller's shell returns immediately. Reconstructs the
- * current argv, drops `--detach` (the child runs in the foreground) and `--json`
- * (the parent already emitted the ack; the child should log normally to its log
- * file, not run silent), pins `--cwd` (absolute) plus any caller-supplied extra
- * flags (a generated branch / conversation id), then detaches via `unref()`.
- *
- * `dispatchBackgroundWorkflow` is deliberately NOT reused here: it is web-
- * adapter-coupled and its fire-and-forget dies with the CLI process. The
- * re-invoke is the only mechanism that survives parent exit.
- *
- * Child stdout/stderr are redirected to a per-conversation log file under
- * ARCHON_HOME/logs so a child that fails BEFORE creating a run record (e.g. DB
- * unreachable, missing worktree) leaves a trail instead of failing silently.
- * Falls back to discarding output only if the log file cannot be opened.
- * Returns the log path (or null when discarded) so the caller can surface it.
- */
-/**
  * Build the argv for the detached re-invoke. Pure (no spawn / no process reads)
  * so both the dev (bun + entry script) and compiled-binary (execPath only)
  * branches are unit-testable — the binary branch is otherwise unreachable in

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -36,8 +36,8 @@ import {
   markTierNoticeShown,
 } from '@archon/paths';
 import { join } from 'node:path';
-import { mkdirSync, openSync, closeSync } from 'node:fs';
-import { spawn } from 'node:child_process';
+import { mkdirSync, openSync, closeSync, readFileSync, writeSync } from 'node:fs';
+import { spawn, type ChildProcess } from 'node:child_process';
 import { createWorkflowDeps } from '@archon/core/workflows/store-adapter';
 import { discoverWorkflowsWithConfig } from '@archon/workflows/workflow-discovery';
 import { resolveWorkflowName } from '@archon/workflows/router';
@@ -80,6 +80,71 @@ let cachedLog: ReturnType<typeof createLogger> | undefined;
 function getLog(): ReturnType<typeof createLogger> {
   if (!cachedLog) cachedLog = createLogger('cli.workflow');
   return cachedLog;
+}
+
+const DETACHED_STARTUP_WINDOW_MS = 500;
+const DETACHED_LOG_TAIL_MAX_CHARS = 4_000;
+const DETACHED_LOG_TAIL_MAX_LINES = 40;
+
+function readDetachedLogTail(path: string): string | null {
+  try {
+    const content = readFileSync(path, 'utf8');
+    const lines = content.slice(-DETACHED_LOG_TAIL_MAX_CHARS).split('\n');
+    const tail = lines.slice(-DETACHED_LOG_TAIL_MAX_LINES).join('\n').trim();
+    return tail.length > 0 ? tail : null;
+  } catch {
+    return null;
+  }
+}
+
+function detachedStartupExitError(
+  code: number | null,
+  signal: NodeJS.Signals | null,
+  logPath: string | null
+): Error {
+  const reason = code === null ? `signal ${signal ?? 'unknown'}` : `exit code ${String(code)}`;
+  const tail = logPath ? readDetachedLogTail(logPath) : null;
+  const diagnostic = tail ? `\n\nChild output (${logPath}):\n${tail}` : '';
+  return new Error(`Detached workflow child exited during startup with ${reason}.${diagnostic}`);
+}
+
+async function waitForDetachedStartup(
+  child: ChildProcess,
+  logPath: string | null,
+  execPath: string,
+  conversationId: string
+): Promise<void> {
+  const outcome = await new Promise<'completed' | 'survived'>((resolve, reject) => {
+    const cleanup = (): void => {
+      clearTimeout(timer);
+      child.off('exit', onExit);
+      child.off('error', onStartupError);
+    };
+    const settle = (result: 'completed' | 'survived' | Error): void => {
+      cleanup();
+      if (result instanceof Error) reject(result);
+      else resolve(result);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
+      if (code === 0) settle('completed');
+      else settle(detachedStartupExitError(code, signal, logPath));
+    };
+    const onStartupError = (error: Error): void => {
+      settle(error);
+    };
+    const timer = setTimeout(() => {
+      settle('survived');
+    }, DETACHED_STARTUP_WINDOW_MS);
+
+    child.once('exit', onExit);
+    child.once('error', onStartupError);
+  });
+
+  if (outcome === 'survived') child.unref();
+  getLog().debug(
+    { execPath, conversationId, outcome, startupWindowMs: DETACHED_STARTUP_WINDOW_MS },
+    'cli.detached_run_startup_acknowledged'
+  );
 }
 
 /**
@@ -257,11 +322,11 @@ export function buildDetachedRunCmd(
   return [...baseCmd, ...userArgs, '--cwd', cwd, ...extraArgs];
 }
 
-function spawnDetachedWorkflowRun(
+async function spawnDetachedWorkflowRun(
   cwd: string,
   conversationId: string,
   extraArgs: string[]
-): string | null {
+): Promise<string | null> {
   const cmd = buildDetachedRunCmd(
     BUNDLED_IS_BINARY,
     process.execPath,
@@ -277,7 +342,18 @@ function spawnDetachedWorkflowRun(
     mkdirSync(logDir, { recursive: true });
     logPath = join(logDir, `detached-run-${conversationId}.log`);
     logFd = openSync(logPath, 'a');
+    writeSync(
+      logFd,
+      `\n--- detached workflow invocation: ${conversationId} at ${new Date().toISOString()} ---\n`
+    );
   } catch (error) {
+    if (logFd !== undefined) {
+      try {
+        closeSync(logFd);
+      } catch {
+        /* fd already closed/invalid — nothing to clean up */
+      }
+    }
     getLog().warn({ err: error as Error }, 'cli.detached_run_log_open_failed');
     logPath = null;
     logFd = undefined;
@@ -312,7 +388,7 @@ function spawnDetachedWorkflowRun(
     if (child.pid === undefined) {
       throw new Error(`Failed to start detached workflow child (executable: ${cmd[0]})`);
     }
-    child.unref();
+    await waitForDetachedStartup(child, logPath, cmd[0], conversationId);
   } finally {
     // The child inherits its own dup of the log fd; close the parent's copy so a
     // synchronous spawn failure (bad execPath, invalid cwd) doesn't leak it.
@@ -911,7 +987,7 @@ export async function workflowRunCommand(
       extraArgs.push('--conversation-id', childConversationId);
     }
 
-    const logPath = spawnDetachedWorkflowRun(cwd, childConversationId, extraArgs);
+    const logPath = await spawnDetachedWorkflowRun(cwd, childConversationId, extraArgs);
 
     if (options.json) {
       console.log(


### PR DESCRIPTION
## Summary

- Problem: `archon workflow run --detach` acknowledged success as soon as it received a child PID, even if that child exited immediately with an error.
- Why it matters: users could be told a background workflow had started when no workflow run was created, and shared detached logs lacked an invocation boundary.
- What changed: the CLI now observes a bounded startup window, reports immediate non-zero exits with a bounded log tail, and writes a timestamped delimiter for each detached invocation; deterministic lifecycle tests cover these paths.
- What did **not** change (scope boundary): detached execution remains asynchronous after the startup acknowledgement; no database-ready handshake, workflow-state mutation, provider behavior, or command-line flags were added.

## UX Journey

### Before

```
  User                    Archon CLI                 Detached child / log
  ────                    ──────────                 ────────────────────
  run --detach ─────────▶ spawns child ────────────▶ starts or exits
                          sees PID
  sees success ◀───────── prints acknowledgement      may fail immediately
                                                       appends output without boundary
```

### After

```
  User                    Archon CLI                 Detached child / log
  ────                    ──────────                 ────────────────────
  run --detach ─────────▶ writes [invocation delimiter]
                          spawns child ────────────▶ starts or exits
                          [waits up to 500 ms]
  sees success ◀───────── [child survives / exits 0]
  sees error + log tail ◀ [immediate non-zero exit]
```

## Architecture Diagram

### Before

```
  workflowRunCommand ──▶ spawnDetachedWorkflowRun ──▶ child process
                                  │                         │
                                  └──────────────────────▶ per-conversation log
  child process ──▶ executeWorkflow ──▶ workflow_runs store
```

### After

```
  [~ workflowRunCommand] ──▶ [~ spawnDetachedWorkflowRun] ──▶ child process
                                      │            │                  │
                                      │            └── [startup exit] ┘
                                      └──────────────▶ [~ per-conversation log]
  child process ──▶ executeWorkflow ──▶ workflow_runs store
  workflow.test ──▶ [~ spawnDetachedWorkflowRun behavior]
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `workflowRunCommand` | `spawnDetachedWorkflowRun` | **modified** | Await the startup acknowledgement before emitting success. |
| `spawnDetachedWorkflowRun` | child process | **modified** | Observe early `exit`/`error` events during the bounded startup window. |
| `spawnDetachedWorkflowRun` | detached log | **modified** | Add invocation delimiter and read a bounded tail on startup failure. |
| child process | `executeWorkflow` | unchanged | The child retains the normal foreground workflow execution path. |
| `executeWorkflow` | workflow run store | unchanged | Run persistence remains child-owned and occurs after startup. |
| `workflow.test` | CLI detached-run helper | **modified** | Deterministic child lifecycle and log coverage. |

## Label Snapshot

- Risk: `risk: medium`
- Size: `size: M`
- Scope: `cli`, `tests`
- Module: `cli:workflow`

## Change Metadata

- Change type: `bug`
- Primary scope: `cli`

## Linked Issue

- Closes #2279
- Related #: None
- Depends on # (if stacked): None
- Supersedes # (if replacing older PR): None

## Validation Evidence (required)

Commands and result summary:

```bash
bun test packages/cli/src/commands/workflow.test.ts  # 190 passed
bun run type-check                                  # passed
bun run lint                                        # passed, zero warnings
bun run format:check                                # passed
bun run validate                                    # passed
```

- Evidence provided (test/log/trace/screenshot): implementation and validation artifacts record focused lifecycle coverage plus a successful full validation run.
- If any command is intentionally skipped, explain why: real detached workflows were not manually launched because they may invoke an AI provider; deterministic tests cover immediate failure, healthy acknowledgement, log tails, delimiters, and undefined PIDs without external side effects.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation: Not applicable.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: Not applicable.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: deterministic focused tests exercise immediate non-zero child exit, normal startup survival, exit code/log-tail diagnostics, repeated-log delimiters, and the undefined-PID regression path.
- Edge cases checked: early zero exit remains a valid acknowledgement; unreadable logs do not mask the startup error; child output routing and Windows-safe detached options remain unchanged.
- What was not verified: a live detached workflow with an actual AI provider was intentionally not launched.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: CLI detached `workflow run` acknowledgement and its per-conversation diagnostic log.
- Potential unintended effects: successful detached commands wait up to the bounded startup window before acknowledgement; early zero exits still acknowledge normally.
- Guardrails/monitoring for early detection: immediate startup failures now surface the child exit code and a bounded log tail; invocation delimiters make retained logs attributable to a single launch.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `4c33764f`.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: detached runs wait briefly before acknowledgement or surface a startup error; reverting restores the prior PID-only acknowledgement.

## Risks and Mitigations

- Risk: the startup window could slightly delay acknowledgement for healthy detached workflows.
  - Mitigation: it is bounded to 500 ms and the child is unreferenced only after it survives that window.
- Risk: a shared conversation log could be unavailable during a failure.
  - Mitigation: log-tail reading is defensive and preserves the original exit-code error when the log cannot be read.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detached workflow execution reliability by validating startup before completion is reported.
  - Added clearer error messages when detached workflows exit early, including recent log output.
  - Ensured workflow logs are safely finalized when startup encounters an error.
  - Improved handling of multiple detached workflow invocations by keeping log entries clearly separated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->