### PR TITLE
fix: issue 2465

### DIFF
--- a/packages/workflows/src/utils/output-truncation.test.ts
+++ b/packages/workflows/src/utils/output-truncation.test.ts
@@ -1,0 +1,50 @@
+import { describe, test, expect } from 'bun:test';
+import { buildTruncationMarker, hasTruncationMarker } from './output-truncation';
+
+describe('buildTruncationMarker', () => {
+  test('formats the byte count into the marker', () => {
+    expect(buildTruncationMarker(1234)).toBe('\n\n… [truncated; original output was 1234 bytes]');
+  });
+
+  test('handles zero bytes', () => {
+    expect(buildTruncationMarker(0)).toBe('\n\n… [truncated; original output was 0 bytes]');
+  });
+});
+
+describe('hasTruncationMarker', () => {
+  test('returns true for a fresh round-trip with no whitespace', () => {
+    const output = `hello${buildTruncationMarker(42)}`;
+    expect(hasTruncationMarker(output)).toBe(true);
+  });
+
+  test('returns true when a single trailing newline is appended — the regression from #2465', () => {
+    // Reproduces the coupling that motivated the .trimEnd() fix: the marker is
+    // matched leniently so a future normalisation step that appends a newline
+    // does not silently revert to the generic "not a JSON object" error.
+    const output = `hello${buildTruncationMarker(42)}\n`;
+    expect(hasTruncationMarker(output)).toBe(true);
+  });
+
+  test('returns true when several trailing whitespace characters are appended', () => {
+    const output = `hello${buildTruncationMarker(42)}\n  \t \n`;
+    expect(hasTruncationMarker(output)).toBe(true);
+  });
+
+  test('returns false when the marker appears mid-string (anchored match)', () => {
+    const output = `${buildTruncationMarker(42)}\nhello`;
+    expect(hasTruncationMarker(output)).toBe(false);
+  });
+
+  test('returns false when a node merely quotes the phrase in its output', () => {
+    const output = 'see the truncation message: [truncated; original output was 9 bytes]';
+    expect(hasTruncationMarker(output)).toBe(false);
+  });
+
+  test('returns false for plain output with no marker', () => {
+    expect(hasTruncationMarker('{"ok":true}')).toBe(false);
+  });
+
+  test('returns false for the empty string', () => {
+    expect(hasTruncationMarker('')).toBe(false);
+  });
+});

--- a/packages/workflows/src/utils/output-truncation.ts
+++ b/packages/workflows/src/utils/output-truncation.ts
@@ -29,5 +29,9 @@ const TRUNCATION_MARKER_PATTERN = /\n\n… \[truncated; original output was \d+ 
 
 /** Whether `output` ends with the persistence truncation marker. */
 export function hasTruncationMarker(output: string): boolean {
-  return TRUNCATION_MARKER_PATTERN.test(output);
+  // Trailing whitespace can never be meaningful *after* the marker, so we
+  // match it leniently — otherwise a future normalisation step that appends a
+  // newline would silently degrade the clipped-output error into the generic
+  // "not a JSON object" one with no test catching the regression.
+  return TRUNCATION_MARKER_PATTERN.test(output.trimEnd());
 }


### PR DESCRIPTION
Automated fix for issue $ARGUMENTS.

## Assessment
'The problem is real and exactly as described: TRUNCATION_MARKER_PATTERN is anchored at $/end-of-string, so any trailing whitespace breaks detection. Today only formatPersistedBashOutput produces this string and it returns `head + marker` with nothing appended, so no production path currently triggers the gap — but the coupling is invisible (normalising, line-ending conversion, or code-fence stripping anywhere downstream would silently revert the accurate '\''output was clipped'\'' advice to the generic '\''producer emitted no JSON'\'' advice, with no test failing). The fix is a one-word change (`output.trimEnd()`) that loses nothing — trailing whitespace after the marker can never be meaningful — and the property the function claims to guarantee ('\''ends with the truncation marker'\'') is restored. Adding a test that pins the trailing-whitespace case is trivial and turns the property from incidental to asserted. Worth doing now while the change is one line; the larger refactor (threading node_output_truncated onto NodeOutput) is only justified if another consumer needs the flag.'

## Final review pass
'BUILD-CLEAN'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of truncated output when the truncation marker is followed by whitespace.

* **Tests**
  * Added coverage for marker formatting, byte counts, whitespace, quoted text, missing markers, and empty output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->