### PR TITLE
fix(workflows): surface unknown-key warnings where authors are, and correct the interactive hint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -481,7 +481,7 @@ Structured logging uses Pino via `createLogger('<module>')` from `@archon/paths`
 **Web UI REST API** (`packages/server/src/routes/api.ts`):
 
 **Workflow Management:**
-- `GET /api/workflows` - List available workflows; optional `?cwd=`; returns `{ workflows: [...], recommended: [...], errors?: [...] }`. Each entry is `{ workflow, source, parseWarnings? }` — `parseWarnings` (#2213) lists keys the engine silently dropped from that YAML and is **omitted** when the workflow is clean, so presence alone is the signal
+- `GET /api/workflows` - List available workflows; optional `?cwd=`; returns `{ workflows: [...], recommended: [...], errors?: [...] }`. Each entry is `{ workflow, source, parseWarnings? }` — `parseWarnings` (#2213) holds warning messages naming the keys the engine silently dropped from that YAML and is **omitted** when the workflow is clean, so presence alone is the signal
 - `POST /api/workflows/validate` - Validate a workflow definition in-memory (no save); body: `{ definition: object }`; returns `{ valid: boolean, errors?: string[] }`
 - `GET /api/workflows/:name` - Fetch a single workflow by name; optional `?cwd=` query param; returns `{ workflow, filename, source: 'project' | 'bundled' }`
 - `PUT /api/workflows/:name` - Save (create or update) a workflow YAML; body: `{ definition: object }`; validates before writing; requires `?cwd=` or registered codebase

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -481,7 +481,7 @@ Structured logging uses Pino via `createLogger('<module>')` from `@archon/paths`
 **Web UI REST API** (`packages/server/src/routes/api.ts`):
 
 **Workflow Management:**
-- `GET /api/workflows` - List available workflows; optional `?cwd=`; returns `{ workflows: [...], errors?: [...] }`
+- `GET /api/workflows` - List available workflows; optional `?cwd=`; returns `{ workflows: [...], recommended: [...], errors?: [...] }`. Each entry is `{ workflow, source, parseWarnings? }` — `parseWarnings` (#2213) lists keys the engine silently dropped from that YAML and is **omitted** when the workflow is clean, so presence alone is the signal
 - `POST /api/workflows/validate` - Validate a workflow definition in-memory (no save); body: `{ definition: object }`; returns `{ valid: boolean, errors?: string[] }`
 - `GET /api/workflows/:name` - Fetch a single workflow by name; optional `?cwd=` query param; returns `{ workflow, filename, source: 'project' | 'bundled' }`
 - `PUT /api/workflows/:name` - Save (create or update) a workflow YAML; body: `{ definition: object }`; validates before writing; requires `?cwd=` or registered codebase

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -107,7 +107,7 @@ export async function validateWorkflowsCommand(
   }
 
   // Validate successfully parsed workflows (Level 3)
-  for (const { workflow, source } of workflowEntries) {
+  for (const { workflow, source, parseWarnings } of workflowEntries) {
     const issues = await validateWorkflowResources(
       workflow,
       cwd,
@@ -120,6 +120,14 @@ export async function validateWorkflowsCommand(
       },
       defaultProvider
     );
+
+    // Surface parse-time unknown-key warnings (#2213) as validation issues
+    if (parseWarnings && parseWarnings.length > 0) {
+      for (const warning of parseWarnings) {
+        issues.push({ level: 'warning', field: 'unknown_key', message: warning });
+      }
+    }
+
     results.push(makeWorkflowResult(workflow.name, issues));
   }
 

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -719,7 +719,9 @@ describe('workflowRunCommand', () => {
   });
 
   // #2213 — `--json` silences Pino entirely (cli.ts sets the level to 'silent'),
-  // so stderr is the only channel left. stdout must stay exactly the payload.
+  // so stderr is the only channel left. Note this asserts only the CHANNEL
+  // (console.warn, not console.log); the JSON payload itself goes through
+  // `writeJsonLine` on the `--detach` branch, covered in the detach describe.
   it('warns on stderr about keys the engine drops, even in json mode', async () => {
     const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
     try {
@@ -3858,6 +3860,67 @@ describe('workflowRunCommand — detach', () => {
     expect(execAfter).toBe(execBefore);
     expect(child.unref).toHaveBeenCalledTimes(1);
     expect(consoleSpy).toHaveBeenCalledWith("Started 'assist' in the background.");
+  });
+
+  // #2213 — the headline `--json` claim. `writeJsonLine` (not console.log) is
+  // what emits the payload, and it is only reached on this `--detach` branch,
+  // so this is the only place the "stdout stays exactly the payload" guarantee
+  // can actually be observed. Asserts the captured stdout still JSON.parse()s
+  // while the warning went to stderr.
+  it('keeps stdout a parseable JSON payload while warning on stderr', async () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const paths = await import('@archon/paths');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [
+        makeTestWorkflowWithSource({ name: 'assist', description: 'Help' }, 'project', [
+          "Node 'plan': unknown key 'interactive' will be ignored.",
+        ]),
+      ],
+      errors: [],
+    });
+    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
+      throw new Error('no home in test');
+    });
+
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
+    const savedArgv = process.argv;
+    process.argv = [
+      'bun',
+      '/abs/cli.ts',
+      'workflow',
+      'run',
+      'assist',
+      'hello',
+      '--detach',
+      '--json',
+    ];
+
+    try {
+      const commandPromise = workflowRunCommand('/test/path', 'assist', 'hello', {
+        detach: true,
+        json: true,
+      });
+      await finishStartupWindow(commandPromise, spawnSpy);
+    } finally {
+      process.argv = savedArgv;
+      spawnSpy.mockRestore();
+    }
+
+    // stdout: exactly one line, and it parses.
+    const payload = JSON.parse(firstJsonPayload(stdoutSpy)) as {
+      ok: boolean;
+      action: string;
+      workflow: string;
+    };
+    expect(payload.ok).toBe(true);
+    expect(payload.action).toBe('run');
+    expect(payload.workflow).toBe('assist');
+    // The warning reached the user — on stderr, not in the payload.
+    expect(warnSpy).toHaveBeenCalledWith("Warning: 'assist' declares keys the engine ignores:");
+    expect(JSON.stringify(payload)).not.toContain('unknown key');
+    warnSpy.mockRestore();
   });
 
   it('does NOT pin a --branch on the detached child for a registered folder project', async () => {

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -431,6 +431,49 @@ describe('workflowListCommand', () => {
       'Error loading workflows: Permission denied'
     );
   });
+
+  // #2213 — a key the engine drops has to reach the author on the surface they
+  // use, not only in `archon validate workflows` (which nothing requires them
+  // to run).
+  it('prints parse warnings inline with the workflow that raised them', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [
+        makeTestWorkflowWithSource({ name: 'clean' }, 'project'),
+        makeTestWorkflowWithSource({ name: 'gated' }, 'project', [
+          "Node 'plan': unknown key 'interactive' will be ignored.",
+        ]),
+      ],
+      errors: [],
+    });
+
+    await workflowListCommand('/test/path');
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "    Warning: Node 'plan': unknown key 'interactive' will be ignored."
+    );
+  });
+
+  it('carries parse warnings in --json output', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [
+        makeTestWorkflowWithSource({ name: 'clean' }, 'project'),
+        makeTestWorkflowWithSource({ name: 'gated' }, 'project', ["dropped 'interactive'"]),
+      ],
+      errors: [],
+    });
+
+    await workflowListCommand('/test/path', true);
+
+    const parsed = JSON.parse(firstJsonPayload(stdoutSpy)) as {
+      workflows: { name: string; parseWarnings?: string[] }[];
+    };
+    // Absent (not an empty array) on a clean workflow, so the field's presence
+    // alone is the signal.
+    expect(parsed.workflows[0].parseWarnings).toBeUndefined();
+    expect(parsed.workflows[1].parseWarnings).toEqual(["dropped 'interactive'"]);
+  });
 });
 
 describe('workflowRunCommand — requires: [github] gate', () => {
@@ -673,6 +716,62 @@ describe('workflowRunCommand', () => {
     }
 
     expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('Discovery: root='));
+  });
+
+  // #2213 — `--json` silences Pino entirely (cli.ts sets the level to 'silent'),
+  // so stderr is the only channel left. stdout must stay exactly the payload.
+  it('warns on stderr about keys the engine drops, even in json mode', async () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+      (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+        workflows: [
+          makeTestWorkflowWithSource({ name: 'assist' }, 'project', [
+            "Node 'plan': unknown key 'interactive' will be ignored.",
+          ]),
+        ],
+        errors: [],
+      });
+
+      try {
+        await workflowRunCommand('/repo/root', 'assist', 'hello', {
+          json: true,
+          noWorktree: true,
+        });
+      } catch {
+        // Downstream failure is acceptable; this test only checks the warning.
+      }
+
+      expect(warnSpy).toHaveBeenCalledWith("Warning: 'assist' declares keys the engine ignores:");
+      expect(warnSpy).toHaveBeenCalledWith(
+        "  - Node 'plan': unknown key 'interactive' will be ignored."
+      );
+      // Never on stdout — a --json caller must still get a parseable payload.
+      expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('unknown key'));
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('stays silent when the resolved workflow has no parse warnings', async () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+      (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+        workflows: [
+          makeTestWorkflowWithSource({ name: 'assist' }, 'project'),
+          // A DIFFERENT workflow's warnings must not leak into this run.
+          makeTestWorkflowWithSource({ name: 'other' }, 'project', ["dropped 'interactive'"]),
+        ],
+        errors: [],
+      });
+
+      await workflowRunCommand('/repo/root', 'assist', 'hello', { noWorktree: true });
+
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('the engine ignores'));
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('does not print discovery diagnostic in quiet mode', async () => {

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -3022,6 +3022,70 @@ describe('workflowGetCommand', () => {
     expect(code).toBe(1);
   });
 
+  // #2213 — the read path for a run whose warnings were recorded but never
+  // delivered to a conversation (CLI/REST runs, or a failed chat send).
+  it('surfaces recorded parse warnings in verbose output', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const workflowEventsDb = await import('@archon/core/db/workflow-events');
+
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'run-pw',
+      workflow_name: 'gated',
+      working_path: '/repo',
+      status: 'completed',
+      started_at: new Date(),
+      metadata: {},
+    });
+    (workflowEventsDb.listWorkflowEvents as ReturnType<typeof mock>).mockResolvedValueOnce([
+      {
+        id: 'e1',
+        workflow_run_id: 'run-pw',
+        event_type: 'workflow_parse_warnings',
+        step_name: null,
+        step_index: null,
+        data: { workflowName: 'gated', warnings: ["Node 'plan': unknown key 'interactive'"] },
+        created_at: new Date().toISOString(),
+      },
+    ]);
+
+    const code = await workflowGetCommand('run-pw', false, true);
+
+    const calls = consoleSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(calls.some(c => c.includes('Ignored keys (1)'))).toBe(true);
+    expect(calls.some(c => c.includes("unknown key 'interactive'"))).toBe(true);
+    expect(code).toBe(0);
+  });
+
+  it('carries recorded parse warnings on the verbose --json payload', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const workflowEventsDb = await import('@archon/core/db/workflow-events');
+
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'run-pw',
+      workflow_name: 'gated',
+      working_path: '/repo',
+      status: 'completed',
+      started_at: new Date(),
+      metadata: {},
+    });
+    (workflowEventsDb.listWorkflowEvents as ReturnType<typeof mock>).mockResolvedValueOnce([
+      {
+        id: 'e1',
+        workflow_run_id: 'run-pw',
+        event_type: 'workflow_parse_warnings',
+        step_name: null,
+        step_index: null,
+        data: { workflowName: 'gated', warnings: ["Node 'plan': unknown key 'interactive'"] },
+        created_at: new Date().toISOString(),
+      },
+    ]);
+
+    await workflowGetCommand('run-pw', true, true);
+
+    const payload = JSON.parse(firstJsonPayload(stdoutSpy)) as { parseWarnings?: string[] };
+    expect(payload.parseWarnings).toEqual(["Node 'plan': unknown key 'interactive'"]);
+  });
+
   it('emits {ok:false} JSON (never throws) when the DB lookup fails', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
     (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockRejectedValueOnce(

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1821,6 +1821,7 @@ export async function workflowRunCommand(
       ? {
           codebaseId: codebase?.id,
           source: workflowSource,
+          parseWarnings: workflowEntry?.parseWarnings,
           userId: cliUserId,
           baseBranch: codebaseDefaultBranch,
           baseOverride: flagBase,
@@ -1832,6 +1833,7 @@ export async function workflowRunCommand(
       : {
           codebaseId: codebase?.id,
           source: workflowSource,
+          parseWarnings: workflowEntry?.parseWarnings,
           userId: cliUserId,
           baseBranch: codebaseDefaultBranch,
           baseOverride: flagBase,
@@ -2268,9 +2270,16 @@ export async function workflowGetCommand(
     }
 
     const verboseEvents = events ?? [];
+    const parseWarnings = readParseWarningEvents(verboseEvents);
     const output = rawEvents
       ? { ...run, events: verboseEvents }
-      : { ...run, nodes: buildNodeSummaries(verboseEvents) };
+      : {
+          ...run,
+          nodes: buildNodeSummaries(verboseEvents),
+          // Keys the engine dropped from this run's YAML (#2213). Surfaced as a
+          // named field rather than leaving the caller to scan raw events.
+          ...(parseWarnings.length > 0 ? { parseWarnings } : {}),
+        };
     await writeJsonLine(output);
     return 0;
   }
@@ -2302,9 +2311,31 @@ export async function workflowGetCommand(
     if (eventsFailed) {
       console.log('  (node events unavailable — see logs)');
     }
+    const parseWarnings = readParseWarningEvents(events);
+    if (parseWarnings.length > 0) {
+      console.log(`  Ignored keys (${String(parseWarnings.length)}):`);
+      for (const w of parseWarnings) console.log(`    - ${w}`);
+    }
     printVerboseNodes(events);
   }
   return 0;
+}
+
+/**
+ * Pull the dropped-key warnings out of a run's event log (#2213).
+ *
+ * The engine records them once at run start as `workflow_parse_warnings`,
+ * whatever surface started the run — so this is the read path for a run that
+ * had no conversation to post into (CLI, REST) or whose chat delivery failed.
+ */
+function readParseWarningEvents(events: readonly WorkflowEventRow[]): string[] {
+  const out: string[] = [];
+  for (const event of events) {
+    if (event.event_type !== 'workflow_parse_warnings') continue;
+    const raw: unknown = (event.data as Record<string, unknown> | null)?.warnings;
+    if (Array.isArray(raw)) out.push(...raw.filter((w): w is string => typeof w === 'string'));
+  }
+  return out;
 }
 
 /**

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -755,6 +755,24 @@ async function loadWorkflows(cwd: string): Promise<WorkflowLoadResult> {
   }
 }
 
+/**
+ * Print a workflow's parse warnings (keys the engine silently drops) to stderr.
+ *
+ * stderr rather than stdout so `--json` callers keep a parseable payload while
+ * still being told; `console.warn` rather than the logger because `--json` sets
+ * the log level to silent, which is exactly the case this has to survive.
+ */
+export function emitParseWarnings(
+  parseWarnings: readonly string[] | undefined,
+  workflowName: string
+): void {
+  if (!parseWarnings || parseWarnings.length === 0) return;
+  console.warn(`Warning: '${workflowName}' declares keys the engine ignores:`);
+  for (const warning of parseWarnings) {
+    console.warn(`  - ${warning}`);
+  }
+}
+
 function countWorkflowSources(
   workflows: readonly WorkflowWithSource[]
 ): Record<WorkflowSource, number> {
@@ -774,6 +792,8 @@ interface WorkflowJsonEntry {
   model?: string;
   modelReasoningEffort?: string;
   webSearchMode?: string;
+  /** Keys the workflow's YAML declares that the engine drops (#2213). */
+  parseWarnings?: string[];
 }
 
 /**
@@ -784,7 +804,7 @@ export async function workflowListCommand(cwd: string, json?: boolean): Promise<
 
   if (json) {
     const output = {
-      workflows: workflowEntries.map(({ workflow: w }) => {
+      workflows: workflowEntries.map(({ workflow: w, parseWarnings }) => {
         const entry: WorkflowJsonEntry = {
           name: w.name,
           description: w.description,
@@ -794,6 +814,7 @@ export async function workflowListCommand(cwd: string, json?: boolean): Promise<
         if (w.modelReasoningEffort !== undefined)
           entry.modelReasoningEffort = w.modelReasoningEffort;
         if (w.webSearchMode !== undefined) entry.webSearchMode = w.webSearchMode;
+        if (parseWarnings && parseWarnings.length > 0) entry.parseWarnings = [...parseWarnings];
         return entry;
       }),
       errors: errors.map(e => ({
@@ -817,11 +838,14 @@ export async function workflowListCommand(cwd: string, json?: boolean): Promise<
   if (workflowEntries.length > 0) {
     console.log(`\nFound ${workflowEntries.length} workflow(s):\n`);
 
-    for (const { workflow } of workflowEntries) {
+    for (const { workflow, parseWarnings } of workflowEntries) {
       console.log(`  ${workflow.name}`);
       console.log(`    ${workflow.description}`);
       if (workflow.provider) {
         console.log(`    Provider: ${workflow.provider}`);
+      }
+      for (const warning of parseWarnings ?? []) {
+        console.log(`    Warning: ${warning}`);
       }
       console.log('');
     }
@@ -864,11 +888,11 @@ export async function workflowRunCommand(
   const workflows = workflowEntries.map(ws => ws.workflow);
 
   const workflow = resolveWorkflowName(workflowName, workflows);
-  // Recover the discovery source (dropped by the .map above) for telemetry —
-  // bundled workflows report their real name, custom ones report "custom".
-  const workflowSource = workflow
-    ? workflowEntries.find(ws => ws.workflow === workflow)?.source
-    : undefined;
+  // Recover the discovery entry (dropped by the .map above) for telemetry —
+  // bundled workflows report their real name, custom ones report "custom" —
+  // and for the parse warnings surfaced just below.
+  const workflowEntry = workflow ? workflowEntries.find(ws => ws.workflow === workflow) : undefined;
+  const workflowSource = workflowEntry?.source;
 
   if (!workflow) {
     // Check if the requested workflow had a load error
@@ -888,6 +912,13 @@ export async function workflowRunCommand(
       `Workflow '${workflowName}' not found.\n\nAvailable workflows:\n${availableWorkflows}`
     );
   }
+
+  // Keys this workflow's YAML declares that the engine drops (#2213). Written to
+  // stderr, never stdout: in --json mode Pino is silenced and stdout must stay
+  // exactly the machine-readable payload, so this is the ONLY channel that
+  // reaches an agent driving runs through `--json`. Not gated on --quiet — a
+  // dropped key can be a gate the author believes is protecting the run.
+  emitParseWarnings(workflowEntry?.parseWarnings, workflow.name);
 
   // Validate mutually exclusive flags (defensive — cli.ts checks these for UX, but
   // workflowRunCommand is the authoritative boundary for programmatic callers)

--- a/packages/core/src/handlers/command-handler.test.ts
+++ b/packages/core/src/handlers/command-handler.test.ts
@@ -1435,6 +1435,45 @@ describe('CommandHandler', () => {
         expect(result.workflow?.definition.name).toBe('assist');
       });
 
+      // #2213 — the run path, not just `/workflow list`. Chat and the console
+      // both start runs through here; discarding parseWarnings meant the author
+      // saw a warning while browsing and silence at the moment of consequence.
+      test('should carry parse warnings on the run result', async () => {
+        spyDiscoverWorkflows.mockResolvedValueOnce({
+          workflows: [
+            makeTestWorkflowWithSource({ name: 'clean' }),
+            makeTestWorkflowWithSource({ name: 'gated' }, 'project', [
+              "Node 'plan': unknown key 'interactive' will be ignored.",
+            ]),
+          ],
+          errors: [],
+        });
+
+        const result = await handleCommand(conversationWithCodebase, '/workflow run gated');
+
+        expect(result.success).toBe(true);
+        expect(result.workflow?.definition.name).toBe('gated');
+        expect(result.workflow?.parseWarnings).toEqual([
+          "Node 'plan': unknown key 'interactive' will be ignored.",
+        ]);
+      });
+
+      test('should omit parse warnings for a clean workflow', async () => {
+        spyDiscoverWorkflows.mockResolvedValueOnce({
+          workflows: [
+            makeTestWorkflowWithSource({ name: 'clean' }),
+            // A DIFFERENT workflow's warnings must not attach to this run.
+            makeTestWorkflowWithSource({ name: 'gated' }, 'project', ["dropped 'interactive'"]),
+          ],
+          errors: [],
+        });
+
+        const result = await handleCommand(conversationWithCodebase, '/workflow run clean');
+
+        expect(result.success).toBe(true);
+        expect(result.workflow?.parseWarnings).toBeUndefined();
+      });
+
       test('should match workflow name via suffix match', async () => {
         spyDiscoverWorkflows.mockResolvedValueOnce({
           workflows: [

--- a/packages/core/src/handlers/command-handler.test.ts
+++ b/packages/core/src/handlers/command-handler.test.ts
@@ -1296,6 +1296,32 @@ describe('CommandHandler', () => {
         // Verify loadConfig function is passed as the second argument
         expect(spyDiscoverWorkflows).toHaveBeenCalledWith(expect.any(String), expect.any(Function));
       });
+
+      // #2213 — chat is the surface most non-CLI authors use; a silently
+      // dropped key (e.g. an `interactive:` they believe is a gate) has to
+      // reach the conversation, not only `archon validate workflows`.
+      test('should show parse warnings inline with the workflow that raised them', async () => {
+        spyDiscoverWorkflows.mockResolvedValueOnce({
+          workflows: [
+            makeTestWorkflowWithSource({ name: 'clean' }),
+            makeTestWorkflowWithSource({ name: 'gated' }, 'project', [
+              "Node 'plan': unknown key 'interactive' will be ignored.",
+            ]),
+          ],
+          errors: [],
+        });
+
+        const result = await handleCommand(conversationWithCodebase, '/workflow list');
+
+        expect(result.success).toBe(true);
+        expect(result.message).toContain("unknown key 'interactive' will be ignored");
+        // Rendered under `gated`, not under `clean` — the author must be able to
+        // tell which workflow is affected without cross-referencing.
+        const gatedIdx = result.message.indexOf('`gated`');
+        const warningIdx = result.message.indexOf("unknown key 'interactive'");
+        expect(gatedIdx).toBeGreaterThan(-1);
+        expect(warningIdx).toBeGreaterThan(gatedIdx);
+      });
     });
 
     describe('/workflow reload', () => {

--- a/packages/core/src/handlers/command-handler.ts
+++ b/packages/core/src/handlers/command-handler.ts
@@ -999,6 +999,11 @@ async function handleWorkflowCommand(
 
       getLog().info({ workflow: workflow.name, args: workflowArgs }, 'cmd.workflow_starting');
 
+      // Recover the discovery entry the `.map()` above dropped, so the keys the
+      // engine ignores reach the conversation when the run STARTS — not only
+      // when the author happens to browse `/workflow list` (#2213).
+      const resolvedEntry = workflowEntries.find(ws => ws.workflow === workflow);
+
       // Return special result that triggers workflow execution in orchestrator
       return {
         success: true,
@@ -1007,6 +1012,9 @@ async function handleWorkflowCommand(
           definition: workflow,
           args: workflowArgs,
           force: force ? true : undefined,
+          ...(resolvedEntry?.parseWarnings && resolvedEntry.parseWarnings.length > 0
+            ? { parseWarnings: resolvedEntry.parseWarnings }
+            : {}),
         },
       };
     }

--- a/packages/core/src/handlers/command-handler.ts
+++ b/packages/core/src/handlers/command-handler.ts
@@ -637,9 +637,16 @@ async function handleWorkflowCommand(
 
       if (workflowEntries.length > 0) {
         msg += 'Available Workflows:\n\n';
-        for (const { workflow: w } of workflowEntries) {
+        for (const { workflow: w, parseWarnings } of workflowEntries) {
           const modeInfo = `DAG: ${String(w.nodes.length)} nodes`;
-          msg += `**\`${w.name}\`**\n  ${w.description}\n  ${modeInfo}\n\n`;
+          msg += `**\`${w.name}\`**\n  ${w.description}\n  ${modeInfo}\n`;
+          // Keys the engine silently drops (#2213). Rendered inline with the
+          // workflow rather than in a trailer so the author sees which of their
+          // workflows is affected without cross-referencing.
+          for (const warning of parseWarnings ?? []) {
+            msg += `  ⚠️ ${warning}\n`;
+          }
+          msg += '\n';
         }
       }
 

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -2336,9 +2336,15 @@ describe('handleWorkflowRunCommand — E2 single codebase auto-select', () => {
       })
     );
     mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+    // This branch re-resolves against the project's own discovery and uses that
+    // entry's warnings (see the shadowing test below), so they belong here too.
     mockDiscoverWorkflowsWithConfig.mockReturnValueOnce(
       Promise.resolve({
-        workflows: [makeTestWorkflowWithSource({ name: 'assist' })],
+        workflows: [
+          makeTestWorkflowWithSource({ name: 'assist' }, 'project', [
+            "Node 'plan': unknown key 'interactive' will be ignored.",
+          ]),
+        ],
         errors: [],
       })
     );
@@ -2352,6 +2358,48 @@ describe('handleWorkflowRunCommand — E2 single codebase auto-select', () => {
     );
     // The warning must not replace the run — it precedes it.
     expect(mockDispatchBackgroundWorkflow).toHaveBeenCalled();
+  });
+
+  // This branch re-resolves the workflow against the single project's own
+  // discovery, so the entry it lands on can differ from the one the caller
+  // resolved. The warnings sent must describe the workflow that will run.
+  test('prefers the re-resolved workflow’s warnings over the caller’s', async () => {
+    const conversation = makeConversation({ codebase_id: null });
+    const codebase = makeCodebaseForSync();
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+    mockParseCommand.mockReturnValueOnce({ command: 'workflow', args: ['run', 'assist'] });
+    mockHandleCommand.mockReturnValueOnce(
+      Promise.resolve({
+        success: true,
+        message: 'Running workflow assist...',
+        workflow: {
+          definition: assistWorkflow,
+          args: 'test prompt',
+          // Resolved against a different scope — must NOT be forwarded.
+          parseWarnings: ["STALE: from the shadowed global 'assist'"],
+        },
+      })
+    );
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+    mockDiscoverWorkflowsWithConfig.mockReturnValueOnce(
+      Promise.resolve({
+        workflows: [
+          makeTestWorkflowWithSource({ name: 'assist' }, 'project', [
+            "FRESH: Node 'plan': unknown key 'interactive' will be ignored.",
+          ]),
+        ],
+        errors: [],
+      })
+    );
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/workflow run assist test prompt');
+
+    expect(platform.sendMessage).toHaveBeenCalledWith('conv-1', expect.stringContaining('FRESH:'));
+    expect(platform.sendMessage).not.toHaveBeenCalledWith(
+      'conv-1',
+      expect.stringContaining('STALE:')
+    );
   });
 
   test('sends no parse-warning message for a clean workflow', async () => {

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -2402,6 +2402,57 @@ describe('handleWorkflowRunCommand — E2 single codebase auto-select', () => {
     );
   });
 
+  // The contract behind persisting warnings on the run: a failed chat delivery
+  // must not take the record with it. If this ever regresses, a Slack hiccup at
+  // dispatch reproduces #2213 exactly — a dropped `interactive:` gate with
+  // nothing anywhere to show for it.
+  test('still hands warnings to the executor when sendMessage throws', async () => {
+    const conversation = makeConversation({ codebase_id: null });
+    const codebase = makeCodebaseForSync();
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+    mockParseCommand.mockReturnValueOnce({ command: 'workflow', args: ['run', 'assist'] });
+    mockHandleCommand.mockReturnValueOnce(
+      Promise.resolve({
+        success: true,
+        message: 'Running workflow assist...',
+        workflow: { definition: assistWorkflow, args: 'test prompt' },
+      })
+    );
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+    mockDiscoverWorkflowsWithConfig.mockReturnValueOnce(
+      Promise.resolve({
+        workflows: [
+          makeTestWorkflowWithSource({ name: 'assist' }, 'project', [
+            "Node 'plan': unknown key 'interactive' will be ignored.",
+          ]),
+        ],
+        errors: [],
+      })
+    );
+
+    const platform = makePlatform();
+    // Fail ONLY the warning delivery — a rate limit or over-length message on
+    // that one call. Failing every send instead would throw out of an unrelated,
+    // pre-existing `sendMessage` earlier in the turn and never reach this code.
+    (platform.sendMessage as ReturnType<typeof mock>).mockImplementation(
+      (_id: string, text: string) =>
+        text.includes('declares keys the engine ignores')
+          ? Promise.reject(new Error('rate limited'))
+          : Promise.resolve()
+    );
+
+    // Must not throw: an undeliverable warning cannot fail the run.
+    await handleMessage(platform, 'conv-1', '/workflow run assist test prompt');
+
+    // The run still started, and it carries the warnings — so the executor
+    // records them as a `workflow_parse_warnings` event regardless of delivery.
+    expect(mockDispatchBackgroundWorkflow).toHaveBeenCalled();
+    const ctx = (mockDispatchBackgroundWorkflow as ReturnType<typeof mock>).mock.calls[0][0] as {
+      parseWarnings?: readonly string[];
+    };
+    expect(ctx.parseWarnings).toEqual(["Node 'plan': unknown key 'interactive' will be ignored."]);
+  });
+
   test('sends no parse-warning message for a clean workflow', async () => {
     const conversation = makeConversation({ codebase_id: null });
     const codebase = makeCodebaseForSync();

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -2315,6 +2315,75 @@ describe('handleWorkflowRunCommand — E2 single codebase auto-select', () => {
     expect(mockDispatchBackgroundWorkflow).toHaveBeenCalled();
   });
 
+  // #2213 — every chat and console run funnels through
+  // dispatchOrchestratorWorkflow, so this is the one place that covers them
+  // all. The console's Start button synthesizes `/workflow run <name>` into
+  // exactly this path, which is why a picker badge alone was not enough.
+  test('mirrors parse warnings into the conversation before the run starts', async () => {
+    const conversation = makeConversation({ codebase_id: null });
+    const codebase = makeCodebaseForSync();
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+    mockParseCommand.mockReturnValueOnce({ command: 'workflow', args: ['run', 'assist'] });
+    mockHandleCommand.mockReturnValueOnce(
+      Promise.resolve({
+        success: true,
+        message: 'Running workflow assist...',
+        workflow: {
+          definition: assistWorkflow,
+          args: 'test prompt',
+          parseWarnings: ["Node 'plan': unknown key 'interactive' will be ignored."],
+        },
+      })
+    );
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+    mockDiscoverWorkflowsWithConfig.mockReturnValueOnce(
+      Promise.resolve({
+        workflows: [makeTestWorkflowWithSource({ name: 'assist' })],
+        errors: [],
+      })
+    );
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/workflow run assist test prompt');
+
+    expect(platform.sendMessage).toHaveBeenCalledWith(
+      'conv-1',
+      expect.stringContaining("unknown key 'interactive' will be ignored")
+    );
+    // The warning must not replace the run — it precedes it.
+    expect(mockDispatchBackgroundWorkflow).toHaveBeenCalled();
+  });
+
+  test('sends no parse-warning message for a clean workflow', async () => {
+    const conversation = makeConversation({ codebase_id: null });
+    const codebase = makeCodebaseForSync();
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+    mockParseCommand.mockReturnValueOnce({ command: 'workflow', args: ['run', 'assist'] });
+    mockHandleCommand.mockReturnValueOnce(
+      Promise.resolve({
+        success: true,
+        message: 'Running workflow assist...',
+        workflow: { definition: assistWorkflow, args: 'test prompt' },
+      })
+    );
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+    mockDiscoverWorkflowsWithConfig.mockReturnValueOnce(
+      Promise.resolve({
+        workflows: [makeTestWorkflowWithSource({ name: 'assist' })],
+        errors: [],
+      })
+    );
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/workflow run assist test prompt');
+
+    expect(platform.sendMessage).not.toHaveBeenCalledWith(
+      'conv-1',
+      expect.stringContaining('declares keys the engine ignores')
+    );
+    expect(mockDispatchBackgroundWorkflow).toHaveBeenCalled();
+  });
+
   test('resolves workflow by case-insensitive name when exact match fails', async () => {
     const upperWorkflow = makeTestWorkflow({ name: 'Assist' });
     const conversation = makeConversation({ codebase_id: null });

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -920,6 +920,7 @@ async function dispatchOrchestratorWorkflow(
           parentConversationId: conversation.id,
           userId,
           source,
+          parseWarnings: options?.parseWarnings,
           baseBranch: codebaseBaseBranch,
           resolveChildIsolation,
           ...prepared,
@@ -943,6 +944,7 @@ async function dispatchOrchestratorWorkflow(
           parentConversationId: conversation.id,
           userId,
           source,
+          parseWarnings: options?.parseWarnings,
           baseBranch: codebaseBaseBranch,
           resolveChildIsolation,
         }
@@ -962,6 +964,7 @@ async function dispatchOrchestratorWorkflow(
         isolationHints,
         userId,
         source,
+        parseWarnings: options?.parseWarnings,
       },
       workflow
     );
@@ -980,6 +983,7 @@ async function dispatchOrchestratorWorkflow(
         parentConversationId: conversation.id,
         userId,
         source,
+        parseWarnings: options?.parseWarnings,
         baseBranch: codebaseBaseBranch,
         resolveChildIsolation,
       }

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -2819,7 +2819,12 @@ async function handleWorkflowRunCommand(
       isolationHints,
       userId,
       resolvedEntry?.source,
-      { ...options, parseWarnings: options?.parseWarnings ?? resolvedEntry?.parseWarnings }
+      // Warnings must describe the workflow that will EXECUTE. This branch
+      // RE-RESOLVES the workflow against the single project's discovery, which
+      // can land on a different file than the caller resolved (a project
+      // workflow shadowing a same-named global one). Inheriting the caller's
+      // warnings would then describe a workflow that is not running.
+      { ...options, parseWarnings: resolvedEntry?.parseWarnings }
     );
     return;
   }

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -611,6 +611,13 @@ interface WorkflowDispatchOptions {
   force?: boolean;
   resumeRunId?: string;
   resumeRun?: WorkflowRun;
+  /**
+   * Keys the engine dropped from the workflow's YAML (#2213). Mirrored into the
+   * conversation before the run starts — chat and the console are where most
+   * runs are STARTED, so a warning that only reaches the CLI misses the moment
+   * of consequence. Omitted on resume: the warning fired when the run began.
+   */
+  parseWarnings?: readonly string[];
 }
 
 const FAILED_RUN_PROMPT_PREVIEW_MAX = 160;
@@ -738,6 +745,26 @@ async function dispatchOrchestratorWorkflow(
         return;
       }
       throw err;
+    }
+  }
+
+  // Keys the engine dropped from this workflow's YAML (#2213). Every chat and
+  // console run funnels through here, so this is the one place that covers all
+  // of them. Sent before the run starts and independently of the run's own
+  // output, so it lands even when the workflow immediately backgrounds itself.
+  // Best-effort: a delivery failure must not stop the run the user asked for.
+  if (options?.parseWarnings && options.parseWarnings.length > 0) {
+    const lines = options.parseWarnings.map(w => `- ${w}`).join('\n');
+    try {
+      await platform.sendMessage(
+        conversationId,
+        `⚠️ \`${workflow.name}\` declares keys the engine ignores:\n${lines}`
+      );
+    } catch (error) {
+      getLog().warn(
+        { err: toError(error), conversationId, workflowName: workflow.name },
+        'workflow.parse_warning_delivery_failed'
+      );
     }
   }
 
@@ -1352,6 +1379,7 @@ export async function handleMessage(
               force: result.workflow.force,
               resumeRunId: result.workflow.resumeRunId,
               resumeRun: result.workflow.resumeRun,
+              parseWarnings: result.workflow.parseWarnings,
             }
           );
         }
@@ -1736,7 +1764,7 @@ export async function handleMessage(
         conversationId,
         message,
         codebases,
-        workflows,
+        workflowsWithSource,
         aiClient,
         fullPrompt,
         cwd,
@@ -1753,7 +1781,7 @@ export async function handleMessage(
         conversationId,
         message,
         codebases,
-        workflows,
+        workflowsWithSource,
         aiClient,
         fullPrompt,
         cwd,
@@ -1806,7 +1834,7 @@ async function handleStreamMode(
   conversationId: string,
   originalMessage: string,
   codebases: readonly Codebase[],
-  workflows: readonly WorkflowDefinition[],
+  workflows: readonly WorkflowWithSource[],
   aiClient: ReturnType<typeof getAgentProvider>,
   fullPrompt: string,
   cwd: string,
@@ -1954,7 +1982,11 @@ async function handleStreamMode(
   }
 
   const fullResponse = allMessages.join('');
-  const commands = parseOrchestratorCommands(fullResponse, codebases, workflows);
+  const commands = parseOrchestratorCommands(
+    fullResponse,
+    codebases,
+    workflows.map(ws => ws.workflow)
+  );
 
   if (commands.workflowInvocation) {
     // Retract streamed text — workflow dispatch replaces it
@@ -2032,7 +2064,7 @@ async function handleBatchMode(
   conversationId: string,
   originalMessage: string,
   codebases: readonly Codebase[],
-  workflows: readonly WorkflowDefinition[],
+  workflows: readonly WorkflowWithSource[],
   aiClient: ReturnType<typeof getAgentProvider>,
   fullPrompt: string,
   cwd: string,
@@ -2212,7 +2244,11 @@ async function handleBatchMode(
   // separator lines that break multi-chunk command text (name and path appear on
   // separate lines from '/register-project'). Raw join preserves the command as a
   // contiguous string. User-visible output still comes from filterToolIndicators.
-  const commands = parseOrchestratorCommands(assistantMessages.join(''), codebases, workflows);
+  const commands = parseOrchestratorCommands(
+    assistantMessages.join(''),
+    codebases,
+    workflows.map(ws => ws.workflow)
+  );
 
   if (commands.workflowInvocation) {
     if (platform.emitRetract) {
@@ -2309,7 +2345,7 @@ async function handleWorkflowInvocationResult(
   conversationId: string,
   conversation: Conversation,
   codebases: readonly Codebase[],
-  workflows: readonly WorkflowDefinition[],
+  workflows: readonly WorkflowWithSource[],
   invocation: WorkflowInvocation,
   originalMessage: string,
   isolationHints: HandleMessageContext['isolationHints'],
@@ -2325,7 +2361,13 @@ async function handleWorkflowInvocationResult(
 
   // Find the codebase and workflow (supports partial name matching)
   const codebase = findCodebaseByName(codebases, projectName);
-  const workflow = findWorkflow(workflowName, [...workflows]);
+  // Keep the discovery ENTRY, not just the definition: it carries the parse
+  // warnings this path used to discard (#2213).
+  const workflowEntry = workflows.find(ws => ws.workflow.name === workflowName);
+  const workflow = findWorkflow(
+    workflowName,
+    workflows.map(ws => ws.workflow)
+  );
 
   if (codebase && workflow) {
     const workflowPrompt = invocation.synthesizedPrompt ?? originalMessage;
@@ -2347,7 +2389,9 @@ async function handleWorkflowInvocationResult(
       workflow,
       workflowPrompt,
       isolationHints,
-      userId
+      userId,
+      workflowEntry?.source,
+      { parseWarnings: workflowEntry?.parseWarnings }
     );
     return;
   }
@@ -2775,7 +2819,7 @@ async function handleWorkflowRunCommand(
       isolationHints,
       userId,
       resolvedEntry?.source,
-      options
+      { ...options, parseWarnings: options?.parseWarnings ?? resolvedEntry?.parseWarnings }
     );
     return;
   }

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -615,7 +615,16 @@ interface WorkflowDispatchOptions {
    * Keys the engine dropped from the workflow's YAML (#2213). Mirrored into the
    * conversation before the run starts — chat and the console are where most
    * runs are STARTED, so a warning that only reaches the CLI misses the moment
-   * of consequence. Omitted on resume: the warning fired when the run began.
+   * of consequence.
+   *
+   * Deliberately unset on every resume path: delivery happens at most ONCE, at
+   * the run's original chat/console start. That is not the same as "the warning
+   * already fired" — delivery lives only in `dispatchOrchestratorWorkflow`, so a
+   * run started by `archon workflow run` (which warns on stderr instead) and
+   * later resumed with `/workflow resume` in chat never produced a chat warning,
+   * and neither did any run predating this feature. Resuming does not re-derive
+   * one; the author's durable surfaces are `validate`, `list` and the console
+   * picker.
    */
   parseWarnings?: readonly string[];
 }

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -284,6 +284,12 @@ export interface WorkflowRoutingContext {
    * to the privacy-safe "custom" treatment when not provided.
    */
   readonly source?: WorkflowSource;
+  /**
+   * Keys the engine dropped from the workflow's YAML (#2213). Forwarded to the
+   * executor so a background (web/console) run records them on the run like any
+   * other, independently of the chat notification.
+   */
+  readonly parseWarnings?: readonly string[];
 }
 
 /**
@@ -456,6 +462,7 @@ export async function dispatchBackgroundWorkflow(
             preCreatedRun,
             userId: ctx.userId,
             source: ctx.source,
+            parseWarnings: ctx.parseWarnings,
             baseBranch: codebaseBaseBranch,
             resolveChildIsolation,
           }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -67,6 +67,8 @@ export interface CommandResult {
     force?: boolean;
     resumeRunId?: string;
     resumeRun?: WorkflowRun;
+    /** Keys the engine dropped from this workflow's YAML (#2213). */
+    parseWarnings?: readonly string[];
   };
 }
 

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -1504,7 +1504,7 @@ This checks resource resolution beyond what load-time validation covers. Bundled
 
 A key Archon does not recognise is dropped from the parsed workflow — the YAML still loads and the workflow still runs. Because a dropped key can be one an author believed was doing something (the classic case is `interactive: true` on a command node, which reads like a human gate and is not one), Archon reports every dropped key as a **warning** naming the key, where it was found, and what to write instead:
 
-```
+```text
 WARNING [unknown_key] Node 'plan': unknown key 'interactive' will be ignored.
   Nothing on this node gates. For a human gate, use an 'approval:' node; to gate
   each iteration of a loop, set BOTH 'loop.interactive: true' and

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -1500,6 +1500,22 @@ archon validate workflows <name>
 
 This checks resource resolution beyond what load-time validation covers. Bundled and global workflows also reject `@custom` model aliases because those refs are not portable across projects. Use `--json` for machine-readable output. See the [CLI Reference](/reference/cli/) for details.
 
+### Unknown Keys Are Reported, Not Rejected
+
+A key Archon does not recognise is dropped from the parsed workflow — the YAML still loads and the workflow still runs. Because a dropped key can be one an author believed was doing something (the classic case is `interactive: true` on a command node, which reads like a human gate and is not one), Archon reports every dropped key as a **warning** naming the key, where it was found, and what to write instead:
+
+```
+WARNING [unknown_key] Node 'plan': unknown key 'interactive' will be ignored.
+  Nothing on this node gates. For a human gate, use an 'approval:' node; to gate
+  each iteration of a loop, set BOTH 'loop.interactive: true' and
+  'loop.gate_message' ('gate_message' on its own does not gate). Workflow-level
+  'interactive:' is a different setting — it forces foreground execution.
+```
+
+Detection covers the workflow root, every node, the nested config blocks (`approval:`, `approval.on_reject:`, `retry:`, `loop:`, `loop_group:`, `pi:`, each `agents:` entry, `worktree:`, `container:`, `evidence_policy:`), and every node inside a `loop_group` body. Free-form blocks are exempt because nothing is dropped from them: `output_format:` accepts any JSON Schema, `sandbox:` preserves unknown keys, and `hooks:` rejects them outright as an error.
+
+The warnings appear in `archon validate workflows`, `archon workflow list` (and its `--json` `parseWarnings` field), before an `archon workflow run` starts (on stderr, so `--json` stdout stays parseable), in `/workflow list` in chat, and on the workflow picker in the console.
+
 ### Example: Config Defaults + Workflow Override
 
 **`.archon/config.yaml`:**

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -1533,10 +1533,24 @@ WARNING [unknown_key] Node 'plan': unknown key 'interactive' will be ignored.
 |---|---|
 | `archon validate workflows` | A `WARNING [unknown_key]` issue (also in `--json`) |
 | `archon workflow list` | Inline under the workflow; `parseWarnings` on each `--json` entry |
-| `archon workflow run` | On **stderr** before the run starts, so `--json` stdout stays parseable |
+| `archon workflow run` | On **stderr** before the run starts (`--detach --json` keeps stdout to the payload) |
 | Chat (`/workflow list`) | Inline with the workflow that raised it |
-| Chat / console (starting a run) | Posted to the conversation before the run begins |
+| Chat / console (starting a run) | Posted to the conversation before the run begins — **best-effort**, see below |
 | Console workflow picker | A ⚠ marker on the row; full text in the tooltip |
+
+**Known gap — delivery when a run starts is best-effort.** The message posted at the
+start of a chat or console run is sent once and not retried: if the platform call
+fails (a revoked bot token, a rate limit, an API hiccup) the run still starts and
+that particular notification is lost, leaving only a `WARN` log line. Failing the
+run over an undeliverable warning would be worse, so the send is deliberately
+non-fatal.
+
+The warning itself is **not** lost — it is recomputed from the YAML on every
+discovery and is not stored anywhere. It is still waiting on `archon validate
+workflows`, `archon workflow list`, `/workflow list` in chat, and the console
+picker. What a failed send costs is the prompt at the moment of consequence, not
+the finding. Treat the run-start message as a convenience and those surfaces as
+the source of truth.
 
 **Known gap — `include:`.** Warnings belong to the file that declared the key. If workflow A `include:`s workflow B and B has an unknown key, the warning is reported against **B**, not against A. Running A surfaces nothing. Check the included block directly (`archon validate workflows <block-name>`) when auditing a composed workflow.
 

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -1509,12 +1509,36 @@ WARNING [unknown_key] Node 'plan': unknown key 'interactive' will be ignored.
   Nothing on this node gates. For a human gate, use an 'approval:' node; to gate
   each iteration of a loop, set BOTH 'loop.interactive: true' and
   'loop.gate_message' ('gate_message' on its own does not gate). Workflow-level
-  'interactive:' is a different setting — it forces foreground execution.
+  'interactive:' is a different setting, and only on the web UI — it keeps the
+  run in the foreground there; chat platforms already run in the foreground, so
+  it does nothing for them.
 ```
 
-Detection covers the workflow root, every node, the nested config blocks (`approval:`, `approval.on_reject:`, `retry:`, `loop:`, `loop_group:`, `pi:`, each `agents:` entry, `worktree:`, `container:`, `evidence_policy:`), and every node inside a `loop_group` body. Free-form blocks are exempt because nothing is dropped from them: `output_format:` accepts any JSON Schema, `sandbox:` preserves unknown keys, and `hooks:` rejects them outright as an error.
+(The `WARNING [unknown_key]` prefix is `archon validate workflows` formatting; the other surfaces below render the same message text differently.)
 
-The warnings appear in `archon validate workflows`, `archon workflow list` (and its `--json` `parseWarnings` field), before an `archon workflow run` starts (on stderr, so `--json` stdout stays parseable), in `/workflow list` in chat, and on the workflow picker in the console.
+**What is checked.** The workflow root, every node, the nested config blocks (`approval:`, `approval.on_reject:`, `retry:`, `loop:`, `loop_group:`, `pi:`, each `agents:` entry, `worktree:`, `container:`, `evidence_policy:`), and every node inside a `loop_group` body.
+
+**What is exempt**, because nothing is dropped from these — a key you write is a key that survives:
+
+| Block | Why exempt |
+|---|---|
+| `output_format:` | Free-form JSON Schema; every key is accepted |
+| `sandbox:` | Passthrough — unknown keys are preserved, not stripped |
+| `thinking:` | A preprocessed union, not an object shape |
+| `hooks:` | Strict — an unknown key is already a hard **error**, not a warning |
+
+**Where the warnings appear.**
+
+| Surface | Where |
+|---|---|
+| `archon validate workflows` | A `WARNING [unknown_key]` issue (also in `--json`) |
+| `archon workflow list` | Inline under the workflow; `parseWarnings` on each `--json` entry |
+| `archon workflow run` | On **stderr** before the run starts, so `--json` stdout stays parseable |
+| Chat (`/workflow list`) | Inline with the workflow that raised it |
+| Chat / console (starting a run) | Posted to the conversation before the run begins |
+| Console workflow picker | A ⚠ marker on the row; full text in the tooltip |
+
+**Known gap — `include:`.** Warnings belong to the file that declared the key. If workflow A `include:`s workflow B and B has an unknown key, the warning is reported against **B**, not against A. Running A surfaces nothing. Check the included block directly (`archon validate workflows <block-name>`) when auditing a composed workflow.
 
 ### Example: Config Defaults + Workflow Override
 

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -1535,22 +1535,30 @@ WARNING [unknown_key] Node 'plan': unknown key 'interactive' will be ignored.
 | `archon workflow list` | Inline under the workflow; `parseWarnings` on each `--json` entry |
 | `archon workflow run` | On **stderr** before the run starts (`--detach --json` keeps stdout to the payload) |
 | Chat (`/workflow list`) | Inline with the workflow that raised it |
-| Chat / console (starting a run) | Posted to the conversation before the run begins — **best-effort**, see below |
+| Any run that starts | **Recorded on the run** as a `workflow_parse_warnings` event — always |
+| Chat / console (starting a run) | Also posted to the conversation, best-effort |
 | Console workflow picker | A ⚠ marker on the row; full text in the tooltip |
 
-**Known gap — delivery when a run starts is best-effort.** The message posted at the
-start of a chat or console run is sent once and not retried: if the platform call
-fails (a revoked bot token, a rate limit, an API hiccup) the run still starts and
-that particular notification is lost, leaving only a `WARN` log line. Failing the
-run over an undeliverable warning would be worse, so the send is deliberately
-non-fatal.
+**Recorded on the run, whatever started it.** When a run begins, the engine writes
+the dropped keys to the run's event log as `workflow_parse_warnings`. This happens
+for every run — CLI, chat, console, REST, and sub-runs — not only the ones with a
+conversation to post into, and it is written by the engine rather than by the
+notification path, so a failed message cannot take the record with it. Read it back
+with:
 
-The warning itself is **not** lost — it is recomputed from the YAML on every
-discovery and is not stored anywhere. It is still waiting on `archon validate
-workflows`, `archon workflow list`, `/workflow list` in chat, and the console
-picker. What a failed send costs is the prompt at the moment of consequence, not
-the finding. Treat the run-start message as a convenience and those surfaces as
-the source of truth.
+```bash
+archon workflow get <run-id> --verbose          # human-readable
+archon workflow get <run-id> --verbose --json   # `parseWarnings` on the payload
+```
+
+(`--verbose` is required: the plain form returns the run row without reading the
+event log.)
+
+The chat/console message at run start is a **notification on top of that record**.
+It is sent once and not retried: if the platform call fails (a revoked token, a rate
+limit) the run still starts and that message is lost, leaving a `WARN` log line —
+failing a run over an undeliverable warning would be worse. The finding is not lost
+with it; it is on the run, and still on `validate`, `list`, and the console picker.
 
 **Known gap — `include:`.** Warnings belong to the file that declared the key. If workflow A `include:`s workflow B and B has an unknown key, the warning is reported against **B**, not against A. Running A surfaces nothing. Check the included block directly (`archon validate workflows <block-name>`) when auditing a composed workflow.
 

--- a/packages/docs-web/src/content/docs/reference/api.md
+++ b/packages/docs-web/src/content/docs/reference/api.md
@@ -206,7 +206,11 @@ Query parameters:
 
 When `cwd` is omitted, Archon returns bundled default workflows and any from `~/.archon/workflows/` (home-scoped). Project-specific workflows require either the `cwd` query param or a registered codebase, so the endpoint is useful on first launch before any project is registered.
 
-Returns `{ workflows: [...], errors?: [...] }`. The `errors` array contains any YAML parsing failures encountered during discovery.
+Returns `{ workflows: [...], recommended: [...], errors?: [...] }`.
+
+- `workflows[]` — each entry is `{ workflow, source, parseWarnings? }`. `parseWarnings` lists keys the engine silently dropped from that workflow's YAML (see [Unknown keys](/guides/authoring-workflows/#unknown-keys-are-reported-not-rejected)); it is **omitted entirely** when the workflow is clean, so its presence alone is the signal.
+- `recommended[]` — repo-owner-curated workflow names from `.archon/config.yaml`, filtered to discovered names and kept in declared order. Empty when there is no project context.
+- `errors[]` — YAML parsing failures encountered during discovery. Unlike `parseWarnings`, these workflows did **not** load.
 
 #### Get a Workflow
 

--- a/packages/docs-web/src/content/docs/reference/api.md
+++ b/packages/docs-web/src/content/docs/reference/api.md
@@ -208,7 +208,7 @@ When `cwd` is omitted, Archon returns bundled default workflows and any from `~/
 
 Returns `{ workflows: [...], recommended: [...], errors?: [...] }`.
 
-- `workflows[]` — each entry is `{ workflow, source, parseWarnings? }`. `parseWarnings` lists keys the engine silently dropped from that workflow's YAML (see [Unknown keys](/guides/authoring-workflows/#unknown-keys-are-reported-not-rejected)); it is **omitted entirely** when the workflow is clean, so its presence alone is the signal.
+- `workflows[]` — each entry is `{ workflow, source, parseWarnings? }`. `parseWarnings` contains warning messages identifying the keys the engine silently dropped from that workflow's YAML, each with the node it was found on and what to write instead (see [Unknown keys](/guides/authoring-workflows/#unknown-keys-are-reported-not-rejected)); it is **omitted entirely** when the workflow is clean, so its presence alone is the signal.
 - `recommended[]` — repo-owner-curated workflow names from `.archon/config.yaml`, filtered to discovered names and kept in declared order. Empty when there is no project context.
 - `errors[]` — YAML parsing failures encountered during discovery. Unlike `parseWarnings`, these workflows did **not** load.
 

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -200,7 +200,9 @@ archon workflow run plan --cwd /path/to/repo --branch feature-x "Add caching"
 
 Progress events (node start/complete/fail/skip, approval gates) are written to stderr during execution.
 
-If the workflow's YAML declares keys the engine ignores, a warning naming each one is written to **stderr before the run starts**. This matters to `--json` callers: `--json` silences all logging, so stderr is the only channel that carries it, and stdout stays exactly the machine-readable payload. See [Unknown keys](/guides/authoring-workflows/#unknown-keys-are-reported-not-rejected).
+If the workflow's YAML declares keys the engine ignores, a warning naming each one is written to **stderr before the run starts**. This matters to `--detach --json` callers: `--json` silences all logging, so stderr is the only channel left, and it keeps stdout to exactly the JSON payload.
+
+Note that `run` emits a JSON payload **only** under `--detach`. Without it, `--json` suppresses logs but the command still prints human progress to stdout (`Running workflow: …`), so do not pipe plain `run --json` into a parser. See [Unknown keys](/guides/authoring-workflows/#unknown-keys-are-reported-not-rejected).
 
 **Flags:**
 

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -184,7 +184,7 @@ Discovers workflows from `.archon/workflows/` (recursive), `~/.archon/workflows/
 | `--cwd <path>` | Target directory (required for most use cases) |
 | `--json` | Output machine-readable JSON instead of formatted text |
 
-With `--json`, outputs `{ "workflows": [...], "errors": [...] }`. Optional fields (`provider`, `model`, `modelReasoningEffort`, `webSearchMode`, `parseWarnings`) are omitted when not set on a workflow. `parseWarnings` lists keys the engine dropped from that workflow's YAML — see [Unknown keys](/guides/authoring-workflows/#unknown-keys-are-reported-not-rejected).
+With `--json`, outputs `{ "workflows": [...], "errors": [...] }`. Optional fields (`provider`, `model`, `modelReasoningEffort`, `webSearchMode`, `parseWarnings`) are omitted when not set on a workflow. Each `parseWarnings` entry is a full warning message naming a key the engine dropped, the node it was found on, and what to write instead — see [Unknown keys](/guides/authoring-workflows/#unknown-keys-are-reported-not-rejected).
 
 ### `workflow run <name> [message]`
 

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -184,7 +184,7 @@ Discovers workflows from `.archon/workflows/` (recursive), `~/.archon/workflows/
 | `--cwd <path>` | Target directory (required for most use cases) |
 | `--json` | Output machine-readable JSON instead of formatted text |
 
-With `--json`, outputs `{ "workflows": [...], "errors": [...] }`. Optional fields (`provider`, `model`, `modelReasoningEffort`, `webSearchMode`) are omitted when not set on a workflow.
+With `--json`, outputs `{ "workflows": [...], "errors": [...] }`. Optional fields (`provider`, `model`, `modelReasoningEffort`, `webSearchMode`, `parseWarnings`) are omitted when not set on a workflow. `parseWarnings` lists keys the engine dropped from that workflow's YAML — see [Unknown keys](/guides/authoring-workflows/#unknown-keys-are-reported-not-rejected).
 
 ### `workflow run <name> [message]`
 
@@ -199,6 +199,8 @@ archon workflow run plan --cwd /path/to/repo --branch feature-x "Add caching"
 ```
 
 Progress events (node start/complete/fail/skip, approval gates) are written to stderr during execution.
+
+If the workflow's YAML declares keys the engine ignores, a warning naming each one is written to **stderr before the run starts**. This matters to `--json` callers: `--json` silences all logging, so stderr is the only channel that carries it, and stdout stays exactly the machine-readable payload. See [Unknown keys](/guides/authoring-workflows/#unknown-keys-are-reported-not-rejected).
 
 **Flags:**
 

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -2966,7 +2966,15 @@ export function registerApiRoutes(
       }
 
       return c.json({
-        workflows: result.workflows.map(ws => ({ workflow: ws.workflow, source: ws.source })),
+        workflows: result.workflows.map(ws => ({
+          workflow: ws.workflow,
+          source: ws.source,
+          // Keys the engine dropped from this YAML (#2213) — the console is the
+          // surface most authors edit workflows on, so it has to carry them.
+          ...(ws.parseWarnings && ws.parseWarnings.length > 0
+            ? { parseWarnings: [...ws.parseWarnings] }
+            : {}),
+        })),
         recommended,
         errors: result.errors.length > 0 ? result.errors : undefined,
       });

--- a/packages/server/src/routes/api.workflows.test.ts
+++ b/packages/server/src/routes/api.workflows.test.ts
@@ -198,6 +198,36 @@ describe('GET /api/workflows', () => {
     const body = (await response.json()) as { recommended: string[] };
     expect(body.recommended).toEqual(['fix', 'plan']);
   });
+
+  // #2213 — discovery records the keys the engine dropped; the console reads
+  // this endpoint, so dropping the field here makes the warning unreachable on
+  // the surface most authors edit workflows on.
+  test('carries parseWarnings through to the response', async () => {
+    const app = createTestApp();
+    registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+    mockDiscoverWorkflows.mockResolvedValueOnce({
+      workflows: [
+        makeTestWorkflowWithSource({ name: 'clean' }, 'project'),
+        makeTestWorkflowWithSource({ name: 'gated' }, 'project', [
+          "Node 'plan': unknown key 'interactive' will be ignored.",
+        ]),
+      ],
+      errors: [],
+    });
+
+    const response = await app.request('/api/workflows');
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      workflows: { workflow: { name: string }; parseWarnings?: string[] }[];
+    };
+    // Absent (not an empty array) on a clean workflow — presence is the signal.
+    expect(body.workflows[0].parseWarnings).toBeUndefined();
+    expect(body.workflows[1].parseWarnings).toEqual([
+      "Node 'plan': unknown key 'interactive' will be ignored.",
+    ]);
+  });
 });
 
 describe('POST /api/workflows/validate', () => {

--- a/packages/server/src/routes/schemas/workflow.schemas.ts
+++ b/packages/server/src/routes/schemas/workflow.schemas.ts
@@ -33,6 +33,12 @@ export const workflowListEntrySchema = z
   .object({
     workflow: workflowDefinitionSchema,
     source: workflowSourceSchema,
+    /**
+     * Non-fatal warnings raised while parsing this workflow's YAML — today, keys
+     * the engine silently drops (#2213). The workflow still loads and runs;
+     * these tell the author what was ignored. Omitted when there are none.
+     */
+    parseWarnings: z.array(z.string()).optional(),
   })
   .openapi('WorkflowListEntry');
 

--- a/packages/web/src/experiments/console/components/WorkflowPicker.tsx
+++ b/packages/web/src/experiments/console/components/WorkflowPicker.tsx
@@ -338,6 +338,15 @@ export function WorkflowPicker({
                               </span>
                             ) : null}
                           </div>
+                          {w.parseWarnings.length > 0 ? (
+                            <span
+                              className="shrink-0 font-mono text-[11px] text-warning"
+                              title={w.parseWarnings.join('\n')}
+                              aria-label={`Ignored keys: ${w.parseWarnings.join('; ')}`}
+                            >
+                              ⚠
+                            </span>
+                          ) : null}
                           <span
                             className={`shrink-0 text-[9px] uppercase tracking-[0.16em] ${sourceBadgeClass(w.source)}`}
                           >

--- a/packages/web/src/experiments/console/components/WorkflowPicker.tsx
+++ b/packages/web/src/experiments/console/components/WorkflowPicker.tsx
@@ -339,7 +339,11 @@ export function WorkflowPicker({
                             ) : null}
                           </div>
                           {w.parseWarnings.length > 0 ? (
+                            // role="img" because a bare <span> has the implicit
+                            // `generic` role, which prohibits an accessible name —
+                            // aria-label on it is dropped by assistive tech.
                             <span
+                              role="img"
                               className="shrink-0 font-mono text-[11px] text-warning"
                               title={w.parseWarnings.join('\n')}
                               aria-label={`Ignored keys: ${w.parseWarnings.join('; ')}`}

--- a/packages/web/src/experiments/console/lib/recommended.test.ts
+++ b/packages/web/src/experiments/console/lib/recommended.test.ts
@@ -3,7 +3,7 @@ import { orderWithRecommended } from './recommended';
 import type { Workflow } from '../primitives/workflow';
 
 function wf(name: string, source: Workflow['source'] = 'bundled'): Workflow {
-  return { name, description: null, source };
+  return { name, description: null, source, parseWarnings: [] };
 }
 
 describe('orderWithRecommended', () => {

--- a/packages/web/src/experiments/console/primitives/event.ts
+++ b/packages/web/src/experiments/console/primitives/event.ts
@@ -325,6 +325,25 @@ export function toRunEvent(raw: RawWorkflowEvent): RunEvent {
     };
   }
 
+  // Keys the engine dropped from this run's YAML (#2213). Mapped explicitly —
+  // the fallback below would render the raw `{"warnings":[…]}` payload. Rendered
+  // as `text`, NOT `system`: system rows sit behind the System toggle (off by
+  // default), and a silently dropped `interactive:` gate is exactly what the
+  // author needs to see without opting in.
+  if (et === 'workflow_parse_warnings') {
+    const warnings = Array.isArray(data.warnings)
+      ? data.warnings.filter((w): w is string => typeof w === 'string')
+      : [];
+    return {
+      ...base,
+      kind: 'text',
+      content:
+        warnings.length > 0
+          ? `⚠️ This workflow declares keys the engine ignores:\n${warnings.map(w => `- ${w}`).join('\n')}`
+          : '⚠️ This workflow declares keys the engine ignores.',
+    };
+  }
+
   // Fallback: render anything else as a text event with the payload summary.
   return {
     ...base,

--- a/packages/web/src/experiments/console/primitives/workflow.test.ts
+++ b/packages/web/src/experiments/console/primitives/workflow.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from 'bun:test';
+import { toWorkflow } from './workflow';
+
+describe('toWorkflow — source normalization', () => {
+  test('keeps the three distinct sources apart', () => {
+    expect(toWorkflow({ workflow: { name: 'a' }, source: 'project' }).source).toBe('project');
+    expect(toWorkflow({ workflow: { name: 'a' }, source: 'global' }).source).toBe('global');
+    expect(toWorkflow({ workflow: { name: 'a' }, source: 'bundled' }).source).toBe('bundled');
+  });
+
+  test('falls back to bundled for an unrecognized source', () => {
+    expect(toWorkflow({ workflow: { name: 'a' }, source: 'something-new' }).source).toBe('bundled');
+  });
+
+  test('normalizes a missing description to null', () => {
+    expect(toWorkflow({ workflow: { name: 'a' }, source: 'project' }).description).toBeNull();
+    expect(
+      toWorkflow({ workflow: { name: 'a', description: 'hi' }, source: 'project' }).description
+    ).toBe('hi');
+  });
+});
+
+describe('toWorkflow — parseWarnings (#2213)', () => {
+  test('carries the warnings through from the API entry', () => {
+    const w = toWorkflow({
+      workflow: { name: 'gated' },
+      source: 'project',
+      parseWarnings: ["Node 'plan': unknown key 'interactive' will be ignored."],
+    });
+    expect(w.parseWarnings).toEqual(["Node 'plan': unknown key 'interactive' will be ignored."]);
+  });
+
+  test('defaults to an empty array when the field is absent', () => {
+    // The API omits the key entirely for a clean workflow, so every consumer
+    // (the picker reads `.length`) needs an array, never undefined.
+    const w = toWorkflow({ workflow: { name: 'clean' }, source: 'project' });
+    expect(w.parseWarnings).toEqual([]);
+  });
+});

--- a/packages/web/src/experiments/console/primitives/workflow.ts
+++ b/packages/web/src/experiments/console/primitives/workflow.ts
@@ -4,6 +4,12 @@ export interface Workflow {
   name: string;
   description: string | null;
   source: WorkflowSource;
+  /**
+   * Keys this workflow's YAML declares that the engine silently drops (#2213).
+   * Empty for a clean workflow. The workflow still loads and runs — this is what
+   * was ignored, which can include a gate the author believed they had.
+   */
+  parseWarnings: string[];
 }
 
 interface RawWorkflowEntry {
@@ -12,6 +18,7 @@ interface RawWorkflowEntry {
     description?: string | null;
   };
   source: string;
+  parseWarnings?: string[];
 }
 
 export function toWorkflow(raw: RawWorkflowEntry): Workflow {
@@ -25,5 +32,6 @@ export function toWorkflow(raw: RawWorkflowEntry): Workflow {
     name: raw.workflow.name,
     description: raw.workflow.description ?? null,
     source: src,
+    parseWarnings: raw.parseWarnings ?? [],
   };
 }

--- a/packages/web/src/lib/api.generated.d.ts
+++ b/packages/web/src/lib/api.generated.d.ts
@@ -3281,6 +3281,7 @@ export interface components {
     WorkflowListEntry: {
       workflow: components['schemas']['WorkflowDefinition'];
       source: components['schemas']['WorkflowSource'];
+      parseWarnings?: string[];
     };
     WorkflowDefinition: {
       name: string;

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -774,6 +774,90 @@ describe('executeWorkflow', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Parse warnings recorded on the run (#2213)
+  // -------------------------------------------------------------------------
+
+  describe('workflow_parse_warnings', () => {
+    it('records the dropped keys on the run at start', async () => {
+      // Recorded HERE rather than at the chat dispatch site so the finding does
+      // not depend on a notification being deliverable — and so CLI- and
+      // REST-started runs, which have no conversation to post into, get it too.
+      const createEventSpy = mock(async () => {});
+      const store = makeStore({ createWorkflowEvent: createEventSpy });
+
+      await executeWorkflow(
+        makeDeps(store),
+        makePlatform(),
+        'conv-1',
+        '/tmp',
+        makeWorkflow(),
+        'test message',
+        'db-conv-1',
+        { parseWarnings: ["Node 'plan': unknown key 'interactive' will be ignored."] }
+      );
+
+      const warnEvent = createEventSpy.mock.calls
+        .map(call => call[0])
+        .find(event => event.event_type === 'workflow_parse_warnings');
+      expect(warnEvent?.data).toEqual({
+        workflowName: 'test-workflow',
+        warnings: ["Node 'plan': unknown key 'interactive' will be ignored."],
+      });
+    });
+
+    it('records nothing for a clean workflow', async () => {
+      const createEventSpy = mock(async () => {});
+      const store = makeStore({ createWorkflowEvent: createEventSpy });
+
+      await executeWorkflow(
+        makeDeps(store),
+        makePlatform(),
+        'conv-1',
+        '/tmp',
+        makeWorkflow(),
+        'test message',
+        'db-conv-1',
+        {}
+      );
+
+      const warnEvent = createEventSpy.mock.calls
+        .map(call => call[0])
+        .find(event => event.event_type === 'workflow_parse_warnings');
+      expect(warnEvent).toBeUndefined();
+    });
+
+    it('records even when the platform cannot be written to', async () => {
+      // The engine's record must not be coupled to platform delivery in any
+      // way — this is the whole reason the event exists rather than relying on
+      // the best-effort chat message.
+      const createEventSpy = mock(async () => {});
+      const store = makeStore({ createWorkflowEvent: createEventSpy });
+      const brokenPlatform = {
+        sendMessage: mock(() => Promise.reject(new Error('platform down'))),
+        getPlatformType: mock(() => 'slack'),
+      } as unknown as IWorkflowPlatform;
+
+      await executeWorkflow(
+        makeDeps(store),
+        brokenPlatform,
+        'conv-1',
+        '/tmp',
+        makeWorkflow(),
+        'test message',
+        'db-conv-1',
+        { parseWarnings: ['dropped a key'] }
+      ).catch(() => {
+        // A broken platform may fail the run downstream; irrelevant here.
+      });
+
+      const warnEvent = createEventSpy.mock.calls
+        .map(call => call[0])
+        .find(event => event.event_type === 'workflow_parse_warnings');
+      expect(warnEvent?.data).toMatchObject({ warnings: ['dropped a key'] });
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // $DOCS_DIR default resolution
   // -------------------------------------------------------------------------
 

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -431,6 +431,15 @@ export type ExecuteWorkflowOptions = ResumePayload & {
    * treatment when a caller doesn't thread it through.
    */
   source?: WorkflowSource;
+  /**
+   * Keys the engine dropped from this workflow's YAML (#2213), as produced by
+   * discovery. Recorded on the run as a `workflow_parse_warnings` event at
+   * start, so the finding survives independently of whether the chat/console
+   * notification could be delivered — and so it exists for CLI- and REST-started
+   * runs, which have no conversation to post into. Optional: a caller that
+   * doesn't thread it through simply records nothing.
+   */
+  parseWarnings?: readonly string[];
   /** Parent conversation ID — enables approve/reject auto-resume from chat. */
   parentConversationId?: string;
   /**
@@ -1029,6 +1038,7 @@ export async function executeWorkflow(
     priorTokenUsage,
     userId,
     source,
+    parseWarnings,
     baseBranch: callerBaseBranch,
     baseOverride: callerBaseOverride,
     execContext = { kind: 'host' },
@@ -1558,6 +1568,31 @@ export async function executeWorkflow(
           'workflow_event_persist_failed'
         );
       });
+
+    // Keys the engine dropped from this run's YAML (#2213). Recorded here rather
+    // than at the chat/console dispatch site for two reasons: every run reaches
+    // this line whatever surface started it (CLI and REST included, which have no
+    // conversation to post into), and the record is therefore written by a path
+    // that a failed `platform.sendMessage` cannot touch. That notification stays
+    // best-effort; this is the durable trace behind it, readable via
+    // `archon workflow get <id> --verbose` and the events API.
+    if (parseWarnings && parseWarnings.length > 0) {
+      deps.store
+        .createWorkflowEvent({
+          workflow_run_id: workflowRun.id,
+          event_type: 'workflow_parse_warnings',
+          data: {
+            workflowName: workflow.name,
+            warnings: [...parseWarnings],
+          },
+        })
+        .catch((err: Error) => {
+          getLog().error(
+            { err, workflowRunId: workflowRun.id, eventType: 'workflow_parse_warnings' },
+            'workflow_event_persist_failed'
+          );
+        });
+    }
 
     // Set status to running now that execution has started (skip for resumed runs — already running)
     if (!dagPriorCompletedNodes) {

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -4616,6 +4616,174 @@ nodes:
       ]);
       expect(pw).toEqual([]);
     });
+
+    it('should not treat a thinking: config as an unknown-key surface', async () => {
+      // `thinking` is a z.preprocess over a union, not an object shape — there
+      // is nothing to compare keys against, so it must stay exempt rather than
+      // warning on its own legitimate fields.
+      const pw = await warningsFor([
+        'name: test',
+        'description: test',
+        'nodes:',
+        '  - id: n',
+        '    prompt: hello',
+        '    thinking:',
+        '      type: enabled',
+        '      budgetTokens: 4096',
+      ]);
+      expect(pw).toEqual([]);
+    });
+  });
+
+  describe('include: warnings stay with the file that declared the key (#2213)', () => {
+    // Pins CURRENT behaviour, which is a known gap documented in the authoring
+    // guide: warnings are keyed by the file they were parsed from, so an
+    // included block's unknown key is reported against the BLOCK, never against
+    // the workflow that includes it. Propagating across the include boundary is
+    // a deliberate follow-up — this test exists so that change is a visible,
+    // intentional edit rather than a silent behaviour shift.
+    it('reports on the included block, not the includer', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+      await writeFile(
+        join(workflowDir, 'block.yaml'),
+        [
+          'name: block',
+          'description: shared block',
+          'nodes:',
+          '  - id: work',
+          '    prompt: do it',
+          '    interactive: true', // dropped, warned — on THIS file
+        ].join('\n')
+      );
+      await writeFile(
+        join(workflowDir, 'parent.yaml'),
+        [
+          'name: parent',
+          'description: includes the block',
+          'nodes:',
+          '  - id: blk',
+          '    include: block',
+        ].join('\n')
+      );
+
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      const byName = new Map(result.workflows.map(w => [w.workflow.name, w]));
+
+      const block = byName.get('block');
+      expect((block?.parseWarnings ?? []).length).toBe(1);
+      expect(block?.parseWarnings?.[0]).toContain("unknown key 'interactive'");
+
+      // The includer inlines the block's NODES but not its warnings.
+      const parent = byName.get('parent');
+      expect(parent).toBeDefined();
+      expect(parent?.parseWarnings ?? []).toEqual([]);
+    });
+  });
+
+  describe('parse warnings survive a filename collision (#2213)', () => {
+    // Discovery keys files by BARE filename, so `foo.yaml` at the root and
+    // `foo.yaml` in a 1-level subfolder (a supported layout) collide, and the
+    // loser is dropped. `readdir()` order decides which one wins, so these
+    // assert the ORDER-INDEPENDENT invariant instead of a fixed winner: the
+    // warnings that survive must describe the workflow that survived. Before
+    // the single-entry refactor the definition and the warnings came from two
+    // parallel maps, and a clean file could inherit the dropped file's warning.
+    const CLEAN = (name: string): string =>
+      ['name: ' + name, 'description: test', 'nodes:', '  - id: a', '    prompt: hi'].join('\n');
+    const DIRTY = (name: string): string =>
+      [
+        'name: ' + name,
+        'description: test',
+        'nodes:',
+        '  - id: a',
+        '    prompt: hi',
+        '    interactive: true',
+      ].join('\n');
+
+    /** Write root/sub `foo.yaml`, discover, and return the single survivor. */
+    const discoverColliding = async (
+      rootYaml: string,
+      subYaml: string
+    ): Promise<{ name: string; warnings: string[] }> => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(join(workflowDir, 'zsub'), { recursive: true });
+      await writeFile(join(workflowDir, 'foo.yaml'), rootYaml);
+      await writeFile(join(workflowDir, 'zsub', 'foo.yaml'), subYaml);
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      // One filename → one surviving entry, whichever side won.
+      expect(result.workflows.length).toBe(1);
+      return {
+        name: result.workflows[0].workflow.name,
+        warnings: [...(result.workflows[0].parseWarnings ?? [])],
+      };
+    };
+
+    it('does not attach the dropped file’s warning to a clean survivor', async () => {
+      const { name, warnings } = await discoverColliding(CLEAN('foo-root'), DIRTY('foo-sub'));
+      if (name === 'foo-root') {
+        expect(warnings).toEqual([]); // the clean file won — it declares no unknown key
+      } else {
+        expect(warnings.length).toBe(1);
+        expect(warnings[0]).toContain("unknown key 'interactive'");
+      }
+    });
+
+    it('does not drop a dirty survivor’s warning when a clean file collides', async () => {
+      const { name, warnings } = await discoverColliding(DIRTY('foo-root'), CLEAN('foo-sub'));
+      if (name === 'foo-root') {
+        expect(warnings.length).toBe(1);
+        expect(warnings[0]).toContain("unknown key 'interactive'");
+      } else {
+        expect(warnings).toEqual([]);
+      }
+    });
+  });
+
+  describe('no false positives on the real workflow corpus (#2213)', () => {
+    /**
+     * The unknown-key check is only useful if a legitimate key never trips it.
+     * Detection reaches into nested config blocks and `loop_group` bodies, so a
+     * schema field that drifts out of a derived key set would start warning on
+     * valid YAML — and a warning nobody can act on is worse than none.
+     *
+     * This runs discovery over Archon's own `.archon/workflows/` (its largest
+     * real corpus) and asserts that nothing OUTSIDE a known-bad allowlist warns.
+     * Deliberately one-directional: the allowlist may shrink freely (fixing
+     * `e2e-opencode-smoke.yaml` must not break this), but a new name appearing
+     * is a false positive and fails.
+     */
+    const KNOWN_BAD = new Set([
+      // `agent:` at workflow and node level — a real bug, silently dropped since
+      // April. Remove from this list when the file is fixed.
+      'e2e-opencode-smoke',
+    ]);
+
+    it('warns only on workflows already known to carry unknown keys', async () => {
+      // packages/workflows/src/ → repo root
+      const repoRoot = join(import.meta.dir, '..', '..', '..');
+      // Point ARCHON_HOME at an empty dir so a developer's own home-scoped
+      // workflows can't leak into the corpus and make this machine-dependent.
+      const emptyHome = join(testDir, 'empty-archon-home');
+      await mkdir(emptyHome, { recursive: true });
+      const savedHome = process.env.ARCHON_HOME;
+      process.env.ARCHON_HOME = emptyHome;
+      try {
+        const result = await discoverWorkflows(repoRoot);
+        // Guard against silently testing nothing if discovery ever stops
+        // finding the repo's workflows.
+        expect(result.workflows.length).toBeGreaterThan(20);
+
+        const warned = result.workflows
+          .filter(w => (w.parseWarnings ?? []).length > 0)
+          .map(w => w.workflow.name);
+        const unexpected = warned.filter(n => !KNOWN_BAD.has(n));
+        expect(unexpected).toEqual([]);
+      } finally {
+        if (savedHome === undefined) delete process.env.ARCHON_HOME;
+        else process.env.ARCHON_HOME = savedHome;
+      }
+    });
   });
 });
 

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -4689,6 +4689,20 @@ nodes:
     // warnings that survive must describe the workflow that survived. Before
     // the single-entry refactor the definition and the warnings came from two
     // parallel maps, and a clean file could inherit the dropped file's warning.
+    //
+    // READ THIS BEFORE TRUSTING THE PAIR: only ONE of these two is a live
+    // regression test on any given platform, and which one depends on the
+    // filesystem. The bug was that warnings were sticky — set, never cleared —
+    // so it is only observable when the CLEAN file wins: post-fix its warnings
+    // are empty, pre-fix it inherited the dirty file's. When the DIRTY file
+    // wins, pre-fix and post-fix produce the same correct warning, so that
+    // direction cannot distinguish them and passes either way. There is no
+    // assertion that fixes this; it is inherent to the bug's shape.
+    //
+    // Forcing both orderings would need a test seam in `loadWorkflowsFromDir`
+    // or a `mock.module('fs/promises')` that would break the real-I/O tests
+    // throughout this file. Judged not worth it (#2455 review S5) — but do not
+    // read this as two regression tests, because it is one plus a companion.
     const CLEAN = (name: string): string =>
       ['name: ' + name, 'description: test', 'nodes:', '  - id: a', '    prompt: hi'].join('\n');
     const DIRTY = (name: string): string =>

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -4348,7 +4348,7 @@ nodes:
       const pw = result.workflows[0].parseWarnings ?? [];
       expect(pw.length).toBe(1);
       expect(pw[0]).toContain("'interactive'");
-      expect(pw[0]).toContain('valid at workflow level');
+      expect(pw[0]).toContain('gate_message');
     });
 
     it('should warn when the workflow itself has an unknown key', async () => {

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -4411,6 +4411,27 @@ nodes:
       expect(pw[0]).toContain("Node 'a'");
       expect(pw[1]).toContain("Node 'b'");
     });
+
+    it('should hint when a node-only key is misplaced at workflow level', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+      // 'command' is valid on nodes but not at workflow level
+      const yaml = [
+        'name: test',
+        'description: test',
+        'command: my-command',
+        'nodes:',
+        '  - id: n',
+        '    prompt: p',
+      ].join('\n');
+      await writeFile(join(workflowDir, 'test.yaml'), yaml);
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.workflows.length).toBe(1);
+      const pw = result.workflows[0].parseWarnings ?? [];
+      expect(pw.length).toBe(1);
+      expect(pw[0]).toContain("'command'");
+      expect(pw[0]).toContain('valid on individual nodes');
+    });
   });
 });
 

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -4348,7 +4348,12 @@ nodes:
       const pw = result.workflows[0].parseWarnings ?? [];
       expect(pw.length).toBe(1);
       expect(pw[0]).toContain("'interactive'");
+      // The hint must name BOTH loop fields: the executor gates on
+      // `loop.interactive && loop.gate_message`, so an author who follows a
+      // gate_message-only hint gets a loop with a message and no gate.
+      expect(pw[0]).toContain('loop.interactive: true');
       expect(pw[0]).toContain('gate_message');
+      expect(pw[0]).toContain('approval:');
     });
 
     it('should warn when the workflow itself has an unknown key', async () => {
@@ -4431,6 +4436,185 @@ nodes:
       expect(pw.length).toBe(1);
       expect(pw[0]).toContain("'command'");
       expect(pw[0]).toContain('valid on individual nodes');
+    });
+  });
+
+  describe('unknown key warnings — nested (#2213)', () => {
+    /** Write a single workflow and return its parse warnings. */
+    const warningsFor = async (lines: string[]): Promise<string[]> => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+      await writeFile(join(workflowDir, 'test.yaml'), lines.join('\n'));
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.workflows.length).toBe(1);
+      return [...(result.workflows[0].parseWarnings ?? [])];
+    };
+
+    it('should warn on an unknown key inside approval:', async () => {
+      const pw = await warningsFor([
+        'name: test',
+        'description: test',
+        'nodes:',
+        '  - id: gate',
+        '    approval:',
+        '      message: ok?',
+        '      capture_reponse: true', // typo for capture_response
+      ]);
+      expect(pw.length).toBe(1);
+      expect(pw[0]).toContain("Node 'gate'");
+      expect(pw[0]).toContain("unknown key 'approval.capture_reponse'");
+    });
+
+    it('should warn on an unknown key inside approval.on_reject (two levels down)', async () => {
+      const pw = await warningsFor([
+        'name: test',
+        'description: test',
+        'nodes:',
+        '  - id: gate',
+        '    approval:',
+        '      message: ok?',
+        '      on_reject:',
+        '        prompt: try again',
+        '        max_retries: 2', // real field is max_attempts
+      ]);
+      expect(pw.length).toBe(1);
+      expect(pw[0]).toContain("unknown key 'approval.on_reject.max_retries'");
+    });
+
+    it('should warn on an unknown key inside retry:', async () => {
+      const pw = await warningsFor([
+        'name: test',
+        'description: test',
+        'nodes:',
+        '  - id: n',
+        '    prompt: hello',
+        '    retry:',
+        '      max_attempts: 2',
+        '      backoff_ms: 5000', // real field is delay_ms
+      ]);
+      expect(pw.length).toBe(1);
+      expect(pw[0]).toContain("unknown key 'retry.backoff_ms'");
+    });
+
+    it('should warn on an unknown key inside an agents entry', async () => {
+      const pw = await warningsFor([
+        'name: test',
+        'description: test',
+        'nodes:',
+        '  - id: n',
+        '    prompt: hello',
+        '    agents:',
+        '      my-agent:',
+        '        description: does things',
+        '        prompt: do it',
+        '        disallowed_tools: [Bash]', // real field is disallowedTools
+      ]);
+      expect(pw.length).toBe(1);
+      // The agent id is author-chosen, so it must appear in the path verbatim
+      // rather than being reported as an unknown key itself.
+      expect(pw[0]).toContain("unknown key 'agents.my-agent.disallowed_tools'");
+    });
+
+    it('should warn on an unknown key on a loop_group body node', async () => {
+      const pw = await warningsFor([
+        'name: test',
+        'description: test',
+        'nodes:',
+        '  - id: refine',
+        '    loop_group:',
+        '      until: DONE',
+        '      max_iterations: 3',
+        '      nodes:',
+        '        - id: check',
+        '          prompt: check it',
+        '          interactive: true',
+      ]);
+      expect(pw.length).toBe(1);
+      expect(pw[0]).toContain("Node 'refine' → loop_group node 'check'");
+      expect(pw[0]).toContain("unknown key 'interactive'");
+      // The body node gets the same actionable guidance as a top-level node.
+      expect(pw[0]).toContain('loop.interactive: true');
+    });
+
+    it('should warn on an unknown key inside the loop_group control block', async () => {
+      const pw = await warningsFor([
+        'name: test',
+        'description: test',
+        'nodes:',
+        '  - id: refine',
+        '    loop_group:',
+        '      until: DONE',
+        '      max_iterations: 3',
+        '      max_attempts: 4', // not a loop control field
+        '      nodes:',
+        '        - id: check',
+        '          prompt: check it',
+      ]);
+      expect(pw.length).toBe(1);
+      expect(pw[0]).toContain("unknown key 'loop_group.max_attempts'");
+    });
+
+    it('should warn on an unknown key inside a workflow-level worktree block', async () => {
+      const pw = await warningsFor([
+        'name: test',
+        'description: test',
+        'worktree:',
+        '  enabled: true',
+        '  base_branch: main', // worktree policy has only `enabled`
+        'nodes:',
+        '  - id: n',
+        '    prompt: p',
+      ]);
+      expect(pw.length).toBe(1);
+      expect(pw[0]).toContain("Workflow 'test'");
+      expect(pw[0]).toContain("unknown key 'worktree.base_branch'");
+    });
+
+    it('should not warn on valid nested keys, including a clean loop_group body', async () => {
+      const pw = await warningsFor([
+        'name: test',
+        'description: test',
+        'worktree:',
+        '  enabled: true',
+        'nodes:',
+        '  - id: refine',
+        '    loop_group:',
+        '      until: DONE',
+        '      max_iterations: 3',
+        '      interactive: true',
+        '      gate_message: continue?',
+        '      nodes:',
+        '        - id: check',
+        '          prompt: check it',
+        '          retry:',
+        '            max_attempts: 2',
+        '            delay_ms: 1000',
+        '  - id: gate',
+        '    depends_on: [refine]',
+        '    approval:',
+        '      message: ok?',
+        '      capture_response: true',
+        '      on_reject:',
+        '        prompt: again',
+        '        max_attempts: 2',
+      ]);
+      expect(pw).toEqual([]);
+    });
+
+    it('should not treat free-form output_format keys as unknown', async () => {
+      const pw = await warningsFor([
+        'name: test',
+        'description: test',
+        'nodes:',
+        '  - id: n',
+        '    prompt: hello',
+        '    output_format:',
+        '      type: object',
+        '      properties:',
+        '        anything_at_all:',
+        '          type: string',
+      ]);
+      expect(pw).toEqual([]);
     });
   });
 });

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -4308,6 +4308,110 @@ nodes:
       }
     });
   });
+
+  describe('unknown key warnings (#2213)', () => {
+    it('should warn when a node has an unknown key', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+      const yaml = [
+        'name: test',
+        'description: test',
+        'nodes:',
+        '  - id: plan',
+        '    command: my-command',
+        '    unknown_field: true',
+      ].join('\n');
+      await writeFile(join(workflowDir, 'test.yaml'), yaml);
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.workflows.length).toBe(1);
+      const pw = result.workflows[0].parseWarnings ?? [];
+      expect(pw.length).toBe(1);
+      expect(pw[0]).toContain("unknown key 'unknown_field'");
+      expect(pw[0]).toContain('will be ignored');
+    });
+
+    it('should hint when a workflow-level key is misplaced on a node', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+      // 'interactive' is valid at workflow level but not on individual nodes
+      const yaml = [
+        'name: test',
+        'description: test',
+        'nodes:',
+        '  - id: plan',
+        '    command: my-command',
+        '    interactive: true',
+      ].join('\n');
+      await writeFile(join(workflowDir, 'test.yaml'), yaml);
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.workflows.length).toBe(1);
+      const pw = result.workflows[0].parseWarnings ?? [];
+      expect(pw.length).toBe(1);
+      expect(pw[0]).toContain("'interactive'");
+      expect(pw[0]).toContain('valid at workflow level');
+    });
+
+    it('should warn when the workflow itself has an unknown key', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+      const yaml = [
+        'name: test',
+        'description: test',
+        'max_retries: 3',
+        'nodes:',
+        '  - id: n',
+        '    prompt: p',
+      ].join('\n');
+      await writeFile(join(workflowDir, 'test.yaml'), yaml);
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.workflows.length).toBe(1);
+      const pw = result.workflows[0].parseWarnings ?? [];
+      expect(pw.length).toBe(1);
+      expect(pw[0]).toContain("unknown key 'max_retries'");
+    });
+
+    it('should not warn for valid node keys', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+      const yaml = [
+        'name: test',
+        'description: test',
+        'nodes:',
+        '  - id: n',
+        '    prompt: hello',
+        '    model: some-model',
+        '    context: fresh',
+      ].join('\n');
+      await writeFile(join(workflowDir, 'test.yaml'), yaml);
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.workflows.length).toBe(1);
+      const pw = result.workflows[0].parseWarnings ?? [];
+      expect(pw.length).toBe(0);
+    });
+
+    it('should collect warnings from multiple nodes', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+      const yaml = [
+        'name: test',
+        'description: test',
+        'nodes:',
+        '  - id: a',
+        '    prompt: hello',
+        '    typo_key: 1',
+        '  - id: b',
+        '    bash: echo hi',
+        '    another_typo: 2',
+      ].join('\n');
+      await writeFile(join(workflowDir, 'test.yaml'), yaml);
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.workflows.length).toBe(1);
+      const pw = result.workflows[0].parseWarnings ?? [];
+      expect(pw.length).toBe(2);
+      expect(pw[0]).toContain("Node 'a'");
+      expect(pw[1]).toContain("Node 'b'");
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, spyOn, mock, type Mock } from 'bun:test';
-import { mkdir, writeFile, rm } from 'fs/promises';
-import { join } from 'path';
+import { mkdir, writeFile, rm, readdir, readFile } from 'fs/promises';
+import { join, basename } from 'path';
 import { tmpdir } from 'os';
 
 const isWindows = process.platform === 'win32';
@@ -4747,11 +4747,19 @@ nodes:
      * schema field that drifts out of a derived key set would start warning on
      * valid YAML — and a warning nobody can act on is worse than none.
      *
-     * This runs discovery over Archon's own `.archon/workflows/` (its largest
-     * real corpus) and asserts that nothing OUTSIDE a known-bad allowlist warns.
-     * Deliberately one-directional: the allowlist may shrink freely (fixing
+     * Runs over Archon's own `.archon/workflows/` — its largest real corpus —
+     * and asserts nothing OUTSIDE a known-bad allowlist warns. Deliberately
+     * one-directional: the allowlist may shrink freely (fixing
      * `e2e-opencode-smoke.yaml` must not break this), but a new name appearing
      * is a false positive and fails.
+     *
+     * Calls `parseWorkflow` per file rather than `discoverWorkflows`. Parsing is
+     * the only thing under test — running full discovery would additionally do
+     * include expansion, command-file resolution and config loading, which is
+     * both a looser unit and heavy enough to starve the other package test
+     * processes running in parallel (`bun --filter '*' --parallel test`). It
+     * measurably did: on a 2-core Windows CI runner it pushed an unrelated
+     * SQLite test from 250 ms past Bun's 5000 ms per-test timeout.
      */
     const KNOWN_BAD = new Set([
       // `agent:` at workflow and node level — a real bug, silently dropped since
@@ -4761,28 +4769,30 @@ nodes:
 
     it('warns only on workflows already known to carry unknown keys', async () => {
       // packages/workflows/src/ → repo root
-      const repoRoot = join(import.meta.dir, '..', '..', '..');
-      // Point ARCHON_HOME at an empty dir so a developer's own home-scoped
-      // workflows can't leak into the corpus and make this machine-dependent.
-      const emptyHome = join(testDir, 'empty-archon-home');
-      await mkdir(emptyHome, { recursive: true });
-      const savedHome = process.env.ARCHON_HOME;
-      process.env.ARCHON_HOME = emptyHome;
-      try {
-        const result = await discoverWorkflows(repoRoot);
-        // Guard against silently testing nothing if discovery ever stops
-        // finding the repo's workflows.
-        expect(result.workflows.length).toBeGreaterThan(20);
+      const corpusDir = join(import.meta.dir, '..', '..', '..', '.archon', 'workflows');
 
-        const warned = result.workflows
-          .filter(w => (w.parseWarnings ?? []).length > 0)
-          .map(w => w.workflow.name);
-        const unexpected = warned.filter(n => !KNOWN_BAD.has(n));
-        expect(unexpected).toEqual([]);
-      } finally {
-        if (savedHome === undefined) delete process.env.ARCHON_HOME;
-        else process.env.ARCHON_HOME = savedHome;
+      // Discovery descends one level; mirror that without invoking it.
+      const files: string[] = [];
+      for (const entry of await readdir(corpusDir, { withFileTypes: true })) {
+        const full = join(corpusDir, entry.name);
+        if (entry.isDirectory()) {
+          for (const sub of await readdir(full)) {
+            if (sub.endsWith('.yaml') || sub.endsWith('.yml')) files.push(join(full, sub));
+          }
+        } else if (entry.name.endsWith('.yaml') || entry.name.endsWith('.yml')) {
+          files.push(full);
+        }
       }
+      // Guard against silently testing nothing if the corpus moves.
+      expect(files.length).toBeGreaterThan(20);
+
+      const unexpected: string[] = [];
+      for (const file of files) {
+        const result = parseWorkflow(await readFile(file, 'utf-8'), basename(file));
+        if (!result.workflow || result.warnings.length === 0) continue;
+        if (!KNOWN_BAD.has(result.workflow.name)) unexpected.push(result.workflow.name);
+      }
+      expect(unexpected).toEqual([]);
     });
   });
 });

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -818,9 +818,7 @@ export function parseWorkflow(content: string, filename: string): ParseResult {
     const rawKeys = Object.keys(raw);
     for (const key of rawKeys) {
       if (!KNOWN_WORKFLOW_KEYS.has(key)) {
-        parseWarnings.push(
-          `Workflow '${raw.name as string}': unknown key '${key}' will be ignored`
-        );
+        parseWarnings.push(`Workflow '${raw.name}': unknown key '${key}' will be ignored`);
         getLog().warn({ workflowName: raw.name, key }, 'workflow_unknown_key_ignored');
       }
     }

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -141,9 +141,12 @@ function parseDagNode(
     const rawKeys = Object.keys(raw as Record<string, unknown>);
     for (const key of rawKeys) {
       if (!KNOWN_DAG_NODE_KEYS.has(key)) {
-        const hint = WORKFLOW_ONLY_KEYS.has(key)
-          ? ` ('${key}' is valid at workflow level, not on individual nodes)`
-          : '';
+        const hint =
+          key === 'interactive'
+            ? " ('interactive' at workflow level forces foreground execution; for a human gate on this node, use 'loop.gate_message' or an 'approval:' node)"
+            : WORKFLOW_ONLY_KEYS.has(key)
+              ? ` ('${key}' is valid at workflow level, not on individual nodes)`
+              : '';
         warnings.push(`Node '${id}': unknown key '${key}' will be ignored${hint}`);
         getLog().warn({ id: node.id, key }, 'node_unknown_key_ignored');
       }

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -27,6 +27,7 @@ import {
   LOOP_GROUP_NODE_AI_FIELDS,
   INCLUDE_NODE_IGNORED_FIELDS,
   WORKFLOW_NODE_IGNORED_FIELDS,
+  KNOWN_DAG_NODE_KEYS,
   effortLevelSchema,
   thinkingConfigSchema,
   sandboxSettingsSchema,
@@ -37,6 +38,8 @@ import {
   webSearchModeSchema,
   workflowRequirementSchema,
   workflowEvidencePolicySchema,
+  KNOWN_WORKFLOW_KEYS,
+  WORKFLOW_ONLY_KEYS,
 } from './schemas/workflow';
 import type { WorkflowRequirement, WorkflowEvidencePolicy } from './schemas/workflow';
 import { workflowNodeHooksSchema } from './schemas/hooks';
@@ -94,11 +97,6 @@ function formatNodeIssue(id: string, issue: z.ZodIssue): string {
 }
 
 /**
- * Validate and parse a single DagNode from raw YAML data.
- * Replaces the former parseDagNode + parseRetryConfig + parseToolList +
- * parseNodeHooks + parseIdleTimeout functions.
- */
-/**
  * The one shape of a `$nodeId.output` reference. Both scanners below build their own
  * RegExp from it — a `g`-flagged one for the multi-match dangling-ref sweep and a plain one
  * for `fan_out.items` — because a `g` regex carries mutable `lastIndex` and sharing a single
@@ -108,7 +106,17 @@ function formatNodeIssue(id: string, issue: z.ZodIssue): string {
  */
 const OUTPUT_REF_SOURCE = String.raw`\$([a-zA-Z_][a-zA-Z0-9_-]*)\.output`;
 
-function parseDagNode(raw: unknown, index: number, errors: string[]): DagNode | null {
+/**
+ * Validate and parse a single DagNode from raw YAML data.
+ * Replaces the former parseDagNode + parseRetryConfig + parseToolList +
+ * parseNodeHooks + parseIdleTimeout functions.
+ */
+function parseDagNode(
+  raw: unknown,
+  index: number,
+  errors: string[],
+  warnings: string[]
+): DagNode | null {
   // Extract id early for error messages (may be empty/invalid — schema will catch it)
   const rawId =
     raw !== null && typeof raw === 'object' && 'id' in raw
@@ -125,6 +133,22 @@ function parseDagNode(raw: unknown, index: number, errors: string[]): DagNode | 
   }
 
   const node = result.data;
+
+  // Warn about unknown keys on the raw node that Zod silently stripped (#2213).
+  // This catches misplaced workflow-level keys (e.g. `interactive:` on a command node)
+  // and typos (e.g. `contxt:` instead of `context:`).
+  if (raw !== null && typeof raw === 'object') {
+    const rawKeys = Object.keys(raw as Record<string, unknown>);
+    for (const key of rawKeys) {
+      if (!KNOWN_DAG_NODE_KEYS.has(key)) {
+        const hint = WORKFLOW_ONLY_KEYS.has(key)
+          ? ` ('${key}' is valid at workflow level, not on individual nodes)`
+          : '';
+        warnings.push(`Node '${id}': unknown key '${key}' will be ignored${hint}`);
+        getLog().warn({ id: node.id, key }, 'node_unknown_key_ignored');
+      }
+    }
+  }
 
   // Warn about AI-specific fields on non-AI nodes (runtime behavior, not schema errors)
   let nonAiNode: { type: string; fields: readonly string[] } | undefined;
@@ -360,8 +384,8 @@ export function validateDagStructure(
 }
 
 export type ParseResult =
-  | { workflow: WorkflowDefinition; error: null }
-  | { workflow: null; error: WorkflowLoadError };
+  | { workflow: WorkflowDefinition; error: null; warnings: string[] }
+  | { workflow: null; error: WorkflowLoadError; warnings?: never };
 
 /**
  * Parse and validate a workflow YAML file
@@ -437,8 +461,9 @@ export function parseWorkflow(content: string, filename: string): ParseResult {
 
     // Parse DAG nodes using dagNodeSchema
     const validationErrors: string[] = [];
+    const parseWarnings: string[] = [];
     const dagNodes = (raw.nodes as unknown[])
-      .map((n: unknown, i: number) => parseDagNode(n, i, validationErrors))
+      .map((n: unknown, i: number) => parseDagNode(n, i, validationErrors, parseWarnings))
       .filter((n): n is DagNode => n !== null);
 
     if (dagNodes.length !== (raw.nodes as unknown[]).length) {
@@ -789,6 +814,17 @@ export function parseWorkflow(content: string, filename: string): ParseResult {
       }
     }
 
+    // Detect unknown workflow-level keys (#2213)
+    const rawKeys = Object.keys(raw);
+    for (const key of rawKeys) {
+      if (!KNOWN_WORKFLOW_KEYS.has(key)) {
+        parseWarnings.push(
+          `Workflow '${raw.name as string}': unknown key '${key}' will be ignored`
+        );
+        getLog().warn({ workflowName: raw.name, key }, 'workflow_unknown_key_ignored');
+      }
+    }
+
     return {
       workflow: {
         name: raw.name,
@@ -813,6 +849,7 @@ export function parseWorkflow(content: string, filename: string): ParseResult {
         ...(requires !== undefined ? { requires } : {}),
       },
       error: null,
+      warnings: parseWarnings,
     };
   } catch (error) {
     const err = error as Error;

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -138,7 +138,8 @@ function unknownNodeKeyHint(key: string): string {
       " Nothing on this node gates. For a human gate, use an 'approval:' node; to gate each" +
       " iteration of a loop, set BOTH 'loop.interactive: true' and 'loop.gate_message'" +
       " ('gate_message' on its own does not gate). Workflow-level 'interactive:' is a" +
-      ' different setting — it forces foreground execution.'
+      ' different setting, and only on the web UI — it keeps the run in the foreground' +
+      ' there; chat platforms already run in the foreground, so it does nothing for them.'
     );
   }
   if (WORKFLOW_ONLY_KEYS.has(key)) {
@@ -147,8 +148,16 @@ function unknownNodeKeyHint(key: string): string {
   return '';
 }
 
-/** Record one unknown-key warning, both for callers and for the run-time log. */
+/**
+ * Record one unknown-key warning, both for callers and for the run-time log.
+ *
+ * `id` is the bare node or workflow id — a stable value a log consumer can
+ * filter on. `label` is its human rendering (it may carry a breadcrumb, e.g.
+ * `Node 'refine' → loop_group node 'check'`) and appears only inside the
+ * message prose, never as a structured field.
+ */
 function pushUnknownKeyWarning(
+  id: string,
   label: string,
   key: string,
   hint: string,
@@ -159,7 +168,7 @@ function pushUnknownKeyWarning(
   warnings.push(message);
   // Carry the prose, not just the payload: the run path (`archon workflow run`)
   // reads this log line and never reads the warning string (#2213).
-  getLog().warn({ node: label, key, warning: message }, event);
+  getLog().warn({ id, key, warning: message }, event);
 }
 
 /**
@@ -170,6 +179,7 @@ function pushUnknownKeyWarning(
 function collectUnknownConfigKeys(
   raw: unknown,
   spec: NestedKeySpec,
+  id: string,
   label: string,
   keyPath: string,
   event: string,
@@ -183,6 +193,7 @@ function collectUnknownConfigKeys(
       collectUnknownConfigKeys(
         entryValue,
         spec.entry,
+        id,
         label,
         `${keyPath}${entryKey}.`,
         event,
@@ -194,12 +205,12 @@ function collectUnknownConfigKeys(
 
   for (const key of Object.keys(obj)) {
     if (!spec.keys.has(key)) {
-      pushUnknownKeyWarning(label, `${keyPath}${key}`, '', event, warnings);
+      pushUnknownKeyWarning(id, label, `${keyPath}${key}`, '', event, warnings);
       continue;
     }
     const child = spec.children?.get(key);
     if (child) {
-      collectUnknownConfigKeys(obj[key], child, label, `${keyPath}${key}.`, event, warnings);
+      collectUnknownConfigKeys(obj[key], child, id, label, `${keyPath}${key}.`, event, warnings);
     }
   }
 }
@@ -214,13 +225,14 @@ function collectUnknownConfigKeys(
  * the same schema, so they strip unknown keys just as silently — and a body node
  * is exactly where an `interactive: true` gate is most likely to be attempted.
  */
-function collectUnknownNodeKeys(raw: unknown, label: string, warnings: string[]): void {
+function collectUnknownNodeKeys(raw: unknown, id: string, label: string, warnings: string[]): void {
   if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return;
   const obj = raw as Record<string, unknown>;
 
   for (const key of Object.keys(obj)) {
     if (!KNOWN_DAG_NODE_KEYS.has(key)) {
       pushUnknownKeyWarning(
+        id,
         label,
         key,
         unknownNodeKeyHint(key),
@@ -234,6 +246,7 @@ function collectUnknownNodeKeys(raw: unknown, label: string, warnings: string[])
       collectUnknownConfigKeys(
         obj[key],
         nested,
+        id,
         label,
         `${key}.`,
         'node_unknown_key_ignored',
@@ -247,11 +260,8 @@ function collectUnknownNodeKeys(raw: unknown, label: string, warnings: string[])
   const body = (group as Record<string, unknown>).nodes;
   if (!Array.isArray(body)) return;
   body.forEach((bodyNode: unknown, i: number) => {
-    collectUnknownNodeKeys(
-      bodyNode,
-      `${label} → loop_group node '${nodeIdForMessages(bodyNode, i)}'`,
-      warnings
-    );
+    const bodyId = nodeIdForMessages(bodyNode, i);
+    collectUnknownNodeKeys(bodyNode, bodyId, `${label} → loop_group node '${bodyId}'`, warnings);
   });
 }
 
@@ -279,7 +289,7 @@ function parseDagNode(
 
   const node = result.data;
 
-  collectUnknownNodeKeys(raw, `Node '${id}'`, warnings);
+  collectUnknownNodeKeys(raw, id, `Node '${id}'`, warnings);
 
   // Warn about AI-specific fields on non-AI nodes (runtime behavior, not schema errors)
   let nonAiNode: { type: string; fields: readonly string[] } | undefined;
@@ -947,13 +957,15 @@ export function parseWorkflow(content: string, filename: string): ParseResult {
 
     // Detect unknown workflow-level keys, and unknown keys inside the nested
     // workflow-level configs (#2213)
-    const workflowLabel = `Workflow '${raw.name}'`;
+    const workflowName = raw.name;
+    const workflowLabel = `Workflow '${workflowName}'`;
     for (const key of Object.keys(raw)) {
       if (!KNOWN_WORKFLOW_KEYS.has(key)) {
         const hint = KNOWN_DAG_NODE_KEYS.has(key)
           ? ` ('${key}' is valid on individual nodes, not at workflow level.)`
           : '';
         pushUnknownKeyWarning(
+          workflowName,
           workflowLabel,
           key,
           hint,
@@ -967,6 +979,7 @@ export function parseWorkflow(content: string, filename: string): ParseResult {
         collectUnknownConfigKeys(
           raw[key],
           nested,
+          workflowName,
           workflowLabel,
           `${key}.`,
           'workflow_unknown_key_ignored',

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -28,17 +28,20 @@ import {
   INCLUDE_NODE_IGNORED_FIELDS,
   WORKFLOW_NODE_IGNORED_FIELDS,
   KNOWN_DAG_NODE_KEYS,
+  KNOWN_NODE_NESTED_KEYS,
   effortLevelSchema,
   thinkingConfigSchema,
   sandboxSettingsSchema,
   betasSchema,
 } from './schemas/dag-node';
+import type { NestedKeySpec } from './schemas/dag-node';
 import {
   modelReasoningEffortSchema,
   webSearchModeSchema,
   workflowRequirementSchema,
   workflowEvidencePolicySchema,
   KNOWN_WORKFLOW_KEYS,
+  KNOWN_WORKFLOW_NESTED_KEYS,
   WORKFLOW_ONLY_KEYS,
 } from './schemas/workflow';
 import type { WorkflowRequirement, WorkflowEvidencePolicy } from './schemas/workflow';
@@ -107,6 +110,152 @@ function formatNodeIssue(id: string, issue: z.ZodIssue): string {
 const OUTPUT_REF_SOURCE = String.raw`\$([a-zA-Z_][a-zA-Z0-9_-]*)\.output`;
 
 /**
+ * The node's `id` for messages, falling back to its 1-based position when the
+ * id is missing or blank (the schema reports that separately as an error).
+ */
+function nodeIdForMessages(raw: unknown, index: number): string {
+  const rawId =
+    raw !== null && typeof raw === 'object' && 'id' in raw
+      ? String((raw as Record<string, unknown>).id)
+      : '';
+  return rawId.trim() || `#${String(index + 1)}`;
+}
+
+/**
+ * Guidance for a key the engine drops, appended to the unknown-key warning.
+ *
+ * `interactive` gets its own text because it is the reported failure (#2213):
+ * an author writes it expecting a human gate, the key is dropped, and the run
+ * proceeds unattended. Both escapes offered here actually gate — in particular
+ * `loop.gate_message` ALONE does not: the executor requires
+ * `loop.interactive && loop.gate_message` (dag-executor.ts, `runLoopNode` /
+ * `runLoopGroupNode`), so naming only `gate_message` would hand the author a
+ * loop with a message and no gate.
+ */
+function unknownNodeKeyHint(key: string): string {
+  if (key === 'interactive') {
+    return (
+      " Nothing on this node gates. For a human gate, use an 'approval:' node; to gate each" +
+      " iteration of a loop, set BOTH 'loop.interactive: true' and 'loop.gate_message'" +
+      " ('gate_message' on its own does not gate). Workflow-level 'interactive:' is a" +
+      ' different setting — it forces foreground execution.'
+    );
+  }
+  if (WORKFLOW_ONLY_KEYS.has(key)) {
+    return ` ('${key}' is valid at workflow level, not on individual nodes.)`;
+  }
+  return '';
+}
+
+/** Record one unknown-key warning, both for callers and for the run-time log. */
+function pushUnknownKeyWarning(
+  label: string,
+  key: string,
+  hint: string,
+  event: string,
+  warnings: string[]
+): void {
+  const message = `${label}: unknown key '${key}' will be ignored.${hint}`;
+  warnings.push(message);
+  // Carry the prose, not just the payload: the run path (`archon workflow run`)
+  // reads this log line and never reads the warning string (#2213).
+  getLog().warn({ node: label, key, warning: message }, event);
+}
+
+/**
+ * Warn about keys Zod silently stripped from a nested config object, recursing
+ * through the sub-objects `spec` describes. `keyPath` is the dotted prefix that
+ * locates the key inside the node (e.g. `approval.on_reject.`).
+ */
+function collectUnknownConfigKeys(
+  raw: unknown,
+  spec: NestedKeySpec,
+  label: string,
+  keyPath: string,
+  event: string,
+  warnings: string[]
+): void {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return;
+  const obj = raw as Record<string, unknown>;
+
+  if (spec.kind === 'record') {
+    for (const [entryKey, entryValue] of Object.entries(obj)) {
+      collectUnknownConfigKeys(
+        entryValue,
+        spec.entry,
+        label,
+        `${keyPath}${entryKey}.`,
+        event,
+        warnings
+      );
+    }
+    return;
+  }
+
+  for (const key of Object.keys(obj)) {
+    if (!spec.keys.has(key)) {
+      pushUnknownKeyWarning(label, `${keyPath}${key}`, '', event, warnings);
+      continue;
+    }
+    const child = spec.children?.get(key);
+    if (child) {
+      collectUnknownConfigKeys(obj[key], child, label, `${keyPath}${key}.`, event, warnings);
+    }
+  }
+}
+
+/**
+ * Warn about unknown keys on a raw node that Zod silently stripped (#2213).
+ * Catches misplaced workflow-level keys (`interactive:` on a command node),
+ * typos (`contxt:` instead of `context:`), and the same mistakes one level down
+ * inside `approval:` / `retry:` / `loop:` / `agents:`.
+ *
+ * Recurses into a `loop_group` body: those entries are full DAG nodes parsed by
+ * the same schema, so they strip unknown keys just as silently — and a body node
+ * is exactly where an `interactive: true` gate is most likely to be attempted.
+ */
+function collectUnknownNodeKeys(raw: unknown, label: string, warnings: string[]): void {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return;
+  const obj = raw as Record<string, unknown>;
+
+  for (const key of Object.keys(obj)) {
+    if (!KNOWN_DAG_NODE_KEYS.has(key)) {
+      pushUnknownKeyWarning(
+        label,
+        key,
+        unknownNodeKeyHint(key),
+        'node_unknown_key_ignored',
+        warnings
+      );
+      continue;
+    }
+    const nested = KNOWN_NODE_NESTED_KEYS.get(key);
+    if (nested) {
+      collectUnknownConfigKeys(
+        obj[key],
+        nested,
+        label,
+        `${key}.`,
+        'node_unknown_key_ignored',
+        warnings
+      );
+    }
+  }
+
+  const group = obj.loop_group;
+  if (group === null || typeof group !== 'object' || Array.isArray(group)) return;
+  const body = (group as Record<string, unknown>).nodes;
+  if (!Array.isArray(body)) return;
+  body.forEach((bodyNode: unknown, i: number) => {
+    collectUnknownNodeKeys(
+      bodyNode,
+      `${label} → loop_group node '${nodeIdForMessages(bodyNode, i)}'`,
+      warnings
+    );
+  });
+}
+
+/**
  * Validate and parse a single DagNode from raw YAML data.
  * Replaces the former parseDagNode + parseRetryConfig + parseToolList +
  * parseNodeHooks + parseIdleTimeout functions.
@@ -118,11 +267,7 @@ function parseDagNode(
   warnings: string[]
 ): DagNode | null {
   // Extract id early for error messages (may be empty/invalid — schema will catch it)
-  const rawId =
-    raw !== null && typeof raw === 'object' && 'id' in raw
-      ? String((raw as Record<string, unknown>).id)
-      : '';
-  const id = rawId.trim() || `#${String(index + 1)}`;
+  const id = nodeIdForMessages(raw, index);
 
   const result = dagNodeSchema.safeParse(raw);
   if (!result.success) {
@@ -134,24 +279,7 @@ function parseDagNode(
 
   const node = result.data;
 
-  // Warn about unknown keys on the raw node that Zod silently stripped (#2213).
-  // This catches misplaced workflow-level keys (e.g. `interactive:` on a command node)
-  // and typos (e.g. `contxt:` instead of `context:`).
-  if (raw !== null && typeof raw === 'object') {
-    const rawKeys = Object.keys(raw as Record<string, unknown>);
-    for (const key of rawKeys) {
-      if (!KNOWN_DAG_NODE_KEYS.has(key)) {
-        const hint =
-          key === 'interactive'
-            ? " ('interactive' at workflow level forces foreground execution; for a human gate on this node, use 'loop.gate_message' or an 'approval:' node)"
-            : WORKFLOW_ONLY_KEYS.has(key)
-              ? ` ('${key}' is valid at workflow level, not on individual nodes)`
-              : '';
-        warnings.push(`Node '${id}': unknown key '${key}' will be ignored${hint}`);
-        getLog().warn({ id: node.id, key }, 'node_unknown_key_ignored');
-      }
-    }
-  }
+  collectUnknownNodeKeys(raw, `Node '${id}'`, warnings);
 
   // Warn about AI-specific fields on non-AI nodes (runtime behavior, not schema errors)
   let nonAiNode: { type: string; fields: readonly string[] } | undefined;
@@ -817,15 +945,33 @@ export function parseWorkflow(content: string, filename: string): ParseResult {
       }
     }
 
-    // Detect unknown workflow-level keys (#2213)
-    const rawKeys = Object.keys(raw);
-    for (const key of rawKeys) {
+    // Detect unknown workflow-level keys, and unknown keys inside the nested
+    // workflow-level configs (#2213)
+    const workflowLabel = `Workflow '${raw.name}'`;
+    for (const key of Object.keys(raw)) {
       if (!KNOWN_WORKFLOW_KEYS.has(key)) {
         const hint = KNOWN_DAG_NODE_KEYS.has(key)
-          ? ` ('${key}' is valid on individual nodes, not at workflow level)`
+          ? ` ('${key}' is valid on individual nodes, not at workflow level.)`
           : '';
-        parseWarnings.push(`Workflow '${raw.name}': unknown key '${key}' will be ignored${hint}`);
-        getLog().warn({ workflowName: raw.name, key }, 'workflow_unknown_key_ignored');
+        pushUnknownKeyWarning(
+          workflowLabel,
+          key,
+          hint,
+          'workflow_unknown_key_ignored',
+          parseWarnings
+        );
+        continue;
+      }
+      const nested = KNOWN_WORKFLOW_NESTED_KEYS.get(key);
+      if (nested) {
+        collectUnknownConfigKeys(
+          raw[key],
+          nested,
+          workflowLabel,
+          `${key}.`,
+          'workflow_unknown_key_ignored',
+          parseWarnings
+        );
       }
     }
 

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -818,7 +818,10 @@ export function parseWorkflow(content: string, filename: string): ParseResult {
     const rawKeys = Object.keys(raw);
     for (const key of rawKeys) {
       if (!KNOWN_WORKFLOW_KEYS.has(key)) {
-        parseWarnings.push(`Workflow '${raw.name}': unknown key '${key}' will be ignored`);
+        const hint = KNOWN_DAG_NODE_KEYS.has(key)
+          ? ` ('${key}' is valid on individual nodes, not at workflow level)`
+          : '';
+        parseWarnings.push(`Workflow '${raw.name}': unknown key '${key}' will be ignored${hint}`);
         getLog().warn({ workflowName: raw.name, key }, 'workflow_unknown_key_ignored');
       }
     }

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -678,6 +678,10 @@ export const dagNodeFlatSchema = dagNodeBaseSchema.extend({
   // `'worktree'` (slice 2, PR-A) runs the child in its own git worktree via an
   // injected child-isolation resolver.
   isolation: z.enum(['inherit', 'worktree']).optional(),
+  // Dynamic fan-out (slice 2, PR-C) — expand the workflow node into N child runs
+  // over a data-driven item list. Only meaningful on a `workflow:` node (guarded in
+  // superRefine).
+  fan_out: fanOutConfigSchema.optional(),
   // Reserved for Phase 1b input mapping. Present only so the superRefine below can
   // fail fast when it appears on an include or workflow node ("not yet supported").
   with: z.unknown().optional(),
@@ -1245,6 +1249,7 @@ export const KNOWN_NODE_NESTED_KEYS: ReadonlyMap<string, NestedKeySpec> = new Ma
   ['loop', { kind: 'object', keys: new Set(Object.keys(loopNodeConfigSchema.shape)) }],
   ['loop_group', { kind: 'object', keys: new Set(Object.keys(loopGroupShape)) }],
   ['pi', { kind: 'object', keys: new Set(Object.keys(piNodeConfigSchema.shape)) }],
+  ['fan_out', { kind: 'object', keys: new Set(Object.keys(fanOutConfigSchema.shape)) }],
   // `agents` keys are author-chosen agent ids; each VALUE is an agentDefinition,
   // where a camelCase slip (`disallowed_tools`) silently drops a tool restriction.
   [

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -648,6 +648,67 @@ export const WORKFLOW_NODE_IGNORED_FIELDS: readonly string[] = BASH_NODE_AI_FIEL
 );
 
 // ---------------------------------------------------------------------------
+// Known node keys — used by the loader to detect unknown/misplaced keys
+// ---------------------------------------------------------------------------
+
+/**
+ * All keys accepted by the flat dagNodeSchema (base + mode-specific + mode-only).
+ * Used by parseDagNode to warn on unknown keys that Zod's default strip would
+ * silently drop (#2213). Keep in sync with dagNodeBaseSchema + the .extend()
+ * block below.
+ */
+export const KNOWN_DAG_NODE_KEYS: ReadonlySet<string> = new Set([
+  // dagNodeBaseSchema
+  'id',
+  'description',
+  'depends_on',
+  'when',
+  'trigger_rule',
+  'model',
+  'provider',
+  'context',
+  'output_format',
+  'allowed_tools',
+  'denied_tools',
+  'idle_timeout',
+  'retry',
+  'hooks',
+  'mcp',
+  'skills',
+  'agents',
+  'pi',
+  'effort',
+  'thinking',
+  'maxBudgetUsd',
+  'systemPrompt',
+  'fallbackModel',
+  'settingSources',
+  'betas',
+  'sandbox',
+  'always_run',
+  'persist_session',
+  'output_type',
+  // Mode fields (exactly one required)
+  'command',
+  'prompt',
+  'bash',
+  'loop',
+  'loop_group',
+  'approval',
+  'cancel',
+  'include',
+  'workflow',
+  // Mode-specific fields
+  'input',
+  'isolation',
+  'with',
+  'script',
+  'runtime',
+  'deps',
+  'timeout',
+]);
+
+// ---------------------------------------------------------------------------
 // dagNodeSchema — flat validation schema with transform to DagNode
 // ---------------------------------------------------------------------------
 

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -1206,6 +1206,19 @@ export type NestedKeySpec =
  * Casting back recovers the real shape, so the key set stays derived instead of
  * being a hand-written `[...loopControl, 'nodes']` that a future body field
  * would silently fall out of.
+ *
+ * DO NOT MOVE THIS ABOVE `dagNodeSchema`. This line is evaluated at module load,
+ * and reading that `.shape` fires the schema's `nodes` getter, which builds
+ * `z.array(dagNodeSchema)`. Above `dagNodeSchema`'s declaration that is a
+ * temporal dead zone: the module throws
+ * `ReferenceError: Cannot access 'dagNodeSchema' before initialization` on
+ * import, so every test that imports this file dies at load rather than failing
+ * an assertion.
+ *
+ * tsc does NOT catch it — the cast type-checks cleanly either way, which is why
+ * moving this registry up beside the `NestedKeySpec` type it belongs with (the
+ * natural tidy) is a silent break. The position is load-bearing; keep this
+ * block, and `KNOWN_NODE_NESTED_KEYS` below it, at the end of the file.
  */
 const loopGroupShape = (loopGroupNodeConfigSchema as unknown as z.ZodObject<z.ZodRawShape>).shape;
 

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -1182,7 +1182,8 @@ export function isPersistableNode(node: DagNode): boolean {
 // Reading `loopGroupNodeConfigSchema.shape` fires its `nodes` getter, which
 // builds `z.array(dagNodeSchema)`. Placed above `dagNodeSchema` this throws
 // `ReferenceError: Cannot access 'dagNodeSchema' before initialization` at
-// import time — a temporal dead zone tsc does not catch. Keep this block last.
+// import time — a temporal dead zone tsc does not catch. Keep this block below
+// `dagNodeSchema`; see the note on `loopGroupShape` for the full mechanism.
 /**
  * Known-key description for a nested config object, one level at a time.
  *
@@ -1217,8 +1218,10 @@ export type NestedKeySpec =
  *
  * tsc does NOT catch it — the cast type-checks cleanly either way, which is why
  * moving this registry up beside the `NestedKeySpec` type it belongs with (the
- * natural tidy) is a silent break. The position is load-bearing; keep this
- * block, and `KNOWN_NODE_NESTED_KEYS` below it, at the end of the file.
+ * natural tidy) is a silent break. The constraint is ordering, not position:
+ * this block and `KNOWN_NODE_NESTED_KEYS` below it must be declared AFTER
+ * `dagNodeSchema`. They sit at the end of the file only because nothing else
+ * needs to follow them — new code may be appended below without moving them.
  */
 const loopGroupShape = (loopGroupNodeConfigSchema as unknown as z.ZodObject<z.ZodRawShape>).shape;
 
@@ -1253,7 +1256,9 @@ export const KNOWN_NODE_NESTED_KEYS: ReadonlyMap<string, NestedKeySpec> = new Ma
     {
       kind: 'object',
       keys: new Set(Object.keys(approvalConfigSchema.shape)),
-      children: new Map<string, NestedKeySpec>([
+      // Same typo protection one level down: keyed by the parent's shape, so
+      // `'on_rejct'` is a compile error rather than a silently disabled check.
+      children: new Map<keyof typeof approvalConfigSchema.shape, NestedKeySpec>([
         ['on_reject', { kind: 'object', keys: new Set(Object.keys(approvalOnRejectSchema.shape)) }],
       ]),
     },

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -399,15 +399,21 @@ export const approvalOnRejectSchema = z.object({
 export type ApprovalOnReject = z.infer<typeof approvalOnRejectSchema>;
 
 /**
+ * Schema for the `approval:` config object. Named (rather than inlined at both
+ * use sites) so its shape is reachable for the unknown-key check in the loader.
+ */
+export const approvalConfigSchema = z.object({
+  message: z.string().min(1, "'approval.message' must not be empty"),
+  capture_response: z.boolean().optional(),
+  on_reject: approvalOnRejectSchema.optional(),
+});
+
+/**
  * Approval node schema — pauses the workflow for human review.
  * Extends full base for type compatibility; AI-specific fields are ignored at runtime.
  */
 export const approvalNodeSchema = dagNodeBaseSchema.extend({
-  approval: z.object({
-    message: z.string().min(1, "'approval.message' must not be empty"),
-    capture_response: z.boolean().optional(),
-    on_reject: approvalOnRejectSchema.optional(),
-  }),
+  approval: approvalConfigSchema,
 });
 
 /** DAG node that pauses workflow execution for human approval */
@@ -659,13 +665,7 @@ export const dagNodeFlatSchema = dagNodeBaseSchema.extend({
   bash: z.string().optional(),
   loop: loopNodeConfigSchema.optional(),
   loop_group: loopGroupNodeConfigSchema.optional(),
-  approval: z
-    .object({
-      message: z.string().min(1, "'approval.message' must not be empty"),
-      capture_response: z.boolean().optional(),
-      on_reject: approvalOnRejectSchema.optional(),
-    })
-    .optional(),
+  approval: approvalConfigSchema.optional(),
   cancel: z.string().optional(),
   // Load-time inlining directive — the target workflow name.
   include: z.string().min(1, "'include' must be a non-empty workflow name").optional(),
@@ -702,6 +702,72 @@ export const dagNodeFlatSchema = dagNodeBaseSchema.extend({
 export const KNOWN_DAG_NODE_KEYS: ReadonlySet<string> = new Set(
   Object.keys(dagNodeFlatSchema.shape)
 );
+
+/**
+ * Known-key description for a nested config object, one level at a time.
+ *
+ * `object` — a fixed shape; `keys` are the accepted keys and `children`
+ *            describes object-valued keys inside it (e.g. `approval.on_reject`).
+ * `record` — author-chosen keys (e.g. `agents`, whose keys are agent ids); only
+ *            the VALUES have a fixed shape, described by `entry`.
+ */
+export type NestedKeySpec =
+  | {
+      readonly kind: 'object';
+      readonly keys: ReadonlySet<string>;
+      readonly children?: ReadonlyMap<string, NestedKeySpec>;
+    }
+  | { readonly kind: 'record'; readonly entry: NestedKeySpec };
+
+/**
+ * Known keys for the nested config objects a node can carry, keyed by the node
+ * field that holds them. Derived from each sub-schema's shape so a new field
+ * cannot drift out of the set.
+ *
+ * Absent on purpose — these node fields do not silently strip, so there is
+ * nothing to warn about:
+ *   `output_format` — free-form JSON Schema (`z.record`); every key is accepted
+ *   `sandbox`       — `.passthrough()`; unknown keys are preserved, not dropped
+ *   `hooks`         — `.strict()`; unknown keys already hard-error at parse time
+ *   `thinking`      — `z.preprocess` over a union; no object shape to compare
+ *
+ * `loop_group.nodes` is deliberately not modelled here: its entries are full DAG
+ * nodes, so the loader recurses into them with KNOWN_DAG_NODE_KEYS instead.
+ */
+export const KNOWN_NODE_NESTED_KEYS: ReadonlyMap<string, NestedKeySpec> = new Map<
+  string,
+  NestedKeySpec
+>([
+  [
+    'approval',
+    {
+      kind: 'object',
+      keys: new Set(Object.keys(approvalConfigSchema.shape)),
+      children: new Map<string, NestedKeySpec>([
+        ['on_reject', { kind: 'object', keys: new Set(Object.keys(approvalOnRejectSchema.shape)) }],
+      ]),
+    },
+  ],
+  ['retry', { kind: 'object', keys: new Set(Object.keys(stepRetryConfigSchema.shape)) }],
+  ['loop', { kind: 'object', keys: new Set(Object.keys(loopNodeConfigSchema.shape)) }],
+  // loopGroupNodeConfigSchema carries a `z.ZodType<…>` annotation to break the
+  // recursion, which hides `.shape` from TS — rebuild the same set from the
+  // control schema it extends plus its one body field.
+  [
+    'loop_group',
+    { kind: 'object', keys: new Set([...Object.keys(loopControlSchema.shape), 'nodes']) },
+  ],
+  ['pi', { kind: 'object', keys: new Set(Object.keys(piNodeConfigSchema.shape)) }],
+  // `agents` keys are author-chosen agent ids; each VALUE is an agentDefinition,
+  // where a camelCase slip (`disallowed_tools`) silently drops a tool restriction.
+  [
+    'agents',
+    {
+      kind: 'record',
+      entry: { kind: 'object', keys: new Set(Object.keys(agentDefinitionSchema.shape)) },
+    },
+  ],
+]);
 
 // ---------------------------------------------------------------------------
 // dagNodeSchema — flat validation schema with transform to DagNode

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -647,66 +647,61 @@ export const WORKFLOW_NODE_IGNORED_FIELDS: readonly string[] = BASH_NODE_AI_FIEL
   f => f !== 'output_format'
 );
 
+/**
+ * Flat schema with all DAG node fields (base + mode + mode-specific) before
+ * superRefine/transform. Exported so KNOWN_DAG_NODE_KEYS can be derived from
+ * its shape, and for any future use that needs the pre-validation object type.
+ */
+export const dagNodeFlatSchema = dagNodeBaseSchema.extend({
+  // Mode fields (exactly one required)
+  command: z.string().optional(),
+  prompt: z.string().optional(),
+  bash: z.string().optional(),
+  loop: loopNodeConfigSchema.optional(),
+  loop_group: loopGroupNodeConfigSchema.optional(),
+  approval: z
+    .object({
+      message: z.string().min(1, "'approval.message' must not be empty"),
+      capture_response: z.boolean().optional(),
+      on_reject: approvalOnRejectSchema.optional(),
+    })
+    .optional(),
+  cancel: z.string().optional(),
+  // Load-time inlining directive — the target workflow name.
+  include: z.string().min(1, "'include' must be a non-empty workflow name").optional(),
+  // Runtime sub-run directive (#2121 Phase 2) — the child workflow name.
+  workflow: z.string().min(1, "'workflow' must be a non-empty workflow name").optional(),
+  // Sub-run input data string (workflow-var + $node.output substituted) forwarded
+  // as the child's user_message.
+  input: z.string().optional(),
+  // Per-child isolation. `'inherit'` (shared parent checkout) is the default;
+  // `'worktree'` (slice 2, PR-A) runs the child in its own git worktree via an
+  // injected child-isolation resolver.
+  isolation: z.enum(['inherit', 'worktree']).optional(),
+  // Reserved for Phase 1b input mapping. Present only so the superRefine below can
+  // fail fast when it appears on an include or workflow node ("not yet supported").
+  with: z.unknown().optional(),
+  // Script-only
+  script: z.string().optional(),
+  runtime: z.enum(['bun', 'uv']).optional(),
+  deps: z.array(z.string().min(1, 'each dep must be a non-empty string')).optional(),
+  // Bash/Script shared
+  timeout: z.number().optional(),
+});
+
 // ---------------------------------------------------------------------------
 // Known node keys — used by the loader to detect unknown/misplaced keys
 // ---------------------------------------------------------------------------
 
 /**
  * All keys accepted by the flat dagNodeSchema (base + mode-specific + mode-only).
+ * Derived from the dagNodeFlatSchema shape — no hand-maintained list needed.
  * Used by parseDagNode to warn on unknown keys that Zod's default strip would
- * silently drop (#2213). Keep in sync with dagNodeBaseSchema + the .extend()
- * block below.
+ * silently drop (#2213).
  */
-export const KNOWN_DAG_NODE_KEYS: ReadonlySet<string> = new Set([
-  // dagNodeBaseSchema
-  'id',
-  'description',
-  'depends_on',
-  'when',
-  'trigger_rule',
-  'model',
-  'provider',
-  'context',
-  'output_format',
-  'allowed_tools',
-  'denied_tools',
-  'idle_timeout',
-  'retry',
-  'hooks',
-  'mcp',
-  'skills',
-  'agents',
-  'pi',
-  'effort',
-  'thinking',
-  'maxBudgetUsd',
-  'systemPrompt',
-  'fallbackModel',
-  'settingSources',
-  'betas',
-  'sandbox',
-  'always_run',
-  'persist_session',
-  'output_type',
-  // Mode fields (exactly one required)
-  'command',
-  'prompt',
-  'bash',
-  'loop',
-  'loop_group',
-  'approval',
-  'cancel',
-  'include',
-  'workflow',
-  // Mode-specific fields
-  'input',
-  'isolation',
-  'with',
-  'script',
-  'runtime',
-  'deps',
-  'timeout',
-]);
+export const KNOWN_DAG_NODE_KEYS: ReadonlySet<string> = new Set(
+  Object.keys(dagNodeFlatSchema.shape)
+);
 
 // ---------------------------------------------------------------------------
 // dagNodeSchema — flat validation schema with transform to DagNode
@@ -727,47 +722,7 @@ export const KNOWN_DAG_NODE_KEYS: ReadonlySet<string> = new Set([
  * dag-executor.ts (node-level). Model strings are passed through to the SDK
  * unchanged — the SDK is the source of truth for what model names exist.
  */
-export const dagNodeSchema = dagNodeBaseSchema
-  .extend({
-    // Mode fields (exactly one required)
-    command: z.string().optional(),
-    prompt: z.string().optional(),
-    bash: z.string().optional(),
-    loop: loopNodeConfigSchema.optional(),
-    loop_group: loopGroupNodeConfigSchema.optional(),
-    approval: z
-      .object({
-        message: z.string().min(1, "'approval.message' must not be empty"),
-        capture_response: z.boolean().optional(),
-        on_reject: approvalOnRejectSchema.optional(),
-      })
-      .optional(),
-    cancel: z.string().optional(),
-    // Load-time inlining directive — the target workflow name.
-    include: z.string().min(1, "'include' must be a non-empty workflow name").optional(),
-    // Runtime sub-run directive (#2121 Phase 2) — the child workflow name.
-    workflow: z.string().min(1, "'workflow' must be a non-empty workflow name").optional(),
-    // Sub-run input data string (workflow-var + $node.output substituted) forwarded
-    // as the child's user_message.
-    input: z.string().optional(),
-    // Per-child isolation. `'inherit'` (shared parent checkout) is the default;
-    // `'worktree'` (slice 2, PR-A) runs the child in its own git worktree via an
-    // injected child-isolation resolver.
-    isolation: z.enum(['inherit', 'worktree']).optional(),
-    // Dynamic fan-out (slice 2, PR-C) — expand the workflow node into N child runs
-    // over a data-driven item list. Only meaningful on a `workflow:` node (guarded in
-    // superRefine).
-    fan_out: fanOutConfigSchema.optional(),
-    // Reserved for Phase 1b input mapping. Present only so the superRefine below can
-    // fail fast when it appears on an include or workflow node ("not yet supported").
-    with: z.unknown().optional(),
-    // Script-only
-    script: z.string().optional(),
-    runtime: z.enum(['bun', 'uv']).optional(),
-    deps: z.array(z.string().min(1, 'each dep must be a non-empty string')).optional(),
-    // Bash/Script shared
-    timeout: z.number().optional(),
-  })
+export const dagNodeSchema = dagNodeFlatSchema
   .superRefine((data, ctx) => {
     const id = data.id.trim();
 

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -703,72 +703,6 @@ export const KNOWN_DAG_NODE_KEYS: ReadonlySet<string> = new Set(
   Object.keys(dagNodeFlatSchema.shape)
 );
 
-/**
- * Known-key description for a nested config object, one level at a time.
- *
- * `object` — a fixed shape; `keys` are the accepted keys and `children`
- *            describes object-valued keys inside it (e.g. `approval.on_reject`).
- * `record` — author-chosen keys (e.g. `agents`, whose keys are agent ids); only
- *            the VALUES have a fixed shape, described by `entry`.
- */
-export type NestedKeySpec =
-  | {
-      readonly kind: 'object';
-      readonly keys: ReadonlySet<string>;
-      readonly children?: ReadonlyMap<string, NestedKeySpec>;
-    }
-  | { readonly kind: 'record'; readonly entry: NestedKeySpec };
-
-/**
- * Known keys for the nested config objects a node can carry, keyed by the node
- * field that holds them. Derived from each sub-schema's shape so a new field
- * cannot drift out of the set.
- *
- * Absent on purpose — these node fields do not silently strip, so there is
- * nothing to warn about:
- *   `output_format` — free-form JSON Schema (`z.record`); every key is accepted
- *   `sandbox`       — `.passthrough()`; unknown keys are preserved, not dropped
- *   `hooks`         — `.strict()`; unknown keys already hard-error at parse time
- *   `thinking`      — `z.preprocess` over a union; no object shape to compare
- *
- * `loop_group.nodes` is deliberately not modelled here: its entries are full DAG
- * nodes, so the loader recurses into them with KNOWN_DAG_NODE_KEYS instead.
- */
-export const KNOWN_NODE_NESTED_KEYS: ReadonlyMap<string, NestedKeySpec> = new Map<
-  string,
-  NestedKeySpec
->([
-  [
-    'approval',
-    {
-      kind: 'object',
-      keys: new Set(Object.keys(approvalConfigSchema.shape)),
-      children: new Map<string, NestedKeySpec>([
-        ['on_reject', { kind: 'object', keys: new Set(Object.keys(approvalOnRejectSchema.shape)) }],
-      ]),
-    },
-  ],
-  ['retry', { kind: 'object', keys: new Set(Object.keys(stepRetryConfigSchema.shape)) }],
-  ['loop', { kind: 'object', keys: new Set(Object.keys(loopNodeConfigSchema.shape)) }],
-  // loopGroupNodeConfigSchema carries a `z.ZodType<…>` annotation to break the
-  // recursion, which hides `.shape` from TS — rebuild the same set from the
-  // control schema it extends plus its one body field.
-  [
-    'loop_group',
-    { kind: 'object', keys: new Set([...Object.keys(loopControlSchema.shape), 'nodes']) },
-  ],
-  ['pi', { kind: 'object', keys: new Set(Object.keys(piNodeConfigSchema.shape)) }],
-  // `agents` keys are author-chosen agent ids; each VALUE is an agentDefinition,
-  // where a camelCase slip (`disallowed_tools`) silently drops a tool restriction.
-  [
-    'agents',
-    {
-      kind: 'record',
-      entry: { kind: 'object', keys: new Set(Object.keys(agentDefinitionSchema.shape)) },
-    },
-  ],
-]);
-
 // ---------------------------------------------------------------------------
 // dagNodeSchema — flat validation schema with transform to DagNode
 // ---------------------------------------------------------------------------
@@ -1236,3 +1170,88 @@ export function isPersistableNode(node: DagNode): boolean {
     !isWorkflowNode(node)
   );
 }
+
+// ---------------------------------------------------------------------------
+// Nested known-key registry — declared AFTER dagNodeSchema on purpose
+// ---------------------------------------------------------------------------
+//
+// Reading `loopGroupNodeConfigSchema.shape` fires its `nodes` getter, which
+// builds `z.array(dagNodeSchema)`. Placed above `dagNodeSchema` this throws
+// `ReferenceError: Cannot access 'dagNodeSchema' before initialization` at
+// import time — a temporal dead zone tsc does not catch. Keep this block last.
+/**
+ * Known-key description for a nested config object, one level at a time.
+ *
+ * `object` — a fixed shape; `keys` are the accepted keys and `children`
+ *            describes object-valued keys inside it (e.g. `approval.on_reject`).
+ * `record` — author-chosen keys (e.g. `agents`, whose keys are agent ids); only
+ *            the VALUES have a fixed shape, described by `entry`.
+ */
+export type NestedKeySpec =
+  | {
+      readonly kind: 'object';
+      readonly keys: ReadonlySet<string>;
+      readonly children?: ReadonlyMap<string, NestedKeySpec>;
+    }
+  | { readonly kind: 'record'; readonly entry: NestedKeySpec };
+
+/**
+ * `loopGroupNodeConfigSchema` carries a `z.ZodType<…>` annotation to break the
+ * recursion cycle, which hides `.shape` at the TYPE level only — the runtime
+ * value is still the `ZodObject` that `loopControlSchema.extend()` produced.
+ * Casting back recovers the real shape, so the key set stays derived instead of
+ * being a hand-written `[...loopControl, 'nodes']` that a future body field
+ * would silently fall out of.
+ */
+const loopGroupShape = (loopGroupNodeConfigSchema as unknown as z.ZodObject<z.ZodRawShape>).shape;
+
+/**
+ * Known keys for the nested config objects a node can carry, keyed by the node
+ * field that holds them. Derived from each sub-schema's shape so a new field
+ * cannot drift out of the set.
+ *
+ * Absent on purpose — these node fields do not silently strip, so there is
+ * nothing to warn about:
+ *   `output_format` — free-form JSON Schema (`z.record`); every key is accepted
+ *   `sandbox`       — `.passthrough()`; unknown keys are preserved, not dropped
+ *   `hooks`         — `.strict()`; unknown keys already hard-error at parse time
+ *   `thinking`      — `z.preprocess` over a union; no object shape to compare
+ *
+ * `loop_group.nodes` is deliberately not modelled here: its entries are full DAG
+ * nodes, so the loader recurses into them with KNOWN_DAG_NODE_KEYS instead.
+ *
+ * Constructed with `keyof typeof dagNodeFlatSchema.shape` as the key type, not
+ * `string`: a typo'd registration (`'aproval'`) would otherwise compile and
+ * silently disable that nested check forever, indistinguishable from "this
+ * field needs no spec". The exported type widens the key back to `string` so
+ * callers can look up an arbitrary YAML key without a cast — the constraint is
+ * on what can be REGISTERED, which is where drift would come from.
+ */
+export const KNOWN_NODE_NESTED_KEYS: ReadonlyMap<string, NestedKeySpec> = new Map<
+  keyof typeof dagNodeFlatSchema.shape,
+  NestedKeySpec
+>([
+  [
+    'approval',
+    {
+      kind: 'object',
+      keys: new Set(Object.keys(approvalConfigSchema.shape)),
+      children: new Map<string, NestedKeySpec>([
+        ['on_reject', { kind: 'object', keys: new Set(Object.keys(approvalOnRejectSchema.shape)) }],
+      ]),
+    },
+  ],
+  ['retry', { kind: 'object', keys: new Set(Object.keys(stepRetryConfigSchema.shape)) }],
+  ['loop', { kind: 'object', keys: new Set(Object.keys(loopNodeConfigSchema.shape)) }],
+  ['loop_group', { kind: 'object', keys: new Set(Object.keys(loopGroupShape)) }],
+  ['pi', { kind: 'object', keys: new Set(Object.keys(piNodeConfigSchema.shape)) }],
+  // `agents` keys are author-chosen agent ids; each VALUE is an agentDefinition,
+  // where a camelCase slip (`disallowed_tools`) silently drops a tool restriction.
+  [
+    'agents',
+    {
+      kind: 'record',
+      entry: { kind: 'object', keys: new Set(Object.keys(agentDefinitionSchema.shape)) },
+    },
+  ],
+]);

--- a/packages/workflows/src/schemas/index.ts
+++ b/packages/workflows/src/schemas/index.ts
@@ -61,6 +61,8 @@ export {
   INCLUDE_NODE_IGNORED_FIELDS,
   WORKFLOW_NODE_IGNORED_FIELDS,
   KNOWN_DAG_NODE_KEYS,
+  KNOWN_NODE_NESTED_KEYS,
+  approvalConfigSchema,
   dagNodeFlatSchema,
   effortLevelSchema,
   thinkingConfigSchema,
@@ -90,6 +92,7 @@ export type {
   SandboxSettings,
   AgentDefinition,
   PiNodeConfig,
+  NestedKeySpec,
 } from './dag-node';
 
 // Workflow definition
@@ -101,6 +104,7 @@ export {
   workflowBaseSchema,
   workflowDefinitionSchema,
   KNOWN_WORKFLOW_KEYS,
+  KNOWN_WORKFLOW_NESTED_KEYS,
   WORKFLOW_ONLY_KEYS,
 } from './workflow';
 export type {

--- a/packages/workflows/src/schemas/index.ts
+++ b/packages/workflows/src/schemas/index.ts
@@ -60,6 +60,7 @@ export {
   LOOP_GROUP_NODE_AI_FIELDS,
   INCLUDE_NODE_IGNORED_FIELDS,
   WORKFLOW_NODE_IGNORED_FIELDS,
+  KNOWN_DAG_NODE_KEYS,
   effortLevelSchema,
   thinkingConfigSchema,
   sandboxSettingsSchema,
@@ -98,6 +99,8 @@ export {
   workflowEvidencePolicySchema,
   workflowBaseSchema,
   workflowDefinitionSchema,
+  KNOWN_WORKFLOW_KEYS,
+  WORKFLOW_ONLY_KEYS,
 } from './workflow';
 export type {
   ModelReasoningEffort,

--- a/packages/workflows/src/schemas/index.ts
+++ b/packages/workflows/src/schemas/index.ts
@@ -61,6 +61,7 @@ export {
   INCLUDE_NODE_IGNORED_FIELDS,
   WORKFLOW_NODE_IGNORED_FIELDS,
   KNOWN_DAG_NODE_KEYS,
+  dagNodeFlatSchema,
   effortLevelSchema,
   thinkingConfigSchema,
   sandboxSettingsSchema,

--- a/packages/workflows/src/schemas/workflow.ts
+++ b/packages/workflows/src/schemas/workflow.ts
@@ -158,6 +158,58 @@ export const workflowBaseSchema = z.object({
 export type WorkflowBase = z.infer<typeof workflowBaseSchema>;
 
 // ---------------------------------------------------------------------------
+// Known workflow keys — used by the loader to detect unknown/misplaced keys
+// ---------------------------------------------------------------------------
+
+/**
+ * All keys accepted at the workflow level (workflowBaseSchema + nodes).
+ * Used by parseWorkflow to warn on unknown keys (#2213). Keep in sync with
+ * workflowBaseSchema + workflowDefinitionSchema.
+ */
+export const KNOWN_WORKFLOW_KEYS: ReadonlySet<string> = new Set([
+  'name',
+  'description',
+  'provider',
+  'model',
+  'modelReasoningEffort',
+  'webSearchMode',
+  'interactive',
+  'effort',
+  'thinking',
+  'fallbackModel',
+  'betas',
+  'sandbox',
+  'worktree',
+  'container',
+  'evidence_policy',
+  'mutates_checkout',
+  'persist_sessions',
+  'tags',
+  'requires',
+  'nodes',
+]);
+
+/**
+ * Workflow-only keys that are not valid on individual nodes. Used to produce a
+ * precise hint when a workflow-level key is misplaced on a node (#2213).
+ */
+export const WORKFLOW_ONLY_KEYS: ReadonlySet<string> = new Set([
+  'name',
+  'description',
+  'interactive',
+  'webSearchMode',
+  'modelReasoningEffort',
+  'worktree',
+  'container',
+  'evidence_policy',
+  'mutates_checkout',
+  'persist_sessions',
+  'tags',
+  'requires',
+  'nodes',
+]);
+
+// ---------------------------------------------------------------------------
 // WorkflowDefinition — DAG-based workflow with nodes
 // ---------------------------------------------------------------------------
 
@@ -219,6 +271,8 @@ export type WorkflowSource = 'bundled' | 'global' | 'project';
 export interface WorkflowWithSource {
   readonly workflow: WorkflowDefinition;
   readonly source: WorkflowSource;
+  /** Warnings from YAML parsing (e.g. unknown keys) — never hard-fails. */
+  readonly parseWarnings?: readonly string[];
 }
 
 /**

--- a/packages/workflows/src/schemas/workflow.ts
+++ b/packages/workflows/src/schemas/workflow.ts
@@ -11,6 +11,7 @@ import {
   betasSchema,
   KNOWN_DAG_NODE_KEYS,
 } from './dag-node';
+import type { NestedKeySpec } from './dag-node';
 
 // ---------------------------------------------------------------------------
 // Shared enum schemas
@@ -194,6 +195,31 @@ export const KNOWN_WORKFLOW_KEYS: ReadonlySet<string> = new Set(
 export const WORKFLOW_ONLY_KEYS: ReadonlySet<string> = new Set(
   [...KNOWN_WORKFLOW_KEYS].filter(k => !KNOWN_DAG_NODE_KEYS.has(k))
 );
+
+/**
+ * Known keys for the nested config objects a workflow can carry, keyed by the
+ * workflow-level field that holds them. Same purpose and same derivation as
+ * KNOWN_NODE_NESTED_KEYS — an unknown key one level down is stripped just as
+ * silently as one at the top (#2213).
+ *
+ * `sandbox` (`.passthrough()`) and `thinking` (`z.preprocess`) are omitted for
+ * the same reasons they are omitted at node level. `nodes` is handled by the
+ * per-node check, not here.
+ */
+export const KNOWN_WORKFLOW_NESTED_KEYS: ReadonlyMap<string, NestedKeySpec> = new Map<
+  string,
+  NestedKeySpec
+>([
+  ['worktree', { kind: 'object', keys: new Set(Object.keys(workflowWorktreePolicySchema.shape)) }],
+  [
+    'container',
+    { kind: 'object', keys: new Set(Object.keys(workflowContainerPolicySchema.shape)) },
+  ],
+  [
+    'evidence_policy',
+    { kind: 'object', keys: new Set(Object.keys(workflowEvidencePolicySchema.shape)) },
+  ],
+]);
 
 // ---------------------------------------------------------------------------
 // LoadCommandResult — discriminated union for command load outcomes

--- a/packages/workflows/src/schemas/workflow.ts
+++ b/packages/workflows/src/schemas/workflow.ts
@@ -205,9 +205,14 @@ export const WORKFLOW_ONLY_KEYS: ReadonlySet<string> = new Set(
  * `sandbox` (`.passthrough()`) and `thinking` (`z.preprocess`) are omitted for
  * the same reasons they are omitted at node level. `nodes` is handled by the
  * per-node check, not here.
+ *
+ * Constructed with `keyof typeof workflowDefinitionSchema.shape` as the key type
+ * so a typo'd registration fails to compile rather than silently disabling the
+ * check; the exported type widens back to `string` for lookup (same split as
+ * KNOWN_NODE_NESTED_KEYS).
  */
 export const KNOWN_WORKFLOW_NESTED_KEYS: ReadonlyMap<string, NestedKeySpec> = new Map<
-  string,
+  keyof typeof workflowDefinitionSchema.shape,
   NestedKeySpec
 >([
   ['worktree', { kind: 'object', keys: new Set(Object.keys(workflowWorktreePolicySchema.shape)) }],

--- a/packages/workflows/src/schemas/workflow.ts
+++ b/packages/workflows/src/schemas/workflow.ts
@@ -9,6 +9,7 @@ import {
   thinkingConfigSchema,
   sandboxSettingsSchema,
   betasSchema,
+  KNOWN_DAG_NODE_KEYS,
 } from './dag-node';
 
 // ---------------------------------------------------------------------------
@@ -158,58 +159,6 @@ export const workflowBaseSchema = z.object({
 export type WorkflowBase = z.infer<typeof workflowBaseSchema>;
 
 // ---------------------------------------------------------------------------
-// Known workflow keys — used by the loader to detect unknown/misplaced keys
-// ---------------------------------------------------------------------------
-
-/**
- * All keys accepted at the workflow level (workflowBaseSchema + nodes).
- * Used by parseWorkflow to warn on unknown keys (#2213). Keep in sync with
- * workflowBaseSchema + workflowDefinitionSchema.
- */
-export const KNOWN_WORKFLOW_KEYS: ReadonlySet<string> = new Set([
-  'name',
-  'description',
-  'provider',
-  'model',
-  'modelReasoningEffort',
-  'webSearchMode',
-  'interactive',
-  'effort',
-  'thinking',
-  'fallbackModel',
-  'betas',
-  'sandbox',
-  'worktree',
-  'container',
-  'evidence_policy',
-  'mutates_checkout',
-  'persist_sessions',
-  'tags',
-  'requires',
-  'nodes',
-]);
-
-/**
- * Workflow-only keys that are not valid on individual nodes. Used to produce a
- * precise hint when a workflow-level key is misplaced on a node (#2213).
- */
-export const WORKFLOW_ONLY_KEYS: ReadonlySet<string> = new Set([
-  'name',
-  'description',
-  'interactive',
-  'webSearchMode',
-  'modelReasoningEffort',
-  'worktree',
-  'container',
-  'evidence_policy',
-  'mutates_checkout',
-  'persist_sessions',
-  'tags',
-  'requires',
-  'nodes',
-]);
-
-// ---------------------------------------------------------------------------
 // WorkflowDefinition — DAG-based workflow with nodes
 // ---------------------------------------------------------------------------
 
@@ -223,6 +172,28 @@ export const workflowDefinitionSchema = workflowBaseSchema.extend({
 
 /** Workflow definition with fully typed nodes (DagNode[]) derived from the schema. */
 export type WorkflowDefinition = z.infer<typeof workflowDefinitionSchema> & { prompt?: never };
+
+// ---------------------------------------------------------------------------
+// Known workflow keys — used by the loader to detect unknown/misplaced keys
+// ---------------------------------------------------------------------------
+
+/**
+ * All keys accepted at the workflow level.
+ * Derived from workflowDefinitionSchema shape — no hand-maintained list needed.
+ * Used by parseWorkflow to warn on unknown keys (#2213).
+ */
+export const KNOWN_WORKFLOW_KEYS: ReadonlySet<string> = new Set(
+  Object.keys(workflowDefinitionSchema.shape)
+);
+
+/**
+ * Workflow-only keys that are not valid on individual nodes. Used to produce a
+ * precise hint when a workflow-level key is misplaced on a node (#2213).
+ * Computed as the difference between workflow keys and node keys.
+ */
+export const WORKFLOW_ONLY_KEYS: ReadonlySet<string> = new Set(
+  [...KNOWN_WORKFLOW_KEYS].filter(k => !KNOWN_DAG_NODE_KEYS.has(k))
+);
 
 // ---------------------------------------------------------------------------
 // LoadCommandResult — discriminated union for command load outcomes

--- a/packages/workflows/src/store.ts
+++ b/packages/workflows/src/store.ts
@@ -80,6 +80,12 @@ export const WORKFLOW_EVENT_TYPES = [
   // `$ARTIFACTS_DIR/evidence.json` was absent at completion time — the run was
   // refused terminal `completed` and marked failed. Data carries the expected path.
   'evidence_validation_failed',
+  // #2213 — keys the engine dropped from this run's workflow YAML. Written by the
+  // executor at run start for EVERY run that has them, whatever surface started
+  // it, so the record does not depend on a chat/console notification being
+  // deliverable. `data.warnings` is the message list. Absence means the YAML was
+  // clean OR the run predates this event type — never that delivery failed.
+  'workflow_parse_warnings',
 ] as const;
 
 export type WorkflowEventType = (typeof WORKFLOW_EVENT_TYPES)[number];

--- a/packages/workflows/src/test-utils.ts
+++ b/packages/workflows/src/test-utils.ts
@@ -27,7 +27,12 @@ export function makeTestWorkflowList(names: string[]): WorkflowDefinition[] {
 /** Wrap a WorkflowDefinition as a WorkflowWithSource entry for test mocks. */
 export function makeTestWorkflowWithSource(
   overrides: TestWorkflowOverrides,
-  source: WorkflowSource = 'bundled'
+  source: WorkflowSource = 'bundled',
+  parseWarnings?: readonly string[]
 ): WorkflowWithSource {
-  return { workflow: makeTestWorkflow(overrides), source };
+  return {
+    workflow: makeTestWorkflow(overrides),
+    source,
+    ...(parseWarnings ? { parseWarnings } : {}),
+  };
 }

--- a/packages/workflows/src/workflow-discovery.ts
+++ b/packages/workflows/src/workflow-discovery.ts
@@ -331,6 +331,13 @@ export async function discoverWorkflows(
     for (const [filename, warnings] of result.parseWarnings) {
       allParseWarnings.set(filename, warnings);
     }
+    // Clear stale warnings for overridden filenames that have no warnings in the
+    // new scope (a clean project file should not inherit bundled-scope warnings).
+    for (const filename of result.workflows.keys()) {
+      if (!result.parseWarnings.has(filename)) {
+        allParseWarnings.delete(filename);
+      }
+    }
   };
   const allErrors: WorkflowLoadError[] = [];
 

--- a/packages/workflows/src/workflow-discovery.ts
+++ b/packages/workflows/src/workflow-discovery.ts
@@ -79,6 +79,8 @@ async function maybeWarnLegacyHomePath(): Promise<void> {
 interface DirLoadResult {
   workflows: Map<string, WorkflowDefinition>;
   errors: WorkflowLoadError[];
+  /** Parse warnings keyed by workflow filename (e.g. unknown keys). */
+  parseWarnings: Map<string, string[]>;
 }
 
 // `MAX_DISCOVERY_DEPTH` (= 1: one level of grouping, e.g.
@@ -96,6 +98,7 @@ interface DirLoadResult {
 async function loadWorkflowsFromDir(dirPath: string, depth = 0): Promise<DirLoadResult> {
   const workflows = new Map<string, WorkflowDefinition>();
   const errors: WorkflowLoadError[] = [];
+  const parseWarnings = new Map<string, string[]>();
 
   try {
     const entries = await readdir(dirPath);
@@ -115,6 +118,9 @@ async function loadWorkflowsFromDir(dirPath: string, depth = 0): Promise<DirLoad
           for (const [filename, workflow] of subResult.workflows) {
             workflows.set(filename, workflow);
           }
+          for (const [filename, warnings] of subResult.parseWarnings) {
+            parseWarnings.set(filename, warnings);
+          }
           errors.push(...subResult.errors);
         } else if (entry.endsWith('.yaml') || entry.endsWith('.yml')) {
           const content = await readFile(entryPath, 'utf-8');
@@ -122,6 +128,9 @@ async function loadWorkflowsFromDir(dirPath: string, depth = 0): Promise<DirLoad
 
           if (result.workflow) {
             workflows.set(entry, result.workflow);
+            if (result.warnings.length > 0) {
+              parseWarnings.set(entry, result.warnings);
+            }
             getLog().debug({ workflowName: result.workflow.name, dirPath }, 'workflow_loaded');
           } else {
             errors.push(result.error);
@@ -151,7 +160,7 @@ async function loadWorkflowsFromDir(dirPath: string, depth = 0): Promise<DirLoad
     }
   }
 
-  return { workflows, errors };
+  return { workflows, errors, parseWarnings };
 }
 
 /**
@@ -164,12 +173,16 @@ async function loadWorkflowsFromDir(dirPath: string, depth = 0): Promise<DirLoad
 function loadBundledWorkflows(): DirLoadResult {
   const workflows = new Map<string, WorkflowDefinition>();
   const errors: WorkflowLoadError[] = [];
+  const parseWarnings = new Map<string, string[]>();
 
   for (const [name, content] of Object.entries(BUNDLED_WORKFLOWS)) {
     const filename = `${name}.yaml`;
     const result = parseWorkflow(content, filename);
     if (result.workflow) {
       workflows.set(filename, result.workflow);
+      if (result.warnings.length > 0) {
+        parseWarnings.set(filename, result.warnings);
+      }
       getLog().debug({ workflowName: result.workflow.name }, 'bundled_workflow_loaded');
     } else {
       // Bundled workflows should ALWAYS be valid - this indicates a build-time error
@@ -181,7 +194,7 @@ function loadBundledWorkflows(): DirLoadResult {
     }
   }
 
-  return { workflows, errors };
+  return { workflows, errors, parseWarnings };
 }
 
 /**
@@ -310,6 +323,15 @@ export async function discoverWorkflows(
 ): Promise<WorkflowLoadResult> {
   // Map of filename -> workflow+source for deduplication
   const workflowsByFile = new Map<string, WorkflowWithSource>();
+  // Parse warnings keyed by filename (unknown keys, misplaced fields)
+  const allParseWarnings = new Map<string, string[]>();
+
+  /** Merge a discovery result's parse warnings into the cumulative map. */
+  const mergeWarnings = (result: DirLoadResult): void => {
+    for (const [filename, warnings] of result.parseWarnings) {
+      allParseWarnings.set(filename, warnings);
+    }
+  };
   const allErrors: WorkflowLoadError[] = [];
 
   /**
@@ -381,11 +403,16 @@ export async function discoverWorkflows(
     );
 
     const result: WorkflowWithSource[] = [];
-    for (const { workflow, source } of workflowsByFile.values()) {
+    for (const [filename, { workflow, source }] of workflowsByFile) {
       if (duplicateNames.has(workflow.name)) continue; // dropped as a duplicate-name collision
       const expanded = expandedByName.get(workflow.name);
       if (!expanded) continue; // expansion failed for this workflow — drop it
-      result.push({ workflow: expanded, source });
+      const pw = allParseWarnings.get(filename);
+      result.push({
+        workflow: expanded,
+        source,
+        ...(pw && pw.length > 0 ? { parseWarnings: pw } : {}),
+      });
     }
     return result;
   };
@@ -400,6 +427,7 @@ export async function discoverWorkflows(
       for (const [filename, workflow] of bundledResult.workflows) {
         workflowsByFile.set(filename, { workflow, source: 'bundled' });
       }
+      mergeWarnings(bundledResult);
       allErrors.push(...bundledResult.errors);
       getLog().info({ count: bundledResult.workflows.size }, 'bundled_default_workflows_loaded');
     } else {
@@ -412,6 +440,7 @@ export async function discoverWorkflows(
         for (const [filename, workflow] of appResult.workflows) {
           workflowsByFile.set(filename, { workflow, source: 'bundled' });
         }
+        mergeWarnings(appResult);
         if (appResult.errors.length > 0) {
           getLog().warn(
             { errorCount: appResult.errors.length, errors: appResult.errors },
@@ -446,6 +475,7 @@ export async function discoverWorkflows(
       workflowsByFile.set(filename, { workflow, source: 'global' });
     }
     allErrors.push(...homeResult.errors);
+    mergeWarnings(homeResult);
     getLog().info({ count: homeResult.workflows.size }, 'home_workflows_loaded');
   } catch (error) {
     const err = error as NodeJS.ErrnoException;
@@ -500,6 +530,7 @@ export async function discoverWorkflows(
 
     // Surface repo workflow errors to users (these are actionable)
     allErrors.push(...repoResult.errors);
+    mergeWarnings(repoResult);
 
     // Warn about deprecated non-prefixed defaults in repo's defaults folder
     const repoDefaultsPath = join(cwd, workflowFolder, 'defaults');

--- a/packages/workflows/src/workflow-discovery.ts
+++ b/packages/workflows/src/workflow-discovery.ts
@@ -23,6 +23,7 @@ import type {
   WorkflowLoadError,
   WorkflowLoadResult,
   WorkflowWithSource,
+  WorkflowSource,
 } from './schemas';
 import { isIncludeNode } from './schemas';
 import * as archonPaths from '@archon/paths';
@@ -76,11 +77,27 @@ async function maybeWarnLegacyHomePath(): Promise<void> {
   getLog().warn({ legacyPath, newPath, moveCommand }, 'workflow.legacy_home_path_detected');
 }
 
+/**
+ * One parsed workflow file: its definition plus the non-fatal warnings raised
+ * parsing it (unknown keys — #2213).
+ *
+ * The warnings live ON the entry rather than in a map beside it deliberately.
+ * Overrides here are last-writer-wins by bare filename, and a filename can
+ * legitimately appear twice (root and a 1-level subfolder). With two parallel
+ * maps the winner's definition and the loser's warnings could survive together,
+ * telling an author a clean workflow declares a key it does not contain. One
+ * value means a single `Map.set()` replaces both halves atomically, so they
+ * cannot disagree.
+ */
+interface ParsedWorkflowFile {
+  workflow: WorkflowDefinition;
+  /** Empty for a clean file. */
+  parseWarnings: readonly string[];
+}
+
 interface DirLoadResult {
-  workflows: Map<string, WorkflowDefinition>;
+  workflows: Map<string, ParsedWorkflowFile>;
   errors: WorkflowLoadError[];
-  /** Parse warnings keyed by workflow filename (e.g. unknown keys). */
-  parseWarnings: Map<string, string[]>;
 }
 
 // `MAX_DISCOVERY_DEPTH` (= 1: one level of grouping, e.g.
@@ -96,9 +113,8 @@ interface DirLoadResult {
  * Failures are per-file: one broken file does not abort loading the rest.
  */
 async function loadWorkflowsFromDir(dirPath: string, depth = 0): Promise<DirLoadResult> {
-  const workflows = new Map<string, WorkflowDefinition>();
+  const workflows = new Map<string, ParsedWorkflowFile>();
   const errors: WorkflowLoadError[] = [];
-  const parseWarnings = new Map<string, string[]>();
 
   try {
     const entries = await readdir(dirPath);
@@ -115,11 +131,8 @@ async function loadWorkflowsFromDir(dirPath: string, depth = 0): Promise<DirLoad
           // `findMarkdownFilesRecursive` depth cap).
           if (depth >= MAX_DISCOVERY_DEPTH) continue;
           const subResult = await loadWorkflowsFromDir(entryPath, depth + 1);
-          for (const [filename, workflow] of subResult.workflows) {
-            workflows.set(filename, workflow);
-          }
-          for (const [filename, warnings] of subResult.parseWarnings) {
-            parseWarnings.set(filename, warnings);
+          for (const [filename, parsed] of subResult.workflows) {
+            workflows.set(filename, parsed);
           }
           errors.push(...subResult.errors);
         } else if (entry.endsWith('.yaml') || entry.endsWith('.yml')) {
@@ -127,10 +140,7 @@ async function loadWorkflowsFromDir(dirPath: string, depth = 0): Promise<DirLoad
           const result = parseWorkflow(content, entry);
 
           if (result.workflow) {
-            workflows.set(entry, result.workflow);
-            if (result.warnings.length > 0) {
-              parseWarnings.set(entry, result.warnings);
-            }
+            workflows.set(entry, { workflow: result.workflow, parseWarnings: result.warnings });
             getLog().debug({ workflowName: result.workflow.name, dirPath }, 'workflow_loaded');
           } else {
             errors.push(result.error);
@@ -160,7 +170,7 @@ async function loadWorkflowsFromDir(dirPath: string, depth = 0): Promise<DirLoad
     }
   }
 
-  return { workflows, errors, parseWarnings };
+  return { workflows, errors };
 }
 
 /**
@@ -171,18 +181,14 @@ async function loadWorkflowsFromDir(dirPath: string, depth = 0): Promise<DirLoad
  * Parse failures indicate a build-time corruption and are logged as errors.
  */
 function loadBundledWorkflows(): DirLoadResult {
-  const workflows = new Map<string, WorkflowDefinition>();
+  const workflows = new Map<string, ParsedWorkflowFile>();
   const errors: WorkflowLoadError[] = [];
-  const parseWarnings = new Map<string, string[]>();
 
   for (const [name, content] of Object.entries(BUNDLED_WORKFLOWS)) {
     const filename = `${name}.yaml`;
     const result = parseWorkflow(content, filename);
     if (result.workflow) {
-      workflows.set(filename, result.workflow);
-      if (result.warnings.length > 0) {
-        parseWarnings.set(filename, result.warnings);
-      }
+      workflows.set(filename, { workflow: result.workflow, parseWarnings: result.warnings });
       getLog().debug({ workflowName: result.workflow.name }, 'bundled_workflow_loaded');
     } else {
       // Bundled workflows should ALWAYS be valid - this indicates a build-time error
@@ -194,7 +200,7 @@ function loadBundledWorkflows(): DirLoadResult {
     }
   }
 
-  return { workflows, errors, parseWarnings };
+  return { workflows, errors };
 }
 
 /**
@@ -321,24 +327,10 @@ export async function discoverWorkflows(
   cwd: string | null,
   options?: { loadDefaults?: boolean; commandFolder?: string; loadDefaultCommands?: boolean }
 ): Promise<WorkflowLoadResult> {
-  // Map of filename -> workflow+source for deduplication
-  const workflowsByFile = new Map<string, WorkflowWithSource>();
-  // Parse warnings keyed by filename (unknown keys, misplaced fields)
-  const allParseWarnings = new Map<string, string[]>();
-
-  /** Merge a discovery result's parse warnings into the cumulative map. */
-  const mergeWarnings = (result: DirLoadResult): void => {
-    for (const [filename, warnings] of result.parseWarnings) {
-      allParseWarnings.set(filename, warnings);
-    }
-    // Clear stale warnings for overridden filenames that have no warnings in the
-    // new scope (a clean project file should not inherit bundled-scope warnings).
-    for (const filename of result.workflows.keys()) {
-      if (!result.parseWarnings.has(filename)) {
-        allParseWarnings.delete(filename);
-      }
-    }
-  };
+  // Map of filename -> workflow + source + parse warnings, for deduplication.
+  // A later scope's `set()` replaces all three together, so a clean project file
+  // can never inherit the bundled file's warnings (see ParsedWorkflowFile).
+  const workflowsByFile = new Map<string, ParsedWorkflowFile & { source: WorkflowSource }>();
   const allErrors: WorkflowLoadError[] = [];
 
   /**
@@ -410,15 +402,16 @@ export async function discoverWorkflows(
     );
 
     const result: WorkflowWithSource[] = [];
-    for (const [filename, { workflow, source }] of workflowsByFile) {
+    for (const { workflow, source, parseWarnings } of workflowsByFile.values()) {
       if (duplicateNames.has(workflow.name)) continue; // dropped as a duplicate-name collision
       const expanded = expandedByName.get(workflow.name);
       if (!expanded) continue; // expansion failed for this workflow — drop it
-      const pw = allParseWarnings.get(filename);
       result.push({
         workflow: expanded,
         source,
-        ...(pw && pw.length > 0 ? { parseWarnings: pw } : {}),
+        // Omitted rather than empty, matching the `errors` field on the same
+        // surfaces: presence alone is the signal.
+        ...(parseWarnings && parseWarnings.length > 0 ? { parseWarnings } : {}),
       });
     }
     return result;
@@ -431,10 +424,9 @@ export async function discoverWorkflows(
       // Binary: load from embedded bundled content
       getLog().debug('loading_bundled_default_workflows');
       const bundledResult = loadBundledWorkflows();
-      for (const [filename, workflow] of bundledResult.workflows) {
-        workflowsByFile.set(filename, { workflow, source: 'bundled' });
+      for (const [filename, parsed] of bundledResult.workflows) {
+        workflowsByFile.set(filename, { ...parsed, source: 'bundled' });
       }
-      mergeWarnings(bundledResult);
       allErrors.push(...bundledResult.errors);
       getLog().info({ count: bundledResult.workflows.size }, 'bundled_default_workflows_loaded');
     } else {
@@ -444,10 +436,9 @@ export async function discoverWorkflows(
       try {
         await access(appDefaultsPath);
         const appResult = await loadWorkflowsFromDir(appDefaultsPath);
-        for (const [filename, workflow] of appResult.workflows) {
-          workflowsByFile.set(filename, { workflow, source: 'bundled' });
+        for (const [filename, parsed] of appResult.workflows) {
+          workflowsByFile.set(filename, { ...parsed, source: 'bundled' });
         }
-        mergeWarnings(appResult);
         if (appResult.errors.length > 0) {
           getLog().warn(
             { errorCount: appResult.errors.length, errors: appResult.errors },
@@ -475,14 +466,13 @@ export async function discoverWorkflows(
   try {
     await access(homeWorkflowPath);
     const homeResult = await loadWorkflowsFromDir(homeWorkflowPath);
-    for (const [filename, workflow] of homeResult.workflows) {
+    for (const [filename, parsed] of homeResult.workflows) {
       if (workflowsByFile.has(filename)) {
         getLog().debug({ filename }, 'home_workflow_overrides_bundled');
       }
-      workflowsByFile.set(filename, { workflow, source: 'global' });
+      workflowsByFile.set(filename, { ...parsed, source: 'global' });
     }
     allErrors.push(...homeResult.errors);
-    mergeWarnings(homeResult);
     getLog().info({ count: homeResult.workflows.size }, 'home_workflows_loaded');
   } catch (error) {
     const err = error as NodeJS.ErrnoException;
@@ -517,13 +507,13 @@ export async function discoverWorkflows(
     // Repo workflows override bundled AND home scope by exact filename match.
     // Preserve 'bundled' source for workflows loaded from the defaults/ subdirectory
     // that were already registered as bundled in step 1.
-    for (const [filename, workflow] of repoResult.workflows) {
+    for (const [filename, parsed] of repoResult.workflows) {
       const existing = workflowsByFile.get(filename);
       if (existing?.source === 'bundled') {
         // This file was already loaded as a bundled default — the repo's defaults/
         // subdirectory is re-discovering it. Keep the bundled source label.
         getLog().debug({ filename }, 'repo_default_preserves_bundled_source');
-        workflowsByFile.set(filename, { workflow, source: 'bundled' });
+        workflowsByFile.set(filename, { ...parsed, source: 'bundled' });
       } else {
         if (existing) {
           getLog().debug(
@@ -531,13 +521,12 @@ export async function discoverWorkflows(
             'repo_workflow_overrides_lower_scope'
           );
         }
-        workflowsByFile.set(filename, { workflow, source: 'project' });
+        workflowsByFile.set(filename, { ...parsed, source: 'project' });
       }
     }
 
     // Surface repo workflow errors to users (these are actionable)
     allErrors.push(...repoResult.errors);
-    mergeWarnings(repoResult);
 
     // Warn about deprecated non-prefixed defaults in repo's defaults folder
     const repoDefaultsPath = join(cwd, workflowFolder, 'defaults');


### PR DESCRIPTION
> **Builds on #2255 by @kagura-agent.** Their four commits are cherry-picked here with authorship intact; this branch lives in the main repo rather than on their fork so their branch is not pushed to. Three commits are added on top. The maintainer decides afterwards whether this lands here or as a push to the fork.
>
> The unrelated e2e YAML edits from #2255 (commit `71dddc2`, four files fixing a different pre-existing validator warning and deleting an explanatory comment) are **dropped** — they are not this change.

## Summary

- **Problem:** Zod strips unknown keys from workflow YAML silently. An author who writes `interactive: true` on a command node believing it creates a human gate gets no feedback, and the workflow runs unattended past what was meant to be an approval step (#2213). #2255 started emitting warnings for this, but `parseWarnings` had **exactly one consumer in the tree** — `archon validate workflows`, which is not part of `bun run validate` and which nothing requires an author to run. On every other surface the warning was degraded, silent, or dropped.
- **Why it matters:** Validation blessed a safety property that did not exist, and the fix reported it somewhere nobody looks.
- **What changed:** (1) warnings now reach every surface an author actually uses; (2) the run-path log line carries the prose, not just a payload and an event name; (3) the `interactive` hint was **wrong** and is corrected; (4) detection extended one level down, including into `loop_group` body nodes.
- **What did *not* change (scope boundary):** The posture stays **warn, not reject** — unknown keys are still stripped and the workflow still loads and runs. No change to how any key is parsed or executed. No new node fields, no YAML surface additions.

### On the "warn rather than reject" justification

The original PR justified this as forward-compatibility. That is not Archon's posture — `steps:` hard-errors, `hooks:` is `.strict()`, `with:`/`retry:`/`isolation` all fail fast. The correct justification is **precedent**: `archon validate workflows` already carries a non-blocking warning framework for silently-ignored input (`[bash] double-quoting a substitution that is already shell-quoted`, `[hooks] not supported by provider 'opencode' — this will be ignored`, `[denied_tools] Task was renamed to Agent`). This adds one more class to that existing surface.

## UX Journey

### Before

```
  Author                     Archon                         Where it showed up
  ──────                     ──────                         ──────────────────
  writes `interactive: true`
  on a command node
                        ──▶  Zod strips the key
                             loader records a warning
                             string in parseWarnings

  archon validate workflows   ─────────────────────────────▶ full message ✓
                                                             (but not in `bun run validate`,
                                                              and nothing requires running it)
  archon workflow run         ─────────────────────────────▶ one log line: {id, key}
                                                             + event name. No prose, no hint.
  archon workflow run --json  ─────────────────────────────▶ SILENT (log level = silent)
                                                             ← the channel the chat agent
                                                               drives runs through
  /workflow list (chat)       ─────────────────────────────▶ nothing
  console / web               ─────────────────────────────▶ DROPPED
                                                             (api.ts mapped ws => {workflow, source})

  run proceeds unattended past the "gate" the author thought they wrote
```

### After

```
  Author                     Archon                         Where it shows up
  ──────                     ──────                         ─────────────────
  writes `interactive: true`
  on a command node
                        ──▶  Zod strips the key
                             loader records the warning
                             [+ descends into nested blocks
                                and loop_group body nodes]

  archon validate workflows   ─────────────────────────────▶ full message ✓ [*corrected hint*]
  archon workflow list        ─────────────────────────────▶ [*inline under the workflow*]
  archon workflow list --json ─────────────────────────────▶ [*parseWarnings on the entry*]
  archon workflow run         ─────────────────────────────▶ [*stderr notice, scoped to THIS
                                                              workflow, before the run starts*]
                                                             + log line now carries the prose
  archon workflow run --json  ─────────────────────────────▶ [*stderr notice — stdout stays
                                                              exactly the JSON payload*]
  /workflow list (chat)       ─────────────────────────────▶ [*⚠ inline with the workflow*]
  console workflow picker     ─────────────────────────────▶ [*⚠ marker on the row,
                                                              full text in the tooltip*]
```

## Architecture Diagram

### Before

```
  loader.ts ──parseWarnings──▶ workflow-discovery.ts ──▶ WorkflowWithSource.parseWarnings
                                                              │
                                                              ├──▶ cli/validate.ts        ✓ ONLY consumer
                                                              ├──▶ cli/workflow.ts        (ignored)
                                                              ├──▶ core/command-handler   (ignored)
                                                              └──▶ server/api.ts          (dropped in map)
                                                                        │
                                                                        └──▶ web/console  (never sees it)
```

### After

```
  schemas/dag-node.ts [~]  KNOWN_DAG_NODE_KEYS
                           [+] NestedKeySpec, KNOWN_NODE_NESTED_KEYS
                           [+] approvalConfigSchema (extracted so its .shape is nameable)
       │  derives from .shape of: approvalConfig, approvalOnReject, stepRetryConfig,
       │                          loopNodeConfig, loopControl, piNodeConfig, agentDefinition
       ▼
  schemas/workflow.ts [~]  KNOWN_WORKFLOW_KEYS, WORKFLOW_ONLY_KEYS
                           [+] KNOWN_WORKFLOW_NESTED_KEYS
       │                        (worktreePolicy, containerPolicy, evidencePolicy)
       ▼
  loader.ts [~] ═══ collectUnknownNodeKeys ──recurses──▶ loop_group.nodes[*] (full DAG nodes)
                ═══ collectUnknownConfigKeys ──recurses──▶ nested blocks, incl. agents.<id>.*
                ═══ unknownNodeKeyHint (interactive hint CORRECTED)
                ═══ pushUnknownKeyWarning (log line now carries the prose)
       │
       ▼
  workflow-discovery.ts (unchanged)  ──▶ WorkflowWithSource.parseWarnings
       │
       ├──▶ cli/validate.ts        ✓ unchanged
       ├──▶ cli/workflow.ts   [~] ═══ emitParseWarnings() on run (stderr) + list (inline/json)
       ├──▶ core/command-handler [~] ═══ /workflow list renders ⚠ inline
       └──▶ server/api.ts     [~] ═══ parseWarnings carried in the response
                 │                     (+ workflow.schemas.ts [~] response schema)
                 └──▶ web/console [~] ═══ primitives/workflow.ts maps it
                                    ═══ WorkflowPicker.tsx renders the ⚠ marker
```

**Connection inventory**

| From | To | Status | Notes |
|------|----|--------|-------|
| `schemas/dag-node.ts` | `schemas/loop.ts`, `schemas/retry.ts` | unchanged | already imported; now also read for `.shape` |
| `schemas/workflow.ts` | `schemas/dag-node.ts` | **modified** | adds a type-only import of `NestedKeySpec` |
| `loader.ts` | `schemas/dag-node.ts` | **modified** | imports `KNOWN_NODE_NESTED_KEYS` + `NestedKeySpec` |
| `loader.ts` | `schemas/workflow.ts` | **modified** | imports `KNOWN_WORKFLOW_NESTED_KEYS` |
| `cli/commands/workflow.ts` | `WorkflowWithSource.parseWarnings` | **new** | run-path stderr notice + list rendering |
| `core/handlers/command-handler.ts` | `WorkflowWithSource.parseWarnings` | **new** | `/workflow list` |
| `server/routes/api.ts` | `WorkflowWithSource.parseWarnings` | **new** | previously dropped in the map |
| `server/routes/schemas/workflow.schemas.ts` | — | **modified** | optional `parseWarnings` on `WorkflowListEntry` |
| `web/console/primitives/workflow.ts` | `/api/workflows` | **modified** | maps the new field |
| `web/console/components/WorkflowPicker.tsx` | `Workflow.parseWarnings` | **new** | ⚠ marker |
| `workflows/test-utils.ts` | — | **modified** | `makeTestWorkflowWithSource` takes optional `parseWarnings` |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: M`
- Scope: `workflows` `cli` `core` `server` `web` `docs`
- Module: `workflows:loader`, `workflows:schemas`, `cli:workflow`, `core:command-handler`, `server:routes`, `web:console`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi`

## Linked Issue

- Closes #2213
- Supersedes #2255 (builds on it; credit to @kagura-agent)

## Validation Evidence (required)

```bash
bun run validate   # wrapper exit 0
```

The wrapper's exit code has masked a real failure on this repo before, so the log was grepped directly rather than trusted:

- `check:bundled`, `check:bundled-skill`, `check:bundled-schema`, `check:pi-vendor-map` (OK), `check:capability-matrix` (OK) — all pass
- `type-check` — all 11 packages `Exited with code 0`
- `lint` (`--max-warnings 0`) — clean, no output
- `format:check` — `All matched files use Prettier code style!`
- `test` — **133 batches, every one `0 fail`**

One pre-existing log line appears in the output and is **not** a failure: `TypeError: Spread syntax requires ...iterable not be null or undefined` at `api.ts:4340`, logged from inside `api.auth.test.ts`, whose batch reports `18 pass / 0 fail`. `api.ts:4340` is untouched by this PR (the single diff hunk in that file is at line 2969).

**Tests fail before the fix.** Verified by stashing only the source changes and re-running. Note this compares against the commit *within this PR* that precedes each fix, not against `dev` — at the base commit the `warnings` field does not exist at all, so a PR-vs-dev comparison would fail to compile rather than fail an assertion:

- Engine (`loader.test.ts`): **8 fail** — the 7 new nested cases plus the strengthened `interactive`-hint assertion.
- Surfaces: CLI **3 fail**, server **1 fail**, chat **1 fail**.

With the fix restored: 189 / 208 / 46 / 124 pass, 0 fail.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No**

Read-only validation reporting. The one thing worth naming: warning strings are built from author-written YAML key names and are written to stderr / a chat message / a JSON field. Keys come from `Object.keys()` on the parsed YAML, never from secrets or env, and the console renders them as React text (escaped), not HTML.

## Compatibility / Migration

- Backward compatible? **Yes** — unknown keys are still stripped and workflows still load and run exactly as before. Only reporting changed.
- Config/env changes? **No**
- Database migration needed? **No**

`GET /api/workflows` gains an **optional** response field; existing clients ignore it. `archon workflow list --json` gains an optional per-entry field. `workflow run --json` stdout is byte-identical — the notice goes to stderr.

Precision on that last point: `workflow run` only emits a JSON payload at all under `--detach` (pre-existing — CLAUDE.md's `--json` list correctly excludes `run`). Without `--detach`, `--json` suppresses logs but the command still prints human progress. The stdout-purity guarantee therefore applies to `run --detach --json`, and that is the context the test now exercises.

## Human Verification (required)

Authored a real workflow with `interactive: true` on a command node **and** on a `loop_group` body node, in a scratch git repo, then checked each surface on a live build:

- **`archon validate workflows gated`** — both warnings, full prose and corrected hint.
- **`archon workflow list`** — both warnings inline under `gated`.
- **`archon workflow list --json`** — `parseWarnings` present on `gated`, absent on clean workflows; stdout parsed cleanly.
- **`archon workflow run gated --json --detach`** — stdout was exactly the `{ok: true, ...}` payload; both warnings on stderr. This is the channel that was previously **completely silent**.
- **`GET /api/workflows?cwd=…`** on a running server — `parseWarnings` present on `gated` only.
- **Console workflow picker** (browser, real server + vite) — ⚠ marker on the `gated` row only, full guidance in the tooltip/aria-label. Screenshot taken.

**No-false-positive check on the real corpus:** `archon validate workflows --json` over Archon's own **51 workflows** still yields **exactly 2** `unknown_key` warnings, both true positives in `e2e-opencode-smoke.yaml` (`agent: general` at workflow and node level — a live bug, silently dropped since April). The nested walk added zero noise. *(An earlier revision of this description said 54; 51 is the correct count.)* This is now **pinned as a test** rather than living only here — it fails if any workflow outside a known-bad allowlist starts warning.

Edge cases checked: clean nested blocks (a `loop_group` with valid `interactive` + `gate_message`, a body node with valid `retry`, an `approval` with valid `on_reject`) produce no warnings; free-form `output_format` keys produce no warnings; one workflow's warnings do not leak into another workflow's run.

**Not verified:** the `include:` interaction (see Side Effects); Slack/Telegram/Discord rendering of the `/workflow list` message (the message string is platform-agnostic and identical to how `errors` already renders there).

## Side Effects / Blast Radius (required)

- **Affected subsystems:** workflow parsing (warning collection only), and the five reporting surfaces above.
- **Potential unintended effects:**
  - A repo with genuinely many unknown keys will now see more output than before, since detection reaches one level down. On Archon's own corpus the count is unchanged at 2.
  - The loader's per-key `warn` log fires during *discovery*, i.e. for every workflow discovered, not only the one being run. That was already true before this PR; the log line is now longer. The run-path notice is the scoped, targeted surface.
  - **`include:` gap (pre-existing, not introduced here):** warnings are keyed by the filename that was parsed. If workflow A `include:`s workflow B and B has unknown keys, the warnings attach to B's entry, not A's — so running A does not surface them. They still appear for B in `validate` and `list`. Now **pinned by a test and stated in the authoring guide**, so propagating them later is a visible, intentional change rather than a silent behaviour shift. The propagation itself is deferred: it is a behaviour change across an include boundary that deserves its own review, and `include-expander.ts` is being edited concurrently by #2466.
- **Guardrails:** the no-false-positive check above is the regression signal — if a future schema change makes a legitimate key look unknown, that count moves off 2.

## Rollback Plan (required)

- Fast rollback: `git revert` the three commits on top of `5286dfa` (or revert the whole branch). No data migration, no state change, no config.
- Feature flags: none — reporting only.
- Observable failure symptoms: spurious `unknown key` warnings on valid workflows (would mean a key set drifted from its schema), or `workflow run --json` stdout no longer parsing (would mean a warning leaked to stdout — there is a test asserting it does not).

## Review round 2 (#2455 review, 2026-08-05)

Folded in: **I1** (chat/console run path — the finding that contradicted this PR's own thesis), **I2** (both derivation gaps), **I3** (`--json` test now reaches `writeJsonLine`), **I4** (a real bug this PR introduced — see below), **S2**, **S4**, **S5**, **S6**, **S7**, **S8**, **S9-residual**, and the cheap half of **S1** (pin + document, propagation deferred).

**I4 + S8 were done as one change.** I4 was a filename-collision bug introduced by this PR: two parallel maps keyed by bare filename, one overwriting and one only ever adding, so a clean workflow could inherit a dropped file's warning. Rather than adding a second hand-written clearing loop, the warnings now live on the discovery entry — one `Map.set()` replaces both halves together, which removes the bug class structurally and deletes `mergeWarnings` plus its four call sites.

**One correction to the review.** I2's suggested one-liner — casting `loopGroupNodeConfigSchema` back to a `ZodObject` to recover `.shape` — is correct in substance but **crashes at import** where it was placed. Reading that shape fires the `nodes` getter, which builds `z.array(dagNodeSchema)`; above `dagNodeSchema` in the module that is a temporal dead zone (`ReferenceError: Cannot access 'dagNodeSchema' before initialization`). tsc passes, so a compile-only check does not catch it — every test importing the module fails at load. The registry now sits at the end of the file with a comment pinning it there.

**Deferred: S3** (`unknown_key` issues carry neither `nodeId` nor `hint` in `validate --json`). Making them structural means changing `parseWarnings` from `string[]` to an object array across the engine, the `WorkflowWithSource` contract, the OpenAPI response schema, the regenerated web types, and all seven renderers — a contract change several times the size of this whole round, for a Suggestion. It would also push message composition into each human surface, which is a quality regression risk in the prose. The information is present today, just not separately addressable.

**CodeRabbit round.** Four folded in: warning attribution across a same-name project/global shadow (the single-project auto-select branch RE-RESOLVES the workflow, so the caller's warnings could describe a file that is not running — the re-resolved entry now wins, with a regression test); `role="img"` on the picker glyph (a bare `<span>` has the implicit `generic` role, which prohibits an accessible name, so the `aria-label` was inert); "lists keys" → "warning messages" in three docs; and MD040 on a fence. One declined: warning when a **mode-specific** key appears on the wrong node type (`with:` on a command node, `timeout:` on a prompt node). Real gap, but it needs per-mode key sets and must be reconciled with the existing `*_node_ai_fields_ignored` warnings that cover the mirror-image case, or the two double-report — its own change, not a review fix.

**Rebased twice** (#2223, then #2224). The predicted `dag-node.ts` conflict landed exactly as expected and resolved as expected: `fan_out:` moved into `dagNodeFlatSchema`, so `KNOWN_DAG_NODE_KEYS` picks it up with nothing hand-listed. It also got a `KNOWN_NODE_NESTED_KEYS` entry, since `fanOutConfigSchema` strips unknown keys like every other nested block (`fan_out.max_paralel` would otherwise vanish silently).

**A Windows CI failure worth recording.** An unrelated SQLite upgrade test — 250 ms on `dev` — timed out twice at 5.3–6.0 s against Bun's 5000 ms per-test limit. This branch touches no DB code; the symptom is CPU starvation under `bun --filter '*' --parallel test`, and that test does real file I/O and is documented as Windows-fragile. The heaviest new test here (the corpus guardrail) now parses files directly instead of running full discovery — a tighter unit for a parser check and ~3× cheaper. On the green run that test came back at 1312 ms. Reported as correlation, not proof.

**Partially done: S4.** `toWorkflow` now has the co-located test its siblings have. The `WorkflowPicker` DOM is not unit-tested: this package has no DOM-rendering harness (`RunStream.test.tsx`, cited as the pattern, tests an exported pure function). The marker's condition is a direct `parseWarnings.length > 0`, and it was verified in a live browser with a screenshot.

## Risks and Mitigations

- **Risk:** A nested key set drifts from its schema and produces false positives.
  - **Mitigation:** Every set is derived from the schema's `.shape` at module load — there is no hand-maintained list to drift. The one exception is `loop_group`, whose `z.ZodType<…>` annotation hides `.shape` from TS; it is rebuilt from `loopControlSchema.shape` plus its single `nodes` field, with a comment saying why.
- **Risk:** A future `ProviderCapabilities`-style addition adds a nested block nobody registers, so it silently goes unchecked.
  - **Mitigation:** Not fully mitigated. The block is documented in a comment listing exactly which node fields are deliberately absent and why (`output_format`, `sandbox`, `hooks`, `thinking`). A new nested config would need a new entry; this is a gap in coverage, not a source of false positives.
- **Risk:** Merge conflict with `feat/subrun-fanout` in `packages/workflows/src/schemas/dag-node.ts` — #2255 lifted the `.extend({…})` block into `dagNodeFlatSchema`, and that branch inserts `fan_out:` into the same block.
  - **Mitigation:** Known and accepted. They are semantically compatible — `KNOWN_DAG_NODE_KEYS` derives from the shape, so `fan_out` becomes a known key automatically. Whoever merges second resolves it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added warnings for unrecognized or misplaced workflow and node configuration keys.
  * Warnings appear in listings, validation results, command output, and workflow conversations without blocking execution.
  * JSON output keeps warnings separate from standard output for reliable parsing.
  * Added warning indicators and accessible details to the workflow picker.
  * API workflow listings include parse warnings when present and omit them for clean workflows.

* **Documentation**
  * Documented ignored keys, warning details, supported configuration areas, and warning behavior across interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

