### PR TITLE
Expose verbose workflow node summaries

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -3,7 +3,9 @@
  */
 import { describe, it, expect, beforeEach, afterEach, spyOn, mock } from 'bun:test';
 import type { WorkflowEmitterEvent } from '@archon/workflows/event-emitter';
+import type { WorkflowEventRow } from '@archon/core';
 import { makeTestWorkflow, makeTestWorkflowWithSource } from '@archon/workflows/test-utils';
+import type { NodeSummary } from './workflow';
 import {
   workflowListCommand,
   workflowRunCommand,
@@ -2433,6 +2435,82 @@ describe('workflowRunCommand', () => {
   });
 });
 
+const VERBOSE_NODE_EVENTS = [
+  {
+    id: 'event-completed-start',
+    workflow_run_id: 'run-node-parity',
+    event_type: 'node_started',
+    step_name: 'completed-node',
+    step_index: 0,
+    data: {},
+    created_at: '2026-08-03T08:00:00.000Z',
+  },
+  {
+    id: 'event-completed-end',
+    workflow_run_id: 'run-node-parity',
+    event_type: 'node_completed',
+    step_name: 'completed-node',
+    step_index: 0,
+    data: { node_output: 'completed output' },
+    created_at: '2026-08-03T08:00:01.000Z',
+  },
+  {
+    id: 'event-failed',
+    workflow_run_id: 'run-node-parity',
+    event_type: 'node_failed',
+    step_name: 'failed-node',
+    step_index: 1,
+    data: { error: 'planned failure' },
+    created_at: '2026-08-03T08:00:02.000Z',
+  },
+  {
+    id: 'event-running',
+    workflow_run_id: 'run-node-parity',
+    event_type: 'node_started',
+    step_name: 'running-node',
+    step_index: 2,
+    data: {},
+    created_at: '2026-08-03T08:00:03.000Z',
+  },
+  {
+    id: 'event-skipped',
+    workflow_run_id: 'run-node-parity',
+    event_type: 'node_skipped',
+    step_name: 'skipped-node',
+    step_index: 3,
+    data: {},
+    created_at: '2026-08-03T08:00:04.000Z',
+  },
+  {
+    id: 'event-prior-success',
+    workflow_run_id: 'run-node-parity',
+    event_type: 'node_skipped_prior_success',
+    step_name: 'prior-success-node',
+    step_index: 4,
+    data: {},
+    created_at: '2026-08-03T08:00:05.000Z',
+  },
+] satisfies WorkflowEventRow[];
+
+function extractTextNodeStates(calls: unknown[][]): Array<Pick<NodeSummary, 'nodeId' | 'state'>> {
+  const statesByGlyph: Record<string, NodeSummary['state']> = {
+    '✓': 'completed',
+    '✗': 'failed',
+    '◌': 'running',
+    '-': 'skipped',
+  };
+  const states: Array<Pick<NodeSummary, 'nodeId' | 'state'>> = [];
+
+  for (const call of calls) {
+    const match = /^ {4}(✓|✗|◌|-) (\S+)/.exec(String(call[0]));
+    if (!match) continue;
+    const state = statesByGlyph[match[1]];
+    if (state) states.push({ nodeId: match[2], state });
+  }
+
+  return states;
+}
+
 describe('workflowStatusCommand', () => {
   let consoleSpy: ReturnType<typeof spyOn>;
 
@@ -2593,37 +2671,73 @@ describe('workflowStatusCommand', () => {
     expect(calls.some(c => c.includes('Nodes:'))).toBe(false);
   });
 
-  it('should include events in JSON verbose output', async () => {
+  it('should include events and text-equivalent node states in JSON verbose output', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
     const workflowEventsDb = await import('@archon/core/db/workflow-events');
 
+    const run = {
+      id: 'run-node-parity',
+      workflow_name: 'implement',
+      working_path: '/path/to/worktree',
+      status: 'running',
+      started_at: new Date(),
+    };
+    (workflowDb.listWorkflowRuns as ReturnType<typeof mock>)
+      .mockResolvedValueOnce([run])
+      .mockResolvedValueOnce([run]);
+    (workflowEventsDb.listWorkflowEvents as ReturnType<typeof mock>)
+      .mockResolvedValueOnce(VERBOSE_NODE_EVENTS)
+      .mockResolvedValueOnce(VERBOSE_NODE_EVENTS);
+
+    await workflowStatusCommand(false, true);
+    const textStates = extractTextNodeStates(consoleSpy.mock.calls as unknown[][]);
+    expect(textStates).toEqual([
+      { nodeId: 'completed-node', state: 'completed' },
+      { nodeId: 'failed-node', state: 'failed' },
+      { nodeId: 'running-node', state: 'running' },
+      { nodeId: 'skipped-node', state: 'skipped' },
+      { nodeId: 'prior-success-node', state: 'skipped' },
+    ]);
+
+    consoleSpy.mockClear();
+
+    await workflowStatusCommand(true, true);
+
+    const jsonOutput = consoleSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(jsonOutput) as {
+      runs: Array<{ events: unknown[]; nodes: NodeSummary[] }>;
+    };
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(parsed.runs[0].events).toHaveLength(VERBOSE_NODE_EVENTS.length);
+    expect(parsed.runs[0].nodes.map(({ nodeId, state }) => ({ nodeId, state }))).toEqual(
+      textStates
+    );
+  });
+
+  it('should emit empty events and nodes when verbose JSON event retrieval fails', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const workflowEventsDb = await import('@archon/core/db/workflow-events');
     (workflowDb.listWorkflowRuns as ReturnType<typeof mock>).mockResolvedValueOnce([
       {
-        id: 'run-json',
+        id: 'run-events-unavailable',
         workflow_name: 'implement',
         working_path: '/path/to/worktree',
         status: 'running',
         started_at: new Date(),
       },
     ]);
-    const fakeEvent = {
-      id: 'ev1',
-      workflow_run_id: 'run-json',
-      event_type: 'node_started',
-      step_name: 'plan',
-      step_index: null,
-      data: {},
-      created_at: new Date().toISOString(),
-    };
-    (workflowEventsDb.listWorkflowEvents as ReturnType<typeof mock>).mockResolvedValueOnce([
-      fakeEvent,
-    ]);
+    (workflowEventsDb.listWorkflowEvents as ReturnType<typeof mock>).mockRejectedValueOnce(
+      new Error('events unavailable')
+    );
 
     await workflowStatusCommand(true, true);
 
-    const jsonOutput = consoleSpy.mock.calls[0]?.[0] as string;
-    const parsed = JSON.parse(jsonOutput) as { runs: Array<{ events: unknown[] }> };
-    expect(parsed.runs[0].events).toHaveLength(1);
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(consoleSpy.mock.calls[0]?.[0] as string) as {
+      runs: Array<{ events: unknown[]; nodes: NodeSummary[] }>;
+    };
+    expect(parsed.runs[0].events).toEqual([]);
+    expect(parsed.runs[0].nodes).toEqual([]);
   });
 });
 
