### PR TITLE
test(workflows): guard against workflow-level schema fields being silently dropped at parse

### DIFF
--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -35,6 +35,9 @@ registerBuiltinProviders();
 
 import { discoverWorkflows, discoverWorkflowsWithConfig } from './workflow-discovery';
 import { isBashNode, isCancelNode, isLoopNode } from './schemas';
+import { parseWorkflow } from './loader';
+import { workflowDefinitionSchema } from './schemas/workflow';
+import type { WorkflowDefinition } from './schemas/workflow';
 import * as bundledDefaults from './defaults/bundled-defaults';
 
 describe('Workflow Loader', () => {
@@ -4073,4 +4076,145 @@ nodes:
       }
     });
   });
+});
+
+// ---------------------------------------------------------------------------
+// Workflow-level field parity (#2457)
+// ---------------------------------------------------------------------------
+
+/**
+ * `parseWorkflow` does not derive its result from `workflowDefinitionSchema` — it
+ * hand-assembles a WorkflowDefinition field by field into an object literal. A field
+ * added to the schema but not added to that literal is SILENTLY DISCARDED: the YAML
+ * parses, the workflow loads, and the feature is simply inert.
+ *
+ * That is not hypothetical. `requires:` was added to `workflowBaseSchema` in ab81248d
+ * (2026-06-01) without touching the loader, and the assembly block only landed in
+ * 2d7bf587 (2026-07-16) — six weeks in which the GitHub capability gate could never
+ * fire for any discovered workflow, fixed incidentally inside an unrelated PR.
+ *
+ * This is the guard. The field list is DERIVED from `workflowDefinitionSchema.shape`,
+ * so a new schema field fails the test until it is given a fixture here — the same
+ * "the derived check fails until the new thing is registered" ratchet used by
+ * `check:capability-matrix` and the schema-parity test in `sqlite.test.ts`.
+ *
+ * Deliberately NOT solved by deriving the assembly itself (`schema.parse(raw)`): the
+ * hand assembly exists BECAUSE of warn-and-drop — a present-but-invalid field is logged
+ * and dropped rather than aborting the whole discovery pass — and `.parse()` rejects
+ * instead. See #2457.
+ */
+describe('workflow-level field parity (#2457)', () => {
+  /**
+   * One fixture per workflow-level schema key: a YAML fragment setting the field, and a
+   * predicate proving it survived `parseWorkflow`. `present` is deliberately a survival
+   * check rather than deep equality — several fields are normalised on the way through
+   * (tags deduped, betas trimmed, thinking preprocessed), and this guard is about the
+   * field reaching the result at all, not about how it is parsed.
+   */
+  const FIELD_FIXTURES: Record<
+    string,
+    { yaml: string; present: (w: WorkflowDefinition) => boolean }
+  > = {
+    name: { yaml: '', present: w => w.name === 'parity' },
+    description: { yaml: '', present: w => w.description === 'parity fixture' },
+    nodes: { yaml: '', present: w => w.nodes.length === 1 },
+    provider: { yaml: 'provider: claude', present: w => w.provider === 'claude' },
+    model: { yaml: 'model: sonnet', present: w => w.model === 'sonnet' },
+    modelReasoningEffort: {
+      yaml: 'modelReasoningEffort: high',
+      present: w => w.modelReasoningEffort === 'high',
+    },
+    webSearchMode: { yaml: 'webSearchMode: live', present: w => w.webSearchMode === 'live' },
+    interactive: { yaml: 'interactive: true', present: w => w.interactive === true },
+    effort: { yaml: 'effort: high', present: w => w.effort !== undefined },
+    thinking: { yaml: 'thinking: adaptive', present: w => w.thinking !== undefined },
+    fallbackModel: {
+      yaml: 'fallbackModel: haiku',
+      present: w => w.fallbackModel === 'haiku',
+    },
+    betas: { yaml: 'betas:\n  - some-beta', present: w => w.betas?.includes('some-beta') === true },
+    sandbox: { yaml: 'sandbox:\n  enabled: true', present: w => w.sandbox !== undefined },
+    worktree: { yaml: 'worktree:\n  enabled: false', present: w => w.worktree?.enabled === false },
+    container: {
+      yaml: 'container:\n  enabled: true',
+      present: w => w.container?.enabled === true,
+    },
+    evidence_policy: {
+      yaml: 'evidence_policy:\n  required: true',
+      present: w => w.evidence_policy?.required === true,
+    },
+    mutates_checkout: {
+      yaml: 'mutates_checkout: false',
+      present: w => w.mutates_checkout === false,
+    },
+    persist_sessions: {
+      yaml: 'persist_sessions: true',
+      present: w => w.persist_sessions === true,
+    },
+    tags: { yaml: 'tags:\n  - alpha', present: w => w.tags?.includes('alpha') === true },
+    requires: {
+      yaml: 'requires:\n  - github',
+      present: w => w.requires?.includes('github') === true,
+    },
+  };
+
+  const schemaKeys = Object.keys(workflowDefinitionSchema.shape);
+
+  it('has a fixture for every workflow-level schema key (the ratchet)', () => {
+    const missing = schemaKeys.filter(k => !(k in FIELD_FIXTURES));
+    expect(
+      missing,
+      `Workflow-level schema keys with no parity fixture: ${missing.join(', ')}. ` +
+        'Add a fixture in FIELD_FIXTURES AND make sure parseWorkflow actually carries the ' +
+        'field into its returned object literal — a schema field missing from that literal ' +
+        'is silently discarded at parse (see #2457).'
+    ).toEqual([]);
+  });
+
+  it('has no fixture for a key that is not in the schema', () => {
+    const stale = Object.keys(FIELD_FIXTURES).filter(k => !schemaKeys.includes(k));
+    expect(stale, `Parity fixtures for keys no longer in the schema: ${stale.join(', ')}`).toEqual(
+      []
+    );
+  });
+
+  for (const key of Object.keys(FIELD_FIXTURES)) {
+    it(`round-trips '${key}' through parseWorkflow`, () => {
+      const fixture = FIELD_FIXTURES[key];
+      const yaml = [
+        'name: parity',
+        'description: parity fixture',
+        fixture.yaml,
+        'nodes:',
+        '  - id: only',
+        '    prompt: hello',
+      ]
+        .filter(line => line !== '')
+        .join('\n');
+
+      // Warn-and-drop means an INVALID fixture value is dropped by design. Clearing the
+      // logger first lets the assertion below tell the two causes apart: a warn means the
+      // fixture is wrong, silence means the loader dropped a valid field (the #2457 bug).
+      mockLogger.warn.mockClear();
+
+      const result = parseWorkflow(yaml, `parity-${key}.yaml`);
+      expect(
+        result.error,
+        `parseWorkflow rejected the '${key}' fixture: ${result.error?.error}`
+      ).toBeNull();
+
+      const warned = mockLogger.warn.mock.calls.length > 0;
+      expect(
+        fixture.present(result.workflow as WorkflowDefinition),
+        warned
+          ? `Field '${key}' did not survive parseWorkflow, but a warning fired — the FIXTURE ` +
+              'value above is almost certainly invalid for this field, which warn-and-drop ' +
+              'discards by design. Fix the fixture, not the loader.'
+          : `Field '${key}' is declared on workflowDefinitionSchema, was accepted without a ` +
+              'warning, and still did NOT survive parseWorkflow — so it is missing from the ' +
+              'object literal parseWorkflow returns. That is the #2457 bug: add the field to ' +
+              'that literal.'
+      ).toBe(true);
+    });
+  }
 });

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -4089,7 +4089,7 @@ nodes:
  * parses, the workflow loads, and the feature is simply inert.
  *
  * That is not hypothetical. `requires:` was added to `workflowBaseSchema` in ab81248d
