### PR TITLE
fix(db): SQLite upgrade broke on event_order — index/trigger ran before the ALTER

### DIFF
--- a/packages/core/src/db/adapters/sqlite.test.ts
+++ b/packages/core/src/db/adapters/sqlite.test.ts
@@ -32,13 +32,16 @@ async function insertCodebase(db: SqliteAdapter, id: string): Promise<void> {
  * the fixture realistic — the upgrade path that broke was an otherwise-current
  * database missing exactly this one column.
  */
-function makeDbWithoutEventOrder(): string {
+async function makeDbWithoutEventOrder(): Promise<string> {
   const path = join(
     import.meta.dir,
     `.test-sqlite-legacy-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
   );
   const seed = new SqliteAdapter(path); // writes the current schema
-  void seed.close();
+  // MUST await: close() is async, and on Windows an unreleased SQLite handle
+  // locks the file, so the Database opened below fails. Harmless on POSIX,
+  // which is why the first version of this test passed locally and failed CI.
+  await seed.close();
   const raw = new Database(path);
   try {
     raw.run('DROP TRIGGER IF EXISTS remote_agent_workflow_events_assign_order');
@@ -83,13 +86,13 @@ describe('SqliteAdapter upgrade path', () => {
   // exec block — so createSchema() threw and migrateColumns(), which adds the
   // column, never ran. Every existing SQLite install was bricked on upgrade,
   // and the migration that would fix it could never execute.
-  test('converges a database that predates event_order', () => {
-    legacyPath = makeDbWithoutEventOrder();
+  test('converges a database that predates event_order', async () => {
+    legacyPath = await makeDbWithoutEventOrder();
     expect(columnsOf(legacyPath, 'remote_agent_workflow_events')).not.toContain('event_order');
 
     // Must not throw, and must converge.
     const upgraded = new SqliteAdapter(legacyPath);
-    void upgraded.close();
+    await upgraded.close();
 
     expect(columnsOf(legacyPath, 'remote_agent_workflow_events')).toContain('event_order');
 

--- a/packages/core/src/db/adapters/sqlite.test.ts
+++ b/packages/core/src/db/adapters/sqlite.test.ts
@@ -25,6 +25,79 @@ async function insertCodebase(db: SqliteAdapter, id: string): Promise<void> {
   ]);
 }
 
+/**
+ * Produce a database in the state it had BEFORE event_order existed: current
+ * schema in every other respect, with the column, its index and its trigger
+ * removed. Building it this way (rather than hand-writing an old schema) keeps
+ * the fixture realistic — the upgrade path that broke was an otherwise-current
+ * database missing exactly this one column.
+ */
+function makeDbWithoutEventOrder(): string {
+  const path = join(
+    import.meta.dir,
+    `.test-sqlite-legacy-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
+  );
+  new SqliteAdapter(path); // writes the current schema
+  const raw = new Database(path);
+  raw.run('DROP TRIGGER IF EXISTS remote_agent_workflow_events_assign_order');
+  raw.run('DROP INDEX IF EXISTS idx_workflow_events_run_order');
+  raw.run('ALTER TABLE remote_agent_workflow_events DROP COLUMN event_order');
+  raw.close();
+  return path;
+}
+
+function columnsOf(path: string, table: string): string[] {
+  const raw = new Database(path);
+  const cols = (raw.prepare(`PRAGMA table_info('${table}')`).all() as { name: string }[]).map(
+    c => c.name
+  );
+  raw.close();
+  return cols;
+}
+
+describe('SqliteAdapter upgrade path', () => {
+  let legacyPath = '';
+  afterEach(() => {
+    if (legacyPath) {
+      try {
+        unlinkSync(legacyPath);
+      } catch {
+        /* already gone */
+      }
+      legacyPath = '';
+    }
+  });
+
+  // Regression: the event_order index and trigger were briefly created inside
+  // createSchema(). Both reference a column absent from any database predating
+  // it, and CREATE INDEX on a missing column aborts the entire createSchema()
+  // exec block — so createSchema() threw and migrateColumns(), which adds the
+  // column, never ran. Every existing SQLite install was bricked on upgrade,
+  // and the migration that would fix it could never execute.
+  test('converges a database that predates event_order', () => {
+    legacyPath = makeDbWithoutEventOrder();
+    expect(columnsOf(legacyPath, 'remote_agent_workflow_events')).not.toContain('event_order');
+
+    // Must not throw, and must converge.
+    new SqliteAdapter(legacyPath);
+
+    expect(columnsOf(legacyPath, 'remote_agent_workflow_events')).toContain('event_order');
+
+    const raw = new Database(legacyPath);
+    const objects = (
+      raw
+        .prepare('SELECT name FROM sqlite_master WHERE name IN (?, ?)')
+        .all('idx_workflow_events_run_order', 'remote_agent_workflow_events_assign_order') as {
+        name: string;
+      }[]
+    ).map(o => o.name);
+    raw.close();
+
+    expect(objects).toContain('idx_workflow_events_run_order');
+    expect(objects).toContain('remote_agent_workflow_events_assign_order');
+  });
+});
+
 describe('SqliteAdapter', () => {
   let db: SqliteAdapter;
 

--- a/packages/core/src/db/adapters/sqlite.test.ts
+++ b/packages/core/src/db/adapters/sqlite.test.ts
@@ -37,22 +37,28 @@ function makeDbWithoutEventOrder(): string {
     import.meta.dir,
     `.test-sqlite-legacy-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
   );
-  new SqliteAdapter(path); // writes the current schema
+  const seed = new SqliteAdapter(path); // writes the current schema
+  void seed.close();
   const raw = new Database(path);
-  raw.run('DROP TRIGGER IF EXISTS remote_agent_workflow_events_assign_order');
-  raw.run('DROP INDEX IF EXISTS idx_workflow_events_run_order');
-  raw.run('ALTER TABLE remote_agent_workflow_events DROP COLUMN event_order');
-  raw.close();
+  try {
+    raw.run('DROP TRIGGER IF EXISTS remote_agent_workflow_events_assign_order');
+    raw.run('DROP INDEX IF EXISTS idx_workflow_events_run_order');
+    raw.run('ALTER TABLE remote_agent_workflow_events DROP COLUMN event_order');
+  } finally {
+    raw.close();
+  }
   return path;
 }
 
 function columnsOf(path: string, table: string): string[] {
   const raw = new Database(path);
-  const cols = (raw.prepare(`PRAGMA table_info('${table}')`).all() as { name: string }[]).map(
-    c => c.name
-  );
-  raw.close();
-  return cols;
+  try {
+    return (raw.prepare(`PRAGMA table_info('${table}')`).all() as { name: string }[]).map(
+      c => c.name
+    );
+  } finally {
+    raw.close();
+  }
 }
 
 describe('SqliteAdapter upgrade path', () => {
@@ -61,8 +67,11 @@ describe('SqliteAdapter upgrade path', () => {
     if (legacyPath) {
       try {
         unlinkSync(legacyPath);
-      } catch {
-        /* already gone */
+      } catch (e: unknown) {
+        // Only a genuinely-absent file is acceptable. Anything else — most
+        // plausibly an unreleased handle holding the file open on Windows —
+        // must surface rather than leave a leaked fixture behind.
+        if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e;
       }
       legacyPath = '';
     }
@@ -79,7 +88,8 @@ describe('SqliteAdapter upgrade path', () => {
     expect(columnsOf(legacyPath, 'remote_agent_workflow_events')).not.toContain('event_order');
 
     // Must not throw, and must converge.
-    new SqliteAdapter(legacyPath);
+    const upgraded = new SqliteAdapter(legacyPath);
+    void upgraded.close();
 
     expect(columnsOf(legacyPath, 'remote_agent_workflow_events')).toContain('event_order');
 

--- a/packages/core/src/db/adapters/sqlite.test.ts
+++ b/packages/core/src/db/adapters/sqlite.test.ts
@@ -5,6 +5,7 @@ import { APP_VERSION, readSchemaVersion } from '../schema-version';
 import { Database } from 'bun:sqlite';
 import { unlinkSync } from 'fs';
 import { join } from 'path';
+import { tmpdir } from 'node:os';
 
 let currentDbPath = '';
 
@@ -33,9 +34,13 @@ async function insertCodebase(db: SqliteAdapter, id: string): Promise<void> {
  * database missing exactly this one column.
  */
 async function makeDbWithoutEventOrder(): Promise<string> {
+  // OS temp dir, not the repo: on Windows bun:sqlite does not always release the
+  // file handle synchronously, so cleanup can hit EBUSY. A stranded file in
+  // tmpdir is harmless and self-cleaning; a stranded file in packages/ is repo
+  // pollution that shows up in everyone's `git status`.
   const path = join(
-    import.meta.dir,
-    `.test-sqlite-legacy-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
+    tmpdir(),
+    `archon-test-sqlite-legacy-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
   );
   const seed = new SqliteAdapter(path); // writes the current schema
   // MUST await: close() is async, and on Windows an unreleased SQLite handle
@@ -75,10 +80,16 @@ describe('SqliteAdapter upgrade path', () => {
       try {
         unlinkSync(legacyPath);
       } catch (e: unknown) {
-        // Only a genuinely-absent file is acceptable. Anything else — most
-        // plausibly an unreleased handle holding the file open on Windows —
-        // must surface rather than leave a leaked fixture behind.
-        if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e;
+        // Tolerate exactly two cases, and nothing else:
+        //   ENOENT — already gone, fine.
+        //   EBUSY  — Windows only. bun:sqlite does not reliably release the file
+        //            handle synchronously on close(), even with statements
+        //            finalized. The fixture is a uniquely-named file in tmpdir,
+        //            so a stranded one is harmless. Tolerated rather than
+        //            swallowed: any other errno still fails the test loudly,
+        //            which is what caught the real leak in the first place.
+        const code = (e as NodeJS.ErrnoException).code;
+        if (code !== 'ENOENT' && code !== 'EBUSY') throw e;
       }
       legacyPath = '';
     }

--- a/packages/core/src/db/adapters/sqlite.test.ts
+++ b/packages/core/src/db/adapters/sqlite.test.ts
@@ -55,11 +55,15 @@ async function makeDbWithoutEventOrder(): Promise<string> {
 
 function columnsOf(path: string, table: string): string[] {
   const raw = new Database(path);
+  // Finalize the statement before closing. On Windows an un-finalized prepared
+  // statement keeps the file handle open past close(), so the afterEach unlink
+  // fails with EBUSY — which is what this test hit on windows-latest while
+  // passing on POSIX.
+  const stmt = raw.prepare(`PRAGMA table_info('${table}')`);
   try {
-    return (raw.prepare(`PRAGMA table_info('${table}')`).all() as { name: string }[]).map(
-      c => c.name
-    );
+    return (stmt.all() as { name: string }[]).map(c => c.name);
   } finally {
+    stmt.finalize();
     raw.close();
   }
 }
@@ -97,14 +101,18 @@ describe('SqliteAdapter upgrade path', () => {
     expect(columnsOf(legacyPath, 'remote_agent_workflow_events')).toContain('event_order');
 
     const raw = new Database(legacyPath);
-    const objects = (
-      raw
-        .prepare('SELECT name FROM sqlite_master WHERE name IN (?, ?)')
-        .all('idx_workflow_events_run_order', 'remote_agent_workflow_events_assign_order') as {
-        name: string;
-      }[]
-    ).map(o => o.name);
-    raw.close();
+    const stmt = raw.prepare('SELECT name FROM sqlite_master WHERE name IN (?, ?)');
+    let objects: string[];
+    try {
+      objects = (
+        stmt.all('idx_workflow_events_run_order', 'remote_agent_workflow_events_assign_order') as {
+          name: string;
+        }[]
+      ).map(o => o.name);
+    } finally {
+      stmt.finalize();
+      raw.close();
+    }
 
     expect(objects).toContain('idx_workflow_events_run_order');
     expect(objects).toContain('remote_agent_workflow_events_assign_order');

--- a/packages/core/src/db/adapters/sqlite.ts
+++ b/packages/core/src/db/adapters/sqlite.ts
@@ -745,20 +745,13 @@ export class SqliteAdapter implements IDatabase {
       CREATE INDEX IF NOT EXISTS idx_workflow_events_run_id ON remote_agent_workflow_events(workflow_run_id);
       CREATE INDEX IF NOT EXISTS idx_workflow_events_type ON remote_agent_workflow_events(event_type);
       CREATE INDEX IF NOT EXISTS idx_workflow_events_created_at ON remote_agent_workflow_events(created_at);
-      CREATE UNIQUE INDEX IF NOT EXISTS idx_workflow_events_run_order
-        ON remote_agent_workflow_events(workflow_run_id, event_order)
-        WHERE event_order IS NOT NULL;
-      CREATE TRIGGER IF NOT EXISTS remote_agent_workflow_events_assign_order
-        AFTER INSERT ON remote_agent_workflow_events
-        WHEN NEW.event_order IS NULL
-        BEGIN
-          UPDATE remote_agent_workflow_events
-          SET event_order = (
-            SELECT COALESCE(MAX(event_order), 0) + 1
-            FROM remote_agent_workflow_events
-          )
-          WHERE rowid = NEW.rowid;
-        END;
+      -- NOTE: the idx_workflow_events_run_order index and the assign_order trigger
+      -- are deliberately NOT created here. Both reference event_order, which does
+      -- not exist on databases created before it was introduced — and CREATE INDEX
+      -- (or a TRIGGER body) referencing a missing column aborts this entire exec
+      -- block, so createSchema() throws before migrateColumns() can ever add the
+      -- column. That is exactly the failure the user_id index comment above warns
+      -- about. migrateColumns() creates both, after its ALTER TABLE, idempotently.
       CREATE INDEX IF NOT EXISTS idx_messages_conversation_id ON remote_agent_messages(conversation_id, created_at ASC);
       CREATE INDEX IF NOT EXISTS idx_workflow_node_sessions_scope ON remote_agent_workflow_node_sessions(scope_key);
       CREATE INDEX IF NOT EXISTS idx_workflow_node_sessions_workflow ON remote_agent_workflow_node_sessions(workflow_name);


### PR DESCRIPTION
**P0 — every existing SQLite install is broken on `dev` right now, and SQLite is the default.** Found within minutes of merging #2414 by running `archon workflow runs` against my own database.

## The failure

```
SQLiteError: no such column: event_order
    at createSchema (packages/core/src/db/adapters/sqlite.ts:516:13)
    at initSchema  (packages/core/src/db/adapters/sqlite.ts:177:10)
```

#2414 added `idx_workflow_events_run_order` and the `assign_order` trigger to `createSchema()`. Both reference `event_order`, which does not exist on any database created before that column. **CREATE INDEX on a missing column aborts the entire `createSchema()` exec block**, so `createSchema()` throws — and `migrateColumns()`, the code that would have added the column, is on the next line and never runs.

Self-perpetuating: the migration that fixes it can never execute.

## The codebase already documented this exact hazard

From the `user_id` index added in 0.4.0, a few hundred lines above:

> `// Index must be created here, not in createSchema(): the column doesn't`
> `// exist on pre-0.4.0 databases until the ALTER TABLE above runs, and`
> `// CREATE INDEX on a missing column aborts the entire createSchema()`
> `// exec block. Idempotent so it's safe to run unconditionally.`

Same trap, same file, previously learned.

## The fix

Both statements move out of `createSchema()`. `migrateColumns()` already creates them idempotently **after** its `ALTER TABLE`, in the correct order — so this is a deletion plus a comment, not new logic. Fresh databases still get the column from `CREATE TABLE` and the index/trigger from `migrateColumns()`.

## Verification

Against a real pre-existing `~/.archon/archon.db` that was broken by the merge:

```
before:  event_order present? 0        archon workflow runs -> ERROR
after:   event_order present? 1        archon workflow runs -> works
         index idx_workflow_events_run_order      created
         trigger remote_agent_workflow_events_assign_order  created
```

Type-check clean, `sqlite.test.ts` 20 pass / 0 fail.

## Why the tests did not catch it

The SQLite suite creates fresh databases, where `CREATE TABLE` includes `event_order` and the index therefore succeeds. The broken path is **upgrade only**: an existing database where `CREATE TABLE IF NOT EXISTS` is a no-op. There is no test that opens a pre-`event_order` database and asserts the schema converges.

That gap is worth closing separately — it would have caught this, and it is the same class as the reverse-drift and parity checks already in that suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database setup and migrations for existing databases.
  * Prevented schema initialization failures when workflow event ordering fields are added during migration.
  * Ensured missing workflow event ordering fields and related database structures are restored during upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->