@@ -2731,6 +2845,7 @@ describe('workflowGetCommand', () => {
     };
     expect(parsed.id).toBe('run-json');
     expect(parsed.status).toBe('completed');
+    expect('nodes' in parsed).toBe(false);
     expect(code).toBe(0);
   });
 
@@ -2792,31 +2907,38 @@ describe('workflowGetCommand', () => {
     );
   });
 
-  it('attaches events in verbose JSON mode', async () => {
+  it('attaches events and text-equivalent node states in verbose JSON mode', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
     const eventsDb = await import('@archon/core/db/workflow-events');
-    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
-      id: 'run-v',
+    const run = {
+      id: 'run-node-parity',
       workflow_name: 'implement',
       status: 'running',
       working_path: '/tmp/wt',
       started_at: new Date(),
       metadata: {},
-    });
-    (eventsDb.listWorkflowEvents as ReturnType<typeof mock>).mockResolvedValueOnce([
-      {
-        event_type: 'node_started',
-        step_name: 'plan',
-        created_at: new Date().toISOString(),
-        data: {},
-      },
-    ]);
+    };
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>)
+      .mockResolvedValueOnce(run)
+      .mockResolvedValueOnce(run);
+    (eventsDb.listWorkflowEvents as ReturnType<typeof mock>)
+      .mockResolvedValueOnce(VERBOSE_NODE_EVENTS)
+      .mockResolvedValueOnce(VERBOSE_NODE_EVENTS);
 
