### PR TITLE
Snapshot resolved workflow run configuration

### DIFF
--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -609,6 +609,171 @@ describe('executeWorkflow', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Durable workflow_started configuration snapshot
+  // -------------------------------------------------------------------------
+
+  describe('workflow_started configuration snapshot', () => {
+    it('persists the resolved configuration and top-level platform origin', async () => {
+      const createEventSpy = mock(async () => {});
+      const store = makeStore({
+        createWorkflowRun: mock(async () =>
+          makeRun({
+            user_message: 'persisted input',
+            user_id: 'user-1',
+            parent_run_id: null,
+          })
+        ),
+        createWorkflowEvent: createEventSpy,
+      });
+      const deps = {
+        ...makeDeps(store),
+        loadConfig: mock(
+          async (): Promise<WorkflowConfig> => ({
+            assistant: 'claude',
+            assistants: { claude: {}, codex: {} },
+            baseBranch: 'config-base',
+            commands: { folder: '' },
+            tiers: {
+              large: { provider: 'codex', model: 'gpt-5.5', effort: 'high' },
+            },
+          })
+        ),
+        getUserAiPrefs: mock(async () => ({ defaultProvider: 'codex' })),
+      } as WorkflowDeps;
+      const platform = {
+        sendMessage: mock(async () => {}),
+        getPlatformType: mock(() => 'web'),
+      } as unknown as IWorkflowPlatform;
+
+      await executeWorkflow(
+        deps,
+        platform,
+        'conv-1',
+        '/tmp/worktree',
+        makeWorkflow({ model: 'large' }),
+        'caller input',
+        'db-conv-1',
+        {
+          userId: 'user-1',
+          baseBranch: 'caller-base',
+          baseOverride: 'override-base',
+          isolationContext: { branchName: 'feature/snapshot' },
+        }
+      );
+
+      const startedEvent = createEventSpy.mock.calls
+        .map(call => call[0])
+        .find(event => event.event_type === 'workflow_started');
+      expect(startedEvent?.data).toEqual({
+        workflowName: 'test-workflow',
+        defaultAssistant: 'codex',
+        provider: 'codex',
+        model: 'gpt-5.5',
+        isolationMode: 'worktree',
+        baseBranch: 'override-base',
+        userId: 'user-1',
+        userMessage: 'persisted input',
+        origin: 'web',
+      });
+    });
+
+    it('persists explicit nulls for an in-place run without a model or user', async () => {
+      const createEventSpy = mock(async () => {});
+      const store = makeStore({
+        createWorkflowRun: mock(async () =>
+          makeRun({ user_message: 'folder input', user_id: null, parent_run_id: null })
+        ),
+        createWorkflowEvent: createEventSpy,
+      });
+
+      await executeWorkflow(
+        makeDeps(store),
+        makePlatform(),
+        'conv-1',
+        '/tmp/folder',
+        makeWorkflow(),
+        'folder input',
+        'db-conv-1'
+      );
+
+      const startedEvent = createEventSpy.mock.calls
+        .map(call => call[0])
+        .find(event => event.event_type === 'workflow_started');
+      expect(startedEvent?.data).toMatchObject({
+        workflowName: 'test-workflow',
+        model: null,
+        isolationMode: 'in-place',
+        userId: null,
+        origin: 'test',
+      });
+      expect(startedEvent?.data).toHaveProperty('model');
+      expect(startedEvent?.data).toHaveProperty('userId');
+    });
+
+    it('classifies a container execution ahead of a worktree context', async () => {
+      const createEventSpy = mock(async () => {});
+      const store = makeStore({
+        createWorkflowRun: mock(async () =>
+          makeRun({ user_message: 'container input', user_id: null, parent_run_id: null })
+        ),
+        createWorkflowEvent: createEventSpy,
+      });
+
+      await executeWorkflow(
+        makeDeps(store),
+        makePlatform(),
+        'conv-1',
+        '/tmp/container',
+        makeWorkflow(),
+        'container input',
+        'db-conv-1',
+        {
+          execContext: { kind: 'container', containerId: 'container-1' },
+          isolationContext: { branchName: 'feature/snapshot' },
+        }
+      );
+
+      const startedEvent = createEventSpy.mock.calls
+        .map(call => call[0])
+        .find(event => event.event_type === 'workflow_started');
+      expect(startedEvent?.data?.isolationMode).toBe('container');
+      expect(startedEvent?.data?.origin).toBe('test');
+    });
+
+    it('uses persisted child-run attribution and input instead of caller values', async () => {
+      const createEventSpy = mock(async () => {});
+      const preCreatedRun = makeRun({
+        id: 'child-run',
+        user_message: 'persisted child input',
+        user_id: null,
+        parent_run_id: 'parent-run',
+      });
+      const store = makeStore({ createWorkflowEvent: createEventSpy });
+
+      await executeWorkflow(
+        makeDeps(store),
+        makePlatform(),
+        'conv-1',
+        '/tmp/shared-worktree',
+        makeWorkflow(),
+        'transient caller input',
+        'db-conv-1',
+        { preCreatedRun, userId: 'transient-user' }
+      );
+
+      const startedEvent = createEventSpy.mock.calls
+        .map(call => call[0])
+        .find(event => event.event_type === 'workflow_started');
+      expect(startedEvent?.data).toMatchObject({
+        workflowName: 'test-workflow',
+        userId: null,
+        userMessage: 'persisted child input',
+        origin: 'workflow',
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // $DOCS_DIR default resolution
   // -------------------------------------------------------------------------
 

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -1400,7 +1400,22 @@ export async function executeWorkflow(
       .createWorkflowEvent({
         workflow_run_id: workflowRun.id,
         event_type: 'workflow_started',
-        data: { workflowName: workflow.name },
+        data: {
+          workflowName: workflow.name,
+          defaultAssistant: userAiPrefs.defaultProvider ?? config.assistant,
+          provider: resolvedProvider,
+          model: resolvedModel ?? null,
+          isolationMode:
+            execContext.kind === 'container'
+              ? 'container'
+              : isolationContext
+                ? 'worktree'
+                : 'in-place',
+          baseBranch,
+          userId: workflowRun.user_id ?? null,
+          userMessage: workflowRun.user_message,
+          origin: workflowRun.parent_run_id ? 'workflow' : platform.getPlatformType(),
+        },
       })
       .catch((err: Error) => {
         getLog().error(

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -1396,6 +1396,14 @@ export async function executeWorkflow(
       usedIsolation: isolationContext !== undefined,
       isResume: dagPriorCompletedNodes !== undefined,
     });
+
+    let isolationMode: 'container' | 'worktree' | 'in-place' = 'in-place';
+    if (execContext.kind === 'container') {
+      isolationMode = 'container';
+    } else if (isolationContext) {
+      isolationMode = 'worktree';
+    }
+
     deps.store
       .createWorkflowEvent({
         workflow_run_id: workflowRun.id,
@@ -1405,12 +1413,7 @@ export async function executeWorkflow(
           defaultAssistant: userAiPrefs.defaultProvider ?? config.assistant,
           provider: resolvedProvider,
           model: resolvedModel ?? null,
-          isolationMode:
-            execContext.kind === 'container'
-              ? 'container'
-              : isolationContext
-                ? 'worktree'
-                : 'in-place',
+          isolationMode,
           baseBranch,
           userId: workflowRun.user_id ?? null,
           userMessage: workflowRun.user_message,


### PR DESCRIPTION
## Summary

- Problem: persisted `workflow_started` events contained only the workflow name, forcing observability and evaluation consumers to reconstruct resolved run context from other records.
- Why it matters: operators can now classify and compare workflow runs from a single durable start event.
- What changed: snapshot the resolved assistant/provider/model, isolation mode, base branch, persisted user/input context, and origin in the existing event payload; add focused coverage for resolved values and edge cases.
- What did **not** change (scope boundary): no event type, database schema, migration, live emitter, SSE bridge, or store-interface change.

## UX Journey

### Before

```
Operator                 Archon workflow executor          Event stream
───────                  ─────────────────────────         ────────────
starts a workflow ────▶  resolves run configuration ────▶  workflow_started
                                                           { workflowName }
inspects run data ─────▶ must join run, config, and events to classify it
```

### After

```
Operator                 Archon workflow executor          Event stream
───────                  ─────────────────────────         ────────────
starts a workflow ────▶  resolves run configuration ────▶  workflow_started
                                                           { workflowName,
                                                             [provider, model,
                                                              isolationMode,
                                                              baseBranch, userId,
                                                              userMessage, origin] }
inspects start event ──▶ classifies the run from one durable record
```

## Architecture Diagram

### Before

```
[workflow configuration] ──▶ [executor] ──▶ [workflow-event store]
[workflow run row] ────────▶ [executor]       workflow_started: workflowName
[platform adapter] ────────▶ [executor]
```

### After

```
[workflow configuration] ──▶ [~ executor] ===▶ [workflow-event store]
[workflow run row] ────────▶ [~ executor]       workflow_started: additive snapshot
[platform adapter] ────────▶ [~ executor]       (resolved config + invocation context)
                                                   │
                                                   ▼
                                             [existing event consumers]
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|---|---|---|---|
| Workflow configuration resolution | `workflows:executor` | unchanged | Supplies effective assistant, provider, model, and base branch. |
| Persisted workflow run | `workflows:executor` | unchanged | Supplies finalized user, input, and parent-run data. |
| Platform adapter | `workflows:executor` | unchanged | Supplies the top-level run origin. |
| `workflows:executor` | Workflow-event store | **modified** | The existing `workflow_started` write now includes an additive configuration snapshot. |
| Workflow-event store | Existing event consumers | unchanged | Consumers retain the same event type and JSON persistence contract. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `workflows`, `tests`
- Module: `workflows:executor`

## Change Metadata

- Change type: `feature`
- Primary scope: `workflows`

## Linked Issue

- Closes #2397
- Related #2393, #2052, #2356
- Depends on # (if stacked): None
- Supersedes # (if replacing older PR): None

## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check       # passed
bun run lint --max-warnings 0  # passed, 0 warnings
bun run format:check     # passed
bun test src/executor.test.ts  # passed: 75 tests, 0 failures
bun run validate         # passed; includes isolated full test suite
bun run build            # passed
```

- Evidence provided (test/log/trace/screenshot): the focused executor tests cover resolved provider/model/base branch, worktree/container/in-place modes, explicit null model/user values, platform origin, and pre-created child-run attribution. A manual smoke run confirmed the persisted SQLite `workflow_started` row contains the complete snapshot.
- If any command is intentionally skipped, explain why: none. The package-script test-file filter was not used because the repository documents permanent Bun `mock.module()` cache pollution across combined batches; the direct isolated file invocation was used instead.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: Not applicable.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes; `workflowName` remains and all added payload keys are additive.
- Config/env changes? (`Yes/No`): No
- Database migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: Not applicable.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: a workflow run persisted a start event with all requested resolved fields in SQLite.
- Edge cases checked: missing model/user persist as `null`; container mode takes precedence over worktree; child runs record `origin: workflow` and persisted rather than transient user/input values.
- What was not verified: live SSE rendering was not exercised because its contract is deliberately unchanged and it does not consume the new payload fields.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `@archon/workflows` executor and durable workflow-event consumers, including observability/evaluation tooling.
- Potential unintended effects: consumers that assume an exact event-data shape could encounter additional JSON keys.
- Guardrails/monitoring for early detection: the existing event type and `workflowName` key are retained; tests assert the complete snapshot and explicit null behavior.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `f21470e1` from the `dev` branch.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: unexpected start-event payload parsing or incorrect run classification in observability consumers.

## Risks and Mitigations

- Risk: a snapshot field could differ from the persisted run context when callers provide transient values.
  - Mitigation: the implementation derives user/input/parent attribution from the finalized `WorkflowRun` row and has dedicated child-run tests.
- Risk: isolation mode could be ambiguous when container and worktree context coexist.
  - Mitigation: container precedence is explicit and covered by tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow start records now include expanded execution details, such as the selected assistant, provider, model, isolation mode, base branch, origin, and user-provided context.
  * Execution metadata is consistently captured across web, in-place, container, and child-run workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->