### PR TITLE
feat(core,workflows): per-project default workflow dispatch

### DIFF
--- a/packages/core/src/config/config-loader.ts
+++ b/packages/core/src/config/config-loader.ts
@@ -222,6 +222,13 @@ const DEFAULT_CONFIG_CONTENT = `# Archon Global Configuration
 # Concurrency settings
 # concurrency:
 #   maxConversations: 10
+
+# Per-project default workflow (global only, all platforms).
+# Every non-slash message in a conversation bound to a listed project runs that
+# workflow instead of the AI router. Prefix a message with "? " to ask the AI instead.
+# dispatch:
+#   githubName/githubRepo: assignedWorkflow   # <registered project name>: <workflow name>
+# dispatchSigil: '? '   # escape prefix; quote it — the trailing space is part of it
 `;
 
 /**
@@ -513,6 +520,18 @@ function mergeGlobalConfig(defaults: MergedConfig, global: GlobalConfig): Merged
   // Container backend defaults (folder projects)
   if (global.container) {
     result.container = { ...global.container };
+  }
+
+  // Project → default-workflow interception table. Global-only by design (the
+  // keys are install-level project names), so there is no matching branch in
+  // mergeRepoConfig.
+  if (global.dispatch) {
+    result.dispatch = { ...global.dispatch };
+  }
+  // Passed through raw — the `"? "` default lives in `resolveDispatchSigil`,
+  // not here, so an unset key stays distinguishable from an explicit one.
+  if (global.dispatchSigil !== undefined) {
+    result.dispatchSigil = global.dispatchSigil;
   }
 
   return result;

--- a/packages/core/src/config/config-types.ts
+++ b/packages/core/src/config/config-types.ts
@@ -178,6 +178,51 @@ export interface GlobalConfig {
    * overrides these per-field.
    */
   container?: ContainerConfig;
+
+  /**
+   * Per-project message interception: `<registered project>: <workflow name>`.
+   *
+   * Every non-slash message in a conversation bound to a listed project goes
+   * straight to that workflow, bypassing the AI router. Projects not listed
+   * here are untouched and keep normal routing.
+   *
+   * Global-only by design: the keys are install-level project names (the ones
+   * used with `/register-project <name>` and `/setproject <name>`), which a
+   * repo's own config cannot know — and folder projects have no repo to hold a
+   * config file at all.
+   *
+   * Platform-agnostic: enforced at the single `handleMessage` intake seam, so
+   * it applies identically to Slack, Telegram, Discord, GitHub, web, and CLI.
+   *
+   * Escape hatches, in precedence order:
+   *   1. `/command`  — slash commands route exactly as they do today
+   *   2. `? message` — the `dispatchSigil:` prefix falls through to normal AI chat
+   *
+   * A listed project whose workflow cannot be resolved is reported to the user,
+   * never silently fallen through to the AI router (Fail Fast — a config typo
+   * must not quietly restore the old behavior).
+   *
+   * @example
+   * dispatch:
+   *   githubName/githubRepo: assignedWorkflow
+   */
+  dispatch?: Record<string, string>;
+
+  /**
+   * Prefix that opts a single message out of `dispatch:` and back into normal
+   * AI chat/routing. Defaults to `"? "` — note the trailing space, which is
+   * part of the sigil and is what makes the escape deliberate rather than
+   * accidental (`?!` and `?typo` are content, `? explain this` is a question).
+   *
+   * Global-only, for the same reason as `dispatch:` itself: it is meaningless
+   * without the table it escapes from, and the two must be read together.
+   *
+   * Quote it in YAML — bare trailing whitespace is stripped by the parser:
+   *
+   * @example
+   * dispatchSigil: '? '
+   */
+  dispatchSigil?: string;
 }
 
 /**
@@ -419,6 +464,20 @@ export interface MergedConfig {
    * config is consumed (CLI folder branch). Undefined when nothing is configured.
    */
   container?: ContainerConfig;
