### PR TITLE
Fix flaky SQLite event_order upgrade test

### DIFF
--- a/packages/core/src/db/adapters/sqlite.test.ts
+++ b/packages/core/src/db/adapters/sqlite.test.ts
@@ -39,15 +39,20 @@ async function makeDbWithoutEventOrder(): Promise<{ uri: string; seed: SqliteAda
   // would get an empty database. Keep the seed connection open so this named
   // shared-cache database survives until the upgrade assertions finish.
   const seed = new SqliteAdapter(uri); // writes the current schema
-  const raw = new Database(uri);
   try {
-    raw.run('DROP TRIGGER IF EXISTS remote_agent_workflow_events_assign_order');
-    raw.run('DROP INDEX IF EXISTS idx_workflow_events_run_order');
-    raw.run('ALTER TABLE remote_agent_workflow_events DROP COLUMN event_order');
-  } finally {
-    raw.close();
+    const raw = new Database(uri);
+    try {
+      raw.run('DROP TRIGGER IF EXISTS remote_agent_workflow_events_assign_order');
+      raw.run('DROP INDEX IF EXISTS idx_workflow_events_run_order');
+      raw.run('ALTER TABLE remote_agent_workflow_events DROP COLUMN event_order');
+    } finally {
+      raw.close();
+    }
+    return { uri, seed };
+  } catch (error) {
+    await seed.close();
+    throw error;
   }
-  return { uri, seed };
 }
 
 function columnsOf(uri: string, table: string): string[] {

--- a/packages/core/src/db/adapters/sqlite.test.ts
+++ b/packages/core/src/db/adapters/sqlite.test.ts
@@ -5,7 +5,6 @@ import { APP_VERSION, readSchemaVersion } from '../schema-version';
 import { Database } from 'bun:sqlite';
 import { unlinkSync } from 'fs';
 import { join } from 'path';
-import { tmpdir } from 'node:os';
 
 let currentDbPath = '';
 
@@ -33,21 +32,14 @@ async function insertCodebase(db: SqliteAdapter, id: string): Promise<void> {
  * the fixture realistic — the upgrade path that broke was an otherwise-current
  * database missing exactly this one column.
  */
-async function makeDbWithoutEventOrder(): Promise<string> {
-  // OS temp dir, not the repo: on Windows bun:sqlite does not always release the
-  // file handle synchronously, so cleanup can hit EBUSY. A stranded file in
-  // tmpdir is harmless and self-cleaning; a stranded file in packages/ is repo
-  // pollution that shows up in everyone's `git status`.
-  const path = join(
-    tmpdir(),
-    `archon-test-sqlite-legacy-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
-  );
-  const seed = new SqliteAdapter(path); // writes the current schema
-  // MUST await: close() is async, and on Windows an unreleased SQLite handle
-  // locks the file, so the Database opened below fails. Harmless on POSIX,
-  // which is why the first version of this test passed locally and failed CI.
-  await seed.close();
-  const raw = new Database(path);
+async function makeDbWithoutEventOrder(): Promise<{ uri: string; seed: SqliteAdapter }> {
+  const name = `archon-test-sqlite-legacy-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const uri = `file:${name}?mode=memory&cache=shared`;
+  // Plain :memory: cannot serve this fixture because each reopened connection
+  // would get an empty database. Keep the seed connection open so this named
+  // shared-cache database survives until the upgrade assertions finish.
+  const seed = new SqliteAdapter(uri); // writes the current schema
+  const raw = new Database(uri);
   try {
     raw.run('DROP TRIGGER IF EXISTS remote_agent_workflow_events_assign_order');
     raw.run('DROP INDEX IF EXISTS idx_workflow_events_run_order');
@@ -55,15 +47,11 @@ async function makeDbWithoutEventOrder(): Promise<string> {
   } finally {
     raw.close();
   }
-  return path;
+  return { uri, seed };
 }
 
-function columnsOf(path: string, table: string): string[] {
-  const raw = new Database(path);
-  // Finalize the statement before closing. On Windows an un-finalized prepared
-  // statement keeps the file handle open past close(), so the afterEach unlink
-  // fails with EBUSY — which is what this test hit on windows-latest while
-  // passing on POSIX.
+function columnsOf(uri: string, table: string): string[] {
+  const raw = new Database(uri);
   const stmt = raw.prepare(`PRAGMA table_info('${table}')`);
   try {
     return (stmt.all() as { name: string }[]).map(c => c.name);
@@ -74,24 +62,11 @@ function columnsOf(path: string, table: string): string[] {
 }
 
 describe('SqliteAdapter upgrade path', () => {
-  let legacyPath = '';
-  afterEach(() => {
-    if (legacyPath) {
-      try {
-        unlinkSync(legacyPath);
-      } catch (e: unknown) {
-        // Tolerate exactly two cases, and nothing else:
-        //   ENOENT — already gone, fine.
-        //   EBUSY  — Windows only. bun:sqlite does not reliably release the file
-        //            handle synchronously on close(), even with statements
-        //            finalized. The fixture is a uniquely-named file in tmpdir,
-        //            so a stranded one is harmless. Tolerated rather than
-        //            swallowed: any other errno still fails the test loudly,
-        //            which is what caught the real leak in the first place.
-        const code = (e as NodeJS.ErrnoException).code;
-        if (code !== 'ENOENT' && code !== 'EBUSY') throw e;
-      }
-      legacyPath = '';
+  let legacySeed: SqliteAdapter | undefined;
+  afterEach(async () => {
+    if (legacySeed) {
+      await legacySeed.close();
+      legacySeed = undefined;
     }
   });
 
@@ -102,16 +77,17 @@ describe('SqliteAdapter upgrade path', () => {
   // column, never ran. Every existing SQLite install was bricked on upgrade,
   // and the migration that would fix it could never execute.
   test('converges a database that predates event_order', async () => {
-    legacyPath = await makeDbWithoutEventOrder();
-    expect(columnsOf(legacyPath, 'remote_agent_workflow_events')).not.toContain('event_order');
+    const legacy = await makeDbWithoutEventOrder();
+    legacySeed = legacy.seed;
+    expect(columnsOf(legacy.uri, 'remote_agent_workflow_events')).not.toContain('event_order');
 
     // Must not throw, and must converge.
-    const upgraded = new SqliteAdapter(legacyPath);
+    const upgraded = new SqliteAdapter(legacy.uri);
     await upgraded.close();
 
-    expect(columnsOf(legacyPath, 'remote_agent_workflow_events')).toContain('event_order');
+    expect(columnsOf(legacy.uri, 'remote_agent_workflow_events')).toContain('event_order');
 
-    const raw = new Database(legacyPath);
+    const raw = new Database(legacy.uri);
     const stmt = raw.prepare('SELECT name FROM sqlite_master WHERE name IN (?, ?)');
     let objects: string[];
     try {

--- a/packages/core/src/db/adapters/sqlite.test.ts
+++ b/packages/core/src/db/adapters/sqlite.test.ts
@@ -67,14 +67,6 @@ function columnsOf(uri: string, table: string): string[] {
 }
 
 describe('SqliteAdapter upgrade path', () => {
-  let legacySeed: SqliteAdapter | undefined;
-  afterEach(async () => {
-    if (legacySeed) {
-      await legacySeed.close();
-      legacySeed = undefined;
-    }
-  });
-
   // Regression: the event_order index and trigger were briefly created inside
   // createSchema(). Both reference a column absent from any database predating
   // it, and CREATE INDEX on a missing column aborts the entire createSchema()
@@ -82,32 +74,38 @@ describe('SqliteAdapter upgrade path', () => {
   // column, never ran. Every existing SQLite install was bricked on upgrade,
   // and the migration that would fix it could never execute.
   test('converges a database that predates event_order', async () => {
-    const legacy = await makeDbWithoutEventOrder();
-    legacySeed = legacy.seed;
-    expect(columnsOf(legacy.uri, 'remote_agent_workflow_events')).not.toContain('event_order');
-
-    // Must not throw, and must converge.
-    const upgraded = new SqliteAdapter(legacy.uri);
-    await upgraded.close();
-
-    expect(columnsOf(legacy.uri, 'remote_agent_workflow_events')).toContain('event_order');
-
-    const raw = new Database(legacy.uri);
-    const stmt = raw.prepare('SELECT name FROM sqlite_master WHERE name IN (?, ?)');
-    let objects: string[];
+    const { uri, seed } = await makeDbWithoutEventOrder();
     try {
-      objects = (
-        stmt.all('idx_workflow_events_run_order', 'remote_agent_workflow_events_assign_order') as {
-          name: string;
-        }[]
-      ).map(o => o.name);
-    } finally {
-      stmt.finalize();
-      raw.close();
-    }
+      expect(columnsOf(uri, 'remote_agent_workflow_events')).not.toContain('event_order');
 
-    expect(objects).toContain('idx_workflow_events_run_order');
-    expect(objects).toContain('remote_agent_workflow_events_assign_order');
+      // Must not throw, and must converge.
+      const upgraded = new SqliteAdapter(uri);
+      await upgraded.close();
+
+      expect(columnsOf(uri, 'remote_agent_workflow_events')).toContain('event_order');
+
+      const raw = new Database(uri);
+      const stmt = raw.prepare('SELECT name FROM sqlite_master WHERE name IN (?, ?)');
+      let objects: string[];
+      try {
+        objects = (
+          stmt.all(
+            'idx_workflow_events_run_order',
+            'remote_agent_workflow_events_assign_order'
+          ) as {
+            name: string;
+          }[]
+        ).map(o => o.name);
+      } finally {
+        stmt.finalize();
+        raw.close();
+      }
+
+      expect(objects).toContain('idx_workflow_events_run_order');
+      expect(objects).toContain('remote_agent_workflow_events_assign_order');
+    } finally {
+      await seed.close();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Problem: the SQLite `event_order` upgrade-path test could time out intermittently on Windows when a real temporary database file remained locked.
- Why it matters: the flaky CI failure delayed unrelated changes and obscured whether the migration itself was correct.
- What changed: the fixture now uses a uniquely named, shared-cache in-memory SQLite URI and retains its seed connection until cleanup.
- What did **not** change (scope boundary): production SQLite behavior, migration SQL, busy timeout, global test timeouts, and test parallelism are unchanged.

## UX Journey

### Before

```
Developer/CI             SQLite upgrade test                Windows filesystem
────────────             ───────────────────                ──────────────────
runs test ────────────▶ creates legacy DB file ───────────▶ opens/closes file handles
                         reopens with SqliteAdapter ───────▶ may wait on a lock
                         assertion can exceed Bun timeout
```

### After

```
Developer/CI             SQLite upgrade test                Shared in-memory SQLite
────────────             ───────────────────                ───────────────────────
runs test ────────────▶ [creates unique named URI] ───────▶ [seed connection retains DB]
                         reopens with SqliteAdapter ───────▶ [runs migration without file locks]
                         verifies column, index, and trigger
```

## Architecture Diagram

### Before

```
sqlite.test.ts fixture ──▶ temporary SQLite file ──▶ bun:sqlite Database
       │                                             │
       └─────────────────────────────────────────────┴──▶ SqliteAdapter initSchema/migrateColumns
```

### After

```
[~] sqlite.test.ts fixture ──▶ [~] named shared-cache in-memory URI ──▶ bun:sqlite Database
       │                                                                    │
       └────────────────────────────────────────────────────────────────────┴──▶ SqliteAdapter initSchema/migrateColumns
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `sqlite.test.ts` fixture | `SqliteAdapter` | unchanged | Reopens the legacy schema and exercises the existing migration path. |
| `sqlite.test.ts` fixture | `bun:sqlite` `Database` | modified | Uses a named shared-cache in-memory URI instead of a temporary filesystem path. |
| `SqliteAdapter` | schema migration SQL | unchanged | Adds `event_order` and restores the existing index and trigger. |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: XS`
- Scope: `tests`
- Module: `core:sqlite-adapter-tests`

## Change Metadata

- Change type: `bug`
- Primary scope: `core`

## Linked Issue

- Closes #2473
- Related #2186, #2306
- Depends on # none
- Supersedes # none

## Validation Evidence (required)

Commands and result summary:

```bash
bun test packages/core/src/db/adapters/sqlite.test.ts  # 22 passed/run; 10 consecutive runs (220 total)
bun run type-check                                   # passed
bun run lint                                         # passed with no warnings
bun run format:check                                 # passed
bun run test                                         # passed
bun run validate                                     # passed
```

- Evidence provided (test/log/trace/screenshot): the focused migration test confirmed `event_order` is absent before the upgrade and present afterward; it also confirmed `idx_workflow_events_run_order` and `remote_agent_workflow_events_assign_order` exist. The fixture artifact check found no `.db`, `-wal`, or `-shm` files.
- If any command is intentionally skipped, explain why: none.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No; the test fixture removes its temporary database-file usage.
- If any `Yes`, describe risk and mitigation: not applicable.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Database migration needed? No; the existing migration logic is unchanged.
- If yes, exact upgrade steps: not applicable.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: the focused test was run ten times; each run retained the full legacy-schema upgrade assertions through the `SqliteAdapter` reopen.
- Edge cases checked: the unique named URI persists across the raw and adapter connections only while the seed stays open, and cleanup closes the retained seed afterward.
- What was not verified: a Windows-hosted run was not performed locally; the change specifically removes the filesystem-handle interaction responsible for that platform's flake.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: only the SQLite adapter's `event_order` legacy-upgrade test fixture.
- Potential unintended effects: a fixture lifecycle mistake could cause the named in-memory database to disappear before assertions; the retained seed connection prevents that.
- Guardrails/monitoring for early detection: existing assertions continue to check the column before and after upgrade, plus the index and trigger; CI runs the focused test and full validation suite.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `380120a524745f9fe856a7045b6c4ecf6abe51d2`.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: the upgrade test would again create a temporary SQLite file and may intermittently time out on Windows.

## Risks and Mitigations

- Risk: named in-memory SQLite state could be destroyed if all connections close before post-upgrade assertions.
  - Mitigation: retain the seed `SqliteAdapter` for the entire test and close it only in async cleanup.

Fixes #2473


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQLite migration regression testing using a shared in-memory database.
  * Ensured database connections are properly closed during successful and failed migration checks.
  * Verified that migrations converge correctly without relying on temporary database files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->