-    await workflowGetCommand('run-v', true, true);
+    await workflowGetCommand('run-node-parity', false, true);
+    const textStates = extractTextNodeStates(consoleSpy.mock.calls as unknown[][]);
 
-    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as { events: unknown[] };
-    expect(Array.isArray(parsed.events)).toBe(true);
-    expect(parsed.events).toHaveLength(1);
+    consoleSpy.mockClear();
+
+    await workflowGetCommand('run-node-parity', true, true);
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as {
+      events: unknown[];
+      nodes: NodeSummary[];
+    };
+    expect(parsed.events).toHaveLength(VERBOSE_NODE_EVENTS.length);
+    expect(parsed.nodes.map(({ nodeId, state }) => ({ nodeId, state }))).toEqual(textStates);
   });
 });
 

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -2940,6 +2940,32 @@ describe('workflowGetCommand', () => {
     expect(parsed.events).toHaveLength(VERBOSE_NODE_EVENTS.length);
     expect(parsed.nodes.map(({ nodeId, state }) => ({ nodeId, state }))).toEqual(textStates);
   });
+
+  it('emits empty events and nodes when verbose JSON event retrieval fails', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const eventsDb = await import('@archon/core/db/workflow-events');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'run-events-unavailable',
+      workflow_name: 'implement',
+      status: 'running',
+      working_path: '/tmp/wt',
+      started_at: new Date(),
+      metadata: {},
+    });
+    (eventsDb.listWorkflowEvents as ReturnType<typeof mock>).mockRejectedValueOnce(
+      new Error('events unavailable')
+    );
+
+    await workflowGetCommand('run-events-unavailable', true, true);
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string) as {
+      events: unknown[];
+      nodes: NodeSummary[];
+    };
+    expect(parsed.events).toEqual([]);
+    expect(parsed.nodes).toEqual([]);
+  });
 });
 
 describe('run-id prefix resolution (short ids from `workflow runs`)', () => {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1925,7 +1925,7 @@ function formatDuration(ms: number): string {
   return `${mins}m${remSecs}s`;
 }
 
-interface NodeSummary {
+export interface NodeSummary {
   nodeId: string;
   state: 'running' | 'completed' | 'failed' | 'skipped';
   durationMs?: number;
@@ -1937,7 +1937,7 @@ interface NodeSummary {
  * Derive per-node summaries from a run's workflow events.
  * Processes node_started / node_completed / node_failed / node_skipped* events.
  */
-function buildNodeSummaries(events: WorkflowEventRow[]): NodeSummary[] {
+export function buildNodeSummaries(events: WorkflowEventRow[]): NodeSummary[] {
   const startTimes = new Map<string, number>();
   const summaries = new Map<string, NodeSummary>();
 
@@ -2060,7 +2060,11 @@ export async function workflowStatusCommand(json?: boolean, verbose?: boolean): 
           workflowEventsDb.listWorkflowEvents(run.id).catch(() => [] as WorkflowEventRow[])
         )
       );
-      runsOutput = runs.map((run, i) => ({ ...run, events: eventsPerRun[i] }));
+      runsOutput = runs.map((run, i) => ({
+        ...run,
+        events: eventsPerRun[i],
+        nodes: buildNodeSummaries(eventsPerRun[i]),
+      }));
     }
     console.log(JSON.stringify({ runs: runsOutput }, null, 2));
     return;
@@ -2098,7 +2102,7 @@ export async function workflowStatusCommand(json?: boolean, verbose?: boolean): 
  * Unlike `status` (active runs only), this resolves one run regardless of
  * status — so an agent can answer "did the review pass?" for a completed/failed
  * run. `--verbose` adds the per-node event summary; `--json` emits the raw run
- * (plus an `events` array when verbose).
+ * (plus `events` and `nodes` arrays when verbose).
  *
  * `runId` may be the short id printed by `workflow runs` (see resolveRunIdArg).
  */
@@ -2146,7 +2150,9 @@ export async function workflowGetCommand(
   }
 
   if (json) {
-    const output = verbose ? { ...run, events: events ?? [] } : run;
+    const output = verbose
+      ? { ...run, events: events ?? [], nodes: buildNodeSummaries(events ?? []) }
+      : run;
     console.log(JSON.stringify(output, null, 2));
     return 0;
   }

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -377,7 +377,11 @@ interface CodexStreamState {
 function getMcpToolName(item: Record<string, unknown>): string {
   const server = item.server as string | undefined;
   const tool = item.tool as string | undefined;
-  const toolInfo = server && tool ? `${server}/${tool}` : (tool ?? server ?? 'MCP tool');
+  if (server && tool) {
+    return `🔌 MCP: ${server}/${tool}`;
+  }
+
+  const toolInfo = tool ?? server ?? 'MCP tool';
   return `🔌 MCP: ${toolInfo}`;
 }
 


### PR DESCRIPTION
## Summary

- Problem: verbose workflow JSON exposed raw event history but not the node-state fold shown in verbose text.
- Why it matters: automation had to reimplement event reduction, risking drift from the CLI's human-visible state.
- What changed: `workflow status --json --verbose` and `workflow get --json --verbose` now include `nodes` alongside retained `events`, using the shared node-summary fold; parity tests cover completed, failed, running, skipped, and prior-success nodes.
- What did **not** change (scope boundary): non-verbose JSON and text output, event storage/querying, node-fold semantics, and command flags remain unchanged.

## UX Journey

### Before

```
Automation              Archon CLI                 Workflow events
──────────              ──────────                 ───────────────
status/get --json --verbose ──▶ returns raw events ──▶ consumer folds states itself
```

### After

```
Automation              Archon CLI                 Workflow events
──────────              ──────────                 ───────────────
status/get --json --verbose ──▶ returns [events + nodes] ◀── shared fold
                                  │
                                  └──▶ consumer reads node states directly
```

## Architecture Diagram

### Before

```
workflow-events DB ──▶ workflow.ts ──▶ verbose text: buildNodeSummaries ──▶ Nodes block
                              └──────▶ verbose JSON ───────────────────────▶ events only
workflow.test.ts ───────────────────────────────────────────────────────────▶ command coverage
```

### After

```
workflow-events DB ──▶ [~ workflow.ts] ──▶ verbose text: buildNodeSummaries ──▶ Nodes block
                                   └──────▶ verbose JSON: events + nodes ───────▶ automation
                                           === shared buildNodeSummaries fold
[~ workflow.test.ts] ────────────────────────────────────────────────────────▶ text/JSON parity coverage
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| workflow event database | `workflow.ts` | unchanged | Existing ordered event retrieval. |
| `workflow.ts` | verbose text renderer | unchanged | Continues to use the shared node-summary fold. |
| `workflow.ts` | verbose JSON output | **modified** | Adds folded `nodes` while retaining raw `events`. |
| `workflow.test.ts` | workflow commands | **modified** | Verifies JSON node states match text output. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `cli`
- Module: `cli:workflow`

## Change Metadata

- Change type: `feature`
- Primary scope: `cli`

## Linked Issue

- Closes #2359
- Related #2365 (decision context reviewed during implementation)
- Depends on # N/A
- Supersedes # N/A

## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check
bun run lint
bun run format:check
bun run test
bun run build
```

- Evidence provided (test/log/trace/screenshot): all listed commands passed; the targeted workflow command tests passed with 197 tests, and a live `workflow status --json --verbose` smoke check produced parseable `events` and `nodes` output.
- If any command is intentionally skipped, explain why: none.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation: not applicable.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: not applicable.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: status and get verbose JSON include raw events and folded node summaries; summary states match the existing verbose-text renderer.
- Edge cases checked: completed, failed, running, skipped, and `node_skipped_prior_success` events; event-fetch failure returns empty `events` and `nodes` arrays.
- What was not verified: no external integrations are affected by this CLI-only additive field.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `@archon/cli` workflow `status` and `get` commands when both `--json` and `--verbose` are selected.
- Potential unintended effects: consumers that strictly validate verbose JSON object shapes must tolerate the additive `nodes` field.
- Guardrails/monitoring for early detection: focused text-to-JSON parity tests retain the shared fold as the single source of truth.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `60894c61`.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: verbose JSON consumers reject the additive `nodes` field or receive summaries inconsistent with raw events.

## Risks and Mitigations

- Risk: JSON and text node state could diverge in a future change.
  - Mitigation: both paths call the same exported summary builder and tests compare their state projections.
