### PR TITLE
chore(docs): forward-port #2155 from main to dev

### DIFF
--- a/packages/docs-web/src/content/docs/docs.mdx
+++ b/packages/docs-web/src/content/docs/docs.mdx
@@ -70,6 +70,6 @@ Archon is a **workflow engine for AI coding agents**. Define multi-step developm
     Chain nodes into DAGs with dependencies, loops, and conditional logic
   </Card>
   <Card title="Multi-provider" icon="rocket">
-    Works with Claude Code SDK and Codex SDK
+    Works with Claude Code SDK, Codex SDK, and local models via Pi.
   </Card>
 </CardGrid>


### PR DESCRIPTION
Forward-port of `ae704a73` (#2155, Matt Chapman), which landed on `main` rather than `dev`.

**Why it's on main:** #2155 was opened against `main` — GitHub defaults new PRs to the repository's default branch, so a contributor using the web UI gets `main` unless they change it. I merged it without checking `baseRefName`, alongside four `dev`-based PRs in the same batch. My error.

**Decision:** leave `main` as-is and forward-port. The content is correct (Pi is a supported provider) and the docs deploy already ran, so reverting production docs to re-land identical wording through another branch would be ceremony rather than safety.

This restores `main`/`dev` parity for the file. Cherry-pick is clean, authorship preserved.

**Worth fixing separately:** every external contributor's PR defaults to `main`. That trap is set for them, not just for me — worth either changing the default branch or adding a base-branch check to CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Multi-provider” documentation to mention support for local models through Pi, alongside Claude Code SDK and Codex SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->