### PR TITLE
Record resolved workflow effort in node events

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -1309,6 +1309,11 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     const nodeConfig = optionsArg.nodeConfig as Record<string, unknown>;
     expect(assistantConfig.modelReasoningEffort).toBe('medium');
     expect(nodeConfig.effort).toBeUndefined();
+
+    const createEventCalls = (mockDeps.store.createWorkflowEvent as ReturnType<typeof mock>).mock
+      .calls as Array<[{ event_type: string; data?: Record<string, unknown> }]>;
+    const nodeStartedCall = createEventCalls.find(([arg]) => arg.event_type === 'node_started');
+    expect(nodeStartedCall?.[0].data?.effort).toBe('medium');
   });
 
   it('applies inherited workflow tier effort to nodes without model overrides', async () => {
@@ -1407,6 +1412,7 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     expect(nodeStartedCall).toBeDefined();
     expect(nodeStartedCall?.[0].data?.tier).toBe('large');
     expect(nodeStartedCall?.[0].data?.model).toBe('opus');
+    expect(nodeStartedCall?.[0].data?.effort).toBe('max');
   });
 
   it('surfaces the workflow-level tier on nodes that inherit the workflow model', async () => {
@@ -5648,7 +5654,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-model-run');
       const aiProfile = buildAiProfile('claude', {
-        repoTiers: { large: { provider: 'claude', model: 'opus' } },
+        repoTiers: { large: { provider: 'claude', model: 'opus', effort: 'max' } },
       });
 
       await executeDagWorkflow(
@@ -5695,6 +5701,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect(startedEvent?.[0].data?.provider).toBe('claude');
       expect(startedEvent?.[0].data?.model).toBe('opus');
       expect(startedEvent?.[0].data?.tier).toBe('large');
+      expect(startedEvent?.[0].data?.effort).toBe('max');
 
       const completedEvent = eventCalls.find(
         ([arg]) => arg.event_type === 'node_completed' && arg.step_name === 'my-loop'

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -938,6 +938,7 @@ async function resolveNodeProviderAndModel(
   model: string | undefined;
   options: SendQueryOptions | undefined;
   tier?: TierName;
+  effort?: string;
 }> {
   const configuredProvider: string = node.provider ?? workflowProvider;
   let provider: string = configuredProvider;
@@ -1128,6 +1129,9 @@ async function resolveNodeProviderAndModel(
     nodeConfig,
     assistantConfig
   );
+  const assistantEffort = assistantConfig.modelReasoningEffort;
+  const resolvedEffort: string | undefined =
+    nodeConfig.effort ?? (typeof assistantEffort === 'string' ? assistantEffort : undefined);
 
   const options: SendQueryOptions = {
     ...baseOptions,
@@ -1146,7 +1150,7 @@ async function resolveNodeProviderAndModel(
         ? workflowLevelOptions.workflowTier
         : undefined;
 
-  return { provider, model, options, tier };
+  return { provider, model, options, tier, effort: resolvedEffort };
 }
 
 /** Evaluate trigger rule for a node given its upstream states */
@@ -1257,6 +1261,7 @@ async function executeNodeInternal(
   issueContext?: string,
   resolvedModel?: string,
   resolvedTier?: TierName,
+  resolvedEffort?: string,
   stepNamePrefix = '',
   iteration?: number
 ): Promise<NodeExecutionResult> {
@@ -1285,6 +1290,7 @@ async function executeNodeInternal(
         provider,
         model: resolvedModel,
         tier: resolvedTier,
+        effort: resolvedEffort,
         ...iterationData,
       },
     })
@@ -1304,6 +1310,7 @@ async function executeNodeInternal(
     provider,
     model: resolvedModel,
     tier: resolvedTier,
+    effort: resolvedEffort,
   });
 
   // Load prompt
@@ -3941,7 +3948,8 @@ async function executeLoopNode(
   stepNamePrefix = '',
   execContext: ExecutionContext = { kind: 'host' },
   resolvedModel?: string,
-  resolvedTier?: TierName
+  resolvedTier?: TierName,
+  resolvedEffort?: string
 ): Promise<NodeExecutionResult> {
   const loop = node.loop;
   const msgContext = { workflowId: workflowRun.id, nodeName: node.id };
@@ -3977,6 +3985,7 @@ async function executeLoopNode(
         provider: workflowProvider,
         model: resolvedModel,
         tier: resolvedTier,
+        effort: resolvedEffort,
       },
     })
     .catch((err: Error) => {
@@ -3994,6 +4003,7 @@ async function executeLoopNode(
     provider: workflowProvider,
     model: resolvedModel,
     tier: resolvedTier,
+    effort: resolvedEffort,
   });
 
   /**
@@ -5154,6 +5164,7 @@ async function executeApprovalNode(
       model: resolvedNodeModel,
       options: nodeOptions,
       tier: resolvedTier,
+      effort: resolvedEffort,
     } = await resolveNodeProviderAndModel(
       syntheticNode,
       workflowProvider,
@@ -5188,6 +5199,7 @@ async function executeApprovalNode(
       issueContext,
       resolvedNodeModel,
       resolvedTier,
+      resolvedEffort,
       stepNamePrefix,
       iteration
     );
@@ -5923,6 +5935,7 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
               options: loopOptions,
               model: resolvedLoopModel,
               tier: resolvedLoopTier,
+              effort: resolvedLoopEffort,
             } = await resolveNodeProviderAndModel(
               node,
               workflowProvider,
@@ -5958,7 +5971,8 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
               stepNamePrefix,
               execContext,
               resolvedLoopModel,
-              resolvedLoopTier
+              resolvedLoopTier,
+              resolvedLoopEffort
             );
             // Loop nodes run every iteration on the same resolved provider, so the
             // result session (if any) is attributable to loopProvider — tag it so a
@@ -6125,6 +6139,7 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
             model: resolvedNodeModel,
             options: nodeOptions,
             tier: resolvedTier,
+            effort: resolvedEffort,
           } = await resolveNodeProviderAndModel(
             node,
             workflowProvider,
@@ -6270,6 +6285,7 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
                 issueContext,
                 resolvedNodeModel,
                 resolvedTier,
+                resolvedEffort,
                 stepNamePrefix,
                 iteration
               ),

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1129,6 +1129,16 @@ async function resolveNodeProviderAndModel(
     nodeConfig,
     assistantConfig
   );
+  // Read POST-routing values only. applyPresetOptions -> routePresetEffort has
+  // already placed effort where the provider actually consumes it — nodeConfig
+  // for providers taking a node-level `effort:`, assistantConfig for Codex's
+  // modelReasoningEffort — and warned + dropped it where unsupported. So both
+  // reads below hold effort that will genuinely be applied.
+  //
+  // Do NOT gate this on caps.effortControl: that flag means "accepts the
+  // node-level effort: field", not "can apply reasoning effort". Codex is
+  // effortControl:false yet applies effort via modelReasoningEffort, so gating
+  // on it would drop a real, applied value from node_started.
   const assistantEffort = assistantConfig.modelReasoningEffort;
   const resolvedEffort: string | undefined =
     nodeConfig.effort ?? (typeof assistantEffort === 'string' ? assistantEffort : undefined);
@@ -1290,7 +1300,7 @@ async function executeNodeInternal(
         provider,
         model: resolvedModel,
         tier: resolvedTier,
-        effort: resolvedEffort,
+        ...(resolvedEffort !== undefined ? { effort: resolvedEffort } : {}),
         ...iterationData,
       },
     })
@@ -1310,7 +1320,7 @@ async function executeNodeInternal(
     provider,
     model: resolvedModel,
     tier: resolvedTier,
-    effort: resolvedEffort,
+    ...(resolvedEffort !== undefined ? { effort: resolvedEffort } : {}),
   });
 
   // Load prompt
@@ -3985,7 +3995,7 @@ async function executeLoopNode(
         provider: workflowProvider,
         model: resolvedModel,
         tier: resolvedTier,
-        effort: resolvedEffort,
+        ...(resolvedEffort !== undefined ? { effort: resolvedEffort } : {}),
       },
     })
     .catch((err: Error) => {
@@ -4003,7 +4013,7 @@ async function executeLoopNode(
     provider: workflowProvider,
     model: resolvedModel,
     tier: resolvedTier,
-    effort: resolvedEffort,
+    ...(resolvedEffort !== undefined ? { effort: resolvedEffort } : {}),
   });
 
   /**

--- a/packages/workflows/src/event-emitter.test.ts
+++ b/packages/workflows/src/event-emitter.test.ts
@@ -661,11 +661,11 @@ describe('WorkflowEventEmitter', () => {
   });
 
   // -------------------------------------------------------------------------
-  // NodeStartedEvent optional model fields (provider/model/tier)
+  // NodeStartedEvent optional model fields (provider/model/tier/effort)
   // -------------------------------------------------------------------------
 
   describe('NodeStartedEvent — optional model fields', () => {
-    it('passes through an event with no provider/model/tier (bash/script-like)', () => {
+    it('passes through an event with no provider/model/tier/effort (bash/script-like)', () => {
       const emitter = getWorkflowEventEmitter();
       const received: WorkflowEmitterEvent[] = [];
       emitter.subscribe(e => received.push(e));
@@ -677,6 +677,7 @@ describe('WorkflowEventEmitter', () => {
       expect(evt.provider).toBeUndefined();
       expect(evt.model).toBeUndefined();
       expect(evt.tier).toBeUndefined();
+      expect(evt.effort).toBeUndefined();
     });
 
     it('passes through provider/model/tier for tier-resolved AI nodes', () => {
@@ -692,12 +693,14 @@ describe('WorkflowEventEmitter', () => {
         provider: 'claude',
         model: 'opus',
         tier: 'large',
+        effort: 'max',
       });
 
       const evt = received[0] as Extract<WorkflowEmitterEvent, { type: 'node_started' }>;
       expect(evt.provider).toBe('claude');
       expect(evt.model).toBe('opus');
       expect(evt.tier).toBe('large');
+      expect(evt.effort).toBe('max');
     });
 
     it('passes through provider/model without tier for literal-model AI nodes', () => {

--- a/packages/workflows/src/event-emitter.ts
+++ b/packages/workflows/src/event-emitter.ts
@@ -87,6 +87,7 @@ interface NodeStartedEvent {
   provider?: string; // resolved AI provider (absent for bash/script nodes)
   model?: string; // resolved model string (absent for bash/script nodes)
   tier?: 'small' | 'medium' | 'large'; // only set when node.model was a tier keyword
+  effort?: string; // resolved AI effort (absent when unset or unsupported)
 }
 
 interface NodeCompletedEvent {


### PR DESCRIPTION
## Summary

- Problem: resolved AI effort was applied to workflow-node execution but discarded before `node_started` events were persisted or emitted.
- Why it matters: completed workflow runs could not be distinguished when their material configuration difference was effort.
- What changed: normalize the resolved effort at provider/model resolution and thread it through AI, loop, retry, and approval-rejection start-event paths; add the optional field to the typed emitter contract and regression coverage.
- What did **not** change (scope boundary): execution behavior, deterministic bash/script events, event consumers/UI rendering, and the broader node completion/failure execution-record work remain unchanged.

## UX Journey

### Before

```
  User                   Archon workflow engine             Event observer
  ----                   -----------------------            --------------
  runs workflow ──────▶  resolves provider/model/tier/effort
                          invokes AI with effort
                          persists node_started ─────────▶  sees provider/model/tier
                                                            (cannot see effort)
```

### After

```
  User                   Archon workflow engine             Event observer
  ----                   -----------------------            --------------
  runs workflow ──────▶  resolves provider/model/tier/[effort]
                          invokes AI with effort
                          persists node_started ─────────▶  sees provider/model/tier/[effort]
```

## Architecture Diagram

### Before

```
dag-executor.resolveNodeProviderAndModel
  -> provider-specific node options (effort applied)
  -> executeNodeInternal / executeLoopNode
  -> workflow_events node_started + WorkflowEventEmitter node_started (provider/model/tier only)

event-emitter.NodeStartedEvent
  -> workflow event subscribers
```

### After

```
[~] dag-executor.resolveNodeProviderAndModel
  -> provider-specific node options (effort applied)
  ===> [~] normalized resolved effort
  -> [~] executeNodeInternal / executeLoopNode
  -> [~] workflow_events node_started + WorkflowEventEmitter node_started (provider/model/tier/effort)

[~] event-emitter.NodeStartedEvent
  -> workflow event subscribers
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `resolveNodeProviderAndModel` | provider node/assistant options | unchanged | Continues applying the effective effort to Claude or Codex options. |
| `resolveNodeProviderAndModel` | `executeNodeInternal` | **modified** | Adds normalized resolved effort for AI and approval-rejection execution. |
| `resolveNodeProviderAndModel` | `executeLoopNode` | **modified** | Adds normalized resolved effort for loop start events. |
| `executeNodeInternal` | persisted and emitted `node_started` | **modified** | Adds optional effort metadata. |
| `executeLoopNode` | persisted and emitted `node_started` | **modified** | Adds optional effort metadata. |
| `NodeStartedEvent` | subscribers | **modified** | Exposes optional resolved effort in the typed contract. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `workflows`
- Module: `workflows:executor`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes #2395
- Related #2393
- Depends on # none
- Supersedes # none

## Validation Evidence (required)

Commands and result summary:

```bash
bun test packages/workflows/src/dag-executor.test.ts
bun test packages/workflows/src/event-emitter.test.ts
bun run type-check
bun run lint
bun run format:check
bun run test
bun run build
bun run validate
```

- Evidence provided (test/log/trace/screenshot): focused workflow tests passed (448 DAG executor tests and 35 event emitter tests); repository type check, lint with zero warnings, format check, per-package test suite, build, and `bun run validate` all passed.
- If any command is intentionally skipped, explain why: none.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation: not applicable.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: not applicable; this is additive optional event metadata.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: focused tests exercise routed Claude effort, routed Codex effort, loop node start metadata, and optional emitter metadata.
- Edge cases checked: non-AI starts continue to omit effort; unsupported or unset effort remains absent; existing explicit effort precedence is preserved by resolving after option application.
- What was not verified: no external provider calls or UI display changes were performed, as this fix is event plumbing only.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: workflow engine provider/model resolution, persisted `node_started` workflow events, and in-process workflow event subscribers.
- Potential unintended effects: consumers that inspect raw event payloads may now receive an additional optional `effort` key for applicable AI nodes.
- Guardrails/monitoring for early detection: strict typed event contract plus focused Claude, Codex, loop, and absent-field regression tests; full validation passed.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `a8769416` (`git revert a8769416`) and deploy the resulting revert through the normal release path.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: `node_started` event consumers reject or mishandle the optional `effort` field; reverting restores the prior payload shape.

## Risks and Mitigations

- Risk: Claude and Codex route effective effort through different option fields.
  - Mitigation: normalize effort only after the existing provider-specific option routing, then pass the value through both event paths.
- Risk: loops, retries, or approval-rejection prompts omit the new metadata.
  - Mitigation: thread the resolver result through all AI dispatch sites; retries reuse the normal AI start path, with dedicated loop coverage.

Fixes #2395


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow execution events now include the resolved effort level when available.
  * Effort settings are applied consistently across standard nodes, loop nodes, approval prompts, and supported AI routing scenarios.
  * Workflow monitoring can distinguish the effort used for each started node, improving visibility into execution behavior and model configuration.
  * Effort details remain optional when no setting is provided, preserving existing event behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->