### PR TITLE
fix: retry transient Codex availability failures

### DIFF
--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -548,10 +548,9 @@ function getEffectiveNodeRetryConfig(node: DagNode): {
 
 /**
  * Check if a NodeOutput failure is transient by delegating to classifyError.
- * FATAL patterns (auth, permission, credits) take priority over TRANSIENT patterns,
- * matching the same precedence rules as classifyError(). This prevents an error
- * message that contains both a FATAL substring and a TRANSIENT substring (e.g.
- * "unauthorized: process exited with code 1") from being silently retried.
+ * Decisive FATAL patterns (credentials, authorization, quota/limit windows) take
+ * priority over TRANSIENT patterns, while generic "auth error" wrapper text is
+ * fatal only when no transient signal matches. This mirrors classifyError().
  */
 function isTransientNodeError(errorMessage: string): boolean {
   return classifyError(new Error(errorMessage)) === 'TRANSIENT';
@@ -577,10 +576,10 @@ function getExplicitNodeRetryConfig(
  * Decide whether a failed node output warrants another retry attempt.
  *
  * Shared by {@link runNodeRetryLoop} for every node type so the retry decision
- * cannot drift. FATAL errors (auth, permissions, credit balance) are never
- * retried, even when `on_error: all` — matching {@link classifyError}'s
- * FATAL-over-TRANSIENT precedence. Also returns `isTransient` so callers can
- * label the notification.
+ * cannot drift. Decisive FATAL errors (credentials, authorization, quota/limit
+ * windows) are never retried, even when `on_error: all`; generic "auth error"
+ * text is fatal only when no transient signal matches. Also returns `isTransient`
+ * so callers can label the notification.
  */
 function shouldRetryNodeFailure(
   output: NodeOutput,

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -547,16 +547,6 @@ function getEffectiveNodeRetryConfig(node: DagNode): {
 }
 
 /**
- * Check if a NodeOutput failure is transient by delegating to classifyError.
- * Decisive FATAL patterns (credentials, authorization, quota/limit windows) take
- * priority over TRANSIENT patterns, while generic "auth error" wrapper text is
- * fatal only when no transient signal matches. This mirrors classifyError().
- */
-function isTransientNodeError(errorMessage: string): boolean {
-  return classifyError(new Error(errorMessage)) === 'TRANSIENT';
-}
-
-/**
  * Retry config for a deterministic (bash/script) node.
  *
  * Same field mapping as {@link getEffectiveNodeRetryConfig}, but deterministic
@@ -591,8 +581,9 @@ function shouldRetryNodeFailure(
   if (output.state !== 'failed') {
     return { shouldRetry: false, isTransient: false };
   }
-  const isFatal = output.error ? classifyError(new Error(output.error)) === 'FATAL' : false;
-  const isTransient = output.error ? isTransientNodeError(output.error) : false;
+  const errorType = output.error ? classifyError(new Error(output.error)) : undefined;
+  const isFatal = errorType === 'FATAL';
+  const isTransient = errorType === 'TRANSIENT';
   const shouldRetry = !isFatal && (onError === 'all' || (onError === 'transient' && isTransient));
   return { shouldRetry, isTransient };
 }

--- a/packages/workflows/src/executor-shared.test.ts
+++ b/packages/workflows/src/executor-shared.test.ts
@@ -651,12 +651,37 @@ describe('classifyError', () => {
     expect(classifyError(new Error('Minimax: overloaded, try again later'))).toBe('TRANSIENT');
   });
 
+  it('classifies Codex 503 responses decorated with auth error as TRANSIENT — #2386', () => {
+    expect(
+      classifyError(
+        new Error(
+          "Node 'prime' failed: SDK returned codex_turn_failed — unexpected status 503 Service Unavailable: Service Unavailable, url: https://chatgpt.com/backend-api/codex/responses, cf-ray: ..., auth error: 503, auth error code: biscuit_baker_service_me_circuit_open"
+        )
+      )
+    ).toBe('TRANSIENT');
+  });
+
+  it('classifies Codex model-capacity errors as TRANSIENT — #2425', () => {
+    expect(
+      classifyError(new Error('Selected model is at capacity. Please try a different model.'))
+    ).toBe('TRANSIENT');
+  });
+
   it('classifies 401 as FATAL', () => {
     expect(classifyError(new Error('401 unauthorized'))).toBe('FATAL');
   });
 
   it('FATAL takes priority over TRANSIENT when both match', () => {
     expect(classifyError(new Error('unauthorized: exited with code 1'))).toBe('FATAL');
+  });
+
+  it('keeps concrete authentication and quota failures FATAL', () => {
+    expect(classifyError(new Error('auth error: 401'))).toBe('FATAL');
+    expect(classifyError(new Error('rate limit: session limit reached'))).toBe('FATAL');
+  });
+
+  it('keeps a generic auth error FATAL when no transient signal is present', () => {
+    expect(classifyError(new Error('auth error: credentials rejected'))).toBe('FATAL');
   });
 
   it('classifies session-limit and usage-limit errors as FATAL (never retried) — #2177', () => {

--- a/packages/workflows/src/executor-shared.ts
+++ b/packages/workflows/src/executor-shared.ts
@@ -40,11 +40,13 @@ export const FATAL_PATTERNS = [
   '401',
   '403',
   'credit balance',
-  'auth error',
   'session limit', // Claude subscription 5h window — covers every detectCreditExhaustion session variant
   'usage limit reached', // Claude CLI quota string, e.g. "Claude AI usage limit reached|<ts>"
   'credit exhaustion', // synthesized "Credit exhaustion detected — resume when credits reset"
 ];
+
+/** Ambiguous fatal patterns that yield to concrete transient evidence. */
+const FALLBACK_FATAL_PATTERNS = ['auth error'];
 
 /** Transient error patterns - temporary issues that may resolve with retry */
 export const TRANSIENT_PATTERNS = [
@@ -59,6 +61,7 @@ export const TRANSIENT_PATTERNS = [
   '502',
   '529', // Anthropic HTTP 529 = service overloaded
   'overloaded', // Anthropic/Minimax overload message text
+  'at capacity', // Codex/OpenAI model-level saturation
   'network error',
   'socket hang up',
   'exited with code',
@@ -74,8 +77,10 @@ export function matchesPattern(message: string, patterns: string[]): boolean {
 
 /**
  * Classify an error to determine if it's transient (can retry) or fatal (should fail).
- * FATAL patterns take priority over TRANSIENT patterns to prevent an error message
+ * Decisive FATAL patterns take priority over TRANSIENT patterns to prevent an error
  * containing both (e.g. "unauthorized: process exited with code 1") from being retried.
+ * Ambiguous provider wrapper text such as "auth error" is fatal only when no concrete
+ * transient signal matches.
  */
 export function classifyError(error: Error): ErrorType {
   const message = error.message.toLowerCase();
@@ -85,6 +90,9 @@ export function classifyError(error: Error): ErrorType {
   }
   if (matchesPattern(message, TRANSIENT_PATTERNS)) {
     return 'TRANSIENT';
+  }
+  if (matchesPattern(message, FALLBACK_FATAL_PATTERNS)) {
+    return 'FATAL';
   }
   return 'UNKNOWN';
 }


### PR DESCRIPTION
## Summary

- Problem: Codex 503 responses containing generic `auth error` were classified as fatal, and model-capacity errors were unknown, so default DAG retries were bypassed.
- Why it matters: temporary provider availability failures could terminate a node and prevent dependent DAG work from running.
- What changed: introduced a fallback-fatal tier for ambiguous `auth error`, added `at capacity` as a transient signal, covered both reported errors, and clarified retry comments.
- What did **not** change (scope boundary): retry-loop behavior, retry configuration, provider-specific code, and the existing fatal treatment of concrete credential, authorization, quota, and session-limit failures.

## UX Journey

### Before

```
Workflow author           Archon DAG                 Codex
───────────────           ──────────                 ─────
runs workflow ────────▶  runs AI node ────────────▶  returns 503 / at-capacity error
                          classifies FATAL/UNKNOWN
sees failed node ◀──────  bypasses default retry
```

### After

```
Workflow author           Archon DAG                 Codex
───────────────           ──────────                 ─────
runs workflow ────────▶  runs AI node ────────────▶  returns 503 / at-capacity error
                          [classifies TRANSIENT]
                          [uses configured DAG retry]
sees successful retry or
final exhausted failure ◀──────────────────────────
```

## Architecture Diagram

### Before

```
Codex turn.failed --> dag-executor retry decision --> executor-shared classifyError
                                                     |
                                                     +--> fatal-first substring matching
                                                          (auth error + 503 => FATAL)
```

### After

```
Codex turn.failed --> [~ dag-executor retry decision] --> [~ executor-shared classifyError]
                                                          |
                                                          +--> decisive fatal patterns
                                                          +--> transient patterns (including at capacity)
                                                          +--> fallback fatal auth error
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|---|---|---|---|
| `dag-executor` | `executor-shared` | **modified** | Existing retry classification now consumes the refined precedence contract. |
| `executor-shared.test` | `executor-shared` | **modified** | Regression coverage pins both Codex availability messages and fatal guardrails. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `workflows`, `tests`
- Module: `workflows:executor`

## Change Metadata

- Change type: `bug`
- Primary scope: `workflows`

## Linked Issue

- Closes #2386
- Related #2425
- Depends on # (if stacked): None
- Supersedes # (if replacing older PR): None

Fixes #2386
Fixes #2425

## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check
bun run lint
bun run format:check
bun run test
bun run build
bun run validate
```

- Evidence provided (test/log/trace/screenshot): All commands passed. `bun run test` reported 6,535 passed and 0 failed; `bun run validate` passed. Focused classifier tests reported 92 passed and DAG executor tests reported 448 passed.
- If any command is intentionally skipped, explain why: None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No.
- New external network calls? (`Yes/No`): No.
- Secrets/tokens handling changed? (`Yes/No`): No.
- File system access scope changed? (`Yes/No`): No.
- If any `Yes`, describe risk and mitigation: Not applicable.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes.
- Config/env changes? (`Yes/No`): No.
- Database migration needed? (`Yes/No`): No.
- If yes, exact upgrade steps: Not applicable.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Exact Codex 503-with-`auth error` and selected-model-at-capacity messages classify as `TRANSIENT`; existing DAG integration coverage verifies transient retry notifications and retry behavior.
- Edge cases checked: `auth error: 401`, bare generic `auth error`, session-limit, credential, and quota failures remain `FATAL`.
- What was not verified: A live Codex provider request was not made; verification is deterministic unit and existing integration coverage.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Shared workflow error classification, DAG retry decisions, critical-message retries, and failure telemetry categorization.
- Potential unintended effects: An availability failure containing generic `auth error` may now retry when it also carries a recognized transient signal.
- Guardrails/monitoring for early detection: Decisive fatal patterns remain first, fallback-fatal handling preserves bare `auth error`, and regression tests cover 401, quota, and session-limit cases.

## Rollback Plan (required)

- Fast rollback command/path: Revert commit `4f3dee06` from this PR.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: DAG nodes retry a failure that should be terminal, visible through retry notifications and workflow event logs.

## Risks and Mitigations

- Risk: Broadening transient classification could retry credential or quota failures.
  - Mitigation: Only ambiguous `auth error` moved to the final fallback tier; concrete authentication, authorization, quota, and session-limit patterns retain priority and direct regression coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow retry handling for temporary service outages, capacity limits, and authentication-related errors.
  * Prevented transient Codex and model-capacity failures from being treated as permanent failures.
  * Preserved decisive handling for concrete quota and authentication failures.

* **Tests**
  * Added regression coverage for transient and fatal error classification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->