### PR TITLE
docs: correct rotted counts and a wrong path in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ bun test --watch            # Watch mode (single package)
 bun test packages/core/src/handlers/command-handler.test.ts  # Single file
 ```
 
-**Test isolation (mock.module pollution):** Bun's `mock.module()` permanently replaces modules in the process-wide cache — `mock.restore()` does NOT undo it ([oven-sh/bun#7823](https://github.com/oven-sh/bun/issues/7823)). To prevent cross-file pollution, packages that have conflicting `mock.module()` calls split their tests into separate `bun test` invocations: `@archon/core` (20 batches), `@archon/workflows` (5), `@archon/adapters` (6), `@archon/isolation` (3). See each package's `package.json` for the exact splits.
+**Test isolation (mock.module pollution):** Bun's `mock.module()` permanently replaces modules in the process-wide cache — `mock.restore()` does NOT undo it ([oven-sh/bun#7823](https://github.com/oven-sh/bun/issues/7823)). To prevent cross-file pollution, packages with conflicting `mock.module()` calls split their tests into separate `bun test` invocations — see each package's `package.json` `test` script for the current splits.
 
 **Do NOT run `bun test` from the repo root** — it discovers all test files across all packages and runs them in one process, causing ~135 mock pollution failures. Always use `bun run test` (which uses `bun --filter '*' --parallel test` for per-package isolation). Note the `--parallel`: all ten package test processes run concurrently, and each one that spawns subprocesses competes for the same cores — which is why subprocess-spawning tests should stay rare and cheap (see #2306).
 
@@ -171,7 +171,7 @@ bun run format:check
 bun run validate
 ```
 
-This runs `check:bundled`, `check:bundled-skill`, `check:bundled-schema`, `check:pi-vendor-map`, `check:capability-matrix`, type-check, lint, format check, and tests. All nine must pass for CI to succeed.
+Every step must pass for CI to succeed — see the `validate` script in the root `package.json` for the current list.
 
 ### ESLint Guidelines
 
