### PR TITLE
Correlate workflow tool lifecycle events

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -5435,6 +5435,29 @@ describe('workflowRunCommand — progress rendering', () => {
     expect(stderrSpy).toHaveBeenCalledWith('[classify] tool: Bash (42ms, call-1, error, exit 1)\n');
   });
 
+  it('should render a legacy tool completion without optional metadata', async () => {
+    setupWorkflowMocks();
+
+    const { executeWorkflow } = require('@archon/workflows/executor');
+    (executeWorkflow as ReturnType<typeof mock>).mockImplementationOnce(async () => {
+      if (capturedSubscribeHandler) {
+        capturedSubscribeHandler({
+          type: 'tool_completed',
+          runId: 'run-1',
+          toolName: 'Bash',
+          stepName: 'classify',
+          durationMs: 42,
+          toolCallId: 'call-1',
+        });
+      }
+      return { success: true, workflowRunId: 'run-1' };
+    });
+
+    await workflowRunCommand('/test/path', 'plan', 'hello', { verbose: true });
+
+    expect(stderrSpy).toHaveBeenCalledWith('[classify] tool: Bash (42ms, call-1)\n');
+  });
+
   it('should call unsubscribe even when executeWorkflow throws', async () => {
     setupWorkflowMocks();
 

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -5391,6 +5391,7 @@ describe('workflowRunCommand — progress rendering', () => {
           runId: 'run-1',
           toolName: 'Bash',
           stepName: 'classify',
+          toolCallId: 'call-1',
         });
       }
       return { success: true, workflowRunId: 'run-1' };
@@ -5412,6 +5413,7 @@ describe('workflowRunCommand — progress rendering', () => {
           runId: 'run-1',
           toolName: 'Bash',
           stepName: 'classify',
+          toolCallId: 'call-1',
         });
         capturedSubscribeHandler({
           type: 'tool_completed',
@@ -5419,6 +5421,9 @@ describe('workflowRunCommand — progress rendering', () => {
           toolName: 'Bash',
           stepName: 'classify',
           durationMs: 42,
+          toolCallId: 'call-1',
+          toolOutcome: 'error',
+          exitCode: 1,
         });
       }
       return { success: true, workflowRunId: 'run-1' };
@@ -5426,8 +5431,8 @@ describe('workflowRunCommand — progress rendering', () => {
 
     await workflowRunCommand('/test/path', 'plan', 'hello', { verbose: true });
 
-    expect(stderrSpy).toHaveBeenCalledWith('[classify] tool: Bash (started)\n');
-    expect(stderrSpy).toHaveBeenCalledWith('[classify] tool: Bash (42ms)\n');
+    expect(stderrSpy).toHaveBeenCalledWith('[classify] tool: Bash (started, call-1)\n');
+    expect(stderrSpy).toHaveBeenCalledWith('[classify] tool: Bash (42ms, call-1, error, exit 1)\n');
   });
 
   it('should call unsubscribe even when executeWorkflow throws', async () => {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -717,13 +717,17 @@ function renderWorkflowEvent(event: WorkflowEmitterEvent, verbose: boolean): voi
     }
     case 'tool_started':
       if (verbose) {
-        process.stderr.write(`[${event.stepName}] tool: ${event.toolName} (started)\n`);
+        process.stderr.write(
+          `[${event.stepName}] tool: ${event.toolName} (started, ${event.toolCallId})\n`
+        );
       }
       break;
     case 'tool_completed':
       if (verbose) {
+        const outcome = event.toolOutcome ? `, ${event.toolOutcome}` : '';
+        const exitCode = event.exitCode !== undefined ? `, exit ${String(event.exitCode)}` : '';
         process.stderr.write(
-          `[${event.stepName}] tool: ${event.toolName} (${String(event.durationMs)}ms)\n`
+          `[${event.stepName}] tool: ${event.toolName} (${String(event.durationMs)}ms, ${event.toolCallId}${outcome}${exitCode})\n`
         );
       }
       break;

--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -1929,6 +1929,29 @@ describe('sendQuery decomposition behaviors', () => {
     ]);
   });
 
+  test('terminal tool result queue drain preserves hook outcome', async () => {
+    mockQuery.mockImplementation(async function* (args: {
+      options: {
+        hooks?: Record<string, Array<{ hooks: Array<(input: unknown) => Promise<unknown>> }>>;
+      };
+    }) {
+      yield { type: 'assistant', message: { content: [{ type: 'text', text: 'done' }] } };
+      const successHook = args.options.hooks?.PostToolUse?.[0]?.hooks?.[0];
+      await successHook?.({ tool_name: 'Read', tool_use_id: 'late-id', tool_response: 'ok' });
+    });
+
+    const chunks = [];
+    for await (const chunk of client.sendQuery('test', '/workspace')) chunks.push(chunk);
+
+    expect(chunks).toContainEqual({
+      type: 'tool_result',
+      toolName: 'Read',
+      toolOutput: 'ok',
+      toolCallId: 'late-id',
+      toolOutcome: 'success',
+    });
+  });
+
   test('PostToolUse hook handles circular reference without crashing', async () => {
     mockQuery.mockImplementation(async function* (args: {
       options: {

--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -1877,6 +1877,58 @@ describe('sendQuery decomposition behaviors', () => {
     expect(err.message).toContain('diagnostic: something broke');
   }, 5_000);
 
+  test('PostToolUse hooks preserve success, failure, and interruption outcomes', async () => {
+    mockQuery.mockImplementation(async function* (args: {
+      options: {
+        hooks?: Record<string, Array<{ hooks: Array<(input: unknown) => Promise<unknown>> }>>;
+      };
+    }) {
+      const successHook = args.options.hooks?.PostToolUse?.[0]?.hooks?.[0];
+      const failureHook = args.options.hooks?.PostToolUseFailure?.[0]?.hooks?.[0];
+      await successHook?.({ tool_name: 'Read', tool_use_id: 'success-id', tool_response: 'ok' });
+      await failureHook?.({
+        tool_name: 'Bash',
+        tool_use_id: 'error-id',
+        error: 'exit 1',
+        is_interrupt: false,
+      });
+      await failureHook?.({
+        tool_name: 'Task',
+        tool_use_id: 'interrupt-id',
+        error: 'stopped',
+        is_interrupt: true,
+      });
+      yield { type: 'assistant', message: { content: [{ type: 'text', text: 'done' }] } };
+    });
+
+    const chunks = [];
+    for await (const chunk of client.sendQuery('test', '/workspace')) chunks.push(chunk);
+
+    expect(chunks.slice(0, 3)).toEqual([
+      {
+        type: 'tool_result',
+        toolName: 'Read',
+        toolOutput: 'ok',
+        toolCallId: 'success-id',
+        toolOutcome: 'success',
+      },
+      {
+        type: 'tool_result',
+        toolName: 'Bash',
+        toolOutput: '❌ Error: exit 1',
+        toolCallId: 'error-id',
+        toolOutcome: 'error',
+      },
+      {
+        type: 'tool_result',
+        toolName: 'Task',
+        toolOutput: '⚠️ Interrupted: stopped',
+        toolCallId: 'interrupt-id',
+        toolOutcome: 'interrupted',
+      },
+    ]);
+  });
+
   test('PostToolUse hook handles circular reference without crashing', async () => {
     mockQuery.mockImplementation(async function* (args: {
       options: {

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -639,6 +639,7 @@ interface ToolResultEntry {
   toolName: string;
   toolOutput: string;
   toolCallId?: string;
+  toolOutcome: 'success' | 'error' | 'interrupted';
 }
 
 /** Bun-runnable JS extensions. `.ts`/`.tsx`/`.jsx` are excluded — the SDK has
@@ -796,6 +797,7 @@ function buildToolCaptureHooks(toolResultQueue: ToolResultEntry[]): Options['hoo
                 toolName,
                 toolOutput: output.length > maxLen ? output.slice(0, maxLen) + '...' : output,
                 ...(toolUseId !== undefined ? { toolCallId: toolUseId } : {}),
+                toolOutcome: 'success',
               });
             } catch (e) {
               getLog().error({ err: e, input }, 'claude.post_tool_use_hook_error');
@@ -823,6 +825,7 @@ function buildToolCaptureHooks(toolResultQueue: ToolResultEntry[]): Options['hoo
                 toolName,
                 toolOutput: `${prefix}: ${errorText}`,
                 ...(toolUseId !== undefined ? { toolCallId: toolUseId } : {}),
+                toolOutcome: isInterrupt ? 'interrupted' : 'error',
               });
             } catch (e) {
               getLog().error({ err: e, input }, 'claude.post_tool_use_failure_hook_error');
@@ -861,6 +864,7 @@ async function* streamClaudeMessages(
           toolName: tr.toolName,
           toolOutput: tr.toolOutput,
           ...(tr.toolCallId !== undefined ? { toolCallId: tr.toolCallId } : {}),
+          toolOutcome: tr.toolOutcome,
         };
       }
     }

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -1150,6 +1150,7 @@ async function* streamClaudeMessages(
         toolName: tr.toolName,
         toolOutput: tr.toolOutput,
         ...(tr.toolCallId !== undefined ? { toolCallId: tr.toolCallId } : {}),
+        toolOutcome: tr.toolOutcome,
       };
     }
   }

--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -246,6 +246,8 @@ describe('CodexProvider', () => {
         toolName: 'npm test',
         toolOutput: 'tests passed\n',
         toolCallId: 'cmd-1',
+        toolOutcome: 'success',
+        exitCode: 0,
       });
     });
 
@@ -280,6 +282,8 @@ describe('CodexProvider', () => {
         toolName: 'npm test',
         toolOutput: 'failure\n\n[exit code: 1]',
         toolCallId: 'cmd-2',
+        toolOutcome: 'error',
+        exitCode: 1,
       });
     });
 
@@ -576,6 +580,7 @@ describe('CodexProvider', () => {
         toolName: '\u{1F50C} MCP: fs/readFile',
         toolOutput: '',
         toolCallId: 'mcp-1',
+        toolOutcome: 'success',
       });
       expect(chunks[2]).toEqual({
         type: 'tool',
@@ -587,6 +592,7 @@ describe('CodexProvider', () => {
         toolName: '\u{1F50C} MCP: fs/readFile',
         toolOutput: '\u274C Error: Permission denied',
         toolCallId: 'mcp-2',
+        toolOutcome: 'error',
       });
       expect(mockLogger.warn).toHaveBeenCalledWith(
         expect.objectContaining({ server: 'fs', tool: 'readFile' }),
@@ -640,6 +646,7 @@ describe('CodexProvider', () => {
         toolName: '\u{1F50C} MCP: readFile',
         toolOutput: '',
         toolCallId: 'mcp-tool',
+        toolOutcome: 'success',
       });
       expect(chunks[2]).toEqual({
         type: 'tool',
@@ -651,6 +658,7 @@ describe('CodexProvider', () => {
         toolName: '\u{1F50C} MCP: fs',
         toolOutput: '',
         toolCallId: 'mcp-server',
+        toolOutcome: 'success',
       });
       expect(chunks[4]).toEqual({
         type: 'tool',
@@ -662,6 +670,7 @@ describe('CodexProvider', () => {
         toolName: '\u{1F50C} MCP: MCP tool',
         toolOutput: '',
         toolCallId: 'mcp-unknown',
+        toolOutcome: 'success',
       });
     });
 
@@ -701,6 +710,7 @@ describe('CodexProvider', () => {
         toolName: '\u{1F50C} MCP: db/query',
         toolOutput: '\u274C Error: MCP tool failed',
         toolCallId: 'mcp-failure',
+        toolOutcome: 'error',
       });
     });
 
@@ -742,6 +752,7 @@ describe('CodexProvider', () => {
         toolName: '\u{1F50C} MCP: fs/readFile',
         toolOutput: JSON.stringify([{ type: 'text', text: 'file contents' }]),
         toolCallId: 'mcp-completed',
+        toolOutcome: 'success',
       });
       expect(chunks[2]).toEqual({
         type: 'result',
@@ -1361,6 +1372,7 @@ describe('CodexProvider', () => {
         toolName: 'npm test',
         toolOutput: '',
         toolCallId: 'item-1',
+        toolOutcome: 'success',
       });
     });
 
@@ -1430,6 +1442,8 @@ describe('CodexProvider', () => {
         toolName: 'npm test',
         toolOutput: 'done',
         toolCallId: 'cmd-completed-only',
+        toolOutcome: 'success',
+        exitCode: 0,
       });
       expect(mockLogger.warn).toHaveBeenCalledWith(
         { itemId: 'cmd-completed-only', itemType: 'command_execution' },

--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -287,6 +287,37 @@ describe('CodexProvider', () => {
       });
     });
 
+    test('marks command execution with a missing exit code as unknown', async () => {
+      mockRunStreamed.mockResolvedValue({
+        events: (async function* () {
+          yield {
+            type: 'item.completed',
+            item: {
+              id: 'cmd-unknown',
+              type: 'command_execution',
+              command: 'npm test',
+              aggregated_output: 'partial output',
+              exit_code: null,
+            },
+          };
+          yield { type: 'turn.completed', usage: defaultUsage };
+        })(),
+      });
+
+      const chunks = [];
+      for await (const chunk of client.sendQuery('test prompt', '/workspace')) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks[0]).toEqual({
+        type: 'tool_result',
+        toolName: 'npm test',
+        toolOutput: 'partial output',
+        toolCallId: 'cmd-unknown',
+        toolOutcome: 'unknown',
+      });
+    });
+
     test('yields thinking events from reasoning items', async () => {
       mockRunStreamed.mockResolvedValue({
         events: (async function* () {
@@ -336,6 +367,7 @@ describe('CodexProvider', () => {
         toolName: '\u{1F50D} Searching: codex sdk',
         toolOutput: '',
         toolCallId: 'search-1',
+        toolOutcome: 'unknown',
       });
     });
 
@@ -1372,7 +1404,7 @@ describe('CodexProvider', () => {
         toolName: 'npm test',
         toolOutput: '',
         toolCallId: 'item-1',
-        toolOutcome: 'success',
+        toolOutcome: 'unknown',
       });
     });
 

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -553,12 +553,20 @@ async function* streamCodexEvents(
             const exitCode = item.exit_code as number | null | undefined;
             const exitSuffix =
               exitCode != null && exitCode !== 0 ? `\n[exit code: ${String(exitCode)}]` : '';
+            let toolOutcome: 'success' | 'error' | 'unknown';
+            if (exitCode === 0) {
+              toolOutcome = 'success';
+            } else if (exitCode == null) {
+              toolOutcome = 'unknown';
+            } else {
+              toolOutcome = 'error';
+            }
             yield {
               type: 'tool_result',
               toolName: cmd,
               toolOutput: ((item.aggregated_output as string) ?? '') + exitSuffix,
               toolCallId: itemId,
-              toolOutcome: exitCode === 0 ? 'success' : exitCode == null ? 'unknown' : 'error',
+              toolOutcome,
               ...(exitCode != null ? { exitCode } : {}),
             };
           } else {

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -558,7 +558,7 @@ async function* streamCodexEvents(
               toolName: cmd,
               toolOutput: ((item.aggregated_output as string) ?? '') + exitSuffix,
               toolCallId: itemId,
-              toolOutcome: exitCode == null || exitCode === 0 ? 'success' : 'error',
+              toolOutcome: exitCode === 0 ? 'success' : exitCode == null ? 'unknown' : 'error',
               ...(exitCode != null ? { exitCode } : {}),
             };
           } else {
@@ -580,6 +580,7 @@ async function* streamCodexEvents(
               toolName: searchToolName,
               toolOutput: '',
               toolCallId: itemId,
+              toolOutcome: 'unknown',
             };
           } else {
             getLog().debug({ itemId: item.id }, 'web_search_missing_query');

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -558,6 +558,8 @@ async function* streamCodexEvents(
               toolName: cmd,
               toolOutput: ((item.aggregated_output as string) ?? '') + exitSuffix,
               toolCallId: itemId,
+              toolOutcome: exitCode == null || exitCode === 0 ? 'success' : 'error',
+              ...(exitCode != null ? { exitCode } : {}),
             };
           } else {
             getLog().warn({ itemId: item.id }, 'command_execution_missing_command');
@@ -665,6 +667,7 @@ async function* streamCodexEvents(
               toolName: mcpToolName,
               toolOutput: errMsg,
               toolCallId: itemId,
+              toolOutcome: 'error',
             };
           } else {
             let toolOutput = '';
@@ -684,7 +687,13 @@ async function* streamCodexEvents(
                 );
               }
             }
-            yield { type: 'tool_result', toolName: mcpToolName, toolOutput, toolCallId: itemId };
+            yield {
+              type: 'tool_result',
+              toolName: mcpToolName,
+              toolOutput,
+              toolCallId: itemId,
+              toolOutcome: 'success',
+            };
           }
           break;
         }

--- a/packages/providers/src/community/copilot/event-bridge.test.ts
+++ b/packages/providers/src/community/copilot/event-bridge.test.ts
@@ -216,6 +216,7 @@ describe('mapCopilotEvent', () => {
         toolName: 'bash',
         toolOutput: 'full diff output',
         toolCallId: 'c1',
+        toolOutcome: 'success',
       },
     ]);
   });
@@ -252,6 +253,7 @@ describe('mapCopilotEvent', () => {
         toolName: 'bash',
         toolOutput: '❌ permission denied',
         toolCallId: 'c1',
+        toolOutcome: 'error',
       },
     ]);
   });

--- a/packages/providers/src/community/copilot/event-bridge.ts
+++ b/packages/providers/src/community/copilot/event-bridge.ts
@@ -202,6 +202,7 @@ export function mapCopilotEvent(event: SessionEvent, ctx: EventMapperContext): M
         toolName,
         toolOutput: success ? rawOutput : `❌ ${rawOutput}`,
         toolCallId,
+        toolOutcome: success ? 'success' : 'error',
       });
       return chunks;
     }

--- a/packages/providers/src/community/opencode/multi-agent.ts
+++ b/packages/providers/src/community/opencode/multi-agent.ts
@@ -277,6 +277,7 @@ export async function* streamMultiAgentOpencodeSession(
                 toolName,
                 toolOutput: typeof stateRecord?.output === 'string' ? stateRecord.output : '',
                 toolCallId: scopedCallId,
+                toolOutcome: 'success',
               });
             } else if (status === 'error') {
               completedToolCalls.add(scopedCallId);
@@ -286,6 +287,7 @@ export async function* streamMultiAgentOpencodeSession(
                 toolOutput:
                   typeof stateRecord?.error === 'string' ? stateRecord.error : 'Tool failed',
                 toolCallId: scopedCallId,
+                toolOutcome: 'error',
               });
             }
           }

--- a/packages/providers/src/community/opencode/provider.test.ts
+++ b/packages/providers/src/community/opencode/provider.test.ts
@@ -311,6 +311,72 @@ describe('OpencodeProvider', () => {
     });
   });
 
+  test('multi-agent tool results retain scoped IDs and factual outcomes', async () => {
+    const cwd = await createTempProjectDir();
+    const sessionIds = ['scout-session', 'reviewer-session'];
+    const runtime = makeRuntime({
+      sessionCreate: mock(async () => ({ data: { id: sessionIds.shift() } })),
+    });
+    runtimeQueue.push(runtime);
+    scriptedEvents = [
+      {
+        type: 'message.part.updated',
+        properties: {
+          part: {
+            sessionID: 'scout-session',
+            type: 'tool',
+            tool: 'read',
+            callID: 'call-1',
+            state: { status: 'completed', output: 'contents' },
+          },
+        },
+      },
+      {
+        type: 'message.part.updated',
+        properties: {
+          part: {
+            sessionID: 'reviewer-session',
+            type: 'tool',
+            tool: 'bash',
+            callID: 'call-1',
+            state: { status: 'error', error: 'command failed' },
+          },
+        },
+      },
+      { type: 'session.idle', properties: { sessionID: 'scout-session' } },
+      { type: 'session.idle', properties: { sessionID: 'reviewer-session' } },
+    ];
+
+    const { chunks, error } = await consume(
+      new OpencodeProvider().sendQuery('hi', cwd, undefined, {
+        assistantConfig: TEST_MODEL,
+        nodeConfig: {
+          nodeId: 'research',
+          agents: {
+            scout: { description: 'Scout', prompt: 'Explore' },
+            reviewer: { description: 'Reviewer', prompt: 'Review' },
+          },
+        },
+      })
+    );
+
+    expect(error).toBeUndefined();
+    expect(chunks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'tool_result',
+          toolCallId: 'scout:call-1',
+          toolOutcome: 'success',
+        }),
+        expect.objectContaining({
+          type: 'tool_result',
+          toolCallId: 'reviewer:call-1',
+          toolOutcome: 'error',
+        }),
+      ])
+    );
+  });
+
   test('terminal result chunk includes sessionId and normalized tokens', async () => {
     scriptedEvents = [
       {

--- a/packages/providers/src/community/opencode/provider.test.ts
+++ b/packages/providers/src/community/opencode/provider.test.ts
@@ -264,9 +264,51 @@ describe('OpencodeProvider', () => {
         toolName: 'read',
         toolOutput: 'file contents',
         toolCallId: 'tool-1',
+        toolOutcome: 'success',
       },
       { type: 'result', sessionId: 'session-1' },
     ]);
+  });
+
+  test('tool errors preserve a structured error outcome', async () => {
+    scriptedEvents = [
+      {
+        type: 'message.part.updated',
+        properties: {
+          part: {
+            sessionID: 'session-1',
+            type: 'tool',
+            tool: 'bash',
+            callID: 'tool-error',
+            state: { status: 'pending', input: { command: 'false' } },
+          },
+        },
+      },
+      {
+        type: 'message.part.updated',
+        properties: {
+          part: {
+            sessionID: 'session-1',
+            type: 'tool',
+            tool: 'bash',
+            callID: 'tool-error',
+            state: { status: 'error', error: 'command failed' },
+          },
+        },
+      },
+      { type: 'session.idle', properties: { sessionID: 'session-1' } },
+    ];
+
+    const { chunks, error } = await consume(
+      new OpencodeProvider().sendQuery('hi', '/tmp', undefined, { assistantConfig: TEST_MODEL })
+    );
+
+    expect(error).toBeUndefined();
+    expect(chunks[1]).toMatchObject({
+      type: 'tool_result',
+      toolCallId: 'tool-error',
+      toolOutcome: 'error',
+    });
   });
 
   test('terminal result chunk includes sessionId and normalized tokens', async () => {

--- a/packages/providers/src/community/opencode/session.ts
+++ b/packages/providers/src/community/opencode/session.ts
@@ -218,6 +218,7 @@ export async function* streamOpencodeSession(
                 toolName,
                 toolOutput: typeof state?.output === 'string' ? state.output : '',
                 ...(callId ? { toolCallId: callId } : {}),
+                toolOutcome: 'success',
               };
             } else if (status === 'error') {
               completedToolCalls.add(callId);
@@ -226,6 +227,7 @@ export async function* streamOpencodeSession(
                 toolName,
                 toolOutput: typeof state?.error === 'string' ? state.error : 'Tool failed',
                 ...(callId ? { toolCallId: callId } : {}),
+                toolOutcome: 'error',
               };
             }
           }

--- a/packages/providers/src/community/pi/event-bridge.test.ts
+++ b/packages/providers/src/community/pi/event-bridge.test.ts
@@ -337,6 +337,7 @@ describe('mapPiEvent', () => {
         toolName: 'read',
         toolOutput: 'file contents',
         toolCallId: 'call-123',
+        toolOutcome: 'success',
       },
     ]);
   });
@@ -351,7 +352,7 @@ describe('mapPiEvent', () => {
     });
     expect(chunks).toHaveLength(2);
     expect(chunks[0].type).toBe('system');
-    expect(chunks[1].type).toBe('tool_result');
+    expect(chunks[1]).toMatchObject({ type: 'tool_result', toolOutcome: 'error' });
   });
 
   test('auto_retry_start → system chunk', () => {

--- a/packages/providers/src/community/pi/event-bridge.ts
+++ b/packages/providers/src/community/pi/event-bridge.ts
@@ -251,6 +251,7 @@ export function mapPiEvent(event: AgentSessionEvent): MessageChunk[] {
         toolName: event.toolName,
         toolOutput: serializeToolResult(event.result),
         toolCallId: event.toolCallId,
+        toolOutcome: event.isError ? 'error' : 'success',
       });
       return chunks;
     }

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -234,6 +234,10 @@ export type MessageChunk =
       toolOutput: string;
       /** Matching ID for the originating `tool` chunk. See `tool` variant above. */
       toolCallId?: string;
+      /** Provider-reported completion status; never inferred from formatted output. */
+      toolOutcome?: 'success' | 'error' | 'interrupted' | 'unknown';
+      /** Provider-reported process exit code, when the tool exposes one. */
+      exitCode?: number;
     }
   // ─── Subagent Task Lifecycle (Claude SDK `system` subtypes) ────────────
   // Forwarded by the Claude provider from SDKTaskStartedMessage /

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -234,7 +234,7 @@ export type MessageChunk =
       toolOutput: string;
       /** Matching ID for the originating `tool` chunk. See `tool` variant above. */
       toolCallId?: string;
-      /** Provider-reported completion status; never inferred from formatted output. */
+      /** Known statuses are provider-reported; `unknown` marks a synthetic closure with no provider result. Never inferred from formatted output. */
       toolOutcome?: 'success' | 'error' | 'interrupted' | 'unknown';
       /** Provider-reported process exit code, when the tool exposes one. */
       exitCode?: number;

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -234,7 +234,16 @@ export type MessageChunk =
       toolOutput: string;
       /** Matching ID for the originating `tool` chunk. See `tool` variant above. */
       toolCallId?: string;
-      /** Known statuses are provider-reported; `unknown` marks a synthetic closure with no provider result. Never inferred from formatted output. */
+      /**
+       * Known statuses are provider-reported. `unknown` covers two distinct
+       * cases that share one property — no authoritative status exists:
+       *   1. the provider completed the tool but reports no status (e.g. Codex
+       *      web_search, provider.ts:591), and
+       *   2. a synthetic closure emitted with no provider result at all.
+       * Never inferred from formatted output: a tool whose text merely looks
+       * like an error is still `unknown`, because guessing here would put a
+       * fabricated status next to reported ones and make neither trustworthy.
+       */
       toolOutcome?: 'success' | 'error' | 'interrupted' | 'unknown';
       /** Provider-reported process exit code, when the tool exposes one. */
       exitCode?: number;

--- a/packages/server/src/adapters/web/workflow-bridge.test.ts
+++ b/packages/server/src/adapters/web/workflow-bridge.test.ts
@@ -56,6 +56,21 @@ describe('mapWorkflowEvent — tool activity correlation', () => {
       exitCode: 1,
     });
   });
+
+  test('omits optional completion metadata for legacy events', () => {
+    const completed: WorkflowEmitterEvent = {
+      type: 'tool_completed',
+      runId: 'run-1',
+      toolName: 'Bash',
+      stepName: 'implement',
+      durationMs: 42,
+      toolCallId: 'call-1',
+    };
+
+    const payload = JSON.parse(mapWorkflowEvent(completed) ?? '{}') as Record<string, unknown>;
+    expect(payload).not.toHaveProperty('toolOutcome');
+    expect(payload).not.toHaveProperty('exitCode');
+  });
 });
 
 describe('mapWorkflowEvent — task_activity (Phase 2 of #975)', () => {

--- a/packages/server/src/adapters/web/workflow-bridge.test.ts
+++ b/packages/server/src/adapters/web/workflow-bridge.test.ts
@@ -23,6 +23,41 @@ mock.module('@archon/paths', () => ({
 import { mapWorkflowEvent } from './workflow-bridge';
 import type { WorkflowEmitterEvent } from '@archon/workflows/event-emitter';
 
+describe('mapWorkflowEvent — tool activity correlation', () => {
+  test('forwards tool call IDs and completion metadata', () => {
+    const started: WorkflowEmitterEvent = {
+      type: 'tool_started',
+      runId: 'run-1',
+      toolName: 'Bash',
+      stepName: 'implement',
+      toolCallId: 'call-1',
+    };
+    const completed: WorkflowEmitterEvent = {
+      type: 'tool_completed',
+      runId: 'run-1',
+      toolName: 'Bash',
+      stepName: 'implement',
+      durationMs: 42,
+      toolCallId: 'call-1',
+      toolOutcome: 'error',
+      exitCode: 1,
+    };
+
+    expect(JSON.parse(mapWorkflowEvent(started) ?? '{}')).toMatchObject({
+      type: 'workflow_tool_activity',
+      status: 'started',
+      toolCallId: 'call-1',
+    });
+    expect(JSON.parse(mapWorkflowEvent(completed) ?? '{}')).toMatchObject({
+      type: 'workflow_tool_activity',
+      status: 'completed',
+      toolCallId: 'call-1',
+      toolOutcome: 'error',
+      exitCode: 1,
+    });
+  });
+});
+
 describe('mapWorkflowEvent — task_activity (Phase 2 of #975)', () => {
   beforeEach(() => {
     mockLogger.warn.mockClear();

--- a/packages/server/src/adapters/web/workflow-bridge.ts
+++ b/packages/server/src/adapters/web/workflow-bridge.ts
@@ -116,6 +116,7 @@ export function mapWorkflowEvent(event: WorkflowEmitterEvent): string | null {
         runId: event.runId,
         toolName: event.toolName,
         stepName: event.stepName,
+        toolCallId: event.toolCallId,
         status: 'started',
         timestamp: Date.now(),
       });
@@ -126,8 +127,11 @@ export function mapWorkflowEvent(event: WorkflowEmitterEvent): string | null {
         runId: event.runId,
         toolName: event.toolName,
         stepName: event.stepName,
+        toolCallId: event.toolCallId,
         status: 'completed',
         durationMs: event.durationMs,
+        toolOutcome: event.toolOutcome,
+        exitCode: event.exitCode,
         timestamp: Date.now(),
       });
 

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -3372,6 +3372,7 @@ describe('executeDagWorkflow -- tool_called event persistence', () => {
     expect((eventData.data as Record<string, unknown>).tool_input).toEqual({
       path: '/tmp/test.ts',
     });
+    expect((eventData.data as Record<string, unknown>).tool_call_id).toBe('anonymous-1');
   });
 
   it('calls sendStructuredEvent for tool messages in streaming mode during DAG', async () => {
@@ -3476,6 +3477,10 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
     expect(readFileComplete).toBeDefined();
     expect(typeof readFileComplete?.[0].data?.duration_ms).toBe('number');
     expect((readFileComplete?.[0].data?.duration_ms as number) >= 0).toBe(true);
+    expect(readFileComplete?.[0].data).toMatchObject({
+      tool_call_id: 'anonymous-1',
+      tool_outcome: 'unknown',
+    });
   });
 
   it('should emit tool_completed for last tool on result in DAG node', async () => {
@@ -3512,6 +3517,10 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
     expect(completedEvents.length).toBe(1);
     expect(completedEvents[0][0].data?.tool_name).toBe('read_file');
     expect(typeof completedEvents[0][0].data?.duration_ms).toBe('number');
+    expect(completedEvents[0][0].data).toMatchObject({
+      tool_call_id: 'anonymous-1',
+      tool_outcome: 'unknown',
+    });
   });
 
   it('emits a DAG tool_completed duration at tool_result, excluding later assistant time', async () => {
@@ -3524,7 +3533,13 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
     mockSendQueryDag.mockImplementation(function* () {
       yield { type: 'tool', toolName: 'read_file', toolInput: { path: '/a' } };
       setSystemTime(new Date('2026-01-01T00:00:00.050Z'));
-      yield { type: 'tool_result', toolName: 'read_file', toolOutput: 'contents' };
+      yield {
+        type: 'tool_result',
+        toolName: 'read_file',
+        toolOutput: 'contents',
+        toolOutcome: 'error',
+        exitCode: 1,
+      };
       setSystemTime(new Date('2026-01-01T00:01:00.050Z'));
       yield { type: 'assistant', content: 'post-tool reasoning' };
       yield { type: 'result', sessionId: 'dag-sess-tool-result' };
@@ -3559,6 +3574,9 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
     expect(completedEvents[0][0].data).toMatchObject({
       tool_name: 'read_file',
       duration_ms: 50,
+      tool_call_id: 'anonymous-1',
+      tool_outcome: 'error',
+      exit_code: 1,
     });
   });
 
@@ -3574,9 +3592,20 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
       setSystemTime(new Date('2026-01-01T00:00:00.010Z'));
       yield { type: 'tool', toolName: 'write_file', toolCallId: 'id-b' };
       setSystemTime(new Date('2026-01-01T00:00:00.040Z'));
-      yield { type: 'tool_result', toolName: 'read_file', toolCallId: 'id-a' };
+      yield {
+        type: 'tool_result',
+        toolName: 'read_file',
+        toolCallId: 'id-a',
+        toolOutcome: 'success',
+      };
       setSystemTime(new Date('2026-01-01T00:00:00.070Z'));
-      yield { type: 'tool_result', toolName: 'write_file', toolCallId: 'id-b' };
+      yield {
+        type: 'tool_result',
+        toolName: 'write_file',
+        toolCallId: 'id-b',
+        toolOutcome: 'error',
+        exitCode: 2,
+      };
       yield { type: 'result', sessionId: 'dag-sess-interleaved-tools' };
     });
 
@@ -3605,8 +3634,19 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
       .map(([event]: [{ data: Record<string, unknown> }]) => event.data);
     expect(completedEvents).toEqual(
       expect.arrayContaining([
-        { tool_name: 'read_file', duration_ms: 40 },
-        { tool_name: 'write_file', duration_ms: 60 },
+        {
+          tool_name: 'read_file',
+          duration_ms: 40,
+          tool_call_id: 'id-a',
+          tool_outcome: 'success',
+        },
+        {
+          tool_name: 'write_file',
+          duration_ms: 60,
+          tool_call_id: 'id-b',
+          tool_outcome: 'error',
+          exit_code: 2,
+        },
       ])
     );
   });
@@ -5475,7 +5515,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       mockSendQueryDag.mockImplementation(function* () {
         yield { type: 'tool', toolName: 'read_file', toolInput: { path: '/a' } };
         setSystemTime(new Date('2026-01-01T00:00:00.050Z'));
-        yield { type: 'tool_result', toolName: 'read_file', toolOutput: 'contents' };
+        yield {
+          type: 'tool_result',
+          toolName: 'read_file',
+          toolOutput: 'contents',
+          toolOutcome: 'success',
+        };
         setSystemTime(new Date('2026-01-01T00:01:00.050Z'));
         yield { type: 'assistant', content: 'Done. <promise>COMPLETE</promise>' };
         yield { type: 'result', sessionId: 'loop-sess-tool-result' };
@@ -5522,6 +5567,8 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect(completedEvents[0][0].data).toMatchObject({
         tool_name: 'read_file',
         duration_ms: 50,
+        tool_call_id: 'anonymous-1',
+        tool_outcome: 'success',
       });
     });
 
@@ -5537,9 +5584,19 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         setSystemTime(new Date('2026-01-01T00:00:00.010Z'));
         yield { type: 'tool', toolName: 'write_file', toolCallId: 'id-b' };
         setSystemTime(new Date('2026-01-01T00:00:00.040Z'));
-        yield { type: 'tool_result', toolName: 'read_file', toolCallId: 'id-a' };
+        yield {
+          type: 'tool_result',
+          toolName: 'read_file',
+          toolCallId: 'id-a',
+          toolOutcome: 'success',
+        };
         setSystemTime(new Date('2026-01-01T00:00:00.070Z'));
-        yield { type: 'tool_result', toolName: 'write_file', toolCallId: 'id-b' };
+        yield {
+          type: 'tool_result',
+          toolName: 'write_file',
+          toolCallId: 'id-b',
+          toolOutcome: 'error',
+        };
         yield { type: 'assistant', content: 'Done. <promise>COMPLETE</promise>' };
         yield { type: 'result', sessionId: 'loop-sess-interleaved-tools' };
       });
@@ -5577,8 +5634,18 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         .map(([event]: [{ data: Record<string, unknown> }]) => event.data);
       expect(completedEvents).toEqual(
         expect.arrayContaining([
-          { tool_name: 'read_file', duration_ms: 40 },
-          { tool_name: 'write_file', duration_ms: 60 },
+          {
+            tool_name: 'read_file',
+            duration_ms: 40,
+            tool_call_id: 'id-a',
+            tool_outcome: 'success',
+          },
+          {
+            tool_name: 'write_file',
+            duration_ms: 60,
+            tool_call_id: 'id-b',
+            tool_outcome: 'error',
+          },
         ])
       );
     });

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1563,6 +1563,8 @@ async function executeNodeInternal(
             toolName: previousTool.toolName,
             stepName: node.id,
             durationMs: now - previousTool.startedAt,
+            toolCallId: lastAnonymousToolCallId,
+            toolOutcome: 'unknown',
           });
           deps.store
             .createWorkflowEvent({
@@ -1572,6 +1574,8 @@ async function executeNodeInternal(
               data: {
                 tool_name: previousTool.toolName,
                 duration_ms: now - previousTool.startedAt,
+                tool_call_id: lastAnonymousToolCallId,
+                tool_outcome: 'unknown',
               },
             })
             .catch((err: Error) => {
@@ -1591,6 +1595,7 @@ async function executeNodeInternal(
           runId: workflowRun.id,
           toolName: msg.toolName,
           stepName: node.id,
+          toolCallId,
         });
 
         if (streamingMode === 'stream') {
@@ -1615,6 +1620,7 @@ async function executeNodeInternal(
             data: {
               tool_name: msg.toolName,
               tool_input: msg.toolInput ?? {},
+              tool_call_id: toolCallId,
             },
           })
           .catch((err: Error) => {
@@ -1634,6 +1640,9 @@ async function executeNodeInternal(
             toolName: tool.toolName,
             stepName: node.id,
             durationMs: now - tool.startedAt,
+            toolCallId: completedToolCallId,
+            ...(msg.toolOutcome !== undefined ? { toolOutcome: msg.toolOutcome } : {}),
+            ...(msg.exitCode !== undefined ? { exitCode: msg.exitCode } : {}),
           });
           deps.store
             .createWorkflowEvent({
@@ -1643,6 +1652,9 @@ async function executeNodeInternal(
               data: {
                 tool_name: tool.toolName,
                 duration_ms: now - tool.startedAt,
+                tool_call_id: completedToolCallId,
+                ...(msg.toolOutcome !== undefined ? { tool_outcome: msg.toolOutcome } : {}),
+                ...(msg.exitCode !== undefined ? { exit_code: msg.exitCode } : {}),
               },
             })
             .catch((err: Error) => {
@@ -1668,6 +1680,8 @@ async function executeNodeInternal(
             toolName: prevTool.toolName,
             stepName: node.id,
             durationMs: Date.now() - prevTool.startedAt,
+            toolCallId,
+            toolOutcome: 'unknown',
           });
           deps.store
             .createWorkflowEvent({
@@ -1677,6 +1691,8 @@ async function executeNodeInternal(
               data: {
                 tool_name: prevTool.toolName,
                 duration_ms: Date.now() - prevTool.startedAt,
+                tool_call_id: toolCallId,
+                tool_outcome: 'unknown',
               },
             })
             .catch((err: Error) => {
@@ -4374,6 +4390,8 @@ async function executeLoopNode(
               toolName: prevTool.toolName,
               stepName: node.id,
               durationMs: Date.now() - prevTool.startedAt,
+              toolCallId,
+              toolOutcome: 'unknown',
             });
             deps.store
               .createWorkflowEvent({
@@ -4383,6 +4401,8 @@ async function executeLoopNode(
                 data: {
                   tool_name: prevTool.toolName,
                   duration_ms: Date.now() - prevTool.startedAt,
+                  tool_call_id: toolCallId,
+                  tool_outcome: 'unknown',
                 },
               })
               .catch((err: Error) => {
@@ -4488,6 +4508,8 @@ async function executeLoopNode(
               toolName: previousTool.toolName,
               stepName: node.id,
               durationMs: now - previousTool.startedAt,
+              toolCallId: lastAnonymousToolCallId,
+              toolOutcome: 'unknown',
             });
             deps.store
               .createWorkflowEvent({
@@ -4497,6 +4519,8 @@ async function executeLoopNode(
                 data: {
                   tool_name: previousTool.toolName,
                   duration_ms: now - previousTool.startedAt,
+                  tool_call_id: lastAnonymousToolCallId,
+                  tool_outcome: 'unknown',
                 },
               })
               .catch((err: Error) => {
@@ -4513,6 +4537,7 @@ async function executeLoopNode(
             runId: workflowRun.id,
             toolName: msg.toolName,
             stepName: node.id,
+            toolCallId,
           });
 
           if (platform.getStreamingMode() === 'stream') {
@@ -4542,7 +4567,11 @@ async function executeLoopNode(
               workflow_run_id: workflowRun.id,
               event_type: 'tool_called',
               step_name: stepName,
-              data: { tool_name: msg.toolName, tool_input: toolInput },
+              data: {
+                tool_name: msg.toolName,
+                tool_input: toolInput,
+                tool_call_id: toolCallId,
+              },
             })
             .catch((err: Error) => {
               logEventStoreError(err, i);
@@ -4558,6 +4587,9 @@ async function executeLoopNode(
               toolName: tool.toolName,
               stepName: node.id,
               durationMs: now - tool.startedAt,
+              toolCallId: completedToolCallId,
+              ...(msg.toolOutcome !== undefined ? { toolOutcome: msg.toolOutcome } : {}),
+              ...(msg.exitCode !== undefined ? { exitCode: msg.exitCode } : {}),
             });
             deps.store
               .createWorkflowEvent({
@@ -4567,6 +4599,9 @@ async function executeLoopNode(
                 data: {
                   tool_name: tool.toolName,
                   duration_ms: now - tool.startedAt,
+                  tool_call_id: completedToolCallId,
+                  ...(msg.toolOutcome !== undefined ? { tool_outcome: msg.toolOutcome } : {}),
+                  ...(msg.exitCode !== undefined ? { exit_code: msg.exitCode } : {}),
                 },
               })
               .catch((err: Error) => {

--- a/packages/workflows/src/event-emitter.ts
+++ b/packages/workflows/src/event-emitter.ts
@@ -122,6 +122,7 @@ interface ToolStartedEvent {
   runId: string;
   toolName: string;
   stepName: string;
+  toolCallId: string;
 }
 
 interface ToolCompletedEvent {
@@ -130,6 +131,9 @@ interface ToolCompletedEvent {
   toolName: string;
   stepName: string;
   durationMs: number;
+  toolCallId: string;
+  toolOutcome?: 'success' | 'error' | 'interrupted' | 'unknown';
+  exitCode?: number;
 }
 
 interface ApprovalPendingEvent {


### PR DESCRIPTION
## Summary

- Problem: persisted `tool_called` and `tool_completed` workflow events could not be reliably paired when tools repeated or interleaved.
- Why it matters: tool latency and failures were not traceable per invocation in stored, SSE, or CLI workflow events.
- What changed: preserve resolved `tool_call_id`, structured `tool_outcome`, and optional `exit_code` from provider normalization through workflow persistence and live event bridges; add regression coverage.
- What did **not** change (scope boundary): no database migration, event-table restructuring, retention policy, pricing data, payload renames, or console UI pairing changes.

## UX Journey

### Before

```
  Workflow operator        Provider             Executor / event store        SSE / CLI
  ─────────────────        ────────             ──────────────────────        ─────────
  runs workflow ───────▶   emits tool chunks ─▶  stores start/completion
                                                    without shared ID ───────▶ displays events
  investigates latency ◀──────────────────────── cannot match repeated calls
```

### After

```
  Workflow operator        Provider             Executor / event store        SSE / CLI
  ─────────────────        ────────             ──────────────────────        ─────────
  runs workflow ───────▶   emits tool chunks ─▶  [resolves tool_call_id]
                                                    [stores matching ID,
                                                     outcome, exit code] ────▶ [displays correlated events]
  investigates latency ◀──────────────────────── pairs each tool lifecycle
```

## Architecture Diagram

### Before

```
Claude / Codex / Pi / Copilot / OpenCode
                 │ MessageChunk(toolCallId only)
                 ▼
          DAG and loop executor
                 │
                 ├── workflow event store: tool name/input/duration
                 ├── workflow event emitter: uncorrelated lifecycle events
                 ▼
              Web SSE bridge / CLI renderer
```

### After

```
[~] Claude / Codex / Pi / Copilot / OpenCode
                 │ MessageChunk(toolCallId, [toolOutcome, exitCode])
                 ▼
          [~] DAG and loop executor
                 │
                 ├── [~] workflow event store: tool_call_id, outcome, exit code
                 ├── [~] workflow event emitter: correlated lifecycle events
                 ▼
              [~] Web SSE bridge / CLI renderer
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| Provider normalizers | Provider `MessageChunk` contract | **modified** | Tool results now optionally carry outcome and exit code. |
| Provider chunks | DAG and loop executor | **modified** | Executor consumes completion metadata alongside existing tool IDs. |
| DAG and loop executor | Workflow event store | **modified** | Persists correlated start/completion data in existing JSON payloads. |
| DAG and loop executor | Workflow event emitter | **modified** | Emits typed correlation and completion metadata. |
| Workflow event emitter | Web SSE bridge | **modified** | Live event payload forwards additive fields. |
| DAG and loop executor | CLI workflow renderer | **modified** | CLI output includes additive live-event fields. |

## Label Snapshot

- Risk: `risk: medium`
- Size: `size: M`
- Scope: `workflows`
- Module: `workflows:executor`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi`

## Linked Issue

- Closes #2396
- Related #2393
- Depends on # none
- Supersedes # none

## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check
bun run lint
bun run format:check
bun run test
bun run build
bun run validate
```

All commands passed: type checking reported no errors, lint reported no errors or warnings, format checking passed, package-isolated tests completed with 0 failures, build compiled successfully, and full validation passed.

- Evidence provided (test/log/trace/screenshot): deterministic provider and workflow-store simulations cover interleaved IDs, anonymous synthetic closures, provider failure/interruption, and Codex non-zero exit codes; focused test suite reported 969 passing tests.
- If any command is intentionally skipped, explain why: none.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation: not applicable.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: not applicable; fields are additive properties in existing workflow-event JSON data.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: deterministic provider and workflow lifecycle simulations confirm matching IDs for interleaved calls, generated IDs for anonymous calls, and terminal synthetic closures.
- Edge cases checked: Claude failure/interruption, community provider errors, and Codex non-zero command exit codes retain structured outcomes without parsing tool output.
- What was not verified: live runs against credentialed external provider accounts; coverage uses provider event fixtures and deterministic store simulations.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: all workflow tool lifecycle event consumers—provider normalization, DAG/loop execution, persisted event data, web SSE, and CLI event output.
- Potential unintended effects: downstream consumers that deserialize workflow event payloads may see additional optional fields.
- Guardrails/monitoring for early detection: fields are additive and optional; focused regression tests cover each provider bridge and lifecycle closure path.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `e8d68dda` from `dev` if event consumers exhibit compatibility issues.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: missing or mismatched tool lifecycle IDs, incorrect outcome/exit-code display, or workflow event consumer parsing failures.

## Risks and Mitigations

- Risk: provider event shapes vary and some providers cannot authoritatively provide a completion result.
  - Mitigation: outcome and exit code are optional; synthetic closures explicitly use `unknown` rather than inferring success.
- Risk: additional event payload properties could affect strict downstream consumers.
  - Mitigation: changes are additive to existing JSON payloads and typed bridges; regression tests exercise persisted and live paths.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow activity now displays tool call IDs, outcomes, and command exit codes when available.
  * Tool execution results consistently report success, error, interrupted, or unknown outcomes across supported providers.
  * Workflow events and persisted activity now correlate tool starts and completions more reliably, including concurrent and looped executions.

* **Bug Fixes**
  * Preserved tool results generated by post-execution hooks, including failed and interrupted operations.
  * Maintained compatibility with older events that lack optional outcome or exit-code metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->