### PR TITLE
fix: issue 2465

### DIFF
--- a/packages/workflows/src/output-ref.test.ts
+++ b/packages/workflows/src/output-ref.test.ts
@@ -208,7 +208,9 @@ describe('resolveNodeOutputField — output clipped before persistence', () => {
   });
 
   it('marker round-trips through build/detect', () => {
-    expect(hasTruncationMarker(`head${buildTruncationMarker(1234)}`)).toBe(true);
+    const output = `head${buildTruncationMarker(1234)}`;
+    expect(hasTruncationMarker(output)).toBe(true);
+    expect(hasTruncationMarker(`${output}\n \t`)).toBe(true);
     expect(hasTruncationMarker('no marker here')).toBe(false);
   });
 });

--- a/packages/workflows/src/utils/output-truncation.ts
+++ b/packages/workflows/src/utils/output-truncation.ts
@@ -29,5 +29,5 @@ const TRUNCATION_MARKER_PATTERN = /\n\n… \[truncated; original output was \d+ 
 
 /** Whether `output` ends with the persistence truncation marker. */
 export function hasTruncationMarker(output: string): boolean {
-  return TRUNCATION_MARKER_PATTERN.test(output);
+  return TRUNCATION_MARKER_PATTERN.test(output.trimEnd());
 }


### PR DESCRIPTION
Automated fix for issue $ARGUMENTS.

## Assessment
'Issue is real and verifiable: the pattern is anchored at end-of-string with `$/`, so any trailing whitespace after the marker makes detection fail. Today no path appends whitespace, but the coupling is invisible — a single normalize/strip/round-trip call in dag-executor or persistence would silently revert users to the worse '\''output is not a JSON object'\'' advice instead of '\''producer was fine, run resumed a clipped copy'\''. The proposed one-word fix (`.trimEnd()` before regex.test) is correct: trailing whitespace after a truncation marker is never meaningful, the start anchor still rules out quoted phrases, and a regression test pinning the property makes the intent explicit. Risk is negligible, payoff is permanent protection of a soft-failure UX that has no other safeguard.'

## Final review pass
'BUILD-CLEAN'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved truncated-output detection when trailing whitespace follows the truncation marker.
  * Added coverage to verify consistent detection in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->