### PR TITLE
Protect unique commits during worktree completion

### DIFF
--- a/packages/cli/src/commands/isolation.test.ts
+++ b/packages/cli/src/commands/isolation.test.ts
@@ -36,6 +36,12 @@ mock.module('@archon/core/db/workflows', () => ({
   getActiveWorkflowRunByPath: mockGetActiveWorkflowRunByPath,
 }));
 
+const mockLoadRepoConfig = mock(() => Promise.resolve({}));
+
+mock.module('@archon/core', () => ({
+  loadRepoConfig: mockLoadRepoConfig,
+}));
+
 const mockRemoveEnvironment = mock(() =>
   Promise.resolve({ worktreeRemoved: true, branchDeleted: true, warnings: [] })
 );
@@ -68,12 +74,12 @@ mock.module('@archon/core/operations/isolation-operations', () => ({
 }));
 
 const mockHasUncommittedChanges = mock(() => Promise.resolve(false));
-// Default: gh returns empty PR array, git log returns empty string (no commits to report)
+// Default: gh returns empty PR array and git reports no unpushed commits.
 const mockExecFileAsync = mock((cmd: string) =>
   Promise.resolve({ stdout: cmd === 'gh' ? '[]' : '', stderr: '' })
 );
 
-const mockGetDefaultBranch = mock(() => Promise.resolve('main'));
+const mockGetUniqueCommitCount = mock(() => Promise.resolve(0));
 
 mock.module('@archon/git', () => ({
   hasUncommittedChanges: mockHasUncommittedChanges,
@@ -82,7 +88,7 @@ mock.module('@archon/git', () => ({
   toRepoPath: mock((p: string) => p),
   toBranchName: mock((b: string) => b),
   worktreeExists: mock(() => Promise.resolve(true)),
-  getDefaultBranch: mockGetDefaultBranch,
+  getUniqueCommitCount: mockGetUniqueCommitCount,
 }));
 
 mock.module('@archon/isolation', () => ({
@@ -122,12 +128,14 @@ describe('isolationCompleteCommand', () => {
     mockGetActiveWorkflowRunByPath.mockReset();
     mockGetActiveWorkflowRunByPath.mockResolvedValue(null);
     mockExecFileAsync.mockReset();
-    // Default: gh returns empty PR array, git log returns empty string (no commits)
+    // Default: gh returns empty PR array and git reports no unpushed commits.
     mockExecFileAsync.mockImplementation((cmd: string) =>
       Promise.resolve({ stdout: cmd === 'gh' ? '[]' : '', stderr: '' })
     );
-    mockGetDefaultBranch.mockReset();
-    mockGetDefaultBranch.mockResolvedValue('main');
+    mockLoadRepoConfig.mockReset();
+    mockLoadRepoConfig.mockResolvedValue({});
+    mockGetUniqueCommitCount.mockReset();
+    mockGetUniqueCommitCount.mockResolvedValue(0);
   });
 
   afterEach(() => {
@@ -219,26 +227,48 @@ describe('isolationCompleteCommand', () => {
     expect(consoleLogSpy).toHaveBeenCalledWith('\nComplete: 0 completed, 1 failed, 0 not found');
   });
 
-  it('blocks when there are unmerged commits', async () => {
+  it('completes a branch identical to dev without --force', async () => {
     mockFindActiveByBranchName.mockResolvedValueOnce(mockEnv);
-    mockExecFileAsync.mockImplementation((cmd: string, args: string[]) => {
-      if (cmd === 'gh') {
-        return Promise.resolve({ stdout: '[]', stderr: '' });
-      }
-      if (cmd === 'git' && args.includes(`main..feature-branch`)) {
-        return Promise.resolve({
-          stdout: 'abc1234 fix: something\ndef5678 fix: other\n',
-          stderr: '',
-        });
-      }
-      return Promise.resolve({ stdout: '', stderr: '' });
+    mockRemoveEnvironment.mockResolvedValueOnce({
+      worktreeRemoved: true,
+      branchDeleted: true,
+      warnings: [],
     });
+    mockGetUniqueCommitCount.mockResolvedValueOnce(0);
+
+    await isolationCompleteCommand(['feature-branch'], { force: false, deleteRemote: true });
+
+    expect(mockGetUniqueCommitCount).toHaveBeenCalledWith('/test/repo', 'feature-branch', 'origin');
+    expect(mockRemoveEnvironment).toHaveBeenCalled();
+  });
+
+  it('forwards the configured remote to the unique commit check', async () => {
+    mockFindActiveByBranchName.mockResolvedValueOnce(mockEnv);
+    mockRemoveEnvironment.mockResolvedValueOnce({
+      worktreeRemoved: true,
+      branchDeleted: true,
+      warnings: [],
+    });
+    mockLoadRepoConfig.mockResolvedValueOnce({ worktree: { remote: 'upstream' } });
+
+    await isolationCompleteCommand(['feature-branch'], { force: false, deleteRemote: true });
+
+    expect(mockGetUniqueCommitCount).toHaveBeenCalledWith(
+      '/test/repo',
+      'feature-branch',
+      'upstream'
+    );
+  });
+
+  it('blocks when commits are unique to the branch', async () => {
+    mockFindActiveByBranchName.mockResolvedValueOnce(mockEnv);
+    mockGetUniqueCommitCount.mockResolvedValueOnce(2);
 
     await isolationCompleteCommand(['feature-branch'], { force: false, deleteRemote: true });
 
     expect(mockRemoveEnvironment).not.toHaveBeenCalled();
     expect(consoleErrorSpy).toHaveBeenCalledWith('  Blocked: feature-branch');
-    expect(consoleErrorSpy).toHaveBeenCalledWith('    ✗ 2 commit(s) not merged into main');
+    expect(consoleErrorSpy).toHaveBeenCalledWith('    ✗ 2 commit(s) unique to this branch');
     expect(consoleErrorSpy).toHaveBeenCalledWith('  Use --force to override.');
     expect(consoleLogSpy).toHaveBeenCalledWith('\nComplete: 0 completed, 1 failed, 0 not found');
   });

--- a/packages/cli/src/commands/isolation.test.ts
+++ b/packages/cli/src/commands/isolation.test.ts
@@ -242,7 +242,7 @@ describe('isolationCompleteCommand', () => {
     expect(mockRemoveEnvironment).toHaveBeenCalled();
   });
 
-  it('forwards the configured remote to the unique commit check', async () => {
+  it('uses the configured remote for the completion commit checks', async () => {
     mockFindActiveByBranchName.mockResolvedValueOnce(mockEnv);
     mockRemoveEnvironment.mockResolvedValueOnce({
       worktreeRemoved: true,
@@ -250,6 +250,15 @@ describe('isolationCompleteCommand', () => {
       warnings: [],
     });
     mockLoadRepoConfig.mockResolvedValueOnce({ worktree: { remote: 'upstream' } });
+    mockExecFileAsync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'gh') {
+        return Promise.resolve({ stdout: '[]', stderr: '' });
+      }
+      if (cmd === 'git' && args.includes('upstream/feature-branch..feature-branch')) {
+        return Promise.resolve({ stdout: '', stderr: '' });
+      }
+      return Promise.reject(new Error('fatal: unknown revision origin/feature-branch'));
+    });
 
     await isolationCompleteCommand(['feature-branch'], { force: false, deleteRemote: true });
 
@@ -258,6 +267,12 @@ describe('isolationCompleteCommand', () => {
       'feature-branch',
       'upstream'
     );
+    expect(mockExecFileAsync).toHaveBeenCalledWith(
+      'git',
+      ['-C', '/test/repo', 'log', 'upstream/feature-branch..feature-branch', '--oneline'],
+      { timeout: 15000 }
+    );
+    expect(mockRemoveEnvironment).toHaveBeenCalled();
   });
 
   it('blocks when commits are unique to the branch', async () => {

--- a/packages/cli/src/commands/isolation.ts
+++ b/packages/cli/src/commands/isolation.ts
@@ -293,9 +293,10 @@ export async function isolationCompleteCommand(
       }
 
       // Check 4: commits that would become unreachable after branch deletion
+      let remote = 'origin';
       try {
         const repoConfig = await loadRepoConfig(env.codebase_default_cwd);
-        const remote = repoConfig.worktree?.remote?.trim() || 'origin';
+        remote = repoConfig.worktree?.remote?.trim() || remote;
         const uniqueCommitCount = await getUniqueCommitCount(
           toRepoPath(env.codebase_default_cwd),
           toBranchName(branch),
@@ -318,7 +319,7 @@ export async function isolationCompleteCommand(
       try {
         const unpushedResult = await execFileAsync(
           'git',
-          ['-C', env.codebase_default_cwd, 'log', `origin/${branch}..${branch}`, '--oneline'],
+          ['-C', env.codebase_default_cwd, 'log', `${remote}/${branch}..${branch}`, '--oneline'],
           { timeout: 15000 }
         );
         const unpushedLines = unpushedResult.stdout.trim().split('\n').filter(Boolean);

--- a/packages/cli/src/commands/isolation.ts
+++ b/packages/cli/src/commands/isolation.ts
@@ -306,12 +306,16 @@ export async function isolationCompleteCommand(
           blockers.push(`${String(uniqueCommitCount)} commit(s) unique to this branch`);
         }
       } catch (error) {
-        getLog().warn(
-          { err: error as Error, branch },
-          'isolation.complete_unique_commit_check_failed'
-        );
-        console.warn(
-          '  Warning: could not check for unique commits — skipping unique commit check'
+        const err = error as Error;
+        getLog().warn({ err, branch }, 'isolation.complete_unique_commit_check_failed');
+        // Fail CLOSED. This check exists to stop a branch being deleted while it
+        // holds commits reachable from nowhere else; treating an unanswerable
+        // check as "no unique commits" would let exactly the loss it guards
+        // against proceed on any git failure — permissions, a corrupt ref, a
+        // timeout. An unnecessary blocker costs the operator one --force; a
+        // wrong skip costs them the commits.
+        blockers.push(
+          `could not determine unique commits (${err.message}) — refusing to delete unverified`
         );
       }
 

--- a/packages/cli/src/commands/isolation.ts
+++ b/packages/cli/src/commands/isolation.ts
@@ -3,6 +3,7 @@
  */
 import * as isolationDb from '@archon/core/db/isolation-environments';
 import * as workflowDb from '@archon/core/db/workflows';
+import { loadRepoConfig } from '@archon/core';
 import { createLogger } from '@archon/paths';
 import {
   toRepoPath,
@@ -10,7 +11,7 @@ import {
   execFileAsync,
   hasUncommittedChanges,
   toWorktreePath,
-  getDefaultBranch,
+  getUniqueCommitCount,
 } from '@archon/git';
 import { getIsolationProvider } from '@archon/isolation';
 import {
@@ -291,21 +292,26 @@ export async function isolationCompleteCommand(
         getLog().warn({ err, branch }, 'isolation.complete_pr_check_failed');
       }
 
-      // Check 4: unmerged commits (not yet in default branch)
+      // Check 4: commits that would become unreachable after branch deletion
       try {
-        const defaultBranch = await getDefaultBranch(toRepoPath(env.codebase_default_cwd));
-        const unmergedResult = await execFileAsync(
-          'git',
-          ['-C', env.codebase_default_cwd, 'log', `${defaultBranch}..${branch}`, '--oneline'],
-          { timeout: 15000 }
+        const repoConfig = await loadRepoConfig(env.codebase_default_cwd);
+        const remote = repoConfig.worktree?.remote?.trim() || 'origin';
+        const uniqueCommitCount = await getUniqueCommitCount(
+          toRepoPath(env.codebase_default_cwd),
+          toBranchName(branch),
+          remote
         );
-        const unmergedLines = unmergedResult.stdout.trim().split('\n').filter(Boolean);
-        if (unmergedLines.length > 0) {
-          blockers.push(`${unmergedLines.length} commit(s) not merged into ${defaultBranch}`);
+        if (uniqueCommitCount > 0) {
+          blockers.push(`${String(uniqueCommitCount)} commit(s) unique to this branch`);
         }
       } catch (error) {
-        getLog().warn({ err: error as Error, branch }, 'isolation.complete_unmerged_check_failed');
-        console.warn('  Warning: could not check for unmerged commits — skipping unmerged check');
+        getLog().warn(
+          { err: error as Error, branch },
+          'isolation.complete_unique_commit_check_failed'
+        );
+        console.warn(
+          '  Warning: could not check for unique commits — skipping unique commit check'
+        );
       }
 
       // Check 5: unpushed commits (not yet on remote)

--- a/packages/git/src/branch.ts
+++ b/packages/git/src/branch.ts
@@ -84,6 +84,58 @@ export async function getDefaultBranch(repoPath: RepoPath, remote = 'origin'): P
 }
 
 /**
+ * Count commits that would become unreachable if a local branch and its remote
+ * counterpart were deleted.
+ *
+ * Every other local branch, remote branch, and tag is treated as a surviving
+ * ref that can keep the candidate branch's commits reachable.
+ */
+export async function getUniqueCommitCount(
+  repoPath: RepoPath,
+  branchName: BranchName,
+  remote = 'origin'
+): Promise<number> {
+  try {
+    const { stdout: refsOutput } = await execFileAsync(
+      'git',
+      [
+        '-C',
+        repoPath,
+        'for-each-ref',
+        '--format=%(refname)',
+        'refs/heads',
+        'refs/remotes',
+        'refs/tags',
+      ],
+      { timeout: 10000 }
+    );
+    const deletedRefs = new Set([
+      `refs/heads/${branchName}`,
+      `refs/remotes/${remote}/${branchName}`,
+    ]);
+    const survivingRefs = refsOutput
+      .split('\n')
+      .map(ref => ref.trim())
+      .filter(ref => ref.length > 0 && !deletedRefs.has(ref));
+
+    const { stdout: commitsOutput } = await execFileAsync(
+      'git',
+      ['-C', repoPath, 'rev-list', branchName, '--not', ...survivingRefs],
+      { timeout: 15000 }
+    );
+
+    return commitsOutput.split('\n').filter(line => line.trim().length > 0).length;
+  } catch (error) {
+    const err = error as Error & { stderr?: string };
+    getLog().error(
+      { repoPath, branchName, remote, err, stderr: err.stderr },
+      'unique_commit_count_failed'
+    );
+    throw new Error(`Failed to count unique commits for ${branchName}: ${err.message}`);
+  }
+}
+
+/**
  * Checkout a branch (creating it if it doesn't exist)
  */
 export async function checkout(repoPath: RepoPath, branchName: BranchName): Promise<void> {

--- a/packages/git/src/git.test.ts
+++ b/packages/git/src/git.test.ts
@@ -959,6 +959,125 @@ branch refs/heads/feature/auth
     });
   });
 
+  describe('getUniqueCommitCount', () => {
+    let execSpy: Mock<typeof git.execFileAsync>;
+
+    beforeEach(() => {
+      execSpy = spyOn(git, 'execFileAsync');
+    });
+
+    afterEach(() => {
+      execSpy.mockRestore();
+    });
+
+    test('returns zero when all tip commits are reachable from surviving refs', async () => {
+      execSpy
+        .mockResolvedValueOnce({
+          stdout:
+            'refs/heads/feature/auth\nrefs/heads/dev\nrefs/remotes/origin/feature/auth\nrefs/remotes/origin/dev\nrefs/tags/v1.0.0\n',
+          stderr: '',
+        })
+        .mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+      const result = await git.getUniqueCommitCount('/workspace/repo', 'feature/auth');
+
+      expect(result).toBe(0);
+      expect(execSpy).toHaveBeenNthCalledWith(
+        1,
+        'git',
+        [
+          '-C',
+          '/workspace/repo',
+          'for-each-ref',
+          '--format=%(refname)',
+          'refs/heads',
+          'refs/remotes',
+          'refs/tags',
+        ],
+        expect.any(Object)
+      );
+      expect(execSpy).toHaveBeenNthCalledWith(
+        2,
+        'git',
+        [
+          '-C',
+          '/workspace/repo',
+          'rev-list',
+          'feature/auth',
+          '--not',
+          'refs/heads/dev',
+          'refs/remotes/origin/dev',
+          'refs/tags/v1.0.0',
+        ],
+        expect.any(Object)
+      );
+    });
+
+    test('counts commits reachable only from the candidate branch', async () => {
+      execSpy
+        .mockResolvedValueOnce({ stdout: 'refs/heads/feature/auth\nrefs/heads/dev\n', stderr: '' })
+        .mockResolvedValueOnce({ stdout: 'abc123\ndef456\n\n', stderr: '' });
+
+      const result = await git.getUniqueCommitCount('/workspace/repo', 'feature/auth');
+
+      expect(result).toBe(2);
+    });
+
+    test('excludes the configured remote counterpart but retains other remotes and tags', async () => {
+      execSpy
+        .mockResolvedValueOnce({
+          stdout:
+            'refs/heads/feature/auth\nrefs/remotes/upstream/feature/auth\nrefs/remotes/origin/feature/auth\nrefs/tags/reviewed\n',
+          stderr: '',
+        })
+        .mockResolvedValueOnce({ stdout: 'abc123\n', stderr: '' });
+
+      await git.getUniqueCommitCount('/workspace/repo', 'feature/auth', 'upstream');
+
+      expect(execSpy).toHaveBeenNthCalledWith(
+        2,
+        'git',
+        [
+          '-C',
+          '/workspace/repo',
+          'rev-list',
+          'feature/auth',
+          '--not',
+          'refs/remotes/origin/feature/auth',
+          'refs/tags/reviewed',
+        ],
+        expect.any(Object)
+      );
+    });
+
+    test('checks the full candidate history when no refs survive deletion', async () => {
+      execSpy
+        .mockResolvedValueOnce({
+          stdout: 'refs/heads/feature/auth\nrefs/remotes/origin/feature/auth\n',
+          stderr: '',
+        })
+        .mockResolvedValueOnce({ stdout: 'abc123\ndef456\n', stderr: '' });
+
+      const result = await git.getUniqueCommitCount('/workspace/repo', 'feature/auth');
+
+      expect(result).toBe(2);
+      expect(execSpy).toHaveBeenNthCalledWith(
+        2,
+        'git',
+        ['-C', '/workspace/repo', 'rev-list', 'feature/auth', '--not'],
+        expect.any(Object)
+      );
+    });
+
+    test('rejects when Git cannot enumerate refs', async () => {
+      execSpy.mockRejectedValueOnce(new Error('fatal: not a git repository'));
+
+      await expect(git.getUniqueCommitCount('/workspace/repo', 'feature/auth')).rejects.toThrow(
+        'Failed to count unique commits for feature/auth: fatal: not a git repository'
+      );
+    });
+  });
+
   describe('commitAllChanges', () => {
     let execSpy: Mock<typeof git.execFileAsync>;
 

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -32,6 +32,7 @@ export type { WorktreeLayout, WorktreeBaseOverride } from './worktree';
 // Branch operations
 export {
   getDefaultBranch,
+  getUniqueCommitCount,
   getCurrentBranch,
   countCommitsAhead,
   checkout,


### PR DESCRIPTION
## Summary

- Problem: `archon complete` treated commits absent from the remote default branch as unsafe, even when they were already retained by the configured development branch.
- Why it matters: dev-based worktree branches with no unique work were blocked unless users used `--force`, which also bypasses unrelated safety checks.
- What changed: completion now counts commits reachable only from refs being deleted; it excludes the local branch and its configured remote counterpart, while retaining all surviving branches, remotes, and tags as evidence of safety.
- What did **not** change (scope boundary): `isolation cleanup --merged` policy and its configured base-branch behavior remain unchanged; dirty-worktree, active-run, open-PR, and unpushed-work guards are unchanged.

## UX Journey

### Before

```
User                     Archon complete                 Git refs
────                     ───────────────                 ────────
complete feature ─────▶  resolves origin/HEAD ───────▶   main
                         compares main..feature
                         blocks dev-based commits
sees error ◀──────────  requires --force
```

### After

```
User                     Archon complete                 Git refs
────                     ───────────────                 ────────
complete feature ─────▶  [enumerates surviving refs] ─▶  dev, tags, remotes
                         [counts commits unique to refs
                          being deleted]
sees completion ◀──────  [proceeds when count is zero]
```

## Architecture Diagram

### Before

```
CLI complete command [~] ──▶ git getDefaultBranch ──▶ origin/HEAD
CLI complete command [~] ──▶ git log default..branch
```

### After

```
CLI complete command [~] ===▶ git getUniqueCommitCount [+]
git getUniqueCommitCount [+] ===▶ for-each-ref surviving refs
git getUniqueCommitCount [+] ===▶ rev-list branch --not surviving refs
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|---|---|---|---|
| CLI isolation complete command | Git branch utilities | **modified** | Replaces default-branch ancestry guard with unique-commit count. |
| Git branch utilities | Git ref enumeration | **new** | Enumerates refs that survive completion. |
| Git branch utilities | Git rev-list | **new** | Counts commits that would disappear after branch/ref deletion. |
| Git package index | Git branch utilities | **modified** | Re-exports the new typed helper. |

## Label Snapshot

- Risk: `risk: medium`
- Size: `size: M`
- Scope: `cli`, `git`, `tests`
- Module: `cli:isolation`, `git:branch`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi`

## Linked Issue

- Closes #2331
- Related #
- Depends on # (if stacked): None
- Supersedes # (if replacing older PR): None

## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check
bun run lint
bun run format:check
bun run test
bun run validate
```

- Evidence provided (test/log/trace/screenshot): all commands passed. Focused Git tests passed (182), CLI isolation tests passed (20), and manual surviving-ref verification confirmed: shared `dev` tip = 0 unique commits, deleted remote-only ref = 1, surviving tag = 0.
- If any command is intentionally skipped, explain why: None.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: N/A.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No
- If yes, exact upgrade steps: N/A.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: a branch whose tip is retained by `dev` can complete without `--force`; branches with unique commits remain blocked.
- Edge cases checked: configured remote counterpart is excluded because completion deletes it; surviving tags and other refs protect shared commits; an empty surviving-ref set counts all candidate commits; Git errors reject rather than reporting safety.
- What was not verified: an interactive production worktree deletion against a live remote; behavior is covered by focused unit tests and manual ref-graph verification.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: CLI `archon complete` and reusable Git branch utilities.
- Potential unintended effects: branches retained only by an unexpected ref now pass the guard, which is intentional because that ref preserves the commits after completion.
- Guardrails/monitoring for early detection: existing dirty, active-run, open-PR, and unpushed-work guards remain; new Git and CLI regression tests cover ref exclusion and unique-commit behavior.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `60e9c45d` from the PR branch or `dev` after merge.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: `archon complete` either blocks branches that are already retained by surviving refs or permits deletion when unique commits exist.

## Risks and Mitigations

- Risk: an error in ref exclusion could undercount commits unique to the deleted branch.
  - Mitigation: tests assert local and configured remote branch exclusion while retaining other branches, remotes, and tags; Git command failures fail explicitly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved isolation completion checks to identify commits unique to the branch before allowing deletion.
  * Branches identical to the development branch can now complete successfully.
  * Completion now respects the repository’s configured remote.
  * If unique-commit verification fails, completion is blocked unless the `--force` option is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->