### PR TITLE
fix(migrations): create indexes after ADD COLUMN for existing Postgres DBs

### DIFF
--- a/migrations/000_combined.sql
+++ b/migrations/000_combined.sql
@@ -125,8 +125,6 @@ CREATE TABLE IF NOT EXISTS remote_agent_conversations (
 
 CREATE INDEX IF NOT EXISTS idx_remote_agent_conversations_codebase
   ON remote_agent_conversations(codebase_id);
-CREATE INDEX IF NOT EXISTS idx_conversations_hidden
-  ON remote_agent_conversations(hidden);
 CREATE INDEX IF NOT EXISTS idx_conversations_codebase
   ON remote_agent_conversations(codebase_id) WHERE deleted_at IS NULL;
 
@@ -156,8 +154,6 @@ CREATE INDEX IF NOT EXISTS idx_remote_agent_sessions_conversation
   ON remote_agent_sessions(conversation_id, active);
 CREATE INDEX IF NOT EXISTS idx_remote_agent_sessions_codebase
   ON remote_agent_sessions(codebase_id);
-CREATE INDEX IF NOT EXISTS idx_sessions_parent
-  ON remote_agent_sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_conversation_started
   ON remote_agent_sessions(conversation_id, started_at DESC);
 
@@ -365,6 +361,10 @@ ALTER TABLE remote_agent_workflow_runs
 -- From migration 010: parent_session_id + transition_reason on sessions
 ALTER TABLE remote_agent_sessions
   ADD COLUMN IF NOT EXISTS parent_session_id UUID REFERENCES remote_agent_sessions(id);
+-- Index must follow the ADD COLUMN so it works on pre-existing Postgres DBs
+-- (CREATE TABLE IF NOT EXISTS is a no-op there, so the column only exists after this ALTER).
+CREATE INDEX IF NOT EXISTS idx_sessions_parent
+  ON remote_agent_sessions(parent_session_id);
 ALTER TABLE remote_agent_sessions
   ADD COLUMN IF NOT EXISTS transition_reason TEXT;
 
@@ -380,6 +380,9 @@ ALTER TABLE remote_agent_workflow_runs
     REFERENCES remote_agent_conversations(id) ON DELETE SET NULL;
 ALTER TABLE remote_agent_conversations
   ADD COLUMN IF NOT EXISTS hidden BOOLEAN DEFAULT FALSE;
+-- Index must follow the ADD COLUMN so it works on pre-existing Postgres DBs.
+CREATE INDEX IF NOT EXISTS idx_conversations_hidden
+  ON remote_agent_conversations(hidden);
 
 -- From migration 016: ended_reason on sessions
 ALTER TABLE remote_agent_sessions


### PR DESCRIPTION
## Summary

Fixes #2442.

`migrations/000_combined.sql` fails on **existing** Postgres DBs: two indexes are created in the `CREATE TABLE` section, before the columns they reference are added in the additive `ALTER TABLE ... ADD COLUMN` block. On an existing DB, `CREATE TABLE IF NOT EXISTS` is a no-op, so those columns do not exist yet when the indexes run, and creation fails with `column ... does not exist`.

This PR moves both indexes to directly follow their `ADD COLUMN`:

- `idx_sessions_parent` -> after `ADD COLUMN ... parent_session_id`
- `idx_conversations_hidden` -> after `ADD COLUMN ... hidden`

Fresh DBs are unaffected (columns already exist inline in `CREATE TABLE`). This complements #2418, which applied the same reordering only in the SQLite path; the Postgres path was still broken.

## Changes

- `migrations/000_combined.sql`: relocate the two `CREATE INDEX IF NOT EXISTS` statements into the additive block, each directly after its `ADD COLUMN`, with a short comment explaining why the order matters.

## Test plan

- [ ] Fresh Postgres DB: run migration end to end, both indexes present.
- [ ] Pre-existing Postgres DB (tables already created without the new columns): run migration, columns are added and both indexes build without `column does not exist`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database upgrades for existing installations by ensuring required indexes are created correctly.
  * Optimized conversation lookups to focus on non-deleted records.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->