@@ -199,7 +199,7 @@ This runs `check:bundled`, `check:bundled-skill`, `check:bundled-schema`, `check
 There is no migration ledger and no version gate. Both schemas are re-applied in full on every connection, by every process that opens the database — the server, *every* CLI invocation, every `--detach` child — including an **older** Archon binary that happens to be on `PATH` beside a dev checkout. Any writer may apply any vintage of the schema at any time. Therefore:
 
 - **Only ADD** tables, columns, and indexes. Never rename, retype, or drop anything a shipped version still reads or writes.
-- **Every `ADD COLUMN ... NOT NULL` must carry a `DEFAULT`.** Without one the statement fails outright on a non-empty table, and a writer that predates the column would produce rows the newer writer rejects. This holds for all 36 `ADD COLUMN` statements in the tree today — keep it that way.
+- **Every `ADD COLUMN ... NOT NULL` must carry a `DEFAULT`.** Without one the statement fails outright on a non-empty table, and a writer that predates the column would produce rows the newer writer rejects. This holds for every `ADD COLUMN` in the tree today — keep it that way.
 - **Adding `NOT NULL` to a column already in a `CREATE TABLE` body only binds databases created after the change.** `CREATE TABLE IF NOT EXISTS` is a no-op on existing tables and SQLite has no `ALTER COLUMN`, so the old shape survives forever. Treat such a constraint as documentation and keep application code tolerant of NULL, or do a full table rebuild in `migrateColumns()`.
 - **Mirror every change into both schemas** (see the generated-files note in the Defaults section). The parity test in `sqlite.test.ts` compares **table names only** — a column present in one dialect and missing in the other passes CI.
 - `remote_agent_schema_version` records which Archon build created the database and which last applied schema to it, surfaced by `archon doctor` and `GET /api/health`. It is diagnostic only — nothing gates on it, and the values come from `APP_VERSION` in `packages/core/src/db/schema-version.ts`, never from a hand-bumped number.
@@ -406,6 +406,7 @@ packages/
 │       ├── worktree.ts       # Worktree operations (create, remove, list)
 │       └── index.ts          # Package exports
 ├── isolation/                # @archon/isolation - Worktree + container isolation (depends on @archon/git + @archon/paths + @archon/providers/types)
+│   ├── docker/               # runner.Dockerfile + entrypoint.sh + SECURITY.md (the container runner image) — sibling of src/, not inside it
 │   └── src/
 │       ├── types.ts          # Isolation types and interfaces (incl. IIsolationBackend, ContainerBackendConfig)
 │       ├── errors.ts         # Error classifiers (classifyIsolationError, IsolationBlockedError; incl. docker patterns)
@@ -416,7 +417,6 @@ packages/
 │       ├── backend-router.ts # Kind-routed folder backend selection (resolveFolderBackend: in-place | container)
 │       ├── backends/         # Folder-project isolation backends (in-place.ts, container.ts — prepare/suspend/resumeEnv/finalize/applyChanges/discardChanges/destroy)
 │       ├── container/        # Docker CLI wrapper (docker-exec.ts) + overlay diff/apply walk (overlay.ts) for the container backend
-│       ├── docker/           # runner.Dockerfile + entrypoint.sh + SECURITY.md (the container runner image)
 │       ├── providers/
 │       │   └── worktree.ts   # WorktreeProvider implementation
 │       └── index.ts          # Package exports


### PR DESCRIPTION
## Summary

- **Problem:** `CLAUDE.md` is the highest-trust file in the repo — every agent reads it, none re-derives it — and several factual claims have rotted. They fail in the "looks fine" direction: an agent that trusts them gets a plausible wrong answer rather than an error.
- **Why it matters:** the counts are the kind of claim an agent quotes back as fact. "All nine must pass" is wrong in a way that reads authoritative.
- **What changed:** four corrections, all shrinking the file. Counts replaced with **pointers**, not fresh numbers.
- **What did NOT change:** normative prose. No Core Principles, Engineering Principles, Product Direction, Git Workflow policy, or constitution summary was touched. No code.

| Claim | Was | Is |
|---|---|---|
| `bun run validate` steps | nine | **ten** (gained `test:install`) |
| `@archon/core` test batches | 20 | **33** |
| `@archon/workflows` | 5 | **18** |
| `@archon/isolation` | 3 | **5** |
| `@archon/adapters` | 6 | 6 ✓ |
| `ADD COLUMN` statements | 36 | **39** (23 migration + 16 SQLite adapter) |
| isolation runner image | `packages/isolation/src/docker/` | **`packages/isolation/docker/`** — sibling of `src/` |

### Why pointers instead of new numbers

Every count above was correct when written. Restating today's figure just resets the clock — the next person to split a test batch re-rots the file, and nothing tells them to come back here. So the counts now point at where the truth actually lives (each package's `package.json`, the root `validate` script). The load-bearing rules are untouched: split conflicting `mock.module()` calls into separate invocations; every `ADD COLUMN ... NOT NULL` carries a `DEFAULT`.

Net **153 characters smaller**.

## UX Journey

### Before

```
Agent                          CLAUDE.md                    Reality
─────                          ─────────                    ───────
"how many validate steps?" ──▶ "All nine must pass"    ✗    ten
"is my test batching right?" ─▶ "core (20 batches)"     ✗    33
"where's the Dockerfile?"  ──▶ isolation/src/docker/    ✗    isolation/docker/
                                     │
                                     ▼
                          quotes it back as fact; no error, no signal
```

### After

```
Agent                          CLAUDE.md                    Reality
─────                          ─────────                    ───────
"how many validate steps?" ──▶ "see the validate script"  ──▶ reads it: correct, always
"is my test batching right?" ─▶ "see each package.json"   ──▶ reads it: correct, always
"where's the Dockerfile?"  ──▶ isolation/docker/       ✓
```

## Architecture Diagram

### Before / After

No modules touched. `git diff --stat` is one file:

```
 CLAUDE.md | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| — | — | unchanged | Docs-only; no module edges exist or change |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `docs`
- Module: `docs:claude-md`

## Change Metadata

- Change type: `docs`
- Primary scope: `multi`

## Linked Issue

- Closes #2462

