### PR TITLE
fix(adapters): download Slack file attachments so Archon can read them

### DIFF
--- a/packages/adapters/src/chat/slack/adapter.test.ts
+++ b/packages/adapters/src/chat/slack/adapter.test.ts
@@ -695,6 +695,29 @@ describe('SlackAdapter', () => {
       expect(globalThis.fetch).not.toHaveBeenCalled();
     });
 
+    test('skips a file exceeding the cap when size is unknown and Content-Length is absent', async () => {
+      // No `file.size` and a streamed (not buffered) response body: Content-Length
+      // is never set, so neither pre-fetch check applies. This exercises the
+      // post-download `buffer.byteLength` check that exists precisely as the
+      // backstop for a missing or understated size.
+      const oversized = new Uint8Array(10 * 1024 * 1024 + 1);
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(oversized);
+          controller.close();
+        },
+      });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(new Response(stream, { status: 200 }))
+      ) as unknown as typeof fetch;
+
+      const result = await adapter.downloadAttachments(
+        [{ id: 'F5', name: 'huge-stream.bin', url_private_download: 'https://files.slack.com/f5' }],
+        'C123:456.789'
+      );
+      expect(result.files).toEqual([]);
+    });
+
     test('skips a file when the download response is not ok', async () => {
       globalThis.fetch = mock(() =>
         Promise.resolve(new Response('', { status: 403 }))
@@ -830,6 +853,50 @@ describe('SlackAdapter', () => {
       expect(saved).not.toContain('..');
       // Nothing may remain that could climb out of the per-call directory.
       expect(basename(saved)).toBe(saved.slice(result.uploadDir.length + 1));
+    });
+
+    test('refuses to send the bot token to a download URL that is not a slack.com host', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(new Response('x', { status: 200 }))
+      ) as unknown as typeof fetch;
+
+      const result = await adapter.downloadAttachments(
+        [
+          {
+            id: 'F_EVIL',
+            name: 'a.txt',
+            size: 1,
+            // Not a Slack-controlled host — must be rejected before the bot
+            // token is ever attached to a request.
+            url_private_download: 'https://evil.example.com/f1',
+          },
+        ],
+        'C123:456.789'
+      );
+
+      expect(result.files).toEqual([]);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    test('refuses a non-HTTPS download URL even on a slack.com host', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(new Response('x', { status: 200 }))
+      ) as unknown as typeof fetch;
+
+      const result = await adapter.downloadAttachments(
+        [
+          {
+            id: 'F_HTTP',
+            name: 'a.txt',
+            size: 1,
+            url_private_download: 'http://files.slack.com/f1',
+          },
+        ],
+        'C123:456.789'
+      );
+
+      expect(result.files).toEqual([]);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
     });
 
     test('sanitizes the conversation id used as the directory segment', async () => {

--- a/packages/adapters/src/chat/slack/adapter.test.ts
+++ b/packages/adapters/src/chat/slack/adapter.test.ts
@@ -4,6 +4,7 @@
 import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
 import type { Mock } from 'bun:test';
 import { tmpdir } from 'node:os';
+import { basename, sep } from 'node:path';
 import { readFile, rm } from 'node:fs/promises';
 
 // Mock logger to suppress noisy output during tests
@@ -800,6 +801,49 @@ describe('SlackAdapter', () => {
       );
 
       expect(result.files).toEqual([]);
+    });
+
+    test('keeps a traversal-laden file id and name inside the upload dir', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(new Response('x', { status: 200 }))
+      ) as unknown as typeof fetch;
+
+      // Both components come from the Slack payload and are untrusted.
+      const result = await adapter.downloadAttachments(
+        [
+          {
+            id: '../../../etc',
+            name: '../../../etc/passwd',
+            size: 1,
+            url_private_download: 'https://files.slack.com/evil',
+          },
+        ],
+        'C123:456.789'
+      );
+      uploadDirs.push(result.uploadDir);
+
+      const saved = result.files[0]?.path ?? '';
+      expect(saved.startsWith(result.uploadDir + sep)).toBe(true);
+      expect(saved).not.toContain('..');
+      // Nothing may remain that could climb out of the per-call directory.
+      expect(basename(saved)).toBe(saved.slice(result.uploadDir.length + 1));
+    });
+
+    test('sanitizes the conversation id used as the directory segment', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(new Response('x', { status: 200 }))
+      ) as unknown as typeof fetch;
+
+      const result = await adapter.downloadAttachments(
+        [{ id: 'F1', name: 'a.txt', size: 1, url_private_download: 'https://files.slack.com/f1' }],
+        '../../escape:99.9'
+      );
+      uploadDirs.push(result.uploadDir);
+
+      // ':' is also invalid in Windows paths, so it must not survive either.
+      expect(basename(result.uploadDir)).not.toContain('..');
+      expect(basename(result.uploadDir)).not.toContain(':');
+      expect(result.uploadDir).toContain('uploads');
     });
 
     test('truncates to the max files per message', async () => {

--- a/packages/adapters/src/chat/slack/adapter.test.ts
+++ b/packages/adapters/src/chat/slack/adapter.test.ts
@@ -1,8 +1,10 @@
 /**
  * Unit tests for Slack adapter
  */
-import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
 import type { Mock } from 'bun:test';
+import { tmpdir } from 'node:os';
+import { readFile, rm } from 'node:fs/promises';
 
 // Mock logger to suppress noisy output during tests
 const mockLogger = {
@@ -22,6 +24,7 @@ const mockLogger = {
 mock.module('@archon/paths', () => ({
   captureApprovalResolved: () => undefined,
   createLogger: mock(() => mockLogger),
+  getArchonHome: mock(() => tmpdir()),
 }));
 
 // Create mock functions
@@ -615,6 +618,105 @@ describe('SlackAdapter', () => {
       const second = await adapter.fetchDisplayName('U_RETRY');
       expect(second).toBe('Eventually');
       expect(mockUsersInfo).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('downloadAttachments', () => {
+    let adapter: SlackAdapter;
+    const originalFetch = globalThis.fetch;
+    const uploadDirs: string[] = [];
+
+    beforeEach(() => {
+      adapter = new SlackAdapter('xoxb-fake', 'xapp-fake');
+    });
+
+    afterEach(async () => {
+      globalThis.fetch = originalFetch;
+      for (const dir of uploadDirs.splice(0)) {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    test('returns an empty result when there are no files', async () => {
+      const result = await adapter.downloadAttachments(undefined, 'C123:456.789');
+      expect(result.files).toEqual([]);
+      expect(result.uploadDir).toBe('');
+    });
+
+    test('downloads a file and saves it to disk as an AttachedFile', async () => {
+      const content = 'hello world';
+      globalThis.fetch = mock(() =>
+        Promise.resolve(new Response(content, { status: 200 }))
+      ) as unknown as typeof fetch;
+
+      const result = await adapter.downloadAttachments(
+        [
+          {
+            id: 'F1',
+            name: 'notes.txt',
+            mimetype: 'text/plain',
+            size: content.length,
+            url_private_download: 'https://files.slack.com/f1',
+          },
+        ],
+        'C123:456.789'
+      );
+      uploadDirs.push(result.uploadDir);
+
+      expect(result.files).toHaveLength(1);
+      expect(result.files[0]?.name).toBe('notes.txt');
+      expect(result.files[0]?.mimeType).toBe('text/plain');
+      expect(result.files[0]?.size).toBe(content.length);
+      const saved = await readFile(result.files[0]?.path ?? '', 'utf-8');
+      expect(saved).toBe(content);
+    });
+
+    test('skips a file over the size cap without failing the batch', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(new Response('irrelevant', { status: 200 }))
+      ) as unknown as typeof fetch;
+
+      const result = await adapter.downloadAttachments(
+        [
+          {
+            id: 'F2',
+            name: 'huge.bin',
+            size: 11 * 1024 * 1024,
+            url_private_download: 'https://files.slack.com/f2',
+          },
+        ],
+        'C123:456.789'
+      );
+      expect(result.files).toEqual([]);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    test('skips a file when the download response is not ok', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(new Response('', { status: 403 }))
+      ) as unknown as typeof fetch;
+
+      const result = await adapter.downloadAttachments(
+        [{ id: 'F3', name: 'blocked.txt', url_private_download: 'https://files.slack.com/f3' }],
+        'C123:456.789'
+      );
+      expect(result.files).toEqual([]);
+    });
+
+    test('truncates to the max files per message', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(new Response('x', { status: 200 }))
+      ) as unknown as typeof fetch;
+
+      const files = Array.from({ length: 7 }, (_, i) => ({
+        id: `F${i.toString()}`,
+        name: `f${i.toString()}.txt`,
+        size: 1,
+        url_private_download: `https://files.slack.com/f${i.toString()}`,
+      }));
+      const result = await adapter.downloadAttachments(files, 'C123:456.789');
+      uploadDirs.push(result.uploadDir);
+      expect(result.files).toHaveLength(5);
     });
   });
 });

--- a/packages/adapters/src/chat/slack/adapter.test.ts
+++ b/packages/adapters/src/chat/slack/adapter.test.ts
@@ -886,6 +886,82 @@ describe('SlackAdapter', () => {
       expect(scopeWarns).toHaveLength(0);
     });
 
+    test('reports why each attachment was dropped', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(new Response('', { status: 403 }))
+      ) as unknown as typeof fetch;
+
+      const result = await adapter.downloadAttachments(
+        [
+          {
+            id: 'F_BIG',
+            name: 'dump.sql',
+            size: 11 * 1024 * 1024,
+            url_private_download: 'https://files.slack.com/big',
+          },
+          { id: 'F_403', name: 'blocked.txt', url_private_download: 'https://files.slack.com/f' },
+          { id: 'F_NOURL', name: 'nourl.txt' },
+        ],
+        'C123:456.789'
+      );
+
+      expect(result.files).toEqual([]);
+      // Every drop must be attributable — that is what the user gets told.
+      expect(result.skipped).toEqual([
+        { name: 'dump.sql', reason: 'too_large' },
+        { name: 'blocked.txt', reason: 'download_failed' },
+        { name: 'nourl.txt', reason: 'download_failed' },
+      ]);
+    });
+
+    test('reports files dropped by the per-message cap as too_many', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(new Response('x', { status: 200 }))
+      ) as unknown as typeof fetch;
+
+      const files = Array.from({ length: 7 }, (_, i) => ({
+        id: `F${i.toString()}`,
+        name: `f${i.toString()}.txt`,
+        size: 1,
+        url_private_download: `https://files.slack.com/f${i.toString()}`,
+      }));
+      const result = await adapter.downloadAttachments(files, 'C123:456.789');
+      uploadDirs.push(result.uploadDir);
+
+      expect(result.files).toHaveLength(5);
+      expect(result.skipped).toEqual([
+        { name: 'f5.txt', reason: 'too_many' },
+        { name: 'f6.txt', reason: 'too_many' },
+      ]);
+    });
+
+    test('reports an aborted download as a timeout', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.reject(Object.assign(new Error('aborted'), { name: 'AbortError' }))
+      ) as unknown as typeof fetch;
+
+      const result = await adapter.downloadAttachments(
+        [{ id: 'F_SLOW', name: 'slow.pdf', url_private_download: 'https://files.slack.com/slow' }],
+        'C123:456.789'
+      );
+
+      expect(result.skipped).toEqual([{ name: 'slow.pdf', reason: 'timeout' }]);
+    });
+
+    test('reports nothing skipped on a clean download', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(new Response('x', { status: 200 }))
+      ) as unknown as typeof fetch;
+
+      const result = await adapter.downloadAttachments(
+        [{ id: 'F1', name: 'a.txt', size: 1, url_private_download: 'https://files.slack.com/f1' }],
+        'C123:456.789'
+      );
+      uploadDirs.push(result.uploadDir);
+
+      expect(result.skipped).toEqual([]);
+    });
+
     test('truncates to the max files per message', async () => {
       globalThis.fetch = mock(() =>
         Promise.resolve(new Response('x', { status: 200 }))

--- a/packages/adapters/src/chat/slack/adapter.test.ts
+++ b/packages/adapters/src/chat/slack/adapter.test.ts
@@ -629,6 +629,9 @@ describe('SlackAdapter', () => {
 
     beforeEach(() => {
       adapter = new SlackAdapter('xoxb-fake', 'xapp-fake');
+      // Warn counts are asserted below, and the shared mock accumulates across
+      // tests — an earlier 403 case would otherwise leak into those totals.
+      mockLogger.warn.mockClear();
     });
 
     afterEach(async () => {
@@ -844,6 +847,43 @@ describe('SlackAdapter', () => {
       expect(basename(result.uploadDir)).not.toContain('..');
       expect(basename(result.uploadDir)).not.toContain(':');
       expect(result.uploadDir).toContain('uploads');
+    });
+
+    test('warns once about files:read when downloads are rejected with 403', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(new Response('', { status: 403 }))
+      ) as unknown as typeof fetch;
+
+      await adapter.downloadAttachments(
+        [{ id: 'F1', name: 'a.txt', url_private_download: 'https://files.slack.com/f1' }],
+        'C123:456.789'
+      );
+      await adapter.downloadAttachments(
+        [{ id: 'F2', name: 'b.txt', url_private_download: 'https://files.slack.com/f2' }],
+        'C123:456.789'
+      );
+
+      // A standing misconfiguration: once per adapter, not once per file.
+      const scopeWarns = (mockLogger.warn as unknown as Mock<() => void>).mock.calls.filter(
+        c => c[1] === 'slack.files_read_missing_scope'
+      );
+      expect(scopeWarns).toHaveLength(1);
+    });
+
+    test('does not blame the scope for a non-auth failure', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(new Response('', { status: 500 }))
+      ) as unknown as typeof fetch;
+
+      await adapter.downloadAttachments(
+        [{ id: 'F1', name: 'a.txt', url_private_download: 'https://files.slack.com/f1' }],
+        'C123:456.789'
+      );
+
+      const scopeWarns = (mockLogger.warn as unknown as Mock<() => void>).mock.calls.filter(
+        c => c[1] === 'slack.files_read_missing_scope'
+      );
+      expect(scopeWarns).toHaveLength(0);
     });
 
     test('truncates to the max files per message', async () => {

--- a/packages/adapters/src/chat/slack/adapter.test.ts
+++ b/packages/adapters/src/chat/slack/adapter.test.ts
@@ -703,6 +703,105 @@ describe('SlackAdapter', () => {
       expect(result.files).toEqual([]);
     });
 
+    test('uses a unique upload dir per call so concurrent thread messages cannot collide', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(new Response('x', { status: 200 }))
+      ) as unknown as typeof fetch;
+
+      const file = {
+        id: 'F1',
+        name: 'a.txt',
+        size: 1,
+        url_private_download: 'https://files.slack.com/f1',
+      };
+      // Same conversation id — every message in a Slack thread shares one.
+      const first = await adapter.downloadAttachments([file], 'C123:456.789');
+      const second = await adapter.downloadAttachments([file], 'C123:456.789');
+      uploadDirs.push(first.uploadDir, second.uploadDir);
+
+      // Cleanup rm -rf's the whole dir, so sharing one would delete the other's
+      // still-unread files (the downloads happen outside the conversation lock).
+      expect(first.uploadDir).not.toBe(second.uploadDir);
+      expect(first.files[0]?.path).not.toBe(second.files[0]?.path);
+    });
+
+    test('skips an oversized file by Content-Length, without buffering the body', async () => {
+      let bodyRead = false;
+      globalThis.fetch = mock(() => {
+        const response = new Response('irrelevant', {
+          status: 200,
+          headers: { 'content-length': String(11 * 1024 * 1024) },
+        });
+        // Prove the body is never pulled into memory when the header alone
+        // already tells us the file is too big.
+        Object.defineProperty(response, 'arrayBuffer', {
+          value: () => {
+            bodyRead = true;
+            return Promise.resolve(new ArrayBuffer(0));
+          },
+        });
+        return Promise.resolve(response);
+      }) as unknown as typeof fetch;
+
+      // No `size` on the ref — the pre-flight metadata check cannot catch this.
+      const result = await adapter.downloadAttachments(
+        [{ id: 'F_BIG', name: 'big.bin', url_private_download: 'https://files.slack.com/big' }],
+        'C123:456.789'
+      );
+
+      expect(result.files).toEqual([]);
+      expect(bodyRead).toBe(false);
+    });
+
+    test('still catches an oversized file when Content-Length is absent', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(new Response('x'.repeat(11 * 1024 * 1024), { status: 200 }))
+      ) as unknown as typeof fetch;
+
+      const result = await adapter.downloadAttachments(
+        [{ id: 'F_NOLEN', name: 'big.bin', url_private_download: 'https://files.slack.com/nolen' }],
+        'C123:456.789'
+      );
+
+      expect(result.files).toEqual([]);
+    });
+
+    test('passes an abort signal so a stalled download cannot hang the message', async () => {
+      let sawSignal = false;
+      globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+        sawSignal = init?.signal instanceof AbortSignal;
+        return Promise.resolve(new Response('x', { status: 200 }));
+      }) as unknown as typeof fetch;
+
+      const result = await adapter.downloadAttachments(
+        [
+          {
+            id: 'F1',
+            name: 'a.txt',
+            size: 1,
+            url_private_download: 'https://files.slack.com/f1',
+          },
+        ],
+        'C123:456.789'
+      );
+      uploadDirs.push(result.uploadDir);
+
+      expect(sawSignal).toBe(true);
+    });
+
+    test('skips an aborted download without failing the batch', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.reject(Object.assign(new Error('aborted'), { name: 'AbortError' }))
+      ) as unknown as typeof fetch;
+
+      const result = await adapter.downloadAttachments(
+        [{ id: 'F_SLOW', name: 'slow.txt', url_private_download: 'https://files.slack.com/slow' }],
+        'C123:456.789'
+      );
+
+      expect(result.files).toEqual([]);
+    });
+
     test('truncates to the max files per message', async () => {
       globalThis.fetch = mock(() =>
         Promise.resolve(new Response('x', { status: 200 }))

--- a/packages/adapters/src/chat/slack/adapter.ts
+++ b/packages/adapters/src/chat/slack/adapter.ts
@@ -3,7 +3,7 @@
  * Handles message sending with markdown block formatting for AI responses
  */
 import { randomUUID } from 'node:crypto';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, rmdir, writeFile } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import { App, LogLevel, type SlashCommand } from '@slack/bolt';
 import type { AttachedFile, IPlatformAdapter, MessageMetadata } from '@archon/core';
@@ -42,6 +42,25 @@ const MAX_SLACK_FILES_PER_MESSAGE = 5;
  * enough that a dead endpoint doesn't strand the user waiting on a reply.
  */
 const SLACK_ATTACHMENT_TIMEOUT_MS = 30_000;
+
+/**
+ * Guards the bot token: `url_private_download` comes from the Slack event
+ * payload, not a fixed Archon-owned constant, so it must be proven to point at
+ * Slack's own file host before the Authorization header is attached to a
+ * request built from it. Requires HTTPS and a `slack.com` (or subdomain) host.
+ */
+function isTrustedSlackDownloadUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  return (
+    parsed.protocol === 'https:' &&
+    (parsed.hostname === 'slack.com' || parsed.hostname.endsWith('.slack.com'))
+  );
+}
 
 /** Slack channel + message ts pair used for reactions and edits. */
 export interface SlackMessageRef {
@@ -409,10 +428,20 @@ export class SlackAdapter implements IPlatformAdapter {
     );
 
     const saved: AttachedFile[] = [];
+    /** Set once `mkdir` has actually run, so a directory that ends up empty (every write below it failed) can be removed instead of left orphaned on disk. */
+    let dirCreated = false;
     for (const file of toDownload) {
       if (!file.url_private_download) {
         // No download URL at all — nothing to fetch, and nothing the user can
         // act on beyond knowing the file did not arrive.
+        skipped.push({ name: displayName(file), reason: 'download_failed' });
+        continue;
+      }
+      if (!isTrustedSlackDownloadUrl(file.url_private_download)) {
+        getLog().warn(
+          { conversationId, fileId: file.id },
+          'slack.attachment_untrusted_download_url'
+        );
         skipped.push({ name: displayName(file), reason: 'download_failed' });
         continue;
       }
@@ -435,6 +464,10 @@ export class SlackAdapter implements IPlatformAdapter {
         const response = await fetch(file.url_private_download, {
           headers: { Authorization: `Bearer ${this.botToken}` },
           signal: controller.signal,
+          // A redirect target is unverified — never let the token silently
+          // follow one. `response.ok` is false for a manual redirect status,
+          // so it falls through to the ordinary download-failed path below.
+          redirect: 'manual',
         });
         if (!response.ok) {
           // A 401/403 on an *authenticated* download is an auth problem rather
@@ -487,6 +520,7 @@ export class SlackAdapter implements IPlatformAdapter {
         }
 
         await mkdir(uploadDir, { recursive: true });
+        dirCreated = true;
         // BOTH path components are untrusted: they come from the Slack event
         // payload. `basename` drops any directory part of the name, then the
         // character classes leave nothing that can traverse. The id is stripped
@@ -524,6 +558,20 @@ export class SlackAdapter implements IPlatformAdapter {
       } finally {
         clearTimeout(timeout);
       }
+    }
+
+    if (dirCreated && saved.length === 0) {
+      // mkdir ran but every write after it failed (disk error, etc.) — the
+      // directory is empty, so remove it rather than leaving it orphaned.
+      // This is the ONLY cleanup for that case: the caller only deletes
+      // uploadDir when `files` comes back non-empty (server/index.ts guards
+      // its cleanup on `attachedFiles.length > 0`), so an empty result here
+      // would otherwise never get swept.
+      await rmdir(uploadDir).catch((err: NodeJS.ErrnoException) => {
+        if (err.code !== 'ENOENT' && err.code !== 'ENOTEMPTY') {
+          getLog().warn({ err, uploadDir, conversationId }, 'slack.attachment_dir_cleanup_failed');
+        }
+      });
     }
 
     getLog().info(

--- a/packages/adapters/src/chat/slack/adapter.ts
+++ b/packages/adapters/src/chat/slack/adapter.ts
@@ -2,8 +2,10 @@
  * Slack platform adapter using @slack/bolt with Socket Mode
  * Handles message sending with markdown block formatting for AI responses
  */
+import { mkdir, writeFile } from 'node:fs/promises';
+import { basename, join } from 'node:path';
 import { App, LogLevel, type SlashCommand } from '@slack/bolt';
-import type { IPlatformAdapter, MessageMetadata } from '@archon/core';
+import type { AttachedFile, IPlatformAdapter, MessageMetadata } from '@archon/core';
 import {
   isPerUserGitHubEnabled,
   connectGithubForUser,
@@ -12,12 +14,12 @@ import {
 } from '@archon/core';
 import * as userDb from '@archon/core/db/users';
 import type { TokenUsage } from '@archon/providers/types';
-import { createLogger } from '@archon/paths';
+import { createLogger, getArchonHome } from '@archon/paths';
 import { isSlackUserAuthorized } from './auth';
 import { parseAllowedUserIds } from './auth';
 import { splitIntoParagraphChunks } from '../../utils/message-splitting';
 import { formatCostFooter } from './blocks';
-import type { SlackMessageEvent } from './types';
+import type { SlackFileRef, SlackMessageEvent } from './types';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
@@ -27,6 +29,11 @@ function getLog(): ReturnType<typeof createLogger> {
 }
 
 const MAX_MARKDOWN_BLOCK_LENGTH = 12000; // Slack markdown block limit
+
+/** Maximum allowed download size per Slack file attachment (mirrors the Web upload cap). */
+const MAX_SLACK_FILE_BYTES = 10 * 1024 * 1024;
+/** Maximum number of file attachments downloaded per Slack message (mirrors the Web upload cap). */
+const MAX_SLACK_FILES_PER_MESSAGE = 5;
 
 /** Slack channel + message ts pair used for reactions and edits. */
 export interface SlackMessageRef {
@@ -39,6 +46,7 @@ const MAX_TRACKED_TRIGGERS = 1000;
 
 export class SlackAdapter implements IPlatformAdapter {
   private app: App;
+  private botToken: string;
   private streamingMode: 'stream' | 'batch';
   private messageHandler: ((event: SlackMessageEvent) => Promise<void>) | null = null;
   private allowedUserIds: string[];
@@ -66,6 +74,7 @@ export class SlackAdapter implements IPlatformAdapter {
       appToken: appToken,
       logLevel: LogLevel.INFO,
     });
+    this.botToken = botToken;
     this.streamingMode = mode;
 
     // Parse Slack user whitelist (optional - empty = open access)
@@ -329,6 +338,94 @@ export class SlackAdapter implements IPlatformAdapter {
   }
 
   /**
+   * Download Slack message file attachments to disk so they can be handed to
+   * the AI as `AttachedFile[]` (same shape the Web upload endpoint produces).
+   * Best-effort per file: an oversized or failed download is skipped with a
+   * WARN log rather than failing the whole message — Slack has no
+   * request/response cycle to surface a hard rejection to the user inline.
+   *
+   * Requires bot token scope `files:read`. Caller is responsible for deleting
+   * `uploadDir` after the AI has had a chance to read the files.
+   */
+  async downloadAttachments(
+    files: SlackFileRef[] | undefined,
+    conversationId: string
+  ): Promise<{ files: AttachedFile[]; uploadDir: string }> {
+    if (!files || files.length === 0) {
+      return { files: [], uploadDir: '' };
+    }
+
+    const toDownload = files.slice(0, MAX_SLACK_FILES_PER_MESSAGE);
+    if (files.length > MAX_SLACK_FILES_PER_MESSAGE) {
+      getLog().warn(
+        { conversationId, fileCount: files.length, limit: MAX_SLACK_FILES_PER_MESSAGE },
+        'slack.attachments_truncated'
+      );
+    }
+
+    // Slack conversation IDs are "channel:ts" — ':' is invalid in Windows
+    // directory names, so sanitize before using it as a path segment.
+    const safeConversationId = conversationId.replace(/[^a-zA-Z0-9_-]/g, '_');
+    const uploadDir = join(getArchonHome(), 'artifacts', 'uploads', `slack-${safeConversationId}`);
+
+    const saved: AttachedFile[] = [];
+    for (const file of toDownload) {
+      if (!file.url_private_download) continue;
+      if (file.size !== undefined && file.size > MAX_SLACK_FILE_BYTES) {
+        getLog().warn(
+          { conversationId, fileId: file.id, size: file.size },
+          'slack.attachment_too_large'
+        );
+        continue;
+      }
+
+      try {
+        const response = await fetch(file.url_private_download, {
+          headers: { Authorization: `Bearer ${this.botToken}` },
+        });
+        if (!response.ok) {
+          getLog().warn(
+            { conversationId, fileId: file.id, status: response.status },
+            'slack.attachment_download_failed'
+          );
+          continue;
+        }
+
+        const buffer = Buffer.from(await response.arrayBuffer());
+        if (buffer.byteLength > MAX_SLACK_FILE_BYTES) {
+          getLog().warn(
+            { conversationId, fileId: file.id, size: buffer.byteLength },
+            'slack.attachment_too_large'
+          );
+          continue;
+        }
+
+        await mkdir(uploadDir, { recursive: true });
+        const safeName = basename(file.name ?? file.id).replace(/[^a-zA-Z0-9._-]/g, '_');
+        const filePath = join(uploadDir, `${file.id}_${safeName}`);
+        await writeFile(filePath, buffer);
+        saved.push({
+          path: filePath,
+          name: safeName || file.id,
+          mimeType: file.mimetype ?? 'application/octet-stream',
+          size: buffer.byteLength,
+        });
+      } catch (error) {
+        getLog().warn(
+          { err: error as Error, conversationId, fileId: file.id },
+          'slack.attachment_download_error'
+        );
+      }
+    }
+
+    getLog().info(
+      { conversationId, requested: files.length, saved: saved.length },
+      'slack.attachments_downloaded'
+    );
+    return { files: saved, uploadDir };
+  }
+
+  /**
    * Get conversation ID from Slack event
    * For threads: returns "channel:thread_ts" to maintain thread context
    * For non-threads: returns channel ID only
@@ -407,6 +504,7 @@ export class SlackAdapter implements IPlatformAdapter {
           ts: event.ts,
           thread_ts: event.thread_ts,
           displayName,
+          files: (event as { files?: SlackFileRef[] }).files,
         };
         this.trackTrigger(this.getConversationId(messageEvent), {
           channel: event.channel,
@@ -449,6 +547,7 @@ export class SlackAdapter implements IPlatformAdapter {
           ts: event.ts,
           thread_ts: 'thread_ts' in event ? event.thread_ts : undefined,
           displayName,
+          files: (event as { files?: SlackFileRef[] }).files,
         };
         this.trackTrigger(this.getConversationId(messageEvent), {
           channel: event.channel,

--- a/packages/adapters/src/chat/slack/adapter.ts
+++ b/packages/adapters/src/chat/slack/adapter.ts
@@ -2,6 +2,7 @@
  * Slack platform adapter using @slack/bolt with Socket Mode
  * Handles message sending with markdown block formatting for AI responses
  */
+import { randomUUID } from 'node:crypto';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import { App, LogLevel, type SlashCommand } from '@slack/bolt';
@@ -34,6 +35,13 @@ const MAX_MARKDOWN_BLOCK_LENGTH = 12000; // Slack markdown block limit
 const MAX_SLACK_FILE_BYTES = 10 * 1024 * 1024;
 /** Maximum number of file attachments downloaded per Slack message (mirrors the Web upload cap). */
 const MAX_SLACK_FILES_PER_MESSAGE = 5;
+/**
+ * Per-attachment download deadline. Slack's file CDN has no guaranteed response
+ * time and `fetch` has no default timeout, so a stalled connection would hang
+ * this message forever. Generous enough for a 10 MB file on a slow link, short
+ * enough that a dead endpoint doesn't strand the user waiting on a reply.
+ */
+const SLACK_ATTACHMENT_TIMEOUT_MS = 30_000;
 
 /** Slack channel + message ts pair used for reactions and edits. */
 export interface SlackMessageRef {
@@ -365,8 +373,19 @@ export class SlackAdapter implements IPlatformAdapter {
 
     // Slack conversation IDs are "channel:ts" — ':' is invalid in Windows
     // directory names, so sanitize before using it as a path segment.
+    //
+    // The random suffix makes the directory unique PER CALL, not per
+    // conversation. Every message in a Slack thread shares one conversation id,
+    // downloads run outside the per-conversation lock, and the caller cleans up
+    // with a recursive delete — so a shared directory would let one message's
+    // cleanup wipe a concurrently-arriving sibling's still-unread attachments.
     const safeConversationId = conversationId.replace(/[^a-zA-Z0-9_-]/g, '_');
-    const uploadDir = join(getArchonHome(), 'artifacts', 'uploads', `slack-${safeConversationId}`);
+    const uploadDir = join(
+      getArchonHome(),
+      'artifacts',
+      'uploads',
+      `slack-${safeConversationId}-${randomUUID()}`
+    );
 
     const saved: AttachedFile[] = [];
     for (const file of toDownload) {
@@ -379,14 +398,35 @@ export class SlackAdapter implements IPlatformAdapter {
         continue;
       }
 
+      // Held across the body read as well as the request: a response that
+      // starts and then stalls mid-body must abort too, not hang forever.
+      const controller = new AbortController();
+      const timeout = setTimeout(() => {
+        controller.abort();
+      }, SLACK_ATTACHMENT_TIMEOUT_MS);
       try {
         const response = await fetch(file.url_private_download, {
           headers: { Authorization: `Bearer ${this.botToken}` },
+          signal: controller.signal,
         });
         if (!response.ok) {
           getLog().warn(
             { conversationId, fileId: file.id, status: response.status },
             'slack.attachment_download_failed'
+          );
+          continue;
+        }
+
+        // Reject oversized files BEFORE buffering them. `file.size` is optional
+        // on the event payload, so without this an attachment of any size gets
+        // pulled fully into memory just to be discarded — which would defeat
+        // the cap as a memory guard. The post-read check below still stands as
+        // a backstop for a missing or understated Content-Length.
+        const declaredLength = Number(response.headers.get('content-length'));
+        if (Number.isFinite(declaredLength) && declaredLength > MAX_SLACK_FILE_BYTES) {
+          getLog().warn(
+            { conversationId, fileId: file.id, size: declaredLength },
+            'slack.attachment_too_large'
           );
           continue;
         }
@@ -411,10 +451,20 @@ export class SlackAdapter implements IPlatformAdapter {
           size: buffer.byteLength,
         });
       } catch (error) {
+        // An abort here is our own deadline firing, not a Slack fault — log it
+        // distinctly so a slow CDN is not mistaken for a broken attachment.
+        const timedOut = (error as Error).name === 'AbortError';
         getLog().warn(
-          { err: error as Error, conversationId, fileId: file.id },
-          'slack.attachment_download_error'
+          {
+            err: error as Error,
+            conversationId,
+            fileId: file.id,
+            ...(timedOut ? { timeoutMs: SLACK_ATTACHMENT_TIMEOUT_MS } : {}),
+          },
+          timedOut ? 'slack.attachment_download_timeout' : 'slack.attachment_download_error'
         );
+      } finally {
+        clearTimeout(timeout);
       }
     }
 

--- a/packages/adapters/src/chat/slack/adapter.ts
+++ b/packages/adapters/src/chat/slack/adapter.ts
@@ -441,12 +441,20 @@ export class SlackAdapter implements IPlatformAdapter {
         }
 
         await mkdir(uploadDir, { recursive: true });
+        // BOTH path components are untrusted: they come from the Slack event
+        // payload. `basename` drops any directory part of the name, then the
+        // character classes leave nothing that can traverse. The id is stripped
+        // of dots as well — real Slack ids never contain one, and that removes
+        // any chance of a `..` segment. Without this, an id carrying separators
+        // would let writeFile escape uploadDir entirely. (The Web upload path
+        // sidesteps this by prefixing with a server-generated UUID instead.)
         const safeName = basename(file.name ?? file.id).replace(/[^a-zA-Z0-9._-]/g, '_');
-        const filePath = join(uploadDir, `${file.id}_${safeName}`);
+        const safeFileId = file.id.replace(/[^a-zA-Z0-9_-]/g, '_');
+        const filePath = join(uploadDir, `${safeFileId}_${safeName}`);
         await writeFile(filePath, buffer);
         saved.push({
           path: filePath,
-          name: safeName || file.id,
+          name: safeName || safeFileId,
           mimeType: file.mimetype ?? 'application/octet-stream',
           size: buffer.byteLength,
         });

--- a/packages/adapters/src/chat/slack/adapter.ts
+++ b/packages/adapters/src/chat/slack/adapter.ts
@@ -74,6 +74,13 @@ export class SlackAdapter implements IPlatformAdapter {
    * `missing_scope` is a permanent misconfiguration, not a per-user incident.
    */
   private missingScopeLogged = false;
+  /**
+   * Tripped the first time an attachment download is rejected with 401/403.
+   * Downloads are still attempted afterwards (the operator may reinstall with
+   * the scope), but the WARN fires once — a missing `files:read` is a standing
+   * misconfiguration, not a per-file incident.
+   */
+  private filesReadMissingScopeLogged = false;
 
   constructor(botToken: string, appToken: string, mode: 'stream' | 'batch' = 'batch') {
     this.app = new App({
@@ -410,6 +417,22 @@ export class SlackAdapter implements IPlatformAdapter {
           signal: controller.signal,
         });
         if (!response.ok) {
+          // A 401/403 on an *authenticated* download is an auth problem rather
+          // than a bad file — in practice, a bot token without `files:read`.
+          // Call that out once, so the operator isn't left reading a generic
+          // per-file failure and assuming the attachment itself is broken.
+          // Only these two statuses are unambiguous; other auth failure modes
+          // still surface as an ordinary download failure below.
+          if (
+            (response.status === 401 || response.status === 403) &&
+            !this.filesReadMissingScopeLogged
+          ) {
+            this.filesReadMissingScopeLogged = true;
+            getLog().warn(
+              { scope: 'files:read', status: response.status },
+              'slack.files_read_missing_scope'
+            );
+          }
           getLog().warn(
             { conversationId, fileId: file.id, status: response.status },
             'slack.attachment_download_failed'

--- a/packages/adapters/src/chat/slack/adapter.ts
+++ b/packages/adapters/src/chat/slack/adapter.ts
@@ -20,7 +20,7 @@ import { isSlackUserAuthorized } from './auth';
 import { parseAllowedUserIds } from './auth';
 import { splitIntoParagraphChunks } from '../../utils/message-splitting';
 import { formatCostFooter } from './blocks';
-import type { SlackFileRef, SlackMessageEvent } from './types';
+import type { SkippedSlackAttachment, SlackFileRef, SlackMessageEvent } from './types';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
@@ -355,9 +355,12 @@ export class SlackAdapter implements IPlatformAdapter {
   /**
    * Download Slack message file attachments to disk so they can be handed to
    * the AI as `AttachedFile[]` (same shape the Web upload endpoint produces).
-   * Best-effort per file: an oversized or failed download is skipped with a
-   * WARN log rather than failing the whole message — Slack has no
-   * request/response cycle to surface a hard rejection to the user inline.
+   *
+   * Best-effort per file: one oversized or failed download never fails the
+   * whole message. Unlike the Web endpoint there is no response in which to
+   * reject the request, so every drop is instead reported back in `skipped`
+   * for the caller to relay in-thread — a silently missing file is exactly the
+   * failure this feature exists to remove.
    *
    * Requires bot token scope `files:read`. Caller is responsible for deleting
    * `uploadDir` after the AI has had a chance to read the files.
@@ -365,10 +368,18 @@ export class SlackAdapter implements IPlatformAdapter {
   async downloadAttachments(
     files: SlackFileRef[] | undefined,
     conversationId: string
-  ): Promise<{ files: AttachedFile[]; uploadDir: string }> {
+  ): Promise<{
+    files: AttachedFile[];
+    uploadDir: string;
+    skipped: SkippedSlackAttachment[];
+  }> {
     if (!files || files.length === 0) {
-      return { files: [], uploadDir: '' };
+      return { files: [], uploadDir: '', skipped: [] };
     }
+
+    const skipped: SkippedSlackAttachment[] = [];
+    /** Display name for user-facing notices; the id is a last resort. */
+    const displayName = (file: SlackFileRef): string => file.name ?? file.id;
 
     const toDownload = files.slice(0, MAX_SLACK_FILES_PER_MESSAGE);
     if (files.length > MAX_SLACK_FILES_PER_MESSAGE) {
@@ -376,6 +387,9 @@ export class SlackAdapter implements IPlatformAdapter {
         { conversationId, fileCount: files.length, limit: MAX_SLACK_FILES_PER_MESSAGE },
         'slack.attachments_truncated'
       );
+      for (const dropped of files.slice(MAX_SLACK_FILES_PER_MESSAGE)) {
+        skipped.push({ name: displayName(dropped), reason: 'too_many' });
+      }
     }
 
     // Slack conversation IDs are "channel:ts" — ':' is invalid in Windows
@@ -396,12 +410,18 @@ export class SlackAdapter implements IPlatformAdapter {
 
     const saved: AttachedFile[] = [];
     for (const file of toDownload) {
-      if (!file.url_private_download) continue;
+      if (!file.url_private_download) {
+        // No download URL at all — nothing to fetch, and nothing the user can
+        // act on beyond knowing the file did not arrive.
+        skipped.push({ name: displayName(file), reason: 'download_failed' });
+        continue;
+      }
       if (file.size !== undefined && file.size > MAX_SLACK_FILE_BYTES) {
         getLog().warn(
           { conversationId, fileId: file.id, size: file.size },
           'slack.attachment_too_large'
         );
+        skipped.push({ name: displayName(file), reason: 'too_large' });
         continue;
       }
 
@@ -437,6 +457,7 @@ export class SlackAdapter implements IPlatformAdapter {
             { conversationId, fileId: file.id, status: response.status },
             'slack.attachment_download_failed'
           );
+          skipped.push({ name: displayName(file), reason: 'download_failed' });
           continue;
         }
 
@@ -451,6 +472,7 @@ export class SlackAdapter implements IPlatformAdapter {
             { conversationId, fileId: file.id, size: declaredLength },
             'slack.attachment_too_large'
           );
+          skipped.push({ name: displayName(file), reason: 'too_large' });
           continue;
         }
 
@@ -460,6 +482,7 @@ export class SlackAdapter implements IPlatformAdapter {
             { conversationId, fileId: file.id, size: buffer.byteLength },
             'slack.attachment_too_large'
           );
+          skipped.push({ name: displayName(file), reason: 'too_large' });
           continue;
         }
 
@@ -494,16 +517,20 @@ export class SlackAdapter implements IPlatformAdapter {
           },
           timedOut ? 'slack.attachment_download_timeout' : 'slack.attachment_download_error'
         );
+        skipped.push({
+          name: displayName(file),
+          reason: timedOut ? 'timeout' : 'download_failed',
+        });
       } finally {
         clearTimeout(timeout);
       }
     }
 
     getLog().info(
-      { conversationId, requested: files.length, saved: saved.length },
+      { conversationId, requested: files.length, saved: saved.length, skipped: skipped.length },
       'slack.attachments_downloaded'
     );
-    return { files: saved, uploadDir };
+    return { files: saved, uploadDir, skipped };
   }
 
   /**

--- a/packages/adapters/src/chat/slack/blocks.test.ts
+++ b/packages/adapters/src/chat/slack/blocks.test.ts
@@ -3,6 +3,7 @@ import {
   buildApprovalResolutionBlocks,
   buildStatusBlocks,
   formatCostFooter,
+  formatSkippedAttachmentsNotice,
   REACTION_FAILURE,
   REACTION_RUNNING,
   REACTION_SUCCESS,
@@ -227,5 +228,51 @@ describe('reaction name constants', () => {
     expect(REACTION_RUNNING).toBe('arrows_counterclockwise');
     expect(REACTION_SUCCESS).toBe('white_check_mark');
     expect(REACTION_FAILURE).toBe('x');
+  });
+});
+
+describe('formatSkippedAttachmentsNotice', () => {
+  test('returns empty string when nothing was skipped', () => {
+    // Caller posts unconditionally, so "" is the no-op signal.
+    expect(formatSkippedAttachmentsNotice([])).toBe('');
+  });
+
+  test('names the file and the reason for a single skip', () => {
+    const notice = formatSkippedAttachmentsNotice([{ name: 'dump.sql', reason: 'too_large' }]);
+
+    expect(notice).toContain('dump.sql');
+    expect(notice).toContain('10 MB');
+    expect(notice).toContain('attachment:');
+  });
+
+  test('consolidates several skips into ONE message', () => {
+    const notice = formatSkippedAttachmentsNotice([
+      { name: 'dump.sql', reason: 'too_large' },
+      { name: 'slow.pdf', reason: 'timeout' },
+    ]);
+
+    // A six-file drop must not produce six notices.
+    expect(notice.split('\n')).toHaveLength(1);
+    expect(notice).toContain('2 attachments');
+    expect(notice).toContain('dump.sql');
+    expect(notice).toContain('slow.pdf');
+    expect(notice).toContain('timed out');
+  });
+
+  test('renders every skip reason', () => {
+    for (const reason of ['too_large', 'too_many', 'timeout', 'download_failed'] as const) {
+      const notice = formatSkippedAttachmentsNotice([{ name: 'f.txt', reason }]);
+      expect(notice).toContain('f.txt');
+      // Each reason must produce prose, never a leaked enum value.
+      expect(notice).not.toContain(reason);
+    }
+  });
+
+  test('keeps operator-only detail out of the channel', () => {
+    const notice = formatSkippedAttachmentsNotice([{ name: 'a.txt', reason: 'download_failed' }]);
+
+    // A missing scope is an operator concern; the log carries it, not the user.
+    expect(notice).not.toContain('files:read');
+    expect(notice).not.toContain('scope');
   });
 });

--- a/packages/adapters/src/chat/slack/blocks.ts
+++ b/packages/adapters/src/chat/slack/blocks.ts
@@ -6,6 +6,7 @@
  */
 import type { types } from '@slack/bolt';
 import type { TokenUsage } from '@archon/providers/types';
+import type { SkippedSlackAttachment, SlackAttachmentSkipReason } from './types';
 
 type KnownBlock = types.KnownBlock;
 
@@ -67,6 +68,36 @@ function formatElapsed(ms: number): string {
  * Format a small italic cost footer line.
  * Returns null when there's nothing meaningful to display (no cost AND no tokens).
  */
+/** How each skip reason reads to the person who sent the file. */
+const SKIP_REASON_TEXT: Record<SlackAttachmentSkipReason, string> = {
+  too_large: 'over the 10 MB limit',
+  too_many: 'only the first 5 attachments are read',
+  timeout: 'download timed out',
+  download_failed: "couldn't be downloaded",
+};
+
+/**
+ * One consolidated in-thread notice for attachments that never reached the AI.
+ *
+ * Deliberately one message per inbound message rather than one per file: a
+ * six-file drop should not produce six notices. Returns '' when nothing was
+ * skipped, so the caller can post unconditionally.
+ *
+ * Reasons stay user-actionable (shrink it, send fewer, retry) — operator-level
+ * detail such as a missing `files:read` scope belongs in the server log, not
+ * in a channel.
+ */
+export function formatSkippedAttachmentsNotice(skipped: readonly SkippedSlackAttachment[]): string {
+  if (skipped.length === 0) return '';
+
+  const details = skipped
+    .map(item => `\`${item.name}\` (${SKIP_REASON_TEXT[item.reason]})`)
+    .join(', ');
+  const subject = skipped.length === 1 ? 'attachment' : `${String(skipped.length)} attachments`;
+
+  return `:warning: I couldn't read ${subject}: ${details}. Answering with the rest of your message.`;
+}
+
 export function formatCostFooter(input: {
   cost?: number;
   tokens?: TokenUsage;

--- a/packages/adapters/src/chat/slack/index.ts
+++ b/packages/adapters/src/chat/slack/index.ts
@@ -1,2 +1,3 @@
 export { SlackAdapter } from './adapter';
 export { SlackWorkflowBridge } from './workflow-bridge';
+export { formatSkippedAttachmentsNotice } from './blocks';

--- a/packages/adapters/src/chat/slack/types.ts
+++ b/packages/adapters/src/chat/slack/types.ts
@@ -1,4 +1,17 @@
 /**
+ * Raw Slack file attachment metadata, as it appears on `message`/`app_mention`
+ * events. `url_private_download` requires the bot token as a Bearer auth
+ * header to fetch (scope `files:read`).
+ */
+export interface SlackFileRef {
+  id: string;
+  name?: string;
+  mimetype?: string;
+  size?: number;
+  url_private_download?: string;
+}
+
+/**
  * Slack message event context for the message handler.
  * `displayName` is enriched lazily via `users.info` on first sight of a user;
  * undefined if the API call fails (e.g. missing `users:read` scope) — the
@@ -12,4 +25,5 @@ export interface SlackMessageEvent {
   ts: string;
   thread_ts?: string;
   displayName?: string;
+  files?: SlackFileRef[];
 }

--- a/packages/adapters/src/chat/slack/types.ts
+++ b/packages/adapters/src/chat/slack/types.ts
@@ -12,6 +12,20 @@ export interface SlackFileRef {
 }
 
 /**
+ * Why an attachment did not reach the AI. Returned so the caller can tell the
+ * user in-thread — a silently dropped file is indistinguishable, from the
+ * user's seat, from Archon not supporting attachments at all.
+ */
+export type SlackAttachmentSkipReason = 'too_large' | 'timeout' | 'download_failed' | 'too_many';
+
+/** An attachment that was not delivered, and the reason it was dropped. */
+export interface SkippedSlackAttachment {
+  /** Best available display name; falls back to the Slack file id. */
+  readonly name: string;
+  readonly reason: SlackAttachmentSkipReason;
+}
+
+/**
  * Slack message event context for the message handler.
  * `displayName` is enriched lazily via `users.info` on first sight of a user;
  * undefined if the API call fails (e.g. missing `users:read` scope) — the

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -1,6 +1,6 @@
 // Chat adapters
 export { TelegramAdapter } from './chat/telegram';
-export { SlackAdapter, SlackWorkflowBridge } from './chat/slack';
+export { SlackAdapter, SlackWorkflowBridge, formatSkippedAttachmentsNotice } from './chat/slack';
 
 // Forge adapters
 export { GitHubAdapter } from './forge/github';

--- a/packages/docs-web/src/content/docs/adapters/slack.md
+++ b/packages/docs-web/src/content/docs/adapters/slack.md
@@ -66,6 +66,7 @@ Archon uses **Socket Mode** for Slack integration, which means:
    - `reactions:write` -- Add lifecycle reactions (🔄 / ✅ / ❌) to the triggering message
    - `commands` -- Required for the `/archon` and `/archon-workflow` slash commands
    - `users:read` -- Look up real names via `users.info` for user attribution. The adapter degrades gracefully if this scope is missing (real names won't appear in the Archon DB, but messages still flow); a one-time `slack.users_info_missing_scope` warning surfaces the misconfiguration in the server log.
+   - `files:read` -- **Required to read file attachments.** Without it Archon cannot download files dropped in a message, and it answers as though no file were attached. Failed downloads log a one-time `slack.files_read_missing_scope` warning plus a per-file `slack.attachment_download_failed`; messages themselves are unaffected. See [File Attachments](#file-attachments).
 
 ## Step 4: Subscribe to Events
 
@@ -184,6 +185,36 @@ You can also DM the bot directly -- no @mention needed:
 /help
 ```
 
+### File Attachments
+
+Drop a file into the message and Archon can read it:
+
+```
+@your-bot summarise the attached spec
+```
+
+Requires the `files:read` bot scope (Step 3). Archon downloads each
+attachment with the bot token, hands the file to the AI for that message,
+and deletes it once the reply is finished -- attachments are never retained.
+
+Limits, matching the Web UI's upload caps:
+
+| Limit | Value | Behaviour when exceeded |
+| --- | --- | --- |
+| Size per file | 10 MB | That file is skipped, the rest of the message proceeds |
+| Files per message | 5 | Extra files are ignored (oldest 5 kept) |
+| Download time per file | 30 s | That file is skipped |
+
+Skipped attachments are logged (`slack.attachment_too_large`,
+`slack.attachment_download_failed`, `slack.attachment_download_timeout`) but
+never fail the message -- Slack has no request/response cycle in which to
+surface a hard rejection, so Archon answers with whatever it could read.
+
+:::caution
+Unlike the Web UI, the Slack path does not restrict attachments by file
+type; only the size, count, and time limits above apply.
+:::
+
 ## In-Thread UX
 
 When a workflow runs in a Slack thread, Archon now:
@@ -235,6 +266,22 @@ Ensure these scopes are added:
 
 - `channels:history` (public channels)
 - `groups:history` (private channels)
+
+### Archon Ignores an Attached File
+
+Archon replies as if no file were attached:
+
+1. **Check the `files:read` scope** (Step 3), then reinstall the app so
+   Slack issues a token that carries it. A
+   `slack.files_read_missing_scope` warning in the server log confirms this
+   is the cause.
+2. **Check the limits** -- files over 10 MB, beyond the fifth attachment in
+   one message, or slower than 30 s to download are skipped. Each logs its
+   own reason (`slack.attachment_too_large`,
+   `slack.attachments_truncated`, `slack.attachment_download_timeout`).
+3. **Check `slack.attachments_downloaded`** -- it logs `requested` vs
+   `saved` per message, which tells you immediately whether Archon saw the
+   file at all versus failed to fetch it.
 
 ## Security Recommendations
 

--- a/packages/docs-web/src/content/docs/adapters/slack.md
+++ b/packages/docs-web/src/content/docs/adapters/slack.md
@@ -205,10 +205,18 @@ Limits, matching the Web UI's upload caps:
 | Files per message | 5 | Extra files are ignored (oldest 5 kept) |
 | Download time per file | 30 s | That file is skipped |
 
-Skipped attachments are logged (`slack.attachment_too_large`,
-`slack.attachment_download_failed`, `slack.attachment_download_timeout`) but
-never fail the message -- Slack has no request/response cycle in which to
-surface a hard rejection, so Archon answers with whatever it could read.
+A skipped attachment never fails the message. Archon posts one short notice
+in the thread naming the files it could not read and why, then answers with
+the rest:
+
+> :warning: I couldn't read 2 attachments: `dump.sql` (over the 10 MB
+> limit), `slow.pdf` (download timed out). Answering with the rest of your
+> message.
+
+One notice per message, however many files were dropped. The matching
+server-log events (`slack.attachment_too_large`,
+`slack.attachment_download_failed`, `slack.attachment_download_timeout`,
+`slack.attachments_truncated`) carry the operator-level detail.
 
 :::caution
 Unlike the Web UI, the Slack path does not restrict attachments by file
@@ -269,7 +277,9 @@ Ensure these scopes are added:
 
 ### Archon Ignores an Attached File
 
-Archon replies as if no file were attached:
+If a limit was hit, Archon says so in the thread (see [File
+Attachments](#file-attachments)) -- start there. If it replies as though no
+file were attached at all, with no notice:
 
 1. **Check the `files:read` scope** (Step 3), then reinstall the app so
    Slack issues a token that carries it. A
@@ -279,9 +289,9 @@ Archon replies as if no file were attached:
    one message, or slower than 30 s to download are skipped. Each logs its
    own reason (`slack.attachment_too_large`,
    `slack.attachments_truncated`, `slack.attachment_download_timeout`).
-3. **Check `slack.attachments_downloaded`** -- it logs `requested` vs
-   `saved` per message, which tells you immediately whether Archon saw the
-   file at all versus failed to fetch it.
+3. **Check `slack.attachments_downloaded`** -- it logs `requested`, `saved`
+   and `skipped` per message, which tells you immediately whether Archon saw
+   the file at all versus failed to fetch it.
 
 ## Security Recommendations
 

--- a/packages/docs-web/src/content/docs/adapters/slack.md
+++ b/packages/docs-web/src/content/docs/adapters/slack.md
@@ -189,13 +189,14 @@ You can also DM the bot directly -- no @mention needed:
 
 Drop a file into the message and Archon can read it:
 
-```
+```text
 @your-bot summarise the attached spec
 ```
 
 Requires the `files:read` bot scope (Step 3). Archon downloads each
 attachment with the bot token, hands the file to the AI for that message,
-and deletes it once the reply is finished -- attachments are never retained.
+and deletes it once the reply is finished on a best-effort basis --
+attachments are not intentionally retained.
 
 Limits, matching the Web UI's upload caps:
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -68,6 +68,7 @@ import {
   DiscordAdapter,
   SlackAdapter,
   SlackWorkflowBridge,
+  formatSkippedAttachmentsNotice,
 } from '@archon/adapters';
 import { GiteaAdapter } from '@archon/adapters/community/forge/gitea';
 import { GitLabAdapter } from '@archon/adapters/community/forge/gitlab';
@@ -644,10 +645,24 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
         const userId = await resolveUserId('slack', event.user, event.displayName);
 
         // Download any file attachments up front (network I/O; doesn't need the lock).
-        const { files: attachedFiles, uploadDir } = await slackAdapter.downloadAttachments(
-          event.files,
-          conversationId
-        );
+        const {
+          files: attachedFiles,
+          uploadDir,
+          skipped: skippedAttachments,
+        } = await slackAdapter.downloadAttachments(event.files, conversationId);
+
+        // Tell the user about anything that did not make it through, BEFORE the
+        // reply lands, so a dropped file reads as a known limit rather than
+        // Archon ignoring the attachment. Never block the message on this.
+        const skipNotice = formatSkippedAttachmentsNotice(skippedAttachments);
+        if (skipNotice) {
+          await slackAdapter.sendMessage(conversationId, skipNotice).catch((err: unknown) => {
+            getLog().warn(
+              { err, conversationId, skipped: skippedAttachments.length },
+              'slack.attachment_skip_notice_failed'
+            );
+          });
+        }
 
         // Fire-and-forget: handler returns immediately, processing happens async
         lockManager

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -104,6 +104,7 @@ import {
 } from '@archon/core';
 import type { IPlatformAdapter } from '@archon/core';
 import type { IdentityPlatform } from '@archon/core';
+import { unlink, rm } from 'node:fs/promises';
 import * as userDb from '@archon/core/db/users';
 import {
   createLogger,
@@ -642,15 +643,50 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
         // the adapter's users.info enrichment (cached per slackUserId).
         const userId = await resolveUserId('slack', event.user, event.displayName);
 
+        // Download any file attachments up front (network I/O; doesn't need the lock).
+        const { files: attachedFiles, uploadDir } = await slackAdapter.downloadAttachments(
+          event.files,
+          conversationId
+        );
+
         // Fire-and-forget: handler returns immediately, processing happens async
         lockManager
           .acquireLock(conversationId, async () => {
-            await handleMessage(slackAdapter, conversationId, content, {
-              threadContext,
-              parentConversationId,
-              isolationHints: { workflowType: 'thread', workflowId: conversationId },
-              userId,
-            });
+            try {
+              await handleMessage(slackAdapter, conversationId, content, {
+                threadContext,
+                parentConversationId,
+                isolationHints: { workflowType: 'thread', workflowId: conversationId },
+                userId,
+                ...(attachedFiles.length > 0 ? { attachedFiles } : {}),
+              });
+            } finally {
+              // Clean up downloaded attachments AFTER handleMessage completes so the
+              // AI subprocess has had a chance to read them (mirrors the Web upload
+              // endpoint's dispatchToOrchestrator cleanup).
+              if (attachedFiles.length > 0) {
+                for (const f of attachedFiles) {
+                  await unlink(f.path).catch((err: NodeJS.ErrnoException) => {
+                    if (err.code !== 'ENOENT') {
+                      getLog().warn(
+                        { err, filePath: f.path, conversationId },
+                        'slack.attachment_cleanup_failed'
+                      );
+                    }
+                  });
+                }
+                await rm(uploadDir, { recursive: true, force: true }).catch(
+                  (err: NodeJS.ErrnoException) => {
+                    if (err.code !== 'ENOENT') {
+                      getLog().warn(
+                        { err, uploadDir, conversationId },
+                        'slack.attachment_dir_cleanup_failed'
+                      );
+                    }
+                  }
+                );
+              }
+            }
           })
           .catch(createMessageErrorHandler('Slack', slackAdapter, conversationId));
       });


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- **Problem**: attachments from a Slack channel were inaccessible — Slack's `app_mention`/DM events carry a `files[]` array, but `SlackMessageEvent` never captured it and nothing downloaded the bytes. The `AttachedFile` mechanism `handleMessage` uses to hand files to the AI was only ever populated by the Web upload endpoint.
- **Why it matters**: sometimes we provide a file to get a summary. Today the user attaches a file, asks for a summary, and Archon answers as though nothing were attached — with no error and no explanation.
- **What changed**: the Slack adapter was extended to forward and download attachments, hand them to the AI, clean them up afterwards, and tell the user in-thread about anything it could not read.
- **What did *not* change (scope boundary)**: no other adapter (Telegram, GitHub, Discord, Web) is touched; the Web upload endpoint is untouched, and the Slack limits deliberately mirror its existing caps rather than introducing new config. No new config keys, no schema changes, no changes to `handleMessage` or the orchestrator — this PR only *populates* an input that already existed.

## UX Journey

### Before

```
- User asks @Archon to provide a summary of the attached file, and receives nothing (as Archon sees no file)

  User (Slack)              SlackAdapter              Archon core / AI
  ───────────                ───────────               ─────────────────
  drops file + @mentions ──▶ builds SlackMessageEvent
                              (files[] ignored)   ──▶  handleMessage (no attachedFiles)
                                                        AI answers with no knowledge
  sees a reply ignoring the file ◀──────────────────    of the attachment
```

### After

<img width="1094" height="1539" alt="image" src="https://github.com/user-attachments/assets/3f5b8620-f4c3-4ca6-aa50-8f3be5c1f820" />

```
  User (Slack)              SlackAdapter                        Archon core / AI
  ───────────                ───────────                         ─────────────────
  drops file + @mentions ──▶ builds SlackMessageEvent (*files[]*)
                              [+] downloadAttachments()
                                  ├─ GET url_private_download (Bearer bot token, 30s deadline)
                                  ├─ enforce 10MB/file, 5 files/msg
                                  ├─ save to ~/.archon/artifacts/uploads/slack-<conv>-<uuid>/
                                  └─ report anything skipped, with a reason
  [+] sees "couldn't read X" ◀── *one consolidated notice, if anything was dropped*
                              ──▶ handleMessage(..., *attachedFiles*) ──▶ AI reads the file
                                  [+] cleanup (unlink + rmdir) after handleMessage returns
  sees a reply that reflects the file's content ◀──────────────────
```

## Architecture Diagram

### Before

```
Slack ──▶ SlackAdapter.onMessage ──▶ server/index.ts ──▶ handleMessage ──▶ orchestrator ──▶ AI provider
                                                          (attachedFiles never set)

routes/api.ts (Web upload) ──▶ persistUploadedFiles ──▶ ~/.archon/artifacts/uploads/<convId>/
                           └──▶ handleMessage(attachedFiles)   ← the ONLY producer today
```

### After

```
Slack ──▶ SlackAdapter.onMessage ──▶ server/index.ts
                                        │
                                        ├──▶ [~] SlackAdapter.downloadAttachments()
                                        │        ═══▶ [+] Slack Files API (url_private_download)
                                        │        ═══▶ [+] ~/.archon/artifacts/uploads/slack-<conv>-<uuid>/
                                        │        └──▶ returns { files, uploadDir, skipped }
                                        │
                                        ├──▶ [+] blocks.formatSkippedAttachmentsNotice(skipped)
                                        │        ═══▶ [+] SlackAdapter.sendMessage()  (in-thread notice)
                                        │
                                        └──▶ [~] handleMessage(..., attachedFiles) ──▶ orchestrator ──▶ AI provider
                                                 └──[+] finally: unlink files + rm uploadDir

routes/api.ts (Web upload) ──▶ persistUploadedFiles ──▶ ~/.archon/artifacts/uploads/<convId>/   (unchanged)
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| Slack (Bolt socket) | `SlackAdapter.onMessage` | unchanged | Now also carries `files[]` on the event object |
| `chat/slack/adapter.ts` | Slack Files API (`url_private_download`) | **new** | Bearer bot-token auth; requires the `files:read` scope; 30 s `AbortController` deadline |
| `chat/slack/adapter.ts` | local disk (`~/.archon/artifacts/uploads/slack-*/`) | **new** | One directory per *call* (random suffix), written then deleted |
| `chat/slack/adapter.ts` | `chat/slack/types.ts` | **modified** | Adds `SlackFileRef`, `SkippedSlackAttachment`, `SlackAttachmentSkipReason` |
| `chat/slack/blocks.ts` | `chat/slack/types.ts` | **new** | Formatter consumes the skip reasons |
| `server/src/index.ts` | `SlackAdapter.downloadAttachments` | **new** | Called before the conversation lock (network I/O doesn't need it) |
| `server/src/index.ts` | `formatSkippedAttachmentsNotice` → `SlackAdapter.sendMessage` | **new** | One in-thread notice per message, best-effort |
| `server/src/index.ts` | `handleMessage` | **modified** | Now passes `attachedFiles`; cleans the files up in a `finally` |
| `handleMessage` / orchestrator / AI provider | — | unchanged | `AttachedFile` plumbing already existed; this PR only supplies it |
| Web upload endpoint (`routes/api.ts`) | — | unchanged | Deliberately untouched; Slack mirrors its caps |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `adapters`
- Module: `adapters:slack`

## Change Metadata

- Change type: `bug`
- Primary scope: `adapters`

## Linked Issue

- Closes #2298

## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check    # PASS - all packages
bun run lint          # PASS - 0 warnings
bun run format:check  # PASS
bun run test          # PASS - @archon/adapters and @archon/server suites, 0 failures
```

- Evidence provided (test/log/trace/screenshot):

<img width="3008" height="402" alt="image" src="https://github.com/user-attachments/assets/d5577227-46d9-4da2-8c54-763b313a81f6" />

Plus **28 new unit tests** (78 passing across the two touched test files):

| Area | Covers |
|---|---|
| `downloadAttachments` – happy path | empty input, successful download + disk write, nothing reported as skipped |
| Limits | oversized by declared size, by `Content-Length` *without reading the body*, by buffered length when no header is sent; 5-file truncation |
| Timeout | an abort signal is passed to `fetch`; an aborted download is skipped, not fatal |
| Isolation | two calls on the *same* conversation id get different upload directories |
| Path safety | a traversal-laden file id **and** name stay inside the upload dir; a conversation id containing `../` and `:` never leaks into the directory segment |
| Scope diagnosis | `files:read` warning fires once across repeated 403s; a 500 does not trigger it |
| Skip reporting | every drop reports a reason; per-message cap reports `too_many`; abort reports `timeout` |
| Notice formatting | empty input, singular, several skips consolidated into **one** line, every reason renders as prose, no operator-only detail leaks to the channel |

- If any command is intentionally skipped, explain why: `bun run test:install` is a bash installer smoke test hard-gated to WSL2/Linux and cannot run on native Windows; it is unrelated to this change.

## Security Impact (required)

- New permissions/capabilities? (`Yes`) — the Slack bot token now needs the **`files:read`** scope to fetch `url_private_download`. No other scope changes. Without it the feature degrades: a one-time `slack.files_read_missing_scope` warning is logged, the user is told the file could not be downloaded, and messages otherwise flow normally.
- New external network calls? (`Yes`) — the adapter fetches attachment bytes directly from Slack's file CDN, authenticated with the existing bot token. Bounded by a 30 s `AbortController` deadline, a 10 MB size cap enforced *before* buffering, and 5 files per message.
- Secrets/tokens handling changed? (`No`) — reuses the bot token the adapter already holds; it is sent only as an `Authorization` header to Slack and is never logged.
- File system access scope changed? (`Yes`) — writes attachment bytes under `~/.archon/artifacts/uploads/slack-<conversation>-<uuid>/`, mirroring the Web upload endpoint's existing location. Files are deleted after the AI has read them.
- If any `Yes`, describe risk and mitigation:
  - **Path traversal.** Both path components come from the Slack payload. The conversation id is stripped to `[a-zA-Z0-9_-]`, the filename goes through `basename()` plus a character allowlist, and the Slack file id is stripped of separators *and* dots so no `..` segment can form. Two regression tests assert a hostile id/name still lands inside the upload directory.
  - **Memory exhaustion.** `file.size` is optional in Slack's payload, so the cap is enforced against `Content-Length` before the body is read, with the post-read length check retained as a backstop for a missing or understated header.
  - **Unbounded wait.** `fetch` has no default timeout; a 30 s deadline is held across the body read, so a stalled CDN connection cannot hang the message.
  - **Cross-message interference.** Every call gets its own upload directory, so the recursive cleanup can only ever delete files that call created.

## Compatibility / Migration

- Backward compatible? (`Yes`) — purely additive. An install that does not add `files:read` behaves exactly as before, minus a log line and a user-facing notice.
- Config/env changes? (`No`) — no new config keys or environment variables. Limits intentionally mirror the Web upload endpoint's existing constants rather than becoming configurable.
- Database migration needed? (`No`)
- If yes, exact upgrade steps: add `files:read` under **OAuth & Permissions → Bot Token Scopes** and reinstall the Slack app so a token carrying the scope is issued. Documented in the Slack adapter guide.

## Human Verification (required)

What was personally validated beyond CI:

- **Verified scenarios**: attaching a file in Slack and asking for a summary now works end to end — Archon reads the file and answers from its contents (screenshot above).
- **Edge cases checked** (unit-level, against a mocked Slack API): oversized files with and without a declared size, a `Content-Length` that alone exceeds the cap, more than five attachments in one message, a non-OK response, an aborted/timed-out download, a file reference with no download URL, hostile `..`/`:` characters in both the file id and the conversation id, and repeated 403s.
- **What was not verified**: the concurrency race that motivated the per-call upload directory was reasoned about and covered by a unit test, but not reproduced against a live workspace — it needs two attachment-bearing messages in the same thread within the same download window. The 30 s timeout and the `files:read` failure path were likewise exercised with mocks rather than a real slow CDN or a real de-scoped token.

## Side Effects / Blast Radius (required)

- **Affected subsystems/workflows**: the Slack adapter (`packages/adapters/src/chat/slack/`) and the Slack branch of `packages/server/src/index.ts`. No other adapter, no orchestrator or workflow change, no shared module altered in a way another surface consumes.
- **Potential unintended effects**: attachment downloads add network I/O before the conversation lock, so a very large or slow file delays that message's reply (bounded at 30 s per file). Disk usage under `~/.archon/artifacts/uploads/` if the process is killed between download and cleanup — cleanup lives in a `finally`, so this needs an abrupt termination rather than an error. The in-thread skip notice adds at most one extra message per inbound message.
- **Guardrails/monitoring for early detection**: structured logs on every path — `slack.attachments_downloaded` (with `requested` / `saved` / `skipped` counts per message), `slack.attachment_too_large`, `slack.attachments_truncated`, `slack.attachment_download_failed`, `slack.attachment_download_timeout`, `slack.attachment_download_error`, `slack.files_read_missing_scope`, `slack.attachment_cleanup_failed`, `slack.attachment_dir_cleanup_failed`, `slack.attachment_skip_notice_failed`. `ENOENT` is treated as success during cleanup so an already-removed file is not noise.

## Rollback Plan (required)

- **Fast rollback command/path**: revert the PR merge commit. The change is additive and self-contained to the Slack adapter plus one call site; there is no schema, config, or migration to unwind, and no other surface depends on the new exports.
- **Feature flags or config toggles (if any)**: none. Behaviour is gated implicitly by the bot token's scopes — removing `files:read` disables downloading without a code change or restart.
- **Observable failure symptoms**: repeated `slack.attachment_download_failed` with 401/403 (usually a missing `files:read` scope, confirmed by the one-time `slack.files_read_missing_scope`); users reporting "Archon ignored my file" with no accompanying notice; growth in `~/.archon/artifacts/uploads/slack-*` directories, which would indicate cleanup is not running.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- **Risk**: a missing `files:read` scope silently disables the whole feature.
  - **Mitigation**: a one-time `slack.files_read_missing_scope` warning for the operator, a user-facing notice that the file could not be downloaded, plus the scope being documented in the setup steps and a dedicated troubleshooting entry.
- **Risk**: an attachment is skipped and the user assumes Archon is broken — the exact failure this PR exists to remove.
  - **Mitigation**: one consolidated in-thread notice naming each dropped file and a user-actionable reason ("over the 10 MB limit", "download timed out"). Posting it is best-effort and can never cost the user their reply.
- **Risk**: concurrent messages in one Slack thread interfering with each other's attachments, since downloads run outside the per-conversation lock and cleanup deletes recursively.
  - **Mitigation**: each call writes to its own uniquely-suffixed directory, so cleanup can only touch its own files. Covered by a unit test.
- **Risk**: attachments are not filtered by file type, unlike the Web upload endpoint, which applies an allowlist.
  - **Mitigation**: accepted and now documented explicitly. Files are only read by the AI, never executed, and size/count/time limits still apply. Adding a shared allowlist would mean changing the Web upload path too, which is outside this PR's scope.
- **Risk**: orphaned upload directories if the process is killed mid-message.
  - **Mitigation**: cleanup runs in a `finally`, so it survives errors and normal failures; only an abrupt termination leaks, bounded at 50 MB per affected message. No hygiene sweep exists for `artifacts/uploads` today — this is pre-existing behaviour shared with the Web upload path and is best addressed separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slack messages can now include downloaded file attachments.
  * Attachments are validated, size-limited, securely stored, and automatically cleaned up after processing.
  * Users receive clear notices when attachments are skipped, including the reason.

* **Bug Fixes**
  * Improved handling of unavailable, oversized, invalid, timed-out, or failed downloads.
  * Added protections against unsafe attachment paths and unauthorized URL access.

* **Documentation**
  * Documented required Slack permissions, attachment limits, skipped-file behavior, cleanup, and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->