### PR TITLE
Fix PowerShell installer exit handling

### DIFF
--- a/packages/docs-web/public/install.ps1
+++ b/packages/docs-web/public/install.ps1
@@ -284,6 +284,11 @@ function Main {
         Write-Info "Verifying installation..."
         try {
             $versionOutput = & $destBinary version 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                Write-Err "Installed binary failed its version check (exit $LASTEXITCODE):"
+                Write-Host $versionOutput
+                exit 1
+            }
             Write-Host $versionOutput
             Write-Ok "Installation complete!"
         } catch {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -284,6 +284,11 @@ function Main {
         Write-Info "Verifying installation..."
         try {
             $versionOutput = & $destBinary version 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                Write-Err "Installed binary failed its version check (exit $LASTEXITCODE):"
+                Write-Host $versionOutput
+                exit 1
+            }
             Write-Host $versionOutput
             Write-Ok "Installation complete!"
         } catch {

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -20,6 +20,24 @@ assert_equals() {
   [ "$expected" = "$actual" ] || fail "$description: expected $expected, got $actual"
 }
 
+assert_powershell_version_guard() {
+  local powershell_installer="$1"
+
+  awk '
+    /# --- Verify installation ---/ { in_verification = 1; next }
+    /# --- Getting started ---/ { exit }
+    !in_verification { next }
+    /\$versionOutput = & \$destBinary version 2>&1/ { invoked = 1; next }
+    invoked && /if \(\$LASTEXITCODE -ne 0\)/ { guarded = 1; next }
+    guarded && /exit 1/ { exits_on_failure = 1; next }
+    exits_on_failure && /Write-Ok "Installation complete!"/ { reports_success = 1 }
+    END {
+      exit !(invoked && guarded && exits_on_failure && reports_success)
+    }
+  ' "$powershell_installer" \
+    || fail "PowerShell installer must fail a non-zero version check before reporting success"
+}
+
 make_platform_mocks() {
   local os="$1"
   local arch="$2"
@@ -90,6 +108,7 @@ cmp -s "$installer" "$repo_root/packages/docs-web/public/install" \
 # PATH-corrupting installer to Windows users while the repo copy was fixed. #2339.
 cmp -s "$repo_root/scripts/install.ps1" "$repo_root/packages/docs-web/public/install.ps1" \
   || fail "public install.ps1 mirror differs from scripts/install.ps1"
+assert_powershell_version_guard "$repo_root/scripts/install.ps1"
 
 mock_dir="$tmp_dir/install-mocks"
 install_dir="$tmp_dir/install-bin"


### PR DESCRIPTION
## Summary

- Problem: The PowerShell installer announced success after `archon.exe version` exited non-zero.
- Why it matters: Windows users could receive a broken executable while being told installation completed.
- What changed: Both canonical and published PowerShell installers now report the captured output and exit 1 before the success message when `$LASTEXITCODE` is non-zero.
- What did **not** change (scope boundary): Download, checksum, copy, PATH, release selection, documentation, and pre-copy/rollback behavior are unchanged.

## UX Journey

### Before

```
Windows user             install.ps1                 archon.exe
────────────             ───────────                 ──────────
runs installer ───────▶ copies binary
                           runs `version` ─────────▶ exits 1 with diagnostic
                           prints diagnostic
sees success ◀────────── prints "Installation complete!" [incorrect]
```

### After

```
Windows user             install.ps1                 archon.exe
────────────             ───────────                 ──────────
runs installer ───────▶ copies binary
                           runs `version` ─────────▶ exits 1 with diagnostic
sees failure ◀────────── [prints error and diagnostic; exits 1]
                           [does not print "Installation complete!"]
```

## Architecture Diagram

### Before

```
scripts/install.ps1 ──copies to──▶ installed archon.exe
scripts/install.ps1 ──invokes version──▶ installed archon.exe
scripts/install.ps1 ──mirrored by──▶ packages/docs-web/public/install.ps1
packages/docs-web/public/install.ps1 ──served as──▶ archon.diy/install.ps1
```

### After

```
[~] scripts/install.ps1 ──copies to──▶ installed archon.exe
[~] scripts/install.ps1 ──invokes version; checks $LASTEXITCODE──▶ installed archon.exe
[~] scripts/install.ps1 ──mirrored by──▶ [~] packages/docs-web/public/install.ps1
[~] packages/docs-web/public/install.ps1 ──served as──▶ archon.diy/install.ps1
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `scripts/install.ps1` | installed `archon.exe` | **modified** | Native version result is now checked. |
| `scripts/install.ps1` | `packages/docs-web/public/install.ps1` | unchanged | Mirror remains byte-identical. |
| `packages/docs-web/public/install.ps1` | `archon.diy/install.ps1` | unchanged | Published installer payload. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `cli`
- Module: `cli:installers`

## Change Metadata

- Change type: `bug`
- Primary scope: `cli`

## Linked Issue

- Closes #2344
- Related #2340
- Depends on # N/A
- Supersedes # N/A

## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check
bun run lint
bun run format:check
bun run test
bun run validate
```

- Evidence provided (test/log/trace/screenshot): The implementation artifacts record passing type check, lint (zero warnings), format check, workspace tests, build, installer parity test, and full `bun run validate`.
- If any command is intentionally skipped, explain why: Native PowerShell failing- and successful-binary scenarios were not run because this macOS workspace has no PowerShell or Windows host.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation: N/A.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: N/A.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Reviewed the installed-binary verification path and confirmed both installer copies contain the identical non-zero-exit guard; existing parity validation passed.
- Edge cases checked: A non-zero native exit prints captured diagnostic output and terminates before the success message; the existing exception path remains unchanged.
- What was not verified: Runtime behavior on a Windows/PowerShell host with controlled failing and successful binary stubs.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Windows PowerShell installation and the publicly served `install.ps1` mirror.
- Potential unintended effects: A previously ignored broken binary now makes the installer fail after it has been copied.
- Guardrails/monitoring for early detection: Existing `bun run test:install` mirror-parity coverage and full validation; installer output explicitly includes the failing exit code and captured diagnostic.

## Rollback Plan (required)

- Fast rollback command/path: Revert commit `06c758e8` with `git revert 06c758e8`.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: Windows installer exits 1 after the version check and omits `Installation complete!` when the installed binary exits non-zero.

## Risks and Mitigations

- Risk: PowerShell native-exit behavior was not executed on Windows in this workspace.
  - Mitigation: The fix uses `$LASTEXITCODE` immediately after the native invocation, preserves captured output and existing exception handling, updates both byte-identical installer copies, and passed repository validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Installation verification now detects failed version checks and reports the captured output instead of incorrectly indicating success.
  * Successful installations continue to display the installed version and completion message.

* **Tests**
  * Added coverage to verify both successful and failed installation checks, including correct reporting order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->