## Validation Evidence (required)

Docs-only, no code touched, so `bun run validate` is not applicable — but every claim was verified by running something:

```bash
$ node -e "console.log(require('./package.json').scripts.validate.split('&&').length)"
10
$ for pkg in core workflows adapters isolation; do
    node -e "console.log('$pkg', require('./packages/$pkg/package.json').scripts.test.split('&&').length)"; done
core 33
workflows 18
adapters 6
isolation 5
$ grep -c "ADD COLUMN" migrations/000_combined.sql packages/core/src/db/adapters/sqlite.ts
migrations/000_combined.sql:23
packages/core/src/db/adapters/sqlite.ts:16
$ ls packages/isolation/docker/
SECURITY.md  entrypoint.sh  runner.Dockerfile
```

- Evidence provided: command output above; `git diff --stat` confirms one file.
- Intentionally skipped: `bun run validate` — no code, no config, no generated file is touched.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No**

## Compatibility / Migration

- Backward compatible? **Yes** — documentation only
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

- **Verified scenarios:** every claim re-run locally on `dev` @ `8704a65f`; the directory-tree edit renders correctly with `docker/` as a sibling of `src/`.
- **Edge cases checked — two of my own greps produced false negatives, and both were re-checked rather than reported:**
  - `grep "function createSchema"` returned 0, which looked like CLAUDE.md citing a function that no longer exists. It is a class method (`private createSchema()`, `sqlite.ts:515`). **Not a finding.**
  - A sweep for CLI subcommands and slash commands reported many "missing". They dispatch from `cli.ts`, not `commands/workflow.ts`, and slash commands are spread across several files. All present. **Not a finding.**
- **Also verified and found correct** (so deliberately not touched): the 19-table count, the `3190-4089` worktree port range, "ten package test processes", `bun --filter '*' --parallel test`, every path in the directory tree except the one fixed, all 16 API routes sampled, all 9 generate/check scripts, all referenced docs paths, all 9 workflow variables, `loader.ts` using `dagNodeSchema.safeParse()`.
- **What was not verified:** the "~135 mock pollution failures" figure — checking it means running `bun test` from the repo root, which the same paragraph tells you not to do. It is hedged with "~" and its instruction stands regardless, so it was left alone rather than guessed at.

## Side Effects / Blast Radius (required)

- **Affected subsystems:** none. Documentation read by agents and contributors.
- **Potential unintended effects:** pointers require one extra lookup to get a number. That is the intent — the number is then always right.
- **Guardrails:** none needed; nothing executes this file.

## Rollback Plan (required)

- **Fast rollback:** `git revert <sha>`.
- **Feature flags:** none.
- **Observable failure symptoms:** none possible.

## Risks and Mitigations

- **Risk:** removing the enumerated `validate` step list makes the section less scannable.
  - **Mitigation:** the list was the thing that rotted, and `package.json` is one command away. The instruction ("every step must pass") is preserved.
- **Risk:** other false claims remain that this sweep missed.
  - **Mitigation:** the sweep covered every count, path, script name, route, variable, and file:line reference in the in-scope sections. Two claims that could not be settled either way are listed above rather than silently changed.

## Reported, not changed

One stale reference sits **inside the off-limits normative prose**, so it is deliberately untouched and flagged for a maintainer call:

> *Engineering Principles → No Autonomous Lifecycle Mutation* cites `packages/cli/src/cli.ts:256-258` as "the CLI orphan-cleanup precedent".

Those lines are now telemetry/help/version handling, and `cli.ts:385` records that orphaned-run cleanup **moved** to the `workflow cleanup` command — so the cited precedent no longer exists in that form. The principle may well still be right; only its supporting evidence is stale. Rewriting a principle's evidence is not a docs-hygiene decision, so it stays as-is pending that call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated testing and validation guidance to reference authoritative project scripts.
  * Clarified database schema parity checks and requirements for adding non-null columns.
  * Improved CLI guidance with references to `--help` and supporting documentation.
  * Refreshed package layout, configuration, directory structure, and Docker asset documentation.
  * Clarified Archon home directories, environment overrides, and SDK typing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->