+  /**
+   * Project → default-workflow interception table, passed through from global
+   * config. Undefined when nothing is configured (the overwhelmingly common
+   * case), which is what keeps the intake seam a single cheap check. Global-only
+   * by design, so there is no repo-level merge for it.
+   */
+  dispatch?: Record<string, string>;
+  /**
+   * Escape prefix for `dispatch:`, passed through from global config. Undefined
+   * when nothing is configured; the default (`"? "`) is applied where it is
+   * consumed, by `resolveDispatchSigil`, so the raw absence stays visible here.
+   * Global-only by design, so there is no repo-level merge for it.
+   */
+  dispatchSigil?: string;
 }
 
 /**

--- a/packages/core/src/orchestrator/dispatch.test.ts
+++ b/packages/core/src/orchestrator/dispatch.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from 'bun:test';
+
+import { DEFAULT_DISPATCH_SIGIL, resolveDispatch, resolveDispatchSigil } from './dispatch';
+
+const DISPATCH = { 'githubName/githubRepo': 'assignedWorkflow' };
+
+describe('resolveDispatch', () => {
+  describe('when the project is listed in dispatch:', () => {
+    it('routes a plain message to the configured workflow', () => {
+      expect(resolveDispatch('log this note', 'githubName/githubRepo', DISPATCH)).toEqual({
+        kind: 'workflow',
+        workflowName: 'assignedWorkflow',
+        message: 'log this note',
+      });
+    });
+
+    it('passes the message through verbatim, without trimming', () => {
+      // The workflow receives $ARGUMENTS exactly as the user typed it.
+      expect(resolveDispatch('  padded  ', 'githubName/githubRepo', DISPATCH)).toEqual({
+        kind: 'workflow',
+        workflowName: 'assignedWorkflow',
+        message: '  padded  ',
+      });
+    });
+
+    it('leaves slash commands alone', () => {
+      expect(resolveDispatch('/status', 'githubName/githubRepo', DISPATCH)).toEqual({
+        kind: 'chat',
+        message: '/status',
+      });
+    });
+
+    it('leaves a slash command alone even with leading whitespace', () => {
+      expect(resolveDispatch('  /workflow list', 'githubName/githubRepo', DISPATCH)).toEqual({
+        kind: 'chat',
+        message: '  /workflow list',
+      });
+    });
+
+    it('falls through to chat on the sigil, stripping it', () => {
+      expect(resolveDispatch('? what did I log today', 'githubName/githubRepo', DISPATCH)).toEqual({
+        kind: 'chat',
+        message: 'what did I log today',
+      });
+    });
+
+    it('strips whitespace between the sigil and the question', () => {
+      expect(resolveDispatch('?   spaced out', 'githubName/githubRepo', DISPATCH)).toEqual({
+        kind: 'chat',
+        message: 'spaced out',
+      });
+    });
+
+    it('matches the sigil after leading whitespace', () => {
+      expect(resolveDispatch('   ? indented', 'githubName/githubRepo', DISPATCH)).toEqual({
+        kind: 'chat',
+        message: 'indented',
+      });
+    });
+
+    it('passes a bare sigil through rather than handing the AI an empty prompt', () => {
+      expect(resolveDispatch('? ', 'githubName/githubRepo', DISPATCH)).toEqual({
+        kind: 'chat',
+        message: '? ',
+      });
+    });
+
+    it('dispatches a message that merely CONTAINS the sigil', () => {
+      // Only a LEADING sigil escapes — otherwise "did it work? really" would too.
+      expect(resolveDispatch('did it work? really', 'githubName/githubRepo', DISPATCH)).toEqual({
+        kind: 'workflow',
+        workflowName: 'assignedWorkflow',
+        message: 'did it work? really',
+      });
+    });
+
+    it('matches the project key case-insensitively', () => {
+      expect(resolveDispatch('note', 'GithubName/GithubRepo', DISPATCH)).toEqual({
+        kind: 'workflow',
+        workflowName: 'assignedWorkflow',
+        message: 'note',
+      });
+    });
+
+    it('trims a padded workflow name from hand-written YAML', () => {
+      expect(resolveDispatch('note', 'proj', { proj: '  assignedWorkflow  ' })).toEqual({
+        kind: 'workflow',
+        workflowName: 'assignedWorkflow',
+        message: 'note',
+      });
+    });
+  });
+
+  describe('the default sigil requires its trailing separator', () => {
+    // The separator is the whole reason the default is `"? "` and not `"?"`: in
+    // an intake thread, a message that merely opens with a question mark is far
+    // likelier to be content than an instruction to the router.
+    it('dispatches a question mark with no space after it', () => {
+      expect(resolveDispatch('?urgent note', 'githubName/githubRepo', DISPATCH)).toEqual({
+        kind: 'workflow',
+        workflowName: 'assignedWorkflow',
+        message: '?urgent note',
+      });
+    });
+
+    it('dispatches a lone question mark', () => {
+      expect(resolveDispatch('?', 'githubName/githubRepo', DISPATCH)).toEqual({
+        kind: 'workflow',
+        workflowName: 'assignedWorkflow',
+        message: '?',
+      });
+    });
+
+    it('dispatches a doubled question mark', () => {
+      expect(resolveDispatch('?? confusing', 'githubName/githubRepo', DISPATCH)).toEqual({
+        kind: 'workflow',
+        workflowName: 'assignedWorkflow',
+        message: '?? confusing',
+      });
+    });
+  });
+
+  describe('with a configured dispatchSigil', () => {
+    it('honors a custom prefix', () => {
+      expect(resolveDispatch('>> ask the ai', 'githubName/githubRepo', DISPATCH, '>> ')).toEqual({
+        kind: 'chat',
+        message: 'ask the ai',
+      });
+    });
+
+    it('stops honoring the default once a custom prefix is set', () => {
+      expect(resolveDispatch('? still a note', 'githubName/githubRepo', DISPATCH, '>> ')).toEqual({
+        kind: 'workflow',
+        workflowName: 'assignedWorkflow',
+        message: '? still a note',
+      });
+    });
+
+    it('supports a separator-less sigil, restoring the original behavior', () => {
+      expect(resolveDispatch('?hello', 'githubName/githubRepo', DISPATCH, '?')).toEqual({
+        kind: 'chat',
+        message: 'hello',
+      });
+    });
+
+    it('supports a multi-character sigil', () => {
+      expect(resolveDispatch('ai: explain', 'githubName/githubRepo', DISPATCH, 'ai: ')).toEqual({
+        kind: 'chat',
+        message: 'explain',
+      });
+    });
+
+    it('is case-sensitive, unlike the project key', () => {
+      // The project key is written once in YAML, where a capitalization slip is
+      // invisible; the sigil is typed by a human on every message, so matching
+      // exactly what was configured is the predictable rule.
+      expect(resolveDispatch('AI: explain', 'githubName/githubRepo', DISPATCH, 'ai: ')).toEqual({
+        kind: 'workflow',
+        workflowName: 'assignedWorkflow',
+        message: 'AI: explain',
+      });
+    });
+  });
+
+  describe('when dispatch does not apply', () => {
+    it('routes to chat for an unlisted project', () => {
+      expect(resolveDispatch('hello', 'some/other-repo', DISPATCH)).toEqual({
+        kind: 'chat',
+        message: 'hello',
+      });
+    });
+
+    it('leaves a leading sigil INTACT for an unlisted project', () => {
+      // The sigil only means "escape dispatch". Where dispatch does not apply
+      // there is nothing to escape, and eating the `? ` would silently change
+      // what every existing install sends to the AI.
+      expect(resolveDispatch('? hello', 'some/other-repo', DISPATCH)).toEqual({
+        kind: 'chat',
+        message: '? hello',
+      });
+    });
+
+    it('leaves a leading sigil INTACT when dispatch is not configured at all', () => {
+      expect(resolveDispatch('? hello', 'githubName/githubRepo', undefined)).toEqual({
+        kind: 'chat',
+        message: '? hello',
+      });
+    });
+
+    it('routes to chat when no project is bound', () => {
+      expect(resolveDispatch('hello', undefined, DISPATCH)).toEqual({
+        kind: 'chat',
+        message: 'hello',
+      });
+    });
+
+    it('routes to chat when dispatch is not configured', () => {
+      expect(resolveDispatch('hello', 'githubName/githubRepo', undefined)).toEqual({
+        kind: 'chat',
+        message: 'hello',
+      });
+    });
+
+    it('routes to chat when the table is empty', () => {
+      expect(resolveDispatch('hello', 'githubName/githubRepo', {})).toEqual({
+        kind: 'chat',
+        message: 'hello',
+      });
+    });
+  });
+
+  describe('defensive handling of unvalidated YAML', () => {
+    it('ignores a non-string workflow name', () => {
+      const malformed = { 'githubName/githubRepo': 42 } as unknown as Record<string, string>;
+      expect(resolveDispatch('hello', 'githubName/githubRepo', malformed)).toEqual({
+        kind: 'chat',
+        message: 'hello',
+      });
+    });
+
+    it('ignores a blank workflow name', () => {
+      expect(
+        resolveDispatch('hello', 'githubName/githubRepo', { 'githubName/githubRepo': '   ' })
+      ).toEqual({
+        kind: 'chat',
+        message: 'hello',
+      });
+    });
+
+    it('ignores a non-object dispatch value', () => {
+      const malformed = 'assignedWorkflow' as unknown as Record<string, string>;
+      expect(resolveDispatch('hello', 'githubName/githubRepo', malformed)).toEqual({
+        kind: 'chat',
+        message: 'hello',
+      });
+    });
+
+    it('falls back to the default sigil when the configured one is empty', () => {
+      // An empty prefix matches EVERY message, which would turn dispatch off for
+      // the whole install with no error anywhere. It must never be honored.
+      expect(resolveDispatch('a note', 'githubName/githubRepo', DISPATCH, '')).toEqual({
+        kind: 'workflow',
+        workflowName: 'assignedWorkflow',
+        message: 'a note',
+      });
+      expect(resolveDispatch('? a question', 'githubName/githubRepo', DISPATCH, '')).toEqual({
+        kind: 'chat',
+        message: 'a question',
+      });
+    });
+  });
+});
+
+describe('resolveDispatchSigil', () => {
+  it('defaults to a question mark FOLLOWED BY A SPACE', () => {
+    expect(DEFAULT_DISPATCH_SIGIL).toBe('? ');
+    expect(resolveDispatchSigil(undefined)).toBe('? ');
+  });
+
+  it('honors a configured sigil', () => {
+    expect(resolveDispatchSigil('>> ')).toBe('>> ');
+  });
+
+  it('preserves trailing whitespace, which is significant', () => {
+    expect(resolveDispatchSigil('!  ')).toBe('!  ');
+  });
+
+  it('rejects an empty or whitespace-only sigil', () => {
+    expect(resolveDispatchSigil('')).toBe('? ');
+    expect(resolveDispatchSigil('   ')).toBe('? ');
+  });
+
+  it('rejects a non-string sigil from unvalidated YAML', () => {
+    expect(resolveDispatchSigil(42 as unknown as string)).toBe('? ');
+    expect(resolveDispatchSigil(null as unknown as string)).toBe('? ');
+  });
+});

--- a/packages/core/src/orchestrator/dispatch.ts
+++ b/packages/core/src/orchestrator/dispatch.ts
@@ -1,0 +1,143 @@
+/**
+ * Convention-based default-workflow dispatch.
+ *
+ * Decides what an inbound message MEANS for a conversation whose project is
+ * listed in the global `dispatch:` table: run that project's default workflow,
+ * or fall through to normal AI chat/routing.
+ *
+ * Kept deliberately pure and I/O-free: the
+ * whole policy is decidable from the message text, the bound project's name,
+ * the config table, and the configured sigil, so it is unit-testable without a
+ * DB, an adapter, or a loaded config. Everything that needs I/O — reading the
+ * config, resolving the codebase, resolving the workflow, running it — stays in
+ * the caller. That is why the sigil arrives as a parameter rather than being
+ * read from config here.
+ */
+
+/**
+ * Default prefix that opts a single message OUT of dispatch and back into
+ * normal AI chat/routing.
+ *
+ * The trailing space is part of the sigil, and is the point of it: `? how does
+ * this work` escapes, while `?!`, `??`, or a bare `?typo` do not. Requiring a
+ * separator makes the escape hatch deliberate — in an intake thread, a message
+ * that merely happens to begin with a question mark is far more likely to be
+ * content than an instruction to the router.
+ *
+ * Override per install with `dispatchSigil:` in `~/.archon/config.yaml`.
+ */
+export const DEFAULT_DISPATCH_SIGIL = '? ';
+
+/**
+ * Normalize a configured `dispatchSigil:` into the prefix to actually match.
+ *
+ * The value comes from YAML that is cast, not schema-validated, so a non-string
+ * or an all-whitespace sigil falls back to the default instead of being used
+ * as-is. That guard is load-bearing rather than cosmetic: `''.startsWith` and
+ * `'   '` against a leading-trimmed message both match essentially everything,
+ * so an empty sigil would route every message in every dispatched project to
+ * the AI — silently disabling the feature install-wide with no error anywhere.
+ *
+ * The value is deliberately NOT trimmed. Trailing whitespace is significant —
+ * it is exactly what makes the default `'? '` require a separator.
+ */
+export function resolveDispatchSigil(configured: string | undefined): string {
+  return typeof configured === 'string' && configured.trim() ? configured : DEFAULT_DISPATCH_SIGIL;
+}
+
+/** What should happen to this message. */
+export type DispatchDecision =
+  /** Route normally (AI chat / router). `message` may have had the sigil stripped. */
+  | { readonly kind: 'chat'; readonly message: string }
+  /** Run the project's configured default workflow with `message` as its input. */
+  | { readonly kind: 'workflow'; readonly workflowName: string; readonly message: string };
+
+/**
+ * Look up a project's default workflow in the `dispatch:` table.
+ *
+ * The table comes from YAML that is cast, not schema-validated, so both the map
+ * and its values are checked defensively. Keys are matched exactly first, then
+ * case-insensitively — exact mirrors `findCodebaseByName` (the SQL lookup every
+ * other project-name resolution uses), and the case-insensitive pass keeps a
+ * capitalization typo in hand-written YAML from silently disabling the whole
+ * feature for that project.
+ */
+function lookupDefaultWorkflow(
+  dispatch: Record<string, string> | undefined,
+  codebaseName: string | undefined
+): string | undefined {
+  if (!dispatch || typeof dispatch !== 'object' || !codebaseName) return undefined;
+
+  const exact = dispatch[codebaseName];
+  if (typeof exact === 'string' && exact.trim()) return exact.trim();
+
+  const lowered = codebaseName.toLowerCase();
+  for (const [project, workflowName] of Object.entries(dispatch)) {
+    if (
+      project.toLowerCase() === lowered &&
+      typeof workflowName === 'string' &&
+      workflowName.trim()
+    ) {
+      return workflowName.trim();
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Decide whether `message` should run the bound project's default workflow.
+ *
+ * Precedence, highest first:
+ *   1. `/command`   — slash commands always route as they do today, untouched.
+ *   2. unlisted project — normal AI chat/routing, message untouched.
+ *   3. `? message`  — the sigil forces normal AI chat/routing for this message.
+ *   4. otherwise    — the listed project's default workflow.
+ *
+ * The mapping is checked BEFORE the sigil, so the sigil only means anything in
+ * a conversation that would otherwise dispatch. Checking it first would make
+ * every install silently swallow a leading `?` even with no `dispatch:`
+ * configured — a behavior change for threads this feature should not touch.
+ *
+ * @param message         Raw inbound message text.
+ * @param codebaseName    Name of the project bound to the conversation, if any.
+ *                        Undefined for unscoped conversations, which never dispatch.
+ * @param dispatch        The global `dispatch:` table, if configured.
+ * @param configuredSigil The global `dispatchSigil:`, if configured. Omitted or
+ *                        unusable falls back to {@link DEFAULT_DISPATCH_SIGIL}.
+ */
+export function resolveDispatch(
+  message: string,
+  codebaseName: string | undefined,
+  dispatch: Record<string, string> | undefined,
+  configuredSigil?: string
+): DispatchDecision {
+  const trimmed = message.trim();
+
+  // 1. Slash commands are unchanged — including the non-deterministic ones the
+  //    caller forwards to the AI, which must keep reaching it.
+  if (trimmed.startsWith('/')) return { kind: 'chat', message };
+
+  // 2. Not a dispatched project — nothing to intercept, and nothing to escape
+  //    from, so the message passes through byte-for-byte.
+  const workflowName = lookupDefaultWorkflow(dispatch, codebaseName);
+  if (!workflowName) return { kind: 'chat', message };
+
+  // 3. Sigil escape. Matched against the message with only its LEADING
+  //    whitespace stripped, never the fully trimmed form: a sigil that ends in
+  //    a separator (the default `'? '` does) can never prefix a string whose
+  //    trailing whitespace has already been removed, so trimming first would
+  //    make the default sigil unmatchable for a sigil-only message.
+  //
+  //    The sigil is consumed so the AI sees the real question; a sigil with
+  //    nothing after it would strip to nothing, so pass the original through
+  //    instead of handing the AI an empty prompt.
+  const sigil = resolveDispatchSigil(configuredSigil);
+  const leading = message.replace(/^\s+/, '');
+  if (leading.startsWith(sigil)) {
+    const stripped = leading.slice(sigil.length).trim();
+    return { kind: 'chat', message: stripped || message };
+  }
+
+  // 4. Plain message in a dispatched project → its default workflow.
+  return { kind: 'workflow', workflowName, message };
+}

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1255,7 +1255,10 @@ describe('discoverAllWorkflows — remote sync', () => {
     mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
     mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
     mockGetCodebaseEnvVars.mockResolvedValueOnce({ DB_SECRET: 'db-value' });
-    mockLoadConfig.mockResolvedValueOnce({
+    // Not `...Once`: handleMessage reads config more than once per turn (the
+    // dispatch lookup, then the chat path), and a single-shot queue would hand
+    // the second reader the default mock. beforeEach resets this.
+    mockLoadConfig.mockResolvedValue({
       assistants: { claude: {}, codex: {} },
       envVars: { FILE_SECRET: 'file-value' },
     });
@@ -1287,7 +1290,10 @@ describe('discoverAllWorkflows — remote sync', () => {
     mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
     mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
     mockGetCodebaseEnvVars.mockRejectedValueOnce(new Error('db unavailable'));
-    mockLoadConfig.mockResolvedValueOnce({
+    // Not `...Once`: handleMessage reads config more than once per turn (the
+    // dispatch lookup, then the chat path), and a single-shot queue would hand
+    // the second reader the default mock. beforeEach resets this.
+    mockLoadConfig.mockResolvedValue({
       assistants: { claude: {}, codex: {} },
       envVars: { FILE_SECRET: 'file-value' },
     });

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -1102,16 +1102,32 @@ async function runDispatchedWorkflow(
     { conversationId, workflowName: workflow.name, codebaseId: conversation.codebase_id },
     'orchestrator.dispatch_started'
   );
-  await handleWorkflowRunCommand(
-    platform,
-    conversationId,
-    conversation,
-    workflow,
-    message,
-    isolationHints,
-    userId,
-    { attachments }
-  );
+  try {
+    await handleWorkflowRunCommand(
+      platform,
+      conversationId,
+      conversation,
+      workflow,
+      message,
+      isolationHints,
+      userId,
+      { attachments }
+    );
+  } catch (error) {
+    // Re-thrown, not swallowed — `handleMessage`'s catch is what tells the user.
+    // Logged here anyway because that catch knows only the conversation: this is
+    // the only frame that can name the workflow the dispatch table chose, which
+    // is the first thing an operator debugging a bad mapping needs.
+    getLog().error(
+      { err: toError(error), conversationId, workflowName: workflow.name },
+      'orchestrator.dispatch_failed'
+    );
+    throw error;
+  }
+  // Terminal pair for `dispatch_started`. Scoped to the DISPATCH, not the run:
+  // a background workflow returns here once it has been STARTED, so this marks a
+  // successful hand-off to the run machinery, never a finished workflow.
+  getLog().info({ conversationId, workflowName: workflow.name }, 'orchestrator.dispatch_completed');
 }
 
 // ─── Session Helpers ────────────────────────────────────────────────────────

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -27,6 +27,7 @@ import { toError } from '../utils/error';
 import { safeDeactivateSession } from '../state/session-transitions';
 import { getAgentProvider, getProviderCapabilities } from '@archon/providers';
 import { buildManageRunTool } from './manage-run-tool';
+import { resolveDispatch, resolveDispatchSigil, type DispatchDecision } from './dispatch';
 import { getArchonWorkspacesPath, ensureArchonWorkspacesPath } from '@archon/paths';
 import { syncArchonToWorktree } from '../utils/worktree-sync';
 import {
@@ -627,6 +628,14 @@ interface WorkflowDispatchOptions {
    * picker.
    */
   parseWarnings?: readonly string[];
+
+  /**
+   * Files that arrived with the triggering message. Delivered to the run as the
+   * `ARCHON_ATTACHMENTS` env var for `bash:`/`script:` nodes. Rides in the
+   * options bag so both entry points (`handleWorkflowRunCommand` for
+   * `/workflow run`, and default-workflow dispatch) thread it the same way.
+   */
+  attachments?: readonly AttachedFile[];
 }
 
 const FAILED_RUN_PROMPT_PREVIEW_MAX = 160;
@@ -921,6 +930,7 @@ async function dispatchOrchestratorWorkflow(
           userId,
           source,
           parseWarnings: options?.parseWarnings,
+          attachments: options?.attachments,
           baseBranch: codebaseBaseBranch,
           resolveChildIsolation,
           ...prepared,
@@ -945,6 +955,7 @@ async function dispatchOrchestratorWorkflow(
           userId,
           source,
           parseWarnings: options?.parseWarnings,
+          attachments: options?.attachments,
           baseBranch: codebaseBaseBranch,
           resolveChildIsolation,
         }
@@ -965,6 +976,7 @@ async function dispatchOrchestratorWorkflow(
         userId,
         source,
         parseWarnings: options?.parseWarnings,
+        attachments: options?.attachments,
       },
       workflow
     );
@@ -984,11 +996,122 @@ async function dispatchOrchestratorWorkflow(
         userId,
         source,
         parseWarnings: options?.parseWarnings,
+        attachments: options?.attachments,
         baseBranch: codebaseBaseBranch,
         resolveChildIsolation,
       }
     );
   }
+}
+
+// ─── Default-Workflow Dispatch ──────────────────────────────────────────────
+
+/**
+ * Decide what the global `dispatch:` table means for this conversation's next
+ * message.
+ *
+ * Split from the execution below so `handleMessage` reads as decide-then-act.
+ * Ordered cheapest-check-first: an unscoped conversation costs nothing, and an
+ * install with no `dispatch:` configured (the overwhelming majority) costs one
+ * memoized global-config read and never touches the database. `loadConfig()` is
+ * called without a repo path on purpose — `dispatch:` is global-only, so the
+ * repo layer has nothing to contribute.
+ */
+async function resolveConversationDispatch(
+  conversation: Conversation,
+  message: string
+): Promise<DispatchDecision> {
+  if (!conversation.codebase_id) return { kind: 'chat', message };
+
+  const { dispatch, dispatchSigil } = await loadConfig();
+  if (!dispatch || Object.keys(dispatch).length === 0) return { kind: 'chat', message };
+
+  const codebase = await codebaseDb.getCodebase(conversation.codebase_id);
+  return resolveDispatch(message, codebase?.name, dispatch, dispatchSigil);
+}
+
+/**
+ * Run the default workflow that a `dispatch:` entry names.
+ *
+ * A configured-but-unresolvable workflow is reported to the user and the
+ * message is dropped — never quietly forwarded to the AI router. Silently
+ * reverting a dispatched project to normal routing is the failure mode that is
+ * hardest to notice from inside a chat thread, since the reply still looks
+ * plausible (Fail Fast + Explicit Errors).
+ *
+ * Execution reuses `handleWorkflowRunCommand`, the same path `/workflow run`
+ * takes, so isolation resolution, `requires:` gates, and resume detection all
+ * behave identically however the workflow was chosen.
+ */
+async function runDispatchedWorkflow(
+  platform: IPlatformAdapter,
+  conversationId: string,
+  conversation: Conversation,
+  workflowName: string,
+  message: string,
+  isolationHints: HandleMessageContext['isolationHints'],
+  userId: string | undefined,
+  attachments: readonly AttachedFile[] | undefined
+): Promise<void> {
+  const { workflows: discovered } = await discoverAllWorkflows(conversation);
+  const available = discovered.map(w => w.workflow);
+
+  // Needed only by the two failure paths below, but naming the install's actual
+  // escape prefix is the whole point of telling the user about it — a hardcoded
+  // `?` would be wrong advice on any install that configured `dispatchSigil:`.
+  // `loadConfig` is memoized, so this re-read costs nothing.
+  const sigil = resolveDispatchSigil((await loadConfig()).dispatchSigil);
+
+  let workflow: WorkflowDefinition | undefined;
+  try {
+    workflow = resolveWorkflowName(workflowName, available);
+  } catch (error) {
+    // resolveWorkflowName throws only on ambiguity (a fuzzy tier matched more
+    // than one workflow). Report the ambiguity verbatim — it names the
+    // candidates, which is exactly what the operator needs to fix the mapping.
+    getLog().error(
+      { err: error as Error, conversationId, workflowName },
+      'orchestrator.dispatch_workflow_ambiguous'
+    );
+    await platform.sendMessage(
+      conversationId,
+      `⚠️ This project's default workflow \`${workflowName}\` (\`dispatch:\` in ` +
+        `\`~/.archon/config.yaml\`) is ambiguous: ${(error as Error).message}\n\n` +
+        'Nothing was run. Use the exact workflow name, or prefix a message with ' +
+        `\`${sigil}\` to chat with the AI instead.`
+    );
+    return;
+  }
+
+  if (!workflow) {
+    getLog().error(
+      { conversationId, workflowName, availableCount: available.length },
+      'orchestrator.dispatch_workflow_not_found'
+    );
+    await platform.sendMessage(
+      conversationId,
+      `⚠️ This project's default workflow \`${workflowName}\` (\`dispatch:\` in ` +
+        '`~/.archon/config.yaml`) was not found.\n\n' +
+        'Nothing was run. Fix the mapping, check `/workflow list`, or prefix a ' +
+        `message with \`${sigil}\` to chat with the AI instead.`
+    );
+    return;
+  }
+
+  getLog().info(
+    { conversationId, workflowName: workflow.name, codebaseId: conversation.codebase_id },
+    'orchestrator.dispatch_started'
+  );
+  await handleWorkflowRunCommand(
+    platform,
+    conversationId,
+    conversation,
+    workflow,
+    message,
+    isolationHints,
+    userId,
+    { attachments }
+  );
 }
 
 // ─── Session Helpers ────────────────────────────────────────────────────────
@@ -1393,12 +1516,40 @@ export async function handleMessage(
               resumeRunId: result.workflow.resumeRunId,
               resumeRun: result.workflow.resumeRun,
               parseWarnings: result.workflow.parseWarnings,
+              attachments: attachedFiles,
             }
           );
         }
         return;
       }
     }
+
+    // 3. Convention-based default-workflow dispatch. A conversation bound to a
+    // project listed in `dispatch:` sends every plain message straight to that
+    // project's workflow, bypassing the AI router. Slash commands already
+    // returned above; a message led by the escape sigil (`dispatchSigil:`,
+    // default `"? "`) falls through to chat below.
+    //
+    // Placed after the paused-approval branch so answering an open gate still
+    // wins, and before the message-persistence block so a dispatched turn
+    // creates no orphan user row — exactly how `/workflow run` behaves.
+    const dispatchDecision = await resolveConversationDispatch(conversation, message);
+    if (dispatchDecision.kind === 'workflow') {
+      await runDispatchedWorkflow(
+        platform,
+        conversationId,
+        conversation,
+        dispatchDecision.workflowName,
+        dispatchDecision.message,
+        isolationHints,
+        userId,
+        attachedFiles
+      );
+      return;
+    }
+    // From here on `message` is the ROUTED text: byte-for-byte the inbound
+    // message, except in a dispatched project where a leading sigil was consumed.
+    message = dispatchDecision.message;
 
     // Persist the inbound user message for non-web platforms (Slack/Telegram/
     // GitHub/Discord/CLI) — the web adapter's route persists web turns itself.

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -44,6 +44,7 @@ import {
   configureIsolation,
   getIsolationProvider,
 } from '@archon/isolation';
+import type { AttachedFile } from '../types';
 import * as db from '../db/conversations';
 import { createIsolationStore } from '../db/isolation-environments';
 import { toError } from '../utils/error';
@@ -290,6 +291,12 @@ export interface WorkflowRoutingContext {
    * other, independently of the chat notification.
    */
   readonly parseWarnings?: readonly string[];
+
+  /**
+   * Files that arrived with the triggering message. Forwarded to the run as the
+   * `ARCHON_ATTACHMENTS` env var for `bash:`/`script:` nodes.
+   */
+  readonly attachments?: readonly AttachedFile[];
 }
 
 /**
@@ -463,6 +470,7 @@ export async function dispatchBackgroundWorkflow(
             userId: ctx.userId,
             source: ctx.source,
             parseWarnings: ctx.parseWarnings,
+            attachments: ctx.attachments,
             baseBranch: codebaseBaseBranch,
             resolveChildIsolation,
           }

--- a/packages/docs-web/src/content/docs/reference/configuration.md
+++ b/packages/docs-web/src/content/docs/reference/configuration.md
@@ -116,6 +116,66 @@ aliases:
 
 The `tiers:` block above is no longer hand-edit-only -- you can also set the `small`/`medium`/`large` presets from the console **AI Settings** -> **Model Tiers** panel, or from the CLI with [`archon ai tier set`](/reference/cli/#ai). Connecting your own provider API key or subscription is covered in [Per-user credentials and AI Settings](/getting-started/ai-assistants/#per-user-credentials-and-ai-settings).
 
+### Default workflow dispatch (`dispatch`)
+
+Makes a project **convention-based**: every plain message in a conversation bound to that project runs one specific workflow, instead of asking the AI router to pick. Useful for integration projects where the thread is an intake channel, not a conversation.
+
+Valid on **global** `~/.archon/config.yaml` only — the keys are install-level project names (the ones used with `/register-project <name> <path>` and `/setproject <name>`), which a project's own repo config cannot know, and folder projects have no repo to hold a config file at all:
+
+```yaml
+dispatch:
+  githubName/githubRepo: assignedWorkflow # <registered project name>: <workflow name>
+```
+
+**How a message is routed** in a listed project:
+
+| Message          | Goes to                             |
+| ---------------- | ----------------------------------- |
+| `add a note`     | the `assignedWorkflow` workflow     |
+| `/workflow list` | the slash command, exactly as today |
+| `? what's in it` | normal AI chat, as `what's in it`   |
+| `?urgent note`   | the `assignedWorkflow` workflow     |
+
+**Semantics:**
+
+- **Every platform** — enforced at Archon's single message-intake seam, so Slack, Telegram, Discord, GitHub, the web UI, and `archon chat` all behave identically. There is nothing per-adapter to configure.
+- **Unlisted projects are untouched** — they keep normal AI routing, byte for byte. So does every conversation with no project bound.
+- **Slash commands always win** — `/help`, `/workflow`, `/setproject` and friends are never intercepted.
+- **A `?` followed by a space escapes a single message** — the prefix is consumed, so the AI sees the question without it. **The trailing space is part of it**: `? what's in it` escapes, but `?urgent note`, `??`, and a lone `?` are ordinary content and still dispatch. Only a *leading* prefix escapes (`did it work? really` still dispatches), and it is only special in a project that actually dispatches — everywhere else it is ordinary text. Change it with [`dispatchSigil`](#escape-prefix-dispatchsigil).
+- **An open approval gate still wins** — if a workflow in the thread is paused awaiting approval, your reply answers the gate rather than starting a new run.
+- **Fails loud, not soft** — if the named workflow can't be resolved (typo, deleted workflow, ambiguous name), Archon says so in the thread and runs nothing. It never silently falls back to the AI router, because a plausible-looking AI reply is the hardest failure to notice from inside a chat thread.
+- **Matching** — project names are matched exactly first, then case-insensitively, so a capitalization slip in hand-written YAML still resolves.
+- **Restart required** — like all global config, `~/.archon/config.yaml` is read once and cached for the life of the server process. Restart Archon after editing `dispatch:`.
+
+#### Escape prefix (`dispatchSigil`)
+
+The escape prefix defaults to `"? "` — a question mark **and a trailing space**. The space is deliberate: in an intake thread, a message that merely opens with a question mark is far more likely to be content than an instruction to the router, so the escape has to be typed as a separated prefix to count.
+
+Override it per install alongside `dispatch:` (global config only):
+
+```yaml
+dispatch:
+  githubName/githubRepo: assignedWorkflow
+
+dispatchSigil: '>> ' # now `>> what's in it` escapes, and `? anything` does not
+```
+
+- **Quote it.** YAML strips unquoted trailing whitespace, so an unquoted `dispatchSigil: ?` followed by a space silently becomes `?`. Always write `'? '`.
+- **Any string works** — `'>> '`, `'ai: '`, `'!'`. Set it to `'?'` (no space) to restore the original behavior, where any leading question mark escapes.
+- **Case-sensitive**, unlike project keys: with `dispatchSigil: 'ai: '`, `AI: explain` dispatches. The project key is written once in YAML where a capitalization slip is invisible; the sigil is retyped on every message, so matching exactly what you configured is the predictable rule.
+- **An empty or whitespace-only value is ignored** and the default is used. An empty prefix would match every message and silently disable dispatch install-wide.
+- The prefix Archon quotes back to you in its error messages is the one your install actually uses.
+
+**Attachments.** Files that arrive with a dispatched message (Slack/Discord uploads, web UI attachments) are exposed to that run's `bash:` and `script:` nodes as the `ARCHON_ATTACHMENTS` environment variable — a JSON array, always set, so a script can parse it without checking for presence:
+
+```ts
+// Inside a script: node
+const attachments = JSON.parse(process.env.ARCHON_ATTACHMENTS ?? '[]');
+// → [{ path: '/abs/path/note.pdf', name: 'note.pdf', mimeType: 'application/pdf', size: 1234 }]
+```
+
+`ARCHON_ATTACHMENTS` is set for **every** run, not just dispatched ones — `/workflow run` with a file attached populates it too.
+
 ## Repository Configuration
 
 Create `.archon/config.yaml` in any repository for project-specific settings:
@@ -295,66 +355,6 @@ container:
 ```
 
 **Selection precedence:** `--container` flag > workflow `container.enabled` > config `container.enabled` > `false`. (A workflow `enabled: false` hard-disables relative to config, but the flag still wins.)
-
-### Default workflow dispatch (`dispatch`)
-
-Makes a project **convention-based**: every plain message in a conversation bound to that project runs one specific workflow, instead of asking the AI router to pick. Useful for integration projects where the thread is an intake channel, not a conversation.
-
-Valid on **global** `~/.archon/config.yaml` only — the keys are install-level project names (the ones used with `/register-project <name> <path>` and `/setproject <name>`), which a project's own repo config cannot know, and folder projects have no repo to hold a config file at all:
-
-```yaml
-dispatch:
-  githubName/githubRepo: assignedWorkflow # <registered project name>: <workflow name>
-```
-
-**How a message is routed** in a listed project:
-
-| Message          | Goes to                             |
-| ---------------- | ----------------------------------- |
-| `add a note`     | the `assignedWorkflow` workflow     |
-| `/workflow list` | the slash command, exactly as today |
-| `? what's in it` | normal AI chat, as `what's in it`   |
-| `?urgent note`   | the `assignedWorkflow` workflow     |
-
-**Semantics:**
-
-- **Every platform** — enforced at Archon's single message-intake seam, so Slack, Telegram, Discord, GitHub, the web UI, and `archon chat` all behave identically. There is nothing per-adapter to configure.
-- **Unlisted projects are untouched** — they keep normal AI routing, byte for byte. So does every conversation with no project bound.
-- **Slash commands always win** — `/help`, `/workflow`, `/setproject` and friends are never intercepted.
-- **`? ` escapes a single message** — the prefix is consumed, so the AI sees the question without it. **The trailing space is part of it**: `? what's in it` escapes, but `?urgent note`, `??`, and a lone `?` are ordinary content and still dispatch. Only a *leading* prefix escapes (`did it work? really` still dispatches), and it is only special in a project that actually dispatches — everywhere else it is ordinary text. Change it with [`dispatchSigil`](#escape-prefix-dispatchsigil).
-- **An open approval gate still wins** — if a workflow in the thread is paused awaiting approval, your reply answers the gate rather than starting a new run.
-- **Fails loud, not soft** — if the named workflow can't be resolved (typo, deleted workflow, ambiguous name), Archon says so in the thread and runs nothing. It never silently falls back to the AI router, because a plausible-looking AI reply is the hardest failure to notice from inside a chat thread.
-- **Matching** — project names are matched exactly first, then case-insensitively, so a capitalization slip in hand-written YAML still resolves.
-- **Restart required** — like all global config, `~/.archon/config.yaml` is read once and cached for the life of the server process. Restart Archon after editing `dispatch:`.
-
-#### Escape prefix (`dispatchSigil`)
-
-The escape prefix defaults to `"? "` — a question mark **and a trailing space**. The space is deliberate: in an intake thread, a message that merely opens with a question mark is far more likely to be content than an instruction to the router, so the escape has to be typed as a separated prefix to count.
-
-Override it per install alongside `dispatch:` (global config only):
-
-```yaml
-dispatch:
-  githubName/githubRepo: assignedWorkflow
-
-dispatchSigil: '>> ' # now `>> what's in it` escapes, and `? anything` does not
-```
-
-- **Quote it.** YAML strips unquoted trailing whitespace, so `dispatchSigil: ? ` silently becomes `?`. Always write `'? '`.
-- **Any string works** — `'>> '`, `'ai: '`, `'!'`. Set it to `'?'` (no space) to restore the original behavior, where any leading question mark escapes.
-- **Case-sensitive**, unlike project keys: with `dispatchSigil: 'ai: '`, `AI: explain` dispatches. The project key is written once in YAML where a capitalization slip is invisible; the sigil is retyped on every message, so matching exactly what you configured is the predictable rule.
-- **An empty or whitespace-only value is ignored** and the default is used. An empty prefix would match every message and silently disable dispatch install-wide.
-- The prefix Archon quotes back to you in its error messages is the one your install actually uses.
-
-**Attachments.** Files that arrive with a dispatched message (Slack/Discord uploads, web UI attachments) are exposed to that run's `bash:` and `script:` nodes as the `ARCHON_ATTACHMENTS` environment variable — a JSON array, always set, so a script can parse it without checking for presence:
-
-```ts
-// Inside a script: node
-const attachments = JSON.parse(process.env.ARCHON_ATTACHMENTS ?? '[]');
-// → [{ path: '/abs/path/note.pdf', name: 'note.pdf', mimeType: 'application/pdf', size: 1234 }]
-```
-
-`ARCHON_ATTACHMENTS` is set for **every** run, not just dispatched ones — `/workflow run` with a file attached populates it too.
 
 **Write-back mode** is a per-workflow policy (not a config key). After a container run finishes, its overlay diff is reviewed before touching the live root:
 

--- a/packages/docs-web/src/content/docs/reference/configuration.md
+++ b/packages/docs-web/src/content/docs/reference/configuration.md
@@ -96,6 +96,11 @@ paths:
 concurrency:
   maxConversations: 10
 
+# Per-project default workflow (global only) — see "Default workflow dispatch" below
+dispatch:
+  githubName/githubRepo: assignedWorkflow # <registered project name>: <workflow name>
+dispatchSigil: '? ' # prefix that escapes a single message back to AI chat (default)
+
 # Model tiers — optional cross-provider presets used by bundled workflows,
 # custom workflows, direct chat (`large`), and title generation (`small`).
 tiers:
@@ -290,6 +295,66 @@ container:
 ```
 
 **Selection precedence:** `--container` flag > workflow `container.enabled` > config `container.enabled` > `false`. (A workflow `enabled: false` hard-disables relative to config, but the flag still wins.)
+
+### Default workflow dispatch (`dispatch`)
+
+Makes a project **convention-based**: every plain message in a conversation bound to that project runs one specific workflow, instead of asking the AI router to pick. Useful for integration projects where the thread is an intake channel, not a conversation.
+
+Valid on **global** `~/.archon/config.yaml` only — the keys are install-level project names (the ones used with `/register-project <name> <path>` and `/setproject <name>`), which a project's own repo config cannot know, and folder projects have no repo to hold a config file at all:
+
+```yaml
+dispatch:
+  githubName/githubRepo: assignedWorkflow # <registered project name>: <workflow name>
+```
+
+**How a message is routed** in a listed project:
+
+| Message          | Goes to                             |
+| ---------------- | ----------------------------------- |
+| `add a note`     | the `assignedWorkflow` workflow     |
+| `/workflow list` | the slash command, exactly as today |
+| `? what's in it` | normal AI chat, as `what's in it`   |
+| `?urgent note`   | the `assignedWorkflow` workflow     |
+
+**Semantics:**
+
+- **Every platform** — enforced at Archon's single message-intake seam, so Slack, Telegram, Discord, GitHub, the web UI, and `archon chat` all behave identically. There is nothing per-adapter to configure.
+- **Unlisted projects are untouched** — they keep normal AI routing, byte for byte. So does every conversation with no project bound.
+- **Slash commands always win** — `/help`, `/workflow`, `/setproject` and friends are never intercepted.
+- **`? ` escapes a single message** — the prefix is consumed, so the AI sees the question without it. **The trailing space is part of it**: `? what's in it` escapes, but `?urgent note`, `??`, and a lone `?` are ordinary content and still dispatch. Only a *leading* prefix escapes (`did it work? really` still dispatches), and it is only special in a project that actually dispatches — everywhere else it is ordinary text. Change it with [`dispatchSigil`](#escape-prefix-dispatchsigil).
+- **An open approval gate still wins** — if a workflow in the thread is paused awaiting approval, your reply answers the gate rather than starting a new run.
+- **Fails loud, not soft** — if the named workflow can't be resolved (typo, deleted workflow, ambiguous name), Archon says so in the thread and runs nothing. It never silently falls back to the AI router, because a plausible-looking AI reply is the hardest failure to notice from inside a chat thread.
+- **Matching** — project names are matched exactly first, then case-insensitively, so a capitalization slip in hand-written YAML still resolves.
+- **Restart required** — like all global config, `~/.archon/config.yaml` is read once and cached for the life of the server process. Restart Archon after editing `dispatch:`.
+
+#### Escape prefix (`dispatchSigil`)
+
+The escape prefix defaults to `"? "` — a question mark **and a trailing space**. The space is deliberate: in an intake thread, a message that merely opens with a question mark is far more likely to be content than an instruction to the router, so the escape has to be typed as a separated prefix to count.
+
+Override it per install alongside `dispatch:` (global config only):
+
+```yaml
+dispatch:
+  githubName/githubRepo: assignedWorkflow
+
+dispatchSigil: '>> ' # now `>> what's in it` escapes, and `? anything` does not
+```
+
+- **Quote it.** YAML strips unquoted trailing whitespace, so `dispatchSigil: ? ` silently becomes `?`. Always write `'? '`.
+- **Any string works** — `'>> '`, `'ai: '`, `'!'`. Set it to `'?'` (no space) to restore the original behavior, where any leading question mark escapes.
+- **Case-sensitive**, unlike project keys: with `dispatchSigil: 'ai: '`, `AI: explain` dispatches. The project key is written once in YAML where a capitalization slip is invisible; the sigil is retyped on every message, so matching exactly what you configured is the predictable rule.
+- **An empty or whitespace-only value is ignored** and the default is used. An empty prefix would match every message and silently disable dispatch install-wide.
+- The prefix Archon quotes back to you in its error messages is the one your install actually uses.
+
+**Attachments.** Files that arrive with a dispatched message (Slack/Discord uploads, web UI attachments) are exposed to that run's `bash:` and `script:` nodes as the `ARCHON_ATTACHMENTS` environment variable — a JSON array, always set, so a script can parse it without checking for presence:
+
+```ts
+// Inside a script: node
+const attachments = JSON.parse(process.env.ARCHON_ATTACHMENTS ?? '[]');
+// → [{ path: '/abs/path/note.pdf', name: 'note.pdf', mimeType: 'application/pdf', size: 1234 }]
+```
+
+`ARCHON_ATTACHMENTS` is set for **every** run, not just dispatched ones — `/workflow run` with a file attached populates it too.
 
 **Write-back mode** is a per-workflow policy (not a config key). After a container run finishes, its overlay diff is reviewed before touching the live root:
 

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -1373,9 +1373,77 @@ describe('executeWorkflow', () => {
       // DB env vars should have been fetched for the codebaseId
       expect(store.getCodebaseEnvVars).toHaveBeenCalledWith('codebase-1');
 
-      // The config passed to executeDagWorkflow (arg index 12) should have merged envVars
+      // The config passed to executeDagWorkflow (arg index 13) should have merged envVars.
+      // ARCHON_ATTACHMENTS is always present — see the attachments suite below.
       const configArg = mockExecuteDagWorkflow.mock.calls[0]?.[13] as WorkflowConfig | undefined;
-      expect(configArg?.envVars).toEqual({ FILE_KEY: 'file_val', DB_KEY: 'db_val' });
+      expect(configArg?.envVars).toEqual({
+        FILE_KEY: 'file_val',
+        DB_KEY: 'db_val',
+        ARCHON_ATTACHMENTS: '[]',
+      });
+    });
+
+    it('exposes inbound attachments to bash/script nodes as ARCHON_ATTACHMENTS', async () => {
+      const deps = makeDeps(makeStore());
+      const attachment = {
+        path: '/tmp/uploads/note.pdf',
+        name: 'note.pdf',
+        mimeType: 'application/pdf',
+        size: 1234,
+      };
+
+      await executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-1',
+        '/tmp',
+        makeWorkflow(),
+        'test message',
+        'db-conv-1',
+        { attachments: [attachment] }
+      );
+
+      const configArg = mockExecuteDagWorkflow.mock.calls[0]?.[13] as WorkflowConfig | undefined;
+      expect(JSON.parse(configArg?.envVars?.ARCHON_ATTACHMENTS ?? 'null')).toEqual([attachment]);
+    });
+
+    it('sets ARCHON_ATTACHMENTS to an empty array when nothing was attached', async () => {
+      // Always set, so a script can JSON.parse without a presence check.
+      const deps = makeDeps(makeStore());
+
+      await executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-1',
+        '/tmp',
+        makeWorkflow(),
+        'test message',
+        'db-conv-1'
+      );
+
+      const configArg = mockExecuteDagWorkflow.mock.calls[0]?.[13] as WorkflowConfig | undefined;
+      expect(configArg?.envVars?.ARCHON_ATTACHMENTS).toBe('[]');
+    });
+
+    it('does not let a stale operator-set ARCHON_ATTACHMENTS shadow the real one', async () => {
+      const store = makeStore({
+        getCodebaseEnvVars: mock(async () => ({ ARCHON_ATTACHMENTS: 'stale' })),
+      });
+      const deps = makeDeps(store);
+
+      await executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-1',
+        '/tmp',
+        makeWorkflow(),
+        'test message',
+        'db-conv-1',
+        { codebaseId: 'codebase-1' }
+      );
+
+      const configArg = mockExecuteDagWorkflow.mock.calls[0]?.[13] as WorkflowConfig | undefined;
+      expect(configArg?.envVars?.ARCHON_ATTACHMENTS).toBe('[]');
     });
 
     it('does not call getCodebaseEnvVars when no codebaseId', async () => {

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -451,9 +451,37 @@ type ResumePayload =
  * and spread them in. The executor never queries the store for a prior run on
  * its own; that decision belongs at the call site.
  */
+/**
+ * A file that arrived with the message that started this run.
+ *
+ * Structurally mirrors `AttachedFile` in `@archon/core` — declared here rather
+ * than imported because `@archon/workflows` must not depend on `@archon/core`
+ * (the dependency runs the other way). The two are assignable, so core call
+ * sites pass their `AttachedFile[]` straight through.
+ */
+export interface WorkflowAttachment {
+  /** Absolute path on disk where the adapter saved the file. */
+  path: string;
+  name: string;
+  mimeType: string;
+  size: number;
+}
+
 export type ExecuteWorkflowOptions = ResumePayload & {
   /** Codebase ID for env vars + isolation context. */
   codebaseId?: string;
+  /**
+   * Files that arrived with the triggering message (Slack/Discord uploads, web
+   * UI attachments). Delivered to `bash:`/`script:` nodes as the
+   * `ARCHON_ATTACHMENTS` env var — a JSON array, ALWAYS set (`[]` when there
+   * are none) so a script can `JSON.parse` it unconditionally rather than
+   * branching on presence.
+   *
+   * Not substituted into prompts: prompt nodes already learn about attachments
+   * from the message text, and a `$ATTACHMENTS` variable would mean inventing
+   * an escaping rule for arbitrary filenames (YAGNI until asked for).
+   */
+  attachments?: readonly WorkflowAttachment[];
   /**
    * Caller-provided base branch fallback for `$BASE_BRANCH`, normally the
    * codebase's stored `default_branch`. Repo config still wins when
@@ -1109,6 +1137,7 @@ export async function executeWorkflow(
     userId,
     source,
     parseWarnings,
+    attachments,
     baseBranch: callerBaseBranch,
     baseOverride: callerBaseOverride,
     execContext = { kind: 'host' },
@@ -1154,12 +1183,24 @@ export async function executeWorkflow(
   const userGitHubEnv = await resolveUserGithubEnvForWorkflow(deps, userId);
   const config: WorkflowConfig = {
     ...fileConfig,
-    // Order: file < db < bot-token < per-user. Per-codebase env vars are
-    // operator-set; the injected bot token is system-set; the per-user override
-    // wins last so a run routes through the originating human's token (or scrubs
-    // the org/bot token when they haven't connected). Empty-string values from
-    // the per-user policy scrub the corresponding key via the subprocess merge.
-    envVars: { ...fileConfig.envVars, ...dbEnvVars, ...botGitHubEnv, ...userGitHubEnv },
+    // Order: file < db < bot-token < per-user < attachments. Per-codebase env
+    // vars are operator-set; the injected bot token is system-set; the per-user
+    // override wins over those so a run routes through the originating human's
+    // token (or scrubs the org/bot token when they haven't connected).
+    // Empty-string values from the per-user policy scrub the corresponding key
+    // via the subprocess merge.
+    //
+    // ARCHON_ATTACHMENTS is applied LAST and unconditionally: it describes THIS
+    // run's inbound files, so a stale operator-set value of the same name must
+    // never shadow it, and always setting it (to `[]` when empty) lets scripts
+    // JSON.parse without a presence check.
+    envVars: {
+      ...fileConfig.envVars,
+      ...dbEnvVars,
+      ...botGitHubEnv,
+      ...userGitHubEnv,
+      ARCHON_ATTACHMENTS: JSON.stringify(attachments ?? []),
+    },
   };
   const configuredCommandFolder = config.commands.folder;
 


### PR DESCRIPTION
Adds an opt-in `dispatch:` table to global config that makes a registered project convention-based: every plain message in a conversation bound to that project runs one named workflow instead of asking the AI router to pick. Slash commands are untouched, and a configurable sigil escapes a single message back to normal AI chat.

    dispatch:
      githubName/githubRepo: assignedWorkflow
    dispatchSigil: '? '   # optional; this is the default

Enforced at handleMessage(), the single seam every source already funnels through, so Slack, Telegram, Discord, GitHub, web and CLI all get it with zero per-adapter code. Execution reuses handleWorkflowRunCommand -- the same path `/workflow run` takes -- so isolation resolution, `requires:` gates and resume detection behave identically however the workflow was chosen.

The routing policy lives in a pure, I/O-free module (orchestrator/ dispatch.ts), so it is unit-testable without a DB or an adapter: 34 tests. The sigil is passed in as a parameter rather than read from config there, which is what keeps that property.

Second, smaller change: attachments never reached the workflow engine at all -- `attachedFiles` only ever became prose in the AI prompt. They are now threaded through ExecuteWorkflowOptions and delivered to `bash:` and `script:` nodes as ARCHON_ATTACHMENTS, a JSON array that is ALWAYS set (`[]` when empty) so a script can JSON.parse it without a presence check. This applies to every run, not only dispatched ones.

Design decisions worth recording:

- `dispatch:` and `dispatchSigil:` are global-only. The table's keys are install-level project names that a repo's own config cannot know, and folder projects have no repo to hold a config file at all. The sigil is meaningless without the table it escapes from, so the two travel together.
- The sigil defaults to `"? "` -- with the trailing space. In an intake thread a message that merely opens with a question mark is far likelier to be content than an instruction to the router, so the escape must be typed as a separated prefix to count. `?urgent note`, `??` and a lone `?` all dispatch; `? explain this` escapes.
- Requiring a separator forced the match to move from `message.trim()` to a leading-whitespace-only strip: a sigil ending in a separator can never prefix an already right-trimmed string.
- An empty or whitespace-only `dispatchSigil:` is rejected in favour of the default. `'x'.startsWith('')` is true, so honouring an empty prefix would route every message to the AI and silently disable dispatch install-wide.
- The sigil's default is applied at the consumer (resolveDispatchSigil), not at config-merge time, so an unset key stays distinguishable from one explicitly set to the default.
- The project mapping is checked BEFORE the sigil. The reverse order would make every install silently swallow a leading sigil even with no `dispatch:` configured -- a behaviour change for threads this feature should not touch.
- An unresolvable or ambiguous workflow name is reported in-thread and nothing runs. It never falls through to the AI router, because a plausible-looking AI reply is the hardest failure to notice from inside a chat thread (Fail Fast + Explicit Errors). The in-thread message quotes the install's configured sigil, not a hardcoded `?`.
- An open approval gate still wins over dispatch.
- Project keys match exactly first, then case-insensitively, so a capitalisation slip in hand-written YAML cannot silently disable the feature for that project. The sigil is matched case-sensitively -- it is retyped on every message, so matching what was configured is predictable.
- ARCHON_ATTACHMENTS is merged last so a stale operator-set env var of the same name cannot shadow the real one.

Two test-only adjustments were forced by the change: the dispatch config read consumes a single-shot `loadConfig` mock queue in orchestrator-agent.test.ts (switched to a persistent mock, which the existing beforeEach already resets), and one executor envVars assertion now accounts for the always-present key.



Adds an opt-in `dispatch:` table to global config that makes a registered project convention-based: every plain message in a conversation bound to that project runs one named workflow instead of asking the AI router to pick. Slash commands are untouched, and a leading `?` escapes a single message back to normal AI chat.

    dispatch:
      githubName/githubRepo: assignedWorkflow

Enforced at handleMessage(), the single seam every source already funnels through, so Slack, Telegram, Discord, GitHub, web and CLI all get it with zero per-adapter code. Execution reuses handleWorkflowRunCommand -- the same path `/workflow run` takes -- so isolation resolution, `requires:` gates and resume detection behave identically however the workflow was chosen.

The routing policy lives in a pure, I/O-free module (orchestrator/ dispatch.ts) modelled on slack-channel-context.ts, so it is unit-testable without a DB or an adapter: 20 tests, 100% line coverage.

Second, smaller change: attachments never reached the workflow engine at all -- `attachedFiles` only ever became prose in the AI prompt. They are now threaded through ExecuteWorkflowOptions and delivered to `bash:` and `script:` nodes as ARCHON_ATTACHMENTS, a JSON array that is ALWAYS set (`[]` when empty) so a script can JSON.parse it without a presence check. This applies to every run, not only dispatched ones.

Design decisions worth recording:

- `dispatch:` is global-only. Its keys are install-level project names that a repo's own config cannot know, and folder projects have no repo to hold a config file at all -- the same rationale as `slack.channelProjects`.
- The project mapping is checked BEFORE the `?` sigil. The reverse order would make every install silently swallow a leading `?` even with no `dispatch:` configured -- a behaviour change for threads this feature should not touch.
- An unresolvable or ambiguous workflow name is reported in-thread and nothing runs. It never falls through to the AI router, because a plausible-looking AI reply is the hardest failure to notice from inside a chat thread (Fail Fast + Explicit Errors).
- An open approval gate still wins over dispatch.
- Project keys match exactly first, then case-insensitively, so a capitalisation slip in hand-written YAML cannot silently disable the feature for that project.
- ARCHON_ATTACHMENTS is merged last so a stale operator-set env var of the same name cannot shadow the real one.

Two test-only adjustments were forced by the change: the dispatch config read consumes a single-shot `loadConfig` mock queue in orchestrator-agent.test.ts (switched to a persistent mock, which the existing beforeEach already resets), and one executor envVars assertion now accounts for the always-present key.

## Summary

Describe this PR in 2-5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did **not** change (scope boundary):

## UX Journey

### Before

```
(Draw the user-facing flow BEFORE this PR. Show each step the user takes.)

Example:
  User                   Archon                   AI Client
  ────                   ──────                   ─────────
  sends message ──────▶  resolves session
                         loads context
                         streams to AI ──────────▶ processes prompt
                         receives chunks ◀──────── streams response
  sees reply ◀─────────  sends to platform
```

### After

```
(Draw the user-facing flow AFTER this PR. Highlight what changed with [brackets] or asterisks.)
```

## Architecture Diagram

### Before

```
(Map ALL modules touched or connected to this change. Draw lines between them.)
```

### After

```
(Same diagram with changes highlighted. Mark new modules with [+], removed with [-],
 modified with [~]. Mark new connections with ===, removed with --x--.)
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| | | unchanged / **new** / **removed** / **modified** | |

## Label Snapshot

- Risk: `risk: low|medium|high`
- Size: `size: XS|S|M|L|XL`
- Scope: `core|workflows|isolation|git|adapters|server|web|cli|paths|config|docs|dependencies|ci|tests|skills`
- Module: `<scope>:<component>` (e.g. `workflows:executor`, `adapters:slack`, `core:orchestrator`)

## Change Metadata

- Change type: `bug|feature|refactor|docs|security|chore`
- Primary scope: `core|workflows|isolation|git|adapters|server|web|cli|paths|multi`

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check
bun run lint
bun run format:check
bun run test
# Or all at once:
bun run validate
```

- Evidence provided (test/log/trace/screenshot):
<img width="976" height="569" alt="image" src="https://github.com/user-attachments/assets/c5b79290-ac2b-464e-b697-de3753397f17" />

- If any command is intentionally skipped, explain why:

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- New external network calls? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- File system access scope changed? (`Yes/No`)
- If any `Yes`, describe risk and mitigation:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Database migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
- Edge cases checked:
- What was not verified:

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows:
- Potential unintended effects:
- Guardrails/monitoring for early detection:

## Rollback Plan (required)

- Fast rollback command/path:
- Feature flags or config toggles (if any):
- Observable failure symptoms:

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk:
  - Mitigation:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable default workflow dispatch for project messages.
  - Added an escape sigil (default `? `) to send messages to normal chat instead.
  - Preserved attachments when routing messages through workflows.
  - Exposed incoming attachments to workflow scripts through `ARCHON_ATTACHMENTS`.
  - Added handling for missing, invalid, ambiguous, or unlisted workflow mappings.

- **Documentation**
  - Documented dispatch configuration, routing behavior, sigil customization, restart behavior, and attachment availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->