- * (2026-06-01) without touching the loader, and the assembly block only landed in
+ * (2026-06-01) without touching the loader, and was not added to that literal until
  * 2d7bf587 (2026-07-16) — six weeks in which the GitHub capability gate could never
  * fire for any discovered workflow, fixed incidentally inside an unrelated PR.
  *
@@ -4098,10 +4098,13 @@ nodes:
  * "the derived check fails until the new thing is registered" ratchet used by
  * `check:capability-matrix` and the schema-parity test in `sqlite.test.ts`.
  *
- * Deliberately NOT solved by deriving the assembly itself (`schema.parse(raw)`): the
- * hand assembly exists BECAUSE of warn-and-drop — a present-but-invalid field is logged
- * and dropped rather than aborting the whole discovery pass — and `.parse()` rejects
- * instead. See #2457.
+ * Deliberately NOT solved by deriving the assembly itself (`schema.parse(raw)`): most
+ * fields warn-and-drop, logging a present-but-invalid value and continuing rather than
+ * aborting the whole discovery pass, and `.parse()` would reject the workflow instead.
+ * That is not universal — a few fields deliberately hard-reject and a few coerce
+ * silently — but one warn-and-drop field is enough to make a blanket `.parse()` wrong.
+ * `loader.ts` is the authority on which field does what; do not restate it here.
+ * See #2457.
  */
 describe('workflow-level field parity (#2457)', () => {
   /**
@@ -4117,7 +4120,7 @@ describe('workflow-level field parity (#2457)', () => {
   > = {
     name: { yaml: '', present: w => w.name === 'parity' },
     description: { yaml: '', present: w => w.description === 'parity fixture' },
-    nodes: { yaml: '', present: w => w.nodes.length === 1 },
+    nodes: { yaml: '', present: w => w.nodes?.length === 1 },
     provider: { yaml: 'provider: claude', present: w => w.provider === 'claude' },
     model: { yaml: 'model: sonnet', present: w => w.model === 'sonnet' },
     modelReasoningEffort: {
@@ -4126,14 +4129,14 @@ describe('workflow-level field parity (#2457)', () => {
     },
     webSearchMode: { yaml: 'webSearchMode: live', present: w => w.webSearchMode === 'live' },
     interactive: { yaml: 'interactive: true', present: w => w.interactive === true },
-    effort: { yaml: 'effort: high', present: w => w.effort !== undefined },
-    thinking: { yaml: 'thinking: adaptive', present: w => w.thinking !== undefined },
+    effort: { yaml: 'effort: high', present: w => w.effort === 'high' },
+    thinking: { yaml: 'thinking: adaptive', present: w => w.thinking?.type === 'adaptive' },
     fallbackModel: {
       yaml: 'fallbackModel: haiku',
       present: w => w.fallbackModel === 'haiku',
     },
     betas: { yaml: 'betas:\n  - some-beta', present: w => w.betas?.includes('some-beta') === true },
-    sandbox: { yaml: 'sandbox:\n  enabled: true', present: w => w.sandbox !== undefined },
+    sandbox: { yaml: 'sandbox:\n  enabled: true', present: w => w.sandbox?.enabled === true },
     worktree: { yaml: 'worktree:\n  enabled: false', present: w => w.worktree?.enabled === false },
     container: {
       yaml: 'container:\n  enabled: true',
@@ -4192,9 +4195,11 @@ describe('workflow-level field parity (#2457)', () => {
         .filter(line => line !== '')
         .join('\n');
 
-      // Warn-and-drop means an INVALID fixture value is dropped by design. Clearing the
-      // logger first lets the assertion below tell the two causes apart: a warn means the
-      // fixture is wrong, silence means the loader dropped a valid field (the #2457 bug).
+      // An INVALID fixture value is dropped by design, which looks identical to the bug
+      // this test hunts. Clearing the logger first lets the failure message rank the two
+      // causes: a warning is strong evidence the fixture is at fault. Silence is NOT
+      // proof of the opposite — a few fields coerce an invalid value away with no log at
+      // all — so the silent branch names both causes rather than rendering a verdict.
       mockLogger.warn.mockClear();
 
       const result = parseWorkflow(yaml, `parity-${key}.yaml`);
@@ -4204,17 +4209,17 @@ describe('workflow-level field parity (#2457)', () => {
       ).toBeNull();
 
       const warned = mockLogger.warn.mock.calls.length > 0;
-      expect(
-        fixture.present(result.workflow as WorkflowDefinition),
-        warned
-          ? `Field '${key}' did not survive parseWorkflow, but a warning fired — the FIXTURE ` +
-              'value above is almost certainly invalid for this field, which warn-and-drop ' +
-              'discards by design. Fix the fixture, not the loader.'
-          : `Field '${key}' is declared on workflowDefinitionSchema, was accepted without a ` +
-              'warning, and still did NOT survive parseWorkflow — so it is missing from the ' +
-              'object literal parseWorkflow returns. That is the #2457 bug: add the field to ' +
-              'that literal.'
-      ).toBe(true);
+      const message = warned
+        ? `Field '${key}' did not survive parseWorkflow, and a warning fired — the FIXTURE ` +
+          'value above is almost certainly invalid for this field, which warn-and-drop ' +
+          'discards by design. Fix the fixture, not the loader.'
+        : `Field '${key}' is declared on workflowDefinitionSchema and did NOT survive ` +
+          'parseWorkflow, with no warning logged. Two possible causes, likeliest first: ' +
+          "(1) the field is missing from the object literal parseWorkflow returns — that's " +
+          'the #2457 bug, add it there; or (2) the fixture value is invalid for a field ' +
+          'that coerces silently without logging, in which case fix the fixture. Check the ' +
+          'fixture value against the schema first — it is the cheaper of the two to rule out.';
+      expect(fixture.present(result.workflow as WorkflowDefinition), message).toBe(true);
     });
   }
 });


### PR DESCRIPTION
## Summary

- **Problem:** `parseWorkflow` hand-assembles its result field by field, so a field added to `workflowDefinitionSchema` but not to that object literal is **silently discarded** — the YAML parses, the workflow loads, and the feature is simply inert. Nothing catches it.
- **Why it matters:** it already happened. `requires:` was added to `workflowBaseSchema` in `ab81248d` (2026-06-01) without touching the loader; the assembly block only landed in `2d7bf587` (2026-07-16). Six weeks in which the GitHub capability gate could never fire for any discovered workflow — fixed incidentally inside an unrelated PR, not by anything noticing.
- **What changed:** a parity test whose field list is **derived** from `workflowDefinitionSchema.shape`, plus a per-field round-trip fixture. A new schema field fails the test until it is given a fixture.
- **What did NOT change:** zero production code. No behaviour change, no semantic change, no new dependency. `git diff --stat` is one test file.

### This is the third instance of one pattern

Parallel enumerations that must agree, with nothing enforcing agreement:

| Enumerations that must agree | Enforced? | Outcome |
|---|---|---|
| The three ref-surfaces (`loader.ts` scan / `rewriteNodeOutputRefs` / `substituteNodeOutputRefs` sites) | No — a comment at `loader.ts:226-231` | **Already broken** — #2450 found the `when:` shorthand escapes ref validation |
| `workflowDefinitionSchema.shape` vs `parseWorkflow`'s literal | No — nothing | **Already broken once** — `requires:`, six weeks |
| Node/workflow key sets vs their schemas | **Yes** — #2455 derives from `.shape` | Cannot drift |

The only difference in the third row is that it is *derived* rather than *described*. This PR applies that form to the second row.

### Why a parity test and not deriving the assembly

Deriving the assembly (`workflowDefinitionSchema.parse(raw)`) would eliminate the class outright, and it is the wrong trade here. The hand assembly exists **because of warn-and-drop**: a present-but-invalid field is logged and dropped rather than rejecting the whole workflow, so one typo cannot abort a discovery pass. `.parse()` rejects instead. Restoring per-field warn-and-drop underneath a derived parse needs `.catch()` plus a logging hook on all 20 fields — a real refactor with behaviour-change risk on the discovery path, for the same protection.

Note what #2455 actually derives: a set of **names**. Names are cheap to derive and carry no semantics. This PR derives the same thing.

## UX Journey

### Before

```
Contributor            Schema                    parseWorkflow            Runtime
───────────            ──────                    ─────────────            ───────
adds `foo:` ────────▶  foo declared
                       (tests pass)
                                                 literal has no `foo`
                                                 → foo DROPPED silently
                                                                          feature inert
                                                                          no error, no warning
                                                                          no failing test
```

### After

```
Contributor            Schema                    parseWorkflow            Test suite
───────────            ──────                    ─────────────            ──────────
adds `foo:` ────────▶  foo declared
                                                 literal has no `foo`
                                                                     ***  RATCHET FAILS  ***
                                                                     "schema keys with no
                                                                      parity fixture: foo"
adds fixture ─────────────────────────────────▶
                                                                     *** ROUND-TRIP FAILS ***
                                                                     "declared, accepted without
                                                                      a warning, and still did
                                                                      NOT survive parseWorkflow"
wires the literal ────────────────────────────▶  literal carries foo  green
```

## Architecture Diagram

### Before

```
  schemas/workflow.ts                     loader.ts
  ┌────────────────────────┐              ┌──────────────────────────┐
  │ workflowDefinitionSchema│              │ parseWorkflow            │
  │   .shape (20 keys)     │   ...no...   │   per-field warn-and-drop │
  │                        │  - - - - - ▶ │   object literal (20 keys)│
  └────────────────────────┘   linkage    └──────────────────────────┘
```

### After

```
  schemas/workflow.ts                     loader.ts
  ┌────────────────────────┐              ┌──────────────────────────┐
  │ workflowDefinitionSchema│              │ parseWorkflow            │
  │   .shape (20 keys)     │              │   object literal (20 keys)│
  └───────────┬────────────┘              └────────────┬─────────────┘
              │                                        │
              │ Object.keys(...)  [+]                  │ round-trip  [+]
              ▼                                        ▼
        ┌──────────────────────────────────────────────────────┐
        │ [+] loader.test.ts — field-parity ratchet (#2457)     │
        │     derived key list === fixture list === survives    │
        └──────────────────────────────────────────────────────┘
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `schemas/workflow.ts` | `loader.test.ts` | **new** | Key list derived via `Object.keys(workflowDefinitionSchema.shape)` |
| `loader.ts` (`parseWorkflow`) | `loader.test.ts` | **new** | Per-field round-trip assertion |
| `schemas/workflow.ts` | `loader.ts` | unchanged | Still no enforced linkage — that is what the test now covers |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `tests`
- Module: `workflows:loader`

## Change Metadata

- Change type: `chore`
- Primary scope: `workflows`

## Linked Issue

- Closes #2457
- Related #2455 (the same guard, derived, one file over), #2450 (the first instance of the pattern, already broken), #2453 (where this was found — its `inputs:`/`returns:` fields would hit exactly this trap)

## Validation Evidence (required)

```bash
bun run validate   # wrapper exit 0
```

Grepped the log rather than trusting the wrapper's exit code:

```
$ grep -oE "[0-9]+ fail" /tmp/validate-2457.log | sort | uniq -c
 132   0 fail
$ grep -cE "[0-9]+ pass" /tmp/validate-2457.log
 132
```

132 test batches reported, every one `0 fail`, and the pass-line count matches the fail-line count so no batch silently failed to report.

**The guard was verified by breaking it, in both directions** — a test that has never been red proves nothing:

1. **Reproduce the historical bug.** Removed `...(requires !== undefined ? { requires } : {})` from `parseWorkflow`'s literal:
   ```
   (fail) workflow-level field parity (#2457) > round-trips 'requires' through parseWorkflow
   error: Field 'requires' is declared on workflowDefinitionSchema, was accepted without a
   warning, and still did NOT survive parseWorkflow — so it is missing from the object
   literal parseWorkflow returns. That is the #2457 bug: add the field to that literal.
   ```
2. **Add a new schema field the way a future contributor would.** Added `brand_new_field: z.string().optional()` to `workflowBaseSchema`, touching nothing else:
   ```
   (fail) workflow-level field parity (#2457) > has a fixture for every workflow-level schema key (the ratchet)
   error: Workflow-level schema keys with no parity fixture: brand_new_field. Add a fixture in
   FIELD_FIXTURES AND make sure parseWorkflow actually carries the field into its returned
   object literal — a schema field missing from that literal is silently discarded at parse.
   ```

Both breaks reverted; the diff is the test file alone.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No**

Test-only change.

## Compatibility / Migration

- Backward compatible? **Yes** — no production code touched
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

- **Verified scenarios:** the guard is green on unmodified `dev` before anything else (all 20 keys already present in the literal, so this lands as a ratchet rather than an unscoped bug hunt — worth knowing, since a red first run would have been a different-sized PR); both deliberate breaks above.
- **Edge cases checked:** an *invalid* fixture value and a *genuinely dropped* field originally produced identical failures with a misleading message. Caught during development — my first `thinking:` fixture used `thinking: true`, which is not a valid `thinkingConfigSchema` value, so warn-and-drop correctly discarded it while the test blamed the loader. Fixed by clearing the mock logger before each parse and branching the message on whether a warning fired, so the two causes are told apart.
- **What was not verified:** nothing runs this outside `bun test`; there is no runtime component to exercise.

## Side Effects / Blast Radius (required)

- **Affected subsystems:** `@archon/workflows` test suite only.
- **Potential unintended effects:** the fixture map is hand-maintained, so adding a workflow-level field now requires a fixture — that is the intended cost, and the failure message says exactly what to do.
- **Guardrails:** the test lives in `loader.test.ts`, which `packages/workflows/package.json` already runs in its own `bun test` invocation.

## Rollback Plan (required)

- **Fast rollback:** `git revert <sha>` — one test file, no production code.
- **Feature flags:** none.
- **Observable failure symptoms:** a red parity test where the field genuinely is wired, which would mean a bad fixture rather than a bug.

## Risks and Mitigations

- **Risk:** the fixture map drifts from reality — someone adds a fixture that passes without wiring the field.
  - **Mitigation:** not possible by construction. The fixture asserts the field survives `parseWorkflow`, so a fixture cannot be satisfied without the literal carrying the field.
- **Risk:** a future field is genuinely hard to fixture (preprocess/union/passthrough shapes).
  - **Mitigation:** `present` is a survival predicate, not deep equality, so `!== undefined` suffices — which is exactly how `thinking` and `sandbox` are handled today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage to ensure workflow fixtures stay aligned with the workflow schema.
  * Added validation that valid workflow fields are preserved during parsing without unexpected warnings.
  * Added checks to detect missing or outdated fixture fields.
  * Added safeguards to identify changes in workflow-level schema fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->