### PR TITLE
fix(release,install): correct the changelog commit boundary, git pull form, and installer env-var docs

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -35,12 +35,36 @@ Creates a release by comparing dev to main, generating changelog entries from co
 ```bash
 # Must be on dev branch with clean working tree
 git checkout dev
-git pull origin dev
+git pull origin dev --no-rebase
 git status --porcelain  # must be empty
 git fetch origin main
 ```
 
 If not on dev or working tree is dirty, abort with a clear message.
+
+**Then check that dev actually contains main.** Anything committed directly to
+main — a docs typo fix, a hotfix, the previous release's formula commit — stays
+stranded there until someone merges it back. The release PR would then propose
+*reverting* it, and the next release inherits the drift.
+
+```bash
+if git merge-base --is-ancestor origin/main origin/dev; then
+  echo "dev contains main — OK"
+else
+  echo "DRIFT: commits exist on main that dev does not have:"
+  git log origin/dev..origin/main --oneline
+  echo ""
+  echo "Resync before releasing:"
+  echo "  git checkout dev && git pull origin main --no-rebase && git push origin dev"
+  exit 1
+fi
+```
+
+Observed on the 0.7.1 release: `ae704a73 Update docs.mdx (#2155)` had been
+committed straight to main after 0.7.0 and never merged back. Someone had
+noticed the *content* gap and hand-forward-ported it via a separate PR (#2403),
+so dev had the change but not the commit — and `main` was still not an ancestor
+of `dev`. Resolve this before Step 2; do not carry it into the release PR.
 
 ### Step 1.5: Pre-flight compiled-binary smoke test (MANDATORY before any other step)
 
@@ -125,16 +149,58 @@ Read the current version from the detected file.
 
 ### Step 4: Collect Commits
 
+> **Do NOT use `git log main..dev`.** This repo **squash**-merges the release PR
+> into main, so main receives one new commit per release and never contains dev's
+> individual commits. `main..dev` therefore accumulates *every commit ever
+> squashed* and grows release over release. On 0.7.1 it returned **61** commits
+> when only **25** were new — the other 36 were already shipped in 0.7.0 and
+> already written into its changelog. Followed literally, it re-logs most of the
+> previous release.
+
+The real boundary is dev's own last `Release x.y.z` commit:
+
 ```bash
-# Get all commits on dev that aren't on main
-git log main..dev --oneline --no-merges
+# The previous release commit ON DEV (not the squashed one on main)
+LAST_RELEASE=$(git log origin/dev --grep='^Release [0-9]' --format='%H' -n 1)
+echo "Previous release commit: $(git log -1 --oneline "$LAST_RELEASE")"
+
+# Everything after it is genuinely new
+git log "$LAST_RELEASE"..origin/dev --oneline --no-merges
 ```
+
+If `LAST_RELEASE` is empty (first-ever release), fall back to the root commit.
+
+Two commit kinds in that range are **release plumbing, not changelog material** —
+exclude them:
+
+- `Release x.y.z (#NNNN)` — main's squash commit, pulled back by Step 9's sync
+- `chore: update Homebrew formula for vx.y.z` / `chore(homebrew): …` — the CI job
+  and the Step 10 commit; note these appear as *two different SHAs* with the same
+  content, one per branch
+
+**Sanity-check the boundary before drafting.** Cross-reference against what the
+previous version already documented — any overlap means the range is wrong:
+
+```bash
+# PR numbers already recorded under the previous version's heading
+awk '/^## \[0\.7\.0\]/,/^## \[0\.6/' CHANGELOG.md | grep -oE '#[0-9]{3,5}' | sort -u
+```
+
+If a PR number in your commit range appears in that list, stop and re-derive the
+boundary — do not write it twice.
 
 If no new commits, abort: "Nothing to release — dev is up to date with main."
 
 ### Step 5: Draft Changelog Entries
 
-Read the commit messages and the actual diffs (`git diff main..dev`) to understand what changed.
+Read the commit messages and the actual diffs (`git diff "$LAST_RELEASE"..origin/dev`) to understand what changed.
+
+Prefer the PR title and its `## Summary` section over the raw commit subject —
+they state the user-visible problem, which is what a changelog entry needs:
+
+```bash
+gh pr view <N> --repo coleam00/Archon --json title,body
+```
 
 **Categorize into Keep a Changelog sections:**
 - **Added** — new features, new files, new capabilities
@@ -246,14 +312,32 @@ gh release create vx.y.z --title "vx.y.z" --notes "{changelog section content wi
 
 # Sync dev with main so both branches are identical
 git checkout dev
-git pull origin main
+git pull origin main --no-rebase
 git push origin dev
+
+# Verify the sync actually converged — do not assume it did
+git fetch origin
+git merge-base --is-ancestor origin/main origin/dev \
+  && echo "dev contains main — OK" \
+  || { echo "STILL DIVERGED"; git log origin/dev..origin/main --oneline; }
 ```
+
+> **`--no-rebase` is required, not optional.** Without it, git aborts with
+> `fatal: Need to specify how to reconcile divergent branches` on any machine
+> that has not set `pull.rebase`. It also pins the behaviour to the merge this
+> step actually wants — a `pull.rebase=true` config would otherwise rewrite dev's
+> history, which is exactly what the warning below forbids.
+
+> **Expect to run this twice.** The CI `update-homebrew` job pushes its own
+> formula commit to dev while you are working, so the `git push origin dev` here
+> (and again in Step 10) can be rejected with `Updates were rejected`. That is
+> normal: `git pull origin dev --no-rebase`, then push again. On 0.7.1 both this
+> step and Step 10 required a second pass.
 
 > **Important**: This sync ensures dev has the merge commit from main. Without it,
 > dev and main diverge. The CI `update-homebrew` job only pushes the formula
 > commit to dev — it does not bring the PR merge commit onto dev. This manual
-> `git pull origin main` is what ensures dev has the merge commit.
+> `git pull origin main --no-rebase` is what ensures dev has the merge commit.
 
 > **Do NOT** use `git pull origin main --ff-only` or `git reset --hard origin/main`
 > for this sync. Fast-forward is impossible across a squash merge — main's squash
@@ -262,7 +346,7 @@ git push origin dev
 > which severs every open PR's merge-base from its original commit and balloons
 > their diffs to thousands of lines (confirmed against v0.3.10's release: PRs
 > went from `+80/-1` to `+6626/-300` after a `git reset --hard origin/main` on
-> dev). The plain `git pull origin main` above creates a regular merge commit on
+> dev). The plain `git pull origin main --no-rebase` above creates a regular merge commit on
 > dev. The merge bubble in dev's `git log` is the right cost for preserving
 > open-PR sanity. If the merge produces a `homebrew/archon.rb` conflict during a
 > recovery flow, resolve with `git checkout origin/main -- homebrew/archon.rb`
@@ -427,15 +511,50 @@ EOF
 
 ```bash
 git checkout main
-git pull origin main
+git pull origin main --no-rebase
 git add homebrew/archon.rb
 git commit -m "chore(homebrew): update formula to vx.y.z"
 git push origin main
 
 # Sync dev with main so the formula update is on both branches
 git checkout dev
-git pull origin main
+git pull origin main --no-rebase
+git push origin dev   # may be rejected — see below
+```
+
+**The CI `update-homebrew` job races you here.** It writes its own formula commit
+directly to dev (e.g. `chore: update Homebrew formula for vx.y.z`) while you are
+committing the same change to main. Both touch the same four `sha256` lines. The
+push above then fails with `Updates were rejected`:
+
+```bash
+git pull origin dev --no-rebase   # merges CI's commit; usually resolves clean
 git push origin dev
+```
+
+**A clean merge is not proof the SHAs are right.** Two commits editing the same
+lines can merge without conflict and still leave the wrong values. Verify against
+the published checksums before pushing — this is the one file where a wrong value
+breaks every user's install:
+
+```bash
+gh release download "vx.y.z" --repo coleam00/Archon --pattern checksums.txt --dir /tmp/rel
+for p in archon-darwin-arm64 archon-darwin-x64 archon-linux-arm64 archon-linux-x64; do
+  real=$(awk -v p="$p" '$2 ~ p"$" {print $1}' /tmp/rel/checksums.txt | head -1)
+  grep -q "$real" homebrew/archon.rb && echo "  OK  $p" || echo "  BAD $p ($real missing)"
+done
+grep -E '^\s+version "' homebrew/archon.rb
+```
+
+All four must print `OK` and the version must match the release. If any print
+`BAD`, regenerate the formula from the Step 10 template rather than hand-editing.
+
+Finally, confirm convergence:
+
+```bash
+git fetch origin
+git merge-base --is-ancestor origin/main origin/dev && echo "dev contains main — OK"
+test "$(git log origin/dev..origin/main --oneline | wc -l)" -eq 0 && echo "no stranded commits — OK"
 ```
 
 ### Step 11: Sync the Homebrew Tap Repo
@@ -557,6 +676,25 @@ Include a line in the new release's CHANGELOG that references the broken prior v
 ## Important Rules
 
 - NEVER force push
+- **NEVER derive the changelog from `git log main..dev`.** main squash-merges, so
+  that range accumulates every previously-released commit and grows each release
+  (61 vs 25 actual on 0.7.1). Use dev's last `Release x.y.z` commit as the
+  boundary, and cross-check the result against the previous version's changelog
+  entries — any PR number appearing in both means the boundary is wrong.
+- **ALWAYS pass `--no-rebase` to `git pull`.** The bare form aborts with
+  `Need to specify how to reconcile divergent branches` unless `pull.rebase` is
+  configured, and a `pull.rebase=true` config would rewrite dev's history.
+- **ALWAYS verify sync convergence rather than assuming it.**
+  `git merge-base --is-ancestor origin/main origin/dev` after every sync step.
+  A commit made directly to main stays stranded silently otherwise.
+- **NEVER trust a clean `homebrew/archon.rb` merge.** The CI `update-homebrew`
+  job edits the same `sha256` lines on dev that you edit on main; the merge can
+  succeed and still be wrong. Diff the four values against the published
+  `checksums.txt` before pushing.
+- **Flag a version bump that contradicts the commit range.** If `patch` was
+  requested but the range contains `feat:` commits or new user-facing CLI
+  surface, say so at the Step 7 review and let the user decide — do not silently
+  ship features as a patch.
 - **NEVER skip Step 1.5 (pre-flight compiled-binary smoke).** If the stack is a Bun/Node project with a build-binaries script, the `bun build --compile` smoke test runs before version bump, PR, or tag. Skipping it means every bundler regression or module-init crash only surfaces after the tag is pushed — by which point `releases/latest` is already 404-ing for every user. The ~30s cost is paid to keep the failure mode local.
 - If Step 1.5 fails, **abort the release** and fix the underlying issue on a feature branch. Do not "just skip it" and hope CI doesn't repro the problem.
 - NEVER skip the review step — always show the changelog before committing

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -160,30 +160,65 @@ Read the current version from the detected file.
 The real boundary is dev's own last `Release x.y.z` commit:
 
 ```bash
-# The previous release commit ON DEV (not the squashed one on main)
-LAST_RELEASE=$(git log origin/dev --grep='^Release [0-9]' --format='%H' -n 1)
+# The previous release commit ON DEV (not the squashed one on main).
+#
+# The `$` anchor is load-bearing. Both commits exist on dev after Step 9's sync:
+#   6c6945ce  Release 0.7.1           <- dev's own version-bump commit  (WANT)
+#   c71f7f52  Release 0.7.1 (#2435)   <- main's squash, pulled back     (WRONG)
+# Picking the squash commit is catastrophic: its ancestry does not include dev's
+# individual history, so the range balloons to the whole repo (383 commits when
+# tested). Match the bare subject only.
+LAST_RELEASE=$(git log origin/dev \
+  --grep='^Release [0-9]+\.[0-9]+\.[0-9]+$' --extended-regexp \
+  --format='%H' -n 1)
+
+# First-ever release: fall back to the root commit. Without this the range
+# becomes `..origin/dev`, which git resolves against HEAD and which returns
+# ZERO commits — the skill would report "nothing to release" and stop.
+if [ -z "$LAST_RELEASE" ]; then
+  LAST_RELEASE=$(git rev-list --max-parents=0 origin/dev | tail -n 1)
+fi
 echo "Previous release commit: $(git log -1 --oneline "$LAST_RELEASE")"
 
-# Everything after it is genuinely new
-git log "$LAST_RELEASE"..origin/dev --oneline --no-merges
+# Everything after it is genuinely new, minus the release-plumbing commits
+# described below.
+git log "$LAST_RELEASE"..origin/dev --oneline --no-merges \
+  --grep='^Release [0-9]+\.[0-9]+\.[0-9]+' \
+  --grep='^chore: update Homebrew formula for v' \
+  --grep='^chore\(homebrew\):' \
+  --extended-regexp --invert-grep
 ```
 
-If `LAST_RELEASE` is empty (first-ever release), fall back to the root commit.
+> The backslashes in `^chore\(homebrew\):` are required. Under `--extended-regexp`
+> bare `(` and `)` are grouping operators, so the unescaped form matches the
+> literal text `chorehomebrew:` and silently fails to filter anything.
 
-Two commit kinds in that range are **release plumbing, not changelog material** —
-exclude them:
+Two commit kinds in that range are **release plumbing, not changelog material**,
+and the `--invert-grep` above drops them:
 
 - `Release x.y.z (#NNNN)` — main's squash commit, pulled back by Step 9's sync
 - `chore: update Homebrew formula for vx.y.z` / `chore(homebrew): …` — the CI job
   and the Step 10 commit; note these appear as *two different SHAs* with the same
   content, one per branch
 
+> The `Release` pattern is anchored to a full `x.y.z` version deliberately. A bare
+> `^Release ` would also swallow a legitimate feature commit whose subject starts
+> with that word. If a real commit is ever dropped, widen the range by hand rather
+> than loosening the pattern.
+
 **Sanity-check the boundary before drafting.** Cross-reference against what the
-previous version already documented — any overlap means the range is wrong:
+previous version already documented — any overlap means the range is wrong.
+Derive both headings from the current version so this does not rot:
 
 ```bash
-# PR numbers already recorded under the previous version's heading
-awk '/^## \[0\.7\.0\]/,/^## \[0\.6/' CHANGELOG.md | grep -oE '#[0-9]{3,5}' | sort -u
+# CURRENT_VERSION is the value read in Step 2, before the bump (e.g. 0.7.1)
+PREV_MAJOR_MINOR_PATCH="$CURRENT_VERSION"
+# The heading immediately above the one we are about to write:
+awk -v prev="## [$PREV_MAJOR_MINOR_PATCH]" '
+  index($0, prev) == 1 { on = 1; next }
+  on && /^## \[/       { exit }
+  on                   { print }
+' CHANGELOG.md | grep -oE '#[0-9]{3,5}' | sort -u
 ```
 
 If a PR number in your commit range appears in that list, stop and re-derive the
@@ -315,11 +350,17 @@ git checkout dev
 git pull origin main --no-rebase
 git push origin dev
 
-# Verify the sync actually converged — do not assume it did
+# Verify the sync actually converged — do not assume it did. FAIL CLOSED:
+# continuing past a failed sync publishes a formula and tap from a tree that
+# does not match what was released.
 git fetch origin
-git merge-base --is-ancestor origin/main origin/dev \
-  && echo "dev contains main — OK" \
-  || { echo "STILL DIVERGED"; git log origin/dev..origin/main --oneline; }
+if git merge-base --is-ancestor origin/main origin/dev; then
+  echo "dev contains main — OK"
+else
+  echo "STILL DIVERGED — stranded on main:"
+  git log origin/dev..origin/main --oneline
+  exit 1
+fi
 ```
 
 > **`--no-rebase` is required, not optional.** Without it, git aborts with
@@ -538,23 +579,63 @@ the published checksums before pushing — this is the one file where a wrong va
 breaks every user's install:
 
 ```bash
-gh release download "vx.y.z" --repo coleam00/Archon --pattern checksums.txt --dir /tmp/rel
+VERSION=x.y.z   # without the leading v
+gh release download "v$VERSION" --repo coleam00/Archon --pattern checksums.txt --dir /tmp/rel
+
+fail=0
+
+# Assert the formula version matches the release. A stale version points every
+# URL at the wrong release while carrying the new digests.
+formula_version=$(awk -F'"' '/^[[:space:]]*version "/ {print $2; exit}' homebrew/archon.rb)
+if [ "$formula_version" != "$VERSION" ]; then
+  echo "  BAD version: formula says '$formula_version', release is '$VERSION'"
+  fail=1
+fi
+
+# Compare each digest against the sha256 that FOLLOWS ITS OWN url line. A naive
+# `grep -q "$digest" formula` only asks whether the value appears anywhere, so
+# two platforms with swapped hashes both pass — and an empty digest degenerates
+# to `grep -q ""`, which matches every file.
 for p in archon-darwin-arm64 archon-darwin-x64 archon-linux-arm64 archon-linux-x64; do
-  real=$(awk -v p="$p" '$2 ~ p"$" {print $1}' /tmp/rel/checksums.txt | head -1)
-  grep -q "$real" homebrew/archon.rb && echo "  OK  $p" || echo "  BAD $p ($real missing)"
+  real=$(awk -v p="$p" '$2 ~ "(^|/)" p "$" {print $1}' /tmp/rel/checksums.txt | head -1)
+  if ! printf '%s' "$real" | grep -qE '^[0-9a-f]{64}$'; then
+    echo "  BAD $p: no 64-char digest in checksums.txt (got '$real')"
+    fail=1
+    continue
+  fi
+  in_formula=$(awk -v p="$p" '
+    index($0, "/" p "\"") { seen = 1; next }
+    seen && /sha256 "/    { gsub(/.*sha256 "|".*/, ""); print; exit }
+  ' homebrew/archon.rb)
+  if [ "$in_formula" = "$real" ]; then
+    echo "  OK   $p"
+  else
+    echo "  BAD  $p: formula has '$in_formula', release has '$real'"
+    fail=1
+  fi
 done
-grep -E '^\s+version "' homebrew/archon.rb
+
+[ "$fail" -eq 0 ] || { echo "formula verification FAILED — do not push"; exit 1; }
+echo "formula verified against v$VERSION checksums"
 ```
 
-All four must print `OK` and the version must match the release. If any print
-`BAD`, regenerate the formula from the Step 10 template rather than hand-editing.
+Every line must print `OK` and the version must match. On any `BAD`, regenerate
+the formula from the Step 10 template rather than hand-editing — a hand edit is
+how a digest ends up under the wrong platform in the first place.
 
-Finally, confirm convergence:
+Finally, confirm convergence. **Fail closed** — Step 11 publishes to the tap that
+users install from, so do not proceed on an unconverged tree:
 
 ```bash
 git fetch origin
-git merge-base --is-ancestor origin/main origin/dev && echo "dev contains main — OK"
-test "$(git log origin/dev..origin/main --oneline | wc -l)" -eq 0 && echo "no stranded commits — OK"
+converged=1
+git merge-base --is-ancestor origin/main origin/dev \
+  || { echo "DIVERGED: dev does not contain main"; converged=0; }
+stranded=$(git log origin/dev..origin/main --oneline | wc -l | tr -d ' ')
+[ "$stranded" -eq 0 ] || { echo "STRANDED: $stranded commit(s) on main not on dev:"; \
+  git log origin/dev..origin/main --oneline; converged=0; }
+[ "$converged" -eq 1 ] || { echo "sync incomplete — resolve before Step 11"; exit 1; }
+echo "branches converged — OK"
 ```
 
 ### Step 11: Sync the Homebrew Tap Repo

--- a/.claude/skills/test-release/SKILL.md
+++ b/.claude/skills/test-release/SKILL.md
@@ -323,13 +323,35 @@ printf 'ANTHROPIC_API_KEY=sk-ant-test-fake\n' > .env
   means the file was not read at all, which is a real regression
 - The workflow is then allowed to proceed and complete normally
 
-Assert on the strip line, not on an exit code:
+Assert on the strip line — pinned to **this** repo and **this** key count, so a
+strip from some other directory cannot produce a false pass. Capture the exit
+status too: under the strip design the workflow is expected to succeed, so a
+non-zero exit is its own failure.
 
 ```bash
-grep -qE '^\[archon\] stripped [1-9][0-9]* keys .*\.env' /tmp/archon-test-leak.log \
-  && echo "PASS: env-leak guard active" \
-  || echo "FAIL: no strip line — guard inactive"
+"$BINARY" workflow run assist "hello" > /tmp/archon-test-leak.log 2>&1
+leak_exit=$?
+
+# $LEAKREPO may be a symlinked path (/tmp -> /private/tmp on macOS); the binary
+# logs the resolved form, so compare against that.
+resolved_repo=$(cd "$LEAKREPO" && pwd -P)
+expected="[archon] stripped 1 keys from ${resolved_repo} (.env) to prevent target repo env from leaking into Archon processes"
+
+if [ "$leak_exit" -ne 0 ]; then
+  echo "FAIL: workflow exited $leak_exit — the guard strips and proceeds, it should not abort"
+elif grep -qxF "$expected" /tmp/archon-test-leak.log; then
+  echo "PASS: env-leak guard stripped exactly the planted key from this repo"
+else
+  echo "FAIL: expected strip line absent. Got:"
+  grep -F '[archon] stripped' /tmp/archon-test-leak.log || echo "  (no strip line at all — guard inactive)"
+fi
 ```
+
+An exact-match assertion is deliberate here. A looser pattern such as
+`stripped [1-9][0-9]* keys .*\.env` passes on **any** positive count from **any**
+path, so a strip belonging to a different repository — or a count inflated by an
+unrelated `.env` — reads as success while the regression it is meant to catch
+goes unnoticed.
 
 > **History — do not re-assert the old criteria.** This test previously expected a
 > *refusal* (`Cannot add codebase` / `Cannot run workflow`, non-zero exit), which

--- a/.claude/skills/test-release/SKILL.md
+++ b/.claude/skills/test-release/SKILL.md
@@ -145,9 +145,20 @@ Install to a dedicated tmp directory so the dev `bun link` binary stays on PATH 
 ```bash
 INSTALL_DIR=/tmp/archon-test-release-$(date +%s)
 mkdir -p "$INSTALL_DIR"
-INSTALL_DIR="$INSTALL_DIR" curl -fsSL https://raw.githubusercontent.com/coleam00/Archon/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/coleam00/Archon/main/scripts/install.sh | INSTALL_DIR="$INSTALL_DIR" bash
 BINARY="$INSTALL_DIR/archon"
 ```
+
+> **The env var must prefix `bash`, not `curl`.** In `VAR=x cmd1 | cmd2` the
+> assignment applies only to `cmd1`, so `INSTALL_DIR=… curl … | bash` sets it for
+> the *download* and leaves the *installer* on its `/usr/local/bin` default. The
+> failure is confusing rather than obvious: the script downloads and verifies the
+> checksum, then demands sudo and dies with
+> `sudo: a terminal is required to read the password`. Observed on the 0.7.1 test.
+>
+> `scripts/install.sh` carries the same broken form in its own header example
+> (`INSTALL_DIR=~/.local/bin curl -fsSL ... | bash`), so users copying it hit this
+> too. Fix both together; see issue #2436.
 
 Verify `$BINARY` exists and is executable. Capture the install directory for cleanup.
 
@@ -304,17 +315,36 @@ printf 'ANTHROPIC_API_KEY=sk-ant-test-fake\n' > .env
 "$BINARY" workflow run assist "hello" 2>&1 | tee /tmp/archon-test-leak.log
 ```
 
-**Pass criteria:**
+**Pass criteria** (current behaviour — the guard **strips**, it does not refuse):
 
-- The command exits with a non-zero code, OR produces an error message containing `Cannot add codebase` or `Cannot run workflow`
-- The error mentions the dangerous key name (`ANTHROPIC_API_KEY`)
-- No Claude subprocess was actually spawned (the gate short-circuited)
+- Output contains a strip line naming the repo and the source file, of the form:
+  `[archon] stripped N keys from <repo> (.env) to prevent target repo env from leaking into Archon processes`
+- `N` equals the number of keys planted (1 for the `.env` above) — a count of `0`
+  means the file was not read at all, which is a real regression
+- The workflow is then allowed to proceed and complete normally
+
+Assert on the strip line, not on an exit code:
+
+```bash
+grep -qE '^\[archon\] stripped [1-9][0-9]* keys .*\.env' /tmp/archon-test-leak.log \
+  && echo "PASS: env-leak guard active" \
+  || echo "FAIL: no strip line — guard inactive"
+```
+
+> **History — do not re-assert the old criteria.** This test previously expected a
+> *refusal* (`Cannot add codebase` / `Cannot run workflow`, non-zero exit), which
+> was the #1036/#1038/#983 behaviour. The current design is the two-layer strip
+> guard: the target repo's `.env` is read, dangerous keys are removed from the
+> environment handed to Archon subprocesses, and the run continues. On the 0.7.1
+> test the old assertions reported FAIL against a binary whose guard was working
+> correctly — it stripped exactly the 1 planted key. Verify the security property
+> (the key never reaches the subprocess), not the obsolete remediation text.
 
 **Common failures:**
 
-- Command proceeds normally → the env-leak gate is not active (regression of #1036)
-- Error is generic or unclear → the context-aware error message from #983 has regressed
-- Gate blocks but with wrong remediation text → `formatLeakError` context detection is broken
+- No strip line at all → the guard is not active; the `.env` is reaching subprocesses
+- `stripped 0 keys` → the file was located but not parsed
+- Strip line names the wrong file or repo → path resolution regression
 
 Clean up the leak test repo:
 

--- a/packages/docs-web/public/install
+++ b/packages/docs-web/public/install
@@ -15,10 +15,14 @@
 #   curl -fsSL https://raw.githubusercontent.com/coleam00/Archon/main/scripts/install.sh | bash
 #
 #   # Install specific version
-#   VERSION=v0.2.0 curl -fsSL ... | bash
+#   curl -fsSL ... | VERSION=v0.2.0 bash
 #
 #   # Install to custom directory
-#   INSTALL_DIR=~/.local/bin curl -fsSL ... | bash
+#   curl -fsSL ... | INSTALL_DIR=~/.local/bin bash
+#
+# NOTE: the variable must prefix `bash`, not `curl`. In `VAR=x cmd1 | cmd2` the
+# assignment applies only to cmd1, so `VERSION=... curl ... | bash` sets it on the
+# download and the installer never sees it — it silently uses the defaults below.
 
 set -euo pipefail
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,10 +15,14 @@
 #   curl -fsSL https://raw.githubusercontent.com/coleam00/Archon/main/scripts/install.sh | bash
 #
 #   # Install specific version
-#   VERSION=v0.2.0 curl -fsSL ... | bash
+#   curl -fsSL ... | VERSION=v0.2.0 bash
 #
 #   # Install to custom directory
-#   INSTALL_DIR=~/.local/bin curl -fsSL ... | bash
+#   curl -fsSL ... | INSTALL_DIR=~/.local/bin bash
+#
+# NOTE: the variable must prefix `bash`, not `curl`. In `VAR=x cmd1 | cmd2` the
+# assignment applies only to cmd1, so `VERSION=... curl ... | bash` sets it on the
+# download and the installer never sees it — it silently uses the defaults below.
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

- **Problem:** Running `/release` and `/test-release` end to end for v0.7.1 surfaced five documented commands that do not do what they say. The worst would have published a changelog re-listing most of the previous release.
- **Why it matters:** These are the instructions followed while cutting a release — the point at which mistakes reach every user. Four of the five fail *silently* or with a misleading error.
- **What changed:** Corrected the commit boundary, the `git pull` form, added a drift guard, fixed the installer's own env-var examples, and replaced stale env-leak assertions.
- **What did NOT change:** No engine, CLI, or runtime behaviour. `install.sh` changes are comment-only — the executable body is untouched. `install.ps1` is correct as written and was left alone.

## UX Journey

### Before

```
Maintainer              /release skill            Result
──────────              ──────────────            ──────
/release patch ──────▶  git log main..dev
                        → 61 commits          ──▶ changelog re-lists 0.7.0
                        git pull origin main  ──▶ fatal: Need to specify how
                                                  to reconcile divergent branches
                        (no ancestry check)   ──▶ ae704a73 stranded on main,
                                                  release PR proposes reverting it

/test-release ───────▶  INSTALL_DIR=… curl … | bash
                                              ──▶ [OK] Checksum verified
                                                  sudo: a terminal is required
                        assert "Cannot add codebase"
                                              ──▶ FAIL (against a working guard)
```

### After

```
Maintainer              /release skill                    Result
──────────              ──────────────                    ──────
/release patch ──────▶  *ancestry check*              ──▶ fails closed if main
                                                          has stranded commits
                        *git log $LAST_RELEASE..dev*  ──▶ 25 commits, verified
                                                          against prior changelog
                        git pull … *--no-rebase*      ──▶ merge commit, converges
                        *verify --is-ancestor*        ──▶ drift caught, not assumed

/test-release ───────▶  curl … | *INSTALL_DIR=… bash* ──▶ installs to the sandbox
                        *assert strip line + count*   ──▶ PASS (tests the real
                                                          security property)
```

## Architecture Diagram

### Before

```
.claude/skills/release/SKILL.md ──── describes ───▶ git (main..dev)      [wrong range]
                                └─── describes ───▶ git pull            [aborts]
.claude/skills/test-release/SKILL.md ─ describes ─▶ scripts/install.sh  [var dropped]
                                     └─ asserts ──▶ env-leak gate       [stale criteria]

scripts/install.sh ──── header documents ───▶ itself                    [var dropped]
        │ (hand-synced, cmp-enforced)
        └──────────────▶ packages/docs-web/public/install               [same bug]
```

### After

```
.claude/skills/release/SKILL.md ──── describes ───▶ git ($LAST_RELEASE..dev)  [correct]
                                ├─── describes ───▶ git pull --no-rebase      [converges]
                                └─── verifies ────▶ merge-base --is-ancestor  [new guard]
.claude/skills/test-release/SKILL.md ─ describes ─▶ scripts/install.sh        [var honoured]
                                     └─ asserts ──▶ strip line + key count    [real property]

scripts/install.sh ──── header documents ───▶ itself                          [var honoured]
        │ (hand-synced, cmp-enforced by scripts/test-install.sh:150)
        └──────────────▶ packages/docs-web/public/install                     [synced]
```

## Label Snapshot

`bug`, `area: infra`, `effort/low`

## Change Metadata

4 files, +196 / -20. Two skill documents, one installer script, one enforced mirror of it.

## Linked Issue

Refs #2436 (the `install.sh` half — filed separately since it ships to users independently of the skills).

## Validation Evidence (required)

- `bash scripts/test-install.sh` → **`Installer tests passed`** (this is the suite that enforces `cmp -s scripts/install.sh packages/docs-web/public/install`)
- `cmp -s scripts/install.sh packages/docs-web/public/install` → byte-identical
- Shell semantics behind the installer fix, demonstrated directly:
  ```
  $ FOO=set-for-first sh -c 'echo "first(curl-position): ${FOO:-UNSET}"'
  first(curl-position): set-for-first
  $ FOO=set-for-first true | sh -c 'echo "second(bash-position): ${FOO:-UNSET}"'
  second(bash-position): UNSET
  ```
- Corrected form exercised for real during the v0.7.1 test: `curl … | INSTALL_DIR=… bash` installed to the sandbox and reported `Archon CLI v0.7.1 / Build: binary`, sha `0cb1dbda…` matching the published `checksums.txt`
- Every claim in the new Step 4 text is from the actual 0.7.1 run: 61 vs 25 commits, and #2066 / #1542 / #1583 present in both the bad range and the 0.7.0 changelog
- Code fences balanced in both skills (44 and 56 markers); frontmatter intact

## Security Impact (required)

Net positive, small. The `test-release` env-leak test previously asserted obsolete remediation text and reported **FAIL against a binary whose guard was working**. A test that cries wolf on correct behaviour gets ignored, and then a real regression is ignored with it. It now asserts the property that matters — keys stripped before subprocess launch, with the count checked so `stripped 0 keys` fails.

The `install.sh` fix also removes a path where a user pinning `VERSION=` to an old release silently receives `latest` instead.

No credential handling, no auth, no network behaviour changed.

## Compatibility / Migration

None. Documentation and comments only; no runtime code path is altered. The `install.sh` executable body is unchanged, so the published `curl | bash` endpoint behaves identically — only its header comments and the mirror are updated.

## Human Verification (required)

1. `bash scripts/test-install.sh` → passes
2. Sandboxed install honours the documented form:
   ```bash
   D=/tmp/archon-verify-$(date +%s); mkdir -p "$D"
   curl -fsSL https://raw.githubusercontent.com/coleam00/Archon/main/scripts/install.sh | INSTALL_DIR="$D" bash
   "$D/archon" version   # expect v0.7.1, Build: binary
   rm -rf "$D"
   ```
3. The old form still misbehaves as described (confirms the bug was real):
   ```bash
   INSTALL_DIR=/tmp/whatever curl -fsSL … | bash   # targets /usr/local/bin, wants sudo
   ```
4. On the next release, Step 4's boundary should yield only that cycle's commits, and none of its PR numbers should appear under the previous version in `CHANGELOG.md`.

## Side Effects / Blast Radius (required)

Confined to two skill documents and the installer's comment header plus its mirror. The mirror is `cmp`-enforced in CI, so the risk of touching one and not the other is caught by `scripts/test-install.sh` — which was run and passes.

The real blast radius is behavioural, on the next release: Step 1's new ancestry check **fails closed**. If main has stranded commits, `/release` now stops instead of proceeding. That is the intent, but it means the next `/release` may halt where it previously continued — resolve the drift, then re-run.

## Rollback Plan (required)

`git revert c6243bd8`. Nothing is consumed at runtime and no state is written, so reverting restores the prior instructions exactly. The only cost of reverting is losing the guards and reinstating the wrong commit range.

## Risks and Mitigations

- **Risk:** `git log --grep='^Release [0-9]'` misses the boundary if a future release commit is renamed. **Mitigation:** the skill states the fallback (root commit) and requires cross-checking against the previous version's changelog PR numbers, which catches a bad boundary regardless of how it was derived.
- **Risk:** the new ancestry check blocks a release at an inconvenient moment. **Mitigation:** it prints the exact stranded commits and the three-command fix; drift is cheaper to resolve before a release than after.
- **Risk:** the env-leak assertion is now coupled to a log line's wording. **Mitigation:** the regex matches the stable part (`stripped N keys … .env`) and the count, not the full sentence. A wording change fails loudly rather than silently passing — the correct direction for a security check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation examples to correctly pass `VERSION` and `INSTALL_DIR` to the installer.
  * Added guidance explaining environment variable handling in piped shell commands.
  * Expanded release workflow guidance with changelog, synchronization, version, and checksum validation requirements.

* **Bug Fixes**
  * Improved handling of sensitive environment variables during installation tests.
  * Added safeguards for release synchronization and Homebrew formula updates.
  * Added verification to help prevent incorrect versions or checksums from being published.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->